### PR TITLE
chore: stop .gitignore re-including the retired .trusty-mpm/INSTRUCTIONS.md (#4286)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,7 @@ jobs:
           # ── Tag-prefix aliases (issue #1128) ─────────────────────────────────
           # Some crates publish to crates.io under a SHORT package name that
           # differs from their directory / canonical crate name, and the
-          # documented release convention (.trusty-mpm/INSTRUCTIONS.md "Git Tag / Release
+          # documented release convention (CLAUDE.md "Git Tag / Release
           # Convention", abbreviation table) lets contributors tag with either
           # form. We canonicalize the alias here so every downstream consumer —
           # the per-crate config map, the homebrew-bump case statement, the

--- a/.gitignore
+++ b/.gitignore
@@ -52,15 +52,21 @@
 # tracked must be named explicitly.
 .claude/agent-memory/
 
-# trusty-mpm session/worktree runtime state is machine-local (issue #3972),
-# except the one intentionally-tracked file. Uses `.trusty-mpm/*` (ignore
-# immediate children only), NOT `.trusty-mpm/` + `!.trusty-mpm/` — the latter
-# un-ignores the directory itself and reproduces the exact `.claude/` bug
-# this issue is about (only the explicitly re-included children survive;
-# every other child falls through as untracked). Mirrors the existing
-# `.claude-mpm/*` + re-include pattern above.
+# trusty-mpm session/worktree runtime state is machine-local (issue #3972).
+# Uses `.trusty-mpm/*` (ignore immediate children only), NOT `.trusty-mpm/` +
+# `!.trusty-mpm/` — the latter un-ignores the directory itself and reproduces
+# the exact `.claude/` bug this issue is about (only the explicitly re-included
+# children survive; every other child falls through as untracked).
+#
+# Nothing here is re-included any more. `INSTRUCTIONS.md` used to be, as the
+# tracked project-instruction host; #4286 retired all five `.trusty-mpm/`
+# override files and #4676 migrated its content into the root `CLAUDE.md`.
+# The `!` re-include outlived the file it existed for, which left the ONE
+# retired name in this directory that git still offered to commit while its
+# four siblings were correctly ignored — so a session that recreated it got a
+# `??` entry inviting it back, and `tm doctor`'s `legacy_overrides` check now
+# fails on exactly that file.
 .trusty-mpm/*
-!.trusty-mpm/INSTRUCTIONS.md
 
 # Harness-generated project tier under a CRATE directory is machine-local and
 # never a deliverable (#4752). Running `tm` inside `crates/<name>/` seeds a full

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,9 @@ clean-runtime:
 	@rm -f tga.db trusty-analyze.facts.redb
 	@echo "Done."
 
-# Run the documented workspace quality gate referenced throughout
-# .trusty-mpm/INSTRUCTIONS.md.
+# Run the documented workspace quality gate referenced throughout CLAUDE.md.
 #
-# Why: .trusty-mpm/INSTRUCTIONS.md instructs contributors to run the test/lint/format gate
+# Why: CLAUDE.md instructs contributors to run the test/lint/format gate
 # before committing, but until now there was no single target to invoke —
 # every contributor had to remember and chain the three commands by hand.
 #


### PR DESCRIPTION
## Defect

The task was to migrate and delete `.trusty-mpm/INSTRUCTIONS.md`. **That already happened on main** — [#4676](https://github.com/bobmatnyc/trusty-tools/pull/4676) (commit `2e8a36be`) git-renamed the file into the root `CLAUDE.md` and split its detail into `docs/reference/{sloc-cap,test-ladder-baseline,release-workflow,common-pitfalls}.md`. `git ls-files .trusty-mpm/` on `origin/main` returns nothing, and none of the five retired names exist in the main checkout.

What #4676 left behind is the `.gitignore` re-include that existed only for that file:

```
.trusty-mpm/*
!.trusty-mpm/INSTRUCTIONS.md
```

The negation outlived the file it was written for. It left the **one** retired name in that directory that git still offered to commit, while its four siblings were correctly ignored by `.trusty-mpm/*` — so a session that recreated `INSTRUCTIONS.md` got a `??` entry inviting it back, and `tm doctor`'s `legacy_overrides` check fails on exactly that file.

## Evidence

Before, on `origin/main` — the retired file is un-ignored, its sibling is not:

```
$ git check-ignore -v .trusty-mpm/INSTRUCTIONS.md
.gitignore:63:!.trusty-mpm/INSTRUCTIONS.md   .trusty-mpm/INSTRUCTIONS.md
$ git status --porcelain .trusty-mpm/
?? .trusty-mpm/

$ git check-ignore -v .trusty-mpm/WORKFLOW.md
.gitignore:62:.trusty-mpm/*                  .trusty-mpm/WORKFLOW.md
```

After, all five retired names ignored uniformly and `git status` silent:

```
IGNORED   .trusty-mpm/INSTRUCTIONS.md
IGNORED   .trusty-mpm/AGENT_DELEGATION.md
IGNORED   .trusty-mpm/WORKFLOW.md
IGNORED   .trusty-mpm/MEMORY.md
IGNORED   .trusty-mpm/PM_INSTRUCTIONS_DEPLOYED.md

$ git status --porcelain .trusty-mpm/
(nothing)
```

**Content audit — nothing was left to migrate.** Diffing the stale copy still on disk in pre-#4676 worktrees against the version main actually migrated (`2e8a36be^`) gives 221 lines only in main's version and 73 only in the stale copy. All 73 are superseded text, not lost instructions:

| Stale block | Disposition |
|---|---|
| Per-PR hand-written `## [Unreleased]` changelog rule + the git-cliff interaction rule | **Superseded** by the per-PR `changelog.d/` fragment convention ([#4477](https://github.com/bobmatnyc/trusty-tools/pull/4477)); `generate-changelog.sh` is deleted |
| `ps -o ppid=` "is launchd the parent" daemon check | **Refuted** by [#4230](https://github.com/bobmatnyc/trusty-tools/issues/4230) — macOS reparents any orphan to PID 1, so it confirmed the orphan as supervised |
| Delivery chain pointing at `.claude-mpm/INSTRUCTIONS.md` | **Obsolete** — that path has never existed in this repo; the chain lives in `tm-pr-workflow` |
| "Each ticket/refactor/experiment gets its own worktree" | **Superseded** by the branch-is-the-workstream model now in `CLAUDE.md` |
| `bump-version.sh` "stages the unreleased CHANGELOG.md section" | **Superseded** — it now calls `assemble-changelog.sh` |

The stale copy is also *missing* the Rust Test Ladder, the Rust issue-boundary search keys, and the baseline-failure rules that main carries. It is behind main, not ahead of it.

## Resolution

- Drop the `!.trusty-mpm/INSTRUCTIONS.md` negation so all five retired names are ignored uniformly; comment records why the re-include is gone so it is not restored.
- Repoint two comments that still cited the migrated path as live documentation — `Makefile` quality-gate target and the `release.yml` tag-alias block — at `CLAUDE.md`.

**Scope note:** this prevents the retired file re-entering the repo. It does not delete the physical leftovers in eight worktrees whose branches predate #4676 (including the live session's). There the file is still *tracked on those branches*, so deleting it locally would dirty their trees — the deletion reaches them when they rebase or merge main.

## Gates — rung 1 (docs/config only; no Rust source changed)

```
sld-lint: scanned 55 spec doc(s) + 3096 code file(s); 0 error(s), 0 warning(s)
line-cap: measured 3712 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.
doc-numbers: scanned 100 doc(s) / 94 claim(s) (floors 20/20); 4 grandfathered, 0 violations — OK.
cargo fmt --check → exit 0
changelog-fragment gate: scanned 3 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
```

Changelog-fragment exemption confirmed by running the gate, not assumed. No `.rs` file changed, so the Cargo build/test/clippy gates do not apply.

Refs [#4286](https://github.com/bobmatnyc/trusty-tools/issues/4286)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools