### PR TITLE
fix(trusty-review): release the in_flight gauge on every exit path

### DIFF
--- a/crates/trusty-review/changelog.d/5026-in-flight-raii-guard.md
+++ b/crates/trusty-review/changelog.d/5026-in-flight-raii-guard.md
@@ -1,0 +1,10 @@
+Fixed
+
+- The `in_flight` gauge reported by `GET /status` no longer leaks. Both review
+  call sites bracketed `run_review(...).await` with a bare `fetch_add` /
+  `fetch_sub` pair, so the decrement was skipped when an HTTP client
+  disconnected mid-review (axum drops the handler future) or when the pipeline
+  panicked — either one inflating the counter permanently for the life of the
+  process. Both sites now hold an `InFlightCountGuard` whose `Drop` decrements,
+  matching the RAII discipline already used for the dedup slot
+  ([#5026](https://github.com/bobmatnyc/trusty-tools/pull/5026)).

--- a/crates/trusty-review/src/service/handlers.rs
+++ b/crates/trusty-review/src/service/handlers.rs
@@ -30,7 +30,7 @@ use crate::{
     llm::LlmProvider,
     pipeline::{DiffSource, ReviewDeps, ReviewInput, TriggerDecision, run_review},
     service::inference_probe::{InferenceProbe, InferenceStatus},
-    store::{DedupStore, InFlightRegistry},
+    store::{DedupStore, InFlightCountGuard, InFlightRegistry},
 };
 
 // ─── AppState ─────────────────────────────────────────────────────────────────
@@ -661,9 +661,12 @@ pub async fn handle_review(
         surface: InvocationSurface::default(),
     };
 
-    state.in_flight.fetch_add(1, Ordering::Relaxed);
+    // The gauge must be released on every exit path. A bare
+    // fetch_add/fetch_sub pair around this `.await` is skipped when the caller
+    // disconnects (axum drops the handler future) or when `run_review` panics,
+    // leaking a permanent +1 for the life of the process.
+    let _in_flight = InFlightCountGuard::acquire(&state.in_flight);
     let result = run_review(&state.config, input, deps).await;
-    state.in_flight.fetch_sub(1, Ordering::Relaxed);
 
     info!(
         verdict = %result.verdict,

--- a/crates/trusty-review/src/service/handlers_tests.rs
+++ b/crates/trusty-review/src/service/handlers_tests.rs
@@ -107,6 +107,67 @@ impl SearchClient for FailSearch {
     }
 }
 
+/// A search stub whose `health()` signals once and then never resolves.
+///
+/// Why: `preflight_context` awaits `search.health()` with no timeout, early in
+/// `run_review` and after `handle_review` has taken the in-flight guard. That
+/// makes it the control point for parking the handler future mid-review, which
+/// is what a client disconnect does in production.
+/// What: notifies `entered` on entry, then returns `Pending` forever.
+/// Test: `review_handler_in_flight_returns_to_zero_when_future_dropped`.
+pub(super) struct PendingSearch {
+    pub(super) entered: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait]
+impl SearchClient for PendingSearch {
+    async fn health(&self) -> Result<SearchHealth, SearchClientError> {
+        self.entered.notify_one();
+        std::future::pending().await
+    }
+
+    async fn list_indexes(&self) -> Result<Vec<IndexInfo>, SearchClientError> {
+        std::future::pending().await
+    }
+
+    async fn search(
+        &self,
+        _: &str,
+        _: &str,
+        _: Option<u32>,
+    ) -> Result<Vec<SearchResult>, SearchClientError> {
+        std::future::pending().await
+    }
+}
+
+/// A search stub whose `health()` panics.
+///
+/// Why: stands in for any panic anywhere inside `run_review` — the second exit
+/// path a bare `fetch_add`/`fetch_sub` pair skips.
+/// What: panics on `health()`, which `preflight_context` awaits unconditionally.
+/// Test: `review_handler_in_flight_returns_to_zero_when_pipeline_panics`.
+pub(super) struct PanicSearch;
+
+#[async_trait]
+impl SearchClient for PanicSearch {
+    async fn health(&self) -> Result<SearchHealth, SearchClientError> {
+        panic!("simulated pipeline panic inside run_review");
+    }
+
+    async fn list_indexes(&self) -> Result<Vec<IndexInfo>, SearchClientError> {
+        Ok(vec![])
+    }
+
+    async fn search(
+        &self,
+        _: &str,
+        _: &str,
+        _: Option<u32>,
+    ) -> Result<Vec<SearchResult>, SearchClientError> {
+        Ok(vec![])
+    }
+}
+
 /// A search stub whose `health()` succeeds at the transport level but reports
 /// an unhealthy embedder — exercises the `Ok(Ok(v))` + `is_healthy(v) ==
 /// false` branch of `bounded_probe` end-to-end through a real `SearchClient`
@@ -464,6 +525,121 @@ async fn review_handler_bad_request_missing_fields() {
     let response = handle_review(State(state), Json(req)).await;
     let resp: axum::response::Response = response.into_response();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// ── in_flight gauge leak regression ──────────────────────────────────────────
+
+/// A unified diff big enough to survive noise filtering and reach the
+/// required-context gate, where the search stubs above take control.
+const LEAK_TEST_DIFF: &str = "diff --git a/src/lib.rs b/src/lib.rs\n\
+index 1111111..2222222 100644\n\
+--- a/src/lib.rs\n\
++++ b/src/lib.rs\n\
+@@ -1,3 +1,4 @@\n\
+ fn existing() {}\n\
++pub fn added_symbol() -> u32 { 7 }\n\
+ fn other() {}\n";
+
+fn leak_test_request() -> ReviewRequest {
+    ReviewRequest {
+        owner: None,
+        repo: None,
+        pr: None,
+        local_diff_text: Some(LEAK_TEST_DIFF.to_string()),
+        ..Default::default()
+    }
+}
+
+/// Dropping the handler future mid-review returns `in_flight` to its prior value.
+///
+/// Why: axum drops the handler future when the HTTP client disconnects. With a
+/// bare `fetch_add` / `fetch_sub` around the `.await`, the decrement never runs
+/// and `GET /status` reports a permanently inflated gauge for the life of the
+/// daemon. Reviews take tens of seconds, so this window is wide.
+/// What: parks `run_review` inside `preflight_context` via `PendingSearch`,
+/// asserts the counter reached 1 while parked, drops the future, and asserts it
+/// is back to 0.
+/// Test: this test. Removing the `InFlightCountGuard` from `handle_review` makes
+/// the post-drop assertion fail with `1`.
+#[tokio::test]
+async fn review_handler_in_flight_returns_to_zero_when_future_dropped() {
+    use std::sync::atomic::Ordering;
+
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let state = AppState::new(
+        crate::config::ReviewConfig::load(None),
+        Arc::new(FakeLlm),
+        Arc::new(PendingSearch {
+            entered: Arc::clone(&entered),
+        }),
+        None,
+    );
+    let counter = Arc::clone(&state.in_flight);
+    assert_eq!(counter.load(Ordering::Relaxed), 0, "gauge starts at zero");
+
+    let mut fut = Box::pin(handle_review(State(state), Json(leak_test_request())));
+
+    // Drive the handler until the pipeline parks on the never-resolving search
+    // probe. `PendingSearch` never completes, so the handler cannot finish.
+    tokio::select! {
+        _ = &mut fut => panic!("handler completed — PendingSearch must never resolve"),
+        _ = entered.notified() => {}
+    }
+
+    assert_eq!(
+        counter.load(Ordering::Relaxed),
+        1,
+        "the review must be counted while it is actually in flight"
+    );
+
+    // The client disconnects: axum drops the handler future mid-review.
+    drop(fut);
+
+    assert_eq!(
+        counter.load(Ordering::Relaxed),
+        0,
+        "dropping the handler future must release the in-flight slot"
+    );
+}
+
+/// A panic inside the pipeline returns `in_flight` to its prior value.
+///
+/// Why: the other exit path a bare `fetch_sub` after the `.await` skips. On the
+/// webhook path the panic is swallowed into a `JoinError` nobody reads, so the
+/// daemon survives with a gauge that can only ever climb.
+/// What: makes `preflight_context`'s search probe panic, runs the handler in a
+/// `tokio::spawn` so the unwind is caught at the task boundary, asserts the task
+/// did panic, and asserts the counter is back to 0.
+/// Test: this test. Removing the `InFlightCountGuard` makes the final assertion
+/// fail with `1`.
+#[tokio::test]
+async fn review_handler_in_flight_returns_to_zero_when_pipeline_panics() {
+    use std::sync::atomic::Ordering;
+
+    let state = AppState::new(
+        crate::config::ReviewConfig::load(None),
+        Arc::new(FakeLlm),
+        Arc::new(PanicSearch),
+        None,
+    );
+    let counter = Arc::clone(&state.in_flight);
+
+    let join = tokio::spawn(async move {
+        let _ = handle_review(State(state), Json(leak_test_request()))
+            .await
+            .into_response();
+    });
+    let outcome = join.await;
+
+    assert!(
+        outcome.is_err_and(|e| e.is_panic()),
+        "PanicSearch must have panicked the review task"
+    );
+    assert_eq!(
+        counter.load(Ordering::Relaxed),
+        0,
+        "a panicking pipeline must still release the in-flight slot"
+    );
 }
 
 // ── Inference-probe handler tests (#719) ──────────────────────────────────────

--- a/crates/trusty-review/src/service/webhook.rs
+++ b/crates/trusty-review/src/service/webhook.rs
@@ -39,6 +39,7 @@ use crate::{
     integrations::github::{RunMode, webhook::verify_webhook_signature},
     pipeline::{DiffSource, ReviewDeps, ReviewInput, classify_review_request, run_review},
     service::handlers::AppState,
+    store::InFlightCountGuard,
 };
 
 // ─── Webhook payload shapes ───────────────────────────────────────────────────
@@ -261,9 +262,12 @@ pub async fn handle_github_webhook(
             }
         };
 
-        state_clone
-            .in_flight
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // Same RAII discipline as `_pr_guard` / `_sha_guard` above — a
+        // `run_review` panic unwinds this spawned task with the panic swallowed
+        // into a `JoinError` nobody reads, so a bare fetch_sub after the
+        // `.await` never runs and the /status gauge stays inflated for the life
+        // of the daemon.
+        let _in_flight = InFlightCountGuard::acquire(&state_clone.in_flight);
 
         let deps = ReviewDeps {
             llm: Arc::clone(&state_clone.llm),
@@ -298,9 +302,6 @@ pub async fn handle_github_webhook(
         };
 
         let result = run_review(&state_clone.config, input, deps).await;
-        state_clone
-            .in_flight
-            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
 
         if let Some(ref err) = result.error {
             warn!(pr = pr_number, error = %err, "webhook pipeline completed with error");

--- a/crates/trusty-review/src/store/in_flight.rs
+++ b/crates/trusty-review/src/store/in_flight.rs
@@ -10,12 +10,18 @@
 //! `(owner,repo,pr)` (active from request receipt, before the SHA is known) and
 //! one keyed by `(owner,repo,pr,sha)`.  `try_acquire_*` insert-if-absent and
 //! return an RAII `InFlightGuard` that removes the key on drop, so the slot is
-//! always released even if the review task panics.
+//! always released even if the review task panics.  `InFlightCountGuard`
+//! applies the same drop-releases discipline to `AppState::in_flight`, the
+//! numeric gauge reported by `GET /status`.
 //!
 //! Test: `pr_guard_blocks_second`, `pr_guard_released_on_drop`,
-//! `sha_guard_independent_of_pr`, `different_pr_not_blocked`.
+//! `sha_guard_independent_of_pr`, `different_pr_not_blocked`,
+//! `count_guard_increments_then_decrements_on_drop`,
+//! `count_guard_decrements_on_panic_unwind`,
+//! `count_guard_nests_and_unwinds_in_order`.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use dashmap::DashSet;
 
@@ -110,6 +116,53 @@ impl Drop for InFlightGuard {
     }
 }
 
+/// RAII guard that increments a shared in-flight counter on acquire and
+/// decrements it on drop.
+///
+/// Why: `AppState::in_flight` is the gauge `GET /status` reports. Both review
+/// call sites used to bracket `run_review(...).await` with a bare
+/// `fetch_add` / `fetch_sub` pair, which is skipped on two real exit paths: the
+/// handler future being dropped when an HTTP client disconnects mid-review, and
+/// `run_review` panicking. Either leaks a permanent +1, and reviews take tens of
+/// seconds so the disconnect window is wide. Tying the decrement to `Drop`
+/// makes it unconditional — drop, panic unwind, early return, or success — the
+/// same discipline `InFlightGuard` already applies to the dedup slot.
+/// What: `acquire` bumps the counter and takes an owning `Arc` handle; `Drop`
+/// decrements it exactly once.
+/// Test: `count_guard_increments_then_decrements_on_drop`,
+/// `count_guard_decrements_on_panic_unwind`,
+/// `count_guard_nests_and_unwinds_in_order`; end-to-end via
+/// `review_handler_in_flight_returns_to_zero_when_future_dropped` and
+/// `review_handler_in_flight_returns_to_zero_when_pipeline_panics`.
+#[derive(Debug)]
+pub struct InFlightCountGuard {
+    counter: Arc<AtomicU64>,
+}
+
+impl InFlightCountGuard {
+    /// Increment `counter` and return a guard that decrements it on drop.
+    ///
+    /// Why: the counter must never be incremented without a matching guard, so
+    /// this is the only constructor — there is no way to spell the increment
+    /// without also arming the decrement.
+    /// What: `fetch_add(1, Relaxed)` then clones the `Arc`. `Relaxed` matches
+    /// the read side (`GET /status` does a plain `load(Relaxed)`); the value is
+    /// an advisory gauge, not a synchronisation edge.
+    /// Test: `count_guard_increments_then_decrements_on_drop`.
+    pub fn acquire(counter: &Arc<AtomicU64>) -> Self {
+        counter.fetch_add(1, Ordering::Relaxed);
+        Self {
+            counter: Arc::clone(counter),
+        }
+    }
+}
+
+impl Drop for InFlightCountGuard {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
 // ─── Unit tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -147,6 +200,59 @@ mod tests {
         assert!(reg.try_acquire_pr("acme", "backend", 43).is_some());
         // A different repo is independent.
         assert!(reg.try_acquire_pr("acme", "frontend", 42).is_some());
+    }
+
+    /// The counter guard bumps on acquire and returns to the prior value on drop.
+    ///
+    /// Why: pins the basic contract — a guard is worthless if it does not
+    /// actually increment, and the /status gauge is wrong if it does not
+    /// decrement.
+    #[test]
+    fn count_guard_increments_then_decrements_on_drop() {
+        let counter = Arc::new(AtomicU64::new(0));
+        {
+            let _g = InFlightCountGuard::acquire(&counter);
+            assert_eq!(counter.load(Ordering::Relaxed), 1, "acquire must increment");
+        }
+        assert_eq!(counter.load(Ordering::Relaxed), 0, "drop must decrement");
+    }
+
+    /// The counter guard decrements when the holding frame panics.
+    ///
+    /// Why: `run_review` panicking used to leak a permanent +1 on the webhook
+    /// path, where the panic is swallowed by the spawned task's `JoinError` and
+    /// the daemon keeps running with an inflated gauge forever.
+    #[test]
+    fn count_guard_decrements_on_panic_unwind() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let probe = Arc::clone(&counter);
+        let outcome = std::panic::catch_unwind(move || {
+            let _g = InFlightCountGuard::acquire(&probe);
+            assert_eq!(probe.load(Ordering::Relaxed), 1);
+            panic!("simulated pipeline panic");
+        });
+        assert!(outcome.is_err(), "the closure must have panicked");
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            0,
+            "panic unwind must still run Drop"
+        );
+    }
+
+    /// Concurrent guards over the same counter nest correctly.
+    ///
+    /// Why: the daemon runs several reviews at once; each must contribute
+    /// exactly one to the gauge and remove exactly one when it finishes.
+    #[test]
+    fn count_guard_nests_and_unwinds_in_order() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let a = InFlightCountGuard::acquire(&counter);
+        let b = InFlightCountGuard::acquire(&counter);
+        assert_eq!(counter.load(Ordering::Relaxed), 2);
+        drop(a);
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+        drop(b);
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/crates/trusty-review/src/store/mod.rs
+++ b/crates/trusty-review/src/store/mod.rs
@@ -17,7 +17,7 @@ pub mod in_flight;
 pub mod outcome_store;
 
 pub use dedup::{ClaimOutcome, DedupError, DedupStore};
-pub use in_flight::{InFlightGuard, InFlightRegistry};
+pub use in_flight::{InFlightCountGuard, InFlightGuard, InFlightRegistry};
 pub use outcome_store::{OutcomeError, OutcomeRecord, OutcomeStore};
 
 /// Classify a `redb::DatabaseError` as an incompatible / unreadable file format


### PR DESCRIPTION
## The defect

`crates/trusty-review/src/service/handlers.rs` and
`crates/trusty-review/src/service/webhook.rs` both bracketed
`run_review(...).await` with a bare `fetch_add` / `fetch_sub` pair on
`AppState::in_flight` — the gauge `GET /status` reports. The decrement is a
plain statement after the `.await`, so it is skipped on two real exit paths:

| Path | What happens | Where |
|---|---|---|
| Client disconnects mid-review | axum drops the handler future; the `fetch_sub` line is never reached | `handle_review` |
| `run_review` panics | the unwind passes over the `fetch_sub`; on the webhook path the panic is swallowed into a `JoinError` nobody reads and the daemon keeps running | both |

Either leaks a permanent +1 for the life of the process. Reviews take a ~36.7s
median, so the disconnect window is wide.

Verified against `origin/main` before fixing — the shape was as reported and no
guard existed.

## The fix

`InFlightCountGuard` in `crates/trusty-review/src/store/in_flight.rs`:
`acquire` increments, `Drop` decrements. That module already owns this exact
idiom — `InFlightGuard` releases the dedup slot on drop, documented there as
"so the slot is always released even if the review task panics." This extends
the existing pattern rather than adding a second one; there is no shared
counter-guard in `trusty-common` to route through.

Both call sites now hold the guard. The increment has no spelling that does not
also arm the decrement — `acquire` is the only constructor.

## Tests

Five new tests, all confirmed to go red with the guard removed:

- `review_handler_in_flight_returns_to_zero_when_future_dropped` — parks
  `run_review` inside `preflight_context` on a never-resolving search probe,
  asserts the gauge reached 1, drops the future, asserts it is back to 0.
- `review_handler_in_flight_returns_to_zero_when_pipeline_panics` — panics
  inside the pipeline, runs the handler under `tokio::spawn` so the unwind is
  caught, asserts the task panicked and the gauge is 0.
- `count_guard_increments_then_decrements_on_drop`,
  `count_guard_decrements_on_panic_unwind`,
  `count_guard_nests_and_unwinds_in_order` — guard-level unit tests.

**Break-and-watch, as required.** Reverting `handlers.rs` to the bare
`fetch_add`/`fetch_sub` shape and re-running:

```
test service::handlers::tests::review_handler_in_flight_returns_to_zero_when_pipeline_panics ... FAILED
test service::handlers::tests::review_handler_in_flight_returns_to_zero_when_future_dropped ... FAILED

assertion `left == right` failed: dropping the handler future must release the in-flight slot
  left: 1
 right: 0
assertion `left == right` failed: a panicking pipeline must still release the in-flight slot
  left: 1
 right: 0

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 1574 filtered out
```

The guard was then restored and the suite re-run green.

The webhook site has no end-to-end drop/panic test of its own — driving that
spawned task through `run_review` needs a GitHub PR-metadata fetch stub the
crate does not have. It is covered by the guard's own unit tests plus the
end-to-end handler tests, since it uses the same guard.

## Also checked, deliberately not changed

- **`in_flight_registry`** — already correct. Its PR- and SHA-level slots are
  RAII guards released on drop; that is the precedent this fix follows.
- **`last_error`** — a `Mutex<Option<String>>` written after `run_review`
  returns, not an acquire/release pair. A panic means the error is not
  recorded, which is a missed log line, not a leak.
- **`InferenceProbe::consecutive_unknown`** — a streak counter with an explicit
  `store(0)` reset, not a paired increment/decrement.
- **The durable dedup claim** — the same drop-mid-flight shape does strand a
  claim, but `DEDUP_STALE_SECS` already reclaims abandoned claims, so it
  self-heals. Nothing to do.

## Out of scope — NOT addressed by this PR

The scoping pass that found this counter leak also flagged two other
daemon-shape bugs in `trusty-review`:

- `resolve_index()` running once at boot rather than per-invocation
- `/health` blocking on a live Bedrock call

**Neither is touched here.** They are entangled with an undecided question
about whether `trusty-review` should remain a daemon at all. Do not read this
PR as having addressed them.

## Gates — rung 3, concurrency-shaped

| Gate | Result |
|---|---|
| `cargo fmt --check` | exit 0 |
| `cargo check -p trusty-review --all-targets` | exit 0 |
| `cargo clippy -p trusty-review --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-review --all-features` | `1571 passed; 0 failed; 5 ignored` + 8 further suites all green, 0 failures |
| `bash scripts/check_line_cap.sh` | `3742 tracked .rs file(s); 0 violations — OK` |
| `bash scripts/check_sld.sh` | `56 spec doc(s) + 3115 code file(s); 0 error(s), 0 warning(s)` |
| `bash scripts/check_test_pointers.sh` | `22079 Test: citation(s) — 0 dangling pointers — OK` |

## Collision check

No other open PR touches `crates/trusty-review/` — the open set is in
trusty-installer ([#5011](https://github.com/bobmatnyc/trusty-tools/pull/5011),
[#5018](https://github.com/bobmatnyc/trusty-tools/pull/5018)),
trusty-common/memory_core ([#5013](https://github.com/bobmatnyc/trusty-tools/pull/5013)),
and trusty-mpm assets ([#5019](https://github.com/bobmatnyc/trusty-tools/pull/5019)).
This PR stays entirely inside trusty-review.

## Note on CI

GitHub Actions is in a major outage — jobs die at "Set up job" with
`Failed to resolve action download info`. Red or absent checks here are that
outage, not this change. The local gates above are the evidence.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
