### PR TITLE
feat: add an opt-in STALE content check to the public-docs gate

### DIFF
--- a/docs/public-manifest.tsv
+++ b/docs/public-manifest.tsv
@@ -36,7 +36,9 @@
 #   SvelteKit build (no YAML/TOML parser).
 #
 # Gate: scripts/check_public_docs.sh — fails when a source is missing, escapes
-#   docs/, lands in a DO-NOT-PUBLISH tree, or when a route is duplicated.
+#   docs/, lands in a DO-NOT-PUBLISH tree, or when a route is duplicated. With
+#   `--stale` it additionally checks each published page's CONTENT against
+#   docs/public-stale-terms.tsv (see "KEEPING A PUBLISHED PAGE CURRENT" below).
 #   Self-test: scripts/check_public_docs_selftest.sh
 #
 # DO-NOT-PUBLISH trees (owner decision, enforced independently of this file by
@@ -62,7 +64,32 @@
 #   Corollary: never give the suffix to a file you intend to publish. Renaming
 #   it is the fix, not adding a manifest row.
 #
-# Issue: #5096 (epic #5092).
+# KEEPING A PUBLISHED PAGE CURRENT — docs/public-stale-terms.tsv
+#
+#   Listing a page proves it EXISTS and sits inside the boundary. It proves
+#   nothing about whether what the page SAYS is still true, and four published
+#   pages were caught naming binaries and crates that no longer exist. A reader
+#   who copies `cargo install trusty-mpmd` off the public site gets an error,
+#   not a daemon, and has no source tree to check it against.
+#
+#   So retired names and install anti-patterns are declared once, in
+#   docs/public-stale-terms.tsv, and matched against every page THIS file
+#   publishes:
+#
+#       TERM   <ere>                              <remedy>
+#       WAIVE  <source>  <ere>  <count>  <reason>
+#
+#   Add a TERM when you retire a name — the rename PR is the moment the
+#   knowledge exists, and the remedy string is printed verbatim to whoever trips
+#   over it later. Add a WAIVE only when an occurrence is genuinely correct
+#   (naming a historical artifact by its recorded name, say), with a reason;
+#   waivers are a count ratchet, so raising one to cover new text fails.
+#
+#   Run it with `bash scripts/check_public_docs.sh --stale`. It is OPT-IN and
+#   wired to nothing while the current repairs are in flight (#5125); the hook
+#   and CI still run the plain gate.
+#
+# Issue: #5096 (epic #5092). STALE content check: #5125.
 
 SECTION	getting-started	Getting Started
 PAGE	getting-started	docs/intro.md	/	Introduction

--- a/docs/public-stale-terms.tsv
+++ b/docs/public-stale-terms.tsv
@@ -1,0 +1,50 @@
+# public-stale-terms.tsv — retired names and anti-patterns that must not appear
+# in a PUBLISHED page (issue #5125, epic #5092).
+#
+# Why: docs/public-manifest.tsv proves a published page EXISTS and sits inside
+#   the boundary. Nothing proved its CONTENT was current, and four published
+#   pages were caught naming binaries and crates that no longer exist — each
+#   found by a human reading closely, which does not scale. A reader who copies
+#   `cargo install trusty-mpmd` off the public site gets an error, not a daemon.
+#
+# What: two record types, tab-separated, consumed by
+#   `scripts/check_public_docs.sh --stale`:
+#
+#     TERM   <ere>                              <remedy>
+#     WAIVE  <source>  <ere>  <count>  <reason>
+#
+#     ere      POSIX extended regular expression, matched line-by-line with
+#              `grep -nE` against every source the manifest publishes. Only the
+#              published set is searched: excluded trees may hold historical
+#              names, and often must.
+#     remedy   what to write instead. It is printed verbatim in the failure, so
+#              an author fixes the page without opening this file.
+#     source   a repo-relative path that some PAGE row publishes.
+#     count    how many matching LINES that source is allowed to keep.
+#     reason   why. Required — an unexplained waiver is indistinguishable from
+#              an oversight a year later.
+#
+#   Blank lines and `#` comments are ignored. No field may contain a tab.
+#
+# Waivers are a COUNT RATCHET, the same mechanic as .line-cap-allowlist.tsv:
+#   N+1 fails (new stale content sneaking in behind an existing waiver) and N-1
+#   fails too (drift — lower the count, or delete the row). A waiver naming a
+#   source no PAGE row publishes, or an ERE no TERM row declares, fails as dead.
+#
+# `@FORMER_REPO_CLONE_URLS@` is a placeholder the gate EXPANDS, not a literal.
+#   It is derived at run time from the `bobmatnyc/<repo>` names in
+#   docs/reference/former-repos.md, so the two can never drift apart, and the
+#   gate FAILS if the derivation finds nothing — a term that silently matches
+#   nothing is worse than no term at all.
+#
+# Author guidance for adding a term lives in docs/public-manifest.tsv's header,
+#   under "KEEPING A PUBLISHED PAGE CURRENT".
+
+TERM	open[-_]mpm	the project was renamed: it is `trusty-agents`, and its binary is `tagent`. `open-mpm` / `open_mpm` names nothing a reader can install.
+TERM	trusty-mpmd	there is no `trusty-mpmd` binary. The daemon folded into `tm` / `trusty-mpm` as the `daemon` subcommand.
+TERM	trusty-mpm-(tui|telegram)	there are no `trusty-mpm-tui` or `trusty-mpm-telegram` binaries. They are the `tm tui` and `tm telegram` subcommands.
+TERM	trusty-code-v0\.0\.0	`trusty-code-v0.0.0` is a placeholder tag that was never cut. The first real tag is `trusty-code-v0.2.0`.
+TERM	@FORMER_REPO_CLONE_URLS@	that repository was folded into `bobmatnyc/trusty-tools` and no longer exists. Clone the workspace instead; see docs/reference/former-repos.md.
+TERM	cp( +-[A-Za-z]+)* +[^ ]*target/(release|debug)/[^ ]+ +[^ ]*bin/	never `cp` a freshly built binary over an on-PATH one on macOS: the stale kernel cdhash cache makes the next exec SIGKILL, which looks exactly like an OOM kill. Use `cargo install --path crates/<name> --locked`.
+
+WAIVE	docs/trusty-search/README.md	open[-_]mpm	1	doc-map row naming the `open-mpm` baseline CORPUS FILE under regression-testing/, not an instruction to install anything. The file keeps its recorded name.

--- a/scripts/check_public_docs.sh
+++ b/scripts/check_public_docs.sh
@@ -28,6 +28,27 @@
 #     BAD-RECORD    a row whose first field is neither SECTION nor PAGE, or
 #                   whose field count is wrong
 #
+#   With `--stale` it additionally reads docs/public-stale-terms.tsv and fails
+#   on:
+#     STALE         a published page contains a retired name or anti-pattern
+#     BAD-WAIVER    a waiver row is malformed, unexplained, dead, or off-count
+#     BAD-TERM      a TERM row is malformed, or its ERE cannot be built
+#
+#   STALE closes the gap the existence checks leave open: they prove a published
+#   page IS THERE, never that what it says is still true. Four published pages
+#   were caught naming binaries and crates that no longer exist, each found by a
+#   human reading closely. A reader who copies `cargo install trusty-mpmd` off
+#   the public site gets an error, not a daemon.
+#
+#   It is OPT-IN and wired to nothing (issue #5125). The pre-commit hook and CI
+#   run this script with no arguments, which skips the pass entirely, because 10
+#   of the 27 published pages hit today and their repairs are in flight on other
+#   branches. Turning it on is a one-line change once those land; the self-test
+#   proves the logic against fixtures in the meantime.
+#
+#   Scope is the published set — the sources of PAGE rows that passed every
+#   other check. Excluded trees may hold historical names, and often must.
+#
 #   FORBIDDEN is DEFENSE IN DEPTH, deliberately redundant with curation. The
 #   manifest is hand-curated, so in a correct tree this check can never fire —
 #   that is the point. It is what stops a later careless edit (a copy-pasted row,
@@ -43,19 +64,27 @@
 #   rendered because the site enumerates the manifest, never the tree.
 #
 # Usage:
-#   bash scripts/check_public_docs.sh                    # default manifest
-#   bash scripts/check_public_docs.sh --manifest <path>  # explicit (self-test)
-#   bash scripts/check_public_docs.sh --root <path>      # resolve sources here
+#   bash scripts/check_public_docs.sh                       # default manifest
+#   bash scripts/check_public_docs.sh --manifest <path>     # explicit (self-test)
+#   bash scripts/check_public_docs.sh --root <path>         # resolve sources here
+#   bash scripts/check_public_docs.sh --stale               # add the STALE pass
+#   bash scripts/check_public_docs.sh --stale-terms <path>  # implies --stale
 #   bash scripts/check_public_docs.sh --help
 #
 # Exit: 0 when every listed page resolves inside the public boundary; 1 on any
 #   finding, with one `FAIL <CODE> line N: …` line per finding on stderr; 2 on a
 #   usage error or an unreadable manifest.
 #
+#   A STALE finding's `line N` is the MANIFEST line that published the page; the
+#   page's own line number is in the message. A BAD-WAIVER or BAD-TERM finding's
+#   `line N` is the line in the stale-terms file, which the message names.
+#
 # Test: scripts/check_public_docs_selftest.sh — fixture manifests under
 #   scripts/test-data/public-docs/ cover each failure code plus the clean case,
 #   including the two the issue names explicitly (a row pointing into
-#   docs/specs/, and a row pointing at a file that does not exist).
+#   docs/specs/, and a row pointing at a file that does not exist). The STALE
+#   cases run against scripts/test-data/public-docs/fakeroot/ via --root, so
+#   they never depend on what the real docs/ tree happens to say today.
 #
 # Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
 #   only — no associative arrays, no jq, no yq.
@@ -66,9 +95,26 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 MANIFEST=""
 ROOT="$REPO_ROOT"
+STALE_MODE=0
+STALE_TERMS=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --stale)
+      STALE_MODE=1
+      shift
+      ;;
+    --stale-terms)
+      [[ $# -lt 2 ]] && {
+        echo "ERROR: --stale-terms needs a path" >&2
+        exit 2
+      }
+      # Implies --stale: a flag that names a terms file and then silently
+      # searches for none of them is a trap, not a convenience.
+      STALE_TERMS="$2"
+      STALE_MODE=1
+      shift 2
+      ;;
     --manifest)
       [[ $# -lt 2 ]] && {
         echo "ERROR: --manifest needs a path" >&2
@@ -86,7 +132,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     -h | --help)
-      sed -n '2,60p' "$0" >&2
+      sed -n '2,90p' "$0" >&2
       exit 0
       ;;
     *)
@@ -149,6 +195,7 @@ sections=""       # newline-separated section ids seen
 current_section="" # section a PAGE row attaches to
 routes=""         # newline-separated routes seen
 sources=""        # newline-separated sources seen
+published=""      # "<manifest-line><TAB><source>" per page that passed everything
 page_count=0
 section_count=0
 
@@ -162,6 +209,230 @@ report() {
 # What: returns 0 when $2 appears as a whole line in $1.
 contains_line() {
   printf '%s\n' "$1" | grep -qxF -- "$2"
+}
+
+# ---------------------------------------------------------------------------
+# STALE pass (--stale). See the header.
+# ---------------------------------------------------------------------------
+
+STALE_WAIVERS=""   # "<terms-line><TAB><source><TAB><ere><TAB><count><TAB><reason>"
+STALE_TERM_LIST="" # "<declared-ere><TAB><expanded-ere><TAB><remedy>"
+STALE_TERM_COUNT=0
+
+# Why: the former-repo clone URLs are already written down once, in
+#   docs/reference/former-repos.md. Hand-copying them into a second list is how
+#   two lists drift, so this term is DERIVED from that page and the two cannot
+#   disagree. A derivation that finds nothing is treated as a failure, not as an
+#   empty term: a pattern matching nothing looks exactly like a clean tree.
+# What: prints `github\.com/bobmatnyc/(a|b|…)` from the `bobmatnyc/<repo>` names
+#   in that page. Returns 1 when the page is unreadable or names no repos.
+# Test: scripts/check_public_docs_selftest.sh — the fakeroot carries its own
+#   minimal former-repos.md, so the STALE fixtures exercise this path.
+derive_former_repo_urls() {
+  local page="${ROOT}/docs/reference/former-repos.md"
+  local names
+  [[ -f "$page" ]] || return 1
+  # shellcheck disable=SC2016  # the backticks are literal grep pattern text
+  names="$(grep -oE '`bobmatnyc/[a-z0-9-]+`' "$page" |
+    tr -d '`' | sed 's|^bobmatnyc/||' | sort -u | paste -sd'|' -)" || return 1
+  [[ -n "$names" ]] || return 1
+  printf 'github\\.com/bobmatnyc/(%s)' "$names"
+}
+
+# Returns 0 if $1 is a POSIX ERE grep can compile. Matching nothing is fine;
+# only a compile error (grep exit > 1) is a finding.
+ere_compiles() {
+  local rc=0
+  printf '' | grep -qE -- "$1" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -le 1 ]]
+}
+
+# Prints the waived line-count for source $1 / declared-ERE $2, or 0.
+waiver_count() {
+  local wl wsrc were wcount wreason out=0
+  while IFS=$'\t' read -r wl wsrc were wcount wreason; do
+    [[ -n "$wl" ]] || continue
+    if [[ "$wsrc" == "$1" && "$were" == "$2" ]]; then
+      out="$wcount"
+      break
+    fi
+  done <<<"$STALE_WAIVERS"
+  printf '%s' "$out"
+}
+
+# Prints the stale-terms line number of the waiver for source $1 / ERE $2, or 0.
+waiver_line() {
+  local wl wsrc were wcount wreason out=0
+  while IFS=$'\t' read -r wl wsrc were wcount wreason; do
+    [[ -n "$wl" ]] || continue
+    if [[ "$wsrc" == "$1" && "$were" == "$2" ]]; then
+      out="$wl"
+      break
+    fi
+  done <<<"$STALE_WAIVERS"
+  printf '%s' "$out"
+}
+
+# Reads $STALE_TERMS into $STALE_TERM_LIST / $STALE_WAIVERS, validating both
+# record types. Called directly, never in `$(…)`: a subshell would discard every
+# global it sets, `fail` included.
+stale_load_terms() {
+  local lineno=0 raw kind rest ere remedy pattern dup
+  local wsrc were wcount wreason wrest wrest2 wrest3
+  local term_keys=""
+
+  while IFS= read -r raw || [[ -n "$raw" ]]; do
+    lineno=$((lineno + 1))
+    raw="${raw%$'\r'}"
+    case "$raw" in
+      '' | '#'*) continue ;;
+    esac
+    kind="${raw%%$'\t'*}"
+
+    case "$kind" in
+      TERM)
+        rest="${raw#*$'\t'}"
+        ere="${rest%%$'\t'*}"
+        remedy="${rest#*$'\t'}"
+        if [[ "$rest" == "$raw" || "$remedy" == "$rest" || -z "$ere" || -z "$remedy" ]]; then
+          report BAD-TERM "$lineno" \
+            "${STALE_TERMS}: TERM needs exactly 3 tab-separated fields: TERM<TAB>ere<TAB>remedy"
+          continue
+        fi
+        if contains_line "$term_keys" "$ere"; then
+          report BAD-TERM "$lineno" "${STALE_TERMS}: term '${ere}' is already declared"
+          continue
+        fi
+
+        pattern="$ere"
+        if [[ "$ere" == "@FORMER_REPO_CLONE_URLS@" ]]; then
+          if ! pattern="$(derive_former_repo_urls)"; then
+            report BAD-TERM "$lineno" \
+              "${STALE_TERMS}: '@FORMER_REPO_CLONE_URLS@' derived ZERO repo names from ${ROOT}/docs/reference/former-repos.md. A term that matches nothing is indistinguishable from a clean tree — fix that page's \`bobmatnyc/<repo>\` list, or delete this term."
+            continue
+          fi
+        fi
+
+        if ! ere_compiles "$pattern"; then
+          report BAD-TERM "$lineno" \
+            "${STALE_TERMS}: '${ere}' is not a valid POSIX extended regular expression"
+          continue
+        fi
+
+        term_keys="${term_keys}${ere}"$'\n'
+        STALE_TERM_LIST="${STALE_TERM_LIST}${ere}"$'\t'"${pattern}"$'\t'"${remedy}"$'\n'
+        STALE_TERM_COUNT=$((STALE_TERM_COUNT + 1))
+        ;;
+
+      WAIVE)
+        wrest="${raw#*$'\t'}"
+        wsrc="${wrest%%$'\t'*}"
+        wrest2="${wrest#*$'\t'}"
+        were="${wrest2%%$'\t'*}"
+        wrest3="${wrest2#*$'\t'}"
+        wcount="${wrest3%%$'\t'*}"
+        wreason="${wrest3#*$'\t'}"
+        if [[ "$wrest" == "$raw" || "$wrest2" == "$wrest" || "$wrest3" == "$wrest2" ||
+          "$wreason" == "$wrest3" || -z "$wsrc" || -z "$were" || -z "$wcount" ]]; then
+          report BAD-WAIVER "$lineno" \
+            "${STALE_TERMS}: WAIVE needs exactly 5 tab-separated fields: WAIVE<TAB>source<TAB>ere<TAB>count<TAB>reason"
+          continue
+        fi
+        # An unexplained waiver is indistinguishable from an oversight a year
+        # later, which is exactly when someone has to decide whether to keep it.
+        if [[ -z "${wreason//[[:space:]]/}" ]]; then
+          report BAD-WAIVER "$lineno" \
+            "${STALE_TERMS}: waiver for '${wsrc}' / '${were}' has an empty reason. Say why the occurrence is legitimate, or delete the row."
+          continue
+        fi
+        case "$wcount" in
+          '' | *[!0-9]*)
+            report BAD-WAIVER "$lineno" \
+              "${STALE_TERMS}: waiver for '${wsrc}' / '${were}' has count '${wcount}', which is not a non-negative integer"
+            continue
+            ;;
+        esac
+        if [[ "$wcount" -lt 1 ]]; then
+          report BAD-WAIVER "$lineno" \
+            "${STALE_TERMS}: waiver for '${wsrc}' / '${were}' waives 0 occurrences, which waives nothing. Delete the row."
+          continue
+        fi
+        dup="$(waiver_line "$wsrc" "$were")"
+        if [[ "$dup" != "0" ]]; then
+          report BAD-WAIVER "$lineno" \
+            "${STALE_TERMS}: '${wsrc}' / '${were}' is already waived on line ${dup}. One waiver per source/term pair — the second would be silently ignored."
+          continue
+        fi
+        STALE_WAIVERS="${STALE_WAIVERS}${lineno}"$'\t'"${wsrc}"$'\t'"${were}"$'\t'"${wcount}"$'\t'"${wreason}"$'\n'
+        ;;
+
+      *)
+        report BAD-RECORD "$lineno" \
+          "${STALE_TERMS}: unknown record type '${kind}' (expected TERM or WAIVE)"
+        ;;
+    esac
+  done <"$STALE_TERMS"
+}
+
+# Fails every waiver that can no longer refer to anything: a source no PAGE row
+# publishes, or an ERE no TERM row declares. Both are dead weight that reads as
+# active protection.
+stale_check_dead_waivers() {
+  local term_keys wl wsrc were wcount wreason
+  term_keys="$(printf '%s' "$STALE_TERM_LIST" | cut -f1)"
+  while IFS=$'\t' read -r wl wsrc were wcount wreason; do
+    [[ -n "$wl" ]] || continue
+    if ! contains_line "$sources" "$wsrc"; then
+      report BAD-WAIVER "$wl" \
+        "${STALE_TERMS}: waiver names '${wsrc}', which no PAGE row publishes. Dead waiver — delete the row."
+      continue
+    fi
+    if ! contains_line "$term_keys" "$were"; then
+      report BAD-WAIVER "$wl" \
+        "${STALE_TERMS}: waiver names ERE '${were}', which no TERM row declares. Dead waiver — delete the row."
+    fi
+  done <<<"$STALE_WAIVERS"
+}
+
+# Searches every published page for every term, enforcing the waiver ratchet.
+stale_scan_pages() {
+  local mline msrc tkey tpat tremedy hits mcount waived note pline h wl
+
+  while IFS=$'\t' read -r mline msrc; do
+    [[ -n "$mline" ]] || continue
+    while IFS=$'\t' read -r tkey tpat tremedy; do
+      [[ -n "$tkey" ]] || continue
+
+      hits="$(grep -nE -- "$tpat" "${ROOT}/${msrc}" || true)"
+      if [[ -z "$hits" ]]; then
+        mcount=0
+      else
+        mcount="$(printf '%s\n' "$hits" | grep -c '' | tr -d ' ')"
+      fi
+      waived="$(waiver_count "$msrc" "$tkey")"
+
+      [[ "$mcount" -eq "$waived" ]] && continue
+
+      # Ratchet, both directions — same mechanic as .line-cap-allowlist.tsv.
+      # N-1 is a finding, not a quiet win: a waiver that over-states is a
+      # standing licence to reintroduce what it no longer covers.
+      if [[ "$mcount" -lt "$waived" ]]; then
+        wl="$(waiver_line "$msrc" "$tkey")"
+        report BAD-WAIVER "$wl" \
+          "${STALE_TERMS}: waiver allows ${waived} occurrence(s) of '${tkey}' in '${msrc}', but only ${mcount} remain. Lower the count to ${mcount}, or delete the row if it is 0."
+        continue
+      fi
+
+      note=""
+      [[ "$waived" -gt 0 ]] && note=" [${waived} occurrence(s) waived, ${mcount} now present — raising the waiver is not the fix]"
+      while IFS= read -r h; do
+        [[ -n "$h" ]] || continue
+        pline="${h%%:*}"
+        report STALE "$mline" \
+          "page '${msrc}' line ${pline} contains retired term '${tkey}' — ${tremedy}${note}"
+      done <<<"$hits"
+    done <<<"$STALE_TERM_LIST"
+  done <<<"$published"
 }
 
 while IFS= read -r raw || [[ -n "$raw" ]]; do
@@ -308,6 +579,7 @@ while IFS= read -r raw || [[ -n "$raw" ]]; do
         report DUP-SOURCE "$lineno" "source '${src}' is already published"
       else
         sources="${sources}${src}"$'\n'
+        published="${published}${lineno}"$'\t'"${src}"$'\n'
       fi
       ;;
 
@@ -328,8 +600,47 @@ if [[ "$page_count" -lt 1 ]]; then
   exit 1
 fi
 
+# The STALE pass runs LAST and only over pages that cleared every check above,
+# so it never reports on a source the manifest could not resolve in the first
+# place. It is opt-in (issue #5125) — see the header for why it is wired to
+# nothing yet.
+stale_scanned=0
+manifest_fail="$fail" # findings raised before the STALE pass began
+if [[ "$STALE_MODE" -eq 1 ]]; then
+  [[ -n "$STALE_TERMS" ]] || STALE_TERMS="${ROOT}/docs/public-stale-terms.tsv"
+  if [[ ! -f "$STALE_TERMS" ]]; then
+    echo "FAIL: stale-terms file not found: ${STALE_TERMS}" >&2
+    exit 2
+  fi
+
+  stale_load_terms
+
+  # Same premise as the page floor above: a terms file that declares nothing
+  # searches for nothing, and "found no stale content" would be a lie.
+  if [[ "$STALE_TERM_COUNT" -lt 1 ]]; then
+    echo "FAIL: SCAN FLOOR — ${STALE_TERMS} declares 0 term(s)." >&2
+    echo "      Nothing was searched for, so the STALE check could not have failed." >&2
+    exit 1
+  fi
+
+  stale_check_dead_waivers
+  stale_scan_pages
+  stale_scanned=1
+fi
+
 if [[ "$fail" -ne 0 ]]; then
-  cat >&2 <<EOF
+  if [[ "$stale_scanned" -eq 1 ]]; then
+    cat >&2 <<EOF
+
+Retired names and anti-patterns are declared in ${STALE_TERMS}.
+Fix the PAGE — a published page is read by people who cannot check it against
+the source tree. Waive an occurrence only when it is genuinely correct (naming a
+historical artifact by its recorded name, for instance), with a reason, and
+never by raising an existing waiver's count.
+EOF
+  fi
+  if [[ "$manifest_fail" -ne 0 ]]; then
+    cat >&2 <<EOF
 
 The public documentation manifest is an ALLOWLIST (${MANIFEST}).
 Every PAGE row must name an existing .md file under docs/ that is outside the
@@ -339,7 +650,12 @@ rows above — never widen the boundary to make this gate green.
 Both rules, and the \`*-internal.md\` naming convention for internal docs that
 live in a mixed-audience directory, are documented in that file's header.
 EOF
+  fi
   exit 1
 fi
 
-echo "public-docs gate: ${page_count} page(s) across ${section_count} section(s) — all resolve inside the public boundary."
+if [[ "$stale_scanned" -eq 1 ]]; then
+  echo "public-docs gate: ${page_count} page(s) across ${section_count} section(s) — all resolve inside the public boundary, and none carries any of the ${STALE_TERM_COUNT} retired term(s) in ${STALE_TERMS}."
+else
+  echo "public-docs gate: ${page_count} page(s) across ${section_count} section(s) — all resolve inside the public boundary."
+fi

--- a/scripts/check_public_docs_selftest.sh
+++ b/scripts/check_public_docs_selftest.sh
@@ -11,6 +11,13 @@
 #       a dressed-up existence check.
 #     - missing-source.tsv points at a docs/ path that does not exist, which is
 #       what a rename or deletion in docs/ looks like to the manifest.
+#   The STALE cases (issue #5125) carry the whole weight of that check, because
+#   it is opt-in and wired to nothing: no hook and no CI job runs
+#   `--stale` today, so these fixtures are the ONLY place its logic is
+#   ever observed working. They run against scripts/test-data/public-docs/fakeroot/
+#   via --root, so they assert on pages this file controls rather than on
+#   whatever the real docs/ tree says this week.
+#
 #   forbidden-internal-suffix.tsv covers the third case, which has no tree rule
 #   behind it: docs/reference/ is mixed-audience, so the internal half of a split
 #   (docs/reference/config-convention-internal.md, PR #5107) sits one row away
@@ -87,6 +94,80 @@ while IFS="$TAB" read -r fixture expected_exit expected_code; do
   rm -f "$err"
 done <<EOF
 $CASES
+EOF
+
+# --- STALE pass (issue #5125) ------------------------------------------------
+#
+# manifest<TAB>terms<TAB>expected_exit<TAB>expected_substrings (comma-separated,
+# ALL required; "-" when exit 0). Requiring several substrings is what makes
+# case 1 prove BOTH that a retired literal fires AND that the derived
+# @FORMER_REPO_CLONE_URLS@ term fires — a single "STALE" assertion would pass on
+# either alone, and the derivation is the half that can silently match nothing.
+FAKEROOT="$FIXTURE_DIR/fakeroot"
+STALE_CASES="stale-hit.tsv${TAB}stale-terms.tsv${TAB}1${TAB}FAIL STALE,trusty-mpmd,@FORMER_REPO_CLONE_URLS@
+stale-waived.tsv${TAB}stale-terms-waived.tsv${TAB}0${TAB}-
+stale-waived.tsv${TAB}stale-terms-empty-reason.tsv${TAB}1${TAB}BAD-WAIVER
+stale-unpublished.tsv${TAB}stale-terms.tsv${TAB}0${TAB}-"
+
+while IFS="$TAB" read -r fixture terms expected_exit expected_subs; do
+  [ -n "$fixture" ] || continue
+  label="$fixture + $terms"
+  mpath="$FIXTURE_DIR/$fixture"
+  tpath="$FIXTURE_DIR/$terms"
+  if [ ! -f "$mpath" ] || [ ! -f "$tpath" ]; then
+    echo "FAIL: stale fixture missing: $mpath / $tpath" >&2
+    fail=1
+    continue
+  fi
+
+  err="$(mktemp "${TMPDIR:-/tmp}/public-docs-selftest.XXXXXX")"
+  rc=0
+  bash "$GATE" --manifest "$mpath" --root "$FAKEROOT" \
+    --stale-terms "$tpath" >/dev/null 2>"$err" || rc=$?
+
+  if [ "$rc" -ne "$expected_exit" ]; then
+    echo "FAIL: $label -> exit $rc (expected $expected_exit)" >&2
+    sed 's/^/       /' "$err" >&2
+    fail=1
+    rm -f "$err"
+    continue
+  fi
+
+  missing=""
+  if [ "$expected_subs" != "-" ]; then
+    # Comma-split without arrays, so this stays bash 3.2 clean.
+    rest="$expected_subs"
+    while [ -n "$rest" ]; do
+      case "$rest" in
+        *,*)
+          sub="${rest%%,*}"
+          rest="${rest#*,}"
+          ;;
+        *)
+          sub="$rest"
+          rest=""
+          ;;
+      esac
+      grep -qF -- "$sub" "$err" || missing="${missing}'${sub}' "
+    done
+  fi
+
+  if [ -n "$missing" ]; then
+    echo "FAIL: $label -> exit $rc but stderr never mentions ${missing}" >&2
+    sed 's/^/       /' "$err" >&2
+    fail=1
+    rm -f "$err"
+    continue
+  fi
+
+  if [ "$expected_subs" = "-" ]; then
+    echo "PASS: $label -> exit $rc (clean)"
+  else
+    echo "PASS: $label -> exit $rc, reported ${expected_subs}"
+  fi
+  rm -f "$err"
+done <<EOF
+$STALE_CASES
 EOF
 
 # The committed manifest itself must pass. A green fixture suite over a red

--- a/scripts/test-data/public-docs/fakeroot/docs/pages/current.md
+++ b/scripts/test-data/public-docs/fakeroot/docs/pages/current.md
@@ -1,0 +1,4 @@
+# Current page (fixture)
+
+Says nothing retired. Install with `cargo install --path crates/trusty-mpm --locked`,
+then run `tm daemon start` and `tm tui`.

--- a/scripts/test-data/public-docs/fakeroot/docs/pages/retired-binary.md
+++ b/scripts/test-data/public-docs/fakeroot/docs/pages/retired-binary.md
@@ -1,0 +1,5 @@
+# Retired binary (fixture)
+
+Start the daemon with `trusty-mpmd --port 8765`.
+
+Clone it first: `git clone https://github.com/bobmatnyc/open-mpm.git`.

--- a/scripts/test-data/public-docs/fakeroot/docs/pages/unpublished.md
+++ b/scripts/test-data/public-docs/fakeroot/docs/pages/unpublished.md
@@ -1,0 +1,4 @@
+# Unpublished page (fixture)
+
+No PAGE row publishes this file, so `trusty-mpmd` here must not be a finding:
+the boundary is what the manifest lists, and everything else may hold history.

--- a/scripts/test-data/public-docs/fakeroot/docs/pages/waived-corpus.md
+++ b/scripts/test-data/public-docs/fakeroot/docs/pages/waived-corpus.md
@@ -1,0 +1,5 @@
+# Waived occurrence (fixture)
+
+| Directory | Contents |
+|---|---|
+| `regression-testing/` | Baselines for the synthetic and open-mpm corpora. |

--- a/scripts/test-data/public-docs/fakeroot/docs/reference/former-repos.md
+++ b/scripts/test-data/public-docs/fakeroot/docs/reference/former-repos.md
@@ -1,0 +1,11 @@
+# Former repositories (fixture)
+
+Minimal stand-in for the real `docs/reference/former-repos.md`. Its only job is
+to give `derive_former_repo_urls()` something to derive from, so the STALE
+fixtures exercise the `@FORMER_REPO_CLONE_URLS@` expansion instead of skipping
+it. Keep the backticked `bobmatnyc/<repo>` shape — that is what the gate greps.
+
+| Former repo | Folded into |
+|---|---|
+| `bobmatnyc/open-mpm` | `bobmatnyc/trusty-tools` |
+| `bobmatnyc/trusty-search` | `bobmatnyc/trusty-tools` |

--- a/scripts/test-data/public-docs/stale-hit.tsv
+++ b/scripts/test-data/public-docs/stale-hit.tsv
@@ -1,0 +1,3 @@
+SECTION	pages	Pages
+PAGE	pages	docs/pages/current.md	/current	Current
+PAGE	pages	docs/pages/retired-binary.md	/retired	Retired binary

--- a/scripts/test-data/public-docs/stale-terms-empty-reason.tsv
+++ b/scripts/test-data/public-docs/stale-terms-empty-reason.tsv
@@ -1,0 +1,5 @@
+# STALE fixture terms. Paired with the fakeroot/ pages, not the real docs/ tree.
+TERM	trusty-mpmd	there is no `trusty-mpmd` binary; use `tm daemon`.
+TERM	open[-_]mpm	renamed to `trusty-agents` (binary `tagent`).
+TERM	@FORMER_REPO_CLONE_URLS@	that repo was folded into `bobmatnyc/trusty-tools`.
+WAIVE	docs/pages/waived-corpus.md	open[-_]mpm	1	

--- a/scripts/test-data/public-docs/stale-terms-waived.tsv
+++ b/scripts/test-data/public-docs/stale-terms-waived.tsv
@@ -1,0 +1,5 @@
+# STALE fixture terms. Paired with the fakeroot/ pages, not the real docs/ tree.
+TERM	trusty-mpmd	there is no `trusty-mpmd` binary; use `tm daemon`.
+TERM	open[-_]mpm	renamed to `trusty-agents` (binary `tagent`).
+TERM	@FORMER_REPO_CLONE_URLS@	that repo was folded into `bobmatnyc/trusty-tools`.
+WAIVE	docs/pages/waived-corpus.md	open[-_]mpm	1	names the open-mpm baseline CORPUS FILE by its recorded name, not an installable thing.

--- a/scripts/test-data/public-docs/stale-terms.tsv
+++ b/scripts/test-data/public-docs/stale-terms.tsv
@@ -1,0 +1,4 @@
+# STALE fixture terms. Paired with the fakeroot/ pages, not the real docs/ tree.
+TERM	trusty-mpmd	there is no `trusty-mpmd` binary; use `tm daemon`.
+TERM	open[-_]mpm	renamed to `trusty-agents` (binary `tagent`).
+TERM	@FORMER_REPO_CLONE_URLS@	that repo was folded into `bobmatnyc/trusty-tools`.

--- a/scripts/test-data/public-docs/stale-unpublished.tsv
+++ b/scripts/test-data/public-docs/stale-unpublished.tsv
@@ -1,0 +1,2 @@
+SECTION	pages	Pages
+PAGE	pages	docs/pages/current.md	/current	Current

--- a/scripts/test-data/public-docs/stale-waived.tsv
+++ b/scripts/test-data/public-docs/stale-waived.tsv
@@ -1,0 +1,2 @@
+SECTION	pages	Pages
+PAGE	pages	docs/pages/waived-corpus.md	/waived	Waived corpus name


### PR DESCRIPTION
Closes [#5125](https://github.com/bobmatnyc/trusty-tools/issues/5125). Epic [#5092](https://github.com/bobmatnyc/trusty-tools/issues/5092).

## Defect

The public-docs gate ([#5096](https://github.com/bobmatnyc/trusty-tools/issues/5096), PR [#5102](https://github.com/bobmatnyc/trusty-tools/pull/5102)) proves a published page EXISTS and sits inside the boundary. Nothing checked whether its CONTENT is current. Four published pages have already been caught naming binaries and crates that no longer exist — `open-mpm`, `trusty-mpmd`, `trusty-mpm-tui`/`-telegram`, and a `cp target/release/... /usr/local/bin/` install line that voids the macOS cdhash. Each was found by a human or agent reading closely, which does not scale. A reader who copies `cargo install trusty-mpmd` off the public site gets an error, not a daemon, and has no source tree to check it against.

## Resolution

`scripts/check_public_docs.sh --stale` matches `docs/public-stale-terms.tsv` against every page the manifest publishes.

```
TERM   <ere>                              <remedy>
WAIVE  <source>  <ere>  <count>  <reason>
```

- The remedy is printed verbatim in the failure, so an author fixes the page without opening the terms file.
- Waivers are a **count ratchet**, same mechanic as `.line-cap-allowlist.tsv`: N+1 fails (new stale content sneaking in behind an existing waiver) and N−1 fails too (drift — lower it or drop it). `reason` is required; a waiver naming an unpublished source, or an ERE no `TERM` declares, fails as dead.
- `@FORMER_REPO_CLONE_URLS@` is a placeholder the gate EXPANDS from the `bobmatnyc/<repo>` names in `docs/reference/former-repos.md`, never hand-copied, and the gate FAILS if the derivation yields zero matches — a term that silently matches nothing is worse than no term at all.
- Scope is the published set: the sources of PAGE rows that passed every other check. Excluded trees may hold historical names, and often must.

Six seed TERMs, one seed WAIVE (`docs/trusty-search/README.md` / `open[-_]mpm` / 1 — a `regression-testing/` doc-map row naming the `open-mpm` baseline corpus FILE, not an instruction).

## Sequencing — this lands WIRED TO NOTHING

10 of the 27 published pages hit today and the repairs are in flight on PR [#5107](https://github.com/bobmatnyc/trusty-tools/pull/5107), PR [#5121](https://github.com/bobmatnyc/trusty-tools/pull/5121), and branch `docs/harnesses-audit`. So the check is behind an opt-in `--stale` flag and is added to **neither the pre-commit hook nor CI**; the default invocation is byte-identical to before. The four self-test cases are the only place its logic is observed working until the repairs land. Wiring it on is [#5134](https://github.com/bobmatnyc/trusty-tools/issues/5134).

No documentation content is fixed here — this is the detector, not the repair.

## Evidence

Default invocation unchanged:

```
$ bash scripts/check_public_docs.sh
public-docs gate: 27 page(s) across 5 section(s) — all resolve inside the public boundary.
EXIT=0
```

`--stale` against the current 27 published pages — 136 findings across 10 pages, exit 1. That is the gate working, reported rather than waived:

```
docs/architecture/harnesses.md                    56
docs/trusty-agents/user/quickstart.md             17
docs/trusty-agents/user/cli-reference.md          17
docs/trusty-agents/user/configuration.md          15
docs/trusty-agents/user/agents-and-skills.md      15
docs/trusty-agents/README.md                       7
docs/trusty-mpm/README.md                          4
docs/trusty-git-analytics/user/user-guide.md       3
docs/reference/running-mcp-servers.md              1
docs/distribution/INSTALL-CONVENTION.md            1
```

Gates (Rust test ladder rung 1 — no crate source changed; scripts + docs only, so no cargo gate applies):

```
$ bash scripts/check_public_docs.sh
public-docs gate: 27 page(s) across 5 section(s) — all resolve inside the public boundary.

$ bash scripts/check_public_docs_selftest.sh
PASS: clean.tsv -> exit 0 (clean)
PASS: missing-source.tsv -> exit 1, reported MISSING
PASS: forbidden-specs.tsv -> exit 1, reported FORBIDDEN
PASS: forbidden-nested.tsv -> exit 1, reported FORBIDDEN
PASS: forbidden-internal-suffix.tsv -> exit 1, reported FORBIDDEN
PASS: escapes-docs.tsv -> exit 1, reported ESCAPES-DOCS
PASS: dup-route.tsv -> exit 1, reported DUP-ROUTE
PASS: bad-record.tsv -> exit 1, reported BAD-RECORD
PASS: empty.tsv -> exit 1, reported SCAN FLOOR
PASS: stale-hit.tsv + stale-terms.tsv -> exit 1, reported FAIL STALE,trusty-mpmd,@FORMER_REPO_CLONE_URLS@
PASS: stale-waived.tsv + stale-terms-waived.tsv -> exit 0 (clean)
PASS: stale-waived.tsv + stale-terms-empty-reason.tsv -> exit 1, reported BAD-WAIVER
PASS: stale-unpublished.tsv + stale-terms.tsv -> exit 0 (clean)
PASS: docs/public-manifest.tsv -> exit 0 (clean)
check_public_docs_selftest: all cases passed.

$ shellcheck scripts/check_public_docs.sh scripts/check_public_docs_selftest.sh
(no output, exit 0)

$ bash scripts/check_line_cap.sh
line-cap: measured 3765 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.

$ bash scripts/check_generation_artifacts.sh
generation-artifacts: scanned 16 stylesheet(s) + 1303 prose file(s) (floors 5/200) — 0 leaked artifacts — OK.

$ bash scripts/check_changelog_fragment.sh
changelog-fragment gate: scanned 15 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 56 spec doc(s) + 3126 code file(s); 0 error(s), 0 warning(s)
```

The four self-test cases each pass for the right reason, verified against negatives that are not committed as fixtures:

- case 2's page WITHOUT its waiver → `FAIL STALE line 2: page 'docs/pages/waived-corpus.md' line 5 contains retired term 'open[-_]mpm'`
- case 4's page PUBLISHED → `FAIL STALE line 2: page 'docs/pages/unpublished.md' line 3 contains retired term 'trusty-mpmd'`
- ratchet N−1 (waive 2, 1 matches) → `FAIL BAD-WAIVER ... waiver allows 2 occurrence(s) ... but only 1 remain. Lower the count to 1`
- ratchet N+1 (waive 1, page grows to 2) → two `FAIL STALE` lines carrying `[1 occurrence(s) waived, 2 now present — raising the waiver is not the fix]`
- dead waiver, unpublished source → `FAIL BAD-WAIVER ... which no PAGE row publishes`
- dead waiver, undeclared ERE → `FAIL BAD-WAIVER ... which no TERM row declares`
- derivation yields zero → `FAIL BAD-TERM ... derived ZERO repo names from .../former-repos.md`
- terms file with 0 TERMs → `FAIL: SCAN FLOOR — ... declares 0 term(s).`

Added: 533 / Removed: 9 / Net: +524 across 15 files.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
