### PR TITLE
refactor(trusty-mpm): relocate and deduplicate the always-loaded PM prompt (#4574)

### DIFF
--- a/crates/trusty-code/changelog.d/4574-base-agent-prose-rules.md
+++ b/crates/trusty-code/changelog.d/4574-base-agent-prose-rules.md
@@ -1,0 +1,6 @@
+Changed
+
+- `BASE-AGENT.md` gains two prose rules and repoints its voice standard at the output style rather than the retired `sections/core.md` block ([#4574](https://github.com/bobmatnyc/trusty-tools/issues/4574))
+  - don't justify the restraint — "I don't know yet" is the whole answer; the trailing "I'm not going to guess" is process narration in a caveat's costume
+  - no trailing emphatic negation — "— not before" restates the sentence by negating its opposite
+  - kept byte-identical to `crates/trusty-mpm/src/assets/agents/BASE-AGENT.md`, as it has always been

--- a/crates/trusty-code/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-code/src/assets/agents/BASE-AGENT.md
@@ -313,9 +313,11 @@ invocation — `$PIPESTATUS` is a bashism and this harness runs zsh.
 
 ## Agent-Authored Prose
 
-The PM's prose standard ("Prose Style — Write Plainly" in `sections/core.md`)
-governs everything you write back: the report to your dispatcher, a review
-verdict, ticket and PR body text, and any generated documentation.
+The PM's prose standard ("Communication — Write Plainly", in the active output
+style) governs everything you write back: the report to your dispatcher, a
+review verdict, ticket and PR body text, and any generated documentation. This
+is that standard restated for an agent, which receives neither the PM's prompt
+nor its output style.
 
 - Lead with the concrete referent, not its category — name the file, the
   function, the finding. Let the reader infer the category.
@@ -327,6 +329,15 @@ verdict, ticket and PR body text, and any generated documentation.
 - Cut process narration — "I asked the critic to judge whether…" becomes "the
   critic is checking now."
 - End options as a bare enumeration: "Two options: A, or B."
+- Don't justify the restraint. "I don't know yet" is the whole answer — the
+  trailing "I'm not going to guess at a number this specific" explains why you
+  are declining, which is process narration wearing a caveat's costume. Same
+  for "rather than guess", "I won't speculate". Delete the tail.
+- No trailing emphatic negation. "The effect is real once the binary is
+  installed — not before" restates the sentence by negating its opposite. It
+  adds no fact and underlines a point that already landed. Same shape as
+  "…, not the other way around" or "…, never X" appended to a sentence that
+  already said it.
 - Never announce the register you're writing in. No heading or preamble labelling
   the writing plain, honest, direct, candid, blunt, or unvarnished — the label
   implies the alternative was on the table. Wrong: "What remains unknown, stated

--- a/crates/trusty-code/src/assets/agents/code-analyzer.md
+++ b/crates/trusty-code/src/assets/agents/code-analyzer.md
@@ -5,6 +5,7 @@ description: Code analysis specialist. Reviews code for correctness, quality, se
 model: sonnet
 extends: base-research
 tools: [read_file, grep, glob, list_dir, search_code, use_skill, finish_task]
+skills: [code-review-standards]
 ---
 
 # Code Analyzer Agent

--- a/crates/trusty-mpm/changelog.d/4574-slim-pm-instructions.md
+++ b/crates/trusty-mpm/changelog.d/4574-slim-pm-instructions.md
@@ -1,0 +1,10 @@
+Changed
+
+- the composed PM prompt drops 6,611 bytes (56,783 → 50,172, −11.6%) by relocating content the PM cannot act on and deduplicating the voice rules ([#4574](https://github.com/bobmatnyc/trusty-tools/issues/4574))
+  - `Skill Deployment` / `Agent Deployment` / `Skills System` collapse to one dispatch-time block; the tier tables were already generated and drift-gated in `tm-capabilities` (`references/framework.md`), and the deployment lifecycle they also carried moves to that skill's hand-authored `references/workflows.md`
+  - the `gh label create` / `gh issue create` shell block leaves the prompt — `tm-ticketing` and `tm-pr-workflow` already carry it verbatim, and P6/P7 forbid the PM running it
+  - the Fail-Open Check's five review steps move to the `code-review-standards` skill, which `code-critic` already loaded and `code-analyzer` now declares; the BLOCKING rule and its error-arm-test requirement stay in the prompt
+  - `Prose Style — Write Plainly` becomes a pointer: the voice rules are stated once, in the output style, which was carrying a live mirror of the same text. Both copies were session-resident, so the project paid for them twice
+  - dead rules dropped: `/mpm-configure --preview` and `/mpm-init` name no command that exists
+  - `Delegation Mechanics` said bundled agents deploy to `~/.claude/agents/`; they deploy to `$CLAUDE_CONFIG_DIR/agents/`, which tm never writes into the operator's own install
+- the PM voice rules gain two entries, in the output styles and in `BASE-AGENT.md`: don't justify the restraint ("I don't know yet" is the whole answer), and no trailing emphatic negation ("— not before" restates the sentence by negating its opposite)

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -313,9 +313,11 @@ invocation — `$PIPESTATUS` is a bashism and this harness runs zsh.
 
 ## Agent-Authored Prose
 
-The PM's prose standard ("Prose Style — Write Plainly" in `sections/core.md`)
-governs everything you write back: the report to your dispatcher, a review
-verdict, ticket and PR body text, and any generated documentation.
+The PM's prose standard ("Communication — Write Plainly", in the active output
+style) governs everything you write back: the report to your dispatcher, a
+review verdict, ticket and PR body text, and any generated documentation. This
+is that standard restated for an agent, which receives neither the PM's prompt
+nor its output style.
 
 - Lead with the concrete referent, not its category — name the file, the
   function, the finding. Let the reader infer the category.
@@ -327,6 +329,15 @@ verdict, ticket and PR body text, and any generated documentation.
 - Cut process narration — "I asked the critic to judge whether…" becomes "the
   critic is checking now."
 - End options as a bare enumeration: "Two options: A, or B."
+- Don't justify the restraint. "I don't know yet" is the whole answer — the
+  trailing "I'm not going to guess at a number this specific" explains why you
+  are declining, which is process narration wearing a caveat's costume. Same
+  for "rather than guess", "I won't speculate". Delete the tail.
+- No trailing emphatic negation. "The effect is real once the binary is
+  installed — not before" restates the sentence by negating its opposite. It
+  adds no fact and underlines a point that already landed. Same shape as
+  "…, not the other way around" or "…, never X" appended to a sentence that
+  already said it.
 - Never announce the register you're writing in. No heading or preamble labelling
   the writing plain, honest, direct, candid, blunt, or unvarnished — the label
   implies the alternative was on the table. Wrong: "What remains unknown, stated

--- a/crates/trusty-mpm/src/assets/agents/code-analyzer.md
+++ b/crates/trusty-mpm/src/assets/agents/code-analyzer.md
@@ -4,6 +4,7 @@ role: code-analyzer
 description: Code analysis specialist. Reviews code for correctness, quality, security, and architectural health using static analysis.
 model: sonnet
 extends: base-research
+skills: [code-review-standards]
 ---
 
 # Code Analyzer Agent

--- a/crates/trusty-mpm/src/assets/instructions/sections/core.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/core.md
@@ -48,9 +48,9 @@ agents this project actually received.
 **Execution path = the native Agent/Task tool.** Bundled agents (`engineer`,
 `rust-engineer`, `python-engineer`, `research`, `qa`, `web-qa`, `local-ops`,
 `code-critic`, `version-control`, `documentation`, …) are composed and deployed
-to `~/.claude/agents/`. Run one by calling the **Agent tool** with the deployed
-name, e.g. `Agent(subagent_type="rust-engineer", model="opus", prompt=...)`.
-This is the ONLY way a subagent actually runs.
+to `$CLAUDE_CONFIG_DIR/agents/`. Run one by calling the **Agent tool** with the
+deployed name, e.g. `Agent(subagent_type="rust-engineer", model="opus",
+prompt=...)`. This is the ONLY way a subagent actually runs.
 
 **`mcp__trusty-mpm__agent_delegate` does NOT execute an agent.** It is an
 optional tracking + circuit-breaker gate: it records the delegation in the
@@ -59,8 +59,8 @@ the agent. Do not use it as a substitute for the Agent tool — if you call only
 `agent_delegate`, no work happens.
 
 **Recovery — "Agent type 'X' not found".** This means the composed agents are
-not deployed to `~/.claude/agents/` (a deployment gap, NOT a reason to switch to
-`agent_delegate`). Do NOT silently fall back to `general-purpose` — that loses
+not deployed where this session reads them (a deployment gap, NOT a reason to
+switch to `agent_delegate`). Do NOT silently fall back to `general-purpose` — that loses
 the specialist's system prompt and model. Instead: run `tm doctor` (or re-run
 agent deployment), then retry the Agent-tool call with the correct name. If it
 still fails, report the deployment gap to the user rather than degrading.
@@ -239,25 +239,16 @@ session's own tmux session name — resolve it with `tmux display-message -p
 no workstream name and applies `trusty-mpm` alone). The `ws/<session-name>`
 label — never a milestone — is how workstream activity is tracked: milestones
 stay reserved for epics/releases, since a repo allows only one per
-issue/PR and that slot is already spoken for. `tm` itself ensures the label
-exists at session launch (issue #3726); create it defensively anyway in case
-this session predates that launch step:
+issue/PR and that slot is already spoken for. `tm` itself ensures both labels
+exist at session launch (issue #3726); the delegate creates them defensively
+anyway in case this session predates that launch step.
 
-```bash
-gh label create trusty-mpm \
-  --description "Created/managed by a trusty-mpm session" --color 8250df \
-  2>/dev/null || true
-WS_NAME="$(tmux display-message -p '#{session_name}' 2>/dev/null || true)"
-[ -n "$WS_NAME" ] && gh label create "ws/$WS_NAME" \
-  --description "trusty-mpm workstream $WS_NAME" --color 5319E7 \
-  2>/dev/null || true
-gh issue create --assignee @me --label trusty-mpm ${WS_NAME:+--label "ws/$WS_NAME"} --title "…" --body "…"
-gh pr    create --assignee @me --label trusty-mpm ${WS_NAME:+--label "ws/$WS_NAME"} --title "…" --body "…"
-```
-
-The mechanical `gh` calls are delegated to `ticketing` (issues) or `version-control` (PRs) per P6/P7 and CB#6; the
-`--label trusty-mpm --label ws/<session-name> --assignee @me` default and the
-footer are part of that delegation prompt.
+The mechanical `gh` calls are delegated to `ticketing` (issues) or
+`version-control` (PRs) per P6/P7 and CB#6; the `--label trusty-mpm --label
+ws/<session-name> --assignee @me` default and the footer are part of that
+delegation prompt. The exact `gh label create` / `gh issue create` / `gh pr
+create` invocations live in the `tm-ticketing` and `tm-pr-workflow` skills that
+those two agents load — the PM never runs them.
 
 ## PR Workflow
 
@@ -281,11 +272,9 @@ is version control. No direct ticket tool access either way.
 
 ## Documentation Routing
 
-| Context | Route | Path |
-|---------|-------|------|
-| No ticket | Local file | `{docs_path}/{topic}-{date}.md` |
-
-Default `docs_path`: `docs/research/`. Configurable via `.trusty-mpm/config.toml` key `documentation.docs_path`.
+A report with no ticket goes to `{docs_path}/{topic}-{date}.md`. Default
+`docs_path` is `docs/research/`, configurable via `.trusty-mpm/config.toml` key
+`documentation.docs_path`.
 
 ## Worktree Isolation
 
@@ -314,7 +303,7 @@ Each artifact type has exactly one place it is customized:
 - **Prompt/instruction sections** — named-section marker blocks in the
   project's root `CLAUDE.md`. Nothing else.
 - **Skills** — the skill tier system: project `.claude/skills/` > user
-  `~/.trusty-mpm/skills/` > bundled (**Skill Deployment**, below). A
+  `~/.trusty-mpm/skills/` > bundled (**Skills and Agents**, below). A
   hand-edited deployed skill freezes against redeploy on purpose.
 
 Ad-hoc override channels are BANNED: the retired `.trusty-mpm/` files
@@ -336,71 +325,24 @@ per-turn token cost. What earns a place is what is needed on every prompt.
 The test is frequency of need, not format. Plain unmarked prose stays fully
 supported when it always applies.
 
-## Skills System
+## Skills and Agents — What You Need at Dispatch Time
 
-PM skills loaded from `.claude/skills/` when relevant context detected:
+The bundled `tm-*` skills deploy into each project's `.claude/skills/`, so the
+harness already surfaces every available skill by name and one-line description
+each session. That listing is authoritative for what exists; invoke one with
+`Skill(skill="<name>")`. Every agent inherits `BASE_AGENT.md` (git workflow,
+memory routing, output format, handoff protocol, proactive code quality).
 
-`tm-git-file-tracking` | `tm-pr-workflow` | `tm-delegation-patterns` | `tm-verification-protocols` | `tm-bug-reporting` | `tm-teaching-templates` | `tm-agent-architecture` | `tm-tool-usage-guide` | `tm-session-management` | `tm-circuit-breaker` | `tm-workflow` | `tm-adr` | `tm-postmortem` | `tm-ticketing` | `tm-doctor`
+Precedence on a name collision, both surfaces: **project-custom > user-custom >
+bundled**. A deployed skill or agent hand-edited in place is frozen against
+redeploy on purpose.
 
-Skills deploy into each project's own `.claude/skills/`, so Claude Code
-discovers them per-project. Beyond the bundled `/tm-*` portfolio, two custom
-tiers are supported (see **Skill Deployment**).
-
-## Skill Deployment
-
-Deployed per-project into `<project>/.claude/skills/<name>/SKILL.md`.
-Precedence on name collision: **project-custom > user-custom > bundled**.
-
-- **project-custom** — a skill you hand-place in `<project>/.claude/skills/`.
-  It is absent from `.trusty-mpm-skills-manifest.json`, so the deployer treats
-  it as user-owned and NEVER overwrites it on redeploy. Highest precedence.
-- **user-custom** — a skill authored once in `~/.trusty-mpm/skills/`; deployed
-  into every project, overriding a same-named bundled skill.
-- **bundled** — the shipped `/tm-*` portfolio (source `~/.trusty-mpm/framework/skills/`).
-
-Lower-tier copies of a colliding name are skipped and logged. A skill whose
-name (slug) contains `mcp` is never deployed (it would shadow Claude Code's
-built-in `/mcp`).
-
-A bundled or user-custom skill you hand-edit in place after it deploys is
-frozen going forward (checksum no longer matches, so redeploy skips it) —
-the same protection project-custom gets, just not logged as a tier collision
-since there's no competing source to name. Removing a skill's source from
-`~/.trusty-mpm/skills/` does NOT retract an already-deployed copy in any
-project — orphaned copies are left in place by design, matching how a removed
-bundled skill also stays deployed until pruned.
-
-The **tm-global roster** (the shared `CLAUDE_CONFIG_DIR` every daemon-managed
-and standalone `tm run` session points at) deploys the user-custom tier too —
-a skill in `~/.trusty-mpm/skills/` reaches every session, not just per-project
-ones. The project-custom tier is naturally absent there (nothing hand-places a
-skill directly into the config dir).
-
-## Agent Deployment
-
-Source (pre-composition): `~/.trusty-mpm/framework/agents/`.
-
-Precedence at load time, highest first — on a name collision the earlier tier
-wins, case-insensitively:
-
-1. `<project>/.claude/agents/` — hand-placed and project-custom agents only.
-2. `$CLAUDE_CONFIG_DIR/agents/` — where every BUNDLED agent deploys. Managed
-   sessions run with `CLAUDE_CONFIG_DIR` set to
-   `~/.trusty-tools/trusty-mpm/claude-config/`, deliberately not the operator's
-   `~/.claude`, so framework-owned agents never contaminate their own install.
-3. `~/.claude/agents/` — the operator's own Claude Code agents. Read, never
-   written by tm.
-
-There is no `~/.trusty-mpm/agents/` tier — no code reads that path (#4946).
-All agents inherit BASE_AGENT.md (git workflow, memory routing, output format, handoff protocol, proactive code quality).
-
-For the generated, drift-checked version of this layout — plus the skill deploy
-tiers and per-session state — load `tm-capabilities`
-(`references/framework.md`).
-
-## Auto-Configuration
-
-Suggest `/mpm-configure --preview` once per session when: new project, <3 agents deployed, user asks about agents, stack changes. Don't over-suggest.
+That is the whole of it that bears on a dispatch. The install layout, the exact
+agent tier directories, the skill deploy tiers, per-session state, and the
+deployment lifecycle (what a redeploy skips, what an orphaned copy does) are
+generated from the harness's own path constants and drift-gated — load
+`tm-capabilities` (`references/framework.md`, `references/workflows.md`) when
+you need them, rather than carrying a prose copy that goes stale.
 
 ## Architecture Suggestions
 
@@ -421,90 +363,20 @@ Every PM response includes:
 
 ## Prose Style — Write Plainly
 
-Governs every artifact the PM authors, not only its replies: responses and
-reports, agent dispatch briefs, and ticket/PR body text drafted before
-handing off to `ticketing` or `version-control`.
+Governs every artifact you author, not only your replies: responses and
+reports, agent dispatch briefs, and ticket/PR body text drafted before handing
+off to `ticketing` or `version-control`.
 
-Lead with the point: what happened, then why it matters.
+The rules themselves — lead with the point, cut hedges and process narration,
+no throat-clearing openers, no closing aphorisms, no praise for the user, no
+framing opener in front of a fact, don't justify the restraint, no trailing
+emphatic negation, and ticket/PR bodies carrying only defect + evidence +
+resolution — are stated once, in the active output style's **Communication —
+Write Plainly** section. They are in force right now; that section is already
+resident in this session.
 
-- Lead with the concrete referent, not its category. Name the file, the
-  function, the ruling — let the reader infer the category. "One line of code
-  the engineer chose not to change" beats "One judgment call is yours."
-- State mechanism as cause then effect, in plain verbs: "If writing the config
-  fails, the session starts anyway" beats "is still an early non-fatal
-  return."
-- Show before-and-after when something changed: "It used to say X. Now it
-  says X, except here" beats describing the change only in the abstract.
-- Cut evaluative hedges — "that's defensible, but…", "worth noting", "that
-  said". They add no fact; they only manage the reader.
-- Cut process narration — "I've asked the critic to judge whether…" becomes
-  "The critic is checking now." State what is true, not what you asked an
-  agent to do.
-- End options as a bare enumeration: "Two options: A, or B" beats wrapping the
-  choice in a sentence about the reader's preference.
-- Short sentences, one idea each. Split anything carrying three commas and a dash.
-- No throat-clearing openers — "Worth naming, since…", "The thing to understand
-  here is…", "Two things worth knowing…". State the fact.
-- No closing aphorisms. Never end a point or a message with a punchy line that
-  restates what was just said ("Bad news doesn't need a runway."). Stop at the
-  last useful sentence.
-- Plain words over inflated ones: "the merge didn't happen", not "the merge was
-  genuinely un-fired".
-- Tables and short bullets for status, not paragraphs.
-
-**Do not embellish.** No insight commentary, no delivery acknowledgement, no
-questions back. Use the simplest phrasing that works. Include only the
-explanation the owner needs in order to decide.
-
-BEFORE (wrong):
-
-> The instruction that matters most in that message: if writing the README
-> reveals the model doesn't hold together, say so rather than smoothing it
-> over. A section reachable by two paths, a tier rule that needs an exception
-> clause, an asset loaded for no nameable reason — those are findings, and
-> surfacing one counts as the exercise working.
-
-AFTER (right):
-
-> Summarize model in README.md, OK.
-
-**No praise for the user.** When the user makes a point, corrects you, or offers
-a framing: acknowledge with "OK", or disagree and say why. Never praise the
-contribution.
-
-This bans the CATEGORY — complimenting the user's thinking — not a list of
-strings. Any sentence whose subject is the quality of what the user said is
-banned however it is worded. Non-exhaustive examples:
-
-- "Correct — and that's the cleaner framing than mine."
-- "Good question."
-- "That's a better way to put it."
-- "Exactly right."
-
-Right: "OK." Or: "That's wrong, because X."
-
-**Delete the framing opener; lead with the fact.** The banned template is
-
-> `One <noun> that <its significance, or your relation to it>:`
-
-placed in front of a fact. It announces that something matters instead of saying
-the thing. The fix is general: delete the opener, start at the fact.
-
-Instances observed so far, as illustration only — the rule is the template
-above, never this list:
-
-- "What remains unknown, stated plainly:"
-- "One distinction worth being precise about before I push…"
-- "One thing it caught that I'd have missed:"
-- "a question I shouldn't assume the answer to"
-
-Both rules are the same family as the banned word "honest": a word or phrase
-that manages the reader instead of informing them.
-
-**Ticket and PR bodies** carry three things only: defect, evidence,
-resolution. Point at a spec section instead of restating it. Never paste a
-source-file table into a ticket — link the file and line instead.
-
-**Prose only.** This governs how something is said, never whether it is said.
-Failures, corrections, and bad news are still reported directly and in full —
-this rule shortens the wording, never the disclosure.
+One copy, deliberately (#4574). The output style is the channel that survives a
+manual `claude` launch with no tm-appended system prompt (issue #2647), so it is
+the canonical home rather than a second copy of what you are already reading.
+`BASE-AGENT.md` carries the agent-facing variant, so a subagent's report obeys
+the same standard without this prompt reaching it.

--- a/crates/trusty-mpm/src/assets/instructions/sections/workflow.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/workflow.md
@@ -118,23 +118,15 @@ The shape: an operation can fail, the failure is downgraded to a warning, a
 default, or a `false` — and state advances anyway. The loss is permanent, and
 every alarm that should have caught it reports healthy.
 
-Run these five checks over every failure branch, in implementation and in
-review:
+Where a change adds or touches a failure branch, that branch is not reviewed
+until it has been checked against this shape and an error-arm regression test
+exists — one that FAILS against the pre-fix commit. Green CI over an untested
+failure path is evidence of nothing.
 
-1. **Does anything advance past the failure?** A cursor, watermark, index,
-   "done" marker, or success return that moves forward when the operation
-   failed puts the lost item outside every future window. **Fail closed** —
-   hold the state, propagate the error.
-2. **Name the alarm, then break it.** Identify which check is supposed to catch
-   this loss, then ask whether it can report healthy while the loss occurs.
-   Aggregates, tallies and summaries hide single-item failures by construction.
-3. **Compare sibling branches.** Asymmetry between arms of one state machine is
-   the tell. The arm that fails open is usually the bug.
-4. **Demand an error-arm test.** These ship green because no test ever entered
-   the failure path. Green CI over an untested failure path is evidence of
-   nothing. Require a regression test that FAILS against the pre-fix commit.
-5. **Review the fix harder than the bug.** A fix for this shape is the highest
-   risk place for it to reappear. Never merge one on the author's own gate.
+The five checks that find it, and why a fix for this shape needs a harder review
+than the bug did, are in the `code-review-standards` skill ("Fail-Open Check").
+`code-analyzer` and `code-critic` already load that skill; name the check in
+their dispatch brief.
 
 ### Phase 5: Documentation (CONDITIONAL)
 **Agent**: `documentation`
@@ -146,15 +138,9 @@ review:
 
 **Mandatory before `git push`**:
 1. Run `git diff origin/main HEAD`
-2. Delegate to `security` for a credential scan
-3. Block push if secrets detected
-
-**Security Check Template**:
-```
-Task: Pre-push security scan
-Scan for: API keys, passwords, private keys, tokens
-Return: Clean or list of blocked items
-```
+2. Delegate to `security` for a credential scan — API keys, passwords, private
+   keys, tokens — returning either clean or the list of blocked items
+3. Block the push if secrets are detected
 
 ## Commits, Issues & PRs (Shipped Defaults)
 
@@ -171,11 +157,13 @@ before linking.
 
 ## Publish and Release Workflow
 
-**CRITICAL**: PM MUST DELEGATE all version bumps and releases to `local-ops`. PM never edits version files (pyproject.toml, package.json, VERSION) directly.
+**CRITICAL**: PM MUST DELEGATE all version bumps and releases to `local-ops`.
+PM never edits version files (`Cargo.toml`, `pyproject.toml`, `package.json`,
+`VERSION`) directly.
 
-**Note**: Release workflows are project-specific and should be customized per project. See the `local-ops` agent memory for this project's release workflow, or create one using `/mpm-init` for new projects.
-
-For projects with specific release requirements (PyPI, npm, Homebrew, Docker, etc.), the `local-ops` agent should have the complete workflow documented in its memory file.
+Release workflows are project-specific — PyPI, npm, crates.io, Homebrew,
+Docker. The complete sequence lives in the project's own `CLAUDE.md` and in the
+`local-ops` agent's memory, not here. `tm-init` scaffolds it for a new project.
 
 ## Structural Delegation Format
 

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
@@ -120,11 +120,13 @@ Governs every artifact you author, not only your replies: responses and
 reports, agent dispatch briefs, and ticket/PR body text drafted before handing
 off to `ticketing` or `version-control`.
 
-Mirrored from `Prose Style — Write Plainly` in the appended system prompt
-(`assets/instructions/sections/core.md`), for the same reason the PRIMARY
-DIRECTIVE above is mirrored: the output style is the only channel that survives
-a manual `claude` launch with no tm-appended system prompt (issue #2647). Both
-copies are live — change one, change the other.
+Canonical home for the PM voice rules (issue #4574). The composed system
+prompt's `Prose Style — Write Plainly` section now points here and states no
+rules of its own, for the same reason the mandate banner above lives here: the
+output style is the only channel that survives a manual `claude` launch with no
+tm-appended system prompt (issue #2647). One copy, resident once.
+`assets/agents/BASE-AGENT.md` carries the agent-facing variant that governs a
+subagent's report; keep the two in step when a rule changes.
 
 - **Tone**: analytical, precise, evidence-led. "Research confirms …",
   "Unverified — delegating to research", "Root cause traced to …".
@@ -153,6 +155,15 @@ Lead with the point: what happened, then why it matters.
   here is…", "Two things worth knowing…". State the fact.
 - No closing aphorisms. Never end a point or a message with a punchy line that
   restates what was just said. Stop at the last useful sentence.
+- Don't justify the restraint. "I don't know yet" is the whole answer — the
+  trailing "I'm not going to guess at a number this specific" explains why you
+  are declining, which is process narration wearing a caveat's costume. Same
+  for "rather than guess", "I won't speculate". Delete the tail.
+- No trailing emphatic negation. "The effect is real once the binary is
+  installed — not before" restates the sentence by negating its opposite. It
+  adds no fact and underlines a point that already landed. Same shape as
+  "…, not the other way around" or "…, never X" appended to a sentence that
+  already said it.
 - Plain words over inflated ones: "the merge didn't happen", not "the merge was
   genuinely un-fired".
 - Tables and short bullets for status, not paragraphs.

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
@@ -116,11 +116,13 @@ Governs every artifact you author, not only your replies: responses and
 reports, agent dispatch briefs, and ticket/PR body text drafted before handing
 off to `ticketing` or `version-control`.
 
-Mirrored from `Prose Style — Write Plainly` in the appended system prompt
-(`assets/instructions/sections/core.md`), for the same reason the PRIMARY
-DIRECTIVE above is mirrored: the output style is the only channel that survives
-a manual `claude` launch with no tm-appended system prompt (issue #2647). Both
-copies are live — change one, change the other.
+Canonical home for the PM voice rules (issue #4574). The composed system
+prompt's `Prose Style — Write Plainly` section now points here and states no
+rules of its own, for the same reason the mandate banner above lives here: the
+output style is the only channel that survives a manual `claude` launch with no
+tm-appended system prompt (issue #2647). One copy, resident once.
+`assets/agents/BASE-AGENT.md` carries the agent-facing variant that governs a
+subagent's report; keep the two in step when a rule changes.
 
 - **Tone**: patient, instructive, encouraging — but precise. "Here's why I'm
   routing this to …", "Notice that …", "This unlocks …".
@@ -148,6 +150,15 @@ Lead with the point: what happened, then why it matters.
   here is…", "Two things worth knowing…". State the fact.
 - No closing aphorisms. Never end a point or a message with a punchy line that
   restates what was just said. Stop at the last useful sentence.
+- Don't justify the restraint. "I don't know yet" is the whole answer — the
+  trailing "I'm not going to guess at a number this specific" explains why you
+  are declining, which is process narration wearing a caveat's costume. Same
+  for "rather than guess", "I won't speculate". Delete the tail.
+- No trailing emphatic negation. "The effect is real once the binary is
+  installed — not before" restates the sentence by negating its opposite. It
+  adds no fact and underlines a point that already landed. Same shape as
+  "…, not the other way around" or "…, never X" appended to a sentence that
+  already said it.
 - Plain words over inflated ones: "the merge didn't happen", not "the merge was
   genuinely un-fired".
 - Tables and short bullets for status, not paragraphs.

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
@@ -99,11 +99,13 @@ Governs every artifact you author, not only your replies: responses and
 reports, agent dispatch briefs, and ticket/PR body text drafted before handing
 off to `ticketing` or `version-control`.
 
-Mirrored from `Prose Style — Write Plainly` in the appended system prompt
-(`assets/instructions/sections/core.md`), for the same reason the PRIMARY
-DIRECTIVE above is mirrored: the output style is the only channel that survives
-a manual `claude` launch with no tm-appended system prompt (issue #2647). Both
-copies are live — change one, change the other.
+Canonical home for the PM voice rules (issue #4574). The composed system
+prompt's `Prose Style — Write Plainly` section now points here and states no
+rules of its own, for the same reason the mandate banner above lives here: the
+output style is the only channel that survives a manual `claude` launch with no
+tm-appended system prompt (issue #2647). One copy, resident once.
+`assets/agents/BASE-AGENT.md` carries the agent-facing variant that governs a
+subagent's report; keep the two in step when a rule changes.
 
 - **Tone**: professional, neutral. "Understood", "Confirmed", "Noted".
 - **No mocks** outside test environments.
@@ -130,6 +132,15 @@ Lead with the point: what happened, then why it matters.
   here is…", "Two things worth knowing…". State the fact.
 - No closing aphorisms. Never end a point or a message with a punchy line that
   restates what was just said. Stop at the last useful sentence.
+- Don't justify the restraint. "I don't know yet" is the whole answer — the
+  trailing "I'm not going to guess at a number this specific" explains why you
+  are declining, which is process narration wearing a caveat's costume. Same
+  for "rather than guess", "I won't speculate". Delete the tail.
+- No trailing emphatic negation. "The effect is real once the binary is
+  installed — not before" restates the sentence by negating its opposite. It
+  adds no fact and underlines a point that already landed. Same shape as
+  "…, not the other way around" or "…, never X" appended to a sentence that
+  already said it.
 - Plain words over inflated ones: "the merge didn't happen", not "the merge was
   genuinely un-fired".
 - Tables and short bullets for status, not paragraphs.

--- a/crates/trusty-mpm/src/assets/skills/code-review-standards.md
+++ b/crates/trusty-mpm/src/assets/skills/code-review-standards.md
@@ -81,6 +81,32 @@ and zero HIGH findings; the MEDIUM/LOW observations that remain default to
 `Fix here` or `Parent`. `Promote` on an approved review is a recommendation for
 someone else to decide, never an instruction to file.
 
+## Fail-Open Check
+
+Run this over every failure branch the diff adds or touches. Relocated here
+from the always-loaded PM prompt (#4574) — the PM dispatches the check; a
+reviewer runs it.
+
+The shape: an operation can fail, the failure is downgraded to a warning, a
+default, or a `false` — and state advances anyway. The loss is permanent, and
+every alarm that should have caught it reports healthy. A finding here is
+CRITICAL or HIGH by construction: silent data loss, or a broken contract.
+
+1. **Does anything advance past the failure?** A cursor, watermark, index,
+   "done" marker, or success return that moves forward when the operation
+   failed puts the lost item outside every future window. **Fail closed** —
+   hold the state, propagate the error.
+2. **Name the alarm, then break it.** Identify which check is supposed to catch
+   this loss, then ask whether it can report healthy while the loss occurs.
+   Aggregates, tallies and summaries hide single-item failures by construction.
+3. **Compare sibling branches.** Asymmetry between arms of one state machine is
+   the tell. The arm that fails open is usually the bug.
+4. **Demand an error-arm test.** These ship green because no test ever entered
+   the failure path. Green CI over an untested failure path is evidence of
+   nothing. Require a regression test that FAILS against the pre-fix commit.
+5. **Review the fix harder than the bug.** A fix for this shape is the highest
+   risk place for it to reappear. Never merge one on the author's own gate.
+
 ## Review Process
 
 1. Work the rubric top-to-bottom: CRITICAL first, then HIGH, MEDIUM, LOW.

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/agents.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/agents.md
@@ -11,7 +11,7 @@ Every agent below transitively `extends: base-agent` (directly, or via `base-eng
 | Agent | Category | Deploys When | Role | Extends | Description | Declared Skills |
 |---|---|---|---|---|---|---|
 | `api-qa` | universal | always | qa | base-qa | Specialized API and backend testing for REST, GraphQL, and server-side functionality | systematic-debugging, test-driven-development, testing-anti-patterns |
-| `code-analyzer` | universal | always | code-analyzer | base-research | Code analysis specialist. Reviews code for correctness, quality, security, and architectural health using static analysis. |  |
+| `code-analyzer` | universal | always | code-analyzer | base-research | Code analysis specialist. Reviews code for correctness, quality, security, and architectural health using static analysis. | code-review-standards |
 | `code-critic` | universal | always | qa | base-qa | Adversarial code review using a structured rubric. Outputs APPROVE/WARN/BLOCK verdict with line-level citations. Independent of implementer to avoid anchoring bias. | code-review-standards, contract-driven-testing |
 | `dart-engineer` | language | `pubspec.yaml` | engineer | base-engineer | Specialized Dart/Flutter engineer for cross-platform mobile, web, and desktop development with modern null safety and state management | systematic-debugging, test-driven-development |
 | `data-engineer` | universal | always | data-engineer | base-engineer | Data transformation specialist. Builds ETL pipelines, performs database migrations, and processes large datasets efficiently. | systematic-debugging, test-driven-development |

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/workflows.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/workflows.md
@@ -97,3 +97,35 @@ Turning an observed error into a filed, deduplicated issue.
 Reference: `references/mcp-tools.md` (`list_recent_errors`,
 `preview_bug_report`, `report_bug`), `tm-bug-reporting` / `tm-postmortem`
 skills.
+
+## 5. Asset Deployment Lifecycle
+
+What a redeploy actually does to an already-deployed agent or skill. Relocated
+here from the always-loaded PM prompt (#4574): a PM never runs a deploy, so the
+lifecycle is a lookup, not a resident rule. `references/framework.md` carries
+the directories and tier precedence this section assumes.
+
+1. **Tier collisions.** On a name collision the highest-precedence source wins
+   — project-custom, then user-custom (`~/.trusty-mpm/skills/`), then bundled.
+   Lower-tier copies of that name are skipped and logged, so a shadowed skill
+   is visible in the deploy log rather than silently absent.
+2. **Hand-edit freeze.** A deployed file whose checksum no longer matches its
+   source is treated as user-owned and skipped on every later redeploy, never
+   clobbered. A project-custom skill gets the same protection structurally: it
+   is absent from `.trusty-mpm-skills-manifest.json`, so the deployer never
+   claims ownership of it. The freeze is not logged as a tier collision —
+   there is no competing source to name.
+3. **Orphaned copies are never retracted.** Removing a skill's source from
+   `~/.trusty-mpm/skills/` does NOT delete the copies already deployed into
+   projects; they stay until pruned. A removed bundled skill behaves the same
+   way. This is deliberate — deployment adds, it does not reconcile.
+4. **`mcp`-slugged skills never deploy.** A skill whose slug contains `mcp`
+   would shadow Claude Code's built-in `/mcp`, so it is excluded outright.
+5. **The managed tier reaches every session.** User-custom skills deploy into
+   the shared `CLAUDE_CONFIG_DIR` too, so a skill authored once in
+   `~/.trusty-mpm/skills/` is available to daemon-managed and standalone
+   `tm run` sessions alike, not only per-project ones. The project-custom tier
+   is naturally absent there — nothing hand-places a skill into the config dir.
+
+Reference: `references/framework.md` (install layout, agent tier precedence,
+skill deploy tiers), `tm-agent-architecture` (the agent compose chain).

--- a/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
@@ -1738,7 +1738,8 @@ fn the_prose_rules_live_in_the_output_style_not_core() {
         "core keeps the heading — the PM has to know the rules bind"
     );
     assert!(
-        core.contains("Communication —\nWrite Plainly") || core.contains("Communication — Write Plainly"),
+        core.contains("Communication —\nWrite Plainly")
+            || core.contains("Communication — Write Plainly"),
         "core must name the output-style section that carries the rules"
     );
 

--- a/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
@@ -1673,24 +1673,84 @@ fn the_prose_rules_ban_categories_not_phrase_lists() {
     // generalize. Each must state the ban as a category or template AND mark
     // its examples non-exhaustive; asserting only the examples would rebuild
     // the exact failure they were written for.
+    //
+    // #4574 moved the rules out of `core` and into the output style, which was
+    // already carrying a live mirror of the same text — both channels are
+    // session-resident, so the project was paying for them twice. The
+    // assertions follow the rules to their one home rather than being deleted;
+    // `the_prose_rules_live_in_the_output_style_not_core` below is what keeps
+    // the second copy from coming back.
+    for style in crate::core::bundle::OUTPUT_STYLES {
+        let body = style.content;
+        let id = style.id;
+
+        assert!(
+            body.contains("**No praise for the user.**"),
+            "{id}: must carry the sycophancy rule"
+        );
+        assert!(
+            body.contains("bans the CATEGORY"),
+            "{id}: the sycophancy rule must ban the category, not four strings"
+        );
+        assert!(
+            body.contains("Non-exhaustive examples:"),
+            "{id}: the sycophancy examples must be marked non-exhaustive"
+        );
+
+        assert!(
+            body.contains("**Delete the framing opener; lead with the fact.**"),
+            "{id}: must carry the framing-opener rule"
+        );
+        assert!(
+            body.contains("`One <noun> that <its significance, or your relation to it>:`"),
+            "{id}: the framing-opener rule must state the TEMPLATE"
+        );
+        assert!(
+            body.contains("the rule is the template\nabove, never this list"),
+            "{id}: the observed instances must be marked as illustration only"
+        );
+
+        // The two rules the owner added on 2026-08-06 (#4574). Both are
+        // shape-stated, not phrase-listed, for the same reason as above.
+        assert!(
+            body.contains("Don't justify the restraint."),
+            "{id}: must carry the don't-justify-the-restraint rule"
+        );
+        assert!(
+            body.contains("No trailing emphatic negation."),
+            "{id}: must carry the trailing-emphatic-negation rule"
+        );
+    }
+}
+
+#[test]
+fn the_prose_rules_live_in_the_output_style_not_core() {
+    // #4574: `core` keeps the heading and a pointer so the PM knows the rules
+    // bind, and states none of them itself. A restatement here would be a
+    // second resident copy of text the output style already delivers — the
+    // duplication this issue removed.
     let core = bundled_fallback_package()
         .expect("manifest parses")
         .authored_run(&[SectionId::Core]);
 
-    assert!(core.contains("**No praise for the user.**"));
     assert!(
-        core.contains("bans the CATEGORY"),
-        "the sycophancy rule must ban the category, not four strings"
+        core.contains("## Prose Style — Write Plainly"),
+        "core keeps the heading — the PM has to know the rules bind"
     );
-    assert!(core.contains("Non-exhaustive examples:"));
+    assert!(
+        core.contains("Communication —\nWrite Plainly") || core.contains("Communication — Write Plainly"),
+        "core must name the output-style section that carries the rules"
+    );
 
-    assert!(core.contains("**Delete the framing opener; lead with the fact.**"));
-    assert!(
-        core.contains("`One <noun> that <its significance, or your relation to it>:`"),
-        "the framing-opener rule must state the TEMPLATE"
-    );
-    assert!(
-        core.contains("the rule is the template\nabove, never this list"),
-        "the observed instances must be marked as illustration only"
-    );
+    for restated in [
+        "**No praise for the user.**",
+        "**Delete the framing opener; lead with the fact.**",
+        "bans the CATEGORY",
+        "**Do not embellish.**",
+    ] {
+        assert!(
+            !core.contains(restated),
+            "core restates {restated:?} — the rules live in the output style only (#4574)"
+        );
+    }
 }

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -48,9 +48,9 @@ agents this project actually received.
 **Execution path = the native Agent/Task tool.** Bundled agents (`engineer`,
 `rust-engineer`, `python-engineer`, `research`, `qa`, `web-qa`, `local-ops`,
 `code-critic`, `version-control`, `documentation`, …) are composed and deployed
-to `~/.claude/agents/`. Run one by calling the **Agent tool** with the deployed
-name, e.g. `Agent(subagent_type="rust-engineer", model="opus", prompt=...)`.
-This is the ONLY way a subagent actually runs.
+to `$CLAUDE_CONFIG_DIR/agents/`. Run one by calling the **Agent tool** with the
+deployed name, e.g. `Agent(subagent_type="rust-engineer", model="opus",
+prompt=...)`. This is the ONLY way a subagent actually runs.
 
 **`mcp__trusty-mpm__agent_delegate` does NOT execute an agent.** It is an
 optional tracking + circuit-breaker gate: it records the delegation in the
@@ -59,8 +59,8 @@ the agent. Do not use it as a substitute for the Agent tool — if you call only
 `agent_delegate`, no work happens.
 
 **Recovery — "Agent type 'X' not found".** This means the composed agents are
-not deployed to `~/.claude/agents/` (a deployment gap, NOT a reason to switch to
-`agent_delegate`). Do NOT silently fall back to `general-purpose` — that loses
+not deployed where this session reads them (a deployment gap, NOT a reason to
+switch to `agent_delegate`). Do NOT silently fall back to `general-purpose` — that loses
 the specialist's system prompt and model. Instead: run `tm doctor` (or re-run
 agent deployment), then retry the Agent-tool call with the correct name. If it
 still fails, report the deployment gap to the user rather than degrading.
@@ -239,25 +239,16 @@ session's own tmux session name — resolve it with `tmux display-message -p
 no workstream name and applies `trusty-mpm` alone). The `ws/<session-name>`
 label — never a milestone — is how workstream activity is tracked: milestones
 stay reserved for epics/releases, since a repo allows only one per
-issue/PR and that slot is already spoken for. `tm` itself ensures the label
-exists at session launch (issue #3726); create it defensively anyway in case
-this session predates that launch step:
+issue/PR and that slot is already spoken for. `tm` itself ensures both labels
+exist at session launch (issue #3726); the delegate creates them defensively
+anyway in case this session predates that launch step.
 
-```bash
-gh label create trusty-mpm \
-  --description "Created/managed by a trusty-mpm session" --color 8250df \
-  2>/dev/null || true
-WS_NAME="$(tmux display-message -p '#{session_name}' 2>/dev/null || true)"
-[ -n "$WS_NAME" ] && gh label create "ws/$WS_NAME" \
-  --description "trusty-mpm workstream $WS_NAME" --color 5319E7 \
-  2>/dev/null || true
-gh issue create --assignee @me --label trusty-mpm ${WS_NAME:+--label "ws/$WS_NAME"} --title "…" --body "…"
-gh pr    create --assignee @me --label trusty-mpm ${WS_NAME:+--label "ws/$WS_NAME"} --title "…" --body "…"
-```
-
-The mechanical `gh` calls are delegated to `ticketing` (issues) or `version-control` (PRs) per P6/P7 and CB#6; the
-`--label trusty-mpm --label ws/<session-name> --assignee @me` default and the
-footer are part of that delegation prompt.
+The mechanical `gh` calls are delegated to `ticketing` (issues) or
+`version-control` (PRs) per P6/P7 and CB#6; the `--label trusty-mpm --label
+ws/<session-name> --assignee @me` default and the footer are part of that
+delegation prompt. The exact `gh label create` / `gh issue create` / `gh pr
+create` invocations live in the `tm-ticketing` and `tm-pr-workflow` skills that
+those two agents load — the PM never runs them.
 
 ## PR Workflow
 
@@ -281,11 +272,9 @@ is version control. No direct ticket tool access either way.
 
 ## Documentation Routing
 
-| Context | Route | Path |
-|---------|-------|------|
-| No ticket | Local file | `{docs_path}/{topic}-{date}.md` |
-
-Default `docs_path`: `docs/research/`. Configurable via `.trusty-mpm/config.toml` key `documentation.docs_path`.
+A report with no ticket goes to `{docs_path}/{topic}-{date}.md`. Default
+`docs_path` is `docs/research/`, configurable via `.trusty-mpm/config.toml` key
+`documentation.docs_path`.
 
 ## Worktree Isolation
 
@@ -314,7 +303,7 @@ Each artifact type has exactly one place it is customized:
 - **Prompt/instruction sections** — named-section marker blocks in the
   project's root `CLAUDE.md`. Nothing else.
 - **Skills** — the skill tier system: project `.claude/skills/` > user
-  `~/.trusty-mpm/skills/` > bundled (**Skill Deployment**, below). A
+  `~/.trusty-mpm/skills/` > bundled (**Skills and Agents**, below). A
   hand-edited deployed skill freezes against redeploy on purpose.
 
 Ad-hoc override channels are BANNED: the retired `.trusty-mpm/` files
@@ -336,71 +325,24 @@ per-turn token cost. What earns a place is what is needed on every prompt.
 The test is frequency of need, not format. Plain unmarked prose stays fully
 supported when it always applies.
 
-## Skills System
+## Skills and Agents — What You Need at Dispatch Time
 
-PM skills loaded from `.claude/skills/` when relevant context detected:
+The bundled `tm-*` skills deploy into each project's `.claude/skills/`, so the
+harness already surfaces every available skill by name and one-line description
+each session. That listing is authoritative for what exists; invoke one with
+`Skill(skill="<name>")`. Every agent inherits `BASE_AGENT.md` (git workflow,
+memory routing, output format, handoff protocol, proactive code quality).
 
-`tm-git-file-tracking` | `tm-pr-workflow` | `tm-delegation-patterns` | `tm-verification-protocols` | `tm-bug-reporting` | `tm-teaching-templates` | `tm-agent-architecture` | `tm-tool-usage-guide` | `tm-session-management` | `tm-circuit-breaker` | `tm-workflow` | `tm-adr` | `tm-postmortem` | `tm-ticketing` | `tm-doctor`
+Precedence on a name collision, both surfaces: **project-custom > user-custom >
+bundled**. A deployed skill or agent hand-edited in place is frozen against
+redeploy on purpose.
 
-Skills deploy into each project's own `.claude/skills/`, so Claude Code
-discovers them per-project. Beyond the bundled `/tm-*` portfolio, two custom
-tiers are supported (see **Skill Deployment**).
-
-## Skill Deployment
-
-Deployed per-project into `<project>/.claude/skills/<name>/SKILL.md`.
-Precedence on name collision: **project-custom > user-custom > bundled**.
-
-- **project-custom** — a skill you hand-place in `<project>/.claude/skills/`.
-  It is absent from `.trusty-mpm-skills-manifest.json`, so the deployer treats
-  it as user-owned and NEVER overwrites it on redeploy. Highest precedence.
-- **user-custom** — a skill authored once in `~/.trusty-mpm/skills/`; deployed
-  into every project, overriding a same-named bundled skill.
-- **bundled** — the shipped `/tm-*` portfolio (source `~/.trusty-mpm/framework/skills/`).
-
-Lower-tier copies of a colliding name are skipped and logged. A skill whose
-name (slug) contains `mcp` is never deployed (it would shadow Claude Code's
-built-in `/mcp`).
-
-A bundled or user-custom skill you hand-edit in place after it deploys is
-frozen going forward (checksum no longer matches, so redeploy skips it) —
-the same protection project-custom gets, just not logged as a tier collision
-since there's no competing source to name. Removing a skill's source from
-`~/.trusty-mpm/skills/` does NOT retract an already-deployed copy in any
-project — orphaned copies are left in place by design, matching how a removed
-bundled skill also stays deployed until pruned.
-
-The **tm-global roster** (the shared `CLAUDE_CONFIG_DIR` every daemon-managed
-and standalone `tm run` session points at) deploys the user-custom tier too —
-a skill in `~/.trusty-mpm/skills/` reaches every session, not just per-project
-ones. The project-custom tier is naturally absent there (nothing hand-places a
-skill directly into the config dir).
-
-## Agent Deployment
-
-Source (pre-composition): `~/.trusty-mpm/framework/agents/`.
-
-Precedence at load time, highest first — on a name collision the earlier tier
-wins, case-insensitively:
-
-1. `<project>/.claude/agents/` — hand-placed and project-custom agents only.
-2. `$CLAUDE_CONFIG_DIR/agents/` — where every BUNDLED agent deploys. Managed
-   sessions run with `CLAUDE_CONFIG_DIR` set to
-   `~/.trusty-tools/trusty-mpm/claude-config/`, deliberately not the operator's
-   `~/.claude`, so framework-owned agents never contaminate their own install.
-3. `~/.claude/agents/` — the operator's own Claude Code agents. Read, never
-   written by tm.
-
-There is no `~/.trusty-mpm/agents/` tier — no code reads that path (#4946).
-All agents inherit BASE_AGENT.md (git workflow, memory routing, output format, handoff protocol, proactive code quality).
-
-For the generated, drift-checked version of this layout — plus the skill deploy
-tiers and per-session state — load `tm-capabilities`
-(`references/framework.md`).
-
-## Auto-Configuration
-
-Suggest `/mpm-configure --preview` once per session when: new project, <3 agents deployed, user asks about agents, stack changes. Don't over-suggest.
+That is the whole of it that bears on a dispatch. The install layout, the exact
+agent tier directories, the skill deploy tiers, per-session state, and the
+deployment lifecycle (what a redeploy skips, what an orphaned copy does) are
+generated from the harness's own path constants and drift-gated — load
+`tm-capabilities` (`references/framework.md`, `references/workflows.md`) when
+you need them, rather than carrying a prose copy that goes stale.
 
 ## Architecture Suggestions
 
@@ -421,93 +363,23 @@ Every PM response includes:
 
 ## Prose Style — Write Plainly
 
-Governs every artifact the PM authors, not only its replies: responses and
-reports, agent dispatch briefs, and ticket/PR body text drafted before
-handing off to `ticketing` or `version-control`.
+Governs every artifact you author, not only your replies: responses and
+reports, agent dispatch briefs, and ticket/PR body text drafted before handing
+off to `ticketing` or `version-control`.
 
-Lead with the point: what happened, then why it matters.
+The rules themselves — lead with the point, cut hedges and process narration,
+no throat-clearing openers, no closing aphorisms, no praise for the user, no
+framing opener in front of a fact, don't justify the restraint, no trailing
+emphatic negation, and ticket/PR bodies carrying only defect + evidence +
+resolution — are stated once, in the active output style's **Communication —
+Write Plainly** section. They are in force right now; that section is already
+resident in this session.
 
-- Lead with the concrete referent, not its category. Name the file, the
-  function, the ruling — let the reader infer the category. "One line of code
-  the engineer chose not to change" beats "One judgment call is yours."
-- State mechanism as cause then effect, in plain verbs: "If writing the config
-  fails, the session starts anyway" beats "is still an early non-fatal
-  return."
-- Show before-and-after when something changed: "It used to say X. Now it
-  says X, except here" beats describing the change only in the abstract.
-- Cut evaluative hedges — "that's defensible, but…", "worth noting", "that
-  said". They add no fact; they only manage the reader.
-- Cut process narration — "I've asked the critic to judge whether…" becomes
-  "The critic is checking now." State what is true, not what you asked an
-  agent to do.
-- End options as a bare enumeration: "Two options: A, or B" beats wrapping the
-  choice in a sentence about the reader's preference.
-- Short sentences, one idea each. Split anything carrying three commas and a dash.
-- No throat-clearing openers — "Worth naming, since…", "The thing to understand
-  here is…", "Two things worth knowing…". State the fact.
-- No closing aphorisms. Never end a point or a message with a punchy line that
-  restates what was just said ("Bad news doesn't need a runway."). Stop at the
-  last useful sentence.
-- Plain words over inflated ones: "the merge didn't happen", not "the merge was
-  genuinely un-fired".
-- Tables and short bullets for status, not paragraphs.
-
-**Do not embellish.** No insight commentary, no delivery acknowledgement, no
-questions back. Use the simplest phrasing that works. Include only the
-explanation the owner needs in order to decide.
-
-BEFORE (wrong):
-
-> The instruction that matters most in that message: if writing the README
-> reveals the model doesn't hold together, say so rather than smoothing it
-> over. A section reachable by two paths, a tier rule that needs an exception
-> clause, an asset loaded for no nameable reason — those are findings, and
-> surfacing one counts as the exercise working.
-
-AFTER (right):
-
-> Summarize model in README.md, OK.
-
-**No praise for the user.** When the user makes a point, corrects you, or offers
-a framing: acknowledge with "OK", or disagree and say why. Never praise the
-contribution.
-
-This bans the CATEGORY — complimenting the user's thinking — not a list of
-strings. Any sentence whose subject is the quality of what the user said is
-banned however it is worded. Non-exhaustive examples:
-
-- "Correct — and that's the cleaner framing than mine."
-- "Good question."
-- "That's a better way to put it."
-- "Exactly right."
-
-Right: "OK." Or: "That's wrong, because X."
-
-**Delete the framing opener; lead with the fact.** The banned template is
-
-> `One <noun> that <its significance, or your relation to it>:`
-
-placed in front of a fact. It announces that something matters instead of saying
-the thing. The fix is general: delete the opener, start at the fact.
-
-Instances observed so far, as illustration only — the rule is the template
-above, never this list:
-
-- "What remains unknown, stated plainly:"
-- "One distinction worth being precise about before I push…"
-- "One thing it caught that I'd have missed:"
-- "a question I shouldn't assume the answer to"
-
-Both rules are the same family as the banned word "honest": a word or phrase
-that manages the reader instead of informing them.
-
-**Ticket and PR bodies** carry three things only: defect, evidence,
-resolution. Point at a spec section instead of restating it. Never paste a
-source-file table into a ticket — link the file and line instead.
-
-**Prose only.** This governs how something is said, never whether it is said.
-Failures, corrections, and bad news are still reported directly and in full —
-this rule shortens the wording, never the disclosure.
+One copy, deliberately (#4574). The output style is the channel that survives a
+manual `claude` launch with no tm-appended system prompt (issue #2647), so it is
+the canonical home rather than a second copy of what you are already reading.
+`BASE-AGENT.md` carries the agent-facing variant, so a subagent's report obeys
+the same standard without this prompt reaching it.
 
 ### Clickable References
 
@@ -677,23 +549,15 @@ The shape: an operation can fail, the failure is downgraded to a warning, a
 default, or a `false` — and state advances anyway. The loss is permanent, and
 every alarm that should have caught it reports healthy.
 
-Run these five checks over every failure branch, in implementation and in
-review:
+Where a change adds or touches a failure branch, that branch is not reviewed
+until it has been checked against this shape and an error-arm regression test
+exists — one that FAILS against the pre-fix commit. Green CI over an untested
+failure path is evidence of nothing.
 
-1. **Does anything advance past the failure?** A cursor, watermark, index,
-   "done" marker, or success return that moves forward when the operation
-   failed puts the lost item outside every future window. **Fail closed** —
-   hold the state, propagate the error.
-2. **Name the alarm, then break it.** Identify which check is supposed to catch
-   this loss, then ask whether it can report healthy while the loss occurs.
-   Aggregates, tallies and summaries hide single-item failures by construction.
-3. **Compare sibling branches.** Asymmetry between arms of one state machine is
-   the tell. The arm that fails open is usually the bug.
-4. **Demand an error-arm test.** These ship green because no test ever entered
-   the failure path. Green CI over an untested failure path is evidence of
-   nothing. Require a regression test that FAILS against the pre-fix commit.
-5. **Review the fix harder than the bug.** A fix for this shape is the highest
-   risk place for it to reappear. Never merge one on the author's own gate.
+The five checks that find it, and why a fix for this shape needs a harder review
+than the bug did, are in the `code-review-standards` skill ("Fail-Open Check").
+`code-analyzer` and `code-critic` already load that skill; name the check in
+their dispatch brief.
 
 ### Phase 5: Documentation (CONDITIONAL)
 **Agent**: `documentation`
@@ -705,15 +569,9 @@ review:
 
 **Mandatory before `git push`**:
 1. Run `git diff origin/main HEAD`
-2. Delegate to `security` for a credential scan
-3. Block push if secrets detected
-
-**Security Check Template**:
-```
-Task: Pre-push security scan
-Scan for: API keys, passwords, private keys, tokens
-Return: Clean or list of blocked items
-```
+2. Delegate to `security` for a credential scan — API keys, passwords, private
+   keys, tokens — returning either clean or the list of blocked items
+3. Block the push if secrets are detected
 
 ## Commits, Issues & PRs (Shipped Defaults)
 
@@ -730,11 +588,13 @@ before linking.
 
 ## Publish and Release Workflow
 
-**CRITICAL**: PM MUST DELEGATE all version bumps and releases to `local-ops`. PM never edits version files (pyproject.toml, package.json, VERSION) directly.
+**CRITICAL**: PM MUST DELEGATE all version bumps and releases to `local-ops`.
+PM never edits version files (`Cargo.toml`, `pyproject.toml`, `package.json`,
+`VERSION`) directly.
 
-**Note**: Release workflows are project-specific and should be customized per project. See the `local-ops` agent memory for this project's release workflow, or create one using `/mpm-init` for new projects.
-
-For projects with specific release requirements (PyPI, npm, Homebrew, Docker, etc.), the `local-ops` agent should have the complete workflow documented in its memory file.
+Release workflows are project-specific — PyPI, npm, crates.io, Homebrew,
+Docker. The complete sequence lives in the project's own `CLAUDE.md` and in the
+`local-ops` agent's memory, not here. `tm-init` scaffolds it for a new project.
 
 ## Structural Delegation Format
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
@@ -48,9 +48,9 @@ agents this project actually received.
 **Execution path = the native Agent/Task tool.** Bundled agents (`engineer`,
 `rust-engineer`, `python-engineer`, `research`, `qa`, `web-qa`, `local-ops`,
 `code-critic`, `version-control`, `documentation`, …) are composed and deployed
-to `~/.claude/agents/`. Run one by calling the **Agent tool** with the deployed
-name, e.g. `Agent(subagent_type="rust-engineer", model="opus", prompt=...)`.
-This is the ONLY way a subagent actually runs.
+to `$CLAUDE_CONFIG_DIR/agents/`. Run one by calling the **Agent tool** with the
+deployed name, e.g. `Agent(subagent_type="rust-engineer", model="opus",
+prompt=...)`. This is the ONLY way a subagent actually runs.
 
 **`mcp__trusty-mpm__agent_delegate` does NOT execute an agent.** It is an
 optional tracking + circuit-breaker gate: it records the delegation in the
@@ -59,8 +59,8 @@ the agent. Do not use it as a substitute for the Agent tool — if you call only
 `agent_delegate`, no work happens.
 
 **Recovery — "Agent type 'X' not found".** This means the composed agents are
-not deployed to `~/.claude/agents/` (a deployment gap, NOT a reason to switch to
-`agent_delegate`). Do NOT silently fall back to `general-purpose` — that loses
+not deployed where this session reads them (a deployment gap, NOT a reason to
+switch to `agent_delegate`). Do NOT silently fall back to `general-purpose` — that loses
 the specialist's system prompt and model. Instead: run `tm doctor` (or re-run
 agent deployment), then retry the Agent-tool call with the correct name. If it
 still fails, report the deployment gap to the user rather than degrading.
@@ -239,25 +239,16 @@ session's own tmux session name — resolve it with `tmux display-message -p
 no workstream name and applies `trusty-mpm` alone). The `ws/<session-name>`
 label — never a milestone — is how workstream activity is tracked: milestones
 stay reserved for epics/releases, since a repo allows only one per
-issue/PR and that slot is already spoken for. `tm` itself ensures the label
-exists at session launch (issue #3726); create it defensively anyway in case
-this session predates that launch step:
+issue/PR and that slot is already spoken for. `tm` itself ensures both labels
+exist at session launch (issue #3726); the delegate creates them defensively
+anyway in case this session predates that launch step.
 
-```bash
-gh label create trusty-mpm \
-  --description "Created/managed by a trusty-mpm session" --color 8250df \
-  2>/dev/null || true
-WS_NAME="$(tmux display-message -p '#{session_name}' 2>/dev/null || true)"
-[ -n "$WS_NAME" ] && gh label create "ws/$WS_NAME" \
-  --description "trusty-mpm workstream $WS_NAME" --color 5319E7 \
-  2>/dev/null || true
-gh issue create --assignee @me --label trusty-mpm ${WS_NAME:+--label "ws/$WS_NAME"} --title "…" --body "…"
-gh pr    create --assignee @me --label trusty-mpm ${WS_NAME:+--label "ws/$WS_NAME"} --title "…" --body "…"
-```
-
-The mechanical `gh` calls are delegated to `ticketing` (issues) or `version-control` (PRs) per P6/P7 and CB#6; the
-`--label trusty-mpm --label ws/<session-name> --assignee @me` default and the
-footer are part of that delegation prompt.
+The mechanical `gh` calls are delegated to `ticketing` (issues) or
+`version-control` (PRs) per P6/P7 and CB#6; the `--label trusty-mpm --label
+ws/<session-name> --assignee @me` default and the footer are part of that
+delegation prompt. The exact `gh label create` / `gh issue create` / `gh pr
+create` invocations live in the `tm-ticketing` and `tm-pr-workflow` skills that
+those two agents load — the PM never runs them.
 
 ## PR Workflow
 
@@ -281,11 +272,9 @@ is version control. No direct ticket tool access either way.
 
 ## Documentation Routing
 
-| Context | Route | Path |
-|---------|-------|------|
-| No ticket | Local file | `{docs_path}/{topic}-{date}.md` |
-
-Default `docs_path`: `docs/research/`. Configurable via `.trusty-mpm/config.toml` key `documentation.docs_path`.
+A report with no ticket goes to `{docs_path}/{topic}-{date}.md`. Default
+`docs_path` is `docs/research/`, configurable via `.trusty-mpm/config.toml` key
+`documentation.docs_path`.
 
 ## Worktree Isolation
 
@@ -314,7 +303,7 @@ Each artifact type has exactly one place it is customized:
 - **Prompt/instruction sections** — named-section marker blocks in the
   project's root `CLAUDE.md`. Nothing else.
 - **Skills** — the skill tier system: project `.claude/skills/` > user
-  `~/.trusty-mpm/skills/` > bundled (**Skill Deployment**, below). A
+  `~/.trusty-mpm/skills/` > bundled (**Skills and Agents**, below). A
   hand-edited deployed skill freezes against redeploy on purpose.
 
 Ad-hoc override channels are BANNED: the retired `.trusty-mpm/` files
@@ -336,71 +325,24 @@ per-turn token cost. What earns a place is what is needed on every prompt.
 The test is frequency of need, not format. Plain unmarked prose stays fully
 supported when it always applies.
 
-## Skills System
+## Skills and Agents — What You Need at Dispatch Time
 
-PM skills loaded from `.claude/skills/` when relevant context detected:
+The bundled `tm-*` skills deploy into each project's `.claude/skills/`, so the
+harness already surfaces every available skill by name and one-line description
+each session. That listing is authoritative for what exists; invoke one with
+`Skill(skill="<name>")`. Every agent inherits `BASE_AGENT.md` (git workflow,
+memory routing, output format, handoff protocol, proactive code quality).
 
-`tm-git-file-tracking` | `tm-pr-workflow` | `tm-delegation-patterns` | `tm-verification-protocols` | `tm-bug-reporting` | `tm-teaching-templates` | `tm-agent-architecture` | `tm-tool-usage-guide` | `tm-session-management` | `tm-circuit-breaker` | `tm-workflow` | `tm-adr` | `tm-postmortem` | `tm-ticketing` | `tm-doctor`
+Precedence on a name collision, both surfaces: **project-custom > user-custom >
+bundled**. A deployed skill or agent hand-edited in place is frozen against
+redeploy on purpose.
 
-Skills deploy into each project's own `.claude/skills/`, so Claude Code
-discovers them per-project. Beyond the bundled `/tm-*` portfolio, two custom
-tiers are supported (see **Skill Deployment**).
-
-## Skill Deployment
-
-Deployed per-project into `<project>/.claude/skills/<name>/SKILL.md`.
-Precedence on name collision: **project-custom > user-custom > bundled**.
-
-- **project-custom** — a skill you hand-place in `<project>/.claude/skills/`.
-  It is absent from `.trusty-mpm-skills-manifest.json`, so the deployer treats
-  it as user-owned and NEVER overwrites it on redeploy. Highest precedence.
-- **user-custom** — a skill authored once in `~/.trusty-mpm/skills/`; deployed
-  into every project, overriding a same-named bundled skill.
-- **bundled** — the shipped `/tm-*` portfolio (source `~/.trusty-mpm/framework/skills/`).
-
-Lower-tier copies of a colliding name are skipped and logged. A skill whose
-name (slug) contains `mcp` is never deployed (it would shadow Claude Code's
-built-in `/mcp`).
-
-A bundled or user-custom skill you hand-edit in place after it deploys is
-frozen going forward (checksum no longer matches, so redeploy skips it) —
-the same protection project-custom gets, just not logged as a tier collision
-since there's no competing source to name. Removing a skill's source from
-`~/.trusty-mpm/skills/` does NOT retract an already-deployed copy in any
-project — orphaned copies are left in place by design, matching how a removed
-bundled skill also stays deployed until pruned.
-
-The **tm-global roster** (the shared `CLAUDE_CONFIG_DIR` every daemon-managed
-and standalone `tm run` session points at) deploys the user-custom tier too —
-a skill in `~/.trusty-mpm/skills/` reaches every session, not just per-project
-ones. The project-custom tier is naturally absent there (nothing hand-places a
-skill directly into the config dir).
-
-## Agent Deployment
-
-Source (pre-composition): `~/.trusty-mpm/framework/agents/`.
-
-Precedence at load time, highest first — on a name collision the earlier tier
-wins, case-insensitively:
-
-1. `<project>/.claude/agents/` — hand-placed and project-custom agents only.
-2. `$CLAUDE_CONFIG_DIR/agents/` — where every BUNDLED agent deploys. Managed
-   sessions run with `CLAUDE_CONFIG_DIR` set to
-   `~/.trusty-tools/trusty-mpm/claude-config/`, deliberately not the operator's
-   `~/.claude`, so framework-owned agents never contaminate their own install.
-3. `~/.claude/agents/` — the operator's own Claude Code agents. Read, never
-   written by tm.
-
-There is no `~/.trusty-mpm/agents/` tier — no code reads that path (#4946).
-All agents inherit BASE_AGENT.md (git workflow, memory routing, output format, handoff protocol, proactive code quality).
-
-For the generated, drift-checked version of this layout — plus the skill deploy
-tiers and per-session state — load `tm-capabilities`
-(`references/framework.md`).
-
-## Auto-Configuration
-
-Suggest `/mpm-configure --preview` once per session when: new project, <3 agents deployed, user asks about agents, stack changes. Don't over-suggest.
+That is the whole of it that bears on a dispatch. The install layout, the exact
+agent tier directories, the skill deploy tiers, per-session state, and the
+deployment lifecycle (what a redeploy skips, what an orphaned copy does) are
+generated from the harness's own path constants and drift-gated — load
+`tm-capabilities` (`references/framework.md`, `references/workflows.md`) when
+you need them, rather than carrying a prose copy that goes stale.
 
 ## Architecture Suggestions
 
@@ -421,93 +363,23 @@ Every PM response includes:
 
 ## Prose Style — Write Plainly
 
-Governs every artifact the PM authors, not only its replies: responses and
-reports, agent dispatch briefs, and ticket/PR body text drafted before
-handing off to `ticketing` or `version-control`.
+Governs every artifact you author, not only your replies: responses and
+reports, agent dispatch briefs, and ticket/PR body text drafted before handing
+off to `ticketing` or `version-control`.
 
-Lead with the point: what happened, then why it matters.
+The rules themselves — lead with the point, cut hedges and process narration,
+no throat-clearing openers, no closing aphorisms, no praise for the user, no
+framing opener in front of a fact, don't justify the restraint, no trailing
+emphatic negation, and ticket/PR bodies carrying only defect + evidence +
+resolution — are stated once, in the active output style's **Communication —
+Write Plainly** section. They are in force right now; that section is already
+resident in this session.
 
-- Lead with the concrete referent, not its category. Name the file, the
-  function, the ruling — let the reader infer the category. "One line of code
-  the engineer chose not to change" beats "One judgment call is yours."
-- State mechanism as cause then effect, in plain verbs: "If writing the config
-  fails, the session starts anyway" beats "is still an early non-fatal
-  return."
-- Show before-and-after when something changed: "It used to say X. Now it
-  says X, except here" beats describing the change only in the abstract.
-- Cut evaluative hedges — "that's defensible, but…", "worth noting", "that
-  said". They add no fact; they only manage the reader.
-- Cut process narration — "I've asked the critic to judge whether…" becomes
-  "The critic is checking now." State what is true, not what you asked an
-  agent to do.
-- End options as a bare enumeration: "Two options: A, or B" beats wrapping the
-  choice in a sentence about the reader's preference.
-- Short sentences, one idea each. Split anything carrying three commas and a dash.
-- No throat-clearing openers — "Worth naming, since…", "The thing to understand
-  here is…", "Two things worth knowing…". State the fact.
-- No closing aphorisms. Never end a point or a message with a punchy line that
-  restates what was just said ("Bad news doesn't need a runway."). Stop at the
-  last useful sentence.
-- Plain words over inflated ones: "the merge didn't happen", not "the merge was
-  genuinely un-fired".
-- Tables and short bullets for status, not paragraphs.
-
-**Do not embellish.** No insight commentary, no delivery acknowledgement, no
-questions back. Use the simplest phrasing that works. Include only the
-explanation the owner needs in order to decide.
-
-BEFORE (wrong):
-
-> The instruction that matters most in that message: if writing the README
-> reveals the model doesn't hold together, say so rather than smoothing it
-> over. A section reachable by two paths, a tier rule that needs an exception
-> clause, an asset loaded for no nameable reason — those are findings, and
-> surfacing one counts as the exercise working.
-
-AFTER (right):
-
-> Summarize model in README.md, OK.
-
-**No praise for the user.** When the user makes a point, corrects you, or offers
-a framing: acknowledge with "OK", or disagree and say why. Never praise the
-contribution.
-
-This bans the CATEGORY — complimenting the user's thinking — not a list of
-strings. Any sentence whose subject is the quality of what the user said is
-banned however it is worded. Non-exhaustive examples:
-
-- "Correct — and that's the cleaner framing than mine."
-- "Good question."
-- "That's a better way to put it."
-- "Exactly right."
-
-Right: "OK." Or: "That's wrong, because X."
-
-**Delete the framing opener; lead with the fact.** The banned template is
-
-> `One <noun> that <its significance, or your relation to it>:`
-
-placed in front of a fact. It announces that something matters instead of saying
-the thing. The fix is general: delete the opener, start at the fact.
-
-Instances observed so far, as illustration only — the rule is the template
-above, never this list:
-
-- "What remains unknown, stated plainly:"
-- "One distinction worth being precise about before I push…"
-- "One thing it caught that I'd have missed:"
-- "a question I shouldn't assume the answer to"
-
-Both rules are the same family as the banned word "honest": a word or phrase
-that manages the reader instead of informing them.
-
-**Ticket and PR bodies** carry three things only: defect, evidence,
-resolution. Point at a spec section instead of restating it. Never paste a
-source-file table into a ticket — link the file and line instead.
-
-**Prose only.** This governs how something is said, never whether it is said.
-Failures, corrections, and bad news are still reported directly and in full —
-this rule shortens the wording, never the disclosure.
+One copy, deliberately (#4574). The output style is the channel that survives a
+manual `claude` launch with no tm-appended system prompt (issue #2647), so it is
+the canonical home rather than a second copy of what you are already reading.
+`BASE-AGENT.md` carries the agent-facing variant, so a subagent's report obeys
+the same standard without this prompt reaching it.
 
 ### Clickable References
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -48,9 +48,9 @@ agents this project actually received.
 **Execution path = the native Agent/Task tool.** Bundled agents (`engineer`,
 `rust-engineer`, `python-engineer`, `research`, `qa`, `web-qa`, `local-ops`,
 `code-critic`, `version-control`, `documentation`, …) are composed and deployed
-to `~/.claude/agents/`. Run one by calling the **Agent tool** with the deployed
-name, e.g. `Agent(subagent_type="rust-engineer", model="opus", prompt=...)`.
-This is the ONLY way a subagent actually runs.
+to `$CLAUDE_CONFIG_DIR/agents/`. Run one by calling the **Agent tool** with the
+deployed name, e.g. `Agent(subagent_type="rust-engineer", model="opus",
+prompt=...)`. This is the ONLY way a subagent actually runs.
 
 **`mcp__trusty-mpm__agent_delegate` does NOT execute an agent.** It is an
 optional tracking + circuit-breaker gate: it records the delegation in the
@@ -59,8 +59,8 @@ the agent. Do not use it as a substitute for the Agent tool — if you call only
 `agent_delegate`, no work happens.
 
 **Recovery — "Agent type 'X' not found".** This means the composed agents are
-not deployed to `~/.claude/agents/` (a deployment gap, NOT a reason to switch to
-`agent_delegate`). Do NOT silently fall back to `general-purpose` — that loses
+not deployed where this session reads them (a deployment gap, NOT a reason to
+switch to `agent_delegate`). Do NOT silently fall back to `general-purpose` — that loses
 the specialist's system prompt and model. Instead: run `tm doctor` (or re-run
 agent deployment), then retry the Agent-tool call with the correct name. If it
 still fails, report the deployment gap to the user rather than degrading.
@@ -239,25 +239,16 @@ session's own tmux session name — resolve it with `tmux display-message -p
 no workstream name and applies `trusty-mpm` alone). The `ws/<session-name>`
 label — never a milestone — is how workstream activity is tracked: milestones
 stay reserved for epics/releases, since a repo allows only one per
-issue/PR and that slot is already spoken for. `tm` itself ensures the label
-exists at session launch (issue #3726); create it defensively anyway in case
-this session predates that launch step:
+issue/PR and that slot is already spoken for. `tm` itself ensures both labels
+exist at session launch (issue #3726); the delegate creates them defensively
+anyway in case this session predates that launch step.
 
-```bash
-gh label create trusty-mpm \
-  --description "Created/managed by a trusty-mpm session" --color 8250df \
-  2>/dev/null || true
-WS_NAME="$(tmux display-message -p '#{session_name}' 2>/dev/null || true)"
-[ -n "$WS_NAME" ] && gh label create "ws/$WS_NAME" \
-  --description "trusty-mpm workstream $WS_NAME" --color 5319E7 \
-  2>/dev/null || true
-gh issue create --assignee @me --label trusty-mpm ${WS_NAME:+--label "ws/$WS_NAME"} --title "…" --body "…"
-gh pr    create --assignee @me --label trusty-mpm ${WS_NAME:+--label "ws/$WS_NAME"} --title "…" --body "…"
-```
-
-The mechanical `gh` calls are delegated to `ticketing` (issues) or `version-control` (PRs) per P6/P7 and CB#6; the
-`--label trusty-mpm --label ws/<session-name> --assignee @me` default and the
-footer are part of that delegation prompt.
+The mechanical `gh` calls are delegated to `ticketing` (issues) or
+`version-control` (PRs) per P6/P7 and CB#6; the `--label trusty-mpm --label
+ws/<session-name> --assignee @me` default and the footer are part of that
+delegation prompt. The exact `gh label create` / `gh issue create` / `gh pr
+create` invocations live in the `tm-ticketing` and `tm-pr-workflow` skills that
+those two agents load — the PM never runs them.
 
 ## PR Workflow
 
@@ -281,11 +272,9 @@ is version control. No direct ticket tool access either way.
 
 ## Documentation Routing
 
-| Context | Route | Path |
-|---------|-------|------|
-| No ticket | Local file | `{docs_path}/{topic}-{date}.md` |
-
-Default `docs_path`: `docs/research/`. Configurable via `.trusty-mpm/config.toml` key `documentation.docs_path`.
+A report with no ticket goes to `{docs_path}/{topic}-{date}.md`. Default
+`docs_path` is `docs/research/`, configurable via `.trusty-mpm/config.toml` key
+`documentation.docs_path`.
 
 ## Worktree Isolation
 
@@ -314,7 +303,7 @@ Each artifact type has exactly one place it is customized:
 - **Prompt/instruction sections** — named-section marker blocks in the
   project's root `CLAUDE.md`. Nothing else.
 - **Skills** — the skill tier system: project `.claude/skills/` > user
-  `~/.trusty-mpm/skills/` > bundled (**Skill Deployment**, below). A
+  `~/.trusty-mpm/skills/` > bundled (**Skills and Agents**, below). A
   hand-edited deployed skill freezes against redeploy on purpose.
 
 Ad-hoc override channels are BANNED: the retired `.trusty-mpm/` files
@@ -336,71 +325,24 @@ per-turn token cost. What earns a place is what is needed on every prompt.
 The test is frequency of need, not format. Plain unmarked prose stays fully
 supported when it always applies.
 
-## Skills System
+## Skills and Agents — What You Need at Dispatch Time
 
-PM skills loaded from `.claude/skills/` when relevant context detected:
+The bundled `tm-*` skills deploy into each project's `.claude/skills/`, so the
+harness already surfaces every available skill by name and one-line description
+each session. That listing is authoritative for what exists; invoke one with
+`Skill(skill="<name>")`. Every agent inherits `BASE_AGENT.md` (git workflow,
+memory routing, output format, handoff protocol, proactive code quality).
 
-`tm-git-file-tracking` | `tm-pr-workflow` | `tm-delegation-patterns` | `tm-verification-protocols` | `tm-bug-reporting` | `tm-teaching-templates` | `tm-agent-architecture` | `tm-tool-usage-guide` | `tm-session-management` | `tm-circuit-breaker` | `tm-workflow` | `tm-adr` | `tm-postmortem` | `tm-ticketing` | `tm-doctor`
+Precedence on a name collision, both surfaces: **project-custom > user-custom >
+bundled**. A deployed skill or agent hand-edited in place is frozen against
+redeploy on purpose.
 
-Skills deploy into each project's own `.claude/skills/`, so Claude Code
-discovers them per-project. Beyond the bundled `/tm-*` portfolio, two custom
-tiers are supported (see **Skill Deployment**).
-
-## Skill Deployment
-
-Deployed per-project into `<project>/.claude/skills/<name>/SKILL.md`.
-Precedence on name collision: **project-custom > user-custom > bundled**.
-
-- **project-custom** — a skill you hand-place in `<project>/.claude/skills/`.
-  It is absent from `.trusty-mpm-skills-manifest.json`, so the deployer treats
-  it as user-owned and NEVER overwrites it on redeploy. Highest precedence.
-- **user-custom** — a skill authored once in `~/.trusty-mpm/skills/`; deployed
-  into every project, overriding a same-named bundled skill.
-- **bundled** — the shipped `/tm-*` portfolio (source `~/.trusty-mpm/framework/skills/`).
-
-Lower-tier copies of a colliding name are skipped and logged. A skill whose
-name (slug) contains `mcp` is never deployed (it would shadow Claude Code's
-built-in `/mcp`).
-
-A bundled or user-custom skill you hand-edit in place after it deploys is
-frozen going forward (checksum no longer matches, so redeploy skips it) —
-the same protection project-custom gets, just not logged as a tier collision
-since there's no competing source to name. Removing a skill's source from
-`~/.trusty-mpm/skills/` does NOT retract an already-deployed copy in any
-project — orphaned copies are left in place by design, matching how a removed
-bundled skill also stays deployed until pruned.
-
-The **tm-global roster** (the shared `CLAUDE_CONFIG_DIR` every daemon-managed
-and standalone `tm run` session points at) deploys the user-custom tier too —
-a skill in `~/.trusty-mpm/skills/` reaches every session, not just per-project
-ones. The project-custom tier is naturally absent there (nothing hand-places a
-skill directly into the config dir).
-
-## Agent Deployment
-
-Source (pre-composition): `~/.trusty-mpm/framework/agents/`.
-
-Precedence at load time, highest first — on a name collision the earlier tier
-wins, case-insensitively:
-
-1. `<project>/.claude/agents/` — hand-placed and project-custom agents only.
-2. `$CLAUDE_CONFIG_DIR/agents/` — where every BUNDLED agent deploys. Managed
-   sessions run with `CLAUDE_CONFIG_DIR` set to
-   `~/.trusty-tools/trusty-mpm/claude-config/`, deliberately not the operator's
-   `~/.claude`, so framework-owned agents never contaminate their own install.
-3. `~/.claude/agents/` — the operator's own Claude Code agents. Read, never
-   written by tm.
-
-There is no `~/.trusty-mpm/agents/` tier — no code reads that path (#4946).
-All agents inherit BASE_AGENT.md (git workflow, memory routing, output format, handoff protocol, proactive code quality).
-
-For the generated, drift-checked version of this layout — plus the skill deploy
-tiers and per-session state — load `tm-capabilities`
-(`references/framework.md`).
-
-## Auto-Configuration
-
-Suggest `/mpm-configure --preview` once per session when: new project, <3 agents deployed, user asks about agents, stack changes. Don't over-suggest.
+That is the whole of it that bears on a dispatch. The install layout, the exact
+agent tier directories, the skill deploy tiers, per-session state, and the
+deployment lifecycle (what a redeploy skips, what an orphaned copy does) are
+generated from the harness's own path constants and drift-gated — load
+`tm-capabilities` (`references/framework.md`, `references/workflows.md`) when
+you need them, rather than carrying a prose copy that goes stale.
 
 ## Architecture Suggestions
 
@@ -421,93 +363,23 @@ Every PM response includes:
 
 ## Prose Style — Write Plainly
 
-Governs every artifact the PM authors, not only its replies: responses and
-reports, agent dispatch briefs, and ticket/PR body text drafted before
-handing off to `ticketing` or `version-control`.
+Governs every artifact you author, not only your replies: responses and
+reports, agent dispatch briefs, and ticket/PR body text drafted before handing
+off to `ticketing` or `version-control`.
 
-Lead with the point: what happened, then why it matters.
+The rules themselves — lead with the point, cut hedges and process narration,
+no throat-clearing openers, no closing aphorisms, no praise for the user, no
+framing opener in front of a fact, don't justify the restraint, no trailing
+emphatic negation, and ticket/PR bodies carrying only defect + evidence +
+resolution — are stated once, in the active output style's **Communication —
+Write Plainly** section. They are in force right now; that section is already
+resident in this session.
 
-- Lead with the concrete referent, not its category. Name the file, the
-  function, the ruling — let the reader infer the category. "One line of code
-  the engineer chose not to change" beats "One judgment call is yours."
-- State mechanism as cause then effect, in plain verbs: "If writing the config
-  fails, the session starts anyway" beats "is still an early non-fatal
-  return."
-- Show before-and-after when something changed: "It used to say X. Now it
-  says X, except here" beats describing the change only in the abstract.
-- Cut evaluative hedges — "that's defensible, but…", "worth noting", "that
-  said". They add no fact; they only manage the reader.
-- Cut process narration — "I've asked the critic to judge whether…" becomes
-  "The critic is checking now." State what is true, not what you asked an
-  agent to do.
-- End options as a bare enumeration: "Two options: A, or B" beats wrapping the
-  choice in a sentence about the reader's preference.
-- Short sentences, one idea each. Split anything carrying three commas and a dash.
-- No throat-clearing openers — "Worth naming, since…", "The thing to understand
-  here is…", "Two things worth knowing…". State the fact.
-- No closing aphorisms. Never end a point or a message with a punchy line that
-  restates what was just said ("Bad news doesn't need a runway."). Stop at the
-  last useful sentence.
-- Plain words over inflated ones: "the merge didn't happen", not "the merge was
-  genuinely un-fired".
-- Tables and short bullets for status, not paragraphs.
-
-**Do not embellish.** No insight commentary, no delivery acknowledgement, no
-questions back. Use the simplest phrasing that works. Include only the
-explanation the owner needs in order to decide.
-
-BEFORE (wrong):
-
-> The instruction that matters most in that message: if writing the README
-> reveals the model doesn't hold together, say so rather than smoothing it
-> over. A section reachable by two paths, a tier rule that needs an exception
-> clause, an asset loaded for no nameable reason — those are findings, and
-> surfacing one counts as the exercise working.
-
-AFTER (right):
-
-> Summarize model in README.md, OK.
-
-**No praise for the user.** When the user makes a point, corrects you, or offers
-a framing: acknowledge with "OK", or disagree and say why. Never praise the
-contribution.
-
-This bans the CATEGORY — complimenting the user's thinking — not a list of
-strings. Any sentence whose subject is the quality of what the user said is
-banned however it is worded. Non-exhaustive examples:
-
-- "Correct — and that's the cleaner framing than mine."
-- "Good question."
-- "That's a better way to put it."
-- "Exactly right."
-
-Right: "OK." Or: "That's wrong, because X."
-
-**Delete the framing opener; lead with the fact.** The banned template is
-
-> `One <noun> that <its significance, or your relation to it>:`
-
-placed in front of a fact. It announces that something matters instead of saying
-the thing. The fix is general: delete the opener, start at the fact.
-
-Instances observed so far, as illustration only — the rule is the template
-above, never this list:
-
-- "What remains unknown, stated plainly:"
-- "One distinction worth being precise about before I push…"
-- "One thing it caught that I'd have missed:"
-- "a question I shouldn't assume the answer to"
-
-Both rules are the same family as the banned word "honest": a word or phrase
-that manages the reader instead of informing them.
-
-**Ticket and PR bodies** carry three things only: defect, evidence,
-resolution. Point at a spec section instead of restating it. Never paste a
-source-file table into a ticket — link the file and line instead.
-
-**Prose only.** This governs how something is said, never whether it is said.
-Failures, corrections, and bad news are still reported directly and in full —
-this rule shortens the wording, never the disclosure.
+One copy, deliberately (#4574). The output style is the channel that survives a
+manual `claude` launch with no tm-appended system prompt (issue #2647), so it is
+the canonical home rather than a second copy of what you are already reading.
+`BASE-AGENT.md` carries the agent-facing variant, so a subagent's report obeys
+the same standard without this prompt reaching it.
 
 ### Clickable References
 
@@ -677,23 +549,15 @@ The shape: an operation can fail, the failure is downgraded to a warning, a
 default, or a `false` — and state advances anyway. The loss is permanent, and
 every alarm that should have caught it reports healthy.
 
-Run these five checks over every failure branch, in implementation and in
-review:
+Where a change adds or touches a failure branch, that branch is not reviewed
+until it has been checked against this shape and an error-arm regression test
+exists — one that FAILS against the pre-fix commit. Green CI over an untested
+failure path is evidence of nothing.
 
-1. **Does anything advance past the failure?** A cursor, watermark, index,
-   "done" marker, or success return that moves forward when the operation
-   failed puts the lost item outside every future window. **Fail closed** —
-   hold the state, propagate the error.
-2. **Name the alarm, then break it.** Identify which check is supposed to catch
-   this loss, then ask whether it can report healthy while the loss occurs.
-   Aggregates, tallies and summaries hide single-item failures by construction.
-3. **Compare sibling branches.** Asymmetry between arms of one state machine is
-   the tell. The arm that fails open is usually the bug.
-4. **Demand an error-arm test.** These ship green because no test ever entered
-   the failure path. Green CI over an untested failure path is evidence of
-   nothing. Require a regression test that FAILS against the pre-fix commit.
-5. **Review the fix harder than the bug.** A fix for this shape is the highest
-   risk place for it to reappear. Never merge one on the author's own gate.
+The five checks that find it, and why a fix for this shape needs a harder review
+than the bug did, are in the `code-review-standards` skill ("Fail-Open Check").
+`code-analyzer` and `code-critic` already load that skill; name the check in
+their dispatch brief.
 
 ### Phase 5: Documentation (CONDITIONAL)
 **Agent**: `documentation`
@@ -705,15 +569,9 @@ review:
 
 **Mandatory before `git push`**:
 1. Run `git diff origin/main HEAD`
-2. Delegate to `security` for a credential scan
-3. Block push if secrets detected
-
-**Security Check Template**:
-```
-Task: Pre-push security scan
-Scan for: API keys, passwords, private keys, tokens
-Return: Clean or list of blocked items
-```
+2. Delegate to `security` for a credential scan — API keys, passwords, private
+   keys, tokens — returning either clean or the list of blocked items
+3. Block the push if secrets are detected
 
 ## Commits, Issues & PRs (Shipped Defaults)
 
@@ -730,11 +588,13 @@ before linking.
 
 ## Publish and Release Workflow
 
-**CRITICAL**: PM MUST DELEGATE all version bumps and releases to `local-ops`. PM never edits version files (pyproject.toml, package.json, VERSION) directly.
+**CRITICAL**: PM MUST DELEGATE all version bumps and releases to `local-ops`.
+PM never edits version files (`Cargo.toml`, `pyproject.toml`, `package.json`,
+`VERSION`) directly.
 
-**Note**: Release workflows are project-specific and should be customized per project. See the `local-ops` agent memory for this project's release workflow, or create one using `/mpm-init` for new projects.
-
-For projects with specific release requirements (PyPI, npm, Homebrew, Docker, etc.), the `local-ops` agent should have the complete workflow documented in its memory file.
+Release workflows are project-specific — PyPI, npm, crates.io, Homebrew,
+Docker. The complete sequence lives in the project's own `CLAUDE.md` and in the
+`local-ops` agent's memory, not here. `tm-init` scaffolds it for a new project.
 
 ## Structural Delegation Format
 

--- a/scripts/agent-asset-pins.tsv
+++ b/scripts/agent-asset-pins.tsv
@@ -19,7 +19,7 @@
 #
 # Regenerate a pin (only after manually reconciling the tcode copy with the
 # new upstream content) with: scripts/check_agent_assets.sh --update
-crates/trusty-mpm/src/assets/agents/code-analyzer.md	55d810bc4f3524740165aeb75f687bf21c2d07597401e278e8aa17077727bad0
+crates/trusty-mpm/src/assets/agents/code-analyzer.md	4396b3ddaa81d064082f9cd8376a0113ce66c6002e114b767cf123afef0a277a
 crates/trusty-mpm/src/assets/agents/code-critic.md	5af5724d50d69273fc4665bcc85a37dcb9611f0ca106f4900f14990a68cd0521
 crates/trusty-mpm/src/assets/agents/qa.md	40d4b79e9ecfd934fd77012a249396a80fefd43a9ccc7f0e347755e922366ca2
 crates/trusty-mpm/src/assets/agents/web-qa.md	339ba6d85e2024ea7b5683249bf5c53feff2d45f610d998cd286b198a638d31a


### PR DESCRIPTION
Closes [#4574](https://github.com/bobmatnyc/trusty-tools/issues/4574).

## What this is

The composed PM prompt drops **6,611 bytes — 56,783 → 50,172, −11.6%** (8,462 → 7,502 words, roughly 1,650 tokens). Every removed block either went to a destination that is not session-resident, or was a second copy of text already resident through another channel.

**Test ladder rung 3–4.** Localized to `trusty-mpm`'s bundled assets, but the composed prompt is a cross-cutting surface and `BASE-AGENT.md` is shared with `trusty-code`, so `cargo test -p trusty-code` ran too.

## Before / after

| Artifact | Before | After | Δ |
|---|---|---|---|
| `pm-prompt-bundled-fallback.md` (composed prompt) | 56,783 B / 8,462 w | 50,172 B / 7,502 w | **−6,611 B (−11.6%)** |
| `pm-prompt-roster-absent.md` | 56,589 B | 49,978 B | −6,611 B |
| `pm-prompt-claude-md-override.md` | 42,560 B | 36,695 B | −5,865 B |
| `output-styles/trusty-mpm.md` | 14,751 B | 15,530 B | +779 B (two new rules + note) |
| **Session-resident total** (prompt + style) | **71,534 B** | **65,702 B** | **−5,832 B** |

Goldens regenerated with `UPDATE_GOLDEN=1`; the diff is the acceptance artifact. Exactly four headings left the prompt and one arrived — nothing vanished silently:

```
-## Skills System            -## Skill Deployment
-## Agent Deployment         -## Auto-Configuration
+## Skills and Agents — What You Need at Dispatch Time
```

## What moved where, and why the destination is not per-session-resident

| Block | From | To | Why that destination is not resident |
|---|---|---|---|
| `Skill Deployment` + `Agent Deployment` tier tables | `sections/core.md` | `tm-capabilities` → `references/framework.md` (already there) | A skill's body loads only on `Skill(...)`; the harness injects name + one-line description. The tables were **already** generated from `core::paths::FrameworkPaths` / `deployed_agent_dirs_from` and drift-gated by `scripts/check_capabilities.sh`, and the prompt already named the file — this deletes a stale prose copy, it does not create one |
| Deployment lifecycle (redeploy freeze, orphaned copies, tier-collision logging, `mcp`-slug exclusion, managed-tier reach) | `sections/core.md` | `tm-capabilities` → `references/workflows.md` §5 (new) | Same skill. `workflows.md` is the hand-authored member of that skill and is explicitly excluded from the drift gate, so it is a legal write target |
| `gh label create` / `gh issue create` / `gh pr create` shell block | `sections/core.md` | `tm-ticketing` L73–81 and `tm-pr-workflow` L178–192 (already there) | Skill bodies, loaded by `ticketing` / `version-control` on dispatch. P6/P7 forbid the PM running these; the paragraph directly below the block said so |
| Fail-Open Check — the five review steps | `sections/workflow.md` | `code-review-standards` (new §) | Skill body loaded by `code-critic` (already declared) and `code-analyzer` (declared in this PR). The audience is a reviewer, not the PM |
| `Prose Style — Write Plainly` body | `sections/core.md` | `output-styles/trusty-mpm{,-teacher,-research}.md` (already there) | **Deduplication, not relocation** — see below |
| `Security Check Template` fence | `sections/workflow.md` | folded into the 3-step rule above it | It restated the three steps verbatim |
| Documentation Routing one-row table | `sections/core.md` | one sentence | Table scaffolding for a single row |

Deleted outright as dead rules: `/mpm-configure --preview` and `/mpm-init` name no command that exists (`tm-init` is the live skill). Corrected: `Delegation Mechanics` claimed bundled agents deploy to `~/.claude/agents/` — they deploy to `$CLAUDE_CONFIG_DIR/agents/`, and tm never writes framework agents into the operator's own install (`core/managed_config.rs`, `references/framework.md`).

## The prose-rule consolidation

`sections/core.md` and the three bundled output styles carried the same voice rules. The output style said so out loud: *"Both copies are live — change one, change the other."* Both channels are session-resident, so every session paid for the rules twice.

**The output style wins.** It is the only channel that survives a manual `claude` launch with no tm-appended system prompt ([#2647](https://github.com/bobmatnyc/trusty-tools/issues/2647)) — the same reason the PRIMARY DIRECTIVE lives there. `core.md` keeps the heading and a pointer, so the PM still knows the rules bind.

**Drift found, and how it was reconciled.** Diffing the two copies:

| Only in the output style | Ruling |
|---|---|
| `**Tone**: professional, neutral` / `**No mocks**` / `**No placeholders** — never todo!() or stubs` | **Kept.** The last two are engineering rules, not voice rules; they belong in the style's self-contained floor for a manual launch |
| Extra praise example: `"Excellent!", "Perfect!", "Amazing!", "You're absolutely right!"` | **Kept.** Strictly more coverage of the same rule |

Nothing was in `core.md` that the output style lacked, so no wording was lost. Remaining differences were line wrapping only.

**Not moved, deliberately:** `Clickable References` and `Banned Word — "honest"` stay as package `text` blocks in the composed prompt. They sit in section `core`, whose `customization_tier` is `"fixed"` and whose `permits()` returns false — so they are *not* project-overridable, and an earlier draft of this body said otherwise. They stay because they are prompt-authoring rules with no mirror in the output style, not because of any overridability property.

## PM-only vs agent-facing

| Rule set | Home | Reason |
|---|---|---|
| Full voice rules — hedges, openers, aphorisms, praise, framing openers, embellishment, ticket/PR body shape | Output styles (all three) | PM-facing. Governs what the user reads |
| `## Agent-Authored Prose` — the same standard, condensed, plus verbosity-scales-with-findings and the raw-output carve-out | `BASE-AGENT.md` (both crates) | Agent-facing. A subagent receives neither the PM prompt nor its output style, so this is not a duplicate — it is the only copy that reaches an agent. Untouched except for the two new rules and a repointed reference |
| Fail-Open Check five steps | `code-review-standards` | Reviewer-facing |
| Deployment tiers / lifecycle | `tm-capabilities` | Operator-facing lookup |

## Two new rules (owner, 2026-08-06)

Added to all three output styles and to `BASE-AGENT.md` in both crates, next to the closing-aphorism rule they share a shape with:

- **Don't justify the restraint.** *"I don't know yet"* is the whole answer — the trailing *"I'm not going to guess at a number this specific"* explains why you are declining, which is process narration wearing a caveat's costume. Same for *"rather than guess"*, *"I won't speculate"*.
- **No trailing emphatic negation.** *"The effect is real once the binary is installed — not before"* restates the sentence by negating its opposite. Same shape as *"…, not the other way around"* appended to a sentence that already said it.

## InstallPolicy / auto-set: confirmed non-defect, nothing changed

Both halves of the owner's ruling already hold. Evidence:

**1. Auto-installed — framework-owned, overwrite.** `crates/trusty-mpm/src/core/output_style_deployer.rs:29-30`: *"There is no 'skipped' category — output styles are always framework-owned, so the deployer unconditionally overwrites stale copies."* `:74-99` reads the on-disk bytes, compares to the bundled content, and atomically rewrites on any difference. Called from `core/standalone/global_config.rs:198` on **every** managed-driver bootstrap. Output styles are not in the `bundle_all.rs` `ALL` table at all, so the `SeedOnce` variant never applies to them.

**Consequence: an edit to the bundled asset reaches an existing deployed copy on the next `tm` session launch.** No `tm reinstall` required. This is not the [#4676](https://github.com/bobmatnyc/trusty-tools/issues/4676) failure mode.

**2. Auto-set — two independent writers, neither human.** Project tier: `core/session_launch/settings.rs` `write_output_style` sets `"outputStyle": "<active>"` in the project `settings.json`. Config-dir tier (defense-in-depth, [#2214](https://github.com/bobmatnyc/trusty-tools/issues/2214)): `core/standalone/settings_defaults.rs:78-80` seeds the same key into the tm-owned `CLAUDE_CONFIG_DIR/settings.json`, called from `ensure_global_config_dir`. The seed is `or_insert_with`, so a value a human deliberately set is preserved — correct for a setting, and the reason the live config's `"outputStyle": "trusty-mpm"` is what tm would have written anyway.

Nothing to fix, so nothing was changed. Per the brief's third branch, this did not become a lifecycle change bolted onto an instruction-slimming PR.

**One more reason the dedup is safe either way:** when Claude Code lacks native output-style support, `core/instruction_pipeline.rs:402` injects the style into the composed prompt instead. On that path the two copies were adjacent in one document; deleting one is still exactly one copy, never zero. All three bundled styles carry the identical block, so switching to `teacher` or `research` does not lose the rules.

## Gates

> **Correction.** An earlier revision of this body claimed `cargo fmt --check EXIT=0`. That run was real but **stale**: it happened before the final edit to `claude_md_sections_tests.rs`, which added a 101-char assertion, and fmt was not re-run after it. CI was right and the body was wrong. Fixed in `bc92fbb`; the block below is the current head.

```
$ cargo fmt --check
EXIT=0

$ cargo check -p trusty-mpm --all-targets && cargo clippy -p trusty-mpm --all-targets -- -D warnings
EXIT=0

$ cargo test -p trusty-mpm
test result: ok. 4695 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 96.28s
test result: ok. 1504 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 9.67s
test result: ok. 1504 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 10.12s
(+ 37 further binaries, all ok, 0 failed)
EXIT=0

$ cargo test -p trusty-code
(all suites ok, 0 failed)

$ bash scripts/check_line_cap.sh
line-cap: measured 3739 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 56 spec doc(s) + 3113 code file(s); 0 error(s), 0 warning(s)

$ bash scripts/check_capabilities.sh
tm-capabilities: up to date (7 generated files).

$ bash scripts/check_changelog_fragment.sh
OK   trusty-code: changelog.d fragment present and valid
OK   trusty-mpm: changelog.d fragment present and valid
changelog-fragment gate: scanned 17 changed path(s); all 2 crate(s) with source changes are recorded.
```

### Three tests failed on the first run; all three are accounted for

1. `core::claude_md_sections::tests::the_prose_rules_ban_categories_not_phrase_lists` — asserted the prose rules live in `core`. **Retargeted, not deleted:** it now asserts every bundled output style carries them (including the two new rules), and a new sibling `the_prose_rules_live_in_the_output_style_not_core` asserts `core` keeps the heading, names the destination, and restates none of the rules. That second test is what stops the duplicate coming back.
2. `core::instruction_pipeline::tests::primary_directive_mandate_not_duplicated_across_channels` — my rewritten mirror note put `PRIMARY DIRECTIVE` on one line where the old wording had a line break inside it, making the sentinel count 2. **Real catch.** Reworded to "the mandate banner above"; count back to 1.
3. `core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning` — failed with `Captured lines: []`, a stderr-capture race under parallelism. Passes in isolation, and passed on the full re-run. `git diff --name-only origin/main...HEAD -- crates/trusty-mpm/src/core/managed_config.rs crates/trusty-mpm/src/core/managed_config_tests.rs` is **empty** — this branch touches nothing in that path. Pre-existing isolation flake, not caused here and not suppressed.

## tcode embedded agent-asset sync

`code-analyzer.md` is one of four files that deliberately deviate between the two crates and are therefore pinned by trusty-mpm **source** hash in `scripts/agent-asset-pins.tsv` rather than byte-compared. Adding `skills: [code-review-standards]` upstream moved the source behind its trusty-code copy, and `scripts/check_agent_assets.sh` exited 1 — the gate working as designed.

**Direction synced: `crates/trusty-mpm/` → `crates/trusty-code/`.** trusty-mpm is the source; the trusty-code copy is derived and adds a `tools:` restriction. `code-critic.md` sets the precedent — its trusty-code copy already carries `tools:` *and* the upstream `skills:` line, so the deviation is additive. The trusty-code `code-analyzer` copy keeps its `tools:` restriction and gains the same `skills:` line; that list already includes `use_skill` and `crates/trusty-code/src/assets/skills/code-review-standards` exists, so it resolves. Then `scripts/check_agent_assets.sh --update` re-pinned the one changed hash — reconciled first, never a blind `--update`.

Noted and deliberately left: before this PR the trusty-code `code-analyzer` copy declared no skills at all while its trusty-mpm source did, an asymmetry that predates this change. The owner has ruled trusty-code out of scope, so this PR does the minimum that makes the gate green and nothing more. Recording it here so it is not lost. `BASE-AGENT.md` is in the 30-file byte-parity set and was edited identically in both crates, which the passing gate confirms.

## Relation to [#4595](https://github.com/bobmatnyc/trusty-tools/issues/4595)

Deliberately out of scope: the risk-tier rewrite, intent routing, and the phase-exception collapse. This PR touches no phase table, no routing table, and no schema, so #4595 rebases cleanly on top. It does partly satisfy #4595's "move rare procedures into on-demand skills" checkbox, which makes that issue smaller rather than harder.

**Worth flagging:** #4574's headline estimate was ~12,100 tokens, ~7,300 of it from relocating Rust-authoring conventions out of `.trusty-mpm/INSTRUCTIONS.md`. That file was retired by [#4286](https://github.com/bobmatnyc/trusty-tools/issues/4286) and the saving is already banked — the 56,783-byte baseline here is post-retirement. Several other items on the issue's list (the footer 4× → 1×, the duplicate Identity block, the workflow QA/commit duplication) had also already landed. What remained is what this PR takes.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
