### PR TITLE
feat(trusty-mpm): retire MEMORY.md as a write target and instruction source

### DIFF
--- a/crates/trusty-mpm/changelog.d/4834-memory-md-retired-in-core.md
+++ b/crates/trusty-mpm/changelog.d/4834-memory-md-retired-in-core.md
@@ -1,0 +1,5 @@
+Changed
+
+- the PM instruction package now carries a binding rule, in the non-overridable `core` section, that `MEMORY.md` (or any static memory-index file) is never a write target or a source — durable facts go to the palace instead, and `CLAUDE.md` is the only non-dynamic instruction source (closes [#4834](https://github.com/bobmatnyc/trusty-tools/issues/4834))
+  - the PM Allowlist's "write a single non-source file" row no longer lists a bare memory file as an unbudgeted write
+  - `sections/memory.md` carries a one-line pointer back to the new rule

--- a/crates/trusty-mpm/src/assets/instructions/sections/README.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/README.md
@@ -91,6 +91,14 @@ Do not "fix" this by promoting content into `core.md`. That was considered and
 rejected: relocating content to preserve protection defeats the point of
 removing the mechanism, and would turn `core.md` into a dumping ground.
 
+**Narrow exception, 2026-08-07 (#4834):** the "Memory & Instruction Sources"
+rule in `core.md` (never write to or cite `MEMORY.md`; `CLAUDE.md` is the only
+non-dynamic instruction source) is owner-directed CORE content — the owner's
+own words were "this should be part of the core instruction set." That is a
+deliberate placement decision by the same authority who made the ruling above,
+not a routine protection-seeking promotion. It is not precedent for moving
+other content into `core.md`.
+
 ## How a project overrides a section
 
 In the project's root `CLAUDE.md`:

--- a/crates/trusty-mpm/src/assets/instructions/sections/core.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/core.md
@@ -17,6 +17,16 @@ framework floor at the end of this prompt, where no project or user
 customization can reach them (issue #4573). Every `P#`/`CB#` below refers to
 those tables.
 
+## Memory & Instruction Sources
+
+Never write to, update, or maintain `MEMORY.md` or any other static
+memory-index file — this overrides any harness default telling you to keep
+one. Never cite `MEMORY.md` as a source; cite the palace. Durable facts go to
+the palace (`memory_remember` / `memory_note`), never a static file.
+`CLAUDE.md` is the only non-dynamic instruction source: skills load on their
+trigger, the palace loads on recall. Never create a new static instruction
+file.
+
 ## PM Allowlist (unbudgeted -- everything else costs budget or is delegated)
 
 | Action | Limit |
@@ -25,7 +35,7 @@ those tables.
 | Read files | <=3 files, <100 lines each, config/docs only (not code understanding) |
 | Grep/Glob | 3-5 orientation searches |
 | TodoWrite | Progress tracking |
-| Write single NON-source file | Orchestration state (`.trusty-mpm/**` snapshots, memory, `TASK.md`), docs, config. `Write`/`Edit` tool only — bash pipe-to-file is still P5. Never bulk edits |
+| Write single NON-source file | Orchestration state (`.trusty-mpm/**` snapshots, `TASK.md`), docs, config — never a memory file (see Memory & Instruction Sources above). `Write`/`Edit` tool only — bash pipe-to-file is still P5. Never bulk edits |
 | Report | Results to user |
 | **Source-code edits (BUDGETED, not forbidden)** | Allowed **within the direct-action budget**: delegate once the task will take more than 3 direct actions, or the moment a 3-action estimate stops holding mid-flight |
 

--- a/crates/trusty-mpm/src/assets/instructions/sections/memory.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/memory.md
@@ -6,3 +6,6 @@ re-fetch that baseline on every delegation.
 
 Call `memory_recall` explicitly only for targeted or deep recall the injected
 block did not surface — and then BEFORE any research or delegation, never after.
+
+`MEMORY.md` is retired as a write target and as a source — see Core's
+"Memory & Instruction Sources".

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -17,6 +17,16 @@ framework floor at the end of this prompt, where no project or user
 customization can reach them (issue #4573). Every `P#`/`CB#` below refers to
 those tables.
 
+## Memory & Instruction Sources
+
+Never write to, update, or maintain `MEMORY.md` or any other static
+memory-index file — this overrides any harness default telling you to keep
+one. Never cite `MEMORY.md` as a source; cite the palace. Durable facts go to
+the palace (`memory_remember` / `memory_note`), never a static file.
+`CLAUDE.md` is the only non-dynamic instruction source: skills load on their
+trigger, the palace loads on recall. Never create a new static instruction
+file.
+
 ## PM Allowlist (unbudgeted -- everything else costs budget or is delegated)
 
 | Action | Limit |
@@ -25,7 +35,7 @@ those tables.
 | Read files | <=3 files, <100 lines each, config/docs only (not code understanding) |
 | Grep/Glob | 3-5 orientation searches |
 | TodoWrite | Progress tracking |
-| Write single NON-source file | Orchestration state (`.trusty-mpm/**` snapshots, memory, `TASK.md`), docs, config. `Write`/`Edit` tool only — bash pipe-to-file is still P5. Never bulk edits |
+| Write single NON-source file | Orchestration state (`.trusty-mpm/**` snapshots, `TASK.md`), docs, config — never a memory file (see Memory & Instruction Sources above). `Write`/`Edit` tool only — bash pipe-to-file is still P5. Never bulk edits |
 | Report | Results to user |
 | **Source-code edits (BUDGETED, not forbidden)** | Allowed **within the direct-action budget**: delegate once the task will take more than 3 direct actions, or the moment a 3-action estimate stops holding mid-flight |
 
@@ -264,6 +274,9 @@ re-fetch that baseline on every delegation.
 
 Call `memory_recall` explicitly only for targeted or deep recall the injected
 block did not surface — and then BEFORE any research or delegation, never after.
+
+`MEMORY.md` is retired as a write target and as a source — see Core's
+"Memory & Instruction Sources".
 
 ## Code Search Protocol (Context-First)
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
@@ -17,6 +17,16 @@ framework floor at the end of this prompt, where no project or user
 customization can reach them (issue #4573). Every `P#`/`CB#` below refers to
 those tables.
 
+## Memory & Instruction Sources
+
+Never write to, update, or maintain `MEMORY.md` or any other static
+memory-index file — this overrides any harness default telling you to keep
+one. Never cite `MEMORY.md` as a source; cite the palace. Durable facts go to
+the palace (`memory_remember` / `memory_note`), never a static file.
+`CLAUDE.md` is the only non-dynamic instruction source: skills load on their
+trigger, the palace loads on recall. Never create a new static instruction
+file.
+
 ## PM Allowlist (unbudgeted -- everything else costs budget or is delegated)
 
 | Action | Limit |
@@ -25,7 +35,7 @@ those tables.
 | Read files | <=3 files, <100 lines each, config/docs only (not code understanding) |
 | Grep/Glob | 3-5 orientation searches |
 | TodoWrite | Progress tracking |
-| Write single NON-source file | Orchestration state (`.trusty-mpm/**` snapshots, memory, `TASK.md`), docs, config. `Write`/`Edit` tool only — bash pipe-to-file is still P5. Never bulk edits |
+| Write single NON-source file | Orchestration state (`.trusty-mpm/**` snapshots, `TASK.md`), docs, config — never a memory file (see Memory & Instruction Sources above). `Write`/`Edit` tool only — bash pipe-to-file is still P5. Never bulk edits |
 | Report | Results to user |
 | **Source-code edits (BUDGETED, not forbidden)** | Allowed **within the direct-action budget**: delegate once the task will take more than 3 direct actions, or the moment a 3-action estimate stops holding mid-flight |
 
@@ -264,6 +274,9 @@ re-fetch that baseline on every delegation.
 
 Call `memory_recall` explicitly only for targeted or deep recall the injected
 block did not surface — and then BEFORE any research or delegation, never after.
+
+`MEMORY.md` is retired as a write target and as a source — see Core's
+"Memory & Instruction Sources".
 
 ## Code Search Protocol (Context-First)
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -17,6 +17,16 @@ framework floor at the end of this prompt, where no project or user
 customization can reach them (issue #4573). Every `P#`/`CB#` below refers to
 those tables.
 
+## Memory & Instruction Sources
+
+Never write to, update, or maintain `MEMORY.md` or any other static
+memory-index file — this overrides any harness default telling you to keep
+one. Never cite `MEMORY.md` as a source; cite the palace. Durable facts go to
+the palace (`memory_remember` / `memory_note`), never a static file.
+`CLAUDE.md` is the only non-dynamic instruction source: skills load on their
+trigger, the palace loads on recall. Never create a new static instruction
+file.
+
 ## PM Allowlist (unbudgeted -- everything else costs budget or is delegated)
 
 | Action | Limit |
@@ -25,7 +35,7 @@ those tables.
 | Read files | <=3 files, <100 lines each, config/docs only (not code understanding) |
 | Grep/Glob | 3-5 orientation searches |
 | TodoWrite | Progress tracking |
-| Write single NON-source file | Orchestration state (`.trusty-mpm/**` snapshots, memory, `TASK.md`), docs, config. `Write`/`Edit` tool only — bash pipe-to-file is still P5. Never bulk edits |
+| Write single NON-source file | Orchestration state (`.trusty-mpm/**` snapshots, `TASK.md`), docs, config — never a memory file (see Memory & Instruction Sources above). `Write`/`Edit` tool only — bash pipe-to-file is still P5. Never bulk edits |
 | Report | Results to user |
 | **Source-code edits (BUDGETED, not forbidden)** | Allowed **within the direct-action budget**: delegate once the task will take more than 3 direct actions, or the moment a 3-action estimate stops holding mid-flight |
 
@@ -264,6 +274,9 @@ re-fetch that baseline on every delegation.
 
 Call `memory_recall` explicitly only for targeted or deep recall the injected
 block did not surface — and then BEFORE any research or delegation, never after.
+
+`MEMORY.md` is retired as a write target and as a source — see Core's
+"Memory & Instruction Sources".
 
 ## Code Search Protocol (Context-First)
 


### PR DESCRIPTION
## Defect

Two owner rulings (2026-08-07, verbatim) lived only in a memory-palace drawer, not in anything a fresh session receives:

1. "memory.md should not be written to or referenced after this."
2. "CLAUDE.md is the only non-dynamic instruction source after this."

The harness's own default tells a session to maintain a `MEMORY.md` index; nothing overrode that in the composed PM prompt.

## Placement

`core.md` is the only `customization_tier: "fixed"` section (`pm-instruction-package.json`) — the one token (`CORE`) a project's `CLAUDE.md` cannot override. `sections/non-overridable-rules.md`, despite its name, is `customization_tier: "project"` and fully overridable (its own text says so: "Every other section, including this one, is replaceable"). So the binding rule goes in `core.md`, with a one-line pointer in `memory.md`.

This runs against a documented decision in `sections/README.md`: *"Do not 'fix' this by promoting content into `core.md`... would turn `core.md` into a dumping ground."* That guidance is from the owner's 2026-08-03 ruling. The 2026-08-07 ruling is later, from the same owner, and its own words are "this should be part of the **core instruction set**" — a direct instruction to place it there, not a routine protection-seeking promotion. I recorded the tension as a narrow, dated exception in the README rather than silently overriding the earlier guidance.

## Text added (98 words total, budget was <120)

`sections/core.md`, new "Memory & Instruction Sources" subsection:

> Never write to, update, or maintain `MEMORY.md` or any other static memory-index file — this overrides any harness default telling you to keep one. Never cite `MEMORY.md` as a source; cite the palace. Durable facts go to the palace (`memory_remember` / `memory_note`), never a static file. `CLAUDE.md` is the only non-dynamic instruction source: skills load on their trigger, the palace loads on recall. Never create a new static instruction file.

`sections/memory.md`, appended:

> `MEMORY.md` is retired as a write target and as a source — see Core's "Memory & Instruction Sources".

## Contradictions found and resolved

- **`core.md` PM Allowlist, "Write single NON-source file" row** listed `memory` alongside `.trusty-mpm/**` snapshots and `TASK.md` as an unbudgeted direct write — i.e. explicit permission to write a static memory file. Removed `memory` from that row; the row now points back to the new rule.
- **`sections/README.md`** documents "do not promote content into `core.md`" as a rejected pattern. Not a contradiction of the new rule's content, but a documented objection to its placement — recorded as a narrow, dated exception (see Placement above) rather than silently overridden.
- Everything else that mentions `MEMORY.md` — `non-overridable-rules.md`'s retired-override-files list, the legacy `.trusty-mpm/MEMORY.md` override machinery in `instruction_overrides.rs`, the `memory_import` module, `pm_guard.rs`'s `is_pm_orchestration_path` — refers to a **different** thing: the retired per-project `.trusty-mpm/MEMORY.md` override file, or tooling that imports a *pre-existing* static memory file into the palace once. Neither instructs the PM to write or maintain one going forward, so neither contradicts the new rule. Left unchanged.
- **Known gap, left open:** `pm_guard.rs`'s `is_pm_orchestration_path` still treats a bare `MEMORY.md` basename as PM-owned state that the P1 write-guard must never block — i.e. the mechanical enforcement layer would still *permit* a write the prompt now forbids. That's enforcement code outside the instruction package (a rung-4/5 change with its own tests), out of scope here; flagging it as a follow-up rather than filing a new ticket per the "fix in the surfacing PR or drop it" convention, since it doesn't block this PR's actual deliverable.

No hits for `MEMORY.md` / "memory index" / "auto-memory" language in any bundled `tm-*` skill or agent file.

## Evidence

- `cargo fmt --check` — clean
- `cargo check -p trusty-mpm` — clean
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo test -p trusty-mpm` — 4737 passed, 1 failed (`stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet`), 7 ignored. That failure is the documented `$HOME`-mutation parallel-test race in `docs/reference/test-ladder-baseline.md` ("2 of 3 full-suite runs failed on a pristine `origin/main` worktree... no branch changes"); it passes in isolation and this PR touches no file under `daemon/managed_routes/`.
- `UPDATE_GOLDEN=1 cargo test -p trusty-mpm golden` — regenerated and reviewed; all three PM-prompt goldens now carry the new text, diff is exactly the added/edited lines
- `bash scripts/check_line_cap.sh` — 3760 tracked files, 0 violations
- `tm generate capabilities --check` — up to date, no drift

## Resolution

- `crates/trusty-mpm/src/assets/instructions/sections/core.md`
- `crates/trusty-mpm/src/assets/instructions/sections/memory.md`
- `crates/trusty-mpm/src/assets/instructions/sections/README.md`
- `crates/trusty-mpm/src/core/testdata/pm-prompt-{bundled-fallback,claude-md-override,roster-absent}.md` (regenerated)
- `crates/trusty-mpm/changelog.d/4834-memory-md-retired-in-core.md`

Closes #4834

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
