### PR TITLE
docs(trusty-mpm): reopen-first and sparse ticket bodies as rules in the ticketing agent

### DIFF
--- a/crates/trusty-code/changelog.d/5003-ticketing-agent-reopen-first.md
+++ b/crates/trusty-code/changelog.d/5003-ticketing-agent-reopen-first.md
@@ -1,0 +1,3 @@
+Changed
+
+- re-synced the mirrored `ticketing` agent asset with trusty-mpm: reopen a closed ticket for a recurrence before creating a new one, and write ticket bodies sparsely (defect, evidence, resolution)

--- a/crates/trusty-code/src/assets/agents/ticketing.md
+++ b/crates/trusty-code/src/assets/agents/ticketing.md
@@ -10,6 +10,54 @@ extends: base-agent
 
 Intelligent ticket management with MCP-first architecture and CLI fallbacks. Enforce scope boundaries and maintain bidirectional traceability.
 
+The two rules below govern every dispatch. Read them before the backend
+mechanics: they decide *whether* a ticket exists and *what it says*, which is
+the part that keeps going wrong.
+
+## Reopen Before You Create
+
+🔴 **Never open a new ticket until you have searched both OPEN and CLOSED
+issues.** A defect that recurs is the same defect — its closed ticket is its
+canonical home, not a dead record. Run this in order, every time:
+
+1. Search **open** issues.
+2. Search **closed** issues, including ones closed as fixed.
+   `gh issue list --search "<key>" --state all` (add `--state closed` to isolate).
+3. A closed ticket covers it → **reopen that ticket**
+   (`gh issue reopen N --comment "…"`) and comment with the new occurrence:
+   date, reproduction, and what differs this time. Never file a fresh ticket
+   for a recurrence.
+4. An open ticket covers it → comment there. Never file a duplicate.
+5. File new **only** when nothing open or closed covers it.
+
+**Search by the keys prior reports were actually written with**, not by file
+path — paths rot as modules move. Where the project's instructions define those
+keys, use that table rather than guessing: in trusty-tools it is the root
+`CLAUDE.md` section "Rust issue boundary" (test name, panic/error text,
+affected symbol, crate).
+
+## Sparse Ticket Bodies — Mandatory
+
+🔴 A ticket body carries three things: **defect, evidence, resolution.** Nothing
+else.
+
+- **No structured headings.** No Background, Analysis, Considerations, Impact,
+  Context, Proposed Approach. A body with `##` sections in it is over-written.
+- **Point, never restate.** If a linked issue, spec, ADR, or PR already says it,
+  link it. Never paste a spec section, a source-file table, or a diff into a
+  ticket.
+- **Cite file and symbol, never line numbers** — `agent_source.rs::autodeploy_agents`,
+  not `agent_source.rs:47`. Line numbers rot as files move, and a project with a
+  file-size cap (trusty-tools caps production files at 500 SLOC) splits modules
+  constantly.
+- **Length is the check.** If the body runs past a short screen, it is
+  over-written. Cut it before posting.
+
+The issue schema in the `tm-ticketing` skill lists facts a reader must be able
+to *tell* from the body. They are not headings to fill in, and most tickets
+convey all of them in under ten lines. When choosing between more detail and
+less, choose less.
+
 ## Integration Priority
 
 Pick the backend by what the project actually uses — check in this order and
@@ -23,7 +71,8 @@ a `gh`-authenticated repo — this is the common case), use `gh` directly:
 ```bash
 gh issue create --title "Title" --body "Details" --assignee @me --label trusty-mpm
 gh issue edit 4069 --add-label bug --milestone "v1.1"
-gh issue list --search "search terms" --state all   # dedupe BEFORE creating
+gh issue list --search "search terms" --state all   # search open AND closed FIRST
+gh issue reopen 4069 --comment "Recurred 2026-08-06: …"   # prefer this over a new issue
 gh issue comment 4069 --body "Progress: …"
 gh issue close 4069 --comment "Fixed by #4194"
 ```
@@ -122,8 +171,16 @@ When PM delegates a TODO list for conversion:
 
 ## Reporting Format
 
-Always report scope classification in your response:
+Report scope classification, and for anything that could have become a ticket,
+which of the four outcomes you took and what you searched:
+
 ```
+Searched: "reconcile" / "WatcherManager" / -p trusty-search — open + closed
+REOPENED #3712 (recurrence, commented)
+COMMENTED on open #4409
+CREATED #5001 (nothing covered it)
+NO TICKET (1 item — fixed in the current PR)
+
 IN-SCOPE (2 items — created as subtasks)
 SCOPE-ADJACENT (1 item — awaiting PM decision)
 OUT-OF-SCOPE (1 item — created as separate ticket)

--- a/crates/trusty-mpm/changelog.d/5003-ticketing-agent-reopen-first.md
+++ b/crates/trusty-mpm/changelog.d/5003-ticketing-agent-reopen-first.md
@@ -1,0 +1,5 @@
+Changed
+
+- `ticketing` agent must search open AND closed issues and reopen a closed ticket for a recurrence before creating a new one, and must report which outcome it took
+  - ticket bodies are now a rule, not advice: defect, evidence, resolution — no structured headings, no restating linked material, file and symbol instead of line numbers
+  - `tm-ticketing`'s issue schema is relabelled six facts a reader must be able to tell, not six headings to fill in

--- a/crates/trusty-mpm/src/assets/agents/ticketing.md
+++ b/crates/trusty-mpm/src/assets/agents/ticketing.md
@@ -10,6 +10,54 @@ extends: base-agent
 
 Intelligent ticket management with MCP-first architecture and CLI fallbacks. Enforce scope boundaries and maintain bidirectional traceability.
 
+The two rules below govern every dispatch. Read them before the backend
+mechanics: they decide *whether* a ticket exists and *what it says*, which is
+the part that keeps going wrong.
+
+## Reopen Before You Create
+
+🔴 **Never open a new ticket until you have searched both OPEN and CLOSED
+issues.** A defect that recurs is the same defect — its closed ticket is its
+canonical home, not a dead record. Run this in order, every time:
+
+1. Search **open** issues.
+2. Search **closed** issues, including ones closed as fixed.
+   `gh issue list --search "<key>" --state all` (add `--state closed` to isolate).
+3. A closed ticket covers it → **reopen that ticket**
+   (`gh issue reopen N --comment "…"`) and comment with the new occurrence:
+   date, reproduction, and what differs this time. Never file a fresh ticket
+   for a recurrence.
+4. An open ticket covers it → comment there. Never file a duplicate.
+5. File new **only** when nothing open or closed covers it.
+
+**Search by the keys prior reports were actually written with**, not by file
+path — paths rot as modules move. Where the project's instructions define those
+keys, use that table rather than guessing: in trusty-tools it is the root
+`CLAUDE.md` section "Rust issue boundary" (test name, panic/error text,
+affected symbol, crate).
+
+## Sparse Ticket Bodies — Mandatory
+
+🔴 A ticket body carries three things: **defect, evidence, resolution.** Nothing
+else.
+
+- **No structured headings.** No Background, Analysis, Considerations, Impact,
+  Context, Proposed Approach. A body with `##` sections in it is over-written.
+- **Point, never restate.** If a linked issue, spec, ADR, or PR already says it,
+  link it. Never paste a spec section, a source-file table, or a diff into a
+  ticket.
+- **Cite file and symbol, never line numbers** — `agent_source.rs::autodeploy_agents`,
+  not `agent_source.rs:47`. Line numbers rot as files move, and a project with a
+  file-size cap (trusty-tools caps production files at 500 SLOC) splits modules
+  constantly.
+- **Length is the check.** If the body runs past a short screen, it is
+  over-written. Cut it before posting.
+
+The issue schema in the `tm-ticketing` skill lists facts a reader must be able
+to *tell* from the body. They are not headings to fill in, and most tickets
+convey all of them in under ten lines. When choosing between more detail and
+less, choose less.
+
 ## Integration Priority
 
 Pick the backend by what the project actually uses — check in this order and
@@ -23,7 +71,8 @@ a `gh`-authenticated repo — this is the common case), use `gh` directly:
 ```bash
 gh issue create --title "Title" --body "Details" --assignee @me --label trusty-mpm
 gh issue edit 4069 --add-label bug --milestone "v1.1"
-gh issue list --search "search terms" --state all   # dedupe BEFORE creating
+gh issue list --search "search terms" --state all   # search open AND closed FIRST
+gh issue reopen 4069 --comment "Recurred 2026-08-06: …"   # prefer this over a new issue
 gh issue comment 4069 --body "Progress: …"
 gh issue close 4069 --comment "Fixed by #4194"
 ```
@@ -122,8 +171,16 @@ When PM delegates a TODO list for conversion:
 
 ## Reporting Format
 
-Always report scope classification in your response:
+Report scope classification, and for anything that could have become a ticket,
+which of the four outcomes you took and what you searched:
+
 ```
+Searched: "reconcile" / "WatcherManager" / -p trusty-search — open + closed
+REOPENED #3712 (recurrence, commented)
+COMMENTED on open #4409
+CREATED #5001 (nothing covered it)
+NO TICKET (1 item — fixed in the current PR)
+
 IN-SCOPE (2 items — created as subtasks)
 SCOPE-ADJACENT (1 item — awaiting PM decision)
 OUT-OF-SCOPE (1 item — created as separate ticket)

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -87,11 +87,14 @@ already in flight; only some are worth a durable artifact that someone else has
 to triage, prioritize, and eventually close. Run this gate before every
 `gh issue create`.
 
-### 1. Search before filing
+### 1. Search before filing — and reopen before creating
 
-Search open and recently closed issues by test name, error/panic text, affected
-symbol, and package. If a canonical issue already exists, append the new
-reproduction and evidence to it — do not file a second one.
+Searching open and closed issues, and **reopening** a closed ticket for a
+recurrence instead of filing a fresh one, is a required ordered procedure the
+`ticketing` agent runs on every dispatch. It is specified once, in the agent
+asset (`assets/agents/ticketing.md`, "Reopen Before You Create") — the agent
+executes it, so that is where it lives. Do not restate it in a delegation
+brief; state the finding and let the agent run its own gate.
 
 ### 2. Promote only an independently prioritizable outcome
 
@@ -151,13 +154,19 @@ was claimed.
   each new occurrence (run URL, SHA, command, failure signature) to it; a new
   issue per occurrence is a duplicate.
 
-### 5. Minimal issue schema (six fields)
+### 5. Minimal issue schema (six facts)
+
+🔴 **These are six facts a reader must be able to tell from the body. They are
+NOT six headings to fill in.** A body carries defect, evidence, and resolution
+in prose, sparsely — the form is specified in the agent asset
+(`assets/agents/ticketing.md`, "Sparse Ticket Bodies"), which is binding here.
+Most tickets convey all six in under ten lines.
 
 1. Outcome/problem and impact.
 2. Confidence: Observed | Reproduced | Inferred | Speculative.
 3. Evidence/reproduction.
 4. Acceptance criteria.
-5. Relationship to parent work, and the duplicate-search result.
+5. Relationship to parent work, and the search/reopen outcome.
 6. Test level expected for closure.
 
 Field 3 governs issue bodies only. It does **not** relax the evidence rule for


### PR DESCRIPTION
Two pieces of owner feedback had to be re-issued in every dispatch brief. Neither was ever written into an asset, so nothing carried them between dispatches. This encodes both.

## Asset chosen: `crates/trusty-mpm/src/assets/agents/ticketing.md`

The `ticketing` agent asset is the canonical home for both rules, and `assets/skills/tm-ticketing.md` gets pointers.

Reason: `tm-ticketing` is the **PM's** skill — "high-level ticketing orchestration for the trusty-mpm PM", "the PM never calls ticketing tools directly." The `ticketing` agent's frontmatter declares no `skills:`, so the DOC-42 co-deploy set never binds `tm-ticketing` to it. The agent that actually searches, reopens, and writes the body never reads the file that describes how. Everything about ticket content lived on a surface the writer doesn't load.

## Change 1 — reopen before creating

Ordered procedure at the top of the agent asset: search open, search closed including closed-as-fixed, reopen and comment on a closed ticket that covers a recurrence, comment on an open one, file new only when nothing covers it — then report which of the four outcomes was taken and what was searched. The search keys point at the project's own table (root `CLAUDE.md`, "Rust issue boundary") rather than copying it. The `gh` snippet block and the Reporting Format block were updated to match.

## Change 2 — sparse bodies, and why the rule kept failing

Structural conclusion, not a fourth restatement:

1. **The rule was never written down.** `grep -rn "sparse\|deliberative\|Background/Analysis" crates/trusty-mpm/src/assets/` returns nothing. Three prior owner instructions (2026-07-27, 08-04, 08-05) reached a dispatch brief and died there. The agent asset had zero guidance on ticket-body content.
2. **The nearest thing to a rule pushed the opposite way.** `tm-ticketing` §5 was titled "Minimal issue schema (**six fields**)" — a numbered list including Confidence, Relationship to parent work, and Test level expected for closure. Read by a writer, six fields is a form to fill in, which produces exactly the heading-laden deliberative body being rejected. That contradiction is resolved here, not restated.

What changed structurally: the binding form moved to the surface the writer loads, placed **ahead of** backend mechanics rather than appended at the end; it is stated as a rule (🔴, "Mandatory", "Nothing else") rather than advice; and §5 in the skill is relabelled six **facts a reader must be able to tell**, explicitly not six headings, pointing at the agent asset for form.

The rule: defect, evidence, resolution. No structured headings. Point at linked material instead of restating it. File and symbol, never line numbers — those rot as modules split. Past a short screen means over-written.

## Deployment: framework-owned, not seed-once

`crates/trusty-mpm/src/core/bundle_all.rs` registers both files with `overwrite(...)` — `InstallPolicy::Overwrite`. Per `bundle_tests.rs`, no shipped artifact uses `SeedOnce` at all. `core/agent_source.rs` states the #4840 policy explicitly: a BUNDLED-origin file whose checksum drifted **is** overwritten, because `agents::deployer` treats framework-owned drift as corruption rather than user ownership (#4408). Only an untracked file or a seed-once entry is preserved.

So the edit reaches sessions with no manual merge:

- `cargo install --path crates/trusty-mpm --locked` (or `tctl install trusty-mpm` for the signed build), then a new session launch redeploys it.
- For an already-running session: `tm sessions sync-assets`, which reuses the same `deploy_agents_filtered` path.

Both entries are `universal` in `framework-manifest.toml`, so every project gets them.

## Second copy: the tcode mirror

`scripts/check_agent_assets.sh` enforces byte-parity between `crates/trusty-mpm/src/assets/agents/*.md` and `crates/trusty-code/src/assets/agents/*.md`. `ticketing.md` is a parity file, not one of the four pinned deviations, so the tcode copy is re-synced here rather than pinned. Caught by CI on the first push; both gates are green now:

```
$ bash scripts/check_agent_assets.sh
agent-assets: scanned 30 byte-parity file(s) (floor 20), all match; 4 pinned deviation(s) match upstream — OK.
EXIT=0

$ cargo check -p trusty-code
EXIT=0

$ cargo test -p trusty-code --lib assets
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 1590 filtered out; finished in 0.01s
EXIT=0

$ bash scripts/check_changelog_fragment.sh
OK   trusty-code: changelog.d fragment present and valid
OK   trusty-mpm: changelog.d fragment present and valid
EXIT=0
```

`trusty-code` has no mirror of `skills/tm-ticketing.md`, so the skill edit is single-copy.

## Gates

No Rust changed — the diff is two `.md` asset files, both `include_str!`'d into the binary, so the crate gates still ran.

```
$ cargo fmt --check && cargo check -p trusty-mpm && bash scripts/check_sld.sh && bash scripts/check_line_cap.sh
EXIT=0
```

```
$ cargo test -p trusty-mpm
test result: FAILED. 4722 passed; 2 failed; 7 ignored; 0 measured; 0 filtered out; finished in 301.16s

failures:
    client::executor::tests::execute_doctor_against_test_daemon
    core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning
```

Both are named in `docs/reference/test-ladder-baseline.md` as known environmental/isolation flakes on this machine — the doctor test loses on timing against a 10 s client timeout (line 37), and the frozen-skill warning test loses its capturing tracing subscriber to a parallel non-serial test (line 42, tracked at [#4931](https://github.com/bobmatnyc/trusty-tools/issues/4931)). Rerun in isolation:

```
$ cargo test -p trusty-mpm --lib -- --test-threads=1 --exact \
    client::executor::tests::execute_doctor_against_test_daemon \
    core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning
test client::executor::tests::execute_doctor_against_test_daemon ... ok
test core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 4729 filtered out; finished in 11.37s
EXIT=0
```

`git diff --name-only origin/main...HEAD` is two `.md` files; neither failing test reads either one. Change-specific gates pass.

No issue filed — instruction fixes go into the assets rather than the backlog.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
