### PR TITLE
fix(trusty-common): stop the memory secret-scanner rejecting prose, branch names, and 4-char tokens

### DIFF
--- a/crates/trusty-common/changelog.d/4898-secret-scanner-false-positives.md
+++ b/crates/trusty-common/changelog.d/4898-secret-scanner-false-positives.md
@@ -1,6 +1,7 @@
 Fixed
 
 - memory secret-scanner no longer rejects ordinary prose, branch names, or short tokens as credentials (closes [#4898](https://github.com/bobmatnyc/trusty-tools/issues/4898))
-  - a `+`-joined English phrase (`PM+instructions+subagents`) is recognised as prose instead of base64; `+` no longer disqualifies a token outright
+  - a `+`-joined English phrase (`PM+instructions+subagents`) is recognised as prose instead of base64; `+` no longer disqualifies a token outright, and each segment must be character-class-uniform so encoder output like `j1u7nJd+tvZers+wdZyr` stays flagged
   - a delimiter segment may carry one capital anywhere, not only in first position, so a branch name like `fix-3696-slice1-gapA-emit` is a human identifier again
-  - the 20-character length floor now runs before the credential-prefix test, so a 4-character token (`Asia`) can no longer match `AKIA`/`ASIA`; AWS key ids are matched by their all-uppercase 20-char shape instead of a lowercased prefix
+  - the 20-character length floor now runs before the credential-prefix test, so a 4-character token (`Asia`) can no longer match `AKIA`/`ASIA`; AWS key ids are matched by the all-uppercase shape of their first 20 bytes, which keeps `AKIAIOSFODNN7EXAMPLE-old` and a key-id/secret-key pair flagged while letting `ASIA-PACIFIC-ROLLOUT-NOTES` through
+  - added a deterministic generated-encoder corpus as a ratchet on base64 and base64url miss rates

--- a/crates/trusty-common/changelog.d/4898-secret-scanner-false-positives.md
+++ b/crates/trusty-common/changelog.d/4898-secret-scanner-false-positives.md
@@ -1,0 +1,6 @@
+Fixed
+
+- memory secret-scanner no longer rejects ordinary prose, branch names, or short tokens as credentials (closes [#4898](https://github.com/bobmatnyc/trusty-tools/issues/4898))
+  - a `+`-joined English phrase (`PM+instructions+subagents`) is recognised as prose instead of base64; `+` no longer disqualifies a token outright
+  - a delimiter segment may carry one capital anywhere, not only in first position, so a branch name like `fix-3696-slice1-gapA-emit` is a human identifier again
+  - the 20-character length floor now runs before the credential-prefix test, so a 4-character token (`Asia`) can no longer match `AKIA`/`ASIA`; AWS key ids are matched by their all-uppercase 20-char shape instead of a lowercased prefix

--- a/crates/trusty-common/src/memory_core/filter.rs
+++ b/crates/trusty-common/src/memory_core/filter.rs
@@ -536,25 +536,43 @@ const SECRET_PREFIXES: &[&str] = &[
 /// `three_4898_reproductions_are_not_flagged`.
 const AWS_KEY_ID_PREFIXES: &[&str] = &["AKIA", "ASIA"];
 
-/// True when `token` has the shape of an AWS access key ID: an
-/// [`AWS_KEY_ID_PREFIXES`] prefix, at least [`SECRET_MIN_LEN`] characters, and
-/// nothing but ASCII uppercase letters and digits throughout.
+/// True when `token` OPENS with an AWS access key ID: an
+/// [`AWS_KEY_ID_PREFIXES`] prefix followed by uppercase-alphanumeric characters
+/// for the full [`SECRET_MIN_LEN`] of a key id. Whatever follows those 20
+/// characters is not examined.
 ///
-/// Why (issue #4898): AWS key IDs are all-uppercase base32 (`[A-Z2-7]`), 20
-/// characters for `AKIA…`, so the mixed-case heuristic can never flag them and
-/// the prefix layer is their only detector (FN-1, issue #1481). Requiring the
-/// all-uppercase-alphanumeric shape keeps every real key id while excluding
-/// every prose token that merely begins with those four letters — a word cannot
-/// be all-uppercase-alphanumeric AND 20+ characters AND hyphen-free.
-/// What: prefix match (case-sensitive), length floor, charset check.
+/// Why (issue #4898): AWS key IDs are all-uppercase base32 (`[A-Z2-7]`), exactly
+/// 20 characters for `AKIA…`, so the mixed-case heuristic can never flag them
+/// and this layer is their only detector (FN-1, issue #1481).
+///
+/// Why it is a PREFIX predicate and not a whole-token one (#4898 review round
+/// 1): the first cut of this function required the ENTIRE token to be
+/// uppercase-alphanumeric, which lost AWS detection completely for any key with
+/// an adjacent character. `AKIAIOSFODNN7EXAMPLE-old` fell through to
+/// [`is_structural_token`], whose segmented-identifier branch rescued it
+/// (`AKIAIOSFODNN7EXAMPLE` and `old` are both case-uniform words), and the
+/// mixed-case branch then could not fire because `has_lower` is false. Measured
+/// FLAG -> MISS, including on AWS's own canonical key-id/secret-key pair
+/// `AKIAIOSFODNN7EXAMPLE/wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`. The
+/// predicate this replaced (`lower.starts_with("akia")`) was a prefix test, and
+/// converting it to a whole-token shape test is what the structural bypass
+/// defeated. Looking at the first 20 bytes only restores prefix semantics while
+/// keeping the shape check that excludes `Asia`, `Asia-Pacific` and
+/// `ASIA-PACIFIC-ROLLOUT-NOTES` (whose fifth byte is `-`).
+/// What: length floor, case-sensitive prefix match, then a charset check over
+/// the first [`SECRET_MIN_LEN`] bytes only.
 /// Test: `aws_access_key_ids_are_blocked`,
+/// `aws_key_ids_with_adjacent_text_are_blocked`,
 /// `real_secrets_still_blocked_after_4898_narrowing`,
 /// `known_accepted_bounds_after_4898`.
 fn is_aws_access_key_id(token: &str) -> bool {
     token.len() >= SECRET_MIN_LEN
         && AWS_KEY_ID_PREFIXES.iter().any(|p| token.starts_with(p))
+        // #4898 review: `.take(SECRET_MIN_LEN)`, not `.all()` over the token —
+        // one neighbouring character must not disable AWS detection.
         && token
             .bytes()
+            .take(SECRET_MIN_LEN)
             .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit())
 }
 
@@ -567,9 +585,12 @@ fn is_aws_access_key_id(token: &str) -> bool {
 /// cannot be a credential. Naming the constant and moving the check above the
 /// prefix test makes the floor apply to every detection path.
 ///
-/// Why 20 does not cost detection: the shortest real credential any layer here
-/// targets is the 20-character AWS access key ID. GitHub PATs are 40, OpenAI
-/// keys 40+, Slack tokens 30+.
+/// Why 20 does not cost detection: no issuer behind a [`SECRET_PREFIXES`] entry
+/// mints a token under 20 characters — `ghp_` is 40, `github_pat_` 93, `xoxb-`
+/// 50+, `sk-` issuers 35+ — and AWS key ids are exactly 20. The one shape the
+/// floor does drop is a self-hosted proxy key that copies a provider prefix
+/// without its length, such as LiteLLM's documented `sk-1234` master key
+/// (verified in review round 1).
 /// What: inclusive minimum token length.
 /// Test: `three_4898_reproductions_are_not_flagged`,
 /// `real_secrets_still_blocked_after_4898_narrowing`.
@@ -624,9 +645,28 @@ const IDENTIFIER_DELIMITERS: [char; 3] = ['-', '_', '.'];
 /// with one trailing capital, the ordinary way engineers label a variant
 /// (`gapA`, `partB`, `phase2B`). The count is what does the discriminating work,
 /// not the position: `AbCd` and `xYzAbc` carry two capitals either way and stay
-/// out. What the relaxation admits that #4739 did not is a segment with a single
-/// interior or trailing capital, which no encoded alphabet produces at segment
-/// scale.
+/// out.
+///
+/// KNOWN RESIDUAL MISS, measured, carried deliberately (#4898 review round 1):
+/// the earlier revision of this doc claimed the relaxation admits a shape "no
+/// encoded alphabet produces at segment scale". That is false for base64url,
+/// which encodes with `-` and `_` — so its tokens arrive already split into 4–8
+/// character segments, exactly the scale at which "at most one capital" is cheap
+/// to satisfy by chance. `9h6Nn6_ivJd6vmb-xEk4` is real
+/// `base64url(urandom(15))` output and flipped FLAG -> MISS on this change. Cost
+/// against `origin/main` over a fixed 300k-sample corpus: 453 additional misses
+/// at 15 input bytes, 210 at 16, 48 at 20, 6 at 24, 0 at 32 — it decays to
+/// nothing as tokens lengthen, because more segments means more chances for one
+/// to carry two capitals.
+///
+/// Why it is not closed here: the narrowing that would close it — refusing a
+/// non-first capital in any segment that also carries a digit — takes `phase2B`
+/// with it, and `slice1`/`gapA` sit either side of that line in the very branch
+/// name this issue is about. Closing it properly is the structural rewrite this
+/// PR defers (see the PR body); a carve-out would be the seventh round of the
+/// same mistake. Pinned as a ratchet in
+/// `generated_encoder_corpus_stays_flagged` so the number cannot drift
+/// unnoticed.
 ///
 /// The ACCEPTED side of that bound, stated because the rejected side alone
 /// would read as a stronger guarantee than this predicate gives: what
@@ -741,33 +781,38 @@ const MIN_PHRASE_WORD_LEN: usize = 5;
 /// in the phrase. The doc on [`is_plausible_b64_charset`] already named this as
 /// an accepted residual gap; this predicate closes it.
 ///
-/// Why it is safe to reopen `+` this narrowly: real base64 places `+` at roughly
-/// 1.6% character density, so its `+`-separated runs average tens of characters
-/// and cannot be case-uniform — every one fails [`is_human_word_segment`]. The
-/// remaining shape, a short-segment `+`-heavy blob such as
-/// `A+DIA+DIA+DIA+…`, IS case-uniform per segment, which is exactly why the
-/// word-length floor exists: its longest segment is three characters.
-///
 /// Why every segment must be purely alphanumeric: [`is_human_word_segment`]
 /// constrains case, not charset — it trims the ends of a segment and ignores
 /// interior punctuation. Without a charset requirement here, `token=A+DIA+DIA+…`
 /// yields the segment `token=A` (one capital, six letters) and
 /// `mongodb+srv://svcuser:hunterhunter@cluster.mongodb.net` yields
 /// `srv://svcuser:hunterhunter@cluster` (all lowercase), so a `key=`-prefixed
-/// base64 blob and a mongo connection string both passed. Both were caught by
-/// the pinned true-positive corpus while writing this, which is what that corpus
-/// is for.
+/// base64 blob and a mongo connection string both passed.
 ///
-/// Known accepted bound: a `+`-joined token whose segments are case-uniform AND
-/// word-length is admitted without any dictionary check —
-/// `Abcdefgh+Ijklmnop+Qrstuvwx` passes. This is the same class of bound
-/// [`is_human_word_segment`] already documents, and no encoder emits it.
+/// Why every segment must additionally be pure-alphabetic OR pure-digit (#4898
+/// review round 1): the first cut argued that base64's `+` density of ~1.6%
+/// makes its `+`-separated runs "average tens of characters and cannot be
+/// case-uniform". That reasoning fails at the 20-char floor, where a token is
+/// short enough for every run to be short. `base64::encode(urandom(15))` yields
+/// shapes like `j1u7nJd+tvZers+wdZyr` whose segments each carry exactly one
+/// capital, and `j1u7nJd` clears [`MIN_PHRASE_WORD_LEN`] on its own. Measured on
+/// a generated corpus, that cost 152 misses per 300k at 15 input bytes, 72 at
+/// 16, 11 at 20. Requiring each segment to be uniformly alphabetic or uniformly
+/// numeric takes it to 1–2 per 300k, because encoder output interleaves letters
+/// and digits inside a run while a `+`-joined phrase never does — `PM`,
+/// `instructions`, `milestone`, `1`, `3`, `5` are each uniform.
+///
+/// Known accepted bound: a `+`-joined token whose segments are case-uniform,
+/// character-class-uniform AND word-length is admitted without any dictionary
+/// check — `Abcdefgh+Ijklmnop+Qrstuvwx` passes. This is the same class of bound
+/// [`is_human_word_segment`] already documents.
 /// What: splits on [`IDENTIFIER_DELIMITERS`] plus `+`, requires at least two
-/// segments, every segment non-empty and ASCII-alphanumeric and a
-/// [`is_human_word_segment`], and one segment holding at least
-/// [`MIN_PHRASE_WORD_LEN`] alphabetic characters.
+/// segments, every segment non-empty, ASCII-alphanumeric, uniformly alphabetic
+/// or uniformly numeric, and a [`is_human_word_segment`]; plus one segment
+/// holding at least [`MIN_PHRASE_WORD_LEN`] alphabetic characters.
 /// Test: `three_4898_reproductions_are_not_flagged`,
 /// `real_secrets_still_blocked_after_4898_narrowing`,
+/// `generated_encoder_corpus_stays_flagged`,
 /// `known_accepted_bounds_after_4898`.
 fn is_plus_joined_word_phrase(token: &str) -> bool {
     let segments: Vec<&str> = token
@@ -776,15 +821,18 @@ fn is_plus_joined_word_phrase(token: &str) -> bool {
     if segments.len() < 2 {
         return false;
     }
-    // #4898: charset first — a segment carrying `=`, `:`, `/` or `@` is not a
-    // word, and `is_human_word_segment` would not notice.
-    if !segments
-        .iter()
-        .all(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric()))
-    {
-        return false;
-    }
-    if !segments.iter().all(|s| is_human_word_segment(s)) {
+    let segment_is_wordlike = |s: &&str| {
+        // #4898: charset first — a segment carrying `=`, `:`, `/` or `@` is not
+        // a word, and `is_human_word_segment` would not notice.
+        !s.is_empty()
+            && s.chars().all(|c| c.is_ascii_alphanumeric())
+            // #4898 review: uniformly alphabetic or uniformly numeric. A run
+            // that interleaves letters and digits is encoder output, not a word.
+            && (s.chars().all(|c| c.is_ascii_alphabetic())
+                || s.chars().all(|c| c.is_ascii_digit()))
+            && is_human_word_segment(s)
+    };
+    if !segments.iter().all(segment_is_wordlike) {
         return false;
     }
     segments

--- a/crates/trusty-common/src/memory_core/filter.rs
+++ b/crates/trusty-common/src/memory_core/filter.rs
@@ -497,14 +497,17 @@ pub fn check_secret(content: &str) -> Result<(), FilterReject> {
 /// Known credential prefixes that should always be treated as secrets.
 ///
 /// Why (issue #1481): provider-issued keys (OpenAI `sk-`, GitHub `ghp_`/`gho_`,
-/// AWS `AKIA`/`ASIA`, Slack `xoxb-`) have distinctive prefixes that make them
-/// unambiguously secret regardless of their entropy profile. Matching the
-/// prefix is cheaper and more precise than entropy alone — and it is the ONLY
-/// thing that catches AWS access key IDs, which are all-uppercase base32 and so
-/// never satisfy the mixed-case-plus-digit fallback in [`looks_like_secret`]
-/// (FN-1, issue #1481).
+/// Slack `xoxb-`) have distinctive prefixes that make them unambiguously secret
+/// regardless of their entropy profile. Matching the prefix is cheaper and more
+/// precise than entropy alone.
+///
+/// Every entry here carries punctuation an English word never does, which is why
+/// [`SECRET_MIN_LEN`] is sufficient protection for this list. AWS `AKIA`/`ASIA`
+/// used to live here and is not (issue #4898) — it is four bare letters, so it
+/// needs a shape check; see [`AWS_KEY_ID_PREFIXES`].
 /// What: lowercased prefix list checked case-insensitively in
-/// [`looks_like_secret`] (which lowercases the token before comparing).
+/// [`looks_like_secret`] (which lowercases the token before comparing), after
+/// the [`SECRET_MIN_LEN`] floor.
 /// Test: `known_key_prefixes_are_blocked`, `aws_access_key_ids_are_blocked`.
 const SECRET_PREFIXES: &[&str] = &[
     "sk-",
@@ -514,12 +517,63 @@ const SECRET_PREFIXES: &[&str] = &[
     "github_pat_",
     "xoxb-",
     "xoxp-",
-    // AWS long-term access key IDs (`AKIA…`) and STS temporary credential IDs
-    // (`ASIA…`): 4-char prefix + 16 base32 chars `[A-Z2-7]`, ALL-UPPERCASE, so
-    // the mixed-case heuristic below can never flag them. Compared lowercased.
-    "akia",
-    "asia",
 ];
+
+/// AWS access key ID prefixes — long-term (`AKIA…`) and STS temporary
+/// credentials (`ASIA…`).
+///
+/// Why these are separated from [`SECRET_PREFIXES`] (issue #4898): every other
+/// entry there carries punctuation (`-`, `_`) that no English word contains, so
+/// a bare length floor is enough to keep prose out. `akia`/`asia` do not — they
+/// were compared case-insensitively against a lowercased token, so `Asia` (the
+/// continent, 4 characters) matched, and `Asia-Pacific` and
+/// `asia-pacific-rollout-notes` matched at any length. Matching the AWS *shape*
+/// instead of a lowercased prefix removes that whole class rather than pushing
+/// it past a length threshold.
+/// What: uppercase prefixes, compared against the token verbatim by
+/// [`is_aws_access_key_id`].
+/// Test: `aws_access_key_ids_are_blocked`,
+/// `three_4898_reproductions_are_not_flagged`.
+const AWS_KEY_ID_PREFIXES: &[&str] = &["AKIA", "ASIA"];
+
+/// True when `token` has the shape of an AWS access key ID: an
+/// [`AWS_KEY_ID_PREFIXES`] prefix, at least [`SECRET_MIN_LEN`] characters, and
+/// nothing but ASCII uppercase letters and digits throughout.
+///
+/// Why (issue #4898): AWS key IDs are all-uppercase base32 (`[A-Z2-7]`), 20
+/// characters for `AKIA…`, so the mixed-case heuristic can never flag them and
+/// the prefix layer is their only detector (FN-1, issue #1481). Requiring the
+/// all-uppercase-alphanumeric shape keeps every real key id while excluding
+/// every prose token that merely begins with those four letters — a word cannot
+/// be all-uppercase-alphanumeric AND 20+ characters AND hyphen-free.
+/// What: prefix match (case-sensitive), length floor, charset check.
+/// Test: `aws_access_key_ids_are_blocked`,
+/// `real_secrets_still_blocked_after_4898_narrowing`,
+/// `known_accepted_bounds_after_4898`.
+fn is_aws_access_key_id(token: &str) -> bool {
+    token.len() >= SECRET_MIN_LEN
+        && AWS_KEY_ID_PREFIXES.iter().any(|p| token.starts_with(p))
+        && token
+            .bytes()
+            .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit())
+}
+
+/// Minimum token length before [`looks_like_secret`] will call anything a
+/// credential.
+///
+/// Why (issue #4898): this floor existed as a bare `20` literal placed AFTER the
+/// prefix test, so it governed the entropy branches only. A four-character token
+/// equal to a prefix entry was flagged regardless of length — four characters
+/// cannot be a credential. Naming the constant and moving the check above the
+/// prefix test makes the floor apply to every detection path.
+///
+/// Why 20 does not cost detection: the shortest real credential any layer here
+/// targets is the 20-character AWS access key ID. GitHub PATs are 40, OpenAI
+/// keys 40+, Slack tokens 30+.
+/// What: inclusive minimum token length.
+/// Test: `three_4898_reproductions_are_not_flagged`,
+/// `real_secrets_still_blocked_after_4898_narrowing`.
+const SECRET_MIN_LEN: usize = 20;
 
 /// Characters that separate the words of a human-readable compound identifier.
 ///
@@ -532,9 +586,12 @@ const SECRET_PREFIXES: &[&str] = &[
 ///
 /// Why this does not widen the base64 branch: [`is_structural_token`] returns
 /// before reaching its segmented-identifier branch whenever the token contains
-/// `+`, `=`, or `/` — which is precisely the `has_b64_sym` set. The segmented
-/// branch is therefore reachable only for tokens the base64 branch can never
-/// fire on, so this delimiter set is confined to the mixed-case branch.
+/// `=` or `/`, and a `+`-bearing token is diverted to
+/// [`is_plus_joined_word_phrase`] — which applies this same delimiter set plus a
+/// word-length floor. The segmented branch proper is therefore reachable only
+/// for tokens the base64 branch can never fire on. (Before #4898 the `+` case
+/// was a flat rejection; the divert is what closed the `PM+instructions+
+/// subagents` false positive without loosening `=` or `/`.)
 /// What: the delimiter set `-`, `_`, `.` used by both `contains` and `split`.
 /// Test: `dotted_capitalised_filenames_are_not_flagged`.
 const IDENTIFIER_DELIMITERS: [char; 3] = ['-', '_', '.'];
@@ -557,9 +614,19 @@ const IDENTIFIER_DELIMITERS: [char; 3] = ['-', '_', '.'];
 /// The bound this predicate actually holds, stated exactly because a reader
 /// will rely on it and because #4723 shipped an absolute here that a
 /// measurement disproved: a segment that is not uniformly uppercase admits **at
-/// most one uppercase letter, and only as its first letter**. That is what
-/// keeps the run-of-two case alternation of an encoded blob (`AbCd`, `EfGh`)
-/// out — two uppercase letters in a non-uppercase segment is disqualifying.
+/// most one uppercase letter, in any position**. That is what keeps the
+/// run-of-two case alternation of an encoded blob (`AbCd`, `EfGh`) out — two
+/// uppercase letters in a non-uppercase segment is disqualifying.
+///
+/// Why the position constraint was dropped (issue #4898, the SIXTH recurrence):
+/// #4739 admitted a capital only in FIRST position, so the git branch name
+/// `fix-3696-slice1-gapA-emit` failed on the segment `gapA` — a lowercase word
+/// with one trailing capital, the ordinary way engineers label a variant
+/// (`gapA`, `partB`, `phase2B`). The count is what does the discriminating work,
+/// not the position: `AbCd` and `xYzAbc` carry two capitals either way and stay
+/// out. What the relaxation admits that #4739 did not is a segment with a single
+/// interior or trailing capital, which no encoded alphabet produces at segment
+/// scale.
 ///
 /// The ACCEPTED side of that bound, stated because the rejected side alone
 /// would read as a stronger guarantee than this predicate gives: what
@@ -597,34 +664,35 @@ const IDENTIFIER_DELIMITERS: [char; 3] = ['-', '_', '.'];
 /// signature of `AbCdEfGhIjKlMnOpQrSt-1234` — a credential miss. Measured, not
 /// assumed; see the residue assertion in the test below.
 /// What: strips leading/trailing non-alnum chars (arrow punctuation like `>`,
-/// `<`), then accepts when the alphabetic characters are all-lowercase,
-/// all-uppercase, or a single leading uppercase followed by lowercase. Interior
-/// non-alphanumeric characters are ignored rather than rejected — this
-/// predicate constrains case, not charset.
+/// `<`), then accepts when the alphabetic characters are all-uppercase, or carry
+/// at most one uppercase letter anywhere. Interior non-alphanumeric characters
+/// are ignored rather than rejected — this predicate constrains case, not
+/// charset.
 /// Test: `structural_tokens_are_not_flagged`,
 /// `dotted_capitalised_filenames_are_not_flagged`,
 /// `real_secrets_still_blocked_after_4739_capitalised_segments`,
-/// `per_segment_case_uniformity_is_a_known_accepted_bound`.
+/// `per_segment_case_uniformity_is_a_known_accepted_bound`,
+/// `three_4898_reproductions_are_not_flagged`,
+/// `real_secrets_still_blocked_after_4898_narrowing`.
 fn is_human_word_segment(seg: &str) -> bool {
     let s = seg.trim_matches(|c: char| !c.is_ascii_alphanumeric());
     if s.is_empty() {
         return false;
     }
-    let alphas: Vec<char> = s.chars().filter(|c| c.is_ascii_alphabetic()).collect();
+    let uppers = s.chars().filter(|c| c.is_ascii_uppercase()).count();
+    let lowers = s.chars().filter(|c| c.is_ascii_lowercase()).count();
     // Digit-only segments are case-neutral (`20260729`, `000028`).
-    let Some((first, rest)) = alphas.split_first() else {
+    if uppers == 0 {
         return true;
-    };
-    let rest_all_lower = rest.iter().all(|c| c.is_ascii_lowercase());
-    let rest_all_upper = rest.iter().all(|c| c.is_ascii_uppercase());
-    // #4739: `lowercase` | `UPPERCASE` | `Capitalized`. A leading uppercase may
-    // be followed by either case run (Capitalized or ALL-UPPERCASE); a leading
-    // lowercase may only be followed by lowercase.
-    if first.is_ascii_uppercase() {
-        rest_all_lower || rest_all_upper
-    } else {
-        rest_all_lower
     }
+    // #4739: ALL-UPPERCASE (`REQUEST_CHANGES`) is a word.
+    if lowers == 0 {
+        return true;
+    }
+    // #4898: one capital anywhere — `Capitalized`, `gapA`, `phase2B`. Two or
+    // more in a mixed-case segment is run-of-two alternation (`AbCd`), the
+    // signature of an encoded blob.
+    uppers == 1
 }
 
 /// True when `token` looks like a compound identifier whose delimiter-separated
@@ -647,6 +715,83 @@ fn is_human_word_segment(seg: &str) -> bool {
 /// rejects the empty segment a trailing delimiter produces).
 /// Test: `structural_tokens_are_not_flagged`,
 /// `dotted_capitalised_filenames_are_not_flagged`.
+/// Minimum alphabetic length one segment of a `+`-joined token must reach
+/// before [`is_plus_joined_word_phrase`] will call the token prose.
+///
+/// Why (issue #4898): `+` is base64's own symbol, so per-segment case uniformity
+/// alone is too weak a signal there — `A+DIA+DIA+DIA+…` is case-uniform in every
+/// segment and is a base64 blob. Requiring one segment to reach word length is
+/// what separates it from `PM+instructions+subagents` (longest segment 12).
+/// Five is the shortest length at which an English word carries enough letters
+/// to be one; the repro's shortest content word (`agents`, `skills`) is six.
+/// What: inclusive minimum count of ASCII alphabetic characters in the longest
+/// segment.
+/// Test: `real_secrets_still_blocked_after_4898_narrowing` (the `base64 with +`
+/// entry is what this constant keeps flagged).
+const MIN_PHRASE_WORD_LEN: usize = 5;
+
+/// True when `token` is a `+`-joined phrase of human-readable words, e.g.
+/// `PM+instructions+subagents`.
+///
+/// Why (issue #4898): [`is_structural_token`] rejected every `+`-bearing token
+/// outright on the reasoning that "`+` is unambiguously base64". It is not — `+`
+/// is also how prose joins terms into a compound label, and the resulting token
+/// went straight to the base64 branch of [`looks_like_secret`], where the
+/// `has_upper || has_digit` entropy floor was satisfied by any capitalised word
+/// in the phrase. The doc on [`is_plausible_b64_charset`] already named this as
+/// an accepted residual gap; this predicate closes it.
+///
+/// Why it is safe to reopen `+` this narrowly: real base64 places `+` at roughly
+/// 1.6% character density, so its `+`-separated runs average tens of characters
+/// and cannot be case-uniform — every one fails [`is_human_word_segment`]. The
+/// remaining shape, a short-segment `+`-heavy blob such as
+/// `A+DIA+DIA+DIA+…`, IS case-uniform per segment, which is exactly why the
+/// word-length floor exists: its longest segment is three characters.
+///
+/// Why every segment must be purely alphanumeric: [`is_human_word_segment`]
+/// constrains case, not charset — it trims the ends of a segment and ignores
+/// interior punctuation. Without a charset requirement here, `token=A+DIA+DIA+…`
+/// yields the segment `token=A` (one capital, six letters) and
+/// `mongodb+srv://svcuser:hunterhunter@cluster.mongodb.net` yields
+/// `srv://svcuser:hunterhunter@cluster` (all lowercase), so a `key=`-prefixed
+/// base64 blob and a mongo connection string both passed. Both were caught by
+/// the pinned true-positive corpus while writing this, which is what that corpus
+/// is for.
+///
+/// Known accepted bound: a `+`-joined token whose segments are case-uniform AND
+/// word-length is admitted without any dictionary check —
+/// `Abcdefgh+Ijklmnop+Qrstuvwx` passes. This is the same class of bound
+/// [`is_human_word_segment`] already documents, and no encoder emits it.
+/// What: splits on [`IDENTIFIER_DELIMITERS`] plus `+`, requires at least two
+/// segments, every segment non-empty and ASCII-alphanumeric and a
+/// [`is_human_word_segment`], and one segment holding at least
+/// [`MIN_PHRASE_WORD_LEN`] alphabetic characters.
+/// Test: `three_4898_reproductions_are_not_flagged`,
+/// `real_secrets_still_blocked_after_4898_narrowing`,
+/// `known_accepted_bounds_after_4898`.
+fn is_plus_joined_word_phrase(token: &str) -> bool {
+    let segments: Vec<&str> = token
+        .split(|c: char| c == '+' || IDENTIFIER_DELIMITERS.contains(&c))
+        .collect();
+    if segments.len() < 2 {
+        return false;
+    }
+    // #4898: charset first — a segment carrying `=`, `:`, `/` or `@` is not a
+    // word, and `is_human_word_segment` would not notice.
+    if !segments
+        .iter()
+        .all(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric()))
+    {
+        return false;
+    }
+    if !segments.iter().all(|s| is_human_word_segment(s)) {
+        return false;
+    }
+    segments
+        .iter()
+        .any(|s| s.chars().filter(|c| c.is_ascii_alphabetic()).count() >= MIN_PHRASE_WORD_LEN)
+}
+
 fn is_segmented_identifier(token: &str) -> bool {
     if !token.contains(IDENTIFIER_DELIMITERS) {
         return false;
@@ -672,27 +817,35 @@ fn is_segmented_identifier(token: &str) -> bool {
 /// This function recognises those structural shapes and short-circuits the
 /// two dangerous branches in `looks_like_secret`.
 ///
-/// How the three branches divide the work (issue #4739): branches (a) and (b)
-/// fire only on tokens carrying `=` or `/`, and branch (a)'s `+` guard returns
-/// first — so (a) and (b) are the ones that can rescue a token from the base64
-/// branch. Branch (c) is reachable only after all of `+`, `=` and `/` are ruled
-/// out, i.e. only for tokens on which `has_b64_sym` is false, so it serves the
-/// mixed-case branch exclusively. That partition is why a fix to (c) cannot
+/// How the branches divide the work (issue #4739, amended #4898): the `+` guard
+/// returns first and decides `+`-bearing tokens on its own via
+/// [`is_plus_joined_word_phrase`]. Branches (a) and (b) then fire only on tokens
+/// carrying `=` or `/`, so they are the ones that can rescue a token from the
+/// base64 branch. Branch (c) is reachable only after all of `+`, `=` and `/` are
+/// ruled out, i.e. only for tokens on which `has_b64_sym` is false, so it serves
+/// the mixed-case branch exclusively. That partition is why a fix to (c) cannot
 /// loosen base64 detection.
-/// What: returns `true` for (a) `=`-containing tokens where the LHS is a
-/// word segment and the RHS is itself structural (a word segment OR a
-/// slash-path), checked before the slash-path branch so that tokens like
-/// `key=path/to/value` are decomposed at `=` first; (b) slash-path tokens
-/// where every `/`-segment is word-like; or (c) `-`/`_`/`.`-segmented compound
-/// identifiers where each segment is a single human-readable word. A token with
-/// `+` is never structural (`+` never appears in identifiers).
+/// What: returns `true` for `+`-bearing tokens that are `+`-joined word phrases
+/// (checked first, and the only way a `+` token can be structural); (a)
+/// `=`-containing tokens where the LHS is a word segment and the RHS is itself
+/// structural (a word segment OR a slash-path), checked before the slash-path
+/// branch so that tokens like `key=path/to/value` are decomposed at `=` first;
+/// (b) slash-path tokens where every `/`-segment is word-like; or (c)
+/// `-`/`_`/`.`-segmented compound identifiers where each segment is a single
+/// human-readable word.
 /// Test: `structural_tokens_are_not_flagged`, `base64_blob_is_blocked`,
 /// `key_equals_slashpath_not_flagged` (issue #1676 regression tests),
-/// `dotted_capitalised_filenames_are_not_flagged` (issue #4739).
+/// `dotted_capitalised_filenames_are_not_flagged` (issue #4739),
+/// `three_4898_reproductions_are_not_flagged` (issue #4898).
 fn is_structural_token(token: &str) -> bool {
-    // `+` is unambiguously base64 — no structural pattern uses it.
+    // #4898: a `+`-bearing token is decided here and nowhere else — it is
+    // structural only when it reads as a `+`-joined word phrase. Keeping the
+    // early return (rather than letting `+` tokens fall through to branches (a)
+    // and (b)) confines the change to this one shape: branch (a)'s `is_word_
+    // segment(lhs) || is_word_segment(rhs)` fallback would otherwise exempt
+    // `foo=<base64-with-plus>` on the strength of the `foo` alone.
     if token.contains('+') {
-        return false;
+        return is_plus_joined_word_phrase(token);
     }
     // A "word segment" for slash/equals splitting: non-empty, contains only
     // ASCII alphanumeric chars plus the minimal set of punctuation that
@@ -771,9 +924,10 @@ fn is_structural_token(token: &str) -> bool {
 /// Why (issue #1481): see [`find_secret_token`]. This is the core decision —
 /// it must say "no" to git SHAs and "yes" to credentials.
 /// What: returns `false` immediately for [`is_git_sha_like`] tokens (the
-/// allowlist), then returns `true` when the token (a) carries a known
-/// [`SECRET_PREFIXES`] credential prefix (e.g. `sk-`, `ghp_`, AWS `AKIA`/`ASIA`),
-/// or (b) is long (≥ 20 chars) AND is not a structural token (see
+/// allowlist) and for anything below [`SECRET_MIN_LEN`], then returns `true`
+/// when the token (a) carries a known [`SECRET_PREFIXES`] credential prefix
+/// (e.g. `sk-`, `ghp_`) or has the AWS key-id shape ([`is_aws_access_key_id`]),
+/// or (b) is not a structural token (see
 /// [`is_structural_token`]) AND mixes character classes in a way SHAs cannot
 /// — i.e. contains BOTH a lowercase and an uppercase letter plus a digit, or
 /// contains a base64-indicator symbol (`+`) or an `=`/`/` that is NOT part of
@@ -802,13 +956,14 @@ fn looks_like_secret(token: &str) -> bool {
     if is_issue_number_list(token) {
         return false;
     }
-    let lower = token.to_ascii_lowercase();
-    if SECRET_PREFIXES.iter().any(|p| lower.starts_with(p)) {
-        return true;
-    }
-    // Below the length floor, entropy is too low to confidently flag.
-    if token.len() < 20 {
+    // #4898: the length floor now runs BEFORE the prefix test. It used to run
+    // after, so a 4-char token equal to a prefix (`Asia`) was flagged.
+    if token.len() < SECRET_MIN_LEN {
         return false;
+    }
+    let lower = token.to_ascii_lowercase();
+    if SECRET_PREFIXES.iter().any(|p| lower.starts_with(p)) || is_aws_access_key_id(token) {
+        return true;
     }
     // Issue #1667: structural tokens (paths, slugs, key=value pairs, and
     // hyphen-segmented compound identifiers) must not be flagged as secrets
@@ -840,8 +995,8 @@ fn looks_like_secret(token: &str) -> bool {
     // so requiring BOTH cases plus a digit excludes them while catching the
     // typical `AbCd12…` / JWT-segment shapes. NOTE (FN-1, issue #1481): this
     // does NOT catch AWS access key IDs — `AKIAIOSFODNN7EXAMPLE` is // pragma: allowlist secret
-    // all-uppercase base32 (`has_lower == false`), so it relies entirely on the
-    // `akia`/`asia` entries in SECRET_PREFIXES above.
+    // all-uppercase base32 (`has_lower == false`), so it relies entirely on
+    // `is_aws_access_key_id` above (#4898 moved that out of SECRET_PREFIXES).
     //
     // Issue #2442: this fallback used to fire on ANY ≥20-char token that
     // mixed case + digit, regardless of what other punctuation it carried.
@@ -924,9 +1079,12 @@ fn is_issue_number_list(token: &str) -> bool {
 ///
 /// Known bound: a token built only from this charset still reaches the branch,
 /// so a hyphen/plus-joined English phrase such as `ticker+shutdown-channel`
-/// remains a false positive. The second gate is what resolves it — the
-/// `has_upper || has_digit` entropy floor in [`looks_like_secret`], with
-/// [`is_url_credential_shaped`] exempting connection strings from that floor.
+/// depends on a second gate. That gate is the `has_upper || has_digit` entropy
+/// floor in [`looks_like_secret`], with [`is_url_credential_shaped`] exempting
+/// connection strings from it. The floor covers the all-lowercase case only,
+/// which left `PM+instructions+subagents` flagged — issue #4898 closed that
+/// residue upstream instead, in [`is_plus_joined_word_phrase`], so a
+/// `+`-joined phrase is now rescued before it reaches this branch at all.
 /// What: returns `true` iff every char is ASCII alphanumeric or in
 /// `{'+', '/', '=', '-', '_', '.', ':', '@'}`.
 /// Test: `four_4312_acceptance_cases_are_not_flagged`,

--- a/crates/trusty-common/src/memory_core/filter_tests.rs
+++ b/crates/trusty-common/src/memory_core/filter_tests.rs
@@ -1654,3 +1654,202 @@ fn per_segment_case_uniformity_is_a_known_accepted_bound() {
         );
     }
 }
+
+// ---- Issue #4898: plus-joined phrases, internal-caps segments, length floor ----
+
+/// Why (issue #4898, the SIXTH recurrence in this detector after #1667, #2800,
+/// #4216, #4312 and #4739): three separate shapes of ordinary memory-palace
+/// content were rejected as credentials in one session.
+///
+/// 1. `PM+instructions+subagents` — an English phrase joined by `+`.
+///    `is_structural_token` refused every `+`-bearing token outright, so the
+///    token fell to the base64 branch, where the `has_upper || has_digit`
+///    entropy floor was satisfied by the two capitals in `PM`. The doc on
+///    `is_plausible_b64_charset` already named this gap: the floor excluded only
+///    the all-lowercase case.
+/// 2. `fix-3696-slice1-gapA-emit` — a git branch name. `is_human_word_segment`
+///    admitted a capital only in first position, so the segment `gapA` was not a
+///    word and the whole token missed the structural rescue.
+/// 3. A four-character token equal to a `SECRET_PREFIXES` entry (`Asia`, the
+///    continent). The prefix test ran BEFORE the 20-char floor, so length never
+///    entered into it.
+///
+/// What: pins all three reproductions verbatim, at both the token predicate and
+/// the `FilterConfig::apply` gate a memory write actually hits, plus further
+/// shapes of each class.
+/// Test: itself.
+#[test]
+fn three_4898_reproductions_are_not_flagged() {
+    let cfg = FilterConfig::default();
+    for (label, tok) in [
+        // (1) plus-joined English phrase carrying an uppercase run.
+        ("4898 repro 1", "PM+instructions+subagents"),
+        ("plus phrase, lowercase", "ticker+shutdown-channel"),
+        ("plus phrase, capitalised", "Instructions+Agents+Skills"),
+        ("plus phrase with digits", "milestone+1.3.5+release"),
+        // (2) branch name with an internal capital inside one segment.
+        ("4898 repro 2", "fix-3696-slice1-gapA-emit"),
+        ("branch with trailing cap", "feat-4172-l0-scoping-partB"),
+        ("issue slug with inner cap", "docs-4898-secretScanner-notes"),
+        ("snake segment with cap", "trusty_mpm_phase2B_rollout"),
+        // (3) short tokens that merely start with a credential prefix.
+        ("4898 repro 3", "Asia"),
+        ("prefix word, uppercase", "ASIA"),
+        ("prefix word, hyphenated", "Asia-Pacific"),
+        ("prefix word in a slug", "asia-pacific-rollout-notes"),
+        ("truncated sk prefix", "sk-1"),
+    ] {
+        assert!(
+            find_secret_token(tok).is_none(),
+            "#4898 ({label}): ordinary content must NOT be flagged: {tok}; got {:?}",
+            find_secret_token(tok)
+        );
+        let prose = format!("Checkpoint: the {tok} work landed on main this morning");
+        assert!(
+            cfg.apply(&prose, true).is_ok(),
+            "#4898 ({label}): the gate must ACCEPT prose carrying {tok}; got {:?}",
+            cfg.apply(&prose, true)
+        );
+    }
+}
+
+/// Why (issue #4898): every one of the three changes NARROWS flagging —
+/// widening `is_human_word_segment` and `is_structural_token` makes
+/// `looks_like_secret` return `false` sooner, and moving the length floor above
+/// the prefix test removes matches outright. A narrowing can only lose
+/// detection, so the true-positive corpus is re-asserted in full against the
+/// post-change code rather than assumed intact.
+///
+/// The load-bearing entries are the `+`-bearing blobs and the delimiter-
+/// segmented mixed-case blobs. `A+DIA+DIA+…` is what pins the word-length
+/// requirement inside `is_plus_joined_word_phrase`: every one of its segments is
+/// case-uniform, so segment shape ALONE would have exempted it.
+/// What: asserts each provider-prefix, base64, base64url, JWT, bare-blob,
+/// connection-string and AWS shape stays flagged.
+/// Test: itself.
+#[test]
+fn real_secrets_still_blocked_after_4898_narrowing() {
+    for (label, tok) in [
+        // LOAD-BEARING for `is_plus_joined_word_phrase`'s word-length floor.
+        ("base64 with +", "A+DIA+DIA+DIA+DIA+DIA+DIA+DIA+DIA+DIA+DI"), // pragma: allowlist secret
+        // LOAD-BEARING for its alphanumeric-segment charset gate: the `token=A`
+        // first segment clears the word-length floor on its own, and the
+        // `srv://svcuser:hunterhunter@cluster` segment is uniformly lowercase.
+        // Both passed before the charset gate was added.
+        (
+            "key= base64 with +",
+            "token=A+DIA+DIA+DIA+DIA+DIA+DIA+DIA+DIA+DIA+DI",
+        ), // pragma: allowlist secret
+        (
+            "base64 with +/",
+            "aGVsbG8rd29ybGQvZm9vK2Jhcj09bG9uZ2Jhc2U2NA==",
+        ), // pragma: allowlist secret
+        ("digits/slash/plus", "1234/5678/9012+3456/7890/1234"), // pragma: allowlist secret
+        // LOAD-BEARING for the one-uppercase-anywhere segment predicate: run-of-
+        // two case alternation carries TWO capitals per segment and stays out.
+        ("hyphenated mixed-case cred", "AbCd1234-EfGh5678-IjKl9012"), // pragma: allowlist secret
+        ("dotted mixed-case cred", "AbCd1234.EfGh5678.IjKl9012"),     // pragma: allowlist secret
+        ("underscored mixed-case cred", "AbCd1234_EfGh5678_IjKl9012"), // pragma: allowlist secret
+        ("camelCase blob segments", "xYzAbc123-qRsTuv456-mNoPqr789"), // pragma: allowlist secret
+        ("slug-prefixed api key", "apikey-Xy7Kp2Qm9Rt4Vw8Nz3Bc6Fj"),  // pragma: allowlist secret
+        ("capitalised head, blob tail", "Prod-AbCd1234EfGh5678IjKl"), // pragma: allowlist secret
+        // LOAD-BEARING for the prefix length floor and the AWS shape gate.
+        ("AWS key id", "AKIAIOSFODNN7EXAMPLE"), // pragma: allowlist secret
+        ("AWS STS id", "ASIAY34FZKBOKMUTVV7A"), // pragma: allowlist secret
+        ("GitHub PAT", "ghp_abcdefghijklmnopqrstuvwxyz0123456789"), // pragma: allowlist secret
+        ("OpenAI key", "sk-abcdefghijklmnopqrstuvwxyz01234567890123"), // pragma: allowlist secret
+        ("OpenAI key, short form", "sk-abcdef0123456789abcdef01"), // pragma: allowlist secret
+        ("Slack token", "xoxb-1234-5678-abcdEFGH"), // pragma: allowlist secret
+        // Unchanged families, re-asserted because the changed predicates all sit
+        // on the path these take.
+        ("bare mixed-case blob", "AbCd1234EfGh5678IjKl9012"), // pragma: allowlist secret
+        ("base64url token", "AbCd1234EfGh5678IjKl9012_MnOp-QrSt="), // pragma: allowlist secret
+        ("colon-bearing credential", "token:aBc123XyZ987uvW456QrS"), // pragma: allowlist secret
+        (
+            "padded base64",
+            "dGhpcyBpcyBhIHZlcnkgbG9uZyBzZWNyZXQgdG9rZW4=",
+        ), // pragma: allowlist secret
+        (
+            "JWT",
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+        ), // pragma: allowlist secret
+        (
+            "basic-auth URL",
+            "https://admin:Sup3rS3cret@internal.example.com/api",
+        ), // pragma: allowlist secret
+        (
+            "lowercase postgres conn",
+            "postgres://user:password@host/database",
+        ), // pragma: allowlist secret
+        (
+            "lowercase mongo srv",
+            "mongodb+srv://svcuser:hunterhunter@cluster.mongodb.net",
+        ), // pragma: allowlist secret
+        (
+            "webhook URL with secret path",
+            "https://webhook.example.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+        ), // pragma: allowlist secret
+    ] {
+        assert!(
+            find_secret_token(tok).is_some(),
+            "{label} must STILL be flagged after the #4898 narrowing: {tok}"
+        );
+    }
+
+    // End-to-end, not just the token predicate: the gate is what a write hits.
+    let cfg = FilterConfig::default();
+    for content in [
+        "Deploy creds leaked: access key AKIAIOSFODNN7EXAMPLE in the log", // pragma: allowlist secret
+        "Use this token AbCd1234EfGh5678IjKl9012 to authenticate the webhook", // pragma: allowlist secret
+        "config blob: aGVsbG8rd29ybGQvZm9vK2Jhcj09bG9uZ2Jhc2U2NA== embedded here", // pragma: allowlist secret
+    ] {
+        assert!(
+            matches!(
+                cfg.apply(content, false),
+                Err(FilterReject::PotentialSecret { .. })
+            ),
+            "the gate must still REJECT leaked-credential prose; got {:?}",
+            cfg.apply(content, false)
+        );
+    }
+}
+
+/// Why (issue #4898): the `+` exemption is gated on segment shape AND on one
+/// segment reaching word length, and the prefix floor is a flat 20 characters.
+/// Both bounds admit shapes that are not prose. They are accepted rather than
+/// fixed, and pinned here so future movement in either direction is visible —
+/// the same treatment the #4312 and #4739 bounds already get above.
+/// What: pins the accepted side of each new bound.
+/// Test: itself.
+#[test]
+fn known_accepted_bounds_after_4898() {
+    // A `+`-joined token whose every segment is case-uniform AND long enough to
+    // read as a word is admitted, even though no English dictionary is
+    // consulted. Base64 does not produce this: its `+` density is ~1.6%, so its
+    // segments run ~60 chars and cannot be case-uniform.
+    for tok in ["Abcdefgh+Ijklmnop+Qrstuvwx", "alphabet+bravocode+charlie"] {
+        assert!(
+            find_secret_token(tok).is_none(),
+            "KNOWN ACCEPTED BOUND (#4898): a `+`-joined token of case-uniform \
+             word-length segments is admitted. If it now FLAGS, the bound \
+             tightened — update the doc on `is_plus_joined_word_phrase`. \
+             Token: {tok}"
+        );
+    }
+    // The prefix floor is length-only for the punctuation-bearing prefixes, so a
+    // 20+-char token that merely STARTS with one is still flagged. That is the
+    // pre-#4898 behaviour for every length at or above the floor, unchanged.
+    assert!(
+        find_secret_token("sk-eleton-key-for-the-front-door").is_some(),
+        "KNOWN ACCEPTED BOUND (#4898): the prefix test is length-gated, not \
+         shape-gated, for `sk-`/`ghp_`/`xoxb-`. A long prose token that starts \
+         with one is still flagged."
+    );
+    // The AWS prefixes ARE shape-gated (all-uppercase alphanumeric), which is
+    // what removes the `Asia…` prose class entirely rather than by length alone.
+    assert!(
+        find_secret_token("ASIA-PACIFIC-ROLLOUT-NOTES").is_none(),
+        "#4898: an all-uppercase but punctuation-bearing `ASIA…` token is not \
+         an AWS key id shape and must not be flagged"
+    );
+}

--- a/crates/trusty-common/src/memory_core/filter_tests.rs
+++ b/crates/trusty-common/src/memory_core/filter_tests.rs
@@ -1756,10 +1756,20 @@ fn real_secrets_still_blocked_after_4898_narrowing() {
         // LOAD-BEARING for the prefix length floor and the AWS shape gate.
         ("AWS key id", "AKIAIOSFODNN7EXAMPLE"), // pragma: allowlist secret
         ("AWS STS id", "ASIAY34FZKBOKMUTVV7A"), // pragma: allowlist secret
+        // LOAD-BEARING for `is_aws_access_key_id` being a PREFIX predicate: the
+        // whole-token form of it lost every one of these (#4898 review round 1).
+        ("AWS key id + suffix", "AKIAIOSFODNN7EXAMPLE-old"), // pragma: allowlist secret
+        (
+            "AWS key id + secret access key",
+            "AKIAIOSFODNN7EXAMPLE/wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        ), // pragma: allowlist secret
+        // LOAD-BEARING for the character-class-uniformity gate: real
+        // `base64(urandom(15))` output whose every `+`-segment is case-uniform.
+        ("base64 of 15 random bytes", "j1u7nJd+tvZers+wdZyr"), // pragma: allowlist secret
         ("GitHub PAT", "ghp_abcdefghijklmnopqrstuvwxyz0123456789"), // pragma: allowlist secret
         ("OpenAI key", "sk-abcdefghijklmnopqrstuvwxyz01234567890123"), // pragma: allowlist secret
         ("OpenAI key, short form", "sk-abcdef0123456789abcdef01"), // pragma: allowlist secret
-        ("Slack token", "xoxb-1234-5678-abcdEFGH"), // pragma: allowlist secret
+        ("Slack token", "xoxb-1234-5678-abcdEFGH"),            // pragma: allowlist secret
         // Unchanged families, re-asserted because the changed predicates all sit
         // on the path these take.
         ("bare mixed-case blob", "AbCd1234EfGh5678IjKl9012"), // pragma: allowlist secret
@@ -1845,11 +1855,224 @@ fn known_accepted_bounds_after_4898() {
          shape-gated, for `sk-`/`ghp_`/`xoxb-`. A long prose token that starts \
          with one is still flagged."
     );
-    // The AWS prefixes ARE shape-gated (all-uppercase alphanumeric), which is
-    // what removes the `Asia…` prose class entirely rather than by length alone.
+    // The AWS prefixes are shape-gated over the first SECRET_MIN_LEN bytes.
+    //
+    // These two assertions are a PAIR and must be read together (#4898 review
+    // round 1). The first cut of `is_aws_access_key_id` checked the whole token,
+    // which satisfied the `ASIA-PACIFIC…` half while silently losing every AWS
+    // key with a neighbouring character — so an assertion on the prose token
+    // alone passes in both the correct and the broken world and discriminates
+    // nothing. What separates them is where the non-key character sits: inside
+    // the first 20 bytes (prose) or after them (a real key with a suffix).
     assert!(
         find_secret_token("ASIA-PACIFIC-ROLLOUT-NOTES").is_none(),
-        "#4898: an all-uppercase but punctuation-bearing `ASIA…` token is not \
-         an AWS key id shape and must not be flagged"
+        "#4898: `ASIA-PACIFIC-ROLLOUT-NOTES` breaks the key-id shape at byte 4, \
+         inside the first 20, so it is prose and must not be flagged"
     );
+    assert!(
+        find_secret_token("ASIAY34FZKBOKMUTVA7Q-staging").is_some(), // pragma: allowlist secret
+        "#4898: `ASIAY34FZKBOKMUTVA7Q-staging` holds the key-id shape for a full \
+         20 bytes and breaks it only afterwards, so it is a real AWS key id with \
+         a suffix and must STILL be flagged. If this fails while the assertion \
+         above passes, the whole-token regression is back."
+    );
+}
+
+// ---- Issue #4898: generated-encoder corpus ----
+
+/// Why (issue #4898 review round 1, MEDIUM finding): every hand-written battery
+/// in this file is a list of shapes someone thought of. Two of the three defects
+/// found in review lived in encoder output nobody had written down —
+/// `j1u7nJd+tvZers+wdZyr` and `9h6Nn6_ivJd6vmb-xEk4` are both what
+/// `base64(urandom(15))` actually produces, and both flipped FLAG -> MISS. A
+/// generated corpus is the only thing that finds those.
+///
+/// What: xorshift64*, seeded by constant, so the corpus is byte-identical on
+/// every machine and every run. No `rand` dev-dependency, no flake.
+/// Test: used by `generated_encoder_corpus_stays_flagged`.
+struct Xorshift(u64);
+
+impl Xorshift {
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    fn fill(&mut self, buf: &mut [u8]) {
+        for b in buf.iter_mut() {
+            *b = (self.next_u64() >> 24) as u8;
+        }
+    }
+}
+
+/// Standard base64 (`A–Za–z0–9+/`) and base64url (`A–Za–z0–9-_`) alphabets.
+fn b64_alphabet(url_safe: bool) -> Vec<u8> {
+    let mut a: Vec<u8> = Vec::with_capacity(64);
+    a.extend(b'A'..=b'Z');
+    a.extend(b'a'..=b'z');
+    a.extend(b'0'..=b'9');
+    if url_safe {
+        a.extend_from_slice(b"-_");
+    } else {
+        a.extend_from_slice(b"+/");
+    }
+    a
+}
+
+/// Minimal base64 encoder — this file cannot take a dev-dependency on `base64`
+/// (it is an optional production dep behind a feature the memory-core test
+/// profile does not enable).
+fn b64_encode(bytes: &[u8], alphabet: &[u8], pad: bool) -> String {
+    let mut out = String::new();
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(alphabet[((n >> 18) & 63) as usize] as char);
+        out.push(alphabet[((n >> 12) & 63) as usize] as char);
+        match chunk.len() {
+            1 => {
+                if pad {
+                    out.push_str("==");
+                }
+            }
+            2 => {
+                out.push(alphabet[((n >> 6) & 63) as usize] as char);
+                if pad {
+                    out.push('=');
+                }
+            }
+            _ => {
+                out.push(alphabet[((n >> 6) & 63) as usize] as char);
+                out.push(alphabet[(n & 63) as usize] as char);
+            }
+        }
+    }
+    out
+}
+
+/// Count how many of `n` generated encoder tokens the detector MISSES.
+fn encoder_miss_count(seed: u64, n: usize, input_len: usize, url_safe: bool, pad: bool) -> usize {
+    let mut rng = Xorshift(seed);
+    let alphabet = b64_alphabet(url_safe);
+    let mut buf = vec![0u8; input_len];
+    let mut misses = 0usize;
+    for _ in 0..n {
+        rng.fill(&mut buf);
+        let tok = b64_encode(&buf, &alphabet, pad);
+        if find_secret_token(&tok).is_none() {
+            misses += 1;
+        }
+    }
+    misses
+}
+
+/// Why (issue #4898 review round 1, MEDIUM finding): a ratchet on generated
+/// encoder output. Two of the three defects found in review lived in shapes
+/// nobody had written into a battery.
+///
+/// Read the ceilings as a ratchet, not as a pass mark. Most of each count is a
+/// PRE-EXISTING baseline this PR neither caused nor fixes: unpadded base64 that
+/// happens to carry no `+` or `/` never reaches the base64 branch, and
+/// `find_secret_token` trims trailing `=` off a token before classifying it, so
+/// padded base64 loses its padding too. Both fall to the mixed-case branch,
+/// which needs all three character classes present.
+///
+/// Measured at this seed and N against `origin/main` (`c679c3c3`) and this
+/// branch:
+///
+/// ```text
+///                          origin/main   this branch   delta
+///   base64        15 bytes     7472          7472          0
+///   base64        16 bytes     6289          6289          0
+///   base64        20 bytes     6620          6620          0
+///   base64 padded 17 bytes     6342          6343         +1
+///   base64 padded 25 bytes     7203          7203          0
+///   base64url     15 bytes      970          1012        +42
+///   base64url     16 bytes      799           833        +34
+///   base64url     20 bytes      286           291         +5
+/// ```
+///
+/// The base64 column is zero because `is_plus_joined_word_phrase`'s
+/// character-class-uniformity gate closed it; at 300k samples the residue is 1.
+/// The base64url column is the KNOWN RESIDUAL MISS documented on
+/// [`is_human_word_segment`], carried deliberately — see that doc for why the
+/// narrowing that would close it costs the `gapA` class this PR exists to fix.
+/// What: 30k generated tokens per configuration, asserting the miss count is at
+/// or below the pinned ceiling.
+/// Test: itself.
+#[test]
+fn generated_encoder_corpus_stays_flagged() {
+    const N: usize = 30_000;
+    const SEED: u64 = 0x4898_1234_5678_9abc;
+    for (label, url_safe, input_len, pad, ceiling) in [
+        ("base64", false, 15usize, false, 7472usize),
+        ("base64", false, 16, false, 6289),
+        ("base64", false, 20, false, 6620),
+        ("base64 padded", false, 17, true, 6343),
+        ("base64 padded", false, 25, true, 7203),
+        ("base64url", true, 15, false, 1012),
+        ("base64url", true, 16, false, 833),
+        ("base64url", true, 20, false, 291),
+    ] {
+        let misses = encoder_miss_count(SEED, N, input_len, url_safe, pad);
+        assert!(
+            misses <= ceiling,
+            "#4898 ratchet: {label} at {input_len} input bytes missed {misses} of \
+             {N}, above the pinned ceiling {ceiling}. Something widened the \
+             structural bypass — re-measure against origin/main before touching \
+             this number."
+        );
+    }
+}
+
+/// Why (issue #4898 review round 1, CRITICAL finding): the first cut of
+/// `is_aws_access_key_id` required the WHOLE token to be uppercase-alphanumeric,
+/// converting what had been a prefix predicate into a shape predicate. One
+/// adjacent character then dropped the token through to `is_structural_token`,
+/// whose segmented-identifier branch rescued it, and the mixed-case branch could
+/// not fire because an AWS key id has no lowercase. AWS detection was lost
+/// entirely for any key not standing completely alone — including AWS's own
+/// canonical key-id/secret-key pair, which stored clean.
+///
+/// Every row below was verified FLAG on `origin/main` (`c679c3c3`) and MISS on
+/// the first cut of this branch. They are the discriminating cases: a test that
+/// only asserts the bare 20-character key id passes in both worlds.
+/// What: asserts AWS key ids stay flagged with text on either side, at both the
+/// token predicate and the `FilterConfig::apply` gate.
+/// Test: itself.
+#[test]
+fn aws_key_ids_with_adjacent_text_are_blocked() {
+    let cfg = FilterConfig::default();
+    for (label, tok) in [
+        ("trailing hyphen suffix", "AKIAIOSFODNN7EXAMPLE-old"), // pragma: allowlist secret
+        ("file extension", "AKIAIOSFODNN7EXAMPLE.csv"),         // pragma: allowlist secret
+        ("STS id with env suffix", "ASIAY34FZKBOKMUTVA7Q-staging"), // pragma: allowlist secret
+        ("underscore suffix", "AKIAIOSFODNN7EXAMPLE_backup"),   // pragma: allowlist secret
+        (
+            // AWS's canonical key-id + secret-access-key pair.
+            "key id followed by secret access key",
+            "AKIAIOSFODNN7EXAMPLE/wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        ), // pragma: allowlist secret
+    ] {
+        assert!(
+            find_secret_token(tok).is_some(),
+            "#4898 ({label}): an AWS key id with an adjacent character must STILL \
+             be flagged: {tok}"
+        );
+        let prose = format!("Rotate {tok} before Friday");
+        assert!(
+            matches!(
+                cfg.apply(&prose, false),
+                Err(FilterReject::PotentialSecret { .. })
+            ),
+            "#4898 ({label}): the gate must REJECT prose carrying {tok}; got {:?}",
+            cfg.apply(&prose, false)
+        );
+    }
 }


### PR DESCRIPTION
## Defect

Three shapes of ordinary memory-palace content were rejected as credentials in one session, and the rejection is unbypassable by `force=true` by design (#2520). All three are in `memory_core/filter.rs`; none is in the `force` / `allow_secret_like` gate, which is untouched.

| # | Repro | Redacted preview | Cause |
|---|---|---|---|
| 1 | `PM+instructions+subagents` | `PM+i…(25 chars)` | `is_structural_token` returned `false` for **any** `+`-bearing token ("`+` is unambiguously base64"). The token fell to the base64 branch, where the `has_upper \|\| has_digit` entropy floor was satisfied by the two capitals in `PM`. The doc on `is_plausible_b64_charset` already named this as an accepted residual gap — the floor excluded only the all-lowercase case. |
| 2 | `fix-3696-slice1-gapA-emit` | `fix-…(25 chars)` | `is_human_word_segment` admitted a capital only in **first** position, so the segment `gapA` was not a word, `is_segmented_identifier` declined the rescue, and the token satisfied the mixed-case+digit branch. |
| 3 | `Asia` | `…(4 chars)` | Ordering bug, not a coverage gap: `looks_like_secret` tested `SECRET_PREFIXES` **before** the `token.len() < 20` floor, so a 4-char token equal to the `asia` prefix matched at any length. `Asia-Pacific` and `asia-pacific-rollout-notes` matched too. |

Fail-before evidence, on `origin/main` at `c679c3c3`:

```
     PM+instructions+subagents -> Some("PM+i…(25 chars)")
     fix-3696-slice1-gapA-emit -> Some("fix-…(25 chars)")
                          Asia -> Some("…(4 chars)")
                          ASIA -> Some("…(4 chars)")
                  Asia-Pacific -> Some("Asia…(12 chars)")
    asia-pacific-rollout-notes -> Some("asia…(26 chars)")
```

Every preview matches the issue body verbatim.

## Resolution

Three narrowings, ~40 lines of logic. Each is a narrowing of one false-positive shape, and each is pinned against the true-positive corpus in the same PR.

1. **`is_plus_joined_word_phrase`** replaces the blanket `+` rejection in `is_structural_token`. A `+`-bearing token is structural only when it splits (on `+ - _ .`) into ≥2 segments that are each non-empty, ASCII-alphanumeric, and case-uniform, with one segment reaching 5 alphabetic characters. Real base64 places `+` at ~1.6% density, so its `+`-separated runs average tens of characters and cannot be case-uniform; the remaining shape — a short-segment `+`-heavy blob like `A+DIA+DIA+…` — is case-uniform per segment, which is exactly what the word-length floor is for (its longest segment is 3).

2. **`is_human_word_segment` counts capitals instead of locating them.** A non-uppercase segment admits at most one capital *anywhere* rather than only in first position. The count is what discriminates: `AbCd` and `xYzAbc` carry two either way and stay out. What this admits that #4739 did not is a single interior or trailing capital (`gapA`, `partB`, `phase2B`), which no encoded alphabet produces at segment scale.

3. **The 20-char floor moved above the prefix test** (`SECRET_MIN_LEN`), and AWS moved out of `SECRET_PREFIXES` into `is_aws_access_key_id`. The other prefixes (`sk-`, `ghp_`, `xoxb-`, …) carry punctuation no English word contains, so a length floor is enough for them. `akia`/`asia` are four bare letters, so they need a shape check: `AKIA`/`ASIA` prefix, ≥20 chars, all-uppercase-alphanumeric. That removes the `Asia…` prose class outright rather than pushing it past a threshold. The shortest real credential any layer targets is the 20-char AWS key id, so the floor costs no detection.

## The true-positive corpus caught two regressions I wrote

`is_human_word_segment` constrains case, not charset — it trims segment ends and ignores interior punctuation. The first cut of `is_plus_joined_word_phrase` therefore admitted:

- `token=A+DIA+DIA+DIA+…` — first segment `token=A` is one capital and six letters, clearing the word-length floor on its own
- `mongodb+srv://svcuser:hunterhunter@cluster.mongodb.net` — segment `srv://svcuser:hunterhunter@cluster` is uniformly lowercase

Both were caught by the pinned batteries from #1676 and #4312 before this PR was opened. The fix is the alphanumeric-segment charset gate, and both shapes are now pinned in this PR's own battery as load-bearing.

## Detection surface: retained, not widened

`real_secrets_still_blocked_after_4898_narrowing` re-asserts the full corpus against the changed code, because all three changes narrow flagging and a narrowing can only lose detection. Load-bearing entries:

- base64 with `+` (`A+DIA+…`), `key=`-prefixed base64 with `+`, `digits/slash/plus`
- delimiter-segmented mixed-case blobs (`AbCd1234-EfGh5678-IjKl9012`, `xYzAbc123-qRsTuv456-mNoPqr789`, `apikey-Xy7Kp2Qm9Rt4Vw8Nz3Bc6Fj`)
- AWS `AKIA…`/`ASIA…`, GitHub PAT, OpenAI `sk-` (long and short forms), Slack `xoxb-`
- bare mixed-case blob, base64url, JWT, padded base64, colon-bearing credential
- connection strings incl. the all-lowercase ones that only `is_url_credential_shaped` keeps, and the webhook URL with an uppercase path secret

plus three end-to-end `FilterConfig::apply` rejections, since the gate is what a memory write actually hits. Every pre-existing battery — #1667, #1676, #2442, #2800, #4312, #4739 — passes unchanged, including their known-miss and known-accepted-bound pins.

New accepted bounds are pinned in `known_accepted_bounds_after_4898` rather than left implicit: a `+`-joined token of case-uniform word-length segments is admitted without a dictionary check (`Abcdefgh+Ijklmnop+Qrstuvwx`), and the prefix test stays length-gated rather than shape-gated for `sk-`/`ghp_`/`xoxb-`.

## Should this have been a structural rework instead?

Yes, eventually — and not in this PR. All six rounds (#1667, #2800/#4216, #4312, #4739, #4898) are the same shape: a delimiter-joined, human-composed token whose parts are individually innocuous but whose whole mixes character classes. Each round patched one delimiter or one charset. The structural fix is a single decomposition predicate over *all* delimiters (`+ - _ . / = : @`), with the base64 and mixed-case branches reduced to "no such decomposition exists", replacing branches (a)/(b)/(c), the `+` guard, `is_issue_number_list` and `is_url_credential_shaped`.

Doing that here would move every existing carve-out onto one code path in a security-adjacent detector, in the same PR as a fix for a bug that is currently blocking writes — and it would require re-measuring three documented accepted bounds and two documented known misses. The two regressions above, hit within one iteration of a 40-line change, are the calibration: a unified predicate loses detection easily and quietly. Worth a follow-up issue with the corpus as the acceptance gate.

## Test ladder — rung 5 (shared library, security-adjacent credential detector)

```
cargo fmt --check
cargo clippy -p trusty-common --features memory-core,embedder-test-support --all-targets -- -D warnings
cargo test -p trusty-common --features memory-core,embedder-test-support -- --test-threads=1
cargo test -p trusty-memory -- --test-threads=1
cargo test -p trusty-mpm
cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui
bash scripts/check_line_cap.sh
bash scripts/check_sld.sh
```

```
$ cargo fmt --check
(no output — clean)

$ cargo clippy -p trusty-common --features memory-core,embedder-test-support --all-targets -- -D warnings
    Checking trusty-common v0.29.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.71s

$ cargo test -p trusty-common --features memory-core,embedder-test-support -- --test-threads=1
test result: ok. 870 passed; 0 failed; 13 ignored; 0 measured; 0 filtered out; finished in 45.01s
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.11s
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.29s
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.53s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.53s
(+ 2 empty targets)

$ cargo test -p trusty-common --features memory-core,embedder-test-support --lib memory_core::filter
test result: ok. 56 passed; 0 failed; 0 ignored; 0 measured; 827 filtered out; finished in 0.01s

$ cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui
    Finished (0 errors; one pre-existing future-incompat note on proc-macro-error2 v2.0.1)

$ bash scripts/check_line_cap.sh
line-cap: measured 3720 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 56 spec doc(s) + 3105 code file(s); 0 error(s), 0 warning(s)

$ bash scripts/check_changelog_fragment.sh
OK   trusty-common: changelog.d fragment present and valid
changelog-fragment gate: scanned 3 changed path(s); all 1 crate(s) with source changes are recorded.
```

Two suites have pre-existing failures on this machine. Neither is caused by this diff, which touches three files, all in `trusty-common`.

**`cargo test -p trusty-memory`** — `commands::doctor::tests::check_daemon_health_fails_cleanly_with_stale_addr_and_no_listener` and `…_fails_when_no_addr_file_and_no_listener` fail, and `commands::inbox_check::tests::inbox_check_logs_attempt_without_daemon` hangs. All three probe for the *absence* of a daemon on 127.0.0.1:7070-7079, and this machine has one:

```
$ lsof -nP -iTCP:7070-7079 -sTCP:LISTEN
trusty-me 72520 masa   11u  IPv4  TCP 127.0.0.1:7070 (LISTEN)
```

Reproduced on a clean `origin/main` worktree at `c679c3c3`, with this branch's code absent:

```
$ cargo test -p trusty-memory -- --test-threads=1 commands::doctor::tests::check_daemon_health…
test commands::doctor::tests::check_daemon_health_fails_cleanly_with_stale_addr_and_no_listener ... FAILED
test commands::doctor::tests::check_daemon_health_fails_when_no_addr_file_and_no_listener ... FAILED
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 564 filtered out; finished in 0.02s
```

The rest of the crate passes with those three skipped:

```
$ cargo test -p trusty-memory -- --test-threads=1 --skip commands::doctor:: --skip commands::inbox_check::
test result: ok. 539 passed; 0 failed; 4 ignored; 0 measured; 23 filtered out; finished in 98.30s
(+ 21 further targets, all ok)
```

**`cargo test -p trusty-mpm`** — `core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning`, the order-dependent tracing-capture flake tracked by [#4931](https://github.com/bobmatnyc/trusty-tools/issues/4931). "Captured lines: []" is the signature: a sibling test won the global-subscriber `try_init` race.

```
$ cargo test -p trusty-mpm
test result: FAILED. 4635 passed; 1 failed; 7 ignored; 0 measured; 0 filtered out; finished in 80.91s

$ cargo test -p trusty-mpm --lib core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning -- --exact
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4642 filtered out; finished in 0.72s
```

Change-specific gates pass; `cargo test -p trusty-memory` is blocked by the live-daemon environment and `cargo test -p trusty-mpm` by [#4931](https://github.com/bobmatnyc/trusty-tools/issues/4931).


`filter.rs` 339 → 365 SLOC (production cap 500); `filter_tests.rs` under the 3000 test cap. Neither file is on the ratchet allowlist and neither needs to be.

Closes [#4898](https://github.com/bobmatnyc/trusty-tools/issues/4898)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
