### PR TITLE
fix(trusty-common): stop deferred embedding from dropping failures silently (#4906)

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -210,7 +210,6 @@ crates/trusty-common/src/memory_core/dream/recall_benchmark.rs	dream_recall_benc
 crates/trusty-common/src/memory_core/registry.rs	evict_idle_skips_recently_accessed_handle
 crates/trusty-common/src/memory_core/registry.rs	open_hydrates_persisted_palaces
 crates/trusty-common/src/memory_core/retrieval/handle.rs	decay_applied_in_l2_score
-crates/trusty-common/src/memory_core/retrieval/handle.rs	deferred_embed_backfills_vector_once_embedder_ready
 crates/trusty-common/src/memory_core/retrieval/handle.rs	palace_handle_read_only_when_locked_by_another_process
 crates/trusty-common/src/memory_core/retrieval/handle.rs	remember_classifies_session_events
 crates/trusty-common/src/memory_core/semantic_consolidation/inference.rs	ollama_inference_new_stores_fields

--- a/crates/trusty-common/changelog.d/4906-silent-embed-failures.md
+++ b/crates/trusty-common/changelog.d/4906-silent-embed-failures.md
@@ -2,7 +2,7 @@ Fixed
 
 - deferred embedding no longer drops failures silently — a drawer can no longer be stored, durable, and permanently unfindable (closes [#4906](https://github.com/bobmatnyc/trusty-tools/issues/4906))
   - the background embed lane retries transient failures with bounded exponential backoff instead of giving up on the first error
-  - a final failure writes a durable row to the palace's `embed_failures.json` ledger, so the loss outlives the `warn!` that used to be its only trace
+  - a final failure writes a durable row to the palace's `embed_failures.json` ledger, so the loss outlives the `warn!` that used to be its only trace — serialised through `json_rmw`, so a burst of concurrent failures keeps every row instead of only the last writer's
   - "no embedder on this host" is separated from "the embedder is here and this drawer failed"; only the second marks a drawer, so a machine with no model downloaded is not reported as having thousands of broken drawers
   - new `PalaceHandle::embed_health()` answers "which drawers have no vector" by set-differencing the drawer table against the vector index, replacing a self-retrieval guess
   - new `PalaceHandle::backfill_missing_vectors()` re-embeds drawers that already lack a vector — idempotent, safe to re-run, and a no-op on a healthy palace (it does not even resolve an embedder when there is nothing to repair)

--- a/crates/trusty-common/changelog.d/4906-silent-embed-failures.md
+++ b/crates/trusty-common/changelog.d/4906-silent-embed-failures.md
@@ -1,0 +1,8 @@
+Fixed
+
+- deferred embedding no longer drops failures silently — a drawer can no longer be stored, durable, and permanently unfindable (closes [#4906](https://github.com/bobmatnyc/trusty-tools/issues/4906))
+  - the background embed lane retries transient failures with bounded exponential backoff instead of giving up on the first error
+  - a final failure writes a durable row to the palace's `embed_failures.json` ledger, so the loss outlives the `warn!` that used to be its only trace
+  - "no embedder on this host" is separated from "the embedder is here and this drawer failed"; only the second marks a drawer, so a machine with no model downloaded is not reported as having thousands of broken drawers
+  - new `PalaceHandle::embed_health()` answers "which drawers have no vector" by set-differencing the drawer table against the vector index, replacing a self-retrieval guess
+  - new `PalaceHandle::backfill_missing_vectors()` re-embeds drawers that already lack a vector — idempotent, safe to re-run, and a no-op on a healthy palace (it does not even resolve an embedder when there is nothing to repair)

--- a/crates/trusty-common/src/json_rmw.rs
+++ b/crates/trusty-common/src/json_rmw.rs
@@ -30,9 +30,14 @@
 //!    serialises separate processes AND separate threads that each call
 //!    [`update`], on Unix and Windows alike.
 //! 2. **All-or-nothing publish.** Readers of `path` see either the complete
-//!    previous document or the complete new one, never a partial write. The
-//!    temp file carries the writer's pid and a nanosecond stamp, so concurrent
-//!    writers never share a scratch path even if one of them bypasses the lock.
+//!    previous document or the complete new one, never a partial write: the
+//!    document is built in a temp file and moved into place with `rename`.
+//!    That is the whole of this guarantee — the temp name (pid plus a
+//!    nanosecond stamp) is scratch-path hygiene, NOT a second line of defence
+//!    for a writer that bypasses the lock. An earlier version of this comment
+//!    claimed it was; #4906's review falsified that experimentally, with 16
+//!    threads landing on a single nanosecond value and colliding. Only
+//!    guarantee 1 keeps concurrent writers apart.
 //! 3. **Never fail open.** Every failure — lock acquisition, read, parse,
 //!    serialise, write, rename — returns `Err` and leaves `path` byte-for-byte
 //!    unchanged. There is no path on which a failed update advances state, and

--- a/crates/trusty-common/src/memory_core/retrieval/deferred_embed.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/deferred_embed.rs
@@ -254,7 +254,7 @@ pub(super) async fn run_deferred_embed(
     let embedder = match shared_embedder().await {
         Ok(e) => e,
         Err(e) => {
-            record_loss(&ctx, id, &EmbedLoss::EmbedderUnavailable(format!("{e:#}")));
+            record_loss(&ctx, id, &EmbedLoss::EmbedderUnavailable(format!("{e:#}"))).await;
             return;
         }
     };
@@ -286,9 +286,9 @@ pub(super) async fn embed_store_or_record(
             );
             // A drawer that has just been embedded is no longer missing; drop
             // any stale row so the ledger cannot outlive the condition.
-            clear_ledger(ctx, id);
+            clear_ledger(ctx, id).await;
         }
-        Err(loss) => record_loss(ctx, id, &loss),
+        Err(loss) => record_loss(ctx, id, &loss).await,
     }
 }
 
@@ -311,10 +311,12 @@ pub(super) fn spawn(ctx: DeferredEmbedCtx, id: Uuid, content: String) {
 /// and a log line nobody keeps are complementary failures, not alternatives.
 /// What: skips the ledger entirely for a host-level embedder outage; otherwise
 /// writes one row keyed by drawer id, but only if the drawer still exists (a
-/// drawer forgotten mid-flight has nothing to annotate).
+/// drawer forgotten mid-flight has nothing to annotate). The write runs on
+/// `spawn_blocking` because `json_rmw::update` blocks the calling thread on an
+/// advisory `flock`.
 /// Test: `permanent_failure_writes_a_ledger_row`,
 /// `missing_embedder_does_not_mark_the_drawer`.
-pub(super) fn record_loss(ctx: &DeferredEmbedCtx, id: Uuid, loss: &EmbedLoss) {
+pub(super) async fn record_loss(ctx: &DeferredEmbedCtx, id: Uuid, loss: &EmbedLoss) {
     let reason = loss.reason();
     if !loss.is_drawer_specific() {
         // Expected on a host with no model downloaded, and on a cold start
@@ -353,21 +355,40 @@ pub(super) fn record_loss(ctx: &DeferredEmbedCtx, id: Uuid, loss: &EmbedLoss) {
         attempts: loss.attempts(),
         reason,
     };
-    if let Err(e) = embed_ledger::record(data_dir, entry) {
-        tracing::error!(
+    let dir = data_dir.clone();
+    let written = tokio::task::spawn_blocking(move || embed_ledger::record(&dir, entry)).await;
+    match written {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::error!(
             palace = %ctx.palace_id, drawer = %id,
             "#4906: could not write the embed-failure ledger: {e:#}"
-        );
+        ),
+        Err(e) => tracing::error!(
+            palace = %ctx.palace_id, drawer = %id,
+            "#4906: embed-failure ledger write task failed: {e}"
+        ),
     }
 }
 
 /// Drop one drawer's ledger row after a successful embed.
-fn clear_ledger(ctx: &DeferredEmbedCtx, id: Uuid) {
+///
+/// Why: a repaired drawer must stop being reported as broken, or the ledger
+/// outlives the condition it describes.
+/// What: a single-id [`embed_ledger::clear`] on `spawn_blocking` (same `flock`
+/// blocking contract as [`record_loss`]). A palace with no ledger short-circuits
+/// inside `clear` without creating one.
+/// Test: `backfill_reembeds_a_marked_drawer`.
+async fn clear_ledger(ctx: &DeferredEmbedCtx, id: Uuid) {
     let Some(data_dir) = ctx.data_dir.as_ref() else {
         return;
     };
-    let ids: std::collections::HashSet<Uuid> = std::iter::once(id).collect();
-    if let Err(e) = embed_ledger::clear(data_dir, &ids) {
+    let dir = data_dir.clone();
+    let cleared = tokio::task::spawn_blocking(move || {
+        let ids: std::collections::HashSet<Uuid> = std::iter::once(id).collect();
+        embed_ledger::clear(&dir, &ids)
+    })
+    .await;
+    if let Ok(Err(e)) = cleared {
         tracing::warn!(palace = %ctx.palace_id, drawer = %id, "#4906: ledger clear failed: {e:#}");
     }
 }

--- a/crates/trusty-common/src/memory_core/retrieval/deferred_embed.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/deferred_embed.rs
@@ -1,0 +1,373 @@
+//! The deferred (background) embed lane: retry, then record what was lost.
+//!
+//! Why (#4906): `PalaceHandle::spawn_deferred_embed` was fire-and-forget. Every
+//! failure path was a `warn!` followed by a bare `return` — one embedder blip
+//! and the drawer stayed durable in redb and permanently invisible to vector
+//! recall, with nothing anywhere that could later say so. Measured on the live
+//! `trusty-tools` palace: 39 of 1,241 drawers had no vector, one of them written
+//! during an in-flight migration. `memory_recall` cannot detect this class of
+//! failure, because it only searches what got embedded.
+//!
+//! What: the same background lane, with three changes. A transient failure is
+//! retried with exponential backoff instead of being dropped on the first
+//! error. A final failure writes a durable row to the palace's embed-failure
+//! ledger. And "no embedder on this host" is separated from "the embedder is
+//! here and this drawer failed" — the first is an expected state on a machine
+//! with no model downloaded and must not mark every drawer broken.
+//!
+//! The write path stays asynchronous on purpose. Storing a drawer must not fail
+//! or hang because the embedder is slow or down (issue #1970); the fix is to
+//! stop LOSING the failure, not to make writes synchronous.
+//!
+//! Test: `retry_succeeds_after_transient_failures`,
+//! `permanent_failure_writes_a_ledger_row`,
+//! `missing_embedder_does_not_mark_the_drawer`.
+
+use super::embedder::shared_embedder;
+use crate::memory_core::embed::Embedder;
+use crate::memory_core::palace::{Drawer, PalaceId};
+use crate::memory_core::store::embed_ledger::{self, EmbedFailure};
+use crate::memory_core::store::vector::{UsearchStore, VectorStore};
+use crate::memory_core::timeouts;
+use parking_lot::RwLock;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use uuid::Uuid;
+
+/// Attempts made before a deferred embed is declared lost.
+///
+/// Why: an ONNX session under memory pressure, or a vector-store write racing a
+/// redb commit, fails once and succeeds immediately after. Three attempts cover
+/// that without turning a genuinely dead embedder into a long stall on a
+/// background task.
+const DEFAULT_EMBED_ATTEMPTS: u32 = 3;
+
+/// First backoff step; doubles per attempt (250 ms, 500 ms).
+const DEFAULT_EMBED_RETRY_BASE_MS: u64 = 250;
+
+/// Bounded exponential-backoff policy for one embed job.
+///
+/// Why: the retry has to be a value rather than a constant so the backfill can
+/// run a longer policy than the write-path lane, and so tests can collapse the
+/// delays to zero instead of sleeping for real.
+/// What: `attempts` total tries (not retries — `attempts: 1` means no retry) and
+/// a base delay doubled on each successive failure.
+/// Test: `retry_succeeds_after_transient_failures`.
+#[derive(Debug, Clone, Copy)]
+pub struct RetryPolicy {
+    pub attempts: u32,
+    pub base_delay: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            attempts: DEFAULT_EMBED_ATTEMPTS,
+            base_delay: Duration::from_millis(DEFAULT_EMBED_RETRY_BASE_MS),
+        }
+    }
+}
+
+impl RetryPolicy {
+    /// Delay to wait after the `attempt`-th failure (1-based).
+    fn delay_for(&self, attempt: u32) -> Duration {
+        let shift = attempt.saturating_sub(1).min(6);
+        self.base_delay.saturating_mul(1u32 << shift)
+    }
+
+    /// Policy with no sleeping, for tests that only care about attempt counts.
+    #[cfg(any(test, feature = "embedder-test-support"))]
+    pub fn instant(attempts: u32) -> Self {
+        Self {
+            attempts,
+            base_delay: Duration::ZERO,
+        }
+    }
+}
+
+/// Why a drawer ended up without a vector.
+///
+/// Why: the two cases demand opposite responses. `EmbedderUnavailable` is an
+/// expected state on a host with no model downloaded — marking every drawer
+/// broken there would be a false alarm at estate scale. Everything else means
+/// the embedder was present and this particular drawer failed, which is
+/// precisely what the ledger exists to record.
+/// What: a three-way split carrying the last error text.
+/// Test: `missing_embedder_does_not_mark_the_drawer`.
+#[derive(Debug, Clone)]
+pub enum EmbedLoss {
+    /// No embedder could be initialised on this host.
+    EmbedderUnavailable(String),
+    /// The embedder was present; producing the vector failed.
+    Embed { reason: String, attempts: u32 },
+    /// The vector was produced but could not be stored.
+    Upsert { reason: String, attempts: u32 },
+}
+
+impl EmbedLoss {
+    /// Whether this loss is the drawer's fault rather than the host's.
+    ///
+    /// Why: only a host-independent failure justifies a durable per-drawer
+    /// marker. See the type docs.
+    /// What: `false` for [`EmbedLoss::EmbedderUnavailable`], `true` otherwise.
+    /// Test: `missing_embedder_does_not_mark_the_drawer`.
+    pub fn is_drawer_specific(&self) -> bool {
+        !matches!(self, EmbedLoss::EmbedderUnavailable(_))
+    }
+
+    /// How many attempts were made before giving up (0 when we never got an
+    /// embedder to try with).
+    pub(super) fn attempts(&self) -> u32 {
+        match self {
+            EmbedLoss::EmbedderUnavailable(_) => 0,
+            EmbedLoss::Embed { attempts, .. } | EmbedLoss::Upsert { attempts, .. } => *attempts,
+        }
+    }
+
+    /// Human-readable failure text, naming the stage that failed.
+    pub(super) fn reason(&self) -> String {
+        match self {
+            EmbedLoss::EmbedderUnavailable(r) => format!("embedder unavailable: {r}"),
+            EmbedLoss::Embed { reason, .. } => format!("embed failed: {reason}"),
+            EmbedLoss::Upsert { reason, .. } => format!("vector upsert failed: {reason}"),
+        }
+    }
+}
+
+/// Run `op` up to `policy.attempts` times, sleeping between failures.
+///
+/// Why: embed and upsert both need the same bounded-retry shape, and writing it
+/// twice is how the two drift into disagreeing about what "transient" means.
+/// What: returns the first `Ok`, or the LAST error text once attempts are
+/// exhausted. Also returns how many attempts were actually made, which is what
+/// the ledger records.
+/// Test: `retry_succeeds_after_transient_failures`.
+pub(super) async fn with_retry<T, F, Fut>(
+    policy: &RetryPolicy,
+    mut op: F,
+) -> Result<(T, u32), (String, u32)>
+where
+    F: FnMut(u32) -> Fut,
+    Fut: std::future::Future<Output = Result<T, String>>,
+{
+    let total = policy.attempts.max(1);
+    let mut last = String::from("no attempt was made");
+    for attempt in 1..=total {
+        match op(attempt).await {
+            Ok(v) => return Ok((v, attempt)),
+            Err(e) => last = e,
+        }
+        if attempt < total {
+            tokio::time::sleep(policy.delay_for(attempt)).await;
+        }
+    }
+    Err((last, total))
+}
+
+/// Embed `content` and store the vector under `id`, retrying transient failures.
+///
+/// Why: this is the single embed+store primitive shared by the write-path
+/// deferred lane and the repair backfill, so a drawer recovered by the backfill
+/// is embedded by exactly the code that would have embedded it at write time.
+/// What: retries `embed_batch` (each attempt under the existing
+/// `TRUSTY_EMBED_BATCH_TIMEOUT_SECS` bound), then retries the vector upsert.
+/// Returns the failing stage in [`EmbedLoss`] so the caller can decide whether
+/// it warrants a durable marker.
+/// Test: `retry_succeeds_after_transient_failures`,
+/// `permanent_failure_writes_a_ledger_row`.
+pub(super) async fn embed_and_store(
+    embedder: &Arc<dyn Embedder + Send + Sync>,
+    vector_store: &Arc<UsearchStore>,
+    id: Uuid,
+    content: &str,
+    policy: &RetryPolicy,
+) -> Result<u32, EmbedLoss> {
+    let batch = [content.to_string()];
+    let embed_timeout = timeouts::embed_batch_timeout();
+    let (vector, embed_attempts) = with_retry(policy, |_| {
+        let embedder = embedder.clone();
+        let batch = &batch;
+        async move {
+            match tokio::time::timeout(embed_timeout, embedder.embed_batch(batch)).await {
+                Ok(Ok(v)) => v
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| "embedder returned an empty batch".to_string()),
+                Ok(Err(e)) => Err(format!("{e:#}")),
+                Err(_) => Err(format!("embed_batch timed out after {embed_timeout:?}")),
+            }
+        }
+    })
+    .await
+    .map_err(|(reason, attempts)| EmbedLoss::Embed { reason, attempts })?;
+
+    let (_, upsert_attempts) = with_retry(policy, |_| {
+        let vector = vector.clone();
+        let vector_store = vector_store.clone();
+        async move {
+            vector_store
+                .upsert(id, vector)
+                .await
+                .map_err(|e| format!("{e:#}"))
+        }
+    })
+    .await
+    .map_err(|(reason, attempts)| EmbedLoss::Upsert { reason, attempts })?;
+
+    Ok(embed_attempts.max(upsert_attempts))
+}
+
+/// The slice of `PalaceHandle` the background lane needs.
+///
+/// Why: the spawned task outlives the `&self` borrow it was created from, and
+/// cloning the individual `Arc`s is cheaper (and clearer about what the lane
+/// touches) than requiring callers to hold an `Arc<PalaceHandle>`.
+/// What: palace id, vector store, the in-memory drawer table, and the data dir
+/// the ledger lives in. `data_dir` is `None` for in-memory test handles, in
+/// which case there is nowhere durable to record a failure and the lane says so
+/// in the log instead.
+/// Test: exercised by every test in `embed_repair_tests`.
+#[derive(Clone)]
+pub(super) struct DeferredEmbedCtx {
+    pub palace_id: PalaceId,
+    pub vector_store: Arc<UsearchStore>,
+    pub drawers: Arc<RwLock<Vec<Drawer>>>,
+    pub data_dir: Option<PathBuf>,
+}
+
+/// Body of the background embed task, as an awaitable future.
+///
+/// Why: kept separate from the `tokio::spawn` wrapper so tests can await the
+/// whole job deterministically instead of racing a detached task.
+/// What: resolves the shared embedder, embeds and stores with retry, and on a
+/// drawer-specific failure records a ledger row. An unavailable embedder is
+/// logged and left unmarked — see [`EmbedLoss::is_drawer_specific`].
+/// Test: `permanent_failure_writes_a_ledger_row`,
+/// `missing_embedder_does_not_mark_the_drawer`.
+pub(super) async fn run_deferred_embed(
+    ctx: DeferredEmbedCtx,
+    id: Uuid,
+    content: String,
+    policy: RetryPolicy,
+) {
+    let embedder = match shared_embedder().await {
+        Ok(e) => e,
+        Err(e) => {
+            record_loss(&ctx, id, &EmbedLoss::EmbedderUnavailable(format!("{e:#}")));
+            return;
+        }
+    };
+    embed_store_or_record(&ctx, &embedder, id, &content, &policy).await;
+}
+
+/// Embed one drawer and durably record the outcome.
+///
+/// Why: split out of [`run_deferred_embed`] so the failure-recording behaviour
+/// can be tested against a deliberately broken embedder — the shared embedder is
+/// a process-wide `OnceCell` that tests seed with a working mock, so a test
+/// driving the whole function could never reach the failure branch.
+/// What: runs [`embed_and_store`]; on success clears any stale ledger row, on
+/// failure hands the loss to [`record_loss`].
+/// Test: `permanent_failure_writes_a_ledger_row`,
+/// `retry_succeeds_after_transient_failures`.
+pub(super) async fn embed_store_or_record(
+    ctx: &DeferredEmbedCtx,
+    embedder: &Arc<dyn Embedder + Send + Sync>,
+    id: Uuid,
+    content: &str,
+    policy: &RetryPolicy,
+) {
+    match embed_and_store(embedder, &ctx.vector_store, id, content, policy).await {
+        Ok(attempts) => {
+            tracing::info!(
+                palace = %ctx.palace_id, drawer = %id, attempts,
+                "deferred embed: vector backfill complete"
+            );
+            // A drawer that has just been embedded is no longer missing; drop
+            // any stale row so the ledger cannot outlive the condition.
+            clear_ledger(ctx, id);
+        }
+        Err(loss) => record_loss(ctx, id, &loss),
+    }
+}
+
+/// Fire the background embed task.
+///
+/// Why: `remember_with_options` must return as soon as the durable KG/redb
+/// write completes (issue #1970) — the caller is not made to wait for a cold
+/// ONNX compile.
+/// What: spawns [`run_deferred_embed`] with the default retry policy.
+/// Test: covered through `PalaceHandle::remember_with_options` in
+/// `retrieval::tests`.
+pub(super) fn spawn(ctx: DeferredEmbedCtx, id: Uuid, content: String) {
+    tokio::spawn(run_deferred_embed(ctx, id, content, RetryPolicy::default()));
+}
+
+/// Persist (or decline to persist) the fact that a drawer has no vector.
+///
+/// Why: this is the whole point of #4906 — the failure must outlive the log
+/// line. It is still logged at `error!`, because a durable marker nobody reads
+/// and a log line nobody keeps are complementary failures, not alternatives.
+/// What: skips the ledger entirely for a host-level embedder outage; otherwise
+/// writes one row keyed by drawer id, but only if the drawer still exists (a
+/// drawer forgotten mid-flight has nothing to annotate).
+/// Test: `permanent_failure_writes_a_ledger_row`,
+/// `missing_embedder_does_not_mark_the_drawer`.
+pub(super) fn record_loss(ctx: &DeferredEmbedCtx, id: Uuid, loss: &EmbedLoss) {
+    let reason = loss.reason();
+    if !loss.is_drawer_specific() {
+        // Expected on a host with no model downloaded, and on a cold start
+        // before the first successful init. Marking every drawer here would be
+        // a false alarm at estate scale; the vector-gap detector still reports
+        // the shortfall, alongside `embedder_ready: false` to explain it.
+        tracing::warn!(
+            palace = %ctx.palace_id, drawer = %id,
+            "#4906: deferred embed skipped — {reason}; drawer stored WITHOUT a \
+             vector and left unmarked (no embedder on this host). Run the \
+             vector backfill once an embedder is available."
+        );
+        return;
+    }
+
+    tracing::error!(
+        palace = %ctx.palace_id, drawer = %id, attempts = loss.attempts(),
+        "#4906: deferred embed FAILED — {reason}; drawer is durable but not \
+         vector-searchable. Recorded in the palace embed-failure ledger."
+    );
+
+    let still_present = ctx.drawers.read().iter().any(|d| d.id == id);
+    if !still_present {
+        return;
+    }
+    let Some(data_dir) = ctx.data_dir.as_ref() else {
+        tracing::warn!(
+            palace = %ctx.palace_id, drawer = %id,
+            "#4906: no data dir on this handle — failure could not be recorded durably"
+        );
+        return;
+    };
+    let entry = EmbedFailure {
+        drawer_id: id,
+        failed_at: chrono::Utc::now(),
+        attempts: loss.attempts(),
+        reason,
+    };
+    if let Err(e) = embed_ledger::record(data_dir, entry) {
+        tracing::error!(
+            palace = %ctx.palace_id, drawer = %id,
+            "#4906: could not write the embed-failure ledger: {e:#}"
+        );
+    }
+}
+
+/// Drop one drawer's ledger row after a successful embed.
+fn clear_ledger(ctx: &DeferredEmbedCtx, id: Uuid) {
+    let Some(data_dir) = ctx.data_dir.as_ref() else {
+        return;
+    };
+    let ids: std::collections::HashSet<Uuid> = std::iter::once(id).collect();
+    if let Err(e) = embed_ledger::clear(data_dir, &ids) {
+        tracing::warn!(palace = %ctx.palace_id, drawer = %id, "#4906: ledger clear failed: {e:#}");
+    }
+}

--- a/crates/trusty-common/src/memory_core/retrieval/embed_repair.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/embed_repair.rs
@@ -1,0 +1,284 @@
+//! Answering "which drawers have no vector", and repairing the ones that don't.
+//!
+//! Why (#4906): fixing the write path forward repairs nothing. On the live
+//! `trusty-tools` palace 39 of 1,241 drawers were already durable-but-unfindable
+//! before the retry lane existed, and no amount of correct future behaviour
+//! makes them retrievable. Two things were missing: a way to ASK the question
+//! without a full re-scan guess, and a way to ACT on the answer.
+//!
+//! What: [`PalaceHandle::embed_health`] set-differences the drawer table against
+//! the vector index — the exact, cheap detector, since a drawer id absent from
+//! the index has no vector by definition — and
+//! [`PalaceHandle::backfill_missing_vectors`] re-embeds what it finds. The
+//! backfill is idempotent: a second run over a repaired palace finds nothing
+//! missing and does no work, and a dry run never touches the embedder at all.
+//!
+//! Note on the cheap `vector_count == drawer_count` check suggested by PR #4903:
+//! it is the right SUMMARY (it is how the 39 were first measured, and it is
+//! what the `trusty-memory doctor` check reports because the daemon already
+//! serves both counts) but it is not sufficient on its own — the vector index
+//! can also hold ORPHANS (vectors whose drawer was forgotten), so equal counts
+//! do not prove full coverage. The set difference here is what the repair path
+//! acts on; the count comparison is the alarm that sends you to it.
+//!
+//! Test: `health_reports_the_drawer_with_no_vector`,
+//! `backfill_reembeds_a_marked_drawer`, `backfill_is_a_noop_on_a_healthy_palace`.
+
+use super::deferred_embed::{RetryPolicy, embed_and_store};
+use super::embedder::{shared_embedder, shared_embedder_initialized};
+use super::handle::PalaceHandle;
+use crate::memory_core::store::embed_ledger::{self, EmbedFailure};
+use anyhow::{Context, Result};
+use std::collections::HashSet;
+use uuid::Uuid;
+
+/// Vector-coverage snapshot for one palace.
+///
+/// Why: the question "is this palace's memory actually findable?" had no answer
+/// short of self-retrieving every drawer and guessing from the ranking, which
+/// is how a 3.1 % coverage hole went unnoticed. This makes it a lookup.
+/// What: the two counts, the exact set of drawer ids with no vector, and any
+/// durable failure rows the deferred lane recorded. `embedder_ready` says
+/// whether an embedder has initialised in this process — without it a shortfall
+/// is unexplained, and "no embedder on this host" reads identically to "the
+/// embedder is dropping writes".
+/// Test: `health_reports_the_drawer_with_no_vector`.
+#[derive(Debug, Clone)]
+pub struct EmbedHealth {
+    pub palace_id: String,
+    /// Live drawers considered (expired non-Tier-C rows are excluded — they are
+    /// reclaimable and never served, so a missing vector for one is not a hole).
+    pub drawer_count: usize,
+    /// Entries in the vector index, orphans included.
+    pub vector_count: usize,
+    /// Drawer ids with no entry in the vector index. This is the authoritative
+    /// answer; everything else on this struct is context for it.
+    pub missing_vector_ids: Vec<Uuid>,
+    /// Rows the deferred lane wrote when it gave up (#4906 ledger).
+    pub recorded_failures: Vec<EmbedFailure>,
+    /// Whether a shared embedder has initialised in this process.
+    pub embedder_ready: bool,
+}
+
+impl EmbedHealth {
+    /// Whether every live drawer is vector-searchable.
+    pub fn is_healthy(&self) -> bool {
+        self.missing_vector_ids.is_empty()
+    }
+}
+
+/// How a backfill run should behave.
+///
+/// Why: the operator's first run should be a read-only measurement — the
+/// migration this unblocks (#4834) deletes source files on the strength of the
+/// answer, so being able to see the number before changing anything is the
+/// point.
+/// What: `dry_run` reports without embedding; `limit` caps the repairs per run
+/// so a huge estate can be worked through in bounded chunks; `retry` is the
+/// per-drawer policy.
+/// Test: `backfill_dry_run_repairs_nothing`.
+#[derive(Debug, Clone, Copy)]
+pub struct VectorBackfillOptions {
+    pub dry_run: bool,
+    pub limit: Option<usize>,
+    pub retry: RetryPolicy,
+}
+
+impl Default for VectorBackfillOptions {
+    fn default() -> Self {
+        Self {
+            dry_run: true,
+            limit: None,
+            retry: RetryPolicy::default(),
+        }
+    }
+}
+
+/// Outcome of one backfill run.
+///
+/// Why: the counts are the evidence an operator needs before deleting a source
+/// file — "repaired 39, still_failing 0" is the statement that unblocks it.
+/// What: what was found, what was attempted, and what is still broken.
+/// Test: `backfill_reembeds_a_marked_drawer`.
+#[derive(Debug, Clone)]
+pub struct VectorBackfillReport {
+    pub palace_id: String,
+    pub dry_run: bool,
+    pub drawer_count: usize,
+    pub vector_count: usize,
+    /// Drawers found with no vector before this run.
+    pub missing: usize,
+    /// Drawers this run tried to embed (0 for a dry run, `<= limit` otherwise).
+    pub attempted: usize,
+    /// Drawers that now have a vector because of this run.
+    pub repaired: usize,
+    /// Drawers this run tried and could not repair.
+    pub still_failing: usize,
+    /// Ids still without a vector after this run (including any skipped by
+    /// `limit`), so a caller can act on the remainder.
+    pub still_missing_ids: Vec<Uuid>,
+}
+
+impl PalaceHandle {
+    /// Vector-coverage snapshot for this palace.
+    ///
+    /// Why: see the module docs — this is the queryable form of "which drawers
+    /// have no vector", replacing a self-retrieval guess with a set difference.
+    /// What: reads the in-memory drawer table (the complete mirror of the redb
+    /// DRAWERS table, hydrated at open) and the vector index's id set. Excludes
+    /// expired non-Tier-C drawers, which are never served regardless. Cheap: no
+    /// embedding, no vector search, no redb write.
+    /// Test: `health_reports_the_drawer_with_no_vector`.
+    pub fn embed_health(&self) -> EmbedHealth {
+        let vector_ids: HashSet<Uuid> = self.vector_store.all_ids().into_iter().collect();
+        let now = chrono::Utc::now();
+        let live: Vec<Uuid> = self
+            .drawers
+            .read()
+            .iter()
+            .filter(|d| !(d.is_expired_at(now) && !d.is_tier_c()))
+            .map(|d| d.id)
+            .collect();
+        let missing_vector_ids: Vec<Uuid> = live
+            .iter()
+            .copied()
+            .filter(|id| !vector_ids.contains(id))
+            .collect();
+        let recorded_failures = self
+            .data_dir
+            .as_ref()
+            .map(|d| embed_ledger::load(d))
+            .unwrap_or_default();
+        EmbedHealth {
+            palace_id: self.id.as_str().to_string(),
+            drawer_count: live.len(),
+            vector_count: vector_ids.len(),
+            missing_vector_ids,
+            recorded_failures,
+            embedder_ready: shared_embedder_initialized(),
+        }
+    }
+
+    /// Re-embed every live drawer that has no vector.
+    ///
+    /// Why: the repair half of #4906. Fixing the write path does not make the
+    /// drawers already written without a vector findable, and #4834 cannot
+    /// delete a source file until they are.
+    /// What: computes [`EmbedHealth`], then (unless `dry_run`) embeds each
+    /// missing drawer through the same `embed_and_store` primitive the write
+    /// path uses, clearing its ledger row on success and refreshing it on
+    /// failure. Idempotent and safe to re-run: a repaired drawer is no longer in
+    /// the missing set, so a second run does nothing.
+    ///
+    /// Errors, rather than half-running, when the palace is read-only (a
+    /// snapshot handle cannot write vectors — route through the daemon) or when
+    /// there is work to do and no embedder can be initialised. A dry run has
+    /// neither constraint, so it still reports on a host with no model.
+    /// Test: `backfill_reembeds_a_marked_drawer`,
+    /// `backfill_is_a_noop_on_a_healthy_palace`, `backfill_dry_run_repairs_nothing`.
+    pub async fn backfill_missing_vectors(
+        &self,
+        opts: VectorBackfillOptions,
+    ) -> Result<VectorBackfillReport> {
+        let health = self.embed_health();
+        let mut report = VectorBackfillReport {
+            palace_id: health.palace_id.clone(),
+            dry_run: opts.dry_run,
+            drawer_count: health.drawer_count,
+            vector_count: health.vector_count,
+            missing: health.missing_vector_ids.len(),
+            attempted: 0,
+            repaired: 0,
+            still_failing: 0,
+            still_missing_ids: health.missing_vector_ids.clone(),
+        };
+
+        // A healthy palace short-circuits BEFORE touching the embedder, so the
+        // no-op case costs nothing and works on a host with no model at all.
+        if opts.dry_run || health.missing_vector_ids.is_empty() {
+            return Ok(report);
+        }
+
+        if self.is_read_only() {
+            anyhow::bail!(
+                "palace '{}' is read-only: the HTTP daemon holds the write lock — run the \
+                 vector backfill through the daemon (`palace_reembed`) or stop it first",
+                self.id
+            );
+        }
+
+        let embedder = shared_embedder()
+            .await
+            .context("acquire shared embedder for vector backfill")?;
+
+        let targets: Vec<Uuid> = match opts.limit {
+            Some(n) => health.missing_vector_ids.iter().copied().take(n).collect(),
+            None => health.missing_vector_ids.clone(),
+        };
+
+        let mut repaired: HashSet<Uuid> = HashSet::new();
+        for id in targets {
+            // Re-read the content under the lock each time: a `forget` may have
+            // landed since `embed_health` ran, in which case there is nothing to
+            // embed and adding a vector would only create an orphan.
+            let content = {
+                let drawers = self.drawers.read();
+                drawers
+                    .iter()
+                    .find(|d| d.id == id)
+                    .map(|d| d.content.clone())
+            };
+            let Some(content) = content else {
+                continue;
+            };
+            report.attempted += 1;
+            match embed_and_store(&embedder, &self.vector_store, id, &content, &opts.retry).await {
+                Ok(attempts) => {
+                    tracing::info!(
+                        palace = %self.id, drawer = %id, attempts,
+                        "#4906: vector backfill repaired a drawer"
+                    );
+                    repaired.insert(id);
+                }
+                Err(loss) => {
+                    report.still_failing += 1;
+                    tracing::error!(
+                        palace = %self.id, drawer = %id,
+                        "#4906: vector backfill could not repair this drawer: {}",
+                        loss.reason()
+                    );
+                    self.record_backfill_failure(id, &loss);
+                }
+            }
+        }
+
+        report.repaired = repaired.len();
+        report.still_missing_ids.retain(|id| !repaired.contains(id));
+        if let Some(data_dir) = self.data_dir.as_ref()
+            && !repaired.is_empty()
+            && let Err(e) = embed_ledger::clear(data_dir, &repaired)
+        {
+            tracing::warn!(palace = %self.id, "#4906: ledger clear after backfill failed: {e:#}");
+        }
+        Ok(report)
+    }
+
+    /// Refresh a drawer's ledger row after a failed repair attempt.
+    fn record_backfill_failure(&self, id: Uuid, loss: &super::deferred_embed::EmbedLoss) {
+        let Some(data_dir) = self.data_dir.as_ref() else {
+            return;
+        };
+        if !loss.is_drawer_specific() {
+            return;
+        }
+        let entry = EmbedFailure {
+            drawer_id: id,
+            failed_at: chrono::Utc::now(),
+            attempts: loss.attempts(),
+            reason: loss.reason(),
+        };
+        if let Err(e) = embed_ledger::record(data_dir, entry) {
+            tracing::error!(palace = %self.id, drawer = %id, "#4906: ledger write failed: {e:#}");
+        }
+    }
+}

--- a/crates/trusty-common/src/memory_core/retrieval/embed_repair.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/embed_repair.rs
@@ -247,7 +247,7 @@ impl PalaceHandle {
                         "#4906: vector backfill could not repair this drawer: {}",
                         loss.reason()
                     );
-                    self.record_backfill_failure(id, &loss);
+                    self.record_backfill_failure(id, &loss).await;
                 }
             }
         }
@@ -256,15 +256,27 @@ impl PalaceHandle {
         report.still_missing_ids.retain(|id| !repaired.contains(id));
         if let Some(data_dir) = self.data_dir.as_ref()
             && !repaired.is_empty()
-            && let Err(e) = embed_ledger::clear(data_dir, &repaired)
         {
-            tracing::warn!(palace = %self.id, "#4906: ledger clear after backfill failed: {e:#}");
+            // `spawn_blocking`: `json_rmw::update` blocks on an advisory flock.
+            let dir = data_dir.clone();
+            let cleared =
+                tokio::task::spawn_blocking(move || embed_ledger::clear(&dir, &repaired)).await;
+            if let Ok(Err(e)) = cleared {
+                tracing::warn!(palace = %self.id, "#4906: ledger clear after backfill failed: {e:#}");
+            }
         }
         Ok(report)
     }
 
     /// Refresh a drawer's ledger row after a failed repair attempt.
-    fn record_backfill_failure(&self, id: Uuid, loss: &super::deferred_embed::EmbedLoss) {
+    ///
+    /// Why: a backfill that tries and fails must leave the drawer marked with
+    /// the fresh attempt count, or the next operator sees a stale reason.
+    /// What: skips a host-level embedder outage (same rule as the write path),
+    /// otherwise records on `spawn_blocking` per `json_rmw`'s contract.
+    /// Test: covered through `backfill_reembeds_a_marked_drawer`'s failure
+    /// counterpart in `permanent_failure_writes_a_ledger_row`.
+    async fn record_backfill_failure(&self, id: Uuid, loss: &super::deferred_embed::EmbedLoss) {
         let Some(data_dir) = self.data_dir.as_ref() else {
             return;
         };
@@ -277,7 +289,9 @@ impl PalaceHandle {
             attempts: loss.attempts(),
             reason: loss.reason(),
         };
-        if let Err(e) = embed_ledger::record(data_dir, entry) {
+        let dir = data_dir.clone();
+        let written = tokio::task::spawn_blocking(move || embed_ledger::record(&dir, entry)).await;
+        if let Ok(Err(e)) = written {
             tracing::error!(palace = %self.id, drawer = %id, "#4906: ledger write failed: {e:#}");
         }
     }

--- a/crates/trusty-common/src/memory_core/retrieval/embed_repair_tests.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/embed_repair_tests.rs
@@ -496,6 +496,52 @@ fn embed_ledger_roundtrips_and_upserts_by_drawer() {
     assert_eq!(a_row.attempts, 7);
 }
 
+/// Why: `clear` runs on the SUCCESS path of every deferred embed, and
+/// `json_rmw::update` has no "nothing changed" branch — reaching it costs an
+/// flock plus two fsyncs even when no row matched. Without the pre-lock check,
+/// one recorded failure anywhere in a palace would make every subsequent
+/// healthy write pay that. This pins the check so the next refactor cannot drop
+/// it again (it was lost once already, in the port to `json_rmw`).
+/// What: seeds one row, clears an unrelated id, and asserts the file's mtime and
+/// bytes are untouched — the observable proxy for "no write happened".
+/// Test: itself.
+#[test]
+fn clear_without_a_matching_row_never_writes() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("embed_failures.json");
+    embed_ledger::record(
+        dir.path(),
+        EmbedFailure {
+            drawer_id: Uuid::new_v4(),
+            failed_at: chrono::Utc::now(),
+            attempts: 1,
+            reason: "x".to_string(),
+        },
+    )
+    .unwrap();
+    let before = std::fs::metadata(&path).unwrap().modified().unwrap();
+    let bytes_before = std::fs::read(&path).unwrap();
+
+    // An id that is not in the ledger — the healthy-write case.
+    embed_ledger::clear(dir.path(), &std::iter::once(Uuid::new_v4()).collect()).unwrap();
+
+    assert_eq!(
+        std::fs::metadata(&path).unwrap().modified().unwrap(),
+        before,
+        "a clear that matches nothing must not republish the ledger"
+    );
+    assert_eq!(std::fs::read(&path).unwrap(), bytes_before);
+
+    // A palace with no ledger at all must not have one created for it.
+    let empty = tempfile::tempdir().unwrap();
+    embed_ledger::clear(empty.path(), &std::iter::once(Uuid::new_v4()).collect()).unwrap();
+    assert!(
+        !empty.path().join("embed_failures.json").exists(),
+        "clearing on a healthy palace must not create the ledger or its lock sidecar"
+    );
+    assert!(!empty.path().join("embed_failures.json.lock").exists());
+}
+
 /// Why: clearing must be surgical — a backfill that repaired one drawer must
 /// not wipe the record of the ones it could not.
 /// What: records two rows, clears one, asserts the other survives.
@@ -577,16 +623,18 @@ fn embed_ledger_load_degrades_to_empty_on_malformed_json() {
 }
 
 /// Why: this is the review's HIGH-1, and the reason it survived the first
-/// suite is that nothing exercised two writers at once. `record` is
-/// load→retain→push→save; without serialisation two writers that both load
-/// before either saves each write their own single-row result and the later
-/// rename wins. That is the DESIGN LOAD, not a corner case:
-/// `spawn_deferred_embed` spawns one detached task per drawer, every task
-/// sleeps the same 250 ms + 500 ms backoff, so a burst against a broken
-/// embedder lands all of them in `record_loss` within a few milliseconds.
+/// suite is that nothing exercised two writers at once. A read-modify-write
+/// without serialisation lets two writers both load before either publishes;
+/// each then writes its own single-row result and the later rename discards the
+/// other's. That is the DESIGN LOAD, not a corner case: `spawn_deferred_embed`
+/// spawns one detached task per drawer, every task sleeps the same
+/// 250 ms + 500 ms backoff, so a burst against a broken embedder lands all of
+/// them in `record_loss` within a few milliseconds.
 ///
-/// Fail-before / pass-after: without [`embed_ledger::dir_lock`] this keeps a
-/// handful of the 16 rows; with it, all 16.
+/// Fail-before / pass-after: [`embed_ledger::record`] routes through
+/// `json_rmw::update`, whose advisory `flock` is held by the open file
+/// description and so serialises threads as well as processes. Patched to skip
+/// only that lock, this test keeps 1 of 16 rows; unpatched, all 16.
 /// What: 16 OS threads released together by a `Barrier`, each recording a
 /// distinct drawer id; asserts every id survives.
 /// Test: itself.

--- a/crates/trusty-common/src/memory_core/retrieval/embed_repair_tests.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/embed_repair_tests.rs
@@ -234,7 +234,8 @@ async fn missing_embedder_does_not_mark_the_drawer() {
         &ctx,
         id,
         &EmbedLoss::EmbedderUnavailable("model not downloaded".to_string()),
-    );
+    )
+    .await;
     assert!(
         embed_ledger::load(dir.path()).is_empty(),
         "a host-level embedder outage must not mark individual drawers broken"
@@ -248,7 +249,8 @@ async fn missing_embedder_does_not_mark_the_drawer() {
             reason: "tensor shape mismatch".to_string(),
             attempts: 3,
         },
-    );
+    )
+    .await;
     assert_eq!(
         embed_ledger::load(dir.path()).len(),
         1,
@@ -273,7 +275,8 @@ async fn loss_for_a_forgotten_drawer_is_not_recorded() {
             reason: "gone".to_string(),
             attempts: 1,
         },
-    );
+    )
+    .await;
     assert!(embed_ledger::load(dir.path()).is_empty());
 }
 
@@ -529,4 +532,157 @@ fn embed_ledger_load_is_empty_when_absent() {
     let dir = tempfile::tempdir().unwrap();
     assert!(embed_ledger::load(dir.path()).is_empty());
     assert!(embed_ledger::load(&dir.path().join("nope")).is_empty());
+}
+
+/// Why: reads and writes take deliberately OPPOSITE positions on a corrupt
+/// ledger, and both need pinning or the next refactor will quietly align them.
+/// A read must never be able to stop a palace opening, so `load` degrades to
+/// empty. A write must never silently discard a file it could not parse, so
+/// `record` — going through `json_rmw`, which never fails open — returns `Err`
+/// and leaves the bytes untouched. Losing an annotation costs less than
+/// refusing access to the memories; destroying one costs more than declining
+/// to write.
+/// What: writes bytes that are not a JSON array; asserts `load` is empty, that
+/// `record` errors rather than overwriting, and that the original bytes survive.
+/// Test: itself.
+#[test]
+fn embed_ledger_load_degrades_to_empty_on_malformed_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("embed_failures.json");
+    std::fs::write(&path, b"{not json at all").unwrap();
+    assert!(
+        embed_ledger::load(dir.path()).is_empty(),
+        "a malformed ledger must read as empty, not panic or error"
+    );
+
+    let err = embed_ledger::record(
+        dir.path(),
+        EmbedFailure {
+            drawer_id: Uuid::new_v4(),
+            failed_at: chrono::Utc::now(),
+            attempts: 1,
+            reason: "x".to_string(),
+        },
+    )
+    .expect_err("a write must not silently replace an unparseable ledger");
+    assert!(
+        format!("{err:#}").contains("embed_failures.json"),
+        "the error must name the file an operator has to look at: {err:#}"
+    );
+    assert_eq!(
+        std::fs::read(&path).unwrap(),
+        b"{not json at all",
+        "the unparseable bytes must survive the refused write"
+    );
+}
+
+/// Why: this is the review's HIGH-1, and the reason it survived the first
+/// suite is that nothing exercised two writers at once. `record` is
+/// load→retain→push→save; without serialisation two writers that both load
+/// before either saves each write their own single-row result and the later
+/// rename wins. That is the DESIGN LOAD, not a corner case:
+/// `spawn_deferred_embed` spawns one detached task per drawer, every task
+/// sleeps the same 250 ms + 500 ms backoff, so a burst against a broken
+/// embedder lands all of them in `record_loss` within a few milliseconds.
+///
+/// Fail-before / pass-after: without [`embed_ledger::dir_lock`] this keeps a
+/// handful of the 16 rows; with it, all 16.
+/// What: 16 OS threads released together by a `Barrier`, each recording a
+/// distinct drawer id; asserts every id survives.
+/// Test: itself.
+#[test]
+fn concurrent_ledger_records_keep_every_row() {
+    const WRITERS: usize = 16;
+    let dir = tempfile::tempdir().unwrap();
+    let ids: Vec<Uuid> = (0..WRITERS).map(|_| Uuid::new_v4()).collect();
+    let barrier = std::sync::Barrier::new(WRITERS);
+
+    std::thread::scope(|scope| {
+        for id in &ids {
+            let path = dir.path();
+            let barrier = &barrier;
+            scope.spawn(move || {
+                // Release every thread at once so the load→save windows overlap.
+                barrier.wait();
+                embed_ledger::record(
+                    path,
+                    EmbedFailure {
+                        drawer_id: *id,
+                        failed_at: chrono::Utc::now(),
+                        attempts: 3,
+                        reason: "burst failure".to_string(),
+                    },
+                )
+                .expect("record");
+            });
+        }
+    });
+
+    let rows = embed_ledger::load(dir.path());
+    assert_eq!(
+        rows.len(),
+        WRITERS,
+        "every concurrent failure must survive — a burst against a broken \
+         embedder is exactly what the ledger exists to capture; got {} of {WRITERS}",
+        rows.len()
+    );
+    for id in &ids {
+        assert!(
+            rows.iter().any(|r| r.drawer_id == *id),
+            "drawer {id} was lost from the ledger"
+        );
+    }
+}
+
+/// Why: a `clear` racing a `record` has the same lost-update shape, and the
+/// repair backfill runs both against one palace — it clears repaired ids while
+/// the deferred lane may still be recording new failures.
+/// What: 8 threads recording fresh rows while 8 clear pre-seeded ones; asserts
+/// the cleared ids are gone and every newly-recorded id is present.
+/// Test: itself.
+#[test]
+fn concurrent_clear_and_record_do_not_lose_each_other() {
+    const N: usize = 8;
+    let dir = tempfile::tempdir().unwrap();
+    let seeded: Vec<Uuid> = (0..N).map(|_| Uuid::new_v4()).collect();
+    let fresh: Vec<Uuid> = (0..N).map(|_| Uuid::new_v4()).collect();
+    let row = |id: Uuid| EmbedFailure {
+        drawer_id: id,
+        failed_at: chrono::Utc::now(),
+        attempts: 1,
+        reason: "x".to_string(),
+    };
+    for id in &seeded {
+        embed_ledger::record(dir.path(), row(*id)).unwrap();
+    }
+
+    let barrier = std::sync::Barrier::new(N * 2);
+    std::thread::scope(|scope| {
+        for i in 0..N {
+            let (path, barrier) = (dir.path(), &barrier);
+            let (drop_id, add_id) = (seeded[i], fresh[i]);
+            scope.spawn(move || {
+                barrier.wait();
+                embed_ledger::clear(path, &std::iter::once(drop_id).collect()).expect("clear");
+            });
+            scope.spawn(move || {
+                barrier.wait();
+                embed_ledger::record(path, row(add_id)).expect("record");
+            });
+        }
+    });
+
+    let rows = embed_ledger::load(dir.path());
+    for id in &seeded {
+        assert!(
+            !rows.iter().any(|r| r.drawer_id == *id),
+            "cleared drawer {id} must not survive"
+        );
+    }
+    for id in &fresh {
+        assert!(
+            rows.iter().any(|r| r.drawer_id == *id),
+            "newly recorded drawer {id} must not be lost to a concurrent clear"
+        );
+    }
 }

--- a/crates/trusty-common/src/memory_core/retrieval/embed_repair_tests.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/embed_repair_tests.rs
@@ -1,0 +1,532 @@
+//! Tests for #4906 — the deferred-embed retry lane, the durable failure
+//! ledger, the vector-coverage health surface, and the repair backfill.
+//!
+//! Why: the defect these cover is silent. A drawer stored without a vector is
+//! byte-identical, from the caller's side, to one stored with a vector — the
+//! write returns `Ok`, the drawer is durable, and only a search that never
+//! finds it reveals the difference. Every test here therefore asserts on state
+//! that survives the process (the ledger file, the vector index), not on log
+//! output.
+//! What: fail-before / pass-after coverage for all four behaviours the fix
+//! claims — transient failure retried, permanent failure marked, backfill
+//! repairing a marked drawer, backfill being a no-op on a healthy palace.
+//! Test: this file IS the tests. Run with
+//!   `cargo test -p trusty-common --features memory-core,embedder-test-support embed_repair`
+
+use super::deferred_embed::{
+    EmbedLoss, RetryPolicy, embed_and_store, embed_store_or_record, record_loss,
+};
+use super::embed_repair::VectorBackfillOptions;
+use super::embedder::seed_shared_embedder_with_mock;
+use super::handle::PalaceHandle;
+use crate::embedder::MockEmbedder;
+use crate::memory_core::embed::Embedder;
+use crate::memory_core::palace::{Drawer, PalaceId};
+use crate::memory_core::store::embed_ledger::{self, EmbedFailure};
+use crate::memory_core::store::{kg::KnowledgeGraph, vector::UsearchStore};
+use anyhow::Result;
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use uuid::Uuid;
+
+/// Embedder that fails its first `fail_times` calls, then behaves like the
+/// deterministic mock.
+///
+/// Why: "transient" is the whole distinction the retry loop exists to make. A
+/// double that only ever fails cannot prove a retry helped; this one fails and
+/// then recovers, so the assertion is that the vector arrived, not that a
+/// counter moved.
+/// What: an `AtomicU32` call counter; calls at or below `fail_times` return an
+/// error, later calls delegate to `MockEmbedder`.
+/// Test: used by `retry_succeeds_after_transient_failures`.
+struct FlakyEmbedder {
+    fail_times: u32,
+    calls: AtomicU32,
+    inner: MockEmbedder,
+}
+
+impl FlakyEmbedder {
+    fn new(fail_times: u32) -> Self {
+        Self {
+            fail_times,
+            calls: AtomicU32::new(0),
+            inner: MockEmbedder::new(384),
+        }
+    }
+    fn call_count(&self) -> u32 {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl Embedder for FlakyEmbedder {
+    async fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        let n = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+        if n <= self.fail_times {
+            anyhow::bail!("simulated transient embedder failure (call {n})");
+        }
+        self.inner.embed_batch(texts).await
+    }
+    fn dimension(&self) -> usize {
+        384
+    }
+}
+
+/// Embedder that always fails — the permanent-failure case.
+struct DeadEmbedder;
+
+#[async_trait]
+impl Embedder for DeadEmbedder {
+    async fn embed_batch(&self, _texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        anyhow::bail!("simulated permanent embedder failure")
+    }
+    fn dimension(&self) -> usize {
+        384
+    }
+}
+
+/// A palace handle backed by a real data dir, so the ledger has somewhere to go.
+fn make_handle(dir: &std::path::Path) -> PalaceHandle {
+    let vs = UsearchStore::new(dir.join("idx.usearch"), 384).unwrap();
+    let kg = KnowledgeGraph::open(&dir.join("kg.db")).unwrap();
+    let mut handle = PalaceHandle::new(PalaceId::new("embed-repair"), String::new(), vs, kg);
+    handle.data_dir = Some(dir.to_path_buf());
+    handle
+}
+
+/// Add a drawer to the in-memory table WITHOUT a vector — the exact state the
+/// 39 live drawers are in.
+fn add_vectorless_drawer(handle: &PalaceHandle, content: &str) -> Uuid {
+    let drawer = Drawer::new(Uuid::new_v4(), content);
+    let id = drawer.id;
+    handle.add_drawer(drawer);
+    id
+}
+
+// ── 1. Transient failure is retried ──────────────────────────────────────────
+
+/// Why: before #4906 the deferred lane took the first `Err` from `embed_batch`
+/// as final — one transient blip and the drawer was permanently unfindable.
+/// This is the fail-before case: with a single-attempt policy (the old
+/// behaviour) the vector never lands; with the shipped default it does.
+/// What: an embedder that fails twice then succeeds, run under a 3-attempt
+/// policy; asserts the vector reached the store and exactly 3 calls were made.
+/// Test: itself.
+#[tokio::test]
+async fn retry_succeeds_after_transient_failures() {
+    let dir = tempfile::tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    let flaky = Arc::new(FlakyEmbedder::new(2));
+    let embedder: Arc<dyn Embedder + Send + Sync> = flaky.clone();
+    let id = Uuid::new_v4();
+
+    // Fail-before: one attempt reproduces the old fire-and-forget behaviour.
+    let single = embed_and_store(
+        &embedder,
+        &handle.vector_store,
+        id,
+        "content",
+        &RetryPolicy::instant(1),
+    )
+    .await;
+    assert!(
+        single.is_err(),
+        "a single attempt must surface the transient failure (this is the pre-fix behaviour)"
+    );
+    assert!(
+        !handle.vector_store.all_ids().contains(&id),
+        "no vector may exist after the failed single attempt"
+    );
+
+    // Pass-after: retrying rides out the same transient failures.
+    let attempts = embed_and_store(
+        &embedder,
+        &handle.vector_store,
+        id,
+        "content",
+        &RetryPolicy::instant(3),
+    )
+    .await
+    .expect("retry must ride out two transient failures");
+    assert_eq!(attempts, 2, "second call succeeds on its 2nd attempt");
+    assert_eq!(
+        flaky.call_count(),
+        3,
+        "1 failed single + 2 retried attempts"
+    );
+    assert!(
+        handle.vector_store.all_ids().contains(&id),
+        "the vector must be in the index after the retry succeeded"
+    );
+}
+
+// ── 2. Permanent failure is marked, not dropped ──────────────────────────────
+
+/// Why: this is the core of the defect. The old code's every failure path was
+/// `warn!` + `return`, leaving nothing durable that said the drawer has no
+/// vector. A marker that only exists in a log line is not a marker.
+/// What: drives the deferred lane's outcome handler with a permanently broken
+/// embedder and asserts the palace's ledger file — re-read from disk, not from
+/// memory — carries a row for that drawer with the attempt count.
+/// Test: itself.
+#[tokio::test]
+async fn permanent_failure_writes_a_ledger_row() {
+    let dir = tempfile::tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    let id = add_vectorless_drawer(&handle, "a fact that will never embed");
+    let embedder: Arc<dyn Embedder + Send + Sync> = Arc::new(DeadEmbedder);
+
+    assert!(
+        embed_ledger::load(dir.path()).is_empty(),
+        "ledger starts empty"
+    );
+
+    embed_store_or_record(
+        &handle.deferred_embed_ctx(),
+        &embedder,
+        id,
+        "a fact that will never embed",
+        &RetryPolicy::instant(2),
+    )
+    .await;
+
+    let rows = embed_ledger::load(dir.path());
+    assert_eq!(
+        rows.len(),
+        1,
+        "the failure must be recorded durably: {rows:?}"
+    );
+    assert_eq!(rows[0].drawer_id, id);
+    assert_eq!(rows[0].attempts, 2, "the attempt count must be recorded");
+    assert!(
+        rows[0].reason.contains("embed failed"),
+        "the reason must name the failing stage: {}",
+        rows[0].reason
+    );
+    assert!(
+        !handle.vector_store.all_ids().contains(&id),
+        "no vector was produced"
+    );
+
+    // The health surface reports it without re-deriving anything.
+    let health = handle.embed_health();
+    assert_eq!(health.missing_vector_ids, vec![id]);
+    assert_eq!(health.recorded_failures.len(), 1);
+    assert!(!health.is_healthy());
+}
+
+/// Why: an embedder that cannot initialise at all is an expected state — a host
+/// with `--no-embedder`-style operation, a cold start, or no model downloaded.
+/// Marking every drawer written on such a host as broken would be a false alarm
+/// at estate scale, so the two failure classes must not share a code path.
+/// What: records an `EmbedderUnavailable` loss and asserts the ledger stays
+/// empty, while a drawer-specific loss for the same drawer does write a row.
+/// Test: itself.
+#[tokio::test]
+async fn missing_embedder_does_not_mark_the_drawer() {
+    let dir = tempfile::tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    let id = add_vectorless_drawer(&handle, "written on a host with no model");
+    let ctx = handle.deferred_embed_ctx();
+
+    record_loss(
+        &ctx,
+        id,
+        &EmbedLoss::EmbedderUnavailable("model not downloaded".to_string()),
+    );
+    assert!(
+        embed_ledger::load(dir.path()).is_empty(),
+        "a host-level embedder outage must not mark individual drawers broken"
+    );
+
+    // The same drawer, failing with the embedder present, IS marked.
+    record_loss(
+        &ctx,
+        id,
+        &EmbedLoss::Embed {
+            reason: "tensor shape mismatch".to_string(),
+            attempts: 3,
+        },
+    );
+    assert_eq!(
+        embed_ledger::load(dir.path()).len(),
+        1,
+        "a drawer-specific failure must be recorded"
+    );
+}
+
+/// Why: a drawer forgotten while its embed was in flight has nothing to
+/// annotate; a ledger row for an id nothing can look up is noise an operator
+/// would have to triage.
+/// What: records a drawer-specific loss for an id that is not in the drawer
+/// table and asserts nothing is written.
+/// Test: itself.
+#[tokio::test]
+async fn loss_for_a_forgotten_drawer_is_not_recorded() {
+    let dir = tempfile::tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    record_loss(
+        &handle.deferred_embed_ctx(),
+        Uuid::new_v4(),
+        &EmbedLoss::Embed {
+            reason: "gone".to_string(),
+            attempts: 1,
+        },
+    );
+    assert!(embed_ledger::load(dir.path()).is_empty());
+}
+
+// ── 3. The backfill repairs what is already broken ───────────────────────────
+
+/// Why: the deliverable that actually unblocks #4834. Fixing the write path
+/// forward leaves the 39 already-vectorless drawers unfindable; only a repair
+/// pass makes them retrievable, and it must clear the marker it repaired so the
+/// ledger cannot outlive the condition.
+/// What: seeds a vectorless drawer plus its ledger row, runs a live backfill,
+/// and asserts the vector landed, the row is gone, and a semantic recall now
+/// finds the drawer it previously could not.
+/// Test: itself.
+#[tokio::test]
+async fn backfill_reembeds_a_marked_drawer() {
+    seed_shared_embedder_with_mock();
+    let dir = tempfile::tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    let id = add_vectorless_drawer(&handle, "Rust ownership and borrowing rules");
+    embed_ledger::record(
+        dir.path(),
+        EmbedFailure {
+            drawer_id: id,
+            failed_at: chrono::Utc::now(),
+            attempts: 3,
+            reason: "embed failed: simulated".to_string(),
+        },
+    )
+    .unwrap();
+
+    // Fail-before: the drawer is invisible to vector recall.
+    let embedder = super::embedder::shared_embedder().await.unwrap();
+    let before = super::layers::retrieve_l2(
+        &handle,
+        embedder.as_ref(),
+        "Rust ownership and borrowing rules",
+        None,
+        5,
+    )
+    .await
+    .unwrap();
+    assert!(
+        before.is_empty(),
+        "a drawer with no vector must not be retrievable — that is the defect"
+    );
+
+    let report = handle
+        .backfill_missing_vectors(VectorBackfillOptions {
+            dry_run: false,
+            limit: None,
+            retry: RetryPolicy::instant(2),
+        })
+        .await
+        .expect("backfill must run");
+
+    assert_eq!(report.missing, 1);
+    assert_eq!(report.attempted, 1);
+    assert_eq!(report.repaired, 1);
+    assert_eq!(report.still_failing, 0);
+    assert!(report.still_missing_ids.is_empty());
+    assert!(
+        embed_ledger::load(dir.path()).is_empty(),
+        "a repaired drawer must lose its ledger row"
+    );
+
+    // Pass-after: the same query now finds it.
+    let after = super::layers::retrieve_l2(
+        &handle,
+        embedder.as_ref(),
+        "Rust ownership and borrowing rules",
+        None,
+        5,
+    )
+    .await
+    .unwrap();
+    assert!(
+        after.iter().any(|r| r.drawer.id == id),
+        "the repaired drawer must now be retrievable"
+    );
+
+    // Idempotent: a second run finds nothing to do.
+    let again = handle
+        .backfill_missing_vectors(VectorBackfillOptions {
+            dry_run: false,
+            limit: None,
+            retry: RetryPolicy::instant(2),
+        })
+        .await
+        .unwrap();
+    assert_eq!(again.missing, 0);
+    assert_eq!(again.attempted, 0);
+    assert_eq!(again.repaired, 0);
+}
+
+/// Why: a repair tool that does work on a healthy palace is a repair tool
+/// nobody dares run on a schedule. It must also be safe on a host with no
+/// embedder — which means it must not even try to resolve one when there is
+/// nothing to repair.
+/// What: writes a drawer through the normal synchronous path (so it has a
+/// vector), then asserts the backfill reports zero missing and attempts nothing.
+/// Test: itself.
+#[tokio::test]
+async fn backfill_is_a_noop_on_a_healthy_palace() {
+    seed_shared_embedder_with_mock();
+    let dir = tempfile::tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    handle
+        .remember(
+            "a fact that embeds normally".to_string(),
+            crate::memory_core::palace::RoomType::Custom("t".into()),
+            vec![],
+            0.5,
+        )
+        .await
+        .expect("remember");
+
+    let health = handle.embed_health();
+    assert!(health.is_healthy(), "palace should be healthy: {health:?}");
+
+    let report = handle
+        .backfill_missing_vectors(VectorBackfillOptions {
+            dry_run: false,
+            limit: None,
+            retry: RetryPolicy::instant(1),
+        })
+        .await
+        .expect("backfill on a healthy palace must succeed");
+    assert_eq!(report.missing, 0);
+    assert_eq!(report.attempted, 0);
+    assert_eq!(report.repaired, 0);
+}
+
+/// Why: the operator's first action on a live palace is a measurement, not a
+/// mutation — #4834 deletes source files on the strength of the number, so
+/// seeing it before changing anything is the point.
+/// What: asserts a dry run reports the gap and repairs nothing.
+/// Test: itself.
+#[tokio::test]
+async fn backfill_dry_run_repairs_nothing() {
+    seed_shared_embedder_with_mock();
+    let dir = tempfile::tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    let id = add_vectorless_drawer(&handle, "unembedded");
+
+    let report = handle
+        .backfill_missing_vectors(VectorBackfillOptions::default())
+        .await
+        .unwrap();
+    assert!(report.dry_run);
+    assert_eq!(report.missing, 1);
+    assert_eq!(report.attempted, 0);
+    assert_eq!(report.repaired, 0);
+    assert_eq!(report.still_missing_ids, vec![id]);
+    assert!(!handle.vector_store.all_ids().contains(&id));
+}
+
+// ── 4. The health surface and the ledger ─────────────────────────────────────
+
+/// Why: "which drawers have no vector" had no answer short of self-retrieving
+/// every drawer and guessing from the ranking. This is the set difference that
+/// replaces the guess.
+/// What: one embedded drawer and one vectorless drawer; asserts only the
+/// vectorless one is reported and the counts are the ones the doctor check
+/// compares.
+/// Test: itself.
+#[tokio::test]
+async fn health_reports_the_drawer_with_no_vector() {
+    seed_shared_embedder_with_mock();
+    let dir = tempfile::tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    handle
+        .remember(
+            "an embedded fact about caching".to_string(),
+            crate::memory_core::palace::RoomType::Custom("t".into()),
+            vec![],
+            0.5,
+        )
+        .await
+        .unwrap();
+    let missing_id = add_vectorless_drawer(&handle, "a fact with no vector");
+
+    let health = handle.embed_health();
+    assert_eq!(health.drawer_count, 2);
+    assert_eq!(health.vector_count, 1);
+    assert_eq!(health.missing_vector_ids, vec![missing_id]);
+    assert!(health.embedder_ready, "the mock embedder is seeded");
+}
+
+/// Why: the ledger is keyed by drawer id precisely so a repeated failure
+/// refreshes the row instead of appending one — an append-only ledger for a
+/// retrying background lane grows without bound.
+/// What: records twice for the same drawer and once for another; asserts two
+/// rows with the second attempt count winning.
+/// Test: itself.
+#[test]
+fn embed_ledger_roundtrips_and_upserts_by_drawer() {
+    let dir = tempfile::tempdir().unwrap();
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let row = |id: Uuid, attempts: u32| EmbedFailure {
+        drawer_id: id,
+        failed_at: chrono::Utc::now(),
+        attempts,
+        reason: "x".to_string(),
+    };
+    embed_ledger::record(dir.path(), row(a, 1)).unwrap();
+    embed_ledger::record(dir.path(), row(b, 1)).unwrap();
+    embed_ledger::record(dir.path(), row(a, 7)).unwrap();
+
+    let rows = embed_ledger::load(dir.path());
+    assert_eq!(
+        rows.len(),
+        2,
+        "the second write for `a` must replace the first"
+    );
+    let a_row = rows.iter().find(|r| r.drawer_id == a).unwrap();
+    assert_eq!(a_row.attempts, 7);
+}
+
+/// Why: clearing must be surgical — a backfill that repaired one drawer must
+/// not wipe the record of the ones it could not.
+/// What: records two rows, clears one, asserts the other survives.
+/// Test: itself.
+#[test]
+fn embed_ledger_clear_removes_only_named_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    for id in [a, b] {
+        embed_ledger::record(
+            dir.path(),
+            EmbedFailure {
+                drawer_id: id,
+                failed_at: chrono::Utc::now(),
+                attempts: 1,
+                reason: "x".to_string(),
+            },
+        )
+        .unwrap();
+    }
+    embed_ledger::clear(dir.path(), &std::iter::once(a).collect()).unwrap();
+    let rows = embed_ledger::load(dir.path());
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].drawer_id, b);
+}
+
+/// Why: every palace that has never failed an embed has no ledger file, which
+/// is the overwhelmingly common case and must not be an error.
+/// What: asserts a missing file reads as an empty ledger.
+/// Test: itself.
+#[test]
+fn embed_ledger_load_is_empty_when_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(embed_ledger::load(dir.path()).is_empty());
+    assert!(embed_ledger::load(&dir.path().join("nope")).is_empty());
+}

--- a/crates/trusty-common/src/memory_core/retrieval/handle.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/handle.rs
@@ -645,9 +645,14 @@ impl PalaceHandle {
         // backfilled by a background task once the embedder resolves. Text
         // and KG indexing never depend on the embedder either way; this
         // branch only changes *when* the drawer becomes vector-searchable.
-        if opts.defer_embedding {
-            self.spawn_deferred_embed(id, content.clone());
-        } else {
+        //
+        // #4906: the deferred branch is SPAWNED BELOW, after the drawer reaches
+        // `self.drawers`. Spawning here raced the push: the background task
+        // refuses to record a failure for a drawer absent from that table, so a
+        // task that failed before the push wrote nothing for a drawer that was
+        // about to become durable and vector-less — the exact combination this
+        // lane exists to eliminate.
+        if !opts.defer_embedding {
             // Issue #906: both `shared_embedder()` (cold init path) and
             // `embed_batch` carry their own bounded timeouts — if the embedder
             // hangs mid-batch the remember call returns an error instead of
@@ -656,17 +661,22 @@ impl PalaceHandle {
                 .await
                 .context("acquire shared embedder for remember")?;
             let embed_timeout = timeouts::embed_batch_timeout();
-            let vecs = tokio::time::timeout(embed_timeout, embedder.embed_batch(&[content]))
-                .await
-                .map_err(|_| {
-                    anyhow::anyhow!(
-                        "embed_batch timed out after {:?} on remember path (issue #906); \
+            let vecs = tokio::time::timeout(
+                embed_timeout,
+                // `from_ref` rather than `&[content]`: the deferred branch below
+                // still needs `content`, so this borrows instead of moving.
+                embedder.embed_batch(std::slice::from_ref(&content)),
+            )
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "embed_batch timed out after {:?} on remember path (issue #906); \
                          increase TRUSTY_EMBED_BATCH_TIMEOUT_SECS if batches legitimately \
                          take longer on this host",
-                        embed_timeout
-                    )
-                })?
-                .context("embed drawer content")?;
+                    embed_timeout
+                )
+            })?
+            .context("embed drawer content")?;
             if let Some(v) = vecs.into_iter().next() {
                 self.vector_store
                     .upsert(id, v)
@@ -692,6 +702,13 @@ impl PalaceHandle {
             // drawer still claims the slot.
             tier_c::retire_in_memory(&mut drawers, retired);
             drawers.push(drawer);
+        }
+
+        // #4906: spawn the background embed only now. The drawer is in redb and
+        // in the in-memory table, so a failure arriving at any point from here
+        // on finds the drawer present and gets recorded. See the branch above.
+        if opts.defer_embedding {
+            self.spawn_deferred_embed(id, content);
         }
 
         // L1 snapshot: re-sort the in-memory table and persist top-15.

--- a/crates/trusty-common/src/memory_core/retrieval/handle.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/handle.rs
@@ -9,6 +9,8 @@
 //! the full retrieval test suite in retrieval::tests.
 
 use super::embedder::shared_embedder;
+// #4906: the deferred-embed lane — retry, then durably record what was lost.
+use super::deferred_embed;
 // #4886: ADR-0028 Tier C admission + retire-on-write. Kept in its own module so
 // the write path's design rationale does not push this file over the SLOC cap.
 use super::tier_c;
@@ -705,83 +707,39 @@ impl PalaceHandle {
         Ok(id)
     }
 
-    /// Fire-and-forget background embed + vector-store backfill for a
-    /// drawer written while the shared embedder was cold (issue #1970).
+    /// Background embed + vector-store backfill for a drawer written while the
+    /// shared embedder was cold (issue #1970).
     ///
-    /// Why: `memory_remember` / `memory_note` / `task_add` must not block
-    /// the caller behind a 30-120s CoreML/CUDA cold compile just to persist
-    /// a memory — the KG/redb write already completed synchronously by the
-    /// time this is called. This task's only job is to make the drawer's
-    /// vector show up in `retrieve_l2` / `retrieve_l3` once the shared
-    /// embedder resolves.
-    /// What: clones the `Arc<UsearchStore>` handle and spawns a detached
-    /// task that awaits `shared_embedder()` (retrying the cold init if
-    /// necessary), embeds `content` under the same bounded timeout the
-    /// synchronous path uses, and upserts the resulting vector under `id`.
-    /// Every failure mode (embedder init failure, embed timeout, upsert
-    /// error) is logged at `warn!` and dropped — the drawer is already
-    /// durable via KG/redb regardless of whether the vector backfill
-    /// succeeds.
-    /// Known limitation: if the drawer is forgotten before this task
-    /// completes, the backfilled vector becomes an orphaned entry in the
-    /// vector store. Acceptable for a best-effort background lane (mirrors
-    /// the existing best-effort tone of BM25 indexing and auto-KG
-    /// extraction elsewhere in this pipeline); tighten with an
-    /// existence check against `self.drawers` if this proves to matter in
-    /// practice.
-    /// Test: `deferred_embed_backfills_vector_once_embedder_ready` in
-    /// `retrieval::tests`.
+    /// Why: `memory_remember` / `memory_note` / `task_add` must not block the
+    /// caller behind a 30-120 s CoreML/CUDA cold compile just to persist a
+    /// memory — the KG/redb write already completed synchronously by the time
+    /// this is called. #4906: it must also not LOSE the failure. This used to
+    /// end every failure branch in a `warn!` and a bare return, which is how 39
+    /// of 1,241 live drawers ended up durable and permanently unfindable.
+    /// What: hands the job to [`deferred_embed::spawn`], which retries transient
+    /// failures with backoff and records a durable ledger row when it gives up.
+    /// The write path is still asynchronous; only the failure handling changed.
+    /// Known limitation (unchanged): a drawer forgotten before the task finishes
+    /// leaves an orphaned vector, reclaimed by `palace_compact`.
+    /// Test: `permanent_failure_writes_a_ledger_row` and
+    /// `retry_succeeds_after_transient_failures` in `embed_repair_tests`.
     fn spawn_deferred_embed(&self, id: Uuid, content: String) {
-        let vector_store = self.vector_store.clone();
-        let palace_id = self.id.clone();
-        tokio::spawn(async move {
-            let embedder = match shared_embedder().await {
-                Ok(e) => e,
-                Err(e) => {
-                    tracing::warn!(
-                        palace = %palace_id,
-                        drawer = %id,
-                        "deferred embed: shared embedder init failed (vector left unindexed): {e:#}"
-                    );
-                    return;
-                }
-            };
-            let embed_timeout = timeouts::embed_batch_timeout();
-            let vecs =
-                match tokio::time::timeout(embed_timeout, embedder.embed_batch(&[content])).await {
-                    Ok(Ok(v)) => v,
-                    Ok(Err(e)) => {
-                        tracing::warn!(
-                            palace = %palace_id,
-                            drawer = %id,
-                            "deferred embed: embed_batch failed: {e:#}"
-                        );
-                        return;
-                    }
-                    Err(_) => {
-                        tracing::warn!(
-                            palace = %palace_id,
-                            drawer = %id,
-                            "deferred embed: embed_batch timed out after {embed_timeout:?}"
-                        );
-                        return;
-                    }
-                };
-            if let Some(v) = vecs.into_iter().next() {
-                match vector_store.upsert(id, v).await {
-                    Ok(()) => tracing::info!(
-                        palace = %palace_id,
-                        drawer = %id,
-                        "deferred embed: vector backfill complete"
-                    ),
-                    Err(e) => tracing::warn!(
-                        palace = %palace_id,
-                        drawer = %id,
-                        "deferred embed: vector upsert failed: {e:#}"
-                    ),
-                }
-            }
-        });
+        deferred_embed::spawn(self.deferred_embed_ctx(), id, content);
+    }
+
+    /// The slice of this handle the background embed lane needs.
+    ///
+    /// Why: the spawned task outlives the `&self` borrow, so it takes owned
+    /// `Arc` clones rather than a reference.
+    /// What: palace id, vector store, drawer table, and data dir.
+    /// Test: exercised by every `embed_repair_tests` case.
+    pub(super) fn deferred_embed_ctx(&self) -> deferred_embed::DeferredEmbedCtx {
+        deferred_embed::DeferredEmbedCtx {
+            palace_id: self.id.clone(),
+            vector_store: self.vector_store.clone(),
+            drawers: self.drawers.clone(),
+            data_dir: self.data_dir.clone(),
+        }
     }
 
     /// Rebuild the closet keyword index from the current in-memory drawer table.

--- a/crates/trusty-common/src/memory_core/retrieval/mod.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/mod.rs
@@ -10,6 +10,11 @@
 //! Test: `cargo test -p trusty-common --features memory-core retrieval::`
 //! exercises L0/L1 cache and L2 vector retrieval end-to-end.
 
+// #4906: the deferred-embed lane (retry + durable failure ledger) and the
+// vector-coverage health/repair surface that answers "which drawers have no
+// vector" and re-embeds them.
+mod deferred_embed;
+mod embed_repair;
 mod embedder;
 mod handle;
 mod layers;
@@ -19,6 +24,8 @@ mod scope;
 mod tier_c;
 mod types;
 
+#[cfg(test)]
+mod embed_repair_tests;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]
@@ -40,6 +47,12 @@ pub use types::{
 
 // Palace handle
 pub use handle::PalaceHandle;
+
+// #4906: vector-coverage health and the repair backfill. `RetryPolicy` is
+// public because a caller choosing to run a longer policy than the write-path
+// default is a legitimate operator decision.
+pub use deferred_embed::RetryPolicy;
+pub use embed_repair::{EmbedHealth, VectorBackfillOptions, VectorBackfillReport};
 
 // Recall scoping (ADR-0027 T9)
 pub use scope::{RecallScope, list_drawers_in_wing, scope_admits};

--- a/crates/trusty-common/src/memory_core/store/embed_ledger.rs
+++ b/crates/trusty-common/src/memory_core/store/embed_ledger.rs
@@ -8,9 +8,33 @@
 //! to embed and fail?" without re-deriving it from a log.
 //!
 //! What: `<data_dir>/embed_failures.json` — a JSON array of [`EmbedFailure`]
-//! rows keyed by drawer id, written atomically (tmp + rename) with the same
-//! per-invocation tmp naming `L1Cache::save_l1_cache` uses so concurrent
-//! writers cannot trample each other.
+//! rows keyed by drawer id. Every mutation goes through
+//! [`crate::json_rmw::update`], this workspace's single implementation of the
+//! locked load → mutate → publish-atomically critical section.
+//!
+//! Routing through `json_rmw` rather than an atomic rename alone is the fix for
+//! a lost-update bug the first review round found here. The two hazards are
+//! distinct, and conflating them is what produced a comment claiming a safety
+//! property the code did not have:
+//!
+//! - **Torn file.** A unique temp path plus `rename` stops a reader seeing a
+//!   half-written document. `json_rmw` does this, with `fsync`.
+//! - **Lost update.** That does NOTHING for a read-modify-write: two writers
+//!   that both load before either saves each publish their own single-row
+//!   result, and the later rename discards the other's work. Each file is
+//!   individually well-formed; the row is simply gone. This is the DESIGN LOAD,
+//!   not a corner case — `spawn_deferred_embed` spawns one detached task per
+//!   drawer, all sharing the same backoff schedule, so a burst against a broken
+//!   embedder lands every one of them in `record_loss` within a few
+//!   milliseconds. `json_rmw`'s advisory `flock` serialises the whole sequence,
+//!   across threads AND across processes.
+//!
+//! One consequence worth stating: `json_rmw` never fails open, so [`record`] and
+//! [`clear`] return `Err` over a ledger that exists but cannot be parsed, rather
+//! than replacing it with a fresh single-row document. [`load`] takes the
+//! opposite position and degrades to empty, because a read must never be able to
+//! stop a palace opening. Losing an annotation costs less than refusing access
+//! to the memories; silently discarding one costs more than declining to write.
 //!
 //! The ledger is an ANNOTATION, never the source of truth. Whether a drawer has
 //! a vector is answered by set-differencing the drawer table against the vector
@@ -18,27 +42,30 @@
 //! one is missing and how hard we tried. That ordering is deliberate: a marker
 //! that could disagree with the index would be one more thing to keep in sync,
 //! and it repairs nothing for the 39 drawers that were already lost before this
-//! code existed. Rows for drawers that no longer exist, or that have since
-//! acquired a vector, are pruned on the next write rather than trusted.
+//! code existed.
 //!
 //! Test: `embed_ledger_roundtrips_and_upserts_by_drawer`,
 //! `embed_ledger_clear_removes_only_named_rows`,
-//! `embed_ledger_load_is_empty_when_absent`.
+//! `embed_ledger_load_is_empty_when_absent`,
+//! `embed_ledger_load_degrades_to_empty_on_malformed_json`,
+//! `concurrent_ledger_records_keep_every_row`,
+//! `concurrent_clear_and_record_do_not_lose_each_other`.
 
+use crate::json_rmw;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 /// Ledger filename inside a palace's data directory.
 const EMBED_FAILURES_JSON: &str = "embed_failures.json";
 
-/// Per-invocation tmp suffix counter — see `L1Cache::save_l1_cache` for why
-/// two concurrent writers must not share a tmp path.
-static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+/// Path to a palace's ledger file.
+fn ledger_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(EMBED_FAILURES_JSON)
+}
 
 /// One drawer's recorded embedding failure.
 ///
@@ -62,12 +89,15 @@ pub struct EmbedFailure {
 ///
 /// Why: a missing or corrupt ledger must never make a palace unusable — it is
 /// diagnostic annotation, and losing it costs strictly less than refusing to
-/// open the palace that holds the actual memories.
+/// open the palace that holds the actual memories. This is the one place that
+/// deliberately diverges from `json_rmw`'s never-fail-open contract, and it does
+/// so in the direction that cannot hurt: a read, never a write.
 /// What: reads `<data_dir>/embed_failures.json`; a missing file yields `[]`, and
 /// a malformed one yields `[]` plus a `warn!` rather than an error.
-/// Test: `embed_ledger_load_is_empty_when_absent`.
+/// Test: `embed_ledger_load_is_empty_when_absent`,
+/// `embed_ledger_load_degrades_to_empty_on_malformed_json`.
 pub fn load(data_dir: &Path) -> Vec<EmbedFailure> {
-    let target = data_dir.join(EMBED_FAILURES_JSON);
+    let target = ledger_path(data_dir);
     let Ok(bytes) = std::fs::read(&target) else {
         return Vec::new();
     };
@@ -88,13 +118,23 @@ pub fn load(data_dir: &Path) -> Vec<EmbedFailure> {
 /// Why: the deferred lane can fail for the same drawer more than once — a
 /// backfill retry that fails again must update the attempt count and reason,
 /// not append a second row that makes the ledger grow without bound.
-/// What: loads, replaces any row with the same `drawer_id`, writes atomically.
-/// Test: `embed_ledger_roundtrips_and_upserts_by_drawer`.
+/// What: inside [`json_rmw::update`]'s locked critical section — which re-reads
+/// the document from disk under the lock, so a concurrent writer's rows are
+/// never clobbered — replaces any row with the same `drawer_id` and appends this
+/// one. Blocking on an advisory `flock`; async callers must run it on a
+/// blocking-safe thread.
+/// Test: `embed_ledger_roundtrips_and_upserts_by_drawer`,
+/// `concurrent_ledger_records_keep_every_row`.
 pub fn record(data_dir: &Path, entry: EmbedFailure) -> Result<()> {
-    let mut rows = load(data_dir);
-    rows.retain(|r| r.drawer_id != entry.drawer_id);
-    rows.push(entry);
-    save(data_dir, &rows)
+    std::fs::create_dir_all(data_dir)
+        .with_context(|| format!("create palace data dir {}", data_dir.display()))?;
+    let path = ledger_path(data_dir);
+    json_rmw::update(&path, |rows: &mut Vec<EmbedFailure>| {
+        rows.retain(|r| r.drawer_id != entry.drawer_id);
+        rows.push(entry);
+        Ok::<(), anyhow::Error>(())
+    })
+    .with_context(|| format!("record embed failure in {}", path.display()))
 }
 
 /// Drop the named drawers from the ledger.
@@ -102,51 +142,20 @@ pub fn record(data_dir: &Path, entry: EmbedFailure) -> Result<()> {
 /// Why: a backfill that re-embeds a drawer successfully must stop reporting it
 /// as broken, and a forgotten drawer must not leave a row behind claiming a
 /// failure for an id nothing can look up. Both are the same operation.
-/// What: loads, retains rows whose id is not in `ids`, writes atomically. A
-/// no-op (no write at all) when nothing matched, so a healthy palace never
-/// touches the file.
-/// Test: `embed_ledger_clear_removes_only_named_rows`.
+/// What: same locked critical section as [`record`] — a clear racing a record
+/// has the identical lost-update shape, and the backfill runs both against one
+/// palace. Returns before taking the lock when `ids` is empty or the palace has
+/// no ledger, so a healthy palace never creates the file or its lock sidecar.
+/// Test: `embed_ledger_clear_removes_only_named_rows`,
+/// `concurrent_clear_and_record_do_not_lose_each_other`.
 pub fn clear(data_dir: &Path, ids: &HashSet<Uuid>) -> Result<()> {
-    if ids.is_empty() {
+    let path = ledger_path(data_dir);
+    if ids.is_empty() || !path.exists() {
         return Ok(());
     }
-    let rows = load(data_dir);
-    let kept: Vec<EmbedFailure> = rows
-        .iter()
-        .filter(|r| !ids.contains(&r.drawer_id))
-        .cloned()
-        .collect();
-    if kept.len() == rows.len() {
-        return Ok(());
-    }
-    save(data_dir, &kept)
-}
-
-/// Atomically overwrite the ledger.
-///
-/// Why: a half-written ledger read at the next open would be indistinguishable
-/// from a corrupt one, and this file is exactly the thing an operator reaches
-/// for when they already do not trust what is on disk.
-/// What: writes to `<name>.tmp.<pid>.<seq>` then renames over the target — the
-/// per-invocation tmp name keeps two concurrent writers from removing each
-/// other's temp file (the `L1Cache` #154 fix, same shape).
-/// Test: covered by `embed_ledger_roundtrips_and_upserts_by_drawer`.
-fn save(data_dir: &Path, rows: &[EmbedFailure]) -> Result<()> {
-    std::fs::create_dir_all(data_dir)
-        .with_context(|| format!("create palace data dir {}", data_dir.display()))?;
-    let target = data_dir.join(EMBED_FAILURES_JSON);
-    let seq = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let tmp = data_dir.join(format!(
-        "{EMBED_FAILURES_JSON}.tmp.{}.{seq}",
-        std::process::id()
-    ));
-    let bytes = serde_json::to_vec_pretty(rows).context("serialize embed-failure ledger")?;
-    std::fs::write(&tmp, &bytes)
-        .with_context(|| format!("write embed-failure ledger tmp {}", tmp.display()))?;
-    if let Err(e) = std::fs::rename(&tmp, &target) {
-        let _ = std::fs::remove_file(&tmp);
-        return Err(anyhow::Error::from(e)
-            .context(format!("rename embed-failure ledger {}", target.display())));
-    }
-    Ok(())
+    json_rmw::update(&path, |rows: &mut Vec<EmbedFailure>| {
+        rows.retain(|r| !ids.contains(&r.drawer_id));
+        Ok::<(), anyhow::Error>(())
+    })
+    .with_context(|| format!("clear embed failures in {}", path.display()))
 }

--- a/crates/trusty-common/src/memory_core/store/embed_ledger.rs
+++ b/crates/trusty-common/src/memory_core/store/embed_ledger.rs
@@ -1,0 +1,152 @@
+//! Durable per-palace ledger of drawers whose embedding permanently failed.
+//!
+//! Why (#4906): the deferred-embed lane used to end every failure branch in a
+//! `warn!` and a bare `return`. A log line scrolls past; the drawer stays
+//! durable in redb and permanently absent from vector recall, and nothing
+//! anywhere records that it happened. This file is the record. It survives a
+//! restart, so an operator (or the backfill) can ask "which drawers did we try
+//! to embed and fail?" without re-deriving it from a log.
+//!
+//! What: `<data_dir>/embed_failures.json` — a JSON array of [`EmbedFailure`]
+//! rows keyed by drawer id, written atomically (tmp + rename) with the same
+//! per-invocation tmp naming `L1Cache::save_l1_cache` uses so concurrent
+//! writers cannot trample each other.
+//!
+//! The ledger is an ANNOTATION, never the source of truth. Whether a drawer has
+//! a vector is answered by set-differencing the drawer table against the vector
+//! index (`PalaceHandle::embed_health`); the ledger only says why a particular
+//! one is missing and how hard we tried. That ordering is deliberate: a marker
+//! that could disagree with the index would be one more thing to keep in sync,
+//! and it repairs nothing for the 39 drawers that were already lost before this
+//! code existed. Rows for drawers that no longer exist, or that have since
+//! acquired a vector, are pruned on the next write rather than trusted.
+//!
+//! Test: `embed_ledger_roundtrips_and_upserts_by_drawer`,
+//! `embed_ledger_clear_removes_only_named_rows`,
+//! `embed_ledger_load_is_empty_when_absent`.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use uuid::Uuid;
+
+/// Ledger filename inside a palace's data directory.
+const EMBED_FAILURES_JSON: &str = "embed_failures.json";
+
+/// Per-invocation tmp suffix counter — see `L1Cache::save_l1_cache` for why
+/// two concurrent writers must not share a tmp path.
+static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// One drawer's recorded embedding failure.
+///
+/// Why: an operator triaging an unfindable memory needs three things — which
+/// drawer, when we gave up, and what the embedder actually said. `attempts`
+/// separates "one transient blip" from "we retried and it is genuinely broken".
+/// What: a serde row; `reason` is the last error text from the retry loop.
+/// Test: `embed_ledger_roundtrips_and_upserts_by_drawer`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EmbedFailure {
+    pub drawer_id: Uuid,
+    pub failed_at: DateTime<Utc>,
+    /// How many embed attempts were made before giving up.
+    pub attempts: u32,
+    /// Last error text observed. Free-form; for humans, not for matching on.
+    pub reason: String,
+}
+
+/// Read the ledger, returning an empty vec when the palace has never recorded
+/// a failure (the overwhelmingly common case).
+///
+/// Why: a missing or corrupt ledger must never make a palace unusable — it is
+/// diagnostic annotation, and losing it costs strictly less than refusing to
+/// open the palace that holds the actual memories.
+/// What: reads `<data_dir>/embed_failures.json`; a missing file yields `[]`, and
+/// a malformed one yields `[]` plus a `warn!` rather than an error.
+/// Test: `embed_ledger_load_is_empty_when_absent`.
+pub fn load(data_dir: &Path) -> Vec<EmbedFailure> {
+    let target = data_dir.join(EMBED_FAILURES_JSON);
+    let Ok(bytes) = std::fs::read(&target) else {
+        return Vec::new();
+    };
+    match serde_json::from_slice::<Vec<EmbedFailure>>(&bytes) {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(
+                path = %target.display(),
+                "#4906: embed-failure ledger is unreadable, treating as empty: {e}"
+            );
+            Vec::new()
+        }
+    }
+}
+
+/// Record (or refresh) one drawer's failure, keyed by drawer id.
+///
+/// Why: the deferred lane can fail for the same drawer more than once — a
+/// backfill retry that fails again must update the attempt count and reason,
+/// not append a second row that makes the ledger grow without bound.
+/// What: loads, replaces any row with the same `drawer_id`, writes atomically.
+/// Test: `embed_ledger_roundtrips_and_upserts_by_drawer`.
+pub fn record(data_dir: &Path, entry: EmbedFailure) -> Result<()> {
+    let mut rows = load(data_dir);
+    rows.retain(|r| r.drawer_id != entry.drawer_id);
+    rows.push(entry);
+    save(data_dir, &rows)
+}
+
+/// Drop the named drawers from the ledger.
+///
+/// Why: a backfill that re-embeds a drawer successfully must stop reporting it
+/// as broken, and a forgotten drawer must not leave a row behind claiming a
+/// failure for an id nothing can look up. Both are the same operation.
+/// What: loads, retains rows whose id is not in `ids`, writes atomically. A
+/// no-op (no write at all) when nothing matched, so a healthy palace never
+/// touches the file.
+/// Test: `embed_ledger_clear_removes_only_named_rows`.
+pub fn clear(data_dir: &Path, ids: &HashSet<Uuid>) -> Result<()> {
+    if ids.is_empty() {
+        return Ok(());
+    }
+    let rows = load(data_dir);
+    let kept: Vec<EmbedFailure> = rows
+        .iter()
+        .filter(|r| !ids.contains(&r.drawer_id))
+        .cloned()
+        .collect();
+    if kept.len() == rows.len() {
+        return Ok(());
+    }
+    save(data_dir, &kept)
+}
+
+/// Atomically overwrite the ledger.
+///
+/// Why: a half-written ledger read at the next open would be indistinguishable
+/// from a corrupt one, and this file is exactly the thing an operator reaches
+/// for when they already do not trust what is on disk.
+/// What: writes to `<name>.tmp.<pid>.<seq>` then renames over the target — the
+/// per-invocation tmp name keeps two concurrent writers from removing each
+/// other's temp file (the `L1Cache` #154 fix, same shape).
+/// Test: covered by `embed_ledger_roundtrips_and_upserts_by_drawer`.
+fn save(data_dir: &Path, rows: &[EmbedFailure]) -> Result<()> {
+    std::fs::create_dir_all(data_dir)
+        .with_context(|| format!("create palace data dir {}", data_dir.display()))?;
+    let target = data_dir.join(EMBED_FAILURES_JSON);
+    let seq = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let tmp = data_dir.join(format!(
+        "{EMBED_FAILURES_JSON}.tmp.{}.{seq}",
+        std::process::id()
+    ));
+    let bytes = serde_json::to_vec_pretty(rows).context("serialize embed-failure ledger")?;
+    std::fs::write(&tmp, &bytes)
+        .with_context(|| format!("write embed-failure ledger tmp {}", tmp.display()))?;
+    if let Err(e) = std::fs::rename(&tmp, &target) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(anyhow::Error::from(e)
+            .context(format!("rename embed-failure ledger {}", target.display())));
+    }
+    Ok(())
+}

--- a/crates/trusty-common/src/memory_core/store/embed_ledger.rs
+++ b/crates/trusty-common/src/memory_core/store/embed_ledger.rs
@@ -144,13 +144,30 @@ pub fn record(data_dir: &Path, entry: EmbedFailure) -> Result<()> {
 /// failure for an id nothing can look up. Both are the same operation.
 /// What: same locked critical section as [`record`] — a clear racing a record
 /// has the identical lost-update shape, and the backfill runs both against one
-/// palace. Returns before taking the lock when `ids` is empty or the palace has
-/// no ledger, so a healthy palace never creates the file or its lock sidecar.
+/// palace.
+///
+/// Three cheap early returns come BEFORE the lock, because `clear` is on the
+/// success path of every deferred embed and `json_rmw::update` always publishes
+/// — it has no "nothing changed" branch, so reaching it costs an flock plus two
+/// fsyncs whether or not a row matched. Skipping it when `ids` is empty, when
+/// the palace has no ledger, or when no listed id is actually present keeps a
+/// healthy palace from paying that on every single write, and from creating the
+/// file or its lock sidecar at all.
+///
+/// The unlocked pre-read is a benign check-then-act: a row that appears between
+/// the check and the (skipped) lock belongs to a drawer that failed after this
+/// caller's drawer succeeded, so clearing it would have been wrong anyway. The
+/// authoritative surface stays `PalaceHandle::embed_health`, which never reads
+/// this file.
 /// Test: `embed_ledger_clear_removes_only_named_rows`,
-/// `concurrent_clear_and_record_do_not_lose_each_other`.
+/// `concurrent_clear_and_record_do_not_lose_each_other`,
+/// `clear_without_a_matching_row_never_writes`.
 pub fn clear(data_dir: &Path, ids: &HashSet<Uuid>) -> Result<()> {
     let path = ledger_path(data_dir);
     if ids.is_empty() || !path.exists() {
+        return Ok(());
+    }
+    if !load(data_dir).iter().any(|r| ids.contains(&r.drawer_id)) {
         return Ok(());
     }
     json_rmw::update(&path, |rows: &mut Vec<EmbedFailure>| {

--- a/crates/trusty-common/src/memory_core/store/mod.rs
+++ b/crates/trusty-common/src/memory_core/store/mod.rs
@@ -8,6 +8,8 @@
 
 pub mod chat_sessions;
 pub mod concurrent_open;
+// #4906: durable record of drawers whose embed permanently failed.
+pub mod embed_ledger;
 pub mod hnsw_store;
 pub mod kg;
 pub mod kg_redb;
@@ -30,6 +32,9 @@ pub mod wings;
 
 pub use chat_sessions::{ChatSession, ChatSessionMeta, ChatSessionStore};
 pub use concurrent_open::{OpenIntent, OpenMode};
+// #4906: the ledger row type; the read/write helpers stay module-qualified so
+// call sites read as `embed_ledger::record(..)`.
+pub use embed_ledger::EmbedFailure;
 pub use kg::{KnowledgeGraph, Triple};
 pub use l1_cache::{L1Cache, L1CacheError};
 pub use palace_store::{PalaceStore, PalaceStoreError};

--- a/crates/trusty-memory/changelog.d/4906-palace-reembed-tool.md
+++ b/crates/trusty-memory/changelog.d/4906-palace-reembed-tool.md
@@ -1,0 +1,5 @@
+Added
+
+- `palace_reembed` MCP tool — reports drawers that have no vector and optionally re-embeds them ([#4906](https://github.com/bobmatnyc/trusty-tools/issues/4906))
+  - defaults to a dry run: it returns the exact set of vectorless drawer ids without touching the embedder
+  - `dry_run: false` repairs them; it lives in the daemon because the daemon holds the palace's writer lock, so a CLI would only ever get a read-only snapshot it cannot write vectors into

--- a/crates/trusty-memory/src/lib_tests.rs
+++ b/crates/trusty-memory/src/lib_tests.rs
@@ -97,8 +97,9 @@ async fn tools_list_returns_all_tools() {
     // `chat_turn_append`; issue #1721 adds `palace_dream`;
     // issue #1722 adds `task_add`, `task_list`, `task_complete`;
     // ADR-0027 T6 (#4805) adds `room_list`, `room_create`, `room_rename`;
-    // ADR-0027 T9 (#4809) adds `wing_list`, `wing_create`, `wing_rename`.
-    assert_eq!(tools.len(), 43);
+    // ADR-0027 T9 (#4809) adds `wing_list`, `wing_create`, `wing_rename`;
+    // #4906 adds `palace_reembed`.
+    assert_eq!(tools.len(), 44);
 }
 
 #[tokio::test]

--- a/crates/trusty-memory/src/mcp_service.rs
+++ b/crates/trusty-memory/src/mcp_service.rs
@@ -15,7 +15,7 @@
 //! functions guarantees the host-merged manifest and the standalone one
 //! stay byte-identical.
 //!
-//! Test: `tests` below assert the tool count (43), the name string, and
+//! Test: `tests` below assert the tool count (44), the name string, and
 //! that the read/write scope split matches what `scopes_for_tool` returns
 //! for representative tools (`memory_recall` → `memory.read`,
 //! `memory_remember` → `memory.write`).
@@ -25,7 +25,7 @@ use trusty_common::mcp::ServiceDescriptor;
 use crate::openrpc::scopes_for_tool;
 use crate::tools::tool_definitions_with;
 
-/// `ServiceDescriptor` impl that advertises this crate's 43 memory tools.
+/// `ServiceDescriptor` impl that advertises this crate's 44 memory tools.
 ///
 /// Why: Lets open-mpm link trusty-memory-mcp directly and include its
 /// tools in a unified `rpc.discover` document without bespoke glue code.
@@ -87,8 +87,8 @@ mod tests {
         let tools = svc.tools();
         assert_eq!(
             tools.len(),
-            43,
-            "expected 43 memory tools (chat-session + dream-ops + palace_dream + the ADR-0027 room and wing surfaces), got {}",
+            44,
+            "expected 44 memory tools (chat-session + dream-ops + palace_dream + the ADR-0027 room and wing surfaces + #4906 palace_reembed), got {}",
             tools.len()
         );
     }
@@ -111,7 +111,7 @@ mod tests {
         //      so we must confirm dynamic dispatch resolves correctly here.
         let svc: Box<dyn ServiceDescriptor> = Box::new(MemoryMcpService);
         assert_eq!(svc.name(), "trusty-memory");
-        assert_eq!(svc.tools().len(), 43);
+        assert_eq!(svc.tools().len(), 44);
         assert_eq!(svc.scopes_for("palace_create"), vec!["memory.write"]);
         assert_eq!(svc.scopes_for("palace_delete"), vec!["memory.write"]);
         assert_eq!(svc.scopes_for("palace_update"), vec!["memory.write"]);

--- a/crates/trusty-memory/src/openrpc.rs
+++ b/crates/trusty-memory/src/openrpc.rs
@@ -76,6 +76,8 @@ pub fn scopes_for_tool(name: &str) -> Vec<String> {
         | "palace_delete"
         | "palace_update"
         | "palace_compact"
+        // #4906: dry-run is read-only but the repair writes vectors.
+        | "palace_reembed"
         | "kg_assert"
         | "add_alias"
         | "remove_prompt_fact"

--- a/crates/trusty-memory/src/tools/definitions.rs
+++ b/crates/trusty-memory/src/tools/definitions.rs
@@ -295,6 +295,19 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
                 }
             },
             {
+                "name": "palace_reembed",
+                "description": "#4906: report drawers that have no vector (durable but unfindable), and optionally re-embed them. Defaults to a dry run.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "palace":  {"type": "string"},
+                        "dry_run": {"type": "boolean", "description": "Report only; do not embed. Default true."},
+                        "limit":   {"type": "integer", "description": "Cap repairs per run."}
+                    },
+                    "required": palace_compact_required,
+                }
+            },
+            {
                 "name": "add_alias",
                 "description": "Add a short→full alias (e.g. tga → trusty-git-analytics) to the prompt-facts surface. Asserts the alias as a hot KG triple and refreshes the session-init prompt cache.",
                 "inputSchema": {

--- a/crates/trusty-memory/src/tools/mod.rs
+++ b/crates/trusty-memory/src/tools/mod.rs
@@ -78,7 +78,7 @@ use memory_ops::{
 };
 use palace_ops::{
     handle_palace_compact, handle_palace_create, handle_palace_delete, handle_palace_info,
-    handle_palace_list, handle_palace_update,
+    handle_palace_list, handle_palace_reembed, handle_palace_update,
 };
 use room_ops::{handle_room_create, handle_room_list, handle_room_rename};
 use task_ops::{handle_task_add, handle_task_complete, handle_task_list};
@@ -114,6 +114,8 @@ pub async fn dispatch_tool(state: &AppState, name: &str, args: Value) -> Result<
         "memory_forget" => handle_memory_forget(state, args).await,
         "palace_info" => handle_palace_info(state, args).await,
         "palace_compact" => handle_palace_compact(state, args).await,
+        // #4906: report / repair drawers that have no vector.
+        "palace_reembed" => handle_palace_reembed(state, args).await,
         "kg_gaps" => handle_kg_gaps(state, args).await,
         "memory_recall_all" => handle_memory_recall_all(state, args).await,
         "get_prompt_context" => handle_get_prompt_context(state, args).await,

--- a/crates/trusty-memory/src/tools/palace_ops.rs
+++ b/crates/trusty-memory/src/tools/palace_ops.rs
@@ -249,6 +249,59 @@ pub(crate) async fn handle_palace_info(state: &AppState, args: Value) -> Result<
     }))
 }
 
+/// `palace_reembed` — report, and optionally repair, drawers with no vector.
+///
+/// Why (#4906): the deferred-embed lane used to drop failures silently, leaving
+/// drawers durable in redb and permanently invisible to vector recall — 39 of
+/// 1,241 on the live `trusty-tools` palace. Fixing the write path forward
+/// repairs none of those, and the repair has to run INSIDE the daemon: the
+/// daemon holds the palace's writer lock, so a CLI would only ever get a
+/// read-only snapshot it cannot write vectors into.
+/// What: `dry_run` (the default) returns the exact set of vectorless drawer ids
+/// without touching the embedder; `dry_run: false` re-embeds them through the
+/// same primitive the write path uses. Idempotent — a second run over a
+/// repaired palace reports zero missing and does no work.
+/// Test: `dispatch_palace_reembed_dry_run_reports_counts` in `tools::tests`.
+pub(crate) async fn handle_palace_reembed(state: &AppState, args: Value) -> Result<Value> {
+    use trusty_common::memory_core::retrieval::VectorBackfillOptions;
+    let palace = resolve_palace(state, &args, "palace_reembed")?;
+    let handle = open_palace_handle(state, &palace)?;
+    // Defaults to a dry run on purpose: the first thing an operator wants is
+    // the number, and #4834 deletes source files on the strength of it.
+    let dry_run = args
+        .get("dry_run")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    let limit = args
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize);
+    let report = handle
+        .backfill_missing_vectors(VectorBackfillOptions {
+            dry_run,
+            limit,
+            ..Default::default()
+        })
+        .await?;
+    let health = handle.embed_health();
+    Ok(json!({
+        "palace": report.palace_id,
+        "dry_run": report.dry_run,
+        "drawer_count": report.drawer_count,
+        "vector_count": report.vector_count,
+        "missing": report.missing,
+        "attempted": report.attempted,
+        "repaired": report.repaired,
+        "still_failing": report.still_failing,
+        "still_missing_ids": report.still_missing_ids
+            .iter().map(|i| i.to_string()).collect::<Vec<_>>(),
+        // Without this a shortfall is unexplained: "no embedder on this host"
+        // reads identically to "the embedder is dropping writes".
+        "embedder_ready": health.embedder_ready,
+        "recorded_failures": health.recorded_failures.len(),
+    }))
+}
+
 pub(crate) async fn handle_palace_compact(state: &AppState, args: Value) -> Result<Value> {
     let palace = resolve_palace(state, &args, "palace_compact")?;
     let handle = open_palace_handle(state, &palace)?;

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -101,6 +101,7 @@ fn tool_definitions_drops_palace_required_when_default_set() {
         ("memory_forget", true),
         ("palace_info", true),
         ("palace_compact", true),
+        ("palace_reembed", true),
         ("kg_assert", true),
         ("kg_query", true),
         // Issue #664: add_alias and discover_aliases now include `palace`
@@ -137,7 +138,8 @@ fn tool_definitions_lists_all_tools() {
     // 34 original + 3 task tools (task_add, task_list, task_complete, issue
     // #1722) + 3 room tools (room_list, room_create, room_rename, ADR-0027 T6)
     // + 3 wing tools (wing_list, wing_create, wing_rename, ADR-0027 T9 / #4809)
-    assert_eq!(tools.len(), 43);
+    // + 1 repair tool (palace_reembed, #4906)
+    assert_eq!(tools.len(), 44);
     let names: Vec<&str> = tools
         .iter()
         .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
@@ -155,6 +157,7 @@ fn tool_definitions_lists_all_tools() {
         "palace_list",
         "palace_info",
         "palace_compact",
+        "palace_reembed",
         "kg_assert",
         "kg_query",
         "memory_recall_all",
@@ -209,6 +212,30 @@ async fn dispatch_palace_create_persists() {
         .expect("palace_list");
     let ids = listed["palaces"].as_array().expect("palaces array");
     assert!(ids.iter().any(|v| v.as_str() == Some("alpha")));
+}
+
+/// Why (#4906): the repair path has to be reachable from the daemon, because
+/// the daemon holds the palace's writer lock — a CLI would only ever get a
+/// read-only snapshot. This confirms the tool is wired end-to-end through
+/// `dispatch_tool` and that a dry run reports rather than mutates.
+/// What: creates a palace, calls `palace_reembed` with no arguments, and
+/// asserts the response carries the coverage counts and defaults to a dry run.
+/// Test: itself.
+#[tokio::test]
+async fn dispatch_palace_reembed_dry_run_reports_counts() {
+    let (state, _tmp) = test_state();
+    dispatch_tool(&state, "palace_create", json!({"name": "reembed-test"}))
+        .await
+        .expect("palace_create");
+    let out = dispatch_tool(&state, "palace_reembed", json!({"palace": "reembed-test"}))
+        .await
+        .expect("palace_reembed");
+    assert_eq!(out["dry_run"], true, "must default to a dry run: {out}");
+    assert_eq!(out["missing"], 0);
+    assert_eq!(out["attempted"], 0);
+    assert_eq!(out["repaired"], 0);
+    assert!(out["drawer_count"].is_number());
+    assert!(out["vector_count"].is_number());
 }
 
 /// Why (issue #1714): `force=true` bypasses slug validation with no

--- a/crates/trusty-memory/src/transport/rpc.rs
+++ b/crates/trusty-memory/src/transport/rpc.rs
@@ -204,6 +204,7 @@ const TOOL_METHODS: &[&str] = &[
     "palace_create",
     "palace_info",
     "palace_list",
+    "palace_reembed",
     "remove_prompt_fact",
 ];
 


### PR DESCRIPTION
## The defect

`spawn_deferred_embed` was fire-and-forget. Every failure path was a `warn!`
followed by a bare `return` — no retry, no marker, no surfaced error. One
embedder blip and the drawer stayed durable in redb and permanently invisible to
vector recall. `memory_recall` cannot detect this class of failure, because it
only searches what got embedded.

**Measured live against the running daemon while writing this PR**
(`GET /api/v1/palaces`, the same surface the issue used):

| palace | drawers | vectors | gap |
|---|---|---|---|
| code-intelligence | 224 | 179 | **45** |
| trusty-tools | 1275 | 1236 | **39** |
| cto-reports | 133 | 98 | **35** |
| apex | 111 | 93 | **18** |

137 across the 4 palaces the daemon currently holds open, out of 93 total. The
issue's 39 reproduces exactly; it is not the whole estate.

## What changed

**1. Failures stop being silent.** `deferred_embed.rs` retries transient
failures with bounded exponential backoff (3 attempts, 250 ms base) instead of
taking the first `Err` as final, and retries the vector upsert on the same
policy. A final failure writes a durable row to the palace's
`embed_failures.json` ledger — drawer id, timestamp, attempt count, and the last
error text — so the loss outlives the log line. It is still logged, at `error!`
rather than `warn!`.

**2. "No embedder" is not "this drawer is broken".** `EmbedLoss` splits
`EmbedderUnavailable` from `Embed`/`Upsert`. Only the latter marks a drawer, so a
host with no model downloaded, or a cold start, does not get every drawer
flagged. The health surface reports `embedder_ready` alongside the shortfall so
an unexplained gap and an expected one read differently.

**3. The condition is queryable.** `PalaceHandle::embed_health()` set-differences
the drawer table against the vector index. That is exact — a drawer id absent
from the index has no vector by definition.

On PR #4903's suggested `vector_count == drawer_count` check: it is the right
**summary** and it is how the numbers above were measured, but it is not
sufficient on its own, because the vector index can also hold **orphans**
(vectors whose drawer was forgotten), so equal counts do not prove full
coverage. The count comparison is the alarm; the set difference is what the
repair acts on. Both are now available — the counts already ship on
`/api/v1/palaces`, and the exact set comes back from `palace_reembed`.

**4. A repair path for what is already broken.**
`PalaceHandle::backfill_missing_vectors()` re-embeds drawers with no vector,
through the same `embed_and_store` primitive the write path uses. Idempotent
(a repaired drawer is no longer in the missing set), and a genuine no-op on a
healthy palace — it short-circuits before resolving an embedder, so it is safe
on a host with no model. Exposed as the `palace_reembed` MCP tool, defaulting to
`dry_run: true`. It lives in the daemon on purpose: the daemon holds the
palace's writer lock, so a CLI would only ever get a read-only snapshot it
cannot write vectors into.

## Constraints honoured

- **The write path is still asynchronous.** Storing a drawer must not fail or
  hang because the embedder is slow or down (#1970). The fix is to stop LOSING
  the failure, not to make writes synchronous.
- **The `force` / `allow_secret_like` gate at `handle.rs:562-576` is untouched.**
- `filter.rs` and `retrieval/layers.rs` are untouched (owned by #4898 / #4904).
  No crate version bumped.

## Design note — why the marker is a sidecar, not a `Drawer` field

The obvious shape is a field on `Drawer`. Two things argued against it. The
drawer row is postcard-encoded and **positional**, so a new field means a fourth
migration-fallback shape in `decode_drawer_record`; get that chain wrong and
every row silently loses `fact_key` — a worse data bug than the one being fixed,
in a chain #4884/#4886 churned days ago. And `Drawer` is built as a struct
literal in `retrieval/layers.rs`, which #4904 owns this session.

`<data_dir>/embed_failures.json` is durable, atomic (tmp + rename, the `L1Cache`
#154 pattern), needs no schema migration, and cannot drift in the harmful
direction: the authoritative answer is always the vector-index set difference,
and the ledger is annotation on top of it. Rows for repaired drawers are cleared;
rows for drawers that no longer exist are never written.

## Test ladder — RUNG 5

Persistence and durability, shared library, silent-data-loss class.

```
cargo fmt --check                                                                  EXIT=0
cargo clippy -p trusty-common --features memory-core,embedder-test-support \
             --all-targets -- -D warnings                                          EXIT=0
cargo test -p trusty-common --features memory-core,embedder-test-support \
             -- --test-threads=1
    test result: ok. 878 passed; 0 failed; 13 ignored; 0 measured; 0 filtered out
    test result: ok. 6 passed; 0 failed; ...
    test result: ok. 11 passed; 0 failed; ...
    test result: ok. 4 passed; 0 failed; ...
    test result: ok. 3 passed; 0 failed; ...
cargo test -p trusty-memory -- --test-threads=1
    test result: FAILED. 561 passed; 2 failed; 4 ignored
cargo test -p trusty-mpm
    test result: FAILED. 4635 passed; 1 failed; 7 ignored
cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui         EXIT=0
bash scripts/check_line_cap.sh
    line-cap: measured 3720 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.
```

### The 3 red tests are pre-existing and environmental

Not "re-run until green" — each is provably outside this diff.

**`commands::doctor::tests::check_daemon_health_*` (2)** —
`git diff --name-only origin/main...HEAD -- crates/trusty-memory/src/commands/`
returns **0 files**. Both probe `127.0.0.1:7070/health`; the daemon on this
machine answers `"daemon_state":"warming"` (the #4836 latch), which
`interpret_health_body` maps to `Warn`, and both tests assert
`Fail | Pass | Unknown`. Any checkout of any commit fails these two while that
daemon is warming.

**`daemon::managed_routes::tests::stale_assets_for_many_...` (1)** —
`git diff --name-only origin/main...HEAD -- crates/trusty-mpm/` returns
**0 files**. This PR does not touch `trusty-mpm` at all.

### New coverage — fail-before / pass-after

11 tests in `retrieval/embed_repair_tests.rs`, all asserting on state that
survives the process (the ledger file, the vector index), never on log output:

- `retry_succeeds_after_transient_failures` — runs the SAME flaky embedder under
  a 1-attempt policy (reproducing the pre-fix behaviour: fails, no vector) and
  then a 3-attempt policy (succeeds, vector lands).
- `permanent_failure_writes_a_ledger_row` — a dead embedder; asserts the ledger
  re-read from disk carries the row, the attempt count, and the failing stage.
- `missing_embedder_does_not_mark_the_drawer` — an `EmbedderUnavailable` loss
  writes nothing; a drawer-specific loss for the same drawer does.
- `loss_for_a_forgotten_drawer_is_not_recorded`
- `backfill_reembeds_a_marked_drawer` — asserts the drawer is NOT retrievable via
  `retrieve_l2` before, and IS after, and that the ledger row is cleared; then
  re-runs and asserts the second pass does nothing.
- `backfill_is_a_noop_on_a_healthy_palace`, `backfill_dry_run_repairs_nothing`
- `health_reports_the_drawer_with_no_vector`
- 3 ledger tests (upsert-by-id, surgical clear, missing file reads empty)
- `dispatch_palace_reembed_dry_run_reports_counts` in `trusty-memory`

## Follow-up not in this PR

A `trusty-memory doctor` check on the count gap. The detection logic now exists
(`embed_health()`) and the counts already ship on `/api/v1/palaces`, so the check
is a display change in the doctor orchestrator, not new logic. Left out to keep
this PR to the data-integrity fix; `doctor/mod.rs` is also at 475/500 SLOC, so
wiring it wants a small split first.

Closes #4906. Unblocks #4834 — the migration can now verify retrievability
before deleting a source file.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
