### PR TITLE
fix(trusty-mpm): branch session worktrees from fetched origin, not stale local main

### DIFF
--- a/crates/trusty-mpm/changelog.d/4957-worktree-stale-main.md
+++ b/crates/trusty-mpm/changelog.d/4957-worktree-stale-main.md
@@ -1,0 +1,6 @@
+Fixed
+
+- session worktrees are now branched from a freshly-fetched `origin/<default-branch>` instead of the base checkout's local `HEAD`, which left every new session as stale as the operator's last `git pull` (closes [#4957](https://github.com/bobmatnyc/trusty-tools/issues/4957))
+  - the default branch is resolved from the repo, never hardcoded to `main`
+  - a failed fetch falls back to the last-known remote-tracking ref (or `HEAD`) and logs a warning naming the stale tip, rather than reporting a clean success
+  - a repo with no remote still branches from `HEAD`, with no spurious warning

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
@@ -430,7 +430,13 @@ pub fn worktree_name_collides(base_path: &Path, worktree_name: &str) -> bool {
 /// record's `workspace_path`, which `spawn_managed_inproject` sets to this
 /// same path) rather than re-deriving a path from the session id.
 /// What: runs `git -C <base_path> worktree add -b session/<worktree_name>
-/// <base_path>/.worktrees/<worktree_name>`. Returns the worktree path on
+/// <base_path>/.worktrees/<worktree_name> <start-point>`, where `<start-point>`
+/// is `origin/<default-branch>` freshly fetched by
+/// [`super::inproject_start_point::resolve`] (#4957 — omitting it inherits the
+/// base checkout's local `HEAD`, which starts every session as stale as the
+/// operator's last `git pull`). A fetch that fails degrades to the last-known
+/// remote-tracking ref (or `HEAD`) and is `warn!`-logged, never silent.
+/// Returns the worktree path on
 /// success. Fails loudly (rather than silently clobbering) if the target
 /// worktree directory already exists — callers are expected to have already
 /// steered `SessionManager::resolve_session_name` away from a colliding name
@@ -443,7 +449,8 @@ pub fn worktree_name_collides(base_path: &Path, worktree_name: &str) -> bool {
 /// to reclaim this worktree.
 /// Test: covered by integration tests against a real temp repo;
 /// `create_session_worktree_rejects_existing_worktree_dir`,
-/// `create_session_worktree_writes_owner_sentinel` (#3649).
+/// `create_session_worktree_writes_owner_sentinel` (#3649),
+/// `session_worktree_branches_from_fetched_origin_not_stale_local_main` (#4957).
 pub fn create_session_worktree(
     base_path: &Path,
     worktree_name: &str,
@@ -460,19 +467,37 @@ pub fn create_session_worktree(
         ));
     }
 
+    // #4957: cut the session branch from the freshly-fetched remote default
+    // branch. Omitting the start-point inherits the base checkout's local
+    // HEAD, which is stale on any machine that has not pulled recently.
+    let start_point = super::inproject_start_point::resolve(base_path);
+    if let Some(reason) = start_point.warning() {
+        warn!(
+            base = %base_path.display(),
+            branch = %branch,
+            "inproject: session worktree is NOT branched from a freshly-fetched origin — {reason}"
+        );
+    }
+
     info!(
         base = %base_path.display(),
         worktree = %worktree_path.display(),
         branch = %branch,
+        start_point = start_point.git_ref().unwrap_or("HEAD"),
         "inproject: creating per-session worktree"
     );
 
-    let out = std::process::Command::new("git")
+    let mut add_cmd = std::process::Command::new("git");
+    add_cmd
         .arg("-C")
         .arg(base_path)
         .args(["worktree", "add", "-b"])
         .arg(&branch)
-        .arg(&worktree_path)
+        .arg(&worktree_path);
+    if let Some(git_ref) = start_point.git_ref() {
+        add_cmd.arg(git_ref);
+    }
+    let out = add_cmd
         .output()
         .map_err(|e| format!("inproject: git worktree add failed to spawn: {e}"))?;
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
@@ -1021,3 +1021,274 @@ fn push_pin_detection_matches_effective_config() {
          the detector must read worktree-scoped config, not the shared repo config"
     );
 }
+
+// ── #4957: session branches must be cut from origin, not stale local main ──
+
+/// Run a git command in `cwd`, asserting success.
+fn g(cwd: &std::path::Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("git {args:?} failed to spawn: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} in {} failed: {}",
+        cwd.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Read trimmed stdout of a git command in `cwd`, asserting success.
+fn g_out(cwd: &std::path::Path, args: &[&str]) -> String {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("git {args:?} failed to spawn: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} in {} failed: {}",
+        cwd.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Add one commit in `cwd` and return its sha.
+fn commit(cwd: &std::path::Path, name: &str) -> String {
+    std::fs::write(cwd.join(name), name.as_bytes()).expect("write file");
+    g(cwd, &["add", "."]);
+    g(cwd, &["commit", "-q", "-m", name]);
+    g_out(cwd, &["rev-parse", "HEAD"])
+}
+
+/// A base clone whose local `main` is DELIBERATELY behind `origin/main`.
+///
+/// Why: this is the whole point of the #4957 fixture. A test that only checks
+/// "a worktree was created" passes against the pre-fix code; only a base whose
+/// local ref lags the remote can tell `HEAD` and `origin/main` apart.
+/// What: builds a bare `origin` seeded with commit A, clones it into `base`
+/// (so `base`'s local `main` AND `refs/remotes/origin/main` both sit at A),
+/// then pushes commit B to `origin` from a separate seed clone that `base`
+/// never sees. Returns `(base_path, sha_a, sha_b)` plus the TempDir guards
+/// that must stay alive for the duration of the test.
+struct StaleBase {
+    base: std::path::PathBuf,
+    origin: std::path::PathBuf,
+    sha_a: String,
+    sha_b: String,
+    _guards: Vec<tempfile::TempDir>,
+}
+
+fn stale_base_fixture() -> StaleBase {
+    let origin_dir = crate::test_support::hermetic_temp_dir();
+    let origin = origin_dir.path().to_path_buf();
+    let init = std::process::Command::new("git")
+        .args(["init", "--bare", "-q", "-b", "main"])
+        .arg(&origin)
+        .output()
+        .expect("git init --bare");
+    assert!(
+        init.status.success(),
+        "git init --bare failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // Seed clone: the only checkout that ever pushes to `origin`.
+    let seed_parent = crate::test_support::hermetic_temp_dir();
+    let seed = seed_parent.path().join("seed");
+    let clone = std::process::Command::new("git")
+        .args(["clone", "-q"])
+        .arg(&origin)
+        .arg(&seed)
+        .output()
+        .expect("git clone seed");
+    assert!(
+        clone.status.success(),
+        "git clone seed failed: {}",
+        String::from_utf8_lossy(&clone.stderr)
+    );
+    g(&seed, &["config", "user.email", "t@example.com"]);
+    g(&seed, &["config", "user.name", "T"]);
+    let sha_a = commit(&seed, "A");
+    g(&seed, &["push", "-q", "origin", "main"]);
+
+    // Base clone: takes A, then never hears about B.
+    let base_parent = crate::test_support::hermetic_temp_dir();
+    let base = base_parent.path().join("base");
+    let clone_base = std::process::Command::new("git")
+        .args(["clone", "-q"])
+        .arg(&origin)
+        .arg(&base)
+        .output()
+        .expect("git clone base");
+    assert!(
+        clone_base.status.success(),
+        "git clone base failed: {}",
+        String::from_utf8_lossy(&clone_base.stderr)
+    );
+    g(&base, &["config", "user.email", "t@example.com"]);
+    g(&base, &["config", "user.name", "T"]);
+
+    // Advance `origin/main` behind the base clone's back.
+    let sha_b = commit(&seed, "B");
+    g(&seed, &["push", "-q", "origin", "main"]);
+
+    assert_eq!(
+        g_out(&base, &["rev-parse", "HEAD"]),
+        sha_a,
+        "fixture precondition: the base clone's local main must be STALE (at A)"
+    );
+    assert_ne!(sha_a, sha_b, "fixture precondition: A and B must differ");
+
+    StaleBase {
+        base,
+        origin,
+        sha_a,
+        sha_b,
+        _guards: vec![origin_dir, seed_parent, base_parent],
+    }
+}
+
+/// #4957: a new session worktree must start at the FETCHED `origin/<default>`
+/// tip, not at the base checkout's stale local `main`.
+///
+/// Why: the reported failure was eight `session/*` branches and local `main`
+/// all pointing at the same three-week-old commit, 667 behind `origin/main`,
+/// because `git worktree add -b` was given no start-point and no fetch
+/// preceded it. Asserting only "a worktree exists" would have passed against
+/// that code; the fixture's deliberately-stale local `main` is what makes this
+/// test fail before the fix.
+/// What: builds a base clone at commit A while `origin/main` has moved to B,
+/// calls the production `create_session_worktree`, and asserts the new
+/// worktree's `HEAD` is B — and explicitly not A.
+/// Test: this function IS the test.
+#[test]
+fn session_worktree_branches_from_fetched_origin_not_stale_local_main() {
+    let fx = stale_base_fixture();
+
+    let worktree = create_session_worktree(
+        &fx.base,
+        "tm-stale-4957",
+        &crate::session_manager::ManagedSessionId::new(),
+    )
+    .expect("create_session_worktree must succeed against a real base clone");
+
+    let head = g_out(&worktree, &["rev-parse", "HEAD"]);
+    assert_ne!(
+        head, fx.sha_a,
+        "the session worktree was cut from the STALE local main ({}) — #4957",
+        fx.sha_a
+    );
+    assert_eq!(
+        head, fx.sha_b,
+        "the session worktree must start at the freshly-fetched origin/main tip"
+    );
+}
+
+/// #4957: when the fetch fails, the session branch must still prefer the
+/// last-known `origin/<default>` over the base checkout's local `HEAD`, and
+/// the degradation must not read as a clean success.
+///
+/// Why: falling straight back to local `HEAD` on a failed fetch reintroduces
+/// the exact defect for every offline spawn — the fail-open shape this repo
+/// keeps getting bitten by. The base is given a LOCAL commit C that `origin`
+/// never saw, so `HEAD` and `refs/remotes/origin/main` are distinguishable.
+/// What: removes the `origin` repo so the fetch cannot succeed, adds local
+/// commit C to the base, then asserts the worktree starts at A (the stale
+/// remote-tracking ref) rather than C, and that
+/// `inproject_start_point::resolve` reports a warning rather than `Fresh`.
+/// Test: this function IS the test.
+#[test]
+fn session_worktree_falls_back_to_remote_tracking_ref_when_fetch_fails() {
+    let fx = stale_base_fixture();
+    let sha_c = commit(&fx.base, "C");
+    std::fs::remove_dir_all(&fx.origin).expect("remove origin to break the fetch");
+
+    let resolved = super::super::inproject_start_point::resolve(&fx.base);
+    assert_eq!(
+        resolved.git_ref(),
+        Some("origin/main"),
+        "a failed fetch must still hand back the last-known remote-tracking ref"
+    );
+    let warning = resolved
+        .warning()
+        .expect("a failed fetch must warn — it must never read as a clean success");
+    assert!(
+        warning.contains("git fetch origin main failed"),
+        "the warning must name the failure: {warning}"
+    );
+
+    let worktree = create_session_worktree(
+        &fx.base,
+        "tm-offline-4957",
+        &crate::session_manager::ManagedSessionId::new(),
+    )
+    .expect("an unreachable remote must not fail worktree creation");
+
+    let head = g_out(&worktree, &["rev-parse", "HEAD"]);
+    assert_ne!(
+        head, sha_c,
+        "an offline spawn must not silently fall back to the base checkout's local HEAD"
+    );
+    assert_eq!(
+        head, fx.sha_a,
+        "an offline spawn must start at the last fetched origin/main"
+    );
+}
+
+/// #4957: a repo with no `origin` remote must keep working, branching from
+/// `HEAD` without a spurious staleness warning.
+///
+/// Why: the fix must not turn "purely local repo" into an error or a noisy
+/// warning — there `HEAD` is simply the correct start point.
+/// What: builds a remote-less repo with one commit, asserts
+/// `inproject_start_point::resolve` reports `LocalOnly` with no warning and no
+/// start-point ref, and that the created worktree starts at that commit.
+/// Test: this function IS the test.
+#[test]
+fn session_worktree_without_a_remote_still_branches_from_head() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let repo = dir.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("mkdir repo");
+    let init = std::process::Command::new("git")
+        .args(["init", "-q", "-b", "main"])
+        .arg(&repo)
+        .output()
+        .expect("git init");
+    assert!(
+        init.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+    g(&repo, &["config", "user.email", "t@example.com"]);
+    g(&repo, &["config", "user.name", "T"]);
+    let sha = commit(&repo, "only");
+
+    let resolved = super::super::inproject_start_point::resolve(&repo);
+    assert_eq!(
+        resolved.git_ref(),
+        None,
+        "a remote-less repo must let git use HEAD"
+    );
+    assert_eq!(
+        resolved.warning(),
+        None,
+        "a remote-less repo is not a degradation and must not warn"
+    );
+
+    let worktree = create_session_worktree(
+        &repo,
+        "tm-local-4957",
+        &crate::session_manager::ManagedSessionId::new(),
+    )
+    .expect("a repo with no remote must still get a worktree");
+    assert_eq!(
+        g_out(&worktree, &["rev-parse", "HEAD"]),
+        sha,
+        "a remote-less repo's worktree must start at the local HEAD commit"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject_start_point.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject_start_point.rs
@@ -1,0 +1,188 @@
+//! Resolve the commit a new session-worktree branch is cut from (#4957).
+//!
+//! Why: `inproject::create_session_worktree` ran `git worktree add -b
+//! session/<name> <path>` with no start-point, so every session branch was cut
+//! from the base checkout's `HEAD` — the local default-branch ref. Nothing in
+//! the in-project spawn path fetches, so on a machine whose local `main` has
+//! not moved in weeks every new session starts weeks behind: the report that
+//! opened #4957 measured 667 commits, with eight `session/*` branches and
+//! local `main` all pointing at the same three-week-old commit. This repo's
+//! `CLAUDE.md` names `origin/<default>` the source of truth for exactly this
+//! reason, and the clone-based sibling path
+//! (`provisioner::workspace::worktree_add`) already fetches before adding.
+//! What: [`resolve`] fetches the repo's actual default branch from `origin`
+//! and returns the ref `git worktree add` should be given, plus whether that
+//! ref is freshly fetched, stale, or absent. Degradation is never silent: a
+//! failed fetch still yields a usable start point but carries a
+//! [`StartPoint::warning`] naming the stale tip, so the caller can log it
+//! rather than report a clean success.
+//! Test: `inproject::tests::session_worktree_branches_from_fetched_origin_not_stale_local_main`,
+//! `inproject::tests::session_worktree_falls_back_to_remote_tracking_ref_when_fetch_fails`,
+//! `inproject::tests::session_worktree_without_a_remote_still_branches_from_head`.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Where a new session branch should be cut from, and how trustworthy that is.
+///
+/// Why: the caller must distinguish three materially different situations that
+/// all still produce a worktree — a fresh remote tip (the intended path), a
+/// last-known remote tip after a failed fetch (degraded, must warn), and no
+/// remote at all (a purely local repo, where `HEAD` is simply correct and a
+/// warning would be noise). Collapsing them into `Option<String>` is what let
+/// #4957 read as success.
+/// What: a start-point ref for `git worktree add` (`None` means "omit the
+/// argument and let git use `HEAD`"), plus an optional operator-facing
+/// warning.
+/// Test: see the module docs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StartPoint {
+    /// `origin/<default>`, refreshed from the remote during this call.
+    Fresh { git_ref: String },
+    /// `origin/<default>` as of some earlier fetch — this call's fetch failed.
+    Stale { git_ref: String, reason: String },
+    /// The repo has no `origin` remote: `HEAD` is the only correct start point
+    /// and this is not a degradation.
+    LocalOnly,
+    /// A remote exists but neither the fetch nor any remote-tracking ref could
+    /// supply a start point, so `HEAD` is used and may be stale.
+    UnverifiedHead { reason: String },
+}
+
+impl StartPoint {
+    /// The ref to pass to `git worktree add`, or `None` to let git use `HEAD`.
+    pub fn git_ref(&self) -> Option<&str> {
+        match self {
+            StartPoint::Fresh { git_ref } | StartPoint::Stale { git_ref, .. } => Some(git_ref),
+            StartPoint::LocalOnly | StartPoint::UnverifiedHead { .. } => None,
+        }
+    }
+
+    /// Operator-facing text when the start point is NOT a freshly-fetched
+    /// remote tip; `None` when nothing is wrong.
+    pub fn warning(&self) -> Option<&str> {
+        match self {
+            StartPoint::Stale { reason, .. } | StartPoint::UnverifiedHead { reason } => {
+                Some(reason)
+            }
+            StartPoint::Fresh { .. } | StartPoint::LocalOnly => None,
+        }
+    }
+}
+
+/// Fetch `origin`'s default branch into `base_path` and report the start point
+/// a new session branch should be cut from (#4957).
+///
+/// Why: see the module docs — without this, `git worktree add -b` silently
+/// inherits the base checkout's local `HEAD`.
+/// What: resolves the default branch via
+/// [`super::inproject_hygiene::get_default_branch`] (the crate's existing
+/// resolver — the branch is never hardcoded to `main`), falling back to the
+/// checked-out branch when `origin/HEAD` is unset but `origin/<current>`
+/// exists; fetches the explicit refspec
+/// `+refs/heads/<branch>:refs/remotes/origin/<branch>` so the remote-tracking
+/// ref is updated deterministically rather than relying on `FETCH_HEAD`; and
+/// maps the outcome onto [`StartPoint`]. `GIT_TERMINAL_PROMPT=0` keeps a
+/// credential prompt from hanging the daemon on a private remote.
+/// Test: see the module docs.
+pub fn resolve(base_path: &Path) -> StartPoint {
+    let Some(branch) = default_remote_branch(base_path) else {
+        return if has_origin_remote(base_path) {
+            StartPoint::UnverifiedHead {
+                reason: "could not resolve origin's default branch (origin/HEAD unset and no \
+                         remote-tracking ref for the checked-out branch); branching from the \
+                         base checkout's local HEAD, which may be behind the remote"
+                    .to_string(),
+            }
+        } else {
+            StartPoint::LocalOnly
+        };
+    };
+
+    let tracking_ref = format!("refs/remotes/origin/{branch}");
+    let git_ref = format!("origin/{branch}");
+    let refspec = format!("+refs/heads/{branch}:{tracking_ref}");
+
+    match fetch(base_path, &refspec) {
+        Ok(()) => StartPoint::Fresh { git_ref },
+        Err(err) if ref_exists(base_path, &tracking_ref) => StartPoint::Stale {
+            reason: format!(
+                "git fetch origin {branch} failed ({err}); branching from the last fetched \
+                 {git_ref} ({}) instead — this session may be behind the remote",
+                tip_description(base_path, &git_ref)
+            ),
+            git_ref,
+        },
+        Err(err) => StartPoint::UnverifiedHead {
+            reason: format!(
+                "git fetch origin {branch} failed ({err}) and there is no {git_ref} \
+                 remote-tracking ref to fall back on; branching from the base checkout's local \
+                 HEAD, which may be behind the remote"
+            ),
+        },
+    }
+}
+
+/// Resolve the branch name `origin` considers default, without hardcoding it.
+fn default_remote_branch(base_path: &Path) -> Option<String> {
+    if let Some(branch) = super::inproject_hygiene::get_default_branch(base_path) {
+        return Some(branch);
+    }
+    // `origin/HEAD` is unset — normal for a repo built with `git init` plus
+    // `git remote add` rather than `git clone`. The checked-out branch is the
+    // best available answer, but only when `origin` actually tracks it.
+    let current = git_stdout(base_path, &["symbolic-ref", "--short", "HEAD"])?;
+    ref_exists(base_path, &format!("refs/remotes/origin/{current}")).then_some(current)
+}
+
+fn fetch(base_path: &Path, refspec: &str) -> Result<(), String> {
+    let out = git(base_path)
+        .args(["fetch", "--no-tags", "origin", refspec])
+        .output()
+        .map_err(|e| format!("failed to spawn git fetch: {e}"))?;
+    if out.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    Err(format!(
+        "exit {}: {}",
+        out.status,
+        stderr.trim().replace('\n', "; ")
+    ))
+}
+
+fn has_origin_remote(base_path: &Path) -> bool {
+    git_stdout(base_path, &["remote", "get-url", "origin"]).is_some()
+}
+
+fn ref_exists(base_path: &Path, full_ref: &str) -> bool {
+    git(base_path)
+        .args(["rev-parse", "--verify", "--quiet", full_ref])
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+/// Short sha plus commit date of `git_ref`, so a staleness warning is legible
+/// rather than abstract. Best-effort: an unreadable ref reports as `unknown`.
+fn tip_description(base_path: &Path, git_ref: &str) -> String {
+    git_stdout(base_path, &["log", "-1", "--format=%h %cs", git_ref])
+        .unwrap_or_else(|| "unknown tip".to_string())
+}
+
+fn git_stdout(base_path: &Path, args: &[&str]) -> Option<String> {
+    let out = git(base_path).args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!s.is_empty()).then_some(s)
+}
+
+fn git(base_path: &Path) -> Command {
+    let mut cmd = Command::new("git");
+    // A daemon has no terminal: without this a private remote's credential
+    // prompt blocks the spawn indefinitely instead of failing fast.
+    cmd.env("GIT_TERMINAL_PROMPT", "0").arg("-C").arg(base_path);
+    cmd
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -33,6 +33,7 @@ mod fleet;
 pub mod front_gate;
 pub mod inproject;
 pub mod inproject_hygiene;
+mod inproject_start_point;
 mod launch_on_main;
 mod lifecycle;
 mod mcp_spawn_gate;


### PR DESCRIPTION
Closes [#4957](https://github.com/bobmatnyc/trusty-tools/issues/4957).

## Defect

`inproject::create_session_worktree` ran `git -C <base> worktree add -b session/<name> <path>` with **no start-point and no preceding fetch**, so every session branch was cut from the base checkout's `HEAD` — the local `main` ref. Nothing in the in-project spawn path fetches, so a session is exactly as stale as the operator's last `git pull`.

`crates/trusty-mpm/src/daemon/managed_routes/inproject.rs:447`. The clone-based sibling path (`provisioner::workspace::worktree_add`) already fetches an explicit refspec before adding; only the in-project path was affected.

## Evidence

Reported on tm 1.3.4 / macOS: a new worktree landed 667 commits behind `origin/main` (`trusty-search` 0.34.0 there vs 0.42.3 on main). Every session branch ever created on that machine sat on the same July commit as local `main`:

```
dce4e9a98a18e65e2e95bb9ab5e46aadc1a97e30  Sat Jul 18 2026
  HEAD -> session/tm-trusty-tools-15, session/tm-trusty-tools-17, session/tm-trusty-tools-16,
  session/tm-trusty-tools-14, session/tm-trusty-tools-13, session/tm-trusty-tools-11,
  session/tm-trusty-tools-06, main
```

A brand-new `session/tm-trusty-tools-18` reproduced it on the next spawn.

## Resolution

New `daemon::managed_routes::inproject_start_point` resolves the start point:

- default branch comes from the crate's existing resolver `inproject_hygiene::get_default_branch` (`refs/remotes/origin/HEAD`), never hardcoded to `main`; falls back to the checked-out branch when `origin/HEAD` is unset but `origin/<current>` exists;
- fetches `+refs/heads/<branch>:refs/remotes/origin/<branch>` so the remote-tracking ref updates deterministically rather than via `FETCH_HEAD`, with `GIT_TERMINAL_PROMPT=0` so a private remote's credential prompt cannot hang the daemon;
- `git worktree add -b <branch> <path> origin/<default>`.

Failure is visible, not fail-open. A failed fetch returns `StartPoint::Stale` — still the last-known `origin/<default>`, never the local `HEAD` — and `create_session_worktree` `warn!`-logs the reason with the stale tip's sha and date. With no remote-tracking ref at all it degrades to `HEAD` and warns. A repo with no `origin` returns `LocalOnly`: `HEAD` is correct there, so no warning.

## Tests

Three regression tests in `inproject/tests.rs`. The fixture builds a base clone whose local `main` is deliberately at commit A while `origin/main` has moved to B — a test that only asserted "a worktree was created" would have passed pre-fix.

Failing against the pre-fix code (start-point argument removed):

```
running 3 tests
test ...::session_worktree_without_a_remote_still_branches_from_head ... ok

panicked at inproject/tests.rs:1181:5:
assertion `left != right` failed: the session worktree was cut from the STALE local main (b73d4894da3e895b9c0eff6e6bebc19d887df01c) — #4957
  left: "b73d4894da3e895b9c0eff6e6bebc19d887df01c"
 right: "b73d4894da3e895b9c0eff6e6bebc19d887df01c"
test ...::session_worktree_branches_from_fetched_origin_not_stale_local_main ... FAILED

panicked at inproject/tests.rs:1233:5:
assertion `left != right` failed: an offline spawn must not silently fall back to the base checkout's local HEAD
  left: "09edba5f5f465f9eed42b5e89da6142359731cba"
 right: "09edba5f5f465f9eed42b5e89da6142359731cba"
test ...::session_worktree_falls_back_to_remote_tracking_ref_when_fetch_fails ... FAILED

test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 4621 filtered out; finished in 0.40s
```

Passing after, alongside the two pre-existing `create_session_worktree` tests (upstream tracking + push pin, unchanged):

```
running 5 tests
test ...::create_session_worktree_rejects_existing_worktree_dir ... ok
test ...::session_worktree_without_a_remote_still_branches_from_head ... ok
test ...::create_session_worktree_sets_pull_upstream_and_worktree_scoped_push ... ok
test ...::session_worktree_branches_from_fetched_origin_not_stale_local_main ... ok
test ...::session_worktree_falls_back_to_remote_tracking_ref_when_fetch_fails ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 4619 filtered out; finished in 0.53s
```

## Gates

Test ladder **rung 3** — localized behavior inside one crate, plus a targeted regression test that provably fails before the change.

```
cargo fmt --check                               EXIT=0
cargo check -p trusty-mpm --all-targets         EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   EXIT=0
bash scripts/check_line_cap.sh   line-cap: measured 3715 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.
bash scripts/check_sld.sh        sld-lint: scanned 55 spec doc(s) + 3098 code file(s); 0 error(s), 0 warning(s)
```

The full `cargo test -p trusty-mpm` suite was **deferred to the end-of-leg pass by owner directive**; the three new tests plus the two neighbouring `create_session_worktree` tests were run narrowly, output above.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools