### PR TITLE
docs(trusty-mpm): teach both catalog managers the real precedence rules

### DIFF
--- a/crates/trusty-agents-common/changelog.d/4958-skill-precedence-log.md
+++ b/crates/trusty-agents-common/changelog.d/4958-skill-precedence-log.md
@@ -1,0 +1,3 @@
+Fixed
+
+- the skill tier-collision log no longer claims a winner it cannot deliver. It said "deploying the higher-precedence copy", which for a project-custom winner stated the opposite of what happens — Claude Code resolves skills personal over project, so a same-named copy under `$CLAUDE_CONFIG_DIR/skills` still beats the project-tier file. The line now scopes itself to deploy-time source precedence within one destination and names that `dest`

--- a/crates/trusty-agents-common/src/skills/tiers.rs
+++ b/crates/trusty-agents-common/src/skills/tiers.rs
@@ -1,4 +1,7 @@
-//! Multi-tier skill precedence — project-custom > user-custom > bundled.
+//! Multi-tier skill DEPLOY-TIME source precedence — project-custom >
+//! user-custom > bundled. NOT Claude Code's runtime resolution (#4958): this
+//! decides which SOURCE is written into one `dest`, never which of several
+//! on-disk copies loads.
 //!
 //! Why: skills are deployed per-project into `<project>/.claude/skills/`, and
 //! historically only ONE source fed that deploy (the bundled framework skills,
@@ -302,12 +305,23 @@ pub fn deploy_all_skill_tiers(
 
     let plan = plan_skill_tiers(&project, &user, &bundled);
 
+    // #4958: say which precedence this is. The old message — "deploying the
+    // higher-precedence copy" — read as a final verdict, and for a project-custom
+    // winner it stated the opposite of what happens: Claude Code resolves skills
+    // `enterprise > personal > project > bundled`, so a same-named copy under
+    // `$CLAUDE_CONFIG_DIR/skills` still beats the project-tier file this line
+    // just called the winner. This function only ever sees ONE `dest`, so it
+    // cannot know the cross-destination outcome; it now says only what it knows
+    // and names `dest` so the reader can tell which tier was decided.
     for shadow in &plan.shadowed {
         tracing::info!(
             skill = %shadow.stem,
             winner = shadow.winner.label(),
             loser = shadow.loser.label(),
-            "skill tier collision — deploying the higher-precedence copy"
+            dest = %dest.display(),
+            "skill tier collision — deploy-time source precedence WITHIN this destination; \
+             Claude Code resolves across destinations separately (for skills, personal \
+             outranks project)"
         );
     }
 

--- a/crates/trusty-mpm/changelog.d/4958-skill-precedence.md
+++ b/crates/trusty-mpm/changelog.d/4958-skill-precedence.md
@@ -1,0 +1,4 @@
+Documentation
+
+- `mpm-skills-manager` and `mpm-agent-manager` now carry Claude Code's verified runtime resolution order for their own artifact type, and state the asymmetry between them: for skills personal `~/.claude/skills/` beats project, for agents project `.claude/agents/` beats user. Each says where to write a file so it actually wins the collision
+  - the skills manager's existing tier section is relabelled deploy-time source precedence, so tm's `project-custom > user-custom > bundled` rule is no longer read as Claude Code's runtime order

--- a/crates/trusty-mpm/changelog.d/4958-skill-precedence.md
+++ b/crates/trusty-mpm/changelog.d/4958-skill-precedence.md
@@ -1,4 +1,6 @@
 Documentation
 
-- `mpm-skills-manager` and `mpm-agent-manager` now carry Claude Code's verified runtime resolution order for their own artifact type, and state the asymmetry between them: for skills personal `~/.claude/skills/` beats project, for agents project `.claude/agents/` beats user. Each says where to write a file so it actually wins the collision
+- corrected trusty-mpm's stated skill precedence, which had Claude Code's runtime order backwards and conflated it with tm's deploy-time order
+  - `mpm-skills-manager` and `mpm-agent-manager` now carry the verified runtime resolution for their own artifact type and state the asymmetry: for skills personal `~/.claude/skills/` beats project, for agents project `.claude/agents/` beats user. Each says where to write a file so it actually wins the collision
   - the skills manager's existing tier section is relabelled deploy-time source precedence, so tm's `project-custom > user-custom > bundled` rule is no longer read as Claude Code's runtime order
+  - `core::project_skill_tier` and `core::managed_config` asserted that `<project>/.claude/skills` outranks `$CLAUDE_CONFIG_DIR/skills`. That is backwards for skills, and it was load-bearing for the #4880 redeploy rationale. Both now state the real order and name which axis they mean; the redeploy still earns its place because the project tier is what loads for every name the managed roster does not carry

--- a/crates/trusty-mpm/src/assets/agents/mpm-agent-manager.md
+++ b/crates/trusty-mpm/src/assets/agents/mpm-agent-manager.md
@@ -39,6 +39,45 @@ cargo test -p trusty-mpm bundle -- --nocapture
 ### Deployment
 Agents deploy to `~/.trusty-mpm/framework/agents/` via `trusty-mpm install`. Each agent in `ALL` is written with `InstallPolicy::Overwrite` so framework upgrades replace prior versions. `InstallPolicy` is a real, honored choice, not boilerplate: `Overwrite` (every agent today) always refreshes on install; `SeedOnce` exists for a genuinely user-owned artifact and is written only once, never clobbered by an upgrade (`--force` resets it back to the shipped default).
 
+### Claude Code Runtime Resolution — where to write so an agent WINS
+
+Deployment above decides what lands on disk. This decides which definition
+Claude Code loads when two files share a `name`:
+
+| Priority | Location | Scope |
+|---|---|---|
+| 1 (highest) | Managed settings | Organization-wide |
+| 2 | `--agents` CLI flag | Current session |
+| 3 | `.claude/agents/` | Current project |
+| 4 | `~/.claude/agents/` | All your projects |
+| 5 (lowest) | Plugin's `agents/` directory | Where plugin is enabled |
+
+🔴 **For AGENTS project beats user. For SKILLS personal (`~/.claude/skills/`)
+beats project. Same two scopes, opposite order.** Anyone who assumes one rule
+covers both will place a file that silently loses. `mpm-skills-manager` carries
+the skill half — never transfer this rule to skills.
+
+**To make an agent win over a user-level one, write it to the PROJECT tier** —
+`<project>/.claude/agents/<name>.md`. Built-ins `Explore`, `Plan`, and
+`general-purpose` are always registered and ARE shadowable by a same-named
+custom agent.
+
+- `CLAUDE_CONFIG_DIR` relocates the ENTIRE `~/.claude` tree wholesale;
+  `~/.claude/agents/` does not keep loading alongside it. tm's bundled roster
+  deploys into `$CLAUDE_CONFIG_DIR/agents` — the USER tier (4), which the
+  project tier (3) outranks. Bundled agent names are NOT namespaced, so this
+  collision is live: a project-tier `rust-engineer` stub beat the real 25 KB
+  agent for a full day (#4408). `tm doctor`'s `asset_tier` check reports it.
+- No frontmatter field declares a tier. Scope is filesystem location only. tm
+  reads a `category:` key; Claude Code ignores it, so it can never be used to
+  win a collision.
+- `plugin:` (a `plugin-name:agent-name` namespace) is the only reserved,
+  guaranteed-non-collidable namespace.
+- Nested project `.claude/agents/`: the definition closest to the working
+  directory wins (v2.1.178+). Two files with the same `name` in the SAME
+  directory tree resolve by filesystem read order with NO documented
+  precedence — `/doctor` flags that as a duplicate. Never rely on it.
+
 ### Adding a New Agent
 1. Create `crates/trusty-mpm/src/assets/agents/<name>.md` with 5-field frontmatter
 2. Add a `pub const` in `core/bundle.rs` with `include_str!`

--- a/crates/trusty-mpm/src/assets/agents/mpm-skills-manager.md
+++ b/crates/trusty-mpm/src/assets/agents/mpm-skills-manager.md
@@ -28,7 +28,12 @@ Skills are Markdown documents that provide reusable, invokable knowledge to agen
   templates, ticketing, PR workflow, delegation patterns, session
   management, bug reporting, and `tm-doctor`)
 
-### Skill Tiers & Precedence (issue #2816)
+### Deploy-Time Source Precedence (issue #2816)
+
+This decides which SOURCE file tm writes into one destination directory. It is
+NOT Claude Code's runtime resolution order — that is the next section, and it
+is the one that decides which copy actually loads.
+
 Skills deploy per-project into `<project>/.claude/skills/<name>/SKILL.md`.
 On a name collision, precedence is **project-custom > user-custom > bundled**:
 
@@ -65,6 +70,38 @@ just per-project deploys, per the stated intent that user-custom skills apply
 everywhere. The project-custom tier is naturally empty at this destination
 (nothing hand-places a skill directly into the config dir's `skills/`), so no
 special-casing was needed there.
+
+### Claude Code Runtime Resolution — where to write so a skill WINS
+
+Deploy-time precedence decides what lands on disk. This decides which copy
+Claude Code loads when the same name exists in more than one place:
+
+**`enterprise > personal ~/.claude/skills/ > project .claude/skills/ > bundled`**
+
+A skill at any of those levels overrides a same-named bundled skill.
+
+🔴 **For SKILLS personal beats project. For AGENTS project beats user. Same two
+scopes, opposite order.** Anyone who assumes one rule covers both will place a
+file that silently loses. `mpm-agent-manager` carries the agent half — never
+transfer this rule to agents.
+
+**To make a skill win a collision, write it to the PERSONAL tier** —
+`~/.claude/skills/<name>/SKILL.md`, or `$CLAUDE_CONFIG_DIR/skills/<name>/SKILL.md`
+when that variable is set. Writing to the project tier does NOT override a
+same-named personal skill.
+
+- `CLAUDE_CONFIG_DIR` relocates the ENTIRE `~/.claude` tree wholesale;
+  `~/.claude/skills/` does not keep loading alongside it. tm's global roster
+  deploys into `$CLAUDE_CONFIG_DIR/skills` — that IS the personal tier, which
+  for skills outranks project.
+- Plugin skills use a `plugin-name:skill-name` namespace and sit OUTSIDE the
+  ranking entirely, so they cannot collide. `plugin:` is the only reserved,
+  guaranteed-non-collidable namespace.
+- No frontmatter field declares a tier. Scope is filesystem location only. tm
+  reads a `category:` key; Claude Code ignores it, so it can never be used to
+  win a collision.
+- Bundled skills are `tm-*` prefixed, so a real collision with a user's own
+  skill is unlikely. Rely on the prefix, not on precedence.
 
 ### Skill Structure
 A valid skill file must have:

--- a/crates/trusty-mpm/src/core/managed_config.rs
+++ b/crates/trusty-mpm/src/core/managed_config.rs
@@ -66,6 +66,14 @@
 //! exceptions were checksum-frozen hand edits the deployer is correct to
 //! decline.
 //!
+//! And this tier WINS for skills (#4958). Claude Code resolves skills
+//! `enterprise > personal > project > bundled`, and `CLAUDE_CONFIG_DIR`
+//! relocates the personal tier — so `$CLAUDE_CONFIG_DIR/skills` outranks the
+//! workspace's `<project_dir>/.claude/skills`. AGENTS invert that (project
+//! beats user), which is why the same directory needs `--reset-agents` to
+//! clear a project-tier shadow but no equivalent for skills. Do not carry
+//! either order across to the other artifact type.
+//!
 //! What: [`ensure_managed_config_dir`] (1) runs the canonical standalone
 //! scaffolding ([`ensure_global_config_dir`] — settings.json + the MPM hook
 //! triad + `.mcp.json` + output-styles, plus a best-effort deploy from the
@@ -82,8 +90,8 @@
 //! declined to refresh — the deploy itself already ran on all three run paths;
 //! only the evidence of it was missing. Since #4880 step (2) also refreshes the
 //! session workspace's PROJECT skill tier (`<project_dir>/.claude/skills`),
-//! which OUTRANKS everything deployed here and previously went stale on resume
-//! and in-place relaunch; that half is stamp-gated on the project manifest, so
+//! which previously went stale on resume and in-place relaunch; that half is
+//! stamp-gated on the project manifest, so
 //! it writes nothing when nothing changed. See
 //! [`crate::core::project_skill_tier`].
 //! Test: `ensure_managed_config_dir_deploys_full_roster`,
@@ -240,9 +248,12 @@ pub fn ensure_managed_config_dir_with_root(
         tracing::warn!("managed config dir: {line}");
     }
 
-    // #4880: the PROJECT tier outranks the user tier deployed just above, so a
-    // stale project copy silently beats a current one. Non-fatal, and a no-op
-    // whenever the project manifest stamp still matches.
+    // #4880: refresh the PROJECT tier, which no other run path touches on a
+    // resume or an in-place relaunch. #4958 corrects why: for SKILLS Claude Code
+    // resolves personal > project, so `$CLAUDE_CONFIG_DIR/skills` (deployed just
+    // above) OUTRANKS this destination — a stale copy here does not beat it. It
+    // is still what loads for every name the managed roster does not carry.
+    // Non-fatal, and a no-op whenever the project manifest stamp still matches.
     match crate::core::project_skill_tier::ensure_project_skill_tier(fw, project_dir) {
         Ok(project) => {
             // Deliberately NOT routed through `skill_skip_summary`: a skipped

--- a/crates/trusty-mpm/src/core/project_skill_tier.rs
+++ b/crates/trusty-mpm/src/core/project_skill_tier.rs
@@ -1,14 +1,30 @@
 //! Deploy the PROJECT skill tier when the project manifest changes (#4880).
 //!
-//! Why: `<workspace>/.claude/skills` is the PROJECT tier, and project outranks
-//! user. It was written by exactly two callers —
-//! `session_launch::prepare_session` and `tm sessions sync-assets` — and neither
-//! runs on a resume or on a bare-`tm` in-place relaunch. The user tier, by
-//! contrast, is refreshed on every run (`managed_config`, #4873). So a
-//! project-tier skill an older binary deployed keeps winning over the current
-//! user-tier copy, silently, for the life of the workspace. That is the #4408
-//! shadowing shape one tier down: there, a 32-byte project-tier stub beat the
-//! real 25KB agent.
+//! Why: `<workspace>/.claude/skills` is the PROJECT tier. It was written by
+//! exactly two callers — `session_launch::prepare_session` and `tm sessions
+//! sync-assets` — and neither runs on a resume or on a bare-`tm` in-place
+//! relaunch, so a skill an older binary deployed here stays stale for the life
+//! of the workspace. The user tier, by contrast, is refreshed on every run
+//! (`managed_config`, #4873).
+//!
+//! WHICH PRECEDENCE (#4958 — two different orders get called that; the earlier
+//! text here conflated them and asserted the wrong one as fact).
+//!
+//! - DEPLOY-TIME SOURCE precedence — which SOURCE tm writes into ONE
+//!   destination: `project-custom > user-custom > bundled`
+//!   ([`crate::core::skill_tiers::plan_skill_tiers`]). This module's deploy
+//!   obeys it, and it says nothing about what Claude Code loads.
+//! - CLAUDE CODE RUNTIME resolution — which on-disk copy loads when the same
+//!   name exists in two directories: `enterprise > personal > project >
+//!   bundled`. For SKILLS personal beats project, so `$CLAUDE_CONFIG_DIR/skills`
+//!   OUTRANKS this destination. AGENTS run the order the other way (project
+//!   beats user), which is why #4408's project-tier stub beat the real 25 KB
+//!   agent — that precedent does NOT transfer to skills.
+//!
+//! So a stale copy here never "beats" the current user-tier one; a same-named
+//! skill under `$CLAUDE_CONFIG_DIR/skills` wins. Refreshing this tier still
+//! matters because it is what loads for every name the managed roster does not
+//! carry — the project-custom case above all.
 //!
 //! WHAT TRIGGERS A REDEPLOY (owner ruling 2026-08-05, refined on PR #4882).
 //! Two things, and deliberately not a third.


### PR DESCRIPTION
## Defect

`mpm-skills-manager` and `mpm-agent-manager` place and override bundled assets, but neither stated Claude Code's runtime resolution order. The skills manager stated only tm's deploy-time source order (`project-custom > user-custom > bundled`) with no label saying which axis that is, so it reads as the runtime rule. It is not.

The two orders are opposite, which is the trap.

## Evidence

Skills — https://code.claude.com/docs/en/skills.md:

> When skills share the same name across levels, enterprise overrides personal, and personal overrides project. A skill at any of these levels also overrides a bundled skill with the same name. [...] Plugin skills use a `plugin-name:skill-name` namespace, so they cannot conflict with other levels.

Subagents — https://code.claude.com/docs/en/sub-agents.md, priority table: managed settings (1) > `--agents` flag (2) > `.claude/agents/` (3) > `~/.claude/agents/` (4) > plugin (5), under "When multiple subagents share the same name, Claude Code uses the one from the higher-priority location."

So for SKILLS personal beats project; for AGENTS project beats user. Same two scopes, opposite order. A manager that assumes one rule covers both writes a file that silently loses.

## Resolution

Each manager now carries the order for its own artifact type, states the asymmetry, and says where to write so the file wins. Plus the details that change what a manager would do: no frontmatter field declares a tier (location only, and `category:` is tm-only), `plugin:` is the only guaranteed-non-collidable namespace, `CLAUDE_CONFIG_DIR` relocates the whole `~/.claude` tree so tm's global roster lands in the personal tier, and two same-`name` agent files in one tree resolve by filesystem read order with no documented precedence.

The skills manager's existing tier section is relabelled **deploy-time source precedence** — it was correct, just unlabelled.

Docs only. No deploy destination, tier model, or code path changed.

## Gates

```
cargo fmt --check && cargo check -p trusty-mpm && bash scripts/check_line_cap.sh && bash scripts/check_sld.sh   → EXIT=0
cargo clippy -p trusty-mpm -- -D warnings                                                                        → EXIT=0
UPDATE_GOLDEN=1 cargo test -p trusty-mpm golden  → test result: ok. 4 passed; 0 failed  (no snapshot churn)
cargo test -p trusty-mpm --lib bundle            → 105 passed; 1 failed
```

The one failure is `resolve_pm_prompt_wrapper_matches_the_source_reporting_form`, and it is pre-existing and machine-local: the roster it composes reads the operator's live `~/.claude/agents/`, which on this machine holds a `copyeditor.md` dated Jul 15 that is not a repo asset. The diff touches two bundled agent bodies and one changelog fragment, none of which can add a roster entry.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools