### PR TITLE
docs: move non-per-prompt CLAUDE.md content to skills and references

### DIFF
--- a/.claude/skills/cargo-commands/SKILL.md
+++ b/.claude/skills/cargo-commands/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: cargo-commands
+description: Full cargo command reference for the trusty-tools workspace — release builds, feature-gated tests, ignored/ONNX integration tests, single-test-by-name runs, the trusty-search performance regression suite, dependency audit, and crate-name-vs-directory resolution
+user-invocable: true
+version: "1.0.0"
+category: local-ops
+tags: [cargo, build, test, workspace, local-ops]
+effort: low
+when_to_use: When you need a cargo invocation beyond the five everyday one-liners in CLAUDE.md — a release build, a feature-gated test, an ignored/ONNX integration test, a single test by name, the trusty-search baseline suite, cargo update/audit, or running a crate binary
+---
+
+# Cargo Commands — trusty-tools Workspace
+
+🔴 **Single-path workflows — use exactly these commands.**
+
+The five everyday one-liners (`cargo build`, `cargo check -p <crate>`,
+`cargo test -p <crate>`, `cargo clippy -p <crate> --all-targets -- -D warnings`,
+`cargo fmt`) are resident in the root `CLAUDE.md` and are not repeated here.
+This skill is the exhaustive variant list.
+
+**Which gate to run for a given change is not this skill's call** — that is the
+Rust Test Ladder in `CLAUDE.md`, with the per-rung command chains in
+[docs/reference/test-ladder-baseline.md](../../../docs/reference/test-ladder-baseline.md).
+This skill tells you how to *spell* a command, not whether you owe it.
+
+## Workspace-wide
+
+```bash
+# Build all crates (release/optimised)
+cargo build --release
+
+# Run all tests across the workspace
+cargo test
+
+# Lint workspace-wide, all targets
+cargo clippy --workspace --all-targets -- -D warnings
+
+# Format check (no writes) / format and fix
+cargo fmt --check
+cargo fmt
+
+# Run ONNX-backed integration tests (slow; skipped in CI)
+cargo test -- --include-ignored
+
+# Update dependencies (review the Cargo.lock diff before committing)
+cargo update
+
+# Audit dependencies for known vulnerabilities
+cargo audit   # requires: cargo install cargo-audit
+```
+
+## Individual Crate
+
+```bash
+# Build a single crate (dev / release)
+cargo build -p trusty-search
+cargo build --release -p trusty-search
+
+# Build only one binary rather than the whole workspace
+cargo build --release -p trusty-mpm
+
+# Test a single crate with a specific feature
+cargo test -p trusty-common --features axum-server
+
+# Test a single test by name within a crate
+cargo test -p trusty-search -- my_test_name
+
+# Exact single test, uncaptured output (the flake-repro form)
+cargo test -p <crate> <test> -- --exact --nocapture
+
+# Test a single crate including its #[ignore]-tagged tests
+cargo test -p trusty-embedderd -- --include-ignored
+
+# Run a binary from a specific crate
+cargo run -p trusty-search -- start
+cargo run -p trusty-mpm -- --help
+
+# trusty-search performance regression suite
+# (requires the daemon running and trusty-tools indexed)
+cargo test -p trusty-search --test baseline_trusty_tools -- --include-ignored --nocapture
+```
+
+## Ignore-Tagged Integration Tests
+
+ONNX-backed embedder tests are marked `#[ignore]` so CI stays fast. They do not
+run under a plain `cargo test`. Use `--include-ignored` when you need local
+validation against the actual model — and expect it to be slow.
+
+## `trusty-mpm-gui` and `trusty-code-gui` Are Excluded by Default
+
+Both are omitted from the root `Cargo.toml`'s `default-members` (#2951), so a
+bare `cargo build` / `test` / `check` skips them. Name them explicitly
+(`cargo build -p trusty-mpm-gui`) or use `--workspace`, which always builds
+everything regardless of `default-members`.
+
+## Crate Names vs. Directory Names
+
+**Crate names** match the `name` field in each crate's `Cargo.toml`, which is
+not always the directory name:
+
+- `crates/trusty-git-analytics/` → `-p tga` (short published name)
+- `crates/trusty-agents/` → `-p trusty-agents`
+
+If you get "package not found", read the `name` field in that crate's
+`Cargo.toml`. The abbreviation table in `CLAUDE.md` resolves the conversational
+short names (`tm`, `ts`, `tc`, …) — expand those *before* composing a `-p` flag.
+
+## Related
+
+- `cargo-publish` — version bumps, tagging, and publishing to crates.io.
+- `docs/reference/test-ladder-baseline.md` — per-rung gate command chains and
+  the baseline-failure protocol.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,79 +38,21 @@ then propagate changes to all crates that depend on it before committing.
 
 ## Build and Test Commands
 
-🔴 **Single-path workflows — use exactly these commands.**
-
-### Workspace-wide Commands
-
-```bash
-# Build all crates (development)
-cargo build
-
-# Build all crates (release/optimised)
-cargo build --release
-
-# Run all tests
-cargo test
-
-# Check (fast compile check, no codegen)
-cargo check
-
-# Lint (workspace-wide, all targets)
-cargo clippy --workspace --all-targets -- -D warnings
-
-# Format check
-cargo fmt --check
-
-# Format and fix
-cargo fmt
-
-# Run ONNX-backed integration tests (slow; skipped in CI)
-cargo test -- --include-ignored
-
-# Update dependencies (review Cargo.lock diff before committing)
-cargo update
-
-# Audit dependencies for known vulnerabilities
-cargo audit   # requires: cargo install cargo-audit
-```
-
-### Individual Crate Commands
+🔴 **Single-path workflows — use exactly these commands.** Scope to the crate
+you changed; a bare workspace run is a hardening gate, not an inner loop.
 
 ```bash
-# Build a single crate (dev)
-cargo build -p trusty-search
-
-# Build a single crate (release)
-cargo build --release -p trusty-search
-
-# Check a single crate (fastest — no codegen)
-cargo check -p trusty-search
-
-# Test a single crate
-cargo test -p trusty-search
-
-# Test a single crate with a specific feature
-cargo test -p trusty-common --features axum-server
-
-# Test a single test by name within a crate
-cargo test -p trusty-search -- my_test_name
-
-# Run a binary from a specific crate
-cargo run -p trusty-search -- start
-cargo run -p trusty-mpm -- --help
-
-# Build only the binary, not the whole workspace
-cargo build --release -p trusty-mpm
-
-# Lint a single crate
-cargo clippy -p trusty-search -- -D warnings
-
-# Test a single crate with ignored tests
-cargo test -p trusty-embedderd -- --include-ignored
-
-# Run trusty-search performance regression suite (requires daemon + indexed trusty-tools)
-cargo test -p trusty-search --test baseline_trusty_tools -- --include-ignored --nocapture
+cargo build                                            # build all crates (dev)
+cargo check -p <crate>                                 # fastest — no codegen
+cargo test -p <crate>                                  # test one crate
+cargo clippy -p <crate> --all-targets -- -D warnings   # lint one crate
+cargo fmt                                              # format (--check to verify only)
 ```
+
+For any other invocation — release builds, feature-gated tests,
+`--include-ignored` / ONNX tests, a single test by name, the `trusty-search`
+performance regression suite, `cargo update` / `cargo audit`, or running a
+crate's binary — call `Skill(skill="cargo-commands")` rather than guessing.
 
 ### Important: Crate Names vs. Directory Names
 
@@ -136,14 +78,20 @@ Required tests stay in the implementation PR (`tm-pr-workflow`, "One Outcome,
 One PR"). Name the rung and paste its command in the PR body so a reviewer can
 see which rung was actually run.
 
-| # | Change class | Risk | Development proof | PR gate — the command to run | Hardening / release gate |
-|---|---|---|---|---|---|
-| 1 | Docs, comments, changelog fragments only | Low | Read the rendered file | `bash scripts/check_sld.sh` (plus `check_doc_numbers.sh` / `check_line_cap.sh` if those surfaces were touched). No Cargo test by default. | CI required checks only |
-| 2 | Test-only stabilization — flake fix, fixture, test harness | Low | Fail-before / pass-after, repeated: `cargo test -p <crate> <test> -- --exact --nocapture` run ~10× | `cargo fmt --check` && `cargo test -p <crate>`; add `-- --test-threads=1` when the flake is isolation-shaped | `cargo test --workspace` **only** when shared test infrastructure changed |
-| 3 | Localized behavior inside one crate | Normal | One targeted regression test that provably fails before the change | `cargo fmt --check` && `cargo check -p <crate>` && `cargo clippy -p <crate> -- -D warnings` && `cargo test -p <crate>` | Workspace gate only when release policy requires it |
-| 4 | **Cross-crate change** — public API or shared library (`trusty-common`, `trusty-embedderd`, …) | Normal → High | Targeted regression plus `cargo test -p <lib>` | rung 3 for the library, then `cargo check --workspace` && `cargo test -p <consumer>` for **each direct dependent** | `cargo test --workspace` && `cargo clippy --workspace --all-targets -- -D warnings` at HARDEN/release |
-| 5 | Cross-crate contract, persistence, security, process lifecycle, **release tooling** | High | Targeted plus failure-path and concurrency tests | rung 4, plus `cargo test -p <crate> -- --include-ignored` for gated integration coverage, plus an adversarial review round (`code-critic`) | full workspace, `cargo audit`, and for release tooling `scripts/check-publish-ready.sh <crate>` && `scripts/preflight-publish.sh <crate>` |
-| 6 | **UI / API surface** — Svelte UIs, MCP tool schemas, HTTP routes | High | Rust crate tests **plus** direct UI/API evidence (curl the route, call the MCP tool, load the page) | rung 3 or 4 for the Rust side, plus `pnpm -C crates/<crate>/ui test` (where the package defines one; otherwise `… build`) and one smoke run of the binary | full product/e2e gate plus `cargo test -- --include-ignored` when hardening |
+| # | Change class | Risk | PR gate, in short |
+|---|---|---|---|
+| 1 | Docs, comments, changelog fragments only | Low | Doc gates only (`check_sld.sh`, plus doc-numbers / line-cap if touched). No Cargo test by default. |
+| 2 | Test-only stabilization — flake fix, fixture, test harness | Low | `fmt --check` + `test -p <crate>`, with the flake re-run ~10× |
+| 3 | Localized behavior inside one crate | Normal | `fmt --check` + `check` + `clippy` + `test`, all `-p <crate>`, plus one regression test that provably failed before |
+| 4 | **Cross-crate change** — public API or shared library (`trusty-common`, `trusty-embedderd`, …) | Normal → High | Rung 3 on the library, then `check --workspace` + `test -p <consumer>` for **each direct dependent** |
+| 5 | Cross-crate contract, persistence, security, process lifecycle, **release tooling** | High | Rung 4, plus `--include-ignored` integration coverage, failure-path/concurrency tests, and a `code-critic` round |
+| 6 | **UI / API surface** — Svelte UIs, MCP tool schemas, HTTP routes | High | Rung 3 or 4 for the Rust side, plus the UI package's own test/build and one binary smoke run — with direct UI/API evidence, not just crate tests |
+
+The exact command chain for each rung, its development-proof step, and its
+hardening/release gate are in
+[docs/reference/test-ladder-baseline.md](docs/reference/test-ladder-baseline.md).
+Read that page's rung entry before running the gate, and paste the command you
+actually ran into the PR body.
 
 🔴 **`cargo test --workspace` is not the default inner-loop proof for a localized
 change.** It belongs at the hardening boundaries (rungs 4–6). Making every narrow
@@ -284,178 +232,68 @@ bespoke read-this-config / find-this-daemon / scrub-this-string logic: search fo
 existing entry point first (`git grep`, then trusty-common source tree) and extend it
 rather than duplicating. A second independent implementation of a shared capability is
 a defect, not a convenience — behavior fixes, security patches, and safety guardrails
-must land once, not N times, and silent drift between copies is a hidden risk. See the
-domain consolidation audit table below for 2026-07-11 baseline status. First enforcement
-instances: inference-adapter epic #2400, tmux common entry point #2398/PR #2399.
+must land once, not N times, and silent drift between copies is a hidden risk. Per-domain
+consolidation status is in
+[docs/reference/domain-consolidation-audit.md](docs/reference/domain-consolidation-audit.md).
 Scope: this rule governs capabilities shared ACROSS crates. Duplication of a
 capability WITHIN a single crate is not covered by it — consolidate that on
 its own merits when the drift has caused (or clearly will cause) a real
 defect, not by citing this rule (#4058 binary-name-table consolidation).
 
-🟡 **Rust editions** — `edition = "2024"` for `trusty-mpm`, `trusty-mpm-gui`, `trusty-agents`, `trusty-agents-common`, `trusty-agents-local`, and `trusty-code`
-(they use let-chains); `edition = "2021"` for all other crates. Check the crate
-`Cargo.toml` before assuming an edition.
-
-🟡 **No global state** — all helpers are free functions or small structs. No
-`lazy_static!` or `once_cell::sync::Lazy` except the tracing subscriber (which
-uses `try_init` to be idempotent across test binaries).
-
-🟡 **Logs to stderr** — `init_tracing` always writes to stderr so stdout stays
-clean for MCP JSON-RPC framing. Never log to stdout in a daemon or MCP server.
-
-🟡 **Ignore-tagged integration tests** — ONNX-backed embedder tests are marked
-`#[ignore]` to keep CI fast. Run with `cargo test -- --include-ignored` when
-you need local validation against the model.
-
-🟢 **Workspace dependency sharing** — all shared external crates (`anyhow`,
-`serde`, `tokio`, `axum`, etc.) are declared once in `[workspace.dependencies]`
-in the root `Cargo.toml` and referenced as `dep = { workspace = true }` in
-crate manifests. Never pin a dependency locally if it is already in the
-workspace table.
-
-🟢 **Internal path deps** — reference sibling crates as:
-```toml
-trusty-common = { workspace = true }
-```
-The workspace manifest declares the path so every member resolves from the
-in-tree source automatically. The `[patch.crates-io]` block in the root
-`Cargo.toml` also redirects any crates that still reference the old published
-versions by version number.
+The remaining 🟡/🟢 conventions — editions, global state, stderr logging,
+dependency declaration, and ignore-tagged tests — are one-liners in the
+"Common Pitfalls — Quick Checklist" below, with the reasoning in
+[docs/reference/common-pitfalls.md](docs/reference/common-pitfalls.md).
 
 ## Git Tag / Release Convention
 
-> **Full release workflow and macOS critical notes:** see [docs/reference/release-workflow.md](docs/reference/release-workflow.md).
+🔴 **Version bumps, tagging, and publishing are delegated to `local-ops`. The PM
+never edits a version file, cuts a tag, or runs `cargo publish` directly.**
 
-### Quick Release Steps
+Every crate versions and tags independently: `<crate-name>-v<version>`.
 
-1. Bump the crate version in `crates/<name>/Cargo.toml`.
-   - Shortcut: `scripts/bump-version.sh <crate-dir> <major|minor|patch>` reads the
-     current version, computes the next semver, edits the package version in
-     place, syncs the root `Cargo.lock` (`cargo update -p <package-name>
-     --precise <next-version>`, resolving `<package-name>` from the crate's
-     `[package] name` field so it works even when that differs from the
-     crates/ directory name, e.g. `tga`) so the release PR is `--locked`-clean
-     on the first CI run (issue #3199), assembles the crate's
-     `changelog.d/` fragments into a `## [<version>]` `CHANGELOG.md` section
-     (via `scripts/assemble-changelog.sh`, issue #4476), and **prints** the exact
-     `git tag` / `git push` commands for you to run. It never tags or pushes —
-     the human stays in the loop per the manual-tag convention. It honours the
-     `trusty-git-analytics` tag-prefix gotcha automatically (tags are
-     `trusty-git-analytics-v*`, not `tga-v*`).
-2. Update any dependent crates that pin that version.
-3. Run `cargo test -p <name>` and `cargo clippy --workspace -- -D warnings`.
-4. Commit the version bump.
-5. Create the tag: `git tag <crate-name>-v<version>`.
-6. Push the tag: `git push origin <crate-name>-v<version>`.
-7. Run `scripts/check-publish-ready.sh <crate>` (or `make publish-check CRATE=<crate>`) —
-   must pass (publish only from merged main; never an unmerged branch). See
-   issue #2227; escape hatch `ALLOW_UNMERGED_PUBLISH=1` is for rare, deliberate
-   use only.
-7b. Run `scripts/preflight-publish.sh <crate>` — must pass immediately before
-    `cargo publish`. Rule: **publish only from merged main, as bobmatnyc.**
-    Checks HEAD == origin/main exactly, the active `gh auth status` account is
-    `bobmatnyc`, the tree is clean, and the target version isn't already live
-    on crates.io. This closes the gap behind the 2026-07-08 incident, where a
-    crate was published from an unmerged branch under the wrong gh account and
-    burned crates.io version 0.22.0 with fix-less content.
-8. Publish: `cargo publish -p <crate-name>` (or `SKIP_UI_BUILD=1 cargo publish` for UI-embedding crates).
-9. Build and install: `cargo install --path crates/<dir> --locked`.
+Before any bump, tag, or publish, call `Skill(skill="cargo-publish")`. It carries
+the full release sequence, the mandatory publish-only-from-merged-main and
+identity/clean-tree guards (`scripts/check-publish-ready.sh`,
+`scripts/preflight-publish.sh`), cross-crate publish ordering and propagation
+waits, the `tga` tag aliases (#1128), and the connection-safe daemon restart.
 
-### Per-PR Changelog Fragment (framework default — issue #4476, supersedes the shared-`[Unreleased]` convention)
+> **Full release workflow, `scripts/bump-version.sh`, and Developer-ID signing
+> setup:** see [docs/reference/release-workflow.md](docs/reference/release-workflow.md).
+
+🔴 **CRITICAL macOS note:** never use `cp` to install a release binary on
+macOS — always `cargo install`. A plain `cp` over an on-PATH binary leaves a
+stale kernel cdhash cache and the next exec is SIGKILL'd as an invalid
+signature, which looks exactly like an OOM kill.
+
+🟢 **macOS TCC scope split — read before re-granting anything:** `trusty-search`
+(and other external-volume daemons) needs **Full Disk Access**; `trusty-mpm` /
+`tm` needs the separate **App Data** category only, and must never be granted
+Full Disk Access. Every `cargo install` mints a new cdhash and voids the
+previous grant; `tctl install <crate>` re-signs with a stable Developer-ID
+identity so the grant survives reinstalls. Certificate setup, signed-install
+scripts, the `launchctl bootout` restart playbook, and orphan-listener
+verification (#873, #2558, #534, #2486, #4230) are in the release-workflow
+reference above.
+
+### Per-PR Changelog Fragment (issue #4476)
 
 🔴 **Every PR that touches a crate's `src/**` adds a changelog FRAGMENT file to
-that crate, in the same PR. Never edit a crate's `CHANGELOG.md` by hand.**
+that crate, in the same PR. Never edit a crate's `CHANGELOG.md` by hand.** A PR
+that changes crate source and lands with no fragment is a **review-gate
+failure** — the same tier as a failing `cargo test` / `cargo clippy` gate — and
+also a CI failure (`scripts/check_changelog_fragment.sh`). No "trivial change"
+exception. Docs-only, CI-only, test-only and `testdata/` PRs may skip it.
 
 ```
 crates/<crate>/changelog.d/<issue-or-pr-number>-<short-slug>.md
 ```
 
-```
-Fixed
-
-- pm_guard no longer scans quoted content (closes [#2741](https://github.com/bobmatnyc/trusty-tools/issues/2741))
-  - indented sub-bullets are preserved verbatim
-```
-
-- **Line 1 is the category:** `Breaking` | `Added` | `Fixed` | `Performance` |
-  `Changed` | `Removed` | `Security` | `Documentation` (the same groups the
-  changelogs already use).
-- **Everything after it is the bullet text**, copied through verbatim. Match the
-  crate CHANGELOG's existing style.
-- **One fragment carries ONE category.** Stacking several into one file — a bare
-  `Changed` line below a `Removed` line 1 — is rejected by the assembler and the
-  CI gate, because "verbatim" means the second category would render as body
-  text under the first one's heading. That shipped once (the 1.3.3
-  `4286-retire-trusty-mpm-override-files.md` fragment put four categories under
-  `### Removed`). Split it: same number, different slug. The heading form
-  (`## Changed`) counts as a second category too; anything inside a code fence
-  does not, so a fragment may show example output freely.
-- **The file must sit directly in `changelog.d/`.** A nested one (`changelog.d/sub/…`)
-  is rejected at release time; `changelog.d/README.md` is the tracked directory
-  placeholder and is never treated as a fragment.
-- **Preview what the next release will say:**
-  `bash scripts/assemble-changelog.sh <crate-dir> --stdout`.
-- **The filename's leading number is what makes this collision-free.** Two
-  concurrent PRs add two differently-named files, so git never sees a conflict.
-  That is the entire point: on 2026-07-31 five concurrent trusty-mpm PRs
-  (#4463–#4475) each wrote a bullet into the shared `## [Unreleased]` section and
-  every merge forced the next PR to rebase and hand-resolve it (#4399 burned
-  three such rounds).
-- Docs-only, CI-only, test-only and `testdata/` PRs may skip this step. A PR that changes
-  crate source and lands with no fragment is a **review-gate failure**, the same
-  tier as a failing `cargo test`/`cargo clippy` gate — and it is now also a CI
-  failure (`.github/workflows/changelog-fragment.yml` →
-  `scripts/check_changelog_fragment.sh`). No "trivial change" exception.
-
-**Fragments are the source of truth for the unreleased set.** `CHANGELOG.md`
-carries released version sections only — no `## [Unreleased]` heading between
-releases. At release time `scripts/bump-version.sh` calls
-`scripts/assemble-changelog.sh <crate-dir> <version>`, which groups the crate's
-fragments by category, writes one `## [<version>] — <date>` section, and deletes
-the consumed fragments in the same operation. Preview the pending set any time
-with `scripts/assemble-changelog.sh <crate-dir> --stdout`.
-
-**git-cliff no longer touches `CHANGELOG.md`.** `scripts/generate-changelog.sh`
-is deleted; it ran `git cliff --unreleased --prepend`, which blindly stacked a
-fresh `## [Unreleased]` on top of the hand-written one — the defect #2793 tracks
-and the reason `bump-version.sh` used to carry a duplicate-heading stopgap. Both
-are gone: there is exactly ONE mechanism that writes a crate changelog, and it
-is the assembler. `cliff.toml` stays, scoped to rendering the **GitHub Release
-body** in `.github/workflows/release.yml` (`--latest --strip all`), which never
-writes `CHANGELOG.md`.
-
-Transitional note: PRs opened before #4476 landed wrote into the shared
-`## [Unreleased]` section and were not converted. The gate accepts a
-`CHANGELOG.md` edit as evidence so they stay green, and the assembler refuses to
-run while a leftover `## [Unreleased]` heading survives — fold those bullets into
-the section being cut at the next release of that crate.
-
-🟢 **`tga` tag aliases (issue #1128):** `trusty-git-analytics` publishes to
-crates.io under the short package name `tga`. The binary-release workflow
-(`.github/workflows/release.yml`) accepts **both** tag forms — `tga-v<version>`
-and `trusty-git-analytics-v<version>` — and they resolve to the **same** build
-config (CARGO_PKG=`tga`, binary `tga`) and the same Homebrew formula. The parse
-step canonicalizes the `tga` prefix to `trusty-git-analytics` for the config map,
-the homebrew-bump job, and changelog path scoping, while the changelog
-`--tag-pattern` keys off the literal pushed tag so release notes match either
-form. Use whichever you prefer; the documented `<crate-name>-v<version>`
-convention (i.e. `tga-v<version>`, matching the abbreviation table) works.
-
-🔴 **CRITICAL macOS note:** Never use `cp` to install release binaries on macOS — always use `cargo install`. See release workflow reference for the detailed explanation.
-
-### macOS TCC (Full Disk Access / App Data) and daemon restart (issues #873, #2558, #534)
-
-🟢 **Scope split — read before re-granting anything:** `trusty-search` (and
-other external-volume daemons) needs **Full Disk Access**; `trusty-mpm` / `tm`
-needs the separate **App Data** TCC category only — it never needs, and should
-never be granted, Full Disk Access. Every `cargo install` mints a new cdhash,
-invalidating the previous grant; `tctl install <crate>` re-signs with a stable
-Developer-ID identity so the grant persists across reinstalls.
-
-See [docs/reference/release-workflow.md](docs/reference/release-workflow.md)
-for certificate setup, signed-install scripts, the restart playbook
-(`launchctl bootout`, never `cp`, never trust a bare `GET /health`), and
-orphan-listener verification (issues #2486, #4230).
+Before opening a PR, call `Skill(skill="tm-pr-workflow")` for the fragment
+format and the category line. This repo's assembler and CI-gate specifics — one
+category per fragment, fragments directly in `changelog.d/`, the `--stdout`
+preview, and why git-cliff no longer writes `CHANGELOG.md` — are in
+[docs/reference/changelog-fragments.md](docs/reference/changelog-fragments.md).
 
 ## Cross-Crate Development Workflow
 
@@ -631,14 +469,18 @@ Quick: `RUST_LOG=info cargo run -p trusty-search -- start` (daemon), `cargo run 
 For extended explanations, see [docs/reference/common-pitfalls.md](docs/reference/common-pitfalls.md).
 
 - **Library error handling:** use `thiserror`, not `unwrap()` in libraries
-- **Daemon stdout:** never log to stdout in daemons or MCP servers
+- **Daemon stdout:** never log to stdout in daemons or MCP servers — `init_tracing` writes to stderr so stdout stays clean for MCP JSON-RPC framing
 - **Axum in libraries:** gate behind `axum-server` feature flag
 - **Shared crate changes:** always run `cargo check` + tests for all dependents
 - **SLOC cap:** respect 500/3000 SLOC limits (prod/test); use `bash scripts/check_line_cap.sh`
 - **UI build:** install pnpm or set `SKIP_UI_BUILD=1` before `cargo build`
 - **Patch tables:** put all `[patch.crates-io]` in root `Cargo.toml` only
+- **Workspace deps:** shared external crates are declared once in `[workspace.dependencies]` and referenced as `dep = { workspace = true }` — never pin locally if already in the workspace table
+- **Internal deps:** reference sibling crates as `trusty-common = { workspace = true }`; the workspace manifest owns the path, so every member resolves from in-tree source
+- **No global state:** helpers are free functions or small structs — no `lazy_static!` / `once_cell::sync::Lazy` except the tracing subscriber, which uses `try_init` to stay idempotent across test binaries
 - **MSRV drift:** prefer stable channel toolchains; don't break `rust-version = "1.94"`
-- **Edition mismatch:** 2024 crates (mpm, agents, mpm-gui, agents-common, agents-local) may use let-chains; 2021 crates cannot
+- **Edition mismatch:** the workspace *default* is edition 2024 (`edition.workspace = true`); 11 crates pin `edition = "2021"` explicitly. Let-chains (`if let … && let …`) only compile in 2024 — read the crate's `Cargo.toml` before copying one in
+- **Ignored tests:** ONNX-backed embedder tests are `#[ignore]`d so CI stays fast; they need `cargo test -- --include-ignored` to run at all
 
 ## Reference Documentation
 
@@ -655,22 +497,6 @@ Full-length reference materials for less-frequent lookups:
 - **Running MCP servers (examples & wiring):** [docs/reference/running-mcp-servers.md](docs/reference/running-mcp-servers.md)
 - **Spec-Linked Documentation (SLD) policy:** [DOC-38](docs/specs/spec-linked-documentation.md) — the standard for declaring source↔spec references; enforced by `scripts/check_sld.sh`.
 - **HTTP trust-boundary threat model:** [docs/reference/threat-model.md](docs/reference/threat-model.md) — per-daemon bind/guard/proxy compliance inventory for the loopback-only doctrine ([ADR-0018](docs/adr/0018-loopback-only-doctrine.md)).
-
-## Domain Consolidation Audit
-
-**Baseline audit 2026-07-11** (session d72fb4a3-f9ff-4394-b148-8200d17a2d5a). Update verdicts
-as consolidations land. Reference: common-entry-point principle above.
-
-| Domain | Verdict | Scale | Status |
-|--------|---------|-------|--------|
-| HTTP clients (reqwest) | FRAGMENTED | 150+ builder sites incl. 20+ inside trusty-common | backlog |
-| git invocations | FRAGMENTED | ~90 production spawn sites, 7 crates | backlog (after tmux pattern proves) |
-| Shared env-var access | FRAGMENTED | OPENROUTER_API_KEY ×22 files/8 crates; GITHUB_TOKEN ×13/6 | partially covered by epic #2400 (#2401) |
-| gh CLI | FRAGMENTED | 3 wrappers (trusty-agents ticketing/gh_cli most complete) | backlog |
-| Config-file loading | FRAGMENTED | 5 implementations (2 pairs within single crates) | backlog |
-| Secret redaction | FRAGMENTED (security) | 4 rule sets (3 inside trusty-mpm) | partially covered by #2401 redact_secret |
-| launchctl | SCATTERED | shared LaunchdConfig exists; 9 bypass sites/4 crates | backlog |
-| Daemon addr discovery | SCATTERED | common resolver exists; 3 daemons re-implement | backlog |
-| Daemon PID discovery | FRAGMENTED | 3 copy-pasted find_daemon_pids() | backlog |
-| tmux (trusty-mpm) | SCATTERED→fixing | 19 sites | in flight: #2398/PR #2399 |
-| LLM inference | FRAGMENTED→fixing | 6 bespoke clients | epic #2400 |
+- **Domain consolidation audit:** [docs/reference/domain-consolidation-audit.md](docs/reference/domain-consolidation-audit.md) — dated per-domain status behind the common-entry-point rule.
+- **Per-PR changelog fragments:** [docs/reference/changelog-fragments.md](docs/reference/changelog-fragments.md) — assembler and CI-gate mechanics.
+- **Rust test ladder gate commands:** [docs/reference/test-ladder-baseline.md](docs/reference/test-ladder-baseline.md) — the exact command chain per rung, plus the baseline-failure protocol.

--- a/crates/trusty-mpm/changelog.d/4968-tm-pr-workflow-description.md
+++ b/crates/trusty-mpm/changelog.d/4968-tm-pr-workflow-description.md
@@ -1,0 +1,5 @@
+Changed
+
+- `tm-pr-workflow`'s frontmatter description now names the per-PR changelog fragment requirement, so a relevance match can load the skill instead of only an explicit pointer reaching it ([#4968](https://github.com/bobmatnyc/trusty-tools/pull/4968))
+  - the description previously covered only branch protection, the trusty-review gate, squash-merge, and worktree discipline, so an agent searching for the `changelog.d` fragment format never matched the one skill that documents it
+  - `tm-capabilities`' generated skill catalog is regenerated to match

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/skills.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/skills.md
@@ -43,7 +43,7 @@ Generated from the bundled `framework-manifest.toml`'s `[skill_categories]` rost
 | `tm-init` | pm-workflow | yes | Initialize or intelligently refresh a project for trusty-mpm — analyze the repo and scaffold or update CLAUDE.md (project instructions), register the project with the daemon, and offer update/context/catchup modes |
 | `tm-issues-prune` | pm-workflow | yes | Prune, organize, prioritize, and suggest next tasks from a project's GitHub issue backlog — natural-language PM delegation pattern (gh-first, JIRA deferred) |
 | `tm-postmortem` | pm-workflow | yes | Analyze session errors captured across trusty-* daemons and route them through the bug-reporting pipeline |
-| `tm-pr-workflow` | pm-workflow | no | Branch protection, trusty-review gate, squash-merge, and worktree discipline for landing work on main |
+| `tm-pr-workflow` | pm-workflow | no | Branch protection, per-PR changelog fragment requirement (changelog.d file format and category line), trusty-review merge gate, squash-merge, and worktree discipline for landing work on main |
 | `tm-session-management` | pm-workflow | yes | PM context-limit pause/resume, project-local session snapshots, worktree pruning, and task-list integration |
 | `tm-session-pause` | pm-workflow | yes | Pause the current PM session — snapshot todos, git state, and context to a project-local session file, prune stale worktrees, and print the resume path |
 | `tm-session-resume` | pm-workflow | yes | Resume from a paused PM session — scan project-local snapshots, validate the project matches, load the latest (or a selected) session, and restore todos and context |

--- a/crates/trusty-mpm/src/assets/skills/tm-pr-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-pr-workflow.md
@@ -1,6 +1,6 @@
 ---
 name: tm-pr-workflow
-description: Branch protection, trusty-review gate, squash-merge, and worktree discipline for landing work on main
+description: Branch protection, per-PR changelog fragment requirement (changelog.d file format and category line), trusty-review merge gate, squash-merge, and worktree discipline for landing work on main
 user-invocable: false
 version: "1.0.0"
 category: pm-workflow

--- a/crates/trusty-mpm/src/core/bundle_tm_skills.rs
+++ b/crates/trusty-mpm/src/core/bundle_tm_skills.rs
@@ -118,7 +118,8 @@ pub const TM_TEACHING_TEMPLATES: &str = include_str!("../assets/skills/tm-teachi
 /// Test: `tm_skills_are_in_bundle`.
 pub const TM_TICKETING: &str = include_str!("../assets/skills/tm-ticketing.md");
 
-/// Branch protection, trusty-review gate, squash-merge, worktree discipline.
+/// Branch protection, changelog fragments, trusty-review gate, squash-merge,
+/// worktree discipline.
 ///
 /// Why: SLIM per the portfolio design — native Claude Code already knows
 /// basic `gh pr create` mechanics; this keeps only the tm-specific layer.

--- a/docs/reference/changelog-fragments.md
+++ b/docs/reference/changelog-fragments.md
@@ -1,0 +1,90 @@
+# Per-PR Changelog Fragments — Repo Mechanics
+
+> **The requirement ("every PR touching a crate's `src/**` adds a fragment") is
+> in [`CLAUDE.md`](../../CLAUDE.md)**, and the fragment file format is in the
+> `tm-pr-workflow` skill — call `Skill(skill="tm-pr-workflow")` for it. This
+> page is the trusty-tools-specific assembler and CI-gate detail: consult it
+> when writing a fragment or debugging a rejected one.
+
+Introduced by issue #4476, superseding the shared-`## [Unreleased]` convention.
+
+## File Location and Name
+
+```
+crates/<crate>/changelog.d/<issue-or-pr-number>-<short-slug>.md
+```
+
+```
+Fixed
+
+- pm_guard no longer scans quoted content (closes [#2741](https://github.com/bobmatnyc/trusty-tools/issues/2741))
+  - indented sub-bullets are preserved verbatim
+```
+
+- **Line 1 is the category:** `Breaking` | `Added` | `Fixed` | `Performance` |
+  `Changed` | `Removed` | `Security` | `Documentation` (the same groups the
+  changelogs already use).
+- **Everything after it is the bullet text**, copied through verbatim. Match the
+  crate CHANGELOG's existing style.
+- **The file must sit directly in `changelog.d/`.** A nested one
+  (`changelog.d/sub/…`) is rejected at release time; `changelog.d/README.md` is
+  the tracked directory placeholder and is never treated as a fragment.
+- **The filename's leading number is what makes this collision-free.** Two
+  concurrent PRs add two differently-named files, so git never sees a conflict.
+  That is the entire point: on 2026-07-31 five concurrent trusty-mpm PRs
+  (#4463–#4475) each wrote a bullet into the shared `## [Unreleased]` section and
+  every merge forced the next PR to rebase and hand-resolve it (#4399 burned
+  three such rounds).
+
+## One Fragment Carries One Category
+
+Stacking several into one file — a bare `Changed` line below a `Removed` line 1
+— is rejected by the assembler and the CI gate, because "verbatim" means the
+second category would render as body text under the first one's heading. That
+shipped once (the 1.3.3 `4286-retire-trusty-mpm-override-files.md` fragment put
+four categories under `### Removed`). Split it: same number, different slug.
+
+The heading form (`## Changed`) counts as a second category too; anything inside
+a code fence does not, so a fragment may show example output freely.
+
+## Preview the Pending Set
+
+```bash
+bash scripts/assemble-changelog.sh <crate-dir> --stdout
+```
+
+## Fragments Are the Source of Truth
+
+`CHANGELOG.md` carries released version sections only — no `## [Unreleased]`
+heading between releases. At release time `scripts/bump-version.sh` calls
+`scripts/assemble-changelog.sh <crate-dir> <version>`, which groups the crate's
+fragments by category, writes one `## [<version>] — <date>` section, and deletes
+the consumed fragments in the same operation.
+
+## git-cliff No Longer Touches `CHANGELOG.md`
+
+`scripts/generate-changelog.sh` is deleted; it ran `git cliff --unreleased
+--prepend`, which blindly stacked a fresh `## [Unreleased]` on top of the
+hand-written one — the defect #2793 tracks and the reason `bump-version.sh` used
+to carry a duplicate-heading stopgap. Both are gone: there is exactly ONE
+mechanism that writes a crate changelog, and it is the assembler. `cliff.toml`
+stays, scoped to rendering the **GitHub Release body** in
+`.github/workflows/release.yml` (`--latest --strip all`), which never writes
+`CHANGELOG.md`.
+
+## Enforcement
+
+A PR that changes crate source and lands with no fragment is a **review-gate
+failure**, the same tier as a failing `cargo test` / `cargo clippy` gate — and it
+is also a CI failure (`.github/workflows/changelog-fragment.yml` →
+`scripts/check_changelog_fragment.sh`). No "trivial change" exception.
+
+Docs-only, CI-only, test-only and `testdata/` PRs may skip the fragment.
+
+## Transitional Note
+
+PRs opened before #4476 landed wrote into the shared `## [Unreleased]` section
+and were not converted. The gate accepts a `CHANGELOG.md` edit as evidence so
+they stay green, and the assembler refuses to run while a leftover
+`## [Unreleased]` heading survives — fold those bullets into the section being
+cut at the next release of that crate.

--- a/docs/reference/common-pitfalls.md
+++ b/docs/reference/common-pitfalls.md
@@ -7,8 +7,8 @@ implementation is a defect: fixes land N times, security patches miss copies, an
 silent behavioral drift emerges. Before writing `Command::new(...)`, `reqwest::Client`,
 `std::env::var()` for a concern used in multiple crates, search for an existing
 entry point (`git grep`, then trusty-common source tree) and extend it. See the
-common-entry-point principle and domain consolidation audit in
-[CLAUDE.md](../../CLAUDE.md).
+common-entry-point principle in [CLAUDE.md](../../CLAUDE.md) and the per-domain
+status in [domain-consolidation-audit.md](domain-consolidation-audit.md).
 
 🔴 **Using `unwrap()` in library crates** — the compiler does not stop you, but
 it violates the project's hard rule. Use `?` with `thiserror` error types in

--- a/docs/reference/domain-consolidation-audit.md
+++ b/docs/reference/domain-consolidation-audit.md
@@ -1,0 +1,26 @@
+# Domain Consolidation Audit
+
+> **The common-entry-point RULE is in [`CLAUDE.md`](../../CLAUDE.md)** (Key
+> Conventions) and binds every change. This page is the dated status data behind
+> it — consult it when you want to know whether a given domain has already been
+> consolidated, not to decide whether the rule applies.
+
+**Baseline audit 2026-07-11** (session d72fb4a3-f9ff-4394-b148-8200d17a2d5a). Update verdicts
+as consolidations land. Reference: common-entry-point principle above.
+
+| Domain | Verdict | Scale | Status |
+|--------|---------|-------|--------|
+| HTTP clients (reqwest) | FRAGMENTED | 150+ builder sites incl. 20+ inside trusty-common | backlog |
+| git invocations | FRAGMENTED | ~90 production spawn sites, 7 crates | backlog (after tmux pattern proves) |
+| Shared env-var access | FRAGMENTED | OPENROUTER_API_KEY ×22 files/8 crates; GITHUB_TOKEN ×13/6 | partially covered by epic #2400 (#2401) |
+| gh CLI | FRAGMENTED | 3 wrappers (trusty-agents ticketing/gh_cli most complete) | backlog |
+| Config-file loading | FRAGMENTED | 5 implementations (2 pairs within single crates) | backlog |
+| Secret redaction | FRAGMENTED (security) | 4 rule sets (3 inside trusty-mpm) | partially covered by #2401 redact_secret |
+| launchctl | SCATTERED | shared LaunchdConfig exists; 9 bypass sites/4 crates | backlog |
+| Daemon addr discovery | SCATTERED | common resolver exists; 3 daemons re-implement | backlog |
+| Daemon PID discovery | FRAGMENTED | 3 copy-pasted find_daemon_pids() | backlog |
+| tmux (trusty-mpm) | SCATTERED→fixing | 19 sites | in flight: #2398/PR #2399 |
+| LLM inference | FRAGMENTED→fixing | 6 bespoke clients | epic #2400 |
+
+First enforcement instances: inference-adapter epic #2400, tmux common entry
+point #2398/PR #2399.

--- a/docs/reference/test-ladder-baseline.md
+++ b/docs/reference/test-ladder-baseline.md
@@ -1,15 +1,33 @@
-# Rust Test Ladder — Baseline-Failure Protocol
+# Rust Test Ladder — Gate Commands and Baseline-Failure Protocol
 
-> **The ladder table, the rung selection rule, and "never make a red gate
-> green by deleting coverage" live in
-> [`CLAUDE.md`](../../CLAUDE.md)** (Rust Test Ladder). This page is the Rust-specific detail for
-> telling a pre-existing red from one your branch caused — consult it while
-> triaging a failing gate, not to decide which rung to run.
+> **Which rung a change lands on — the change classes, the risk labels, and
+> "never make a red gate green by deleting coverage" — is decided in
+> [`CLAUDE.md`](../../CLAUDE.md)** (Rust Test Ladder). Choose the rung there,
+> then come here for the exact command to run and for triaging a red gate.
 
 The six-step baseline-failure protocol (establish whose red it is, fix if
 branch-caused, append to the canonical issue if tracked, one canonical issue if
 not, and the literal report string) lives in `tm-pr-workflow`. It is **not**
 restated here. What follows is only what that generic version cannot carry.
+
+## Per-Rung Gate Commands
+
+Run the smallest deterministic gate that covers the change's blast radius. Paste
+the command you actually ran into the PR body so a reviewer can see which rung
+was exercised.
+
+| # | Development proof | PR gate — the command to run | Hardening / release gate |
+|---|---|---|---|
+| 1 | Read the rendered file | `bash scripts/check_sld.sh` (plus `check_doc_numbers.sh` / `check_line_cap.sh` if those surfaces were touched). No Cargo test by default. | CI required checks only |
+| 2 | Fail-before / pass-after, repeated: `cargo test -p <crate> <test> -- --exact --nocapture` run ~10× | `cargo fmt --check` && `cargo test -p <crate>`; add `-- --test-threads=1` when the flake is isolation-shaped | `cargo test --workspace` **only** when shared test infrastructure changed |
+| 3 | One targeted regression test that provably fails before the change | `cargo fmt --check` && `cargo check -p <crate>` && `cargo clippy -p <crate> -- -D warnings` && `cargo test -p <crate>` | Workspace gate only when release policy requires it |
+| 4 | Targeted regression plus `cargo test -p <lib>` | rung 3 for the library, then `cargo check --workspace` && `cargo test -p <consumer>` for **each direct dependent** | `cargo test --workspace` && `cargo clippy --workspace --all-targets -- -D warnings` at HARDEN/release |
+| 5 | Targeted plus failure-path and concurrency tests | rung 4, plus `cargo test -p <crate> -- --include-ignored` for gated integration coverage, plus an adversarial review round (`code-critic`) | full workspace, `cargo audit`, and for release tooling `scripts/check-publish-ready.sh <crate>` && `scripts/preflight-publish.sh <crate>` |
+| 6 | Rust crate tests **plus** direct UI/API evidence (curl the route, call the MCP tool, load the page) | rung 3 or 4 for the Rust side, plus `pnpm -C crates/<crate>/ui test` (where the package defines one; otherwise `… build`) and one smoke run of the binary | full product/e2e gate plus `cargo test -- --include-ignored` when hardening |
+
+Why `cargo test --workspace` is absent from rungs 1–3, and the "scope down,
+never scope away" line that constrains picking a lower rung, are stated with the
+ladder itself in [`CLAUDE.md`](../../CLAUDE.md) — not repeated here.
 
 ## Known-Environmental On This Machine — Expect These, Do Not Re-File Them
 


### PR DESCRIPTION
## Rule being applied

Owner's framework rule, verbatim: **"any instruction not needed for EACH prompt should be moved to a skill and referenced."** Owner explicitly authorized these cuts.

**Size: 38,034 → 29,602 chars (−8,432, −22%).**

## What moved, and where

| Cut | Moved to | Verified against |
|---|---|---|
| Per-PR changelog fragment mechanics | `tm-pr-workflow` + new `docs/reference/changelog-fragments.md` | Skill's "Changelog Requirement (Before Merge)" |
| Release convention, Quick Release Steps, macOS TCC/daemon restart | `cargo-publish` + `docs/reference/release-workflow.md` | Skill's "Git Tag / Release Convention (from CLAUDE.md)", "macOS cdhash Trap", "Connection-Safe Daemon Restart" |
| Domain Consolidation Audit table | new `docs/reference/domain-consolidation-audit.md` | Dated data, no behavioral rule depends on it |
| 🟡/🟢 Key Conventions subset | "Common Pitfalls — Quick Checklist" | See correction below |
| Test-ladder per-rung command chains | `docs/reference/test-ladder-baseline.md` | Decision columns stay resident |
| Exhaustive cargo variants | new `.claude/skills/cargo-commands/SKILL.md` | Five everyday one-liners stay resident |

## Factual correction: the edition rule was wrong for more than half the workspace

This is a **behavioral fix, not formatting**, and easy to miss in a docs diff. Anyone who trusted this list to decide whether let-chains were available was misled.

**Before** — CLAUDE.md claimed six edition-2024 crates:

> `edition = "2024"` for `trusty-mpm`, `trusty-mpm-gui`, `trusty-agents`, `trusty-agents-common`, `trusty-agents-local`, and `trusty-code` (they use let-chains); `edition = "2021"` for all other crates.

**Actual state**, verified by reading every `crates/*/Cargo.toml`:

- `[workspace.package] edition = "2024"` is the **workspace default**. The "2021 for all other crates" half was backwards.
- **16 crates are edition 2024**, not 6. Seven inherit it via `edition.workspace = true` (`trusty-mpm`, `trusty-agents-common`, `trusty-common`, `tc-services`, `trusty-cto-db`, `trusty-publish-guard`, `trusty-tui`); nine pin it explicitly.
- **11 crates pin `edition = "2021"`** explicitly: `trusty-analyze`, `trusty-bm25-daemon`, `trusty-channels`, `trusty-embedderd`, `trusty-embedderd-py`, `trusty-git-analytics`, `trusty-installer`, `trusty-memory`, `trusty-progress`, `trusty-search`, `trusty-sld-lint`.
- **Five edition-2024 crates were missing from the list entirely**: `trusty-code-gui`, `trusty-kb`, `trusty-gworkspace`, `trusty-console`, `trusty-review`.
- `trusty-mpm` and `trusty-agents-common` were listed as if hand-pinned; both actually inherit.

**After** — replaced the enumeration with default-plus-exceptions framing, which cannot go stale as crates are added:

> the workspace *default* is edition 2024 (`edition.workspace = true`); 11 crates pin `edition = "2021"` explicitly. Let-chains (`if let … && let …`) only compile in 2024 — read the crate's `Cargo.toml` before copying one in

## Two places the redundancy assumption was wrong

Re-verification found content that would have been **lost**, so it was preserved rather than dropped.

**1. Only 2 of 6 🟡/🟢 conventions were actually covered by the checklist.** Covered: stderr logging, editions (partially). *Not* covered anywhere — global state, workspace dependency sharing, internal path deps, ignore-tagged tests. The checklist gained one-liners for each; ignored-tests also went into `cargo-commands`.

**2. `tm-pr-workflow` does not carry the repo-specific changelog detail** — one-category-per-fragment, fragments directly in `changelog.d/`, `assemble-changelog.sh --stdout`, the CI gate name, or the git-cliff history. That landed in `docs/reference/changelog-fragments.md`.

## Follow-up in this PR: `tm-pr-workflow`'s description now fires on relevance

Its frontmatter description never mentioned the changelog, so an agent searching for the fragment format could not match the one skill documenting it — the skill loaded only when something named it explicitly. Same failure mode this branch exists to fix.

- **Before:** `Branch protection, trusty-review gate, squash-merge, and worktree discipline for landing work on main`
- **After:** `Branch protection, per-PR changelog fragment requirement (changelog.d file format and category line), trusty-review merge gate, squash-merge, and worktree discipline for landing work on main`

`user-invocable: false` is left alone — it governs whether a human can type `/tm-pr-workflow`, which is a separate decision from model-side loading.

**The description feeds a generated artifact.** `crates/trusty-mpm/src/bin/tm/generate/skills.rs` renders `tm-capabilities/references/skills.md` from this frontmatter, and `scripts/check_capabilities.sh` drift-gates it. Regenerated via `tm generate capabilities`; one line changed. The `bundle_tm_skills.rs` doc comment was updated to match.

## Changelog status — corrected

The earlier version of this body claimed a docs-only exemption. **That is no longer true.** `tm-pr-workflow`'s source is `crates/trusty-mpm/src/assets/skills/tm-pr-workflow.md` — under `crates/trusty-mpm/src/**` and embedded via `include_str!`, so it is a bundled framework skill, not a deployed copy. A fragment is required and is included: `crates/trusty-mpm/changelog.d/4968-tm-pr-workflow-description.md`.

The CLAUDE.md and `docs/reference/` half of this PR remains docs-only; the fragment covers the `trusty-mpm` source change.

## Kept resident (per the same rule)

- Abbreviations & Aliases table — **byte-identical**, verified by hash.
- Parallel Worktree Discipline in full — **byte-identical**, verified by hash.
- Development Environment pointers — **byte-identical**, verified by hash.
- Every 🔴 Key Convention: no `unwrap()` in library code, thiserror-vs-anyhow, SLOC dual cap, common-entry-point rule, Why/What/Test doc pattern.

## Pointer style

Every pointer names the call as an instruction — `Before opening a PR, call \`Skill(skill="tm-pr-workflow")\`…`. Zero bare `[SKILL: name]` brackets (grepped: none). Three such pointers: `cargo-commands`, `cargo-publish`, `tm-pr-workflow`.

## Gates

```
check_sld          EXIT=0
check_line_cap     EXIT=0
check_doc_numbers  EXIT=0
check_capabilities EXIT=0
cargo fmt --check  EXIT=0
```

`cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean (exit 0; the only `warning:` lines in the log are pre-existing cargo manifest notices about `main.rs` in multiple build targets and a future-incompat `proc-macro-error2` dep, not lints).

`cargo test -p trusty-mpm -- --test-threads=1` → `SERIAL_TEST_EXIT=0`:

```
test result: ok. 4636 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 208.13s
test result: ok. 1480 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 22.95s
test result: ok. 1480 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 20.33s
```

### Baseline / flake notes — full disclosure

Three distinct isolation-shaped flakes surfaced across runs on this machine. **None is branch-caused**, and none was suppressed: no `#[ignore]`, no `cfg`-gate, no `--exclude`, no `--lib` narrowing. `--test-threads=1` is the remedy this repo's own `docs/reference/test-ladder-baseline.md` prescribes for them, and it runs coverage *more* strictly, not less.

A pre-edit baseline run on clean `origin/main` was already red:

```
test result: FAILED. 4634 passed; 2 failed; 7 ignored; 0 measured; 0 filtered out; finished in 109.13s
    client::executor::tests::execute_doctor_against_test_daemon
    core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning
```

- `execute_doctor_against_test_daemon` — already in the known-environmental table (9–13 s against a 10 s client timeout).
- `ensure_managed_config_dir_emits_the_frozen_skill_warning` — failed with `Captured lines: []`, a process-global `tracing` interest-cache race, not a missing warning. It is `TempDir`-isolated and cannot see this repo's `.claude/skills/`, so the new `cargo-commands` skill cannot reach it. Isolation: `test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4642 filtered out`.
- `stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet` — failed once in a parallel run on this branch. Already in the known-environmental table verbatim (`$HOME`-mutation race, "fails 3 of 5 runs on a clean baseline worktree with no branch changes"). Isolation: `test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4642 filtered out`.

A parallel run on this branch also went fully green once — `GATE_EXIT=0`, `4636 passed; 0 failed` — which is itself the signature of a flake rather than a regression.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools