### PR TITLE
fix(trusty-memory): give prompt-context recall a relevance floor, a bigger budget, and a withheld signal (#5037)

### DIFF
--- a/crates/trusty-common/changelog.d/5037-relevance-floor.md
+++ b/crates/trusty-common/changelog.d/5037-relevance-floor.md
@@ -1,0 +1,24 @@
+Added
+
+- **A relevance floor for recall results ([#5037](https://github.com/bobmatnyc/trusty-tools/issues/5037)).** `DEFAULT_RELEVANCE_FLOOR`,
+  `FloorOutcome`, and `apply_relevance_floor` in a new
+  `memory_core::retrieval::relevance` module. Every retrieval path in `layers.rs`
+  ended in `truncate(top_k)` and nothing else, so a query with no good answer
+  still returned a full `top_k` of whatever ranked highest — including L1
+  drawers scoring `importance * L1_NO_SIMILARITY_PENALTY`, at most `0.15`.
+  `apply_relevance_floor` is the one implementation of "below the floor, it is
+  not shown", and it returns the count of what it dropped so a caller can say so
+  rather than going silent. An item whose score is unknown is kept, never
+  dropped.
+
+  The default is `0.35`, picked from measured distributions against the live
+  1,332-drawer `trusty-tools` palace rather than guessed: 150 candidates from 15
+  off-topic prompts span 0.1500–0.3439 (75 of them at exactly 0.1500, the L1
+  penalty), while 57 self-retrieval correct-drawer hits span 0.4844–0.9743 and
+  1,200 candidates from real logged hook prompts span 0.4042–0.7527. `0.35` is
+  the smallest swept value at which no off-topic candidate survives.
+
+  `recall`/`recall_scoped` are deliberately unchanged: `truncate(top_k)` stays a
+  length cap, and gating inside it would change every MCP and CLI recall
+  caller's contract. Callers that must not show a weak match apply the floor to
+  what comes back.

--- a/crates/trusty-common/src/memory_core/retrieval/layers.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/layers.rs
@@ -233,6 +233,9 @@ pub fn rescore_l1_by_similarity(
                 Some(&sim) => sim,
                 // Drawer was not in the HNSW results — likely off-topic.
                 // Apply penalty so importance alone can't dominate ranking.
+                // #5037: demoted is not excluded — this branch still yields a
+                // score that competes for a `top_k` slot. See
+                // `super::relevance::DEFAULT_RELEVANCE_FLOOR`.
                 None => r.drawer.importance * L1_NO_SIMILARITY_PENALTY,
             };
         }
@@ -664,6 +667,10 @@ pub async fn recall_scoped(
     // L1_CAP+1 entries before any L2 hits are merged; without this truncation
     // the caller receives more than top_k results whenever the palace has a
     // non-empty identity string plus several high-importance drawers.
+    // #5037: this stays a length cap, not a quality gate — callers that must
+    // not show a weak match apply `super::relevance::apply_relevance_floor` to
+    // what comes back. Gating here would silently change every MCP and CLI
+    // recall caller's contract, which #5037's ruling does not ask for.
     combined.truncate(top_k);
 
     handle.log_recall(query, &combined);

--- a/crates/trusty-common/src/memory_core/retrieval/mod.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/mod.rs
@@ -18,6 +18,9 @@ mod embed_repair;
 mod embedder;
 mod handle;
 mod layers;
+// #5037: the minimum-score gate `layers` never had — `truncate(top_k)` was its
+// only length control.
+mod relevance;
 // ADR-0027 T9: room/wing recall scoping, shared by L2 and the list paths.
 mod scope;
 // ADR-0028 D3/D4/D5 (#4886): Tier C admission and atomic retire-on-write.
@@ -59,6 +62,10 @@ pub use embed_repair::{
 
 // Recall scoping (ADR-0027 T9)
 pub use scope::{RecallScope, list_drawers_in_wing, scope_admits};
+
+// #5037: relevance floor. Public because the consumer that must apply it —
+// trusty-memory's prompt-context injection — lives in another crate.
+pub use relevance::{DEFAULT_RELEVANCE_FLOOR, FloorOutcome, apply_relevance_floor};
 
 // ADR-0028 Tier C admission (#4886). The write half (`persist_with_retirement`)
 // stays crate-internal — every writer reaches it through

--- a/crates/trusty-common/src/memory_core/retrieval/relevance.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/relevance.rs
@@ -1,0 +1,179 @@
+//! Relevance floor for recall results (#5037).
+//!
+//! Why: every retrieval path in [`super::layers`] ends in `truncate(top_k)` and
+//! nothing else — `top_k` is the only length control, so a query with no good
+//! answer still returns a full `top_k` of whatever ranked highest. This module
+//! is the missing half: a minimum score a candidate must clear to be shown at
+//! all, plus a count of what was dropped so the caller can say so out loud.
+//! What: [`DEFAULT_RELEVANCE_FLOOR`], [`FloorOutcome`], and
+//! [`apply_relevance_floor`]. Pure — no I/O, no allocation beyond the returned
+//! vector.
+//! Test: `relevance_floor_drops_l1_penalty_noise`,
+//! `relevance_floor_keeps_genuine_hit`, `relevance_floor_keeps_unscored_items`,
+//! `relevance_floor_counts_withheld`.
+//!
+//! Lives beside `layers.rs` rather than inside it because `layers.rs` sits at
+//! 464 of its 500 SLOC budget; the repo's cap forces the split
+//! (`docs/reference/sloc-cap.md`).
+
+/// Minimum score a recall candidate must reach to be worth showing.
+///
+/// Why: `rescore_l1_by_similarity` assigns an L1 drawer the HNSW search never
+/// returned a score of `importance * L1_NO_SIMILARITY_PENALTY` — at most
+/// `0.15`. That is a nonzero score, so it competes for a `top_k` slot and
+/// renders identically to a real hit. Measured against the live `trusty-tools`
+/// palace (1,332 drawers) over four query populations:
+///
+/// | population | n | min | median | max |
+/// |---|---|---|---|---|
+/// | 15 off-topic prompts × top-10 ("capital of France", "go", "ok", …) | 150 | 0.1500 | 0.1510 | **0.3439** |
+/// | 60 self-retrieval queries, score of the *correct* drawer | 57 | **0.4844** | 0.6950 | 0.9743 |
+/// | 120 real logged hook prompts × top-10 | 1200 | 0.4042 | 0.5422 | 0.7527 |
+/// | 12 paraphrased on-topic questions, best hit per query | 12 | 0.3293 | 0.4317 | 0.5359 |
+///
+/// 75 of the 150 off-topic candidates scored *exactly* 0.1500 — the L1 penalty
+/// itself. The noise and signal distributions are nearly disjoint, and the gap
+/// between them (0.3439 … 0.4042) is where this constant sits.
+/// What: `0.35` — the smallest swept value at which zero off-topic candidates
+/// survive, rounded up from the highest observed noise score (0.3439). At this
+/// floor the real logged corpus loses 0 of 1200 candidates and 0 of 120
+/// queries; self-retrieval keeps 57 of 57 correct drawers; 10 of 12 paraphrased
+/// questions still return something. The 2 that stop returning are short
+/// keyword-bearing queries ("what is the MSRV for this workspace", 0.3293),
+/// which is dense retrieval's known weak spot and BM25's strength — #5036 is
+/// the named fix for that class. Their loss is reported, never silent: see
+/// [`FloorOutcome::withheld`].
+/// Test: `relevance_floor_drops_l1_penalty_noise` pins the 0.15 case;
+/// `relevance_floor_keeps_genuine_hit` pins the 0.56 case.
+pub const DEFAULT_RELEVANCE_FLOOR: f32 = 0.35;
+
+/// What cleared a relevance floor, and how much did not.
+///
+/// Why: dropping weak candidates silently turns "we found nothing good" into
+/// something indistinguishable from "this palace is empty". Carrying the count
+/// alongside the survivors is what lets a caller render the difference.
+/// What: `kept` in the input's order; `withheld` is how many were dropped.
+/// Test: `relevance_floor_counts_withheld`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FloorOutcome<T> {
+    /// Candidates at or above the floor, in input order.
+    pub kept: Vec<T>,
+    /// How many candidates fell below the floor.
+    pub withheld: usize,
+}
+
+impl<T> FloorOutcome<T> {
+    /// True when the floor dropped everything it was given a score for.
+    ///
+    /// Why: this is the case a caller must announce rather than render as an
+    /// empty section — see [`FloorOutcome`].
+    /// What: `kept.is_empty() && withheld > 0`. A run with nothing to judge
+    /// (`withheld == 0`) is "nothing existed", not "everything was withheld".
+    /// Test: `relevance_floor_counts_withheld`.
+    pub fn silenced(&self) -> bool {
+        self.kept.is_empty() && self.withheld > 0
+    }
+}
+
+/// Drop candidates scoring below `floor`, counting what went.
+///
+/// Why: the one implementation of "below the floor, it is not shown" — the
+/// prompt-context injection and any future recall consumer must agree on the
+/// comparison and on how an unscored candidate is treated, or the two drift.
+/// What: keeps every item whose `score_of` is `>= floor`. `score_of` returning
+/// `None` means the score is unknown, and an unknown-score item is **kept** and
+/// not counted as withheld — dropping what cannot be judged would let a wire
+/// format that stops emitting `score` silently empty the result set. A
+/// non-positive or NaN `floor` disables the gate entirely.
+/// Test: `relevance_floor_drops_l1_penalty_noise`,
+/// `relevance_floor_keeps_genuine_hit`, `relevance_floor_keeps_unscored_items`,
+/// `relevance_floor_counts_withheld`.
+pub fn apply_relevance_floor<T>(
+    items: Vec<T>,
+    floor: f32,
+    score_of: impl Fn(&T) -> Option<f32>,
+) -> FloorOutcome<T> {
+    if floor.is_nan() || floor <= 0.0 {
+        return FloorOutcome {
+            kept: items,
+            withheld: 0,
+        };
+    }
+    let mut kept = Vec::with_capacity(items.len());
+    let mut withheld = 0usize;
+    for item in items {
+        match score_of(&item) {
+            Some(s) if s < floor => withheld += 1,
+            _ => kept.push(item),
+        }
+    }
+    FloorOutcome { kept, withheld }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why (#5037): a probe of "what is the capital of France" returned five
+    /// drawers all scoring exactly 0.15 — `L1_NO_SIMILARITY_PENALTY` — and they
+    /// rendered identically to a real hit. The floor exists to make that set
+    /// empty.
+    /// What: five 0.15 candidates against the default floor.
+    /// Test: itself.
+    #[test]
+    fn relevance_floor_drops_l1_penalty_noise() {
+        let noise = vec![0.15_f32; 5];
+        let out = apply_relevance_floor(noise, DEFAULT_RELEVANCE_FLOOR, |s| Some(*s));
+        assert!(out.kept.is_empty(), "0.15 noise must not survive the floor");
+        assert_eq!(out.withheld, 5);
+        assert!(out.silenced(), "all-withheld must be announceable");
+    }
+
+    /// Why (#5037): the floor must not be so high that it eats real answers.
+    /// 0.56 is the measured median of the self-retrieval signal population.
+    /// What: one genuine hit plus four noise candidates.
+    /// Test: itself.
+    #[test]
+    fn relevance_floor_keeps_genuine_hit() {
+        let mixed = vec![0.56_f32, 0.15, 0.15, 0.15, 0.15];
+        let out = apply_relevance_floor(mixed, DEFAULT_RELEVANCE_FLOOR, |s| Some(*s));
+        assert_eq!(out.kept, vec![0.56_f32]);
+        assert_eq!(out.withheld, 4);
+        assert!(!out.silenced(), "a surviving hit is not a silenced recall");
+    }
+
+    /// Why: an unscored candidate is unjudgeable, and dropping it would let a
+    /// wire format that stops emitting `score` empty the injection silently —
+    /// the fail-open/fail-closed inversion this fix exists to prevent.
+    /// What: `score_of` returns `None`.
+    /// Test: itself.
+    #[test]
+    fn relevance_floor_keeps_unscored_items() {
+        let out = apply_relevance_floor(vec!["a", "b"], DEFAULT_RELEVANCE_FLOOR, |_| None);
+        assert_eq!(out.kept.len(), 2);
+        assert_eq!(out.withheld, 0);
+        assert!(!out.silenced());
+    }
+
+    /// Why: `withheld` is the input to requirement 4's "more" signal, so its
+    /// arithmetic is load-bearing, including the disabled-gate case.
+    /// What: partial drop, empty input, and a zero floor.
+    /// Test: itself.
+    #[test]
+    fn relevance_floor_counts_withheld() {
+        let out = apply_relevance_floor(vec![0.9_f32, 0.2, 0.4, 0.1], 0.35, |s| Some(*s));
+        assert_eq!(out.kept, vec![0.9_f32, 0.4]);
+        assert_eq!(out.withheld, 2);
+
+        let empty = apply_relevance_floor(Vec::<f32>::new(), 0.35, |s| Some(*s));
+        assert_eq!(empty.withheld, 0);
+        assert!(
+            !empty.silenced(),
+            "nothing to judge is not the same as everything withheld"
+        );
+
+        let off = apply_relevance_floor(vec![0.01_f32, 0.02], 0.0, |s| Some(*s));
+        assert_eq!(off.kept.len(), 2, "a zero floor must disable the gate");
+        assert_eq!(off.withheld, 0);
+    }
+}

--- a/crates/trusty-memory/changelog.d/5037-prompt-context-relevance.md
+++ b/crates/trusty-memory/changelog.d/5037-prompt-context-relevance.md
@@ -1,0 +1,31 @@
+Fixed
+
+- **`prompt-context` no longer injects drawers that did not match the prompt
+  ([#5037](https://github.com/bobmatnyc/trusty-tools/issues/5037)).** The hook asked for `top_k` drawers and rendered whatever came
+  back. A probe of "what is the capital of France" against the live palace
+  returned five drawers all scoring exactly `0.15` — the L1 no-similarity
+  penalty — formatted identically to a genuine `0.56` hit, so the reader could
+  not tell noise from signal. Four changes:
+
+  - **Relevance floor.** `RecalledDrawer` now parses the `score` the recall
+    endpoint has always sent, and drawers below the floor are dropped via
+    `trusty-common`'s `apply_relevance_floor` (default `0.35`; set
+    `TRUSTY_MEMORY_PROMPT_MIN_SCORE=0` to restore the old behaviour). It runs
+    after the deny-tag filter so a tag-excluded drawer is never also counted as
+    withheld.
+  - **Withheld notice.** When the floor drops drawers the injection says so and
+    points at `memory_recall`, with distinct wording for a partial drop and for
+    a recall that kept nothing. Zero candidates still renders nothing — an empty
+    palace has nothing to announce. Without this the floor would have swapped a
+    visible wrong answer for an invisible one.
+  - **Larger budget.** `DEFAULT_TOP_K` 5 → 12 (override ceiling 20 → 30) and
+    `INJECTION_BYTE_CAP` 4 KB → 8 KB. Both were sized when nothing distinguished
+    a good recall from a bad one, so extra room only bought more noise; with the
+    floor active the extra slots can only fill with candidates that cleared it.
+    Measured over 80 real logged prompts, `K=12` renders a drawer section of at
+    most ~2.7 KB.
+  - **Whole-input query, pinned.** The recall query was already the entire user
+    prompt; `recall_query_is_the_whole_prompt` now pins that against the
+    truncating `hook_prompt_excerpt` helper sitting next to it. Truncation at
+    the embedder's 512-token window is a separate layer and remains
+    [#4972](https://github.com/bobmatnyc/trusty-tools/issues/4972).

--- a/crates/trusty-memory/src/commands/prompt_context/filter.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/filter.rs
@@ -5,25 +5,33 @@
 //! testing and future tuning straightforward without touching the network or
 //! orchestration layers.
 //! What: exports `RecalledDrawer`, `RawTriple`, `filter_drawers_by_deny_tags`,
-//! `select_relevant_triples`, and `triple_overlaps`.
-//! Test: `filter_drawers_by_deny_tags_handles_edge_cases` and
+//! `filter_drawers_by_relevance_floor`, `select_relevant_triples`, and
+//! `triple_overlaps`.
+//! Test: `filter_drawers_by_deny_tags_handles_edge_cases`,
+//! `relevance_floor_drops_all_noise_drawers`, and
 //! `select_relevant_triples_filters_by_prompt_overlap` in `mod.rs`.
 
 use serde_json::Value;
+use trusty_common::memory_core::retrieval::{apply_relevance_floor, FloorOutcome};
 
 /// A drawer parsed from the `/recall` endpoint's flat JSON shape.
 ///
 /// Why: the recall endpoint hoists drawer fields to the top level (see
 /// `web::recall_entry_json`), so we don't need the full `Drawer` schema —
 /// only the fields the injection renders.
-/// What: holds the content string, tag list, and recall layer. Implements
-/// `from_recall_entry` for safe extraction from `serde_json::Value`.
+/// What: holds the content string, tag list, recall layer, and the recall
+/// score. Implements `from_recall_entry` for safe extraction from
+/// `serde_json::Value`.
 /// Test: indirectly via `prompt_context_recalls_palace_drawers`.
 #[derive(Debug, Clone)]
 pub(super) struct RecalledDrawer {
     pub(super) content: String,
     pub(super) tags: Vec<String>,
     pub(super) layer: Option<u8>,
+    // #5037: the wire has always carried `score` (`service::recall_entry_json`
+    // inserts it); nothing parsed it, so noise and signal were indistinguishable
+    // by the time they reached the injection.
+    pub(super) score: Option<f32>,
 }
 
 impl RecalledDrawer {
@@ -46,6 +54,9 @@ impl RecalledDrawer {
             })
             .unwrap_or_default();
         let layer = v.get("layer").and_then(|l| l.as_u64()).map(|n| n as u8);
+        // #5037: `None` here means "the daemon did not tell us" — the floor
+        // keeps such an entry rather than dropping what it cannot judge.
+        let score = v.get("score").and_then(|s| s.as_f64()).map(|n| n as f32);
         if content.trim().is_empty() {
             return None;
         }
@@ -53,6 +64,7 @@ impl RecalledDrawer {
             content,
             tags,
             layer,
+            score,
         })
     }
 }
@@ -129,6 +141,28 @@ pub(super) fn filter_drawers_by_deny_tags(
                 .any(|t| deny_tags.iter().any(|deny| deny.eq_ignore_ascii_case(t)))
         })
         .collect()
+}
+
+/// Drop recalled drawers whose score falls below `floor`, counting them.
+///
+/// Why (issue #5037): the deny-tag filter above judges *provenance*; nothing
+/// judged *relevance*. A probe of "what is the capital of France" against the
+/// live palace returned five drawers all scoring exactly `0.15` — the
+/// `L1_NO_SIMILARITY_PENALTY` given to an essential drawer the vector search
+/// never returned — rendered identically to a genuine hit at `0.56`. `top_k`
+/// cannot tell those apart because it is a length cap, not a quality gate.
+/// What: delegates to `trusty_common`'s [`apply_relevance_floor`] so the
+/// comparison and the unknown-score policy have exactly one implementation
+/// shared with any other recall consumer. Returns the survivors plus the count
+/// of what was withheld, which the injection renders as the "more" signal so a
+/// suppressed recall is never mistaken for an empty palace.
+/// Test: `relevance_floor_drops_all_noise_drawers`,
+/// `relevance_floor_keeps_high_scoring_drawer`.
+pub(super) fn filter_drawers_by_relevance_floor(
+    drawers: Vec<RecalledDrawer>,
+    floor: f32,
+) -> FloorOutcome<RecalledDrawer> {
+    apply_relevance_floor(drawers, floor, |d| d.score)
 }
 
 /// Filter a triple list down to those whose subject or object appears in

--- a/crates/trusty-memory/src/commands/prompt_context/format.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/format.rs
@@ -17,12 +17,18 @@ use super::{DRAWER_PREVIEW_CHARS, INJECTION_BYTE_CAP};
 /// where each piece came from so it can weigh them appropriately.
 /// What: appends sections in priority order (workspace facts → drawers →
 /// KG triples), each separated by a blank line. Truncates at
-/// [`INJECTION_BYTE_CAP`] bytes with a `…` marker.
+/// [`INJECTION_BYTE_CAP`] bytes with a `…` marker. `withheld` is how many
+/// drawers the relevance floor dropped (#5037); when it is non-zero the drawer
+/// section carries the [`withheld_notice`] line, including when every drawer was
+/// dropped and there is otherwise no section at all.
 /// Test: `compose_injection_truncates_at_cap`,
+/// `compose_injection_announces_withheld_drawers`,
+/// `compose_injection_announces_total_silence`,
 /// `prompt_context_recalls_palace_drawers`.
 pub(super) fn compose_injection(
     global_facts: Option<&str>,
     drawers: &[RecalledDrawer],
+    withheld: usize,
     triples: &[RawTriple],
     palace_slug: Option<&str>,
 ) -> String {
@@ -30,7 +36,7 @@ pub(super) fn compose_injection(
     if let Some(facts) = global_facts {
         push_section(&mut out, facts.trim_end());
     }
-    if !drawers.is_empty() {
+    if !drawers.is_empty() || withheld > 0 {
         let mut section = String::new();
         if let Some(slug) = palace_slug {
             section.push_str(&format!("## Relevant memories from palace `{slug}`\n"));
@@ -52,6 +58,10 @@ pub(super) fn compose_injection(
                 section.push(')');
                 section.push('_');
             }
+            section.push('\n');
+        }
+        if withheld > 0 {
+            section.push_str(&withheld_notice(withheld, drawers.is_empty()));
             section.push('\n');
         }
         push_section(&mut out, section.trim_end());
@@ -80,6 +90,36 @@ pub(super) fn compose_injection(
         out.push(ELLIPSIS);
     }
     out
+}
+
+/// Render the "results were withheld" line for the drawer section.
+///
+/// Why (issue #5037, requirement 4): the relevance floor is allowed to return
+/// zero drawers where five noisy ones used to appear — that is the correct
+/// outcome for a prompt with no good match. It is only correct if the reader can
+/// tell it apart from "this palace holds nothing", because those two call for
+/// opposite next actions: one means search harder, the other means store
+/// something first. Without this line the floor would have swapped a visible
+/// wrong answer for an invisible one.
+/// What: one italic Markdown line naming the count, worded differently for a
+/// partial drop and a total one, and pointing at `memory_recall` as the way to
+/// see past the floor.
+/// Test: `compose_injection_announces_withheld_drawers`,
+/// `compose_injection_announces_total_silence`.
+pub(super) fn withheld_notice(withheld: usize, nothing_kept: bool) -> String {
+    let plural = if withheld == 1 { "memory" } else { "memories" };
+    if nothing_kept {
+        format!(
+            "_(No stored {plural} cleared the relevance floor for this prompt — \
+             {withheld} withheld as too weak a match. Nothing is missing from the \
+             palace; call `memory_recall` to search it directly.)_"
+        )
+    } else {
+        format!(
+            "_({withheld} further {plural} withheld below the relevance floor — \
+             call `memory_recall` for the full ranked set.)_"
+        )
+    }
 }
 
 /// Append `section` to `out` separated by a blank line when `out`

--- a/crates/trusty-memory/src/commands/prompt_context/mod.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/mod.rs
@@ -54,8 +54,11 @@ use crate::prompt_log::{PromptLogEntry, PromptLogger};
 use crate::{hook_prompt_excerpt, HookType, InjectionKind};
 
 use fetch::{fetch_global_prompt_context, fetch_palace_kg_triples, fetch_palace_recall};
-use filter::{filter_drawers_by_deny_tags, select_relevant_triples};
+use filter::{
+    filter_drawers_by_deny_tags, filter_drawers_by_relevance_floor, select_relevant_triples,
+};
 use format::{compose_injection, count_facts};
+use trusty_common::memory_core::retrieval::DEFAULT_RELEVANCE_FLOOR;
 
 /// HTTP path for the global hot-facts block.
 pub(super) const PROMPT_CONTEXT_PATH: &str = "/api/v1/kg/prompt-context";
@@ -124,25 +127,47 @@ const EMIT_DEADLINE: Duration = Duration::from_millis(300);
 
 /// Default top-K for drawer recall and KG triple selection.
 ///
-/// Why: 5 + 5 keeps the injection focused on the strongest signal without
-/// flooding the prompt. With a 4 KB cap on total output, this leaves ample
-/// budget for hot facts and per-bullet content.
+/// Why (#5037): 5 was a hard limit on how much a *good* recall could return,
+/// chosen when nothing distinguished a good recall from a bad one — every
+/// query returned 5 entries whether or not any of them matched, so a bigger K
+/// only meant more noise. The relevance floor removes that coupling: above the
+/// floor, extra slots can only fill with candidates that actually cleared it,
+/// and below it they stay empty. Measured over 80 real logged hook prompts
+/// against the live palace, K=12 with the floor active renders a drawer section
+/// of at most ~2.7 KB, which fits [`INJECTION_BYTE_CAP`] alongside hot facts
+/// and KG triples.
 /// What: a `usize` constant used unless the env override below is set.
 /// Test: `prompt_context_recalls_palace_drawers` uses the default.
-pub(super) const DEFAULT_TOP_K: usize = 5;
+pub(super) const DEFAULT_TOP_K: usize = 12;
+
+/// Upper bound on the operator-supplied [`ENV_TOP_K`] override.
+///
+/// Why: the ceiling exists so a mistyped override cannot blow the byte budget.
+/// It has to stay above [`DEFAULT_TOP_K`] to remain an escape hatch at all.
+/// What: `30`, raised from 20 alongside the default (#5037).
+/// Test: `configured_top_k_clamps_to_bounds`.
+pub(super) const MAX_TOP_K: usize = 30;
+
+// A ceiling at or below the default would silently cap every operator override,
+// which is the escape hatch dead. Enforced at compile time so the two constants
+// cannot drift apart in a later edit.
+const _: () = assert!(MAX_TOP_K > DEFAULT_TOP_K);
 
 /// Hard byte cap on the rendered injection.
 ///
-/// Why: hook-injection budgets in Claude Code are small (~few KB) and
-/// every byte we emit is a token the model has to spend reading. 4 KB is
-/// a comfortable ceiling above the typical render and well under any
-/// downstream limit.
-/// What: `4 * 1024` bytes. Sections are appended until the cap is hit;
+/// Why: hook-injection budgets in Claude Code are small and every byte we emit
+/// is a token the model has to spend reading. #5037 raised this from 4 KB
+/// because the relevance floor changed what fills it: the cap now bounds
+/// *above-floor* content rather than a fixed-size mixture of hits and noise, so
+/// the same ceiling was costing real matches to hold room for candidates that
+/// no longer get rendered.
+/// What: `8 * 1024` bytes. Sections are appended until the cap is hit;
 /// truncation emits an explicit `…` marker so downstream readers know
 /// the block was cut.
-/// Test: `prompt_context_recalls_palace_drawers` exercises the budget
-/// implicitly by asserting a real (non-placeholder) injection.
-pub(super) const INJECTION_BYTE_CAP: usize = 4 * 1024;
+/// Test: `compose_injection_truncates_at_cap`;
+/// `prompt_context_recalls_palace_drawers` exercises the budget implicitly by
+/// asserting a real (non-placeholder) injection.
+pub(super) const INJECTION_BYTE_CAP: usize = 8 * 1024;
 
 /// Per-drawer-content preview cap inside the injection.
 ///
@@ -157,10 +182,22 @@ pub(super) const DRAWER_PREVIEW_CHARS: usize = 220;
 ///
 /// Why: gives operators an emergency knob without re-deploying. Optional
 /// — when unset / unparseable / zero, [`DEFAULT_TOP_K`] is used.
-/// What: a string env var parsed as a `usize`; clamped to `[1, 20]` to
+/// What: a string env var parsed as a `usize`; clamped to `[1, MAX_TOP_K]` to
 /// keep the byte budget meaningful.
-/// Test: not unit-tested (env mutation across parallel tests is hostile).
+/// Test: `configured_top_k_clamps_to_bounds` covers the clamp arithmetic.
 pub const ENV_TOP_K: &str = "TRUSTY_MEMORY_PROMPT_TOP_K";
+
+/// Env override for the relevance floor applied to recalled drawers.
+///
+/// Why (issue #5037): the ticket asks for a *configurable* minimum, because the
+/// right threshold depends on the embedder and on how a given palace is
+/// written, and neither is knowable from here. Setting it to `0` disables the
+/// gate and restores the pre-#5037 behaviour exactly, which is the escape hatch
+/// an operator needs if the default over-cuts on their corpus.
+/// What: a string env var parsed as an `f32` and clamped to `[0.0, 1.0]`; when
+/// unset or unparseable, `trusty_common`'s `DEFAULT_RELEVANCE_FLOOR` is used.
+/// Test: `configured_relevance_floor_clamps_to_bounds`.
+pub const ENV_MIN_SCORE: &str = "TRUSTY_MEMORY_PROMPT_MIN_SCORE";
 
 /// Env override for the deny-listed drawer tags filtered out of recall.
 ///
@@ -427,9 +464,12 @@ pub(crate) async fn build_injection_body(trigger_payload: &str) -> String {
     // slower of drawers/kg); joining all three caps the fetch phase at
     // ~1× HTTP_TIMEOUT regardless of palace_slug.
     let global_fut = fetch_global_prompt_context(&client, &base);
-    let (global_facts, drawers, kg_triples) = match &palace_slug {
+    let (global_facts, drawers, withheld, kg_triples) = match &palace_slug {
         Some(slug) => {
             let top_k = configured_top_k();
+            // #5037 (requirement 3): the recall query is `user_prompt` whole —
+            // never a first line, a prefix, or an excerpt. `hook_prompt_excerpt`
+            // exists for telemetry only and must not be used here.
             let drawers_fut = fetch_palace_recall(&client, &base, slug, &user_prompt, top_k);
             let kg_fut = fetch_palace_kg_triples(&client, &base, slug);
             let (global_facts, drawers, kg_all) = tokio::join!(global_fut, drawers_fut, kg_fut);
@@ -439,10 +479,16 @@ pub(crate) async fn build_injection_body(trigger_payload: &str) -> String {
             // back to global hot facts via the existing branch below.
             let deny_tags = configured_deny_tags();
             let drawers = filter_drawers_by_deny_tags(drawers, &deny_tags);
+            // #5037: the deny filter judges provenance; this one judges
+            // relevance. It runs second so a drawer excluded for its tags is
+            // never also counted as "withheld below the floor" — the notice
+            // would then promise `memory_recall` results the deny list also
+            // suppresses.
+            let floor = filter_drawers_by_relevance_floor(drawers, configured_relevance_floor());
             let kg_filtered = select_relevant_triples(&kg_all, &user_prompt, top_k);
-            (global_facts, drawers, kg_filtered)
+            (global_facts, floor.kept, floor.withheld, kg_filtered)
         }
-        None => (global_fut.await, Vec::new(), Vec::new()),
+        None => (global_fut.await, Vec::new(), 0, Vec::new()),
     };
 
     // 5. Compose the injection. If every section is empty, emit the legacy
@@ -451,6 +497,7 @@ pub(crate) async fn build_injection_body(trigger_payload: &str) -> String {
     let composed = compose_injection(
         global_facts.as_deref(),
         &drawers,
+        withheld,
         &kg_triples,
         palace_slug.as_deref(),
     );
@@ -582,16 +629,51 @@ fn parse_user_prompt(stdin_payload: &str) -> String {
 ///
 /// Why: operator escape hatch with a strict ceiling so accidental large
 /// values can't blow the byte budget.
-/// What: parses the env string as a `usize`; on success clamps to
-/// `[1, 20]`; on failure returns [`DEFAULT_TOP_K`].
-/// Test: not unit-tested (env mutation races); covered by the default
-/// path through `prompt_context_recalls_palace_drawers`.
+/// What: reads the env var and hands the raw string to [`clamp_top_k`], which
+/// owns the parse and the clamp so both are testable without env mutation.
+/// Test: `configured_top_k_clamps_to_bounds` covers [`clamp_top_k`]; the
+/// default path is covered by `prompt_context_recalls_palace_drawers`.
 fn configured_top_k() -> usize {
-    std::env::var(ENV_TOP_K)
-        .ok()
-        .and_then(|v| v.trim().parse::<usize>().ok())
-        .map(|k| k.clamp(1, 20))
+    clamp_top_k(std::env::var(ENV_TOP_K).ok().as_deref())
+}
+
+/// Parse and clamp a raw [`ENV_TOP_K`] value.
+///
+/// Why: split from [`configured_top_k`] so the arithmetic can be asserted
+/// directly — env mutation across parallel tests is hostile.
+/// What: parses `raw` as a `usize` and clamps to `[1, MAX_TOP_K]`. `None`,
+/// unparseable, and zero all fall back to [`DEFAULT_TOP_K`].
+/// Test: `configured_top_k_clamps_to_bounds`.
+fn clamp_top_k(raw: Option<&str>) -> usize {
+    raw.and_then(|v| v.trim().parse::<usize>().ok())
+        .filter(|k| *k > 0)
+        .map(|k| k.clamp(1, MAX_TOP_K))
         .unwrap_or(DEFAULT_TOP_K)
+}
+
+/// Read the optional [`ENV_MIN_SCORE`] env var, clamped to `[0.0, 1.0]`.
+///
+/// Why (issue #5037): see [`ENV_MIN_SCORE`] — the floor has to be tunable per
+/// corpus, and settable to `0` to turn the gate off entirely.
+/// What: reads the env var and hands the raw string to [`clamp_floor`].
+/// Test: `configured_relevance_floor_clamps_to_bounds` covers [`clamp_floor`].
+fn configured_relevance_floor() -> f32 {
+    clamp_floor(std::env::var(ENV_MIN_SCORE).ok().as_deref())
+}
+
+/// Parse and clamp a raw [`ENV_MIN_SCORE`] value.
+///
+/// Why: same split as [`clamp_top_k`] — assertable without touching the
+/// process environment.
+/// What: parses `raw` as an `f32` and clamps to `[0.0, 1.0]`. `None`,
+/// unparseable, and NaN fall back to `DEFAULT_RELEVANCE_FLOOR`. A parsed `0.0`
+/// is honoured, disabling the gate.
+/// Test: `configured_relevance_floor_clamps_to_bounds`.
+fn clamp_floor(raw: Option<&str>) -> f32 {
+    raw.and_then(|v| v.trim().parse::<f32>().ok())
+        .filter(|f| !f.is_nan())
+        .map(|f| f.clamp(0.0, 1.0))
+        .unwrap_or(DEFAULT_RELEVANCE_FLOOR)
 }
 
 /// Resolve the effective deny-list of drawer tags for prompt-context recall.

--- a/crates/trusty-memory/src/commands/prompt_context/tests.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/tests.rs
@@ -47,6 +47,7 @@ fn filter_drawers_by_deny_tags_handles_edge_cases() {
         content: "irrelevant".into(),
         tags: tags.iter().map(|s| s.to_string()).collect(),
         layer: Some(2),
+        score: Some(0.9),
     };
 
     // Empty deny list → passthrough.
@@ -130,12 +131,16 @@ fn compose_injection_truncates_at_cap() {
     // 4 KB byte cap. Drawer previews are already capped at
     // DRAWER_PREVIEW_CHARS so the cap-trigger has to come from the
     // global section.
-    let big_global = "## Big block\n".to_string() + &"- fact line\n".repeat(500);
+    // #5037 raised INJECTION_BYTE_CAP from 4 KB to 8 KB; size the fixture off
+    // the constant so the next raise cannot silently stop exercising truncation.
+    let lines = INJECTION_BYTE_CAP / "- fact line\n".len() + 64;
+    let big_global = "## Big block\n".to_string() + &"- fact line\n".repeat(lines);
     let drawers: Vec<RecalledDrawer> = (0..5)
         .map(|i| RecalledDrawer {
             content: format!("drawer {i} content"),
             tags: vec!["tag1".into()],
             layer: Some(2),
+            score: Some(0.9),
         })
         .collect();
     let triples: Vec<RawTriple> = (0..5)
@@ -145,7 +150,7 @@ fn compose_injection_truncates_at_cap() {
             object: "object".into(),
         })
         .collect();
-    let out = compose_injection(Some(&big_global), &drawers, &triples, Some("alpha"));
+    let out = compose_injection(Some(&big_global), &drawers, 0, &triples, Some("alpha"));
     assert!(
         out.len() <= INJECTION_BYTE_CAP,
         "expected len <= cap; got {}",
@@ -169,8 +174,214 @@ fn compose_injection_truncates_at_cap() {
 #[test]
 fn compose_injection_empty_inputs_yields_empty() {
     use format::compose_injection;
-    let out = compose_injection(None, &[], &[], Some("alpha"));
+    let out = compose_injection(None, &[], 0, &[], Some("alpha"));
     assert!(out.is_empty(), "got: {out:?}");
+}
+
+/// Why (issue #5037): the truncation budget was raised from 4 KB to 8 KB
+/// alongside the relevance floor. Pin the new ceiling explicitly so a future
+/// edit cannot quietly shrink it back and blame the floor for lost content.
+/// What: asserts the constant and that `compose_injection` respects it.
+/// Test: itself.
+#[test]
+fn injection_byte_cap_is_eight_kib() {
+    assert_eq!(INJECTION_BYTE_CAP, 8 * 1024);
+    assert_eq!(DEFAULT_TOP_K, 12, "requirement 2: max size raised from 5");
+}
+
+/// Why (issue #5037, requirement 1 + the primary probe): "what is the capital
+/// of France" returned five drawers all scoring exactly `0.15` — the
+/// `L1_NO_SIMILARITY_PENALTY` floor — and the reader could not tell them from a
+/// genuine `0.56` hit. That set must now be empty.
+/// What: five 0.15-scored drawers through the relevance filter at the shipped
+/// default; asserts nothing survives and all five are counted as withheld.
+/// Test: itself.
+#[test]
+fn relevance_floor_drops_all_noise_drawers() {
+    use filter::{filter_drawers_by_relevance_floor, RecalledDrawer};
+    let noise: Vec<RecalledDrawer> = (0..5)
+        .map(|i| RecalledDrawer {
+            content: format!("off-topic session drawer {i}"),
+            tags: vec!["signal".into()],
+            layer: Some(1),
+            // The exact value `rescore_l1_by_similarity` assigns an essential
+            // drawer the HNSW search never returned.
+            score: Some(0.15),
+        })
+        .collect();
+    let out = filter_drawers_by_relevance_floor(noise, DEFAULT_RELEVANCE_FLOOR);
+    assert!(
+        out.kept.is_empty(),
+        "0.15 L1-penalty drawers must not reach the injection; got {:?}",
+        out.kept.len()
+    );
+    assert_eq!(out.withheld, 5, "all five must be counted for the notice");
+}
+
+/// Why (issue #5037): a floor that also cut real matches would trade one defect
+/// for a worse one. `0.56` is the measured median of the self-retrieval signal
+/// population against the live palace.
+/// What: one genuine hit among four noise drawers; asserts only the hit
+/// survives, in order, with the rest counted.
+/// Test: itself.
+#[test]
+fn relevance_floor_keeps_high_scoring_drawer() {
+    use filter::{filter_drawers_by_relevance_floor, RecalledDrawer};
+    let make = |content: &str, score: f32| RecalledDrawer {
+        content: content.into(),
+        tags: Vec::new(),
+        layer: Some(2),
+        score: Some(score),
+    };
+    let mixed = vec![
+        make("genuine on-topic hit about rust integration", 0.56),
+        make("noise a", 0.15),
+        make("noise b", 0.15),
+        make("noise c", 0.2446),
+        make("noise d", 0.3439),
+    ];
+    let out = filter_drawers_by_relevance_floor(mixed, DEFAULT_RELEVANCE_FLOOR);
+    assert_eq!(out.kept.len(), 1, "the genuine hit must survive");
+    assert!(out.kept[0].content.contains("genuine on-topic hit"));
+    assert_eq!(out.withheld, 4);
+}
+
+/// Why (issue #5037): a drawer whose `score` the daemon did not send is
+/// unjudgeable. Dropping it would let a wire-format change silently empty every
+/// injection — the fail-open inversion this fix exists to prevent.
+/// What: a drawer with `score: None` through the filter at the default floor.
+/// Test: itself.
+#[test]
+fn relevance_floor_keeps_drawer_without_score() {
+    use filter::{filter_drawers_by_relevance_floor, RecalledDrawer};
+    let drawers = vec![RecalledDrawer {
+        content: "daemon predates the score field".into(),
+        tags: Vec::new(),
+        layer: Some(2),
+        score: None,
+    }];
+    let out = filter_drawers_by_relevance_floor(drawers, DEFAULT_RELEVANCE_FLOOR);
+    assert_eq!(out.kept.len(), 1, "unknown score must not mean dropped");
+    assert_eq!(out.withheld, 0);
+}
+
+/// Why (issue #5037, requirement 4): a partial drop must tell the reader more
+/// exists, so "the model saw everything relevant" is never assumed wrongly.
+/// What: composes with two kept drawers and three withheld; asserts the count
+/// and the `memory_recall` pointer both render.
+/// Test: itself.
+#[test]
+fn compose_injection_announces_withheld_drawers() {
+    use filter::RecalledDrawer;
+    use format::compose_injection;
+    let drawers: Vec<RecalledDrawer> = (0..2)
+        .map(|i| RecalledDrawer {
+            content: format!("kept drawer {i}"),
+            tags: Vec::new(),
+            layer: Some(2),
+            score: Some(0.7),
+        })
+        .collect();
+    let out = compose_injection(None, &drawers, 3, &[], Some("alpha"));
+    assert!(out.contains("kept drawer 0"), "kept content must render");
+    assert!(
+        out.contains("3 further memories withheld"),
+        "the withheld count must be visible; got:\n{out}"
+    );
+    assert!(
+        out.contains("memory_recall"),
+        "the notice must point at how to see past the floor; got:\n{out}"
+    );
+}
+
+/// Why (issue #5037, requirement 4 — the case the ruling calls out): returning
+/// zero drawers where five noisy ones used to appear is correct, but only if it
+/// is visible. Silence must be distinguishable from nothing-existed.
+/// What: composes with zero kept and five withheld, then with zero of both.
+/// Asserts the first announces itself and the second stays silent — an empty
+/// palace has nothing to announce.
+/// Test: itself.
+#[test]
+fn compose_injection_announces_total_silence() {
+    use format::compose_injection;
+    let silenced = compose_injection(None, &[], 5, &[], Some("alpha"));
+    assert!(
+        !silenced.is_empty(),
+        "an all-withheld recall must not render as an empty injection"
+    );
+    assert!(
+        silenced.contains("cleared the relevance floor") && silenced.contains('5'),
+        "total silence must be announced with its count; got:\n{silenced}"
+    );
+    assert!(
+        silenced.contains("Nothing is missing from the palace"),
+        "the notice must distinguish withheld from absent; got:\n{silenced}"
+    );
+
+    let nothing_existed = compose_injection(None, &[], 0, &[], Some("alpha"));
+    assert!(
+        nothing_existed.is_empty(),
+        "zero candidates is not a withheld recall; got:\n{nothing_existed}"
+    );
+}
+
+/// Why (issue #5037): the floor is required to be *configurable*, including
+/// settable to zero to restore pre-fix behaviour. The clamp is the only thing
+/// standing between an operator typo and a disabled or total-blackout gate.
+/// What: exercises `clamp_floor` across unset, valid, zero, out-of-range,
+/// unparseable, and NaN inputs.
+/// Test: itself.
+#[test]
+fn configured_relevance_floor_clamps_to_bounds() {
+    assert_eq!(clamp_floor(None), DEFAULT_RELEVANCE_FLOOR);
+    assert_eq!(clamp_floor(Some("0.5")), 0.5);
+    assert_eq!(clamp_floor(Some(" 0.42 ")), 0.42);
+    assert_eq!(clamp_floor(Some("0")), 0.0, "zero must disable the gate");
+    assert_eq!(clamp_floor(Some("-3")), 0.0);
+    assert_eq!(clamp_floor(Some("9")), 1.0);
+    assert_eq!(clamp_floor(Some("banana")), DEFAULT_RELEVANCE_FLOOR);
+    assert_eq!(clamp_floor(Some("NaN")), DEFAULT_RELEVANCE_FLOOR);
+}
+
+/// Why (issue #5037, requirement 2): the K ceiling moved with the default, and
+/// a ceiling below the default would silently cap every operator override.
+/// What: exercises `clamp_top_k` across unset, valid, zero, over-ceiling, and
+/// unparseable inputs.
+/// Test: itself.
+#[test]
+fn configured_top_k_clamps_to_bounds() {
+    assert_eq!(clamp_top_k(None), DEFAULT_TOP_K);
+    assert_eq!(clamp_top_k(Some("7")), 7);
+    assert_eq!(clamp_top_k(Some("0")), DEFAULT_TOP_K);
+    assert_eq!(clamp_top_k(Some("999")), MAX_TOP_K);
+    assert_eq!(clamp_top_k(Some("nope")), DEFAULT_TOP_K);
+}
+
+/// Why (issue #5037, requirement 3): the recall query must be the whole user
+/// input. `hook_prompt_excerpt` exists a few lines away in the same module and
+/// truncates for telemetry — wiring it into the query by mistake would fragment
+/// every recall silently. Pin that `parse_user_prompt` hands back the prompt
+/// entire.
+/// What: a 12,000-character prompt through `parse_user_prompt`; asserts the
+/// result is byte-identical, and that the telemetry excerpt is not.
+/// Test: itself.
+#[test]
+fn recall_query_is_the_whole_prompt() {
+    let long: String = "explain the retrieval floor and why it matters. "
+        .repeat(400)
+        .trim_end()
+        .to_string();
+    assert!(long.len() > 12_000, "fixture must exceed any plausible cap");
+    let payload = serde_json::json!({ "prompt": long, "cwd": "/tmp" }).to_string();
+
+    let parsed = parse_user_prompt(&payload);
+    assert_eq!(parsed, long, "the recall query must not be truncated");
+
+    // The telemetry excerpt IS truncated — that asymmetry is the point.
+    assert!(
+        crate::hook_prompt_excerpt(&parsed).len() < parsed.len(),
+        "excerpt helper must stay distinct from the query path"
+    );
 }
 
 /// Why (issue #125): when Claude Code invokes the UserPromptSubmit hook,
@@ -346,6 +557,80 @@ async fn prompt_context_recalls_palace_drawers() {
     assert!(
         elapsed_ms < 5_000,
         "prompt-context too slow ({elapsed_ms}ms) — investigate"
+    );
+
+    addr_handle.shutdown().await;
+}
+
+/// Why (issue #5037, end to end): the unit tests above pin the floor over
+/// synthetic scores. This one proves the whole chain — real embedder, real HTTP
+/// recall, real `score` on the wire, real filter — turns an off-topic prompt
+/// into zero injected drawers plus a visible withheld notice, which is the
+/// behaviour the probe found missing ("what is the capital of France" returned
+/// five drawers at 0.15, rendered as if they matched).
+/// What: populates a palace with three Rust/Python/KG drawers, then submits a
+/// prompt about none of them. Asserts no drawer content reaches the injection,
+/// and that the block says results were withheld rather than going silent.
+/// Test: itself.
+/// Note (issue #226): gated on `axum-server`; spins up the HTTP daemon.
+#[cfg(feature = "axum-server")]
+#[tokio::test]
+async fn prompt_context_off_topic_prompt_withholds_and_says_so() {
+    let _guard = crate::commands::env_test_lock().lock().await;
+    unsafe {
+        std::env::remove_var(ENV_MIN_SCORE);
+        std::env::remove_var(ENV_RECALL_DENY_TAGS);
+    }
+    let (state, _data_dir_tmp, _project_dir_tmp, project_dir, slug, addr_handle) =
+        spin_up_test_daemon_with_palace("prompt-ctx-floor-e2e").await;
+
+    for (text, tags) in [
+        (
+            "Rust integration uses tokio for async tasks and serde for JSON encoding",
+            vec!["rust", "tokio"],
+        ),
+        (
+            "Python bindings ship via PyO3 with custom ABI shims for the runtime",
+            vec!["python", "pyo3"],
+        ),
+        (
+            "Knowledge graph stores triples in redb with valid_from intervals per edge",
+            vec!["kg", "redb"],
+        ),
+    ] {
+        let tags_json: Vec<serde_json::Value> = tags.iter().map(|t| json!(t)).collect();
+        let _ = crate::tools::dispatch_tool(
+            &state,
+            "memory_remember",
+            json!({
+                "palace": slug,
+                "text": text,
+                "room": "General",
+                "tags": tags_json,
+            }),
+        )
+        .await
+        .expect("memory_remember");
+    }
+
+    // The probe query from #5037 — nothing in this palace answers it.
+    let payload = json!({
+        "hook_event_name": "UserPromptSubmit",
+        "cwd": project_dir.to_string_lossy(),
+        "prompt": "what is the capital of France"
+    })
+    .to_string();
+    let body = build_injection_body(&payload).await;
+
+    for leaked in ["tokio", "PyO3", "valid_from"] {
+        assert!(
+            !body.contains(leaked),
+            "off-topic prompt must not inject `{leaked}`; got:\n{body}"
+        );
+    }
+    assert!(
+        body.contains("relevance floor"),
+        "a withheld recall must announce itself, not go silent; got:\n{body}"
     );
 
     addr_handle.shutdown().await;


### PR DESCRIPTION
Closes #5037

## Defect

`prompt-context` asked for `top_k` drawers and rendered whatever came back. `truncate(top_k)` is the only length control in the whole retrieval chain (`layers.rs::recall_scoped` ~667, `retrieve_l2_scoped` ~397) and no layer applies a minimum score. `rescore_l1_by_similarity` gives an essential drawer the vector search never returned `importance * L1_NO_SIMILARITY_PENALTY` — at most `0.15` — which is nonzero, so it competes for a slot.

Probe against the live 1,332-drawer palace: "what is the capital of France" returned five drawers all at exactly 0.15, formatted identically to a genuine 0.56 hit.

## The threshold, from measurement

Two probes against the live daemon, script in the session scratchpad.

| population | n | min | p10 | median | max |
|---|---|---|---|---|---|
| 15 off-topic prompts × top-10 | 150 | 0.1500 | 0.1500 | 0.1510 | **0.3439** |
| 60 self-retrieval queries, score of the *correct* drawer | 57 | **0.4844** | 0.6117 | 0.6950 | 0.9743 |
| 120 real logged hook prompts × top-10 | 1200 | 0.4042 | 0.4671 | 0.5422 | 0.7527 |
| 12 paraphrased on-topic questions, best hit per query | 12 | 0.3293 | — | 0.4317 | 0.5359 |

75 of the 150 off-topic candidates scored exactly 0.1500 — the L1 penalty itself. Floor sweep:

```
floor=0.25  noise kept  18/150 (12.0%)  noise queries still firing  3/15  correct-drawer retained 57/57
floor=0.30  noise kept   5/150 ( 3.3%)  noise queries still firing  1/15  correct-drawer retained 57/57
floor=0.35  noise kept   0/150 ( 0.0%)  noise queries still firing  0/15  correct-drawer retained 57/57
floor=0.45  noise kept   0/150 ( 0.0%)  noise queries still firing  0/15  correct-drawer retained 57/57
```

**0.35** is the smallest swept value at which no off-topic candidate survives, rounded up from the highest observed noise score (0.3439). At it the real logged corpus loses 0 of 1200 candidates and 0 of 120 queries.

The cost, stated plainly: 2 of 12 paraphrased on-topic questions stop injecting. Both are short keyword-bearing queries ("what is the MSRV for this workspace", 0.3293) — dense retrieval's weak spot and BM25's strength, which #5036 is the named fix for. The floor is configurable (`TRUSTY_MEMORY_PROMPT_MIN_SCORE`, `0` disables) and the loss is announced, not silent.

## The four requirements

1. **Relevance floor.** New `trusty_common::memory_core::retrieval::relevance` owns the one implementation. `RecalledDrawer` now parses the `score` the recall endpoint has always sent (`service::recall_entry_json`) and drops what falls below. Runs *after* the deny-tag filter so a tag-excluded drawer is never also counted as withheld. An unknown score is kept, never dropped.
2. **Larger max size.** `DEFAULT_TOP_K` 5 → 12 (override ceiling 20 → 30, compile-time asserted above the default), `INJECTION_BYTE_CAP` 4 KB → 8 KB. Measured over 80 real logged prompts, K=12 with the floor renders a drawer section of at most ~2.7 KB.
3. **Whole-input-only — already satisfied, now pinned.** `parse_user_prompt` returns the entire prompt and `fetch_palace_recall` sends it whole; nothing on that path truncates. Verified against the live daemon at query lengths 500 B → 64 KB (no URI failure). `recall_query_is_the_whole_prompt` pins it against the truncating `hook_prompt_excerpt` helper sitting a few lines away. The residual fragmentation is the embedder's 512-token window — scores plateau identically from ~5 KB up, visible in that same probe — which is #4972, a different layer.
4. **"More" signal.** When the floor drops drawers the injection says so and points at `memory_recall`, with distinct wording for a partial drop and for a recall that kept nothing. Zero candidates still renders nothing: an empty palace has nothing to announce.

`recall`/`recall_scoped` are deliberately unchanged. Gating inside `truncate(top_k)` would change every MCP and CLI recall caller's contract, which the ruling does not ask for.

## Scope

Included: **#5037** only. Left alone and stated rather than silently absorbed:
- **#5038** (uncapped provenance/tag rendering) — a rendering-budget fix in the same `format.rs`, independent of match quality. Its symptom is visible in the red-check output below (`creator:client=…`, `creator:version=…` on every bullet).
- **#5036** (BM25 fusion) — an engineer is already on `fix/recall-http-bm25-fusion` per the ticket.
- **#4972** (512-token truncation) — embedder layer; see requirement 3.

## Red before green

Isolation: on a scratch branch, set `DEFAULT_RELEVANCE_FLOOR = 0.0` (the defect: "no confidence floor") and revert `DEFAULT_TOP_K`/`INJECTION_BYTE_CAP`. Every test file unchanged.

```
---- relevance_floor_drops_all_noise_drawers stdout ----
0.15 L1-penalty drawers must not reach the injection; got 5

---- relevance_floor_keeps_high_scoring_drawer stdout ----
assertion `left == right` failed: the genuine hit must survive
  left: 5
 right: 1

---- prompt_context_off_topic_prompt_withholds_and_says_so stdout ----
off-topic prompt must not inject `tokio`; got:
## Relevant memories from palace `prompt-ctx-floor-e2e`
- Knowledge graph stores triples in redb with valid_from intervals per edge  _(tags: `kg`, `redb`, `creator:client=trusty-memory-mcp`, …)_
- Python bindings ship via PyO3 with custom ABI shims for the runtime  _(tags: `python`, `pyo3`, …)_
- Rust integration uses tokio for async tasks and serde for JSON encoding  _(tags: `rust`, `tokio`, …)_

test result: FAILED. 28 passed; 4 failed; 0 ignored; 0 measured; 585 filtered out
```

```
---- memory_core::retrieval::relevance::tests::relevance_floor_drops_l1_penalty_noise ----
0.15 noise must not survive the floor
test result: FAILED. 2 passed; 2 failed; 0 ignored; 0 measured; 923 filtered out
```

The e2e failure reproduces the reported defect exactly: the France probe injecting three unrelated drawers at full formatting.

Green after restoring the fix: `test result: ok. 32 passed; 0 failed` (prompt_context filter).

## Gate — Rust Test Ladder rung 4

| gate | result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo check --workspace --all-targets` * | EXIT=0 |
| `cargo clippy -p trusty-common --all-targets -- -D warnings` | EXIT=0 |
| `cargo clippy -p trusty-memory --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-common --features memory-core` | `ok. 914 passed; 0 failed; 13 ignored` |
| `cargo test -p trusty-memory` | `ok. 613 passed; 0 failed; 4 ignored` |
| `bash scripts/check_line_cap.sh` | `3763 files; 7 allowlisted, 0 violations — OK` |
| `bash scripts/check_changelog_fragment.sh` | `all 2 crate(s) with source changes are recorded` |
| `bash scripts/check_sld.sh` | `0 error(s), 0 warning(s)` |

\* with `SKIP_UI_BUILD=1 --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui`, exactly as `.github/workflows/ci.yml` runs every workspace job. Without the excludes the three Tauri crates fail on a missing `ui/dist`, unrelated to this diff (which touches zero files in them).

`-p trusty-common` alone runs with default features, which exclude `memory-core` — the new tests would not have run. `--features memory-core` is what actually covers the change.

No coverage was deleted, `#[ignore]`d, `cfg`-gated, or excluded to make anything green.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
