### PR TITLE
fix(trusty-mpm): guard `tm catalog apply --prune` against deleting user content (#391)

### DIFF
--- a/crates/trusty-mpm/changelog.d/391-guard-catalog-apply-prune.md
+++ b/crates/trusty-mpm/changelog.d/391-guard-catalog-apply-prune.md
@@ -1,0 +1,8 @@
+Fixed
+
+- `tm catalog apply --prune` no longer deletes user content (closes [#391](https://github.com/bobmatnyc/trusty-tools/issues/391))
+  - it removed any managed skill directory the current include/exclude rejected, with no checksum comparison, no frozen check and no backup — the only skill-mutating path with none of the guards `deploy_one_file` and `skill_repair` already have
+  - a hand-edited (frozen) agent or skill is now left in place, as is a skill directory holding any file trusty-mpm did not deploy — `remove_dir_all` would have taken that file too
+  - a skill the user-custom tier supplies is never pruned, whatever the bundled include/exclude says: `deploy_all_skill_tiers` deploys that tier in full and exempt from those rules, but its ledger entry is indistinguishable from a bundled one, so a checksum gate alone waved a pristine user skill through. The tier is derived from the live `~/.trusty-mpm/skills/` source rather than a new manifest field, so no existing ledger entry has to be guessed at
+  - everything actually deleted is copied to `~/.trusty-mpm/backup-catalog-prune-<timestamp>/` first, and the command now prints what it kept and why
+  - prune judges skill STEMS, not raw ledger keys: an `include` rule matching a stem but not its carried `<stem>/references/*.md` key used to drop that file's ledger entry while leaving the file on disk, after which the deployer read it as user-owned and never updated it again

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -904,6 +904,19 @@ pub(crate) async fn catalog(action: CatalogAction) -> anyhow::Result<()> {
                     report.skills_pruned.len()
                 );
             }
+            // #391: a guard that declines to delete is invisible unless it says
+            // so — the operator asked for a prune and must be told what survived
+            // it, and where the deleted content went.
+            if let Some(backup) = &report.prune_backup_dir {
+                println!("  backed up to {}", backup.display());
+            }
+            for line in report
+                .agents_prune_kept
+                .iter()
+                .chain(report.skills_prune_kept.iter())
+            {
+                println!("  kept: {line}");
+            }
         }
     }
     Ok(())

--- a/crates/trusty-mpm/src/core/update_check/apply.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply.rs
@@ -14,7 +14,8 @@
 //! Test: this module's `tests` cover redeploy-clears-staleness and prune-removes-
 //! deselected against a `FakeGitBackend`-seeded catalog.
 
-use std::path::Path;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 
 use crate::core::agent_deployer::deploy_agents_filtered;
 use crate::core::agent_manifest::{
@@ -22,11 +23,16 @@ use crate::core::agent_manifest::{
 };
 use crate::core::manifest::HarnessPlan;
 use crate::core::paths::FrameworkPaths;
+use crate::core::skill_drift::key_stem;
 use crate::core::skill_manifest::{
     SKILL_MANIFEST_FILE, SkillManifest, SkillManifestSave, with_skill_manifest_lock,
 };
-use crate::core::skill_tiers::deploy_all_skill_tiers;
+use crate::core::skill_tiers::{deploy_all_skill_tiers, list_source_stems};
 use crate::provisioner::GitBackend;
+
+mod prune_guard;
+
+use prune_guard::Verdict;
 
 /// A failure raised while applying a catalog update.
 ///
@@ -90,6 +96,31 @@ pub struct ApplyReport {
     pub agents_pruned: Vec<String>,
     /// Managed skill stems removed because the manifest no longer selects them.
     pub skills_pruned: Vec<String>,
+    /// Deselected agents a guard left in place, as `<filename>: <reason>` (#391).
+    pub agents_prune_kept: Vec<String>,
+    /// Deselected skills a guard left in place, as `<stem>: <reason>` (#391).
+    pub skills_prune_kept: Vec<String>,
+    /// Where the pruned content was copied before deletion, when anything was
+    /// deleted (#391). `None` means nothing was removed, so nothing was backed up.
+    pub prune_backup_dir: Option<PathBuf>,
+}
+
+/// One prune stage's result: what went, what stayed, and whether a backup exists.
+///
+/// Why (#391): a prune that silently declines to delete something is a guard the
+/// operator cannot see working. Carrying the kept set alongside the removed set
+/// is what lets `tm catalog apply --prune` say "left 2 alone, here is why".
+/// What: removed names, kept names each with their reason, and whether this
+/// stage wrote anything under the run's backup root.
+/// Test: `apply_prune_skips_hand_edited_skill`, `apply_prune_removes_deselected`.
+#[derive(Debug, Default)]
+struct PruneOutcome {
+    /// Names actually deleted this run.
+    removed: Vec<String>,
+    /// Names a guard declined to delete, formatted `<name>: <reason>`.
+    kept: Vec<String>,
+    /// True once this stage has copied something under the backup root.
+    used_backup: bool,
 }
 
 /// Apply a catalog update: sync, redeploy the selected set, optionally prune.
@@ -104,10 +135,36 @@ pub struct ApplyReport {
 /// [`HarnessPlan`], redeploys the selected agents/skills via the filtered
 /// deployers, and — when `prune` is set — removes managed agents/skills the plan
 /// no longer selects (and drops their manifest entries). Returns an
-/// [`ApplyReport`]. Pruning is opt-in and only ever touches MANAGED files (those
-/// in the checksum manifest); user-owned files are never removed.
+/// [`ApplyReport`].
+///
+/// Pruning is opt-in, and #391 replaced the old summary ("only ever touches
+/// MANAGED files; user-owned files are never removed") because it was true of
+/// UNMANAGED files and silent on the two kinds of user content that were in fact
+/// deletable. Precisely what prune will and will not remove:
+///
+/// - Only files the checksum manifest records as trusty-mpm-managed are eligible.
+///   A file the user dropped in was never, and is still not, a candidate.
+/// - An eligible asset is removed only when its bytes still match the checksum
+///   the ledger recorded, so a hand-edited (frozen) agent or skill stays. A
+///   skill directory is judged whole: any file under it that no ledger key
+///   claims disqualifies the directory, because `remove_dir_all` would take that
+///   file too.
+/// - A skill stem the user-custom tier supplies is never pruned, whatever the
+///   bundled include/exclude says — [`deploy_all_skill_tiers`] deploys that tier
+///   in full and exempt from those rules, but its ledger entries look identical
+///   to bundled ones.
+/// - Everything actually deleted is copied under
+///   `<framework-root>/backup-catalog-prune-<timestamp>/` first;
+///   [`ApplyReport::prune_backup_dir`] names it.
+///
+/// What this does NOT promise: a stem the user has since deleted from
+/// `~/.trusty-mpm/skills/` is no longer user-tier and prunes normally, and
+/// nothing here restores a backup — that stays a human decision.
 /// Test: `apply_redeploys_and_clears_staleness`, `apply_prune_removes_deselected`,
-/// `apply_prune_spares_user_owned`.
+/// `apply_prune_spares_user_owned`, `apply_prune_removes_deselected_skill`,
+/// `apply_prune_skips_hand_edited_skill`, `apply_prune_spares_user_tier_skill`,
+/// `apply_prune_spares_untracked_file_in_a_managed_skill`,
+/// `apply_prune_backs_up_before_removing_a_skill`.
 pub fn apply_catalog<G: GitBackend>(
     git: G,
     fw: &FrameworkPaths,
@@ -167,8 +224,24 @@ pub fn apply_catalog<G: GitBackend>(
 
     // 4. Optionally prune managed artifacts the manifest no longer selects.
     if prune {
-        report.agents_pruned = prune_agents(&agent_target, &plan)?;
-        report.skills_pruned = prune_skills(&skill_target, &plan)?;
+        // #391: ONE backup root per run, so an operator undoing a prune finds
+        // everything it took in one place. Named here but created lazily — a
+        // prune that removes nothing must not litter the framework root.
+        let backup_root = prune_guard::prune_backup_root(&fw.root, chrono::Utc::now());
+        let agents = prune_agents(&agent_target, &plan, &backup_root)?;
+        let skills = prune_skills(
+            &skill_target,
+            &fw.user_skill_source_dir(),
+            &plan,
+            &backup_root,
+        )?;
+        if agents.used_backup || skills.used_backup {
+            report.prune_backup_dir = Some(backup_root);
+        }
+        report.agents_pruned = agents.removed;
+        report.agents_prune_kept = agents.kept;
+        report.skills_pruned = skills.removed;
+        report.skills_prune_kept = skills.kept;
     }
 
     Ok(report)
@@ -178,11 +251,16 @@ pub fn apply_catalog<G: GitBackend>(
 ///
 /// Why: HR-2 deferred removal of deselected agents; HR-3 supplies it behind the
 /// explicit `--prune` flag. Only MANAGED files (present in the agent checksum
-/// manifest) are eligible — a user-dropped file is never removed.
-/// What: for each manifest-managed agent filename whose stem the plan rejects,
+/// manifest) are eligible — a user-dropped file is never removed — and since
+/// #391 an eligible file is deleted only when its bytes still match the recorded
+/// checksum, so a hand-edited agent survives being deselected.
+/// What: for each manifest-managed agent filename whose stem the plan rejects
+/// AND whose on-disk copy is unmodified, backs the file up under `backup_root`,
 /// deletes `<target>/<filename>` (ignoring an already-absent file) and drops the
-/// manifest entry; saves the manifest if anything changed. Returns the removed
-/// filenames, sorted.
+/// manifest entry; saves the manifest if anything changed. A modified or
+/// unreadable file keeps BOTH its content and its ledger entry — dropping the
+/// entry would reclassify it as user-owned and freeze it against future deploys.
+/// Returns the removed and kept names, sorted.
 ///
 /// CONCURRENCY (#4409): the whole load-modify-save runs under the shared ledger
 /// lock, because `target` is now the ONE machine-global agent tier rather than a
@@ -198,9 +276,14 @@ pub fn apply_catalog<G: GitBackend>(
 /// residual window means a session launching between the two steps can deploy an
 /// agent this prune then removes; that agent returns on the next launch or
 /// sync-assets, since deploy is idempotent. No update is ever lost.
-/// Test: `apply_prune_removes_deselected`, `apply_prune_spares_user_owned`.
-fn prune_agents(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>, ApplyError> {
-    with_agent_manifest_lock(target, || prune_agents_locked(target, plan))
+/// Test: `apply_prune_removes_deselected`, `apply_prune_spares_user_owned`,
+/// `apply_prune_skips_hand_edited_agent`.
+fn prune_agents(
+    target: &Path,
+    plan: &HarnessPlan,
+    backup_root: &Path,
+) -> Result<PruneOutcome, ApplyError> {
+    with_agent_manifest_lock(target, || prune_agents_locked(target, plan, backup_root))
 }
 
 /// The body of [`prune_agents`], run while holding the ledger lock.
@@ -209,10 +292,15 @@ fn prune_agents(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>, ApplyE
 /// section is one expression so the lock's scope cannot be misread. Never call
 /// it directly, and never from inside another `with_agent_manifest_lock` on the
 /// same directory (`flock` on a second descriptor in one process deadlocks).
-/// Test: `apply_prune_removes_deselected`, `apply_prune_spares_user_owned`.
-fn prune_agents_locked(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>, ApplyError> {
+/// Test: `apply_prune_removes_deselected`, `apply_prune_spares_user_owned`,
+/// `apply_prune_skips_hand_edited_agent`.
+fn prune_agents_locked(
+    target: &Path,
+    plan: &HarnessPlan,
+    backup_root: &Path,
+) -> Result<PruneOutcome, ApplyError> {
     let mut manifest = AgentManifest::load(target);
-    let mut pruned: Vec<String> = Vec::new();
+    let mut outcome = PruneOutcome::default();
 
     let candidates: Vec<String> = manifest.managed.keys().cloned().collect();
     for filename in candidates {
@@ -220,30 +308,64 @@ fn prune_agents_locked(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>,
         if plan.agent_selected(stem) {
             continue;
         }
-        remove_if_present(&target.join(&filename))?;
+        // #391: deselected is not the same as disposable — check the file is
+        // still the one trusty-mpm wrote before deleting it.
+        if let Verdict::Kept(why) = prune_guard::agent_verdict(&manifest, target, &filename) {
+            tracing::info!(agent = %filename, reason = %why, "not pruning a deselected agent");
+            outcome.kept.push(format!("{filename}: {why}"));
+            continue;
+        }
+        let path = target.join(&filename);
+        if path.exists() {
+            prune_guard::back_up_file(&path, backup_root, &Path::new("agents").join(&filename))?;
+            outcome.used_backup = true;
+        }
+        remove_if_present(&path)?;
         manifest.managed.remove(&filename);
-        pruned.push(filename);
+        outcome.removed.push(filename);
     }
 
-    if !pruned.is_empty() {
+    if !outcome.removed.is_empty() {
         manifest
             .save(target)
             .map_err(|e| ApplyError::Prune(e.to_string()))?;
         // The manifest file itself is never an agent; ensure it is left intact.
         debug_assert!(target.join(AGENT_MANIFEST_FILE).exists());
     }
-    pruned.sort_unstable();
-    Ok(pruned)
+    outcome.removed.sort_unstable();
+    outcome.kept.sort_unstable();
+    Ok(outcome)
 }
 
 /// Remove managed skill directories the plan no longer selects; return stems.
 ///
 /// Why: the skill counterpart to [`prune_agents`]. Skills deploy as
-/// `<target>/<stem>/SKILL.md`, so pruning removes the whole skill directory.
-/// What: for each manifest-managed skill stem the plan rejects, removes
-/// `<target>/<stem>/` (ignoring absence) and drops the manifest entry; saves the
-/// manifest if anything changed. The [`SkillManifest`] is keyed by stem, matching
-/// the skill deployer. Returns the removed stems, sorted.
+/// `<target>/<stem>/SKILL.md`, so pruning removes the whole skill directory —
+/// which is why #391 gave it TWO guards rather than one. A checksum gate alone
+/// protects a hand-edited skill (its bytes no longer match) but waves through a
+/// PRISTINE user-custom one, because [`deploy_all_skill_tiers`] deploys
+/// `~/.trusty-mpm/skills/` in full, exempt from the bundled include/exclude, and
+/// the ledger records no origin tier to tell the two apart afterwards.
+///
+/// The tier half is answered from the LIVE user source
+/// ([`list_source_stems`]), not from a recorded origin field. A schema field
+/// would have to decide what every pre-existing entry means, and the only
+/// available default — "bundled" — is precisely this bug; deriving it from the
+/// same directory `deploy_all_skill_tiers` reads makes the two structurally
+/// unable to disagree, and needs no migration.
+/// What: for each manifest-managed skill STEM the plan rejects, that the user
+/// tier does not supply, and whose deployed directory holds nothing but
+/// unmodified tm-deployed files, copies the directory under `backup_root`,
+/// removes `<target>/<stem>/` (ignoring absence) and drops EVERY ledger key
+/// belonging to that stem; saves the manifest if anything changed. Returns the
+/// removed and kept stems, sorted.
+///
+/// Candidates are stems, not raw ledger keys: a key like
+/// `<stem>/references/x.md` names a file the skill CARRIES, and judging it
+/// independently let an `include` rule that matched the stem but not the nested
+/// key drop that file's ledger entry while leaving the file on disk — after
+/// which the deployer reads it as user-owned and never updates it again (#4881's
+/// freeze shape, reached from this path).
 ///
 /// CONCURRENCY (#4881): the whole load-modify-save runs under the skill ledger
 /// lock, for the same reason [`prune_agents`] does — an unlocked prune racing a
@@ -255,9 +377,20 @@ fn prune_agents_locked(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>,
 /// a worse hazard than the residual window. A skill deployed between the two
 /// steps that this prune then removes returns on the next deploy — deploy is
 /// idempotent, and no ledger update is ever lost.
-/// Test: `apply_prune_removes_deselected`.
-fn prune_skills(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>, ApplyError> {
-    with_skill_manifest_lock(target, || prune_skills_locked(target, plan))
+/// Test: `apply_prune_removes_deselected_skill`, `apply_prune_skips_hand_edited_skill`,
+/// `apply_prune_spares_user_tier_skill`.
+fn prune_skills(
+    target: &Path,
+    user_source: &Path,
+    plan: &HarnessPlan,
+    backup_root: &Path,
+) -> Result<PruneOutcome, ApplyError> {
+    // Read OUTSIDE the lock: this is the user's own source directory, not the
+    // deploy target the lock serialises.
+    let user_stems = list_source_stems(user_source)?;
+    with_skill_manifest_lock(target, || {
+        prune_skills_locked(target, plan, &user_stems, backup_root)
+    })
 }
 
 /// The body of [`prune_skills`], run while holding the skill ledger lock.
@@ -265,29 +398,63 @@ fn prune_skills(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>, ApplyE
 /// Why/What: mirrors [`prune_agents_locked`] — the critical section is one
 /// expression so the lock's scope cannot be misread. Never call it directly, and
 /// never from inside another `with_skill_manifest_lock` on the same directory.
-/// Test: `apply_prune_removes_deselected`.
-fn prune_skills_locked(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>, ApplyError> {
+/// Test: `apply_prune_removes_deselected_skill`, `apply_prune_skips_hand_edited_skill`,
+/// `apply_prune_spares_user_tier_skill`,
+/// `apply_prune_spares_untracked_file_in_a_managed_skill`.
+fn prune_skills_locked(
+    target: &Path,
+    plan: &HarnessPlan,
+    user_stems: &BTreeSet<String>,
+    backup_root: &Path,
+) -> Result<PruneOutcome, ApplyError> {
     let mut manifest = SkillManifest::load(target);
     // #4881: the snapshot the merging save replays this run's delta against —
     // here the delta is REMOVALS, which `save_merging` applies to the current
     // on-disk document rather than reverting a concurrent writer's inserts.
     let base = manifest.clone();
-    let mut pruned: Vec<String> = Vec::new();
+    let mut outcome = PruneOutcome::default();
 
-    let candidates: Vec<String> = manifest.managed.keys().cloned().collect();
+    // #391: candidates are STEMS. A ledger key may name a carried file
+    // (`<stem>/references/x.md`); it is pruned with its skill, never on its own.
+    let candidates: BTreeSet<String> = manifest
+        .managed
+        .keys()
+        .map(|key| key_stem(key).to_string())
+        .collect();
     for stem in candidates {
         if plan.skill_selected(&stem) {
             continue;
         }
+        // #391: the bundled include/exclude does not govern the user-custom
+        // tier, so it must not be able to select a user stem for deletion.
+        if user_stems.contains(&stem) {
+            tracing::info!(
+                skill = %stem,
+                "not pruning a deselected skill — the user-custom tier supplies it"
+            );
+            outcome
+                .kept
+                .push(format!("{stem}: supplied by the user-custom skill tier"));
+            continue;
+        }
+        // #391: and the directory must still hold only unmodified tm-deployed
+        // files — `remove_dir_all` takes everything else with it.
+        if let Verdict::Kept(why) = prune_guard::skill_verdict(&manifest, target, &stem) {
+            tracing::info!(skill = %stem, reason = %why, "not pruning a deselected skill");
+            outcome.kept.push(format!("{stem}: {why}"));
+            continue;
+        }
         let skill_dir = target.join(&stem);
         if skill_dir.is_dir() {
+            prune_guard::back_up_tree(&skill_dir, backup_root, &Path::new("skills").join(&stem))?;
+            outcome.used_backup = true;
             std::fs::remove_dir_all(&skill_dir).map_err(|e| ApplyError::Prune(e.to_string()))?;
         }
-        manifest.managed.remove(&stem);
-        pruned.push(stem);
+        manifest.managed.retain(|key, _| key_stem(key) != stem);
+        outcome.removed.push(stem);
     }
 
-    if !pruned.is_empty() {
+    if !outcome.removed.is_empty() {
         // #4881: the skill DIRECTORIES are already removed, so this save must
         // publish or the manifest keeps listing files that no longer exist.
         if manifest
@@ -303,8 +470,9 @@ fn prune_skills_locked(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>,
         }
         debug_assert!(target.join(SKILL_MANIFEST_FILE).exists());
     }
-    pruned.sort_unstable();
-    Ok(pruned)
+    outcome.removed.sort_unstable();
+    outcome.kept.sort_unstable();
+    Ok(outcome)
 }
 
 /// Delete a file if it exists, treating "already gone" as success.

--- a/crates/trusty-mpm/src/core/update_check/apply/prune_guard.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply/prune_guard.rs
@@ -1,0 +1,296 @@
+//! The safety gate `tm catalog apply --prune` applies before it deletes (#391).
+//!
+//! Why: pruning was the ONLY asset-mutating path in the codebase with none of
+//! the guards its neighbours have. `skills::deployer::deploy_one_file` refuses
+//! to overwrite a file whose bytes no longer match the recorded checksum, and
+//! [`crate::core::skill_repair`] backs up before every overwrite and deletes
+//! nothing at all — while `prune_skills_locked` called `remove_dir_all` on any
+//! managed stem the current include/exclude rule rejected. Two distinct kinds of
+//! user content sat behind that call:
+//!
+//! 1. **A hand-edited asset.** Its checksum no longer matches the ledger, which
+//!    is exactly what every other path reads as "the user owns this now".
+//! 2. **A pristine user-custom skill.** `skills::tiers::deploy_all_skill_tiers`
+//!    deploys `~/.trusty-mpm/skills/` in full and explicitly exempt from the
+//!    harness manifest's bundled include/exclude — but once deployed that stem
+//!    sits in the ledger with a perfectly matching checksum, indistinguishable
+//!    from a bundled one. A checksum gate alone waves it straight through, so
+//!    tier awareness is a SECOND, independent requirement, handled by the
+//!    caller (see `prune_skills`).
+//!
+//! What: [`agent_verdict`] and [`skill_verdict`] answer "may prune delete this?"
+//! and carry the operator-facing reason when the answer is no; [`back_up_file`]
+//! and [`back_up_tree`] copy what is about to go under a timestamped root named
+//! by [`prune_backup_root`].
+//!
+//! Neither verdict ever mutates the ledger. A kept asset stays MANAGED — dropping
+//! its entry would reclassify it as user-owned and freeze it against every future
+//! deploy, which is the #4881 shape.
+//! Test: `crate::core::update_check::apply::tests` —
+//! `apply_prune_skips_hand_edited_skill`, `apply_prune_spares_user_tier_skill`,
+//! `apply_prune_spares_untracked_file_in_a_managed_skill`,
+//! `apply_prune_backs_up_before_removing_a_skill`,
+//! `apply_prune_skips_hand_edited_agent`.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use super::ApplyError;
+use crate::core::agent_manifest::AgentManifest;
+use crate::core::skill_drift::{deployed_path, key_stem};
+use crate::core::skill_manifest::SkillManifest;
+
+/// Whether one managed asset may be deleted, and why not when it may not.
+///
+/// Why: "left in place" and "deleted" must be reportable separately — a silent
+/// skip is how a guard becomes invisible to the operator who asked for a prune.
+/// What: `Prunable`, or `Kept` carrying a reason phrased for a log line.
+/// Test: every `apply_prune_*` test asserts on one branch or the other.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Verdict {
+    /// Nothing of the user's is in this asset; prune may remove it.
+    Prunable,
+    /// Left in place; the string says why, in operator-facing terms.
+    Kept(String),
+}
+
+/// Timestamped backup root for one `--prune` run.
+///
+/// Why: mirrors [`crate::core::skill_repair::backup_root_for`]'s convention so
+/// an operator finds prune backups next to the remediation ones, and a per-run
+/// directory means a second prune never overwrites the first run's copies.
+/// What: `<framework-root>/backup-catalog-prune-<YYYYmmdd-HHMMSS>`. The
+/// directory is NOT created here — only when something is actually backed up.
+/// Test: `prune_backup_root_is_timestamped_under_the_framework_root`.
+pub(super) fn prune_backup_root(fw_root: &Path, now: chrono::DateTime<chrono::Utc>) -> PathBuf {
+    fw_root.join(format!(
+        "backup-catalog-prune-{}",
+        now.format("%Y%m%d-%H%M%S")
+    ))
+}
+
+/// May prune delete this managed agent file?
+///
+/// Why (#391): the same rule `agents::deployer` already applies before an
+/// overwrite. Deleting a file whose bytes the user changed destroys work no
+/// backup was asked for.
+/// What: `Prunable` when the file is absent (prune is idempotent — there is
+/// nothing to lose) or its content still checksums to the ledger entry;
+/// `Kept` when it differs, or cannot be read as text at all.
+/// Test: `apply_prune_skips_hand_edited_agent`, `apply_prune_removes_deselected`.
+pub(super) fn agent_verdict(manifest: &AgentManifest, target: &Path, filename: &str) -> Verdict {
+    let path = target.join(filename);
+    if !path.exists() {
+        return Verdict::Prunable;
+    }
+    match std::fs::read_to_string(&path) {
+        Ok(content) if manifest.checksum_matches(filename, &content) => Verdict::Prunable,
+        Ok(_) => Verdict::Kept(format!(
+            "{} was edited after it was deployed",
+            path.display()
+        )),
+        Err(e) => Verdict::Kept(format!(
+            "{} could not be read, so it cannot be verified: {e}",
+            path.display()
+        )),
+    }
+}
+
+/// May prune delete this managed skill's whole directory?
+///
+/// Why (#391): a skill is a DIRECTORY, so the question is not "does one file
+/// match" but "is everything under it something trusty-mpm deployed and the user
+/// has not touched". `remove_dir_all` takes the untracked sibling with it, which
+/// is why an unclaimed file is disqualifying on its own.
+/// What: `Prunable` when the directory is absent, or when every file under it is
+/// claimed by a ledger key belonging to `stem` AND still checksums to that key's
+/// entry. `Kept` when the directory holds a file no ledger key claims, when a
+/// claimed file's bytes differ, or when anything under it cannot be read. A
+/// claimed file that is already gone is not disqualifying — there is nothing
+/// left to lose.
+/// Test: `apply_prune_skips_hand_edited_skill`,
+/// `apply_prune_spares_untracked_file_in_a_managed_skill`,
+/// `apply_prune_removes_deselected_skill`.
+pub(super) fn skill_verdict(manifest: &SkillManifest, target: &Path, stem: &str) -> Verdict {
+    let dir = target.join(stem);
+    if !dir.is_dir() {
+        return Verdict::Prunable;
+    }
+
+    let claimed_keys: Vec<&String> = manifest
+        .managed
+        .keys()
+        .filter(|key| key_stem(key) == stem)
+        .collect();
+    let claimed_paths: BTreeSet<PathBuf> = claimed_keys
+        .iter()
+        .map(|key| deployed_path(target, key))
+        .collect();
+
+    let mut on_disk = Vec::new();
+    if let Err(e) = collect_files(&dir, &mut on_disk) {
+        return Verdict::Kept(format!(
+            "{} could not be walked, so it cannot be verified: {e}",
+            dir.display()
+        ));
+    }
+    // A file the ledger does not claim is the user's — and `remove_dir_all`
+    // would take it along with everything else in the directory.
+    if let Some(stray) = on_disk.iter().find(|path| !claimed_paths.contains(*path)) {
+        return Verdict::Kept(format!(
+            "it holds {}, which trusty-mpm never deployed",
+            stray.display()
+        ));
+    }
+
+    for key in claimed_keys {
+        let path = deployed_path(target, key);
+        if !path.exists() {
+            continue;
+        }
+        match std::fs::read_to_string(&path) {
+            Ok(content) if manifest.checksum_matches(key, &content) => {}
+            Ok(_) => {
+                return Verdict::Kept(format!(
+                    "{} was edited after it was deployed",
+                    path.display()
+                ));
+            }
+            Err(e) => {
+                return Verdict::Kept(format!(
+                    "{} could not be read, so it cannot be verified: {e}",
+                    path.display()
+                ));
+            }
+        }
+    }
+    Verdict::Prunable
+}
+
+/// Collect every regular file under `dir`, recursively.
+///
+/// Why: [`skill_verdict`] must see the whole subtree `remove_dir_all` would
+/// take, not just the entry point — a reference file or a carried script is user
+/// content too.
+/// What: appends each file path to `out`. Directory entries recurse; a symlink
+/// is reported as a plain path (`DirEntry::file_type` does not follow it), which
+/// makes it unclaimed and therefore disqualifying — the conservative answer.
+/// Test: exercised through [`skill_verdict`] by
+/// `apply_prune_spares_untracked_file_in_a_managed_skill`.
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            collect_files(&path, out)?;
+        } else {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Copy one file under the prune backup root before it is deleted.
+///
+/// Why (#391): the guards above decide what is safe to delete; the backup is
+/// what makes a WRONG decision recoverable. `skill_repair` already treats a
+/// backup as a precondition of touching operator state, and deletion is the
+/// stronger operation.
+/// What: copies `src` to `<backup_root>/<rel>`, creating parents. Returns the
+/// backup path.
+/// Test: `apply_prune_removes_deselected`.
+pub(super) fn back_up_file(
+    src: &Path,
+    backup_root: &Path,
+    rel: &Path,
+) -> Result<PathBuf, ApplyError> {
+    let dest = backup_root.join(rel);
+    create_parents(&dest)?;
+    std::fs::copy(src, &dest).map_err(|e| {
+        ApplyError::Prune(format!(
+            "could not back up {} to {}: {e}",
+            src.display(),
+            dest.display()
+        ))
+    })?;
+    Ok(dest)
+}
+
+/// Copy a whole directory tree under the prune backup root before it is deleted.
+///
+/// Why: the skill counterpart to [`back_up_file`] — a skill's reference files
+/// and carried assets go with the directory, so they must come back with it.
+/// What: recursively copies `src` to `<backup_root>/<rel>`. Returns that path.
+/// Test: `apply_prune_backs_up_before_removing_a_skill`.
+pub(super) fn back_up_tree(
+    src: &Path,
+    backup_root: &Path,
+    rel: &Path,
+) -> Result<PathBuf, ApplyError> {
+    let dest = backup_root.join(rel);
+    copy_tree(src, &dest)?;
+    Ok(dest)
+}
+
+/// Recursively copy `src` onto `dest`.
+///
+/// Why: `std::fs` has no recursive copy, and pulling a crate in for one call
+/// site is not worth the dependency.
+/// What: creates `dest`, then copies each entry, recursing into directories.
+/// Test: through [`back_up_tree`] in `apply_prune_backs_up_before_removing_a_skill`.
+fn copy_tree(src: &Path, dest: &Path) -> Result<(), ApplyError> {
+    std::fs::create_dir_all(dest)
+        .map_err(|e| ApplyError::Prune(format!("could not create {}: {e}", dest.display())))?;
+    let entries = std::fs::read_dir(src)
+        .map_err(|e| ApplyError::Prune(format!("could not read {}: {e}", src.display())))?;
+    for entry in entries {
+        let entry = entry
+            .map_err(|e| ApplyError::Prune(format!("could not read {}: {e}", src.display())))?;
+        let from = entry.path();
+        let to = dest.join(entry.file_name());
+        let is_dir = entry
+            .file_type()
+            .map_err(|e| ApplyError::Prune(format!("could not stat {}: {e}", from.display())))?
+            .is_dir();
+        if is_dir {
+            copy_tree(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to).map_err(|e| {
+                ApplyError::Prune(format!(
+                    "could not back up {} to {}: {e}",
+                    from.display(),
+                    to.display()
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Create `path`'s parent directory chain.
+fn create_parents(path: &Path) -> Result<(), ApplyError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            ApplyError::Prune(format!("could not create {}: {e}", parent.display()))
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prune_backup_root_is_timestamped_under_the_framework_root() {
+        // The root must live beside the other `~/.trusty-mpm/backup-*` dirs and
+        // carry the run's timestamp, so a second prune cannot overwrite a first
+        // prune's copies.
+        let now = chrono::DateTime::from_timestamp(1_754_000_000, 0).unwrap();
+        let root = prune_backup_root(Path::new("/home/.trusty-mpm"), now);
+        assert_eq!(
+            root,
+            PathBuf::from("/home/.trusty-mpm/backup-catalog-prune-20250731-221320")
+        );
+    }
+}

--- a/crates/trusty-mpm/src/core/update_check/apply/tests.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply/tests.rs
@@ -64,6 +64,45 @@ fn seed_catalog_skill(catalog_root: &Path, stem: &str, body: &str) {
     .unwrap();
 }
 
+/// Seed a DIRECTORY-shaped catalog skill (`<stem>/SKILL.md`) that carries one
+/// reference file, so a test can exercise the multi-file ledger keys
+/// (`<stem>/references/<file>`) prune has to reason about (#391).
+fn seed_catalog_skill_dir(catalog_root: &Path, stem: &str, body: &str, reference: &str) {
+    mark_catalog_repo_as_valid(catalog_root);
+    let dir = catalog_root.join("repo/.claude/skills").join(stem);
+    fs::create_dir_all(dir.join("references")).unwrap();
+    fs::write(dir.join("SKILL.md"), format!("# {stem}\n\n{body}\n")).unwrap();
+    fs::write(dir.join("references/notes.md"), reference).unwrap();
+}
+
+/// Overwrite the project manifest with `body` (the `[agents]`/`[skills]` TOML).
+fn rewrite_manifest(project_dir: &Path, body: &str) {
+    fs::write(
+        project_dir
+            .join(".trusty-mpm")
+            .join("framework")
+            .join("manifest.toml"),
+        body,
+    )
+    .unwrap();
+}
+
+/// The single `backup-catalog-prune-*` directory under a framework root, if any.
+///
+/// Why (#391): the backup root is timestamped, so a test cannot name it up
+/// front; it asserts on the one that appeared.
+fn prune_backup_dir(fw_root: &Path) -> Option<std::path::PathBuf> {
+    fs::read_dir(fw_root)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("backup-catalog-prune-"))
+        })
+}
+
 /// Write a project manifest selecting the CATALOG source for agents and skills.
 fn write_catalog_manifest(project_dir: &Path) {
     // #4832: the project manifest layer lives in `.trusty-mpm/framework/`.
@@ -198,6 +237,15 @@ fn apply_prune_removes_deselected() {
     let manifest = AgentManifest::load(&fw.agent_deploy_dir());
     assert!(!manifest.is_managed("drop-me.md"));
     assert!(manifest.is_managed("keep-me.md"));
+
+    // #391: and what it removed is recoverable.
+    let backup = prune_backup_dir(&fw.root).expect("a prune that deleted must leave a backup");
+    assert!(
+        fs::read_to_string(backup.join("agents/drop-me.md"))
+            .unwrap()
+            .contains("DROP"),
+        "the pruned agent is backed up with its original content"
+    );
 }
 
 #[test]
@@ -293,4 +341,324 @@ fn apply_prune_spares_user_owned() {
     );
     assert!(user_file.is_file(), "user-owned file survives prune");
     assert_eq!(fs::read_to_string(&user_file).unwrap(), "USER OWNED");
+}
+
+// ---------------------------------------------------------------------------
+// #391 — skill prune had none of the guards every other skill-mutating path has.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn apply_prune_removes_deselected_skill() {
+    // The feature still works: a deselected, PRISTINE, bundled-source skill is
+    // removed, directory and ledger entry together. Before #391 this was the
+    // only thing skill prune did — and it did it to everything.
+    let fw_root = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::from_root(fw_root.path().join(".trusty-mpm"));
+
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    seed_catalog_skill(&catalog_root, "keep-me", "KEEP");
+    seed_catalog_skill(&catalog_root, "drop-me", "DROP");
+
+    write_catalog_manifest(project.path());
+    apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
+    assert!(fw.claude_skills_dir().join("drop-me/SKILL.md").is_file());
+
+    rewrite_manifest(
+        project.path(),
+        "[agents]\nsource = \"catalog\"\n\n[skills]\nsource = \"catalog\"\nexclude = [\"drop-me\"]\n",
+    );
+    let report = apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, true).unwrap();
+
+    assert!(
+        report.skills_pruned.contains(&"drop-me".to_string()),
+        "deselected pristine skill must be pruned: {report:?}"
+    );
+    assert!(
+        !fw.claude_skills_dir().join("drop-me").exists(),
+        "pruned skill directory removed"
+    );
+    assert!(
+        fw.claude_skills_dir().join("keep-me/SKILL.md").is_file(),
+        "selected skill retained"
+    );
+    let manifest = SkillManifest::load(&fw.claude_skills_dir());
+    assert!(!manifest.is_managed("drop-me"));
+    assert!(manifest.is_managed("keep-me"));
+}
+
+#[test]
+fn apply_prune_skips_hand_edited_skill() {
+    // A deselected skill the user HAND-EDITED is frozen, exactly as
+    // `deploy_one_file` treats it — prune must not be the one path that deletes
+    // what every other path refuses to overwrite.
+    let fw_root = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::from_root(fw_root.path().join(".trusty-mpm"));
+
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    seed_catalog_skill(&catalog_root, "edited", "ORIGINAL");
+    write_catalog_manifest(project.path());
+    apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
+
+    let deployed = fw.claude_skills_dir().join("edited/SKILL.md");
+    fs::write(&deployed, "# edited\n\nMY OWN NOTES\n").unwrap();
+
+    rewrite_manifest(
+        project.path(),
+        "[agents]\nsource = \"catalog\"\n\n[skills]\nsource = \"catalog\"\nexclude = [\"edited\"]\n",
+    );
+    let report = apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, true).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&deployed).unwrap(),
+        "# edited\n\nMY OWN NOTES\n",
+        "a hand-edited skill must survive --prune byte-identical"
+    );
+    assert!(
+        !report.skills_pruned.contains(&"edited".to_string()),
+        "hand-edited skill must not be reported pruned: {report:?}"
+    );
+    // The ledger entry stays too — dropping it would reclassify the file as
+    // user-owned and freeze it against every future deploy (#4881's shape).
+    assert!(
+        SkillManifest::load(&fw.claude_skills_dir()).is_managed("edited"),
+        "the kept skill stays managed"
+    );
+}
+
+#[test]
+fn apply_prune_spares_user_tier_skill() {
+    // The case a checksum gate alone does NOT catch: a PRISTINE user-custom
+    // skill. `deploy_all_skill_tiers` deploys `~/.trusty-mpm/skills/` in full,
+    // exempt from the bundled include/exclude — but its ledger entry is then
+    // indistinguishable from a bundled one, so a bundled exclude rule used to
+    // select it for deletion and its matching checksum waved it through.
+    let fw_root = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::from_root(fw_root.path().join(".trusty-mpm"));
+
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    seed_catalog_skill(&catalog_root, "bundled-one", "BUNDLED");
+
+    let user_source = fw.user_skill_source_dir();
+    fs::create_dir_all(&user_source).unwrap();
+    fs::write(user_source.join("mine.md"), "# mine\n\nMY SKILL\n").unwrap();
+
+    // A bundled include list that names only the bundled skill — so the user
+    // stem `mine` is "deselected" by the bundled rule it was never subject to.
+    write_catalog_manifest(project.path());
+    rewrite_manifest(
+        project.path(),
+        "[agents]\nsource = \"catalog\"\n\n[skills]\nsource = \"catalog\"\ninclude = [\"bundled-one\"]\n",
+    );
+    apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
+
+    let deployed = fw.claude_skills_dir().join("mine/SKILL.md");
+    assert!(
+        deployed.is_file(),
+        "the user tier deploys regardless of the bundled selection"
+    );
+    assert!(
+        SkillManifest::load(&fw.claude_skills_dir()).is_managed("mine"),
+        "and it lands in the ledger looking exactly like a bundled skill"
+    );
+
+    let report = apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, true).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&deployed).unwrap(),
+        "# mine\n\nMY SKILL\n",
+        "a user-custom skill must survive --prune even when pristine"
+    );
+    assert!(
+        !report.skills_pruned.contains(&"mine".to_string()),
+        "user-tier skill must not be pruned: {report:?}"
+    );
+}
+
+#[test]
+fn apply_prune_spares_untracked_file_in_a_managed_skill() {
+    // `remove_dir_all` takes the whole directory, so a file the user dropped
+    // INSIDE a managed skill disqualifies the skill — the same rule
+    // `deploy_one_file` applies to an unmanaged target, extended to the unit
+    // prune actually deletes.
+    let fw_root = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::from_root(fw_root.path().join(".trusty-mpm"));
+
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    seed_catalog_skill(&catalog_root, "hosted", "HOSTED");
+    write_catalog_manifest(project.path());
+    apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
+
+    let stray = fw.claude_skills_dir().join("hosted/my-notes.md");
+    fs::write(&stray, "USER NOTES").unwrap();
+
+    rewrite_manifest(
+        project.path(),
+        "[agents]\nsource = \"catalog\"\n\n[skills]\nsource = \"catalog\"\nexclude = [\"hosted\"]\n",
+    );
+    let report = apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, true).unwrap();
+
+    assert!(stray.is_file(), "the user's own file must survive --prune");
+    assert_eq!(fs::read_to_string(&stray).unwrap(), "USER NOTES");
+    assert!(
+        !report.skills_pruned.contains(&"hosted".to_string()),
+        "a skill holding an untracked file must not be pruned: {report:?}"
+    );
+}
+
+#[test]
+fn apply_prune_backs_up_before_removing_a_skill() {
+    // A legitimate prune is still recoverable: the directory it removed is
+    // copied under a timestamped backup root first, reference files included.
+    let fw_root = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::from_root(fw_root.path().join(".trusty-mpm"));
+
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    seed_catalog_skill_dir(&catalog_root, "doomed", "DOOMED BODY", "REFERENCE BODY");
+    write_catalog_manifest(project.path());
+    apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
+    assert!(
+        fw.claude_skills_dir()
+            .join("doomed/references/notes.md")
+            .is_file()
+    );
+
+    rewrite_manifest(
+        project.path(),
+        "[agents]\nsource = \"catalog\"\n\n[skills]\nsource = \"catalog\"\nexclude = [\"doomed\"]\n",
+    );
+    let report = apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, true).unwrap();
+    assert!(report.skills_pruned.contains(&"doomed".to_string()));
+    assert!(!fw.claude_skills_dir().join("doomed").exists());
+
+    let backup = prune_backup_dir(&fw.root).expect("a prune that deleted must leave a backup");
+    let entry = backup.join("skills/doomed/SKILL.md");
+    assert!(entry.is_file(), "backup holds the entry point: {backup:?}");
+    assert!(
+        fs::read_to_string(&entry).unwrap().contains("DOOMED BODY"),
+        "backup holds the ORIGINAL content"
+    );
+    assert!(
+        fs::read_to_string(backup.join("skills/doomed/references/notes.md"))
+            .unwrap()
+            .contains("REFERENCE BODY"),
+        "backup holds the carried reference file too"
+    );
+}
+
+#[test]
+fn apply_prune_keeps_the_ledger_entry_for_a_selected_skills_carried_file() {
+    // A ledger key like `<stem>/references/notes.md` names a file the skill
+    // CARRIES. Judging keys instead of stems meant an `include` rule matching
+    // the stem but not the nested key dropped that file's entry while leaving
+    // the file on disk — after which the deployer reads it as user-owned and
+    // never updates it again.
+    let fw_root = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::from_root(fw_root.path().join(".trusty-mpm"));
+
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    seed_catalog_skill_dir(&catalog_root, "carrier", "CARRIER BODY", "REFERENCE BODY");
+    write_catalog_manifest(project.path());
+    rewrite_manifest(
+        project.path(),
+        "[agents]\nsource = \"catalog\"\n\n[skills]\nsource = \"catalog\"\ninclude = [\"carrier\"]\n",
+    );
+    apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
+
+    let key = "carrier/references/notes.md";
+    assert!(SkillManifest::load(&fw.claude_skills_dir()).is_managed(key));
+
+    let report = apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, true).unwrap();
+
+    assert!(
+        report.skills_pruned.is_empty(),
+        "nothing is deselected here: {report:?}"
+    );
+    assert!(
+        fw.claude_skills_dir()
+            .join("carrier/references/notes.md")
+            .is_file()
+    );
+    assert!(
+        SkillManifest::load(&fw.claude_skills_dir()).is_managed(key),
+        "a selected skill's carried file keeps its ledger entry"
+    );
+}
+
+#[test]
+fn apply_prune_skips_hand_edited_agent() {
+    // Agent parity: prune deletes a deselected agent only while its bytes still
+    // match the ledger. A hand-edited one is the user's work, not stale content.
+    let fw_root = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::from_root(fw_root.path().join(".trusty-mpm"));
+
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    seed_catalog_agent(&catalog_root, "tweaked", "ORIGINAL");
+    write_catalog_manifest(project.path());
+    apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
+
+    let deployed = fw.agent_deploy_dir().join("tweaked.md");
+    fs::write(&deployed, "---\nname: tweaked\n---\n\nMY OWN AGENT\n").unwrap();
+
+    rewrite_manifest(
+        project.path(),
+        "[agents]\nsource = \"catalog\"\nexclude = [\"tweaked\"]\n\n[skills]\nsource = \"catalog\"\n",
+    );
+    let report = apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, true).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&deployed).unwrap(),
+        "---\nname: tweaked\n---\n\nMY OWN AGENT\n",
+        "a hand-edited agent must survive --prune byte-identical"
+    );
+    assert!(
+        !report.agents_pruned.contains(&"tweaked.md".to_string()),
+        "hand-edited agent must not be reported pruned: {report:?}"
+    );
+    assert!(AgentManifest::load(&fw.agent_deploy_dir()).is_managed("tweaked.md"));
+}
+
+#[test]
+fn apply_prune_reports_what_it_kept_and_where_backups_went() {
+    // A guard that declines silently is invisible to the operator who asked for
+    // a prune. The report names what survived, with the reason, and the backup
+    // root for what did not.
+    let fw_root = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::from_root(fw_root.path().join(".trusty-mpm"));
+
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    seed_catalog_skill(&catalog_root, "pristine", "PRISTINE");
+    seed_catalog_skill(&catalog_root, "edited", "ORIGINAL");
+    write_catalog_manifest(project.path());
+    apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
+    fs::write(
+        fw.claude_skills_dir().join("edited/SKILL.md"),
+        "MY OWN NOTES",
+    )
+    .unwrap();
+
+    rewrite_manifest(
+        project.path(),
+        "[agents]\nsource = \"catalog\"\n\n[skills]\nsource = \"catalog\"\nexclude = [\"pristine\", \"edited\"]\n",
+    );
+    let report = apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, true).unwrap();
+
+    assert_eq!(report.skills_pruned, vec!["pristine".to_string()]);
+    assert_eq!(report.skills_prune_kept.len(), 1, "{report:?}");
+    assert!(
+        report.skills_prune_kept[0].starts_with("edited: "),
+        "the kept entry names the skill and the reason: {report:?}"
+    );
+    let backup = report
+        .prune_backup_dir
+        .as_ref()
+        .expect("something was deleted, so a backup root is reported");
+    assert!(backup.join("skills/pristine/SKILL.md").is_file());
 }


### PR DESCRIPTION
## Defect

`prune_skills_locked` (`crates/trusty-mpm/src/core/update_check/apply.rs`) iterated every stem in `manifest.managed` and called `std::fs::remove_dir_all` on any the current `HarnessPlan::skill_selected()` rejected. No checksum comparison, no frozen check, no backup — the only skill-mutating path with none of the guards its neighbours have. `skills::deployer::deploy_one_file` refuses to overwrite a checksum-mismatched file; `core::skill_repair` backs up before every overwrite and deletes nothing at all.

**A checksum gate alone is not enough.** It protects a hand-edited skill, whose bytes no longer match the ledger. It does not protect a *pristine* user-custom one: `deploy_all_skill_tiers` deploys `~/.trusty-mpm/skills/` in full and explicitly exempt from the bundled include/exclude, but the resulting ledger entry is indistinguishable from a bundled entry — matching checksum and all. An operator writing a `[skills] include` rule to curate the *bundled* set could delete their own skill with it.

## Resolution

Both guards, plus the same checksum gate and backup on the agent path:

| Guard | Applies to |
|---|---|
| Checksum + frozen gate before removal | agents and skills |
| A skill directory holding any file no ledger key claims is left alone (`remove_dir_all` would take it too) | skills |
| A stem the live `~/.trusty-mpm/skills/` source supplies is never pruned | skills |
| Everything deleted is copied to `<framework-root>/backup-catalog-prune-<ts>/` first | agents and skills |
| A kept asset keeps its ledger entry — dropping it would reclassify it as user-owned and freeze it | agents and skills |

### Why the tier is derived, not recorded

Recording an origin tier in the skill manifest is the obvious route and is a schema change. It would have to decide what every *existing* entry means, and the only available default — "bundled" — is precisely this bug: a user-custom skill deployed before the field existed would be pruned exactly as before. Reading the live `~/.trusty-mpm/skills/` source through `skills::tiers::list_source_stems` — the same function `deploy_all_skill_tiers` uses to build its user set — makes the two structurally unable to disagree, needs no migration, and has no wrong default. Documented consequence: a stem the user has since *deleted* from that source is no longer user-tier and prunes normally, which is the intent.

### Also fixed here

Prune judged raw ledger keys, so an `include` rule matching a stem but not its carried `<stem>/references/*.md` key dropped that file's ledger entry while leaving the file on disk — after which the deployer reads it as user-owned and never updates it again ([#4881](https://github.com/bobmatnyc/trusty-tools/issues/4881)'s freeze shape, reached from this path). Candidates are now stems; a carried file is pruned with its skill or not at all.

### Doc correction

`apply_catalog`'s doc said "user-owned files are never removed". True of *unmanaged* files, silent on the frozen and user-tier ones — the code implemented the sentence's literal words, not the safety a reader infers. It now enumerates exactly what is protected, and what is not (a stem removed from the user source; nothing here restores a backup).

## Tests — fail-before / pass-after

Seven new tests in `apply/tests.rs`, plus one unit test on the backup-root path. **6 of 7 fail on the pre-fix code**; the seventh (`apply_prune_removes_deselected_skill`) passes by design — it is the "the feature still works" case.

<details><summary>FAIL BEFORE — production files reverted to <code>73599f364</code>, tests kept</summary>

```
running 12 tests
test core::update_check::apply::tests::apply_prune_skips_hand_edited_agent ... FAILED
test core::update_check::apply::tests::apply_prune_spares_user_owned ... ok
test core::update_check::apply::tests::apply_is_stale_before_apply_then_fresh_after ... ok
test core::update_check::apply::tests::apply_redeploys_and_clears_staleness ... ok
test core::update_check::apply::tests::apply_prune_spares_untracked_file_in_a_managed_skill ... FAILED
test core::update_check::apply::tests::apply_preserves_user_tier_override_deployed_via_launch_path ... ok
test core::update_check::apply::tests::apply_prune_removes_deselected_skill ... ok
test core::update_check::apply::tests::apply_prune_keeps_the_ledger_entry_for_a_selected_skills_carried_file ... FAILED
test core::update_check::apply::tests::apply_prune_skips_hand_edited_skill ... FAILED
test core::update_check::apply::tests::apply_prune_backs_up_before_removing_a_skill ... FAILED
test core::update_check::apply::tests::apply_prune_removes_deselected ... ok
test core::update_check::apply::tests::apply_prune_spares_user_tier_skill ... FAILED

---- apply_prune_skips_hand_edited_skill stdout ----
panicked at tests.rs:405:39:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, ... }

---- apply_prune_spares_untracked_file_in_a_managed_skill stdout ----
panicked at tests.rs:495:5:
the user's own file must survive --prune

---- apply_prune_keeps_the_ledger_entry_for_a_selected_skills_carried_file stdout ----
panicked at tests.rs:569:5:
nothing is deselected here: ApplyReport { ..., skills_pruned: ["carrier/references/notes.md"] }

---- apply_prune_backs_up_before_removing_a_skill stdout ----
panicked at tests.rs:529:45: a prune that deleted must leave a backup

---- apply_prune_spares_user_tier_skill stdout ----
panicked at tests.rs:461:39:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, ... }

test result: FAILED. 6 passed; 6 failed; 0 ignored; 0 measured; 4640 filtered out
```

(The `NotFound` unwraps are the data loss itself — the test reads back a file prune had just deleted. One test was withheld from this run: `apply_prune_reports_what_it_kept_and_where_backups_went` asserts on report fields that do not exist before the fix, so it cannot compile against the old code.)
</details>

<details><summary>PASS AFTER</summary>

```
running 13 tests
test core::update_check::apply::tests::apply_prune_skips_hand_edited_agent ... ok
test core::update_check::apply::tests::apply_redeploys_and_clears_staleness ... ok
test core::update_check::apply::tests::apply_prune_spares_user_owned ... ok
test core::update_check::apply::tests::apply_prune_skips_hand_edited_skill ... ok
test core::update_check::apply::tests::apply_is_stale_before_apply_then_fresh_after ... ok
test core::update_check::apply::tests::apply_prune_spares_untracked_file_in_a_managed_skill ... ok
test core::update_check::apply::tests::apply_prune_spares_user_tier_skill ... ok
test core::update_check::apply::tests::apply_prune_keeps_the_ledger_entry_for_a_selected_skills_carried_file ... ok
test core::update_check::apply::tests::apply_preserves_user_tier_override_deployed_via_launch_path ... ok
test core::update_check::apply::tests::apply_prune_removes_deselected ... ok
test core::update_check::apply::tests::apply_prune_reports_what_it_kept_and_where_backups_went ... ok
test core::update_check::apply::tests::apply_prune_removes_deselected_skill ... ok
test core::update_check::apply::tests::apply_prune_backs_up_before_removing_a_skill ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 4640 filtered out
```
</details>

## Gates — Rust Test Ladder rung 5 (destructive path, cross-crate reads, user-data loss)

```
cargo fmt --check                                              # EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings        # EXIT=0
cargo clippy -p trusty-agents-common --all-targets -- -D warnings  # EXIT=0
cargo test -p trusty-mpm                                       # 4646 passed; 1 failed (known flake, below)
cargo test -p trusty-agents-common                             # 482 passed; 0 failed
cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui  # see note
bash scripts/check_line_cap.sh          # 3725 files, 0 violations — OK
bash scripts/check_sld.sh               # 0 errors, 0 warnings
bash scripts/check_test_pointers.sh     # 21913 citations, 0 dangling
bash scripts/check_changelog_fragment.sh # OK trusty-mpm
bash scripts/check_capabilities.sh      # up to date (7 generated files)
```

Two reds, both pre-existing and neither caused by this branch:

- `stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet` — the `$HOME`-mutation parallel-run race listed in `docs/reference/test-ladder-baseline.md` line 38. Passes in isolation on this branch:
  ```
  running 1 test
  test daemon::managed_routes::tests::stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet ... ok
  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4653 filtered out
  ```
  This diff touches no file in `daemon/`.
- `cargo check --workspace` fails on `trusty-agents-ui`: `The frontendDist configuration is set to "../dist" but this path doesn't exist` — a Tauri `generate_context!` proc-macro panic on a fresh worktree with no built Svelte bundle. Adding `--exclude trusty-agents-ui` gives `EXIT=0` across every other member.

Full raw output for each command is in the run logs; nothing above is a summary of results in my own words beyond the counts cargo printed.

## Scope note

The agent prune path got the checksum gate and backup (it had the same hand-edit hazard, and the issue's own acceptance criteria ask for equivalent agent and skill coverage). It did **not** get tier awareness: no user-level agent tier deploys into `agent_deploy_dir()`, so there is no second tier for a bundled rule to reach across.

Closes [#391](https://github.com/bobmatnyc/trusty-tools/issues/391)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools