### PR TITLE
fix(trusty-mpm): surface the daemon's message when a session rename fails

### DIFF
--- a/crates/trusty-mpm/changelog.d/5001-session-rename-500.md
+++ b/crates/trusty-mpm/changelog.d/5001-session-rename-500.md
@@ -1,0 +1,5 @@
+Fixed
+
+- `tm sessions rename` (and the `tm ls` picker's `r<N> <new-name>`) now surfaces the daemon's own failure message instead of a bare `HTTP status server error (500 …)` (closes [#5001](https://github.com/bobmatnyc/trusty-tools/issues/5001))
+  - the client called `error_for_status()`, which discards the response body — the daemon had always sent an actionable reason there, and it was thrown away before the operator ever saw it
+  - the daemon also now logs a `warn!` when a rename fails with an unmapped error, so a 500 leaves a diagnosable trace

--- a/crates/trusty-mpm/src/bin/tm/commands/rename.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/rename.rs
@@ -187,13 +187,21 @@ async fn finish_rename(
 /// didn't ("renamed → tm-x" when the session is really `tm-x-2`), poisoning
 /// their next `tmux attach`/resume-by-name.
 /// What: PATCHes `{ "name": … }`; 404 bails; 400 (and the legacy 409, kept for
-/// older daemons) surfaces the daemon's message on stderr and errors. On
+/// older daemons) surfaces the daemon's message on stderr and errors. Any
+/// OTHER non-success status reads the body and carries it into the error — the
+/// daemon writes an actionable reason there (e.g. `store error: session store
+/// serialization error: trailing characters at line 3755 column 2` when
+/// `sessions.json` is corrupt), and `error_for_status()` used to DISCARD it,
+/// leaving the operator with a bare `HTTP status server error (500 …)`. On
 /// success, parses the response body's `name` field and returns
 /// [`rename_success_message`] built from it — falling back to the requested
 /// name only when the body carries none (an older daemon). Returns the
 /// message rather than printing so tests can assert it.
 /// Test: `do_rename_request_reports_server_confirmed_suffixed_name`,
-/// `do_rename_request_reports_plain_success` (`rename_tests.rs`).
+/// `do_rename_request_reports_plain_success`,
+/// `do_rename_request_surfaces_daemon_500_body`,
+/// `do_rename_request_reports_bare_status_when_500_body_is_empty`
+/// (`rename_tests.rs`).
 ///
 /// `pub(super)` (rather than private): the `tm ls`/bare-`tm` picker's `r<N>
 /// <new-name>` rename input mode (`commands::session_picker_rename`) calls
@@ -226,8 +234,20 @@ pub(super) async fn do_rename_request(
             eprintln!("error: {msg}");
             Err(anyhow::anyhow!("rename rejected: {msg}"))
         }
+        status if !status.is_success() => {
+            // Every OTHER non-success status (500 above all). `error_for_status()`
+            // used to handle this arm, and it DISCARDS the response body — the
+            // daemon's own actionable text was thrown away and the operator got
+            // only "HTTP status server error (500 …) for url (…)". Read the body
+            // and carry it into the error instead.
+            let body = resp.text().await.unwrap_or_default();
+            let detail = body.trim();
+            if detail.is_empty() {
+                anyhow::bail!("daemon returned {status} with no detail");
+            }
+            anyhow::bail!("daemon returned {status}: {detail}");
+        }
         _ => {
-            let resp = resp.error_for_status()?;
             // The daemon's summary carries the name it ACTUALLY applied,
             // which may be an auto-suffixed variant of what we sent (#3692).
             let confirmed = resp

--- a/crates/trusty-mpm/src/bin/tm/commands/rename_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/rename_tests.rs
@@ -233,3 +233,50 @@ async fn do_rename_request_reports_plain_success() {
         .expect("rename succeeds");
     assert_eq!(msg, "renamed sess-1 -> tm-new");
 }
+
+#[tokio::test]
+async fn do_rename_request_surfaces_daemon_500_body() {
+    // #5001, live repro: `sessions.json` was corrupt, so `SessionManager::rename`
+    // failed at `store.all()` and the route's unmapped-error arm returned 500
+    // with the reason IN THE BODY. The CLI called `error_for_status()`, which
+    // DISCARDS the body, so the operator saw only:
+    //   "HTTP status server error (500 Internal Server Error) for url (…)"
+    // The body text — the only actionable part — must reach the error message.
+    // This is the exact body the live daemon returned (verified by curl).
+    let body = "store error: session store serialization error: \
+                trailing characters at line 3755 column 2";
+    let url = spawn_mock_rename_daemon("500 Internal Server Error", body).await;
+    let client = reqwest::Client::new();
+    let err = do_rename_request(&client, &url, "sess-1", "sess-1", "tm-code".to_string())
+        .await
+        .expect_err("a 500 must fail");
+    let msg = err.to_string();
+    // The load-bearing assertion: the DAEMON'S OWN text, not just "500".
+    // `error_for_status()` can never satisfy this — it never reads the body.
+    assert!(
+        msg.contains("session store serialization error"),
+        "the daemon's reason must reach the operator: {msg}"
+    );
+    assert!(
+        msg.contains("line 3755 column 2"),
+        "the full body must survive, not a truncated prefix: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn do_rename_request_reports_bare_status_when_500_body_is_empty() {
+    // Guard the fallback: a daemon that 500s with NO body must still produce a
+    // message naming the status, never an empty/confusing error. This pins the
+    // `detail.is_empty()` branch so a later refactor cannot silently drop it.
+    let url = spawn_mock_rename_daemon("500 Internal Server Error", "").await;
+    let client = reqwest::Client::new();
+    let err = do_rename_request(&client, &url, "sess-1", "sess-1", "tm-code".to_string())
+        .await
+        .expect_err("a 500 must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("500"), "must name the status: {msg}");
+    assert!(
+        msg.contains("no detail"),
+        "must say the daemon sent nothing rather than print an empty reason: {msg}"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/rename.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/rename.rs
@@ -21,6 +21,7 @@ use axum::{
     response::IntoResponse,
 };
 use serde::Deserialize;
+use tracing::warn;
 
 use super::{parse_id, record_to_summary};
 use crate::daemon::state::DaemonState;
@@ -75,6 +76,13 @@ pub async fn rename_managed_session(
         Err(ManagedError::InvalidState(_, reason)) => {
             (StatusCode::BAD_REQUEST, reason).into_response()
         }
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Err(e) => {
+            // #5001: the body already carried this message, but nothing logged
+            // it — a 500 here left NO daemon-side trace, so diagnosing one meant
+            // correlating unrelated log spam. The unmapped remainder is by
+            // definition the case nobody anticipated; log it where it happens.
+            warn!(id = %id_str, error = %e, "rename failed with an unmapped error");
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+        }
     }
 }


### PR DESCRIPTION
## Defect

The `tm ls` picker's `r<N> <new-name>` rename failed with no usable message:

```
tm: rename failed: HTTP status server error (500 Internal Server Error) for url (http://127.0.0.1:7880/api/v1/sessions/managed/7f00be37-a30d-4c46-90b1-37ffa8a270d1)
```

## Evidence

The daemon had always sent an actionable reason. Probing the live endpoint with the
same PATCH the CLI issues:

```
$ curl -s -w "\nHTTP_STATUS=%{http_code}\n" -X PATCH \
    http://127.0.0.1:7880/api/v1/sessions/managed/7f00be37-a30d-4c46-90b1-37ffa8a270d1 \
    -H 'Content-Type: application/json' -d '{"name":"tm-trusty-tools-05"}'
store error: session store serialization error: trailing characters at line 3755 column 2
HTTP_STATUS=500
```

`~/.trusty-mpm/session-manager/sessions.json` was corrupt — a complete JSON document
ended at byte 145090, followed by 1111 stale bytes from a longer earlier document.
`SessionManager::rename` reads the store before it does anything else
(`crates/trusty-mpm/src/session_manager/rename.rs:139`), so the parse failure became
`ManagedError::Store` and fell through to the route's unmapped-error arm.

The chain, with the line that matters at each step:

1. `crates/trusty-mpm/src/session_manager/rename.rs:139` — `store.all().await?`
   propagates the parse failure.
2. `crates/trusty-mpm/src/daemon/managed_routes/rename.rs:78` — the unmapped-error
   arm returns 500 **with the message in the body**, and logs nothing.
3. `crates/trusty-mpm/src/bin/tm/commands/rename.rs:230` — `resp.error_for_status()?`
   discards the body. That is where the message died.

`tm ls` kept working throughout because the list path catches the same error and falls
back to the in-memory set (`session list: reload failed: …; returning last-known
in-memory set count=121`), which is why the picker re-printed the old name instead of
reporting anything.

### The collision hypothesis is refuted

The filed suspicion was that `tm-code` was already taken. It was not — no record and no
live tmux session held that name:

```
$ tmux ls | grep -i tm-code
tm-code-intelligence-01: 1 windows (...) (attached)      # different name
```

It would not have mattered either way: since [#3692](https://github.com/bobmatnyc/trusty-tools/issues/3692)
`rename` auto-suffixes on collision and never returns `NameCollision`, so a collision
cannot produce this 500.

### Not a binary-lag artifact

Both rename files last changed 2026-07-23 (`481c97b0`, `97c5d6f7`); the installed
binary is from Aug 5 21:15. The installed code and `origin/main` agree, so this is a
live defect on main, not a missing install.

## Resolution

**Fixed the fallthrough, not one more typed arm.** The server's typed mappings
(`SessionNotFound`→404, `NameCollision`→409, `InvalidState`→400) are already correct,
and its unmapped arm already put `e.to_string()` in the body — the server never
swallowed anything. The swallowing was entirely client-side. So the fix reads the body
for **every** non-success status rather than adding an arm for whichever variant bit us
today; the next unanticipated variant surfaces its message with no further change.

- `crates/trusty-mpm/src/bin/tm/commands/rename.rs` — replaced `error_for_status()`
  with a `status if !status.is_success()` arm that reads the body and carries it into
  the error. Empty body falls back to naming the status.
- `crates/trusty-mpm/src/daemon/managed_routes/rename.rs` — `warn!` on the unmapped-error
  arm. A 500 previously left no daemon-side trace at all, which is why diagnosing this
  one required correlating unrelated log spam.

The operator now sees:

```
tm: rename failed: daemon returned 500 Internal Server Error: store error: session store serialization error: trailing characters at line 3755 column 2
```

No status was reclassified. A corrupt store is a genuine server-state fault, so 500 stays
correct; the defect was the message never arriving, not the code.

### Regression test

`do_rename_request_surfaces_daemon_500_body` mocks a 500 carrying the exact body the live
daemon returned and asserts the daemon's text reaches the error. Against the pre-fix code
it fails with the owner's exact string:

```
thread 'commands::rename::tests::do_rename_request_surfaces_daemon_500_body' panicked at crates/trusty-mpm/src/bin/tm/commands/rename_tests.rs:256:5:
the daemon's reason must reach the operator: HTTP status server error (500 Internal Server Error) for url (http://127.0.0.1:58415/api/v1/sessions/managed/sess-1)
test result: FAILED. 2 passed; 2 failed; 0 ignored; 0 measured; 1508 filtered out
```

`do_rename_request_reports_bare_status_when_500_body_is_empty` pins the empty-body branch.

## The owner's live daemon

The corrupt `sessions.json` could not self-heal: `upsert` reloads before it saves, so the
daemon could not write because it could not read — every mutation path was failing, not
just rename. Repaired in place by truncating to the end of the valid document, after
verifying the discarded 1111 bytes contained exactly one session id
(`5662a9da-e787-488f-aa2f-8790cf1b493b`) that was **already present** in the valid prefix,
so nothing was lost. Backup at
`~/.trusty-mpm/session-manager/sessions.json.corrupt-backup-20260806-090117`. The endpoint
now answers 200. No daemon restart was needed — `reload_if_changed` picks the file up.

**What corrupted it is still unknown and is not addressed here.** The store's own `save()`
is atomic (write `.tmp`, then rename), so the daemon cannot produce a torn file this way;
the trailing-bytes shape is a shorter document written over a longer one without
truncating, which points at an out-of-band writer.

## Why [#4472](https://github.com/bobmatnyc/trusty-tools/issues/4472) is not closed here

#4472 is a different mechanism in a different file: `resolve_target`'s exact-name tier
(`crates/trusty-mpm/src/client/resolver.rs:51-71`) has no ambiguity guard, so when a live
and a terminal record share a name, every `<id-or-name>` verb silently picks whichever the
list returns first. That is a shared-resolver change affecting ~10 verbs — a wider blast
radius and a different outcome from "a rename failure reports its reason". #4472's own
analysis concludes the rename path is correct and consistent; there is no one coherent
change covering both.

On whether a stopped or decommissioned session should keep reserving its name: **unchanged
here, deliberately.** Non-terminal `stopped` sessions do reserve their names — they are
resumable and the name is the resume handle, so the `tm-deadrt*` rows in the picker
correctly force an auto-suffix. Terminal (`decommissioned`/`deleted`) tombstones do not,
per the explicit owner decision in #3692. Reversing either is exactly what #4472 is open to
decide, and doing it inside a fix for an opaque error message would bury a behavior change
in an unrelated PR.

## Gates (rung 3 — localized crate behavior)

Rung 3, not 5: the change touches CLI error formatting and one log line. It adds no
persistence or lifecycle behavior — the store and `SessionManager::rename` are untouched.

`cargo fmt --check` && `cargo check -p trusty-mpm --all-targets` &&
`cargo clippy -p trusty-mpm --all-targets -- -D warnings` — all pass (the chain is
`&&`-gated and reached the test phase).

```
cargo test -p trusty-mpm --bin tm
test commands::rename::tests::do_rename_request_reports_bare_status_when_500_body_is_empty ... ok
test commands::rename::tests::do_rename_request_reports_plain_success ... ok
test commands::rename::tests::do_rename_request_reports_server_confirmed_suffixed_name ... ok
test commands::rename::tests::do_rename_request_surfaces_daemon_500_body ... ok
test result: ok. 1511 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 48.25s
```

```
cargo test -p trusty-mpm   (lib target)
test result: FAILED. 4722 passed; 2 failed; 7 ignored; 0 measured; 0 filtered out; finished in 286.08s

failures:
    client::executor::tests::execute_doctor_against_test_daemon
    core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning
```

Both are known-environmental flakes already recorded in
`docs/reference/test-ladder-baseline.md` (lines 37 and 42) — the first loses on timing
(9–13 s against a 10 s client timeout), the second is the `#[serial]`/tracing-subscriber
race tracked at [#4931](https://github.com/bobmatnyc/trusty-tools/issues/4931). Re-run
serially, the second passes:

```
cargo test -p trusty-mpm --lib -- --test-threads=1 <both>
test client::executor::tests::execute_doctor_against_test_daemon ... FAILED
test core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning ... ok
```

Neither is caused by this branch — the diff touches four files and none is in
`client/executor/` or `core/managed_config`:

```
$ git diff --name-only origin/main...HEAD
crates/trusty-mpm/changelog.d/5001-session-rename-500.md
crates/trusty-mpm/src/bin/tm/commands/rename.rs
crates/trusty-mpm/src/bin/tm/commands/rename_tests.rs
crates/trusty-mpm/src/daemon/managed_routes/rename.rs
```

`bash scripts/check_line_cap.sh` — `3742 tracked .rs file(s); 7 allowlisted, 0 violations — OK`.
`bash scripts/check_changelog_fragment.sh` — `OK trusty-mpm: changelog.d fragment present and valid`.

Closes [#5001](https://github.com/bobmatnyc/trusty-tools/issues/5001)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
