### PR TITLE
fix(trusty-common): rank memory recall by relevance, not importance (#4904)

### DIFF
--- a/crates/trusty-common/changelog.d/4904-hook-recall-precision.md
+++ b/crates/trusty-common/changelog.d/4904-hook-recall-precision.md
@@ -1,0 +1,5 @@
+Fixed
+
+- memory recall ranks by relevance again: L2/L3 scored a candidate `eff_importance * similarity`, but inside one candidate pool `eff_importance` spans ~0.44 where similarity spans ~0.07, so the product ranked by importance and discarded the search. Importance now tilts the score by at most 5% (`IMPORTANCE_TILT`), which is the tiebreaker role its own docs described. Measured on a 1,272-drawer palace with a 400-drawer self-retrieval probe: recall@5 295/400 → 351/400, recall@1 102/400 → 291/400 (closes [#4904](https://github.com/bobmatnyc/trusty-tools/issues/4904))
+  - L2 and L3 now share one `rank_score` instead of repeating the expression, so deep recall cannot be left on an older formula
+  - every L2 candidate is traced with its score components before the `top_k` truncation, on the `memory_recall_rank` target — the pre-truncation view that tells "never a candidate" apart from "ranked below the cutoff"

--- a/crates/trusty-common/src/memory_core/retrieval/layers.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/layers.rs
@@ -2,14 +2,15 @@
 //!
 //! Why: Extracted from retrieval/mod.rs to keep each file under the 500-SLOC
 //! cap (#607). All pure query functions live here; mutation lives in handle.rs.
-//! What: `retrieve_l0_l1`, `rescore_l1_by_similarity`, `retrieve_l2`,
-//! `retrieve_l3`, `expand_query`, `recall`, `recall_deep`,
+//! What: `retrieve_l0_l1`, `rescore_l1_by_similarity`, `rank_score`,
+//! `retrieve_l2`, `retrieve_l3`, `expand_query`, `recall`, `recall_deep`,
 //! `recall_with_default_embedder`, `recall_deep_with_default_embedder`,
 //! `recall_across_palaces`, `recall_across_palaces_with_default_embedder`,
 //! `uuid_prefix_eq`, `dedup_extend`.
 //! Test: `recall_ranks_by_similarity_over_importance`, `l0_l1_always_present`,
 //! `l2_returns_relevant_drawer`, `l2_room_filter_excludes_other_rooms`,
-//! `recall_across_palaces_merges_results`.
+//! `recall_across_palaces_merges_results`,
+//! `l2_ranks_similar_low_importance_above_less_similar_high_importance`.
 //!
 //! # Read-time expiry (#4885, ADR-0028 D4)
 //!
@@ -62,10 +63,64 @@ use uuid::Uuid;
 /// reduces their effective score below typical in-topic L2 hits, turning
 /// importance into a mild tiebreaker rather than the primary ranking signal.
 /// What: `0.15` — chosen so a maximum-importance L1 drawer without a
-/// similarity score (0.15) is outranked by a mediocre-similarity L2 hit
-/// (e.g. importance=0.5 * similarity=0.4 = 0.20).
+/// similarity score (0.15) is outranked by a mediocre-similarity L2 hit. #4904
+/// widened that margin rather than narrowing it: an L2 hit now scores close to
+/// its raw similarity (see [`rank_score`]) instead of similarity times a
+/// ~0.46-median `eff_importance`, so the same 0.15 ceiling sits further below a
+/// real hit than it did.
 /// Test: `recall_ranks_by_similarity_over_importance` in the tests below.
 pub(super) const L1_NO_SIMILARITY_PENALTY: f32 = 0.15;
+
+/// Share of an L2/L3 candidate's score that effective importance may move.
+///
+/// Why (#4904): L2 and L3 used to score a candidate `eff_importance *
+/// similarity`. Measured over the trusty-tools palace (1,272 drawers) and 200
+/// real hook queries, the two factors are not comparable in scale: inside one
+/// query's 15-candidate pool, similarity spans 0.067 on average while
+/// `eff_importance` spans 0.436 — 6.5× more. Multiplying by it therefore does
+/// not weight the ranking, it *replaces* it: the final top-5 matched the
+/// similarity top-5 in 1 of those 200 queries. On a 400-drawer self-retrieval
+/// probe (each drawer queried with its own leading text, so the right answer is
+/// known) the product scored recall@1 of 102/400 where similarity alone scored
+/// 291/400 — the multiplier was discarding two thirds of the correct top hits.
+/// What: `0.05` — a candidate's score is similarity scaled by
+/// `0.95 + 0.05 * eff_importance`, so importance can move a score by at most 5%
+/// and acts as the tiebreaker its own docs always described, not the primary
+/// signal. The same sweep read 350/400 recall@5 at this weight, matching
+/// similarity-only (350/400) while keeping importance live; the shipped
+/// multiplier scored 295/400.
+/// Test: `rank_score_keeps_importance_a_tiebreaker`,
+/// `l2_ranks_similar_low_importance_above_less_similar_high_importance`.
+pub(super) const IMPORTANCE_TILT: f32 = 0.05;
+
+/// Combine the three L2/L3 ranking inputs into one comparable score.
+///
+/// Why: L2 and L3 scored candidates with the same three-term expression written
+/// out twice, so a change to one silently left the other on the old formula —
+/// exactly the drift that made `retrieve_l3` the odd one out for room filtering
+/// in #3274. One function is also the only place a reader has to look to see
+/// what "score" means.
+/// What: tilts `similarity` by at most [`IMPORTANCE_TILT`] according to
+/// `eff_importance`, adds the closet `tag_boost`, and clamps to `1.0`.
+/// Test: `rank_score_keeps_importance_a_tiebreaker`.
+pub(super) fn rank_score(similarity: f32, eff_importance: f32, tag_boost: f32) -> f32 {
+    let tilted = similarity * ((1.0 - IMPORTANCE_TILT) + IMPORTANCE_TILT * eff_importance);
+    (tilted + tag_boost).min(1.0)
+}
+
+/// Tracing target for per-candidate L2 ranking traces (#4904).
+///
+/// Why: a missed fact looks identical whether it never entered the candidate
+/// set, entered but ranked below the cutoff, or was never queried for. Only the
+/// pre-truncation candidate list with its score components tells them apart, and
+/// nothing logged it. Its own target keeps `RUST_LOG=trusty_common=debug` from
+/// drowning in one line per candidate per recall while still letting an operator
+/// ask for exactly this with `RUST_LOG=memory_recall_rank=debug`.
+/// What: the `target:` string on the `tracing::debug!` inside
+/// [`retrieve_l2_scoped`], emitted once per surviving candidate before the
+/// `top_k` truncation.
+/// Test: `l2_rank_trace_emits_one_event_per_candidate`.
+pub const RANK_TRACE_TARGET: &str = "memory_recall_rank";
 
 /// Compare two UUIDs by their first 8 bytes.
 ///
@@ -195,9 +250,8 @@ pub fn rescore_l1_by_similarity(
 /// match, applies the optional room filter by comparing `drawer.room_id`
 /// against the id the palace's `ROOMS` registry holds for that room
 /// (issue #3274 for the filter itself; ADR-0027 D1.3 for resolving the id
-/// through the table instead of re-hashing it), scores as
-/// `drawer.importance * hit.score`, and returns the top `top_k`
-/// drawers tagged with `layer: 2`.
+/// through the table instead of re-hashing it), scores each candidate with
+/// [`rank_score`], and returns the top `top_k` drawers tagged with `layer: 2`.
 /// Test: `l2_returns_relevant_drawer` upserts a Rust-themed drawer and
 /// asserts a Rust-themed query retrieves it at rank 0.
 /// `l2_room_filter_excludes_other_rooms` (issue #3274) asserts a drawer from
@@ -297,7 +351,6 @@ pub async fn retrieve_l2_scoped(
             handle
                 .decay_config
                 .effective_importance(drawer.importance, age_days, boost);
-        let effective_score = eff_importance * hit.score;
 
         // Closet tag boost: if any query token matches a closet keyword that
         // contains this drawer, add a 0.15 bump (capped at 1.0) so topical
@@ -307,7 +360,25 @@ pub async fn retrieve_l2_scoped(
             .iter()
             .any(|tok| closets.get(tok).is_some_and(|ids| ids.contains(&drawer_id)));
         let tag_boost = if in_closet { 0.15_f32 } else { 0.0 };
-        let final_score = (effective_score + tag_boost).min(1.0);
+        // #4904: importance tilts the similarity score, it no longer multiplies
+        // it — see `IMPORTANCE_TILT`.
+        let final_score = rank_score(hit.score, eff_importance, tag_boost);
+
+        // #4904: the three candidate explanations for a missed fact — absent
+        // from the candidate set, present but ranked below the cutoff, or never
+        // queried for — are indistinguishable from the outside, because the only
+        // observable is the truncated top-k. Emitting every candidate WITH its
+        // score components before `truncate` is what separates them.
+        tracing::debug!(
+            target: RANK_TRACE_TARGET,
+            drawer_id = %drawer.id,
+            similarity = hit.score,
+            importance = drawer.importance,
+            eff_importance,
+            tag_boost,
+            score = final_score,
+            "l2 candidate"
+        );
 
         results.push(RecallResult {
             drawer: drawer.clone(),
@@ -339,8 +410,9 @@ pub async fn retrieve_l2_scoped(
 /// What: Embeds the query, searches with `top_k` (over-fetched to `top_k * 3`
 /// when a room filter is active, since filtered-out hits would otherwise eat
 /// the budget), joins each hit to its drawer via UUID-prefix match, drops
-/// drawers outside the requested room, scores as `importance * hit.score`,
-/// sorts descending, and returns at most `top_k` `RecallResult`s.
+/// drawers outside the requested room, scores each candidate with
+/// [`rank_score`], sorts descending, and returns at most `top_k`
+/// `RecallResult`s.
 /// Test: Symmetric with `l2_returns_relevant_drawer`; same join logic.
 /// `l3_room_filter_excludes_other_rooms` covers the filter.
 pub async fn retrieve_l3(
@@ -419,14 +491,15 @@ pub async fn retrieve_l3_scoped(
             handle
                 .decay_config
                 .effective_importance(drawer.importance, age_days, boost);
-        let effective_score = eff_importance * hit.score;
 
         let drawer_id = drawer.id;
         let in_closet = query_tokens
             .iter()
             .any(|tok| closets.get(tok).is_some_and(|ids| ids.contains(&drawer_id)));
         let tag_boost = if in_closet { 0.15_f32 } else { 0.0 };
-        let final_score = (effective_score + tag_boost).min(1.0);
+        // #4904: shares the one `rank_score` L2 uses, so deep recall cannot be
+        // left ranking on the old importance-multiplier formula.
+        let final_score = rank_score(hit.score, eff_importance, tag_boost);
 
         results.push(RecallResult {
             drawer: drawer.clone(),

--- a/crates/trusty-common/src/memory_core/retrieval/tests.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/tests.rs
@@ -1877,3 +1877,238 @@ async fn wing_scoped_deep_recall_returns_only_that_wing() {
         "a pm-wing drawer leaked through an engineer-wing deep recall"
     );
 }
+
+// ── #4904: importance must tilt the ranking, not replace it ─────────────────
+
+/// Build a unit vector at a chosen cosine similarity to `reference`.
+///
+/// Why (#4904): the ranking defect only shows up when two candidates are close
+/// in similarity and far apart in importance — the shape the live palace
+/// measured (0.067 similarity spread against a 0.436 importance spread). A
+/// hash-based `MockEmbedder` cannot be steered to that shape, so the test
+/// synthesises the vectors and inserts them into the store directly.
+/// What: normalises `reference`, picks a direction orthogonal to it by
+/// Gram-Schmidt against a `seed`-selected sign pattern, and returns
+/// `cos * r̂ + sqrt(1 - cos²) * ô`. Varying `seed` spreads the fillers over
+/// distinct directions instead of stacking them on one plane.
+/// Test: used by `l2_ranks_similar_low_importance_above_less_similar_high_importance`.
+fn vec_at_cosine(reference: &[f32], cos: f32, seed: usize) -> Vec<f32> {
+    let norm = |v: &[f32]| v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let rn = norm(reference);
+    let r: Vec<f32> = reference.iter().map(|x| x / rn).collect();
+    // Sign pattern keyed on `seed` — guarantees a non-parallel starting vector
+    // for any non-degenerate reference, and a different one per seed.
+    let base: Vec<f32> = (0..r.len())
+        .map(|i| {
+            if (i / (seed + 1)).is_multiple_of(2) {
+                1.0
+            } else {
+                -1.0
+            }
+        })
+        .collect();
+    let dot: f32 = base.iter().zip(&r).map(|(s, x)| s * x).sum();
+    let mut o: Vec<f32> = base.iter().zip(&r).map(|(s, x)| s - dot * x).collect();
+    let on = norm(&o);
+    for x in o.iter_mut() {
+        *x /= on;
+    }
+    let sin = (1.0 - cos * cos).max(0.0).sqrt();
+    r.iter().zip(&o).map(|(a, b)| cos * a + sin * b).collect()
+}
+
+/// Fill a handle's vector index with off-topic drawers around `qv`.
+///
+/// Why (#4904): `hnsw_rs` recall on a two-point graph is not reliable — the
+/// pre-existing `dream_cycle_merges_duplicates` failure is the same shape, a
+/// top-3 search over two vectors that intermittently returns one. A ranking
+/// assertion must not inherit that. Padding the index to a couple of dozen
+/// points makes the search effectively exhaustive, so what the test observes is
+/// the scoring order and nothing else.
+/// What: inserts `n` drawers at cosines stepping down from 0.60, each on its own
+/// orthogonal direction, with mid-range importance so they cannot dominate under
+/// either the old or the new formula.
+/// Test: used by the two #4904 ranking tests below.
+async fn pad_index(handle: &PalaceHandle, qv: &[f32], n: usize) {
+    let room_id = Uuid::new_v4();
+    for i in 0..n {
+        let mut d = Drawer::new(room_id, format!("unrelated filler drawer {i}"));
+        d.importance = 0.5;
+        handle
+            .vector_store
+            .upsert(d.id, vec_at_cosine(qv, 0.60 - 0.02 * i as f32, i + 2))
+            .await
+            .unwrap();
+        handle.add_drawer(d);
+    }
+}
+
+/// Why (#4904): `rank_score` is the one place the three ranking inputs meet, so
+/// the tiebreaker property is asserted on it directly rather than inferred from
+/// an end-to-end ordering.
+/// What: asserts a 0.05-wide similarity gap survives a full-width importance
+/// gap, that importance still orders equal-similarity candidates, and that the
+/// clamp holds.
+/// Test: this is the test.
+#[test]
+fn rank_score_keeps_importance_a_tiebreaker() {
+    use super::layers::rank_score;
+
+    // The measured production shape: similarity differs by 0.05, importance by
+    // the full range. Similarity must win.
+    let more_similar_less_important = rank_score(0.80, 0.05, 0.0);
+    let less_similar_most_important = rank_score(0.75, 1.00, 0.0);
+    assert!(
+        more_similar_less_important > less_similar_most_important,
+        "importance overrode a 0.05 similarity gap: {more_similar_less_important} vs \
+         {less_similar_most_important}"
+    );
+
+    // With similarity equal, importance still decides — it is a tiebreaker,
+    // not a no-op.
+    assert!(
+        rank_score(0.70, 1.00, 0.0) > rank_score(0.70, 0.05, 0.0),
+        "importance stopped breaking ties between equally-similar candidates"
+    );
+
+    // The closet boost and the 1.0 clamp are unchanged.
+    assert!(rank_score(0.70, 0.5, 0.15) > rank_score(0.70, 0.5, 0.0));
+    assert_eq!(rank_score(1.0, 1.0, 0.15), 1.0);
+}
+
+/// Why (#4904): the hook injected ~1,211 tokens per prompt while missing
+/// curated facts because L2 scored `eff_importance * similarity`. With
+/// `eff_importance` spanning 0.436 inside a candidate pool whose similarity
+/// spans 0.067, the product ranked by importance and ignored relevance — a
+/// 400-drawer self-retrieval probe on the live palace scored recall@1 102/400
+/// under that formula against 291/400 for similarity alone.
+/// What: two drawers with hand-built vectors 0.05 apart in cosine and at
+/// opposite ends of the importance range. Under the old formula the
+/// high-importance drawer wins (0.75 × 1.0 = 0.75 beats 0.80 × 0.05 = 0.04);
+/// under [`rank_score`] the more similar one does.
+/// Test: this is the test.
+#[tokio::test]
+async fn l2_ranks_similar_low_importance_above_less_similar_high_importance() {
+    init_embedder();
+    let dir = tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    let embedder = shared_embedder().await.unwrap();
+
+    let query = "context budget startup memory migration duplicate deletion";
+    let qv = embedder
+        .embed_batch(&[query.to_string()])
+        .await
+        .unwrap()
+        .remove(0);
+
+    let room_id = Uuid::new_v4();
+
+    let mut on_topic = Drawer::new(room_id, "the fact the user was actually asking for");
+    on_topic.importance = 0.05;
+    let on_topic_id = on_topic.id;
+
+    let mut loud = Drawer::new(room_id, "an unrelated but maximally important drawer");
+    loud.importance = 1.0;
+    let loud_id = loud.id;
+
+    handle
+        .vector_store
+        .upsert(on_topic_id, vec_at_cosine(&qv, 0.80, 0))
+        .await
+        .unwrap();
+    handle
+        .vector_store
+        .upsert(loud_id, vec_at_cosine(&qv, 0.75, 1))
+        .await
+        .unwrap();
+    handle.add_drawer(on_topic);
+    handle.add_drawer(loud);
+    pad_index(&handle, &qv, 24).await;
+
+    let results = retrieve_l2(&handle, embedder.as_ref(), query, None, 5)
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 5, "top_k=5 over a padded index");
+    assert!(
+        uuid_prefix_eq(results[0].drawer.id, on_topic_id),
+        "the more similar drawer must rank first; importance won instead \
+         (top={:?} scores={:?})",
+        results[0].drawer.id,
+        results.iter().map(|r| r.score).collect::<Vec<_>>()
+    );
+    assert!(
+        uuid_prefix_eq(results[1].drawer.id, loud_id),
+        "expected the high-importance drawer second"
+    );
+}
+
+/// Why (#4904): the three explanations for a fact missing from an injection —
+/// absent from the candidate set, present but below the cutoff, never queried —
+/// are indistinguishable from the truncated top-k alone. The pre-truncation
+/// trace is what separates them, so it must survive refactors of the scoring
+/// loop.
+/// What: captures `tracing` events on [`RANK_TRACE_TARGET`] across a `top_k=1`
+/// L2 call and asserts every candidate the HNSW pool yielded was traced, not
+/// just the one that survived truncation.
+/// Test: this is the test.
+#[tokio::test]
+async fn l2_rank_trace_emits_one_event_per_candidate() {
+    use std::sync::Mutex;
+    use tracing::subscriber::with_default;
+
+    init_embedder();
+    let dir = tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    let embedder = shared_embedder().await.unwrap();
+
+    let query = "trace every candidate before truncation";
+    let qv = embedder
+        .embed_batch(&[query.to_string()])
+        .await
+        .unwrap()
+        .remove(0);
+    pad_index(&handle, &qv, 24).await;
+
+    // The pool `retrieve_l2` will see: `top_k=1` over-fetches to 3.
+    let pool = handle.vector_store.search(&qv, 3).await.unwrap();
+    assert_eq!(
+        pool.len(),
+        3,
+        "expected a 3-wide over-fetched candidate pool"
+    );
+
+    #[derive(Clone, Default)]
+    struct Counter(Arc<Mutex<usize>>);
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for Counter {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if event.metadata().target() == super::layers::RANK_TRACE_TARGET {
+                *self.0.lock().unwrap() += 1;
+            }
+        }
+    }
+
+    let counter = Counter::default();
+    let seen = counter.0.clone();
+    {
+        use tracing_subscriber::layer::SubscriberExt as _;
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_subscriber::filter::LevelFilter::DEBUG)
+            .with(counter);
+        // `retrieve_l2` is async; drive it to completion inside the dispatch
+        // scope so every event is attributed to this subscriber.
+        let fut = retrieve_l2(&handle, embedder.as_ref(), query, None, 1);
+        let results = with_default(subscriber, || futures::executor::block_on(fut)).unwrap();
+        assert_eq!(results.len(), 1, "top_k=1 must truncate to one result");
+    }
+
+    assert_eq!(
+        *seen.lock().unwrap(),
+        pool.len(),
+        "every candidate must be traced, including the ones truncation drops"
+    );
+}


### PR DESCRIPTION
## Diagnosis

Three explanations produced the same observable and nothing separated them. They are separated now.

**(b) ranked below the cutoff — dominant.** L2/L3 scored `eff_importance * similarity`. Inside one candidate pool the two factors are not comparable: similarity spans **0.067**, `eff_importance` spans **0.436** — 6.5× more. The product therefore ranks by importance and discards the search. Over 200 real hook queries replayed from `enriched-prompts.*.jsonl`, the final top-5 matched the similarity top-5 in **1 of 200**.

Ground truth via a **self-retrieval probe** on the live 1,272-drawer palace — each drawer queried with its own leading 300 chars, so the right answer is known:

| ranking | recall@5 | recall@1 |
|---|---|---|
| `sim * eff` (shipped) | 295/400 | 102/400 |
| `sim * (0.95 + 0.05*eff)` (this PR) | **351/400** | **291/400** |
| `sim` alone | 350/400 | 291/400 |

The multiplier was discarding two thirds of the correct top hits. On a 150-drawer slice, 25 drawers that raw cosine put in the top-5 were pushed out by it and only 1 was pulled in — a net loss of 24 of 129.

**(a) never a candidate — real but small.** 385/400 drawers reach the HNSW top-150 by their own text; 369/400 reach the top-15 pool production actually fetches. The ~3.8% floor is [#4906](https://github.com/bobmatnyc/trusty-tools/issues/4906) (39 of 1,272 drawers have no vector — 1,272 drawers vs 1,233 vectors on the live palace). Not a ranking defect and not fixed here.

**(c) query construction — real, second order, not fixed here.** Over 1,363 firings (Aug 1–5, trusty-tools palace): **51.5% of queries exceed the embedder's 512-token window** and are silently truncated; **63% are `<task-notification>` blobs** — agent result reports, not user questions — whose first ~647 chars are boilerplate, eating a median 32% of the window that survives. `expand_query` fires on 22% of real queries but only via incidental substring hits ("performance", "thread") in long blobs; it never expands a standing behavioural preference. Fixing this well is a design change with no ground truth to validate against, so it is reported, not guessed at.

## The fix

Importance now tilts the score by at most 5% (`IMPORTANCE_TILT`) — the tiebreaker role its own docs always described. L2 and L3 share one `rank_score` instead of repeating the expression, so deep recall cannot be left on an older formula. Every L2 candidate is traced with its score components **before** the `top_k` truncation, on the `memory_recall_rank` target; that pre-truncation view is what tells (a) apart from (b), and its absence is why this was undiagnosable.

Scope kept deliberately narrow: the HNSW over-fetch is unchanged (with ranking now ≈ cosine order, widening the pool cannot change a top-5 of a top-15), and `top_k`/the byte cap are untouched.

## Two bounded questions

**Is trimming the injection the better lever?** No — not now. Precision was the problem and it moved: recall@1 nearly tripled. Re-measure the injection against the same corpus after this lands before touching `top_k`, the 4 KB cap, or gating the hook. At current precision, trimming would remove signal that now exists.

**Should an exact-tag / keyword leg be blended in?** One already exists in the ranker and carries no signal at either end. The closet tag boost (`+0.15` on a query-token/closet match) is **dead on a freshly-opened palace** — `rebuild_closets` runs only after a write, never at `open`, so every recall before the first write sees an empty index — and **saturated once populated**: over 200 real queries it fired on **2,751 of 3,000 candidates (91.7%)**, on every candidate in 148/200 queries, because the mean query carries 158.8 keywords after stop-word filtering against a 35,581-key index built from every drawer's full content. Against ground truth it is a no-op: the self-retrieval probe scores 351/400 with the index rebuilt and 351/400 with it empty. Adding a call to `rebuild_closets` at open would cost a full tokenisation of every drawer for zero measured gain. What demonstrably works is `memory_list`, which filters the drawer's **`tags`** field — a different index from this content-token one. A real tag leg would have to key on `tags`, and it should be scoped and measured on its own.

## Test ladder — rung 4 (trusty-common plus its direct dependent trusty-memory)

```
cargo fmt --check                                                                              — clean
cargo clippy -p trusty-common --features memory-core,embedder-test-support --all-targets -- -D warnings — clean
cargo test  -p trusty-common --features memory-core,embedder-test-support -- --test-threads=1  — 870 passed, 0 failed, 13 ignored (lib) + 24 passed across 5 integration targets
cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui                     — clean
cargo test  -p trusty-memory -- --test-threads=1                                               — 560 passed, 2 failed (pre-existing, see below)
bash scripts/check_line_cap.sh                                                                 — 3720 files, 0 violations
```

**Fail-before / pass-after.** With `rank_score` reverted to the old product in place:

```
l2_ranks_similar_low_importance_above_less_similar_high_importance
  the more similar drawer must rank first; importance won instead (scores=[0.75, 0.040000003])
rank_score_keeps_importance_a_tiebreaker
  importance overrode a 0.05 similarity gap: 0.040000003 vs 0.75
test result: FAILED. 42 passed; 2 failed
```

**Pre-existing failures, reproduced on clean `origin/main` (`c679c3c3`) in a scratch worktree, not caused by this branch:**

- `trusty-memory` `commands::doctor::tests::check_daemon_health_fails_{cleanly_with_stale_addr,when_no_addr_file}_and_no_listener` — environmental; a live trusty-memory daemon on this host makes the "no listener" precondition false. Baseline: `0 passed; 2 failed`.
- `trusty-common` `memory_core::dream::tests::dream_cycle_{merges_duplicates,compression_ratio_nonzero_after_dedup}` — fail only when the suite is filtered, pass in the unfiltered run. Same root cause my own tests had to work around: `hnsw_rs` recall over a two-point graph is not reliable, and `dedup_pass` does a top-3 search over two vectors. Baseline under `--lib memory_core::`: `464 passed; 2 failed` — identical set to this branch's `467 passed; 2 failed` (+3 = the tests added here). Unfiltered, both are green.

Diagnosis harness: `PalaceHandle::open` on a copy of the live palace, driving `retrieve_l2_scoped` and `UsearchStore::search` directly over drawers and replayed prompts. Not committed — the shipped `memory_recall_rank` trace is the durable half.

Added: 178 / Removed: 12 / Net: +166.

Closes #4904

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
