### PR TITLE
fix(trusty-agents): pin the loopback bind default with a regression test; correct stale 0.0.0.0 docs

### DIFF
--- a/crates/trusty-agents/changelog.d/3329-loopback-bind-regression-guard.md
+++ b/crates/trusty-agents/changelog.d/3329-loopback-bind-regression-guard.md
@@ -1,0 +1,21 @@
+Fixed
+
+- Pinned the API server's loopback bind default with a regression test and
+  collapsed the duplicated default into one place
+  (follow-up to [#3329](https://github.com/bobmatnyc/trusty-tools/issues/3329)).
+  The `0.0.0.0` bind itself was fixed in
+  [#3341](https://github.com/bobmatnyc/trusty-tools/pull/3341); the suite
+  covered only the *refusal* of a non-loopback bind without a token, so nothing
+  would have caught the default itself being flipped back — verified by
+  reintroducing `0.0.0.0` and watching the two new tests fail while all six
+  pre-existing guard tests stayed green. `--bind` is now parsed into an
+  `Option<IpAddr>` and resolved through the new `ApiConfig::with_bind`, so the
+  raw-argv path in `runtime::startup` and the clap path in
+  `runtime::mode_dispatch` can no longer drift apart on a security-relevant
+  default.
+- Corrected the `auth.rs` module and `auth_middleware` doc comments, which
+  still stated as fact that the server binds `0.0.0.0` and that bearer auth is
+  what keeps it off the LAN. Both have been false since #3341 — the bind is the
+  control, and on the loopback default the auth middleware is not installed at
+  all. This stale text was the evidence cited in the original report and caused
+  the exposure to be re-investigated as if it were still live.

--- a/crates/trusty-agents/src/api/server/auth.rs
+++ b/crates/trusty-agents/src/api/server/auth.rs
@@ -1,11 +1,14 @@
 //! Server configuration + bearer-token auth middleware (#181).
 //!
-//! Why: The server binds `0.0.0.0`, so any process on the LAN can reach the
-//! REST API + UI. Bearer-token auth, configurable per launch, gates the
-//! sensitive `/api/*` routes while exempting health/config/events probes and
-//! the embedded UI assets.
-//! What: `ApiConfig` carries the port + optional token; `auth_middleware`
-//! enforces the token; `ApiClientConfig` tells the UI whether auth is needed.
+//! Why: The server binds loopback (`127.0.0.1`) by default, so auth is not the
+//! control that keeps it off the LAN — the bind is (#3329). Bearer-token auth
+//! covers the one case the bind cannot: an operator who explicitly opts into a
+//! non-loopback `--bind`, which `serve_with_config` refuses to start without a
+//! token. It gates the sensitive `/api/*` routes while exempting
+//! health/config/events probes and the embedded UI assets.
+//! What: `ApiConfig` carries the bind + port + optional token;
+//! `auth_middleware` enforces the token; `ApiClientConfig` tells the UI whether
+//! auth is needed.
 //! Test: `auth_middleware_*` and `config_endpoint_*` in `super::tests`.
 
 use axum::{
@@ -57,6 +60,26 @@ impl ApiConfig {
             token: None,
         }
     }
+
+    /// Build a config from an optional operator-supplied bind. (#3329)
+    ///
+    /// Why: `--bind` is parsed in two independent places — the `--api` early
+    /// dispatch in `runtime::startup` (raw argv, so the Tauri sidecar can skip
+    /// PM state init) and the clap path in `runtime::mode_dispatch`. Both must
+    /// apply the same loopback default; an `unwrap_or(LOCALHOST)` open-coded at
+    /// each site leaves a security-relevant default free to drift between them.
+    /// `serve_with_config` still enforces the doctrine whatever this returns,
+    /// so this is defence in depth rather than the primary control.
+    /// What: `None` → `127.0.0.1`. `Some(ip)` is taken verbatim; a non-loopback
+    /// `ip` is then refused by `serve_with_config` unless `token` is `Some`.
+    /// Test: `unspecified_bind_defaults_to_loopback`.
+    pub fn with_bind(bind: Option<std::net::IpAddr>, port: u16, token: Option<String>) -> Self {
+        Self {
+            bind: bind.unwrap_or_else(|| std::net::Ipv4Addr::LOCALHOST.into()),
+            port,
+            token,
+        }
+    }
 }
 
 /// Wrapper used by the auth middleware so axum can extract the optional
@@ -90,10 +113,13 @@ pub(super) fn bearer_token_matches(expected: &str, provided: &str) -> bool {
 
 /// Bearer-token authentication middleware. (#181)
 ///
-/// Why: The server binds `0.0.0.0`, so any process on the LAN can reach the
-/// REST API + UI. When the operator sets a token, we reject requests that
-/// don't present it. We deliberately exempt `GET /api/health` so probes from
-/// load balancers or healthchecks don't need credentials, and exempt the
+/// Why: On the loopback default this middleware is not installed at all — a
+/// local caller reaches every route, which is the accepted posture for a
+/// same-host daemon (#3329). It exists for the non-loopback `--bind` opt-in,
+/// where `serve_with_config` requires a token: there, any host that can route
+/// to the port must present it. We deliberately exempt `GET /api/health` so
+/// probes from load balancers or healthchecks don't need credentials, and
+/// exempt the
 /// embedded UI's static assets so a browser can load `index.html` and obtain
 /// the token via `/api/config` before issuing authenticated requests.
 /// What: For requests under `/api/*` (other than `/api/health`), checks

--- a/crates/trusty-agents/src/api/server/tests/guard.rs
+++ b/crates/trusty-agents/src/api/server/tests/guard.rs
@@ -153,3 +153,46 @@ async fn non_loopback_without_token_refuses_start() {
         "refusal should point at the console proxy as the intended remote path, got: {msg}"
     );
 }
+
+/// Why: #3329's control is the DEFAULT bind, not the refusal — the refusal only
+/// fires once something has already chosen a non-loopback address.
+/// `non_loopback_without_token_refuses_start` covers that branch; nothing
+/// pinned the default itself, so flipping `unauthenticated` back to `0.0.0.0`
+/// would restore the original LAN exposure with every other test still green.
+/// This is the assertion that fails against the pre-#3341 code, where the
+/// server bound `0.0.0.0` unconditionally.
+/// What: asserts the no-token constructor binds a loopback address.
+/// Test: this test.
+#[test]
+fn unauthenticated_config_binds_loopback() {
+    let cfg = ApiConfig::unauthenticated(7654);
+    assert!(
+        cfg.bind.is_loopback(),
+        "the unauthenticated default must bind loopback, got {}",
+        cfg.bind
+    );
+}
+
+/// Why: `--bind` is parsed independently in `runtime::startup` (raw argv) and
+/// `runtime::mode_dispatch` (clap). Both now route through
+/// `ApiConfig::with_bind`, so this pins the shared default once instead of
+/// trusting two open-coded `unwrap_or`s to stay in agreement.
+/// What: absent `--bind` resolves to loopback; an explicit address is taken
+/// verbatim so `serve_with_config` can apply the token gate to it.
+/// Test: this test.
+#[test]
+fn unspecified_bind_defaults_to_loopback() {
+    assert!(
+        ApiConfig::with_bind(None, 7654, None).bind.is_loopback(),
+        "omitting --bind must resolve to loopback"
+    );
+    let explicit = ApiConfig::with_bind(
+        Some(std::net::Ipv4Addr::UNSPECIFIED.into()),
+        7654,
+        Some("tok".to_string()),
+    );
+    assert!(
+        !explicit.bind.is_loopback(),
+        "an explicit --bind must be passed through verbatim for the token gate to judge"
+    );
+}

--- a/crates/trusty-agents/src/runtime/mode_dispatch.rs
+++ b/crates/trusty-agents/src/runtime/mode_dispatch.rs
@@ -215,14 +215,9 @@ pub(super) async fn dispatch_cli_mode(
             .filter(|s| !s.is_empty());
         // #3329: default to loopback; `--bind` is the explicit non-loopback
         // opt-in (which serve_with_config gates on a token being present).
-        let bind = cli
-            .bind
-            .unwrap_or_else(|| std::net::Ipv4Addr::LOCALHOST.into());
-        return crate::api::server::serve_with_config(crate::api::server::ApiConfig {
-            bind,
-            port,
-            token,
-        })
+        return crate::api::server::serve_with_config(crate::api::server::ApiConfig::with_bind(
+            cli.bind, port, token,
+        ))
         .await;
     }
 

--- a/crates/trusty-agents/src/runtime/startup.rs
+++ b/crates/trusty-agents/src/runtime/startup.rs
@@ -345,20 +345,20 @@ pub(super) async fn run_startup_init(_args: &[String]) -> Result<bool> {
             // #3329: `--bind <addr>` / `--bind=<addr>`; default loopback. A
             // non-loopback bind without a token is refused inside
             // serve_with_config (loopback-only doctrine).
-            let mut bind: std::net::IpAddr = std::net::Ipv4Addr::LOCALHOST.into();
+            let mut bind: Option<std::net::IpAddr> = None;
             let mut iter = raw_args.iter();
             while let Some(a) = iter.next() {
                 if a == "--bind"
                     && let Some(v) = iter.next()
                     && let Ok(ip) = v.parse::<std::net::IpAddr>()
                 {
-                    bind = ip;
+                    bind = Some(ip);
                     break;
                 }
                 if let Some(rest) = a.strip_prefix("--bind=")
                     && let Ok(ip) = rest.parse::<std::net::IpAddr>()
                 {
-                    bind = ip;
+                    bind = Some(ip);
                     break;
                 }
             }
@@ -390,7 +390,8 @@ pub(super) async fn run_startup_init(_args: &[String]) -> Result<bool> {
                 api::watchdog::arm_parent_death_watchdog(pp);
             }
 
-            api::server::serve_with_config(api::server::ApiConfig { bind, port, token }).await?;
+            api::server::serve_with_config(api::server::ApiConfig::with_bind(bind, port, token))
+                .await?;
             return Ok(false);
         }
     }

--- a/docs/reference/threat-model.md
+++ b/docs/reference/threat-model.md
@@ -65,14 +65,25 @@ the daemons' listener setup code moves independently of this doc.
 | **trusty-memory** | `127.0.0.1:7070`–`7079` (auto-selects next free); `--http` accepts any explicit addr | **Yes** — router-wide `SelfOrigins` guard (`web/mod.rs`) | Yes (`memory` → `trusty-memory`) | Yes, embedded (`ui/`) | CLI, native MCP stdio bridge — a pure HTTP proxy forwarding JSON-RPC to the daemon's own `/rpc` (no local tool logic), embedded UI, console proxy |
 | **trusty-analyze** | `127.0.0.1:7879` (`commands/port.rs::DEFAULT_PORT`) | **Yes** — router-wide `SelfOrigins` guard (`service/routes.rs`) | Yes (`analyze` → `trusty-analyze`) | Yes, embedded (`ui/`) | CLI, native MCP stdio bridge, embedded UI, console proxy, **direct GitHub webhook** (`POST /webhooks/github` — see Known Gaps) |
 | **trusty-review** | `127.0.0.1:7891` | **Yes** — `SelfOrigins` guard wraps all routes (`service/routes.rs`) | Yes (`review` → `trusty-review`) | No embedded UI | CLI, console proxy, HMAC-verified GitHub webhook (signature check is independent of the origin guard) |
-| **trusty-agents** | **`0.0.0.0:7654`** (LAN-reachable by default) — optional bearer auth, **off by default** | **No** | **No** — not yet in the allowlist | Yes, separate `agents-ui` crate | CLI, native MCP stdio bridge, `agents-ui` (Tauri, talks directly to the `0.0.0.0` API), any host on the LAN (this is the gap) |
+| **trusty-agents** | `127.0.0.1:8080` (`--port`; 7654 is the conventional dev/UI port, passed explicitly). `--bind` is an explicit non-loopback opt-in that `serve_with_config` **refuses to start without `--api-token`** (`api/server/routes.rs`) | **Yes** — router-wide `SelfOrigins` guard via `with_guarded_middleware` (`api/server/routes.rs::build_router_with_origins`) | Yes (`agents` → `trusty-agents`, #3331) | Yes, separate `agents-ui` crate | CLI, native MCP stdio bridge, `agents-ui` (Tauri — writes go over Tauri IPC, not HTTP), console proxy |
 | **trusty-mpm** | `127.0.0.1:7880` | **Yes** — `guard_router` wraps the listener with the `SelfOrigins` guard (`daemon/api/origin_guard.rs`) | Yes (`mpm` → `trusty-mpm`, #1849 Phase 1) | No embedded UI (separate `trusty-mpm-gui` Tauri app) | CLI (`tm`), native MCP stdio bridge, `trusty-mpm-gui` (talks **directly** to the daemon, not gateway-first — migration tracked as [#3333](https://github.com/bobmatnyc/trusty-tools/issues/3333), #1849 Phase 2), console proxy |
 | **trusty-console** | `127.0.0.1:7788` by default; `--tailscale` widens to a dual listener (loopback + tailnet IP); Funnel mode (ADR-0017, Proposed) layers public HTTPS on top | Yes — the original router-wide guard this pattern was lifted from (`crates/trusty-common/src/server/origin_guard.rs` docs the provenance: #3268/#3269/#3280) | n/a — console is the proxy, not a proxied target (`full_id("console")` is explicitly `None`) | Yes, the dashboard SPA | Browsers (local or, in `--tailscale`/Funnel mode, remote), every CLI/UI above via the reverse proxy, and — the **sole off-loopback surface** per ADR-0018 |
 
-**One item above is still in progress:** trusty-agents'
-bind/guard/allowlist fix (#3329, epic #3328). The trusty-mpm `--tailscale`
-listener removal (#3330) and trusty-review origin guard (#3332) are resolved in
-this version.
+**Every row above is now resolved.** trusty-agents' bind/guard/allowlist fix
+(#3329, epic #3328) landed in [#3341](https://github.com/bobmatnyc/trusty-tools/pull/3341)
+together with the console `agents` proxy route (#3331); the trusty-mpm
+`--tailscale` listener removal (#3330) and trusty-review origin guard (#3332)
+were resolved earlier.
+
+**Remote access to trusty-agents goes through trusty-console**, not through a
+direct bind. Per [ADR-0018](../adr/0018-loopback-only-doctrine.md) console is
+the sole off-loopback surface and the only component that widens over
+Tailscale, and [ADR-0031](../adr/0031-uds-for-inter-crate-transport-http-for-external.md) routes all
+external comms through the one shared HTTP server. trusty-agents publishes its
+bound address to the standard `http_addr` discovery file so the console proxy
+resolves `/api/agents/*` to it. The `--bind` escape hatch remains for the case
+console cannot cover, which is why it is token-gated at startup rather than
+merely discouraged.
 
 ## Why the guard fails open on a missing `Origin` header
 
@@ -129,9 +140,10 @@ firing a cross-origin write.
 - **trusty-agents' undeclared 7th HTTP surface.** `crates/trusty-agents/src/search/service/mod.rs`
   runs a per-project search-as-a-service daemon in the background (PID
   tracked at `.trusty-agents/state/search.pid`). It does not appear in any
-  daemon inventory, port table, or (until this document) threat model; it is
-  not currently subject to the loopback-only doctrine's enforcement and is
-  not wrapped by the shared write-origin guard. Tracked as
+  daemon inventory, port table, or (until this document) threat model. It does
+  bind loopback — `TcpListener::bind("127.0.0.1:0")`, hardcoded, so there is no
+  configuration that widens it — but that is incidental rather than enforced,
+  and it is not wrapped by the shared write-origin guard. Tracked as
   [#3335](https://github.com/bobmatnyc/trusty-tools/issues/3335) — needs
   either formal declaration (loopback bind + guard) or retirement.
 


### PR DESCRIPTION
## The reported exposure is already fixed; the docs saying otherwise are not

trusty-agents was reported as binding `0.0.0.0:7654` unauthenticated. It does not. [#3341](https://github.com/bobmatnyc/trusty-tools/pull/3341) landed the loopback default on 2026-07-19 and closed [#3329](https://github.com/bobmatnyc/trusty-tools/issues/3329). Current `origin/main`:

- `ApiConfig::unauthenticated` binds `127.0.0.1`; both CLI paths default to loopback.
- `serve_with_config` **refuses to start** on a non-loopback bind without `--api-token`, before opening a socket (`api/server/routes.rs`).
- The router-wide `SelfOrigins` write guard is applied via the shared `trusty_common::server::with_guarded_middleware`.
- `agents` is in the console proxy allowlist (`full_id("agents") => Some("trusty-agents")`, #3331).

Verified on this machine: nothing listens on 7654, and every running daemon binds loopback.

```
trusty-co  3804 TCP 127.0.0.1:7788 (LISTEN)
trusty-mp 28532 TCP 127.0.0.1:7880 (LISTEN)
trusty-se 30736 TCP 127.0.0.1:7878 (LISTEN)
trusty-an 36061 TCP 127.0.0.1:7879 (LISTEN)
trusty-me 98860 TCP 127.0.0.1:7070 (LISTEN)
```

Two things were genuinely wrong, and this PR fixes both.

### 1. The default was untested

`non_loopback_without_token_refuses_start` covers the refusal branch — which only fires once something has already chosen a non-loopback address. Nothing pinned the default itself. Proof: reintroducing `0.0.0.0` as the default leaves all six pre-existing guard tests green.

```
test result: FAILED. 6 passed; 2 failed
  api::server::tests::guard::unauthenticated_config_binds_loopback
    panicked: the unauthenticated default must bind loopback, got 0.0.0.0
  api::server::tests::guard::unspecified_bind_defaults_to_loopback
    panicked: omitting --bind must resolve to loopback
```

Both new tests fail against the pre-fix state and pass against this branch. `--bind` now parses into `Option<IpAddr>` and resolves through `ApiConfig::with_bind`, so the raw-argv path in `runtime::startup` (the Tauri sidecar's PM-state bypass) and the clap path in `runtime::mode_dispatch` cannot drift apart on a security-relevant default.

### 2. The docs still described the vulnerable state

`auth.rs:3` and `auth.rs:93` asserted as fact that "the server binds `0.0.0.0`, so any process on the LAN can reach the REST API + UI", and that bearer auth is what gates it. Both false since #3341 — the bind is the control, and on the loopback default the auth middleware is **not installed at all**. That stale text is the evidence quoted in #3329 and is what caused this to be re-reported as a live exposure. `docs/reference/threat-model.md` carried the same drift: its trusty-agents row said `0.0.0.0:7654`, origin guard "No", allowlist "No" — all three wrong — plus a paragraph calling the fix "still in progress".

## What an unauthenticated caller can actually reach

Asked explicitly, so stated in full.

**On the default config (loopback, no token), a local caller reaches all 45 routes.** `auth_middleware` is only layered in when a token is set, so with `token: None` there is no authentication anywhere. That includes:

| Route | What it grants |
|---|---|
| `POST /api/task` | Spawns arbitrary subprocesses — code execution as the user. The repo's own guard docs call it "DESTRUCTIVE" |
| `POST /rpc` | The full JSON-RPC/MCP tool surface |
| `POST /api/tm/sessions/{name}/send`, `/api/tm/tell` | Injects text into live trusty-mpm sessions — code execution by proxy |
| `POST /api/ctrl/sessions`, `.../attach` | Create/attach CTRL sessions |
| `DELETE /api/task/{id}`, `DELETE /api/tasks`, `POST /api/clear-context` | Destroy in-flight and historical work |
| `PATCH /api/agents/{name}/permissions`, `/persona`, `/skills`, `/stores` | Mutate agent permission ceilings |
| `GET /api/tm/sessions/{name}/pane` | Reads live terminal pane content |
| `GET /api/agents/{name}/knowledge`, `/kg/*` | Agent knowledge-graph contents |

Two controls stand between that surface and an attacker, and only one of them is load-bearing:

1. **The loopback bind.** Load-bearing. An attacker must already have local code execution, at which point they run as the user anyway. This is the standard same-host daemon posture, identical to trusty-search/memory/analyze/review/mpm.
2. **The write-origin guard.** Not an authn control, and should not be read as one. It is method-gated (writes only) and **fails open on a missing `Origin` header** by design, so it stops a malicious *web page* the operator visits from driving writes cross-origin (CSRF), but does nothing against `curl` or a malicious npm postinstall script running locally.

**Severity: Low as it stands.** Pre-#3341 this was Critical — unauthenticated RCE from any host on the LAN. Today, exploitation presupposes the local code execution that would make it redundant.

**One residual gap, unchanged by this PR and reported rather than fixed:** `GET /api/health`, `/api/config`, and `/api/events` stay exempt from auth even when a token *is* set (`auth.rs`). `/api/events` is the SSE telemetry stream, exempt because browser `EventSource` cannot attach headers. On the loopback default that is local-only and uninteresting. On the token-guarded `--bind` opt-in it means the telemetry stream is readable by any host that can route to the port. Deliberate and documented — the in-code guidance is to front that deployment with a reverse proxy — but worth naming since it is the one thing a token does not cover.

## Remote access: option (a), through the console proxy

Asked to choose between (a) loopback-only behind trusty-console's proxy and (b) a per-daemon Tailscale path. **(a)**, and it is already built:

- [ADR-0018](https://github.com/bobmatnyc/trusty-tools/blob/main/docs/adr/0018-loopback-only-doctrine.md) makes trusty-console the sole off-loopback surface and the only component that widens over Tailscale. A Tailscale binder inside trusty-agents contradicts it directly.
- [ADR-0031](https://github.com/bobmatnyc/trusty-tools/blob/main/docs/adr/0031-uds-for-inter-crate-transport-http-for-external.md) routes all external comms through the one shared HTTP server. Same conclusion.
- The plumbing exists: trusty-agents writes its bound address to the standard `http_addr` discovery file, `agents` is in the proxy allowlist, and the startup refusal message already points operators at `/api/agents/*`. Option (b) would build a second remote path duplicating a working one.
- Nothing needs (b). trusty-agents is unreleased (0.38.6, no tags, not on crates.io), is not running here, and its only direct consumer — `agents-ui` — is a Tauri app whose writes travel over Tauri IPC, never HTTP.

The `--bind` escape hatch stays: explicit opt-in, never the default, refused without a token, and now documented in the threat model as required.

## Gates — rung 5

```
cargo fmt --check                                      EXIT=0
cargo check -p trusty-agents --all-targets             EXIT=0
cargo clippy -p trusty-agents --all-targets -D warnings EXIT=0
cargo test -p trusty-agents      test result: ok. 3377 passed; 0 failed; 11 ignored
                                 (+ 10 further suites, all ok, 0 failed)
cargo test -p trusty-agents-local EXIT=0 (0 tests — crate has none; compiles against the change)
scripts/check_line_cap.sh        3745 files, 0 violations
scripts/check_sld.sh             56 specs + 4093 files, 0 errors, 0 warnings
scripts/check_changelog_fragment.sh  all crates with source changes recorded
```

`cargo check --workspace` is not run: it fails on `trusty-code-gui`/`trusty-mpm-gui` for unbuilt `ui/dist`. This diff touches neither — it is confined to `crates/trusty-agents/` and `docs/reference/threat-model.md`. `ApiConfig` is used nowhere outside trusty-agents, and the only crate depending on the package (`trusty-agents-local`) builds and tests clean; the change to `ApiConfig` is additive.

Refs #3329

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
