### PR TITLE
fix(trusty-agents-common): deploy directory-shaped skills instead of dropping them silently

### DIFF
--- a/crates/trusty-agents-common/changelog.d/4949-directory-shaped-skills.md
+++ b/crates/trusty-agents-common/changelog.d/4949-directory-shaped-skills.md
@@ -1,0 +1,7 @@
+Fixed
+
+- Skill deployment now accepts a directory-shaped skill (`<stem>/SKILL.md`), not only a flat `<stem>.md` (closes [#4949](https://github.com/bobmatnyc/trusty-tools/issues/4949))
+  - the source scan tested `entry.file_type()?.is_file()`, so a directory-shaped skill was dropped with no warning on every deploy and the run still reported success
+  - every file the skill carries — `metadata.json`, `references/**`, `scripts/**`, at any depth — now deploys and is recorded in the ownership manifest, so a multi-file skill is never half-tracked
+  - a directory that carries no `SKILL.md` is reported by name in `DeployStats::skipped` and logged, instead of being skipped silently
+  - `skills::tiers::list_source_stems` now calls the deployer's own scan rather than its own copy of the filter, so the planner and the deployer cannot disagree about which skills exist

--- a/crates/trusty-agents-common/src/skills/deployer.rs
+++ b/crates/trusty-agents-common/src/skills/deployer.rs
@@ -12,18 +12,21 @@
 //! source compatibility. [`is_skill_file`] and [`skill_stem`] widen from
 //! `pub(crate)` to `pub` (mirroring `agents::deployer::is_agent_file`, #2892)
 //! so trusty-mpm's `skill_staleness` module can keep calling them cross-crate.
-//! What: [`deploy_skills`] reads every `*.md` file from a source directory,
-//! derives the skill name by stripping the `.md` extension, and writes each
-//! one as `~/.claude/skills/<name>/SKILL.md`. It consults the
+//! What: [`deploy_skills`] enumerates the source directory's skills through
+//! [`crate::skills::source_scan::scan_skill_sources`] — which accepts BOTH a
+//! flat `<stem>.md` and a directory-shaped `<stem>/SKILL.md` (#4949) — and
+//! writes each one as `~/.claude/skills/<name>/SKILL.md`. It consults the
 //! [`SkillManifest`] to classify each target file and writes only the files it
-//! safely may. It also mirrors any `references/*.md` sibling files a
-//! multi-file skill carries alongside its entry point (issue #2903, ported
-//! from `trusty-mpm` PR #2915) under the identical ownership rule, keyed as
-//! `<stem>/references/<file>`. It returns a [`DeployStats`] summarising what
-//! happened.
+//! safely may. Every file a multi-file skill carries alongside its entry point
+//! travels with it under the identical ownership rule, keyed as
+//! `<stem>/<relative-path>` (issue #2903 introduced this for
+//! `references/*.md`; #4949 widened it to `metadata.json`, `scripts/`, and any
+//! other carried file). It returns a [`DeployStats`] summarising what
+//! happened, including — since #4949 — the names it could not deploy.
 //! Test: `cargo test -p trusty-agents-common skills::deployer` covers a new
 //! deploy, a skipped user-modified file, an unchanged file, a user-owned
-//! file, and the reference-file mirroring cases.
+//! file, the reference-file mirroring cases, and the directory-shaped-skill
+//! cases (`deploy_directory_shaped_skill` and siblings).
 
 use std::path::Path;
 
@@ -31,6 +34,7 @@ use crate::agents::manifest::{Result, atomic_write, checksum};
 use crate::skills::manifest::{
     SkillManifest, SkillManifestEntry, SkillManifestSave, with_skill_manifest_lock,
 };
+use crate::skills::source_scan::{SourceSkill, scan_skill_sources};
 
 /// Summary of one [`deploy_skills`] run.
 ///
@@ -178,35 +182,48 @@ fn deploy_skills_locked(
     let base = manifest.clone();
     let now = chrono::Utc::now().to_rfc3339();
 
-    // Collect skill filenames deterministically so output and tests are stable.
-    let mut names: Vec<String> = Vec::new();
-    let mut source_file_count = 0usize;
-    for entry in std::fs::read_dir(source)? {
-        let entry = entry?;
-        let file_name = entry.file_name();
-        let Some(name) = file_name.to_str() else {
-            continue;
-        };
-        if entry.file_type()?.is_file() && is_skill_file(name) {
-            source_file_count += 1;
-            // Honour the manifest's skill-set selection (HR-2). The stem is the
-            // `.md`-stripped name used as the skill id and target dir name.
-            if select(skill_stem(name)) {
-                names.push(name.to_string());
-            }
-        }
+    // #4949: ONE shared scan answers "what is a skill here?", covering both the
+    // flat `<stem>.md` layout and the directory `<stem>/SKILL.md` layout. The
+    // loop this replaced tested `entry.file_type()?.is_file()`, so a
+    // directory-shaped skill failed it and was dropped with no warning on every
+    // deploy. `skills::tiers::list_source_stems` calls the same scan, so the
+    // planner and this deployer cannot disagree about which stems exist.
+    let scan = scan_skill_sources(source)?;
+
+    // #4949: a directory the scan could not turn into a skill (no `SKILL.md`)
+    // rides `stats.skipped` — the channel callers already summarise for the
+    // user (`managed_config::skill_skip_summary`, `tm sync-assets`) — plus a
+    // warn line, matching how the `mcp`-name rejection below is surfaced.
+    for name in &scan.rejected {
+        tracing::warn!(
+            skill = %name,
+            source = %source.display(),
+            "skill directory has no SKILL.md — it cannot be deployed"
+        );
+        stats.skipped.push(name.clone());
     }
-    names.sort_unstable();
 
     // An existing but empty source directory is just as silent a failure mode
     // as a missing one — e.g. a populated `agents/skills/` submodule checked
-    // out shallow, or a source dir pointed at the wrong path (A2).
-    if source_file_count == 0 {
+    // out shallow, or a source dir pointed at the wrong path (A2). Judged
+    // BEFORE `select` runs, as it always was: a filtered deploy that legitimately
+    // selects nothing (every stem shadowed by a higher tier) is not an empty
+    // source. A directory holding only malformed skills is not empty either —
+    // those were just reported by name.
+    if scan.skills.is_empty() && scan.rejected.is_empty() {
         tracing::warn!(
             source = %source.display(),
             "skill source directory is empty — no skills will be deployed"
         );
     }
+
+    // Honour the manifest's skill-set selection (HR-2). The scan is already
+    // sorted by stem, so output and tests stay deterministic.
+    let selected: Vec<SourceSkill> = scan
+        .skills
+        .into_iter()
+        .filter(|skill| select(&skill.stem))
+        .collect();
 
     // #4881: the write loop's failure sites (an unreadable source file, a failed
     // `atomic_write`) can return AFTER earlier `SKILL.md` files are already on
@@ -216,7 +233,7 @@ fn deploy_skills_locked(
     // held, the ledger is saved either way, and the error propagates after.
     // Pre-existing (it predates this issue's lock work) but fixed here because
     // it violates the same invariant.
-    let write_result = deploy_selected(source, dest, &names, &now, &mut manifest, &mut stats);
+    let write_result = deploy_selected(dest, &selected, &now, &mut manifest, &mut stats);
 
     let save_result = manifest.save_merging(dest, &base);
 
@@ -241,23 +258,23 @@ fn deploy_skills_locked(
 /// whether it returns `Ok` or `Err`, so the caller must save the ledger on BOTH
 /// paths — a shape that is easy to get wrong while the loop and the save share
 /// one function body, and was wrong here before this change.
-/// What: for each name, writes `<dest>/<stem>/SKILL.md` plus any
-/// `references/*.md` siblings through [`deploy_one_file`], recording each in
-/// `manifest` and `stats`. Skills whose stem contains `mcp` are rejected before
-/// any I/O (#2186). Returns the first I/O error; `manifest` and `stats` still
-/// describe everything written up to that point.
-/// Test: `deploy_records_files_written_before_a_mid_loop_failure`, plus every
-/// `deploy_*` test through the public entry point.
+/// What: for each skill, writes `<dest>/<stem>/SKILL.md` plus every file the
+/// skill carries through [`deploy_one_file`], recording each in `manifest` and
+/// `stats`. Skills whose stem contains `mcp` are rejected before any I/O
+/// (#2186). Returns the first I/O error; `manifest` and `stats` still describe
+/// everything written up to that point.
+/// Test: `deploy_records_files_written_before_a_mid_loop_failure`,
+/// `deploy_directory_shaped_skill`, plus every `deploy_*` test through the
+/// public entry point.
 fn deploy_selected(
-    source: &Path,
     dest: &Path,
-    names: &[String],
+    skills: &[SourceSkill],
     now: &str,
     manifest: &mut SkillManifest,
     stats: &mut DeployStats,
 ) -> Result<()> {
-    for filename in names {
-        let stem = skill_stem(filename).to_string();
+    for skill in skills {
+        let stem = skill.stem.clone();
 
         // Claude Code ships a built-in `/mcp` slash command. A deployed skill
         // whose invocable name (the stem, i.e. the directory Claude Code
@@ -273,39 +290,44 @@ fn deploy_selected(
             continue;
         }
 
-        let source_path = source.join(filename);
-        let content = std::fs::read_to_string(&source_path)?;
+        let content = std::fs::read_to_string(&skill.entry)?;
         // Claude Code discovers skills from <dest>/<name>/SKILL.md.
         let skill_dir = dest.join(&stem);
         let target_path = skill_dir.join("SKILL.md");
 
         deploy_one_file(manifest, &stem, &target_path, &content, now, stats)?;
 
-        // Mirror any reference files a multi-file skill carries alongside its
-        // SKILL.md (issue #2903, ported from `trusty-mpm` PR #2915 —
-        // upstream progressive-disclosure skills ship a lean entry point plus
-        // a `references/*.md` subtree loaded on demand). This runs
-        // independent of whether the entry point itself changed this pass,
-        // so a skill that gains a new reference file on a later deploy still
-        // picks it up even when its SKILL.md content is unchanged
-        // (`stats.unchanged`).
-        let refs_source_dir = source.join(&stem).join("references");
-        if refs_source_dir.is_dir() {
-            let mut ref_names: Vec<String> = std::fs::read_dir(&refs_source_dir)?
-                .filter_map(|e| e.ok())
-                .filter_map(|e| {
-                    let name = e.file_name().to_str()?.to_string();
-                    (e.file_type().ok()?.is_file() && is_skill_file(&name)).then_some(name)
-                })
-                .collect();
-            ref_names.sort_unstable();
-
-            for ref_name in ref_names {
-                let ref_content = std::fs::read_to_string(refs_source_dir.join(&ref_name))?;
-                let ref_key = format!("{stem}/references/{ref_name}");
-                let ref_target = skill_dir.join("references").join(&ref_name);
-                deploy_one_file(manifest, &ref_key, &ref_target, &ref_content, now, stats)?;
+        // Mirror every file the skill carries alongside its entry point — the
+        // `references/*.md` subtree a progressive-disclosure skill ships (issue
+        // #2903), and since #4949 also its `metadata.json`, `scripts/`, and
+        // anything else at any depth. This runs independent of whether the
+        // entry point itself changed this pass, so a skill that gains a file on
+        // a later deploy still picks it up even when its SKILL.md content is
+        // unchanged (`stats.unchanged`).
+        for extra in &skill.extras {
+            // A non-UTF-8 file (an image, a compiled asset) cannot ride the
+            // manifest's text checksum. Report it and carry on — aborting the
+            // whole deploy over one carried asset would be a worse failure than
+            // the one #4949 fixed.
+            let extra_content = match std::fs::read_to_string(&extra.path) {
+                Ok(content) => content,
+                Err(err) if err.kind() == std::io::ErrorKind::InvalidData => {
+                    let key = format!("{stem}/{}", extra.rel);
+                    tracing::warn!(
+                        file = %key,
+                        "skill file is not UTF-8 — it cannot be deployed"
+                    );
+                    stats.skipped.push(key);
+                    continue;
+                }
+                Err(err) => return Err(err.into()),
+            };
+            let key = format!("{stem}/{}", extra.rel);
+            let mut extra_target = skill_dir.clone();
+            for segment in extra.rel.split('/') {
+                extra_target.push(segment);
             }
+            deploy_one_file(manifest, &key, &extra_target, &extra_content, now, stats)?;
         }
     }
 

--- a/crates/trusty-agents-common/src/skills/deployer_tests.rs
+++ b/crates/trusty-agents-common/src/skills/deployer_tests.rs
@@ -549,3 +549,204 @@ fn deploy_records_files_written_before_a_mid_loop_failure() {
     );
     assert!(stats.unchanged.contains(&"aaa-skill".to_string()));
 }
+
+// ---------------------------------------------------------------------------
+// #4949 — directory-shaped skills at the user tier
+// ---------------------------------------------------------------------------
+
+/// Write a directory-shaped skill mirroring the real `duetto-design-system`.
+fn write_directory_skill(dir: &Path, stem: &str) {
+    let skill = dir.join(stem);
+    fs::create_dir_all(skill.join("references")).unwrap();
+    fs::write(skill.join("SKILL.md"), format!("# {stem}\n")).unwrap();
+    fs::write(skill.join("metadata.json"), "{\"v\":1}\n").unwrap();
+    fs::write(skill.join("references").join("tokens.md"), "# Tokens\n").unwrap();
+    fs::write(skill.join("references").join("index.md"), "# Index\n").unwrap();
+}
+
+#[test]
+fn deploy_directory_shaped_skill() {
+    // #4949: `~/.trusty-mpm/skills/<stem>/SKILL.md` is a skill. Before the fix
+    // the source scan's `is_file()` test rejected the directory outright and
+    // the deploy reported success having written nothing.
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    write_directory_skill(src.path(), "duetto-design-system");
+
+    let stats = deploy_skills(src.path(), tgt.path()).unwrap();
+
+    assert!(
+        stats.deployed.contains(&"duetto-design-system".to_string()),
+        "the entry point must deploy: {stats:?}"
+    );
+    // Every file the skill carries lands at the destination.
+    let dest = tgt.path().join("duetto-design-system");
+    assert!(dest.join("SKILL.md").is_file(), "SKILL.md missing");
+    assert!(
+        dest.join("metadata.json").is_file(),
+        "metadata.json missing"
+    );
+    assert!(
+        dest.join("references").join("tokens.md").is_file(),
+        "references/tokens.md missing"
+    );
+    assert!(
+        dest.join("references").join("index.md").is_file(),
+        "references/index.md missing"
+    );
+    assert!(
+        stats.skipped.is_empty(),
+        "nothing may be skipped: {stats:?}"
+    );
+}
+
+#[test]
+fn deploy_directory_skill_records_every_file_in_the_manifest() {
+    // Ownership tracking must cover a multi-file skill, not just its entry
+    // point — an unrecorded file reads as user-owned on the next pass and is
+    // then frozen forever.
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    write_directory_skill(src.path(), "duetto-design-system");
+
+    deploy_skills(src.path(), tgt.path()).unwrap();
+
+    let manifest = SkillManifest::load(tgt.path());
+    for key in [
+        "duetto-design-system",
+        "duetto-design-system/metadata.json",
+        "duetto-design-system/references/tokens.md",
+        "duetto-design-system/references/index.md",
+    ] {
+        assert!(manifest.is_managed(key), "manifest missing key {key}");
+    }
+
+    // The proof the ledger is right: a second deploy changes nothing and
+    // freezes nothing.
+    let again = deploy_skills(src.path(), tgt.path()).unwrap();
+    assert!(again.deployed.is_empty(), "second deploy wrote: {again:?}");
+    assert!(again.skipped.is_empty(), "second deploy froze: {again:?}");
+    assert_eq!(again.unchanged.len(), 4, "{again:?}");
+}
+
+#[test]
+fn deploy_flat_skill_still_works_alongside_a_directory_skill() {
+    // The pre-#4949 flat path must not regress, including its hybrid
+    // `<stem>/references/` companion directory.
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    write_sources(src.path()); // tm-doctor.md + example-skill.md
+    fs::create_dir_all(src.path().join("tm-doctor").join("references")).unwrap();
+    fs::write(
+        src.path()
+            .join("tm-doctor")
+            .join("references")
+            .join("cli.md"),
+        "# CLI\n",
+    )
+    .unwrap();
+    write_directory_skill(src.path(), "duetto-design-system");
+
+    let stats = deploy_skills(src.path(), tgt.path()).unwrap();
+
+    for stem in ["tm-doctor", "example-skill", "duetto-design-system"] {
+        assert!(
+            tgt.path().join(stem).join("SKILL.md").is_file(),
+            "{stem}/SKILL.md missing: {stats:?}"
+        );
+    }
+    // The flat skill's companion reference file keeps its established key.
+    assert!(
+        tgt.path()
+            .join("tm-doctor")
+            .join("references")
+            .join("cli.md")
+            .is_file()
+    );
+    let manifest = SkillManifest::load(tgt.path());
+    assert!(manifest.is_managed("tm-doctor/references/cli.md"));
+}
+
+#[test]
+fn deploy_reports_a_skill_directory_with_no_entry_point() {
+    // #4949's other half: a source name the deployer cannot use must be
+    // REPORTED, not silently dropped. `stats.skipped` is the channel callers
+    // already summarise for the user (`managed_config::skill_skip_summary`,
+    // `tm sync-assets`), so the rejection rides it alongside a `tracing::warn!`.
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    fs::create_dir_all(src.path().join("broken-skill")).unwrap();
+    fs::write(src.path().join("broken-skill").join("notes.md"), "x\n").unwrap();
+
+    let stats = deploy_skills(src.path(), tgt.path()).unwrap();
+
+    assert!(
+        stats.skipped.contains(&"broken-skill".to_string()),
+        "a malformed skill directory must be reported: {stats:?}"
+    );
+    assert!(stats.deployed.is_empty(), "{stats:?}");
+    assert!(
+        !tgt.path().join("broken-skill").exists(),
+        "a malformed skill must not be partially written"
+    );
+}
+
+#[test]
+fn deploy_directory_skill_respects_the_select_predicate() {
+    // Tier precedence drives deploys through `select`; a directory skill must
+    // be selectable by the same stem the planner derives.
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    write_directory_skill(src.path(), "duetto-design-system");
+    write_directory_skill(src.path(), "cto-kb-ingest");
+
+    let stats =
+        deploy_skills_filtered(src.path(), tgt.path(), |name| name == "cto-kb-ingest").unwrap();
+
+    assert!(stats.deployed.contains(&"cto-kb-ingest".to_string()));
+    assert!(!tgt.path().join("duetto-design-system").exists());
+}
+
+#[test]
+fn deploy_directory_skill_preserves_a_user_edited_reference() {
+    // The ownership rule applies per file, so a hand-edited reference doc is
+    // preserved while the rest of the skill still refreshes.
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    write_directory_skill(src.path(), "duetto-design-system");
+    deploy_skills(src.path(), tgt.path()).unwrap();
+
+    let edited = tgt
+        .path()
+        .join("duetto-design-system")
+        .join("references")
+        .join("tokens.md");
+    fs::write(&edited, "# Tokens (hand-edited)\n").unwrap();
+    fs::write(
+        src.path()
+            .join("duetto-design-system")
+            .join("references")
+            .join("index.md"),
+        "# Index v2\n",
+    )
+    .unwrap();
+
+    let stats = deploy_skills(src.path(), tgt.path()).unwrap();
+
+    assert!(
+        stats
+            .skipped
+            .contains(&"duetto-design-system/references/tokens.md".to_string()),
+        "{stats:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(&edited).unwrap(),
+        "# Tokens (hand-edited)\n"
+    );
+    assert!(
+        stats
+            .deployed
+            .contains(&"duetto-design-system/references/index.md".to_string()),
+        "{stats:?}"
+    );
+}

--- a/crates/trusty-agents-common/src/skills/mod.rs
+++ b/crates/trusty-agents-common/src/skills/mod.rs
@@ -30,5 +30,6 @@
 pub mod deployer;
 pub mod manifest;
 pub mod reconcile;
+pub mod source_scan;
 pub mod tiers;
 pub mod unmanaged;

--- a/crates/trusty-agents-common/src/skills/source_scan.rs
+++ b/crates/trusty-agents-common/src/skills/source_scan.rs
@@ -1,0 +1,241 @@
+//! Enumerate the skills a source directory offers, in either supported layout.
+//!
+//! Why (#4949): the deployer and the tier planner each decide "what is a skill
+//! here?" and both decided it with `entry.file_type()?.is_file() &&
+//! is_skill_file(name)` — a flat `<stem>.md` at the source root, and nothing
+//! else. A directory-shaped skill (`<stem>/SKILL.md` plus whatever it carries)
+//! failed that `is_file()` test and was dropped with no warning on every
+//! deploy: `deploy_skills_filtered` reported success having never seen it.
+//! Bundled skills escaped the bug only because they ship a HYBRID layout — a
+//! flat `tm-capabilities.md` entry point beside a `tm-capabilities/references/`
+//! companion directory — so the entry point still satisfied `is_file()` and the
+//! companion directory was reached afterwards, keyed off the stem. There was no
+//! working directory-skill path to route the user tier through; both tiers read
+//! the same blind scan. Two real user skills sat hidden behind it for weeks:
+//! `duetto-design-system` and `cto-kb-ingest`.
+//!
+//! What: [`scan_skill_sources`] returns one [`SourceSkill`] per skill in
+//! `source`, accepting BOTH layouts, plus the names it had to reject so the
+//! caller can report them instead of dropping them. Every non-hidden file a
+//! skill's companion directory carries — `metadata.json`, `references/**`,
+//! `scripts/**`, at any depth — travels with it as an [`SourceExtra`], keyed
+//! `<stem>/<relative-path>`. That key scheme is byte-identical to the
+//! `<stem>/references/<file>` keys the previous reference-mirroring code wrote,
+//! so existing manifests keep matching and no skill re-deploys spuriously.
+//! This module is the ONE place that answers the question, per this repo's
+//! common-entry-point rule; [`crate::skills::deployer`] and
+//! [`crate::skills::tiers`] both call it rather than re-deriving it.
+//!
+//! Test: `scan_finds_directory_shaped_skill`, `scan_finds_flat_skill`,
+//! `scan_companion_dir_is_not_a_reject`, `scan_rejects_dir_without_skill_md`,
+//! `scan_ignores_hidden_entries`, `scan_extras_are_recursive_and_sorted`.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::agents::manifest::Result;
+use crate::skills::deployer::{is_skill_file, skill_stem};
+
+/// One extra file a skill carries alongside its entry point.
+///
+/// Why: the manifest keys every managed file individually, so each companion
+/// file needs a stable relative identity independent of the absolute source
+/// path it was read from.
+/// What: `rel` is the `/`-joined path below the skill's own directory (e.g.
+/// `references/design-tokens.md`, `scripts/ingest.sh`); `path` is where to read
+/// it from.
+/// Test: `scan_extras_are_recursive_and_sorted`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceExtra {
+    /// Path below the skill directory, `/`-separated.
+    pub rel: String,
+    /// Absolute (or source-relative) path to read the content from.
+    pub path: PathBuf,
+}
+
+/// One deployable skill discovered in a source directory.
+///
+/// Why: the deployer needs the entry-point content and the carried files as one
+/// unit so a multi-file skill cannot half-deploy, and the tier planner needs the
+/// stem from the identical scan so it never greenlights a stem the deployer
+/// then rejects (the drift PR #2818's review already caught once).
+/// What: the skill name, the file whose content becomes `<dest>/<stem>/SKILL.md`,
+/// and every extra file it carries.
+/// Test: `scan_finds_directory_shaped_skill`, `scan_finds_flat_skill`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceSkill {
+    /// The skill name — manifest key and destination directory name.
+    pub stem: String,
+    /// Source of the `SKILL.md` content.
+    pub entry: PathBuf,
+    /// Companion files, sorted by `rel` for deterministic output.
+    pub extras: Vec<SourceExtra>,
+}
+
+/// Everything one source directory offers, including what it could not offer.
+///
+/// Why (#4949): a name this scan cannot turn into a skill must reach the
+/// caller. Returning only the successes is what made the original defect
+/// invisible — there was no channel for "I saw this and could not use it".
+/// What: the usable skills, sorted by stem, plus the rejected directory names,
+/// sorted.
+/// Test: `scan_rejects_dir_without_skill_md`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SourceScan {
+    /// Deployable skills, sorted by stem.
+    pub skills: Vec<SourceSkill>,
+    /// Directory names that look like a skill but carry no `SKILL.md`.
+    pub rejected: Vec<String>,
+}
+
+/// Whether a directory entry name is hidden and must be ignored.
+///
+/// Why: `.git`, `.DS_Store`, and editor sidecars live beside real content and
+/// must never be deployed or reported as a malformed skill.
+/// What: true when the name starts with `.`.
+/// Test: `scan_ignores_hidden_entries`.
+fn is_hidden(name: &str) -> bool {
+    name.starts_with('.')
+}
+
+/// Enumerate the skills in `source`, accepting both supported layouts.
+///
+/// Why: see the module doc — one shared answer to "what is a skill here?",
+/// covering the directory shape that #4949 dropped silently.
+/// What: a flat `<stem>.md` file is a skill whose entry point is that file. A
+/// non-hidden subdirectory containing `SKILL.md` is a skill whose entry point
+/// is that `SKILL.md`. Either way, every non-hidden file under `<source>/<stem>/`
+/// (except a directory skill's own `SKILL.md`) is carried as an extra. A
+/// subdirectory that merely accompanies a flat skill of the same name is the
+/// hybrid bundled layout, NOT a malformed skill, and is never rejected — every
+/// bundled skill would otherwise warn on every deploy. Any other non-hidden
+/// subdirectory without a `SKILL.md` is returned in `rejected`. A missing
+/// `source` yields an empty scan; errors reading an existing directory
+/// propagate.
+/// Test: `scan_finds_directory_shaped_skill`, `scan_finds_flat_skill`,
+/// `scan_companion_dir_is_not_a_reject`, `scan_rejects_dir_without_skill_md`.
+pub fn scan_skill_sources(source: &Path) -> Result<SourceScan> {
+    let mut scan = SourceScan::default();
+    if !source.is_dir() {
+        return Ok(scan);
+    }
+
+    // Two passes over one read_dir result: the flat entry points must all be
+    // known before any directory is judged, because a directory whose name
+    // matches a flat skill is that skill's companion, not a candidate.
+    let mut flat: BTreeMap<String, PathBuf> = BTreeMap::new();
+    let mut dirs: Vec<String> = Vec::new();
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if is_hidden(name) {
+            continue;
+        }
+        let file_type = entry.file_type()?;
+        if file_type.is_file() && is_skill_file(name) {
+            flat.insert(skill_stem(name).to_string(), entry.path());
+        } else if file_type.is_dir() {
+            dirs.push(name.to_string());
+        }
+    }
+
+    for (stem, entry) in &flat {
+        scan.skills.push(SourceSkill {
+            stem: stem.clone(),
+            entry: entry.clone(),
+            extras: collect_extras(&source.join(stem), None)?,
+        });
+    }
+
+    dirs.sort_unstable();
+    for name in dirs {
+        if flat.contains_key(&name) {
+            // Companion directory of a flat skill — already carried above.
+            continue;
+        }
+        let dir = source.join(&name);
+        if dir.join("SKILL.md").is_file() {
+            scan.skills.push(SourceSkill {
+                stem: name.clone(),
+                entry: dir.join("SKILL.md"),
+                extras: collect_extras(&dir, Some("SKILL.md"))?,
+            });
+        } else {
+            scan.rejected.push(name);
+        }
+    }
+
+    scan.skills.sort_by(|a, b| a.stem.cmp(&b.stem));
+    Ok(scan)
+}
+
+/// Collect every non-hidden file under `dir`, recursively.
+///
+/// Why: a skill's carried files are not limited to `references/*.md` — the two
+/// skills #4949 hid between them ship `metadata.json`, four `references/*.md`
+/// docs, and a `scripts/ingest.sh`. Filtering to `.md` here would fix the
+/// `is_file()` half of the defect and leave a second silent-drop in its place.
+/// What: walks `dir` depth-first, returning `/`-joined relative paths and their
+/// source paths, skipping hidden entries at every level and `skip_root` (a
+/// directory skill's own entry point) at the top. A missing `dir` yields an
+/// empty vector. Results are sorted by `rel`.
+/// Test: `scan_extras_are_recursive_and_sorted`, `scan_ignores_hidden_entries`.
+fn collect_extras(dir: &Path, skip_root: Option<&str>) -> Result<Vec<SourceExtra>> {
+    let mut extras = Vec::new();
+    collect_extras_into(dir, "", skip_root, &mut extras)?;
+    extras.sort_by(|a, b| a.rel.cmp(&b.rel));
+    Ok(extras)
+}
+
+/// Recursive worker for [`collect_extras`].
+///
+/// Why: split out so the public helper owns the sort and the caller never has
+/// to thread a prefix through.
+/// What: appends each non-hidden file below `dir` to `out`, prefixing its name
+/// with `prefix`. Errors reading an existing directory propagate.
+/// Test: via [`collect_extras`]'s tests.
+fn collect_extras_into(
+    dir: &Path,
+    prefix: &str,
+    skip_root: Option<&str>,
+    out: &mut Vec<SourceExtra>,
+) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if is_hidden(name) {
+            continue;
+        }
+        if prefix.is_empty() && skip_root == Some(name) {
+            continue;
+        }
+        let rel = if prefix.is_empty() {
+            name.to_string()
+        } else {
+            format!("{prefix}/{name}")
+        };
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_extras_into(&entry.path(), &rel, skip_root, out)?;
+        } else if file_type.is_file() {
+            out.push(SourceExtra {
+                rel,
+                path: entry.path(),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "source_scan_tests.rs"]
+mod tests;

--- a/crates/trusty-agents-common/src/skills/source_scan_tests.rs
+++ b/crates/trusty-agents-common/src/skills/source_scan_tests.rs
@@ -1,0 +1,175 @@
+//! Tests for `source_scan` — the shared "what is a skill here?" enumeration.
+//!
+//! Why: #4949 was a scan that recognised exactly one layout and reported
+//! nothing about what it declined. Every case below pins one half of that:
+//! the layouts that must be recognised, and the names that must come back as
+//! rejects instead of vanishing.
+//! What: covers the flat, directory, and hybrid layouts, hidden-entry
+//! filtering, recursive extras, and the malformed-directory reject.
+//! Test: this file IS the test module for `source_scan`; run with
+//! `cargo test -p trusty-agents-common -- skills::source_scan`.
+
+use super::*;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn scan_finds_flat_skill() {
+    // The pre-#4949 layout must keep working unchanged.
+    let src = TempDir::new().unwrap();
+    fs::write(src.path().join("tm-doctor.md"), "# Doctor\n").unwrap();
+
+    let scan = scan_skill_sources(src.path()).unwrap();
+
+    assert_eq!(scan.skills.len(), 1);
+    assert_eq!(scan.skills[0].stem, "tm-doctor");
+    assert_eq!(scan.skills[0].entry, src.path().join("tm-doctor.md"));
+    assert!(scan.skills[0].extras.is_empty());
+    assert!(scan.rejected.is_empty());
+}
+
+#[test]
+fn scan_finds_directory_shaped_skill() {
+    // #4949: `<stem>/SKILL.md` is a skill. Before the fix the top-level
+    // `is_file()` test rejected the directory and the scan returned nothing.
+    let src = TempDir::new().unwrap();
+    let skill = src.path().join("duetto-design-system");
+    fs::create_dir_all(skill.join("references")).unwrap();
+    fs::write(skill.join("SKILL.md"), "# Duetto\n").unwrap();
+    fs::write(skill.join("metadata.json"), "{}\n").unwrap();
+    fs::write(skill.join("references").join("tokens.md"), "# Tokens\n").unwrap();
+
+    let scan = scan_skill_sources(src.path()).unwrap();
+
+    assert_eq!(scan.skills.len(), 1, "got {:?}", scan);
+    let found = &scan.skills[0];
+    assert_eq!(found.stem, "duetto-design-system");
+    assert_eq!(found.entry, skill.join("SKILL.md"));
+    // Every carried file travels — not just `references/*.md`. `SKILL.md`
+    // itself is the entry point, never an extra.
+    let rels: Vec<&str> = found.extras.iter().map(|e| e.rel.as_str()).collect();
+    assert_eq!(rels, vec!["metadata.json", "references/tokens.md"]);
+    assert!(scan.rejected.is_empty());
+}
+
+#[test]
+fn scan_carries_non_markdown_extras() {
+    // `cto-kb-ingest` ships `scripts/ingest.sh`. A `.md`-only extras filter
+    // would fix the `is_file()` half of #4949 and leave a second silent drop.
+    let src = TempDir::new().unwrap();
+    let skill = src.path().join("cto-kb-ingest");
+    fs::create_dir_all(skill.join("scripts")).unwrap();
+    fs::write(skill.join("SKILL.md"), "# Ingest\n").unwrap();
+    fs::write(skill.join("scripts").join("ingest.sh"), "#!/bin/sh\n").unwrap();
+
+    let scan = scan_skill_sources(src.path()).unwrap();
+
+    let rels: Vec<&str> = scan.skills[0]
+        .extras
+        .iter()
+        .map(|e| e.rel.as_str())
+        .collect();
+    assert_eq!(rels, vec!["scripts/ingest.sh"]);
+}
+
+#[test]
+fn scan_companion_dir_is_not_a_reject() {
+    // The bundled hybrid layout: a flat `tm-capabilities.md` beside a
+    // `tm-capabilities/references/` companion. The directory carries no
+    // SKILL.md, but it is not malformed — warning about it would fire on
+    // every bundled skill on every deploy.
+    let src = TempDir::new().unwrap();
+    fs::write(src.path().join("tm-capabilities.md"), "# Caps\n").unwrap();
+    fs::create_dir_all(src.path().join("tm-capabilities").join("references")).unwrap();
+    fs::write(
+        src.path()
+            .join("tm-capabilities")
+            .join("references")
+            .join("cli.md"),
+        "# CLI\n",
+    )
+    .unwrap();
+
+    let scan = scan_skill_sources(src.path()).unwrap();
+
+    assert_eq!(scan.skills.len(), 1);
+    assert_eq!(scan.skills[0].stem, "tm-capabilities");
+    assert_eq!(scan.skills[0].entry, src.path().join("tm-capabilities.md"));
+    let rels: Vec<&str> = scan.skills[0]
+        .extras
+        .iter()
+        .map(|e| e.rel.as_str())
+        .collect();
+    assert_eq!(rels, vec!["references/cli.md"]);
+    assert!(
+        scan.rejected.is_empty(),
+        "companion dir must not be rejected: {:?}",
+        scan.rejected
+    );
+}
+
+#[test]
+fn scan_rejects_dir_without_skill_md() {
+    // A directory that looks like a skill but has no entry point cannot be
+    // deployed. It must come back named, not disappear.
+    let src = TempDir::new().unwrap();
+    fs::create_dir_all(src.path().join("broken-skill")).unwrap();
+    fs::write(src.path().join("broken-skill").join("notes.md"), "x\n").unwrap();
+
+    let scan = scan_skill_sources(src.path()).unwrap();
+
+    assert!(scan.skills.is_empty());
+    assert_eq!(scan.rejected, vec!["broken-skill".to_string()]);
+}
+
+#[test]
+fn scan_ignores_hidden_entries() {
+    // `.git` and friends are neither skills nor malformed skills.
+    let src = TempDir::new().unwrap();
+    fs::create_dir_all(src.path().join(".git")).unwrap();
+    fs::write(src.path().join(".hidden.md"), "x\n").unwrap();
+    let skill = src.path().join("real");
+    fs::create_dir_all(skill.join(".cache")).unwrap();
+    fs::write(skill.join("SKILL.md"), "# Real\n").unwrap();
+    fs::write(skill.join(".DS_Store"), "junk").unwrap();
+    fs::write(skill.join(".cache").join("x.md"), "junk").unwrap();
+
+    let scan = scan_skill_sources(src.path()).unwrap();
+
+    assert_eq!(scan.skills.len(), 1);
+    assert_eq!(scan.skills[0].stem, "real");
+    assert!(
+        scan.skills[0].extras.is_empty(),
+        "{:?}",
+        scan.skills[0].extras
+    );
+    assert!(scan.rejected.is_empty());
+}
+
+#[test]
+fn scan_extras_are_recursive_and_sorted() {
+    // Deterministic ordering keeps deploy output and manifest writes stable.
+    let src = TempDir::new().unwrap();
+    let skill = src.path().join("deep");
+    fs::create_dir_all(skill.join("a").join("b")).unwrap();
+    fs::write(skill.join("SKILL.md"), "# Deep\n").unwrap();
+    fs::write(skill.join("z.txt"), "z\n").unwrap();
+    fs::write(skill.join("a").join("m.md"), "m\n").unwrap();
+    fs::write(skill.join("a").join("b").join("n.md"), "n\n").unwrap();
+
+    let scan = scan_skill_sources(src.path()).unwrap();
+
+    let rels: Vec<&str> = scan.skills[0]
+        .extras
+        .iter()
+        .map(|e| e.rel.as_str())
+        .collect();
+    assert_eq!(rels, vec!["a/b/n.md", "a/m.md", "z.txt"]);
+}
+
+#[test]
+fn scan_missing_source_is_empty() {
+    let src = TempDir::new().unwrap();
+    let scan = scan_skill_sources(&src.path().join("nope")).unwrap();
+    assert_eq!(scan, SourceScan::default());
+}

--- a/crates/trusty-agents-common/src/skills/tiers.rs
+++ b/crates/trusty-agents-common/src/skills/tiers.rs
@@ -196,38 +196,35 @@ pub fn plan_skill_tiers(
 /// List the deployable skill stems in a source directory.
 ///
 /// Why: the planner works over stem sets; the orchestrator must translate a
-/// source directory into that set using the EXACT SAME file filter and stem
-/// derivation `deploy_skills_filtered` uses. A second, independently-written
-/// rule here previously used a repeated `trim_end_matches(".md")` strip
-/// against the deployer's single `strip_suffix(".md")` (PR #2818 review,
-/// MEDIUM): for a pathological `foo.md.md` source file the planner would
-/// derive stem `foo` while the deployer's own `select` predicate — driven by
-/// [`crate::skills::deployer::skill_stem`] — expects `foo.md`, so the
-/// planner would greenlight a stem the deployer then silently rejected and the
-/// skill never deployed. Reusing the deployer's own [`is_skill_file`] and
-/// [`skill_stem`] helpers makes that drift structurally impossible.
-/// What: returns the stem (per [`skill_stem`]) of every file directly under
-/// `dir` that [`is_skill_file`] accepts. A missing or non-directory path
-/// yields an empty set (an absent tier is not an error). Errors reading an
-/// existing directory propagate.
-/// Test: `list_source_stems_reads_md_files`, `list_source_stems_missing_empty`.
+/// source directory into that set using the EXACT SAME scan
+/// `deploy_skills_filtered` uses. A second, independently-written rule here
+/// previously used a repeated `trim_end_matches(".md")` strip against the
+/// deployer's single `strip_suffix(".md")` (PR #2818 review, MEDIUM): for a
+/// pathological `foo.md.md` source file the planner would derive stem `foo`
+/// while the deployer expected `foo.md`, so the planner would greenlight a stem
+/// the deployer then silently rejected and the skill never deployed. Calling
+/// the deployer's own scan makes that drift structurally impossible — and #4949
+/// proved the point again from the other direction, where the two copies were
+/// identically blind to directory-shaped skills.
+/// What: returns the stem of every skill
+/// [`crate::skills::source_scan::scan_skill_sources`] finds in `dir` — the flat
+/// `<stem>.md` form and, since #4949, the directory `<stem>/SKILL.md` form. A
+/// missing or non-directory path yields an empty set (an absent tier is not an
+/// error). Errors reading an existing directory propagate.
+/// Test: `list_source_stems_reads_md_files`, `list_source_stems_missing_empty`,
+/// `list_source_stems_reads_directory_skills`.
 pub fn list_source_stems(dir: &Path) -> Result<BTreeSet<String>> {
-    use crate::skills::deployer::{is_skill_file, skill_stem};
-
-    let mut stems = BTreeSet::new();
-    if !dir.is_dir() {
-        return Ok(stems);
-    }
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
-            continue;
-        };
-        if is_skill_file(&name) && entry.file_type()?.is_file() {
-            stems.insert(skill_stem(&name).to_string());
-        }
-    }
-    Ok(stems)
+    // #4949: delegate rather than re-derive. This function previously carried
+    // its own `is_skill_file(&name) && entry.file_type()?.is_file()` copy of the
+    // deployer's scan, so it inherited the same blindness to directory-shaped
+    // skills — and a planner that greenlights a different stem set than the
+    // deployer acts on is exactly the drift PR #2818's review caught once
+    // already.
+    Ok(crate::skills::source_scan::scan_skill_sources(dir)?
+        .skills
+        .into_iter()
+        .map(|skill| skill.stem)
+        .collect())
 }
 
 /// List the project-custom skill stems already present in the deploy target.

--- a/crates/trusty-agents-common/src/skills/tiers_tests.rs
+++ b/crates/trusty-agents-common/src/skills/tiers_tests.rs
@@ -289,3 +289,81 @@ fn deploy_all_no_user_tier_matches_bundled_only() {
     assert!(dest.path().join("a").join("SKILL.md").is_file());
     assert!(dest.path().join("b").join("SKILL.md").is_file());
 }
+
+// ---------------------------------------------------------------------------
+// #4949 — directory-shaped skills reach the tier planner and the deploy
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_source_stems_reads_directory_skills() {
+    // The planner must see the same stems the deployer acts on. Before #4949
+    // this function carried its own `is_file()` copy of the scan and returned
+    // an empty set for a directory-shaped tier, so the user tier was planned
+    // as absent and every one of its skills was dropped.
+    let src = TempDir::new().unwrap();
+    let skill = src.path().join("duetto-design-system");
+    fs::create_dir_all(skill.join("references")).unwrap();
+    fs::write(skill.join("SKILL.md"), "# Duetto\n").unwrap();
+    fs::write(skill.join("references").join("tokens.md"), "# T\n").unwrap();
+    write_skill(src.path(), "flat-skill", "F");
+
+    let stems = list_source_stems(src.path()).unwrap();
+
+    assert_eq!(stems, set(&["duetto-design-system", "flat-skill"]));
+}
+
+#[test]
+fn deploy_all_deploys_a_directory_shaped_user_skill() {
+    // End-to-end at the tier the defect was reported at: a user-custom skill
+    // authored as a directory in `~/.trusty-mpm/skills/` must reach the
+    // destination with every file it carries.
+    let bundled = TempDir::new().unwrap();
+    let user = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    write_skill(bundled.path(), "shipped", "S");
+    let skill = user.path().join("cto-kb-ingest");
+    fs::create_dir_all(skill.join("scripts")).unwrap();
+    fs::write(skill.join("SKILL.md"), "# Ingest\n").unwrap();
+    fs::write(skill.join("scripts").join("ingest.sh"), "#!/bin/sh\n").unwrap();
+
+    let deploy =
+        deploy_all_skill_tiers(bundled.path(), user.path(), dest.path(), |_| true).unwrap();
+
+    assert!(
+        deploy.stats.deployed.contains(&"cto-kb-ingest".to_string()),
+        "{:?}",
+        deploy.stats
+    );
+    assert!(dest.path().join("cto-kb-ingest").join("SKILL.md").is_file());
+    assert!(
+        dest.path()
+            .join("cto-kb-ingest")
+            .join("scripts")
+            .join("ingest.sh")
+            .is_file(),
+        "carried script missing"
+    );
+    // The bundled tier is untouched by the addition.
+    assert!(dest.path().join("shipped").join("SKILL.md").is_file());
+}
+
+#[test]
+fn deploy_all_lets_a_directory_user_skill_shadow_a_bundled_one() {
+    // Precedence must hold across layouts: a directory-shaped user skill
+    // outranks a same-named flat bundled skill.
+    let bundled = TempDir::new().unwrap();
+    let user = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    write_skill(bundled.path(), "shared", "BUNDLED");
+    let skill = user.path().join("shared");
+    fs::create_dir_all(&skill).unwrap();
+    fs::write(skill.join("SKILL.md"), "USER").unwrap();
+
+    let deploy =
+        deploy_all_skill_tiers(bundled.path(), user.path(), dest.path(), |_| true).unwrap();
+
+    let content = fs::read_to_string(dest.path().join("shared").join("SKILL.md")).unwrap();
+    assert_eq!(content, "USER", "user tier must win");
+    assert_eq!(deploy.shadowed.len(), 1);
+    assert_eq!(deploy.shadowed[0].winner, SkillTier::User);
+}

--- a/crates/trusty-mpm/changelog.d/4949-directory-shaped-skills.md
+++ b/crates/trusty-mpm/changelog.d/4949-directory-shaped-skills.md
@@ -1,0 +1,5 @@
+Fixed
+
+- User-tier skills authored as a directory (`~/.trusty-mpm/skills/<name>/SKILL.md`) now deploy into every project (closes [#4949](https://github.com/bobmatnyc/trusty-tools/issues/4949))
+  - they were silently rejected by the source scan, so `duetto-design-system` and `cto-kb-ingest` were hidden from every project's skill manifest
+  - a skill directory with no `SKILL.md` is now named in the deploy warning instead of vanishing


### PR DESCRIPTION
Closes [#4949](https://github.com/bobmatnyc/trusty-tools/issues/4949).

## Defect

The skill source scan accepted only a flat `<stem>.md` file. A directory-shaped skill — `<stem>/SKILL.md` plus `metadata.json`, `references/`, whatever else it carries — failed the `is_file()` test and fell through with no `else` branch. Every deploy skipped it and still reported success.

Two real user skills in `~/.trusty-mpm/skills/` were hidden from every project by this:

- **`duetto-design-system`** — SKILL.md, metadata.json, 4 reference docs
- **`cto-kb-ingest`** — SKILL.md, scripts/ingest.sh; three weeks older, hidden that entire time

A human worked around it by hand-copying the 6 duetto files into one project`s `.claude/skills/` and hand-registering their checksums in that project`s manifest. **That is not a fix.** It covers exactly one project, it leaves the other one hidden, and any automated redeploy undoes it. This PR does not touch it; the deployer change is what makes it unnecessary.

## Evidence

`crates/trusty-agents-common/src/skills/deployer.rs`, the source enumeration (the reported `skill_deployer.rs:112-154` is a 16-line re-export shim; the implementation moved here in #2892):

```rust
if entry.file_type()?.is_file() && is_skill_file(name) {
```

`crates/trusty-agents-common/src/skills/tiers.rs::list_source_stems` carried an independent copy of the same test, so the tier planner was identically blind and planned the user tier as absent.

**Bundled skills are not evidence of a working path.** They ship a HYBRID layout — a flat `tm-capabilities.md` beside a `tm-capabilities/references/` companion directory. The flat entry point satisfies `is_file()`; the companion directory is reached afterwards, keyed off the stem. Every bundled companion dir in the tree has a sibling `<stem>.md`; none is directory-shaped. So there was no existing directory-skill implementation to route the user tier through — both tiers read the same blind scan, and the fix had to be in that scan.

Fail-before, against unfixed code:

```
test skills::deployer::tests::deploy_directory_shaped_skill ... FAILED
the entry point must deploy: DeployStats { deployed: [], skipped: [], unchanged: [] }

test skills::deployer::tests::deploy_reports_a_skill_directory_with_no_entry_point ... FAILED
a malformed skill directory must be reported: DeployStats { deployed: [], skipped: [], unchanged: [] }

test result: FAILED. 0 passed; 6 failed; 0 ignored; 0 measured; 465 filtered out
```

`DeployStats { deployed: [], skipped: [], unchanged: [] }` is the whole defect: nothing deployed, nothing reported.

## Resolution

`skills::source_scan::scan_skill_sources` is now the single answer to "what is a skill here?", per the repo`s common-entry-point rule. Both the deployer and `list_source_stems` call it rather than each deriving their own.

- **Both layouts deploy.** Flat `<stem>.md`, and directory `<stem>/SKILL.md`.
- **Every carried file travels** — `metadata.json`, `references/**`, `scripts/**`, at any depth — under the same per-file ownership rule, keyed `<stem>/<relpath>`. That key scheme is byte-identical to the `<stem>/references/<file>` keys #2903 already wrote, so existing manifests keep matching and nothing re-deploys spuriously. Restricting extras to `references/*.md` would have fixed the `is_file()` half and left a second silent drop in place of the first: `cto-kb-ingest` ships `scripts/ingest.sh`.
- **A companion dir is not a malformed skill.** A directory whose name matches a flat skill in the same source is the bundled hybrid layout and is never reported — otherwise every bundled skill would warn on every deploy.
- **Silence is gone.** A directory with no `SKILL.md` is named in `DeployStats::skipped` and logged. `skipped` is the channel callers already surface (`managed_config::skill_skip_summary`, `tm sync-assets`), and it is what the sibling `mcp`-name rejection uses. Caveat, stated plainly: bare `tm` registers no tracing subscriber ([#4878](https://github.com/bobmatnyc/trusty-tools/issues/4878)), so on those paths the `warn!` line alone would not reach the user — riding `stats.skipped` is what makes the rejection reach a caller that can print it, and that is the strongest mechanism available without fixing #4878 here.
- **Non-UTF-8 carried file** is reported and skipped rather than aborting the deploy.

Scope note: `trusty-mpm::core::skill_staleness` has the same flat-only scan, but it is a read-only `tm doctor` diagnostic called with the BUNDLED source, where no directory skill exists. Left alone deliberately to keep the diff to the defect.

## Verification

Real skills through the fixed deployer (source copied read-only to scratch; `~/.trusty-mpm/skills/` untouched):

```
DEPLOYED: ["cto-kb-ingest", "cto-kb-ingest/scripts/ingest.sh", "duetto-design-system",
           "duetto-design-system/metadata.json",
           "duetto-design-system/references/component-index.md",
           "duetto-design-system/references/currency-and-numerical-display.md",
           "duetto-design-system/references/date-and-time-formatting.md",
           "duetto-design-system/references/design-tokens.md"]
SKIPPED:  []
```

All 8 files land. Rung 4 gates:

```
cargo fmt --check                                        — clean
cargo clippy -p trusty-agents-common --all-targets       — 0 warnings
cargo clippy -p trusty-mpm --all-targets                 — 0 warnings
cargo test -p trusty-agents-common — 482 passed; 0 failed
cargo test -p trusty-mpm           — 4614 passed; 0 failed; 7 ignored (+ all integration bins green)
bash scripts/check_line_cap.sh     — 3712 files, 0 violations
bash scripts/check_sld.sh          — 0 errors, 0 warnings
```

New coverage: 6 `source_scan` cases, 6 deployer cases, 3 tier cases. All 6 deployer cases failed before the fix.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools