### PR TITLE
docs: fix trusty-mpmd, publish-status, and config-extension errors in INSTALL-CONVENTION.md

### DIFF
--- a/docs/distribution/INSTALL-CONVENTION.md
+++ b/docs/distribution/INSTALL-CONVENTION.md
@@ -15,7 +15,7 @@ This document defines the canonical installation convention that every distribut
 - `trusty-git-analytics` (tga) — developer productivity analytics
 - `trusty-code` — per-project Claude-Code orchestration harness
 
-**Out of scope**: library-only crates, internal binaries, and publish=false crates (trusty-mpm-gui, trusty-agents, etc.).
+**Out of scope**: library-only crates, internal binaries, `publish = false` crates (e.g. `trusty-mpm-gui`), and crates that have simply never been published (e.g. `trusty-agents` — no `publish` field, no `trusty-agents-v*` release tag, zero crates.io or GitHub releases; install it with `cargo install --path crates/trusty-agents --locked` from a source checkout instead).
 
 ## Installation Channels
 
@@ -277,11 +277,18 @@ Install with `cargo install --git https://github.com/bobmatnyc/trusty-tools trus
 
 #### Configuration
 
-The daemon reads from `~/.config/trusty-mpm/config.yaml` by default. See the `trusty-mpm` crate README for configuration examples and the full option reference.
+The daemon reads from `$XDG_CONFIG_HOME/trusty-mpm/config.toml`, falling back to `~/.config/trusty-mpm/config.toml`, by default. See the `trusty-mpm` crate README for configuration examples and the full option reference.
+
+There is no separate `trusty-mpmd` binary — the crate ships one binary
+(installed as both `tm` and `trusty-mpm`), and the daemon is its `daemon`
+subcommand:
 
 ```bash
-trusty-mpmd --config /path/to/config.yaml
+tm daemon
 ```
+
+The `daemon` subcommand has no `--config` flag; to use a config file at a
+non-default location, set `XDG_CONFIG_HOME` before running it.
 
 The CLI (`tm` / `trusty-mpm`) discovers the running daemon automatically via the standard socket or HTTP port and requires no configuration beyond a running daemon.
 ```


### PR DESCRIPTION
## Defect

`docs/distribution/INSTALL-CONVENTION.md` is on the public manifest (`docs/public-manifest.tsv`, route `/installation/convention`) — this was missed in [#5107](https://github.com/bobmatnyc/trusty-tools/pull/5107) because it was initially believed not to be published; confirmed otherwise by reading the manifest directly. Three defects, launch blockers since the page ships as-is:

1. Claims `trusty-agents` is `publish = false`, in the same breath as `trusty-mpm-gui`.
2. `trusty-mpmd --config /path/to/config.yaml` — names a binary that doesn't exist and a flag its replacement doesn't have.
3. Names the trusty-mpm config file `~/.config/trusty-mpm/config.yaml` (wrong extension).

## Evidence

- `crates/trusty-agents/Cargo.toml`: no `publish` field anywhere in the package section (only comments about *other* crates' `publish = false`). `git tag --list 'trusty-agents-v*'` → empty. `gh release list` → no trusty-agents/tagent releases. `crates/trusty-mpm-gui/Cargo.toml:7`: `publish = false` — genuinely true for that one. So the two crates cited together were in different situations; the old text collapsed them into one claim that's only true for one of them.
- `crates/trusty-mpm/Cargo.toml`: only two `[[bin]]` targets, `tm` and `trusty-mpm`, both `src/bin/tm/main.rs` — no `trusty-mpmd`.
- `crates/trusty-mpm/src/bin/tm/cli/mod.rs`'s `Daemon` variant: fields are `addr`, `tailscale`, `mcp`, `force` — no `--config` flag exists to remove or rename.
- `crates/trusty-mpm/src/bin/tm/commands/managed_root.rs:197-209`: config path is `$XDG_CONFIG_HOME/trusty-mpm/config.toml` falling back to `~/.config/trusty-mpm/config.toml` — TOML, not YAML.
- Spot-checked the file's other per-crate claims while in it: `trusty-review` and `trusty-code` are both genuinely live on crates.io (`curl .../crates/trusty-review`, `.../crates/trusty-code`), and `trusty-installer`'s `[[bin]]` targets are exactly `trusty-installer` + `tctl` as claimed. No further errors found in this file.

Gates:

```
$ bash scripts/check_sld.sh
sld-lint: scanned 56 spec doc(s) + 3126 code file(s); 0 error(s), 0 warning(s)
$ bash scripts/check_doc_numbers.sh → EXIT=0
$ bash scripts/check_line_cap.sh → EXIT=0
$ bash scripts/check_changelog_fragment.sh
changelog-fragment gate: scanned 1 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
```

## Resolution

- Scope line now states the real, differentiated situation for `trusty-agents` (never published — no `publish` field, no tag, no release) vs. `trusty-mpm-gui` (`publish = false`), with the correct build-from-source install command.
- Config section: `trusty-mpmd --config ...` replaced with `tm daemon` (no `--config` flag exists; documented the `XDG_CONFIG_HOME` override instead) and the extension corrected to `.toml`.

## Related

- Part of [#5092](https://github.com/bobmatnyc/trusty-tools/issues/5092). See [#5115](https://github.com/bobmatnyc/trusty-tools/issues/5115) — its re-scope to "this is a published page" had not landed at the time of this PR (body still says "not launch blockers" and cites a different path), so this PR references it rather than closing it. Please confirm/re-check once the re-scope lands.
- Distinct from [#5107](https://github.com/bobmatnyc/trusty-tools/pull/5107), which fixed the same `trusty-mpmd` defect class in `docs/reference/running-mcp-servers.md` and `docs/trusty-mpm/README.md`.
- `docs/architecture/harnesses.md` and `crates/trusty-code/README.md` are explicitly out of scope for this PR (per owner instruction) — left untouched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools