### PR TITLE
refactor(trusty-mpm): move per-prompt-unnecessary PM instructions into skills

### DIFF
--- a/crates/trusty-mpm/changelog.d/4969-instruction-redundancy-per-prompt-rule.md
+++ b/crates/trusty-mpm/changelog.d/4969-instruction-redundancy-per-prompt-rule.md
@@ -1,0 +1,8 @@
+Changed
+
+- PM prompt: moved instructions not needed on every prompt into the skills that already held them, shrinking the compiled prompt 60,243 → 56,783 bytes (−5.7%) ([#4969](https://github.com/bobmatnyc/trusty-tools/pull/4969))
+  - the QA evidence table, QA-target routing table and forbidden-phrase list are stated once, in `tm-verification-protocols`; `core` keeps the gate trigger and `workflow`'s third copy is gone
+  - PM identity is stated once in `core`; the `identity` section keeps only its own tm-session context
+  - the attribution footer is stated once in Framework-Guaranteed Conventions; `workflow`'s inline copy is gone
+  - parked-subagent re-engagement MECHANICS moved to `tm-delegation-patterns`' new "PM Re-Engagement" section, whose frontmatter description now names the CI-wait / parked-agent trigger so it can fire on its own; `core` keeps the trigger
+  - every skill pointer now reads as an instruction naming the `Skill(...)` call. Bare `[SKILL: name]` notation is documentation style, not a tool call, which is how a pointer and a re-inlined copy of its target came to sit side by side; a test forbids the notation from returning

--- a/crates/trusty-mpm/src/assets/instructions/sections/core.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/core.md
@@ -134,38 +134,16 @@ When delegated work fails (build error, test failure, lint issue):
 
 Agents do NOT block on CI. A delegated agent pushes, takes a one-shot status read
 (`gh pr view` / `gh pr checks`, never `--watch`), reports, and ends its turn —
-that is correct, expected behavior, not a park. **Re-engagement is YOUR job.**
-Blocking waits were retired for context cost: `--watch` streams check output for
-the whole run, and one engineer burned 546k tokens over 54 minutes on a single
-PR. Do not nudge an agent back into a blocking wait, and do not restore that
-advice anywhere.
+that is correct behavior, not a park. **Re-engagement is YOUR job**, and nothing
+wakes a stopped agent, so an agent you never re-engage is work abandoned.
 
-**When an agent hands back with CI pending**, own the gap yourself: re-read the
-status when the run should have settled and `SendMessage` the SAME agent (never a
-fresh delegation — zero context reload) with the outcome, either the merge
-go-ahead or the failing check output. Treat `bucket` as advisory — under GitHub
-API eventual-consistency lag it can report a false DONE, so cross-check `state`
-before telling an agent the PR is green.
-
-If you monitor the gap with a `Monitor`, size the interval to the known CI
-wall-clock (5-minute-plus for a ~15-min run), message only on state change, and
-run a one-shot `gh run view <run-id>` if it overruns. Do NOT tight-poll:
-never a 30-second blind poll (that is the spam counter-failure, #2833).
-Disarm the monitor the moment checks settle.
-
-**A genuine park still exists and is still yours to catch:** a subagent returns
-with its goal unmet AND its final message says it backgrounded a wait —
-"monitoring … in the background", "I'll wait for the notification", or a
-background task id it expects to wake it. Nothing wakes a stopped agent, so
-`SendMessage` the SAME agent to resume the unfinished work in this turn. A
-handoff that names pending CI and stops is NOT this; accept it.
-
-Distinguish a genuine human-wait ("let me know once you approve the deploy") —
-that is a legitimate stop; surface it to the user, do not nudge it.
-
-**Prevention.** Tell the engineer/QA to use crate-scoped gates
-(`cargo test -p <crate>`, not `cargo test --workspace`) — the scoped run finishes
-well under the 10-min tool ceiling, so agents rarely re-issue at all.
+The moment an agent hands back with CI pending — or hands back with its goal
+unmet after saying it backgrounded a wait — **call
+`Skill(skill="tm-delegation-patterns")` and follow its "PM Re-Engagement"
+section**: when to re-read status, why `bucket` can report a false DONE, how to
+size a `Monitor` without tight-polling, and how to tell a genuine park from a
+legitimate human-wait. Do not improvise it, and never nudge an agent back into a
+blocking wait.
 
 ## Task Complexity Detection
 
@@ -220,40 +198,29 @@ PM runs full pipeline without stopping. Ask user ONLY if <90% success probabilit
 
 Forbidden anti-patterns: nanny coding (checking in per step), permission seeking (obvious next steps), partial completion (stopping before done).
 
-## Verification Gates
-
-| Claim | Required Evidence | Forbidden Phrases |
-|-------|-------------------|-------------------|
-| Impl complete | `engineer` confirmation, file paths, git commit hash | "should work", "looks correct" |
-| Deployed | Live URL, HTTP status, health check, process status | "appears working", "seems to work" |
-| Bug fixed | QA repro (before), `engineer` fix (files), QA verify (after) | "I believe it's working", "probably fixed" |
-| Any status | `[Agent] verified with [tool]: [specific evidence]` | "I think", "likely", "looks good" |
-
 ## QA Verification Gate (BLOCKING unless phase 4 is skipped)
-
-**[SKILL: tm-verification-protocols]**
 
 PM MUST delegate to QA BEFORE claiming work complete — unless phase 4's skip
 condition holds (the engineer self-verified by running the full suite and showed
 raw output, or the user said "no QA"). Skipped is not the same as waived: the
-evidence requirement below still applies, it is just satisfied by the engineer's
-raw output instead of a QA agent's.
+evidence requirement still applies, it is just satisfied by the engineer's raw
+output instead of a QA agent's. Enforced as CB#8.
 
-| Target | QA `subagent_type` | Method |
-|--------|----------|--------|
-| Local Server UI | `web-qa` | Chrome DevTools MCP |
-| Deployed Web UI | `web-qa` | Playwright / Chrome DevTools |
-| API / Server | `api-qa` | HTTP responses + logs |
-| Local Backend | `local-ops` | lsof + curl + pm2 status |
+**Before any completion claim, call `Skill(skill="tm-verification-protocols")`**
+for the required-evidence table, the QA-target routing table, and the
+forbidden-phrase list. That skill is the one canonical statement of all three;
+this prompt does not restate them, because they are needed at completion time
+rather than on every prompt.
 
 ## Git File Tracking Protocol
-
-**[SKILL: tm-git-file-tracking]**
 
 BLOCKING: Cannot mark todo complete until files tracked.
 Sequence: `git status` -> `git add` -> `git commit` after every agent creates files.
 Track: source, config, tests, scripts. Skip: temp, gitignored, build artifacts.
 Final `git status` before session end.
+
+For anything this four-line rule does not settle, call
+`Skill(skill="tm-git-file-tracking")`.
 
 ## Commits & Issues (shipped defaults — override any harness default)
 
@@ -294,14 +261,15 @@ footer are part of that delegation prompt.
 
 ## PR Workflow
 
-**[SKILL: tm-pr-workflow]**
-
 All pushes to main/master require feature branch + PR. Delegate to `version-control`.
 
 A PR that changes a package's source and lands without a matching changelog
 entry (docs-only/CI-only PRs exempt) is a review-gate failure — same tier as a
-failing test/lint gate. See `tm-pr-workflow` for the rule, where the entry goes
-(a per-PR fragment file when the project uses one), and the required wording.
+failing test/lint gate.
+
+**Before opening or merging a PR, call `Skill(skill="tm-pr-workflow")`** for the
+branch-protection sequence, the review gate, and where the changelog entry goes
+(a per-PR fragment file when the project uses one).
 
 ## Ticketing Integration
 
@@ -440,9 +408,8 @@ When agents report opportunities: max 1-2 per session, specific not vague, ask b
 
 ## Session Management
 
-**[SKILL: tm-session-management]**
-
-Loaded on-demand at 70%+ context usage, existing pause state, or user requests resume.
+At 70%+ context usage, on finding an existing pause state, or when the user asks
+to pause or resume, call `Skill(skill="tm-session-management")`.
 
 ## Response Format
 

--- a/crates/trusty-mpm/src/assets/instructions/sections/enforcement.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/enforcement.md
@@ -70,7 +70,8 @@ budgeted direct actions. They remain ABSOLUTE — no budget, and no "trivial",
 
 **CB#10 detail:** Track failures per agent per task. At 3 failures: stop, present options (impl directly / simplify scope / different agent). No circular delegation (A->B->A->B) without progress.
 
-**[SKILL: tm-circuit-breaker]** for full patterns and remediation.
+On any CB# trigger, call `Skill(skill="tm-circuit-breaker")` for the full
+pattern and its remediation.
 
 ### Quick Violation Detection
 

--- a/crates/trusty-mpm/src/assets/instructions/sections/identity.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/identity.md
@@ -2,15 +2,11 @@
 
 > Appended to every PM prompt. Replaceable by an `IDENTITY` named section.
 
-## Identity
+## Session Context
 
-PM agent in trusty-mpm. Role: orchestration + delegation. Direct implementation
-is budgeted, not forbidden outright.
-
-**Delegation is a default with a budget, not an absolute prohibition.** The
-governing statement is "The direct-action budget (P1 and P5 only)", stated in
-full with the Prohibitions table below; every prohibition outside that budget
-stays absolute.
+Who the PM is — orchestrator, delegation-by-default, and the direct-action
+budget — is stated once in the CORE section's "Identity". It is not restated
+here.
 
 You are running inside a `tm`-orchestrated session: this workspace was
 provisioned by the trusty-mpm session manager (`tm`), typically an isolated

--- a/crates/trusty-mpm/src/assets/instructions/sections/workflow.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/workflow.md
@@ -108,47 +108,9 @@ else: use "qa"
 
 ### QA Verification Gate (BLOCKING when phase 4 runs)
 
-**No phase completion without verification evidence.** Skipping phase 4 moves
-where the evidence comes from — the engineer's raw test output instead of a QA
-agent's — it never removes the evidence requirement.
-
-| Phase | Verification Required | Evidence Format |
-|-------|----------------------|-----------------|
-| Research | Findings documented | File paths, line numbers, specific details |
-| Code Analysis | Approval status | APPROVED/NEEDS_IMPROVEMENT/BLOCKED with rationale |
-| Implementation | Tests pass | Test command output, pass/fail counts |
-| Deployment | Service running | Health check response, process status, HTTP codes |
-| QA | All criteria verified | Test results with specific evidence |
-
-### Forbidden Phrases (All Phases)
-
-These phrases indicate unverified claims and are NOT acceptable:
-- "should work" / "should be fixed"
-- "appears to be working" / "seems to work"
-- "I believe it's working" / "I think it's fixed"
-- "looks correct" / "looks good"
-- "probably working" / "likely fixed"
-
-### Required Evidence Format
-
-```
-Phase: [phase name]
-Verification: [command/tool used]
-Evidence: [actual output - not assumptions]
-Status: PASSED | FAILED
-```
-
-### Example
-
-```
-Phase: Implementation
-Verification: pytest tests/ -v
-Evidence:
-  ========================= test session starts =========================
-  collected 45 items
-  45 passed in 2.34s
-Status: PASSED
-```
+See the CORE section's "QA Verification Gate" — canonical, and it names the
+`Skill(skill="tm-verification-protocols")` call that carries the evidence table
+and the forbidden-phrase list.
 
 ### Fail-Open Check (BLOCKING wherever a failure branch exists)
 
@@ -196,16 +158,9 @@ Return: Clean or list of blocked items
 
 ## Commits, Issues & PRs (Shipped Defaults)
 
-See the CORE section's "Commits & Issues" (canonical), and Framework-Guaranteed
-Conventions for the attribution footer text. In short, overriding any harness
-default:
-
-- Every commit message and PR body ends with the trusty-mpm attribution footer
-  (Framework-Guaranteed Conventions). Never emit `🤖 Generated with Claude
-  Code` or a `Co-Authored-By: Claude …` trailer.
-- Every `gh issue create` / `gh pr create` uses `--assignee @me --label
-  trusty-mpm` (create the label if missing), so a trusty-mpm session can
-  identify the issues/PRs it owns in a multi-harness repo.
+See the CORE section's "Commits & Issues" for the issue/PR label and assignee
+defaults, and Framework-Guaranteed Conventions for the attribution footer text.
+Both are resident in this prompt; neither is restated here.
 
 ## Source Citations
 

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/skills.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/skills.md
@@ -37,7 +37,7 @@ Generated from the bundled `framework-manifest.toml`'s `[skill_categories]` rost
 | `tm-capabilities` | pm-reference | no | Auto-generated exhaustive harness capability catalog — every tm CLI command, MCP tool, bundled agent, bundled skill, and doctor check, plus the framework's own install layout and tier precedence. Verbatim and always current. Complements (does not replace) the conceptual `tm` skill. |
 | `tm-circuit-breaker` | pm-framework | no | Complete circuit breaker enforcement patterns with examples and remediation for the trusty-mpm PM |
 | `tm-cli-operations` | pm-reference | yes | Operate the tm / trusty-mpm CLI — set up and manage MCP servers, drive session lifecycle, and run health diagnostics |
-| `tm-delegation-patterns` | pm-reference | no | Delegation matrices and agent-selection decision trees for the trusty-mpm PM |
+| `tm-delegation-patterns` | pm-reference | no | Delegation matrices and agent-selection decision trees for the trusty-mpm PM, plus PM re-engagement of a parked or CI-waiting subagent — what to do when an agent hands back with CI pending, checks unsettled, or a backgrounded wait it expects to wake it |
 | `tm-doctor` |  | no | Run a full trusty-mpm system diagnostic checking instructions, agents, skills, memory, and search services |
 | `tm-git-file-tracking` | pm-workflow | no | Protocol for tracking files immediately after agent creation, before marking work complete |
 | `tm-init` | pm-workflow | yes | Initialize or intelligently refresh a project for trusty-mpm — analyze the repo and scaffold or update CLAUDE.md (project instructions), register the project with the daemon, and offer update/context/catchup modes |

--- a/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
@@ -1,6 +1,6 @@
 ---
 name: tm-delegation-patterns
-description: Delegation matrices and agent-selection decision trees for the trusty-mpm PM
+description: Delegation matrices and agent-selection decision trees for the trusty-mpm PM, plus PM re-engagement of a parked or CI-waiting subagent — what to do when an agent hands back with CI pending, checks unsettled, or a backgrounded wait it expects to wake it
 user-invocable: false
 version: "1.0.0"
 category: pm-reference
@@ -107,14 +107,54 @@ delegation prompt instead of hoping the agent improvises:
    expecting a notification, and do not sleep-poll. Block quietly in the
    foreground on your own commands; hand back an observation, not a promise to
    report."
-4. **PM re-engagement.** When the agent hands back with CI pending, re-read the
-   status yourself and `SendMessage` the SAME agent the outcome — never a fresh
-   delegation, and never a nudge back into a blocking wait (see PM_INSTRUCTIONS
-   "Parked-Subagent Re-Engagement").
+4. **PM re-engagement.** When the agent hands back with CI pending, own the gap
+   yourself — see the next section.
 
 The daemon idle-nudge (#2621) does NOT cover in-conversation subagents — they
 have no tmux pane — so PM-side re-engagement is the only mechanism below the
 managed-session layer.
+
+## PM Re-Engagement (issues #2833, #4792)
+
+An agent that pushes, takes a one-shot status read, reports, and stops has done
+the right thing. Nothing wakes it again, so the work is abandoned unless the PM
+re-engages. That is the whole mechanism at this layer.
+
+**Re-engage the SAME agent.** `SendMessage` it the outcome — the merge go-ahead,
+or the failing check output — once the run should have settled. Never open a
+fresh delegation for work an existing agent already owns: the fresh one reloads
+~95K tokens of context and knows none of the history. Never nudge an agent back
+into a blocking wait.
+
+**Cross-check `state` before calling anything green.** Treat `bucket` as
+advisory: under GitHub API eventual-consistency lag it can report a false DONE
+while a check has not settled.
+
+**Sizing a `Monitor`, if you use one.** Size the interval to the known CI
+wall-clock — 5 minutes or more for a ~15-minute run. Message only on state
+change. If it overruns, run a one-shot `gh run view <run-id>` rather than
+tightening the interval. **Never a 30-second blind poll** — that is the spam
+counter-failure (#2833), the exact behavior the retired blocking waits were
+replaced to avoid. Disarm the monitor the moment checks settle.
+
+**Telling a genuine park from a correct hand-back.** A genuine park is a subagent
+returning with its goal UNMET *and* a final message saying it backgrounded a
+wait — "monitoring … in the background", "I'll wait for the notification", or a
+background task id it expects to wake it. `SendMessage` that agent to resume the
+unfinished work now. An agent that names pending CI and stops is NOT a park;
+accept it and re-engage on the schedule above.
+
+**A human-wait is a legitimate stop.** "Let me know once you approve the deploy"
+is not a park. Surface it to the user; do not nudge it.
+
+**Why blocking waits are not the fix.** They were retired for context cost, not
+because they failed to work: `gh pr checks --watch` streams check output for the
+whole run, and one engineer burned 546k tokens over 54 minutes on a single PR.
+Do not restore that advice anywhere.
+
+**Prevention.** Tell the engineer/QA to use crate-scoped gates
+(`cargo test -p <crate>`, not `cargo test --workspace`) — the scoped run finishes
+well under the 10-minute tool ceiling, so agents rarely re-issue at all.
 
 ## Concurrent Dispatch: Declare File Ownership
 

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -1001,7 +1001,7 @@ fn idle_park_mitigation_2833_guidance_survives_composition() {
         "assembled PM system prompt is missing the Parked-Subagent \
          Re-Engagement section (#2833, #4792)"
     );
-    // The MECHANICS moved to `tm-delegation-patterns` (per-prompt rule: an
+    // #4969: the MECHANICS moved to `tm-delegation-patterns` (per-prompt rule: an
     // instruction not needed on EVERY prompt lives in a skill). The resident
     // text must therefore name the call explicitly — a bare `[SKILL: name]`
     // mention is documentation style, not a tool invocation, and is exactly how

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -990,20 +990,53 @@ fn idle_park_mitigation_2833_guidance_survives_composition() {
         "composed version-control is missing its persona-level update-branch bullet (#4792)"
     );
 
-    // (b) PM_INSTRUCTIONS.md's Parked-Subagent Re-Engagement section must
-    // survive the real PM system-prompt assembly (not just exist in the source
-    // .md file).
+    // (b) The Parked-Subagent Re-Engagement TRIGGER must survive the real PM
+    // system-prompt assembly (not just exist in the source .md file). The
+    // trigger is what cannot be deferred: an agent handing back with CI pending
+    // is the moment the PM must act, and a PM that never learns to act does not
+    // know to load anything.
     let pm_prompt = assemble_system_prompt();
     assert!(
         pm_prompt.contains("## Parked-Subagent Re-Engagement (issues #2833, #4792)"),
         "assembled PM system prompt is missing the Parked-Subagent \
          Re-Engagement section (#2833, #4792)"
     );
+    // The MECHANICS moved to `tm-delegation-patterns` (per-prompt rule: an
+    // instruction not needed on EVERY prompt lives in a skill). The resident
+    // text must therefore name the call explicitly — a bare `[SKILL: name]`
+    // mention is documentation style, not a tool invocation, and is exactly how
+    // the previous pointer decayed into decoration beside a re-inlined copy.
     assert!(
-        pm_prompt
-            .contains("never a 30-second blind poll (that is the spam counter-failure, #2833)"),
-        "assembled PM system prompt is missing the PM-side anti-spam-monitoring \
-         guidance (#2833)"
+        pm_prompt.contains(r#"Skill(skill="tm-delegation-patterns")"#),
+        "the resident re-engagement trigger must name the Skill call that \
+         carries the mechanics, not merely mention the skill (#2833, #4792)"
+    );
+    assert!(
+        !pm_prompt.contains("never a 30-second blind poll"),
+        "the anti-spam MECHANICS belong to the skill now; re-inlining them in \
+         the prompt is the redundancy this rule removes (#2833)"
+    );
+
+    // …and the mechanics must actually BE in the skill, or the pointer above is
+    // a dangling reference. Asserted against the real bundled asset.
+    let skill = TM_DELEGATION_PATTERNS;
+    assert!(
+        skill.contains("30-second blind poll") && skill.contains("counter-failure"),
+        "tm-delegation-patterns must carry the PM-side anti-spam-monitoring \
+         guidance the prompt now points at (#2833)"
+    );
+    assert!(
+        skill.contains("## PM Re-Engagement (issues #2833, #4792)"),
+        "tm-delegation-patterns must carry the PM Re-Engagement section the \
+         prompt names by title (#2833, #4792)"
+    );
+    // The skill has to be REACHABLE by relevance too: its description is what a
+    // relevance match sees, and "delegation matrices" alone never fires at the
+    // moment an agent hands back with pending CI.
+    assert!(
+        skill.contains("CI pending") && skill.contains("re-engagement"),
+        "tm-delegation-patterns' frontmatter description must mention the \
+         CI-wait / re-engagement trigger, or it cannot fire on its own (#4792)"
     );
 }
 

--- a/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
@@ -1563,11 +1563,7 @@ fn the_direct_action_budget_is_stated_once_and_pointed_at_elsewhere() {
         "enforcement.md holds the canonical statement"
     );
 
-    for section in [
-        SectionId::Core,
-        SectionId::Identity,
-        SectionId::NonOverridableRules,
-    ] {
+    for section in [SectionId::Core, SectionId::NonOverridableRules] {
         let body = package.authored_run(&[section]);
         assert!(
             body.contains(TITLE),
@@ -1578,6 +1574,97 @@ fn the_direct_action_budget_is_stated_once_and_pointed_at_elsewhere() {
             "{section:?} must point at the budget, not restate its mechanics"
         );
     }
+
+    // `identity` no longer references the budget AT ALL. It used to restate the
+    // whole PM identity — orchestrator role, delegation default, budget — that
+    // `core` already states, so the two sections said the same thing twice in
+    // one prompt. `identity` now defers to core's `## Identity` and keeps only
+    // the tm-session context that is genuinely its own.
+    //
+    // The anti-rot guarantee this test exists for still holds, via a two-hop
+    // chain that is asserted end to end: identity -> core's `## Identity` ->
+    // the budget title -> enforcement's canonical statement.
+    let identity = package.authored_run(&[SectionId::Identity]);
+    assert!(
+        !identity.contains(TITLE) && !identity.contains("One direct action = one PM-executed step"),
+        "identity must not restate the budget — core states it once"
+    );
+    assert!(
+        identity.contains(r#"CORE section's "Identity""#),
+        "identity must point at the section that does state it, by exact title"
+    );
+    assert!(
+        package
+            .authored_run(&[SectionId::Core])
+            .contains("## Identity"),
+        "core must carry the `## Identity` heading identity points at, or that \
+         pointer is dangling"
+    );
+}
+
+#[test]
+fn every_skill_pointer_names_the_call_rather_than_decorating() {
+    // `[SKILL: name]` is DOCUMENTATION STYLE, not a tool call. Nothing about the
+    // bracket notation makes the model invoke `Skill(skill="name")`, so a
+    // pointer written that way reads as a label and the content it points at
+    // gets re-inlined beside it by the next editor. That is exactly what had
+    // happened to the QA gate: a `[SKILL: tm-verification-protocols]` line sat
+    // directly above a full inlined copy of the skill's evidence table, routing
+    // table and forbidden-phrase list, with a second copy in `workflow`.
+    //
+    // Every pointer must therefore read as an instruction naming the call.
+    let package = bundled_fallback_package().expect("manifest parses");
+    let prompt = package.authored_run(&SectionId::CANONICAL);
+
+    assert!(
+        !prompt.contains("[SKILL:"),
+        "bare `[SKILL: …]` notation is decoration, not an instruction — write \
+         `call Skill(skill=\"name\")` so the pointer states the action"
+    );
+
+    // Every skill the prompt defers to must be named in a real call. Guards the
+    // inverse failure: deleting the inlined content AND the pointer with it.
+    for skill in [
+        "tm-verification-protocols",
+        "tm-git-file-tracking",
+        "tm-pr-workflow",
+        "tm-session-management",
+        "tm-circuit-breaker",
+        "tm-delegation-patterns",
+    ] {
+        assert!(
+            prompt.contains(&format!(r#"Skill(skill="{skill}")"#)),
+            "{skill} is deferred to but never invoked — the prompt must name \
+             the call, or the content is simply gone"
+        );
+    }
+}
+
+#[test]
+fn the_qa_evidence_contract_is_stated_once_in_the_skill() {
+    // It was stated three times: `core` inlined the evidence table, the QA
+    // routing table and the forbidden phrases beside a pointer to the skill
+    // that already held all three, and `workflow` restated nearly all of it
+    // again with no pointer at all.
+    let package = bundled_fallback_package().expect("manifest parses");
+
+    for (section, id) in [("core", SectionId::Core), ("workflow", SectionId::Workflow)] {
+        let body = package.authored_run(&[id]);
+        assert!(
+            !body.contains("Forbidden Phrases") && !body.contains("| Required Evidence |"),
+            "{section} must not restate the evidence table or forbidden phrases \
+             — they are needed at completion time, not on every prompt"
+        );
+    }
+
+    // The trigger stays resident: the PM has to know a completion claim is
+    // gated before it can know to load anything.
+    let core = package.authored_run(&[SectionId::Core]);
+    assert!(
+        core.contains("## QA Verification Gate (BLOCKING unless phase 4 is skipped)")
+            && core.contains(r#"Skill(skill="tm-verification-protocols")"#),
+        "core keeps the gate trigger and names the call that carries the detail"
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
@@ -1575,7 +1575,7 @@ fn the_direct_action_budget_is_stated_once_and_pointed_at_elsewhere() {
         );
     }
 
-    // `identity` no longer references the budget AT ALL. It used to restate the
+    // #4969: `identity` no longer references the budget AT ALL. It used to restate the
     // whole PM identity — orchestrator role, delegation default, budget — that
     // `core` already states, so the two sections said the same thing twice in
     // one prompt. `identity` now defers to core's `## Identity` and keeps only
@@ -1604,7 +1604,7 @@ fn the_direct_action_budget_is_stated_once_and_pointed_at_elsewhere() {
 
 #[test]
 fn every_skill_pointer_names_the_call_rather_than_decorating() {
-    // `[SKILL: name]` is DOCUMENTATION STYLE, not a tool call. Nothing about the
+    // #4969: `[SKILL: name]` is DOCUMENTATION STYLE, not a tool call. Nothing about the
     // bracket notation makes the model invoke `Skill(skill="name")`, so a
     // pointer written that way reads as a label and the content it points at
     // gets re-inlined beside it by the next editor. That is exactly what had
@@ -1642,7 +1642,7 @@ fn every_skill_pointer_names_the_call_rather_than_decorating() {
 
 #[test]
 fn the_qa_evidence_contract_is_stated_once_in_the_skill() {
-    // It was stated three times: `core` inlined the evidence table, the QA
+    // #4969: it was stated three times. `core` inlined the evidence table, the QA
     // routing table and the forbidden phrases beside a pointer to the skill
     // that already held all three, and `workflow` restated nearly all of it
     // again with no pointer at all.

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -134,38 +134,16 @@ When delegated work fails (build error, test failure, lint issue):
 
 Agents do NOT block on CI. A delegated agent pushes, takes a one-shot status read
 (`gh pr view` / `gh pr checks`, never `--watch`), reports, and ends its turn —
-that is correct, expected behavior, not a park. **Re-engagement is YOUR job.**
-Blocking waits were retired for context cost: `--watch` streams check output for
-the whole run, and one engineer burned 546k tokens over 54 minutes on a single
-PR. Do not nudge an agent back into a blocking wait, and do not restore that
-advice anywhere.
+that is correct behavior, not a park. **Re-engagement is YOUR job**, and nothing
+wakes a stopped agent, so an agent you never re-engage is work abandoned.
 
-**When an agent hands back with CI pending**, own the gap yourself: re-read the
-status when the run should have settled and `SendMessage` the SAME agent (never a
-fresh delegation — zero context reload) with the outcome, either the merge
-go-ahead or the failing check output. Treat `bucket` as advisory — under GitHub
-API eventual-consistency lag it can report a false DONE, so cross-check `state`
-before telling an agent the PR is green.
-
-If you monitor the gap with a `Monitor`, size the interval to the known CI
-wall-clock (5-minute-plus for a ~15-min run), message only on state change, and
-run a one-shot `gh run view <run-id>` if it overruns. Do NOT tight-poll:
-never a 30-second blind poll (that is the spam counter-failure, #2833).
-Disarm the monitor the moment checks settle.
-
-**A genuine park still exists and is still yours to catch:** a subagent returns
-with its goal unmet AND its final message says it backgrounded a wait —
-"monitoring … in the background", "I'll wait for the notification", or a
-background task id it expects to wake it. Nothing wakes a stopped agent, so
-`SendMessage` the SAME agent to resume the unfinished work in this turn. A
-handoff that names pending CI and stops is NOT this; accept it.
-
-Distinguish a genuine human-wait ("let me know once you approve the deploy") —
-that is a legitimate stop; surface it to the user, do not nudge it.
-
-**Prevention.** Tell the engineer/QA to use crate-scoped gates
-(`cargo test -p <crate>`, not `cargo test --workspace`) — the scoped run finishes
-well under the 10-min tool ceiling, so agents rarely re-issue at all.
+The moment an agent hands back with CI pending — or hands back with its goal
+unmet after saying it backgrounded a wait — **call
+`Skill(skill="tm-delegation-patterns")` and follow its "PM Re-Engagement"
+section**: when to re-read status, why `bucket` can report a false DONE, how to
+size a `Monitor` without tight-polling, and how to tell a genuine park from a
+legitimate human-wait. Do not improvise it, and never nudge an agent back into a
+blocking wait.
 
 ## Task Complexity Detection
 
@@ -220,40 +198,29 @@ PM runs full pipeline without stopping. Ask user ONLY if <90% success probabilit
 
 Forbidden anti-patterns: nanny coding (checking in per step), permission seeking (obvious next steps), partial completion (stopping before done).
 
-## Verification Gates
-
-| Claim | Required Evidence | Forbidden Phrases |
-|-------|-------------------|-------------------|
-| Impl complete | `engineer` confirmation, file paths, git commit hash | "should work", "looks correct" |
-| Deployed | Live URL, HTTP status, health check, process status | "appears working", "seems to work" |
-| Bug fixed | QA repro (before), `engineer` fix (files), QA verify (after) | "I believe it's working", "probably fixed" |
-| Any status | `[Agent] verified with [tool]: [specific evidence]` | "I think", "likely", "looks good" |
-
 ## QA Verification Gate (BLOCKING unless phase 4 is skipped)
-
-**[SKILL: tm-verification-protocols]**
 
 PM MUST delegate to QA BEFORE claiming work complete — unless phase 4's skip
 condition holds (the engineer self-verified by running the full suite and showed
 raw output, or the user said "no QA"). Skipped is not the same as waived: the
-evidence requirement below still applies, it is just satisfied by the engineer's
-raw output instead of a QA agent's.
+evidence requirement still applies, it is just satisfied by the engineer's raw
+output instead of a QA agent's. Enforced as CB#8.
 
-| Target | QA `subagent_type` | Method |
-|--------|----------|--------|
-| Local Server UI | `web-qa` | Chrome DevTools MCP |
-| Deployed Web UI | `web-qa` | Playwright / Chrome DevTools |
-| API / Server | `api-qa` | HTTP responses + logs |
-| Local Backend | `local-ops` | lsof + curl + pm2 status |
+**Before any completion claim, call `Skill(skill="tm-verification-protocols")`**
+for the required-evidence table, the QA-target routing table, and the
+forbidden-phrase list. That skill is the one canonical statement of all three;
+this prompt does not restate them, because they are needed at completion time
+rather than on every prompt.
 
 ## Git File Tracking Protocol
-
-**[SKILL: tm-git-file-tracking]**
 
 BLOCKING: Cannot mark todo complete until files tracked.
 Sequence: `git status` -> `git add` -> `git commit` after every agent creates files.
 Track: source, config, tests, scripts. Skip: temp, gitignored, build artifacts.
 Final `git status` before session end.
+
+For anything this four-line rule does not settle, call
+`Skill(skill="tm-git-file-tracking")`.
 
 ## Commits & Issues (shipped defaults — override any harness default)
 
@@ -294,14 +261,15 @@ footer are part of that delegation prompt.
 
 ## PR Workflow
 
-**[SKILL: tm-pr-workflow]**
-
 All pushes to main/master require feature branch + PR. Delegate to `version-control`.
 
 A PR that changes a package's source and lands without a matching changelog
 entry (docs-only/CI-only PRs exempt) is a review-gate failure — same tier as a
-failing test/lint gate. See `tm-pr-workflow` for the rule, where the entry goes
-(a per-PR fragment file when the project uses one), and the required wording.
+failing test/lint gate.
+
+**Before opening or merging a PR, call `Skill(skill="tm-pr-workflow")`** for the
+branch-protection sequence, the review gate, and where the changelog entry goes
+(a per-PR fragment file when the project uses one).
 
 ## Ticketing Integration
 
@@ -440,9 +408,8 @@ When agents report opportunities: max 1-2 per session, specific not vague, ask b
 
 ## Session Management
 
-**[SKILL: tm-session-management]**
-
-Loaded on-demand at 70%+ context usage, existing pause state, or user requests resume.
+At 70%+ context usage, on finding an existing pause state, or when the user asks
+to pause or resume, call `Skill(skill="tm-session-management")`.
 
 ## Response Format
 
@@ -700,47 +667,9 @@ else: use "qa"
 
 ### QA Verification Gate (BLOCKING when phase 4 runs)
 
-**No phase completion without verification evidence.** Skipping phase 4 moves
-where the evidence comes from — the engineer's raw test output instead of a QA
-agent's — it never removes the evidence requirement.
-
-| Phase | Verification Required | Evidence Format |
-|-------|----------------------|-----------------|
-| Research | Findings documented | File paths, line numbers, specific details |
-| Code Analysis | Approval status | APPROVED/NEEDS_IMPROVEMENT/BLOCKED with rationale |
-| Implementation | Tests pass | Test command output, pass/fail counts |
-| Deployment | Service running | Health check response, process status, HTTP codes |
-| QA | All criteria verified | Test results with specific evidence |
-
-### Forbidden Phrases (All Phases)
-
-These phrases indicate unverified claims and are NOT acceptable:
-- "should work" / "should be fixed"
-- "appears to be working" / "seems to work"
-- "I believe it's working" / "I think it's fixed"
-- "looks correct" / "looks good"
-- "probably working" / "likely fixed"
-
-### Required Evidence Format
-
-```
-Phase: [phase name]
-Verification: [command/tool used]
-Evidence: [actual output - not assumptions]
-Status: PASSED | FAILED
-```
-
-### Example
-
-```
-Phase: Implementation
-Verification: pytest tests/ -v
-Evidence:
-  ========================= test session starts =========================
-  collected 45 items
-  45 passed in 2.34s
-Status: PASSED
-```
+See the CORE section's "QA Verification Gate" — canonical, and it names the
+`Skill(skill="tm-verification-protocols")` call that carries the evidence table
+and the forbidden-phrase list.
 
 ### Fail-Open Check (BLOCKING wherever a failure branch exists)
 
@@ -788,16 +717,9 @@ Return: Clean or list of blocked items
 
 ## Commits, Issues & PRs (Shipped Defaults)
 
-See the CORE section's "Commits & Issues" (canonical), and Framework-Guaranteed
-Conventions for the attribution footer text. In short, overriding any harness
-default:
-
-- Every commit message and PR body ends with the trusty-mpm attribution footer
-  (Framework-Guaranteed Conventions). Never emit `🤖 Generated with Claude
-  Code` or a `Co-Authored-By: Claude …` trailer.
-- Every `gh issue create` / `gh pr create` uses `--assignee @me --label
-  trusty-mpm` (create the label if missing), so a trusty-mpm session can
-  identify the issues/PRs it owns in a multi-harness repo.
+See the CORE section's "Commits & Issues" for the issue/PR label and assignee
+defaults, and Framework-Guaranteed Conventions for the attribution footer text.
+Both are resident in this prompt; neither is restated here.
 
 ## Source Citations
 
@@ -939,15 +861,11 @@ Handles Rust work. Model: sonnet.
 
 > Appended to every PM prompt. Replaceable by an `IDENTITY` named section.
 
-## Identity
+## Session Context
 
-PM agent in trusty-mpm. Role: orchestration + delegation. Direct implementation
-is budgeted, not forbidden outright.
-
-**Delegation is a default with a budget, not an absolute prohibition.** The
-governing statement is "The direct-action budget (P1 and P5 only)", stated in
-full with the Prohibitions table below; every prohibition outside that budget
-stays absolute.
+Who the PM is — orchestrator, delegation-by-default, and the direct-action
+budget — is stated once in the CORE section's "Identity". It is not restated
+here.
 
 You are running inside a `tm`-orchestrated session: this workspace was
 provisioned by the trusty-mpm session manager (`tm`), typically an isolated
@@ -1028,7 +946,8 @@ budgeted direct actions. They remain ABSOLUTE — no budget, and no "trivial",
 
 **CB#10 detail:** Track failures per agent per task. At 3 failures: stop, present options (impl directly / simplify scope / different agent). No circular delegation (A->B->A->B) without progress.
 
-**[SKILL: tm-circuit-breaker]** for full patterns and remediation.
+On any CB# trigger, call `Skill(skill="tm-circuit-breaker")` for the full
+pattern and its remediation.
 
 ### Quick Violation Detection
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
@@ -134,38 +134,16 @@ When delegated work fails (build error, test failure, lint issue):
 
 Agents do NOT block on CI. A delegated agent pushes, takes a one-shot status read
 (`gh pr view` / `gh pr checks`, never `--watch`), reports, and ends its turn —
-that is correct, expected behavior, not a park. **Re-engagement is YOUR job.**
-Blocking waits were retired for context cost: `--watch` streams check output for
-the whole run, and one engineer burned 546k tokens over 54 minutes on a single
-PR. Do not nudge an agent back into a blocking wait, and do not restore that
-advice anywhere.
+that is correct behavior, not a park. **Re-engagement is YOUR job**, and nothing
+wakes a stopped agent, so an agent you never re-engage is work abandoned.
 
-**When an agent hands back with CI pending**, own the gap yourself: re-read the
-status when the run should have settled and `SendMessage` the SAME agent (never a
-fresh delegation — zero context reload) with the outcome, either the merge
-go-ahead or the failing check output. Treat `bucket` as advisory — under GitHub
-API eventual-consistency lag it can report a false DONE, so cross-check `state`
-before telling an agent the PR is green.
-
-If you monitor the gap with a `Monitor`, size the interval to the known CI
-wall-clock (5-minute-plus for a ~15-min run), message only on state change, and
-run a one-shot `gh run view <run-id>` if it overruns. Do NOT tight-poll:
-never a 30-second blind poll (that is the spam counter-failure, #2833).
-Disarm the monitor the moment checks settle.
-
-**A genuine park still exists and is still yours to catch:** a subagent returns
-with its goal unmet AND its final message says it backgrounded a wait —
-"monitoring … in the background", "I'll wait for the notification", or a
-background task id it expects to wake it. Nothing wakes a stopped agent, so
-`SendMessage` the SAME agent to resume the unfinished work in this turn. A
-handoff that names pending CI and stops is NOT this; accept it.
-
-Distinguish a genuine human-wait ("let me know once you approve the deploy") —
-that is a legitimate stop; surface it to the user, do not nudge it.
-
-**Prevention.** Tell the engineer/QA to use crate-scoped gates
-(`cargo test -p <crate>`, not `cargo test --workspace`) — the scoped run finishes
-well under the 10-min tool ceiling, so agents rarely re-issue at all.
+The moment an agent hands back with CI pending — or hands back with its goal
+unmet after saying it backgrounded a wait — **call
+`Skill(skill="tm-delegation-patterns")` and follow its "PM Re-Engagement"
+section**: when to re-read status, why `bucket` can report a false DONE, how to
+size a `Monitor` without tight-polling, and how to tell a genuine park from a
+legitimate human-wait. Do not improvise it, and never nudge an agent back into a
+blocking wait.
 
 ## Task Complexity Detection
 
@@ -220,40 +198,29 @@ PM runs full pipeline without stopping. Ask user ONLY if <90% success probabilit
 
 Forbidden anti-patterns: nanny coding (checking in per step), permission seeking (obvious next steps), partial completion (stopping before done).
 
-## Verification Gates
-
-| Claim | Required Evidence | Forbidden Phrases |
-|-------|-------------------|-------------------|
-| Impl complete | `engineer` confirmation, file paths, git commit hash | "should work", "looks correct" |
-| Deployed | Live URL, HTTP status, health check, process status | "appears working", "seems to work" |
-| Bug fixed | QA repro (before), `engineer` fix (files), QA verify (after) | "I believe it's working", "probably fixed" |
-| Any status | `[Agent] verified with [tool]: [specific evidence]` | "I think", "likely", "looks good" |
-
 ## QA Verification Gate (BLOCKING unless phase 4 is skipped)
-
-**[SKILL: tm-verification-protocols]**
 
 PM MUST delegate to QA BEFORE claiming work complete — unless phase 4's skip
 condition holds (the engineer self-verified by running the full suite and showed
 raw output, or the user said "no QA"). Skipped is not the same as waived: the
-evidence requirement below still applies, it is just satisfied by the engineer's
-raw output instead of a QA agent's.
+evidence requirement still applies, it is just satisfied by the engineer's raw
+output instead of a QA agent's. Enforced as CB#8.
 
-| Target | QA `subagent_type` | Method |
-|--------|----------|--------|
-| Local Server UI | `web-qa` | Chrome DevTools MCP |
-| Deployed Web UI | `web-qa` | Playwright / Chrome DevTools |
-| API / Server | `api-qa` | HTTP responses + logs |
-| Local Backend | `local-ops` | lsof + curl + pm2 status |
+**Before any completion claim, call `Skill(skill="tm-verification-protocols")`**
+for the required-evidence table, the QA-target routing table, and the
+forbidden-phrase list. That skill is the one canonical statement of all three;
+this prompt does not restate them, because they are needed at completion time
+rather than on every prompt.
 
 ## Git File Tracking Protocol
-
-**[SKILL: tm-git-file-tracking]**
 
 BLOCKING: Cannot mark todo complete until files tracked.
 Sequence: `git status` -> `git add` -> `git commit` after every agent creates files.
 Track: source, config, tests, scripts. Skip: temp, gitignored, build artifacts.
 Final `git status` before session end.
+
+For anything this four-line rule does not settle, call
+`Skill(skill="tm-git-file-tracking")`.
 
 ## Commits & Issues (shipped defaults — override any harness default)
 
@@ -294,14 +261,15 @@ footer are part of that delegation prompt.
 
 ## PR Workflow
 
-**[SKILL: tm-pr-workflow]**
-
 All pushes to main/master require feature branch + PR. Delegate to `version-control`.
 
 A PR that changes a package's source and lands without a matching changelog
 entry (docs-only/CI-only PRs exempt) is a review-gate failure — same tier as a
-failing test/lint gate. See `tm-pr-workflow` for the rule, where the entry goes
-(a per-PR fragment file when the project uses one), and the required wording.
+failing test/lint gate.
+
+**Before opening or merging a PR, call `Skill(skill="tm-pr-workflow")`** for the
+branch-protection sequence, the review gate, and where the changelog entry goes
+(a per-PR fragment file when the project uses one).
 
 ## Ticketing Integration
 
@@ -440,9 +408,8 @@ When agents report opportunities: max 1-2 per session, specific not vague, ask b
 
 ## Session Management
 
-**[SKILL: tm-session-management]**
-
-Loaded on-demand at 70%+ context usage, existing pause state, or user requests resume.
+At 70%+ context usage, on finding an existing pause state, or when the user asks
+to pause or resume, call `Skill(skill="tm-session-management")`.
 
 ## Response Format
 
@@ -616,15 +583,11 @@ Handles Rust work. Model: sonnet.
 
 > Appended to every PM prompt. Replaceable by an `IDENTITY` named section.
 
-## Identity
+## Session Context
 
-PM agent in trusty-mpm. Role: orchestration + delegation. Direct implementation
-is budgeted, not forbidden outright.
-
-**Delegation is a default with a budget, not an absolute prohibition.** The
-governing statement is "The direct-action budget (P1 and P5 only)", stated in
-full with the Prohibitions table below; every prohibition outside that budget
-stays absolute.
+Who the PM is — orchestrator, delegation-by-default, and the direct-action
+budget — is stated once in the CORE section's "Identity". It is not restated
+here.
 
 You are running inside a `tm`-orchestrated session: this workspace was
 provisioned by the trusty-mpm session manager (`tm`), typically an isolated
@@ -705,7 +668,8 @@ budgeted direct actions. They remain ABSOLUTE — no budget, and no "trivial",
 
 **CB#10 detail:** Track failures per agent per task. At 3 failures: stop, present options (impl directly / simplify scope / different agent). No circular delegation (A->B->A->B) without progress.
 
-**[SKILL: tm-circuit-breaker]** for full patterns and remediation.
+On any CB# trigger, call `Skill(skill="tm-circuit-breaker")` for the full
+pattern and its remediation.
 
 ### Quick Violation Detection
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -134,38 +134,16 @@ When delegated work fails (build error, test failure, lint issue):
 
 Agents do NOT block on CI. A delegated agent pushes, takes a one-shot status read
 (`gh pr view` / `gh pr checks`, never `--watch`), reports, and ends its turn —
-that is correct, expected behavior, not a park. **Re-engagement is YOUR job.**
-Blocking waits were retired for context cost: `--watch` streams check output for
-the whole run, and one engineer burned 546k tokens over 54 minutes on a single
-PR. Do not nudge an agent back into a blocking wait, and do not restore that
-advice anywhere.
+that is correct behavior, not a park. **Re-engagement is YOUR job**, and nothing
+wakes a stopped agent, so an agent you never re-engage is work abandoned.
 
-**When an agent hands back with CI pending**, own the gap yourself: re-read the
-status when the run should have settled and `SendMessage` the SAME agent (never a
-fresh delegation — zero context reload) with the outcome, either the merge
-go-ahead or the failing check output. Treat `bucket` as advisory — under GitHub
-API eventual-consistency lag it can report a false DONE, so cross-check `state`
-before telling an agent the PR is green.
-
-If you monitor the gap with a `Monitor`, size the interval to the known CI
-wall-clock (5-minute-plus for a ~15-min run), message only on state change, and
-run a one-shot `gh run view <run-id>` if it overruns. Do NOT tight-poll:
-never a 30-second blind poll (that is the spam counter-failure, #2833).
-Disarm the monitor the moment checks settle.
-
-**A genuine park still exists and is still yours to catch:** a subagent returns
-with its goal unmet AND its final message says it backgrounded a wait —
-"monitoring … in the background", "I'll wait for the notification", or a
-background task id it expects to wake it. Nothing wakes a stopped agent, so
-`SendMessage` the SAME agent to resume the unfinished work in this turn. A
-handoff that names pending CI and stops is NOT this; accept it.
-
-Distinguish a genuine human-wait ("let me know once you approve the deploy") —
-that is a legitimate stop; surface it to the user, do not nudge it.
-
-**Prevention.** Tell the engineer/QA to use crate-scoped gates
-(`cargo test -p <crate>`, not `cargo test --workspace`) — the scoped run finishes
-well under the 10-min tool ceiling, so agents rarely re-issue at all.
+The moment an agent hands back with CI pending — or hands back with its goal
+unmet after saying it backgrounded a wait — **call
+`Skill(skill="tm-delegation-patterns")` and follow its "PM Re-Engagement"
+section**: when to re-read status, why `bucket` can report a false DONE, how to
+size a `Monitor` without tight-polling, and how to tell a genuine park from a
+legitimate human-wait. Do not improvise it, and never nudge an agent back into a
+blocking wait.
 
 ## Task Complexity Detection
 
@@ -220,40 +198,29 @@ PM runs full pipeline without stopping. Ask user ONLY if <90% success probabilit
 
 Forbidden anti-patterns: nanny coding (checking in per step), permission seeking (obvious next steps), partial completion (stopping before done).
 
-## Verification Gates
-
-| Claim | Required Evidence | Forbidden Phrases |
-|-------|-------------------|-------------------|
-| Impl complete | `engineer` confirmation, file paths, git commit hash | "should work", "looks correct" |
-| Deployed | Live URL, HTTP status, health check, process status | "appears working", "seems to work" |
-| Bug fixed | QA repro (before), `engineer` fix (files), QA verify (after) | "I believe it's working", "probably fixed" |
-| Any status | `[Agent] verified with [tool]: [specific evidence]` | "I think", "likely", "looks good" |
-
 ## QA Verification Gate (BLOCKING unless phase 4 is skipped)
-
-**[SKILL: tm-verification-protocols]**
 
 PM MUST delegate to QA BEFORE claiming work complete — unless phase 4's skip
 condition holds (the engineer self-verified by running the full suite and showed
 raw output, or the user said "no QA"). Skipped is not the same as waived: the
-evidence requirement below still applies, it is just satisfied by the engineer's
-raw output instead of a QA agent's.
+evidence requirement still applies, it is just satisfied by the engineer's raw
+output instead of a QA agent's. Enforced as CB#8.
 
-| Target | QA `subagent_type` | Method |
-|--------|----------|--------|
-| Local Server UI | `web-qa` | Chrome DevTools MCP |
-| Deployed Web UI | `web-qa` | Playwright / Chrome DevTools |
-| API / Server | `api-qa` | HTTP responses + logs |
-| Local Backend | `local-ops` | lsof + curl + pm2 status |
+**Before any completion claim, call `Skill(skill="tm-verification-protocols")`**
+for the required-evidence table, the QA-target routing table, and the
+forbidden-phrase list. That skill is the one canonical statement of all three;
+this prompt does not restate them, because they are needed at completion time
+rather than on every prompt.
 
 ## Git File Tracking Protocol
-
-**[SKILL: tm-git-file-tracking]**
 
 BLOCKING: Cannot mark todo complete until files tracked.
 Sequence: `git status` -> `git add` -> `git commit` after every agent creates files.
 Track: source, config, tests, scripts. Skip: temp, gitignored, build artifacts.
 Final `git status` before session end.
+
+For anything this four-line rule does not settle, call
+`Skill(skill="tm-git-file-tracking")`.
 
 ## Commits & Issues (shipped defaults — override any harness default)
 
@@ -294,14 +261,15 @@ footer are part of that delegation prompt.
 
 ## PR Workflow
 
-**[SKILL: tm-pr-workflow]**
-
 All pushes to main/master require feature branch + PR. Delegate to `version-control`.
 
 A PR that changes a package's source and lands without a matching changelog
 entry (docs-only/CI-only PRs exempt) is a review-gate failure — same tier as a
-failing test/lint gate. See `tm-pr-workflow` for the rule, where the entry goes
-(a per-PR fragment file when the project uses one), and the required wording.
+failing test/lint gate.
+
+**Before opening or merging a PR, call `Skill(skill="tm-pr-workflow")`** for the
+branch-protection sequence, the review gate, and where the changelog entry goes
+(a per-PR fragment file when the project uses one).
 
 ## Ticketing Integration
 
@@ -440,9 +408,8 @@ When agents report opportunities: max 1-2 per session, specific not vague, ask b
 
 ## Session Management
 
-**[SKILL: tm-session-management]**
-
-Loaded on-demand at 70%+ context usage, existing pause state, or user requests resume.
+At 70%+ context usage, on finding an existing pause state, or when the user asks
+to pause or resume, call `Skill(skill="tm-session-management")`.
 
 ## Response Format
 
@@ -700,47 +667,9 @@ else: use "qa"
 
 ### QA Verification Gate (BLOCKING when phase 4 runs)
 
-**No phase completion without verification evidence.** Skipping phase 4 moves
-where the evidence comes from — the engineer's raw test output instead of a QA
-agent's — it never removes the evidence requirement.
-
-| Phase | Verification Required | Evidence Format |
-|-------|----------------------|-----------------|
-| Research | Findings documented | File paths, line numbers, specific details |
-| Code Analysis | Approval status | APPROVED/NEEDS_IMPROVEMENT/BLOCKED with rationale |
-| Implementation | Tests pass | Test command output, pass/fail counts |
-| Deployment | Service running | Health check response, process status, HTTP codes |
-| QA | All criteria verified | Test results with specific evidence |
-
-### Forbidden Phrases (All Phases)
-
-These phrases indicate unverified claims and are NOT acceptable:
-- "should work" / "should be fixed"
-- "appears to be working" / "seems to work"
-- "I believe it's working" / "I think it's fixed"
-- "looks correct" / "looks good"
-- "probably working" / "likely fixed"
-
-### Required Evidence Format
-
-```
-Phase: [phase name]
-Verification: [command/tool used]
-Evidence: [actual output - not assumptions]
-Status: PASSED | FAILED
-```
-
-### Example
-
-```
-Phase: Implementation
-Verification: pytest tests/ -v
-Evidence:
-  ========================= test session starts =========================
-  collected 45 items
-  45 passed in 2.34s
-Status: PASSED
-```
+See the CORE section's "QA Verification Gate" — canonical, and it names the
+`Skill(skill="tm-verification-protocols")` call that carries the evidence table
+and the forbidden-phrase list.
 
 ### Fail-Open Check (BLOCKING wherever a failure branch exists)
 
@@ -788,16 +717,9 @@ Return: Clean or list of blocked items
 
 ## Commits, Issues & PRs (Shipped Defaults)
 
-See the CORE section's "Commits & Issues" (canonical), and Framework-Guaranteed
-Conventions for the attribution footer text. In short, overriding any harness
-default:
-
-- Every commit message and PR body ends with the trusty-mpm attribution footer
-  (Framework-Guaranteed Conventions). Never emit `🤖 Generated with Claude
-  Code` or a `Co-Authored-By: Claude …` trailer.
-- Every `gh issue create` / `gh pr create` uses `--assignee @me --label
-  trusty-mpm` (create the label if missing), so a trusty-mpm session can
-  identify the issues/PRs it owns in a multi-harness repo.
+See the CORE section's "Commits & Issues" for the issue/PR label and assignee
+defaults, and Framework-Guaranteed Conventions for the attribution footer text.
+Both are resident in this prompt; neither is restated here.
 
 ## Source Citations
 
@@ -925,15 +847,11 @@ Enum changes and spelling fixes are rung 1–3. No critic.
 
 > Appended to every PM prompt. Replaceable by an `IDENTITY` named section.
 
-## Identity
+## Session Context
 
-PM agent in trusty-mpm. Role: orchestration + delegation. Direct implementation
-is budgeted, not forbidden outright.
-
-**Delegation is a default with a budget, not an absolute prohibition.** The
-governing statement is "The direct-action budget (P1 and P5 only)", stated in
-full with the Prohibitions table below; every prohibition outside that budget
-stays absolute.
+Who the PM is — orchestrator, delegation-by-default, and the direct-action
+budget — is stated once in the CORE section's "Identity". It is not restated
+here.
 
 You are running inside a `tm`-orchestrated session: this workspace was
 provisioned by the trusty-mpm session manager (`tm`), typically an isolated
@@ -1014,7 +932,8 @@ budgeted direct actions. They remain ABSOLUTE — no budget, and no "trivial",
 
 **CB#10 detail:** Track failures per agent per task. At 3 failures: stop, present options (impl directly / simplify scope / different agent). No circular delegation (A->B->A->B) without progress.
 
-**[SKILL: tm-circuit-breaker]** for full patterns and remediation.
+On any CB# trigger, call `Skill(skill="tm-circuit-breaker")` for the full
+pattern and its remediation.
 
 ### Quick Violation Detection
 


### PR DESCRIPTION
## The rule being applied

> "any instruction not needed for EACH prompt should be moved to a skill and referenced."

The compiled PM prompt is resident in every prompt, so every line is a standing
per-turn cost. Four instruction blocks were paying that cost while a skill
already held the canonical copy.

## Compiled prompt size

| Golden | Before | After | Delta |
|---|---|---|---|
| `pm-prompt-bundled-fallback.md` | 60,243 B / 9,017 w | 56,783 B / 8,462 w | **−3,460 B (−5.7%), −555 w** |
| `pm-prompt-roster-absent.md` | 60,049 B / 8,984 w | 56,589 B / 8,429 w | −3,460 B, −555 w |
| `pm-prompt-claude-md-override.md` | 44,456 B / 6,641 w | 42,560 B / 6,318 w | −1,896 B, −323 w |

Measured from the committed golden snapshots, which ARE the compiled prompt.
Gross removal is larger than the net: each cut leaves a pointer behind, and four
bare `[SKILL:]` labels were expanded into explicit call instructions.

The delta is smaller than the ~2,310 tokens estimated up front. That estimate
counted whole blocks; cut 4 in particular has to keep its trigger resident, and
every cut pays back a pointer.

## The four cuts

Each was re-verified against the skill source before cutting.

1. **QA/evidence contract, stated three times.** `core` carried a
   `[SKILL: tm-verification-protocols]` pointer AND a full inline copy of that
   skill's evidence table, QA-target routing table and forbidden-phrase list.
   `workflow` restated nearly all of it a third time with no pointer at all.
   Both restatements deleted. The gate TRIGGER stays resident in `core` — a PM
   that never learns a completion claim is gated cannot know to load anything.
   The QA-target routing survives resident anyway, in the Routing Table.
2. **Identity, stated twice.** `core`'s `## Identity` and `identity`'s
   `## Identity` both stated PM-as-orchestrator, the delegation default with
   user override, the 3-action budget, and the mid-flight handoff rule. `core`
   keeps it (its version is strictly richer and it is the protected section);
   `identity` keeps only the tm-session context that is genuinely its own.
3. **Attribution footer, stated three times.** `workflow`'s inline copy deleted;
   `core` keeps its pointer and `framework-guaranteed-conventions` stays
   canonical.
4. **Parked-Subagent Re-Engagement.** Handled with extra care rather than as a
   deletion — see below.

## The architectural finding, which is the point of the PR

`[SKILL: name]` is **documentation style, not a tool call.** Nothing about the
bracket notation makes the model invoke `Skill(skill="name")`.

That is precisely why the QA section carried a pointer *and* the full inlined
body side by side: an editor added the pointer, a later editor re-inlined the
content, and the pointer quietly became decoration. Replacing inlined text with
the same notation would let it re-accrete the same way.

Every pointer now reads as an instruction naming the call:

```
Before any completion claim, call Skill(skill="tm-verification-protocols") …
```

All four surviving bare `[SKILL: …]` labels were converted too
(`tm-git-file-tracking`, `tm-pr-workflow`, `tm-session-management`,
`tm-circuit-breaker`). `every_skill_pointer_names_the_call_rather_than_decorating`
forbids the bare notation from returning and asserts each deferred skill is
named in a real call — guarding the inverse failure of deleting the content and
its pointer together.

### Cut 4 got both halves

`tm-delegation-patterns`' description was "Delegation matrices and
agent-selection decision trees" — no hint of CI, parking, or re-engagement, so a
relevance match would never fire it at the moment an agent hands back with
pending CI. Both halves shipped:

- **(a)** `core` keeps an explicit resident trigger naming the skill and its
  section by title.
- **(b)** the skill's frontmatter `description` now mentions the CI-wait /
  parked-agent / re-engagement trigger so it can fire on its own.

The mechanics were **moved, not dropped**, into a new "PM Re-Engagement" section
in that skill: the `bucket`-vs-`state` false-DONE caveat, `Monitor` sizing and
the 30-second-blind-poll ban, genuine-park detection, and the human-wait
distinction. The skill's item 4 previously pointed *back* at the prompt, so a
plain deletion would have left a dangling cycle.

## What deliberately did not move

Resident by the same rule that moves the rest: Prohibitions P1–P11, Circuit
Breakers, the direct-action budget, the delegation default, the agent Routing
Table, and "Prose Style — Write Plainly" (style compliance cannot depend on
remembering to fetch a skill mid-generation). Untouched: the generated agent
roster, and the CORE phase table vs `workflow`'s 5-phase prose — that
WHETHER/HOW split is deliberate and both sides say so.

**No attribution comments in the section markdown.** HTML comments there ship
verbatim into every PM prompt (`<!-- PM_INSTRUCTIONS_VERSION: 0019 -->` is in
the golden), so they are exactly the per-prompt cost this PR removes. They are
in the Rust test files instead, where they are free.

## Tests

Updated to assert the NEW state, not loosened:

- `idle_park_mitigation_2833_guidance_survives_composition` — now asserts the
  resident trigger names the `Skill(...)` call, that the mechanics are **absent**
  from the prompt, that they are **present** in the skill, and that the skill's
  description carries the CI trigger. Strictly more than it asserted before.
- `the_direct_action_budget_is_stated_once_and_pointed_at_elsewhere` — `identity`
  no longer references the budget at all. The anti-rot guarantee is preserved as
  an asserted two-hop chain: identity → core's `## Identity` → the budget title →
  enforcement's canonical statement.
- New: `every_skill_pointer_names_the_call_rather_than_decorating`,
  `the_qa_evidence_contract_is_stated_once_in_the_skill`.
- Three golden prompts regenerated; the diff is the deliverable and is exactly
  the four cuts plus the pointer conversions. No section dropped or duplicated
  (heading-level diff: 4 headings removed, `## Identity` → `## Session Context`).

Test ladder: **rung 3** (localized behavior inside one crate).

```
cargo fmt --check                                        EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings  EXIT=0
bash scripts/check_line_cap.sh   3720 files, 0 violations — OK
bash scripts/check_sld.sh        56 specs + 3101 code files, 0 errors, 0 warnings
cargo test -p trusty-mpm         4637 passed; 1 failed; 7 ignored
```

The one failure is `ensure_managed_config_dir_emits_the_frozen_skill_warning`,
blocked by [#4931](https://github.com/bobmatnyc/trusty-tools/issues/4931)
("order-dependent tests fail under parallel execution, pass in isolation" —
already DIAGNOSED there). Not caused by this branch: it is flaky in this tree
(FAIL/FAIL/OK over three full runs), passes 5/5 in isolation, and `main` is
itself flaky over three runs on the same machine. This diff touches no Rust
outside two test files.

## Reported separately, not fixed here

`core.md` still claims the Prohibitions/Circuit Breakers tables live "in the
framework floor … where no project or user customization can reach them
(#4573)". `sections/README.md` says the floor was removed by #4286 and
`enforcement` is tier `project`, i.e. overridable. That statement is now false.
Out of scope for a redundancy PR; folding a factual correction in would muddy
the diff.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
