### PR TITLE
fix(trusty-mpm): stop startup hygiene destroying gitignored content in the managed checkout

### DIFF
--- a/crates/trusty-mpm/changelog.d/4961-hygiene-reset-data-loss.md
+++ b/crates/trusty-mpm/changelog.d/4961-hygiene-reset-data-loss.md
@@ -1,0 +1,6 @@
+Fixed
+
+- startup hygiene no longer destroys gitignored working-tree content in the managed checkout (closes [#4961](https://github.com/bobmatnyc/trusty-tools/issues/4961))
+  - the update step is now a non-destructive `git merge --ff-only`, never `git reset --hard`, and it refuses when any path the update would write already exists untracked on disk — `git status --porcelain` never reported gitignored paths, so a gitignored file holding real content read as clean and was silently overwritten
+  - the update also refuses off the default branch, where the ahead-count validated `origin/<checked-out>` while the operation moved the branch to `origin/<default>`
+  - a `.trusty-mpm-no-hygiene` marker file in a base clone now opts that single checkout out of the sweep; previously the only control was the process-wide `TRUSTY_MPM_INPROJECT_HYGIENE` env var

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject_hygiene.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject_hygiene.rs
@@ -4,103 +4,151 @@
 //! always be on the default branch and up to date with the remote when the
 //! daemon starts. Without hygiene, a stale or diverged base clone silently
 //! yields sessions on an outdated branch, confusing agents. Running a short
-//! fetch + hard-reset sequence at daemon startup keeps every base clone
+//! fetch + fast-forward sequence at daemon startup keeps every base clone
 //! current. Dead worktrees from previous sessions are also pruned to prevent
 //! the base clone's worktree list from growing indefinitely.
 //!
-//! CRITICAL SAFETY INVARIANT (#2177): the hygiene sweep must NEVER discard
-//! local commits or uncommitted changes. Before the hard-reset step runs, the
-//! base clone's current branch is checked for unpushed commits (ahead of its
-//! origin counterpart) and a dirty working tree; either condition SKIPS the
-//! reset entirely and logs a warning instead. This closed a data-loss bug
-//! where an unconditional `git reset --hard origin/<branch>` on every daemon
-//! startup silently discarded committed-but-unpushed work.
-//! What: [`get_default_branch`] reads the origin/HEAD symref; [`run_hygiene_for_base`]
-//! runs fetch, a safety-gated hard-reset, and worktree prune for one base
-//! clone directory; [`run_hygiene_for_all_bases`] walks
+//! CRITICAL SAFETY INVARIANT (#2177, #4961): the hygiene sweep must NEVER
+//! discard local work of any kind. The update step is a NON-DESTRUCTIVE
+//! fast-forward (`git merge --ff-only`), never `git reset --hard`, and it is
+//! preceded by three gates: the checked-out branch must be the default branch
+//! (so the safety checks validate the very ref being moved), it must have zero
+//! unpushed commits and a clean working tree, and no path the update would
+//! write may already exist untracked on disk.
+//!
+//! That last gate is what #4961 added, and it is not redundant with the dirty
+//! check. `git status --porcelain` does not report gitignored paths at all, so
+//! a gitignored file holding real user content reads as "clean" — and both
+//! `git reset --hard` AND `git merge --ff-only` silently overwrite it when the
+//! target commit tracks the same path. A user pointing Obsidian, Cursor, or
+//! any editor at a managed checkout creates exactly that shape. Adding
+//! `--ignored` to the dirty check is NOT the fix: `target/` is gitignored and
+//! present in any built checkout, so the gate would always see dirt and
+//! hygiene would become a permanent no-op.
+//!
+//! What: [`get_default_branch`] reads the origin/HEAD symref;
+//! [`run_hygiene_for_base`] runs fetch, a gated fast-forward, and worktree
+//! prune for one base clone directory; [`run_hygiene_for_all_bases`] walks
 //! `<repos_root>/<owner>/<repo>/` and calls the per-base function for each;
 //! wired into daemon startup via [`super::super::serve_http`] (the main
-//! `serve_http` function in daemon/mod.rs).
-//! Test: `get_default_branch_returns_none_for_non_git` and
-//! `run_hygiene_skips_missing_dir` unit tests; `decide_reset_*` unit tests
-//! cover the pure decision logic; `hygiene_*` integration tests exercise real
-//! temp git repos for the ahead/dirty/clean/recovery-ref cases; integration
-//! coverage via daemon startup tests.
+//! `serve_http` function in daemon/mod.rs). A per-repo opt-out marker file
+//! ([`HYGIENE_OPT_OUT_MARKER`]) disables the sweep for a single checkout.
+//! Test: unit coverage in `inproject_hygiene_tests.rs`; `hygiene_*` integration
+//! tests in `crates/trusty-mpm/tests/inproject_hygiene_test.rs` exercise real
+//! temp git repos for the ahead/dirty/clean/gitignored/off-default/opt-out
+//! cases.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use tracing::{info, warn};
 
-/// Decision on whether the destructive `git reset --hard` step may proceed.
+/// Marker file that opts a single base clone out of the startup hygiene sweep.
 ///
-/// Why: the reset decision has several independent inputs (ahead-count,
-/// working-tree cleanliness, detached/unknown states) that are easiest to
-/// reason about — and unit-test — as a small pure function separated from the
-/// git-shelling plumbing that gathers those inputs.
-/// What: two variants — `Reset` (safe to fast-forward the base clone to
+/// Why: before #4961 the only control was the process-wide
+/// `TRUSTY_MPM_INPROJECT_HYGIENE` env var — all-or-nothing across every managed
+/// checkout. A user who actively edits one checkout in an external editor had
+/// no way to exempt just that one without disabling hygiene everywhere.
+/// What: an empty file named `.trusty-mpm-no-hygiene` in the base clone root.
+/// Its mere presence skips every step of the sweep for that checkout.
+/// Test: `hygiene_opt_out_marker_skips_update` (integration),
+/// `hygiene_opt_out_marker_detected` (unit).
+pub const HYGIENE_OPT_OUT_MARKER: &str = ".trusty-mpm-no-hygiene";
+
+/// Decision on whether the fast-forward update step may proceed.
+///
+/// Why: the update decision has several independent inputs (checked-out branch
+/// identity, ahead-count, working-tree cleanliness, detached/unknown states)
+/// that are easiest to reason about — and unit-test — as a small pure function
+/// separated from the git-shelling plumbing that gathers those inputs.
+/// What: two variants — `Update` (safe to fast-forward the base clone to
 /// origin) and `Skip(reason)` (refuse, carrying a human-readable reason for
 /// the warning log).
-/// Test: `decide_reset_*` unit tests below.
+/// Test: `decide_update_*` unit tests in `inproject_hygiene_tests.rs`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum ResetDecision {
-    Reset,
+enum UpdateDecision {
+    Update,
     Skip(String),
 }
 
-/// Decide whether a hard-reset may proceed, given ahead-count and dirty state.
+/// Decide whether the fast-forward may proceed, given branch, ahead and dirty state.
 ///
 /// Why: centralizes the data-loss-prevention rule in one pure, testable place
 /// rather than scattering conditionals through the git-shelling code. Any
 /// input that could not be determined (detached HEAD, no upstream, a failed
-/// `git` invocation) is treated conservatively as "do not reset" — the reset
-/// is only ever allowed when we have positive confirmation the branch is not
-/// ahead of origin and the working tree is clean.
-/// What: `ahead_count: None` (unknown — detached HEAD, no upstream, or a
-/// `rev-list` failure) always yields `Skip`. `dirty: None` (a `status`
-/// failure) always yields `Skip`. `ahead_count: Some(n) if n > 0` yields
-/// `Skip` (unpushed commits would be discarded). `dirty: Some(true)` yields
-/// `Skip` (uncommitted changes would be discarded). Only `ahead_count:
-/// Some(0)` combined with `dirty: Some(false)` yields `Reset`.
-/// Test: `decide_reset_ahead_skips`, `decide_reset_dirty_skips`,
-/// `decide_reset_unknown_ahead_skips`, `decide_reset_unknown_dirty_skips`,
-/// `decide_reset_clean_and_even_resets`.
-fn decide_reset(ahead_count: Option<usize>, dirty: Option<bool>) -> ResetDecision {
+/// `git` invocation) is treated conservatively as "do not update".
+///
+/// The branch gate closes #4961's second finding: the ahead-count is measured
+/// as `origin/<checked-out>..<checked-out>`, but the update targets
+/// `origin/<default>`. Off the default branch those are different refs, so the
+/// safety check could pass against one ref while the operation moved the local
+/// branch to another. Requiring `checked_out == default_branch` makes the
+/// check validate exactly the ref being moved.
+/// What: `checked_out: None` (detached HEAD) yields `Skip`. A `checked_out`
+/// that differs from `default_branch` yields `Skip`. `ahead_count: None`
+/// (unknown — no upstream, or a `rev-list` failure) yields `Skip`. `dirty:
+/// None` (a `status` failure) yields `Skip`. `ahead_count: Some(n) if n > 0`
+/// yields `Skip` (unpushed commits). `dirty: Some(true)` yields `Skip`. Only a
+/// checked-out default branch with `Some(0)` ahead and `Some(false)` dirty
+/// yields `Update`.
+/// Test: `decide_update_ahead_skips`, `decide_update_dirty_skips`,
+/// `decide_update_unknown_ahead_skips`, `decide_update_unknown_dirty_skips`,
+/// `decide_update_detached_head_skips`, `decide_update_non_default_branch_skips`,
+/// `decide_update_clean_and_even_updates`.
+fn decide_update(
+    checked_out: Option<&str>,
+    default_branch: &str,
+    ahead_count: Option<usize>,
+    dirty: Option<bool>,
+) -> UpdateDecision {
+    let Some(branch) = checked_out else {
+        return UpdateDecision::Skip(
+            "HEAD is detached (no branch checked out); refusing to move any ref".to_string(),
+        );
+    };
+    // #4961: the ahead-count below is measured against `origin/<branch>`, so it
+    // only proves anything when `branch` is the ref the update actually moves.
+    if branch != default_branch {
+        return UpdateDecision::Skip(format!(
+            "checked-out branch `{branch}` is not the default branch `{default_branch}`; \
+             refusing to move it to a different ref"
+        ));
+    }
     let Some(ahead) = ahead_count else {
-        return ResetDecision::Skip(
-            "branch ahead-count unknown (detached HEAD, no upstream, or git error); \
+        return UpdateDecision::Skip(
+            "branch ahead-count unknown (no upstream, or git error); \
              refusing to discard local work"
                 .to_string(),
         );
     };
     let Some(is_dirty) = dirty else {
-        return ResetDecision::Skip(
-            "working tree status unknown (git error); refusing hard reset".to_string(),
+        return UpdateDecision::Skip(
+            "working tree status unknown (git error); refusing to update".to_string(),
         );
     };
     if ahead > 0 {
-        return ResetDecision::Skip(format!(
+        return UpdateDecision::Skip(format!(
             "{ahead} commit(s) ahead of origin (unpushed); refusing to discard local work"
         ));
     }
     if is_dirty {
-        return ResetDecision::Skip("uncommitted changes present; refusing hard reset".to_string());
+        return UpdateDecision::Skip("uncommitted changes present; refusing to update".to_string());
     }
-    ResetDecision::Reset
+    UpdateDecision::Update
 }
 
 /// Read the short name of the currently checked-out branch, if any.
 ///
-/// Why: the ahead-count and reset-target checks need to know which branch is
+/// Why: the ahead-count and branch-identity checks need to know which branch is
 /// actually checked out in the base clone (not merely the repo's configured
-/// default branch) — resetting a detached HEAD or misidentifying the branch
-/// could silently discard work on the wrong ref.
+/// default branch) — updating a detached HEAD or misidentifying the branch
+/// could silently move the wrong ref.
 /// What: runs `git -C <base_path> symbolic-ref --short HEAD`; returns `None`
 /// on any failure, including detached HEAD (where `symbolic-ref` exits
 /// non-zero because `HEAD` does not point at a branch).
-/// Test: covered indirectly via `hygiene_*` integration tests (a normal
-/// branch checkout resolves; detached HEAD is exercised through
-/// `decide_reset_unknown_ahead_skips`, which models the `None` case this
-/// function would produce).
+/// Test: `hygiene_non_default_branch_is_not_updated` (integration) drives a
+/// real non-default checkout through this function; the `None` case is modelled
+/// by `decide_update_detached_head_skips`.
 fn current_branch(base_path: &Path) -> Option<String> {
     let out = std::process::Command::new("git")
         .arg("-C")
@@ -121,13 +169,13 @@ fn current_branch(base_path: &Path) -> Option<String> {
 
 /// Count commits on `branch` that are not yet on `origin/<branch>`.
 ///
-/// Why: this is the direct measure of "would a hard reset to origin discard
-/// committed work" — the data-loss bug this module fixes.
+/// Why: this is the direct measure of "would an update to origin discard
+/// committed work" — the data-loss bug #2177 fixed.
 /// What: runs `git -C <base_path> rev-list --count origin/<branch>..<branch>`
 /// and parses the count. Returns `None` if the command fails (e.g. no
 /// `origin/<branch>` upstream exists) or the output does not parse as a
-/// number — both are treated as "unknown" by [`decide_reset`], which refuses
-/// to reset on unknown input.
+/// number — both are treated as "unknown" by [`decide_update`], which refuses
+/// to proceed on unknown input.
 /// Test: `hygiene_ahead_branch_is_not_reset` integration test (via
 /// [`run_hygiene_for_base`]).
 fn ahead_count(base_path: &Path, branch: &str) -> Option<usize> {
@@ -144,13 +192,16 @@ fn ahead_count(base_path: &Path, branch: &str) -> Option<usize> {
     String::from_utf8_lossy(&out.stdout).trim().parse().ok()
 }
 
-/// Determine whether the working tree has uncommitted changes.
+/// Determine whether the working tree has uncommitted changes to TRACKED files.
 ///
-/// Why: a hard reset discards uncommitted modifications just as readily as
-/// unpushed commits; this is the second half of the data-loss guard.
+/// Why: an update must not clobber uncommitted modifications; this is one half
+/// of the data-loss guard. It is deliberately NOT the whole guard — see
+/// [`colliding_untracked_paths`] for the gitignored-content half (#4961).
 /// What: runs `git -C <base_path> status --porcelain`; `Some(true)` if any
 /// output is produced (dirty), `Some(false)` if output is empty (clean),
-/// `None` if the command itself fails.
+/// `None` if the command itself fails. Note that `--porcelain` without
+/// `--ignored` reports nothing for gitignored paths, which is why it cannot be
+/// the only guard.
 /// Test: `hygiene_dirty_tree_is_not_reset` integration test (via
 /// [`run_hygiene_for_base`]).
 fn is_dirty(base_path: &Path) -> Option<bool> {
@@ -166,19 +217,83 @@ fn is_dirty(base_path: &Path) -> Option<bool> {
     Some(!out.stdout.is_empty())
 }
 
-/// Best-effort write of a recovery ref pointing at the pre-reset HEAD.
+/// Run `git -C <base_path> <args>` and return NUL-separated stdout entries.
 ///
-/// Why: defense-in-depth — even when the ahead/dirty checks correctly clear a
-/// reset to proceed, leaving a cheap breadcrumb to the prior HEAD costs
-/// nothing and gives a manual recovery path (`git reset --hard
+/// Why: both halves of the collision check parse `-z` git output the same way;
+/// a shared helper keeps the parsing (and the "any failure is fatal to the
+/// check" contract) in one place.
+/// What: spawns git, returns `Err` with a description on spawn failure or a
+/// non-zero exit, otherwise splits stdout on NUL and drops empty entries.
+/// Test: exercised through `colliding_untracked_paths` by
+/// `hygiene_gitignored_file_is_not_clobbered`.
+fn git_z_lines(base_path: &Path, args: &[&str]) -> Result<Vec<String>, String> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(base_path)
+        .args(args)
+        .output()
+        .map_err(|e| format!("git {args:?} error: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "git {args:?} failed ({}): {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout)
+        .split('\0')
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect())
+}
+
+/// Paths the pending update would write that already exist untracked on disk.
+///
+/// Why: this is the #4961 fix. Git itself will NOT protect these files. A
+/// gitignored path is invisible to `git status --porcelain`, and both `git
+/// reset --hard` and `git merge --ff-only` silently overwrite an ignored file
+/// when the target commit tracks the same path (`--overwrite-ignore` is git's
+/// default and `merge` offers no way to turn it off). Reproduced with a
+/// gitignored `notes.md` holding real content: destroyed, no warning, no
+/// recovery path. Detecting the collision ourselves and refusing is the only
+/// way to make the update genuinely non-destructive.
+/// What: takes the paths the update would touch (`git diff --name-only HEAD
+/// <target>`), subtracts everything currently tracked (`git ls-files`), and
+/// returns those of the remainder that exist on disk. A path deleted by the
+/// target is tracked at HEAD, so it is never flagged. `symlink_metadata` is
+/// used so a broken symlink still counts as present. Any git failure returns
+/// `Err`, which the caller treats as "refuse".
+/// Test: `hygiene_gitignored_file_is_not_clobbered` (integration).
+fn colliding_untracked_paths(base_path: &Path, target: &str) -> Result<Vec<String>, String> {
+    let incoming = git_z_lines(base_path, &["diff", "--name-only", "-z", "HEAD", target])?;
+    if incoming.is_empty() {
+        return Ok(Vec::new());
+    }
+    let tracked: HashSet<String> = git_z_lines(base_path, &["ls-files", "-z"])?
+        .into_iter()
+        .collect();
+
+    Ok(incoming
+        .into_iter()
+        .filter(|p| !tracked.contains(p) && base_path.join(p).symlink_metadata().is_ok())
+        .collect())
+}
+
+/// Best-effort write of a recovery ref pointing at the pre-update HEAD.
+///
+/// Why: defense-in-depth — even when every gate correctly clears an update to
+/// proceed, leaving a cheap breadcrumb to the prior HEAD costs nothing and
+/// gives a manual recovery path (`git reset --hard
 /// refs/trusty-mpm/pre-hygiene/<branch>`) if some unanticipated case still
-/// loses work. This must never abort the sweep: any failure here is logged
-/// and swallowed, matching the file's existing "every step logged, no step is
-/// fatal" pattern.
+/// loses committed work. It is structurally incapable of restoring
+/// never-committed working-tree content, which is why the gates — not this ref
+/// — are the actual guarantee. This must never abort the sweep: any failure
+/// here is logged and swallowed, matching the file's existing "every step
+/// logged, no step is fatal" pattern.
 /// What: resolves the current HEAD sha via `git rev-parse HEAD`, then runs
 /// `git update-ref refs/trusty-mpm/pre-hygiene/<branch> <sha>`. Both steps are
 /// best-effort; failures are logged via `warn!` and otherwise ignored.
-/// Test: `hygiene_recovery_ref_written_before_reset` integration test (via
+/// Test: `hygiene_recovery_ref_written_before_update` integration test (via
 /// [`run_hygiene_for_base`]).
 fn write_recovery_ref(base_path: &Path, branch: &str) {
     let head = std::process::Command::new("git")
@@ -232,7 +347,7 @@ fn write_recovery_ref(base_path: &Path, branch: &str) {
 
 /// Read the default branch for a base clone by inspecting `origin/HEAD`.
 ///
-/// Why: the hard-reset step needs the default branch name; reading the symref
+/// Why: the update step needs the default branch name; reading the symref
 /// is more reliable than hardcoding `main` across diverse repositories.
 /// What: runs `git -C <base_path> symbolic-ref --short refs/remotes/origin/HEAD`
 /// and returns the short branch name (e.g. `main`) on success, or `None` if git
@@ -262,34 +377,118 @@ pub fn get_default_branch(base_path: &Path) -> Option<String> {
     }
 }
 
-/// Run hygiene for a single base clone: fetch, safety-gated hard-reset, prune worktrees.
+/// Fetch, then fast-forward the base clone to origin if every gate clears.
+///
+/// Why: split out of [`run_hygiene_for_base`] so the update step's four gates
+/// read as one sequence rather than being buried between the fetch and prune
+/// steps. Returns nothing: like every other step in the sweep, a refusal or a
+/// git failure is logged and never propagated.
+/// What: resolves the default branch, the checked-out branch, its ahead-count
+/// and dirty state, and feeds them to [`decide_update`]. On `Update` it then
+/// runs the [`colliding_untracked_paths`] check and refuses if any path the
+/// update would write already exists untracked on disk (#4961). Only when that
+/// too is clear does it write a recovery ref and run `git merge --ff-only
+/// origin/<default>` — which is itself non-destructive and fails cleanly
+/// rather than overwriting when it cannot fast-forward.
+/// Test: `hygiene_gitignored_file_is_not_clobbered`,
+/// `hygiene_non_default_branch_is_not_updated`, `hygiene_ahead_branch_is_not_reset`,
+/// `hygiene_dirty_tree_is_not_reset`, `hygiene_clean_branch_is_fast_forwarded`.
+fn update_to_origin(base_path: &Path) {
+    let default_branch = get_default_branch(base_path).unwrap_or_else(|| "main".to_string());
+    let checked_out = current_branch(base_path);
+    let ahead = checked_out
+        .as_deref()
+        .and_then(|b| ahead_count(base_path, b));
+    let dirty = is_dirty(base_path);
+
+    if let UpdateDecision::Skip(reason) =
+        decide_update(checked_out.as_deref(), &default_branch, ahead, dirty)
+    {
+        warn!(
+            path = %base_path.display(),
+            branch = %checked_out.as_deref().unwrap_or("<unknown/detached>"),
+            "inproject-hygiene: SKIP update — {reason}"
+        );
+        return;
+    }
+
+    let target = format!("origin/{default_branch}");
+
+    // #4961: gitignored working-tree content is invisible to `git status
+    // --porcelain`, and git overwrites it without complaint. Refuse instead.
+    match colliding_untracked_paths(base_path, &target) {
+        Ok(collisions) if !collisions.is_empty() => {
+            warn!(
+                path = %base_path.display(),
+                paths = %collisions.join(", "),
+                "inproject-hygiene: SKIP update — {} untracked path(s) on disk would be \
+                 overwritten by the update; refusing to discard them",
+                collisions.len()
+            );
+            return;
+        }
+        Ok(_) => {}
+        Err(e) => {
+            warn!(path = %base_path.display(), "inproject-hygiene: SKIP update — collision check failed: {e}");
+            return;
+        }
+    }
+
+    if let Some(branch) = checked_out.as_deref() {
+        write_recovery_ref(base_path, branch);
+    }
+
+    let merge = std::process::Command::new("git")
+        .arg("-C")
+        .arg(base_path)
+        .args(["merge", "--ff-only", &target])
+        .output();
+    match merge {
+        Ok(out) if out.status.success() => {
+            info!(path = %base_path.display(), branch = %default_branch, "inproject-hygiene: fast-forward OK");
+        }
+        Ok(out) => {
+            warn!(
+                path = %base_path.display(),
+                "inproject-hygiene: fast-forward declined ({}): {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        Err(e) => {
+            warn!(path = %base_path.display(), "inproject-hygiene: fast-forward error: {e}");
+        }
+    }
+}
+
+/// Run hygiene for a single base clone: fetch, gated fast-forward, prune worktrees.
 ///
 /// Why: each step targets a distinct failure mode — fetch syncs the remote object
-/// store; hard-reset (when safe) discards any accidental local modifications;
-/// worktree prune cleans up working-tree entries for worktrees whose paths no
-/// longer exist (left behind by decommissioned sessions). All steps are
-/// non-fatal: a failure is logged as a warning and the next step still runs,
-/// so a transient git error does not prevent the other steps from running.
-/// Critically (#2177), the hard-reset step is gated: it only runs when the
-/// checked-out branch has zero unpushed commits ahead of its origin
-/// counterpart AND the working tree is clean, so it can never discard local
-/// work. When it does proceed, a recovery ref is written first as a
-/// defense-in-depth breadcrumb.
-/// What: (1) `git -C <base_path> fetch origin`; (2) resolves the current
-/// branch via [`current_branch`] and, if resolvable, its ahead-count via
-/// [`ahead_count`] and dirty state via [`is_dirty`]; feeds both into
-/// [`decide_reset`] — on `Skip`, logs a warning and does not reset; on
-/// `Reset`, writes a recovery ref via [`write_recovery_ref`] then runs `git
-/// -C <base_path> reset --hard origin/<default-branch>` (default branch via
-/// [`get_default_branch`], falls back to `"main"`); (3) `git -C <base_path>
-/// worktree prune`.
+/// store; the fast-forward (when safe) brings the checkout up to the remote
+/// default branch; worktree prune cleans up working-tree entries for worktrees
+/// whose paths no longer exist (left behind by decommissioned sessions). All
+/// steps are non-fatal: a failure is logged as a warning and the next step
+/// still runs, so a transient git error does not prevent the other steps from
+/// running. Critically (#2177, #4961), the update step can never discard local
+/// work — see [`update_to_origin`].
+/// What: returns early when `.git` is absent, or when the
+/// [`HYGIENE_OPT_OUT_MARKER`] file is present (a per-repo opt-out; every step is
+/// skipped so an opted-out checkout is left entirely alone). Otherwise: (1)
+/// `git -C <base_path> fetch origin`; (2) [`update_to_origin`]; (3) `git -C
+/// <base_path> worktree prune`.
 /// Test: `run_hygiene_skips_missing_dir` (unit — directory absent → early
-/// return); `hygiene_ahead_branch_is_not_reset`,
-/// `hygiene_dirty_tree_is_not_reset`, `hygiene_clean_branch_is_reset`,
-/// `hygiene_recovery_ref_written_before_reset` (integration, real temp git
-/// repos).
+/// return); `hygiene_opt_out_marker_skips_update`,
+/// `hygiene_ahead_branch_is_not_reset`, `hygiene_dirty_tree_is_not_reset`,
+/// `hygiene_clean_branch_is_fast_forwarded`, `hygiene_gitignored_file_is_not_clobbered`,
+/// `hygiene_non_default_branch_is_not_updated`,
+/// `hygiene_recovery_ref_written_before_update` (integration, real temp git repos).
 pub fn run_hygiene_for_base(base_path: &Path) -> Result<(), String> {
     if !base_path.join(".git").exists() {
+        return Ok(());
+    }
+    // #4961: per-repo opt-out for a checkout the user actively edits.
+    if base_path.join(HYGIENE_OPT_OUT_MARKER).exists() {
+        info!(path = %base_path.display(), marker = %HYGIENE_OPT_OUT_MARKER, "inproject-hygiene: opted out, skipping");
         return Ok(());
     }
 
@@ -318,52 +517,8 @@ pub fn run_hygiene_for_base(base_path: &Path) -> Result<(), String> {
         }
     }
 
-    // Step 2: safety-gated hard-reset to the default branch (#2177 — never
-    // discard local commits or uncommitted changes).
-    let default_branch = get_default_branch(base_path).unwrap_or_else(|| "main".to_string());
-    let checked_out = current_branch(base_path);
-    let ahead = checked_out
-        .as_deref()
-        .and_then(|b| ahead_count(base_path, b));
-    let dirty = is_dirty(base_path);
-
-    match decide_reset(ahead, dirty) {
-        ResetDecision::Skip(reason) => {
-            warn!(
-                path = %base_path.display(),
-                branch = %checked_out.as_deref().unwrap_or("<unknown/detached>"),
-                "inproject-hygiene: SKIP reset — {reason}"
-            );
-        }
-        ResetDecision::Reset => {
-            if let Some(branch) = checked_out.as_deref() {
-                write_recovery_ref(base_path, branch);
-            }
-
-            let target = format!("origin/{default_branch}");
-            let reset = std::process::Command::new("git")
-                .arg("-C")
-                .arg(base_path)
-                .args(["reset", "--hard", &target])
-                .output();
-            match reset {
-                Ok(out) if out.status.success() => {
-                    info!(path = %base_path.display(), branch = %default_branch, "inproject-hygiene: reset OK");
-                }
-                Ok(out) => {
-                    warn!(
-                        path = %base_path.display(),
-                        "inproject-hygiene: reset failed ({}): {}",
-                        out.status,
-                        String::from_utf8_lossy(&out.stderr).trim()
-                    );
-                }
-                Err(e) => {
-                    warn!(path = %base_path.display(), "inproject-hygiene: reset error: {e}");
-                }
-            }
-        }
-    }
+    // Step 2: non-destructive, gated fast-forward to the default branch.
+    update_to_origin(base_path);
 
     // Step 3: prune stale worktrees.
     let prune = std::process::Command::new("git")
@@ -444,77 +599,5 @@ pub fn run_hygiene_for_all_bases(repos_root: &Path) {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn get_default_branch_returns_none_for_non_git() {
-        // A non-git directory must return None cleanly.
-        let tmp = std::env::temp_dir();
-        assert!(get_default_branch(&tmp).is_none());
-    }
-
-    #[test]
-    fn run_hygiene_skips_missing_dir() {
-        // A path that does not have .git must return Ok(()) immediately.
-        let tmp = std::env::temp_dir();
-        let result = run_hygiene_for_base(&tmp);
-        assert!(
-            result.is_ok(),
-            "should skip non-git dir cleanly: {result:?}"
-        );
-    }
-
-    #[test]
-    fn run_hygiene_for_all_bases_skips_missing_root() {
-        // A non-existent repos root must complete without panicking.
-        let missing = std::path::Path::new("/tmp/trusty-nonexistent-repos-root-hygiene-test");
-        run_hygiene_for_all_bases(missing); // must not panic
-    }
-
-    // ── decide_reset: pure decision-logic unit tests (#2177) ──────────────
-
-    #[test]
-    fn decide_reset_ahead_skips() {
-        // Any unpushed commit must refuse the reset, even on a clean tree.
-        match decide_reset(Some(1), Some(false)) {
-            ResetDecision::Skip(reason) => assert!(reason.contains("ahead")),
-            ResetDecision::Reset => panic!("an ahead branch must never be reset"),
-        }
-    }
-
-    #[test]
-    fn decide_reset_dirty_skips() {
-        // A dirty tree must refuse the reset, even when not ahead.
-        match decide_reset(Some(0), Some(true)) {
-            ResetDecision::Skip(reason) => assert!(reason.contains("uncommitted")),
-            ResetDecision::Reset => panic!("a dirty tree must never be reset"),
-        }
-    }
-
-    #[test]
-    fn decide_reset_unknown_ahead_skips() {
-        // Detached HEAD / no upstream / rev-list failure (ahead=None) must
-        // conservatively refuse, regardless of the dirty state.
-        match decide_reset(None, Some(false)) {
-            ResetDecision::Skip(_) => {}
-            ResetDecision::Reset => panic!("unknown ahead-count must never be reset"),
-        }
-    }
-
-    #[test]
-    fn decide_reset_unknown_dirty_skips() {
-        // A `git status` failure (dirty=None) must conservatively refuse,
-        // regardless of the ahead-count.
-        match decide_reset(Some(0), None) {
-            ResetDecision::Skip(_) => {}
-            ResetDecision::Reset => panic!("unknown dirty-state must never be reset"),
-        }
-    }
-
-    #[test]
-    fn decide_reset_clean_and_even_resets() {
-        // The only case that may proceed: zero ahead AND confirmed clean.
-        assert_eq!(decide_reset(Some(0), Some(false)), ResetDecision::Reset);
-    }
-}
+#[path = "inproject_hygiene_tests.rs"]
+mod inproject_hygiene_tests;

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject_hygiene_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject_hygiene_tests.rs
@@ -1,0 +1,129 @@
+//! Unit tests for startup hygiene's pure decision logic (#2177, #4961).
+//!
+//! Why: the update gate is the only thing standing between a daemon restart and
+//! a user's uncommitted work. Its decision logic is deliberately a pure
+//! function so every refusal path can be asserted without a git fixture; the
+//! git-shelling half is covered by the integration tests in
+//! `crates/trusty-mpm/tests/inproject_hygiene_test.rs`.
+//! What: one test per `decide_update` refusal reason, plus the single
+//! proceed case, plus the cheap non-git early returns.
+//! Test: this file IS the test module.
+
+use super::*;
+
+#[test]
+fn get_default_branch_returns_none_for_non_git() {
+    // A non-git directory must return None cleanly.
+    let tmp = std::env::temp_dir();
+    assert!(get_default_branch(&tmp).is_none());
+}
+
+#[test]
+fn run_hygiene_skips_missing_dir() {
+    // A path that does not have .git must return Ok(()) immediately.
+    let tmp = std::env::temp_dir();
+    let result = run_hygiene_for_base(&tmp);
+    assert!(
+        result.is_ok(),
+        "should skip non-git dir cleanly: {result:?}"
+    );
+}
+
+#[test]
+fn run_hygiene_for_all_bases_skips_missing_root() {
+    // A non-existent repos root must complete without panicking.
+    let missing = std::path::Path::new("/tmp/trusty-nonexistent-repos-root-hygiene-test");
+    run_hygiene_for_all_bases(missing); // must not panic
+}
+
+#[test]
+fn hygiene_opt_out_marker_detected() {
+    // The marker short-circuits the sweep before any git command runs, so a
+    // directory that merely LOOKS like a repo is enough to assert the path.
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    std::fs::create_dir(tmp.path().join(".git")).expect("mkdir .git");
+    std::fs::write(tmp.path().join(HYGIENE_OPT_OUT_MARKER), "").expect("write marker");
+    // Without the marker this would shell out to git against a bogus .git dir;
+    // with it, the function returns before that happens.
+    assert!(run_hygiene_for_base(tmp.path()).is_ok());
+}
+
+// ── decide_update: pure decision-logic unit tests (#2177, #4961) ──────────
+
+#[test]
+fn decide_update_ahead_skips() {
+    // Any unpushed commit must refuse the update, even on a clean tree.
+    match decide_update(Some("main"), "main", Some(1), Some(false)) {
+        UpdateDecision::Skip(reason) => assert!(reason.contains("ahead")),
+        UpdateDecision::Update => panic!("an ahead branch must never be updated"),
+    }
+}
+
+#[test]
+fn decide_update_dirty_skips() {
+    // A dirty tree must refuse the update, even when not ahead.
+    match decide_update(Some("main"), "main", Some(0), Some(true)) {
+        UpdateDecision::Skip(reason) => assert!(reason.contains("uncommitted")),
+        UpdateDecision::Update => panic!("a dirty tree must never be updated"),
+    }
+}
+
+#[test]
+fn decide_update_unknown_ahead_skips() {
+    // No upstream / rev-list failure (ahead=None) must conservatively refuse,
+    // regardless of the dirty state.
+    match decide_update(Some("main"), "main", None, Some(false)) {
+        UpdateDecision::Skip(_) => {}
+        UpdateDecision::Update => panic!("unknown ahead-count must never be updated"),
+    }
+}
+
+#[test]
+fn decide_update_unknown_dirty_skips() {
+    // A `git status` failure (dirty=None) must conservatively refuse,
+    // regardless of the ahead-count.
+    match decide_update(Some("main"), "main", Some(0), None) {
+        UpdateDecision::Skip(_) => {}
+        UpdateDecision::Update => panic!("unknown dirty-state must never be updated"),
+    }
+}
+
+#[test]
+fn decide_update_detached_head_skips() {
+    // Detached HEAD: there is no branch to fast-forward, so refuse outright
+    // rather than moving whatever ref happens to be nearby.
+    match decide_update(None, "main", Some(0), Some(false)) {
+        UpdateDecision::Skip(reason) => assert!(reason.contains("detached")),
+        UpdateDecision::Update => panic!("a detached HEAD must never be updated"),
+    }
+}
+
+#[test]
+fn decide_update_non_default_branch_skips() {
+    // #4961 second finding: ahead-count is measured against `origin/<branch>`
+    // but the update targets `origin/<default>`. Off the default branch the
+    // check proves nothing about the ref being moved, so refuse.
+    match decide_update(Some("feature"), "main", Some(0), Some(false)) {
+        UpdateDecision::Skip(reason) => {
+            assert!(
+                reason.contains("feature"),
+                "reason names the branch: {reason}"
+            );
+            assert!(
+                reason.contains("main"),
+                "reason names the default: {reason}"
+            );
+        }
+        UpdateDecision::Update => panic!("a non-default branch must never be moved to origin/main"),
+    }
+}
+
+#[test]
+fn decide_update_clean_and_even_updates() {
+    // The only case that may proceed: on the default branch, zero ahead,
+    // confirmed clean.
+    assert_eq!(
+        decide_update(Some("main"), "main", Some(0), Some(false)),
+        UpdateDecision::Update
+    );
+}

--- a/crates/trusty-mpm/tests/inproject_hygiene_test.rs
+++ b/crates/trusty-mpm/tests/inproject_hygiene_test.rs
@@ -1,17 +1,18 @@
-//! Integration tests for the startup-hygiene data-loss fix (#2177).
+//! Integration tests for the startup-hygiene data-loss fixes (#2177, #4961).
 //!
-//! Why: `run_hygiene_for_base` used to run `git reset --hard origin/<branch>`
-//! unconditionally on every daemon startup, discarding committed-but-unpushed
-//! work and uncommitted changes in real base clones. These tests drive the
-//! real function against real temporary git repositories (an `origin` repo and
-//! a `base` clone of it) to prove the safety gate: a base clone ahead of
-//! origin, or with a dirty working tree, must survive `run_hygiene_for_base`
-//! completely untouched, while a clean/behind clone is still fast-forwarded
-//! to origin as before, and a recovery ref is written before any reset that
-//! does proceed.
+//! Why: `run_hygiene_for_base` runs on every daemon start against the managed
+//! checkout a user may have open in an editor, so every claim it makes about
+//! not losing work has to be proven against real git, not a mock. #2177 proved
+//! the committed-but-unpushed and dirty-tree cases. #4961 adds the case those
+//! missed: `git status --porcelain` does not report gitignored paths, so
+//! gitignored content reads as clean and BOTH `git reset --hard` and `git merge
+//! --ff-only` silently overwrite it when the target commit tracks the same
+//! path. Only a real git fixture can demonstrate that, because the bug lives
+//! entirely in what git chooses to report and overwrite.
 //! What: a small git-repo-pair harness (`origin` + `base` clone, both real
 //! on-disk git repos under a `tempfile::TempDir`) plus one test per safety
-//! scenario.
+//! scenario, plus the preserved fast-forward case so the sweep's actual
+//! purpose is not silently killed.
 //! Test: this file IS the test suite; run with `cargo test -p trusty-mpm
 //! --test inproject_hygiene_test`.
 
@@ -38,9 +39,11 @@ fn git(dir: &Path, args: &[&str]) -> String {
 
 /// Create an `origin` repo with one commit on `main`, and a `base` clone of it.
 ///
+/// `gitignore` is written into the initial commit when non-empty, which is how
+/// the #4961 fixture makes a path invisible to `git status --porcelain`.
 /// Returns `(origin_path, base_path)`. The base clone has `origin/HEAD` set up
-/// (via `git clone`) so [`get_default_branch`] resolves `"main"`.
-fn init_repo_pair(root: &Path) -> (PathBuf, PathBuf) {
+/// (via `git clone`) so `get_default_branch` resolves `"main"`.
+fn init_repo_pair_with_ignore(root: &Path, gitignore: &str) -> (PathBuf, PathBuf) {
     let origin = root.join("origin");
     let base = root.join("base");
     std::fs::create_dir_all(&origin).expect("mkdir origin");
@@ -49,6 +52,9 @@ fn init_repo_pair(root: &Path) -> (PathBuf, PathBuf) {
     git(&origin, &["config", "user.email", "test@example.com"]);
     git(&origin, &["config", "user.name", "Test"]);
     std::fs::write(origin.join("file.txt"), "v1\n").expect("write file");
+    if !gitignore.is_empty() {
+        std::fs::write(origin.join(".gitignore"), gitignore).expect("write gitignore");
+    }
     git(&origin, &["add", "."]);
     git(&origin, &["commit", "-q", "-m", "initial"]);
 
@@ -73,8 +79,71 @@ fn init_repo_pair(root: &Path) -> (PathBuf, PathBuf) {
     (origin, base)
 }
 
+/// The common no-gitignore fixture.
+fn init_repo_pair(root: &Path) -> (PathBuf, PathBuf) {
+    init_repo_pair_with_ignore(root, "")
+}
+
+/// Advance origin's `main` by one commit that rewrites `file.txt`.
+fn advance_origin(origin: &Path) -> String {
+    std::fs::write(origin.join("file.txt"), "v2 from origin\n").expect("write file");
+    git(origin, &["add", "."]);
+    git(origin, &["commit", "-q", "-m", "origin moved forward"]);
+    git(origin, &["rev-parse", "HEAD"])
+}
+
+/// THE #4961 REGRESSION TEST: gitignored working-tree content must survive.
+///
+/// The exact reproduced scenario. `notes.md` is gitignored, so it holds real
+/// user content while `git status --porcelain` reports the tree clean and the
+/// branch is not ahead — every pre-#4961 gate passes. Origin then starts
+/// tracking that same path. `git reset --hard origin/main` (pre-fix) and `git
+/// merge --ff-only origin/main` (the naive fix) BOTH overwrite the file
+/// silently. The update must refuse instead, and the content must survive.
+#[test]
+fn hygiene_gitignored_file_is_not_clobbered() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let (origin, base) = init_repo_pair_with_ignore(tmp.path(), "notes.md\n");
+
+    // The user's real, never-committed content, in a gitignored path.
+    std::fs::write(base.join("notes.md"), "MY PRECIOUS NOTES\n").expect("write notes");
+
+    // The premise of the bug: this content is invisible to the dirty check.
+    let porcelain = git(&base, &["status", "--porcelain"]);
+    assert!(
+        porcelain.is_empty(),
+        "premise: gitignored content must read as clean, got: {porcelain:?}"
+    );
+
+    // Origin starts tracking the same path, with different content.
+    std::fs::write(origin.join("notes.md"), "origin version\n").expect("write notes");
+    git(&origin, &["add", "-f", "notes.md"]);
+    git(
+        &origin,
+        &["commit", "-q", "-m", "origin now tracks notes.md"],
+    );
+
+    let head_before = git(&base, &["rev-parse", "HEAD"]);
+    let result = run_hygiene_for_base(&base);
+    assert!(
+        result.is_ok(),
+        "run_hygiene_for_base should not error: {result:?}"
+    );
+
+    let contents = std::fs::read_to_string(base.join("notes.md")).expect("read notes");
+    assert_eq!(
+        contents, "MY PRECIOUS NOTES\n",
+        "gitignored user content must survive the hygiene sweep"
+    );
+    assert_eq!(
+        head_before,
+        git(&base, &["rev-parse", "HEAD"]),
+        "the update must be skipped, not forced through"
+    );
+}
+
 /// A base clone that is AHEAD of origin (an unpushed local commit) must NOT be
-/// reset — the extra commit must survive `run_hygiene_for_base` (#2177).
+/// updated — the extra commit must survive `run_hygiene_for_base` (#2177).
 #[test]
 fn hygiene_ahead_branch_is_not_reset() {
     let tmp = tempfile::TempDir::new().expect("temp dir");
@@ -95,7 +164,7 @@ fn hygiene_ahead_branch_is_not_reset() {
     let head_after = git(&base, &["rev-parse", "HEAD"]);
     assert_eq!(
         head_before, head_after,
-        "an ahead branch must not be reset — HEAD must be unchanged"
+        "an ahead branch must not be updated — HEAD must be unchanged"
     );
     assert!(
         base.join("unpushed.txt").exists(),
@@ -104,7 +173,7 @@ fn hygiene_ahead_branch_is_not_reset() {
 }
 
 /// A base clone with a DIRTY working tree (uncommitted changes) must NOT be
-/// reset — the uncommitted file must survive `run_hygiene_for_base` (#2177).
+/// updated — the uncommitted file must survive `run_hygiene_for_base` (#2177).
 #[test]
 fn hygiene_dirty_tree_is_not_reset() {
     let tmp = tempfile::TempDir::new().expect("temp dir");
@@ -133,19 +202,19 @@ fn hygiene_dirty_tree_is_not_reset() {
     );
 }
 
-/// A base clone that is clean and NOT ahead of origin must still be reset to
-/// origin — the sweep's original fast-forward purpose is preserved (#2177).
+/// A base clone that is clean and NOT ahead of origin must still advance to
+/// origin — the sweep's original purpose is preserved (#2177, #4961).
+///
+/// This is the test that would catch a "fix" that made hygiene a permanent
+/// no-op, which is what adding `--ignored` to the dirty check would do.
 #[test]
-fn hygiene_clean_branch_is_reset() {
+fn hygiene_clean_branch_is_fast_forwarded() {
     let tmp = tempfile::TempDir::new().expect("temp dir");
     let (origin, base) = init_repo_pair(tmp.path());
 
     // Origin moves forward; base has NOT fetched or committed anything new,
     // so base is behind (clean, ahead_count == 0 relative to a post-fetch origin).
-    std::fs::write(origin.join("file.txt"), "v2 from origin\n").expect("write file");
-    git(&origin, &["add", "."]);
-    git(&origin, &["commit", "-q", "-m", "origin moved forward"]);
-    let origin_head = git(&origin, &["rev-parse", "HEAD"]);
+    let origin_head = advance_origin(&origin);
 
     let result = run_hygiene_for_base(&base);
     assert!(
@@ -161,21 +230,122 @@ fn hygiene_clean_branch_is_reset() {
     let contents = std::fs::read_to_string(base.join("file.txt")).expect("read file");
     assert_eq!(
         contents, "v2 from origin\n",
-        "the reset must land origin's content"
+        "the fast-forward must land origin's content"
     );
 }
 
-/// When a reset proceeds, a recovery ref pointing at the pre-reset HEAD must be
-/// written first, as a defense-in-depth breadcrumb (#2177).
+/// A base clone whose gitignored content does NOT collide with the incoming
+/// commit must still fast-forward (#4961).
+///
+/// The distinction that makes the collision check a real fix rather than a
+/// feature-kill: a built checkout always has a gitignored `target/`, and that
+/// must not block hygiene forever.
 #[test]
-fn hygiene_recovery_ref_written_before_reset() {
+fn hygiene_non_colliding_ignored_content_still_fast_forwards() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let (origin, base) = init_repo_pair_with_ignore(tmp.path(), "target/\n");
+
+    // The analogue of a built checkout: gitignored, present, never tracked.
+    std::fs::create_dir(base.join("target")).expect("mkdir target");
+    std::fs::write(base.join("target/artifact.bin"), "build output\n").expect("write artifact");
+
+    let origin_head = advance_origin(&origin);
+
+    let result = run_hygiene_for_base(&base);
+    assert!(
+        result.is_ok(),
+        "run_hygiene_for_base should not error: {result:?}"
+    );
+
+    assert_eq!(
+        git(&base, &["rev-parse", "HEAD"]),
+        origin_head,
+        "non-colliding gitignored content must not block the fast-forward"
+    );
+    assert!(
+        base.join("target/artifact.bin").exists(),
+        "and it must still be there afterwards"
+    );
+}
+
+/// Off the default branch, the update must refuse rather than move the local
+/// branch ref to `origin/<default>` (#4961, second finding).
+///
+/// The ahead-count is measured as `origin/feature..feature`, so it can read
+/// zero while the operation targets `origin/main` — a different ref entirely.
+#[test]
+fn hygiene_non_default_branch_is_not_updated() {
     let tmp = tempfile::TempDir::new().expect("temp dir");
     let (origin, base) = init_repo_pair(tmp.path());
-    let pre_reset_head = git(&base, &["rev-parse", "HEAD"]);
 
-    std::fs::write(origin.join("file.txt"), "v2 from origin\n").expect("write file");
-    git(&origin, &["add", "."]);
-    git(&origin, &["commit", "-q", "-m", "origin moved forward"]);
+    // A real `feature` branch on origin, so `origin/feature` exists and the
+    // ahead-count resolves to Some(0) — the exact pre-fix passing condition.
+    git(&origin, &["branch", "feature"]);
+    git(&base, &["fetch", "-q", "origin"]);
+    git(
+        &base,
+        &["checkout", "-q", "-b", "feature", "origin/feature"],
+    );
+    let feature_head = git(&base, &["rev-parse", "HEAD"]);
+
+    let origin_main_head = advance_origin(&origin);
+    assert_ne!(feature_head, origin_main_head, "fixture sanity");
+
+    let result = run_hygiene_for_base(&base);
+    assert!(
+        result.is_ok(),
+        "run_hygiene_for_base should not error: {result:?}"
+    );
+
+    assert_eq!(
+        git(&base, &["rev-parse", "HEAD"]),
+        feature_head,
+        "a non-default branch must never be silently moved to origin/<default>"
+    );
+}
+
+/// The per-repo opt-out marker skips the sweep for a single checkout (#4961).
+#[test]
+fn hygiene_opt_out_marker_skips_update() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let (origin, base) = init_repo_pair(tmp.path());
+
+    // Exclude the marker locally so it does not itself dirty the tree — the
+    // skip must be attributable to the marker, not to a dirty working tree.
+    std::fs::write(base.join(".git/info/exclude"), ".trusty-mpm-no-hygiene\n")
+        .expect("write exclude");
+    std::fs::write(base.join(".trusty-mpm-no-hygiene"), "").expect("write marker");
+    assert!(
+        git(&base, &["status", "--porcelain"]).is_empty(),
+        "fixture sanity: the marker must not make the tree dirty"
+    );
+
+    let head_before = git(&base, &["rev-parse", "HEAD"]);
+    let origin_head = advance_origin(&origin);
+    assert_ne!(head_before, origin_head, "fixture sanity");
+
+    let result = run_hygiene_for_base(&base);
+    assert!(
+        result.is_ok(),
+        "run_hygiene_for_base should not error: {result:?}"
+    );
+
+    assert_eq!(
+        git(&base, &["rev-parse", "HEAD"]),
+        head_before,
+        "an opted-out checkout must be left entirely alone"
+    );
+}
+
+/// When an update proceeds, a recovery ref pointing at the pre-update HEAD must
+/// be written first, as a defense-in-depth breadcrumb (#2177).
+#[test]
+fn hygiene_recovery_ref_written_before_update() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let (origin, base) = init_repo_pair(tmp.path());
+    let pre_update_head = git(&base, &["rev-parse", "HEAD"]);
+
+    advance_origin(&origin);
 
     let result = run_hygiene_for_base(&base);
     assert!(
@@ -185,7 +355,7 @@ fn hygiene_recovery_ref_written_before_reset() {
 
     let recovery_sha = git(&base, &["rev-parse", "refs/trusty-mpm/pre-hygiene/main"]);
     assert_eq!(
-        recovery_sha, pre_reset_head,
-        "the recovery ref must point at the HEAD sha from before the reset"
+        recovery_sha, pre_update_head,
+        "the recovery ref must point at the HEAD sha from before the update"
     );
 }


### PR DESCRIPTION
## Defect

`crates/trusty-mpm/src/daemon/managed_routes/inproject_hygiene.rs` ran `git reset --hard origin/<default_branch>` against `~/trusty-mpm-projects/<owner>/<repo>` on every daemon start. The guard required `is_dirty() == Some(false)`, and `is_dirty` ran `git status --porcelain` with no `--ignored`.

Porcelain does not report gitignored paths at all. Gitignored working-tree content was invisible to the gate, so the reset proceeded and silently overwrote it whenever it collided with a path tracked by the target commit. `write_recovery_ref` records only a commit SHA, so never-committed content had no recovery path.

Hygiene is on by default, fires once per daemon start, restarts happen several times a day, and there was no per-repo opt-out. Users point Obsidian or Cursor at this directory, where `.obsidian/` and note files are routinely gitignored.

Second finding, same code path: the ahead-count was measured as `rev-list --count origin/<checked-out>..<checked-out>` while the reset targeted `origin/<default_branch>`. Off the default branch the check validated one ref while the operation moved the local branch to a different one.

Closes [#4961](https://github.com/bobmatnyc/trusty-tools/issues/4961).

## Evidence

`hygiene_gitignored_file_is_not_clobbered` reproduces the exact scenario — gitignored `notes.md` holding real content, porcelain clean, branch not ahead, and the target commit tracking the same path.

Against pre-fix `origin/main` (1128abc2), with only the new test file dropped in:

```
running 8 tests
test hygiene_gitignored_file_is_not_clobbered ... FAILED
test hygiene_opt_out_marker_skips_update ... FAILED
test hygiene_non_default_branch_is_not_updated ... FAILED

---- hygiene_gitignored_file_is_not_clobbered stdout ----
assertion `left == right` failed: gitignored user content must survive the hygiene sweep
  left: "origin version\n"
 right: "MY PRECIOUS NOTES\n"

---- hygiene_non_default_branch_is_not_updated stdout ----
assertion `left == right` failed: a non-default branch must never be silently moved to origin/<default>
  left: "ef52de7525da1a45bc3340e7ab24511080b6307d"
 right: "2a8bef0758ebb0dfd3f195f8dfc563bb7666b7a6"

test result: FAILED. 5 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out
```

After the fix:

```
running 8 tests
test hygiene_opt_out_marker_skips_update ... ok
test hygiene_dirty_tree_is_not_reset ... ok
test hygiene_ahead_branch_is_not_reset ... ok
test hygiene_gitignored_file_is_not_clobbered ... ok
test hygiene_recovery_ref_written_before_update ... ok
test hygiene_clean_branch_is_fast_forwarded ... ok
test hygiene_non_colliding_ignored_content_still_fast_forwards ... ok
test hygiene_non_default_branch_is_not_updated ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.37s
```

## Resolution

`git merge --ff-only` alone is not sufficient. Measured against git 2.54.0: `merge --ff-only` clobbers the ignored file identically to `reset --hard`, because `--overwrite-ignore` is git's default and `merge` offers no way to disable it. The fix is the fast-forward **plus** an explicit collision gate.

- **Non-destructive update.** `reset --hard` replaced with `merge --ff-only`, which fails cleanly rather than overwriting when it cannot fast-forward.
- **Collision gate** (`colliding_untracked_paths`). Refuses when any path the update would write (`git diff --name-only HEAD <target>`) already exists on disk and is not tracked (`git ls-files`). A path deleted by the target is tracked at HEAD, so it is never flagged. Any git failure refuses.
- **Not `--ignored` on the dirty check.** That looks like the obvious fix and is a silent feature-kill: `target/` is gitignored and present in any built checkout, so the gate would always see dirt and hygiene would become a permanent no-op. `hygiene_non_colliding_ignored_content_still_fast_forwards` is the test that would catch that regression.
- **Default-branch gate.** `decide_update` now refuses when the checked-out branch is not the default branch, so the ahead-count validates exactly the ref being moved. Detached HEAD refuses outright.
- **Per-repo opt-out** — decided IN scope, since the defect's live-risk premise is precisely that users edit in this directory. A `.trusty-mpm-no-hygiene` marker file in a base clone skips every step of the sweep for that checkout. Previously the only control was the process-wide `TRUSTY_MPM_INPROJECT_HYGIENE` env var.
- `write_recovery_ref` is preserved and still runs before any update that proceeds.

The inline `#[cfg(test)]` module moved to a sibling `inproject_hygiene_tests.rs` (local precedent: `reconcile_tests.rs`, `sync_assets_tests.rs`), keeping the production file at 345 SLOC against the 500 cap.

## Gates

Rung 5 (data-loss path, process lifecycle), all run from the worktree:

| Gate | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo check -p trusty-mpm` | pass |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | pass |
| `cargo test -p trusty-mpm --test inproject_hygiene_test` | 8 passed, 0 failed |
| `cargo test -p trusty-mpm --lib …inproject_hygiene` | 11 passed, 0 failed |
| `bash scripts/check_line_cap.sh` | 0 violations |
| `bash scripts/check_sld.sh` | 0 errors, 0 warnings |
| `bash scripts/check_changelog_fragment.sh` | fragment present and valid |

The full `cargo test -p trusty-mpm` suite was deferred by owner directive to one end-of-leg pass.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
