### PR TITLE
docs: state that the SLOC cap excludes comments and blank lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,12 @@ TEST_CAP raised #4074):**
 | Production source files | **500 SLOC** |
 | Test / benchmark files | **3000 SLOC** |
 
+Comments, doc comments (`//`, `///`, `//!`, `/* … */`), and blank lines do
+**not** count toward the cap — only non-comment code lines in tracked `.rs`
+files do (e.g. `crates/trusty-common/src/lib.rs` is 809 raw lines but 113
+SLOC). Exact counting definition:
+[docs/reference/sloc-cap.md](docs/reference/sloc-cap.md).
+
 A file is classified as a **test/benchmark file** when ANY of these match:
 - basename is exactly `tests.rs`
 - basename ends with `_test.rs` or `_tests.rs`


### PR DESCRIPTION
## Defect

CLAUDE.md's "SLOC file size hard cap" table stated the 500/3000 caps but
never said the counter excludes comments, doc comments, and blank lines.
That exclusion rule lived only in `docs/reference/sloc-cap.md`, one hop away
and rarely read — CLAUDE.md is resident in every agent's prompt every
session. The unstated assumption an agent formed from CLAUDE.md alone was
that doc comments count against the cap, which pulls against this repo's own
Why/What/Test doc-pattern mandate.

## Evidence

Verified `scripts/check_line_cap.sh` (via `scripts/lib/sloc_awk.sh`) directly:
it counts a line only when it has non-whitespace source code after stripping
all comment matter (`//`, `///`, `//!`, `/* … */` including multi-line
spans); blank/whitespace-only lines are excluded; only tracked `.rs` files
are scanned (`git ls-files '*.rs'`).

Measured: `crates/trusty-common/src/lib.rs` is 809 raw lines, counts as 113
SLOC.

## Resolution

Added two sentences directly under the existing cap table in CLAUDE.md,
plus a pointer to `docs/reference/sloc-cap.md` for the exact definition. No
change to the counting script, the reference doc, or the allowlist — the
counter was already correct; only CLAUDE.md's silence on the exclusion was
the defect.

Closes #5159

## Gates (all passing, raw output)

```
sld-lint: scanned 56 spec doc(s) + 3127 code file(s); 0 error(s), 0 warning(s)
doc-numbers: scanned 106 doc(s) / 100 claim(s) (floors 20/20); 4 grandfathered, 0 violations — OK.
line-cap: measured 3777 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
changelog-fragment gate: scanned 1 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
public-docs gate: 27 page(s) across 5 section(s) — all resolve inside the public boundary.
```

No cargo gates run (docs-only change, per task scope). Note: `main` may be
red on #5084 (a pre-existing timing-ceiling flake), unrelated to this PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools