### PR TITLE
fix(trusty-mpm): tm doctor resolves the PINNED trusty-search index instead of trusting the fail-open (#5045)

### DIFF
--- a/crates/trusty-mpm/changelog.d/5045-doctor-index-pin-check.md
+++ b/crates/trusty-mpm/changelog.d/5045-doctor-index-pin-check.md
@@ -1,0 +1,6 @@
+Added
+
+- `tm doctor` gains a `search_index_pin` check that resolves the trusty-search index a session is actually pinned to ([#5045](https://github.com/bobmatnyc/trusty-tools/issues/5045))
+  - session launch writes `trusty-search serve --index <id>` into the project's `.mcp.json` and registers that index best-effort. Every step of the registration swallows its failures at `warn!`, so the pin advances even when index creation never happened. The existing `search` check asks the daemon whether it is healthy and whether the *derived* id appears in `/indexes`, so it kept reporting fine: 4 of 75 live worktrees had an index, while a bare `search` in the rest returned `404 unknown index`
+  - the new check reads the pinned id out of `.mcp.json` and resolves it with `GET /indexes/{id}/status`. A 404 is `Fail` and names the id; an index that resolves with 0 chunks is `Warn` (registered, never populated); an unanswered daemon is `Unknown`, never `Ok`
+  - read-only — it never creates or reindexes anything

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities.md
@@ -41,7 +41,7 @@ relevant `references/*.md` file here when you need an exact answer.
 | "What MCP tools exist and what parameters do they take?" | `references/mcp-tools.md` (33 tools, plus sibling-daemon pointers) |
 | "What agents can I delegate to, and what do they declare?" | `references/agents.md` (37 concrete agents) |
 | "What skills exist, and are they user-invocable?" | `references/skills.md` (52 bundled skills) |
-| "What does a `tm doctor` check name actually mean?" | `references/doctor.md` (29 checks) |
+| "What does a `tm doctor` check name actually mean?" | `references/doctor.md` (30 checks) |
 | "Where do agents/skills/instructions actually live, and which tier wins?" | `references/framework.md` (install layout, tier precedence, doc index) |
 | "How do the pieces fit into an end-to-end flow?" | `references/workflows.md` (hand-authored, not generated) |
 

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/doctor.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/doctor.md
@@ -2,7 +2,7 @@
 
 Generated from a maintained literal list cross-checked against `run_doctor`'s actual check names (see this module's `doctor_checks_match_run_doctor_names` test — an added, removed, or renamed check fails the test suite). Source: `crates/trusty-mpm/src/daemon/doctor.rs` and its five sibling `doctor_*.rs` files. Regenerate with `tm generate capabilities`.
 
-29 checks, in execution order.
+30 checks, in execution order.
 
 | # | Check | What it probes |
 |---|---|---|
@@ -25,13 +25,14 @@ Generated from a maintained literal list cross-checked against `run_doctor`'s ac
 | 17 | `agent_skills_prose_hints` | Informational: skill names mentioned in agent prose but not declared in `skills:` frontmatter (always `Ok`, issue #2906). |
 | 18 | `memory` | trusty-memory sidecar reachability probe (bounded by `PROBE_TIMEOUT`). |
 | 19 | `search` | trusty-search sidecar reachability + expected-index-present probe (bounded by `PROBE_TIMEOUT`). |
-| 20 | `worktrees` | No orphaned git worktrees under the managed workspace root (Fix 1b, #1840). |
-| 21 | `worktree_disk` | Bytes held by every git-registered worktree, and how much sits on already-merged pull requests with no unsaved work (issue #2919). |
-| 22 | `gh_account` | Active `gh` CLI identity is unambiguous — warns on multi-account ambiguity. |
-| 23 | `oauth_token` | Warns when a managed session risks the `CLAUDE_CONFIG_DIR`-keyed Keychain login loop (issue #2246). |
-| 24 | `hooks_contamination` | Warns when a project's `.claude/settings*.json` still carries tm hook entries from a pre-fix `tm install` — suggests `tm hooks clean` (issue #2940). |
-| 25 | `hooks_foreign_conflict` | Informational: warns when a project's `.claude/settings*.json` carries foreign (claude-mpm) hook entries that would fire inside a tm session — never auto-removed (issue #2940). |
-| 26 | `tcc_taint` | macOS: whether managed panes spawn `claude` with TCC responsibility disclaimed so its data-access prompts aren't attributed to the shared tmux server (issue #2997). |
-| 27 | `scaffold_tracking` | Warns when a harness-scaffolding path (`.claude/agents/`, `.claude/skills/`, `.claude/output-styles/`) is BOTH tracked in git AND regenerated locally by tm — the precondition for a `git merge --ff-only` "would be overwritten" collision; reports the exact true-intersection paths, never auto-modifies the index (issue #3427). |
-| 28 | `push_guard` | Warns when the project's clone carries no trusty-mpm cross-branch `pre-push` guard, or an older revision of it — the guard installs itself only on the clone path, so a base provisioned before it shipped is silently unprotected and a worktree tracking a foreign branch can force-push over that branch's reviewed lineage. Names the `tm repair push-guard` retrofit; doctor never writes into a repository (issue #2867). |
-| 29 | `binary_provenance` | Where the RUNNING binary came from and whether that source still exists: reads cargo's own `$CARGO_HOME/.crates2.json` install ledger and compares it against the running executable. Fails when the same binary is provided by more than one install, when the ledger's recorded version disagrees with what is running, or when a `cargo install --path` source directory has been reaped (no provenance, no upgrade path). Warns for a live path/git install, which is invisible to registry update detection. Reports UNKNOWN — never `Ok` — when the ledger is unreadable or does not cover the binary (a prebuilt-installer or package-manager install). Read-only; never installs, moves, or deletes (issue #4033, ADR-0021). |
+| 20 | `search_index_pin` | Resolves the index id the project's `.mcp.json` actually PINS (`trusty-search serve --index <id>`) against `GET /indexes/{id}/status`, and FAILS on a 404 — the pin names an index the daemon does not have, so every `search`/`grep` call in the session returns "unknown index". Index registration is fail-open at every step, so the pin advances even when creation failed and the `search` check above still reports healthy; 4 of 75 live worktrees had an index when this was measured. Read-only; never creates or reindexes (issue #5045). |
+| 21 | `worktrees` | No orphaned git worktrees under the managed workspace root (Fix 1b, #1840). |
+| 22 | `worktree_disk` | Bytes held by every git-registered worktree, and how much sits on already-merged pull requests with no unsaved work (issue #2919). |
+| 23 | `gh_account` | Active `gh` CLI identity is unambiguous — warns on multi-account ambiguity. |
+| 24 | `oauth_token` | Warns when a managed session risks the `CLAUDE_CONFIG_DIR`-keyed Keychain login loop (issue #2246). |
+| 25 | `hooks_contamination` | Warns when a project's `.claude/settings*.json` still carries tm hook entries from a pre-fix `tm install` — suggests `tm hooks clean` (issue #2940). |
+| 26 | `hooks_foreign_conflict` | Informational: warns when a project's `.claude/settings*.json` carries foreign (claude-mpm) hook entries that would fire inside a tm session — never auto-removed (issue #2940). |
+| 27 | `tcc_taint` | macOS: whether managed panes spawn `claude` with TCC responsibility disclaimed so its data-access prompts aren't attributed to the shared tmux server (issue #2997). |
+| 28 | `scaffold_tracking` | Warns when a harness-scaffolding path (`.claude/agents/`, `.claude/skills/`, `.claude/output-styles/`) is BOTH tracked in git AND regenerated locally by tm — the precondition for a `git merge --ff-only` "would be overwritten" collision; reports the exact true-intersection paths, never auto-modifies the index (issue #3427). |
+| 29 | `push_guard` | Warns when the project's clone carries no trusty-mpm cross-branch `pre-push` guard, or an older revision of it — the guard installs itself only on the clone path, so a base provisioned before it shipped is silently unprotected and a worktree tracking a foreign branch can force-push over that branch's reviewed lineage. Names the `tm repair push-guard` retrofit; doctor never writes into a repository (issue #2867). |
+| 30 | `binary_provenance` | Where the RUNNING binary came from and whether that source still exists: reads cargo's own `$CARGO_HOME/.crates2.json` install ledger and compares it against the running executable. Fails when the same binary is provided by more than one install, when the ledger's recorded version disagrees with what is running, or when a `cargo install --path` source directory has been reaped (no provenance, no upgrade path). Warns for a live path/git install, which is invisible to registry update detection. Reports UNKNOWN — never `Ok` — when the ledger is unreadable or does not cover the binary (a prebuilt-installer or package-manager install). Read-only; never installs, moves, or deletes (issue #4033, ADR-0021). |

--- a/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
+++ b/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
@@ -108,6 +108,10 @@ pub(crate) const DOCTOR_CHECKS: &[(&str, &str)] = &[
         "trusty-search sidecar reachability + expected-index-present probe (bounded by `PROBE_TIMEOUT`).",
     ),
     (
+        "search_index_pin",
+        "Resolves the index id the project's `.mcp.json` actually PINS (`trusty-search serve --index <id>`) against `GET /indexes/{id}/status`, and FAILS on a 404 — the pin names an index the daemon does not have, so every `search`/`grep` call in the session returns \"unknown index\". Index registration is fail-open at every step, so the pin advances even when creation failed and the `search` check above still reports healthy; 4 of 75 live worktrees had an index when this was measured. Read-only; never creates or reindexes (issue #5045).",
+    ),
+    (
         "worktrees",
         "No orphaned git worktrees under the managed workspace root (Fix 1b, #1840).",
     ),

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -196,7 +196,7 @@ async fn execute_doctor_against_test_daemon() {
     match executor.execute(TrustyCommand::Doctor).await {
         CommandResult::Doctor(report) => {
             // This test owns the EXECUTOR round-trip, not the check roster.
-            // The exact count is pinned by `run_doctor_produces_twenty_eight_checks`
+            // The exact count is pinned by `run_doctor_produces_thirty_checks`
             // and `doctor_endpoint_returns_report`, both of which derive it from
             // their own name list — duplicating a bare literal here just made it a
             // fourth place to forget (#4090 review LOW-1).

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1173,7 +1173,8 @@ async fn doctor_endpoint_returns_report() {
     // added the output_style_staleness check; issue #2997 added the tcc_taint
     // check; issue #3453 part 2 added the output_style_legacy_ids check;
     // issue #3427 added the scaffold_tracking check; issue #4442 added the
-    // asset_tier check; issue #4033 added the binary_provenance check).
+    // asset_tier check; issue #4033 added the binary_provenance check; issue
+    // #5045 added the search_index_pin check).
     // #1905's stale-skill
     // cleanup is a one-time migration, not a `run_doctor` probe, so it does
     // not appear here; the per-check statuses carry the diagnosis, not the
@@ -1201,6 +1202,7 @@ async fn doctor_endpoint_returns_report() {
         "agent_skills_prose_hints",
         "memory",
         "search",
+        "search_index_pin",
         "worktrees",
         "worktree_disk",
         "gh_account",

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -139,6 +139,16 @@ use doctor_worktree_disk::check_worktree_disk;
 mod doctor_legacy_overrides;
 use doctor_legacy_overrides::check_legacy_overrides;
 
+// #5045: the resolution half of `check_search` below. That probe asks the
+// daemon whether it is healthy and whether the DERIVED id appears in
+// `/indexes`; this one resolves the id the session is actually PINNED to. The
+// registration path is fail-open at every step, so the pin advances even when
+// index creation failed — 4 of 75 live worktrees had an index while `search`
+// reported fine.
+#[path = "doctor_search_pin.rs"]
+mod doctor_search_pin;
+use doctor_search_pin::check_search_index_pin;
+
 /// Per-probe network timeout.
 ///
 /// Why: a sidecar that is down or wedged must not stall the whole diagnostic;
@@ -227,9 +237,13 @@ const PROBE_RETRY_DELAY: Duration = Duration::from_millis(500);
 /// `project_dir`'s clone has no trusty-mpm cross-branch `pre-push` guard, or
 /// carries an older revision of it, naming the `tm repair push-guard`
 /// retrofit; this is the only way a base clone provisioned BEFORE the guard
-/// shipped is discoverable as unprotected) — folding the resulting twenty-two
-/// [`DoctorCheck`]s into a [`DoctorReport`] whose `overall` status is the
-/// worst of them.
+/// shipped is discoverable as unprotected), and the `search_index_pin` probe
+/// (issue #5045 — resolves the index id the project's `.mcp.json` actually
+/// PINS against `GET /indexes/{id}/status` and `Fail`s on a 404; index
+/// registration is fail-open at every step, so the pin advances even when
+/// creation failed and the `search` probe above stays green) — folding the
+/// resulting [`DoctorCheck`]s into a [`DoctorReport`] whose `overall` status
+/// is the worst of them.
 ///
 /// Note (#1905): the mpm-*→tm-* stale-skill cleanup is intentionally NOT a
 /// permanent probe here — it is a one-time migration
@@ -254,7 +268,7 @@ const PROBE_RETRY_DELAY: Duration = Duration::from_millis(500);
 /// the one tm-managed `CLAUDE_CONFIG_DIR` tier and nowhere else, so
 /// `check_agents`/`check_agent_skills` probe `paths.agent_deploy_dir()`, which
 /// is the same directory whether or not a `project_dir` was supplied.
-/// Test: `run_doctor_produces_twenty_nine_checks`,
+/// Test: `run_doctor_produces_thirty_checks`,
 /// `agents_check_probes_the_managed_config_tier_not_the_workspace`.
 pub async fn run_doctor(
     project_dir: Option<&Path>,
@@ -312,6 +326,10 @@ pub async fn run_doctor(
     ];
     checks.push(check_memory(&home).await);
     checks.push(check_search(&home, project_dir).await);
+    // #5045: `check_search` above reports the daemon and the DERIVED id; this
+    // resolves the id `.mcp.json` actually pins, which is what every `search`
+    // call in the session sends.
+    checks.push(check_search_index_pin(&home, project_dir).await);
     checks.push(check_worktrees(repos_root, active_workspace_paths).await);
     // #2919: `check_worktrees` above counts ORPHANS and has never reported a
     // byte, so it read identically whether the worktree store held 4 GiB or the

--- a/crates/trusty-mpm/src/daemon/doctor_search_pin.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_search_pin.rs
@@ -1,0 +1,324 @@
+//! `tm doctor` pinned-search-index resolution probe (issue #5045).
+//!
+//! Why: session launch pins a trusty-search index id into the project's
+//! `.mcp.json` (`trusty-search serve --index <id>`) and registers that index
+//! best-effort. Every step of the registration is fail-open —
+//! `trusty_common::search_index::ensure_project_indexed` "ALWAYS returns the
+//! derived id … even if the daemon is unreachable", and both
+//! `best_effort_create_index` and `best_effort_trigger_reindex` swallow their
+//! failures at `tracing::warn!`. So the pin advances whether or not the index
+//! was ever created, and the existing `search` probe — which asks the daemon
+//! whether it is healthy and whether the *derived* id appears in `/indexes` —
+//! keeps reporting fine. Measured on 2026-08-07: 4 of 75 live worktrees had a
+//! registered index, and `POST /indexes/<pinned-id>/search` returned
+//! `404 Not Found: {"error":"unknown index"}` in a worktree whose `search`
+//! check was green.
+//!
+//! What: [`check_search_index_pin`] reads the id the session is ACTUALLY
+//! pinned to out of `.mcp.json` and resolves it against the daemon with
+//! `GET /indexes/{id}/status`. A 404 is `Fail` — the pin names an index that
+//! does not exist, so every `search` call in that session 404s. This is
+//! deliberately not a health question: asking the daemon "are you well?"
+//! reproduces the blind spot rather than closing it.
+//!
+//! Test: the `tests` module below covers every [`PinState`] / [`PinProbe`]
+//! verdict, the `.mcp.json` reader against real files, and the 404 → `Fail`
+//! path over a real HTTP socket.
+
+use std::path::Path;
+
+use crate::core::doctor::{CheckStatus, DoctorCheck};
+
+use crate::daemon::discover::{TRUSTY_SEARCH_DEFAULT_ADDR, discover_addr};
+
+use super::PROBE_TIMEOUT;
+
+/// Stable name of this check, as it appears in the report and in
+/// `generate::doctor::DOCTOR_CHECKS`.
+const CHECK: &str = "search_index_pin";
+
+/// What the project's `.mcp.json` says the session's search index is.
+///
+/// Why: the four cases carry different verdicts and each is reachable in the
+/// field — an unmanaged project has no `.mcp.json` at all, a pre-#1373 stub is
+/// present but unpinned, and only the last case gives the probe an id to
+/// resolve. Naming them keeps [`build_pin_check`] a pure, exhaustive match.
+/// What: the parse outcome of `<project>/.mcp.json`'s
+/// `mcpServers["trusty-search"].args`.
+/// Test: `read_pin_*` in the `tests` module below.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PinState {
+    /// No `.mcp.json` in the project — nothing was pinned, nothing to verify.
+    NoMcpJson,
+    /// `.mcp.json` exists but could not be read or parsed as JSON.
+    Unreadable(String),
+    /// `.mcp.json` parses but carries no `trusty-search` MCP server.
+    NoSearchServer,
+    /// A `trusty-search` server is registered without an `--index <id>` pin.
+    Unpinned,
+    /// The session is pinned to this index id.
+    Pinned(String),
+}
+
+/// What `GET /indexes/{id}/status` reported for the pinned id.
+///
+/// Why: `UnknownIndex` is the whole point of this check (issue #5045) and must
+/// never be collapsed into the generic error case — a 404 is a definite,
+/// actionable "this pin resolves to nothing", whereas a transport failure is
+/// an absence of information.
+/// What: the classified outcome of one bounded status request.
+/// Test: `probe_reports_unknown_index_on_404`, `probe_reports_resolved_on_200`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PinProbe {
+    /// The daemon knows the index; `chunk_count` is its reported corpus size
+    /// (`None` when the body carried no count).
+    Resolved { chunk_count: Option<u64> },
+    /// 404 — the daemon has no index under that id.
+    UnknownIndex,
+    /// The daemon answered with some other non-2xx status.
+    HttpStatus(u16),
+    /// No trusty-search daemon address could be discovered, or the request
+    /// failed at the transport layer.
+    Unreachable(String),
+}
+
+/// Resolve the session's PINNED trusty-search index and report whether it
+/// actually exists (issue #5045).
+///
+/// Why: the index-registration path is fail-open end to end, so the pin in
+/// `.mcp.json` advances even when index creation failed, and the pre-existing
+/// `search` probe stays green because it asks about daemon health and the
+/// *derived* id rather than resolving the id the session will really use. This
+/// probe exists because "health reports ok" is exactly the symptom — see the
+/// module doc.
+/// What: reads the pin via [`read_pinned_index_id`], resolves the daemon
+/// address the same way [`super::doctor`]'s `search` probe does, issues one
+/// [`PROBE_TIMEOUT`]-bounded `GET /indexes/{id}/status`, and folds the two
+/// results with [`build_pin_check`]. Read-only: it never creates, reindexes,
+/// or repairs anything.
+/// Test: `pinned_but_missing_index_is_fail` (the full path, over a real
+/// socket), plus the `build_pin_check_*` verdict tests.
+pub(super) async fn check_search_index_pin(home: &Path, project_dir: Option<&Path>) -> DoctorCheck {
+    let Some(project) = project_dir else {
+        return DoctorCheck::new(
+            CHECK,
+            CheckStatus::Warn,
+            "no project directory supplied — cannot resolve a pinned trusty-search index",
+        );
+    };
+
+    let pin = read_pinned_index_id(project);
+    let probe = match &pin {
+        PinState::Pinned(id) => {
+            let dir = home.join(".trusty-search");
+            let default = TRUSTY_SEARCH_DEFAULT_ADDR
+                .parse()
+                .expect("static default is valid");
+            let env = std::env::var("TRUSTY_SEARCH_ADDR").ok();
+            let addr = discover_addr(&dir, default, env.as_deref()).await;
+            Some(probe_pinned_index(&format!("http://{addr}"), id).await)
+        }
+        _ => None,
+    };
+
+    build_pin_check(&pin, probe.as_ref())
+}
+
+/// Read the `--index <id>` pin out of `<project>/.mcp.json`.
+///
+/// Why: the pin is the id the session's MCP client will send on every `search`
+/// call, so it — not the id doctor would derive today — is the thing whose
+/// existence has to be proven. The two can differ whenever the workspace was
+/// pinned under a different root, which is the ordinary case for a worktree.
+/// What: parses `mcpServers["trusty-search"].args` and returns the element
+/// following `--index`. Distinguishes an absent file, an unparseable one, a
+/// missing server entry, and an unpinned stub so the caller can report each
+/// honestly rather than folding them into one verdict.
+/// Test: `read_pin_finds_the_pinned_id`, `read_pin_reports_unpinned_stub`,
+/// `read_pin_reports_missing_file`, `read_pin_reports_missing_server`,
+/// `read_pin_reports_unreadable_json`.
+pub(super) fn read_pinned_index_id(project_dir: &Path) -> PinState {
+    let path = project_dir.join(".mcp.json");
+    if !path.exists() {
+        return PinState::NoMcpJson;
+    }
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(e) => return PinState::Unreadable(e.to_string()),
+    };
+    let value: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => return PinState::Unreadable(e.to_string()),
+    };
+
+    let Some(args) = value
+        .get("mcpServers")
+        .and_then(|m| m.get("trusty-search"))
+        .and_then(|s| s.get("args"))
+        .and_then(serde_json::Value::as_array)
+    else {
+        return PinState::NoSearchServer;
+    };
+
+    let pinned = args
+        .iter()
+        .position(|a| a.as_str() == Some("--index"))
+        .and_then(|i| args.get(i + 1))
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.trim().is_empty());
+
+    match pinned {
+        Some(id) => PinState::Pinned(id.to_string()),
+        None => PinState::Unpinned,
+    }
+}
+
+/// Ask the daemon whether `index_id` resolves.
+///
+/// Why: `GET /indexes/{id}/status` is the cheapest endpoint that answers the
+/// exact question — it 404s for an id the daemon does not hold, which is the
+/// signature issue #5045 reproduced. `/health` and `/indexes` do not: the
+/// former reports the daemon, the latter is where the fail-open pin was
+/// already passing unnoticed.
+/// What: one `GET {base}/indexes/{index_id}/status` bounded by
+/// [`PROBE_TIMEOUT`], classified into [`PinProbe`]. A 404 maps to
+/// `UnknownIndex`; a 2xx body's `chunk_count` is carried through so the caller
+/// can distinguish "resolves and holds a corpus" from "resolves but is empty".
+/// Test: `probe_reports_unknown_index_on_404`, `probe_reports_resolved_on_200`,
+/// `probe_reports_unreachable_when_nothing_listens`.
+pub(super) async fn probe_pinned_index(base: &str, index_id: &str) -> PinProbe {
+    let client = match reqwest::Client::builder().timeout(PROBE_TIMEOUT).build() {
+        Ok(c) => c,
+        Err(e) => return PinProbe::Unreachable(e.to_string()),
+    };
+    let url = format!("{base}/indexes/{index_id}/status");
+    match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let chunk_count = resp
+                .json::<serde_json::Value>()
+                .await
+                .ok()
+                .and_then(|b| b.get("chunk_count").and_then(serde_json::Value::as_u64));
+            PinProbe::Resolved { chunk_count }
+        }
+        Ok(resp) if resp.status().as_u16() == 404 => PinProbe::UnknownIndex,
+        Ok(resp) => PinProbe::HttpStatus(resp.status().as_u16()),
+        Err(e) => PinProbe::Unreachable(e.to_string()),
+    }
+}
+
+/// Fold the pin and its probe into a verdict (pure).
+///
+/// Why: keeping the verdict logic pure makes every branch — including the one
+/// that matters, a live pin the daemon 404s — assertable without a daemon,
+/// a filesystem, or a network.
+/// What: `Fail` when a pinned id 404s (issue #5045's defect) or the daemon
+/// answers another non-2xx; `Warn` for an unpinned stub, an unreadable
+/// `.mcp.json`, or a pin that resolves to an EMPTY index (registered but never
+/// populated — every query still returns nothing, issue #1908's shape);
+/// `Unknown` when the daemon could not be reached, because an unanswered probe
+/// has established nothing about the pin; `Ok` only when the pinned id
+/// resolves to a non-empty index, or when the project pins nothing at all.
+/// Test: `build_pin_check_fails_on_unknown_index`,
+/// `build_pin_check_warns_on_empty_index`,
+/// `build_pin_check_unreachable_is_unknown_not_ok`,
+/// `build_pin_check_ok_when_index_resolves`,
+/// `build_pin_check_warns_on_unpinned_stub`.
+pub(super) fn build_pin_check(pin: &PinState, probe: Option<&PinProbe>) -> DoctorCheck {
+    let id = match pin {
+        PinState::NoMcpJson => {
+            return DoctorCheck::new(
+                CHECK,
+                CheckStatus::Ok,
+                "no .mcp.json in this project — no trusty-search index pin to resolve",
+            );
+        }
+        PinState::Unreadable(e) => {
+            return DoctorCheck::new(
+                CHECK,
+                CheckStatus::Warn,
+                format!(
+                    ".mcp.json is present but unreadable ({e}) — whether this session pins a \
+                     trusty-search index, and whether that index exists, is UNVERIFIABLE"
+                ),
+            );
+        }
+        PinState::NoSearchServer => {
+            return DoctorCheck::new(
+                CHECK,
+                CheckStatus::Ok,
+                ".mcp.json registers no trusty-search server — no index pin to resolve",
+            );
+        }
+        PinState::Unpinned => {
+            return DoctorCheck::new(
+                CHECK,
+                CheckStatus::Warn,
+                "the trusty-search MCP stub carries no `--index` pin — a bare `search` falls back \
+                 to whichever index the daemon guesses for this path, which is the wrong-index \
+                 bug issue #1373 fixed by pinning. Relaunch the session to rewrite .mcp.json",
+            );
+        }
+        PinState::Pinned(id) => id,
+    };
+
+    // #5045: this is the branch the check exists for. The pin advanced because
+    // index registration is fail-open; nothing else in the report notices.
+    match probe {
+        Some(PinProbe::UnknownIndex) => DoctorCheck::new(
+            CHECK,
+            CheckStatus::Fail,
+            format!(
+                "this session is pinned to trusty-search index `{id}` but the daemon has NO such \
+                 index — every `search`/`grep` call in this session returns 404 \"unknown index\". \
+                 Index registration is best-effort and swallows its failures, so the pin advanced \
+                 anyway and the `search` health check stays green (issue #5045). Run \
+                 `trusty-search index create` for this project, or relaunch the session"
+            ),
+        ),
+        Some(PinProbe::HttpStatus(code)) => DoctorCheck::new(
+            CHECK,
+            CheckStatus::Fail,
+            format!("status of pinned trusty-search index `{id}` returned HTTP {code}"),
+        ),
+        Some(PinProbe::Resolved { chunk_count }) => match chunk_count {
+            Some(0) => DoctorCheck::new(
+                CHECK,
+                CheckStatus::Warn,
+                format!(
+                    "pinned trusty-search index `{id}` exists but holds 0 chunks — it was \
+                     registered and never populated, so every query returns nothing. Trigger a \
+                     reindex for this project"
+                ),
+            ),
+            Some(n) => DoctorCheck::new(
+                CHECK,
+                CheckStatus::Ok,
+                format!("pinned trusty-search index `{id}` resolves ({n} chunks)"),
+            ),
+            None => DoctorCheck::new(
+                CHECK,
+                CheckStatus::Ok,
+                format!("pinned trusty-search index `{id}` resolves"),
+            ),
+        },
+        Some(PinProbe::Unreachable(e)) => DoctorCheck::new(
+            CHECK,
+            CheckStatus::Unknown,
+            format!(
+                "this session is pinned to trusty-search index `{id}` but the daemon did not \
+                 answer ({e}) — whether that index exists is UNKNOWN. The `search` check above \
+                 reports the daemon itself"
+            ),
+        ),
+        None => DoctorCheck::new(
+            CHECK,
+            CheckStatus::Unknown,
+            format!("pinned trusty-search index `{id}` was not probed"),
+        ),
+    }
+}
+
+#[cfg(test)]
+#[path = "doctor_search_pin_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/doctor_search_pin_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_search_pin_tests.rs
@@ -1,0 +1,285 @@
+//! Unit tests for `daemon::doctor_search_pin` (issue #5045).
+//!
+//! Why: split into a sibling file so the production module stays under the
+//! 500-SLOC cap.
+//! What: covers the `.mcp.json` reader against real files, the HTTP probe
+//! against a real socket (including the 404 that defines this check), and
+//! every `build_pin_check` verdict.
+//! Test: this module IS the test suite for `super`.
+
+use super::*;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Write a `.mcp.json` carrying a trusty-search stub with `args`.
+fn write_mcp_json(project: &Path, args: &serde_json::Value) {
+    let body = serde_json::json!({
+        "mcpServers": {
+            "trusty-memory": {"type": "stdio", "command": "trusty-memory", "args": ["serve"]},
+            "trusty-search": {"type": "stdio", "command": "trusty-search", "args": args},
+        }
+    });
+    std::fs::write(
+        project.join(".mcp.json"),
+        serde_json::to_string_pretty(&body).unwrap(),
+    )
+    .unwrap();
+}
+
+/// Serve one fixed raw HTTP response on a loopback port; returns its base URL.
+///
+/// A real socket, not a mock: the 404 path is the whole point of this check,
+/// and asserting it against a hand-rolled fake response type would prove
+/// nothing about how `reqwest` classifies a real `404 Not Found`.
+async fn spawn_stub(response: &'static str) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        while let Ok((mut sock, _)) = listener.accept().await {
+            let mut buf = [0u8; 2048];
+            let _ = sock.read(&mut buf).await;
+            let _ = sock.write_all(response.as_bytes()).await;
+            let _ = sock.flush().await;
+        }
+    });
+    format!("http://{addr}")
+}
+
+// ---------------------------------------------------------------- pin reader
+
+#[test]
+fn read_pin_finds_the_pinned_id() {
+    // The shape `session_launch::search_index::trusty_search_mcp_value` writes.
+    let tmp = tempfile::tempdir().unwrap();
+    write_mcp_json(
+        tmp.path(),
+        &serde_json::json!(["serve", "--index", "trusty-tools"]),
+    );
+    assert_eq!(
+        read_pinned_index_id(tmp.path()),
+        PinState::Pinned("trusty-tools".to_string())
+    );
+}
+
+#[test]
+fn read_pin_reports_unpinned_stub() {
+    // The pre-#1373 stub: tools present, no `--index`.
+    let tmp = tempfile::tempdir().unwrap();
+    write_mcp_json(tmp.path(), &serde_json::json!(["serve"]));
+    assert_eq!(read_pinned_index_id(tmp.path()), PinState::Unpinned);
+}
+
+#[test]
+fn read_pin_treats_a_blank_id_as_unpinned() {
+    // `--index ""` pins nothing; reporting it as a pinned id would send the
+    // probe after an empty URL segment.
+    let tmp = tempfile::tempdir().unwrap();
+    write_mcp_json(tmp.path(), &serde_json::json!(["serve", "--index", "  "]));
+    assert_eq!(read_pinned_index_id(tmp.path()), PinState::Unpinned);
+}
+
+#[test]
+fn read_pin_reports_missing_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert_eq!(read_pinned_index_id(tmp.path()), PinState::NoMcpJson);
+}
+
+#[test]
+fn read_pin_reports_missing_server() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join(".mcp.json"),
+        r#"{"mcpServers":{"trusty-memory":{"args":["serve"]}}}"#,
+    )
+    .unwrap();
+    assert_eq!(read_pinned_index_id(tmp.path()), PinState::NoSearchServer);
+}
+
+#[test]
+fn read_pin_reports_unreadable_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".mcp.json"), "{not json").unwrap();
+    assert!(matches!(
+        read_pinned_index_id(tmp.path()),
+        PinState::Unreadable(_)
+    ));
+}
+
+// -------------------------------------------------------------- http probing
+
+#[tokio::test]
+async fn probe_reports_unknown_index_on_404() {
+    // The signature observed live in #5045:
+    // `POST /indexes/<id>/search → 404 {"error":"unknown index"}`.
+    let base = spawn_stub(
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 27\r\nConnection: close\r\n\r\n\
+         {\"error\":\"unknown index\"}",
+    )
+    .await;
+    assert_eq!(
+        probe_pinned_index(&base, "ghost-index").await,
+        PinProbe::UnknownIndex
+    );
+}
+
+#[tokio::test]
+async fn probe_reports_resolved_on_200() {
+    let base = spawn_stub(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 21\r\n\
+         Connection: close\r\n\r\n{\"chunk_count\": 4210}",
+    )
+    .await;
+    assert_eq!(
+        probe_pinned_index(&base, "trusty-tools").await,
+        PinProbe::Resolved {
+            chunk_count: Some(4210)
+        }
+    );
+}
+
+#[tokio::test]
+async fn probe_reports_unreachable_when_nothing_listens() {
+    // Port 0 never accepts a connection.
+    assert!(matches!(
+        probe_pinned_index("http://127.0.0.1:0", "trusty-tools").await,
+        PinProbe::Unreachable(_)
+    ));
+}
+
+// ------------------------------------------------------------------ verdicts
+
+#[test]
+fn build_pin_check_fails_on_unknown_index() {
+    // THE regression this check exists for (#5045): the pin advanced because
+    // index registration is fail-open, and nothing else in the report notices.
+    let check = build_pin_check(
+        &PinState::Pinned("trusty-tools".to_string()),
+        Some(&PinProbe::UnknownIndex),
+    );
+    assert_eq!(check.status, CheckStatus::Fail);
+    assert!(check.message.contains("trusty-tools"));
+    assert!(
+        check.message.contains("#5045"),
+        "the failure must cite the issue: {}",
+        check.message
+    );
+}
+
+#[test]
+fn build_pin_check_warns_on_empty_index() {
+    let check = build_pin_check(
+        &PinState::Pinned("trusty-tools".to_string()),
+        Some(&PinProbe::Resolved {
+            chunk_count: Some(0),
+        }),
+    );
+    assert_eq!(check.status, CheckStatus::Warn);
+}
+
+#[test]
+fn build_pin_check_ok_when_index_resolves() {
+    let check = build_pin_check(
+        &PinState::Pinned("trusty-tools".to_string()),
+        Some(&PinProbe::Resolved {
+            chunk_count: Some(4210),
+        }),
+    );
+    assert_eq!(check.status, CheckStatus::Ok);
+}
+
+#[test]
+fn build_pin_check_unreachable_is_unknown_not_ok() {
+    // An unanswered probe establishes nothing about the pin — reporting Ok
+    // here would rebuild the fail-open this check was added to catch.
+    let check = build_pin_check(
+        &PinState::Pinned("trusty-tools".to_string()),
+        Some(&PinProbe::Unreachable("connection refused".to_string())),
+    );
+    assert_eq!(check.status, CheckStatus::Unknown);
+}
+
+#[test]
+fn build_pin_check_fails_on_other_non_2xx() {
+    let check = build_pin_check(
+        &PinState::Pinned("trusty-tools".to_string()),
+        Some(&PinProbe::HttpStatus(500)),
+    );
+    assert_eq!(check.status, CheckStatus::Fail);
+}
+
+#[test]
+fn build_pin_check_warns_on_unpinned_stub() {
+    let check = build_pin_check(&PinState::Unpinned, None);
+    assert_eq!(check.status, CheckStatus::Warn);
+}
+
+#[test]
+fn build_pin_check_warns_on_unreadable_mcp_json() {
+    let check = build_pin_check(&PinState::Unreadable("bad".to_string()), None);
+    assert_eq!(check.status, CheckStatus::Warn);
+}
+
+#[test]
+fn build_pin_check_ok_when_nothing_is_pinned() {
+    assert_eq!(
+        build_pin_check(&PinState::NoMcpJson, None).status,
+        CheckStatus::Ok
+    );
+    assert_eq!(
+        build_pin_check(&PinState::NoSearchServer, None).status,
+        CheckStatus::Ok
+    );
+}
+
+// --------------------------------------------------------------- end-to-end
+
+/// The whole path, exactly as issue #5045 asks: a session whose `.mcp.json`
+/// pins an index the daemon does not have must report a FAILURE.
+///
+/// Mutates `TRUSTY_SEARCH_ADDR`, so it is `#[serial]` against the other
+/// env-touching tests in this crate.
+#[tokio::test]
+#[serial_test::serial]
+async fn pinned_but_missing_index_is_fail() {
+    let base = spawn_stub(
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 27\r\nConnection: close\r\n\r\n\
+         {\"error\":\"unknown index\"}",
+    )
+    .await;
+    let addr = base.trim_start_matches("http://").to_string();
+
+    let project = tempfile::tempdir().unwrap();
+    write_mcp_json(
+        project.path(),
+        &serde_json::json!(["serve", "--index", "2eb72dca-de08-481b-8dfa-22ab7f81b1f9"]),
+    );
+    let home = tempfile::tempdir().unwrap();
+
+    unsafe {
+        std::env::set_var("TRUSTY_SEARCH_ADDR", &addr);
+    }
+    let check = check_search_index_pin(home.path(), Some(project.path())).await;
+    unsafe {
+        std::env::remove_var("TRUSTY_SEARCH_ADDR");
+    }
+
+    assert_eq!(
+        check.status,
+        CheckStatus::Fail,
+        "a pinned-but-nonexistent index must FAIL, not report healthy: {}",
+        check.message
+    );
+    assert!(
+        check
+            .message
+            .contains("2eb72dca-de08-481b-8dfa-22ab7f81b1f9")
+    );
+}
+
+#[tokio::test]
+async fn unscoped_run_warns_rather_than_reporting_ok() {
+    // `tm doctor` outside a project must not claim a pin it never looked at is
+    // fine.
+    let home = tempfile::tempdir().unwrap();
+    let check = check_search_index_pin(home.path(), None).await;
+    assert_eq!(check.status, CheckStatus::Warn);
+}

--- a/crates/trusty-mpm/src/daemon/doctor_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_tests.rs
@@ -137,7 +137,7 @@ async fn agents_check_probes_the_managed_config_tier_not_the_workspace() {
 }
 
 #[tokio::test]
-async fn run_doctor_produces_twenty_nine_checks() {
+async fn run_doctor_produces_thirty_checks() {
     // Issue #2158 added the `deployment` probe (nine → ten); issue #2246
     // adds `oauth_token` (ten → eleven); issue #2876 adds `skill_staleness`
     // and `legacy_sources` (eleven → thirteen); DOC-42 / issue #2889 adds
@@ -155,7 +155,8 @@ async fn run_doctor_produces_twenty_nine_checks() {
     // twenty-five); issue #2919 adds `worktree_disk` (twenty-five →
     // twenty-six); issue #4605 adds `skill_unmanaged` (twenty-six →
     // twenty-seven); issue #4033 adds `binary_provenance` (twenty-seven →
-    // twenty-eight).
+    // twenty-eight); issue #5045 adds `search_index_pin` (twenty-nine →
+    // thirty).
     // #1905's stale-skill cleanup is deliberately NOT a `run_doctor` probe
     // — see the `run_doctor` doc.
     let report = run_doctor(None, None, &[]).await;
@@ -180,6 +181,7 @@ async fn run_doctor_produces_twenty_nine_checks() {
         "agent_skills_prose_hints",
         "memory",
         "search",
+        "search_index_pin",
         "worktrees",
         "worktree_disk",
         "gh_account",


### PR DESCRIPTION
## Primary outcome

Closes #5045 — `tm doctor` gains a `search_index_pin` check that resolves the trusty-search index a session is **actually pinned to** and fails when that pin names nothing.

## What changed

`ensure_project_indexed` (`crates/trusty-common/src/search_index.rs`) is fail-open end to end. Its own doc says it "ALWAYS returns the derived id … even if the daemon is unreachable", and both `best_effort_create_index` and `best_effort_trigger_reindex` swallow every failure at `tracing::warn!`. So index creation fails, the `--index <id>` pin in `.mcp.json` advances anyway, and the existing `search` check — which asks the daemon whether it is *healthy* and whether the *derived* id appears in `/indexes` — keeps reporting fine. Measured: 4 of 75 live worktrees had an index; a bare `search` in the rest returned `404 unknown index`.

New `crates/trusty-mpm/src/daemon/doctor_search_pin.rs` reads the pinned id out of `<project>/.mcp.json` (`mcpServers["trusty-search"].args`, the element after `--index`) and resolves it with `GET /indexes/{id}/status`:

| Observed | Verdict |
|---|---|
| 404 | **Fail** — names the id and the fail-open that hid it |
| 2xx, `chunk_count: 0` | Warn — registered, never populated |
| 2xx, non-empty | Ok |
| other non-2xx | Fail |
| no answer | Unknown, never Ok |
| no `.mcp.json` / no `--index` | Ok / Warn respectively |

It asks a resolution question, not a health question — a health probe would reproduce the blind spot rather than close it.

Registration + the three roster assertions + the `generate::doctor::DOCTOR_CHECKS` drift list are updated; `tm generate capabilities` re-run.

### Out of scope

`crates/trusty-common/src/search_index.rs` is untouched — PR #5065 is in flight on that file. Whether the fail-open contract itself should change is a separate question; this check backstops it either way. Auto-provisioning a missing index is #4715; per-worktree index keying is #2611.

## Risk

Additive, read-only, one crate. The check never creates, reindexes, or repairs. A project with no `.mcp.json` or no pin reports Ok, so unmanaged projects see no new noise.

## Test evidence — Rust Test Ladder rung 3 (localized to `trusty-mpm`)

```
cargo fmt --check                                   — clean
cargo check -p trusty-mpm --all-targets             — EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings — EXIT=0
cargo test -p trusty-mpm                            — 4757 passed, 1 failed (see below)
bash scripts/check_line_cap.sh                      — 3764 files, 0 violations
bash scripts/check_changelog_fragment.sh            — OK, 1 crate recorded
bash scripts/check_capabilities.sh                  — up to date (7 generated files)
bash scripts/check_sld.sh                           — 0 errors, 0 warnings
```

New coverage, 21 tests, all green:

```
test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 4744 filtered out
```

**Red-then-green proof.** Two mutations applied to the pre-fix state — the check unregistered from `run_doctor`, and `UnknownIndex` mapped to `Ok` (the fail-open this replaces):

```
test daemon::doctor::doctor_search_pin::tests::build_pin_check_fails_on_unknown_index ... FAILED
  left: Ok / right: Fail
test daemon::doctor::doctor_search_pin::tests::pinned_but_missing_index_is_fail ... FAILED
  assertion failed: a pinned-but-nonexistent index must FAIL, not report healthy
  left: Ok / right: Fail
test daemon::doctor::tests::run_doctor_produces_thirty_checks ... FAILED
test daemon::api::tests::doctor_endpoint_returns_report ... FAILED
test result: FAILED. 0 passed; 4 failed
```

`pinned_but_missing_index_is_fail` is the integration test #5045 asks for: a real `.mcp.json` pinning a real worktree uuid, resolved over a real loopback socket that answers `404 {"error":"unknown index"}`.

## Baseline failure

`daemon::managed_routes::tests::stale_assets_for_many_*` — canonical issue #4931 ("two order-dependent tests fail under parallel execution, pass in isolation"). Two full-suite runs failed a *different* one of that pair each time, and both pass in isolation (`1 passed; 0 failed`). This diff touches zero files under `managed_routes/`.

**change-specific gates pass; `cargo test -p trusty-mpm` blocked by canonical issue #4931**

## Documentation / changelog

`crates/trusty-mpm/changelog.d/5045-doctor-index-pin-check.md` (Added). Full Why/What/Test docs on every public item; `// #5045:` pointers at both change sites in `doctor.rs`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools