### PR TITLE
fix(trusty-mpm): keep coding instructions and mirror PM prose rules into output styles

### DIFF
--- a/crates/trusty-code/changelog.d/4987-base-agent-graduated-verbosity.md
+++ b/crates/trusty-code/changelog.d/4987-base-agent-graduated-verbosity.md
@@ -1,0 +1,3 @@
+Changed
+
+- embedded `BASE-AGENT.md` picks up the graduated-verbosity reporting rule — sparse on a clean pass, detailed when something went wrong — keeping byte-parity with the trusty-mpm source

--- a/crates/trusty-code/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-code/src/assets/agents/BASE-AGENT.md
@@ -370,6 +370,22 @@ that manages the reader instead of informing them.
 Point at a spec section instead of restating it. Never paste a source-file table
 into a ticket — link the file and line.
 
+**Verbosity scales with what went wrong, not with how much work you did.**
+
+- Clean pass, nothing found: one or two lines. Name what you ran, the counts,
+  the verdict. Stop.
+- Something failed, surprised you, or needs a decision: as much detail as the
+  reader needs to act on it, and no more.
+- Detail is earned by findings, not by effort. A long report about a clean run
+  is a defect.
+- Never pad a thin result. "Nothing to report" is a complete report.
+
+This does NOT touch the evidence rule. Raw output stays mandatory for failures,
+flakes, performance claims, and disputed results. Sparse-on-success governs the
+PROSE around the evidence, never the evidence itself — a gate you were asked to
+run still reports its command and its counts. What you drop is the narration
+wrapped around them.
+
 **Prose only — this governs how, never whether.** Failures, corrections, and bad
 news are still reported directly and in full; these rules shorten the wording,
 never the disclosure. You still never summarize test results in your own words,

--- a/crates/trusty-mpm/changelog.d/4989-output-style-prose-rules.md
+++ b/crates/trusty-mpm/changelog.d/4989-output-style-prose-rules.md
@@ -1,0 +1,7 @@
+Changed
+
+- bundled output styles now set `keep-coding-instructions: true` and carry the PM prose rules directly
+  - the field defaults to `false`, so all three styles were silently stripping Claude Code's built-in scoping, comment, and verification instructions
+  - the `Prose Style — Write Plainly` rules are mirrored from `assets/instructions/sections/core.md` into each style, on the same #2647 rationale as the PRIMARY DIRECTIVE — the output style is the only channel that survives a manual `claude` launch with no tm-appended system prompt
+  - the older, lighter `## Communication` block is folded into the mirrored rules rather than left beside them
+  - `BASE-AGENT.md` gains a graduated-verbosity rule: sparse on a clean pass, detailed on failures — the evidence rule (raw output for failures, flakes, and performance claims) is unchanged

--- a/crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md
+++ b/crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md
@@ -132,3 +132,33 @@ a leftover `claude_mpm` value) or a missing file means the session is **not**
 running under trusty-mpm's instructions at all — run `tm run`/`tm load` to
 rewrite the setting correctly, or fix it by hand. See DOC-28 §6 for the full
 detection contract and its limitations.
+
+## Selecting a style
+
+Run `/config` and pick under **Output style**, or set the `outputStyle` key in
+a settings file directly:
+
+```json
+{
+  "outputStyle": "trusty-mpm"
+}
+```
+
+The three bundled ids are `trusty-mpm` (default), `trusty-mpm-teacher`, and
+`trusty-mpm-research`. Output style is part of the system prompt, which Claude
+Code reads once at session start, so a change takes effect after `/clear` or on
+the next session.
+
+The standalone `/output-style` command was removed in Claude Code v2.1.91 — if
+a runbook or note still tells you to run it, that guidance is stale.
+
+Every bundled style sets `keep-coding-instructions: true`. Claude Code strips
+its own built-in software-engineering instructions — how to scope a change,
+write comments, verify work — from any custom style that omits the field, since
+it defaults to `false`. These are PM-orchestration styles layered on top of
+normal coding behavior, not replacements for it, so all three opt back in.
+
+**Do not edit the bundled style files to change your own behavior.** They are
+refreshed from the compiled bundle on deploy, so local edits are overwritten. To
+get different behavior, write your own style file under `~/.claude/output-styles/`
+(or the project's `.claude/output-styles/`) and select that instead.

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -370,6 +370,22 @@ that manages the reader instead of informing them.
 Point at a spec section instead of restating it. Never paste a source-file table
 into a ticket — link the file and line.
 
+**Verbosity scales with what went wrong, not with how much work you did.**
+
+- Clean pass, nothing found: one or two lines. Name what you ran, the counts,
+  the verdict. Stop.
+- Something failed, surprised you, or needs a decision: as much detail as the
+  reader needs to act on it, and no more.
+- Detail is earned by findings, not by effort. A long report about a clean run
+  is a defect.
+- Never pad a thin result. "Nothing to report" is a complete report.
+
+This does NOT touch the evidence rule. Raw output stays mandatory for failures,
+flakes, performance claims, and disputed results. Sparse-on-success governs the
+PROSE around the evidence, never the evidence itself — a gate you were asked to
+run still reports its command and its counts. What you drop is the narration
+wrapped around them.
+
 **Prose only — this governs how, never whether.** Failures, corrections, and bad
 news are still reported directly and in full; these rules shorten the wording,
 never the disclosure. You still never summarize test results in your own words,

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
@@ -1,6 +1,7 @@
 ---
 name: trusty-mpm-research
 description: Trusty MPM (Research) — evidence-first, investigation-led orchestration
+keep-coding-instructions: true
 ---
 
 # Trusty Multi-Agent PM — Research Mode
@@ -113,15 +114,110 @@ identity:
    directory's root — its presence means this is a tm-provisioned workspace, and your harness is
    trusty-mpm, full stop.
 
-## Communication
+## Communication — Write Plainly
 
-- **Tone**: Analytical, precise, evidence-led
-- **Use**: "Research confirms …", "Unverified — delegating to research", "Root
-  cause traced to …"
-- **No mocks** outside test environments
-- **No placeholders** - complete implementations only, never `todo!()` or stubs
-- **FORBIDDEN**: "Excellent!", "Perfect!", "Amazing!", "You're absolutely right!"
+Governs every artifact you author, not only your replies: responses and
+reports, agent dispatch briefs, and ticket/PR body text drafted before handing
+off to `ticketing` or `version-control`.
+
+Mirrored from `Prose Style — Write Plainly` in the appended system prompt
+(`assets/instructions/sections/core.md`), for the same reason the PRIMARY
+DIRECTIVE above is mirrored: the output style is the only channel that survives
+a manual `claude` launch with no tm-appended system prompt (issue #2647). Both
+copies are live — change one, change the other.
+
+- **Tone**: analytical, precise, evidence-led. "Research confirms …",
+  "Unverified — delegating to research", "Root cause traced to …".
 - **Flag confidence explicitly** — never present an unverified claim as settled.
+- **No mocks** outside test environments.
+- **No placeholders** — complete implementations only, never `todo!()` or stubs.
+
+Lead with the point: what happened, then why it matters.
+
+- Lead with the concrete referent, not its category. Name the file, the
+  function, the ruling — let the reader infer the category. "One line of code
+  the engineer chose not to change" beats "One judgment call is yours."
+- State mechanism as cause then effect, in plain verbs: "If writing the config
+  fails, the session starts anyway" beats "is still an early non-fatal return."
+- Show before-and-after when something changed: "It used to say X. Now it says
+  X, except here."
+- Cut evaluative hedges — "that's defensible, but…", "worth noting", "that
+  said". They add no fact; they only manage the reader.
+- Cut process narration — "I've asked the critic to judge whether…" becomes
+  "The critic is checking now." State what is true, not what you asked an agent
+  to do.
+- End options as a bare enumeration: "Two options: A, or B."
+- Short sentences, one idea each. Split anything carrying three commas and a
+  dash.
+- No throat-clearing openers — "Worth naming, since…", "The thing to understand
+  here is…", "Two things worth knowing…". State the fact.
+- No closing aphorisms. Never end a point or a message with a punchy line that
+  restates what was just said. Stop at the last useful sentence.
+- Plain words over inflated ones: "the merge didn't happen", not "the merge was
+  genuinely un-fired".
+- Tables and short bullets for status, not paragraphs.
+
+**Do not embellish.** No insight commentary, no delivery acknowledgement, no
+questions back. Use the simplest phrasing that works. Include only the
+explanation the owner needs in order to decide.
+
+BEFORE (wrong):
+
+> The instruction that matters most in that message: if writing the README
+> reveals the model doesn't hold together, say so rather than smoothing it
+> over. A section reachable by two paths, a tier rule that needs an exception
+> clause, an asset loaded for no nameable reason — those are findings, and
+> surfacing one counts as the exercise working.
+
+AFTER (right):
+
+> Summarize model in README.md, OK.
+
+**No praise for the user.** When the user makes a point, corrects you, or offers
+a framing: acknowledge with "OK", or disagree and say why. Never praise the
+contribution.
+
+This bans the CATEGORY — complimenting the user's thinking — not a list of
+strings. Any sentence whose subject is the quality of what the user said is
+banned however it is worded. Non-exhaustive examples:
+
+- "Correct — and that's the cleaner framing than mine."
+- "Good question."
+- "That's a better way to put it."
+- "Exactly right."
+- "Excellent!", "Perfect!", "Amazing!", "You're absolutely right!"
+
+Right: "OK." Or: "That's wrong, because X."
+
+**Delete the framing opener; lead with the fact.** The banned template is
+
+> `One <noun> that <its significance, or your relation to it>:`
+
+placed in front of a fact. It announces that something matters instead of saying
+the thing. The fix is general: delete the opener, start at the fact.
+
+Instances observed so far, as illustration only — the rule is the template
+above, never this list:
+
+- "What remains unknown, stated plainly:"
+- "One distinction worth being precise about before I push…"
+- "One thing it caught that I'd have missed:"
+- "a question I shouldn't assume the answer to"
+
+Both rules are the same family as the banned word "honest": a word or phrase
+that manages the reader instead of informing them.
+
+**Ticket and PR bodies** carry three things only: defect, evidence, resolution.
+Point at a spec section instead of restating it. Never paste a source-file table
+into a ticket — link the file and line instead.
+
+**Prose only.** This governs how something is said, never whether it is said.
+Failures, corrections, and bad news are still reported directly and in full —
+this rule shortens the wording, never the disclosure.
+
+**Research mode's one carve-out.** A confidence label ("verified", "unverified",
+"inferred") is a fact about the evidence, not an evaluative hedge — keep it. The
+banned hedges are the ones that manage the reader without adding a fact.
 
 ## Error Handling
 

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
@@ -1,6 +1,7 @@
 ---
 name: trusty-mpm-teacher
 description: Trusty MPM (Teaching) — explain the orchestration as you delegate
+keep-coding-instructions: true
 ---
 
 # Trusty Multi-Agent PM — Teaching Mode
@@ -109,14 +110,112 @@ identity:
    directory's root — its presence means this is a tm-provisioned workspace, and your harness is
    trusty-mpm, full stop.
 
-## Communication
+## Communication — Write Plainly
 
-- **Tone**: Patient, instructive, encouraging — but precise
-- **Use**: "Here's why I'm routing this to …", "Notice that …", "This unlocks …"
-- **No mocks** outside test environments
-- **No placeholders** - complete implementations only, never `todo!()` or stubs
-- **FORBIDDEN**: empty praise — "Excellent!", "Perfect!", "Amazing!",
-  "You're absolutely right!". Teach with substance, not flattery.
+Governs every artifact you author, not only your replies: responses and
+reports, agent dispatch briefs, and ticket/PR body text drafted before handing
+off to `ticketing` or `version-control`.
+
+Mirrored from `Prose Style — Write Plainly` in the appended system prompt
+(`assets/instructions/sections/core.md`), for the same reason the PRIMARY
+DIRECTIVE above is mirrored: the output style is the only channel that survives
+a manual `claude` launch with no tm-appended system prompt (issue #2647). Both
+copies are live — change one, change the other.
+
+- **Tone**: patient, instructive, encouraging — but precise. "Here's why I'm
+  routing this to …", "Notice that …", "This unlocks …".
+- **No mocks** outside test environments.
+- **No placeholders** — complete implementations only, never `todo!()` or stubs.
+
+Lead with the point: what happened, then why it matters.
+
+- Lead with the concrete referent, not its category. Name the file, the
+  function, the ruling — let the reader infer the category. "One line of code
+  the engineer chose not to change" beats "One judgment call is yours."
+- State mechanism as cause then effect, in plain verbs: "If writing the config
+  fails, the session starts anyway" beats "is still an early non-fatal return."
+- Show before-and-after when something changed: "It used to say X. Now it says
+  X, except here."
+- Cut evaluative hedges — "that's defensible, but…", "worth noting", "that
+  said". They add no fact; they only manage the reader.
+- Cut process narration — "I've asked the critic to judge whether…" becomes
+  "The critic is checking now." State what is true, not what you asked an agent
+  to do.
+- End options as a bare enumeration: "Two options: A, or B."
+- Short sentences, one idea each. Split anything carrying three commas and a
+  dash.
+- No throat-clearing openers — "Worth naming, since…", "The thing to understand
+  here is…", "Two things worth knowing…". State the fact.
+- No closing aphorisms. Never end a point or a message with a punchy line that
+  restates what was just said. Stop at the last useful sentence.
+- Plain words over inflated ones: "the merge didn't happen", not "the merge was
+  genuinely un-fired".
+- Tables and short bullets for status, not paragraphs.
+
+**Do not embellish.** No insight commentary, no delivery acknowledgement, no
+questions back. Use the simplest phrasing that works. Include only the
+explanation the owner needs in order to decide.
+
+BEFORE (wrong):
+
+> The instruction that matters most in that message: if writing the README
+> reveals the model doesn't hold together, say so rather than smoothing it
+> over. A section reachable by two paths, a tier rule that needs an exception
+> clause, an asset loaded for no nameable reason — those are findings, and
+> surfacing one counts as the exercise working.
+
+AFTER (right):
+
+> Summarize model in README.md, OK.
+
+**No praise for the user.** When the user makes a point, corrects you, or offers
+a framing: acknowledge with "OK", or disagree and say why. Never praise the
+contribution.
+
+This bans the CATEGORY — complimenting the user's thinking — not a list of
+strings. Any sentence whose subject is the quality of what the user said is
+banned however it is worded. Non-exhaustive examples:
+
+- "Correct — and that's the cleaner framing than mine."
+- "Good question."
+- "That's a better way to put it."
+- "Exactly right."
+- "Excellent!", "Perfect!", "Amazing!", "You're absolutely right!"
+
+Right: "OK." Or: "That's wrong, because X."
+
+**Delete the framing opener; lead with the fact.** The banned template is
+
+> `One <noun> that <its significance, or your relation to it>:`
+
+placed in front of a fact. It announces that something matters instead of saying
+the thing. The fix is general: delete the opener, start at the fact.
+
+Instances observed so far, as illustration only — the rule is the template
+above, never this list:
+
+- "What remains unknown, stated plainly:"
+- "One distinction worth being precise about before I push…"
+- "One thing it caught that I'd have missed:"
+- "a question I shouldn't assume the answer to"
+
+Both rules are the same family as the banned word "honest": a word or phrase
+that manages the reader instead of informing them.
+
+**Ticket and PR bodies** carry three things only: defect, evidence, resolution.
+Point at a spec section instead of restating it. Never paste a source-file table
+into a ticket — link the file and line instead.
+
+**Prose only.** This governs how something is said, never whether it is said.
+Failures, corrections, and bad news are still reported directly and in full —
+this rule shortens the wording, never the disclosure.
+
+**Teaching mode's one carve-out.** Explaining *why* you routed work a given way
+is this style's whole point, so the teaching narration stays. It is not the
+"cut process narration" the rule bans: teach the mechanism ("engineer owns the
+implementation, qa owns the proof"), never the play-by-play of your own tool
+calls. Every other rule above applies unchanged — teach with substance, not
+flattery.
 
 ## Error Handling
 

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
@@ -1,6 +1,7 @@
 ---
 name: trusty-mpm
 description: Trusty MPM — project-aware PM orchestration (stack-neutral; detects each project's stack per session)
+keep-coding-instructions: true
 ---
 
 # Trusty Multi-Agent PM
@@ -92,13 +93,104 @@ identity:
    directory's root — its presence means this is a tm-provisioned workspace, and your harness is
    trusty-mpm, full stop.
 
-## Communication
+## Communication — Write Plainly
 
-- **Tone**: Professional, neutral
-- **Use**: "Understood", "Confirmed", "Noted"
-- **No mocks** outside test environments
-- **No placeholders** - complete implementations only, never `todo!()` or stubs
-- **FORBIDDEN**: "Excellent!", "Perfect!", "Amazing!", "You're absolutely right!"
+Governs every artifact you author, not only your replies: responses and
+reports, agent dispatch briefs, and ticket/PR body text drafted before handing
+off to `ticketing` or `version-control`.
+
+Mirrored from `Prose Style — Write Plainly` in the appended system prompt
+(`assets/instructions/sections/core.md`), for the same reason the PRIMARY
+DIRECTIVE above is mirrored: the output style is the only channel that survives
+a manual `claude` launch with no tm-appended system prompt (issue #2647). Both
+copies are live — change one, change the other.
+
+- **Tone**: professional, neutral. "Understood", "Confirmed", "Noted".
+- **No mocks** outside test environments.
+- **No placeholders** — complete implementations only, never `todo!()` or stubs.
+
+Lead with the point: what happened, then why it matters.
+
+- Lead with the concrete referent, not its category. Name the file, the
+  function, the ruling — let the reader infer the category. "One line of code
+  the engineer chose not to change" beats "One judgment call is yours."
+- State mechanism as cause then effect, in plain verbs: "If writing the config
+  fails, the session starts anyway" beats "is still an early non-fatal return."
+- Show before-and-after when something changed: "It used to say X. Now it says
+  X, except here."
+- Cut evaluative hedges — "that's defensible, but…", "worth noting", "that
+  said". They add no fact; they only manage the reader.
+- Cut process narration — "I've asked the critic to judge whether…" becomes
+  "The critic is checking now." State what is true, not what you asked an agent
+  to do.
+- End options as a bare enumeration: "Two options: A, or B."
+- Short sentences, one idea each. Split anything carrying three commas and a
+  dash.
+- No throat-clearing openers — "Worth naming, since…", "The thing to understand
+  here is…", "Two things worth knowing…". State the fact.
+- No closing aphorisms. Never end a point or a message with a punchy line that
+  restates what was just said. Stop at the last useful sentence.
+- Plain words over inflated ones: "the merge didn't happen", not "the merge was
+  genuinely un-fired".
+- Tables and short bullets for status, not paragraphs.
+
+**Do not embellish.** No insight commentary, no delivery acknowledgement, no
+questions back. Use the simplest phrasing that works. Include only the
+explanation the owner needs in order to decide.
+
+BEFORE (wrong):
+
+> The instruction that matters most in that message: if writing the README
+> reveals the model doesn't hold together, say so rather than smoothing it
+> over. A section reachable by two paths, a tier rule that needs an exception
+> clause, an asset loaded for no nameable reason — those are findings, and
+> surfacing one counts as the exercise working.
+
+AFTER (right):
+
+> Summarize model in README.md, OK.
+
+**No praise for the user.** When the user makes a point, corrects you, or offers
+a framing: acknowledge with "OK", or disagree and say why. Never praise the
+contribution.
+
+This bans the CATEGORY — complimenting the user's thinking — not a list of
+strings. Any sentence whose subject is the quality of what the user said is
+banned however it is worded. Non-exhaustive examples:
+
+- "Correct — and that's the cleaner framing than mine."
+- "Good question."
+- "That's a better way to put it."
+- "Exactly right."
+- "Excellent!", "Perfect!", "Amazing!", "You're absolutely right!"
+
+Right: "OK." Or: "That's wrong, because X."
+
+**Delete the framing opener; lead with the fact.** The banned template is
+
+> `One <noun> that <its significance, or your relation to it>:`
+
+placed in front of a fact. It announces that something matters instead of saying
+the thing. The fix is general: delete the opener, start at the fact.
+
+Instances observed so far, as illustration only — the rule is the template
+above, never this list:
+
+- "What remains unknown, stated plainly:"
+- "One distinction worth being precise about before I push…"
+- "One thing it caught that I'd have missed:"
+- "a question I shouldn't assume the answer to"
+
+Both rules are the same family as the banned word "honest": a word or phrase
+that manages the reader instead of informing them.
+
+**Ticket and PR bodies** carry three things only: defect, evidence, resolution.
+Point at a spec section instead of restating it. Never paste a source-file table
+into a ticket — link the file and line instead.
+
+**Prose only.** This governs how something is said, never whether it is said.
+Failures, corrections, and bad news are still reported directly and in full —
+this rule shortens the wording, never the disclosure.
 
 ## Error Handling
 

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -1222,3 +1222,103 @@ fn rust_build_performance_declared_by_rust_family_agents() {
         );
     }
 }
+
+#[test]
+fn output_styles_keep_claude_code_coding_instructions() {
+    // Claude Code strips its built-in software-engineering instructions (how to
+    // scope changes, write comments, verify work) from any custom output style
+    // unless `keep-coding-instructions` is true — the field defaults to FALSE.
+    // All three bundled styles are PM-orchestration styles layered ON TOP of
+    // normal coding behaviour, so all three must opt back in.
+    for style in OUTPUT_STYLES {
+        let frontmatter = style
+            .content
+            .split("---")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{} must open with a YAML frontmatter block", style.id));
+        assert!(
+            frontmatter.contains("keep-coding-instructions: true"),
+            "{} frontmatter must set `keep-coding-instructions: true`, or Claude \
+             Code silently drops its built-in coding instructions",
+            style.id
+        );
+    }
+}
+
+#[test]
+fn output_styles_mirror_the_pm_prose_rules() {
+    // #2647: the output style is the only channel that survives a manual
+    // `claude` launch with no tm-appended system prompt, so the PM prose rules
+    // in `assets/instructions/sections/core.md` are MIRRORED here rather than
+    // referenced. Guard every load-bearing rule plus the #2647 rationale, so a
+    // future edit cannot quietly drop the mirror back to a dangling reference.
+    const REQUIRED: &[&str] = &[
+        "## Communication — Write Plainly",
+        "issue #2647",
+        "**No praise for the user.**",
+        "**Delete the framing opener; lead with the fact.**",
+        "**Do not embellish.**",
+        "the banned word \"honest\"",
+        "**Ticket and PR bodies**",
+        "never whether it is said",
+    ];
+    for style in OUTPUT_STYLES {
+        for needle in REQUIRED {
+            assert!(
+                style.content.contains(needle),
+                "{} is missing mirrored prose rule {needle:?} (#2647)",
+                style.id
+            );
+        }
+        // The superseded lighter rule set must be FOLDED IN, not left alongside
+        // the mirrored rules as a second overlapping statement of the same thing.
+        assert!(
+            !style.content.contains("**Tone**: Professional, neutral"),
+            "{}: the old Communication block must be folded into the mirrored \
+             prose rules, not duplicated beside them",
+            style.id
+        );
+    }
+}
+
+#[test]
+fn base_agent_graduated_verbosity_survives_composition() {
+    // Output styles do NOT apply to subagents (they run their own system
+    // prompt), so the sparse-on-success rule has to reach agents through
+    // BASE-AGENT.md composition instead. Assert it lands in a composed agent,
+    // and that it did not weaken the raw-output evidence rule it sits beside.
+    use crate::core::agent_builder::compose_agent;
+    use std::path::Path;
+
+    let assets_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("assets")
+        .join("agents");
+
+    let composed =
+        compose_agent("version-control", &assets_dir).expect("compose_agent must succeed");
+
+    assert!(
+        composed.contains("Verbosity scales with what went wrong"),
+        "composed agent is missing the graduated-verbosity rule"
+    );
+    assert!(
+        composed.contains("A long report about a clean run"),
+        "composed agent is missing the sparse-on-success rule"
+    );
+    // The evidence floor must survive verbatim next to it.
+    assert!(
+        composed.contains("Show raw output. Never summarise test results in your own words."),
+        "graduated verbosity must not weaken the raw-output rule"
+    );
+    assert!(
+        composed.contains("Sparse-on-success governs the"),
+        "composed agent is missing the evidence-rule carve-out"
+    );
+    // "Caveman" is taken: hooks/optimizer.toml uses it for an unrelated
+    // tool-output compression level. The prose rule must not collide with it.
+    assert!(
+        !composed.contains("Caveman"),
+        "graduated-verbosity rule must not reuse the optimizer's `Caveman` term"
+    );
+}

--- a/docs/specs/trusty-mpm-self-awareness.md
+++ b/docs/specs/trusty-mpm-self-awareness.md
@@ -414,6 +414,25 @@ because (per the Rationale below) neither alone is reliable.
   (a) is the one that catches total omission, because it inspects the launch configuration from
   outside the model's own context — see §9.
 
+**(c) Style selection and the `keep-coding-instructions` floor:**
+
+A user selects a style with `/config` → **Output style**, or by setting the `outputStyle` key
+in a settings file. The standalone `/output-style` command was deprecated in Claude Code
+v2.1.73 and removed in v2.1.91; it is not a valid selection mechanism and must not be
+referenced. Style is read once at session start, so a change lands after `/clear` or on the
+next session.
+
+Every bundled style MUST set `keep-coding-instructions: true` in its frontmatter. Claude Code
+strips its built-in software-engineering instructions (scoping, comments, verification) from
+any custom style that omits the field — it defaults to `false`. Omitting it produces a
+degradation this section's mechanism (a) cannot see: the style id resolves, the file exists,
+`tm doctor` reports `Ok`, and the session is nonetheless missing the coding floor these
+PM-orchestration styles are meant to layer on top of.
+
+Bundled styles are refreshed from the compiled bundle on deploy, so they are not a user
+customization surface — a user wanting different behavior writes their own style file under
+`~/.claude/output-styles/` (or the project's `.claude/output-styles/`) and selects that.
+
 ### Rationale (WHY)
 
 The incident's actual failure (F4) was precisely the case mechanism (b) cannot see: `outputStyle`
@@ -441,6 +460,8 @@ a fast, no-tooling way to sanity-check a live session mid-conversation.
 - `BASE_SM.md` and all three output styles contain the literal marker line
   `<!-- trusty-mpm-instructions-loaded: v1 -->` as the first line of their respective floor
   sections.
+- Every entry in `bundle::OUTPUT_STYLES` carries `keep-coding-instructions: true` in its
+  frontmatter (`bundle_tests::output_styles_keep_claude_code_coding_instructions`).
 
 ### Implementing Modules
 


### PR DESCRIPTION
## What changed

**1. The real defect — `keep-coding-instructions`.** All three bundled output styles omitted this frontmatter field. It defaults to `false`, so Claude Code was stripping its built-in software-engineering instructions (how to scope a change, write comments, verify work) from every trusty-mpm session. These are PM-orchestration styles layered *on top of* normal coding behavior, not replacements for it, so all three now set it `true`.

Verified against current Claude Code docs before writing it: the key is `keep-coding-instructions`, boolean, default `false` ([output-styles reference](https://code.claude.com/docs/en/output-styles)).

**2. PM prose rules mirrored into the styles.** The `Prose Style — Write Plainly` section of `assets/instructions/sections/core.md` is mirrored into each style's `## Communication` region — lead-with-the-point, "No praise for the user", "Delete the framing opener", the banned word "honest", the BEFORE/AFTER example, "Do not embellish", and the ticket/PR-body scoping.

`core.md` is unchanged. This is a mirror, not a move, on the same rationale the codebase already applies to the PRIMARY DIRECTIVE — `trusty-mpm.md` calls that block "this style's own self-contained floor for when that channel is absent (issue #2647)". The output style is the only channel that survives a manually launched `claude` with no tm-appended system prompt, so the rules have to exist in both places. Each mirrored block says so and names #2647.

The older, lighter `## Communication` block ("Tone: Professional, neutral", forbidden "Excellent!"/"You're absolutely right!") is **folded into** the mirrored rules rather than left beside them — the forbidden-praise strings now live as examples under "No praise for the user", where they belong.

Two carve-outs were needed and are stated explicitly, because the mirrored rules otherwise contradict what those styles exist to do:
- **teacher**: "cut process narration" would ban the teaching narration that is the style's entire point. The carve-out keeps teaching the *mechanism*, still bans play-by-play of tool calls.
- **research**: a confidence label is a fact about the evidence, not an evaluative hedge, so it survives the hedge ban.

**3. Graduated verbosity in `BASE-AGENT.md`.** Output styles do not apply to subagents — they run their own system prompt — so agents need this separately. Verbosity scales with what went wrong, not with how much work was done: a clean pass earns a line or two, a failure earns as much detail as the reader needs to act.

It does **not** weaken `Show raw output. Never summarise test results in your own words.` The addition says so directly: sparse-on-success governs the prose *around* the evidence, never the evidence itself. Raw output stays mandatory for failures, flakes, performance claims, and disputed results. "Caveman" is deliberately avoided as a term — `assets/hooks/optimizer.toml:11` already uses it for an unrelated tool-output compression level.

**4. Docs.** Extended, not duplicated. `WHAT-IS-TRUSTY-MPM.md` and DOC-28 §6 now record the current selection mechanism — `/config` → **Output style**, or the `outputStyle` settings key — plus the `keep-coding-instructions` floor and the fact that bundled styles are refreshed from the compiled bundle, so a user wanting different behavior writes their own style file instead of editing these. The standalone `/output-style` command was removed in Claude Code v2.1.91 and is not referenced.

No manifest or deployer wiring was needed: `OUTPUT_STYLES` is iterated unconditionally by both deployers, and `bundle_all.rs:107` already registers `BASE-AGENT.md` with `InstallPolicy::Overwrite`.

## Gate — Rust Test Ladder rung 3 (localized behavior, one crate)

```
cargo fmt --check && cargo check -p trusty-mpm && cargo clippy -p trusty-mpm -- -D warnings && cargo test -p trusty-mpm
```

- `cargo fmt --check` — EXIT=0
- `cargo check -p trusty-mpm` — `Finished dev profile`
- `cargo clippy -p trusty-mpm -- -D warnings` — `Finished dev profile`, zero warnings
- `cargo test -p trusty-mpm --lib` — `test result: ok. 4653 passed; 0 failed; 7 ignored` (3 consecutive clean runs)
- `cargo test -p trusty-mpm --bin tm` — `test result: ok. 1480 passed; 0 failed; 1 ignored` (3 consecutive clean runs)
- new tests — `test result: ok. 3 passed; 0 failed`
- `core::bundle::tests` module — `test result: ok. 39 passed; 0 failed`
- `scripts/check_line_cap.sh` — `0 violations — OK`
- `scripts/check_sld.sh` — `0 error(s), 0 warning(s)`
- `scripts/check_changelog_fragment.sh` — `OK trusty-mpm: changelog.d fragment present and valid`

Three regression tests in `bundle_tests.rs`, all **verified failing before the change** (assets reverted to `origin/main`, tests kept):

```
test core::bundle::tests::output_styles_mirror_the_pm_prose_rules ... FAILED
test core::bundle::tests::output_styles_keep_claude_code_coding_instructions ... FAILED
test core::bundle::tests::base_agent_graduated_verbosity_survives_composition ... FAILED
test result: FAILED. 0 passed; 3 failed
```
```
trusty-mpm frontmatter must set `keep-coding-instructions: true`, or Claude Code silently drops its built-in coding instructions
trusty-mpm is missing mirrored prose rule "## Communication — Write Plainly" (#2647)
composed agent is missing the graduated-verbosity rule
```

## Pre-existing flakes, not caused by this branch

The whole-package run (`cargo test -p trusty-mpm`, all targets) is intermittently red on this machine with a rotating cast:

- `daemon::managed_routes::tests::stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet`
- `daemon::managed_routes::tests::stale_assets_for_many_sees_an_agent_change_on_the_very_next_call`
- `core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning`

Reproduced on a **pristine `origin/main` worktree** (a08e7bd8, no changes): 2 of 3 whole-package runs failed with these same tests. This diff touches zero files under `daemon/managed_routes/` or `core/managed_config.rs`. Each passes in isolation; the first one's own doc comment documents the mechanism — the deployed-read log is process-global and load-sensitive (#4619 review). No canonical issue found for it; flagged here rather than filed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools