### PR TITLE
feat(trusty-mpm): add `n [name]` picker command for launching a named session

### DIFF
--- a/crates/trusty-common/src/session_naming/mod.rs
+++ b/crates/trusty-common/src/session_naming/mod.rs
@@ -261,7 +261,33 @@ pub fn leaf_slug_from_dir(path: &Path) -> String {
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_default();
-    sanitize_slug(&basename, MAX_FOLDER_LEN)
+    leaf_slug_from_hint(&basename)
+}
+
+/// Sanitize an operator-typed name hint to the SAME leaf slug the daemon's
+/// `name_hint` path would produce — the shared CLI/daemon contract (#4965).
+///
+/// Why: `SessionManager::resolve_session_name` sanitizes a `name_hint` by
+/// routing it through [`leaf_slug_from_dir`], which first takes
+/// `Path::file_name()` — so a hint of `feature/auth` loses everything before
+/// the last `/` and lands as `tm-auth-NN`, indistinguishable from a
+/// `hotfix/auth` hint. The CLI must therefore slugify BEFORE sending, and it
+/// must do so with the exact same algorithm and the exact same cap, or the two
+/// sides drift. This is that entry point: the private [`sanitize_slug`] under
+/// its `name_hint`-path cap ([`MAX_FOLDER_LEN`]), with no `file_name()` step.
+/// Because its output is always a single component of `[a-z0-9]`-bounded
+/// kebab-case within the cap, feeding it back through [`leaf_slug_from_dir`]
+/// daemon-side is a provable no-op — the CLI's chosen leaf is the leaf the
+/// session gets.
+/// What: delegates to [`sanitize_slug`] with [`MAX_FOLDER_LEN`]. Returns an
+/// empty string when nothing alphanumeric survives — the caller decides
+/// whether that is a fallback (`build_managed_session_name`'s `"local"`) or a
+/// refusal (the picker's `n <name>`, which will not spawn an unusable name).
+/// Test: `leaf_slug_from_hint_keeps_path_like_segments`,
+/// `leaf_slug_from_hint_matches_leaf_slug_from_dir_for_plain_names`,
+/// `leaf_slug_from_hint_is_a_fixed_point_for_its_own_output`.
+pub fn leaf_slug_from_hint(hint: &str) -> String {
+    sanitize_slug(hint, MAX_FOLDER_LEN)
 }
 
 /// Derive a session name from a project directory's basename (no serial).
@@ -635,6 +661,75 @@ mod tests {
     #[test]
     fn leaf_slug_from_dir_empty_for_root() {
         assert_eq!(leaf_slug_from_dir(Path::new("/")), "");
+    }
+
+    // ── leaf_slug_from_hint (#4965) ───────────────────────────────────────
+
+    /// Why (#4965): this is the whole reason the hint cannot just go through
+    /// [`leaf_slug_from_dir`] — that function's `Path::file_name()` step
+    /// discards everything before the last `/`, so `feature/auth` and
+    /// `hotfix/auth` both collapse to `auth` and name the same session.
+    /// Test: itself.
+    #[test]
+    fn leaf_slug_from_hint_keeps_path_like_segments() {
+        assert_eq!(leaf_slug_from_hint("feature/auth"), "feature-auth");
+        assert_eq!(leaf_slug_from_hint("hotfix/auth"), "hotfix-auth");
+        // The contrast that motivates it: the dir-based function loses them.
+        assert_eq!(leaf_slug_from_dir(Path::new("feature/auth")), "auth");
+        assert_eq!(leaf_slug_from_dir(Path::new("hotfix/auth")), "auth");
+    }
+
+    /// Why: for a hint with no path separators the two functions must agree
+    /// exactly, including the cap — otherwise sanitizing CLI-side would still
+    /// leave the daemon free to produce a different name.
+    /// Test: itself.
+    #[test]
+    fn leaf_slug_from_hint_matches_leaf_slug_from_dir_for_plain_names() {
+        for hint in [
+            "auth-refactor",
+            "My Auth Fix!",
+            "TRUSTY_TOOLS",
+            "a-very-long-name-that-exceeds-the-folder-cap",
+        ] {
+            assert_eq!(
+                leaf_slug_from_hint(hint),
+                leaf_slug_from_dir(Path::new(hint)),
+                "hint {hint:?} must slugify identically on both sides"
+            );
+        }
+    }
+
+    /// Why (#4965): the CLI slugifies before sending so the daemon's own
+    /// `leaf_slug_from_dir(Path::new(hint))` is a provable NO-OP. That only
+    /// holds if this function's output is a fixed point of BOTH functions.
+    /// Test: itself.
+    #[test]
+    fn leaf_slug_from_hint_is_a_fixed_point_for_its_own_output() {
+        for raw in [
+            "feature/auth",
+            "My Auth Fix!",
+            "  ---weird---  ",
+            "a-very-long-name-that-exceeds-the-folder-cap",
+            "v1.2.3",
+        ] {
+            let once = leaf_slug_from_hint(raw);
+            assert_eq!(leaf_slug_from_hint(&once), once, "hint {raw:?}");
+            assert_eq!(
+                leaf_slug_from_dir(Path::new(&once)),
+                once,
+                "the daemon's own sanitization must be a no-op for {raw:?}"
+            );
+        }
+    }
+
+    /// Why: an all-punctuation hint has no usable name — callers must be able
+    /// to see that and refuse, rather than silently inheriting a fallback.
+    /// Test: itself.
+    #[test]
+    fn leaf_slug_from_hint_empty_when_nothing_survives() {
+        assert_eq!(leaf_slug_from_hint("!!!"), "");
+        assert_eq!(leaf_slug_from_hint("---"), "");
+        assert_eq!(leaf_slug_from_hint("   "), "");
     }
 
     // ── slug_project ──────────────────────────────────────────────────────

--- a/crates/trusty-mpm/changelog.d/4965-picker-n-named-launch.md
+++ b/crates/trusty-mpm/changelog.d/4965-picker-n-named-launch.md
@@ -1,0 +1,5 @@
+Added
+
+- the interactive session picker (bare `tm`, `tm ls`) accepts `n` to launch a new session and `n <name>` to name it (closes [#4965](https://github.com/bobmatnyc/trusty-tools/issues/4965))
+  - `n` is slot-independent: the `[N] launch new session` number shifts as sessions come and go, so there was nothing to memorize — that entry stays, and `n` is additive
+  - `n <name>` forwards the raw string as `name_hint`, which the daemon sanitizes the same way `tm session new --name-hint` already does, so `n my auth fix` yields `tm-my-auth-fix-01`

--- a/crates/trusty-mpm/changelog.d/4965-picker-n-named-launch.md
+++ b/crates/trusty-mpm/changelog.d/4965-picker-n-named-launch.md
@@ -2,4 +2,6 @@ Added
 
 - the interactive session picker (bare `tm`, `tm ls`) accepts `n` to launch a new session and `n <name>` to name it (closes [#4965](https://github.com/bobmatnyc/trusty-tools/issues/4965))
   - `n` is slot-independent: the `[N] launch new session` number shifts as sessions come and go, so there was nothing to memorize — that entry stays, and `n` is additive
-  - `n <name>` forwards the raw string as `name_hint`, which the daemon sanitizes the same way `tm session new --name-hint` already does, so `n my auth fix` yields `tm-my-auth-fix-01`
+  - the token must be exactly `n`/`N`, and a name requires a whitespace separator, so `new`, `no`, `nn`, `n1` and `nauth` are all unrecognised — no n-initial typo can spawn a session
+  - `n <name>` launches as `tm-<name>-NN`, with the name kebab-cased in the CLI before it is sent (`n My Auth Fix!` → `tm-my-auth-fix-01`); sanitizing here is what keeps `n feature/auth` and `n hotfix/auth` distinct, since the daemon's own hint sanitization takes the path basename and would collapse both to `auth`
+  - a name with no usable characters (`n !!!`) is refused with a message rather than spawning under the daemon's shared `local` fallback leaf

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_launch.rs
@@ -125,7 +125,10 @@ fn provisioning_message(label: Option<&str>, detail: Option<&str>) -> String {
 /// clone-percent progress, before attaching.
 /// What: (1) shows a `trusty_progress` spinner (auto-hidden in non-TTY/plain
 /// output); (2) POSTs `{ repo_url, ref: "HEAD", task: "", force_new: true,
-/// background: true }`; (3) if the daemon answered synchronously (`201` with a
+/// background: true }`, plus `name_hint` when the caller supplied one (#4965 —
+/// the picker's `n <name>`; the key is omitted entirely for `None`, so the
+/// unnamed path's wire shape is unchanged); (3) if the daemon answered
+/// synchronously (`201` with a
 /// name — an older daemon ignoring `background`) attaches immediately; (4)
 /// otherwise polls `GET .../{id}/provision-status` every [`POLL_INTERVAL`] up
 /// to [`PROVISION_DEADLINE`], upgrading the spinner via [`provisioning_message`]
@@ -143,6 +146,7 @@ pub(crate) async fn launch_new_session_and_attach(
     client: &reqwest::Client,
     url: &str,
     repo_url: &str,
+    name_hint: Option<&str>,
 ) -> anyhow::Result<AttachOutcome> {
     let first_run = needs_first_run_clone(repo_url);
     let progress_output = trusty_progress::Output::to_stderr();
@@ -151,21 +155,30 @@ pub(crate) async fn launch_new_session_and_attach(
         spawn_progress_message(first_run.as_ref()),
     );
 
+    let mut body = serde_json::json!({
+        "repo_url": repo_url,
+        "ref": "HEAD",
+        "task": "",
+        // #2450: the picker's EXPLICIT "launch new session" choice — force a
+        // fresh session so the daemon's in-project reconnect pre-flight
+        // (#1707) never adopts an unrelated live session for this project.
+        "force_new": true,
+        // #2605: provision asynchronously — the POST returns a job id
+        // immediately and we poll for progress, so a large-repo clone can
+        // never outlast the client's HTTP timeout.
+        "background": true,
+    });
+    // #4965: added only when the operator named the session (`n <name>`) —
+    // `body` is a literal object, so the index-assign always inserts. Omitting
+    // the key for `None` keeps the unnamed request byte-identical to what
+    // `session::start`'s wire-shape tests already pin.
+    if let Some(hint) = name_hint {
+        body["name_hint"] = serde_json::Value::String(hint.to_string());
+    }
+
     let send_result = client
         .post(format!("{url}/api/v1/sessions/managed"))
-        .json(&serde_json::json!({
-            "repo_url": repo_url,
-            "ref": "HEAD",
-            "task": "",
-            // #2450: the picker's EXPLICIT "launch new session" choice — force a
-            // fresh session so the daemon's in-project reconnect pre-flight
-            // (#1707) never adopts an unrelated live session for this project.
-            "force_new": true,
-            // #2605: provision asynchronously — the POST returns a job id
-            // immediately and we poll for progress, so a large-repo clone can
-            // never outlast the client's HTTP timeout.
-            "background": true,
-        }))
+        .json(&body)
         .send()
         .await;
 

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_launch.rs
@@ -126,7 +126,9 @@ fn provisioning_message(label: Option<&str>, detail: Option<&str>) -> String {
 /// What: (1) shows a `trusty_progress` spinner (auto-hidden in non-TTY/plain
 /// output); (2) POSTs `{ repo_url, ref: "HEAD", task: "", force_new: true,
 /// background: true }`, plus `name_hint` when the caller supplied one (#4965 —
-/// the picker's `n <name>`; the key is omitted entirely for `None`, so the
+/// the picker's `n <name>`, ALREADY kebab-cased by
+/// `trusty_common::session_naming::leaf_slug_from_hint` so the daemon's own
+/// sanitization is a no-op; the key is omitted entirely for `None`, so the
 /// unnamed path's wire shape is unchanged); (3) if the daemon answered
 /// synchronously (`201` with a
 /// name — an older daemon ignoring `background`) attaches immediately; (4)
@@ -139,7 +141,10 @@ fn provisioning_message(label: Option<&str>, detail: Option<&str>) -> String {
 /// `run_tty_picker` loop uses it to decide whether it must stop reading
 /// stdin (a `switch-client` handoff, or a fail-closed skip, means this
 /// pane is no longer the one the operator sees).
-/// Test: covered by the `POST /api/v1/sessions/managed` + `provision-status`
+/// Test: `launch_new_session_and_attach_sends_the_name_hint` and
+/// `launch_new_session_and_attach_omits_name_hint_when_unnamed` (in
+/// `session::start_tests`) pin the `name_hint` key on the wire; the rest is
+/// covered by the `POST /api/v1/sessions/managed` + `provision-status`
 /// integration tests; the message formatting by `spawn_progress_message_*` and
 /// `provisioning_message_*`.
 pub(crate) async fn launch_new_session_and_attach(

--- a/crates/trusty-mpm/src/bin/tm/commands/session/start_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session/start_tests.rs
@@ -213,9 +213,18 @@ async fn session_start_in_place_writes_stash_and_hard_fails_on_daemon_unreachabl
 /// dev-dependency of this crate).
 /// What: binds an ephemeral loopback port, serves one `axum` route via a
 /// background task, and returns `(captured, url)` where `captured` is filled
-/// in by the handler once a request lands.
-/// Test: `session_start_posts_the_same_wire_shape_bare_tm_guided_default_sends`.
-async fn spawn_capturing_managed_spawn_server() -> (
+/// in by the handler once a request lands. `answer` selects what the handler
+/// replies with AFTER capturing (#4965): [`StatusCode::OK`] plus the ack for a
+/// caller that must continue past the POST, or any error status for a caller
+/// whose only subject is the request body — `launch_new_session_and_attach`
+/// answered `200` would go on to run a REAL `tmux attach`, so its wire tests
+/// use `500` to make the function return the moment the body is captured.
+/// Test: `session_start_posts_the_same_wire_shape_bare_tm_guided_default_sends`,
+/// `launch_new_session_and_attach_sends_the_name_hint`,
+/// `launch_new_session_and_attach_omits_name_hint_when_unnamed`.
+async fn spawn_capturing_managed_spawn_server_answering(
+    answer: axum::http::StatusCode,
+) -> (
     std::sync::Arc<std::sync::Mutex<Option<serde_json::Value>>>,
     String,
 ) {
@@ -229,13 +238,16 @@ async fn spawn_capturing_managed_spawn_server() -> (
         let captured = std::sync::Arc::clone(&captured_for_handler);
         async move {
             *captured.lock().expect("captured mutex poisoned") = Some(body);
-            Json(serde_json::json!({
-                "id": "11111111-1111-1111-1111-111111111111",
-                "name": "tmpm-test-session",
-                "state": "Active",
-                "runtime": "claude-code",
-                "attach_cmd": "tmux attach -t tmpm-test-session",
-            }))
+            (
+                answer,
+                Json(serde_json::json!({
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "name": "tmpm-test-session",
+                    "state": "Active",
+                    "runtime": "claude-code",
+                    "attach_cmd": "tmux attach -t tmpm-test-session",
+                })),
+            )
         }
     };
     let router = Router::new().route("/api/v1/sessions/managed", post(handler));
@@ -249,6 +261,15 @@ async fn spawn_capturing_managed_spawn_server() -> (
     });
 
     (captured, format!("http://{addr}"))
+}
+
+/// [`spawn_capturing_managed_spawn_server_answering`] with the success answer
+/// — the shape every caller wanted before #4965 added the reject variant.
+async fn spawn_capturing_managed_spawn_server() -> (
+    std::sync::Arc<std::sync::Mutex<Option<serde_json::Value>>>,
+    String,
+) {
+    spawn_capturing_managed_spawn_server_answering(axum::http::StatusCode::OK).await
 }
 
 /// #1916 item 3: `session start`'s protected-path branch must POST the SAME
@@ -405,5 +426,91 @@ fn session_start_accepts_a_git_directory() {
     assert!(
         super::refuse_outside_a_git_project(&plain).is_err(),
         "a non-git directory is refused"
+    );
+}
+
+// ── #4965: the picker's `n <name>` name_hint on the wire ───────────────────
+
+/// Drive [`crate::commands::guided_launch::launch_new_session_and_attach`]
+/// against the capturing server and return the request body it POSTed.
+///
+/// Why: the `name_hint` plumbing had no test of its own — `session start`'s
+/// wire-shape test only pins a hand-copied MIRROR of this body, so a wrong key
+/// name, a wrong JSON type, or a key leaking on the `None` path would all have
+/// gone unnoticed. This drives the REAL function.
+/// What: answers `500` after capturing so the function returns immediately
+/// after the POST instead of continuing into `tmux_attach`/`provision-status`
+/// (the returned `Err` is expected and ignored — the request body is the
+/// entire subject). `repo_url` is a non-directory string, so
+/// `needs_first_run_clone` short-circuits without touching the filesystem.
+/// Test: `launch_new_session_and_attach_sends_the_name_hint`,
+/// `launch_new_session_and_attach_omits_name_hint_when_unnamed`.
+async fn capture_guided_launch_body(name_hint: Option<&str>) -> serde_json::Value {
+    let (captured, url) = spawn_capturing_managed_spawn_server_answering(
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+    )
+    .await;
+    let client = reqwest::Client::new();
+    let result = crate::commands::guided_launch::launch_new_session_and_attach(
+        &client,
+        &url,
+        "https://example.invalid/owner/repo.git",
+        name_hint,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "the harness answers 500 so the call stops at the POST; got {result:?}"
+    );
+
+    captured
+        .lock()
+        .expect("captured mutex poisoned")
+        .clone()
+        .expect("launch_new_session_and_attach must have POSTed to /api/v1/sessions/managed")
+}
+
+/// #4965: a named launch must put the operator's leaf on the wire under the
+/// key the daemon reads (`name_hint`), as a JSON string.
+///
+/// FAILS BEFORE THIS CHANGE: nothing exercised this function's body at all —
+/// renaming the key to `nameHint`, or sending it as a number, kept every test
+/// green.
+/// What: captures the real POST body for `Some("auth")`.
+#[tokio::test]
+async fn launch_new_session_and_attach_sends_the_name_hint() {
+    let body = capture_guided_launch_body(Some("auth")).await;
+    assert_eq!(
+        body.get("name_hint"),
+        Some(&serde_json::Value::String("auth".to_string())),
+        "the named launch must send name_hint as a JSON string: {body}"
+    );
+}
+
+/// #4965: the unnamed launch must OMIT the key entirely — not send `null`.
+///
+/// Why: the daemon's `Option<String>` deserialization accepts a missing key
+/// and a `null` alike, but `session start`'s wire-shape test asserts the two
+/// surfaces' bodies are EQUAL, so a leaked `null` here would be a silent
+/// divergence between the two spawn entry points (#1916 item 3).
+/// What: captures the real POST body for `None` and asserts the key is absent,
+/// then that the rest of the body is unchanged.
+#[tokio::test]
+async fn launch_new_session_and_attach_omits_name_hint_when_unnamed() {
+    let body = capture_guided_launch_body(None).await;
+    assert!(
+        body.get("name_hint").is_none(),
+        "the unnamed launch must omit name_hint entirely, not send null: {body}"
+    );
+    assert_eq!(
+        body,
+        serde_json::json!({
+            "repo_url": "https://example.invalid/owner/repo.git",
+            "ref": "HEAD",
+            "task": "",
+            "force_new": true,
+            "background": true,
+        }),
+        "the unnamed request's wire shape must be unchanged by #4965"
     );
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
@@ -67,8 +67,12 @@ use super::managed::filter_live_sessions;
 pub(crate) enum PickerDecision {
     /// Resume the session at this 0-based index into the sessions slice.
     Resume(usize),
-    /// Launch a brand-new session.
-    LaunchNew,
+    /// Launch a brand-new session, optionally with an operator-supplied name
+    /// hint (#4965). `None` — the bare-Enter, `[N]` and bare-`n` paths — lets
+    /// the daemon derive the name from the repo as it always has; `Some(name)`
+    /// — typed as `n <name>` — forwards the raw string as `name_hint`, which
+    /// `trusty_common::session_naming` sanitizes daemon-side.
+    LaunchNew(Option<String>),
     /// User chose to quit without action.
     Quit,
     /// Input was not recognised; the caller quits cleanly.
@@ -625,14 +629,18 @@ fn decide_for_index(
 ///   • `"q"` / `"Q"` → `Quit`
 ///   • `"ls"` / `"list"` (case-insensitive, #3863) → `ListSessions` — re-print
 ///     the current list in place, never a selection
-///   • empty / whitespace, `sessions` empty → `LaunchNew`
+///   • empty / whitespace, `sessions` empty → `LaunchNew(None)`
 ///   • empty / whitespace, `sessions` non-empty → [`decide_for_index`] on
 ///     position 0, gated by `first_needs_restart`
 ///   • `N` matching some `sessions[i].slot` → [`decide_for_index`] on `i`
 ///     (an EXPLICIT numeric choice never applies the restart-confirm gate —
 ///     it always dispatches directly, confirm or not, per #2148)
 ///   • `N` == `(highest displayed slot) + 1` (or `1` when `sessions` is
-///     empty) → `LaunchNew`
+///     empty) → `LaunchNew(None)`
+///   • `n` / `N` with an empty or whitespace-only remainder → `LaunchNew(None)`
+///     — a slot-independent alias for the numeric launch-new choice (#4965)
+///   • `n<name>` / `n <name>` → `LaunchNew(Some(name))`; the raw trimmed
+///     remainder is forwarded as `name_hint` and sanitized daemon-side
 ///   • `d<N>` / `d <N>` matching a LIVE `sessions[i].slot` → `Delete(i)`
 ///     (#2304); the driver still runs a confirm/force-confirm prompt before
 ///     deleting. Matching a TOMBSTONED slot → `SlotDeleted(i)` (#3034 — no
@@ -655,7 +663,10 @@ fn decide_for_index(
 /// `guided_picker_delete_prefix_on_deleted_slot_blocked`,
 /// `guided_picker_launch_new_uses_highest_slot_with_gaps`,
 /// `guided_picker_ls_returns_list_sessions`,
-/// `guided_picker_list_returns_list_sessions`.
+/// `guided_picker_list_returns_list_sessions`,
+/// `guided_picker_n_launches_new_unnamed`,
+/// `guided_picker_n_with_argument_carries_name_hint`,
+/// `guided_picker_n_does_not_shadow_other_commands`.
 pub(crate) fn parse_picker_choice(
     line: &str,
     sessions: &[ManagedSessionSummary],
@@ -720,9 +731,24 @@ pub(crate) fn parse_picker_choice(
             None => PickerDecision::Unrecognised,
         };
     }
+    // #4965: `n` / `n <name>` launches a new session. The numeric launch-new
+    // slot moves as sessions come and go, so there was nothing to memorize and
+    // no way to name the result — every other spawn surface already accepts a
+    // `name_hint`. Parsed with the same `strip_prefix` shape as `d<N>`/`r<N>`,
+    // and after them so those prefixes stay unambiguous. The remainder is
+    // passed through raw: `session_naming::resolve_session_name` lowercases,
+    // collapses separators and truncates it daemon-side, so validating here
+    // would only duplicate (and eventually contradict) that.
+    if let Some(rest) = choice.strip_prefix(['n', 'N']) {
+        let name = rest.trim();
+        return match name.is_empty() {
+            true => PickerDecision::LaunchNew(None),
+            false => PickerDecision::LaunchNew(Some(name.to_string())),
+        };
+    }
     if choice.is_empty() {
         if sessions.is_empty() {
-            return PickerDecision::LaunchNew;
+            return PickerDecision::LaunchNew(None);
         }
         return decide_for_index(sessions, 0, first_needs_restart);
     }
@@ -733,7 +759,7 @@ pub(crate) fn parse_picker_choice(
             return decide_for_index(sessions, idx, false);
         }
         if n == next_slot {
-            return PickerDecision::LaunchNew;
+            return PickerDecision::LaunchNew(None);
         }
     }
     PickerDecision::Unrecognised
@@ -751,8 +777,9 @@ pub(crate) fn parse_picker_choice(
 /// input; propagates attach/launch errors.
 ///   • `Resume(i)` → [`super::guided_resume::resume_guided_session`] which
 ///     handles daemon restart when needed and then attaches internally;
-///   • `LaunchNew` → [`super::guided_launch::launch_new_session_and_attach`] when
-///     the scope carries a `repo_url`; otherwise prints an actionable hint and
+///   • `LaunchNew(name_hint)` → [`super::guided_launch::launch_new_session_and_attach`]
+///     when the scope carries a `repo_url`, forwarding the `n <name>` hint
+///     (#4965) when one was typed; otherwise prints an actionable hint and
 ///     redisplays the menu (fleet-wide `tm ls` has no single launch target);
 ///   • `ConfirmRestart(i)` (#2148) → print a one-line "type the number to
 ///     confirm" notice and redisplay the SAME menu — no daemon round-trip;
@@ -835,9 +862,11 @@ pub(crate) async fn run_tty_picker(
             .map(|s| !s.deleted && super::guided_resume::needs_restart(&s.state))
             .unwrap_or(false);
         if sessions.is_empty() {
-            eprintln!("[Enter] launch new session");
-            eprintln!("[ls]    re-print this list");
-            eprintln!("[q]     quit");
+            eprintln!("[Enter]    launch new session");
+            // #4965: the named form, advertised wherever launch-new is offered.
+            eprintln!("[n <name>] launch new session named <name>");
+            eprintln!("[ls]       re-print this list");
+            eprintln!("[q]        quit");
         } else {
             if stale_slots {
                 // #4230: `tm restart` is a hard error where launchd owns the
@@ -864,6 +893,10 @@ pub(crate) async fn run_tty_picker(
                 );
             }
             eprintln!("[{new_idx}] launch new session");
+            // #4965: `n` is the slot-independent alias for the line above —
+            // the `[{new_idx}]` number shifts as sessions come and go, so it
+            // is nothing an operator can memorize, and it cannot carry a name.
+            eprintln!("[n <name>] launch new session named <name> (e.g. n auth-refactor)");
             eprintln!("[d<N>] delete session N (e.g. d1)");
             eprintln!("[r<N> <new-name>] rename session N (e.g. r1 tm-my-new-name)");
             eprintln!("[ls] re-print this list");
@@ -912,11 +945,15 @@ pub(crate) async fn run_tty_picker(
                     break;
                 }
             }
-            PickerDecision::LaunchNew => match scope.repo_url.as_deref() {
+            PickerDecision::LaunchNew(name_hint) => match scope.repo_url.as_deref() {
                 Some(repo) => {
-                    let outcome =
-                        super::guided_launch::launch_new_session_and_attach(client, url, repo)
-                            .await?;
+                    let outcome = super::guided_launch::launch_new_session_and_attach(
+                        client,
+                        url,
+                        repo,
+                        name_hint.as_deref(),
+                    )
+                    .await?;
                     if outcome.ends_interactive_loop() {
                         break;
                     }
@@ -1002,8 +1039,8 @@ pub(crate) async fn run_tty_picker(
             // instead — no daemon round-trip.
             PickerDecision::Unrecognised => {
                 eprintln!(
-                    "tm: unrecognised choice '{}' — accepted: 1..{new_idx}, ls, d<N>, \
-                     r<N> <name>, q",
+                    "tm: unrecognised choice '{}' — accepted: 1..{new_idx}, n [<name>], \
+                     ls, d<N>, r<N> <name>, q",
                     line.trim()
                 );
                 continue;

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
@@ -69,14 +69,30 @@ pub(crate) enum PickerDecision {
     Resume(usize),
     /// Launch a brand-new session, optionally with an operator-supplied name
     /// hint (#4965). `None` — the bare-Enter, `[N]` and bare-`n` paths — lets
-    /// the daemon derive the name from the repo as it always has; `Some(name)`
-    /// — typed as `n <name>` — forwards the raw string as `name_hint`, which
-    /// `trusty_common::session_naming` sanitizes daemon-side.
+    /// the daemon derive the name from the repo as it always has. `Some(leaf)`
+    /// — typed as `n <name>` — carries the name ALREADY sanitized to the
+    /// daemon's own kebab-case leaf form via
+    /// [`trusty_common::session_naming::leaf_slug_from_hint`], never the raw
+    /// typed string: the daemon's `name_hint` path runs the hint through
+    /// `Path::file_name()`, which would silently collapse `feature/auth` and
+    /// `hotfix/auth` to the same `auth`. Sanitizing here makes that step a
+    /// no-op. Never empty — an unusable name resolves to
+    /// [`Self::UnusableName`] instead.
     LaunchNew(Option<String>),
     /// User chose to quit without action.
     Quit,
     /// Input was not recognised; the caller quits cleanly.
     Unrecognised,
+    /// `n <name>` was typed with a name that sanitizes to nothing — `n !!!`,
+    /// `n ---` (#4965). Carries the raw text so the driver can quote it back.
+    ///
+    /// Why this is NOT `LaunchNew(None)`: falling back to the unnamed path
+    /// would spawn a session in the daemon's shared `local` leaf namespace —
+    /// a name LESS identifiable than the repo-derived default, produced by a
+    /// command the operator typed specifically to make it MORE identifiable.
+    /// A spawn is not undoable enough to guess at; the driver reprints the
+    /// menu instead.
+    UnusableName(String),
     /// Bare Enter was pressed but the 0-based-indexed session at this slot is
     /// stopped/errored — resuming it would KILL and recreate its tmux pane
     /// (or, if the pane already happened to be dead, spawn a fresh one). #2148:
@@ -605,6 +621,34 @@ fn decide_for_index(
     }
 }
 
+/// Recognise the `n` launch-new command and return its raw argument (#4965).
+///
+/// Why the token is matched EXACTLY rather than stripped like `d<N>`/`r<N>`:
+/// those prefixes are safe only because their remainder must still parse as a
+/// live slot number, so `d2` is unambiguous while `delete` falls through to
+/// `Unrecognised`. `n` has no such gate — an unbounded `strip_prefix(['n','N'])`
+/// makes EVERY n-initial word a spawn with no confirmation, and the menu line
+/// itself reads "launch new session", so an operator typing `new` gets a real
+/// cloned, spawned, attached session named `tm-ew-NN`. `n` is also already the
+/// "no" answer in this tool's own `[y/N]` delete confirm. So: the token before
+/// the first whitespace must be exactly `n`/`N`, and a name requires a
+/// separator — the no-space `nauth` form is deliberately NOT accepted.
+///
+/// What: `None` when `choice` is not the `n` command at all (`new`, `no`,
+/// `nn`, `n1`, `nauth`). `Some("")` for a bare `n`/`N`, or one whose remainder
+/// is only whitespace. `Some(name)` — trimmed, possibly multi-word, NOT yet
+/// sanitized — for `n <name>`. `choice` must already be trimmed.
+/// Test: `guided_picker_n_grammar_is_bounded`,
+/// `guided_picker_n_launches_new_unnamed`,
+/// `guided_picker_n_with_argument_carries_name_hint`.
+fn launch_new_argument(choice: &str) -> Option<&str> {
+    let (token, rest) = match choice.split_once(char::is_whitespace) {
+        Some((token, rest)) => (token, rest.trim()),
+        None => (choice, ""),
+    };
+    token.eq_ignore_ascii_case("n").then_some(rest)
+}
+
 /// Parse one line of picker input into a [`PickerDecision`].
 ///
 /// Why: separating parse-and-decide from the I/O driver makes the dispatch
@@ -637,10 +681,14 @@ fn decide_for_index(
 ///     it always dispatches directly, confirm or not, per #2148)
 ///   • `N` == `(highest displayed slot) + 1` (or `1` when `sessions` is
 ///     empty) → `LaunchNew(None)`
-///   • `n` / `N` with an empty or whitespace-only remainder → `LaunchNew(None)`
-///     — a slot-independent alias for the numeric launch-new choice (#4965)
-///   • `n<name>` / `n <name>` → `LaunchNew(Some(name))`; the raw trimmed
-///     remainder is forwarded as `name_hint` and sanitized daemon-side
+///   • exactly `n` / `N` (or one whose remainder is only whitespace) →
+///     `LaunchNew(None)` — a slot-independent alias for the numeric
+///     launch-new choice (#4965)
+///   • `n <name>` — whitespace separator REQUIRED — → `LaunchNew(Some(leaf))`,
+///     where `leaf` is the name already kebab-cased by
+///     [`trusty_common::session_naming::leaf_slug_from_hint`], or
+///     `UnusableName(raw)` when nothing alphanumeric survives. `new`, `no`,
+///     `nn`, `n1`, `nauth` are `Unrecognised` — see [`launch_new_argument`]
 ///   • `d<N>` / `d <N>` matching a LIVE `sessions[i].slot` → `Delete(i)`
 ///     (#2304); the driver still runs a confirm/force-confirm prompt before
 ///     deleting. Matching a TOMBSTONED slot → `SlotDeleted(i)` (#3034 — no
@@ -666,6 +714,8 @@ fn decide_for_index(
 /// `guided_picker_list_returns_list_sessions`,
 /// `guided_picker_n_launches_new_unnamed`,
 /// `guided_picker_n_with_argument_carries_name_hint`,
+/// `guided_picker_n_grammar_is_bounded`,
+/// `guided_picker_n_sanitizes_the_name_cli_side`,
 /// `guided_picker_n_does_not_shadow_other_commands`.
 pub(crate) fn parse_picker_choice(
     line: &str,
@@ -731,19 +781,23 @@ pub(crate) fn parse_picker_choice(
             None => PickerDecision::Unrecognised,
         };
     }
-    // #4965: `n` / `n <name>` launches a new session. The numeric launch-new
-    // slot moves as sessions come and go, so there was nothing to memorize and
-    // no way to name the result — every other spawn surface already accepts a
-    // `name_hint`. Parsed with the same `strip_prefix` shape as `d<N>`/`r<N>`,
-    // and after them so those prefixes stay unambiguous. The remainder is
-    // passed through raw: `session_naming::resolve_session_name` lowercases,
-    // collapses separators and truncates it daemon-side, so validating here
-    // would only duplicate (and eventually contradict) that.
-    if let Some(rest) = choice.strip_prefix(['n', 'N']) {
-        let name = rest.trim();
-        return match name.is_empty() {
-            true => PickerDecision::LaunchNew(None),
-            false => PickerDecision::LaunchNew(Some(name.to_string())),
+    // #4965: `n` / `n <name>` launches a new session — see
+    // [`launch_new_argument`] for the grammar and why it is exact-match rather
+    // than a `d<N>`/`r<N>`-style prefix strip.
+    if let Some(name) = launch_new_argument(choice) {
+        if name.is_empty() {
+            return PickerDecision::LaunchNew(None);
+        }
+        // Sanitize HERE, not daemon-side. `resolve_session_name` feeds a
+        // `name_hint` to `leaf_slug_from_dir`, whose `Path::file_name()` step
+        // drops everything before the last `/` — `n feature/auth` and
+        // `n hotfix/auth` would both become `tm-auth-NN`. Slugifying with the
+        // same function and the same cap makes the daemon's pass a no-op, so
+        // what the operator sees here is the leaf the session actually gets.
+        let slug = trusty_common::session_naming::leaf_slug_from_hint(name);
+        return match slug.is_empty() {
+            true => PickerDecision::UnusableName(name.to_string()),
+            false => PickerDecision::LaunchNew(Some(slug)),
         };
     }
     if choice.is_empty() {
@@ -778,9 +832,13 @@ pub(crate) fn parse_picker_choice(
 ///   • `Resume(i)` → [`super::guided_resume::resume_guided_session`] which
 ///     handles daemon restart when needed and then attaches internally;
 ///   • `LaunchNew(name_hint)` → [`super::guided_launch::launch_new_session_and_attach`]
-///     when the scope carries a `repo_url`, forwarding the `n <name>` hint
-///     (#4965) when one was typed; otherwise prints an actionable hint and
-///     redisplays the menu (fleet-wide `tm ls` has no single launch target);
+///     when the scope carries a `repo_url`, forwarding the already-sanitized
+///     `n <name>` leaf (#4965) when one was typed — and printing a one-line
+///     note first when that leaf differs from the typed text; otherwise prints
+///     an actionable hint and redisplays the menu (fleet-wide `tm ls` has no
+///     single launch target);
+///   • `UnusableName(typed)` (#4965) → print "no usable name characters" and
+///     redisplay the SAME menu — never a spawn under a fallback name;
 ///   • `ConfirmRestart(i)` (#2148) → print a one-line "type the number to
 ///     confirm" notice and redisplay the SAME menu — no daemon round-trip;
 ///   • `Unresumable(i)` (#2595) → print the dead-session notice pointing at
@@ -861,12 +919,14 @@ pub(crate) async fn run_tty_picker(
             .first()
             .map(|s| !s.deleted && super::guided_resume::needs_restart(&s.state))
             .unwrap_or(false);
+        // #4965: the `[key] description` legend is built by
+        // `session_picker_render::command_legend` — column-aligned in BOTH
+        // menus (the populated one used to be ragged), and pure so its wording
+        // is testable without driving this loop.
         if sessions.is_empty() {
-            eprintln!("[Enter]    launch new session");
-            // #4965: the named form, advertised wherever launch-new is offered.
-            eprintln!("[n <name>] launch new session named <name>");
-            eprintln!("[ls]       re-print this list");
-            eprintln!("[q]        quit");
+            for l in super::session_picker_render::command_legend(None) {
+                eprintln!("{l}");
+            }
         } else {
             if stale_slots {
                 // #4230: `tm restart` is a hard error where launchd owns the
@@ -892,15 +952,13 @@ pub(crate) async fn run_tty_picker(
                     super::session_picker_render::format_session_row(num, s, use_color)
                 );
             }
-            eprintln!("[{new_idx}] launch new session");
-            // #4965: `n` is the slot-independent alias for the line above —
-            // the `[{new_idx}]` number shifts as sessions come and go, so it
-            // is nothing an operator can memorize, and it cannot carry a name.
-            eprintln!("[n <name>] launch new session named <name> (e.g. n auth-refactor)");
-            eprintln!("[d<N>] delete session N (e.g. d1)");
-            eprintln!("[r<N> <new-name>] rename session N (e.g. r1 tm-my-new-name)");
-            eprintln!("[ls] re-print this list");
-            eprintln!("[q] quit");
+            // #4965: `n` is the slot-independent alias for the `[{new_idx}]`
+            // launch-new row — that number shifts as sessions come and go, so
+            // it is nothing an operator can memorize, and it cannot carry a
+            // name.
+            for l in super::session_picker_render::command_legend(Some(new_idx)) {
+                eprintln!("{l}");
+            }
             let first = &sessions[0];
             let first_num = shown_slot(&sessions, 0);
             if first.deleted {
@@ -947,6 +1005,21 @@ pub(crate) async fn run_tty_picker(
             }
             PickerDecision::LaunchNew(name_hint) => match scope.repo_url.as_deref() {
                 Some(repo) => {
+                    // #4965: the name is kebab-cased before it is sent, so
+                    // `n My Auth Fix!` produces `tm-my-auth-fix-NN`. Say so
+                    // when the result differs from what was typed — a spawn
+                    // is not cheap to undo, and a silently rewritten name is
+                    // exactly the surprise this command exists to remove.
+                    // `launch_new_argument` is the SAME parser
+                    // `parse_picker_choice` used, so the raw text cannot drift
+                    // from the grammar; it returns `None` for the bare-Enter
+                    // and numeric launch paths, which have nothing to compare.
+                    if let (Some(raw), Some(slug)) =
+                        (launch_new_argument(line.trim()), name_hint.as_deref())
+                        && raw != slug
+                    {
+                        eprintln!("tm: naming it '{slug}' (from '{raw}').");
+                    }
                     let outcome = super::guided_launch::launch_new_session_and_attach(
                         client,
                         url,
@@ -1042,6 +1115,18 @@ pub(crate) async fn run_tty_picker(
                     "tm: unrecognised choice '{}' — accepted: 1..{new_idx}, n [<name>], \
                      ls, d<N>, r<N> <name>, q",
                     line.trim()
+                );
+                continue;
+            }
+            // #4965: `n <name>` whose name sanitizes to nothing. Spawning
+            // anyway would put the session in the daemon's shared `local`
+            // leaf namespace — less identifiable than the default the
+            // operator was trying to improve on. No daemon round-trip;
+            // redisplay the SAME menu.
+            PickerDecision::UnusableName(typed) => {
+                eprintln!(
+                    "tm: '{typed}' has no usable name characters — try `n <letters>` \
+                     (e.g. n auth-refactor)."
                 );
                 continue;
             }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_render.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_render.rs
@@ -164,3 +164,49 @@ pub(crate) fn format_session_row(num: u32, s: &ManagedSessionSummary, use_color:
     let state = colorize(shown_state, color, use_color);
     format!("[{num}] {} ({state})", s.name)
 }
+
+/// Column width the command legend pads each `[key]` to (#4965).
+///
+/// Why: the descriptions must line up in BOTH menus — the empty-session
+/// variant was aligned while the populated one (the common case) was left
+/// ragged, so the two looked like different tools. Sized to the widest key,
+/// `[r<N> <new-name>]`, plus one separating space.
+const MENU_KEY_WIDTH: usize = 18;
+
+/// Build the picker's command legend — the `[key]  description` lines printed
+/// under the session rows.
+///
+/// Why: kept out of `run_tty_picker` for two reasons. This module exists
+/// because `session_picker.rs` sits at the 500-SLOC production cap, and the
+/// legend is exactly the kind of pure formatting it was split off to hold;
+/// and a pure function makes the wording and the column alignment assertable
+/// without driving a real TTY loop.
+/// What: `launch_slot` is `None` for the no-sessions menu (bare Enter is the
+/// launch key, and the delete/rename rows have nothing to target) and
+/// `Some(slot)` for the populated one. The `n` row spells out `tm-<name>-NN`
+/// because the adjacent `r<N> <new-name>` row takes a VERBATIM full session
+/// name — without it the two `<name>` arguments read as interchangeable and
+/// are not.
+/// Test: `command_legend_empty_menu_shape`, `command_legend_populated_menu_shape`,
+/// `command_legend_columns_are_aligned`.
+pub(crate) fn command_legend(launch_slot: Option<u32>) -> Vec<String> {
+    let row = |key: String, description: &str| format!("{key:<MENU_KEY_WIDTH$} {description}");
+    let mut lines = match launch_slot {
+        None => vec![row("[Enter]".to_string(), "launch new session")],
+        Some(slot) => vec![row(format!("[{slot}]"), "launch new session")],
+    };
+    lines.push(row(
+        "[n <name>]".to_string(),
+        "launch new session as tm-<name>-NN (e.g. n auth-refactor)",
+    ));
+    if launch_slot.is_some() {
+        lines.push(row("[d<N>]".to_string(), "delete session N (e.g. d1)"));
+        lines.push(row(
+            "[r<N> <new-name>]".to_string(),
+            "rename session N (e.g. r1 tm-my-new-name)",
+        ));
+    }
+    lines.push(row("[ls]".to_string(), "re-print this list"));
+    lines.push(row("[q]".to_string(), "quit"));
+    lines
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_tests.rs
@@ -15,7 +15,7 @@ use trusty_mpm::client::ManagedSessionSummary;
 
 use super::{PickerDecision, next_launch_slot, parse_picker_choice};
 use crate::commands::session_picker_render::{
-    StateColor, colorize, format_session_row, picker_use_color, state_color,
+    StateColor, colorize, command_legend, format_session_row, picker_use_color, state_color,
 };
 
 /// Minimal `ManagedSessionSummary` fixture with a given `slot`.
@@ -346,4 +346,80 @@ fn format_session_row_color_disabled_is_plain_text() {
         !row.contains('\x1b'),
         "no ANSI escapes when use_color is false"
     );
+}
+
+// ── command_legend (#4965) ────────────────────────────────────────────────────
+
+/// The no-sessions menu offers bare Enter and `n <name>`, and nothing to
+/// delete or rename — there is no session to target.
+#[test]
+fn command_legend_empty_menu_shape() {
+    let lines = command_legend(None);
+    let keys: Vec<&str> = lines
+        .iter()
+        .map(|l| l.split("  ").next().unwrap())
+        .collect();
+    assert_eq!(keys, ["[Enter]", "[n <name>]", "[ls]", "[q]"]);
+}
+
+/// The populated menu leads with the launch slot and adds the delete/rename
+/// rows.
+#[test]
+fn command_legend_populated_menu_shape() {
+    let lines = command_legend(Some(4));
+    let keys: Vec<&str> = lines
+        .iter()
+        .map(|l| l.split("  ").next().unwrap())
+        .collect();
+    assert_eq!(
+        keys,
+        [
+            "[4]",
+            "[n <name>]",
+            "[d<N>]",
+            "[r<N> <new-name>]",
+            "[ls]",
+            "[q]"
+        ]
+    );
+}
+
+/// #4965: `n <name>` must be self-documenting. `r1 <name>` right below it
+/// takes a VERBATIM full session name while `n <name>` takes a leaf the daemon
+/// wraps as `tm-<name>-NN` — adjacent rows with an unexplained `<name>` each
+/// read as interchangeable.
+#[test]
+fn command_legend_n_row_names_the_resulting_session_shape() {
+    let lines = command_legend(Some(4));
+    let n_row = lines
+        .iter()
+        .find(|l| l.starts_with("[n <name>]"))
+        .expect("the n row must be present");
+    assert!(
+        n_row.contains("tm-<name>-NN"),
+        "the n row must spell out the name it produces: {n_row}"
+    );
+}
+
+/// #4965 (LOW): BOTH menus are padded to the same column. The empty variant
+/// was aligned and the populated one — the common case — was left ragged.
+#[test]
+fn command_legend_columns_are_aligned() {
+    for lines in [command_legend(None), command_legend(Some(12))] {
+        let offsets: Vec<usize> = lines
+            .iter()
+            .map(|l| {
+                l.find("launch")
+                    .or_else(|| l.find("delete"))
+                    .or_else(|| l.find("rename"))
+                    .or_else(|| l.find("re-print"))
+                    .or_else(|| l.find("quit"))
+                    .expect("every row has a description")
+            })
+            .collect();
+        assert!(
+            offsets.windows(2).all(|w| w[0] == w[1]),
+            "descriptions must all start in the same column: {lines:#?}"
+        );
+    }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_tests.rs
@@ -118,7 +118,7 @@ fn parse_picker_choice_launch_new_uses_max_slot_after_reorder() {
     );
     assert_eq!(
         parse_picker_choice("32", &sessions, false),
-        PickerDecision::LaunchNew
+        PickerDecision::LaunchNew(None)
     );
 }
 

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -52,11 +52,11 @@ fn guided_picker_bare_enter_no_sessions_launches_new() {
     // Why: bare Enter with no sessions must launch a new session, not hang.
     assert_eq!(
         parse_picker_choice("", &[], false),
-        PickerDecision::LaunchNew
+        PickerDecision::LaunchNew(None)
     );
     assert_eq!(
         parse_picker_choice("  \t", &[], false),
-        PickerDecision::LaunchNew
+        PickerDecision::LaunchNew(None)
     );
 }
 
@@ -183,7 +183,7 @@ fn guided_picker_launch_new_uses_highest_slot_with_gaps() {
     ];
     assert_eq!(
         parse_picker_choice("6", &sessions, false),
-        PickerDecision::LaunchNew
+        PickerDecision::LaunchNew(None)
     );
     // The old `len()+1` value (3) must NOT be treated as launch-new here.
     assert_eq!(
@@ -284,11 +284,11 @@ fn guided_picker_numeric_launch_new() {
     // Why: "[highest slot + 1]" must always launch a new session.
     assert_eq!(
         parse_picker_choice("1", &[], false),
-        PickerDecision::LaunchNew
+        PickerDecision::LaunchNew(None)
     );
     assert_eq!(
         parse_picker_choice("4", &picker_fixture(3, &[]), false),
-        PickerDecision::LaunchNew
+        PickerDecision::LaunchNew(None)
     );
 }
 
@@ -324,7 +324,7 @@ fn guided_picker_stale_daemon_slots_render_distinct_incrementing_choices() {
     // fixed `1` (the pre-fix `sessions.last().slot + 1 == 0 + 1` bug).
     assert_eq!(
         parse_picker_choice("4", &sessions, false),
-        PickerDecision::LaunchNew
+        PickerDecision::LaunchNew(None)
     );
 }
 
@@ -438,6 +438,106 @@ fn guided_picker_ls_does_not_shadow_launch_new_or_delete_prefix() {
     assert_eq!(
         parse_picker_choice("lsx", &picker_fixture(3, &[]), false),
         PickerDecision::Unrecognised
+    );
+}
+
+#[test]
+fn guided_picker_n_launches_new_unnamed() {
+    // #4965: bare `n` is the slot-independent alias for the numeric
+    // launch-new choice — same outcome, nothing to memorize. Case-insensitive
+    // like `d`/`r`/`q`, and a whitespace-only remainder is still "unnamed",
+    // never an empty `name_hint` the daemon would have to fall back on.
+    assert_eq!(
+        parse_picker_choice("n", &picker_fixture(3, &[]), false),
+        PickerDecision::LaunchNew(None)
+    );
+    assert_eq!(
+        parse_picker_choice("N", &picker_fixture(3, &[]), false),
+        PickerDecision::LaunchNew(None)
+    );
+    assert_eq!(
+        parse_picker_choice("n\n", &[], false),
+        PickerDecision::LaunchNew(None)
+    );
+    assert_eq!(
+        parse_picker_choice("  n  ", &picker_fixture(1, &[]), true),
+        PickerDecision::LaunchNew(None)
+    );
+    assert_eq!(
+        parse_picker_choice("n   ", &picker_fixture(3, &[]), false),
+        PickerDecision::LaunchNew(None),
+        "a whitespace-only remainder must launch unnamed, not with an empty name"
+    );
+}
+
+#[test]
+fn guided_picker_n_with_argument_carries_name_hint() {
+    // #4965: the remainder rides through as `name_hint` verbatim — no
+    // validation, no sanitization here; `session_naming::resolve_session_name`
+    // owns that daemon-side, so `my auth fix` becomes `my-auth-fix` there.
+    assert_eq!(
+        parse_picker_choice("n auth-refactor", &picker_fixture(3, &[]), false),
+        PickerDecision::LaunchNew(Some("auth-refactor".to_string()))
+    );
+    // No space needed after the prefix, matching `d2` ≡ `d 2`.
+    assert_eq!(
+        parse_picker_choice("nauth", &picker_fixture(3, &[]), false),
+        PickerDecision::LaunchNew(Some("auth".to_string()))
+    );
+    assert_eq!(
+        parse_picker_choice("N auth-refactor\n", &[], false),
+        PickerDecision::LaunchNew(Some("auth-refactor".to_string()))
+    );
+    assert_eq!(
+        parse_picker_choice("n my auth fix", &picker_fixture(3, &[]), false),
+        PickerDecision::LaunchNew(Some("my auth fix".to_string())),
+        "multi-word names must survive to name_hint; the daemon sanitizes"
+    );
+}
+
+#[test]
+fn guided_picker_n_does_not_shadow_other_commands() {
+    // #4965 is purely additive: adding the `n` prefix must not swallow any
+    // existing token, and none of them may swallow `n`. Every case here is a
+    // command that already worked before `n` existed.
+    let sessions = picker_fixture(3, &[]);
+    assert_eq!(
+        parse_picker_choice("ls", &sessions, false),
+        PickerDecision::ListSessions
+    );
+    assert_eq!(
+        parse_picker_choice("list", &sessions, false),
+        PickerDecision::ListSessions
+    );
+    assert_eq!(
+        parse_picker_choice("d2", &sessions, false),
+        PickerDecision::Delete(1)
+    );
+    assert_eq!(
+        parse_picker_choice("r1 tm-renamed", &sessions, false),
+        PickerDecision::Rename(0, "tm-renamed".to_string())
+    );
+    assert_eq!(
+        parse_picker_choice("q", &sessions, false),
+        PickerDecision::Quit
+    );
+    assert_eq!(
+        parse_picker_choice("2", &sessions, false),
+        PickerDecision::Resume(1)
+    );
+    assert_eq!(
+        parse_picker_choice("4", &sessions, false),
+        PickerDecision::LaunchNew(None)
+    );
+    // Bare Enter still resolves against position 0, never the new `n` branch.
+    assert_eq!(
+        parse_picker_choice("", &sessions, false),
+        PickerDecision::Resume(0)
+    );
+    // And the reverse direction: `n` is not shadowed by any of them.
+    assert_eq!(
+        parse_picker_choice("n", &sessions, false),
+        PickerDecision::LaunchNew(None)
     );
 }
 

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -472,32 +472,103 @@ fn guided_picker_n_launches_new_unnamed() {
 
 #[test]
 fn guided_picker_n_with_argument_carries_name_hint() {
-    // #4965: the remainder rides through as `name_hint` verbatim — no
-    // validation, no sanitization here; `session_naming::resolve_session_name`
-    // owns that daemon-side, so `my auth fix` becomes `my-auth-fix` there.
+    // #4965: `n <name>` — the whitespace separator is REQUIRED — carries the
+    // name through as `name_hint`, already sanitized (see
+    // `guided_picker_n_sanitizes_the_name_cli_side`).
     assert_eq!(
         parse_picker_choice("n auth-refactor", &picker_fixture(3, &[]), false),
         PickerDecision::LaunchNew(Some("auth-refactor".to_string()))
-    );
-    // No space needed after the prefix, matching `d2` ≡ `d 2`.
-    assert_eq!(
-        parse_picker_choice("nauth", &picker_fixture(3, &[]), false),
-        PickerDecision::LaunchNew(Some("auth".to_string()))
     );
     assert_eq!(
         parse_picker_choice("N auth-refactor\n", &[], false),
         PickerDecision::LaunchNew(Some("auth-refactor".to_string()))
     );
     assert_eq!(
-        parse_picker_choice("n my auth fix", &picker_fixture(3, &[]), false),
-        PickerDecision::LaunchNew(Some("my auth fix".to_string())),
-        "multi-word names must survive to name_hint; the daemon sanitizes"
+        parse_picker_choice("n   auth-refactor   ", &picker_fixture(3, &[]), false),
+        PickerDecision::LaunchNew(Some("auth-refactor".to_string())),
+        "extra separator whitespace must not become part of the name"
+    );
+}
+
+/// #4965 round 2: the `n` grammar is BOUNDED — `strip_prefix(['n','N'])` made
+/// every n-initial word a real, unconfirmed spawn. The menu line itself says
+/// "launch new session", so an operator typing `new` got a cloned, spawned,
+/// attached session named `tm-ew-NN`; `n` is also this tool's own "no" answer
+/// in the `[y/N]` delete confirm. The token must be exactly `n`, and a name
+/// requires a separator.
+///
+/// FAILS BEFORE THIS CHANGE: every assertion in the first block returned
+/// `LaunchNew(Some(...))`.
+#[test]
+fn guided_picker_n_grammar_is_bounded() {
+    let sessions = picker_fixture(3, &[]);
+    for input in ["new", "no", "nn", "n1", "nauth", "N0", "note", "next"] {
+        assert_eq!(
+            parse_picker_choice(input, &sessions, false),
+            PickerDecision::Unrecognised,
+            "{input:?} must not spawn a session"
+        );
+    }
+    // The exact token, with or without a whitespace-only remainder, still
+    // launches unnamed.
+    for input in ["n", "N", "n ", "  n  ", "n\t\n"] {
+        assert_eq!(
+            parse_picker_choice(input, &sessions, false),
+            PickerDecision::LaunchNew(None),
+            "{input:?} is the bare launch-new alias"
+        );
+    }
+    // And a separated name is still accepted.
+    assert_eq!(
+        parse_picker_choice("n auth-refactor", &sessions, false),
+        PickerDecision::LaunchNew(Some("auth-refactor".to_string()))
+    );
+}
+
+/// #4965 round 2: the name is kebab-cased in the PICKER, before it is sent.
+///
+/// Why: the daemon's `resolve_session_name` runs a `name_hint` through
+/// `leaf_slug_from_dir`, whose `Path::file_name()` step drops everything
+/// before the last `/` — so `n feature/auth` and `n hotfix/auth` both used to
+/// produce `tm-auth-NN`, defeating the point of naming them. And a name that
+/// sanitizes to nothing fell back to the daemon's shared `local` leaf,
+/// silently producing `tm-local-NN`.
+///
+/// FAILS BEFORE THIS CHANGE: `n feature/auth` yielded the raw
+/// `Some("feature/auth")`, which the daemon then collapsed to `auth`; `n !!!`
+/// yielded `Some("!!!")` and spawned.
+#[test]
+fn guided_picker_n_sanitizes_the_name_cli_side() {
+    let sessions = picker_fixture(3, &[]);
+    assert_eq!(
+        parse_picker_choice("n My Auth Fix!", &sessions, false),
+        PickerDecision::LaunchNew(Some("my-auth-fix".to_string())),
+        "a multi-word name must arrive kebab-cased"
+    );
+    assert_eq!(
+        parse_picker_choice("n feature/auth", &sessions, false),
+        PickerDecision::LaunchNew(Some("feature-auth".to_string())),
+        "the path-like segment must SURVIVE — the daemon's file_name() would drop it"
+    );
+    assert_eq!(
+        parse_picker_choice("n hotfix/auth", &sessions, false),
+        PickerDecision::LaunchNew(Some("hotfix-auth".to_string())),
+        "and must stay distinct from feature/auth"
+    );
+    // Unusable names refuse rather than spawning under a fallback leaf.
+    assert_eq!(
+        parse_picker_choice("n !!!", &sessions, false),
+        PickerDecision::UnusableName("!!!".to_string())
+    );
+    assert_eq!(
+        parse_picker_choice("n ---", &sessions, false),
+        PickerDecision::UnusableName("---".to_string())
     );
 }
 
 #[test]
 fn guided_picker_n_does_not_shadow_other_commands() {
-    // #4965 is purely additive: adding the `n` prefix must not swallow any
+    // #4965 is purely additive: adding the `n` command must not swallow any
     // existing token, and none of them may swallow `n`. Every case here is a
     // command that already worked before `n` existed.
     let sessions = picker_fixture(3, &[]);


### PR DESCRIPTION
Closes #4965

Adds an `n` command to the interactive session picker (bare `tm` / `tm ls`) so a new session can be launched with a meaningful name instead of the daemon-derived `tm-<repo>-NN`.

## Grammar

| Input | Result |
|---|---|
| `n` / `N` (exact) | Launch new, auto-named |
| `n <name>` / `N <name>` (separator required) | Launch new, named |
| `new`, `no`, `nn`, `n1`, `nauth` | `Unrecognised` — unchanged |

The integer "launch new session" entry is unchanged. This is purely additive.

## Two commits

**`c8ccb317`** — the feature as originally specified in #4965.

**`7fdbf4d7`** — fixes from an adversarial review that returned WARN. The first commit used `strip_prefix(['n','N'])`, which consumed **any** n-prefixed input and returned a decision that unconditionally clones a repo, creates a worktree, starts tmux, and attaches — with no confirm step. The menu line literally reads *launch new session*, so an operator typing `new` would get a real session named `tm-ew-01`. The delete confirm is spelled `[y/N]`, so `n` already means "no" inside this tool.

The `d<N>` / `r<N> <name>` no-space precedent is only safe because their remainder must resolve to a live slot — `d9` on a 3-session list is `Unrecognised`. `n` had no such gate. It is now an exact-match token plus a required separator.

## Sanitization moved CLI-side

Previously the raw string was forwarded and the daemon sanitized it. Two bad outcomes:

- `n feature/auth` and `n hotfix/auth` both produced `tm-auth-NN` — the daemon's `resolve_session_name` routes the hint through `leaf_slug_from_dir`, whose `Path::file_name()` discards everything before the last `/`. That defeats the point of the feature.
- `n !!!` sanitized to empty and fell back to `tm-local-NN`, a name in a leaf namespace shared with every other project on the daemon and *less* identifiable than the default.

The name is now kebab-cased in the picker before it is sent. Rather than exposing the private `sanitize_slug` (which would also mean exposing `MAX_FOLDER_LEN`, inviting drift), this adds one public item — `leaf_slug_from_hint` in `trusty-common` — and refactors `leaf_slug_from_dir` to delegate to it. No second kebab-caser. `leaf_slug_from_hint_is_a_fixed_point_for_its_own_output` proves the daemon's own pass is a no-op rather than asserting it.

A name that sanitizes to empty is now rejected with a message instead of silently spawning. When the sanitized name differs from what was typed, one line is printed before launch: `tm: naming it 'my-auth-fix' (from 'My Auth Fix!').`

## Other changes

- The command legend moved out of `session_picker.rs` into `session_picker_render.rs` as `command_legend(Option<u32>) -> Vec<String>`. Inline, the file hit 515 SLOC against the repo's 500 cap and `check_line_cap.sh` refused it. This also made the column alignment and the `tm-<name>-NN` wording assertable — 4 tests.
- The `n` legend line is self-documenting (`launch new session as tm-<name>-NN`), since the adjacent `r<N> <name>` takes a *verbatim* full session name while `n <name>` takes a leaf.
- `launch_new_session_and_attach`'s `name_hint` plumbing had zero coverage. Two wire tests now assert the key is present on `Some` and **absent** (not null) on `None`.

## Test ladder — rung 4

`trusty-common` gained public API, so this is a cross-crate change.

```
cargo fmt --check                                        → 0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   → 0
cargo clippy -p trusty-common --features session-naming   → 0
scripts/check_line_cap.sh                                 → 0
cargo test -p trusty-common  → 340 passed; 0 failed; 6 ignored
cargo test (lib)             → 4636 passed; 0 failed; 7 ignored
cargo test (bin tm)          → 1491 passed; 0 failed; 1 ignored
cargo test (bin trusty-mpm)  → 1491 passed; 0 failed; 1 ignored
cargo check --workspace (excl. GUI crates) → 0
```

## Pre-existing failures on this base — not from this change

Each was verified against the stashed base before being set aside. Nothing was `#[ignore]`d or narrowed to make a gate green.

- `ensure_managed_config_dir_emits_the_frozen_skill_warning` — fails ~1 run in 4, passes in isolation. `#[serial]` only serializes against other `#[serial]` tests, and installing a subscriber perturbs the process-global interest cache. Failed 1-of-4 on base.
- `compose_session_instructions_display_matches_live_prompt[_with_override]` — `tm` and `trusty-mpm` are duplicate bin targets over the same `main.rs`, so `cargo test -p trusty-mpm` runs the test twice concurrently against the same on-disk project state. Failed 1-of-3 on base; green when the targets run separately.
- `cargo check --workspace` — `trusty-code-gui` and `trusty-mpm-gui` panic in `tauri::generate_context!` because `ui/dist` is not built in this worktree. Identical exit 101 on base.

CI may be flaky on this PR for those reasons, unrelated to the change.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
