### PR TITLE
fix(ci): stop the docs-only detector from running on a stale base ref

### DIFF
--- a/.github/workflows/capabilities-drift.yml
+++ b/.github/workflows/capabilities-drift.yml
@@ -4,6 +4,21 @@
 # tree, MCP tool catalog, agent roster, skill catalog, doctor checks) matches
 # exactly what `tm generate capabilities` produces right now — a stale
 # generated file fails the job instead of silently rotting.
+#
+# DOCS-ONLY GATING (issue #4468 follow-up): this job's only inputs are the
+# harness's own in-process data — clap's CLI tree, the MCP tool catalog, the
+# bundled agent/skill rosters, a maintained doctor-check list (see
+# crates/trusty-mpm/src/core/bundle_tm_capabilities.rs's own doc comment) —
+# none of which lives under docs/. A change confined to docs/ therefore cannot
+# make this check's verdict differ, yet it previously ran a full Rust
+# toolchain install + `cargo run -p trusty-mpm` on every single PR (verified:
+# PR #4960, five files all under docs/, still paid this job's ~90s build).
+# Reuses the SAME classification ci.yml computes (`scripts/detect-docs-only.sh`,
+# via a `changes` job identical in shape to ci.yml's) rather than growing a
+# second definition of "docs-only" — this repo's common-entry-point doctrine.
+# This job is NOT in branch protection's required-checks list (verified via
+# `gh api repos/.../branches/main/protection`), so gating its steps costs
+# nothing risk-wise even in the worst case.
 name: Capabilities drift
 
 on:
@@ -26,8 +41,48 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 jobs:
+  # Classify the diff as docs-only or not, mirroring ci.yml's `changes` job
+  # exactly (same script, same base-ref-refresh fix for #4688-class staleness)
+  # so this workflow never grows its own, second definition of "docs-only".
+  changes:
+    name: Detect docs-only change set
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs_only: ${{ steps.detect.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Refresh the base branch ref (#4688 pattern — avoid a stale merge-base)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --quiet origin \
+            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          git rev-parse --verify "refs/remotes/origin/${BASE_REF}"
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+
+      - name: Classify changed paths
+        id: detect
+        env:
+          DOCS_ONLY_BASE: origin/${{ github.event.pull_request.base.ref }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "push to ${{ github.ref }} — verifying in full, no docs-only exemption"
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          bash scripts/detect-docs-only.sh > /dev/null
+
   capabilities-drift:
     name: tm-capabilities generated-skill drift check
+    needs: [changes]
+    # `needs:` alone would SKIP this job when `changes` fails, and GitHub
+    # reports a skipped job as passing — a broken classifier must cost a full
+    # run, never a silent skip. Matches ci.yml's #4179 reasoning.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -37,12 +92,15 @@ jobs:
 
       # MSRV floor is 1.94 (root Cargo.toml rust-version), matching ci.yml.
       - name: Install Rust toolchain (1.94)
+        if: needs.changes.outputs.docs_only != 'true'
         uses: dtolnay/rust-toolchain@1.94
 
       - name: Cache cargo build
+        if: needs.changes.outputs.docs_only != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: capabilities-drift
 
       - name: Check tm-capabilities generated skill for drift
+        if: needs.changes.outputs.docs_only != 'true'
         run: bash scripts/check_capabilities.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,10 +177,37 @@ jobs:
       - name: CI helper selftests (#4179, #4468, #4421)
         run: bash scripts/check-ci-helpers-selftest.sh
 
+      # Refresh the base branch ref (same fix as #4688 in version-parity.yml's
+      # pr-version-bump job). `github.event.pull_request.base.sha` is a
+      # SNAPSHOT taken when the triggering event was delivered, but
+      # `actions/checkout`'s default ref for a pull_request event
+      # (`refs/pull/<PR>/merge`) is a GitHub-generated merge commit whose first
+      # parent tracks the base branch's CURRENT tip, refreshed continuously and
+      # independently of that snapshot. On a repo merging this frequently, the
+      # gap between "when the event fired" and "when this job actually runs"
+      # routinely spans several unrelated merges to main. `git merge-base
+      # <stale-sha> HEAD` then resolves to that stale snapshot itself (it IS an
+      # ancestor of HEAD), so the diff against it sweeps in every file touched
+      # by every commit merged to main in between — a genuinely docs-only PR
+      # gets misclassified as docs_only=false. Live instance: PR #4960 (4 files,
+      # all under docs/) was classified as 23 changed paths including a dozen
+      # unrelated trusty-mpm .rs files, because its stale base.sha lagged the
+      # live merge ref by ~25 minutes / several merges. Re-fetching
+      # `origin/<base-ref>` right before diffing pins DOCS_ONLY_BASE to the
+      # freshest tip available at diff time, closing that window.
+      - name: Refresh the base branch ref (#4688 pattern — avoid a stale merge-base)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --quiet origin \
+            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          git rev-parse --verify "refs/remotes/origin/${BASE_REF}"
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+
       - name: Classify changed paths
         id: detect
         env:
-          DOCS_ONLY_BASE: ${{ github.event.pull_request.base.sha }}
+          DOCS_ONLY_BASE: origin/${{ github.event.pull_request.base.ref }}
         run: |
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "push to ${{ github.ref }} — verifying in full, no docs-only exemption"

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -266,6 +266,39 @@ assert_eq "workflow no longer passes the frozen base.sha" "0" \
 assert_eq "main-side parity also runs on a schedule (#4688)" "1" \
   "$(grep -c '^  schedule:' "${version_parity_wf}" || true)"
 
+# Same #4688 staleness class, found live on PR #4960: ci.yml's own `changes`
+# job (the docs-only classifier every gated job in ci.yml consumes) fed
+# detect-docs-only.sh a frozen `github.event.pull_request.base.sha`. On a
+# repo merging this often, the gap between "when the PR event fired" and
+# "when this job runs" routinely spans several unrelated main merges, so
+# `git merge-base <stale-sha> HEAD` resolved to the stale snapshot itself and
+# swept every file touched by those merges into the diff — PR #4960 (4 files,
+# all docs/) was classified as 23 changed paths and ran full Clippy/Test/MSRV/
+# search-daemon-smoke. Same wiring guard as version-parity.yml above: assert
+# the fix is actually wired, not just that detect-docs-only.sh is correct in
+# isolation.
+ci_wf=".github/workflows/ci.yml"
+assert_eq "ci.yml passes a base BRANCH, not base.sha" "1" \
+  "$(grep -c 'DOCS_ONLY_BASE: origin/\${{ github.event.pull_request.base.ref }}' \
+    "${ci_wf}" || true)"
+assert_eq "ci.yml no longer passes the frozen base.sha" "0" \
+  "$(grep -c 'DOCS_ONLY_BASE: \${{ github.event.pull_request.base.sha }}' \
+    "${ci_wf}" || true)"
+
+# capabilities-drift.yml grew its own `changes` job (reusing detect-docs-only.sh,
+# not a second predicate) so the tm-capabilities cargo build stops running
+# unconditionally on every PR. Same wiring guard, same reason: the script being
+# correct proves nothing if the workflow never passes it a live base.
+capabilities_wf=".github/workflows/capabilities-drift.yml"
+# 3 = every cargo-touching step in the job (toolchain install, cache, the
+# actual `check_capabilities.sh` run) — update this count if a step is added
+# or removed, the same way the count itself would need a human to notice.
+assert_eq "capabilities-drift.yml gates its cargo run on docs_only" "3" \
+  "$(grep -c "if: needs.changes.outputs.docs_only != 'true'" "${capabilities_wf}" || true)"
+assert_eq "capabilities-drift.yml passes a base BRANCH, not base.sha" "1" \
+  "$(grep -c 'DOCS_ONLY_BASE: origin/\${{ github.event.pull_request.base.ref }}' \
+    "${capabilities_wf}" || true)"
+
 echo
 if [ "${FAILURES}" -gt 0 ]; then
   echo "check-ci-helpers-selftest: ${FAILURES}/${CASES} case(s) FAILED"


### PR DESCRIPTION
## Defect

PR #4960 (4 files, all under `docs/`) still ran full `Clippy`, `MSRV check (1.94)`, `Test`, `trusty-search daemon smoke test`, and `tm-capabilities generated-skill drift check`. Two separate causes, both fixed here:

1. **ci.yml's own `changes` job computed the wrong verdict.** It fed `detect-docs-only.sh` a frozen `github.event.pull_request.base.sha` (a snapshot from event-delivery time), while the checked-out `refs/pull/N/merge` ref's first parent tracks the base branch's *live* tip. On a repo merging this often, the gap between event and job run swept unrelated main commits into the diff. This is NOT "nothing consumes the output" — every downstream job (`fmt`, `clippy`, `test`, `msrv`, `agents-ui`, `embedder-cuda-check`, `ui-checks`, `search-daemon-smoke`) already correctly gates its cargo steps on `needs.changes.outputs.docs_only`. The classifier itself was wrong.
2. **`capabilities-drift.yml` never consulted any classifier at all.** It ran `cargo run -p trusty-mpm` unconditionally on every PR, docs-only or not.

## Evidence

Pulled the actual job log for PR #4960's `Detect docs-only change set` step: `DOCS_ONLY_BASE=184bc0d8...` (a commit ~25 minutes / several merges behind `origin/main` at job-run time) produced `detect-docs-only: 23 changed path(s) -> docs_only=false`, including a dozen unrelated `crates/trusty-mpm/src/**/*.rs` files that PR #4960 never touched (confirmed against `gh pr view 4960 --json files`, which correctly lists only the 4 docs files). Re-running the same diff logic against the *current* `origin/main` tip (right now, same base commit) yields exactly the 4 real files — confirming the staleness, not the predicate, was the bug.

Branch protection (`gh api repos/bobmatnyc/trusty-tools/branches/main/protection`) required contexts: `Format check`, `500-line file-size cap`, `Clippy`, `MSRV check (1.91)`, `Test`, `trusty-search daemon smoke test`. `tm-capabilities generated-skill drift check` and `SLD lint` are **not required** — gating (or not) either carries zero risk of a permanently-pending PR.

## Resolution

- `ci.yml`'s `changes` job: added a "Refresh the base branch ref" step (identical pattern to the existing `#4688` fix in `version-parity.yml`'s `pr-version-bump` job) and pointed `DOCS_ONLY_BASE` at `origin/${{ github.event.pull_request.base.ref }}` instead of the frozen `base.sha`. No `paths:`/`paths-ignore:` filter added anywhere — every gated job still runs and reports, just exits its cargo steps in seconds when `docs_only=true`.
- `capabilities-drift.yml`: added its own `changes` job that calls the same `scripts/detect-docs-only.sh` (not a second predicate — reused entry point per this repo's common-entry-point doctrine), and gated its three cargo-touching steps. Verified its inputs (clap CLI tree, MCP tool catalog, bundled agent/skill rosters, doctor-check list — see `crates/trusty-mpm/src/core/bundle_tm_capabilities.rs`) are all in-process harness data with nothing under `docs/`, so gating cannot hide a real drift.
- Left `SLD lint`, `DOC-N/doc-number lint`, `doc-comment pointer lint`, `line-cap`, `changelog-fragment`, `AI-artifact lint`, `Format check` **unconditional** on purpose. Verified each script's inputs before deciding: `check_test_pointers.sh` scans only tracked `.rs` files (`git ls-files '*.rs'`), so it's already unaffected by `docs/` either way; `SLD lint` specifically validates spec-doc references, which a `docs/` change is exactly the thing that can invalidate, so gating it would be wrong.
- Checked `check_changelog_fragment.sh` for a duplicate docs-only predicate before touching anything — it computes a narrower, genuinely different question ("did `crates/<crate>/src/**` change", for changelog-requirement purposes) via its own diff, not a reimplementation of `is_inert_path`. No consolidation needed there.
- **Deliberately did not gate** `version-parity.yml`'s `pr-version-bump` job, despite being in the original scope list. It installs no Rust toolchain and runs no `cargo` (pure shell + one `curl` per touched crate, ~10s) — not a heavyweight job — and its own diff logic already no-ops when no `Cargo.toml` changed. Adding a third copy of the docs-only classifier there to save ~10s seemed like exactly the second-predicate duplication this repo's doctrine warns against. Flagging for a follow-up if you still want it gated explicitly.
- Added wiring-guard selftest cases to `scripts/check-ci-helpers-selftest.sh` (mirroring the existing `#4688` guards for `version-parity.yml`) asserting `ci.yml` and `capabilities-drift.yml` actually pass a live base branch, not a frozen sha, and that `capabilities-drift.yml`'s cargo steps are actually gated — so a future edit that reintroduces either regression fails CI instead of rotting silently.

## Verification

- `bash scripts/check-ci-helpers-selftest.sh` — all 51 cases passed (was 47; 4 new wiring-guard cases added).
- `bash scripts/check_line_cap.sh` — clean.
- `bash scripts/check_sld.sh` — clean.
- `actionlint .github/workflows/ci.yml .github/workflows/capabilities-drift.yml` — clean. Full-repo `actionlint` shows one pre-existing, unrelated shellcheck style note in `e2e-docker.yml` (a file this PR does not touch).
- No `cargo test -p trusty-mpm` run, per standing owner directive to defer the full suite.

## Changelog

CI-only diff (`.github/workflows/*.yml`, `scripts/check-ci-helpers-selftest.sh`) — no `crates/*/src/**` touched, so exempt from the per-PR changelog fragment rule.

## Expected behavior on THIS PR

This PR itself is the test case. It touches only `.github/workflows/**` and `scripts/**`, which `detect-docs-only.sh` deliberately treats as NOT inert ("a CI change must re-verify against real CI"). So this PR should be classified `docs_only=false` and run the FULL Clippy/Test/MSRV/search-daemon-smoke/capabilities-drift suite — exactly like a normal code PR, never like a docs-only one. A future genuinely docs-only PR is the one that should short-circuit.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools