### PR TITLE
docs: state that the SLOC cap counts code lines only (#5159)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,13 @@ TEST_CAP raised #4074):**
 | Production source files | **500 SLOC** |
 | Test / benchmark files | **3000 SLOC** |
 
+**SLOC counts code lines only** — blank lines, `//` comments, `///` and `//!`
+doc comments, and `/* … */` block comments (nesting included) are stripped
+before counting, so documentation never costs cap budget and the Why/What/Test
+mandate above never competes with this cap. A line of code with a trailing `//`
+comment still counts as 1; stripping is not a credit, so adding comments never
+lowers a file's SLOC.
+
 A file is classified as a **test/benchmark file** when ANY of these match:
 - basename is exactly `tests.rs`
 - basename ends with `_test.rs` or `_tests.rs`


### PR DESCRIPTION
Closes #5159

## Defect

CLAUDE.md's dual-cap table gives the 500/3000 numbers and never says what SLOC
means. The exclusion rule lives only in `docs/reference/sloc-cap.md`, one hop
away. CLAUDE.md is resident in every agent's prompt every session, so an agent
reading it alone would reasonably assume doc comments count against the cap and
write thinner docs to stay under it — pulling directly against this repo's own
Why/What/Test mandate three sections earlier.

## Evidence

Verified in `scripts/lib/sloc_awk.sh` (pass 1): a line counts only when
non-whitespace source text remains after comment stripping. Excluded are blank
lines, `//` line comments, `///` and `//!` doc comments, and `/* … */` block
comments including nested ones. Code with a trailing `//` comment keeps the text
before the marker and still counts as 1.

Empirical probe — a 10-line file containing every comment form counts 3, exactly
its three code lines:

```
$ source scripts/lib/sloc_awk.sh && awk "$SLOC_AWK" probe.rs
3
```

`docs/reference/sloc-cap.md:23-31` and `scripts/check_line_cap.sh:42-48` already
document this identically. PR #5154 (`5aa67e82`) added `#[cfg(test)]` module
exclusion — a separate pass-2 rule, already covered by CLAUDE.md's #5153 bullet;
it did not change comment handling.

## Resolution

Six lines added to CLAUDE.md immediately below the cap table. Deliberately
precise rather than reassuring: it states what is excluded, and closes the
over-read by noting a trailing-comment line still counts as 1 and that stripping
is not a credit, so padding a file with comments never lowers its SLOC.

Scope was narrowed mid-task at the owner's direction. `BASE-AGENT.md` was
considered and rejected — it is a trusty-mpm framework asset composed into every
project, and the 500/3000 cap is trusty-tools policy. Checked and confirmed
clean: neither `crates/trusty-mpm/src/assets/agents/BASE-AGENT.md` nor
`crates/trusty-mpm/src/assets/instructions/sections/*.md` mentions SLOC or the
cap, so no framework surface leaks this repo's numbers and no golden
regeneration is needed.

No number, script, allowlist, or reference doc changed.

## Gates — rung 1 (docs only)

| Gate | Result |
|---|---|
| `bash scripts/check_sld.sh` | 56 spec docs + 3127 code files; 0 errors, 0 warnings |
| `bash scripts/check_line_cap.sh` | 3780 tracked .rs files; 4 allowlisted, 0 violations — OK |
| `bash scripts/check_changelog_fragment.sh` | scanned 1 changed path; no crate source changed — OK |
| `bash scripts/check_test_pointers.sh` | 22446 `Test:` citations resolved; 0 dangling — OK |

No Cargo gate: the diff is one Markdown file at the repo root, zero `.rs` files.
The changelog-fragment gate confirms no fragment is owed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools