### PR TITLE
feat(trusty-mpm): tm f type-to-filter picker, ID color, STATE column alignment

### DIFF
--- a/crates/trusty-mpm/changelog.d/5011-ls-state-column-alignment.md
+++ b/crates/trusty-mpm/changelog.d/5011-ls-state-column-alignment.md
@@ -1,0 +1,5 @@
+Fixed
+
+- `tm ls` no longer staggers `NAME`/`TASK`/`CREATED` on rows whose state carries an annotation
+  - the `STATE` column was a hardcoded 14 characters wide, but its rendered value is the state plus any annotation — `attached [stale-assets]` is 23 — so every annotated row pushed the three columns after it nine places right
+  - the width is now measured across the rows actually being printed, floored at the historical 14 so an unannotated listing keeps its shape

--- a/crates/trusty-mpm/changelog.d/5011-tm-f-filter-picker.md
+++ b/crates/trusty-mpm/changelog.d/5011-tm-f-filter-picker.md
@@ -5,9 +5,3 @@ Added
   - `tm ls <term>` is unchanged: still the one-shot, pipeable listing, still matching every visible column (id, name, project, state, task). `tm f` is the narrow lookup — a task description mentioning "api" no longer pads the answer to "which sessions are CALLED api-something"
   - piped output, `--json`, `--all`, or `TERM=dumb` never enter raw mode; they print the same static filtered table `tm ls` would. The gate is checked before raw mode is requested, so a script that pipes `tm f` cannot hang on a keyboard nobody is at
 - `tm ls` colors the `ID` column, dimmed — it was the widest cell on the row and the only uncolored one, so the table read as a wall of undifferentiated UUID. `NUM`, `ID`, and `NAME` now carry three distinct hues, all suppressed on a pipe and under `NO_COLOR` as before
-
-Fixed
-
-- `tm ls` no longer staggers `NAME`/`TASK`/`CREATED` on rows whose state carries an annotation
-  - the `STATE` column was a hardcoded 14 characters wide, but its rendered value is the state plus any annotation — `attached [stale-assets]` is 23 — so every annotated row pushed the three columns after it nine places right
-  - the width is now measured across the rows actually being printed, floored at the historical 14 so an unannotated listing keeps its shape

--- a/crates/trusty-mpm/changelog.d/5011-tm-ls-color-filter.md
+++ b/crates/trusty-mpm/changelog.d/5011-tm-ls-color-filter.md
@@ -1,0 +1,13 @@
+Added
+
+- `tm f [pattern]` — find a session by name, filtering as you type
+  - the list stays on screen and narrows per keystroke against the session NAME only; `[pattern]` seeds the filter box. Up/Down select, Enter opens the highlighted session through the numbered picker's own resume path, Backspace edits, Ctrl-U clears, Esc cancels
+  - `tm ls <term>` is unchanged: still the one-shot, pipeable listing, still matching every visible column (id, name, project, state, task). `tm f` is the narrow lookup — a task description mentioning "api" no longer pads the answer to "which sessions are CALLED api-something"
+  - piped output, `--json`, `--all`, or `TERM=dumb` never enter raw mode; they print the same static filtered table `tm ls` would. The gate is checked before raw mode is requested, so a script that pipes `tm f` cannot hang on a keyboard nobody is at
+- `tm ls` colors the `ID` column, dimmed — it was the widest cell on the row and the only uncolored one, so the table read as a wall of undifferentiated UUID. `NUM`, `ID`, and `NAME` now carry three distinct hues, all suppressed on a pipe and under `NO_COLOR` as before
+
+Fixed
+
+- `tm ls` no longer staggers `NAME`/`TASK`/`CREATED` on rows whose state carries an annotation
+  - the `STATE` column was a hardcoded 14 characters wide, but its rendered value is the state plus any annotation — `attached [stale-assets]` is 23 — so every annotated row pushed the three columns after it nine places right
+  - the width is now measured across the rows actually being printed, floored at the historical 14 so an unannotated listing keeps its shape

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities.md
@@ -37,7 +37,7 @@ relevant `references/*.md` file here when you need an exact answer.
 
 | Question | Load |
 |---|---|
-| "What are the exact `tm <command>` subcommands / flags?" | `references/cli.md` (57 top-level commands) |
+| "What are the exact `tm <command>` subcommands / flags?" | `references/cli.md` (58 top-level commands) |
 | "What MCP tools exist and what parameters do they take?" | `references/mcp-tools.md` (33 tools, plus sibling-daemon pointers) |
 | "What agents can I delegate to, and what do they declare?" | `references/agents.md` (37 concrete agents) |
 | "What skills exist, and are they user-invocable?" | `references/skills.md` (52 bundled skills) |

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
@@ -2,7 +2,7 @@
 
 Generated from `Cli::command()` (clap's command-tree introspection) — every `tm <command>` and its nested subcommands, verbatim. Source: `crates/trusty-mpm/src/bin/tm/cli/mod.rs` (top-level `Command` enum) plus one action enum per group under `cli/actions/*.rs`. Regenerate with `tm generate capabilities`.
 
-57 top-level commands.
+58 top-level commands.
 
 - `agent` — Inspect the deployed agent roster's declared skills (DOC-42, issue #2889)
   - `list` — List every deployed agent with its declared skills
@@ -31,6 +31,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
 - `daemon` — Run the trusty-mpm daemon
 - `doctor` — Run a full system diagnostic of the trusty-mpm stack
 - `events` — Show the recent hook-event feed
+- `f` — Find a session by NAME, filtering as you type — `tm f [pattern]`
 - `generate` — Regenerate derived, committed artifacts from live harness surfaces (issue #2913)
   - `capabilities` — Regenerate the `tm-capabilities` bundled skill's generated files
 - `gui` — Launch the Tauri desktop GUI (or open the web build in the browser when Tauri is unavailable)

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -929,6 +929,28 @@ pub(crate) enum Command {
         root: Option<String>,
     },
 
+    /// Find a session by NAME, filtering as you type — `tm f [pattern]`.
+    ///
+    /// Why: `tm ls <term>` is a one-shot filter over every visible column, so a
+    /// wrong guess means retyping the whole command, and a task description
+    /// mentioning "api" pads the answer to "which sessions are CALLED
+    /// api-something". `tm f` keeps the list on screen and narrows it per
+    /// keystroke against the NAME only, which is the lookup an operator with
+    /// ~90 sessions runs constantly. `tm ls` is unchanged — it stays the
+    /// one-shot, pipeable listing.
+    /// What: opens the type-to-filter picker. `[pattern]` seeds the filter box;
+    /// typing narrows, Up/Down select, Enter opens the highlighted session (the
+    /// same resume path the numbered picker uses), Esc cancels, Backspace edits,
+    /// Ctrl-U clears. Matching is case-insensitive substring on the name.
+    /// Piped, `--json`, `--all`, or `TERM=dumb` never enter raw mode: they print
+    /// the same static filtered table `tm ls` would.
+    /// Test: `cli_parses_f_pattern`, `cli_parses_f_multi_word_pattern`,
+    /// `cli_parses_f_bare_is_allowed`, `cli_parses_f_json`,
+    /// `cli_f_source_id_and_current_conflict`; the fallback gate by
+    /// `interactive_filter_allowed_*`.
+    #[command(name = "f")]
+    F(FindArgs),
+
     /// Clone or refresh the managed workspace for a registered alias (DOC-24).
     ///
     /// Why: `load` is the idempotent step that materializes a registered alias
@@ -1324,4 +1346,42 @@ pub(crate) struct ReinstallArgs {
     /// Skip the `--binary` confirmation prompt.
     #[arg(long, requires = "binary")]
     pub(crate) yes: bool,
+}
+
+/// Flags for [`Command::F`] (`tm f`).
+///
+/// Why: same reason as [`ReinstallArgs`] — five fields as a struct variant make
+/// the `main.rs` dispatch arm wrap onto seven lines, and that file sits against
+/// the 500-SLOC production cap. Flattened by clap, so the parsed CLI surface is
+/// identical to the inline form.
+/// What: the pattern seed plus the four `tm ls`-mirroring flags.
+/// Test: `cli_parses_f_pattern`, `cli_parses_f_bare_is_allowed`,
+/// `cli_parses_f_json`, `cli_f_source_id_and_current_conflict`.
+#[derive(Debug, Clone, clap::Args)]
+pub(crate) struct FindArgs {
+    /// Substring to seed the filter with (case-insensitive, name only).
+    ///
+    /// Optional — bare `tm f` opens the picker with an empty filter box.
+    /// Multiple words are joined with a single space and matched as one
+    /// substring.
+    #[arg(value_name = "PATTERN", num_args = 0..)]
+    pub(crate) pattern: Vec<String>,
+    /// Output the raw daemon managed-session JSON (byte-for-byte
+    /// passthrough), forcing static output even on a TTY.
+    ///
+    /// As with `tm ls --json`, the passthrough is the complete unfiltered
+    /// fleet — scripts consuming it do their own filtering.
+    #[arg(long)]
+    pub(crate) json: bool,
+    /// Also restrict to this `owner/repo` slug (passed to the daemon).
+    #[arg(long)]
+    pub(crate) source_id: Option<String>,
+    /// Derive `source_id` from the cwd's git remote.
+    ///
+    /// Mutually exclusive with `--source-id`; passing both is a parse error.
+    #[arg(long, conflicts_with = "source_id")]
+    pub(crate) current: bool,
+    /// Include decommissioned tombstone sessions (forces static output).
+    #[arg(long)]
+    pub(crate) all: bool,
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -213,7 +213,7 @@ pub(crate) async fn session_ls(
     source_id: Option<&str>,
     all: bool,
     sort: crate::commands::session_picker::SessionSortArg,
-    term: Option<String>,
+    term: Option<crate::commands::session_picker::SessionFilter>,
 ) -> anyhow::Result<()> {
     let ctx = crate::commands::session_picker_prune::PruneContext::production();
     session_ls_at(client, url, json, source_id, all, sort, term, &ctx).await
@@ -257,7 +257,7 @@ pub(crate) async fn session_ls_at(
     source_id: Option<&str>,
     all: bool,
     sort: crate::commands::session_picker::SessionSortArg,
-    term: Option<String>,
+    term: Option<crate::commands::session_picker::SessionFilter>,
     ctx: &crate::commands::session_picker_prune::PruneContext,
 ) -> anyhow::Result<()> {
     // Fetch the response body ONCE via the shared fetch path. `--json` echoes
@@ -292,7 +292,7 @@ pub(crate) async fn session_ls_at(
         &listing.dead_ids,
     );
     let mut sessions =
-        crate::commands::session_picker::filter_sessions_by_term(sessions, term.as_deref());
+        crate::commands::session_picker::filter_sessions_by_term(sessions, term.as_ref());
     crate::commands::session_picker::sort_sessions(&mut sessions, sort);
     crate::commands::managed_render::render_session_table(&sessions, source_id);
     Ok(())

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_render.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_render.rs
@@ -11,15 +11,15 @@
 //! [`format_tombstone_row`] are the pure row formatters; [`format_state_column`]
 //! and the two small text helpers came across unchanged.
 //!
-//! Color, and why padding had to change with it: `NUM` and `NAME` are colored
-//! in DISTINCT hues. They must not share one — a name's trailing `NN` is a
-//! per-project serial from `allocate_serial` that reuses gaps, while `NUM` is a
-//! global slot, so `tm-foo-01` sitting at `NUM 1` is coincidence. 57 currently
-//! listed sessions end in `-01`; one hue across both columns would assert a
-//! correspondence that does not exist. Colored text also breaks `{:<N}`, which
-//! counts an ANSI escape's bytes as width while the terminal draws none of
-//! them — hence [`pad_visible`], which measures the visible text and appends
-//! the padding outside the escape.
+//! Color, and why padding had to change with it: `NUM`, `ID`, and `NAME` are
+//! colored in DISTINCT hues. `NUM` and `NAME` must not share one — a name's
+//! trailing `NN` is a per-project serial from `allocate_serial` that reuses
+//! gaps, while `NUM` is a global slot, so `tm-foo-01` sitting at `NUM 1` is
+//! coincidence. 57 currently listed sessions end in `-01`; one hue across both
+//! columns would assert a correspondence that does not exist. Colored text also
+//! breaks `{:<N}`, which counts an ANSI escape's bytes as width while the
+//! terminal draws none of them — hence [`pad_visible`], which measures the
+//! visible text and appends the padding outside the escape.
 //!
 //! Test: `format_tombstone_row_*`, `format_state_column_*`, `truncate_*`,
 //! `short_timestamp_*`, and the color/alignment cases in `managed_tests.rs`.
@@ -31,8 +31,30 @@ use super::session_picker_render::{StateColor, colorize};
 /// Hue for the `NUM` column — the stable, global slot number (#3034).
 const NUM_COLOR: StateColor = StateColor::Magenta;
 
+/// Hue for the `ID` column — dimmed, because the full UUID is the widest thing
+/// on the row and the least often read: it exists to be copy-pasted, not
+/// scanned. Dimming pushes it behind `NUM`/`NAME` without hiding it, and it is
+/// a third hue so no two adjacent columns share one.
+const ID_COLOR: StateColor = StateColor::Dim;
+
 /// Hue for the `NAME` column, deliberately different from [`NUM_COLOR`].
 const NAME_COLOR: StateColor = StateColor::Cyan;
+
+/// Rendered width of the `NUM` column.
+const NUM_WIDTH: usize = 5;
+
+/// Rendered width of the `ID` column — a full UUID is exactly 36 chars.
+const ID_WIDTH: usize = 36;
+
+/// Rendered width of the `NAME` column; names are truncated to match.
+const NAME_WIDTH: usize = 24;
+
+/// Rendered width of the `TASK` column; tasks are truncated to match.
+const TASK_WIDTH: usize = 30;
+
+/// Floor for the `STATE` column, preserving the pre-#4061 table shape when no
+/// row carries an annotation.
+const STATE_MIN_WIDTH: usize = 14;
 
 /// Left-align `text` in a `width`-wide column, coloring only the text itself.
 ///
@@ -77,8 +99,9 @@ pub(crate) fn render_session_table(sessions: &[ManagedSessionSummary], source_id
         return;
     }
     let use_color = super::session_picker_render::table_use_color(std::io::stdout().is_terminal());
+    let state_width = state_column_width(sessions);
     println!(
-        "{:<5}  {:<36}  {:<14}  {:<24}  {:<30}  CREATED",
+        "{:<NUM_WIDTH$}  {:<ID_WIDTH$}  {:<state_width$}  {:<NAME_WIDTH$}  {:<TASK_WIDTH$}  CREATED",
         "NUM", "ID", "STATE", "NAME", "TASK"
     );
     for s in sessions {
@@ -88,9 +111,53 @@ pub(crate) fn render_session_table(sessions: &[ManagedSessionSummary], source_id
             // now dead rather than having it vanish from the listing.
             println!("{}", format_tombstone_row(s.slot, use_color));
         } else {
-            println!("{}", format_ls_row(s, use_color));
+            println!("{}", format_ls_row(s, use_color, state_width));
         }
     }
+}
+
+/// Width the `STATE` column needs so no row's annotation overflows it.
+///
+/// Why: `STATE` used to be a hardcoded `{:<14}`, but the column's rendered
+/// value is the state PLUS any annotation — `attached [stale-assets]` is 23
+/// chars, `stopped [assets ?]` is 18. Every row wider than 14 pushed `NAME`,
+/// `TASK`, and `CREATED` right by the overflow, so a single annotated session
+/// staggered the whole table. The width has to be measured across the rows
+/// actually being printed, not guessed at compile time.
+/// What: the longest [`row_state`] value among the non-tombstone rows, floored
+/// at [`STATE_MIN_WIDTH`] so an all-plain listing keeps its historical shape.
+/// Tombstone rows are excluded — they have no `STATE` cell at all.
+/// Test: `state_column_width_absorbs_longest_annotation`,
+/// `ls_table_columns_align_when_a_row_carries_an_annotation`.
+pub(crate) fn state_column_width(sessions: &[ManagedSessionSummary]) -> usize {
+    sessions
+        .iter()
+        .filter(|s| !s.deleted)
+        .map(|s| row_state(s).chars().count())
+        .max()
+        .unwrap_or(0)
+        .max(STATE_MIN_WIDTH)
+}
+
+/// The `STATE` cell for one live row, annotations included.
+///
+/// Why: the width pass and the render pass must agree exactly on the cell's
+/// text, so both go through this one function rather than rebuilding it.
+/// What: maps `attached` onto the base state, then delegates to
+/// [`format_state_column`].
+/// Test: `state_column_width_absorbs_longest_annotation`.
+fn row_state(s: &ManagedSessionSummary) -> String {
+    let base_state = if s.attached {
+        "attached"
+    } else {
+        s.state.as_str()
+    };
+    format_state_column(
+        base_state,
+        s.unresumable,
+        s.stale_assets,
+        s.stale_assets_unchecked,
+    )
 }
 
 /// Format one live `tm ls` row.
@@ -112,14 +179,22 @@ pub(crate) fn render_session_table(sessions: &[ManagedSessionSummary], source_id
 /// (live-tmux reconciled by the daemon) reads `attached` rather than the raw
 /// `active`, so a session the operator is connected to is distinguishable from
 /// a merely-running one.
+/// `state_width` comes from [`state_column_width`] over the whole listing, so a
+/// row whose annotation is longer than [`STATE_MIN_WIDTH`] widens the column for
+/// every row instead of shoving its own `NAME`/`TASK`/`CREATED` out of line.
 /// Test: `ls_row_colors_num_and_name_in_distinct_hues`,
-/// `ls_row_plain_when_color_disabled`,
-/// `ls_row_alignment_matches_with_and_without_color`.
-pub(crate) fn format_ls_row(s: &ManagedSessionSummary, use_color: bool) -> String {
+/// `ls_row_colors_id_column_dimmed`, `ls_row_plain_when_color_disabled`,
+/// `ls_row_alignment_matches_with_and_without_color`,
+/// `ls_table_columns_align_when_a_row_carries_an_annotation`.
+pub(crate) fn format_ls_row(
+    s: &ManagedSessionSummary,
+    use_color: bool,
+    state_width: usize,
+) -> String {
     let task = s
         .task
         .as_deref()
-        .map(|t| truncate(t, 30))
+        .map(|t| truncate(t, TASK_WIDTH))
         .unwrap_or_else(|| "(interactive)".to_string());
     let created = s
         .created_at
@@ -131,23 +206,17 @@ pub(crate) fn format_ls_row(s: &ManagedSessionSummary, use_color: bool) -> Strin
         .as_deref()
         .map(|d| format!(" [pending: {d}]"))
         .unwrap_or_default();
-    let base_state = if s.attached {
-        "attached"
-    } else {
-        s.state.as_str()
-    };
-    let state = format_state_column(
-        base_state,
-        s.unresumable,
-        s.stale_assets,
-        s.stale_assets_unchecked,
-    );
     format!(
-        "{}  {:<36}  {:<14}  {}  {:<30}  {}{}",
-        pad_visible(&s.slot.to_string(), 5, NUM_COLOR, use_color),
-        s.id,
-        state,
-        pad_visible(&truncate(&s.name, 24), 24, NAME_COLOR, use_color),
+        "{}  {}  {:<state_width$}  {}  {:<TASK_WIDTH$}  {}{}",
+        pad_visible(&s.slot.to_string(), NUM_WIDTH, NUM_COLOR, use_color),
+        pad_visible(&s.id, ID_WIDTH, ID_COLOR, use_color),
+        row_state(s),
+        pad_visible(
+            &truncate(&s.name, NAME_WIDTH),
+            NAME_WIDTH,
+            NAME_COLOR,
+            use_color
+        ),
         task,
         created,
         pending
@@ -167,7 +236,7 @@ pub(crate) fn format_ls_row(s: &ManagedSessionSummary, use_color: bool) -> Strin
 pub(crate) fn format_tombstone_row(slot: u32, use_color: bool) -> String {
     format!(
         "{}  -- deleted --",
-        pad_visible(&slot.to_string(), 5, NUM_COLOR, use_color)
+        pad_visible(&slot.to_string(), NUM_WIDTH, NUM_COLOR, use_color)
     )
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -30,7 +30,8 @@
 use std::future::IntoFuture as _;
 
 use super::super::managed_render::{
-    format_ls_row, format_state_column, format_tombstone_row, short_timestamp, truncate,
+    format_ls_row, format_state_column, format_tombstone_row, short_timestamp, state_column_width,
+    truncate,
 };
 use super::{session_activity, session_decommission, session_resume, session_stop};
 
@@ -909,7 +910,7 @@ fn strip_ansi(s: &str) -> String {
 /// Test: this test.
 #[test]
 fn ls_row_colors_num_and_name_in_distinct_hues() {
-    let row = format_ls_row(&ls_session("tm-trusty-tools-01", 7), true);
+    let row = format_ls_row(&ls_session("tm-trusty-tools-01", 7), true, 14);
     assert!(
         row.starts_with("\u{1b}[35m7\u{1b}[0m"),
         "NUM colored: {row:?}"
@@ -932,10 +933,10 @@ fn ls_row_colors_num_and_name_in_distinct_hues() {
 #[test]
 fn ls_row_plain_when_color_disabled() {
     let s = ls_session("tm-trusty-tools-01", 7);
-    let plain = format_ls_row(&s, false);
+    let plain = format_ls_row(&s, false, 14);
     assert!(!plain.contains('\u{1b}'), "no escapes: {plain:?}");
     assert_eq!(
-        strip_ansi(&format_ls_row(&s, true)),
+        strip_ansi(&format_ls_row(&s, true, 14)),
         plain,
         "color must change bytes only inside the escapes"
     );
@@ -956,8 +957,8 @@ fn ls_row_alignment_matches_with_and_without_color() {
         for slot in [1u32, 107] {
             let s = ls_session(name, slot);
             assert_eq!(
-                strip_ansi(&format_ls_row(&s, true)).chars().count(),
-                format_ls_row(&s, false).chars().count(),
+                strip_ansi(&format_ls_row(&s, true, 14)).chars().count(),
+                format_ls_row(&s, false, 14).chars().count(),
                 "row width drifts for name={name:?} slot={slot}"
             );
         }
@@ -975,8 +976,118 @@ fn ls_row_alignment_matches_with_and_without_color() {
         let plain = format_tombstone_row(slot, false);
         assert_eq!(
             &plain[..7],
-            &format_ls_row(&ls_session("n", slot), false)[..7],
+            &format_ls_row(&ls_session("n", slot), false, 14)[..7],
             "tombstone NUM column matches the live row's"
+        );
+    }
+}
+
+/// Why: `ID` is the widest cell on the row and was the only uncolored one, so
+/// the table read as a wall of undifferentiated UUID. It is dimmed rather than
+/// hued because it exists to be copy-pasted, not scanned — and it must be a
+/// THIRD escape, distinct from `NUM`'s and `NAME`'s, so no two columns blur
+/// together.
+/// What: asserts the id is wrapped in the dim SGR escape, and that the three
+/// column escapes are pairwise distinct.
+/// Test: this test.
+#[test]
+fn ls_row_colors_id_column_dimmed() {
+    let s = ls_session("tm-trusty-tools-01", 7);
+    let row = format_ls_row(&s, true, 14);
+    assert!(
+        row.contains(&format!("\u{1b}[2m{}\u{1b}[0m", s.id)),
+        "ID colored dim: {row:?}"
+    );
+    let hues = ["\u{1b}[35m", "\u{1b}[2m", "\u{1b}[36m"];
+    for (i, a) in hues.iter().enumerate() {
+        for b in &hues[i + 1..] {
+            assert_ne!(a, b, "NUM/ID/NAME must not share a hue");
+        }
+    }
+}
+
+/// Why: the `STATE` cell is the state PLUS any annotation, and the column was a
+/// hardcoded `{:<14}`. `attached [stale-assets]` is 23 chars, so an annotated
+/// row pushed `NAME`/`TASK`/`CREATED` nine columns right and staggered the
+/// table — visible in any real `tm ls`.
+/// What: asserts the computed width covers the longest annotated cell, is
+/// floored at the historical 14 when nothing is annotated, and ignores
+/// tombstone rows (which have no `STATE` cell).
+/// Test: this test.
+#[test]
+fn state_column_width_absorbs_longest_annotation() {
+    let plain = vec![ls_session("a", 1), ls_session("b", 2)];
+    assert_eq!(
+        state_column_width(&plain),
+        14,
+        "an all-plain listing keeps the historical width"
+    );
+
+    let mut stale = ls_session("c", 3);
+    stale.attached = true;
+    stale.stale_assets = true;
+    let annotated = vec![ls_session("a", 1), stale];
+    // "attached [stale-assets]" — the widest cell the table can produce.
+    assert_eq!(
+        state_column_width(&annotated),
+        "attached [stale-assets]".len()
+    );
+
+    let mut tomb = ls_session("d", 4);
+    tomb.deleted = true;
+    tomb.state = "a-very-long-state-string-that-is-not-rendered".into();
+    assert_eq!(
+        state_column_width(&[tomb]),
+        14,
+        "a tombstone row has no STATE cell and must not widen the column"
+    );
+}
+
+/// Why: this is the alignment bug itself. Before the fix, an annotated row's
+/// `NAME` started nine columns right of every plain row's, because the
+/// annotation overflowed a fixed-width `STATE`. The fix is only real if the
+/// columns after `STATE` start at the SAME offset on both row shapes.
+///
+/// It also proves padding is computed on VISIBLE text: the assertion runs on
+/// the colored rows with the escapes stripped, so padding measured on the
+/// escaped string would put `NAME` ~9 chars early on every colored row and
+/// fail here.
+/// What: renders a plain row and an annotated row at the listing's shared
+/// width, then asserts the `NAME` column begins at the same character offset in
+/// both — in plain output and in stripped colored output.
+/// Test: this test.
+#[test]
+fn ls_table_columns_align_when_a_row_carries_an_annotation() {
+    let plain = ls_session("plain-name", 1);
+    let mut annotated = ls_session("stale-name", 2);
+    annotated.attached = true;
+    annotated.stale_assets = true;
+    let sessions = vec![plain.clone(), annotated.clone()];
+    let width = state_column_width(&sessions);
+
+    let name_offset = |row: &str, name: &str| row.find(name).expect("name present in row");
+    for use_color in [false, true] {
+        let a = strip_ansi(&format_ls_row(&plain, use_color, width));
+        let b = strip_ansi(&format_ls_row(&annotated, use_color, width));
+        assert_eq!(
+            name_offset(&a, "plain-name"),
+            name_offset(&b, "stale-name"),
+            "NAME column drifts between a plain and an annotated row (use_color={use_color})"
+        );
+    }
+
+    // And the annotation is actually present — otherwise the offsets above
+    // would agree for the trivial reason that nothing was annotated.
+    assert!(format_ls_row(&annotated, false, width).contains("attached [stale-assets]"));
+
+    // Padding is computed on the VISIBLE text: stripping the escapes from the
+    // colored row must reproduce the plain row byte-for-byte. Padding measured
+    // on the escaped string would eat ~9 spaces per colored column here.
+    for s in [&plain, &annotated] {
+        assert_eq!(
+            strip_ansi(&format_ls_row(s, true, width)),
+            format_ls_row(s, false, width),
+            "padding must be measured on visible text, not the ANSI-wrapped string"
         );
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -83,6 +83,7 @@ pub(crate) mod services;
 pub(crate) mod sessctl;
 pub(crate) mod session;
 pub(crate) mod session_picker;
+pub(crate) mod session_picker_filter;
 pub(crate) mod session_picker_prune;
 pub(crate) mod session_picker_rename;
 pub(crate) mod session_picker_render;

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -364,8 +364,19 @@ pub(crate) async fn session(
                 source_id
             };
             let (sort, term) = crate::commands::session_picker::parse_ls_terms(&terms);
-            crate::commands::managed::session_ls(client, url, json, sid.as_deref(), all, sort, term)
-                .await?
+            // `tm sessions ls <term>` keeps the #3483 all-visible-columns scope;
+            // only `tm f` narrows to NAME.
+            let filter = term.map(crate::commands::session_picker::SessionFilter::visible);
+            crate::commands::managed::session_ls(
+                client,
+                url,
+                json,
+                sid.as_deref(),
+                all,
+                sort,
+                filter,
+            )
+            .await?
         }
         // `activity` stays on the raw path: its CLI output carries confidence,
         // token, cache, and latency detail that `CommandResult::ManagedActivity`

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
@@ -137,7 +137,7 @@ pub(crate) struct PickerScope {
     pub(crate) sort: SessionSortArg,
     /// Case-insensitive substring filter re-applied after every re-fetch
     /// (#3483); `None` shows every (live) session.
-    pub(crate) term: Option<String>,
+    pub(crate) term: Option<SessionFilter>,
 }
 
 impl PickerScope {
@@ -319,48 +319,106 @@ fn join_non_empty(words: &[String]) -> Option<String> {
     }
 }
 
-/// Case-insensitive substring filter over a session's visible identifying
-/// columns (#3483).
+/// Which columns a filter term is matched against.
 ///
-/// Why: the operator scans `id`, `name`, the project slug, `state`, and `task`
-/// on the rendered table/picker — the filter should match anything they can
-/// actually see, not an internal-only field.
-/// What: keeps a session when `term` (lowercased) is a substring of ANY of:
-/// `id`, `name`, `source_id` (project), `state`, `task`. A `None`/absent field
-/// is simply skipped. `term = None` is a no-op (returns `sessions` unchanged).
+/// Why: `tm ls <term>` and `tm f <pattern>` share one filter/sort/render path
+/// but ask different questions. `tm ls` matches everything the operator can see
+/// on the row, which is the right default when they are hunting and only half
+/// remember where the string lives. `tm f` is the narrow tool: "show me the
+/// sessions CALLED this", and a task description mentioning the word must not
+/// pad the answer. The distinction is data on the filter, not a second
+/// filtering function, so neither behaviour can drift from the other.
+/// What: [`Visible`](FilterScope::Visible) matches `id`, `name`, `source_id`,
+/// `state`, and `task`; [`Name`](FilterScope::Name) matches `name` only.
+/// Test: `filter_sessions_by_name_ignores_non_name_columns`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FilterScope {
+    /// Every column the table renders (`tm ls <term>`, #3483).
+    Visible,
+    /// The `NAME` column only (`tm f <pattern>`).
+    Name,
+}
+
+/// A case-insensitive substring filter plus the columns it applies to.
+///
+/// Why: see [`FilterScope`] — the scope has to ride along with the term through
+/// `run_ls_connector` → `session_ls` → the picker's re-fetch loop, so the
+/// picker keeps filtering the way the invoking command asked.
+/// What: an owned lowercase-compared needle and its [`FilterScope`]. Construct
+/// via [`SessionFilter::visible`] or [`SessionFilter::name`].
+/// Test: `filter_sessions_by_term_*`, `filter_sessions_by_name_*`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionFilter {
+    /// The needle, already lowercased at construction.
+    needle_lower: String,
+    /// Which columns [`SessionFilter::matches`] reads.
+    scope: FilterScope,
+}
+
+impl SessionFilter {
+    /// Filter over every visible column — the `tm ls` grammar's behaviour.
+    pub(crate) fn visible(term: impl AsRef<str>) -> Self {
+        Self::new(term, FilterScope::Visible)
+    }
+
+    /// Filter over the `NAME` column only — `tm f <pattern>`.
+    pub(crate) fn name(term: impl AsRef<str>) -> Self {
+        Self::new(term, FilterScope::Name)
+    }
+
+    fn new(term: impl AsRef<str>, scope: FilterScope) -> Self {
+        Self {
+            needle_lower: term.as_ref().to_lowercase(),
+            scope,
+        }
+    }
+
+    /// Does `s` match this filter?
+    ///
+    /// Why: a `None`/absent optional column must be skipped rather than treated
+    /// as an empty string, which every term would trivially "contain".
+    /// What: case-insensitive `contains` over the columns [`Self::scope`]
+    /// selects.
+    /// Test: `filter_sessions_by_term_*`, `filter_sessions_by_name_*`.
+    pub(crate) fn matches(&self, s: &ManagedSessionSummary) -> bool {
+        let fields: &[Option<&str>] = match self.scope {
+            FilterScope::Visible => &[
+                Some(s.id.as_str()),
+                Some(s.name.as_str()),
+                s.source_id.as_deref(),
+                Some(s.state.as_str()),
+                s.task.as_deref(),
+            ],
+            FilterScope::Name => &[Some(s.name.as_str())],
+        };
+        fields
+            .iter()
+            .flatten()
+            .any(|field| field.to_lowercase().contains(&self.needle_lower))
+    }
+}
+
+/// Apply a [`SessionFilter`] to a session list (#3483).
+///
+/// Why: the static table and the interactive picker must filter identically, so
+/// both call this rather than open-coding the predicate.
+/// What: keeps the sessions [`SessionFilter::matches`] accepts. `filter = None`
+/// is a no-op (returns `sessions` unchanged).
 /// Test: `filter_sessions_by_term_matches_name`,
 /// `filter_sessions_by_term_matches_task`,
 /// `filter_sessions_by_term_matches_source_id`,
 /// `filter_sessions_by_term_is_case_insensitive`,
 /// `filter_sessions_by_term_no_match_returns_empty`,
-/// `filter_sessions_by_term_none_is_noop`.
+/// `filter_sessions_by_term_none_is_noop`,
+/// `filter_sessions_by_name_ignores_non_name_columns`.
 pub(crate) fn filter_sessions_by_term(
     sessions: Vec<ManagedSessionSummary>,
-    term: Option<&str>,
+    filter: Option<&SessionFilter>,
 ) -> Vec<ManagedSessionSummary> {
-    let Some(term) = term else {
+    let Some(filter) = filter else {
         return sessions;
     };
-    let needle = term.to_lowercase();
-    sessions
-        .into_iter()
-        .filter(|s| session_matches_term(s, &needle))
-        .collect()
-}
-
-/// Pure predicate backing [`filter_sessions_by_term`]; `needle_lower` must
-/// already be lowercased.
-fn session_matches_term(s: &ManagedSessionSummary, needle_lower: &str) -> bool {
-    [
-        Some(s.id.as_str()),
-        Some(s.name.as_str()),
-        s.source_id.as_deref(),
-        Some(s.state.as_str()),
-        s.task.as_deref(),
-    ]
-    .into_iter()
-    .flatten()
-    .any(|field| field.to_lowercase().contains(needle_lower))
+    sessions.into_iter().filter(|s| filter.matches(s)).collect()
 }
 
 /// The attached→active→everything-else group a session belongs in (owner
@@ -609,7 +667,7 @@ pub(crate) fn next_launch_slot(sessions: &[ManagedSessionSummary]) -> u32 {
 /// Test: `guided_picker_numeric_deleted_slot_blocked`,
 /// `guided_picker_bare_enter_unresumable_session_blocked`,
 /// `guided_picker_numeric_unresumable_session_blocked`.
-fn decide_for_index(
+pub(crate) fn decide_for_index(
     sessions: &[ManagedSessionSummary],
     idx: usize,
     bare_enter_needs_restart: bool,
@@ -1040,7 +1098,7 @@ pub(crate) async fn run_tty_picker(
         // Issue TBD: re-apply the scope's filter/sort so the redisplayed menu
         // never drifts from the one the operator picked against.
         sessions = fetch_live_sessions(client, url, scope.source_id.as_deref(), false).await?;
-        sessions = filter_sessions_by_term(sessions, scope.term.as_deref());
+        sessions = filter_sessions_by_term(sessions, scope.term.as_ref());
         sort_sessions(&mut sessions, scope.sort);
     }
     Ok(())
@@ -1091,7 +1149,7 @@ pub(crate) async fn run_ls_connector(
     current: bool,
     all: bool,
     sort: SessionSortArg,
-    term: Option<String>,
+    term: Option<SessionFilter>,
 ) -> anyhow::Result<()> {
     // `--current` derives the source_id from the cwd git remote, exactly like
     // `tm session ls --current`. `--source-id` and `--current` are mutually
@@ -1133,7 +1191,7 @@ pub(crate) async fn run_ls_connector(
             .await;
         }
     };
-    let mut sessions = filter_sessions_by_term(sessions, term.as_deref());
+    let mut sessions = filter_sessions_by_term(sessions, term.as_ref());
     sort_sessions(&mut sessions, sort);
 
     if !should_show_picker(stdin_tty, stdout_tty, json, all, sessions.len()) {

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_filter.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_filter.rs
@@ -1,0 +1,479 @@
+//! `tm f` — the type-to-filter session picker.
+//!
+//! Why: `tm ls <term>` is a one-shot filter — you type a guess, get a table,
+//! and retype the whole command when the guess was wrong. With ~90 sessions
+//! that is the slow half of every lookup. `tm f` keeps the list on screen and
+//! narrows it per keystroke, so the guess is refined instead of re-issued.
+//!
+//! What this reuses, and what it does not: rows render through
+//! [`session_picker_render::format_session_row`](super::session_picker_render::format_session_row),
+//! selection resolves through
+//! [`session_picker::decide_for_index`](super::session_picker::decide_for_index),
+//! and Enter dispatches into the same
+//! [`guided_resume::resume_guided_session`](super::guided_resume::resume_guided_session)
+//! the numbered picker uses — so the tombstone (#3034), dead-session (#2595),
+//! and attach/switch-client (#2678) semantics are the picker's, not a
+//! reimplementation. What is NOT shared is the INPUT loop: the numbered picker
+//! reads whole lines (`stdin().read_line`), which cannot re-render per
+//! keystroke. Per-keystroke input requires raw mode, so this module owns a raw
+//! key loop and the numbered picker keeps its line loop. That is the one
+//! deliberate divergence; the keys below are additive (arrows and Backspace
+//! have no meaning in a line-reader) rather than conflicting.
+//!
+//! Keys: printable characters extend the pattern, Backspace deletes, Up/Down
+//! move the selection, Enter acts on the selected session, Esc / Ctrl-C / Ctrl-D
+//! cancel, Ctrl-U clears the pattern.
+//!
+//! Non-TTY safety: [`interactive_filter_allowed`] is the single gate, and it is
+//! checked BEFORE raw mode is ever requested. A pipe, `--json`, `--all`, or
+//! `TERM=dumb` all fall through to the static one-shot listing — a picker that
+//! grabbed raw mode on a pipe would hang every script that pipes `tm`.
+//!
+//! Test: `session_picker_filter_tests.rs` covers the gate, the match predicate,
+//! and every state transition. The terminal I/O in [`read_filter_selection`] is
+//! verified by hand only.
+
+use std::io::Write as _;
+
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::{cursor, execute, queue, terminal};
+use trusty_mpm::client::ManagedSessionSummary;
+
+use super::session_picker::{PickerDecision, SessionFilter, SessionSortArg};
+
+/// Most rows drawn at once, so a 90-session fleet cannot scroll its own prompt
+/// off the screen before the operator has typed anything.
+const MAX_VISIBLE_ROWS: usize = 15;
+
+/// One key press, reduced to the actions this picker understands.
+///
+/// Why: separating "which key" from "what crossterm reported" makes every
+/// transition testable without a terminal — the untestable part shrinks to the
+/// one `From<KeyEvent>`-shaped mapping in [`read_filter_selection`].
+/// What: the seven inputs the key loop acts on.
+/// Test: `filter_state_*` transitions in `session_picker_filter_tests.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FilterKey {
+    /// A printable character to append to the pattern.
+    Char(char),
+    /// Delete the last pattern character.
+    Backspace,
+    /// Move the selection one row up.
+    Up,
+    /// Move the selection one row down.
+    Down,
+    /// Clear the whole pattern (Ctrl-U).
+    ClearPattern,
+    /// Act on the selected row (Enter).
+    Accept,
+    /// Leave without acting (Esc / Ctrl-C / Ctrl-D).
+    Cancel,
+}
+
+/// What the key loop should do after a [`FilterKey`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FilterAction {
+    /// State changed — redraw the list.
+    Redraw,
+    /// Act on the currently selected visible row.
+    Accept,
+    /// Exit the picker without acting.
+    Cancel,
+    /// Nothing changed; do not redraw.
+    Ignore,
+}
+
+/// The mutable state of a type-to-filter session: the pattern and the cursor.
+///
+/// Why: the whole point of extracting this is that a TUI loop is otherwise
+/// untestable. Every rule that could regress — the selection clamping when a
+/// keystroke shrinks the list under the cursor, Enter on an empty result set,
+/// Backspace on an empty pattern — lives here as a pure transition and is unit
+/// tested, leaving only the draw calls unverified.
+/// What: `pattern` is the raw text the operator typed (matched
+/// case-insensitively; see [`matches_pattern`]); `selected` is a 0-based index
+/// into the CURRENTLY VISIBLE rows, not into the full session list.
+/// Test: every `filter_state_*` test in `session_picker_filter_tests.rs`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct FilterState {
+    pattern: String,
+    selected: usize,
+}
+
+impl FilterState {
+    /// Start with `pattern` pre-typed (the `tm f <pattern>` seed) and the first
+    /// row selected.
+    pub(crate) fn new(pattern: impl Into<String>) -> Self {
+        Self {
+            pattern: pattern.into(),
+            selected: 0,
+        }
+    }
+
+    /// The pattern typed so far.
+    pub(crate) fn pattern(&self) -> &str {
+        &self.pattern
+    }
+
+    /// The 0-based index into the visible rows.
+    pub(crate) fn selected(&self) -> usize {
+        self.selected
+    }
+
+    /// Apply one key and report what the caller should do next.
+    ///
+    /// Why: `visible_len` is passed in rather than stored because the visible
+    /// set is recomputed from the pattern after every edit. Editing the pattern
+    /// can shrink the list out from under the cursor, so an edit ALWAYS resets
+    /// the selection to the first row — leaving it where it was would point at
+    /// a different session than the one under it a keystroke ago, which is how
+    /// a fuzzy picker acts on the wrong row.
+    /// What: `Char`/`Backspace`/`ClearPattern` edit the pattern and reset the
+    /// selection, returning `Redraw` (or `Ignore` when the edit is a no-op, e.g.
+    /// Backspace on an empty pattern). `Up`/`Down` move the selection, saturating
+    /// at both ends and returning `Ignore` when already there. `Accept` returns
+    /// `Ignore` when nothing is visible — Enter on an empty result set must do
+    /// nothing rather than act on a row that is not there. `Cancel` always
+    /// returns `Cancel`.
+    /// Test: `filter_state_char_appends_and_resets_selection`,
+    /// `filter_state_backspace_on_empty_pattern_is_ignored`,
+    /// `filter_state_down_saturates_at_last_row`,
+    /// `filter_state_up_saturates_at_first_row`,
+    /// `filter_state_accept_with_no_visible_rows_is_ignored`,
+    /// `filter_state_edit_resets_selection_when_list_shrinks`,
+    /// `filter_state_clear_pattern_empties_and_resets`.
+    pub(crate) fn apply(&mut self, key: FilterKey, visible_len: usize) -> FilterAction {
+        match key {
+            FilterKey::Char(c) => {
+                self.pattern.push(c);
+                self.selected = 0;
+                FilterAction::Redraw
+            }
+            FilterKey::Backspace => {
+                if self.pattern.pop().is_none() {
+                    return FilterAction::Ignore;
+                }
+                self.selected = 0;
+                FilterAction::Redraw
+            }
+            FilterKey::ClearPattern => {
+                if self.pattern.is_empty() {
+                    return FilterAction::Ignore;
+                }
+                self.pattern.clear();
+                self.selected = 0;
+                FilterAction::Redraw
+            }
+            FilterKey::Up => {
+                if self.selected == 0 {
+                    return FilterAction::Ignore;
+                }
+                self.selected -= 1;
+                FilterAction::Redraw
+            }
+            FilterKey::Down => {
+                let last = visible_len.saturating_sub(1);
+                if visible_len == 0 || self.selected >= last {
+                    return FilterAction::Ignore;
+                }
+                self.selected += 1;
+                FilterAction::Redraw
+            }
+            FilterKey::Accept => {
+                if visible_len == 0 {
+                    FilterAction::Ignore
+                } else {
+                    FilterAction::Accept
+                }
+            }
+            FilterKey::Cancel => FilterAction::Cancel,
+        }
+    }
+}
+
+/// Does this session's NAME contain `pattern`, case-insensitively?
+///
+/// Why: routed through [`SessionFilter::name`] rather than an inline
+/// `to_lowercase().contains(…)` so the interactive filter and the one-shot
+/// `tm f` / `tm ls` filters can never disagree about what "matches" means.
+/// What: `true` for an empty pattern (an unfiltered list is the starting state).
+/// Test: `matches_pattern_is_case_insensitive_on_name`,
+/// `matches_pattern_ignores_task_and_project`,
+/// `matches_pattern_empty_matches_everything`.
+pub(crate) fn matches_pattern(s: &ManagedSessionSummary, pattern: &str) -> bool {
+    if pattern.is_empty() {
+        return true;
+    }
+    SessionFilter::name(pattern).matches(s)
+}
+
+/// Indices of the sessions currently passing `pattern`, in list order.
+///
+/// Why: indices, not clones — the selection has to resolve back to the ORIGINAL
+/// session so the resume path acts on the row the operator was looking at.
+/// Test: `visible_indices_narrows_to_matching_names`.
+pub(crate) fn visible_indices(sessions: &[ManagedSessionSummary], pattern: &str) -> Vec<usize> {
+    sessions
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| matches_pattern(s, pattern))
+        .map(|(i, _)| i)
+        .collect()
+}
+
+/// May `tm f` take over the terminal, or must it print a static list?
+///
+/// Why: this is the regression that hangs scripts. `tm ls` is piped in the
+/// wild; if the interactive path engages when stdout is a pipe, the process
+/// grabs raw mode and blocks on a keyboard nobody is at. The gate is a pure
+/// function, checked before raw mode is requested, so the non-TTY case is a
+/// unit test rather than a thing discovered in production.
+/// What: requires BOTH stdin and stdout to be TTYs (a piped stdin would EOF
+/// immediately; a piped stdout must stay a clean table), no `--json`, no
+/// `--all`, and a `TERM` that is neither absent nor `dumb` — a dumb terminal
+/// has no cursor addressing, so the redraw would smear the list down the
+/// screen. `NO_COLOR` is deliberately NOT consulted: it suppresses color, not
+/// interactivity, and the row renderer already honours it.
+/// Test: `interactive_filter_allowed_requires_both_ttys`,
+/// `interactive_filter_allowed_false_for_json_and_all`,
+/// `interactive_filter_allowed_false_for_dumb_or_missing_term`,
+/// `interactive_filter_allowed_true_on_a_real_terminal`,
+/// `interactive_filter_allowed_ignores_no_color`.
+pub(crate) fn interactive_filter_allowed(
+    stdin_tty: bool,
+    stdout_tty: bool,
+    json: bool,
+    all: bool,
+    term: Option<&str>,
+) -> bool {
+    stdin_tty
+        && stdout_tty
+        && !json
+        && !all
+        && matches!(term, Some(t) if !t.is_empty() && !t.eq_ignore_ascii_case("dumb"))
+}
+
+/// `tm f [pattern]` — filter sessions by name, interactively when possible.
+///
+/// Why: one entry point owns the interactive-vs-static decision so the fallback
+/// can never be bypassed by a future caller.
+/// What: when [`interactive_filter_allowed`] says no, delegates to the same
+/// static renderer `tm ls` uses, with the pattern applied as a NAME-scoped
+/// [`SessionFilter`] — so a piped `tm f api` is exactly a filtered `tm ls`.
+/// Otherwise fetches the fleet once and runs the raw-mode key loop, dispatching
+/// an accepted row through the numbered picker's own resume path.
+/// Test: the gate by `interactive_filter_allowed_*`; the static branch shares
+/// `session_ls`'s coverage; the key loop by hand.
+pub(crate) async fn run_f_command(
+    client: &reqwest::Client,
+    url: &str,
+    args: crate::cli::FindArgs,
+) -> anyhow::Result<()> {
+    use std::io::IsTerminal as _;
+
+    let crate::cli::FindArgs {
+        pattern,
+        json,
+        source_id,
+        current,
+        all,
+    } = args;
+    let pattern = pattern.join(" ");
+    let sid: Option<String> = if current {
+        super::session::derive_source_id_from_cwd()
+    } else {
+        source_id
+    };
+    let filter = (!pattern.is_empty()).then(|| SessionFilter::name(&pattern));
+
+    let term = std::env::var("TERM").ok();
+    if !interactive_filter_allowed(
+        std::io::stdin().is_terminal(),
+        std::io::stdout().is_terminal(),
+        json,
+        all,
+        term.as_deref(),
+    ) {
+        return super::managed::session_ls(
+            client,
+            url,
+            json,
+            sid.as_deref(),
+            all,
+            SessionSortArg::Recent,
+            filter,
+        )
+        .await;
+    }
+
+    let mut sessions =
+        super::session_picker::fetch_live_sessions(client, url, sid.as_deref(), false).await?;
+    super::session_picker::sort_sessions(&mut sessions, SessionSortArg::Recent);
+    if sessions.is_empty() {
+        super::managed_render::render_session_table(&sessions, sid.as_deref());
+        return Ok(());
+    }
+
+    let Some(idx) = read_filter_selection(&sessions, &pattern)? else {
+        eprintln!("tm: quit.");
+        return Ok(());
+    };
+
+    // The SAME resolution the numbered picker applies to an explicit numeric
+    // choice, so the tombstone (#3034) and dead-session (#2595) gates hold here
+    // too. `false` because those gates key off bare Enter in the numbered
+    // picker; here Enter is always an explicit selection of a highlighted row.
+    match super::session_picker::decide_for_index(&sessions, idx, false) {
+        PickerDecision::Resume(i) => {
+            super::guided_resume::resume_guided_session(client, url, &sessions[i]).await?;
+        }
+        PickerDecision::Unresumable(i) => {
+            eprintln!(
+                "tm: '{}' is dead — its workspace no longer exists anywhere on disk; \
+                 run `tm sessions rm {}` to remove the record.",
+                sessions[i].name, sessions[i].id
+            );
+        }
+        PickerDecision::SlotDeleted(i) => {
+            eprintln!(
+                "tm: session [{}] was deleted.",
+                super::session_picker::shown_slot(&sessions, i)
+            );
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Restores cooked mode however the key loop exits — including on `?`.
+///
+/// Why: leaving a terminal in raw mode is the worst failure this module can
+/// have; the operator's shell stops echoing and Ctrl-C stops working. A `Drop`
+/// guard covers the early-return and panic paths a trailing
+/// `disable_raw_mode()` would miss.
+struct RawModeGuard;
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = terminal::disable_raw_mode();
+        let _ = execute!(std::io::stderr(), cursor::Show);
+    }
+}
+
+/// Run the raw-mode key loop; return the accepted session's index, or `None` on
+/// cancel.
+///
+/// Why: the list is drawn to STDERR, matching the numbered picker — stdout stays
+/// clean so `tm f … | …` never carries escape sequences even in the branch
+/// where a TTY was detected on both streams.
+/// What: draws the pattern line plus up to [`MAX_VISIBLE_ROWS`] matching rows,
+/// blocks on one key at a time, and redraws in place by rewinding the cursor
+/// over the lines it drew. Raw mode is dropped before returning, so the caller's
+/// tmux attach gets a cooked terminal.
+/// Test: hand-verified. The pure decisions it delegates to ([`FilterState::apply`],
+/// [`visible_indices`], [`interactive_filter_allowed`]) are unit tested.
+fn read_filter_selection(
+    sessions: &[ManagedSessionSummary],
+    seed: &str,
+) -> anyhow::Result<Option<usize>> {
+    let use_color = super::session_picker_render::picker_use_color(true);
+    terminal::enable_raw_mode()?;
+    let _guard = RawModeGuard;
+
+    let mut state = FilterState::new(seed);
+    let mut visible = visible_indices(sessions, state.pattern());
+    let mut drawn = 0usize;
+    loop {
+        drawn = draw(sessions, &visible, &state, drawn, use_color)?;
+
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        // Windows reports both press and release; act on press only.
+        if key.kind == KeyEventKind::Release {
+            continue;
+        }
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let mapped = match key.code {
+            KeyCode::Esc => Some(FilterKey::Cancel),
+            KeyCode::Char('c' | 'd') if ctrl => Some(FilterKey::Cancel),
+            KeyCode::Char('u') if ctrl => Some(FilterKey::ClearPattern),
+            KeyCode::Char(c) if !ctrl => Some(FilterKey::Char(c)),
+            KeyCode::Backspace => Some(FilterKey::Backspace),
+            KeyCode::Up => Some(FilterKey::Up),
+            KeyCode::Down => Some(FilterKey::Down),
+            KeyCode::Enter => Some(FilterKey::Accept),
+            _ => None,
+        };
+        let Some(mapped) = mapped else { continue };
+
+        match state.apply(mapped, visible.len()) {
+            FilterAction::Redraw => visible = visible_indices(sessions, state.pattern()),
+            FilterAction::Accept => return Ok(visible.get(state.selected()).copied()),
+            FilterAction::Cancel => return Ok(None),
+            FilterAction::Ignore => {}
+        }
+    }
+}
+
+/// Draw the filter prompt and the visible rows; return the line count drawn.
+///
+/// Why: the returned count is how the next call rewinds — an off-by-one here
+/// smears the list, so the drawing function is the one that reports it.
+/// What: rewinds `previous` lines, clears downward, then writes the pattern
+/// line, up to [`MAX_VISIBLE_ROWS`] rows (the selected one marked `>` and
+/// bolded via the shared row renderer's color gate), an overflow note when the
+/// match count exceeds the cap, and the key legend. Raw mode needs `\r\n`.
+fn draw(
+    sessions: &[ManagedSessionSummary],
+    visible: &[usize],
+    state: &FilterState,
+    previous: usize,
+    use_color: bool,
+) -> anyhow::Result<usize> {
+    let mut out = std::io::stderr();
+    if previous > 0 {
+        queue!(out, cursor::MoveUp(previous as u16))?;
+    }
+    queue!(
+        out,
+        cursor::MoveToColumn(0),
+        terminal::Clear(terminal::ClearType::FromCursorDown),
+        cursor::Hide
+    )?;
+
+    let shown = visible.len().min(MAX_VISIBLE_ROWS);
+    write!(
+        out,
+        "tm: filter> {}\u{2588}\r\n{} of {} session(s)\r\n",
+        state.pattern(),
+        visible.len(),
+        sessions.len()
+    )?;
+    let mut lines = 2;
+    for (row, &idx) in visible.iter().take(shown).enumerate() {
+        let marker = if row == state.selected() { ">" } else { " " };
+        let text = super::session_picker_render::format_session_row(
+            super::session_picker::shown_slot(sessions, idx),
+            &sessions[idx],
+            use_color,
+        );
+        write!(out, "{marker} {text}\r\n")?;
+        lines += 1;
+    }
+    if visible.len() > shown {
+        write!(out, "  … {} more — keep typing\r\n", visible.len() - shown)?;
+        lines += 1;
+    }
+    write!(
+        out,
+        "[type] filter  [\u{2191}\u{2193}] select  [Enter] open  [Esc] cancel\r\n"
+    )?;
+    lines += 1;
+    out.flush()?;
+    Ok(lines)
+}
+
+#[cfg(test)]
+#[path = "session_picker_filter_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_filter_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_filter_tests.rs
@@ -1,0 +1,296 @@
+//! Unit tests for the `tm f` type-to-filter picker.
+//!
+//! Why: a raw-mode key loop is not directly testable, so every decision it
+//! makes was pushed into pure functions — the non-TTY gate, the match
+//! predicate, and the state machine. Those are what this file covers. The
+//! terminal drawing itself (`draw`, `read_filter_selection`) is hand-verified
+//! and deliberately untested here; it contains no branching policy.
+//!
+//! Test: this file IS the test module for `commands::session_picker_filter`.
+
+use super::*;
+
+/// A session summary with everything but `name`/`task`/`source_id` defaulted.
+fn s(name: &str, task: Option<&str>, source_id: Option<&str>) -> ManagedSessionSummary {
+    ManagedSessionSummary {
+        id: format!("id-{name}"),
+        name: name.to_string(),
+        state: "active".into(),
+        persisted_state: None,
+        workspace_path: None,
+        repo_url: None,
+        branch: None,
+        created_at: None,
+        last_activity_at: None,
+        pending_decision: None,
+        proposed_default: None,
+        source_id: source_id.map(str::to_string),
+        task: task.map(str::to_string),
+        cwd: None,
+        claude_session_id: None,
+        deliverable_id: None,
+        pane_id: None,
+        injection_status: None,
+        unresumable: false,
+        stale_assets: false,
+        stale_assets_unchecked: false,
+        attached: false,
+        slot: 1,
+        deleted: false,
+    }
+}
+
+// ── the non-TTY fallback gate ────────────────────────────────────────────────
+//
+// The highest-risk regression in `tm f`: raw mode on a pipe hangs any script
+// that pipes `tm`. Each of these asserts one way the gate must say "no".
+
+/// Why: a piped stdin EOFs instantly and a piped stdout must stay a clean,
+/// greppable table. Either one alone is enough to refuse raw mode.
+#[test]
+fn interactive_filter_allowed_requires_both_ttys() {
+    assert!(!interactive_filter_allowed(
+        false,
+        true,
+        false,
+        false,
+        Some("xterm-256color")
+    ));
+    assert!(!interactive_filter_allowed(
+        true,
+        false,
+        false,
+        false,
+        Some("xterm-256color")
+    ));
+    assert!(!interactive_filter_allowed(
+        false,
+        false,
+        false,
+        false,
+        Some("xterm-256color")
+    ));
+}
+
+/// Why: `--json` is a machine contract and `--all` is the forensic listing —
+/// neither is a connect target, so both force static output even on a terminal.
+#[test]
+fn interactive_filter_allowed_false_for_json_and_all() {
+    assert!(!interactive_filter_allowed(
+        true,
+        true,
+        true,
+        false,
+        Some("xterm")
+    ));
+    assert!(!interactive_filter_allowed(
+        true,
+        true,
+        false,
+        true,
+        Some("xterm")
+    ));
+}
+
+/// Why: a dumb (or unset) `TERM` has no cursor addressing, so the in-place
+/// redraw would smear the list down the screen instead of replacing it.
+#[test]
+fn interactive_filter_allowed_false_for_dumb_or_missing_term() {
+    assert!(!interactive_filter_allowed(true, true, false, false, None));
+    assert!(!interactive_filter_allowed(
+        true,
+        true,
+        false,
+        false,
+        Some("")
+    ));
+    assert!(!interactive_filter_allowed(
+        true,
+        true,
+        false,
+        false,
+        Some("dumb")
+    ));
+    assert!(!interactive_filter_allowed(
+        true,
+        true,
+        false,
+        false,
+        Some("DUMB")
+    ));
+}
+
+/// Why: the gate must still say yes in the one case it exists to serve, or
+/// `tm f` is a slower `tm ls`.
+#[test]
+fn interactive_filter_allowed_true_on_a_real_terminal() {
+    assert!(interactive_filter_allowed(
+        true,
+        true,
+        false,
+        false,
+        Some("xterm-256color")
+    ));
+}
+
+/// Why: `NO_COLOR` means "do not colour", not "do not be interactive". The row
+/// renderer honours it; the gate must not conflate the two and silently drop
+/// the operator into the static list.
+#[test]
+fn interactive_filter_allowed_ignores_no_color() {
+    // The gate takes no NO_COLOR input at all — this asserts the signature has
+    // not grown one, i.e. the same TTY inputs still decide yes.
+    assert!(interactive_filter_allowed(
+        true,
+        true,
+        false,
+        false,
+        Some("screen-256color")
+    ));
+}
+
+// ── the match predicate ──────────────────────────────────────────────────────
+
+/// Why: the operator types lowercase; session names carry mixed case.
+#[test]
+fn matches_pattern_is_case_insensitive_on_name() {
+    let sess = s("tm-TrustyTools-01", None, None);
+    assert!(matches_pattern(&sess, "trustytools"));
+    assert!(matches_pattern(&sess, "TRUSTY"));
+    assert!(!matches_pattern(&sess, "nope"));
+}
+
+/// Why: this is the whole reason `tm f` exists next to `tm ls` — a task
+/// description or project slug mentioning the pattern must NOT match, or the
+/// narrow lookup is just the broad one again.
+#[test]
+fn matches_pattern_ignores_task_and_project() {
+    let sess = s("tm-alpha-01", Some("fix the api"), Some("acme/api-server"));
+    assert!(!matches_pattern(&sess, "api"));
+    assert!(matches_pattern(&sess, "alpha"));
+}
+
+/// Why: an empty filter box is the starting state; it must show everything.
+#[test]
+fn matches_pattern_empty_matches_everything() {
+    assert!(matches_pattern(&s("anything", None, None), ""));
+}
+
+/// Why: the selection resolves through these indices back into the ORIGINAL
+/// list, so they must be original-list positions, not positions in the
+/// filtered copy.
+#[test]
+fn visible_indices_narrows_to_matching_names() {
+    let sessions = vec![
+        s("tm-api-01", None, None),
+        s("tm-web-01", None, None),
+        s("tm-api-02", None, None),
+    ];
+    assert_eq!(visible_indices(&sessions, "api"), vec![0, 2]);
+    assert_eq!(visible_indices(&sessions, ""), vec![0, 1, 2]);
+    assert!(visible_indices(&sessions, "zzz").is_empty());
+}
+
+// ── the state machine ────────────────────────────────────────────────────────
+
+/// Why: typing must extend the pattern AND put the cursor back on the first
+/// row — the row under the cursor a keystroke ago is a different session now.
+#[test]
+fn filter_state_char_appends_and_resets_selection() {
+    let mut st = FilterState::new("ap");
+    assert_eq!(st.apply(FilterKey::Down, 5), FilterAction::Redraw);
+    assert_eq!(st.selected(), 1);
+    assert_eq!(st.apply(FilterKey::Char('i'), 5), FilterAction::Redraw);
+    assert_eq!(st.pattern(), "api");
+    assert_eq!(st.selected(), 0, "an edit must re-anchor the selection");
+}
+
+/// Why: an edit that shrinks the list under a moved cursor is exactly how a
+/// fuzzy picker opens the wrong session. The reset must hold when the new
+/// visible count is smaller than the old selection index.
+#[test]
+fn filter_state_edit_resets_selection_when_list_shrinks() {
+    let mut st = FilterState::new("");
+    st.apply(FilterKey::Down, 10);
+    st.apply(FilterKey::Down, 10);
+    assert_eq!(st.selected(), 2);
+    st.apply(FilterKey::Char('z'), 10);
+    assert_eq!(st.selected(), 0);
+    // …and Accept against the now-1-row list resolves to row 0, in range.
+    assert_eq!(st.apply(FilterKey::Accept, 1), FilterAction::Accept);
+    assert_eq!(st.selected(), 0);
+}
+
+/// Why: Backspace on an empty pattern is a no-op, not a redraw — redrawing on
+/// every rejected keystroke flickers the list.
+#[test]
+fn filter_state_backspace_on_empty_pattern_is_ignored() {
+    let mut st = FilterState::new("");
+    assert_eq!(st.apply(FilterKey::Backspace, 3), FilterAction::Ignore);
+    assert_eq!(st.pattern(), "");
+    let mut st = FilterState::new("ab");
+    assert_eq!(st.apply(FilterKey::Backspace, 3), FilterAction::Redraw);
+    assert_eq!(st.pattern(), "a");
+}
+
+/// Why: Ctrl-U clears in one stroke; on an already-empty box it must be inert.
+#[test]
+fn filter_state_clear_pattern_empties_and_resets() {
+    let mut st = FilterState::new("api");
+    st.apply(FilterKey::Down, 4);
+    assert_eq!(st.apply(FilterKey::ClearPattern, 4), FilterAction::Redraw);
+    assert_eq!(st.pattern(), "");
+    assert_eq!(st.selected(), 0);
+    assert_eq!(st.apply(FilterKey::ClearPattern, 4), FilterAction::Ignore);
+}
+
+/// Why: the cursor must never run past the last visible row — an out-of-range
+/// selection would index a session that is not on screen.
+#[test]
+fn filter_state_down_saturates_at_last_row() {
+    let mut st = FilterState::new("");
+    for _ in 0..10 {
+        st.apply(FilterKey::Down, 3);
+    }
+    assert_eq!(st.selected(), 2);
+    assert_eq!(st.apply(FilterKey::Down, 3), FilterAction::Ignore);
+    // An empty result set has no row to move onto at all.
+    let mut empty = FilterState::new("");
+    assert_eq!(empty.apply(FilterKey::Down, 0), FilterAction::Ignore);
+    assert_eq!(empty.selected(), 0);
+}
+
+/// Why: symmetric guard at the top of the list.
+#[test]
+fn filter_state_up_saturates_at_first_row() {
+    let mut st = FilterState::new("");
+    assert_eq!(st.apply(FilterKey::Up, 3), FilterAction::Ignore);
+    assert_eq!(st.selected(), 0);
+}
+
+/// Why: Enter on "no matches" must do nothing. Accepting there would resolve
+/// `visible[0]` on an empty vec — the picker's one genuine panic risk.
+#[test]
+fn filter_state_accept_with_no_visible_rows_is_ignored() {
+    let mut st = FilterState::new("zzz");
+    assert_eq!(st.apply(FilterKey::Accept, 0), FilterAction::Ignore);
+    assert_eq!(st.apply(FilterKey::Accept, 1), FilterAction::Accept);
+}
+
+/// Why: Esc/Ctrl-C must leave, whatever else is on screen.
+#[test]
+fn filter_state_cancel_always_cancels() {
+    let mut st = FilterState::new("api");
+    assert_eq!(st.apply(FilterKey::Cancel, 0), FilterAction::Cancel);
+    assert_eq!(st.apply(FilterKey::Cancel, 9), FilterAction::Cancel);
+}
+
+/// Why: the seed is the `tm f <pattern>` argument — it must arrive pre-typed
+/// and editable, not as a locked-in pre-filter.
+#[test]
+fn filter_state_seeds_from_pattern_and_stays_editable() {
+    let mut st = FilterState::new("api");
+    assert_eq!(st.pattern(), "api");
+    st.apply(FilterKey::Backspace, 2);
+    assert_eq!(st.pattern(), "ap");
+}

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -576,11 +576,18 @@ async fn main() -> anyhow::Result<()> {
                 // #2311: bare `tm ls` is the interactive managed-session connector
                 // (TTY-aware; static + pipeable when non-TTY / --json / --all / 0).
                 let (sort, term) = commands::session_picker::parse_ls_terms(&terms);
+                // #3483 scope: `tm ls <term>` matches every visible column.
+                let filter = term.map(commands::session_picker::SessionFilter::visible);
                 commands::session_picker::run_ls_connector(
-                    &client, &url, json, source_id, current, all, sort, term,
+                    &client, &url, json, source_id, current, all, sort, filter,
                 )
                 .await
             }
+        }
+        // `tm f [pattern]` — the type-to-filter picker. It gates on TTY-ness
+        // BEFORE touching raw mode and degrades to the static filtered table.
+        Some(Command::F(args)) => {
+            commands::session_picker_filter::run_f_command(&client, &url, args).await
         }
         Some(Command::Load { alias, root }) => {
             let paths = commands::managed_root::resolve_managed_paths(root.as_deref())?;

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -924,7 +924,7 @@ fn ls_connector_should_show_picker_flags_and_empty_static() {
 // `sort_sessions` are the pure list operations it feeds.
 
 use crate::commands::session_picker::{
-    SessionSortArg, filter_sessions_by_term, parse_ls_terms, sort_sessions,
+    SessionFilter, SessionSortArg, filter_sessions_by_term, parse_ls_terms, sort_sessions,
 };
 
 /// Bare `tm ls` (no positional words) → default sort, no filter.
@@ -1058,7 +1058,7 @@ fn filter_sessions_by_term_matches_name() {
         ls_test_session("api-worker", "active", None, None, None, None),
         ls_test_session("web-frontend", "active", None, None, None, None),
     ];
-    let out = filter_sessions_by_term(sessions, Some("API"));
+    let out = filter_sessions_by_term(sessions, Some(&SessionFilter::visible("API")));
     assert_eq!(out.len(), 1);
     assert_eq!(out[0].name, "api-worker");
 }
@@ -1070,7 +1070,7 @@ fn filter_sessions_by_term_matches_task() {
         ls_test_session("s1", "active", None, None, None, Some("fix the login bug")),
         ls_test_session("s2", "active", None, None, None, Some("write docs")),
     ];
-    let out = filter_sessions_by_term(sessions, Some("login"));
+    let out = filter_sessions_by_term(sessions, Some(&SessionFilter::visible("login")));
     assert_eq!(out.len(), 1);
     assert_eq!(out[0].name, "s1");
 }
@@ -1089,7 +1089,7 @@ fn filter_sessions_by_term_matches_source_id() {
         ),
         ls_test_session("s2", "active", None, None, Some("other/repo"), None),
     ];
-    let out = filter_sessions_by_term(sessions, Some("trusty-tools"));
+    let out = filter_sessions_by_term(sessions, Some(&SessionFilter::visible("trusty-tools")));
     assert_eq!(out.len(), 1);
     assert_eq!(out[0].name, "s1");
 }
@@ -1099,17 +1099,23 @@ fn filter_sessions_by_term_matches_source_id() {
 fn filter_sessions_by_term_is_case_insensitive() {
     let sessions = vec![ls_test_session("MyApp", "ACTIVE", None, None, None, None)];
     assert_eq!(
-        filter_sessions_by_term(sessions.clone(), Some("myapp")).len(),
+        filter_sessions_by_term(sessions.clone(), Some(&SessionFilter::visible("myapp"))).len(),
         1
     );
-    assert_eq!(filter_sessions_by_term(sessions, Some("active")).len(), 1);
+    assert_eq!(
+        filter_sessions_by_term(sessions, Some(&SessionFilter::visible("active"))).len(),
+        1
+    );
 }
 
 /// A filter matching nothing returns an empty result (not an error).
 #[test]
 fn filter_sessions_by_term_no_match_returns_empty() {
     let sessions = vec![ls_test_session("s1", "active", None, None, None, None)];
-    let out = filter_sessions_by_term(sessions, Some("nonexistent-substring"));
+    let out = filter_sessions_by_term(
+        sessions,
+        Some(&SessionFilter::visible("nonexistent-substring")),
+    );
     assert!(out.is_empty(), "no match must yield an empty result");
 }
 
@@ -1301,7 +1307,7 @@ fn filter_and_sort_combined() {
             None,
         ),
     ];
-    let mut filtered = filter_sessions_by_term(sessions, Some("api"));
+    let mut filtered = filter_sessions_by_term(sessions, Some(&SessionFilter::visible("api")));
     assert_eq!(
         filtered.len(),
         2,
@@ -3484,4 +3490,114 @@ async fn session_ls_json_never_refetches_after_pruning() {
     );
 
     handle.abort();
+}
+
+// ── `tm f` — the type-to-filter picker's CLI surface ─────────────────────────
+//
+// `f` is a new top-level command under `infer_subcommands = true`. No other
+// subcommand starts with `f`, so it shadows nothing; these tests pin that the
+// exact spelling resolves to `Command::F` and that its flags mirror `ls`.
+
+/// `tm f api` captures the pattern positionally.
+#[test]
+fn cli_parses_f_pattern() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "f", "api"]).unwrap();
+    match cli.command.unwrap() {
+        Command::F(a) => assert_eq!(a.pattern, vec!["api".to_string()]),
+        other => panic!("expected top-level f, got {other:?}"),
+    }
+}
+
+/// Multi-word patterns are captured in order; the handler joins them with a
+/// single space. Unlike `ls`, the first word is NEVER a sort keyword — `alpha`
+/// here is part of the pattern.
+#[test]
+fn cli_parses_f_multi_word_pattern() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "f", "alpha", "api"]).unwrap();
+    match cli.command.unwrap() {
+        Command::F(a) => {
+            assert_eq!(a.pattern, vec!["alpha".to_string(), "api".to_string()])
+        }
+        other => panic!("expected top-level f, got {other:?}"),
+    }
+}
+
+/// Bare `tm f` opens the picker with an empty filter box — the pattern is a
+/// seed, not a required argument.
+#[test]
+fn cli_parses_f_bare_is_allowed() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "f"]).unwrap();
+    match cli.command.unwrap() {
+        Command::F(a) => assert!(a.pattern.is_empty()),
+        other => panic!("expected top-level f, got {other:?}"),
+    }
+}
+
+/// `--json` parses and rides alongside the pattern; the handler uses it to skip
+/// the interactive path entirely.
+#[test]
+fn cli_parses_f_json() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "f", "--json", "api"]).unwrap();
+    match cli.command.unwrap() {
+        Command::F(a) => {
+            assert_eq!(a.pattern, vec!["api".to_string()]);
+            assert!(a.json);
+        }
+        other => panic!("expected top-level f --json, got {other:?}"),
+    }
+}
+
+/// `--source-id` and `--current` are mutually exclusive, matching `tm ls`.
+#[test]
+fn cli_f_source_id_and_current_conflict() {
+    let err = Cli::try_parse_from([
+        "trusty-mpm",
+        "f",
+        "--source-id",
+        "owner/repo",
+        "--current",
+        "api",
+    ]);
+    assert!(err.is_err(), "--source-id and --current must conflict");
+}
+
+/// `tm f` must not shadow any pre-existing subcommand. Under
+/// `infer_subcommands`, an `f` that collided with (say) a hypothetical `fix`
+/// would either resolve to that command or error as ambiguous — this pins that
+/// it resolves to `Command::F` itself.
+#[test]
+fn cli_f_does_not_shadow_another_subcommand() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "f", "x"]).unwrap();
+    assert!(matches!(cli.command, Some(Command::F(_))));
+}
+
+/// `tm f`'s NAME-only scope is the reason it exists next to `tm ls <term>`,
+/// whose scope stays every visible column. Both scopes go through the SAME
+/// `filter_sessions_by_term`, so this pins that the scope — not a second
+/// filter function — is what differs.
+#[test]
+fn filter_sessions_by_name_ignores_non_name_columns() {
+    let sessions = vec![
+        ls_test_session(
+            "tm-alpha-01",
+            "active",
+            None,
+            None,
+            Some("acme/api-server"),
+            Some("fix the api"),
+        ),
+        ls_test_session("tm-api-02", "active", None, None, None, None),
+    ];
+    let by_name = filter_sessions_by_term(sessions.clone(), Some(&SessionFilter::name("api")));
+    assert_eq!(
+        by_name.iter().map(|s| s.name.as_str()).collect::<Vec<_>>(),
+        vec!["tm-api-02"],
+        "NAME scope must ignore a matching task and project slug"
+    );
+    let by_visible = filter_sessions_by_term(sessions, Some(&SessionFilter::visible("api")));
+    assert_eq!(
+        by_visible.len(),
+        2,
+        "the ls scope still matches task/source_id"
+    );
 }


### PR DESCRIPTION
## What changed

**`tm f [pattern]` — find a session by name, filtering as you type.** The list stays on screen and narrows per keystroke against the session NAME only. `[pattern]` seeds the filter box. Up/Down select, Enter opens the highlighted session, Backspace edits, Ctrl-U clears, Esc cancels.

**`tm ls` colors the ID column, dimmed.** It was the widest cell on the row and the only uncolored one. NUM/ID/NAME now carry three distinct hues, suppressed on a pipe and under `NO_COLOR` as before. `--json` is untouched.

**`tm ls` no longer staggers NAME/TASK/CREATED on annotated rows.** STATE was a hardcoded 14 chars wide, but its rendered value is the state plus any annotation — `attached [stale-assets]` is 23 — so every annotated row pushed the three columns after it nine places right. The width is now measured across the rows actually being printed, floored at 14.

Before (piped, from the wild):

```
48     7f00be37-…  attached [stale-assets]  tm-trusty-tools-05                                        2026-08-06 01:38
58     4bb64210-…  stopped [assets ?]  tm-deadrt40783-01         adopted session                 2026-08-06 20:06
```

After — every column starts at the same offset on both row shapes.

## What the existing `ls` filter matched (asked for explicitly)

`tm ls [recent|alpha] [word...]` — if the first word is `recent`/`alpha` (case-insensitive) it selects the sort and the rest joins with a space into the filter; otherwise all words are the filter. The filter is a **case-insensitive substring over five columns**: `id`, `name`, `source_id` (project), `state`, `task` (`session_picker::filter_sessions_by_term`, #3483). `tm f` narrows that to `name` only. Both go through the same function; a `FilterScope` on the filter value is what differs, so the two can't drift.

## What `tm f` reuses, and the one thing it does not

Rows render through `session_picker_render::format_session_row`; selection resolves through `session_picker::decide_for_index`, so the tombstone (#3034) and dead-session (#2595) gates hold; Enter dispatches into the same `guided_resume::resume_guided_session` the numbered picker uses.

**The input loop is not shared, and could not be.** The existing picker reads whole lines (`stdin().read_line`) off a numbered menu — it has no selection cursor, no arrow keys, and no raw mode. Per-keystroke re-rendering requires raw mode, so `tm f` owns a raw key loop and the numbered picker keeps its line loop. The keys are additive (arrows and Backspace have no meaning in a line-reader) rather than conflicting.

## Piping cannot break

`interactive_filter_allowed` is a pure function checked **before** raw mode is ever requested: it requires both stdin and stdout to be TTYs, no `--json`, no `--all`, and a `TERM` that is neither absent nor `dumb`. `NO_COLOR` is deliberately not consulted — it suppresses color, not interactivity. Five unit tests cover it, and mutating it to ignore `stdout_tty` makes them fail.

Verified against the real binary: `tm f tm | cat`, `TERM=dumb tm f tm`, `tm f --json tm`, and `tm ls` all return promptly with no escapes and correct columns.

## Test ladder — rung 3 (localized, one crate)

```
cargo fmt --check && cargo check -p trusty-mpm \
  && cargo clippy -p trusty-mpm --all-targets --no-deps -- -D warnings \
  && cargo test -p trusty-mpm
→ EXIT=0
→ lib: test result: ok. 4725 passed; 0 failed; 7 ignored
→ bin tm: test result: ok. 1546 passed; 0 failed; 1 ignored
bash scripts/check_line_cap.sh → 0 violations
```

`--no-deps` on clippy: `crates/trusty-common/src/memory_core/retrieval/embed_repair.rs:139` fails `clippy::nonminimal_bool` on `origin/main`. This diff touches zero files in `trusty-common` (`git diff --name-only origin/main...HEAD -- crates/trusty-common/` is empty), so it is a pre-existing baseline red, not one this branch caused. Change-specific gates pass.

Two `trusty-mpm` lib tests went red on one loaded run — `execute_doctor_against_test_daemon` (a documented environmental flake) and `daemon::managed_routes::tests::stale_assets_for_many_sees_an_agent_change_on_the_very_next_call`. Both pass 3/3 in isolation and on the reported clean run; this diff touches zero files under `src/client/` or `src/daemon/`.

## Regression tests — each proven to fail before the fix

Every one was mutation-tested: the fix was reverted, the test was run, and it failed.

| Task | Test | Mutation that breaks it |
|---|---|---|
| ID color | `ls_row_colors_id_column_dimmed` | render `s.id` uncolored → FAILED |
| STATE width | `state_column_width_absorbs_longest_annotation` | clamp the width to 14 → FAILED (left: 14, right: 23) |
| STATE width | `ls_table_columns_align_when_a_row_carries_an_annotation` | same → FAILED (NAME at offset 61 vs 70) |
| Padding on visible text | `ls_row_alignment_matches_with_and_without_color`, `ls_row_plain_when_color_disabled` | `format!("{:<width$}", colorize(…))` → both FAILED |
| Name scope | `filter_sessions_by_name_ignores_non_name_columns`, `matches_pattern_ignores_task_and_project` | let `FilterScope::Name` read task/source_id → both FAILED |
| Pipe safety | `interactive_filter_allowed_requires_both_ttys` | drop the `stdout_tty` term → FAILED |
| Selection reset | `filter_state_char_appends_and_resets_selection`, `filter_state_edit_resets_selection_when_list_shrinks` | don't reset on edit → both FAILED |

## Automated vs hand-verified

**Automated** (`session_picker_filter_tests.rs`, 16 tests): the non-TTY gate, the name-match predicate, `visible_indices`, and every state transition — selection clamping at both ends, reset-on-edit, Backspace/Ctrl-U on an empty pattern, Enter on an empty result set.

**Hand-verified only**: `draw` and `read_filter_selection` — the terminal escapes and the key-code mapping. Driven through a real pty: typing narrowed 38 → 1 live, Down/Down/Up walked the selection, typing re-anchored it to row 1, Ctrl-U restored the full list, Esc printed `tm: quit.` and re-showed the cursor.

## Notes

- `main.rs` hit 511 SLOC. Rather than exempt it, the `f` flags moved into a `clap::Args` struct (`FindArgs`) — the same fix `ReinstallArgs` already applies in this file, for the same documented reason.
- `f` shadows nothing: no other subcommand starts with `f`, pinned by `cli_f_does_not_shadow_another_subcommand` under `infer_subcommands = true`.
- Changelog fragment: `crates/trusty-mpm/changelog.d/5011-tm-ls-color-filter.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools