### PR TITLE
ci: move the SemVer gate from per-PR to release-time

### DIFF
--- a/.claude/skills/cargo-publish/SKILL.md
+++ b/.claude/skills/cargo-publish/SKILL.md
@@ -98,7 +98,7 @@ scripts/preflight-publish.sh trusty-mpm
 
 Reads the crate's name/version straight from `crates/trusty-mpm/Cargo.toml`
 (pass an explicit version as a second argument to check a hypothetical
-version instead). Runs four checks and fails loud on any of them:
+version instead). Runs five checks and fails loud on any of them:
 
 1. **merged-main**: current HEAD's commit SHA is EXACTLY `origin/main`'s HEAD
    SHA (stricter than `check-publish-ready.sh`'s ancestor check).
@@ -108,8 +108,19 @@ version instead). Runs four checks and fails loud on any of them:
 4. **version-not-live**: the target version is not already published on
    crates.io (queries `https://crates.io/api/v1/crates/<name>/<version>`) —
    this is the exact guard that would have caught the 0.22.0 collision.
+5. **semver** (#5149): runs `scripts/check_semver.sh --crate <pkg>`, which
+   compares the crate's public API against its latest non-yanked crates.io
+   release and fails when a break is not carried by a breaking version bump
+   (0.x crates break in the MINOR position). This is the ONLY place that can
+   block a bad publish — a crates.io upload is irreversible except by yank, and
+   #4088 is what a gate arriving afterwards costs. Requires
+   `cargo install cargo-semver-checks@0.50.0 --locked`; a missing tool is a
+   failure, not a skip. No override — the fix is to bump the breaking position,
+   which the gate then skips as an already-breaking release.
+   `.github/workflows/semver-checks.yml` runs the same check on the tag push
+   (step 4), so a red run there is visible before you reach step 6.
 
-`scripts/preflight-publish.sh --check-only <crate>` runs all four checks
+`scripts/preflight-publish.sh --check-only <crate>` runs all five checks
 unconditionally and prints a `[PASS]`/`[FAIL]` line per check without
 assuming you're mid-publish — use it to preview status. `--help` documents
 the rare, logged `PREFLIGHT_ALLOW_DETACHED=1` override for check 1 (validated

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,4 +1,5 @@
-# Public-API / SemVer gate for the trusty-tools workspace (issue #5050).
+# Public-API / SemVer gate for the trusty-tools workspace (issue #5050),
+# moved from per-PR to release-time by #5149.
 #
 # The workspace publishes 20+ crates to crates.io and had no check that a
 # breaking public-API change carried a matching version bump. #4088 is what that
@@ -9,33 +10,46 @@
 # override always pairs local source with local dependency — so this job
 # compares against the REGISTRY instead.
 #
-# Cost control: the gate is diff-scoped, the same way check_changelog_fragment.sh
-# is. It builds rustdoc for a crate only when that crate's `src/**` changed AND
-# it is published AND its declared version does not already carry a breaking
-# bump. On a docs-only, CI-only, or unpublished-crate PR the job is a few
-# seconds of git and metadata; the two rustdoc builds are paid only by the PRs
-# that can actually cause the defect.
+# WHY THIS IS NOT A PR GATE (#5149). It used to run on every `pull_request`.
+# Installing the pinned `cargo-semver-checks` and warming a cold
+# `target/semver-checks` cache costs 20+ minutes under a 40-minute timeout,
+# and it is paid before crate selection has even decided whether the PR is
+# exempt. A SemVer break only becomes a defect when something is published, so
+# the check belongs where a publish happens. Between releases the repo is
+# deliberately unprotected against this class of break: a breaking change can
+# merge to main, and the gate catches it at the release that would ship it.
 #
-# Deliberately NO `paths:` filter (issue #4468): a required check skipped by a
-# path filter never reports on the PRs it skips and leaves them pending forever.
-# This job always runs and reports SUCCESS on an exempt PR — the exemption lives
-# in the script, not the trigger.
+# WHERE THE BLOCKING GATE LIVES — READ THIS BEFORE TREATING THIS JOB AS THE
+# GATE. It is not. `cargo publish` for this workspace is run LOCALLY by a human
+# (`local-ops`), not by any workflow here, so no CI job can stop an upload. The
+# barrier is `scripts/preflight-publish.sh` CHECK 5, which runs the same
+# `scripts/check_semver.sh` immediately before `cargo publish` and whose nonzero
+# exit is the documented absolute stop. This job is the SECOND, INDEPENDENT
+# report: it fires on the tag push, which in this project's sequence happens
+# BEFORE `cargo publish` (see .claude/skills/cargo-publish/SKILL.md steps 4-6),
+# so a red run here is visible while the publish can still be called off. Same
+# blocking-vs-independent split, and the same reasoning, as release.yml's
+# `publish-dry-run` job.
 #
-# `pull_request` only: crate selection is a diff against the base branch, which
-# is empty (and would trip the gate's own scan floor) on a push to main.
+# ON-DEMAND: workflow_dispatch takes a crate name so a break can be checked
+# without cutting a release. `bash scripts/check_semver.sh --crate <crate>`
+# does the same thing locally.
 name: SemVer checks
 
 on:
-  pull_request:
-    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
-    # and is the event a base-branch RETARGET fires, so without it a stacked PR
-    # retargeted onto main never re-triggers. Matches ci.yml.
-    types: [opened, synchronize, reopened, ready_for_review, edited]
-    branches: [main]
+  push:
+    tags:
+      - "*-v*"
+  workflow_dispatch:
+    inputs:
+      crate:
+        description: "Crate to check — package name (tga) or crates/ directory (trusty-git-analytics)"
+        required: true
+        type: string
 
 concurrency:
   group: semver-checks-${{ github.ref }}
-  cancel-in-progress: ${{ github.event.action != 'edited' }}
+  cancel-in-progress: true
 
 jobs:
   semver-checks:
@@ -43,22 +57,47 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
-      # fetch-depth: 0 — the gate needs `git merge-base` against the base
-      # branch, which a shallow checkout cannot resolve.
       - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
+
+      # The tag prefix is whichever accepted form the tagger used —
+      # `tga-v1.4.2` and `trusty-git-analytics-v1.4.2` are both valid tags for
+      # the same crate (#1128). check_semver.sh's `--crate` accepts either, so
+      # no alias table is duplicated here.
+      - name: Resolve crate to check
+        id: crate
+        env:
+          TAG: ${{ github.ref_name }}
+          INPUT_CRATE: ${{ inputs.crate }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            NAME="$INPUT_CRATE"
+          else
+            NAME="$(printf '%s' "$TAG" | sed -E 's/-v[0-9].*$//')"
+            # An unchanged string means the sed matched nothing, i.e. the ref is
+            # not <crate>-v<version>. Resolving it would hand check_semver.sh a
+            # crate name that does not exist and read as a tooling error.
+            if [[ "$NAME" == "$TAG" ]]; then
+              echo "::error::Ref '${TAG}' is not a <crate>-v<version> release tag."
+              exit 1
+            fi
+          fi
+          if [[ -z "$NAME" ]]; then
+            echo "::error::Empty crate name — nothing to check."
+            exit 1
+          fi
+          echo "crate=${NAME}" >> "$GITHUB_OUTPUT"
+          echo "Checking crate: ${NAME}"
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
       # A prebuilt binary, PINNED. `cargo install cargo-semver-checks` compiles
-      # ~2 minutes of tool before a single crate is checked, which is exactly the
-      # kind of overhead that gets a gate disabled. install-action downloads a
-      # release artifact instead, and pinning the version keeps a tool release
-      # from silently changing the lint set under a PR. It also never touches
-      # this workspace's Cargo.lock — refreshing that turns the MSRV 1.94 job
-      # red (see CLAUDE.md, "Version bumps must not refresh Cargo.lock").
+      # ~2 minutes of tool before a single crate is checked. install-action
+      # downloads a release artifact instead, and pinning the version keeps a
+      # tool release from silently changing the lint set under a release. It
+      # also never touches this workspace's Cargo.lock — refreshing that turns
+      # the MSRV 1.94 job red (see CLAUDE.md).
       - name: Install cargo-semver-checks (pinned prebuilt)
         uses: taiki-e/install-action@v2
         with:
@@ -69,20 +108,15 @@ jobs:
         with:
           shared-key: semver-checks
           # cargo-semver-checks builds into target/semver-checks/, which
-          # rust-cache prunes as "unrecognised" by default. Keeping it is the
-          # difference between a warm 1-minute check and a cold 5-minute one.
+          # rust-cache prunes as "unrecognised" by default.
           cache-directories: target/semver-checks
 
       # Runs BEFORE the real gate, matching line-cap.yml's selftest-then-gate
       # ordering: a gate that cannot fail makes the real run's green meaningless.
-      # These four cases are the gate's fail-open surface — an unscanned diff and
-      # an unreachable crates.io — plus the 404 case that proves the other three
-      # fail for the right reason.
       - name: SemVer gate selftest (must refuse a blind run)
         run: bash scripts/check_semver_selftest.sh
 
       - name: Enforce public-API SemVer against crates.io
         env:
-          SEMVER_GATE_BASE: ${{ github.event.pull_request.base.sha }}
           SKIP_UI_BUILD: '1'
-        run: bash scripts/check_semver.sh
+        run: bash scripts/check_semver.sh --crate "${{ steps.crate.outputs.crate }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,16 +211,24 @@ waits, the `tga` tag aliases (#1128), and the connection-safe daemon restart.
 > **Full release workflow, `scripts/bump-version.sh`, and Developer-ID signing
 > setup:** see [docs/reference/release-workflow.md](docs/reference/release-workflow.md).
 
-🔴 **A breaking public-API change needs a matching version bump, and CI now
-enforces it (#5050).** `scripts/check_semver.sh` runs `cargo-semver-checks`
-against the crate's latest crates.io release for every crate whose `src/**` the
-PR changed. Cargo's 0.x rule applies: for a `0.y.z` crate the breaking bump is
-the MINOR position. A workspace `cargo check` can never catch this class of
-break — the root `Cargo.toml` path override pairs local source with local
-dependency — which is how #4088 shipped `trusty-common` 0.22.5's required new
-public field on a patch bump and cost `trusty-analyze` 0.7.3 a yank. Prefer
+🔴 **A breaking public-API change needs a matching version bump, and the release
+path enforces it (#5050, moved to release-time by #5149).**
+`scripts/preflight-publish.sh` CHECK 5 runs `cargo-semver-checks` against the
+crate's latest crates.io release immediately before `cargo publish`, and its
+nonzero exit is the absolute stop — that is what blocks a bad upload, since
+`cargo publish` runs locally and no CI job can stop it. The tag-push workflow
+`.github/workflows/semver-checks.yml` reports the same check independently.
+Cargo's 0.x rule applies: for a `0.y.z` crate the breaking bump is the MINOR
+position. A workspace `cargo check` can never catch this class of break — the
+root `Cargo.toml` path override pairs local source with local dependency — which
+is how #4088 shipped `trusty-common` 0.22.5's required new public field on a
+patch bump and cost `trusty-analyze` 0.7.3 a yank.
+
+🟡 **It does not run on PRs**, so between releases a breaking change can merge
+unnoticed and will surface at the release that ships it. Prefer
 `#[non_exhaustive]` on public structs and enums so field and variant additions
-stay non-breaking by construction. See
+stay non-breaking by construction, and check a risky change yourself with
+`bash scripts/check_semver.sh --crate <crate>`. See
 [docs/reference/semver-gate.md](docs/reference/semver-gate.md).
 
 🔴 **CRITICAL macOS note:** never use `cp` to install a release binary on
@@ -442,7 +450,7 @@ Full-length reference materials for less-frequent lookups:
 - **HTTP trust-boundary threat model:** [docs/reference/threat-model.md](docs/reference/threat-model.md) — per-daemon bind/guard/proxy compliance inventory for the loopback-only doctrine ([ADR-0018](docs/adr/0018-loopback-only-doctrine.md)).
 - **Domain consolidation audit:** [docs/reference/domain-consolidation-audit.md](docs/reference/domain-consolidation-audit.md) — dated per-domain status behind the common-entry-point rule.
 - **Per-PR changelog fragments:** [docs/reference/changelog-fragments.md](docs/reference/changelog-fragments.md) — assembler and CI-gate mechanics.
-- **Public-API / SemVer gate:** [docs/reference/semver-gate.md](docs/reference/semver-gate.md) — what it checks, which crates it skips and why, and the feature-exclusion file.
+- **Public-API / SemVer gate:** [docs/reference/semver-gate.md](docs/reference/semver-gate.md) — where it runs (release-time, not per-PR), what it checks, which crates it skips and why, and the feature-exclusion file.
 - **Rust test ladder gate commands:** [docs/reference/test-ladder-baseline.md](docs/reference/test-ladder-baseline.md) — the exact command chain per rung, the baseline-failure protocol, and how much gate output a PR body owes.
 - **Rust issue search keys:** [docs/reference/issue-search-keys.md](docs/reference/issue-search-keys.md) — why test name / panic text / symbol / crate find the canonical issue.
 - **Public documentation allowlist:** [docs/public-manifest.tsv](docs/public-manifest.tsv) — the curated list of `docs/` pages the public website may publish; format documented in the file header. It is an ALLOWLIST, so a page absent from it is never public. Enforced by `scripts/check_public_docs.sh` (self-test `scripts/check_public_docs_selftest.sh`). The internal mdBook (`docs/book.toml` + `docs/SUMMARY.md`) is unaffected and remains the complete offline book.

--- a/docs/reference/semver-gate.md
+++ b/docs/reference/semver-gate.md
@@ -1,7 +1,45 @@
 # Public-API / SemVer gate
 
-`scripts/check_semver.sh`, wired into CI by `.github/workflows/semver-checks.yml`
-(issue [#5050](https://github.com/bobmatnyc/trusty-tools/issues/5050)).
+`scripts/check_semver.sh` (issue
+[#5050](https://github.com/bobmatnyc/trusty-tools/issues/5050)). It runs at
+**release time**, not on pull requests —
+[#5149](https://github.com/bobmatnyc/trusty-tools/issues/5060) moved it.
+
+## Where it runs
+
+| Caller | When | Blocks a publish? |
+|---|---|---|
+| `scripts/preflight-publish.sh` CHECK 5 | immediately before `cargo publish` | **Yes** |
+| `.github/workflows/semver-checks.yml` | on a `<crate>-v<version>` tag push | No — reports |
+| `bash scripts/check_semver.sh --crate <crate>` | on demand, any time | n/a |
+
+`cargo publish` for this workspace is run locally by a human (`local-ops`), so
+no CI job can stop an upload. `preflight-publish.sh` is what can: the release
+sequence runs it as the last step before `cargo publish`, and a nonzero exit is
+the documented absolute stop (`Skill(skill="cargo-publish")`, step 5). CHECK 5
+sits there, so a break is caught while the upload can still be prevented — which
+matters because a crates.io publish is irreversible except by yank, and a gate
+that reported only after the upload would have caught #4088 with nothing left to
+do about it.
+
+The tag-push workflow is a second, independent report. In this project's
+sequence the tag is pushed *before* `cargo publish` (steps 4 then 6), so a red
+run there is still visible in time to call the release off. Same
+blocking-vs-independent split as `release.yml`'s `publish-dry-run` job.
+
+## What is not protected, and when
+
+Between releases, nothing checks this. A breaking public-API change can merge to
+main on a patch-versioned crate and sit there; the gate catches it at the release
+that would ship it. That is the deliberate trade #5149 made: as a `pull_request`
+gate it installed the pinned tool and warmed a cold `target/semver-checks` cache
+before crate selection had even decided whether the PR was exempt — 20+ minutes
+on every PR, including the docs-only ones. A SemVer break only becomes a defect
+when something is published, so the cost belongs at the publish.
+
+The consequence to know: the break surfaces at release time, on the release
+critic path, not in the PR that introduced it. Fixing it then means bumping the
+breaking position or reworking the API with the release already in motion.
 
 ## What it prevents
 
@@ -20,14 +58,27 @@ compares to.
 
 ## What runs
 
-For each crate whose `crates/<crate>/src/**` changed in the PR, the gate resolves
-the latest non-yanked crates.io release and runs `cargo semver-checks` against
-it. The tool version is pinned in the workflow.
+For the named crate, the gate resolves the latest non-yanked crates.io release
+and runs `cargo semver-checks` against it. `--crate` accepts either the package
+name (`tga`) or the `crates/` directory name (`trusty-git-analytics`), because a
+release tag's prefix can be either
+([#1128](https://github.com/bobmatnyc/trusty-tools/issues/1128)).
+
+With no arguments the gate still selects crates by diffing `crates/*/src/**`
+against a base ref. Nothing calls it that way now; it is kept because it is the
+right shape for a local "what would this branch break" check.
+
+`cargo-semver-checks` must be installed — `cargo install
+cargo-semver-checks@0.50.0 --locked`. Its absence is a hard failure with that
+remedy, never a skip: on the release path this gate is the last barrier, so a
+missing tool reporting green would put the repo back where #4088 found it. CI
+installs the same pinned version as a prebuilt binary.
 
 ## Skips, and why each one is a fact rather than an excuse
 
 | Condition | Behaviour |
 |---|---|
+| `cargo-semver-checks` not installed | **hard failure** |
 | `publish = false` | skip — never reaches crates.io |
 | no library target | skip — a bin-only crate has no API surface to compare |
 | crates.io returns 404 | skip — never published, so no baseline exists |
@@ -74,20 +125,37 @@ coverage hole and has to earn its place. "It is slow" is not a reason.
 
 ## When it fires
 
-Bump the version, or make the change non-breaking. `#[non_exhaustive]` on a
-struct or enum makes future field and variant additions non-breaking by
+Bump the breaking position, or make the change non-breaking. `#[non_exhaustive]`
+on a struct or enum makes future field and variant additions non-breaking by
 construction — the fix #4088 asked for and deferred.
 
 ```bash
 cargo semver-checks --explain constructible_struct_adds_field
 ```
 
+There is no override flag on CHECK 5, and none is needed. Bumping the breaking
+position makes the gate record an already-breaking release and skip it, so a
+false positive and a real break have the same safe remedy.
+
 ## Running it locally
 
 ```bash
-bash scripts/check_semver.sh                        # diff against origin/main
-bash scripts/check_semver.sh --crate trusty-common  # one crate, ignore the diff
+bash scripts/check_semver.sh --crate trusty-common  # one crate — the release path
 bash scripts/check_semver.sh --probe trusty-common  # what would it compare to?
+bash scripts/check_semver.sh                        # every crate changed vs origin/main
+```
+
+Or through the blocking caller, which also reports the other four publish
+guards:
+
+```bash
+bash scripts/preflight-publish.sh --check-only trusty-common
+```
+
+To run it in CI without cutting a release, dispatch the workflow:
+
+```bash
+gh workflow run semver-checks.yml -f crate=trusty-common
 ```
 
 ## Self-test

--- a/scripts/check_semver.sh
+++ b/scripts/check_semver.sh
@@ -13,10 +13,22 @@
 #   Cargo.toml always pairs local source with local dependency. The break is
 #   only visible against the REGISTRY, which is what this gate compares to.
 #
-# What: for every crate whose `crates/<crate>/src/**` changed in the PR, resolves
-#   the latest non-yanked version on crates.io and runs `cargo semver-checks`
-#   against it. A crate needs a check only when its declared version does not
-#   already carry a breaking bump; see "Already-breaking" below.
+# What: for one or more crates, resolves the latest non-yanked version on
+#   crates.io and runs `cargo semver-checks` against it. A crate needs a check
+#   only when its declared version does not already carry a breaking bump; see
+#   "Already-breaking" below. Crate selection is either explicit (`--crate`) or,
+#   with no arguments, every crate whose `crates/<crate>/src/**` changed against
+#   a base ref.
+#
+# Where this runs (#5149, moved from per-PR): the BLOCKING caller is
+#   `scripts/preflight-publish.sh` CHECK 5, which runs immediately before
+#   `cargo publish` and whose nonzero exit is the documented absolute stop — so
+#   a break is caught while the upload can still be prevented, not after
+#   crates.io has made it permanent. `.github/workflows/semver-checks.yml` runs
+#   the same command on every `<crate>-v<version>` tag push as a second,
+#   independent report. The per-PR trigger was removed: installing the pinned
+#   tool and warming a cold rustdoc cache cost 20+ minutes on every PR, and a
+#   SemVer break only matters when something is actually published.
 #
 # Baseline policy — SCOPED TO PUBLISHED CRATES, and an absent baseline is a
 #   RECORDED SKIP, never a silent one:
@@ -55,11 +67,15 @@
 #   silent hole.
 #
 # Usage:
+#   bash scripts/check_semver.sh --crate trusty-common # one crate (release path)
+#   bash scripts/check_semver.sh --probe trusty-common # baseline decision only
 #   bash scripts/check_semver.sh                       # diff vs origin/main
 #   bash scripts/check_semver.sh --base <ref>          # explicit base
-#   bash scripts/check_semver.sh --crate trusty-common # one crate, ignore diff
-#   bash scripts/check_semver.sh --probe trusty-common # baseline decision only
 #   SEMVER_GATE_BASE=<ref> bash scripts/check_semver.sh
+#
+#   `--crate` accepts either the crates.io package name (`tga`) or the crates/
+#   directory name (`trusty-git-analytics`), so a release tag's prefix can be
+#   handed straight to it in either accepted form (#1128).
 #
 # Exit: 0 when every checked crate is SemVer-clean (or is a recorded skip);
 #   1 when a crate needs a bump it does not have, or when the gate itself could
@@ -110,7 +126,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     -h | --help)
-      sed -n '2,90p' "$0" >&2
+      sed -n '2,89p' "$0" >&2
       exit 0
       ;;
     *)
@@ -305,6 +321,10 @@ elif mode == "dir":
             print(p["name"])
             break
 
+elif mode == "exists":
+    want = sys.argv[3]
+    print("yes" if any(p["name"] == want for p in meta["packages"]) else "no")
+
 elif mode == "features":
     crate = sys.argv[3]
     excluded = set(filter(None, sys.argv[4].split()))
@@ -349,6 +369,44 @@ dir_to_crate() {
   python3 "$PY_HELPER" dir "$META_FILE" "$REPO_ROOT" "$1"
 }
 
+# resolve_crate <name-or-dir> — print the package name for either a crates.io
+# package name (`tga`) or a crates/ directory name (`trusty-git-analytics`).
+#
+# Why: the release-time caller has a git tag, and a tag prefix is whichever of
+# the two the tagger used — `tga-v1.4.2` and `trusty-git-analytics-v1.4.2` are
+# both accepted tags for the same crate (#1128). Accepting both here mirrors
+# preflight-publish.sh's resolver so this workspace keeps ONE lookup convention.
+resolve_crate() {
+  local want="$1" name
+  if [[ "$(python3 "$PY_HELPER" exists "$META_FILE" "$want")" == "yes" ]]; then
+    echo "$want"
+    return 0
+  fi
+  name="$(dir_to_crate "$want")"
+  if [[ -n "$name" ]]; then
+    echo "$name"
+    return 0
+  fi
+  echo "FAIL: '${want}' is neither a workspace package name nor a crates/ directory." >&2
+  return 1
+}
+
+# require_tool — cargo-semver-checks must be installed, and its absence is a
+# HARD FAIL with a remedy, never a skip. This is the gate's last fail-open
+# surface on the release path: preflight-publish.sh runs it as the final barrier
+# before `cargo publish`, so "the tool wasn't there" reporting green would put
+# the repo back in the state that yanked trusty-analyze 0.7.3 (#4088).
+require_tool() {
+  if cargo semver-checks --version > /dev/null 2>&1; then
+    return 0
+  fi
+  echo "FAIL: TOOL ERROR — 'cargo semver-checks' is not installed." >&2
+  echo "      Install it before publishing:" >&2
+  echo "        cargo install cargo-semver-checks@0.50.0 --locked" >&2
+  echo "      A missing tool is NOT a pass (issue #5050)." >&2
+  return 1
+}
+
 # ---------------------------------------------------------------------------
 # --probe: report the baseline decision for one crate and stop. Exists so the
 # self-test can drive the registry probe — the gate's only fail-open surface —
@@ -372,7 +430,14 @@ fi
 CANDIDATES=""
 
 if [[ -n "$EXPLICIT_CRATES" ]]; then
-  CANDIDATES="$(printf '%s' "$EXPLICIT_CRATES" | grep -v '^$' | LC_ALL=C sort -u)"
+  while IFS= read -r want; do
+    [[ -z "$want" ]] && continue
+    if ! name="$(resolve_crate "$want")"; then
+      exit 1
+    fi
+    CANDIDATES="${CANDIDATES}${name}"$'\n'
+  done <<<"$(printf '%s' "$EXPLICIT_CRATES" | grep -v '^$')"
+  CANDIDATES="$(printf '%s' "$CANDIDATES" | grep -v '^$' | LC_ALL=C sort -u)"
   SCANNED="(explicit)"
 else
   if ! MERGE_BASE="$(git merge-base "$BASE" HEAD 2>/dev/null)"; then
@@ -472,6 +537,13 @@ while IFS= read -r crate; do
     echo "SKIP ${crate}: ${baseline} -> ${current} is already a major release — every lint is inapplicable"
     skipped=$((skipped + 1))
     continue
+  fi
+
+  # Checked lazily — a run whose every candidate skipped never needed the tool,
+  # and demanding it there would be friction with no coverage behind it.
+  if [[ -z "${TOOL_OK:-}" ]]; then
+    require_tool || exit 1
+    TOOL_OK=1
   fi
 
   if ! feature_args "$crate" > "${SCRATCH}/features.txt"; then

--- a/scripts/preflight-publish.sh
+++ b/scripts/preflight-publish.sh
@@ -17,7 +17,7 @@
 #   absolute stop.
 #
 # What: given a crate (by package name or crates/ directory name) and,
-#   optionally, an explicit version, runs FOUR independent checks and exits
+#   optionally, an explicit version, runs FIVE independent checks and exits
 #   nonzero if any of them fail:
 #
 #   CHECK 1 (merged-main): after `git fetch origin main`, current HEAD's
@@ -55,6 +55,31 @@
 #     Any other outcome (network error, unexpected status) fails CLOSED
 #     (cannot verify safety, so refuse) rather than silently passing.
 #
+#   CHECK 5 (public-API SemVer, #5149): runs `scripts/check_semver.sh --crate
+#     <pkg>`, which compares this crate's public API against its latest
+#     non-yanked crates.io release and fails when a breaking change is not
+#     carried by a breaking version bump (Cargo's 0.x rule: for 0.y.z the MINOR
+#     position is the breaking one).
+#
+#     WHY IT LIVES HERE, and not only in CI: this script is the LAST thing that
+#     runs before `cargo publish`, and its nonzero exit is the documented
+#     absolute stop — so a break caught here is caught while the upload can
+#     still be prevented. A crates.io publish is irreversible except by yank, so
+#     a gate that only reports AFTER the upload has no way to undo the damage:
+#     that is exactly #4088, where trusty-common 0.22.5 shipped a required new
+#     public field on a patch bump and cost trusty-analyze 0.7.3 a yank.
+#     `.github/workflows/semver-checks.yml` runs the same command on the tag
+#     push, but a CI job cannot stop a `cargo publish` a human runs locally —
+#     it reports, this blocks.
+#
+#     No override flag exists, and none is needed: the correct response to a
+#     firing gate is to bump the breaking position, which the gate then records
+#     as an already-breaking release and skips. A false positive and a real
+#     break have the same safe remedy.
+#
+#     Requires `cargo-semver-checks` (`cargo install cargo-semver-checks@0.50.0
+#     --locked`). Its absence is a FAILURE with that remedy, never a skip.
+#
 # Crate + version resolution: accepts EITHER
 #     scripts/preflight-publish.sh <crate-name-or-dir> [version]
 #   or, when [version] is omitted, reads the version from that crate's
@@ -69,7 +94,7 @@
 #   check-publish-ready.sh does, to avoid a second, divergent lookup
 #   convention in this workspace.
 #
-#   --check-only     run all 4 checks unconditionally (never short-circuits)
+#   --check-only     run all 5 checks unconditionally (never short-circuits)
 #                     and print one [PASS]/[FAIL] line per check, then a
 #                     one-line summary. Useful to preview status without
 #                     assuming you are mid-publish. Exit code is still
@@ -97,6 +122,14 @@
 #         at true origin/main (or PREFLIGHT_ALLOW_DETACHED=1, explicitly
 #         labeled) for check 1, real `gh auth status` output for check 2, a
 #         clean tree for check 3, and a not-yet-published version for check 4.
+#     (e) BOTH modes for check 5 (#5149), against real source rather than a
+#         synthetic break: `fix/5064-redb-flock-collision`'s trusty-review
+#         source paired with version 0.11.1 (a MINOR bump over the published
+#         0.11.0, so the already-breaking skip does not apply) FAILS on 2 major
+#         lints — enum_marked_non_exhaustive on DedupError, and
+#         method_receiver_type_changed on DedupStore::{claim,complete,release}
+#         — and the script exits 1 with "do NOT run 'cargo publish'". The same
+#         crate unmodified at 0.11.1 PASSES: 196 checks, 196 pass.
 #   See the PR description for this script for the full raw terminal output.
 
 set -euo pipefail
@@ -348,16 +381,43 @@ check4_version_not_live() {
   esac
 }
 
+# ===========================================================================
+# CHECK 5 — public-API SemVer against the latest crates.io release (#5149)
+# ===========================================================================
+# Output goes to a file rather than the terminal because cargo-semver-checks
+# prints a per-lint progress stream; the file is echoed only when the check
+# fails, which is the only time any of it carries information.
+check5_semver() {
+  local log="${TMP_SEMVER}" rc=0
+
+  SKIP_UI_BUILD=1 bash "${REPO_ROOT}/scripts/check_semver.sh" \
+    --crate "$PKG_NAME" > "$log" 2>&1 || rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    echo "[PASS] semver: $(tail -1 "$log")" >&2
+    return 0
+  fi
+
+  echo "[FAIL] semver: public-API check failed for ${PKG_NAME} ${VERSION}:" >&2
+  sed 's/^/       /' "$log" >&2
+  echo "       Publishing this would ship a breaking change without a breaking" >&2
+  echo "       version bump — the #4088 shape that yanked trusty-analyze 0.7.3." >&2
+  echo "       Bump the breaking position in ${MANIFEST}, or make the change" >&2
+  echo "       non-breaking (#[non_exhaustive] on public structs and enums)." >&2
+  return 1
+}
+
 # ---------------------------------------------------------------------------
 # Scratch temp file for check 4's curl response body. Created once up front
 # and cleaned up via a script-scoped EXIT trap (matches check_line_cap.sh's
 # convention: mktemp + trap 'rm -f ...' EXIT).
 # ---------------------------------------------------------------------------
 TMP_BODY="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.body.XXXXXX")"
-trap 'rm -f "$TMP_BODY"' EXIT
+TMP_SEMVER="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.semver.XXXXXX")"
+trap 'rm -f "$TMP_BODY" "$TMP_SEMVER"' EXIT
 
 # ---------------------------------------------------------------------------
-# Run all 4 checks. Always run every check (rather than short-circuiting) so
+# Run all 5 checks. Always run every check (rather than short-circuiting) so
 # --check-only and normal mode share one code path and a single run always
 # reports the full picture — a partial preflight is how gaps get missed.
 # ---------------------------------------------------------------------------
@@ -366,6 +426,7 @@ check1_merged_main;      [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check2_identity;         [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check3_clean_tree;       [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check4_version_not_live; [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
+check5_semver;           [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 set -e
 
 if [ "$FAILURES" -gt 0 ]; then
@@ -373,5 +434,5 @@ if [ "$FAILURES" -gt 0 ]; then
   exit 1
 fi
 
-echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 4 checks. Safe to publish." >&2
+echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 5 checks. Safe to publish." >&2
 exit 0


### PR DESCRIPTION
Closes #5149

The SemVer gate (#5050, PR #5055) ran on every `pull_request`. It installed a pinned `cargo-semver-checks` and warmed a cold `target/semver-checks` cache before crate selection had decided whether the PR was even exempt — 20+ minutes under a 40-minute timeout, on docs-only PRs too. A SemVer break only becomes a defect when something is published, so the check moves to the publish.

## Where the gate now runs

| Caller | When | Blocks a publish? |
|---|---|---|
| `scripts/preflight-publish.sh` CHECK 5 | immediately before `cargo publish` | **Yes** |
| `.github/workflows/semver-checks.yml` | on a `<crate>-v<version>` tag push | No — reports |
| `bash scripts/check_semver.sh --crate <crate>` | on demand | n/a |

**Where it sits relative to `cargo publish`, and how a failure blocks the upload.** `cargo publish` for this workspace is run locally by `local-ops`, not by any workflow here, so no CI job can stop an upload. `preflight-publish.sh` can: the release sequence runs it as step 5, the last step before `cargo publish` at step 6, and its nonzero exit is the documented absolute stop. CHECK 5 runs `check_semver.sh --crate <pkg>` there, so `preflight-publish: FAILED — do NOT run 'cargo publish'` is reached with the upload not yet attempted. That ordering is the whole point: a crates.io publish is irreversible except by yank, and a gate that reported afterwards would have caught #4088 with nothing left to do about it.

The tag-push workflow is a second, independent report — the same split, and the same reasoning, as `release.yml`'s `publish-dry-run` job. The tag is pushed at step 4, before `cargo publish` at step 6, so a red run there is still visible in time to call the release off.

`workflow_dispatch` takes a crate name, so a crate can be checked without cutting a release: `gh workflow run semver-checks.yml -f crate=trusty-common`.

## What is no longer protected

Between releases, nothing checks this. A breaking change can merge to main on a patch-versioned crate and sit there until the release that would ship it. That is the trade this PR makes, and it is stated in both `CLAUDE.md` and `docs/reference/semver-gate.md` rather than left implicit.

## Also in this PR

- `check_semver.sh --crate` now accepts a `crates/` directory name as well as a package name, so a release tag's prefix resolves in either accepted form (`tga-v1.4.2` and `trusty-git-analytics-v1.4.2`, #1128). No alias table is duplicated in the workflow.
- A missing `cargo-semver-checks` is a hard failure with an install remedy, never a skip. On the release path this gate is the last barrier, so "the tool wasn't there" reporting green would put the repo back where #4088 found it.

## Proof it fires

Not a synthetic break — real source. `fix/5064-redb-flock-collision`'s `trusty-review` is at 0.12.0, which is already a major bump under Cargo's 0.x rules and which the gate correctly skips as already-breaking. So the proof pairs that branch's source with version **0.11.1**, a MINOR bump over the published 0.11.0 — exactly the #4088 shape, a real break riding a non-breaking version.

**Breaking case — `bash scripts/check_semver.sh --crate trusty-review`, exit 1:**

```
CHECK trusty-review: 0.11.0 -> 0.11.1 (minor release), 4 feature(s)
    Checking trusty-review v0.11.0 -> v0.11.1 (minor change)
     Checked [   0.063s] 196 checks: 194 pass, 2 fail, 0 warn, 58 skip

--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---
Failed in:
  enum DedupError in crates/trusty-review/src/store/dedup.rs:79

--- failure method_receiver_type_changed: method receiver changed type ---
Failed in:
  trusty_review::store::dedup::DedupStore::claim now takes &Arc<Self>, not &Self, in crates/trusty-review/src/store/dedup.rs:432
  trusty_review::store::dedup::DedupStore::complete now takes &Arc<Self>, not &Self, in crates/trusty-review/src/store/dedup.rs:444
  trusty_review::store::dedup::DedupStore::release now takes &Arc<Self>, not &Self, in crates/trusty-review/src/store/dedup.rs:456

     Summary semver requires new major version: 2 major and 0 minor checks failed
FAIL trusty-review: cargo semver-checks exited 100 against baseline 0.11.0
```

**The same break through the blocking caller — `bash scripts/preflight-publish.sh --check-only trusty-review`, exit 1:**

```
[PASS] merged-main: HEAD (9196c667...) == origin/main (9196c667...)
[PASS] identity: active gh account is bobmatnyc
[FAIL] clean-tree: working tree is not clean:
[PASS] version-not-live: trusty-review 0.11.1 is not yet published (HTTP 404)
[FAIL] semver: public-API check failed for trusty-review 0.11.1:
preflight-publish: FAILED (2 check(s) failed) — do NOT run 'cargo publish'.
```

(`clean-tree` fails because the break was applied uncommitted to produce it.)

**Clean case — same crate, unmodified at 0.11.1, exit 0:**

```
CHECK trusty-review: 0.11.0 -> 0.11.1 (minor release), 4 feature(s)
    Checking trusty-review v0.11.0 -> v0.11.1 (minor change)
     Checked [   0.060s] 196 checks: 196 pass, 58 skip
     Summary no semver update required
semver gate: scanned (explicit); 1 crate(s) checked, 0 skipped — OK.
```

**Clean case through the blocking caller — CHECK 5 passes:**

```
[PASS] version-not-live: trusty-review 0.11.1 is not yet published (HTTP 404)
[PASS] semver: semver gate: scanned (explicit); 1 crate(s) checked, 0 skipped — OK.
```

**New paths, both fail closed:**

```
$ bash scripts/check_semver.sh --crate trusty-git-analytics     # directory name
    Finished [  60.657s] tga
semver gate: scanned (explicit); 1 crate(s) checked, 0 skipped — OK.          EXIT=0

$ bash scripts/check_semver.sh --crate not-a-real-crate
FAIL: 'not-a-real-crate' is neither a workspace package name nor a crates/ directory.   EXIT=1

$ PATH=/tmp/nosemver:$PATH bash scripts/check_semver.sh --crate trusty-review
FAIL: TOOL ERROR — 'cargo semver-checks' is not installed.
      Install it before publishing:
        cargo install cargo-semver-checks@0.50.0 --locked
      A missing tool is NOT a pass (issue #5050).                             EXIT=1
```

## Gates

Rung 1 — CI, scripts and docs only, no crate `src/**`. No Cargo test applies; the changelog gate confirms the exemption rather than assuming it.

```
YAML OK
changelog-fragment gate: scanned 6 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
sld-lint: scanned 56 spec doc(s) + 3126 code file(s); 0 error(s), 0 warning(s)
line-cap: measured 3765 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.
  ok  scan floor rejects an empty diff (exit 1)
  ok  probe rejects an unreachable index (exit 1)
  ok  probe rejects HTTP 503 (exit 1)
  ok  probe treats HTTP 404 as 'never published' (exit 0, baseline=NONE)
check_semver_selftest: 4 passed, 0 failed.
EXIT=0
```

`bash -n` passes on both modified scripts, and `shellcheck -S warning` is clean on both — the remaining findings are `style`-level (SC2001, SC2181) and are the file's pre-existing pattern, which the new `check5_semver;` dispatch line follows.

Branch protection is untouched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools