### PR TITLE
ci: add a public-API/SemVer gate against crates.io (#5050)

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,0 +1,88 @@
+# Public-API / SemVer gate for the trusty-tools workspace (issue #5050).
+#
+# The workspace publishes 20+ crates to crates.io and had no check that a
+# breaking public-API change carried a matching version bump. #4088 is what that
+# costs: `trusty-common` 0.22.5 added a required public field on a patch bump,
+# every dependent on a `^0.22` floor stopped compiling on a lockfile-free
+# `cargo install`, and `trusty-analyze` 0.7.3 was yanked. A workspace
+# `cargo check` cannot see that class of break — the root Cargo.toml's path
+# override always pairs local source with local dependency — so this job
+# compares against the REGISTRY instead.
+#
+# Cost control: the gate is diff-scoped, the same way check_changelog_fragment.sh
+# is. It builds rustdoc for a crate only when that crate's `src/**` changed AND
+# it is published AND its declared version does not already carry a breaking
+# bump. On a docs-only, CI-only, or unpublished-crate PR the job is a few
+# seconds of git and metadata; the two rustdoc builds are paid only by the PRs
+# that can actually cause the defect.
+#
+# Deliberately NO `paths:` filter (issue #4468): a required check skipped by a
+# path filter never reports on the PRs it skips and leaves them pending forever.
+# This job always runs and reports SUCCESS on an exempt PR — the exemption lives
+# in the script, not the trigger.
+#
+# `pull_request` only: crate selection is a diff against the base branch, which
+# is empty (and would trip the gate's own scan floor) on a push to main.
+name: SemVer checks
+
+on:
+  pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # and is the event a base-branch RETARGET fires, so without it a stacked PR
+    # retargeted onto main never re-triggers. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+    branches: [main]
+
+concurrency:
+  group: semver-checks-${{ github.ref }}
+  cancel-in-progress: ${{ github.event.action != 'edited' }}
+
+jobs:
+  semver-checks:
+    name: Public API / SemVer
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      # fetch-depth: 0 — the gate needs `git merge-base` against the base
+      # branch, which a shallow checkout cannot resolve.
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # A prebuilt binary, PINNED. `cargo install cargo-semver-checks` compiles
+      # ~2 minutes of tool before a single crate is checked, which is exactly the
+      # kind of overhead that gets a gate disabled. install-action downloads a
+      # release artifact instead, and pinning the version keeps a tool release
+      # from silently changing the lint set under a PR. It also never touches
+      # this workspace's Cargo.lock — refreshing that turns the MSRV 1.94 job
+      # red (see CLAUDE.md, "Version bumps must not refresh Cargo.lock").
+      - name: Install cargo-semver-checks (pinned prebuilt)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-semver-checks@0.50.0
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: semver-checks
+          # cargo-semver-checks builds into target/semver-checks/, which
+          # rust-cache prunes as "unrecognised" by default. Keeping it is the
+          # difference between a warm 1-minute check and a cold 5-minute one.
+          cache-directories: target/semver-checks
+
+      # Runs BEFORE the real gate, matching line-cap.yml's selftest-then-gate
+      # ordering: a gate that cannot fail makes the real run's green meaningless.
+      # These four cases are the gate's fail-open surface — an unscanned diff and
+      # an unreachable crates.io — plus the 404 case that proves the other three
+      # fail for the right reason.
+      - name: SemVer gate selftest (must refuse a blind run)
+        run: bash scripts/check_semver_selftest.sh
+
+      - name: Enforce public-API SemVer against crates.io
+        env:
+          SEMVER_GATE_BASE: ${{ github.event.pull_request.base.sha }}
+          SKIP_UI_BUILD: '1'
+        run: bash scripts/check_semver.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,18 @@ waits, the `tga` tag aliases (#1128), and the connection-safe daemon restart.
 > **Full release workflow, `scripts/bump-version.sh`, and Developer-ID signing
 > setup:** see [docs/reference/release-workflow.md](docs/reference/release-workflow.md).
 
+🔴 **A breaking public-API change needs a matching version bump, and CI now
+enforces it (#5050).** `scripts/check_semver.sh` runs `cargo-semver-checks`
+against the crate's latest crates.io release for every crate whose `src/**` the
+PR changed. Cargo's 0.x rule applies: for a `0.y.z` crate the breaking bump is
+the MINOR position. A workspace `cargo check` can never catch this class of
+break — the root `Cargo.toml` path override pairs local source with local
+dependency — which is how #4088 shipped `trusty-common` 0.22.5's required new
+public field on a patch bump and cost `trusty-analyze` 0.7.3 a yank. Prefer
+`#[non_exhaustive]` on public structs and enums so field and variant additions
+stay non-breaking by construction. See
+[docs/reference/semver-gate.md](docs/reference/semver-gate.md).
+
 🔴 **CRITICAL macOS note:** never use `cp` to install a release binary on
 macOS — always `cargo install`. A plain `cp` over an on-PATH binary leaves a
 stale kernel cdhash cache and the next exec is SIGKILL'd as an invalid
@@ -430,5 +442,6 @@ Full-length reference materials for less-frequent lookups:
 - **HTTP trust-boundary threat model:** [docs/reference/threat-model.md](docs/reference/threat-model.md) — per-daemon bind/guard/proxy compliance inventory for the loopback-only doctrine ([ADR-0018](docs/adr/0018-loopback-only-doctrine.md)).
 - **Domain consolidation audit:** [docs/reference/domain-consolidation-audit.md](docs/reference/domain-consolidation-audit.md) — dated per-domain status behind the common-entry-point rule.
 - **Per-PR changelog fragments:** [docs/reference/changelog-fragments.md](docs/reference/changelog-fragments.md) — assembler and CI-gate mechanics.
+- **Public-API / SemVer gate:** [docs/reference/semver-gate.md](docs/reference/semver-gate.md) — what it checks, which crates it skips and why, and the feature-exclusion file.
 - **Rust test ladder gate commands:** [docs/reference/test-ladder-baseline.md](docs/reference/test-ladder-baseline.md) — the exact command chain per rung, the baseline-failure protocol, and how much gate output a PR body owes.
 - **Rust issue search keys:** [docs/reference/issue-search-keys.md](docs/reference/issue-search-keys.md) — why test name / panic text / symbol / crate find the canonical issue.

--- a/docs/reference/semver-gate.md
+++ b/docs/reference/semver-gate.md
@@ -1,0 +1,98 @@
+# Public-API / SemVer gate
+
+`scripts/check_semver.sh`, wired into CI by `.github/workflows/semver-checks.yml`
+(issue [#5050](https://github.com/bobmatnyc/trusty-tools/issues/5050)).
+
+## What it prevents
+
+[#4088](https://github.com/bobmatnyc/trusty-tools/issues/4088). `trusty-common`
+0.22.5 added a required public field — `DaemonBridgeConfig.no_spawn_hint` — and
+published it as a patch bump. `DaemonBridgeConfig` had neither
+`#[non_exhaustive]` nor a `Default`, so every cross-crate struct literal that
+omitted the new field became an E0063 compile error. A fresh `cargo install` has
+no lockfile, re-resolved a `^0.22` floor to 0.22.5, and paired pre-field source
+with post-field dependency. `trusty-analyze` 0.7.3 was yanked over it.
+
+A workspace `cargo check` cannot see this. The root `Cargo.toml` path override
+always compiles local source against the local dependency, and those always
+agree. The break is only visible against the registry, which is what this gate
+compares to.
+
+## What runs
+
+For each crate whose `crates/<crate>/src/**` changed in the PR, the gate resolves
+the latest non-yanked crates.io release and runs `cargo semver-checks` against
+it. The tool version is pinned in the workflow.
+
+## Skips, and why each one is a fact rather than an excuse
+
+| Condition | Behaviour |
+|---|---|
+| `publish = false` | skip — never reaches crates.io |
+| no library target | skip — a bin-only crate has no API surface to compare |
+| crates.io returns 404 | skip — never published, so no baseline exists |
+| only yanked versions | skip — no installable baseline |
+| declared version is already a major bump over the baseline | skip — see below |
+| **registry probe fails any other way** | **hard failure** |
+
+The last row is the point. A SemVer gate that reports green because it could not
+reach crates.io is worse than no gate, and "the failure branch advances state
+anyway" is this repo's most-repeated defect shape. A network error, a 5xx, or a
+malformed index entry exits non-zero and names `TOOL ERROR`.
+
+Every skip prints its reason, and the final line reports how many crates were
+checked versus skipped, so a run that verified nothing says so.
+
+### The already-a-major-bump skip
+
+When the declared version already carries a breaking bump, `cargo-semver-checks`
+itself runs zero lints. Observed directly on `trusty-common`:
+
+```
+Checking trusty-common v0.28.1 -> v0.29.0 (major change)
+ Checked 0 checks: 0 pass, 254 skip
+ Summary no semver update required
+```
+
+The gate reaches that verdict by comparing versions instead of building two
+rustdoc trees to be told nothing applies. This cuts cost, not coverage — the
+skipped run had no coverage to give. Cargo's 0.x rule applies: `0.28.1 → 0.29.0`
+is a major release.
+
+## Features
+
+`cargo-semver-checks` defaults to enabling every feature, which here means
+building CUDA and CoreML backends no CI runner can build. `--default-features`
+is not the fix — it is theatre: `trusty-common` declares `default = []` and
+`DaemonBridgeConfig` lives behind `mcp`, so the real #4088 break passes clean
+under it (196 checks, 196 pass, 0 fail).
+
+So the gate enumerates every declared feature and subtracts only what
+`scripts/semver-checks-feature-exclusions.tsv` lists, each row carrying a written
+reason. An excluded feature's public API is unchecked, so every row is a real
+coverage hole and has to earn its place. "It is slow" is not a reason.
+
+## When it fires
+
+Bump the version, or make the change non-breaking. `#[non_exhaustive]` on a
+struct or enum makes future field and variant additions non-breaking by
+construction — the fix #4088 asked for and deferred.
+
+```bash
+cargo semver-checks --explain constructible_struct_adds_field
+```
+
+## Running it locally
+
+```bash
+bash scripts/check_semver.sh                        # diff against origin/main
+bash scripts/check_semver.sh --crate trusty-common  # one crate, ignore the diff
+bash scripts/check_semver.sh --probe trusty-common  # what would it compare to?
+```
+
+## Self-test
+
+`scripts/check_semver_selftest.sh` runs first in CI and covers the gate's two
+fail-open surfaces — an unscanned diff and an unreachable or erroring index —
+plus the 404 case, which must stay a clean skip so the other cases are known to
+fail for the right reason.

--- a/scripts/check_semver.sh
+++ b/scripts/check_semver.sh
@@ -1,0 +1,519 @@
+#!/usr/bin/env bash
+#
+# check_semver.sh — public-API / SemVer gate (issue #5050, evidence #4088).
+#
+# Why: this workspace publishes 20+ crates to crates.io and had NO mechanical
+#   check that a public-API change carried a matching version bump. #4088 is the
+#   proof: `trusty-common` 0.22.5 added a required public field
+#   (`DaemonBridgeConfig.no_spawn_hint`, daemon_bridge.rs:117) and shipped it as
+#   a PATCH bump. Every dependent on a `^0.22` floor re-resolved to it on a
+#   lockfile-free `cargo install` and failed to compile with E0063;
+#   `trusty-analyze` 0.7.3 was yanked as a result. A workspace `cargo check`
+#   CANNOT reproduce that class of bug, because the path override in the root
+#   Cargo.toml always pairs local source with local dependency. The break is
+#   only visible against the REGISTRY, which is what this gate compares to.
+#
+# What: for every crate whose `crates/<crate>/src/**` changed in the PR, resolves
+#   the latest non-yanked version on crates.io and runs `cargo semver-checks`
+#   against it. A crate needs a check only when its declared version does not
+#   already carry a breaking bump; see "Already-breaking" below.
+#
+# Baseline policy — SCOPED TO PUBLISHED CRATES, and an absent baseline is a
+#   RECORDED SKIP, never a silent one:
+#     - `publish = false`            -> skip (never reaches crates.io)
+#     - no library target            -> skip (a bin-only crate has no API surface
+#                                       cargo-semver-checks can compare)
+#     - registry says 404            -> skip (never published; no baseline exists)
+#     - registry has only yanked vers-> skip (no installable baseline)
+#     - registry probe fails any
+#       other way (network, 5xx,
+#       malformed index, curl error) -> HARD FAIL, exit non-zero
+#   The last line is the point. This repo's recurring defect shape is a failure
+#   branch that advances state anyway ("fail-open / cursor-advance"), and a
+#   SemVer gate that reports green because it could not reach crates.io is worse
+#   than no gate at all. Every skip above is a fact about the crate; a probe
+#   error is a fact about the GATE, and the gate does not get to excuse itself.
+#
+# Already-breaking: when the declared version is already a major bump over the
+#   baseline (0.28.1 -> 0.29.0 is major under Cargo's 0.x rules, as is
+#   1.3.4 -> 2.0.0), cargo-semver-checks itself runs ZERO lints and exits 0 —
+#   there is no rule left to break. Observed directly on trusty-common 0.28.1 ->
+#   0.29.0: "0 checks: 0 pass, 254 skip". So the gate reaches the same verdict by
+#   comparing the versions, and does not spend ~4 minutes of CI building two
+#   rustdoc trees to be told nothing applies. This is a cost cut, not a coverage
+#   cut: the skipped run had no coverage to give.
+#
+# Features: cargo-semver-checks' default heuristic enables every feature, which
+#   here means building CUDA and CoreML backends that no CI runner can build
+#   (`cudarc` panics with "nvcc --version failed"). Passing --default-features
+#   instead would be THEATRE: `trusty-common`'s default feature set is literally
+#   `default = []`, and `DaemonBridgeConfig` lives behind `mcp`, so the #4088
+#   break passes cleanly under it (verified: "196 checks: 196 pass"). The gate
+#   therefore enumerates every declared feature and subtracts only the ones
+#   listed in scripts/semver-checks-feature-exclusions.tsv, each with a written
+#   reason. A new unbuildable feature is a deliberate line in that file, not a
+#   silent hole.
+#
+# Usage:
+#   bash scripts/check_semver.sh                       # diff vs origin/main
+#   bash scripts/check_semver.sh --base <ref>          # explicit base
+#   bash scripts/check_semver.sh --crate trusty-common # one crate, ignore diff
+#   bash scripts/check_semver.sh --probe trusty-common # baseline decision only
+#   SEMVER_GATE_BASE=<ref> bash scripts/check_semver.sh
+#
+# Exit: 0 when every checked crate is SemVer-clean (or is a recorded skip);
+#   1 when a crate needs a bump it does not have, or when the gate itself could
+#   not do its job.
+#
+# Test: `scripts/check_semver_selftest.sh` proves the two ways this gate could
+#   lie — a vacuous scan and an unreachable registry — both exit non-zero. The
+#   catch itself is demonstrated in PR #5051 against #4088's real shape.
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
+#   plus `git`, `curl`, `cargo`, `python3` (JSON parsing only).
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+BASE="${SEMVER_GATE_BASE:-origin/main}"
+EXPLICIT_CRATES=""
+PROBE_ONLY=""
+INDEX_BASE="${SEMVER_GATE_INDEX_BASE:-https://index.crates.io}"
+EXCLUSIONS_FILE="${REPO_ROOT}/scripts/semver-checks-feature-exclusions.tsv"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      [[ $# -lt 2 ]] && {
+        echo "ERROR: --base needs a ref" >&2
+        exit 2
+      }
+      BASE="$2"
+      shift 2
+      ;;
+    --crate)
+      [[ $# -lt 2 ]] && {
+        echo "ERROR: --crate needs a package name" >&2
+        exit 2
+      }
+      EXPLICIT_CRATES="${EXPLICIT_CRATES}${2}"$'\n'
+      shift 2
+      ;;
+    --probe)
+      [[ $# -lt 2 ]] && {
+        echo "ERROR: --probe needs a package name" >&2
+        exit 2
+      }
+      PROBE_ONLY="$2"
+      shift 2
+      ;;
+    -h | --help)
+      sed -n '2,90p' "$0" >&2
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# registry_latest <crate> — print the latest NON-YANKED version on crates.io,
+# or the literal `NONE` when the crate has no installable release.
+#
+# Why: this is the one place the gate talks to the network, so it is the one
+#   place a fail-open can hide. `curl -f` alone is not enough — it conflates a
+#   404 (a real fact: never published) with a 503 (the gate is blind). The two
+#   are separated here by reading the HTTP status explicitly, and everything that
+#   is neither 200 nor 404 exits the whole script.
+# What: reads the crates.io sparse index (newline-delimited JSON, one object per
+#   version) and returns the greatest non-yanked `vers`. The sparse index is used
+#   rather than the crates.io API because it is CDN-cached and unrate-limited.
+# ---------------------------------------------------------------------------
+registry_latest() {
+  local crate="$1" path body code
+  case "${#crate}" in
+    1) path="1/${crate}" ;;
+    2) path="2/${crate}" ;;
+    3) path="3/${crate:0:1}/${crate}" ;;
+    *) path="${crate:0:2}/${crate:2:2}/${crate}" ;;
+  esac
+
+  body="$(mktemp "${TMPDIR:-/tmp}/semver.idx.XXXXXX")"
+  code="$(curl -sS --retry 3 --retry-connrefused --max-time 60 \
+    -o "$body" -w '%{http_code}' "${INDEX_BASE}/${path}" 2>/dev/null)" || {
+    rm -f "$body"
+    echo "FAIL: TOOL ERROR — could not reach the crates.io index for '${crate}'." >&2
+    echo "      ${INDEX_BASE}/${path} — curl failed." >&2
+    echo "      Whether a baseline exists is UNKNOWN, so no skip may be granted." >&2
+    echo "      This is NOT a pass (issue #5050)." >&2
+    exit 1
+  }
+
+  if [[ "$code" == "404" ]]; then
+    rm -f "$body"
+    echo "NONE"
+    return 0
+  fi
+
+  if [[ "$code" != "200" ]]; then
+    echo "FAIL: TOOL ERROR — crates.io index returned HTTP ${code} for '${crate}'." >&2
+    echo "      ${INDEX_BASE}/${path}" >&2
+    sed 's/^/       /' "$body" >&2 | head -5
+    echo "      Whether a baseline exists is UNKNOWN, so no skip may be granted." >&2
+    echo "      This is NOT a pass (issue #5050)." >&2
+    rm -f "$body"
+    exit 1
+  fi
+
+  local latest rc=0
+  latest="$(python3 - "$body" <<'PY'
+import json, sys
+
+def key(v):
+    core = v.split("+")[0].split("-")[0]
+    parts = (core.split(".") + ["0", "0", "0"])[:3]
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError:
+        raise SystemExit(2)
+
+best = None
+with open(sys.argv[1]) as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        rec = json.loads(line)
+        if rec.get("yanked"):
+            continue
+        v = rec["vers"]
+        if best is None or key(v) > key(best):
+            best = v
+print(best if best else "NONE")
+PY
+  )" || rc=$?
+
+  rm -f "$body"
+  if [[ "$rc" -ne 0 ]]; then
+    echo "FAIL: TOOL ERROR — the crates.io index entry for '${crate}' did not parse." >&2
+    echo "      Whether a baseline exists is UNKNOWN, so no skip may be granted." >&2
+    echo "      This is NOT a pass (issue #5050)." >&2
+    exit 1
+  fi
+  echo "$latest"
+}
+
+# ---------------------------------------------------------------------------
+# release_type <baseline> <current> — print major | minor | patch | none.
+#
+# Cargo's compatibility rules, not plain SemVer: for 0.x the MINOR position is
+# the breaking one, so 0.28.1 -> 0.29.0 is a major release. `none` means the two
+# versions are equal, or current is older than baseline (which is a version
+# mistake, not a SemVer question — it is reported and checked, never skipped).
+# ---------------------------------------------------------------------------
+release_type() {
+  python3 - "$1" "$2" <<'PY'
+import sys
+
+def parse(v):
+    core = v.split("+")[0].split("-")[0]
+    parts = (core.split(".") + ["0", "0", "0"])[:3]
+    return tuple(int(p) for p in parts)
+
+b = parse(sys.argv[1])
+c = parse(sys.argv[2])
+if c <= b:
+    print("none")
+elif b[0] == 0 and c[0] == 0:
+    print("major" if c[1] != b[1] else ("minor" if c[2] != b[2] else "none"))
+elif c[0] != b[0]:
+    print("major")
+elif c[1] != b[1]:
+    print("minor")
+else:
+    print("patch")
+PY
+}
+
+# ---------------------------------------------------------------------------
+# feature_args <crate> — print one `--features <name>` pair per line for every
+# declared feature except `default` (implied), the tool's own reserved prefixes,
+# and anything listed in the exclusions TSV for this crate.
+# ---------------------------------------------------------------------------
+feature_args() {
+  local crate="$1" excluded=""
+  if [[ -f "$EXCLUSIONS_FILE" ]]; then
+    excluded="$(awk -F'\t' -v c="$crate" '$0 !~ /^#/ && $1 == c { print $2 }' "$EXCLUSIONS_FILE")"
+  fi
+  python3 "$PY_HELPER" features "$META_FILE" "$crate" "$excluded" || {
+    echo "FAIL: TOOL ERROR — could not resolve the feature set for '${crate}'." >&2
+    exit 1
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Workspace metadata, captured ONCE to a file. `--no-deps` does not resolve the
+# dependency graph, so this neither reads nor rewrites Cargo.lock — required,
+# because refreshing the lockfile turns the MSRV 1.94 job red.
+#
+# The metadata goes to a FILE rather than a shell variable piped into `python3 -`
+# because `python3 -` reads its program from stdin: a pipe and a heredoc cannot
+# both feed it, and the pipe silently loses.
+# ---------------------------------------------------------------------------
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/semver-gate.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+META_FILE="${SCRATCH}/metadata.json"
+PY_HELPER="${SCRATCH}/meta.py"
+
+cat > "$PY_HELPER" <<'PY'
+"""Metadata queries for check_semver.sh. Exits 2 on anything unanswerable."""
+import json
+import os
+import sys
+
+mode, meta_path = sys.argv[1], sys.argv[2]
+with open(meta_path) as fh:
+    meta = json.load(fh)
+
+if mode == "field":
+    crate, field = sys.argv[3], sys.argv[4]
+    for p in meta["packages"]:
+        if p["name"] != crate:
+            continue
+        if field == "version":
+            print(p["version"])
+        elif field == "publishable":
+            print("no" if p.get("publish") == [] else "yes")
+        elif field == "has_lib":
+            kinds = {k for t in p["targets"] for k in t["kind"]}
+            print("yes" if kinds & {"lib", "rlib", "cdylib", "proc-macro"} else "no")
+        else:
+            raise SystemExit(2)
+        break
+    else:
+        raise SystemExit(2)
+
+elif mode == "dir":
+    root, want = sys.argv[3], sys.argv[4]
+    target = os.path.realpath(os.path.join(root, "crates", want, "Cargo.toml"))
+    for p in meta["packages"]:
+        if os.path.realpath(p["manifest_path"]) == target:
+            print(p["name"])
+            break
+
+elif mode == "features":
+    crate = sys.argv[3]
+    excluded = set(filter(None, sys.argv[4].split()))
+    for p in meta["packages"]:
+        if p["name"] != crate:
+            continue
+        for f in sorted(p["features"]):
+            if f == "default" or f in excluded:
+                continue
+            # Mirrors cargo-semver-checks' own reserved-name heuristic.
+            if f.startswith(("_", "unstable")) or f in ("nightly", "bench", "no_std"):
+                continue
+            print("--features")
+            print(f)
+        break
+    else:
+        raise SystemExit(2)
+
+else:
+    raise SystemExit(2)
+PY
+
+if ! cargo metadata --no-deps --format-version 1 > "$META_FILE" 2> "${SCRATCH}/meta-err.txt"; then
+  echo "FAIL: TOOL ERROR — 'cargo metadata --no-deps' failed:" >&2
+  sed 's/^/       /' "${SCRATCH}/meta-err.txt" >&2
+  exit 1
+fi
+
+# pkg_field <crate> <field> — one line of package metadata. A crate the metadata
+# does not describe is a gate failure, never an empty answer that reads as a skip.
+pkg_field() {
+  python3 "$PY_HELPER" field "$META_FILE" "$1" "$2" || {
+    echo "FAIL: TOOL ERROR — no workspace metadata for package '${1}' (field '${2}')." >&2
+    exit 1
+  }
+}
+
+# dir_to_crate <dirname> — package name for crates/<dirname>/, or empty when the
+# directory holds no package. The two names differ in this workspace
+# (crates/trusty-git-analytics/ is package `tga`).
+dir_to_crate() {
+  python3 "$PY_HELPER" dir "$META_FILE" "$REPO_ROOT" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# --probe: report the baseline decision for one crate and stop. Exists so the
+# self-test can drive the registry probe — the gate's only fail-open surface —
+# without a Cargo build, and so a human can ask "what would you compare against?"
+# ---------------------------------------------------------------------------
+if [[ -n "$PROBE_ONLY" ]]; then
+  # `registry_latest` runs in a command substitution, i.e. a SUBSHELL, so its
+  # `exit 1` cannot terminate this script on its own — it only ends the subshell.
+  # Every caller must re-raise it explicitly. Leaving that to `set -e` is exactly
+  # the fail-open shape this gate exists to avoid.
+  if ! latest="$(registry_latest "$PROBE_ONLY")"; then
+    exit 1
+  fi
+  echo "probe ${PROBE_ONLY}: baseline=${latest}"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Candidate selection.
+# ---------------------------------------------------------------------------
+CANDIDATES=""
+
+if [[ -n "$EXPLICIT_CRATES" ]]; then
+  CANDIDATES="$(printf '%s' "$EXPLICIT_CRATES" | grep -v '^$' | LC_ALL=C sort -u)"
+  SCANNED="(explicit)"
+else
+  if ! MERGE_BASE="$(git merge-base "$BASE" HEAD 2>/dev/null)"; then
+    echo "FAIL: TOOL ERROR — cannot find a merge base between '${BASE}' and HEAD." >&2
+    echo "      Fetch the base ref first (CI must check out with fetch-depth: 0):" >&2
+    echo "        git fetch origin main" >&2
+    exit 1
+  fi
+
+  CHANGED="$(git diff --name-only --no-renames "$MERGE_BASE" HEAD)"
+  CHANGED_COUNT="$(printf '%s\n' "$CHANGED" | grep -c '[^[:space:]]' || true)"
+
+  # Scan floor (#4618 shape). An empty diff means the base ref is wrong or the
+  # checkout is shallow — never that the PR is clean. A gate that scanned nothing
+  # has not passed.
+  if [[ "${CHANGED_COUNT:-0}" -lt 1 ]]; then
+    echo "FAIL: SCAN FLOOR — the diff ${MERGE_BASE}..HEAD lists 0 changed path(s)." >&2
+    echo "      Nothing was examined, so this gate could not have failed. Check that" >&2
+    echo "      '${BASE}' is the right base and that CI checked out with fetch-depth: 0." >&2
+    exit 1
+  fi
+  SCANNED="${CHANGED_COUNT} changed path(s)"
+
+  dirs=""
+  while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+    case "$path" in
+      crates/*/src/*)
+        d="$(printf '%s' "$path" | sed -E 's#^crates/([^/]+)/src/.*#\1#')"
+        [[ "$d" == */* ]] && continue
+        dirs="${dirs}${d}"$'\n'
+        ;;
+    esac
+  done <<<"$CHANGED"
+
+  dirs="$(printf '%s' "$dirs" | grep -v '^$' | LC_ALL=C sort -u || true)"
+  while IFS= read -r d; do
+    [[ -z "$d" ]] && continue
+    name="$(dir_to_crate "$d")"
+    # A directory with no package at HEAD was deleted by this PR; there is no
+    # API left to compare. Same exemption shape as check_changelog_fragment.sh.
+    [[ -z "$name" ]] && {
+      echo "SKIP crates/${d}: no package at HEAD (crate removed by this PR)"
+      continue
+    }
+    CANDIDATES="${CANDIDATES}${name}"$'\n'
+  done <<<"$dirs"
+  CANDIDATES="$(printf '%s' "$CANDIDATES" | grep -v '^$' | LC_ALL=C sort -u || true)"
+fi
+
+if [[ -z "$CANDIDATES" ]]; then
+  echo "semver gate: scanned ${SCANNED}; no crate source changed (docs-only / CI-only) — OK."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Per-crate check.
+# ---------------------------------------------------------------------------
+checked=0
+skipped=0
+fail=0
+
+while IFS= read -r crate; do
+  [[ -z "$crate" ]] && continue
+
+  if [[ "$(pkg_field "$crate" publishable)" == "no" ]]; then
+    echo "SKIP ${crate}: publish = false — never reaches crates.io"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [[ "$(pkg_field "$crate" has_lib)" == "no" ]]; then
+    echo "SKIP ${crate}: no library target — no public API surface to compare"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  current="$(pkg_field "$crate" version)" || exit 1
+
+  # Subshell re-raise, as at --probe above: a helper's `exit 1` dies with the
+  # command substitution unless the caller checks for it.
+  if ! baseline="$(registry_latest "$crate")"; then
+    exit 1
+  fi
+
+  if [[ "$baseline" == "NONE" ]]; then
+    echo "SKIP ${crate} v${current}: no installable release on crates.io — no baseline exists"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if ! rtype="$(release_type "$baseline" "$current")"; then
+    echo "FAIL: TOOL ERROR — could not compare '${baseline}' and '${current}' for ${crate}." >&2
+    exit 1
+  fi
+  if [[ "$rtype" == "major" ]]; then
+    echo "SKIP ${crate}: ${baseline} -> ${current} is already a major release — every lint is inapplicable"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if ! feature_args "$crate" > "${SCRATCH}/features.txt"; then
+    exit 1
+  fi
+
+  # shellcheck disable=SC2046
+  set -- $(cat "${SCRATCH}/features.txt")
+  echo "CHECK ${crate}: ${baseline} -> ${current} (${rtype} release), $(($# / 2)) feature(s)"
+
+  rc=0
+  SKIP_UI_BUILD=1 cargo semver-checks \
+    --package "$crate" \
+    --baseline-version "$baseline" \
+    --only-explicit-features "$@" || rc=$?
+
+  if [[ "$rc" -ne 0 ]]; then
+    echo "FAIL ${crate}: cargo semver-checks exited ${rc} against baseline ${baseline}" >&2
+    fail=1
+  fi
+  checked=$((checked + 1))
+done <<<"$CANDIDATES"
+
+if [[ "$fail" -ne 0 ]]; then
+  cat >&2 <<'EOF'
+
+A public API change requires a matching version bump.
+
+  0.x crates: a break needs the MINOR position (0.28.1 -> 0.29.0).
+  1.x+ crates: a break needs the MAJOR position (1.3.4 -> 2.0.0).
+
+Either bump the version in the crate's Cargo.toml, or make the change
+non-breaking. `#[non_exhaustive]` on a struct/enum makes future field and
+variant additions non-breaking by construction — the fix #4088 asked for.
+
+Explain any lint:  cargo semver-checks --explain <lint_name>
+
+This is not advisory. #4088: trusty-common 0.22.5 shipped exactly this class of
+break as a patch bump and bricked `cargo install` for every dependent on a
+^0.22 floor, costing trusty-analyze 0.7.3 a yank.
+EOF
+  exit 1
+fi
+
+echo "semver gate: scanned ${SCANNED}; ${checked} crate(s) checked, ${skipped} skipped — OK."

--- a/scripts/check_semver_selftest.sh
+++ b/scripts/check_semver_selftest.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# check_semver_selftest.sh — mutation self-test for the SemVer gate (issue #5050).
+#
+# Why: a gate that reports green when it could not do its job is worse than no
+#   gate, because "SemVer check passed" then means "SemVer check was skipped".
+#   scripts/check_semver.sh has exactly two ways to reach that state — a diff it
+#   never scanned, and a crates.io probe it could not complete — and both are
+#   ordinary-looking failure branches that a later refactor can turn back into
+#   `|| continue`. This script re-proves in CI that neither one passes.
+#
+# What: four cases, each a mutation that a fail-open gate would report as OK.
+#   1. SCAN FLOOR      — nothing in the diff. Must exit non-zero.
+#   2. probe: refused  — the index host is unreachable (curl fails outright).
+#   3. probe: HTTP 503 — the index answers, but not with an answer.
+#   4. probe: HTTP 404 — the ONLY negative response that is a real fact about
+#                        the crate. Must exit 0 reporting `baseline=NONE`, so
+#                        this file also proves cases 2 and 3 fail for the right
+#                        reason rather than because every probe path is broken.
+#
+#   Cases 2-4 drive the probe through `--probe`, which reaches the network
+#   without a Cargo build, so the whole file runs in seconds.
+#
+# Usage:  bash scripts/check_semver_selftest.sh
+# Exit:   0 when every case behaves; 1 (naming the case) when one does not.
+#
+# Portability: bash 3.2 (macOS) and bash 5 (Linux CI). Needs python3 for the
+# stub index server; the gate needs it anyway.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+GATE="${REPO_ROOT}/scripts/check_semver.sh"
+
+PASSED=0
+FAILED=0
+STUB_PID=""
+cleanup() { [[ -n "$STUB_PID" ]] && kill "$STUB_PID" 2>/dev/null; return 0; }
+trap cleanup EXIT
+
+fail_case() {
+  echo "SELF-TEST FAIL: $1" >&2
+  shift
+  printf '%s\n' "$@" | sed 's/^/       /' >&2
+  FAILED=$((FAILED + 1))
+}
+
+pass_case() {
+  echo "  ok  $1"
+  PASSED=$((PASSED + 1))
+}
+
+# ===========================================================================
+# 1. Scan floor — base == HEAD, so the diff lists nothing.
+# ===========================================================================
+out=""
+rc=0
+out="$(cd "$REPO_ROOT" && bash "$GATE" --base HEAD 2>&1)" || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  fail_case "scan floor: the gate exited 0 over a diff of 0 paths" "$out"
+elif [[ "$out" != *"SCAN FLOOR"* ]]; then
+  fail_case "scan floor: exited ${rc} but did not name SCAN FLOOR, so it may be failing for an unrelated reason" "$out"
+else
+  pass_case "scan floor rejects an empty diff (exit ${rc})"
+fi
+
+# ===========================================================================
+# Stub crates.io index. Serves a status chosen by the path so cases 3 and 4
+# share one server:  /503/...  -> 503        /404/...  -> 404
+# ===========================================================================
+PORT_FILE="$(mktemp "${TMPDIR:-/tmp}/semver-selftest.XXXXXX")"
+python3 - "$PORT_FILE" > /dev/null 2>&1 <<'PY' &
+import http.server, socketserver, sys, threading
+
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        code = 503 if self.path.startswith("/503") else 404
+        self.send_response(code)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *a):
+        pass
+
+with socketserver.TCPServer(("127.0.0.1", 0), H) as srv:
+    with open(sys.argv[1], "w") as fh:
+        fh.write(str(srv.server_address[1]))
+    srv.serve_forever()
+PY
+STUB_PID=$!
+
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+  [[ -s "$PORT_FILE" ]] && break
+  sleep 0.25
+done
+PORT="$(cat "$PORT_FILE")"
+rm -f "$PORT_FILE"
+if [[ -z "$PORT" ]]; then
+  echo "SELF-TEST FAIL: stub index server never reported a port." >&2
+  exit 1
+fi
+
+# ===========================================================================
+# 2. Connection refused — port 1 on loopback accepts nothing.
+# ===========================================================================
+rc=0
+out="$(cd "$REPO_ROOT" && SEMVER_GATE_INDEX_BASE="http://127.0.0.1:1" \
+  bash "$GATE" --probe trusty-common 2>&1)" || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  fail_case "probe/refused: an unreachable index exited 0 — the gate would report green while blind" "$out"
+elif [[ "$out" != *"TOOL ERROR"* ]]; then
+  fail_case "probe/refused: exited ${rc} without naming TOOL ERROR" "$out"
+else
+  pass_case "probe rejects an unreachable index (exit ${rc})"
+fi
+
+# ===========================================================================
+# 3. HTTP 503 — the index answered, but said nothing about the crate.
+# ===========================================================================
+rc=0
+out="$(cd "$REPO_ROOT" && SEMVER_GATE_INDEX_BASE="http://127.0.0.1:${PORT}/503" \
+  bash "$GATE" --probe trusty-common 2>&1)" || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  fail_case "probe/503: a 503 from the index exited 0 — an outage would silently disable the gate" "$out"
+elif [[ "$out" != *"TOOL ERROR"* ]]; then
+  fail_case "probe/503: exited ${rc} without naming TOOL ERROR" "$out"
+else
+  pass_case "probe rejects HTTP 503 (exit ${rc})"
+fi
+
+# ===========================================================================
+# 4. HTTP 404 — the one negative answer that IS an answer. Must be a clean,
+#    reported skip, otherwise cases 2 and 3 prove nothing.
+# ===========================================================================
+rc=0
+out="$(cd "$REPO_ROOT" && SEMVER_GATE_INDEX_BASE="http://127.0.0.1:${PORT}/404" \
+  bash "$GATE" --probe never-published-crate 2>&1)" || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  fail_case "probe/404: an unpublished crate must be a recorded skip, not a failure (exit ${rc})" "$out"
+elif [[ "$out" != *"baseline=NONE"* ]]; then
+  fail_case "probe/404: exited 0 but did not report baseline=NONE" "$out"
+else
+  pass_case "probe treats HTTP 404 as 'never published' (exit 0, baseline=NONE)"
+fi
+
+echo
+if [[ "$FAILED" -ne 0 ]]; then
+  echo "check_semver_selftest: ${PASSED} passed, ${FAILED} FAILED." >&2
+  exit 1
+fi
+echo "check_semver_selftest: ${PASSED} passed, 0 failed."

--- a/scripts/semver-checks-feature-exclusions.tsv
+++ b/scripts/semver-checks-feature-exclusions.tsv
@@ -1,0 +1,17 @@
+# Features that scripts/check_semver.sh must NOT enable (issue #5050).
+#
+# The gate enables every declared feature, because the alternative
+# (--default-features) is theatre here: trusty-common declares `default = []`,
+# so the #4088 break — a required public field on DaemonBridgeConfig, behind the
+# `mcp` feature — passes clean under it. Verified: 196 checks, 196 pass.
+#
+# This file is the ONLY subtraction from that set, and every row must say why the
+# feature cannot be built on a stock CI runner. "It is slow" is not a reason —
+# an excluded feature's public API is unchecked, so each row is a real coverage
+# hole and has to earn its place.
+#
+# Format (tab-separated):  <crate>	<feature>	<reason>
+#
+# <crate>	<feature>	<reason>
+trusty-common	embedder-cuda	cudarc/candle-kernels build.rs panics without nvcc; no CI runner has the CUDA toolkit
+trusty-common	embedder-coreml	links the macOS CoreML framework; cannot build on ubuntu-latest


### PR DESCRIPTION
Closes #5050.

## Defect

No `cargo-semver-checks` or equivalent existed anywhere in `.github/workflows/`,
`scripts/`, or `docs/`. Breaking changes reached crates.io undetected.

## Evidence

#4088. `trusty-common` 0.22.5 added a required public field —
`DaemonBridgeConfig.no_spawn_hint`, `daemon_bridge.rs:117` — on a PATCH bump.
Dependents on a `^0.22` floor re-resolved to it on a lockfile-free
`cargo install` and failed with E0063; `trusty-analyze` 0.7.3 was yanked.

## Resolution

`scripts/check_semver.sh` + `.github/workflows/semver-checks.yml`. For each crate
whose `crates/<crate>/src/**` changed, it resolves the latest non-yanked
crates.io release and runs `cargo semver-checks` against it.

**Scope: published crates only, and every skip prints its reason.**

| Condition | Behaviour |
|---|---|
| `publish = false` | skip |
| no library target | skip |
| crates.io 404 / only-yanked | skip — no baseline exists |
| version already carries a major bump | skip — the tool would run 0 lints |
| **probe fails any other way** | **hard failure, `TOOL ERROR`** |

Five workspace crates are genuinely unpublished (`trusty-kb`, `trusty-channels`,
`trusty-sld-lint`, `trusty-tui`, `trusty-agents`), so the absent-baseline path is
load-bearing, not hypothetical.

**Fail-loud, not fail-open.** A network error, a 5xx, or a malformed index entry
exits non-zero. `scripts/check_semver_selftest.sh` runs first in CI and proves
it, including the 404 case that keeps the other three honest:

```
  ok  scan floor rejects an empty diff (exit 1)
  ok  probe rejects an unreachable index (exit 1)
  ok  probe rejects HTTP 503 (exit 1)
  ok  probe treats HTTP 404 as 'never published' (exit 0, baseline=NONE)
check_semver_selftest: 4 passed, 0 failed.
```

**Feature policy.** `--default-features` would be theatre: `trusty-common`
declares `default = []` and `DaemonBridgeConfig` sits behind `mcp`, so the real
#4088 break passes clean under it (verified below). The default all-features
heuristic instead builds CUDA/CoreML backends no runner can build. The gate
enumerates every declared feature and subtracts only
`scripts/semver-checks-feature-exclusions.tsv`, two rows, each with a reason.

## Demonstrated catch

### 1. #4088's actual shape, registry versus registry

`trusty-common` 0.22.5 source from crates.io, baseline 0.22.4 — no workspace
involved:

```
$ cargo semver-checks --manifest-path trusty-common-0.22.5/Cargo.toml \
      --baseline-version 0.22.4 --only-explicit-features --features mcp
    Checking trusty-common v0.22.4 -> v0.22.5 (minor change)
     Checked [0.007s] 196 checks: 195 pass, 1 fail, 0 warn, 58 skip

--- failure constructible_struct_adds_field: struct exhaustively constructible through public API adds field ---

Failed in:
  field DaemonBridgeConfig.no_spawn_hint in .../src/mcp/daemon_bridge.rs:117

     Summary semver requires new major version: 1 major and 0 minor checks failed
EXIT=100
```

The same command with `--default-features` exits **0** — "196 checks: 196 pass" —
which is why the feature policy above is not a detail.

### 2. The gate script, end to end, through its real diff path

A required new public field on `PerRepoFetch` in `tga` (2.11.0, equal to the
published version) — the identical `constructible_struct_adds_field` shape:

```
$ bash scripts/check_semver.sh --base origin/main
CHECK tga: 2.11.0 -> 2.11.0 (none release), 1 feature(s)
    Checking tga v2.11.0 -> v2.11.0 (no change; assume patch)
     Checked [0.045s] 223 checks: 222 pass, 1 fail, 0 warn, 31 skip

--- failure constructible_struct_adds_field: struct exhaustively constructible through public API adds field ---

Failed in:
  field PerRepoFetch.remote_name in .../src/collect/collector.rs:65

     Summary semver requires new major version: 1 major and 0 minor checks failed
FAIL tga: cargo semver-checks exited 100 against baseline 2.11.0
EXIT=1
```

Same tree with the break kept and `tga` bumped 2.11.0 → 3.0.0:

```
SKIP tga: 2.11.0 -> 3.0.0 is already a major release — every lint is inapplicable
semver gate: scanned 9 changed path(s); 0 crate(s) checked, 1 skipped — OK.
EXIT=0
```

Unmodified `tga`, gate run in full:

```
CHECK tga: 2.11.0 -> 2.11.0 (none release), 1 feature(s)
     Checked [0.040s] 223 checks: 223 pass, 31 skip
     Summary no semver update required
semver gate: scanned (explicit); 1 crate(s) checked, 0 skipped — OK.
EXIT=0
```

Both demo commits were reverted; the branch is `bdddff170` plus the docs commit.

## Cost

Measured on this workspace (10-core arm64, warm cargo registry):

| Case | Wall clock |
|---|---|
| Docs-only / CI-only PR (this PR's own run) | ~1 s — git + `cargo metadata`, no build |
| Crate at an already-major version (`trusty-common` 0.28.1 → 0.29.0) | ~1 s — skipped before any build |
| `tga`, cold — two rustdoc builds | 1 m 04 s |
| `tga`, warm baseline | 7 s |
| `trusty-common`, cold, all 37 buildable features | 3 m 50 s |

The last row is the worst case and only lands on a PR that changes
`trusty-common/src/**` while its version sits at or one patch above the published
release. The already-major skip is what keeps it off the common path — and it
costs no coverage, because `cargo-semver-checks` itself runs zero lints there:

```
Checking trusty-common v0.28.1 -> v0.29.0 (major change)
 Checked 0 checks: 0 pass, 254 skip
```

Tool install is a pinned prebuilt binary via `taiki-e/install-action`, not
`cargo install` — that alone compiles for ~2 minutes before checking anything.
Nothing in the job touches `Cargo.lock` (`cargo metadata --no-deps`, and
`cargo-semver-checks` builds in its own scratch workspace; `git status` was clean
after every run above), so the MSRV 1.94 job is unaffected.

## Gates

CI-only + docs-only change; no crate `src/**` touched, so no changelog fragment
(confirmed by the gate, not assumed).

```
cargo fmt --check                       — clean
scripts/check_line_cap.sh               — 3745 files, 0 violations
scripts/check_sld.sh                    — 0 errors, 0 warnings
scripts/check_doc_numbers.sh            — 0 violations
scripts/check_changelog_fragment.sh     — "no crate source changed (docs-only / CI-only / test-only) — OK"
scripts/check_semver_selftest.sh        — 4 passed, 0 failed
scripts/check_semver.sh                 — "scanned 4 changed path(s); no crate source changed — OK"
```

## Follow-up, not in this PR

`SemVer checks` needs adding to the branch-protection required-check set, which
needs repo-admin rights. #4088's other two acceptance items — the registry-only
install smoke test, and the `#[non_exhaustive]`/builder decision on
`DaemonBridgeConfig` — stay open there.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
