### PR TITLE
feat(trusty-mpm): `tm run <owner>/<repo>` cold-starts a daemon-managed session

### DIFF
--- a/crates/trusty-mpm/changelog.d/4991-tm-run-owner-repo.md
+++ b/crates/trusty-mpm/changelog.d/4991-tm-run-owner-repo.md
@@ -1,0 +1,7 @@
+Added
+
+- `tm run <owner>/<repo>` cold-starts a daemon-managed session for a repo that is not on disk yet
+  - clones to the managed checkout at `~/trusty-mpm-projects/<owner>/<repo>`, then hands off to the existing `tm launch` path — so the result is a real `SessionRecord` with a tmux pane, visible in `tm ls` and `tm sessions`, not a blocking foreground `claude`
+  - the positional is classified by the same predicate `tm register` uses, so `tm run bobmatnyc/trusty-tools` and `tm register bobmatnyc/trusty-tools` cannot disagree about what a string means; a registered alias keeps the unchanged DOC-24 standalone behaviour
+  - reusing an existing managed checkout FAILS LOUD in two cases rather than proceeding silently: its `origin` names a different repository, or its tree is dirty and so cannot be refreshed. Neither is auto-fixed, and both refuse before anything writes to the directory
+  - `tm run ./some/dir` now reports that a relative path is not a repository instead of "alias not found"

--- a/crates/trusty-mpm/changelog.d/4991-tm-run-owner-repo.md
+++ b/crates/trusty-mpm/changelog.d/4991-tm-run-owner-repo.md
@@ -3,5 +3,6 @@ Added
 - `tm run <owner>/<repo>` cold-starts a daemon-managed session for a repo that is not on disk yet
   - clones to the managed checkout at `~/trusty-mpm-projects/<owner>/<repo>`, then hands off to the existing `tm launch` path — so the result is a real `SessionRecord` with a tmux pane, visible in `tm ls` and `tm sessions`, not a blocking foreground `claude`
   - the positional is classified by the same predicate `tm register` uses, so `tm run bobmatnyc/trusty-tools` and `tm register bobmatnyc/trusty-tools` cannot disagree about what a string means; a registered alias keeps the unchanged DOC-24 standalone behaviour
-  - reusing an existing managed checkout FAILS LOUD in two cases rather than proceeding silently: its `origin` names a different repository, or its tree is dirty and so cannot be refreshed. Neither is auto-fixed, and both refuse before anything writes to the directory
+  - reusing an existing managed checkout FAILS LOUD when its `origin` names a different repository — no auto-repoint, and the refusal lands before anything writes to the directory
+  - a dirty existing checkout is not an error: the fast-forward is skipped and said so in normal output, while the fetch still runs. The session's branch is cut from a freshly-fetched `origin/<default-branch>`, so it never inherits the checkout's local `HEAD`
   - `tm run ./some/dir` now reports that a relative path is not a repository instead of "alias not found"

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
@@ -101,7 +101,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `push-guard` — Retrofit the #2867 cross-branch `pre-push` guard onto an existing clone
 - `restart` — Stop the running daemon and start a fresh one
 - `rm` — Remove a managed alias: deregister and delete its project dir (DOC-24)
-- `run` — Launch an interactive `claude` session for a managed alias (DOC-24)
+- `run` — Start a session for a GitHub repo (`<owner>/<repo>`) or a managed alias
 - `serve` — Alias for `start` — start the daemon if not running, no-op if it is
 - `services` — Inspect and probe workspace service daemons
   - `health` — Probe the health endpoint and print OK or FAIL

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -923,17 +923,31 @@ pub(crate) enum Command {
         root: Option<String>,
     },
 
-    /// Launch an interactive `claude` session for a managed alias (DOC-24).
+    /// Start a session for a GitHub repo (`<owner>/<repo>`) or a managed alias.
     ///
-    /// Why: `tm run` is the claude-mpm replacement — it launches Claude Code
-    /// with `CLAUDE_CONFIG_DIR=<root>/claude-config` so the global
-    /// hooks/MCPs are supplied and the real `~/.claude` is excluded.
-    /// What: loads the alias if needed, checks credentials, and spawns `claude`
-    /// with inherited stdio.
-    /// Test: `cli_parses_run_standalone`.
+    /// Why (#4990): `tm run` accepted only a DOC-24 registry alias, so starting
+    /// work on a repo that was neither registered nor already cloned had no
+    /// entry point. `tm run <owner>/<repo>` is that cold start, and it lands on
+    /// the DAEMON-MANAGED system (ADR-0030): the checkout goes to
+    /// `~/trusty-mpm-projects/<owner>/<repo>`, and the session is a real
+    /// `SessionRecord` with a tmux pane that shows up in `tm ls` and
+    /// `tm sessions` — not a blocking foreground `claude`.
+    /// What: a positional naming a repo (`<owner>/<repo>` with GitHub assumed,
+    /// or a full URL for any host — classified by the same predicate
+    /// `tm register` uses) clones or verifies the managed checkout, then hands
+    /// off to the `tm launch` path. A positional naming a registered alias
+    /// keeps the unchanged standalone behaviour: load if needed, check
+    /// credentials, spawn `claude` with inherited stdio and
+    /// `CLAUDE_CONFIG_DIR=<root>/claude-config`.
+    ///
+    /// Reusing an existing managed checkout FAILS LOUD when its `origin` names
+    /// a different repository, or when its tree is dirty and so cannot be
+    /// refreshed. Neither case is auto-fixed.
+    /// Test: `cli_parses_run_standalone`, `run_target_tests.rs`.
     Run {
-        /// Registered alias to run.
-        alias: String,
+        /// `<owner>/<repo>` (GitHub assumed), a full repository URL, or a
+        /// registered alias (see `tm ls --projects`).
+        target: String,
         /// Optional initial task to pre-seed (currently unused by MVP).
         #[arg(long)]
         task: Option<String>,

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -941,8 +941,14 @@ pub(crate) enum Command {
     /// `CLAUDE_CONFIG_DIR=<root>/claude-config`.
     ///
     /// Reusing an existing managed checkout FAILS LOUD when its `origin` names
-    /// a different repository, or when its tree is dirty and so cannot be
-    /// refreshed. Neither case is auto-fixed.
+    /// a different repository — trusty-mpm never re-points a remote. A DIRTY
+    /// checkout is not an error: the fast-forward is skipped, a warning naming
+    /// the path and what is uncommitted is printed, and the session starts
+    /// anyway. Its branch is cut from a freshly-fetched
+    /// `origin/<default-branch>`, so it does not inherit the checkout's state.
+    ///
+    /// `--root` applies to the alias form only. The managed checkout's location
+    /// is set by `TRUSTY_MPM_REPOS_ROOT` / `TRUSTY_MPM_WORKSPACE_ROOT`.
     /// Test: `cli_parses_run_standalone`, `run_target_tests.rs`.
     Run {
         /// `<owner>/<repo>` (GitHub assumed), a full repository URL, or a
@@ -951,11 +957,16 @@ pub(crate) enum Command {
         /// Optional initial task to pre-seed (currently unused by MVP).
         #[arg(long)]
         task: Option<String>,
-        /// Override the managed root (default: `~/.trusty-mpm`).
+        /// Override the managed root (default: `~/.trusty-mpm`). ALIAS FORM ONLY.
         ///
         /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >
         /// `[standalone] root` in `$XDG_CONFIG_HOME/trusty-mpm/config.toml` >
         /// default `~/.trusty-mpm`.
+        ///
+        /// With an `<owner>/<repo>` target this root is not consulted — the
+        /// managed checkout lives under `TRUSTY_MPM_REPOS_ROOT` /
+        /// `TRUSTY_MPM_WORKSPACE_ROOT` instead — so passing it there warns
+        /// rather than being silently ignored.
         ///
         /// Note: do NOT use `env = "TRUSTY_MPM_ROOT"` here — see `Register`.
         #[arg(long)]

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -74,6 +74,7 @@ pub(crate) mod reconcile_worktrees;
 pub(crate) mod register_args;
 pub(crate) mod rename;
 pub(crate) mod repair;
+pub(crate) mod run_target;
 pub(crate) mod serve_stdio;
 pub(crate) mod services;
 pub(crate) mod sessctl;

--- a/crates/trusty-mpm/src/bin/tm/commands/register_args.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/register_args.rs
@@ -146,8 +146,11 @@ fn is_name_segment(s: &str) -> bool {
 /// disjointness holds — a valid alias matches `^[a-z0-9][a-z0-9._-]*$`
 /// (`validate_alias` in `core::standalone::registry`), so it can never contain
 /// the `/` or `:` every repo form requires.
+/// #4990: `tm run` shares this predicate so `tm run <owner>/<repo>` and
+/// `tm register <owner>/<repo>` cannot disagree about what a string names.
+/// A positional this rejects is a DOC-24 registry alias to `tm run`.
 /// Test: `looks_like_repo_rejects_aliases`, `two_args_legacy_alias_first`.
-fn looks_like_repo(s: &str) -> bool {
+pub(crate) fn looks_like_repo(s: &str) -> bool {
     matches!(
         classify(s),
         Positional::Url(_) | Positional::Shorthand { .. }
@@ -202,13 +205,28 @@ pub(crate) fn resolve_register_args(
     }
 }
 
+/// True when a positional is a relative path (`./x`, `../x`, `.hidden/x`).
+///
+/// Why (#4990): `tm run` has to tell a repo from a REGISTRY ALIAS, and
+/// [`looks_like_repo`] alone cannot: it answers `false` for a relative path,
+/// which would route `tm run ./some/dir` into an alias lookup and report
+/// "alias './some/dir' not found" instead of the path advice [`rejection`]
+/// already carries. A relative path is neither — an alias matches
+/// `^[a-z0-9][a-z0-9._-]*$` and can never start with a dot.
+/// What: `true` for exactly the [`Positional::RelativePath`] arm.
+/// Test: `classify_rejects_browser_pastes_and_paths` (in `run_target_tests.rs`),
+/// `relative_paths_are_never_shorthand`.
+pub(crate) fn is_relative_path(s: &str) -> bool {
+    matches!(classify(s.trim()), Positional::RelativePath)
+}
+
 /// Build the error for a positional that does not name a repository.
 ///
 /// Why: the message is the remedy. A relative path and a bare word fail for
 /// different reasons and need different advice.
 /// Test: `relative_paths_are_never_shorthand`, `one_arg_non_repo_errors`,
 /// `two_non_urls_error`.
-fn rejection(s: &str) -> anyhow::Error {
+pub(crate) fn rejection(s: &str) -> anyhow::Error {
     match classify(s) {
         Positional::RelativePath => anyhow::anyhow!(
             "'{s}' is a relative path, not a repository. It would be resolved \
@@ -240,7 +258,11 @@ fn rejection(s: &str) -> anyhow::Error {
 /// `browser_paste_shapes_are_rejected`, `github_tab_urls_are_rejected`,
 /// `query_and_fragment_are_stripped`, `scheme_less_host_gains_https`,
 /// `home_relative_path_is_expanded`.
-fn resolved_url(s: &str) -> anyhow::Result<String> {
+///
+/// #4990: `tm run <owner>/<repo>` resolves its clone URL through this same
+/// function, so the string `tm register` would store is the string `tm run`
+/// clones.
+pub(crate) fn resolved_url(s: &str) -> anyhow::Result<String> {
     let url: String = match classify(s) {
         // #4912: GitHub is assumed for shorthand; the stored value must be
         // clone-able, so the host goes on here rather than at clone time.

--- a/crates/trusty-mpm/src/bin/tm/commands/run_target.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/run_target.rs
@@ -106,9 +106,17 @@ pub(crate) fn classify_run_target(spec: &str) -> anyhow::Result<RunTarget> {
 /// Why: one command, two subsystems. Keeping the branch here rather than in
 /// `main.rs` keeps the dispatch table flat and gives the routing decision a
 /// testable home.
-/// What: warns about the unimplemented `--task`, classifies the target, and
+/// What: warns about flags that do not apply, classifies the target, and
 /// dispatches — alias to `core::standalone`'s driver (unchanged), repo to
 /// [`run_managed`].
+///
+/// Two flags reach an arm that cannot use them, and BOTH warn rather than being
+/// dropped silently. `--task` is unimplemented on either arm. `--root` selects
+/// the DOC-24 managed root, which the daemon-managed arm never consults: its
+/// checkout location comes from `repos_root()` (`TRUSTY_MPM_REPOS_ROOT` >
+/// `TRUSTY_MPM_WORKSPACE_ROOT` > config > `~/trusty-mpm-projects`), a different
+/// setting entirely. A user passing `--root` there is trying to relocate the
+/// checkout and would otherwise get no hint that it had no effect.
 /// Test: `classify_sorts_alias_from_repo` covers the routing decision; the
 /// managed arm's checkout half is covered by
 /// `daemon::managed_routes::inproject_cold_start` tests.
@@ -138,7 +146,16 @@ pub(crate) async fn run(
             owner,
             repo,
             clone_url,
-        } => run_managed(client, url, &owner, &repo, &clone_url).await,
+        } => {
+            if let Some(r) = &root {
+                eprintln!(
+                    "warning: --root '{r}' does not apply to a <owner>/<repo> target and will \
+                     be ignored. It selects the standalone managed root; the managed checkout \
+                     location comes from TRUSTY_MPM_REPOS_ROOT / TRUSTY_MPM_WORKSPACE_ROOT."
+                );
+            }
+            run_managed(client, url, &owner, &repo, &clone_url).await
+        }
     }
 }
 
@@ -150,11 +167,13 @@ pub(crate) async fn run(
 /// What: (1) ensures the managed base clone at
 /// `<repos_root>/<owner>/<repo>` via
 /// [`trusty_mpm::daemon::managed_routes::inproject_cold_start::ensure_managed_checkout`],
-/// which clones when absent and fails loud on a mismatched remote or a dirty
-/// tree; (2) hands that directory to [`super::launch::launch`], the existing
-/// daemon-managed launch path — which registers the project alias, provisions
-/// the per-session worktree, prepares the session, registers the session with
-/// the daemon, creates the tmux host, and attaches.
+/// which clones when absent and fails loud on a mismatched remote — a dirty
+/// tree is NOT a failure there, it reports a skipped fast-forward through
+/// `ManagedCheckout::refresh_skipped`, which this function prints; (2) hands
+/// that directory to [`super::launch::launch`], the existing daemon-managed
+/// launch path — which registers the project alias, provisions the per-session
+/// worktree, prepares the session, registers the session with the daemon,
+/// creates the tmux host, and attaches.
 ///
 /// Step 2 is a HANDOFF, not a reimplementation: everything after the checkout
 /// exists already and is shared with `tm launch`, so a managed session started

--- a/crates/trusty-mpm/src/bin/tm/commands/run_target.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/run_target.rs
@@ -1,0 +1,198 @@
+//! `tm run <target>` routing: DOC-24 alias vs. daemon-managed cold start (#4990).
+//!
+//! Why: `tm run` used to accept exactly one thing — a DOC-24 registry alias —
+//! and launch a blocking foreground `claude` for it. Starting work on a repo
+//! that is not already registered and not already on disk had no entry point
+//! at all: the daemon-managed system (ADR-0030's tm checkout at
+//! `~/trusty-mpm-projects/<owner>/<repo>`, a real `SessionRecord`, a tmux pane)
+//! can only be entered from a checkout that already exists, because
+//! `try_inproject_spawn` gates on `.git` and derives the GitHub identity from
+//! `remote.origin.url`. `tm run <owner>/<repo>` is the cold start: clone or
+//! verify the managed checkout, then hand off to the daemon-managed launch.
+//!
+//! What: [`classify_run_target`] sorts the positional using the SAME predicate
+//! `tm register` uses ([`super::register_args::looks_like_repo`]) so the two
+//! commands cannot disagree about what a string means; [`run`] dispatches an
+//! alias to the unchanged standalone driver and a repo to [`run_managed`],
+//! which drives [`trusty_mpm::daemon::managed_routes::inproject_cold_start`]
+//! and then the existing [`super::launch::launch`] path.
+//! Test: `run_target_tests.rs`.
+
+use trusty_common::github_path::{parse_github_path, parse_owner_repo};
+
+/// What a `tm run` positional names.
+///
+/// Why: the positional now carries two disjoint meanings, and the disjointness
+/// is real rather than assumed — a DOC-24 alias matches
+/// `^[a-z0-9][a-z0-9._-]*$` (`core::standalone::registry::validate_alias`), so
+/// it can never contain the `/` or `:` every repo form requires.
+/// What: `Alias` is the pre-existing standalone target; `Repo` carries the
+/// resolved GitHub identity and the URL to clone.
+/// Test: `classify_sorts_alias_from_repo`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RunTarget {
+    /// A DOC-24 registry alias — the unchanged standalone `tm run <alias>`.
+    Alias(String),
+    /// A GitHub repo to cold-start under daemon management.
+    Repo {
+        /// Slugified repository owner.
+        owner: String,
+        /// Slugified repository name.
+        repo: String,
+        /// Fully-resolved clone URL.
+        clone_url: String,
+    },
+}
+
+/// Sort a `tm run` positional into the case that decides its outcome.
+///
+/// Why: routing has to happen before any I/O, so an unparseable repo string is
+/// rejected with a usable message rather than becoming a `git clone` that
+/// fails minutes later — or, worse, a registry lookup for an alias that was
+/// never meant to be one.
+/// What: delegates the repo-or-not question to
+/// [`super::register_args::looks_like_repo`] and the URL resolution to
+/// [`super::register_args::resolved_url`], so `tm run` inherits every rejection
+/// `tm register` makes (browser pastes into a repo's web UI, relative paths,
+/// host-only URLs). Identity comes from
+/// [`trusty_common::github_path::parse_owner_repo`] for the `owner/repo`
+/// shorthand — the shared, tested primitive for a canonical identity path —
+/// falling back to [`trusty_common::github_path::parse_github_path`] for a full
+/// URL, which `parse_owner_repo` refuses by design.
+/// Test: `classify_sorts_alias_from_repo`, `classify_resolves_shorthand`,
+/// `classify_resolves_full_urls`, `classify_rejects_browser_pastes`,
+/// `shorthand_identity_agrees_with_url_identity`.
+pub(crate) fn classify_run_target(spec: &str) -> anyhow::Result<RunTarget> {
+    let spec = spec.trim();
+    if spec.is_empty() {
+        anyhow::bail!(
+            "tm run needs a target. Pass <owner>/<repo> to start a managed session for a \
+             GitHub repo, or a registered alias (see `tm ls --projects`)."
+        );
+    }
+
+    // A relative path is neither a repo nor an alias, and `looks_like_repo`
+    // answers `false` for it — so without this arm `tm run ./some/dir` would
+    // become a registry lookup and report "alias not found" instead of the
+    // path advice. An alias matches `^[a-z0-9][a-z0-9._-]*$` and can never
+    // start with a dot.
+    if super::register_args::is_relative_path(spec) {
+        return Err(super::register_args::rejection(spec));
+    }
+
+    if !super::register_args::looks_like_repo(spec) {
+        return Ok(RunTarget::Alias(spec.to_string()));
+    }
+
+    let clone_url = super::register_args::resolved_url(spec)?;
+    let gh = parse_owner_repo(spec)
+        .or_else(|| parse_github_path(&clone_url))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "cannot derive an owner/repo identity from '{spec}'. \
+                 Pass <owner>/<repo>, or a full repository URL."
+            )
+        })?;
+
+    Ok(RunTarget::Repo {
+        owner: gh.owner,
+        repo: gh.repo,
+        clone_url,
+    })
+}
+
+/// `tm run` handler.
+///
+/// Why: one command, two subsystems. Keeping the branch here rather than in
+/// `main.rs` keeps the dispatch table flat and gives the routing decision a
+/// testable home.
+/// What: warns about the unimplemented `--task`, classifies the target, and
+/// dispatches — alias to `core::standalone`'s driver (unchanged), repo to
+/// [`run_managed`].
+/// Test: `classify_sorts_alias_from_repo` covers the routing decision; the
+/// managed arm's checkout half is covered by
+/// `daemon::managed_routes::inproject_cold_start` tests.
+pub(crate) async fn run(
+    client: &reqwest::Client,
+    url: &str,
+    target: &str,
+    task: Option<String>,
+    root: Option<String>,
+) -> anyhow::Result<()> {
+    // `--task` is not implemented on either arm. Per DOC-24 autonomous/task
+    // dispatch is the session-manager layer's concern; warn rather than drop
+    // the flag silently.
+    if let Some(ref t) = task {
+        eprintln!(
+            "warning: --task '{t}' is not yet implemented and will be ignored. \
+             Task dispatch is handled by the session-manager layer."
+        );
+    }
+
+    match classify_run_target(target)? {
+        RunTarget::Alias(alias) => {
+            let paths = super::managed_root::resolve_managed_paths(root.as_deref())?;
+            super::standalone::run_cmd(&paths, &alias)
+        }
+        RunTarget::Repo {
+            owner,
+            repo,
+            clone_url,
+        } => run_managed(client, url, &owner, &repo, &clone_url).await,
+    }
+}
+
+/// Cold-start a daemon-managed session for a GitHub `owner/repo`.
+///
+/// Why: this is the whole point of #4990 — a bare string ends in a real
+/// `SessionRecord` with a tmux pane, visible in `tm ls` and `tm sessions`, not
+/// a blocking foreground `claude`.
+/// What: (1) ensures the managed base clone at
+/// `<repos_root>/<owner>/<repo>` via
+/// [`trusty_mpm::daemon::managed_routes::inproject_cold_start::ensure_managed_checkout`],
+/// which clones when absent and fails loud on a mismatched remote or a dirty
+/// tree; (2) hands that directory to [`super::launch::launch`], the existing
+/// daemon-managed launch path — which registers the project alias, provisions
+/// the per-session worktree, prepares the session, registers the session with
+/// the daemon, creates the tmux host, and attaches.
+///
+/// Step 2 is a HANDOFF, not a reimplementation: everything after the checkout
+/// exists already and is shared with `tm launch`, so a managed session started
+/// cold is indistinguishable from one started from a local checkout.
+/// Test: the checkout half is covered by the `inproject_cold_start` tests and
+/// `tests/inproject_cold_start.rs`; the launch half is `tm launch`'s existing
+/// coverage.
+async fn run_managed(
+    client: &reqwest::Client,
+    url: &str,
+    owner: &str,
+    repo: &str,
+    clone_url: &str,
+) -> anyhow::Result<()> {
+    let checkout =
+        trusty_mpm::daemon::managed_routes::inproject_cold_start::ensure_managed_checkout(
+            owner, repo, clone_url,
+        )
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    if checkout.reused {
+        eprintln!(
+            "tm: reusing managed checkout {}",
+            checkout.base_path.display()
+        );
+    } else {
+        eprintln!("tm: cloned {clone_url} → {}", checkout.base_path.display());
+    }
+
+    super::launch::launch(
+        client,
+        url,
+        Some(checkout.base_path.to_string_lossy().into_owned()),
+        None,
+    )
+    .await
+}
+
+#[cfg(test)]
+#[path = "run_target_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/run_target.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/run_target.rs
@@ -60,7 +60,7 @@ pub(crate) enum RunTarget {
 /// falling back to [`trusty_common::github_path::parse_github_path`] for a full
 /// URL, which `parse_owner_repo` refuses by design.
 /// Test: `classify_sorts_alias_from_repo`, `classify_resolves_shorthand`,
-/// `classify_resolves_full_urls`, `classify_rejects_browser_pastes`,
+/// `classify_resolves_full_urls`, `classify_rejects_browser_pastes_and_paths`,
 /// `shorthand_identity_agrees_with_url_identity`.
 pub(crate) fn classify_run_target(spec: &str) -> anyhow::Result<RunTarget> {
     let spec = spec.trim();
@@ -182,6 +182,21 @@ async fn run_managed(
         );
     } else {
         eprintln!("tm: cloned {clone_url} → {}", checkout.base_path.display());
+    }
+
+    // A skipped fast-forward must be VISIBLE, not just logged. `pull_ff_only`
+    // (`core::standalone::load.rs`) is the shape to avoid: it warns where nobody
+    // looks and returns Ok, so a stale checkout reads as a refreshed one.
+    if let Some(reason) = &checkout.refresh_skipped {
+        eprintln!(
+            "tm: warning: did NOT fast-forward {} — {reason}",
+            checkout.base_path.display()
+        );
+        eprintln!(
+            "tm:          the session's branch is cut from a freshly-fetched \
+             origin/<default-branch>, so it is unaffected (#4957). \
+             The checkout itself stays where you left it."
+        );
     }
 
     super::launch::launch(

--- a/crates/trusty-mpm/src/bin/tm/commands/run_target_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/run_target_tests.rs
@@ -1,0 +1,161 @@
+//! Unit tests for `tm run` target classification (#4990).
+//!
+//! Why: classification decides which subsystem a `tm run` invocation reaches,
+//! and it must happen before any network call — a bad `owner/repo` string has
+//! to be rejected with a usable message, not become a `git clone` that fails
+//! minutes later. It must also agree with `tm register`, or the same string
+//! would name two different things depending on which command saw it.
+//! What: the alias/repo split, shorthand and full-URL resolution, the
+//! rejections inherited from `tm register`, and the agreement between the two
+//! identity primitives.
+//! Test: this file IS the test module.
+
+use super::*;
+
+/// The routing decision itself: an alias goes to the standalone driver, a
+/// repo shape goes to the daemon-managed cold start.
+///
+/// Why: the two arms are disjoint by construction — a DOC-24 alias matches
+/// `^[a-z0-9][a-z0-9._-]*$`, so it can never contain the `/` a repo form
+/// requires. This pins that disjointness rather than trusting it.
+/// Test: itself.
+#[test]
+fn classify_sorts_alias_from_repo() {
+    for alias in ["my-project", "trusty-tools", "a", "x.y_z-1"] {
+        assert_eq!(
+            classify_run_target(alias).expect("alias classifies"),
+            RunTarget::Alias(alias.to_string()),
+            "{alias} must route to the standalone driver"
+        );
+    }
+
+    let target = classify_run_target("bobmatnyc/trusty-tools").expect("shorthand classifies");
+    assert!(
+        matches!(target, RunTarget::Repo { .. }),
+        "owner/repo must route to the managed cold start, got {target:?}"
+    );
+}
+
+/// `owner/repo` resolves to the GitHub URL `tm register` would store.
+///
+/// Why: the brief's headline case, and the exact string this later hands to
+/// `git clone`.
+/// Test: itself.
+#[test]
+fn classify_resolves_shorthand() {
+    let target = classify_run_target("bobmatnyc/trusty-tools").expect("classifies");
+    assert_eq!(
+        target,
+        RunTarget::Repo {
+            owner: "bobmatnyc".into(),
+            repo: "trusty-tools".into(),
+            clone_url: "https://github.com/bobmatnyc/trusty-tools".into(),
+        }
+    );
+}
+
+/// A full URL — SSH or HTTPS, any host — resolves to the same identity shape.
+///
+/// Why: `parse_owner_repo` refuses URL-shaped input by design, so this is the
+/// `parse_github_path` fallback arm. Without it a full URL would be rejected.
+/// Test: itself.
+#[test]
+fn classify_resolves_full_urls() {
+    let ssh = classify_run_target("git@github.com:bobmatnyc/trusty-tools.git").expect("ssh");
+    assert_eq!(
+        ssh,
+        RunTarget::Repo {
+            owner: "bobmatnyc".into(),
+            repo: "trusty-tools".into(),
+            clone_url: "git@github.com:bobmatnyc/trusty-tools.git".into(),
+        }
+    );
+
+    let https = classify_run_target("https://gitlab.com/acme/widget.git").expect("https");
+    assert_eq!(
+        https,
+        RunTarget::Repo {
+            owner: "acme".into(),
+            repo: "widget".into(),
+            clone_url: "https://gitlab.com/acme/widget.git".into(),
+        }
+    );
+}
+
+/// AGREEMENT: for shorthand, the identity primitive this module uses matches
+/// the one derived from the resolved URL.
+///
+/// Why: `classify_run_target` prefers `parse_owner_repo` and falls back to
+/// `parse_github_path`. Two derivations is one more than the number that can
+/// silently drift, so the property that they agree is pinned here rather than
+/// assumed. If it ever fails, `tm run owner/repo` and `tm register owner/repo`
+/// would resolve to different directories.
+/// Test: itself.
+#[test]
+fn shorthand_identity_agrees_with_url_identity() {
+    for spec in [
+        "bobmatnyc/trusty-tools",
+        "Acme/Cool_App",
+        "123/repo",
+        "a-b/c.d",
+    ] {
+        let url = crate::commands::register_args::resolved_url(spec).expect("resolves");
+        let from_shorthand = parse_owner_repo(spec).expect("shorthand parses");
+        let from_url = parse_github_path(&url).expect("url parses");
+        assert_eq!(
+            from_shorthand, from_url,
+            "identity for '{spec}' must not depend on which parser saw it"
+        );
+    }
+}
+
+/// INVALID INPUT IS REJECTED BEFORE ANY NETWORK CALL.
+///
+/// Why: `classify_run_target` is pure — it runs no git, opens no socket. These
+/// strings therefore fail with a message while a user is still watching, which
+/// is the whole reason the rejection lives at the CLI boundary and not at
+/// clone time. The specific shapes are inherited from `tm register`: a browser
+/// paste into a repo's web UI, a relative path, and a host with no repo.
+/// Test: itself.
+#[test]
+fn classify_rejects_browser_pastes_and_paths() {
+    for (bad, expected) in [
+        (
+            "https://github.com/bobmatnyc/trusty-tools/pull/4990",
+            "points inside a repository",
+        ),
+        (
+            "https://github.com/bobmatnyc/trusty-tools/tree/main",
+            "points inside a repository",
+        ),
+        // A relative path is neither a repo nor an alias. Routing it to the
+        // registry would report "alias './some/dir' not found", which names
+        // the wrong problem — the regression this case pins.
+        ("./some/dir", "is a relative path"),
+        ("../sibling", "is a relative path"),
+        ("https://github.com", "names a host"),
+    ] {
+        let err = match classify_run_target(bad) {
+            Err(e) => e.to_string(),
+            Ok(t) => panic!("'{bad}' must be refused before any network call, got {t:?}"),
+        };
+        assert!(
+            err.contains(expected),
+            "rejection of '{bad}' must say '{expected}', got: {err}"
+        );
+    }
+}
+
+/// An empty or whitespace-only target names nothing and must say so.
+///
+/// Test: itself.
+#[test]
+fn classify_rejects_empty_target() {
+    for empty in ["", "   ", "\t"] {
+        let err = classify_run_target(empty).expect_err("empty must be refused");
+        assert!(
+            err.to_string().contains("needs a target"),
+            "message must name the remedy: {err}"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/run_target_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/run_target_tests.rs
@@ -82,6 +82,30 @@ fn classify_resolves_full_urls() {
     );
 }
 
+/// An absolute local path is a clone source, and its identity comes from the
+/// last TWO path segments.
+///
+/// Why: `classify` sorts a leading `/` as a `Url`, so `tm run
+/// /Users/me/code/app` is accepted and clones from that local repo. The
+/// identity is then `code/app` — `owner` is the PARENT DIRECTORY name, not a
+/// GitHub owner — so the managed checkout lands at
+/// `<repos_root>/code/app`. That is deterministic and harmless, but it is
+/// surprising enough to pin: a future change to the fallback order would
+/// silently relocate an existing operator's checkout.
+/// Test: itself.
+#[test]
+fn absolute_path_derives_identity_from_the_last_two_segments() {
+    let target = classify_run_target("/Users/me/code/app").expect("absolute path classifies");
+    assert_eq!(
+        target,
+        RunTarget::Repo {
+            owner: "code".into(),
+            repo: "app".into(),
+            clone_url: "/Users/me/code/app".into(),
+        }
+    );
+}
+
 /// AGREEMENT: for shorthand, the identity primitive this module uses matches
 /// the one derived from the resolved URL.
 ///

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -585,20 +585,12 @@ async fn main() -> anyhow::Result<()> {
             let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
             commands::standalone::load_cmd(&paths, &alias)
         }
-        Some(Command::Run { alias, task, root }) => {
-            // F5: --task is not yet implemented in the MVP standalone driver.
-            // Per spec (DOC-24), autonomous/task dispatch is the session-manager
-            // layer, not `tm run`. Warn clearly so the flag is not silently
-            // dropped without user awareness.
-            if let Some(ref t) = task {
-                eprintln!(
-                    "warning: --task '{t}' is not yet implemented in the standalone MVP \
-                     and will be ignored. Task dispatch is handled by the session-manager \
-                     layer (a future phase of DOC-24)."
-                );
-            }
-            let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;
-            commands::standalone::run_cmd(&paths, &alias)
+        // #4990: `tm run` now carries two disjoint targets. A repo shape
+        // (`<owner>/<repo>` or a full URL) cold-starts a DAEMON-MANAGED session;
+        // a registry alias keeps the unchanged DOC-24 standalone behaviour. The
+        // routing decision lives in `run_target` so it is unit-testable.
+        Some(Command::Run { target, task, root }) => {
+            commands::run_target::run(&client, &url, &target, task, root).await
         }
         Some(Command::Path { alias, root }) => {
             let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;

--- a/crates/trusty-mpm/src/daemon/managed_routes/delete.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/delete.rs
@@ -1,0 +1,85 @@
+//! Record-deletion route handlers for managed sessions (#2012).
+//!
+//! Why: split out of `managed_routes/mod.rs`, which had grown to exactly the
+//! 500-SLOC production cap and could not accept another module declaration.
+//! These two handlers are one cohesive concept — removing a session from the
+//! operator's list — and are the only handlers in that file that never touch
+//! the runtime or the workspace, so they detach cleanly.
+//! What: [`delete_managed_session`] soft-deletes the RECORD;
+//! [`stop_managed_session`] is the legacy `DELETE` alias that delegates to
+//! runtime-stop. Both are re-exported from the parent so route wiring and
+//! external callers keep their existing paths.
+//! Test: `delete_route_marks_deleted`, `delete_route_refuses_running_without_force`,
+//! `delete_route_force_bypasses_guard` in `managed_routes::tests`.
+
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Path as AxumPath, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+
+use super::{
+    DeleteQuery, DeleteResponse, parse_id, record_to_summary, stop_managed_session_runtime,
+};
+use crate::daemon::state::DaemonState;
+
+/// POST /api/v1/sessions/managed/{id}/delete — soft-delete the RECORD, mark `--deleted--` (#2012).
+///
+/// Why: distinct from `decommission` (stop runtime + maybe remove workspace +
+/// `Decommissioned` tombstone) — this marks the record `Deleted` (rendered
+/// `--deleted--`) so the operator's master list REFLECTS the deletion instead
+/// of the row vanishing, honouring the "fully-tracked lifecycle" standard.
+/// Fail-closed: a RUNNING session (`Active`/`Provisioning`) is refused unless
+/// `?force=true`.
+/// What: parses the id and the `force` query flag, delegates to
+/// [`crate::session_manager::SessionManager::delete_record`], and maps its
+/// result — `Ok` → 200 with the pre-deletion [`DeleteResponse`] snapshot;
+/// `SessionNotFound` → 404; `InvalidState` (the running-guard refusal) → 409
+/// with the manager's actionable message; any other error → 500. NEVER
+/// touches the workspace directory on disk (see `delete_record`'s doc).
+/// Test: `delete_route_marks_deleted`, `delete_route_refuses_running_without_force`,
+/// `delete_route_force_bypasses_guard` in managed_routes tests.
+pub async fn delete_managed_session(
+    State(state): State<Arc<DaemonState>>,
+    AxumPath(id_str): AxumPath<String>,
+    axum::extract::Query(q): axum::extract::Query<DeleteQuery>,
+) -> impl IntoResponse {
+    let id = match parse_id(&id_str) {
+        Ok(id) => id,
+        Err((code, msg)) => return (code, msg).into_response(),
+    };
+    let mgr = state.session_manager().await;
+    match mgr.delete_record(&id, q.force).await {
+        Ok(record) => Json(DeleteResponse {
+            summary: record_to_summary(&record),
+            deleted: true,
+        })
+        .into_response(),
+        Err(crate::session_manager::ManagedError::SessionNotFound(_)) => {
+            (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
+        }
+        Err(crate::session_manager::ManagedError::InvalidState(_, reason)) => {
+            (StatusCode::CONFLICT, reason).into_response()
+        }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+/// DELETE /api/v1/sessions/managed/{id} — stop and deregister (legacy alias).
+///
+/// Why: the original MVP wired DELETE to a "stop" that marked the record Dead.
+/// The new semantic is `POST /{id}/runtime-stop` (keep workspace) and
+/// `POST /{id}/decommission` (full teardown). This handler now delegates to
+/// `runtime-stop` (marks Stopped, keeps workspace) so existing scripts that use
+/// DELETE do not experience data loss.
+/// What: delegates to SessionManager::stop.
+/// Test: covered by `stop_managed_session_runtime` tests.
+pub async fn stop_managed_session(
+    State(state): State<Arc<DaemonState>>,
+    AxumPath(id_str): AxumPath<String>,
+) -> impl IntoResponse {
+    stop_managed_session_runtime(State(state), AxumPath(id_str)).await
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject_cold_start.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject_cold_start.rs
@@ -11,57 +11,72 @@
 //!
 //! What: [`ensure_managed_checkout`] resolves `<repos_root>/<owner>/<repo>` via
 //! [`super::inproject::base_clone_path`] and drives
-//! [`super::inproject::ensure_base_clone`] against it, returning the path and
-//! whether an existing checkout was reused. Reuse is gated by two checks that
-//! FAIL LOUD rather than proceeding:
+//! [`super::inproject::ensure_base_clone`] against it, returning the path,
+//! whether an existing checkout was reused, and whether its fast-forward was
+//! skipped. Reusing an existing checkout has two distinct outcomes, and the
+//! difference between them is deliberate:
 //!
-//! 1. **Remote mismatch.** An existing checkout whose `origin` names a
-//!    different repository is an error. trusty-mpm never re-points a remote —
-//!    doing so silently would make `tm run <owner>/<repo>` operate on some
-//!    other repository under that repository's name.
-//! 2. **Dirty tree.** An existing checkout with uncommitted changes cannot be
-//!    refreshed, so it is an error rather than a silent no-op on stale
-//!    content. This is the shape `core::standalone::load::pull_ff_only` gets
-//!    wrong: it warns and returns `Ok(())`, so a failed refresh is
-//!    indistinguishable from a successful one.
+//! 1. **Remote mismatch → FAIL LOUD.** An existing checkout whose `origin`
+//!    names a different repository is an error. trusty-mpm never re-points a
+//!    remote: doing so silently would make `tm run <owner>/<repo>` operate on
+//!    some other repository under that repository's name, and every future
+//!    pull would keep coming from the wrong place.
+//! 2. **Dirty tree → WARN AND PROCEED.** A dirty tree cannot be
+//!    fast-forwarded, so the fast-forward is skipped and the operator is told
+//!    so in normal output. It is NOT an error, because since #4957 the session
+//!    branch is cut from a freshly-fetched `origin/<default>`
+//!    ([`super::inproject_start_point::resolve`]) and never inherits the base
+//!    checkout's local `HEAD` — so a skipped fast-forward cannot leak stale
+//!    content into the session. The tm checkout is shared with the operator and
+//!    their editors, which makes uncommitted content its expected steady state
+//!    (ADR-0030 §4/§5); refusing there would block the common case to guard
+//!    against nothing.
 //!
-//! Only after both clear does the refresh run, through
+//! What must never happen is SILENCE. The failure shape this module exists to
+//! avoid is `core::standalone::load::pull_ff_only`, which warns at a level
+//! nobody reads and returns `Ok(())`, leaving a failed refresh
+//! indistinguishable from a successful one at the call site. Here the skip is
+//! both `warn!`-logged and returned to the caller in
+//! [`ManagedCheckout::refresh_skipped`] so the CLI can print it.
+//!
+//! Either way the refresh still runs through
 //! [`super::inproject_hygiene::run_hygiene_for_base`] — the crate's single
-//! non-destructive base-clone refresh (fetch, gated fast-forward, worktree
-//! prune). Its own gates then have nothing left to decline for.
+//! non-destructive base-clone refresh. Its fetch is unconditional (which is
+//! what keeps `origin/<default>` current) and only its fast-forward is gated,
+//! matching ADR-0030 §4 exactly.
 //!
-//! Test: `inproject_cold_start_tests.rs` (pure canonicalization + the two
-//! loud-failure paths against real temp git repos);
-//! `tests/inproject_cold_start.rs` (fresh clone → the shape
+//! Test: `inproject_cold_start_tests.rs` (pure canonicalization, the
+//! remote-mismatch refusal, and the dirty warn-and-proceed path against real
+//! temp git repos); `tests/inproject_cold_start.rs` (fresh clone → the shape
 //! `try_inproject_spawn` requires).
 
 use std::path::{Path, PathBuf};
 
-use tracing::info;
+use tracing::{info, warn};
 
 use super::{inproject, inproject_hygiene};
 
-/// How many working-tree entries a [`ColdStartError::DirtyCheckout`] message
-/// lists before it summarises the rest.
+/// How many working-tree entries a skipped-refresh notice lists before it
+/// summarises the rest.
 ///
-/// Why: a managed checkout can be thousands of lines dirty; an error that
-/// scrolls the terminal hides its own first line, which is the remedy.
+/// Why: a managed checkout can be thousands of lines dirty; a notice that
+/// scrolls the terminal hides its own first line, which is the point.
 /// What: `10`.
 /// Test: `dirty_message_truncates_long_status`.
 const DIRTY_ENTRY_PREVIEW: usize = 10;
 
 /// Why a cold start refused. Every variant is a loud stop, never a warning.
 ///
-/// Why: the two reuse hazards this module exists to close are both
-/// silent-success shapes elsewhere in the codebase, so they are modelled as
-/// errors that carry the offending path and what is wrong with it — not as
-/// booleans a caller could ignore.
-/// What: `RemoteMismatch` and `DirtyCheckout` are the two decided fail-loud
-/// cases; `NoOrigin` and `StatusUnavailable` are the fail-safe directions for
-/// a checkout whose state cannot be established; `Provision` wraps the
+/// Why: a checkout whose IDENTITY cannot be confirmed is the one hazard no
+/// warning can cover — proceeding would operate on the wrong repository under
+/// the requested one's name. A dirty tree is deliberately NOT here: it is
+/// reported through [`ManagedCheckout::refresh_skipped`] instead, because the
+/// session branch never inherits the base checkout's `HEAD` (module docs).
+/// What: `RemoteMismatch` when `origin` names another repository; `NoOrigin`
+/// when there is no `origin` to compare at all; `Provision` wraps the
 /// underlying clone/hygiene failure verbatim.
 /// Test: `existing_checkout_on_a_different_remote_fails_loud`,
-/// `dirty_existing_checkout_fails_loud`.
+/// `existing_checkout_without_an_origin_fails_loud`.
 #[derive(Debug, thiserror::Error)]
 pub enum ColdStartError {
     /// The existing managed checkout belongs to a different repository.
@@ -81,21 +96,6 @@ pub enum ColdStartError {
         requested: String,
     },
 
-    /// The existing managed checkout has uncommitted changes.
-    #[error(
-        "managed checkout {} has uncommitted changes, so it cannot be refreshed:\n{}\n\
-         Refusing to start a session on content that may be stale. Commit, stash, or \
-         discard those changes and run the command again.",
-        .path.display(),
-        summarize_entries(.entries)
-    )]
-    DirtyCheckout {
-        /// The managed checkout that was inspected.
-        path: PathBuf,
-        /// `git status --porcelain` lines, verbatim.
-        entries: Vec<String>,
-    },
-
     /// The existing managed checkout has no `remote.origin.url`.
     #[error(
         "managed checkout {} exists but has no remote.origin.url, so it cannot be matched \
@@ -109,18 +109,6 @@ pub enum ColdStartError {
         requested: String,
     },
 
-    /// git could not report the state of the existing managed checkout.
-    #[error(
-        "cannot read the git state of managed checkout {}: {detail}",
-        .path.display()
-    )]
-    StatusUnavailable {
-        /// The managed checkout that was inspected.
-        path: PathBuf,
-        /// The underlying git failure.
-        detail: String,
-    },
-
     /// Cloning or refreshing the base clone failed.
     #[error("{0}")]
     Provision(String),
@@ -128,16 +116,27 @@ pub enum ColdStartError {
 
 /// The managed base clone a cold start produced.
 ///
-/// Why: the caller needs the path to launch into, and needs to say whether it
-/// cloned or reused so the operator can tell a first run from a repeat one.
-/// What: the absolute `<repos_root>/<owner>/<repo>` path, plus `reused`.
-/// Test: `fresh_clone_yields_the_shape_try_inproject_spawn_requires`.
+/// Why: the caller needs the path to launch into, whether it cloned or reused
+/// (so the operator can tell a first run from a repeat one), and — critically —
+/// whether the fast-forward was skipped. That last field exists so the skip
+/// cannot be silent: a `warn!` alone goes to a log the operator is not reading,
+/// which is the `pull_ff_only` failure mode. Returning it makes the CLI able to
+/// print it in normal output.
+/// What: the absolute `<repos_root>/<owner>/<repo>` path, `reused`, and
+/// `refresh_skipped` — `Some(reason)` when the fast-forward was declined, in a
+/// form suitable for printing directly after the path.
+/// Test: `dirty_existing_checkout_warns_and_proceeds`,
+/// `clean_matching_checkout_is_reused_and_refreshed`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ManagedCheckout {
     /// Absolute path to the managed base clone.
     pub base_path: PathBuf,
     /// `true` when an existing checkout was verified and reused rather than cloned.
     pub reused: bool,
+    /// Why the fast-forward was skipped, when it was. `None` means it was not.
+    ///
+    /// The caller MUST surface this in normal output. See the type-level doc.
+    pub refresh_skipped: Option<String>,
 }
 
 /// Ensure a managed base clone exists for `owner`/`repo`, cloning from `clone_url`.
@@ -163,37 +162,54 @@ pub fn ensure_managed_checkout(
 /// Why: split from [`ensure_managed_checkout`] so tests can supply a temp
 /// directory directly rather than mutating `TRUSTY_MPM_REPOS_ROOT`, which
 /// races other threads in the same test binary.
-/// What: when `base_path/.git` is absent, clones. When it is present, runs the
-/// remote check then the dirty check — both fail loud — and only then
-/// refreshes through [`super::inproject_hygiene::run_hygiene_for_base`].
-/// Either way it finishes through [`super::inproject::ensure_base_clone`], so
-/// a reused checkout gets the same `.worktrees/` exclusion invariant a fresh
-/// clone does.
+/// What: when `base_path/.git` is absent, clones. When it is present, the
+/// remote check runs FIRST and can refuse; then the fast-forward gate is
+/// evaluated ([`fast_forward_skip_reason`]) and reported rather than enforced;
+/// then the refresh runs through
+/// [`super::inproject_hygiene::run_hygiene_for_base`], whose fetch is
+/// unconditional and whose fast-forward is gated by the same conditions. Either
+/// way it finishes through [`super::inproject::ensure_base_clone`], so a reused
+/// checkout gets the same `.worktrees/` exclusion invariant a fresh clone does.
 ///
-/// ORDERING IS THE POINT. Both guards run BEFORE anything writes to the
-/// directory, so a mismatched or dirty checkout is never fetched into, merged
-/// into, or otherwise touched.
+/// ORDERING IS THE POINT. The identity check runs BEFORE anything writes to the
+/// directory, so a checkout belonging to another repository is never fetched
+/// into, merged into, or otherwise touched.
 /// Test: `existing_checkout_on_a_different_remote_fails_loud`,
-/// `dirty_existing_checkout_fails_loud`,
+/// `dirty_existing_checkout_warns_and_proceeds`,
 /// `clean_matching_checkout_is_reused_and_refreshed`.
 pub fn ensure_managed_checkout_at(
     base_path: &Path,
     clone_url: &str,
 ) -> Result<ManagedCheckout, ColdStartError> {
     let reused = base_path.join(".git").exists();
+    let mut refresh_skipped = None;
 
     if reused {
+        // The one refusal: an existing checkout must be the repo that was asked
+        // for. Checked before any write.
         verify_remote_matches(base_path, clone_url)?;
-        verify_tree_is_clean(base_path)?;
 
-        // Refresh through the crate's single base-clone hygiene entry point.
-        // It is non-destructive by construction (fetch, gated fast-forward,
-        // worktree prune) and its dirty/ahead gates have nothing to decline
-        // for here, because `verify_tree_is_clean` already stopped that case.
-        info!(
-            path = %base_path.display(),
-            "cold-start: reusing managed checkout; refreshing"
-        );
+        refresh_skipped = fast_forward_skip_reason(base_path);
+        if let Some(reason) = &refresh_skipped {
+            // Logged here for the daemon/log path AND returned to the caller,
+            // which prints it. A warn! alone would be the `pull_ff_only`
+            // failure mode: technically not silent, practically unread.
+            warn!(
+                path = %base_path.display(),
+                "cold-start: NOT fast-forwarding the managed checkout — {reason}"
+            );
+        } else {
+            info!(
+                path = %base_path.display(),
+                "cold-start: reusing managed checkout; refreshing"
+            );
+        }
+
+        // Runs either way. The fetch is what keeps `origin/<default>` current,
+        // and that ref — not the local HEAD — is what the session branch is cut
+        // from (#4957), which is exactly why a declined fast-forward is
+        // reportable rather than fatal. Only the fast-forward is gated, matching
+        // ADR-0030 §4.
         inproject_hygiene::run_hygiene_for_base(base_path).map_err(ColdStartError::Provision)?;
     }
 
@@ -202,6 +218,7 @@ pub fn ensure_managed_checkout_at(
     Ok(ManagedCheckout {
         base_path: base_path.to_path_buf(),
         reused,
+        refresh_skipped,
     })
 }
 
@@ -236,36 +253,37 @@ fn verify_remote_matches(base_path: &Path, requested: &str) -> Result<(), ColdSt
     })
 }
 
-/// Refuse when an existing checkout has uncommitted changes.
+/// Report why the fast-forward will be skipped, if it will be.
 ///
-/// Why: a dirty tree cannot be fast-forwarded, so proceeding means running the
-/// session against whatever the checkout was last left at. `pull_ff_only`
-/// (`core::standalone::load.rs`) does exactly that — it prints a warning and
-/// returns `Ok(())`, making a failed refresh indistinguishable from a
-/// successful one at the call site.
+/// Why: this predicts the hygiene sweep's own dirty gate so the skip can be
+/// stated to the operator in normal output. It does NOT enforce anything —
+/// enforcement would block the common case for no benefit, because the session
+/// branch is cut from freshly-fetched `origin/<default>` and never inherits the
+/// base checkout's local `HEAD` (#4957). What it buys is that the skip is not
+/// silent, which is the half of the `pull_ff_only` shape that IS a defect: that
+/// function warns at a level nobody reads and returns `Ok(())`.
 ///
-/// The check is `git status --porcelain` WITHOUT `--ignored`, deliberately:
-/// the question is whether tracked work is at risk of being outrun, and
-/// gitignored build output is not that. The gitignored-collision hazard has
-/// its own, narrower guard inside the hygiene sweep
+/// The check is `git status --porcelain` WITHOUT `--ignored`, deliberately: the
+/// question is whether git can fast-forward this tree, and gitignored build
+/// output does not affect that. The gitignored-collision hazard has its own,
+/// narrower guard inside the hygiene sweep
 /// (`inproject_hygiene::colliding_untracked_paths`, #4961), which runs against
 /// the specific paths an update would write.
-/// What: `Ok(())` on empty output; `DirtyCheckout` carrying the porcelain
-/// lines otherwise; `StatusUnavailable` when git itself fails, which is the
-/// fail-safe direction — an unreadable checkout is never assumed clean.
-/// Test: `dirty_existing_checkout_fails_loud`,
+/// What: `None` when the tree is clean. `Some(reason)` when it is dirty (naming
+/// up to [`DIRTY_ENTRY_PREVIEW`] entries) or when git could not report at all —
+/// an unreadable checkout is never assumed clean, and the hygiene sweep's own
+/// gate declines the fast-forward in that case too, so predicting a skip
+/// matches what actually happens.
+/// Test: `dirty_existing_checkout_warns_and_proceeds`,
 /// `clean_matching_checkout_is_reused_and_refreshed`.
-fn verify_tree_is_clean(base_path: &Path) -> Result<(), ColdStartError> {
+fn fast_forward_skip_reason(base_path: &Path) -> Option<String> {
     match inproject_hygiene::porcelain_status(base_path) {
-        Ok(entries) if entries.is_empty() => Ok(()),
-        Ok(entries) => Err(ColdStartError::DirtyCheckout {
-            path: base_path.to_path_buf(),
-            entries,
-        }),
-        Err(detail) => Err(ColdStartError::StatusUnavailable {
-            path: base_path.to_path_buf(),
-            detail,
-        }),
+        Ok(entries) if entries.is_empty() => None,
+        Ok(entries) => Some(format!(
+            "it has uncommitted changes:\n{}",
+            summarize_entries(&entries)
+        )),
+        Err(detail) => Some(format!("its git state could not be read: {detail}")),
     }
 }
 
@@ -311,10 +329,10 @@ pub fn canonical_remote(url: &str) -> String {
         .join("/")
 }
 
-/// Render the working-tree entries for a [`ColdStartError::DirtyCheckout`].
+/// Render the working-tree entries naming why a fast-forward was skipped.
 ///
-/// Why: see [`DIRTY_ENTRY_PREVIEW`] — the remedy is the message's last line,
-/// and an untruncated status can push it off the screen.
+/// Why: see [`DIRTY_ENTRY_PREVIEW`] — an untruncated status can push the notice
+/// that matters off the screen.
 /// What: joins up to [`DIRTY_ENTRY_PREVIEW`] entries with newlines, appending
 /// a `… and N more` line when there are more.
 /// Test: `dirty_message_truncates_long_status`.

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject_cold_start.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject_cold_start.rs
@@ -39,11 +39,17 @@
 //! both `warn!`-logged and returned to the caller in
 //! [`ManagedCheckout::refresh_skipped`] so the CLI can print it.
 //!
-//! Either way the refresh still runs through
+//! Either way the refresh is still ATTEMPTED through
 //! [`super::inproject_hygiene::run_hygiene_for_base`] — the crate's single
-//! non-destructive base-clone refresh. Its fetch is unconditional (which is
-//! what keeps `origin/<default>` current) and only its fast-forward is gated,
-//! matching ADR-0030 §4 exactly.
+//! non-destructive base-clone refresh — which fetches and then gates only the
+//! fast-forward, matching ADR-0030 §4. One exception: a checkout carrying the
+//! `inproject_hygiene::HYGIENE_OPT_OUT_MARKER` file
+//! (`.trusty-mpm-no-hygiene`) skips the sweep entirely, fetch included. That is
+//! the marker's whole purpose, and the session is still unaffected — its start
+//! point does its own fetch (#4957).
+//!
+//! The reported skip is one-sided: `Some` means no fast-forward, `None` does
+//! not mean there was one. See [`ManagedCheckout::refresh_skipped`].
 //!
 //! Test: `inproject_cold_start_tests.rs` (pure canonicalization, the
 //! remote-mismatch refusal, and the dirty warn-and-proceed path against real
@@ -123,8 +129,15 @@ pub enum ColdStartError {
 /// which is the `pull_ff_only` failure mode. Returning it makes the CLI able to
 /// print it in normal output.
 /// What: the absolute `<repos_root>/<owner>/<repo>` path, `reused`, and
-/// `refresh_skipped` — `Some(reason)` when the fast-forward was declined, in a
-/// form suitable for printing directly after the path.
+/// `refresh_skipped`, in a form suitable for printing directly after the path.
+///
+/// 🔴 `refresh_skipped` is ONE-SIDED, and reading it as a fast-forward receipt
+/// is wrong. `Some(reason)` is a reliable "the fast-forward did not happen".
+/// `None` means only that the dirty gate did not predict a skip — see
+/// [`fast_forward_skip_reason`] for the five other conditions under which
+/// `inproject_hygiene::decide_update` declines, and the gitignored-collision
+/// refusal after it, none of which this field reports. A clean checkout sitting
+/// on a non-default branch produces `None` and no fast-forward.
 /// Test: `dirty_existing_checkout_warns_and_proceeds`,
 /// `clean_matching_checkout_is_reused_and_refreshed`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -133,9 +146,10 @@ pub struct ManagedCheckout {
     pub base_path: PathBuf,
     /// `true` when an existing checkout was verified and reused rather than cloned.
     pub reused: bool,
-    /// Why the fast-forward was skipped, when it was. `None` means it was not.
+    /// A predicted reason the fast-forward will be skipped, when one is known.
     ///
-    /// The caller MUST surface this in normal output. See the type-level doc.
+    /// `Some` implies no fast-forward; `None` does NOT imply one happened. See
+    /// the type-level doc. The caller MUST surface a `Some` in normal output.
     pub refresh_skipped: Option<String>,
 }
 
@@ -165,10 +179,12 @@ pub fn ensure_managed_checkout(
 /// What: when `base_path/.git` is absent, clones. When it is present, the
 /// remote check runs FIRST and can refuse; then the fast-forward gate is
 /// evaluated ([`fast_forward_skip_reason`]) and reported rather than enforced;
-/// then the refresh runs through
-/// [`super::inproject_hygiene::run_hygiene_for_base`], whose fetch is
-/// unconditional and whose fast-forward is gated by the same conditions. Either
-/// way it finishes through [`super::inproject::ensure_base_clone`], so a reused
+/// then the refresh is attempted through
+/// [`super::inproject_hygiene::run_hygiene_for_base`], which fetches and gates
+/// the fast-forward on a SUPERSET of the conditions checked here — so it can
+/// decline when nothing was reported. It skips wholesale, fetch included, when
+/// the checkout carries `inproject_hygiene::HYGIENE_OPT_OUT_MARKER`. Either way
+/// it finishes through [`super::inproject::ensure_base_clone`], so a reused
 /// checkout gets the same `.worktrees/` exclusion invariant a fresh clone does.
 ///
 /// ORDERING IS THE POINT. The identity check runs BEFORE anything writes to the
@@ -205,11 +221,11 @@ pub fn ensure_managed_checkout_at(
             );
         }
 
-        // Runs either way. The fetch is what keeps `origin/<default>` current,
-        // and that ref — not the local HEAD — is what the session branch is cut
-        // from (#4957), which is exactly why a declined fast-forward is
-        // reportable rather than fatal. Only the fast-forward is gated, matching
-        // ADR-0030 §4.
+        // Attempted either way. The fetch keeps `origin/<default>` current, and
+        // that ref — not the local HEAD — is what the session branch is cut from
+        // (#4957), which is why a declined fast-forward is reportable rather
+        // than fatal. Only the fast-forward is gated (ADR-0030 §4) — except
+        // under the `HYGIENE_OPT_OUT_MARKER`, which skips the sweep whole.
         inproject_hygiene::run_hygiene_for_base(base_path).map_err(ColdStartError::Provision)?;
     }
 
@@ -274,6 +290,18 @@ fn verify_remote_matches(base_path: &Path, requested: &str) -> Result<(), ColdSt
 /// an unreadable checkout is never assumed clean, and the hygiene sweep's own
 /// gate declines the fast-forward in that case too, so predicting a skip
 /// matches what actually happens.
+///
+/// 🔴 PARTIAL PREDICTOR, deliberately. It mirrors two of the conditions
+/// `inproject_hygiene::decide_update` checks, not all of them. That function
+/// also declines on a detached HEAD, a checked-out branch that is not the
+/// default branch, an unknown ahead-count, and unpushed commits; and
+/// `update_to_origin` refuses separately when the update would clobber a
+/// gitignored path (#4961). None of those produce a `Some` here, so a clean
+/// checkout on a feature branch returns `None` and is still not fast-forwarded.
+/// Widening this to a full receipt means either duplicating those gates or
+/// having the sweep report its own decision, which is a change to
+/// `inproject_hygiene`'s contract — out of scope while the consequence is only
+/// a missing notice. The session is unaffected either way (#4957).
 /// Test: `dirty_existing_checkout_warns_and_proceeds`,
 /// `clean_matching_checkout_is_reused_and_refreshed`.
 fn fast_forward_skip_reason(base_path: &Path) -> Option<String> {

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject_cold_start.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject_cold_start.rs
@@ -1,0 +1,339 @@
+//! Cold start: a bare `owner/repo` string becomes a managed base clone (#4990).
+//!
+//! Why: [`super::inproject::try_inproject_spawn`] can only start a managed
+//! session from a checkout that ALREADY exists — it gates on
+//! `path.join(".git").exists()` and reads `remote.origin.url` to learn the
+//! GitHub identity. Nothing turned a string the operator types into that
+//! checkout, so `tm` could not begin work on a repo that is not already on
+//! disk. This module is the missing direction: identity first, checkout
+//! second, then hand off to the same session-launch path an in-project spawn
+//! uses.
+//!
+//! What: [`ensure_managed_checkout`] resolves `<repos_root>/<owner>/<repo>` via
+//! [`super::inproject::base_clone_path`] and drives
+//! [`super::inproject::ensure_base_clone`] against it, returning the path and
+//! whether an existing checkout was reused. Reuse is gated by two checks that
+//! FAIL LOUD rather than proceeding:
+//!
+//! 1. **Remote mismatch.** An existing checkout whose `origin` names a
+//!    different repository is an error. trusty-mpm never re-points a remote —
+//!    doing so silently would make `tm run <owner>/<repo>` operate on some
+//!    other repository under that repository's name.
+//! 2. **Dirty tree.** An existing checkout with uncommitted changes cannot be
+//!    refreshed, so it is an error rather than a silent no-op on stale
+//!    content. This is the shape `core::standalone::load::pull_ff_only` gets
+//!    wrong: it warns and returns `Ok(())`, so a failed refresh is
+//!    indistinguishable from a successful one.
+//!
+//! Only after both clear does the refresh run, through
+//! [`super::inproject_hygiene::run_hygiene_for_base`] — the crate's single
+//! non-destructive base-clone refresh (fetch, gated fast-forward, worktree
+//! prune). Its own gates then have nothing left to decline for.
+//!
+//! Test: `inproject_cold_start_tests.rs` (pure canonicalization + the two
+//! loud-failure paths against real temp git repos);
+//! `tests/inproject_cold_start.rs` (fresh clone → the shape
+//! `try_inproject_spawn` requires).
+
+use std::path::{Path, PathBuf};
+
+use tracing::info;
+
+use super::{inproject, inproject_hygiene};
+
+/// How many working-tree entries a [`ColdStartError::DirtyCheckout`] message
+/// lists before it summarises the rest.
+///
+/// Why: a managed checkout can be thousands of lines dirty; an error that
+/// scrolls the terminal hides its own first line, which is the remedy.
+/// What: `10`.
+/// Test: `dirty_message_truncates_long_status`.
+const DIRTY_ENTRY_PREVIEW: usize = 10;
+
+/// Why a cold start refused. Every variant is a loud stop, never a warning.
+///
+/// Why: the two reuse hazards this module exists to close are both
+/// silent-success shapes elsewhere in the codebase, so they are modelled as
+/// errors that carry the offending path and what is wrong with it — not as
+/// booleans a caller could ignore.
+/// What: `RemoteMismatch` and `DirtyCheckout` are the two decided fail-loud
+/// cases; `NoOrigin` and `StatusUnavailable` are the fail-safe directions for
+/// a checkout whose state cannot be established; `Provision` wraps the
+/// underlying clone/hygiene failure verbatim.
+/// Test: `existing_checkout_on_a_different_remote_fails_loud`,
+/// `dirty_existing_checkout_fails_loud`.
+#[derive(Debug, thiserror::Error)]
+pub enum ColdStartError {
+    /// The existing managed checkout belongs to a different repository.
+    #[error(
+        "managed checkout {} already exists and its origin is {found}, not {requested}.\n\
+         trusty-mpm will not re-point a checkout's remote — that would run a different \
+         repository under this one's name. Move or remove that directory, or ask for the \
+         repo that is actually there.",
+        .path.display()
+    )]
+    RemoteMismatch {
+        /// The managed checkout that was inspected.
+        path: PathBuf,
+        /// The `remote.origin.url` found there.
+        found: String,
+        /// The clone URL the caller asked for.
+        requested: String,
+    },
+
+    /// The existing managed checkout has uncommitted changes.
+    #[error(
+        "managed checkout {} has uncommitted changes, so it cannot be refreshed:\n{}\n\
+         Refusing to start a session on content that may be stale. Commit, stash, or \
+         discard those changes and run the command again.",
+        .path.display(),
+        summarize_entries(.entries)
+    )]
+    DirtyCheckout {
+        /// The managed checkout that was inspected.
+        path: PathBuf,
+        /// `git status --porcelain` lines, verbatim.
+        entries: Vec<String>,
+    },
+
+    /// The existing managed checkout has no `remote.origin.url`.
+    #[error(
+        "managed checkout {} exists but has no remote.origin.url, so it cannot be matched \
+         against {requested}. Move or remove that directory and run the command again.",
+        .path.display()
+    )]
+    NoOrigin {
+        /// The managed checkout that was inspected.
+        path: PathBuf,
+        /// The clone URL the caller asked for.
+        requested: String,
+    },
+
+    /// git could not report the state of the existing managed checkout.
+    #[error(
+        "cannot read the git state of managed checkout {}: {detail}",
+        .path.display()
+    )]
+    StatusUnavailable {
+        /// The managed checkout that was inspected.
+        path: PathBuf,
+        /// The underlying git failure.
+        detail: String,
+    },
+
+    /// Cloning or refreshing the base clone failed.
+    #[error("{0}")]
+    Provision(String),
+}
+
+/// The managed base clone a cold start produced.
+///
+/// Why: the caller needs the path to launch into, and needs to say whether it
+/// cloned or reused so the operator can tell a first run from a repeat one.
+/// What: the absolute `<repos_root>/<owner>/<repo>` path, plus `reused`.
+/// Test: `fresh_clone_yields_the_shape_try_inproject_spawn_requires`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedCheckout {
+    /// Absolute path to the managed base clone.
+    pub base_path: PathBuf,
+    /// `true` when an existing checkout was verified and reused rather than cloned.
+    pub reused: bool,
+}
+
+/// Ensure a managed base clone exists for `owner`/`repo`, cloning from `clone_url`.
+///
+/// Why: this is the cold-start entry point — the one call that takes an
+/// identity with no local checkout behind it and returns a directory the
+/// existing session-launch path can accept.
+/// What: resolves the base path via [`super::inproject::base_clone_path`]
+/// (the SAME resolver the daemon and `tm launch` use, so all three agree on
+/// where a project lives) and delegates to [`ensure_managed_checkout_at`].
+/// Test: `tests/inproject_cold_start.rs`.
+pub fn ensure_managed_checkout(
+    owner: &str,
+    repo: &str,
+    clone_url: &str,
+) -> Result<ManagedCheckout, ColdStartError> {
+    let base_path = inproject::base_clone_path(owner, repo);
+    ensure_managed_checkout_at(&base_path, clone_url)
+}
+
+/// Ensure a managed base clone exists at an explicit `base_path`.
+///
+/// Why: split from [`ensure_managed_checkout`] so tests can supply a temp
+/// directory directly rather than mutating `TRUSTY_MPM_REPOS_ROOT`, which
+/// races other threads in the same test binary.
+/// What: when `base_path/.git` is absent, clones. When it is present, runs the
+/// remote check then the dirty check — both fail loud — and only then
+/// refreshes through [`super::inproject_hygiene::run_hygiene_for_base`].
+/// Either way it finishes through [`super::inproject::ensure_base_clone`], so
+/// a reused checkout gets the same `.worktrees/` exclusion invariant a fresh
+/// clone does.
+///
+/// ORDERING IS THE POINT. Both guards run BEFORE anything writes to the
+/// directory, so a mismatched or dirty checkout is never fetched into, merged
+/// into, or otherwise touched.
+/// Test: `existing_checkout_on_a_different_remote_fails_loud`,
+/// `dirty_existing_checkout_fails_loud`,
+/// `clean_matching_checkout_is_reused_and_refreshed`.
+pub fn ensure_managed_checkout_at(
+    base_path: &Path,
+    clone_url: &str,
+) -> Result<ManagedCheckout, ColdStartError> {
+    let reused = base_path.join(".git").exists();
+
+    if reused {
+        verify_remote_matches(base_path, clone_url)?;
+        verify_tree_is_clean(base_path)?;
+
+        // Refresh through the crate's single base-clone hygiene entry point.
+        // It is non-destructive by construction (fetch, gated fast-forward,
+        // worktree prune) and its dirty/ahead gates have nothing to decline
+        // for here, because `verify_tree_is_clean` already stopped that case.
+        info!(
+            path = %base_path.display(),
+            "cold-start: reusing managed checkout; refreshing"
+        );
+        inproject_hygiene::run_hygiene_for_base(base_path).map_err(ColdStartError::Provision)?;
+    }
+
+    inproject::ensure_base_clone(clone_url, base_path).map_err(ColdStartError::Provision)?;
+
+    Ok(ManagedCheckout {
+        base_path: base_path.to_path_buf(),
+        reused,
+    })
+}
+
+/// Refuse when an existing checkout's `origin` names a different repository.
+///
+/// Why: nothing checks this today. `core::standalone::load` pulls from
+/// whatever `origin` happens to be configured, so re-registering an alias to a
+/// new URL keeps pulling the old remote forever — silently, and with the new
+/// URL's name on it. Auto-fixing is worse than refusing: re-pointing `origin`
+/// under a directory that may hold branches, worktrees, and unpushed commits
+/// from the OTHER repository is not a repair.
+/// What: reads `remote.origin.url` via
+/// [`super::inproject::get_origin_url`] and compares it to `requested` through
+/// [`canonical_remote`], so remote spellings of the same repo agree. A
+/// checkout with no origin at all is `NoOrigin`, not a match.
+/// Test: `existing_checkout_on_a_different_remote_fails_loud`,
+/// `equivalent_remote_spellings_match`.
+fn verify_remote_matches(base_path: &Path, requested: &str) -> Result<(), ColdStartError> {
+    let Some(found) = inproject::get_origin_url(base_path) else {
+        return Err(ColdStartError::NoOrigin {
+            path: base_path.to_path_buf(),
+            requested: requested.to_string(),
+        });
+    };
+    if canonical_remote(&found) == canonical_remote(requested) {
+        return Ok(());
+    }
+    Err(ColdStartError::RemoteMismatch {
+        path: base_path.to_path_buf(),
+        found,
+        requested: requested.to_string(),
+    })
+}
+
+/// Refuse when an existing checkout has uncommitted changes.
+///
+/// Why: a dirty tree cannot be fast-forwarded, so proceeding means running the
+/// session against whatever the checkout was last left at. `pull_ff_only`
+/// (`core::standalone::load.rs`) does exactly that — it prints a warning and
+/// returns `Ok(())`, making a failed refresh indistinguishable from a
+/// successful one at the call site.
+///
+/// The check is `git status --porcelain` WITHOUT `--ignored`, deliberately:
+/// the question is whether tracked work is at risk of being outrun, and
+/// gitignored build output is not that. The gitignored-collision hazard has
+/// its own, narrower guard inside the hygiene sweep
+/// (`inproject_hygiene::colliding_untracked_paths`, #4961), which runs against
+/// the specific paths an update would write.
+/// What: `Ok(())` on empty output; `DirtyCheckout` carrying the porcelain
+/// lines otherwise; `StatusUnavailable` when git itself fails, which is the
+/// fail-safe direction — an unreadable checkout is never assumed clean.
+/// Test: `dirty_existing_checkout_fails_loud`,
+/// `clean_matching_checkout_is_reused_and_refreshed`.
+fn verify_tree_is_clean(base_path: &Path) -> Result<(), ColdStartError> {
+    match inproject_hygiene::porcelain_status(base_path) {
+        Ok(entries) if entries.is_empty() => Ok(()),
+        Ok(entries) => Err(ColdStartError::DirtyCheckout {
+            path: base_path.to_path_buf(),
+            entries,
+        }),
+        Err(detail) => Err(ColdStartError::StatusUnavailable {
+            path: base_path.to_path_buf(),
+            detail,
+        }),
+    }
+}
+
+/// Reduce a git remote URL to a comparable `host/owner/repo` token.
+///
+/// Why: the remote check must not fire on spelling. `git@github.com:o/r.git`,
+/// `https://github.com/o/r`, and `ssh://git@github.com/o/r.git` are one
+/// repository, and a mismatch error for any pair of them would be a false
+/// alarm on the most common setup there is.
+///
+/// This is deliberately NOT
+/// [`trusty_common::github_path::parse_github_path`], which drops the host on
+/// purpose: two different hosts serving the same `owner/repo` are DIFFERENT
+/// repositories, and that is precisely the confusion this check exists to
+/// catch.
+/// What: lower-cases, strips the scheme and any `user@` credential, rewrites
+/// the scp-syntax `:` separator to `/`, and trims a trailing `.git` and
+/// slashes. An explicit `:port` is rewritten to a path segment, so
+/// `https://host:443/o/r` and `https://host/o/r` compare UNEQUAL — a false
+/// mismatch, which fails loud rather than silently proceeding, the safe
+/// direction for a check whose whole job is to refuse.
+/// Test: `equivalent_remote_spellings_match`, `different_hosts_do_not_match`.
+pub fn canonical_remote(url: &str) -> String {
+    let lowered = url.trim().to_ascii_lowercase();
+    let after_scheme = match lowered.find("://") {
+        Some(i) => &lowered[i + 3..],
+        None => &lowered[..],
+    };
+    let after_creds = match after_scheme.find('@') {
+        Some(i) => &after_scheme[i + 1..],
+        None => after_scheme,
+    };
+    // scp-syntax `host:owner/repo` and an explicit `host:port/…` both collapse
+    // to a path separator; both sides of the comparison get the same treatment.
+    let normalized = after_creds.replacen(':', "/", 1);
+    let trimmed = normalized.trim_end_matches('/');
+    let no_git = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+    no_git
+        .trim_end_matches('/')
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Render the working-tree entries for a [`ColdStartError::DirtyCheckout`].
+///
+/// Why: see [`DIRTY_ENTRY_PREVIEW`] — the remedy is the message's last line,
+/// and an untruncated status can push it off the screen.
+/// What: joins up to [`DIRTY_ENTRY_PREVIEW`] entries with newlines, appending
+/// a `… and N more` line when there are more.
+/// Test: `dirty_message_truncates_long_status`.
+fn summarize_entries(entries: &[String]) -> String {
+    let shown: Vec<&str> = entries
+        .iter()
+        .take(DIRTY_ENTRY_PREVIEW)
+        .map(String::as_str)
+        .collect();
+    let mut out = shown.join("\n");
+    if entries.len() > DIRTY_ENTRY_PREVIEW {
+        out.push_str(&format!(
+            "\n  … and {} more",
+            entries.len() - DIRTY_ENTRY_PREVIEW
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "inproject_cold_start_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject_cold_start_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject_cold_start_tests.rs
@@ -1,14 +1,16 @@
 //! Unit tests for the cold-start entry point (#4990).
 //!
-//! Why: the two reuse guards are the whole reason this module exists, so both
-//! are proven against REAL temp git repositories rather than mocks — the
-//! failures they prevent (a checkout on the wrong remote, a dirty tree that
-//! cannot be fast-forwarded) live entirely in what git reports about a working
+//! Why: the two reuse behaviours are the whole reason this module exists, and
+//! they are deliberately DIFFERENT — a wrong remote refuses, a dirty tree warns
+//! and proceeds. Both are proven against REAL temp git repositories rather than
+//! mocks, because each one lives entirely in what git reports about a working
 //! directory. The remote canonicalization is pure and gets ordinary table
 //! tests.
 //! What: `canonical_remote` equivalence and non-equivalence; the
-//! remote-mismatch refusal; the dirty-tree refusal; the clean-reuse success;
-//! and the truncation of a long dirty-status message.
+//! remote-mismatch and no-origin refusals; the dirty-tree warn-and-proceed
+//! (including that the fetch still lands and the local branch does not move);
+//! the clean-reuse fast-forward; the fresh clone; and the truncation of a long
+//! dirty-status notice.
 //! Test: this file IS the test module.
 
 use std::path::Path;
@@ -152,51 +154,85 @@ fn existing_checkout_without_an_origin_fails_loud() {
     );
 }
 
-/// DECIDED BEHAVIOR: a dirty existing checkout fails loud.
+/// DECIDED BEHAVIOR: a dirty existing checkout WARNS AND PROCEEDS.
 ///
-/// Why: this is the `pull_ff_only` hole (`core::standalone::load.rs`) — it
-/// warns on a failed refresh and returns `Ok(())`, so the caller cannot tell a
-/// refreshed checkout from a stale one. Here the refusal happens BEFORE any
-/// write, so the dirty content is never at risk either.
+/// Why: this reverses an earlier fail-loud decision on this same path. A dirty
+/// tree cannot be fast-forwarded, but since #4957 the session branch is cut
+/// from a freshly-fetched `origin/<default>` and never inherits the base
+/// checkout's local `HEAD`, so a skipped fast-forward cannot leak stale content
+/// into the session. Refusing would block the common case — the tm checkout is
+/// shared with the operator's editors, making uncommitted content its steady
+/// state (ADR-0030 §4/§5) — to guard against nothing.
+///
+/// What must NOT happen is silence, which is the half of the `pull_ff_only`
+/// (`core::standalone::load.rs`) shape that really is a defect: it warns where
+/// nobody looks and returns `Ok(())`. So this asserts four things at once — the
+/// call succeeds, the skip is REPORTED to the caller naming what is dirty, the
+/// uncommitted content survives, and the local branch genuinely did not move
+/// while `origin/main` genuinely did.
 /// Test: itself.
 #[test]
-fn dirty_existing_checkout_fails_loud() {
+fn dirty_existing_checkout_warns_and_proceeds() {
     let tmp = tempfile::TempDir::new().expect("temp dir");
     let origin = init_origin(&tmp.path().join("origin")).to_path_buf();
     let base = tmp.path().join("base");
     clone_to(&origin, &base);
+    let head_before = git(&base, &["rev-parse", "HEAD"]);
+
+    // Origin moves forward, so a fast-forward is genuinely AVAILABLE — without
+    // this the "was not fast-forwarded" assertion would pass vacuously.
+    std::fs::write(origin.join("file.txt"), "v2 from origin\n").expect("write");
+    git(&origin, &["add", "."]);
+    git(&origin, &["commit", "-q", "-m", "moved forward"]);
 
     // The operator's uncommitted work.
     std::fs::write(base.join("file.txt"), "MY UNCOMMITTED EDIT\n").expect("write");
 
     let url = origin.to_string_lossy().into_owned();
-    let err =
-        ensure_managed_checkout_at(&base, &url).expect_err("a dirty checkout must be refused");
+    let checkout =
+        ensure_managed_checkout_at(&base, &url).expect("a dirty checkout must NOT be refused");
 
+    assert!(checkout.reused);
+    let reason = checkout
+        .refresh_skipped
+        .as_deref()
+        .expect("the skip must be REPORTED to the caller, not merely logged");
     assert!(
-        matches!(err, ColdStartError::DirtyCheckout { .. }),
-        "expected DirtyCheckout, got {err:?}"
+        reason.contains("uncommitted changes"),
+        "reason must state the cause: {reason}"
     );
-    let msg = err.to_string();
     assert!(
-        msg.contains(&base.display().to_string()),
-        "names path: {msg}"
+        reason.contains("file.txt"),
+        "reason must name what is dirty: {reason}"
     );
-    assert!(msg.contains("file.txt"), "names what is dirty: {msg}");
 
-    // And the edit survives — the refusal happens before anything writes.
+    // The edit survives, and the local branch did not move.
     assert_eq!(
         std::fs::read_to_string(base.join("file.txt")).expect("read"),
         "MY UNCOMMITTED EDIT\n"
     );
+    assert_eq!(
+        git(&base, &["rev-parse", "HEAD"]),
+        head_before,
+        "a dirty tree must not be fast-forwarded"
+    );
+
+    // But the FETCH still happened, which is what keeps the session's start
+    // point current — the whole reason the skipped fast-forward costs nothing.
+    assert_ne!(
+        git(&base, &["rev-parse", "refs/remotes/origin/main"]),
+        head_before,
+        "origin/main must be fetched even when the fast-forward is skipped"
+    );
 }
 
-/// The success case the two refusals must not swallow: a clean checkout on the
-/// requested remote is reused, refreshed, and reported as `reused`.
+/// The success case the refusal must not swallow: a clean checkout on the
+/// requested remote is reused, fast-forwarded, and reports NO skip.
 ///
-/// Why: a guard that refuses everything is not a guard. This also pins the
-/// refresh actually happening — origin moves forward and the reused checkout
-/// follows it.
+/// Why: a guard that refuses everything is not a guard. This pins the refresh
+/// actually happening — origin moves forward and the reused checkout follows it
+/// — and that `refresh_skipped` is `None`, so the notice cannot fire spuriously
+/// on every clean run.
 /// Test: itself.
 #[test]
 fn clean_matching_checkout_is_reused_and_refreshed() {
@@ -215,6 +251,10 @@ fn clean_matching_checkout_is_reused_and_refreshed() {
 
     assert!(checkout.reused, "an existing checkout must report reused");
     assert_eq!(checkout.base_path, base);
+    assert_eq!(
+        checkout.refresh_skipped, None,
+        "a clean checkout must report no skipped refresh"
+    );
     assert_eq!(
         std::fs::read_to_string(base.join("file.txt")).expect("read"),
         "v2 from origin\n",

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject_cold_start_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject_cold_start_tests.rs
@@ -1,0 +1,262 @@
+//! Unit tests for the cold-start entry point (#4990).
+//!
+//! Why: the two reuse guards are the whole reason this module exists, so both
+//! are proven against REAL temp git repositories rather than mocks — the
+//! failures they prevent (a checkout on the wrong remote, a dirty tree that
+//! cannot be fast-forwarded) live entirely in what git reports about a working
+//! directory. The remote canonicalization is pure and gets ordinary table
+//! tests.
+//! What: `canonical_remote` equivalence and non-equivalence; the
+//! remote-mismatch refusal; the dirty-tree refusal; the clean-reuse success;
+//! and the truncation of a long dirty-status message.
+//! Test: this file IS the test module.
+
+use std::path::Path;
+use std::process::Command;
+
+use super::*;
+
+/// Run a git command in `dir`, panicking with full output on failure.
+fn git(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn git {args:?} in {dir:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} in {dir:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Create a one-commit `main` repo at `path` and return it.
+fn init_origin(path: &Path) -> &Path {
+    std::fs::create_dir_all(path).expect("mkdir origin");
+    git(path, &["init", "-q", "-b", "main"]);
+    git(path, &["config", "user.email", "test@example.com"]);
+    git(path, &["config", "user.name", "Test"]);
+    std::fs::write(path.join("file.txt"), "v1\n").expect("write file");
+    git(path, &["add", "."]);
+    git(path, &["commit", "-q", "-m", "initial"]);
+    path
+}
+
+/// Clone `origin` to `dest` so `dest` has a real `origin` remote and `origin/HEAD`.
+fn clone_to(origin: &Path, dest: &Path) {
+    let out = Command::new("git")
+        .args([
+            "clone",
+            "-q",
+            origin.to_str().expect("utf8"),
+            dest.to_str().expect("utf8"),
+        ])
+        .output()
+        .expect("spawn git clone");
+    assert!(
+        out.status.success(),
+        "git clone failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    git(dest, &["config", "user.email", "test@example.com"]);
+    git(dest, &["config", "user.name", "Test"]);
+}
+
+/// Why: the same repository is spelled three ways in the wild, and a mismatch
+/// error for any pair of them would fire on every ordinary GitHub setup.
+/// Test: itself.
+#[test]
+fn equivalent_remote_spellings_match() {
+    let want = "github.com/bobmatnyc/trusty-tools";
+    for url in [
+        "git@github.com:bobmatnyc/trusty-tools.git",
+        "git@github.com:bobmatnyc/trusty-tools",
+        "https://github.com/bobmatnyc/trusty-tools",
+        "https://github.com/bobmatnyc/trusty-tools.git",
+        "https://github.com/bobmatnyc/trusty-tools/",
+        "ssh://git@github.com/bobmatnyc/trusty-tools.git",
+        "HTTPS://GitHub.com/BobMatNYC/Trusty-Tools.git",
+    ] {
+        assert_eq!(canonical_remote(url), want, "canonicalizing {url}");
+    }
+}
+
+/// Why: the host is load-bearing here. `parse_github_path` drops it on
+/// purpose, so a comparison built on that parser would call two different
+/// hosts' `owner/repo` the same repository — exactly the confusion the remote
+/// check exists to catch.
+/// Test: itself.
+#[test]
+fn different_hosts_do_not_match() {
+    assert_ne!(
+        canonical_remote("git@github.com:acme/widget.git"),
+        canonical_remote("git@gitlab.com:acme/widget.git")
+    );
+    assert_ne!(
+        canonical_remote("https://github.com/acme/widget"),
+        canonical_remote("https://github.com/other/widget")
+    );
+}
+
+/// DECIDED BEHAVIOR: an existing checkout whose origin names a different
+/// repository is an error, not an auto-fix.
+///
+/// Why: no check exists anywhere today — the standalone driver pulls from
+/// whatever `origin` happens to be, so re-pointing an alias at a new URL keeps
+/// serving the old remote forever under the new name. Refusing is the only
+/// non-destructive answer: re-pointing `origin` under a directory that may hold
+/// branches and unpushed commits from the OTHER repository is not a repair.
+/// Test: itself.
+#[test]
+fn existing_checkout_on_a_different_remote_fails_loud() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let origin = init_origin(&tmp.path().join("origin")).to_path_buf();
+    let base = tmp.path().join("base");
+    clone_to(&origin, &base);
+
+    let err = ensure_managed_checkout_at(&base, "https://github.com/someone/else.git")
+        .expect_err("a different remote must be refused");
+
+    assert!(
+        matches!(err, ColdStartError::RemoteMismatch { .. }),
+        "expected RemoteMismatch, got {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains(&base.display().to_string()),
+        "names path: {msg}"
+    );
+    assert!(msg.contains("someone/else"), "names requested repo: {msg}");
+    assert!(
+        msg.contains("will not re-point"),
+        "states the refusal: {msg}"
+    );
+}
+
+/// FAIL-SAFE: a checkout with no `origin` at all cannot be matched, so it is
+/// refused rather than assumed to be the requested repo.
+///
+/// Test: itself.
+#[test]
+fn existing_checkout_without_an_origin_fails_loud() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let base = init_origin(&tmp.path().join("base")).to_path_buf();
+
+    let err = ensure_managed_checkout_at(&base, "https://github.com/acme/widget.git")
+        .expect_err("a checkout with no origin must be refused");
+    assert!(
+        matches!(err, ColdStartError::NoOrigin { .. }),
+        "expected NoOrigin, got {err:?}"
+    );
+}
+
+/// DECIDED BEHAVIOR: a dirty existing checkout fails loud.
+///
+/// Why: this is the `pull_ff_only` hole (`core::standalone::load.rs`) — it
+/// warns on a failed refresh and returns `Ok(())`, so the caller cannot tell a
+/// refreshed checkout from a stale one. Here the refusal happens BEFORE any
+/// write, so the dirty content is never at risk either.
+/// Test: itself.
+#[test]
+fn dirty_existing_checkout_fails_loud() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let origin = init_origin(&tmp.path().join("origin")).to_path_buf();
+    let base = tmp.path().join("base");
+    clone_to(&origin, &base);
+
+    // The operator's uncommitted work.
+    std::fs::write(base.join("file.txt"), "MY UNCOMMITTED EDIT\n").expect("write");
+
+    let url = origin.to_string_lossy().into_owned();
+    let err =
+        ensure_managed_checkout_at(&base, &url).expect_err("a dirty checkout must be refused");
+
+    assert!(
+        matches!(err, ColdStartError::DirtyCheckout { .. }),
+        "expected DirtyCheckout, got {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains(&base.display().to_string()),
+        "names path: {msg}"
+    );
+    assert!(msg.contains("file.txt"), "names what is dirty: {msg}");
+
+    // And the edit survives — the refusal happens before anything writes.
+    assert_eq!(
+        std::fs::read_to_string(base.join("file.txt")).expect("read"),
+        "MY UNCOMMITTED EDIT\n"
+    );
+}
+
+/// The success case the two refusals must not swallow: a clean checkout on the
+/// requested remote is reused, refreshed, and reported as `reused`.
+///
+/// Why: a guard that refuses everything is not a guard. This also pins the
+/// refresh actually happening — origin moves forward and the reused checkout
+/// follows it.
+/// Test: itself.
+#[test]
+fn clean_matching_checkout_is_reused_and_refreshed() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let origin = init_origin(&tmp.path().join("origin")).to_path_buf();
+    let base = tmp.path().join("base");
+    clone_to(&origin, &base);
+
+    // Origin moves forward after the clone.
+    std::fs::write(origin.join("file.txt"), "v2 from origin\n").expect("write");
+    git(&origin, &["add", "."]);
+    git(&origin, &["commit", "-q", "-m", "moved forward"]);
+
+    let url = origin.to_string_lossy().into_owned();
+    let checkout = ensure_managed_checkout_at(&base, &url).expect("clean reuse succeeds");
+
+    assert!(checkout.reused, "an existing checkout must report reused");
+    assert_eq!(checkout.base_path, base);
+    assert_eq!(
+        std::fs::read_to_string(base.join("file.txt")).expect("read"),
+        "v2 from origin\n",
+        "the reused checkout must have been fast-forwarded"
+    );
+}
+
+/// A fresh clone into an absent path succeeds and reports `reused = false`.
+///
+/// Why: the cold-start case itself — no `.git`, no cwd, nothing on disk. Uses a
+/// local source repo so the test never touches the network.
+/// Test: itself.
+#[test]
+fn absent_path_is_cloned_and_reports_not_reused() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let origin = init_origin(&tmp.path().join("origin")).to_path_buf();
+    let base = tmp.path().join("owner").join("repo");
+
+    let url = origin.to_string_lossy().into_owned();
+    let checkout = ensure_managed_checkout_at(&base, &url).expect("fresh clone succeeds");
+
+    assert!(!checkout.reused, "a fresh clone must not report reused");
+    assert!(base.join(".git").exists(), "clone produced a git checkout");
+    assert_eq!(
+        std::fs::read_to_string(base.join("file.txt")).expect("read"),
+        "v1\n"
+    );
+}
+
+/// Why: a managed checkout can be thousands of lines dirty, and an
+/// untruncated status pushes the remedy off the screen.
+/// Test: itself.
+#[test]
+fn dirty_message_truncates_long_status() {
+    let entries: Vec<String> = (0..25).map(|i| format!(" M file{i}.txt")).collect();
+    let rendered = summarize_entries(&entries);
+    assert!(rendered.contains("file0.txt"));
+    assert!(rendered.contains("file9.txt"));
+    assert!(!rendered.contains("file10.txt"));
+    assert!(rendered.contains("… and 15 more"));
+
+    // Short lists render in full with no summary line.
+    let short = summarize_entries(&[" M a.txt".to_string()]);
+    assert_eq!(short, " M a.txt");
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject_hygiene.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject_hygiene.rs
@@ -222,7 +222,7 @@ fn is_dirty(base_path: &Path) -> Option<bool> {
 /// `--ignored` reports nothing for gitignored paths, which is why this cannot
 /// be the only data-loss guard; see [`colliding_untracked_paths`].
 /// Test: `hygiene_dirty_tree_is_not_reset` (via [`run_hygiene_for_base`]);
-/// `dirty_existing_checkout_fails_loud` (via the cold-start gate).
+/// `dirty_existing_checkout_warns_and_proceeds` (via the cold-start gate).
 pub(crate) fn porcelain_status(base_path: &Path) -> Result<Vec<String>, String> {
     let out = std::process::Command::new("git")
         .arg("-C")

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject_hygiene.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject_hygiene.rs
@@ -205,16 +205,43 @@ fn ahead_count(base_path: &Path, branch: &str) -> Option<usize> {
 /// Test: `hygiene_dirty_tree_is_not_reset` integration test (via
 /// [`run_hygiene_for_base`]).
 fn is_dirty(base_path: &Path) -> Option<bool> {
+    porcelain_status(base_path).ok().map(|e| !e.is_empty())
+}
+
+/// Read `git status --porcelain` for a base clone as a list of entries.
+///
+/// Why: two callers need the same answer at different resolutions. [`is_dirty`]
+/// wants the verdict; the cold-start reuse gate
+/// ([`super::inproject_cold_start`]) wants the entries themselves, because its
+/// error message names what is dirty. Sharing one reader keeps them from
+/// drifting into two different definitions of "dirty" for the same directory.
+/// What: runs `git -C <base_path> status --porcelain` and returns the non-empty
+/// stdout lines verbatim. `Err` carries the spawn or non-zero-exit failure —
+/// callers decide whether that is fail-safe (`is_dirty` → `None` → refuse the
+/// update) or fatal (cold start → stop). Note that `--porcelain` without
+/// `--ignored` reports nothing for gitignored paths, which is why this cannot
+/// be the only data-loss guard; see [`colliding_untracked_paths`].
+/// Test: `hygiene_dirty_tree_is_not_reset` (via [`run_hygiene_for_base`]);
+/// `dirty_existing_checkout_fails_loud` (via the cold-start gate).
+pub(crate) fn porcelain_status(base_path: &Path) -> Result<Vec<String>, String> {
     let out = std::process::Command::new("git")
         .arg("-C")
         .arg(base_path)
         .args(["status", "--porcelain"])
         .output()
-        .ok()?;
+        .map_err(|e| format!("git status --porcelain failed to spawn: {e}"))?;
     if !out.status.success() {
-        return None;
+        return Err(format!(
+            "git status --porcelain failed ({}): {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
     }
-    Some(!out.stdout.is_empty())
+    Ok(String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(str::to_string)
+        .collect())
 }
 
 /// Run `git -C <base_path> <args>` and return NUL-separated stdout entries.

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -27,11 +27,13 @@ use crate::runtime::RuntimeKind;
 use crate::session_manager::ManagedSessionId;
 
 pub mod activity;
+mod delete;
 mod deliverable_link;
 mod deployment_check;
 mod fleet;
 pub mod front_gate;
 pub mod inproject;
+pub mod inproject_cold_start;
 pub mod inproject_hygiene;
 mod inproject_start_point;
 mod launch_on_main;
@@ -51,6 +53,7 @@ mod session_summary;
 mod summary;
 pub mod sync_assets;
 pub use activity::{ActivityResponse, get_session_activity};
+pub use delete::{delete_managed_session, stop_managed_session};
 pub use fleet::{FleetByProjectResponse, FleetProjectGroup, fleet_by_project_route};
 pub use front_gate::{
     ConformanceGate, FrontGateOutcome, HeadlessApproval, IsrConformanceGate, run_front_gate,
@@ -904,64 +907,6 @@ pub async fn decommission_managed_session(
         }
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
-}
-
-/// POST /api/v1/sessions/managed/{id}/delete — soft-delete the RECORD, mark `--deleted--` (#2012).
-///
-/// Why: distinct from `decommission` (stop runtime + maybe remove workspace +
-/// `Decommissioned` tombstone) — this marks the record `Deleted` (rendered
-/// `--deleted--`) so the operator's master list REFLECTS the deletion instead
-/// of the row vanishing, honouring the "fully-tracked lifecycle" standard.
-/// Fail-closed: a RUNNING session (`Active`/`Provisioning`) is refused unless
-/// `?force=true`.
-/// What: parses the id and the `force` query flag, delegates to
-/// [`crate::session_manager::SessionManager::delete_record`], and maps its
-/// result — `Ok` → 200 with the pre-deletion [`DeleteResponse`] snapshot;
-/// `SessionNotFound` → 404; `InvalidState` (the running-guard refusal) → 409
-/// with the manager's actionable message; any other error → 500. NEVER
-/// touches the workspace directory on disk (see `delete_record`'s doc).
-/// Test: `delete_route_marks_deleted`, `delete_route_refuses_running_without_force`,
-/// `delete_route_force_bypasses_guard` in managed_routes tests.
-pub async fn delete_managed_session(
-    State(state): State<Arc<DaemonState>>,
-    AxumPath(id_str): AxumPath<String>,
-    axum::extract::Query(q): axum::extract::Query<DeleteQuery>,
-) -> impl IntoResponse {
-    let id = match parse_id(&id_str) {
-        Ok(id) => id,
-        Err((code, msg)) => return (code, msg).into_response(),
-    };
-    let mgr = state.session_manager().await;
-    match mgr.delete_record(&id, q.force).await {
-        Ok(record) => Json(DeleteResponse {
-            summary: record_to_summary(&record),
-            deleted: true,
-        })
-        .into_response(),
-        Err(crate::session_manager::ManagedError::SessionNotFound(_)) => {
-            (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
-        }
-        Err(crate::session_manager::ManagedError::InvalidState(_, reason)) => {
-            (StatusCode::CONFLICT, reason).into_response()
-        }
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-    }
-}
-
-/// DELETE /api/v1/sessions/managed/{id} — stop and deregister (legacy alias).
-///
-/// Why: the original MVP wired DELETE to a "stop" that marked the record Dead.
-/// The new semantic is `POST /{id}/runtime-stop` (keep workspace) and
-/// `POST /{id}/decommission` (full teardown). This handler now delegates to
-/// `runtime-stop` (marks Stopped, keeps workspace) so existing scripts that use
-/// DELETE do not experience data loss.
-/// What: delegates to SessionManager::stop.
-/// Test: covered by `stop_managed_session_runtime` tests.
-pub async fn stop_managed_session(
-    State(state): State<Arc<DaemonState>>,
-    AxumPath(id_str): AxumPath<String>,
-) -> impl IntoResponse {
-    stop_managed_session_runtime(State(state), AxumPath(id_str)).await
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/tests/inproject_cold_start.rs
+++ b/crates/trusty-mpm/tests/inproject_cold_start.rs
@@ -1,0 +1,178 @@
+//! Integration test: a cold start hands off to the daemon-managed spawn path (#4990).
+//!
+//! Why: the unit tests prove `ensure_managed_checkout_at` clones and refuses
+//! correctly. They do NOT prove the thing that makes the feature work — that
+//! what it produces is exactly what the daemon-managed session-launch path
+//! demands. `try_inproject_spawn` is that gate: it accepts a directory only
+//! when `.git` exists AND `remote.origin.url` parses into a GitHub identity,
+//! and its `Ok(Some((base, owner, repo)))` return is what the lifecycle layer
+//! turns into a `SessionRecord` with a tmux pane. Feeding a freshly
+//! cold-started checkout through the real gate is the strongest claim available
+//! without a live daemon, tmux server, and `claude` binary.
+//!
+//! HERMETIC BY CONSTRUCTION. Both the cold start and `try_inproject_spawn`
+//! resolve `<repos_root>/<owner>/<repo>`, which defaults to the operator's real
+//! `~/trusty-mpm-projects`. Pinning `TRUSTY_MPM_REPOS_ROOT` to a temp directory
+//! is what keeps this test from writing into a real checkout — or, on a machine
+//! that has not cloned the repo, from cloning it over the network.
+//! What: builds a real local source repo, cold-starts a managed checkout from
+//! it with no pre-existing cwd, and asserts `try_inproject_spawn` accepts the
+//! result and reports the same base path.
+//! Test: this file IS the test; run with `cargo test -p trusty-mpm --test
+//! inproject_cold_start`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use trusty_mpm::daemon::managed_routes::inproject::{REPOS_ROOT_ENV, try_inproject_spawn};
+use trusty_mpm::daemon::managed_routes::inproject_cold_start::{
+    ensure_managed_checkout, ensure_managed_checkout_at,
+};
+
+/// RAII guard pinning `TRUSTY_MPM_REPOS_ROOT` and restoring it on drop.
+///
+/// Why: `base_clone_path` resolves against the operator's real home by default.
+/// Without this, the cold start under test would clone into (and
+/// `try_inproject_spawn` would write `.git/info/exclude` inside) the real
+/// `~/trusty-mpm-projects/bobmatnyc/trusty-tools`. `std::env::set_var` is
+/// `unsafe` in Rust 2024 because it is thread-unsafe, so every test using this
+/// guard is `#[serial_test::serial]` — the same pattern `tests/local_spawn.rs`
+/// uses for `$HOME`.
+struct ReposRootGuard(Option<String>);
+
+impl ReposRootGuard {
+    fn set(dir: &Path) -> Self {
+        let prev = std::env::var(REPOS_ROOT_ENV).ok();
+        // SAFETY: every caller is `#[serial_test::serial]`, so only one thread
+        // in this test binary mutates the environment at a time.
+        unsafe { std::env::set_var(REPOS_ROOT_ENV, dir) };
+        Self(prev)
+    }
+}
+
+impl Drop for ReposRootGuard {
+    fn drop(&mut self) {
+        // SAFETY: see `set`.
+        match &self.0 {
+            Some(p) => unsafe { std::env::set_var(REPOS_ROOT_ENV, p) },
+            None => unsafe { std::env::remove_var(REPOS_ROOT_ENV) },
+        }
+    }
+}
+
+/// Run a git command in `dir`, panicking with full output on failure.
+fn git(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn git {args:?} in {dir:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} in {dir:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Build a one-commit source repository to clone from.
+fn init_source(path: &Path) -> PathBuf {
+    std::fs::create_dir_all(path).expect("mkdir source");
+    git(path, &["init", "-q", "-b", "main"]);
+    git(path, &["config", "user.email", "test@example.com"]);
+    git(path, &["config", "user.name", "Test"]);
+    std::fs::write(path.join("README.md"), "hello\n").expect("write");
+    git(path, &["add", "."]);
+    git(path, &["commit", "-q", "-m", "initial"]);
+    path.to_path_buf()
+}
+
+/// THE COLD-START PROOF: no checkout, no cwd — just an identity and a URL — and
+/// the result satisfies the daemon-managed spawn gate.
+///
+/// Why: `try_inproject_spawn` returning `Ok(Some(..))` is precisely the
+/// condition under which `spawn_managed_routed` proceeds to resolve a session
+/// name, create the per-session worktree, and register a `SessionRecord`. A
+/// cold-started checkout that fails this gate would silently fall through to
+/// the local-path spawn — the exact "not a managed session" outcome the feature
+/// exists to prevent.
+#[test]
+#[serial_test::serial]
+fn cold_start_produces_a_checkout_the_managed_spawn_path_accepts() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let source = init_source(&tmp.path().join("source"));
+    let repos_root = tmp.path().join("repos");
+    let _guard = ReposRootGuard::set(&repos_root);
+
+    // Cold start: nothing exists at the destination.
+    let expected = repos_root.join("bobmatnyc").join("trusty-tools");
+    assert!(!expected.exists(), "precondition: no checkout on disk");
+
+    let checkout = ensure_managed_checkout(
+        "bobmatnyc",
+        "trusty-tools",
+        source.to_str().expect("utf8 path"),
+    )
+    .expect("cold start clones");
+
+    assert!(!checkout.reused, "nothing was there to reuse");
+    assert_eq!(
+        checkout.base_path, expected,
+        "the cold start must land on the canonical <repos_root>/<owner>/<repo>"
+    );
+
+    // A real `git clone` of a GitHub remote leaves that GitHub URL as `origin`;
+    // this fixture cloned from a local path, so point `origin` where the real
+    // one would be. It is what the identity gate reads.
+    git(
+        &checkout.base_path,
+        &[
+            "remote",
+            "set-url",
+            "origin",
+            "git@github.com:bobmatnyc/trusty-tools.git",
+        ],
+    );
+
+    // THE GATE — the real function the daemon's lifecycle layer calls.
+    let (resolved_base, owner, repo) = try_inproject_spawn(&checkout.base_path)
+        .expect("in-project spawn detection must not error")
+        .expect("a cold-started checkout must be accepted, not fall through to local-path spawn");
+
+    assert_eq!(owner, "bobmatnyc");
+    assert_eq!(repo, "trusty-tools");
+    assert_eq!(
+        resolved_base, checkout.base_path,
+        "the spawn path must resolve to the very directory the cold start produced"
+    );
+}
+
+/// A wrong-remote reuse is refused with the existing checkout untouched.
+///
+/// Why: the unit test proves the error type; this proves the ordering claim
+/// that matters operationally — nothing is fetched into or merged into a
+/// directory belonging to a different repository before the refusal lands.
+#[test]
+#[serial_test::serial]
+fn wrong_remote_reuse_is_refused_without_touching_the_checkout() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let source = init_source(&tmp.path().join("source"));
+    let base = tmp.path().join("base");
+
+    ensure_managed_checkout_at(&base, source.to_str().expect("utf8 path")).expect("first clone");
+    let head_before = git(&base, &["rev-parse", "HEAD"]);
+
+    let err = ensure_managed_checkout_at(&base, "https://github.com/someone/else.git")
+        .expect_err("a different remote must be refused");
+    assert!(
+        err.to_string().contains("someone/else"),
+        "message names the requested repo: {err}"
+    );
+
+    assert_eq!(
+        git(&base, &["rev-parse", "HEAD"]),
+        head_before,
+        "the refused checkout must be left exactly as it was"
+    );
+}


### PR DESCRIPTION
## What

`tm run` accepted only a DOC-24 registry alias. Starting work on a repo that was neither registered nor already cloned had no entry point: the daemon-managed system can only be entered from a checkout that already exists, because `try_inproject_spawn` (`daemon/managed_routes/inproject.rs:781-800`) gates on `path.join(".git").exists()` and derives the GitHub identity from `remote.origin.url`.

`tm run <owner>/<repo>` is that cold start:

1. classify the positional (shared with `tm register`) → clone URL + `owner`/`repo`;
2. `inproject_cold_start::ensure_managed_checkout` → the managed checkout at `~/trusty-mpm-projects/<owner>/<repo>`, cloned or verified;
3. hand off to the existing `tm launch` path.

Step 3 is a handoff, not a reimplementation. `launch()` registers the project alias, provisions the per-session worktree, prepares the session, registers it with the daemon, creates the tmux host, and attaches — so the outcome is a real `SessionRecord` with a tmux pane, visible in `tm ls` and `tm sessions`, not a blocking foreground `claude`. A session started cold is indistinguishable from one started in-project.

`tm run <alias>` is unchanged.

## Reusing an existing checkout: one refusal, one warning

**Wrong remote → FAIL LOUD.** No check exists anywhere today — the standalone driver pulls from whatever `origin` happens to be, so re-pointing an alias at a new URL keeps serving the old remote forever under the new name. Refusing is the only non-destructive answer: re-pointing `origin` under a directory that may hold branches and unpushed commits from the *other* repository is not a repair. Checked before anything writes. Remotes compare through a host-aware canonicalization, so `git@github.com:o/r.git` and `https://github.com/o/r` match while two different hosts do not.

**Dirty tree → WARN AND PROCEED.** This reverses the PR's first revision, on the finding below. Since #4957 the session branch is cut from a freshly-fetched `origin/<default>` (`inproject_start_point::resolve`) and never inherits the base checkout's local `HEAD`, so a skipped fast-forward cannot leak stale content into the session. Meanwhile the tm checkout is shared with the operator and their editors, making uncommitted content its expected steady state (ADR-0030 §4/§5) — refusing blocks the common case, including this repo's own checkout, which is dirty right now.

What must not happen is silence, which is the half of the `pull_ff_only` (`core/standalone/load.rs:186-199`) shape that really is a defect: it warns where nobody looks and returns `Ok(())`. So the skip goes two places — a `warn!` for the log path, and `ManagedCheckout::refresh_skipped`, which `tm run` prints to stderr naming the path and what is dirty.

The fetch runs either way. Only the fast-forward is gated — ADR-0030 §4 exactly.

## Incidental fix

`tm run ./some/dir` routed a relative path into a registry lookup and reported `alias './some/dir' not found`. Caught by a test; it now reports that a relative path is not a repository, the same remedy `tm register` gives.

## 🔴 ADR-0030 is NOT flipped to Accepted — three findings

The original brief asked for the status flip here. It is not in this PR: ADR-0030's Consequences section is wrong about this codebase, and the ADR's decision is not what this PR implements.

**1. The `reset --hard` bullet describes code that is not there.** ADR-0030's Negative consequence says `run_hygiene_for_base` "runs a safety-gated `reset --hard` against the tm checkout at daemon startup (`inproject_hygiene.rs:291-303`)". On `origin/main` at a08e7bd8 there is no `reset --hard` in that file — it became `git merge --ff-only` in #2181 (`62fdc1c11`), before the ADR was written. Lines 291-303 are `write_recovery_ref`'s doc comment.

**2. The fix it calls "in flight on another branch" has merged.** The gitignored-clobber hole (`is_dirty` omitting `--ignored`) landed as #4962 (`51c08788e`), which added `colliding_untracked_paths` and `HYGIENE_OPT_OUT_MARKER`. Decision point 4's "never `reset --hard`" is already satisfied.

**3. Of its eight decision points only #5 is implemented, and this PR implements none of them.** A cold-start entry point is orthogonal to session↔workstream cardinality; the ADR never mentions `tm run`, cloning, or registration.

Flipping to Accepted is defensible as recording the owner's 2026-08-05 ruling — this repo uses Accepted for decision-acceptance, not implementation — but it should carry those three corrections, so it is its own change.

Finding 3's §4/§5 reading is what reversed the dirty-tree decision above.

## Gate — rung 5

```
cargo fmt --check && cargo check -p trusty-mpm --all-targets \
  && cargo clippy -p trusty-mpm --all-targets -- -D warnings \
  && cargo test -p trusty-mpm -- --test-threads=1
RUNG5_GATE_EXIT=0
TOTAL: 7919 passed, 0 failed, 17 ignored across 46 binaries
```

All nine repo lints:

```
check_line_cap.sh            EXIT=0  | 3731 tracked .rs file(s); 7 allowlisted, 0 violations — OK.
check_sld.sh                 EXIT=0  | 56 spec doc(s) + 3108 code file(s); 0 error(s), 0 warning(s)
check_doc_numbers.sh         EXIT=0  | 102 doc(s) / 96 claim(s); 4 grandfathered, 0 violations — OK.
check_test_pointers.sh       EXIT=0  | resolved 21947 Test: citation(s) — 0 dangling pointers — OK.
check_capabilities.sh        EXIT=0  | tm-capabilities: up to date (7 generated files).
check_changelog_fragment.sh  EXIT=0  | all 1 crate(s) with source changes are recorded.
check_generation_artifacts.sh EXIT=0 | 16 stylesheet(s) + 1232 prose file(s) — 0 leaked artifacts — OK.
check_agent_assets.sh        EXIT=0  | 30 byte-parity file(s) all match; 4 pinned deviation(s) — OK.
check_buildrs_sync.sh        EXIT=0  | build.rs canonical blocks in sync across all 4 crates.
```

`tm generate capabilities` was re-run and its one-line `tm run` description change committed.

```
cargo test -p trusty-mpm -- --include-ignored --test-threads=1
TOTAL: 7752 passed, 1 failed
  meta_run_demo_writes_and_verifies_artifact
```

### Baseline failures, not change-specific

Three tests fail on a parallel run; all three are already rows in `docs/reference/test-ladder-baseline.md`, and `git diff --name-only origin/main...HEAD` returns empty for every path they live in.

| Test | Baseline row |
|---|---|
| `stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet` | "Parallel-run race on `$HOME` mutation between tests. Fails 3 of 5 runs on a clean baseline worktree with no branch changes. Passes under `-- --test-threads=1`" |
| `ensure_managed_config_dir_emits_the_frozen_skill_warning` | #4931 thread-local tracing subscriber losing to a global one; signature `Captured lines: []` |
| `meta_run_demo_writes_and_verifies_artifact` | "Times out at ~187s… launches a real Claude Code session… Reproduced identically on a clean baseline worktree" |

The doc prescribes `-- --test-threads=1` as the remedy, which is what the green run above uses. That runs every test — no `#[ignore]`, no `cfg`-gating, no `--exclude`, no `--lib` narrowing.

## Coverage

| Case | Test |
|---|---|
| Invalid `owner/repo` rejected before any network call | `classify_rejects_browser_pastes_and_paths`, `classify_rejects_empty_target` (both pure) |
| Dirty checkout warns and proceeds | `dirty_existing_checkout_warns_and_proceeds` — asserts the call succeeds, the skip is reported to the caller naming the dirty file, the uncommitted edit survives, the local branch did NOT move, and `origin/main` WAS fetched |
| Wrong-remote checkout fails loud, HEAD unmoved | `existing_checkout_on_a_different_remote_fails_loud`, `wrong_remote_reuse_is_refused_without_touching_the_checkout` |
| No-origin checkout fails loud | `existing_checkout_without_an_origin_fails_loud` |
| Fresh clone feeds the real daemon-managed spawn gate | `cold_start_produces_a_checkout_the_managed_spawn_path_accepts` — asserts `try_inproject_spawn` accepts the cold-started checkout and resolves to the same path |
| Clean reuse fast-forwards and reports no skip | `clean_matching_checkout_is_reused_and_refreshed` |
| `tm run` and `tm register` agree on a string | `shorthand_identity_agrees_with_url_identity` |

The dirty-tree test moves origin forward first, so "was not fast-forwarded" cannot pass vacuously.

The `SessionRecord` claim is proven at the gate that produces one (`try_inproject_spawn` returning `Ok(Some(..))` is what makes `spawn_managed_routed` register a record), not through a live daemon — that would need a running daemon, tmux server, and `claude` binary.

Integration tests pin `TRUSTY_MPM_REPOS_ROOT` to a tempdir. Without that they would have written into the operator's real `~/trusty-mpm-projects/bobmatnyc/trusty-tools`, or cloned it over the network on a machine that lacks it.

## Incidental split

`managed_routes/mod.rs` sat at exactly the 500-SLOC cap, so one `pub mod` line broke the gate. The two record-deletion handlers move to a sibling `delete.rs` and are re-exported; route wiring and callers are unchanged. Not allowlisted.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
