### PR TITLE
fix(trusty-mpm): honour agent ledger origin in the catalog-prune guard (#391 follow-up)

### DIFF
--- a/crates/trusty-mpm/changelog.d/391-agent-verdict-honours-origin.md
+++ b/crates/trusty-mpm/changelog.d/391-agent-verdict-honours-origin.md
@@ -1,0 +1,5 @@
+Fixed
+
+- `tm catalog apply --prune` now reads an agent's ledger ownership tier, not just its checksum (completes the agent half of [#391](https://github.com/bobmatnyc/trusty-tools/issues/391))
+  - the agent manifest records an `Origin` the skill manifest lacks, and `agents::deployer` already honours it — a non-`Bundled` entry is the seed-once tier and is preserved on a checksum mismatch. Prune read the checksum and not the tier, so a pristine user- or registry-owned agent could still be deleted by a bundled exclude rule: the hole the skill side closed by deriving the user tier from its source directory
+  - latent today, because nothing writes a non-`Bundled` origin; pinned by a regression test that constructs the ledger entry directly

--- a/crates/trusty-mpm/src/core/update_check/apply.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply.rs
@@ -153,6 +153,10 @@ struct PruneOutcome {
 ///   bundled include/exclude says — [`deploy_all_skill_tiers`] deploys that tier
 ///   in full and exempt from those rules, but its ledger entries look identical
 ///   to bundled ones.
+/// - The agent equivalent of that rule reads the ledger instead of a source
+///   directory, because the agent ledger records a tier and the skill one does
+///   not: an entry whose `Origin` is not `Bundled` is user-owned and is never
+///   pruned, matching how `agents::deployer` already treats it.
 /// - Everything actually deleted is copied under
 ///   `<framework-root>/backup-catalog-prune-<timestamp>/` first;
 ///   [`ApplyReport::prune_backup_dir`] names it.
@@ -252,10 +256,13 @@ pub fn apply_catalog<G: GitBackend>(
 /// Why: HR-2 deferred removal of deselected agents; HR-3 supplies it behind the
 /// explicit `--prune` flag. Only MANAGED files (present in the agent checksum
 /// manifest) are eligible — a user-dropped file is never removed — and since
-/// #391 an eligible file is deleted only when its bytes still match the recorded
-/// checksum, so a hand-edited agent survives being deselected.
+/// #391 an eligible file is deleted only when the ledger attributes it to the
+/// framework (`Origin::Bundled`) AND its bytes still match the recorded
+/// checksum. So a hand-edited agent survives being deselected, and so does a
+/// pristine one the ledger records as user- or registry-owned.
 /// What: for each manifest-managed agent filename whose stem the plan rejects
-/// AND whose on-disk copy is unmodified, backs the file up under `backup_root`,
+/// AND whose on-disk copy is framework-owned and unmodified, backs the file up
+/// under `backup_root`,
 /// deletes `<target>/<filename>` (ignoring an already-absent file) and drops the
 /// manifest entry; saves the manifest if anything changed. A modified or
 /// unreadable file keeps BOTH its content and its ledger entry — dropping the
@@ -277,7 +284,7 @@ pub fn apply_catalog<G: GitBackend>(
 /// agent this prune then removes; that agent returns on the next launch or
 /// sync-assets, since deploy is idempotent. No update is ever lost.
 /// Test: `apply_prune_removes_deselected`, `apply_prune_spares_user_owned`,
-/// `apply_prune_skips_hand_edited_agent`.
+/// `apply_prune_skips_hand_edited_agent`, `apply_prune_spares_a_user_origin_agent`.
 fn prune_agents(
     target: &Path,
     plan: &HarnessPlan,
@@ -293,7 +300,7 @@ fn prune_agents(
 /// it directly, and never from inside another `with_agent_manifest_lock` on the
 /// same directory (`flock` on a second descriptor in one process deadlocks).
 /// Test: `apply_prune_removes_deselected`, `apply_prune_spares_user_owned`,
-/// `apply_prune_skips_hand_edited_agent`.
+/// `apply_prune_skips_hand_edited_agent`, `apply_prune_spares_a_user_origin_agent`.
 fn prune_agents_locked(
     target: &Path,
     plan: &HarnessPlan,
@@ -308,8 +315,9 @@ fn prune_agents_locked(
         if plan.agent_selected(stem) {
             continue;
         }
-        // #391: deselected is not the same as disposable — check the file is
-        // still the one trusty-mpm wrote before deleting it.
+        // #391: deselected is not the same as disposable — check the ledger
+        // still attributes the file to the framework, and that it is still the
+        // one trusty-mpm wrote, before deleting it.
         if let Verdict::Kept(why) = prune_guard::agent_verdict(&manifest, target, &filename) {
             tracing::info!(agent = %filename, reason = %why, "not pruning a deselected agent");
             outcome.kept.push(format!("{filename}: {why}"));

--- a/crates/trusty-mpm/src/core/update_check/apply/prune_guard.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply/prune_guard.rs
@@ -30,7 +30,8 @@
 //! `apply_prune_skips_hand_edited_skill`, `apply_prune_spares_user_tier_skill`,
 //! `apply_prune_spares_untracked_file_in_a_managed_skill`,
 //! `apply_prune_backs_up_before_removing_a_skill`,
-//! `apply_prune_skips_hand_edited_agent`.
+//! `apply_prune_skips_hand_edited_agent`,
+//! `apply_prune_spares_a_user_origin_agent`.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -74,14 +75,47 @@ pub(super) fn prune_backup_root(fw_root: &Path, now: chrono::DateTime<chrono::Ut
 /// Why (#391): the same rule `agents::deployer` already applies before an
 /// overwrite. Deleting a file whose bytes the user changed destroys work no
 /// backup was asked for.
+/// A checksum gate alone is not the whole rule, for the same reason it was not
+/// on the skill side: it protects an EDITED file, never a pristine one the user
+/// owns. Skills had to derive that from the live user source because their
+/// ledger records no tier. The agent ledger already carries it —
+/// `ManifestEntry::origin`, which `agents::deployer` consults through
+/// `Origin::is_framework_owned` to decide refresh-vs-preserve — so this guard
+/// reads the same field rather than inventing a second answer.
+///
+/// Nothing writes a non-`Bundled` origin today, so no live prune reaches that
+/// branch. It is closed now because the day something does, it becomes a data
+/// -loss path with no test and no record of why it mattered.
 /// What: `Prunable` when the file is absent (prune is idempotent — there is
-/// nothing to lose) or its content still checksums to the ledger entry;
-/// `Kept` when it differs, or cannot be read as text at all.
-/// Test: `apply_prune_skips_hand_edited_agent`, `apply_prune_removes_deselected`.
+/// nothing to lose), or when the ledger records it framework-owned AND its
+/// content still checksums to that entry. `Kept` when the ledger has no entry
+/// for it, when the entry is user-owned (`User`/`Registry` — the seed-once
+/// tier), when the content differs, or when it cannot be read as text.
+/// Test: `apply_prune_skips_hand_edited_agent`,
+/// `apply_prune_spares_a_user_origin_agent`, `apply_prune_removes_deselected`.
 pub(super) fn agent_verdict(manifest: &AgentManifest, target: &Path, filename: &str) -> Verdict {
     let path = target.join(filename);
     if !path.exists() {
         return Verdict::Prunable;
+    }
+    // #391: an agent the ledger attributes to the user is theirs whether or not
+    // they have edited it — the same case a matching checksum waved through on
+    // the skill side. Callers only pass managed filenames, so a missing entry is
+    // unreachable; treated as user-owned rather than unwrapped.
+    match manifest.managed.get(filename) {
+        Some(entry) if entry.origin.is_framework_owned() => {}
+        Some(entry) => {
+            return Verdict::Kept(format!(
+                "the ledger records it as {:?}-owned, not framework-owned",
+                entry.origin
+            ));
+        }
+        None => {
+            return Verdict::Kept(format!(
+                "{} has no ledger entry, so trusty-mpm does not own it",
+                path.display()
+            ));
+        }
     }
     match std::fs::read_to_string(&path) {
         Ok(content) if manifest.checksum_matches(filename, &content) => Verdict::Prunable,

--- a/crates/trusty-mpm/src/core/update_check/apply/tests.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply/tests.rs
@@ -662,3 +662,72 @@ fn apply_prune_reports_what_it_kept_and_where_backups_went() {
         .expect("something was deleted, so a backup root is reported");
     assert!(backup.join("skills/pristine/SKILL.md").is_file());
 }
+
+#[test]
+fn apply_prune_spares_a_user_origin_agent() {
+    // #391 follow-up: the agent ledger records an ownership tier the skill
+    // ledger lacks, and `agents::deployer` already honours it — a non-`Bundled`
+    // entry is the seed-once tier, preserved on a checksum mismatch. Prune read
+    // the checksum and not the tier, so a PRISTINE user-owned agent was deleted
+    // by a bundled exclude rule: the exact hole #4979 closed for skills.
+    //
+    // Nothing writes a non-`Bundled` origin in production today, so this test
+    // constructs the ledger entry directly. That is deliberate — the state is
+    // unreachable until something does write one, and the point of pinning it
+    // now is that the day it becomes reachable it must not also be the day the
+    // guard is discovered missing.
+    let fw_root = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let fw = crate::core::paths::FrameworkPaths::from_root(fw_root.path().join(".trusty-mpm"));
+
+    let catalog_root = crate::content::catalog_root_for(&fw.root);
+    seed_catalog_agent(&catalog_root, "operator-owned", "BODY");
+    write_catalog_manifest(project.path());
+    apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
+
+    let deployed = fw.agent_deploy_dir().join("operator-owned.md");
+    let before = fs::read_to_string(&deployed).unwrap();
+
+    // Re-attribute the (unmodified) entry to the user tier.
+    let target = fw.agent_deploy_dir();
+    let mut ledger = AgentManifest::load(&target);
+    ledger
+        .managed
+        .get_mut("operator-owned.md")
+        .expect("the deploy recorded it")
+        .origin = crate::core::agent_manifest::Origin::User;
+    ledger.save(&target).unwrap();
+
+    rewrite_manifest(
+        project.path(),
+        "[agents]\nsource = \"catalog\"\nexclude = [\"operator-owned\"]\n\n[skills]\nsource = \"catalog\"\n",
+    );
+    let report = apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, true).unwrap();
+
+    assert_eq!(
+        fs::read_to_string(&deployed).unwrap(),
+        before,
+        "a user-origin agent must survive --prune even while pristine"
+    );
+    assert!(
+        !report
+            .agents_pruned
+            .contains(&"operator-owned.md".to_string()),
+        "user-origin agent must not be pruned: {report:?}"
+    );
+    assert_eq!(
+        report.agents_prune_kept.len(),
+        1,
+        "and the operator is told it was kept: {report:?}"
+    );
+    assert!(
+        report.agents_prune_kept[0].starts_with("operator-owned.md: "),
+        "the kept entry names the agent and the reason: {report:?}"
+    );
+    // The ledger keeps both the entry and its tier.
+    let after = AgentManifest::load(&target);
+    assert_eq!(
+        after.managed.get("operator-owned.md").map(|e| e.origin),
+        Some(crate::core::agent_manifest::Origin::User)
+    );
+}


### PR DESCRIPTION
Completes the agent half of what [#4979](https://github.com/bobmatnyc/trusty-tools/pull/4979) did for skills. Raised as a MEDIUM in that PR's `code-critic` round.

## Defect

`agent_verdict` (`crates/trusty-mpm/src/core/update_check/apply/prune_guard.rs:81`) gated only on the recorded checksum. A checksum gate protects an **edited** agent — its bytes no longer match — and never a **pristine** one the user owns. That is exactly the hole #4979 spent its second guard closing on the skill side.

The difference: skills had to derive their tier from the live `~/.trusty-mpm/skills/` source, because the skill ledger records no tier. **The agent ledger already records one.** `ManifestEntry::origin` exists, and `agents::deployer.rs:345` already consults it through `Origin::is_framework_owned` to decide refresh-vs-preserve — `Bundled` is the framework-owned Overwrite tier, `User`/`Registry` are the seed-once tier that survives a checksum mismatch. The information was present on this path and the guard simply did not read it.

## Fix

One branch, ahead of the checksum read: an entry whose origin is not `Bundled` is `Kept`, and so is a filename with no ledger entry at all (unreachable — callers only pass managed names — but treated as user-owned rather than unwrapped).

## Latency, stated plainly

Nothing writes a non-`Bundled` origin in production today, so no live prune reaches the new branch. It is closed now rather than filed because the day something does write one, this becomes a data-loss path with no test and no record of why it mattered.

That has a consequence for the test: **`apply_prune_spares_a_user_origin_agent` constructs the ledger entry directly** — it deploys normally, then re-attributes the unmodified entry to `Origin::User` and saves. The test comment says so. It exercises a currently-unreachable state deliberately, not by accident.

## Fail-before / pass-after

`prune_guard.rs` reverted to the merged `dd7127093`, test kept:

```
running 1 test
test core::update_check::apply::tests::apply_prune_spares_a_user_origin_agent ... FAILED

---- apply_prune_spares_a_user_origin_agent stdout ----
panicked at tests.rs:708:39:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4654 filtered out
```

The `NotFound` is the data loss: the test reads back the agent prune had just deleted. With the fix:

```
running 15 tests
test core::update_check::apply::prune_guard::tests::prune_backup_root_is_timestamped_under_the_framework_root ... ok
test core::update_check::apply::tests::apply_prune_skips_hand_edited_agent ... ok
test core::update_check::apply::tests::apply_prune_spares_untracked_file_in_a_managed_skill ... ok
test core::update_check::apply::tests::apply_prune_spares_a_user_origin_agent ... ok
test core::update_check::apply::tests::apply_prune_skips_hand_edited_skill ... ok
test core::update_check::apply::tests::apply_preserves_user_tier_override_deployed_via_launch_path ... ok
test core::update_check::apply::tests::apply_prune_spares_user_owned ... ok
test core::update_check::apply::tests::apply_redeploys_and_clears_staleness ... ok
test core::update_check::apply::tests::apply_prune_keeps_the_ledger_entry_for_a_selected_skills_carried_file ... ok
test core::update_check::apply::tests::apply_prune_removes_deselected ... ok
test core::update_check::apply::tests::apply_is_stale_before_apply_then_fresh_after ... ok
test core::update_check::apply::tests::apply_prune_removes_deselected_skill ... ok
test core::update_check::apply::tests::apply_prune_spares_user_tier_skill ... ok
test core::update_check::apply::tests::apply_prune_reports_what_it_kept_and_where_backups_went ... ok
test core::update_check::apply::tests::apply_prune_backs_up_before_removing_a_skill ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 4640 filtered out
```

## Gates — Rust Test Ladder rung 5 (same destructive path as #4979)

```
cargo fmt --check                                                  # EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings            # EXIT=0
cargo clippy -p trusty-agents-common --all-targets -- -D warnings  # EXIT=0
cargo test -p trusty-mpm                    # 4647 passed; 1 failed (known flake, below)
cargo test -p trusty-agents-common          # 482 passed; 0 failed
cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui --exclude trusty-agents-ui   # EXIT=0
bash scripts/check_line_cap.sh              # 3725 files, 0 violations — OK
bash scripts/check_sld.sh                   # 0 errors, 0 warnings
bash scripts/check_test_pointers.sh         # 21916 citations, 0 dangling
bash scripts/check_changelog_fragment.sh    # OK trusty-mpm
bash scripts/check_capabilities.sh          # up to date (7 generated files)
```

The one red is `stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet`, the `$HOME`-mutation parallel-run race in `docs/reference/test-ladder-baseline.md` line 38. Passes in isolation on this branch:

```
running 1 test
test daemon::managed_routes::tests::stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4653 filtered out
```

This diff touches no file in `daemon/`.

The workspace check carries the third exclusion the critic independently confirmed on #4979: `trusty-agents-ui`'s `tauri::generate_context!` panics with `The frontendDist configuration is set to "../dist" but this path doesn't exist` in any worktree with no built Svelte dist. With it, `EXIT=0` across every other member.

See [#391](https://github.com/bobmatnyc/trusty-tools/issues/391) — that issue is already closed by #4979; this does not reopen it.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools