### PR TITLE
docs: fix three factual errors on published pages

### DIFF
--- a/crates/trusty-search/README.md
+++ b/crates/trusty-search/README.md
@@ -514,9 +514,9 @@ trusty-search doctor [--fix]                         # 6-check diagnostic + auto
 trusty-search ui [--port N]                          # open web management UI in browser
 trusty-search convert project|all [--dry-run]        # migrate from mcp-vector-search
 trusty-search serve [--http <addr>]                  # MCP stdio (default) or HTTP/SSE
-trusty-search port                                   # print daemon port to stdout (bare: 7879)
-trusty-search port --addr                            # print host:port (127.0.0.1:7879)
-trusty-search port --json                            # print {"addr":"127.0.0.1","port":7879}
+trusty-search port                                   # print daemon port to stdout (bare: 7878)
+trusty-search port --addr                            # print host:port (127.0.0.1:7878)
+trusty-search port --json                            # print {"addr":"127.0.0.1","port":7878}
 # Shell substitution idiom (stdout is clean — log lines go to stderr):
 curl http://127.0.0.1:$(trusty-search port)/health
 # Aliases preserved for backward compatibility:

--- a/docs/reference/running-mcp-servers.md
+++ b/docs/reference/running-mcp-servers.md
@@ -7,7 +7,7 @@ All daemons log to **stderr** — never stdout.
 # trusty-search daemon (HTTP + MCP stdio)
 RUST_LOG=info cargo run -p trusty-search -- start
 # Query via CLI
-cargo run -p trusty-search -- query "fn authenticate" --index <id>
+cargo run -p trusty-search -- query "fn authenticate" --indexes <name>
 # MCP stdio mode (used by Claude Code via .mcp.json)
 cargo run -p trusty-search -- serve
 
@@ -23,9 +23,9 @@ cargo run -p trusty-mpm --bin trusty-mpm -- --help
 RUST_LOG=info cargo run -p trusty-memory
 
 # Report the daemon's listening port (stdout is clean — safe for shell substitution):
-trusty-search port                                   # bare port: 7879
-trusty-search port --addr                            # host:port: 127.0.0.1:7879
-trusty-search port --json                            # {"addr":"127.0.0.1","port":7879}
+trusty-search port                                   # bare port: 7878
+trusty-search port --addr                            # host:port: 127.0.0.1:7878
+trusty-search port --json                            # {"addr":"127.0.0.1","port":7878}
 # Shell substitution idiom — queries the daemon without guessing the port:
 curl http://127.0.0.1:$(trusty-search port)/health
 

--- a/docs/trusty-analyze/README.md
+++ b/docs/trusty-analyze/README.md
@@ -11,7 +11,8 @@ research documentation. The crate `README.md` and rustdoc stay in-crate
 ## Role in Technical DD Report Generation
 
 trusty-analyze is the **standalone analysis engine** for the trusty-review report-generation 
-feature (announced 2026-07-10). When `trusty-review report --repo <path>` is invoked, 
+feature (announced 2026-07-10). When `trusty-review report --manifest <file>` is invoked 
+with `--analyze` (the manifest TOML declares each target repository's local path or remote), 
 trusty-analyze performs all static code analysis (complexity, smells, quality metrics, size/LoC 
 breakdowns, violations, ISO-5055 compliance, etc.) and exposes results via HTTP API on port 7879. 
 trusty-review consumes those metrics and fills templated DD report skeletons (generic or 

--- a/docs/trusty-memory/README.md
+++ b/docs/trusty-memory/README.md
@@ -1,6 +1,9 @@
 # trusty-memory — documentation
 
-Memory palace storage daemon + MCP server frontend (`crates/trusty-memory-core` + `crates/trusty-memory`).
+Memory palace storage daemon + MCP server frontend. The storage engine lives in
+`crates/trusty-common`'s `memory_core` module (behind the `memory-core` feature
+flag, absorbing the former `trusty-memory-core` crate); the frontend is
+`crates/trusty-memory`.
 
 ## Canonical specification
 

--- a/docs/trusty-review/reports/README.md
+++ b/docs/trusty-review/reports/README.md
@@ -6,16 +6,20 @@ complexity, quality metrics) with `trusty-search` as a context guide for archite
 
 ## How instances are produced
 
-Reports are produced via the `trusty-review report` subcommand:
+Reports are produced via the `trusty-review report` subcommand. `--manifest` is
+required — it points at a TOML file that declares the report title plus one or
+more `[[repositories]]` entries, each with a local `path` or a declared
+`remote`:
 
 ```bash
-trusty-review report --repo <path> --template <name> [--out <dir>]
+trusty-review report --manifest <file> [--template <name>] [--out <dir>] [--analyze]
 ```
 
 The pipeline:
 
-1. **trusty-analyze** inspects the repository, producing structured metrics (complexity, smells,
-   quality grades, LoC breakdowns, violations, risk scores).
+1. **trusty-analyze** inspects each manifest repository (when `--analyze` is
+   set), producing structured metrics (complexity, smells, quality grades, LoC
+   breakdowns, violations, risk scores).
 2. **trusty-review** loads a template skeleton (generic or CAST-specific) and fills placeholders
    from trusty-analyze output, optionally synthesizing prose (executive summary, findings narratives) via LLM.
 3. The result is a standalone markdown report (plus optional JSON) with scorecard, findings by


### PR DESCRIPTION
## Summary

Fixes the last three known doc-side launch blockers for the public website — factual errors on pages listed in `docs/public-manifest.tsv`. Part of epic #5092.

## Defects, evidence, resolution

**1. Wrong trusty-search port ([#5143](https://github.com/bobmatnyc/trusty-tools/issues/5143))**

- `docs/reference/running-mcp-servers.md` and `crates/trusty-search/README.md` claimed `trusty-search port` prints `7879`.
- Verified against `crates/trusty-search/src/service/constants.rs`, `DEFAULT_PORT`: the real value is `7878`. `7879` is trusty-analyze's port (`crates/trusty-analyze/src/main.rs`, `DEFAULT_PORT`) — a copy-paste collision between the two daemons' docs.
- Fixed all three port-command examples in both files to `7878`.
- Also found and fixed, during the required full re-read of `running-mcp-servers.md`: the `query` example used a nonexistent `--index <id>` flag. Verified against `crates/trusty-search/src/main.rs`, `Commands::Query` — the real field is `indexes: String` (`--indexes`, comma-separated names or `*`). Corrected to `--indexes <name>`.
- Rest of the file re-verified line by line against source: the `daemon` subcommand (`crates/trusty-mpm/src/bin/tm/main.rs`), the two `trusty-mpm`/`tm` bin targets (`crates/trusty-mpm/Cargo.toml`), trusty-memory's `DEFAULT_HTTP_PORT = 7070` (`crates/trusty-memory/src/http_server.rs`), the `note` subcommand and `POST /api/v1/remember` (`crates/trusty-memory/src/main.rs::Command::Note`, `crates/trusty-memory/src/commands/note.rs`), and both daemons' `/health` routes — all check out, no other changes needed there.

**2. Non-existent `--repo` flag ([#5144](https://github.com/bobmatnyc/trusty-tools/issues/5144))**

- `docs/trusty-analyze/README.md` and `docs/trusty-review/reports/README.md` documented `trusty-review report --repo <path>`.
- Verified against `crates/trusty-review/src/cli_report.rs`, `struct ReportArgs`: there is no `repo` field. `manifest: PathBuf` is the required flag (a TOML file with `[[repositories]]` entries carrying a local `path` or a `remote`), matching the already-correct `docs/trusty-review/spec/report-generation.md` ("the earlier `--repo` flag is replaced by `--manifest`").
- Corrected both examples to `--manifest <file>`, and noted that `trusty-analyze` inspection is gated behind the `--analyze` flag (`ReportArgs::analyze`) rather than automatic.

**3. Stale `trusty-memory-core` crate reference ([#5146](https://github.com/bobmatnyc/trusty-tools/issues/5146))**

- `docs/trusty-memory/README.md` named `crates/trusty-memory-core` as a current crate.
- Verified: no such directory exists. `crates/trusty-common/src/memory_core/mod.rs` (module doc: "formerly the `trusty-memory-core` crate... Absorbed into `trusty-common` (issue #5 phase 2d)") confirms the engine now lives in `trusty-common` behind the `memory-core` feature flag (`crates/trusty-common/Cargo.toml`, `memory-core = [...]`), consistent with `docs/trusty-memory/decisions/0001-frontend-core-split.md`.
- Corrected the reference to name `crates/trusty-common`'s `memory_core` module instead.

## Verify, do not transcribe

Each fix was checked against the declaring symbol in source (clap struct fields, `DEFAULT_PORT` constants, the `memory_core` module doc), not against other docs — several of these files were wrong in identical ways because they copied each other.

## Gates

```
sld-lint: scanned 56 spec doc(s) + 3126 code file(s); 0 error(s), 0 warning(s)
doc-numbers: scanned 106 doc(s) / 100 claim(s) (floors 20/20); 4 grandfathered, 0 violations — OK.
line-cap: measured 3765 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.
changelog-fragment gate: scanned 5 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
public-docs gate: 27 page(s) across 5 section(s) — all resolve inside the public boundary.
```

Docs-only change — no changelog fragment required.

Also locally checked the added lines against the retired-terms list from the in-flight `--stale` gate on `feat/public-docs-stale-gate` (PR #5135, not merged, not edited here) — none of my additions match a retired term. (`docs/reference/running-mcp-servers.md` line 14's pre-existing `trusty-mpmd` mention — explaining that no such binary exists — was already handled by merged PR #5107 and is untouched by this PR.)

## Test plan

- [x] `bash scripts/check_sld.sh` — pass
- [x] `bash scripts/check_doc_numbers.sh` — pass
- [x] `bash scripts/check_line_cap.sh` — pass
- [x] `bash scripts/check_changelog_fragment.sh` — pass (docs-only, skipped)
- [x] `bash scripts/check_public_docs.sh` — pass

Closes #5143
Closes #5144
Closes #5146

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools