### PR TITLE
fix(trusty-common): scan exactly below 256 points instead of trusting HNSW recall

### DIFF
--- a/crates/trusty-common/changelog.d/5171-hnsw-exact-small-index-search.md
+++ b/crates/trusty-common/changelog.d/5171-hnsw-exact-small-index-search.md
@@ -10,6 +10,19 @@ Fixed
   true top-5 neighbour at 6–16 points; recall is now exact below the threshold.
   The scan is also faster than the traversal it replaces at these sizes
   (27µs vs 34µs at 64 points, 45µs vs 56µs at 128); at 256 it costs 5% more.
-  Larger indexes are unchanged (#5171)
-- `HnswStore::search` no longer returns the same drawer twice when a re-upsert
-  has left a shadow copy of its vector in the in-memory graph (#5171)
+  Palaces above 256 drawers keep the graph path and its recall loss, which is
+  larger there, not smaller — 8.4% of queries lost a true top-5 neighbour at
+  1024 points, and 1.8% lost the nearest one. That residual is unchanged by
+  this fix (#5171)
+- `HnswStore::search` now scores a re-embedded drawer against the vector
+  `VECTORS` currently holds for it. Because `hnsw_rs` cannot remove a point, a
+  re-upsert leaves the old embedding in the graph until the next palace open,
+  and the drawer was ranked by whichever copy was closer — so a query matching
+  text the drawer no longer holds came back at distance 0.0, which
+  `VectorStore::search` reports as similarity 1.0. `palace_reembed` creates
+  that state in bulk. The drawer also no longer occupies two result slots
+  (#5171)
+- `HnswStore::search` selects the exact path on the live drawer count rather
+  than the graph's point count, so deletes and re-embeds accumulating within a
+  session can no longer push a small palace back onto the approximate path
+  (#5171)

--- a/crates/trusty-common/changelog.d/5171-hnsw-exact-small-index-search.md
+++ b/crates/trusty-common/changelog.d/5171-hnsw-exact-small-index-search.md
@@ -1,0 +1,15 @@
+Fixed
+
+- `HnswStore::search` now ranks by scanning every point when the index holds
+  256 or fewer, instead of traversing the HNSW graph. The traversal returned
+  only what was reachable from its descent pivot along pruned layer-0 neighbour
+  lists, so a genuinely relevant drawer could be absent from the candidate
+  pool — and because `hnsw_rs` seeds its level RNG from OS entropy, *which*
+  drawer went missing changed on every palace open. Measured against
+  brute-force truth on real 384-dim palace embeddings, 2–4% of queries lost a
+  true top-5 neighbour at 6–16 points; recall is now exact below the threshold.
+  The scan is also faster than the traversal it replaces at these sizes
+  (27µs vs 34µs at 64 points, 45µs vs 56µs at 128); at 256 it costs 5% more.
+  Larger indexes are unchanged (#5171)
+- `HnswStore::search` no longer returns the same drawer twice when a re-upsert
+  has left a shadow copy of its vector in the in-memory graph (#5171)

--- a/crates/trusty-common/changelog.d/5171-hnsw-exact-small-index-search.md
+++ b/crates/trusty-common/changelog.d/5171-hnsw-exact-small-index-search.md
@@ -26,3 +26,11 @@ Fixed
   than the graph's point count, so deletes and re-embeds accumulating within a
   session can no longer push a small palace back onto the approximate path
   (#5171)
+- Below the threshold, `HnswStore::search` no longer trims its candidate list
+  before re-scoring re-embedded drawers. A drawer that has been re-embedded is
+  ranked provisionally by whichever of its two embeddings is nearer, and
+  trimming on that optimistic score let a drawer whose SUPERSEDED vector sat
+  near the query push a genuinely nearer drawer out of the results entirely —
+  the same lost-neighbour symptom this fix exists to remove, reached through
+  re-embedding rather than through the graph. `palace_reembed` puts every
+  drawer in that state (#5171)

--- a/crates/trusty-common/src/memory_core/store/hnsw_store.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store.rs
@@ -566,6 +566,10 @@ impl HnswStore {
         // copy is nearer, which is the defect. A search that sees the flag
         // without the shadow re-reads the already-committed `VECTORS` row and
         // gets the right answer, so over-marking costs one point read.
+        //
+        // #5171: safe only because `exhaustive_nearest` (exhaustive.rs) never
+        // truncates before `resolve_shadowed` corrects every candidate — a
+        // pre-correction cap there would reopen this race.
         if shadows_previous {
             self.shadowed.write().insert(vector_id);
         }

--- a/crates/trusty-common/src/memory_core/store/hnsw_store.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store.rs
@@ -332,8 +332,10 @@ pub struct HnswStore {
     /// candidate — the steady state is empty, and this costs nothing there.
     /// What: written by `upsert` when the uuid already had a mapping. Starts
     /// empty at every `open`, which is correct: `open` rebuilds the graph with
-    /// one point per live vector.
-    /// Test: `search_scores_a_re_upserted_drawer_by_its_current_vector`.
+    /// one point per live vector. Marked before the shadow point enters the
+    /// graph, so no search can observe the point without the flag.
+    /// Test: `search_scores_a_re_upserted_drawer_by_its_current_vector`,
+    /// `upsert_marks_a_shadow_before_the_graph_can_serve_it`.
     shadowed: RwLock<std::collections::HashSet<u64>>,
 }
 
@@ -558,10 +560,16 @@ impl HnswStore {
         }
         wtx.commit()?;
 
-        self.index.read().insert((vector, vector_id as usize));
+        // #5171: mark BEFORE the graph can serve the shadow point. The two
+        // steps cannot be atomic, and the asymmetry runs one way: a search
+        // that sees the shadow without the flag scores the drawer by whichever
+        // copy is nearer, which is the defect. A search that sees the flag
+        // without the shadow re-reads the already-committed `VECTORS` row and
+        // gets the right answer, so over-marking costs one point read.
         if shadows_previous {
             self.shadowed.write().insert(vector_id);
         }
+        self.index.read().insert((vector, vector_id as usize));
 
         Ok(vector_id)
     }
@@ -617,19 +625,23 @@ impl HnswStore {
             }
         }
 
-        // Over-fetch so tombstoning doesn't starve callers asking for k.
-        // 2x is sufficient in the common case; for pathological cases the
-        // caller can re-issue.
+        // Over-fetch so tombstoning doesn't starve callers asking for k. 2x is
+        // sufficient in the common case; for pathological cases the caller can
+        // re-issue. Bounds the graph arm only — the scan returns everything.
         let want = k.saturating_mul(2).max(k);
         let ef = HNSW_DEFAULT_EF_SEARCH.max(k * 2);
-        // #5171: `reverse.len()` is the LIVE drawer count. `get_nb_point()`
-        // would also count tombstones and re-upsert shadows, so a small palace
-        // could churn past the threshold mid-session and silently revert to the
-        // approximate path.
+        // #5171: `reverse.len()` is the LIVE drawer count — `get_nb_point()`
+        // also counts tombstones and shadows, so a small palace could churn
+        // past the threshold mid-session and silently revert to the approximate
+        // path. The scan returns every live candidate rather than a
+        // `want`-sized prefix: a shadowed drawer's provisional distance is
+        // `min(stale, current)`, so cutting before `resolve_shadowed` lets a
+        // superseded vector evict a true neighbour. The `out.len() >= k` break
+        // below does the bounding instead, on the corrected ranking.
         let mut raw: Vec<(u64, f32)> = {
             let index = self.index.read();
             if reverse.len() <= EXHAUSTIVE_SCAN_MAX_POINTS {
-                exhaustive_nearest(&index, query, want, &tombstones)
+                exhaustive_nearest(&index, query, &tombstones)
             } else {
                 index
                     .search(query, want, ef)

--- a/crates/trusty-common/src/memory_core/store/hnsw_store.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store.rs
@@ -31,7 +31,7 @@ use crate::memory_core::store::kg_store::{
 };
 
 mod exhaustive;
-use exhaustive::{EXHAUSTIVE_SCAN_MAX_POINTS, exhaustive_nearest};
+use exhaustive::{EXHAUSTIVE_SCAN_MAX_POINTS, exhaustive_nearest, resolve_shadowed};
 
 /// Default HNSW connectivity. Maps to `max_nb_connection` in `hnsw_rs`.
 ///
@@ -322,6 +322,19 @@ pub struct HnswStore {
     /// `delete`, and `compact_orphans`.
     /// Test: `vector_writes_rejected_on_snapshot` (in `vector.rs`).
     read_only: bool,
+    /// `vector_id`s that have more than one point in the in-memory graph.
+    ///
+    /// Why (#5171): `hnsw_rs` cannot remove a point, so re-upserting a mapped
+    /// uuid leaves its previous embedding in the graph under the same id. A
+    /// search that scores the drawer by that stale copy reports content the
+    /// drawer no longer holds. Knowing exactly which ids are ambiguous lets
+    /// `search` re-read only those from `VECTORS` instead of re-reading every
+    /// candidate — the steady state is empty, and this costs nothing there.
+    /// What: written by `upsert` when the uuid already had a mapping. Starts
+    /// empty at every `open`, which is correct: `open` rebuilds the graph with
+    /// one point per live vector.
+    /// Test: `search_scores_a_re_upserted_drawer_by_its_current_vector`.
+    shadowed: RwLock<std::collections::HashSet<u64>>,
 }
 
 impl HnswStore {
@@ -460,6 +473,7 @@ impl HnswStore {
             index: Arc::new(RwLock::new(index)),
             dim,
             read_only,
+            shadowed: RwLock::new(std::collections::HashSet::new()),
         })
     }
 
@@ -515,6 +529,9 @@ impl HnswStore {
         let encoded: Vec<u8> = postcard::to_allocvec(&vector.to_vec())?;
         let wtx = self.db.begin_write()?;
         let vector_id;
+        // #5171: a re-upsert leaves the old embedding in the graph under this
+        // same id, so `search` must re-read the authoritative vector for it.
+        let shadows_previous;
         {
             let mut vectors = wtx.open_table(VECTORS)?;
             let mut keys = wtx.open_table(VECTOR_KEYS)?;
@@ -525,6 +542,7 @@ impl HnswStore {
             // (immutable borrow of `keys`) is dropped before we re-borrow
             // `keys` mutably for `insert`.
             let existing: Option<u64> = keys.get(uuid)?.map(|g| g.value());
+            shadows_previous = existing.is_some();
             vector_id = match existing {
                 Some(id) => id,
                 None => {
@@ -541,6 +559,9 @@ impl HnswStore {
         wtx.commit()?;
 
         self.index.read().insert((vector, vector_id as usize));
+        if shadows_previous {
+            self.shadowed.write().insert(vector_id);
+        }
 
         Ok(vector_id)
     }
@@ -554,11 +575,12 @@ impl HnswStore {
     /// hit. Tombstoned ids are filtered out before the lookup so callers
     /// never see deleted points.
     /// What: Ranks candidates — exactly, by scanning every point, when the
-    /// index holds at most [`EXHAUSTIVE_SCAN_MAX_POINTS`]; otherwise via
-    /// `Hnsw::search(query, k, ef_search)`. Filters the result against
-    /// `DELETED_VECTORS`, then maps each surviving `vector_id` back to its UUID
-    /// via the `VECTOR_KEYS` reverse map. Returns hits sorted by ascending
-    /// distance (best first), each UUID at most once.
+    /// palace holds at most [`EXHAUSTIVE_SCAN_MAX_POINTS`] live drawers;
+    /// otherwise via `Hnsw::search(query, k, ef_search)`. Re-scores any drawer
+    /// that has a shadow copy in the graph against its `VECTORS` row, filters
+    /// the result against `DELETED_VECTORS`, then maps each surviving
+    /// `vector_id` back to its UUID via the `VECTOR_KEYS` reverse map. Returns
+    /// hits sorted by ascending distance (best first), each UUID at most once.
     ///
     /// #5171: below the threshold the graph traversal returns only the points
     /// reachable from its descent pivot along pruned layer-0 neighbour lists,
@@ -567,7 +589,8 @@ impl HnswStore {
     /// *which* drawer went missing changed on every palace open. See
     /// [`exhaustive`] for the measurement and the threshold's rationale.
     /// Test: `upsert_and_search_round_trips`, `delete_filters_results`,
-    /// `exhaustive_scan_finds_every_true_neighbour_across_rebuilds`.
+    /// `search_returns_the_exact_top_k_below_the_exhaustive_threshold`,
+    /// `search_scores_a_re_upserted_drawer_by_its_current_vector`.
     pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<(String, f32)>> {
         if query.len() != self.dim {
             return Err(HnswStoreError::DimensionMismatch {
@@ -599,12 +622,14 @@ impl HnswStore {
         // caller can re-issue.
         let want = k.saturating_mul(2).max(k);
         let ef = HNSW_DEFAULT_EF_SEARCH.max(k * 2);
-        // One guard for both the size test and the search, so the branch and
-        // the work it selects observe the same graph.
-        let raw: Vec<(u64, f32)> = {
+        // #5171: `reverse.len()` is the LIVE drawer count. `get_nb_point()`
+        // would also count tombstones and re-upsert shadows, so a small palace
+        // could churn past the threshold mid-session and silently revert to the
+        // approximate path.
+        let mut raw: Vec<(u64, f32)> = {
             let index = self.index.read();
-            if index.get_nb_point() <= EXHAUSTIVE_SCAN_MAX_POINTS {
-                exhaustive_nearest(&index, query, want)
+            if reverse.len() <= EXHAUSTIVE_SCAN_MAX_POINTS {
+                exhaustive_nearest(&index, query, want, &tombstones)
             } else {
                 index
                     .search(query, want, ef)
@@ -613,6 +638,16 @@ impl HnswStore {
                     .collect()
             }
         };
+
+        // #5171: a drawer with two embeddings in the graph is scored against
+        // the one `VECTORS` holds, never against the copy it superseded.
+        let shadowed = self.shadowed.read();
+        if !shadowed.is_empty() {
+            let rtx = self.db.begin_read()?;
+            let vectors = rtx.open_table(VECTORS)?;
+            resolve_shadowed(&mut raw, &shadowed, query, &vectors)?;
+        }
+        drop(shadowed);
 
         let mut out: Vec<(String, f32)> = Vec::with_capacity(k);
         let mut emitted: std::collections::HashSet<u64> = std::collections::HashSet::new();

--- a/crates/trusty-common/src/memory_core/store/hnsw_store.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store.rs
@@ -30,6 +30,9 @@ use crate::memory_core::store::kg_store::{
     DELETED_VECTORS, NEXT_VECTOR_ID, VECTOR_ID_SEQ, VECTOR_KEYS, VECTORS,
 };
 
+mod exhaustive;
+use exhaustive::{EXHAUSTIVE_SCAN_MAX_POINTS, exhaustive_nearest};
+
 /// Default HNSW connectivity. Maps to `max_nb_connection` in `hnsw_rs`.
 ///
 /// Why: 16 is the recommended value from the original HNSW paper for
@@ -550,11 +553,21 @@ impl HnswStore {
     /// path is a single in-memory graph traversal plus a hash lookup per
     /// hit. Tombstoned ids are filtered out before the lookup so callers
     /// never see deleted points.
-    /// What: Calls `Hnsw::search(query, k, ef_search)`, filters results
-    /// against `DELETED_VECTORS`, then maps each surviving `d_id` back to
-    /// its UUID via the `VECTOR_KEYS` reverse map. Returns hits sorted by
-    /// ascending distance (best first).
-    /// Test: `upsert_and_search_round_trips`, `delete_filters_results`.
+    /// What: Ranks candidates — exactly, by scanning every point, when the
+    /// index holds at most [`EXHAUSTIVE_SCAN_MAX_POINTS`]; otherwise via
+    /// `Hnsw::search(query, k, ef_search)`. Filters the result against
+    /// `DELETED_VECTORS`, then maps each surviving `vector_id` back to its UUID
+    /// via the `VECTOR_KEYS` reverse map. Returns hits sorted by ascending
+    /// distance (best first), each UUID at most once.
+    ///
+    /// #5171: below the threshold the graph traversal returns only the points
+    /// reachable from its descent pivot along pruned layer-0 neighbour lists,
+    /// which on real embeddings dropped a true top-5 neighbour on 2–4% of
+    /// queries — and because `hnsw_rs` seeds its level RNG from OS entropy,
+    /// *which* drawer went missing changed on every palace open. See
+    /// [`exhaustive`] for the measurement and the threshold's rationale.
+    /// Test: `upsert_and_search_round_trips`, `delete_filters_results`,
+    /// `exhaustive_scan_finds_every_true_neighbour_across_rebuilds`.
     pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<(String, f32)>> {
         if query.len() != self.dim {
             return Err(HnswStoreError::DimensionMismatch {
@@ -584,20 +597,31 @@ impl HnswStore {
         // Over-fetch so tombstoning doesn't starve callers asking for k.
         // 2x is sufficient in the common case; for pathological cases the
         // caller can re-issue.
+        let want = k.saturating_mul(2).max(k);
         let ef = HNSW_DEFAULT_EF_SEARCH.max(k * 2);
-        let raw = self
-            .index
-            .read()
-            .search(query, k.saturating_mul(2).max(k), ef);
+        // One guard for both the size test and the search, so the branch and
+        // the work it selects observe the same graph.
+        let raw: Vec<(u64, f32)> = {
+            let index = self.index.read();
+            if index.get_nb_point() <= EXHAUSTIVE_SCAN_MAX_POINTS {
+                exhaustive_nearest(&index, query, want)
+            } else {
+                index
+                    .search(query, want, ef)
+                    .into_iter()
+                    .map(|hit| (hit.d_id as u64, hit.distance))
+                    .collect()
+            }
+        };
 
         let mut out: Vec<(String, f32)> = Vec::with_capacity(k);
-        for hit in raw {
-            let id = hit.d_id as u64;
-            if tombstones.contains(&id) {
+        let mut emitted: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for (id, distance) in raw {
+            if tombstones.contains(&id) || !emitted.insert(id) {
                 continue;
             }
             if let Some(uuid) = reverse.get(&id) {
-                out.push((uuid.clone(), hit.distance));
+                out.push((uuid.clone(), distance));
                 if out.len() >= k {
                     break;
                 }

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs
@@ -13,10 +13,13 @@
 //! at these sizes, no more expensive. 93% of this machine's 94 real palaces
 //! hold 64 vectors or fewer.
 //! What: [`exhaustive_nearest`] evaluates the index's own `DistCosine` against
-//! every point the graph holds and keeps the closest `want` by `vector_id`, so
-//! its distances are identical to the ones the traversal would have reported
-//! for the same points. [`resolve_shadowed`] then re-scores any drawer that has
-//! more than one embedding in the graph against the one `VECTORS` holds.
+//! every point the graph holds and keeps one entry per `vector_id`, so its
+//! distances are identical to the ones the traversal would have reported for
+//! the same points. [`resolve_shadowed`] then re-scores any drawer that has
+//! more than one embedding in the graph against the one `VECTORS` holds. The
+//! scan deliberately hands back its FULL ranking: a shadowed drawer's
+//! provisional distance is optimistic, so any cut taken before re-scoring can
+//! drop a true neighbour — see [`exhaustive_nearest`].
 //! Test: `exhaustive_scan_returns_every_point_the_graph_holds`,
 //! `search_returns_the_exact_top_k_below_the_exhaustive_threshold`,
 //! `search_scores_a_re_upserted_drawer_by_its_current_vector`.
@@ -51,30 +54,42 @@ use redb::ReadableTable;
 /// `deleting_drawers_does_not_push_a_small_palace_off_the_exhaustive_path`.
 pub(super) const EXHAUSTIVE_SCAN_MAX_POINTS: usize = 256;
 
-/// Every point in `index`, ranked by exact distance to `query`, best first.
+/// Every live point in `index`, ranked by exact distance to `query`, best
+/// first — the whole ranking, not a prefix of it.
 ///
 /// Why: see the module header — below [`EXHAUSTIVE_SCAN_MAX_POINTS`] the graph
 /// traversal can silently omit a true nearest neighbour, and a full scan cannot.
 /// What: walks the point indexation (which visits layer 0 upward and yields
 /// every stored point exactly once), skips `tombstoned` ids, evaluates the
 /// index's own distance function, keeps one entry per `vector_id` so a
-/// re-upsert's shadow copy cannot occupy two result slots, and returns at most
-/// `want` `(vector_id, distance)` pairs sorted ascending by distance.
+/// re-upsert's shadow copy cannot occupy two result slots, and returns every
+/// surviving `(vector_id, distance)` pair sorted ascending by distance.
 ///
-/// Tombstones are excluded here rather than by the caller because `want` is a
-/// small over-fetch: `delete` never removes a point from the graph, so a palace
-/// that has deleted most of its drawers would otherwise fill every returned
-/// slot with dead ids and hand the caller nothing.
+/// Tombstones are excluded here rather than by the caller because `delete`
+/// never removes a point from the graph, so a palace that has deleted most of
+/// its drawers would otherwise spend a distance evaluation on every dead point
+/// and rank it against live ones.
 ///
-/// The distance kept for a shadowed id is provisional — it is whichever copy
-/// is nearer, which is not necessarily the current one. [`resolve_shadowed`]
-/// corrects it before the caller sees it; nothing else may rely on the value.
+/// Why this returns everything rather than a `want`-sized prefix (#5171): the
+/// distance held for a shadowed id is PROVISIONAL — it is whichever of the
+/// drawer's copies is nearer, and `min` is optimistic. Cutting the list on that
+/// provisional key lets a drawer whose SUPERSEDED vector sits near the query
+/// evict a drawer whose CURRENT vector is a true neighbour, before
+/// [`resolve_shadowed`] can correct either score. That is the same
+/// missing-true-neighbour defect #5171 exists to close, reached through
+/// re-embedding instead of through graph reachability, and `palace_reembed`
+/// marks every drawer shadowed. Any bounding of the result must therefore
+/// happen AFTER re-scoring; [`super::HnswStore::search`] does it with the
+/// `out.len() >= k` break on the already-corrected ranking. Cost is bounded by
+/// the gate that selects this path: at most one entry per live drawer, so at
+/// most [`EXHAUSTIVE_SCAN_MAX_POINTS`] plus whatever dead-but-untombstoned
+/// overhang the graph carries.
 /// Test: `exhaustive_scan_returns_every_point_the_graph_holds`,
-/// `search_scores_a_re_upserted_drawer_by_its_current_vector`.
+/// `search_scores_a_re_upserted_drawer_by_its_current_vector`,
+/// `search_keeps_a_true_neighbour_a_shadowed_decoy_would_evict`.
 pub(super) fn exhaustive_nearest(
     index: &Hnsw<'static, f32, DistCosine>,
     query: &[f32],
-    want: usize,
     tombstoned: &HashSet<u64>,
 ) -> Vec<(u64, f32)> {
     // `hnsw_rs`'s point iterator unwraps the entry point (`hnsw.rs:662`), which
@@ -104,7 +119,6 @@ pub(super) fn exhaustive_nearest(
     // identically — `f32::total_cmp` alone leaves equal distances in HashMap
     // iteration order, which is not stable across runs.
     ranked.sort_by(|a, b| a.1.total_cmp(&b.1).then(a.0.cmp(&b.0)));
-    ranked.truncate(want);
     ranked
 }
 
@@ -127,9 +141,15 @@ pub(super) fn exhaustive_nearest(
 /// is dropped rather than reported at a distance nothing backs. Re-sorts, since
 /// re-scoring can reorder. Costs one point read per shadowed candidate and
 /// nothing at all when no re-upsert has happened since the palace was opened,
-/// which is the steady state.
+/// which is the steady state. On the scan path `candidates` is the full live
+/// ranking rather than a small over-fetch, because a cut taken before this
+/// function runs is taken on the wrong key (see [`exhaustive_nearest`]); after
+/// a bulk `palace_reembed` that is one point read per live drawer, bounded by
+/// [`EXHAUSTIVE_SCAN_MAX_POINTS`], on a path that already evaluates a distance
+/// against every point.
 /// Test: `search_scores_a_re_upserted_drawer_by_its_current_vector`,
-/// `search_drops_a_shadowed_candidate_whose_vector_row_is_gone`.
+/// `search_drops_a_shadowed_candidate_whose_vector_row_is_gone`,
+/// `search_keeps_a_true_neighbour_a_shadowed_decoy_would_evict`.
 pub(super) fn resolve_shadowed<T: ReadableTable<u64, &'static [u8]>>(
     candidates: &mut Vec<(u64, f32)>,
     shadowed: &HashSet<u64>,

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs
@@ -1,0 +1,86 @@
+//! Exact nearest-neighbour scan for collections small enough that HNSW's
+//! approximation is pure downside (#5171).
+//!
+//! Why: `hnsw_rs` seeds its level-assignment RNG from OS entropy, so
+//! `HnswStore::open` builds a different random graph on every palace open. A
+//! layer-0 search returns only what is reachable from the descent pivot along
+//! neighbour lists that Navarro's heuristic has pruned, and that reachable set
+//! is not the whole index. Below `ef_search` points the candidate budget
+//! already covers every point in the collection, so the traversal is spending a
+//! full scan's worth of distance evaluations and still returning a subset —
+//! measured on real 384-dim palace embeddings, 2–4% of queries lost a true
+//! top-5 neighbour at 6–16 points. Scanning every point instead is exact and,
+//! at these sizes, no more expensive. 93% of this machine's 94 real palaces
+//! hold 64 vectors or fewer.
+//! What: [`exhaustive_nearest`] evaluates the index's own `DistCosine` against
+//! every point the graph holds and keeps the closest `want` by
+//! `vector_id`, so its distances are identical to the ones the traversal would
+//! have reported for the same points.
+//! Test: `exhaustive_scan_returns_every_point_the_graph_holds`,
+//! `search_returns_the_exact_top_k_below_the_exhaustive_threshold`,
+//! `search_reports_a_re_upserted_drawer_once_at_its_current_vector`.
+
+use std::collections::HashMap;
+
+use hnsw_rs::prelude::{DistCosine, Distance, Hnsw};
+
+/// Live-point ceiling at or below which [`super::HnswStore::search`] scans
+/// exhaustively instead of traversing the graph.
+///
+/// Why (#5171): the recall loss this scan removes is not confined to tiny
+/// collections — on real embeddings it was still 3.2% of queries at 256 points
+/// — but the scan has to stay cheap enough that it never becomes the reason a
+/// recall is slow. 256 is where the two curves meet on this workload: an
+/// in-memory scan of 256 384-dim vectors costs about the same as the
+/// `VECTOR_KEYS` reverse-map build `search` already performs on every call, and
+/// it covers 99% of this machine's real palaces. Above it the graph traversal's
+/// sublinear cost is worth its approximation, which is the trade HNSW exists to
+/// make.
+/// What: compared against `Hnsw::get_nb_point()`, which counts inserted points
+/// including any shadow copies left by a re-upsert.
+/// Test: `search_uses_the_graph_above_the_exhaustive_threshold`.
+pub(super) const EXHAUSTIVE_SCAN_MAX_POINTS: usize = 256;
+
+/// Every point in `index`, ranked by exact distance to `query`, best first.
+///
+/// Why: see the module header — below [`EXHAUSTIVE_SCAN_MAX_POINTS`] the graph
+/// traversal can silently omit a true nearest neighbour, and a full scan cannot.
+/// What: walks the point indexation (which visits layer 0 upward and yields
+/// every stored point exactly once), evaluates the index's own distance
+/// function, keeps the smallest distance per `vector_id` so a re-upsert's
+/// shadow copy cannot occupy two result slots, and returns at most `want`
+/// `(vector_id, distance)` pairs sorted ascending by distance.
+/// Test: `exhaustive_scan_returns_every_point_the_graph_holds`,
+/// `search_reports_a_re_upserted_drawer_once_at_its_current_vector`.
+pub(super) fn exhaustive_nearest(
+    index: &Hnsw<'static, f32, DistCosine>,
+    query: &[f32],
+    want: usize,
+) -> Vec<(u64, f32)> {
+    // `hnsw_rs`'s point iterator unwraps the entry point (`hnsw.rs:662`), which
+    // is `None` until the first insert — iterating an empty index panics.
+    if index.get_nb_point() == 0 {
+        return Vec::new();
+    }
+    let dist = index.get_distance();
+    let mut best: HashMap<u64, f32> = HashMap::new();
+    for point in index.get_point_indexation() {
+        let d = dist.eval(query, point.get_v());
+        let id = point.get_origin_id() as u64;
+        best.entry(id)
+            .and_modify(|cur| {
+                if d < *cur {
+                    *cur = d;
+                }
+            })
+            .or_insert(d);
+    }
+
+    let mut ranked: Vec<(u64, f32)> = best.into_iter().collect();
+    // Ties broken by id so a rebuilt graph ranks an unchanged collection
+    // identically — `f32::total_cmp` alone leaves equal distances in HashMap
+    // iteration order, which is not stable across runs.
+    ranked.sort_by(|a, b| a.1.total_cmp(&b.1).then(a.0.cmp(&b.0)));
+    ranked.truncate(want);
+    ranked
+}

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs
@@ -84,6 +84,10 @@ pub(super) const EXHAUSTIVE_SCAN_MAX_POINTS: usize = 256;
 /// the gate that selects this path: at most one entry per live drawer, so at
 /// most [`EXHAUSTIVE_SCAN_MAX_POINTS`] plus whatever dead-but-untombstoned
 /// overhang the graph carries.
+///
+/// #5171: `HnswStore::upsert` depends on this — it marks a shadow id before
+/// inserting its graph point, safe only because nothing here cuts before
+/// `resolve_shadowed` corrects it.
 /// Test: `exhaustive_scan_returns_every_point_the_graph_holds`,
 /// `search_scores_a_re_upserted_drawer_by_its_current_vector`,
 /// `search_keeps_a_true_neighbour_a_shadowed_decoy_would_evict`.

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs
@@ -13,18 +13,20 @@
 //! at these sizes, no more expensive. 93% of this machine's 94 real palaces
 //! hold 64 vectors or fewer.
 //! What: [`exhaustive_nearest`] evaluates the index's own `DistCosine` against
-//! every point the graph holds and keeps the closest `want` by
-//! `vector_id`, so its distances are identical to the ones the traversal would
-//! have reported for the same points.
+//! every point the graph holds and keeps the closest `want` by `vector_id`, so
+//! its distances are identical to the ones the traversal would have reported
+//! for the same points. [`resolve_shadowed`] then re-scores any drawer that has
+//! more than one embedding in the graph against the one `VECTORS` holds.
 //! Test: `exhaustive_scan_returns_every_point_the_graph_holds`,
 //! `search_returns_the_exact_top_k_below_the_exhaustive_threshold`,
-//! `search_reports_a_re_upserted_drawer_once_at_its_current_vector`.
+//! `search_scores_a_re_upserted_drawer_by_its_current_vector`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use hnsw_rs::prelude::{DistCosine, Distance, Hnsw};
+use redb::ReadableTable;
 
-/// Live-point ceiling at or below which [`super::HnswStore::search`] scans
+/// Live-drawer ceiling at or below which [`super::HnswStore::search`] scans
 /// exhaustively instead of traversing the graph.
 ///
 /// Why (#5171): the recall loss this scan removes is not confined to tiny
@@ -36,9 +38,17 @@ use hnsw_rs::prelude::{DistCosine, Distance, Hnsw};
 /// it covers 99% of this machine's real palaces. Above it the graph traversal's
 /// sublinear cost is worth its approximation, which is the trade HNSW exists to
 /// make.
-/// What: compared against `Hnsw::get_nb_point()`, which counts inserted points
-/// including any shadow copies left by a re-upsert.
-/// Test: `search_uses_the_graph_above_the_exhaustive_threshold`.
+/// What: compared against the number of LIVE drawers — `VECTOR_KEYS` rows, the
+/// `reverse` map `search` builds two statements earlier. Not
+/// `Hnsw::get_nb_point()`, which also counts tombstoned points and re-upsert
+/// shadows: those accumulate within a session, so a palace of 200 real drawers
+/// could drift past 256 graph points mid-session and silently revert to the
+/// path this module exists to replace. Scan cost does follow the graph count,
+/// but the overhang is bounded by churn since the last open — one extra point
+/// per delete or re-upsert, and `HnswStore::open` rebuilds one point per live
+/// vector — so a bulk `palace_reembed` at most doubles it.
+/// Test: `search_uses_the_graph_above_the_exhaustive_threshold`,
+/// `deleting_drawers_does_not_push_a_small_palace_off_the_exhaustive_path`.
 pub(super) const EXHAUSTIVE_SCAN_MAX_POINTS: usize = 256;
 
 /// Every point in `index`, ranked by exact distance to `query`, best first.
@@ -46,16 +56,26 @@ pub(super) const EXHAUSTIVE_SCAN_MAX_POINTS: usize = 256;
 /// Why: see the module header — below [`EXHAUSTIVE_SCAN_MAX_POINTS`] the graph
 /// traversal can silently omit a true nearest neighbour, and a full scan cannot.
 /// What: walks the point indexation (which visits layer 0 upward and yields
-/// every stored point exactly once), evaluates the index's own distance
-/// function, keeps the smallest distance per `vector_id` so a re-upsert's
-/// shadow copy cannot occupy two result slots, and returns at most `want`
-/// `(vector_id, distance)` pairs sorted ascending by distance.
+/// every stored point exactly once), skips `tombstoned` ids, evaluates the
+/// index's own distance function, keeps one entry per `vector_id` so a
+/// re-upsert's shadow copy cannot occupy two result slots, and returns at most
+/// `want` `(vector_id, distance)` pairs sorted ascending by distance.
+///
+/// Tombstones are excluded here rather than by the caller because `want` is a
+/// small over-fetch: `delete` never removes a point from the graph, so a palace
+/// that has deleted most of its drawers would otherwise fill every returned
+/// slot with dead ids and hand the caller nothing.
+///
+/// The distance kept for a shadowed id is provisional — it is whichever copy
+/// is nearer, which is not necessarily the current one. [`resolve_shadowed`]
+/// corrects it before the caller sees it; nothing else may rely on the value.
 /// Test: `exhaustive_scan_returns_every_point_the_graph_holds`,
-/// `search_reports_a_re_upserted_drawer_once_at_its_current_vector`.
+/// `search_scores_a_re_upserted_drawer_by_its_current_vector`.
 pub(super) fn exhaustive_nearest(
     index: &Hnsw<'static, f32, DistCosine>,
     query: &[f32],
     want: usize,
+    tombstoned: &HashSet<u64>,
 ) -> Vec<(u64, f32)> {
     // `hnsw_rs`'s point iterator unwraps the entry point (`hnsw.rs:662`), which
     // is `None` until the first insert — iterating an empty index panics.
@@ -65,8 +85,11 @@ pub(super) fn exhaustive_nearest(
     let dist = index.get_distance();
     let mut best: HashMap<u64, f32> = HashMap::new();
     for point in index.get_point_indexation() {
-        let d = dist.eval(query, point.get_v());
         let id = point.get_origin_id() as u64;
+        if tombstoned.contains(&id) {
+            continue;
+        }
+        let d = dist.eval(query, point.get_v());
         best.entry(id)
             .and_modify(|cur| {
                 if d < *cur {
@@ -83,4 +106,56 @@ pub(super) fn exhaustive_nearest(
     ranked.sort_by(|a, b| a.1.total_cmp(&b.1).then(a.0.cmp(&b.0)));
     ranked.truncate(want);
     ranked
+}
+
+/// Re-score every candidate whose `vector_id` has more than one point in the
+/// graph, against the vector `VECTORS` currently holds for it.
+///
+/// Why (#5171): `upsert` on an already-mapped uuid inserts a second point under
+/// the same `vector_id` — `hnsw_rs` cannot remove the old one — so until the
+/// next `HnswStore::open` rebuilds the graph, one drawer has two embeddings in
+/// it. Ranking that drawer by whichever copy is nearer means a query against
+/// text the drawer NO LONGER HOLDS scores it as an exact match:
+/// `VectorStore::search` maps distance 0.0 to score 1.0, so a re-embedded
+/// drawer would clear a 0.99 near-duplicate threshold against superseded
+/// content. `palace_reembed` creates these in bulk, so it is not a rare state.
+/// The `VECTORS` row is the single authority on what a drawer currently holds,
+/// and it is the only thing the caller may be scored against.
+/// What: for each candidate id in `shadowed`, decodes its `VECTORS` row and
+/// replaces the provisional distance with `DistCosine` against that vector; a
+/// candidate whose row has gone (compacted between the search and this read)
+/// is dropped rather than reported at a distance nothing backs. Re-sorts, since
+/// re-scoring can reorder. Costs one point read per shadowed candidate and
+/// nothing at all when no re-upsert has happened since the palace was opened,
+/// which is the steady state.
+/// Test: `search_scores_a_re_upserted_drawer_by_its_current_vector`,
+/// `search_drops_a_shadowed_candidate_whose_vector_row_is_gone`.
+pub(super) fn resolve_shadowed<T: ReadableTable<u64, &'static [u8]>>(
+    candidates: &mut Vec<(u64, f32)>,
+    shadowed: &HashSet<u64>,
+    query: &[f32],
+    vectors: &T,
+) -> super::Result<()> {
+    let mut touched = false;
+    for slot in candidates.iter_mut() {
+        if !shadowed.contains(&slot.0) {
+            continue;
+        }
+        touched = true;
+        match vectors.get(slot.0)? {
+            Some(row) => {
+                let current: Vec<f32> = postcard::from_bytes(row.value())?;
+                slot.1 = DistCosine.eval(query, &current);
+            }
+            // NaN marks the slot for removal below. `DistCosine::eval` clamps
+            // at 0 and never returns NaN, so it cannot collide with a score.
+            None => slot.1 = f32::NAN,
+        }
+    }
+    if !touched {
+        return Ok(());
+    }
+    candidates.retain(|(_, d)| !d.is_nan());
+    candidates.sort_by(|a, b| a.1.total_cmp(&b.1).then(a.0.cmp(&b.0)));
+    Ok(())
 }

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/tests.rs
@@ -672,7 +672,7 @@ fn exhaustive_scan_returns_every_point_the_graph_holds() {
     }
 
     let query = spread_vec(dim, 7777);
-    let got = exhaustive::exhaustive_nearest(&index, &query, n);
+    let got = exhaustive::exhaustive_nearest(&index, &query, n, &Default::default());
     let ids: Vec<usize> = got.iter().map(|(id, _)| *id as usize).collect();
 
     assert_eq!(
@@ -793,15 +793,20 @@ fn search_on_an_empty_index_returns_nothing() {
 }
 
 /// Why (#5171): `upsert` of an already-mapped uuid leaves the previous vector
-/// in the in-memory graph under the same `vector_id` — `hnsw_rs` cannot remove
-/// a point. The scan sees both copies, so without dedup a re-embedded drawer
-/// would occupy two of the caller's `k` slots and push a real neighbour out.
-/// What: upserts one uuid twice with different vectors, then asserts the drawer
-/// appears exactly once and at the distance of the CURRENT vector, not the
-/// stale copy's.
+/// in the graph under the same `vector_id` — `hnsw_rs` cannot remove a point.
+/// Ranking that drawer by whichever copy is nearer scores it as an exact match
+/// for text it no longer holds; `VectorStore::search` turns distance 0.0 into
+/// score 1.0, so a re-embedded drawer would clear a 0.99 near-duplicate
+/// threshold against superseded content. `palace_reembed` creates this state in
+/// bulk.
+/// What: upserts one uuid twice, then queries with the STALE vector — the only
+/// input that separates "scored by the current vector" from "scored by the
+/// nearer copy", since querying `current` makes the two agree. Asserts the
+/// drawer is not an exact match for what it no longer holds, that the distance
+/// is the one its current vector gives, and that it takes one result slot.
 /// Test: this test itself is the verification.
 #[test]
-fn search_reports_a_re_upserted_drawer_once_at_its_current_vector() {
+fn search_scores_a_re_upserted_drawer_by_its_current_vector() {
     let dim = 32;
     let (_dir, store) = open_store(dim);
     let target = Uuid::new_v4().to_string();
@@ -815,14 +820,130 @@ fn search_reports_a_re_upserted_drawer_once_at_its_current_vector() {
             .unwrap();
     }
 
-    let hits = store.search(&current, 7).unwrap();
-    assert_eq!(
-        hits.iter().filter(|(u, _)| *u == target).count(),
-        1,
-        "a re-upserted drawer must occupy one result slot, not two: {hits:?}"
-    );
+    // The discriminating query: the vector the drawer USED to hold.
+    let hits = store.search(&stale, 7).unwrap();
+    let scored = hits
+        .iter()
+        .find(|(u, _)| *u == target)
+        .unwrap_or_else(|| panic!("target must still be reachable: {hits:?}"));
     assert!(
-        hits[0].0 == target && hits[0].1 < 1e-3,
-        "the current vector, not the shadowed copy, must set the distance: {hits:?}"
+        scored.1 > 1e-3,
+        "a superseded vector must not score its drawer as an exact match \
+         (distance {}, hits {hits:?})",
+        scored.1
+    );
+    // `DistCosine` between two independent random unit vectors in 32 dims sits
+    // far from 0; the assertion below is that the reported distance is the
+    // current vector's, to within f32 noise.
+    let expected = 1.0
+        - stale.iter().zip(&current).map(|(a, b)| a * b).sum::<f32>()
+            / (stale.iter().map(|a| a * a).sum::<f32>().sqrt()
+                * current.iter().map(|b| b * b).sum::<f32>().sqrt());
+    assert!(
+        (scored.1 - expected).abs() < 1e-4,
+        "distance must come from the current vector ({expected}), got {}",
+        scored.1
+    );
+
+    assert_eq!(
+        store
+            .search(&current, 7)
+            .unwrap()
+            .iter()
+            .filter(|(u, _)| *u == target)
+            .count(),
+        1,
+        "a re-upserted drawer must occupy one result slot, not two"
+    );
+}
+
+/// Why (#5171): re-scoring reads the `VECTORS` row a candidate claims, and
+/// `compact_orphans` can remove that row between the search and the read. There
+/// is no honest distance to report for a drawer whose vector is gone, and the
+/// stale graph copy is exactly what must not be reported, so the candidate is
+/// dropped instead.
+/// What: shadows a `vector_id` by re-upserting it, deletes its `VECTORS` row
+/// through the store's own db handle, and asserts search omits it and still
+/// returns the other drawers.
+/// Test: this test itself is the verification.
+#[test]
+fn search_drops_a_shadowed_candidate_whose_vector_row_is_gone() {
+    let dim = 16;
+    let (_dir, store) = open_store(dim);
+    let target = Uuid::new_v4().to_string();
+    let id = store.upsert(&target, &spread_vec(dim, 5)).unwrap();
+    store.upsert(&target, &spread_vec(dim, 6)).unwrap();
+    let others: Vec<String> = (0..3).map(|_| Uuid::new_v4().to_string()).collect();
+    for (i, u) in others.iter().enumerate() {
+        store.upsert(u, &spread_vec(dim, 700 + i as u64)).unwrap();
+    }
+
+    let wtx = store.db.begin_write().unwrap();
+    {
+        let mut vectors = wtx.open_table(VECTORS).unwrap();
+        vectors.remove(id).unwrap();
+    }
+    wtx.commit().unwrap();
+
+    let hits = store.search(&spread_vec(dim, 6), 5).unwrap();
+    assert!(
+        !hits.iter().any(|(u, _)| *u == target),
+        "a drawer with no vector row must not be reported: {hits:?}"
+    );
+    assert_eq!(hits.len(), 3, "the other drawers still rank: {hits:?}");
+}
+
+/// Why (#5171): the exhaustive path is selected on the LIVE drawer count, not
+/// on `Hnsw::get_nb_point()`. `delete` never removes a point from the graph and
+/// `upsert` inserts unconditionally, so a graph-count test lets a small palace
+/// churn past the threshold within one session and silently revert to the
+/// approximate path — the fix disabling itself with no signal.
+/// What: fills a store past the threshold, deletes back down to a handful of
+/// live drawers (leaving 300 points in the graph), and asserts search is exact
+/// again — which only holds on the scan path.
+/// Test: this test itself is the verification.
+#[test]
+fn deleting_drawers_does_not_push_a_small_palace_off_the_exhaustive_path() {
+    let dim = 16;
+    let total = exhaustive::EXHAUSTIVE_SCAN_MAX_POINTS + 44;
+    let (_dir, store) = open_store(dim);
+    let uuids: Vec<String> = (0..total).map(|_| Uuid::new_v4().to_string()).collect();
+    let vecs: Vec<Vec<f32>> = (0..total)
+        .map(|i| spread_vec(dim, 8_000 + i as u64))
+        .collect();
+    for (u, v) in uuids.iter().zip(&vecs) {
+        store.upsert(u, v).unwrap();
+    }
+    let keep = 6usize;
+    for u in &uuids[keep..] {
+        store.delete(u).unwrap();
+    }
+    assert_eq!(store.len().unwrap(), keep, "only the kept drawers are live");
+
+    let query = spread_vec(dim, 99_001);
+    let mut expected: Vec<(usize, f32)> = (0..keep)
+        .map(|i| {
+            let dot: f32 = vecs[i].iter().zip(&query).map(|(a, b)| a * b).sum();
+            let na: f32 = vecs[i].iter().map(|a| a * a).sum::<f32>().sqrt();
+            let nb: f32 = query.iter().map(|b| b * b).sum::<f32>().sqrt();
+            (i, 1.0 - dot / (na * nb))
+        })
+        .collect();
+    expected.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+
+    let got: Vec<String> = store
+        .search(&query, keep)
+        .unwrap()
+        .into_iter()
+        .map(|(u, _)| u)
+        .collect();
+    assert_eq!(
+        got,
+        expected
+            .iter()
+            .map(|(i, _)| uuids[*i].clone())
+            .collect::<Vec<_>>(),
+        "a palace with {keep} live drawers must stay on the exact path however \
+         many dead points the graph still carries"
     );
 }

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/tests.rs
@@ -617,6 +617,18 @@ fn spread_vec(dim: usize, seed: u64) -> Vec<f32> {
     raw.into_iter().map(|v| v / norm).collect()
 }
 
+/// Unit vector at `degrees` in the plane spanned by axes 0 and 1, so the cosine
+/// distance between two of them is `1 - cos(Δdegrees)` — monotone in the angle
+/// and checkable by hand. `spread_vec` cannot express "nearer than A but
+/// farther than B" without solving for it.
+fn planar_vec(dim: usize, degrees: f32) -> Vec<f32> {
+    let mut v = vec![0.0f32; dim];
+    let radians = degrees.to_radians();
+    v[0] = radians.cos();
+    v[1] = radians.sin();
+    v
+}
+
 /// Brute-force cosine ranking, computed independently of `hnsw_rs`.
 fn reference_ranking(pool: &[Vec<f32>], query: &[f32]) -> Vec<usize> {
     let mut scored: Vec<(usize, f64)> = pool
@@ -672,7 +684,7 @@ fn exhaustive_scan_returns_every_point_the_graph_holds() {
     }
 
     let query = spread_vec(dim, 7777);
-    let got = exhaustive::exhaustive_nearest(&index, &query, n, &Default::default());
+    let got = exhaustive::exhaustive_nearest(&index, &query, &Default::default());
     let ids: Vec<usize> = got.iter().map(|(id, _)| *id as usize).collect();
 
     assert_eq!(
@@ -945,5 +957,118 @@ fn deleting_drawers_does_not_push_a_small_palace_off_the_exhaustive_path() {
             .collect::<Vec<_>>(),
         "a palace with {keep} live drawers must stay on the exact path however \
          many dead points the graph still carries"
+    );
+}
+
+/// Why (#5171): re-scoring a shadowed drawer fixes its DISTANCE but not its
+/// SELECTION, and selection is what #5171 is about. `exhaustive_nearest` ranks
+/// a shadowed id on `min(stale, current)`, which is optimistic, so cutting the
+/// candidate list on that provisional key promotes a drawer whose superseded
+/// vector sits near the query over one whose current vector is a true
+/// neighbour — and evicts the true neighbour before anything corrects either
+/// score. `palace_reembed` marks every drawer shadowed, which is the maximal
+/// case. Same missing-true-neighbour defect, reached through re-embedding
+/// instead of through graph reachability.
+/// What: one truth drawer at 40° from the query, and six decoys that each USED
+/// to hold a vector nearer than that (10°–15°) and now hold one much farther
+/// (80°–85°). Six exceeds `want` = 2k, so on the provisional key the decoys
+/// fill every slot. Asserts the truth drawer is still ranked first, which only
+/// holds if the list is cut after re-scoring.
+/// Test: this test itself is the verification.
+#[test]
+fn search_keeps_a_true_neighbour_a_shadowed_decoy_would_evict() {
+    let dim = 16;
+    let k = 2usize;
+    let (_dir, store) = open_store(dim);
+
+    let query = planar_vec(dim, 0.0);
+    let truth = Uuid::new_v4().to_string();
+    store.upsert(&truth, &planar_vec(dim, 40.0)).unwrap();
+
+    let decoys: Vec<String> = (0..6)
+        .map(|i| {
+            let u = Uuid::new_v4().to_string();
+            store.upsert(&u, &planar_vec(dim, 10.0 + i as f32)).unwrap();
+            store.upsert(&u, &planar_vec(dim, 80.0 + i as f32)).unwrap();
+            u
+        })
+        .collect();
+
+    let hits = store.search(&query, k).unwrap();
+    assert_eq!(
+        hits.len(),
+        k,
+        "seven live drawers must fill k={k}: {hits:?}"
+    );
+    assert_eq!(
+        hits[0].0, truth,
+        "the nearest LIVE drawer must survive selection — a re-embedded drawer \
+         may be ranked only by the vector it currently holds, never by the one \
+         it superseded (hits {hits:?}, decoys {decoys:?})"
+    );
+    // 1 - cos(40°) = 0.234. A decoy scored by its stale copy would be under
+    // 0.04; scored by its current copy, over 0.8.
+    assert!(
+        (hits[0].1 - 0.234).abs() < 1e-3,
+        "the truth drawer's distance must be its own (0.234), got {}",
+        hits[0].1
+    );
+}
+
+/// Why (#5171): `upsert` cannot insert the shadow point into the graph and mark
+/// the id in `shadowed` atomically, so one of the two orders leaves a window
+/// where a concurrent `search` misbehaves. The asymmetry is one-directional: a
+/// search that sees the shadow point WITHOUT the flag scores the drawer by
+/// whichever copy is nearer, which is the whole defect; a search that sees the
+/// flag WITHOUT the shadow point re-reads the already-committed `VECTORS` row
+/// and gets the right answer at the cost of one point read. So the flag must go
+/// first.
+/// What: holds the graph's write lock so the re-upsert parks at its
+/// `index.insert`, then asserts the flag is already set while it is parked —
+/// which is precisely the state a search in that window would observe. Polls
+/// rather than sleeps, so the passing path costs microseconds; the failing path
+/// is the one that waits, and it cannot pass by luck because the marking is
+/// unreachable until the lock is released.
+/// Test: this test itself is the verification.
+#[test]
+fn upsert_marks_a_shadow_before_the_graph_can_serve_it() {
+    let dim = 8;
+    let (_dir, store) = open_store(dim);
+    let store = Arc::new(store);
+    let target = Uuid::new_v4().to_string();
+    let id = store.upsert(&target, &planar_vec(dim, 0.0)).unwrap();
+    assert!(
+        !store.shadowed.read().contains(&id),
+        "a first upsert shadows nothing"
+    );
+
+    let graph = store.index.write();
+    let writer = {
+        let store = Arc::clone(&store);
+        let target = target.clone();
+        std::thread::spawn(move || store.upsert(&target, &planar_vec(dim, 90.0)).unwrap())
+    };
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    let mut marked = false;
+    while std::time::Instant::now() < deadline {
+        if store.shadowed.read().contains(&id) {
+            marked = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+    drop(graph);
+    assert_eq!(
+        writer.join().expect("upsert thread"),
+        id,
+        "the re-upsert reuses the drawer's id"
+    );
+
+    assert!(
+        marked,
+        "the shadow flag must be set before the shadow point can be reached \
+         through the graph — a search in the window between them would score \
+         the drawer by its superseded vector (#5171)"
     );
 }

--- a/crates/trusty-common/src/memory_core/store/hnsw_store/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/hnsw_store/tests.rs
@@ -588,3 +588,241 @@ fn upsert_refuses_an_id_that_only_vector_keys_still_claims() {
     assert_eq!(audit.key_rows, 2);
     assert_eq!(audit.distinct_vector_ids, 2);
 }
+
+// ---------------------------------------------------------------------------
+// #5171 — exact search below the exhaustive threshold.
+// ---------------------------------------------------------------------------
+
+/// Deterministic pseudo-random unit vectors.
+///
+/// Why: the #5171 miss depends on the shape of the pruned layer-0 neighbour
+/// lists, and `unit_vec`'s monotone ramps are far too correlated to produce a
+/// realistic graph — every vector is nearly parallel to every other. An
+/// xorshift-driven Gaussian-ish spread reproduces the isotropic-with-clusters
+/// geometry of a real sentence embedding, which is what the recall measurement
+/// in this issue used.
+/// What: xorshift64* seeded per vector, mapped to [-1, 1), then L2-normalised.
+/// The seed fully determines the output, so a failure is reproducible.
+/// Test: used by the tests below.
+fn spread_vec(dim: usize, seed: u64) -> Vec<f32> {
+    let mut x = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    let mut next = || {
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        ((x >> 11) as f64 / (1u64 << 53) as f64) as f32 * 2.0 - 1.0
+    };
+    let raw: Vec<f32> = (0..dim).map(|_| next()).collect();
+    let norm: f32 = raw.iter().map(|v| v * v).sum::<f32>().sqrt();
+    raw.into_iter().map(|v| v / norm).collect()
+}
+
+/// Brute-force cosine ranking, computed independently of `hnsw_rs`.
+fn reference_ranking(pool: &[Vec<f32>], query: &[f32]) -> Vec<usize> {
+    let mut scored: Vec<(usize, f64)> = pool
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            let dot: f64 = v
+                .iter()
+                .zip(query)
+                .map(|(a, b)| *a as f64 * *b as f64)
+                .sum();
+            let na: f64 = v.iter().map(|a| *a as f64 * *a as f64).sum::<f64>().sqrt();
+            let nb: f64 = query
+                .iter()
+                .map(|b| *b as f64 * *b as f64)
+                .sum::<f64>()
+                .sqrt();
+            (i, 1.0 - dot / (na * nb))
+        })
+        .collect();
+    scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap().then(a.0.cmp(&b.0)));
+    scored.into_iter().map(|(i, _)| i).collect()
+}
+
+/// Why (#5171): the defect is that a search can return a strict subset of the
+/// index, so the invariant worth asserting is total coverage — not a rate. This
+/// test is deterministic: it does not depend on which random graph `hnsw_rs`
+/// built, because a full scan reaches every point by construction. It is the
+/// direct statement of "a known-nearest point is always present in the
+/// candidate pool", and it pins the ranking to an independently computed
+/// brute-force reference so a future "optimisation" of the scan cannot quietly
+/// reorder results.
+/// What: builds a 40-point graph, then asserts `exhaustive_nearest` returns all
+/// 40 ids in exactly the reference order, and that its top-5 prefix is the
+/// reference top-5.
+/// Test: this test itself is the verification.
+#[test]
+fn exhaustive_scan_returns_every_point_the_graph_holds() {
+    use hnsw_rs::prelude::{DistCosine, Hnsw};
+
+    let dim = 64;
+    let n = 40usize;
+    let pool: Vec<Vec<f32>> = (0..n).map(|i| spread_vec(dim, 900 + i as u64)).collect();
+    let index = Hnsw::<f32, DistCosine>::new(
+        HNSW_MAX_NB_CONNECTION,
+        HNSW_INITIAL_CAPACITY,
+        HNSW_MAX_LAYER,
+        HNSW_EF_CONSTRUCTION,
+        DistCosine,
+    );
+    for (i, v) in pool.iter().enumerate() {
+        index.insert((v.as_slice(), i));
+    }
+
+    let query = spread_vec(dim, 7777);
+    let got = exhaustive::exhaustive_nearest(&index, &query, n);
+    let ids: Vec<usize> = got.iter().map(|(id, _)| *id as usize).collect();
+
+    assert_eq!(
+        ids.len(),
+        n,
+        "the scan must reach every point in the index, got {} of {n}",
+        ids.len()
+    );
+    assert_eq!(
+        ids,
+        reference_ranking(&pool, &query),
+        "the scan must rank identically to an independent brute-force ranking"
+    );
+    assert!(
+        got.windows(2).all(|w| w[0].1 <= w[1].1),
+        "distances must be non-decreasing: {got:?}"
+    );
+}
+
+/// Why (#5171): `HnswStore::search` used to hand back only the points reachable
+/// from the graph's descent pivot along pruned layer-0 neighbour lists. Because
+/// `hnsw_rs` seeds its level RNG from OS entropy, every `HnswStore::open`
+/// builds a different graph, so the omission moved from drawer to drawer on
+/// every palace open — the reason this could not be caught by a single-build
+/// test. Rebuilding the same collection repeatedly is what samples that
+/// distribution.
+/// What: builds the same 12-vector collection under 12 independently seeded
+/// graphs and asserts that for 25 queries against each, `search` returns
+/// exactly the brute-force top-5, in order. Below
+/// `EXHAUSTIVE_SCAN_MAX_POINTS` that holds with probability 1, so this test
+/// cannot flake once fixed. Before the fix it failed on roughly 3% of the 300
+/// (graph, query) pairs, which makes a passing run vanishingly unlikely.
+/// Test: this test itself is the verification.
+#[test]
+fn search_returns_the_exact_top_k_below_the_exhaustive_threshold() {
+    let dim = 64;
+    let n = 12usize;
+    let k = 5usize;
+    let pool: Vec<Vec<f32>> = (0..n).map(|i| spread_vec(dim, 100 + i as u64)).collect();
+
+    for build in 0..12u64 {
+        let (_dir, store) = open_store(dim);
+        let uuids: Vec<String> = (0..n).map(|_| Uuid::new_v4().to_string()).collect();
+        for (u, v) in uuids.iter().zip(&pool) {
+            store.upsert(u, v).unwrap();
+        }
+        for q in 0..25u64 {
+            let query = spread_vec(dim, 50_000 + build * 100 + q);
+            let expected: Vec<String> = reference_ranking(&pool, &query)
+                .into_iter()
+                .take(k)
+                .map(|i| uuids[i].clone())
+                .collect();
+            let got: Vec<String> = store
+                .search(&query, k)
+                .unwrap()
+                .into_iter()
+                .map(|(u, _)| u)
+                .collect();
+            assert_eq!(
+                got, expected,
+                "build {build}, query {q}: search must return the exact top-{k} \
+                 for a {n}-point index (#5171)"
+            );
+        }
+    }
+}
+
+/// Why (#5171): the exhaustive path is bounded by
+/// `EXHAUSTIVE_SCAN_MAX_POINTS` precisely so a large palace keeps HNSW's
+/// sublinear cost. Without a test on the seam, raising the constant — or
+/// dropping the comparison altogether — turns every recall into a linear scan
+/// with nothing to catch it.
+/// What: asserts the threshold is the small-collection bound the module claims,
+/// and that an index one point past it still answers through the graph, by
+/// checking `search` remains correct there rather than by inspecting internals.
+/// Test: this test itself is the verification.
+#[test]
+fn search_uses_the_graph_above_the_exhaustive_threshold() {
+    assert_eq!(
+        exhaustive::EXHAUSTIVE_SCAN_MAX_POINTS,
+        256,
+        "changing this bound changes the cost profile of every recall; \
+         update the measurement in exhaustive.rs before changing the number"
+    );
+
+    let dim = 16;
+    let n = exhaustive::EXHAUSTIVE_SCAN_MAX_POINTS + 1;
+    let (_dir, store) = open_store(dim);
+    let mut uuids = Vec::with_capacity(n);
+    for i in 0..n {
+        let u = Uuid::new_v4().to_string();
+        store
+            .upsert(&u, &spread_vec(dim, 4_000 + i as u64))
+            .unwrap();
+        uuids.push(u);
+    }
+    // The graph path is approximate by design, so assert only what it still
+    // owes: an exact query returns its own drawer first.
+    let hits = store.search(&spread_vec(dim, 4_000), 3).unwrap();
+    assert_eq!(
+        hits[0].0, uuids[0],
+        "above the threshold the graph path must still rank an exact match first"
+    );
+}
+
+/// Why (#5171): a fresh palace has zero points, and `hnsw_rs`'s point iterator
+/// unwraps an entry point that does not exist until the first insert
+/// (`hnsw.rs:662`). Routing an empty index down the scan therefore panicked
+/// inside the library rather than returning nothing — caught by
+/// `backfill_reembeds_a_marked_drawer`, whose store searches before it embeds.
+/// What: searches a store with no upserts and asserts an empty result.
+/// Test: this test itself is the verification.
+#[test]
+fn search_on_an_empty_index_returns_nothing() {
+    let (_dir, store) = open_store(8);
+    assert!(store.search(&spread_vec(8, 1), 5).unwrap().is_empty());
+}
+
+/// Why (#5171): `upsert` of an already-mapped uuid leaves the previous vector
+/// in the in-memory graph under the same `vector_id` — `hnsw_rs` cannot remove
+/// a point. The scan sees both copies, so without dedup a re-embedded drawer
+/// would occupy two of the caller's `k` slots and push a real neighbour out.
+/// What: upserts one uuid twice with different vectors, then asserts the drawer
+/// appears exactly once and at the distance of the CURRENT vector, not the
+/// stale copy's.
+/// Test: this test itself is the verification.
+#[test]
+fn search_reports_a_re_upserted_drawer_once_at_its_current_vector() {
+    let dim = 32;
+    let (_dir, store) = open_store(dim);
+    let target = Uuid::new_v4().to_string();
+    let stale = spread_vec(dim, 11);
+    let current = spread_vec(dim, 22);
+    store.upsert(&target, &stale).unwrap();
+    store.upsert(&target, &current).unwrap();
+    for i in 0..5 {
+        store
+            .upsert(&Uuid::new_v4().to_string(), &spread_vec(dim, 300 + i))
+            .unwrap();
+    }
+
+    let hits = store.search(&current, 7).unwrap();
+    assert_eq!(
+        hits.iter().filter(|(u, _)| *u == target).count(),
+        1,
+        "a re-upserted drawer must occupy one result slot, not two: {hits:?}"
+    );
+    assert!(
+        hits[0].0 == target && hits[0].1 < 1e-3,
+        "the current vector, not the shadowed copy, must set the distance: {hits:?}"
+    );
+}


### PR DESCRIPTION
## Outcome

Closes [#5171](https://github.com/bobmatnyc/trusty-tools/issues/5171). `HnswStore::search` now ranks by scanning every point when the index holds 256 or fewer, so a small palace can no longer drop a genuinely relevant drawer from the candidate pool.

## Step 1 — the measurement, before choosing a fix

The issue's 0.42% came from `vec_at_cosine`, whose vectors share sign-pattern structure. The real-embedding rate was unknown, so I measured it first.

**Methodology.** I copied two live palaces' `index.usearch.redb` files out of `~/Library/Application Support/trusty-memory/palaces/` (read-only copy; the live files were never opened for write) and decoded their `VECTORS` rows — 1354 live 384-dim vectors written by the configured embedder against this repo's own memory. These are production embeddings, not a model of them. For each collection size I sampled a pool from that corpus, built a graph, and queried with corpus vectors held out of the pool, which is the realistic case: a recall query is a new sentence, not a row already in the index. Truth is a brute-force cosine ranking computed in f64 independently of `hnsw_rs`. A query counts as a miss when any member of the exact top-5 is absent from the pool `search` returned. 40 independently seeded graphs × 100 queries = 4000 queries per cell, so graph-to-graph variation is sampled rather than assumed away.

**Result — miss rate is 3–10× the fixture's, and `ef_search` is not the lever.**

```
n=    6 ef=  64  queries=  4000  recall@5<1.0 on    85 (2.125%)  nearest_lost=   0 (0.000%)  neighbours_lost=   85/ 20000 (0.425%)
n=   10 ef=  64  queries=  4000  recall@5<1.0 on   174 (4.350%)  nearest_lost=   0 (0.000%)  neighbours_lost=  174/ 20000 (0.870%)
n=   16 ef=  64  queries=  4000  recall@5<1.0 on   117 (2.925%)  nearest_lost=   0 (0.000%)  neighbours_lost=  119/ 20000 (0.595%)
n=   26 ef=  64  queries=  4000  recall@5<1.0 on    13 (0.325%)  nearest_lost=   0 (0.000%)  neighbours_lost=   13/ 20000 (0.065%)
n=   42 ef=  64  queries=  4000  recall@5<1.0 on    37 (0.925%)  nearest_lost=   0 (0.000%)  neighbours_lost=   39/ 20000 (0.195%)
n=   64 ef=  64  queries=  4000  recall@5<1.0 on    38 (0.950%)  nearest_lost=   5 (0.125%)  neighbours_lost=   38/ 20000 (0.190%)
n=  128 ef=  64  queries=  4000  recall@5<1.0 on    44 (1.100%)  nearest_lost=   0 (0.000%)  neighbours_lost=   45/ 20000 (0.225%)
n=  128 ef= 256  queries=  4000  recall@5<1.0 on    35 (0.875%)  nearest_lost=   0 (0.000%)  neighbours_lost=   36/ 20000 (0.180%)
n=  256 ef=  64  queries=  4000  recall@5<1.0 on   129 (3.225%)  nearest_lost=  13 (0.325%)  neighbours_lost=  132/ 20000 (0.660%)
n=  256 ef= 256  queries=  4000  recall@5<1.0 on   112 (2.800%)  nearest_lost=  13 (0.325%)  neighbours_lost=  114/ 20000 (0.570%)
n=  512 ef=  64  queries=  4000  recall@5<1.0 on   295 (7.375%)  nearest_lost=  63 (1.575%)  neighbours_lost=  304/ 20000 (1.520%)
n=  512 ef= 256  queries=  4000  recall@5<1.0 on   253 (6.325%)  nearest_lost=  58 (1.450%)  neighbours_lost=  259/ 20000 (1.295%)
n= 1024 ef=  64  queries=  4000  recall@5<1.0 on   335 (8.375%)  nearest_lost=  73 (1.825%)  neighbours_lost=  356/ 20000 (1.780%)
n= 1024 ef= 128  queries=  4000  recall@5<1.0 on   303 (7.575%)  nearest_lost=  69 (1.725%)  neighbours_lost=  278/ 20000 (1.605%)
n= 1024 ef= 256  queries=  4000  recall@5<1.0 on   278 (6.950%)  nearest_lost=  65 (1.625%)  neighbours_lost=  292/ 20000 (1.460%)
```

Two caveats on how to read it. The held-out queries are document embeddings, not question embeddings, and questions occupy a different region of the space — so the rate is an estimate whose bias direction is unknown. And the multiplier against the fixture's 0.42% is not a measured constant: with 40 graphs per cell and no error bars, and an n=26 cell at 0.325% sitting below n=10 at 4.35%, graph-to-graph variance dominates the cell-to-cell differences. What the data supports is that the loss is percent-level rather than sub-percent, and that the `ef=64/128/256` identity below the boundary is structural.

Two things fall out of that table.

At 6–16 points, 2.1–4.4% of queries lose a true top-5 neighbour, and the `ef=64` / `ef=128` / `ef=256` rows are *byte-identical* — the candidate budget already exceeds the point count, so raising it changes nothing. That is the issue's mechanism reproduced on production data: the answer is fixed by which points are reachable from the descent pivot, not by how many candidates the search is allowed to hold.

Above the boundary `ef_search` starts to bite, but weakly: 8.375% → 6.950% going from 64 to 256 at 1024 points, at 4× the candidate work. That is the fourth knob the investigation had not tried, and it is not the fix either.

**Which sizes real palaces actually reach.** Counting live vectors in every palace on this machine:

```
CENSUS-SUMMARY palaces=94  <=64: 87 (93%)  <=128: 89 (95%)  <=256: 93 (99%)  <=1024: 93 (99%)
```

`trusty-tools` at 1354 is the only palace above 256; the median is under 10. So the sizes where the defect is worst are the sizes essentially every palace occupies.

## Step 2 — the fix, and why the rate justifies it

`HnswStore::search` scans every point when `Hnsw::get_nb_point()` is at most 256, and takes the graph path above that. The scan lives in [`exhaustive.rs`](https://github.com/bobmatnyc/trusty-tools/blob/fix/5171-hnsw-recall/crates/trusty-common/src/memory_core/store/hnsw_store/exhaustive.rs) and evaluates the index's own `DistCosine`, so distances are identical to what the traversal would have reported for the same points.

The threshold is not a guess about where the bug stops — the recall loss continues past it. It is where the scan stops being free. `search` already builds the whole `VECTOR_KEYS` reverse map and the tombstone set on every call, so it is already O(n) in redb reads and `String` allocations; at 256 points a 384-dim float scan costs about the same as work the function was already doing. Past that, HNSW's sublinear cost is worth its approximation, which is the trade the algorithm exists to make.

Deterministic seeding was considered and rejected as a fix. It makes the failure reproducible, not absent — the same drawer would go missing on every open instead of a different one. It is worth having for testability, but the regression test below gets that property from the scan being exact, without pinning the graph.

**Performance.** End-to-end `HnswStore::search`, k=10, same seeds and machine, before and after:

| points | before | after | delta |
|---|---|---|---|
| 16 | 12.56µs | 11.08µs | −12% |
| 64 | 34.14µs | 27.33µs | −20% |
| 128 | 55.57µs | 45.33µs | −18% |
| 256 | 93.06µs | 98.17µs | +5% |
| 512 | 145.79µs | 139.87µs | graph path, unchanged |
| 1024 | 199.86µs | 201.71µs | graph path, unchanged |

The scan is *faster* than the traversal below 128 points. With `ef=64` over 64–128 points the graph search evaluates most of the collection anyway, through a visited set and two heaps; one flat pass with sequential access beats it. Exact results at lower cost, up to a +5% ceiling at the threshold itself.

**Post-fix recall, measured the same way:**

```
POSTFIX n=    6  queries= 1000  recall@5<1.0 on    0 (0.000%)  mean_search=6.563µs
POSTFIX n=   16  queries= 1000  recall@5<1.0 on    0 (0.000%)  mean_search=13.389µs
POSTFIX n=   64  queries= 1000  recall@5<1.0 on    0 (0.000%)  mean_search=40.77µs
POSTFIX n=  128  queries= 1000  recall@5<1.0 on    0 (0.000%)  mean_search=60.081µs
POSTFIX n=  256  queries= 1000  recall@5<1.0 on    0 (0.000%)  mean_search=107.028µs
POSTFIX n=  257  queries= 1000  recall@5<1.0 on   34 (3.400%)  mean_search=111.538µs
POSTFIX n=  512  queries= 1000  recall@5<1.0 on   56 (5.600%)  mean_search=166.823µs
POSTFIX n= 1024  queries= 1000  recall@5<1.0 on   87 (8.700%)  mean_search=240.568µs
```

Zero misses at every size through 256, 3.4% at 257. The seam is exactly where the constant puts it.

Three smaller fixes ride along because the scan reaches states the traversal did not:

- **Shadowed drawers are scored by their current vector.** `upsert` on an already-mapped uuid leaves the old embedding in the graph under the same `vector_id`; `hnsw_rs` cannot remove a point. Ranking that drawer by whichever copy is nearer means a query against text it NO LONGER HOLDS scores it at distance 0.0 — similarity 1.0 to `VectorStore::search`, enough to clear a 0.99 near-duplicate threshold against superseded content, and `palace_reembed` creates that state in bulk. `upsert` now records which ids have a shadow copy, and `search` re-scores exactly those against their `VECTORS` row, which is the only authority on what a drawer currently holds. One point read per shadowed candidate, and nothing at all in the steady state where no re-upsert has happened since the palace opened. The drawer also stops occupying two result slots.
- **Tombstones are excluded inside the scan, not after it.** `want` is a small over-fetch and `delete` never removes a point from the graph, so a palace that had deleted most of its drawers filled every returned slot with dead ids and handed the caller nothing.
- **Empty index panic.** `hnsw_rs`'s point iterator unwraps an entry point that does not exist until the first insert (`hnsw.rs:662`), so routing a fresh palace down the scan panicked inside the library. Caught by `backfill_reembeds_a_marked_drawer`, whose store searches before it embeds; guarded and covered by its own test.

The path is selected on the **live drawer count** (`reverse.len()`), not `Hnsw::get_nb_point()`. The graph count includes tombstones and shadows, which accumulate within a session, so gating on it would let a 200-drawer palace churn past 256 points and silently revert to the path this change exists to replace. Scan cost does follow the graph count, but the overhang is bounded by churn since the last open — one extra point per delete or re-upsert — so a bulk `palace_reembed` at most doubles it, and a restart resets it.

## Out of scope

Recall above 256 points. At 1024 the loss is 8.4% of queries and 1.8% of true nearest neighbours, which is within the range an approximate index is expected to produce and which no `hnsw_rs` knob measured here removes — the four tried across this issue are `set_keeping_pruned`, `set_extend_candidates`, both together, and now `ef_search`. Improving it means a different index structure or a rerank pass over a wider candidate pool, not a parameter change. This PR does not touch it and does not claim to; `trusty-tools` is the only palace on this machine in that regime. It also sits underneath [#4904](https://github.com/bobmatnyc/trusty-tools/issues/4904)'s recall@1 of 291/400, which this PR improves for 99% of palaces but does not resolve.

## Regression test, with failing-before evidence

`search_returns_the_exact_top_k_below_the_exhaustive_threshold` builds the same 12-vector collection under 12 independently seeded graphs and asserts `search` returns exactly the brute-force top-5 for 25 queries against each. Rebuilding is what samples the OS-seeded RNG a single-build test cannot see. Post-fix the assertion holds with probability 1, because the scan is exact — it cannot flake. Pre-fix it failed on ~3% of the 300 (graph, query) pairs, so a passing run was vanishingly unlikely.

Demonstrated by setting `EXHAUSTIVE_SCAN_MAX_POINTS` to 0, which routes `search` down the pre-fix graph path with nothing else changed, and running the test 10 times:

```
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 939 filtered out; finished in 0.86s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 939 filtered out; finished in 0.41s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 939 filtered out; finished in 0.10s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 939 filtered out; finished in 0.87s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 939 filtered out; finished in 0.55s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 939 filtered out; finished in 0.80s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 939 filtered out; finished in 0.27s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 939 filtered out; finished in 1.71s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 939 filtered out; finished in 1.45s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 939 filtered out; finished in 0.73s
```

10 of 10. A representative failure — rank 4 of the true top-5 is missing and a worse drawer has taken its place:

```
assertion `left == right` failed: build 1, query 14: search must return the exact top-5 for a 12-point index (#5171)
  left: [..."894b25e5-5cbb-4327-a2ce-ca1814913d3f", "ad748527-ec61-4dff-9d23-395baecc2d62", "b59b4ae6-44b9-4bee-9bdd-2b4fbdac8ca9"]
 right: [..."894b25e5-5cbb-4327-a2ce-ca1814913d3f", "10d81b67-5a82-45b3-a46a-3385b7eb85d5", "ad748527-ec61-4dff-9d23-395baecc2d62"]
```

Review round 1 added two more, each demonstrated failing against the behaviour it replaces (`CRITIC_DEMO_*` switches, applied temporarily and removed before commit):

- `search_scores_a_re_upserted_drawer_by_its_current_vector` — queries with the **stale** vector, the only input that separates "scored by the current vector" from "scored by the nearer copy"; querying `current` makes the two branches agree, which is why the first version of this test did not catch it. With shadow resolution disabled, 3 of 3 runs FAILED:

```
a superseded vector must not score its drawer as an exact match (distance 0, hits [("27cd10c8-…", 0.0), ("3dcb10f0-…", 0.89625216), …])
```

- `deleting_drawers_does_not_push_a_small_palace_off_the_exhaustive_path` — fills past the threshold, deletes down to 6 live drawers leaving 300 graph points, asserts search is still exact. Gated on `get_nb_point()`, 3 of 3 runs FAILED with an empty result set.

Four more tests, none probabilistic:

- `exhaustive_scan_returns_every_point_the_graph_holds` — asserts the invariant directly and deterministically: over a 40-point graph the scan returns all 40 ids in exactly the order of an independently computed f64 brute-force ranking, regardless of which graph `hnsw_rs` built.
- `search_uses_the_graph_above_the_exhaustive_threshold` — pins the constant and checks an index one point past it still answers correctly through the graph, so nobody silently turns every recall into a linear scan.
- `search_drops_a_shadowed_candidate_whose_vector_row_is_gone` — `compact_orphans` can remove the row between the search and the re-read; there is no honest distance to report, and the stale copy is exactly what must not be reported, so the candidate is dropped.
- `search_on_an_empty_index_returns_nothing` — the `hnsw_rs` iterator panic.

The measurement harness itself was a temporary `#[ignore]`d module and is not in the diff; it needs a live palace, so it cannot be a repo test.

## Risk

`trusty-common`'s `memory-core` feature; behaviour change to recall semantics on every palace with ≤256 vectors, which is 99% of them. Results below the threshold become exact, so any caller depending on the old approximate ordering changes — no caller does; `PalaceHandle` and the retrieval layer treat the output as a ranked candidate list. Above the threshold the only change is duplicate suppression.

## Test evidence — rung 5

Every gate run in this worktree. `cargo test --workspace` deliberately not run; `--workspace` invocations use the three GUI excludes documented in the root `Cargo.toml` and `docs/reference/common-pitfalls.md` (#4982).

```
cargo fmt --check                                                        — clean
cargo check -p trusty-common --features memory-core                      — EXIT=0
cargo clippy -p trusty-common --all-targets --features memory-core -D warnings — EXIT=0
cargo test  -p trusty-common --features memory-core
    test result: ok. 925 passed; 0 failed; 13 ignored; 0 measured; 0 filtered out; finished in 19.53s
    (plus 6 integration binaries, all ok: 6, 0, 11, 4, 0 passed)
cargo check --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui
    Finished `dev` profile in 1m 10s                                     — EXIT=0
```

Direct dependents of `memory-core` (`trusty-agents`, `trusty-cto-db`, `tga`, `trusty-memory`, `trusty-mpm`):

```
cargo test -p trusty-memory   test result: ok. 606 passed; 0 failed; 4 ignored  (+5, 6, 11, 2, 3, 5, 2, 14, 1, 3, 3, 4, 2, 4, 1, 5, 15 across 22 integration binaries, all ok)
cargo test -p trusty-cto-db   test result: ok. 12 passed; 0 failed; 0 ignored
cargo test -p trusty-agents --lib  test result: ok. 3387 passed; 0 failed; 11 ignored
cargo test -p tga --lib            test result: ok. 774 passed; 0 failed; 1 ignored
cargo test -p trusty-mpm --lib     test result: FAILED. 4783 passed; 1 failed; 7 ignored  (see Baseline failures)
```

Repo gates:

```
line-cap: measured 3791 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
sld-lint: scanned 56 spec doc(s) + 5765 code file(s); 0 error(s), 0 warning(s)
OK   trusty-common: changelog.d fragment present and valid
changelog-fragment gate: scanned 9 changed path(s); all 1 crate(s) with source changes are recorded.
```

The new logic went in a sibling module because `hnsw_store.rs` was at 462 of its 500 SLOC.

## Baseline failures

A bare `cargo check --workspace` fails in `trusty-code-gui` on a missing `ui/dist` — the pnpm/Svelte toolchain gap that the three documented excludes exist for, not a branch failure. The diff touches nothing in that crate:

```
$ git diff --name-only origin/main...HEAD -- crates/trusty-code-gui/
(no output)
```

`ensure_managed_config_dir_emits_the_frozen_skill_warning` failed once in the round-2 `cargo test -p trusty-mpm --lib` run. It is the documented parallel-isolation race in `docs/reference/test-ladder-baseline.md`, tracked at [#4931](https://github.com/bobmatnyc/trusty-tools/issues/4931): a non-serial test's globally-installed tracing subscriber beats this one's capturing subscriber. It passed in the round-1 run of the same command, and passes in isolation:

```
$ cargo test -p trusty-mpm --lib -- --exact core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning
test core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4790 filtered out; finished in 0.82s

$ git diff --name-only origin/main...HEAD -- crates/trusty-mpm/
(no output)
```

Change-specific gates pass; `cargo test -p trusty-mpm --lib` intermittently blocked by canonical issue #4931.

`a_dead_child_is_evicted_and_respawned` ([#5085](https://github.com/bobmatnyc/trusty-tools/issues/5085)) and `disabled_salvage_budget…` ([#5084](https://github.com/bobmatnyc/trusty-tools/issues/5084)) both passed in both runs.

## Documentation / changelog

`crates/trusty-common/changelog.d/5171-hnsw-exact-small-index-search.md`, category `Fixed`. `exhaustive.rs` carries the Why/What/Test module and item docs, including the measurement behind the threshold constant. No spec governs this module, so no `# Spec References` block.

## Review-finding disposition

`code-critic` round 1 returned WARN with two findings, both fixed here in commit `d11a9ad`:

- **HIGH — shadowed drawers resolved by minimum distance.** Fixed at the seam the critic named: resolve against the `VECTORS` row, not by distance, on both paths. The test now queries the stale vector, the discriminating input the first version missed.
- **MEDIUM — threshold gated on `get_nb_point()`.** Fixed: gated on the live drawer count, with a test that deletes a palace down to 6 live drawers behind 300 graph points.

Also addressed: the changelog fragment now states plainly that recall loss continues above 256 and is larger there, and the measurement section above carries the two caveats on query distribution and on the "3–10×" multiplier not being a measured constant.

The above-256 residual is tracked separately and is not in this PR's scope.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
