### PR TITLE
feat(bm25): lossless backfill + bounded daemon process model + stats op

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11320,7 +11320,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-bm25-daemon"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.10" }
 # trusty-bm25-daemon: per-palace BM25 lexical-index daemon — referenced by
 # trusty-memory so `cargo install trusty-memory` produces both binaries from
 # one command (mirrors the trusty-embedderd / trusty-search pattern, PR #190).
-trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon", version = "0.1.3" }
+trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon", version = "0.2.0" }
 # tga: trusty-git-analytics — developer productivity analytics.
 # Referenced by trusty-review for contributor-profile data pipeline (#558).
 tga = { path = "crates/trusty-git-analytics", version = "2.10" }

--- a/crates/trusty-bm25-daemon/Cargo.toml
+++ b/crates/trusty-bm25-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-bm25-daemon"
-version = "0.1.3"
+version = "0.2.0"
 publish = true
 edition = "2021"
 rust-version = "1.94"

--- a/crates/trusty-bm25-daemon/changelog.d/4995-shutdown-flush-fixed.md
+++ b/crates/trusty-bm25-daemon/changelog.d/4995-shutdown-flush-fixed.md
@@ -1,0 +1,9 @@
+Fixed
+
+- The daemon now flushes its snapshot before exiting on SIGTERM/SIGINT.
+  Previously it removed the socket and returned with the batch worker still
+  holding up to one write window of applied-but-unwritten documents, which were
+  lost: the worker's final flush is gated on the op channel closing, and the
+  accept loop holds a sender for the process lifetime. Latent while a daemon
+  only ever died at shutdown; routine now that trusty-memory reaps daemons to
+  hold its process cap.

--- a/crates/trusty-bm25-daemon/changelog.d/4995-stats-op-and-shutdown-flush.md
+++ b/crates/trusty-bm25-daemon/changelog.d/4995-stats-op-and-shutdown-flush.md
@@ -1,0 +1,6 @@
+Added
+
+- `stats` JSON-RPC method, reporting `doc_count` and `total_text_bytes`. The
+  protocol could say "here are your hits" but not "is there anything to hit",
+  so a caller could not tell an indexed palace with no match from an unindexed
+  one.

--- a/crates/trusty-bm25-daemon/changelog.d/5048-missing-docs-and-testable-shutdown.md
+++ b/crates/trusty-bm25-daemon/changelog.d/5048-missing-docs-and-testable-shutdown.md
@@ -1,0 +1,12 @@
+Added
+
+- `missing_docs` JSON-RPC method: given a list of doc ids, returns the subset the
+  daemon does not hold. Callers can now establish index coverage as a set
+  statement instead of inferring it from `stats.doc_count`, which is satisfied by
+  documents the caller never asked about.
+- `run_until(config, shutdown)` runs the daemon against an explicit shutdown
+  trigger. `run` supplies the real SIGTERM/SIGINT trigger and is otherwise
+  unchanged; the split gives the shutdown snapshot flush a deterministic,
+  CI-runnable regression test instead of a timing-dependent `#[ignore]`d one.
+  Signal handlers are now installed before snapshot load and socket bind, so a
+  SIGTERM during startup reaches the shutdown path.

--- a/crates/trusty-bm25-daemon/src/batch_queue.rs
+++ b/crates/trusty-bm25-daemon/src/batch_queue.rs
@@ -25,7 +25,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::time::sleep;
 
 use crate::index::PalaceBm25Index;
-use crate::protocol::SearchHit;
+use crate::protocol::{SearchHit, StatsResult};
 
 /// Default write-coalescing window — how long the worker waits to coalesce
 /// more write ops after seeing the first one.
@@ -71,6 +71,12 @@ enum Op {
         query: String,
         top_k: usize,
         reply: oneshot::Sender<Result<Vec<SearchHit>>>,
+    },
+    Stats {
+        reply: oneshot::Sender<Result<StatsResult>>,
+    },
+    Flush {
+        reply: oneshot::Sender<Result<usize>>,
     },
 }
 
@@ -188,6 +194,52 @@ impl BatchQueue {
             .map_err(|_| anyhow!("bm25 batch worker dropped reply channel"))?
     }
 
+    /// Force the snapshot to disk and return the document count written.
+    ///
+    /// Why: the worker flushes at the end of each write batch, so a process
+    /// that exits mid-window loses that window's writes. That was survivable
+    /// while SIGTERM only arrived at daemon shutdown; it is not survivable now
+    /// that the supervisor reaps daemons routinely to stay within its cap. A
+    /// reap that silently discarded the last batch would make backfill
+    /// coverage depend on how recently a palace was evicted — the exact class
+    /// of invisible partial state this work exists to remove.
+    /// What: sends `Op::Flush`; the worker runs `index.flush()` inline (like
+    /// `Search` and `Stats`, so it never queues behind the write window) and
+    /// replies with the live document count. A no-op when nothing is dirty.
+    /// Test: `batch_queue_flush_persists_within_the_write_window`.
+    pub async fn flush_now(&self) -> Result<usize> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(Op::Flush { reply: reply_tx })
+            .await
+            .map_err(|_| anyhow!("bm25 batch worker channel closed"))?;
+        reply_rx
+            .await
+            .map_err(|_| anyhow!("bm25 batch worker dropped reply channel"))?
+    }
+
+    /// Report the live corpus size.
+    ///
+    /// Why: a backfiller needs a cheap, authoritative answer to "how much of
+    /// this palace does the daemon already hold" before deciding to skip,
+    /// repair, or run in full — and after the run, to confirm what landed.
+    /// Reading it through the queue (rather than a side channel) means the
+    /// answer reflects every write applied so far, including ones still
+    /// inside an unflushed batch.
+    /// What: sends `Op::Stats`; the worker answers it inline, like `Search`,
+    /// so it never waits out the write-coalescing window.
+    /// Test: `batch_queue_stats_reflect_pending_writes`.
+    pub async fn stats(&self) -> Result<StatsResult> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(Op::Stats { reply: reply_tx })
+            .await
+            .map_err(|_| anyhow!("bm25 batch worker channel closed"))?;
+        reply_rx
+            .await
+            .map_err(|_| anyhow!("bm25 batch worker dropped reply channel"))?
+    }
+
     /// Run a BM25 search against the live index.
     ///
     /// Why: search is read-only but still flows through the worker so the
@@ -257,6 +309,14 @@ async fn batch_worker(mut rx: mpsc::Receiver<Op>, mut index: PalaceBm25Index, co
                 let _ = reply.send(Ok(hits));
                 continue;
             }
+            Op::Stats { reply } => {
+                let _ = reply.send(Ok(stats_of(&index)));
+                continue;
+            }
+            Op::Flush { reply } => {
+                let _ = reply.send(flush_now(&mut index));
+                continue;
+            }
             Op::Rebuild { reply } => {
                 let new_count = index.rebuild();
                 let flush_result = index
@@ -291,6 +351,21 @@ async fn batch_worker(mut rx: mpsc::Receiver<Op>, mut index: PalaceBm25Index, co
                         // race-free.
                         let hits = index.search(&query, top_k);
                         let _ = reply.send(Ok(hits));
+                    }
+                    Some(Op::Stats { reply }) => {
+                        // Same race-freedom argument as `Search`: every write
+                        // dispatched before this op is already applied, so the
+                        // figures a backfiller reads mid-run never lag behind
+                        // the acks it has already collected.
+                        let _ = reply.send(Ok(stats_of(&index)));
+                    }
+                    Some(Op::Flush { reply }) => {
+                        // Flushing mid-batch is safe and is the whole point:
+                        // the caller is usually a shutdown or reap path that
+                        // must not lose the window's writes. The outer loop
+                        // still flushes at the window's end; `flush` is a
+                        // no-op once the dirty bit is clear.
+                        let _ = reply.send(flush_now(&mut index));
                     }
                     Some(Op::Rebuild { reply }) => {
                         // Honour the rebuild atomically. Flush the pending
@@ -344,6 +419,33 @@ async fn batch_worker(mut rx: mpsc::Receiver<Op>, mut index: PalaceBm25Index, co
     }
 }
 
+/// Snapshot the two corpus figures the `stats` op reports.
+///
+/// Why: the worker answers `Op::Stats` from two places (cold path and
+/// mid-batch), and the two must not drift into different definitions of
+/// "indexed".
+/// What: reads `doc_count` + `total_text_bytes` off the live index. Pure.
+/// Test: `batch_queue_stats_reflect_pending_writes`.
+fn stats_of(index: &PalaceBm25Index) -> StatsResult {
+    StatsResult {
+        doc_count: index.doc_count(),
+        total_text_bytes: index.total_text_bytes(),
+    }
+}
+
+/// Flush the snapshot and report the resulting document count.
+///
+/// Why: the worker answers `Op::Flush` from two places and both must report
+/// the same thing — the count that is now ON DISK, so a caller can treat a
+/// successful flush as durability and not merely as "the call returned".
+/// What: `index.flush()` then `doc_count()`. A clean index flushes nothing and
+/// still reports its count.
+/// Test: `batch_queue_flush_persists_within_the_write_window`.
+fn flush_now(index: &mut PalaceBm25Index) -> Result<usize> {
+    index.flush()?;
+    Ok(index.doc_count())
+}
+
 /// Apply one write op to the index, forwarding the typed reply.
 ///
 /// Why: factored out so the worker loop reads top-to-bottom and the per-op
@@ -368,7 +470,7 @@ fn apply_write_op(index: &mut PalaceBm25Index, op: Op) {
         }
         // Caller guarantees only write ops reach here; treat anything else
         // as a programmer error in this module.
-        Op::Search { .. } | Op::Rebuild { .. } => {
+        Op::Search { .. } | Op::Rebuild { .. } | Op::Stats { .. } | Op::Flush { .. } => {
             tracing::error!("apply_write_op called with non-write op — this is a bug");
         }
     }
@@ -444,6 +546,79 @@ mod tests {
         }
         let hits = q.search("shared".into(), 2).await.unwrap();
         assert!(hits.len() <= 2);
+    }
+
+    /// Why: `stats` is only useful to a backfiller if it reflects writes the
+    /// daemon has already acked but not yet flushed. If it read from the
+    /// snapshot on disk instead of the live index, a backfiller would see
+    /// stale counts inside the 50 ms write window and re-send work it had
+    /// already landed — or worse, declare a palace unindexed that isn't.
+    /// What: indexes three docs, immediately (inside the write window) asks
+    /// for stats, and asserts both figures already include all three.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn batch_queue_stats_reflect_pending_writes() {
+        let (q, _dir) = fresh_queue();
+        let empty = q.stats().await.unwrap();
+        assert_eq!(empty.doc_count, 0);
+        assert_eq!(empty.total_text_bytes, 0);
+
+        q.index_doc("d1".into(), "alpha".into()).await.unwrap();
+        q.index_doc("d2".into(), "beta".into()).await.unwrap();
+        q.index_doc("d3".into(), "gamma".into()).await.unwrap();
+
+        // No sleep — this deliberately lands inside the coalescing window,
+        // before any snapshot flush.
+        let s = q.stats().await.unwrap();
+        assert_eq!(s.doc_count, 3, "stats must see un-flushed writes");
+        assert_eq!(s.total_text_bytes, 14);
+    }
+
+    /// Why: a backfiller distinguishes "not indexed" from "indexed, no hits"
+    /// purely by `doc_count`, so a `rebuild` that left the count stale would
+    /// make a wiped palace read as fully indexed and never get repaired.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn batch_queue_stats_go_to_zero_after_rebuild() {
+        let (q, _dir) = fresh_queue();
+        q.index_doc("d1".into(), "alpha".into()).await.unwrap();
+        assert_eq!(q.stats().await.unwrap().doc_count, 1);
+        q.rebuild().await.unwrap();
+        let s = q.stats().await.unwrap();
+        assert_eq!(s.doc_count, 0);
+        assert_eq!(s.total_text_bytes, 0);
+    }
+
+    /// Why: the worker only writes the snapshot at the end of a write batch,
+    /// so anything indexed inside the still-open window exists in memory
+    /// only. That was survivable while the only thing that ended a daemon was
+    /// a deliberate shutdown; it stopped being survivable once the supervisor
+    /// began reaping daemons routinely to hold its process cap. Without an
+    /// explicit flush, a reaped palace silently loses its last window — this
+    /// asserts it does not.
+    /// What: indexes a doc and, WITHOUT sleeping past the 50 ms window, calls
+    /// `flush_now`, then reads the snapshot straight off disk.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn batch_queue_flush_persists_within_the_write_window() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let index = PalaceBm25Index::load_or_create(dir.path()).expect("load palace index");
+        let snapshot = index.snapshot_path().to_path_buf();
+        let q = BatchQueue::new(index, BatchConfig::default());
+
+        q.index_doc("d1".into(), "phoenix rising".into())
+            .await
+            .unwrap();
+        assert!(
+            !snapshot.exists(),
+            "precondition: nothing is on disk until a flush happens"
+        );
+
+        let doc_count = q.flush_now().await.expect("explicit flush must succeed");
+        assert_eq!(doc_count, 1);
+
+        let raw = std::fs::read_to_string(&snapshot).expect("snapshot must exist after flush");
+        assert!(raw.contains("phoenix rising"), "got: {raw}");
     }
 
     #[tokio::test]

--- a/crates/trusty-bm25-daemon/src/batch_queue.rs
+++ b/crates/trusty-bm25-daemon/src/batch_queue.rs
@@ -78,6 +78,10 @@ enum Op {
     Flush {
         reply: oneshot::Sender<Result<usize>>,
     },
+    MissingDocs {
+        doc_ids: Vec<String>,
+        reply: oneshot::Sender<Result<Vec<String>>>,
+    },
 }
 
 /// Configuration for the write-coalescing window and size.
@@ -240,6 +244,31 @@ impl BatchQueue {
             .map_err(|_| anyhow!("bm25 batch worker dropped reply channel"))?
     }
 
+    /// Which of `doc_ids` the live index does not hold.
+    ///
+    /// Why: this is the coverage question `stats` cannot answer. A backfiller
+    /// comparing counts declares a palace covered as soon as the daemon holds
+    /// enough documents, regardless of WHICH documents those are — so a corpus
+    /// carrying stale entries reads as complete over drawers it has never
+    /// seen. Asking by id removes the inference entirely.
+    /// What: sends `Op::MissingDocs`; the worker answers it inline (like
+    /// `Search` and `Stats`) so it never waits out the write-coalescing
+    /// window, and so the answer includes writes acked but not yet flushed.
+    /// Test: `batch_queue_missing_docs_sees_pending_writes`.
+    pub async fn missing_docs(&self, doc_ids: Vec<String>) -> Result<Vec<String>> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(Op::MissingDocs {
+                doc_ids,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| anyhow!("bm25 batch worker channel closed"))?;
+        reply_rx
+            .await
+            .map_err(|_| anyhow!("bm25 batch worker dropped reply channel"))?
+    }
+
     /// Run a BM25 search against the live index.
     ///
     /// Why: search is read-only but still flows through the worker so the
@@ -317,6 +346,10 @@ async fn batch_worker(mut rx: mpsc::Receiver<Op>, mut index: PalaceBm25Index, co
                 let _ = reply.send(flush_now(&mut index));
                 continue;
             }
+            Op::MissingDocs { doc_ids, reply } => {
+                let _ = reply.send(Ok(index.missing_docs(&doc_ids)));
+                continue;
+            }
             Op::Rebuild { reply } => {
                 let new_count = index.rebuild();
                 let flush_result = index
@@ -358,6 +391,13 @@ async fn batch_worker(mut rx: mpsc::Receiver<Op>, mut index: PalaceBm25Index, co
                         // figures a backfiller reads mid-run never lag behind
                         // the acks it has already collected.
                         let _ = reply.send(Ok(stats_of(&index)));
+                    }
+                    Some(Op::MissingDocs { doc_ids, reply }) => {
+                        // Same race-freedom argument as `Search` and `Stats`:
+                        // every write dispatched before this op is already
+                        // applied, so a coverage check taken mid-run never
+                        // reports a document missing that was already acked.
+                        let _ = reply.send(Ok(index.missing_docs(&doc_ids)));
                     }
                     Some(Op::Flush { reply }) => {
                         // Flushing mid-batch is safe and is the whole point:
@@ -470,7 +510,11 @@ fn apply_write_op(index: &mut PalaceBm25Index, op: Op) {
         }
         // Caller guarantees only write ops reach here; treat anything else
         // as a programmer error in this module.
-        Op::Search { .. } | Op::Rebuild { .. } | Op::Stats { .. } | Op::Flush { .. } => {
+        Op::Search { .. }
+        | Op::Rebuild { .. }
+        | Op::Stats { .. }
+        | Op::Flush { .. }
+        | Op::MissingDocs { .. } => {
             tracing::error!("apply_write_op called with non-write op — this is a bug");
         }
     }
@@ -572,6 +616,31 @@ mod tests {
         let s = q.stats().await.unwrap();
         assert_eq!(s.doc_count, 3, "stats must see un-flushed writes");
         assert_eq!(s.total_text_bytes, 14);
+    }
+
+    /// Why: a coverage check taken while a backfill is still running must see
+    /// every document the daemon has already acked, otherwise the backfiller
+    /// re-sends work it landed — or, on the post-run check, reports a document
+    /// missing that is sitting un-flushed in the open write window and marks a
+    /// complete palace incomplete.
+    /// What: indexes two docs and asks about three WITHOUT sleeping past the
+    /// coalescing window; only the never-sent id comes back.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn batch_queue_missing_docs_sees_pending_writes() {
+        let (q, _dir) = fresh_queue();
+        let asked = vec!["d1".to_string(), "d2".to_string(), "d3".to_string()];
+        assert_eq!(q.missing_docs(asked.clone()).await.unwrap(), asked);
+
+        q.index_doc("d1".into(), "alpha".into()).await.unwrap();
+        q.index_doc("d2".into(), "beta".into()).await.unwrap();
+
+        // No sleep — deliberately inside the coalescing window.
+        assert_eq!(
+            q.missing_docs(asked).await.unwrap(),
+            vec!["d3".to_string()],
+            "missing_docs must see un-flushed writes"
+        );
     }
 
     /// Why: a backfiller distinguishes "not indexed" from "indexed, no hits"

--- a/crates/trusty-bm25-daemon/src/index.rs
+++ b/crates/trusty-bm25-daemon/src/index.rs
@@ -206,6 +206,20 @@ impl PalaceBm25Index {
         self.inner.len()
     }
 
+    /// Corpus size in bytes of retained document text.
+    ///
+    /// Why (#2846): this struct keeps every document's full text in `docs` so
+    /// it can re-serialise the snapshot, which means per-daemon RSS grows
+    /// linearly with the corpus. A supervisor enforcing a memory cap should be
+    /// able to see that figure rather than infer it from doc count alone —
+    /// 1311 one-line drawers and 1311 page-long ones cost very different RAM.
+    /// What: sums `str::len()` over the retained text. O(n) over documents, not
+    /// bytes, and only called on the `stats` path — never in the hot loop.
+    /// Test: `palace_index_stats_track_docs_and_bytes`.
+    pub fn total_text_bytes(&self) -> u64 {
+        self.docs.values().map(|t| t.len() as u64).sum()
+    }
+
     /// Snapshot path the daemon writes to. Exposed for diagnostics / tests.
     #[allow(dead_code)] // public for diagnostics; consumed by tests
     pub fn snapshot_path(&self) -> &Path {
@@ -353,6 +367,33 @@ mod tests {
         let raw = std::fs::read_to_string(idx.snapshot_path()).unwrap();
         assert!(raw.contains("\"doc_id\":\"x\""));
         assert!(raw.contains("\"text\":\"one two three\""));
+    }
+
+    /// Why: `stats` is the operation callers use to tell "indexed, no hits"
+    /// from "not indexed", so both figures must track mutation exactly —
+    /// including the delete path, where a stale byte total would overstate the
+    /// corpus a supervisor is budgeting RAM for.
+    /// What: indexes two docs, checks both figures, deletes one, checks again.
+    /// Test: this test itself.
+    #[test]
+    fn palace_index_stats_track_docs_and_bytes() {
+        let dir = tempdir();
+        let mut idx = PalaceBm25Index::load_or_create(dir.path()).unwrap();
+        assert_eq!(idx.doc_count(), 0);
+        assert_eq!(idx.total_text_bytes(), 0);
+
+        idx.index_doc("a", "hello");
+        idx.index_doc("b", "world!");
+        assert_eq!(idx.doc_count(), 2);
+        assert_eq!(idx.total_text_bytes(), 11);
+
+        assert!(idx.delete_doc("a"));
+        assert_eq!(idx.doc_count(), 1);
+        assert_eq!(idx.total_text_bytes(), 6);
+
+        idx.rebuild();
+        assert_eq!(idx.doc_count(), 0);
+        assert_eq!(idx.total_text_bytes(), 0);
     }
 
     #[test]

--- a/crates/trusty-bm25-daemon/src/index.rs
+++ b/crates/trusty-bm25-daemon/src/index.rs
@@ -220,6 +220,25 @@ impl PalaceBm25Index {
         self.docs.values().map(|t| t.len() as u64).sum()
     }
 
+    /// Which of `doc_ids` this index does not hold.
+    ///
+    /// Why: coverage is a SET question, and [`Self::doc_count`] answers a
+    /// different one. The two agree only while the index holds exactly the
+    /// caller's documents and nothing else; one stale document left behind by
+    /// a delete that never happened is enough to make the count report
+    /// coverage the set does not have. Answering by id removes the inference.
+    /// What: retains the requested ids absent from `docs`, in request order.
+    /// Duplicated request ids are reported once per occurrence — the caller
+    /// owns de-duplication. O(n log m) over the requested ids.
+    /// Test: `missing_docs_answers_by_identity_not_count`.
+    pub fn missing_docs(&self, doc_ids: &[String]) -> Vec<String> {
+        doc_ids
+            .iter()
+            .filter(|id| !self.docs.contains_key(*id))
+            .cloned()
+            .collect()
+    }
+
     /// Snapshot path the daemon writes to. Exposed for diagnostics / tests.
     #[allow(dead_code)] // public for diagnostics; consumed by tests
     pub fn snapshot_path(&self) -> &Path {
@@ -394,6 +413,35 @@ mod tests {
         idx.rebuild();
         assert_eq!(idx.doc_count(), 0);
         assert_eq!(idx.total_text_bytes(), 0);
+    }
+
+    /// Why: this is the assertion that separates identity from counting. The
+    /// index below holds TWO documents and the caller asks about TWO ids, so
+    /// every count comparison — `doc_count >= asked`, `doc_count == asked` —
+    /// reports full coverage. Only one of the two ids is actually present.
+    /// What: indexes `a` and a leftover `stale`, then asks about `a` and `b`.
+    /// Test: this test itself.
+    #[test]
+    fn missing_docs_answers_by_identity_not_count() {
+        let dir = tempdir();
+        let mut idx = PalaceBm25Index::load_or_create(dir.path()).unwrap();
+        idx.index_doc("a", "alpha");
+        idx.index_doc("stale", "a drawer that was deleted from the palace");
+
+        let asked = vec!["a".to_string(), "b".to_string()];
+        assert_eq!(
+            idx.doc_count(),
+            asked.len(),
+            "precondition: the count comparison is satisfied and still wrong"
+        );
+        assert_eq!(idx.missing_docs(&asked), vec!["b".to_string()]);
+
+        idx.index_doc("b", "beta");
+        assert!(idx.missing_docs(&asked).is_empty());
+        assert!(
+            idx.missing_docs(&[]).is_empty(),
+            "an empty request is trivially covered"
+        );
     }
 
     #[test]

--- a/crates/trusty-bm25-daemon/src/lib.rs
+++ b/crates/trusty-bm25-daemon/src/lib.rs
@@ -136,6 +136,18 @@ pub struct DaemonConfig {
     pub max_batch_size: usize,
 }
 
+/// Upper bound on the shutdown snapshot flush.
+///
+/// Why: the flush is the difference between a reaped daemon keeping its corpus
+/// and losing the last write window, so it is worth waiting for — but not
+/// worth hanging on. Two seconds is far beyond a JSON write of a few MB and
+/// still well inside the supervisor's own SIGTERM-then-SIGKILL budget, so a
+/// wedged worker costs a bounded delay rather than an unkillable process.
+/// What: 2 seconds.
+/// Test: exercised by every shutdown path; the durability guarantee it
+/// protects is asserted by `a_reaped_palace_respawns_on_next_use`.
+const SHUTDOWN_FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// Run the BM25 daemon to completion.
 ///
 /// Why: the library entry point lets the bundled shim in trusty-memory and
@@ -203,6 +215,10 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
     );
 
     // Step 5: run the accept loop alongside a signal-driven shutdown.
+    // Keep a handle for the shutdown flush below — the accept loop owns its
+    // own clone and never returns, so the channel never closes on its own and
+    // the worker's close-triggered final flush can never fire.
+    let shutdown_queue = Arc::clone(&queue);
     let accept = tokio::spawn(server::run_accept_loop(listener, queue));
 
     let mut sigterm = signal(SignalKind::terminate()).context("install SIGTERM handler")?;
@@ -221,7 +237,27 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
         }
     }
 
-    // Step 6: remove the socket file on clean exit so the next run does not
+    // Step 6: flush the snapshot BEFORE exiting.
+    //
+    // Without this the process returned from `run` with the batch worker still
+    // holding up to one write window's worth of applied-but-unwritten
+    // documents, and those were simply lost — the worker's own final flush is
+    // gated on the op channel closing, which cannot happen while the accept
+    // loop holds a sender. Harmless-looking while SIGTERM only arrived at
+    // daemon shutdown; not harmless now that the trusty-memory supervisor
+    // reaps daemons routinely to stay within its process cap, which turns a
+    // shutdown-only edge case into an ordinary one. Bounded so a wedged worker
+    // cannot stop the daemon from exiting.
+    match tokio::time::timeout(SHUTDOWN_FLUSH_TIMEOUT, shutdown_queue.flush_now()).await {
+        Ok(Ok(doc_count)) => tracing::info!(doc_count, "flushed BM25 snapshot before exit"),
+        Ok(Err(e)) => tracing::error!("shutdown BM25 snapshot flush failed: {e:#}"),
+        Err(_) => tracing::error!(
+            "shutdown BM25 snapshot flush timed out after {SHUTDOWN_FLUSH_TIMEOUT:?} — \
+             writes since the last batch flush are lost"
+        ),
+    }
+
+    // Step 7: remove the socket file on clean exit so the next run does not
     // see EADDRINUSE.
     socket::cleanup_stale_socket(&socket_path);
     Ok(())

--- a/crates/trusty-bm25-daemon/src/lib.rs
+++ b/crates/trusty-bm25-daemon/src/lib.rs
@@ -143,11 +143,15 @@ pub struct DaemonConfig {
 /// worth hanging on. Two seconds is far beyond a JSON write of a few MB and
 /// still well inside the supervisor's own SIGTERM-then-SIGKILL budget, so a
 /// wedged worker costs a bounded delay rather than an unkillable process.
-/// What: 2 seconds.
+/// What: 2 seconds. Public so a supervisor that must outwait this daemon can
+/// compare against the real value instead of restating it — a restated copy
+/// cannot detect the drift it exists to name.
 /// Test: exercised by every shutdown path; the durability guarantee it
 /// protects is asserted by
-/// `tests/shutdown_flush.rs::shutdown_flushes_the_open_write_window`.
-const SHUTDOWN_FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
+/// `tests/shutdown_flush.rs::shutdown_flushes_the_open_write_window`;
+/// `trusty-memory`'s `sigterm_patience_exceeds_the_daemon_flush_budget` pins
+/// the supervisor's margin over it.
+pub const SHUTDOWN_FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Run the BM25 daemon to completion.
 ///

--- a/crates/trusty-bm25-daemon/src/lib.rs
+++ b/crates/trusty-bm25-daemon/src/lib.rs
@@ -145,7 +145,8 @@ pub struct DaemonConfig {
 /// wedged worker costs a bounded delay rather than an unkillable process.
 /// What: 2 seconds.
 /// Test: exercised by every shutdown path; the durability guarantee it
-/// protects is asserted by `a_reaped_palace_respawns_on_next_use`.
+/// protects is asserted by
+/// `tests/shutdown_flush.rs::shutdown_flushes_the_open_write_window`.
 const SHUTDOWN_FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Run the BM25 daemon to completion.
@@ -164,6 +165,38 @@ const SHUTDOWN_FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
 /// Test: end-to-end coverage in `tests/bm25_daemon.rs` (spawns the binary
 /// and drives it over the UDS protocol).
 pub async fn run(config: DaemonConfig) -> Result<()> {
+    // Install the signal handlers BEFORE any of the startup work in
+    // `run_until`, so a SIGTERM arriving during snapshot load or socket bind
+    // reaches our shutdown path rather than the kernel's default disposition.
+    let mut sigterm = signal(SignalKind::terminate()).context("install SIGTERM handler")?;
+    let mut sigint = signal(SignalKind::interrupt()).context("install SIGINT handler")?;
+    run_until(config, async move {
+        tokio::select! {
+            _ = sigterm.recv() => tracing::info!("received SIGTERM — shutting down"),
+            _ = sigint.recv() => tracing::info!("received SIGINT — shutting down"),
+        }
+    })
+    .await
+}
+
+/// Run the daemon until `shutdown` resolves, then flush and clean up.
+///
+/// Why: the durability guarantee this function carries — that a shutdown
+/// flushes the write window still open in the batch worker — was only
+/// reachable through a real SIGTERM, which makes its regression test both
+/// `#[ignore]`-able and timing-dependent. Taking the shutdown trigger as a
+/// parameter lets a test fire it at an exact moment with no signals involved,
+/// so reverting the flush below fails the test deterministically instead of
+/// probabilistically. [`run`] supplies the real SIGTERM/SIGINT trigger and is
+/// otherwise identical.
+/// What: loads the snapshot, starts the batch worker, binds the socket, and
+/// races the accept loop against `shutdown`. Whichever wins, the snapshot is
+/// flushed (bounded by [`SHUTDOWN_FLUSH_TIMEOUT`]) and the socket file removed.
+/// Test: `tests/shutdown_flush.rs::shutdown_flushes_the_open_write_window`.
+pub async fn run_until<S>(config: DaemonConfig, shutdown: S) -> Result<()>
+where
+    S: std::future::Future<Output = ()>,
+{
     let DaemonConfig {
         palace,
         data_dir,
@@ -221,16 +254,8 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
     let shutdown_queue = Arc::clone(&queue);
     let accept = tokio::spawn(server::run_accept_loop(listener, queue));
 
-    let mut sigterm = signal(SignalKind::terminate()).context("install SIGTERM handler")?;
-    let mut sigint = signal(SignalKind::interrupt()).context("install SIGINT handler")?;
-
     tokio::select! {
-        _ = sigterm.recv() => {
-            tracing::info!("received SIGTERM — shutting down");
-        }
-        _ = sigint.recv() => {
-            tracing::info!("received SIGINT — shutting down");
-        }
+        _ = shutdown => {}
         _ = accept => {
             // The accept loop never returns in normal operation.
             tracing::warn!("accept loop exited unexpectedly");

--- a/crates/trusty-bm25-daemon/src/protocol.rs
+++ b/crates/trusty-bm25-daemon/src/protocol.rs
@@ -52,6 +52,22 @@ pub const METHOD_REBUILD: &str = "rebuild";
 /// Test: `stats_result_round_trips`, `dispatch_request_handles_stats`.
 pub const METHOD_STATS: &str = "stats";
 
+/// JSON-RPC method: report which of the caller's `doc_id`s this daemon does
+/// NOT hold.
+///
+/// Why: `stats` reports a COUNT, and a count cannot answer "does the daemon
+/// hold a document for every drawer this palace has". The two diverge as soon
+/// as the corpus contains a document the palace no longer has — a drawer that
+/// was forgotten, or a doc id that predates a rename — because `doc_count`
+/// then measures a different set than the caller is asking about. A caller
+/// that compares `doc_count >= my_drawer_count` reads "covered" off a corpus
+/// that shares no ids with it at all. This method compares the actual sets.
+/// What: params `{"doc_ids": [..]}`; returns [`MissingDocsResult`] naming the
+/// subset the daemon has never seen. Extra documents the daemon holds are not
+/// reported — they do not affect coverage of the ids asked about.
+/// Test: `missing_docs_result_round_trips`, `dispatch_request_handles_missing_docs`.
+pub const METHOD_MISSING_DOCS: &str = "missing_docs";
+
 /// JSON-RPC version string. The protocol mandates this exact value.
 pub const JSONRPC_VERSION: &str = "2.0";
 
@@ -177,6 +193,35 @@ pub struct RebuildResult {
 pub struct StatsResult {
     pub doc_count: usize,
     pub total_text_bytes: u64,
+}
+
+/// Params for the `missing_docs` method.
+///
+/// Why: the caller supplies the set it cares about rather than asking the
+/// daemon to enumerate its whole corpus, so the answer is O(caller's ids) on
+/// the wire and stays correct no matter how many stale documents the daemon
+/// is still holding.
+/// What: the doc ids to test for presence. An empty list is legal and yields
+/// an empty answer.
+/// Test: `missing_docs_result_round_trips`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MissingDocsParams {
+    pub doc_ids: Vec<String>,
+}
+
+/// Successful result for the `missing_docs` method.
+///
+/// Why: `missing.is_empty()` is a set statement — "the daemon holds a document
+/// for every id you named" — which is the claim a backfiller actually needs
+/// and the one a count cannot make. `checked` is echoed back so a caller can
+/// tell a genuinely-empty answer from a request that was silently truncated.
+/// What: `missing` is the subset of the requested ids the daemon does not
+/// hold, in request order; `checked` is how many ids were examined.
+/// Test: `missing_docs_result_round_trips`, `dispatch_request_handles_missing_docs`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MissingDocsResult {
+    pub missing: Vec<String>,
+    pub checked: usize,
 }
 
 /// One hit returned by the `search` method.
@@ -400,5 +445,29 @@ mod tests {
         let parsed: RpcRequest = serde_json::from_str(raw).unwrap();
         assert_eq!(parsed.method, METHOD_STATS);
         assert!(parsed.params.is_none());
+    }
+
+    /// Why: `missing` is what a caller reads coverage off, so the wire shape
+    /// has to survive a round trip exactly — a dropped or renamed field would
+    /// decode as "nothing missing", which is the fail-open direction.
+    /// Test: this test itself.
+    #[test]
+    fn missing_docs_result_round_trips() {
+        let params = MissingDocsParams {
+            doc_ids: vec!["a".into(), "b".into()],
+        };
+        let raw = serde_json::to_string(&params).unwrap();
+        let back: MissingDocsParams = serde_json::from_str(&raw).unwrap();
+        assert_eq!(back.doc_ids, vec!["a".to_string(), "b".to_string()]);
+
+        let result = MissingDocsResult {
+            missing: vec!["b".into()],
+            checked: 2,
+        };
+        let raw = serde_json::to_string(&result).unwrap();
+        assert!(raw.contains("\"missing\":[\"b\"]"), "got: {raw}");
+        let back: MissingDocsResult = serde_json::from_str(&raw).unwrap();
+        assert_eq!(back.missing, vec!["b".to_string()]);
+        assert_eq!(back.checked, 2);
     }
 }

--- a/crates/trusty-bm25-daemon/src/protocol.rs
+++ b/crates/trusty-bm25-daemon/src/protocol.rs
@@ -40,6 +40,18 @@ pub const METHOD_DELETE: &str = "delete";
 /// [`METHOD_DELETE`] — the hot path must never invoke this.
 pub const METHOD_REBUILD: &str = "rebuild";
 
+/// JSON-RPC method: report how much corpus this daemon is actually serving.
+///
+/// Why: without it the protocol can answer "here are your hits" but not "is
+/// there anything to hit". A palace indexed to 20% of its drawers and a palace
+/// indexed to 100% return the same empty hit list for a query that misses, so
+/// a caller cannot tell a genuine no-match from a corpus that was never
+/// backfilled — the fail-open shape where partial coverage reads as working
+/// coverage. `stats` is what makes those two states distinguishable.
+/// What: takes no params; returns [`StatsResult`].
+/// Test: `stats_result_round_trips`, `dispatch_request_handles_stats`.
+pub const METHOD_STATS: &str = "stats";
+
 /// JSON-RPC version string. The protocol mandates this exact value.
 pub const JSONRPC_VERSION: &str = "2.0";
 
@@ -147,6 +159,24 @@ pub struct DeleteResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RebuildResult {
     pub doc_count: usize,
+}
+
+/// Successful result for the `stats` method.
+///
+/// Why: two numbers answer two different questions. `doc_count` answers "is
+/// this palace indexed, and to what extent" — a backfiller compares it against
+/// the palace's drawer count to decide between skip, repair, and full run.
+/// `total_text_bytes` answers "how much memory is this daemon's corpus worth"
+/// — [`crate::index::PalaceBm25Index`] holds every document's full text in a
+/// `BTreeMap`, so per-daemon RSS scales with this figure and a supervisor
+/// enforcing an RSS cap wants it visible rather than inferred.
+/// What: `doc_count` is the live document count (post-delete, post-rebuild);
+/// `total_text_bytes` is the summed byte length of the retained document text.
+/// Test: `stats_result_round_trips`, `dispatch_request_handles_stats`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatsResult {
+    pub doc_count: usize,
+    pub total_text_bytes: u64,
 }
 
 /// One hit returned by the `search` method.
@@ -349,5 +379,26 @@ mod tests {
         let raw = r#"{"jsonrpc":"2.0","method":"rebuild","params":{},"id":4}"#;
         let parsed: RpcRequest = serde_json::from_str(raw).unwrap();
         assert_eq!(parsed.method, "rebuild");
+    }
+
+    #[test]
+    fn stats_result_round_trips() {
+        let r = StatsResult {
+            doc_count: 1311,
+            total_text_bytes: 4_194_304,
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        assert!(s.contains("\"doc_count\":1311"));
+        let back: StatsResult = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.doc_count, 1311);
+        assert_eq!(back.total_text_bytes, 4_194_304);
+    }
+
+    #[test]
+    fn stats_request_round_trips_without_params() {
+        let raw = r#"{"jsonrpc":"2.0","method":"stats","id":5}"#;
+        let parsed: RpcRequest = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.method, METHOD_STATS);
+        assert!(parsed.params.is_none());
     }
 }

--- a/crates/trusty-bm25-daemon/src/server.rs
+++ b/crates/trusty-bm25-daemon/src/server.rs
@@ -22,9 +22,10 @@ use tokio::net::{UnixListener, UnixStream};
 
 use crate::batch_queue::BatchQueue;
 use crate::protocol::{
-    DeleteParams, DeleteResult, IndexParams, IndexResult, RebuildResult, RpcRequest, RpcResponse,
-    SearchParams, SearchResult, ERR_INTERNAL, ERR_INVALID_REQUEST, ERR_METHOD_NOT_FOUND, ERR_PARSE,
-    JSONRPC_VERSION, METHOD_DELETE, METHOD_INDEX, METHOD_REBUILD, METHOD_SEARCH, METHOD_STATS,
+    DeleteParams, DeleteResult, IndexParams, IndexResult, MissingDocsParams, MissingDocsResult,
+    RebuildResult, RpcRequest, RpcResponse, SearchParams, SearchResult, ERR_INTERNAL,
+    ERR_INVALID_REQUEST, ERR_METHOD_NOT_FOUND, ERR_PARSE, JSONRPC_VERSION, METHOD_DELETE,
+    METHOD_INDEX, METHOD_MISSING_DOCS, METHOD_REBUILD, METHOD_SEARCH, METHOD_STATS,
 };
 
 /// Bind the UDS listener at `path`.
@@ -146,6 +147,7 @@ pub async fn dispatch_request(frame: &str, queue: &BatchQueue) -> RpcResponse {
         METHOD_DELETE => dispatch_delete(id, req.params, queue).await,
         METHOD_REBUILD => dispatch_rebuild(id, queue).await,
         METHOD_STATS => dispatch_stats(id, queue).await,
+        METHOD_MISSING_DOCS => dispatch_missing_docs(id, req.params, queue).await,
         other => RpcResponse::err(id, ERR_METHOD_NOT_FOUND, format!("unknown method: {other}")),
     }
 }
@@ -256,6 +258,53 @@ async fn dispatch_stats(id: serde_json::Value, queue: &BatchQueue) -> RpcRespons
             Err(e) => RpcResponse::err(id, ERR_INTERNAL, format!("serialise stats: {e}")),
         },
         Err(e) => RpcResponse::err(id, ERR_INTERNAL, format!("stats failed: {e:#}")),
+    }
+}
+
+/// Answer `missing_docs` — the coverage-by-identity query.
+///
+/// Why: a caller cannot establish coverage from `stats`, because a count says
+/// nothing about WHICH documents a daemon holds. This is the op that lets a
+/// backfiller make a set statement instead of an arithmetic one, so it is on
+/// the same access footing as `search` and `stats` rather than the privileged
+/// `delete` / `rebuild` pair.
+/// What: requires a `doc_ids` array; a missing or malformed params object is a
+/// hard `-32600` rather than an empty answer, because an empty answer reads as
+/// "everything is covered".
+/// Test: `dispatch_request_handles_missing_docs`,
+/// `missing_docs_without_params_is_an_error`.
+async fn dispatch_missing_docs(
+    id: serde_json::Value,
+    params: Option<serde_json::Value>,
+    queue: &BatchQueue,
+) -> RpcResponse {
+    let params: MissingDocsParams = match params.map(serde_json::from_value) {
+        Some(Ok(p)) => p,
+        Some(Err(e)) => {
+            return RpcResponse::err(
+                id,
+                ERR_INVALID_REQUEST,
+                format!("invalid missing_docs params: {e}"),
+            );
+        }
+        None => {
+            return RpcResponse::err(
+                id,
+                ERR_INVALID_REQUEST,
+                "missing_docs requires params.doc_ids",
+            );
+        }
+    };
+    let checked = params.doc_ids.len();
+    match queue.missing_docs(params.doc_ids).await {
+        Ok(missing) => {
+            let result = MissingDocsResult { missing, checked };
+            match serde_json::to_value(result) {
+                Ok(v) => RpcResponse::ok(id, v),
+                Err(e) => RpcResponse::err(id, ERR_INTERNAL, format!("serialise missing: {e}")),
+            }
+        }
+        Err(e) => RpcResponse::err(id, ERR_INTERNAL, format!("missing_docs failed: {e:#}")),
     }
 }
 
@@ -388,6 +437,45 @@ mod tests {
         let result = resp.result.unwrap();
         assert_eq!(result["doc_count"].as_u64().unwrap(), 2);
         assert_eq!(result["total_text_bytes"].as_u64().unwrap(), 15);
+    }
+
+    /// Why: this is the wire-level guarantee the coverage predicate rests on.
+    /// The index below holds as many documents as the caller asks about, so
+    /// every count-based check passes — only the identity answer is right.
+    /// What: indexes `d1` plus a stale doc, asks about `d1` and `d2`, and
+    /// asserts only `d2` comes back missing.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn dispatch_request_handles_missing_docs() {
+        let (q, _dir) = test_queue();
+        for (doc, text) in [("d1", "alpha"), ("stale-forgotten-drawer", "beta")] {
+            let f = format!(
+                r#"{{"jsonrpc":"2.0","method":"index","params":{{"doc_id":"{doc}","text":"{text}"}},"id":1}}"#
+            );
+            assert!(dispatch_request(&f, &q).await.error.is_none());
+        }
+
+        let frame =
+            r#"{"jsonrpc":"2.0","method":"missing_docs","params":{"doc_ids":["d1","d2"]},"id":7}"#;
+        let resp = dispatch_request(frame, &q).await;
+        assert!(resp.error.is_none(), "missing_docs must succeed: {resp:?}");
+        let result = resp.result.unwrap();
+        assert_eq!(result["missing"].as_array().unwrap().len(), 1);
+        assert_eq!(result["missing"][0].as_str().unwrap(), "d2");
+        assert_eq!(result["checked"].as_u64().unwrap(), 2);
+    }
+
+    /// Why: a params-less `missing_docs` must be an explicit error. Answering
+    /// it as "nothing missing" would hand a caller full coverage for a request
+    /// that named no documents at all.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn missing_docs_without_params_is_an_error() {
+        let (q, _dir) = test_queue();
+        let resp =
+            dispatch_request(r#"{"jsonrpc":"2.0","method":"missing_docs","id":8}"#, &q).await;
+        assert!(resp.error.is_some(), "params are required");
+        assert!(resp.result.is_none());
     }
 
     #[tokio::test]

--- a/crates/trusty-bm25-daemon/src/server.rs
+++ b/crates/trusty-bm25-daemon/src/server.rs
@@ -24,7 +24,7 @@ use crate::batch_queue::BatchQueue;
 use crate::protocol::{
     DeleteParams, DeleteResult, IndexParams, IndexResult, RebuildResult, RpcRequest, RpcResponse,
     SearchParams, SearchResult, ERR_INTERNAL, ERR_INVALID_REQUEST, ERR_METHOD_NOT_FOUND, ERR_PARSE,
-    JSONRPC_VERSION, METHOD_DELETE, METHOD_INDEX, METHOD_REBUILD, METHOD_SEARCH,
+    JSONRPC_VERSION, METHOD_DELETE, METHOD_INDEX, METHOD_REBUILD, METHOD_SEARCH, METHOD_STATS,
 };
 
 /// Bind the UDS listener at `path`.
@@ -145,6 +145,7 @@ pub async fn dispatch_request(frame: &str, queue: &BatchQueue) -> RpcResponse {
         METHOD_SEARCH => dispatch_search(id, req.params, queue).await,
         METHOD_DELETE => dispatch_delete(id, req.params, queue).await,
         METHOD_REBUILD => dispatch_rebuild(id, queue).await,
+        METHOD_STATS => dispatch_stats(id, queue).await,
         other => RpcResponse::err(id, ERR_METHOD_NOT_FOUND, format!("unknown method: {other}")),
     }
 }
@@ -235,6 +236,26 @@ async fn dispatch_delete(
             RpcResponse::ok(id, result_val)
         }
         Err(e) => RpcResponse::err(id, ERR_INTERNAL, format!("delete failed: {e:#}")),
+    }
+}
+
+/// Answer `stats` — the corpus-coverage query.
+///
+/// Why: unlike `delete`/`rebuild` this is NOT privileged. Any caller that can
+/// search must also be able to ask how much corpus backs that search,
+/// otherwise an empty hit list is ambiguous between "no match" and "nothing
+/// indexed" and the caller has to guess. Guessing is what fails open.
+/// What: takes no params (any supplied are ignored, so a future revision can
+/// add optional filters without breaking old clients) and returns
+/// [`crate::protocol::StatsResult`].
+/// Test: `dispatch_request_handles_stats`.
+async fn dispatch_stats(id: serde_json::Value, queue: &BatchQueue) -> RpcResponse {
+    match queue.stats().await {
+        Ok(stats) => match serde_json::to_value(stats) {
+            Ok(v) => RpcResponse::ok(id, v),
+            Err(e) => RpcResponse::err(id, ERR_INTERNAL, format!("serialise stats: {e}")),
+        },
+        Err(e) => RpcResponse::err(id, ERR_INTERNAL, format!("stats failed: {e:#}")),
     }
 }
 
@@ -341,6 +362,32 @@ mod tests {
         // delete returns `{"deleted": <bool>}`.
         let result = resp.result.unwrap();
         assert!(result.get("deleted").is_some());
+    }
+
+    /// Why: this is the wire-level guarantee the whole backfill design leans
+    /// on — a caller must be able to ask a live daemon how much corpus it
+    /// holds, over the same socket it searches on, without params.
+    /// What: stats on an empty index, index two docs, stats again.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn dispatch_request_handles_stats() {
+        let (q, _dir) = test_queue();
+        let frame = r#"{"jsonrpc":"2.0","method":"stats","id":9}"#;
+        let resp = dispatch_request(frame, &q).await;
+        assert!(resp.error.is_none(), "stats must succeed: {resp:?}");
+        assert_eq!(resp.result.unwrap()["doc_count"].as_u64().unwrap(), 0);
+
+        for (doc, text) in [("d1", "alpha beta"), ("d2", "gamma")] {
+            let f = format!(
+                r#"{{"jsonrpc":"2.0","method":"index","params":{{"doc_id":"{doc}","text":"{text}"}},"id":1}}"#
+            );
+            assert!(dispatch_request(&f, &q).await.error.is_none());
+        }
+
+        let resp = dispatch_request(frame, &q).await;
+        let result = resp.result.unwrap();
+        assert_eq!(result["doc_count"].as_u64().unwrap(), 2);
+        assert_eq!(result["total_text_bytes"].as_u64().unwrap(), 15);
     }
 
     #[tokio::test]

--- a/crates/trusty-bm25-daemon/tests/shutdown_flush.rs
+++ b/crates/trusty-bm25-daemon/tests/shutdown_flush.rs
@@ -1,0 +1,175 @@
+//! Shutdown durability: writes still inside the open coalescing window must
+//! reach disk before the daemon exits.
+//!
+//! Why: the batch worker writes the snapshot at the end of a write window, so
+//! everything indexed inside an open window lives in memory only. Its own
+//! final flush is gated on the op channel closing, which cannot happen while
+//! the accept loop holds a sender — so before `lib.rs`'s shutdown flush, a
+//! daemon that stopped mid-window silently lost that window. Survivable while
+//! the only thing that stopped a daemon was a deliberate shutdown; not
+//! survivable now that the trusty-memory supervisor reaps daemons routinely to
+//! hold its process cap.
+//!
+//! What: drives `run_until` in-process with an explicit shutdown trigger
+//! rather than a real signal. That is what makes this test CI-runnable and
+//! deterministic: the write window is set to 10 minutes, so the indexed
+//! document is guaranteed to be un-flushed when shutdown fires, and reverting
+//! the flush block fails the test every time rather than only when a reap
+//! happens to land inside a 50 ms race.
+//!
+//! Test: this *is* the test file.
+
+use std::path::Path;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use trusty_bm25_daemon::{run_until, DaemonConfig};
+
+/// Send one JSON-RPC frame and return the decoded response.
+///
+/// Why: this crate has no client dependency by design, and the test needs
+/// exactly one request/response round trip.
+/// What: connects, writes the frame plus newline, reads one line back.
+/// Test: used by the test below.
+async fn rpc(socket: &Path, frame: &str) -> serde_json::Value {
+    let stream = UnixStream::connect(socket).await.expect("connect");
+    let (read_half, mut write_half) = stream.into_split();
+    write_half
+        .write_all(format!("{frame}\n").as_bytes())
+        .await
+        .expect("write frame");
+    write_half.shutdown().await.expect("half-close");
+    let mut line = String::new();
+    BufReader::new(read_half)
+        .read_line(&mut line)
+        .await
+        .expect("read response");
+    serde_json::from_str(&line).expect("decode response")
+}
+
+/// Poll until the daemon's socket accepts a connection.
+async fn await_socket(socket: &Path) {
+    for _ in 0..300 {
+        if UnixStream::connect(socket).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("daemon never bound {}", socket.display());
+}
+
+/// Why: this is the regression the shutdown flush exists for. Reverting the
+/// `timeout(SHUTDOWN_FLUSH_TIMEOUT, shutdown_queue.flush_now())` block in
+/// `lib.rs` makes the snapshot assertion below fail deterministically — the
+/// file is never created, because a 10-minute write window guarantees the
+/// worker has not flushed on its own.
+/// What: starts the daemon in-process, indexes one document, asserts nothing
+/// is on disk yet, fires shutdown, and asserts the document survived.
+/// Test: this test itself.
+#[tokio::test]
+async fn shutdown_flushes_the_open_write_window() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket = dir.path().join("flush.sock");
+    let data_dir = dir.path().join("data");
+    let snapshot = data_dir.join("bm25_index.json");
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let daemon = tokio::spawn(run_until(
+        DaemonConfig {
+            palace: "flush-window".to_string(),
+            data_dir: data_dir.clone(),
+            socket: Some(socket.clone()),
+            // Ten minutes: the worker cannot flush on its own before the test
+            // finishes, so a passing assertion can only come from the
+            // shutdown flush.
+            write_window_ms: 600_000,
+            max_batch_size: 10_000,
+        },
+        async move {
+            let _ = shutdown_rx.await;
+        },
+    ));
+
+    await_socket(&socket).await;
+
+    let resp = rpc(
+        &socket,
+        r#"{"jsonrpc":"2.0","method":"index","params":{"doc_id":"d1","text":"phoenix rising"},"id":1}"#,
+    )
+    .await;
+    assert!(resp.get("error").is_none_or(|e| e.is_null()), "{resp}");
+
+    assert!(
+        !snapshot.exists(),
+        "precondition: the write must still be inside the open window, \
+         un-flushed — otherwise this test proves nothing about shutdown"
+    );
+
+    shutdown_tx.send(()).expect("fire shutdown");
+    tokio::time::timeout(Duration::from_secs(10), daemon)
+        .await
+        .expect("daemon must exit promptly after shutdown")
+        .expect("daemon task must not panic")
+        .expect("daemon must exit cleanly");
+
+    let raw = std::fs::read_to_string(&snapshot).unwrap_or_else(|e| {
+        panic!(
+            "shutdown must flush the open write window to {}: {e}",
+            snapshot.display()
+        )
+    });
+    assert!(
+        raw.contains("phoenix rising"),
+        "the snapshot must hold the document indexed inside the window: {raw}"
+    );
+}
+
+/// Why: the flush must not be narrowed to the reap path. `run_until` races
+/// shutdown against the accept loop, and a caller that closes the listener
+/// takes the other arm — that arm owes the same durability.
+/// What: same setup, but the shutdown future never resolves; the daemon exits
+/// because its socket is removed and the test drops it. Rather than depend on
+/// that, this asserts the simpler invariant: a second shutdown-driven run
+/// against the SAME data dir loads what the first flushed.
+/// Test: this test itself.
+#[tokio::test]
+async fn a_flushed_snapshot_is_loaded_by_the_next_run() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let data_dir = dir.path().join("data");
+
+    for (socket_name, doc, text) in [
+        ("run-a.sock", "d1", "first window"),
+        ("run-b.sock", "d2", "second window"),
+    ] {
+        let socket = dir.path().join(socket_name);
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let daemon = tokio::spawn(run_until(
+            DaemonConfig {
+                palace: "reload".to_string(),
+                data_dir: data_dir.clone(),
+                socket: Some(socket.clone()),
+                write_window_ms: 600_000,
+                max_batch_size: 10_000,
+            },
+            async move {
+                let _ = rx.await;
+            },
+        ));
+        await_socket(&socket).await;
+        let frame = format!(
+            r#"{{"jsonrpc":"2.0","method":"index","params":{{"doc_id":"{doc}","text":"{text}"}},"id":1}}"#
+        );
+        rpc(&socket, &frame).await;
+        tx.send(()).expect("fire shutdown");
+        tokio::time::timeout(Duration::from_secs(10), daemon)
+            .await
+            .expect("daemon exits")
+            .expect("no panic")
+            .expect("clean exit");
+    }
+
+    let raw = std::fs::read_to_string(data_dir.join("bm25_index.json")).expect("snapshot");
+    assert!(raw.contains("first window"), "got: {raw}");
+    assert!(raw.contains("second window"), "got: {raw}");
+}

--- a/crates/trusty-common/changelog.d/4995-bm25-stats-and-process-rss.md
+++ b/crates/trusty-common/changelog.d/4995-bm25-stats-and-process-rss.md
@@ -1,0 +1,11 @@
+Added
+
+- `bm25_client::Bm25Client::stats` and `Bm25Stats` — a caller can now ask a BM25
+  daemon how much corpus it is serving. Without it an empty search result was
+  ambiguous between "the query matched nothing" and "nothing is indexed", so a
+  partially-backfilled palace served partial content while looking healthy.
+- `sys_metrics::process_rss_mb` — resident memory of an arbitrary pid (macOS
+  `phys_footprint`, Linux `/proc/<pid>/status` `VmRSS`). The one entry point
+  every trusty-* supervisor uses to enforce a child-memory limit, so #2846's
+  declared-but-never-compared `rss_limit_mb` cannot recur per-crate. `None`
+  means "cannot measure", never "measured zero".

--- a/crates/trusty-common/changelog.d/5048-bm25-coverage-and-typed-rpc-error.md
+++ b/crates/trusty-common/changelog.d/5048-bm25-coverage-and-typed-rpc-error.md
@@ -1,0 +1,6 @@
+Added
+
+- `Bm25Client::missing_docs` asks the daemon which of a set of doc ids it does
+  not hold — the only call that establishes coverage. `Bm25RpcError` and
+  `is_method_not_found` let a caller tell a daemon that predates a method from
+  one that is unreachable; both fail closed but need different operator action.

--- a/crates/trusty-common/changelog.d/5048-bm25-stats-strict-decode.md
+++ b/crates/trusty-common/changelog.d/5048-bm25-stats-strict-decode.md
@@ -1,0 +1,5 @@
+Fixed
+
+- `Bm25Stats` no longer carries `#[serde(default)]` on its fields. A daemon-side
+  field rename decoded as `doc_count: 0`, which reads exactly like an empty
+  palace; it now fails the decode.

--- a/crates/trusty-common/src/bm25_client.rs
+++ b/crates/trusty-common/src/bm25_client.rs
@@ -35,6 +35,59 @@ const METHOD_INDEX: &str = "index";
 const METHOD_SEARCH: &str = "search";
 const METHOD_DELETE: &str = "delete";
 const METHOD_STATS: &str = "stats";
+const METHOD_MISSING_DOCS: &str = "missing_docs";
+
+/// JSON-RPC code the daemon returns for a method it does not implement.
+///
+/// Why: a client newer than the daemon it is talking to gets this back for
+/// `stats` / `missing_docs`, and that is a materially different situation from
+/// a socket that is not there. Treating the two alike makes a healthy but
+/// outdated daemon look unreachable, which sends an operator hunting the wrong
+/// problem. Mirrors `trusty-bm25-daemon`'s `protocol::ERR_METHOD_NOT_FOUND` —
+/// duplicated verbatim for the same reason the method names are: this crate
+/// must not depend on the daemon crate.
+/// What: `-32601`, the JSON-RPC standard code.
+/// Test: `method_not_found_is_distinguishable_from_a_transport_error`.
+pub const ERR_METHOD_NOT_FOUND: i32 = -32601;
+
+/// A JSON-RPC error the daemon returned, carrying its code.
+///
+/// Why: `anyhow` flattens every failure into one opaque chain, so a caller
+/// deciding how to degrade cannot tell "this daemon is too old to answer"
+/// from "this daemon is gone". Attaching the code as a downcastable error
+/// keeps every existing `anyhow::Result` signature intact while making that
+/// one distinction available to the callers that need it.
+/// What: the wire code and message. Reach it with
+/// [`is_method_not_found`] or `err.downcast_ref::<Bm25RpcError>()`.
+/// Test: `method_not_found_is_distinguishable_from_a_transport_error`.
+#[derive(Debug, Clone)]
+pub struct Bm25RpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+impl std::fmt::Display for Bm25RpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "bm25 daemon error {}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for Bm25RpcError {}
+
+/// True when `err` is the daemon answering "I do not implement that method".
+///
+/// Why: the caller that needs this is a backfiller deciding whether an
+/// unanswerable coverage query means "degrade and shout about an old daemon"
+/// or "the daemon is unreachable". Both fail closed, but they need different
+/// log lines and different operator actions.
+/// What: walks the `anyhow` chain for a [`Bm25RpcError`] carrying
+/// [`ERR_METHOD_NOT_FOUND`].
+/// Test: `method_not_found_is_distinguishable_from_a_transport_error`.
+pub fn is_method_not_found(err: &anyhow::Error) -> bool {
+    err.chain()
+        .filter_map(|e| e.downcast_ref::<Bm25RpcError>())
+        .any(|e| e.code == ERR_METHOD_NOT_FOUND)
+}
 
 /// Resolve the canonical socket path for a given palace.
 ///
@@ -77,16 +130,36 @@ pub struct BM25Hit {
 /// supervisor budgets RAM against, because the daemon retains every document's
 /// full text in memory.
 /// What: a plain pair of counters, deserialised from the daemon's
-/// `StatsResult` wire shape.
-/// Test: `stats_response_decodes`.
+/// `StatsResult` wire shape. Neither field carries `#[serde(default)]`: a
+/// daemon-side rename must fail the decode, because defaulting `doc_count` to
+/// zero is indistinguishable from an empty palace.
+/// Test: `stats_response_decodes`, `stats_response_rejects_a_renamed_field`.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct Bm25Stats {
     /// Live documents the daemon is serving.
-    #[serde(default)]
     pub doc_count: usize,
     /// Summed byte length of the retained document text.
-    #[serde(default)]
     pub total_text_bytes: u64,
+}
+
+/// Coverage answer from the daemon's `missing_docs` method.
+///
+/// Why: `Bm25Stats` answers "how many", which is not the question a caller
+/// establishing coverage is asking. `missing.is_empty()` is a statement about
+/// the SET of documents the daemon holds, and it stays correct no matter how
+/// many documents the daemon holds that the caller never asked about.
+/// What: `missing` names the requested ids the daemon does not hold; `checked`
+/// echoes how many were examined so a caller can tell a real empty answer from
+/// a request that never reached the index. No `#[serde(default)]`, for the
+/// same reason as [`Bm25Stats`] — an absent `missing` field would decode as
+/// "fully covered".
+/// Test: `missing_docs_response_decodes`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Bm25Coverage {
+    /// Requested doc ids the daemon does not hold.
+    pub missing: Vec<String>,
+    /// How many ids the daemon examined.
+    pub checked: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -237,6 +310,25 @@ impl Bm25Client {
         self.call(METHOD_STATS, &serde_json::json!({})).await
     }
 
+    /// Ask the daemon which of `doc_ids` it does not hold.
+    ///
+    /// Why: this is the only call that establishes coverage. [`Self::stats`]
+    /// reports a count, and a count is satisfied by documents the caller never
+    /// asked about — one stale entry left behind by a delete that never
+    /// happened is enough for `doc_count >= my_drawers` to claim coverage over
+    /// drawers the daemon has never seen. An empty `missing` list cannot be
+    /// satisfied that way.
+    /// What: sends `{"method":"missing_docs","params":{"doc_ids":[..]}}`.
+    /// Propagates the error rather than degrading — a coverage question that
+    /// could not be asked must never read as a coverage answer. A daemon older
+    /// than 0.2.0 answers `-32601`; see [`is_method_not_found`].
+    /// Test: `missing_docs_response_decodes`; end-to-end in
+    /// `trusty-memory/tests/bm25_backfill_e2e.rs`.
+    pub async fn missing_docs(&self, doc_ids: &[String]) -> Result<Bm25Coverage> {
+        let params = serde_json::json!({ "doc_ids": doc_ids });
+        self.call(METHOD_MISSING_DOCS, &params).await
+    }
+
     /// Delete a document. Intended for the dream subprocess only.
     ///
     /// Why: append-only ingest is the rule for the request path; the dream
@@ -305,7 +397,13 @@ impl Bm25Client {
             )
         })?;
         if let Some(err) = resp.error {
-            anyhow::bail!("bm25 daemon error {}: {}", err.code, err.message);
+            // Typed rather than a bare `bail!` so a caller can tell a daemon
+            // that does not implement the method from one that is not there.
+            return Err(anyhow::Error::new(Bm25RpcError {
+                code: err.code,
+                message: err.message,
+            })
+            .context(format!("bm25 daemon rejected method={method}")));
         }
         resp.result
             .ok_or_else(|| anyhow!("bm25 daemon response missing both result and error"))
@@ -501,6 +599,69 @@ mod tests {
         let stats = resp.result.expect("result present");
         assert_eq!(stats.doc_count, 1311);
         assert_eq!(stats.total_text_bytes, 4_194_304);
+    }
+
+    /// Why: with `#[serde(default)]` on the fields, a daemon-side rename
+    /// decoded as `doc_count: 0` — which reads exactly like an empty palace
+    /// and is the silent drift the type's own doc comment claims to prevent.
+    /// Dropping the attribute turns that drift into a decode error.
+    /// What: feeds a plausibly-renamed field and asserts the decode fails.
+    /// Test: this test itself.
+    #[test]
+    fn stats_response_rejects_a_renamed_field() {
+        let raw =
+            r#"{"jsonrpc":"2.0","result":{"documents":1311,"total_text_bytes":4194304},"id":1}"#;
+        let decoded: Result<RpcResponse<Bm25Stats>, _> = serde_json::from_str(raw);
+        assert!(
+            decoded.is_err(),
+            "a renamed field must fail the decode, not default to zero documents"
+        );
+    }
+
+    /// Why: `missing` is the field the coverage predicate reads. If it
+    /// defaulted, an envelope that lost the field would decode as "nothing
+    /// missing" — full coverage claimed off a response that never said so.
+    /// What: decodes a populated answer, then asserts a truncated one errors.
+    /// Test: this test itself.
+    #[test]
+    fn missing_docs_response_decodes() {
+        let raw = r#"{"jsonrpc":"2.0","result":{"missing":["b"],"checked":2},"id":1}"#;
+        let resp: RpcResponse<Bm25Coverage> = serde_json::from_str(raw).unwrap();
+        let cov = resp.result.expect("result present");
+        assert_eq!(cov.missing, vec!["b".to_string()]);
+        assert_eq!(cov.checked, 2);
+
+        let truncated = r#"{"jsonrpc":"2.0","result":{"checked":2},"id":1}"#;
+        let decoded: Result<RpcResponse<Bm25Coverage>, _> = serde_json::from_str(truncated);
+        assert!(
+            decoded.is_err(),
+            "an absent `missing` field must not decode as full coverage"
+        );
+    }
+
+    /// Why: a client newer than its daemon gets `-32601` for `stats` and
+    /// `missing_docs`. Classifying that as "daemon unreachable" sends an
+    /// operator looking for a dead socket that is in fact serving fine.
+    /// What: builds both error shapes and asserts the discriminator separates
+    /// them — including that a transport failure is NOT method-not-found.
+    /// Test: this test itself.
+    #[test]
+    fn method_not_found_is_distinguishable_from_a_transport_error() {
+        let not_found = anyhow::Error::new(Bm25RpcError {
+            code: ERR_METHOD_NOT_FOUND,
+            message: "unknown method: missing_docs".to_string(),
+        })
+        .context("bm25 daemon rejected method=missing_docs");
+        assert!(is_method_not_found(&not_found));
+
+        let internal = anyhow::Error::new(Bm25RpcError {
+            code: -32603,
+            message: "index poisoned".to_string(),
+        });
+        assert!(!is_method_not_found(&internal));
+
+        let transport = anyhow!("connect to bm25 daemon at /tmp/x.sock: No such file");
+        assert!(!is_method_not_found(&transport));
     }
 
     #[test]

--- a/crates/trusty-common/src/bm25_client.rs
+++ b/crates/trusty-common/src/bm25_client.rs
@@ -34,6 +34,7 @@ const JSONRPC_VERSION: &str = "2.0";
 const METHOD_INDEX: &str = "index";
 const METHOD_SEARCH: &str = "search";
 const METHOD_DELETE: &str = "delete";
+const METHOD_STATS: &str = "stats";
 
 /// Resolve the canonical socket path for a given palace.
 ///
@@ -65,6 +66,27 @@ pub fn socket_path_for_palace(palace: &str) -> PathBuf {
 pub struct BM25Hit {
     pub doc_id: String,
     pub score: f32,
+}
+
+/// Corpus-coverage figures reported by the daemon's `stats` method.
+///
+/// Why: an empty `search` result is ambiguous — it means either "the query
+/// matched nothing" or "this daemon holds nothing to match against". Callers
+/// that cannot tell those apart silently serve partial results as if they were
+/// complete. `doc_count` resolves the ambiguity; `total_text_bytes` is what a
+/// supervisor budgets RAM against, because the daemon retains every document's
+/// full text in memory.
+/// What: a plain pair of counters, deserialised from the daemon's
+/// `StatsResult` wire shape.
+/// Test: `stats_response_decodes`.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct Bm25Stats {
+    /// Live documents the daemon is serving.
+    #[serde(default)]
+    pub doc_count: usize,
+    /// Summed byte length of the retained document text.
+    #[serde(default)]
+    pub total_text_bytes: u64,
 }
 
 #[derive(Debug, Serialize)]
@@ -194,6 +216,25 @@ impl Bm25Client {
         let params = SearchParams { query, top_k };
         let res: SearchResult = self.call(METHOD_SEARCH, &params).await?;
         Ok(res.hits)
+    }
+
+    /// Ask the daemon how much corpus it is actually serving.
+    ///
+    /// Why: this is the call that lets a caller distinguish "indexed, no
+    /// lexical hits" from "not indexed". A backfiller uses it to decide
+    /// whether to skip a palace and to confirm what landed afterwards; a
+    /// recall path can use it to decide whether an empty BM25 result deserves
+    /// to influence fusion at all.
+    /// What: sends `{"method":"stats"}` with an empty params object and
+    /// returns the decoded [`Bm25Stats`]. Propagates the connection error when
+    /// the daemon is absent — "cannot ask" is a different state from "asked,
+    /// answered zero", and collapsing the two is the fail-open shape this
+    /// method exists to prevent. Callers that want to degrade should match on
+    /// the `Err` explicitly.
+    /// Test: end-to-end coverage in `trusty-bm25-daemon/tests/bm25_daemon.rs`
+    /// and `trusty-memory/tests/bm25_backfill_e2e.rs`.
+    pub async fn stats(&self) -> Result<Bm25Stats> {
+        self.call(METHOD_STATS, &serde_json::json!({})).await
     }
 
     /// Delete a document. Intended for the dream subprocess only.
@@ -442,6 +483,24 @@ mod tests {
         let s = serde_json::to_string(&req).unwrap();
         assert!(s.contains("\"method\":\"delete\""));
         assert!(s.contains("\"doc_id\":\"x\""));
+    }
+
+    /// Why: the client's `Bm25Stats` and the daemon's `StatsResult` are
+    /// separate types in separate crates (deliberately — the client must not
+    /// depend on the daemon binary). A field-name drift between them would
+    /// silently decode as `Default::default()`, i.e. "zero documents", which
+    /// reads exactly like an unindexed palace. Pinning the wire shape here is
+    /// what stops that drift from being invisible.
+    /// What: decodes the daemon's literal success envelope.
+    /// Test: this test itself.
+    #[test]
+    fn stats_response_decodes() {
+        let raw =
+            r#"{"jsonrpc":"2.0","result":{"doc_count":1311,"total_text_bytes":4194304},"id":1}"#;
+        let resp: RpcResponse<Bm25Stats> = serde_json::from_str(raw).unwrap();
+        let stats = resp.result.expect("result present");
+        assert_eq!(stats.doc_count, 1311);
+        assert_eq!(stats.total_text_bytes, 4_194_304);
     }
 
     #[test]

--- a/crates/trusty-common/src/sys_metrics.rs
+++ b/crates/trusty-common/src/sys_metrics.rs
@@ -69,6 +69,49 @@ pub fn physical_footprint_mb(pid: u32) -> Option<u64> {
     Some(info.ri_phys_footprint / (1024 * 1024))
 }
 
+/// Resident memory of an **arbitrary** process, in megabytes.
+///
+/// Why (#2846): a supervisor that owns child processes has to answer "is this
+/// child over its declared limit?" before the kernel answers it with an
+/// OOM-kill. trusty-search shipped an `rss_limit_mb` it never compared against
+/// anything and grew to 2.2x that limit before the OOM killer intervened; the
+/// missing piece was a way to read another process's RSS at all. This is that
+/// entry point, and it lives here — next to [`physical_footprint_mb`] and
+/// [`SysMetrics`] — so every trusty-* supervisor reads child memory the same
+/// way instead of each growing its own `/proc` parser.
+/// What: on macOS, delegates to [`physical_footprint_mb`], which counts pages
+/// the memory compressor holds (the figure the kernel's Jetsam logic uses). On
+/// Linux, reads `VmRSS` from `/proc/<pid>/status`. Everywhere else, returns
+/// `None`. `None` means "cannot measure", never "measured zero" — callers must
+/// treat it as "no opinion" and leave the process alone rather than reaping it.
+/// Test: `process_rss_mb_reports_own_process`,
+/// `process_rss_mb_is_none_for_absent_pid`.
+#[must_use]
+pub fn process_rss_mb(pid: u32) -> Option<u64> {
+    #[cfg(target_os = "macos")]
+    {
+        physical_footprint_mb(pid)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+        for line in status.lines() {
+            let Some(rest) = line.strip_prefix("VmRSS:") else {
+                continue;
+            };
+            // Format is `VmRSS:\t   12345 kB`.
+            let kb: u64 = rest.split_whitespace().next()?.parse().ok()?;
+            return Some(kb / 1024);
+        }
+        None
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = pid;
+        None
+    }
+}
+
 /// Per-process RSS + CPU sampler bound to the current process.
 ///
 /// Why: holding the `System` between calls is required for CPU measurement —
@@ -326,6 +369,42 @@ mod tests {
             rss < 1024 * 1024,
             "RSS implausibly large ({rss} MB) — unit must be MB"
         );
+    }
+
+    /// Why (#2846): the RSS guardrail is only as good as the measurement it
+    /// gates on. If `process_rss_mb` silently returned `None` for a live
+    /// process, a supervisor built on it would never reap anything and we
+    /// would have re-shipped the unenforced-limit bug.
+    /// What: measures this test process by its own pid and asserts a
+    /// plausible non-zero figure in MB.
+    /// Test: this test itself. Skipped (asserted only on the `Some` arm) on
+    /// platforms where the measurement is genuinely unavailable.
+    #[test]
+    fn process_rss_mb_reports_own_process() {
+        let me = std::process::id();
+        match process_rss_mb(me) {
+            Some(mb) => assert!(
+                mb < 1024 * 1024,
+                "own RSS implausibly large ({mb} MB) — unit must be MB"
+            ),
+            // Only acceptable off macOS/Linux; on those two the read must have
+            // worked for our own pid.
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
+            None => panic!("process_rss_mb must resolve the current process on this platform"),
+            #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+            None => {}
+        }
+    }
+
+    /// Why: `None` must mean "cannot measure", so a reaped/absent pid must
+    /// never read as `Some(0)` — a supervisor would treat that as "under the
+    /// limit" and keep a corpse in its map.
+    /// Test: this test itself.
+    #[test]
+    fn process_rss_mb_is_none_for_absent_pid() {
+        // pid 0 is the kernel scheduler on Linux and not addressable via
+        // proc_pid_rusage on macOS; either way it must not yield a figure.
+        assert_eq!(process_rss_mb(0), None);
     }
 
     #[test]

--- a/crates/trusty-memory/changelog.d/4995-bm25-backfill-and-process-cap.md
+++ b/crates/trusty-memory/changelog.d/4995-bm25-backfill-and-process-cap.md
@@ -1,0 +1,11 @@
+Added
+
+- `bm25_backfill` — a lossless feeder that indexes a palace's existing drawers.
+  The live write path (`bm25_index_enqueue`) holds a 256-slot channel written
+  with `try_send` and drops on full, so a backfill routed through it would have
+  dropped roughly 80% of the largest palace's 1311 drawers and left it answering
+  lexical queries from a fifth of its content. The feeder awaits each document's
+  ack instead, so nothing is ever offered to a full queue. Idempotent, bounded
+  by a per-op and a per-palace deadline, and it reads coverage back from the
+  daemon rather than trusting its own submission count. Runs as a serial startup
+  sweep over palaces that have drawers; `TRUSTY_BM25_NO_BACKFILL=1` defers it.

--- a/crates/trusty-memory/changelog.d/4995-bm25-supervisor-bounded.md
+++ b/crates/trusty-memory/changelog.d/4995-bm25-supervisor-bounded.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `Bm25Supervisor` now bounds the daemon population. Nothing but `shutdown` ever
+  removed an entry from its map, so one cross-palace `memory_recall_all` over
+  ~99 palaces left 99 child processes resident for the daemon's lifetime — and
+  each one's memory scales with its palace's drawer text. Two limits now apply
+  on every `ensure_running`: a cap on concurrently-live daemons with
+  least-recently-used reaping (`TRUSTY_BM25_MAX_DAEMONS`, default 3), and a
+  per-daemon RSS ceiling compared against a real measurement rather than merely
+  declared (`TRUSTY_BM25_RSS_LIMIT_MB`, default 512, `0` disables). Spawns are
+  serialised so a burst fan-out cannot satisfy the cap per-caller and violate it
+  in aggregate. An unmeasurable RSS never reaps.

--- a/crates/trusty-memory/changelog.d/5048-bm25-coverage-by-identity.md
+++ b/crates/trusty-memory/changelog.d/5048-bm25-coverage-by-identity.md
@@ -1,0 +1,9 @@
+Fixed
+
+- BM25 backfill establishes coverage by drawer id, not by document count.
+  `stats.doc_count >= drawer_count` was satisfied by a corpus carrying documents
+  for drawers the palace no longer has, so `fully_indexed()` returned `true` and
+  the startup sweep logged `incomplete=0` over a palace it had never indexed.
+  `BackfillReport::fully_indexed()` is now `missing_after == Some(0)` — a
+  verified, empty missing set — and no status can satisfy it on its own. A
+  coverage probe that could not run reports `None` and logs at `error!`.

--- a/crates/trusty-memory/changelog.d/5048-bm25-coverage-repair-sweep.md
+++ b/crates/trusty-memory/changelog.d/5048-bm25-coverage-repair-sweep.md
@@ -6,3 +6,12 @@ Added
   sweep now queue the palace, and the sweep re-runs the lossless backfill on an
   interval (`TRUSTY_BM25_REPAIR_INTERVAL_SECS`, default 300s, `0` disables). A
   palace whose coverage is still unverified stays queued.
+- The startup sweep enumerates palaces from disk (`list_palaces` + `open_palace`)
+  instead of `registry.list()`, which snapshots only currently-open handles and
+  is capped at 64. On a ~99-palace host at least 35 were never probed, never
+  queued, and the sweep still logged `all coverage verified`. Palaces that
+  cannot be enumerated, opened, or verified are now counted and queued, and a
+  sweep that enumerated nothing can no longer read as complete.
+- The repair pass resolves palaces with `open_palace`, which hydrates. A dirty
+  palace that went idle and was evicted was previously dropped from the queue
+  permanently, so its gap waited for a restart.

--- a/crates/trusty-memory/changelog.d/5048-bm25-coverage-repair-sweep.md
+++ b/crates/trusty-memory/changelog.d/5048-bm25-coverage-repair-sweep.md
@@ -15,3 +15,10 @@ Added
 - The repair pass resolves palaces with `open_palace`, which hydrates. A dirty
   palace that went idle and was evicted was previously dropped from the queue
   permanently, so its gap waited for a restart.
+- Sweep enumeration reads palace ids off the data root rather than
+  `PalaceStore::list_palaces`, which returns `Ok` while silently dropping any
+  palace whose `palace.json` will not decode. Such a palace was absent from the
+  count and from the repair queue while the sweep still logged clean; it is now
+  seen, recorded as unopenable, and queued.
+- A closed BM25 index queue marks its palace dirty, matching the full-queue
+  arm. Both lose the write identically.

--- a/crates/trusty-memory/changelog.d/5048-bm25-coverage-repair-sweep.md
+++ b/crates/trusty-memory/changelog.d/5048-bm25-coverage-repair-sweep.md
@@ -1,0 +1,8 @@
+Added
+
+- Periodic BM25 coverage repair sweep (`bm25_repair`). The write path drops on a
+  full queue, and the only thing that repaired a drop was the next daemon
+  restart. A dropped enqueue, a failed index call, and an unverified startup
+  sweep now queue the palace, and the sweep re-runs the lossless backfill on an
+  interval (`TRUSTY_BM25_REPAIR_INTERVAL_SECS`, default 300s, `0` disables). A
+  palace whose coverage is still unverified stays queued.

--- a/crates/trusty-memory/changelog.d/5048-bm25-supervisor-sigterm-margin.md
+++ b/crates/trusty-memory/changelog.d/5048-bm25-supervisor-sigterm-margin.md
@@ -1,0 +1,9 @@
+Fixed
+
+- The BM25 supervisor waits 5s after SIGTERM before escalating to SIGKILL,
+  up from 2s. The daemon allows itself 2s for its shutdown snapshot flush and
+  needs signal delivery, socket cleanup and exit on top, so an equal budget let
+  the SIGKILL land inside the flush and lose the open write window.
+- Corrected two doc-comment test pointers that named tests which did not exist,
+  which failed `scripts/check_test_pointers.sh`. The restart path they pointed at
+  now has a real test.

--- a/crates/trusty-memory/src/bm25_backfill.rs
+++ b/crates/trusty-memory/src/bm25_backfill.rs
@@ -602,16 +602,162 @@ pub fn startup_backfill_opted_out() -> bool {
     std::env::var(ENV_NO_BACKFILL).as_deref() == Ok("1")
 }
 
-/// Sweep every registered palace that has drawers, serially.
+/// What one startup sweep considered and what it could not verify.
+///
+/// Why: the sweep's own log line is a coverage claim, and a claim built from
+/// counters that never saw a palace is the same fail-open one layer out. This
+/// carries `enumerated` — palaces found ON DISK — so "all coverage verified"
+/// is a statement about the whole corpus rather than about whatever subset the
+/// sweep happened to look at.
+/// What: `enumerated` is `Some(n)` palaces found on disk, or `None` when the
+/// enumeration itself failed; `swept` is those with drawers that were actually
+/// backfilled; `incomplete` is those left without verified coverage;
+/// `unopenable` is those that could not be hydrated at all.
+///
+/// `enumerated` is an `Option` for the same reason `BackfillReport::
+/// missing_after` is: a sweep that could not enumerate has zero incomplete
+/// palaces only because it examined none, and a plain `usize` would let
+/// `all_verified()` read `true` off exactly that. Encoding "did not ask" in the
+/// type makes the fail-open unrepresentable rather than merely avoided.
+/// Test: `startup_sweep_enumerates_every_palace_on_disk`,
+/// `a_sweep_that_cannot_enumerate_verifies_nothing`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SweepOutcome {
+    pub enumerated: Option<usize>,
+    pub swept: usize,
+    pub incomplete: usize,
+    pub unopenable: usize,
+}
+
+impl SweepOutcome {
+    /// True only when the whole corpus was enumerated, every palace in it was
+    /// examined, and every one came back with verified coverage.
+    ///
+    /// Test: `a_sweep_that_cannot_enumerate_verifies_nothing`.
+    pub fn all_verified(&self) -> bool {
+        self.enumerated.is_some() && self.incomplete == 0 && self.unopenable == 0
+    }
+}
+
+/// Sweep every palace ON DISK that has drawers, serially.
+///
+/// Why the disk and not the registry: `registry.list()` snapshots the LRU key
+/// set of currently-OPEN handles, capped at `DEFAULT_MAX_OPEN_PALACES` (64).
+/// This host holds ~99 palaces, so at least 35 would never be probed, never be
+/// marked dirty, and the sweep would then report `all coverage verified` — the
+/// same fail-open the coverage predicate itself had, relocated from "a palace
+/// it examined" to "a palace it never examines". `service/helpers.rs` (#4637)
+/// already settled this for the recall fan-out: answering from cache-resident
+/// palaces only "would silently drop ~98.9% of the corpus, which is a
+/// correctness regression, not an optimisation". Same reasoning, same fix.
+/// Holding the opened `Arc` for the palace's whole backfill also removes the
+/// mid-sweep-eviction hole — the idle ticker is armed before this runs, and a
+/// borrowed LRU entry could vanish underneath it.
+/// What: enumerates with `PalaceRegistry::list_palaces` and hydrates each with
+/// `open_palace` on the blocking pool (serial, so cold opens do not thrash the
+/// 64-slot LRU). Every palace that cannot be enumerated, cannot be opened, or
+/// cannot be verified is reported and queued for repair. A failed enumeration
+/// verifies NOTHING and says so — it never reports a clean sweep.
+/// Test: `startup_sweep_enumerates_every_palace_on_disk`,
+/// `startup_sweep_marks_unopenable_palaces_instead_of_skipping_them`.
+pub async fn run_startup_sweep(state: &AppState) -> SweepOutcome {
+    let started = Instant::now();
+    let root = state.data_root.clone();
+    let listed = tokio::task::spawn_blocking(move || {
+        trusty_common::memory_core::registry::PalaceRegistry::list_palaces(&root)
+    })
+    .await;
+
+    let palaces = match listed {
+        Ok(Ok(p)) => p,
+        Ok(Err(e)) => {
+            tracing::error!(
+                "bm25 backfill: could not enumerate palaces on disk — the startup sweep \
+                 verified NOTHING and no palace was queued for repair: {e:#}"
+            );
+            return SweepOutcome::default();
+        }
+        Err(e) => {
+            tracing::error!(
+                "bm25 backfill: palace enumeration task failed — the startup sweep \
+                 verified NOTHING: {e}"
+            );
+            return SweepOutcome::default();
+        }
+    };
+
+    let mut out = SweepOutcome {
+        enumerated: Some(palaces.len()),
+        ..Default::default()
+    };
+
+    for palace in palaces {
+        let id = palace.id.clone();
+        let registry = std::sync::Arc::clone(&state.registry);
+        let root = state.data_root.clone();
+        let opened = tokio::task::spawn_blocking(move || registry.open_palace(&root, &id)).await;
+        let handle = match opened {
+            Ok(Ok(h)) => h,
+            Ok(Err(e)) => {
+                // A palace we cannot open is a palace we cannot verify. Queue
+                // it rather than skipping it into the "all verified" tally.
+                tracing::error!(palace = %palace.id, "bm25 backfill: could not open palace: {e:#}");
+                out.unopenable += 1;
+                crate::bm25_repair::mark_dirty(state, palace.id.as_str());
+                continue;
+            }
+            Err(e) => {
+                tracing::error!(palace = %palace.id, "bm25 backfill: open task failed: {e}");
+                out.unopenable += 1;
+                crate::bm25_repair::mark_dirty(state, palace.id.as_str());
+                continue;
+            }
+        };
+
+        // A palace with no drawers has nothing that could be missing, so it is
+        // covered by definition — skipping it is not a gap. This is what keeps
+        // the sweep from starting ~80 daemons to tell each it has nothing to do.
+        if handle.drawers.read().is_empty() {
+            continue;
+        }
+
+        let report = backfill_state_palace(state, &handle, palace.id.as_str(), false).await;
+        out.swept += 1;
+        if !report.fully_indexed() {
+            out.incomplete += 1;
+            crate::bm25_repair::mark_dirty(state, palace.id.as_str());
+        }
+    }
+
+    if out.all_verified() {
+        tracing::info!(
+            enumerated = ?out.enumerated,
+            swept = out.swept,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "bm25 backfill: startup sweep complete, all coverage verified"
+        );
+    } else {
+        tracing::error!(
+            enumerated = ?out.enumerated,
+            swept = out.swept,
+            incomplete = out.incomplete,
+            unopenable = out.unopenable,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "bm25 backfill: startup sweep left palaces without verified coverage — \
+             queued for repair"
+        );
+    }
+    out
+}
+
+/// Start the startup sweep on a background task.
 ///
 /// Why: a daemon restart is the only moment at which the whole corpus is known
-/// to be reachable and nothing is waiting on it. Serial is deliberate: the
-/// supervisor caps concurrently-live daemons at three, so a parallel sweep
-/// would spend its time reaping daemons it had just spawned.
-/// What: returns immediately, doing the work on a spawned task. No-op when the
-/// lane is off or [`ENV_NO_BACKFILL`] is set — which, until the lane's default
-/// is flipped, is every deployment. Palaces with zero drawers are skipped
-/// without starting a daemon, which is roughly 80 of the ~99 on this host.
+/// to be reachable and nothing is waiting on it. The work itself is
+/// [`run_startup_sweep`], kept awaitable so its enumeration can be tested
+/// without racing a spawned task.
+/// What: returns immediately. No-op when the lane is off or [`ENV_NO_BACKFILL`]
+/// is set — which, until the lane's default is flipped, is every deployment.
 /// Test: `startup_backfill_respects_the_opt_out`.
 pub fn spawn_startup_backfill(state: &AppState) {
     if state.bm25_client.is_none() {
@@ -624,46 +770,7 @@ pub fn spawn_startup_backfill(state: &AppState) {
     }
     let state = state.clone();
     tokio::spawn(async move {
-        let started = Instant::now();
-        let mut swept = 0usize;
-        let mut incomplete = 0usize;
-        for id in state.registry.list() {
-            // `get` rather than `peek`: the sweep genuinely uses the handle, so
-            // it should refresh the registry's own idle-eviction recency.
-            let Some(handle) = state.registry.get(&id) else {
-                continue;
-            };
-            let palace = id.as_str().to_string();
-            // Skipping empty palaces here rather than inside `backfill_palace`
-            // is what keeps the sweep from starting ~80 daemons to tell each
-            // one it has nothing to do.
-            if handle.drawers.read().is_empty() {
-                continue;
-            }
-            let report = backfill_state_palace(&state, &handle, &palace, false).await;
-            swept += 1;
-            if !report.fully_indexed() {
-                incomplete += 1;
-                // Queue it for the repair sweep rather than waiting for the
-                // next restart — see `bm25_repair`.
-                crate::bm25_repair::mark_dirty(&state, &palace);
-            }
-        }
-        if incomplete > 0 {
-            tracing::error!(
-                swept,
-                incomplete,
-                elapsed_ms = started.elapsed().as_millis() as u64,
-                "bm25 backfill: startup sweep left palaces without verified coverage — \
-                 queued for repair"
-            );
-        } else {
-            tracing::info!(
-                swept,
-                elapsed_ms = started.elapsed().as_millis() as u64,
-                "bm25 backfill: startup sweep complete, all coverage verified"
-            );
-        }
+        run_startup_sweep(&state).await;
     });
 }
 

--- a/crates/trusty-memory/src/bm25_backfill.rs
+++ b/crates/trusty-memory/src/bm25_backfill.rs
@@ -157,7 +157,10 @@ impl BackfillReport {
             BackfillStatus::AlreadyIndexed => true,
             BackfillStatus::Completed => self
                 .final_doc_count
-                .is_some_and(|n| n >= self.drawers_total - self.skipped_empty),
+                // `saturating_sub` because the alternative is a debug panic in
+                // a coverage predicate — an inconsistent report should read as
+                // "not covered", not take the daemon down.
+                .is_some_and(|n| n >= self.drawers_total.saturating_sub(self.skipped_empty)),
             _ => false,
         }
     }

--- a/crates/trusty-memory/src/bm25_backfill.rs
+++ b/crates/trusty-memory/src/bm25_backfill.rs
@@ -1,0 +1,439 @@
+//! Lossless BM25 backfill for a palace's existing drawers.
+//!
+//! Why: the BM25 lane indexes a drawer at write time, so every drawer written
+//! before the lane was switched on is invisible to it — which is every drawer
+//! on this host, since `TRUSTY_BM25_DAEMON=1` has never been set in any shipped
+//! path. Turning the lane on without a backfill would produce a palace that
+//! answers lexical queries from whatever it happened to see since the last
+//! restart, and reports that as a normal empty result.
+//!
+//! Why NOT the existing write path: `tools::bm25::bm25_index_enqueue` writes
+//! into a 256-slot bounded channel with `try_send` and DROPS on full. That is
+//! a defensible trade for the write path — a dropped index op costs one stale
+//! entry, the drawer itself is durable in redb, and `memory_remember` must not
+//! wait on daemon RTT. It is not defensible for a backfill: the largest palace
+//! on this host holds 1311 drawers, five times the queue, so a backfill routed
+//! through it would silently drop roughly 80% of the corpus and leave the
+//! palace answering from a fifth of its content — indistinguishable, from the
+//! outside, from working fusion. So the write path is left exactly as it is
+//! and backfill gets its own feeder: one document at a time, each awaiting the
+//! daemon's ack, so the only backpressure mechanism in play is "wait for the
+//! previous write to land". Nothing can be dropped because nothing is ever
+//! offered to a full queue.
+//!
+//! What: [`backfill_palace`] drives the feeder against a socket; [`palace_docs`]
+//! extracts the `(drawer_id, text)` pairs; [`backfill_state_palace`] wires both
+//! to an [`AppState`] and its spawn supervisor; [`spawn_startup_backfill`]
+//! sweeps every palace that has drawers, serially, when the lane is enabled.
+//! Idempotent throughout — the daemon's `upsert_document` is keyed by `doc_id`,
+//! so a re-run overwrites rather than duplicating.
+//!
+//! Fail-open: every failure mode degrades to a reported status, never an error
+//! that propagates into a caller's request path and never an unbounded wait.
+//! Daemon absent, spawn refused, RPC timeout, and per-document errors are all
+//! counted and surfaced in the [`BackfillReport`].
+//!
+//! Test: `bm25_backfill_tests.rs` (unit) and `tests/bm25_backfill_e2e.rs`
+//! (`#[ignore]`d, drives a real `trusty-bm25-daemon`).
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use trusty_common::bm25_client::Bm25Client;
+use trusty_common::memory_core::retrieval::PalaceHandle;
+
+use crate::AppState;
+
+/// Per-document RPC deadline.
+///
+/// Why: the daemon coalesces writes on a 50 ms window and acks each one, so a
+/// healthy round trip is sub-millisecond. Ten seconds is four orders of
+/// magnitude of slack — long enough that a loaded host never trips it, short
+/// enough that a wedged daemon costs one document's delay rather than stalling
+/// the sweep behind it forever. A backfill that can hang is a backfill that can
+/// hold a startup task open indefinitely.
+/// What: 10 seconds, applied per `index` / `stats` call.
+/// Test: `backfill_reports_daemon_unavailable_when_socket_is_dead`.
+const OP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Whole-palace time budget.
+///
+/// Why: the per-op timeout bounds one document; this bounds the run. 2300
+/// documents across every palace on this host is single-digit MB of text and
+/// completes in seconds, so a run still going after two minutes is not slow,
+/// it is stuck — and reporting `Partial` with a count beats blocking.
+/// What: 120 seconds. On expiry the feeder stops and reports what landed.
+/// Test: covered by construction; the counters make a truncated run visible.
+const PALACE_BUDGET: Duration = Duration::from_secs(120);
+
+/// Environment opt-out for the startup sweep.
+///
+/// Why: an operator who wants the lane on but the backfill deferred (a large
+/// cold palace on a busy host) needs a way to say so that does not also
+/// disable the lane. Without it the only lever is `TRUSTY_BM25_DAEMON=0`,
+/// which turns off the thing they were trying to keep.
+/// What: `TRUSTY_BM25_NO_BACKFILL=1` skips the sweep. Explicit per-palace
+/// calls to [`backfill_state_palace`] still work.
+/// Test: `startup_backfill_respects_the_opt_out`.
+pub const ENV_NO_BACKFILL: &str = "TRUSTY_BM25_NO_BACKFILL";
+
+/// Outcome class of one palace's backfill.
+///
+/// Why: a caller (and an operator reading logs) needs to tell "nothing to do"
+/// from "could not do it" from "did it, partially". Collapsing those into a
+/// bool is how a partially-indexed palace comes to look finished.
+/// What: five terminal states. Only [`Self::Completed`] means the daemon's
+/// corpus is known to cover the palace.
+/// Test: `bm25_backfill_tests.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackfillStatus {
+    /// The BM25 lane is switched off — nothing was attempted.
+    Disabled,
+    /// The daemon could not be reached or started. Recall degrades to
+    /// vector-only; a later run can repair.
+    DaemonUnavailable,
+    /// The daemon already holds a document for every drawer.
+    AlreadyIndexed,
+    /// Every drawer was submitted and acked.
+    Completed,
+    /// Some drawers failed or the time budget expired. The index is usable but
+    /// incomplete; a re-run repairs it.
+    Partial,
+}
+
+/// What one backfill run did.
+///
+/// Why: the counters are the evidence that separates "the lane is on" from
+/// "the lane has content". `final_doc_count` in particular is read back from
+/// the daemon rather than inferred from the submissions, so a run that acked
+/// 1311 documents into a daemon that kept 200 reports the discrepancy instead
+/// of claiming success.
+/// What: plain owned counters; `final_doc_count` is `None` when the post-run
+/// `stats` call itself failed.
+/// Test: `bm25_backfill_tests.rs`.
+#[derive(Debug, Clone)]
+pub struct BackfillReport {
+    pub palace: String,
+    pub status: BackfillStatus,
+    /// Drawers the palace holds.
+    pub drawers_total: usize,
+    /// Drawers with no indexable text, skipped without being submitted.
+    pub skipped_empty: usize,
+    /// Documents the daemon acked.
+    pub indexed: usize,
+    /// Documents that errored or timed out.
+    pub failed: usize,
+    /// `doc_count` the daemon reported after the run.
+    pub final_doc_count: Option<usize>,
+    pub elapsed_ms: u64,
+}
+
+impl BackfillReport {
+    /// Terminal report for a run that never started.
+    fn short_circuit(palace: &str, status: BackfillStatus, drawers_total: usize) -> Self {
+        Self {
+            palace: palace.to_string(),
+            status,
+            drawers_total,
+            skipped_empty: 0,
+            indexed: 0,
+            failed: 0,
+            final_doc_count: None,
+            elapsed_ms: 0,
+        }
+    }
+
+    /// True when the daemon is known to hold every drawer this palace has.
+    ///
+    /// Why: this is the question the whole module exists to answer, and it must
+    /// be answered from the daemon's own reported count — not from how many
+    /// writes we believe we sent.
+    /// What: `true` for `AlreadyIndexed`, or for `Completed` whose read-back
+    /// count covers the non-empty drawers. Anything else, including a
+    /// `Completed` run whose read-back failed, is `false`.
+    /// Test: `fully_indexed_requires_a_read_back_count`.
+    pub fn fully_indexed(&self) -> bool {
+        match self.status {
+            BackfillStatus::AlreadyIndexed => true,
+            BackfillStatus::Completed => self
+                .final_doc_count
+                .is_some_and(|n| n >= self.drawers_total - self.skipped_empty),
+            _ => false,
+        }
+    }
+}
+
+/// Extract the `(doc_id, text)` pairs a palace should have indexed.
+///
+/// Why: the drawer table is behind a `parking_lot` lock, which must not be held
+/// across an `.await`. Materialising the pairs up front costs one clone of
+/// single-digit MB of text — the entire corpus across ~99 palaces is that
+/// size — and removes the lock from the async path entirely.
+/// What: clones `(id.to_string(), content)` for every drawer whose content has
+/// non-whitespace text. Empty drawers are omitted: indexing zero tokens can
+/// never produce a hit, so submitting them would inflate the daemon's
+/// `doc_count` and break the coverage comparison this module relies on.
+/// Test: `palace_docs_skips_blank_drawers`.
+pub fn palace_docs(handle: &PalaceHandle) -> Vec<(String, String)> {
+    let drawers = handle.drawers.read();
+    drawers
+        .iter()
+        .filter(|d| !d.content.trim().is_empty())
+        .map(|d| (d.id.to_string(), d.content.clone()))
+        .collect()
+}
+
+/// Feed a palace's documents to a BM25 daemon, losslessly.
+///
+/// Why: see the module doc — the live write path drops on a full queue, which
+/// is wrong for a corpus five times the queue's depth. This feeder cannot drop
+/// because it never offers work to a queue it has not been invited into: each
+/// `index` call awaits the daemon's ack, and the daemon's own intake channel
+/// applies real backpressure (`send().await`) behind that ack.
+/// What: submits `docs` one at a time under [`OP_TIMEOUT`], stopping early if
+/// [`PALACE_BUDGET`] expires. Skips the whole run when a pre-flight `stats`
+/// shows the daemon already holds at least as many documents as we are about
+/// to send, unless `force`. Reads `stats` back afterwards so the report carries
+/// the daemon's own count rather than ours.
+/// Failure handling is deliberately asymmetric: a failed pre-flight `stats`
+/// proceeds with the full run (doing redundant work is safe; skipping work we
+/// cannot prove is done is not), while a failed post-run `stats` leaves
+/// `final_doc_count` as `None` so `fully_indexed` reports `false`.
+/// Test: `tests/bm25_backfill_e2e.rs::backfill_indexes_every_drawer_without_drops`.
+pub async fn backfill_palace(
+    socket: &Path,
+    palace: &str,
+    docs: Vec<(String, String)>,
+    force: bool,
+) -> BackfillReport {
+    let started = Instant::now();
+    let client = Bm25Client::new(socket.to_path_buf());
+    let total = docs.len();
+
+    if total == 0 {
+        return BackfillReport::short_circuit(palace, BackfillStatus::AlreadyIndexed, 0);
+    }
+
+    // Pre-flight. A failure here is NOT a reason to skip — it is a reason to
+    // do the work, because we cannot show the work is already done.
+    if !force {
+        match tokio::time::timeout(OP_TIMEOUT, client.stats()).await {
+            Ok(Ok(stats)) if stats.doc_count >= total => {
+                tracing::debug!(
+                    palace = %palace,
+                    doc_count = stats.doc_count,
+                    drawers = total,
+                    "bm25 backfill: palace already indexed — skipping"
+                );
+                let mut report =
+                    BackfillReport::short_circuit(palace, BackfillStatus::AlreadyIndexed, total);
+                report.final_doc_count = Some(stats.doc_count);
+                report.elapsed_ms = started.elapsed().as_millis() as u64;
+                return report;
+            }
+            Ok(Ok(stats)) => tracing::info!(
+                palace = %palace,
+                indexed = stats.doc_count,
+                drawers = total,
+                "bm25 backfill: palace under-indexed — running"
+            ),
+            // The daemon is unreachable. Report it rather than spending the
+            // whole budget discovering the same thing 1311 more times.
+            Ok(Err(e)) => {
+                tracing::warn!(palace = %palace, "bm25 backfill: daemon unreachable: {e:#}");
+                return BackfillReport::short_circuit(
+                    palace,
+                    BackfillStatus::DaemonUnavailable,
+                    total,
+                );
+            }
+            Err(_) => {
+                tracing::warn!(palace = %palace, "bm25 backfill: stats timed out — daemon wedged");
+                return BackfillReport::short_circuit(
+                    palace,
+                    BackfillStatus::DaemonUnavailable,
+                    total,
+                );
+            }
+        }
+    }
+
+    let deadline = started + PALACE_BUDGET;
+    let mut indexed = 0usize;
+    let mut failed = 0usize;
+    let mut truncated = false;
+
+    for (doc_id, text) in &docs {
+        if Instant::now() >= deadline {
+            tracing::warn!(
+                palace = %palace,
+                indexed,
+                remaining = total - indexed - failed,
+                "bm25 backfill: time budget expired — reporting partial coverage"
+            );
+            truncated = true;
+            break;
+        }
+        match tokio::time::timeout(OP_TIMEOUT, client.index(doc_id, text)).await {
+            Ok(Ok(())) => indexed += 1,
+            Ok(Err(e)) => {
+                failed += 1;
+                tracing::warn!(palace = %palace, doc_id = %doc_id, "bm25 backfill index failed: {e:#}");
+            }
+            Err(_) => {
+                failed += 1;
+                tracing::warn!(palace = %palace, doc_id = %doc_id, "bm25 backfill index timed out");
+            }
+        }
+    }
+
+    // Read the coverage back from the daemon. Our own ack count is what we
+    // believe happened; this is what the daemon says happened.
+    let final_doc_count = match tokio::time::timeout(OP_TIMEOUT, client.stats()).await {
+        Ok(Ok(stats)) => Some(stats.doc_count),
+        Ok(Err(e)) => {
+            tracing::warn!(palace = %palace, "bm25 backfill: post-run stats failed: {e:#}");
+            None
+        }
+        Err(_) => {
+            tracing::warn!(palace = %palace, "bm25 backfill: post-run stats timed out");
+            None
+        }
+    };
+
+    let status = if failed == 0 && !truncated {
+        BackfillStatus::Completed
+    } else {
+        BackfillStatus::Partial
+    };
+    let report = BackfillReport {
+        palace: palace.to_string(),
+        status,
+        drawers_total: total,
+        skipped_empty: 0,
+        indexed,
+        failed,
+        final_doc_count,
+        elapsed_ms: started.elapsed().as_millis() as u64,
+    };
+    tracing::info!(
+        palace = %palace,
+        ?status,
+        indexed,
+        failed,
+        final_doc_count = ?final_doc_count,
+        elapsed_ms = report.elapsed_ms,
+        "bm25 backfill finished"
+    );
+    report
+}
+
+/// Resolve a palace's daemon socket, starting the daemon if needed.
+///
+/// Why: [`backfill_palace`] takes a socket rather than an `AppState` so it can
+/// be tested against a bare daemon. This is the adapter that turns "a palace
+/// id" into "a socket that is being served", and it is also the point at which
+/// the supervisor's daemon cap applies — a sweep across many palaces spawns
+/// them one at a time and the cap reaps the ones that fall out of the window.
+/// What: `None` when the lane is off or the supervisor could not start a
+/// daemon. Uses the per-palace socket the supervisor returns, NOT
+/// `state.bm25_client`, which is bound to the default palace's socket only.
+/// Test: `backfill_state_palace_is_disabled_without_a_client`.
+async fn socket_for_palace(state: &AppState, palace: &str) -> Option<PathBuf> {
+    state.bm25_client.as_ref()?;
+    let supervisor = state.bm25_supervisor.as_ref()?;
+    let data_dir = state.data_root.join(palace).join("bm25");
+    match supervisor.ensure_running(palace, &data_dir).await {
+        Ok(socket) => Some(socket),
+        Err(e) => {
+            tracing::warn!(palace = %palace, "bm25 backfill: could not start daemon: {e:#}");
+            None
+        }
+    }
+}
+
+/// Backfill one palace through the daemon's spawn supervisor.
+///
+/// Why: the entry point callers actually use. Keeping the lane check here
+/// means every caller degrades identically when the lane is off, instead of
+/// each remembering to test `bm25_client.is_some()` first.
+/// What: returns [`BackfillStatus::Disabled`] when the lane is off and
+/// [`BackfillStatus::DaemonUnavailable`] when the daemon will not start —
+/// neither is an error, because neither should fail a caller's request.
+/// Test: `backfill_state_palace_is_disabled_without_a_client`.
+pub async fn backfill_state_palace(
+    state: &AppState,
+    handle: &PalaceHandle,
+    palace: &str,
+    force: bool,
+) -> BackfillReport {
+    if state.bm25_client.is_none() {
+        return BackfillReport::short_circuit(palace, BackfillStatus::Disabled, 0);
+    }
+    let docs = palace_docs(handle);
+    let Some(socket) = socket_for_palace(state, palace).await else {
+        return BackfillReport::short_circuit(
+            palace,
+            BackfillStatus::DaemonUnavailable,
+            docs.len(),
+        );
+    };
+    backfill_palace(&socket, palace, docs, force).await
+}
+
+/// Sweep every registered palace that has drawers, serially.
+///
+/// Why: a daemon restart is the only moment at which the whole corpus is known
+/// to be reachable and nothing is waiting on it. Serial is deliberate: the
+/// supervisor caps concurrently-live daemons at three, so a parallel sweep
+/// would spend its time reaping daemons it had just spawned.
+/// What: returns immediately, doing the work on a spawned task. No-op when the
+/// lane is off or [`ENV_NO_BACKFILL`] is set — which, until the lane's default
+/// is flipped, is every deployment. Palaces with zero drawers are skipped
+/// without starting a daemon, which is roughly 80 of the ~99 on this host.
+/// Test: `startup_backfill_respects_the_opt_out`.
+pub fn spawn_startup_backfill(state: &AppState) {
+    if state.bm25_client.is_none() {
+        tracing::debug!("bm25 backfill: lane disabled — skipping startup sweep");
+        return;
+    }
+    if std::env::var(ENV_NO_BACKFILL).as_deref() == Ok("1") {
+        tracing::info!("bm25 backfill: {ENV_NO_BACKFILL}=1 — skipping startup sweep");
+        return;
+    }
+    let state = state.clone();
+    tokio::spawn(async move {
+        let started = Instant::now();
+        let mut swept = 0usize;
+        let mut incomplete = 0usize;
+        for id in state.registry.list() {
+            // `get` rather than `peek`: the sweep genuinely uses the handle, so
+            // it should refresh the registry's own idle-eviction recency.
+            let Some(handle) = state.registry.get(&id) else {
+                continue;
+            };
+            let palace = id.as_str().to_string();
+            // Skipping empty palaces here rather than inside `backfill_palace`
+            // is what keeps the sweep from starting ~80 daemons to tell each
+            // one it has nothing to do.
+            if handle.drawers.read().is_empty() {
+                continue;
+            }
+            let report = backfill_state_palace(&state, &handle, &palace, false).await;
+            swept += 1;
+            if !report.fully_indexed() {
+                incomplete += 1;
+            }
+        }
+        tracing::info!(
+            swept,
+            incomplete,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "bm25 backfill: startup sweep complete"
+        );
+    });
+}
+
+#[cfg(test)]
+#[path = "bm25_backfill_tests.rs"]
+mod tests;

--- a/crates/trusty-memory/src/bm25_backfill.rs
+++ b/crates/trusty-memory/src/bm25_backfill.rs
@@ -21,12 +21,27 @@
 //! previous write to land". Nothing can be dropped because nothing is ever
 //! offered to a full queue.
 //!
+//! Coverage is established by IDENTITY, never by counting. `stats.doc_count`
+//! is a count over the daemon's whole corpus, and trusty-memory issues no BM25
+//! `delete` on the forget path (#5053), so the corpus accumulates documents
+//! for drawers the palace no longer has. Once those stale documents outnumber
+//! the ones still missing, `doc_count >= drawer_count` is satisfied by a
+//! corpus that shares no ids with the palace at all. Every coverage decision
+//! here — the pre-flight skip, the post-run verdict, and
+//! [`BackfillReport::fully_indexed`] — therefore goes through
+//! `Bm25Client::missing_docs`, which answers about the exact set of drawer ids
+//! being asked about. A coverage question that could not be asked reports
+//! `None`, never `covered`.
+//!
 //! What: [`backfill_palace`] drives the feeder against a socket; [`palace_docs`]
 //! extracts the `(drawer_id, text)` pairs; [`backfill_state_palace`] wires both
 //! to an [`AppState`] and its spawn supervisor; [`spawn_startup_backfill`]
 //! sweeps every palace that has drawers, serially, when the lane is enabled.
 //! Idempotent throughout — the daemon's `upsert_document` is keyed by `doc_id`,
 //! so a re-run overwrites rather than duplicating.
+//!
+//! Repair after a drop is handled by [`crate::bm25_repair`], which consumes the
+//! dirty flags `bm25_index_enqueue` sets when it drops on a full queue.
 //!
 //! Fail-open: every failure mode degrades to a reported status, never an error
 //! that propagates into a caller's request path and never an unbounded wait.
@@ -39,7 +54,8 @@
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use trusty_common::bm25_client::Bm25Client;
+use trusty_common::bm25_client::{is_method_not_found, Bm25Client};
+use trusty_common::memory_core::palace::Drawer;
 use trusty_common::memory_core::retrieval::PalaceHandle;
 
 use crate::AppState;
@@ -52,7 +68,7 @@ use crate::AppState;
 /// enough that a wedged daemon costs one document's delay rather than stalling
 /// the sweep behind it forever. A backfill that can hang is a backfill that can
 /// hold a startup task open indefinitely.
-/// What: 10 seconds, applied per `index` / `stats` call.
+/// What: 10 seconds, applied per `index` / `missing_docs` call.
 /// Test: `backfill_reports_daemon_unavailable_when_socket_is_dead`.
 const OP_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -65,6 +81,16 @@ const OP_TIMEOUT: Duration = Duration::from_secs(10);
 /// What: 120 seconds. On expiry the feeder stops and reports what landed.
 /// Test: covered by construction; the counters make a truncated run visible.
 const PALACE_BUDGET: Duration = Duration::from_secs(120);
+
+/// How many doc ids one `missing_docs` request carries.
+///
+/// Why: the wire framing is one newline-terminated JSON line per request, so
+/// a 1311-id palace would otherwise build a single ~50 KB frame. Chunking
+/// bounds the frame and the daemon's per-request allocation without changing
+/// the answer — coverage is the union of the chunks' missing sets.
+/// What: 256 ids per request.
+/// Test: `coverage_probe_chunks_large_id_sets` (e2e).
+const COVERAGE_CHUNK: usize = 256;
 
 /// Environment opt-out for the startup sweep.
 ///
@@ -82,8 +108,8 @@ pub const ENV_NO_BACKFILL: &str = "TRUSTY_BM25_NO_BACKFILL";
 /// Why: a caller (and an operator reading logs) needs to tell "nothing to do"
 /// from "could not do it" from "did it, partially". Collapsing those into a
 /// bool is how a partially-indexed palace comes to look finished.
-/// What: five terminal states. Only [`Self::Completed`] means the daemon's
-/// corpus is known to cover the palace.
+/// What: five terminal states, all advisory — the load-bearing claim is
+/// [`BackfillReport::fully_indexed`], which no status can satisfy on its own.
 /// Test: `bm25_backfill_tests.rs`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BackfillStatus {
@@ -92,30 +118,32 @@ pub enum BackfillStatus {
     /// The daemon could not be reached or started. Recall degrades to
     /// vector-only; a later run can repair.
     DaemonUnavailable,
-    /// The daemon already holds a document for every drawer.
+    /// The daemon was already verified to hold a document for every drawer.
     AlreadyIndexed,
     /// Every drawer was submitted and acked.
     Completed,
-    /// Some drawers failed or the time budget expired. The index is usable but
-    /// incomplete; a re-run repairs it.
+    /// Some drawers failed, the time budget expired, or coverage could not be
+    /// verified. The index may be usable but is not known complete; a re-run
+    /// repairs it.
     Partial,
 }
 
 /// What one backfill run did.
 ///
 /// Why: the counters are the evidence that separates "the lane is on" from
-/// "the lane has content". `final_doc_count` in particular is read back from
-/// the daemon rather than inferred from the submissions, so a run that acked
-/// 1311 documents into a daemon that kept 200 reports the discrepancy instead
-/// of claiming success.
-/// What: plain owned counters; `final_doc_count` is `None` when the post-run
-/// `stats` call itself failed.
+/// "the lane has content". `missing_after` in particular is read back from the
+/// daemon BY DRAWER ID rather than inferred from the submissions or from a
+/// corpus count, so a run that acked 1311 documents into a daemon holding a
+/// different 1311 reports the discrepancy instead of claiming success.
+/// What: plain owned counters. `missing_after` is `None` when the post-run
+/// coverage probe itself failed — which reads as "not covered", never as
+/// "covered".
 /// Test: `bm25_backfill_tests.rs`.
 #[derive(Debug, Clone)]
 pub struct BackfillReport {
     pub palace: String,
     pub status: BackfillStatus,
-    /// Drawers the palace holds.
+    /// Drawers the palace holds, including the blank ones.
     pub drawers_total: usize,
     /// Drawers with no indexable text, skipped without being submitted.
     pub skipped_empty: usize,
@@ -123,13 +151,25 @@ pub struct BackfillReport {
     pub indexed: usize,
     /// Documents that errored or timed out.
     pub failed: usize,
-    /// `doc_count` the daemon reported after the run.
+    /// How many of this palace's drawer ids the daemon still does NOT hold,
+    /// asked by id after the run. `None` when the question could not be
+    /// answered at all.
+    pub missing_after: Option<usize>,
+    /// `doc_count` the daemon reported after the run — observability only.
+    /// Larger than `drawers_total - skipped_empty` means stale documents for
+    /// drawers this palace no longer has (#5053). Never a coverage signal.
     pub final_doc_count: Option<usize>,
     pub elapsed_ms: u64,
 }
 
 impl BackfillReport {
     /// Terminal report for a run that never started.
+    ///
+    /// Why: a run that never started has, by construction, verified nothing —
+    /// so `missing_after` starts as `None` and only the genuinely-empty case
+    /// overrides it.
+    /// What: zeroed counters with `missing_after: None`.
+    /// Test: `short_circuit_reports_are_never_covered`.
     fn short_circuit(palace: &str, status: BackfillStatus, drawers_total: usize) -> Self {
         Self {
             palace: palace.to_string(),
@@ -138,30 +178,74 @@ impl BackfillReport {
             skipped_empty: 0,
             indexed: 0,
             failed: 0,
+            missing_after: None,
             final_doc_count: None,
             elapsed_ms: 0,
         }
     }
 
-    /// True when the daemon is known to hold every drawer this palace has.
+    /// True when the daemon is known to hold a document for every drawer.
     ///
-    /// Why: this is the question the whole module exists to answer, and it must
-    /// be answered from the daemon's own reported count — not from how many
-    /// writes we believe we sent.
-    /// What: `true` for `AlreadyIndexed`, or for `Completed` whose read-back
-    /// count covers the non-empty drawers. Anything else, including a
-    /// `Completed` run whose read-back failed, is `false`.
-    /// Test: `fully_indexed_requires_a_read_back_count`.
+    /// Why: this is the question the whole module exists to answer, and it is
+    /// the alarm the design rests on — so it must be a SET statement, not an
+    /// arithmetic one. The previous version compared the daemon's `doc_count`
+    /// against the palace's drawer count; because trusty-memory issues no BM25
+    /// `delete`, stale documents accumulate and that comparison eventually
+    /// returns `true` over a palace the daemon has never indexed.
+    /// What: `true` only when a post-run probe asked the daemon about every one
+    /// of this palace's drawer ids and it named none as missing. A probe that
+    /// failed, timed out, or was never run leaves `None` and reports `false`.
+    /// No status alone can satisfy it.
+    /// Test: `fully_indexed_requires_a_verified_empty_missing_set`.
     pub fn fully_indexed(&self) -> bool {
-        match self.status {
-            BackfillStatus::AlreadyIndexed => true,
-            BackfillStatus::Completed => self
-                .final_doc_count
-                // `saturating_sub` because the alternative is a debug panic in
-                // a coverage predicate — an inconsistent report should read as
-                // "not covered", not take the daemon down.
-                .is_some_and(|n| n >= self.drawers_total.saturating_sub(self.skipped_empty)),
-            _ => false,
+        self.missing_after == Some(0)
+    }
+
+    /// Stale documents the daemon holds beyond this palace's indexable drawers.
+    ///
+    /// Why: this is the count whose growth broke the old predicate, and an
+    /// operator should be able to see it climbing rather than discover it when
+    /// coverage starts lying. Reported, never acted on.
+    /// What: `final_doc_count` minus the indexable drawer count, floored at
+    /// zero; `None` when the count was not read.
+    /// Test: `stale_doc_estimate_is_reported_not_acted_on`.
+    pub fn stale_doc_estimate(&self) -> Option<usize> {
+        let indexable = self.drawers_total.saturating_sub(self.skipped_empty);
+        self.final_doc_count.map(|n| n.saturating_sub(indexable))
+    }
+}
+
+/// A palace's drawers, split into what is worth indexing and what is not.
+///
+/// Why: the two numbers a report needs — how many drawers exist and how many
+/// carry no indexable text — can only be taken together, under one read of the
+/// drawer lock. Deriving `skipped_empty` at a second call site is how the field
+/// ended up permanently zero and the `drawers_total` doc ended up wrong.
+/// What: `docs` is the `(doc_id, text)` pairs to submit; `skipped_empty` is how
+/// many drawers were dropped for having no non-whitespace content.
+/// Test: `docs_from_drawers_splits_blank_from_indexable`.
+#[derive(Debug, Clone, Default)]
+pub struct PalaceDocs {
+    pub docs: Vec<(String, String)>,
+    pub skipped_empty: usize,
+}
+
+impl PalaceDocs {
+    /// Every drawer the palace holds, indexable or not.
+    pub fn drawers_total(&self) -> usize {
+        self.docs.len() + self.skipped_empty
+    }
+
+    /// Build from `(doc_id, text)` pairs that are already known indexable.
+    ///
+    /// Why: tests and callers driving the feeder directly have pairs, not a
+    /// palace, and should not have to fabricate a drawer table to use it.
+    /// What: takes the pairs verbatim with `skipped_empty: 0`.
+    /// Test: used throughout `tests/bm25_backfill_e2e.rs`.
+    pub fn from_pairs(docs: Vec<(String, String)>) -> Self {
+        Self {
+            docs,
+            skipped_empty: 0,
         }
     }
 }
@@ -172,18 +256,90 @@ impl BackfillReport {
 /// across an `.await`. Materialising the pairs up front costs one clone of
 /// single-digit MB of text — the entire corpus across ~99 palaces is that
 /// size — and removes the lock from the async path entirely.
-/// What: clones `(id.to_string(), content)` for every drawer whose content has
-/// non-whitespace text. Empty drawers are omitted: indexing zero tokens can
-/// never produce a hit, so submitting them would inflate the daemon's
-/// `doc_count` and break the coverage comparison this module relies on.
-/// Test: `palace_docs_skips_blank_drawers`.
-pub fn palace_docs(handle: &PalaceHandle) -> Vec<(String, String)> {
+/// What: one read of the lock, delegating the split to [`docs_from_drawers`].
+/// Test: `docs_from_drawers_splits_blank_from_indexable`.
+pub fn palace_docs(handle: &PalaceHandle) -> PalaceDocs {
     let drawers = handle.drawers.read();
-    drawers
-        .iter()
-        .filter(|d| !d.content.trim().is_empty())
-        .map(|d| (d.id.to_string(), d.content.clone()))
-        .collect()
+    docs_from_drawers(&drawers)
+}
+
+/// Split a drawer slice into indexable pairs and a blank count.
+///
+/// Why: separated from the lock so the filter — the load-bearing part — can be
+/// exercised directly rather than restated in a test.
+/// What: clones `(id.to_string(), content)` for every drawer whose content has
+/// non-whitespace text, and counts the rest. Empty drawers are omitted because
+/// indexing zero tokens can never produce a hit, so submitting them would only
+/// inflate the daemon's corpus.
+/// Test: `docs_from_drawers_splits_blank_from_indexable`.
+pub fn docs_from_drawers(drawers: &[Drawer]) -> PalaceDocs {
+    let mut docs = Vec::with_capacity(drawers.len());
+    let mut skipped_empty = 0usize;
+    for d in drawers {
+        if d.content.trim().is_empty() {
+            skipped_empty += 1;
+        } else {
+            docs.push((d.id.to_string(), d.content.clone()));
+        }
+    }
+    PalaceDocs {
+        docs,
+        skipped_empty,
+    }
+}
+
+/// Outcome of asking the daemon which drawer ids it is missing.
+///
+/// Why: three answers, three different actions. "None missing" is the only one
+/// that may skip work or claim coverage; the other two must not be collapsed
+/// into it, and must not be collapsed into each other either — an outdated
+/// daemon and an absent one send an operator after different problems.
+/// What: `Missing(n)` carries a verified count; the other two carry no claim.
+/// Test: `coverage_probe_classifies_the_three_failure_modes`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Coverage {
+    /// The daemon answered: this many of the ids asked about are absent.
+    Missing(usize),
+    /// The daemon answered `-32601` — it predates the `missing_docs` op.
+    Unsupported,
+    /// The daemon could not be reached, or did not answer in time.
+    Unreachable,
+}
+
+/// Ask the daemon which of `ids` it does not hold, in bounded chunks.
+///
+/// Why: the coverage claim must never be inferred. This is the only place that
+/// produces one, so every caller — pre-flight skip, post-run verdict — reaches
+/// the same answer through the same failure classification.
+/// What: chunks by [`COVERAGE_CHUNK`] under [`OP_TIMEOUT`] each and sums the
+/// missing sets. Any chunk failing aborts with the corresponding non-answer;
+/// a partial sum is not a coverage answer.
+/// Test: `coverage_probe_classifies_the_three_failure_modes`.
+async fn probe_coverage(client: &Bm25Client, palace: &str, ids: &[String]) -> Coverage {
+    let mut missing = 0usize;
+    for chunk in ids.chunks(COVERAGE_CHUNK) {
+        match tokio::time::timeout(OP_TIMEOUT, client.missing_docs(chunk)).await {
+            Ok(Ok(cov)) => missing += cov.missing.len(),
+            Ok(Err(e)) if is_method_not_found(&e) => {
+                tracing::error!(
+                    palace = %palace,
+                    "bm25 backfill: daemon does not implement `missing_docs` — it predates \
+                     0.2.0. Coverage CANNOT be verified for this palace; upgrade the daemon. \
+                     Reporting the palace as incomplete rather than guessing: {e:#}"
+                );
+                return Coverage::Unsupported;
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(palace = %palace, "bm25 backfill: coverage probe failed: {e:#}");
+                return Coverage::Unreachable;
+            }
+            Err(_) => {
+                tracing::warn!(palace = %palace, "bm25 backfill: coverage probe timed out");
+                return Coverage::Unreachable;
+            }
+        }
+    }
+    Coverage::Missing(missing)
 }
 
 /// Feed a palace's documents to a BM25 daemon, losslessly.
@@ -194,69 +350,84 @@ pub fn palace_docs(handle: &PalaceHandle) -> Vec<(String, String)> {
 /// `index` call awaits the daemon's ack, and the daemon's own intake channel
 /// applies real backpressure (`send().await`) behind that ack.
 /// What: submits `docs` one at a time under [`OP_TIMEOUT`], stopping early if
-/// [`PALACE_BUDGET`] expires. Skips the whole run when a pre-flight `stats`
-/// shows the daemon already holds at least as many documents as we are about
-/// to send, unless `force`. Reads `stats` back afterwards so the report carries
-/// the daemon's own count rather than ours.
-/// Failure handling is deliberately asymmetric: a failed pre-flight `stats`
+/// [`PALACE_BUDGET`] expires. Skips the run only when a pre-flight probe named
+/// zero missing drawer ids — a verified set statement, not a count comparison
+/// — unless `force`. Probes again afterwards so the report's coverage claim is
+/// the daemon's own answer about this palace's ids.
+/// Failure handling is deliberately asymmetric: a failed pre-flight probe
 /// proceeds with the full run (doing redundant work is safe; skipping work we
-/// cannot prove is done is not), while a failed post-run `stats` leaves
-/// `final_doc_count` as `None` so `fully_indexed` reports `false`.
+/// cannot prove is done is not), while a failed post-run probe leaves
+/// `missing_after` as `None` so `fully_indexed` reports `false`.
 /// Test: `tests/bm25_backfill_e2e.rs::backfill_indexes_every_drawer_without_drops`.
 pub async fn backfill_palace(
     socket: &Path,
     palace: &str,
-    docs: Vec<(String, String)>,
+    palace_docs: PalaceDocs,
     force: bool,
 ) -> BackfillReport {
     let started = Instant::now();
     let client = Bm25Client::new(socket.to_path_buf());
+    let PalaceDocs {
+        docs,
+        skipped_empty,
+    } = palace_docs;
+    let drawers_total = docs.len() + skipped_empty;
     let total = docs.len();
 
     if total == 0 {
-        return BackfillReport::short_circuit(palace, BackfillStatus::AlreadyIndexed, 0);
+        // Nothing indexable means nothing can be missing — the one case where
+        // coverage is established without asking the daemon anything.
+        let mut report =
+            BackfillReport::short_circuit(palace, BackfillStatus::AlreadyIndexed, drawers_total);
+        report.skipped_empty = skipped_empty;
+        report.missing_after = Some(0);
+        return report;
     }
+
+    let ids: Vec<String> = docs.iter().map(|(id, _)| id.clone()).collect();
 
     // Pre-flight. A failure here is NOT a reason to skip — it is a reason to
     // do the work, because we cannot show the work is already done.
     if !force {
-        match tokio::time::timeout(OP_TIMEOUT, client.stats()).await {
-            Ok(Ok(stats)) if stats.doc_count >= total => {
+        match probe_coverage(&client, palace, &ids).await {
+            Coverage::Missing(0) => {
                 tracing::debug!(
                     palace = %palace,
-                    doc_count = stats.doc_count,
                     drawers = total,
-                    "bm25 backfill: palace already indexed — skipping"
+                    "bm25 backfill: every drawer id already present — skipping"
                 );
-                let mut report =
-                    BackfillReport::short_circuit(palace, BackfillStatus::AlreadyIndexed, total);
-                report.final_doc_count = Some(stats.doc_count);
+                let mut report = BackfillReport::short_circuit(
+                    palace,
+                    BackfillStatus::AlreadyIndexed,
+                    drawers_total,
+                );
+                report.skipped_empty = skipped_empty;
+                report.missing_after = Some(0);
+                report.final_doc_count = read_doc_count(&client, palace).await;
                 report.elapsed_ms = started.elapsed().as_millis() as u64;
+                log_stale_docs(&report);
                 return report;
             }
-            Ok(Ok(stats)) => tracing::info!(
+            Coverage::Missing(n) => tracing::info!(
                 palace = %palace,
-                indexed = stats.doc_count,
+                missing = n,
                 drawers = total,
                 "bm25 backfill: palace under-indexed — running"
             ),
+            // Fall through and do the work. The post-run probe will hit the
+            // same wall and leave `missing_after: None`, so the palace reports
+            // as incomplete rather than as silently complete.
+            Coverage::Unsupported => {}
             // The daemon is unreachable. Report it rather than spending the
             // whole budget discovering the same thing 1311 more times.
-            Ok(Err(e)) => {
-                tracing::warn!(palace = %palace, "bm25 backfill: daemon unreachable: {e:#}");
-                return BackfillReport::short_circuit(
+            Coverage::Unreachable => {
+                let mut report = BackfillReport::short_circuit(
                     palace,
                     BackfillStatus::DaemonUnavailable,
-                    total,
+                    drawers_total,
                 );
-            }
-            Err(_) => {
-                tracing::warn!(palace = %palace, "bm25 backfill: stats timed out — daemon wedged");
-                return BackfillReport::short_circuit(
-                    palace,
-                    BackfillStatus::DaemonUnavailable,
-                    total,
-                );
+                report.skipped_empty = skipped_empty;
+                return report;
             }
         }
     }
@@ -290,21 +461,14 @@ pub async fn backfill_palace(
         }
     }
 
-    // Read the coverage back from the daemon. Our own ack count is what we
-    // believe happened; this is what the daemon says happened.
-    let final_doc_count = match tokio::time::timeout(OP_TIMEOUT, client.stats()).await {
-        Ok(Ok(stats)) => Some(stats.doc_count),
-        Ok(Err(e)) => {
-            tracing::warn!(palace = %palace, "bm25 backfill: post-run stats failed: {e:#}");
-            None
-        }
-        Err(_) => {
-            tracing::warn!(palace = %palace, "bm25 backfill: post-run stats timed out");
-            None
-        }
+    // Read the coverage back from the daemon BY ID. Our own ack count is what
+    // we believe happened; this is what the daemon says it holds.
+    let missing_after = match probe_coverage(&client, palace, &ids).await {
+        Coverage::Missing(n) => Some(n),
+        Coverage::Unsupported | Coverage::Unreachable => None,
     };
 
-    let status = if failed == 0 && !truncated {
+    let status = if missing_after == Some(0) && failed == 0 && !truncated {
         BackfillStatus::Completed
     } else {
         BackfillStatus::Partial
@@ -312,23 +476,64 @@ pub async fn backfill_palace(
     let report = BackfillReport {
         palace: palace.to_string(),
         status,
-        drawers_total: total,
-        skipped_empty: 0,
+        drawers_total,
+        skipped_empty,
         indexed,
         failed,
-        final_doc_count,
+        missing_after,
+        final_doc_count: read_doc_count(&client, palace).await,
         elapsed_ms: started.elapsed().as_millis() as u64,
     };
-    tracing::info!(
-        palace = %palace,
-        ?status,
-        indexed,
-        failed,
-        final_doc_count = ?final_doc_count,
-        elapsed_ms = report.elapsed_ms,
-        "bm25 backfill finished"
-    );
+    if !report.fully_indexed() {
+        tracing::error!(
+            palace = %palace,
+            ?status,
+            indexed,
+            failed,
+            missing_after = ?missing_after,
+            "bm25 backfill did NOT establish coverage — this palace answers lexical \
+             queries from a partial corpus"
+        );
+    } else {
+        tracing::info!(
+            palace = %palace,
+            indexed,
+            elapsed_ms = report.elapsed_ms,
+            "bm25 backfill finished — coverage verified by drawer id"
+        );
+    }
+    log_stale_docs(&report);
     report
+}
+
+/// Read the daemon's corpus size for the log line. Never a coverage signal.
+async fn read_doc_count(client: &Bm25Client, palace: &str) -> Option<usize> {
+    match tokio::time::timeout(OP_TIMEOUT, client.stats()).await {
+        Ok(Ok(stats)) => Some(stats.doc_count),
+        Ok(Err(e)) => {
+            tracing::debug!(palace = %palace, "bm25 backfill: stats read failed: {e:#}");
+            None
+        }
+        Err(_) => None,
+    }
+}
+
+/// Surface documents the daemon holds for drawers the palace no longer has.
+///
+/// Why: this drift is the disease the old count-based predicate died of, and
+/// it is invisible unless something says so out loud (#5053).
+/// What: one `warn!` when the estimate is positive. Advisory only.
+/// Test: `stale_doc_estimate_is_reported_not_acted_on`.
+fn log_stale_docs(report: &BackfillReport) {
+    if let Some(stale) = report.stale_doc_estimate().filter(|n| *n > 0) {
+        tracing::warn!(
+            palace = %report.palace,
+            stale,
+            doc_count = ?report.final_doc_count,
+            "bm25 daemon holds documents for drawers this palace no longer has — \
+             stale lexical hits are possible (see #5053)"
+        );
+    }
 }
 
 /// Resolve a palace's daemon socket, starting the daemon if needed.
@@ -362,7 +567,8 @@ async fn socket_for_palace(state: &AppState, palace: &str) -> Option<PathBuf> {
 /// each remembering to test `bm25_client.is_some()` first.
 /// What: returns [`BackfillStatus::Disabled`] when the lane is off and
 /// [`BackfillStatus::DaemonUnavailable`] when the daemon will not start —
-/// neither is an error, because neither should fail a caller's request.
+/// neither is an error, because neither should fail a caller's request, and
+/// neither reports coverage.
 /// Test: `backfill_state_palace_is_disabled_without_a_client`.
 pub async fn backfill_state_palace(
     state: &AppState,
@@ -374,14 +580,26 @@ pub async fn backfill_state_palace(
         return BackfillReport::short_circuit(palace, BackfillStatus::Disabled, 0);
     }
     let docs = palace_docs(handle);
+    let drawers_total = docs.drawers_total();
     let Some(socket) = socket_for_palace(state, palace).await else {
-        return BackfillReport::short_circuit(
-            palace,
-            BackfillStatus::DaemonUnavailable,
-            docs.len(),
-        );
+        let mut report =
+            BackfillReport::short_circuit(palace, BackfillStatus::DaemonUnavailable, drawers_total);
+        report.skipped_empty = docs.skipped_empty;
+        return report;
     };
     backfill_palace(&socket, palace, docs, force).await
+}
+
+/// Whether the startup sweep is switched off by [`ENV_NO_BACKFILL`].
+///
+/// Why: the guard has to be reachable from a test without spawning the sweep,
+/// otherwise the test restates the comparison instead of exercising it — which
+/// is how it came to pass against a deleted implementation.
+/// What: exact `"1"`, matching every other trusty-* flag; anything else, and an
+/// unset var, leave the sweep enabled.
+/// Test: `startup_backfill_respects_the_opt_out`.
+pub fn startup_backfill_opted_out() -> bool {
+    std::env::var(ENV_NO_BACKFILL).as_deref() == Ok("1")
 }
 
 /// Sweep every registered palace that has drawers, serially.
@@ -400,7 +618,7 @@ pub fn spawn_startup_backfill(state: &AppState) {
         tracing::debug!("bm25 backfill: lane disabled — skipping startup sweep");
         return;
     }
-    if std::env::var(ENV_NO_BACKFILL).as_deref() == Ok("1") {
+    if startup_backfill_opted_out() {
         tracing::info!("bm25 backfill: {ENV_NO_BACKFILL}=1 — skipping startup sweep");
         return;
     }
@@ -426,14 +644,26 @@ pub fn spawn_startup_backfill(state: &AppState) {
             swept += 1;
             if !report.fully_indexed() {
                 incomplete += 1;
+                // Queue it for the repair sweep rather than waiting for the
+                // next restart — see `bm25_repair`.
+                crate::bm25_repair::mark_dirty(&state, &palace);
             }
         }
-        tracing::info!(
-            swept,
-            incomplete,
-            elapsed_ms = started.elapsed().as_millis() as u64,
-            "bm25 backfill: startup sweep complete"
-        );
+        if incomplete > 0 {
+            tracing::error!(
+                swept,
+                incomplete,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "bm25 backfill: startup sweep left palaces without verified coverage — \
+                 queued for repair"
+            );
+        } else {
+            tracing::info!(
+                swept,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "bm25 backfill: startup sweep complete, all coverage verified"
+            );
+        }
     });
 }
 

--- a/crates/trusty-memory/src/bm25_backfill.rs
+++ b/crates/trusty-memory/src/bm25_backfill.rs
@@ -639,6 +639,45 @@ impl SweepOutcome {
     }
 }
 
+/// Every palace id present under `data_root`.
+///
+/// Why not `PalaceStore::list_palaces`: it returns `Ok` while silently dropping
+/// any palace whose `palace.json` fails to decode, and any `read_dir` entry
+/// that errors. The sweep would read that `Ok` as a complete enumeration, so an
+/// undecodable palace would be absent from the count, absent from the repair
+/// queue, and the sweep would still log `all coverage verified` — the same
+/// fail-open as the LRU enumeration, one layer further out. This enumerates
+/// ids, not metadata, so a palace with unreadable metadata is still SEEN; the
+/// sweep then fails to open it and records it as unopenable.
+///
+/// An errored directory entry fails the whole enumeration rather than
+/// shrinking it, because a partial list is indistinguishable from a short one
+/// and the caller can only tell "verified everything" from "verified what I
+/// happened to see" if the difference reaches it.
+///
+/// What: returns the name of every immediate subdirectory holding a
+/// `palace.json`.
+/// Test: `startup_sweep_counts_an_undecodable_palace_instead_of_skipping_it`,
+/// `a_sweep_that_cannot_enumerate_verifies_nothing`.
+fn palace_ids_on_disk(data_root: &std::path::Path) -> anyhow::Result<Vec<String>> {
+    let mut ids = Vec::new();
+    for entry in std::fs::read_dir(data_root)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.join("palace.json").is_file() {
+            continue;
+        }
+        match path.file_name().and_then(|n| n.to_str()) {
+            Some(name) => ids.push(name.to_string()),
+            None => anyhow::bail!(
+                "palace directory name is not valid UTF-8: {}",
+                path.display()
+            ),
+        }
+    }
+    Ok(ids)
+}
+
 /// Sweep every palace ON DISK that has drawers, serially.
 ///
 /// Why the disk and not the registry: `registry.list()` snapshots the LRU key
@@ -653,20 +692,19 @@ impl SweepOutcome {
 /// Holding the opened `Arc` for the palace's whole backfill also removes the
 /// mid-sweep-eviction hole — the idle ticker is armed before this runs, and a
 /// borrowed LRU entry could vanish underneath it.
-/// What: enumerates with `PalaceRegistry::list_palaces` and hydrates each with
-/// `open_palace` on the blocking pool (serial, so cold opens do not thrash the
-/// 64-slot LRU). Every palace that cannot be enumerated, cannot be opened, or
-/// cannot be verified is reported and queued for repair. A failed enumeration
-/// verifies NOTHING and says so — it never reports a clean sweep.
+/// What: enumerates palace ids straight off the data root and hydrates each
+/// with `open_palace` on the blocking pool (serial, so cold opens do not thrash
+/// the 64-slot LRU). Every palace that cannot be enumerated, cannot be opened,
+/// or cannot be verified is reported and queued for repair. A failed
+/// enumeration verifies NOTHING and says so — it never reports a clean sweep.
 /// Test: `startup_sweep_enumerates_every_palace_on_disk`,
-/// `startup_sweep_marks_unopenable_palaces_instead_of_skipping_them`.
+/// `startup_sweep_marks_unopenable_palaces_instead_of_skipping_them`,
+/// `startup_sweep_counts_an_undecodable_palace_instead_of_skipping_it`,
+/// `a_sweep_that_cannot_enumerate_verifies_nothing`.
 pub async fn run_startup_sweep(state: &AppState) -> SweepOutcome {
     let started = Instant::now();
     let root = state.data_root.clone();
-    let listed = tokio::task::spawn_blocking(move || {
-        trusty_common::memory_core::registry::PalaceRegistry::list_palaces(&root)
-    })
-    .await;
+    let listed = tokio::task::spawn_blocking(move || palace_ids_on_disk(&root)).await;
 
     let palaces = match listed {
         Ok(Ok(p)) => p,
@@ -692,7 +730,7 @@ pub async fn run_startup_sweep(state: &AppState) -> SweepOutcome {
     };
 
     for palace in palaces {
-        let id = palace.id.clone();
+        let id = trusty_common::memory_core::palace::PalaceId::new(palace.clone());
         let registry = std::sync::Arc::clone(&state.registry);
         let root = state.data_root.clone();
         let opened = tokio::task::spawn_blocking(move || registry.open_palace(&root, &id)).await;
@@ -701,31 +739,38 @@ pub async fn run_startup_sweep(state: &AppState) -> SweepOutcome {
             Ok(Err(e)) => {
                 // A palace we cannot open is a palace we cannot verify. Queue
                 // it rather than skipping it into the "all verified" tally.
-                tracing::error!(palace = %palace.id, "bm25 backfill: could not open palace: {e:#}");
+                tracing::error!(palace = %palace, "bm25 backfill: could not open palace: {e:#}");
                 out.unopenable += 1;
-                crate::bm25_repair::mark_dirty(state, palace.id.as_str());
+                crate::bm25_repair::mark_dirty(state, &palace);
                 continue;
             }
             Err(e) => {
-                tracing::error!(palace = %palace.id, "bm25 backfill: open task failed: {e}");
+                tracing::error!(palace = %palace, "bm25 backfill: open task failed: {e}");
                 out.unopenable += 1;
-                crate::bm25_repair::mark_dirty(state, palace.id.as_str());
+                crate::bm25_repair::mark_dirty(state, &palace);
                 continue;
             }
         };
 
-        // A palace with no drawers has nothing that could be missing, so it is
-        // covered by definition — skipping it is not a gap. This is what keeps
-        // the sweep from starting ~80 daemons to tell each it has nothing to do.
+        // A palace whose served drawer table is empty has no id that could be
+        // missing from the index, so it is covered — skipping it is not a gap.
+        // The justification is `handle.drawers` specifically, NOT "the palace
+        // has no data": `open_with_intent` falls back to an empty table when
+        // `load_drawers` fails, and `load_drawers` itself skips undecodable
+        // rows, so drawers CAN be absent here while sitting in redb. That stays
+        // correct only because `handle.drawers` is what every lane serves from,
+        // vector included — coverage is defined relative to what the palace
+        // serves, not to what is on disk behind it. Change where the lanes read
+        // from and this skip stops being safe.
         if handle.drawers.read().is_empty() {
             continue;
         }
 
-        let report = backfill_state_palace(state, &handle, palace.id.as_str(), false).await;
+        let report = backfill_state_palace(state, &handle, &palace, false).await;
         out.swept += 1;
         if !report.fully_indexed() {
             out.incomplete += 1;
-            crate::bm25_repair::mark_dirty(state, palace.id.as_str());
+            crate::bm25_repair::mark_dirty(state, &palace);
         }
     }
 

--- a/crates/trusty-memory/src/bm25_backfill_tests.rs
+++ b/crates/trusty-memory/src/bm25_backfill_tests.rs
@@ -470,3 +470,184 @@ async fn coverage_probe_chunks_large_id_sets() {
     );
     h.abort();
 }
+
+/// Create `count` palaces on disk under the state's data root, each holding one
+/// indexable drawer.
+///
+/// Why: the enumeration bug is only visible when a palace exists on disk and is
+/// absent from the open-handle LRU, so the fixture has to go through the
+/// registry's own create path.
+/// What: returns the ids created.
+/// Test: used by the sweep tests below.
+fn create_palaces_on_disk(state: &AppState, count: usize) -> Vec<String> {
+    use trusty_common::memory_core::palace::{Palace, PalaceId};
+    (0..count)
+        .map(|i| {
+            let id = format!("sweep-{i}");
+            let handle = state
+                .registry
+                .create_palace(
+                    &state.data_root,
+                    Palace {
+                        id: PalaceId::new(&id),
+                        name: id.clone(),
+                        description: None,
+                        created_at: chrono::Utc::now(),
+                        data_dir: state.data_root.join(&id),
+                    },
+                )
+                .expect("create palace on disk");
+            // Persist through redb — the drawer table is rebuilt from there on
+            // open, so an in-memory push alone would leave the reopened palace
+            // empty and the test would prove nothing about the sweep.
+            let drawer = Drawer::new(Uuid::new_v4(), "content worth indexing");
+            handle
+                .kg
+                .upsert_drawer_sync(&drawer)
+                .expect("persist drawer");
+            handle.drawers.write().push(drawer);
+            id
+        })
+        .collect()
+}
+
+/// Why (#5048 re-review): the sweep enumerated `registry.list()` — the LRU key
+/// set of currently-OPEN handles, capped at 64 — while this host holds ~99
+/// palaces. At least 35 were never probed, never marked dirty, and the sweep
+/// then logged `all coverage verified`. That is the coverage fail-open moved
+/// one layer out: the predicate stopped lying about palaces it examined, and
+/// the sweep started lying about palaces it never examines.
+/// What: builds three palaces on disk, then runs the sweep from a COLD
+/// `AppState` whose registry holds nothing — the worst case of the eviction the
+/// cap causes. All three must be enumerated, and with the lane off all three
+/// must land in the repair queue rather than being silently skipped.
+/// Test: this test itself. Revert the enumeration to `state.registry.list()`
+/// and `enumerated` reads 0, the queue is empty, and `all_verified()` is true.
+#[tokio::test]
+async fn startup_sweep_enumerates_every_palace_on_disk() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    let ids = create_palaces_on_disk(&AppState::new(root.clone()), 3);
+
+    let cold = AppState::new(root);
+    assert!(
+        cold.registry.list().is_empty(),
+        "precondition: the registry must be cold, so an LRU-based enumeration finds nothing"
+    );
+
+    let out = run_startup_sweep(&cold).await;
+
+    assert_eq!(
+        out.enumerated,
+        Some(3),
+        "every palace on disk must be enumerated, not just the open ones"
+    );
+    assert_eq!(
+        out.swept, 3,
+        "each has a drawer, so each must be backfilled"
+    );
+    assert_eq!(
+        out.incomplete, 3,
+        "the lane is off, so none can be verified"
+    );
+    assert!(
+        !out.all_verified(),
+        "a sweep that verified nothing must never read as complete"
+    );
+
+    let mut queued = crate::bm25_repair::dirty_palaces(&cold);
+    queued.sort();
+    assert_eq!(
+        queued, ids,
+        "every unverified palace must be queued for repair"
+    );
+}
+
+/// Depth-first search for a file by name under `root`.
+fn find_file(root: &std::path::Path, name: &str) -> Option<std::path::PathBuf> {
+    for entry in std::fs::read_dir(root).ok()?.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(found) = find_file(&path, name) {
+                return Some(found);
+            }
+        } else if path.file_name().is_some_and(|f| f == name) {
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// Why: a palace the sweep cannot open is a palace it cannot verify, and the
+/// pre-existing code `continue`d past it into the "all verified" tally. Same
+/// shape as the enumeration gap, one case narrower.
+/// What: replaces the palace's KG redb file with a DIRECTORY, so `list_palaces`
+/// still decodes the row from `palace.json` but `open_palace` cannot open the
+/// store. Asserts the sweep counts it, queues it, and does not report a clean
+/// sweep. Corrupting `palace.json` instead would not exercise this branch —
+/// `list_palaces` skips rows it cannot decode, so the palace would never be
+/// enumerated in the first place.
+/// Test: this test itself. Replace the `unopenable` arm with a bare `continue`
+/// and `all_verified()` reads true over a palace that was never examined.
+#[tokio::test]
+async fn startup_sweep_marks_unopenable_palaces_instead_of_skipping_them() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    create_palaces_on_disk(&AppState::new(root.clone()), 1);
+
+    // Locate the store rather than assuming the layout — `create_palace`
+    // normalises `data_dir`, so the path is the registry's to decide.
+    let kg_path = find_file(&root, "kg.redb").expect("the palace must have a KG store on disk");
+    std::fs::remove_file(&kg_path).expect("remove kg.db");
+    std::fs::create_dir(&kg_path).expect("a directory cannot be opened as a redb file");
+
+    let cold = AppState::new(root);
+    let out = run_startup_sweep(&cold).await;
+
+    assert_eq!(
+        out.enumerated,
+        Some(1),
+        "precondition: the row is still decodable, so the palace IS enumerated"
+    );
+    assert_eq!(out.unopenable, 1, "an unopenable palace must be counted");
+    assert!(
+        !out.all_verified(),
+        "a palace that could not be examined must not read as verified"
+    );
+    assert_eq!(
+        crate::bm25_repair::dirty_palaces(&cold),
+        vec!["sweep-0".to_string()],
+        "and queued for repair rather than skipped"
+    );
+}
+
+/// Why: a failed enumeration is the outermost fail-open — the sweep would run
+/// its loop zero times and report a clean result over the entire corpus. It
+/// must verify nothing and say so.
+/// What: points the state at a data root that cannot be listed.
+/// Test: this test itself.
+#[tokio::test]
+async fn a_sweep_that_cannot_enumerate_verifies_nothing() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // A regular file where the data root should be — `read_dir` cannot walk it.
+    let root = tmp.path().join("not-a-directory");
+    std::fs::write(&root, b"x").expect("write file");
+
+    let state = AppState::new(root);
+    let out = run_startup_sweep(&state).await;
+
+    assert_eq!(
+        out.enumerated, None,
+        "the enumeration failed — say so in the type"
+    );
+    assert_eq!(out.swept, 0);
+    assert!(
+        !out.all_verified(),
+        "a sweep that examined nothing has zero incomplete palaces only because \
+         it looked at none — that must never read as complete"
+    );
+    assert!(
+        crate::bm25_repair::dirty_palaces(&state).is_empty(),
+        "nothing was examined, so nothing can be queued — the log line is the alarm"
+    );
+}

--- a/crates/trusty-memory/src/bm25_backfill_tests.rs
+++ b/crates/trusty-memory/src/bm25_backfill_tests.rs
@@ -4,18 +4,24 @@
 //! the 500-SLOC cap, the same way `worker_liveness_tests.rs` is. Wired back in
 //! via `#[path] mod tests;`.
 //! What: covers the fail-open statuses (lane off, daemon absent, wedged
-//! daemon), the coverage predicate, and the drawer-extraction filter. The
-//! lossless-under-saturation property needs a real daemon and lives in
-//! `tests/bm25_backfill_e2e.rs`.
+//! daemon), the coverage predicate, and the drawer-extraction filter. Every
+//! test here calls the production function it names — a test that restates the
+//! logic inline passes against a deleted implementation, which is how three of
+//! these came to prove nothing. The lossless-under-saturation property needs a
+//! real daemon and lives in `tests/bm25_backfill_e2e.rs`.
 //! Test: this *is* the test file.
 
 use super::*;
+use trusty_common::memory_core::palace::Drawer;
+use uuid::Uuid;
 
 /// Why: with the lane off, a backfill must be a reported no-op — not an error
 /// that a caller has to catch, and not a silent success that makes an
 /// unindexed palace look covered.
-/// What: an `AppState` with no BM25 client, backfilled against a palace that
-/// does not need to exist because the check precedes any I/O.
+/// What: calls `backfill_state_palace` against an `AppState` with no BM25
+/// client. The lane check precedes every use of the handle, so a bare in-memory
+/// handle is enough to reach it — the point is that the REAL function is what
+/// produces the status, not a report built by hand.
 /// Test: this test itself.
 #[tokio::test]
 async fn backfill_state_palace_is_disabled_without_a_client() {
@@ -26,11 +32,47 @@ async fn backfill_state_palace_is_disabled_without_a_client() {
         "the lane must still be off by default — this PR does not flip it"
     );
 
-    // `backfill_state_palace` short-circuits on the client check before it
-    // touches the handle, so the Disabled path is reachable without one.
-    let report = BackfillReport::short_circuit("anything", BackfillStatus::Disabled, 0);
+    let handle = test_handle(tmp.path(), &["some content"]);
+    let report = backfill_state_palace(&state, &handle, "anything", false).await;
+
     assert_eq!(report.status, BackfillStatus::Disabled);
+    assert_eq!(
+        report.missing_after, None,
+        "a run that never happened has verified nothing"
+    );
     assert!(!report.fully_indexed());
+}
+
+/// Build an in-memory `PalaceHandle` holding one drawer per content string.
+///
+/// Why: the disabled and blank-filter paths need a real handle so the tests can
+/// call the production functions rather than restate them. Nothing here touches
+/// disk — `PalaceHandle::new` takes an in-memory vector store and KG.
+/// What: an empty palace with the given drawer contents pushed in.
+/// Test: used by the tests above and below.
+fn test_handle(
+    dir: &std::path::Path,
+    contents: &[&str],
+) -> trusty_common::memory_core::retrieval::PalaceHandle {
+    use trusty_common::memory_core::palace::PalaceId;
+    use trusty_common::memory_core::store::kg::KnowledgeGraph;
+    use trusty_common::memory_core::store::vector::UsearchStore;
+
+    let vs = UsearchStore::new(dir.join("idx.usearch"), 384).expect("vector store");
+    let kg = KnowledgeGraph::open(&dir.join("kg.db")).expect("kg");
+    let handle = trusty_common::memory_core::retrieval::PalaceHandle::new(
+        PalaceId::new("unit-test"),
+        String::new(),
+        vs,
+        kg,
+    );
+    {
+        let mut drawers = handle.drawers.write();
+        for c in contents {
+            drawers.push(Drawer::new(Uuid::new_v4(), *c));
+        }
+    }
+    handle
 }
 
 /// Why (fail-open, daemon absent): pointing the feeder at a socket nothing is
@@ -44,7 +86,7 @@ async fn backfill_state_palace_is_disabled_without_a_client() {
 async fn backfill_reports_daemon_unavailable_when_socket_is_dead() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let socket = tmp.path().join("nothing-here.sock");
-    let docs = vec![("d1".to_string(), "alpha beta".to_string())];
+    let docs = PalaceDocs::from_pairs(vec![("d1".to_string(), "alpha beta".to_string())]);
 
     let started = std::time::Instant::now();
     let report = backfill_palace(&socket, "ghost", docs, false).await;
@@ -52,6 +94,7 @@ async fn backfill_reports_daemon_unavailable_when_socket_is_dead() {
     assert_eq!(report.status, BackfillStatus::DaemonUnavailable);
     assert_eq!(report.indexed, 0);
     assert_eq!(report.drawers_total, 1);
+    assert_eq!(report.missing_after, None);
     assert!(!report.fully_indexed());
     assert!(
         started.elapsed() < OP_TIMEOUT,
@@ -64,9 +107,8 @@ async fn backfill_reports_daemon_unavailable_when_socket_is_dead() {
 /// the only thing standing between that and a stalled sweep, so it needs a
 /// test that actually produces the condition.
 /// What: binds a listener that accepts connections and then does nothing, and
-/// asserts the pre-flight `stats` gives up and reports the daemon unavailable.
-/// Uses a short local timeout budget by asserting on the status rather than
-/// waiting the full deadline — the test tolerates the 10 s worst case.
+/// asserts the pre-flight coverage probe gives up and reports the daemon
+/// unavailable.
 /// Test: this test itself.
 #[tokio::test]
 async fn backfill_gives_up_on_a_socket_that_never_answers() {
@@ -81,39 +123,63 @@ async fn backfill_gives_up_on_a_socket_that_never_answers() {
         }
     });
 
-    let docs = vec![("d1".to_string(), "alpha".to_string())];
+    let docs = PalaceDocs::from_pairs(vec![("d1".to_string(), "alpha".to_string())]);
     let report = backfill_palace(&socket, "silent", docs, false).await;
     assert_eq!(
         report.status,
         BackfillStatus::DaemonUnavailable,
         "a wedged daemon must be reported, not waited on forever"
     );
+    assert!(!report.fully_indexed());
 
     accepted.abort();
 }
 
-/// Why (fail-open, empty palace): a palace with nothing to index is fully
-/// indexed by definition. Reporting it as `Partial` would make a healthy
-/// no-op look like a failure and would keep the startup sweep retrying it.
+/// Why (fail-open, empty palace): a palace with nothing indexable is fully
+/// indexed by definition — there is no id that could be missing. It is the one
+/// case where coverage is established without asking the daemon, and it must
+/// not require a daemon to be reachable.
 /// Test: this test itself.
 #[tokio::test]
 async fn empty_palace_is_already_indexed() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let socket = tmp.path().join("unused.sock");
-    let report = backfill_palace(&socket, "empty", Vec::new(), false).await;
+    let report = backfill_palace(&socket, "empty", PalaceDocs::default(), false).await;
     assert_eq!(report.status, BackfillStatus::AlreadyIndexed);
     assert!(report.fully_indexed());
+    assert_eq!(report.missing_after, Some(0));
     assert_eq!(report.drawers_total, 0);
 }
 
-/// Why: this predicate is what a caller uses to decide whether an empty BM25
-/// result is trustworthy. It must be answered from the daemon's own read-back
-/// count, so a `Completed` run whose post-run `stats` failed reports `false` —
-/// "I sent everything" is not the same claim as "the daemon holds everything".
-/// What: walks the four interesting shapes of a completed report.
+/// Why: a palace of nothing but blank drawers has nothing to index, so it is
+/// covered — but its `drawers_total` must still report the drawers it holds,
+/// otherwise the report lies about the palace's size.
+/// Test: this test itself.
+#[tokio::test]
+async fn a_palace_of_only_blank_drawers_is_covered_and_counted() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("unused.sock");
+    let docs = PalaceDocs {
+        docs: Vec::new(),
+        skipped_empty: 3,
+    };
+    let report = backfill_palace(&socket, "blanks", docs, false).await;
+    assert!(report.fully_indexed());
+    assert_eq!(report.drawers_total, 3, "the palace holds three drawers");
+    assert_eq!(report.skipped_empty, 3);
+}
+
+/// Why: this predicate is the alarm the whole design rests on. It previously
+/// answered from `stats.doc_count >= drawers_total`, a COUNT comparison — and
+/// because trusty-memory issues no BM25 `delete`, stale documents accumulate
+/// until that comparison is satisfied by a corpus sharing no ids with the
+/// palace. It must now be answerable only by a verified, empty missing set.
+/// What: walks every shape of report, including the one that broke it — a
+/// daemon holding MORE documents than the palace has drawers while still
+/// missing one of them.
 /// Test: this test itself.
 #[test]
-fn fully_indexed_requires_a_read_back_count() {
+fn fully_indexed_requires_a_verified_empty_missing_set() {
     let base = BackfillReport {
         palace: "p".into(),
         status: BackfillStatus::Completed,
@@ -121,73 +187,286 @@ fn fully_indexed_requires_a_read_back_count() {
         skipped_empty: 0,
         indexed: 10,
         failed: 0,
+        missing_after: Some(0),
         final_doc_count: Some(10),
         elapsed_ms: 1,
     };
     assert!(base.fully_indexed());
 
-    let no_readback = BackfillReport {
-        final_doc_count: None,
+    // The regression: a corpus bloated with stale documents satisfies every
+    // count comparison while still missing a live drawer.
+    let stale_bloat = BackfillReport {
+        missing_after: Some(1),
+        final_doc_count: Some(400),
         ..base.clone()
     };
     assert!(
-        !no_readback.fully_indexed(),
+        !stale_bloat.fully_indexed(),
+        "400 documents cannot cover 10 drawers when one of the 10 is absent"
+    );
+    assert_eq!(stale_bloat.stale_doc_estimate(), Some(390));
+
+    let no_verification = BackfillReport {
+        missing_after: None,
+        ..base.clone()
+    };
+    assert!(
+        !no_verification.fully_indexed(),
         "an unverifiable run must not claim coverage"
     );
 
-    let short = BackfillReport {
-        final_doc_count: Some(9),
-        ..base.clone()
-    };
-    assert!(
-        !short.fully_indexed(),
-        "the daemon holding fewer docs than the palace has drawers is not coverage"
+    // Status alone must not be able to satisfy the predicate — this is the
+    // exact fail-open the `AlreadyIndexed` arm used to have.
+    for status in [
+        BackfillStatus::AlreadyIndexed,
+        BackfillStatus::Completed,
+        BackfillStatus::Partial,
+        BackfillStatus::DaemonUnavailable,
+        BackfillStatus::Disabled,
+    ] {
+        let unverified = BackfillReport {
+            status,
+            missing_after: None,
+            ..base.clone()
+        };
+        assert!(
+            !unverified.fully_indexed(),
+            "{status:?} must not claim coverage without a verified missing set"
+        );
+    }
+}
+
+/// Why: a short-circuit report is produced by paths that did no work and
+/// verified nothing. If its constructor defaulted `missing_after` to `Some(0)`
+/// the whole predicate would invert.
+/// Test: this test itself.
+#[test]
+fn short_circuit_reports_are_never_covered() {
+    for status in [
+        BackfillStatus::Disabled,
+        BackfillStatus::DaemonUnavailable,
+        BackfillStatus::Partial,
+    ] {
+        let r = BackfillReport::short_circuit("p", status, 7);
+        assert_eq!(r.missing_after, None);
+        assert!(!r.fully_indexed(), "{status:?}");
+        assert_eq!(r.drawers_total, 7);
+    }
+}
+
+/// Why: stale-document drift is what broke the old predicate. It must be
+/// visible to an operator and must never feed back into a coverage decision.
+/// Test: this test itself.
+#[test]
+fn stale_doc_estimate_is_reported_not_acted_on() {
+    let mut r = BackfillReport::short_circuit("p", BackfillStatus::Completed, 10);
+    r.skipped_empty = 2;
+    r.missing_after = Some(0);
+    r.final_doc_count = Some(50);
+    assert_eq!(
+        r.stale_doc_estimate(),
+        Some(42),
+        "8 indexable drawers, 50 documents held"
     );
+    assert!(r.fully_indexed(), "stale documents do not remove coverage");
 
-    let partial = BackfillReport {
-        status: BackfillStatus::Partial,
-        ..base.clone()
-    };
-    assert!(!partial.fully_indexed());
-
-    let unavailable = BackfillReport {
-        status: BackfillStatus::DaemonUnavailable,
-        ..base
-    };
-    assert!(!unavailable.fully_indexed());
+    r.final_doc_count = Some(3);
+    assert_eq!(r.stale_doc_estimate(), Some(0), "never negative");
+    r.final_doc_count = None;
+    assert_eq!(r.stale_doc_estimate(), None);
 }
 
 /// Why: a blank drawer indexes zero tokens and can never produce a hit, but it
-/// WOULD inflate the daemon's `doc_count`. Since `doc_count` is the figure the
-/// coverage comparison is built on, submitting blanks would let an
-/// under-indexed palace read as fully indexed.
-/// What: pins the filter to non-whitespace content.
+/// WOULD add a document to the daemon's corpus. It must be dropped from the
+/// submission set and still counted in the palace's size, because a report that
+/// silently forgets blank drawers understates what the palace holds.
+/// What: calls the production splitter with real `Drawer` values — the earlier
+/// version of this test re-implemented the filter inline and passed whether or
+/// not `docs_from_drawers` existed.
 /// Test: this test itself.
 #[test]
-fn palace_docs_skips_blank_drawers() {
-    // The filter is the load-bearing part; assert it directly rather than
-    // standing up a full palace on disk.
-    let contents = ["real content", "", "   ", "\n\t", "also real"];
-    let kept: Vec<&str> = contents
+fn docs_from_drawers_splits_blank_from_indexable() {
+    let room = Uuid::new_v4();
+    let drawers: Vec<Drawer> = ["real content", "", "   ", "\n\t", "also real"]
         .iter()
-        .copied()
-        .filter(|c| !c.trim().is_empty())
+        .map(|c| Drawer::new(room, *c))
         .collect();
-    assert_eq!(kept, vec!["real content", "also real"]);
+
+    let split = docs_from_drawers(&drawers);
+
+    let texts: Vec<&str> = split.docs.iter().map(|(_, t)| t.as_str()).collect();
+    assert_eq!(texts, vec!["real content", "also real"]);
+    assert_eq!(split.skipped_empty, 3);
+    assert_eq!(split.drawers_total(), 5);
+    for (id, _) in &split.docs {
+        assert!(
+            drawers.iter().any(|d| d.id.to_string() == *id),
+            "doc ids must be the drawer ids the coverage probe will ask about"
+        );
+    }
+}
+
+/// Why: `palace_docs` is the lock-holding wrapper the production path uses; a
+/// test that only exercises the inner splitter would not catch a wrapper that
+/// read the wrong field.
+/// Test: this test itself.
+#[test]
+fn palace_docs_reads_the_drawer_table() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let handle = test_handle(tmp.path(), &["alpha", "  ", "beta"]);
+    let split = palace_docs(&handle);
+    assert_eq!(split.docs.len(), 2);
+    assert_eq!(split.skipped_empty, 1);
+    assert_eq!(split.drawers_total(), 3);
 }
 
 /// Why: the opt-out exists so an operator can keep the lane on while deferring
 /// the sweep. If it were wired to the lane check instead, saying "not now"
 /// would also say "not ever".
-/// What: with no client the sweep is skipped regardless; this pins that the
-/// env var is read as an exact `"1"`, matching every other trusty-* flag.
+/// What: calls the production guard with each value set in the environment —
+/// the earlier version compared a locally-built `Ok(value).as_deref()` against
+/// `Ok("1")`, which is the guard's source restated, not the guard.
 /// Test: this test itself.
 #[test]
 fn startup_backfill_respects_the_opt_out() {
     assert_eq!(ENV_NO_BACKFILL, "TRUSTY_BM25_NO_BACKFILL");
-    // The sweep's guard is `== Ok("1")`; anything else must not disable it.
+    let prev = std::env::var(ENV_NO_BACKFILL).ok();
+
     for (value, expected) in [("1", true), ("0", false), ("true", false), ("", false)] {
-        let disabled = Ok::<&str, ()>(value).as_deref() == Ok("1");
-        assert_eq!(disabled, expected, "value {value:?}");
+        // SAFETY: test-only env mutation, restored below. No other test in
+        // this module reads this variable.
+        unsafe { std::env::set_var(ENV_NO_BACKFILL, value) };
+        assert_eq!(startup_backfill_opted_out(), expected, "value {value:?}");
     }
+
+    // SAFETY: same invariant — restoring the captured prior value.
+    unsafe { std::env::remove_var(ENV_NO_BACKFILL) };
+    assert!(
+        !startup_backfill_opted_out(),
+        "an unset variable must leave the sweep enabled"
+    );
+    if let Some(v) = prev {
+        // SAFETY: restoring the caller's environment.
+        unsafe { std::env::set_var(ENV_NO_BACKFILL, v) };
+    }
+}
+
+/// Spawn a stub daemon that answers every frame with `reply`, counting frames.
+///
+/// Why: the coverage probe's three outcomes and its chunking both need a
+/// controllable peer. A real daemon cannot be made to answer `-32601`, and a
+/// test that constructs the `Coverage` value by hand would restate the
+/// classification instead of exercising it.
+/// What: binds `socket`, and for every newline-delimited request writes
+/// `reply(seen)` back. Returns the shared request counter and the task handle.
+/// Test: used by the two tests below.
+fn stub_daemon(
+    socket: std::path::PathBuf,
+    reply: fn(usize) -> String,
+) -> (
+    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    tokio::task::JoinHandle<()>,
+) {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    let seen = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let counter = std::sync::Arc::clone(&seen);
+    let listener = tokio::net::UnixListener::bind(&socket).expect("bind stub daemon");
+    let handle = tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            let counter = std::sync::Arc::clone(&counter);
+            tokio::spawn(async move {
+                let (read_half, mut write_half) = stream.into_split();
+                let mut reader = BufReader::new(read_half);
+                let mut line = String::new();
+                while reader.read_line(&mut line).await.unwrap_or(0) > 0 {
+                    let n = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let out = format!("{}\n", reply(n));
+                    if write_half.write_all(out.as_bytes()).await.is_err() {
+                        break;
+                    }
+                    line.clear();
+                }
+            });
+        }
+    });
+    (seen, handle)
+}
+
+/// Why: the three ways a coverage probe can end are three different operator
+/// situations, and only one of them may skip work. Collapsing "the daemon is
+/// too old to answer" into "the daemon is gone" sends an operator hunting a
+/// dead socket that is in fact serving; collapsing either into "covered" is
+/// the fail-open this whole module exists to remove.
+/// What: drives the real `probe_coverage` against stub daemons answering a
+/// clean result, a `-32601`, and an internal error.
+/// Test: this test itself.
+#[tokio::test]
+async fn coverage_probe_classifies_the_three_failure_modes() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let ids = vec!["a".to_string(), "b".to_string()];
+
+    let ok = tmp.path().join("ok.sock");
+    let (_n, h) = stub_daemon(ok.clone(), |_| {
+        r#"{"jsonrpc":"2.0","result":{"missing":["b"],"checked":2},"id":1}"#.to_string()
+    });
+    let client = Bm25Client::new(ok);
+    assert_eq!(
+        probe_coverage(&client, "p", &ids).await,
+        Coverage::Missing(1)
+    );
+    h.abort();
+
+    let old = tmp.path().join("old.sock");
+    let (_n, h) = stub_daemon(old.clone(), |_| {
+        r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"unknown method: missing_docs"},"id":1}"#
+            .to_string()
+    });
+    let client = Bm25Client::new(old);
+    assert_eq!(
+        probe_coverage(&client, "p", &ids).await,
+        Coverage::Unsupported,
+        "a daemon that predates the op must be reported as such, never as covered"
+    );
+    h.abort();
+
+    let broken = tmp.path().join("broken.sock");
+    let (_n, h) = stub_daemon(broken.clone(), |_| {
+        r#"{"jsonrpc":"2.0","error":{"code":-32603,"message":"index poisoned"},"id":1}"#.to_string()
+    });
+    let client = Bm25Client::new(broken);
+    assert_eq!(
+        probe_coverage(&client, "p", &ids).await,
+        Coverage::Unreachable
+    );
+    h.abort();
+}
+
+/// Why: the wire framing is one JSON line per request, so an unchunked probe
+/// over the largest palace on this host would build a single ~50 KB frame.
+/// Chunking must not change the answer — the missing counts have to sum.
+/// What: 600 ids against a chunk size of 256 must produce exactly three
+/// requests, and the per-chunk missing sets must add up.
+/// Test: this test itself.
+#[tokio::test]
+async fn coverage_probe_chunks_large_id_sets() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("chunked.sock");
+    // Each chunk reports exactly one missing doc, so three chunks sum to three.
+    let (seen, h) = stub_daemon(socket.clone(), |_| {
+        r#"{"jsonrpc":"2.0","result":{"missing":["x"],"checked":1},"id":1}"#.to_string()
+    });
+    let ids: Vec<String> = (0..600).map(|i| format!("d{i}")).collect();
+    let client = Bm25Client::new(socket);
+
+    assert_eq!(
+        probe_coverage(&client, "p", &ids).await,
+        Coverage::Missing(3),
+        "the missing sets of every chunk must sum"
+    );
+    assert_eq!(
+        seen.load(std::sync::atomic::Ordering::SeqCst),
+        3,
+        "600 ids at a chunk size of {COVERAGE_CHUNK} must be three requests"
+    );
+    h.abort();
 }

--- a/crates/trusty-memory/src/bm25_backfill_tests.rs
+++ b/crates/trusty-memory/src/bm25_backfill_tests.rs
@@ -621,6 +621,52 @@ async fn startup_sweep_marks_unopenable_palaces_instead_of_skipping_them() {
     );
 }
 
+/// Why (#5048 re-review): `PalaceStore::list_palaces` returns `Ok` while
+/// silently dropping any palace whose `palace.json` fails to decode. Routing
+/// the sweep through it made that palace absent from the count AND absent from
+/// the repair queue, while `all_verified()` still read true — a clean log line
+/// over a palace the sweep never knew existed. The enumeration now yields ids
+/// off the directory, so an undecodable palace is seen, fails to open, and is
+/// recorded.
+///
+/// A palace in this state is dark to the whole memory system, not just to
+/// BM25 — `open_palace` fails for every caller — so the sweep's job is to
+/// report it, not to repair it.
+/// What: persists a real palace, then corrupts its `palace.json`.
+/// Test: this test itself. Enumerate via `PalaceStore::list_palaces` instead
+/// and `enumerated` drops to `Some(0)` with an empty queue and a clean verdict.
+#[tokio::test]
+async fn startup_sweep_counts_an_undecodable_palace_instead_of_skipping_it() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    create_palaces_on_disk(&AppState::new(root.clone()), 1);
+
+    std::fs::write(
+        root.join("sweep-0").join("palace.json"),
+        b"{ not valid json",
+    )
+    .expect("corrupt palace.json");
+
+    let cold = AppState::new(root);
+    let out = run_startup_sweep(&cold).await;
+
+    assert_eq!(
+        out.enumerated,
+        Some(1),
+        "a palace whose metadata will not decode must still be SEEN"
+    );
+    assert_eq!(out.unopenable, 1, "and recorded as unopenable");
+    assert!(
+        !out.all_verified(),
+        "a sweep that could not read a palace must never report clean"
+    );
+    assert_eq!(
+        crate::bm25_repair::dirty_palaces(&cold),
+        vec!["sweep-0".to_string()],
+        "and queued, so the state is visible rather than silent"
+    );
+}
+
 /// Why: a failed enumeration is the outermost fail-open — the sweep would run
 /// its loop zero times and report a clean result over the entire corpus. It
 /// must verify nothing and say so.

--- a/crates/trusty-memory/src/bm25_backfill_tests.rs
+++ b/crates/trusty-memory/src/bm25_backfill_tests.rs
@@ -1,0 +1,193 @@
+//! Unit tests for [`super`] — the lossless BM25 backfill feeder.
+//!
+//! Why: split out of `bm25_backfill.rs` so the production module stays under
+//! the 500-SLOC cap, the same way `worker_liveness_tests.rs` is. Wired back in
+//! via `#[path] mod tests;`.
+//! What: covers the fail-open statuses (lane off, daemon absent, wedged
+//! daemon), the coverage predicate, and the drawer-extraction filter. The
+//! lossless-under-saturation property needs a real daemon and lives in
+//! `tests/bm25_backfill_e2e.rs`.
+//! Test: this *is* the test file.
+
+use super::*;
+
+/// Why: with the lane off, a backfill must be a reported no-op — not an error
+/// that a caller has to catch, and not a silent success that makes an
+/// unindexed palace look covered.
+/// What: an `AppState` with no BM25 client, backfilled against a palace that
+/// does not need to exist because the check precedes any I/O.
+/// Test: this test itself.
+#[tokio::test]
+async fn backfill_state_palace_is_disabled_without_a_client() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = AppState::new(tmp.path().to_path_buf());
+    assert!(
+        state.bm25_client.is_none(),
+        "the lane must still be off by default — this PR does not flip it"
+    );
+
+    // `backfill_state_palace` short-circuits on the client check before it
+    // touches the handle, so the Disabled path is reachable without one.
+    let report = BackfillReport::short_circuit("anything", BackfillStatus::Disabled, 0);
+    assert_eq!(report.status, BackfillStatus::Disabled);
+    assert!(!report.fully_indexed());
+}
+
+/// Why (fail-open, daemon absent): pointing the feeder at a socket nothing is
+/// listening on must produce `DaemonUnavailable` promptly. The two failures
+/// this rules out are a propagated error (which would fail a caller's request)
+/// and a hang (which would hold a startup task open).
+/// What: a tempdir path with no listener; asserts the status and that the call
+/// returned well inside the per-op timeout rather than waiting it out.
+/// Test: this test itself.
+#[tokio::test]
+async fn backfill_reports_daemon_unavailable_when_socket_is_dead() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("nothing-here.sock");
+    let docs = vec![("d1".to_string(), "alpha beta".to_string())];
+
+    let started = std::time::Instant::now();
+    let report = backfill_palace(&socket, "ghost", docs, false).await;
+
+    assert_eq!(report.status, BackfillStatus::DaemonUnavailable);
+    assert_eq!(report.indexed, 0);
+    assert_eq!(report.drawers_total, 1);
+    assert!(!report.fully_indexed());
+    assert!(
+        started.elapsed() < OP_TIMEOUT,
+        "a refused connection must fail fast, not wait out the {OP_TIMEOUT:?} deadline"
+    );
+}
+
+/// Why (fail-open, wedged daemon): a socket that accepts but never answers is
+/// the case a plain `read_line` would hang on forever. The per-op timeout is
+/// the only thing standing between that and a stalled sweep, so it needs a
+/// test that actually produces the condition.
+/// What: binds a listener that accepts connections and then does nothing, and
+/// asserts the pre-flight `stats` gives up and reports the daemon unavailable.
+/// Uses a short local timeout budget by asserting on the status rather than
+/// waiting the full deadline — the test tolerates the 10 s worst case.
+/// Test: this test itself.
+#[tokio::test]
+async fn backfill_gives_up_on_a_socket_that_never_answers() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("silent.sock");
+    let listener = tokio::net::UnixListener::bind(&socket).expect("bind silent listener");
+    // Accept and hold, never reply.
+    let accepted = tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((stream, _)) = listener.accept().await {
+            held.push(stream);
+        }
+    });
+
+    let docs = vec![("d1".to_string(), "alpha".to_string())];
+    let report = backfill_palace(&socket, "silent", docs, false).await;
+    assert_eq!(
+        report.status,
+        BackfillStatus::DaemonUnavailable,
+        "a wedged daemon must be reported, not waited on forever"
+    );
+
+    accepted.abort();
+}
+
+/// Why (fail-open, empty palace): a palace with nothing to index is fully
+/// indexed by definition. Reporting it as `Partial` would make a healthy
+/// no-op look like a failure and would keep the startup sweep retrying it.
+/// Test: this test itself.
+#[tokio::test]
+async fn empty_palace_is_already_indexed() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("unused.sock");
+    let report = backfill_palace(&socket, "empty", Vec::new(), false).await;
+    assert_eq!(report.status, BackfillStatus::AlreadyIndexed);
+    assert!(report.fully_indexed());
+    assert_eq!(report.drawers_total, 0);
+}
+
+/// Why: this predicate is what a caller uses to decide whether an empty BM25
+/// result is trustworthy. It must be answered from the daemon's own read-back
+/// count, so a `Completed` run whose post-run `stats` failed reports `false` —
+/// "I sent everything" is not the same claim as "the daemon holds everything".
+/// What: walks the four interesting shapes of a completed report.
+/// Test: this test itself.
+#[test]
+fn fully_indexed_requires_a_read_back_count() {
+    let base = BackfillReport {
+        palace: "p".into(),
+        status: BackfillStatus::Completed,
+        drawers_total: 10,
+        skipped_empty: 0,
+        indexed: 10,
+        failed: 0,
+        final_doc_count: Some(10),
+        elapsed_ms: 1,
+    };
+    assert!(base.fully_indexed());
+
+    let no_readback = BackfillReport {
+        final_doc_count: None,
+        ..base.clone()
+    };
+    assert!(
+        !no_readback.fully_indexed(),
+        "an unverifiable run must not claim coverage"
+    );
+
+    let short = BackfillReport {
+        final_doc_count: Some(9),
+        ..base.clone()
+    };
+    assert!(
+        !short.fully_indexed(),
+        "the daemon holding fewer docs than the palace has drawers is not coverage"
+    );
+
+    let partial = BackfillReport {
+        status: BackfillStatus::Partial,
+        ..base.clone()
+    };
+    assert!(!partial.fully_indexed());
+
+    let unavailable = BackfillReport {
+        status: BackfillStatus::DaemonUnavailable,
+        ..base
+    };
+    assert!(!unavailable.fully_indexed());
+}
+
+/// Why: a blank drawer indexes zero tokens and can never produce a hit, but it
+/// WOULD inflate the daemon's `doc_count`. Since `doc_count` is the figure the
+/// coverage comparison is built on, submitting blanks would let an
+/// under-indexed palace read as fully indexed.
+/// What: pins the filter to non-whitespace content.
+/// Test: this test itself.
+#[test]
+fn palace_docs_skips_blank_drawers() {
+    // The filter is the load-bearing part; assert it directly rather than
+    // standing up a full palace on disk.
+    let contents = ["real content", "", "   ", "\n\t", "also real"];
+    let kept: Vec<&str> = contents
+        .iter()
+        .copied()
+        .filter(|c| !c.trim().is_empty())
+        .collect();
+    assert_eq!(kept, vec!["real content", "also real"]);
+}
+
+/// Why: the opt-out exists so an operator can keep the lane on while deferring
+/// the sweep. If it were wired to the lane check instead, saying "not now"
+/// would also say "not ever".
+/// What: with no client the sweep is skipped regardless; this pins that the
+/// env var is read as an exact `"1"`, matching every other trusty-* flag.
+/// Test: this test itself.
+#[test]
+fn startup_backfill_respects_the_opt_out() {
+    assert_eq!(ENV_NO_BACKFILL, "TRUSTY_BM25_NO_BACKFILL");
+    // The sweep's guard is `== Ok("1")`; anything else must not disable it.
+    for (value, expected) in [("1", true), ("0", false), ("true", false), ("", false)] {
+        let disabled = Ok::<&str, ()>(value).as_deref() == Ok("1");
+        assert_eq!(disabled, expected, "value {value:?}");
+    }
+}

--- a/crates/trusty-memory/src/bm25_repair.rs
+++ b/crates/trusty-memory/src/bm25_repair.rs
@@ -236,6 +236,15 @@ pub fn spawn_repair_sweep(state: &AppState) {
         ticker.tick().await;
         loop {
             ticker.tick().await;
+            // Hardening note (#5048 re-review), not a guarantee: a panic
+            // inside `run_repair_pass` aborts this task and silently disarms
+            // the sweep for the process lifetime, with the queue still growing
+            // and nothing draining it. No panic source is identified in the
+            // pass today — every fallible step returns `Result` — so this is
+            // recorded rather than guarded. What the pass DOES guarantee is
+            // that such an abort loses no work: entries leave the queue only
+            // on verified coverage, so every gap is still queued for whatever
+            // runs next.
             let (attempted, repaired) = run_repair_pass(&state).await;
             if attempted > 0 {
                 tracing::info!(attempted, repaired, "bm25 repair: pass complete");

--- a/crates/trusty-memory/src/bm25_repair.rs
+++ b/crates/trusty-memory/src/bm25_repair.rs
@@ -110,39 +110,86 @@ pub fn dirty_palaces(state: &AppState) -> Vec<String> {
 /// Run one repair pass over the queued palaces.
 ///
 /// Why: exposed separately from the timer so a test can drive a pass
-/// deterministically rather than sleeping out an interval, and so the startup
-/// path could invoke one directly if that ever becomes useful.
-/// What: drains the dirty set, then for each palace runs the lossless backfill
-/// (not forced — the coverage probe decides whether there is work). A palace
-/// whose coverage is still unverified afterwards is re-marked, so a daemon
-/// that is down stays queued instead of being quietly forgotten. Returns
-/// `(attempted, repaired)`.
-/// Test: `an_unrepairable_palace_stays_queued`, `a_vanished_palace_is_dropped_from_the_queue`.
+/// deterministically rather than sleeping out an interval.
+/// What: for each queued palace, resolves the handle with `open_palace` —
+/// which HYDRATES from disk — and re-runs the lossless backfill. An entry is
+/// removed only on verified coverage, or when the palace is genuinely absent
+/// from disk. Everything else stays queued, so an interruption at any point
+/// loses nothing.
+///
+/// `open_palace`, not `registry.get`: `get` is a bare LRU lookup that misses a
+/// palace which has gone idle and been evicted — and a dirty palace is exactly
+/// the kind that goes idle, because its writes are failing. Dropping it there
+/// left its gap waiting for a restart, which is the outcome this module exists
+/// to prevent. Telling "evicted" from "deleted" needs the on-disk palace list;
+/// without it, a transient open failure and a deleted palace look identical and
+/// one of the two answers is always wrong.
+/// Returns `(attempted, repaired)`.
+/// Test: `an_evicted_palace_is_rehydrated_not_dropped`,
+/// `a_palace_absent_from_disk_is_dropped_from_the_queue`,
+/// `an_unrepairable_palace_stays_queued`.
 pub async fn run_repair_pass(state: &AppState) -> (usize, usize) {
-    let queued: Vec<String> = state
-        .bm25_dirty
-        .iter()
-        .map(|e| e.key().clone())
-        .collect::<Vec<_>>();
-    for palace in &queued {
-        state.bm25_dirty.remove(palace);
-    }
+    // Snapshot rather than drain: an entry leaves the set only once its
+    // coverage is verified, so a panic or cancellation mid-pass cannot silently
+    // discard the very gap the set exists to remember.
+    let queued: Vec<String> = state.bm25_dirty.iter().map(|e| e.key().clone()).collect();
     if queued.is_empty() {
         return (0, 0);
     }
 
+    let root = state.data_root.clone();
+    let on_disk = match tokio::task::spawn_blocking(move || {
+        trusty_common::memory_core::registry::PalaceRegistry::list_palaces(&root)
+    })
+    .await
+    {
+        Ok(Ok(palaces)) => palaces
+            .into_iter()
+            .map(|p| p.id.0)
+            .collect::<std::collections::HashSet<String>>(),
+        Ok(Err(e)) => {
+            // Without the on-disk list we cannot tell a deleted palace from an
+            // evicted one. Keep everything queued and try again next pass —
+            // guessing here would drop a real gap.
+            tracing::warn!("bm25 repair: could not enumerate palaces, deferring pass: {e:#}");
+            return (0, 0);
+        }
+        Err(e) => {
+            tracing::warn!("bm25 repair: enumeration task failed, deferring pass: {e}");
+            return (0, 0);
+        }
+    };
+
     let mut repaired = 0usize;
     for palace in &queued {
-        let id = trusty_common::memory_core::palace::PalaceId::new(palace.clone());
-        let Some(handle) = state.registry.get(&id) else {
-            // The palace was evicted or deleted. Nothing to repair, and
-            // re-queueing it would spin forever.
-            tracing::debug!(palace = %palace, "bm25 repair: palace no longer resident — dropping");
+        if !on_disk.contains(palace) {
+            // Genuinely gone. Re-queueing a deleted palace spins forever.
+            state.bm25_dirty.remove(palace);
+            tracing::debug!(palace = %palace, "bm25 repair: palace no longer on disk — dropping");
             continue;
+        }
+
+        let id = trusty_common::memory_core::palace::PalaceId::new(palace.clone());
+        let registry = Arc::clone(&state.registry);
+        let root = state.data_root.clone();
+        let handle = match tokio::task::spawn_blocking(move || registry.open_palace(&root, &id))
+            .await
+        {
+            Ok(Ok(h)) => h,
+            Ok(Err(e)) => {
+                tracing::warn!(palace = %palace, "bm25 repair: open failed, staying queued: {e:#}");
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(palace = %palace, "bm25 repair: open task failed, staying queued: {e}");
+                continue;
+            }
         };
+
         let report =
             crate::bm25_backfill::backfill_state_palace(state, &handle, palace, false).await;
         if report.fully_indexed() {
+            state.bm25_dirty.remove(palace);
             repaired += 1;
             tracing::info!(
                 palace = %palace,
@@ -150,10 +197,8 @@ pub async fn run_repair_pass(state: &AppState) -> (usize, usize) {
                 "bm25 repair: coverage restored"
             );
         } else {
-            // Still broken — keep it queued. This is what makes "a drop is
-            // recoverable" true across a daemon outage rather than only across
-            // a lucky one.
-            state.bm25_dirty.insert(palace.clone());
+            // Stays queued — that is what makes "a drop is recoverable" true
+            // across a daemon outage rather than only across a lucky one.
             tracing::warn!(
                 palace = %palace,
                 status = ?report.status,

--- a/crates/trusty-memory/src/bm25_repair.rs
+++ b/crates/trusty-memory/src/bm25_repair.rs
@@ -1,0 +1,208 @@
+//! Runtime repair for palaces whose BM25 coverage is known to be broken.
+//!
+//! Why: the live write path (`tools::bm25::bm25_index_enqueue`) writes into a
+//! 256-slot bounded channel with `try_send` and DROPS on full. That trade is
+//! defensible only if something eventually repairs a drop — and before this
+//! module, nothing did. `spawn_startup_backfill` was the sole production
+//! caller of backfill, so a drop stayed invisible until the next trusty-memory
+//! restart, which on a long-lived daemon is measured in weeks. "Recoverable
+//! across a restart" is not recoverability; it is a promise the process makes
+//! and does not keep.
+//!
+//! What: a dirty set on [`AppState`] plus one periodic task. Every place that
+//! observes lost coverage — a dropped enqueue, a startup sweep that could not
+//! verify a palace, a repair pass that came up short — calls [`mark_dirty`].
+//! [`spawn_repair_sweep`] drains the set on an interval and re-runs the
+//! lossless backfill for each entry, re-marking any palace whose coverage is
+//! still unverified afterwards. The sweep is idempotent and cheap when nothing
+//! dropped: an empty set costs one wakeup.
+//!
+//! The sweep is bounded the same way the startup sweep is — serial, one palace
+//! at a time, so it cannot outrun the supervisor's three-daemon cap.
+//!
+//! Test: `bm25_repair_tests.rs`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::AppState;
+
+/// Default interval between repair passes.
+///
+/// Why: a drop happens under write burst, and the burst is what makes the
+/// repair expensive — so the sweep should wait out the burst rather than race
+/// it. Five minutes is short enough that a dropped drawer is lexically
+/// searchable within one coffee break and long enough that a sustained burst
+/// does not trigger a repair per minute.
+/// What: 300 seconds.
+/// Test: `repair_interval_honours_env_override`.
+pub const DEFAULT_REPAIR_INTERVAL_SECS: u64 = 300;
+
+/// Environment override for the repair interval, in seconds.
+///
+/// Why: an operator on a write-heavy host may want repairs further apart, and
+/// the integration test wants them closer together. `0` disables the sweep
+/// entirely — an explicit, documented opt-out rather than an accident of
+/// parsing, matching how `TRUSTY_BM25_RSS_LIMIT_MB=0` disables its limit.
+/// What: env var `TRUSTY_BM25_REPAIR_INTERVAL_SECS`. Unparseable values fall
+/// back to [`DEFAULT_REPAIR_INTERVAL_SECS`].
+/// Test: `repair_interval_honours_env_override`.
+pub const ENV_REPAIR_INTERVAL_SECS: &str = "TRUSTY_BM25_REPAIR_INTERVAL_SECS";
+
+/// Set of palace ids whose BM25 coverage is known to be incomplete.
+///
+/// Why: `Arc<DashSet>` rather than a channel because the signal is idempotent
+/// — a palace that dropped forty writes needs exactly one repair, not forty —
+/// and because a set cannot overflow the way the bounded channel it exists to
+/// compensate for can. Bounded by the palace count, which is bounded by disk.
+/// What: shared by every `AppState` clone.
+/// Test: `mark_dirty_is_idempotent`.
+pub type DirtyPalaces = Arc<dashmap::DashSet<String>>;
+
+/// Resolve the repair interval from the environment.
+///
+/// Why: same knob-with-a-typo argument as the supervisor's limits — silently
+/// ignoring a malformed value is worse than not offering the knob.
+/// What: parses as `u64`; `0` means disabled (`None`); unparseable falls back
+/// to the default.
+/// Test: `repair_interval_honours_env_override`.
+pub fn repair_interval() -> Option<Duration> {
+    match std::env::var(ENV_REPAIR_INTERVAL_SECS) {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(0) => None,
+            Ok(n) => Some(Duration::from_secs(n)),
+            Err(_) => {
+                tracing::warn!(
+                    "{ENV_REPAIR_INTERVAL_SECS}={raw:?} is not an integer — \
+                     using default {DEFAULT_REPAIR_INTERVAL_SECS}s"
+                );
+                Some(Duration::from_secs(DEFAULT_REPAIR_INTERVAL_SECS))
+            }
+        },
+        Err(_) => Some(Duration::from_secs(DEFAULT_REPAIR_INTERVAL_SECS)),
+    }
+}
+
+/// Record that `palace` has lost BM25 coverage and needs a repair pass.
+///
+/// Why: this is the half of the drop-on-full trade that was missing. The write
+/// path may keep dropping — that is the right call for `memory_remember`'s
+/// latency — but each drop now leaves a durable-enough marker that a later
+/// pass acts on, instead of a `warn!` nobody reads.
+/// What: inserts the palace id. Idempotent: repeated drops for one palace
+/// queue exactly one repair. Costs one hash insert on the write path, which is
+/// why it is safe to call from `bm25_index_enqueue`'s `Full` arm.
+/// Test: `mark_dirty_is_idempotent`, `bm25_index_queue_drops_when_full`.
+pub fn mark_dirty(state: &AppState, palace: &str) {
+    if state.bm25_dirty.insert(palace.to_string()) {
+        tracing::debug!(
+            palace = %palace,
+            "bm25: palace queued for coverage repair"
+        );
+    }
+}
+
+/// Palaces currently queued for repair. Observability and tests.
+pub fn dirty_palaces(state: &AppState) -> Vec<String> {
+    state.bm25_dirty.iter().map(|e| e.key().clone()).collect()
+}
+
+/// Run one repair pass over the queued palaces.
+///
+/// Why: exposed separately from the timer so a test can drive a pass
+/// deterministically rather than sleeping out an interval, and so the startup
+/// path could invoke one directly if that ever becomes useful.
+/// What: drains the dirty set, then for each palace runs the lossless backfill
+/// (not forced — the coverage probe decides whether there is work). A palace
+/// whose coverage is still unverified afterwards is re-marked, so a daemon
+/// that is down stays queued instead of being quietly forgotten. Returns
+/// `(attempted, repaired)`.
+/// Test: `an_unrepairable_palace_stays_queued`, `a_vanished_palace_is_dropped_from_the_queue`.
+pub async fn run_repair_pass(state: &AppState) -> (usize, usize) {
+    let queued: Vec<String> = state
+        .bm25_dirty
+        .iter()
+        .map(|e| e.key().clone())
+        .collect::<Vec<_>>();
+    for palace in &queued {
+        state.bm25_dirty.remove(palace);
+    }
+    if queued.is_empty() {
+        return (0, 0);
+    }
+
+    let mut repaired = 0usize;
+    for palace in &queued {
+        let id = trusty_common::memory_core::palace::PalaceId::new(palace.clone());
+        let Some(handle) = state.registry.get(&id) else {
+            // The palace was evicted or deleted. Nothing to repair, and
+            // re-queueing it would spin forever.
+            tracing::debug!(palace = %palace, "bm25 repair: palace no longer resident — dropping");
+            continue;
+        };
+        let report =
+            crate::bm25_backfill::backfill_state_palace(state, &handle, palace, false).await;
+        if report.fully_indexed() {
+            repaired += 1;
+            tracing::info!(
+                palace = %palace,
+                indexed = report.indexed,
+                "bm25 repair: coverage restored"
+            );
+        } else {
+            // Still broken — keep it queued. This is what makes "a drop is
+            // recoverable" true across a daemon outage rather than only across
+            // a lucky one.
+            state.bm25_dirty.insert(palace.clone());
+            tracing::warn!(
+                palace = %palace,
+                status = ?report.status,
+                missing_after = ?report.missing_after,
+                "bm25 repair: coverage still unverified — staying queued"
+            );
+        }
+    }
+    (queued.len(), repaired)
+}
+
+/// Start the periodic repair sweep.
+///
+/// Why: without a live trigger, a `try_send` drop is only repaired by a
+/// restart, and the write path's justification for dropping ("it is
+/// recoverable") is not true of the running process. This is that trigger.
+/// What: no-op when the BM25 lane is off or the interval is disabled. Otherwise
+/// spawns one task that ticks and calls [`run_repair_pass`]. The first tick is
+/// one full interval away, so startup work is not competing with the startup
+/// sweep.
+/// Test: `repair_sweep_is_a_noop_without_the_lane`.
+pub fn spawn_repair_sweep(state: &AppState) {
+    if state.bm25_client.is_none() {
+        tracing::debug!("bm25 repair: lane disabled — no repair sweep");
+        return;
+    }
+    let Some(interval) = repair_interval() else {
+        tracing::info!("bm25 repair: {ENV_REPAIR_INTERVAL_SECS}=0 — repair sweep disabled");
+        return;
+    };
+    let state = state.clone();
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        // The immediate first tick would race the startup sweep; skip it.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let (attempted, repaired) = run_repair_pass(&state).await;
+            if attempted > 0 {
+                tracing::info!(attempted, repaired, "bm25 repair: pass complete");
+            }
+        }
+    });
+    tracing::info!(
+        interval_secs = interval.as_secs(),
+        "bm25 repair: coverage repair sweep armed"
+    );
+}
+
+#[cfg(test)]
+#[path = "bm25_repair_tests.rs"]
+mod tests;

--- a/crates/trusty-memory/src/bm25_repair_tests.rs
+++ b/crates/trusty-memory/src/bm25_repair_tests.rs
@@ -1,0 +1,141 @@
+//! Unit tests for [`super`] — the BM25 coverage repair sweep.
+//!
+//! Why: split out of `bm25_repair.rs` to keep the production module under the
+//! 500-SLOC cap, wired back in via `#[path] mod tests;`.
+//! What: covers the dirty-set contract, the interval knob, and the repair
+//! pass's two terminal branches — a palace that is gone is dropped, a palace
+//! whose coverage is still unverified stays queued.
+//! Test: this *is* the test file.
+
+use super::*;
+use trusty_common::memory_core::palace::{Drawer, PalaceId};
+use trusty_common::memory_core::retrieval::PalaceHandle;
+use trusty_common::memory_core::store::kg::KnowledgeGraph;
+use trusty_common::memory_core::store::vector::UsearchStore;
+use uuid::Uuid;
+
+/// Why: a write burst drops many requests for one palace, and each drop calls
+/// `mark_dirty` on the hot path. If the set were a queue, forty drops would
+/// mean forty repairs of a palace that needs one.
+/// Test: this test itself.
+#[tokio::test]
+async fn mark_dirty_is_idempotent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = AppState::new(tmp.path().to_path_buf());
+    assert!(dirty_palaces(&state).is_empty());
+
+    for _ in 0..40 {
+        mark_dirty(&state, "alpha");
+    }
+    mark_dirty(&state, "beta");
+
+    let mut queued = dirty_palaces(&state);
+    queued.sort();
+    assert_eq!(queued, vec!["alpha".to_string(), "beta".to_string()]);
+}
+
+/// Why: `0` must be a documented way to turn the sweep off, distinct from a
+/// zero-second interval — which would be a busy loop, not a disabled sweep.
+/// A typo must not silently disable it either.
+/// Test: this test itself.
+#[test]
+fn repair_interval_honours_env_override() {
+    let prev = std::env::var(ENV_REPAIR_INTERVAL_SECS).ok();
+    let cases: [(&str, Option<Duration>); 3] = [
+        ("30", Some(Duration::from_secs(30))),
+        ("0", None),
+        (
+            "banana",
+            Some(Duration::from_secs(DEFAULT_REPAIR_INTERVAL_SECS)),
+        ),
+    ];
+    for (raw, expected) in cases {
+        // SAFETY: test-only env mutation, restored at the end of this test.
+        unsafe { std::env::set_var(ENV_REPAIR_INTERVAL_SECS, raw) };
+        assert_eq!(repair_interval(), expected, "value {raw:?}");
+    }
+    // SAFETY: same invariant.
+    unsafe { std::env::remove_var(ENV_REPAIR_INTERVAL_SECS) };
+    assert_eq!(
+        repair_interval(),
+        Some(Duration::from_secs(DEFAULT_REPAIR_INTERVAL_SECS))
+    );
+    if let Some(v) = prev {
+        // SAFETY: restoring the caller's environment.
+        unsafe { std::env::set_var(ENV_REPAIR_INTERVAL_SECS, v) };
+    }
+}
+
+/// Why: with the lane off there is nothing to repair, and arming a timer that
+/// wakes every five minutes for the rest of the process's life to do nothing
+/// is a cost with no benefit. The lane is off in every shipped deployment
+/// until piece 2 flips it, so this is the common case.
+/// Test: this test itself.
+#[tokio::test]
+async fn repair_sweep_is_a_noop_without_the_lane() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = AppState::new(tmp.path().to_path_buf());
+    assert!(state.bm25_client.is_none());
+    spawn_repair_sweep(&state);
+    mark_dirty(&state, "alpha");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        dirty_palaces(&state),
+        vec!["alpha".to_string()],
+        "no sweep may run, so nothing may be drained"
+    );
+}
+
+/// Why: a palace queued for repair that is no longer resident must be dropped,
+/// not re-queued — otherwise a deleted palace spins in the set forever and
+/// every pass logs about it.
+/// Test: this test itself.
+#[tokio::test]
+async fn a_vanished_palace_is_dropped_from_the_queue() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = AppState::new(tmp.path().to_path_buf());
+    mark_dirty(&state, "no-such-palace");
+
+    let (attempted, repaired) = run_repair_pass(&state).await;
+
+    assert_eq!(attempted, 1);
+    assert_eq!(repaired, 0);
+    assert!(
+        dirty_palaces(&state).is_empty(),
+        "a palace that no longer exists must not stay queued forever"
+    );
+}
+
+/// Why: this is the half of the drop-on-full trade that was missing. A repair
+/// pass that could not restore coverage must leave the palace queued, so the
+/// next pass tries again — otherwise a daemon that happens to be down during
+/// one pass converts a recoverable drop back into a permanent gap.
+/// What: a resident palace with the lane off, so `backfill_state_palace`
+/// returns `Disabled` and coverage stays unverified. Removing the re-insert in
+/// `run_repair_pass`'s failure arm empties the queue and fails this.
+/// Test: this test itself.
+#[tokio::test]
+async fn an_unrepairable_palace_stays_queued() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = AppState::new(tmp.path().to_path_buf());
+
+    let vs = UsearchStore::new(tmp.path().join("idx.usearch"), 384).expect("vector store");
+    let kg = KnowledgeGraph::open(&tmp.path().join("kg.db")).expect("kg");
+    let handle = PalaceHandle::new(PalaceId::new("resident"), String::new(), vs, kg);
+    handle
+        .drawers
+        .write()
+        .push(Drawer::new(Uuid::new_v4(), "content worth indexing"));
+    state.registry.register(handle);
+
+    mark_dirty(&state, "resident");
+    let (attempted, repaired) = run_repair_pass(&state).await;
+
+    assert_eq!(attempted, 1);
+    assert_eq!(repaired, 0, "the lane is off, so nothing can be repaired");
+    assert_eq!(
+        dirty_palaces(&state),
+        vec!["resident".to_string()],
+        "an unverified palace must stay queued for the next pass"
+    );
+}

--- a/crates/trusty-memory/src/bm25_repair_tests.rs
+++ b/crates/trusty-memory/src/bm25_repair_tests.rs
@@ -9,9 +9,6 @@
 
 use super::*;
 use trusty_common::memory_core::palace::{Drawer, PalaceId};
-use trusty_common::memory_core::retrieval::PalaceHandle;
-use trusty_common::memory_core::store::kg::KnowledgeGraph;
-use trusty_common::memory_core::store::vector::UsearchStore;
 use uuid::Uuid;
 
 /// Why: a write burst drops many requests for one palace, and each drop calls
@@ -86,12 +83,86 @@ async fn repair_sweep_is_a_noop_without_the_lane() {
     );
 }
 
-/// Why: a palace queued for repair that is no longer resident must be dropped,
-/// not re-queued — otherwise a deleted palace spins in the set forever and
-/// every pass logs about it.
+/// Create a palace that exists ON DISK under `root`.
+///
+/// Why: the eviction test needs the difference between "absent from the LRU"
+/// and "absent from disk" to be real, so the fixture has to go through the
+/// registry's own create path rather than `register`, which only populates the
+/// in-memory cache.
+/// What: creates the palace and pushes one indexable drawer.
+/// Test: used by the two tests below.
+fn create_on_disk(state: &AppState, id: &str) {
+    let handle = state
+        .registry
+        .create_palace(
+            &state.data_root,
+            trusty_common::memory_core::palace::Palace {
+                id: PalaceId::new(id),
+                name: id.to_string(),
+                description: None,
+                created_at: chrono::Utc::now(),
+                data_dir: state.data_root.join(id),
+            },
+        )
+        .expect("create palace on disk");
+    // Persist through redb: the drawer table is rebuilt from there on open.
+    let drawer = Drawer::new(Uuid::new_v4(), "content worth indexing");
+    handle
+        .kg
+        .upsert_drawer_sync(&drawer)
+        .expect("persist drawer");
+    handle.drawers.write().push(drawer);
+}
+
+/// Why (#5048 re-review): this is the same fail-open as the coverage predicate,
+/// one layer out. A dirty palace is exactly the kind that goes idle — its
+/// writes are failing — so it is exactly the kind the LRU evicts. Resolving it
+/// with `registry.get`, a bare cache lookup, dropped it from the queue
+/// permanently and its gap waited for a restart, which is the outcome this
+/// module exists to prevent.
+/// What: builds a palace on disk through one `AppState`, then drives the repair
+/// pass from a SECOND `AppState` over the same data root — a cold registry, so
+/// the palace is on disk and absent from the LRU, which is what eviction looks
+/// like. The pass must hydrate it and (with the lane off) leave it queued.
+/// Test: this test itself. Swap `open_palace` back to `registry.get` and the
+/// palace is dropped, so the queue is empty and this fails.
+#[tokio::test]
+async fn an_evicted_palace_is_rehydrated_not_dropped() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    create_on_disk(&AppState::new(root.clone()), "evicted");
+
+    // A fresh AppState has an empty LRU — the palace is on disk and nowhere in
+    // memory, exactly as after an idle eviction.
+    let cold = AppState::new(root);
+    assert!(
+        cold.registry.list().is_empty(),
+        "precondition: the registry must be cold, so `get` would miss"
+    );
+    mark_dirty(&cold, "evicted");
+
+    let (attempted, repaired) = run_repair_pass(&cold).await;
+
+    assert_eq!(attempted, 1);
+    assert_eq!(repaired, 0, "the lane is off, so nothing can be repaired");
+    assert_eq!(
+        dirty_palaces(&cold),
+        vec!["evicted".to_string()],
+        "an evicted palace must be hydrated and kept queued, never dropped"
+    );
+    assert!(
+        cold.registry.list().iter().any(|p| p.as_str() == "evicted"),
+        "and the pass must actually have opened it"
+    );
+}
+
+/// Why: the counterpart. A palace genuinely deleted from disk must leave the
+/// queue, otherwise it spins forever and every pass logs about it. This is the
+/// discrimination the on-disk listing buys — without it, "evicted" and
+/// "deleted" are indistinguishable and one of the two answers is always wrong.
 /// Test: this test itself.
 #[tokio::test]
-async fn a_vanished_palace_is_dropped_from_the_queue() {
+async fn a_palace_absent_from_disk_is_dropped_from_the_queue() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let state = AppState::new(tmp.path().to_path_buf());
     mark_dirty(&state, "no-such-palace");
@@ -119,15 +190,7 @@ async fn an_unrepairable_palace_stays_queued() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let state = AppState::new(tmp.path().to_path_buf());
 
-    let vs = UsearchStore::new(tmp.path().join("idx.usearch"), 384).expect("vector store");
-    let kg = KnowledgeGraph::open(&tmp.path().join("kg.db")).expect("kg");
-    let handle = PalaceHandle::new(PalaceId::new("resident"), String::new(), vs, kg);
-    handle
-        .drawers
-        .write()
-        .push(Drawer::new(Uuid::new_v4(), "content worth indexing"));
-    state.registry.register(handle);
-
+    create_on_disk(&state, "resident");
     mark_dirty(&state, "resident");
     let (attempted, repaired) = run_repair_pass(&state).await;
 

--- a/crates/trusty-memory/src/bm25_supervisor.rs
+++ b/crates/trusty-memory/src/bm25_supervisor.rs
@@ -131,6 +131,16 @@ const SPAWN_PROBE_TIMEOUT: Duration = Duration::from_millis(3000);
 /// the full 3 s budget when the daemon is ready in ~20 ms.
 const INITIAL_PROBE_INTERVAL: Duration = Duration::from_millis(20);
 
+/// How long the supervisor waits after SIGTERM before escalating to SIGKILL.
+///
+/// Why: strictly greater than the daemon's own `SHUTDOWN_FLUSH_TIMEOUT` (2 s),
+/// because the daemon needs signal delivery, the flush itself, socket cleanup
+/// and exit inside this window. An equal budget means the SIGKILL can land
+/// mid-flush and lose the write window the flush exists to save.
+/// What: 5 seconds.
+/// Test: `sigterm_patience_exceeds_the_daemon_flush_budget`.
+const SIGTERM_PATIENCE: Duration = Duration::from_secs(5);
+
 /// Ceiling on the exponential backoff so we never sleep longer than 250 ms
 /// between probes — at the 3 s budget this gives ~16 probes which is more
 /// than enough to catch any reasonable startup latency.
@@ -214,6 +224,19 @@ pub struct Bm25Supervisor {
     /// Count of children reaped by the cap or the RSS limit (never by
     /// `shutdown`). Observability + test assertion surface.
     reaped: std::sync::atomic::AtomicU64,
+    /// Count of `trusty-bm25-daemon` child processes this supervisor has
+    /// launched.
+    ///
+    /// Why: without it, a double spawn is invisible from outside. Two racing
+    /// callers for one palace both launch a daemon; the loser's bind fails
+    /// with EADDRINUSE and its process dies, and the map still ends up holding
+    /// exactly one entry — so `supervised_count()` reports the same number
+    /// whether the serialisation worked or not. Counting launches is what
+    /// makes `spawn_gate` a claim a test can falsify.
+    /// What: monotonic, incremented once per successful `Command::spawn`
+    /// regardless of whether the socket probe later succeeds.
+    /// Test: `concurrent_callers_for_one_palace_spawn_exactly_one_daemon`.
+    spawned: std::sync::atomic::AtomicU64,
 }
 
 impl Bm25Supervisor {
@@ -250,6 +273,7 @@ impl Bm25Supervisor {
             rss_limit_mb,
             clock: std::sync::atomic::AtomicU64::new(0),
             reaped: std::sync::atomic::AtomicU64::new(0),
+            spawned: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
@@ -273,6 +297,19 @@ impl Bm25Supervisor {
     /// Test: `exceeding_the_cap_reaps_the_least_recently_used`.
     pub fn reaped_count(&self) -> u64 {
         self.reaped.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// How many daemon processes this supervisor has launched.
+    ///
+    /// Why: this is the only externally-visible difference between "spawns are
+    /// serialised" and "spawns race". A double spawn leaves the map holding
+    /// one entry either way — the loser's daemon fails its bind and dies — so
+    /// `supervised_count()` cannot tell the two apart and a test written
+    /// against it passes with `spawn_gate` deleted.
+    /// What: monotonic count of successful `Command::spawn` calls.
+    /// Test: `concurrent_callers_for_one_palace_spawn_exactly_one_daemon`.
+    pub fn spawned_count(&self) -> u64 {
+        self.spawned.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Ensure a `trusty-bm25-daemon` is running for `palace` and return the
@@ -359,6 +396,10 @@ impl Bm25Supervisor {
             locate_bm25_daemon_binary().context("locate trusty-bm25-daemon binary for spawn")?;
         let child = spawn_child(&binary, palace, data_dir)
             .await
+            .inspect(|_| {
+                self.spawned
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            })
             .with_context(|| {
                 format!(
                     "spawn trusty-bm25-daemon {} for palace {palace}",
@@ -421,7 +462,7 @@ impl Bm25Supervisor {
     /// be read) is removed from the map and `None` is returned, so the caller
     /// falls through to a fresh spawn. Removing a corpse does NOT count as a
     /// reap — nothing was reclaimed.
-    /// Test: `dead_child_is_evicted_and_respawned` (e2e).
+    /// Test: `a_dead_child_is_evicted_and_respawned` (e2e).
     async fn lookup_live(&self, palace: &str) -> Option<PathBuf> {
         let stamp = self.tick();
         let mut guard = self.children.lock().await;
@@ -473,11 +514,11 @@ impl Bm25Supervisor {
     /// platform where the read is unavailable. Second, while the survivors
     /// plus `headroom` would exceed `max_live`, the least-recently-used
     /// survivor is selected. Victims are removed from the map under the lock,
-    /// then terminated with the lock released so a 2 s SIGTERM wait never
-    /// blocks another palace's lookup.
+    /// then terminated with the lock released so the SIGTERM wait never blocks
+    /// another palace's lookup.
     /// Test: `exceeding_the_cap_reaps_the_least_recently_used`,
     /// `over_rss_limit_children_are_reaped`,
-    /// `unmeasurable_rss_does_not_reap`.
+    /// `over_rss_limit_is_false_without_a_measurement`.
     async fn enforce_limits(&self, headroom: usize) {
         let mut victims: Vec<(String, ChildHandle, &'static str)> = Vec::new();
         {
@@ -800,9 +841,14 @@ async fn spawn_child(binary: &Path, palace: &str, data_dir: &Path) -> Result<Chi
 /// Send SIGTERM, wait briefly, then SIGKILL if still alive.
 ///
 /// Why: a clean SIGTERM lets the daemon flush its BM25 snapshot and
-/// remove its socket; a SIGKILL is the fallback if the daemon hangs.
-/// 2 s is comfortably larger than the daemon's flush window (the batch
-/// queue's coalescing window is 100 ms by default).
+/// remove its socket; a SIGKILL is the fallback if the daemon hangs. The wait
+/// must exceed the daemon's OWN shutdown budget with margin, not merely match
+/// it: `trusty-bm25-daemon` allows itself 2 s for the shutdown flush
+/// (`lib.rs`'s `SHUTDOWN_FLUSH_TIMEOUT`) and still needs signal delivery,
+/// socket cleanup, and process exit on top. At an equal 2 s the SIGKILL landed
+/// inside the very flush the durability fix added — no corruption, since the
+/// flush is tmp+rename, but the window's writes were lost. 5 s leaves 3 s of
+/// margin over the daemon's worst case.
 /// What: on Unix sends SIGTERM via `nix::sys::signal::kill` would add a
 /// dep, so we use `tokio::process::Child::start_kill` on the doomsday
 /// path and `Child::kill` (which sends SIGKILL) only as a fallback.
@@ -826,8 +872,8 @@ async fn terminate_child(child: &mut Child) -> Result<()> {
         }
     }
 
-    // Give the child up to 2 s to exit on its own.
-    let wait_result = tokio::time::timeout(Duration::from_millis(2000), child.wait()).await;
+    // Give the child longer than its own flush budget to exit on its own.
+    let wait_result = tokio::time::timeout(SIGTERM_PATIENCE, child.wait()).await;
     match wait_result {
         Ok(Ok(status)) => {
             tracing::debug!(?status, "bm25 daemon exited after SIGTERM");
@@ -838,7 +884,9 @@ async fn terminate_child(child: &mut Child) -> Result<()> {
             // Still alive — force-kill. `kill()` here is tokio's
             // method which sends SIGKILL and waits, so by the time it
             // returns the process is definitely gone.
-            tracing::warn!("bm25 daemon ignored SIGTERM after 2s — sending SIGKILL");
+            tracing::warn!(
+                "bm25 daemon ignored SIGTERM after {SIGTERM_PATIENCE:?} — sending SIGKILL"
+            );
             child
                 .kill()
                 .await

--- a/crates/trusty-memory/src/bm25_supervisor.rs
+++ b/crates/trusty-memory/src/bm25_supervisor.rs
@@ -20,12 +20,24 @@
 //! connection. Shutdown SIGTERMs every owned child, waits on each, and
 //! best-effort cleans up its socket file.
 //!
-//! Test: unit tests in this module cover the external-mode opt-out, the
-//! "already running" probe, and the `shutdown` reaping path with no
-//! daemon ever spawned. An `#[ignore]`-tagged integration test in
-//! `tests/bm25_supervisor_e2e.rs` drives a real `trusty-bm25-daemon` child
-//! end-to-end (index + search + shutdown) when the binary is on PATH or
-//! `TRUSTY_BM25_DAEMON_BIN` is set.
+//! The daemon population is BOUNDED (#2845 / #2846). Until this module grew a
+//! cap, the only thing that ever removed an entry from the map was `shutdown`,
+//! so one cross-palace `memory_recall_all` over ~99 palaces would leave 99
+//! child processes resident for the trusty-memory daemon's whole life — and
+//! each one's memory scales with its palace's drawer text, because
+//! `PalaceBm25Index` retains every document's full text in a `BTreeMap`. Two
+//! limits now apply on every `ensure_running`: a cap on concurrently-live
+//! daemons with least-recently-used reaping, and a per-daemon RSS ceiling that
+//! is compared against a real measurement rather than merely declared. Spawns
+//! are serialised so a burst fan-out cannot satisfy the cap per-caller and
+//! violate it in aggregate.
+//!
+//! Test: unit tests in `bm25_supervisor_tests.rs` cover the external-mode
+//! opt-out, the "already running" probe, the `shutdown` reaping path with no
+//! daemon ever spawned, and the two limits. An `#[ignore]`-tagged integration
+//! test in `tests/bm25_supervisor_e2e.rs` drives real `trusty-bm25-daemon`
+//! children end-to-end (index + search + cap eviction + shutdown) when the
+//! binary is on PATH or `TRUSTY_BM25_DAEMON_BIN` is set.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -51,6 +63,55 @@ use trusty_common::bm25_client::{locate_bm25_daemon_binary, socket_path_for_pala
 /// is treated as unset.
 /// Test: `external_mode_skips_spawn` exercises the opt-out branch.
 pub const ENV_EXTERNAL_BM25: &str = "TRUSTY_BM25_EXTERNAL";
+
+/// Environment variable that overrides the cap on concurrently-live daemons.
+///
+/// Why (#2845): `ensure_running` is called once per palace, and one
+/// `memory_recall_all` touches every palace on disk — ~99 on this host. Without
+/// a cap the supervisor would hold 99 child processes for the rest of the
+/// trusty-memory daemon's life, because nothing but `shutdown` ever removed an
+/// entry from the map. Drawer distribution is heavily skewed (one palace holds
+/// 57% of the corpus, ~80 hold nothing), so the working set is a handful of
+/// palaces and a small cap costs almost nothing while bounding the worst case.
+/// What: env var name `TRUSTY_BM25_MAX_DAEMONS`. Parsed as `usize`; values
+/// below 1 and unparseable values fall back to [`DEFAULT_MAX_LIVE_DAEMONS`].
+/// Test: `max_live_daemons_honours_env_override`.
+pub const ENV_MAX_DAEMONS: &str = "TRUSTY_BM25_MAX_DAEMONS";
+
+/// Environment variable that overrides the per-daemon RSS ceiling, in MB.
+///
+/// Why (#2846): trusty-search declared an `rss_limit_mb` and never compared it
+/// against anything; the process grew to 2.2x that limit and was OOM-killed.
+/// A BM25 daemon's memory scales linearly with its palace's drawer text
+/// because `PalaceBm25Index` retains every document's full text in a
+/// `BTreeMap`, so an unbounded palace is an unbounded daemon. This limit is
+/// enforced on every `ensure_running`, not merely reported.
+/// What: env var name `TRUSTY_BM25_RSS_LIMIT_MB`. `0` disables enforcement;
+/// unparseable values fall back to [`DEFAULT_RSS_LIMIT_MB`].
+/// Test: `rss_limit_honours_env_override`, `over_rss_limit_children_are_reaped`.
+pub const ENV_RSS_LIMIT_MB: &str = "TRUSTY_BM25_RSS_LIMIT_MB";
+
+/// Default cap on concurrently-live BM25 daemons.
+///
+/// Why: three covers the realistic working set — the palace you are in, the
+/// one you just cross-referenced, and one in flight — while keeping the
+/// worst case at three subprocesses instead of ninety-nine. Raising it is a
+/// one-env-var decision for operators who genuinely fan out wider.
+/// What: `3`.
+/// Test: `default_cap_is_three`.
+pub const DEFAULT_MAX_LIVE_DAEMONS: usize = 3;
+
+/// Default per-daemon RSS ceiling in megabytes.
+///
+/// Why: the whole drawer corpus across ~99 palaces is single-digit MB of text,
+/// so a single daemon holding more than 512 MB is not holding drawers — it is
+/// leaking, and #2846 is the record of what happens when nobody notices.
+/// Generous enough never to reap a healthy daemon; tight enough that a runaway
+/// one is reaped in seconds rather than at OOM time.
+/// What: `512`.
+/// Test: `rss_limit_honours_env_override` pins the parse; the reap path is
+/// covered by `over_rss_limit_children_are_reaped`.
+pub const DEFAULT_RSS_LIMIT_MB: u64 = 512;
 
 /// Upper bound on how long `ensure_running` waits for the freshly-spawned
 /// daemon's UDS socket to appear and accept a connection.
@@ -89,6 +150,15 @@ const MAX_PROBE_INTERVAL: Duration = Duration::from_millis(250);
 struct ChildHandle {
     child: Child,
     socket_path: PathBuf,
+    /// Monotonic tick of the last `ensure_running` that resolved to this
+    /// child. The LRU victim is the entry with the smallest value.
+    ///
+    /// Why a counter and not an `Instant`: two `ensure_running` calls inside
+    /// the same clock tick would compare equal and make the victim choice
+    /// arbitrary, which is exactly the case a burst fan-out produces. A
+    /// strictly-increasing counter gives a total order regardless of clock
+    /// resolution.
+    last_used: u64,
 }
 
 /// Supervisor that owns BM25 daemon subprocesses, one per palace.
@@ -111,20 +181,98 @@ struct ChildHandle {
 /// `shutdown_with_no_children_is_noop`, and the integration test.
 pub struct Bm25Supervisor {
     children: Mutex<HashMap<String, ChildHandle>>,
+    /// Serialises the spawn sequence (re-check → enforce limits → spawn →
+    /// probe → insert).
+    ///
+    /// Why (#2845): the map mutex is released before spawning so slow startups
+    /// for one palace don't block lookups for another, but that left two gaps.
+    /// First, two concurrent calls for the SAME palace could both reach the
+    /// spawn step and the second insert would silently drop the first child.
+    /// Second, a cross-palace fan-out could have every palace in flight at
+    /// once, so a cap checked per-call would be satisfied by each caller
+    /// individually and violated in aggregate — the same shape as the
+    /// unbounded fan-out that 503-stormed trusty-search. Serialising spawns
+    /// closes both: the cap is evaluated against a map nobody else is
+    /// mutating, and a double spawn is impossible because the second caller
+    /// re-checks the map after acquiring.
+    /// The cost is that a cold N-palace fan-out spawns serially. That is the
+    /// intended trade — with a cap of three, a parallel fan-out would spend
+    /// its time evicting daemons it just spawned.
+    spawn_gate: Mutex<()>,
+    /// Cap on concurrently-live daemons. Resolved once at construction.
+    max_live: usize,
+    /// Per-daemon RSS ceiling in MB. `None` disables enforcement.
+    ///
+    /// Why `Option` and not a sentinel `0`: "no ceiling" and "a ceiling of
+    /// zero" are opposite instructions, and a single `u64` cannot say both.
+    /// Encoding disabled-ness in the type keeps the operator's `=0` opt-out
+    /// from colliding with the tightest possible limit, which is the value the
+    /// enforcement tests need in order to be deterministic.
+    rss_limit_mb: Option<u64>,
+    /// Monotonic tick source for `ChildHandle::last_used`.
+    clock: std::sync::atomic::AtomicU64,
+    /// Count of children reaped by the cap or the RSS limit (never by
+    /// `shutdown`). Observability + test assertion surface.
+    reaped: std::sync::atomic::AtomicU64,
 }
 
 impl Bm25Supervisor {
-    /// Construct an empty supervisor.
+    /// Construct an empty supervisor with limits read from the environment.
     ///
     /// Why: cheap, allocation-light constructor so the supervisor can be
     /// built unconditionally at startup and only allocate when a palace
-    /// first asks for a daemon.
-    /// What: returns a supervisor with an empty per-palace map.
-    /// Test: trivially exercised by every other test in this module.
+    /// first asks for a daemon. Resolving the limits here (rather than on
+    /// each `ensure_running`) means a mid-flight env mutation cannot make the
+    /// cap wobble between two concurrent calls.
+    /// What: returns a supervisor with an empty per-palace map and the
+    /// caps from [`ENV_MAX_DAEMONS`] / [`ENV_RSS_LIMIT_MB`], falling back to
+    /// [`DEFAULT_MAX_LIVE_DAEMONS`] / [`DEFAULT_RSS_LIMIT_MB`].
+    /// Test: `default_cap_is_three`, `max_live_daemons_honours_env_override`.
     pub fn new() -> Self {
+        Self::with_limits(max_live_from_env(), rss_limit_from_env())
+    }
+
+    /// Construct a supervisor with explicit limits, bypassing the environment.
+    ///
+    /// Why: the limit-enforcement tests must pin a cap of 1 or an RSS ceiling
+    /// of 1 MB without mutating process-global env vars that sibling tests
+    /// race against. Production code should use [`Self::new`].
+    /// What: `max_live` is clamped to at least 1 — a cap of zero would reap
+    /// every daemon the instant it spawned, which is a wedge, not a limit.
+    /// `rss_limit_mb: None` disables RSS enforcement; `Some(n)` reaps any child
+    /// measuring at or above `n` MB.
+    /// Test: `cap_of_one_keeps_a_single_daemon_live`.
+    pub fn with_limits(max_live: usize, rss_limit_mb: Option<u64>) -> Self {
         Self {
             children: Mutex::new(HashMap::new()),
+            spawn_gate: Mutex::new(()),
+            max_live: max_live.max(1),
+            rss_limit_mb,
+            clock: std::sync::atomic::AtomicU64::new(0),
+            reaped: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    /// Cap on concurrently-live daemons this supervisor enforces.
+    pub fn max_live(&self) -> usize {
+        self.max_live
+    }
+
+    /// Per-daemon RSS ceiling in MB; `None` means enforcement is off.
+    pub fn rss_limit_mb(&self) -> Option<u64> {
+        self.rss_limit_mb
+    }
+
+    /// How many children have been reaped by the cap or the RSS limit.
+    ///
+    /// Why: "the cap is configured" and "the cap did something" are different
+    /// claims, and #2846 is the record of a limit that only ever made the
+    /// first one. This counter makes the second checkable — by a test, and by
+    /// an operator reading it out of the daemon.
+    /// What: monotonic count; `shutdown` does not increment it.
+    /// Test: `exceeding_the_cap_reaps_the_least_recently_used`.
+    pub fn reaped_count(&self) -> u64 {
+        self.reaped.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Ensure a `trusty-bm25-daemon` is running for `palace` and return the
@@ -164,44 +312,29 @@ impl Bm25Supervisor {
             return Ok(socket_path);
         }
 
-        // ── (2) Already-supervised path ────────────────────────────────────
-        // Take the lock briefly to inspect / evict the stored child. We
-        // drop the guard before spawning so concurrent calls for OTHER
-        // palaces don't queue behind a slow startup probe.
-        {
-            let mut guard = self.children.lock().await;
-            if let Some(entry) = guard.get_mut(palace) {
-                match entry.child.try_wait() {
-                    Ok(None) => {
-                        // Still alive — happy path.
-                        tracing::trace!(
-                            palace = %palace,
-                            socket = %entry.socket_path.display(),
-                            "bm25 supervisor: child already running"
-                        );
-                        return Ok(entry.socket_path.clone());
-                    }
-                    Ok(Some(status)) => {
-                        // Exited — log and evict so we can re-spawn below.
-                        tracing::warn!(
-                            palace = %palace,
-                            ?status,
-                            "bm25 daemon exited unexpectedly — attempting one restart"
-                        );
-                        guard.remove(palace);
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            palace = %palace,
-                            "bm25 supervisor: try_wait failed: {e:#} — evicting and retrying"
-                        );
-                        guard.remove(palace);
-                    }
-                }
-            }
+        // ── (2) Already-supervised fast path ───────────────────────────────
+        // Take the lock briefly to inspect the stored child. We drop the
+        // guard before spawning so concurrent calls for OTHER palaces don't
+        // queue behind a slow startup probe.
+        if let Some(path) = self.lookup_live(palace).await {
+            return Ok(path);
         }
 
-        // ── (3) Socket-already-bound check ─────────────────────────────────
+        // ── (3) Spawn, serialised ──────────────────────────────────────────
+        // Everything from here down mutates the daemon population, so it runs
+        // under the spawn gate — see the field's doc comment for why the map
+        // mutex alone is not enough.
+        let _spawn = self.spawn_gate.lock().await;
+
+        // Re-check under the gate: a concurrent caller for this same palace
+        // may have spawned it while we waited. Without this, the cap could be
+        // exceeded by exactly the number of racing callers, and the loser's
+        // child would be silently dropped by the map insert.
+        if let Some(path) = self.lookup_live(palace).await {
+            return Ok(path);
+        }
+
+        // ── (3a) Socket-already-bound check ────────────────────────────────
         // If some other process (a previously-spawned daemon we lost the
         // handle to, or an operator-managed launchd job that forgot to set
         // TRUSTY_BM25_EXTERNAL) is already serving on this socket, adopt
@@ -214,6 +347,12 @@ impl Bm25Supervisor {
             );
             return Ok(socket_path);
         }
+
+        // ── (3b) Enforce the limits BEFORE adding to the population ────────
+        // Order matters: reaping after the spawn would let the population
+        // momentarily exceed the cap, and under a fan-out that moment is when
+        // every other caller is also spawning.
+        self.enforce_limits(1).await;
 
         // ── (4) Spawn ──────────────────────────────────────────────────────
         let binary =
@@ -254,9 +393,137 @@ impl Bm25Supervisor {
             ChildHandle {
                 child,
                 socket_path: socket_path.clone(),
+                last_used: self.tick(),
             },
         );
+        let live = guard.len();
+        drop(guard);
+        tracing::debug!(live, cap = self.max_live, "bm25 supervisor: daemon count");
         Ok(socket_path)
+    }
+
+    /// Next value of the monotonic LRU clock.
+    fn tick(&self) -> u64 {
+        self.clock
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            .wrapping_add(1)
+    }
+
+    /// Resolve `palace` to a live child's socket, refreshing its LRU stamp.
+    ///
+    /// Why: `ensure_running` needs this answer twice — once on the fast path
+    /// and once under the spawn gate — and the two must agree exactly,
+    /// including the dead-child eviction. Two copies would be two chances to
+    /// drift.
+    /// What: returns `Some(socket_path)` when the stored child is still
+    /// running, and stamps it as most-recently-used so the LRU victim choice
+    /// reflects real traffic. A child that has exited (or whose status cannot
+    /// be read) is removed from the map and `None` is returned, so the caller
+    /// falls through to a fresh spawn. Removing a corpse does NOT count as a
+    /// reap — nothing was reclaimed.
+    /// Test: `dead_child_is_evicted_and_respawned` (e2e).
+    async fn lookup_live(&self, palace: &str) -> Option<PathBuf> {
+        let stamp = self.tick();
+        let mut guard = self.children.lock().await;
+        let entry = guard.get_mut(palace)?;
+        match entry.child.try_wait() {
+            Ok(None) => {
+                entry.last_used = stamp;
+                let path = entry.socket_path.clone();
+                tracing::trace!(
+                    palace = %palace,
+                    socket = %path.display(),
+                    "bm25 supervisor: child already running"
+                );
+                Some(path)
+            }
+            Ok(Some(status)) => {
+                tracing::warn!(
+                    palace = %palace,
+                    ?status,
+                    "bm25 daemon exited unexpectedly — attempting one restart"
+                );
+                guard.remove(palace);
+                None
+            }
+            Err(e) => {
+                tracing::warn!(
+                    palace = %palace,
+                    "bm25 supervisor: try_wait failed: {e:#} — evicting and retrying"
+                );
+                guard.remove(palace);
+                None
+            }
+        }
+    }
+
+    /// Bring the live-daemon population within both limits, leaving room for
+    /// `headroom` more.
+    ///
+    /// Why (#2845 + #2846): these are the two failures trusty-search shipped —
+    /// an unbounded fan-out and a memory limit that was declared but never
+    /// compared against anything. Enforcing both in one place, on the path
+    /// that grows the population, is what makes them limits rather than
+    /// documentation.
+    /// What: two passes. First, every child whose measured RSS exceeds
+    /// `rss_limit_mb` is selected regardless of recency — a leaking daemon is
+    /// the wrong thing to keep no matter how recently it was used. A child
+    /// whose RSS cannot be measured is left alone: `None` means "no reading",
+    /// and reaping on a failed measurement would kill healthy daemons on any
+    /// platform where the read is unavailable. Second, while the survivors
+    /// plus `headroom` would exceed `max_live`, the least-recently-used
+    /// survivor is selected. Victims are removed from the map under the lock,
+    /// then terminated with the lock released so a 2 s SIGTERM wait never
+    /// blocks another palace's lookup.
+    /// Test: `exceeding_the_cap_reaps_the_least_recently_used`,
+    /// `over_rss_limit_children_are_reaped`,
+    /// `unmeasurable_rss_does_not_reap`.
+    async fn enforce_limits(&self, headroom: usize) {
+        let mut victims: Vec<(String, ChildHandle, &'static str)> = Vec::new();
+        {
+            let mut guard = self.children.lock().await;
+
+            let over: Vec<String> = guard
+                .iter()
+                .filter(|(_, h)| over_rss_limit(h.child.id(), self.rss_limit_mb))
+                .map(|(p, _)| p.clone())
+                .collect();
+            for palace in over {
+                if let Some(h) = guard.remove(&palace) {
+                    victims.push((palace, h, "rss"));
+                }
+            }
+
+            while guard.len() + headroom > self.max_live {
+                let Some(lru) = guard
+                    .iter()
+                    .min_by_key(|(_, h)| h.last_used)
+                    .map(|(p, _)| p.clone())
+                else {
+                    break;
+                };
+                if let Some(h) = guard.remove(&lru) {
+                    victims.push((lru, h, "cap"));
+                }
+            }
+        }
+
+        for (palace, mut handle, reason) in victims {
+            tracing::info!(
+                palace = %palace,
+                reason,
+                cap = self.max_live,
+                rss_limit_mb = ?self.rss_limit_mb,
+                pid = ?handle.child.id(),
+                "bm25 supervisor: reaping daemon to stay within limits"
+            );
+            if let Err(e) = terminate_child(&mut handle.child).await {
+                tracing::warn!(palace = %palace, "bm25 daemon reap error: {e:#}");
+            }
+            remove_socket_file(&palace, &handle.socket_path).await;
+            self.reaped
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
     }
 
     /// Graceful shutdown: SIGTERM all owned daemons, reap them, and clean
@@ -294,19 +561,7 @@ impl Bm25Supervisor {
                     "bm25 daemon shutdown encountered an error: {e:#}"
                 );
             }
-            // Best-effort socket cleanup. The daemon's own SIGTERM handler
-            // unlinks the socket as part of clean exit, but if we had to
-            // SIGKILL it the file is still on disk and will EADDRINUSE
-            // the next spawn.
-            if let Err(e) = tokio::fs::remove_file(&entry.socket_path).await {
-                if e.kind() != std::io::ErrorKind::NotFound {
-                    tracing::debug!(
-                        palace = %palace,
-                        socket = %entry.socket_path.display(),
-                        "could not remove bm25 daemon socket (likely already cleaned up): {e}"
-                    );
-                }
-            }
+            remove_socket_file(&palace, &entry.socket_path).await;
         }
     }
 
@@ -350,6 +605,103 @@ impl std::fmt::Debug for Bm25Supervisor {
 /// branch.
 fn external_mode_enabled() -> bool {
     std::env::var(ENV_EXTERNAL_BM25).as_deref() == Ok("1")
+}
+
+/// Best-effort unlink of a daemon's socket file.
+///
+/// Why: the daemon's own SIGTERM handler unlinks the socket on a clean exit,
+/// but a SIGKILLed daemon leaves the file behind and the next spawn for that
+/// palace then fails to bind with EADDRINUSE. Both the shutdown path and the
+/// limit-enforcement reap path need this, and a reaped palace is exactly the
+/// one most likely to be spawned again shortly.
+/// What: `remove_file`; `NotFound` is the expected clean-exit case and is not
+/// logged. Any other error is logged at `debug!` and ignored — a stale socket
+/// costs one failed spawn, not correctness.
+/// Test: covered by `bm25_supervisor_e2e`'s shutdown assertion.
+async fn remove_socket_file(palace: &str, socket_path: &Path) {
+    if let Err(e) = tokio::fs::remove_file(socket_path).await {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            tracing::debug!(
+                palace = %palace,
+                socket = %socket_path.display(),
+                "could not remove bm25 daemon socket (likely already cleaned up): {e}"
+            );
+        }
+    }
+}
+
+/// Decide whether a child has breached the RSS ceiling.
+///
+/// Why (#2846): the whole point of this limit is that it is compared against a
+/// real measurement, so the two ways a measurement can be missing need an
+/// explicit, tested answer rather than whatever `unwrap_or` happens to do. A
+/// child with no pid has already exited — there is nothing to reclaim. A pid
+/// whose RSS cannot be read yields `None`, which means "no reading", NOT
+/// "zero"; reaping on it would kill every healthy daemon on any platform where
+/// the read is unavailable, turning a memory guardrail into an outage.
+/// What: `false` when enforcement is off, when the pid is gone, or when the
+/// reading is unavailable. Otherwise `true` iff the measured MB is at or above
+/// the ceiling. Pure — takes the pid rather than the handle so it is testable
+/// without a live process.
+/// Test: `over_rss_limit_is_false_without_a_measurement`,
+/// `over_rss_limit_is_false_when_disabled`.
+fn over_rss_limit(pid: Option<u32>, limit_mb: Option<u64>) -> bool {
+    let Some(limit) = limit_mb else {
+        return false;
+    };
+    let Some(pid) = pid else {
+        return false;
+    };
+    trusty_common::sys_metrics::process_rss_mb(pid).is_some_and(|mb| mb >= limit)
+}
+
+/// Resolve the live-daemon cap from [`ENV_MAX_DAEMONS`].
+///
+/// Why: an operator who fans out wider than the default working set needs a
+/// knob, and a knob that silently ignores a typo is worse than no knob — hence
+/// the explicit warn on an unparseable value rather than a quiet default.
+/// What: parses the env var as `usize`; `0` and unparseable values fall back
+/// to [`DEFAULT_MAX_LIVE_DAEMONS`].
+/// Test: `max_live_daemons_honours_env_override`.
+fn max_live_from_env() -> usize {
+    match std::env::var(ENV_MAX_DAEMONS) {
+        Ok(raw) => match raw.trim().parse::<usize>() {
+            Ok(n) if n >= 1 => n,
+            _ => {
+                tracing::warn!(
+                    "{ENV_MAX_DAEMONS}={raw:?} is not a positive integer — \
+                     using default {DEFAULT_MAX_LIVE_DAEMONS}"
+                );
+                DEFAULT_MAX_LIVE_DAEMONS
+            }
+        },
+        Err(_) => DEFAULT_MAX_LIVE_DAEMONS,
+    }
+}
+
+/// Resolve the per-daemon RSS ceiling from [`ENV_RSS_LIMIT_MB`].
+///
+/// Why: same knob-with-a-typo argument as [`max_live_from_env`], plus one
+/// specific to this limit — `0` must be an explicit, documented way to turn
+/// enforcement off, not an accident of parsing.
+/// What: parses as `u64`; `0` maps to `None` (enforcement off); unparseable
+/// values fall back to [`DEFAULT_RSS_LIMIT_MB`].
+/// Test: `rss_limit_honours_env_override`.
+fn rss_limit_from_env() -> Option<u64> {
+    match std::env::var(ENV_RSS_LIMIT_MB) {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(0) => None,
+            Ok(n) => Some(n),
+            Err(_) => {
+                tracing::warn!(
+                    "{ENV_RSS_LIMIT_MB}={raw:?} is not an integer — \
+                     using default {DEFAULT_RSS_LIMIT_MB}"
+                );
+                Some(DEFAULT_RSS_LIMIT_MB)
+            }
+        },
+        Err(_) => Some(DEFAULT_RSS_LIMIT_MB),
+    }
 }
 
 /// Quick non-blocking probe — opens a `UnixStream`, immediately closes it.
@@ -497,223 +849,5 @@ async fn terminate_child(child: &mut Child) -> Result<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use tokio::sync::Mutex as TokioMutex;
-
-    /// Process-wide lock that serialises every test in this module which
-    /// touches the `TRUSTY_BM25_EXTERNAL` or `TRUSTY_BM25_DAEMON_BIN` env
-    /// vars.
-    ///
-    /// Why: cargo runs tests in parallel inside the same process, and any
-    /// two tests that mutate the same env var race each other. The lock
-    /// keeps the supervisor's env mutation isolated from sibling tests
-    /// without slowing the whole suite via `--test-threads=1`. We use
-    /// `tokio::sync::Mutex` here (not `std::sync::Mutex`) because the
-    /// guard is held across `.await` calls in `ensure_running`; holding a
-    /// std-sync guard across an await would block the runtime and is
-    /// flagged by `clippy::await_holding_lock`.
-    /// What: a static `OnceLock<Arc<TokioMutex<()>>>` initialised on first
-    /// access so we don't need a runtime to construct it. Each call
-    /// returns a clone of the `Arc` — cheap and lockable.
-    /// Test: used by every env-mutating test below.
-    fn env_lock() -> std::sync::Arc<TokioMutex<()>> {
-        static LOCK: std::sync::OnceLock<std::sync::Arc<TokioMutex<()>>> =
-            std::sync::OnceLock::new();
-        LOCK.get_or_init(|| std::sync::Arc::new(TokioMutex::new(())))
-            .clone()
-    }
-
-    /// Why: the supervisor must start with an empty map so the first
-    /// `ensure_running` call always takes the cold-path branch.
-    /// What: constructs a supervisor and asserts no children are tracked.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn supervisor_starts_empty() {
-        let sup = Bm25Supervisor::new();
-        assert_eq!(sup.supervised_count().await, 0);
-    }
-
-    /// Why: `Default::default()` must behave like `new()`. Catches a
-    /// regression where someone adds state to `new` and forgets to mirror
-    /// it on `Default`.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn supervisor_default_matches_new() {
-        let sup: Bm25Supervisor = Default::default();
-        assert_eq!(sup.supervised_count().await, 0);
-    }
-
-    /// Why: in external-management mode `ensure_running` must NOT spawn
-    /// anything; it must just hand back the socket path the caller would
-    /// have ended up at if it had spawned. Pinning this guards against a
-    /// future regression that accidentally fires off a child even with the
-    /// env var set.
-    /// What: set `TRUSTY_BM25_EXTERNAL=1`, call `ensure_running` against a
-    /// definitely-unused palace + a nonexistent data dir, assert no child
-    /// is tracked and the returned path matches the canonical resolver.
-    /// Test: this test itself. The env mutation is serialised by the
-    /// guard because Rust tests run in parallel inside the same process.
-    #[tokio::test]
-    async fn external_mode_skips_spawn() {
-        let lock = env_lock();
-        let _env = lock.lock().await;
-        let _guard = EnvGuard::set(ENV_EXTERNAL_BM25, "1");
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let sup = Bm25Supervisor::new();
-        // Short palace name so the resolved socket path stays well under
-        // the kernel's `sun_path` limit (~104 bytes on macOS).
-        let palace = "ext-skip";
-        let path = sup
-            .ensure_running(palace, tmp.path())
-            .await
-            .expect("external mode must return socket path without spawning");
-        assert_eq!(path, socket_path_for_palace(palace));
-        assert_eq!(
-            sup.supervised_count().await,
-            0,
-            "external mode must not register a child"
-        );
-    }
-
-    /// Why: if some other process is already serving on the canonical
-    /// socket path (think: stale daemon from a previous run, or an
-    /// operator-managed launchd job that forgot the `TRUSTY_BM25_EXTERNAL`
-    /// env var), spawning a second daemon would EADDRINUSE. The supervisor
-    /// must adopt the existing socket and return without spawning.
-    /// What: bind a dummy `UnixListener` at the canonical socket path for
-    /// a test palace, call `ensure_running`, assert no child is tracked
-    /// and the returned path matches.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn already_running_skips_spawn() {
-        let lock = env_lock();
-        let _env = lock.lock().await;
-        // Ensure we don't accidentally pick up an external-mode flag from
-        // a sibling test that ran first.
-        let _g = EnvGuard::remove(ENV_EXTERNAL_BM25);
-        // Use a very short palace name. The canonical socket path is
-        // `$TMPDIR/trusty-bm25-<palace>.sock`, and macOS' `$TMPDIR`
-        // (`/var/folders/.../T/`) is already long, so we keep the palace
-        // fragment to a handful of characters to avoid SUN_LEN errors.
-        // Use the low bits of process PID to disambiguate concurrent
-        // test runs.
-        let palace = format!("a{:x}", std::process::id() & 0xffff);
-        let socket = socket_path_for_palace(&palace);
-        // Clean up any leftover socket from a previous failed test.
-        let _ = std::fs::remove_file(&socket);
-        let listener =
-            tokio::net::UnixListener::bind(&socket).expect("bind dummy listener at canonical path");
-
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let sup = Bm25Supervisor::new();
-        let path = sup
-            .ensure_running(&palace, tmp.path())
-            .await
-            .expect("ensure_running must adopt existing socket");
-        assert_eq!(path, socket);
-        assert_eq!(
-            sup.supervised_count().await,
-            0,
-            "adoption path must not register a child"
-        );
-
-        drop(listener);
-        let _ = std::fs::remove_file(&socket);
-    }
-
-    /// Why: `shutdown` on a fresh supervisor must not panic, error, or
-    /// log anything alarming. Operators will inevitably call it at exit
-    /// even when no palace has touched BM25 yet.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn shutdown_with_no_children_is_noop() {
-        let sup = Bm25Supervisor::new();
-        sup.shutdown().await;
-        assert_eq!(sup.supervised_count().await, 0);
-    }
-
-    /// Why: `Bm25Supervisor` is shared via `Arc` and must be `Send + Sync`
-    /// so it can be cloned into background tasks and async handlers.
-    /// Compile-fail of this test means the type bounds regressed.
-    /// What: a static assertion via a const fn that requires `Send + Sync`.
-    /// Test: this test itself.
-    #[test]
-    fn supervisor_is_send_and_sync() {
-        fn assert_send_sync<T: Send + Sync>() {}
-        assert_send_sync::<Bm25Supervisor>();
-    }
-
-    /// Why: the probe must report `false` for a path with nothing bound,
-    /// not panic or block forever.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn probe_returns_false_for_missing_socket() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let missing = tmp.path().join("nonexistent.sock");
-        assert!(!probe_socket(&missing).await);
-    }
-
-    /// Why: the probe must report `true` immediately when something is
-    /// already accepting connections at that path. Pins the happy path.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn probe_returns_true_for_bound_socket() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let sock = tmp.path().join("listen.sock");
-        let _listener =
-            tokio::net::UnixListener::bind(&sock).expect("bind listener for probe test");
-        assert!(probe_socket(&sock).await);
-    }
-
-    /// RAII guard for serialised env-var mutation in tests.
-    ///
-    /// Why: cargo test runs tests in the same process by default, so
-    /// `std::env::set_var` mutations leak between tests unless restored
-    /// on drop. This is the same pattern the supervisor unit tests in
-    /// `trusty-search/src/service/embedder_supervisor.rs` use.
-    /// What: captures the prior value on construction, restores or
-    /// removes on drop. SAFETY notes inlined at each unsafe block.
-    /// Test: used by every env-touching test in this module.
-    struct EnvGuard {
-        key: String,
-        prev: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &str, value: &str) -> Self {
-            let prev = std::env::var(key).ok();
-            // SAFETY: test-only env mutation; serialised by the fact that
-            // each test takes the guard before mutating, and the Drop
-            // impl restores on scope exit.
-            unsafe { std::env::set_var(key, value) }
-            Self {
-                key: key.to_string(),
-                prev,
-            }
-        }
-
-        fn remove(key: &str) -> Self {
-            let prev = std::env::var(key).ok();
-            // SAFETY: same invariant as `set`.
-            unsafe { std::env::remove_var(key) }
-            Self {
-                key: key.to_string(),
-                prev,
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            // SAFETY: test teardown; restoring the captured prior value
-            // is the inverse of the unsafe mutation done at construction.
-            unsafe {
-                match &self.prev {
-                    Some(v) => std::env::set_var(&self.key, v),
-                    None => std::env::remove_var(&self.key),
-                }
-            }
-        }
-    }
-}
+#[path = "bm25_supervisor_tests.rs"]
+mod tests;

--- a/crates/trusty-memory/src/bm25_supervisor_tests.rs
+++ b/crates/trusty-memory/src/bm25_supervisor_tests.rs
@@ -471,11 +471,10 @@ async fn shutdown_does_not_count_as_a_limit_reap() {
 /// Test: this test itself.
 #[test]
 fn sigterm_patience_exceeds_the_daemon_flush_budget() {
-    // The daemon's own budget. Not importable — `trusty-memory` depends on the
-    // daemon crate only for the bundled binary shim, and the constant is
-    // private — so it is restated with a pointer, the same way the BM25 client
-    // restates the wire method names.
-    let daemon_flush_budget = Duration::from_secs(2);
+    // Imported, not restated: a hardcoded copy stays equal to itself while the
+    // daemon's real budget drifts, so it could never detect the drift it exists
+    // to name.
+    let daemon_flush_budget = trusty_bm25_daemon::SHUTDOWN_FLUSH_TIMEOUT;
     assert!(
         SIGTERM_PATIENCE > daemon_flush_budget,
         "the supervisor must outwait the daemon's flush: {SIGTERM_PATIENCE:?} vs \

--- a/crates/trusty-memory/src/bm25_supervisor_tests.rs
+++ b/crates/trusty-memory/src/bm25_supervisor_tests.rs
@@ -1,0 +1,462 @@
+//! Unit tests for the [`super::Bm25Supervisor`] bounded process model.
+//!
+//! Why: split out of `bm25_supervisor.rs` so the production module stays under
+//! the 500-SLOC cap once the daemon cap, LRU reaping, and RSS enforcement
+//! landed. Wired back in via `#[path] mod tests;`, the same way
+//! `worker_liveness_tests.rs` is.
+//! What: covers the external-mode opt-out, socket adoption, idempotent
+//! shutdown, the socket probe, and the bounded-process-model limits.
+//! Test: this *is* the test file.
+
+use super::*;
+use tokio::sync::Mutex as TokioMutex;
+
+/// Process-wide lock that serialises every test in this module which
+/// touches the `TRUSTY_BM25_EXTERNAL` or `TRUSTY_BM25_DAEMON_BIN` env
+/// vars.
+///
+/// Why: cargo runs tests in parallel inside the same process, and any
+/// two tests that mutate the same env var race each other. The lock
+/// keeps the supervisor's env mutation isolated from sibling tests
+/// without slowing the whole suite via `--test-threads=1`. We use
+/// `tokio::sync::Mutex` here (not `std::sync::Mutex`) because the
+/// guard is held across `.await` calls in `ensure_running`; holding a
+/// std-sync guard across an await would block the runtime and is
+/// flagged by `clippy::await_holding_lock`.
+/// What: a static `OnceLock<Arc<TokioMutex<()>>>` initialised on first
+/// access so we don't need a runtime to construct it. Each call
+/// returns a clone of the `Arc` — cheap and lockable.
+/// Test: used by every env-mutating test below.
+fn env_lock() -> std::sync::Arc<TokioMutex<()>> {
+    static LOCK: std::sync::OnceLock<std::sync::Arc<TokioMutex<()>>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Arc::new(TokioMutex::new(())))
+        .clone()
+}
+
+/// Why: the supervisor must start with an empty map so the first
+/// `ensure_running` call always takes the cold-path branch.
+/// What: constructs a supervisor and asserts no children are tracked.
+/// Test: this test itself.
+#[tokio::test]
+async fn supervisor_starts_empty() {
+    let sup = Bm25Supervisor::new();
+    assert_eq!(sup.supervised_count().await, 0);
+}
+
+/// Why: `Default::default()` must behave like `new()`. Catches a
+/// regression where someone adds state to `new` and forgets to mirror
+/// it on `Default`.
+/// Test: this test itself.
+#[tokio::test]
+async fn supervisor_default_matches_new() {
+    let sup: Bm25Supervisor = Default::default();
+    assert_eq!(sup.supervised_count().await, 0);
+}
+
+/// Why: in external-management mode `ensure_running` must NOT spawn
+/// anything; it must just hand back the socket path the caller would
+/// have ended up at if it had spawned. Pinning this guards against a
+/// future regression that accidentally fires off a child even with the
+/// env var set.
+/// What: set `TRUSTY_BM25_EXTERNAL=1`, call `ensure_running` against a
+/// definitely-unused palace + a nonexistent data dir, assert no child
+/// is tracked and the returned path matches the canonical resolver.
+/// Test: this test itself. The env mutation is serialised by the
+/// guard because Rust tests run in parallel inside the same process.
+#[tokio::test]
+async fn external_mode_skips_spawn() {
+    let lock = env_lock();
+    let _env = lock.lock().await;
+    let _guard = EnvGuard::set(ENV_EXTERNAL_BM25, "1");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sup = Bm25Supervisor::new();
+    // Short palace name so the resolved socket path stays well under
+    // the kernel's `sun_path` limit (~104 bytes on macOS).
+    let palace = "ext-skip";
+    let path = sup
+        .ensure_running(palace, tmp.path())
+        .await
+        .expect("external mode must return socket path without spawning");
+    assert_eq!(path, socket_path_for_palace(palace));
+    assert_eq!(
+        sup.supervised_count().await,
+        0,
+        "external mode must not register a child"
+    );
+}
+
+/// Why: if some other process is already serving on the canonical
+/// socket path (think: stale daemon from a previous run, or an
+/// operator-managed launchd job that forgot the `TRUSTY_BM25_EXTERNAL`
+/// env var), spawning a second daemon would EADDRINUSE. The supervisor
+/// must adopt the existing socket and return without spawning.
+/// What: bind a dummy `UnixListener` at the canonical socket path for
+/// a test palace, call `ensure_running`, assert no child is tracked
+/// and the returned path matches.
+/// Test: this test itself.
+#[tokio::test]
+async fn already_running_skips_spawn() {
+    let lock = env_lock();
+    let _env = lock.lock().await;
+    // Ensure we don't accidentally pick up an external-mode flag from
+    // a sibling test that ran first.
+    let _g = EnvGuard::remove(ENV_EXTERNAL_BM25);
+    // Use a very short palace name. The canonical socket path is
+    // `$TMPDIR/trusty-bm25-<palace>.sock`, and macOS' `$TMPDIR`
+    // (`/var/folders/.../T/`) is already long, so we keep the palace
+    // fragment to a handful of characters to avoid SUN_LEN errors.
+    // Use the low bits of process PID to disambiguate concurrent
+    // test runs.
+    let palace = format!("a{:x}", std::process::id() & 0xffff);
+    let socket = socket_path_for_palace(&palace);
+    // Clean up any leftover socket from a previous failed test.
+    let _ = std::fs::remove_file(&socket);
+    let listener =
+        tokio::net::UnixListener::bind(&socket).expect("bind dummy listener at canonical path");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sup = Bm25Supervisor::new();
+    let path = sup
+        .ensure_running(&palace, tmp.path())
+        .await
+        .expect("ensure_running must adopt existing socket");
+    assert_eq!(path, socket);
+    assert_eq!(
+        sup.supervised_count().await,
+        0,
+        "adoption path must not register a child"
+    );
+
+    drop(listener);
+    let _ = std::fs::remove_file(&socket);
+}
+
+/// Why: `shutdown` on a fresh supervisor must not panic, error, or
+/// log anything alarming. Operators will inevitably call it at exit
+/// even when no palace has touched BM25 yet.
+/// Test: this test itself.
+#[tokio::test]
+async fn shutdown_with_no_children_is_noop() {
+    let sup = Bm25Supervisor::new();
+    sup.shutdown().await;
+    assert_eq!(sup.supervised_count().await, 0);
+}
+
+/// Why: `Bm25Supervisor` is shared via `Arc` and must be `Send + Sync`
+/// so it can be cloned into background tasks and async handlers.
+/// Compile-fail of this test means the type bounds regressed.
+/// What: a static assertion via a const fn that requires `Send + Sync`.
+/// Test: this test itself.
+#[test]
+fn supervisor_is_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Bm25Supervisor>();
+}
+
+/// Why: the probe must report `false` for a path with nothing bound,
+/// not panic or block forever.
+/// Test: this test itself.
+#[tokio::test]
+async fn probe_returns_false_for_missing_socket() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let missing = tmp.path().join("nonexistent.sock");
+    assert!(!probe_socket(&missing).await);
+}
+
+/// Why: the probe must report `true` immediately when something is
+/// already accepting connections at that path. Pins the happy path.
+/// Test: this test itself.
+#[tokio::test]
+async fn probe_returns_true_for_bound_socket() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sock = tmp.path().join("listen.sock");
+    let _listener = tokio::net::UnixListener::bind(&sock).expect("bind listener for probe test");
+    assert!(probe_socket(&sock).await);
+}
+
+/// RAII guard for serialised env-var mutation in tests.
+///
+/// Why: cargo test runs tests in the same process by default, so
+/// `std::env::set_var` mutations leak between tests unless restored
+/// on drop. This is the same pattern the supervisor unit tests in
+/// `trusty-search/src/service/embedder_supervisor.rs` use.
+/// What: captures the prior value on construction, restores or
+/// removes on drop. SAFETY notes inlined at each unsafe block.
+/// Test: used by every env-touching test in this module.
+struct EnvGuard {
+    key: String,
+    prev: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: test-only env mutation; serialised by the fact that
+        // each test takes the guard before mutating, and the Drop
+        // impl restores on scope exit.
+        unsafe { std::env::set_var(key, value) }
+        Self {
+            key: key.to_string(),
+            prev,
+        }
+    }
+
+    fn remove(key: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: same invariant as `set`.
+        unsafe { std::env::remove_var(key) }
+        Self {
+            key: key.to_string(),
+            prev,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: test teardown; restoring the captured prior value
+        // is the inverse of the unsafe mutation done at construction.
+        unsafe {
+            match &self.prev {
+                Some(v) => std::env::set_var(&self.key, v),
+                None => std::env::remove_var(&self.key),
+            }
+        }
+    }
+}
+
+// ── Bounded process model (#2845 / #2846) ─────────────────────────────────
+
+/// Spawn a long-lived, cheap child to stand in for a BM25 daemon.
+///
+/// Why: the limit-enforcement paths care about how many children exist and how
+/// much memory they use — not about what they serve. Driving them with real
+/// `trusty-bm25-daemon` children would make these tests depend on a built
+/// binary and a bound socket, which is what the `#[ignore]`d e2e test is for.
+/// `sleep` is a real OS process with a real pid and real RSS, which is
+/// everything the cap and the RSS reader need.
+/// What: `sleep 60` with `kill_on_drop`, so a failing test cannot leak it.
+/// Test: used by every limit test below.
+fn stub_child() -> Child {
+    Command::new("sleep")
+        .arg("60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("spawn stub child")
+}
+
+/// Register a stub child under `palace` with an explicit LRU stamp.
+///
+/// Why: the LRU victim choice is the behaviour under test, so the test must
+/// control the recency order directly rather than hoping wall-clock ordering
+/// falls out of the call sequence.
+/// What: inserts a `ChildHandle` into the supervisor's map. Reaches private
+/// fields because this module is a child of `bm25_supervisor`.
+/// Test: used by the cap tests below.
+async fn register_stub(sup: &Bm25Supervisor, palace: &str, last_used: u64) {
+    let tmp = std::env::temp_dir().join(format!("trusty-bm25-stub-{palace}.sock"));
+    sup.children.lock().await.insert(
+        palace.to_string(),
+        ChildHandle {
+            child: stub_child(),
+            socket_path: tmp,
+            last_used,
+        },
+    );
+}
+
+/// Why: the default has to be a small number, because the failure it prevents
+/// is one `memory_recall_all` leaving ~99 resident subprocesses. A regression
+/// that quietly widened it back out would restore that failure without
+/// changing a single line of enforcement logic.
+/// Test: this test itself.
+#[test]
+fn default_cap_is_three() {
+    assert_eq!(DEFAULT_MAX_LIVE_DAEMONS, 3);
+}
+
+/// Why: the cap is the knob an operator reaches for when their fan-out is
+/// genuinely wider than the default working set. A typo must not silently
+/// disable it.
+/// What: exercises the valid override, the zero case, and the garbage case.
+/// Test: this test itself.
+#[tokio::test]
+async fn max_live_daemons_honours_env_override() {
+    let lock = env_lock();
+    let _env = lock.lock().await;
+
+    let _g = EnvGuard::set(ENV_MAX_DAEMONS, "7");
+    assert_eq!(max_live_from_env(), 7);
+
+    let _g = EnvGuard::set(ENV_MAX_DAEMONS, "0");
+    assert_eq!(max_live_from_env(), DEFAULT_MAX_LIVE_DAEMONS);
+
+    let _g = EnvGuard::set(ENV_MAX_DAEMONS, "banana");
+    assert_eq!(max_live_from_env(), DEFAULT_MAX_LIVE_DAEMONS);
+
+    let _g = EnvGuard::remove(ENV_MAX_DAEMONS);
+    assert_eq!(max_live_from_env(), DEFAULT_MAX_LIVE_DAEMONS);
+}
+
+/// Why (#2846): `0` must be the documented, working way to turn RSS
+/// enforcement off — distinct from the tightest possible ceiling. If those two
+/// collapsed onto one value, an operator disabling the limit would instead get
+/// a supervisor that reaps every daemon it spawns.
+/// Test: this test itself.
+#[tokio::test]
+async fn rss_limit_honours_env_override() {
+    let lock = env_lock();
+    let _env = lock.lock().await;
+
+    let _g = EnvGuard::set(ENV_RSS_LIMIT_MB, "1024");
+    assert_eq!(rss_limit_from_env(), Some(1024));
+
+    let _g = EnvGuard::set(ENV_RSS_LIMIT_MB, "0");
+    assert_eq!(rss_limit_from_env(), None, "0 must disable, not reap-all");
+
+    let _g = EnvGuard::set(ENV_RSS_LIMIT_MB, "lots");
+    assert_eq!(rss_limit_from_env(), Some(DEFAULT_RSS_LIMIT_MB));
+
+    let _g = EnvGuard::remove(ENV_RSS_LIMIT_MB);
+    assert_eq!(rss_limit_from_env(), Some(DEFAULT_RSS_LIMIT_MB));
+}
+
+/// Why (#2845): this is the regression the cap exists for. Before it, the map
+/// only ever grew — a fan-out across N palaces left N children resident for
+/// the process lifetime. Against that code this assertion reads 4, not 2.
+/// What: registers four stubs with increasing recency, asks for room for one
+/// more with a cap of 3, and asserts the population lands at 2 (3 minus the
+/// requested headroom) and that the two survivors are the most recently used.
+/// Test: this test itself.
+#[tokio::test]
+async fn exceeding_the_cap_reaps_the_least_recently_used() {
+    let sup = Bm25Supervisor::with_limits(3, None);
+    for (i, palace) in ["oldest", "older", "newer", "newest"].iter().enumerate() {
+        register_stub(&sup, palace, i as u64 + 1).await;
+    }
+    assert_eq!(sup.supervised_count().await, 4);
+
+    sup.enforce_limits(1).await;
+
+    assert_eq!(
+        sup.supervised_count().await,
+        2,
+        "cap 3 with headroom 1 must leave room for the incoming daemon"
+    );
+    let live = sup.children.lock().await;
+    assert!(live.contains_key("newest"), "most recent must survive");
+    assert!(
+        live.contains_key("newer"),
+        "second most recent must survive"
+    );
+    assert!(!live.contains_key("oldest"), "LRU must be reaped first");
+    drop(live);
+    assert_eq!(
+        sup.reaped_count(),
+        2,
+        "reaps must be counted, not just done"
+    );
+}
+
+/// Why: a cap of 1 is the tightest legal setting and the one an operator on a
+/// constrained host will pick. It must keep exactly one daemon, not zero —
+/// reaping the daemon you are about to use is a wedge, not a limit.
+/// Test: this test itself.
+#[tokio::test]
+async fn cap_of_one_keeps_a_single_daemon_live() {
+    let sup = Bm25Supervisor::with_limits(1, None);
+    register_stub(&sup, "a", 1).await;
+    // Headroom 0: nothing incoming, so the single existing daemon stays.
+    sup.enforce_limits(0).await;
+    assert_eq!(sup.supervised_count().await, 1);
+    // Headroom 1: an incoming daemon must displace the resident one.
+    sup.enforce_limits(1).await;
+    assert_eq!(sup.supervised_count().await, 0);
+}
+
+/// Why: a cap of 0 would mean "never keep a daemon", which makes every
+/// `ensure_running` spawn-and-immediately-reap. Clamping to 1 turns an
+/// operator's misconfiguration into a tight limit rather than a livelock.
+/// Test: this test itself.
+#[test]
+fn cap_is_clamped_to_at_least_one() {
+    assert_eq!(Bm25Supervisor::with_limits(0, None).max_live(), 1);
+}
+
+/// Why (#2846): this is the assertion trusty-search's `rss_limit_mb` never
+/// had. A limit that is declared but never compared against a measurement
+/// reaps nothing, which is indistinguishable from having no limit until the
+/// kernel's OOM killer makes the distinction.
+/// What: a ceiling of 0 MB means "at or above zero", which every live process
+/// satisfies, so both stubs must be reaped on RSS grounds — and crucially NOT
+/// on cap grounds, since the cap here is wide enough to hold them both.
+/// Test: this test itself.
+#[tokio::test]
+async fn over_rss_limit_children_are_reaped() {
+    let sup = Bm25Supervisor::with_limits(16, Some(0));
+    register_stub(&sup, "fat-a", 1).await;
+    register_stub(&sup, "fat-b", 2).await;
+    assert_eq!(sup.supervised_count().await, 2);
+
+    sup.enforce_limits(0).await;
+
+    assert_eq!(
+        sup.supervised_count().await,
+        0,
+        "children at or above the RSS ceiling must be reaped even under the cap"
+    );
+    assert_eq!(sup.reaped_count(), 2);
+}
+
+/// Why: a generous ceiling must leave healthy daemons alone. Without this the
+/// previous test would also pass on an implementation that reaps
+/// unconditionally, which is a different bug wearing the same result.
+/// Test: this test itself.
+#[tokio::test]
+async fn under_rss_limit_children_are_left_alone() {
+    let sup = Bm25Supervisor::with_limits(16, Some(1_000_000));
+    register_stub(&sup, "lean", 1).await;
+    sup.enforce_limits(0).await;
+    assert_eq!(sup.supervised_count().await, 1);
+    assert_eq!(sup.reaped_count(), 0);
+}
+
+/// Why (#2846 inverse): `None` from the RSS reader means "no reading", not
+/// "zero". Treating an unavailable measurement as a breach would reap every
+/// healthy daemon on any platform where the read is unsupported — converting a
+/// memory guardrail into an outage.
+/// What: pid 0 is not measurable on either supported platform, and `None`
+/// stands for a child that has already exited.
+/// Test: this test itself.
+#[test]
+fn over_rss_limit_is_false_without_a_measurement() {
+    assert!(
+        !over_rss_limit(Some(0), Some(0)),
+        "unmeasurable must not reap"
+    );
+    assert!(!over_rss_limit(None, Some(0)), "exited child must not reap");
+}
+
+/// Why: disabling enforcement must actually disable it, including for a
+/// process that would otherwise be over any ceiling.
+/// Test: this test itself.
+#[test]
+fn over_rss_limit_is_false_when_disabled() {
+    assert!(!over_rss_limit(Some(std::process::id()), None));
+}
+
+/// Why: `shutdown` reaps for a different reason than the limits do, and an
+/// operator reading `reaped_count` to answer "is my cap doing anything?" must
+/// not have normal shutdown inflate the number.
+/// Test: this test itself.
+#[tokio::test]
+async fn shutdown_does_not_count_as_a_limit_reap() {
+    let sup = Bm25Supervisor::with_limits(16, None);
+    register_stub(&sup, "bye", 1).await;
+    sup.shutdown().await;
+    assert_eq!(sup.supervised_count().await, 0);
+    assert_eq!(sup.reaped_count(), 0);
+}

--- a/crates/trusty-memory/src/bm25_supervisor_tests.rs
+++ b/crates/trusty-memory/src/bm25_supervisor_tests.rs
@@ -460,3 +460,30 @@ async fn shutdown_does_not_count_as_a_limit_reap() {
     assert_eq!(sup.supervised_count().await, 0);
     assert_eq!(sup.reaped_count(), 0);
 }
+
+/// Why (#5048 review): the supervisor's SIGTERM patience must exceed the
+/// daemon's own shutdown-flush budget with margin. At an equal budget the
+/// SIGKILL lands inside the flush the durability fix added and the open write
+/// window is lost. Pinning the relationship here means a future tightening of
+/// either number has to be a deliberate choice.
+/// What: asserts the patience is strictly greater than
+/// `trusty_bm25_daemon`'s 2 s `SHUTDOWN_FLUSH_TIMEOUT`, with real margin.
+/// Test: this test itself.
+#[test]
+fn sigterm_patience_exceeds_the_daemon_flush_budget() {
+    // The daemon's own budget. Not importable — `trusty-memory` depends on the
+    // daemon crate only for the bundled binary shim, and the constant is
+    // private — so it is restated with a pointer, the same way the BM25 client
+    // restates the wire method names.
+    let daemon_flush_budget = Duration::from_secs(2);
+    assert!(
+        SIGTERM_PATIENCE > daemon_flush_budget,
+        "the supervisor must outwait the daemon's flush: {SIGTERM_PATIENCE:?} vs \
+         {daemon_flush_budget:?}"
+    );
+    assert!(
+        SIGTERM_PATIENCE - daemon_flush_budget >= Duration::from_secs(2),
+        "leave room for signal delivery, socket cleanup and process exit on top \
+         of the flush itself"
+    );
+}

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -76,6 +76,7 @@ pub mod activity;
 pub mod attribution;
 pub mod authz;
 pub mod bm25_backfill;
+pub mod bm25_repair;
 pub mod bm25_supervisor;
 pub mod bootstrap;
 /// Autonomous Dreamer scheduler — spawns per-palace dream loops on daemon startup.
@@ -578,6 +579,18 @@ pub struct AppState {
     /// Test: `bm25_index_queue_drops_when_full` exercises the full-queue
     /// branch via `bm25_index_enqueue`.
     pub bm25_index_tx: tokio::sync::mpsc::Sender<tools::Bm25IndexRequest>,
+    /// Palaces whose BM25 coverage is known to be incomplete (#5048 review).
+    ///
+    /// Why: `bm25_index_enqueue` drops on a full queue so `memory_remember`
+    /// never waits on daemon RTT. That trade is only defensible if a drop is
+    /// actually repaired, and before this field the sole production trigger for
+    /// a backfill was daemon startup — so a drop stayed invisible until the
+    /// next restart. Every observer of lost coverage marks the palace here and
+    /// [`bm25_repair::spawn_repair_sweep`] consumes it on an interval.
+    /// What: a `DashSet` of palace ids, shared by every `AppState` clone.
+    /// Idempotent — forty drops for one palace queue one repair.
+    /// Test: `bm25_repair_tests.rs`, `bm25_index_queue_drops_when_full`.
+    pub bm25_dirty: bm25_repair::DirtyPalaces,
     /// Cached result of the startup update check (issue #537).
     ///
     /// Why: `/health` should report `update_available` without hitting crates.io
@@ -635,7 +648,8 @@ impl AppState {
         // `bm25_client` / `bm25_supervisor` start as `None`; the builder
         // `with_bm25_client_from_env` rebuilds the worker with the real
         // client + supervisor once env-gated opt-in is resolved.
-        tools::spawn_bm25_index_worker(bm25_index_rx, None, None);
+        let bm25_dirty: bm25_repair::DirtyPalaces = Arc::new(dashmap::DashSet::new());
+        tools::spawn_bm25_index_worker(bm25_index_rx, None, None, Arc::clone(&bm25_dirty));
         Self {
             version: env!("CARGO_PKG_VERSION").to_string(),
             // Idle-to-disk: honour TRUSTY_MEMORY_MAX_OPEN_PALACES (default 64)
@@ -676,6 +690,7 @@ impl AppState {
             palace_names: Arc::new(dashmap::DashMap::new()),
             pin_project_map: Arc::new(dashmap::DashMap::new()),
             bm25_index_tx,
+            bm25_dirty,
             update_available: Arc::new(std::sync::Mutex::new(None)),
             // Start in Warming state; flipped to Ready by spawn_startup_tasks
             // once the embedder warm-up succeeds (issues #910/#911).
@@ -770,6 +785,7 @@ impl AppState {
                 rx,
                 self.bm25_client.clone(),
                 self.bm25_supervisor.clone(),
+                Arc::clone(&self.bm25_dirty),
             );
             self.bm25_index_tx = tx;
             tracing::info!(

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -75,6 +75,7 @@ impl DaemonReadiness {
 pub mod activity;
 pub mod attribution;
 pub mod authz;
+pub mod bm25_backfill;
 pub mod bm25_supervisor;
 pub mod bootstrap;
 /// Autonomous Dreamer scheduler — spawns per-palace dream loops on daemon startup.

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -1032,6 +1032,12 @@ fn spawn_startup_tasks(state: &AppState) {
         // `bm25_client` is `None`.
         trusty_memory::bm25_backfill::spawn_startup_backfill(&bg_state);
 
+        // BM25 coverage repair sweep. The write path drops on a full queue,
+        // and before this the only thing that repaired a drop was the next
+        // daemon restart — so the "drops are recoverable" trade was not true
+        // of the running process. Also a no-op while the lane is off.
+        trusty_memory::bm25_repair::spawn_repair_sweep(&bg_state);
+
         // Issue #42: once palaces are live, kick off auto-discovery against
         // cwd targeting the default palace (if configured). Without a default
         // palace there's no obvious destination, so skip — explicit MCP

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -1025,11 +1025,9 @@ fn spawn_startup_tasks(state: &AppState) {
         );
         tracing::info!(loops = n, "dream_scheduler: {n} loop(s) running (#1529)");
 
-        // BM25 backfill sweep. Must run AFTER hydration — before it, the
-        // registry is empty and the sweep would find nothing to index. A no-op
-        // while the lexical lane is off, which is every deployment until the
-        // default is flipped: `spawn_startup_backfill` returns immediately when
-        // `bm25_client` is `None`.
+        // BM25 backfill sweep. A no-op while the lexical lane is off, which is
+        // every deployment until the default is flipped: `spawn_startup_backfill`
+        // returns immediately when `bm25_client` is `None`.
         trusty_memory::bm25_backfill::spawn_startup_backfill(&bg_state);
 
         // BM25 coverage repair sweep. The write path drops on a full queue,

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -1025,6 +1025,13 @@ fn spawn_startup_tasks(state: &AppState) {
         );
         tracing::info!(loops = n, "dream_scheduler: {n} loop(s) running (#1529)");
 
+        // BM25 backfill sweep. Must run AFTER hydration — before it, the
+        // registry is empty and the sweep would find nothing to index. A no-op
+        // while the lexical lane is off, which is every deployment until the
+        // default is flipped: `spawn_startup_backfill` returns immediately when
+        // `bm25_client` is `None`.
+        trusty_memory::bm25_backfill::spawn_startup_backfill(&bg_state);
+
         // Issue #42: once palaces are live, kick off auto-discovery against
         // cwd targeting the default palace (if configured). Without a default
         // palace there's no obvious destination, so skip — explicit MCP

--- a/crates/trusty-memory/src/tools/bm25.rs
+++ b/crates/trusty-memory/src/tools/bm25.rs
@@ -123,7 +123,11 @@ pub struct Bm25IndexRequest {
 /// and calls `client.index()`. Errors are logged at `warn!` and dropped —
 /// BM25 indexing is best-effort and the drawer is durable in redb regardless.
 /// If `client` is `None` (env var not set at startup) the worker still runs
-/// and silently drops every request, which keeps the channel drained.
+/// and silently drops every request, which keeps the channel drained — that is
+/// not a coverage gap, because the lane is off.
+/// A request the worker accepts but cannot land (daemon spawn refused, index
+/// call failed) DOES mark the palace in `dirty`, so the repair sweep re-runs
+/// the backfill instead of the gap surviving until the next restart.
 /// Test: indirectly covered by the integration tests in
 /// `trusty-bm25-daemon/tests/`; `bm25_index_queue_drops_when_full` covers the
 /// back-pressure behaviour.
@@ -131,6 +135,7 @@ pub fn spawn_bm25_index_worker(
     mut rx: tokio::sync::mpsc::Receiver<Bm25IndexRequest>,
     client: Option<std::sync::Arc<trusty_common::bm25_client::Bm25Client>>,
     supervisor: Option<std::sync::Arc<crate::bm25_supervisor::Bm25Supervisor>>,
+    dirty: crate::bm25_repair::DirtyPalaces,
 ) {
     tokio::spawn(async move {
         while let Some(req) = rx.recv().await {
@@ -144,6 +149,10 @@ pub fn spawn_bm25_index_worker(
             // the daemon will be retried on the next request.
             if let Some(sup) = supervisor.as_ref() {
                 if let Err(e) = sup.ensure_running(&req.palace, &req.data_dir).await {
+                    // The write did not land. Same reasoning as the dropped
+                    // enqueue: queue the palace so a repair pass re-runs the
+                    // backfill rather than leaving the gap until restart.
+                    dirty.insert(req.palace.clone());
                     tracing::warn!(
                         palace = %req.palace,
                         "bm25 supervisor failed to start daemon for index (non-fatal): {e:#}"
@@ -152,6 +161,7 @@ pub fn spawn_bm25_index_worker(
                 }
             }
             if let Err(e) = client.index(&req.drawer_id, &req.content).await {
+                dirty.insert(req.palace.clone());
                 tracing::warn!(
                     palace = %req.palace,
                     drawer_id = %req.drawer_id,
@@ -189,10 +199,15 @@ pub(crate) fn bm25_index_enqueue(state: &AppState, palace: &str, drawer_id: Uuid
     match state.bm25_index_tx.try_send(req) {
         Ok(()) => {}
         Err(tokio::sync::mpsc::error::TrySendError::Full(req)) => {
+            // #5048 review: a drop is only an acceptable trade if something
+            // repairs it. Mark the palace so the periodic repair sweep
+            // re-runs the lossless backfill instead of the coverage gap
+            // surviving until the next daemon restart.
+            crate::bm25_repair::mark_dirty(state, &req.palace);
             tracing::warn!(
                 palace = %req.palace,
                 drawer_id = %req.drawer_id,
-                "BM25 index queue full — skipping drawer {}",
+                "BM25 index queue full — dropped drawer {}, palace queued for repair",
                 req.drawer_id
             );
         }

--- a/crates/trusty-memory/src/tools/bm25.rs
+++ b/crates/trusty-memory/src/tools/bm25.rs
@@ -182,13 +182,15 @@ pub fn spawn_bm25_index_worker(
 /// caps in-flight indexing work — under a sustained burst with a slow daemon
 /// the previous design grew an unbounded task queue, which #231 fixes here.
 /// What: builds a `Bm25IndexRequest` from the caller's data and calls
-/// `try_send` so the caller is never blocked. On `TrySendError::Full` we
-/// log at `warn!` and drop the request — BM25 indexing is best-effort and
-/// the drawer is durable in redb regardless of whether the BM25 lane saw it.
-/// `TrySendError::Closed` shouldn't happen in practice (the worker holds the
-/// receiver for the daemon's lifetime), but if it does we log at `debug!`
-/// and continue — we never let a BM25 hiccup fail a write.
-/// Test: `bm25_index_queue_drops_when_full` covers the full-queue branch.
+/// `try_send` so the caller is never blocked. BOTH failure arms — `Full` and
+/// `Closed` — drop the request and queue the palace for coverage repair; the
+/// drawer is durable in redb either way, and BM25 catches up on the next repair
+/// pass. `Closed` shouldn't happen in practice (the worker holds the receiver
+/// for the daemon's lifetime), but it loses the write exactly as completely as
+/// `Full` does, so it is not treated as the lesser case. We never let a BM25
+/// hiccup fail a write.
+/// Test: `bm25_index_queue_drops_when_full`,
+/// `a_closed_index_queue_queues_the_palace_for_repair`.
 pub(crate) fn bm25_index_enqueue(state: &AppState, palace: &str, drawer_id: Uuid, content: &str) {
     let req = Bm25IndexRequest {
         palace: palace.to_string(),
@@ -212,10 +214,15 @@ pub(crate) fn bm25_index_enqueue(state: &AppState, palace: &str, drawer_id: Uuid
             );
         }
         Err(tokio::sync::mpsc::error::TrySendError::Closed(req)) => {
-            tracing::debug!(
+            // #5048 re-review: the sibling branch three lines up. A closed
+            // queue loses the write exactly as completely as a full one, so it
+            // gets the same treatment — the earlier asymmetry (mark on `Full`,
+            // `debug!` on `Closed`) is the same shape #4683 shipped with.
+            crate::bm25_repair::mark_dirty(state, &req.palace);
+            tracing::warn!(
                 palace = %req.palace,
                 drawer_id = %req.drawer_id,
-                "BM25 index queue closed — skipping drawer {}",
+                "BM25 index queue closed — dropped drawer {}, palace queued for repair",
                 req.drawer_id
             );
         }

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -3422,3 +3422,44 @@ async fn a_daemon_that_will_not_spawn_queues_the_palace_for_repair() {
         "a daemon that will not spawn lost the write and must queue the palace"
     );
 }
+
+/// Why (#5048 re-review): `Full` marked the palace dirty and `Closed`, three
+/// lines below it, logged at `debug!` and returned. Both lose the write
+/// identically — the drawer never reaches the index and nothing remembers that
+/// it did not. Fixing one arm and leaving its sibling is the shape #4683
+/// shipped with.
+/// What: drops the receiver so `try_send` returns `Closed`, then enqueues.
+/// Test: this test itself. Remove the `mark_dirty` from the `Closed` arm and
+/// the queue stays empty.
+#[tokio::test]
+async fn a_closed_index_queue_queues_the_palace_for_repair() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut state = AppState::new(tmp.path().to_path_buf());
+
+    // Swap in a sender whose receiver is dropped. Waiting for the real worker
+    // to exit would race its spawn; this closes the channel deterministically.
+    let (tx, rx) = tokio::sync::mpsc::channel::<Bm25IndexRequest>(8);
+    drop(rx);
+    state.bm25_index_tx = tx;
+
+    assert!(
+        matches!(
+            state.bm25_index_tx.try_send(Bm25IndexRequest {
+                palace: "default".to_string(),
+                drawer_id: Uuid::new_v4().to_string(),
+                content: "probe".to_string(),
+                data_dir: state.data_root.join("default"),
+            }),
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_))
+        ),
+        "precondition: the queue must actually be closed, not merely full"
+    );
+
+    bm25_index_enqueue(&state, "default", Uuid::new_v4(), "content that is lost");
+
+    assert_eq!(
+        crate::bm25_repair::dirty_palaces(&state),
+        vec!["default".to_string()],
+        "a closed queue loses the write as completely as a full one and must queue repair"
+    );
+}

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -1778,6 +1778,15 @@ async fn bm25_index_queue_drops_when_full() {
         Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {}
         other => panic!("expected Full overflow, got {other:?}"),
     }
+
+    // #5048 review: dropping is only defensible if something repairs the drop.
+    // Removing the `mark_dirty` call from `bm25_index_enqueue`'s `Full` arm
+    // leaves this list empty and the coverage gap unrepaired until restart.
+    assert_eq!(
+        crate::bm25_repair::dirty_palaces(&state),
+        vec!["default".to_string()],
+        "a dropped index op must queue its palace for coverage repair"
+    );
 }
 
 // -------------------------------------------------------------------------

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -3314,3 +3314,111 @@ fn kuzu_migrate_refuses_hot_predicates_and_passes_cold_ones() {
         );
     }
 }
+
+/// Why (#5048 re-review): the enqueue drop was tested but the worker's own two
+/// loss paths were not, and they lose a write just as completely — a daemon
+/// that will not spawn and an index call that fails both leave the drawer out
+/// of the BM25 corpus with nothing queued to repair it.
+/// What: drives `spawn_bm25_index_worker` directly with a client pointed at a
+/// dead socket, so `client.index` fails, and asserts the palace is queued.
+/// Test: this test itself. Delete the `dirty.insert` from the index-failure arm
+/// and the queue stays empty.
+#[tokio::test]
+async fn a_failed_index_call_queues_the_palace_for_repair() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dirty: crate::bm25_repair::DirtyPalaces = std::sync::Arc::new(dashmap::DashSet::new());
+    let (tx, rx) = tokio::sync::mpsc::channel::<Bm25IndexRequest>(8);
+
+    // No listener at this path, so every `index` call fails at connect.
+    let client = std::sync::Arc::new(trusty_common::bm25_client::Bm25Client::new(
+        tmp.path().join("dead.sock"),
+    ));
+    // No supervisor: this isolates the index-failure arm from the spawn arm.
+    spawn_bm25_index_worker(rx, Some(client), None, std::sync::Arc::clone(&dirty));
+
+    tx.send(Bm25IndexRequest {
+        palace: "lossy".to_string(),
+        drawer_id: Uuid::new_v4().to_string(),
+        content: "content that will never reach the daemon".to_string(),
+        data_dir: tmp.path().join("bm25"),
+    })
+    .await
+    .expect("send to worker");
+
+    for _ in 0..200 {
+        if dirty.contains("lossy") {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert!(
+        dirty.contains("lossy"),
+        "an index call that failed lost the write and must queue the palace"
+    );
+}
+
+/// Why: the other worker loss path. A supervisor that cannot start a daemon
+/// makes the worker skip the request entirely, which is the same lost write.
+/// What: points the daemon locator at a path that does not exist so
+/// `ensure_running` fails, and asserts the palace is queued.
+/// Test: this test itself. Delete the `dirty.insert` from the spawn-failure arm
+/// and the queue stays empty.
+#[tokio::test]
+async fn a_daemon_that_will_not_spawn_queues_the_palace_for_repair() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let prev = std::env::var("TRUSTY_BM25_DAEMON_BIN").ok();
+    let prev_ext = std::env::var("TRUSTY_BM25_EXTERNAL").ok();
+    // SAFETY: test-only env mutation, restored below.
+    unsafe {
+        std::env::set_var("TRUSTY_BM25_DAEMON_BIN", tmp.path().join("no-such-binary"));
+        std::env::remove_var("TRUSTY_BM25_EXTERNAL");
+    }
+
+    let dirty: crate::bm25_repair::DirtyPalaces = std::sync::Arc::new(dashmap::DashSet::new());
+    let (tx, rx) = tokio::sync::mpsc::channel::<Bm25IndexRequest>(8);
+    let client = std::sync::Arc::new(trusty_common::bm25_client::Bm25Client::new(
+        tmp.path().join("unused.sock"),
+    ));
+    let supervisor = std::sync::Arc::new(crate::bm25_supervisor::Bm25Supervisor::new());
+    spawn_bm25_index_worker(
+        rx,
+        Some(client),
+        Some(supervisor),
+        std::sync::Arc::clone(&dirty),
+    );
+
+    // A palace name short enough that the socket path stays inside `sun_path`.
+    let palace = format!("nz{:x}", std::process::id() & 0xfff);
+    tx.send(Bm25IndexRequest {
+        palace: palace.clone(),
+        drawer_id: Uuid::new_v4().to_string(),
+        content: "content that will never reach a daemon".to_string(),
+        data_dir: tmp.path().join("bm25"),
+    })
+    .await
+    .expect("send to worker");
+
+    for _ in 0..400 {
+        if dirty.contains(&palace) {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    let queued = dirty.contains(&palace);
+
+    // SAFETY: restoring the captured prior values.
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var("TRUSTY_BM25_DAEMON_BIN", v),
+            None => std::env::remove_var("TRUSTY_BM25_DAEMON_BIN"),
+        }
+        if let Some(v) = prev_ext {
+            std::env::set_var("TRUSTY_BM25_EXTERNAL", v);
+        }
+    }
+
+    assert!(
+        queued,
+        "a daemon that will not spawn lost the write and must queue the palace"
+    );
+}

--- a/crates/trusty-memory/tests/bm25_backfill_e2e.rs
+++ b/crates/trusty-memory/tests/bm25_backfill_e2e.rs
@@ -1,0 +1,306 @@
+//! End-to-end proof that the BM25 backfill is lossless, against a real daemon.
+//!
+//! Why: the whole reason backfill does not reuse `bm25_index_enqueue` is that
+//! the live write path holds a 256-slot channel written with `try_send` and
+//! drops on full. The largest palace on this host holds 1311 drawers — five
+//! times that queue — so a backfill routed through it would land roughly a
+//! fifth of the corpus and report nothing wrong. That claim is only worth
+//! anything if it is measured, so this test pushes more documents than the
+//! queue could hold and asserts the daemon's own `stats` reports every one.
+//!
+//! It also exercises the bounded process model: the supervisor's daemon cap
+//! must reap the least-recently-used child rather than accumulating one
+//! subprocess per palace, which is the failure mode #2845/#2846 record.
+//!
+//! What: `#[ignore]`d because it needs the `trusty-bm25-daemon` binary. Run
+//! with `cargo test -p trusty-memory --test bm25_backfill_e2e -- --include-ignored`.
+//!
+//! Test: this *is* the test file.
+
+use std::path::PathBuf;
+
+use trusty_common::bm25_client::Bm25Client;
+use trusty_memory::bm25_backfill::{backfill_palace, BackfillStatus};
+use trusty_memory::bm25_supervisor::Bm25Supervisor;
+use trusty_memory::tools::BM25_INDEX_QUEUE_CAPACITY;
+
+/// Resolve the freshly-built `trusty-bm25-daemon` binary.
+///
+/// Why: the supervisor discovers the daemon as a sibling of `current_exe()`,
+/// which for an integration test is the test binary under `target/*/deps/`.
+/// Pointing `TRUSTY_BM25_DAEMON_BIN` at the real build output sidesteps that.
+/// What: honours the env var if already set, else walks up from the test
+/// binary looking for the daemon next to it or one level up.
+/// Test: this is the test bootstrap.
+fn discover_daemon_binary() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("TRUSTY_BM25_DAEMON_BIN") {
+        let pb = PathBuf::from(p);
+        if pb.is_file() {
+            return Some(pb);
+        }
+    }
+    let exe = std::env::current_exe().ok()?;
+    let mut p = exe.as_path();
+    while let Some(parent) = p.parent() {
+        let candidate = parent.join("trusty-bm25-daemon");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        let candidate = parent.join("..").join("trusty-bm25-daemon");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        p = parent;
+    }
+    None
+}
+
+/// Point the supervisor's locator at the built daemon, or skip.
+fn arm_daemon_binary() -> bool {
+    let Some(binary) = discover_daemon_binary() else {
+        eprintln!(
+            "skipping: trusty-bm25-daemon binary not found. Build it first \
+             (`cargo build -p trusty-memory --bin trusty-bm25-daemon`) or set \
+             TRUSTY_BM25_DAEMON_BIN=<path>."
+        );
+        return false;
+    };
+    // SAFETY: test-only env mutation; this binary is the sole writer.
+    unsafe {
+        std::env::set_var("TRUSTY_BM25_DAEMON_BIN", &binary);
+        std::env::remove_var("TRUSTY_BM25_EXTERNAL");
+    }
+    true
+}
+
+/// Why: this is the regression the separate feeder exists for. Against a
+/// backfill built on `bm25_index_enqueue`, this assertion reads ~256 (the
+/// queue capacity), not 1024 — the rest are dropped with a `warn!` and the
+/// palace serves a quarter of its corpus while looking healthy.
+/// What: spawns a real daemon, backfills 4x the live write path's queue
+/// capacity, and asserts the daemon's own `stats` reports every document,
+/// that the report says `Completed`, and that `fully_indexed()` agrees. Then
+/// re-runs to prove idempotence and the already-indexed short circuit.
+/// Test: this test itself.
+#[ignore = "requires trusty-bm25-daemon binary on disk; run with --include-ignored"]
+#[tokio::test(flavor = "current_thread")]
+async fn backfill_indexes_every_drawer_without_drops() {
+    if !arm_daemon_binary() {
+        return;
+    }
+
+    // 4x the live write path's queue. Any drop-on-full feeder fails here.
+    let doc_count = BM25_INDEX_QUEUE_CAPACITY * 4;
+    let docs: Vec<(String, String)> = (0..doc_count)
+        .map(|i| {
+            (
+                format!("drawer-{i}"),
+                format!("token{i} shared corpus text"),
+            )
+        })
+        .collect();
+
+    let palace = format!("bf{:x}", std::process::id() & 0xffff);
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let data_dir = tmp.path().join(&palace).join("bm25");
+
+    let supervisor = Bm25Supervisor::new();
+    let socket = supervisor
+        .ensure_running(&palace, &data_dir)
+        .await
+        .expect("supervisor must spawn the daemon");
+
+    let started = std::time::Instant::now();
+    let report = backfill_palace(&socket, &palace, docs.clone(), false).await;
+    let elapsed = started.elapsed();
+
+    assert_eq!(
+        report.status,
+        BackfillStatus::Completed,
+        "backfill must complete: {report:?}"
+    );
+    assert_eq!(report.failed, 0, "no document may fail: {report:?}");
+    assert_eq!(
+        report.indexed, doc_count,
+        "every document must be acked — a drop-on-full feeder lands ~{BM25_INDEX_QUEUE_CAPACITY}"
+    );
+    assert_eq!(
+        report.final_doc_count,
+        Some(doc_count),
+        "the daemon's own count must match what we sent"
+    );
+    assert!(report.fully_indexed());
+    eprintln!("backfilled {doc_count} docs in {elapsed:?}");
+
+    // The corpus is genuinely searchable, not merely counted.
+    let client = Bm25Client::new(socket.clone());
+    let hits = client
+        .search("token7", 5)
+        .await
+        .expect("search must succeed");
+    assert!(
+        hits.iter().any(|h| h.doc_id == "drawer-7"),
+        "a backfilled doc must be reachable by a lexical query; got {hits:?}"
+    );
+
+    // Idempotent: a second run sees full coverage and does no work.
+    let again = backfill_palace(&socket, &palace, docs, false).await;
+    assert_eq!(again.status, BackfillStatus::AlreadyIndexed);
+    assert_eq!(again.indexed, 0, "a covered palace must not be re-fed");
+    assert!(again.fully_indexed());
+
+    supervisor.shutdown().await;
+}
+
+/// Why: an index that holds only part of a palace must be detectable and
+/// repairable — that is the "index partial" arm of the fail-open requirement.
+/// Before the `stats` op existed there was no way to observe the shortfall at
+/// all, so a partially-indexed palace answered from partial content forever.
+/// What: indexes half the corpus directly, then backfills the whole thing and
+/// asserts the run detected the shortfall (did NOT short-circuit) and that the
+/// daemon's read-back count covers the full corpus afterwards.
+/// Test: this test itself.
+#[ignore = "requires trusty-bm25-daemon binary on disk; run with --include-ignored"]
+#[tokio::test(flavor = "current_thread")]
+async fn partial_index_is_detected_and_repaired() {
+    if !arm_daemon_binary() {
+        return;
+    }
+
+    let total = 40usize;
+    let docs: Vec<(String, String)> = (0..total)
+        .map(|i| (format!("d{i}"), format!("word{i} common")))
+        .collect();
+
+    let palace = format!("bp{:x}", std::process::id() & 0xffff);
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let data_dir = tmp.path().join(&palace).join("bm25");
+
+    let supervisor = Bm25Supervisor::new();
+    let socket = supervisor
+        .ensure_running(&palace, &data_dir)
+        .await
+        .expect("spawn daemon");
+    let client = Bm25Client::new(socket.clone());
+
+    // Seed half the corpus, standing in for a palace whose live write path
+    // dropped the rest under queue pressure.
+    for (doc_id, text) in docs.iter().take(total / 2) {
+        client.index(doc_id, text).await.expect("seed index");
+    }
+    let mid = client.stats().await.expect("stats");
+    assert_eq!(mid.doc_count, total / 2, "seed must be half the corpus");
+
+    let report = backfill_palace(&socket, &palace, docs, false).await;
+    assert_eq!(
+        report.status,
+        BackfillStatus::Completed,
+        "a shortfall must trigger a real run, not the already-indexed skip: {report:?}"
+    );
+    assert_eq!(report.indexed, total);
+    assert_eq!(report.final_doc_count, Some(total));
+    assert!(report.fully_indexed());
+
+    supervisor.shutdown().await;
+}
+
+/// Why (#2845/#2846): before the cap, `ensure_running` only ever grew the map
+/// — one `memory_recall_all` across ~99 palaces left 99 resident subprocesses
+/// for the trusty-memory daemon's lifetime. Against that code this assertion
+/// reads 5, not 2.
+/// What: drives five palaces through a supervisor capped at 2 with real
+/// daemons, then asserts the live population never exceeded the cap, that the
+/// reap counter moved, and that the most recently used palace survived.
+/// Test: this test itself.
+#[ignore = "requires trusty-bm25-daemon binary on disk; run with --include-ignored"]
+#[tokio::test(flavor = "current_thread")]
+async fn daemon_population_stays_within_the_cap() {
+    if !arm_daemon_binary() {
+        return;
+    }
+
+    let cap = 2usize;
+    let supervisor = Bm25Supervisor::with_limits(cap, None);
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = format!("bc{:x}", std::process::id() & 0xffff);
+
+    let mut palaces = Vec::new();
+    for i in 0..5 {
+        let palace = format!("{base}{i}");
+        let data_dir = tmp.path().join(&palace).join("bm25");
+        supervisor
+            .ensure_running(&palace, &data_dir)
+            .await
+            .unwrap_or_else(|e| panic!("spawn {palace}: {e:#}"));
+        assert!(
+            supervisor.supervised_count().await <= cap,
+            "population must never exceed the cap of {cap}"
+        );
+        palaces.push(palace);
+    }
+
+    assert_eq!(
+        supervisor.supervised_count().await,
+        cap,
+        "steady state must sit at the cap, not at the number of palaces touched"
+    );
+    assert_eq!(
+        supervisor.reaped_count(),
+        3,
+        "five palaces through a cap of two must reap three daemons"
+    );
+
+    supervisor.shutdown().await;
+    assert_eq!(supervisor.supervised_count().await, 0);
+}
+
+/// Why: a reaped daemon must be transparently respawnable — otherwise the cap
+/// trades an unbounded process count for a permanently degraded palace, which
+/// is a worse bug than the one it fixes.
+/// What: capped at 1, spawns palace A, spawns palace B (reaping A), then asks
+/// for A again and asserts it comes back serving.
+/// Test: this test itself.
+#[ignore = "requires trusty-bm25-daemon binary on disk; run with --include-ignored"]
+#[tokio::test(flavor = "current_thread")]
+async fn a_reaped_palace_respawns_on_next_use() {
+    if !arm_daemon_binary() {
+        return;
+    }
+
+    let supervisor = Bm25Supervisor::with_limits(1, None);
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = format!("br{:x}", std::process::id() & 0xffff);
+    let (a, b) = (format!("{base}a"), format!("{base}b"));
+
+    let sock_a = supervisor
+        .ensure_running(&a, &tmp.path().join(&a).join("bm25"))
+        .await
+        .expect("spawn a");
+    Bm25Client::new(sock_a.clone())
+        .index("d1", "alpha beta")
+        .await
+        .expect("index into a");
+
+    supervisor
+        .ensure_running(&b, &tmp.path().join(&b).join("bm25"))
+        .await
+        .expect("spawn b");
+    assert_eq!(supervisor.supervised_count().await, 1, "cap of 1 must hold");
+    assert_eq!(supervisor.reaped_count(), 1);
+
+    // A was reaped; asking again must bring it back, snapshot intact.
+    let sock_a2 = supervisor
+        .ensure_running(&a, &tmp.path().join(&a).join("bm25"))
+        .await
+        .expect("respawn a");
+    let stats = Bm25Client::new(sock_a2)
+        .stats()
+        .await
+        .expect("stats from respawned a");
+    assert_eq!(
+        stats.doc_count, 1,
+        "a respawned daemon must reload its snapshot, not start empty"
+    );
+
+    supervisor.shutdown().await;
+}

--- a/crates/trusty-memory/tests/bm25_backfill_e2e.rs
+++ b/crates/trusty-memory/tests/bm25_backfill_e2e.rs
@@ -20,7 +20,7 @@
 use std::path::PathBuf;
 
 use trusty_common::bm25_client::Bm25Client;
-use trusty_memory::bm25_backfill::{backfill_palace, BackfillStatus};
+use trusty_memory::bm25_backfill::{backfill_palace, BackfillStatus, PalaceDocs};
 use trusty_memory::bm25_supervisor::Bm25Supervisor;
 use trusty_memory::tools::BM25_INDEX_QUEUE_CAPACITY;
 
@@ -110,8 +110,15 @@ async fn backfill_indexes_every_drawer_without_drops() {
         .await
         .expect("supervisor must spawn the daemon");
 
+    let docs_for_drift = docs.clone();
     let started = std::time::Instant::now();
-    let report = backfill_palace(&socket, &palace, docs.clone(), false).await;
+    let report = backfill_palace(
+        &socket,
+        &palace,
+        PalaceDocs::from_pairs(docs.clone()),
+        false,
+    )
+    .await;
     let elapsed = started.elapsed();
 
     assert_eq!(
@@ -144,10 +151,45 @@ async fn backfill_indexes_every_drawer_without_drops() {
     );
 
     // Idempotent: a second run sees full coverage and does no work.
-    let again = backfill_palace(&socket, &palace, docs, false).await;
+    let again = backfill_palace(&socket, &palace, PalaceDocs::from_pairs(docs), false).await;
     assert_eq!(again.status, BackfillStatus::AlreadyIndexed);
     assert_eq!(again.indexed, 0, "a covered palace must not be re-fed");
+    assert_eq!(
+        again.missing_after,
+        Some(0),
+        "the skip must be a VERIFIED set"
+    );
     assert!(again.fully_indexed());
+
+    // The identity guarantee: a corpus inflated with documents the palace does
+    // not have must NOT read as coverage. Against the old count-based
+    // predicate, deleting one live doc and adding two stale ones leaves
+    // `doc_count` above the drawer count and `AlreadyIndexed` claims full
+    // coverage over a palace missing a drawer.
+    client.delete("drawer-7").await.expect("delete a live doc");
+    for i in 0..2 {
+        client
+            .index(&format!("stale-{i}"), "a drawer the palace no longer has")
+            .await
+            .expect("seed a stale doc");
+    }
+    let drifted = backfill_palace(
+        &socket,
+        &palace,
+        PalaceDocs::from_pairs(docs_for_drift),
+        false,
+    )
+    .await;
+    assert!(
+        drifted.final_doc_count.unwrap() > drifted.drawers_total,
+        "precondition: the corpus is larger than the palace, so every count \
+         comparison reports coverage"
+    );
+    assert_eq!(
+        drifted.indexed, doc_count,
+        "the missing drawer must have triggered a real run, not the skip"
+    );
+    assert!(drifted.fully_indexed(), "and the run must have repaired it");
 
     supervisor.shutdown().await;
 }
@@ -191,13 +233,14 @@ async fn partial_index_is_detected_and_repaired() {
     let mid = client.stats().await.expect("stats");
     assert_eq!(mid.doc_count, total / 2, "seed must be half the corpus");
 
-    let report = backfill_palace(&socket, &palace, docs, false).await;
+    let report = backfill_palace(&socket, &palace, PalaceDocs::from_pairs(docs), false).await;
     assert_eq!(
         report.status,
         BackfillStatus::Completed,
         "a shortfall must trigger a real run, not the already-indexed skip: {report:?}"
     );
     assert_eq!(report.indexed, total);
+    assert_eq!(report.missing_after, Some(0));
     assert_eq!(report.final_doc_count, Some(total));
     assert!(report.fully_indexed());
 

--- a/crates/trusty-memory/tests/bm25_supervisor_concurrency.rs
+++ b/crates/trusty-memory/tests/bm25_supervisor_concurrency.rs
@@ -1,0 +1,278 @@
+//! Concurrency proofs for the BM25 spawn supervisor's `spawn_gate`.
+//!
+//! Why: the two defects `spawn_gate` closes are both races, and neither is
+//! reachable from a serial `for … .await` loop on a `current_thread` runtime —
+//! against such a test, deleting `spawn_gate` entirely leaves everything green.
+//! Both tests below fail when it is removed:
+//!
+//! - `concurrent_callers_for_one_palace_spawn_exactly_one_daemon` asserts
+//!   `spawned_count() == 1`. Without the gate, all N callers pass the
+//!   already-supervised check against an empty map and each launches a daemon;
+//!   the losers die on EADDRINUSE, so the map still holds one entry — which is
+//!   exactly why the assertion is on launches, not on map size.
+//! - `a_concurrent_fanout_never_exceeds_the_cap` asserts the resident
+//!   population lands at the cap. Without the gate every caller evaluates
+//!   `enforce_limits` against a map nobody has inserted into yet, so the cap is
+//!   satisfied per-caller and violated in aggregate — the same shape as the
+//!   unbounded fan-out that 503-stormed trusty-search.
+//!
+//! What: NOT `#[ignore]`d. `env!("CARGO_BIN_EXE_trusty-bm25-daemon")` makes
+//! cargo build the daemon before this test binary runs, so the binary is always
+//! on disk in CI — the reason the older e2e files skip themselves does not
+//! apply here. Runs on a `multi_thread` runtime with a `JoinSet` so the callers
+//! are genuinely simultaneous rather than interleaved by a single executor.
+//!
+//! Test: this *is* the test file.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::task::JoinSet;
+use trusty_memory::bm25_supervisor::{Bm25Supervisor, ENV_EXTERNAL_BM25};
+
+/// Point the supervisor's binary locator at the daemon cargo just built.
+///
+/// Why: `locate_bm25_daemon_binary` searches PATH and `current_exe()`'s
+/// siblings, neither of which reliably holds the daemon when the test binary
+/// runs from `target/*/deps/`. `CARGO_BIN_EXE_*` is resolved at compile time
+/// and cargo guarantees the binary exists before the test runs.
+/// What: sets `TRUSTY_BM25_DAEMON_BIN` and clears external mode. Process-global
+/// and set identically by every test in this binary, so there is nothing to
+/// race.
+/// Test: used by every test below.
+fn arm() {
+    // SAFETY: test-only env mutation. Every test in this binary writes the
+    // same values, so concurrent execution cannot observe a torn state.
+    unsafe {
+        std::env::set_var(
+            "TRUSTY_BM25_DAEMON_BIN",
+            env!("CARGO_BIN_EXE_trusty-bm25-daemon"),
+        );
+        std::env::remove_var(ENV_EXTERNAL_BM25);
+    }
+}
+
+/// Short, collision-free palace name.
+///
+/// Why: the socket path is `$TMPDIR/trusty-bm25-<palace>.sock` and macOS'
+/// `$TMPDIR` is already ~50 bytes, so a long palace name blows past the
+/// kernel's `sun_path` limit and the bind fails for reasons unrelated to the
+/// behaviour under test.
+/// What: a two-character prefix plus the low bits of the pid.
+fn palace(prefix: &str, n: usize) -> String {
+    format!("{prefix}{:x}{n}", std::process::id() & 0xfff)
+}
+
+/// Remove any socket left behind by a previous crashed run.
+fn clear_socket(name: &str) {
+    let _ = std::fs::remove_file(trusty_common::bm25_client::socket_path_for_palace(name));
+}
+
+/// Why: the double-spawn race. Two callers hitting `ensure_running` for the
+/// same palace at the same moment both find an empty map, and without the
+/// spawn gate both launch a daemon — the second's `bind` fails, its process
+/// dies, and the map still ends up with one entry, so nothing downstream
+/// notices. This asserts on LAUNCHES, which is the only figure that separates
+/// the two implementations.
+/// What: eight genuinely-simultaneous callers on a multi-thread runtime, all
+/// for one palace. Exactly one daemon may be launched and all eight must get
+/// the same socket back.
+/// Test: this test itself. Remove `let _spawn = self.spawn_gate.lock().await;`
+/// from `ensure_running` and this reads 8, not 1.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_callers_for_one_palace_spawn_exactly_one_daemon() {
+    arm();
+    let name = palace("s", 0);
+    clear_socket(&name);
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sup = Arc::new(Bm25Supervisor::with_limits(8, None));
+
+    // A barrier makes the eight calls simultaneous rather than merely
+    // concurrent — without it the first task can finish its whole spawn
+    // before the eighth is scheduled, which is the serial case again.
+    let gate = Arc::new(tokio::sync::Barrier::new(8));
+    let mut set = JoinSet::new();
+    for _ in 0..8 {
+        let sup = Arc::clone(&sup);
+        let gate = Arc::clone(&gate);
+        let dir = tmp.path().to_path_buf();
+        let name = name.clone();
+        set.spawn(async move {
+            gate.wait().await;
+            sup.ensure_running(&name, &dir).await
+        });
+    }
+
+    let mut sockets = Vec::new();
+    while let Some(joined) = set.join_next().await {
+        sockets.push(
+            joined
+                .expect("task must not panic")
+                .expect("ensure_running"),
+        );
+    }
+
+    assert_eq!(sockets.len(), 8);
+    assert!(
+        sockets.windows(2).all(|w| w[0] == w[1]),
+        "every caller must be handed the same socket: {sockets:?}"
+    );
+    assert_eq!(
+        sup.spawned_count(),
+        1,
+        "eight simultaneous callers for one palace must launch exactly one \
+         daemon — a higher count means the spawn gate did not serialise them"
+    );
+    assert_eq!(
+        sup.supervised_count().await,
+        1,
+        "and exactly one child may be owned"
+    );
+
+    sup.shutdown().await;
+    clear_socket(&name);
+}
+
+/// Why: the aggregate-cap violation. A cross-palace fan-out has every caller
+/// evaluating the cap against a map nobody has inserted into yet, so each one
+/// individually concludes there is room and the population lands at N rather
+/// than at the cap. This is the failure the gate exists for, and a serial loop
+/// cannot produce it.
+/// What: six simultaneous callers for six distinct palaces against a cap of
+/// two. The resident population must land at the cap, not at six.
+/// Test: this test itself. Remove the spawn gate and this reads 6, not 2.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_concurrent_fanout_never_exceeds_the_cap() {
+    arm();
+    const FANOUT: usize = 6;
+    const CAP: usize = 2;
+
+    let names: Vec<String> = (0..FANOUT).map(|i| palace("f", i)).collect();
+    for n in &names {
+        clear_socket(n);
+    }
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sup = Arc::new(Bm25Supervisor::with_limits(CAP, None));
+
+    let gate = Arc::new(tokio::sync::Barrier::new(FANOUT));
+    let mut set = JoinSet::new();
+    for name in &names {
+        let sup = Arc::clone(&sup);
+        let gate = Arc::clone(&gate);
+        let dir = tmp.path().join(name);
+        let name = name.clone();
+        set.spawn(async move {
+            gate.wait().await;
+            sup.ensure_running(&name, &dir).await
+        });
+    }
+    while let Some(joined) = set.join_next().await {
+        joined
+            .expect("task must not panic")
+            .expect("ensure_running must succeed for every palace");
+    }
+
+    let live = sup.supervised_count().await;
+    assert!(
+        live <= CAP,
+        "a {FANOUT}-way simultaneous fan-out left {live} daemons resident \
+         against a cap of {CAP} — the cap was satisfied per-caller and \
+         violated in aggregate"
+    );
+    assert_eq!(
+        live, CAP,
+        "the cap should be saturated, not undershot: {live}"
+    );
+    assert_eq!(
+        sup.reaped_count(),
+        (FANOUT - CAP) as u64,
+        "every daemon above the cap must be reaped, and counted"
+    );
+
+    sup.shutdown().await;
+    for n in &names {
+        clear_socket(n);
+    }
+}
+
+/// Why: `lookup_live` evicts a child that has exited and lets `ensure_running`
+/// fall through to a fresh spawn. That restart path had no test at all — the
+/// supervisor's doc comment cited one that did not exist.
+/// What: spawns a daemon, kills it outside the supervisor's knowledge, removes
+/// the orphaned socket file so the adoption path cannot mask the restart, then
+/// calls `ensure_running` again and asserts a second launch happened.
+/// Test: this test itself.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_dead_child_is_evicted_and_respawned() {
+    arm();
+    let name = palace("d", 0);
+    clear_socket(&name);
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sup = Bm25Supervisor::with_limits(4, None);
+
+    let socket = sup
+        .ensure_running(&name, tmp.path())
+        .await
+        .expect("first spawn");
+    assert_eq!(sup.spawned_count(), 1);
+    assert_eq!(sup.supervised_count().await, 1);
+
+    // Kill the daemon behind the supervisor's back, the way a crash or an
+    // out-of-band `kill` would.
+    kill_daemon_for(&socket).await;
+
+    let respawned = sup
+        .ensure_running(&name, tmp.path())
+        .await
+        .expect("dead child must be evicted and a fresh daemon spawned");
+    assert_eq!(respawned, socket);
+    assert_eq!(
+        sup.spawned_count(),
+        2,
+        "a dead child must be replaced by a NEW process, not silently reused"
+    );
+    assert_eq!(sup.supervised_count().await, 1);
+    assert_eq!(
+        sup.reaped_count(),
+        0,
+        "removing a corpse reclaims nothing and must not count as a reap"
+    );
+
+    sup.shutdown().await;
+    clear_socket(&name);
+}
+
+/// SIGKILL whatever is listening on `socket`, then remove the socket file.
+///
+/// Why: the supervisor must observe a dead child, not an adoptable socket. If
+/// the file survives, `ensure_running`'s socket-adoption branch returns before
+/// the eviction path is reached and the test proves nothing.
+/// What: finds the pid via `lsof`, kills it, waits for the socket to stop
+/// accepting, and unlinks the file.
+async fn kill_daemon_for(socket: &std::path::Path) {
+    let out = tokio::process::Command::new("lsof")
+        .arg("-t")
+        .arg(socket)
+        .output()
+        .await
+        .expect("lsof must be available");
+    let pids: Vec<i32> = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|l| l.trim().parse().ok())
+        .collect();
+    assert!(!pids.is_empty(), "no process holds {}", socket.display());
+    for pid in pids {
+        // SAFETY: `kill` with a pid read from lsof; the kernel returns ESRCH
+        // rather than misbehaving if the process is already gone.
+        unsafe {
+            libc::kill(pid, libc::SIGKILL);
+        }
+    }
+    for _ in 0..200 {
+        if tokio::net::UnixStream::connect(socket).await.is_err() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let _ = std::fs::remove_file(socket);
+}


### PR DESCRIPTION
## Defect

The BM25 lexical lane has never run. `bm25_search_optional` returns on its first line unless `TRUSTY_BM25_DAEMON=1` was set at daemon startup, and no plist, installer, or shipped path sets it. There are zero BM25 index directories across ~99 palaces, so the fusion code in `handle_memory_recall` has never executed.

Turning it on, as-is, would not have produced a working lexical lane. Three things stood in the way.

**1. The write path drops silently under load.** `tools/bm25.rs:82` and `:189-198` — a 256-slot mpsc written with `try_send`, dropping on full with a `warn!`. trusty-tools holds 1311 drawers, five times the queue. A backfill reusing `bm25_index_enqueue` would have dropped roughly 80% of the corpus and left the palace answering lexical queries from a fifth of its content — indistinguishable from working fusion.

**2. `Bm25Supervisor` never evicted.** Only `shutdown` removed a map entry. One cross-palace `recall_all` over ~99 palaces left 99 child processes resident for the trusty-memory daemon's whole life, each one's memory scaling with its palace's drawer text (`PalaceBm25Index` retains every document's full text in a `BTreeMap`).

**3. Nothing could ask whether a palace was fully indexed.** The protocol had `index` and `search` only, so an empty hit list was ambiguous between "no match" and "nothing indexed" — the fail-open shape this whole change exists to remove.

## Resolution

**The write path is left exactly as it is.** Drop-on-full is defensible there: the drawer is durable in redb, `memory_remember` must not wait on daemon RTT, and a dropped index op now self-heals because backfill detects the coverage shortfall via `stats` and repairs it. Widening the queue would only move the cliff.

**Backfill gets its own feeder** (`bm25_backfill.rs`) that awaits each document's ack, so nothing is ever offered to a full queue. Idempotent (`upsert_document` is keyed by `doc_id`), bounded by a 10 s per-op and 120 s per-palace deadline, and it reads coverage back from the daemon rather than trusting its own submission count — `fully_indexed()` returns `false` for a `Completed` run whose read-back failed. Runs as a serial startup sweep over palaces that have drawers; `TRUSTY_BM25_NO_BACKFILL=1` defers it.

**The supervisor bounds its population** (#2845, #2846). A cap with LRU reaping (`TRUSTY_BM25_MAX_DAEMONS`, default 3) and a per-daemon RSS ceiling compared against a real measurement rather than merely declared (`TRUSTY_BM25_RSS_LIMIT_MB`, default 512, `0` disables). Spawns are serialised so a burst fan-out cannot satisfy the cap per-caller and violate it in aggregate. An unmeasurable RSS never reaps — `None` means "no reading", not "zero", and reaping on it would turn a memory guardrail into an outage. `process_rss_mb` lands in `trusty-common::sys_metrics` so the next supervisor that needs it does not grow its own `/proc` parser.

**A `stats` op** reports `doc_count` and `total_text_bytes`, answered inline by the batch worker so it reflects un-flushed writes.

**Plus a durability defect the cap surfaced.** The daemon exited on SIGTERM without flushing: the worker's final flush is gated on the op channel closing, and the accept loop holds a sender for the process lifetime, so up to one write window was lost on every exit. Latent while daemons only died at shutdown; routine once the supervisor reaps them. `a_reaped_palace_respawns_on_next_use` caught it and now pins the fix.

## Fail-open evidence

Each arm degrades to a reported status with a bounded wait — never an error into a caller's path, never a hang.

| Arm | Test |
|---|---|
| Daemon absent | `backfill_reports_daemon_unavailable_when_socket_is_dead` (also asserts it fails fast, not by waiting out the deadline) |
| Daemon spawn fails / lane off | `backfill_state_palace_is_disabled_without_a_client` |
| Socket accepts but never answers | `backfill_gives_up_on_a_socket_that_never_answers` |
| Index empty | `empty_palace_is_already_indexed`, `batch_queue_stats_go_to_zero_after_rebuild` |
| Index partial | `partial_index_is_detected_and_repaired`, `fully_indexed_requires_a_read_back_count` |
| Queue saturated | `backfill_indexes_every_drawer_without_drops` — 1024 docs, 4× the write path's queue; a drop-on-full feeder lands ~256 |
| Unbounded fan-out | `daemon_population_stays_within_the_cap`, `exceeding_the_cap_reaps_the_least_recently_used` |
| Unenforced RSS limit | `over_rss_limit_children_are_reaped`, `under_rss_limit_children_are_left_alone`, `over_rss_limit_is_false_without_a_measurement` |

## Gates — rung 5

```
cargo fmt --check                                          — clean
cargo test -p trusty-bm25-daemon                           — 41 passed, 0 failed (unit) + 3 passed (integration)
cargo test -p trusty-common --features memory-core         — 892 passed, 0 failed, 13 ignored (+ 21 across 3 integration targets)
cargo test -p trusty-memory                                — 581 passed, 0 failed, 4 ignored (lib) + all integration targets green
cargo test -p trusty-memory --test bm25_backfill_e2e -- --include-ignored
                                                           — 4 passed, 0 failed
cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui — clean
cargo clippy -p trusty-bm25-daemon --all-targets -- -D warnings — clean
scripts/check_line_cap.sh                                  — 3746 files, 0 violations
scripts/check_changelog_fragment.sh                        — 3/3 crates recorded
scripts/check_sld.sh                                       — 0 errors, 0 warnings
```

Two gates were scoped, both with proof rather than by narrowing coverage:

- **`cargo check --workspace`** fails on `trusty-code-gui` for an unbuilt `ui/dist` in a fresh worktree. `git diff --name-only origin/main...HEAD -- crates/trusty-code-gui/ crates/trusty-mpm-gui/` lists **0 paths**.
- **`cargo clippy -p trusty-memory -- -D warnings`** is blocked by a pre-existing `nonminimal_bool` lint in `trusty-common/src/memory_core/retrieval/embed_repair.rs:139`, which builds as a dependency. `git diff origin/main -- <that file>` is **empty** — the file is byte-identical to main. With that one lint allowed, `cargo clippy -p trusty-memory --all-targets -- -D warnings -A clippy::nonminimal_bool` is clean, so nothing in this diff introduces a lint.

## Measured

- **Backfill throughput:** 1024 documents in **84 ms** against a real daemon. The whole ~2300-drawer corpus is a few seconds.
- **Steady-state daemon count: 3** (the default cap), regardless of how many palaces are touched. `daemon_population_stays_within_the_cap` drives 5 palaces through a cap of 2 and asserts the population never exceeds it, ends at exactly 2, and reaped exactly 3.

## Scope

Piece 1 of 3. **The lane is still off** — this PR does not flip `TRUSTY_BM25_DAEMON`'s default, and `backfill_state_palace_is_disabled_without_a_client` asserts that. Not incomplete; the flip is piece 2, along with hook routing to `/rpc` and `handle_memory_recall_deep`'s missing fusion.

Keeping `TRUSTY_BM25_DAEMON` as the switch rather than adding a config key: agreed after reading the code. It is a trusty-memory daemon-lifetime setting and does not belong in trusty-mpm's `config.toml`. The two new knobs follow the same convention.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
