### PR TITLE
fix(scripts): stop inline #[cfg(test)] modules counting against the 500-SLOC production cap

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -5,12 +5,10 @@
 #   or path contains /tests/ or /benches/ segment. All others = production.
 # SLOC excludes blank lines, // line comments, /// doc comments, //! inner-doc comments,
 # and /* ... */ block comments (including multi-line spans). Trailing-comment lines count.
+# SLOC also excludes inline '#[cfg(test)] mod <name> { ... }' bodies (issue #5153).
 # Ratchet: budgets may only DECREASE; when a file drops <= its applicable cap, remove it.
 # Regenerate with: scripts/check_line_cap.sh --update  (use --seed only to bootstrap).
-crates/trusty-common/src/embedder/mod.rs	535
 crates/trusty-git-analytics/src/collect/collector.rs	766
-crates/trusty-mpm/src/daemon/api.rs	1272
-crates/trusty-mpm/src/daemon/api/control_routes.rs	543
+crates/trusty-mpm/src/daemon/api.rs	1176
 crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs	818
-crates/trusty-search/src/main.rs	658
-crates/trusty-search/src/service/walker.rs	1167
+crates/trusty-search/src/main.rs	617

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,14 @@ A file is classified as a **test/benchmark file** when ANY of these match:
 
 All other tracked `.rs` files are **production files**, capped at 500 SLOC.
 
+🟡 **Inline `#[cfg(test)] mod <name> { … }` bodies do not count (#5153).** Add
+tests to a 460-SLOC module without splitting it. Only that exact shape is
+excluded — `#[cfg(test)] mod tests;` sibling declarations, `#[cfg(test)]` on an
+`fn`/`impl`/`use`, and predicates like `all(test, …)` or `any(test, …)` are all
+still counted, as is any test module whose brace balance is skewed by a brace
+inside a string literal. The matcher is line-based and fails closed: it can
+raise a false cap violation, never silently drop production code.
+
 🔴 Mechanically enforced by `scripts/check_line_cap.sh` in CI and the pre-commit
 hook (#610) — a new tracked file over its cap **cannot merge**. Never turn this
 gate green by deleting, `#[ignore]`-ing, or excluding a file from the count;

--- a/docs/reference/sloc-cap.md
+++ b/docs/reference/sloc-cap.md
@@ -26,11 +26,49 @@ comment matter is stripped. These are **excluded** from the count:
 - `/* ... */` block comments — including multi-line spans; every line inside an
   open block comment is excluded
 - lines that consist entirely of a closing `*/`
+- inline `#[cfg(test)] mod <name> { … }` unit-test modules — see below
 
 A line that has code followed by a trailing `// comment` **still counts** — it
 has code. The counter is a pragmatic awk heuristic that errs toward leniency:
 edge cases (e.g. `//` inside a string literal) may undercount SLOC but will
 never falsely fail a legitimate file.
+
+## `#[cfg(test)]` Modules Do Not Count (issue #5153)
+
+Inline unit tests are not production code, and the cap is about production
+code. Before #5153 they counted, so a 460-SLOC module that gained tests crossed
+500 and had to have its test module mechanically moved into a sibling
+`_tests.rs` — a large diff for zero change in what the cap exists to limit.
+
+**What is excluded:** exactly one shape, `#[cfg(test)]` on its own line
+followed (blank lines and further `#[…]` attributes permitted) by
+`mod <name> {` at the *same indentation*, through the matching close. The
+`mod` may carry a `pub` / `pub(crate)` / `pub(super)` visibility. Both the
+top-level and the nested/indented forms work.
+
+**What is NOT excluded — each of these is counted as production:**
+
+| Construct | Why it still counts |
+|---|---|
+| `#[cfg(test)] mod tests;` and `#[cfg(test)] #[path = "x.rs"] mod y;` | Sibling-file declaration, one or two lines. The named file is classified as a test file by its own path anyway. |
+| `#[cfg(test)]` on an `fn`, `impl`, `static`, or `use` | Matching them means parsing multi-line signatures and `where` clauses whose opening brace is not on the item's first line — a large fail-open surface for the ~20 occurrences in this workspace. Put test helpers inside the `#[cfg(test)] mod`. |
+| `#[cfg(all(test, unix))]`, `#[cfg(any(test, feature = "x"))]`, `#[cfg(not(test))]` | Only the exact literal `#[cfg(test)]` is recognised. `any(test, …)` genuinely compiles into non-test builds. |
+| A test module whose brace balance is skewed by a `{` or `}` inside a string, char, or raw-string literal | The counter is line-based, not a Rust parser. It cannot verify the extent, so it does not guess. |
+| A test module with no matching close before EOF | Same — no extent, no exclusion. |
+
+**The limitation, stated plainly.** The matcher has no notion of string
+literals. It finds a region's end by requiring two independent methods to
+agree: the running `{`/`}` balance must return to zero on the same line that
+is exactly the attribute's indent followed by `}`. When literals skew the
+balance the two disagree, and the region is counted in full. So the failure
+mode is a **false cap violation** on an unusual test module, never a silently
+under-counted production file. That direction is deliberate: an over-matching
+stripper would let real production bloat through a gate reporting OK.
+
+Fixtures for every row above live in `scripts/test-data/sloc-cfg-test-*.rs` and
+are asserted by `scripts/check_line_cap_selftest.sh`, which also runs the gate
+end to end against a 600-SLOC production decoy (must fail) and a
+400-production + 400-inline-test file (must pass).
 
 ## The Ratchet — Allowlist That Can Only Shrink
 

--- a/scripts/check_line_cap.sh
+++ b/scripts/check_line_cap.sh
@@ -44,8 +44,22 @@
 #     - lines consisting entirely of // line comments (including /// and //!)
 #     - lines consisting entirely of /* ... */ block comments (including /**/)
 #     - lines that are inside an open /* ... */ block comment
+#     - inline `#[cfg(test)] mod <name> { … }` unit-test modules (issue #5153)
 #   A line that has code followed by a trailing // comment COUNTS (it has code).
 #   A line inside a multi-line /* */ block does NOT count.
+#
+# #[cfg(test)] EXCLUSION (issue #5153): a 460-SLOC module that gained inline
+#   tests used to cross the 500 production cap and had to have its test module
+#   mechanically split into a sibling _tests.rs — an inflated diff for no
+#   change in production code, which is already what the cap is about. The
+#   matcher recognises ONLY `#[cfg(test)]` + `mod <name> {` at a shared indent,
+#   and excludes the body through the matching close. It is deliberately
+#   FAIL-CLOSED: `#[cfg(test)] mod tests;` sibling declarations, `#[cfg(test)]`
+#   on an fn/impl/use/static, any non-literal cfg predicate (`all(test, …)`,
+#   `any(test, …)`, `not(test)`), and any module whose brace balance is skewed
+#   by braces inside string literals are all COUNTED AS PRODUCTION. The exact
+#   matcher, its two independent agreement checks, and the full list of what it
+#   does NOT exclude are in scripts/lib/sloc_awk.sh.
 #
 # Lenient-heuristic note: the SLOC counter is a pragmatic awk heuristic.
 #   Edge cases where // or /* appear inside a string literal, char literal, or
@@ -284,6 +298,7 @@ if [ "$MODE" = "update" ]; then
     echo "#   or path contains /tests/ or /benches/ segment. All others = production."
     echo "# SLOC excludes blank lines, // line comments, /// doc comments, //! inner-doc comments,"
     echo "# and /* ... */ block comments (including multi-line spans). Trailing-comment lines count."
+    echo "# SLOC also excludes inline '#[cfg(test)] mod <name> { ... }' bodies (issue #5153)."
     echo "# Ratchet: budgets may only DECREASE; when a file drops <= its applicable cap, remove it."
     echo "# Regenerate with: scripts/check_line_cap.sh --update  (use --seed only to bootstrap)."
     sort "$NEWLIST.body"

--- a/scripts/check_line_cap_selftest.sh
+++ b/scripts/check_line_cap_selftest.sh
@@ -23,9 +23,24 @@
 #   There is no bats/shell-test convention elsewhere in scripts/, so this is
 #   a minimal, dependency-free self-test runnable directly with bash.
 #
-# What: runs the shared $SLOC_AWK program (scripts/lib/sloc_awk.sh) against
-#   each fixture in scripts/test-data/ and asserts the exact expected SLOC
-#   count. Exits non-zero and prints a diff-style report on any mismatch.
+#   Issue #5153 added `#[cfg(test)] mod` exclusion to the counter. That change
+#   can only fail in one direction that matters — excluding too much, so real
+#   production bloat sails through a gate reporting OK — so its fixtures come
+#   in two halves: three that must be EXCLUDED, and four that must be COUNTED
+#   because the construct is ambiguous or out of scope. Part 2 below then
+#   proves the whole gate end to end, because a counter fixture alone cannot
+#   show that a 600-SLOC production file still FAILS.
+#
+# What: two parts.
+#   1. Runs the shared $SLOC_AWK program (scripts/lib/sloc_awk.sh) against
+#      each fixture in scripts/test-data/ and asserts the exact expected SLOC
+#      count.
+#   2. Builds throwaway git repos and runs the real scripts/check_line_cap.sh
+#      against a 600-SLOC decoy (must FAIL) and a 400-production + 400-inline-
+#      test file (must PASS, and the assertion pins that its raw non-blank line
+#      count is over the cap, so the pass is the exclusion's doing and not a
+#      shrunken fixture).
+#   Exits non-zero and prints a diff-style report on any mismatch.
 #
 # Test: this IS the test. Run directly: bash scripts/check_line_cap_selftest.sh
 #
@@ -62,12 +77,48 @@ FIXTURE_DIR="$SCRIPT_DIR/test-data"
 #                              here so this known trade-off cannot silently
 #                              change (e.g. into an overcount) without a
 #                              deliberate selftest update.
+#
+# #[cfg(test)] exclusion (issue #5153) — MUST BE EXCLUDED:
+# - sloc-cfg-test-mod.rs:      the canonical inline `#[cfg(test)] mod tests
+#                              { … }`; only the 6 production lines count.
+# - sloc-cfg-test-nested-mod.rs: the same, INDENTED inside another module —
+#                              the closer is matched at the attribute's own
+#                              indent, not at column 0.
+# - sloc-cfg-test-brace-skew.rs and -unterminated.rs below are the fail-closed
+#                              half of the same matcher.
+#
+# #[cfg(test)] exclusion — MUST STILL BE COUNTED (fail-closed half):
+# - sloc-cfg-test-decl.rs:     `#[cfg(test)] mod tests;` declares a sibling
+#                              file, not an inline body. Nothing to exclude;
+#                              behaviour unchanged from before #5153.
+# - sloc-cfg-test-other-predicate.rs: `all(test, …)`, `any(test, …)` and
+#                              `not(test)` are NOT the literal `#[cfg(test)]`
+#                              and are counted. `any(test, …)` in particular
+#                              really does compile into non-test builds.
+# - sloc-cfg-test-non-mod-item.rs: `#[cfg(test)]` on an `fn` or a `use` is
+#                              counted — only `mod` bodies are in scope.
+# - sloc-cfg-test-brace-skew.rs: an unmatched `{` inside a raw string skews
+#                              the module's brace balance. The gate must
+#                              COUNT the module rather than guess where it
+#                              ends. This is THE fail-open regression: if a
+#                              future edit makes this fixture drop to 3, the
+#                              counter has started trusting a balance it
+#                              cannot verify.
+# - sloc-cfg-test-unterminated.rs: a `mod tests {` with no closer at all —
+#                              no closer found, nothing excluded.
 CASES="sloc-normal.rs	7
 sloc-pathglob-doc.rs	6
 sloc-real-block-comment.rs	2
 sloc-nested-block-comment.rs	1
 sloc-trailing-comment.rs	4
-sloc-string-literal-slash-star.rs	2"
+sloc-string-literal-slash-star.rs	2
+sloc-cfg-test-mod.rs	6
+sloc-cfg-test-nested-mod.rs	5
+sloc-cfg-test-decl.rs	8
+sloc-cfg-test-other-predicate.rs	17
+sloc-cfg-test-non-mod-item.rs	9
+sloc-cfg-test-brace-skew.rs	11
+sloc-cfg-test-unterminated.rs	9"
 
 fail=0
 while IFS="$(printf '\t')" read -r fixture expected; do
@@ -93,4 +144,106 @@ if [ "$fail" -ne 0 ]; then
 fi
 
 echo "check_line_cap_selftest: all SLOC-counter regression cases passed."
+
+# ===========================================================================
+# Part 2 — end-to-end gate cases for the #[cfg(test)] exclusion (issue #5153).
+#
+# A counter fixture proves what a number is; it cannot prove the GATE still
+# rejects a fat production file. These two cases do, against the real
+# scripts/check_line_cap.sh in a throwaway repo:
+#
+#   decoy   600 production SLOC + a small #[cfg(test)] block  -> must FAIL
+#   inverse 400 production SLOC + 400 inline test SLOC        -> must PASS,
+#           with the raw non-blank line count asserted to be over the cap so
+#           the pass is provably the exclusion's doing.
+#
+# The repo is padded to clear check_line_cap.sh's MIN_RS_FILES scan floor
+# (#4618), which otherwise rejects a small fixture before it counts anything.
+# ===========================================================================
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+PAD_FILES=520
+
+# new_gate_fixture — print the path to a throwaway git repo holding a copy of
+# the gate (so its SCRIPT_DIR-derived repo root resolves inside the fixture)
+# and enough filler .rs files to clear the scan floor.
+new_gate_fixture() {
+  local tmp i
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/linecap.e2e.XXXXXX")"
+  git -C "$tmp" init -q
+  git -C "$tmp" config user.email selftest@example.invalid
+  git -C "$tmp" config user.name "line-cap self-test"
+  mkdir -p "$tmp/scripts" "$tmp/pad"
+  cp "$REPO_ROOT/scripts/check_line_cap.sh" "$tmp/scripts/"
+  cp -R "$REPO_ROOT/scripts/lib" "$tmp/scripts/"
+  i=0
+  while [ "$i" -lt "$PAD_FILES" ]; do
+    printf 'pub fn pad%s() -> u32 {\n    %s\n}\n' "$i" "$i" > "$tmp/pad/pad$i.rs"
+    i=$((i + 1))
+  done
+  echo "$tmp"
+}
+
+# emit_prod <count> — <count> lines of one-SLOC-each production code.
+emit_prod() {
+  awk -v n="$1" 'BEGIN { for (i = 0; i < n; i++) printf "pub fn p%d() -> u32 { %d }\n", i, i }'
+}
+
+e2e_fail=0
+
+# ---- decoy: genuine production bloat must still be rejected ----------------
+f="$(new_gate_fixture)"
+{
+  emit_prod 600
+  printf '\n#[cfg(test)]\nmod tests {\n    #[test]\n    fn t() {\n        assert_eq!(p0(), 0);\n    }\n}\n'
+} > "$f/decoy.rs"
+git -C "$f" add -A >/dev/null && git -C "$f" commit -qm fixture
+decoy_out="$(cd "$f" && bash scripts/check_line_cap.sh 2>&1)" && decoy_rc=0 || decoy_rc=$?
+case "$decoy_rc:$decoy_out" in
+  0:*)
+    echo "SELF-TEST FAIL: 600-SLOC production decoy PASSED the gate — the #[cfg(test)]" >&2
+    echo "       stripper is over-matching and the cap is no longer enforced." >&2
+    e2e_fail=1 ;;
+  *"decoy.rs is 600 SLOC"*)
+    echo "  ok  decoy 600 production SLOC + small #[cfg(test)] block -> FAILED as required" ;;
+  *)
+    echo "SELF-TEST FAIL: decoy was rejected, but not for being 600 SLOC:" >&2
+    printf '%s\n' "$decoy_out" | sed 's/^/       /' >&2
+    e2e_fail=1 ;;
+esac
+rm -rf "$f"
+
+# ---- inverse: production under cap, inline tests over it ------------------
+f="$(new_gate_fixture)"
+{
+  emit_prod 400
+  printf '\n#[cfg(test)]\nmod tests {\n    #[test]\n    fn big() {\n'
+  awk 'BEGIN { for (i = 0; i < 396; i++) printf "        let _v%d = %d;\n", i, i }'
+  printf '    }\n}\n'
+} > "$f/inverse.rs"
+raw_lines="$(grep -c . "$f/inverse.rs")"
+counted="$(awk "$SLOC_AWK" "$f/inverse.rs")"
+git -C "$f" add -A >/dev/null && git -C "$f" commit -qm fixture
+inv_out="$(cd "$f" && bash scripts/check_line_cap.sh 2>&1)" && inv_rc=0 || inv_rc=$?
+if [ "$raw_lines" -le 500 ]; then
+  echo "SELF-TEST FAIL: the inverse fixture has only ${raw_lines} non-blank lines, so it" >&2
+  echo "       would pass the cap even WITHOUT the exclusion. It proves nothing." >&2
+  e2e_fail=1
+elif [ "$counted" -ne 400 ]; then
+  echo "SELF-TEST FAIL: inverse fixture counted ${counted} SLOC, expected 400." >&2
+  e2e_fail=1
+elif [ "$inv_rc" -ne 0 ]; then
+  echo "SELF-TEST FAIL: 400-production + 400-inline-test file was REJECTED:" >&2
+  printf '%s\n' "$inv_out" | sed 's/^/       /' >&2
+  e2e_fail=1
+else
+  echo "  ok  inverse ${raw_lines} raw non-blank lines, ${counted} counted -> PASSED as required"
+fi
+rm -rf "$f"
+
+if [ "$e2e_fail" -ne 0 ]; then
+  echo "check_line_cap_selftest: end-to-end gate cases FAILED." >&2
+  exit 1
+fi
+
+echo "check_line_cap_selftest: end-to-end gate cases passed."
 exit 0

--- a/scripts/lib/sloc_awk.sh
+++ b/scripts/lib/sloc_awk.sh
@@ -6,15 +6,19 @@
 #   means there is exactly one place this algorithm lives (issues #2489/#2509).
 #
 # What: defines the `SLOC_AWK` shell variable — an awk program that counts
-#   SLOC (source lines of code) in a single file, excluding blank lines,
-#   `//`/`///`/`//!` line comments, and `/* ... */` block comments (including
-#   multi-line spans AND nested block comments — Rust supports nesting them,
-#   e.g. `/* outer /* inner */ still outer */`). A line with code followed by
-#   a trailing `//` comment still counts.
+#   SLOC (source lines of code) in a single file. It excludes, in two passes:
+#     1. blank lines, `//`/`///`/`//!` line comments, and `/* ... */` block
+#        comments (including multi-line spans AND nested block comments —
+#        Rust supports nesting them, e.g. `/* outer /* inner */ still outer */`).
+#        A line with code followed by a trailing `//` comment still counts.
+#     2. `#[cfg(test)] mod <name> { … }` regions — inline unit-test modules
+#        (issue #5153). See "Pass 2" below for the exact matcher and its
+#        deliberately narrow scope.
 #
-# Algorithm (issue #2489/#2509 fix, extended by issue #2563 for nesting): the
-#   awk program walks each line left-to-right with a single cursor `pos` and a
-#   block-comment NESTING DEPTH counter `depth` (carried across lines):
+# Pass 1 algorithm (issue #2489/#2509 fix, extended by issue #2563 for
+#   nesting): the awk program walks each line left-to-right with a single
+#   cursor `pos` and a block-comment NESTING DEPTH counter `depth` (carried
+#   across lines):
 #     - While `depth > 0` (we are inside one or more nested block comments),
 #       scan forward from `pos` for whichever of `/*` or `*/` occurs first.
 #       A `*/` decrements `depth`; a `/*` increments it (issue #2563 — a plain
@@ -37,32 +41,111 @@
 #         - `/*` first: keep the text before it as code, set `depth = 1`, and
 #           continue the walk (now in the `depth > 0` branch above) so any
 #           further nesting or a same-line close is still handled correctly.
-#   Whatever code text survives the walk (i.e. was never inside a comment) is
-#   whitespace-stripped; the line counts as 1 SLOC iff any characters remain.
-#   This preserves the pre-existing behavior for non-nested block comments and
-#   trailing `//` comments while fixing the nested-comment overcount.
+#   The surviving code text is stored per line in `code[]` (original leading
+#   whitespace preserved) for pass 2 to inspect. A line counts as 1 SLOC iff
+#   any non-whitespace character remains after pass 2 has had its say.
 #
-# Intentional leniency (unchanged from the original heuristic, issue #2563
-#   item 2): this awk program has no notion of string/char literals or raw
-#   strings, so a `//` or `/*` INSIDE a string literal is still treated as a
-#   real comment marker. An unmatched `/*` inside a string literal (i.e. one
-#   with no `*/` anywhere later in the string or file) sets `depth = 1` and,
-#   because no real `*/` ever appears to close it, SWALLOWS EVERY SUBSEQUENT
-#   LINE TO EOF as if it were still inside that block comment — the same
-#   failure class as #2489/#2509 via a different trigger. This is a known,
-#   accepted trade-off: the counter is designed to err TOWARD LENIENCY (it may
-#   UNDERCOUNT real code, e.g. missing genuine code lines after such a string),
-#   but per the invariant above it will NEVER overcount. See
-#   scripts/test-data/sloc-string-literal-slash-star.rs for a pinned fixture
-#   of this exact swallow-to-EOF behavior, and scripts/check_line_cap.sh's
-#   header comment for the full leniency note.
+# Pass 2 algorithm — `#[cfg(test)]` module exclusion (issue #5153).
+#
+#   Why: the 500-SLOC production cap was counting inline `#[cfg(test)] mod
+#   tests { … }` blocks as production code, so adding tests to a 460-SLOC
+#   module forced a mechanical split of its test module into a sibling
+#   `_tests.rs` file. That inflates diffs and buys nothing — the production
+#   code did not grow. Test code is already capped separately at 3000 SLOC.
+#
+#   THE FAIL-OPEN RISK IS THE WHOLE DIFFICULTY. An over-matching stripper
+#   silently under-counts, and real production bloat then sails through a gate
+#   that reports OK. So this matcher is built to FAIL CLOSED: every ambiguous
+#   or unrecognised construct is COUNTED AS PRODUCTION. A false cap violation
+#   is annoying; a gate that lies is a defect.
+#
+#   Two INDEPENDENT methods must agree before a region is excluded:
+#     (a) Brace balance. Starting at the `mod … {` line, sum `{` minus `}`
+#         per line over the comment-stripped text. The region ends at the
+#         first line where the running total returns to 0.
+#     (b) Indentation anchor. That same line must be exactly the anchor's
+#         leading-whitespace prefix followed by `}` and nothing else.
+#   If (a) and (b) disagree, if the balance never returns to 0 before EOF, or
+#   if the balance goes negative, NOTHING is excluded. Requiring agreement is
+#   what makes brace counting safe without a real Rust lexer: the brace
+#   counter has no notion of string, char, or raw-string literals, so a `{`
+#   or `}` inside `r#"…"#` JSON fixture text or a `'{'` char literal skews
+#   the balance — which breaks the equality check and falls back to counting.
+#
+#   Recognised shape (and ONLY this shape):
+#     <indent>#[cfg(test)]
+#     <indent>[further #[…] attribute lines]
+#     <indent>[pub |pub(crate) |pub(super) |…]mod <ident> {
+#     …
+#     <indent>}
+#   Blank lines between the attribute and the item are tolerated.
+#
+#   EXPLICITLY NOT EXCLUDED — each of these is counted as production:
+#     - `#[cfg(test)] mod tests;` and `#[cfg(test)] #[path = "x.rs"] mod y;`
+#       — sibling-file declarations. They are one or two lines and the file
+#       they name is classified as a test file by its own path, so there is
+#       nothing to gain. Behaviour is unchanged for them.
+#     - `#[cfg(test)]` on an `fn`, `impl`, `static`, or `use` item. In this
+#       workspace those are ~20 occurrences totalling a few dozen lines,
+#       against 1261 `mod` blocks. Matching them means parsing multi-line
+#       signatures, `where` clauses, and expression bodies whose opening
+#       brace is not on the item's first line — a large fail-open surface for
+#       negligible gain. Put test helpers inside the `#[cfg(test)] mod`.
+#     - Any `cfg` predicate other than the exact literal `#[cfg(test)]`:
+#       `#[cfg(all(test, unix))]`, `#[cfg(any(test, feature = "x"))]`, and
+#       `#[cfg(not(test))]` are all counted. `any(test, …)` genuinely compiles
+#       into non-test builds; `all(test, …)` does not, but recognising it
+#       would mean parsing nested cfg predicates, and there are 10 such
+#       blocks in the workspace.
+#     - A `mod … {` whose leading whitespace differs from the `#[cfg(test)]`
+#       attribute's, or whose line does not end in `{`.
+#
+#   KNOWN LIMITATION — the counter is line-based, not a parser. A test module
+#   whose brace balance is skewed by braces inside string/char/raw-string
+#   literals is not excluded at all (it stays counted as production). That is
+#   the intended failure direction. There is no construct that causes the
+#   opposite — production code silently dropped — because exclusion requires
+#   the brace balance to return to exactly 0 on a line that is exactly the
+#   anchor indent plus `}`.
+#
+# Intentional pass-1 leniency (unchanged, issue #2563 item 2): this awk
+#   program has no notion of string/char literals or raw strings, so a `//` or
+#   `/*` INSIDE a string literal is still treated as a real comment marker. An
+#   unmatched `/*` inside a string literal (i.e. one with no `*/` anywhere
+#   later in the string or file) sets `depth = 1` and, because no real `*/`
+#   ever appears to close it, SWALLOWS EVERY SUBSEQUENT LINE TO EOF as if it
+#   were still inside that block comment — the same failure class as
+#   #2489/#2509 via a different trigger. This is a known, accepted trade-off
+#   for COMMENT stripping specifically: it may UNDERCOUNT real code, but it
+#   will never treat comment prose as code. See
+#   scripts/test-data/sloc-string-literal-slash-star.rs for a pinned fixture,
+#   and scripts/check_line_cap.sh's header for the full note.
 #
 # Test: scripts/check_line_cap_selftest.sh exercises this against fixtures in
 #   scripts/test-data/ (normal file, `/*` inside doc-comment prose, real block
 #   comments, nested block comments, trailing `//` after code, `/*` inside a
-#   string literal).
+#   string literal, and the six `#[cfg(test)]` cases from #5153: excluded
+#   inline mod, nested/indented mod, sibling-file `mod tests;` declaration,
+#   non-literal cfg predicate, brace-skewing raw string, and an unterminated
+#   region).
 SLOC_AWK='
-BEGIN { depth = 0; sloc = 0 }
+function rtrim(s) { sub(/[ \t\r]+$/, "", s); return s }
+function ltrim(s) { sub(/^[ \t]+/, "", s); return s }
+# Leading-whitespace prefix of s ("" when s starts with a non-blank).
+function lead_ws(s,   t) {
+  t = s
+  if (t ~ /^[ \t]*$/) return ""
+  sub(/[^ \t].*$/, "", t)
+  return t
+}
+# Net "{" minus "}" on a line. gsub returns the substitution count, which is
+# far faster in awk than a per-character walk over ~500k lines.
+function brace_delta(s,   a, b, t) {
+  t = s; a = gsub(/\{/, "", t)
+  t = s; b = gsub(/\}/, "", t)
+  return a - b
+}
+BEGIN { depth = 0; sloc = 0; nlines = 0 }
 {
   line = $0
   n = length(line)
@@ -109,8 +192,64 @@ BEGIN { depth = 0; sloc = 0 }
       }
     }
   }
-  gsub(/[[:space:]]/, "", out)
-  if (length(out) > 0) sloc++
+  nlines++
+  code[nlines] = out
 }
-END { print sloc }
+END {
+  # ---- Pass 2: mark #[cfg(test)] mod regions for exclusion (issue #5153).
+  # Every branch that cannot prove a region falls through WITHOUT marking,
+  # so the lines stay counted as production. Fail closed, always.
+  i = 1
+  while (i <= nlines) {
+    if (rtrim(ltrim(code[i])) != "#[cfg(test)]") { i++; continue }
+    lead = lead_ws(code[i])
+
+    # Walk to the attributed item, tolerating blank lines and further
+    # attribute lines at the SAME indent.
+    j = i + 1
+    is_mod = 0
+    while (j <= nlines) {
+      t = rtrim(ltrim(code[j]))
+      if (t == "") { j++; continue }
+      if (lead_ws(code[j]) != lead) break
+      if (t ~ /^#\[.*\]$/) { j++; continue }
+      if (t ~ /^(pub([(][a-z]+[)])?[ ]+)?mod[ ]+[A-Za-z_][A-Za-z0-9_]*[ ]*\{$/) is_mod = 1
+      break
+    }
+    if (!is_mod) { i++; continue }
+
+    # Method (a): brace balance from the `mod … {` line.
+    # Method (b): the closing line must be exactly <lead>} and nothing else.
+    d = 0
+    close_at = 0
+    for (k = j; k <= nlines; k++) {
+      d += brace_delta(code[k])
+      if (d < 0) break                                  # malformed -> count it
+      if (d == 0) {
+        if (rtrim(code[k]) == lead "}") close_at = k    # both methods agree
+        break                                           # disagree -> count it
+      }
+    }
+    if (close_at == 0) { i++; continue }                # unterminated -> count it
+
+    for (m = i; m <= close_at; m++) skip[m] = 1
+    i = close_at + 1
+  }
+
+  # Audit hook: `awk -v emit_skip=1 "$SLOC_AWK" file.rs` prints the excluded
+  # line ranges instead of the count, so the pass-2 matcher can be diffed
+  # against an independent implementation without duplicating this program.
+  if (emit_skip) {
+    for (i = 1; i <= nlines; i++) if (i in skip) print i
+    exit 0
+  }
+
+  for (i = 1; i <= nlines; i++) {
+    if (i in skip) continue
+    t = code[i]
+    gsub(/[[:space:]]/, "", t)
+    if (length(t) > 0) sloc++
+  }
+  print sloc
+}
 '

--- a/scripts/test-data/sloc-cfg-test-brace-skew.rs
+++ b/scripts/test-data/sloc-cfg-test-brace-skew.rs
@@ -1,0 +1,17 @@
+//! Fixture: FAIL-CLOSED case. The raw string below holds an unmatched `{`, so
+//! the module's brace balance never returns to zero and the gate refuses to
+//! guess where the module ends. Every line is counted as production.
+
+pub fn parse() -> u8 {
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    const BROKEN: &str = r#"{ "unclosed": true "#;
+
+    #[test]
+    fn t() {
+        assert_eq!(parse(), 1);
+    }
+}

--- a/scripts/test-data/sloc-cfg-test-decl.rs
+++ b/scripts/test-data/sloc-cfg-test-decl.rs
@@ -1,0 +1,13 @@
+//! Fixture: `#[cfg(test)] mod tests;` declares a SIBLING FILE, not an inline
+//! body. Nothing is excluded; behaviour is unchanged from before #5153.
+
+pub fn thing() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(test)]
+#[path = "sloc-cfg-test-elsewhere.rs"]
+mod elsewhere;

--- a/scripts/test-data/sloc-cfg-test-mod.rs
+++ b/scripts/test-data/sloc-cfg-test-mod.rs
@@ -1,0 +1,25 @@
+//! Fixture: an inline `#[cfg(test)] mod tests { … }` is excluded from the
+//! SLOC count (issue #5153). Only the six production lines below count.
+
+pub fn one() -> u32 {
+    1
+}
+
+pub fn two() -> u32 {
+    2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_is_one() {
+        assert_eq!(one(), 1);
+    }
+
+    #[test]
+    fn two_is_two() {
+        assert_eq!(two(), 2);
+    }
+}

--- a/scripts/test-data/sloc-cfg-test-nested-mod.rs
+++ b/scripts/test-data/sloc-cfg-test-nested-mod.rs
@@ -1,0 +1,18 @@
+//! Fixture: an INDENTED `#[cfg(test)] mod tests` nested inside another module
+//! is excluded too — the closer is matched at the attribute's own indent.
+
+pub mod outer {
+    pub fn value() -> u32 {
+        7
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn value_is_seven() {
+            assert_eq!(value(), 7);
+        }
+    }
+}

--- a/scripts/test-data/sloc-cfg-test-non-mod-item.rs
+++ b/scripts/test-data/sloc-cfg-test-non-mod-item.rs
@@ -1,0 +1,15 @@
+//! Fixture: `#[cfg(test)]` on an `fn` or a `use` is COUNTED. Only `mod` bodies
+//! are excluded — see scripts/lib/sloc_awk.sh for why the item grammar stops
+//! there. Put test helpers inside the `#[cfg(test)] mod`.
+
+#[cfg(test)]
+pub fn helper() -> u8 {
+    5
+}
+
+#[cfg(test)]
+use std::collections::BTreeMap;
+
+pub fn real() -> u8 {
+    6
+}

--- a/scripts/test-data/sloc-cfg-test-other-predicate.rs
+++ b/scripts/test-data/sloc-cfg-test-other-predicate.rs
@@ -1,0 +1,23 @@
+//! Fixture: only the exact literal `#[cfg(test)]` is recognised. Every other
+//! cfg predicate is COUNTED, because recognising them means parsing nested
+//! cfg expressions and `any(test, …)` genuinely compiles into non-test builds.
+
+#[cfg(all(test, unix))]
+mod unix_tests {
+    #[test]
+    fn t() {
+        assert!(true);
+    }
+}
+
+#[cfg(any(test, feature = "x"))]
+mod support {
+    pub fn helper() -> u8 {
+        3
+    }
+}
+
+#[cfg(not(test))]
+pub fn real() -> u8 {
+    4
+}

--- a/scripts/test-data/sloc-cfg-test-unterminated.rs
+++ b/scripts/test-data/sloc-cfg-test-unterminated.rs
@@ -1,0 +1,13 @@
+//! Fixture: FAIL-CLOSED case. The test module is never closed (the file is
+//! truncated), so no closer is found and nothing is excluded.
+
+pub fn live() -> u8 {
+    9
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn t() {
+        assert_eq!(live(), 9);
+    }


### PR DESCRIPTION
Closes #5153

`scripts/lib/sloc_awk.sh` gains a second pass that excludes inline
`#[cfg(test)] mod <name> { … }` bodies from the SLOC count. `PROD_CAP` stays
500 and `TEST_CAP` stays 3000 — this changes the counting, not the limits.

Before this, a 460-SLOC module that gained inline tests crossed 500 and had to
have its test module mechanically moved into a sibling `_tests.rs`. On #5152
that happened to three files at 467, 415 and 492 SLOC. The production code did
not grow, and test code is already capped separately at 3000.

## The matcher, and where it stops

Recognised, and only this: `#[cfg(test)]` alone on a line, then (blank lines
and further `#[…]` attributes permitted) `mod <name> {` at the **same
indentation**, through the matching close.

Counted as production, deliberately:

| Construct | Why |
|---|---|
| `#[cfg(test)] mod tests;` / `#[cfg(test)] #[path = "x.rs"] mod y;` | Sibling-file declaration; the named file is already classified as a test file by its own path. Behaviour unchanged. |
| `#[cfg(test)]` on an `fn`, `impl`, `use`, `static` | ~20 occurrences workspace-wide against 1261 `mod` blocks. Matching them means parsing multi-line signatures and `where` clauses whose opening brace is not on the item's first line — a large fail-open surface for a few dozen lines. |
| `all(test, …)`, `any(test, …)`, `not(test)` | Only the exact literal `#[cfg(test)]` is matched. `any(test, …)` genuinely compiles into non-test builds. 10 blocks total. |
| A module whose brace balance is skewed by a brace inside a string/char/raw-string literal | The counter is line-based, not a parser. It cannot verify the extent, so it does not guess. |
| A module with no matching close before EOF | Same. |

## Fail-closed by construction

Two independent methods must agree before anything is excluded: the running
`{`/`}` balance must return to zero **on the same line** that is exactly the
attribute's indent followed by `}`. The brace counter has no notion of
literals, so a `{` inside `r#"…"#` fixture text breaks the equality and the
region is counted in full.

Stated limitation: the failure mode is a **false cap violation** on an unusual
test module, never a silently under-counted production file. Over-extension is
structurally impossible — the scan stops at the *first* zero-crossing.

## Verification

**Whole-tree diff, old counter vs new** (3770 tracked `.rs` files):

```
files changed: 1202   increases: 0   SLOC excluded: 116341
```

Zero files count higher. Only **3 production files** cross the 500 cap, and
they are exactly the 3 allowlist removals below.

**Independent oracle.** A literal-aware Python tokenizer (raw strings, escapes,
char-vs-lifetime) computed its own excluded-line set. It agreed exactly on
3766/3770 files. The 4 disagreements were hand-checked and the gate was right
in all 4 — the tokenizer had closed regions early on multi-line `"\` string
continuations.

**Decisive check — the real Rust parser.** Each of the 1211 excluded regions
was extracted standalone and fed to `rustfmt --edition 2024`:

```
=== regions that do NOT parse standalone as a complete item (must be 0) ===
0
```

A truncated region is missing closing braces; an over-extended one has an
unmatched trailing `}`. Neither parses. All 1211 do.

**Decoy — 600 production SLOC + a small `#[cfg(test)]` block. Must still fail:**

```
NEW GATE
FAIL: decoy.rs is 600 SLOC (> 500 prod cap) and not allowlisted. New oversized file; split it or it cannot merge.
line-cap: measured 522 tracked .rs file(s); 0 allowlisted, 1 violation(s) — FAILED.
EXIT=1
```

**Inverse — 400 production SLOC + 400 inline test SLOC (802 raw non-blank
lines). Red before, green after, same fixture:**

```
OLD counter: 802 SLOC     NEW counter: 400 SLOC

OLD GATE (origin/main)
FAIL: decoy.rs is 607 SLOC (> 500 prod cap) and not allowlisted. ...
FAIL: inverse.rs is 802 SLOC (> 500 prod cap) and not allowlisted. ...
line-cap: measured 522 tracked .rs file(s); 0 allowlisted, 2 violation(s) — FAILED.

NEW GATE — inverse.rs no longer listed; only the decoy fails.
```

## Allowlist

Ratcheted with `--update` only — never `--seed` or `--force-add`, so no
violation can be forgiven. Three entries dropped under cap and were removed;
two budgets ratcheted down.

| Path | Budget | New SLOC | Action |
|---|---|---|---|
| `crates/trusty-common/src/embedder/mod.rs` | 535 | 22 | removed |
| `crates/trusty-mpm/src/daemon/api/control_routes.rs` | 543 | 222 | removed |
| `crates/trusty-search/src/service/walker.rs` | 1167 | 297 | removed |
| `crates/trusty-mpm/src/daemon/api.rs` | 1272 | 1176 | budget lowered — pre-existing drift, unrelated to this change (old counter also reads 1176) |
| `crates/trusty-search/src/main.rs` | 658 | 617 | budget lowered — 41 SLOC of inline tests |
| `crates/trusty-git-analytics/src/collect/collector.rs` | 766 | 766 | unchanged |
| `crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs` | 818 | 818 | unchanged |

Each removal was hand-verified: the excluded region is `#[cfg(test)]` +
`mod tests {` running to a column-0 `}` at EOF, with no column-0 code between.

## Tests

Seven fixtures in `scripts/test-data/sloc-cfg-test-*.rs` — two that must be
excluded, five that must stay counted — plus two end-to-end gate cases
(decoy, inverse) in `check_line_cap_selftest.sh`. `line-cap.yml` already runs
that self-test before the gate, so these run in CI with no workflow change.

`sloc-cfg-test-brace-skew.rs` is the fail-open regression: if a future edit
drops it from 11 SLOC to 3, the counter has started trusting a brace balance it
cannot verify.

## Gates

Rung 1 (no crate `src/**` touched; the changelog gate confirms no fragment is
required).

```
bash -n scripts/check_line_cap.sh                     OK
bash -n scripts/lib/sloc_awk.sh                       OK
bash -n scripts/check_line_cap_selftest.sh            OK
shellcheck -S warning (check_line_cap.sh, selftest)   clean
bash scripts/check_line_cap_selftest.sh               13 counter cases + 2 e2e cases pass
bash scripts/check_scan_floor_selftest.sh line_cap    gate still refuses a vacuous scan
bash scripts/check_line_cap.sh                        3777 files, 4 allowlisted, 0 violations — OK
bash scripts/check_sld.sh                             56 specs + 3127 files, 0 errors
bash scripts/check_changelog_fragment.sh              13 paths, no crate source changed — OK
bash scripts/check_test_pointers.sh                   22436 citations, 0 dangling
```

`shellcheck` on `scripts/lib/sloc_awk.sh` reports SC2148/SC2034 — identical on
`origin/main`; it is a sourced fragment with no shebang and is never
shellchecked standalone.

## Follow-up

The three files #5152 split are deliberately left split — that PR is in flight
and owned elsewhere. Their test modules can be folded back afterward.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
