### PR TITLE
docs: document third required --exclude on workspace-wide cargo gates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = []
 # — a second Tauri desktop GUI needing the pnpm/Svelte UI toolchain).
 #
 # Why: CI already runs the workspace-wide gates with
-# `--workspace --exclude trusty-mpm-gui --exclude trusty-code-gui`
+# `--workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui`
 # (`.github/workflows/ci.yml`) because these GUIs need the pnpm/Svelte UI
 # toolchain — a bare `cargo build`/`test`/`check` had no equivalent exclusion,
 # so every agent worktree (which routinely runs the bare form per this
@@ -36,7 +36,13 @@ exclude = []
 # and keep working exactly as before (`cargo build --workspace`,
 # `cargo test -p trusty-mpm-gui`, `cargo check -p trusty-code-gui`, etc.), so
 # this only changes what the bare, no-flag form does — it does not remove
-# either GUI crate from the workspace.
+# either GUI crate from the workspace. `trusty-agents-ui` needs the same
+# `--exclude` on `--workspace` invocations for a different reason: its
+# `tauri::generate_context!()` reads the same `crates/trusty-agents/ui/dist/`
+# that `trusty-agents`' own build.rs populates, so a `--workspace` run that
+# happens to check/build `trusty-agents-ui` before that build script has run
+# panics on the missing path — a real cargo build-order race, not merely a
+# missing-toolchain skip (#3053).
 #
 # Maintenance note: Cargo has no "members minus one" glob for
 # `default-members`, so this list must be updated by hand when a new crate

--- a/docs/reference/common-pitfalls.md
+++ b/docs/reference/common-pitfalls.md
@@ -92,7 +92,11 @@ work in edition 2024. Do not copy let-chain patterns into edition-2021 crates.
 
 🟢 **`trusty-mpm-gui` is excluded from bare `cargo build`/`test`/`check`**
 (#2951) — the root `Cargo.toml`'s `default-members` list omits it, matching
-CI's existing `--workspace --exclude trusty-mpm-gui` for the same commands.
+CI's existing `--workspace --exclude trusty-mpm-gui --exclude trusty-code-gui
+--exclude trusty-agents-ui` for the same commands (the third exclusion guards
+against a build-order race: `trusty-agents-ui`'s `tauri::generate_context!()`
+reads the same `ui/dist/` that `trusty-agents`' own build.rs populates, and
+panics if it runs first).
 Use `cargo build -p trusty-mpm-gui` (or `--workspace`, which always builds
 everything regardless of `default-members`) when you actually need it. This
 also stops every agent worktree from silently producing a fresh ad-hoc-signed


### PR DESCRIPTION
## Summary

Two docs still quoted the two-exclusion `cargo check --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui` form. CI's own `.github/workflows/ci.yml` (msrv/clippy/test jobs) already runs the three-exclusion form — `--exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui` — so this brings the docs into agreement with what CI actually does.

- `Cargo.toml` (default-members comment, line ~27): quoted CI's flags and explained the rationale for `trusty-mpm-gui`/`trusty-code-gui`. Added the third exclusion and a short clause on why `trusty-agents-ui` needs it too.
- `docs/reference/common-pitfalls.md` (line ~95): same quote, same fix.

No changelog fragment — docs-only, no `crates/**/src` touched.

## Verification (reproduced in a fresh worktree off origin/main, no pre-built UI dist)

Two-exclusion form fails:
```
$ rm -rf crates/trusty-agents/ui/dist
$ cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui
...
   Compiling trusty-agents v0.38.6 (.../crates/trusty-agents)
    Checking trusty-agents-ui v0.16.1 (.../crates/trusty-agents/ui/src-tauri)
error: proc macro panicked
   --> crates/trusty-agents/ui/src-tauri/src/main.rs:144:16
    |
144 |         .build(tauri::generate_context!())
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: message: The `frontendDist` configuration is set to `"../dist"` but this path doesn't exist

error: could not compile `trusty-agents-ui` (bin "trusty-agents-ui") due to 1 previous error
$ echo EXIT=$?
EXIT=101
```

Three-exclusion form passes:
```
$ cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui --exclude trusty-agents-ui
    Finished `dev` profile [unoptimized + debuginfo] target(s) in ...
$ echo EXIT=$?
EXIT=0
```

Root cause: `trusty-agents-ui`'s `tauri::generate_context!()` reads `crates/trusty-agents/ui/dist/`, the same directory `trusty-agents`' own `build.rs` populates via `pnpm build`. The two crates have no Cargo dependency edge, so cargo's scheduling order between them is not guaranteed — if `trusty-agents-ui` gets checked before `trusty-agents`' build script has run, the shared dist directory doesn't exist yet and the macro panics. It is not purely worktree-freshness-dependent: it's a genuine build-order race, reproducible whenever the shared dist hasn't been populated yet (a fresh worktree just makes that the common case). I confirmed both outcomes are reachable from the identical starting state depending on scheduling — a first run with the two-exclusion form happened to pass because `trusty-agents` got scheduled first that time, and a second run (dist removed again) failed.

CI itself already avoids this entirely: `.github/workflows/ci.yml` excludes `trusty-agents-ui` from every workspace-wide job (`msrv` line 998, `clippy` line 331, `test` lines 811/885) and instead build/lint-verifies it in a dedicated `agents-ui` job (`-p trusty-agents-ui`) that manually stubs a placeholder `ui/dist/index.html` first. So this PR is strictly a docs-to-reality sync — CI was already correct; `Cargo.toml`'s comment and `common-pitfalls.md` had drifted.

## Test plan
- [x] `bash scripts/check_sld.sh` — exit 0
- [x] `bash scripts/check_line_cap.sh` — exit 0
- [x] `bash scripts/check_doc_numbers.sh` — exit 0
- [x] `bash scripts/check_capabilities.sh` — exit 0 (no bundled skill touched, no drift)
- [x] `cargo test -p trusty-mpm` — `test result: ok. 4638 passed; 0 failed; 7 ignored` (plus smaller sub-suites, all `0 failed`), including `stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet` passing this run
- [x] `cargo fmt --check` — exit 0

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools