### PR TITLE
fix(trusty-mpm): stop `tm ls` labelling a multi-client session `(active)`

### DIFF
--- a/crates/trusty-mpm/changelog.d/4983-tm-ls-multi-client-attached.md
+++ b/crates/trusty-mpm/changelog.d/4983-tm-ls-multi-client-attached.md
@@ -1,0 +1,7 @@
+Fixed
+
+- `tm ls` no longer labels a session with two or more attached tmux clients
+  `(active)` instead of `(attached)`. `#{session_attached}` is a client count,
+  not a boolean, and the row parser compared it to the literal `"1"` — so the
+  session the operator was actually sitting in (two terminals on it) read as
+  detached while every single-client session read correctly.

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -127,7 +127,7 @@ pub struct SessionInfo {
     pub name: String,
     /// Unix epoch seconds the session was created.
     pub created: i64,
-    /// Whether a client is currently attached.
+    /// Whether at least one client is currently attached.
     pub attached: bool,
 }
 
@@ -135,10 +135,16 @@ impl SessionInfo {
     /// Parse one `name:created:attached` row from `list-sessions`.
     ///
     /// Why: a single parser keeps the format in sync with
-    /// `core::tmux::SESSION_LIST_FORMAT`.
-    /// What: splits on `:`; tolerates a malformed `attached` flag by defaulting
-    /// it to `false`.
-    /// Test: `parses_session_row`.
+    /// `core::tmux::SESSION_LIST_FORMAT`. The third field is
+    /// `#{session_attached}`, which tmux documents as the NUMBER of clients the
+    /// session is attached to — not a boolean. Comparing it to the literal
+    /// `"1"` therefore read every session with two or more clients as detached,
+    /// and `tm ls` labelled it `(active)` instead of `(attached)`.
+    /// What: splits on `:`; the attachment field is parsed as a count and any
+    /// value `> 0` means attached. A missing or unparseable field still
+    /// degrades to `false` rather than failing the row.
+    /// Test: `parses_session_row`, `parses_multi_client_session_row_as_attached`,
+    /// `attachment_flips_to_detached_when_client_count_drops_to_zero`.
     pub fn parse(line: &str) -> Result<Self> {
         let mut parts = line.splitn(3, ':');
         let name = parts
@@ -150,7 +156,13 @@ impl SessionInfo {
             .next()
             .and_then(|s| s.parse::<i64>().ok())
             .ok_or_else(|| Error::Protocol(format!("bad tmux created field: {line:?}")))?;
-        let attached = parts.next().map(|s| s == "1").unwrap_or(false);
+        // PR #4983: `#{session_attached}` is a client COUNT, not a flag — a
+        // session with a second terminal on it reports `2`, and the old
+        // `== "1"` test read that as detached.
+        let attached = parts
+            .next()
+            .and_then(|s| s.trim().parse::<u32>().ok())
+            .is_some_and(|clients| clients > 0);
         Ok(Self {
             name,
             created,

--- a/crates/trusty-mpm/src/daemon/tmux_tests.rs
+++ b/crates/trusty-mpm/src/daemon/tmux_tests.rs
@@ -163,6 +163,68 @@ fn parses_session_row() {
     assert!(!detached.attached);
 }
 
+/// `#{session_attached}` is a CLIENT COUNT, not a boolean.
+///
+/// Why: `tm ls` labelled `tm-dogfood-relaunch-01` — the session the operator
+/// was sitting in, with two tmux clients on it — `(active)` rather than
+/// `(attached)`, while nine single-client sessions read `(attached)`. The
+/// parser compared the field to the literal `"1"`, so every count above one
+/// fell through to `false`. Two clients on one session is ordinary (a second
+/// terminal tab, an `attach -r` observer, a detached-and-reattached shell), so
+/// the label failed exactly for the session most likely to be the operator's.
+/// What: any count `> 0` is attached; `0` is not; a malformed field still
+/// degrades to `false` rather than erroring the whole row.
+/// Test: this function IS the test.
+#[test]
+fn parses_multi_client_session_row_as_attached() {
+    for clients in ["1", "2", "3", "17"] {
+        let info = SessionInfo::parse(&format!("tm-dogfood-relaunch-01:1785443731:{clients}"))
+            .unwrap_or_else(|e| panic!("row with {clients} client(s) must parse: {e}"));
+        assert!(
+            info.attached,
+            "session_attached={clients} is a client COUNT — any non-zero value \
+             means a client is connected, so the row must read attached"
+        );
+    }
+
+    assert!(
+        !SessionInfo::parse("tm-detached-01:1785443731:0")
+            .unwrap()
+            .attached,
+        "zero clients is the only value that means detached"
+    );
+
+    // A field tmux would never emit must not be read as attachment.
+    assert!(
+        !SessionInfo::parse("tm-garbage-01:1785443731:banana")
+            .unwrap()
+            .attached,
+        "an unparseable count degrades to detached, never to attached"
+    );
+}
+
+/// The label must FLIP when the last client goes away.
+///
+/// Why: a count-aware parser that only ever widened `attached` would still be
+/// wrong — the point of reading live tmux is that detaching is observable on
+/// the very next `tm ls`. This pins both directions of the transition.
+/// What: the same session name parsed at two client counts yields
+/// `attached == true` then `attached == false`.
+/// Test: this function IS the test.
+#[test]
+fn attachment_flips_to_detached_when_client_count_drops_to_zero() {
+    let name = "tm-dogfood-relaunch-01";
+    let while_attached = SessionInfo::parse(&format!("{name}:1785443731:2")).unwrap();
+    let after_detach = SessionInfo::parse(&format!("{name}:1785443731:0")).unwrap();
+
+    assert_eq!(while_attached.name, after_detach.name);
+    assert!(while_attached.attached);
+    assert!(
+        !after_detach.attached,
+        "once the last client detaches the very next listing must report detached"
+    );
+}
+
 #[test]
 fn parses_managed_pane_row() {
     let row = TmuxDriver::parse_managed_pane_row("tmpm-brave-otter\tclaude\t12345\t%7").unwrap();


### PR DESCRIPTION
## Defect

`tm ls` labelled `tm-dogfood-relaunch-01` — the session the operator was sitting in — `(active)` instead of `(attached)`, while nine other sessions read `(attached)` correctly.

`#{session_attached}` is the NUMBER of clients attached to a tmux session, not a boolean. `SessionInfo::parse` compared the field to the literal `"1"`, so any session with two or more clients parsed as detached.

**Root cause:** `crates/trusty-mpm/src/daemon/tmux.rs:153` (on `origin/main` 73599f36)

```rust
let attached = parts.next().map(|s| s == "1").unwrap_or(false);
```

This is the single site where the attachment field is parsed. The label is derived from a LIVE `tmux list-sessions` on every `tm ls` — no cache, no persisted marker, no daemon-held value — through `real_tmux.rs:89` → `summary.rs:212` → `session_picker_render.rs:158`. The render layer and the reconcile layer were both correct.

## Evidence

Raw `tmux list-sessions -F "$SESSION_LIST_FORMAT"` at the time of the report:

```
tm-apex-01:1785104361:1               -> (attached)  correct
tm-cto-02:1785888572:1                -> (attached)  correct
tm-xflux-01:1785851153:1              -> (attached)  correct
...six more single-client sessions, all correct...
tm-dogfood-relaunch-01:1785443731:2   -> (active)    WRONG
tm-compset-engine-notes-01:...:0      -> (active)    correct
```

Nine clients on nine sessions across nine ttys is real — each is a separate terminal tab. Exactly one row was wrong, and it was the one with the most clients (`/dev/ttys000,/dev/ttys002`). A second terminal on a session is ordinary, so the label failed precisely for the session most likely to be the operator's.

## `(active)` vs `(attached)`

They are distinct states, not a fallback pair. `state_color` (`session_picker_render.rs:100`) gives `attached` precedence over every `state` value. `(active)` legitimately means the tmux session is live but has zero clients — correct for the six detached sessions in that listing. Only sessions with two or more clients were mislabelled.

## Resolution

Parse the field as the count it is; any value `> 0` is attached. A missing or unparseable field still degrades to `false` rather than failing the row.

No cache was removed because none existed, and no tmux invocation was added — this is a string→integer parse on a line already fetched. `tm ls` cost is unchanged.

## Tests

`crates/trusty-mpm/src/daemon/tmux_tests.rs`:

- `parses_multi_client_session_row_as_attached` — counts 1/2/3/17 all read attached, `0` does not, garbage degrades to detached.
- `attachment_flips_to_detached_when_client_count_drops_to_zero` — the same session flips when its last client goes away.

Fail-before, on the unfixed parser:

```
thread 'daemon::tmux::tests::parses_multi_client_session_row_as_attached' panicked at
crates/trusty-mpm/src/daemon/tmux_tests.rs:183:9:
session_attached=2 is a client COUNT — any non-zero value means a client is
connected, so the row must read attached

test result: FAILED. 11 passed; 1 failed; 0 ignored; 0 measured; 4635 filtered out
```

Pass-after:

```
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 4634 filtered out
```

## Gates — test ladder rung 3 (localized inside `trusty-mpm`)

```
cargo fmt --check && cargo clippy -p trusty-mpm --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-mpm -- --test-threads=1
  test result: ok. 4640 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
bash scripts/check_line_cap.sh           3724 files, 0 violations — OK
bash scripts/check_sld.sh                0 errors, 0 warnings
bash scripts/check_test_pointers.sh      21893 citations, 0 dangling
bash scripts/check_changelog_fragment.sh OK trusty-mpm
```

Two default-threaded runs each produced one failure, in a different test each time, both passing in isolation and both in files this diff does not touch (`git diff --name-only origin/main -- crates/trusty-mpm/src/core/` is empty):

- `stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet` — documented in `docs/reference/test-ladder-baseline.md:38` as a parallel `$HOME`-mutation race, remedy `--test-threads=1`.
- `core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning` — same family: a `tracing::subscriber::with_default` capture test whose `#[serial]` guard only serializes against other `#[serial]` tests. Not yet in the baseline doc; worth adding there, not fixed here.

The documented single-threaded run is clean.

## Scope

Attached/active labelling only. The auto-prune gap (#4384), the `tm-deadrt*` DEAD detection, and default-resume-target behaviour are untouched. This fix does not make any of them easier.

No open issue covers this defect — the closest, #3291, is a different bug (`(stopped)` for running sessions) and is closed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools