### PR TITLE
fix(trusty-mpm): stop pm_guard always-allowing a bare MEMORY.md write

### DIFF
--- a/crates/trusty-mpm/changelog.d/5086-pm-guard-memory-md.md
+++ b/crates/trusty-mpm/changelog.d/5086-pm-guard-memory-md.md
@@ -1,0 +1,5 @@
+Fixed
+
+- `pm_guard` no longer always-allows a bare `MEMORY.md` write, matching the PM prompt's write prohibition ([#5086](https://github.com/bobmatnyc/trusty-tools/issues/5086))
+  - `is_pm_orchestration_path` matched any path whose basename was literally `MEMORY.md`, so a top-level `MEMORY.md` landed in the HARD always-allow set that wins over the source-code rule. `core.md` (merged in [#5079](https://github.com/bobmatnyc/trusty-tools/pull/5079)) says never to write, update, or cite `MEMORY.md`, so the enforcement layer contradicted the prompt
+  - the two legitimate targets — the palace index under `~/.trusty-tools/…/memory/MEMORY.md` and the retired `.trusty-mpm/MEMORY.md` override — already match on the `.trusty-tools` / `.trusty-mpm` path-component check, so dropping the basename match removes no real coverage. `TASK.md` is unchanged

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
@@ -589,18 +589,19 @@ fn edit_tool_target_path(tool_input: Option<&serde_json::Value>) -> Option<&str>
 /// home, and `TASK.md`-style session files. A session-pause writing
 /// `.trusty-mpm/sessions/session-*.md` must always pass, independent of the
 /// source-code rule.
-/// What: `true` when the basename is `TASK.md` or `MEMORY.md`, or when any path
-/// *component* is exactly `.trusty-mpm` or `.trusty-tools`. Component matching
-/// (not substring) is deliberate so the crate source dir `crates/trusty-mpm/`
-/// — note no leading dot — is NOT matched.
+/// What: `true` when the basename is `TASK.md`, or when any path *component* is
+/// exactly `.trusty-mpm` or `.trusty-tools`. Component matching (not substring)
+/// is deliberate so the crate source dir `crates/trusty-mpm/` — note no leading
+/// dot — is NOT matched. A `MEMORY.md` under either component still matches, so
+/// the palace index and the retired `.trusty-mpm/MEMORY.md` override stay
+/// allowed.
 /// Test: `is_pm_orchestration_path_matches_owned_state`.
 fn is_pm_orchestration_path(path: &str) -> bool {
     use std::path::{Component, Path};
     let p = Path::new(path);
-    if matches!(
-        p.file_name().and_then(|s| s.to_str()),
-        Some("TASK.md" | "MEMORY.md")
-    ) {
+    // #5086: `MEMORY.md` dropped from the basename match — core.md (#5079)
+    // forbids the PM writing it, so a bare one must not be always-allowed.
+    if matches!(p.file_name().and_then(|s| s.to_str()), Some("TASK.md")) {
         return true;
     }
     p.components().any(|c| {
@@ -881,7 +882,16 @@ mod tests {
             assert!(is_pm_orchestration_path(p), "{p} should be PM-owned");
         }
         // The crate source dir `trusty-mpm` (no leading dot) must NOT match.
-        for p in ["crates/trusty-mpm/src/lib.rs", "src/main.rs", "notes.md"] {
+        // #5086: a bare `MEMORY.md` outside a PM-owned directory must NOT match
+        // either — the prompt forbids writing it (core.md, #5079).
+        for p in [
+            "crates/trusty-mpm/src/lib.rs",
+            "src/main.rs",
+            "notes.md",
+            "MEMORY.md",
+            "/Users/x/some/project/MEMORY.md",
+            "docs/MEMORY.md",
+        ] {
             assert!(!is_pm_orchestration_path(p), "{p} should NOT be PM-owned");
         }
     }


### PR DESCRIPTION
Closes #5086

## Outcome

`pm_guard`'s write guard no longer always-allows a bare `MEMORY.md`. `is_pm_orchestration_path` matched any path whose basename was literally `MEMORY.md`, so a top-level `MEMORY.md` landed in the HARD always-allow set that wins over the source-code rule — while `core.md` (merged 66373cec, #5079) tells the PM never to write, update, or cite `MEMORY.md`. Enforcement contradicted the prompt.

## What changed

`crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs` — `MEMORY.md` dropped from the basename match; `TASK.md` and both `.trusty-mpm` / `.trusty-tools` path-component checks unchanged.

Verified before deleting: the two legitimate targets already match on the component check, so no real coverage is lost.

| Path | Still matches, via |
|---|---|
| `~/.trusty-tools/trusty-mpm/.../memory/MEMORY.md` | `.trusty-tools` component |
| `.trusty-mpm/MEMORY.md` (retired override) | `.trusty-mpm` component |
| `MEMORY.md`, `docs/MEMORY.md` | no longer matches — the fix |

Out of scope: `TASK.md`; the deny-by-default persona gate; anything in `evaluate_edit_tool` beyond this allow-list.

## Risk

Low, and narrower than it looks. `is_pm_orchestration_path` has exactly one caller (`evaluate_edit_tool`), which after the allow-list falls through to `is_source_code_path` — `.md` is not a source extension, so a bare `MEMORY.md` Edit/Write still returns ALLOW today. What changes is that the HARD always-allow no longer asserts a bare `MEMORY.md` is PM-owned state, so it can't grant a bogus exemption if the source rule widens or a new caller reads this predicate as an enforcement signal.

## Test evidence — Rust Test Ladder rung 3 (localized behavior, one crate)

Regression assertion added to `is_pm_orchestration_path_matches_owned_state`: `MEMORY.md`, `/Users/x/some/project/MEMORY.md`, `docs/MEMORY.md` must NOT be PM-owned. The pre-existing positive assertion for `/Users/x/.trusty-tools/trusty-mpm/x/memory/MEMORY.md` stays and still passes.

RED against the unfixed code (test added first, fix stashed):

```
running 1 test
test commands::pm_guard::tests::is_pm_orchestration_path_matches_owned_state ... FAILED

thread '...' panicked at crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs:894:13:
MEMORY.md should NOT be PM-owned

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1546 filtered out; finished in 0.00s
```

GREEN after the fix:

```
running 1 test
test commands::pm_guard::tests::is_pm_orchestration_path_matches_owned_state ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1546 filtered out; finished in 0.00s
```

Full rung-3 chain:

| Gate | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo check -p trusty-mpm` | pass |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | pass, zero warnings |
| `cargo test -p trusty-mpm` | `4739 passed; 0 failed; 7 ignored` (lib) + all integration targets green |
| `bash scripts/check_line_cap.sh` | `3762 tracked .rs file(s); 0 violations — OK` |
| `bash scripts/check_changelog_fragment.sh` | `OK trusty-mpm: changelog.d fragment present and valid` |

## Baseline failures

The first `cargo test -p trusty-mpm` run hit `core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning` (`4738 passed; 1 failed`). Pre-existing and tracked as #4931 (order-dependent tests that fail under parallel execution, pass in isolation) — evidence appended there. It passes standalone and passed on an immediate unmodified full-suite rerun; this diff touches zero files under `src/core/`.

## Docs / changelog

`crates/trusty-mpm/changelog.d/5086-pm-guard-memory-md.md` (Fixed). The `is_pm_orchestration_path` doc comment's What/Test block is updated to match the new behavior; change site carries `// #5086: …`.

## Review findings

None yet — opened fresh.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
