### PR TITLE
feat(trusty-mpm): add `[hooks] prompt_context` opt-out for the per-prompt memory injection

### DIFF
--- a/crates/trusty-mpm/changelog.d/5034-memory-hook-optout.md
+++ b/crates/trusty-mpm/changelog.d/5034-memory-hook-optout.md
@@ -1,0 +1,9 @@
+Added
+
+- `[hooks] prompt_context = false` in `~/.trusty-mpm/config.toml` turns off the per-prompt `trusty-memory prompt-context` injection (closes [#5034](https://github.com/bobmatnyc/trusty-tools/issues/5034))
+  - the hook costs a measured ~1,211 tokens on every prompt (median 1,252, range 693–1,438 across 1,114 firings over five days) — roughly 24,000 tokens across a 20-turn session, recurring — and [#4904](https://github.com/bobmatnyc/trusty-tools/issues/4904) measured 0 clean matches out of 17 curated facts on that same corpus. There was no way to stop paying it: the hook block is a hardcoded const written unconditionally at every session launch, so a hand edit to `.claude/settings.json` was overwritten on the next launch
+  - default is `true`. An absent `[hooks]` section, and a present-but-empty one, both leave the write byte-identical to before
+  - only the `UserPromptSubmit` entry is suppressed. `SessionStart` → `trusty-memory inbox-check`, the `PreToolUse` PM guard, and the six-event lifecycle triad are written either way
+  - the strip that removes trusty-mpm's own prior entries now covers every event trusty-mpm owns rather than only the ones the current config writes. Without that, the key would have done nothing on any project already launched once — the stale `UserPromptSubmit` entry would have stayed in `.claude/settings.json` and kept firing
+  - config file only, by design: no CLI flag and no environment variable
+  - `config.rs`'s inline test module moved to a sibling `config_tests.rs` (no test changed) — the new section pushed the production file to 533 SLOC, over the 500 cap

--- a/crates/trusty-mpm/src/core/config.rs
+++ b/crates/trusty-mpm/src/core/config.rs
@@ -268,6 +268,42 @@ pub struct PmConfig {
     pub circuit_breaker: Option<bool>,
 }
 
+/// `[hooks]` section — per-hook opt-outs for the project-tier hook block
+/// [`crate::core::session_launch`] writes at every session launch.
+///
+/// Why (#5034): the `UserPromptSubmit` → `trusty-memory prompt-context` hook
+/// injects a measured ~1,211 tokens (median 1,252, range 693–1,438) into EVERY
+/// prompt — roughly 24,000 tokens across a 20-turn session, recurring. Issue
+/// #4904 measured the precision of that spend at 0 clean matches out of 17
+/// curated facts across 1,114 real firings, so an operator may reasonably want
+/// it off until relevance improves. Hand-editing `.claude/settings.json` cannot
+/// achieve that: the launch writer re-adds its own entries on every launch.
+/// This section is the supported off switch.
+/// What: boolean toggles, all defaulting to `true`, so an absent `[hooks]`
+/// section (and an absent key within a present section) leaves the shipped
+/// hook block exactly as it was.
+/// Test: `config_hooks_defaults_to_enabled`, `config_hooks_prompt_context_off`,
+/// `config_absent_yields_defaults`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct HooksConfig {
+    /// Write the `UserPromptSubmit` → `trusty-memory prompt-context` hook.
+    ///
+    /// `true` (default) → unchanged behavior. `false` → the entry is omitted
+    /// from the project-tier `.claude/settings.json`, and any entry a previous
+    /// launch wrote there is stripped. Every other hook — `SessionStart`, the
+    /// PM guard, and the six-event lifecycle triad — is unaffected either way.
+    pub prompt_context: bool,
+}
+
+impl Default for HooksConfig {
+    fn default() -> Self {
+        Self {
+            prompt_context: true,
+        }
+    }
+}
+
 // ──────────────────────────────────────────────
 // Root config
 // ──────────────────────────────────────────────
@@ -308,6 +344,13 @@ pub struct MpmConfig {
 
     /// `[pm]` — PM-layer feature toggles.
     pub pm: PmConfig,
+
+    /// `[hooks]` — per-hook opt-outs for the project-tier hook block (#5034).
+    ///
+    /// Absent section → every hook enabled, byte-identical to the pre-#5034
+    /// write. Set `prompt_context = false` to suppress the per-prompt
+    /// `trusty-memory prompt-context` injection.
+    pub hooks: HooksConfig,
 
     /// `[session_manager]` — Session Manager agent config (DOC-14 §10).
     ///
@@ -524,366 +567,5 @@ pub fn resolve_agent_model(
 // ──────────────────────────────────────────────
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Helper: write `content` to `<dir>/config.toml` and load from `dir`.
-    fn load_from_str(dir: &Path, content: &str) -> MpmConfig {
-        std::fs::write(dir.join("config.toml"), content).unwrap();
-        MpmConfig::load(dir)
-    }
-
-    #[test]
-    fn config_absent_yields_defaults() {
-        // An absent config.toml must silently yield the default struct.
-        let dir = tempfile::TempDir::new().unwrap();
-        let cfg = MpmConfig::load(dir.path());
-        assert_eq!(cfg, MpmConfig::default());
-        assert!(cfg.agents.sources.is_empty());
-        assert!(cfg.models.agents.is_empty());
-        // SM-1 zero-regression: absent [session_manager] → disabled by default.
-        assert!(!cfg.session_manager.enabled);
-    }
-
-    #[test]
-    fn config_valid_parsed() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let toml = r#"
-[agents]
-sources = ["bundled", "user"]
-
-[models]
-default = "sonnet"
-
-[models.agents]
-engineer = "haiku"
-rust-engineer = "opus"
-
-[models.tiers]
-haiku = "claude-haiku-4-5"
-sonnet = "claude-sonnet-4-5"
-opus = "claude-opus-4-5"
-
-[skills]
-sources = ["bundled"]
-
-[pm]
-circuit_breaker = true
-
-[session_manager]
-enabled = true
-
-[session_manager.inference]
-provider = "anthropic"
-sm_model = "anthropic/claude-sonnet-4-6"
-temperature = 0.4
-
-[session_manager.memory]
-palace = "session-manager"
-recall_top_k = 8
-
-[session_manager.rounds]
-window = 12
-"#;
-        let cfg = load_from_str(dir.path(), toml);
-        assert_eq!(cfg.agents.sources, vec!["bundled", "user"]);
-        assert_eq!(
-            cfg.models.agents.get("engineer").map(|s| s.as_str()),
-            Some("haiku")
-        );
-        assert_eq!(
-            cfg.models.agents.get("rust-engineer").map(|s| s.as_str()),
-            Some("opus")
-        );
-        assert_eq!(cfg.models.tiers.haiku.as_deref(), Some("claude-haiku-4-5"));
-        assert_eq!(cfg.models.default.as_deref(), Some("sonnet"));
-        assert_eq!(cfg.skills.sources, vec!["bundled"]);
-        assert_eq!(cfg.pm.circuit_breaker, Some(true));
-        // [session_manager] parses through MpmConfig (DOC-14 §10).
-        assert!(cfg.session_manager.enabled);
-        assert_eq!(cfg.session_manager.inference.provider, "anthropic");
-        assert_eq!(cfg.session_manager.inference.temperature, 0.4);
-        assert_eq!(cfg.session_manager.memory.recall_top_k, 8);
-        assert_eq!(cfg.session_manager.rounds.window, 12);
-        // A field omitted from the partial inference block keeps its spec default.
-        assert_eq!(cfg.session_manager.inference.context_token_budget, 24_000);
-    }
-
-    #[test]
-    fn config_session_manager_partial_takes_defaults() {
-        // A [session_manager] section that sets only `enabled` must leave every
-        // nested subsection at its spec §10 default.
-        let dir = tempfile::TempDir::new().unwrap();
-        let toml = r#"
-[session_manager]
-enabled = true
-"#;
-        let cfg = load_from_str(dir.path(), toml);
-        assert!(cfg.session_manager.enabled);
-        assert_eq!(cfg.session_manager.inference.provider, "auto");
-        assert_eq!(cfg.session_manager.memory.palace, "session-manager");
-        assert_eq!(cfg.session_manager.rounds.window, 10);
-    }
-
-    #[test]
-    fn config_session_manager_absent_is_noop_default() {
-        // No [session_manager] section at all → the whole struct defaults and
-        // the SM is disabled (zero-regression proof for SM-1).
-        let dir = tempfile::TempDir::new().unwrap();
-        let toml = r#"
-[models.agents]
-engineer = "haiku"
-"#;
-        let cfg = load_from_str(dir.path(), toml);
-        assert_eq!(
-            cfg.session_manager,
-            crate::core::sm::config::SessionManagerConfig::default()
-        );
-        assert!(!cfg.session_manager.enabled);
-    }
-
-    #[test]
-    fn config_manifest_section_parses() {
-        // HR-2: the [manifest] section must parse the catalog source overrides,
-        // and an absent section must leave them all None (no behavior change).
-        let dir = tempfile::TempDir::new().unwrap();
-        let toml = r#"
-[manifest]
-repo = "https://github.com/me/my-fork"
-git_ref = "dev"
-ttl_hours = 6
-"#;
-        let cfg = load_from_str(dir.path(), toml);
-        assert_eq!(
-            cfg.manifest.repo.as_deref(),
-            Some("https://github.com/me/my-fork")
-        );
-        assert_eq!(cfg.manifest.git_ref.as_deref(), Some("dev"));
-        assert_eq!(cfg.manifest.ttl_hours, Some(6));
-
-        // Absent section → all None.
-        let empty = MpmConfig::load(tempfile::TempDir::new().unwrap().path());
-        assert_eq!(empty.manifest, ManifestConfig::default());
-    }
-
-    #[test]
-    fn config_malformed_falls_back() {
-        // A malformed config.toml must log (tested by absence of panic) and
-        // return defaults — the daemon must not crash on a bad file.
-        let dir = tempfile::TempDir::new().unwrap();
-        let cfg = load_from_str(dir.path(), "this is not toml {{{{");
-        assert_eq!(cfg, MpmConfig::default());
-    }
-
-    #[test]
-    fn config_partial_sections_are_fine() {
-        // Users should be able to configure only the sections they care about.
-        let dir = tempfile::TempDir::new().unwrap();
-        let toml = r#"
-[models.agents]
-engineer = "haiku"
-"#;
-        let cfg = load_from_str(dir.path(), toml);
-        assert_eq!(
-            cfg.models.agents.get("engineer").map(|s| s.as_str()),
-            Some("haiku")
-        );
-        // Other sections must yield defaults.
-        assert!(cfg.agents.sources.is_empty());
-        assert!(cfg.pm.circuit_breaker.is_none());
-    }
-
-    #[test]
-    fn tier_alias_expansion() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let toml = r#"
-[models.tiers]
-haiku = "claude-haiku-4-5"
-sonnet = "claude-sonnet-4-7"
-opus = "claude-opus-4-7"
-"#;
-        let cfg = load_from_str(dir.path(), toml);
-        assert_eq!(cfg.expand_model_alias("haiku"), "claude-haiku-4-5");
-        assert_eq!(cfg.expand_model_alias("sonnet"), "claude-sonnet-4-7");
-        assert_eq!(cfg.expand_model_alias("opus"), "claude-opus-4-7");
-        // Full model ids pass through unchanged.
-        assert_eq!(cfg.expand_model_alias("claude-opus-4-7"), "claude-opus-4-7");
-        // "auto" maps to sonnet.
-        assert_eq!(cfg.expand_model_alias("auto"), "claude-sonnet-4-5");
-    }
-
-    #[test]
-    fn tier_alias_defaults_when_not_configured() {
-        // Without explicit tier config, built-in defaults must apply.
-        let cfg = MpmConfig::default();
-        assert_eq!(cfg.expand_model_alias("haiku"), "claude-haiku-4-5");
-        assert_eq!(cfg.expand_model_alias("sonnet"), "claude-sonnet-4-5");
-        assert_eq!(cfg.expand_model_alias("opus"), "claude-opus-4-5");
-    }
-
-    #[test]
-    fn config_catchup_defaults_parse() {
-        // An absent [catchup] section must silently yield the default struct.
-        let dir = tempfile::TempDir::new().unwrap();
-        let cfg = MpmConfig::load(dir.path());
-        assert!(cfg.catchup.auto, "auto defaults to true");
-        assert!(cfg.catchup.include_git, "include_git defaults to true");
-        assert!(
-            cfg.catchup.include_palace,
-            "include_palace defaults to true"
-        );
-        assert_eq!(cfg.catchup.git_limit, 50);
-        assert_eq!(cfg.catchup.drawer_limit, 15);
-    }
-
-    #[test]
-    fn config_catchup_section_parses() {
-        // A full [catchup] section must override all defaults.
-        let dir = tempfile::TempDir::new().unwrap();
-        let toml = r#"
-[catchup]
-auto = false
-include_git = false
-include_palace = true
-git_limit = 25
-drawer_limit = 5
-"#;
-        let cfg = load_from_str(dir.path(), toml);
-        assert!(!cfg.catchup.auto);
-        assert!(!cfg.catchup.include_git);
-        assert!(cfg.catchup.include_palace);
-        assert_eq!(cfg.catchup.git_limit, 25);
-        assert_eq!(cfg.catchup.drawer_limit, 5);
-    }
-
-    #[test]
-    fn config_idle_auto_stop_defaults() {
-        // An absent [idle_auto_stop] section must yield disabled (false) with
-        // sensible numeric defaults — the zero-change guarantee for #1816.
-        let dir = tempfile::TempDir::new().unwrap();
-        let cfg = MpmConfig::load(dir.path());
-        assert!(
-            !cfg.idle_auto_stop.enabled,
-            "idle_auto_stop must default to disabled"
-        );
-        assert!(
-            cfg.idle_auto_stop.dry_run,
-            "idle_auto_stop must default to report-only (dry_run = true) — #1783"
-        );
-        assert_eq!(cfg.idle_auto_stop.poll_interval_secs, 300);
-        assert_eq!(cfg.idle_auto_stop.idle_consecutive_threshold, 3);
-        assert_eq!(cfg.idle_auto_stop.done_consecutive_threshold, 1);
-    }
-
-    #[test]
-    fn config_idle_auto_stop_section_parses() {
-        // A full [idle_auto_stop] section must override all defaults.
-        let dir = tempfile::TempDir::new().unwrap();
-        let toml = r#"
-[idle_auto_stop]
-enabled = true
-dry_run = false
-poll_interval_secs = 120
-idle_consecutive_threshold = 5
-done_consecutive_threshold = 2
-"#;
-        let cfg = load_from_str(dir.path(), toml);
-        assert!(cfg.idle_auto_stop.enabled);
-        assert!(
-            !cfg.idle_auto_stop.dry_run,
-            "explicit dry_run = false must disable report-only mode"
-        );
-        assert_eq!(cfg.idle_auto_stop.poll_interval_secs, 120);
-        assert_eq!(cfg.idle_auto_stop.idle_consecutive_threshold, 5);
-        assert_eq!(cfg.idle_auto_stop.done_consecutive_threshold, 2);
-    }
-
-    #[test]
-    fn config_idle_auto_stop_enabled_only_keeps_defaults() {
-        // Setting only `enabled = true` must leave numeric fields at defaults
-        // AND keep dry_run at its report-only default (the teardown-safe gate).
-        let dir = tempfile::TempDir::new().unwrap();
-        let toml = r#"
-[idle_auto_stop]
-enabled = true
-"#;
-        let cfg = load_from_str(dir.path(), toml);
-        assert!(cfg.idle_auto_stop.enabled);
-        assert!(
-            cfg.idle_auto_stop.dry_run,
-            "enabling the loop alone must NOT enact teardown — dry_run stays true (#1783)"
-        );
-        assert_eq!(cfg.idle_auto_stop.poll_interval_secs, 300);
-        assert_eq!(cfg.idle_auto_stop.idle_consecutive_threshold, 3);
-        assert_eq!(cfg.idle_auto_stop.done_consecutive_threshold, 1);
-    }
-
-    #[test]
-    fn config_idle_nudge_section_parses() {
-        // Absent → disabled defaults (#2621, zero behavior change); a full
-        // section overrides every field; a partial section (only `enabled`)
-        // keeps the caps and message at their conservative defaults.
-        let dir = tempfile::TempDir::new().unwrap();
-        let absent = load_from_str(dir.path(), "");
-        assert!(!absent.idle_nudge.enabled, "must default to disabled");
-        assert_eq!(absent.idle_nudge.max_nudges_per_session, 2);
-        assert_eq!(absent.idle_nudge.cooldown_secs, 300);
-        assert_eq!(
-            absent.idle_nudge.message,
-            crate::core::idle_nudge::DEFAULT_NUDGE_MESSAGE
-        );
-        let full = load_from_str(
-            dir.path(),
-            "[idle_nudge]\nenabled = true\nmax_nudges_per_session = 1\ncooldown_secs = 60\nmessage = \"resume now\"\n",
-        );
-        assert!(full.idle_nudge.enabled);
-        assert_eq!(full.idle_nudge.max_nudges_per_session, 1);
-        assert_eq!(full.idle_nudge.cooldown_secs, 60);
-        assert_eq!(full.idle_nudge.message, "resume now");
-
-        let partial = load_from_str(dir.path(), "[idle_nudge]\nenabled = true\n");
-        assert!(partial.idle_nudge.enabled);
-        assert_eq!(partial.idle_nudge.max_nudges_per_session, 2);
-        assert_eq!(partial.idle_nudge.cooldown_secs, 300);
-        assert_eq!(
-            partial.idle_nudge.message,
-            crate::core::idle_nudge::DEFAULT_NUDGE_MESSAGE
-        );
-    }
-
-    #[test]
-    fn model_resolution_precedence() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let toml = r#"
-[models]
-default = "sonnet"
-
-[models.agents]
-engineer = "haiku"
-"#;
-        let cfg = load_from_str(dir.path(), toml);
-
-        // 1. Explicit override wins over everything.
-        let m = resolve_agent_model(&cfg, "engineer", Some("opus"), Some("claude-opus-4-5"));
-        assert_eq!(m, "claude-opus-4-5");
-
-        // 2. Config per-agent override wins over frontmatter.
-        let m = resolve_agent_model(&cfg, "engineer", Some("opus"), None);
-        // "engineer" maps to "haiku" → default haiku id.
-        assert_eq!(m, "claude-haiku-4-5");
-
-        // 3. Frontmatter hint wins over config default.
-        let m = resolve_agent_model(&cfg, "unknown-agent", Some("opus"), None);
-        assert_eq!(m, "claude-opus-4-5");
-
-        // 4. Config default is the final fallback for unknown agents.
-        let m = resolve_agent_model(&cfg, "unknown-agent", None, None);
-        // "sonnet" tier default expands.
-        assert_eq!(m, "claude-sonnet-4-5");
-
-        // 5. Built-in fallback when neither config default nor anything else matches.
-        let cfg_empty = MpmConfig::default();
-        let m = resolve_agent_model(&cfg_empty, "nobody", None, None);
-        assert_eq!(m, "claude-sonnet-4-5");
-    }
-}
+#[path = "config_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/config_tests.rs
+++ b/crates/trusty-mpm/src/core/config_tests.rs
@@ -1,0 +1,416 @@
+//! Unit tests for [`super::config`] — `~/.trusty-mpm/config.toml` parsing.
+//!
+//! Why: split out of `config.rs` (issue #5034) so the production file stays
+//! under the 500-SLOC cap as sections are added, mirroring the
+//! `project_hooks.rs` / `project_hooks_tests.rs` split already used in this
+//! crate. No test was changed by the move.
+//! What: covers absent/valid/malformed loading, every config section's
+//! defaults, and the four-level model-resolution precedence.
+//! Test: this module IS the test suite for `super`.
+
+use super::*;
+
+/// Helper: write `content` to `<dir>/config.toml` and load from `dir`.
+fn load_from_str(dir: &Path, content: &str) -> MpmConfig {
+    std::fs::write(dir.join("config.toml"), content).unwrap();
+    MpmConfig::load(dir)
+}
+
+#[test]
+fn config_absent_yields_defaults() {
+    // An absent config.toml must silently yield the default struct.
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg = MpmConfig::load(dir.path());
+    assert_eq!(cfg, MpmConfig::default());
+    assert!(cfg.agents.sources.is_empty());
+    assert!(cfg.models.agents.is_empty());
+    // SM-1 zero-regression: absent [session_manager] → disabled by default.
+    assert!(!cfg.session_manager.enabled);
+    // #5034 zero-regression: absent [hooks] → prompt-context hook ON.
+    assert!(cfg.hooks.prompt_context);
+}
+
+/// Why (#5034): the opt-out must be opt-OUT. A present-but-partial
+/// `[hooks]` section, and a config that never mentions hooks at all, must
+/// both leave the injection enabled — otherwise adding the section for some
+/// future key would silently switch memory injection off.
+#[test]
+fn config_hooks_defaults_to_enabled() {
+    let dir = tempfile::TempDir::new().unwrap();
+    // Present-but-empty section.
+    assert!(load_from_str(dir.path(), "[hooks]\n").hooks.prompt_context);
+    // Unrelated section only.
+    assert!(
+        load_from_str(dir.path(), "[pm]\ncircuit_breaker = true\n")
+            .hooks
+            .prompt_context
+    );
+    assert!(HooksConfig::default().prompt_context);
+}
+
+/// Why (#5034): the key is the only supported way to suppress the
+/// per-prompt `trusty-memory prompt-context` injection — there is
+/// deliberately no CLI flag and no env var — so its parsing is load-bearing.
+/// What: sets `[hooks] prompt_context = false` alongside another section and
+/// asserts it parses through and leaves everything else at its default.
+#[test]
+fn config_hooks_prompt_context_off() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg = load_from_str(
+        dir.path(),
+        r#"
+[models.tiers]
+opus = "claude-opus-5"
+
+[hooks]
+prompt_context = false
+"#,
+    );
+    assert!(!cfg.hooks.prompt_context);
+    assert_eq!(cfg.models.tiers.opus.as_deref(), Some("claude-opus-5"));
+    // Every other section stays default — the toggle is narrow.
+    assert_eq!(cfg.pm, PmConfig::default());
+    assert_eq!(cfg.catchup, CatchupConfig::default());
+}
+
+#[test]
+fn config_valid_parsed() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let toml = r#"
+[agents]
+sources = ["bundled", "user"]
+
+[models]
+default = "sonnet"
+
+[models.agents]
+engineer = "haiku"
+rust-engineer = "opus"
+
+[models.tiers]
+haiku = "claude-haiku-4-5"
+sonnet = "claude-sonnet-4-5"
+opus = "claude-opus-4-5"
+
+[skills]
+sources = ["bundled"]
+
+[pm]
+circuit_breaker = true
+
+[session_manager]
+enabled = true
+
+[session_manager.inference]
+provider = "anthropic"
+sm_model = "anthropic/claude-sonnet-4-6"
+temperature = 0.4
+
+[session_manager.memory]
+palace = "session-manager"
+recall_top_k = 8
+
+[session_manager.rounds]
+window = 12
+"#;
+    let cfg = load_from_str(dir.path(), toml);
+    assert_eq!(cfg.agents.sources, vec!["bundled", "user"]);
+    assert_eq!(
+        cfg.models.agents.get("engineer").map(|s| s.as_str()),
+        Some("haiku")
+    );
+    assert_eq!(
+        cfg.models.agents.get("rust-engineer").map(|s| s.as_str()),
+        Some("opus")
+    );
+    assert_eq!(cfg.models.tiers.haiku.as_deref(), Some("claude-haiku-4-5"));
+    assert_eq!(cfg.models.default.as_deref(), Some("sonnet"));
+    assert_eq!(cfg.skills.sources, vec!["bundled"]);
+    assert_eq!(cfg.pm.circuit_breaker, Some(true));
+    // [session_manager] parses through MpmConfig (DOC-14 §10).
+    assert!(cfg.session_manager.enabled);
+    assert_eq!(cfg.session_manager.inference.provider, "anthropic");
+    assert_eq!(cfg.session_manager.inference.temperature, 0.4);
+    assert_eq!(cfg.session_manager.memory.recall_top_k, 8);
+    assert_eq!(cfg.session_manager.rounds.window, 12);
+    // A field omitted from the partial inference block keeps its spec default.
+    assert_eq!(cfg.session_manager.inference.context_token_budget, 24_000);
+}
+
+#[test]
+fn config_session_manager_partial_takes_defaults() {
+    // A [session_manager] section that sets only `enabled` must leave every
+    // nested subsection at its spec §10 default.
+    let dir = tempfile::TempDir::new().unwrap();
+    let toml = r#"
+[session_manager]
+enabled = true
+"#;
+    let cfg = load_from_str(dir.path(), toml);
+    assert!(cfg.session_manager.enabled);
+    assert_eq!(cfg.session_manager.inference.provider, "auto");
+    assert_eq!(cfg.session_manager.memory.palace, "session-manager");
+    assert_eq!(cfg.session_manager.rounds.window, 10);
+}
+
+#[test]
+fn config_session_manager_absent_is_noop_default() {
+    // No [session_manager] section at all → the whole struct defaults and
+    // the SM is disabled (zero-regression proof for SM-1).
+    let dir = tempfile::TempDir::new().unwrap();
+    let toml = r#"
+[models.agents]
+engineer = "haiku"
+"#;
+    let cfg = load_from_str(dir.path(), toml);
+    assert_eq!(
+        cfg.session_manager,
+        crate::core::sm::config::SessionManagerConfig::default()
+    );
+    assert!(!cfg.session_manager.enabled);
+}
+
+#[test]
+fn config_manifest_section_parses() {
+    // HR-2: the [manifest] section must parse the catalog source overrides,
+    // and an absent section must leave them all None (no behavior change).
+    let dir = tempfile::TempDir::new().unwrap();
+    let toml = r#"
+[manifest]
+repo = "https://github.com/me/my-fork"
+git_ref = "dev"
+ttl_hours = 6
+"#;
+    let cfg = load_from_str(dir.path(), toml);
+    assert_eq!(
+        cfg.manifest.repo.as_deref(),
+        Some("https://github.com/me/my-fork")
+    );
+    assert_eq!(cfg.manifest.git_ref.as_deref(), Some("dev"));
+    assert_eq!(cfg.manifest.ttl_hours, Some(6));
+
+    // Absent section → all None.
+    let empty = MpmConfig::load(tempfile::TempDir::new().unwrap().path());
+    assert_eq!(empty.manifest, ManifestConfig::default());
+}
+
+#[test]
+fn config_malformed_falls_back() {
+    // A malformed config.toml must log (tested by absence of panic) and
+    // return defaults — the daemon must not crash on a bad file.
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg = load_from_str(dir.path(), "this is not toml {{{{");
+    assert_eq!(cfg, MpmConfig::default());
+}
+
+#[test]
+fn config_partial_sections_are_fine() {
+    // Users should be able to configure only the sections they care about.
+    let dir = tempfile::TempDir::new().unwrap();
+    let toml = r#"
+[models.agents]
+engineer = "haiku"
+"#;
+    let cfg = load_from_str(dir.path(), toml);
+    assert_eq!(
+        cfg.models.agents.get("engineer").map(|s| s.as_str()),
+        Some("haiku")
+    );
+    // Other sections must yield defaults.
+    assert!(cfg.agents.sources.is_empty());
+    assert!(cfg.pm.circuit_breaker.is_none());
+}
+
+#[test]
+fn tier_alias_expansion() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let toml = r#"
+[models.tiers]
+haiku = "claude-haiku-4-5"
+sonnet = "claude-sonnet-4-7"
+opus = "claude-opus-4-7"
+"#;
+    let cfg = load_from_str(dir.path(), toml);
+    assert_eq!(cfg.expand_model_alias("haiku"), "claude-haiku-4-5");
+    assert_eq!(cfg.expand_model_alias("sonnet"), "claude-sonnet-4-7");
+    assert_eq!(cfg.expand_model_alias("opus"), "claude-opus-4-7");
+    // Full model ids pass through unchanged.
+    assert_eq!(cfg.expand_model_alias("claude-opus-4-7"), "claude-opus-4-7");
+    // "auto" maps to sonnet.
+    assert_eq!(cfg.expand_model_alias("auto"), "claude-sonnet-4-5");
+}
+
+#[test]
+fn tier_alias_defaults_when_not_configured() {
+    // Without explicit tier config, built-in defaults must apply.
+    let cfg = MpmConfig::default();
+    assert_eq!(cfg.expand_model_alias("haiku"), "claude-haiku-4-5");
+    assert_eq!(cfg.expand_model_alias("sonnet"), "claude-sonnet-4-5");
+    assert_eq!(cfg.expand_model_alias("opus"), "claude-opus-4-5");
+}
+
+#[test]
+fn config_catchup_defaults_parse() {
+    // An absent [catchup] section must silently yield the default struct.
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg = MpmConfig::load(dir.path());
+    assert!(cfg.catchup.auto, "auto defaults to true");
+    assert!(cfg.catchup.include_git, "include_git defaults to true");
+    assert!(
+        cfg.catchup.include_palace,
+        "include_palace defaults to true"
+    );
+    assert_eq!(cfg.catchup.git_limit, 50);
+    assert_eq!(cfg.catchup.drawer_limit, 15);
+}
+
+#[test]
+fn config_catchup_section_parses() {
+    // A full [catchup] section must override all defaults.
+    let dir = tempfile::TempDir::new().unwrap();
+    let toml = r#"
+[catchup]
+auto = false
+include_git = false
+include_palace = true
+git_limit = 25
+drawer_limit = 5
+"#;
+    let cfg = load_from_str(dir.path(), toml);
+    assert!(!cfg.catchup.auto);
+    assert!(!cfg.catchup.include_git);
+    assert!(cfg.catchup.include_palace);
+    assert_eq!(cfg.catchup.git_limit, 25);
+    assert_eq!(cfg.catchup.drawer_limit, 5);
+}
+
+#[test]
+fn config_idle_auto_stop_defaults() {
+    // An absent [idle_auto_stop] section must yield disabled (false) with
+    // sensible numeric defaults — the zero-change guarantee for #1816.
+    let dir = tempfile::TempDir::new().unwrap();
+    let cfg = MpmConfig::load(dir.path());
+    assert!(
+        !cfg.idle_auto_stop.enabled,
+        "idle_auto_stop must default to disabled"
+    );
+    assert!(
+        cfg.idle_auto_stop.dry_run,
+        "idle_auto_stop must default to report-only (dry_run = true) — #1783"
+    );
+    assert_eq!(cfg.idle_auto_stop.poll_interval_secs, 300);
+    assert_eq!(cfg.idle_auto_stop.idle_consecutive_threshold, 3);
+    assert_eq!(cfg.idle_auto_stop.done_consecutive_threshold, 1);
+}
+
+#[test]
+fn config_idle_auto_stop_section_parses() {
+    // A full [idle_auto_stop] section must override all defaults.
+    let dir = tempfile::TempDir::new().unwrap();
+    let toml = r#"
+[idle_auto_stop]
+enabled = true
+dry_run = false
+poll_interval_secs = 120
+idle_consecutive_threshold = 5
+done_consecutive_threshold = 2
+"#;
+    let cfg = load_from_str(dir.path(), toml);
+    assert!(cfg.idle_auto_stop.enabled);
+    assert!(
+        !cfg.idle_auto_stop.dry_run,
+        "explicit dry_run = false must disable report-only mode"
+    );
+    assert_eq!(cfg.idle_auto_stop.poll_interval_secs, 120);
+    assert_eq!(cfg.idle_auto_stop.idle_consecutive_threshold, 5);
+    assert_eq!(cfg.idle_auto_stop.done_consecutive_threshold, 2);
+}
+
+#[test]
+fn config_idle_auto_stop_enabled_only_keeps_defaults() {
+    // Setting only `enabled = true` must leave numeric fields at defaults
+    // AND keep dry_run at its report-only default (the teardown-safe gate).
+    let dir = tempfile::TempDir::new().unwrap();
+    let toml = r#"
+[idle_auto_stop]
+enabled = true
+"#;
+    let cfg = load_from_str(dir.path(), toml);
+    assert!(cfg.idle_auto_stop.enabled);
+    assert!(
+        cfg.idle_auto_stop.dry_run,
+        "enabling the loop alone must NOT enact teardown — dry_run stays true (#1783)"
+    );
+    assert_eq!(cfg.idle_auto_stop.poll_interval_secs, 300);
+    assert_eq!(cfg.idle_auto_stop.idle_consecutive_threshold, 3);
+    assert_eq!(cfg.idle_auto_stop.done_consecutive_threshold, 1);
+}
+
+#[test]
+fn config_idle_nudge_section_parses() {
+    // Absent → disabled defaults (#2621, zero behavior change); a full
+    // section overrides every field; a partial section (only `enabled`)
+    // keeps the caps and message at their conservative defaults.
+    let dir = tempfile::TempDir::new().unwrap();
+    let absent = load_from_str(dir.path(), "");
+    assert!(!absent.idle_nudge.enabled, "must default to disabled");
+    assert_eq!(absent.idle_nudge.max_nudges_per_session, 2);
+    assert_eq!(absent.idle_nudge.cooldown_secs, 300);
+    assert_eq!(
+        absent.idle_nudge.message,
+        crate::core::idle_nudge::DEFAULT_NUDGE_MESSAGE
+    );
+    let full = load_from_str(
+        dir.path(),
+        "[idle_nudge]\nenabled = true\nmax_nudges_per_session = 1\ncooldown_secs = 60\nmessage = \"resume now\"\n",
+    );
+    assert!(full.idle_nudge.enabled);
+    assert_eq!(full.idle_nudge.max_nudges_per_session, 1);
+    assert_eq!(full.idle_nudge.cooldown_secs, 60);
+    assert_eq!(full.idle_nudge.message, "resume now");
+
+    let partial = load_from_str(dir.path(), "[idle_nudge]\nenabled = true\n");
+    assert!(partial.idle_nudge.enabled);
+    assert_eq!(partial.idle_nudge.max_nudges_per_session, 2);
+    assert_eq!(partial.idle_nudge.cooldown_secs, 300);
+    assert_eq!(
+        partial.idle_nudge.message,
+        crate::core::idle_nudge::DEFAULT_NUDGE_MESSAGE
+    );
+}
+
+#[test]
+fn model_resolution_precedence() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let toml = r#"
+[models]
+default = "sonnet"
+
+[models.agents]
+engineer = "haiku"
+"#;
+    let cfg = load_from_str(dir.path(), toml);
+
+    // 1. Explicit override wins over everything.
+    let m = resolve_agent_model(&cfg, "engineer", Some("opus"), Some("claude-opus-4-5"));
+    assert_eq!(m, "claude-opus-4-5");
+
+    // 2. Config per-agent override wins over frontmatter.
+    let m = resolve_agent_model(&cfg, "engineer", Some("opus"), None);
+    // "engineer" maps to "haiku" → default haiku id.
+    assert_eq!(m, "claude-haiku-4-5");
+
+    // 3. Frontmatter hint wins over config default.
+    let m = resolve_agent_model(&cfg, "unknown-agent", Some("opus"), None);
+    assert_eq!(m, "claude-opus-4-5");
+
+    // 4. Config default is the final fallback for unknown agents.
+    let m = resolve_agent_model(&cfg, "unknown-agent", None, None);
+    // "sonnet" tier default expands.
+    assert_eq!(m, "claude-sonnet-4-5");
+
+    // 5. Built-in fallback when neither config default nor anything else matches.
+    let cfg_empty = MpmConfig::default();
+    let m = resolve_agent_model(&cfg_empty, "nobody", None, None);
+    assert_eq!(m, "claude-sonnet-4-5");
+}

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -1012,7 +1012,11 @@ fn prepare_session_inner(
     // daemon's managed launch excludes the user tier where that triad would
     // otherwise be provisioned. Non-fatal: the session still launches, it
     // just won't record memory or lifecycle events via the hooks.
-    let hooks_written = match write_project_hooks(project_dir) {
+    //
+    // #5034: `[hooks] prompt_context = false` suppresses the per-prompt
+    // `trusty-memory prompt-context` injection (and strips one a prior launch
+    // wrote). Default `true` — every other hook is written either way.
+    let hooks_written = match write_project_hooks(project_dir, config.hooks.prompt_context) {
         Ok(()) => true,
         Err(err) => {
             tracing::warn!("failed to write trusty-mpm project hooks: {err}");

--- a/crates/trusty-mpm/src/core/session_launch/project_hooks.rs
+++ b/crates/trusty-mpm/src/core/session_launch/project_hooks.rs
@@ -39,13 +39,22 @@ use crate::core::standalone::hooks::{is_mpm_hook_command, mpm_hook_additions_wit
 /// `PreToolUse` and `SessionStart` — sources for more than one of the three —
 /// end up with multiple handler groups (PM-guard + tm-hook, or trusty-memory +
 /// tm-hook) rather than one clobbering the other.
+/// `inject_prompt_context` is the `[hooks] prompt_context` config key (#5034):
+/// `true` (the default) keeps the `UserPromptSubmit` entry; `false` drops that
+/// event key entirely and leaves every other source untouched.
 /// Test: `project_managed_hook_additions_combines_all_three_sources`,
-/// `project_managed_hook_additions_is_stable_across_calls`.
-pub(super) fn project_managed_hook_additions() -> serde_json::Value {
+/// `project_managed_hook_additions_is_stable_across_calls`,
+/// `project_managed_hook_additions_omits_prompt_context_when_disabled`.
+pub(super) fn project_managed_hook_additions(inject_prompt_context: bool) -> serde_json::Value {
     let mut hooks: serde_json::Value =
         serde_json::from_str(TRUSTY_MEMORY_HOOKS).expect("bundled hook block is valid JSON");
     if let Some(obj) = hooks.as_object_mut() {
         obj.insert("PreToolUse".to_string(), pm_guard_hook_value());
+        // #5034: the opt-out drops only this one event. `SessionStart` (also a
+        // TRUSTY_MEMORY_HOOKS key) and every other source stay as they are.
+        if !inject_prompt_context {
+            obj.remove("UserPromptSubmit");
+        }
     }
 
     let triad = mpm_hook_additions_with_exe(None);
@@ -71,6 +80,28 @@ pub(super) fn project_managed_hook_additions() -> serde_json::Value {
     }
 
     serde_json::json!({ "hooks": hooks })
+}
+
+/// Every hook event key trusty-mpm owns at the project tier, regardless of
+/// which ones the current config asks to write.
+///
+/// Why (#5034): [`super::settings::write_project_hooks`] strips its own prior
+/// entries only for the events it is about to write. Deriving that strip list
+/// from the toggled-down additions would make the opt-out a no-op on any
+/// project launched at least once with the hook enabled — the stale
+/// `UserPromptSubmit` entry would sit in `.claude/settings.json` forever,
+/// still firing, because the strip no longer covered that key. The strip
+/// domain must therefore be the full owned set, not the write set.
+/// What: the event keys of [`project_managed_hook_additions`]`(true)` — a
+/// superset of every toggled variant by construction, so it cannot drift as
+/// toggles are added.
+/// Test: `project_managed_hook_events_is_a_superset_of_every_variant`,
+/// `write_project_hooks_strips_stale_prompt_context_when_disabled`.
+pub(super) fn project_managed_hook_events() -> Vec<String> {
+    project_managed_hook_additions(true)["hooks"]
+        .as_object()
+        .map(|events| events.keys().cloned().collect())
+        .unwrap_or_default()
 }
 
 /// Recognise a hook command belonging to ANY of the three project-tier

--- a/crates/trusty-mpm/src/core/session_launch/project_hooks_tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/project_hooks_tests.rs
@@ -18,7 +18,7 @@ use tempfile::TempDir;
 
 #[test]
 fn project_managed_hook_additions_combines_all_three_sources() {
-    let additions = project_managed_hook_additions();
+    let additions = project_managed_hook_additions(true);
     let hooks = additions["hooks"]
         .as_object()
         .expect("hooks must be an object");
@@ -71,9 +71,76 @@ fn project_managed_hook_additions_combines_all_three_sources() {
 fn project_managed_hook_additions_is_stable_across_calls() {
     // Why: two independent calls must produce byte-identical output so the
     // caller's merge is idempotent across repeated `write_project_hooks` runs.
-    let first = project_managed_hook_additions();
-    let second = project_managed_hook_additions();
+    let first = project_managed_hook_additions(true);
+    let second = project_managed_hook_additions(true);
     assert_eq!(first, second);
+}
+
+/// Why (#5034): `[hooks] prompt_context = false` must drop the
+/// `UserPromptSubmit` entry and NOTHING else. The regression this guards is a
+/// toggle that also takes out `SessionStart` — the other `TRUSTY_MEMORY_HOOKS`
+/// key, sharing the same constant and the same `trusty-memory ` command prefix.
+/// What: builds the additions with the toggle off and asserts `UserPromptSubmit`
+/// is absent while `SessionStart`, the PM guard, and all six lifecycle-triad
+/// events are byte-identical to the enabled build.
+#[test]
+fn project_managed_hook_additions_omits_prompt_context_when_disabled() {
+    let enabled = project_managed_hook_additions(true);
+    let disabled = project_managed_hook_additions(false);
+
+    let off = disabled["hooks"].as_object().expect("hooks is an object");
+    assert!(
+        !off.contains_key("UserPromptSubmit"),
+        "UserPromptSubmit must be absent when the toggle is off: {off:?}"
+    );
+
+    // Every other event must survive with its enabled-build value untouched.
+    let on = enabled["hooks"].as_object().unwrap();
+    for event in [
+        "SessionStart",
+        "PreToolUse",
+        "PostToolUse",
+        "Stop",
+        "SubagentStop",
+        "SessionEnd",
+    ] {
+        assert_eq!(
+            off.get(event),
+            on.get(event),
+            "{event} must be unchanged by the prompt_context toggle"
+        );
+    }
+    assert_eq!(
+        off.len(),
+        on.len() - 1,
+        "exactly one event key may differ between the two builds"
+    );
+}
+
+/// Why (#5034): the strip domain must not shrink with the toggle, or the
+/// opt-out silently does nothing on any project already launched once.
+/// What: asserts the owned-event list covers the key set of BOTH toggle
+/// variants.
+#[test]
+fn project_managed_hook_events_is_a_superset_of_every_variant() {
+    let owned = project_managed_hook_events();
+    for enabled in [true, false] {
+        for key in project_managed_hook_additions(enabled)["hooks"]
+            .as_object()
+            .unwrap()
+            .keys()
+        {
+            assert!(
+                owned.contains(key),
+                "{key} (toggle={enabled}) must be in the owned strip domain: {owned:?}"
+            );
+        }
+    }
+    assert!(
+        owned.iter().any(|e| e == "UserPromptSubmit"),
+        "UserPromptSubmit must stay in the strip domain even though the \
+         disabled build never writes it: {owned:?}"
+    );
 }
 
 #[test]
@@ -109,7 +176,7 @@ fn write_project_hooks_writes_lifecycle_triad() {
     let tmp = TempDir::new().unwrap();
     let project = tmp.path();
 
-    super::super::settings::write_project_hooks(project).expect("write succeeds");
+    super::super::settings::write_project_hooks(project, true).expect("write succeeds");
 
     let value: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
@@ -164,7 +231,7 @@ fn write_project_hooks_preserves_foreign_hooks() {
     )
     .unwrap();
 
-    super::super::settings::write_project_hooks(project).expect("write succeeds");
+    super::super::settings::write_project_hooks(project, true).expect("write succeeds");
 
     let value: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(claude_dir.join("settings.json")).unwrap())
@@ -186,7 +253,7 @@ fn write_project_hooks_preserves_foreign_hooks() {
     );
 
     // Re-running must not duplicate the foreign entry or our own groups.
-    super::super::settings::write_project_hooks(project).expect("second write succeeds");
+    super::super::settings::write_project_hooks(project, true).expect("second write succeeds");
     let value2: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(claude_dir.join("settings.json")).unwrap())
             .unwrap();
@@ -221,7 +288,7 @@ fn write_project_hooks_writes_via_atomic_path() {
     let bak_path = claude_dir.join("settings.json.bak");
     let tmp_path = claude_dir.join("settings.json.tmp");
 
-    super::super::settings::write_project_hooks(project).expect("first write succeeds");
+    super::super::settings::write_project_hooks(project, true).expect("first write succeeds");
     assert!(settings_path.exists(), "settings.json must be created");
     assert!(
         !bak_path.exists(),
@@ -233,7 +300,7 @@ fn write_project_hooks_writes_via_atomic_path() {
     );
     let first_content = std::fs::read_to_string(&settings_path).unwrap();
 
-    super::super::settings::write_project_hooks(project).expect("second write succeeds");
+    super::super::settings::write_project_hooks(project, true).expect("second write succeeds");
     assert!(
         bak_path.exists(),
         "write_json_atomic must back up the prior file before replacing it"
@@ -251,4 +318,210 @@ fn write_project_hooks_writes_via_atomic_path() {
     let value: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
     assert!(value["hooks"]["SessionStart"].is_array());
+}
+
+/// Why (#5034): the end-to-end opt-out — `[hooks] prompt_context = false` must
+/// leave no `UserPromptSubmit` entry in the file the launched session reads,
+/// while every other hook trusty-mpm writes is still there. The measured cost
+/// this buys back is ~1,211 tokens per prompt (#4904).
+/// What: writes with the toggle off into a fresh project and asserts
+/// `UserPromptSubmit` is absent, `SessionStart` still carries the
+/// `trusty-memory inbox-check` group, `PreToolUse` still carries the PM guard,
+/// and all six lifecycle-triad events are present.
+#[test]
+fn write_project_hooks_omits_prompt_context_when_disabled() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+
+    super::super::settings::write_project_hooks(project, false).expect("write succeeds");
+
+    let value: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
+    )
+    .unwrap();
+    let hooks = value["hooks"].as_object().expect("hooks must be an object");
+
+    assert!(
+        !hooks.contains_key("UserPromptSubmit"),
+        "UserPromptSubmit must not be written when disabled: {hooks:?}"
+    );
+    let raw = serde_json::to_string(&value).unwrap();
+    assert!(
+        !raw.contains("prompt-context"),
+        "no prompt-context command may survive anywhere in the file: {raw}"
+    );
+
+    // The SessionStart trusty-memory group is a separate hook and must stay.
+    let session_start = hooks["SessionStart"].as_array().unwrap();
+    let ss_commands: Vec<&str> = session_start
+        .iter()
+        .map(|g| g["hooks"][0]["command"].as_str().unwrap())
+        .collect();
+    assert!(
+        ss_commands.contains(&"trusty-memory inbox-check"),
+        "SessionStart must keep the inbox-check hook: {ss_commands:?}"
+    );
+
+    // The PM guard and the full lifecycle triad must be unaffected.
+    let pre_commands: Vec<&str> = hooks["PreToolUse"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|g| g["hooks"][0]["command"].as_str().unwrap())
+        .collect();
+    assert!(
+        pre_commands.iter().any(|c| c.ends_with(" hook --pm-guard")),
+        "the PM guard must still be registered: {pre_commands:?}"
+    );
+    for event in [
+        "PreToolUse",
+        "PostToolUse",
+        "Stop",
+        "SubagentStop",
+        "SessionStart",
+        "SessionEnd",
+    ] {
+        assert!(
+            hooks[event]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|g| g["hooks"][0]["command"]
+                    .as_str()
+                    .is_some_and(|c| c.ends_with(" hook"))),
+            "{event} must still carry the lifecycle-triad command"
+        );
+    }
+}
+
+/// Why (#5034): this is the test that fails if the strip domain is derived from
+/// the additions instead of the owned set. Every project in the wild has
+/// already been launched with the hook enabled, so the entry is ALREADY in
+/// `.claude/settings.json`; an opt-out that only stops re-writing it would
+/// leave it firing forever and the config key would appear to do nothing.
+/// What: writes once enabled (seeding the entry), then writes disabled, and
+/// asserts the stale entry is gone while a foreign `UserPromptSubmit` entry
+/// added by the operator survives.
+#[test]
+fn write_project_hooks_strips_stale_prompt_context_when_disabled() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    let settings_path = project.join(".claude").join("settings.json");
+
+    super::super::settings::write_project_hooks(project, true).expect("enabled write succeeds");
+    let seeded: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+    assert_eq!(
+        seeded["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"],
+        serde_json::json!("trusty-memory prompt-context"),
+        "precondition: the enabled write must have seeded the entry"
+    );
+
+    // The operator also has a hook of their own on the same event.
+    let mut with_foreign = seeded.clone();
+    with_foreign["hooks"]["UserPromptSubmit"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!({
+            "matcher": "",
+            "hooks": [{ "type": "command", "command": "my-own-tool inject", "timeout": 5 }]
+        }));
+    std::fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&with_foreign).unwrap(),
+    )
+    .unwrap();
+
+    super::super::settings::write_project_hooks(project, false).expect("disabled write succeeds");
+
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+    let raw = serde_json::to_string(&value).unwrap();
+    assert!(
+        !raw.contains("trusty-memory prompt-context"),
+        "the stale entry from the earlier enabled launch must be stripped: {raw}"
+    );
+
+    let remaining: Vec<&str> = value["hooks"]["UserPromptSubmit"]
+        .as_array()
+        .expect("the operator's own group keeps the event key alive")
+        .iter()
+        .map(|g| g["hooks"][0]["command"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        remaining,
+        vec!["my-own-tool inject"],
+        "a foreign UserPromptSubmit entry must survive the strip"
+    );
+}
+
+/// Why (#5034): the opt-out must be reversible — clearing the config key has to
+/// restore the hook, not leave the project permanently stripped.
+/// What: enabled → disabled → enabled, asserting the final file is
+/// byte-identical to the first enabled write.
+#[test]
+fn write_project_hooks_re_enabling_restores_the_hook() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    let settings_path = project.join(".claude").join("settings.json");
+
+    super::super::settings::write_project_hooks(project, true).expect("write 1");
+    let first = std::fs::read_to_string(&settings_path).unwrap();
+    super::super::settings::write_project_hooks(project, false).expect("write 2");
+    super::super::settings::write_project_hooks(project, true).expect("write 3");
+    let third = std::fs::read_to_string(&settings_path).unwrap();
+
+    assert_eq!(
+        third, first,
+        "re-enabling must reproduce the enabled write byte for byte"
+    );
+}
+
+/// Why (#5034): the default path must not move. `#[hooks] prompt_context`
+/// defaults to `true`, and the enabled write must be exactly what the
+/// pre-toggle code produced — which, for the strip half of the change, means
+/// the widened strip domain has to be a no-op when the hook is enabled.
+/// What: asserts the config default is `true`, and that the enabled write is
+/// unchanged whether the strip runs over the owned event set or over the
+/// additions' own keys (the pre-#5034 derivation), on both a fresh project and
+/// one already carrying a prior write.
+#[test]
+fn write_project_hooks_enabled_output_is_unchanged_by_the_toggle() {
+    assert!(
+        crate::core::config::MpmConfig::default()
+            .hooks
+            .prompt_context,
+        "the shipped default must keep the hook enabled"
+    );
+
+    // The pre-#5034 strip domain was the additions' own key set. With the hook
+    // enabled the two derivations must be identical, which is what makes the
+    // default path byte-identical to before.
+    let mut from_additions: Vec<String> = project_managed_hook_additions(true)["hooks"]
+        .as_object()
+        .unwrap()
+        .keys()
+        .cloned()
+        .collect();
+    let mut owned = project_managed_hook_events();
+    from_additions.sort();
+    owned.sort();
+    assert_eq!(
+        owned, from_additions,
+        "with the hook enabled the widened strip domain must be a no-op"
+    );
+
+    // And the write itself is stable across repeats, on a project that already
+    // carries a prior launch's entries.
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    let settings_path = project.join(".claude").join("settings.json");
+    super::super::settings::write_project_hooks(project, true).expect("write 1");
+    let first = std::fs::read_to_string(&settings_path).unwrap();
+    super::super::settings::write_project_hooks(project, true).expect("write 2");
+    assert_eq!(
+        std::fs::read_to_string(&settings_path).unwrap(),
+        first,
+        "the enabled write must be idempotent"
+    );
 }

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -278,13 +278,28 @@ pub(super) fn write_output_style(
 /// the result back pretty-printed via
 /// [`trusty_common::claude_config::write_json_atomic`]. Creates the file and
 /// `.claude/` directory when absent.
+///
+/// `inject_prompt_context` carries the `[hooks] prompt_context` config key
+/// (#5034). It gates ONE entry — `UserPromptSubmit` → `trusty-memory
+/// prompt-context`. The strip is deliberately NOT narrowed with it (see
+/// [`super::project_hooks::project_managed_hook_events`]), so turning the key
+/// off also removes the entry a prior launch wrote. Note the write is
+/// framework-owned either way: a hand-deleted entry is re-added on the next
+/// launch when the key is `true`. The config key, not a manual edit, is the
+/// supported off switch.
 /// Test: `write_project_hooks_writes_all_event_types`,
 /// `write_project_hooks_registers_pm_guard`,
 /// `write_project_hooks_replaces_existing`,
 /// `project_hooks_tests::write_project_hooks_writes_lifecycle_triad`,
 /// `project_hooks_tests::write_project_hooks_preserves_foreign_hooks`,
-/// `project_hooks_tests::write_project_hooks_writes_via_atomic_path`.
-pub(super) fn write_project_hooks(project_dir: &Path) -> Result<(), PrepError> {
+/// `project_hooks_tests::write_project_hooks_writes_via_atomic_path`,
+/// `project_hooks_tests::write_project_hooks_omits_prompt_context_when_disabled`,
+/// `project_hooks_tests::write_project_hooks_strips_stale_prompt_context_when_disabled`,
+/// `project_hooks_tests::write_project_hooks_enabled_output_is_unchanged_by_the_toggle`.
+pub(super) fn write_project_hooks(
+    project_dir: &Path,
+    inject_prompt_context: bool,
+) -> Result<(), PrepError> {
     let claude_dir = project_dir.join(".claude");
     std::fs::create_dir_all(&claude_dir).map_err(|source| PrepError::Io {
         path: claude_dir.clone(),
@@ -302,21 +317,23 @@ pub(super) fn write_project_hooks(project_dir: &Path) -> Result<(), PrepError> {
         Err(_) => serde_json::Value::Object(serde_json::Map::new()),
     };
 
-    let additions = super::project_hooks::project_managed_hook_additions();
+    let additions = super::project_hooks::project_managed_hook_additions(inject_prompt_context);
 
     // Replace-by-identity at entry granularity: strip any existing entry we
-    // own (trusty-memory / PM-guard / lifecycle-triad) for the events we are
-    // about to (re)add, so re-running this on every launch never duplicates
-    // our own groups while a foreign entry sharing one of our matcher groups
-    // survives untouched.
-    if let Some(events) = additions.get("hooks").and_then(|h| h.as_object()) {
-        let event_keys: Vec<String> = events.keys().cloned().collect();
-        crate::core::standalone::hooks::strip_hook_entries_matching_for_events(
-            &mut settings,
-            Some(&event_keys),
-            super::project_hooks::is_project_managed_hook_command,
-        );
-    }
+    // own (trusty-memory / PM-guard / lifecycle-triad), so re-running this on
+    // every launch never duplicates our own groups while a foreign entry
+    // sharing one of our matcher groups survives untouched.
+    //
+    // #5034: the strip covers every event we OWN, not just the ones this call
+    // writes. Scoping it to the additions instead would leave a
+    // previously-written `UserPromptSubmit` entry in place once the operator
+    // sets `[hooks] prompt_context = false`, and the opt-out would do nothing.
+    let event_keys = super::project_hooks::project_managed_hook_events();
+    crate::core::standalone::hooks::strip_hook_entries_matching_for_events(
+        &mut settings,
+        Some(&event_keys),
+        super::project_hooks::is_project_managed_hook_command,
+    );
 
     let merged = trusty_common::claude_config::merge_hook_entries(&settings, &additions);
 

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -995,7 +995,7 @@ fn write_project_hooks_writes_all_event_types() {
     let tmp = tempdir().unwrap();
     let project = tmp.path();
 
-    write_project_hooks(project).expect("write succeeds");
+    write_project_hooks(project, true).expect("write succeeds");
 
     let value: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
@@ -1025,7 +1025,7 @@ fn write_project_hooks_uses_canonical_commands() {
     let tmp = tempdir().unwrap();
     let project = tmp.path();
 
-    write_project_hooks(project).expect("write succeeds");
+    write_project_hooks(project, true).expect("write succeeds");
 
     let value: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
@@ -1059,7 +1059,7 @@ fn write_project_hooks_omits_post_tool_use_and_stop() {
     let tmp = tempdir().unwrap();
     let project = tmp.path();
 
-    write_project_hooks(project).expect("write succeeds");
+    write_project_hooks(project, true).expect("write succeeds");
 
     let value: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
@@ -1089,7 +1089,7 @@ fn write_project_hooks_registers_pm_guard() {
     let tmp = tempdir().unwrap();
     let project = tmp.path();
 
-    write_project_hooks(project).expect("write succeeds");
+    write_project_hooks(project, true).expect("write succeeds");
 
     let value: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
@@ -1130,8 +1130,8 @@ fn write_project_hooks_replaces_existing() {
     let tmp = tempdir().unwrap();
     let project = tmp.path();
 
-    write_project_hooks(project).expect("first write succeeds");
-    write_project_hooks(project).expect("second write succeeds");
+    write_project_hooks(project, true).expect("first write succeeds");
+    write_project_hooks(project, true).expect("second write succeeds");
 
     let value: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
@@ -1146,7 +1146,7 @@ fn write_project_hooks_replaces_existing() {
         "re-running must not duplicate our own handler groups"
     );
     // Unrelated keys must survive the replace.
-    write_project_hooks(project).expect("third write succeeds");
+    write_project_hooks(project, true).expect("third write succeeds");
     let value: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(project.join(".claude").join("settings.json")).unwrap(),
     )


### PR DESCRIPTION
## Defect

There is no supported way to turn off the per-prompt memory injection.

The `UserPromptSubmit` → `trusty-memory prompt-context` hook costs a measured **~1,211 tokens on every prompt** (median 1,252, range 693–1,438, from trusty-memory's enriched-prompts JSONL across 1,114 firings over five days). A 20-turn session pays **~24,000 tokens** in recall injections, recurring. [#4904](https://github.com/bobmatnyc/trusty-tools/issues/4904) measured the precision of that spend on the same corpus: 0 clean matches out of 17 curated facts.

Hand-editing `.claude/settings.json` does not work. `TRUSTY_MEMORY_HOOKS` is a hardcoded const written unconditionally at every launch, so the edit is overwritten on the next one.

## Resolution

`[hooks] prompt_context = false` in `~/.trusty-mpm/config.toml`, read through the existing `core::config` reader.

```toml
[hooks]
prompt_context = false
```

- **Default `true`.** Opt-out, not a behavior flip. An absent `[hooks]` section and a present-but-empty one both leave the write unchanged.
- **Only the `UserPromptSubmit` entry is suppressed.** `SessionStart` → `trusty-memory inbox-check`, the `PreToolUse` PM guard, and the six-event lifecycle triad are written either way.
- **Config file only** — no CLI flag, no environment variable.

### The strip domain had to widen

`write_project_hooks` strips its own prior entries only for the events it is about to write. Deriving that list from the toggled-down additions would have made the key a no-op on every project already launched once: the stale `UserPromptSubmit` entry would sit in `.claude/settings.json` forever, still firing. The strip now covers every event trusty-mpm owns, derived from `project_managed_hook_additions(true)` so it cannot drift as toggles are added. `write_project_hooks_strips_stale_prompt_context_when_disabled` fails without this.

### Overwrite semantics, unchanged and stated

The write is framework-owned. It strips entries matching `is_project_managed_hook_command` for the owned events, then merges its own back in — so a hand-deleted entry is re-added on the next launch, while a genuinely foreign entry on the same event survives untouched (`write_project_hooks_preserves_foreign_hooks`, and the new strip test asserts a foreign `UserPromptSubmit` entry survives). I did not change that, and recommend not changing it: honoring manual deletions would break idempotent provisioning for every hook, to solve a problem the config key now solves properly.

### `tm doctor`

No doctor check covers this hook, so nothing reports it as missing when disabled. `hooks_contamination` classifies via `is_mpm_hook_command`, which requires a `<binary> hook` suffix and never matches `trusty-memory prompt-context`; it also runs in the opposite direction (warning that tm hooks are present). No doctor change needed.

### Documentation

There is no user-facing doc page for `~/.trusty-mpm/config.toml`. `[models.tiers]` appears only in PM-instruction prose; `[pm]`, `[catchup]`, and `[idle_auto_stop]` are documented solely in `config.rs` doc comments. The new key is documented the same way, plus the changelog fragment. Writing a config reference from scratch is a separate outcome.

### `config.rs` split

The new section pushed `config.rs` to 533 SLOC, over the 500 production cap. Its inline test module moved to a sibling `config_tests.rs`, matching the existing `project_hooks.rs` / `project_hooks_tests.rs` pattern. No test changed in the move.

## Gates — Rust Test Ladder rung 3

```
$ cargo fmt --check
(clean)

$ cargo check -p trusty-mpm --all-targets
EXIT=0

$ cargo clippy -p trusty-mpm --all-targets -- -D warnings
EXIT=0

$ bash scripts/check_line_cap.sh
line-cap: measured 3743 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.

$ bash scripts/check_changelog_fragment.sh
OK   trusty-mpm: changelog.d fragment present and valid

$ bash scripts/check_sld.sh
sld-lint: scanned 56 spec doc(s) + 3115 code file(s); 0 error(s), 0 warning(s)
```

Change-scoped tests:

```
$ cargo test -p trusty-mpm --lib core::session_launch
test result: ok. 228 passed; 0 failed; 0 ignored; 0 measured; 4512 filtered out; finished in 12.52s

$ cargo test -p trusty-mpm --lib core::config
test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 4722 filtered out; finished in 0.01s

$ cargo test -p trusty-mpm --lib -- --exact <the nine new/changed tests>
test core::session_launch::project_hooks::tests::project_managed_hook_additions_omits_prompt_context_when_disabled ... ok
test core::session_launch::project_hooks::tests::project_managed_hook_events_is_a_superset_of_every_variant ... ok
test core::config::tests::config_absent_yields_defaults ... ok
test core::config::tests::config_hooks_prompt_context_off ... ok
test core::config::tests::config_hooks_defaults_to_enabled ... ok
test core::session_launch::project_hooks::tests::write_project_hooks_omits_prompt_context_when_disabled ... ok
test core::session_launch::project_hooks::tests::write_project_hooks_enabled_output_is_unchanged_by_the_toggle ... ok
test core::session_launch::project_hooks::tests::write_project_hooks_strips_stale_prompt_context_when_disabled ... ok
test core::session_launch::project_hooks::tests::write_project_hooks_re_enabling_restores_the_hook ... ok
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 4731 filtered out; finished in 0.00s
```

### Proof the regression test earns its place

Reverting only the strip-domain widening, keeping the rest of the change:

```
$ cargo test -p trusty-mpm --lib write_project_hooks_strips_stale_prompt_context_when_disabled
test ...write_project_hooks_strips_stale_prompt_context_when_disabled ... FAILED

panicked at project_hooks_tests.rs:440:
the stale entry from the earlier enabled launch must be stripped:
  ..."UserPromptSubmit":[{"hooks":[{"command":"trusty-memory prompt-context",...
test result: FAILED. 0 passed; 1 failed
```

### Proof the default path did not move

The strongest available check, run rather than argued: generate the enabled `settings.json` on `origin/main` and on this branch, and diff.

```
$ diff /tmp/main_settings.json /tmp/branch_settings.json
IDENTICAL: default-path output is byte-for-byte unchanged

$ md5 /tmp/main_settings.json /tmp/branch_settings.json
MD5 (/tmp/main_settings.json)   = 29e4045a7d0d969d1ed94d05cc9d9e16
MD5 (/tmp/branch_settings.json) = 29e4045a7d0d969d1ed94d05cc9d9e16
```

Both dumps came from a temporary probe test, removed before commit.

## Pre-existing baseline failures — not caused by this branch

**`cargo test -p trusty-mpm` (full suite) is red on `origin/main`.** Filed as [#5040](https://github.com/bobmatnyc/trusty-tools/issues/5040). The `stale_assets_for_many_*` pair in `daemon::managed_routes::tests` fails only under the full suite, and which of the two fails varies:

```
# origin/main @ 8ab2c147a, no local changes
test ...stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet ... FAILED
test result: FAILED. 4724 passed; 1 failed; 7 ignored

# this branch
test ...stale_assets_for_many_sees_an_agent_change_on_the_very_next_call ... FAILED
test result: FAILED. 4732 passed; 1 failed; 7 ignored
```

This diff touches zero files under `crates/trusty-mpm/src/daemon/` (`git diff --name-only origin/main...HEAD -- crates/trusty-mpm/src/daemon/` is empty), and each test passes in isolation on this branch.

**Local clippy trips a lint in `trusty-common`** at `memory_core/retrieval/embed_repair.rs:139` (`nonminimal_bool`), under both `-p trusty-mpm` and `--workspace`. It reproduces identically on `origin/main` with no local changes, this diff touches zero `trusty-common` files, and CI's Clippy job passes on main commits containing that exact line — so it appears local-only. To still get real clippy evidence for this crate, I patched that one line locally, confirmed `cargo clippy -p trusty-mpm --all-targets -- -D warnings` exits 0, and reverted it. No `trusty-common` change is in this PR.

Closes #5034

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
