### PR TITLE
feat(trusty-mpm): tm doctor --fix repairs findings instead of only reporting them

### DIFF
--- a/crates/trusty-mpm/changelog.d/4948-doctor-fix.md
+++ b/crates/trusty-mpm/changelog.d/4948-doctor-fix.md
@@ -1,0 +1,8 @@
+Added
+
+- `tm doctor --fix` repairs the findings tm can prove it owns, instead of only reporting them (closes [#4948](https://github.com/bobmatnyc/trusty-tools/issues/4948))
+  - dry run by default: it prints every change per item, with paths, and writes nothing until `--yes`
+  - covers `skill_staleness` (redeploy from the bundled asset), `hooks_contamination` (strip tm's own hook entries from this project's `.claude/settings*.json`, backing the file up first), and `push_guard` (retrofit the cross-branch `pre-push` guard)
+  - `legacy_sources` findings under `~/.claude` are reported as REFUSED and never deleted — a copy there may be hand-edited, and a directory name cannot prove otherwise
+  - a hand-edited (FROZEN) skill and a foreign `pre-push` hook are refused in both modes; `--include-frozen` now works with either `--fix` or `--fix-skills`
+  - `--fix-skills` gained a preview through `--fix`, and its output now names the exact file it repaired at each tier

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -1145,10 +1145,18 @@ pub(crate) enum Command {
 /// caller signature widen in step. One flattened struct keeps the dispatch a
 /// single binding and gives the actions a place to be documented together.
 /// What: a clap `Args` group; every field is opt-in and defaults to off, so a
-/// bare `tm doctor` is unchanged and READ-ONLY.
+/// bare `tm doctor` is unchanged and READ-ONLY. The `repair` arg group holds
+/// the two flags that select a repair (`--fix`, `--fix-skills`) so
+/// `--include-frozen` can require either one without duplicating the check.
 /// Test: `cli_parses_doctor`, `cli_parses_doctor_prune_stale_skills`,
-/// `cli_parses_doctor_fix_skills`.
+/// `cli_parses_doctor_fix_skills`, `cli_parses_doctor_fix`.
 #[derive(clap::Args, Debug, Clone, PartialEq, Eq)]
+#[command(group(
+    clap::ArgGroup::new("repair")
+        .args(["fix", "fix_skills"])
+        .multiple(true)
+        .required(false)
+))]
 pub struct DoctorFlags {
     /// Hidden manual escape hatch: force-remove stale pre-rename
     /// `~/.claude/skills/mpm-*` directories.
@@ -1186,13 +1194,41 @@ pub struct DoctorFlags {
     #[arg(long)]
     pub fix_skills: bool,
 
-    /// With `--fix-skills`, also overwrite skills that were HAND-EDITED
-    /// after deployment.
+    /// Repair every finding tm can prove it owns. DRY RUN unless `--yes`.
+    ///
+    /// Why (#4948): doctor checks were pull-only, so findings persisted
+    /// for weeks — 23 legacy skill copies, 26 project settings files
+    /// carrying tm hook entries, a repairable skill drift — all `Warn`,
+    /// none actionable without a separate command the operator had to know
+    /// existed. This runs the repairs whose target is something tm itself
+    /// wrote: the skill redeploy (`skill_staleness`), the project hook
+    /// cleanup (`hooks_contamination`), and the push-guard retrofit
+    /// (`push_guard`).
+    /// What: on its own it CHANGES NOTHING — it prints, per item and with
+    /// the path, exactly what it would do. `--yes` performs the writes.
+    /// It never deletes: `legacy_sources` findings under `~/.claude` are
+    /// reported as refused, because a copy there may be hand-edited and a
+    /// directory name cannot prove otherwise. Worktree checks stay
+    /// report-only.
+    #[arg(long)]
+    pub fix: bool,
+
+    /// With `--fix`, actually perform the repairs instead of previewing.
+    ///
+    /// Why (#4948): these repairs rewrite files the operator can see and
+    /// care about, so a preview is the default and writing is a second
+    /// deliberate act. Every overwrite is still backed up first.
+    /// What: promotes `--fix` from a dry run to an applied run.
+    #[arg(long, requires = "fix")]
+    pub yes: bool,
+
+    /// With `--fix` or `--fix-skills`, also overwrite skills that were
+    /// HAND-EDITED after deployment.
     ///
     /// Why (#4604): a frozen file is deliberate user customization, not
     /// rot, so overwriting one is an explicit opt-in and never the default
     /// fix path. Every overwrite is still backed up first.
     /// What: promotes `DriftedFrozen` findings into the repair set.
-    #[arg(long, requires = "fix_skills")]
+    #[arg(long, requires = "repair")]
     pub include_frozen: bool,
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/doctor_fix_skills.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/doctor_fix_skills.rs
@@ -1,11 +1,89 @@
-//! `tm doctor --fix-skills` — the local repair action (issue #4604).
+//! `tm doctor --fix-skills` — the local skill-repair action (issue #4604).
 //!
 //! Why: split out of `commands/misc.rs`, which the 500-SLOC production cap
 //! would otherwise reject. The behaviour and its constraints live in
 //! [`trusty_mpm::core::skill_repair`]; this file is CLI plumbing and printing.
-//! What: [`fix_skills_locally`] — resolve the deploy tiers and the skill
-//! reference, run the repair, print one line per outcome.
+//! `tm doctor --fix` (#4948) drives the same functions in dry-run mode, so the
+//! path resolution and the per-outcome wording live here once rather than
+//! being written twice and drifting.
+//! What: [`skill_repair_outcomes`] — resolve the deploy tiers and the skill
+//! reference and run the repair in a given mode; [`describe`] — one line per
+//! outcome; [`fix_skills_locally`] — the `--fix-skills` handler.
 //! Test: `core::skill_repair`'s own tests cover every outcome.
+
+use trusty_mpm::core::doctor_repair::RepairMode;
+use trusty_mpm::core::skill_repair::{RepairAction, RepairOutcome};
+
+/// Run the skill repair against this machine, in `mode`.
+///
+/// Why (#4604): the reference point must be the RUNNING BINARY's embedded
+/// assets — never the `~/.trusty-mpm/framework/skills` extraction cache, which
+/// is what lagged the installed binary and made every skill it covered report
+/// clean regardless of what shipped.
+/// What: resolves the deploy tiers from [`FrameworkPaths::default`] and the
+/// current directory, builds the reference (preferring a checked-out
+/// `agents/skills` submodule when this is a source checkout), and returns the
+/// reference's origin label alongside the outcomes. Local-filesystem only —
+/// independent of where the daemon that produced the report happens to be
+/// reachable. In [`RepairMode::DryRun`] nothing is written.
+/// Test: `core::skill_repair`'s own tests; this function is path resolution.
+pub(crate) fn skill_repair_outcomes(
+    include_frozen: bool,
+    mode: RepairMode,
+) -> (String, Vec<RepairOutcome>) {
+    use trusty_mpm::core::paths::FrameworkPaths;
+    use trusty_mpm::core::skill_drift::skill_reference;
+    use trusty_mpm::core::skill_repair::{backup_root_for, repair_skills_in_mode};
+
+    let paths = FrameworkPaths::default();
+    let project_dir = std::env::current_dir().ok();
+    let source = paths.skill_source_dir();
+    let submodule = (source != paths.skills).then_some(source);
+    let reference = skill_reference(submodule.as_deref());
+
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    let backup_root = backup_root_for(&home, chrono::Utc::now());
+
+    let outcomes = repair_skills_in_mode(
+        &reference,
+        &paths,
+        project_dir.as_deref(),
+        include_frozen,
+        &backup_root,
+        mode,
+    );
+    (reference.origin, outcomes)
+}
+
+/// One human line for one repair outcome.
+///
+/// Why: `--fix-skills` and `--fix` must describe the same outcome the same
+/// way; two renderers would let the preview and the applied run disagree about
+/// what happened.
+/// What: a phrase per [`RepairAction`] variant. A frozen skip names the opt-in
+/// that would overwrite it, and says the overwrite is backed up first.
+/// Test: `core::skill_repair`'s own tests produce every variant.
+pub(crate) fn describe(action: &RepairAction) -> String {
+    match action {
+        RepairAction::Repaired { backup: Some(p) } => {
+            format!("repaired and verified from disk (backup: {})", p.display())
+        }
+        RepairAction::Repaired { backup: None } => {
+            "written and verified from disk (was absent)".to_string()
+        }
+        RepairAction::WouldRepair { existed: true } => {
+            "would be overwritten from the bundled asset (backed up first)".to_string()
+        }
+        RepairAction::WouldRepair { existed: false } => {
+            "would be written (currently absent)".to_string()
+        }
+        RepairAction::SkippedFrozen => "FROZEN — hand-edited after deployment; left untouched \
+             (pass `--include-frozen` to overwrite it, backing it up first)"
+            .to_string(),
+        RepairAction::SkippedUnverifiable(why) => format!("skipped — {why}"),
+        RepairAction::Failed(why) => format!("FAILED — {why}"),
+    }
+}
 
 /// `--fix-skills` action — redeploy drifted skills and VERIFY from disk.
 ///
@@ -20,38 +98,17 @@
 /// intent.
 ///
 /// It never deletes anything and never touches worktrees — `tm doctor`'s
-/// worktree checks are report-only and stay that way.
-/// What: resolves the deploy tiers from [`FrameworkPaths::default`] and the
-/// current directory, builds the skill reference from the running binary (or a
-/// checked-out `agents/skills` submodule), runs the repair, and prints one line
-/// per outcome plus a summary. Local-filesystem only — independent of where the
-/// daemon that produced the report above happens to be reachable.
+/// worktree checks are report-only and stay that way. To see what it would do
+/// before it does it, use `tm doctor --fix`, which previews this repair
+/// alongside the others.
+/// What: runs [`skill_repair_outcomes`] in [`RepairMode::Apply`] and prints one
+/// path-tagged line per outcome plus a summary.
 /// Test: `core::skill_repair`'s own tests cover every outcome; this function is
-/// path resolution + printing.
+/// printing.
 pub(crate) fn fix_skills_locally(include_frozen: bool) {
-    use trusty_mpm::core::paths::FrameworkPaths;
-    use trusty_mpm::core::skill_drift::skill_reference;
-    use trusty_mpm::core::skill_repair::{RepairAction, backup_root_for, repair_skills};
+    let (origin, outcomes) = skill_repair_outcomes(include_frozen, RepairMode::Apply);
 
-    let paths = FrameworkPaths::default();
-    let project_dir = std::env::current_dir().ok();
-    // NEVER the `~/.trusty-mpm/framework/skills` extraction cache — that is the
-    // reference point #4604 proved untrustworthy.
-    let source = paths.skill_source_dir();
-    let submodule = (source != paths.skills).then_some(source);
-    let reference = skill_reference(submodule.as_deref());
-
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
-    let backup_root = backup_root_for(&home, chrono::Utc::now());
-
-    println!("\nfix-skills (compared against {})", reference.origin);
-    let outcomes = repair_skills(
-        &reference,
-        &paths,
-        project_dir.as_deref(),
-        include_frozen,
-        &backup_root,
-    );
+    println!("\nfix-skills (compared against {origin})");
     if outcomes.is_empty() {
         println!("  nothing to repair — every deployed skill already matches");
         return;
@@ -60,28 +117,18 @@ pub(crate) fn fix_skills_locally(include_frozen: bool) {
     let mut repaired = 0usize;
     let mut failed = 0usize;
     for outcome in &outcomes {
-        let line = match &outcome.action {
-            RepairAction::Repaired { backup } => {
-                repaired += 1;
-                match backup {
-                    Some(p) => format!("repaired and verified from disk (backup: {})", p.display()),
-                    None => "written and verified from disk (was absent)".to_string(),
-                }
-            }
-            RepairAction::SkippedFrozen => {
-                "FROZEN — hand-edited after deployment; left untouched (pass \
-                 `--include-frozen` to overwrite it, backing it up first)"
-                    .to_string()
-            }
-            RepairAction::SkippedUnverifiable(why) => {
-                format!("skipped — {why}")
-            }
-            RepairAction::Failed(why) => {
-                failed += 1;
-                format!("FAILED — {why}")
-            }
-        };
-        println!("  {}/{}: {line}", outcome.tier, outcome.stem);
+        match &outcome.action {
+            RepairAction::Repaired { .. } => repaired += 1,
+            RepairAction::Failed(_) => failed += 1,
+            _ => {}
+        }
+        println!(
+            "  {}/{} [{}]: {}",
+            outcome.tier,
+            outcome.stem,
+            outcome.path.display(),
+            describe(&outcome.action)
+        );
     }
     println!(
         "  {repaired} repaired, {} skipped, {failed} failed",

--- a/crates/trusty-mpm/src/bin/tm/commands/doctor_repair.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/doctor_repair.rs
@@ -1,0 +1,225 @@
+//! `tm doctor --fix` — run every safely-repairable doctor finding (#4948).
+//!
+//! Why: the checks were pull-only, so findings persisted for weeks — 23 legacy
+//! skill copies, 26 contaminated project settings files, one repairable skill
+//! drift, all `Warn`, none actionable in the same breath as the report. This
+//! is the action half. It is deliberately narrow: only repairs whose target is
+//! something tm itself wrote and can prove it owns.
+//! It is also where every OTHER opt-in local action `tm doctor` can be
+//! followed by is dispatched from — `--prune-stale-skills`, `--fix-skills`,
+//! `--fix` — so `commands/misc.rs` stays the report and the actions stay
+//! together (and under the 500-SLOC production cap).
+//! What: [`run_post_report_actions`] — the dispatch; [`run_repairs`] — resolve
+//! the paths, run each repair from [`trusty_mpm::core::doctor_repair`] plus the
+//! skill redeploy, and print one line per item, dry run unless `apply`;
+//! [`prune_stale_skills_locally`] — the hidden pre-rename cleanup.
+//! Test: `core::doctor_repair`'s tests cover every repair and every refusal;
+//! this file is path resolution and printing.
+
+use colored::Colorize;
+use trusty_mpm::core::doctor_repair::{
+    RepairMode, RepairStep, StepStatus, refuse_legacy_sources, repair_hooks_contamination,
+    repair_push_guard,
+};
+use trusty_mpm::core::skill_repair::RepairAction;
+
+use crate::cli::DoctorFlags;
+
+/// Run whichever post-report local actions the operator opted into.
+///
+/// Why: `tm doctor` itself is READ-ONLY and stays that way. Every action here
+/// requires its own flag, and they run after the report so the operator sees
+/// the diagnosis above the remediation. They are local-filesystem operations,
+/// independent of where the daemon that produced the report is reachable.
+/// What: `--prune-stale-skills`, then `--fix-skills`, then `--fix` — the
+/// unified driver last, so an operator who passed both skill flags sees the
+/// narrow section first and the full list second rather than an order that
+/// implies the second run did nothing.
+/// Test: `cli_parses_doctor_fix`, `cli_parses_doctor_fix_skills` pin the flags;
+/// the actions' own modules carry the behaviour tests.
+pub(crate) fn run_post_report_actions(flags: &DoctorFlags) {
+    if flags.prune_stale_skills {
+        prune_stale_skills_locally();
+    }
+    if flags.fix_skills {
+        super::doctor_fix_skills::fix_skills_locally(flags.include_frozen);
+    }
+    if flags.fix {
+        run_repairs(flags.yes, flags.include_frozen);
+    }
+}
+
+/// Hidden `--prune-stale-skills` action — force-remove pre-rename
+/// `~/.claude/skills/mpm-*` directories.
+///
+/// Why: the mpm-*→tm-* skill rename (#1905) never deletes a skill's old
+/// directory when it is renamed (`skill_deployer::deploy_skills` only writes,
+/// never removes). In normal operation this is handled automatically and
+/// silently by the one-time startup migration
+/// (`core::stale_skills::run_stale_mpm_skills_migration_once`); this hidden
+/// flag exists only as a manual escape hatch for troubleshooting (e.g. the
+/// migration marker file was lost or hand-edited).
+///
+/// It is the ONE action here that deletes, which is why it is hidden, narrowly
+/// scoped to trusty-mpm's own frozen pre-rename skill names, and deliberately
+/// NOT part of `--fix`: `--fix` never deletes.
+/// What: resolves `~/.claude/skills/` via `FrameworkPaths::default`, lists only
+/// trusty-mpm's own pre-rename skill names (never an unrelated `mpm-*` skill
+/// from another tool), prints what it found, then removes them.
+/// Test: `core::stale_skills::tests` covers the detection/removal logic this
+/// wraps; this function itself is thin I/O + printing.
+fn prune_stale_skills_locally() {
+    use trusty_mpm::core::paths::FrameworkPaths;
+    use trusty_mpm::core::stale_skills::{find_stale_mpm_skills, remove_stale_mpm_skills};
+
+    let paths = FrameworkPaths::default();
+    let dir = paths.claude_skills_dir();
+    let stale = find_stale_mpm_skills(&dir);
+    if stale.is_empty() {
+        println!(
+            "\nno stale pre-rename mpm-* skills found in {}",
+            dir.display()
+        );
+        return;
+    }
+
+    println!("\nremoving {} stale pre-rename skill(s):", stale.len());
+    for skill in &stale {
+        println!("  - {}", skill.name);
+    }
+    match remove_stale_mpm_skills(&stale) {
+        Ok(n) => println!("removed {n} stale skill directory(ies)"),
+        Err(e) => eprintln!("failed to remove stale skills: {e}"),
+    }
+}
+
+/// `--fix` action — preview, or apply, every safe repair.
+///
+/// Why: see the module doc. The default is a preview because these repairs
+/// rewrite files the operator can see and care about; `--yes` is the second
+/// deliberate act that lets one write.
+/// What: runs, in order, the skill redeploy (`skill_staleness`), the project
+/// hook cleanup (`hooks_contamination`), the push-guard retrofit
+/// (`push_guard`), and the `legacy_sources` refusals — printing each item's
+/// path, what would change, and the outcome. In dry run it closes by naming
+/// the flag that applies. It never deletes, and every `legacy_sources` finding
+/// is reported as refused rather than acted on.
+/// Test: `core::doctor_repair`'s tests; this function is printing.
+pub(crate) fn run_repairs(apply: bool, include_frozen: bool) {
+    let mode = RepairMode::from_apply_flag(apply);
+    println!(
+        "\nfix ({})",
+        if apply {
+            "applying".to_string()
+        } else {
+            "dry run — nothing will be written".to_string()
+        }
+    );
+
+    let mut steps = skill_steps(include_frozen, mode);
+
+    let project_dir = std::env::current_dir().ok();
+    if let Some(project) = &project_dir {
+        steps.extend(repair_hooks_contamination(project, mode));
+        steps.extend(repair_push_guard(project, mode));
+    } else {
+        eprintln!("  could not resolve the current directory — skipped the project-scoped repairs");
+    }
+
+    if let Some(home) = dirs::home_dir() {
+        steps.extend(refuse_legacy_sources(&home));
+    }
+
+    if steps.is_empty() {
+        println!("  nothing to repair");
+        return;
+    }
+
+    let mut planned = 0usize;
+    let mut applied = 0usize;
+    let mut refused = 0usize;
+    let mut failed = 0usize;
+    for step in &steps {
+        let (icon, detail) = match &step.status {
+            StepStatus::Planned => {
+                planned += 1;
+                ("~".yellow(), format!("would {}", step.what))
+            }
+            StepStatus::Applied { backup } => {
+                applied += 1;
+                match backup {
+                    Some(p) => (
+                        "✓".green(),
+                        format!("{} (backup: {})", step.what, p.display()),
+                    ),
+                    None => ("✓".green(), step.what.clone()),
+                }
+            }
+            StepStatus::Refused(why) => {
+                refused += 1;
+                ("-".blue(), format!("{} — REFUSED: {why}", step.what))
+            }
+            StepStatus::Failed(why) => {
+                failed += 1;
+                ("✗".red(), format!("{} — FAILED: {why}", step.what))
+            }
+        };
+        println!(
+            "  {icon} [{}] {}: {detail}",
+            step.check,
+            step.path.display()
+        );
+    }
+
+    println!("\n  {applied} applied, {planned} planned, {refused} refused, {failed} failed");
+    if !apply && planned > 0 {
+        println!("  dry run — re-run with `tm doctor --fix --yes` to apply.");
+    }
+    if refused > 0 {
+        println!(
+            "  refused items are reported, never repaired — tm does not delete files it \
+             cannot prove it owns."
+        );
+    }
+}
+
+/// The skill redeploy, expressed as [`RepairStep`]s.
+///
+/// Why: `--fix` prints one uniform list, so the skill repair's richer outcome
+/// type is projected onto the shared shape here rather than printed through a
+/// second format the operator has to learn. The mapping is deliberately lossy
+/// in one direction only: a FROZEN skip becomes a [`StepStatus::Refused`],
+/// which is exactly what it is.
+/// What: calls [`super::doctor_fix_skills::skill_repair_outcomes`] — the same
+/// function `--fix-skills` uses, in the mode this run selected — and maps each
+/// outcome onto a step. The classification itself is never re-derived here.
+/// Test: `core::skill_repair`'s tests produce every outcome variant.
+fn skill_steps(include_frozen: bool, mode: RepairMode) -> Vec<RepairStep> {
+    let (_origin, outcomes) = super::doctor_fix_skills::skill_repair_outcomes(include_frozen, mode);
+    outcomes
+        .into_iter()
+        .map(|o| {
+            let what = format!(
+                "redeploy `{}` at the {} tier from the bundled asset",
+                o.stem, o.tier
+            );
+            let status = match o.action {
+                RepairAction::Repaired { backup } => StepStatus::Applied { backup },
+                RepairAction::WouldRepair { .. } => StepStatus::Planned,
+                RepairAction::SkippedFrozen => StepStatus::Refused(
+                    "hand-edited after deployment — pass `--include-frozen` to overwrite it, \
+                     backing it up first"
+                        .to_string(),
+                ),
+                RepairAction::SkippedUnverifiable(why) => StepStatus::Refused(why),
+                RepairAction::Failed(why) => StepStatus::Failed(why),
+            };
+            RepairStep {
+                check: "skill_staleness",
+                path: o.path,
+                what,
+                status,
+            }
+        })
+        .collect()
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/misc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/misc.rs
@@ -206,59 +206,12 @@ pub(crate) async fn doctor(url: &str, flags: &crate::cli::DoctorFlags) -> anyhow
         other => eprintln!("doctor: unexpected result {other:?}"),
     }
 
-    if flags.prune_stale_skills {
-        prune_stale_skills_locally();
-    }
-
-    if flags.fix_skills {
-        super::doctor_fix_skills::fix_skills_locally(flags.include_frozen);
-    }
+    // #4948: every opt-in local action the report can be followed by lives in
+    // `doctor_repair`, so this file stays the report and the actions stay
+    // together.
+    super::doctor_repair::run_post_report_actions(flags);
 
     Ok(())
-}
-
-/// Hidden `--prune-stale-skills` action — force-remove pre-rename
-/// `~/.claude/skills/mpm-*` directories.
-///
-/// Why: the mpm-*→tm-* skill rename (#1905) never deletes a skill's old
-/// directory when it is renamed (`skill_deployer::deploy_skills` only writes,
-/// never removes). In normal operation this is handled automatically and
-/// silently by the one-time startup migration
-/// (`core::stale_skills::run_stale_mpm_skills_migration_once`); this hidden
-/// flag exists only as a manual escape hatch for troubleshooting (e.g. the
-/// migration marker file was lost or hand-edited). This runs entirely
-/// against the local filesystem — like `tm install` and `tm repair` —
-/// independent of where the daemon (whose report is printed above) happens
-/// to be reachable.
-/// What: resolves `~/.claude/skills/` via [`FrameworkPaths::default`], calls
-/// [`find_stale_mpm_skills`] to list only trusty-mpm's own frozen pre-rename
-/// skill names (never an unrelated `mpm-*` skill from another tool), prints
-/// what it found, then [`remove_stale_mpm_skills`] to delete them.
-/// Test: `core::stale_skills::tests` covers the detection/removal logic this
-/// wraps; this function itself is thin I/O + printing.
-fn prune_stale_skills_locally() {
-    use trusty_mpm::core::paths::FrameworkPaths;
-    use trusty_mpm::core::stale_skills::{find_stale_mpm_skills, remove_stale_mpm_skills};
-
-    let paths = FrameworkPaths::default();
-    let dir = paths.claude_skills_dir();
-    let stale = find_stale_mpm_skills(&dir);
-    if stale.is_empty() {
-        println!(
-            "\nno stale pre-rename mpm-* skills found in {}",
-            dir.display()
-        );
-        return;
-    }
-
-    println!("\nremoving {} stale pre-rename skill(s):", stale.len());
-    for skill in &stale {
-        println!("  - {}", skill.name);
-    }
-    match remove_stale_mpm_skills(&stale) {
-        Ok(n) => println!("removed {n} stale skill directory(ies)"),
-        Err(e) => eprintln!("failed to remove stale skills: {e}"),
-    }
 }
 
 /// `validate` subcommand — diff a workspace's deployed `.claude/{agents,skills}`

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -23,6 +23,8 @@ pub(crate) mod delete;
 // cannot detect that the process answering it is the unsupervised one.
 pub(crate) mod doctor_fix_skills;
 pub(crate) mod doctor_orphan;
+// #4948: the `tm doctor --fix` driver — dry-run by default, `--yes` to write.
+pub(crate) mod doctor_repair;
 pub(crate) mod doctor_stale;
 pub(crate) mod first_run;
 pub(crate) mod generate;

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -277,6 +277,8 @@ fn cli_parses_doctor() {
             flags: DoctorFlags {
                 prune_stale_skills: false,
                 fix_skills: false,
+                fix: false,
+                yes: false,
                 include_frozen: false,
             }
         }
@@ -292,6 +294,8 @@ fn cli_parses_doctor_prune_stale_skills() {
             flags: DoctorFlags {
                 prune_stale_skills: true,
                 fix_skills: false,
+                fix: false,
+                yes: false,
                 include_frozen: false,
             }
         }
@@ -314,6 +318,8 @@ fn cli_parses_doctor_fix_skills() {
             flags: DoctorFlags {
                 prune_stale_skills: false,
                 fix_skills: true,
+                fix: false,
+                yes: false,
                 include_frozen: false,
             }
         }
@@ -336,6 +342,60 @@ fn cli_parses_doctor_fix_skills() {
         Cli::try_parse_from(["trusty-mpm", "doctor", "--include-frozen"]).is_err(),
         "--include-frozen without --fix-skills must be rejected"
     );
+}
+
+/// #4948: `--fix` is a DRY RUN, and writing needs `--yes` on top of it.
+///
+/// Why: `--fix` rewrites project settings files and deployed skills. The CLI
+/// is where "the default cannot write" is actually enforced, so it gets a test
+/// — a `--yes` that parses without `--fix` would let a future refactor reach a
+/// write path from a flag the operator thinks is inert.
+/// Test: this test.
+#[test]
+fn cli_parses_doctor_fix() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "doctor", "--fix"]).unwrap();
+    assert!(matches!(
+        cli.command.unwrap(),
+        Command::Doctor {
+            flags: DoctorFlags {
+                fix: true,
+                yes: false,
+                fix_skills: false,
+                ..
+            }
+        }
+    ));
+
+    let cli = Cli::try_parse_from(["trusty-mpm", "doctor", "--fix", "--yes"]).unwrap();
+    assert!(matches!(
+        cli.command.unwrap(),
+        Command::Doctor {
+            flags: DoctorFlags {
+                fix: true,
+                yes: true,
+                ..
+            }
+        }
+    ));
+
+    assert!(
+        Cli::try_parse_from(["trusty-mpm", "doctor", "--yes"]).is_err(),
+        "--yes without --fix must be rejected"
+    );
+
+    // `--include-frozen` requires EITHER repair flag (issue #4948 widened the
+    // `requires` from `--fix-skills` alone to the `repair` group).
+    let cli = Cli::try_parse_from(["trusty-mpm", "doctor", "--fix", "--include-frozen"]).unwrap();
+    assert!(matches!(
+        cli.command.unwrap(),
+        Command::Doctor {
+            flags: DoctorFlags {
+                fix: true,
+                include_frozen: true,
+                ..
+            }
+        }
+    ));
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/doctor_repair.rs
+++ b/crates/trusty-mpm/src/core/doctor_repair.rs
@@ -41,8 +41,9 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::core::push_guard::{GuardState, HookInstall, inspect_pre_push_guard,
-    install_pre_push_guard};
+use crate::core::push_guard::{
+    GuardState, HookInstall, inspect_pre_push_guard, install_pre_push_guard,
+};
 use crate::core::standalone::hooks::cleanup::clean_settings_file;
 
 /// Whether a repair may write, or is only describing what it would write.
@@ -285,11 +286,7 @@ pub fn refuse_legacy_sources(home: &Path) -> Vec<RepairStep> {
     if let Ok(entries) = std::fs::read_dir(&skills) {
         let mut legacy: Vec<PathBuf> = entries
             .flatten()
-            .filter(|e| {
-                e.file_name()
-                    .to_str()
-                    .is_some_and(|n| n.starts_with("tm-"))
-            })
+            .filter(|e| e.file_name().to_str().is_some_and(|n| n.starts_with("tm-")))
             .map(|e| e.path())
             .collect();
         legacy.sort();

--- a/crates/trusty-mpm/src/core/doctor_repair.rs
+++ b/crates/trusty-mpm/src/core/doctor_repair.rs
@@ -1,0 +1,323 @@
+//! `tm doctor --fix`: the repair driver behind the diagnostic (issue #4948).
+//!
+//! Why: every doctor check was pull-only. On the machine that motivated #4948,
+//! `legacy_sources` had been reporting 23 leftover `tm-*` skill copies,
+//! `hooks_contamination` 26 project settings files, and `skill_staleness` one
+//! repairable drift — for weeks. All three are `Warn`, none auto-repairs, and
+//! all three only surface when a human happens to run `tm doctor`. A report
+//! nobody can act on in the same breath is a report that gets ignored.
+//!
+//! `tm doctor --fix-skills` (#4604) already proved the shape a repair must
+//! take here, so this module extends that shape rather than inventing a second
+//! one: back up before overwriting, verify from disk, never silently overwrite
+//! a hand-edited file, and never delete. What it adds is the preview
+//! `--fix-skills` lacked and a registry so a second repairable check does not
+//! mean a second bespoke flag.
+//!
+//! Three rules bound everything here, and they are the reason the module is
+//! this small:
+//!
+//! 1. **Dry run is the default.** [`RepairMode::DryRun`] is what a bare
+//!    `--fix` gets; writing requires `--yes`. Every repair must be able to
+//!    describe itself, per item and with a path, before it acts.
+//! 2. **Nothing is deleted, and nothing the operator authored is rewritten.**
+//!    A checksum mismatch means a human edited the file, which is ownership,
+//!    not rot — the same rule `skill_repair` enforces for FROZEN skills and
+//!    `push_guard` enforces for a foreign `pre-push` hook. This module honours
+//!    it by delegating to those modules rather than re-deriving ownership.
+//! 3. **`~/.claude/` is the operator's real Claude Code config.** tm refreshes
+//!    the skill copies it deployed there and it removes the hook entries a
+//!    pre-#2940 `tm install` wrote into project settings — both are tm's own
+//!    residue, recorded in tm's own ledgers. It does NOT delete anything else
+//!    there. [`refuse_legacy_sources`] is that refusal, made visible rather
+//!    than silent: `legacy_sources` findings are REPORTED with their paths and
+//!    a reason, never acted on. See #4409.
+//!
+//! What: [`RepairMode`], the [`RepairStep`] outcome model, and the three
+//! repairs `--fix` drives — [`repair_hooks_contamination`],
+//! [`repair_push_guard`], and (via [`crate::core::skill_repair`]) the skill
+//! redeploy — plus [`refuse_legacy_sources`].
+//! Test: `doctor_repair_tests.rs`.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::push_guard::{GuardState, HookInstall, inspect_pre_push_guard,
+    install_pre_push_guard};
+use crate::core::standalone::hooks::cleanup::clean_settings_file;
+
+/// Whether a repair may write, or is only describing what it would write.
+///
+/// Why: a command that rewrites operator state needs the preview and the apply
+/// to be the same code path — a separate planner drifts from the actor exactly
+/// when it matters. Threading a mode rather than duplicating the logic is what
+/// makes "print exactly what would change before changing it" a guarantee
+/// instead of an intention.
+/// What: two variants; [`RepairMode::DryRun`] is the default a bare `--fix`
+/// selects, and [`RepairMode::Apply`] requires `--yes`.
+/// Test: every `*_dry_run_*` test in `doctor_repair_tests.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepairMode {
+    /// Describe what would change. Write nothing.
+    DryRun,
+    /// Perform the repair.
+    Apply,
+}
+
+impl RepairMode {
+    /// Pick the mode a CLI flag pair selects.
+    ///
+    /// Why: `--fix` alone must never write, so the conversion lives in one
+    /// place rather than as an `if apply { … } else { … }` at each call site.
+    /// What: [`RepairMode::Apply`] only when `apply` is `true`.
+    /// Test: `mode_defaults_to_dry_run`.
+    pub fn from_apply_flag(apply: bool) -> Self {
+        if apply { Self::Apply } else { Self::DryRun }
+    }
+}
+
+/// What one repair did — or deliberately did not do — to one file.
+///
+/// Why: "would change", "changed", "refused" and "failed" are four different
+/// facts and collapsing any pair of them is how a fix mode lies. `Refused` in
+/// particular is the safety rule working, not an error, and must never render
+/// like one.
+/// What: four terminal states. `Applied` carries the backup so an operator can
+/// undo it; `Refused` carries the reason.
+/// Test: `doctor_repair_tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StepStatus {
+    /// Dry run: this WOULD change, and nothing was written.
+    Planned,
+    /// Applied, with the backup taken beforehand when one was possible.
+    Applied { backup: Option<PathBuf> },
+    /// Deliberately not repaired; the string says why.
+    Refused(String),
+    /// Attempted and did not work; the string says why.
+    Failed(String),
+}
+
+/// One repair's outcome against one path.
+///
+/// Why: an operator triaging `tm doctor --fix` output needs to map every line
+/// back to the check that produced it and the file it concerns, without
+/// re-running the diagnostic.
+/// What: the originating check name, the exact path, a one-line description of
+/// the change, and the [`StepStatus`].
+/// Test: `doctor_repair_tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepairStep {
+    /// The `tm doctor` check this repair answers (`hooks_contamination`, …).
+    pub check: &'static str,
+    /// The file or directory the step concerns.
+    pub path: PathBuf,
+    /// One line describing the change, in the same words for both modes.
+    pub what: String,
+    /// What happened.
+    pub status: StepStatus,
+}
+
+impl RepairStep {
+    /// Did this step actually modify the filesystem?
+    ///
+    /// Why: the summary counts applied repairs and must not count a plan, a
+    /// refusal, or a failure as one.
+    /// What: `true` only for [`StepStatus::Applied`].
+    /// Test: `hooks_repair_applies_and_backs_up`.
+    pub fn changed(&self) -> bool {
+        matches!(self.status, StepStatus::Applied { .. })
+    }
+}
+
+/// Remove tm's own hook entries from a project's `.claude/settings*.json`.
+///
+/// Why (#2940, #4948): a pre-#2940 `tm install` wired tm hooks into every
+/// project settings file it could reach, and `hooks_contamination` has been
+/// reporting the leftovers ever since without being able to clear them. The
+/// entries are tm's — tm wrote them, tm recognises them, and removing them
+/// restores a file the project owns to what the project put there.
+///
+/// It removes ONLY entries [`crate::core::standalone::hooks`] classifies as
+/// tm-owned. A foreign (claude-mpm) entry in the same file, or even in the same
+/// hand-mixed hook group, is left exactly where it is — that call belongs to
+/// the operator, and `hooks_foreign_conflict` stays report-only for the same
+/// reason.
+/// What: scans `<project>/.claude/settings.json` and `settings.local.json`
+/// through [`clean_settings_file`], whose `force` parameter IS the dry-run
+/// gate, so preview and apply share one reader and one classifier. Applying
+/// writes a byte-identical `<path>.bak-<epoch>` first. A file with no tm
+/// entries produces no step. Scope is this project only — the `$HOME`-wide
+/// sweep stays `tm hooks clean`, which pays that cost once on request rather
+/// than on every diagnostic.
+/// Test: `hooks_repair_applies_and_backs_up`,
+/// `hooks_repair_dry_run_changes_nothing`,
+/// `hooks_repair_leaves_foreign_entries_alone`.
+pub fn repair_hooks_contamination(project_dir: &Path, mode: RepairMode) -> Vec<RepairStep> {
+    let claude = project_dir.join(".claude");
+    let mut steps = Vec::new();
+    for name in ["settings.json", "settings.local.json"] {
+        let path = claude.join(name);
+        match clean_settings_file(&path, mode == RepairMode::Apply) {
+            Ok(None) => {}
+            Ok(Some(outcome)) => {
+                let what = format!(
+                    "remove tm hook entries under [{}]",
+                    outcome.removed_events.join(", ")
+                );
+                let status = match mode {
+                    RepairMode::DryRun => StepStatus::Planned,
+                    RepairMode::Apply => StepStatus::Applied {
+                        backup: outcome.backup_path,
+                    },
+                };
+                steps.push(RepairStep {
+                    check: "hooks_contamination",
+                    path: outcome.path,
+                    what,
+                    status,
+                });
+            }
+            Err(e) => steps.push(RepairStep {
+                check: "hooks_contamination",
+                path,
+                what: "remove tm hook entries".to_string(),
+                status: StepStatus::Failed(e.to_string()),
+            }),
+        }
+    }
+    steps
+}
+
+/// Install the #2867 cross-branch `pre-push` guard on this clone.
+///
+/// Why (#2867, #4948): the guard installs itself only on the clone path, so
+/// every base clone that predates it is silently unprotected and a worktree
+/// tracking a foreign branch can force-push over that branch's reviewed
+/// lineage. `push_guard` has been naming `tm repair push-guard` as the
+/// retrofit; this makes `--fix` run it. The repair is purely additive — it
+/// writes one file that was absent or that tm itself wrote an older revision
+/// of — which is why it is in the auto-repairable set at all.
+///
+/// It never overwrites a hook it does not own. A foreign `pre-push`, a
+/// symlink, an unreadable file, or a `core.hooksPath` redirect each produce a
+/// [`StepStatus::Refused`] naming the reason, because
+/// [`inspect_pre_push_guard`] and [`install_pre_push_guard`] make one shared
+/// ownership judgement rather than two that could drift.
+/// What: classifies the slot with [`inspect_pre_push_guard`] — read-only, and
+/// the whole of the dry run — then in [`RepairMode::Apply`] calls
+/// [`install_pre_push_guard`]. An already-current guard produces no step.
+/// Test: `push_guard_repair_installs_when_missing`,
+/// `push_guard_repair_dry_run_writes_nothing`,
+/// `push_guard_repair_refuses_a_foreign_hook`.
+pub fn repair_push_guard(repo_path: &Path, mode: RepairMode) -> Vec<RepairStep> {
+    let what = match inspect_pre_push_guard(repo_path) {
+        GuardState::Current(_) => return Vec::new(),
+        GuardState::Missing(path) => (path, "install the cross-branch pre-push guard"),
+        GuardState::Outdated(path) => (path, "upgrade the cross-branch pre-push guard"),
+        GuardState::Foreign(reason) => {
+            return vec![RepairStep {
+                check: "push_guard",
+                path: repo_path.to_path_buf(),
+                what: "install the cross-branch pre-push guard".to_string(),
+                status: StepStatus::Refused(reason),
+            }];
+        }
+    };
+    let (path, description) = what;
+
+    if mode == RepairMode::DryRun {
+        return vec![RepairStep {
+            check: "push_guard",
+            path,
+            what: description.to_string(),
+            status: StepStatus::Planned,
+        }];
+    }
+
+    let status = match install_pre_push_guard(repo_path) {
+        Ok(HookInstall::Installed(_)) => StepStatus::Applied { backup: None },
+        // Between the inspection above and this call the slot became current
+        // or foreign. Report what actually happened, never what was planned.
+        Ok(HookInstall::AlreadyCurrent(_)) => {
+            StepStatus::Refused("already current — nothing to do".to_string())
+        }
+        Ok(HookInstall::Refused(reason)) => StepStatus::Refused(reason),
+        Err(e) => StepStatus::Failed(e),
+    };
+    vec![RepairStep {
+        check: "push_guard",
+        path,
+        what: description.to_string(),
+        status,
+    }]
+}
+
+/// Report every `legacy_sources` finding as REFUSED — never delete one.
+///
+/// Why (#4948, #4409): this is the check whose "obvious" repair is the one
+/// that must not ship. `legacy_sources` counts `~/.claude/skills/tm-*` copies
+/// and the legacy `~/.trusty-mpm/claude-config` directory; the repair that
+/// would clear the warning is deletion, inside the operator's real Claude Code
+/// config. Some of those copies are hand-edited — a checksum mismatch is
+/// ownership, not rot — and tm cannot tell a stale duplicate from somebody's
+/// customization by looking at a directory name. A fix mode that deletes what
+/// it thinks is orphaned is the 2026-07-21 `rm -rf .base/*` incident with a
+/// scheduler: that command wiped a shared bare clone's git internals and
+/// orphaned ~70 worktrees.
+///
+/// So the answer is "report, refuse, and say why", and it is implemented
+/// rather than merely documented — an operator running `--fix` sees each path
+/// and the reason it survived, instead of silence they could mistake for
+/// "nothing found". Refreshing the CONTENT of a tm-deployed copy there is a
+/// different operation and is still available: it goes through the skill
+/// repair, which consults tm's own ownership ledger first.
+/// What: one [`StepStatus::Refused`] step per `tm-*` entry directly under
+/// `<home>/.claude/skills`, plus one for the legacy managed-config directory
+/// if present. Reads directory names only; opens nothing; writes nothing.
+/// Test: `legacy_sources_are_refused_never_deleted`,
+/// `legacy_sources_ignores_a_foreign_skill`.
+pub fn refuse_legacy_sources(home: &Path) -> Vec<RepairStep> {
+    const REASON: &str = "tm never deletes inside ~/.claude — a copy here may be hand-edited, \
+                          and a directory name cannot prove otherwise. Remove it by hand once \
+                          you have confirmed nothing depends on it";
+
+    let mut steps = Vec::new();
+    let skills = home.join(".claude").join("skills");
+    if let Ok(entries) = std::fs::read_dir(&skills) {
+        let mut legacy: Vec<PathBuf> = entries
+            .flatten()
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.starts_with("tm-"))
+            })
+            .map(|e| e.path())
+            .collect();
+        legacy.sort();
+        steps.extend(legacy.into_iter().map(|path| RepairStep {
+            check: "legacy_sources",
+            path,
+            what: "leftover pre-migration tm-* skill copy".to_string(),
+            status: StepStatus::Refused(REASON.to_string()),
+        }));
+    }
+
+    let legacy_config = home.join(".trusty-mpm").join("claude-config");
+    if legacy_config.is_dir() {
+        steps.push(RepairStep {
+            check: "legacy_sources",
+            path: legacy_config,
+            what: "legacy managed-config directory".to_string(),
+            status: StepStatus::Refused(
+                "superseded by the tm-owned ~/.trusty-tools config home, but tm does not \
+                 delete a directory it can no longer attribute. Remove it by hand once no \
+                 session references it"
+                    .to_string(),
+            ),
+        });
+    }
+    steps
+}
+
+#[cfg(test)]
+#[path = "doctor_repair_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/doctor_repair_tests.rs
+++ b/crates/trusty-mpm/src/core/doctor_repair_tests.rs
@@ -1,0 +1,261 @@
+//! Tests for [`super`] — the `tm doctor --fix` repair driver (issue #4948).
+//!
+//! Why: this command deletes and rewrites operator state, so each of its three
+//! safety rules gets a test that fails if the rule is removed — dry run writes
+//! nothing, a file tm does not own is refused, and `legacy_sources` findings
+//! are never deleted. The "it actually repairs" tests are the easy half; the
+//! refusals are the half worth having.
+//! What: per repair, one apply test and one dry-run test, plus the ownership
+//! refusals.
+//! Test: this file.
+
+use super::*;
+use std::fs;
+
+/// A settings file carrying one tm hook entry and one foreign (claude-mpm) one.
+///
+/// Why: the interesting case is the mixed file — the repair must strip tm's
+/// entry and leave the other harness's alone. A tm-only fixture cannot show
+/// that.
+fn write_mixed_settings(project: &Path) -> PathBuf {
+    let claude = project.join(".claude");
+    fs::create_dir_all(&claude).unwrap();
+    let path = claude.join("settings.json");
+    fs::write(
+        &path,
+        serde_json::json!({
+            "model": "opus",
+            "hooks": {
+                "PreToolUse": [
+                    { "hooks": [{ "type": "command", "command": "tm hook" }] },
+                    { "hooks": [{ "type": "command", "command": "claude-mpm hook" }] }
+                ]
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    path
+}
+
+/// Create a real, minimal git repo in a hermetic temp dir.
+///
+/// Why: `push_guard` resolves its hooks directory by shelling out to `git
+/// rev-parse --git-common-dir`, so a plain temp directory cannot exercise it.
+/// Mirrors `core::push_guard`'s own helper, including the `None` return when
+/// git is unavailable.
+fn temp_repo() -> Option<(tempfile::TempDir, PathBuf)> {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let path = dir.path().to_path_buf();
+    let ok = std::process::Command::new("git")
+        .args(["init", "-q", "-b", "main"])
+        .arg(&path)
+        .status()
+        .ok()?;
+    ok.success().then_some((dir, path))
+}
+
+#[test]
+fn mode_defaults_to_dry_run() {
+    // The whole safety posture rests on this one conversion: a `--fix` with no
+    // `--yes` must never reach a write path.
+    assert_eq!(RepairMode::from_apply_flag(false), RepairMode::DryRun);
+    assert_eq!(RepairMode::from_apply_flag(true), RepairMode::Apply);
+}
+
+#[test]
+fn hooks_repair_applies_and_backs_up() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = write_mixed_settings(tmp.path());
+
+    let steps = repair_hooks_contamination(tmp.path(), RepairMode::Apply);
+    assert_eq!(steps.len(), 1, "{steps:?}");
+    assert_eq!(steps[0].check, "hooks_contamination");
+    assert_eq!(steps[0].path, path);
+    assert!(steps[0].changed(), "{:?}", steps[0]);
+
+    // Verified from disk, not from the repair's own claim.
+    let after: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    let groups = after["hooks"]["PreToolUse"].as_array().unwrap();
+    let commands: Vec<&str> = groups
+        .iter()
+        .flat_map(|g| g["hooks"].as_array().unwrap())
+        .map(|e| e["command"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        commands,
+        vec!["claude-mpm hook"],
+        "only tm's own entry may be removed"
+    );
+    assert_eq!(after["model"], "opus", "unrelated keys must survive");
+
+    // The backup the step reports must exist and hold the pre-repair bytes.
+    let StepStatus::Applied { backup: Some(bak) } = &steps[0].status else {
+        panic!("expected a backup path, got {:?}", steps[0].status);
+    };
+    assert!(
+        fs::read_to_string(bak).unwrap().contains("tm hook"),
+        "the backup must carry what was removed"
+    );
+}
+
+#[test]
+fn hooks_repair_dry_run_changes_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = write_mixed_settings(tmp.path());
+    let before = fs::read(&path).unwrap();
+
+    let steps = repair_hooks_contamination(tmp.path(), RepairMode::DryRun);
+    assert_eq!(steps.len(), 1, "{steps:?}");
+    assert_eq!(steps[0].status, StepStatus::Planned);
+    assert!(!steps[0].changed());
+    assert!(
+        steps[0].what.contains("PreToolUse"),
+        "the preview must name what it would remove: {}",
+        steps[0].what
+    );
+
+    assert_eq!(fs::read(&path).unwrap(), before, "dry run rewrote the file");
+    // And it must not have left a backup behind either — a backup is a write.
+    let stray: Vec<_> = fs::read_dir(tmp.path().join(".claude"))
+        .unwrap()
+        .flatten()
+        .filter(|e| e.file_name().to_string_lossy().contains(".bak"))
+        .collect();
+    assert!(stray.is_empty(), "dry run wrote a backup: {stray:?}");
+}
+
+#[test]
+fn hooks_repair_leaves_foreign_entries_alone() {
+    // A project carrying ONLY another harness's hooks has no tm contamination,
+    // so the repair must produce no step at all — never a step that would
+    // remove somebody else's configuration.
+    let tmp = tempfile::tempdir().unwrap();
+    let claude = tmp.path().join(".claude");
+    fs::create_dir_all(&claude).unwrap();
+    let path = claude.join("settings.json");
+    let body = serde_json::json!({
+        "hooks": { "Stop": [{ "hooks": [{ "command": "claude-mpm hook" }] }] }
+    })
+    .to_string();
+    fs::write(&path, &body).unwrap();
+
+    let steps = repair_hooks_contamination(tmp.path(), RepairMode::Apply);
+    assert!(steps.is_empty(), "{steps:?}");
+    assert_eq!(fs::read_to_string(&path).unwrap(), body);
+}
+
+#[test]
+fn push_guard_repair_installs_when_missing() {
+    let Some((_dir, repo)) = temp_repo() else {
+        return;
+    };
+    let steps = repair_push_guard(&repo, RepairMode::Apply);
+    assert_eq!(steps.len(), 1, "{steps:?}");
+    assert_eq!(steps[0].check, "push_guard");
+    assert!(steps[0].changed(), "{:?}", steps[0]);
+    assert!(
+        fs::read_to_string(&steps[0].path)
+            .unwrap()
+            .contains(crate::core::push_guard::HOOK_MARKER),
+        "the guard must actually be on disk at the reported path"
+    );
+
+    // Idempotent: a second run has nothing to report.
+    assert!(repair_push_guard(&repo, RepairMode::Apply).is_empty());
+}
+
+#[test]
+fn push_guard_repair_dry_run_writes_nothing() {
+    let Some((_dir, repo)) = temp_repo() else {
+        return;
+    };
+    let steps = repair_push_guard(&repo, RepairMode::DryRun);
+    assert_eq!(steps.len(), 1, "{steps:?}");
+    assert_eq!(steps[0].status, StepStatus::Planned);
+    assert!(
+        !steps[0].path.exists(),
+        "dry run installed the hook at {}",
+        steps[0].path.display()
+    );
+}
+
+#[test]
+fn push_guard_repair_refuses_a_foreign_hook() {
+    // The ownership rule: a `pre-push` tm did not write is never overwritten,
+    // in either mode. This is the same judgement `inspect_pre_push_guard`
+    // makes for the read-only doctor check, which is why there is one of it.
+    let Some((_dir, repo)) = temp_repo() else {
+        return;
+    };
+    let hooks = crate::core::push_guard::effective_hooks_dir(&repo).unwrap();
+    fs::create_dir_all(&hooks).unwrap();
+    let hook = hooks.join("pre-push");
+    fs::write(&hook, "#!/bin/sh\n# somebody else's hook\n").unwrap();
+
+    for mode in [RepairMode::DryRun, RepairMode::Apply] {
+        let steps = repair_push_guard(&repo, mode);
+        assert_eq!(steps.len(), 1, "{steps:?}");
+        assert!(
+            matches!(steps[0].status, StepStatus::Refused(_)),
+            "{mode:?} must refuse a foreign hook, got {:?}",
+            steps[0].status
+        );
+    }
+    assert_eq!(
+        fs::read_to_string(&hook).unwrap(),
+        "#!/bin/sh\n# somebody else's hook\n",
+        "the foreign hook was modified"
+    );
+}
+
+#[test]
+fn legacy_sources_are_refused_never_deleted() {
+    // The check whose obvious repair must not ship. Every finding is reported
+    // with its path and a reason, and every file survives — including one
+    // hand-edited copy, which is precisely the case a name-based delete could
+    // not have distinguished.
+    let tmp = tempfile::tempdir().unwrap();
+    let skills = tmp.path().join(".claude").join("skills");
+    for stem in ["tm-workflow", "tm-doctor"] {
+        let dir = skills.join(stem);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("SKILL.md"), "hand-edited by the operator").unwrap();
+    }
+    fs::create_dir_all(tmp.path().join(".trusty-mpm").join("claude-config")).unwrap();
+
+    let steps = refuse_legacy_sources(tmp.path());
+    assert_eq!(steps.len(), 3, "{steps:?}");
+    for step in &steps {
+        assert_eq!(step.check, "legacy_sources");
+        assert!(
+            matches!(step.status, StepStatus::Refused(_)),
+            "every legacy_sources finding must be refused, got {:?}",
+            step.status
+        );
+        assert!(!step.changed());
+        assert!(step.path.exists(), "{} was deleted", step.path.display());
+    }
+    assert!(
+        skills.join("tm-workflow").join("SKILL.md").is_file(),
+        "the hand-edited copy must survive verbatim"
+    );
+}
+
+#[test]
+fn legacy_sources_ignores_a_foreign_skill() {
+    // Only `tm-*` entries are trusty-mpm's. An unrelated user skill in the
+    // same directory must not even be mentioned.
+    let tmp = tempfile::tempdir().unwrap();
+    let skills = tmp.path().join(".claude").join("skills");
+    fs::create_dir_all(skills.join("my-own-skill")).unwrap();
+
+    assert!(refuse_legacy_sources(tmp.path()).is_empty());
+}
+
+#[test]
+fn legacy_sources_is_empty_on_a_clean_home() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(refuse_legacy_sources(tmp.path()).is_empty());
+}

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -65,6 +65,7 @@ pub mod deploy_validate;
 pub mod deterministic_overseer;
 pub mod discovery;
 pub mod doctor;
+pub mod doctor_repair;
 pub mod error;
 pub mod exit_codes;
 pub mod external_session;

--- a/crates/trusty-mpm/src/core/skill_repair.rs
+++ b/crates/trusty-mpm/src/core/skill_repair.rs
@@ -41,6 +41,7 @@ use std::path::{Path, PathBuf};
 
 use crate::core::agent_manifest::ManifestError;
 use crate::core::agent_manifest::{atomic_write, checksum};
+use crate::core::doctor_repair::RepairMode;
 use crate::core::paths::FrameworkPaths;
 use crate::core::skill_deploy_tiers::{SkillDeployTier, skill_deploy_tiers};
 use crate::core::skill_drift::{
@@ -64,6 +65,10 @@ pub enum RepairAction {
     /// Carries the backup path, or `None` when the file had been absent (there
     /// was nothing to back up).
     Repaired { backup: Option<PathBuf> },
+    /// [`RepairMode::DryRun`] only: this file WOULD have been rewritten, and
+    /// nothing was written. `existed` distinguishes an overwrite (which would
+    /// be backed up first) from a file that is simply absent.
+    WouldRepair { existed: bool },
     /// Hand-edited after deployment and `include_frozen` was not set. Untouched.
     SkippedFrozen,
     /// Could not be verified in the first place, so it is not repairable — the
@@ -80,6 +85,15 @@ pub struct RepairOutcome {
     pub tier: &'static str,
     /// Skill stem.
     pub stem: String,
+    /// The exact file this outcome is about.
+    ///
+    /// Why (#4948): a preview that names only a tier label and a stem is not a
+    /// preview — the operator cannot tell which of the three tiers' copies is
+    /// about to be overwritten without re-deriving the path themselves. The
+    /// repair already resolves it via [`deployed_path`]; carrying it out is
+    /// what makes "print exactly what would change, with paths" true. For the
+    /// synthetic `<manifest>` outcomes this is the tier directory.
+    pub path: PathBuf,
     /// What happened.
     pub action: RepairAction,
 }
@@ -116,6 +130,43 @@ pub fn repair_skills(
     include_frozen: bool,
     backup_root: &Path,
 ) -> Vec<RepairOutcome> {
+    repair_skills_in_mode(
+        reference,
+        paths,
+        project_dir,
+        include_frozen,
+        backup_root,
+        RepairMode::Apply,
+    )
+}
+
+/// [`repair_skills`], with the write suppressed in [`RepairMode::DryRun`].
+///
+/// Why (#4948): a repair that deletes and rewrites operator state must be able
+/// to say what it is about to do BEFORE it does it, and the only preview worth
+/// trusting is one produced by the code that performs the repair. A separate
+/// planner would be a second implementation of the frozen/unverifiable
+/// classification, and the two would disagree exactly when it mattered — the
+/// preview would promise a rewrite the apply path then skips, or say nothing
+/// about a file it is about to overwrite. So the mode is threaded through the
+/// SAME audit → classify → act pipeline, and only the final write is gated.
+/// What: identical to [`repair_skills`] except that in
+/// [`RepairMode::DryRun`] nothing is written — no skill file, no backup, no
+/// manifest — and every finding the apply path would have rewritten is
+/// reported as [`RepairAction::WouldRepair`] instead. The tier ledger lock is
+/// still taken, so a preview cannot race a concurrent deploy into reporting a
+/// half-written ledger's contents.
+/// Test: `dry_run_reports_the_same_set_it_would_repair`,
+/// `dry_run_writes_absolutely_nothing`,
+/// `dry_run_still_refuses_a_frozen_skill`.
+pub fn repair_skills_in_mode(
+    reference: &SkillReference,
+    paths: &FrameworkPaths,
+    project_dir: Option<&Path>,
+    include_frozen: bool,
+    backup_root: &Path,
+    mode: RepairMode,
+) -> Vec<RepairOutcome> {
     let mut outcomes = Vec::new();
     for tier in skill_deploy_tiers(paths, project_dir) {
         // #4881: a tier directory that does not exist has no ledger and so no
@@ -132,12 +183,14 @@ pub fn repair_skills(
         // described then read as hand-edited and freeze — the very state this
         // module exists to remedy.
         let label = tier.label;
+        let dir = tier.dir.clone();
         let locked = with_skill_manifest_lock::<_, ManifestError, _>(&tier.dir, || {
             Ok(repair_tier_locked(
                 reference,
                 &tier,
                 include_frozen,
                 backup_root,
+                mode,
             ))
         });
         match locked {
@@ -145,6 +198,7 @@ pub fn repair_skills(
             Err(e) => outcomes.push(RepairOutcome {
                 tier: label,
                 stem: "<manifest>".to_string(),
+                path: dir,
                 action: RepairAction::Failed(format!(
                     "could not lock the deploy manifest: {e} — refusing to repair this tier \
                      unserialised"
@@ -169,6 +223,7 @@ fn repair_tier_locked(
     tier: &SkillDeployTier,
     include_frozen: bool,
     backup_root: &Path,
+    mode: RepairMode,
 ) -> Vec<RepairOutcome> {
     let mut outcomes = Vec::new();
     let audit = audit_deployed_skills(reference, &tier.dir);
@@ -181,6 +236,7 @@ fn repair_tier_locked(
         outcomes.push(RepairOutcome {
             tier: tier.label,
             stem: "<manifest>".to_string(),
+            path: tier.dir.clone(),
             action: RepairAction::SkippedUnverifiable(format!(
                 "{why} — refusing to touch this tier; repairing it would rewrite an                      ownership ledger that cannot be read"
             )),
@@ -194,6 +250,7 @@ fn repair_tier_locked(
     let mut manifest_dirty = false;
 
     for finding in audit.findings {
+        let target = deployed_path(&tier.dir, &finding.stem);
         let action = match finding.state {
             SkillDrift::Fresh => continue,
             SkillDrift::Unverifiable(why) => RepairAction::SkippedUnverifiable(why),
@@ -205,32 +262,49 @@ fn repair_tier_locked(
                     outcomes.push(RepairOutcome {
                         tier: tier.label,
                         stem: finding.stem,
+                        path: target,
                         action: RepairAction::Failed(
                             "no bundled asset available to write".to_string(),
                         ),
                     });
                     continue;
                 };
-                match rewrite_and_verify(&tier.dir, tier.label, &finding.stem, content, backup_root)
-                {
-                    Ok(backup) => {
-                        manifest.managed.insert(
-                            finding.stem.clone(),
-                            SkillManifestEntry {
-                                checksum: checksum(content),
-                                deployed_at: chrono::Utc::now().to_rfc3339(),
-                            },
-                        );
-                        manifest_dirty = true;
-                        RepairAction::Repaired { backup }
+                // #4948: the ONE gate between preview and apply. Everything
+                // above — the audit, the frozen skip, the unverifiable skip —
+                // has already run identically in both modes, so what a dry run
+                // reports here is what an apply will act on.
+                if mode == RepairMode::DryRun {
+                    RepairAction::WouldRepair {
+                        existed: target.exists(),
                     }
-                    Err(e) => RepairAction::Failed(e),
+                } else {
+                    match rewrite_and_verify(
+                        &tier.dir,
+                        tier.label,
+                        &finding.stem,
+                        content,
+                        backup_root,
+                    ) {
+                        Ok(backup) => {
+                            manifest.managed.insert(
+                                finding.stem.clone(),
+                                SkillManifestEntry {
+                                    checksum: checksum(content),
+                                    deployed_at: chrono::Utc::now().to_rfc3339(),
+                                },
+                            );
+                            manifest_dirty = true;
+                            RepairAction::Repaired { backup }
+                        }
+                        Err(e) => RepairAction::Failed(e),
+                    }
                 }
             }
         };
         outcomes.push(RepairOutcome {
             tier: tier.label,
             stem: finding.stem,
+            path: target,
             action,
         });
     }
@@ -240,6 +314,11 @@ fn repair_tier_locked(
     // hand-edited — the exact state it was invoked to clear. `save_merging`
     // folds in a writer that bypassed the lock rather than dropping it.
     if manifest_dirty {
+        debug_assert_eq!(
+            mode,
+            RepairMode::Apply,
+            "a dry run must never mark the ledger dirty — it wrote nothing to record"
+        );
         match manifest.save_merging(&tier.dir, &base) {
             // `OverwroteUnreadable` is already reported by `save_merging` at
             // error level — louder than this warn would be — so it needs no
@@ -253,6 +332,7 @@ fn repair_tier_locked(
             Err(e) => outcomes.push(RepairOutcome {
                 tier: tier.label,
                 stem: "<manifest>".to_string(),
+                path: tier.dir.clone(),
                 action: RepairAction::Failed(format!("could not save the deploy manifest: {e}")),
             }),
         }

--- a/crates/trusty-mpm/src/core/skill_repair_tests.rs
+++ b/crates/trusty-mpm/src/core/skill_repair_tests.rs
@@ -427,3 +427,122 @@ fn repair_leaves_a_missing_tier_directory_alone() {
         "repair must not create a skills directory it was only inspecting"
     );
 }
+
+/// #4948: a dry run reports exactly the set an apply would rewrite.
+///
+/// Why: the preview is only worth trusting if it is produced by the code that
+/// performs the repair. This asserts the two agree on the SET — same tiers,
+/// same stems, same order — which is what a separate planner would eventually
+/// get wrong.
+#[test]
+fn dry_run_reports_the_same_set_it_would_repair() {
+    let tmp = TempDir::new().unwrap();
+    let backups = TempDir::new().unwrap();
+    let paths = paths_under(&tmp);
+    let dest = paths.claude_skills_dir();
+    let _src = deploy_real(&dest, "tm-workflow", "v1", None);
+    let reference = reference_of(&[("tm-workflow", "v2")]);
+
+    let previewed = repair_skills_in_mode(
+        &reference,
+        &paths,
+        None,
+        false,
+        backups.path(),
+        RepairMode::DryRun,
+    );
+    assert_eq!(previewed.len(), 1, "{previewed:?}");
+    assert_eq!(
+        previewed[0].action,
+        RepairAction::WouldRepair { existed: true }
+    );
+    assert_eq!(previewed[0].path, dest.join("tm-workflow").join("SKILL.md"));
+    assert!(
+        !previewed[0].changed(),
+        "a preview never counts as a change"
+    );
+
+    let applied = repair_skills(&reference, &paths, None, false, backups.path());
+    let previewed_keys: Vec<_> = previewed
+        .iter()
+        .map(|o| (o.tier, &o.stem, &o.path))
+        .collect();
+    let applied_keys: Vec<_> = applied.iter().map(|o| (o.tier, &o.stem, &o.path)).collect();
+    assert_eq!(
+        previewed_keys, applied_keys,
+        "the preview and the apply disagreed about what to repair"
+    );
+}
+
+/// #4948: the dry run writes NOTHING — not the skill, not a backup, not the
+/// ledger.
+///
+/// Why: `--fix` defaults to this mode, so "changes nothing" is the entire
+/// safety claim. It is asserted against the filesystem, not against the
+/// function's own report.
+#[test]
+fn dry_run_writes_absolutely_nothing() {
+    let tmp = TempDir::new().unwrap();
+    let backups = TempDir::new().unwrap();
+    let paths = paths_under(&tmp);
+    let dest = paths.claude_skills_dir();
+    let _src = deploy_real(&dest, "tm-workflow", "v1", None);
+
+    let skill = dest.join("tm-workflow").join("SKILL.md");
+    let manifest_before =
+        fs::read(dest.join(crate::core::skill_manifest::SKILL_MANIFEST_FILE)).unwrap();
+
+    repair_skills_in_mode(
+        &reference_of(&[("tm-workflow", "v2")]),
+        &paths,
+        None,
+        true,
+        backups.path(),
+        RepairMode::DryRun,
+    );
+
+    assert_eq!(
+        fs::read_to_string(&skill).unwrap(),
+        "v1",
+        "the dry run rewrote the skill"
+    );
+    assert_eq!(
+        fs::read(dest.join(crate::core::skill_manifest::SKILL_MANIFEST_FILE)).unwrap(),
+        manifest_before,
+        "the dry run rewrote the ownership ledger"
+    );
+    assert!(
+        !backups.path().join("operator-home").exists(),
+        "the dry run took a backup, which is itself a write"
+    );
+}
+
+/// #4948: a FROZEN (hand-edited) skill is refused in the preview too.
+///
+/// Why: the preview must not promise a repair the apply path would skip — an
+/// operator reading "would be overwritten" about their own hand-edited file
+/// and then finding it untouched has been told two wrong things at once.
+#[test]
+fn dry_run_still_refuses_a_frozen_skill() {
+    let tmp = TempDir::new().unwrap();
+    let backups = TempDir::new().unwrap();
+    let paths = paths_under(&tmp);
+    let dest = paths.claude_skills_dir();
+    let _src = deploy_real(&dest, "tm-workflow", "v1", None);
+    hand_edit(&dest, "tm-workflow", "the operator's own edit");
+
+    let previewed = repair_skills_in_mode(
+        &reference_of(&[("tm-workflow", "v2")]),
+        &paths,
+        None,
+        false,
+        backups.path(),
+        RepairMode::DryRun,
+    );
+    assert_eq!(previewed.len(), 1, "{previewed:?}");
+    assert_eq!(previewed[0].action, RepairAction::SkippedFrozen);
+    assert_eq!(
+        fs::read_to_string(dest.join("tm-workflow").join("SKILL.md")).unwrap(),
+        "the operator's own edit"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/doctor_hooks_hygiene.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_hooks_hygiene.rs
@@ -122,8 +122,13 @@ pub(super) fn check_hooks_hygiene(
             "hooks_contamination",
             CheckStatus::Warn,
             format!(
-                "{} project settings file{} carr{} tm hook entries — run `tm hooks clean` \
-                 (dry run first) to remove them: {}",
+                // #4948: name the in-place repair first — an operator reading
+                // this is already running `tm doctor`, and a remedy they have
+                // to remember a different command for is the reason these
+                // findings sat unactioned for weeks.
+                "{} project settings file{} carr{} tm hook entries — `tm doctor --fix` \
+                 previews the removal for this project and `--yes` applies it; \
+                 `tm hooks clean` sweeps every project under $HOME: {}",
                 contaminated.len(),
                 if contaminated.len() == 1 { "" } else { "s" },
                 if contaminated.len() == 1 { "ies" } else { "y" },

--- a/crates/trusty-mpm/src/daemon/doctor_push_guard.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_push_guard.rs
@@ -58,7 +58,8 @@ pub(super) fn check_push_guard(project_dir: Option<&Path>) -> DoctorCheck {
             format!(
                 "no cross-branch push guard at {} — a worktree tracking a foreign branch can \
                  force-push over that branch's reviewed lineage (#2867). Install it (idempotent, \
-                 covers every worktree of this clone at once): `tm repair push-guard`",
+                 covers every worktree of this clone at once): `tm repair push-guard`, or \
+                 `tm doctor --fix --yes` (#4948)",
                 path.display()
             ),
         ),
@@ -67,7 +68,7 @@ pub(super) fn check_push_guard(project_dir: Option<&Path>) -> DoctorCheck {
             CheckStatus::Warn,
             format!(
                 "the cross-branch push guard at {} is an older revision (#2867). Upgrade it: \
-                 `tm repair push-guard`",
+                 `tm repair push-guard`, or `tm doctor --fix --yes` (#4948)",
                 path.display()
             ),
         ),


### PR DESCRIPTION
## Defect

Every `tm doctor` check is pull-only. Measured on the owner's machine today: `legacy_sources` reported 23 leftover `tm-*` skill copies in `~/.claude/skills`, `hooks_contamination` 26 project settings files carrying tm hook entries, `skill_staleness` one drifted+repairable skill. All had persisted unremarked for weeks — the checks are `Warn`, never auto-repair, and only fire when a human runs `tm doctor`. A report nobody can act on in the same breath is a report that gets ignored.

Closes [#4948](https://github.com/bobmatnyc/trusty-tools/issues/4948).

## Evidence

Survey of the existing fix surface, `tm doctor --fix-skills` (#4604): it audits every skill deploy tier, backs up each file under `~/.trusty-mpm/backup-doctor-remediation-<ts>/`, rewrites from the bundled asset, and re-reads the file to confirm. A FROZEN (hand-edited) skill is refused unless `--include-frozen`. It never deletes. What it lacked was a preview — it writes immediately — and it covered exactly one check.

Classification of all 29 checks:

| Class | Checks |
|---|---|
| **Safely auto-repairable** — deterministic, target is something tm wrote and can prove it owns | `skill_staleness` (redeploy from bundled asset, backed up, verified from disk), `hooks_contamination` (strip tm's own hook entries; backup first), `push_guard` (install a file that is absent, or upgrade one tm wrote) |
| **Repairable, explicitly gated** | `skill_staleness` when FROZEN → `--include-frozen`; `skill_unmanaged` → `tm install --reconcile-skills` (already exists, left alone) |
| **Not repairable — deliberately refused** | `legacy_sources` (deletion inside `~/.claude`), `legacy_overrides` (content must be migrated to `CLAUDE.md` by a human), `asset_tier`, `output_style_staleness` orphans, `worktrees`, `worktree_disk`, `binary_provenance`, `oauth_token`, `tcc_taint`, `scaffold_tracking`, `hooks_foreign_conflict`, `gh_account`, and every reachability probe (`memory`, `search`, `agent_reachability`) |

## Resolution

`tm doctor --fix` extends the `--fix-skills` shape rather than adding a second mechanism.

- **Dry run by default.** `--fix` alone prints every change per item, with the path, and writes nothing. `--yes` applies. The preview is produced by the same code path that applies — `repair_skills_in_mode` threads a `RepairMode` through the one audit/classify/act pipeline, so a preview cannot promise a repair the apply path then skips.
- **Never deletes.** `legacy_sources` findings are enumerated with their paths and reported `REFUSED`, with the reason: a copy under `~/.claude` may be hand-edited, and a directory name cannot prove otherwise (#4409). Implemented, not merely documented — an operator sees the refusal rather than silence.
- **Never overwrites what the operator authored.** A checksum-mismatched skill and a foreign `pre-push` hook are refused in both modes. Ownership is decided by the existing `skill_repair` and `push_guard` judgements, not re-derived here.
- Hook cleanup removes only entries `is_mpm_hook_command` classifies as tm-owned; a claude-mpm entry in the same hand-mixed group survives. Scope is this project; the `$HOME`-wide sweep stays `tm hooks clean`.
- `--include-frozen` now accepts either repair flag (clap `repair` arg group).
- `--fix-skills` output now names the exact file repaired at each tier.

Also moved the post-report action dispatch and `prune_stale_skills_locally` out of `commands/misc.rs` (which the 500-SLOC cap rejected at 503) into `commands/doctor_repair.rs`.

## Test ladder

Rung 3 — localized behavior inside one crate.

```
cargo fmt --check                                      → clean
cargo clippy -p trusty-mpm --all-targets -- -D warnings → clean
bash scripts/check_line_cap.sh  → 3713 files, 0 violations
bash scripts/check_sld.sh       → 0 errors, 0 warnings
cargo test -p trusty-mpm        → 4626 passed, 1 failed, 7 ignored
```

Every repair has an apply test and a dry-run test asserting the filesystem is untouched, plus an ownership-refusal test:

```
core::doctor_repair::tests::hooks_repair_applies_and_backs_up ... ok
core::doctor_repair::tests::hooks_repair_dry_run_changes_nothing ... ok
core::doctor_repair::tests::hooks_repair_leaves_foreign_entries_alone ... ok
core::doctor_repair::tests::push_guard_repair_installs_when_missing ... ok
core::doctor_repair::tests::push_guard_repair_dry_run_writes_nothing ... ok
core::doctor_repair::tests::push_guard_repair_refuses_a_foreign_hook ... ok
core::doctor_repair::tests::legacy_sources_are_refused_never_deleted ... ok
core::doctor_repair::tests::legacy_sources_ignores_a_foreign_skill ... ok
core::doctor_repair::tests::mode_defaults_to_dry_run ... ok
core::skill_repair::tests::dry_run_reports_the_same_set_it_would_repair ... ok
core::skill_repair::tests::dry_run_writes_absolutely_nothing ... ok
core::skill_repair::tests::dry_run_still_refuses_a_frozen_skill ... ok
```

**Pre-existing failure, not caused by this branch:** `daemon::managed_routes::tests::stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet` fails under the parallel workspace run and passes in isolation:

```
cargo test -p trusty-mpm --lib -- --exact daemon::managed_routes::tests::stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4633 filtered out
```

`git diff --name-only origin/main...HEAD -- crates/trusty-mpm/src/daemon/managed_routes` is empty — this diff touches zero files in that module.

## Notes

- The first commit on this branch (`77f0acba wip: salvage in-progress work from interrupted session`) was created and pushed by an external salvage process mid-implementation, not by hand. It holds a partial snapshot of the same work; the squash-merge collapses it.
- Deliberately not touched: `crates/trusty-agents-common/src/skills/` and the skill manifest schema ([PR #4950](https://github.com/bobmatnyc/trusty-tools/pull/4950)), and the `tm-capabilities` generator and `assets/instructions/`. The `DOCTOR_CHECKS` prose for `hooks_contamination` and `push_guard` still names only the old remedies — a one-line follow-up on the capabilities surface.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools