### PR TITLE
test: pin repo-root-relative resolution in the token drift checker

### DIFF
--- a/scripts/check_token_drift.mjs
+++ b/scripts/check_token_drift.mjs
@@ -100,6 +100,17 @@ const ALLOWLIST = [];
 //
 // `lightSelector`/`darkSelector`: block-scoped regex for each theme block
 //   (the last capture group is the block body).
+//
+// `file` is REPO-ROOT-relative, not crate-relative — an entry does not have to
+// live under `crates/`. Registering a root-level consumer such as `website/`
+// (#5092) is therefore a config entry here, not a code change: pick the mode
+// its stylesheet already uses (Tailwind -> "rgb-triple" with a mappings table,
+// plain CSS -> "hex"), give it its own theme selectors, and add it to the list.
+// check_token_drift.test.mjs pins that root-relative resolution (#5095).
+//
+// Nothing DISCOVERS unregistered consumers: a new UI that never gets an entry
+// here is simply not checked, and the gate stays green. Adding the entry is
+// part of landing the UI.
 // ---------------------------------------------------------------------------
 const ENFORCED = [
   {

--- a/scripts/check_token_drift.test.mjs
+++ b/scripts/check_token_drift.test.mjs
@@ -34,6 +34,7 @@ import path from "node:path";
 
 import {
   ENFORCED,
+  REPO_ROOT,
   checkCrate,
   parseCanonical,
   parseCanonicalFromSource,
@@ -313,4 +314,60 @@ test("hex mode: a missing dark block throws (disk-based)", () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+// ---------------------------------------------------------------------------
+// Repo-root-relative `file` resolution (#5095)
+//
+// Every ENFORCED entry today sits under `crates/`, so nothing yet proves that
+// `file` is resolved as repo-root-relative rather than crate-relative. The
+// website (#5092) sits at the repo ROOT, so if a future refactor folded a
+// `crates/` prefix into resolveCrateFilePath every existing entry would keep
+// passing and registering the website would silently become a code change.
+// This fixture is written inside REPO_ROOT — not tmpdir like the tests above —
+// precisely because the root-relative branch is the thing under test.
+// ---------------------------------------------------------------------------
+
+function withRootFixture(css, fn) {
+  const dir = mkdtempSync(path.join(REPO_ROOT, ".token-drift-fixture-"));
+  try {
+    writeFileSync(path.join(dir, "app.css"), css);
+    return fn(path.join(path.basename(dir), "app.css"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const ROOT_FIXTURE_CSS = `
+:root {
+  --color-foo: 17 34 51;
+}
+
+.dark {
+  --color-foo: 68 85 102;
+}
+`;
+
+test("an enforced entry outside crates/ resolves relative to the repo root", () => {
+  const canonical = parseCanonicalFromSource(CANONICAL_SOURCE, "inline");
+  withRootFixture(ROOT_FIXTURE_CSS, (relPath) => {
+    assert.ok(!relPath.startsWith("crates/"), "fixture must live outside crates/");
+    // No parsedOverride, so this exercises the real disk read through
+    // resolveCrateFilePath rather than an injected declaration map.
+    const diffs = checkCrate(makeFixtureCrate({ name: "website", file: relPath }), canonical);
+    assert.equal(diffs.comparedCount, 2, "expected one comparison per theme");
+    assert.equal(diffs.length, 0, JSON.stringify(diffs));
+  });
+});
+
+test("a root-relative entry still DETECTS drift (not a vacuous pass)", () => {
+  const canonical = parseCanonicalFromSource(CANONICAL_SOURCE, "inline");
+  const drifted = ROOT_FIXTURE_CSS.replace("--color-foo: 17 34 51;", "--color-foo: 1 2 3;");
+  withRootFixture(drifted, (relPath) => {
+    const diffs = checkCrate(makeFixtureCrate({ name: "website", file: relPath }), canonical);
+    assert.equal(diffs.length, 1);
+    assert.equal(diffs[0].theme, "light");
+    assert.equal(diffs[0].var, "--color-foo");
+    assert.match(diffs[0].actual, /1 2 3/);
+  });
 });


### PR DESCRIPTION
Closes [#5095](https://github.com/bobmatnyc/trusty-tools/issues/5095). Part of [#5092](https://github.com/bobmatnyc/trusty-tools/issues/5092).

## Finding first: no generator is needed

[#5095](https://github.com/bobmatnyc/trusty-tools/issues/5095) asked for a generator because `crates/trusty-agents/ui` was believed to be the only consumer of `docs/design/UI/design-system/tokens.css`, hand-porting values with nothing to catch drift. That premise was wrong. Seven UI crates consume it, hand-transcription is the deliberate convention, and [`token-drift.yml`](.github/workflows/token-drift.yml) already gates all seven — allowlist empty, green today. A generator would have been a second mechanism for a capability that already has one.

I built the generator before catching this. It is discarded; the values it produced were byte-identical to the current hand-port (22/22 tokens for `trusty-agents`), which independently confirms the existing checker is doing its job.

## Defect

`resolveCrateFilePath` in [`scripts/check_token_drift.mjs`](scripts/check_token_drift.mjs) resolves an entry's `file` against the repo root, so a consumer need not live under `crates/`. Nothing proved that: all 7 entries are under `crates/`, and the one disk-based test uses an absolute temp path, which takes the `isAbsolute` branch instead.

`website/` ([#5092](https://github.com/bobmatnyc/trusty-tools/issues/5092)) will sit at the repo root. A refactor that folded a `crates/` prefix into that function would leave all 7 crates green while making the website impossible to register without a code change — a silent regression in exactly the path the next consumer depends on.

## Evidence

Verified against a fixture written outside `crates/`, driven through the real disk read:

```
compared=6 diffs=0                                          # correct values
compared=6 diffs=1                                          # after mutating one
  [light] --color-primary: expected 183 65 14 (#b7410e), found 1 2 3 (#010203)
```

## Resolution

Two regression tests pinning that branch in both directions, plus a note in the `ENFORCED` comment recording what registering a root-level consumer takes.

**Registering `website/` is a config entry, not code:** add an entry with `file: "website/src/app.css"`, mode `rgb-triple` (SvelteKit + Tailwind needs `rgb(var(--color-*) / <alpha-value>)`; all three existing Tailwind crates are v3), its own light/dark selectors, and a mappings table. `token-drift.yml` has no `paths:` filter, so it already runs on website PRs.

**Residual gap, not fixed here:** nothing DISCOVERS unregistered consumers. A UI that lands without an entry is simply not checked and the gate stays green. Recorded in the comment; worth its own ticket if you want it enforced, but auto-discovery is speculative until `website/` exists and its shape is known.

## Scope, risk, tests

Test-and-comment only — no production code, no behavior change. `scripts/**`, so no changelog fragment (gate agrees: `no crate source changed — OK`).

```
# tests 13
# pass 13
# fail 0

OK   trusty-agents (crates/trusty-agents/ui/src/app.css) — 22 tokens match canonical [rgb-triple]
OK   trusty-code-gui (crates/trusty-code-gui/ui/src/app.css) — 40 tokens match canonical [rgb-triple]
OK   trusty-mpm-gui (crates/trusty-mpm-gui/ui/src/app.css) — 30 tokens match canonical [rgb-triple]
OK   trusty-console (crates/trusty-console/ui/src/theme.css) — 26 tokens match canonical [hex]
OK   trusty-analyze (crates/trusty-analyze/ui/src/lib/styles/tokens.css) — 47 tokens match canonical [hex]
OK   trusty-search (crates/trusty-search/ui/src/lib/styles/tokens.css) — 49 tokens match canonical [hex]
OK   trusty-memory (crates/trusty-memory/ui/src/lib/styles/tokens.css) — 49 tokens match canonical [hex]
All enforced crates match the canonical token source.
```

`check_line_cap.sh`, `check_generation_artifacts.sh`, `check_sld.sh`: all OK. No baseline failures encountered.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools