### PR TITLE
feat(trusty-common): promote the BM25 supervisor to a generic UdsServiceSupervisor (#5089 step 2)

### DIFF
--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -329,6 +329,15 @@ bm25-client = ["uds"]
 # Pulls in `thiserror` (error enum) and uses the `libc` and `tokio` workspace
 # deps already required — adds no new dependencies to the lockfile.
 uds = ["dep:thiserror"]
+# Enables the `uds::supervisor` module: the generic on-demand spawn supervisor
+# (`UdsServiceSupervisor`) promoted from trusty-memory's `Bm25Supervisor`
+# (issue #5089 step 2, ADR-0034 §1). Implies `uds` — it verifies an adopted
+# socket through `verify_socket_for_connect` and checks the `sun_path` budget
+# before spawning. Adds no new dependencies: `tokio/process`, `libc` on unix and
+# the unconditional `sys_metrics` module are already required by this crate.
+# Off by default so a consumer that only binds a socket does not compile the
+# child-process lifecycle.
+uds-supervisor = ["uds"]
 # Bundle the ONNX Runtime static libs via fastembed's
 # `ort-download-binaries-native-tls`. Right choice for macOS and modern
 # Linux (glibc ≥ 2.38). Mutually exclusive with `embedder-load-dynamic`

--- a/crates/trusty-common/changelog.d/5089-uds-service-supervisor.md
+++ b/crates/trusty-common/changelog.d/5089-uds-service-supervisor.md
@@ -34,3 +34,10 @@ Added
   #5089)
 - Every new public enum and struct is `#[non_exhaustive]` while the crate is
   unpublished at 0.30.0 against a released 0.28.1 (#5089)
+- `ServiceTimeouts::try_new` is the fallible sibling of the `const fn`
+  constructor, for a service deriving its timeouts from config rather than
+  declaring them as a `const`. `#[non_exhaustive]` left no other way to build
+  the value, so without it the runtime case could only panic. The type also now
+  documents the sourcing rule the assert cannot check: `shutdown_flush` must be
+  the supervised binary's own flush constant, imported, not a literal that
+  happens to match it today (#5089)

--- a/crates/trusty-common/changelog.d/5089-uds-service-supervisor.md
+++ b/crates/trusty-common/changelog.d/5089-uds-service-supervisor.md
@@ -1,0 +1,36 @@
+Added
+
+- `uds::supervisor::UdsServiceSupervisor`, behind the new `uds-supervisor`
+  feature: the on-demand spawn supervisor generalised out of `trusty-memory`'s
+  `Bm25Supervisor`, so `trusty-console` can start `trusty-review` /
+  `trusty-analyze` at webhook-delivery time without either being resident
+  (ADR-0034 §1, milestone `tm 1.3.5` criterion (c)). It carries the whole state
+  machine that crate had already hardened: spawn-gate serialisation against
+  double-spawn and against a fan-out that satisfies the cap per-caller,
+  adoption of a socket another process bound, an LRU cap on live children, an
+  RSS ceiling compared against a real measurement, exponential-backoff socket
+  probing, `kill_on_drop`, and SIGTERM→SIGKILL with a patience window (#5089)
+- Liveness is decided by the socket, never by `try_wait()`. `SocketVerdict` is
+  three-state and only ENOENT / ECONNREFUSED mean `NotServing`; a timeout or any
+  other errno is `Inconclusive` and leaves the child alone, so load cannot turn
+  into a respawn storm. A child evicted while still alive goes onto a `doomed`
+  queue drained under the spawn gate — SIGTERM plus socket unlink, in that order
+  — rather than being dropped onto `kill_on_drop`'s SIGKILL, because the doomed
+  child unlinks the shared socket path as the last step of its own shutdown and
+  a concurrent termination could land that unlink after the replacement bound
+  the same path (#5085, #5119, #5089)
+- `ServiceTimeouts` makes the spawn-probe budget, the child's own shutdown-flush
+  budget and the SIGTERM patience per-service values rather than constants. Its
+  constructor is a `const fn` whose assert enforces `sigterm_patience >
+  shutdown_flush`, so a service that declares its timeouts as a `const` gets the
+  same compile-time failure `bm25_supervisor.rs`'s `const _: () = assert!(…)`
+  gave — now bound to the value actually passed to the supervisor rather than to
+  a free-standing constant (#5089)
+- Socket adoption is verified, not assumed: a socket that answers but fails
+  `verify_socket_for_connect` is refused with `SupervisorError::UntrustedSocket`
+  instead of being adopted silently or falling through to a spawn that dies on
+  EADDRINUSE. This is the one path where the target's own `bind_hardened` never
+  runs, which ADR-0034 §3 makes the permission bits load-bearing for (#5099,
+  #5089)
+- Every new public enum and struct is `#[non_exhaustive]` while the crate is
+  unpublished at 0.30.0 against a released 0.28.1 (#5089)

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -49,8 +49,29 @@ mod tests;
 pub mod dir;
 mod peer;
 
+/// On-demand supervision of a UDS-serving child process (#5089 step 2).
+///
+/// Why: ADR-0034 §1 needs `trusty-console` to start `trusty-review` /
+/// `trusty-analyze` at delivery time so neither has to be resident. The
+/// mechanism ADR-0032 said "does not yet exist" did exist, as `trusty-memory`'s
+/// `Bm25Supervisor`; this is that supervisor with its BM25-specific parts lifted
+/// into per-service configuration.
+/// What: [`supervisor::UdsServiceSupervisor`] plus its config, error and probe
+/// types. Gated behind the `uds-supervisor` feature because it pulls the whole
+/// child-process lifecycle in, which a crate that only binds a socket does not
+/// need.
+/// Test: `supervisor/tests.rs`, and `trusty-memory`'s
+/// `tests/bm25_supervisor_concurrency.rs` against real children.
+#[cfg(feature = "uds-supervisor")]
+pub mod supervisor;
+
 pub use dir::prepare_socket_dir;
 pub use peer::{ensure_peer_is_self, peer_uid, self_uid};
+#[cfg(feature = "uds-supervisor")]
+pub use supervisor::{
+    ServiceTimeouts, SocketVerdict, SpawnSpec, SupervisorConfig, SupervisorError,
+    UdsServiceSupervisor,
+};
 
 use std::fs::Permissions;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};

--- a/crates/trusty-common/src/uds/supervisor/child.rs
+++ b/crates/trusty-common/src/uds/supervisor/child.rs
@@ -1,0 +1,163 @@
+//! Child-process lifecycle for [`super::UdsServiceSupervisor`] (#5089).
+//!
+//! Why: spawn, graceful termination, socket-file cleanup and the RSS
+//! measurement are the four mechanical operations the supervisor's state
+//! machine sits on top of. Keeping them here leaves the state machine readable
+//! and keeps each one testable without standing up a supervisor.
+//! What: [`ChildHandle`] (the per-instance bookkeeping), [`spawn_child`],
+//! [`terminate_child`], [`remove_socket_file`], and [`over_rss_limit`].
+//! Test: `tests.rs` — `over_rss_limit_is_false_without_a_measurement`,
+//! `over_rss_limit_is_false_when_disabled`, `terminate_child_reaps_a_live_child`.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::process::{Child, Command};
+
+use super::{SpawnSpec, SupervisorError};
+
+/// Per-instance child bookkeeping stored in the supervisor's map.
+///
+/// Why: keeping the `Child` alongside the socket path lets every reaping path
+/// terminate the process and clean up its socket in one pass without
+/// re-resolving anything.
+/// What: the `tokio::process::Child`, the socket it was told to bind, and a
+/// monotonic LRU stamp. The stamp is a counter rather than an `Instant` because
+/// two `ensure_running` calls inside the same clock tick would compare equal and
+/// make the victim choice arbitrary — which is exactly what a burst fan-out
+/// produces.
+/// Test: covered through every supervisor test that reaps.
+#[derive(Debug)]
+pub(super) struct ChildHandle {
+    pub(super) child: Child,
+    pub(super) socket_path: PathBuf,
+    pub(super) last_used: u64,
+}
+
+/// Spawn one child from `spec`.
+///
+/// Why: isolates the `Command` builder so the supervisor's state machine can be
+/// read without it, and so the stdio and `kill_on_drop` decisions live in one
+/// place rather than at each service's call site.
+/// What: creates `spec.create_dirs` first (failing here gives a cleaner error
+/// than a child that immediately exits), closes stdin and stdout — a supervised
+/// UDS service speaks its socket, not its pipes — inherits stderr so the child's
+/// tracing output reaches the parent's log stream, and sets `kill_on_drop` so an
+/// unsupervised drop reaps the child rather than leaking it.
+/// Test: `spawn_child_creates_requested_directories`,
+/// `spawn_child_reports_a_missing_binary`.
+pub(super) async fn spawn_child(
+    service: &str,
+    key: &str,
+    spec: &SpawnSpec,
+) -> Result<Child, SupervisorError> {
+    for dir in &spec.create_dirs {
+        if !dir.exists() {
+            tokio::fs::create_dir_all(dir)
+                .await
+                .map_err(|source| SupervisorError::CreateDir {
+                    service: service.to_string(),
+                    key: key.to_string(),
+                    path: dir.clone(),
+                    source,
+                })?;
+        }
+    }
+
+    Command::new(&spec.program)
+        .args(&spec.args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|source| SupervisorError::Spawn {
+            service: service.to_string(),
+            key: key.to_string(),
+            program: spec.program.clone(),
+            source,
+        })
+}
+
+/// Send SIGTERM, wait out the service's patience window, then SIGKILL.
+///
+/// Why: a clean SIGTERM is the only signal a child's own shutdown handler can
+/// act on, and for a service that acks writes before flushing them, that
+/// handler is the difference between durable and lost. The wait must exceed the
+/// child's OWN budget with margin, not merely match it — signal delivery, the
+/// flush, socket cleanup and exit all have to fit. [`super::ServiceTimeouts`]
+/// enforces that relationship at construction.
+/// What: `libc::kill(SIGTERM)` on unix (tokio's `Child` exposes no SIGTERM),
+/// then `wait()` under `patience`, then tokio's `kill()` — which sends SIGKILL
+/// and waits, so the process is definitely gone when it returns.
+/// Test: `terminate_child_reaps_a_live_child`.
+pub(super) async fn terminate_child(child: &mut Child, patience: Duration) -> std::io::Result<()> {
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        // SAFETY: `libc::kill` is safe to call with any pid; the kernel returns
+        // -1/EINVAL/ESRCH rather than misbehaving on bad input. The return value
+        // is intentionally ignored — either the signal landed (the child exits)
+        // or it did not (the SIGKILL below covers it).
+        unsafe {
+            let _ = libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
+    }
+
+    match tokio::time::timeout(patience, child.wait()).await {
+        Ok(Ok(status)) => {
+            tracing::debug!(?status, "supervised child exited after SIGTERM");
+            Ok(())
+        }
+        Ok(Err(e)) => Err(e),
+        Err(_elapsed) => {
+            tracing::warn!("supervised child ignored SIGTERM after {patience:?} — sending SIGKILL");
+            child.kill().await
+        }
+    }
+}
+
+/// Best-effort unlink of a child's socket file.
+///
+/// Why: a child that exits cleanly unlinks its own socket, but a SIGKILLed one
+/// leaves the file behind and the next spawn for that instance then fails to
+/// bind with EADDRINUSE — and a reaped instance is exactly the one most likely
+/// to be spawned again shortly.
+/// What: `remove_file`; `NotFound` is the expected clean-exit case and is not
+/// logged. Any other error is logged at `debug!` and ignored — a stale socket
+/// costs one failed spawn, not correctness.
+/// Test: covered through the supervisor's shutdown and reap paths.
+pub(super) async fn remove_socket_file(service: &str, key: &str, socket_path: &Path) {
+    if let Err(e) = tokio::fs::remove_file(socket_path).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::debug!(
+            service = %service,
+            instance = %key,
+            socket = %socket_path.display(),
+            "could not remove supervised child's socket (likely already cleaned up): {e}"
+        );
+    }
+}
+
+/// Decide whether a child has breached the RSS ceiling.
+///
+/// Why (#2846): the point of this limit is that it is compared against a real
+/// measurement, so the two ways a measurement can be missing need an explicit,
+/// tested answer rather than whatever `unwrap_or` happens to do. A child with no
+/// pid has already exited — nothing to reclaim. A pid whose RSS cannot be read
+/// yields `None`, which means "no reading", NOT "zero"; reaping on it would kill
+/// every healthy child on any platform where the read is unavailable, turning a
+/// memory guardrail into an outage.
+/// What: `false` when enforcement is off, when the pid is gone, or when the
+/// reading is unavailable. Otherwise `true` iff the measured MB is at or above
+/// the ceiling. Pure — takes the pid rather than the handle so it is testable
+/// without a live process.
+/// Test: `over_rss_limit_is_false_without_a_measurement`,
+/// `over_rss_limit_is_false_when_disabled`.
+pub fn over_rss_limit(pid: Option<u32>, limit_mb: Option<u64>) -> bool {
+    let (Some(limit), Some(pid)) = (limit_mb, pid) else {
+        return false;
+    };
+    crate::sys_metrics::process_rss_mb(pid).is_some_and(|mb| mb >= limit)
+}

--- a/crates/trusty-common/src/uds/supervisor/config.rs
+++ b/crates/trusty-common/src/uds/supervisor/config.rs
@@ -1,0 +1,282 @@
+//! Per-service configuration for [`super::UdsServiceSupervisor`] (#5089).
+//!
+//! Why: the supervisor this generalises carried two timing constants bound to
+//! `trusty-bm25-daemon` specifically. `SPAWN_PROBE_TIMEOUT` was 3 s, justified
+//! in its own doc comment by "BM25 has no model-loading step" against the
+//! embedder's 30 s. `SIGTERM_PATIENCE_SECS` was 5, tied to the daemon's real
+//! flush budget by a `const _: () = assert!(SIGTERM_PATIENCE_SECS >
+//! trusty_bm25_daemon::SHUTDOWN_FLUSH_TIMEOUT.as_secs(), …)`. Carried across as
+//! bare constants both break silently for the first service with a model to
+//! load or a longer flush, and each failure wears a misleading costume — a
+//! spawn timeout that looks like a broken binary, and a SIGKILL landing inside
+//! a flush that discards acked writes with no error anywhere. So they are
+//! per-service values here.
+//!
+//! What: [`ServiceTimeouts`] carries the three numbers that must move together
+//! and re-derives the compile-time guard as a precondition of a `const fn`
+//! constructor — see [`ServiceTimeouts::new`]. [`SupervisorConfig`] carries the
+//! population limits, the log label, and the external-mode opt-out.
+//! [`SpawnSpec`] is what the supervisor executes, resolved lazily so a service
+//! that is already running never pays for locating its binary.
+//!
+//! Test: `tests.rs` — `service_timeouts_reject_patience_equal_to_the_flush`,
+//! `service_timeouts_carry_probe_defaults_and_honour_overrides`,
+//! `supervisor_config_clamps_max_live_to_one`.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Initial socket-probe interval, doubled on each miss.
+///
+/// 20 ms gives sub-50 ms detection on a fast bind without busy-waiting.
+pub const DEFAULT_INITIAL_PROBE_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Ceiling on the exponential probe backoff.
+pub const DEFAULT_MAX_PROBE_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Per-attempt timeout on the liveness connect.
+///
+/// Short on purpose: an unresponsive-but-bound socket must not stall the probe
+/// loop, and a connect that does not settle inside it is
+/// [`super::SocketVerdict::Inconclusive`] rather than a reason to kill anything.
+pub const DEFAULT_CONNECT_PROBE_TIMEOUT: Duration = Duration::from_millis(200);
+
+/// Const-evaluable `a > b` for [`Duration`].
+///
+/// Why: [`ServiceTimeouts::new`] must compare two durations inside a `const fn`,
+/// and this pair of accessors has been `const` since long before this crate's
+/// MSRV — unlike the whole-value comparison operators, which are not `const`.
+const fn duration_gt(a: Duration, b: Duration) -> bool {
+    a.as_secs() > b.as_secs() || (a.as_secs() == b.as_secs() && a.subsec_nanos() > b.subsec_nanos())
+}
+
+/// The timing budget of ONE supervised service.
+///
+/// Why: see the module docs. Every field here is a statement about the
+/// supervised child, not about supervision in general.
+///
+/// What: `spawn_probe` is how long [`super::UdsServiceSupervisor::ensure_running`]
+/// waits for a freshly-spawned child to bind and accept. `shutdown_flush` is the
+/// child's OWN shutdown budget, declared by the service so the relationship
+/// below is checkable. `sigterm_patience` is how long the supervisor waits after
+/// SIGTERM before escalating to SIGKILL, and it must strictly exceed
+/// `shutdown_flush` — the child still needs signal delivery, the flush itself,
+/// socket cleanup and exit inside that window.
+///
+/// `#[non_exhaustive]`: free while `trusty-common` sits unpublished at 0.30.0
+/// against a published 0.28.1, and never free again. On a STRUCT the attribute
+/// bars construction from outside the crate, including functional-update syntax
+/// (E0639) — which is the intent: [`ServiceTimeouts::new`] is the only way in,
+/// and it is where the guard lives.
+///
+/// Test: `service_timeouts_reject_patience_equal_to_the_flush`,
+/// `service_timeouts_carry_probe_defaults_and_honour_overrides`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ServiceTimeouts {
+    /// Total budget waiting for a freshly-spawned child to accept a connection.
+    pub spawn_probe: Duration,
+    /// The child's own shutdown-flush budget, as declared by its service.
+    pub shutdown_flush: Duration,
+    /// SIGTERM-to-SIGKILL patience. Strictly greater than `shutdown_flush`.
+    pub sigterm_patience: Duration,
+    /// First probe interval after spawn.
+    pub initial_probe_interval: Duration,
+    /// Ceiling on the doubling probe interval.
+    pub max_probe_interval: Duration,
+    /// Per-attempt timeout on a liveness connect.
+    pub connect_probe: Duration,
+}
+
+impl ServiceTimeouts {
+    /// Declare a service's timing budget, checking the one relationship that
+    /// loses data when it is wrong.
+    ///
+    /// Why: this is what replaces `bm25_supervisor.rs`'s
+    /// `const _: () = assert!(SIGTERM_PATIENCE_SECS > …SHUTDOWN_FLUSH_TIMEOUT…)`.
+    /// That assertion could not cross the abstraction — `trusty-common` cannot
+    /// name any particular daemon's flush budget without depending on it — so
+    /// the check moved to where both numbers are in scope: the service's own
+    /// declaration. Because this is a `const fn`, a service that writes
+    /// `const T: ServiceTimeouts = ServiceTimeouts::new(…)` gets the identical
+    /// compile-time failure it had before, now bound to the value actually used
+    /// rather than to a free-standing constant that a refactor could leave
+    /// behind. A service that builds its timeouts at runtime instead gets a
+    /// panic at construction — startup, before any child exists — which is the
+    /// programmer-error case `expect` is reserved for, not a runtime condition
+    /// a correct caller can reach.
+    ///
+    /// What: `sigterm_patience` must be strictly greater than `shutdown_flush`.
+    /// At an equal budget the SIGKILL lands inside the very flush the child's
+    /// shutdown handler exists to perform, and every write inside its open
+    /// window is discarded with nothing left to recover from. Probe intervals
+    /// default to [`DEFAULT_INITIAL_PROBE_INTERVAL`],
+    /// [`DEFAULT_MAX_PROBE_INTERVAL`] and [`DEFAULT_CONNECT_PROBE_TIMEOUT`];
+    /// override them with [`Self::with_probe_intervals`] /
+    /// [`Self::with_connect_probe`].
+    ///
+    /// Test: `service_timeouts_reject_patience_equal_to_the_flush` (runtime
+    /// half) and `trusty-memory`'s `BM25_TIMEOUTS` const item (compile-time
+    /// half — flip its patience below the daemon's flush and the build fails).
+    pub const fn new(
+        spawn_probe: Duration,
+        shutdown_flush: Duration,
+        sigterm_patience: Duration,
+    ) -> Self {
+        assert!(
+            duration_gt(sigterm_patience, shutdown_flush),
+            "SIGTERM patience must strictly exceed the supervised child's own \
+             shutdown-flush budget, or the SIGKILL lands mid-flush and discards \
+             acked writes"
+        );
+        Self {
+            spawn_probe,
+            shutdown_flush,
+            sigterm_patience,
+            initial_probe_interval: DEFAULT_INITIAL_PROBE_INTERVAL,
+            max_probe_interval: DEFAULT_MAX_PROBE_INTERVAL,
+            connect_probe: DEFAULT_CONNECT_PROBE_TIMEOUT,
+        }
+    }
+
+    /// Override the exponential-backoff probe intervals.
+    pub const fn with_probe_intervals(self, initial: Duration, max: Duration) -> Self {
+        Self {
+            initial_probe_interval: initial,
+            max_probe_interval: max,
+            ..self
+        }
+    }
+
+    /// Override the per-attempt liveness-connect timeout.
+    pub const fn with_connect_probe(self, connect_probe: Duration) -> Self {
+        Self {
+            connect_probe,
+            ..self
+        }
+    }
+}
+
+/// Everything a [`super::UdsServiceSupervisor`] needs that is fixed for its
+/// lifetime.
+///
+/// Why: resolving the limits once at construction — rather than on each
+/// `ensure_running` — means a mid-flight environment mutation cannot make the
+/// cap wobble between two concurrent calls.
+///
+/// What: `service` is the label every log line carries. `max_live` caps
+/// concurrently-live children, with least-recently-used reaping.
+/// `rss_limit_mb` is a per-child ceiling compared against a real measurement;
+/// `None` disables enforcement, which is a different instruction from a ceiling
+/// of zero and so cannot share an encoding with it. `external_env` names an
+/// environment variable that, when set to exactly `"1"`, suppresses spawning
+/// entirely so an operator running the target under `tctl` (ADR-0011,
+/// ADR-0034 §1) keeps ownership of its lifecycle.
+///
+/// Test: `supervisor_config_clamps_max_live_to_one`,
+/// `external_env_only_honours_exactly_one`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SupervisorConfig {
+    /// Label for log fields; typically the supervised binary's name.
+    pub service: String,
+    /// Cap on concurrently-live children. Clamped to at least 1.
+    pub max_live: usize,
+    /// Per-child RSS ceiling in MB. `None` disables enforcement.
+    pub rss_limit_mb: Option<u64>,
+    /// Timing budget of the supervised service.
+    pub timeouts: ServiceTimeouts,
+    /// Environment variable that opts spawn supervision out when set to `"1"`.
+    pub external_env: Option<String>,
+}
+
+impl SupervisorConfig {
+    /// Configure a supervisor for one service.
+    ///
+    /// `max_live` is clamped to at least 1: a cap of zero would reap every
+    /// child the instant it spawned, which is a wedge rather than a limit.
+    pub fn new(service: impl Into<String>, max_live: usize, timeouts: ServiceTimeouts) -> Self {
+        Self {
+            service: service.into(),
+            max_live: max_live.max(1),
+            rss_limit_mb: None,
+            timeouts,
+            external_env: None,
+        }
+    }
+
+    /// Set the per-child RSS ceiling in MB; `None` disables enforcement.
+    pub fn with_rss_limit_mb(mut self, rss_limit_mb: Option<u64>) -> Self {
+        self.rss_limit_mb = rss_limit_mb;
+        self
+    }
+
+    /// Name the environment variable that suppresses spawning when set to `"1"`.
+    pub fn with_external_env(mut self, var: impl Into<String>) -> Self {
+        self.external_env = Some(var.into());
+        self
+    }
+
+    /// Whether spawn supervision is currently opted out.
+    ///
+    /// Why: read per call rather than cached at construction, because an
+    /// operator flipping the variable expects the next request to honour it,
+    /// and because the supervisor's own tests set it after construction.
+    /// What: true iff `external_env` is set and the variable holds exactly
+    /// `"1"`. Any other value is treated as unset, matching how the
+    /// `TRUSTY_BM25_DAEMON=1` client-side gate reads.
+    /// Test: `external_env_only_honours_exactly_one`.
+    pub fn external_mode_enabled(&self) -> bool {
+        self.external_env
+            .as_deref()
+            .is_some_and(|key| std::env::var(key).as_deref() == Ok("1"))
+    }
+}
+
+/// The command that starts one instance of a supervised service.
+///
+/// Why: resolved by a closure the supervisor calls only when it has decided to
+/// spawn, so a service that is already running — or externally managed, or
+/// adoptable from a socket someone else bound — never pays for locating its
+/// binary, and a missing binary is not an error on any of those paths.
+///
+/// What: the program, its arguments, and directories to create first. `stdin`
+/// and `stdout` are closed and `stderr` is inherited so the child's tracing
+/// output reaches the parent's log stream; `kill_on_drop` is always set so an
+/// unsupervised drop still reaps the child rather than leaking it.
+///
+/// Test: `spawn_spec_builder_accumulates_args_and_dirs`.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct SpawnSpec {
+    /// Binary to execute.
+    pub program: PathBuf,
+    /// Arguments, in order.
+    pub args: Vec<OsString>,
+    /// Directories created (recursively) before the spawn.
+    pub create_dirs: Vec<PathBuf>,
+}
+
+impl SpawnSpec {
+    /// Start a spec for `program`.
+    pub fn new(program: impl Into<PathBuf>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            create_dirs: Vec::new(),
+        }
+    }
+
+    /// Append one argument.
+    pub fn arg(mut self, arg: impl Into<OsString>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    /// Create `dir` (and its parents) before spawning.
+    pub fn create_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.create_dirs.push(dir.into());
+        self
+    }
+}

--- a/crates/trusty-common/src/uds/supervisor/config.rs
+++ b/crates/trusty-common/src/uds/supervisor/config.rs
@@ -27,6 +27,8 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use super::SupervisorError;
+
 /// Initial socket-probe interval, doubled on each miss.
 ///
 /// 20 ms gives sub-50 ms detection on a fast bind without busy-waiting.
@@ -64,14 +66,30 @@ const fn duration_gt(a: Duration, b: Duration) -> bool {
 /// `shutdown_flush` — the child still needs signal delivery, the flush itself,
 /// socket cleanup and exit inside that window.
 ///
+/// 🔴 **Sourcing rule for `shutdown_flush`, and what the assert cannot check.**
+/// `shutdown_flush` MUST be the supervised binary's own flush constant,
+/// imported — `trusty_bm25_daemon::SHUTDOWN_FLUSH_TIMEOUT`, not a literal `2 s`
+/// that happens to match it today. [`ServiceTimeouts::new`] enforces the
+/// RELATION (`sigterm_patience > shutdown_flush`) and nothing else: it has no
+/// way to know what your child's real budget is, so a literal that understates
+/// it compiles, passes the assert, and SIGKILLs mid-flush — the exact failure
+/// this type exists to prevent. A hardcoded copy also stays equal to itself
+/// while the daemon's real value drifts, so it can never detect the drift.
+/// Import the constant, or add a test pinning your value against it the way
+/// `sigterm_patience_exceeds_the_daemon_flush_budget` does. If your service's
+/// flush budget is not a constant you can name, that is the thing to fix first.
+///
 /// `#[non_exhaustive]`: free while `trusty-common` sits unpublished at 0.30.0
 /// against a published 0.28.1, and never free again. On a STRUCT the attribute
 /// bars construction from outside the crate, including functional-update syntax
-/// (E0639) — which is the intent: [`ServiceTimeouts::new`] is the only way in,
-/// and it is where the guard lives.
+/// (E0639) — which is the intent: the constructors are the only way in, and
+/// they are where the guard lives. Use [`ServiceTimeouts::new`] for a `const`
+/// declaration (compile-time check) and [`ServiceTimeouts::try_new`] when the
+/// values are computed at runtime.
 ///
 /// Test: `service_timeouts_reject_patience_equal_to_the_flush`,
-/// `service_timeouts_carry_probe_defaults_and_honour_overrides`.
+/// `service_timeouts_carry_probe_defaults_and_honour_overrides`,
+/// `try_new_rejects_an_inverted_pair_without_panicking`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ServiceTimeouts {
@@ -138,6 +156,34 @@ impl ServiceTimeouts {
             max_probe_interval: DEFAULT_MAX_PROBE_INTERVAL,
             connect_probe: DEFAULT_CONNECT_PROBE_TIMEOUT,
         }
+    }
+
+    /// [`Self::new`] for values that are not known at compile time.
+    ///
+    /// Why: `new` is a `const fn`, which is what makes the guard a build error
+    /// at a `const` call site — but it also means the only thing it can do about
+    /// a bad pair at runtime is panic. A service deriving its timeouts from
+    /// config or an environment variable needs to report that as an error, not
+    /// take the process down. `#[non_exhaustive]` leaves no other way to build
+    /// the value, so without this the runtime case is unserviceable.
+    /// What: identical to [`Self::new`] except the relation failure is returned
+    /// as [`SupervisorError::InvalidTimeouts`]. The sourcing rule on the type
+    /// still applies — this checks the relation, never whether `shutdown_flush`
+    /// is your child's real budget.
+    /// Test: `try_new_rejects_an_inverted_pair_without_panicking`,
+    /// `try_new_matches_new_for_a_valid_pair`.
+    pub fn try_new(
+        spawn_probe: Duration,
+        shutdown_flush: Duration,
+        sigterm_patience: Duration,
+    ) -> Result<Self, SupervisorError> {
+        if !duration_gt(sigterm_patience, shutdown_flush) {
+            return Err(SupervisorError::InvalidTimeouts {
+                sigterm_patience,
+                shutdown_flush,
+            });
+        }
+        Ok(Self::new(spawn_probe, shutdown_flush, sigterm_patience))
     }
 
     /// Override the exponential-backoff probe intervals.

--- a/crates/trusty-common/src/uds/supervisor/error.rs
+++ b/crates/trusty-common/src/uds/supervisor/error.rs
@@ -1,0 +1,112 @@
+//! Failures [`super::UdsServiceSupervisor`] reports to its caller (#5089).
+//!
+//! Why: `Bm25Supervisor` returned `anyhow::Result` because it lived in a
+//! binary-adjacent crate. Promoted into `trusty-common` the same failures cross
+//! a library boundary, where this workspace's convention is a structured
+//! `thiserror` enum — and where a caller deciding whether to retry, degrade, or
+//! surface a 5xx needs to tell "the binary is missing" from "it bound too
+//! slowly" from "something untrusted is already on that path".
+//! What: one variant per way `ensure_running` can decline to hand back a socket.
+//! Test: exercised through `tests.rs`'s spawn-failure and untrusted-socket
+//! cases; the `Display` strings are the operator-facing contract.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Why a supervised service could not be made available.
+///
+/// `#[non_exhaustive]`: on an ENUM the attribute constrains *matching* — an
+/// external crate needs a wildcard arm (E0004) — which is the intended cost of
+/// keeping variant additions non-breaking once `trusty-common` publishes.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SupervisorError {
+    /// The caller's spawn-spec closure failed — typically because the service's
+    /// binary could not be located.
+    #[error("resolve the spawn command for {service} instance {key}: {source}")]
+    SpawnSpec {
+        /// Service label.
+        service: String,
+        /// Instance key.
+        key: String,
+        /// Underlying failure.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// A directory the spec asked for could not be created.
+    #[error("create directory {path} for {service} instance {key}: {source}")]
+    CreateDir {
+        /// Service label.
+        service: String,
+        /// Instance key.
+        key: String,
+        /// Directory that could not be created.
+        path: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// `Command::spawn` failed.
+    #[error("spawn {program} for {service} instance {key}: {source}")]
+    Spawn {
+        /// Service label.
+        service: String,
+        /// Instance key.
+        key: String,
+        /// Binary that could not be executed.
+        program: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The child started but never bound its socket inside the service's
+    /// `spawn_probe` budget.
+    #[error(
+        "{service} instance {key} did not bind {socket} within {budget:?} — \
+         if this service loads a model at startup, its ServiceTimeouts::spawn_probe \
+         is too small"
+    )]
+    SpawnTimeout {
+        /// Service label.
+        service: String,
+        /// Instance key.
+        key: String,
+        /// Socket the child was expected to bind.
+        socket: PathBuf,
+        /// The budget that elapsed.
+        budget: Duration,
+    },
+
+    /// Something is serving the socket, but it does not pass the
+    /// [`crate::uds::verify_socket_for_connect`] check — so adopting it would
+    /// mean trusting a socket whose permissions are not the credential
+    /// ADR-0034 §3 says they are.
+    #[error("refusing to adopt {socket} for {service} instance {key}: {source}")]
+    UntrustedSocket {
+        /// Service label.
+        service: String,
+        /// Instance key.
+        key: String,
+        /// The socket that was refused.
+        socket: PathBuf,
+        /// Which property failed.
+        #[source]
+        source: crate::uds::UdsSecurityError,
+    },
+
+    /// The socket path does not fit the kernel's address buffer, so no child
+    /// could ever bind it.
+    #[error("socket path for {service} instance {key} is unusable: {source}")]
+    SocketPath {
+        /// Service label.
+        service: String,
+        /// Instance key.
+        key: String,
+        /// The underlying budget failure.
+        #[source]
+        source: crate::uds::UdsSecurityError,
+    },
+}

--- a/crates/trusty-common/src/uds/supervisor/error.rs
+++ b/crates/trusty-common/src/uds/supervisor/error.rs
@@ -92,9 +92,28 @@ pub enum SupervisorError {
         key: String,
         /// The socket that was refused.
         socket: PathBuf,
-        /// Which property failed.
+        /// Which property failed. Boxed: `UdsSecurityError` is the largest
+        /// payload in this enum, and unboxed it pushes `SupervisorError` past
+        /// clippy's `result_large_err` threshold for every fallible non-async
+        /// caller.
         #[source]
-        source: crate::uds::UdsSecurityError,
+        source: Box<crate::uds::UdsSecurityError>,
+    },
+
+    /// A runtime-derived [`crate::uds::ServiceTimeouts`] pair fails the one
+    /// relation the type enforces. Only [`crate::uds::ServiceTimeouts::try_new`]
+    /// produces this — the `const fn` constructor turns the same condition into
+    /// a build error.
+    #[error(
+        "SIGTERM patience {sigterm_patience:?} must strictly exceed the supervised \
+         child's shutdown-flush budget {shutdown_flush:?}, or the SIGKILL lands \
+         mid-flush and discards acked writes"
+    )]
+    InvalidTimeouts {
+        /// The patience that was too short.
+        sigterm_patience: Duration,
+        /// The child's declared flush budget.
+        shutdown_flush: Duration,
     },
 
     /// The socket path does not fit the kernel's address buffer, so no child
@@ -105,8 +124,9 @@ pub enum SupervisorError {
         service: String,
         /// Instance key.
         key: String,
-        /// The underlying budget failure.
+        /// The underlying budget failure. Boxed for the same reason as
+        /// [`SupervisorError::UntrustedSocket`]'s.
         #[source]
-        source: crate::uds::UdsSecurityError,
+        source: Box<crate::uds::UdsSecurityError>,
     },
 }

--- a/crates/trusty-common/src/uds/supervisor/mod.rs
+++ b/crates/trusty-common/src/uds/supervisor/mod.rs
@@ -185,9 +185,11 @@ impl UdsServiceSupervisor {
     /// [`SupervisorError::UntrustedSocket`] rather than a spawn that dies on
     /// EADDRINUSE.
     ///
-    /// Test: `external_mode_skips_spawn`, `adoption_requires_a_hardened_socket`,
-    /// `a_serving_child_is_reused`, plus `trusty-memory`'s concurrency suite for
-    /// the racing cases.
+    /// Test: `external_mode_skips_spawn`,
+    /// `adoption_refuses_a_world_writable_socket`,
+    /// `adoption_accepts_a_hardened_socket_without_spawning`,
+    /// `a_serving_child_is_reused_without_a_spawn`, plus `trusty-memory`'s
+    /// concurrency suite for the racing cases.
     pub async fn ensure_running<F>(
         &self,
         key: &str,
@@ -235,7 +237,7 @@ impl UdsServiceSupervisor {
                     service: service.to_string(),
                     key: key.to_string(),
                     socket: socket_path.to_path_buf(),
-                    source,
+                    source: Box::new(source),
                 }
             })?;
             tracing::info!(
@@ -256,7 +258,7 @@ impl UdsServiceSupervisor {
             SupervisorError::SocketPath {
                 service: service.to_string(),
                 key: key.to_string(),
-                source,
+                source: Box::new(source),
             }
         })?;
 
@@ -333,7 +335,8 @@ impl UdsServiceSupervisor {
     /// another instance's lookup. Eviction then re-acquires and fires only if the
     /// map still holds the same child, so a replacement spawned concurrently is
     /// never evicted by this call's stale verdict.
-    /// Test: `a_dead_child_is_evicted`, `an_unserved_child_is_queued_as_doomed`.
+    /// Test: `a_dead_child_is_evicted_without_counting_as_a_reap`,
+    /// `an_unserved_live_child_is_queued_for_graceful_termination`.
     async fn lookup_live(&self, key: &str) -> Option<PathBuf> {
         let (pid, path) = {
             let stamp = self.tick();

--- a/crates/trusty-common/src/uds/supervisor/mod.rs
+++ b/crates/trusty-common/src/uds/supervisor/mod.rs
@@ -1,0 +1,545 @@
+//! On-demand supervision of a UDS-serving child process (#5089 step 2).
+//!
+//! Why: ADR-0034 §1 puts `trusty-console` in charge of starting
+//! `trusty-review` / `trusty-analyze` at the moment a webhook arrives, so
+//! neither has to be resident — which is milestone `tm 1.3.5` criterion (c).
+//! ADR-0032 had said that spawn-on-delivery mechanism "does not yet exist";
+//! it did, as `trusty-memory`'s `Bm25Supervisor`, carrying the scars of #2845,
+//! #2846 and #5085. This module is that supervisor with its BM25-specific parts
+//! lifted out, so the next service inherits the hardening instead of
+//! re-earning it.
+//!
+//! What: [`UdsServiceSupervisor`] owns a keyed population of children, each
+//! serving one Unix socket. [`UdsServiceSupervisor::ensure_running`] resolves an
+//! instance key to a socket path, spawning if it has to, and is the whole public
+//! surface a caller needs. Configuration is per-service — see `config.rs` for why
+//! that is not a nicety.
+//!
+//! **Two invariants a reader must not "simplify" away.**
+//!
+//! 1. Liveness is decided by the SOCKET, not by `try_wait()`. See `probe.rs`.
+//! 2. The timeouts belong to the supervised service, not to supervision. See
+//!    `config.rs`.
+//!
+//! Test: `tests.rs` for the state machine and the limits; `trusty-memory`'s
+//! `tests/bm25_supervisor_concurrency.rs` drives the same code with real
+//! children for the double-spawn, aggregate-cap, dead-child, unserved-socket
+//! and evicted-live-child-flush cases.
+
+mod child;
+mod config;
+mod error;
+mod probe;
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;
+
+pub use child::over_rss_limit;
+pub use config::{
+    DEFAULT_CONNECT_PROBE_TIMEOUT, DEFAULT_INITIAL_PROBE_INTERVAL, DEFAULT_MAX_PROBE_INTERVAL,
+    ServiceTimeouts, SpawnSpec, SupervisorConfig,
+};
+pub use error::SupervisorError;
+pub use probe::{SocketVerdict, probe_socket_verdict, socket_is_serving};
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::sync::Mutex;
+
+use child::{ChildHandle, remove_socket_file, spawn_child, terminate_child};
+
+/// Supervisor that owns a keyed population of UDS-serving child processes.
+///
+/// Why: a caller wants one function that handles the four states a child can be
+/// in — externally managed, already-spawned, dead-and-needs-restart,
+/// never-spawned — without each call site reimplementing the probe-and-spawn
+/// logic, and without any of them getting the fail-open cases wrong.
+///
+/// What: a `Mutex<HashMap<String, ChildHandle>>` keyed by instance. All public
+/// methods take `&self` so the supervisor lives behind an `Arc` and is shared
+/// across handlers. The map mutex is fine-grained — it protects only the map;
+/// spawns and socket probes run with it released so a slow startup for one
+/// instance never blocks another's lookup.
+///
+/// Test: `tests.rs`, plus `trusty-memory`'s concurrency suite.
+pub struct UdsServiceSupervisor {
+    config: SupervisorConfig,
+    children: Mutex<HashMap<String, ChildHandle>>,
+    /// Serialises the spawn sequence (re-check → drain doomed → adopt-check →
+    /// enforce limits → spawn → probe → insert).
+    ///
+    /// Why (#2845): the map mutex is released before spawning, which left two
+    /// gaps. Two concurrent calls for the SAME key could both reach the spawn
+    /// step and the second insert would silently drop the first child. And a
+    /// cross-key fan-out could have every instance in flight at once, so a cap
+    /// checked per-call is satisfied by each caller individually and violated in
+    /// aggregate — the same shape as the unbounded fan-out that 503-stormed
+    /// trusty-search. Serialising spawns closes both: the cap is evaluated
+    /// against a map nobody else is mutating, and a double spawn is impossible
+    /// because the second caller re-checks after acquiring.
+    spawn_gate: Mutex<()>,
+    /// Monotonic tick source for `ChildHandle::last_used`.
+    clock: AtomicU64,
+    /// Children reaped by the cap or the RSS limit — never by `shutdown`.
+    reaped: AtomicU64,
+    /// Child processes this supervisor has launched.
+    ///
+    /// Why: without it a double spawn is invisible from outside. Two racing
+    /// callers for one key both launch a child; the loser's bind fails with
+    /// EADDRINUSE and its process dies, so the map still holds exactly one entry
+    /// and `supervised_count()` reports the same number whether the
+    /// serialisation worked or not. Counting launches is what makes `spawn_gate`
+    /// a claim a test can falsify.
+    spawned: AtomicU64,
+    /// Children evicted by [`Self::lookup_live`] that are still ALIVE and owe a
+    /// graceful shutdown.
+    ///
+    /// Why (#5085/#5119): every other eviction here removes a corpse, so
+    /// dropping the handle — and letting `kill_on_drop` SIGKILL it — is free.
+    /// The unserved-socket arm is the first that evicts a LIVE child, and a live
+    /// child may hold acked-but-unflushed work that only its own SIGTERM handler
+    /// writes out. A bare drop discards it with nothing left to recover from.
+    ///
+    /// Why a queue rather than a detached kill task: the doomed child unlinks
+    /// the socket path as the last step of its own shutdown. Terminating it
+    /// concurrently with the respawn would let that unlink land AFTER the
+    /// replacement bound the same path, leaving the replacement alive and
+    /// permanently unreachable — #5085 reintroduced by its own fix. Draining the
+    /// queue UNDER THE SPAWN GATE, before the replacement is spawned, is what
+    /// orders the two so that cannot happen.
+    doomed: Mutex<Vec<(String, ChildHandle)>>,
+}
+
+impl UdsServiceSupervisor {
+    /// Construct an empty supervisor for one service.
+    pub fn new(config: SupervisorConfig) -> Self {
+        Self {
+            config,
+            children: Mutex::new(HashMap::new()),
+            spawn_gate: Mutex::new(()),
+            clock: AtomicU64::new(0),
+            reaped: AtomicU64::new(0),
+            spawned: AtomicU64::new(0),
+            doomed: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// The configuration this supervisor was built with.
+    pub fn config(&self) -> &SupervisorConfig {
+        &self.config
+    }
+
+    /// Cap on concurrently-live children.
+    pub fn max_live(&self) -> usize {
+        self.config.max_live
+    }
+
+    /// Per-child RSS ceiling in MB; `None` means enforcement is off.
+    pub fn rss_limit_mb(&self) -> Option<u64> {
+        self.config.rss_limit_mb
+    }
+
+    /// How many children have been reaped by the cap or the RSS limit.
+    ///
+    /// Why: "the cap is configured" and "the cap did something" are different
+    /// claims, and #2846 is the record of a limit that only ever made the first
+    /// one. `shutdown` does not increment this.
+    pub fn reaped_count(&self) -> u64 {
+        self.reaped.load(Ordering::Relaxed)
+    }
+
+    /// How many child processes this supervisor has launched.
+    pub fn spawned_count(&self) -> u64 {
+        self.spawned.load(Ordering::Relaxed)
+    }
+
+    /// Number of instances currently supervised.
+    pub async fn supervised_count(&self) -> usize {
+        self.children.lock().await.len()
+    }
+
+    /// Ensure a child is serving `socket_path` for `key`, and return that path.
+    ///
+    /// Why: returning the socket path rather than a connected client keeps the
+    /// supervisor free of any dependency on a service's wire protocol and lets
+    /// the caller decide whether to build one client per call or cache.
+    ///
+    /// What, in order: (1) external mode returns the path untouched, so an
+    /// operator running the service under `tctl` keeps its lifecycle. (2) The
+    /// already-supervised fast path — a stored child that is both un-reaped and
+    /// serving. (3) Under the spawn gate: re-check, then drain the doomed queue,
+    /// then adopt a socket some other process already bound (verified, see
+    /// below), then enforce the limits BEFORE growing the population, then spawn
+    /// and probe. `spec` is called only at (3) — a service that is already
+    /// running never pays for locating its binary, and a missing binary is not
+    /// an error on any earlier path.
+    ///
+    /// Adoption is verified, not assumed. ADR-0034 §3 makes the socket's
+    /// filesystem permissions the credential the relay hop rests on, and this is
+    /// the one path where the service's own `bind_hardened` never runs — so an
+    /// unhardened socket would otherwise be adopted silently. A socket that is
+    /// serving but fails [`crate::uds::verify_socket_for_connect`] produces
+    /// [`SupervisorError::UntrustedSocket`] rather than a spawn that dies on
+    /// EADDRINUSE.
+    ///
+    /// Test: `external_mode_skips_spawn`, `adoption_requires_a_hardened_socket`,
+    /// `a_serving_child_is_reused`, plus `trusty-memory`'s concurrency suite for
+    /// the racing cases.
+    pub async fn ensure_running<F>(
+        &self,
+        key: &str,
+        socket_path: &Path,
+        spec: F,
+    ) -> Result<PathBuf, SupervisorError>
+    where
+        F: FnOnce() -> Result<SpawnSpec, Box<dyn std::error::Error + Send + Sync + 'static>>,
+    {
+        let service = self.config.service.as_str();
+
+        if self.config.external_mode_enabled() {
+            tracing::debug!(
+                service = %service,
+                instance = %key,
+                socket = %socket_path.display(),
+                "external mode — skipping spawn supervision"
+            );
+            return Ok(socket_path.to_path_buf());
+        }
+
+        if let Some(path) = self.lookup_live(key).await {
+            return Ok(path);
+        }
+
+        // Everything below mutates the population, so it runs under the gate.
+        let _spawn = self.spawn_gate.lock().await;
+
+        // A concurrent caller for this same key may have spawned it while we
+        // waited. Without this re-check the cap could be exceeded by exactly the
+        // number of racing callers.
+        if let Some(path) = self.lookup_live(key).await {
+            return Ok(path);
+        }
+
+        // #5085: settle any live child the lookups above evicted BEFORE the
+        // socket is probed or rebound. The doomed child flushes and unlinks this
+        // very path on its way out, so letting it overlap the respawn would
+        // strand the replacement on an unlinked socket.
+        self.reap_doomed().await;
+
+        if socket_is_serving(socket_path, self.config.timeouts.connect_probe).await {
+            crate::uds::verify_socket_for_connect(socket_path).map_err(|source| {
+                SupervisorError::UntrustedSocket {
+                    service: service.to_string(),
+                    key: key.to_string(),
+                    socket: socket_path.to_path_buf(),
+                    source,
+                }
+            })?;
+            tracing::info!(
+                service = %service,
+                instance = %key,
+                socket = %socket_path.display(),
+                "socket already responding — not spawning a new child"
+            );
+            return Ok(socket_path.to_path_buf());
+        }
+
+        // Reaping AFTER the spawn would let the population momentarily exceed
+        // the cap, and under a fan-out that moment is when every other caller is
+        // also spawning.
+        self.enforce_limits(1).await;
+
+        crate::uds::check_sun_path_budget(socket_path).map_err(|source| {
+            SupervisorError::SocketPath {
+                service: service.to_string(),
+                key: key.to_string(),
+                source,
+            }
+        })?;
+
+        let spec = spec().map_err(|source| SupervisorError::SpawnSpec {
+            service: service.to_string(),
+            key: key.to_string(),
+            source,
+        })?;
+        let child = spawn_child(service, key, &spec).await?;
+        self.spawned.fetch_add(1, Ordering::Relaxed);
+
+        if !probe::wait_for_socket(socket_path, &self.config.timeouts).await {
+            // Explicit drop: `kill_on_drop` SIGKILLs the child that never bound.
+            // Nothing was acked to it, so there is nothing to flush.
+            drop(child);
+            return Err(SupervisorError::SpawnTimeout {
+                service: service.to_string(),
+                key: key.to_string(),
+                socket: socket_path.to_path_buf(),
+                budget: self.config.timeouts.spawn_probe,
+            });
+        }
+
+        tracing::info!(
+            service = %service,
+            instance = %key,
+            socket = %socket_path.display(),
+            program = %spec.program.display(),
+            "spawned supervised child"
+        );
+
+        let mut guard = self.children.lock().await;
+        guard.insert(
+            key.to_string(),
+            ChildHandle {
+                child,
+                socket_path: socket_path.to_path_buf(),
+                last_used: self.tick(),
+            },
+        );
+        let live = guard.len();
+        drop(guard);
+        tracing::debug!(service = %service, live, cap = self.config.max_live, "child count");
+        Ok(socket_path.to_path_buf())
+    }
+
+    /// Next value of the monotonic LRU clock.
+    fn tick(&self) -> u64 {
+        self.clock.fetch_add(1, Ordering::Relaxed).wrapping_add(1)
+    }
+
+    /// Resolve `key` to a live child's socket, refreshing its LRU stamp.
+    ///
+    /// Why: `ensure_running` needs this answer twice — once on the fast path and
+    /// once under the spawn gate — and the two must agree exactly, including the
+    /// eviction. Two copies would be two chances to drift.
+    ///
+    /// Liveness is decided by TWO questions (#5085). `try_wait()` answers "has
+    /// this child been reaped", which is not "is it serving" — see `probe.rs` for
+    /// the measurement. Trusting it alone made this the fast path's fail-open.
+    ///
+    /// What: returns `Some(socket_path)` when the stored child is un-reaped AND
+    /// its socket is not definitively unserved, stamping it most-recently-used
+    /// so the LRU victim choice reflects real traffic. A child that has exited,
+    /// whose status cannot be read, or whose socket answers
+    /// [`SocketVerdict::NotServing`] is removed and `None` returned so the caller
+    /// falls through to a fresh spawn. [`SocketVerdict::Inconclusive`] keeps the
+    /// child, so an unanswerable connect never turns load into a respawn storm.
+    /// A child evicted while still alive goes to [`Self::doomed`] rather than
+    /// being dropped, because it owes a flush. Removing a corpse does NOT count
+    /// as a reap — nothing was reclaimed.
+    ///
+    /// The probe runs with the map lock released, so a slow connect never blocks
+    /// another instance's lookup. Eviction then re-acquires and fires only if the
+    /// map still holds the same child, so a replacement spawned concurrently is
+    /// never evicted by this call's stale verdict.
+    /// Test: `a_dead_child_is_evicted`, `an_unserved_child_is_queued_as_doomed`.
+    async fn lookup_live(&self, key: &str) -> Option<PathBuf> {
+        let (pid, path) = {
+            let stamp = self.tick();
+            let mut guard = self.children.lock().await;
+            let entry = guard.get_mut(key)?;
+            match entry.child.try_wait() {
+                Ok(None) => {
+                    entry.last_used = stamp;
+                    (entry.child.id(), entry.socket_path.clone())
+                }
+                Ok(Some(status)) => {
+                    tracing::warn!(
+                        service = %self.config.service,
+                        instance = %key,
+                        ?status,
+                        "supervised child exited unexpectedly — attempting one restart"
+                    );
+                    guard.remove(key);
+                    return None;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        service = %self.config.service,
+                        instance = %key,
+                        "try_wait failed: {e:#} — evicting and retrying"
+                    );
+                    guard.remove(key);
+                    return None;
+                }
+            }
+        };
+
+        // Lock released. #5085: an un-reaped child is not the same claim as a
+        // serving one; ask the socket the caller will actually use.
+        if probe_socket_verdict(&path, self.config.timeouts.connect_probe).await
+            != SocketVerdict::NotServing
+        {
+            return Some(path);
+        }
+
+        tracing::warn!(
+            service = %self.config.service,
+            instance = %key,
+            socket = %path.display(),
+            pid = ?pid,
+            "supervised child is not serving its socket — evicting and respawning"
+        );
+        let evicted = {
+            let mut guard = self.children.lock().await;
+            // #5085: identify the child by pid so a replacement spawned while the
+            // probe ran is never evicted on this call's stale verdict. Two
+            // unreadable pids must not alias into "same child", so an absent pid
+            // on either side is never a match.
+            let same_child = matches!(
+                (pid, guard.get(key).and_then(|h| h.child.id())),
+                (Some(ours), Some(current)) if ours == current
+            );
+            if same_child { guard.remove(key) } else { None }
+        };
+        if let Some(handle) = evicted {
+            self.doomed.lock().await.push((key.to_string(), handle));
+        }
+        None
+    }
+
+    /// SIGTERM every child [`Self::lookup_live`] evicted while it was still
+    /// alive, and wait for each to exit.
+    ///
+    /// Why (#5085/#5119): see the [`Self::doomed`] field — a live child may hold
+    /// acked work only its own SIGTERM handler writes, and it unlinks the shared
+    /// socket path on its way out, so it must be fully gone before a replacement
+    /// binds that path.
+    /// What: drains the queue and runs the same terminate + unlink sequence the
+    /// reap and shutdown paths use. Callers MUST hold the spawn gate — that is
+    /// what orders this before the respawn. Does NOT increment `reaped`: this is
+    /// a restart, not a reclamation. A no-op (one uncontended lock) when nothing
+    /// has been evicted, which is the overwhelmingly common case.
+    /// Test: `trusty-memory`'s `an_evicted_live_child_is_given_a_chance_to_flush`.
+    async fn reap_doomed(&self) {
+        let doomed: Vec<(String, ChildHandle)> = {
+            let mut guard = self.doomed.lock().await;
+            if guard.is_empty() {
+                return;
+            }
+            std::mem::take(&mut *guard)
+        };
+        for (key, mut handle) in doomed {
+            tracing::info!(
+                service = %self.config.service,
+                instance = %key,
+                pid = ?handle.child.id(),
+                "gracefully terminating an evicted child so it can flush"
+            );
+            if let Err(e) =
+                terminate_child(&mut handle.child, self.config.timeouts.sigterm_patience).await
+            {
+                tracing::warn!(instance = %key, "graceful termination error: {e:#}");
+            }
+            remove_socket_file(&self.config.service, &key, &handle.socket_path).await;
+        }
+    }
+
+    /// Bring the live population within both limits, leaving room for `headroom`
+    /// more.
+    ///
+    /// Why (#2845 + #2846): these are the two failures trusty-search shipped — an
+    /// unbounded fan-out, and a memory limit that was declared but never compared
+    /// against anything. Enforcing both in one place, on the path that grows the
+    /// population, is what makes them limits rather than documentation.
+    /// What: two passes. Every child whose MEASURED RSS is at or above the
+    /// ceiling is selected regardless of recency — a leaking child is the wrong
+    /// thing to keep no matter how recently it was used — while a child whose RSS
+    /// cannot be measured is left alone. Then, while the survivors plus
+    /// `headroom` would exceed `max_live`, the least-recently-used survivor is
+    /// selected. Victims are removed under the lock and terminated with it
+    /// released, so the SIGTERM wait never blocks another instance's lookup.
+    /// Test: `exceeding_the_cap_reaps_the_least_recently_used`,
+    /// `over_rss_limit_children_are_reaped`.
+    async fn enforce_limits(&self, headroom: usize) {
+        let mut victims: Vec<(String, ChildHandle, &'static str)> = Vec::new();
+        {
+            let mut guard = self.children.lock().await;
+
+            let over: Vec<String> = guard
+                .iter()
+                .filter(|(_, h)| over_rss_limit(h.child.id(), self.config.rss_limit_mb))
+                .map(|(k, _)| k.clone())
+                .collect();
+            for key in over {
+                if let Some(h) = guard.remove(&key) {
+                    victims.push((key, h, "rss"));
+                }
+            }
+
+            while guard.len() + headroom > self.config.max_live {
+                let Some(lru) = guard
+                    .iter()
+                    .min_by_key(|(_, h)| h.last_used)
+                    .map(|(k, _)| k.clone())
+                else {
+                    break;
+                };
+                if let Some(h) = guard.remove(&lru) {
+                    victims.push((lru, h, "cap"));
+                }
+            }
+        }
+
+        for (key, mut handle, reason) in victims {
+            tracing::info!(
+                service = %self.config.service,
+                instance = %key,
+                reason,
+                cap = self.config.max_live,
+                rss_limit_mb = ?self.config.rss_limit_mb,
+                pid = ?handle.child.id(),
+                "reaping supervised child to stay within limits"
+            );
+            if let Err(e) =
+                terminate_child(&mut handle.child, self.config.timeouts.sigterm_patience).await
+            {
+                tracing::warn!(instance = %key, "reap error: {e:#}");
+            }
+            remove_socket_file(&self.config.service, &key, &handle.socket_path).await;
+            self.reaped.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Graceful shutdown: SIGTERM all owned children, reap them, clean up their
+    /// sockets.
+    ///
+    /// Why: the parent's normal exit is a SIGTERM from launchd or a ctrl-c.
+    /// Relying on `kill_on_drop` instead would skip each child's own cleanup and
+    /// leave any acked-but-unflushed work discarded.
+    /// What: drains the doomed queue first (a child evicted but never respawned
+    /// still owes a flush), then the map. Idempotent.
+    /// Test: `shutdown_with_no_children_is_noop`,
+    /// `shutdown_does_not_count_as_a_limit_reap`.
+    pub async fn shutdown(&self) {
+        self.reap_doomed().await;
+        let handles: Vec<(String, ChildHandle)> = self.children.lock().await.drain().collect();
+
+        for (key, mut entry) in handles {
+            tracing::info!(
+                service = %self.config.service,
+                instance = %key,
+                pid = ?entry.child.id(),
+                "shutting down supervised child"
+            );
+            if let Err(e) =
+                terminate_child(&mut entry.child, self.config.timeouts.sigterm_patience).await
+            {
+                tracing::warn!(instance = %key, "shutdown encountered an error: {e:#}");
+            }
+            remove_socket_file(&self.config.service, &key, &entry.socket_path).await;
+        }
+    }
+}
+
+impl std::fmt::Debug for UdsServiceSupervisor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Deliberately does not lock: `Debug` may be invoked while another task
+        // holds the guard, and a placeholder beats a deadlock.
+        f.debug_struct("UdsServiceSupervisor")
+            .field("service", &self.config.service)
+            .field("children", &"<locked>")
+            .finish()
+    }
+}

--- a/crates/trusty-common/src/uds/supervisor/probe.rs
+++ b/crates/trusty-common/src/uds/supervisor/probe.rs
@@ -106,7 +106,9 @@ pub async fn probe_socket_verdict(path: &Path, timeout: Duration) -> SocketVerdi
 /// "may I skip the spawn?" — for which anything short of a completed connect
 /// must read as no.
 /// What: true iff [`probe_socket_verdict`] returns [`SocketVerdict::Serving`].
-/// Test: `probe_reports_false_for_a_missing_socket`.
+/// Test: `probe_verdict_reports_not_serving_for_a_missing_socket`,
+/// `probe_verdict_reports_serving_for_a_bound_socket` — both assert this
+/// function alongside the verdict it wraps.
 pub async fn socket_is_serving(path: &Path, timeout: Duration) -> bool {
     probe_socket_verdict(path, timeout).await == SocketVerdict::Serving
 }

--- a/crates/trusty-common/src/uds/supervisor/probe.rs
+++ b/crates/trusty-common/src/uds/supervisor/probe.rs
@@ -1,0 +1,140 @@
+//! Socket-backed liveness probing for [`super::UdsServiceSupervisor`] (#5089).
+//!
+//! Why (#5085): `try_wait()` answers "has this child been REAPED", which is not
+//! the same question as "is it SERVING". A SIGKILLed daemon closes its listener
+//! during `do_exit` and only becomes reapable once the kernel finishes tearing
+//! it down — measured at up to 32.6 µs, with the socket dying first in 35 of 40
+//! rounds. For that window a dead child reads alive and the caller is handed a
+//! socket path nothing listens on, with nothing anywhere reporting a problem.
+//! That was the fail-open PR #5119 closed, and the promotion has to carry the
+//! probe or it reintroduces it at the shared layer for every future service.
+//!
+//! What: [`SocketVerdict`] and the two probes over it. The three-state shape is
+//! the load-bearing part — see the type's docs for why a timeout must never be
+//! grounds for eviction.
+//!
+//! Test: `probe_verdict_reports_not_serving_for_a_missing_socket`,
+//! `probe_verdict_reports_not_serving_for_a_stale_socket_file`,
+//! `probe_verdict_reports_serving_for_a_bound_socket`,
+//! `wait_for_socket_gives_up_within_the_spawn_budget`.
+
+use std::path::Path;
+use std::time::Duration;
+
+use tokio::net::UnixStream;
+
+use super::ServiceTimeouts;
+
+/// What a connect attempt says about whether anything is serving a socket.
+///
+/// Why (#5085): the spawn path only ever needed "did it answer, yes or no", but
+/// eviction needs a third answer. Evicting a child because one connect did not
+/// complete turns a load spike into a respawn storm — the child is killed, a
+/// replacement is spawned into the same contention, and the cycle repeats
+/// (#3631 is the record of a give-up rule that never fired; this is its
+/// mirror-image). Separating "I could not tell" from a definite answer keeps
+/// eviction off the ambiguous cases.
+///
+/// **What ECONNREFUSED does NOT tell you, and why it is the design contract
+/// here rather than a footnote.** ECONNREFUSED is not exclusively "no
+/// listener". On macOS/BSD a bound listener whose accept queue is full answers
+/// connects with ECONNREFUSED too (`unp_connect` rejects once
+/// `so_qlen >= so_qlimit`) — measured directly: `listen(1)`, never accept, six
+/// non-blocking connects, connect 0 OK and connects 1–5 all ECONNREFUSED.
+/// Linux instead queues to the backlog and only then refuses. So on macOS a
+/// saturated backlog is indistinguishable from a dead one, and this
+/// classification alone does not make the difference safe.
+///
+/// What makes it safe is a property of the supervised service, which is
+/// therefore a REQUIREMENT this supervisor places on anything it supervises:
+/// **accept promptly and off the request path.** `trusty-bm25-daemon` satisfies
+/// it — tokio's default backlog is 1024 and its accept loop spawns a task per
+/// connection rather than serving inline, so the queue does not saturate. A
+/// service that accepts inline, or sets a small backlog, breaks the assumption
+/// and will be evicted under load. Check that before putting a new service
+/// behind this supervisor.
+///
+/// What: `NotServing` covers exactly ENOENT and ECONNREFUSED. A timeout or any
+/// other errno (EPERM, and Linux's EAGAIN) is `Inconclusive` and leaves the
+/// child alone.
+///
+/// `#[non_exhaustive]`: a fourth state (separating "refused" from "absent" for
+/// metrics) is plausible, and external crates match this with a wildcard arm.
+///
+/// Test: `probe_verdict_reports_not_serving_for_a_missing_socket`,
+/// `probe_verdict_reports_not_serving_for_a_stale_socket_file`,
+/// `probe_verdict_reports_serving_for_a_bound_socket`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SocketVerdict {
+    /// A connection was accepted — something is serving this path.
+    Serving,
+    /// The kernel proved no listener is bound (ENOENT / ECONNREFUSED).
+    NotServing,
+    /// The probe could not settle the question; assume the child is fine.
+    Inconclusive,
+}
+
+/// Quick non-blocking probe — opens a `UnixStream`, immediately closes it.
+///
+/// Why: one answer to "is something listening on this socket right now?"
+/// without depending on any service's wire protocol and without spending more
+/// than a few ms. Deliberately a bare `UnixStream::connect` rather than
+/// [`crate::uds::connect_hardened`]: the classification keys off the raw errno,
+/// and a permission failure would arrive as a `UdsSecurityError` that carries
+/// no errno to classify. Permission verification happens where it decides
+/// something — the adoption path — not here.
+/// What: attempts the connect with `timeout` and classifies the outcome per
+/// [`SocketVerdict`].
+/// Test: the three `probe_verdict_*` tests.
+pub async fn probe_socket_verdict(path: &Path, timeout: Duration) -> SocketVerdict {
+    match tokio::time::timeout(timeout, UnixStream::connect(path)).await {
+        Ok(Ok(_)) => SocketVerdict::Serving,
+        Ok(Err(e)) => match e.kind() {
+            std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused => {
+                SocketVerdict::NotServing
+            }
+            _ => SocketVerdict::Inconclusive,
+        },
+        Err(_elapsed) => SocketVerdict::Inconclusive,
+    }
+}
+
+/// Whether a socket is definitely accepting connections right now.
+///
+/// Why: the spawn and adoption paths only care about the affirmative case —
+/// "may I skip the spawn?" — for which anything short of a completed connect
+/// must read as no.
+/// What: true iff [`probe_socket_verdict`] returns [`SocketVerdict::Serving`].
+/// Test: `probe_reports_false_for_a_missing_socket`.
+pub async fn socket_is_serving(path: &Path, timeout: Duration) -> bool {
+    probe_socket_verdict(path, timeout).await == SocketVerdict::Serving
+}
+
+/// Poll the socket with exponential backoff until it accepts a connection or
+/// the service's spawn budget elapses.
+///
+/// Why: a freshly-spawned child takes an unknown time to bind — a few ms for a
+/// service with nothing to load, tens of seconds for one that loads a model.
+/// Polling from a short initial interval and doubling gives sub-50 ms detection
+/// on the fast case without hammering the kernel on the slow one.
+/// What: loops [`socket_is_serving`] until success or until the cumulative wait
+/// exceeds `timeouts.spawn_probe`. Never sleeps past the deadline.
+/// Test: `wait_for_socket_gives_up_within_the_spawn_budget`,
+/// `wait_for_socket_returns_once_the_socket_binds`.
+pub(super) async fn wait_for_socket(path: &Path, timeouts: &ServiceTimeouts) -> bool {
+    let deadline = tokio::time::Instant::now() + timeouts.spawn_probe;
+    let mut interval = timeouts.initial_probe_interval;
+    loop {
+        if socket_is_serving(path, timeouts.connect_probe).await {
+            return true;
+        }
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return false;
+        }
+        let sleep_for = interval.min(deadline.saturating_duration_since(now));
+        tokio::time::sleep(sleep_for).await;
+        interval = (interval * 2).min(timeouts.max_probe_interval);
+    }
+}

--- a/crates/trusty-common/src/uds/supervisor/tests.rs
+++ b/crates/trusty-common/src/uds/supervisor/tests.rs
@@ -14,13 +14,20 @@
 //! Measured on this file: `probe_verdict_reports_not_serving_for_a_stale_socket_file`
 //! passed 3/3 alone and 3/3 alongside the other probe tests, but failed 4 of 5
 //! runs of the whole module and 2 of 3 runs of the wider `uds::` filter —
-//! reading `Serving` for a listener this test had already dropped. The
-//! interference tracks the fork-heavy tests, not the probe ones. The mechanism
-//! is not characterised here and this file does not guess at one; what is
-//! measured is that a socket-liveness assertion and a concurrent `Command::spawn`
-//! in the same process do not coexist. `trusty-memory`'s
-//! `bm25_supervisor_concurrency.rs` reached the same conclusion for the same
-//! assertion and took the same remedy. Serialising removes no coverage.
+//! reading `Serving` for a listener this test had already dropped.
+//!
+//! The mechanism is **fd inheritance across a concurrent fork**. macOS has no
+//! atomic `SOCK_CLOEXEC`, so `UnixListener::bind` creates the socket and then
+//! sets `FD_CLOEXEC` in a second syscall. A `Command::spawn` on another test
+//! thread that forks inside that window hands the listening fd to the child —
+//! here a `sleep 60` stub — and the child holds it open. The parent's
+//! `drop(listener)` then closes only its own descriptor, the socket stays bound,
+//! and the connect this test expects to be refused completes instead. It is a
+//! property of the test harness, not of the supervisor: a supervised service
+//! binds its own socket in its own process, and this supervisor never holds one
+//! to leak. Serialising the fork-heavy tests against the liveness assertions
+//! closes the window. `trusty-memory`'s `bm25_supervisor_concurrency.rs` reached
+//! the same remedy for the same assertion. It removes no coverage.
 //! Test: this *is* the test file.
 
 use std::path::PathBuf;
@@ -162,6 +169,41 @@ fn service_timeouts_accept_a_subsecond_margin() {
         Duration::from_millis(600),
     );
     assert_eq!(t.sigterm_patience, Duration::from_millis(600));
+}
+
+/// Why: `new` is a `const fn`, so the only thing it can do about a bad pair at
+/// runtime is panic — and `#[non_exhaustive]` leaves no other way to build the
+/// value. A service deriving its timeouts from config needs to report that as an
+/// error rather than take the process down.
+/// Test: this test itself.
+#[serial_test::serial]
+#[test]
+fn try_new_rejects_an_inverted_pair_without_panicking() {
+    let err = ServiceTimeouts::try_new(
+        Duration::from_secs(1),
+        Duration::from_secs(2),
+        Duration::from_secs(2),
+    )
+    .expect_err("an equal pair must be rejected");
+    assert!(
+        matches!(err, SupervisorError::InvalidTimeouts { .. }),
+        "expected InvalidTimeouts, got {err:?}"
+    );
+}
+
+/// Why: the fallible constructor must be the same check, not a second one that
+/// could drift from the `const fn`'s.
+/// Test: this test itself.
+#[serial_test::serial]
+#[test]
+fn try_new_matches_new_for_a_valid_pair() {
+    let built = ServiceTimeouts::try_new(
+        Duration::from_millis(400),
+        Duration::from_millis(50),
+        Duration::from_secs(5),
+    )
+    .expect("a valid pair must be accepted");
+    assert_eq!(built, TEST_TIMEOUTS);
 }
 
 /// Why: the probe cadence is supervision's own concern, not the service's, so

--- a/crates/trusty-common/src/uds/supervisor/tests.rs
+++ b/crates/trusty-common/src/uds/supervisor/tests.rs
@@ -1,0 +1,823 @@
+//! Unit tests for [`super::UdsServiceSupervisor`] (#5089 step 2).
+//!
+//! Why: the limits, the probe classification and the eviction bookkeeping moved
+//! here from `trusty-memory`'s `bm25_supervisor_tests.rs` along with the code
+//! they cover — the machinery is no longer BM25's, so its unit coverage cannot
+//! stay behind. Every assertion in those tests has a counterpart below, plus the
+//! cases the generalisation newly makes reachable: a per-service timeout
+//! relationship, an untrusted adoption, and a spawn budget that expires.
+//! What: stub children are real `sleep` processes — a real pid with real RSS is
+//! everything the cap and the RSS reader need, and it keeps these tests free of
+//! any built daemon binary.
+//!
+//! Every test is `#[serial]`, and that is load-bearing rather than tidy.
+//! Measured on this file: `probe_verdict_reports_not_serving_for_a_stale_socket_file`
+//! passed 3/3 alone and 3/3 alongside the other probe tests, but failed 4 of 5
+//! runs of the whole module and 2 of 3 runs of the wider `uds::` filter —
+//! reading `Serving` for a listener this test had already dropped. The
+//! interference tracks the fork-heavy tests, not the probe ones. The mechanism
+//! is not characterised here and this file does not guess at one; what is
+//! measured is that a socket-liveness assertion and a concurrent `Command::spawn`
+//! in the same process do not coexist. `trusty-memory`'s
+//! `bm25_supervisor_concurrency.rs` reached the same conclusion for the same
+//! assertion and took the same remedy. Serialising removes no coverage.
+//! Test: this *is* the test file.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::process::{Child, Command};
+
+use super::child::{ChildHandle, terminate_child};
+use super::*;
+
+/// Timeouts for a service that binds instantly and flushes nothing.
+///
+/// Deliberately tight so a test that waits out the spawn budget costs
+/// milliseconds rather than seconds.
+const TEST_TIMEOUTS: ServiceTimeouts = ServiceTimeouts::new(
+    Duration::from_millis(400),
+    Duration::from_millis(50),
+    Duration::from_secs(5),
+);
+
+fn config(max_live: usize, rss_limit_mb: Option<u64>) -> SupervisorConfig {
+    SupervisorConfig::new("test-service", max_live, TEST_TIMEOUTS).with_rss_limit_mb(rss_limit_mb)
+}
+
+fn supervisor(max_live: usize, rss_limit_mb: Option<u64>) -> UdsServiceSupervisor {
+    UdsServiceSupervisor::new(config(max_live, rss_limit_mb))
+}
+
+/// A long-lived, cheap child standing in for a supervised service.
+fn stub_child() -> Child {
+    Command::new("sleep")
+        .arg("60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("spawn stub child")
+}
+
+/// Register a stub child under `key` with an explicit LRU stamp.
+///
+/// Why: the LRU victim choice is the behaviour under test, so the test must
+/// control the recency order directly rather than hoping wall-clock ordering
+/// falls out of the call sequence.
+async fn register_stub(sup: &UdsServiceSupervisor, key: &str, socket: PathBuf, last_used: u64) {
+    sup.children.lock().await.insert(
+        key.to_string(),
+        ChildHandle {
+            child: stub_child(),
+            socket_path: socket,
+            last_used,
+        },
+    );
+}
+
+/// A spec closure that must never be called.
+fn never_spawn() -> Result<SpawnSpec, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    panic!("the supervisor must not resolve a spawn spec on this path");
+}
+
+/// RAII guard for serialised env-var mutation in tests.
+struct EnvGuard {
+    key: String,
+    prev: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: test-only env mutation, serialised by `#[serial]` on every
+        // test that constructs one; the Drop impl restores on scope exit.
+        unsafe { std::env::set_var(key, value) }
+        Self {
+            key: key.to_string(),
+            prev,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: test teardown; the inverse of the mutation in `set`.
+        unsafe {
+            match &self.prev {
+                Some(v) => std::env::set_var(&self.key, v),
+                None => std::env::remove_var(&self.key),
+            }
+        }
+    }
+}
+
+// ── ServiceTimeouts: the promoted compile-time invariant ──────────────────
+
+/// Why (#5085 / #5089): this is what replaces `bm25_supervisor.rs`'s
+/// `const _: () = assert!(SIGTERM_PATIENCE_SECS > …SHUTDOWN_FLUSH_TIMEOUT…)`.
+/// A patience equal to the child's flush budget lets the SIGKILL land inside the
+/// very flush the child's shutdown handler exists to perform. The `const fn`
+/// makes the check a compile error for a service that declares its timeouts as a
+/// `const`; this pins the runtime half of the same guard.
+/// Test: this test itself.
+#[serial_test::serial]
+#[test]
+#[should_panic(expected = "SIGTERM patience must strictly exceed")]
+fn service_timeouts_reject_patience_equal_to_the_flush() {
+    let _ = ServiceTimeouts::new(
+        Duration::from_secs(1),
+        Duration::from_secs(2),
+        Duration::from_secs(2),
+    );
+}
+
+/// Why: an inverted pair is the same defect as an equal one, and the comparison
+/// is hand-written (`Duration`'s own operators are not `const`), so both sides
+/// of it need a test.
+/// Test: this test itself.
+#[serial_test::serial]
+#[test]
+#[should_panic(expected = "SIGTERM patience must strictly exceed")]
+fn service_timeouts_reject_patience_below_the_flush() {
+    let _ = ServiceTimeouts::new(
+        Duration::from_secs(1),
+        Duration::from_secs(2),
+        Duration::from_secs(1),
+    );
+}
+
+/// Why: the hand-written const comparison must get sub-second margins right —
+/// a service with a 500 ms flush and a 600 ms patience is legal, and an
+/// implementation that only compared whole seconds would reject it.
+/// Test: this test itself.
+#[serial_test::serial]
+#[test]
+fn service_timeouts_accept_a_subsecond_margin() {
+    let t = ServiceTimeouts::new(
+        Duration::from_millis(100),
+        Duration::from_millis(500),
+        Duration::from_millis(600),
+    );
+    assert_eq!(t.sigterm_patience, Duration::from_millis(600));
+}
+
+/// Why: the probe cadence is supervision's own concern, not the service's, so
+/// `new` must supply working defaults and the overrides must actually take.
+/// Test: this test itself.
+#[serial_test::serial]
+#[test]
+fn service_timeouts_carry_probe_defaults_and_honour_overrides() {
+    assert_eq!(
+        TEST_TIMEOUTS.initial_probe_interval,
+        DEFAULT_INITIAL_PROBE_INTERVAL
+    );
+    assert_eq!(TEST_TIMEOUTS.max_probe_interval, DEFAULT_MAX_PROBE_INTERVAL);
+    assert_eq!(TEST_TIMEOUTS.connect_probe, DEFAULT_CONNECT_PROBE_TIMEOUT);
+
+    let tuned = TEST_TIMEOUTS
+        .with_probe_intervals(Duration::from_millis(1), Duration::from_millis(2))
+        .with_connect_probe(Duration::from_millis(3));
+    assert_eq!(tuned.initial_probe_interval, Duration::from_millis(1));
+    assert_eq!(tuned.max_probe_interval, Duration::from_millis(2));
+    assert_eq!(tuned.connect_probe, Duration::from_millis(3));
+    assert_eq!(
+        tuned.spawn_probe, TEST_TIMEOUTS.spawn_probe,
+        "an override must not disturb the service's own budget"
+    );
+}
+
+/// Why: a cap of 0 would mean "never keep a child", making every
+/// `ensure_running` spawn-and-immediately-reap. Clamping turns an operator's
+/// misconfiguration into a tight limit rather than a livelock.
+/// Test: this test itself.
+#[serial_test::serial]
+#[test]
+fn supervisor_config_clamps_max_live_to_one() {
+    assert_eq!(supervisor(0, None).max_live(), 1);
+}
+
+/// Why: the opt-out exists so an operator running the target under `tctl`
+/// (ADR-0011 / ADR-0034 §1) keeps its lifecycle. A loose truthiness check would
+/// let `TRUSTY_X_EXTERNAL=0` disable supervision, which is the opposite of what
+/// the operator wrote.
+/// Test: this test itself.
+#[serial_test::serial]
+#[test]
+fn external_env_only_honours_exactly_one() {
+    const VAR: &str = "TRUSTY_TEST_SUPERVISOR_EXTERNAL";
+    let cfg = config(2, None).with_external_env(VAR);
+
+    let _g = EnvGuard::set(VAR, "1");
+    assert!(cfg.external_mode_enabled());
+    let _g = EnvGuard::set(VAR, "0");
+    assert!(!cfg.external_mode_enabled());
+    let _g = EnvGuard::set(VAR, "true");
+    assert!(!cfg.external_mode_enabled());
+
+    assert!(
+        !config(2, None).external_mode_enabled(),
+        "a config with no external var can never be opted out"
+    );
+}
+
+/// Why: the builder is the only way to construct a spec from outside this
+/// crate, so silent argument loss would be undetectable at the call site.
+/// Test: this test itself.
+#[serial_test::serial]
+#[test]
+fn spawn_spec_builder_accumulates_args_and_dirs() {
+    let spec = SpawnSpec::new("/bin/echo")
+        .arg("--palace")
+        .arg("alpha")
+        .create_dir("/tmp/a")
+        .create_dir("/tmp/b");
+    assert_eq!(spec.program, PathBuf::from("/bin/echo"));
+    assert_eq!(spec.args, vec!["--palace", "alpha"]);
+    assert_eq!(spec.create_dirs.len(), 2);
+}
+
+// ── Socket-backed liveness (#5085) ────────────────────────────────────────
+
+/// Why (#5085): eviction keys off `NotServing` specifically, so an absent socket
+/// must produce that verdict and not the `Inconclusive` catch-all — otherwise a
+/// crashed child is never replaced.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn probe_verdict_reports_not_serving_for_a_missing_socket() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let missing = tmp.path().join("nonexistent.sock");
+    assert_eq!(
+        probe_socket_verdict(&missing, DEFAULT_CONNECT_PROBE_TIMEOUT).await,
+        SocketVerdict::NotServing
+    );
+    assert!(!socket_is_serving(&missing, DEFAULT_CONNECT_PROBE_TIMEOUT).await);
+}
+
+/// Why (#5085): a stale socket file left behind by a SIGKILLed child answers
+/// ECONNREFUSED rather than ENOENT. That is still proof nothing is listening,
+/// and it is the shape a real crash leaves on disk.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn probe_verdict_reports_not_serving_for_a_stale_socket_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sock = tmp.path().join("stale.sock");
+    let listener = tokio::net::UnixListener::bind(&sock).expect("bind listener");
+    drop(listener);
+    assert!(sock.exists(), "the socket file must outlive the listener");
+    assert_eq!(
+        probe_socket_verdict(&sock, DEFAULT_CONNECT_PROBE_TIMEOUT).await,
+        SocketVerdict::NotServing
+    );
+}
+
+/// Why (#5085): a serving socket must never be classified as `NotServing`, or
+/// `lookup_live` would evict healthy children on every call.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn probe_verdict_reports_serving_for_a_bound_socket() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sock = tmp.path().join("listen.sock");
+    let _listener = tokio::net::UnixListener::bind(&sock).expect("bind listener");
+    assert_eq!(
+        probe_socket_verdict(&sock, DEFAULT_CONNECT_PROBE_TIMEOUT).await,
+        SocketVerdict::Serving
+    );
+    assert!(socket_is_serving(&sock, DEFAULT_CONNECT_PROBE_TIMEOUT).await);
+}
+
+/// Why: the backoff loop must terminate on the service's own budget, not on a
+/// constant. A loop that ignored `spawn_probe` would hang a caller for whatever
+/// the old BM25 3 s value happened to be.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn wait_for_socket_gives_up_within_the_spawn_budget() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let missing = tmp.path().join("never.sock");
+    let budget = Duration::from_millis(120);
+    let timeouts = ServiceTimeouts::new(budget, Duration::from_millis(10), Duration::from_secs(1));
+
+    let started = std::time::Instant::now();
+    assert!(!super::probe::wait_for_socket(&missing, &timeouts).await);
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= budget,
+        "must not give up before the budget: {elapsed:?}"
+    );
+    assert!(
+        elapsed < budget * 8,
+        "must not overshoot the budget by an order of magnitude: {elapsed:?}"
+    );
+}
+
+/// Why: the affirmative half — a socket that IS bound must be detected on the
+/// first probe rather than after a full backoff.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn wait_for_socket_returns_once_the_socket_binds() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sock = tmp.path().join("bound.sock");
+    let _listener = tokio::net::UnixListener::bind(&sock).expect("bind listener");
+    assert!(super::probe::wait_for_socket(&sock, &TEST_TIMEOUTS).await);
+}
+
+// ── Child lifecycle ───────────────────────────────────────────────────────
+
+/// Why (#2846 inverse): `None` from the RSS reader means "no reading", not
+/// "zero". Treating an unavailable measurement as a breach would reap every
+/// healthy child on any platform where the read is unsupported — converting a
+/// memory guardrail into an outage.
+/// Test: this test itself.
+#[serial_test::serial]
+#[test]
+fn over_rss_limit_is_false_without_a_measurement() {
+    assert!(
+        !over_rss_limit(Some(0), Some(0)),
+        "unmeasurable must not reap"
+    );
+    assert!(!over_rss_limit(None, Some(0)), "exited child must not reap");
+}
+
+/// Why: disabling enforcement must actually disable it, including for a process
+/// that would otherwise be over any ceiling.
+/// Test: this test itself.
+#[serial_test::serial]
+#[test]
+fn over_rss_limit_is_false_when_disabled() {
+    assert!(!over_rss_limit(Some(std::process::id()), None));
+}
+
+/// Why: SIGTERM is the only signal a child's own shutdown handler can act on, so
+/// "terminate" that quietly SIGKILLed would defeat every flush this supervisor
+/// exists to allow.
+/// What: `sleep` dies on SIGTERM well inside the patience window, so a
+/// terminate that returns without escalating is the observable proof.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn terminate_child_reaps_a_live_child() {
+    let mut child = stub_child();
+    terminate_child(&mut child, Duration::from_secs(5))
+        .await
+        .expect("terminate a live child");
+    assert!(
+        child.try_wait().expect("try_wait").is_some(),
+        "the child must be reaped by the time terminate returns"
+    );
+}
+
+/// Why: a spec that names directories expects them to exist before the child
+/// runs — a service told to write into a missing data dir would otherwise exit
+/// immediately and be reported as a spawn timeout.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn spawn_child_creates_requested_directories() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let data = tmp.path().join("nested/data");
+    let spec = SpawnSpec::new("/bin/echo").create_dir(&data);
+    let mut child = super::child::spawn_child("test-service", "k", &spec)
+        .await
+        .expect("spawn");
+    let _ = child.wait().await;
+    assert!(data.is_dir(), "the spec's directory must exist after spawn");
+}
+
+/// Why: a missing binary must surface as a spawn error naming the program, not
+/// as a spawn timeout naming the socket — the two send an operator to different
+/// places.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn spawn_child_reports_a_missing_binary() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spec = SpawnSpec::new(tmp.path().join("no-such-binary"));
+    let err = super::child::spawn_child("test-service", "k", &spec)
+        .await
+        .expect_err("a missing binary must fail");
+    assert!(
+        matches!(err, SupervisorError::Spawn { .. }),
+        "expected Spawn, got {err:?}"
+    );
+}
+
+// ── Supervisor state machine ──────────────────────────────────────────────
+
+/// Why: the supervisor must start with an empty map so the first
+/// `ensure_running` always takes the cold path.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn supervisor_starts_empty() {
+    let sup = supervisor(3, None);
+    assert_eq!(sup.supervised_count().await, 0);
+    assert_eq!(sup.spawned_count(), 0);
+    assert_eq!(sup.reaped_count(), 0);
+}
+
+/// Why: the supervisor is shared via `Arc` across handlers; a regression in its
+/// bounds would only show up at a distant call site.
+/// Test: this test itself.
+#[serial_test::serial]
+#[test]
+fn supervisor_is_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<UdsServiceSupervisor>();
+}
+
+/// Why: `shutdown` on a fresh supervisor must not panic or error. Callers will
+/// invoke it at exit even when nothing was ever spawned.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn shutdown_with_no_children_is_noop() {
+    let sup = supervisor(3, None);
+    sup.shutdown().await;
+    assert_eq!(sup.supervised_count().await, 0);
+}
+
+/// Why: in external-management mode `ensure_running` must not spawn anything or
+/// even try to resolve a spawn spec — the operator owns that lifecycle, and a
+/// supervisor that located the binary anyway would fail on hosts where it is not
+/// installed at all.
+/// What: the spec closure panics if called, which is the strongest available
+/// assertion that this path never reaches it.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn external_mode_skips_spawn() {
+    const VAR: &str = "TRUSTY_TEST_SUPERVISOR_EXTERNAL";
+    let _g = EnvGuard::set(VAR, "1");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("external.sock");
+    let sup = UdsServiceSupervisor::new(config(3, None).with_external_env(VAR));
+
+    let path = sup
+        .ensure_running("inst", &socket, never_spawn)
+        .await
+        .expect("external mode must return the socket path without spawning");
+    assert_eq!(path, socket);
+    assert_eq!(sup.supervised_count().await, 0);
+    assert_eq!(sup.spawned_count(), 0);
+}
+
+/// Why: the fast path is the common case, and it must be reached without
+/// resolving a spawn spec. It is also the path #5085 made socket-backed: a
+/// stored child counts as live only when its socket answers.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_serving_child_is_reused_without_a_spawn() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("live.sock");
+    let _listener = tokio::net::UnixListener::bind(&socket).expect("bind");
+    let sup = supervisor(3, None);
+    register_stub(&sup, "inst", socket.clone(), 1).await;
+
+    let path = sup
+        .ensure_running("inst", &socket, never_spawn)
+        .await
+        .expect("a serving child must be reused");
+    assert_eq!(path, socket);
+    assert_eq!(sup.spawned_count(), 0);
+    assert_eq!(sup.supervised_count().await, 1);
+    sup.shutdown().await;
+}
+
+/// Why: a child that has exited must be removed so the caller falls through to a
+/// fresh spawn, and removing a corpse reclaims nothing — counting it as a reap
+/// would make `reaped_count` useless for answering "is my cap doing anything?".
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_dead_child_is_evicted_without_counting_as_a_reap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("dead.sock");
+    let sup = supervisor(3, None);
+    {
+        let mut child = Command::new("true")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn a child that exits immediately");
+        child.wait().await.expect("wait");
+        sup.children.lock().await.insert(
+            "inst".to_string(),
+            ChildHandle {
+                child,
+                socket_path: socket.clone(),
+                last_used: 1,
+            },
+        );
+    }
+
+    assert!(sup.lookup_live("inst").await.is_none());
+    assert_eq!(sup.supervised_count().await, 0);
+    assert_eq!(sup.reaped_count(), 0);
+    assert_eq!(
+        sup.doomed.lock().await.len(),
+        0,
+        "a corpse owes no flush and must not enter the doomed queue"
+    );
+}
+
+/// Why (#5085 / #5119): the unserved-socket arm is the only eviction that
+/// removes a LIVE child, and a live child may hold acked work only its own
+/// SIGTERM handler writes. It must therefore be queued for graceful termination
+/// rather than dropped onto `kill_on_drop`'s SIGKILL — and drained under the
+/// spawn gate, before anything rebinds the path it is about to unlink.
+/// What: a live stub whose socket does not exist. `try_wait()` reports it alive
+/// forever, so nothing here depends on timing.
+/// Test: this test itself. Replace the doomed queue with a bare drop and the
+/// queue length reads 0.
+#[serial_test::serial]
+#[tokio::test]
+async fn an_unserved_live_child_is_queued_for_graceful_termination() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("gone.sock");
+    let sup = supervisor(3, None);
+    register_stub(&sup, "inst", socket, 1).await;
+
+    assert!(sup.lookup_live("inst").await.is_none());
+    assert_eq!(sup.supervised_count().await, 0);
+    assert_eq!(
+        sup.doomed.lock().await.len(),
+        1,
+        "a live evictee owes a flush and must be queued, not dropped"
+    );
+
+    sup.reap_doomed().await;
+    assert_eq!(sup.doomed.lock().await.len(), 0);
+    assert_eq!(
+        sup.reaped_count(),
+        0,
+        "a restart is not a reclamation and must not inflate the reap count"
+    );
+}
+
+/// Why (#2845): this is the regression the cap exists for. Before it the map
+/// only ever grew — a fan-out across N keys left N children resident for the
+/// process lifetime.
+/// What: four stubs with increasing recency, room asked for one more against a
+/// cap of 3. The population must land at 2 and the survivors must be the two
+/// most recently used.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn exceeding_the_cap_reaps_the_least_recently_used() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sup = supervisor(3, None);
+    for (i, key) in ["oldest", "older", "newer", "newest"].iter().enumerate() {
+        register_stub(&sup, key, tmp.path().join(key), i as u64 + 1).await;
+    }
+    assert_eq!(sup.supervised_count().await, 4);
+
+    sup.enforce_limits(1).await;
+
+    assert_eq!(
+        sup.supervised_count().await,
+        2,
+        "cap 3 with headroom 1 must leave room for the incoming child"
+    );
+    let live = sup.children.lock().await;
+    assert!(live.contains_key("newest"), "most recent must survive");
+    assert!(
+        live.contains_key("newer"),
+        "second most recent must survive"
+    );
+    assert!(!live.contains_key("oldest"), "LRU must be reaped first");
+    drop(live);
+    assert_eq!(
+        sup.reaped_count(),
+        2,
+        "reaps must be counted, not just done"
+    );
+}
+
+/// Why: a cap of 1 is the tightest legal setting and the one an operator on a
+/// constrained host picks. It must keep exactly one child, not zero.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn cap_of_one_keeps_a_single_child_live() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sup = supervisor(1, None);
+    register_stub(&sup, "a", tmp.path().join("a"), 1).await;
+    sup.enforce_limits(0).await;
+    assert_eq!(sup.supervised_count().await, 1);
+    sup.enforce_limits(1).await;
+    assert_eq!(sup.supervised_count().await, 0);
+}
+
+/// Why (#2846): this is the assertion trusty-search's `rss_limit_mb` never had.
+/// A limit that is declared but never compared against a measurement reaps
+/// nothing, which is indistinguishable from having no limit until the kernel's
+/// OOM killer makes the distinction.
+/// What: a ceiling of 0 MB means "at or above zero", which every live process
+/// satisfies — so both stubs must be reaped on RSS grounds, and crucially NOT on
+/// cap grounds, since the cap here holds them both.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn over_rss_limit_children_are_reaped() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sup = supervisor(16, Some(0));
+    register_stub(&sup, "fat-a", tmp.path().join("a"), 1).await;
+    register_stub(&sup, "fat-b", tmp.path().join("b"), 2).await;
+    assert_eq!(sup.supervised_count().await, 2);
+
+    sup.enforce_limits(0).await;
+
+    assert_eq!(
+        sup.supervised_count().await,
+        0,
+        "children at or above the RSS ceiling must be reaped even under the cap"
+    );
+    assert_eq!(sup.reaped_count(), 2);
+}
+
+/// Why: a generous ceiling must leave healthy children alone. Without this the
+/// previous test would also pass against an implementation that reaps
+/// unconditionally — a different bug wearing the same result.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn under_rss_limit_children_are_left_alone() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sup = supervisor(16, Some(1_000_000));
+    register_stub(&sup, "lean", tmp.path().join("lean"), 1).await;
+    sup.enforce_limits(0).await;
+    assert_eq!(sup.supervised_count().await, 1);
+    assert_eq!(sup.reaped_count(), 0);
+}
+
+/// Why: `shutdown` reaps for a different reason than the limits do, and an
+/// operator reading `reaped_count` to answer "is my cap doing anything?" must
+/// not have normal shutdown inflate the number.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn shutdown_does_not_count_as_a_limit_reap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sup = supervisor(16, None);
+    register_stub(&sup, "bye", tmp.path().join("bye"), 1).await;
+    sup.shutdown().await;
+    assert_eq!(sup.supervised_count().await, 0);
+    assert_eq!(sup.reaped_count(), 0);
+}
+
+/// Why (ADR-0034 §3): adoption is the one path where the service's own
+/// `bind_hardened` never runs, so without a check here an unhardened — or
+/// foreign — socket would be adopted silently, and the permission bits the relay
+/// hop rests on would be a documented intention rather than a boundary. #5099's
+/// `connect_hardened` doc names this exact path as the reason a dialer must
+/// verify.
+/// What: a socket that IS serving but sits at mode 0666 must be refused with
+/// `UntrustedSocket` rather than adopted, and rather than falling through to a
+/// spawn that dies on EADDRINUSE.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn adoption_refuses_a_world_writable_socket() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("wide.sock");
+    let _listener = tokio::net::UnixListener::bind(&socket).expect("bind");
+    std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o666))
+        .expect("widen the socket");
+
+    let sup = supervisor(3, None);
+    let err = sup
+        .ensure_running("inst", &socket, never_spawn)
+        .await
+        .expect_err("an unhardened socket must not be adopted");
+    assert!(
+        matches!(err, SupervisorError::UntrustedSocket { .. }),
+        "expected UntrustedSocket, got {err:?}"
+    );
+    assert_eq!(sup.spawned_count(), 0);
+}
+
+/// Why: the affirmative half of adoption. A socket some other process bound
+/// through `bind_hardened` — an operator-managed job that forgot the external
+/// opt-out, or a child this supervisor lost the handle to — must be adopted, or
+/// the spawn that follows would EADDRINUSE.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn adoption_accepts_a_hardened_socket_without_spawning() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("hardened.sock");
+    let _listener = crate::uds::bind_hardened(&socket).expect("bind_hardened");
+
+    let sup = supervisor(3, None);
+    let path = sup
+        .ensure_running("inst", &socket, never_spawn)
+        .await
+        .expect("a hardened serving socket must be adopted");
+    assert_eq!(path, socket);
+    assert_eq!(sup.spawned_count(), 0);
+    assert_eq!(
+        sup.supervised_count().await,
+        0,
+        "adoption must not register a child this supervisor does not own"
+    );
+}
+
+/// Why (#5089): the spawn budget is now the SERVICE's number, and the error has
+/// to say so — a 3 s budget carried over from a service with nothing to load
+/// produces a timeout that looks like a broken binary rather than a mistuned
+/// constant.
+/// What: a child that runs but never binds, against a deliberately tiny budget.
+/// The error must name that budget and the child must still have been launched.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_child_that_never_binds_fails_with_the_service_budget() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("never.sock");
+    let budget = Duration::from_millis(150);
+    let cfg = SupervisorConfig::new(
+        "test-service",
+        3,
+        ServiceTimeouts::new(budget, Duration::from_millis(10), Duration::from_secs(1)),
+    );
+    let sup = UdsServiceSupervisor::new(cfg);
+
+    let err = sup
+        .ensure_running("inst", &socket, || Ok(SpawnSpec::new("sleep").arg("30")))
+        .await
+        .expect_err("a child that never binds must not be reported as running");
+    match err {
+        SupervisorError::SpawnTimeout {
+            budget: reported, ..
+        } => assert_eq!(
+            reported, budget,
+            "the error must carry the service's budget"
+        ),
+        other => panic!("expected SpawnTimeout, got {other:?}"),
+    }
+    assert_eq!(sup.spawned_count(), 1, "the launch itself did happen");
+    assert_eq!(
+        sup.supervised_count().await,
+        0,
+        "a child that never bound must not be registered"
+    );
+}
+
+/// Why: a spec closure that fails must surface as its own variant rather than as
+/// a spawn or timeout error — "the binary is missing" and "it bound too slowly"
+/// send an operator to different places.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn a_failing_spawn_spec_is_reported_as_such() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("nospec.sock");
+    let sup = supervisor(3, None);
+
+    let err = sup
+        .ensure_running("inst", &socket, || {
+            Err("no binary on PATH".to_string().into())
+        })
+        .await
+        .expect_err("an unresolvable spec must fail");
+    assert!(
+        matches!(err, SupervisorError::SpawnSpec { .. }),
+        "expected SpawnSpec, got {err:?}"
+    );
+    assert_eq!(sup.spawned_count(), 0);
+}
+
+/// Why: an over-long socket path can never be bound, and Rust rejects it with a
+/// bare `invalid argument` that names neither the limit nor the path. Catching it
+/// before the spawn turns "the daemon is broken" into "this name is N bytes too
+/// long" — and avoids launching a child that is guaranteed to fail.
+/// Test: this test itself.
+#[serial_test::serial]
+#[tokio::test]
+async fn an_over_long_socket_path_is_rejected_before_spawning() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket = tmp.path().join("x".repeat(crate::uds::sun_path_capacity()));
+    let sup = supervisor(3, None);
+
+    let err = sup
+        .ensure_running("inst", &socket, never_spawn)
+        .await
+        .expect_err("an unbindable path must fail before the spawn");
+    assert!(
+        matches!(err, SupervisorError::SocketPath { .. }),
+        "expected SocketPath, got {err:?}"
+    );
+    assert_eq!(sup.spawned_count(), 0);
+}

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -83,7 +83,7 @@ path = "src/bin/mcp_bridge.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.30", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }
+trusty-common = { path = "../trusty-common", version = "0.30", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "uds-supervisor", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside

--- a/crates/trusty-memory/changelog.d/5089-bm25-supervisor-on-shared.md
+++ b/crates/trusty-memory/changelog.d/5089-bm25-supervisor-on-shared.md
@@ -1,0 +1,21 @@
+Changed
+
+- `Bm25Supervisor` is now a thin face over `trusty-common`'s
+  `uds::supervisor::UdsServiceSupervisor` (#5089). Its public API is unchanged —
+  same constructors, same `ensure_running(palace, data_dir)`, same counters —
+  and every behaviour it had is preserved by the shared implementation. What
+  stays here is what is genuinely BM25's: the `TRUSTY_BM25_*` knobs, the socket
+  path convention, the daemon's argv, and its two timing numbers. Those two are
+  now passed in as a `ServiceTimeouts` value rather than being module constants:
+  the 3 s spawn budget is justified by BM25 having no model to load, and the 5 s
+  SIGTERM patience by the daemon's own 2 s `SHUTDOWN_FLUSH_TIMEOUT`. The
+  compile-time guard on that relationship survives as the `BM25_TIMEOUTS` const
+  item — `ServiceTimeouts::new` is a `const fn` that asserts it, so lowering the
+  patience below the daemon's flush budget still fails the build
+- The daemon binary is now located lazily, inside the spawn-spec closure, so the
+  external-mode, already-running and socket-adoption paths no longer require
+  `trusty-bm25-daemon` to be installed at all
+- Unit coverage for the shared machinery — the LRU cap, the RSS ceiling, the
+  three-state socket probe, the eviction bookkeeping — moved to
+  `trusty-common`'s `uds/supervisor/tests.rs` with the code it covers. Every
+  assertion has a counterpart there; nothing was dropped

--- a/crates/trusty-memory/src/bm25_supervisor.rs
+++ b/crates/trusty-memory/src/bm25_supervisor.rs
@@ -1,67 +1,47 @@
 //! Per-palace `trusty-bm25-daemon` spawn supervisor (issue #193).
 //!
-//! Why: trusty-memory ships the `trusty-bm25-daemon` binary alongside its
-//! own (`cargo install trusty-memory` produces all three binaries) but never
-//! actually spawns it. Operators who set `TRUSTY_BM25_DAEMON=1` then have to
-//! manually `launchctl bootstrap` (or otherwise babysit) one daemon per
-//! palace, which is the exact UX trap PR #190 closed for trusty-embedderd.
-//! This module makes BM25 a single-process concern: on first BM25 use for a
-//! palace, we discover the binary via `locate_bm25_daemon_binary()`, spawn
-//! a child with the right `--palace` + `--data-dir`, poll the socket until
-//! it appears, and own the `tokio::process::Child` for the rest of the
-//! daemon's life. Operators who run their own daemon out-of-band (launchd,
-//! systemd, manual) set `TRUSTY_BM25_EXTERNAL=1` to opt out of spawn.
+//! Why: trusty-memory ships the `trusty-bm25-daemon` binary alongside its own
+//! but never actually spawned it, so operators who set `TRUSTY_BM25_DAEMON=1`
+//! had to babysit one daemon per palace by hand. This module makes BM25 a
+//! single-process concern: on first BM25 use for a palace, discover the binary,
+//! spawn a child with the right `--palace` + `--data-dir`, poll the socket until
+//! it serves, and own the child for the rest of the daemon's life.
 //!
-//! What: a single `Bm25Supervisor` value keyed by palace id, internally
-//! using a `tokio::sync::Mutex<HashMap<String, ChildHandle>>` so concurrent
-//! callers don't race a double-spawn. `ensure_running` returns the socket
-//! path the caller should connect to; it skips spawn entirely when
-//! `TRUSTY_BM25_EXTERNAL=1` is set or when the socket already accepts a
-//! connection. Shutdown SIGTERMs every owned child, waits on each, and
-//! best-effort cleans up its socket file.
+//! What: a thin BM25-shaped face over
+//! [`trusty_common::uds::supervisor::UdsServiceSupervisor`] (#5089 step 2). The
+//! state machine — spawn-gate serialisation, socket adoption, the LRU cap, the
+//! RSS ceiling, socket-backed liveness, the doomed queue, SIGTERM→SIGKILL — is
+//! shared now, so `trusty-console` inherits the same hardening for
+//! `trusty-review` / `trusty-analyze` (ADR-0034 §1) instead of re-earning it.
+//! What stays here is what is genuinely BM25's: the env-var knobs, the socket
+//! path convention, the daemon's argv, and — see [`BM25_TIMEOUTS`] — the two
+//! timing numbers that are statements about `trusty-bm25-daemon` rather than
+//! about supervision.
 //!
-//! The daemon population is BOUNDED (#2845 / #2846). Until this module grew a
-//! cap, the only thing that ever removed an entry from the map was `shutdown`,
-//! so one cross-palace `memory_recall_all` over ~99 palaces would leave 99
-//! child processes resident for the trusty-memory daemon's whole life — and
-//! each one's memory scales with its palace's drawer text, because
-//! `PalaceBm25Index` retains every document's full text in a `BTreeMap`. Two
-//! limits now apply on every `ensure_running`: a cap on concurrently-live
-//! daemons with least-recently-used reaping, and a per-daemon RSS ceiling that
-//! is compared against a real measurement rather than merely declared. Spawns
-//! are serialised so a burst fan-out cannot satisfy the cap per-caller and
-//! violate it in aggregate.
-//!
-//! Test: unit tests in `bm25_supervisor_tests.rs` cover the external-mode
-//! opt-out, the "already running" probe, the `shutdown` reaping path with no
-//! daemon ever spawned, and the two limits. An `#[ignore]`-tagged integration
-//! test in `tests/bm25_supervisor_e2e.rs` drives real `trusty-bm25-daemon`
-//! children end-to-end (index + search + cap eviction + shutdown) when the
-//! binary is on PATH or `TRUSTY_BM25_DAEMON_BIN` is set.
+//! Test: unit tests in `bm25_supervisor_tests.rs` cover the env knobs, the
+//! external-mode opt-out, socket adoption, idempotent shutdown, and the
+//! patience-vs-flush relationship. `tests/bm25_supervisor_concurrency.rs` drives
+//! real daemon children through the double-spawn, aggregate-cap, dead-child,
+//! unserved-socket and evicted-live-child-flush paths. The shared machinery's
+//! own unit coverage lives in `trusty-common`'s `uds/supervisor/tests.rs`.
 
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use tokio::net::UnixStream;
-use tokio::process::{Child, Command};
-use tokio::sync::Mutex;
 
 use trusty_common::bm25_client::{locate_bm25_daemon_binary, socket_path_for_palace};
+use trusty_common::uds::supervisor::{
+    ServiceTimeouts, SpawnSpec, SupervisorConfig, UdsServiceSupervisor,
+};
 
 /// Environment variable that disables spawn supervision entirely.
 ///
 /// Why: operators who manage `trusty-bm25-daemon` themselves (launchd plist,
-/// systemd unit, docker sidecar) must be able to opt the in-process
-/// supervisor out so we don't end up with two daemons fighting over the
-/// same socket. Setting this to `1` makes `ensure_running` skip the spawn
-/// step and just return the socket path the caller would have connected to
-/// anyway.
-/// What: the env var name `TRUSTY_BM25_EXTERNAL`. Any value other than `"1"`
-/// is treated as unset.
-/// Test: `external_mode_skips_spawn` exercises the opt-out branch.
+/// systemd unit, docker sidecar) must be able to opt the in-process supervisor
+/// out so two daemons never fight over one socket.
+/// What: `TRUSTY_BM25_EXTERNAL`. Any value other than `"1"` is treated as unset.
+/// Test: `external_mode_skips_spawn`.
 pub const ENV_EXTERNAL_BM25: &str = "TRUSTY_BM25_EXTERNAL";
 
 /// Environment variable that overrides the cap on concurrently-live daemons.
@@ -69,34 +49,30 @@ pub const ENV_EXTERNAL_BM25: &str = "TRUSTY_BM25_EXTERNAL";
 /// Why (#2845): `ensure_running` is called once per palace, and one
 /// `memory_recall_all` touches every palace on disk — ~99 on this host. Without
 /// a cap the supervisor would hold 99 child processes for the rest of the
-/// trusty-memory daemon's life, because nothing but `shutdown` ever removed an
-/// entry from the map. Drawer distribution is heavily skewed (one palace holds
-/// 57% of the corpus, ~80 hold nothing), so the working set is a handful of
-/// palaces and a small cap costs almost nothing while bounding the worst case.
-/// What: env var name `TRUSTY_BM25_MAX_DAEMONS`. Parsed as `usize`; values
-/// below 1 and unparseable values fall back to [`DEFAULT_MAX_LIVE_DAEMONS`].
+/// trusty-memory daemon's life. Drawer distribution is heavily skewed, so the
+/// working set is a handful of palaces and a small cap costs almost nothing.
+/// What: `TRUSTY_BM25_MAX_DAEMONS`, parsed as `usize`; values below 1 and
+/// unparseable values fall back to [`DEFAULT_MAX_LIVE_DAEMONS`].
 /// Test: `max_live_daemons_honours_env_override`.
 pub const ENV_MAX_DAEMONS: &str = "TRUSTY_BM25_MAX_DAEMONS";
 
 /// Environment variable that overrides the per-daemon RSS ceiling, in MB.
 ///
 /// Why (#2846): trusty-search declared an `rss_limit_mb` and never compared it
-/// against anything; the process grew to 2.2x that limit and was OOM-killed.
-/// A BM25 daemon's memory scales linearly with its palace's drawer text
-/// because `PalaceBm25Index` retains every document's full text in a
-/// `BTreeMap`, so an unbounded palace is an unbounded daemon. This limit is
-/// enforced on every `ensure_running`, not merely reported.
-/// What: env var name `TRUSTY_BM25_RSS_LIMIT_MB`. `0` disables enforcement;
-/// unparseable values fall back to [`DEFAULT_RSS_LIMIT_MB`].
-/// Test: `rss_limit_honours_env_override`, `over_rss_limit_children_are_reaped`.
+/// against anything; the process grew to 2.2x that limit and was OOM-killed. A
+/// BM25 daemon's memory scales linearly with its palace's drawer text because
+/// `PalaceBm25Index` retains every document's full text, so an unbounded palace
+/// is an unbounded daemon.
+/// What: `TRUSTY_BM25_RSS_LIMIT_MB`. `0` disables enforcement; unparseable
+/// values fall back to [`DEFAULT_RSS_LIMIT_MB`].
+/// Test: `rss_limit_honours_env_override`.
 pub const ENV_RSS_LIMIT_MB: &str = "TRUSTY_BM25_RSS_LIMIT_MB";
 
 /// Default cap on concurrently-live BM25 daemons.
 ///
-/// Why: three covers the realistic working set — the palace you are in, the
-/// one you just cross-referenced, and one in flight — while keeping the
-/// worst case at three subprocesses instead of ninety-nine. Raising it is a
-/// one-env-var decision for operators who genuinely fan out wider.
+/// Why: three covers the realistic working set — the palace you are in, the one
+/// you just cross-referenced, and one in flight — while keeping the worst case
+/// at three subprocesses instead of ninety-nine.
 /// What: `3`.
 /// Test: `default_cap_is_three`.
 pub const DEFAULT_MAX_LIVE_DAEMONS: usize = 3;
@@ -106,201 +82,75 @@ pub const DEFAULT_MAX_LIVE_DAEMONS: usize = 3;
 /// Why: the whole drawer corpus across ~99 palaces is single-digit MB of text,
 /// so a single daemon holding more than 512 MB is not holding drawers — it is
 /// leaking, and #2846 is the record of what happens when nobody notices.
-/// Generous enough never to reap a healthy daemon; tight enough that a runaway
-/// one is reaped in seconds rather than at OOM time.
 /// What: `512`.
-/// Test: `rss_limit_honours_env_override` pins the parse; the reap path is
-/// covered by `over_rss_limit_children_are_reaped`.
+/// Test: `rss_limit_honours_env_override`.
 pub const DEFAULT_RSS_LIMIT_MB: u64 = 512;
 
-/// Upper bound on how long `ensure_running` waits for the freshly-spawned
-/// daemon's UDS socket to appear and accept a connection.
+/// Upper bound on how long `ensure_running` waits for a freshly-spawned daemon
+/// to bind and accept.
 ///
-/// Why: the daemon's bind step is fast (the BM25 snapshot load is the
-/// slowest part and runs on a tempdir-sized fixture in tests), so 3 s is
-/// comfortably more than the observed worst case while still failing
-/// fast on a misconfigured spawn. Mirrors the trusty-search supervisor's
-/// `TRUSTY_EMBEDDERD_STARTUP_TIMEOUT_SECS=30` default but scaled down
-/// because BM25 has no model-loading step.
-///
-/// 🔴 INVARIANT, and it is per-service, not universal: this must exceed the
-/// supervised service's cold-start work. The 10x gap against the embedder's
-/// 30 s is entirely explained by BM25 having no model to load. Promoting this
-/// supervisor (#5089) with 3 s as a bare constant silently breaks the first
-/// service that loads a model, and the failure looks like a spawn timeout
-/// rather than a mistuned constant. Make it a per-service parameter there.
-/// What: 3 seconds (3000 ms).
-/// Test: covered indirectly by the integration test's spawn path.
+/// Why: BM25's bind step is fast — the snapshot load is the slowest part and
+/// runs on a tempdir-sized fixture in tests — so 3 s is comfortably more than
+/// the observed worst case while still failing fast on a misconfigured spawn.
+/// The 10x gap against the embedder supervisor's 30 s default is entirely
+/// explained by BM25 having no model to load, which is exactly why this number
+/// is declared here rather than in the shared supervisor.
 const SPAWN_PROBE_TIMEOUT: Duration = Duration::from_millis(3000);
-
-/// How long the supervisor waits after SIGTERM before escalating to SIGKILL.
-const SIGTERM_PATIENCE_SECS: u64 = 5;
-
-// 🔴 The invariant SIGTERM_PATIENCE is justified by, enforced at compile time
-// rather than in prose (#5085). This number is NOT free-standing: it means
-// "longer than the supervised daemon's own flush budget, with margin", and a
-// SIGKILL landing inside that flush discards acked writes. Bound to the real
-// `SHUTDOWN_FLUSH_TIMEOUT` rather than a copy of it, so raising the daemon's
-// budget past ours fails the build instead of silently truncating a flush.
-// Any service promoted onto this supervisor (#5089) must re-derive it from ITS
-// flush budget — a bare `5` carried across is wrong for the first service that
-// needs longer.
-const _: () = assert!(
-    SIGTERM_PATIENCE_SECS > trusty_bm25_daemon::SHUTDOWN_FLUSH_TIMEOUT.as_secs(),
-    "SIGTERM patience must exceed the daemon's own shutdown-flush budget, or \
-     the SIGKILL lands mid-flush and discards acked writes"
-);
-
-/// Initial polling interval used to probe the socket after spawn; doubled
-/// on each miss up to a ceiling so we don't busy-wait but also don't sleep
-/// the full 3 s budget when the daemon is ready in ~20 ms.
-const INITIAL_PROBE_INTERVAL: Duration = Duration::from_millis(20);
 
 /// How long the supervisor waits after SIGTERM before escalating to SIGKILL.
 ///
 /// Why: strictly greater than the daemon's own `SHUTDOWN_FLUSH_TIMEOUT` (2 s),
 /// because the daemon needs signal delivery, the flush itself, socket cleanup
-/// and exit inside this window. An equal budget means the SIGKILL can land
-/// mid-flush and lose the write window the flush exists to save.
-/// What: 5 seconds, guarded by a static assertion against the daemon's real
-/// `SHUTDOWN_FLUSH_TIMEOUT` that fails the build if the margin is ever erased.
+/// and exit inside this window. At an equal budget the SIGKILL lands mid-flush
+/// and the open write window is lost.
 /// Test: `sigterm_patience_exceeds_the_daemon_flush_budget`.
-const SIGTERM_PATIENCE: Duration = Duration::from_secs(SIGTERM_PATIENCE_SECS);
+const SIGTERM_PATIENCE: Duration = Duration::from_secs(5);
 
-/// Ceiling on the exponential backoff so we never sleep longer than 250 ms
-/// between probes — at the 3 s budget this gives ~16 probes which is more
-/// than enough to catch any reasonable startup latency.
-const MAX_PROBE_INTERVAL: Duration = Duration::from_millis(250);
-
-/// Per-palace child handle stored in the supervisor's map.
+/// `trusty-bm25-daemon`'s timing budget, and the compile-time guard on it.
 ///
-/// Why: keeping the `Child` plus the resolved socket path together lets
-/// `shutdown` reap each daemon and clean up its socket file in one pass
-/// without re-resolving the path. Mirrors the trusty-search embedder
-/// supervisor's per-slot bookkeeping.
-/// What: holds the `tokio::process::Child` and the socket path that the
-/// daemon was instructed to bind. The `Child` is moved out on shutdown
-/// so we can call `.wait()`.
-/// Test: covered indirectly by `shutdown_with_no_children_is_noop` and
-/// the end-to-end integration test.
-struct ChildHandle {
-    child: Child,
-    socket_path: PathBuf,
-    /// Monotonic tick of the last `ensure_running` that resolved to this
-    /// child. The LRU victim is the entry with the smallest value.
-    ///
-    /// Why a counter and not an `Instant`: two `ensure_running` calls inside
-    /// the same clock tick would compare equal and make the victim choice
-    /// arbitrary, which is exactly the case a burst fan-out produces. A
-    /// strictly-increasing counter gives a total order regardless of clock
-    /// resolution.
-    last_used: u64,
-}
+/// 🔴 This `const` item is what replaces the old
+/// `const _: () = assert!(SIGTERM_PATIENCE_SECS > …SHUTDOWN_FLUSH_TIMEOUT…)`
+/// (#5085). That assertion could not cross into `trusty-common` — a shared
+/// supervisor cannot name any particular daemon's flush budget without depending
+/// on it — so the check moved into [`ServiceTimeouts::new`], which is a
+/// `const fn`. Evaluating it in a `const` item runs the assert at compile time,
+/// exactly as before, and binds it to the value actually handed to the
+/// supervisor rather than to a free-standing constant a refactor could leave
+/// behind. Lower `SIGTERM_PATIENCE` to 2 s, or raise the daemon's
+/// `SHUTDOWN_FLUSH_TIMEOUT` past it, and this line fails the build.
+///
+/// The daemon's budget is imported, never restated: a hardcoded copy stays equal
+/// to itself while the real value drifts, so it could not detect the drift it
+/// exists to name.
+/// Test: `sigterm_patience_exceeds_the_daemon_flush_budget` pins the margin;
+/// the strict inequality is the compiler's job.
+const BM25_TIMEOUTS: ServiceTimeouts = ServiceTimeouts::new(
+    SPAWN_PROBE_TIMEOUT,
+    trusty_bm25_daemon::SHUTDOWN_FLUSH_TIMEOUT,
+    SIGTERM_PATIENCE,
+);
 
 /// Supervisor that owns BM25 daemon subprocesses, one per palace.
 ///
-/// Why: trusty-memory wants the BM25 lane to be a zero-touch feature — set
-/// `TRUSTY_BM25_DAEMON=1` and recall just gets a lexical boost without any
-/// extra process management. Owning the children here means the trusty-memory
-/// daemon's lifetime IS the BM25 daemons' lifetime, which is the same
-/// guarantee `tokio::process::Child` gives us via `kill_on_drop` (set on
-/// every spawn). Restart-on-crash is handled lazily: the next
-/// `ensure_running` call observes the dead child via `try_wait()` and
-/// re-spawns once.
-/// What: a `Mutex<HashMap<String, ChildHandle>>` keyed by palace id. All
-/// public methods are `&self` so the supervisor can live behind an `Arc`
-/// and be shared across handlers without `Mutex<Supervisor>` plumbing at
-/// the call site. The map mutex is fine-grained: it only protects the
-/// HashMap; the actual spawn + socket probe happen with the lock released
-/// so concurrent palaces don't queue behind each other.
-/// Test: `external_mode_skips_spawn`, `already_running_skips_spawn`,
-/// `shutdown_with_no_children_is_noop`, and the integration test.
+/// Why: trusty-memory wants the BM25 lane to be zero-touch — set
+/// `TRUSTY_BM25_DAEMON=1` and recall just gets a lexical boost. Owning the
+/// children here means the trusty-memory daemon's lifetime IS the BM25 daemons'
+/// lifetime.
+/// What: a [`UdsServiceSupervisor`] keyed by palace id, plus BM25's socket-path
+/// and argv conventions. Every method is `&self` so the supervisor can live
+/// behind an `Arc`.
+/// Test: `bm25_supervisor_tests.rs` and `tests/bm25_supervisor_concurrency.rs`.
+#[derive(Debug)]
 pub struct Bm25Supervisor {
-    children: Mutex<HashMap<String, ChildHandle>>,
-    /// Serialises the spawn sequence (re-check → enforce limits → spawn →
-    /// probe → insert).
-    ///
-    /// Why (#2845): the map mutex is released before spawning so slow startups
-    /// for one palace don't block lookups for another, but that left two gaps.
-    /// First, two concurrent calls for the SAME palace could both reach the
-    /// spawn step and the second insert would silently drop the first child.
-    /// Second, a cross-palace fan-out could have every palace in flight at
-    /// once, so a cap checked per-call would be satisfied by each caller
-    /// individually and violated in aggregate — the same shape as the
-    /// unbounded fan-out that 503-stormed trusty-search. Serialising spawns
-    /// closes both: the cap is evaluated against a map nobody else is
-    /// mutating, and a double spawn is impossible because the second caller
-    /// re-checks the map after acquiring.
-    /// The cost is that a cold N-palace fan-out spawns serially. That is the
-    /// intended trade — with a cap of three, a parallel fan-out would spend
-    /// its time evicting daemons it just spawned.
-    spawn_gate: Mutex<()>,
-    /// Cap on concurrently-live daemons. Resolved once at construction.
-    max_live: usize,
-    /// Per-daemon RSS ceiling in MB. `None` disables enforcement.
-    ///
-    /// Why `Option` and not a sentinel `0`: "no ceiling" and "a ceiling of
-    /// zero" are opposite instructions, and a single `u64` cannot say both.
-    /// Encoding disabled-ness in the type keeps the operator's `=0` opt-out
-    /// from colliding with the tightest possible limit, which is the value the
-    /// enforcement tests need in order to be deterministic.
-    rss_limit_mb: Option<u64>,
-    /// Monotonic tick source for `ChildHandle::last_used`.
-    clock: std::sync::atomic::AtomicU64,
-    /// Count of children reaped by the cap or the RSS limit (never by
-    /// `shutdown`). Observability + test assertion surface.
-    reaped: std::sync::atomic::AtomicU64,
-    /// Count of `trusty-bm25-daemon` child processes this supervisor has
-    /// launched.
-    ///
-    /// Why: without it, a double spawn is invisible from outside. Two racing
-    /// callers for one palace both launch a daemon; the loser's bind fails
-    /// with EADDRINUSE and its process dies, and the map still ends up holding
-    /// exactly one entry — so `supervised_count()` reports the same number
-    /// whether the serialisation worked or not. Counting launches is what
-    /// makes `spawn_gate` a claim a test can falsify.
-    /// What: monotonic, incremented once per successful `Command::spawn`
-    /// regardless of whether the socket probe later succeeds.
-    /// Test: `concurrent_callers_for_one_palace_spawn_exactly_one_daemon`.
-    spawned: std::sync::atomic::AtomicU64,
-    /// Children evicted by [`Self::lookup_live`] that are still ALIVE and owe
-    /// a graceful shutdown.
-    ///
-    /// Why (#5085): every other eviction in this module removes a corpse — the
-    /// `Ok(Some(status))` arm evicts a child that has already exited, so
-    /// dropping the handle is free. The unserved-socket arm is the first that
-    /// evicts a LIVE child, and a live BM25 daemon holds acked-but-unflushed
-    /// documents: writes are acked on the in-memory apply and only written at
-    /// the end of the batch window, so the `kill_on_drop` SIGKILL that a bare
-    /// drop performs would discard them with nothing left to recover from.
-    /// `trusty-bm25-daemon`'s shutdown flush exists precisely for this
-    /// supervisor and only runs on SIGTERM.
-    ///
-    /// Why a queue rather than a detached kill task: the doomed daemon unlinks
-    /// the socket path as the last step of its own shutdown. Terminating it
-    /// concurrently with the respawn would let that unlink land AFTER the
-    /// replacement bound the same path, leaving the replacement alive and
-    /// permanently unreachable — this very bug, reintroduced by its own fix.
-    /// Draining the queue under the spawn gate, before the replacement is
-    /// spawned, orders the two so that cannot happen.
-    /// What: `(palace, handle)` pairs pushed by `lookup_live` (a lock and a
-    /// push, so the fast path never waits on a kill) and drained by
-    /// [`Self::reap_doomed`].
-    /// Test: `an_evicted_live_child_is_given_a_chance_to_flush`.
-    doomed: Mutex<Vec<(String, ChildHandle)>>,
+    inner: UdsServiceSupervisor,
 }
 
 impl Bm25Supervisor {
     /// Construct an empty supervisor with limits read from the environment.
     ///
-    /// Why: cheap, allocation-light constructor so the supervisor can be
-    /// built unconditionally at startup and only allocate when a palace
-    /// first asks for a daemon. Resolving the limits here (rather than on
-    /// each `ensure_running`) means a mid-flight env mutation cannot make the
-    /// cap wobble between two concurrent calls.
-    /// What: returns a supervisor with an empty per-palace map and the
-    /// caps from [`ENV_MAX_DAEMONS`] / [`ENV_RSS_LIMIT_MB`], falling back to
-    /// [`DEFAULT_MAX_LIVE_DAEMONS`] / [`DEFAULT_RSS_LIMIT_MB`].
+    /// Why: resolving the limits here — rather than on each `ensure_running` —
+    /// means a mid-flight env mutation cannot make the cap wobble between two
+    /// concurrent calls.
     /// Test: `default_cap_is_three`, `max_live_daemons_honours_env_override`.
     pub fn new() -> Self {
         Self::with_limits(max_live_from_env(), rss_limit_from_env())
@@ -308,470 +158,97 @@ impl Bm25Supervisor {
 
     /// Construct a supervisor with explicit limits, bypassing the environment.
     ///
-    /// Why: the limit-enforcement tests must pin a cap of 1 or an RSS ceiling
-    /// of 1 MB without mutating process-global env vars that sibling tests
-    /// race against. Production code should use [`Self::new`].
-    /// What: `max_live` is clamped to at least 1 — a cap of zero would reap
-    /// every daemon the instant it spawned, which is a wedge, not a limit.
-    /// `rss_limit_mb: None` disables RSS enforcement; `Some(n)` reaps any child
-    /// measuring at or above `n` MB.
-    /// Test: `cap_of_one_keeps_a_single_daemon_live`.
+    /// Why: the limit tests must pin a cap of 1 or an RSS ceiling of 1 MB
+    /// without mutating process-global env vars that sibling tests race against.
+    /// What: `max_live` is clamped to at least 1 — a cap of zero would reap every
+    /// daemon the instant it spawned. `rss_limit_mb: None` disables RSS
+    /// enforcement; `Some(n)` reaps any child measuring at or above `n` MB.
+    /// Test: `cap_is_clamped_to_at_least_one`.
     pub fn with_limits(max_live: usize, rss_limit_mb: Option<u64>) -> Self {
         Self {
-            children: Mutex::new(HashMap::new()),
-            spawn_gate: Mutex::new(()),
-            max_live: max_live.max(1),
-            rss_limit_mb,
-            clock: std::sync::atomic::AtomicU64::new(0),
-            reaped: std::sync::atomic::AtomicU64::new(0),
-            spawned: std::sync::atomic::AtomicU64::new(0),
-            doomed: Mutex::new(Vec::new()),
+            inner: UdsServiceSupervisor::new(
+                SupervisorConfig::new("trusty-bm25-daemon", max_live, BM25_TIMEOUTS)
+                    .with_rss_limit_mb(rss_limit_mb)
+                    .with_external_env(ENV_EXTERNAL_BM25),
+            ),
         }
     }
 
     /// Cap on concurrently-live daemons this supervisor enforces.
     pub fn max_live(&self) -> usize {
-        self.max_live
+        self.inner.max_live()
     }
 
     /// Per-daemon RSS ceiling in MB; `None` means enforcement is off.
     pub fn rss_limit_mb(&self) -> Option<u64> {
-        self.rss_limit_mb
+        self.inner.rss_limit_mb()
     }
 
     /// How many children have been reaped by the cap or the RSS limit.
     ///
     /// Why: "the cap is configured" and "the cap did something" are different
-    /// claims, and #2846 is the record of a limit that only ever made the
-    /// first one. This counter makes the second checkable — by a test, and by
-    /// an operator reading it out of the daemon.
-    /// What: monotonic count; `shutdown` does not increment it.
-    /// Test: `exceeding_the_cap_reaps_the_least_recently_used`.
+    /// claims, and #2846 is the record of a limit that only ever made the first.
+    /// `shutdown` does not increment it.
+    /// Test: `a_concurrent_fanout_never_exceeds_the_cap`.
     pub fn reaped_count(&self) -> u64 {
-        self.reaped.load(std::sync::atomic::Ordering::Relaxed)
+        self.inner.reaped_count()
     }
 
     /// How many daemon processes this supervisor has launched.
     ///
     /// Why: this is the only externally-visible difference between "spawns are
-    /// serialised" and "spawns race". A double spawn leaves the map holding
-    /// one entry either way — the loser's daemon fails its bind and dies — so
-    /// `supervised_count()` cannot tell the two apart and a test written
-    /// against it passes with `spawn_gate` deleted.
-    /// What: monotonic count of successful `Command::spawn` calls.
+    /// serialised" and "spawns race" — a double spawn leaves the map holding one
+    /// entry either way, because the loser's daemon fails its bind and dies.
     /// Test: `concurrent_callers_for_one_palace_spawn_exactly_one_daemon`.
     pub fn spawned_count(&self) -> u64 {
-        self.spawned.load(std::sync::atomic::Ordering::Relaxed)
+        self.inner.spawned_count()
+    }
+
+    /// Number of palaces currently being supervised.
+    pub async fn supervised_count(&self) -> usize {
+        self.inner.supervised_count().await
     }
 
     /// Ensure a `trusty-bm25-daemon` is running for `palace` and return the
     /// socket path the caller should connect to.
     ///
-    /// Why: callers want a single function that handles the four states a
-    /// per-palace daemon can be in — externally managed, already-spawned,
-    /// dead-and-needs-restart, never-spawned — without each call site
-    /// reimplementing the probe + spawn logic. Returning the socket path
-    /// (rather than the `Bm25Client`) keeps the supervisor free of any
-    /// dependency on the client type and lets the caller decide whether
-    /// to construct one new client per call or cache.
-    /// What: when `TRUSTY_BM25_EXTERNAL=1`, returns the socket path without
-    /// touching anything. Otherwise: (1) checks the in-memory map; if the
-    /// stored child is alive, returns its socket path. If the child has
-    /// exited unexpectedly, evicts it and falls through to a fresh spawn
-    /// (one restart attempt per call — if THAT spawn also fails the error
-    /// propagates and the caller degrades). (2) Probes the socket — if some
-    /// out-of-band process already runs the daemon for this palace, we adopt
-    /// the socket and skip the spawn so we don't EADDRINUSE. (3) Spawns
-    /// `trusty-bm25-daemon --palace <name> --data-dir <data_dir>` via
-    /// `tokio::process::Command`, polls the socket with exponential backoff
-    /// until the bound listener accepts a connection (or the timeout
-    /// elapses), then stores the child and returns the path.
-    /// Test: `external_mode_skips_spawn`, `already_running_skips_spawn`,
-    /// and the integration test cover all four states.
+    /// Why: callers want one function that handles every state a per-palace
+    /// daemon can be in without reimplementing probe-and-spawn. Returning the
+    /// socket path rather than a `Bm25Client` keeps the supervisor free of the
+    /// BM25 wire protocol.
+    /// What: resolves BM25's canonical socket path, then defers to
+    /// [`UdsServiceSupervisor::ensure_running`]. The daemon binary is located
+    /// lazily, inside the spawn-spec closure, so the external-mode, fast and
+    /// adoption paths never require it to be installed.
+    /// Test: `external_mode_skips_spawn`, `already_running_skips_spawn`, and the
+    /// concurrency suite.
     pub async fn ensure_running(&self, palace: &str, data_dir: &Path) -> Result<PathBuf> {
         let socket_path = socket_path_for_palace(palace);
-
-        // ── (1) External-mode opt-out ──────────────────────────────────────
-        if external_mode_enabled() {
-            tracing::debug!(
-                palace = %palace,
-                socket = %socket_path.display(),
-                "{ENV_EXTERNAL_BM25}=1 — skipping spawn supervision"
-            );
-            return Ok(socket_path);
-        }
-
-        // ── (2) Already-supervised fast path ───────────────────────────────
-        // Take the lock briefly to inspect the stored child. We drop the
-        // guard before spawning so concurrent calls for OTHER palaces don't
-        // queue behind a slow startup probe.
-        if let Some(path) = self.lookup_live(palace).await {
-            return Ok(path);
-        }
-
-        // ── (3) Spawn, serialised ──────────────────────────────────────────
-        // Everything from here down mutates the daemon population, so it runs
-        // under the spawn gate — see the field's doc comment for why the map
-        // mutex alone is not enough.
-        let _spawn = self.spawn_gate.lock().await;
-
-        // Re-check under the gate: a concurrent caller for this same palace
-        // may have spawned it while we waited. Without this, the cap could be
-        // exceeded by exactly the number of racing callers, and the loser's
-        // child would be silently dropped by the map insert.
-        if let Some(path) = self.lookup_live(palace).await {
-            return Ok(path);
-        }
-
-        // #5085: settle any live child the lookups above evicted BEFORE the
-        // socket is probed or rebound. The doomed daemon flushes its acked
-        // writes and unlinks this very path on its way out, so letting it
-        // overlap the respawn would strand the replacement on an unlinked
-        // socket — the same fail-open this eviction path exists to close.
-        self.reap_doomed().await;
-
-        // ── (3a) Socket-already-bound check ────────────────────────────────
-        // If some other process (a previously-spawned daemon we lost the
-        // handle to, or an operator-managed launchd job that forgot to set
-        // TRUSTY_BM25_EXTERNAL) is already serving on this socket, adopt
-        // it. Spawning a second daemon would EADDRINUSE the bind.
-        if probe_socket(&socket_path).await {
-            tracing::info!(
-                palace = %palace,
-                socket = %socket_path.display(),
-                "bm25 daemon socket already responding — not spawning a new child"
-            );
-            return Ok(socket_path);
-        }
-
-        // ── (3b) Enforce the limits BEFORE adding to the population ────────
-        // Order matters: reaping after the spawn would let the population
-        // momentarily exceed the cap, and under a fan-out that moment is when
-        // every other caller is also spawning.
-        self.enforce_limits(1).await;
-
-        // ── (4) Spawn ──────────────────────────────────────────────────────
-        let binary =
-            locate_bm25_daemon_binary().context("locate trusty-bm25-daemon binary for spawn")?;
-        let child = spawn_child(&binary, palace, data_dir)
-            .await
-            .inspect(|_| {
-                self.spawned
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let data_dir = data_dir.to_path_buf();
+        self.inner
+            .ensure_running(palace, &socket_path, || {
+                let binary = locate_bm25_daemon_binary()?;
+                Ok(SpawnSpec::new(binary)
+                    .arg("--palace")
+                    .arg(palace)
+                    .arg("--data-dir")
+                    .arg(&data_dir)
+                    .create_dir(&data_dir))
             })
-            .with_context(|| {
-                format!(
-                    "spawn trusty-bm25-daemon {} for palace {palace}",
-                    binary.display()
-                )
-            })?;
-
-        // Probe the socket until it accepts a connection (or we time out).
-        // If the probe fails we still hold the `Child` — drop it so
-        // `kill_on_drop` SIGKILLs the doomed daemon before we propagate.
-        if let Err(e) = wait_for_socket(&socket_path).await {
-            // Explicit drop — clarifies intent for the next reader.
-            drop(child);
-            return Err(e.context(format!(
-                "bm25 daemon for palace {palace} did not bind {} within {:?}",
-                socket_path.display(),
-                SPAWN_PROBE_TIMEOUT
-            )));
-        }
-
-        tracing::info!(
-            palace = %palace,
-            socket = %socket_path.display(),
-            binary = %binary.display(),
-            "spawned trusty-bm25-daemon"
-        );
-
-        // Store the handle so the next `ensure_running` sees it.
-        let mut guard = self.children.lock().await;
-        guard.insert(
-            palace.to_string(),
-            ChildHandle {
-                child,
-                socket_path: socket_path.clone(),
-                last_used: self.tick(),
-            },
-        );
-        let live = guard.len();
-        drop(guard);
-        tracing::debug!(live, cap = self.max_live, "bm25 supervisor: daemon count");
-        Ok(socket_path)
+            .await
+            .with_context(|| format!("ensure trusty-bm25-daemon is running for palace {palace}"))
     }
 
-    /// Next value of the monotonic LRU clock.
-    fn tick(&self) -> u64 {
-        self.clock
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            .wrapping_add(1)
-    }
-
-    /// Resolve `palace` to a live child's socket, refreshing its LRU stamp.
+    /// Graceful shutdown: SIGTERM all owned daemons, reap them, and clean up
+    /// their sockets.
     ///
-    /// Why: `ensure_running` needs this answer twice — once on the fast path
-    /// and once under the spawn gate — and the two must agree exactly,
-    /// including the dead-child eviction. Two copies would be two chances to
-    /// drift.
-    ///
-    /// Liveness is decided by TWO questions, not one (#5085). `try_wait()`
-    /// answers "has this child been reaped", which is not the same as "is it
-    /// serving": a SIGKILLed daemon closes its listening socket during
-    /// `do_exit` and only becomes reapable once the kernel finishes tearing it
-    /// down, so for that window `try_wait()` reports `Ok(None)` for a process
-    /// that is already refusing connections. Trusting it alone made this the
-    /// fast path's fail-open — the caller was handed a socket path nothing was
-    /// listening on and nothing reported a problem. The socket the caller is
-    /// about to use is the authority, so we ask it too.
-    ///
-    /// What: returns `Some(socket_path)` when the stored child is both
-    /// un-reaped AND its socket is not definitively unserved, and stamps it as
-    /// most-recently-used so the LRU victim choice reflects real traffic. A
-    /// child that has exited, whose status cannot be read, or whose socket
-    /// answers [`SocketVerdict::NotServing`] is removed from the map and `None`
-    /// is returned, so the caller falls through to a fresh spawn. An
-    /// [`SocketVerdict::Inconclusive`] probe keeps the child, so an
-    /// unanswerable connect never turns load into a respawn storm — but note
-    /// that on macOS/BSD a saturated backlog is NOT inconclusive, it is
-    /// ECONNREFUSED; see [`SocketVerdict`] for why that is safe here. A child
-    /// evicted while still alive is handed to [`Self::doomed`] rather than
-    /// dropped, because it owes a flush. Removing a corpse does NOT count as a
-    /// reap — nothing was reclaimed.
-    ///
-    /// The probe runs with the map lock released, so a slow connect never
-    /// blocks another palace's lookup. Eviction then re-acquires and fires only
-    /// if the map still holds the same child, so a replacement spawned
-    /// concurrently is never evicted by this call's stale verdict.
-    /// Test: `a_dead_child_is_evicted_and_respawned` and
-    /// `a_live_child_that_stopped_serving_is_evicted_and_respawned`.
-    async fn lookup_live(&self, palace: &str) -> Option<PathBuf> {
-        // Phase 1 — under the map lock: reap check, LRU stamp, snapshot.
-        let (pid, path) = {
-            let stamp = self.tick();
-            let mut guard = self.children.lock().await;
-            let entry = guard.get_mut(palace)?;
-            match entry.child.try_wait() {
-                Ok(None) => {
-                    entry.last_used = stamp;
-                    (entry.child.id(), entry.socket_path.clone())
-                }
-                Ok(Some(status)) => {
-                    tracing::warn!(
-                        palace = %palace,
-                        ?status,
-                        "bm25 daemon exited unexpectedly — attempting one restart"
-                    );
-                    guard.remove(palace);
-                    return None;
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        palace = %palace,
-                        "bm25 supervisor: try_wait failed: {e:#} — evicting and retrying"
-                    );
-                    guard.remove(palace);
-                    return None;
-                }
-            }
-        };
-
-        // Phase 2 — lock released. #5085: an un-reaped child is not the same
-        // claim as a serving one; ask the socket the caller will actually use.
-        if probe_socket_verdict(&path).await != SocketVerdict::NotServing {
-            tracing::trace!(
-                palace = %palace,
-                socket = %path.display(),
-                "bm25 supervisor: child already running"
-            );
-            return Some(path);
-        }
-
-        // Phase 3 — evict, but only if the map still holds THIS child.
-        tracing::warn!(
-            palace = %palace,
-            socket = %path.display(),
-            pid = ?pid,
-            "bm25 daemon is not serving its socket — evicting and respawning"
-        );
-        let evicted = {
-            let mut guard = self.children.lock().await;
-            // #5085: identify the child by pid so a replacement spawned while
-            // the probe ran is never evicted on this call's stale verdict. Two
-            // unreadable pids must not alias into "same child", so an absent
-            // pid on either side is never a match.
-            let same_child = matches!(
-                (pid, guard.get(palace).and_then(|h| h.child.id())),
-                (Some(ours), Some(current)) if ours == current
-            );
-            if same_child {
-                guard.remove(palace)
-            } else {
-                None
-            }
-        };
-        if let Some(handle) = evicted {
-            // #5085: this child is alive and owes a flush — see `doomed`.
-            self.doomed.lock().await.push((palace.to_string(), handle));
-        }
-        None
-    }
-
-    /// SIGTERM every child `lookup_live` evicted while it was still alive, and
-    /// wait for each to exit.
-    ///
-    /// Why (#5085): see the [`Self::doomed`] field. A live daemon holds acked
-    /// documents that only its own SIGTERM handler writes, and it unlinks the
-    /// shared socket path on its way out — so it must be fully gone before a
-    /// replacement binds that path.
-    /// What: drains the queue and, for each child, runs the same
-    /// `terminate_child` + `remove_socket_file` sequence `enforce_limits` and
-    /// `shutdown` use. Callers must hold the spawn gate, which is what orders
-    /// this before the respawn. Does NOT increment `reaped` — this is a
-    /// restart, not a reclamation. A no-op (one uncontended lock) when nothing
-    /// has been evicted, which is the overwhelmingly common case.
-    /// Test: `an_evicted_live_child_is_given_a_chance_to_flush`.
-    async fn reap_doomed(&self) {
-        let doomed: Vec<(String, ChildHandle)> = {
-            let mut guard = self.doomed.lock().await;
-            if guard.is_empty() {
-                return;
-            }
-            std::mem::take(&mut *guard)
-        };
-        for (palace, mut handle) in doomed {
-            tracing::info!(
-                palace = %palace,
-                pid = ?handle.child.id(),
-                "bm25 supervisor: gracefully terminating an evicted daemon so it can flush"
-            );
-            if let Err(e) = terminate_child(&mut handle.child).await {
-                tracing::warn!(palace = %palace, "bm25 daemon graceful termination error: {e:#}");
-            }
-            remove_socket_file(&palace, &handle.socket_path).await;
-        }
-    }
-
-    /// Bring the live-daemon population within both limits, leaving room for
-    /// `headroom` more.
-    ///
-    /// Why (#2845 + #2846): these are the two failures trusty-search shipped —
-    /// an unbounded fan-out and a memory limit that was declared but never
-    /// compared against anything. Enforcing both in one place, on the path
-    /// that grows the population, is what makes them limits rather than
-    /// documentation.
-    /// What: two passes. First, every child whose measured RSS exceeds
-    /// `rss_limit_mb` is selected regardless of recency — a leaking daemon is
-    /// the wrong thing to keep no matter how recently it was used. A child
-    /// whose RSS cannot be measured is left alone: `None` means "no reading",
-    /// and reaping on a failed measurement would kill healthy daemons on any
-    /// platform where the read is unavailable. Second, while the survivors
-    /// plus `headroom` would exceed `max_live`, the least-recently-used
-    /// survivor is selected. Victims are removed from the map under the lock,
-    /// then terminated with the lock released so the SIGTERM wait never blocks
-    /// another palace's lookup.
-    /// Test: `exceeding_the_cap_reaps_the_least_recently_used`,
-    /// `over_rss_limit_children_are_reaped`,
-    /// `over_rss_limit_is_false_without_a_measurement`.
-    async fn enforce_limits(&self, headroom: usize) {
-        let mut victims: Vec<(String, ChildHandle, &'static str)> = Vec::new();
-        {
-            let mut guard = self.children.lock().await;
-
-            let over: Vec<String> = guard
-                .iter()
-                .filter(|(_, h)| over_rss_limit(h.child.id(), self.rss_limit_mb))
-                .map(|(p, _)| p.clone())
-                .collect();
-            for palace in over {
-                if let Some(h) = guard.remove(&palace) {
-                    victims.push((palace, h, "rss"));
-                }
-            }
-
-            while guard.len() + headroom > self.max_live {
-                let Some(lru) = guard
-                    .iter()
-                    .min_by_key(|(_, h)| h.last_used)
-                    .map(|(p, _)| p.clone())
-                else {
-                    break;
-                };
-                if let Some(h) = guard.remove(&lru) {
-                    victims.push((lru, h, "cap"));
-                }
-            }
-        }
-
-        for (palace, mut handle, reason) in victims {
-            tracing::info!(
-                palace = %palace,
-                reason,
-                cap = self.max_live,
-                rss_limit_mb = ?self.rss_limit_mb,
-                pid = ?handle.child.id(),
-                "bm25 supervisor: reaping daemon to stay within limits"
-            );
-            if let Err(e) = terminate_child(&mut handle.child).await {
-                tracing::warn!(palace = %palace, "bm25 daemon reap error: {e:#}");
-            }
-            remove_socket_file(&palace, &handle.socket_path).await;
-            self.reaped
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        }
-    }
-
-    /// Graceful shutdown: SIGTERM all owned daemons, reap them, and clean
-    /// up their sockets.
-    ///
-    /// Why: trusty-memory's normal exit path is a SIGTERM from launchd or a
-    /// ctrl-c at the foreground. Without this we'd rely on `kill_on_drop`
-    /// to send SIGKILL on each child, which (a) skips the daemon's own
-    /// cleanup of the socket file and (b) leaves the BM25 snapshot
-    /// half-flushed if the daemon was mid-batch. Sending SIGTERM lets the
-    /// daemon run its own shutdown sequence (drain queue, flush snapshot,
-    /// unlink socket) before we move on.
-    /// What: drains the per-palace map; for each child sends SIGTERM, waits
-    /// up to ~2 s for it to exit, then `kill()`s (SIGKILL) if it's still
-    /// alive. Best-effort `remove_file` on each socket path because the
-    /// daemon's own cleanup may have already done it. Idempotent — calling
-    /// `shutdown` twice is harmless.
-    /// Test: `shutdown_with_no_children_is_noop` covers the empty-map case;
-    /// the integration test asserts the child is reaped and the socket
-    /// file removed.
+    /// Why: trusty-memory's normal exit is a SIGTERM from launchd or a ctrl-c.
+    /// Relying on `kill_on_drop` instead would SIGKILL each daemon, skipping its
+    /// own socket cleanup and leaving the BM25 snapshot half-flushed.
+    /// Test: `shutdown_with_no_children_is_noop`, and the e2e test's assertion
+    /// that the child is reaped and the socket file removed.
     pub async fn shutdown(&self) {
-        // #5085: a child evicted but never respawned still owes a flush.
-        self.reap_doomed().await;
-        let mut guard = self.children.lock().await;
-        let handles: Vec<(String, ChildHandle)> = guard.drain().collect();
-        drop(guard);
-
-        for (palace, mut entry) in handles {
-            tracing::info!(
-                palace = %palace,
-                pid = ?entry.child.id(),
-                "shutting down bm25 daemon"
-            );
-            if let Err(e) = terminate_child(&mut entry.child).await {
-                tracing::warn!(
-                    palace = %palace,
-                    "bm25 daemon shutdown encountered an error: {e:#}"
-                );
-            }
-            remove_socket_file(&palace, &entry.socket_path).await;
-        }
-    }
-
-    /// Number of palaces currently being supervised — primarily for tests
-    /// and observability.
-    ///
-    /// Why: lets `shutdown_with_no_children_is_noop` and similar checks
-    /// avoid reaching into the private map.
-    /// What: returns the size of the per-palace handle map.
-    /// Test: `supervisor_starts_empty`.
-    pub async fn supervised_count(&self) -> usize {
-        self.children.lock().await.len()
+        self.inner.shutdown().await;
     }
 }
 
@@ -781,85 +258,12 @@ impl Default for Bm25Supervisor {
     }
 }
 
-impl std::fmt::Debug for Bm25Supervisor {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // We deliberately don't lock the mutex here — `Debug` may be
-        // invoked while another task already holds the guard, and we'd
-        // rather print a placeholder than deadlock or panic.
-        f.debug_struct("Bm25Supervisor")
-            .field("children", &"<locked>")
-            .finish()
-    }
-}
-
-/// Returns true when `TRUSTY_BM25_EXTERNAL=1`.
-///
-/// Why: tiny helper so the env-var check is testable and not duplicated
-/// at each call site.
-/// What: reads `TRUSTY_BM25_EXTERNAL`; treats anything other than the
-/// exact string `"1"` as unset, matching how `TRUSTY_BM25_DAEMON=1`
-/// gates the client side.
-/// Test: `external_mode_skips_spawn` flips the env var to verify the
-/// branch.
-fn external_mode_enabled() -> bool {
-    std::env::var(ENV_EXTERNAL_BM25).as_deref() == Ok("1")
-}
-
-/// Best-effort unlink of a daemon's socket file.
-///
-/// Why: the daemon's own SIGTERM handler unlinks the socket on a clean exit,
-/// but a SIGKILLed daemon leaves the file behind and the next spawn for that
-/// palace then fails to bind with EADDRINUSE. Both the shutdown path and the
-/// limit-enforcement reap path need this, and a reaped palace is exactly the
-/// one most likely to be spawned again shortly.
-/// What: `remove_file`; `NotFound` is the expected clean-exit case and is not
-/// logged. Any other error is logged at `debug!` and ignored — a stale socket
-/// costs one failed spawn, not correctness.
-/// Test: covered by `bm25_supervisor_e2e`'s shutdown assertion.
-async fn remove_socket_file(palace: &str, socket_path: &Path) {
-    if let Err(e) = tokio::fs::remove_file(socket_path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            tracing::debug!(
-                palace = %palace,
-                socket = %socket_path.display(),
-                "could not remove bm25 daemon socket (likely already cleaned up): {e}"
-            );
-        }
-    }
-}
-
-/// Decide whether a child has breached the RSS ceiling.
-///
-/// Why (#2846): the whole point of this limit is that it is compared against a
-/// real measurement, so the two ways a measurement can be missing need an
-/// explicit, tested answer rather than whatever `unwrap_or` happens to do. A
-/// child with no pid has already exited — there is nothing to reclaim. A pid
-/// whose RSS cannot be read yields `None`, which means "no reading", NOT
-/// "zero"; reaping on it would kill every healthy daemon on any platform where
-/// the read is unavailable, turning a memory guardrail into an outage.
-/// What: `false` when enforcement is off, when the pid is gone, or when the
-/// reading is unavailable. Otherwise `true` iff the measured MB is at or above
-/// the ceiling. Pure — takes the pid rather than the handle so it is testable
-/// without a live process.
-/// Test: `over_rss_limit_is_false_without_a_measurement`,
-/// `over_rss_limit_is_false_when_disabled`.
-fn over_rss_limit(pid: Option<u32>, limit_mb: Option<u64>) -> bool {
-    let Some(limit) = limit_mb else {
-        return false;
-    };
-    let Some(pid) = pid else {
-        return false;
-    };
-    trusty_common::sys_metrics::process_rss_mb(pid).is_some_and(|mb| mb >= limit)
-}
-
 /// Resolve the live-daemon cap from [`ENV_MAX_DAEMONS`].
 ///
 /// Why: an operator who fans out wider than the default working set needs a
-/// knob, and a knob that silently ignores a typo is worse than no knob — hence
-/// the explicit warn on an unparseable value rather than a quiet default.
-/// What: parses the env var as `usize`; `0` and unparseable values fall back
-/// to [`DEFAULT_MAX_LIVE_DAEMONS`].
+/// knob, and a knob that silently ignores a typo is worse than no knob.
+/// What: parses as `usize`; `0` and unparseable values fall back to
+/// [`DEFAULT_MAX_LIVE_DAEMONS`].
 /// Test: `max_live_daemons_honours_env_override`.
 fn max_live_from_env() -> usize {
     match std::env::var(ENV_MAX_DAEMONS) {
@@ -899,212 +303,6 @@ fn rss_limit_from_env() -> Option<u64> {
             }
         },
         Err(_) => Some(DEFAULT_RSS_LIMIT_MB),
-    }
-}
-
-/// What a connect attempt says about whether anything is serving a socket.
-///
-/// Why (#5085): the spawn path only ever needed "did it answer, yes or no",
-/// but eviction needs a third answer. Evicting a daemon because one connect
-/// did not complete would turn a load spike into a respawn storm — the daemon
-/// is killed, a replacement is spawned into the same contention, and the cycle
-/// repeats. Separating "I could not tell" from a definite answer keeps
-/// eviction off the ambiguous cases.
-///
-/// What ECONNREFUSED does NOT tell you: it is not exclusively "no listener".
-/// On macOS/BSD a bound listener whose accept queue is full answers connects
-/// with ECONNREFUSED too (`unp_connect` rejects once `so_qlen >= so_qlimit`),
-/// so on those platforms a saturated backlog is indistinguishable from a dead
-/// one — measured directly: `listen(1)`, never accept, six non-blocking
-/// connects, connect 0 OK and connects 1-5 all ECONNREFUSED. Linux instead
-/// queues to the backlog and only then refuses. What keeps that from causing
-/// spurious evictions here is not this classification but the daemon's shape:
-/// tokio's default backlog is 1024 and `run_accept_loop` spawns a task per
-/// connection rather than serving inline, so the queue does not saturate. A
-/// service that accepts inline, or sets a small backlog, would break that
-/// assumption — which matters for the #5089 promotion, not for BM25 today.
-///
-/// What: `NotServing` covers ENOENT and ECONNREFUSED. A timeout or any other
-/// errno (EPERM, and Linux's EAGAIN) is `Inconclusive` and leaves the child
-/// alone.
-/// Test: `probe_verdict_reports_not_serving_for_a_missing_socket`,
-/// `probe_verdict_reports_not_serving_for_a_stale_socket_file`,
-/// `probe_verdict_reports_serving_for_a_bound_socket`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SocketVerdict {
-    /// A connection was accepted — something is serving this path.
-    Serving,
-    /// The kernel proved no listener is bound (ENOENT / ECONNREFUSED).
-    NotServing,
-    /// The probe could not settle the question; assume the daemon is fine.
-    Inconclusive,
-}
-
-/// Quick non-blocking probe — opens a `UnixStream`, immediately closes it.
-///
-/// Why: we want a single answer to "is something listening on this socket
-/// right now?" without depending on `Bm25Client` (which would couple us to the
-/// BM25 wire protocol) and without spending more than a few ms.
-/// What: attempts `UnixStream::connect` with a short timeout and classifies the
-/// outcome per [`SocketVerdict`].
-/// Test: `probe_verdict_reports_not_serving_for_a_missing_socket`,
-/// `probe_verdict_reports_serving_for_a_bound_socket`.
-async fn probe_socket_verdict(path: &Path) -> SocketVerdict {
-    // Use a short timeout so an unresponsive (but still bound) socket
-    // doesn't stall the probe loop.
-    let connect = UnixStream::connect(path);
-    match tokio::time::timeout(Duration::from_millis(200), connect).await {
-        Ok(Ok(_)) => SocketVerdict::Serving,
-        Ok(Err(e)) => match e.kind() {
-            std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused => {
-                SocketVerdict::NotServing
-            }
-            _ => SocketVerdict::Inconclusive,
-        },
-        Err(_elapsed) => SocketVerdict::Inconclusive,
-    }
-}
-
-/// Whether a socket is definitely accepting connections right now.
-///
-/// Why: the spawn and adoption paths only care about the affirmative case —
-/// "may I skip the spawn?" — for which anything short of a completed connect
-/// must read as no.
-/// What: true iff [`probe_socket_verdict`] returns [`SocketVerdict::Serving`].
-/// Test: covered indirectly — every spawn path goes through this probe
-/// in a tight loop.
-async fn probe_socket(path: &Path) -> bool {
-    probe_socket_verdict(path).await == SocketVerdict::Serving
-}
-
-/// Poll the socket with exponential backoff until it accepts a connection
-/// or the spawn timeout elapses.
-///
-/// Why: a freshly-spawned daemon takes a few ms to load its snapshot and
-/// bind the listener. We don't know exactly how long, so polling with a
-/// short initial interval (and doubling on each miss) gives sub-50 ms
-/// detection on the happy path without hammering the kernel.
-/// What: loops `probe_socket` until success or until the cumulative wait
-/// exceeds `SPAWN_PROBE_TIMEOUT`. Returns `Err` with the timeout duration
-/// in the message so the caller can surface it.
-/// Test: covered indirectly by the integration test.
-async fn wait_for_socket(path: &Path) -> Result<()> {
-    let deadline = tokio::time::Instant::now() + SPAWN_PROBE_TIMEOUT;
-    let mut interval = INITIAL_PROBE_INTERVAL;
-    loop {
-        if probe_socket(path).await {
-            return Ok(());
-        }
-        let now = tokio::time::Instant::now();
-        if now >= deadline {
-            anyhow::bail!(
-                "socket {} did not become connectable within {:?}",
-                path.display(),
-                SPAWN_PROBE_TIMEOUT
-            );
-        }
-        // Don't sleep past the deadline.
-        let remaining = deadline.saturating_duration_since(now);
-        let sleep_for = interval.min(remaining);
-        tokio::time::sleep(sleep_for).await;
-        // Exponential backoff with a cap so we never sleep too long.
-        interval = (interval * 2).min(MAX_PROBE_INTERVAL);
-    }
-}
-
-/// Spawn a single `trusty-bm25-daemon` child for `palace`.
-///
-/// Why: keeps the `tokio::process::Command` builder isolated so tests can
-/// focus on the supervisor's higher-level state machine.
-/// What: builds the command with `--palace <name> --data-dir <dir>`,
-/// inherits stderr so the daemon's tracing log appears in the parent's
-/// log stream, ignores stdin/stdout (the daemon speaks UDS only), and
-/// sets `kill_on_drop` so an unsupervised drop (e.g. panic propagation)
-/// still SIGKILLs the child rather than leaking it.
-/// Test: covered indirectly by the integration test.
-async fn spawn_child(binary: &Path, palace: &str, data_dir: &Path) -> Result<Child> {
-    // Ensure the data dir exists before launching — the daemon would
-    // create it itself but failing here gives a cleaner error message
-    // and avoids spawning a child that immediately exits.
-    if !data_dir.exists() {
-        tokio::fs::create_dir_all(data_dir)
-            .await
-            .with_context(|| format!("create bm25 data dir {}", data_dir.display()))?;
-    }
-
-    let child = Command::new(binary)
-        .arg("--palace")
-        .arg(palace)
-        .arg("--data-dir")
-        .arg(data_dir)
-        // The daemon never reads stdin; closing it cleanly is the only
-        // reasonable behaviour. Stdout is also unused — the daemon logs
-        // to stderr.
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::inherit())
-        .kill_on_drop(true)
-        .spawn()
-        .with_context(|| format!("spawn {}", binary.display()))?;
-
-    Ok(child)
-}
-
-/// Send SIGTERM, wait briefly, then SIGKILL if still alive.
-///
-/// Why: a clean SIGTERM lets the daemon flush its BM25 snapshot and
-/// remove its socket; a SIGKILL is the fallback if the daemon hangs. The wait
-/// must exceed the daemon's OWN shutdown budget with margin, not merely match
-/// it: `trusty-bm25-daemon` allows itself 2 s for the shutdown flush
-/// (`lib.rs`'s `SHUTDOWN_FLUSH_TIMEOUT`) and still needs signal delivery,
-/// socket cleanup, and process exit on top. At an equal 2 s the SIGKILL landed
-/// inside the very flush the durability fix added — no corruption, since the
-/// flush is tmp+rename, but the window's writes were lost. 5 s leaves 3 s of
-/// margin over the daemon's worst case.
-/// What: on Unix sends SIGTERM via `nix::sys::signal::kill` would add a
-/// dep, so we use `tokio::process::Child::start_kill` on the doomsday
-/// path and `Child::kill` (which sends SIGKILL) only as a fallback.
-/// Since tokio's API doesn't expose SIGTERM directly, we send SIGTERM
-/// via libc when the platform exposes it, otherwise fall back to the
-/// stdlib `kill` (SIGKILL). On test/non-unix builds we just kill.
-/// Test: integration test verifies the process is gone after shutdown.
-async fn terminate_child(child: &mut Child) -> Result<()> {
-    // Attempt a graceful SIGTERM first. tokio::process::Child doesn't
-    // expose a direct SIGTERM method, so on Unix we reach into the raw
-    // PID and use libc::kill. Failures here just fall through to the
-    // SIGKILL path below.
-    #[cfg(unix)]
-    if let Some(pid) = child.id() {
-        // SAFETY: libc::kill is safe to call with any pid; the kernel
-        // returns -1/EINVAL/ESRCH rather than UB on bad input. We
-        // intentionally ignore the return value because either the
-        // signal landed (child will exit) or it didn't (we'll SIGKILL).
-        unsafe {
-            let _ = libc::kill(pid as libc::pid_t, libc::SIGTERM);
-        }
-    }
-
-    // Give the child longer than its own flush budget to exit on its own.
-    let wait_result = tokio::time::timeout(SIGTERM_PATIENCE, child.wait()).await;
-    match wait_result {
-        Ok(Ok(status)) => {
-            tracing::debug!(?status, "bm25 daemon exited after SIGTERM");
-            Ok(())
-        }
-        Ok(Err(e)) => Err(e).context("wait on bm25 daemon child after SIGTERM"),
-        Err(_elapsed) => {
-            // Still alive — force-kill. `kill()` here is tokio's
-            // method which sends SIGKILL and waits, so by the time it
-            // returns the process is definitely gone.
-            tracing::warn!(
-                "bm25 daemon ignored SIGTERM after {SIGTERM_PATIENCE:?} — sending SIGKILL"
-            );
-            child
-                .kill()
-                .await
-                .context("SIGKILL bm25 daemon after SIGTERM timeout")?;
-            Ok(())
-        }
     }
 }
 

--- a/crates/trusty-memory/src/bm25_supervisor_tests.rs
+++ b/crates/trusty-memory/src/bm25_supervisor_tests.rs
@@ -1,31 +1,25 @@
-//! Unit tests for the [`super::Bm25Supervisor`] bounded process model.
+//! Unit tests for [`super::Bm25Supervisor`].
 //!
 //! Why: split out of `bm25_supervisor.rs` so the production module stays under
-//! the 500-SLOC cap once the daemon cap, LRU reaping, and RSS enforcement
-//! landed. Wired back in via `#[path] mod tests;`, the same way
-//! `worker_liveness_tests.rs` is.
-//! What: covers the external-mode opt-out, socket adoption, idempotent
-//! shutdown, the socket probe, and the bounded-process-model limits.
+//! the 500-SLOC cap. Since #5089 promoted the state machine into
+//! `trusty-common`, this file covers only what is still BM25's: the env knobs,
+//! the external-mode opt-out, socket adoption at BM25's canonical path,
+//! idempotent shutdown, and the patience-vs-flush relationship that binds this
+//! service's timeouts to `trusty-bm25-daemon`'s own budget. The limits, the
+//! probe classification and the eviction bookkeeping moved to
+//! `trusty-common`'s `uds/supervisor/tests.rs` with the code they cover.
 //! Test: this *is* the test file.
 
 use super::*;
 use tokio::sync::Mutex as TokioMutex;
 
-/// Process-wide lock that serialises every test in this module which
-/// touches the `TRUSTY_BM25_EXTERNAL` or `TRUSTY_BM25_DAEMON_BIN` env
-/// vars.
+/// Process-wide lock serialising every test that touches `TRUSTY_BM25_*`.
 ///
-/// Why: cargo runs tests in parallel inside the same process, and any
-/// two tests that mutate the same env var race each other. The lock
-/// keeps the supervisor's env mutation isolated from sibling tests
-/// without slowing the whole suite via `--test-threads=1`. We use
-/// `tokio::sync::Mutex` here (not `std::sync::Mutex`) because the
-/// guard is held across `.await` calls in `ensure_running`; holding a
-/// std-sync guard across an await would block the runtime and is
+/// Why: cargo runs tests in parallel inside the same process, so two tests
+/// mutating the same env var race each other. A `tokio::sync::Mutex` (not
+/// `std::sync::Mutex`) because the guard is held across `.await` calls in
+/// `ensure_running`; a std guard held across an await blocks the runtime and is
 /// flagged by `clippy::await_holding_lock`.
-/// What: a static `OnceLock<Arc<TokioMutex<()>>>` initialised on first
-/// access so we don't need a runtime to construct it. Each call
-/// returns a clone of the `Arc` — cheap and lockable.
 /// Test: used by every env-mutating test below.
 fn env_lock() -> std::sync::Arc<TokioMutex<()>> {
     static LOCK: std::sync::OnceLock<std::sync::Arc<TokioMutex<()>>> = std::sync::OnceLock::new();
@@ -35,7 +29,6 @@ fn env_lock() -> std::sync::Arc<TokioMutex<()>> {
 
 /// Why: the supervisor must start with an empty map so the first
 /// `ensure_running` call always takes the cold-path branch.
-/// What: constructs a supervisor and asserts no children are tracked.
 /// Test: this test itself.
 #[tokio::test]
 async fn supervisor_starts_empty() {
@@ -43,9 +36,8 @@ async fn supervisor_starts_empty() {
     assert_eq!(sup.supervised_count().await, 0);
 }
 
-/// Why: `Default::default()` must behave like `new()`. Catches a
-/// regression where someone adds state to `new` and forgets to mirror
-/// it on `Default`.
+/// Why: `Default::default()` must behave like `new()`. Catches a regression
+/// where someone adds state to `new` and forgets to mirror it on `Default`.
 /// Test: this test itself.
 #[tokio::test]
 async fn supervisor_default_matches_new() {
@@ -53,16 +45,12 @@ async fn supervisor_default_matches_new() {
     assert_eq!(sup.supervised_count().await, 0);
 }
 
-/// Why: in external-management mode `ensure_running` must NOT spawn
-/// anything; it must just hand back the socket path the caller would
-/// have ended up at if it had spawned. Pinning this guards against a
-/// future regression that accidentally fires off a child even with the
-/// env var set.
-/// What: set `TRUSTY_BM25_EXTERNAL=1`, call `ensure_running` against a
-/// definitely-unused palace + a nonexistent data dir, assert no child
-/// is tracked and the returned path matches the canonical resolver.
-/// Test: this test itself. The env mutation is serialised by the
-/// guard because Rust tests run in parallel inside the same process.
+/// Why: in external-management mode `ensure_running` must NOT spawn anything; it
+/// must hand back the socket path the caller would have ended up at. Pinning it
+/// here guards against a regression that fires off a child with the env var set.
+/// What: sets `TRUSTY_BM25_EXTERNAL=1` and calls `ensure_running` against a
+/// definitely-unused palace and a nonexistent data dir.
+/// Test: this test itself.
 #[tokio::test]
 async fn external_mode_skips_spawn() {
     let lock = env_lock();
@@ -70,8 +58,8 @@ async fn external_mode_skips_spawn() {
     let _guard = EnvGuard::set(ENV_EXTERNAL_BM25, "1");
     let tmp = tempfile::tempdir().expect("tempdir");
     let sup = Bm25Supervisor::new();
-    // Short palace name so the resolved socket path stays well under
-    // the kernel's `sun_path` limit (~104 bytes on macOS).
+    // Short palace name so the resolved socket path stays well under the
+    // kernel's `sun_path` limit (~104 bytes on macOS).
     let palace = "ext-skip";
     let path = sup
         .ensure_running(palace, tmp.path())
@@ -85,35 +73,28 @@ async fn external_mode_skips_spawn() {
     );
 }
 
-/// Why: if some other process is already serving on the canonical
-/// socket path (think: stale daemon from a previous run, or an
-/// operator-managed launchd job that forgot the `TRUSTY_BM25_EXTERNAL`
-/// env var), spawning a second daemon would EADDRINUSE. The supervisor
-/// must adopt the existing socket and return without spawning.
-/// What: bind a dummy `UnixListener` at the canonical socket path for
-/// a test palace, call `ensure_running`, assert no child is tracked
-/// and the returned path matches.
+/// Why: if some other process is already serving BM25's canonical socket path
+/// — a stale daemon from a previous run, or an operator-managed launchd job that
+/// forgot `TRUSTY_BM25_EXTERNAL` — spawning a second daemon would EADDRINUSE.
+/// The supervisor must adopt the existing socket.
+/// What: binds a listener the way the real daemon does (`bind_hardened`, so the
+/// socket passes the adoption-time verification #5089 added) at the canonical
+/// path for a test palace, then asserts no child is tracked.
 /// Test: this test itself.
 #[tokio::test]
 async fn already_running_skips_spawn() {
     let lock = env_lock();
     let _env = lock.lock().await;
-    // Ensure we don't accidentally pick up an external-mode flag from
-    // a sibling test that ran first.
+    // Don't pick up an external-mode flag from a sibling test that ran first.
     let _g = EnvGuard::remove(ENV_EXTERNAL_BM25);
-    // Use a very short palace name. The canonical socket path is
-    // `$TMPDIR/trusty-<uid>/trusty-bm25-<palace>.sock`, and macOS' `$TMPDIR`
-    // (`/var/folders/.../T/`) is already long, so we keep the palace
-    // fragment to a handful of characters to avoid SUN_LEN errors.
-    // Use the low bits of process PID to disambiguate concurrent
-    // test runs.
+    // The canonical path is `$TMPDIR/trusty-<uid>/trusty-bm25-<palace>.sock`,
+    // and macOS' `$TMPDIR` is already long, so keep the palace fragment short.
     let palace = format!("a{:x}", std::process::id() & 0xffff);
     let socket = socket_path_for_palace(&palace);
-    // Clean up any leftover socket from a previous failed test.
     let _ = std::fs::remove_file(&socket);
     // #5099: bind the way the real daemon does. A bare `UnixListener::bind`
-    // here fails with ENOENT now that the canonical path sits inside a
-    // uid-keyed directory that only `bind_hardened` creates.
+    // fails with ENOENT now that the canonical path sits inside a uid-keyed
+    // directory that only `bind_hardened` creates.
     let listener =
         trusty_common::uds::bind_hardened(&socket).expect("bind dummy listener at canonical path");
 
@@ -134,9 +115,8 @@ async fn already_running_skips_spawn() {
     let _ = std::fs::remove_file(&socket);
 }
 
-/// Why: `shutdown` on a fresh supervisor must not panic, error, or
-/// log anything alarming. Operators will inevitably call it at exit
-/// even when no palace has touched BM25 yet.
+/// Why: `shutdown` on a fresh supervisor must not panic, error, or log anything
+/// alarming. Operators will call it at exit even when no palace has touched BM25.
 /// Test: this test itself.
 #[tokio::test]
 async fn shutdown_with_no_children_is_noop() {
@@ -145,10 +125,8 @@ async fn shutdown_with_no_children_is_noop() {
     assert_eq!(sup.supervised_count().await, 0);
 }
 
-/// Why: `Bm25Supervisor` is shared via `Arc` and must be `Send + Sync`
-/// so it can be cloned into background tasks and async handlers.
-/// Compile-fail of this test means the type bounds regressed.
-/// What: a static assertion via a const fn that requires `Send + Sync`.
+/// Why: `Bm25Supervisor` is shared via `Arc` and must be `Send + Sync` so it can
+/// be cloned into background tasks and async handlers.
 /// Test: this test itself.
 #[test]
 fn supervisor_is_send_and_sync() {
@@ -156,75 +134,11 @@ fn supervisor_is_send_and_sync() {
     assert_send_sync::<Bm25Supervisor>();
 }
 
-/// Why: the probe must report `false` for a path with nothing bound,
-/// not panic or block forever.
-/// Test: this test itself.
-#[tokio::test]
-async fn probe_returns_false_for_missing_socket() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let missing = tmp.path().join("nonexistent.sock");
-    assert!(!probe_socket(&missing).await);
-}
-
-/// Why: the probe must report `true` immediately when something is
-/// already accepting connections at that path. Pins the happy path.
-/// Test: this test itself.
-#[tokio::test]
-async fn probe_returns_true_for_bound_socket() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let sock = tmp.path().join("listen.sock");
-    let _listener = tokio::net::UnixListener::bind(&sock).expect("bind listener for probe test");
-    assert!(probe_socket(&sock).await);
-}
-
-/// Why (#5085): eviction keys off `NotServing` specifically, so an absent
-/// socket must produce that verdict and not the `Inconclusive` catch-all —
-/// otherwise a crashed daemon is never replaced.
-/// Test: this test itself.
-#[tokio::test]
-async fn probe_verdict_reports_not_serving_for_a_missing_socket() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let missing = tmp.path().join("nonexistent.sock");
-    assert_eq!(
-        probe_socket_verdict(&missing).await,
-        SocketVerdict::NotServing
-    );
-}
-
-/// Why (#5085): a stale socket file left behind by a SIGKILLed daemon answers
-/// ECONNREFUSED rather than ENOENT. That is still proof nothing is listening,
-/// and it is the shape a real crash leaves on disk.
-/// Test: this test itself.
-#[tokio::test]
-async fn probe_verdict_reports_not_serving_for_a_stale_socket_file() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let sock = tmp.path().join("stale.sock");
-    // Bind then drop: the file survives, the listener does not.
-    let listener = tokio::net::UnixListener::bind(&sock).expect("bind listener");
-    drop(listener);
-    assert!(sock.exists(), "the socket file must outlive the listener");
-    assert_eq!(probe_socket_verdict(&sock).await, SocketVerdict::NotServing);
-}
-
-/// Why (#5085): a serving socket must never be classified as `NotServing`, or
-/// `lookup_live` would evict healthy daemons on every call.
-/// Test: this test itself.
-#[tokio::test]
-async fn probe_verdict_reports_serving_for_a_bound_socket() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let sock = tmp.path().join("listen.sock");
-    let _listener = tokio::net::UnixListener::bind(&sock).expect("bind listener for probe test");
-    assert_eq!(probe_socket_verdict(&sock).await, SocketVerdict::Serving);
-}
-
 /// RAII guard for serialised env-var mutation in tests.
 ///
 /// Why: cargo test runs tests in the same process by default, so
-/// `std::env::set_var` mutations leak between tests unless restored
-/// on drop. This is the same pattern the supervisor unit tests in
-/// `trusty-search/src/service/embedder_supervisor.rs` use.
-/// What: captures the prior value on construction, restores or
-/// removes on drop. SAFETY notes inlined at each unsafe block.
+/// `std::env::set_var` mutations leak between tests unless restored on drop.
+/// What: captures the prior value on construction, restores or removes on drop.
 /// Test: used by every env-touching test in this module.
 struct EnvGuard {
     key: String,
@@ -234,9 +148,8 @@ struct EnvGuard {
 impl EnvGuard {
     fn set(key: &str, value: &str) -> Self {
         let prev = std::env::var(key).ok();
-        // SAFETY: test-only env mutation; serialised by the fact that
-        // each test takes the guard before mutating, and the Drop
-        // impl restores on scope exit.
+        // SAFETY: test-only env mutation; each test takes `env_lock` before
+        // mutating, and the Drop impl restores on scope exit.
         unsafe { std::env::set_var(key, value) }
         Self {
             key: key.to_string(),
@@ -257,8 +170,7 @@ impl EnvGuard {
 
 impl Drop for EnvGuard {
     fn drop(&mut self) {
-        // SAFETY: test teardown; restoring the captured prior value
-        // is the inverse of the unsafe mutation done at construction.
+        // SAFETY: test teardown; the inverse of the mutation in `set`.
         unsafe {
             match &self.prev {
                 Some(v) => std::env::set_var(&self.key, v),
@@ -268,57 +180,17 @@ impl Drop for EnvGuard {
     }
 }
 
-// ── Bounded process model (#2845 / #2846) ─────────────────────────────────
+// ── Bounded process model: the knobs that stayed here (#2845 / #2846) ──────
 
-/// Spawn a long-lived, cheap child to stand in for a BM25 daemon.
-///
-/// Why: the limit-enforcement paths care about how many children exist and how
-/// much memory they use — not about what they serve. Driving them with real
-/// `trusty-bm25-daemon` children would make these tests depend on a built
-/// binary and a bound socket, which is what the `#[ignore]`d e2e test is for.
-/// `sleep` is a real OS process with a real pid and real RSS, which is
-/// everything the cap and the RSS reader need.
-/// What: `sleep 60` with `kill_on_drop`, so a failing test cannot leak it.
-/// Test: used by every limit test below.
-fn stub_child() -> Child {
-    Command::new("sleep")
-        .arg("60")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .kill_on_drop(true)
-        .spawn()
-        .expect("spawn stub child")
-}
-
-/// Register a stub child under `palace` with an explicit LRU stamp.
-///
-/// Why: the LRU victim choice is the behaviour under test, so the test must
-/// control the recency order directly rather than hoping wall-clock ordering
-/// falls out of the call sequence.
-/// What: inserts a `ChildHandle` into the supervisor's map. Reaches private
-/// fields because this module is a child of `bm25_supervisor`.
-/// Test: used by the cap tests below.
-async fn register_stub(sup: &Bm25Supervisor, palace: &str, last_used: u64) {
-    let tmp = std::env::temp_dir().join(format!("trusty-bm25-stub-{palace}.sock"));
-    sup.children.lock().await.insert(
-        palace.to_string(),
-        ChildHandle {
-            child: stub_child(),
-            socket_path: tmp,
-            last_used,
-        },
-    );
-}
-
-/// Why: the default has to be a small number, because the failure it prevents
-/// is one `memory_recall_all` leaving ~99 resident subprocesses. A regression
-/// that quietly widened it back out would restore that failure without
-/// changing a single line of enforcement logic.
+/// Why: the default has to be a small number, because the failure it prevents is
+/// one `memory_recall_all` leaving ~99 resident subprocesses. A regression that
+/// quietly widened it would restore that failure without changing a line of
+/// enforcement logic.
 /// Test: this test itself.
 #[test]
 fn default_cap_is_three() {
     assert_eq!(DEFAULT_MAX_LIVE_DAEMONS, 3);
+    assert_eq!(Bm25Supervisor::new().max_live(), 3);
 }
 
 /// Why: the cap is the knob an operator reaches for when their fan-out is
@@ -344,10 +216,10 @@ async fn max_live_daemons_honours_env_override() {
     assert_eq!(max_live_from_env(), DEFAULT_MAX_LIVE_DAEMONS);
 }
 
-/// Why (#2846): `0` must be the documented, working way to turn RSS
-/// enforcement off — distinct from the tightest possible ceiling. If those two
-/// collapsed onto one value, an operator disabling the limit would instead get
-/// a supervisor that reaps every daemon it spawns.
+/// Why (#2846): `0` must be the documented, working way to turn RSS enforcement
+/// off — distinct from the tightest possible ceiling. If those two collapsed
+/// onto one value, an operator disabling the limit would instead get a
+/// supervisor that reaps every daemon it spawns.
 /// Test: this test itself.
 #[tokio::test]
 async fn rss_limit_honours_env_override() {
@@ -367,60 +239,7 @@ async fn rss_limit_honours_env_override() {
     assert_eq!(rss_limit_from_env(), Some(DEFAULT_RSS_LIMIT_MB));
 }
 
-/// Why (#2845): this is the regression the cap exists for. Before it, the map
-/// only ever grew — a fan-out across N palaces left N children resident for
-/// the process lifetime. Against that code this assertion reads 4, not 2.
-/// What: registers four stubs with increasing recency, asks for room for one
-/// more with a cap of 3, and asserts the population lands at 2 (3 minus the
-/// requested headroom) and that the two survivors are the most recently used.
-/// Test: this test itself.
-#[tokio::test]
-async fn exceeding_the_cap_reaps_the_least_recently_used() {
-    let sup = Bm25Supervisor::with_limits(3, None);
-    for (i, palace) in ["oldest", "older", "newer", "newest"].iter().enumerate() {
-        register_stub(&sup, palace, i as u64 + 1).await;
-    }
-    assert_eq!(sup.supervised_count().await, 4);
-
-    sup.enforce_limits(1).await;
-
-    assert_eq!(
-        sup.supervised_count().await,
-        2,
-        "cap 3 with headroom 1 must leave room for the incoming daemon"
-    );
-    let live = sup.children.lock().await;
-    assert!(live.contains_key("newest"), "most recent must survive");
-    assert!(
-        live.contains_key("newer"),
-        "second most recent must survive"
-    );
-    assert!(!live.contains_key("oldest"), "LRU must be reaped first");
-    drop(live);
-    assert_eq!(
-        sup.reaped_count(),
-        2,
-        "reaps must be counted, not just done"
-    );
-}
-
-/// Why: a cap of 1 is the tightest legal setting and the one an operator on a
-/// constrained host will pick. It must keep exactly one daemon, not zero —
-/// reaping the daemon you are about to use is a wedge, not a limit.
-/// Test: this test itself.
-#[tokio::test]
-async fn cap_of_one_keeps_a_single_daemon_live() {
-    let sup = Bm25Supervisor::with_limits(1, None);
-    register_stub(&sup, "a", 1).await;
-    // Headroom 0: nothing incoming, so the single existing daemon stays.
-    sup.enforce_limits(0).await;
-    assert_eq!(sup.supervised_count().await, 1);
-    // Headroom 1: an incoming daemon must displace the resident one.
-    sup.enforce_limits(1).await;
-    assert_eq!(sup.supervised_count().await, 0);
-}
-
-/// Why: a cap of 0 would mean "never keep a daemon", which makes every
+/// Why: a cap of 0 would mean "never keep a daemon", making every
 /// `ensure_running` spawn-and-immediately-reap. Clamping to 1 turns an
 /// operator's misconfiguration into a tight limit rather than a livelock.
 /// Test: this test itself.
@@ -429,103 +248,61 @@ fn cap_is_clamped_to_at_least_one() {
     assert_eq!(Bm25Supervisor::with_limits(0, None).max_live(), 1);
 }
 
-/// Why (#2846): this is the assertion trusty-search's `rss_limit_mb` never
-/// had. A limit that is declared but never compared against a measurement
-/// reaps nothing, which is indistinguishable from having no limit until the
-/// kernel's OOM killer makes the distinction.
-/// What: a ceiling of 0 MB means "at or above zero", which every live process
-/// satisfies, so both stubs must be reaped on RSS grounds — and crucially NOT
-/// on cap grounds, since the cap here is wide enough to hold them both.
+/// Why: the RSS ceiling must reach the shared supervisor rather than being
+/// silently dropped by the wrapper. A ceiling that never arrives is #2846
+/// again — declared, never compared.
 /// Test: this test itself.
-#[tokio::test]
-async fn over_rss_limit_children_are_reaped() {
-    let sup = Bm25Supervisor::with_limits(16, Some(0));
-    register_stub(&sup, "fat-a", 1).await;
-    register_stub(&sup, "fat-b", 2).await;
-    assert_eq!(sup.supervised_count().await, 2);
-
-    sup.enforce_limits(0).await;
-
+#[test]
+fn explicit_limits_reach_the_shared_supervisor() {
+    let sup = Bm25Supervisor::with_limits(9, Some(42));
+    assert_eq!(sup.max_live(), 9);
+    assert_eq!(sup.rss_limit_mb(), Some(42));
     assert_eq!(
-        sup.supervised_count().await,
-        0,
-        "children at or above the RSS ceiling must be reaped even under the cap"
+        Bm25Supervisor::with_limits(9, None).rss_limit_mb(),
+        None,
+        "disabled enforcement must survive the wrapper too"
     );
-    assert_eq!(sup.reaped_count(), 2);
 }
 
-/// Why: a generous ceiling must leave healthy daemons alone. Without this the
-/// previous test would also pass on an implementation that reaps
-/// unconditionally, which is a different bug wearing the same result.
-/// Test: this test itself.
-#[tokio::test]
-async fn under_rss_limit_children_are_left_alone() {
-    let sup = Bm25Supervisor::with_limits(16, Some(1_000_000));
-    register_stub(&sup, "lean", 1).await;
-    sup.enforce_limits(0).await;
-    assert_eq!(sup.supervised_count().await, 1);
-    assert_eq!(sup.reaped_count(), 0);
-}
-
-/// Why (#2846 inverse): `None` from the RSS reader means "no reading", not
-/// "zero". Treating an unavailable measurement as a breach would reap every
-/// healthy daemon on any platform where the read is unsupported — converting a
-/// memory guardrail into an outage.
-/// What: pid 0 is not measurable on either supported platform, and `None`
-/// stands for a child that has already exited.
-/// Test: this test itself.
-#[test]
-fn over_rss_limit_is_false_without_a_measurement() {
-    assert!(
-        !over_rss_limit(Some(0), Some(0)),
-        "unmeasurable must not reap"
-    );
-    assert!(!over_rss_limit(None, Some(0)), "exited child must not reap");
-}
-
-/// Why: disabling enforcement must actually disable it, including for a
-/// process that would otherwise be over any ceiling.
-/// Test: this test itself.
-#[test]
-fn over_rss_limit_is_false_when_disabled() {
-    assert!(!over_rss_limit(Some(std::process::id()), None));
-}
-
-/// Why: `shutdown` reaps for a different reason than the limits do, and an
-/// operator reading `reaped_count` to answer "is my cap doing anything?" must
-/// not have normal shutdown inflate the number.
-/// Test: this test itself.
-#[tokio::test]
-async fn shutdown_does_not_count_as_a_limit_reap() {
-    let sup = Bm25Supervisor::with_limits(16, None);
-    register_stub(&sup, "bye", 1).await;
-    sup.shutdown().await;
-    assert_eq!(sup.supervised_count().await, 0);
-    assert_eq!(sup.reaped_count(), 0);
-}
-
-/// Why (#5048 review): the supervisor's SIGTERM patience must exceed the
-/// daemon's own shutdown-flush budget with margin. At an equal budget the
-/// SIGKILL lands inside the flush the durability fix added and the open write
-/// window is lost. Pinning the relationship here means a future tightening of
-/// either number has to be a deliberate choice.
-/// What: asserts the patience is strictly greater than
-/// `trusty_bm25_daemon`'s 2 s `SHUTDOWN_FLUSH_TIMEOUT`, with real margin.
+/// Why (#5048 review, #5085, #5089): the supervisor's SIGTERM patience must
+/// exceed the daemon's own shutdown-flush budget with margin. At an equal budget
+/// the SIGKILL lands inside the flush the durability fix added and the open
+/// write window is lost. The strict inequality is now enforced at compile time
+/// by [`super::BM25_TIMEOUTS`] — `ServiceTimeouts::new` is a `const fn` whose
+/// assert fires during const evaluation — so what this test still owes is the
+/// MARGIN, which no type can express: signal delivery, socket cleanup and
+/// process exit all have to fit on top of the flush itself.
+/// What: asserts at least 2 s of headroom over `trusty_bm25_daemon`'s real
+/// `SHUTDOWN_FLUSH_TIMEOUT`, imported rather than restated — a hardcoded copy
+/// stays equal to itself while the daemon's budget drifts, so it could never
+/// detect the drift it exists to name.
 /// Test: this test itself.
 #[test]
 fn sigterm_patience_exceeds_the_daemon_flush_budget() {
-    // Imported, not restated: a hardcoded copy stays equal to itself while the
-    // daemon's real budget drifts, so it could never detect the drift it exists
-    // to name.
     let daemon_flush_budget = trusty_bm25_daemon::SHUTDOWN_FLUSH_TIMEOUT;
-    assert!(
-        SIGTERM_PATIENCE > daemon_flush_budget,
-        "the supervisor must outwait the daemon's flush: {SIGTERM_PATIENCE:?} vs \
-         {daemon_flush_budget:?}"
+    assert_eq!(
+        BM25_TIMEOUTS.shutdown_flush, daemon_flush_budget,
+        "the supervisor must be configured with the daemon's REAL flush budget, \
+         or the compile-time guard checks the wrong number"
     );
     assert!(
-        SIGTERM_PATIENCE - daemon_flush_budget >= Duration::from_secs(2),
+        BM25_TIMEOUTS.sigterm_patience > daemon_flush_budget,
+        "the supervisor must outwait the daemon's flush: {:?} vs {daemon_flush_budget:?}",
+        BM25_TIMEOUTS.sigterm_patience
+    );
+    assert!(
+        BM25_TIMEOUTS.sigterm_patience - daemon_flush_budget >= Duration::from_secs(2),
         "leave room for signal delivery, socket cleanup and process exit on top \
          of the flush itself"
     );
+}
+
+/// Why (#5089): the spawn budget is BM25's, not supervision's — 3 s is justified
+/// by BM25 having no model to load, against 30 s for the embedder. A promotion
+/// that dropped it on the floor and inherited someone else's default would fail
+/// as a spawn timeout that looks like a broken binary.
+/// Test: this test itself.
+#[test]
+fn spawn_probe_budget_reaches_the_shared_supervisor() {
+    assert_eq!(BM25_TIMEOUTS.spawn_probe, Duration::from_millis(3000));
 }


### PR DESCRIPTION
Step 2 of four for #5089 (ADR-0034 §1, milestone `tm 1.3.5` criterion (c)). Does **not** close #5089.

## What changed

`trusty-memory`'s `Bm25Supervisor` is promoted into `trusty-common` as
`uds::supervisor::UdsServiceSupervisor`, behind a new `uds-supervisor` feature,
so `trusty-console` can spawn `trusty-review` / `trusty-analyze` on demand for
webhook delivery. `Bm25Supervisor` becomes a thin face over it — same
constructors, same `ensure_running(palace, data_dir)`, same counters, no call
site changed.

New public surface in `trusty-common`: `UdsServiceSupervisor`, `SupervisorConfig`,
`ServiceTimeouts`, `SpawnSpec`, `SupervisorError`, `SocketVerdict`,
`probe_socket_verdict`, `socket_is_serving`, `over_rss_limit`.
Every new enum and struct is `#[non_exhaustive]`.

Built on #5124's `uds/` primitives rather than reimplementing: adoption verifies
through `verify_socket_for_connect`, and the spawn path pre-checks
`check_sun_path_budget`.

## The two invariants that had to survive

**1. Socket-backed liveness, not `try_wait()`.** Carried verbatim. `try_wait()`
answers "has this child been reaped", not "is it serving" — a SIGKILLed daemon
closes its listener during `do_exit` and only becomes reapable once the kernel
finishes tearing it down. `SocketVerdict` stays three-state and only ENOENT /
ECONNREFUSED mean `NotServing`; a timeout or any other errno is `Inconclusive`
and leaves the child alone. The `doomed` queue is still drained **under the spawn
gate**, because the doomed child unlinks the shared socket path as the last step
of its own shutdown and a concurrent termination could land that unlink after the
replacement bound the same path.

The macOS/BSD saturated-backlog fact (a full accept queue answers ECONNREFUSED,
so it is indistinguishable from a dead listener) is now written as an explicit
**requirement on anything supervised**: accept promptly and off the request path,
or eviction under load is a live risk. It is stated on `SocketVerdict` where the
next service author will read it, not left as a BM25 footnote.

**2. The timeouts are per-service.** `SPAWN_PROBE_TIMEOUT` (3 s, justified by
BM25 having no model to load, against 30 s for the embedder) and
`SIGTERM_PATIENCE` (5 s, bound to the daemon's own `SHUTDOWN_FLUSH_TIMEOUT`) are
now fields of a `ServiceTimeouts` value the service supplies.

**What replaced the compile-time assert.** `const _: () = assert!(SIGTERM_PATIENCE_SECS
> trusty_bm25_daemon::SHUTDOWN_FLUSH_TIMEOUT.as_secs(), …)` could not cross the
abstraction — `trusty-common` cannot name any particular daemon's flush budget
without depending on it. So the check moved into `ServiceTimeouts::new`, which is
a **`const fn`** whose `assert!` requires `sigterm_patience > shutdown_flush`,
and the service now declares its child's flush budget as an argument.
`trusty-memory` writes `const BM25_TIMEOUTS: ServiceTimeouts = ServiceTimeouts::new(…)`,
so the assert fires during const evaluation exactly as before. It is strictly
stronger than what it replaces: it is bound to the value actually handed to the
supervisor rather than to a free-standing constant a refactor could leave behind.
Lower `SIGTERM_PATIENCE` to 2 s and the build fails. A service that builds
timeouts at runtime instead gets a panic at construction — startup, before any
child exists.

Coverage: `service_timeouts_reject_patience_equal_to_the_flush`,
`service_timeouts_reject_patience_below_the_flush`,
`service_timeouts_accept_a_subsecond_margin` (the const comparison is
hand-written, since `Duration`'s operators are not `const`), plus
`sigterm_patience_exceeds_the_daemon_flush_budget` which now asserts
`BM25_TIMEOUTS.shutdown_flush == trusty_bm25_daemon::SHUTDOWN_FLUSH_TIMEOUT` —
so a supervisor configured with the *wrong* budget cannot pass a guard that
checks the right relationship between wrong numbers.

## One behaviour change

Adoption is verified rather than assumed. A socket that answers but fails
`verify_socket_for_connect` now produces `SupervisorError::UntrustedSocket`
instead of being adopted silently or falling through to a spawn that dies on
EADDRINUSE. This is the one path where the target's own `bind_hardened` never
runs, which #5099's dialer docs already named as the reason a dialer must
verify, and ADR-0034 §3 makes the socket's permissions the credential the relay
hop rests on. Post-#5099 daemons bind through `bind_hardened`, so this is inert
for them.

## Everything else preserved, verified

| Behaviour | Where it is proved |
|---|---|
| Spawn-gate serialisation vs. double-spawn | `concurrent_callers_for_one_palace_spawn_exactly_one_daemon` (asserts launches, not map size) |
| Cap not violated in aggregate under fan-out | `a_concurrent_fanout_never_exceeds_the_cap` |
| Adoption of a socket another process bound | `already_running_skips_spawn`, `adoption_accepts_a_hardened_socket_without_spawning` |
| LRU cap | `exceeding_the_cap_reaps_the_least_recently_used`, `cap_of_one_keeps_a_single_child_live` |
| RSS ceiling vs. a real measurement | `over_rss_limit_children_are_reaped`, `under_rss_limit_children_are_left_alone`, `over_rss_limit_is_false_without_a_measurement` |
| `kill_on_drop` + SIGTERM→SIGKILL patience | `terminate_child_reaps_a_live_child`, `a_child_that_never_binds_fails_with_the_service_budget` |
| `doomed` + `reap_doomed` instead of a bare SIGKILL | `an_evicted_live_child_is_given_a_chance_to_flush` (asserts the acked doc reaches the evictee's own snapshot), `an_unserved_live_child_is_queued_for_graceful_termination` |
| Dead-child eviction, corpse is not a reap | `a_dead_child_is_evicted_and_respawned`, `a_dead_child_is_evicted_without_counting_as_a_reap` |
| Unserved-socket eviction, both errnos | `a_live_child_that_stopped_serving_is_evicted_and_respawned`, `a_child_behind_a_stale_socket_file_is_evicted_and_respawned` |
| External-mode opt-out | `external_mode_skips_spawn` (its spec closure panics if called, so the path provably never resolves a binary), `external_env_only_honours_exactly_one` |

Unit coverage for the shared machinery moved to `trusty-common`'s
`uds/supervisor/tests.rs` **with the code it covers**; every assertion has a
counterpart there. `trusty-memory` keeps what is still BM25's: the env knobs,
adoption at BM25's canonical path, and the patience-vs-flush margin.

## The flake, now with its mechanism

`probe_verdict_reports_not_serving_for_a_stale_socket_file` passed 3/3 alone and
3/3 alongside the other probe tests, but failed 4 of 5 runs of the whole module
and 2 of 3 of the wider `uds::` filter — reading `Serving` for a listener the
test had already dropped.

Mechanism, identified in review: **fd inheritance across a concurrent fork.**
macOS has no atomic `SOCK_CLOEXEC`, so `UnixListener::bind` creates the socket
and sets `FD_CLOEXEC` in a second syscall. A `Command::spawn` on another test
thread that forks inside that window hands the listening fd to the child — here
a `sleep 60` stub — which holds it open. The parent's `drop(listener)` then
closes only its own descriptor; the socket stays bound and the connect completes.

It is a property of the test harness, not of the supervisor: a supervised service
binds its own socket in its own process, and this supervisor never holds one to
leak. Remedy: every test in that file is `#[serial]`, which closes the window.
10/10 clean after. The mechanism is written into the test file's module doc.

## Gates — rung 5

🔴 **Corrected 2026-08-07.** The first version of this table reported
`check_test_pointers.sh … 0 dangling — OK`. It was **red**: five dangling
pointers in `crates/trusty-common/src/uds/supervisor/`. See "How that entry came
to say OK" below. Every row here was re-run after `git add`, at `060eda02`.

```
cargo fmt --check                                                    EXIT=0
cargo clippy -p trusty-common --features uds,uds-supervisor \
  --all-targets -- -D warnings                                       EXIT=0
cargo clippy -p trusty-memory --all-targets -- -D warnings           EXIT=0
cargo check --workspace --all-targets \
  --exclude trusty-mpm-gui --exclude trusty-code-gui \
  --exclude trusty-agents-ui                                         EXIT=0  (SKIP_UI_BUILD=1)
cargo test --no-fail-fast -p trusty-common --features uds,uds-supervisor
   test result: ok. 365 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out
cargo test --no-fail-fast -p trusty-memory
   test result: ok. 606 passed; 0 failed; 4 ignored   (+23 integration binaries, 24 suites ok, 0 failed)
cargo test -p trusty-memory --test bm25_supervisor_concurrency  ×50
   CONCURRENCY 50x: pass=50 fail=0     (6 tests per run)
cargo test -p trusty-common --features uds,uds-supervisor --lib uds::  ×10
   uds:: 10x: pass=10 fail=0           (the fd-inheritance flake, post-#[serial])
check_test_pointers.sh   resolved 22496 Test: citation(s) — 0 dangling pointers — OK
check_line_cap.sh        measured 3790 tracked .rs file(s); 4 allowlisted, 0 violations — OK
check_changelog_fragment.sh   scanned 13 changed path(s); both crates recorded — OK
check_sld.sh             56 spec doc(s) + 3135 code file(s); 0 errors, 0 warnings — OK
```

The gate command differs from the issue's in one place: `--features uds` alone
does not compile the new module. `--features uds,uds-supervisor` is what covers
this change.

### How that entry came to say OK

Not a stale run, not a wrong directory, not a pre-rename invocation. The run was
real, in this worktree, at the right moment — over a file set that excluded
everything under review.

`check_test_pointers.sh` enumerates with `git ls-files '*.rs'` (line 502). I ran
it before `git add`, while all six files under
`crates/trusty-common/src/uds/supervisor/` were untracked. `git ls-files` does
not list untracked files, so the scan covered the rest of the repo, found it
clean, and exited 0. Nothing about the output distinguishes "your files passed"
from "your files were not looked at" — the counts are repo-wide.

`check_line_cap.sh` has the identical blind spot, visible in its own output:
**3784** tracked `.rs` files before `git add`, **3790** after. It passed either
way, so it cost nothing here, but it was measuring the same incomplete set.

The changelog gate is the counter-example: it failed loudly with *"Nothing was
examined, so this gate could not have failed"* (#4618), which is exactly the
guard the other two lack.

Fix, and what stops it recurring: **stage first, then gate.** Every row above was
re-run after `git add -A`. A `git ls-files`-driven gate run against an untracked
change is not a run of that gate, and its green is not evidence.

### Baseline reds under `--include-ignored`

`cargo test --no-fail-fast -p trusty-memory -- --include-ignored` is red with 8
failures in two `#[ignore]`d suites, neither of which this diff touches
(`git diff --name-only origin/main...HEAD` lists no file in either) and neither
of which references the supervisor at all (`grep -c supervisor` → 0 in both):

- `tests/concurrent_perf.rs` — 4 × `palace_create failed: no project root found
  at or above '/'`. Environmental: the spawned daemon's cwd is `/`.
- `tests/mcp_stdio_tools.rs` — 4 perf-threshold failures on a debug build, e.g.
  `kg_assert took 28.84825ms (budget: 10ms)`.

Not matched to a canonical issue by test name or panic text; reported rather than
suppressed. **Change-specific gates pass**; `--include-ignored` for
`trusty-memory` is blocked by these two pre-existing suites.

## Review round (critic WARN, two HIGH) — addressed at `060eda02`

- **HIGH 1** — five dangling `Test:` pointers, all citing names renamed during
  authoring. Corrected to `adoption_refuses_a_world_writable_socket` /
  `adoption_accepts_a_hardened_socket_without_spawning`,
  `a_serving_child_is_reused_without_a_spawn`,
  `a_dead_child_is_evicted_without_counting_as_a_reap`,
  `an_unserved_live_child_is_queued_for_graceful_termination`, and
  `probe_verdict_reports_not_serving_for_a_missing_socket`.
- **HIGH 2** — the gate table reported that red gate as green. Corrected above,
  with the cause.
- **MEDIUM 3** — nothing bound `shutdown_flush` to a service's real budget.
  `ServiceTimeouts` now carries the sourcing rule where the next implementer
  reads it: `shutdown_flush` MUST be the supervised binary's own flush constant,
  imported, never a literal; the assert enforces the relation and has no way to
  know the child's real budget, so a literal that understates it compiles, passes,
  and SIGKILLs mid-flush.
- **LOW 4** — `ServiceTimeouts::try_new` added for runtime-derived values, with
  `SupervisorError::InvalidTimeouts`. Covered by
  `try_new_rejects_an_inverted_pair_without_panicking` and
  `try_new_matches_new_for_a_valid_pair`.
- Consequence of adding the first fallible non-async constructor:
  `SupervisorError::UntrustedSocket` and `SocketPath` now box their
  `UdsSecurityError` source, which unboxed pushed the enum past clippy's
  `result_large_err` threshold.

## Versioning

`trusty-common` is 0.30.0 in-tree against a published max of 0.28.1 (checked
against the crates.io versions API, not assumed). Under Cargo's 0.x rule the
breaking position is MINOR, and 0.28 → 0.30 is already past it, so this additive
API needs no further bump.

Refs #5089. Owes a `code-critic` round after CI.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
