### PR TITLE
docs(agents): forbid ending a subagent turn narrating an intention to wait

### DIFF
--- a/crates/trusty-code/changelog.d/5019-base-agent-no-narrated-wait.md
+++ b/crates/trusty-code/changelog.d/5019-base-agent-no-narrated-wait.md
@@ -1,0 +1,3 @@
+Changed
+
+- the embedded `BASE-AGENT.md` copy tracks trusty-mpm's new `Never Narrate a Wait` section, keeping the two byte-identical for `scripts/check_agent_assets.sh` ([#5019](https://github.com/bobmatnyc/trusty-tools/pull/5019))

--- a/crates/trusty-code/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-code/src/assets/agents/BASE-AGENT.md
@@ -49,6 +49,37 @@ Two axes, never conflated:
 | **Authority** | "Is this authorized?" | The PM's word. Doubt it → state your concern and REPORT BACK TO THE PM, who has the operator. Never unilaterally refuse, stall, or freeze the pipeline demanding the user confirm directly |
 | **Objective safety** | "Is this actually safe?" | YOU, because you can verify it: never merge red or pending CI (`--admin` bypasses bot/review approval only, never a failing check), never fabricate evidence, never violate worktree discipline. Non-negotiable no matter who authorizes it |
 
+## Never Narrate a Wait
+
+Your turn ends the moment you stop emitting tool calls, and that stop IS your
+result to the PM. Nothing wakes you afterward — there is no re-invoke-on-
+completion path for a subagent; only the PM's `SendMessage` resumes you.
+
+1. NEVER end a turn narrating an intention to wait. "I'll wait for the pull to
+   finish", "will resume when the monitor reports completion", "monitoring in
+   the background" — these do nothing. The task is stranded until a human
+   notices.
+2. To await a long operation, STAY IN THE TURN: start it with
+   `run_in_background`, then poll an until-loop against its output file or the
+   process until the condition holds.
+3. 🔴 FOREGROUND `sleep` IS BLOCKED IN THIS HARNESS. `sleep 60 && check` does
+   not work, and reaching for it is the exact move that produces the parking
+   this rule prevents. Background the waiter too:
+
+   ```bash
+   # both calls use run_in_background; then read the sentinel file
+   <long-command> > /tmp/op.txt 2>&1
+   until grep -q DONE /tmp/op.txt; do sleep 10; done; echo READY
+   ```
+
+4. Genuinely cannot finish in-turn? REPORT STATE AND STOP. "Still pending: head
+   SHA abc1234, 10 checks unsettled" is a CORRECT and complete outcome. The
+   failure is never stopping — it is stopping while implying you will continue.
+5. Never re-issue a long-running command because a shell call returned early.
+   Foreground bash caps near 120s here and auto-backgrounds; check whether the
+   original is still running before starting a second. A duplicate 17-minute
+   build or VM run is the failure mode.
+
 ## Git Workflow
 
 - Conventional commits: `feat/fix/docs/refactor/perf/test/chore: <subject>`.
@@ -288,9 +319,9 @@ the evidence you owe. Run it as a plain foreground command with an explicit long
 - Keep gates crate-scoped (`cargo test -p <crate>`) so they finish inside one
   invocation. Re-issue in the SAME turn if one legitimately outlasts the ceiling.
 - Already backgrounded a command? Poll it to completion in the same turn.
-- Never spawn a background monitor, watcher, poller, or timer as a wake mechanism
-  and end your turn expecting it to report back. That mechanism does not exist
-  for a delegated agent.
+- Never spawn a background monitor, watcher, poller, or timer as a wake
+  mechanism and end your turn expecting it to report back — see "Never Narrate
+  a Wait".
 - Armed a `Monitor`, `/loop`, or `/schedule` whose goal completed or went moot?
   Disarm it before reporting. A stale monitor re-fires as a spurious wake.
 

--- a/crates/trusty-mpm/changelog.d/5019-base-agent-no-narrated-wait.md
+++ b/crates/trusty-mpm/changelog.d/5019-base-agent-no-narrated-wait.md
@@ -1,0 +1,8 @@
+Changed
+
+- `BASE-AGENT.md` gains a `Never Narrate a Wait` section, placed directly before `Git Workflow` so an agent reads it before it starts work ([#5019](https://github.com/bobmatnyc/trusty-tools/pull/5019))
+  - a subagent's turn ends the moment it stops emitting tool calls, and nothing re-invokes it afterward — `CLAUDE_SUBAGENT_BG_SHELL_MAX_MS` lets a subagent-owned background shell outlive the turn, but no completion event reconnects the two. Ending a turn with "I'll wait for the pull", "will resume when the monitor reports completion", or "monitoring in the background" strands the task until a human notices; observed five times in one session
+  - to await a long operation the agent stays in the turn: start it with `run_in_background`, then poll an until-loop against its output file. The loop is backgrounded too, because foreground `sleep` is blocked in this harness — a prior revision's bare "poll" advice was itself producing the parking it meant to prevent
+  - reporting unfinished state and stopping ("still pending: head SHA abc1234, 10 checks unsettled") is now stated as a correct, complete outcome; the failure is stopping while implying you will continue
+  - never re-issue a long-running command because a foreground shell call returned early at the ~120s cap and auto-backgrounded — check whether the original is still running first
+  - the now-redundant "never spawn a background monitor as a wake mechanism" bullet under `Your own gates DO block, in the foreground` collapses to a pointer at the new section

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -49,6 +49,37 @@ Two axes, never conflated:
 | **Authority** | "Is this authorized?" | The PM's word. Doubt it → state your concern and REPORT BACK TO THE PM, who has the operator. Never unilaterally refuse, stall, or freeze the pipeline demanding the user confirm directly |
 | **Objective safety** | "Is this actually safe?" | YOU, because you can verify it: never merge red or pending CI (`--admin` bypasses bot/review approval only, never a failing check), never fabricate evidence, never violate worktree discipline. Non-negotiable no matter who authorizes it |
 
+## Never Narrate a Wait
+
+Your turn ends the moment you stop emitting tool calls, and that stop IS your
+result to the PM. Nothing wakes you afterward — there is no re-invoke-on-
+completion path for a subagent; only the PM's `SendMessage` resumes you.
+
+1. NEVER end a turn narrating an intention to wait. "I'll wait for the pull to
+   finish", "will resume when the monitor reports completion", "monitoring in
+   the background" — these do nothing. The task is stranded until a human
+   notices.
+2. To await a long operation, STAY IN THE TURN: start it with
+   `run_in_background`, then poll an until-loop against its output file or the
+   process until the condition holds.
+3. 🔴 FOREGROUND `sleep` IS BLOCKED IN THIS HARNESS. `sleep 60 && check` does
+   not work, and reaching for it is the exact move that produces the parking
+   this rule prevents. Background the waiter too:
+
+   ```bash
+   # both calls use run_in_background; then read the sentinel file
+   <long-command> > /tmp/op.txt 2>&1
+   until grep -q DONE /tmp/op.txt; do sleep 10; done; echo READY
+   ```
+
+4. Genuinely cannot finish in-turn? REPORT STATE AND STOP. "Still pending: head
+   SHA abc1234, 10 checks unsettled" is a CORRECT and complete outcome. The
+   failure is never stopping — it is stopping while implying you will continue.
+5. Never re-issue a long-running command because a shell call returned early.
+   Foreground bash caps near 120s here and auto-backgrounds; check whether the
+   original is still running before starting a second. A duplicate 17-minute
+   build or VM run is the failure mode.
+
 ## Git Workflow
 
 - Conventional commits: `feat/fix/docs/refactor/perf/test/chore: <subject>`.
@@ -288,9 +319,9 @@ the evidence you owe. Run it as a plain foreground command with an explicit long
 - Keep gates crate-scoped (`cargo test -p <crate>`) so they finish inside one
   invocation. Re-issue in the SAME turn if one legitimately outlasts the ceiling.
 - Already backgrounded a command? Poll it to completion in the same turn.
-- Never spawn a background monitor, watcher, poller, or timer as a wake mechanism
-  and end your turn expecting it to report back. That mechanism does not exist
-  for a delegated agent.
+- Never spawn a background monitor, watcher, poller, or timer as a wake
+  mechanism and end your turn expecting it to report back — see "Never Narrate
+  a Wait".
 - Armed a `Monitor`, `/loop`, or `/schedule` whose goal completed or went moot?
   Disarm it before reporting. A stale monitor re-fires as a spurious wake.
 


### PR DESCRIPTION
## Defect

A subagent handed a long-running operation ends its turn narrating an intention to wait — "I'll wait for the pull to complete", "will resume automatically when the monitor reports completion", "monitoring in the background" — with its task unfinished. Nothing resumes it. Observed five times in one session; the parent had to notice and re-engage each one by hand.

This is a harness gap, not misuse. A subagent's turn ends the moment it stops emitting tool calls, and that stop **is** its result to the parent. `CLAUDE_SUBAGENT_BG_SHELL_MAX_MS` explicitly lets a subagent-owned background shell **outlive** the subagent's turn, but nothing reconnects the two when it finishes: the main loop is re-invoked on background completion, and there is no subagent equivalent. Parent-driven `SendMessage` is the only resume mechanism.

## Resolution

One new section in `BASE-AGENT.md`, `Never Narrate a Wait`, carrying five rules: never end a turn narrating a wait; stay in the turn via `run_in_background` plus an until-loop; foreground `sleep` is blocked in this harness so the waiter must be backgrounded too; reporting unfinished state and stopping is a *correct* outcome; never re-issue a long-running command because a foreground shell returned early at the ~120s cap.

Rule 3 is called out explicitly because a prior session recorded that plain "poll" advice was itself producing the parking it meant to prevent — `sleep 60 && check` is the shape agents reach for, and it does not run here.

The now-redundant "never spawn a background monitor as a wake mechanism" bullet under `Your own gates DO block, in the foreground` collapses to a pointer at the new section.

### Where it sits, and why

Immediately before `## Git Workflow`, in the operating-rules band after `PM Authority & Escalation` — roughly a quarter of the way into the file.

The existing turn-ending guidance (`Finishing Work — Push, Report, Stop`, `Report, don't promise`) lives at ~line 250 and is framed around CI. An agent reads that band only once it believes it is finishing. The stranding happens *mid-task*, on a build, a clone, a VM run — so the rule has to be in front of the agent before it picks its first long command, not appended at the bottom.

Register matches the file: numbered imperatives, one 🔴 marker on the blocked-`sleep` trap, one code block. No harness-internals essay.

## Byte-parity mirror

`BASE-AGENT.md` exists in two crates and is held at byte parity by `scripts/check_agent_assets.sh`:

- `crates/trusty-mpm/src/assets/agents/BASE-AGENT.md`
- `crates/trusty-code/src/assets/agents/BASE-AGENT.md`

Both are in the gate's **PARITY** set (5 `BASE-*` + 24 roster agents), not the 4-file pinned-deviation set, so no re-pinning was needed and `scripts/agent-asset-pins.tsv` is untouched. Both files hash `0ee276e2a1d5ab5a7e9aa2de72f6a52924017ec4` after the change.

## Ownership and how a user picks this up

**Framework-owned, overwritten on install.** `crates/trusty-mpm/src/core/bundle_all.rs:107` registers it as `overwrite("agents/BASE-AGENT.md", BASE_AGENT)` — `InstallPolicy::Overwrite`, not `SeedOnce`. A user-modified copy is still respected by the deployer's ownership rule (a file whose on-disk content no longer matches what tm wrote is left alone), but the shipped default tracks upgrades.

**A rebuild alone does not deploy it.** The asset is `include_str!`-embedded, so it reaches an agent only through an install plus an asset deploy:

```bash
cargo install --path crates/trusty-mpm --locked   # or: tctl install trusty-mpm (keeps the TCC grant)
tm sessions sync-assets                            # or start a new session
```

Session launch deploys agents exactly once, at launch (DOC-34/#2002); `tm sessions sync-assets` is the offline redeploy for a live session.

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo check -p trusty-mpm` | `Finished dev profile ... in 41.53s`, EXIT=0 |
| `cargo test -p trusty-mpm` | `4724 passed; 1 failed; 7 ignored` — see below |
| `bash scripts/check_agent_assets.sh` | `scanned 30 byte-parity file(s) (floor 20), all match; 4 pinned deviation(s) match upstream — OK.` |
| `bash scripts/check_sld.sh` | `scanned 56 spec doc(s) + 3115 code file(s); 0 error(s), 0 warning(s)` |
| `bash scripts/check_line_cap.sh` | `measured 3742 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.` |
| `bash scripts/check_test_pointers.sh` | `resolved 22070 Test: citation(s) (floor 200) — 0 dangling pointers — OK.` |
| `bash scripts/check_changelog_fragment.sh` | `scanned 4 changed path(s); all 2 crate(s) with source changes are recorded.` |

### The one failure is pre-existing

`client::executor::tests::execute_doctor_against_test_daemon` — a documented baseline flake (`docs/reference/test-ladder-baseline.md`). Proven, not assumed: with both `BASE-AGENT.md` files reverted to `origin/main` via `git checkout origin/main -- <paths>`, the full `cargo test -p trusty-mpm` failed on **the same single test**:

```
baseline (origin/main assets):  test result: FAILED. 4724 passed; 1 failed; 7 ignored  →  execute_doctor_against_test_daemon
with this change:               test result: FAILED. 4724 passed; 1 failed; 7 ignored  →  execute_doctor_against_test_daemon
```

### Two other flakes seen and traced, not silenced

An earlier run also failed `compose_session_instructions_display_matches_live_prompt` and `..._with_override`. Cause found, and it is not this diff: the assertion diff is the **agent roster embedded in the PM prompt**, differing by five user-tier entries (`copyeditor`, `pangram-editor`, `proofreader`, `writer`, `writing-critic`) between the test's two prompt builds. Both builds scan the live `$CLAUDE_CONFIG_DIR/agents` directory, and that directory was being rewritten by a concurrent deploy on this machine at the time (`drwxr-xr-x ... Aug 6 13:31 .`, mid-run). Same machine, load average 35/51/64. `cargo test -p trusty-mpm --bin tm` on pristine `origin/main` assets passed 3/3 at `1518 passed`; the same suite with this change passed 1/3 and failed with a *different* test (`guided_fallback_non_git_dir_with_managed_env_settles_quickly_returns_promptly`, a timing test) on one of the reds. Nothing was ignored, cfg-gated, or excluded.

`check_test_pointers.sh` did not return within 9 minutes on a second invocation under that load; its result above is from the earlier chain, on identical content — this change touches zero `.rs` files.

## Changelog

`crates/trusty-mpm/changelog.d/5019-base-agent-no-narrated-wait.md` and `crates/trusty-code/changelog.d/5019-base-agent-no-narrated-wait.md`, one `Changed` category each.

No issue filed — instruction fixes go straight into the assets.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools