### PR TITLE
fix(trusty-common): simplify embed_health liveness guard to satisfy clippy

### DIFF
--- a/crates/trusty-common/changelog.d/4989-embed-health-nonminimal-bool.md
+++ b/crates/trusty-common/changelog.d/4989-embed-health-nonminimal-bool.md
@@ -1,0 +1,8 @@
+Changed
+
+- `PalaceHandle::embed_health` states its liveness filter as
+  `!expired || tier_c` instead of `!(expired && !tier_c)`. Same drawers, same
+  order — De Morgan on the guard clippy flagged as `nonminimal_bool`, which
+  broke `cargo clippy -p trusty-common --features memory-core --all-targets
+  -- -D warnings` on `main`. The new form also reads as the doc comment already
+  described it: keep a drawer unless it is expired and not Tier C

--- a/crates/trusty-common/src/memory_core/retrieval/embed_repair.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/embed_repair.rs
@@ -136,7 +136,7 @@ impl PalaceHandle {
             .drawers
             .read()
             .iter()
-            .filter(|d| !(d.is_expired_at(now) && !d.is_tier_c()))
+            .filter(|d| !d.is_expired_at(now) || d.is_tier_c())
             .map(|d| d.id)
             .collect();
         let missing_vector_ids: Vec<Uuid> = live


### PR DESCRIPTION
## Defect

`cargo clippy -p trusty-common --features memory-core --all-targets -- -D warnings` fails on `main`:

```
error: this boolean expression can be simplified
   --> crates/trusty-common/src/memory_core/retrieval/embed_repair.rs:139
    |    help: try: `!d.is_expired_at(now) || d.is_tier_c()`
    = note: `-D clippy::nonminimal-bool` implied by `-D warnings`
```

Plain `cargo clippy -p trusty-common --all-targets` passes, which is why this
survived: the crate's default feature set is empty, so `memory_core` is not
compiled in and the lint never reaches this file. Any gate that enables
`memory-core` hits it.

## Resolution

De Morgan: `!(A && !B)` → `!A || B`.

```rust
- .filter(|d| !(d.is_expired_at(now) && !d.is_tier_c()))
+ .filter(|d| !d.is_expired_at(now) || d.is_tier_c())
```

Equivalence checked across all four combinations of (expired, tier_c). The new
form also matches what the doc comment already claimed — "Excludes expired
non-Tier-C drawers".

Found while investigating BM25 recall fusion; fixed here under the
opportunistic-fix rule rather than spun into its own ticket.

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --check` | `EXIT=0` |
| `cargo clippy -p trusty-common --features memory-core --all-targets -- -D warnings` | `EXIT=0` (was `EXIT=101` before this commit) |
| `cargo test -p trusty-common --features memory-core` | `test result: ok. 890 passed; 0 failed; 13 ignored` (+6, +11, +4 in other targets, 0 failed) |
| `bash scripts/check_line_cap.sh` | `EXIT=0` |
| `cargo check --workspace` | `EXIT=101` — pre-existing, see below |

The branch-guarding test passes:

```
test memory_core::retrieval::embed_repair_tests::health_reports_the_drawer_with_no_vector ... ok
```

### Pre-existing workspace-check failure

`cargo check --workspace` fails on `trusty-code-gui` and `trusty-mpm-gui`:

```
error: proc macro panicked
  = help: message: The `frontendDist` configuration is set to `"ui/dist"` but this path doesn't exist
```

Both are Tauri crates whose Svelte frontend is not built in a fresh worktree —
environmental, not a code failure. This diff touches zero files in either crate
(`git diff --name-only` lists only `embed_repair.rs` and the changelog
fragment). Excluding only those two:

```
SKIP_UI_BUILD=1 cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui  →  EXIT=0
```

The exclusion is diagnostic isolation of a pre-existing environmental red, not
a narrowing of this change's own gate.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools