### PR TITLE
feat(trusty-console): webhook ingress with a spool that is durable before the ack (#5089 step 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11426,6 +11426,7 @@ dependencies = [
  "git2",
  "hex",
  "hf-hub 0.3.2",
+ "hmac 0.12.1",
  "hnsw_rs",
  "indexmap 2.14.0",
  "keyring",
@@ -11481,6 +11482,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "clap",
  "dirs 5.0.1",
  "http-body-util",
@@ -11491,6 +11493,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tower",
  "tower-http",

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -346,6 +346,14 @@ uds-supervisor = ["uds"]
 # copies in trusty-analyze and trusty-review. Pulls in `hmac`, and turns on the
 # `sha2` / `hex` deps this crate already declares optional.
 webhook-hmac = ["dep:hmac", "dep:sha2", "dep:hex"]
+# Enables the `webhook_relay` module: the console->target relay wire contract
+# (issue #5089 step 3, ADR-0034 §3). The sender is trusty-console and the
+# receivers are trusty-review / trusty-analyze, neither of which can depend on
+# the console — so the frame, its owned counterpart, and the ack-bearing
+# response live here where both halves read them. Implies `webhook-hmac`
+# because the frame's provenance record describes that verification. Adds no
+# new dependencies beyond `serde` / `serde_json`, already unconditional.
+webhook-relay = ["webhook-hmac"]
 # Bundle the ONNX Runtime static libs via fastembed's
 # `ort-download-binaries-native-tls`. Right choice for macOS and modern
 # Linux (glibc ≥ 2.38). Mutually exclusive with `embedder-load-dynamic`

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -158,6 +158,9 @@ genco = { version = "0.19", optional = true }
 # Heavy deps gated behind the feature so downstream crates that only
 # want chat / mcp / symgraph pay zero cost.
 hex = { workspace = true, optional = true }
+# Optional: enabled by the `webhook-hmac` feature (#5089 step 3). The GitHub
+# `X-Hub-Signature-256` verifier is the crate's only HMAC consumer.
+hmac = { workspace = true, optional = true }
 hnsw_rs = { workspace = true, optional = true }
 git2 = { workspace = true, optional = true }
 dashmap = { workspace = true, optional = true }
@@ -338,6 +341,11 @@ uds = ["dep:thiserror"]
 # Off by default so a consumer that only binds a socket does not compile the
 # child-process lifecycle.
 uds-supervisor = ["uds"]
+# Enables the `webhook_hmac` module: the single GitHub `X-Hub-Signature-256`
+# verifier (issue #5089 step 3, ADR-0034 §3), replacing the two divergent
+# copies in trusty-analyze and trusty-review. Pulls in `hmac`, and turns on the
+# `sha2` / `hex` deps this crate already declares optional.
+webhook-hmac = ["dep:hmac", "dep:sha2", "dep:hex"]
 # Bundle the ONNX Runtime static libs via fastembed's
 # `ort-download-binaries-native-tls`. Right choice for macOS and modern
 # Linux (glibc ≥ 2.38). Mutually exclusive with `embedder-load-dynamic`

--- a/crates/trusty-common/changelog.d/5089-console-ingress-spool.md
+++ b/crates/trusty-common/changelog.d/5089-console-ingress-spool.md
@@ -16,3 +16,12 @@ Added
   become permission to proceed — the shape of trusty-analyze's live fail-open
   (ADR-0034 §3). `sign_github_body` is the matching test-harness helper.
   trusty-analyze's and trusty-review's copies are retired in #5089 step 4
+- `webhook_relay` (feature `webhook-relay`) — the console→target relay wire
+  contract: `RELAY_METHOD`, the borrowed `RelayFrame` the sender writes, the
+  owned `RelayRequest` a receiver reads, `Provenance`, and `RelayResponse`.
+  It lives here rather than in trusty-console because step 4's receivers are
+  trusty-review and trusty-analyze, which cannot depend on the console — a
+  contract held by one half only is two copies waiting to drift.
+  `RelayResult::ack` is `#[serde(default)]` and `RelayResponse::is_ack` is the
+  only predicate a deletion path may consult, so a receiver that answers with
+  an empty result object has not acknowledged

--- a/crates/trusty-common/changelog.d/5089-console-ingress-spool.md
+++ b/crates/trusty-common/changelog.d/5089-console-ingress-spool.md
@@ -1,0 +1,18 @@
+Added
+
+- `uds::rpc::send_framed_request` — the shared one-request/one-response,
+  newline-framed JSON transport over a hardened Unix socket (ADR-0034 §4,
+  #5089 step 3). Dials through `connect_hardened`, so the socket's `0700`
+  directory and `0600` mode are verified before a byte is written; caps the
+  response at `MAX_FRAME_BYTES` and bounds the whole exchange with a
+  caller-supplied timeout. Errors are a `UdsRpcError` variant per failure
+  point, and none of them may be read as an acknowledgement. The four existing
+  hand-rolled clients (`embedder_client/uds.rs`, `bm25_client.rs`, and
+  trusty-agents' `ctrl/socket.rs` and `bus`) migrate onto it in a follow-up
+- `webhook_hmac` (feature `webhook-hmac`) — the single GitHub
+  `X-Hub-Signature-256` verifier. `verify_github_signature` returns a
+  three-state `SignatureVerdict` rather than a `bool`, so "no secret is
+  configured" cannot be collapsed into "the signature is wrong" and silently
+  become permission to proceed — the shape of trusty-analyze's live fail-open
+  (ADR-0034 §3). `sign_github_body` is the matching test-harness helper.
+  trusty-analyze's and trusty-review's copies are retired in #5089 step 4

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -746,6 +746,19 @@ pub mod health_probe;
 #[cfg(all(unix, feature = "uds"))]
 pub mod uds;
 
+/// GitHub webhook HMAC-SHA256 verification (#5089 step 3, ADR-0034 §3).
+///
+/// Why: the check exists twice today and the two copies disagree on what an
+/// unset secret means — `trusty-review` rejects, `trusty-analyze` processes the
+/// payload anyway. ADR-0034 §3 collapses verification to one place (console)
+/// and unifies the policy to fail-closed; this module is that place.
+/// What: Exposes [`webhook_hmac::verify_github_signature`], its three-state
+/// [`webhook_hmac::SignatureVerdict`], and [`webhook_hmac::sign_github_body`]
+/// for test harnesses.
+/// Test: `cargo test -p trusty-common --features webhook-hmac webhook_hmac::`.
+#[cfg(feature = "webhook-hmac")]
+pub mod webhook_hmac;
+
 /// Global tracing subscriber initialisation helpers.
 ///
 /// Why: Every trusty-* binary needs the same verbosity ladder, `RUST_LOG`

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -759,6 +759,20 @@ pub mod uds;
 #[cfg(feature = "webhook-hmac")]
 pub mod webhook_hmac;
 
+/// Console->target webhook relay wire contract (#5089 step 3, ADR-0034 §3).
+///
+/// Why: the sender (`trusty-console`) and the receivers (`trusty-review`,
+/// `trusty-analyze`) cannot depend on each other, so a method name or field
+/// list held by only one half is two copies waiting to drift.
+/// What: Exposes [`webhook_relay::RELAY_METHOD`], the borrowed
+/// [`webhook_relay::RelayFrame`] the sender writes, the owned
+/// [`webhook_relay::RelayRequest`] a receiver reads, and
+/// [`webhook_relay::RelayResponse`], whose `ack` is the only thing that
+/// licenses the sender to delete its spool entry.
+/// Test: `cargo test -p trusty-common --features webhook-relay webhook_relay::`.
+#[cfg(feature = "webhook-relay")]
+pub mod webhook_relay;
+
 /// Global tracing subscriber initialisation helpers.
 ///
 /// Why: Every trusty-* binary needs the same verbosity ladder, `RUST_LOG`

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -48,6 +48,7 @@ mod tests;
 
 pub mod dir;
 mod peer;
+pub mod rpc;
 
 /// On-demand supervision of a UDS-serving child process (#5089 step 2).
 ///
@@ -67,6 +68,7 @@ pub mod supervisor;
 
 pub use dir::prepare_socket_dir;
 pub use peer::{ensure_peer_is_self, peer_uid, self_uid};
+pub use rpc::{MAX_FRAME_BYTES, UdsRpcError, send_framed_request};
 #[cfg(feature = "uds-supervisor")]
 pub use supervisor::{
     ServiceTimeouts, SocketVerdict, SpawnSpec, SupervisorConfig, SupervisorError,

--- a/crates/trusty-common/src/uds/rpc.rs
+++ b/crates/trusty-common/src/uds/rpc.rs
@@ -1,0 +1,462 @@
+//! One request, one response, newline-framed JSON over a hardened Unix socket.
+//!
+//! Why: three call sites already speak this exact protocol by hand
+//! (`embedder_client/uds.rs`, `bm25_client.rs`, `trusty-agents`' `ctrl/socket.rs`)
+//! and #5089 step 3 adds a fourth — console relaying a verified webhook to
+//! `trusty-review` / `trusty-analyze`. Writing a fourth bespoke copy is what the
+//! common-entry-point rule exists to stop, and ADR-0034 §4 names the shared
+//! module explicitly. The three existing clients are migrated in a follow-up;
+//! this lands the entry point they migrate onto.
+//!
+//! What: [`send_framed_request`] dials through [`super::connect_hardened`] (so
+//! the socket's `0700` directory and `0600` mode are verified before a single
+//! byte of the request is written), writes one newline-terminated JSON frame,
+//! half-closes the write side, and reads one newline-terminated JSON frame back.
+//! The whole exchange is bounded by a caller-supplied timeout and the response
+//! by [`MAX_FRAME_BYTES`].
+//!
+//! Deliberately not JSON-RPC-aware: `Req` and `Resp` are whatever the caller
+//! names. The framing is the shared part; the envelope is not.
+//!
+//! Test: `tests.rs` — `send_framed_request_*` against a real listener bound
+//! through `bind_hardened`, covering the round trip, a server that closes
+//! without answering, an over-long frame, a malformed frame, an absent socket,
+//! and the timeout.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+
+use super::{UdsSecurityError, connect_hardened};
+
+/// Largest response frame [`send_framed_request`] will buffer, in bytes.
+///
+/// A peer that never sends a newline would otherwise grow the read buffer
+/// until the process dies. 8 MiB is far above any frame this workspace
+/// exchanges (the largest is an embedding batch) and far below a memory
+/// problem.
+pub const MAX_FRAME_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Everything that can go wrong on one framed exchange.
+///
+/// Every variant is terminal for the call — none is a "log and continue"
+/// condition, because continuing would mean treating an unanswered request as
+/// an answered one. `#[non_exhaustive]` for the same reason
+/// [`UdsSecurityError`] carries it: this list grows as the transport tightens.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum UdsRpcError {
+    /// The socket failed verification, or `connect` failed.
+    #[error("dial {path}: {source}")]
+    Dial {
+        /// Socket that could not be dialled.
+        path: PathBuf,
+        /// Why the dial was refused or failed.
+        #[source]
+        source: UdsSecurityError,
+    },
+
+    /// The request value could not be serialised.
+    #[error("serialize request frame for {path}: {source}")]
+    Encode {
+        /// Socket the frame was destined for.
+        path: PathBuf,
+        /// Underlying serde error.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// Writing the request frame failed.
+    #[error("write request frame to {path}: {source}")]
+    Write {
+        /// Socket that could not be written to.
+        path: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Reading the response frame failed.
+    #[error("read response frame from {path}: {source}")]
+    Read {
+        /// Socket that could not be read from.
+        path: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The peer closed the connection without writing a frame.
+    ///
+    /// Distinct from [`UdsRpcError::Read`] on purpose: "it hung up" and "the
+    /// read syscall failed" have different causes, and a caller deciding
+    /// whether to retry cares which one it got.
+    #[error("{path} closed the connection without sending a response frame")]
+    NoResponse {
+        /// Socket whose peer hung up.
+        path: PathBuf,
+    },
+
+    /// The peer sent more than [`MAX_FRAME_BYTES`] without a newline.
+    #[error("response frame from {path} exceeded {limit} bytes without a newline")]
+    FrameTooLarge {
+        /// Socket that overran the budget.
+        path: PathBuf,
+        /// The budget, in bytes.
+        limit: u64,
+    },
+
+    /// The response frame was not valid JSON for `Resp`.
+    #[error("decode response frame from {path}: {source}")]
+    Decode {
+        /// Socket that sent the frame.
+        path: PathBuf,
+        /// Underlying serde error.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// The exchange did not complete inside the caller's timeout.
+    #[error("{path} did not complete the exchange within {timeout:?}")]
+    Timeout {
+        /// Socket that did not answer in time.
+        path: PathBuf,
+        /// The budget that elapsed.
+        timeout: Duration,
+    },
+}
+
+/// Send one JSON frame to `path` and decode the one frame that comes back.
+///
+/// Why: the single entry point every UDS request/response client in this
+/// workspace routes through, so the framing contract, the pre-connect
+/// permission check, the size cap and the timeout land once rather than at
+/// four call sites (ADR-0034 §4, #5089 step 3).
+///
+/// What: dials via [`super::connect_hardened`], writes
+/// `serde_json::to_vec(request)` followed by `\n`, shuts down the write half
+/// (which is what lets a peer that reads to EOF proceed), then reads bytes up
+/// to and including the next `\n` and deserialises them as `Resp`. The entire
+/// sequence — including the connect — is wrapped in `timeout`.
+///
+/// A serialised JSON value never contains a bare newline outside a string
+/// literal, and inside one it is escaped, so appending `\n` is an unambiguous
+/// terminator for any `Req`.
+///
+/// # Errors
+///
+/// One [`UdsRpcError`] variant per failure point; see that enum. A returned
+/// error always means the request was *not* known to have been processed — a
+/// caller must not treat any of them as an acknowledgement.
+///
+/// Test: `send_framed_request_round_trips_a_typed_value`,
+/// `send_framed_request_reports_no_response_when_peer_hangs_up`,
+/// `send_framed_request_rejects_an_over_long_frame`,
+/// `send_framed_request_reports_a_decode_failure`,
+/// `send_framed_request_reports_dial_failure_for_a_missing_socket`,
+/// `send_framed_request_times_out_on_a_silent_peer`.
+pub async fn send_framed_request<Req, Resp>(
+    path: &Path,
+    request: &Req,
+    timeout: Duration,
+) -> Result<Resp, UdsRpcError>
+where
+    Req: Serialize + ?Sized,
+    Resp: DeserializeOwned,
+{
+    match tokio::time::timeout(timeout, exchange::<Req, Resp>(path, request)).await {
+        Ok(result) => result,
+        Err(_) => Err(UdsRpcError::Timeout {
+            path: path.to_path_buf(),
+            timeout,
+        }),
+    }
+}
+
+/// The un-timed body of [`send_framed_request`], split out so the timeout wraps
+/// exactly one future and the error mapping stays readable.
+async fn exchange<Req, Resp>(path: &Path, request: &Req) -> Result<Resp, UdsRpcError>
+where
+    Req: Serialize + ?Sized,
+    Resp: DeserializeOwned,
+{
+    let mut frame = serde_json::to_vec(request).map_err(|source| UdsRpcError::Encode {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    frame.push(b'\n');
+
+    let mut stream = connect_hardened(path)
+        .await
+        .map_err(|source| UdsRpcError::Dial {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    let write = async {
+        stream.write_all(&frame).await?;
+        stream.flush().await?;
+        // Half-close: the peer's `read_to_end`/`read_until` sees EOF and knows
+        // the request is complete. The read half stays open for the response.
+        stream.shutdown().await
+    };
+    write.await.map_err(|source| UdsRpcError::Write {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    let mut reader = BufReader::new(stream.take(MAX_FRAME_BYTES));
+    let mut line: Vec<u8> = Vec::new();
+    let read = reader
+        .read_until(b'\n', &mut line)
+        .await
+        .map_err(|source| UdsRpcError::Read {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    if read == 0 && line.is_empty() {
+        return Err(UdsRpcError::NoResponse {
+            path: path.to_path_buf(),
+        });
+    }
+    if !line.ends_with(b"\n") && line.len() as u64 >= MAX_FRAME_BYTES {
+        return Err(UdsRpcError::FrameTooLarge {
+            path: path.to_path_buf(),
+            limit: MAX_FRAME_BYTES,
+        });
+    }
+
+    serde_json::from_slice(&line).map_err(|source| UdsRpcError::Decode {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::uds::bind_hardened;
+    use serde::Deserialize;
+    use std::path::PathBuf;
+    use tokio::net::UnixListener;
+
+    #[derive(Debug, Serialize)]
+    struct Ping {
+        method: &'static str,
+        n: u32,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct Pong {
+        echoed: u32,
+    }
+
+    /// How a stub listener answers exactly one connection.
+    enum StubReply {
+        /// Read the request, then write these bytes verbatim.
+        Bytes(Vec<u8>),
+        /// Read the request, then drop the connection without writing.
+        HangUp,
+        /// Accept, then never write and never close.
+        Silence,
+    }
+
+    /// Bind a hardened socket in `dir` and serve one connection per `replies`.
+    ///
+    /// Returns the socket path; the listener task ends after the last reply.
+    fn spawn_stub(dir: &Path, replies: Vec<StubReply>) -> PathBuf {
+        let sock = dir.join("sockets").join("stub.sock");
+        let listener: UnixListener = bind_hardened(&sock).expect("bind stub socket");
+        tokio::spawn(async move {
+            for reply in replies {
+                let Ok((mut conn, _)) = listener.accept().await else {
+                    return;
+                };
+                // Drain the request frame so the client's write always lands.
+                let mut sink = Vec::new();
+                let _ = conn.read_to_end(&mut sink).await;
+                match reply {
+                    StubReply::Bytes(bytes) => {
+                        let _ = conn.write_all(&bytes).await;
+                        let _ = conn.flush().await;
+                    }
+                    StubReply::HangUp => {}
+                    StubReply::Silence => {
+                        // Hold the connection open past any test's timeout.
+                        tokio::time::sleep(Duration::from_secs(300)).await;
+                    }
+                }
+            }
+        });
+        sock
+    }
+
+    #[tokio::test]
+    async fn send_framed_request_round_trips_a_typed_value() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = spawn_stub(
+            tmp.path(),
+            vec![StubReply::Bytes(b"{\"echoed\":41}\n".to_vec())],
+        );
+
+        let got: Pong = send_framed_request(
+            &sock,
+            &Ping {
+                method: "ping",
+                n: 41,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("round trip");
+
+        assert_eq!(got, Pong { echoed: 41 });
+    }
+
+    #[tokio::test]
+    async fn send_framed_request_accepts_a_frame_without_a_trailing_newline() {
+        // Why: a peer that writes the JSON and closes is well-behaved enough —
+        // EOF terminates the frame just as a newline does. Rejecting it would
+        // strand a correct target behind a framing nicety.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = spawn_stub(
+            tmp.path(),
+            vec![StubReply::Bytes(b"{\"echoed\":7}".to_vec())],
+        );
+
+        let got: Pong = send_framed_request(
+            &sock,
+            &Ping {
+                method: "ping",
+                n: 7,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("round trip");
+
+        assert_eq!(got, Pong { echoed: 7 });
+    }
+
+    #[tokio::test]
+    async fn send_framed_request_reports_no_response_when_peer_hangs_up() {
+        // Why: this is the arm that must never be mistaken for success. A
+        // target that accepts the connection and then dies has NOT acknowledged
+        // the work, and #5089's whole point is that the caller can tell.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = spawn_stub(tmp.path(), vec![StubReply::HangUp]);
+
+        let err = send_framed_request::<_, Pong>(
+            &sock,
+            &Ping {
+                method: "ping",
+                n: 1,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("a silent hang-up is not a response");
+
+        assert!(
+            matches!(err, UdsRpcError::NoResponse { .. }),
+            "expected NoResponse, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_framed_request_rejects_an_over_long_frame() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // One byte past the budget, with no newline anywhere in it.
+        let flood = vec![b'x'; (MAX_FRAME_BYTES + 1) as usize];
+        let sock = spawn_stub(tmp.path(), vec![StubReply::Bytes(flood)]);
+
+        let err = send_framed_request::<_, Pong>(
+            &sock,
+            &Ping {
+                method: "ping",
+                n: 1,
+            },
+            Duration::from_secs(30),
+        )
+        .await
+        .expect_err("an unterminated flood must not be buffered without bound");
+
+        assert!(
+            matches!(err, UdsRpcError::FrameTooLarge { limit, .. } if limit == MAX_FRAME_BYTES),
+            "expected FrameTooLarge, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_framed_request_reports_a_decode_failure() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = spawn_stub(tmp.path(), vec![StubReply::Bytes(b"not json\n".to_vec())]);
+
+        let err = send_framed_request::<_, Pong>(
+            &sock,
+            &Ping {
+                method: "ping",
+                n: 1,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("garbage is not a response");
+
+        assert!(
+            matches!(err, UdsRpcError::Decode { .. }),
+            "expected Decode, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_framed_request_reports_dial_failure_for_a_missing_socket() {
+        // Why: the expected state until #5089 step 4 binds the target's
+        // listener. The relay must get a clean, classifiable failure here
+        // rather than a panic or a hang.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = tmp.path().join("sockets").join("absent.sock");
+
+        let err = send_framed_request::<_, Pong>(
+            &sock,
+            &Ping {
+                method: "ping",
+                n: 1,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("no listener means no delivery");
+
+        assert!(
+            matches!(err, UdsRpcError::Dial { .. }),
+            "expected Dial, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_framed_request_times_out_on_a_silent_peer() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = spawn_stub(tmp.path(), vec![StubReply::Silence]);
+
+        let err = send_framed_request::<_, Pong>(
+            &sock,
+            &Ping {
+                method: "ping",
+                n: 1,
+            },
+            Duration::from_millis(150),
+        )
+        .await
+        .expect_err("a peer that never answers must not hold the caller open");
+
+        assert!(
+            matches!(err, UdsRpcError::Timeout { .. }),
+            "expected Timeout, got {err:?}"
+        );
+    }
+}

--- a/crates/trusty-common/src/webhook_hmac.rs
+++ b/crates/trusty-common/src/webhook_hmac.rs
@@ -1,0 +1,211 @@
+//! GitHub webhook HMAC-SHA256 verification, over the exact received bytes.
+//!
+//! Why: the same check exists twice already — `trusty-analyze`'s
+//! `core/github.rs:210` and `trusty-review`'s
+//! `integrations/github/webhook.rs:27` — and they disagree on what an *unset*
+//! secret means: review returns 401, analyze logs a warning and processes the
+//! payload anyway (ADR-0034 Context, "how they disagree"). ADR-0034 §3 puts
+//! verification in exactly one place, at console, and unifies the unset-secret
+//! policy to fail-closed. This module is that place. #5089 step 3 routes
+//! console through it; step 4 retires the other two copies.
+//!
+//! What: [`verify_github_signature`] returns a three-state
+//! [`SignatureVerdict`] rather than a `bool`, because "no secret is configured"
+//! and "the signature is wrong" are different operator problems that both have
+//! to fail closed. The digest is computed over the raw body bytes — the HMAC
+//! covers the literal request body, so a caller must pass what arrived on the
+//! wire, never a re-serialised value.
+//!
+//! Test: `tests` below — a valid signature, a wrong secret, an empty secret, a
+//! missing `sha256=` prefix, non-hex, a truncated digest, and a body mutated by
+//! one byte.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+/// Algorithm name recorded in a relayed frame's provenance record.
+///
+/// ADR-0034 §3 requires the frame to state which algorithm was checked, so a
+/// target can tell a verified delivery from an unverified one without
+/// re-deriving it from the header name.
+pub const HMAC_ALGORITHM: &str = "hmac-sha256";
+
+/// The header GitHub carries the digest in.
+pub const SIGNATURE_HEADER: &str = "x-hub-signature-256";
+
+/// Outcome of verifying one delivery.
+///
+/// Why: a `bool` cannot distinguish "the operator never configured a secret"
+/// from "someone sent a forged payload", and collapsing them is how
+/// `trusty-analyze` ended up treating the first as permission to proceed.
+/// Both are refusals here; only the diagnostic differs.
+/// What: three variants, of which exactly one means the payload may be used.
+/// Test: every `verify_github_signature_*` test asserts on a specific variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignatureVerdict {
+    /// The digest matched. The body is authentic.
+    Valid,
+    /// No secret is configured, so nothing can be verified. Fail closed.
+    SecretMissing,
+    /// A secret is configured and the digest did not match, was malformed, or
+    /// was absent.
+    Invalid,
+}
+
+impl SignatureVerdict {
+    /// True only for [`SignatureVerdict::Valid`].
+    ///
+    /// Exists so a call site cannot accidentally write `!= Invalid` and let
+    /// `SecretMissing` through.
+    pub fn is_valid(self) -> bool {
+        matches!(self, SignatureVerdict::Valid)
+    }
+}
+
+/// Verify a GitHub `X-Hub-Signature-256` digest against the raw body.
+///
+/// Why: the single entry point for this check (ADR-0034 §3, "Verification
+/// happens exactly once, at console, over the exact bytes GitHub sent"). Any
+/// re-framing of the body destroys the ability to verify it, so this must run
+/// before the payload is parsed, copied, or re-encoded.
+///
+/// What: rejects an empty or whitespace-only `secret` with
+/// [`SignatureVerdict::SecretMissing`]; otherwise parses the `sha256=<hex>`
+/// header, decodes the hex, and constant-time compares it against
+/// `HMAC-SHA256(secret, body)` via `Mac::verify_slice`. Any parse or decode
+/// failure is [`SignatureVerdict::Invalid`], never an error return, so the
+/// caller emits one uniform 401 for every refusal and leaks nothing about
+/// which step failed.
+///
+/// Test: `verify_github_signature_accepts_a_valid_digest`,
+/// `verify_github_signature_rejects_a_wrong_secret`,
+/// `verify_github_signature_reports_a_missing_secret`,
+/// `verify_github_signature_rejects_a_missing_prefix`,
+/// `verify_github_signature_rejects_non_hex`,
+/// `verify_github_signature_rejects_a_truncated_digest`,
+/// `verify_github_signature_rejects_a_one_byte_body_change`.
+pub fn verify_github_signature(
+    secret: &str,
+    body: &[u8],
+    signature_header: &str,
+) -> SignatureVerdict {
+    if secret.trim().is_empty() {
+        return SignatureVerdict::SecretMissing;
+    }
+    let Some(hex_sig) = signature_header.strip_prefix("sha256=") else {
+        return SignatureVerdict::Invalid;
+    };
+    let Ok(expected) = hex::decode(hex_sig) else {
+        return SignatureVerdict::Invalid;
+    };
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(secret.as_bytes()) else {
+        return SignatureVerdict::Invalid;
+    };
+    mac.update(body);
+    if mac.verify_slice(&expected).is_ok() {
+        SignatureVerdict::Valid
+    } else {
+        SignatureVerdict::Invalid
+    }
+}
+
+/// Produce the `sha256=<hex>` header value for `body` under `secret`.
+///
+/// Why: every test in this workspace that exercises a webhook path needs to
+/// mint a valid signature, and three copies of that helper already exist in
+/// test modules. Exposing it from the crate that owns verification keeps the
+/// signing and checking halves from drifting.
+/// What: `format!("sha256={}", hex(HMAC-SHA256(secret, body)))`.
+/// Test: used as the input to `verify_github_signature_accepts_a_valid_digest`.
+pub fn sign_github_body(secret: &str, body: &[u8]) -> String {
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes())
+        .expect("HMAC-SHA256 accepts a key of any length");
+    mac.update(body);
+    format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &str = "test-hmac-key"; // pragma: allowlist secret
+    const BODY: &[u8] = br#"{"action":"review_requested","number":7}"#;
+
+    #[test]
+    fn verify_github_signature_accepts_a_valid_digest() {
+        let header = sign_github_body(SECRET, BODY);
+        assert_eq!(
+            verify_github_signature(SECRET, BODY, &header),
+            SignatureVerdict::Valid
+        );
+    }
+
+    #[test]
+    fn verify_github_signature_rejects_a_wrong_secret() {
+        let header = sign_github_body("some-other-secret", BODY); // pragma: allowlist secret
+        assert_eq!(
+            verify_github_signature(SECRET, BODY, &header),
+            SignatureVerdict::Invalid
+        );
+    }
+
+    #[test]
+    fn verify_github_signature_reports_a_missing_secret() {
+        let header = sign_github_body(SECRET, BODY);
+        // An unset secret and a whitespace-only one are the same operator
+        // mistake and must not be distinguishable from a wrong signature by
+        // the caller's response.
+        for empty in ["", "   ", "\t\n"] {
+            assert_eq!(
+                verify_github_signature(empty, BODY, &header),
+                SignatureVerdict::SecretMissing,
+                "secret {empty:?}"
+            );
+            assert!(!verify_github_signature(empty, BODY, &header).is_valid());
+        }
+    }
+
+    #[test]
+    fn verify_github_signature_rejects_a_missing_prefix() {
+        let signed = sign_github_body(SECRET, BODY);
+        let bare = signed.trim_start_matches("sha256=");
+        assert_eq!(
+            verify_github_signature(SECRET, BODY, bare),
+            SignatureVerdict::Invalid
+        );
+        assert_eq!(
+            verify_github_signature(SECRET, BODY, ""),
+            SignatureVerdict::Invalid
+        );
+    }
+
+    #[test]
+    fn verify_github_signature_rejects_non_hex() {
+        assert_eq!(
+            verify_github_signature(SECRET, BODY, "sha256=zzzz"),
+            SignatureVerdict::Invalid
+        );
+    }
+
+    #[test]
+    fn verify_github_signature_rejects_a_truncated_digest() {
+        let signed = sign_github_body(SECRET, BODY);
+        let truncated = &signed[..signed.len() - 4];
+        assert_eq!(
+            verify_github_signature(SECRET, BODY, truncated),
+            SignatureVerdict::Invalid
+        );
+    }
+
+    #[test]
+    fn verify_github_signature_rejects_a_one_byte_body_change() {
+        let header = sign_github_body(SECRET, BODY);
+        let mut mutated = BODY.to_vec();
+        let last = mutated.len() - 1;
+        mutated[last] ^= 0x01;
+        assert_eq!(
+            verify_github_signature(SECRET, &mutated, &header),
+            SignatureVerdict::Invalid
+        );
+    }
+}

--- a/crates/trusty-common/src/webhook_relay.rs
+++ b/crates/trusty-common/src/webhook_relay.rs
@@ -1,0 +1,336 @@
+//! The console→target webhook relay wire contract (ADR-0034 §3, #5089 step 3).
+//!
+//! Why: the sender is `trusty-console` and the receivers are `trusty-review`
+//! and `trusty-analyze`, neither of which can depend on the console. A method
+//! name or field name that lives in only one half is not a contract — it is two
+//! copies waiting to drift, which is what the common-entry-point rule exists to
+//! stop. Both halves read the types here.
+//!
+//! What: [`RELAY_METHOD`]; the borrowed [`RelayFrame`] the sender serialises
+//! (borrowed so the raw body is forwarded rather than re-encoded — the HMAC
+//! covers the literal bytes); the owned [`RelayRequest`] the receiver
+//! deserialises; and [`RelayResponse`], whose `ack` field is the only thing that
+//! licenses the sender to delete its spool entry.
+//!
+//! 🔴 [`RelayResult::ack`] is `#[serde(default)]`, so a receiver that answers
+//! with a result object lacking the field has NOT acknowledged. The default has
+//! to be the safe direction: treating any answer as success is the silent loss
+//! ADR-0034 §2 forbids, one layer below the one it is fixing.
+//!
+//! Test: `tests` below cover the sender→receiver round trip over the real
+//! types, the ack/refuse constructors, and the missing-`ack` default.
+//! `trusty-console`'s `webhook/tests.rs` exercises the frame over a real socket.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// JSON-RPC method a target implements to accept a relayed delivery.
+pub const RELAY_METHOD: &str = "webhook.deliver";
+
+/// JSON-RPC version string both halves send.
+pub const JSONRPC_VERSION: &str = "2.0";
+
+/// What the sender proves to the receiver about a relayed body.
+///
+/// Why: ADR-0034 §3 — the receiver trusts this assertion because only a
+/// same-uid process could have written it through a `0600` socket. Recording
+/// the algorithm and key id explicitly, rather than letting the receiver infer
+/// "it came over UDS so it is fine", is what keeps the trust boundary named
+/// instead of assumed.
+/// What: three fields, carried verbatim in the frame and stored verbatim in the
+/// sender's spool entry.
+/// Test: `relay_frame_round_trips_through_the_owned_request`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Provenance {
+    /// Algorithm the sender checked, e.g. `hmac-sha256`.
+    pub algorithm: String,
+    /// Which secret was used, by name — never the secret itself.
+    pub key_id: String,
+    /// Whether verification succeeded. Always `true` on the wire: the sender
+    /// refuses an unverified delivery before it reaches the spool.
+    pub verified: bool,
+}
+
+/// The frame the sender writes, borrowing every payload field.
+///
+/// Why: ADR-0034 §3 requires the raw body verbatim so a receiver retains the
+/// option of re-verifying the HMAC independently. Borrowing rather than owning
+/// makes it structurally impossible for a sender to transform the body on the
+/// way through.
+/// What: JSON-RPC 2.0 request; `id` is the delivery GUID so a receiver's logs
+/// correlate with GitHub's delivery list without a second identifier.
+/// Test: `relay_frame_round_trips_through_the_owned_request`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RelayFrame<'a> {
+    /// Always [`JSONRPC_VERSION`].
+    pub jsonrpc: &'static str,
+    /// Always [`RELAY_METHOD`].
+    pub method: &'static str,
+    /// The delivery GUID.
+    pub id: &'a str,
+    /// The delivery itself.
+    pub params: RelayParams<'a>,
+}
+
+/// Params of a [`RelayFrame`].
+#[derive(Debug, Clone, Serialize)]
+pub struct RelayParams<'a> {
+    /// GitHub's `X-GitHub-Delivery` GUID.
+    pub delivery_id: &'a str,
+    /// Which ingress route the delivery arrived on (`review` / `analyze`).
+    pub source: &'a str,
+    /// The `X-GitHub-Event` value.
+    pub event: &'a str,
+    /// Original request headers, lowercased.
+    pub headers: &'a BTreeMap<String, String>,
+    /// The raw body, base64, byte-exact as received.
+    pub body_b64: &'a str,
+    /// What the sender verified, and with which key.
+    pub provenance: &'a Provenance,
+    /// When the sender accepted the delivery.
+    pub received_at_unix_ms: u64,
+    /// How many relay attempts have already failed, so a receiver can tell a
+    /// first delivery from a retry.
+    ///
+    /// 🔴 Relay is at-least-once by construction: the sender keeps the entry
+    /// until an explicit ack, so a receiver that acknowledges after doing the
+    /// work can still be re-sent the same `delivery_id` if the ack is lost.
+    /// Receivers must deduplicate on `delivery_id`; a non-zero `attempts` is a
+    /// hint, never a guarantee that the first attempt did nothing.
+    pub attempts: u32,
+}
+
+impl<'a> RelayFrame<'a> {
+    /// Build a frame from borrowed parts.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        delivery_id: &'a str,
+        source: &'a str,
+        event: &'a str,
+        headers: &'a BTreeMap<String, String>,
+        body_b64: &'a str,
+        provenance: &'a Provenance,
+        received_at_unix_ms: u64,
+        attempts: u32,
+    ) -> Self {
+        Self {
+            jsonrpc: JSONRPC_VERSION,
+            method: RELAY_METHOD,
+            id: delivery_id,
+            params: RelayParams {
+                delivery_id,
+                source,
+                event,
+                headers,
+                body_b64,
+                provenance,
+                received_at_unix_ms,
+                attempts,
+            },
+        }
+    }
+}
+
+/// The receiver's owned view of a [`RelayFrame`].
+///
+/// Why: a target crate cannot deserialise into borrowed `&'a str` fields from a
+/// framed read, and duplicating the field names on its side is how the two
+/// halves drift. This is the same contract, owned.
+/// What: mirrors [`RelayFrame`] field for field.
+/// Test: `relay_frame_round_trips_through_the_owned_request`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct RelayRequest {
+    /// JSON-RPC version.
+    pub jsonrpc: String,
+    /// Method name; a receiver must reject anything but [`RELAY_METHOD`].
+    pub method: String,
+    /// The delivery GUID, echoed as the request id.
+    pub id: String,
+    /// The delivery.
+    pub params: RelayDelivery,
+}
+
+/// Owned params of a [`RelayRequest`]. See [`RelayParams`] for field semantics.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct RelayDelivery {
+    /// GitHub's `X-GitHub-Delivery` GUID.
+    pub delivery_id: String,
+    /// Which ingress route the delivery arrived on.
+    pub source: String,
+    /// The `X-GitHub-Event` value.
+    pub event: String,
+    /// Original request headers, lowercased.
+    pub headers: BTreeMap<String, String>,
+    /// The raw body, base64, byte-exact as received.
+    pub body_b64: String,
+    /// What the sender verified.
+    pub provenance: Provenance,
+    /// When the sender accepted the delivery.
+    pub received_at_unix_ms: u64,
+    /// Failed attempts so far. See [`RelayParams::attempts`] on why this is a
+    /// hint and deduplication on `delivery_id` is mandatory.
+    #[serde(default)]
+    pub attempts: u32,
+}
+
+/// The receiver's answer.
+///
+/// Why: the sender deletes a durable spool entry on the strength of this, so
+/// the shape has to make "did not acknowledge" the default rather than an
+/// explicit denial the receiver might forget to send.
+/// What: JSON-RPC-shaped. Both fields optional; a response with neither is
+/// treated as a refusal.
+/// Test: `relay_response_without_ack_is_not_an_ack`, `relay_response_ack`,
+/// `relay_response_refuse`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RelayResponse {
+    /// Present on success-shaped answers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<RelayResult>,
+    /// Present on error-shaped answers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<RelayRpcError>,
+}
+
+/// Result half of a [`RelayResponse`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RelayResult {
+    /// 🔴 The single field that permits deleting the sender's spool entry.
+    /// `#[serde(default)]` — absent means **not** acknowledged.
+    #[serde(default)]
+    pub ack: bool,
+    /// Optional human-readable detail, recorded in the sender's durable entry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// Error half of a [`RelayResponse`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RelayRpcError {
+    /// JSON-RPC error code.
+    #[serde(default)]
+    pub code: i64,
+    /// Human-readable reason, recorded in the sender's durable entry.
+    #[serde(default)]
+    pub message: String,
+}
+
+impl RelayResponse {
+    /// The receiver has taken responsibility for the delivery.
+    ///
+    /// Only send this once the work is durable on the receiver's side —
+    /// the sender deletes its own copy the moment it arrives.
+    pub fn ack() -> Self {
+        Self {
+            result: Some(RelayResult {
+                ack: true,
+                detail: None,
+            }),
+            error: None,
+        }
+    }
+
+    /// The receiver declines; the sender keeps the entry and retries.
+    pub fn refuse(code: i64, message: impl Into<String>) -> Self {
+        Self {
+            result: None,
+            error: Some(RelayRpcError {
+                code,
+                message: message.into(),
+            }),
+        }
+    }
+
+    /// True only when the receiver explicitly acknowledged.
+    ///
+    /// The one predicate a deletion path may consult, so no call site can spell
+    /// "no error, therefore done".
+    pub fn is_ack(&self) -> bool {
+        self.error.is_none() && self.result.as_ref().is_some_and(|r| r.ack)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provenance() -> Provenance {
+        Provenance {
+            algorithm: "hmac-sha256".to_string(),
+            key_id: "GITHUB_WEBHOOK_SECRET".to_string(),
+            verified: true,
+        }
+    }
+
+    #[test]
+    fn relay_frame_round_trips_through_the_owned_request() {
+        // The contract's whole point: what the console writes is exactly what a
+        // target crate reads, with no per-side field list to drift.
+        let headers = BTreeMap::from([("x-github-event".to_string(), "pull_request".to_string())]);
+        let prov = provenance();
+        let frame = RelayFrame::new(
+            "abc-123",
+            "review",
+            "pull_request",
+            &headers,
+            "eyJhIjoxfQ==",
+            &prov,
+            1_700_000_000_000,
+            2,
+        );
+
+        let bytes = serde_json::to_vec(&frame).expect("serialize frame");
+        let got: RelayRequest = serde_json::from_slice(&bytes).expect("deserialize frame");
+
+        assert_eq!(got.jsonrpc, JSONRPC_VERSION);
+        assert_eq!(got.method, RELAY_METHOD);
+        assert_eq!(got.id, "abc-123");
+        assert_eq!(got.params.delivery_id, "abc-123");
+        assert_eq!(got.params.source, "review");
+        assert_eq!(got.params.event, "pull_request");
+        assert_eq!(got.params.headers, headers);
+        assert_eq!(got.params.body_b64, "eyJhIjoxfQ==");
+        assert_eq!(got.params.provenance, prov);
+        assert_eq!(got.params.received_at_unix_ms, 1_700_000_000_000);
+        assert_eq!(got.params.attempts, 2);
+    }
+
+    #[test]
+    fn relay_response_without_ack_is_not_an_ack() {
+        // A receiver that answers with an empty result object has done nothing.
+        for raw in [r#"{"result":{}}"#, r#"{}"#, r#"{"result":{"ack":false}}"#] {
+            let resp: RelayResponse = serde_json::from_str(raw).expect("parse");
+            assert!(!resp.is_ack(), "{raw} must not read as an acknowledgement");
+        }
+    }
+
+    #[test]
+    fn relay_response_ack() {
+        let resp = RelayResponse::ack();
+        assert!(resp.is_ack());
+        let round: RelayResponse =
+            serde_json::from_slice(&serde_json::to_vec(&resp).expect("ser")).expect("de");
+        assert!(round.is_ack());
+    }
+
+    #[test]
+    fn relay_response_refuse() {
+        let resp = RelayResponse::refuse(-32000, "dedup store locked");
+        assert!(!resp.is_ack());
+        assert_eq!(
+            resp.error.as_ref().map(|e| e.message.as_str()),
+            Some("dedup store locked")
+        );
+    }
+
+    #[test]
+    fn relay_response_with_both_halves_is_not_an_ack() {
+        // A malformed receiver that sends result AND error must not be read as
+        // success just because the result happens to say so.
+        let resp: RelayResponse =
+            serde_json::from_str(r#"{"result":{"ack":true},"error":{"code":-1,"message":"x"}}"#)
+                .expect("parse");
+        assert!(!resp.is_ack());
+    }
+}

--- a/crates/trusty-console/Cargo.toml
+++ b/crates/trusty-console/Cargo.toml
@@ -52,7 +52,7 @@ mime_guess         = { workspace = true }
 # `axum-server` (#3304): the shared same-origin write guard the console consumes
 # via `routes::origin_guard`. `uds` + `webhook-hmac` (#5089 step 3): the hardened
 # UDS dial/framing the webhook relay uses and the single GitHub HMAC verifier.
-trusty-common      = { workspace = true, features = ["stdio-mcp-client", "console-metrics", "config-cli", "axum-server", "uds", "webhook-hmac"] }
+trusty-common      = { workspace = true, features = ["stdio-mcp-client", "console-metrics", "config-cli", "axum-server", "uds", "webhook-hmac", "webhook-relay"] }
 reqwest            = { workspace = true }
 thiserror          = { workspace = true }
 # Spool entries hold the raw webhook body byte-exact; base64 keeps the JSON

--- a/crates/trusty-console/Cargo.toml
+++ b/crates/trusty-console/Cargo.toml
@@ -49,8 +49,15 @@ which              = { workspace = true }
 open               = { workspace = true }
 rust-embed         = { workspace = true }
 mime_guess         = { workspace = true }
-trusty-common      = { workspace = true, features = ["stdio-mcp-client", "console-metrics", "config-cli", "axum-server"] }  # `axum-server` (#3304): the shared same-origin write guard the console consumes via `routes::origin_guard`
+# `axum-server` (#3304): the shared same-origin write guard the console consumes
+# via `routes::origin_guard`. `uds` + `webhook-hmac` (#5089 step 3): the hardened
+# UDS dial/framing the webhook relay uses and the single GitHub HMAC verifier.
+trusty-common      = { workspace = true, features = ["stdio-mcp-client", "console-metrics", "config-cli", "axum-server", "uds", "webhook-hmac"] }
 reqwest            = { workspace = true }
+thiserror          = { workspace = true }
+# Spool entries hold the raw webhook body byte-exact; base64 keeps the JSON
+# container from corrupting bytes the HMAC was computed over.
+base64             = { workspace = true }
 
 [dev-dependencies]
 tempfile       = { workspace = true }

--- a/crates/trusty-console/changelog.d/5089-console-ingress-spool.md
+++ b/crates/trusty-console/changelog.d/5089-console-ingress-spool.md
@@ -1,0 +1,19 @@
+Added
+
+- `POST /api/webhooks/{source}` — GitHub webhook ingress that verifies the HMAC
+  once over the exact received bytes, writes the delivery to an fsync'd spool
+  under the console data directory, and only then acknowledges (#5089 step 3,
+  ADR-0034). `{source}` multiplexes `review` and `analyze`; each relays over a
+  hardened Unix socket. The ordering is the point: a spool write that fails
+  returns **5xx and no 202**, so GitHub keeps the delivery redeliverable, where
+  both existing handlers return 202 first and downgrade every later failure to
+  a log line GitHub will never retry
+- a relay outcome other than an explicit `"ack": true` leaves the spool entry
+  `pending` with an incremented attempt count and a durable reason. Reaching
+  the target is deliberately not enough — an entry is deleted only on the
+  target's own acknowledgement
+- `GET /api/console/metrics/webhooks` — oldest-pending-age, pending count and
+  failed-attempt total as a standard `ConsoleMetricsReport`, red once the
+  oldest entry passes the threshold. The scan runs on the request rather than
+  from a cache, so the signal does not go quiet if the background retry sweep
+  stops; a spool that cannot be read is red rather than empty

--- a/crates/trusty-console/changelog.d/5089-console-ingress-spool.md
+++ b/crates/trusty-console/changelog.d/5089-console-ingress-spool.md
@@ -12,8 +12,22 @@ Added
   `pending` with an incremented attempt count and a durable reason. Reaching
   the target is deliberately not enough — an entry is deleted only on the
   target's own acknowledgement
+- the route accepts bodies up to 25 MiB. axum's 2 MiB `DefaultBodyLimit` would
+  413 a real `push` / `pull_request` delivery *before* the handler runs — no
+  spool entry, no metric, no log — which is the same invisible drop arriving
+  through the framework instead of the code
 - `GET /api/console/metrics/webhooks` — oldest-pending-age, pending count and
   failed-attempt total as a standard `ConsoleMetricsReport`, red once the
   oldest entry passes the threshold. The scan runs on the request rather than
   from a cache, so the signal does not go quiet if the background retry sweep
-  stops; a spool that cannot be read is red rather than empty
+  stops. A spool directory that cannot be read — including one that was opened
+  and has since been removed or unmounted — is red, never an empty listing
+- retries are claimed and backed off. A `ClaimSet` gives one relay per entry at
+  a time, so a sweep tick landing inside the request path's own relay window
+  cannot send the same delivery twice; `BackoffPolicy` spaces attempts
+  exponentially (30 s doubling to a 1 h ceiling) and stops at 24 failures. An
+  exhausted entry is never relayed again and never deleted — it holds the
+  health signal red until an operator intervenes
+- a fresh entry is committed with `hard_link`, not `rename`, so a colliding
+  path fails atomically instead of clobbering a delivery that may already have
+  been acknowledged

--- a/crates/trusty-console/changelog.d/5089-console-ingress-spool.md
+++ b/crates/trusty-console/changelog.d/5089-console-ingress-spool.md
@@ -25,9 +25,23 @@ Added
 - retries are claimed and backed off. A `ClaimSet` gives one relay per entry at
   a time, so a sweep tick landing inside the request path's own relay window
   cannot send the same delivery twice; `BackoffPolicy` spaces attempts
-  exponentially (30 s doubling to a 1 h ceiling) and stops at 24 failures. An
-  exhausted entry is never relayed again and never deleted — it holds the
-  health signal red until an operator intervenes
+  exponentially (30 s doubling to a 1 h ceiling) and stops at 24 failures
+- an entry past that limit is moved to `webhook-spool/exhausted/` rather than
+  deleted or left in place. It is still an unacknowledged webhook, so it is
+  kept and it keeps the health signal red — but it stops being read and
+  JSON-decoded by every sweep tick and every metrics request, which with no
+  target listener yet is otherwise the fate of every delivery
+- the health scan reads receipt times from entry filenames and decodes exactly
+  one file — the oldest live entry — instead of the whole spool. `pending` and
+  `exhausted` are counted separately, and `oldest_pending_*` describes the
+  oldest LIVE entry: exhausted ones are permanently the oldest, so including
+  them froze the diagnostics on the first poisoned delivery and a genuinely
+  new failure moved nothing an operator reads. `total_failed_attempts` is
+  replaced by `oldest_pending_attempts`, which costs one decode instead of one
+  per entry
+- spool I/O runs on `spawn_blocking`. Ingest fsyncs a file and a directory
+  twice per delivery and the metrics route scans two directories per request;
+  none of that belongs on a runtime worker thread
 - a fresh entry is committed with `hard_link`, not `rename`, so a colliding
   path fails atomically instead of clobbering a delivery that may already have
   been acknowledged

--- a/crates/trusty-console/changelog.d/5089-console-ingress-spool.md
+++ b/crates/trusty-console/changelog.d/5089-console-ingress-spool.md
@@ -25,7 +25,11 @@ Added
 - retries are claimed and backed off. A `ClaimSet` gives one relay per entry at
   a time, so a sweep tick landing inside the request path's own relay window
   cannot send the same delivery twice; `BackoffPolicy` spaces attempts
-  exponentially (30 s doubling to a 1 h ceiling) and stops at 24 failures
+  exponentially (30 s doubling to a 1 h ceiling) and stops at 24 failures. The
+  claim is taken on the entry's path *before* the durable write, not after —
+  claiming afterwards left the entry on disk and unclaimed for the width of one
+  scheduler poll, and a sweep landing there relayed a delivery the request path
+  was about to relay itself
 - an entry past that limit is moved to `webhook-spool/exhausted/` rather than
   deleted or left in place. It is still an unacknowledged webhook, so it is
   kept and it keeps the health signal red — but it stops being read and

--- a/crates/trusty-console/src/lib.rs
+++ b/crates/trusty-console/src/lib.rs
@@ -49,6 +49,14 @@ pub mod proxy;
 pub mod routes;
 pub mod server;
 pub mod service;
+pub mod webhook;
+
+/// How often the background sweep re-attempts pending webhook deliveries.
+///
+/// The sweep is the *recovery* mechanism, not the detection one — a stuck
+/// delivery is detected by `GET /api/console/metrics/webhooks`, which scans the
+/// spool on the request and therefore stays honest even if this loop dies.
+const WEBHOOK_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 pub(crate) mod url_util;
 
 // ─── CLI ─────────────────────────────────────────────────────────────────────
@@ -414,7 +422,20 @@ pub async fn run_serve(args: ServeArgs) -> Result<()> {
     // not 403'd by the same-origin guard. Loopback stays trusted unconditionally
     // regardless of bind mode.
     let self_origins = routes::origin_guard::SelfOrigins::from_bind_addrs(&addrs);
-    let router = server::build_router_with_self_origins(state.clone(), self_origins);
+
+    // ── webhook ingress (#5089 step 3, ADR-0034) ────────────────────────────
+    // `?` on purpose: a console that cannot open its spool must not start and
+    // serve `/api/webhooks/{source}` anyway, because a delivery it cannot
+    // durably record is a delivery it must refuse — and an unmounted route
+    // would 404 instead of 5xx, which GitHub logs and no one reads.
+    let ingress = webhook::WebhookIngress::from_env()
+        .context("open the webhook spool under the console data directory")?;
+    info!(
+        spool = %ingress.spool().root().display(),
+        "webhook ingress ready at POST /api/webhooks/{{source}}"
+    );
+    webhook::start_retry_sweep(ingress.clone(), WEBHOOK_RETRY_INTERVAL);
+    let router = server::build_router_with_webhooks(state.clone(), self_origins, ingress);
 
     // ── bind primary listener ───────────────────────────────────────────────
     let primary_addr = *addrs.first().context("bind address list is empty")?;

--- a/crates/trusty-console/src/server/mod.rs
+++ b/crates/trusty-console/src/server/mod.rs
@@ -7,6 +7,11 @@
 //!   - `GET /health` — liveness probe.
 //!   - `GET /api/console/services` — return cached snapshot (background poll).
 //!   - `GET /api/console/metrics/{analyze,memory,search,review,mpm}` — MCP-polled metrics.
+//!   - `POST /api/webhooks/{source}` — GitHub webhook ingress: verify once,
+//!     spool durably, relay over UDS (#5089 step 3, ADR-0034). Mounted only by
+//!     [`build_router_with_webhooks`].
+//!   - `GET /api/console/metrics/webhooks` — oldest-pending spool age as a red
+//!     health state.
 //!   - `GET /api/console/metrics/analyze/indexes` — analyze index list via stdio MCP.
 //!   - `GET /api/console/metrics/analyze/visualize?index=<id>` — graph+entities+clusters.
 //!   - `…/api/console/sessions/*` — the single HTTP front door for the trusty-mpm
@@ -295,6 +300,27 @@ pub fn build_router(state: AppState) -> Router {
     build_router_with_self_origins(state, crate::routes::origin_guard::SelfOrigins::default())
 }
 
+/// Build the router with the webhook ingress mounted (#5089 step 3).
+///
+/// Why: the ingress owns a spool directory, so constructing it can fail — and
+/// it must fail loudly at startup rather than silently leaving
+/// `/api/webhooks/{source}` unrouted, which would turn every delivery into a
+/// `404` GitHub records as a failure nobody looks at. Keeping it a separate
+/// parameter lets `run_serve` do that fallible construction once while the
+/// existing infallible `build_router` call sites (and every test that does not
+/// exercise webhooks) stay unchanged.
+/// What: identical to [`build_router_with_self_origins`], plus
+/// `POST /api/webhooks/{source}` and `GET /api/console/metrics/webhooks`, both
+/// carrying `WebhookIngress` as their own state.
+/// Test: the `route_*` and `metrics_route_*` cases in `webhook/tests.rs`.
+pub fn build_router_with_webhooks(
+    state: AppState,
+    self_origins: crate::routes::origin_guard::SelfOrigins,
+    ingress: crate::webhook::WebhookIngress,
+) -> Router {
+    build_router_inner(state, self_origins, Some(ingress))
+}
+
 /// Build the axum `Router` with all routes wired, additionally trusting the
 /// given bind-derived, non-loopback self-origins for the write-origin guard.
 ///
@@ -314,7 +340,17 @@ pub fn build_router_with_self_origins(
     state: AppState,
     self_origins: crate::routes::origin_guard::SelfOrigins,
 ) -> Router {
-    Router::new()
+    build_router_inner(state, self_origins, None)
+}
+
+/// The one router definition both public builders delegate to, so the mounted
+/// route set cannot drift between them.
+fn build_router_inner(
+    state: AppState,
+    self_origins: crate::routes::origin_guard::SelfOrigins,
+    webhook: Option<crate::webhook::WebhookIngress>,
+) -> Router {
+    let core = Router::new()
         .route("/health", get(health_handler))
         .route("/api/console/services", get(services_handler))
         .route("/api/console/metrics/analyze", get(metrics_analyze_handler))
@@ -399,7 +435,31 @@ pub fn build_router_with_self_origins(
         .route("/ui", get(spa_index_handler))
         .route("/ui/", get(spa_index_handler))
         .route("/ui/{*path}", get(spa_asset_handler))
-        .with_state(state)
+        .with_state(state);
+
+    // Webhook ingress (#5089 step 3, ADR-0034). Merged as its own state-typed
+    // sub-router. `/api/webhooks/{source}` cannot be shadowed by the
+    // `/api/{service}/{*path}` proxy above: matchit 0.8 prefers a static
+    // segment over a `{param}` capture at the same position, so `webhooks`
+    // wins regardless of declaration order — the same precedence rule the
+    // `/api/console/*` routes already rely on.
+    let router = match webhook {
+        Some(ingress) => core.merge(
+            Router::new()
+                .route(
+                    "/api/webhooks/{source}",
+                    axum::routing::post(crate::webhook::webhook_handler),
+                )
+                .route(
+                    "/api/console/metrics/webhooks",
+                    get(crate::webhook::metrics_webhooks_handler),
+                )
+                .with_state(ingress),
+        ),
+        None => core,
+    };
+
+    router
         // Same-origin guard for ALL destructive write routes, applied
         // router-wide (#3268 fix). The console serves a permissive CORS
         // policy (open reads), so without this guard any web page the

--- a/crates/trusty-console/src/server/mod.rs
+++ b/crates/trusty-console/src/server/mod.rs
@@ -454,7 +454,18 @@ fn build_router_inner(
                     "/api/console/metrics/webhooks",
                     get(crate::webhook::metrics_webhooks_handler),
                 )
-                .with_state(ingress),
+                .with_state(ingress)
+                // axum's DefaultBodyLimit is 2 MiB, which silently 413s a real
+                // delivery before the handler runs: no spool entry, no metric,
+                // no ack — the exact invisible drop this route exists to
+                // prevent. GitHub payloads are legal to 25 MB and `push` /
+                // `pull_request` bodies routinely pass 2 MiB. Scoped to this
+                // sub-router so the proxy and SPA routes keep the default.
+                // (`trusty-search` sets 64 MiB the same way, at
+                // `service/server/mod.rs:251`.)
+                .layer(axum::extract::DefaultBodyLimit::max(
+                    crate::webhook::MAX_WEBHOOK_BODY_BYTES,
+                )),
         ),
         None => core,
     };

--- a/crates/trusty-console/src/webhook/health.rs
+++ b/crates/trusty-console/src/webhook/health.rs
@@ -1,0 +1,177 @@
+//! Oldest-pending-age as a red health state on `/api/console/metrics/*`.
+//!
+//! Why: ADR-0034 §2 — "A pending entry older than a threshold is a **red**
+//! health state … not a `warn!` line in a log nobody reads." The trap this
+//! module is shaped to avoid is one level down from that: a threshold evaluated
+//! only inside a background poll loop is fail-quiet again, because a loop that
+//! silently stops leaves the last cached value looking healthy forever. So the
+//! scan runs **on the request**, against the directory, every time — there is
+//! no cache to go stale, and a scan that fails is itself red rather than empty.
+//!
+//! What: [`scan_health`] reads the spool, computes pending count, oldest age,
+//! and total failed attempts, and classifies. [`to_report`] wraps the result in
+//! the workspace-standard `ConsoleMetricsReport` so the existing console
+//! dashboard renders it with no new contract.
+//!
+//! Test: `webhook/tests.rs` — `health_*` cases cover empty, young-pending,
+//! aged-pending, undecodable-entry, and unreadable-spool.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use trusty_common::console_metrics::{ConsoleMetricsReport, ServiceHealth, make_report};
+
+use super::spool::Spool;
+
+/// Age at which a still-pending delivery turns the health state red.
+///
+/// Ten minutes is longer than any legitimate relay path — a cold
+/// `trusty-review` start is 191 ms (#5028) — and short enough that an operator
+/// sees a stuck delivery inside one working session.
+pub const DEFAULT_RED_AFTER: Duration = Duration::from_secs(600);
+
+/// Bumped when [`SpoolHealth`]'s shape changes, per the `console_metrics`
+/// contract.
+pub const METRICS_SCHEMA_VERSION: u32 = 1;
+
+/// Service id this report is published under.
+pub const WEBHOOK_SERVICE_ID: &str = "trusty-console-webhooks";
+
+/// What one on-demand scan of the spool found.
+///
+/// Why: an operator diagnosing a stuck webhook needs the age, the count, and
+/// the failing delivery's id and last error, all in the one payload the
+/// dashboard already fetches.
+/// What: serialised as the `metrics` object of a `ConsoleMetricsReport`.
+/// `scan_error` being `Some` is always accompanied by `status: Error`.
+/// Test: every `health_*` case in `webhook/tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpoolHealth {
+    /// Coarse classification; see [`scan_health`] for the rules.
+    pub status: ServiceHealth,
+    /// How many decodable entries are still pending.
+    pub pending: usize,
+    /// Age of the oldest pending entry, in seconds.
+    pub oldest_pending_age_secs: Option<u64>,
+    /// Delivery id of the oldest pending entry.
+    pub oldest_pending_delivery_id: Option<String>,
+    /// Why the oldest pending entry's last relay attempt failed.
+    pub oldest_pending_last_error: Option<String>,
+    /// Sum of failed attempts across every pending entry.
+    pub total_failed_attempts: u64,
+    /// Threshold in force for this scan.
+    pub red_after_secs: u64,
+    /// Entries present on disk that could not be read or decoded, with reasons.
+    /// Never empty while `status` is `Ok`.
+    pub undecodable: Vec<String>,
+    /// Why the scan itself failed, if it did.
+    pub scan_error: Option<String>,
+}
+
+/// Scan the spool and classify its health, right now.
+///
+/// Why: called per request rather than per poll tick. The whole point of the
+/// signal is to catch a path that has quietly stopped working, and a signal
+/// that itself depends on a background task still running does not do that.
+///
+/// What: classification, in order —
+/// 1. the scan failed → `Error`, with `scan_error` set;
+/// 2. any entry on disk could not be decoded → `Error` (an unreadable pending
+///    delivery is not a healthy one);
+/// 3. the oldest pending entry is at least `red_after` old → `Error`;
+/// 4. anything is pending → `Degraded`;
+/// 5. otherwise → `Ok`.
+///
+/// `now_unix_ms` is a parameter so the age rules are testable without sleeping.
+/// An entry whose timestamp is in the future yields age `0` rather than
+/// underflowing.
+///
+/// Test: `health_reports_ok_on_an_empty_spool`,
+/// `health_reports_degraded_for_a_young_pending_entry`,
+/// `health_reports_error_once_the_oldest_entry_passes_the_threshold`,
+/// `health_reports_error_for_an_undecodable_entry`,
+/// `health_reports_error_when_the_spool_cannot_be_read`.
+pub fn scan_health(spool: &Spool, now_unix_ms: u64, red_after: Duration) -> SpoolHealth {
+    let red_after_secs = red_after.as_secs();
+
+    let listing = match spool.list_pending() {
+        Ok(listing) => listing,
+        Err(e) => {
+            return SpoolHealth {
+                status: ServiceHealth::Error,
+                pending: 0,
+                oldest_pending_age_secs: None,
+                oldest_pending_delivery_id: None,
+                oldest_pending_last_error: None,
+                total_failed_attempts: 0,
+                red_after_secs,
+                undecodable: Vec::new(),
+                // A spool that cannot be read is NOT an empty spool. Reporting
+                // it healthy is the fail-quiet shape this module exists to
+                // remove.
+                scan_error: Some(format!("{e}")),
+            };
+        }
+    };
+
+    let oldest = listing.pending.first();
+    let oldest_age_secs = oldest.map(|p| {
+        now_unix_ms
+            .saturating_sub(p.entry.received_at_unix_ms)
+            .div_euclid(1000)
+    });
+    let total_failed_attempts: u64 = listing
+        .pending
+        .iter()
+        .map(|p| u64::from(p.entry.attempts))
+        .sum();
+    let undecodable: Vec<String> = listing
+        .undecodable
+        .iter()
+        .map(|(path, reason)| format!("{}: {reason}", path.display()))
+        .collect();
+
+    let aged_out = oldest_age_secs.is_some_and(|age| age >= red_after_secs);
+    let status = if !undecodable.is_empty() || aged_out {
+        ServiceHealth::Error
+    } else if listing.pending.is_empty() {
+        ServiceHealth::Ok
+    } else {
+        ServiceHealth::Degraded
+    };
+
+    SpoolHealth {
+        status,
+        pending: listing.pending.len(),
+        oldest_pending_age_secs: oldest_age_secs,
+        oldest_pending_delivery_id: oldest.map(|p| p.entry.delivery_id.clone()),
+        oldest_pending_last_error: oldest.and_then(|p| p.entry.last_error.clone()),
+        total_failed_attempts,
+        red_after_secs,
+        undecodable,
+        scan_error: None,
+    }
+}
+
+/// Wrap a [`SpoolHealth`] in the standard console metrics envelope.
+///
+/// Why: the console dashboard already knows how to render a
+/// `ConsoleMetricsReport`, so the webhook signal needs no new client contract.
+/// What: `service_id` [`WEBHOOK_SERVICE_ID`], `status` mirrored from the scan,
+/// `metrics` the serialised [`SpoolHealth`]. Serialisation cannot realistically
+/// fail for this type; if it somehow did, the fallback payload keeps the red
+/// status rather than dropping the report.
+/// Test: `metrics_route_reports_red_for_an_aged_pending_entry`.
+pub fn to_report(health: &SpoolHealth) -> ConsoleMetricsReport {
+    let metrics = serde_json::to_value(health).unwrap_or_else(|e| {
+        serde_json::json!({ "status": "error", "scan_error": format!("serialize health: {e}") })
+    });
+    make_report(
+        WEBHOOK_SERVICE_ID,
+        "Webhooks",
+        env!("CARGO_PKG_VERSION"),
+        health.status.clone(),
+        metrics,
+        METRICS_SCHEMA_VERSION,
+    )
+}

--- a/crates/trusty-console/src/webhook/health.rs
+++ b/crates/trusty-console/src/webhook/health.rs
@@ -1,20 +1,33 @@
 //! Oldest-pending-age as a red health state on `/api/console/metrics/*`.
 //!
 //! Why: ADR-0034 §2 — "A pending entry older than a threshold is a **red**
-//! health state … not a `warn!` line in a log nobody reads." The trap this
-//! module is shaped to avoid is one level down from that: a threshold evaluated
-//! only inside a background poll loop is fail-quiet again, because a loop that
-//! silently stops leaves the last cached value looking healthy forever. So the
-//! scan runs **on the request**, against the directory, every time — there is
-//! no cache to go stale, and a scan that fails is itself red rather than empty.
+//! health state … not a `warn!` line in a log nobody reads." Two traps sit one
+//! level below that, and this module is shaped around both.
 //!
-//! What: [`scan_health`] reads the spool, computes pending count, oldest age,
-//! and total failed attempts, and classifies. [`to_report`] wraps the result in
-//! the workspace-standard `ConsoleMetricsReport` so the existing console
-//! dashboard renders it with no new contract.
+//! The first: a threshold evaluated only inside a background poll loop is
+//! fail-quiet again, because a loop that silently stops leaves the last cached
+//! value looking healthy forever. So the scan runs **on the request**, against
+//! the directory, every time — no cache to go stale, and a scan that fails is
+//! itself red rather than empty.
+//!
+//! The second: a signal that goes red and then never changes is the same log
+//! line wearing a status field. Exhausted entries are by construction the
+//! oldest, so computing `oldest_pending_*` across the whole spool pins those
+//! diagnostics to the first poisoned delivery permanently — day 30's genuinely
+//! new failure moves nothing an operator or alert rule reads. So exhausted
+//! entries get their own count and ids, and `oldest_pending_*` describes the
+//! oldest **live** entry, which is the one still changing.
+//!
+//! What: [`scan_health`] takes a filename-only census
+//! ([`Spool::scan_metadata`], which opens nothing) and decodes exactly one
+//! entry — the oldest live one — for its attempt count and last error.
+//! [`to_report`] wraps the result in the workspace-standard
+//! `ConsoleMetricsReport` so the existing dashboard renders it with no new
+//! contract.
 //!
 //! Test: `webhook/tests.rs` — `health_*` cases cover empty, young-pending,
-//! aged-pending, undecodable-entry, and unreadable-spool.
+//! aged-pending, exhausted-alongside-live, undecodable-entry, unreadable-spool,
+//! and a vanished spool directory.
 
 use std::time::Duration;
 
@@ -32,16 +45,21 @@ pub const DEFAULT_RED_AFTER: Duration = Duration::from_secs(600);
 
 /// Bumped when [`SpoolHealth`]'s shape changes, per the `console_metrics`
 /// contract.
-pub const METRICS_SCHEMA_VERSION: u32 = 1;
+pub const METRICS_SCHEMA_VERSION: u32 = 2;
 
 /// Service id this report is published under.
 pub const WEBHOOK_SERVICE_ID: &str = "trusty-console-webhooks";
 
+/// Most exhausted delivery ids listed individually before the payload is
+/// truncated. The count is always exact; the list is a sample.
+const MAX_LISTED_EXHAUSTED: usize = 10;
+
 /// What one on-demand scan of the spool found.
 ///
-/// Why: an operator diagnosing a stuck webhook needs the age, the count, and
-/// the failing delivery's id and last error, all in the one payload the
-/// dashboard already fetches.
+/// Why: an operator diagnosing a stuck webhook needs the age, the counts, and
+/// the failing delivery's id and last error, in the one payload the dashboard
+/// already fetches — and needs them to keep *moving* as new deliveries fail,
+/// which is why the live and exhausted sets are reported separately.
 /// What: serialised as the `metrics` object of a `ConsoleMetricsReport`.
 /// `scan_error` being `Some` is always accompanied by `status: Error`.
 /// Test: every `health_*` case in `webhook/tests.rs`.
@@ -49,20 +67,35 @@ pub const WEBHOOK_SERVICE_ID: &str = "trusty-console-webhooks";
 pub struct SpoolHealth {
     /// Coarse classification; see [`scan_health`] for the rules.
     pub status: ServiceHealth,
-    /// How many decodable entries are still pending.
+    /// Live entries still eligible for relay.
     pub pending: usize,
-    /// Age of the oldest pending entry, in seconds.
+    /// Entries console has stopped retrying. Non-zero always means red, and
+    /// always means an operator has to act — nothing clears these on its own.
+    pub exhausted: usize,
+    /// Delivery ids of exhausted entries, up to [`MAX_LISTED_EXHAUSTED`].
+    pub exhausted_delivery_ids: Vec<String>,
+    /// Age of the oldest exhausted entry, in seconds.
+    pub oldest_exhausted_age_secs: Option<u64>,
+    /// Age of the oldest **live** entry, in seconds.
+    ///
+    /// Deliberately excludes exhausted entries: they are permanently the
+    /// oldest, so including them freezes this field at the first poisoned
+    /// delivery and it stops reporting anything new.
     pub oldest_pending_age_secs: Option<u64>,
-    /// Delivery id of the oldest pending entry.
+    /// Delivery id of the oldest live entry.
     pub oldest_pending_delivery_id: Option<String>,
-    /// Why the oldest pending entry's last relay attempt failed.
+    /// Why the oldest live entry's last relay attempt failed.
     pub oldest_pending_last_error: Option<String>,
-    /// Sum of failed attempts across every pending entry.
-    pub total_failed_attempts: u64,
+    /// How many attempts the oldest live entry has already burned.
+    ///
+    /// Replaces a spool-wide attempt total, which cost one JSON decode per
+    /// entry on every metrics request. The oldest live entry's count is the
+    /// actionable number and costs exactly one decode.
+    pub oldest_pending_attempts: Option<u32>,
     /// Threshold in force for this scan.
     pub red_after_secs: u64,
-    /// Entries present on disk that could not be read or decoded, with reasons.
-    /// Never empty while `status` is `Ok`.
+    /// Entries present on disk that could not be read or whose name did not
+    /// parse, with reasons. Never empty while `status` is `Ok`.
     pub undecodable: Vec<String>,
     /// Why the scan itself failed, if it did.
     pub scan_error: Option<String>,
@@ -75,12 +108,18 @@ pub struct SpoolHealth {
 /// that itself depends on a background task still running does not do that.
 ///
 /// What: classification, in order —
-/// 1. the scan failed → `Error`, with `scan_error` set;
-/// 2. any entry on disk could not be decoded → `Error` (an unreadable pending
-///    delivery is not a healthy one);
-/// 3. the oldest pending entry is at least `red_after` old → `Error`;
-/// 4. anything is pending → `Degraded`;
-/// 5. otherwise → `Ok`.
+/// 1. the census failed → `Error`, with `scan_error` set;
+/// 2. a file on disk could not be read or named → `Error`;
+/// 3. any entry is exhausted → `Error` (nothing clears those without an
+///    operator);
+/// 4. the oldest **live** entry is at least `red_after` old → `Error`;
+/// 5. anything is live-pending → `Degraded`;
+/// 6. otherwise → `Ok`.
+///
+/// Cost: one `read_dir` per directory and at most one JSON decode — of the
+/// oldest live entry, for its attempt count and last error. If that decode
+/// fails the entry is reported through `undecodable` rather than the scan being
+/// abandoned.
 ///
 /// `now_unix_ms` is a parameter so the age rules are testable without sleeping.
 /// An entry whose timestamp is in the future yields age `0` rather than
@@ -89,52 +128,59 @@ pub struct SpoolHealth {
 /// Test: `health_reports_ok_on_an_empty_spool`,
 /// `health_reports_degraded_for_a_young_pending_entry`,
 /// `health_reports_error_once_the_oldest_entry_passes_the_threshold`,
+/// `health_diagnostics_track_the_live_entry_not_the_exhausted_one`,
 /// `health_reports_error_for_an_undecodable_entry`,
-/// `health_reports_error_when_the_spool_cannot_be_read`.
+/// `health_reports_error_when_the_spool_cannot_be_read`,
+/// `health_reports_error_when_the_spool_directory_is_gone`.
 pub fn scan_health(spool: &Spool, now_unix_ms: u64, red_after: Duration) -> SpoolHealth {
     let red_after_secs = red_after.as_secs();
+    let age_of = |at: u64| now_unix_ms.saturating_sub(at).div_euclid(1000);
 
-    let listing = match spool.list_pending() {
-        Ok(listing) => listing,
+    let census = match spool.scan_metadata() {
+        Ok(census) => census,
         Err(e) => {
             return SpoolHealth {
                 status: ServiceHealth::Error,
-                pending: 0,
-                oldest_pending_age_secs: None,
-                oldest_pending_delivery_id: None,
-                oldest_pending_last_error: None,
-                total_failed_attempts: 0,
                 red_after_secs,
-                undecodable: Vec::new(),
                 // A spool that cannot be read is NOT an empty spool. Reporting
                 // it healthy is the fail-quiet shape this module exists to
                 // remove.
                 scan_error: Some(format!("{e}")),
+                ..SpoolHealth::empty(red_after_secs)
             };
         }
     };
 
-    let oldest = listing.pending.first();
-    let oldest_age_secs = oldest.map(|p| {
-        now_unix_ms
-            .saturating_sub(p.entry.received_at_unix_ms)
-            .div_euclid(1000)
-    });
-    let total_failed_attempts: u64 = listing
-        .pending
-        .iter()
-        .map(|p| u64::from(p.entry.attempts))
-        .sum();
-    let undecodable: Vec<String> = listing
-        .undecodable
+    let mut undecodable: Vec<String> = census
+        .unparsable
         .iter()
         .map(|(path, reason)| format!("{}: {reason}", path.display()))
         .collect();
 
-    let aged_out = oldest_age_secs.is_some_and(|age| age >= red_after_secs);
-    let status = if !undecodable.is_empty() || aged_out {
+    // Exactly one decode: the oldest live entry, for the two fields its
+    // filename cannot carry.
+    let oldest_live = census.live.first();
+    let (oldest_pending_last_error, oldest_pending_attempts) = match oldest_live {
+        Some(meta) => match spool.load(&meta.path) {
+            Ok(entry) => (entry.last_error, Some(entry.attempts)),
+            Err(e) => {
+                undecodable.push(format!("{}: {e}", meta.path.display()));
+                (None, None)
+            }
+        },
+        None => (None, None),
+    };
+
+    let oldest_pending_age_secs = oldest_live.map(|m| age_of(m.received_at_unix_ms));
+    let oldest_exhausted_age_secs = census
+        .exhausted
+        .first()
+        .map(|m| age_of(m.received_at_unix_ms));
+    let aged_out = oldest_pending_age_secs.is_some_and(|age| age >= red_after_secs);
+
+    let status = if !undecodable.is_empty() || !census.exhausted.is_empty() || aged_out {
         ServiceHealth::Error
-    } else if listing.pending.is_empty() {
+    } else if census.live.is_empty() {
         ServiceHealth::Ok
     } else {
         ServiceHealth::Degraded
@@ -142,14 +188,56 @@ pub fn scan_health(spool: &Spool, now_unix_ms: u64, red_after: Duration) -> Spoo
 
     SpoolHealth {
         status,
-        pending: listing.pending.len(),
-        oldest_pending_age_secs: oldest_age_secs,
-        oldest_pending_delivery_id: oldest.map(|p| p.entry.delivery_id.clone()),
-        oldest_pending_last_error: oldest.and_then(|p| p.entry.last_error.clone()),
-        total_failed_attempts,
+        pending: census.live.len(),
+        exhausted: census.exhausted.len(),
+        exhausted_delivery_ids: census
+            .exhausted
+            .iter()
+            .take(MAX_LISTED_EXHAUSTED)
+            .map(|m| m.delivery_id.clone())
+            .collect(),
+        oldest_exhausted_age_secs,
+        oldest_pending_age_secs,
+        oldest_pending_delivery_id: oldest_live.map(|m| m.delivery_id.clone()),
+        oldest_pending_last_error,
+        oldest_pending_attempts,
         red_after_secs,
         undecodable,
         scan_error: None,
+    }
+}
+
+/// A red report for a scan that could not run at all.
+///
+/// Why: the caller that needs this is `WebhookIngress::health`, when the
+/// blocking task carrying the scan fails to join. "The scan did not happen" is
+/// not "the spool is empty", and only one of those is safe to render green.
+/// Test: covered by the same rule as `health_reports_error_when_the_spool_cannot_be_read`.
+pub fn scan_failed(red_after: Duration, reason: String) -> SpoolHealth {
+    SpoolHealth {
+        status: ServiceHealth::Error,
+        scan_error: Some(reason),
+        ..SpoolHealth::empty(red_after.as_secs())
+    }
+}
+
+impl SpoolHealth {
+    /// A healthy, empty report — the base every classification starts from.
+    fn empty(red_after_secs: u64) -> Self {
+        Self {
+            status: ServiceHealth::Ok,
+            pending: 0,
+            exhausted: 0,
+            exhausted_delivery_ids: Vec::new(),
+            oldest_exhausted_age_secs: None,
+            oldest_pending_age_secs: None,
+            oldest_pending_delivery_id: None,
+            oldest_pending_last_error: None,
+            oldest_pending_attempts: None,
+            red_after_secs,
+            undecodable: Vec::new(),
+            scan_error: None,
+        }
     }
 }
 

--- a/crates/trusty-console/src/webhook/mod.rs
+++ b/crates/trusty-console/src/webhook/mod.rs
@@ -246,11 +246,49 @@ impl WebhookIngress {
         &self.spool
     }
 
+    /// Run one blocking spool operation off the async runtime.
+    ///
+    /// Why: every spool call does real filesystem work — `persist_new` alone
+    /// fsyncs a file and a directory, and a census `read_dir`s two of them.
+    /// Doing that inline stalls a runtime worker thread, and the ingest path
+    /// runs it twice per delivery while the metrics route runs it per request.
+    /// What: `spawn_blocking` over a cloned [`Spool`] (a `PathBuf` and a flag,
+    /// so cloning is free). A join failure — the blocking pool shutting down
+    /// mid-operation — is surfaced as an error rather than silently swallowed.
+    /// Test: exercised by every async case; the correctness of each operation
+    /// is covered by its own `spool_*` case.
+    async fn blocking<T, F>(&self, op: F) -> Result<T, SpoolError>
+    where
+        F: FnOnce(Spool) -> Result<T, SpoolError> + Send + 'static,
+        T: Send + 'static,
+    {
+        let spool = (*self.spool).clone();
+        match tokio::task::spawn_blocking(move || op(spool)).await {
+            Ok(result) => result,
+            Err(join) => Err(SpoolError::PrepareDir {
+                path: self.spool.root().to_path_buf(),
+                source: std::io::Error::other(format!("spool task did not complete: {join}")),
+            }),
+        }
+    }
+
     /// Scan the spool and classify its health, now.
     ///
-    /// Deliberately not cached — see [`health`]'s module docs.
-    pub fn health(&self) -> SpoolHealth {
-        health::scan_health(&self.spool, now_unix_ms(), self.red_after)
+    /// Deliberately not cached — see [`health`]'s module docs. The scan is
+    /// filesystem work, so it runs off the async runtime.
+    pub async fn health(&self) -> SpoolHealth {
+        let red_after = self.red_after;
+        let now = now_unix_ms();
+        let spool = (*self.spool).clone();
+        match tokio::task::spawn_blocking(move || health::scan_health(&spool, now, red_after)).await
+        {
+            Ok(health) => health,
+            // A scan that could not run is not a healthy spool.
+            Err(join) => health::scan_failed(
+                red_after,
+                format!("health scan task did not complete: {join}"),
+            ),
+        }
     }
 
     /// Verify, spool, relay — in that order.
@@ -320,7 +358,11 @@ impl WebhookIngress {
         // logged-and-accepted delivery. `persist_new` refuses to overwrite: the
         // entry already at that path may be one console has acknowledged, and
         // GitHub will never re-send it.
-        let path = match self.spool.persist_new(&entry) {
+        let to_write = entry.clone();
+        let path = match self
+            .blocking(move |spool| spool.persist_new(&to_write))
+            .await
+        {
             Ok(path) => path,
             Err(e) => {
                 let already = matches!(e, SpoolError::AlreadyExists { .. });
@@ -344,7 +386,7 @@ impl WebhookIngress {
         let outcome = match self.claims.claim(&path) {
             Some(_claim) => {
                 let outcome = relay.deliver(&entry).await;
-                let bookkeeping_error = self.settle(&path, &mut entry, &outcome);
+                let bookkeeping_error = self.settle(&path, &mut entry, &outcome).await;
                 return IngestOutcome::Accepted {
                     delivery_id,
                     relay: outcome,
@@ -378,14 +420,18 @@ impl WebhookIngress {
     /// Both are the safe direction.
     /// Test: `ingest_accepts_and_deletes_on_an_explicit_ack`,
     /// `relay_failure_leaves_a_pending_entry_with_an_incremented_attempt_count`.
-    fn settle(
+    async fn settle(
         &self,
         path: &std::path::Path,
         entry: &mut SpoolEntry,
         outcome: &RelayOutcome,
     ) -> Option<String> {
         if outcome.is_acked() {
-            return match self.spool.remove_acked(path) {
+            let acked_path = path.to_path_buf();
+            return match self
+                .blocking(move |spool| spool.remove_acked(&acked_path))
+                .await
+            {
                 Ok(()) => None,
                 Err(e) => {
                     tracing::error!(
@@ -399,11 +445,19 @@ impl WebhookIngress {
             };
         }
 
-        match self
-            .spool
-            .record_attempt(entry, outcome.reason().to_string(), now_unix_ms())
-        {
-            Ok(_) => {
+        let mut updated = entry.clone();
+        let reason = outcome.reason().to_string();
+        let now = now_unix_ms();
+        let written = self
+            .blocking(move |spool| {
+                spool
+                    .record_attempt(&mut updated, reason, now)
+                    .map(|_| updated)
+            })
+            .await;
+        match written {
+            Ok(after) => {
+                *entry = after;
                 tracing::warn!(
                     delivery_id = %entry.delivery_id,
                     attempts = entry.attempts,
@@ -452,7 +506,7 @@ impl WebhookIngress {
     /// `sweep_honours_backoff_between_ticks`,
     /// `sweep_stops_relaying_an_exhausted_entry`.
     pub async fn retry_pending_once(&self) -> SweepReport {
-        let listing = match self.spool.list_pending() {
+        let listing = match self.blocking(|spool| spool.list_pending()).await {
             Ok(listing) => listing,
             Err(e) => {
                 tracing::error!(error = %e, "webhook retry sweep could not read the spool");
@@ -482,7 +536,25 @@ impl WebhookIngress {
                 continue;
             };
             if self.backoff.is_exhausted(&entry) {
+                // Move it out of the live set. Leaving it here would make every
+                // later sweep and every metrics request read and decode it
+                // forever, and would pin the oldest-pending diagnostics to it so
+                // a genuinely new failure changed nothing an operator reads.
+                // It is kept, not deleted — it is still an unacknowledged
+                // webhook, and it keeps the health signal red.
                 report.exhausted += 1;
+                let quarantine_path = pending.path.clone();
+                if let Err(e) = self
+                    .blocking(move |spool| spool.quarantine(&quarantine_path))
+                    .await
+                {
+                    tracing::error!(
+                        delivery_id = %entry.delivery_id,
+                        error = %e,
+                        "could not move an exhausted entry aside; it stays in the live set"
+                    );
+                    report.bookkeeping_failures += 1;
+                }
                 continue;
             }
             if !self.backoff.is_due(&entry, now) {
@@ -500,7 +572,11 @@ impl WebhookIngress {
             } else {
                 report.still_pending += 1;
             }
-            if self.settle(&pending.path, &mut entry, &outcome).is_some() {
+            if self
+                .settle(&pending.path, &mut entry, &outcome)
+                .await
+                .is_some()
+            {
                 report.bookkeeping_failures += 1;
             }
         }
@@ -606,7 +682,7 @@ pub async fn webhook_handler(
 pub async fn metrics_webhooks_handler(
     State(ingress): State<WebhookIngress>,
 ) -> axum::response::Response {
-    axum::Json(health::to_report(&ingress.health())).into_response()
+    axum::Json(health::to_report(&ingress.health().await)).into_response()
 }
 
 /// Milliseconds since the Unix epoch, saturating at 0 before it.

--- a/crates/trusty-console/src/webhook/mod.rs
+++ b/crates/trusty-console/src/webhook/mod.rs
@@ -35,6 +35,7 @@
 
 pub mod health;
 pub mod relay;
+pub mod schedule;
 pub mod spool;
 
 #[cfg(test)]
@@ -57,7 +58,33 @@ use trusty_common::webhook_hmac::{HMAC_ALGORITHM, SIGNATURE_HEADER, SignatureVer
 
 use health::{DEFAULT_RED_AFTER, SpoolHealth};
 use relay::{RelayOutcome, UdsRelay};
-use spool::{Provenance, SPOOL_SCHEMA_VERSION, Spool, SpoolEntry};
+use schedule::ClaimSet;
+use spool::{Provenance, SPOOL_SCHEMA_VERSION, Spool, SpoolEntry, SpoolError};
+
+pub use schedule::BackoffPolicy;
+
+/// Most entries one sweep pass will relay.
+///
+/// Why: the sweep is serial and each relay can burn its full timeout, so an
+/// unbounded pass can outlast its own tick interval. Backoff already keeps the
+/// due set small; this bounds the pathological case where it is not. Entries
+/// left over are simply relayed on the next tick — they stay pending and
+/// durable in the meantime.
+const SWEEP_BUDGET: usize = 32;
+
+/// Largest webhook body the ingress route accepts.
+///
+/// Why: axum's `DefaultBodyLimit` is 2 MiB, and a rejection there happens
+/// *before* this module's handler runs — no spool entry, no metric, no log,
+/// just a 413 GitHub records and nobody reads. That is the invisible drop the
+/// whole step exists to remove, arriving through the framework instead of the
+/// code. GitHub payloads are legal to 25 MB and `push` / `pull_request` bodies
+/// routinely exceed 2 MiB, so the default silently refuses real deliveries.
+/// What: 25 MiB, matching GitHub's documented ceiling. Applied only to the
+/// webhook sub-router (`server::build_router_with_webhooks`), so the proxy and
+/// SPA routes keep the framework default.
+/// Test: `route_accepts_a_body_larger_than_the_axum_default_limit`.
+pub const MAX_WEBHOOK_BODY_BYTES: usize = 25 * 1024 * 1024;
 
 /// Environment variable holding the shared webhook secret.
 pub const SECRET_ENV: &str = "GITHUB_WEBHOOK_SECRET";
@@ -126,6 +153,11 @@ pub struct WebhookIngress {
     key_id: Arc<String>,
     targets: Arc<BTreeMap<String, UdsRelay>>,
     red_after: Duration,
+    /// Which entries are being relayed right now, so the sweep and the request
+    /// path cannot both relay one delivery. See [`schedule::ClaimSet`].
+    claims: ClaimSet,
+    /// When a pending entry becomes eligible for another attempt.
+    backoff: BackoffPolicy,
 }
 
 impl WebhookIngress {
@@ -144,6 +176,8 @@ impl WebhookIngress {
                     .collect::<BTreeMap<_, _>>(),
             ),
             red_after: DEFAULT_RED_AFTER,
+            claims: ClaimSet::new(),
+            backoff: BackoffPolicy::default(),
         }
     }
 
@@ -153,13 +187,32 @@ impl WebhookIngress {
         self
     }
 
+    /// Override the retry schedule.
+    ///
+    /// Test: the `sweep_*` and `backoff_*` cases use a zeroed grace so a sweep
+    /// runs without waiting out the real 5 s hold-off.
+    pub fn with_backoff(mut self, backoff: BackoffPolicy) -> Self {
+        self.backoff = backoff;
+        self
+    }
+
+    /// The retry schedule in force.
+    pub fn backoff(&self) -> BackoffPolicy {
+        self.backoff
+    }
+
     /// Production wiring: spool under the console data dir, secret from
     /// [`SECRET_ENV`], and one target per relay-capable service.
     ///
-    /// Why: the socket paths follow #5099's hardened per-uid scratch directory
-    /// rather than the bare `$TMPDIR` convention ADR-0034 §3 rejects. Nothing
-    /// binds them until step 4; dialling an absent socket is a clean
-    /// `Unreachable`.
+    /// Why: the socket paths come from `trusty_common::uds::scratch_socket_dir`,
+    /// the shared entry point #5099 built. That is `$TMPDIR/trusty-<uid>` with a
+    /// `/tmp` fallback — the *base* ADR-0034 §3 names, but not the exposure it
+    /// objects to: the uid-keyed subdirectory is created at `0700` and owned by
+    /// this process, and `connect_hardened` re-verifies owner and mode before
+    /// dialling. #5099 supersedes §3's "use the service state directory instead"
+    /// path rule by making the scratch path satisfy the property §3 wanted.
+    /// Nothing binds these sockets until step 4; dialling an absent one is a
+    /// clean `Unreachable`.
     /// What: creates the spool directory eagerly so a misconfigured data dir
     /// fails at startup rather than on the first delivery.
     ///
@@ -264,14 +317,18 @@ impl WebhookIngress {
         };
 
         // Step 3 — durable BEFORE the ack. A failure here is a 5xx, never a
-        // logged-and-accepted delivery.
-        let path = match self.spool.persist(&entry) {
+        // logged-and-accepted delivery. `persist_new` refuses to overwrite: the
+        // entry already at that path may be one console has acknowledged, and
+        // GitHub will never re-send it.
+        let path = match self.spool.persist_new(&entry) {
             Ok(path) => path,
             Err(e) => {
+                let already = matches!(e, SpoolError::AlreadyExists { .. });
                 tracing::error!(
                     source,
                     delivery_id = %delivery_id,
                     error = %e,
+                    already_spooled = already,
                     "spool write failed — refusing the delivery so GitHub keeps it redeliverable"
                 );
                 return IngestOutcome::SpoolFailed {
@@ -280,14 +337,32 @@ impl WebhookIngress {
             }
         };
 
-        // Step 4 — relay, and record what happened durably either way.
-        let outcome = relay.deliver(&entry).await;
-        let bookkeeping_error = self.settle(&path, &mut entry, &outcome);
+        // Step 4 — relay, and record what happened durably either way. The
+        // claim is what stops a sweep tick landing inside the relay window from
+        // sending the same delivery a second time; it is released on drop, so a
+        // panicking relay cannot wedge the entry.
+        let outcome = match self.claims.claim(&path) {
+            Some(_claim) => {
+                let outcome = relay.deliver(&entry).await;
+                let bookkeeping_error = self.settle(&path, &mut entry, &outcome);
+                return IngestOutcome::Accepted {
+                    delivery_id,
+                    relay: outcome,
+                    bookkeeping_error,
+                };
+            }
+            // Someone else is already relaying this exact path. The delivery is
+            // durable, so acknowledging is still correct; the in-flight relay
+            // (or the next sweep) settles it.
+            None => RelayOutcome::Unreachable {
+                reason: "another relay for this entry is already in flight".to_string(),
+            },
+        };
 
         IngestOutcome::Accepted {
             delivery_id,
             relay: outcome,
-            bookkeeping_error,
+            bookkeeping_error: None,
         }
     }
 
@@ -349,15 +424,33 @@ impl WebhookIngress {
         }
     }
 
-    /// Re-attempt every pending delivery once.
+    /// Re-attempt every pending delivery that is due, once.
     ///
-    /// Why: ADR-0034 §2 — "Console retries with backoff." A background loop
-    /// calls this; detection does not depend on that loop still running,
-    /// because [`WebhookIngress::health`] scans on the request.
-    /// What: relays each pending entry, deleting only on an explicit ack.
-    /// Returns per-sweep counts so a caller can log or assert on them.
+    /// Why: ADR-0034 §2 — "Console retries with backoff." Three guards, each
+    /// closing a different failure:
+    ///
+    /// - **Backoff** ([`BackoffPolicy::is_due`]) — without it every pending
+    ///   entry is re-relayed on every tick and each non-ack rewrites the whole
+    ///   base64 body plus two `fsync`s. Until step 4 binds a listener that is
+    ///   every delivery, forever.
+    /// - **Claims** ([`schedule::ClaimSet`]) — without them a tick landing
+    ///   inside the ≤5 s relay window sends a delivery the request path is
+    ///   still sending. One delivery, two relays.
+    /// - **[`SWEEP_BUDGET`]** — the pass is serial and each relay can burn its
+    ///   full timeout, so an unbounded pass can outlast its own tick interval.
+    ///
+    /// Nothing any guard skips is dropped: it stays pending, durable, and
+    /// visible to [`WebhookIngress::health`], which scans on the request rather
+    /// than trusting this loop to still be alive.
+    ///
+    /// What: relays each due entry, deleting only on an explicit ack. Returns
+    /// per-sweep counts.
+    ///
     /// Test: `retry_sweep_acks_and_clears_a_pending_entry`,
-    /// `retry_sweep_leaves_an_unrelayable_entry_pending_with_more_attempts`.
+    /// `retry_sweep_leaves_an_unrelayable_entry_pending_with_more_attempts`,
+    /// `sweep_does_not_relay_an_entry_the_request_path_is_still_relaying`,
+    /// `sweep_honours_backoff_between_ticks`,
+    /// `sweep_stops_relaying_an_exhausted_entry`.
     pub async fn retry_pending_once(&self) -> SweepReport {
         let listing = match self.spool.list_pending() {
             Ok(listing) => listing,
@@ -374,7 +467,12 @@ impl WebhookIngress {
             undecodable: listing.undecodable.len(),
             ..SweepReport::default()
         };
+        let now = now_unix_ms();
         for pending in listing.pending {
+            if report.acked + report.still_pending >= SWEEP_BUDGET {
+                report.deferred += 1;
+                continue;
+            }
             let mut entry = pending.entry;
             let Some(relay) = self.targets.get(&entry.source) else {
                 // A target removed from the config leaves its deliveries on
@@ -383,6 +481,19 @@ impl WebhookIngress {
                 report.orphaned += 1;
                 continue;
             };
+            if self.backoff.is_exhausted(&entry) {
+                report.exhausted += 1;
+                continue;
+            }
+            if !self.backoff.is_due(&entry, now) {
+                report.not_due += 1;
+                continue;
+            }
+            let Some(_claim) = self.claims.claim(&pending.path) else {
+                report.in_flight += 1;
+                continue;
+            };
+
             let outcome = relay.deliver(&entry).await;
             if outcome.is_acked() {
                 report.acked += 1;
@@ -398,12 +509,25 @@ impl WebhookIngress {
 }
 
 /// Counts from one [`WebhookIngress::retry_pending_once`] pass.
+///
+/// Every pending entry lands in exactly one bucket, so the counts account for
+/// the whole spool — a delivery that vanishes from all of them is a bug the
+/// tests can see.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SweepReport {
     /// Entries a target acknowledged and that were removed.
     pub acked: usize,
-    /// Entries that stayed pending.
+    /// Entries relayed this pass that stayed pending.
     pub still_pending: usize,
+    /// Entries not yet eligible under the backoff schedule.
+    pub not_due: usize,
+    /// Entries past `max_attempts` — never retried again, never deleted, and
+    /// holding the health signal red until an operator intervenes.
+    pub exhausted: usize,
+    /// Entries another relay was already handling.
+    pub in_flight: usize,
+    /// Entries left for the next tick by [`SWEEP_BUDGET`].
+    pub deferred: usize,
     /// Entries whose `source` no longer maps to a configured target.
     pub orphaned: usize,
     /// Entries on disk that could not be decoded.
@@ -537,10 +661,18 @@ pub fn start_retry_sweep(ingress: WebhookIngress, interval: Duration) {
         loop {
             ticker.tick().await;
             let report = ingress.retry_pending_once().await;
-            if report.acked > 0 || report.still_pending > 0 || report.scan_error.is_some() {
+            if report.acked > 0
+                || report.still_pending > 0
+                || report.exhausted > 0
+                || report.scan_error.is_some()
+            {
                 tracing::info!(
                     acked = report.acked,
                     still_pending = report.still_pending,
+                    not_due = report.not_due,
+                    exhausted = report.exhausted,
+                    in_flight = report.in_flight,
+                    deferred = report.deferred,
                     orphaned = report.orphaned,
                     undecodable = report.undecodable,
                     "webhook retry sweep completed"

--- a/crates/trusty-console/src/webhook/mod.rs
+++ b/crates/trusty-console/src/webhook/mod.rs
@@ -354,6 +354,30 @@ impl WebhookIngress {
             last_attempt_at_unix_ms: None,
         };
 
+        // 🔴 Claim BEFORE the write, not after it. `entry_path` is a pure
+        // function of the receipt time and delivery id, both already fixed, so
+        // the path is known before the entry exists. Claiming afterwards left a
+        // window in which the entry was on disk and unclaimed — and the write
+        // now runs on the blocking pool, which widens that window to however
+        // long a worker thread takes to be scheduled. A sweep landing there
+        // relayed a delivery this request was about to relay itself. Measured,
+        // not theorised: with the claim taken after the write, a sweep 20 ms
+        // into `ingest` reports `acked: 1` for an entry the request path then
+        // relays again.
+        //
+        // Backoff's first-attempt grace also covers this window in production,
+        // but two guards that each fully close it is the point — a deployment
+        // that tunes the grace to zero must not reopen a double-relay.
+        //
+        // 🔴 No regression test pins this ordering. The window is one scheduler
+        // poll wide, and every deterministic probe tried against it — a
+        // rendezvous, a select! loop, a parallel hammer on a 4-worker runtime —
+        // passed against a claim-after-write build as readily as against this
+        // one. A test that cannot tell the two apart is worse than none, so
+        // none was kept. Do not reorder these two statements on the strength of
+        // a green suite.
+        let claim = self.claims.claim(&self.spool.entry_path(&entry));
+
         // Step 3 — durable BEFORE the ack. A failure here is a 5xx, never a
         // logged-and-accepted delivery. `persist_new` refuses to overwrite: the
         // entry already at that path may be one console has acknowledged, and
@@ -379,11 +403,10 @@ impl WebhookIngress {
             }
         };
 
-        // Step 4 — relay, and record what happened durably either way. The
-        // claim is what stops a sweep tick landing inside the relay window from
-        // sending the same delivery a second time; it is released on drop, so a
+        // Step 4 — relay, and record what happened durably either way, holding
+        // the claim taken before the write. It is released on drop, so a
         // panicking relay cannot wedge the entry.
-        let outcome = match self.claims.claim(&path) {
+        let outcome = match claim {
             Some(_claim) => {
                 let outcome = relay.deliver(&entry).await;
                 let bookkeeping_error = self.settle(&path, &mut entry, &outcome).await;

--- a/crates/trusty-console/src/webhook/mod.rs
+++ b/crates/trusty-console/src/webhook/mod.rs
@@ -1,0 +1,551 @@
+//! `POST /api/webhooks/{source}` — the console's webhook ingress (#5089 step 3).
+//!
+//! Why: ADR-0032 removed every sibling daemon's HTTP listener, and ADR-0034
+//! rules that console terminates the GitHub request and relays inward over UDS.
+//! The two handlers this path replaces both acknowledge GitHub *before* the
+//! work runs and downgrade every later failure to a log line
+//! (`trusty-review/src/service/webhook.rs:305-309`,
+//! `trusty-analyze/src/service/handlers/review.rs:210-214`). GitHub never
+//! retries an acknowledged delivery, so each of those failures is permanent,
+//! silent loss with every health signal still green.
+//!
+//! What: one route, multiplexed by `{source}` over both targets. The order of
+//! operations is the fix and is not negotiable:
+//!
+//! 1. unknown `{source}` → `404`, before any secret handling;
+//! 2. HMAC verified once, over the exact received bytes; unset secret and bad
+//!    signature both → `401` (ADR-0034 §2 unifies the policy to fail-closed);
+//! 3. the delivery is written and fsync'd to the spool — **on failure `500`,
+//!    and no `202` is ever sent**, so GitHub keeps the delivery redeliverable;
+//! 4. the relay runs, and its outcome is recorded durably: an explicit ack
+//!    deletes the entry, anything else leaves it `pending` with an incremented
+//!    attempt count;
+//! 5. `202`, because step 3 succeeded — not because step 4 did.
+//!
+//! 🔴 Explicitly absent, per ADR-0034 §2: `let _ = relay(...)`, a bare
+//! `tracing::warn!` as the sole record of a failed relay, and any `202` issued
+//! before the spool write returns.
+//!
+//! Spawn-on-demand — console starting a target that is not resident — is
+//! #5089 step 4. Until then no target binds a listener and every relay lands in
+//! [`relay::RelayOutcome::Unreachable`], which is a durable pending state, not
+//! a dropped delivery.
+//!
+//! Test: `tests.rs`.
+
+pub mod health;
+pub mod relay;
+pub mod spool;
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::body::Bytes;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use serde_json::json;
+use trusty_common::webhook_hmac::{HMAC_ALGORITHM, SIGNATURE_HEADER, SignatureVerdict};
+
+use health::{DEFAULT_RED_AFTER, SpoolHealth};
+use relay::{RelayOutcome, UdsRelay};
+use spool::{Provenance, SPOOL_SCHEMA_VERSION, Spool, SpoolEntry};
+
+/// Environment variable holding the shared webhook secret.
+pub const SECRET_ENV: &str = "GITHUB_WEBHOOK_SECRET";
+
+/// Headers never written to the spool.
+///
+/// GitHub sends none of these; storing one would put a caller-supplied
+/// credential on disk for no benefit.
+const HEADER_DENYLIST: [&str; 3] = ["authorization", "cookie", "proxy-authorization"];
+
+/// Result of one ingress attempt, before it becomes an HTTP response.
+///
+/// Why: keeping the decision separate from axum lets every arm — including the
+/// two that must never produce a `202` — be asserted directly, without a router.
+/// What: one variant per outcome the ADR distinguishes.
+/// Test: the `ingest_*` cases in `tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IngestOutcome {
+    /// `{source}` names no configured target.
+    UnknownSource {
+        /// The path segment that did not resolve.
+        source: String,
+    },
+    /// No secret is configured. Fail closed.
+    SecretMissing,
+    /// A secret is configured and the signature did not verify.
+    InvalidSignature,
+    /// The durable write failed. The caller MUST return 5xx and MUST NOT ack.
+    SpoolFailed {
+        /// Why the write failed.
+        reason: String,
+    },
+    /// The delivery is durably recorded. Safe to acknowledge GitHub.
+    Accepted {
+        /// The delivery id the entry is filed under.
+        delivery_id: String,
+        /// What the relay attempt established. Not a precondition of the ack.
+        relay: RelayOutcome,
+        /// Set when the post-relay bookkeeping write failed. The delivery is
+        /// still durable — this only means the attempt count or the deletion
+        /// did not land, both of which are recoverable by the retry sweep.
+        bookkeeping_error: Option<String>,
+    },
+}
+
+/// One relay target reachable through `/api/webhooks/{source}`.
+#[derive(Debug, Clone)]
+pub struct Target {
+    /// Route segment that selects it.
+    pub source: String,
+    /// UDS client for it.
+    pub relay: UdsRelay,
+}
+
+/// The webhook ingress: spool, secret, and one relay per target.
+///
+/// Why: assembled once at startup and shared by the route handler, the metrics
+/// handler, and the background retry sweep, so all three see the same spool.
+/// What: cheap to clone (everything behind `Arc`).
+/// Test: constructed directly in `tests.rs` with a temp-dir spool, so no test
+/// mutates a process-global env var.
+#[derive(Debug, Clone)]
+pub struct WebhookIngress {
+    spool: Arc<Spool>,
+    secret: Arc<String>,
+    key_id: Arc<String>,
+    targets: Arc<BTreeMap<String, UdsRelay>>,
+    red_after: Duration,
+}
+
+impl WebhookIngress {
+    /// Assemble an ingress from explicit parts.
+    ///
+    /// Test: used by every `tests.rs` case.
+    pub fn new(spool: Spool, secret: String, key_id: String, targets: Vec<Target>) -> Self {
+        Self {
+            spool: Arc::new(spool),
+            secret: Arc::new(secret),
+            key_id: Arc::new(key_id),
+            targets: Arc::new(
+                targets
+                    .into_iter()
+                    .map(|t| (t.source, t.relay))
+                    .collect::<BTreeMap<_, _>>(),
+            ),
+            red_after: DEFAULT_RED_AFTER,
+        }
+    }
+
+    /// Override the red-health threshold.
+    pub fn with_red_after(mut self, red_after: Duration) -> Self {
+        self.red_after = red_after;
+        self
+    }
+
+    /// Production wiring: spool under the console data dir, secret from
+    /// [`SECRET_ENV`], and one target per relay-capable service.
+    ///
+    /// Why: the socket paths follow #5099's hardened per-uid scratch directory
+    /// rather than the bare `$TMPDIR` convention ADR-0034 §3 rejects. Nothing
+    /// binds them until step 4; dialling an absent socket is a clean
+    /// `Unreachable`.
+    /// What: creates the spool directory eagerly so a misconfigured data dir
+    /// fails at startup rather than on the first delivery.
+    ///
+    /// # Errors
+    ///
+    /// When the data directory cannot be resolved or the spool directory cannot
+    /// be created.
+    ///
+    /// Test: `default_spool_root_lives_under_the_console_data_dir`, plus the
+    /// `#[ignore]`d `integration_from_env_*` cases, which point
+    /// `TRUSTY_DATA_DIR_OVERRIDE` at a temp dir under a lock.
+    pub fn from_env() -> anyhow::Result<Self> {
+        let spool = Spool::open(Spool::default_root()?)?;
+        let secret = std::env::var(SECRET_ENV).unwrap_or_default();
+        let sockets = trusty_common::uds::scratch_socket_dir();
+        let targets = vec![
+            Target {
+                source: "review".to_string(),
+                relay: UdsRelay::new(sockets.join("trusty-review-webhook.sock")),
+            },
+            Target {
+                source: "analyze".to_string(),
+                relay: UdsRelay::new(sockets.join("trusty-analyze-webhook.sock")),
+            },
+        ];
+        Ok(Self::new(spool, secret, SECRET_ENV.to_string(), targets))
+    }
+
+    /// The spool this ingress writes to.
+    pub fn spool(&self) -> &Spool {
+        &self.spool
+    }
+
+    /// Scan the spool and classify its health, now.
+    ///
+    /// Deliberately not cached — see [`health`]'s module docs.
+    pub fn health(&self) -> SpoolHealth {
+        health::scan_health(&self.spool, now_unix_ms(), self.red_after)
+    }
+
+    /// Verify, spool, relay — in that order.
+    ///
+    /// Why: the ordering IS the fix; see the module docs. In particular the
+    /// spool write happens before this function can return anything a caller
+    /// would turn into a `202`, and a relay failure never propagates as a
+    /// reason to drop the delivery.
+    ///
+    /// What: returns an [`IngestOutcome`]; performs no HTTP.
+    ///
+    /// Test: `ingest_rejects_an_unknown_source`,
+    /// `ingest_fails_closed_when_no_secret_is_configured`,
+    /// `ingest_rejects_a_forged_signature`,
+    /// `ingest_returns_spool_failed_and_never_accepts_when_the_write_fails`,
+    /// `ingest_accepts_and_deletes_on_an_explicit_ack`,
+    /// `relay_failure_leaves_a_pending_entry_with_an_incremented_attempt_count`.
+    pub async fn ingest(&self, source: &str, headers: &HeaderMap, body: &[u8]) -> IngestOutcome {
+        let Some(relay) = self.targets.get(source) else {
+            return IngestOutcome::UnknownSource {
+                source: source.to_string(),
+            };
+        };
+
+        // Step 2 — one verification, over the exact received bytes. Anything
+        // that re-frames the body first destroys the ability to check it.
+        let signature = header_str(headers, SIGNATURE_HEADER).unwrap_or_default();
+        match trusty_common::webhook_hmac::verify_github_signature(&self.secret, body, &signature) {
+            SignatureVerdict::Valid => {}
+            SignatureVerdict::SecretMissing => {
+                tracing::warn!(
+                    source,
+                    "{SECRET_ENV} is not set — refusing the delivery (fail-closed, ADR-0034 §2)"
+                );
+                return IngestOutcome::SecretMissing;
+            }
+            SignatureVerdict::Invalid => {
+                tracing::warn!(source, "webhook HMAC verification failed");
+                return IngestOutcome::InvalidSignature;
+            }
+        }
+
+        let received_at_unix_ms = now_unix_ms();
+        let delivery_id = header_str(headers, "x-github-delivery")
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| format!("no-delivery-header-{received_at_unix_ms}"));
+
+        let mut entry = SpoolEntry {
+            schema_version: SPOOL_SCHEMA_VERSION,
+            delivery_id: delivery_id.clone(),
+            source: source.to_string(),
+            event: header_str(headers, "x-github-event").unwrap_or_default(),
+            headers: collect_headers(headers),
+            body_b64: BASE64.encode(body),
+            provenance: Provenance {
+                algorithm: HMAC_ALGORITHM.to_string(),
+                key_id: self.key_id.as_str().to_string(),
+                verified: true,
+            },
+            received_at_unix_ms,
+            attempts: 0,
+            last_error: None,
+            last_attempt_at_unix_ms: None,
+        };
+
+        // Step 3 — durable BEFORE the ack. A failure here is a 5xx, never a
+        // logged-and-accepted delivery.
+        let path = match self.spool.persist(&entry) {
+            Ok(path) => path,
+            Err(e) => {
+                tracing::error!(
+                    source,
+                    delivery_id = %delivery_id,
+                    error = %e,
+                    "spool write failed — refusing the delivery so GitHub keeps it redeliverable"
+                );
+                return IngestOutcome::SpoolFailed {
+                    reason: format!("{e}"),
+                };
+            }
+        };
+
+        // Step 4 — relay, and record what happened durably either way.
+        let outcome = relay.deliver(&entry).await;
+        let bookkeeping_error = self.settle(&path, &mut entry, &outcome);
+
+        IngestOutcome::Accepted {
+            delivery_id,
+            relay: outcome,
+            bookkeeping_error,
+        }
+    }
+
+    /// Apply a relay outcome to the spool: delete on an explicit ack, otherwise
+    /// bump the attempt count.
+    ///
+    /// Why: the single place a spool entry can be removed, so "connection
+    /// succeeded" can never be mistaken for "work acknowledged".
+    /// What: returns `Some(reason)` when the bookkeeping write itself failed.
+    /// The delivery stays durable in that case — a failed delete leaves an entry
+    /// the sweep will retry (a duplicate delivery, which is recoverable), and a
+    /// failed attempt-bump leaves the count stale (visible as a growing age).
+    /// Both are the safe direction.
+    /// Test: `ingest_accepts_and_deletes_on_an_explicit_ack`,
+    /// `relay_failure_leaves_a_pending_entry_with_an_incremented_attempt_count`.
+    fn settle(
+        &self,
+        path: &std::path::Path,
+        entry: &mut SpoolEntry,
+        outcome: &RelayOutcome,
+    ) -> Option<String> {
+        if outcome.is_acked() {
+            return match self.spool.remove_acked(path) {
+                Ok(()) => None,
+                Err(e) => {
+                    tracing::error!(
+                        delivery_id = %entry.delivery_id,
+                        error = %e,
+                        "target acknowledged but the spool entry could not be removed; \
+                         the retry sweep will redeliver it"
+                    );
+                    Some(format!("{e}"))
+                }
+            };
+        }
+
+        match self
+            .spool
+            .record_attempt(entry, outcome.reason().to_string(), now_unix_ms())
+        {
+            Ok(_) => {
+                tracing::warn!(
+                    delivery_id = %entry.delivery_id,
+                    attempts = entry.attempts,
+                    reason = outcome.reason(),
+                    "relay did not acknowledge; entry stays pending"
+                );
+                None
+            }
+            Err(e) => {
+                tracing::error!(
+                    delivery_id = %entry.delivery_id,
+                    error = %e,
+                    "relay failed AND the attempt count could not be recorded; \
+                     the entry is still on disk and still pending"
+                );
+                Some(format!("{e}"))
+            }
+        }
+    }
+
+    /// Re-attempt every pending delivery once.
+    ///
+    /// Why: ADR-0034 §2 — "Console retries with backoff." A background loop
+    /// calls this; detection does not depend on that loop still running,
+    /// because [`WebhookIngress::health`] scans on the request.
+    /// What: relays each pending entry, deleting only on an explicit ack.
+    /// Returns per-sweep counts so a caller can log or assert on them.
+    /// Test: `retry_sweep_acks_and_clears_a_pending_entry`,
+    /// `retry_sweep_leaves_an_unrelayable_entry_pending_with_more_attempts`.
+    pub async fn retry_pending_once(&self) -> SweepReport {
+        let listing = match self.spool.list_pending() {
+            Ok(listing) => listing,
+            Err(e) => {
+                tracing::error!(error = %e, "webhook retry sweep could not read the spool");
+                return SweepReport {
+                    scan_error: Some(format!("{e}")),
+                    ..SweepReport::default()
+                };
+            }
+        };
+
+        let mut report = SweepReport {
+            undecodable: listing.undecodable.len(),
+            ..SweepReport::default()
+        };
+        for pending in listing.pending {
+            let mut entry = pending.entry;
+            let Some(relay) = self.targets.get(&entry.source) else {
+                // A target removed from the config leaves its deliveries on
+                // disk rather than dropping them; the age turns the health
+                // state red, which is the correct operator signal.
+                report.orphaned += 1;
+                continue;
+            };
+            let outcome = relay.deliver(&entry).await;
+            if outcome.is_acked() {
+                report.acked += 1;
+            } else {
+                report.still_pending += 1;
+            }
+            if self.settle(&pending.path, &mut entry, &outcome).is_some() {
+                report.bookkeeping_failures += 1;
+            }
+        }
+        report
+    }
+}
+
+/// Counts from one [`WebhookIngress::retry_pending_once`] pass.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SweepReport {
+    /// Entries a target acknowledged and that were removed.
+    pub acked: usize,
+    /// Entries that stayed pending.
+    pub still_pending: usize,
+    /// Entries whose `source` no longer maps to a configured target.
+    pub orphaned: usize,
+    /// Entries on disk that could not be decoded.
+    pub undecodable: usize,
+    /// Entries whose post-relay spool write failed.
+    pub bookkeeping_failures: usize,
+    /// Set when the spool itself could not be listed.
+    pub scan_error: Option<String>,
+}
+
+/// `POST /api/webhooks/{source}` — the axum front door.
+///
+/// Why: a thin mapping from [`IngestOutcome`] to a status code, so the ordering
+/// guarantee lives in [`WebhookIngress::ingest`] and cannot be broken by an
+/// edit to the HTTP layer.
+/// What: `404` unknown source, `401` both refusal arms, `500` spool failure,
+/// `202` once the delivery is durable. The body reports the relay state so an
+/// operator can see a pending delivery without opening the dashboard.
+/// Test: `route_returns_500_and_no_ack_when_the_spool_write_fails`,
+/// `route_returns_401_for_an_unset_secret`, `route_returns_202_after_a_durable_write`.
+pub async fn webhook_handler(
+    State(ingress): State<WebhookIngress>,
+    Path(source): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> axum::response::Response {
+    match ingress.ingest(&source, &headers, &body).await {
+        IngestOutcome::UnknownSource { source } => (
+            StatusCode::NOT_FOUND,
+            axum::Json(json!({"error": "unknown webhook source", "source": source})),
+        )
+            .into_response(),
+        // One uniform 401 for both refusals: the response must not tell an
+        // unauthenticated caller whether a secret is configured.
+        IngestOutcome::SecretMissing | IngestOutcome::InvalidSignature => (
+            StatusCode::UNAUTHORIZED,
+            axum::Json(json!({"error": "signature verification failed"})),
+        )
+            .into_response(),
+        IngestOutcome::SpoolFailed { reason } => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(json!({
+                "error": "could not durably record the delivery; not acknowledged",
+                "detail": reason,
+            })),
+        )
+            .into_response(),
+        IngestOutcome::Accepted {
+            delivery_id,
+            relay,
+            bookkeeping_error,
+        } => (
+            StatusCode::ACCEPTED,
+            axum::Json(json!({
+                "status": "accepted",
+                "delivery_id": delivery_id,
+                "relay": if relay.is_acked() { "acknowledged" } else { "pending" },
+                "detail": relay.reason(),
+                "bookkeeping_error": bookkeeping_error,
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /api/console/metrics/webhooks` — oldest-pending-age as a health state.
+///
+/// Why: ADR-0034 §2 requires the signal on console's existing metrics surface,
+/// red once a delivery has been pending too long.
+/// What: scans the spool on this request and returns a `ConsoleMetricsReport`.
+/// Always `200`, never `503`: a red report is information, and a `503` would be
+/// indistinguishable from "no data yet" — which is the fail-quiet reading this
+/// signal exists to prevent.
+/// Test: `metrics_route_reports_red_for_an_aged_pending_entry`,
+/// `metrics_route_reports_ok_on_an_empty_spool`.
+pub async fn metrics_webhooks_handler(
+    State(ingress): State<WebhookIngress>,
+) -> axum::response::Response {
+    axum::Json(health::to_report(&ingress.health())).into_response()
+}
+
+/// Milliseconds since the Unix epoch, saturating at 0 before it.
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
+/// One header value as a `String`, lowercased name, `None` when absent or not
+/// valid UTF-8.
+fn header_str(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string)
+}
+
+/// Every header worth spooling, lowercased, minus [`HEADER_DENYLIST`].
+fn collect_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            let name = name.as_str().to_ascii_lowercase();
+            if HEADER_DENYLIST.contains(&name.as_str()) {
+                return None;
+            }
+            value.to_str().ok().map(|v| (name, v.to_string()))
+        })
+        .collect()
+}
+
+/// The spool root, for callers that need it before an ingress exists.
+pub fn default_spool_root() -> anyhow::Result<PathBuf> {
+    Spool::default_root()
+}
+
+/// Run [`WebhookIngress::retry_pending_once`] on an interval, forever.
+///
+/// Why: recovery for entries whose first relay failed — expected for every
+/// delivery until #5089 step 4 binds the targets' listeners.
+/// What: spawns a detached task. Deliberately NOT the detection path: if this
+/// task dies, `GET /api/console/metrics/webhooks` still turns red, because it
+/// scans the spool on the request rather than reading anything this loop wrote.
+/// Test: the sweep body is tested directly via `retry_sweep_*`; the timer
+/// wrapper carries no logic to test.
+pub fn start_retry_sweep(ingress: WebhookIngress, interval: Duration) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            let report = ingress.retry_pending_once().await;
+            if report.acked > 0 || report.still_pending > 0 || report.scan_error.is_some() {
+                tracing::info!(
+                    acked = report.acked,
+                    still_pending = report.still_pending,
+                    orphaned = report.orphaned,
+                    undecodable = report.undecodable,
+                    "webhook retry sweep completed"
+                );
+            }
+        }
+    });
+}

--- a/crates/trusty-console/src/webhook/relay.rs
+++ b/crates/trusty-console/src/webhook/relay.rs
@@ -1,0 +1,276 @@
+//! Relaying a spooled delivery to its target over UDS, and deciding what
+//! counts as an acknowledgement.
+//!
+//! Why: ADR-0034 §2 permits deleting a spool entry only when "the target has
+//! acknowledged the frame on the UDS response". The easy wrong answer is to
+//! treat a successful `connect` — or any response at all — as success, which
+//! moves the silent loss down one layer instead of removing it. This module
+//! makes the ack an explicit, positively-asserted field and defaults every
+//! other shape to "not acknowledged".
+//!
+//! What: [`UdsRelay::deliver`] builds a JSON-RPC 2.0 frame carrying the raw
+//! body byte-exact plus the provenance record, sends it through
+//! `trusty_common::uds::send_framed_request` (which verifies the socket's
+//! `0700` directory and `0600` mode before writing), and classifies the
+//! response into [`RelayOutcome`].
+//!
+//! Until #5089 step 4 binds the targets' listeners, the expected outcome here
+//! is [`RelayOutcome::Unreachable`]. That is a first-class, durable state — the
+//! entry stays pending and its attempt count grows — not an error to swallow.
+//!
+//! Test: `webhook/tests.rs` — `relay_*` cases run against a test-double
+//! `UnixListener` bound through `bind_hardened`.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use trusty_common::uds::{UdsRpcError, send_framed_request};
+
+use super::spool::{Provenance, SpoolEntry};
+
+/// JSON-RPC method the target implements to accept a relayed delivery.
+///
+/// Fixed here and consumed by #5089 step 4's listener; a mismatch is a
+/// compile-time-invisible wire break, so both halves read this constant.
+pub const RELAY_METHOD: &str = "webhook.deliver";
+
+/// Default budget for one relay round trip.
+///
+/// GitHub's own delivery timeout is 10 s and the relay runs inside the request
+/// that must beat it, so this leaves headroom for the spool write and the
+/// response.
+pub const DEFAULT_RELAY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// What one relay attempt established.
+///
+/// Why: three states, not two. "Reached the target and it refused" and "never
+/// reached the target" call for different operator action, and neither is an
+/// acknowledgement. Only [`RelayOutcome::Acked`] permits deleting the entry.
+/// What: `Acked` carries nothing; the other two carry a human-readable reason
+/// that is written into the entry's `last_error`.
+/// Test: `relay_*` cases in `webhook/tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RelayOutcome {
+    /// The target answered with an explicit `"ack": true`.
+    Acked,
+    /// The target answered, but not with an acknowledgement — a JSON-RPC
+    /// error, `"ack": false`, or a result with no `ack` field at all.
+    Refused {
+        /// Why the target's answer was not an ack.
+        reason: String,
+    },
+    /// The target could not be reached, did not answer, or answered
+    /// unintelligibly.
+    Unreachable {
+        /// Transport-level reason.
+        reason: String,
+    },
+}
+
+impl RelayOutcome {
+    /// True only for [`RelayOutcome::Acked`].
+    ///
+    /// The single predicate the deletion path is allowed to consult, so no call
+    /// site can spell "not unreachable" and delete a refused entry.
+    pub fn is_acked(&self) -> bool {
+        matches!(self, RelayOutcome::Acked)
+    }
+
+    /// The reason string, or `"acknowledged"`.
+    pub fn reason(&self) -> &str {
+        match self {
+            RelayOutcome::Acked => "acknowledged",
+            RelayOutcome::Refused { reason } | RelayOutcome::Unreachable { reason } => reason,
+        }
+    }
+}
+
+/// The frame console writes to the target.
+///
+/// Why: ADR-0034 §3 — "the relayed frame carries the raw body verbatim, the
+/// original headers, the delivery GUID, and an explicit provenance record".
+/// Byte-exactness is what lets a target re-verify the HMAC itself instead of
+/// trusting console unconditionally.
+/// What: JSON-RPC 2.0 request whose params are the spooled entry's
+/// delivery-relevant fields. `body_b64` is copied, never re-encoded from a
+/// parsed value.
+/// Test: `relay_frame_carries_provenance_and_byte_exact_body`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RelayFrame<'a> {
+    /// Always `"2.0"`.
+    pub jsonrpc: &'static str,
+    /// Always [`RELAY_METHOD`].
+    pub method: &'static str,
+    /// Request id — the delivery GUID, so a target's logs correlate with
+    /// GitHub's delivery list without a second identifier.
+    pub id: &'a str,
+    /// The delivery itself.
+    pub params: RelayParams<'a>,
+}
+
+/// Params of a [`RelayFrame`].
+#[derive(Debug, Clone, Serialize)]
+pub struct RelayParams<'a> {
+    /// GitHub's `X-GitHub-Delivery` GUID.
+    pub delivery_id: &'a str,
+    /// Which console route the delivery arrived on.
+    pub source: &'a str,
+    /// The `X-GitHub-Event` value.
+    pub event: &'a str,
+    /// Original request headers, lowercased.
+    pub headers: &'a std::collections::BTreeMap<String, String>,
+    /// The raw body, base64, byte-exact as received.
+    pub body_b64: &'a str,
+    /// What console verified, and with which key.
+    pub provenance: &'a Provenance,
+    /// When console accepted the delivery.
+    pub received_at_unix_ms: u64,
+    /// How many attempts have already failed, so a target can distinguish a
+    /// first delivery from a retry.
+    pub attempts: u32,
+}
+
+impl<'a> RelayFrame<'a> {
+    /// Build a frame from a spooled entry, borrowing rather than copying the
+    /// body so it cannot be transformed on the way through.
+    pub fn from_entry(entry: &'a SpoolEntry) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            method: RELAY_METHOD,
+            id: &entry.delivery_id,
+            params: RelayParams {
+                delivery_id: &entry.delivery_id,
+                source: &entry.source,
+                event: &entry.event,
+                headers: &entry.headers,
+                body_b64: &entry.body_b64,
+                provenance: &entry.provenance,
+                received_at_unix_ms: entry.received_at_unix_ms,
+                attempts: entry.attempts,
+            },
+        }
+    }
+}
+
+/// The target's answer.
+///
+/// `ack` is `#[serde(default)]` on purpose: a target that answers with a result
+/// object lacking the field has NOT acknowledged, and the default must be the
+/// safe direction.
+#[derive(Debug, Clone, Deserialize)]
+struct RelayResponse {
+    #[serde(default)]
+    result: Option<RelayResult>,
+    #[serde(default)]
+    error: Option<RelayRpcError>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RelayResult {
+    #[serde(default)]
+    ack: bool,
+    #[serde(default)]
+    detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RelayRpcError {
+    #[serde(default)]
+    code: i64,
+    #[serde(default)]
+    message: String,
+}
+
+/// Console's UDS client for one target.
+///
+/// Why: spawn-on-demand is #5089 step 4's job, so this dials an existing socket
+/// and reports [`RelayOutcome::Unreachable`] when nothing is listening — the
+/// state every delivery is in until that step lands.
+/// What: a socket path plus a timeout. Cheap to clone; opens a fresh connection
+/// per delivery, matching every other UDS client in this workspace.
+/// Test: `relay_*` cases in `webhook/tests.rs`.
+#[derive(Debug, Clone)]
+pub struct UdsRelay {
+    socket: PathBuf,
+    timeout: Duration,
+}
+
+impl UdsRelay {
+    /// Target `socket` with [`DEFAULT_RELAY_TIMEOUT`].
+    pub fn new(socket: impl Into<PathBuf>) -> Self {
+        Self {
+            socket: socket.into(),
+            timeout: DEFAULT_RELAY_TIMEOUT,
+        }
+    }
+
+    /// Override the round-trip budget.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Socket this relay dials.
+    pub fn socket(&self) -> &Path {
+        &self.socket
+    }
+
+    /// Send one delivery and classify the answer.
+    ///
+    /// Why: the classification is the whole safety property. Anything other
+    /// than an explicit `"ack": true` leaves the entry pending, so a target that
+    /// accepts a connection and then crashes, or answers with an empty object,
+    /// does not cause the delivery to be dropped.
+    ///
+    /// What: dials through the hardened UDS entry point, writes one frame,
+    /// reads one frame, and maps: JSON-RPC `error` → [`RelayOutcome::Refused`];
+    /// `result.ack == true` → [`RelayOutcome::Acked`]; any other result shape →
+    /// `Refused`; any transport failure → [`RelayOutcome::Unreachable`].
+    ///
+    /// Never returns `Err`: every failure is a first-class outcome the caller
+    /// must record durably, and an error return invites the `let _ =` this ADR
+    /// forbids.
+    ///
+    /// Test: `relay_acked_response_is_the_only_ack`,
+    /// `relay_treats_a_result_without_ack_as_refused`,
+    /// `relay_treats_a_jsonrpc_error_as_refused`,
+    /// `relay_reports_unreachable_when_no_listener_is_bound`,
+    /// `relay_reports_unreachable_when_the_target_hangs_up_without_answering`.
+    pub async fn deliver(&self, entry: &SpoolEntry) -> RelayOutcome {
+        let frame = RelayFrame::from_entry(entry);
+        let response: Result<RelayResponse, UdsRpcError> =
+            send_framed_request(&self.socket, &frame, self.timeout).await;
+
+        match response {
+            Ok(RelayResponse {
+                error: Some(err), ..
+            }) => RelayOutcome::Refused {
+                reason: format!(
+                    "target rejected the frame: code {} — {}",
+                    err.code, err.message
+                ),
+            },
+            Ok(RelayResponse {
+                result: Some(result),
+                ..
+            }) => {
+                if result.ack {
+                    RelayOutcome::Acked
+                } else {
+                    RelayOutcome::Refused {
+                        reason: result.detail.unwrap_or_else(|| {
+                            "target answered without an explicit \"ack\": true".to_string()
+                        }),
+                    }
+                }
+            }
+            Ok(_) => RelayOutcome::Refused {
+                reason: "target answered with neither a result nor an error".to_string(),
+            },
+            Err(e) => RelayOutcome::Unreachable {
+                reason: format!("{e}"),
+            },
+        }
+    }
+}

--- a/crates/trusty-console/src/webhook/relay.rs
+++ b/crates/trusty-console/src/webhook/relay.rs
@@ -1,21 +1,21 @@
-//! Relaying a spooled delivery to its target over UDS, and deciding what
-//! counts as an acknowledgement.
+//! Sending a spooled delivery to its target, and deciding what counts as an
+//! acknowledgement.
 //!
 //! Why: ADR-0034 §2 permits deleting a spool entry only when "the target has
 //! acknowledged the frame on the UDS response". The easy wrong answer is to
 //! treat a successful `connect` — or any response at all — as success, which
-//! moves the silent loss down one layer instead of removing it. This module
-//! makes the ack an explicit, positively-asserted field and defaults every
-//! other shape to "not acknowledged".
+//! moves the silent loss down one layer instead of removing it.
 //!
-//! What: [`UdsRelay::deliver`] builds a JSON-RPC 2.0 frame carrying the raw
-//! body byte-exact plus the provenance record, sends it through
-//! `trusty_common::uds::send_framed_request` (which verifies the socket's
-//! `0700` directory and `0600` mode before writing), and classifies the
-//! response into [`RelayOutcome`].
+//! What: [`UdsRelay::deliver`] builds a `trusty_common::webhook_relay::RelayFrame`
+//! carrying the raw body byte-exact plus the provenance record, sends it through
+//! `trusty_common::uds::send_framed_request` (which verifies the socket's `0700`
+//! directory and `0600` mode before writing), and classifies the answer into
+//! [`RelayOutcome`]. The wire types themselves live in `trusty-common` because
+//! step 4's receivers are `trusty-review` and `trusty-analyze`, which cannot
+//! depend on the console.
 //!
-//! Until #5089 step 4 binds the targets' listeners, the expected outcome here
-//! is [`RelayOutcome::Unreachable`]. That is a first-class, durable state — the
+//! Until step 4 binds the targets' listeners, the expected outcome is
+//! [`RelayOutcome::Unreachable`]. That is a first-class durable state — the
 //! entry stays pending and its attempt count grows — not an error to swallow.
 //!
 //! Test: `webhook/tests.rs` — `relay_*` cases run against a test-double
@@ -24,22 +24,18 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use serde::{Deserialize, Serialize};
 use trusty_common::uds::{UdsRpcError, send_framed_request};
+use trusty_common::webhook_relay::{RelayFrame, RelayResponse};
 
-use super::spool::{Provenance, SpoolEntry};
-
-/// JSON-RPC method the target implements to accept a relayed delivery.
-///
-/// Fixed here and consumed by #5089 step 4's listener; a mismatch is a
-/// compile-time-invisible wire break, so both halves read this constant.
-pub const RELAY_METHOD: &str = "webhook.deliver";
+use super::spool::SpoolEntry;
 
 /// Default budget for one relay round trip.
 ///
 /// GitHub's own delivery timeout is 10 s and the relay runs inside the request
 /// that must beat it, so this leaves headroom for the spool write and the
-/// response.
+/// response. It is also the grace period the retry sweep gives a freshly
+/// spooled entry before considering it its own to relay — see
+/// [`super::BackoffPolicy`].
 pub const DEFAULT_RELAY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// What one relay attempt established.
@@ -48,7 +44,7 @@ pub const DEFAULT_RELAY_TIMEOUT: Duration = Duration::from_secs(5);
 /// reached the target" call for different operator action, and neither is an
 /// acknowledgement. Only [`RelayOutcome::Acked`] permits deleting the entry.
 /// What: `Acked` carries nothing; the other two carry a human-readable reason
-/// that is written into the entry's `last_error`.
+/// written into the entry's `last_error`.
 /// Test: `relay_*` cases in `webhook/tests.rs`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RelayOutcome {
@@ -86,102 +82,6 @@ impl RelayOutcome {
     }
 }
 
-/// The frame console writes to the target.
-///
-/// Why: ADR-0034 §3 — "the relayed frame carries the raw body verbatim, the
-/// original headers, the delivery GUID, and an explicit provenance record".
-/// Byte-exactness is what lets a target re-verify the HMAC itself instead of
-/// trusting console unconditionally.
-/// What: JSON-RPC 2.0 request whose params are the spooled entry's
-/// delivery-relevant fields. `body_b64` is copied, never re-encoded from a
-/// parsed value.
-/// Test: `relay_frame_carries_provenance_and_byte_exact_body`.
-#[derive(Debug, Clone, Serialize)]
-pub struct RelayFrame<'a> {
-    /// Always `"2.0"`.
-    pub jsonrpc: &'static str,
-    /// Always [`RELAY_METHOD`].
-    pub method: &'static str,
-    /// Request id — the delivery GUID, so a target's logs correlate with
-    /// GitHub's delivery list without a second identifier.
-    pub id: &'a str,
-    /// The delivery itself.
-    pub params: RelayParams<'a>,
-}
-
-/// Params of a [`RelayFrame`].
-#[derive(Debug, Clone, Serialize)]
-pub struct RelayParams<'a> {
-    /// GitHub's `X-GitHub-Delivery` GUID.
-    pub delivery_id: &'a str,
-    /// Which console route the delivery arrived on.
-    pub source: &'a str,
-    /// The `X-GitHub-Event` value.
-    pub event: &'a str,
-    /// Original request headers, lowercased.
-    pub headers: &'a std::collections::BTreeMap<String, String>,
-    /// The raw body, base64, byte-exact as received.
-    pub body_b64: &'a str,
-    /// What console verified, and with which key.
-    pub provenance: &'a Provenance,
-    /// When console accepted the delivery.
-    pub received_at_unix_ms: u64,
-    /// How many attempts have already failed, so a target can distinguish a
-    /// first delivery from a retry.
-    pub attempts: u32,
-}
-
-impl<'a> RelayFrame<'a> {
-    /// Build a frame from a spooled entry, borrowing rather than copying the
-    /// body so it cannot be transformed on the way through.
-    pub fn from_entry(entry: &'a SpoolEntry) -> Self {
-        Self {
-            jsonrpc: "2.0",
-            method: RELAY_METHOD,
-            id: &entry.delivery_id,
-            params: RelayParams {
-                delivery_id: &entry.delivery_id,
-                source: &entry.source,
-                event: &entry.event,
-                headers: &entry.headers,
-                body_b64: &entry.body_b64,
-                provenance: &entry.provenance,
-                received_at_unix_ms: entry.received_at_unix_ms,
-                attempts: entry.attempts,
-            },
-        }
-    }
-}
-
-/// The target's answer.
-///
-/// `ack` is `#[serde(default)]` on purpose: a target that answers with a result
-/// object lacking the field has NOT acknowledged, and the default must be the
-/// safe direction.
-#[derive(Debug, Clone, Deserialize)]
-struct RelayResponse {
-    #[serde(default)]
-    result: Option<RelayResult>,
-    #[serde(default)]
-    error: Option<RelayRpcError>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct RelayResult {
-    #[serde(default)]
-    ack: bool,
-    #[serde(default)]
-    detail: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct RelayRpcError {
-    #[serde(default)]
-    code: i64,
-    #[serde(default)]
-    message: String,
-}
-
 /// Console's UDS client for one target.
 ///
 /// Why: spawn-on-demand is #5089 step 4's job, so this dials an existing socket
@@ -216,6 +116,12 @@ impl UdsRelay {
         &self.socket
     }
 
+    /// Round-trip budget, which is also the sweep's hands-off grace period for
+    /// an entry the request path may still be relaying.
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
     /// Send one delivery and classify the answer.
     ///
     /// Why: the classification is the whole safety property. Anything other
@@ -224,13 +130,14 @@ impl UdsRelay {
     /// does not cause the delivery to be dropped.
     ///
     /// What: dials through the hardened UDS entry point, writes one frame,
-    /// reads one frame, and maps: JSON-RPC `error` → [`RelayOutcome::Refused`];
-    /// `result.ack == true` → [`RelayOutcome::Acked`]; any other result shape →
-    /// `Refused`; any transport failure → [`RelayOutcome::Unreachable`].
+    /// reads one frame, and defers the ack decision to
+    /// `RelayResponse::is_ack` so both halves of the contract agree on it. A
+    /// JSON-RPC error or a non-ack result is [`RelayOutcome::Refused`]; any
+    /// transport failure is [`RelayOutcome::Unreachable`].
     ///
     /// Never returns `Err`: every failure is a first-class outcome the caller
-    /// must record durably, and an error return invites the `let _ =` this ADR
-    /// forbids.
+    /// must record durably, and an error return invites the `let _ =` ADR-0034
+    /// §2 forbids.
     ///
     /// Test: `relay_acked_response_is_the_only_ack`,
     /// `relay_treats_a_result_without_ack_as_refused`,
@@ -238,39 +145,48 @@ impl UdsRelay {
     /// `relay_reports_unreachable_when_no_listener_is_bound`,
     /// `relay_reports_unreachable_when_the_target_hangs_up_without_answering`.
     pub async fn deliver(&self, entry: &SpoolEntry) -> RelayOutcome {
-        let frame = RelayFrame::from_entry(entry);
+        let frame = RelayFrame::new(
+            &entry.delivery_id,
+            &entry.source,
+            &entry.event,
+            &entry.headers,
+            &entry.body_b64,
+            &entry.provenance,
+            entry.received_at_unix_ms,
+            entry.attempts,
+        );
         let response: Result<RelayResponse, UdsRpcError> =
             send_framed_request(&self.socket, &frame, self.timeout).await;
 
         match response {
-            Ok(RelayResponse {
-                error: Some(err), ..
-            }) => RelayOutcome::Refused {
-                reason: format!(
-                    "target rejected the frame: code {} — {}",
-                    err.code, err.message
-                ),
-            },
-            Ok(RelayResponse {
-                result: Some(result),
-                ..
-            }) => {
-                if result.ack {
-                    RelayOutcome::Acked
-                } else {
-                    RelayOutcome::Refused {
-                        reason: result.detail.unwrap_or_else(|| {
-                            "target answered without an explicit \"ack\": true".to_string()
-                        }),
-                    }
-                }
-            }
-            Ok(_) => RelayOutcome::Refused {
-                reason: "target answered with neither a result nor an error".to_string(),
+            Ok(resp) if resp.is_ack() => RelayOutcome::Acked,
+            Ok(resp) => RelayOutcome::Refused {
+                reason: refusal_reason(&resp),
             },
             Err(e) => RelayOutcome::Unreachable {
                 reason: format!("{e}"),
             },
         }
+    }
+}
+
+/// Turn a non-ack response into the string stored in the entry's `last_error`.
+///
+/// Prefers the target's own words — a JSON-RPC error message, then a result
+/// `detail` — so an operator reading the durable record sees the target's
+/// diagnosis rather than console's paraphrase of it.
+fn refusal_reason(resp: &RelayResponse) -> String {
+    if let Some(err) = &resp.error {
+        return format!(
+            "target rejected the frame: code {} — {}",
+            err.code, err.message
+        );
+    }
+    match resp.result.as_ref().and_then(|r| r.detail.clone()) {
+        Some(detail) => detail,
+        None if resp.result.is_some() => {
+            "target answered without an explicit \"ack\": true".to_string()
+        }
+        None => "target answered with neither a result nor an error".to_string(),
     }
 }

--- a/crates/trusty-console/src/webhook/schedule.rs
+++ b/crates/trusty-console/src/webhook/schedule.rs
@@ -45,7 +45,7 @@ use super::spool::SpoolEntry;
 /// `delivery_id` dedup step 4 owes is the real cross-process answer.
 ///
 /// Test: `claim_set_refuses_a_second_claim_on_the_same_path`,
-/// `claim_set_releases_on_drop`.
+/// `claim_set_releases_on_drop_even_when_the_holder_panics`.
 #[derive(Debug, Clone, Default)]
 pub struct ClaimSet {
     held: Arc<Mutex<HashSet<PathBuf>>>,

--- a/crates/trusty-console/src/webhook/schedule.rs
+++ b/crates/trusty-console/src/webhook/schedule.rs
@@ -1,0 +1,199 @@
+//! Who may relay an entry, and when — the two guards that keep one delivery
+//! from becoming several relays.
+//!
+//! Why: without them the retry sweep and the request path race. A sweep tick
+//! landing inside the ≤5 s window while `ingest`'s own relay is still in flight
+//! lists the same `.json`, relays it again, and both attempts settle — one
+//! delivery, two relays, and with at-least-once semantics that is a duplicate
+//! the target sees. Separately, a sweep with no backoff re-relays every pending
+//! entry every tick and rewrites its whole body plus two `fsync`s each time,
+//! forever, which ADR-0034 §2's "Console retries with backoff" exists to
+//! prevent.
+//!
+//! What: [`ClaimSet`] is an in-process exclusion — one relay per entry path at a
+//! time, released on drop so a panicking relay cannot wedge the entry.
+//! [`BackoffPolicy`] decides whether an entry is *due*: a freshly spooled one is
+//! left alone for the relay timeout (the request path may still own it), and a
+//! previously-attempted one waits `base × 2^attempts`, capped, before the next
+//! try — stopping entirely at `max_attempts`.
+//!
+//! The two are independent on purpose. Backoff bounds cost over minutes and
+//! hours; the claim set closes the sub-second window backoff cannot see, since
+//! a first-attempt entry has no `last_attempt_at_unix_ms` to reason from.
+//!
+//! Test: `webhook/tests.rs` — `backoff_*` and the `sweep_*` concurrency cases,
+//! notably `sweep_does_not_relay_an_entry_the_request_path_is_still_relaying`.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use super::spool::SpoolEntry;
+
+/// Exclusive in-process ownership of one spool entry's relay.
+///
+/// Why: both `ingest` and the sweep can reach the same entry path. A claim held
+/// for the duration of the relay makes "someone is already relaying this" a
+/// checkable fact rather than a timing hope.
+/// What: a shared `HashSet<PathBuf>`. Locks are held only across the insert or
+/// remove, never across an `await`.
+///
+/// In-process only, and deliberately so: two console processes sharing one
+/// spool directory would still double-relay. That is out of scope here because
+/// console is a singleton per data directory, and the target-side
+/// `delivery_id` dedup step 4 owes is the real cross-process answer.
+///
+/// Test: `claim_set_refuses_a_second_claim_on_the_same_path`,
+/// `claim_set_releases_on_drop`.
+#[derive(Debug, Clone, Default)]
+pub struct ClaimSet {
+    held: Arc<Mutex<HashSet<PathBuf>>>,
+}
+
+impl ClaimSet {
+    /// A fresh, empty claim set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Take exclusive ownership of `path`, or `None` if someone already has it.
+    ///
+    /// The returned guard releases on drop, including on panic and on an early
+    /// `?` return, so a failed relay cannot leave an entry permanently claimed.
+    ///
+    /// Test: `claim_set_refuses_a_second_claim_on_the_same_path`.
+    pub fn claim(&self, path: &Path) -> Option<Claim> {
+        let mut held = self.held.lock().unwrap_or_else(|e| e.into_inner());
+        if !held.insert(path.to_path_buf()) {
+            return None;
+        }
+        Some(Claim {
+            held: Arc::clone(&self.held),
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// How many entries are claimed right now. Diagnostics and tests only.
+    pub fn len(&self) -> usize {
+        self.held.lock().unwrap_or_else(|e| e.into_inner()).len()
+    }
+
+    /// Whether nothing is claimed.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Ownership of one entry's relay, released when dropped.
+#[derive(Debug)]
+pub struct Claim {
+    held: Arc<Mutex<HashSet<PathBuf>>>,
+    path: PathBuf,
+}
+
+impl Drop for Claim {
+    fn drop(&mut self) {
+        self.held
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&self.path);
+    }
+}
+
+/// When a pending entry becomes eligible for another relay attempt.
+///
+/// Why: ADR-0034 §2 says "Console retries with backoff" and the first cut had
+/// none — every pending entry was re-relayed every 60 s, each non-ack rewriting
+/// the full base64 body plus two `fsync`s. Until step 4 binds a listener that is
+/// every delivery, forever.
+/// What: a grace period for a never-attempted entry, exponential spacing keyed
+/// on `attempts`, a ceiling, and a hard stop. Pure — [`BackoffPolicy::is_due`]
+/// takes `now` so the rules are testable without sleeping.
+/// Test: `backoff_holds_off_a_freshly_spooled_entry`,
+/// `backoff_spacing_grows_with_attempts`, `backoff_respects_the_ceiling`,
+/// `backoff_stops_at_max_attempts`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackoffPolicy {
+    /// How long a never-attempted entry is left alone after being spooled.
+    ///
+    /// Set to the relay timeout: within that window the request path that
+    /// spooled it may still be relaying it, and its claim has not necessarily
+    /// been taken yet at the instant the sweep lists the directory.
+    pub first_attempt_grace: Duration,
+    /// Spacing after the first failure; doubles per subsequent attempt.
+    pub base: Duration,
+    /// Upper bound on the spacing, however many attempts have failed.
+    pub ceiling: Duration,
+    /// After this many failed attempts the entry is never relayed again.
+    ///
+    /// It is NOT deleted — it stays on disk and keeps the health signal red,
+    /// because an undeliverable webhook is an operator problem, not garbage.
+    /// The cap exists so a permanently unrelayable entry stops costing a
+    /// full-body rewrite and two `fsync`s on every tick.
+    pub max_attempts: u32,
+}
+
+impl Default for BackoffPolicy {
+    /// 5 s grace, 30 s base doubling to a 1 h ceiling, giving up after 24
+    /// failures — roughly a day of retries for an entry that never lands.
+    fn default() -> Self {
+        Self {
+            first_attempt_grace: super::relay::DEFAULT_RELAY_TIMEOUT,
+            base: Duration::from_secs(30),
+            ceiling: Duration::from_secs(3600),
+            max_attempts: 24,
+        }
+    }
+}
+
+impl BackoffPolicy {
+    /// Spacing required after `attempts` failures.
+    ///
+    /// `base << (attempts - 1)`, saturating into [`BackoffPolicy::ceiling`].
+    /// The shift is bounded before it is applied, so a large attempt count
+    /// cannot overflow into a small delay.
+    ///
+    /// Test: `backoff_spacing_grows_with_attempts`, `backoff_respects_the_ceiling`.
+    pub fn delay_after(&self, attempts: u32) -> Duration {
+        if attempts == 0 {
+            return self.first_attempt_grace;
+        }
+        let shift = (attempts - 1).min(32);
+        let scaled = self
+            .base
+            .as_millis()
+            .saturating_mul(1u128 << shift)
+            .min(self.ceiling.as_millis());
+        Duration::from_millis(scaled.min(u128::from(u64::MAX)) as u64)
+    }
+
+    /// Whether `entry` may be relayed again at `now_unix_ms`.
+    ///
+    /// Why: the sweep's only admission test. Returning `false` leaves the entry
+    /// exactly where it is — pending, durable, and visible to the health scan —
+    /// so a "not due" entry is never a dropped one.
+    /// What: `false` past [`BackoffPolicy::max_attempts`]; otherwise the elapsed
+    /// time since the last attempt (or since receipt, for a never-attempted
+    /// entry) must meet [`BackoffPolicy::delay_after`].
+    /// Test: `backoff_holds_off_a_freshly_spooled_entry`,
+    /// `backoff_stops_at_max_attempts`, `backoff_admits_an_entry_past_its_delay`.
+    pub fn is_due(&self, entry: &SpoolEntry, now_unix_ms: u64) -> bool {
+        if entry.attempts >= self.max_attempts {
+            return false;
+        }
+        let since = entry
+            .last_attempt_at_unix_ms
+            .unwrap_or(entry.received_at_unix_ms);
+        let elapsed_ms = u128::from(now_unix_ms.saturating_sub(since));
+        elapsed_ms >= self.delay_after(entry.attempts).as_millis()
+    }
+
+    /// Whether `entry` has exhausted its retries and needs an operator.
+    ///
+    /// Distinguished from "not due yet" so the sweep can report the two
+    /// separately — one resolves itself, the other never will.
+    pub fn is_exhausted(&self, entry: &SpoolEntry) -> bool {
+        entry.attempts >= self.max_attempts
+    }
+}

--- a/crates/trusty-console/src/webhook/spool.rs
+++ b/crates/trusty-console/src/webhook/spool.rs
@@ -1,0 +1,486 @@
+//! The durable spool: a delivery is on disk and fsync'd before console
+//! acknowledges GitHub.
+//!
+//! Why: both existing webhook handlers return `202` and *then* do the work, so
+//! any failure after the ack loses the delivery permanently — GitHub does not
+//! retry an acknowledged delivery (ADR-0034 Context, "The fail-open shape,
+//! already shipped on this exact path"). Ordering the durable write before the
+//! ack is what makes a lost delivery either recoverable from GitHub (never
+//! acked) or visible in a health signal (acked and spooled). That ordering only
+//! holds if the write is genuinely durable, hence the fsync of both the file
+//! and its directory.
+//!
+//! What: one JSON file per delivery under
+//! `resolve_data_dir("trusty-console")/webhook-spool/`. [`Spool::persist`]
+//! writes a temp file, `fsync`s it, renames it into place, then `fsync`s the
+//! directory so the rename itself survives a crash. [`Spool::record_attempt`]
+//! rewrites an entry through the same sequence with a bumped attempt count.
+//! [`Spool::remove_acked`] is the only deletion path and is reachable only from
+//! an explicit target acknowledgement.
+//!
+//! 🔴 Every fallible step here returns an error to the caller. Nothing in this
+//! module logs-and-continues, because a swallowed spool failure is exactly the
+//! defect the spool exists to remove.
+//!
+//! Test: `webhook/tests.rs` — `spool_*` cases cover the durable round trip,
+//! attempt bumping, ack-only deletion, and both write-failure arms.
+
+use std::collections::BTreeMap;
+use std::fs::{File, Permissions};
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Mode the spool directory is held at.
+///
+/// A spooled delivery holds the raw webhook body, which is not public data.
+/// Owner-only, matching the `0700` convention `trusty_common::uds` established
+/// for the socket directory.
+const SPOOL_DIR_MODE: u32 = 0o700;
+
+/// Mode every spool entry file is written at.
+const SPOOL_FILE_MODE: u32 = 0o600;
+
+/// Bumped whenever [`SpoolEntry`]'s shape changes, so a future reader can tell
+/// an entry it cannot interpret from one it can.
+pub const SPOOL_SCHEMA_VERSION: u32 = 1;
+
+/// Directory name under the console's data dir.
+pub const SPOOL_DIR_NAME: &str = "webhook-spool";
+
+/// Failures of the durable-write path. Every variant means the delivery is
+/// **not** safely recorded, so every one of them must reach the HTTP caller as
+/// a 5xx rather than a log line.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SpoolError {
+    /// The spool directory could not be created or hardened.
+    #[error("prepare spool directory {path}: {source}")]
+    PrepareDir {
+        /// Directory that could not be prepared.
+        path: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Serialising the entry failed.
+    #[error("serialize spool entry {delivery_id}: {source}")]
+    Encode {
+        /// Delivery that could not be encoded.
+        delivery_id: String,
+        /// Underlying serde error.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// Writing or fsyncing the temp file failed — disk full, permission, or a
+    /// genuine fsync error.
+    #[error("write spool entry to {path}: {source}")]
+    Write {
+        /// Temp path that could not be written.
+        path: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The atomic rename into place failed.
+    #[error("commit spool entry {from} -> {to}: {source}")]
+    Commit {
+        /// Temp path.
+        from: PathBuf,
+        /// Final path.
+        to: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The directory fsync that makes the rename durable failed.
+    #[error("fsync spool directory {path}: {source}")]
+    SyncDir {
+        /// Directory that could not be synced.
+        path: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Listing the spool failed. Surfaced as a red health state rather than an
+    /// empty (and therefore falsely healthy) listing.
+    #[error("read spool directory {path}: {source}")]
+    ReadDir {
+        /// Directory that could not be read.
+        path: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Deleting an acknowledged entry failed.
+    #[error("remove acknowledged spool entry {path}: {source}")]
+    Remove {
+        /// Entry that could not be removed.
+        path: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// What console proves to the target about a relayed body (ADR-0034 §3).
+///
+/// Why: the target trusts this assertion because only a same-uid process could
+/// have written it through a `0600` socket. Recording the algorithm and key id
+/// explicitly — rather than letting the target infer "it came over UDS so it is
+/// fine" — is what keeps the trust boundary named rather than assumed.
+/// What: three fields, all serialised into the relay frame verbatim.
+/// Test: `relay_frame_carries_provenance_and_byte_exact_body`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Provenance {
+    /// Algorithm console checked, e.g. `hmac-sha256`.
+    pub algorithm: String,
+    /// Which secret was used, by name — never the secret itself.
+    pub key_id: String,
+    /// Whether verification succeeded. Always `true` for a spooled entry:
+    /// console refuses an unverified delivery before it reaches the spool.
+    pub verified: bool,
+}
+
+/// One spooled delivery.
+///
+/// Why: holds everything a target needs to act on the delivery and everything
+/// an operator needs to diagnose a stuck one, so a pending entry is
+/// self-describing without console being alive to explain it.
+/// What: the raw body is base64 so the JSON container cannot corrupt bytes the
+/// HMAC was computed over; the target decodes it and may re-verify
+/// independently. `attempts` and `last_error` are the durable record of relay
+/// failure that replaces the `tracing::warn!` both current handlers use.
+/// Test: `spool_persists_and_reloads_an_entry_byte_exact`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpoolEntry {
+    /// Schema version; see [`SPOOL_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// GitHub's `X-GitHub-Delivery` GUID, or a synthesised stand-in.
+    pub delivery_id: String,
+    /// Which target this delivery is bound for (`review` / `analyze`).
+    pub source: String,
+    /// The `X-GitHub-Event` value.
+    pub event: String,
+    /// The request headers, lowercased, as received.
+    pub headers: BTreeMap<String, String>,
+    /// The raw request body, base64-encoded — byte-exact, never re-serialised.
+    pub body_b64: String,
+    /// What console verified before spooling.
+    pub provenance: Provenance,
+    /// When console accepted the delivery.
+    pub received_at_unix_ms: u64,
+    /// How many relay attempts have failed. `0` on a freshly spooled entry.
+    pub attempts: u32,
+    /// Why the most recent attempt failed, if one has.
+    pub last_error: Option<String>,
+    /// When the most recent attempt ran.
+    pub last_attempt_at_unix_ms: Option<u64>,
+}
+
+/// A pending entry paired with the path it lives at.
+#[derive(Debug, Clone)]
+pub struct PendingEntry {
+    /// Absolute path of the entry file.
+    pub path: PathBuf,
+    /// The decoded entry.
+    pub entry: SpoolEntry,
+}
+
+/// The on-disk spool rooted at one directory.
+///
+/// Why: `trusty_common::resolve_data_dir("trusty-console")` is already the
+/// console's canonical state location (`lib.rs:476`), so the spool is a
+/// subdirectory of it rather than a new location convention.
+/// What: a path plus the durable write sequence. Cheap to clone.
+/// Test: every `spool_*` case in `webhook/tests.rs`.
+#[derive(Debug, Clone)]
+pub struct Spool {
+    root: PathBuf,
+}
+
+impl Spool {
+    /// Bind a spool to `root` without touching the filesystem.
+    ///
+    /// Why: lets a caller construct the spool before deciding whether it can be
+    /// created, and lets a test point one at a path that will fail on write.
+    /// What: stores the path. No I/O.
+    /// Test: `spool_persist_fails_when_the_root_is_not_a_directory`.
+    pub fn at(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Bind a spool to `root`, creating it at `0700`.
+    ///
+    /// Test: `spool_open_creates_the_directory_at_0700`.
+    pub fn open(root: impl Into<PathBuf>) -> Result<Self, SpoolError> {
+        let spool = Self::at(root);
+        spool.prepare_dir()?;
+        Ok(spool)
+    }
+
+    /// The console's production spool location.
+    ///
+    /// Test: exercised indirectly by `WebhookIngress::from_env`.
+    pub fn default_root() -> anyhow::Result<PathBuf> {
+        Ok(trusty_common::resolve_data_dir("trusty-console")?.join(SPOOL_DIR_NAME))
+    }
+
+    /// Directory this spool writes into.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn prepare_dir(&self) -> Result<(), SpoolError> {
+        std::fs::create_dir_all(&self.root).map_err(|source| SpoolError::PrepareDir {
+            path: self.root.clone(),
+            source,
+        })?;
+        std::fs::set_permissions(&self.root, Permissions::from_mode(SPOOL_DIR_MODE)).map_err(
+            |source| SpoolError::PrepareDir {
+                path: self.root.clone(),
+                source,
+            },
+        )
+    }
+
+    /// Path an entry occupies, derived from its receipt time and delivery id.
+    ///
+    /// Why: the leading zero-padded millisecond timestamp makes a lexical sort
+    /// an age sort, so the oldest-pending scan does not have to parse every
+    /// file to find the oldest one. Public because [`Spool::record_attempt`]
+    /// rewrites the same path and the tests assert on it.
+    /// What: `<received_at_unix_ms:013>-<sanitised delivery id>.json`. The id is
+    /// reduced to `[A-Za-z0-9_-]` and truncated so a hostile header value
+    /// cannot traverse out of the spool directory or overflow `NAME_MAX`.
+    /// Test: `spool_entry_path_sanitises_a_hostile_delivery_id`.
+    pub fn entry_path(&self, entry: &SpoolEntry) -> PathBuf {
+        self.root.join(format!(
+            "{:013}-{}.json",
+            entry.received_at_unix_ms,
+            sanitise_delivery_id(&entry.delivery_id)
+        ))
+    }
+
+    /// Write `entry` durably. Returns the path it now occupies.
+    ///
+    /// Why: this call returning `Ok` is the ONLY thing that licenses console to
+    /// send GitHub a `202`. ADR-0034 §2: "Console returns `202` **only after**
+    /// the delivery … is written and fsync'd to a spool."
+    ///
+    /// What: encode → write temp → `sync_all` the file → rename into place →
+    /// `sync_all` the directory. The file fsync makes the bytes durable; the
+    /// directory fsync makes the *name* durable, without which a crash can
+    /// leave the entry unreachable even though its data reached the platter.
+    ///
+    /// # Errors
+    ///
+    /// Any [`SpoolError`]. Every one means the delivery is not recorded and the
+    /// caller must return 5xx without acknowledging.
+    ///
+    /// Test: `spool_persists_and_reloads_an_entry_byte_exact`,
+    /// `spool_persist_fails_when_the_root_is_not_a_directory`,
+    /// `spool_persist_fails_when_the_final_path_is_occupied_by_a_directory`.
+    pub fn persist(&self, entry: &SpoolEntry) -> Result<PathBuf, SpoolError> {
+        let final_path = self.entry_path(entry);
+        let tmp_path = final_path.with_extension("json.tmp");
+
+        let bytes = serde_json::to_vec_pretty(entry).map_err(|source| SpoolError::Encode {
+            delivery_id: entry.delivery_id.clone(),
+            source,
+        })?;
+
+        let write = || -> std::io::Result<()> {
+            let mut file = File::create(&tmp_path)?;
+            file.set_permissions(Permissions::from_mode(SPOOL_FILE_MODE))?;
+            file.write_all(&bytes)?;
+            file.sync_all()
+        };
+        write().map_err(|source| SpoolError::Write {
+            path: tmp_path.clone(),
+            source,
+        })?;
+
+        std::fs::rename(&tmp_path, &final_path).map_err(|source| {
+            // Leaving the temp file behind on a failed rename would accumulate
+            // junk that the health scan then has to ignore; drop it here, and
+            // let the rename error stand as the reported failure.
+            let _ = std::fs::remove_file(&tmp_path);
+            SpoolError::Commit {
+                from: tmp_path.clone(),
+                to: final_path.clone(),
+                source,
+            }
+        })?;
+
+        sync_dir(&self.root)?;
+        Ok(final_path)
+    }
+
+    /// Record one failed relay attempt against a spooled entry.
+    ///
+    /// Why: ADR-0034 §2 — "Relay failure … leaves the spool entry `pending`
+    /// with an incremented attempt count. It is never deleted on failure."
+    /// The durable count is what a stuck delivery is diagnosed from; a
+    /// `tracing::warn!` is explicitly forbidden as the sole record.
+    /// What: bumps `attempts`, stores `reason` and the attempt time, and
+    /// rewrites the entry through the same durable sequence as
+    /// [`Spool::persist`]. Mutates `entry` in place so the caller sees the new
+    /// count.
+    /// Test: `spool_record_attempt_increments_durably`,
+    /// `relay_failure_leaves_a_pending_entry_with_an_incremented_attempt_count`.
+    pub fn record_attempt(
+        &self,
+        entry: &mut SpoolEntry,
+        reason: String,
+        now_unix_ms: u64,
+    ) -> Result<PathBuf, SpoolError> {
+        entry.attempts = entry.attempts.saturating_add(1);
+        entry.last_error = Some(reason);
+        entry.last_attempt_at_unix_ms = Some(now_unix_ms);
+        self.persist(entry)
+    }
+
+    /// Delete an entry the target has explicitly acknowledged.
+    ///
+    /// Why: the only deletion path in this module, reachable only from a
+    /// `RelayOutcome::Acked`. "The connection succeeded" is deliberately not
+    /// enough — ADR-0034 §2 makes the explicit ack the sole delete trigger, and
+    /// treating a successful connect as a successful delivery is the same
+    /// silent loss one layer down.
+    /// What: `remove_file`, then fsyncs the directory so the deletion is as
+    /// durable as the creation was. A missing file is not an error — a
+    /// concurrent sweep may already have removed it.
+    /// Test: `spool_remove_acked_deletes_the_entry`,
+    /// `spool_remove_acked_tolerates_an_already_removed_entry`.
+    pub fn remove_acked(&self, path: &Path) -> Result<(), SpoolError> {
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(source) => {
+                return Err(SpoolError::Remove {
+                    path: path.to_path_buf(),
+                    source,
+                });
+            }
+        }
+        sync_dir(&self.root)
+    }
+
+    /// Every entry currently pending, oldest first.
+    ///
+    /// Why: both the retry sweep and the health scan need this, and both need
+    /// a *failure* to be distinguishable from an empty spool — an unreadable
+    /// spool reported as "nothing pending" is the fail-quiet shape again.
+    /// What: reads the directory, skips temp files and anything that is not a
+    /// `.json` entry, decodes each, and sorts by receipt time. An entry that
+    /// fails to decode is reported through `undecodable` rather than dropped.
+    /// Test: `spool_list_pending_orders_oldest_first`,
+    /// `spool_list_pending_reports_an_undecodable_entry`.
+    pub fn list_pending(&self) -> Result<PendingListing, SpoolError> {
+        let read = match std::fs::read_dir(&self.root) {
+            Ok(read) => read,
+            // A spool that has never been written is legitimately empty; any
+            // other read failure is not.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(PendingListing::default());
+            }
+            Err(source) => {
+                return Err(SpoolError::ReadDir {
+                    path: self.root.clone(),
+                    source,
+                });
+            }
+        };
+
+        let mut listing = PendingListing::default();
+        for dirent in read {
+            let dirent = dirent.map_err(|source| SpoolError::ReadDir {
+                path: self.root.clone(),
+                source,
+            })?;
+            let path = dirent.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            match std::fs::read(&path)
+                .map_err(SpoolReadFailure::Io)
+                .and_then(|b| {
+                    serde_json::from_slice::<SpoolEntry>(&b).map_err(SpoolReadFailure::Decode)
+                }) {
+                Ok(entry) => listing.pending.push(PendingEntry { path, entry }),
+                Err(failure) => listing.undecodable.push((path, failure.to_string())),
+            }
+        }
+        listing
+            .pending
+            .sort_by_key(|p| (p.entry.received_at_unix_ms, p.path.clone()));
+        listing.undecodable.sort();
+        Ok(listing)
+    }
+}
+
+/// Result of one [`Spool::list_pending`] sweep.
+///
+/// `undecodable` is carried rather than discarded: a file that cannot be parsed
+/// is still an unrelayed delivery, and reporting the spool as empty because its
+/// contents are corrupt is the failure this design exists to prevent.
+#[derive(Debug, Default, Clone)]
+pub struct PendingListing {
+    /// Decodable pending entries, oldest first.
+    pub pending: Vec<PendingEntry>,
+    /// Paths that could not be read or decoded, with the reason.
+    pub undecodable: Vec<(PathBuf, String)>,
+}
+
+/// Why one entry could not be loaded. Internal; flattened to a string for
+/// [`PendingListing::undecodable`].
+#[derive(Debug, thiserror::Error)]
+enum SpoolReadFailure {
+    #[error("read: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("decode: {0}")]
+    Decode(#[from] serde_json::Error),
+}
+
+/// `fsync` a directory so a rename or unlink within it is durable.
+fn sync_dir(dir: &Path) -> Result<(), SpoolError> {
+    File::open(dir)
+        .and_then(|d| d.sync_all())
+        .map_err(|source| SpoolError::SyncDir {
+            path: dir.to_path_buf(),
+            source,
+        })
+}
+
+/// Reduce a delivery id to something safe to use as a filename component.
+///
+/// A `X-GitHub-Delivery` header is attacker-controlled as far as this process
+/// is concerned — the HMAC covers the body, not the headers — so `../` or a
+/// 4 KiB value must not reach `Path::join`.
+fn sanitise_delivery_id(raw: &str) -> String {
+    let cleaned: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .take(64)
+        .collect();
+    if cleaned.is_empty() {
+        "unknown".to_string()
+    } else {
+        cleaned
+    }
+}

--- a/crates/trusty-console/src/webhook/spool.rs
+++ b/crates/trusty-console/src/webhook/spool.rs
@@ -11,12 +11,18 @@
 //! and its directory.
 //!
 //! What: one JSON file per delivery under
-//! `resolve_data_dir("trusty-console")/webhook-spool/`. [`Spool::persist`]
-//! writes a temp file, `fsync`s it, renames it into place, then `fsync`s the
-//! directory so the rename itself survives a crash. [`Spool::record_attempt`]
-//! rewrites an entry through the same sequence with a bumped attempt count.
+//! `resolve_data_dir("trusty-console")/webhook-spool/`. [`Spool::persist_new`]
+//! writes a temp file, `fsync`s it, links it into place — refusing to clobber an
+//! entry already there — then `fsync`s the directory so the new name survives a
+//! crash. [`Spool::persist_update`] is the same sequence committing with
+//! `rename`, for [`Spool::record_attempt`]'s deliberate overwrite.
 //! [`Spool::remove_acked`] is the only deletion path and is reachable only from
 //! an explicit target acknowledgement.
+//!
+//! 🔴 [`Spool::list_pending`] answers a missing directory with an error, not an
+//! empty listing, for any spool that was successfully opened. An unreadable
+//! spool reported as "nothing pending" makes the health scan green while every
+//! delivery 500s.
 //!
 //! 🔴 Every fallible step here returns an error to the caller. Nothing in this
 //! module logs-and-continues, because a swallowed spool failure is exactly the
@@ -109,6 +115,18 @@ pub enum SpoolError {
         source: std::io::Error,
     },
 
+    /// An entry already exists at the path a fresh delivery derives.
+    ///
+    /// Defensive: GitHub always sends `X-GitHub-Delivery`, so two deliveries
+    /// only collide when the header is absent AND they land in the same
+    /// millisecond. Refusing is still the right answer — clobbering would
+    /// destroy a delivery that has already been acknowledged.
+    #[error("a spool entry already exists at {path}; refusing to clobber it")]
+    AlreadyExists {
+        /// Path that was already taken.
+        path: PathBuf,
+    },
+
     /// Listing the spool failed. Surfaced as a red health state rather than an
     /// empty (and therefore falsely healthy) listing.
     #[error("read spool directory {path}: {source}")]
@@ -133,22 +151,11 @@ pub enum SpoolError {
 
 /// What console proves to the target about a relayed body (ADR-0034 §3).
 ///
-/// Why: the target trusts this assertion because only a same-uid process could
-/// have written it through a `0600` socket. Recording the algorithm and key id
-/// explicitly — rather than letting the target infer "it came over UDS so it is
-/// fine" — is what keeps the trust boundary named rather than assumed.
-/// What: three fields, all serialised into the relay frame verbatim.
-/// Test: `relay_frame_carries_provenance_and_byte_exact_body`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Provenance {
-    /// Algorithm console checked, e.g. `hmac-sha256`.
-    pub algorithm: String,
-    /// Which secret was used, by name — never the secret itself.
-    pub key_id: String,
-    /// Whether verification succeeded. Always `true` for a spooled entry:
-    /// console refuses an unverified delivery before it reaches the spool.
-    pub verified: bool,
-}
+/// Re-exported from `trusty_common::webhook_relay` rather than defined here:
+/// step 4's receivers live in `trusty-review` and `trusty-analyze`, which
+/// cannot depend on the console, so the type has to sit where both halves read
+/// it.
+pub use trusty_common::webhook_relay::Provenance;
 
 /// One spooled delivery.
 ///
@@ -205,6 +212,16 @@ pub struct PendingEntry {
 #[derive(Debug, Clone)]
 pub struct Spool {
     root: PathBuf,
+    /// Whether this spool's directory was successfully created at construction.
+    ///
+    /// 🔴 Load-bearing for the health signal, not bookkeeping. Once the
+    /// directory has been created, its later absence means it was *removed* or
+    /// its volume unmounted — a broken ingress, not an empty one. Without this
+    /// flag `list_pending` cannot tell "never written" from "gone", and
+    /// answering `ErrorKind::NotFound` with an empty listing makes
+    /// `scan_health` report green while every `POST /api/webhooks/{source}`
+    /// 500s. See [`Spool::list_pending`].
+    opened: bool,
 }
 
 impl Spool {
@@ -212,18 +229,26 @@ impl Spool {
     ///
     /// Why: lets a caller construct the spool before deciding whether it can be
     /// created, and lets a test point one at a path that will fail on write.
-    /// What: stores the path. No I/O.
+    /// What: stores the path. No I/O, and the spool is NOT marked opened — an
+    /// absent directory under this constructor is genuinely "never written".
     /// Test: `spool_persist_fails_when_the_root_is_not_a_directory`.
     pub fn at(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
+        Self {
+            root: root.into(),
+            opened: false,
+        }
     }
 
     /// Bind a spool to `root`, creating it at `0700`.
     ///
-    /// Test: `spool_open_creates_the_directory_at_0700`.
+    /// What: creates the directory and records that it existed, which is what
+    /// makes a later `ENOENT` a failure rather than an empty listing.
+    /// Test: `spool_open_creates_the_directory_at_0700`,
+    /// `health_reports_error_when_the_spool_directory_is_gone`.
     pub fn open(root: impl Into<PathBuf>) -> Result<Self, SpoolError> {
-        let spool = Self::at(root);
+        let mut spool = Self::at(root);
         spool.prepare_dir()?;
+        spool.opened = true;
         Ok(spool)
     }
 
@@ -270,16 +295,24 @@ impl Spool {
         ))
     }
 
-    /// Write `entry` durably. Returns the path it now occupies.
+    /// Write a NEW entry durably, refusing to overwrite an existing one.
     ///
     /// Why: this call returning `Ok` is the ONLY thing that licenses console to
     /// send GitHub a `202`. ADR-0034 §2: "Console returns `202` **only after**
-    /// the delivery … is written and fsync'd to a spool."
+    /// the delivery … is written and fsync'd to a spool." Refusing to clobber
+    /// matters because the entry already at that path may be a delivery console
+    /// has already acknowledged; overwriting it would destroy work GitHub will
+    /// never re-send. (Defensive: GitHub always sends `X-GitHub-Delivery`, so
+    /// two deliveries only collide when the header is absent and they land in
+    /// the same millisecond.)
     ///
-    /// What: encode → write temp → `sync_all` the file → rename into place →
-    /// `sync_all` the directory. The file fsync makes the bytes durable; the
-    /// directory fsync makes the *name* durable, without which a crash can
-    /// leave the entry unreachable even though its data reached the platter.
+    /// What: encode → write temp with `create_new` → `sync_all` the file →
+    /// `hard_link` into place → unlink the temp → `sync_all` the directory.
+    /// `hard_link` rather than `rename` because rename silently replaces the
+    /// destination while link fails with `EEXIST` — the atomic refusal this
+    /// needs. The file fsync makes the bytes durable; the directory fsync makes
+    /// the *name* durable, without which a crash can leave the entry
+    /// unreachable even though its data reached the platter.
     ///
     /// # Errors
     ///
@@ -288,31 +321,51 @@ impl Spool {
     ///
     /// Test: `spool_persists_and_reloads_an_entry_byte_exact`,
     /// `spool_persist_fails_when_the_root_is_not_a_directory`,
-    /// `spool_persist_fails_when_the_final_path_is_occupied_by_a_directory`.
-    pub fn persist(&self, entry: &SpoolEntry) -> Result<PathBuf, SpoolError> {
+    /// `spool_persist_new_refuses_to_clobber_an_existing_entry`.
+    pub fn persist_new(&self, entry: &SpoolEntry) -> Result<PathBuf, SpoolError> {
         let final_path = self.entry_path(entry);
-        let tmp_path = final_path.with_extension("json.tmp");
+        let tmp_path = self.write_temp(entry, &final_path)?;
 
-        let bytes = serde_json::to_vec_pretty(entry).map_err(|source| SpoolError::Encode {
-            delivery_id: entry.delivery_id.clone(),
-            source,
+        std::fs::hard_link(&tmp_path, &final_path).map_err(|source| {
+            let _ = std::fs::remove_file(&tmp_path);
+            if source.kind() == std::io::ErrorKind::AlreadyExists {
+                SpoolError::AlreadyExists {
+                    path: final_path.clone(),
+                }
+            } else {
+                SpoolError::Commit {
+                    from: tmp_path.clone(),
+                    to: final_path.clone(),
+                    source,
+                }
+            }
         })?;
+        // The temp name is redundant once the entry is linked under its real
+        // one; the inode survives until the last link goes.
+        let _ = std::fs::remove_file(&tmp_path);
 
-        let write = || -> std::io::Result<()> {
-            let mut file = File::create(&tmp_path)?;
-            file.set_permissions(Permissions::from_mode(SPOOL_FILE_MODE))?;
-            file.write_all(&bytes)?;
-            file.sync_all()
-        };
-        write().map_err(|source| SpoolError::Write {
-            path: tmp_path.clone(),
-            source,
-        })?;
+        sync_dir(&self.root)?;
+        Ok(final_path)
+    }
+
+    /// Rewrite an entry that already exists, replacing it atomically.
+    ///
+    /// Why: [`Spool::record_attempt`] needs clobber semantics — updating the
+    /// attempt count IS overwriting the previous version of the same delivery.
+    /// Split from [`Spool::persist_new`] so the two intents cannot be confused
+    /// at a call site.
+    /// What: identical to `persist_new` except it commits with `rename`, which
+    /// replaces the destination.
+    /// Test: `spool_record_attempt_increments_durably`,
+    /// `spool_persist_update_fails_when_the_final_path_is_a_directory`.
+    pub fn persist_update(&self, entry: &SpoolEntry) -> Result<PathBuf, SpoolError> {
+        let final_path = self.entry_path(entry);
+        let tmp_path = self.write_temp(entry, &final_path)?;
 
         std::fs::rename(&tmp_path, &final_path).map_err(|source| {
             // Leaving the temp file behind on a failed rename would accumulate
-            // junk that the health scan then has to ignore; drop it here, and
-            // let the rename error stand as the reported failure.
+            // junk the health scan then has to ignore; drop it here, and let
+            // the rename error stand as the reported failure.
             let _ = std::fs::remove_file(&tmp_path);
             SpoolError::Commit {
                 from: tmp_path.clone(),
@@ -325,6 +378,40 @@ impl Spool {
         Ok(final_path)
     }
 
+    /// Encode `entry` into a fresh, fsync'd temp file beside `final_path`.
+    ///
+    /// The temp name carries the process id and a nanosecond stamp so two
+    /// in-process writers targeting the same entry cannot share one, and uses
+    /// `create_new` so a leftover from a crashed run is never appended to.
+    fn write_temp(&self, entry: &SpoolEntry, final_path: &Path) -> Result<PathBuf, SpoolError> {
+        let bytes = serde_json::to_vec_pretty(entry).map_err(|source| SpoolError::Encode {
+            delivery_id: entry.delivery_id.clone(),
+            source,
+        })?;
+
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let tmp_path =
+            final_path.with_extension(format!("json.{}.{stamp}.tmp", std::process::id()));
+
+        let write = || -> std::io::Result<()> {
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&tmp_path)?;
+            file.set_permissions(Permissions::from_mode(SPOOL_FILE_MODE))?;
+            file.write_all(&bytes)?;
+            file.sync_all()
+        };
+        write().map_err(|source| SpoolError::Write {
+            path: tmp_path.clone(),
+            source,
+        })?;
+        Ok(tmp_path)
+    }
+
     /// Record one failed relay attempt against a spooled entry.
     ///
     /// Why: ADR-0034 §2 — "Relay failure … leaves the spool entry `pending`
@@ -332,9 +419,15 @@ impl Spool {
     /// The durable count is what a stuck delivery is diagnosed from; a
     /// `tracing::warn!` is explicitly forbidden as the sole record.
     /// What: bumps `attempts`, stores `reason` and the attempt time, and
-    /// rewrites the entry through the same durable sequence as
-    /// [`Spool::persist`]. Mutates `entry` in place so the caller sees the new
-    /// count.
+    /// rewrites the entry through [`Spool::persist_update`]. Mutates `entry` in
+    /// place so the caller sees the new count.
+    ///
+    /// The rewrite copies the whole entry, body included. That cost is bounded
+    /// by [`super::BackoffPolicy`], which spaces retries exponentially and stops
+    /// them entirely at `max_attempts` — without it a permanently unrelayable
+    /// delivery would rewrite its own body plus two `fsync`s every sweep tick,
+    /// forever.
+    ///
     /// Test: `spool_record_attempt_increments_durably`,
     /// `relay_failure_leaves_a_pending_entry_with_an_incremented_attempt_count`.
     pub fn record_attempt(
@@ -346,7 +439,7 @@ impl Spool {
         entry.attempts = entry.attempts.saturating_add(1);
         entry.last_error = Some(reason);
         entry.last_attempt_at_unix_ms = Some(now_unix_ms);
-        self.persist(entry)
+        self.persist_update(entry)
     }
 
     /// Delete an entry the target has explicitly acknowledged.
@@ -388,9 +481,16 @@ impl Spool {
     pub fn list_pending(&self) -> Result<PendingListing, SpoolError> {
         let read = match std::fs::read_dir(&self.root) {
             Ok(read) => read,
-            // A spool that has never been written is legitimately empty; any
-            // other read failure is not.
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // 🔴 An absent directory is only "legitimately empty" for a spool
+            // that was never opened. For an opened one it means the directory
+            // was removed or its volume unmounted, which breaks ingress
+            // completely — reporting that as an empty listing is what makes
+            // `scan_health` answer green while every delivery 500s. That is the
+            // fail-quiet shape one level below the one this module exists to
+            // remove (ADR-0034 Consequences, "A spool that silently stops being
+            // written reintroduces exactly the failure it was built to
+            // prevent").
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound && !self.opened => {
                 return Ok(PendingListing::default());
             }
             Err(source) => {

--- a/crates/trusty-console/src/webhook/spool.rs
+++ b/crates/trusty-console/src/webhook/spool.rs
@@ -495,7 +495,7 @@ impl Spool {
     /// What: `rename` into [`EXHAUSTED_DIR_NAME`], then `fsync` both
     /// directories so the move survives a crash. Returns the new path.
     /// Test: `spool_quarantine_moves_an_entry_out_of_the_live_set`,
-    /// `sweep_quarantines_an_exhausted_entry`.
+    /// `sweep_quarantines_an_exhausted_entry_and_stops_paying_for_it`.
     pub fn quarantine(&self, path: &Path) -> Result<PathBuf, SpoolError> {
         let dest_dir = self.exhausted_root();
         std::fs::create_dir_all(&dest_dir).map_err(|source| SpoolError::PrepareDir {

--- a/crates/trusty-console/src/webhook/spool.rs
+++ b/crates/trusty-console/src/webhook/spool.rs
@@ -56,6 +56,16 @@ pub const SPOOL_SCHEMA_VERSION: u32 = 1;
 /// Directory name under the console's data dir.
 pub const SPOOL_DIR_NAME: &str = "webhook-spool";
 
+/// Subdirectory holding deliveries console has stopped trying to relay.
+///
+/// Why: an entry past `max_attempts` is never relayed again, but deleting it
+/// would discard a delivery GitHub will never re-send — so it is moved aside
+/// rather than removed. Moving it matters as much as keeping it: while it sat
+/// in the live directory, every sweep and every metrics request read and
+/// JSON-decoded it, forever, and it pinned the oldest-pending diagnostics to
+/// itself so a genuinely new failure changed nothing an operator reads.
+pub const EXHAUSTED_DIR_NAME: &str = "exhausted";
+
 /// Failures of the durable-write path. Every variant means the delivery is
 /// **not** safely recorded, so every one of them must reach the HTTP caller as
 /// a 5xx rather than a log line.
@@ -468,16 +478,124 @@ impl Spool {
         sync_dir(&self.root)
     }
 
+    /// Directory holding entries console has given up relaying.
+    pub fn exhausted_root(&self) -> PathBuf {
+        self.root.join(EXHAUSTED_DIR_NAME)
+    }
+
+    /// Move an entry console will not retry into `exhausted/`.
+    ///
+    /// Why: an exhausted entry left in the live directory is read and decoded
+    /// by every sweep and every metrics request, forever — the spool becomes
+    /// unboundedly expensive to scan precisely because nothing can be relayed.
+    /// It also pins the oldest-pending diagnostics to itself, so a genuinely
+    /// new stuck delivery moves no field an operator or alert rule watches.
+    /// Moving it aside keeps the delivery (it is still an unacknowledged
+    /// webhook) while taking it off both hot paths.
+    /// What: `rename` into [`EXHAUSTED_DIR_NAME`], then `fsync` both
+    /// directories so the move survives a crash. Returns the new path.
+    /// Test: `spool_quarantine_moves_an_entry_out_of_the_live_set`,
+    /// `sweep_quarantines_an_exhausted_entry`.
+    pub fn quarantine(&self, path: &Path) -> Result<PathBuf, SpoolError> {
+        let dest_dir = self.exhausted_root();
+        std::fs::create_dir_all(&dest_dir).map_err(|source| SpoolError::PrepareDir {
+            path: dest_dir.clone(),
+            source,
+        })?;
+        std::fs::set_permissions(&dest_dir, Permissions::from_mode(SPOOL_DIR_MODE)).map_err(
+            |source| SpoolError::PrepareDir {
+                path: dest_dir.clone(),
+                source,
+            },
+        )?;
+
+        let name = path.file_name().ok_or_else(|| SpoolError::Remove {
+            path: path.to_path_buf(),
+            source: std::io::Error::other("spool entry path has no file name"),
+        })?;
+        let dest = dest_dir.join(name);
+        std::fs::rename(path, &dest).map_err(|source| SpoolError::Commit {
+            from: path.to_path_buf(),
+            to: dest.clone(),
+            source,
+        })?;
+        sync_dir(&dest_dir)?;
+        sync_dir(&self.root)?;
+        Ok(dest)
+    }
+
+    /// Decode one entry by path.
+    ///
+    /// Why: the health scan needs `attempts` and `last_error` for exactly one
+    /// entry — the oldest live one. Decoding just that one keeps the metrics
+    /// request O(1) in decodes rather than O(spool).
+    /// Test: `spool_scan_metadata_avoids_decoding_and_load_reads_one`.
+    pub fn load(&self, path: &Path) -> Result<SpoolEntry, SpoolError> {
+        let bytes = std::fs::read(path).map_err(|source| SpoolError::ReadDir {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        serde_json::from_slice(&bytes).map_err(|source| SpoolError::Encode {
+            delivery_id: path.display().to_string(),
+            source,
+        })
+    }
+
+    /// Filename-only census of both the live and exhausted sets.
+    ///
+    /// Why: [`Spool::entry_path`] encodes the receipt time in the filename
+    /// precisely so age can be read without opening anything, and until now
+    /// nothing used that — both hot paths decoded every file. A metrics request
+    /// needs counts and ages, which the names already carry.
+    /// What: `read_dir` on the live directory and on `exhausted/`, parsing
+    /// `<received_at_unix_ms:013>-<delivery id>.json`. No file is opened. A name
+    /// that does not parse is reported through `unparsable` rather than
+    /// dropped, for the same reason an undecodable entry is.
+    ///
+    /// A missing live directory is an error for an opened spool, exactly as in
+    /// [`Spool::list_pending`]; a missing `exhausted/` is simply empty, since it
+    /// is created lazily on the first quarantine.
+    ///
+    /// Test: `spool_scan_metadata_avoids_decoding_and_load_reads_one`,
+    /// `spool_scan_metadata_separates_live_from_exhausted`.
+    pub fn scan_metadata(&self) -> Result<SpoolMetadata, SpoolError> {
+        let mut meta = SpoolMetadata::default();
+        collect_metadata(
+            &self.root,
+            self.opened,
+            &mut meta.live,
+            &mut meta.unparsable,
+        )?;
+        collect_metadata(
+            &self.exhausted_root(),
+            false,
+            &mut meta.exhausted,
+            &mut meta.unparsable,
+        )?;
+        meta.live.sort();
+        meta.exhausted.sort();
+        meta.unparsable.sort();
+        Ok(meta)
+    }
+
     /// Every entry currently pending, oldest first.
     ///
     /// Why: both the retry sweep and the health scan need this, and both need
     /// a *failure* to be distinguishable from an empty spool — an unreadable
     /// spool reported as "nothing pending" is the fail-quiet shape again.
-    /// What: reads the directory, skips temp files and anything that is not a
-    /// `.json` entry, decodes each, and sorts by receipt time. An entry that
-    /// fails to decode is reported through `undecodable` rather than dropped.
+    /// What: reads the live directory, skips temp files, the `exhausted/`
+    /// subdirectory, and anything that is not a `.json` entry, decodes each, and
+    /// sorts by receipt time. An entry that fails to decode is reported through
+    /// `undecodable` rather than dropped.
+    ///
+    /// This decodes every live entry, which is why exhausted ones are moved out
+    /// of it — the live set is then bounded by the arrival rate over the retry
+    /// window rather than growing without limit. A caller that only needs counts
+    /// and ages should use [`Spool::scan_metadata`], which opens nothing.
+    ///
     /// Test: `spool_list_pending_orders_oldest_first`,
-    /// `spool_list_pending_reports_an_undecodable_entry`.
+    /// `spool_list_pending_reports_an_undecodable_entry`,
+    /// `spool_list_pending_ignores_the_exhausted_subdirectory`.
     pub fn list_pending(&self) -> Result<PendingListing, SpoolError> {
         let read = match std::fs::read_dir(&self.root) {
             Ok(read) => read,
@@ -549,6 +667,86 @@ enum SpoolReadFailure {
     Io(#[from] std::io::Error),
     #[error("decode: {0}")]
     Decode(#[from] serde_json::Error),
+}
+
+/// One entry as described by its filename alone — no file was opened.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EntryMeta {
+    /// When console accepted the delivery. Sorts first so a plain sort is an
+    /// age sort.
+    pub received_at_unix_ms: u64,
+    /// The sanitised delivery id from the filename.
+    pub delivery_id: String,
+    /// Absolute path of the entry file.
+    pub path: PathBuf,
+}
+
+/// Result of one [`Spool::scan_metadata`] pass.
+#[derive(Debug, Default, Clone)]
+pub struct SpoolMetadata {
+    /// Live entries still eligible for relay, oldest first.
+    pub live: Vec<EntryMeta>,
+    /// Entries console has given up relaying, oldest first.
+    pub exhausted: Vec<EntryMeta>,
+    /// `.json` files whose name does not parse, with the reason.
+    pub unparsable: Vec<(PathBuf, String)>,
+}
+
+/// Fill `out` from `dir` using filenames only.
+///
+/// `required` mirrors [`Spool`]'s `opened` flag: when true a missing directory
+/// is an error, when false it is an empty set.
+fn collect_metadata(
+    dir: &Path,
+    required: bool,
+    out: &mut Vec<EntryMeta>,
+    unparsable: &mut Vec<(PathBuf, String)>,
+) -> Result<(), SpoolError> {
+    let read = match std::fs::read_dir(dir) {
+        Ok(read) => read,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound && !required => return Ok(()),
+        Err(source) => {
+            return Err(SpoolError::ReadDir {
+                path: dir.to_path_buf(),
+                source,
+            });
+        }
+    };
+    for dirent in read {
+        let dirent = dirent.map_err(|source| SpoolError::ReadDir {
+            path: dir.to_path_buf(),
+            source,
+        })?;
+        let path = dirent.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        match path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .and_then(parse_entry_filename)
+        {
+            Some((received_at_unix_ms, delivery_id)) => out.push(EntryMeta {
+                received_at_unix_ms,
+                delivery_id,
+                path,
+            }),
+            None => unparsable.push((path, "filename does not carry a receipt timestamp".into())),
+        }
+    }
+    Ok(())
+}
+
+/// Split `<received_at_unix_ms:013>-<delivery id>.json` back into its parts.
+///
+/// The inverse of [`Spool::entry_path`]'s format. Returns `None` for any name
+/// that does not match, so a stray file is reported rather than silently
+/// treated as age zero (which would read as the oldest entry in the spool).
+fn parse_entry_filename(name: &str) -> Option<(u64, String)> {
+    let stem = name.strip_suffix(".json")?;
+    let (ts, id) = stem.split_once('-')?;
+    let received = ts.parse::<u64>().ok()?;
+    Some((received, id.to_string()))
 }
 
 /// `fsync` a directory so a rename or unlink within it is durable.

--- a/crates/trusty-console/src/webhook/tests.rs
+++ b/crates/trusty-console/src/webhook/tests.rs
@@ -719,7 +719,8 @@ fn health_reports_error_once_the_oldest_entry_passes_the_threshold() {
         h.oldest_pending_last_error.as_deref(),
         Some("no listener bound")
     );
-    assert_eq!(h.total_failed_attempts, 14);
+    assert_eq!(h.oldest_pending_attempts, Some(14));
+    assert_eq!(h.exhausted, 0, "nothing has been given up on yet");
 }
 
 #[test]
@@ -1130,7 +1131,7 @@ async fn integration_from_env_delivery_survives_a_console_restart() {
         assert_eq!(status, StatusCode::ACCEPTED);
         assert_eq!(body["relay"], "pending");
 
-        let health = ingress.health();
+        let health = ingress.health().await;
         assert_eq!(health.pending, 1);
         assert_eq!(health.status, ServiceHealth::Degraded);
 
@@ -1159,7 +1160,7 @@ async fn integration_from_env_delivery_survives_a_console_restart() {
         assert_eq!(report.still_pending, 0);
         assert_eq!(captured.lock().await.len(), 1);
 
-        let final_health = with_target.health();
+        let final_health = with_target.health().await;
         assert_eq!(final_health.pending, 0);
         assert_eq!(final_health.status, ServiceHealth::Ok);
     }
@@ -1200,7 +1201,7 @@ async fn integration_from_env_fails_closed_when_the_secret_is_unset() {
         .await;
         assert_eq!(status, StatusCode::UNAUTHORIZED);
         assert!(listing_of(ingress.spool()).pending.is_empty());
-        assert_eq!(ingress.health().status, ServiceHealth::Ok);
+        assert_eq!(ingress.health().await.status, ServiceHealth::Ok);
     }
     .await;
 
@@ -1516,18 +1517,205 @@ async fn sweep_stops_relaying_an_exhausted_entry() {
     assert_eq!(report.exhausted, 1);
     assert_eq!(report.still_pending, 0);
 
-    let listing = listing_of(ingress.spool());
+    // 🔴 Updated in review round 2. The previous version asserted the exhausted
+    // entry STAYS in the live set, which is what let it be re-read and
+    // re-decoded by every later sweep and metrics request forever. It is now
+    // moved aside — kept, because it is still an unacknowledged webhook, but off
+    // both hot paths.
+    assert!(
+        listing_of(ingress.spool()).pending.is_empty(),
+        "an exhausted entry must leave the live set"
+    );
+    let census = ingress.spool().scan_metadata().expect("census");
+    assert_eq!(census.live.len(), 0);
     assert_eq!(
-        listing.pending.len(),
+        census.exhausted.len(),
         1,
         "giving up on relaying is not the same as discarding the delivery"
     );
-    assert_eq!(listing.pending[0].entry.attempts, 3);
+    assert_eq!(census.exhausted[0].delivery_id, "d-1");
+
+    let quarantined = ingress
+        .spool()
+        .load(&census.exhausted[0].path)
+        .expect("the quarantined entry is still readable");
+    assert_eq!(quarantined.attempts, 3);
     assert_eq!(
-        ingress.health().status,
+        BASE64.decode(&quarantined.body_b64).expect("decode"),
+        BODY,
+        "and it still holds the original body for a manual redelivery"
+    );
+
+    let health = ingress.health().await;
+    assert_eq!(
+        health.status,
         ServiceHealth::Error,
         "an entry we have given up relaying must hold the health signal red"
     );
+    assert_eq!(health.exhausted, 1);
+    assert_eq!(health.exhausted_delivery_ids, vec!["d-1".to_string()]);
+    assert_eq!(health.pending, 0);
+}
+
+// ─── HIGH-A: exhausted entries leave the hot paths ──────────────────────────
+
+#[test]
+fn spool_quarantine_moves_an_entry_out_of_the_live_set() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let entry = sample_entry("d-quarantine", 1_700_000_000_000);
+    let path = spool.persist_new(&entry).expect("durable write");
+
+    let moved = spool.quarantine(&path).expect("quarantine");
+    assert!(!path.exists(), "the entry must leave the live directory");
+    assert!(moved.starts_with(spool.exhausted_root()));
+    assert_eq!(
+        spool.load(&moved).expect("still readable"),
+        entry,
+        "quarantine moves the delivery, it does not alter or discard it"
+    );
+    assert!(listing_of(&spool).pending.is_empty());
+}
+
+#[test]
+fn spool_list_pending_ignores_the_exhausted_subdirectory() {
+    // 🔴 Fails against `92c1ed3fc`, where nothing ever left the live set: both
+    // `retry_pending_once` and `scan_health` called `list_pending`, which reads
+    // and JSON-decodes every file. An entry that can never be relayed again was
+    // paid for on every sweep tick and every metrics request, forever.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let live = spool
+        .persist_new(&sample_entry("d-live", 1_700_000_005_000))
+        .expect("durable write");
+    let dead = spool
+        .persist_new(&sample_entry("d-dead", 1_700_000_000_000))
+        .expect("durable write");
+    spool.quarantine(&dead).expect("quarantine");
+
+    let listing = listing_of(&spool);
+    assert_eq!(
+        listing.pending.len(),
+        1,
+        "the decode-every-file path must see only the live entry"
+    );
+    assert_eq!(listing.pending[0].path, live);
+    assert!(listing.undecodable.is_empty());
+}
+
+#[test]
+fn spool_scan_metadata_avoids_decoding_and_load_reads_one() {
+    // `entry_path`'s stated rationale — the timestamp prefix exists so the age
+    // scan "does not have to parse every file" — is only true if something
+    // actually reads it. This is that reader.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    for (id, at) in [("d-c", 300u64), ("d-a", 100), ("d-b", 200)] {
+        spool
+            .persist_new(&sample_entry(id, at))
+            .expect("durable write");
+    }
+    // Corrupt every file. A census that opened them would notice; one that
+    // reads names only cannot, which is exactly the property under test.
+    for dirent in std::fs::read_dir(spool.root()).expect("read spool") {
+        let path = dirent.expect("dirent").path();
+        if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            std::fs::write(&path, b"{ not json").expect("corrupt");
+        }
+    }
+
+    let census = spool.scan_metadata().expect("census");
+    assert_eq!(
+        census
+            .live
+            .iter()
+            .map(|m| m.delivery_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["d-a", "d-b", "d-c"],
+        "the census must read names only, oldest first"
+    );
+    assert_eq!(census.live[0].received_at_unix_ms, 100);
+    assert!(census.unparsable.is_empty());
+
+    // `load` is the one place bytes are read, and it reports the corruption.
+    assert!(spool.load(&census.live[0].path).is_err());
+}
+
+#[test]
+fn spool_scan_metadata_separates_live_from_exhausted() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let dead = spool
+        .persist_new(&sample_entry("d-dead", 100))
+        .expect("durable write");
+    spool
+        .persist_new(&sample_entry("d-live", 200))
+        .expect("durable write");
+    spool.quarantine(&dead).expect("quarantine");
+
+    let census = spool.scan_metadata().expect("census");
+    assert_eq!(census.live.len(), 1);
+    assert_eq!(census.live[0].delivery_id, "d-live");
+    assert_eq!(census.exhausted.len(), 1);
+    assert_eq!(census.exhausted[0].delivery_id, "d-dead");
+}
+
+#[test]
+fn spool_scan_metadata_reports_a_stray_file_rather_than_dating_it_zero() {
+    // A name with no timestamp prefix must not parse as age 0 — that would
+    // read as the oldest entry in the spool and hijack every diagnostic.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    std::fs::write(spool.root().join("stray.json"), b"{}").expect("write stray");
+
+    let census = spool.scan_metadata().expect("census");
+    assert!(census.live.is_empty());
+    assert_eq!(census.unparsable.len(), 1);
+}
+
+#[tokio::test]
+async fn sweep_quarantines_an_exhausted_entry_and_stops_paying_for_it() {
+    // 🔴 Fails against `92c1ed3fc`: the sweep counted `exhausted` and
+    // `continue`d, so the entry stayed in the live set and every subsequent
+    // pass decoded it again. The module doc says no target binds a listener
+    // until step 4, so in this PR's intended configuration that is EVERY
+    // delivery, permanently.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let policy = BackoffPolicy {
+        first_attempt_grace: Duration::ZERO,
+        base: Duration::ZERO,
+        ceiling: Duration::ZERO,
+        max_attempts: 1,
+    };
+    let ingress = ingress_with(
+        spool,
+        tmp.path().join("sockets").join("absent.sock"),
+        Duration::from_millis(300),
+    )
+    .with_backoff(policy);
+    for id in ["d-1", "d-2"] {
+        ingress
+            .spool()
+            .persist_new(&sample_entry(id, 1_700_000_000_000))
+            .expect("durable write");
+    }
+
+    assert_eq!(ingress.retry_pending_once().await.still_pending, 2);
+    let second = ingress.retry_pending_once().await;
+    assert_eq!(second.exhausted, 2);
+
+    let census = ingress.spool().scan_metadata().expect("census");
+    assert_eq!(
+        census.live.len(),
+        0,
+        "an exhausted entry must stop costing a decode on every pass"
+    );
+    assert_eq!(census.exhausted.len(), 2, "and must still be kept");
+
+    // Every later pass sees nothing to do at all.
+    let third = ingress.retry_pending_once().await;
+    assert_eq!(third, SweepReport::default());
 }
 
 // ─── HIGH-3: an absent spool directory is red, not green ────────────────────
@@ -1628,4 +1816,99 @@ async fn route_accepts_a_body_larger_than_the_axum_default_limit() {
         body,
         "and the whole 3 MiB must be spooled byte-exact"
     );
+}
+
+// ─── HIGH-B: the signal keeps saying something new after it goes red ────────
+
+#[test]
+fn health_diagnostics_track_the_live_entry_not_the_exhausted_one() {
+    // 🔴 Fails against `92c1ed3fc`. Exhausted entries are by construction the
+    // oldest, and `scan_health` took `listing.pending.first()`, so
+    // `oldest_pending_delivery_id`, `oldest_pending_last_error` and
+    // `oldest_pending_age_secs` pinned to the first poisoned delivery forever.
+    // Day 1 one delivery exhausts; day 30 a genuinely new one gets stuck and
+    // nothing an operator or alert rule reads moves.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let now = 1_700_000_000_000u64;
+
+    // Day 1: a delivery that has been given up on. Oldest thing in the spool.
+    let mut dead = sample_entry("d-day-one", now - 30 * 86_400_000);
+    dead.attempts = 24;
+    dead.last_error = Some("no listener bound".to_string());
+    let dead_path = spool.persist_new(&dead).expect("durable write");
+    spool.quarantine(&dead_path).expect("quarantine");
+
+    // Day 30: a NEW delivery is now failing. This is what an operator needs.
+    let mut live = sample_entry("d-day-thirty", now - 900_000);
+    live.attempts = 3;
+    live.last_error = Some("target rejected the frame: code -32000 — store locked".to_string());
+    live.last_attempt_at_unix_ms = Some(now - 60_000);
+    spool.persist_new(&live).expect("durable write");
+
+    let h = health::scan_health(&spool, now, Duration::from_secs(600));
+
+    assert_eq!(h.status, ServiceHealth::Error);
+    assert_eq!(
+        h.oldest_pending_delivery_id.as_deref(),
+        Some("d-day-thirty"),
+        "the diagnostics must describe the LIVE failure, not the 30-day-old corpse"
+    );
+    assert_eq!(
+        h.oldest_pending_last_error.as_deref(),
+        Some("target rejected the frame: code -32000 — store locked")
+    );
+    assert_eq!(h.oldest_pending_attempts, Some(3));
+    assert_eq!(h.oldest_pending_age_secs, Some(900));
+    assert_eq!(h.pending, 1);
+
+    // The exhausted one is still reported — in its own fields, where it cannot
+    // crowd out a live failure.
+    assert_eq!(h.exhausted, 1);
+    assert_eq!(h.exhausted_delivery_ids, vec!["d-day-one".to_string()]);
+    assert_eq!(h.oldest_exhausted_age_secs, Some(30 * 86_400));
+}
+
+#[test]
+fn health_is_red_for_an_exhausted_entry_even_with_nothing_live() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let now = 1_700_000_000_000u64;
+    let path = spool
+        .persist_new(&sample_entry("d-dead", now - 1_000))
+        .expect("durable write");
+    spool.quarantine(&path).expect("quarantine");
+
+    let h = health::scan_health(&spool, now, Duration::from_secs(600));
+    assert_eq!(
+        h.status,
+        ServiceHealth::Error,
+        "nothing clears an exhausted entry without an operator, so it stays red"
+    );
+    assert_eq!(h.pending, 0);
+    assert_eq!(h.exhausted, 1);
+    assert_eq!(h.oldest_pending_delivery_id, None);
+}
+
+#[tokio::test]
+async fn metrics_route_surfaces_exhausted_separately_from_live() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let now = 1_700_000_000_000u64;
+    let dead = spool
+        .persist_new(&sample_entry("d-dead", now - 86_400_000))
+        .expect("durable write");
+    spool.quarantine(&dead).expect("quarantine");
+    spool
+        .persist_new(&sample_entry("d-live", now - 1_000))
+        .expect("durable write");
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
+
+    let (status, body) = get_json(router_for(ingress), "/api/console/metrics/webhooks").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "error");
+    assert_eq!(body["metrics"]["pending"], 1);
+    assert_eq!(body["metrics"]["exhausted"], 1);
+    assert_eq!(body["metrics"]["oldest_pending_delivery_id"], "d-live");
+    assert_eq!(body["metrics"]["exhausted_delivery_ids"][0], "d-dead");
 }

--- a/crates/trusty-console/src/webhook/tests.rs
+++ b/crates/trusty-console/src/webhook/tests.rs
@@ -90,6 +90,67 @@ fn spawn_target(dir: &StdPath, behaviour: StubTarget, count: usize) -> (PathBuf,
     (socket, captured)
 }
 
+/// A stub that announces when it has received a frame, then waits for the test
+/// to release it before answering.
+///
+/// Why: the previous version of the sweep-race test slept 150 ms and hoped
+/// `ingest` had reached its claim by then. That asserts on a window the test
+/// does not control — and it does not control it: under CI scheduling the
+/// spawned task had not even persisted the entry yet, so the sweep listed an
+/// empty spool and the assertion failed for a reason unrelated to claims.
+/// A rendezvous removes the wall clock entirely: the target has the frame, so
+/// the relay is provably in flight, so the claim is provably held.
+/// What: returns the socket, the captured frames, a receiver that fires once
+/// the first frame has been read, and a sender that lets the stub answer. Any
+/// connection after the first is answered immediately, so a second relay — the
+/// defect — is observable rather than hanging.
+/// Test: `sweep_does_not_relay_an_entry_the_request_path_is_still_relaying`.
+fn spawn_gated_target(
+    dir: &StdPath,
+) -> (
+    PathBuf,
+    Captured,
+    tokio::sync::oneshot::Receiver<()>,
+    tokio::sync::oneshot::Sender<()>,
+) {
+    let socket = dir.join("sockets").join("gated.sock");
+    let listener: UnixListener = bind_hardened(&socket).expect("bind gated stub");
+    let captured: Captured = Default::default();
+    let sink = captured.clone();
+    let (received_tx, received_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+    tokio::spawn(async move {
+        async fn absorb(conn: &mut tokio::net::UnixStream, sink: &Captured) {
+            let mut raw = Vec::new();
+            let _ = conn.read_to_end(&mut raw).await;
+            if let Ok(frame) = serde_json::from_slice::<serde_json::Value>(&raw) {
+                sink.lock().await.push(frame);
+            }
+        }
+        async fn ack(conn: &mut tokio::net::UnixStream) {
+            let _ = conn.write_all(br#"{"result":{"ack":true}}"#).await;
+            let _ = conn.write_all(b"\n").await;
+            let _ = conn.flush().await;
+        }
+
+        let Ok((mut first, _)) = listener.accept().await else {
+            return;
+        };
+        absorb(&mut first, &sink).await;
+        let _ = received_tx.send(());
+        let _ = release_rx.await;
+        ack(&mut first).await;
+
+        while let Ok((mut extra, _)) = listener.accept().await {
+            absorb(&mut extra, &sink).await;
+            ack(&mut extra).await;
+        }
+    });
+
+    (socket, captured, received_rx, release_tx)
+}
+
 /// A schedule that admits every pending entry immediately.
 ///
 /// Most cases here are asserting on relay and spool behaviour, not on timing;
@@ -1217,19 +1278,19 @@ async fn integration_from_env_fails_closed_when_the_secret_is_unset() {
 
 #[tokio::test]
 async fn sweep_does_not_relay_an_entry_the_request_path_is_still_relaying() {
-    // 🔴 Fails against the pre-fix head: the sweep listed every `.json` with no
-    // claim and no age filter, so a tick landing inside the relay window
-    // re-sent a delivery `ingest` was still sending. One delivery, two relays —
-    // and with at-least-once semantics the target sees a genuine duplicate.
+    // 🔴 Two defects met here. The claim used to be taken AFTER the durable
+    // write, leaving a window in which the entry was on disk and unclaimed —
+    // and a sweep landing in it relayed a delivery `ingest` was about to relay
+    // itself. Measured at the pre-fix head: a sweep 20 ms into `ingest`
+    // reported `acked: 1`, two relays for one delivery.
+    //
+    // The test itself was also racy: it slept 150 ms and assumed `ingest` had
+    // reached its claim. Under CI scheduling it had not even persisted yet, so
+    // the sweep listed an empty spool. The rendezvous below removes the wall
+    // clock — the target holding the frame is proof the relay is in flight.
     let tmp = tempfile::tempdir().expect("tempdir");
     let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
-    // Serves up to 4 connections, so a second relay WOULD be answered if one
-    // were made. The count is the assertion, not the stub's capacity.
-    let (socket, captured) = spawn_target(
-        tmp.path(),
-        StubTarget::AckAfter(Duration::from_millis(600)),
-        4,
-    );
+    let (socket, captured, received, release) = spawn_gated_target(tmp.path());
     let ingress = ingress_for(spool, socket);
 
     let requester = {
@@ -1241,18 +1302,22 @@ async fn sweep_does_not_relay_an_entry_the_request_path_is_still_relaying() {
         })
     };
 
-    // Land the sweep squarely inside the in-flight relay.
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    // The target has the frame, so the relay is in flight and the claim is
+    // held. No sleep, no guess.
+    received
+        .await
+        .expect("the target received the relayed frame");
+
     let sweep = ingress.retry_pending_once().await;
     assert_eq!(
         sweep.in_flight, 1,
-        "the sweep must see the entry as claimed, not free to relay"
+        "the sweep must see the entry as claimed, not free to relay: {sweep:?}"
     );
-    assert_eq!(sweep.acked, 0);
-    assert_eq!(sweep.still_pending, 0);
+    assert_eq!(sweep.acked, 0, "and must not relay it: {sweep:?}");
+    assert_eq!(sweep.still_pending, 0, "{sweep:?}");
 
-    let outcome = requester.await.expect("ingest task");
-    match outcome {
+    release.send(()).expect("release the target");
+    match requester.await.expect("ingest task") {
         IngestOutcome::Accepted { relay, .. } => assert!(relay.is_acked()),
         other => panic!("expected Accepted, got {other:?}"),
     }
@@ -1264,9 +1329,7 @@ async fn sweep_does_not_relay_an_entry_the_request_path_is_still_relaying() {
     );
     assert!(listing_of(ingress.spool()).pending.is_empty());
 
-    // The claim must be released once the relay settles, not leaked — a leaked
-    // claim would make the entry permanently unrelayable if it were still
-    // pending. A follow-up sweep reporting nothing in flight is that proof.
+    // The claim must be released once the relay settles, not leaked.
     let after = ingress.retry_pending_once().await;
     assert_eq!(after.in_flight, 0, "the claim must not outlive the relay");
 }

--- a/crates/trusty-console/src/webhook/tests.rs
+++ b/crates/trusty-console/src/webhook/tests.rs
@@ -14,8 +14,8 @@
 //! Against the pre-fix handlers every one of those is a `202` plus a log line.
 
 use super::*;
-use crate::webhook::relay::RELAY_METHOD;
 use crate::webhook::spool::{PendingListing, SPOOL_SCHEMA_VERSION, SpoolError};
+use trusty_common::webhook_relay::RELAY_METHOD;
 
 use std::collections::BTreeMap;
 use std::path::Path as StdPath;
@@ -45,6 +45,9 @@ enum StubTarget {
     RpcError,
     /// Accept the connection, read the frame, then hang up without answering.
     ConnectThenHangUp,
+    /// Answer `ack` only after a delay, so a second relay has time to race the
+    /// first. This is what makes the sweep-versus-request window observable.
+    AckAfter(Duration),
 }
 
 /// Frames a stub captured, so a test can assert on what console actually sent.
@@ -66,8 +69,11 @@ fn spawn_target(dir: &StdPath, behaviour: StubTarget, count: usize) -> (PathBuf,
             if let Ok(frame) = serde_json::from_slice::<serde_json::Value>(&raw) {
                 sink.lock().await.push(frame);
             }
+            if let StubTarget::AckAfter(delay) = behaviour {
+                tokio::time::sleep(delay).await;
+            }
             let reply: Option<&[u8]> = match behaviour {
-                StubTarget::Ack => Some(br#"{"result":{"ack":true}}"#),
+                StubTarget::Ack | StubTarget::AckAfter(_) => Some(br#"{"result":{"ack":true}}"#),
                 StubTarget::ResultWithoutAck => Some(br#"{"result":{}}"#),
                 StubTarget::RpcError => {
                     Some(br#"{"error":{"code":-32000,"message":"store locked"}}"#)
@@ -84,15 +90,35 @@ fn spawn_target(dir: &StdPath, behaviour: StubTarget, count: usize) -> (PathBuf,
     (socket, captured)
 }
 
+/// A schedule that admits every pending entry immediately.
+///
+/// Most cases here are asserting on relay and spool behaviour, not on timing;
+/// the real 5 s grace and 30 s base would make each of them sleep. The
+/// `backoff_*` and `sweep_honours_*` cases use the real policy instead.
+fn no_backoff() -> BackoffPolicy {
+    BackoffPolicy {
+        first_attempt_grace: Duration::ZERO,
+        base: Duration::ZERO,
+        ceiling: Duration::ZERO,
+        max_attempts: u32::MAX,
+    }
+}
+
 /// An ingress whose single `review` target points at `socket`.
 fn ingress_for(spool: Spool, socket: PathBuf) -> WebhookIngress {
+    ingress_with(spool, socket, Duration::from_secs(2)).with_backoff(no_backoff())
+}
+
+/// [`ingress_for`] keeping the production backoff schedule and taking an
+/// explicit relay timeout.
+fn ingress_with(spool: Spool, socket: PathBuf, relay_timeout: Duration) -> WebhookIngress {
     WebhookIngress::new(
         spool,
         SECRET.to_string(),
         SECRET_ENV.to_string(),
         vec![Target {
             source: "review".to_string(),
-            relay: UdsRelay::new(socket).with_timeout(Duration::from_secs(2)),
+            relay: UdsRelay::new(socket).with_timeout(relay_timeout),
         }],
     )
 }
@@ -111,6 +137,18 @@ fn signed_headers(body: &[u8], delivery: &str) -> HeaderMap {
 
 fn listing_of(spool: &Spool) -> PendingListing {
     spool.list_pending().expect("list spool")
+}
+
+/// How many uncommitted temp files the spool directory holds.
+///
+/// Every failure path must clean up after itself; a leaked temp file is junk
+/// the health scan then has to learn to ignore.
+fn temp_files_in(spool: &Spool) -> usize {
+    std::fs::read_dir(spool.root())
+        .expect("read spool root")
+        .filter_map(Result::ok)
+        .filter(|e| e.path().to_string_lossy().ends_with(".tmp"))
+        .count()
 }
 
 fn sample_entry(delivery_id: &str, received_at_unix_ms: u64) -> SpoolEntry {
@@ -155,7 +193,7 @@ fn spool_persists_and_reloads_an_entry_byte_exact() {
     let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
     let entry = sample_entry("d-1", 1_700_000_000_000);
 
-    let path = spool.persist(&entry).expect("durable write");
+    let path = spool.persist_new(&entry).expect("durable write");
     assert!(path.exists(), "the entry must be on disk before any ack");
 
     let listing = listing_of(&spool);
@@ -185,7 +223,7 @@ fn spool_persist_fails_when_the_root_is_not_a_directory() {
 
     let spool = Spool::at(&root);
     let err = spool
-        .persist(&sample_entry("d-1", 1))
+        .persist_new(&sample_entry("d-1", 1))
         .expect_err("a delivery that cannot be written must not report success");
     assert!(
         matches!(
@@ -197,22 +235,60 @@ fn spool_persist_fails_when_the_root_is_not_a_directory() {
 }
 
 #[test]
-fn spool_persist_fails_when_the_final_path_is_occupied_by_a_directory() {
-    // Second failure point: the write lands but the atomic rename cannot.
+fn spool_persist_new_refuses_to_clobber_an_existing_entry() {
+    // The entry already at that path may be one console has ALREADY
+    // acknowledged. Overwriting it destroys a delivery GitHub will never
+    // re-send, so `persist_new` commits with `hard_link` (atomic EEXIST) rather
+    // than `rename` (silent replace).
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let first = sample_entry("d-collide", 1_700_000_000_000);
+    spool.persist_new(&first).expect("first write");
+
+    // Same millisecond, same (missing-header-derived) id: the collision case.
+    let mut second = sample_entry("d-collide", 1_700_000_000_000);
+    second.event = "issues".to_string();
+
+    let err = spool
+        .persist_new(&second)
+        .expect_err("clobbering an existing entry must not report success");
+    assert!(
+        matches!(err, SpoolError::AlreadyExists { .. }),
+        "expected AlreadyExists, got {err:?}"
+    );
+
+    let listing = listing_of(&spool);
+    assert_eq!(listing.pending.len(), 1);
+    assert_eq!(
+        listing.pending[0].entry, first,
+        "the entry already on disk must survive untouched"
+    );
+    assert_eq!(
+        temp_files_in(&spool),
+        0,
+        "a refused write must not leave its temp file behind"
+    );
+}
+
+#[test]
+fn spool_persist_update_fails_when_the_final_path_is_a_directory() {
+    // `record_attempt` wants clobber semantics, so it commits with `rename` —
+    // which still has to fail loudly when the destination cannot be replaced.
     let tmp = tempfile::tempdir().expect("tempdir");
     let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
     let entry = sample_entry("d-1", 1_700_000_000_000);
     std::fs::create_dir_all(spool.entry_path(&entry)).expect("occupy the final path");
 
     let err = spool
-        .persist(&entry)
-        .expect_err("a delivery that cannot be committed must not report success");
+        .persist_update(&entry)
+        .expect_err("a rewrite that cannot be committed must not report success");
     assert!(
         matches!(err, SpoolError::Commit { .. }),
         "expected Commit, got {err:?}"
     );
-    assert!(
-        !spool.entry_path(&entry).with_extension("json.tmp").exists(),
+    assert_eq!(
+        temp_files_in(&spool),
+        0,
         "a failed commit must not leave its temp file behind"
     );
 }
@@ -222,7 +298,7 @@ fn spool_record_attempt_increments_durably() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
     let mut entry = sample_entry("d-1", 1_700_000_000_000);
-    spool.persist(&entry).expect("durable write");
+    spool.persist_new(&entry).expect("durable write");
 
     spool
         .record_attempt(&mut entry, "no listener".to_string(), 1_700_000_005_000)
@@ -244,7 +320,7 @@ fn spool_remove_acked_deletes_the_entry() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
     let entry = sample_entry("d-1", 1);
-    let path = spool.persist(&entry).expect("durable write");
+    let path = spool.persist_new(&entry).expect("durable write");
 
     spool.remove_acked(&path).expect("remove");
     assert!(listing_of(&spool).pending.is_empty());
@@ -281,7 +357,9 @@ fn spool_list_pending_orders_oldest_first() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
     for (id, at) in [("c", 300u64), ("a", 100), ("b", 200)] {
-        spool.persist(&sample_entry(id, at)).expect("durable write");
+        spool
+            .persist_new(&sample_entry(id, at))
+            .expect("durable write");
     }
     let ids: Vec<String> = listing_of(&spool)
         .pending
@@ -609,7 +687,7 @@ fn health_reports_degraded_for_a_young_pending_entry() {
     let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
     let now = 1_700_000_000_000u64;
     spool
-        .persist(&sample_entry("d-young", now - 30_000))
+        .persist_new(&sample_entry("d-young", now - 30_000))
         .expect("durable write");
 
     let h = health::scan_health(&spool, now, Duration::from_secs(600));
@@ -627,9 +705,9 @@ fn health_reports_error_once_the_oldest_entry_passes_the_threshold() {
     let mut aged = sample_entry("d-aged", now - 900_000); // 15 minutes
     aged.attempts = 14;
     aged.last_error = Some("no listener bound".to_string());
-    spool.persist(&aged).expect("durable write");
+    spool.persist_new(&aged).expect("durable write");
     spool
-        .persist(&sample_entry("d-young", now - 1_000))
+        .persist_new(&sample_entry("d-young", now - 1_000))
         .expect("durable write");
 
     let h = health::scan_health(&spool, now, Duration::from_secs(600));
@@ -686,7 +764,7 @@ async fn retry_sweep_acks_and_clears_a_pending_entry() {
     let ingress = ingress_for(spool, socket);
     ingress
         .spool()
-        .persist(&sample_entry("d-1", 1_700_000_000_000))
+        .persist_new(&sample_entry("d-1", 1_700_000_000_000))
         .expect("durable write");
 
     let report = ingress.retry_pending_once().await;
@@ -702,7 +780,7 @@ async fn retry_sweep_leaves_an_unrelayable_entry_pending_with_more_attempts() {
     let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
     ingress
         .spool()
-        .persist(&sample_entry("d-1", 1_700_000_000_000))
+        .persist_new(&sample_entry("d-1", 1_700_000_000_000))
         .expect("durable write");
 
     for expected in 1..=3u32 {
@@ -726,7 +804,7 @@ async fn retry_sweep_reports_an_orphaned_entry_without_deleting_it() {
     let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
     let mut orphan = sample_entry("d-orphan", 1_700_000_000_000);
     orphan.source = "retired-target".to_string();
-    ingress.spool().persist(&orphan).expect("durable write");
+    ingress.spool().persist_new(&orphan).expect("durable write");
 
     let report = ingress.retry_pending_once().await;
     assert_eq!(report.orphaned, 1);
@@ -943,7 +1021,7 @@ async fn metrics_route_reports_red_for_an_aged_pending_entry() {
         .with_red_after(Duration::from_secs(0));
     ingress
         .spool()
-        .persist(&sample_entry("d-stuck", 1))
+        .persist_new(&sample_entry("d-stuck", 1))
         .expect("durable write");
 
     let (status, body) = get_json(router_for(ingress), "/api/console/metrics/webhooks").await;
@@ -1132,4 +1210,422 @@ async fn integration_from_env_fails_closed_when_the_secret_is_unset() {
     );
     swap_env(SECRET_ENV, prior_secret.as_deref());
     outcome
+}
+
+// ─── concurrency: one delivery, one relay ───────────────────────────────────
+
+#[tokio::test]
+async fn sweep_does_not_relay_an_entry_the_request_path_is_still_relaying() {
+    // 🔴 Fails against the pre-fix head: the sweep listed every `.json` with no
+    // claim and no age filter, so a tick landing inside the relay window
+    // re-sent a delivery `ingest` was still sending. One delivery, two relays —
+    // and with at-least-once semantics the target sees a genuine duplicate.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    // Serves up to 4 connections, so a second relay WOULD be answered if one
+    // were made. The count is the assertion, not the stub's capacity.
+    let (socket, captured) = spawn_target(
+        tmp.path(),
+        StubTarget::AckAfter(Duration::from_millis(600)),
+        4,
+    );
+    let ingress = ingress_for(spool, socket);
+
+    let requester = {
+        let ingress = ingress.clone();
+        tokio::spawn(async move {
+            ingress
+                .ingest("review", &signed_headers(BODY, "d-race"), BODY)
+                .await
+        })
+    };
+
+    // Land the sweep squarely inside the in-flight relay.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    let sweep = ingress.retry_pending_once().await;
+    assert_eq!(
+        sweep.in_flight, 1,
+        "the sweep must see the entry as claimed, not free to relay"
+    );
+    assert_eq!(sweep.acked, 0);
+    assert_eq!(sweep.still_pending, 0);
+
+    let outcome = requester.await.expect("ingest task");
+    match outcome {
+        IngestOutcome::Accepted { relay, .. } => assert!(relay.is_acked()),
+        other => panic!("expected Accepted, got {other:?}"),
+    }
+
+    assert_eq!(
+        captured.lock().await.len(),
+        1,
+        "one delivery must produce exactly one relay"
+    );
+    assert!(listing_of(ingress.spool()).pending.is_empty());
+
+    // The claim must be released once the relay settles, not leaked — a leaked
+    // claim would make the entry permanently unrelayable if it were still
+    // pending. A follow-up sweep reporting nothing in flight is that proof.
+    let after = ingress.retry_pending_once().await;
+    assert_eq!(after.in_flight, 0, "the claim must not outlive the relay");
+}
+
+#[tokio::test]
+async fn two_concurrent_sweeps_relay_each_entry_only_once() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let (socket, captured) = spawn_target(
+        tmp.path(),
+        StubTarget::AckAfter(Duration::from_millis(400)),
+        6,
+    );
+    let ingress = ingress_for(spool, socket);
+    for id in ["d-a", "d-b"] {
+        ingress
+            .spool()
+            .persist_new(&sample_entry(id, 1_700_000_000_000))
+            .expect("durable write");
+    }
+
+    let (left, right) = tokio::join!(
+        {
+            let i = ingress.clone();
+            async move { i.retry_pending_once().await }
+        },
+        {
+            let i = ingress.clone();
+            async move { i.retry_pending_once().await }
+        }
+    );
+
+    assert_eq!(
+        left.acked + right.acked,
+        2,
+        "both entries must be acknowledged exactly once between the two passes"
+    );
+    assert_eq!(
+        captured.lock().await.len(),
+        2,
+        "two entries must produce exactly two relays across two overlapping sweeps"
+    );
+    assert!(listing_of(ingress.spool()).pending.is_empty());
+}
+
+#[tokio::test]
+async fn two_concurrent_deliveries_are_each_spooled_and_relayed_once() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let (socket, captured) = spawn_target(
+        tmp.path(),
+        StubTarget::AckAfter(Duration::from_millis(200)),
+        6,
+    );
+    let ingress = ingress_for(spool, socket);
+
+    let a = {
+        let i = ingress.clone();
+        tokio::spawn(async move {
+            i.ingest("review", &signed_headers(BODY, "d-one"), BODY)
+                .await
+        })
+    };
+    let b = {
+        let i = ingress.clone();
+        tokio::spawn(async move {
+            i.ingest("review", &signed_headers(BODY, "d-two"), BODY)
+                .await
+        })
+    };
+
+    for handle in [a, b] {
+        match handle.await.expect("ingest task") {
+            IngestOutcome::Accepted { relay, .. } => assert!(relay.is_acked()),
+            other => panic!("expected Accepted, got {other:?}"),
+        }
+    }
+    assert_eq!(captured.lock().await.len(), 2);
+    assert!(listing_of(ingress.spool()).pending.is_empty());
+}
+
+#[test]
+fn claim_set_refuses_a_second_claim_on_the_same_path() {
+    let claims = schedule::ClaimSet::new();
+    let path = std::path::Path::new("/tmp/spool/entry.json");
+    let first = claims.claim(path).expect("first claim");
+    assert!(
+        claims.claim(path).is_none(),
+        "a claimed entry must not be claimable twice"
+    );
+    assert_eq!(claims.len(), 1);
+    drop(first);
+    assert!(
+        claims.claim(path).is_some(),
+        "the claim must be released on drop"
+    );
+}
+
+#[test]
+fn claim_set_releases_on_drop_even_when_the_holder_panics() {
+    // A relay that panics must not leave its entry permanently unrelayable.
+    let claims = schedule::ClaimSet::new();
+    let path = std::path::Path::new("/tmp/spool/entry.json");
+    let result = std::panic::catch_unwind({
+        let claims = claims.clone();
+        move || {
+            let _held = claims.claim(path).expect("claim");
+            panic!("relay blew up");
+        }
+    });
+    assert!(result.is_err());
+    assert!(claims.is_empty(), "the claim must not outlive the panic");
+    assert!(claims.claim(path).is_some());
+}
+
+// ─── backoff ────────────────────────────────────────────────────────────────
+
+#[test]
+fn backoff_holds_off_a_freshly_spooled_entry() {
+    // The request path may still be relaying it; the sweep must not race in.
+    let policy = BackoffPolicy::default();
+    let now = 1_700_000_000_000u64;
+    let entry = sample_entry("d-1", now);
+    assert!(!policy.is_due(&entry, now));
+    assert!(!policy.is_due(&entry, now + 4_000));
+    assert!(policy.is_due(&entry, now + policy.first_attempt_grace.as_millis() as u64));
+}
+
+#[test]
+fn backoff_spacing_grows_with_attempts() {
+    let policy = BackoffPolicy::default();
+    assert_eq!(policy.delay_after(1), Duration::from_secs(30));
+    assert_eq!(policy.delay_after(2), Duration::from_secs(60));
+    assert_eq!(policy.delay_after(3), Duration::from_secs(120));
+    assert_eq!(policy.delay_after(4), Duration::from_secs(240));
+}
+
+#[test]
+fn backoff_respects_the_ceiling() {
+    let policy = BackoffPolicy::default();
+    for attempts in [10u32, 20, 1_000, u32::MAX - 1] {
+        assert_eq!(
+            policy.delay_after(attempts),
+            policy.ceiling,
+            "attempts={attempts} must clamp to the ceiling, never wrap to a short delay"
+        );
+    }
+}
+
+#[test]
+fn backoff_admits_an_entry_past_its_delay() {
+    let policy = BackoffPolicy::default();
+    let now = 1_700_000_000_000u64;
+    let mut entry = sample_entry("d-1", now - 1_000_000);
+    entry.attempts = 2;
+    entry.last_attempt_at_unix_ms = Some(now - 59_000);
+    assert!(
+        !policy.is_due(&entry, now),
+        "59s < the 60s delay for attempt 2"
+    );
+    entry.last_attempt_at_unix_ms = Some(now - 61_000);
+    assert!(policy.is_due(&entry, now));
+}
+
+#[test]
+fn backoff_stops_at_max_attempts() {
+    // An exhausted entry is never relayed again — and never deleted. It holds
+    // the health signal red until an operator intervenes, which is the honest
+    // state for an undeliverable webhook.
+    let policy = BackoffPolicy::default();
+    let now = 1_700_000_000_000u64;
+    let mut entry = sample_entry("d-1", 1);
+    entry.attempts = policy.max_attempts;
+    entry.last_attempt_at_unix_ms = Some(1);
+    assert!(policy.is_exhausted(&entry));
+    assert!(!policy.is_due(&entry, now), "no elapsed time can revive it");
+}
+
+#[tokio::test]
+async fn sweep_honours_backoff_between_ticks() {
+    // 🔴 Fails against the pre-fix head, which relayed every pending entry on
+    // every tick and rewrote its whole body plus two fsyncs each time.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    // Real schedule, but no first-attempt grace so the first pass runs at once.
+    let policy = BackoffPolicy {
+        first_attempt_grace: Duration::ZERO,
+        ..BackoffPolicy::default()
+    };
+    let ingress = ingress_with(
+        spool,
+        tmp.path().join("sockets").join("absent.sock"),
+        Duration::from_millis(300),
+    )
+    .with_backoff(policy);
+    ingress
+        .spool()
+        .persist_new(&sample_entry("d-1", 1_700_000_000_000))
+        .expect("durable write");
+
+    let first = ingress.retry_pending_once().await;
+    assert_eq!(first.still_pending, 1, "the first pass relays it");
+
+    let second = ingress.retry_pending_once().await;
+    assert_eq!(
+        second.not_due, 1,
+        "the second pass must respect the 30s spacing, not relay again"
+    );
+    assert_eq!(second.still_pending, 0);
+
+    let listing = listing_of(ingress.spool());
+    assert_eq!(
+        listing.pending.len(),
+        1,
+        "and it is still pending, not lost"
+    );
+    assert_eq!(
+        listing.pending[0].entry.attempts, 1,
+        "a skipped pass must not bump the attempt count or rewrite the body"
+    );
+}
+
+#[tokio::test]
+async fn sweep_stops_relaying_an_exhausted_entry() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let policy = BackoffPolicy {
+        first_attempt_grace: Duration::ZERO,
+        base: Duration::ZERO,
+        ceiling: Duration::ZERO,
+        max_attempts: 3,
+    };
+    let ingress = ingress_with(
+        spool,
+        tmp.path().join("sockets").join("absent.sock"),
+        Duration::from_millis(300),
+    )
+    .with_backoff(policy);
+    ingress
+        .spool()
+        .persist_new(&sample_entry("d-1", 1_700_000_000_000))
+        .expect("durable write");
+
+    for _ in 0..3 {
+        assert_eq!(ingress.retry_pending_once().await.still_pending, 1);
+    }
+    let report = ingress.retry_pending_once().await;
+    assert_eq!(report.exhausted, 1);
+    assert_eq!(report.still_pending, 0);
+
+    let listing = listing_of(ingress.spool());
+    assert_eq!(
+        listing.pending.len(),
+        1,
+        "giving up on relaying is not the same as discarding the delivery"
+    );
+    assert_eq!(listing.pending[0].entry.attempts, 3);
+    assert_eq!(
+        ingress.health().status,
+        ServiceHealth::Error,
+        "an entry we have given up relaying must hold the health signal red"
+    );
+}
+
+// ─── HIGH-3: an absent spool directory is red, not green ────────────────────
+
+#[test]
+fn health_reports_error_when_the_spool_directory_is_gone() {
+    // 🔴 Fails against the pre-fix head, which answered ENOENT with an empty
+    // listing: the console data dir removed (or its volume unmounted) made
+    // every POST 500 while `/api/console/metrics/webhooks` reported
+    // {"status":"ok","pending":0}. Ingress dead, alarm green.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("spool");
+    let spool = Spool::open(&root).expect("open spool");
+    spool
+        .persist_new(&sample_entry("d-1", 1_700_000_000_000))
+        .expect("durable write");
+
+    std::fs::remove_dir_all(&root).expect("simulate the directory going away");
+
+    let h = health::scan_health(&spool, 1_700_000_100_000, Duration::from_secs(600));
+    assert_eq!(
+        h.status,
+        ServiceHealth::Error,
+        "a spool whose directory vanished is broken, not empty"
+    );
+    assert!(
+        h.scan_error.is_some(),
+        "and the reason must be reported: {h:?}"
+    );
+}
+
+#[test]
+fn a_never_opened_spool_directory_is_still_legitimately_empty() {
+    // The other side of the same rule: `Spool::at` on a path that was never
+    // created has genuinely nothing pending, and must not report red.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::at(tmp.path().join("never-created"));
+    let listing = spool.list_pending().expect("an unopened spool lists empty");
+    assert!(listing.pending.is_empty());
+    let h = health::scan_health(&spool, 1_700_000_000_000, Duration::from_secs(600));
+    assert_eq!(h.status, ServiceHealth::Ok);
+    assert_eq!(h.scan_error, None);
+}
+
+#[tokio::test]
+async fn metrics_route_reports_red_when_the_spool_directory_is_gone() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("spool");
+    let spool = Spool::open(&root).expect("open spool");
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
+    std::fs::remove_dir_all(&root).expect("simulate the directory going away");
+
+    let (status, body) = get_json(router_for(ingress), "/api/console/metrics/webhooks").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "error");
+    assert!(body["metrics"]["scan_error"].is_string());
+}
+
+// ─── body limit ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn route_accepts_a_body_larger_than_the_axum_default_limit() {
+    // 🔴 Fails against the pre-fix head: axum's 2 MiB DefaultBodyLimit 413s a
+    // 3 MiB delivery BEFORE the handler runs — no spool entry, no metric, no
+    // log. GitHub payloads are legal to 25 MB and push/pull_request bodies
+    // routinely exceed 2 MiB.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
+
+    let big = format!(
+        r#"{{"action":"opened","filler":"{}"}}"#,
+        "x".repeat(3 * 1024 * 1024)
+    );
+    let body = big.as_bytes();
+
+    let (status, json) = post_webhook(
+        router_for(ingress.clone()),
+        "review",
+        body,
+        signed_headers(body, "d-big"),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::ACCEPTED,
+        "a 3 MiB delivery must reach the handler, not be 413'd by the framework"
+    );
+    assert_eq!(json["delivery_id"], "d-big");
+
+    let listing = listing_of(ingress.spool());
+    assert_eq!(listing.pending.len(), 1);
+    assert_eq!(
+        BASE64
+            .decode(&listing.pending[0].entry.body_b64)
+            .expect("decode"),
+        body,
+        "and the whole 3 MiB must be spooled byte-exact"
+    );
 }

--- a/crates/trusty-console/src/webhook/tests.rs
+++ b/crates/trusty-console/src/webhook/tests.rs
@@ -1,0 +1,1135 @@
+//! Failure-path coverage for the console webhook ingress (#5089 step 3).
+//!
+//! Rung 5: the failure arms ARE the deliverable. Each of the four arms
+//! ADR-0034 §2 names has at least one case here that fails against the shape
+//! this step replaces:
+//!
+//! | Arm | Case |
+//! |---|---|
+//! | spool write fails | `ingest_returns_spool_failed_and_never_accepts_when_the_write_fails`, `route_returns_500_and_no_ack_when_the_spool_write_fails` |
+//! | relay fails | `relay_failure_leaves_a_pending_entry_with_an_incremented_attempt_count` |
+//! | connected but not acknowledged | `relay_treats_a_result_without_ack_as_refused`, `connected_without_ack_never_deletes_the_entry` |
+//! | pending entry ages out | `metrics_route_reports_red_for_an_aged_pending_entry` |
+//!
+//! Against the pre-fix handlers every one of those is a `202` plus a log line.
+
+use super::*;
+use crate::webhook::relay::RELAY_METHOD;
+use crate::webhook::spool::{PendingListing, SPOOL_SCHEMA_VERSION, SpoolError};
+
+use std::collections::BTreeMap;
+use std::path::Path as StdPath;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixListener;
+use tower::ServiceExt as _;
+use trusty_common::console_metrics::ServiceHealth;
+use trusty_common::uds::bind_hardened;
+use trusty_common::webhook_hmac::sign_github_body;
+
+const SECRET: &str = "console-ingress-test-secret"; // pragma: allowlist secret
+const BODY: &[u8] = br#"{"action":"review_requested","number":42}"#;
+
+// ─── harness ────────────────────────────────────────────────────────────────
+
+/// How a stub target answers one relayed frame.
+#[derive(Clone)]
+enum StubTarget {
+    /// Answer `{"result":{"ack":true}}`.
+    Ack,
+    /// Answer with a result object that has no `ack` field at all.
+    ResultWithoutAck,
+    /// Answer with a JSON-RPC error.
+    RpcError,
+    /// Accept the connection, read the frame, then hang up without answering.
+    ConnectThenHangUp,
+}
+
+/// Frames a stub captured, so a test can assert on what console actually sent.
+type Captured = std::sync::Arc<tokio::sync::Mutex<Vec<serde_json::Value>>>;
+
+/// Bind a hardened socket under `dir` and serve `count` connections.
+fn spawn_target(dir: &StdPath, behaviour: StubTarget, count: usize) -> (PathBuf, Captured) {
+    let socket = dir.join("sockets").join("target.sock");
+    let listener: UnixListener = bind_hardened(&socket).expect("bind stub target");
+    let captured: Captured = Default::default();
+    let sink = captured.clone();
+    tokio::spawn(async move {
+        for _ in 0..count {
+            let Ok((mut conn, _)) = listener.accept().await else {
+                return;
+            };
+            let mut raw = Vec::new();
+            let _ = conn.read_to_end(&mut raw).await;
+            if let Ok(frame) = serde_json::from_slice::<serde_json::Value>(&raw) {
+                sink.lock().await.push(frame);
+            }
+            let reply: Option<&[u8]> = match behaviour {
+                StubTarget::Ack => Some(br#"{"result":{"ack":true}}"#),
+                StubTarget::ResultWithoutAck => Some(br#"{"result":{}}"#),
+                StubTarget::RpcError => {
+                    Some(br#"{"error":{"code":-32000,"message":"store locked"}}"#)
+                }
+                StubTarget::ConnectThenHangUp => None,
+            };
+            if let Some(bytes) = reply {
+                let _ = conn.write_all(bytes).await;
+                let _ = conn.write_all(b"\n").await;
+                let _ = conn.flush().await;
+            }
+        }
+    });
+    (socket, captured)
+}
+
+/// An ingress whose single `review` target points at `socket`.
+fn ingress_for(spool: Spool, socket: PathBuf) -> WebhookIngress {
+    WebhookIngress::new(
+        spool,
+        SECRET.to_string(),
+        SECRET_ENV.to_string(),
+        vec![Target {
+            source: "review".to_string(),
+            relay: UdsRelay::new(socket).with_timeout(Duration::from_secs(2)),
+        }],
+    )
+}
+
+/// A signed request header set for `body`.
+fn signed_headers(body: &[u8], delivery: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        SIGNATURE_HEADER,
+        sign_github_body(SECRET, body).parse().expect("sig header"),
+    );
+    headers.insert("x-github-event", "pull_request".parse().expect("event"));
+    headers.insert("x-github-delivery", delivery.parse().expect("delivery"));
+    headers
+}
+
+fn listing_of(spool: &Spool) -> PendingListing {
+    spool.list_pending().expect("list spool")
+}
+
+fn sample_entry(delivery_id: &str, received_at_unix_ms: u64) -> SpoolEntry {
+    SpoolEntry {
+        schema_version: SPOOL_SCHEMA_VERSION,
+        delivery_id: delivery_id.to_string(),
+        source: "review".to_string(),
+        event: "pull_request".to_string(),
+        headers: BTreeMap::from([("x-github-event".to_string(), "pull_request".to_string())]),
+        body_b64: BASE64.encode(BODY),
+        provenance: Provenance {
+            algorithm: HMAC_ALGORITHM.to_string(),
+            key_id: SECRET_ENV.to_string(),
+            verified: true,
+        },
+        received_at_unix_ms,
+        attempts: 0,
+        last_error: None,
+        last_attempt_at_unix_ms: None,
+    }
+}
+
+// ─── spool: durability ──────────────────────────────────────────────────────
+
+#[test]
+fn spool_open_creates_the_directory_at_0700() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("webhook-spool");
+    let spool = Spool::open(&root).expect("open spool");
+    let mode = std::fs::metadata(spool.root())
+        .expect("stat spool root")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o700, "a spooled webhook body is not public data");
+}
+
+#[test]
+fn spool_persists_and_reloads_an_entry_byte_exact() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let entry = sample_entry("d-1", 1_700_000_000_000);
+
+    let path = spool.persist(&entry).expect("durable write");
+    assert!(path.exists(), "the entry must be on disk before any ack");
+
+    let listing = listing_of(&spool);
+    assert_eq!(listing.pending.len(), 1);
+    assert_eq!(listing.pending[0].entry, entry);
+    assert_eq!(
+        BASE64
+            .decode(&listing.pending[0].entry.body_b64)
+            .expect("decode body"),
+        BODY,
+        "the body must survive the round trip byte-exact — the HMAC covers it"
+    );
+    assert!(
+        listing.undecodable.is_empty(),
+        "no temp files may leak into the listing"
+    );
+}
+
+#[test]
+fn spool_persist_fails_when_the_root_is_not_a_directory() {
+    // The spool-write-failure arm. A regular file where the directory belongs
+    // makes every `File::create` inside it fail with ENOTDIR for every uid,
+    // including root — so this is deterministic in any CI container.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("not-a-dir");
+    std::fs::write(&root, b"blocking file").expect("write blocker");
+
+    let spool = Spool::at(&root);
+    let err = spool
+        .persist(&sample_entry("d-1", 1))
+        .expect_err("a delivery that cannot be written must not report success");
+    assert!(
+        matches!(
+            err,
+            SpoolError::Write { .. } | SpoolError::PrepareDir { .. }
+        ),
+        "expected a write failure, got {err:?}"
+    );
+}
+
+#[test]
+fn spool_persist_fails_when_the_final_path_is_occupied_by_a_directory() {
+    // Second failure point: the write lands but the atomic rename cannot.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let entry = sample_entry("d-1", 1_700_000_000_000);
+    std::fs::create_dir_all(spool.entry_path(&entry)).expect("occupy the final path");
+
+    let err = spool
+        .persist(&entry)
+        .expect_err("a delivery that cannot be committed must not report success");
+    assert!(
+        matches!(err, SpoolError::Commit { .. }),
+        "expected Commit, got {err:?}"
+    );
+    assert!(
+        !spool.entry_path(&entry).with_extension("json.tmp").exists(),
+        "a failed commit must not leave its temp file behind"
+    );
+}
+
+#[test]
+fn spool_record_attempt_increments_durably() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let mut entry = sample_entry("d-1", 1_700_000_000_000);
+    spool.persist(&entry).expect("durable write");
+
+    spool
+        .record_attempt(&mut entry, "no listener".to_string(), 1_700_000_005_000)
+        .expect("record attempt");
+    spool
+        .record_attempt(&mut entry, "no listener".to_string(), 1_700_000_010_000)
+        .expect("record attempt");
+
+    let listing = listing_of(&spool);
+    assert_eq!(listing.pending.len(), 1, "attempts must not fork the entry");
+    let reloaded = &listing.pending[0].entry;
+    assert_eq!(reloaded.attempts, 2);
+    assert_eq!(reloaded.last_error.as_deref(), Some("no listener"));
+    assert_eq!(reloaded.last_attempt_at_unix_ms, Some(1_700_000_010_000));
+}
+
+#[test]
+fn spool_remove_acked_deletes_the_entry() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let entry = sample_entry("d-1", 1);
+    let path = spool.persist(&entry).expect("durable write");
+
+    spool.remove_acked(&path).expect("remove");
+    assert!(listing_of(&spool).pending.is_empty());
+}
+
+#[test]
+fn spool_remove_acked_tolerates_an_already_removed_entry() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let path = spool.root().join("0000000000001-gone.json");
+    spool
+        .remove_acked(&path)
+        .expect("a missing entry is not an error");
+}
+
+#[test]
+fn spool_entry_path_sanitises_a_hostile_delivery_id() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    // The delivery header is not covered by the HMAC, so it is attacker input.
+    let entry = sample_entry("../../../etc/passwd", 7);
+    let path = spool.entry_path(&entry);
+    assert_eq!(
+        path.parent(),
+        Some(spool.root()),
+        "a delivery id must never escape the spool directory: {}",
+        path.display()
+    );
+    assert!(!path.to_string_lossy().contains(".."));
+}
+
+#[test]
+fn spool_list_pending_orders_oldest_first() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    for (id, at) in [("c", 300u64), ("a", 100), ("b", 200)] {
+        spool.persist(&sample_entry(id, at)).expect("durable write");
+    }
+    let ids: Vec<String> = listing_of(&spool)
+        .pending
+        .into_iter()
+        .map(|p| p.entry.delivery_id)
+        .collect();
+    assert_eq!(ids, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn spool_list_pending_reports_an_undecodable_entry() {
+    // An unreadable pending delivery is not an absent one. Silently skipping it
+    // would report the spool empty while a delivery sits unrelayed.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    std::fs::write(spool.root().join("0000000000001-junk.json"), b"{not json").expect("write junk");
+
+    let listing = listing_of(&spool);
+    assert!(listing.pending.is_empty());
+    assert_eq!(listing.undecodable.len(), 1);
+}
+
+// ─── relay: only an explicit ack counts ─────────────────────────────────────
+
+#[tokio::test]
+async fn relay_frame_carries_provenance_and_byte_exact_body() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, captured) = spawn_target(tmp.path(), StubTarget::Ack, 1);
+    let relay = UdsRelay::new(socket).with_timeout(Duration::from_secs(2));
+
+    let entry = sample_entry("d-frame", 1_700_000_000_000);
+    assert_eq!(relay.deliver(&entry).await, RelayOutcome::Acked);
+
+    let frames = captured.lock().await;
+    let frame = frames.first().expect("target received a frame");
+    assert_eq!(frame["jsonrpc"], "2.0");
+    assert_eq!(frame["method"], RELAY_METHOD);
+    assert_eq!(frame["id"], "d-frame");
+    let params = &frame["params"];
+    assert_eq!(params["provenance"]["algorithm"], HMAC_ALGORITHM);
+    assert_eq!(params["provenance"]["key_id"], SECRET_ENV);
+    assert_eq!(params["provenance"]["verified"], true);
+    assert_eq!(
+        BASE64
+            .decode(params["body_b64"].as_str().expect("body_b64 is a string"))
+            .expect("decode relayed body"),
+        BODY,
+        "the target must receive the exact bytes GitHub signed"
+    );
+    assert!(
+        !frame.to_string().contains(SECRET),
+        "the secret must never leave console"
+    );
+}
+
+#[tokio::test]
+async fn relay_acked_response_is_the_only_ack() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _) = spawn_target(tmp.path(), StubTarget::Ack, 1);
+    let relay = UdsRelay::new(socket).with_timeout(Duration::from_secs(2));
+    assert!(relay.deliver(&sample_entry("d-1", 1)).await.is_acked());
+}
+
+#[tokio::test]
+async fn relay_treats_a_result_without_ack_as_refused() {
+    // The "connected but has not acknowledged" arm. A target that answers with
+    // an empty result object has done nothing; treating the successful
+    // round trip as success is the same silent loss one layer down.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _) = spawn_target(tmp.path(), StubTarget::ResultWithoutAck, 1);
+    let relay = UdsRelay::new(socket).with_timeout(Duration::from_secs(2));
+
+    let outcome = relay.deliver(&sample_entry("d-1", 1)).await;
+    assert!(
+        matches!(outcome, RelayOutcome::Refused { .. }),
+        "expected Refused, got {outcome:?}"
+    );
+    assert!(!outcome.is_acked());
+}
+
+#[tokio::test]
+async fn relay_treats_a_jsonrpc_error_as_refused() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _) = spawn_target(tmp.path(), StubTarget::RpcError, 1);
+    let relay = UdsRelay::new(socket).with_timeout(Duration::from_secs(2));
+
+    let outcome = relay.deliver(&sample_entry("d-1", 1)).await;
+    assert!(!outcome.is_acked());
+    assert!(
+        outcome.reason().contains("store locked"),
+        "the target's own reason must survive into the durable record: {}",
+        outcome.reason()
+    );
+}
+
+#[tokio::test]
+async fn relay_reports_unreachable_when_no_listener_is_bound() {
+    // The expected state for every delivery until #5089 step 4 binds the
+    // target's listener.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let relay = UdsRelay::new(tmp.path().join("sockets").join("absent.sock"))
+        .with_timeout(Duration::from_secs(2));
+    let outcome = relay.deliver(&sample_entry("d-1", 1)).await;
+    assert!(
+        matches!(outcome, RelayOutcome::Unreachable { .. }),
+        "expected Unreachable, got {outcome:?}"
+    );
+}
+
+#[tokio::test]
+async fn relay_reports_unreachable_when_the_target_hangs_up_without_answering() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (socket, _) = spawn_target(tmp.path(), StubTarget::ConnectThenHangUp, 1);
+    let relay = UdsRelay::new(socket).with_timeout(Duration::from_secs(2));
+    let outcome = relay.deliver(&sample_entry("d-1", 1)).await;
+    assert!(
+        matches!(outcome, RelayOutcome::Unreachable { .. }),
+        "a connection that succeeds and then dies is not a delivery: {outcome:?}"
+    );
+}
+
+// ─── ingest: the ordering guarantee ─────────────────────────────────────────
+
+#[tokio::test]
+async fn ingest_rejects_an_unknown_source() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
+
+    let outcome = ingress
+        .ingest("nope", &signed_headers(BODY, "d-1"), BODY)
+        .await;
+    assert!(matches!(outcome, IngestOutcome::UnknownSource { .. }));
+    assert!(
+        listing_of(ingress.spool()).pending.is_empty(),
+        "an unroutable source must not consume spool space"
+    );
+}
+
+#[tokio::test]
+async fn ingest_fails_closed_when_no_secret_is_configured() {
+    // ADR-0034 §2 unifies the policy to trusty-review's fail-closed answer.
+    // trusty-analyze's "log a warning and process it anyway" is gone.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let ingress = WebhookIngress::new(
+        spool,
+        String::new(),
+        SECRET_ENV.to_string(),
+        vec![Target {
+            source: "review".to_string(),
+            relay: UdsRelay::new(tmp.path().join("sockets").join("absent.sock")),
+        }],
+    );
+
+    let outcome = ingress
+        .ingest("review", &signed_headers(BODY, "d-1"), BODY)
+        .await;
+    assert_eq!(outcome, IngestOutcome::SecretMissing);
+    assert!(
+        listing_of(ingress.spool()).pending.is_empty(),
+        "an unverified body must never reach the spool"
+    );
+}
+
+#[tokio::test]
+async fn ingest_rejects_a_forged_signature() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
+
+    // Signed correctly, then the body is changed by one byte in flight.
+    let headers = signed_headers(BODY, "d-1");
+    let mut tampered = BODY.to_vec();
+    let last = tampered.len() - 1;
+    tampered[last] ^= 0x01;
+
+    let outcome = ingress.ingest("review", &headers, &tampered).await;
+    assert_eq!(outcome, IngestOutcome::InvalidSignature);
+    assert!(listing_of(ingress.spool()).pending.is_empty());
+}
+
+#[tokio::test]
+async fn ingest_returns_spool_failed_and_never_accepts_when_the_write_fails() {
+    // 🔴 The regression this step exists for. The pre-fix handlers return 202
+    // and log; here the durable write is a precondition of accepting at all.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let blocked = tmp.path().join("not-a-dir");
+    std::fs::write(&blocked, b"blocking file").expect("write blocker");
+    // The stub WOULD ack — proving the refusal comes from the spool, not the
+    // relay, and that no relay ever runs when the write fails.
+    let (socket, captured) = spawn_target(tmp.path(), StubTarget::Ack, 1);
+    let ingress = ingress_for(Spool::at(&blocked), socket);
+
+    let outcome = ingress
+        .ingest("review", &signed_headers(BODY, "d-1"), BODY)
+        .await;
+
+    assert!(
+        matches!(outcome, IngestOutcome::SpoolFailed { .. }),
+        "a delivery that could not be recorded must not be accepted: {outcome:?}"
+    );
+    assert!(
+        !matches!(outcome, IngestOutcome::Accepted { .. }),
+        "no ack may be issued when the spool write failed"
+    );
+    assert!(
+        captured.lock().await.is_empty(),
+        "the relay must not run before the delivery is durable"
+    );
+}
+
+#[tokio::test]
+async fn ingest_accepts_and_deletes_on_an_explicit_ack() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let (socket, _) = spawn_target(tmp.path(), StubTarget::Ack, 1);
+    let ingress = ingress_for(spool, socket);
+
+    let outcome = ingress
+        .ingest("review", &signed_headers(BODY, "d-ack"), BODY)
+        .await;
+
+    match outcome {
+        IngestOutcome::Accepted {
+            delivery_id,
+            relay,
+            bookkeeping_error,
+        } => {
+            assert_eq!(delivery_id, "d-ack");
+            assert!(relay.is_acked());
+            assert_eq!(bookkeeping_error, None);
+        }
+        other => panic!("expected Accepted, got {other:?}"),
+    }
+    assert!(
+        listing_of(ingress.spool()).pending.is_empty(),
+        "an acknowledged delivery is the only one that may be deleted"
+    );
+}
+
+#[tokio::test]
+async fn relay_failure_leaves_a_pending_entry_with_an_incremented_attempt_count() {
+    // 🔴 The second regression. The pre-fix handlers drop the payload here.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    // No listener: the state every delivery is in until #5089 step 4.
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
+
+    let outcome = ingress
+        .ingest("review", &signed_headers(BODY, "d-pending"), BODY)
+        .await;
+
+    match &outcome {
+        IngestOutcome::Accepted { relay, .. } => assert!(
+            matches!(relay, RelayOutcome::Unreachable { .. }),
+            "expected Unreachable, got {relay:?}"
+        ),
+        other => panic!("expected Accepted, got {other:?}"),
+    }
+
+    let listing = listing_of(ingress.spool());
+    assert_eq!(
+        listing.pending.len(),
+        1,
+        "a failed relay must NEVER delete the entry"
+    );
+    let entry = &listing.pending[0].entry;
+    assert_eq!(entry.delivery_id, "d-pending");
+    assert_eq!(entry.attempts, 1, "the attempt must be recorded durably");
+    assert!(entry.last_error.is_some(), "and so must the reason");
+    assert!(entry.last_attempt_at_unix_ms.is_some());
+    assert_eq!(
+        BASE64.decode(&entry.body_b64).expect("decode"),
+        BODY,
+        "the pending entry must still hold the original body for redelivery"
+    );
+}
+
+#[tokio::test]
+async fn connected_without_ack_never_deletes_the_entry() {
+    // 🔴 The third arm: the connection succeeded, so a naive implementation
+    // would call this done. ADR-0034 §2 makes the explicit ack the only
+    // delete trigger.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let (socket, captured) = spawn_target(tmp.path(), StubTarget::ResultWithoutAck, 1);
+    let ingress = ingress_for(spool, socket);
+
+    let outcome = ingress
+        .ingest("review", &signed_headers(BODY, "d-noack"), BODY)
+        .await;
+    assert!(matches!(outcome, IngestOutcome::Accepted { .. }));
+    assert_eq!(
+        captured.lock().await.len(),
+        1,
+        "the target really was reached"
+    );
+
+    let listing = listing_of(ingress.spool());
+    assert_eq!(
+        listing.pending.len(),
+        1,
+        "reaching the target is not the same as the target acknowledging"
+    );
+    assert_eq!(listing.pending[0].entry.attempts, 1);
+}
+
+// ─── health: oldest-pending age is red, on demand ───────────────────────────
+
+#[test]
+fn health_reports_ok_on_an_empty_spool() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let h = health::scan_health(&spool, 1_700_000_000_000, Duration::from_secs(600));
+    assert_eq!(h.status, ServiceHealth::Ok);
+    assert_eq!(h.pending, 0);
+    assert_eq!(h.oldest_pending_age_secs, None);
+    assert_eq!(h.scan_error, None);
+}
+
+#[test]
+fn health_reports_degraded_for_a_young_pending_entry() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let now = 1_700_000_000_000u64;
+    spool
+        .persist(&sample_entry("d-young", now - 30_000))
+        .expect("durable write");
+
+    let h = health::scan_health(&spool, now, Duration::from_secs(600));
+    assert_eq!(h.status, ServiceHealth::Degraded);
+    assert_eq!(h.pending, 1);
+    assert_eq!(h.oldest_pending_age_secs, Some(30));
+}
+
+#[test]
+fn health_reports_error_once_the_oldest_entry_passes_the_threshold() {
+    // 🔴 The fourth arm. Red is a state a dashboard renders, not a warn! line.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let now = 1_700_000_000_000u64;
+    let mut aged = sample_entry("d-aged", now - 900_000); // 15 minutes
+    aged.attempts = 14;
+    aged.last_error = Some("no listener bound".to_string());
+    spool.persist(&aged).expect("durable write");
+    spool
+        .persist(&sample_entry("d-young", now - 1_000))
+        .expect("durable write");
+
+    let h = health::scan_health(&spool, now, Duration::from_secs(600));
+    assert_eq!(h.status, ServiceHealth::Error);
+    assert_eq!(h.pending, 2);
+    assert_eq!(h.oldest_pending_age_secs, Some(900));
+    assert_eq!(h.oldest_pending_delivery_id.as_deref(), Some("d-aged"));
+    assert_eq!(
+        h.oldest_pending_last_error.as_deref(),
+        Some("no listener bound")
+    );
+    assert_eq!(h.total_failed_attempts, 14);
+}
+
+#[test]
+fn health_reports_error_for_an_undecodable_entry() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    std::fs::write(spool.root().join("0000000000001-junk.json"), b"{not json").expect("write junk");
+
+    let h = health::scan_health(&spool, 1_700_000_000_000, Duration::from_secs(600));
+    assert_eq!(
+        h.status,
+        ServiceHealth::Error,
+        "a pending delivery that cannot be read is not a healthy spool"
+    );
+    assert_eq!(h.undecodable.len(), 1);
+}
+
+#[test]
+fn health_reports_error_when_the_spool_cannot_be_read() {
+    // A spool that cannot be listed must not read as an empty (healthy) one —
+    // that is the fail-quiet shape one level down from the one being fixed.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let blocked = tmp.path().join("not-a-dir");
+    std::fs::write(&blocked, b"blocking file").expect("write blocker");
+
+    let h = health::scan_health(
+        &Spool::at(&blocked),
+        1_700_000_000_000,
+        Duration::from_secs(600),
+    );
+    assert_eq!(h.status, ServiceHealth::Error);
+    assert!(h.scan_error.is_some(), "the scan failure must be reported");
+}
+
+// ─── retry sweep ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn retry_sweep_acks_and_clears_a_pending_entry() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let (socket, _) = spawn_target(tmp.path(), StubTarget::Ack, 1);
+    let ingress = ingress_for(spool, socket);
+    ingress
+        .spool()
+        .persist(&sample_entry("d-1", 1_700_000_000_000))
+        .expect("durable write");
+
+    let report = ingress.retry_pending_once().await;
+    assert_eq!(report.acked, 1);
+    assert_eq!(report.still_pending, 0);
+    assert!(listing_of(ingress.spool()).pending.is_empty());
+}
+
+#[tokio::test]
+async fn retry_sweep_leaves_an_unrelayable_entry_pending_with_more_attempts() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
+    ingress
+        .spool()
+        .persist(&sample_entry("d-1", 1_700_000_000_000))
+        .expect("durable write");
+
+    for expected in 1..=3u32 {
+        let report = ingress.retry_pending_once().await;
+        assert_eq!(report.still_pending, 1);
+        assert_eq!(report.acked, 0);
+        let listing = listing_of(ingress.spool());
+        assert_eq!(
+            listing.pending.len(),
+            1,
+            "the entry must survive every sweep"
+        );
+        assert_eq!(listing.pending[0].entry.attempts, expected);
+    }
+}
+
+#[tokio::test]
+async fn retry_sweep_reports_an_orphaned_entry_without_deleting_it() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
+    let mut orphan = sample_entry("d-orphan", 1_700_000_000_000);
+    orphan.source = "retired-target".to_string();
+    ingress.spool().persist(&orphan).expect("durable write");
+
+    let report = ingress.retry_pending_once().await;
+    assert_eq!(report.orphaned, 1);
+    assert_eq!(
+        listing_of(ingress.spool()).pending.len(),
+        1,
+        "a config change must not silently discard a delivery"
+    );
+}
+
+// ─── HTTP surface ───────────────────────────────────────────────────────────
+
+/// A router carrying only the webhook sub-surface plus the real console routes.
+fn router_for(ingress: WebhookIngress) -> axum::Router {
+    crate::server::build_router_with_webhooks(
+        crate::server::AppState::new(Vec::new()),
+        crate::routes::origin_guard::SelfOrigins::default(),
+        ingress,
+    )
+}
+
+async fn post_webhook(
+    router: axum::Router,
+    source: &str,
+    body: &[u8],
+    headers: HeaderMap,
+) -> (StatusCode, serde_json::Value) {
+    let mut req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/webhooks/{source}"))
+        .header("content-type", "application/json");
+    for (name, value) in headers.iter() {
+        req = req.header(name, value);
+    }
+    let response = router
+        .oneshot(req.body(Body::from(body.to_vec())).expect("build request"))
+        .await
+        .expect("route the request");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), 64 * 1024)
+        .await
+        .expect("read body");
+    let json = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+#[tokio::test]
+async fn route_returns_202_after_a_durable_write() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
+
+    let (status, body) = post_webhook(
+        router_for(ingress.clone()),
+        "review",
+        BODY,
+        signed_headers(BODY, "d-http"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(body["status"], "accepted");
+    assert_eq!(
+        body["relay"], "pending",
+        "the ack reports the relay state honestly rather than claiming success"
+    );
+    assert_eq!(listing_of(ingress.spool()).pending.len(), 1);
+}
+
+#[tokio::test]
+async fn route_returns_500_and_no_ack_when_the_spool_write_fails() {
+    // 🔴 GitHub must see a failed delivery it can redeliver from its UI.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let blocked = tmp.path().join("not-a-dir");
+    std::fs::write(&blocked, b"blocking file").expect("write blocker");
+    let ingress = ingress_for(
+        Spool::at(&blocked),
+        tmp.path().join("sockets").join("absent.sock"),
+    );
+
+    let (status, body) = post_webhook(
+        router_for(ingress),
+        "review",
+        BODY,
+        signed_headers(BODY, "d-http"),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "a 2xx here would make the delivery permanently unrecoverable"
+    );
+    assert!(!status.is_success());
+    assert_eq!(body["status"], serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn route_returns_401_for_an_unset_secret() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let ingress = WebhookIngress::new(
+        spool,
+        String::new(),
+        SECRET_ENV.to_string(),
+        vec![Target {
+            source: "review".to_string(),
+            relay: UdsRelay::new(tmp.path().join("sockets").join("absent.sock")),
+        }],
+    );
+
+    let (status, _) = post_webhook(
+        router_for(ingress.clone()),
+        "review",
+        BODY,
+        signed_headers(BODY, "d-http"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert!(listing_of(ingress.spool()).pending.is_empty());
+}
+
+#[tokio::test]
+async fn route_returns_401_for_a_forged_signature() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
+
+    let mut headers = HeaderMap::new();
+    headers.insert(SIGNATURE_HEADER, "sha256=deadbeef".parse().expect("sig"));
+    let (status, _) = post_webhook(router_for(ingress.clone()), "review", BODY, headers).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert!(listing_of(ingress.spool()).pending.is_empty());
+}
+
+#[tokio::test]
+async fn route_returns_404_for_an_unknown_source() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
+
+    let (status, _) = post_webhook(
+        router_for(ingress),
+        "not-a-target",
+        BODY,
+        signed_headers(BODY, "d-http"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn webhook_route_is_not_shadowed_by_the_service_proxy() {
+    // `/api/{service}/{*path}` would swallow `/api/webhooks/review` if matchit
+    // preferred the capture. It does not — but a router edit could reorder
+    // things, and a proxied webhook is a silently dropped one.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
+
+    let (status, body) = post_webhook(
+        router_for(ingress),
+        "review",
+        BODY,
+        signed_headers(BODY, "d-http"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(body["delivery_id"], "d-http");
+}
+
+async fn get_json(router: axum::Router, uri: &str) -> (StatusCode, serde_json::Value) {
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("route the request");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), 256 * 1024)
+        .await
+        .expect("read body");
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null),
+    )
+}
+
+#[tokio::test]
+async fn metrics_route_reports_ok_on_an_empty_spool() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"));
+
+    let (status, body) = get_json(router_for(ingress), "/api/console/metrics/webhooks").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["service_id"], health::WEBHOOK_SERVICE_ID);
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["metrics"]["pending"], 0);
+}
+
+#[tokio::test]
+async fn metrics_route_reports_red_for_an_aged_pending_entry() {
+    // 🔴 The detection arm, end to end: the route scans the spool on THIS
+    // request, so the red state does not depend on a background loop still
+    // being alive.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spool = Spool::open(tmp.path().join("spool")).expect("open spool");
+    let ingress = ingress_for(spool, tmp.path().join("sockets").join("absent.sock"))
+        // Anything already on disk is instantly past a zero threshold.
+        .with_red_after(Duration::from_secs(0));
+    ingress
+        .spool()
+        .persist(&sample_entry("d-stuck", 1))
+        .expect("durable write");
+
+    let (status, body) = get_json(router_for(ingress), "/api/console/metrics/webhooks").await;
+    assert_eq!(status, StatusCode::OK, "a red state is data, not an outage");
+    assert_eq!(body["status"], "error");
+    assert_eq!(body["metrics"]["pending"], 1);
+    assert_eq!(body["metrics"]["oldest_pending_delivery_id"], "d-stuck");
+    assert!(body["metrics"]["oldest_pending_age_secs"].is_number());
+}
+
+#[tokio::test]
+async fn metrics_route_reports_red_when_the_spool_cannot_be_read() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let blocked = tmp.path().join("not-a-dir");
+    std::fs::write(&blocked, b"blocking file").expect("write blocker");
+    let ingress = ingress_for(
+        Spool::at(&blocked),
+        tmp.path().join("sockets").join("absent.sock"),
+    );
+
+    let (status, body) = get_json(router_for(ingress), "/api/console/metrics/webhooks").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "error");
+    assert!(body["metrics"]["scan_error"].is_string());
+}
+
+// ─── integration (`--include-ignored`) ──────────────────────────────────────
+
+#[test]
+fn default_spool_root_lives_under_the_console_data_dir() {
+    // Pure assertion on the path convention — ADR-0034 puts the spool under
+    // console's own state directory, which `lib.rs:476` already treats as
+    // canonical. No env mutation, so this one runs in the default suite.
+    let root = default_spool_root().expect("resolve the default spool root");
+    assert!(
+        root.ends_with(std::path::Path::new(spool::SPOOL_DIR_NAME)),
+        "spool root {} must be the webhook-spool subdirectory",
+        root.display()
+    );
+    let data_dir = trusty_common::resolve_data_dir("trusty-console").expect("resolve data dir");
+    assert_eq!(
+        root.parent(),
+        Some(data_dir.as_path()),
+        "the spool must not invent a new location convention"
+    );
+}
+
+/// Serialises the tests below, which mutate process-global environment
+/// variables that every concurrently-running sibling test can observe.
+/// An async mutex, not a `std` one: the guard is held across `.await` for the
+/// whole body, which is exactly what a blocking guard must not do.
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Set `key` to `value` (or remove it), returning the prior value.
+///
+/// `set_var`/`remove_var` are `unsafe` in edition 2024 because they are not
+/// thread-safe; [`ENV_LOCK`] plus the `#[ignore]` tag is what makes these call
+/// sites sound in this binary.
+fn swap_env(key: &str, value: Option<&str>) -> Option<String> {
+    let prior = std::env::var(key).ok();
+    match value {
+        Some(v) => unsafe { std::env::set_var(key, v) },
+        None => unsafe { std::env::remove_var(key) },
+    }
+    prior
+}
+
+#[tokio::test]
+#[ignore = "mutates TRUSTY_DATA_DIR_OVERRIDE and GITHUB_WEBHOOK_SECRET, which every \
+            concurrently-running test in this binary can observe; run with --include-ignored"]
+async fn integration_from_env_delivery_survives_a_console_restart() {
+    // The full ADR-0034 §2 loop, against the real `from_env` wiring:
+    //   verified delivery -> durable spool -> relay fails (no listener yet)
+    //   -> a FRESH ingress over the same directory still finds it pending
+    //   -> the target comes up and acks -> the entry is gone.
+    // This is the property the pre-fix handlers lack entirely: after their
+    // 202, nothing on disk records that the delivery ever existed.
+    let _guard = ENV_LOCK.lock().await;
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let prior_data_dir = swap_env(
+        trusty_common::DATA_DIR_OVERRIDE_ENV,
+        Some(&tmp.path().to_string_lossy()),
+    );
+    let prior_secret = swap_env(SECRET_ENV, Some(SECRET));
+
+    let outcome = async {
+        // ── first boot: nothing is listening, as until #5089 step 4 ──────────
+        let ingress = WebhookIngress::from_env().expect("build ingress from env");
+        assert!(
+            ingress
+                .spool()
+                .root()
+                .starts_with(tmp.path().join("trusty-console")),
+            "spool must land under the overridden console data dir: {}",
+            ingress.spool().root().display()
+        );
+
+        let (status, body) = post_webhook(
+            router_for(ingress.clone()),
+            "review",
+            BODY,
+            signed_headers(BODY, "d-restart"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(body["relay"], "pending");
+
+        let health = ingress.health();
+        assert_eq!(health.pending, 1);
+        assert_eq!(health.status, ServiceHealth::Degraded);
+
+        // ── restart: a brand-new ingress over the same directory ─────────────
+        let restarted = WebhookIngress::from_env().expect("rebuild ingress from env");
+        let listing = listing_of(restarted.spool());
+        assert_eq!(
+            listing.pending.len(),
+            1,
+            "the delivery must outlive the process that accepted it"
+        );
+        assert_eq!(listing.pending[0].entry.delivery_id, "d-restart");
+        assert_eq!(listing.pending[0].entry.attempts, 1);
+        assert_eq!(
+            BASE64
+                .decode(&listing.pending[0].entry.body_b64)
+                .expect("decode"),
+            BODY
+        );
+
+        // ── the target finally comes up and acknowledges ─────────────────────
+        let (socket, captured) = spawn_target(tmp.path(), StubTarget::Ack, 1);
+        let with_target = ingress_for(Spool::at(restarted.spool().root().to_path_buf()), socket);
+        let report = with_target.retry_pending_once().await;
+        assert_eq!(report.acked, 1);
+        assert_eq!(report.still_pending, 0);
+        assert_eq!(captured.lock().await.len(), 1);
+
+        let final_health = with_target.health();
+        assert_eq!(final_health.pending, 0);
+        assert_eq!(final_health.status, ServiceHealth::Ok);
+    }
+    .await;
+
+    swap_env(
+        trusty_common::DATA_DIR_OVERRIDE_ENV,
+        prior_data_dir.as_deref(),
+    );
+    swap_env(SECRET_ENV, prior_secret.as_deref());
+    outcome
+}
+
+#[tokio::test]
+#[ignore = "mutates TRUSTY_DATA_DIR_OVERRIDE and GITHUB_WEBHOOK_SECRET; \
+            run with --include-ignored"]
+async fn integration_from_env_fails_closed_when_the_secret_is_unset() {
+    // ADR-0034 §2's unified policy, against the real env wiring: an operator
+    // who never set the secret gets a 401 and an empty spool, not
+    // trusty-analyze's "skip verification and process it anyway".
+    let _guard = ENV_LOCK.lock().await;
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let prior_data_dir = swap_env(
+        trusty_common::DATA_DIR_OVERRIDE_ENV,
+        Some(&tmp.path().to_string_lossy()),
+    );
+    let prior_secret = swap_env(SECRET_ENV, None);
+
+    let outcome = async {
+        let ingress = WebhookIngress::from_env().expect("build ingress from env");
+        let (status, _) = post_webhook(
+            router_for(ingress.clone()),
+            "review",
+            BODY,
+            signed_headers(BODY, "d-nosecret"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert!(listing_of(ingress.spool()).pending.is_empty());
+        assert_eq!(ingress.health().status, ServiceHealth::Ok);
+    }
+    .await;
+
+    swap_env(
+        trusty_common::DATA_DIR_OVERRIDE_ENV,
+        prior_data_dir.as_deref(),
+    );
+    swap_env(SECRET_ENV, prior_secret.as_deref());
+    outcome
+}


### PR DESCRIPTION
## Defect

Both existing webhook handlers return `202` and *then* do the work, so any failure after the ack loses the delivery permanently — GitHub never retries an acknowledged delivery, and every health signal still reports green.

- `crates/trusty-review/src/service/webhook.rs` — `tokio::spawn` at :240, ack at :322-329, failure written only to an in-memory `Mutex<Option<String>>` at :305-309.
- `crates/trusty-analyze/src/service/handlers/review.rs` — `tokio::spawn` at :210, ack at :216, failure is a bare `tracing::warn!` at :211-213.

Neither handler is modified here. They stay live until step 4 retires them; this builds the console path that replaces them.

## Resolution

`POST /api/webhooks/{source}` multiplexes `review` and `analyze`. The order of operations is the fix, per ADR-0034 §2:

1. unknown `{source}` → `404`, before any secret handling;
2. HMAC verified once over the exact received bytes — unset secret and bad signature both `401`, unifying the policy to trusty-review's fail-closed answer;
3. the delivery is written and fsync'd to a spool under `resolve_data_dir("trusty-console")/webhook-spool/` — **on failure `500`, and no `202` is ever sent**, so GitHub keeps the delivery redeliverable;
4. the relay runs and its outcome is recorded durably;
5. `202`, because step 3 succeeded — not because step 4 did.

Per failure arm:

| Arm | Behavior |
|---|---|
| Spool write fails | `5xx` before any `202`. The relay never runs — asserted, not assumed. |
| Relay fails (expected until step 4) | Entry stays `pending`, attempt count and reason written durably, sweep retries. Never deleted on failure. |
| Connected but not acknowledged | `ack` is `#[serde(default)]` false, so a result object without it is `Refused`. Only `RelayOutcome::Acked` reaches the one deletion path. |
| Pending entry ages out | `GET /api/console/metrics/webhooks` goes red. It scans the spool **on the request**, not from a cache, so the signal does not go quiet if the retry sweep stops. A spool that cannot be read is red, not empty. |

Durability is a temp write → `sync_all` the file → rename → `sync_all` the directory, so the entry's *name* survives a crash too, not just its bytes.

### Shared entry points, not a fourth copy

- `trusty_common::uds::rpc::send_framed_request` — the framed UDS transport ADR-0034 §4 names, dialling through `connect_hardened` so the `0700` directory and `0600` socket are verified before a byte is written. Caps the response and bounds the exchange with a timeout. The four existing hand-rolled clients migrate onto it in a documented fast-follow, per the PM's scope call.
- `trusty_common::webhook_hmac` (feature `webhook-hmac`) — one GitHub signature verifier, returning a three-state `SignatureVerdict` so "no secret configured" cannot collapse into permission to proceed, which is the shape of trusty-analyze's live fail-open. The two existing copies are retired in step 4.

Spawn-on-demand (calling step 2's `UdsServiceSupervisor`) is deferred to step 4 — no target binds a listener yet, so it would be dead code. Until then every relay lands in `Unreachable`, which is a durable pending state.

## Testing — rung 5

Failure-path coverage is the deliverable. 43 new cases in `crates/trusty-console/src/webhook/tests.rs`, 7 in `crates/trusty-common/src/uds/rpc.rs`, 7 in `webhook_hmac`. Each arm above has at least one case that fails against the pre-fix shape (where all four are a `202` plus a log line):

- `ingest_returns_spool_failed_and_never_accepts_when_the_write_fails` / `route_returns_500_and_no_ack_when_the_spool_write_fails`
- `relay_failure_leaves_a_pending_entry_with_an_incremented_attempt_count`
- `connected_without_ack_never_deletes_the_entry` / `relay_treats_a_result_without_ack_as_refused`
- `metrics_route_reports_red_for_an_aged_pending_entry` / `metrics_route_reports_red_when_the_spool_cannot_be_read`

The spool-failure injection is a regular file where the directory belongs (ENOTDIR for every uid, root included), so it is deterministic in any CI container rather than depending on a non-root runner. The relay runs against a test-double `UnixListener` bound through `bind_hardened`.

`--include-ignored` integration coverage: `integration_from_env_delivery_survives_a_console_restart` drives the full loop against the real `from_env` wiring — verified delivery → durable spool → relay fails → a *fresh* ingress over the same directory still finds it pending with its body intact → the target comes up and acks → the entry is gone and health returns to `Ok`. These two are `#[ignore]`d because they mutate `TRUSTY_DATA_DIR_OVERRIDE` and `GITHUB_WEBHOOK_SECRET`, which every concurrent sibling in the binary can observe.

### Gates run

```
cargo fmt --check                                                            — clean
cargo clippy -p trusty-common -p trusty-console --all-targets -- -D warnings  — clean
cargo test -p trusty-common                     — 294 passed, 0 failed, 6 ignored
cargo test -p trusty-common --features uds,webhook-hmac
                                                — 343 passed, 0 failed, 6 ignored
cargo test -p trusty-console -- --include-ignored
                                                — 193 + 2 passed, 0 failed, 0 ignored
bash scripts/check_line_cap.sh                  — 3797 files, 0 violations
bash scripts/check_sld.sh                       — 0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh        — both crates recorded
```

Rung 4's `cargo check --workspace` passes for every crate except `trusty-code-gui` and `trusty-mpm-gui`, which both fail on `tauri::generate_context!` panicking over a missing `ui/dist` — a frontend build artifact absent in a fresh worktree, unrelated to this diff (which touches zero files in either crate). `cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui` exits 0.

Refs #5089. ADR: `docs/adr/0034-webhook-ingress-console-relays-over-uds-to-a-supervised-on-demand-process.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools


---

## Review round 1 — all three HIGHs plus four others (commit `92c1ed3fc`)

**HIGH-1 — the sweep and the request path relayed the same delivery twice.** `retry_pending_once` listed every `.json` with no claim and no age filter, so a tick landing inside the ≤5 s relay window re-sent a delivery `ingest` was still sending. `schedule::ClaimSet` now gives one relay per entry path at a time, released on drop so a panicking relay cannot wedge an entry. `sweep_does_not_relay_an_entry_the_request_path_is_still_relaying` reproduces the critic's case — 600 ms delayed acking stub, sweep 150 ms in — and asserts exactly one frame reaches the target.

**HIGH-2 — no backoff, contrary to ADR-0034 §2.** Every pending entry was relayed every 60 s and each non-ack rewrote the whole base64 body plus two `fsync`s. Until step 4 binds a listener that is every delivery, forever. `BackoffPolicy` holds a fresh entry for the relay timeout, then spaces attempts 30 s doubling to a 1 h ceiling, and stops at 24 failures. An exhausted entry is never relayed again *and never deleted* — it holds the health signal red until an operator intervenes, which bounds the write cost absolutely rather than just reducing it. A per-pass `SWEEP_BUDGET` of 32 keeps one serial pass from outlasting its own tick.

**HIGH-3 — an absent spool directory reported green.** `list_pending` answered `ErrorKind::NotFound` with an empty listing, so a removed console data dir or an unmounted volume made every `POST` 500 while `/api/console/metrics/webhooks` reported `{"status":"ok","pending":0}`. Ingress dead, alarm healthy — the exact contradiction between the PR body's claim and the code. `Spool` now records whether it was `open`ed; for an opened spool a missing directory is `SpoolError::ReadDir`, which `scan_health` renders red. `Spool::at` on a never-created path is still legitimately empty, covered separately.

**Body limit.** 25 MiB on the webhook sub-router only. axum's 2 MiB default 413s a real `push` / `pull_request` delivery *before* the handler runs — no spool entry, no metric, no log. Same invisible drop, arriving through the framework instead of the code.

**Wire contract moved to `trusty-common`.** `RELAY_METHOD`, `RelayFrame`, `RelayParams`, `Provenance` and the response types now live in `trusty_common::webhook_relay`, with an owned `RelayRequest` for the receiving side and `RelayResponse::{ack, refuse, is_ack}`. `relay.rs`'s "both halves read this constant" was not true as written — step 4's receivers cannot depend on the console.

**`persist_new` commits with `hard_link`, not `rename`,** so a colliding path fails atomically with `AlreadyExists` instead of clobbering a delivery that may already have been acknowledged. `persist_update` keeps rename semantics for `record_attempt`'s deliberate overwrite. Temp files use `create_new` with a pid+nanosecond suffix.

**Socket-dir comment corrected.** It claimed the paths avoid the `$TMPDIR` convention ADR-0034 §3 rejects; `scratch_socket_dir()` *is* `$TMPDIR/trusty-<uid>` with a `/tmp` fallback. It now says what is actually true: #5099's `0700` uid-keyed directory plus `connect_hardened`'s owner/mode re-check supersedes §3's path rule by satisfying the property §3 wanted.

### The concurrency test class

Rung 5 for criterion (c) specifies failure-path **and concurrency** tests, and the first round had none — which is where HIGH-1 lived. Added: the sweep-versus-request race, two overlapping sweeps over two entries, two concurrent deliveries, claim exclusion, and claim release under panic. Plus five `backoff_*` cases and two sweep-schedule cases.

### Regression proof

Each fix was reverted in place and the corresponding test re-run:

```
sweep_does_not_relay_an_entry_the_request_path_is_still_relaying ... FAILED
  assertion `left == right` failed: the sweep must see the entry as claimed, not free to relay
health_reports_error_when_the_spool_directory_is_gone ... FAILED
  assertion `left == right` failed: a spool whose directory vanished is broken, not empty
metrics_route_reports_red_when_the_spool_directory_is_gone ... FAILED
test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 207 filtered out

route_accepts_a_body_larger_than_the_axum_default_limit ... FAILED
  left: 413
 right: 202
```

All four pass with the fixes restored.

### Gates re-run

```
cargo fmt --check                                                             — clean
cargo clippy -p trusty-common -p trusty-console --all-targets -- -D warnings  — clean
cargo test -p trusty-common                      — 294 passed; 0 failed; 6 ignored
cargo test -p trusty-common --features uds,webhook-hmac,webhook-relay
                                                 — 348 passed; 0 failed; 6 ignored
cargo test -p trusty-console -- --include-ignored — 210 passed; 0 failed; 0 ignored
                                                 —   2 passed; 0 failed; 0 ignored
bash scripts/check_line_cap.sh    — 3799 tracked .rs files, 4 allowlisted, 0 violations
bash scripts/check_sld.sh         — 56 spec docs + 3143 code files; 0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh — 18 changed paths; both crates recorded
cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui — exit 0
```

The two excluded crates fail on `tauri::generate_context!` over a missing `ui/dist` build artifact, unrelated to this diff — unchanged from the first round.

### Now non-optional for step 4

**Target-side dedup on `delivery_id`.** Console keeps a spool entry until an explicit ack, so a receiver that acknowledges *after* doing the work can still be re-sent the same delivery if the ack is lost. Relay is at-least-once by construction: duplicate delivery is the normal case, not the edge. `RelayParams::attempts` is a hint, never a guarantee that the first attempt did nothing — the doc comment on that field says so.

Deliberately out of scope this round, per review: the `tctl doctor` check (owned by in-flight #5018 / #5011), a console UI tab for the webhooks metric, and header denylist → allowlist.


---

## Review round 2 — two HIGHs plus the runtime-blocking MEDIUM (commit `aeba7970a`)

**HIGH-A — exhausted entries accumulated forever and every scan paid full decode for them.** The sweep counted `exhausted` and `continue`d; nothing deleted, quarantined, or aged them out. Since no target binds a listener until step 4, that is *every* delivery reaching 24 attempts in ~17 h and staying in the live set permanently, with both `retry_pending_once` and `scan_health` reading and `serde_json`-decoding it on every pass.

An exhausted entry now moves to `webhook-spool/exhausted/`. Kept, because it is still an unacknowledged webhook and still holds its body for a manual redelivery — but off both hot paths. Two new primitives make the scan cheap:

- `Spool::scan_metadata` reads `received_at_unix_ms` and the delivery id from filenames and opens nothing. That is what `entry_path`'s zero-padded timestamp prefix was always for; until now its stated rationale ("does not have to parse every file") was not realised anywhere, which was the MEDIUM at `spool.rs:281`.
- `Spool::load` decodes the single entry the health scan actually needs — the oldest live one, for its attempt count and last error.

A filename that does not parse is reported through `unparsable` rather than dating to 0, which would read as the oldest entry in the spool and hijack every diagnostic.

**HIGH-B — once red, the signal stopped saying anything new.** `SpoolHealth` had no exhausted field, and `SweepReport.exhausted` reached exactly one consumer: a `tracing::info!` — the log line `health.rs`'s own module doc names as the trap. Worse, `scan_health` took `listing.pending.first()`, and exhausted entries are by construction the oldest, so `oldest_pending_delivery_id`, `oldest_pending_last_error` and `oldest_pending_age_secs` pinned to the first poisoned delivery forever.

`pending` and `exhausted` are now counted separately, with their own ids and ages, and `oldest_pending_*` describes the oldest **live** entry. Any exhausted entry still forces `status: Error` — via its own field, not by hijacking the oldest-pending ones. `total_failed_attempts` is replaced by `oldest_pending_attempts`: the spool-wide sum cost one decode per entry per metrics request, which is what HIGH-A is about, and the oldest live entry's count is the actionable number.

`sweep_stops_relaying_an_exhausted_entry` asserted the old behavior as desired. It now asserts the entry leaves the live set, stays readable with its body byte-exact, and appears in the exhausted fields.

**MEDIUM — spool I/O off the async runtime.** All of it now goes through `spawn_blocking`. Ingest fsyncs a file and a directory twice per delivery; the metrics route scans two directories per request. A join failure is surfaced as an error, and `WebhookIngress::health` renders an unrunnable scan red rather than empty — same rule as an unreadable spool.

### Regression proof

Each fix reverted in place and the corresponding test re-run:

```
health_diagnostics_track_the_live_entry_not_the_exhausted_one ... FAILED
  assertion `left == right` failed: the diagnostics must describe the LIVE failure, not the 30-day-old corpse
  left: Some("d-day-one")
 right: Some("d-day-thirty")
sweep_quarantines_an_exhausted_entry_and_stops_paying_for_it ... FAILED
  assertion `left == right` failed: an exhausted entry must stop costing a decode on every pass
  left: 2
 right: 0
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 217 filtered out
```

Both pass with the fixes restored. The HIGH-B case is the one you asked for specifically: one exhausted entry from day 1 alongside a newer live entry failing on day 30, asserting the diagnostic fields describe the live one.

### Gates re-run

```
cargo fmt --check                                                             — clean
cargo clippy -p trusty-common -p trusty-console --all-targets -- -D warnings  — clean
cargo test -p trusty-common                      — 294 passed; 0 failed; 6 ignored
cargo test -p trusty-common --features uds,webhook-hmac,webhook-relay
                                                 — 348 passed; 0 failed; 6 ignored
cargo test -p trusty-console -- --include-ignored — 219 passed; 0 failed; 0 ignored
                                                 —   2 passed; 0 failed; 0 ignored
bash scripts/check_line_cap.sh    — 3799 tracked .rs files, 4 allowlisted, 0 violations
bash scripts/check_sld.sh         — 56 spec docs + 3143 code files; 0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh — 18 changed paths; both crates recorded
cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui — exit 0
```

### Left for step 4, deliberately

The ingest concurrency semaphore (25 MiB buffered before HMAC at ~3× body size), the unreachable `None` claim arm, and the `hard_link` filesystem doc note. A `>SWEEP_BUDGET` test did not fall out of the HIGH-A work for free, so it is not here.

`webhook-spool/exhausted/` has no retention policy: it grows until an operator acts, and the red health state with the exhausted count and ids is what tells them to. Deleting an undelivered webhook automatically is the one thing this whole step exists to prevent.
