### PR TITLE
docs(trusty-mpm): add the fail-open / cursor-advance doctrine to the PM workflow section

### DIFF
--- a/crates/trusty-mpm/changelog.d/4956-fail-open-doctrine.md
+++ b/crates/trusty-mpm/changelog.d/4956-fail-open-doctrine.md
@@ -1,0 +1,3 @@
+Added
+
+- Fail-Open Check added to the bundled PM workflow section — a five-question review gate for any failure branch that advances a cursor, watermark, index or "done" marker past the thing that failed

--- a/crates/trusty-mpm/src/assets/instructions/sections/workflow.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/workflow.md
@@ -150,6 +150,30 @@ Evidence:
 Status: PASSED
 ```
 
+### Fail-Open Check (BLOCKING wherever a failure branch exists)
+
+The shape: an operation can fail, the failure is downgraded to a warning, a
+default, or a `false` — and state advances anyway. The loss is permanent, and
+every alarm that should have caught it reports healthy.
+
+Run these five checks over every failure branch, in implementation and in
+review:
+
+1. **Does anything advance past the failure?** A cursor, watermark, index,
+   "done" marker, or success return that moves forward when the operation
+   failed puts the lost item outside every future window. **Fail closed** —
+   hold the state, propagate the error.
+2. **Name the alarm, then break it.** Identify which check is supposed to catch
+   this loss, then ask whether it can report healthy while the loss occurs.
+   Aggregates, tallies and summaries hide single-item failures by construction.
+3. **Compare sibling branches.** Asymmetry between arms of one state machine is
+   the tell. The arm that fails open is usually the bug.
+4. **Demand an error-arm test.** These ship green because no test ever entered
+   the failure path. Green CI over an untested failure path is evidence of
+   nothing. Require a regression test that FAILS against the pre-fix commit.
+5. **Review the fix harder than the bug.** A fix for this shape is the highest
+   risk place for it to reappear. Never merge one on the author's own gate.
+
 ### Phase 5: Documentation (CONDITIONAL)
 **Agent**: `documentation`
 **When**: Code changes made

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -697,6 +697,30 @@ Evidence:
 Status: PASSED
 ```
 
+### Fail-Open Check (BLOCKING wherever a failure branch exists)
+
+The shape: an operation can fail, the failure is downgraded to a warning, a
+default, or a `false` — and state advances anyway. The loss is permanent, and
+every alarm that should have caught it reports healthy.
+
+Run these five checks over every failure branch, in implementation and in
+review:
+
+1. **Does anything advance past the failure?** A cursor, watermark, index,
+   "done" marker, or success return that moves forward when the operation
+   failed puts the lost item outside every future window. **Fail closed** —
+   hold the state, propagate the error.
+2. **Name the alarm, then break it.** Identify which check is supposed to catch
+   this loss, then ask whether it can report healthy while the loss occurs.
+   Aggregates, tallies and summaries hide single-item failures by construction.
+3. **Compare sibling branches.** Asymmetry between arms of one state machine is
+   the tell. The arm that fails open is usually the bug.
+4. **Demand an error-arm test.** These ship green because no test ever entered
+   the failure path. Green CI over an untested failure path is evidence of
+   nothing. Require a regression test that FAILS against the pre-fix commit.
+5. **Review the fix harder than the bug.** A fix for this shape is the highest
+   risk place for it to reappear. Never merge one on the author's own gate.
+
 ### Phase 5: Documentation (CONDITIONAL)
 **Agent**: `documentation`
 **When**: Code changes made

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -697,6 +697,30 @@ Evidence:
 Status: PASSED
 ```
 
+### Fail-Open Check (BLOCKING wherever a failure branch exists)
+
+The shape: an operation can fail, the failure is downgraded to a warning, a
+default, or a `false` — and state advances anyway. The loss is permanent, and
+every alarm that should have caught it reports healthy.
+
+Run these five checks over every failure branch, in implementation and in
+review:
+
+1. **Does anything advance past the failure?** A cursor, watermark, index,
+   "done" marker, or success return that moves forward when the operation
+   failed puts the lost item outside every future window. **Fail closed** —
+   hold the state, propagate the error.
+2. **Name the alarm, then break it.** Identify which check is supposed to catch
+   this loss, then ask whether it can report healthy while the loss occurs.
+   Aggregates, tallies and summaries hide single-item failures by construction.
+3. **Compare sibling branches.** Asymmetry between arms of one state machine is
+   the tell. The arm that fails open is usually the bug.
+4. **Demand an error-arm test.** These ship green because no test ever entered
+   the failure path. Green CI over an untested failure path is evidence of
+   nothing. Require a regression test that FAILS against the pre-fix commit.
+5. **Review the fix harder than the bug.** A fix for this shape is the highest
+   risk place for it to reappear. Never merge one on the author's own gate.
+
 ### Phase 5: Documentation (CONDITIONAL)
 **Agent**: `documentation`
 **When**: Code changes made


### PR DESCRIPTION
## Defect

A failure branch downgrades the error to a warning, a default, or a `false` — and then a cursor, watermark, index, or "done" marker advances past the thing that failed. The lost item falls outside every future window, so the loss is permanent, and every alarm that should have caught it reports healthy.

## Evidence

This repo has shipped the shape repeatedly: a boolean that answered "degraded" and "unreachable" with the same value, silently stripping search context from every code review; a cursor advanced before the fetch that failed and never withdrawn; `git status --porcelain` reading a worktree full of gitignored work as CLEAN and eligible for deletion; `#[serde(default)]` on a completeness field making a `retrieved < total` guard pass vacuously; `Ok(())` on an unparseable archive; a delete loop reporting success having deleted nothing. Every one of them passed CI, because no test ever entered the failure path.

## Resolution

Adds a **Fail-Open Check** to `crates/trusty-mpm/src/assets/instructions/sections/workflow.md`, in the verification-gate cluster between the evidence-format material and Phase 5. Five questions over every failure branch:

1. Does any cursor, watermark, index, "done" marker, or success return advance past the failure? Fail closed instead.
2. Name the alarm supposed to catch this, then confirm it can't report healthy while the loss occurs. Aggregates hide single-item failures.
3. Are sibling branches of the state machine symmetric? The asymmetric arm is usually the bug.
4. Is there an error-arm test? Require a regression test that FAILS against the pre-fix commit.
5. Review the fix harder than the bug — never merge one on the author's own gate.

This is a framework convention shipped to every trusty-mpm project, so it lives in the bundled workflow section rather than `core.md` or any project's `CLAUDE.md`.

Golden snapshots regenerated, not hand-edited: `pm-prompt-bundled-fallback.md` and `pm-prompt-roster-absent.md` each gain the 24 new lines. `pm-prompt-claude-md-override.md` is unchanged — that configuration overrides the workflow section.

## Gates

The full suite was **deferred by owner directive** to a single end-of-leg pass; bare `cargo test -p trusty-mpm` was not run. Gates that were run, all exit 0:

- `cargo fmt --check`
- `cargo check -p trusty-mpm`
- `cargo clippy -p trusty-mpm -- -D warnings`
- `bash scripts/check_line_cap.sh`
- `bash scripts/check_sld.sh`
- `UPDATE_GOLDEN=1 cargo test -p trusty-mpm golden` — `test result: ok. 4 passed; 0 failed; 0 ignored`

No new test was added; the existing golden snapshots already assert the rule's presence in the composed prompt.

## Collision note

PRs #4954 and #4952 also regenerate `crates/trusty-mpm/src/core/testdata/`. Neither touches `workflow.md`, so only the snapshots will conflict — resolve by re-running `UPDATE_GOLDEN=1 cargo test -p trusty-mpm golden`, never by hand-merging snapshot text.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools