### PR TITLE
fix(security): enforce UDS socket permissions the ADRs already claim exist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11517,7 +11517,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-embedderd"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -58,7 +58,7 @@ trusty-code = { workspace = true }
 #      stub. Zero added dependency weight: `aws-config`/`aws-sdk-bedrockruntime`/
 #      `aws-types` below are already unconditional direct dependencies of this
 #      crate for the existing `llm::bedrock` (Converse, non-streaming) client.
-trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memory-core", "cli-help", "stdio-mcp-client", "session-naming", "config-cli", "axum-server", "inference-client", "bedrock"] }
+trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memory-core", "cli-help", "stdio-mcp-client", "session-naming", "config-cli", "axum-server", "inference-client", "bedrock", "uds"] }
 # Why (issue #226): trusty-agents only links `trusty_memory::MemoryMcpService` for
 #      in-process `rpc.discover` merging; it does not need the axum HTTP/SSE
 #      surface (it owns its own axum stack for the orchestrator's UI). Setting

--- a/crates/trusty-agents/changelog.d/5099-uds-socket-permissions.md
+++ b/crates/trusty-agents/changelog.d/5099-uds-socket-permissions.md
@@ -1,0 +1,12 @@
+Fixed
+
+- **The controller and message-bus sockets were world-readable**
+  ([#5099](https://github.com/bobmatnyc/trusty-tools/issues/5099)).
+  `CtrlSocket::bind`, `CtrlSocket::bind_singleton`, and `MessageBus::start` each
+  created `~/.trusty-agents/sockets/` with `create_dir_all` and then bound bare,
+  so both the directory and the socket landed at the process umask (`0755`).
+  All three now route through `trusty_common::uds::bind_hardened` (`0700`
+  directory, `0600` socket before the first accept); `bind_singleton` hardens the
+  directory *before* probing, so a takeover of a stale socket is narrowed too.
+  The ctrl and bus accept loops drop any connection whose peer uid is not this
+  process's own.

--- a/crates/trusty-agents/src/bus/mod.rs
+++ b/crates/trusty-agents/src/bus/mod.rs
@@ -71,15 +71,14 @@ impl MessageBus {
     /// and assert the envelope arrives.
     pub async fn start(project_id: &str) -> Result<Arc<Self>> {
         let socket_path = Self::socket_path_for(project_id)?;
-        if let Some(parent) = socket_path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
         // Remove stale socket from a previous run.
         if socket_path.exists() {
             fs::remove_file(&socket_path).await.ok();
         }
 
-        let listener = UnixListener::bind(&socket_path)?;
+        // #5099: was `create_dir_all` + a bare bind, so both the sockets
+        // directory and the socket landed at the process umask.
+        let listener = trusty_common::uds::bind_hardened(&socket_path)?;
         let (tx, _) = broadcast::channel(CHANNEL_CAPACITY);
 
         let bus = Arc::new(Self {
@@ -255,6 +254,11 @@ async fn accept_loop(listener: UnixListener, tx: broadcast::Sender<BusEnvelope>)
     loop {
         match listener.accept().await {
             Ok((stream, _addr)) => {
+                // #5099: a foreign-uid peer is dropped without being served.
+                if let Err(e) = trusty_common::uds::ensure_peer_is_self(&stream) {
+                    tracing::warn!(error = %e, "bus accept_loop: rejected connection");
+                    continue;
+                }
                 let tx_clone = tx.clone();
                 tokio::spawn(handle_connection(stream, tx_clone));
             }

--- a/crates/trusty-agents/src/ctrl/socket.rs
+++ b/crates/trusty-agents/src/ctrl/socket.rs
@@ -180,17 +180,19 @@ impl CtrlSocket {
     /// Why: Encapsulates parent-dir creation + stale-file cleanup + the
     /// actual bind, which would otherwise be duplicated between the
     /// controller startup path and any future "restart the listener" code.
-    /// What: Creates `~/.trusty-agents/sockets/`, removes any stale file at
-    /// `path`, then binds. Caller is responsible for `tokio::spawn`-ing the
-    /// accept loop and removing the socket file on shutdown.
-    /// Test: `bind_creates_listener_and_replaces_stale_file`.
+    /// What: removes any stale file at `path`, then binds through
+    /// [`trusty_common::uds::bind_hardened`], which creates
+    /// `~/.trusty-agents/sockets/` at `0700` and narrows the socket to `0600`
+    /// before the first accept (#5099 — this used to be `create_dir_all` plus a
+    /// bare bind, so both landed at the process umask). Caller is responsible
+    /// for `tokio::spawn`-ing the accept loop and removing the socket file on
+    /// shutdown.
+    /// Test: `bind_creates_listener_and_replaces_stale_file`,
+    /// `bind_produces_a_0600_socket_in_a_0700_dir`.
     pub async fn bind(path: &Path) -> io::Result<UnixListener> {
-        if let Some(parent) = path.parent() {
-            tokio::fs::create_dir_all(parent).await?;
-        }
         // Remove stale socket before binding (otherwise bind fails with EADDRINUSE).
         Self::cleanup(path);
-        UnixListener::bind(path)
+        trusty_common::uds::bind_hardened(path).map_err(io::Error::other)
     }
 
     /// Singleton-safe bind: probe first, only clobber a confirmed-dead socket.
@@ -213,8 +215,11 @@ impl CtrlSocket {
     /// `bind_singleton_binds_when_socket_absent`, and
     /// `bind_singleton_binds_over_stale_socket`.
     pub async fn bind_singleton(path: &Path, timeout: Duration) -> io::Result<BindOutcome> {
+        // #5099: harden the directory BEFORE probing. The probe can succeed
+        // against a socket sitting in a wide directory, and the takeover branch
+        // below must not be the only path that narrows it.
         if let Some(parent) = path.parent() {
-            tokio::fs::create_dir_all(parent).await?;
+            trusty_common::uds::prepare_socket_dir(parent).map_err(io::Error::other)?;
         }
         match Self::probe(path, timeout).await {
             // A controller answered — refuse to clobber; hand the stream back.
@@ -222,7 +227,8 @@ impl CtrlSocket {
             // Stale socket (or no socket at all): safe to take over.
             Err(e) if is_connection_refused(&e) || e.kind() == io::ErrorKind::TimedOut => {
                 Self::cleanup(path);
-                Ok(BindOutcome::Bound(UnixListener::bind(path)?))
+                let listener = trusty_common::uds::bind_hardened(path).map_err(io::Error::other)?;
+                Ok(BindOutcome::Bound(listener))
             }
             // Any other error (permission denied, etc.): do NOT clobber.
             Err(e) => Err(e),
@@ -252,6 +258,47 @@ impl CtrlSocket {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    /// #5099 regression: `CtrlSocket::bind` must produce a 0600 socket in a
+    /// 0700 directory. Against the pre-fix commit it used `create_dir_all`
+    /// plus a bare bind, so both landed at the process umask (0755/0755).
+    #[tokio::test]
+    async fn bind_produces_a_0600_socket_in_a_0700_dir() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("sockets");
+        let sock = dir.join("p.ctrl.sock");
+
+        let _listener = CtrlSocket::bind(&sock).await.expect("bind");
+
+        let mode = |p: &Path| std::fs::metadata(p).expect("stat").permissions().mode() & 0o777;
+        assert_eq!(mode(&sock), 0o600, "ctrl socket must be 0600");
+        assert_eq!(mode(&dir), 0o700, "ctrl socket dir must be 0700");
+    }
+
+    /// #5099: the singleton path hardens the directory before probing, so a
+    /// takeover of a stale socket also lands 0600/0700.
+    #[tokio::test]
+    async fn bind_singleton_hardens_the_socket_it_takes_over() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("sockets");
+        let sock = dir.join("p.ctrl.sock");
+
+        let outcome = CtrlSocket::bind_singleton_default(&sock)
+            .await
+            .expect("bind singleton");
+        assert!(
+            matches!(outcome, BindOutcome::Bound(_)),
+            "must win the race"
+        );
+
+        let mode = |p: &Path| std::fs::metadata(p).expect("stat").permissions().mode() & 0o777;
+        assert_eq!(mode(&sock), 0o600, "ctrl socket must be 0600");
+        assert_eq!(mode(&dir), 0o700, "ctrl socket dir must be 0700");
+    }
 
     #[test]
     fn sanitize_project_id_replaces_unsafe_chars() {

--- a/crates/trusty-agents/src/ctrl/socket_listener.rs
+++ b/crates/trusty-agents/src/ctrl/socket_listener.rs
@@ -41,6 +41,11 @@ pub async fn spawn_socket_listener(listener: tokio::net::UnixListener) {
     loop {
         match listener.accept().await {
             Ok((stream, _addr)) => {
+                // #5099: a foreign-uid peer is dropped without being served.
+                if let Err(e) = trusty_common::uds::ensure_peer_is_self(&stream) {
+                    tracing::warn!(error = %e, "ctrl: rejected connection");
+                    continue;
+                }
                 tokio::spawn(handle_socket_connection(stream));
             }
             Err(e) => {

--- a/crates/trusty-bm25-daemon/Cargo.toml
+++ b/crates/trusty-bm25-daemon/Cargo.toml
@@ -39,7 +39,7 @@ crate-type = ["rlib"]
 # Uses the in-tree, zero-dep BM25 implementation from trusty-common
 # (`bm25` feature). Keeps the tokenizer's camelCase / alpha↔digit splits
 # in lock-step with every other consumer (trusty-search, trusty-memory).
-trusty-common = { workspace = true, features = ["bm25"] }
+trusty-common = { workspace = true, features = ["bm25", "uds"] }
 tokio = { workspace = true, features = ["full"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/trusty-bm25-daemon/changelog.d/5099-uds-socket-permissions.md
+++ b/crates/trusty-bm25-daemon/changelog.d/5099-uds-socket-permissions.md
@@ -1,0 +1,11 @@
+Fixed
+
+- **The daemon socket was world-readable and lived in a shared directory**
+  ([#5099](https://github.com/bobmatnyc/trusty-tools/issues/5099)).
+  `bind_listener` called `UnixListener::bind` bare, leaving the socket at the
+  process umask, and `default_socket_path` resolved to `$TMPDIR` falling back to
+  `/tmp` — world-writable on a Linux host with `TMPDIR` unset. The bind now goes
+  through `trusty_common::uds::bind_hardened` (`0700` directory, `0600` socket),
+  the path resolves under `<$TMPDIR or /tmp>/trusty-<uid>/`, and `run_accept_loop`
+  drops any connection whose peer uid is not this process's own. **A running
+  daemon must be restarted** to be found at the new path.

--- a/crates/trusty-bm25-daemon/src/server.rs
+++ b/crates/trusty-bm25-daemon/src/server.rs
@@ -33,11 +33,14 @@ use crate::protocol::{
 /// Why: extracted so the binary's startup sequence (cleanup → bind) is
 /// readable and so tests can exercise the same bind path against a tempfile
 /// socket.
-/// What: returns the `UnixListener` ready to accept connections. The caller
-/// must have already removed any stale socket file at `path`.
-/// Test: covered by the integration test.
+/// What: returns the `UnixListener` ready to accept connections, bound through
+/// [`trusty_common::uds::bind_hardened`] so the containing directory is `0700`
+/// and the socket `0600` before the first accept (#5099 — this bind used to be
+/// bare, leaving the socket at the process umask). The caller must have already
+/// removed any stale socket file at `path`.
+/// Test: `bind_listener_produces_a_0600_socket`, plus the integration test.
 pub fn bind_listener(path: &Path) -> Result<UnixListener> {
-    UnixListener::bind(path)
+    trusty_common::uds::bind_hardened(path)
         .with_context(|| format!("bind unix domain socket at {}", path.display()))
 }
 
@@ -46,13 +49,19 @@ pub fn bind_listener(path: &Path) -> Result<UnixListener> {
 /// Why: a single-threaded accept loop with detached per-connection tasks
 /// scales well for the daemon's expected load (a handful of in-host
 /// clients, short-lived requests) without the complexity of a thread pool.
-/// What: loops `listener.accept().await`; on each accept, clones the
-/// `BatchQueue` handle and spawns [`handle_connection`].
+/// What: loops `listener.accept().await`; on each accept, verifies the peer's
+/// uid matches this process's own (#5099), then clones the `BatchQueue` handle
+/// and spawns [`handle_connection`]. A foreign-uid peer is dropped without being
+/// served.
 /// Test: covered by the integration test.
 pub async fn run_accept_loop(listener: UnixListener, queue: Arc<BatchQueue>) {
     loop {
         match listener.accept().await {
             Ok((stream, _addr)) => {
+                if let Err(e) = trusty_common::uds::ensure_peer_is_self(&stream) {
+                    tracing::warn!("rejected UDS connection: {e}");
+                    continue;
+                }
                 let queue = Arc::clone(&queue);
                 tokio::spawn(async move {
                     if let Err(e) = handle_connection(stream, queue).await {
@@ -337,6 +346,25 @@ mod tests {
         // Keep the TempDir alive — `rebuild` and write batches flush the
         // on-disk snapshot, so the data dir must outlive the queue.
         (BatchQueue::new(index, BatchConfig::default()), dir)
+    }
+
+    /// #5099 regression: the daemon's own bind path must produce a 0600 socket
+    /// in a 0700 directory. Against the pre-fix commit this bind was bare and
+    /// the socket came back at the process umask (0755 under 022).
+    #[tokio::test]
+    async fn bind_listener_produces_a_0600_socket() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("sockets");
+        let sock = dir.join("bm25.sock");
+
+        let _listener = bind_listener(&sock).expect("bind");
+
+        let mode =
+            |p: &std::path::Path| std::fs::metadata(p).expect("stat").permissions().mode() & 0o777;
+        assert_eq!(mode(&sock), 0o600, "socket must be 0600");
+        assert_eq!(mode(&dir), 0o700, "socket dir must be 0700");
     }
 
     #[tokio::test]

--- a/crates/trusty-bm25-daemon/src/socket.rs
+++ b/crates/trusty-bm25-daemon/src/socket.rs
@@ -6,7 +6,7 @@
 //! logic keeps the two contracts identical.
 //!
 //! What: `default_socket_path(palace)` returns
-//! `$TMPDIR/trusty-bm25-<palace>.sock` (falling back to `/tmp` if `TMPDIR`
+//! `$TMPDIR/trusty-<uid>/trusty-bm25-<palace>.sock` (falling back to `/tmp`
 //! is unset or empty); `cleanup_stale_socket` best-effort removes the file
 //! at the given path, ignoring "not found".
 //!
@@ -61,17 +61,19 @@ pub fn sanitise_palace(palace: &str) -> String {
 /// `/var/folders/...`, while Linux servers usually leave `TMPDIR` unset and
 /// expect `/tmp`. Honouring the env var keeps the socket inside whatever
 /// scratch space the OS assigned the daemon.
-/// What: returns `<TMPDIR>/trusty-bm25-<palace>.sock`. If `TMPDIR` is
-/// unset, empty, or whitespace, falls back to `/tmp`. The palace fragment
-/// is sanitised via [`sanitise_palace`].
+/// What: returns `<$TMPDIR or /tmp>/trusty-<uid>/trusty-bm25-<palace>.sock`.
+/// The palace fragment is sanitised via [`sanitise_palace`].
+///
+/// #5099: the socket used to sit directly in `$TMPDIR`, falling back to `/tmp`.
+/// On a Linux host with `TMPDIR` unset that is world-writable and cannot be
+/// narrowed, so the uid-keyed subdirectory from
+/// [`trusty_common::uds::scratch_socket_dir`] is interposed and held at `0700`.
+/// This must stay byte-identical to `trusty_common::bm25_client`'s resolver —
+/// client and daemon have to agree on the path.
 /// Test: `default_socket_path_uses_tmpdir`.
 pub fn default_socket_path(palace: &str) -> PathBuf {
-    let dir = match std::env::var("TMPDIR") {
-        Ok(p) if !p.trim().is_empty() => PathBuf::from(p),
-        _ => PathBuf::from("/tmp"),
-    };
     let fname = format!("{SOCKET_PREFIX}{}{SOCKET_SUFFIX}", sanitise_palace(palace));
-    dir.join(fname)
+    trusty_common::uds::scratch_socket_dir().join(fname)
 }
 
 /// Best-effort remove a (possibly-stale) socket file before bind.

--- a/crates/trusty-bm25-daemon/tests/bm25_daemon.rs
+++ b/crates/trusty-bm25-daemon/tests/bm25_daemon.rs
@@ -135,7 +135,9 @@ async fn run_test_daemon(listener: UnixListener) {
 async fn end_to_end_index_then_search_via_client() {
     let tmp = tempfile::tempdir().unwrap();
     let socket_path = tmp.path().join("bm25.sock");
-    let listener = UnixListener::bind(&socket_path).expect("bind UDS");
+    // #5099: bind the way the real daemon does. A bare bind leaves the socket
+    // and its directory at the process umask, which `Bm25Client` now refuses.
+    let listener = trusty_common::uds::bind_hardened(&socket_path).expect("bind UDS");
     let daemon_handle = tokio::spawn(run_test_daemon(listener));
 
     tokio::time::sleep(Duration::from_millis(20)).await;
@@ -156,7 +158,9 @@ async fn end_to_end_index_then_search_via_client() {
 async fn end_to_end_delete_via_client() {
     let tmp = tempfile::tempdir().unwrap();
     let socket_path = tmp.path().join("bm25.sock");
-    let listener = UnixListener::bind(&socket_path).expect("bind UDS");
+    // #5099: bind the way the real daemon does. A bare bind leaves the socket
+    // and its directory at the process umask, which `Bm25Client` now refuses.
+    let listener = trusty_common::uds::bind_hardened(&socket_path).expect("bind UDS");
     let daemon_handle = tokio::spawn(run_test_daemon(listener));
 
     tokio::time::sleep(Duration::from_millis(20)).await;
@@ -175,7 +179,9 @@ async fn raw_protocol_smoke_test() {
     // Mirrors what a non-Rust consumer would send on the wire.
     let tmp = tempfile::tempdir().unwrap();
     let socket_path = tmp.path().join("bm25.sock");
-    let listener = UnixListener::bind(&socket_path).expect("bind UDS");
+    // #5099: bind the way the real daemon does. A bare bind leaves the socket
+    // and its directory at the process umask, which `Bm25Client` now refuses.
+    let listener = trusty_common::uds::bind_hardened(&socket_path).expect("bind UDS");
     let daemon_handle = tokio::spawn(run_test_daemon(listener));
 
     tokio::time::sleep(Duration::from_millis(20)).await;

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -214,8 +214,10 @@ aws-smithy-types = { workspace = true, optional = true }
 # reqwest, dirs, serde, serde_json, anyhow, tokio) are already unconditional.
 rusqlite = { workspace = true, optional = true }
 
-# launchd module is macOS-only and needs getuid(2) for the gui/<uid> domain.
-[target.'cfg(target_os = "macos")'.dependencies]
+# libc on every unix target: the macOS `launchd` module needs getuid(2) for the
+# gui/<uid> domain, and (#5099) the `uds` module needs getuid(2) plus
+# SO_PEERCRED / getpeereid on both macOS and Linux for peer-credential checks.
+[target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
 # Cross-platform direct ort dep for the `embedder` feature. Pinned to the
@@ -320,7 +322,13 @@ migrations = []
 # Enables the `bm25_client` module: a UDS JSON-RPC client for the per-palace
 # `trusty-bm25-daemon` subprocess (issue #156). Pure user of existing
 # `tokio` / `serde_json` / `anyhow` workspace deps — adds no new deps.
-bm25-client = []
+# Implies `uds` for the shared socket-path resolver (#5099).
+bm25-client = ["uds"]
+# Enables the `uds` module: the shared 0700-directory / 0600-socket /
+# peer-uid enforcement every UDS bind site routes through (issue #5099).
+# Pulls in `thiserror` (error enum) and uses the `libc` and `tokio` workspace
+# deps already required — adds no new dependencies to the lockfile.
+uds = ["dep:thiserror"]
 # Bundle the ONNX Runtime static libs via fastembed's
 # `ort-download-binaries-native-tls`. Right choice for macOS and modern
 # Linux (glibc ≥ 2.38). Mutually exclusive with `embedder-load-dynamic`
@@ -453,7 +461,7 @@ monitor-tui = ["dep:ratatui", "dep:crossterm"]
 # both the in-process and remote paths.
 # Note: module name is `embedder_client` (with `er`) to distinguish from the
 # existing `embed_client` (UDS, PR #157). Issue #164 will reconcile them.
-embedder-client = ["dep:thiserror", "embedder"]
+embedder-client = ["dep:thiserror", "embedder", "uds"]
 # Enables the `tickets` module: unified ticketing MCP server with GitHub,
 # JIRA, and Linear backends (absorbed from the former standalone `trusty-tickets`
 # crate). Pulls in `chrono`, `uuid`, `base64`, `thiserror`, and `toml` as

--- a/crates/trusty-common/changelog.d/5099-uds-socket-permissions-added.md
+++ b/crates/trusty-common/changelog.d/5099-uds-socket-permissions-added.md
@@ -25,3 +25,11 @@ Added
 - **`uds::check_sun_path_budget`** turns the kernel's bare `invalid argument`
   into a diagnostic naming the platform's `sun_path` capacity (104 on macOS, 108
   on Linux), the actual byte length, and the offending path.
+- **`UdsSecurityError` is `#[non_exhaustive]`.** It gained two variants across
+  two review rounds of this PR alone and will keep growing as the checks
+  tighten. The attribute is free while this crate is unpublished at 0.30.0
+  against a published 0.28.1, and stops being free once 0.30.0 ships — after
+  which each variant would be a break. On an enum it constrains matching only
+  (external crates need a wildcard arm), not construction; every in-tree
+  consumer converts the error rather than matching it, so nothing changed.
+  Matches `DedupError` (#5112) and `IndexOptions` (#5065).

--- a/crates/trusty-common/changelog.d/5099-uds-socket-permissions-added.md
+++ b/crates/trusty-common/changelog.d/5099-uds-socket-permissions-added.md
@@ -14,3 +14,14 @@ Added
   bits an enforced boundary rather than a documented intention. Gated behind a
   new `uds` feature, implied by `bm25-client` and `embedder-client`; adds no new
   dependency (`libc` moves from a macOS-only to a `cfg(unix)` target dependency).
+- **`uds::connect_hardened` — the dialer's half of the same contract.** Hardening
+  only the bind side left every client trusting whatever sat at the path: a
+  daemon predating the change still answers, and `Bm25Supervisor` adopts an
+  existing socket rather than spawning, so the daemon's own ownership check may
+  never run. `connect_hardened` refuses unless the containing directory is a
+  non-symlink `0700` directory owned by this uid and the socket is a non-symlink
+  socket owned by this uid at `0600`. `bm25_client` and `UdsEmbedderClient` now
+  dial through it.
+- **`uds::check_sun_path_budget`** turns the kernel's bare `invalid argument`
+  into a diagnostic naming the platform's `sun_path` capacity (104 on macOS, 108
+  on Linux), the actual byte length, and the offending path.

--- a/crates/trusty-common/changelog.d/5099-uds-socket-permissions-added.md
+++ b/crates/trusty-common/changelog.d/5099-uds-socket-permissions-added.md
@@ -14,18 +14,3 @@ Added
   bits an enforced boundary rather than a documented intention. Gated behind a
   new `uds` feature, implied by `bm25-client` and `embedder-client`; adds no new
   dependency (`libc` moves from a macOS-only to a `cfg(unix)` target dependency).
-
-Changed
-
-- **BM25 and embedder sockets move into a per-uid directory**
-  ([#5099](https://github.com/bobmatnyc/trusty-tools/issues/5099)).
-  `bm25_client::socket_path_for_palace` and `UdsEmbedderClient::default_path`
-  resolved to `$TMPDIR`, falling back to `/tmp` when `TMPDIR` was unset — mode
-  `1777` and owned by root on a Linux host, so the socket was reachable by every
-  local user and the directory could be neither narrowed nor trusted. Both now
-  resolve under `uds::scratch_socket_dir()` — `<$TMPDIR or /tmp>/trusty-<uid>` —
-  which the daemon holds at `0700`. **A running daemon must be restarted to be
-  found at the new path**; the client and daemon resolvers changed together.
-  The extra path segment costs 11 bytes of the kernel's `sun_path` budget (104
-  on macOS, where `$TMPDIR` alone is ~50), narrowing the usable palace-name
-  length from roughly 37 characters to roughly 26.

--- a/crates/trusty-common/changelog.d/5099-uds-socket-permissions-changed.md
+++ b/crates/trusty-common/changelog.d/5099-uds-socket-permissions-changed.md
@@ -1,0 +1,14 @@
+Changed
+
+- **BM25 and embedder sockets move into a per-uid directory**
+  ([#5099](https://github.com/bobmatnyc/trusty-tools/issues/5099)).
+  `bm25_client::socket_path_for_palace` and `UdsEmbedderClient::default_path`
+  resolved to `$TMPDIR`, falling back to `/tmp` when `TMPDIR` was unset — mode
+  `1777` and owned by root on a Linux host, so the socket was reachable by every
+  local user and the directory could be neither narrowed nor trusted. Both now
+  resolve under `uds::scratch_socket_dir()` — `<$TMPDIR or /tmp>/trusty-<uid>` —
+  which the daemon holds at `0700`. **A running daemon must be restarted to be
+  found at the new path**; the client and daemon resolvers changed together.
+  The extra path segment costs 11 bytes of the kernel's `sun_path` budget (104
+  on macOS, where `$TMPDIR` alone is ~50), narrowing the usable palace-name
+  length from roughly 37 characters to roughly 26.

--- a/crates/trusty-common/changelog.d/5099-uds-socket-permissions-fixed.md
+++ b/crates/trusty-common/changelog.d/5099-uds-socket-permissions-fixed.md
@@ -1,0 +1,15 @@
+Fixed
+
+- **`prepare_socket_dir` followed symlinks, which defeated the whole scheme**
+  ([#5099](https://github.com/bobmatnyc/trusty-tools/issues/5099) review finding
+  1). `std::fs::metadata` and `set_permissions` both resolve links, so when the
+  socket directory already existed as a symlink the owner and mode checks read
+  the *target's* inode and the chmod retargeted it. An attacker who pre-created
+  `trusty-<uid>` as a link to any directory the running user owns passed the
+  ownership check outright — verified on macOS: `mkdir` returned `EEXIST`,
+  `metadata()` reported uid 502 / mode 0777 from the target, and
+  `set_permissions` chmod'd the target to 0700. Directory verification now uses
+  `symlink_metadata` and refuses a symlink before considering owner or mode. The
+  residual post-check swap race is not closed — it needs `openat`/`fchmod` on a
+  directory fd, and `/tmp`'s sticky bit makes it impractical — and the module
+  documentation now states that boundary instead of claiming more than it holds.

--- a/crates/trusty-common/changelog.d/5099-uds-socket-permissions-fixed.md
+++ b/crates/trusty-common/changelog.d/5099-uds-socket-permissions-fixed.md
@@ -13,3 +13,14 @@ Fixed
   residual post-check swap race is not closed — it needs `openat`/`fchmod` on a
   directory fd, and `/tmp`'s sticky bit makes it impractical — and the module
   documentation now states that boundary instead of claiming more than it holds.
+- **A non-directory at the socket-directory path got chmod'd to `0700`.**
+  `classify_existing_dir` asserted symlink and ownership but never the file
+  type, so a regular file owned by this uid was classified `Narrow`, had its
+  mode rewritten, and only then failed `ENOTDIR` at `bind` — mangling a file
+  this process did not create and naming neither the cause nor what was
+  actually there. It now refuses with `NotADirectory`, which reports the type
+  `lstat` found, before anything can chmod it. Both `prepare_socket_dir` and
+  `connect_hardened` apply the check.
+- **A dialer reported "create socket directory …" while creating nothing.** A
+  failed `symlink_metadata` on the connect path mapped to `CreateDir`; it now
+  uses a dedicated `StatForConnect` variant.

--- a/crates/trusty-common/changelog.d/5099-uds-socket-permissions.md
+++ b/crates/trusty-common/changelog.d/5099-uds-socket-permissions.md
@@ -1,0 +1,31 @@
+Added
+
+- **New `uds` module: the `0600` socket permission ADR-0031 and ADR-0032 both
+  cite as an existing property** ([#5099](https://github.com/bobmatnyc/trusty-tools/issues/5099)).
+  No production code in the workspace set permissions on any socket — every
+  `set_permissions` / `PermissionsExt` hit was a test fixture — so sockets were
+  created at the process umask (commonly `0755`). `uds::bind_hardened` is the
+  single entry point every bind site now routes through: it creates the
+  containing directory at `0700` via `DirBuilder::mode()` (passed to `mkdir(2)`,
+  so the directory is never observable at a wider mode) and narrows the socket
+  to `0600` before the caller's first `accept`. `uds::ensure_peer_is_self`
+  refuses any connection whose uid is not this process's own, via `SO_PEERCRED`
+  on Linux and `getpeereid` on macOS/BSD, which is what makes the permission
+  bits an enforced boundary rather than a documented intention. Gated behind a
+  new `uds` feature, implied by `bm25-client` and `embedder-client`; adds no new
+  dependency (`libc` moves from a macOS-only to a `cfg(unix)` target dependency).
+
+Changed
+
+- **BM25 and embedder sockets move into a per-uid directory**
+  ([#5099](https://github.com/bobmatnyc/trusty-tools/issues/5099)).
+  `bm25_client::socket_path_for_palace` and `UdsEmbedderClient::default_path`
+  resolved to `$TMPDIR`, falling back to `/tmp` when `TMPDIR` was unset — mode
+  `1777` and owned by root on a Linux host, so the socket was reachable by every
+  local user and the directory could be neither narrowed nor trusted. Both now
+  resolve under `uds::scratch_socket_dir()` — `<$TMPDIR or /tmp>/trusty-<uid>` —
+  which the daemon holds at `0700`. **A running daemon must be restarted to be
+  found at the new path**; the client and daemon resolvers changed together.
+  The extra path segment costs 11 bytes of the kernel's `sun_path` budget (104
+  on macOS, where `$TMPDIR` alone is ~50), narrowing the usable palace-name
+  length from roughly 37 characters to roughly 26.

--- a/crates/trusty-common/src/bm25_client.rs
+++ b/crates/trusty-common/src/bm25_client.rs
@@ -24,7 +24,6 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::UnixStream;
 
 /// JSON-RPC protocol version string. Must match the daemon's expectation.
 const JSONRPC_VERSION: &str = "2.0";

--- a/crates/trusty-common/src/bm25_client.rs
+++ b/crates/trusty-common/src/bm25_client.rs
@@ -354,7 +354,11 @@ impl Bm25Client {
         method: &'static str,
         params: &P,
     ) -> Result<R> {
-        let stream = UnixStream::connect(&self.socket_path)
+        // #5099: verify the directory and socket before trusting them. A daemon
+        // predating the hardening still answers at this path, and the
+        // supervisor adopts an existing socket rather than spawning, so the
+        // daemon's own checks may never run.
+        let stream = crate::uds::connect_hardened(&self.socket_path)
             .await
             .with_context(|| {
                 format!(

--- a/crates/trusty-common/src/bm25_client.rs
+++ b/crates/trusty-common/src/bm25_client.rs
@@ -94,17 +94,18 @@ pub fn is_method_not_found(err: &anyhow::Error) -> bool {
 /// Why: callers (the client, the daemon's startup, and operators reading
 /// `lsof`) must all agree on where the per-palace socket lives. Keying the
 /// filename by palace name keeps multiple palaces isolated from each other.
-/// What: `$TMPDIR/trusty-bm25-<palace>.sock`. Falls back to `/tmp` when
-/// `TMPDIR` is unset, empty, or whitespace. The palace name is taken
-/// verbatim — callers are expected to have sanitised it already (the palace
-/// id is already kebab-case / underscore-safe).
+/// What: `<$TMPDIR or /tmp>/trusty-<uid>/trusty-bm25-<palace>.sock`. The palace
+/// name is taken verbatim — callers are expected to have sanitised it already
+/// (the palace id is already kebab-case / underscore-safe).
+///
+/// #5099: the socket used to sit directly in `$TMPDIR`, falling back to `/tmp`.
+/// On a Linux host with `TMPDIR` unset that is a world-writable directory that
+/// cannot be narrowed, so the uid-keyed subdirectory from
+/// [`crate::uds::scratch_socket_dir`] is interposed and held at `0700`.
+///
 /// Test: `socket_path_uses_tmpdir_and_palace_name`.
 pub fn socket_path_for_palace(palace: &str) -> PathBuf {
-    let dir = match std::env::var("TMPDIR") {
-        Ok(p) if !p.trim().is_empty() => PathBuf::from(p),
-        _ => PathBuf::from("/tmp"),
-    };
-    dir.join(format!("trusty-bm25-{palace}.sock"))
+    crate::uds::scratch_socket_dir().join(format!("trusty-bm25-{palace}.sock"))
 }
 
 /// One BM25 search hit returned by the daemon.
@@ -521,7 +522,13 @@ mod tests {
             fname.ends_with(".sock"),
             "filename must end with .sock: {fname}"
         );
-        assert!(p.parent().is_some());
+        // #5099: the parent must be the uid-keyed directory the daemon holds
+        // at 0700, not a bare `$TMPDIR` (or worse, a world-writable `/tmp`).
+        assert_eq!(
+            p.parent(),
+            Some(crate::uds::scratch_socket_dir().as_path()),
+            "socket must live in the per-uid scratch socket directory"
+        );
     }
 
     #[test]

--- a/crates/trusty-common/src/embedder_client/uds.rs
+++ b/crates/trusty-common/src/embedder_client/uds.rs
@@ -25,7 +25,6 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::UnixStream;
 
 use super::{EmbedderClient, EmbedderError};
 

--- a/crates/trusty-common/src/embedder_client/uds.rs
+++ b/crates/trusty-common/src/embedder_client/uds.rs
@@ -117,19 +117,20 @@ impl UdsEmbedderClient {
         }
     }
 
-    /// Default socket path under `$TMPDIR` (or `/tmp` if unset).
+    /// Default socket path in the per-uid scratch socket directory.
     ///
     /// Why: matches `trusty-embedderd`'s own default socket path so callers
     /// can construct a client with no explicit configuration.
-    /// What: returns `<TMPDIR>/trusty-embedderd.sock`. Falls back to `/tmp`
-    /// when `TMPDIR` is unset or empty (typical on Linux servers).
+    /// What: returns `<$TMPDIR or /tmp>/trusty-<uid>/trusty-embedderd.sock`.
+    ///
+    /// #5099: the socket used to sit directly in `$TMPDIR`, falling back to a
+    /// world-writable `/tmp` when `TMPDIR` was unset. The uid-keyed
+    /// subdirectory from [`crate::uds::scratch_socket_dir`] is what the daemon
+    /// can hold at `0700`.
+    ///
     /// Test: `default_socket_path_uses_tmpdir`.
     pub fn default_path() -> PathBuf {
-        let dir = match std::env::var("TMPDIR") {
-            Ok(p) if !p.trim().is_empty() => PathBuf::from(p),
-            _ => PathBuf::from("/tmp"),
-        };
-        dir.join(SOCKET_FILENAME)
+        crate::uds::scratch_socket_dir().join(SOCKET_FILENAME)
     }
 
     /// The socket path this client is configured to use.
@@ -326,7 +327,13 @@ mod tests {
             Some(SOCKET_FILENAME),
             "default path must end with {SOCKET_FILENAME}"
         );
-        assert!(p.parent().is_some(), "must have a parent directory");
+        // #5099: the parent must be the uid-keyed directory the daemon holds
+        // at 0700, not a bare `$TMPDIR` (or worse, a world-writable `/tmp`).
+        assert_eq!(
+            p.parent(),
+            Some(crate::uds::scratch_socket_dir().as_path()),
+            "default path must live in the per-uid scratch socket directory"
+        );
     }
 
     #[test]

--- a/crates/trusty-common/src/embedder_client/uds.rs
+++ b/crates/trusty-common/src/embedder_client/uds.rs
@@ -182,12 +182,15 @@ impl EmbedderClient for UdsEmbedderClient {
         // Open a fresh connection. UDS connect on a local socket is typically
         // sub-millisecond, so the simplicity of one-connection-per-call is
         // justified in Phase 1.
-        let stream = UnixStream::connect(&self.socket_path).await.map_err(|e| {
-            EmbedderError::Uds(format!(
-                "connect to {} failed: {e}",
-                self.socket_path.display()
-            ))
-        })?;
+        // #5099: verify the directory and socket before trusting them.
+        let stream = crate::uds::connect_hardened(&self.socket_path)
+            .await
+            .map_err(|e| {
+                EmbedderError::Uds(format!(
+                    "connect to {} failed: {e}",
+                    self.socket_path.display()
+                ))
+            })?;
         let (read_half, mut write_half) = stream.into_split();
 
         // Build and send the request frame.

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -738,7 +738,11 @@ pub mod health_probe;
 /// [`uds::prepare_socket_dir`], [`uds::scratch_socket_dir`] (the per-uid
 /// replacement for the `$TMPDIR`-with-`/tmp`-fallback convention), and
 /// [`uds::ensure_peer_is_self`] (`SO_PEERCRED` / `getpeereid`).
-/// Test: `cargo test -p trusty-common -- uds::`.
+/// Test: `cargo test -p trusty-common --features uds uds::` — the `--features`
+/// flag is load-bearing. `uds` is not a default feature, so the bare
+/// `-p trusty-common` form compiles the module out and reports 0 tests run
+/// while exiting 0. CI's `cargo test --workspace` enables it via feature
+/// unification from `trusty-embedderd` and `trusty-bm25-daemon`.
 #[cfg(all(unix, feature = "uds"))]
 pub mod uds;
 

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -727,6 +727,21 @@ pub mod daemon_addr;
 /// Test: covered via daemon_addr integration tests.
 pub mod health_probe;
 
+/// Unix-domain-socket permission enforcement (issue #5099).
+///
+/// Why: ADR-0031 and ADR-0032 both argue for UDS over loopback TCP on the
+/// strength of a `0600` socket, and no production code created one — every
+/// `set_permissions` hit in the workspace was a test fixture. Four bind sites
+/// each called `UnixListener::bind` bare. This is the single entry point they
+/// now share, so the permission contract cannot drift between them.
+/// What: Exposes [`uds::bind_hardened`] (`0700` directory, `0600` socket),
+/// [`uds::prepare_socket_dir`], [`uds::scratch_socket_dir`] (the per-uid
+/// replacement for the `$TMPDIR`-with-`/tmp`-fallback convention), and
+/// [`uds::ensure_peer_is_self`] (`SO_PEERCRED` / `getpeereid`).
+/// Test: `cargo test -p trusty-common -- uds::`.
+#[cfg(all(unix, feature = "uds"))]
+pub mod uds;
+
 /// Global tracing subscriber initialisation helpers.
 ///
 /// Why: Every trusty-* binary needs the same verbosity ladder, `RUST_LOG`

--- a/crates/trusty-common/src/uds/dir.rs
+++ b/crates/trusty-common/src/uds/dir.rs
@@ -1,0 +1,167 @@
+//! Socket-directory creation and verification.
+//!
+//! Why: the containing directory — not the socket's own mode — is what makes a
+//! socket unreachable to another uid, because Unix path resolution requires
+//! search permission on every component. Getting the directory right is
+//! therefore the whole security argument, and it is the part with the sharp
+//! edge: `std::fs::metadata` and `set_permissions` both FOLLOW SYMLINKS, so a
+//! naive owner+mode check reads the wrong inode when an attacker pre-creates
+//! the path as a link (#5099 review finding 1).
+//!
+//! What: [`prepare_socket_dir`] creates the directory at `0700` atomically, or
+//! — when it already exists — refuses a symlink outright and verifies owner and
+//! mode on the directory itself. [`classify_existing_dir`] is the pure decision
+//! function behind that verification, so every refusal is testable without root.
+//!
+//! Test: `tests.rs` — `classify_existing_dir_*` for the decisions,
+//! `prepare_socket_dir_*` for the filesystem behavior including
+//! `prepare_socket_dir_rejects_a_symlink`.
+
+use std::fs::{DirBuilder, Permissions};
+use std::io;
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+use std::path::Path;
+
+use super::{SOCKET_DIR_MODE, UdsSecurityError, peer::self_uid};
+
+/// What [`prepare_socket_dir`] must do about a directory that already exists.
+///
+/// Why: separating the decision from the syscalls makes the refusal paths —
+/// which otherwise need root or a second uid to reach — testable unprivileged.
+/// Test: the `classify_existing_dir_*` tests.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum DirVerdict {
+    /// Owner and mode are already correct; nothing to do.
+    Accept,
+    /// Owner is correct but the mode is wider than `0700`; narrow it.
+    Narrow,
+}
+
+/// Decide whether a pre-existing socket directory is usable, as a pure function.
+///
+/// Why: the three refusal paths (symlink, foreign owner, unnarrowable mode) are
+/// the security-critical ones and the hardest to reach from a test — a symlink
+/// swap needs a race, a foreign owner needs root. Taking the `lstat` results as
+/// plain arguments makes each decision assertable directly (#5099 review
+/// finding 5).
+///
+/// What: rejects a symlink before anything else — this is the fix for the
+/// review's finding 1, where `metadata()` on a symlinked directory reported the
+/// *target's* uid and mode, so a link pointing at any directory the running
+/// user happens to own passed the owner check and `set_permissions` then
+/// chmod'd the target. Then rejects a foreign owner, then reports whether the
+/// mode needs narrowing.
+///
+/// `is_symlink`, `owner`, and `mode` must come from `symlink_metadata` (i.e.
+/// `lstat`), never `metadata` — passing followed values reintroduces the bug
+/// this function exists to prevent.
+///
+/// Test: `classify_existing_dir_rejects_a_symlink`,
+/// `classify_existing_dir_rejects_a_foreign_owner`,
+/// `classify_existing_dir_narrows_a_wide_dir`,
+/// `classify_existing_dir_accepts_an_already_correct_dir`.
+pub(crate) fn classify_existing_dir(
+    path: &Path,
+    is_symlink: bool,
+    owner: u32,
+    mode: u32,
+    own_uid: u32,
+) -> Result<DirVerdict, UdsSecurityError> {
+    if is_symlink {
+        return Err(UdsSecurityError::SymlinkDir {
+            path: path.to_path_buf(),
+        });
+    }
+    if owner != own_uid {
+        return Err(UdsSecurityError::ForeignDirOwner {
+            path: path.to_path_buf(),
+            owner,
+            expected: own_uid,
+        });
+    }
+    if mode & 0o777 == SOCKET_DIR_MODE {
+        Ok(DirVerdict::Accept)
+    } else {
+        Ok(DirVerdict::Narrow)
+    }
+}
+
+/// Create `dir` at [`SOCKET_DIR_MODE`], or verify and repair it if it exists.
+///
+/// Why: this is what closes the bind-then-chmod window. Binding a Unix socket
+/// creates the file, so a `chmod` after `bind` leaves an interval in which the
+/// socket exists at the umask-derived mode. A caller cannot shrink that
+/// interval to zero, and the obvious alternative — setting the process umask
+/// around the bind — is process-global and therefore racy under a
+/// multi-threaded tokio runtime, where a sibling thread creating an unrelated
+/// file would silently inherit it. Holding the *directory* at `0700` before the
+/// socket is created removes the exposure instead of narrowing it: path
+/// resolution requires search permission on every component, so no other uid
+/// can traverse to the socket at any point, including during the window.
+///
+/// What: creates `dir` with the mode passed to `mkdir(2)`, which is atomic —
+/// unlike `create_dir_all` followed by `set_permissions`, which reproduces the
+/// same ordering bug one level up. Ancestors are created with the default mode
+/// because only the leaf holds sockets. If `dir` already exists, its `lstat`
+/// results go through [`classify_existing_dir`]: a symlink is refused, a
+/// foreign owner is refused, and a wider mode is narrowed.
+///
+/// **Residual race, deliberately not chased:** an attacker who can write to the
+/// parent could in principle swap the directory for a symlink between the
+/// `lstat` and the `chmod`. Under `/tmp`'s sticky bit that is impractical (only
+/// the owner may rename or unlink an entry), and closing it properly needs
+/// `openat`/`fchmod` on a directory fd. Rejecting symlinks removes the
+/// pre-created-link attack, which is the practical one.
+///
+/// Test: `prepare_socket_dir_creates_at_0700`,
+/// `prepare_socket_dir_narrows_a_wide_existing_dir`,
+/// `prepare_socket_dir_rejects_a_symlink`, `prepare_socket_dir_is_idempotent`.
+pub fn prepare_socket_dir(dir: &Path) -> Result<(), UdsSecurityError> {
+    // `Path::parent` yields `Some("")` for a bare relative name; `create_dir_all`
+    // on an empty path fails, so filter it out rather than branching twice.
+    if let Some(parent) = dir.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent).map_err(|source| UdsSecurityError::CreateDir {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+
+    // #5099: mkdir(2) applies the mode atomically, so the directory is never
+    // observable at a wider mode. `create_dir_all` + `set_permissions` is not
+    // an acceptable substitute here.
+    match DirBuilder::new().mode(SOCKET_DIR_MODE).create(dir) {
+        Ok(()) => return Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {}
+        Err(source) => {
+            return Err(UdsSecurityError::CreateDir {
+                path: dir.to_path_buf(),
+                source,
+            });
+        }
+    }
+
+    // #5099 review finding 1: `symlink_metadata` (lstat), NOT `metadata` —
+    // the latter follows the link and reports the target's owner and mode.
+    let meta = std::fs::symlink_metadata(dir).map_err(|source| UdsSecurityError::CreateDir {
+        path: dir.to_path_buf(),
+        source,
+    })?;
+    let verdict = classify_existing_dir(
+        dir,
+        meta.file_type().is_symlink(),
+        meta.uid(),
+        meta.permissions().mode(),
+        self_uid(),
+    )?;
+
+    if verdict == DirVerdict::Narrow {
+        std::fs::set_permissions(dir, Permissions::from_mode(SOCKET_DIR_MODE)).map_err(
+            |source| UdsSecurityError::HardenDir {
+                path: dir.to_path_buf(),
+                mode: SOCKET_DIR_MODE,
+                source,
+            },
+        )?;
+    }
+    Ok(())
+}

--- a/crates/trusty-common/src/uds/dir.rs
+++ b/crates/trusty-common/src/uds/dir.rs
@@ -24,6 +24,32 @@ use std::path::Path;
 
 use super::{SOCKET_DIR_MODE, UdsSecurityError, peer::self_uid};
 
+/// Name the file type an `lstat` found, for a diagnostic that says what is
+/// actually there rather than only what was expected.
+///
+/// Test: `classify_existing_dir_rejects_a_regular_file` asserts the rendered
+/// message names the type.
+pub(crate) fn describe_file_type(ft: &std::fs::FileType) -> &'static str {
+    use std::os::unix::fs::FileTypeExt as _;
+    if ft.is_dir() {
+        "directory"
+    } else if ft.is_file() {
+        "regular file"
+    } else if ft.is_symlink() {
+        "symlink"
+    } else if ft.is_socket() {
+        "socket"
+    } else if ft.is_fifo() {
+        "fifo"
+    } else if ft.is_block_device() {
+        "block device"
+    } else if ft.is_char_device() {
+        "character device"
+    } else {
+        "unknown file type"
+    }
+}
+
 /// What [`prepare_socket_dir`] must do about a directory that already exists.
 ///
 /// Why: separating the decision from the syscalls makes the refusal paths —
@@ -52,17 +78,27 @@ pub(crate) enum DirVerdict {
 /// chmod'd the target. Then rejects a foreign owner, then reports whether the
 /// mode needs narrowing.
 ///
-/// `is_symlink`, `owner`, and `mode` must come from `symlink_metadata` (i.e.
-/// `lstat`), never `metadata` — passing followed values reintroduces the bug
-/// this function exists to prevent.
+/// The file-type assertion comes second, before ownership. Without it a regular
+/// file owned by this uid at the socket-dir path passed both remaining checks,
+/// was classified [`DirVerdict::Narrow`], and got chmod'd to `0700` before
+/// `bind` failed `ENOTDIR` — mangling the mode of a file this process did not
+/// create, and reporting neither the cause nor what it actually found
+/// (#5099 review round 2, finding 1).
+///
+/// `is_symlink`, `is_dir`, `owner`, and `mode` must come from
+/// `symlink_metadata` (i.e. `lstat`), never `metadata` — passing followed values
+/// reintroduces the bug this function exists to prevent.
 ///
 /// Test: `classify_existing_dir_rejects_a_symlink`,
+/// `classify_existing_dir_rejects_a_regular_file`,
 /// `classify_existing_dir_rejects_a_foreign_owner`,
 /// `classify_existing_dir_narrows_a_wide_dir`,
 /// `classify_existing_dir_accepts_an_already_correct_dir`.
 pub(crate) fn classify_existing_dir(
     path: &Path,
     is_symlink: bool,
+    is_dir: bool,
+    found: &str,
     owner: u32,
     mode: u32,
     own_uid: u32,
@@ -70,6 +106,12 @@ pub(crate) fn classify_existing_dir(
     if is_symlink {
         return Err(UdsSecurityError::SymlinkDir {
             path: path.to_path_buf(),
+        });
+    }
+    if !is_dir {
+        return Err(UdsSecurityError::NotADirectory {
+            path: path.to_path_buf(),
+            found: found.to_string(),
         });
     }
     if owner != own_uid {
@@ -104,7 +146,8 @@ pub(crate) fn classify_existing_dir(
 /// same ordering bug one level up. Ancestors are created with the default mode
 /// because only the leaf holds sockets. If `dir` already exists, its `lstat`
 /// results go through [`classify_existing_dir`]: a symlink is refused, a
-/// foreign owner is refused, and a wider mode is narrowed.
+/// non-directory is refused before anything can chmod it, a foreign owner is
+/// refused, and a wider mode is narrowed.
 ///
 /// **Residual race, deliberately not chased:** an attacker who can write to the
 /// parent could in principle swap the directory for a symlink between the
@@ -115,7 +158,9 @@ pub(crate) fn classify_existing_dir(
 ///
 /// Test: `prepare_socket_dir_creates_at_0700`,
 /// `prepare_socket_dir_narrows_a_wide_existing_dir`,
-/// `prepare_socket_dir_rejects_a_symlink`, `prepare_socket_dir_is_idempotent`.
+/// `prepare_socket_dir_rejects_a_symlink`,
+/// `prepare_socket_dir_rejects_a_regular_file_without_chmodding_it`,
+/// `prepare_socket_dir_is_idempotent`.
 pub fn prepare_socket_dir(dir: &Path) -> Result<(), UdsSecurityError> {
     // `Path::parent` yields `Some("")` for a bare relative name; `create_dir_all`
     // on an empty path fails, so filter it out rather than branching twice.
@@ -146,9 +191,12 @@ pub fn prepare_socket_dir(dir: &Path) -> Result<(), UdsSecurityError> {
         path: dir.to_path_buf(),
         source,
     })?;
+    let ftype = meta.file_type();
     let verdict = classify_existing_dir(
         dir,
-        meta.file_type().is_symlink(),
+        ftype.is_symlink(),
+        ftype.is_dir(),
+        describe_file_type(&ftype),
         meta.uid(),
         meta.permissions().mode(),
         self_uid(),

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -72,7 +72,19 @@ pub const SOCKET_MODE: u32 = 0o600;
 /// trusted. Every variant is fatal to the operation — none is a "log and
 /// continue" condition, because continuing would use a socket wider than the
 /// ADRs promise.
+///
+/// `#[non_exhaustive]`: this enum gained two variants across two review rounds
+/// of #5099 alone, so it will keep growing as the checks tighten. The attribute
+/// costs nothing while `trusty-common` sits unpublished at 0.30.0 against a
+/// published 0.28.1, and stops being free the moment 0.30.0 ships — after which
+/// each new variant would be a breaking change. On an enum it constrains
+/// *matching* only (external crates need a wildcard arm); it does not bar
+/// constructing variants, which is the separate effect the attribute has on a
+/// struct. Matching this exhaustively from outside `trusty-common` was never
+/// possible anyway — every consumer converts it (`io::Error::other`, `?` into
+/// `anyhow`, or `Display` in a log) rather than inspecting variants.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum UdsSecurityError {
     /// The socket path is a bare filename with no directory component, so
     /// there is nothing to harden.

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -1,0 +1,305 @@
+//! Permission enforcement for Unix-domain sockets — the `0600` guarantee
+//! ADR-0031 and ADR-0032 cite as an existing property.
+//!
+//! Why: both ADRs rest their case for UDS-over-loopback-TCP on "a loopback
+//! port is reachable by any local process, a `0600` socket is not". Until
+//! #5099 no production code in this workspace called `set_permissions` on any
+//! socket — every hit was a test fixture. Sockets were created at the process
+//! umask (commonly `0755`) and two of the three path conventions placed them
+//! in `$TMPDIR` falling back to a shared, world-writable `/tmp`. This module
+//! makes the claimed guarantee real, in one place, so a behavior fix lands
+//! once rather than at four bind sites.
+//!
+//! What: three primitives, in the order a daemon uses them.
+//!   - [`scratch_socket_dir`] resolves a per-uid directory under the system
+//!     scratch space, replacing the bare `$TMPDIR`-with-`/tmp`-fallback.
+//!   - [`bind_hardened`] creates that directory at `0700`, binds, and sets the
+//!     socket to `0600` before returning it to the caller.
+//!   - [`ensure_peer_is_self`] refuses an accepted connection whose peer uid is
+//!     not this process's own, which is what turns the permission bits into an
+//!     enforced boundary rather than a documented intention.
+//!
+//! Deliberately not a transport: there is no framing, dialing, or JSON-RPC
+//! here. #5089 step 1 builds the shared UDS transport module; this is the
+//! security layer that module mounts, not a competing implementation of it.
+//!
+//! Test: `tests.rs` — directory and socket modes after a real bind, the
+//! pre-existing-wide-directory repair path, the foreign-owner refusal, and the
+//! same-uid peer accept. Cross-uid rejection is `#[ignore]`d (needs two uids).
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;
+
+mod peer;
+
+pub use peer::{ensure_peer_is_self, peer_uid, self_uid};
+
+use std::fs::{DirBuilder, Permissions};
+use std::io;
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+
+use tokio::net::UnixListener;
+
+/// Mode every socket-bearing directory is created at and verified against.
+///
+/// Owner-only `rwx`. Unix path resolution needs search (`x`) permission on
+/// every directory component, so a `0700` directory makes every socket inside
+/// it unreachable to any other uid regardless of the socket's own mode.
+pub const SOCKET_DIR_MODE: u32 = 0o700;
+
+/// Mode every bound socket is set to before its first `accept`.
+pub const SOCKET_MODE: u32 = 0o600;
+
+/// Failures that mean a socket could not be made private. Every variant is
+/// fatal to the bind — none is a "log and continue" condition, because
+/// continuing would leave a socket wider than the ADRs promise.
+#[derive(Debug, thiserror::Error)]
+pub enum UdsSecurityError {
+    /// The socket path is a bare filename with no directory component, so
+    /// there is nothing to harden.
+    #[error("socket path {path} has no parent directory to harden")]
+    NoParent {
+        /// The offending socket path.
+        path: PathBuf,
+    },
+
+    /// Creating the socket directory failed.
+    #[error("create socket directory {path}: {source}")]
+    CreateDir {
+        /// Directory that could not be created.
+        path: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: io::Error,
+    },
+
+    /// The directory already existed but belongs to a different uid. Repairing
+    /// its mode would not make it safe — another user controls its contents —
+    /// so this fails closed instead.
+    #[error("socket directory {path} is owned by uid {owner}, not {expected}")]
+    ForeignDirOwner {
+        /// Directory whose ownership was rejected.
+        path: PathBuf,
+        /// uid that actually owns it.
+        owner: u32,
+        /// uid this process runs as.
+        expected: u32,
+    },
+
+    /// The directory existed at a wider mode and could not be narrowed.
+    #[error("narrow socket directory {path} to {mode:04o}: {source}")]
+    HardenDir {
+        /// Directory that could not be narrowed.
+        path: PathBuf,
+        /// Mode that was being applied.
+        mode: u32,
+        /// Underlying OS error.
+        #[source]
+        source: io::Error,
+    },
+
+    /// `UnixListener::bind` failed.
+    #[error("bind unix socket at {path}: {source}")]
+    Bind {
+        /// Socket path that could not be bound.
+        path: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: io::Error,
+    },
+
+    /// The socket bound but could not be narrowed to [`SOCKET_MODE`].
+    #[error("narrow socket {path} to {mode:04o}: {source}")]
+    Chmod {
+        /// Socket that could not be narrowed.
+        path: PathBuf,
+        /// Mode that was being applied.
+        mode: u32,
+        /// Underlying OS error.
+        #[source]
+        source: io::Error,
+    },
+
+    /// Reading the connected peer's credentials failed.
+    #[error("read peer credentials: {source}")]
+    PeerCred {
+        /// Underlying OS error.
+        #[source]
+        source: io::Error,
+    },
+
+    /// The connected peer runs as a different uid.
+    #[error("refused connection from uid {peer}; this process runs as uid {expected}")]
+    ForeignPeer {
+        /// uid on the other end of the connection.
+        peer: u32,
+        /// uid this process runs as.
+        expected: u32,
+    },
+
+    /// No peer-credential syscall is wired up for this target.
+    #[error("peer-credential checks are not implemented for this platform")]
+    UnsupportedPlatform,
+}
+
+/// Per-uid directory under the system scratch space for daemon sockets.
+///
+/// Why: the convention this replaces was `$TMPDIR`, falling back to `/tmp`.
+/// On macOS `$TMPDIR` is a per-user `/var/folders/…/T/` that is already
+/// `0700`, so the fallback never bit there. On a Linux host with `TMPDIR`
+/// unset it resolved to `/tmp` — mode `1777`, owned by root — which can be
+/// neither narrowed to `0700` nor trusted, so any socket in it was reachable
+/// by every local user. Interposing a uid-keyed subdirectory gives a directory
+/// this process owns and can hold at `0700` on both platforms uniformly.
+///
+/// What: `<$TMPDIR or /tmp>/trusty-<uid>`. The name is kept short on purpose:
+/// `sun_path` is 104 bytes on macOS and macOS' `$TMPDIR` already consumes
+/// roughly half of that, so every byte here comes out of the budget available
+/// to palace names (see `trusty-memory`'s `bm25_supervisor_concurrency` tests).
+///
+/// Test: `scratch_socket_dir_is_uid_keyed`; the `$TMPDIR` resolution rules are
+/// asserted against [`scratch_socket_dir_from`] so no test has to mutate the
+/// process-global `TMPDIR` (which reddens unrelated sibling tests — see the
+/// `trusty-mpm` `tmpdir-cross-test-pollution` fragment).
+pub fn scratch_socket_dir() -> PathBuf {
+    scratch_socket_dir_from(std::env::var("TMPDIR").ok().as_deref(), self_uid())
+}
+
+/// [`scratch_socket_dir`] with its two environment inputs passed explicitly.
+///
+/// Why: keeps the resolution rules unit-testable without `set_var`. A test
+/// that mutates `TMPDIR` is visible to every concurrently-running sibling in
+/// the same test binary, and `tempfile` honors it.
+/// What: treats an absent, empty, or whitespace-only `tmpdir` as `/tmp`.
+/// Test: `scratch_socket_dir_from_uses_tmpdir_when_set`,
+/// `scratch_socket_dir_from_falls_back_to_tmp`.
+pub fn scratch_socket_dir_from(tmpdir: Option<&str>, uid: u32) -> PathBuf {
+    let base = match tmpdir {
+        Some(p) if !p.trim().is_empty() => PathBuf::from(p),
+        _ => PathBuf::from("/tmp"),
+    };
+    base.join(format!("trusty-{uid}"))
+}
+
+/// Create `dir` at [`SOCKET_DIR_MODE`], or verify and repair it if it exists.
+///
+/// Why: this is what closes the bind-then-chmod window. Binding a Unix socket
+/// creates the file, so a `chmod` after `bind` leaves an interval in which the
+/// socket exists at the umask-derived mode. A caller cannot shrink that
+/// interval to zero, and the obvious alternative — setting the process umask
+/// around the bind — is process-global and therefore racy under a
+/// multi-threaded tokio runtime, where a sibling thread creating an unrelated
+/// file would silently inherit it. Holding the *directory* at `0700` before
+/// the socket is created removes the exposure instead of narrowing it: path
+/// resolution requires search permission on every component, so no other uid
+/// can name the socket at any point, including during the window.
+///
+/// What: creates `dir` with the mode passed to `mkdir(2)`, which is atomic —
+/// unlike `create_dir_all` followed by `set_permissions`, which reproduces the
+/// same ordering bug one level up. Ancestors are created with the default mode
+/// because only the leaf holds sockets. If `dir` already exists, its owner must
+/// be this uid (a foreign owner fails closed rather than being repaired) and a
+/// wider mode is narrowed.
+///
+/// Test: `prepare_socket_dir_creates_at_0700`,
+/// `prepare_socket_dir_narrows_a_wide_existing_dir`, and
+/// `prepare_socket_dir_rejects_foreign_owner` (`#[ignore]`d — needs two uids).
+pub fn prepare_socket_dir(dir: &Path) -> Result<(), UdsSecurityError> {
+    // `Path::parent` yields `Some("")` for a bare relative name; `create_dir_all`
+    // on an empty path fails, so filter it out rather than branching twice.
+    if let Some(parent) = dir.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent).map_err(|source| UdsSecurityError::CreateDir {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+
+    // #5099: mkdir(2) applies the mode atomically, so the directory is never
+    // observable at a wider mode. `create_dir_all` + `set_permissions` is not
+    // an acceptable substitute here.
+    match DirBuilder::new().mode(SOCKET_DIR_MODE).create(dir) {
+        Ok(()) => return Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {}
+        Err(source) => {
+            return Err(UdsSecurityError::CreateDir {
+                path: dir.to_path_buf(),
+                source,
+            });
+        }
+    }
+
+    let meta = std::fs::metadata(dir).map_err(|source| UdsSecurityError::CreateDir {
+        path: dir.to_path_buf(),
+        source,
+    })?;
+    let expected = self_uid();
+    if meta.uid() != expected {
+        return Err(UdsSecurityError::ForeignDirOwner {
+            path: dir.to_path_buf(),
+            owner: meta.uid(),
+            expected,
+        });
+    }
+    if meta.permissions().mode() & 0o777 != SOCKET_DIR_MODE {
+        std::fs::set_permissions(dir, Permissions::from_mode(SOCKET_DIR_MODE)).map_err(
+            |source| UdsSecurityError::HardenDir {
+                path: dir.to_path_buf(),
+                mode: SOCKET_DIR_MODE,
+                source,
+            },
+        )?;
+    }
+    Ok(())
+}
+
+/// Bind a listener at `path` with its directory at `0700` and the socket at
+/// `0600`.
+///
+/// Why: the single entry point every daemon binds through, so the permission
+/// contract cannot drift between the four bind sites that previously each
+/// called `UnixListener::bind` bare (`trusty-embedderd`, `trusty-bm25-daemon`,
+/// and two in `trusty-agents`). See #5099.
+///
+/// What: hardens the parent directory via [`prepare_socket_dir`], binds, then
+/// narrows the socket to [`SOCKET_MODE`] before returning — so the listener is
+/// already `0600` when the caller first calls `accept`. Deliberately does *not*
+/// remove a stale socket file: `CtrlSocket::bind_singleton` must probe before
+/// clobbering, and folding an unconditional unlink in here would break that
+/// singleton guarantee. Callers that want stale-file cleanup keep doing it
+/// themselves, immediately before this call.
+///
+/// The `0600` step is defence in depth, not the race fix — the `0700`
+/// directory is what makes the socket unreachable during the window between
+/// `bind` and `chmod`. [`prepare_socket_dir`]'s docs carry the reasoning.
+///
+/// Test: `bind_hardened_sets_socket_0600_and_dir_0700` and
+/// `bind_hardened_socket_is_connectable_after_hardening`.
+pub fn bind_hardened(path: &Path) -> Result<UnixListener, UdsSecurityError> {
+    // `Path::parent` yields `Some("")` — not `None` — for a bare filename, so
+    // the empty case has to be filtered explicitly or a relative socket name
+    // would bind into an unhardened cwd.
+    let dir = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .ok_or_else(|| UdsSecurityError::NoParent {
+            path: path.to_path_buf(),
+        })?;
+    prepare_socket_dir(dir)?;
+
+    let listener = UnixListener::bind(path).map_err(|source| UdsSecurityError::Bind {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    std::fs::set_permissions(path, Permissions::from_mode(SOCKET_MODE)).map_err(|source| {
+        UdsSecurityError::Chmod {
+            path: path.to_path_buf(),
+            mode: SOCKET_MODE,
+            source,
+        }
+    })?;
+
+    Ok(listener)
+}

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -1,46 +1,61 @@
 //! Permission enforcement for Unix-domain sockets — the `0600` guarantee
 //! ADR-0031 and ADR-0032 cite as an existing property.
 //!
-//! Why: both ADRs rest their case for UDS-over-loopback-TCP on "a loopback
-//! port is reachable by any local process, a `0600` socket is not". Until
-//! #5099 no production code in this workspace called `set_permissions` on any
-//! socket — every hit was a test fixture. Sockets were created at the process
-//! umask (commonly `0755`) and two of the three path conventions placed them
-//! in `$TMPDIR` falling back to a shared, world-writable `/tmp`. This module
-//! makes the claimed guarantee real, in one place, so a behavior fix lands
-//! once rather than at four bind sites.
+//! Why: both ADRs rest their case for UDS-over-loopback-TCP on "a loopback port
+//! is reachable by any local process, a `0600` socket is not". Until #5099 no
+//! production code in this workspace called `set_permissions` on any socket —
+//! every hit was a test fixture. Sockets were created at the process umask
+//! (commonly `0755`) and two of the three path conventions placed them in
+//! `$TMPDIR` falling back to a shared, world-writable `/tmp`. This module makes
+//! the claimed guarantee real, in one place, so a behavior fix lands once
+//! rather than at four bind sites. ADR-0034 §3 ("The trust boundary") states
+//! the requirement: `0700` directory, `0600` socket, peer-uid check on accept.
 //!
-//! What: three primitives, in the order a daemon uses them.
+//! What: four primitives, in the order a daemon uses them.
 //!   - [`scratch_socket_dir`] resolves a per-uid directory under the system
 //!     scratch space, replacing the bare `$TMPDIR`-with-`/tmp`-fallback.
 //!   - [`bind_hardened`] creates that directory at `0700`, binds, and sets the
 //!     socket to `0600` before returning it to the caller.
+//!   - [`connect_hardened`] is the dialer's half: it verifies the directory and
+//!     socket a client is about to trust before writing anything to it.
 //!   - [`ensure_peer_is_self`] refuses an accepted connection whose peer uid is
 //!     not this process's own, which is what turns the permission bits into an
 //!     enforced boundary rather than a documented intention.
 //!
-//! Deliberately not a transport: there is no framing, dialing, or JSON-RPC
-//! here. #5089 step 1 builds the shared UDS transport module; this is the
-//! security layer that module mounts, not a competing implementation of it.
+//! **What this does and does not guarantee.** With the directory held at `0700`
+//! and owned by this uid, no other unprivileged user can traverse to the socket
+//! — that is the load-bearing property, and it holds from the moment the
+//! directory is created. It is *not* an unconditional claim about every path
+//! this module can be handed: a caller that points it at a directory an
+//! attacker can rename or unlink entries in retains a residual swap race that
+//! only `openat`/`fchmod` on a directory fd could close. Symlink pre-creation,
+//! which is the practical version of that attack, is refused outright — see
+//! [`dir::prepare_socket_dir`]. Root is not defended against and cannot be.
+//!
+//! Deliberately not a transport: there is no framing or JSON-RPC here. #5089
+//! step 1 builds the shared UDS transport module; this is the security layer
+//! that module mounts, including the dialer it needs, not a competing
+//! implementation of it.
 //!
 //! Test: `tests.rs` — directory and socket modes after a real bind, the
-//! pre-existing-wide-directory repair path, the foreign-owner refusal, and the
-//! same-uid peer accept. Cross-uid rejection is `#[ignore]`d (needs two uids).
+//! pre-existing-wide-directory repair, symlink refusal, the pure decision
+//! functions behind every refusal, and the `sun_path` budget pre-check.
 
 #[cfg(test)]
 #[path = "tests.rs"]
 mod tests;
 
+pub mod dir;
 mod peer;
 
+pub use dir::prepare_socket_dir;
 pub use peer::{ensure_peer_is_self, peer_uid, self_uid};
 
-use std::fs::{DirBuilder, Permissions};
-use std::io;
-use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+use std::fs::Permissions;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
-use tokio::net::UnixListener;
+use tokio::net::{UnixListener, UnixStream};
 
 /// Mode every socket-bearing directory is created at and verified against.
 ///
@@ -52,9 +67,10 @@ pub const SOCKET_DIR_MODE: u32 = 0o700;
 /// Mode every bound socket is set to before its first `accept`.
 pub const SOCKET_MODE: u32 = 0o600;
 
-/// Failures that mean a socket could not be made private. Every variant is
-/// fatal to the bind — none is a "log and continue" condition, because
-/// continuing would leave a socket wider than the ADRs promise.
+/// Failures that mean a socket could not be made private, or could not be
+/// trusted. Every variant is fatal to the operation — none is a "log and
+/// continue" condition, because continuing would use a socket wider than the
+/// ADRs promise.
 #[derive(Debug, thiserror::Error)]
 pub enum UdsSecurityError {
     /// The socket path is a bare filename with no directory component, so
@@ -65,6 +81,20 @@ pub enum UdsSecurityError {
         path: PathBuf,
     },
 
+    /// The socket path does not fit the kernel's `sockaddr_un.sun_path` buffer.
+    #[error(
+        "socket path is {len} bytes but the kernel's sun_path buffer holds {capacity} \
+         (including its NUL terminator): {path}"
+    )]
+    PathTooLong {
+        /// The path that overflowed.
+        path: PathBuf,
+        /// Length of `path` in bytes.
+        len: usize,
+        /// Bytes available in `sockaddr_un.sun_path` on this platform.
+        capacity: usize,
+    },
+
     /// Creating the socket directory failed.
     #[error("create socket directory {path}: {source}")]
     CreateDir {
@@ -72,7 +102,16 @@ pub enum UdsSecurityError {
         path: PathBuf,
         /// Underlying OS error.
         #[source]
-        source: io::Error,
+        source: std::io::Error,
+    },
+
+    /// The socket directory is a symlink. Refused outright: `metadata` and
+    /// `set_permissions` follow links, so verifying a symlinked directory reads
+    /// and chmods the wrong inode (#5099 review finding 1).
+    #[error("socket directory {path} is a symlink; refusing to trust it")]
+    SymlinkDir {
+        /// The symlinked path.
+        path: PathBuf,
     },
 
     /// The directory already existed but belongs to a different uid. Repairing
@@ -97,7 +136,7 @@ pub enum UdsSecurityError {
         mode: u32,
         /// Underlying OS error.
         #[source]
-        source: io::Error,
+        source: std::io::Error,
     },
 
     /// `UnixListener::bind` failed.
@@ -107,7 +146,7 @@ pub enum UdsSecurityError {
         path: PathBuf,
         /// Underlying OS error.
         #[source]
-        source: io::Error,
+        source: std::io::Error,
     },
 
     /// The socket bound but could not be narrowed to [`SOCKET_MODE`].
@@ -119,7 +158,26 @@ pub enum UdsSecurityError {
         mode: u32,
         /// Underlying OS error.
         #[source]
-        source: io::Error,
+        source: std::io::Error,
+    },
+
+    /// A client refused to dial a socket that failed verification.
+    #[error("refusing to connect to {path}: {reason}")]
+    UntrustedSocket {
+        /// The socket that was refused.
+        path: PathBuf,
+        /// Which property failed.
+        reason: String,
+    },
+
+    /// `UnixStream::connect` failed.
+    #[error("connect to unix socket at {path}: {source}")]
+    Connect {
+        /// Socket path that could not be dialled.
+        path: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
     },
 
     /// Reading the connected peer's credentials failed.
@@ -127,7 +185,7 @@ pub enum UdsSecurityError {
     PeerCred {
         /// Underlying OS error.
         #[source]
-        source: io::Error,
+        source: std::io::Error,
     },
 
     /// The connected peer runs as a different uid.
@@ -144,15 +202,49 @@ pub enum UdsSecurityError {
     UnsupportedPlatform,
 }
 
+/// Bytes available in this platform's `sockaddr_un.sun_path`, NUL included.
+///
+/// Why: 104 on macOS, 108 on Linux. Rust rejects an over-long path before the
+/// syscall with a bare `invalid argument` that names neither the limit nor the
+/// offending path, which is a poor diagnostic for a value assembled from
+/// `$TMPDIR` plus a palace name (#5099 review finding 4).
+/// What: derived from the actual struct layout rather than hardcoded.
+/// Test: `sun_path_capacity_is_platform_plausible`.
+pub fn sun_path_capacity() -> usize {
+    size_of::<libc::sockaddr_un>() - std::mem::offset_of!(libc::sockaddr_un, sun_path)
+}
+
+/// Reject a socket path that cannot fit the kernel's address buffer.
+///
+/// Why: turns `invalid argument` into a message naming the budget, the actual
+/// length, and the path — the difference between "the daemon is broken" and
+/// "this palace name is 12 characters too long".
+/// What: compares the path's byte length against [`sun_path_capacity`], leaving
+/// room for the NUL terminator.
+/// Test: `check_sun_path_budget_accepts_a_path_that_fits` and
+/// `check_sun_path_budget_rejects_an_over_long_path`.
+pub fn check_sun_path_budget(path: &Path) -> Result<(), UdsSecurityError> {
+    let len = path.as_os_str().as_encoded_bytes().len();
+    let capacity = sun_path_capacity();
+    if len >= capacity {
+        return Err(UdsSecurityError::PathTooLong {
+            path: path.to_path_buf(),
+            len,
+            capacity,
+        });
+    }
+    Ok(())
+}
+
 /// Per-uid directory under the system scratch space for daemon sockets.
 ///
-/// Why: the convention this replaces was `$TMPDIR`, falling back to `/tmp`.
-/// On macOS `$TMPDIR` is a per-user `/var/folders/…/T/` that is already
-/// `0700`, so the fallback never bit there. On a Linux host with `TMPDIR`
-/// unset it resolved to `/tmp` — mode `1777`, owned by root — which can be
-/// neither narrowed to `0700` nor trusted, so any socket in it was reachable
-/// by every local user. Interposing a uid-keyed subdirectory gives a directory
-/// this process owns and can hold at `0700` on both platforms uniformly.
+/// Why: the convention this replaces was `$TMPDIR`, falling back to `/tmp`. On
+/// macOS `$TMPDIR` is a per-user `/var/folders/…/T/` that is already `0700`, so
+/// the fallback never bit there. On a Linux host with `TMPDIR` unset it
+/// resolved to `/tmp` — mode `1777`, owned by root — which can be neither
+/// narrowed to `0700` nor trusted, so any socket in it was reachable by every
+/// local user. Interposing a uid-keyed subdirectory gives a directory this
+/// process owns and can hold at `0700` on both platforms uniformly.
 ///
 /// What: `<$TMPDIR or /tmp>/trusty-<uid>`. The name is kept short on purpose:
 /// `sun_path` is 104 bytes on macOS and macOS' `$TMPDIR` already consumes
@@ -169,9 +261,9 @@ pub fn scratch_socket_dir() -> PathBuf {
 
 /// [`scratch_socket_dir`] with its two environment inputs passed explicitly.
 ///
-/// Why: keeps the resolution rules unit-testable without `set_var`. A test
-/// that mutates `TMPDIR` is visible to every concurrently-running sibling in
-/// the same test binary, and `tempfile` honors it.
+/// Why: keeps the resolution rules unit-testable without `set_var`. A test that
+/// mutates `TMPDIR` is visible to every concurrently-running sibling in the
+/// same test binary, and `tempfile` honors it.
 /// What: treats an absent, empty, or whitespace-only `tmpdir` as `/tmp`.
 /// Test: `scratch_socket_dir_from_uses_tmpdir_when_set`,
 /// `scratch_socket_dir_from_falls_back_to_tmp`.
@@ -183,75 +275,17 @@ pub fn scratch_socket_dir_from(tmpdir: Option<&str>, uid: u32) -> PathBuf {
     base.join(format!("trusty-{uid}"))
 }
 
-/// Create `dir` at [`SOCKET_DIR_MODE`], or verify and repair it if it exists.
+/// Resolve a socket path's parent, rejecting a bare filename.
 ///
-/// Why: this is what closes the bind-then-chmod window. Binding a Unix socket
-/// creates the file, so a `chmod` after `bind` leaves an interval in which the
-/// socket exists at the umask-derived mode. A caller cannot shrink that
-/// interval to zero, and the obvious alternative — setting the process umask
-/// around the bind — is process-global and therefore racy under a
-/// multi-threaded tokio runtime, where a sibling thread creating an unrelated
-/// file would silently inherit it. Holding the *directory* at `0700` before
-/// the socket is created removes the exposure instead of narrowing it: path
-/// resolution requires search permission on every component, so no other uid
-/// can name the socket at any point, including during the window.
-///
-/// What: creates `dir` with the mode passed to `mkdir(2)`, which is atomic —
-/// unlike `create_dir_all` followed by `set_permissions`, which reproduces the
-/// same ordering bug one level up. Ancestors are created with the default mode
-/// because only the leaf holds sockets. If `dir` already exists, its owner must
-/// be this uid (a foreign owner fails closed rather than being repaired) and a
-/// wider mode is narrowed.
-///
-/// Test: `prepare_socket_dir_creates_at_0700`,
-/// `prepare_socket_dir_narrows_a_wide_existing_dir`, and
-/// `prepare_socket_dir_rejects_foreign_owner` (`#[ignore]`d — needs two uids).
-pub fn prepare_socket_dir(dir: &Path) -> Result<(), UdsSecurityError> {
-    // `Path::parent` yields `Some("")` for a bare relative name; `create_dir_all`
-    // on an empty path fails, so filter it out rather than branching twice.
-    if let Some(parent) = dir.parent().filter(|p| !p.as_os_str().is_empty()) {
-        std::fs::create_dir_all(parent).map_err(|source| UdsSecurityError::CreateDir {
-            path: parent.to_path_buf(),
-            source,
-        })?;
-    }
-
-    // #5099: mkdir(2) applies the mode atomically, so the directory is never
-    // observable at a wider mode. `create_dir_all` + `set_permissions` is not
-    // an acceptable substitute here.
-    match DirBuilder::new().mode(SOCKET_DIR_MODE).create(dir) {
-        Ok(()) => return Ok(()),
-        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {}
-        Err(source) => {
-            return Err(UdsSecurityError::CreateDir {
-                path: dir.to_path_buf(),
-                source,
-            });
-        }
-    }
-
-    let meta = std::fs::metadata(dir).map_err(|source| UdsSecurityError::CreateDir {
-        path: dir.to_path_buf(),
-        source,
-    })?;
-    let expected = self_uid();
-    if meta.uid() != expected {
-        return Err(UdsSecurityError::ForeignDirOwner {
-            path: dir.to_path_buf(),
-            owner: meta.uid(),
-            expected,
-        });
-    }
-    if meta.permissions().mode() & 0o777 != SOCKET_DIR_MODE {
-        std::fs::set_permissions(dir, Permissions::from_mode(SOCKET_DIR_MODE)).map_err(
-            |source| UdsSecurityError::HardenDir {
-                path: dir.to_path_buf(),
-                mode: SOCKET_DIR_MODE,
-                source,
-            },
-        )?;
-    }
-    Ok(())
+/// `Path::parent` yields `Some("")` — not `None` — for a bare filename, so the
+/// empty case has to be filtered explicitly or a relative socket name would be
+/// treated as living in an unhardened cwd.
+fn socket_parent(path: &Path) -> Result<&Path, UdsSecurityError> {
+    path.parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .ok_or_else(|| UdsSecurityError::NoParent {
+            path: path.to_path_buf(),
+        })
 }
 
 /// Bind a listener at `path` with its directory at `0700` and the socket at
@@ -262,31 +296,26 @@ pub fn prepare_socket_dir(dir: &Path) -> Result<(), UdsSecurityError> {
 /// called `UnixListener::bind` bare (`trusty-embedderd`, `trusty-bm25-daemon`,
 /// and two in `trusty-agents`). See #5099.
 ///
-/// What: hardens the parent directory via [`prepare_socket_dir`], binds, then
-/// narrows the socket to [`SOCKET_MODE`] before returning — so the listener is
-/// already `0600` when the caller first calls `accept`. Deliberately does *not*
-/// remove a stale socket file: `CtrlSocket::bind_singleton` must probe before
-/// clobbering, and folding an unconditional unlink in here would break that
-/// singleton guarantee. Callers that want stale-file cleanup keep doing it
-/// themselves, immediately before this call.
+/// What: checks the `sun_path` budget, hardens the parent directory via
+/// [`prepare_socket_dir`], binds, then narrows the socket to [`SOCKET_MODE`]
+/// before returning — so the listener is already `0600` when the caller first
+/// calls `accept`. Deliberately does *not* remove a stale socket file:
+/// `CtrlSocket::bind_singleton` must probe before clobbering, and folding an
+/// unconditional unlink in here would break that singleton guarantee. Callers
+/// that want stale-file cleanup keep doing it themselves, immediately before
+/// this call.
 ///
-/// The `0600` step is defence in depth, not the race fix — the `0700`
-/// directory is what makes the socket unreachable during the window between
-/// `bind` and `chmod`. [`prepare_socket_dir`]'s docs carry the reasoning.
+/// The `0600` step is defence in depth, not the race fix — the `0700` directory
+/// is what makes the socket unreachable during the window between `bind` and
+/// `chmod`. [`prepare_socket_dir`]'s docs carry the reasoning and the residual
+/// race it does not close.
 ///
-/// Test: `bind_hardened_sets_socket_0600_and_dir_0700` and
-/// `bind_hardened_socket_is_connectable_after_hardening`.
+/// Test: `bind_hardened_sets_socket_0600_and_dir_0700`,
+/// `bind_hardened_socket_is_connectable_after_hardening`,
+/// `bind_hardened_rejects_an_over_long_path`.
 pub fn bind_hardened(path: &Path) -> Result<UnixListener, UdsSecurityError> {
-    // `Path::parent` yields `Some("")` — not `None` — for a bare filename, so
-    // the empty case has to be filtered explicitly or a relative socket name
-    // would bind into an unhardened cwd.
-    let dir = path
-        .parent()
-        .filter(|p| !p.as_os_str().is_empty())
-        .ok_or_else(|| UdsSecurityError::NoParent {
-            path: path.to_path_buf(),
-        })?;
-    prepare_socket_dir(dir)?;
+    check_sun_path_budget(path)?;
+    prepare_socket_dir(socket_parent(path)?)?;
 
     let listener = UnixListener::bind(path).map_err(|source| UdsSecurityError::Bind {
         path: path.to_path_buf(),
@@ -302,4 +331,101 @@ pub fn bind_hardened(path: &Path) -> Result<UnixListener, UdsSecurityError> {
     })?;
 
     Ok(listener)
+}
+
+/// Verify a socket and its directory, then connect.
+///
+/// Why: hardening only the bind side leaves the client trusting whatever is at
+/// the path. A daemon that predates this change, or a socket an attacker
+/// planted, still answers — and the supervisor's adopt-an-existing-socket path
+/// means the daemon's own `ForeignDirOwner` check may never run, because it
+/// never spawns when something is already listening (#5099 review finding 3).
+/// The dialer has to do its own verification.
+///
+/// What: refuses unless the parent directory is a non-symlink `0700` directory
+/// owned by this uid, and the socket itself is a non-symlink socket owned by
+/// this uid at mode `0600`. Then connects.
+///
+/// This is a check-then-use, so a sufficiently privileged attacker could swap
+/// the target between the `lstat` and the `connect`. It is not trying to win
+/// that race — it is closing the case that actually occurs, where a wrong-mode
+/// or wrong-owner socket persists and would otherwise be dialled silently.
+///
+/// Test: `connect_hardened_accepts_a_properly_hardened_socket`,
+/// `connect_hardened_refuses_a_world_readable_socket`,
+/// `connect_hardened_refuses_a_socket_in_a_wide_directory`,
+/// `connect_hardened_refuses_a_regular_file`.
+pub async fn connect_hardened(path: &Path) -> Result<UnixStream, UdsSecurityError> {
+    check_sun_path_budget(path)?;
+    verify_socket_for_connect(path)?;
+
+    UnixStream::connect(path)
+        .await
+        .map_err(|source| UdsSecurityError::Connect {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+/// The filesystem half of [`connect_hardened`], split out so it is testable
+/// without standing up a listener.
+///
+/// Test: the `connect_hardened_*` tests plus `verify_socket_for_connect_*`.
+pub fn verify_socket_for_connect(path: &Path) -> Result<(), UdsSecurityError> {
+    let own = self_uid();
+    let refuse = |reason: String| UdsSecurityError::UntrustedSocket {
+        path: path.to_path_buf(),
+        reason,
+    };
+
+    let parent = socket_parent(path)?;
+    let dmeta =
+        std::fs::symlink_metadata(parent).map_err(|source| UdsSecurityError::CreateDir {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    if dmeta.file_type().is_symlink() {
+        return Err(UdsSecurityError::SymlinkDir {
+            path: parent.to_path_buf(),
+        });
+    }
+    if dmeta.uid() != own {
+        return Err(UdsSecurityError::ForeignDirOwner {
+            path: parent.to_path_buf(),
+            owner: dmeta.uid(),
+            expected: own,
+        });
+    }
+    let dmode = dmeta.permissions().mode() & 0o777;
+    if dmode != SOCKET_DIR_MODE {
+        return Err(refuse(format!(
+            "containing directory {} is mode {dmode:04o}, not {SOCKET_DIR_MODE:04o}",
+            parent.display()
+        )));
+    }
+
+    let smeta = std::fs::symlink_metadata(path).map_err(|source| UdsSecurityError::Connect {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let ftype = smeta.file_type();
+    if ftype.is_symlink() {
+        return Err(refuse("socket path is a symlink".to_string()));
+    }
+    if !std::os::unix::fs::FileTypeExt::is_socket(&ftype) {
+        return Err(refuse("path is not a socket".to_string()));
+    }
+    if smeta.uid() != own {
+        return Err(refuse(format!(
+            "socket is owned by uid {}, not {own}",
+            smeta.uid()
+        )));
+    }
+    let smode = smeta.permissions().mode() & 0o777;
+    if smode != SOCKET_MODE {
+        return Err(refuse(format!(
+            "socket is mode {smode:04o}, not {SOCKET_MODE:04o}"
+        )));
+    }
+    Ok(())
 }

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -29,7 +29,8 @@
 //! this module can be handed: a caller that points it at a directory an
 //! attacker can rename or unlink entries in retains a residual swap race that
 //! only `openat`/`fchmod` on a directory fd could close. Symlink pre-creation,
-//! which is the practical version of that attack, is refused outright — see
+//! which is the practical version of that attack, is refused outright, as is a
+//! non-directory sitting at the socket-directory path — see
 //! [`dir::prepare_socket_dir`]. Root is not defended against and cannot be.
 //!
 //! Deliberately not a transport: there is no framing or JSON-RPC here. #5089
@@ -114,6 +115,17 @@ pub enum UdsSecurityError {
         path: PathBuf,
     },
 
+    /// The socket-directory path exists but is not a directory. Refused before
+    /// anything chmods it — a regular file here used to be narrowed to `0700`
+    /// on its way to a confusing `ENOTDIR` from `bind` (#5099 review round 2).
+    #[error("socket directory {path} is a {found}, not a directory")]
+    NotADirectory {
+        /// The offending path.
+        path: PathBuf,
+        /// What `lstat` actually found there.
+        found: String,
+    },
+
     /// The directory already existed but belongs to a different uid. Repairing
     /// its mode would not make it safe — another user controls its contents —
     /// so this fails closed instead.
@@ -168,6 +180,19 @@ pub enum UdsSecurityError {
         path: PathBuf,
         /// Which property failed.
         reason: String,
+    },
+
+    /// Could not `lstat` a path while verifying it ahead of a connect. Distinct
+    /// from [`UdsSecurityError::CreateDir`]: a dialer creates nothing, so
+    /// reporting a creation failure there named an action never attempted
+    /// (#5099 review round 2, finding 2).
+    #[error("stat {path} while verifying it for connect: {source}")]
+    StatForConnect {
+        /// Path that could not be stat'd.
+        path: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
     },
 
     /// `UnixStream::connect` failed.
@@ -380,13 +405,19 @@ pub fn verify_socket_for_connect(path: &Path) -> Result<(), UdsSecurityError> {
 
     let parent = socket_parent(path)?;
     let dmeta =
-        std::fs::symlink_metadata(parent).map_err(|source| UdsSecurityError::CreateDir {
+        std::fs::symlink_metadata(parent).map_err(|source| UdsSecurityError::StatForConnect {
             path: parent.to_path_buf(),
             source,
         })?;
     if dmeta.file_type().is_symlink() {
         return Err(UdsSecurityError::SymlinkDir {
             path: parent.to_path_buf(),
+        });
+    }
+    if !dmeta.file_type().is_dir() {
+        return Err(UdsSecurityError::NotADirectory {
+            path: parent.to_path_buf(),
+            found: dir::describe_file_type(&dmeta.file_type()).to_string(),
         });
     }
     if dmeta.uid() != own {
@@ -404,10 +435,11 @@ pub fn verify_socket_for_connect(path: &Path) -> Result<(), UdsSecurityError> {
         )));
     }
 
-    let smeta = std::fs::symlink_metadata(path).map_err(|source| UdsSecurityError::Connect {
-        path: path.to_path_buf(),
-        source,
-    })?;
+    let smeta =
+        std::fs::symlink_metadata(path).map_err(|source| UdsSecurityError::StatForConnect {
+            path: path.to_path_buf(),
+            source,
+        })?;
     let ftype = smeta.file_type();
     if ftype.is_symlink() {
         return Err(refuse("socket path is a symlink".to_string()));

--- a/crates/trusty-common/src/uds/peer.rs
+++ b/crates/trusty-common/src/uds/peer.rs
@@ -1,0 +1,138 @@
+//! Peer-credential checks on an accepted Unix-domain connection.
+//!
+//! Why: filesystem permissions alone are a documented intention. A `0600`
+//! socket in a `0700` directory is unreachable to another uid *while those
+//! bits hold*, but nothing in the process re-checks them — an operator who
+//! loosens the directory, a backup tool that restores it wide, or a socket
+//! reached before this crate's hardening ran would all pass unnoticed. Asking
+//! the kernel who is on the other end turns the permission bits into an
+//! enforced boundary. ADR-0034 requires it for exactly this reason.
+//!
+//! What: [`peer_uid`] wraps the platform syscall — `SO_PEERCRED` on Linux,
+//! `getpeereid` on macOS and the BSDs — and [`ensure_peer_is_self`] refuses any
+//! peer whose uid differs from this process's own. Targets with neither
+//! syscall fail closed via [`UdsSecurityError::UnsupportedPlatform`] rather
+//! than compiling to an unchecked accept.
+//!
+//! Test: `peer_uid_of_self_connection_is_self` and
+//! `ensure_peer_is_self_accepts_same_uid` in `tests.rs`; the cross-uid refusal
+//! is `#[ignore]`d because it needs a second uid.
+
+use std::io;
+use std::os::fd::AsRawFd;
+
+use tokio::net::UnixStream;
+
+use super::UdsSecurityError;
+
+/// The uid this process runs as.
+///
+/// Why: the comparison target for every peer check, and the key
+/// [`super::scratch_socket_dir`] uses to give each user its own directory.
+/// What: `getuid(2)`. Cannot fail per POSIX.
+/// Test: exercised by every peer test; equality with `id -u` is not asserted
+/// because the test process has no independent source of truth for it.
+pub fn self_uid() -> u32 {
+    // SAFETY: `getuid` takes no arguments, touches no caller memory, and is
+    // documented as always succeeding.
+    unsafe { libc::getuid() }
+}
+
+/// Read the uid of the process on the other end of `stream`.
+///
+/// Why: split from [`ensure_peer_is_self`] so a caller that wants to log or
+/// meter the peer identity does not have to duplicate the platform `cfg`s.
+/// What: `getsockopt(SO_PEERCRED)` on Linux, `getpeereid(3)` elsewhere on
+/// unix. The credentials the kernel reports are those captured at `connect`
+/// time, so a peer cannot change uid after connecting to defeat the check.
+/// Test: `peer_uid_of_self_connection_is_self`.
+#[cfg(target_os = "linux")]
+pub fn peer_uid(stream: &UnixStream) -> Result<u32, UdsSecurityError> {
+    let mut cred = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+
+    // SAFETY: `stream` owns a live connected socket fd for the duration of the
+    // call; `cred` and `len` are a correctly-sized, correctly-typed
+    // out-parameter pair for SO_PEERCRED on SOL_SOCKET.
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            (&raw mut cred).cast::<libc::c_void>(),
+            &raw mut len,
+        )
+    };
+    if rc != 0 {
+        return Err(UdsSecurityError::PeerCred {
+            source: io::Error::last_os_error(),
+        });
+    }
+    Ok(cred.uid)
+}
+
+/// See the Linux variant for the contract; this is the BSD/macOS syscall.
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+pub fn peer_uid(stream: &UnixStream) -> Result<u32, UdsSecurityError> {
+    let mut uid: libc::uid_t = 0;
+    let mut gid: libc::gid_t = 0;
+
+    // SAFETY: `stream` owns a live connected socket fd for the duration of the
+    // call; both out-parameters are valid, correctly-typed stack slots.
+    let rc = unsafe { libc::getpeereid(stream.as_raw_fd(), &raw mut uid, &raw mut gid) };
+    if rc != 0 {
+        return Err(UdsSecurityError::PeerCred {
+            source: io::Error::last_os_error(),
+        });
+    }
+    Ok(uid)
+}
+
+/// Fail closed on a unix target with neither `SO_PEERCRED` nor `getpeereid`.
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+)))]
+pub fn peer_uid(_stream: &UnixStream) -> Result<u32, UdsSecurityError> {
+    Err(UdsSecurityError::UnsupportedPlatform)
+}
+
+/// Refuse a connection whose peer is not this same uid.
+///
+/// Why: the accept-side half of the `0600` contract. ADR-0034: "the target
+/// verifies peer credentials on accept and refuses any connection whose uid is
+/// not its own. This is what makes the permission bits an enforced boundary
+/// rather than a documented intention."
+///
+/// What: compares [`peer_uid`] against [`self_uid`] and returns
+/// [`UdsSecurityError::ForeignPeer`] on mismatch. Root is refused like any
+/// other foreign uid — root can bypass the filesystem check anyway, so
+/// admitting it would buy nothing and widen the accepted set.
+///
+/// Test: `ensure_peer_is_self_accepts_same_uid`; the refusal path is
+/// `ensure_peer_is_self_refuses_foreign_uid`, `#[ignore]`d because an
+/// unprivileged CI runner cannot connect as a second uid.
+pub fn ensure_peer_is_self(stream: &UnixStream) -> Result<(), UdsSecurityError> {
+    let peer = peer_uid(stream)?;
+    let expected = self_uid();
+    if peer != expected {
+        return Err(UdsSecurityError::ForeignPeer { peer, expected });
+    }
+    Ok(())
+}

--- a/crates/trusty-common/src/uds/peer.rs
+++ b/crates/trusty-common/src/uds/peer.rs
@@ -1,22 +1,25 @@
 //! Peer-credential checks on an accepted Unix-domain connection.
 //!
 //! Why: filesystem permissions alone are a documented intention. A `0600`
-//! socket in a `0700` directory is unreachable to another uid *while those
-//! bits hold*, but nothing in the process re-checks them — an operator who
-//! loosens the directory, a backup tool that restores it wide, or a socket
-//! reached before this crate's hardening ran would all pass unnoticed. Asking
-//! the kernel who is on the other end turns the permission bits into an
-//! enforced boundary. ADR-0034 requires it for exactly this reason.
+//! socket in a `0700` directory is unreachable to another uid *while those bits
+//! hold*, but nothing in the process re-checks them — an operator who loosens
+//! the directory, a backup tool that restores it wide, or a socket reached
+//! before this crate's hardening ran would all pass unnoticed. Asking the
+//! kernel who is on the other end turns the permission bits into an enforced
+//! boundary. ADR-0034 §3 ("The trust boundary") requires it for this reason.
 //!
 //! What: [`peer_uid`] wraps the platform syscall — `SO_PEERCRED` on Linux,
-//! `getpeereid` on macOS and the BSDs — and [`ensure_peer_is_self`] refuses any
-//! peer whose uid differs from this process's own. Targets with neither
-//! syscall fail closed via [`UdsSecurityError::UnsupportedPlatform`] rather
-//! than compiling to an unchecked accept.
+//! `getpeereid` on macOS and the BSDs — [`peer_uid_verdict`] is the pure
+//! comparison behind the refusal, and [`ensure_peer_is_self`] joins them.
+//! Targets with neither syscall fail closed via
+//! [`UdsSecurityError::UnsupportedPlatform`] rather than compiling to an
+//! unchecked accept.
 //!
 //! Test: `peer_uid_of_self_connection_is_self` and
-//! `ensure_peer_is_self_accepts_same_uid` in `tests.rs`; the cross-uid refusal
-//! is `#[ignore]`d because it needs a second uid.
+//! `bind_hardened_socket_is_connectable_after_hardening` cover the syscall;
+//! `peer_uid_verdict_refuses_a_foreign_uid` and
+//! `peer_uid_verdict_accepts_the_same_uid` cover the decision without needing a
+//! second uid.
 
 use std::io;
 use std::os::fd::AsRawFd;
@@ -38,13 +41,38 @@ pub fn self_uid() -> u32 {
     unsafe { libc::getuid() }
 }
 
+/// Decide whether a peer uid is acceptable, as a pure function.
+///
+/// Why: the refusal branch is the security-critical one and cannot be reached
+/// from an unprivileged test — connecting as a second uid needs root or a
+/// pre-provisioned account. Taking both uids as arguments makes the decision
+/// assertable directly, so only the syscall plumbing remains untested rather
+/// than the whole policy (#5099 review finding 5).
+///
+/// What: returns [`UdsSecurityError::ForeignPeer`] unless `peer == own`. Root
+/// is refused like any other foreign uid — root can bypass the filesystem check
+/// anyway, so admitting it would buy nothing and widen the accepted set.
+///
+/// Test: `peer_uid_verdict_accepts_the_same_uid`,
+/// `peer_uid_verdict_refuses_a_foreign_uid`,
+/// `peer_uid_verdict_refuses_root_when_we_are_not_root`.
+pub fn peer_uid_verdict(peer: u32, own: u32) -> Result<(), UdsSecurityError> {
+    if peer != own {
+        return Err(UdsSecurityError::ForeignPeer {
+            peer,
+            expected: own,
+        });
+    }
+    Ok(())
+}
+
 /// Read the uid of the process on the other end of `stream`.
 ///
 /// Why: split from [`ensure_peer_is_self`] so a caller that wants to log or
 /// meter the peer identity does not have to duplicate the platform `cfg`s.
-/// What: `getsockopt(SO_PEERCRED)` on Linux, `getpeereid(3)` elsewhere on
-/// unix. The credentials the kernel reports are those captured at `connect`
-/// time, so a peer cannot change uid after connecting to defeat the check.
+/// What: `getsockopt(SO_PEERCRED)` on Linux, `getpeereid(3)` elsewhere on unix.
+/// The credentials the kernel reports are those captured at `connect` time, so
+/// a peer cannot change uid after connecting to defeat the check.
 /// Test: `peer_uid_of_self_connection_is_self`.
 #[cfg(target_os = "linux")]
 pub fn peer_uid(stream: &UnixStream) -> Result<u32, UdsSecurityError> {
@@ -53,7 +81,7 @@ pub fn peer_uid(stream: &UnixStream) -> Result<u32, UdsSecurityError> {
         uid: 0,
         gid: 0,
     };
-    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    let mut len = size_of::<libc::ucred>() as libc::socklen_t;
 
     // SAFETY: `stream` owns a live connected socket fd for the duration of the
     // call; `cred` and `len` are a correctly-sized, correctly-typed
@@ -115,24 +143,17 @@ pub fn peer_uid(_stream: &UnixStream) -> Result<u32, UdsSecurityError> {
 
 /// Refuse a connection whose peer is not this same uid.
 ///
-/// Why: the accept-side half of the `0600` contract. ADR-0034: "the target
+/// Why: the accept-side half of the `0600` contract. ADR-0034 §3: "the target
 /// verifies peer credentials on accept and refuses any connection whose uid is
 /// not its own. This is what makes the permission bits an enforced boundary
 /// rather than a documented intention."
 ///
-/// What: compares [`peer_uid`] against [`self_uid`] and returns
-/// [`UdsSecurityError::ForeignPeer`] on mismatch. Root is refused like any
-/// other foreign uid — root can bypass the filesystem check anyway, so
-/// admitting it would buy nothing and widen the accepted set.
+/// What: reads [`peer_uid`] and applies [`peer_uid_verdict`] against
+/// [`self_uid`].
 ///
-/// Test: `ensure_peer_is_self_accepts_same_uid`; the refusal path is
-/// `ensure_peer_is_self_refuses_foreign_uid`, `#[ignore]`d because an
-/// unprivileged CI runner cannot connect as a second uid.
+/// Test: `bind_hardened_socket_is_connectable_after_hardening` proves the
+/// accept path for a same-uid peer; `peer_uid_verdict_refuses_a_foreign_uid`
+/// proves the refusal decision without needing a second uid.
 pub fn ensure_peer_is_self(stream: &UnixStream) -> Result<(), UdsSecurityError> {
-    let peer = peer_uid(stream)?;
-    let expected = self_uid();
-    if peer != expected {
-        return Err(UdsSecurityError::ForeignPeer { peer, expected });
-    }
-    Ok(())
+    peer_uid_verdict(peer_uid(stream)?, self_uid())
 }

--- a/crates/trusty-common/src/uds/tests.rs
+++ b/crates/trusty-common/src/uds/tests.rs
@@ -1,23 +1,33 @@
 //! Coverage for the #5099 socket-permission contract.
 //!
-//! The mode assertions here are the regression proof: against the pre-fix
-//! commit — where every bind site called `UnixListener::bind` bare — the
-//! socket comes back at the umask-derived mode (`0755` under the common
-//! `022` umask) and the directory at whatever `create_dir_all` produced.
+//! The mode assertions are the regression proof: against the pre-fix commit —
+//! where every bind site called `UnixListener::bind` bare — the socket comes
+//! back at the umask-derived mode (`0755` under the common `022` umask) and the
+//! directory at whatever `create_dir_all` produced.
+//!
+//! Every refusal path is covered by a pure decision function
+//! (`classify_existing_dir`, `peer_uid_verdict`), so foreign-uid and
+//! foreign-owner policy is asserted without root and without a second account.
+//! What remains genuinely unreachable unprivileged is only the platform syscall
+//! plumbing that feeds those functions.
 
+use super::dir::{DirVerdict, classify_existing_dir};
+use super::peer::peer_uid_verdict;
 use super::*;
 
 use std::os::unix::fs::PermissionsExt;
-use tokio::net::UnixStream;
 
-/// Mode bits of `path`, masked to the permission nibbles.
+/// Mode bits of `path`, masked to the permission nibbles. Uses `lstat` so a
+/// symlink's own mode is reported, never its target's.
 fn mode_of(path: &Path) -> u32 {
-    std::fs::metadata(path)
+    std::fs::symlink_metadata(path)
         .expect("stat path under test")
         .permissions()
         .mode()
         & 0o777
 }
+
+// ── path resolution ─────────────────────────────────────────────────────────
 
 #[test]
 fn scratch_socket_dir_from_uses_tmpdir_when_set() {
@@ -53,10 +63,112 @@ fn scratch_socket_dir_is_uid_keyed() {
     assert_eq!(leaf, format!("trusty-{}", self_uid()));
 }
 
+// ── sun_path budget (review finding 4) ──────────────────────────────────────
+
+#[test]
+fn sun_path_capacity_is_platform_plausible() {
+    // Why: derived from struct layout, so a wrong answer would silently skew
+    // every budget check. macOS is 104, Linux 108.
+    let cap = sun_path_capacity();
+    assert!(
+        (104..=108).contains(&cap),
+        "sun_path capacity {cap} is outside the known 104..=108 range"
+    );
+}
+
+#[test]
+fn check_sun_path_budget_accepts_a_path_that_fits() {
+    let path = PathBuf::from("/tmp/trusty-501/short.sock");
+    check_sun_path_budget(&path).expect("a short path must fit");
+}
+
+#[test]
+fn check_sun_path_budget_rejects_an_over_long_path() {
+    // Why: the pre-check exists to replace a bare `invalid argument` with a
+    // message naming the budget and the overflow.
+    let long = format!("/tmp/{}.sock", "x".repeat(sun_path_capacity()));
+    let err = check_sun_path_budget(Path::new(&long)).expect_err("must reject");
+    match err {
+        UdsSecurityError::PathTooLong { len, capacity, .. } => {
+            assert!(len >= capacity, "len {len} must exceed capacity {capacity}");
+            let rendered = err.to_string();
+            assert!(
+                rendered.contains(&capacity.to_string()) && rendered.contains(&len.to_string()),
+                "diagnostic must name both the budget and the actual length: {rendered}"
+            );
+        }
+        other => panic!("expected PathTooLong, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn bind_hardened_rejects_an_over_long_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let long = tmp.path().join(format!("{}.sock", "x".repeat(120)));
+    let err = bind_hardened(&long).expect_err("must reject before binding");
+    assert!(
+        matches!(err, UdsSecurityError::PathTooLong { .. }),
+        "expected PathTooLong, got {err:?}"
+    );
+}
+
+// ── directory decisions, as pure functions (review finding 5) ───────────────
+
+#[test]
+fn classify_existing_dir_rejects_a_symlink() {
+    // Why: THE review-finding-1 policy. `metadata()` on a symlinked directory
+    // reports the TARGET's owner and mode, so a link pointing at any directory
+    // this uid happens to own would otherwise pass the owner check — and
+    // `set_permissions` would then chmod the target.
+    let err = classify_existing_dir(Path::new("/tmp/x"), true, 501, 0o700, 501)
+        .expect_err("a symlink must be refused even when owner and mode look right");
+    assert!(
+        matches!(err, UdsSecurityError::SymlinkDir { .. }),
+        "expected SymlinkDir, got {err:?}"
+    );
+}
+
+#[test]
+fn classify_existing_dir_rejects_a_foreign_owner() {
+    let err = classify_existing_dir(Path::new("/tmp/x"), false, 0, 0o700, 501)
+        .expect_err("a root-owned directory must be refused");
+    match err {
+        UdsSecurityError::ForeignDirOwner {
+            owner, expected, ..
+        } => {
+            assert_eq!((owner, expected), (0, 501));
+        }
+        other => panic!("expected ForeignDirOwner, got {other:?}"),
+    }
+}
+
+#[test]
+fn classify_existing_dir_narrows_a_wide_dir() {
+    let v = classify_existing_dir(Path::new("/tmp/x"), false, 501, 0o755, 501).expect("ours");
+    assert_eq!(v, DirVerdict::Narrow);
+}
+
+#[test]
+fn classify_existing_dir_accepts_an_already_correct_dir() {
+    let v = classify_existing_dir(Path::new("/tmp/x"), false, 501, 0o700, 501).expect("ours");
+    assert_eq!(v, DirVerdict::Accept);
+}
+
+#[test]
+fn classify_existing_dir_checks_symlink_before_owner() {
+    // Why: ordering matters. An attacker-owned symlink must report SymlinkDir,
+    // not ForeignDirOwner — the latter would imply the path itself was checked.
+    let err = classify_existing_dir(Path::new("/tmp/x"), true, 999, 0o777, 501).expect_err("no");
+    assert!(
+        matches!(err, UdsSecurityError::SymlinkDir { .. }),
+        "symlink must be rejected before ownership is considered, got {err:?}"
+    );
+}
+
+// ── directory behaviour on a real filesystem ────────────────────────────────
+
 #[test]
 fn prepare_socket_dir_creates_at_0700() {
-    // Why: the directory mode is what closes the bind-then-chmod window, so it
-    // must be 0700 the moment the directory exists.
     let tmp = tempfile::tempdir().expect("tempdir");
     let dir = tmp.path().join("sockets");
 
@@ -71,8 +183,6 @@ fn prepare_socket_dir_creates_at_0700() {
 
 #[test]
 fn prepare_socket_dir_creates_missing_ancestors() {
-    // Why: callers pass a nested path (`~/.trusty-agents/sockets/`) whose
-    // ancestors may not exist. Only the leaf is security-relevant.
     let tmp = tempfile::tempdir().expect("tempdir");
     let dir = tmp.path().join("a").join("b").join("sockets");
 
@@ -84,13 +194,11 @@ fn prepare_socket_dir_creates_missing_ancestors() {
 #[test]
 fn prepare_socket_dir_narrows_a_wide_existing_dir() {
     // Why: the directory this replaces was created by `create_dir_all`, so on
-    // every existing install it is already 0755. Upgrading must repair it
-    // rather than trusting whatever is on disk.
+    // every existing install it is already 0755. Upgrading must repair it.
     let tmp = tempfile::tempdir().expect("tempdir");
     let dir = tmp.path().join("sockets");
     std::fs::create_dir(&dir).expect("create wide dir");
-    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755))
-        .expect("widen dir to 0755");
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).expect("widen");
     assert_eq!(mode_of(&dir), 0o755, "precondition: dir starts wide");
 
     prepare_socket_dir(&dir).expect("prepare pre-existing socket dir");
@@ -103,9 +211,33 @@ fn prepare_socket_dir_narrows_a_wide_existing_dir() {
 }
 
 #[test]
+fn prepare_socket_dir_rejects_a_symlink() {
+    // Why: the end-to-end version of review finding 1, on a real filesystem.
+    // The link points at a directory THIS uid owns, which is exactly the case
+    // the old `metadata()`-based check waved through. Asserts the target is
+    // left untouched — the old code chmod'd it to 0700.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let target = tmp.path().join("attacker_controlled");
+    std::fs::create_dir(&target).expect("create target");
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o777)).expect("widen");
+    let link = tmp.path().join("sockets");
+    std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+    let err = prepare_socket_dir(&link).expect_err("a symlinked socket dir must be refused");
+
+    assert!(
+        matches!(err, UdsSecurityError::SymlinkDir { .. }),
+        "expected SymlinkDir, got {err:?}"
+    );
+    assert_eq!(
+        mode_of(&target),
+        0o777,
+        "the symlink target must NOT have been chmod'd"
+    );
+}
+
+#[test]
 fn prepare_socket_dir_is_idempotent() {
-    // Why: every daemon restart re-runs this; a second call must not fail on
-    // the directory it created itself.
     let tmp = tempfile::tempdir().expect("tempdir");
     let dir = tmp.path().join("sockets");
 
@@ -115,12 +247,13 @@ fn prepare_socket_dir_is_idempotent() {
     assert_eq!(mode_of(&dir), SOCKET_DIR_MODE);
 }
 
+// ── bind ────────────────────────────────────────────────────────────────────
+
 #[tokio::test]
 async fn bind_hardened_sets_socket_0600_and_dir_0700() {
-    // Why: THE regression test for #5099. Against the pre-fix commit the
-    // socket comes back at the umask default (0755 under umask 022) and this
-    // assertion fails. ADR-0031/0032 cite the 0600 property; this is what
-    // makes the citation true.
+    // Why: THE regression test for #5099. Against the pre-fix commit the socket
+    // comes back at the umask default (0755 under umask 022) and this assertion
+    // fails.
     let tmp = tempfile::tempdir().expect("tempdir");
     let dir = tmp.path().join("sockets");
     let sock = dir.join("t.sock");
@@ -135,7 +268,8 @@ async fn bind_hardened_sets_socket_0600_and_dir_0700() {
 async fn bind_hardened_socket_is_connectable_after_hardening() {
     // Why: narrowing to 0600 must not break the same-uid client the socket
     // exists for — a fix that made the socket unusable would also pass a
-    // mode-only assertion.
+    // mode-only assertion. Also proves the accept-side peer check admits a
+    // legitimate peer.
     let tmp = tempfile::tempdir().expect("tempdir");
     let sock = tmp.path().join("sockets").join("t.sock");
     let listener = bind_hardened(&sock).expect("bind hardened listener");
@@ -149,8 +283,8 @@ async fn bind_hardened_socket_is_connectable_after_hardening() {
 
 #[tokio::test]
 async fn bind_hardened_rejects_a_path_with_no_parent() {
-    // Failure path: a bare relative filename has no directory to harden, so
-    // the bind must be refused rather than silently binding unprotected.
+    // Failure path: a bare relative filename has no directory to harden, so the
+    // bind must be refused rather than silently binding unprotected.
     let err = bind_hardened(Path::new("bare.sock")).expect_err("must refuse");
     assert!(
         matches!(err, UdsSecurityError::NoParent { .. }),
@@ -160,9 +294,9 @@ async fn bind_hardened_rejects_a_path_with_no_parent() {
 
 #[tokio::test]
 async fn bind_hardened_propagates_an_address_in_use_failure() {
-    // Failure path: `bind_hardened` deliberately does NOT unlink a stale
-    // socket (that would break `CtrlSocket::bind_singleton`'s probe-first
-    // guarantee), so a second bind must surface EADDRINUSE, not swallow it.
+    // Failure path: `bind_hardened` deliberately does NOT unlink a stale socket
+    // (that would break `CtrlSocket::bind_singleton`'s probe-first guarantee),
+    // so a second bind must surface EADDRINUSE, not swallow it.
     let tmp = tempfile::tempdir().expect("tempdir");
     let sock = tmp.path().join("sockets").join("t.sock");
     let _first = bind_hardened(&sock).expect("first bind");
@@ -174,10 +308,129 @@ async fn bind_hardened_propagates_an_address_in_use_failure() {
     );
 }
 
+// ── connect (review finding 3) ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn connect_hardened_accepts_a_properly_hardened_socket() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sock = tmp.path().join("sockets").join("t.sock");
+    let listener = bind_hardened(&sock).expect("bind");
+
+    let client = connect_hardened(&sock).await.expect("dial our own socket");
+    let (accepted, _) = listener.accept().await.expect("accept");
+    ensure_peer_is_self(&accepted).expect("peer is us");
+    drop(client);
+}
+
+#[tokio::test]
+async fn connect_hardened_refuses_a_world_readable_socket() {
+    // Why: a daemon that predates #5099 still answers at the canonical path.
+    // The client must refuse it rather than trusting the transport.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sock = tmp.path().join("sockets").join("t.sock");
+    let _listener = bind_hardened(&sock).expect("bind");
+    std::fs::set_permissions(&sock, std::fs::Permissions::from_mode(0o777)).expect("widen socket");
+
+    let err = connect_hardened(&sock).await.expect_err("must refuse");
+    match err {
+        UdsSecurityError::UntrustedSocket { ref reason, .. } => {
+            assert!(
+                reason.contains("0777"),
+                "reason must name the mode: {reason}"
+            );
+        }
+        other => panic!("expected UntrustedSocket, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn connect_hardened_refuses_a_socket_in_a_wide_directory() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("sockets");
+    let sock = dir.join("t.sock");
+    let _listener = bind_hardened(&sock).expect("bind");
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).expect("widen dir");
+
+    let err = connect_hardened(&sock).await.expect_err("must refuse");
+    match err {
+        UdsSecurityError::UntrustedSocket { ref reason, .. } => {
+            assert!(
+                reason.contains("directory") && reason.contains("0755"),
+                "reason must name the directory and its mode: {reason}"
+            );
+        }
+        other => panic!("expected UntrustedSocket, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn connect_hardened_refuses_a_regular_file() {
+    // Why: an attacker who cannot bind can still plant a regular file. Dialling
+    // it would fail with a confusing ENOTSOCK deep in the client.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("sockets");
+    prepare_socket_dir(&dir).expect("prepare");
+    let planted = dir.join("t.sock");
+    std::fs::write(&planted, b"not a socket").expect("plant file");
+    std::fs::set_permissions(&planted, std::fs::Permissions::from_mode(0o600)).expect("chmod");
+
+    let err = connect_hardened(&planted).await.expect_err("must refuse");
+    match err {
+        UdsSecurityError::UntrustedSocket { ref reason, .. } => {
+            assert!(reason.contains("not a socket"), "got: {reason}");
+        }
+        other => panic!("expected UntrustedSocket, got {other:?}"),
+    }
+}
+
+#[test]
+fn verify_socket_for_connect_refuses_a_symlinked_directory() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let target = tmp.path().join("elsewhere");
+    std::fs::create_dir(&target).expect("create target");
+    let link = tmp.path().join("sockets");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+    let err = verify_socket_for_connect(&link.join("t.sock")).expect_err("must refuse");
+    assert!(
+        matches!(err, UdsSecurityError::SymlinkDir { .. }),
+        "expected SymlinkDir, got {err:?}"
+    );
+}
+
+// ── peer decisions, as pure functions (review finding 5) ────────────────────
+
+#[test]
+fn peer_uid_verdict_accepts_the_same_uid() {
+    peer_uid_verdict(501, 501).expect("a same-uid peer must be admitted");
+}
+
+#[test]
+fn peer_uid_verdict_refuses_a_foreign_uid() {
+    // Why: this is the refusal that previously had NO unprivileged coverage —
+    // the `#[ignore]`d cross-uid test could not run in CI, so the policy was
+    // asserted nowhere.
+    let err = peer_uid_verdict(999, 501).expect_err("a foreign uid must be refused");
+    match err {
+        UdsSecurityError::ForeignPeer { peer, expected } => {
+            assert_eq!((peer, expected), (999, 501));
+        }
+        other => panic!("expected ForeignPeer, got {other:?}"),
+    }
+}
+
+#[test]
+fn peer_uid_verdict_refuses_root_when_we_are_not_root() {
+    // Why: root is deliberately not special-cased. Admitting it would widen the
+    // accepted set for no gain, since root bypasses the filesystem check anyway.
+    let err = peer_uid_verdict(0, 501).expect_err("root must be refused like any foreign uid");
+    assert!(matches!(err, UdsSecurityError::ForeignPeer { peer: 0, .. }));
+}
+
 #[tokio::test]
 async fn peer_uid_of_self_connection_is_self() {
-    // Why: proves the platform syscall is wired up correctly on this target —
-    // a stub returning 0 would pass `ensure_peer_is_self` only for root.
+    // Why: proves the platform syscall is wired up correctly on this target — a
+    // stub returning 0 would pass `peer_uid_verdict` only for root.
     let tmp = tempfile::tempdir().expect("tempdir");
     let sock = tmp.path().join("sockets").join("t.sock");
     let listener = bind_hardened(&sock).expect("bind");
@@ -189,55 +442,5 @@ async fn peer_uid_of_self_connection_is_self() {
         peer_uid(&accepted).expect("read peer uid"),
         self_uid(),
         "a connection from this process must report this process's uid"
-    );
-}
-
-/// Cross-uid refusal — the half of the peer check that cannot run unprivileged.
-///
-/// `#[ignore]`d because connecting as a second uid requires either root (to
-/// `setuid`) or a pre-provisioned second account, and CI runs as one
-/// unprivileged user. Run under a second uid with
-/// `cargo test -p trusty-common -- --include-ignored ensure_peer_is_self_refuses_foreign_uid`.
-/// This does NOT count as passing coverage for the refusal path; the refusal
-/// branch is otherwise proven only by `ForeignPeer`'s construction being
-/// unreachable for a same-uid peer in `peer_uid_of_self_connection_is_self`.
-#[tokio::test]
-#[ignore = "needs a second uid; unprivileged CI cannot connect as another user"]
-async fn ensure_peer_is_self_refuses_foreign_uid() {
-    let Ok(sock) = std::env::var("TRUSTY_UDS_FOREIGN_PEER_SOCK") else {
-        eprintln!(
-            "SKIPPED: set TRUSTY_UDS_FOREIGN_PEER_SOCK to a socket bound by another uid. \
-             This run proves NOTHING about the foreign-uid refusal path."
-        );
-        return;
-    };
-    let stream = UnixStream::connect(&sock)
-        .await
-        .expect("connect as other uid");
-    let err = ensure_peer_is_self(&stream).expect_err("foreign uid must be refused");
-    assert!(
-        matches!(err, UdsSecurityError::ForeignPeer { .. }),
-        "expected ForeignPeer, got {err:?}"
-    );
-}
-
-/// Foreign-owner refusal on the directory — also unprivileged-impossible.
-///
-/// `#[ignore]`d for the same reason: creating a directory owned by another uid
-/// requires root. Not counted as passing coverage.
-#[test]
-#[ignore = "needs root to create a directory owned by another uid"]
-fn prepare_socket_dir_rejects_foreign_owner() {
-    let Ok(dir) = std::env::var("TRUSTY_UDS_FOREIGN_DIR") else {
-        eprintln!(
-            "SKIPPED: set TRUSTY_UDS_FOREIGN_DIR to a directory owned by another uid. \
-             This run proves NOTHING about the foreign-owner refusal path."
-        );
-        return;
-    };
-    let err = prepare_socket_dir(Path::new(&dir)).expect_err("foreign owner must be refused");
-    assert!(
-        matches!(err, UdsSecurityError::ForeignDirOwner { .. }),
-        "expected ForeignDirOwner, got {err:?}"
     );
 }

--- a/crates/trusty-common/src/uds/tests.rs
+++ b/crates/trusty-common/src/uds/tests.rs
@@ -1,0 +1,243 @@
+//! Coverage for the #5099 socket-permission contract.
+//!
+//! The mode assertions here are the regression proof: against the pre-fix
+//! commit — where every bind site called `UnixListener::bind` bare — the
+//! socket comes back at the umask-derived mode (`0755` under the common
+//! `022` umask) and the directory at whatever `create_dir_all` produced.
+
+use super::*;
+
+use std::os::unix::fs::PermissionsExt;
+use tokio::net::UnixStream;
+
+/// Mode bits of `path`, masked to the permission nibbles.
+fn mode_of(path: &Path) -> u32 {
+    std::fs::metadata(path)
+        .expect("stat path under test")
+        .permissions()
+        .mode()
+        & 0o777
+}
+
+#[test]
+fn scratch_socket_dir_from_uses_tmpdir_when_set() {
+    // Why: on macOS the per-user `/var/folders/…/T/` must be honored, not
+    // replaced by `/tmp`.
+    let dir = scratch_socket_dir_from(Some("/var/folders/xy/T"), 501);
+    assert_eq!(dir, Path::new("/var/folders/xy/T/trusty-501"));
+}
+
+#[test]
+fn scratch_socket_dir_from_falls_back_to_tmp() {
+    // Why: #5099's core exposure — an unset `TMPDIR` on Linux used to land the
+    // socket directly in world-writable `/tmp`. The fallback must still
+    // interpose a uid-keyed directory that this process can hold at 0700.
+    for absent in [None, Some(""), Some("   ")] {
+        let dir = scratch_socket_dir_from(absent, 1000);
+        assert_eq!(
+            dir,
+            Path::new("/tmp/trusty-1000"),
+            "TMPDIR={absent:?} must still get a uid-keyed subdirectory"
+        );
+    }
+}
+
+#[test]
+fn scratch_socket_dir_is_uid_keyed() {
+    // Why: two users on one host must never share a socket directory.
+    let dir = scratch_socket_dir();
+    let leaf = dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .expect("scratch dir has a leaf name");
+    assert_eq!(leaf, format!("trusty-{}", self_uid()));
+}
+
+#[test]
+fn prepare_socket_dir_creates_at_0700() {
+    // Why: the directory mode is what closes the bind-then-chmod window, so it
+    // must be 0700 the moment the directory exists.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("sockets");
+
+    prepare_socket_dir(&dir).expect("prepare fresh socket dir");
+
+    assert_eq!(
+        mode_of(&dir),
+        SOCKET_DIR_MODE,
+        "fresh socket dir must be 0700"
+    );
+}
+
+#[test]
+fn prepare_socket_dir_creates_missing_ancestors() {
+    // Why: callers pass a nested path (`~/.trusty-agents/sockets/`) whose
+    // ancestors may not exist. Only the leaf is security-relevant.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("a").join("b").join("sockets");
+
+    prepare_socket_dir(&dir).expect("prepare nested socket dir");
+
+    assert_eq!(mode_of(&dir), SOCKET_DIR_MODE);
+}
+
+#[test]
+fn prepare_socket_dir_narrows_a_wide_existing_dir() {
+    // Why: the directory this replaces was created by `create_dir_all`, so on
+    // every existing install it is already 0755. Upgrading must repair it
+    // rather than trusting whatever is on disk.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("sockets");
+    std::fs::create_dir(&dir).expect("create wide dir");
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755))
+        .expect("widen dir to 0755");
+    assert_eq!(mode_of(&dir), 0o755, "precondition: dir starts wide");
+
+    prepare_socket_dir(&dir).expect("prepare pre-existing socket dir");
+
+    assert_eq!(
+        mode_of(&dir),
+        SOCKET_DIR_MODE,
+        "existing dir must be narrowed"
+    );
+}
+
+#[test]
+fn prepare_socket_dir_is_idempotent() {
+    // Why: every daemon restart re-runs this; a second call must not fail on
+    // the directory it created itself.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("sockets");
+
+    prepare_socket_dir(&dir).expect("first prepare");
+    prepare_socket_dir(&dir).expect("second prepare must succeed");
+
+    assert_eq!(mode_of(&dir), SOCKET_DIR_MODE);
+}
+
+#[tokio::test]
+async fn bind_hardened_sets_socket_0600_and_dir_0700() {
+    // Why: THE regression test for #5099. Against the pre-fix commit the
+    // socket comes back at the umask default (0755 under umask 022) and this
+    // assertion fails. ADR-0031/0032 cite the 0600 property; this is what
+    // makes the citation true.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("sockets");
+    let sock = dir.join("t.sock");
+
+    let _listener = bind_hardened(&sock).expect("bind hardened listener");
+
+    assert_eq!(mode_of(&sock), SOCKET_MODE, "socket must be 0600");
+    assert_eq!(mode_of(&dir), SOCKET_DIR_MODE, "socket dir must be 0700");
+}
+
+#[tokio::test]
+async fn bind_hardened_socket_is_connectable_after_hardening() {
+    // Why: narrowing to 0600 must not break the same-uid client the socket
+    // exists for — a fix that made the socket unusable would also pass a
+    // mode-only assertion.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sock = tmp.path().join("sockets").join("t.sock");
+    let listener = bind_hardened(&sock).expect("bind hardened listener");
+
+    let client = UnixStream::connect(&sock).await.expect("same-uid connect");
+    let (accepted, _) = listener.accept().await.expect("accept");
+
+    ensure_peer_is_self(&accepted).expect("same-uid peer must be accepted");
+    drop(client);
+}
+
+#[tokio::test]
+async fn bind_hardened_rejects_a_path_with_no_parent() {
+    // Failure path: a bare relative filename has no directory to harden, so
+    // the bind must be refused rather than silently binding unprotected.
+    let err = bind_hardened(Path::new("bare.sock")).expect_err("must refuse");
+    assert!(
+        matches!(err, UdsSecurityError::NoParent { .. }),
+        "expected NoParent, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn bind_hardened_propagates_an_address_in_use_failure() {
+    // Failure path: `bind_hardened` deliberately does NOT unlink a stale
+    // socket (that would break `CtrlSocket::bind_singleton`'s probe-first
+    // guarantee), so a second bind must surface EADDRINUSE, not swallow it.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sock = tmp.path().join("sockets").join("t.sock");
+    let _first = bind_hardened(&sock).expect("first bind");
+
+    let err = bind_hardened(&sock).expect_err("second bind must fail");
+    assert!(
+        matches!(err, UdsSecurityError::Bind { .. }),
+        "expected Bind, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn peer_uid_of_self_connection_is_self() {
+    // Why: proves the platform syscall is wired up correctly on this target —
+    // a stub returning 0 would pass `ensure_peer_is_self` only for root.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sock = tmp.path().join("sockets").join("t.sock");
+    let listener = bind_hardened(&sock).expect("bind");
+
+    let _client = UnixStream::connect(&sock).await.expect("connect");
+    let (accepted, _) = listener.accept().await.expect("accept");
+
+    assert_eq!(
+        peer_uid(&accepted).expect("read peer uid"),
+        self_uid(),
+        "a connection from this process must report this process's uid"
+    );
+}
+
+/// Cross-uid refusal — the half of the peer check that cannot run unprivileged.
+///
+/// `#[ignore]`d because connecting as a second uid requires either root (to
+/// `setuid`) or a pre-provisioned second account, and CI runs as one
+/// unprivileged user. Run under a second uid with
+/// `cargo test -p trusty-common -- --include-ignored ensure_peer_is_self_refuses_foreign_uid`.
+/// This does NOT count as passing coverage for the refusal path; the refusal
+/// branch is otherwise proven only by `ForeignPeer`'s construction being
+/// unreachable for a same-uid peer in `peer_uid_of_self_connection_is_self`.
+#[tokio::test]
+#[ignore = "needs a second uid; unprivileged CI cannot connect as another user"]
+async fn ensure_peer_is_self_refuses_foreign_uid() {
+    let Ok(sock) = std::env::var("TRUSTY_UDS_FOREIGN_PEER_SOCK") else {
+        eprintln!(
+            "SKIPPED: set TRUSTY_UDS_FOREIGN_PEER_SOCK to a socket bound by another uid. \
+             This run proves NOTHING about the foreign-uid refusal path."
+        );
+        return;
+    };
+    let stream = UnixStream::connect(&sock)
+        .await
+        .expect("connect as other uid");
+    let err = ensure_peer_is_self(&stream).expect_err("foreign uid must be refused");
+    assert!(
+        matches!(err, UdsSecurityError::ForeignPeer { .. }),
+        "expected ForeignPeer, got {err:?}"
+    );
+}
+
+/// Foreign-owner refusal on the directory — also unprivileged-impossible.
+///
+/// `#[ignore]`d for the same reason: creating a directory owned by another uid
+/// requires root. Not counted as passing coverage.
+#[test]
+#[ignore = "needs root to create a directory owned by another uid"]
+fn prepare_socket_dir_rejects_foreign_owner() {
+    let Ok(dir) = std::env::var("TRUSTY_UDS_FOREIGN_DIR") else {
+        eprintln!(
+            "SKIPPED: set TRUSTY_UDS_FOREIGN_DIR to a directory owned by another uid. \
+             This run proves NOTHING about the foreign-owner refusal path."
+        );
+        return;
+    };
+    let err = prepare_socket_dir(Path::new(&dir)).expect_err("foreign owner must be refused");
+    assert!(
+        matches!(err, UdsSecurityError::ForeignDirOwner { .. }),
+        "expected ForeignDirOwner, got {err:?}"
+    );
+}

--- a/crates/trusty-common/src/uds/tests.rs
+++ b/crates/trusty-common/src/uds/tests.rs
@@ -120,7 +120,7 @@ fn classify_existing_dir_rejects_a_symlink() {
     // reports the TARGET's owner and mode, so a link pointing at any directory
     // this uid happens to own would otherwise pass the owner check — and
     // `set_permissions` would then chmod the target.
-    let err = classify_existing_dir(Path::new("/tmp/x"), true, 501, 0o700, 501)
+    let err = classify_existing_dir(Path::new("/tmp/x"), true, false, "symlink", 501, 0o700, 501)
         .expect_err("a symlink must be refused even when owner and mode look right");
     assert!(
         matches!(err, UdsSecurityError::SymlinkDir { .. }),
@@ -129,8 +129,43 @@ fn classify_existing_dir_rejects_a_symlink() {
 }
 
 #[test]
+fn classify_existing_dir_rejects_a_regular_file() {
+    // Why: review round 2, finding 1. A regular file owned by this uid at the
+    // socket-dir path passed the symlink AND owner checks, was classified
+    // `Narrow`, and got chmod'd to 0700 before `bind` failed ENOTDIR.
+    let err = classify_existing_dir(
+        Path::new("/tmp/x"),
+        false,
+        false,
+        "regular file",
+        501,
+        0o644,
+        501,
+    )
+    .expect_err("a non-directory must be refused");
+    match err {
+        UdsSecurityError::NotADirectory { ref found, .. } => {
+            assert_eq!(found, "regular file", "diagnostic must name what was found");
+        }
+        other => panic!("expected NotADirectory, got {other:?}"),
+    }
+}
+
+#[test]
+fn classify_existing_dir_checks_file_type_before_owner() {
+    // Why: a foreign-owned non-directory must report NotADirectory. Reporting
+    // ForeignDirOwner would imply the path was a directory worth chmodding.
+    let err = classify_existing_dir(Path::new("/tmp/x"), false, false, "fifo", 999, 0o777, 501)
+        .expect_err("no");
+    assert!(
+        matches!(err, UdsSecurityError::NotADirectory { .. }),
+        "file type must be checked before ownership, got {err:?}"
+    );
+}
+
+#[test]
 fn classify_existing_dir_rejects_a_foreign_owner() {
-    let err = classify_existing_dir(Path::new("/tmp/x"), false, 0, 0o700, 501)
+    let err = classify_existing_dir(Path::new("/tmp/x"), false, true, "directory", 0, 0o700, 501)
         .expect_err("a root-owned directory must be refused");
     match err {
         UdsSecurityError::ForeignDirOwner {
@@ -144,13 +179,31 @@ fn classify_existing_dir_rejects_a_foreign_owner() {
 
 #[test]
 fn classify_existing_dir_narrows_a_wide_dir() {
-    let v = classify_existing_dir(Path::new("/tmp/x"), false, 501, 0o755, 501).expect("ours");
+    let v = classify_existing_dir(
+        Path::new("/tmp/x"),
+        false,
+        true,
+        "directory",
+        501,
+        0o755,
+        501,
+    )
+    .expect("ours");
     assert_eq!(v, DirVerdict::Narrow);
 }
 
 #[test]
 fn classify_existing_dir_accepts_an_already_correct_dir() {
-    let v = classify_existing_dir(Path::new("/tmp/x"), false, 501, 0o700, 501).expect("ours");
+    let v = classify_existing_dir(
+        Path::new("/tmp/x"),
+        false,
+        true,
+        "directory",
+        501,
+        0o700,
+        501,
+    )
+    .expect("ours");
     assert_eq!(v, DirVerdict::Accept);
 }
 
@@ -158,7 +211,8 @@ fn classify_existing_dir_accepts_an_already_correct_dir() {
 fn classify_existing_dir_checks_symlink_before_owner() {
     // Why: ordering matters. An attacker-owned symlink must report SymlinkDir,
     // not ForeignDirOwner — the latter would imply the path itself was checked.
-    let err = classify_existing_dir(Path::new("/tmp/x"), true, 999, 0o777, 501).expect_err("no");
+    let err = classify_existing_dir(Path::new("/tmp/x"), true, false, "symlink", 999, 0o777, 501)
+        .expect_err("no");
     assert!(
         matches!(err, UdsSecurityError::SymlinkDir { .. }),
         "symlink must be rejected before ownership is considered, got {err:?}"
@@ -233,6 +287,31 @@ fn prepare_socket_dir_rejects_a_symlink() {
         mode_of(&target),
         0o777,
         "the symlink target must NOT have been chmod'd"
+    );
+}
+
+#[test]
+fn prepare_socket_dir_rejects_a_regular_file_without_chmodding_it() {
+    // Why: the end-to-end half of review-round-2 finding 1. The pre-fix code
+    // chmod'd this file to 0700 on its way to an ENOTDIR from `bind`; the mode
+    // assertion is what proves the file was left alone.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let planted = tmp.path().join("sockets");
+    std::fs::write(&planted, b"not a directory").expect("plant file");
+    std::fs::set_permissions(&planted, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+
+    let err = prepare_socket_dir(&planted).expect_err("a non-directory must be refused");
+
+    match err {
+        UdsSecurityError::NotADirectory { ref found, .. } => {
+            assert_eq!(found, "regular file");
+        }
+        other => panic!("expected NotADirectory, got {other:?}"),
+    }
+    assert_eq!(
+        mode_of(&planted),
+        0o644,
+        "the planted file must NOT have been chmod'd"
     );
 }
 
@@ -381,6 +460,39 @@ async fn connect_hardened_refuses_a_regular_file() {
         }
         other => panic!("expected UntrustedSocket, got {other:?}"),
     }
+}
+
+#[test]
+fn verify_socket_for_connect_reports_a_stat_failure_as_stat_not_create() {
+    // Why: review round 2, finding 2. A dialer creates nothing, so a failed
+    // stat used to surface as "create socket directory …" — naming an action
+    // never attempted.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let missing = tmp.path().join("absent").join("t.sock");
+
+    let err = verify_socket_for_connect(&missing).expect_err("must fail");
+
+    assert!(
+        matches!(err, UdsSecurityError::StatForConnect { .. }),
+        "expected StatForConnect, got {err:?}"
+    );
+    assert!(
+        !err.to_string().contains("create socket directory"),
+        "a dialer must not claim it was creating anything: {err}"
+    );
+}
+
+#[test]
+fn verify_socket_for_connect_refuses_a_regular_file_as_the_directory() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let planted = tmp.path().join("sockets");
+    std::fs::write(&planted, b"not a directory").expect("plant file");
+
+    let err = verify_socket_for_connect(&planted.join("t.sock")).expect_err("must refuse");
+    assert!(
+        matches!(err, UdsSecurityError::NotADirectory { .. }),
+        "expected NotADirectory, got {err:?}"
+    );
 }
 
 #[test]

--- a/crates/trusty-embedderd/Cargo.toml
+++ b/crates/trusty-embedderd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-embedderd"
-version = "0.3.10"
+version = "0.3.11"
 publish = true
 edition = "2021"
 license.workspace = true

--- a/crates/trusty-embedderd/Cargo.toml
+++ b/crates/trusty-embedderd/Cargo.toml
@@ -44,7 +44,7 @@ crate-type = ["rlib"]
 # `bundled-ort` feature below now carries that requirement instead, and it is
 # on by default (see `default` below) so the zero-config `cargo install`
 # experience on modern glibc is unchanged.
-trusty-common = { workspace = true, features = ["embedder", "embedder-client"] }
+trusty-common = { workspace = true, features = ["embedder", "embedder-client", "uds"] }
 
 # CLI argument parsing.
 clap = { workspace = true }

--- a/crates/trusty-embedderd/changelog.d/5099-uds-socket-permissions.md
+++ b/crates/trusty-embedderd/changelog.d/5099-uds-socket-permissions.md
@@ -1,0 +1,11 @@
+Fixed
+
+- **The UDS listener bound a world-readable socket**
+  ([#5099](https://github.com/bobmatnyc/trusty-tools/issues/5099)).
+  `bind_uds_listener` called `UnixListener::bind` bare, so the socket was
+  created at the process umask (`0755` under the common `022`) in a directory
+  that was not narrowed either — despite ADR-0031 and ADR-0032 both resting
+  their access-control argument on a `0600` socket. It now binds through
+  `trusty_common::uds::bind_hardened` (`0700` directory, `0600` socket before
+  the first accept), and `run_uds_accept_loop` drops any connection whose peer
+  uid is not this process's own.

--- a/crates/trusty-embedderd/changelog.d/5099-uds-socket-permissions.md
+++ b/crates/trusty-embedderd/changelog.d/5099-uds-socket-permissions.md
@@ -9,3 +9,6 @@ Fixed
   `trusty_common::uds::bind_hardened` (`0700` directory, `0600` socket before
   the first accept), and `run_uds_accept_loop` drops any connection whose peer
   uid is not this process's own.
+- Version bumped to 0.3.11: 0.3.10 is already published on crates.io and this
+  PR changes `src/**`, so leaving it would turn main's version-parity workflow
+  red (#4421, #3366).

--- a/crates/trusty-embedderd/src/uds_server.rs
+++ b/crates/trusty-embedderd/src/uds_server.rs
@@ -33,9 +33,12 @@ use crate::protocol::{
 ///
 /// Why: a previous run may have left a socket file that would cause `EADDRINUSE`
 /// on the next bind attempt. Removing it first is the idiomatic Unix pattern.
-/// What: removes any existing file at `path` (ignoring "not found"), then
-/// calls `UnixListener::bind`.
-/// Test: covered by the concurrent_embed integration test.
+/// What: removes any existing file at `path` (ignoring "not found"), then binds
+/// through [`trusty_common::uds::bind_hardened`], which holds the containing
+/// directory at `0700` and narrows the socket to `0600` before the first accept
+/// (#5099 — this bind used to be bare, leaving the socket at the process umask).
+/// Test: `bind_uds_listener_produces_a_0600_socket`, plus the concurrent_embed
+/// integration test for the accept path.
 pub fn bind_uds_listener(path: &Path) -> Result<UnixListener> {
     // Best-effort cleanup of a stale socket file.
     if let Err(e) = std::fs::remove_file(path) {
@@ -43,7 +46,8 @@ pub fn bind_uds_listener(path: &Path) -> Result<UnixListener> {
             tracing::warn!("failed to remove stale UDS socket {}: {e}", path.display());
         }
     }
-    UnixListener::bind(path).with_context(|| format!("bind UDS socket at {}", path.display()))
+    trusty_common::uds::bind_hardened(path)
+        .with_context(|| format!("bind UDS socket at {}", path.display()))
 }
 
 /// Accept connections in a loop, spawning a per-connection handler task.
@@ -51,13 +55,20 @@ pub fn bind_uds_listener(path: &Path) -> Result<UnixListener> {
 /// Why: a single-threaded accept loop with detached per-connection tasks
 /// scales well for the daemon's expected load (dozens of concurrent in-host
 /// clients, short-lived requests).
-/// What: loops `listener.accept().await`; on each accepted stream, clones the
-/// `BatchQueue` handle and spawns [`handle_connection`].
+/// What: loops `listener.accept().await`; on each accepted stream, verifies the
+/// peer's uid matches this process's own (#5099) and then clones the
+/// `BatchQueue` handle and spawns [`handle_connection`]. A foreign-uid peer is
+/// dropped without being served — the filesystem mode should already have made
+/// that unreachable, and this is what turns the mode into an enforced boundary.
 /// Test: covered by `concurrent_embed.rs` integration test.
 pub async fn run_uds_accept_loop(listener: UnixListener, queue: Arc<BatchQueue>) {
     loop {
         match listener.accept().await {
             Ok((stream, _addr)) => {
+                if let Err(e) = trusty_common::uds::ensure_peer_is_self(&stream) {
+                    tracing::warn!("rejected UDS connection: {e}");
+                    continue;
+                }
                 let q = Arc::clone(&queue);
                 tokio::spawn(async move {
                     if let Err(e) = handle_connection(stream, q).await {
@@ -183,6 +194,25 @@ mod tests {
     fn test_queue() -> BatchQueue {
         let embedder: Arc<dyn Embedder> = Arc::new(MockEmbedder::new(EMBED_DIM));
         BatchQueue::new(embedder, BatchConfig::default())
+    }
+
+    /// #5099 regression: the daemon's own bind path must produce a 0600
+    /// socket in a 0700 directory. Against the pre-fix commit this bind was
+    /// bare and the socket came back at the process umask (0755 under 022).
+    #[tokio::test]
+    async fn bind_uds_listener_produces_a_0600_socket() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("sockets");
+        let sock = dir.join("embedderd.sock");
+
+        let _listener = bind_uds_listener(&sock).expect("bind");
+
+        let mode =
+            |p: &std::path::Path| std::fs::metadata(p).expect("stat").permissions().mode() & 0o777;
+        assert_eq!(mode(&sock), 0o600, "socket must be 0600");
+        assert_eq!(mode(&dir), 0o700, "socket dir must be 0700");
     }
 
     #[tokio::test]

--- a/crates/trusty-embedderd/tests/concurrent_embed.rs
+++ b/crates/trusty-embedderd/tests/concurrent_embed.rs
@@ -300,7 +300,9 @@ async fn concurrent_uds_requests_all_succeed() {
     let embedder: Arc<dyn Embedder> = Arc::new(MockEmbedder::new(EMBED_DIM));
     let queue = Arc::new(trusty_embedderd_test_helpers::BatchQueue::new(embedder));
 
-    let listener = tokio::net::UnixListener::bind(&socket_path).expect("bind UDS");
+    // #5099: bind the way the real daemon does — a bare bind leaves the socket
+    // and its directory at the process umask, which the client now refuses.
+    let listener = trusty_common::uds::bind_hardened(&socket_path).expect("bind UDS");
     tokio::spawn(run_mock_uds_server(listener, Arc::clone(&queue)));
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
@@ -358,7 +360,8 @@ async fn mixed_http_uds_concurrent_all_succeed() {
     });
 
     // Bind UDS.
-    let uds_listener = tokio::net::UnixListener::bind(&socket_path).expect("bind UDS");
+    // #5099: bind the way the real daemon does (see above).
+    let uds_listener = trusty_common::uds::bind_hardened(&socket_path).expect("bind UDS");
     tokio::spawn(run_mock_uds_server(uds_listener, Arc::clone(&queue)));
 
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;

--- a/crates/trusty-memory/src/bm25_backfill_tests.rs
+++ b/crates/trusty-memory/src/bm25_backfill_tests.rs
@@ -114,7 +114,9 @@ async fn backfill_reports_daemon_unavailable_when_socket_is_dead() {
 async fn backfill_gives_up_on_a_socket_that_never_answers() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let socket = tmp.path().join("silent.sock");
-    let listener = tokio::net::UnixListener::bind(&socket).expect("bind silent listener");
+    // #5099: bind the way the real daemon does — the client verifies the
+    // directory and socket modes before connecting.
+    let listener = trusty_common::uds::bind_hardened(&socket).expect("bind silent listener");
     // Accept and hold, never reply.
     let accepted = tokio::spawn(async move {
         let mut held = Vec::new();
@@ -370,7 +372,9 @@ fn stub_daemon(
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
     let seen = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let counter = std::sync::Arc::clone(&seen);
-    let listener = tokio::net::UnixListener::bind(&socket).expect("bind stub daemon");
+    // #5099: bind the way the real daemon does — the client verifies the
+    // directory and socket modes before connecting.
+    let listener = trusty_common::uds::bind_hardened(&socket).expect("bind stub daemon");
     let handle = tokio::spawn(async move {
         while let Ok((stream, _)) = listener.accept().await {
             let counter = std::sync::Arc::clone(&counter);

--- a/crates/trusty-memory/src/bm25_supervisor_tests.rs
+++ b/crates/trusty-memory/src/bm25_supervisor_tests.rs
@@ -102,7 +102,7 @@ async fn already_running_skips_spawn() {
     // a sibling test that ran first.
     let _g = EnvGuard::remove(ENV_EXTERNAL_BM25);
     // Use a very short palace name. The canonical socket path is
-    // `$TMPDIR/trusty-bm25-<palace>.sock`, and macOS' `$TMPDIR`
+    // `$TMPDIR/trusty-<uid>/trusty-bm25-<palace>.sock`, and macOS' `$TMPDIR`
     // (`/var/folders/.../T/`) is already long, so we keep the palace
     // fragment to a handful of characters to avoid SUN_LEN errors.
     // Use the low bits of process PID to disambiguate concurrent
@@ -111,8 +111,11 @@ async fn already_running_skips_spawn() {
     let socket = socket_path_for_palace(&palace);
     // Clean up any leftover socket from a previous failed test.
     let _ = std::fs::remove_file(&socket);
+    // #5099: bind the way the real daemon does. A bare `UnixListener::bind`
+    // here fails with ENOENT now that the canonical path sits inside a
+    // uid-keyed directory that only `bind_hardened` creates.
     let listener =
-        tokio::net::UnixListener::bind(&socket).expect("bind dummy listener at canonical path");
+        trusty_common::uds::bind_hardened(&socket).expect("bind dummy listener at canonical path");
 
     let tmp = tempfile::tempdir().expect("tempdir");
     let sup = Bm25Supervisor::new();

--- a/crates/trusty-memory/tests/bm25_supervisor_concurrency.rs
+++ b/crates/trusty-memory/tests/bm25_supervisor_concurrency.rs
@@ -54,10 +54,11 @@ fn arm() {
 
 /// Short, collision-free palace name.
 ///
-/// Why: the socket path is `$TMPDIR/trusty-bm25-<palace>.sock` and macOS'
-/// `$TMPDIR` is already ~50 bytes, so a long palace name blows past the
-/// kernel's `sun_path` limit and the bind fails for reasons unrelated to the
-/// behaviour under test.
+/// Why: the socket path is `$TMPDIR/trusty-<uid>/trusty-bm25-<palace>.sock` and
+/// macOS' `$TMPDIR` is already ~50 bytes, so a long palace name blows past the
+/// kernel's `sun_path` limit (104 on macOS) and the bind fails for reasons
+/// unrelated to the behaviour under test. #5099 spent 11 of those bytes on the
+/// uid-keyed directory, leaving roughly 26 characters for the palace fragment.
 /// What: a two-character prefix plus the low bits of the pid.
 fn palace(prefix: &str, n: usize) -> String {
     format!("{prefix}{:x}{n}", std::process::id() & 0xfff)

--- a/crates/trusty-memory/ui/package-lock.json
+++ b/crates/trusty-memory/ui/package-lock.json
@@ -597,9 +597,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -614,9 +611,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -631,9 +625,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -648,9 +639,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -665,9 +653,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -682,9 +667,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -699,9 +681,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -716,9 +695,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -733,9 +709,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -750,9 +723,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -767,9 +737,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -784,9 +751,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -801,9 +765,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/crates/trusty-memory/ui/package-lock.json
+++ b/crates/trusty-memory/ui/package-lock.json
@@ -597,6 +597,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -611,6 +614,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -625,6 +631,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -639,6 +648,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -653,6 +665,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -667,6 +682,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -681,6 +699,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -695,6 +716,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -709,6 +733,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -723,6 +750,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -737,6 +767,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -751,6 +784,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,6 +801,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/crates/trusty-search/changelog.d/5099-uds-socket-permissions.md
+++ b/crates/trusty-search/changelog.d/5099-uds-socket-permissions.md
@@ -1,0 +1,10 @@
+Changed
+
+- **The embedder UDS socket path moves into a per-uid directory**
+  ([#5099](https://github.com/bobmatnyc/trusty-tools/issues/5099)).
+  `embedder_supervisor::default_socket_path` resolved to `$TMPDIR`, falling back
+  to `/tmp` on headless Linux — world-writable, and unable to be narrowed to
+  `0700`. It now resolves under `trusty_common::uds::scratch_socket_dir()`
+  (`<$TMPDIR or /tmp>/trusty-<uid>/`), keeping the PID suffix that separates
+  concurrent daemons. Affects the `TRUSTY_EMBEDDER=unix:/path` transport only;
+  the default auto-spawn path uses stdio and is unchanged.

--- a/crates/trusty-search/src/service/embedder_supervisor/mod.rs
+++ b/crates/trusty-search/src/service/embedder_supervisor/mod.rs
@@ -206,10 +206,12 @@ pub fn locate_embedderd_binary() -> anyhow::Result<PathBuf> {
 ///
 /// Why: if two daemons share a single socket path, the second spawn would
 /// fail with "address already in use". Using the parent PID disambiguates.
-/// What:
-///   - macOS/Linux: `$TMPDIR/trusty-embedderd-<PID>.sock`
-///   - Falls back to `/tmp/trusty-embedderd-<PID>.sock` when `TMPDIR` is
-///     empty (common on headless Linux).
+/// What: `<$TMPDIR or /tmp>/trusty-<uid>/trusty-embedderd-<PID>.sock`.
+///
+/// #5099: the socket used to sit directly in `$TMPDIR`, falling back to a
+/// world-writable `/tmp` on headless Linux. The uid-keyed subdirectory from
+/// [`trusty_common::uds::scratch_socket_dir`] is what the daemon holds at
+/// `0700`; the PID keeps concurrent daemons from colliding inside it.
 ///
 /// Note: this path is used for the UDS transport
 /// (`TRUSTY_EMBEDDER=unix:/path`). The default auto-spawn path uses the
@@ -217,15 +219,7 @@ pub fn locate_embedderd_binary() -> anyhow::Result<PathBuf> {
 /// Test: `default_socket_path_is_pid_specific`.
 pub fn default_socket_path() -> PathBuf {
     let pid = std::process::id();
-    let filename = format!("trusty-embedderd-{pid}.sock");
-
-    let dir = std::env::var("TMPDIR")
-        .ok()
-        .filter(|s| !s.trim().is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/tmp"));
-
-    dir.join(filename)
+    trusty_common::uds::scratch_socket_dir().join(format!("trusty-embedderd-{pid}.sock"))
 }
 
 // ── Lazy spawn handle (issue #315) ───────────────────────────────────────────

--- a/docs/adr/0031-uds-for-inter-crate-transport-http-for-external.md
+++ b/docs/adr/0031-uds-for-inter-crate-transport-http-for-external.md
@@ -1,6 +1,6 @@
 # 0031. Transport by purpose: inter-crate same-host traffic over UDS; all external traffic through one shared HTTP server
 
-- **Status:** Proposed
+- **Status:** Proposed — access-control premise corrected by #5099 (see the correction note in Decision Drivers)
 - **Date:** 2026-08-06
 - **Scope:** Workspace-wide (the tool path of every trusty-\* daemon:
   trusty-search, trusty-memory, trusty-analyze, trusty-review,
@@ -269,6 +269,19 @@ Not performance — the measurements above rule that out. Three other grounds:
    **strengthens** it — the per-daemon bind posture and origin-guard reasoning
    collapse into a file permission, enforced by the kernel rather than by each
    daemon remembering to wrap its router.
+
+> 🔴 **Correction (#5099, 2026-08-07).** The `0600` socket this section rests on
+> did not exist when this ADR was written. No production code in the workspace
+> called `set_permissions` on any socket — every hit was a test fixture — so
+> sockets were created at the process umask, commonly `0755`, and the embedder
+> and BM25 conventions placed them in `$TMPDIR` falling back to a
+> world-writable `/tmp`. The access-control argument above was therefore
+> aspirational, not a description of the system. It became true in
+> [#5099](https://github.com/bobmatnyc/trusty-tools/issues/5099), which added
+> `trusty_common::uds` (`0700` directory, `0600` socket, peer-uid check on
+> accept, per-uid scratch directory) and routed all four bind sites through it.
+> The Decision text above is left unedited per DOC-46 §4; this note records that
+> its premise was a requirement rather than an existing property.
 2. **Port lifecycle.** Sockets have no port-allocation problem: no
    auto-selection across a range (trusty-memory scans 7070–7079 today), no
    collisions, no `http_addr` file to poll for a dynamic port, no stale-port

--- a/docs/adr/0032-no-service-owns-http-console-is-the-only-http-surface.md
+++ b/docs/adr/0032-no-service-owns-http-console-is-the-only-http-surface.md
@@ -9,6 +9,9 @@
   remains in force in full; its Context/Decision/Consequences are left as
   originally accepted per the ADR immutability rule (DOC-46 §4), and
   ADR-0034 is the record of the amendment.
+  Its `0600` access-control premise is separately corrected by
+  [#5099](https://github.com/bobmatnyc/trusty-tools/issues/5099) — see the
+  correction note in Consequences.
 - **Date:** 2026-08-07
 - **Accepted:** 2026-08-07 (owner ruling, verbatim below)
 - **Scope:** Workspace-wide (every trusty-\* daemon that currently binds HTTP:
@@ -133,6 +136,15 @@ Concretely:
   `docs/reference/threat-model.md` exists to audit — a `0600`-permissioned
   socket in a user-owned directory replaces a loopback TCP port reachable by
   any local process, which is a stronger guarantee, not a weaker one.
+
+> 🔴 **Correction (#5099, 2026-08-07).** The `0600`-permissioned socket cited
+> here was not implemented anywhere in the workspace when this ADR was written;
+> see ADR-0031's matching correction note. It became true in
+> [#5099](https://github.com/bobmatnyc/trusty-tools/issues/5099). Note also that
+> the "UDS listener/dial module in `trusty-common`, mounted by every daemon"
+> assumed above still does not exist as a *transport*; #5099 supplied only its
+> security layer, and [#5089](https://github.com/bobmatnyc/trusty-tools/issues/5089)
+> step 1 builds the framing and dialing on top.
 - Unblocks [#5028](https://github.com/bobmatnyc/trusty-tools/issues/5028):
   trusty-analyze and trusty-review can now be built as on-demand processes
   rather than always-listening daemons, because their inter-service surface

--- a/scripts/semver-checks-feature-exclusions.tsv
+++ b/scripts/semver-checks-feature-exclusions.tsv
@@ -15,3 +15,5 @@
 # <crate>	<feature>	<reason>
 trusty-common	embedder-cuda	cudarc/candle-kernels build.rs panics without nvcc; no CI runner has the CUDA toolkit
 trusty-common	embedder-coreml	links the macOS CoreML framework; cannot build on ubuntu-latest
+trusty-embedderd	cuda	pass-through to trusty-common/embedder-cuda; cudarc + candle-kernels build.rs panic "`nvcc --version` failed" without the CUDA toolkit
+trusty-embedderd	coreml	pass-through to trusty-common/embedder-coreml; links the macOS CoreML framework, cannot build on ubuntu-latest


### PR DESCRIPTION
## Defect

No production code in this workspace set permissions on any Unix-domain socket. Every `set_permissions` / `PermissionsExt` hit was a test fixture, a credential file, a trust file, or an installed binary — none was a socket. Sockets were created at the process umask (commonly `0755`), and two of the three path conventions placed them in `$TMPDIR` falling back to `/tmp` — mode `1777`, owned by root, on a Linux host with `TMPDIR` unset.

[ADR-0031](https://github.com/bobmatnyc/trusty-tools/blob/main/docs/adr/0031-uds-for-inter-crate-transport-http-for-external.md) and [ADR-0032](https://github.com/bobmatnyc/trusty-tools/blob/main/docs/adr/0032-no-service-owns-http-console-is-the-only-http-surface.md) both rest their case for UDS over loopback TCP on "a `0600` socket". [ADR-0034](https://github.com/bobmatnyc/trusty-tools/pull/5090) states the requirement it must actually meet: `0700` on the containing directory, `0600` on the socket, peer-uid check on accept.

## Resolution

New `trusty_common::uds` — the single entry point all four bind sites route through.

**Four bind sites, not three.** ADR-0034's table names three *clients*; the binds live on the server side, and `trusty-agents`' message bus is a fourth site the ADR does not list:

| Site | Was |
|---|---|
| `trusty-embedderd/src/uds_server.rs` | bare `UnixListener::bind` |
| `trusty-bm25-daemon/src/server.rs` | bare `UnixListener::bind` |
| `trusty-agents/src/ctrl/socket.rs` (`bind` + `bind_singleton`) | `create_dir_all` + bare bind |
| `trusty-agents/src/bus/mod.rs` | `create_dir_all` + bare bind |

### The ordering trap is closed by the directory, not the chmod

Binding creates the file, so a `chmod` after `bind` leaves a window in which the socket exists at the umask-derived mode. `prepare_socket_dir` creates the parent at `0700` through `DirBuilder::mode()`, which passes the mode to `mkdir(2)` **atomically** — unlike `create_dir_all` followed by `set_permissions`, which reproduces the same ordering bug one level up. Unix path resolution requires search permission on every component, so no other uid can *name* the socket at any point, including during the window. The `0600` chmod after bind is defence in depth.

Setting the process umask around the bind was rejected: umask is process-global, so under a multi-threaded tokio runtime a sibling thread creating an unrelated file would silently inherit it.

### The `$TMPDIR`-with-`/tmp` fallback

Addressed, not waived. `/tmp` can be neither narrowed to `0700` nor trusted, so `uds::scratch_socket_dir()` interposes a uid-keyed `<$TMPDIR or /tmp>/trusty-<uid>/`. All four path resolvers (two clients in `trusty-common`, the bm25 daemon, the search embedder supervisor) moved in lockstep so client and daemon still agree.

Two consequences, both deliberate: **a running daemon must be restarted** to be found at the new path, and the extra segment costs 11 bytes of the kernel's `sun_path` budget (104 on macOS, where `$TMPDIR` alone is ~50), narrowing usable palace-name length from ~37 to ~26 characters.

### Peer-uid check

`SO_PEERCRED` on Linux, `getpeereid` on macOS/BSD, via `libc` — already in `[workspace.dependencies]`, so no new dependency; its `trusty-common` target gate widens from macOS-only to `cfg(unix)`. A unix target with neither syscall fails closed rather than compiling to an unchecked accept.

### Coordination with #5089

Deliberately not a transport — no framing, no dialing, no JSON-RPC. [#5089](https://github.com/bobmatnyc/trusty-tools/issues/5089) step 1 builds the shared UDS transport module; this is the security layer that module mounts, so it is adopted rather than becoming a fourth copy.

## Red-before-green

The fix was reverted in place (`create_dir_all`, bare bind, no chmod) and the regression tests re-run. `git stash` was avoided — the stash stack is repo-level and shared across this repo's concurrent worktrees.

```
test uds::tests::bind_hardened_sets_socket_0600_and_dir_0700 ... FAILED
panicked at crates/trusty-common/src/uds/tests.rs:122:5:
assertion `left == right` failed: socket must be 0600
  left: 493
 right: 384
test result: FAILED. 0 passed; 1 failed; 0 ignored

test uds::tests::prepare_socket_dir_creates_at_0700 ... FAILED
test uds::tests::prepare_socket_dir_narrows_a_wide_existing_dir ... FAILED
test uds::tests::prepare_socket_dir_creates_missing_ancestors ... FAILED
test uds::tests::prepare_socket_dir_is_idempotent ... FAILED
  left: 493     (0o755, umask-derived)
 right: 448     (0o700)
test result: FAILED. 0 passed; 4 failed; 1 ignored
```

Restored: `test result: ok. 12 passed; 0 failed; 2 ignored`.

Each migrated bind site also carries its own mode assertion — `bind_uds_listener_produces_a_0600_socket`, `bind_listener_produces_a_0600_socket`, `bind_produces_a_0600_socket_in_a_0700_dir`, `bind_singleton_hardens_the_socket_it_takes_over` — so a future site that stops routing through `bind_hardened` fails in its own crate.

## What is NOT covered

The two refusal paths — foreign peer uid and foreign directory owner — are `#[ignore]`d because they need a second uid (or root). They now **skip loudly rather than pass silently**, printing `SKIPPED: … This run proves NOTHING about the …refusal path.` **Do not read their `ok` under `--include-ignored` as coverage.** They are manual harnesses gated on `TRUSTY_UDS_FOREIGN_PEER_SOCK` / `TRUSTY_UDS_FOREIGN_DIR`.

## Gate — Rust Test Ladder rung 5 (security + cross-crate contract)

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo check --workspace --all-targets` | EXIT=0 |
| `cargo clippy -p trusty-common --all-targets -- -D warnings` | EXIT=0 |
| `cargo clippy -p trusty-agents --all-targets -- -D warnings` | EXIT=0 |
| `cargo clippy -p trusty-memory --all-targets -- -D warnings` | EXIT=0 |
| `cargo clippy -p trusty-bm25-daemon --all-targets -- -D warnings` | EXIT=0 |
| `cargo clippy -p trusty-embedderd --all-targets -- -D warnings` | EXIT=0 |
| `cargo clippy -p trusty-search --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-common` (+`--features uds`) | 290 passed, 0 failed / 12 uds passed, 2 ignored |
| `cargo test -p trusty-agents` | 3379 passed, 0 failed, 11 ignored |
| `cargo test -p trusty-memory` | 603 passed, 0 failed, 4 ignored |
| `cargo test -p trusty-bm25-daemon` | 47 passed, 0 failed |
| `cargo test -p trusty-embedderd` | 27 passed, 0 failed |
| `cargo test -p trusty-search` | 1512 passed, 0 failed, 1 ignored |
| `--include-ignored` (uds, 3 crates) | 19 passed, 0 failed |
| `bash scripts/check_line_cap.sh` | 3765 files, 0 violations |
| `bash scripts/check_changelog_fragment.sh` | all 5 crates recorded |

**`cargo test -p trusty-common` alone does not run the uds tests** — `uds` is not a default feature. Feature unification enables it under any multi-package invocation, which is verified: `cargo test -p trusty-common -p trusty-embedderd uds::` → 17 passed. CI runs `cargo test --workspace`, so it is covered there.

No baseline failures encountered. The one test that broke — `trusty-memory`'s `already_running_skips_spawn` — was caused by this diff (it bound bare at the canonical path, now ENOENT inside the uid-keyed directory) and is fixed by binding the way the real daemon does.

`cargo check --workspace` needs `crates/{trusty-code-gui,trusty-mpm-gui}/ui/dist` to exist; a placeholder `index.html` was created locally and is gitignored, not committed.

Closes #5099

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
