### PR TITLE
fix(trusty-agents): authenticate the /api/events SSE stream and stop cross-origin reads (#5052)

### DIFF
--- a/crates/trusty-agents/changelog.d/5052-sse-auth.md
+++ b/crates/trusty-agents/changelog.d/5052-sse-auth.md
@@ -14,9 +14,10 @@ Security
   short-lived ticket minted at the new `POST /api/events/ticket`, which a
   browser can put in the `EventSource` URL. Minting is a write method, so it is
   behind the router-wide same-origin guard even when no operator token is
-  configured — which is what closes the shipped default. A ticket that leaks
-  into an access log or `Referer` grants five minutes of read-only stream
-  access, not the whole `/api/*` write surface.
+  configured — which is what closes the shipped default. A ticket expires 5
+  minutes after its last use and 1 hour after issue whatever happens in
+  between, and grants only the read-only event stream — never the `/api/*`
+  write surface, which can spawn arbitrary subprocesses.
 
   `/api/health` and `/api/config` stay exempt deliberately: the sidecar polls
   health before it holds any credential, and `/api/config` publishes only the

--- a/crates/trusty-agents/changelog.d/5052-sse-auth.md
+++ b/crates/trusty-agents/changelog.d/5052-sse-auth.md
@@ -1,0 +1,34 @@
+Security
+
+- **`GET /api/events` no longer streams conversation content to unauthenticated
+  callers** ([#5052](https://github.com/bobmatnyc/trusty-tools/issues/5052)).
+  The SSE stream was exempt from bearer auth outright, on the grounds that a
+  browser `EventSource` cannot send an `Authorization` header. A loopback bind
+  did not contain that: any web page open in the operator's browser could call
+  `new EventSource("http://127.0.0.1:7654/api/events")` and read
+  `PmThinking.text`, `AgentMessage.text`, and `PmDelegating.task_preview`
+  cross-origin — no shell access, no token, no non-loopback opt-in, and no log
+  entry. The shipped Tauri sidecar starts that port by default.
+
+  The stream now requires either a matching `Authorization: Bearer <token>` or a
+  short-lived ticket minted at the new `POST /api/events/ticket`, which a
+  browser can put in the `EventSource` URL. Minting is a write method, so it is
+  behind the router-wide same-origin guard even when no operator token is
+  configured — which is what closes the shipped default. A ticket that leaks
+  into an access log or `Referer` grants five minutes of read-only stream
+  access, not the whole `/api/*` write surface.
+
+  `/api/health` and `/api/config` stay exempt deliberately: the sidecar polls
+  health before it holds any credential, and `/api/config` publishes only the
+  `auth_required` boolean that any 401 already reveals.
+
+- **The trusty-agents API no longer serves permissive CORS**
+  ([#5052](https://github.com/bobmatnyc/trusty-tools/issues/5052)).
+  `allow_origin(Any)` let a page on any origin read every GET response —
+  `/api/tasks`, `/api/task/{id}`, `/api/sessions/{id}/recap` all carry
+  conversation content, and the same-origin write guard did not cover them
+  because it is method-gated. The daemon now reflects only same-machine origins:
+  loopback (including a `pnpm dev` server on `localhost:5173`), the Tauri
+  webview, and its own resolved non-loopback bind. Server-side callers — the
+  trusty-console reverse proxy, `curl`, MCP stdio bridges — send no `Origin` and
+  are unaffected.

--- a/crates/trusty-agents/src/api/server/auth.rs
+++ b/crates/trusty-agents/src/api/server/auth.rs
@@ -4,8 +4,10 @@
 //! control that keeps it off the LAN — the bind is (#3329). Bearer-token auth
 //! covers the one case the bind cannot: an operator who explicitly opts into a
 //! non-loopback `--bind`, which `serve_with_config` refuses to start without a
-//! token. It gates the sensitive `/api/*` routes while exempting
-//! health/config/events probes and the embedded UI assets.
+//! token. It gates the sensitive `/api/*` routes while exempting the
+//! `/api/health` and `/api/config` bootstrap probes and the embedded UI assets.
+//! #5052: `/api/events` is NO LONGER exempt — see `auth_middleware` and
+//! `super::event_tickets`.
 //! What: `ApiConfig` carries the bind + port + optional token;
 //! `auth_middleware` enforces the token; `ApiClientConfig` tells the UI whether
 //! auth is needed.
@@ -122,14 +124,35 @@ pub(super) fn bearer_token_matches(expected: &str, provided: &str) -> bool {
 /// exempt the
 /// embedded UI's static assets so a browser can load `index.html` and obtain
 /// the token via `/api/config` before issuing authenticated requests.
-/// What: For requests under `/api/*` (other than `/api/health`), checks
-/// `Authorization: Bearer <token>` and returns 401 JSON
+///
+/// Two routes remain exempt, and #5052 settled each deliberately rather than by
+/// inheritance:
+///   - `/api/health` — a liveness probe, and the Tauri sidecar polls it BEFORE
+///     it has any credential to present. Its body is
+///     `{status, version, pid, ppid}`; nothing there is conversation content.
+///   - `/api/config` — its entire purpose is pre-auth bootstrap: it tells the UI
+///     whether to prompt for a token. Its body is the single boolean
+///     `auth_required`, which any caller can already infer from whether an
+///     `/api/*` request 401s, so putting it behind the middleware would remove
+///     no information from an attacker while breaking the browser's only way to
+///     learn it needs a token.
+///
+/// `/api/events` USED to be a third exemption, on the grounds that a browser
+/// `EventSource` cannot send an `Authorization` header. That was a
+/// cross-origin disclosure of live conversation content, not a telemetry
+/// trade-off (#5052): the stream carries `PmThinking.text`, `AgentMessage.text`,
+/// and `PmDelegating.task_preview`, and any page in the operator's browser could
+/// read it from `127.0.0.1` with no credential at all. It is now authenticated
+/// by ticket — see `super::event_tickets`.
+/// What: For requests under `/api/*` (other than `/api/health` and
+/// `/api/config`), checks `Authorization: Bearer <token>` and returns 401 JSON
 /// `{"error":"unauthorized"}` on mismatch. #3761: the comparison is
 /// constant-time (`bearer_token_matches`) — this is the higher-value secret of
 /// the two the server holds, so it gets the same treatment as the relay token.
 /// Test: `auth_middleware_rejects_missing_token`,
 /// `auth_middleware_accepts_valid_token`, `auth_middleware_allows_health`,
-/// `bearer_token_matches_is_exact`.
+/// `bearer_token_matches_is_exact`,
+/// `event_tickets::mint_route_requires_bearer_token_when_configured`.
 pub(super) async fn auth_middleware(
     State(auth): State<AuthState>,
     req: Request<axum::body::Body>,
@@ -138,19 +161,14 @@ pub(super) async fn auth_middleware(
     let path = req.uri().path();
 
     // Public endpoints — never require auth:
-    //   - GET /api/health  (health probes)
+    //   - GET /api/health  (health probes; the sidecar polls it pre-credential)
     //   - GET /api/config  (UI bootstrap: tells client whether auth is needed)
     //   - any non-/api path (UI static assets at "/" and "/*path")
-    // #192 Phase B: `/api/events` is exempt from Bearer auth because the
-    // browser EventSource API cannot attach custom Authorization headers.
-    // Auth-sensitive deployments should front the server with a reverse proxy
-    // and gate `/api/events` there (e.g. mTLS or cookie-based auth) since the
-    // event stream itself contains only telemetry, not actionable controls.
-    if path == "/api/health"
-        || path == "/api/config"
-        || path == "/api/events"
-        || !path.starts_with("/api/")
-    {
+    // #5052: `/api/events` was a third exemption and is not one any more — it
+    // streams conversation content and is now gated by a ticket that a browser
+    // EventSource CAN carry (see `super::event_tickets`). Both remaining
+    // exemptions are justified in this function's doc comment.
+    if path == "/api/health" || path == "/api/config" || !path.starts_with("/api/") {
         return next.run(req).await;
     }
 

--- a/crates/trusty-agents/src/api/server/auth.rs
+++ b/crates/trusty-agents/src/api/server/auth.rs
@@ -170,10 +170,6 @@ pub(super) async fn auth_middleware(
     //   - GET /api/health  (health probes; the sidecar polls it pre-credential)
     //   - GET /api/config  (UI bootstrap: tells client whether auth is needed)
     //   - any non-/api path (UI static assets at "/" and "/*path")
-    // #5052: `/api/events` was a third exemption and is not one any more — it
-    // streams conversation content and is now gated by a ticket that a browser
-    // EventSource CAN carry (see `super::event_tickets`). Both remaining
-    // exemptions are justified in this function's doc comment.
     // #5052 (critic HIGH): `/api/events` is exempt HERE and gated in the handler
     // instead. This middleware is layered OUTSIDE the routes, so a request
     // carrying only a ticket never reached `EventStreamAuth` — the server minted

--- a/crates/trusty-agents/src/api/server/auth.rs
+++ b/crates/trusty-agents/src/api/server/auth.rs
@@ -6,7 +6,9 @@
 //! non-loopback `--bind`, which `serve_with_config` refuses to start without a
 //! token. It gates the sensitive `/api/*` routes while exempting the
 //! `/api/health` and `/api/config` bootstrap probes and the embedded UI assets.
-//! #5052: `/api/events` is NO LONGER exempt — see `auth_middleware` and
+//! #5052: `/api/events` is exempt HERE but not unauthenticated — it is gated in
+//! `events_sse::events_handler`, which takes this bearer token OR a ticket a
+//! browser `EventSource` can carry. See `auth_middleware` and
 //! `super::event_tickets`.
 //! What: `ApiConfig` carries the bind + port + optional token;
 //! `auth_middleware` enforces the token; `ApiClientConfig` tells the UI whether
@@ -137,15 +139,19 @@ pub(super) fn bearer_token_matches(expected: &str, provided: &str) -> bool {
 ///     no information from an attacker while breaking the browser's only way to
 ///     learn it needs a token.
 ///
-/// `/api/events` USED to be a third exemption, on the grounds that a browser
-/// `EventSource` cannot send an `Authorization` header. That was a
-/// cross-origin disclosure of live conversation content, not a telemetry
-/// trade-off (#5052): the stream carries `PmThinking.text`, `AgentMessage.text`,
-/// and `PmDelegating.task_preview`, and any page in the operator's browser could
-/// read it from `127.0.0.1` with no credential at all. It is now authenticated
-/// by ticket — see `super::event_tickets`.
-/// What: For requests under `/api/*` (other than `/api/health` and
-/// `/api/config`), checks `Authorization: Bearer <token>` and returns 401 JSON
+/// `/api/events` is a third exempt path, but for the opposite reason it used to
+/// be: it is not unauthenticated, it is authenticated SOMEWHERE ELSE. Pre-#5052
+/// it streamed conversation content — `PmThinking.text`, `AgentMessage.text`,
+/// `PmDelegating.task_preview` — to anyone, and any page in the operator's
+/// browser could read it from `127.0.0.1`. It is now gated inside
+/// `events_sse::events_handler`, which accepts this same bearer token OR a
+/// ticket a browser `EventSource` can carry in the URL, and 401s with neither.
+/// The gate had to move into the handler because this middleware wraps the
+/// routes from the outside: a ticket-only request was rejected here before
+/// `EventStreamAuth` ever saw it.
+/// What: For requests under `/api/*` (other than `/api/health`, `/api/config`,
+/// and the separately-gated `/api/events`), checks
+/// `Authorization: Bearer <token>` and returns 401 JSON
 /// `{"error":"unauthorized"}` on mismatch. #3761: the comparison is
 /// constant-time (`bearer_token_matches`) — this is the higher-value secret of
 /// the two the server holds, so it gets the same treatment as the relay token.
@@ -168,7 +174,20 @@ pub(super) async fn auth_middleware(
     // streams conversation content and is now gated by a ticket that a browser
     // EventSource CAN carry (see `super::event_tickets`). Both remaining
     // exemptions are justified in this function's doc comment.
-    if path == "/api/health" || path == "/api/config" || !path.starts_with("/api/") {
+    // #5052 (critic HIGH): `/api/events` is exempt HERE and gated in the handler
+    // instead. This middleware is layered OUTSIDE the routes, so a request
+    // carrying only a ticket never reached `EventStreamAuth` — the server minted
+    // tickets it would then always 401, and since a non-loopback bind REQUIRES a
+    // token, the browser stream was dead in exactly the deployment #5052 was
+    // filed about. The exemption is safe only because `events_handler` accepts
+    // the same bearer token this middleware would have checked, AND a ticket;
+    // with neither it returns 401. It is an EXACT path match, so the sibling
+    // `/api/events/ticket` mint route stays fully covered here.
+    if path == "/api/health"
+        || path == "/api/config"
+        || path == "/api/events"
+        || !path.starts_with("/api/")
+    {
         return next.run(req).await;
     }
 

--- a/crates/trusty-agents/src/api/server/event_tickets.rs
+++ b/crates/trusty-agents/src/api/server/event_tickets.rs
@@ -1,0 +1,253 @@
+//! Short-lived tickets that authenticate the `/api/events` SSE stream (#5052).
+//!
+//! Why: `/api/events` streams conversation content — `PmThinking.text`,
+//! `AgentMessage.text`, `PmDelegating.task_preview` — and used to be exempt from
+//! bearer auth outright, because the browser `EventSource` API cannot attach an
+//! `Authorization` header. A loopback bind does not contain that: any page in
+//! the operator's browser could open
+//! `new EventSource("http://127.0.0.1:7654/api/events")` and read the stream,
+//! with no shell access, no token, and no non-loopback opt-in. Removing the
+//! exemption alone would break the shipped UI, so the stream needs a credential
+//! a `EventSource` URL can carry.
+//!
+//! A ticket rather than the bearer token itself in `?token=`: the URL is the one
+//! part of the request that leaks — into access logs, the `Referer` header, and
+//! browser history. A ticket that leaks grants read-only access to the event
+//! stream for a few minutes; the bearer token that leaks grants the whole
+//! `/api/*` write surface, which can spawn arbitrary subprocesses, forever.
+//!
+//! What: [`EventTicketStore`] mints unguessable ticket strings and redeems them
+//! for a sliding TTL window. [`EventStreamAuth`] is the request-time decision:
+//! a matching bearer token, or a live ticket, or 401. Minting happens at
+//! `POST /api/events/ticket`, which — being a write method — is already behind
+//! the router-wide same-origin guard even when no bearer token is configured, so
+//! a cross-origin page cannot mint one for itself.
+//! Test: `super::tests::event_tickets`.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::http::{HeaderMap, header};
+use base64::Engine as _;
+use rand::RngCore as _;
+use serde::Serialize;
+
+use super::auth::bearer_token_matches;
+
+/// How long a ticket stays valid, measured from mint OR from its last
+/// successful redemption (a sliding window).
+///
+/// Long enough that the browser's own `EventSource` reconnect after a transient
+/// blip re-uses the same URL successfully; short enough that a ticket recovered
+/// from an access log after the fact is dead. The UI mints a fresh ticket when a
+/// reconnect does fail (`connectEventSource` in `ui/src/lib/transport.ts`), so
+/// this value is not an upper bound on stream lifetime.
+pub(super) const TICKET_TTL: Duration = Duration::from_secs(300);
+
+/// Cap on simultaneously-live tickets, so a client that mints in a loop cannot
+/// grow the store without bound. The oldest ticket is evicted past this.
+const MAX_LIVE_TICKETS: usize = 32;
+
+/// One minted, not-yet-expired ticket.
+struct LiveTicket {
+    value: String,
+    expires_at: Instant,
+}
+
+/// Body returned by `POST /api/events/ticket`. (#5052)
+///
+/// `expires_in_secs` is advisory — it lets a client schedule a refresh instead
+/// of discovering expiry as a failed reconnect.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct EventTicketResponse {
+    pub(super) ticket: String,
+    pub(super) expires_in_secs: u64,
+}
+
+/// In-memory store of live event-stream tickets. (#5052)
+///
+/// Why: process-local and non-persistent on purpose — a ticket outliving the
+/// server that issued it has no legitimate use, and persisting it would put a
+/// credential on disk. A `Vec` rather than a `HashMap` because redemption is a
+/// constant-time comparison against every entry (see [`Self::redeem`]) and the
+/// store is capped at [`MAX_LIVE_TICKETS`].
+/// What: [`Self::mint`] issues a 256-bit random ticket; [`Self::redeem`]
+/// consumes one for a refreshed TTL window; both prune expired entries first.
+/// Test: `event_tickets::*` in `super::tests`.
+#[derive(Default)]
+pub(super) struct EventTicketStore {
+    live: Mutex<Vec<LiveTicket>>,
+}
+
+impl EventTicketStore {
+    /// Issue a new ticket, valid for [`TICKET_TTL`].
+    ///
+    /// Why: the caller has already proven it is allowed to read the stream (it
+    /// got past the same-origin write guard and, when one is configured, the
+    /// bearer-token middleware). This converts that one-shot proof into a
+    /// credential the browser can put in an `EventSource` URL.
+    /// What: draws 32 bytes from the OS CSPRNG, encodes them URL-safe (so the
+    /// value survives a query string unescaped), prunes expired entries, evicts
+    /// the oldest if the store is at capacity, and returns the ticket.
+    /// Test: `mint_returns_distinct_unguessable_tickets`,
+    /// `store_is_capacity_bounded`.
+    pub(super) fn mint(&self) -> EventTicketResponse {
+        let mut bytes = [0u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut bytes);
+        let value = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
+
+        let now = Instant::now();
+        let mut live = self.lock();
+        live.retain(|t| t.expires_at > now);
+        if live.len() >= MAX_LIVE_TICKETS {
+            // Evict the entry closest to expiry — the one whose loss costs the
+            // least. `min_by_key` over a <= 32-entry Vec is not worth a heap.
+            if let Some(idx) = live
+                .iter()
+                .enumerate()
+                .min_by_key(|(_, t)| t.expires_at)
+                .map(|(i, _)| i)
+            {
+                live.remove(idx);
+            }
+        }
+        live.push(LiveTicket {
+            value: value.clone(),
+            expires_at: now + TICKET_TTL,
+        });
+
+        EventTicketResponse {
+            ticket: value,
+            expires_in_secs: TICKET_TTL.as_secs(),
+        }
+    }
+
+    /// Whether `presented` is a live ticket; refreshes its TTL if so.
+    ///
+    /// Why: a ticket is not single-use because `EventSource` reconnects to the
+    /// SAME url after a dropped connection — invalidating on first use would
+    /// turn every transient network blip into a permanently dead stream.
+    /// Refreshing on redemption instead means an ACTIVELY reconnecting client
+    /// keeps working indefinitely while an abandoned ticket still ages out.
+    /// What: prunes expired entries, then compares `presented` against every
+    /// remaining ticket with the same constant-time comparison the bearer token
+    /// uses (#3761) — a short-circuiting `==` or a `HashMap` lookup would leak
+    /// the matching prefix to an attacker who can time their own requests.
+    /// Every entry is compared even after a hit, so the time taken does not
+    /// reveal WHICH ticket matched.
+    /// Test: `redeem_rejects_unknown_ticket`, `redeem_rejects_expired_ticket`,
+    /// `minted_ticket_is_redeemable_more_than_once`.
+    pub(super) fn redeem(&self, presented: &str) -> bool {
+        let now = Instant::now();
+        let mut live = self.lock();
+        live.retain(|t| t.expires_at > now);
+
+        let mut hit = None;
+        for (idx, ticket) in live.iter().enumerate() {
+            if bearer_token_matches(&ticket.value, presented) {
+                hit = Some(idx);
+            }
+        }
+        match hit {
+            Some(idx) => {
+                live[idx].expires_at = now + TICKET_TTL;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Lock the store, recovering from a poisoned mutex.
+    ///
+    /// A panic in one redemption must not permanently 401 every subsequent
+    /// stream connection; the guarded data is a plain `Vec` with no invariant a
+    /// panic could have broken mid-update.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Vec<LiveTicket>> {
+        self.live.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Test-only: number of live (not-yet-pruned) tickets.
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.lock().len()
+    }
+
+    /// Test-only: force every live ticket to have already expired, so the
+    /// expiry branch is reachable without sleeping for [`TICKET_TTL`].
+    #[cfg(test)]
+    pub(super) fn expire_all_for_test(&self) {
+        let past = Instant::now() - Duration::from_secs(1);
+        for t in self.lock().iter_mut() {
+            t.expires_at = past;
+        }
+    }
+}
+
+/// Everything `GET /api/events` needs to decide whether a caller may read the
+/// stream. (#5052)
+///
+/// Why: the SSE route accepts TWO credentials for two different callers — a
+/// bearer header for programmatic clients (`curl`, a reverse proxy, the desktop
+/// shell's Rust SSE bridge) and a ticket for the browser, which cannot set
+/// headers on an `EventSource`. Carrying both in one value, delivered as an
+/// axum `Extension`, keeps the decision in one place instead of splitting it
+/// between the middleware and the handler.
+/// What: `token` is the configured bearer token, if any; `tickets` is the
+/// process-wide store. Cloning is cheap — both fields are `Arc`-backed.
+/// Test: `super::tests::event_tickets`.
+#[derive(Clone)]
+pub(super) struct EventStreamAuth {
+    tickets: Arc<EventTicketStore>,
+    token: Option<Arc<str>>,
+}
+
+impl EventStreamAuth {
+    /// Build the stream-auth state for a router with the given bearer token.
+    pub(super) fn new(token: Option<String>) -> Self {
+        Self {
+            tickets: Arc::new(EventTicketStore::default()),
+            token: token.map(Arc::from),
+        }
+    }
+
+    /// Mint a ticket (see [`EventTicketStore::mint`]).
+    pub(super) fn mint(&self) -> EventTicketResponse {
+        self.tickets.mint()
+    }
+
+    /// Whether this request may read the event stream.
+    ///
+    /// Why: the exact opposite of the pre-#5052 rule, which let EVERY request
+    /// through. Note that when no bearer token is configured there is nothing
+    /// for the header branch to match, so a ticket is the only way in — that is
+    /// deliberate: the shipped default (Tauri sidecar on `127.0.0.1:7654`, no
+    /// token) is exactly the configuration the cross-origin `EventSource` attack
+    /// targeted, and it must be closed too.
+    /// What: accepts an `Authorization: Bearer <t>` header that matches the
+    /// configured token, else a live ticket, else rejects.
+    /// Test: `event_stream_without_credential_is_rejected`,
+    /// `event_stream_without_credential_is_rejected_with_token_configured`,
+    /// `minted_ticket_opens_event_stream`, `bearer_token_opens_event_stream`,
+    /// `event_stream_with_unknown_ticket_is_rejected`.
+    pub(super) fn authorize(&self, headers: &HeaderMap, ticket: Option<&str>) -> bool {
+        if let Some(expected) = self.token.as_deref()
+            && let Some(presented) = bearer_header(headers)
+            && bearer_token_matches(expected, presented)
+        {
+            return true;
+        }
+        matches!(ticket, Some(t) if self.tickets.redeem(t))
+    }
+}
+
+/// Extract the `Bearer` credential from an `Authorization` header.
+///
+/// Mirrors the parsing in `auth::auth_middleware` (same prefix, same trim) so
+/// the two paths cannot disagree about what counts as a presented token.
+fn bearer_header(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(str::trim)
+}

--- a/crates/trusty-agents/src/api/server/event_tickets.rs
+++ b/crates/trusty-agents/src/api/server/event_tickets.rs
@@ -13,8 +13,9 @@
 //! A ticket rather than the bearer token itself in `?token=`: the URL is the one
 //! part of the request that leaks — into access logs, the `Referer` header, and
 //! browser history. A ticket that leaks grants read-only access to the event
-//! stream for a few minutes; the bearer token that leaks grants the whole
-//! `/api/*` write surface, which can spawn arbitrary subprocesses, forever.
+//! stream, expiring after 5 minutes idle and after 1 hour absolutely however
+//! often it is used; the bearer token that leaks grants the whole `/api/*`
+//! write surface, which can spawn arbitrary subprocesses, forever.
 //!
 //! What: [`EventTicketStore`] mints unguessable ticket strings and redeems them
 //! for a sliding TTL window. [`EventStreamAuth`] is the request-time decision:
@@ -44,6 +45,18 @@ use super::auth::bearer_token_matches;
 /// this value is not an upper bound on stream lifetime.
 pub(super) const TICKET_TTL: Duration = Duration::from_secs(300);
 
+/// Hard ceiling on a ticket's total life, regardless of how often it is
+/// redeemed. (#5052, critic MEDIUM-1)
+///
+/// Why: a purely sliding window has a failure mode — a ticket recovered from an
+/// access log and then polled every four minutes renews forever, so the
+/// "short-lived credential" the whole ticket design rests on quietly becomes a
+/// permanent one. The absolute cap makes the bound unconditional.
+/// Chosen an hour because it self-heals: when a live client's ticket hits the
+/// ceiling its next reconnect 401s, and both shipped clients (the Svelte
+/// `connectEventSource` loop and the desktop `sse_bridge`) re-mint on error.
+const MAX_TICKET_LIFETIME: Duration = Duration::from_secs(3600);
+
 /// Cap on simultaneously-live tickets, so a client that mints in a loop cannot
 /// grow the store without bound. The oldest ticket is evicted past this.
 const MAX_LIVE_TICKETS: usize = 32;
@@ -51,7 +64,18 @@ const MAX_LIVE_TICKETS: usize = 32;
 /// One minted, not-yet-expired ticket.
 struct LiveTicket {
     value: String,
+    /// End of the sliding idle window; refreshed on every redemption.
     expires_at: Instant,
+    /// End of the absolute lifetime; never moves after mint.
+    expires_hard_at: Instant,
+}
+
+impl LiveTicket {
+    /// Whether this ticket is still usable at `now` — inside BOTH the sliding
+    /// idle window and the absolute lifetime.
+    fn is_live(&self, now: Instant) -> bool {
+        self.expires_at > now && self.expires_hard_at > now
+    }
 }
 
 /// Body returned by `POST /api/events/ticket`. (#5052)
@@ -98,7 +122,7 @@ impl EventTicketStore {
 
         let now = Instant::now();
         let mut live = self.lock();
-        live.retain(|t| t.expires_at > now);
+        live.retain(|t| t.is_live(now));
         if live.len() >= MAX_LIVE_TICKETS {
             // Evict the entry closest to expiry — the one whose loss costs the
             // least. `min_by_key` over a <= 32-entry Vec is not worth a heap.
@@ -114,6 +138,7 @@ impl EventTicketStore {
         live.push(LiveTicket {
             value: value.clone(),
             expires_at: now + TICKET_TTL,
+            expires_hard_at: now + MAX_TICKET_LIFETIME,
         });
 
         EventTicketResponse {
@@ -128,7 +153,8 @@ impl EventTicketStore {
     /// SAME url after a dropped connection — invalidating on first use would
     /// turn every transient network blip into a permanently dead stream.
     /// Refreshing on redemption instead means an ACTIVELY reconnecting client
-    /// keeps working indefinitely while an abandoned ticket still ages out.
+    /// keeps working while an abandoned ticket still ages out — bounded by
+    /// [`MAX_TICKET_LIFETIME`], which the refresh can never push past.
     /// What: prunes expired entries, then compares `presented` against every
     /// remaining ticket with the same constant-time comparison the bearer token
     /// uses (#3761) — a short-circuiting `==` or a `HashMap` lookup would leak
@@ -136,11 +162,12 @@ impl EventTicketStore {
     /// Every entry is compared even after a hit, so the time taken does not
     /// reveal WHICH ticket matched.
     /// Test: `redeem_rejects_unknown_ticket`, `redeem_rejects_expired_ticket`,
-    /// `minted_ticket_is_redeemable_more_than_once`.
+    /// `minted_ticket_is_redeemable_more_than_once`,
+    /// `sliding_ttl_cannot_outlive_the_absolute_cap`.
     pub(super) fn redeem(&self, presented: &str) -> bool {
         let now = Instant::now();
         let mut live = self.lock();
-        live.retain(|t| t.expires_at > now);
+        live.retain(|t| t.is_live(now));
 
         let mut hit = None;
         for (idx, ticket) in live.iter().enumerate() {
@@ -150,7 +177,11 @@ impl EventTicketStore {
         }
         match hit {
             Some(idx) => {
-                live[idx].expires_at = now + TICKET_TTL;
+                // #5052 (critic MEDIUM-1): the sliding window may extend the
+                // idle deadline but never past the absolute lifetime, so a
+                // ticket polled forever still dies at `MAX_TICKET_LIFETIME`.
+                let hard = live[idx].expires_hard_at;
+                live[idx].expires_at = (now + TICKET_TTL).min(hard);
                 true
             }
             None => false,
@@ -179,6 +210,18 @@ impl EventTicketStore {
         let past = Instant::now() - Duration::from_secs(1);
         for t in self.lock().iter_mut() {
             t.expires_at = past;
+        }
+    }
+
+    /// Test-only: force every live ticket past its ABSOLUTE lifetime while
+    /// leaving the sliding idle window wide open, so `MAX_TICKET_LIFETIME` is
+    /// reachable without waiting an hour.
+    #[cfg(test)]
+    pub(super) fn expire_hard_deadline_for_test(&self) {
+        let past = Instant::now() - Duration::from_secs(1);
+        for t in self.lock().iter_mut() {
+            t.expires_hard_at = past;
+            t.expires_at = Instant::now() + TICKET_TTL;
         }
     }
 }
@@ -215,6 +258,13 @@ impl EventStreamAuth {
         self.tickets.mint()
     }
 
+    /// Test-only: the underlying store, so a test can age its tickets without
+    /// reaching into the router's request extensions.
+    #[cfg(test)]
+    pub(super) fn store(&self) -> &EventTicketStore {
+        &self.tickets
+    }
+
     /// Whether this request may read the event stream.
     ///
     /// Why: the exact opposite of the pre-#5052 rule, which let EVERY request
@@ -228,7 +278,8 @@ impl EventStreamAuth {
     /// Test: `event_stream_without_credential_is_rejected`,
     /// `event_stream_without_credential_is_rejected_with_token_configured`,
     /// `minted_ticket_opens_event_stream`, `bearer_token_opens_event_stream`,
-    /// `event_stream_with_unknown_ticket_is_rejected`.
+    /// `event_stream_with_unknown_ticket_is_rejected`,
+    /// `ticket_opens_event_stream_on_a_token_configured_server`.
     pub(super) fn authorize(&self, headers: &HeaderMap, ticket: Option<&str>) -> bool {
         if let Some(expected) = self.token.as_deref()
             && let Some(presented) = bearer_header(headers)

--- a/crates/trusty-agents/src/api/server/events_sse.rs
+++ b/crates/trusty-agents/src/api/server/events_sse.rs
@@ -15,12 +15,18 @@ use std::convert::Infallible;
 use std::time::Duration;
 
 use axum::{
+    Extension, Json,
     extract::Query,
-    response::sse::{Event as SseEvent, KeepAlive, Sse},
+    http::{HeaderMap, StatusCode},
+    response::{
+        IntoResponse, Response,
+        sse::{Event as SseEvent, KeepAlive, Sse},
+    },
 };
 use serde::Deserialize;
 use tokio_stream::Stream;
 
+use super::event_tickets::EventStreamAuth;
 use crate::events::{self, Event};
 
 /// Query string for `GET /api/events`. (#192 Phase B, #3760)
@@ -50,6 +56,11 @@ pub(super) struct EventsQuery {
     session_id: Option<String>,
     /// #3760: Slack channel id to scope the Slack conversation mirror to.
     channel: Option<String>,
+    /// #5052: the stream credential a browser `EventSource` can carry, since it
+    /// cannot set an `Authorization` header. Minted at `POST
+    /// /api/events/ticket`. Programmatic clients send a bearer header instead
+    /// and leave this absent.
+    ticket: Option<String>,
 }
 
 /// #3760: Whether one bus event should be delivered to a subscriber holding
@@ -106,13 +117,57 @@ pub(super) fn event_passes(
 /// reverse proxies and mobile networks don't reap idle connections. On
 /// `RecvError::Lagged(n)` (slow subscriber), yields one `event: lag\ndata:
 /// {"skipped":<n>}` notice and resumes — never silently drops the stream.
-/// Test: After `cargo run -- --api --port 7654 &`, run
-/// `curl -N http://localhost:7654/api/events` and watch events stream as
-/// tasks execute. The connection is exempt from Bearer auth (see
-/// `auth_middleware`).
+/// #5052: the connection is NO LONGER exempt from auth. A caller must present
+/// either a matching `Authorization: Bearer <token>` (programmatic clients) or a
+/// live `?ticket=` minted at `POST /api/events/ticket` (browsers, whose
+/// `EventSource` cannot set headers); anything else gets 401. This holds even
+/// when no bearer token is configured, because the shipped default — the Tauri
+/// sidecar on `127.0.0.1:7654` with no token — is precisely the configuration
+/// the cross-origin `EventSource` disclosure targeted.
+/// Test: `cargo run -- --api --port 7654 &`, then
+/// `T=$(curl -sX POST localhost:7654/api/events/ticket | jq -r .ticket)` and
+/// `curl -N "http://localhost:7654/api/events?ticket=$T"`; the same `curl -N`
+/// without a ticket returns 401. Unit coverage:
+/// `super::tests::event_tickets`.
 pub(super) async fn events_handler(
+    Extension(auth): Extension<EventStreamAuth>,
+    headers: HeaderMap,
     Query(params): Query<EventsQuery>,
-) -> Sse<impl Stream<Item = Result<SseEvent, Infallible>>> {
+) -> Response {
+    // #5052: authenticate before subscribing to the bus, so an unauthorized
+    // caller never holds a receiver on a channel carrying conversation content.
+    if !auth.authorize(&headers, params.ticket.as_deref()) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({ "error": "unauthorized" })),
+        )
+            .into_response();
+    }
+    event_stream(params).into_response()
+}
+
+/// `POST /api/events/ticket` — issue a short-lived credential for the SSE
+/// stream. (#5052)
+///
+/// Why: the browser needs a credential it can put in an `EventSource` URL, and
+/// this is the authenticated endpoint that hands one out. It is a POST, and
+/// therefore already behind the router-wide same-origin write guard
+/// (`trusty_common::server::guard_write_origin`) — that is what closes the
+/// default, token-less configuration: a page on `https://evil.example` gets a
+/// 403 here and so can never obtain a ticket, whatever it does with
+/// `EventSource` afterwards. When a bearer token IS configured, `auth_middleware`
+/// gates this route on top, since `/api/events/ticket` is not an exempt path.
+/// What: mints a ticket and returns `{"ticket": "<opaque>", "expires_in_secs":
+/// 300}`.
+/// Test: `event_tickets::mint_route_requires_bearer_token_when_configured`,
+/// `event_tickets::mint_route_rejects_cross_origin_caller`.
+pub(super) async fn mint_event_ticket(Extension(auth): Extension<EventStreamAuth>) -> Response {
+    Json(auth.mint()).into_response()
+}
+
+/// The SSE body itself, split out so [`events_handler`] can return either it or
+/// a 401 from one function without the stream type leaking into that signature.
+fn event_stream(params: EventsQuery) -> Sse<impl Stream<Item = Result<SseEvent, Infallible>>> {
     let mut rx = events::subscribe();
     let session_filter = params.session_id;
     // #3760: optional Slack-channel scope for the conversation mirror.

--- a/crates/trusty-agents/src/api/server/mod.rs
+++ b/crates/trusty-agents/src/api/server/mod.rs
@@ -51,6 +51,8 @@ mod auth;
 mod cancel;
 mod costs;
 mod ctrl_sessions;
+// #5052: short-lived tickets that authenticate the `/api/events` SSE stream.
+mod event_tickets;
 mod events_sse;
 mod handlers;
 mod listener_events;

--- a/crates/trusty-agents/src/api/server/routes.rs
+++ b/crates/trusty-agents/src/api/server/routes.rs
@@ -16,10 +16,10 @@
 
 use anyhow::Result;
 use axum::{
-    Json, Router, middleware,
+    Extension, Json, Router, middleware,
     routing::{get, post},
 };
-use trusty_common::server::{SelfOrigins, with_guarded_middleware};
+use trusty_common::server::{SelfOrigins, with_guarded_middleware_same_origin_cors};
 
 use super::agent_create::create_agent_route;
 // #4290: read-only KG proxy routes backing the Knowledge Graph browser.
@@ -39,7 +39,8 @@ use super::ctrl_sessions::{
     attach_ctrl_session_handler, create_ctrl_session_handler, get_ctrl_session_handler,
     list_ctrl_sessions_handler, terminate_ctrl_session_handler,
 };
-use super::events_sse::events_handler;
+use super::event_tickets::EventStreamAuth;
+use super::events_sse::{events_handler, mint_event_ticket};
 use super::handlers::{
     clear_context, clear_recent_tasks, docs_search, get_session_recap, get_task, health,
     list_tasks, submit_task,
@@ -276,7 +277,14 @@ pub fn build_router_with_origins(
         // (project, harness) pair.
         .route("/api/tm/tell", post(tm_tell))
         // #192 Phase B: SSE event stream — replaces 2s stderr polling.
+        // #5052: authenticated by ticket or bearer token; see `events_sse`.
         .route("/api/events", get(events_handler))
+        // #5052: mints the short-lived ticket a browser `EventSource` presents
+        // on `/api/events`. A POST on purpose — that puts it behind the
+        // router-wide same-origin write guard applied below, which is what
+        // stops a cross-origin page minting one in the default, token-less
+        // configuration.
+        .route("/api/events/ticket", post(mint_event_ticket))
         // #3820: durable, persisted eventstream-listener event list + the
         // per-event-type include/exclude toggle (Events pane, #3818). Named
         // `/api/listener-events` — NOT `/api/events` — because that path is
@@ -305,17 +313,30 @@ pub fn build_router_with_origins(
         .route("/{*path}", get(serve_asset))
         .with_state(state);
 
+    // #5052: the SSE stream's own credential state — the ticket store plus the
+    // configured bearer token — delivered to `/api/events` and
+    // `/api/events/ticket` as a request extension. Built unconditionally: the
+    // stream is gated whether or not an operator token is configured.
+    router = router.layer(Extension(EventStreamAuth::new(token.clone())));
+
     if let Some(tok) = token {
         let auth_state = AuthState { token: tok };
         router = router.layer(middleware::from_fn_with_state(auth_state, auth_middleware));
     }
 
     // #3329: router-wide same-origin write guard + the shared standard
-    // middleware stack (permissive CORS, tracing, gzip), applied AFTER all
-    // route registration so every destructive route is covered (#3268 lesson).
-    // Replaces the crate-local CORS/compression/trace layers so trusty-agents
-    // no longer drifts from the sibling trusty-* daemons' middleware.
-    with_guarded_middleware(router, self_origins)
+    // middleware stack (tracing, gzip), applied AFTER all route registration so
+    // every destructive route is covered (#3268 lesson). Replaces the
+    // crate-local CORS/compression/trace layers so trusty-agents no longer
+    // drifts from the sibling trusty-* daemons' middleware.
+    //
+    // #5052: this daemon takes the SAME-ORIGIN CORS variant rather than the
+    // permissive one its siblings use. Its GET surface is conversation content
+    // — `/api/events`, `/api/tasks`, `/api/task/{id}`,
+    // `/api/sessions/{id}/recap` — and `allow_origin(Any)` let any page in the
+    // operator's browser read all of it from `127.0.0.1`. The write guard did
+    // not help, because it is method-gated and reads are GET.
+    with_guarded_middleware_same_origin_cors(router, self_origins)
 }
 
 /// Serve the HTTP API and embedded web UI on `127.0.0.1:<port>` until killed.

--- a/crates/trusty-agents/src/api/server/tests/event_tickets.rs
+++ b/crates/trusty-agents/src/api/server/tests/event_tickets.rs
@@ -1,0 +1,343 @@
+//! `/api/events` stream authentication (#5052).
+//!
+//! Why: the SSE stream carries conversation content — `PmThinking.text`,
+//! `AgentMessage.text`, `PmDelegating.task_preview` — and was exempt from auth
+//! outright, so any page in the operator's browser could read it cross-origin
+//! from `127.0.0.1` with no credential. These tests pin BOTH halves of the fix:
+//! the route now refuses an uncredentialed caller, and the ticket that lets a
+//! browser `EventSource` authenticate can only be minted by a same-origin
+//! (and, when a token is configured, token-bearing) caller.
+//!
+//! `event_stream_without_credential_is_rejected` is the regression test: it
+//! returns 200 against the pre-fix code and 401 after.
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode, header};
+use tower::ServiceExt;
+
+use super::super::event_tickets::EventTicketStore;
+use super::super::routes::{build_router, build_router_with_config};
+use super::super::state::AppState;
+
+/// Router with no operator token — the SHIPPED DEFAULT (Tauri sidecar on
+/// `127.0.0.1:7654`), and the exact configuration the disclosure targeted.
+fn default_router() -> Router {
+    build_router(AppState::default())
+}
+
+fn token_router(token: &str) -> Router {
+    build_router_with_config(AppState::default(), Some(token.to_string()))
+}
+
+async fn status_of(app: &Router, req: Request<Body>) -> StatusCode {
+    app.clone()
+        .oneshot(req)
+        .await
+        .expect("router responds")
+        .status()
+}
+
+fn get_events(query: &str) -> Request<Body> {
+    Request::builder()
+        .uri(format!("/api/events{query}"))
+        .body(Body::empty())
+        .expect("request builds")
+}
+
+/// Mint a ticket through the live route and return it.
+async fn mint_ticket(app: &Router, bearer: Option<&str>) -> String {
+    let mut builder = Request::builder()
+        .method(Method::POST)
+        .uri("/api/events/ticket");
+    if let Some(t) = bearer {
+        builder = builder.header(header::AUTHORIZATION, format!("Bearer {t}"));
+    }
+    let resp = app
+        .clone()
+        .oneshot(builder.body(Body::empty()).expect("request builds"))
+        .await
+        .expect("router responds");
+    assert_eq!(resp.status(), StatusCode::OK, "mint should succeed");
+    let bytes = axum::body::to_bytes(resp.into_body(), 4096)
+        .await
+        .expect("body reads");
+    let v: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
+    assert_eq!(v["expires_in_secs"], 300);
+    v["ticket"]
+        .as_str()
+        .expect("ticket is a string")
+        .to_string()
+}
+
+// -- the regression: an uncredentialed stream request is refused --
+
+/// Why: THE defect. Pre-#5052 `auth_middleware` exempted `/api/events` before
+/// comparing anything, and on the default (token-less) config the middleware was
+/// not even installed — so this request streamed live conversation content to
+/// anyone who could open a socket, including a cross-origin `EventSource` in the
+/// operator's own browser. This test returns 200 against the pre-fix commit.
+/// Test: this test.
+#[tokio::test]
+async fn event_stream_without_credential_is_rejected() {
+    assert_eq!(
+        status_of(&default_router(), get_events("")).await,
+        StatusCode::UNAUTHORIZED,
+    );
+}
+
+/// Why: the same request against a token-guarded server — the case #5052 was
+/// filed for. A configured token must actually cover the stream.
+/// Test: this test.
+#[tokio::test]
+async fn event_stream_without_credential_is_rejected_with_token_configured() {
+    assert_eq!(
+        status_of(&token_router("secret"), get_events("")).await,
+        StatusCode::UNAUTHORIZED,
+    );
+}
+
+/// Why: an attacker who guesses at the parameter must not get in, and the 401
+/// must carry the same body shape as `auth_middleware`'s so clients can treat
+/// the two identically.
+/// Test: this test.
+#[tokio::test]
+async fn event_stream_with_unknown_ticket_is_rejected() {
+    let app = default_router();
+    let resp = app
+        .clone()
+        .oneshot(get_events("?ticket=not-a-real-ticket"))
+        .await
+        .expect("router responds");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let bytes = axum::body::to_bytes(resp.into_body(), 1024)
+        .await
+        .expect("body reads");
+    let v: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
+    assert_eq!(v["error"], "unauthorized");
+}
+
+// -- the mechanism: a minted ticket opens the stream --
+
+/// Why: the fix must not break the shipped UI. A browser mints a ticket and
+/// opens `EventSource` with it; that path must reach a real `text/event-stream`.
+/// Test: this test.
+#[tokio::test]
+async fn minted_ticket_opens_event_stream() {
+    let app = default_router();
+    let ticket = mint_ticket(&app, None).await;
+
+    let resp = app
+        .clone()
+        .oneshot(get_events(&format!("?ticket={ticket}")))
+        .await
+        .expect("router responds");
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("text/event-stream"),
+    );
+    // The body is an endless stream — never read it, just drop the connection.
+    drop(resp);
+}
+
+/// Why: `EventSource` reconnects to the SAME url after a dropped connection, so
+/// a single-use ticket would turn any transient blip into a permanently dead
+/// stream. Redemption must be repeatable.
+/// Test: this test.
+#[tokio::test]
+async fn minted_ticket_is_redeemable_more_than_once() {
+    let app = default_router();
+    let ticket = mint_ticket(&app, None).await;
+    let query = format!("?ticket={ticket}");
+    for attempt in 0..3 {
+        assert_eq!(
+            status_of(&app, get_events(&query)).await,
+            StatusCode::OK,
+            "reconnect {attempt} must succeed"
+        );
+    }
+}
+
+/// Why: programmatic clients (`curl`, a reverse proxy, the desktop shell's Rust
+/// SSE bridge) CAN set headers, so a configured bearer token must open the
+/// stream directly without a ticket round-trip.
+/// Test: this test.
+#[tokio::test]
+async fn bearer_token_opens_event_stream() {
+    let app = token_router("secret");
+    let req = Request::builder()
+        .uri("/api/events")
+        .header(header::AUTHORIZATION, "Bearer secret")
+        .body(Body::empty())
+        .expect("request builds");
+    assert_eq!(status_of(&app, req).await, StatusCode::OK);
+}
+
+/// Why: a ticket carries only stream-read authority; it must never be usable as
+/// a substitute for the bearer token on the write surface.
+/// Test: this test.
+#[tokio::test]
+async fn ticket_does_not_unlock_the_rest_of_the_api() {
+    let app = token_router("secret");
+    let ticket = mint_ticket(&app, Some("secret")).await;
+    let req = Request::builder()
+        .uri(format!("/api/tasks?ticket={ticket}"))
+        .body(Body::empty())
+        .expect("request builds");
+    assert_eq!(status_of(&app, req).await, StatusCode::UNAUTHORIZED);
+}
+
+// -- the mint endpoint's own gates --
+
+/// Why: with a token configured, minting must require it — otherwise the ticket
+/// endpoint is a credential-laundering bypass of `auth_middleware`.
+/// Test: this test.
+#[tokio::test]
+async fn mint_route_requires_bearer_token_when_configured() {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/events/ticket")
+        .body(Body::empty())
+        .expect("request builds");
+    assert_eq!(
+        status_of(&token_router("secret"), req).await,
+        StatusCode::UNAUTHORIZED,
+    );
+}
+
+/// Why: SECURITY — this is what closes the DEFAULT (token-less) config. Minting
+/// is a POST, so the router-wide same-origin write guard rejects a cross-origin
+/// caller; a page on `https://evil.example` therefore cannot obtain a ticket,
+/// and without one its `EventSource` is refused by the stream route.
+/// Test: this test.
+#[tokio::test]
+async fn mint_route_rejects_cross_origin_caller() {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/events/ticket")
+        .header(header::ORIGIN, "https://evil.example")
+        .body(Body::empty())
+        .expect("request builds");
+    assert_eq!(
+        status_of(&default_router(), req).await,
+        StatusCode::FORBIDDEN,
+    );
+}
+
+/// Why: the daemon's own SPA and a `pnpm dev` Vite server are loopback origins
+/// and must keep minting successfully.
+/// Test: this test.
+#[tokio::test]
+async fn mint_route_allows_loopback_origin() {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/events/ticket")
+        .header(header::ORIGIN, "http://localhost:5173")
+        .body(Body::empty())
+        .expect("request builds");
+    assert_eq!(status_of(&default_router(), req).await, StatusCode::OK);
+}
+
+// -- the CORS half of the fix --
+
+/// Why: SECURITY (#5052) — even holding a ticket, a page on a remote origin must
+/// not be able to READ the response, because the browser only exposes a
+/// cross-origin body when the server reflects the origin. `allow_origin(Any)`
+/// did reflect it; the same-origin policy does not.
+/// Test: this test.
+#[tokio::test]
+async fn cross_origin_request_gets_no_cors_reflection() {
+    let app = default_router();
+    let req = Request::builder()
+        .uri("/api/tasks")
+        .header(header::ORIGIN, "https://evil.example")
+        .body(Body::empty())
+        .expect("request builds");
+    let resp = app.clone().oneshot(req).await.expect("router responds");
+    assert!(
+        resp.headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .is_none(),
+        "a remote origin must not be reflected"
+    );
+}
+
+/// Why: the tightened policy must not break the local browser surfaces — the
+/// daemon's own SPA on `127.0.0.1` and the Vite dev server on `localhost:5173`.
+/// Test: this test.
+#[tokio::test]
+async fn loopback_origin_is_cors_reflected() {
+    let app = default_router();
+    for origin in ["http://localhost:5173", "http://127.0.0.1:7654"] {
+        let req = Request::builder()
+            .uri("/api/tasks")
+            .header(header::ORIGIN, origin)
+            .body(Body::empty())
+            .expect("request builds");
+        let resp = app.clone().oneshot(req).await.expect("router responds");
+        assert_eq!(
+            resp.headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .and_then(|v| v.to_str().ok()),
+            Some(origin),
+            "{origin} must be reflected"
+        );
+    }
+}
+
+// -- the store, directly --
+
+/// Why: a guessable ticket is no credential at all.
+/// Test: this test.
+#[test]
+fn mint_returns_distinct_unguessable_tickets() {
+    let store = EventTicketStore::default();
+    let a = store.mint().ticket;
+    let b = store.mint().ticket;
+    assert_ne!(a, b);
+    // 32 random bytes, URL-safe base64 without padding.
+    assert_eq!(a.len(), 43);
+    assert!(
+        a.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+        "ticket must survive a query string unescaped: {a}"
+    );
+}
+
+/// Why: an expired ticket recovered from an access log must be dead.
+/// Test: this test.
+#[test]
+fn redeem_rejects_expired_ticket() {
+    let store = EventTicketStore::default();
+    let ticket = store.mint().ticket;
+    assert!(store.redeem(&ticket));
+    store.expire_all_for_test();
+    assert!(!store.redeem(&ticket));
+    assert_eq!(store.len(), 0, "expired tickets are pruned");
+}
+
+/// Why: a client minting in a loop must not grow the store without bound.
+/// Test: this test.
+#[test]
+fn store_is_capacity_bounded() {
+    let store = EventTicketStore::default();
+    for _ in 0..200 {
+        let _ = store.mint();
+    }
+    assert!(store.len() <= 32, "live tickets: {}", store.len());
+}
+
+/// Why: the obvious negative case — an unrelated string is not a ticket.
+/// Test: this test.
+#[test]
+fn redeem_rejects_unknown_ticket() {
+    let store = EventTicketStore::default();
+    let ticket = store.mint().ticket;
+    assert!(!store.redeem(""));
+    assert!(!store.redeem("nope"));
+    // A one-character truncation must not match either.
+    assert!(!store.redeem(&ticket[..ticket.len() - 1]));
+}

--- a/crates/trusty-agents/src/api/server/tests/event_tickets.rs
+++ b/crates/trusty-agents/src/api/server/tests/event_tickets.rs
@@ -13,10 +13,10 @@
 
 use axum::Router;
 use axum::body::Body;
-use axum::http::{Method, Request, StatusCode, header};
+use axum::http::{HeaderMap, Method, Request, StatusCode, header};
 use tower::ServiceExt;
 
-use super::super::event_tickets::EventTicketStore;
+use super::super::event_tickets::{EventStreamAuth, EventTicketStore};
 use super::super::routes::{build_router, build_router_with_config};
 use super::super::state::AppState;
 
@@ -190,6 +190,79 @@ async fn ticket_does_not_unlock_the_rest_of_the_api() {
     assert_eq!(status_of(&app, req).await, StatusCode::UNAUTHORIZED);
 }
 
+// -- the ticket path on a TOKEN-CONFIGURED server (#5052, critic HIGH) --
+//
+// Every success case above uses `default_router()`, which has no token — so
+// none of them exercised `auth_middleware`, which axum layers OUTSIDE the
+// handler. `bearer_token_opens_event_stream` passed because the HEADER cleared
+// that middleware, not because the ticket path worked. It did not: the server
+// minted tickets it would then always 401. And since `serve_with_config`
+// refuses a non-loopback bind without a token, a token-configured server is the
+// ONLY way to run off-loopback — the deployment #5052 was filed about, where
+// the browser stream was therefore dead. These are the cases that were missing.
+
+/// Why: THE critic HIGH. A browser holding a valid ticket and no
+/// `Authorization` header — the only thing `EventSource` can do — must reach
+/// the stream on a token-configured server. Fails with 401 against the
+/// pre-fix head, where `auth_middleware` rejected it before `EventStreamAuth`
+/// ever ran.
+/// Test: this test.
+#[tokio::test]
+async fn ticket_opens_event_stream_on_a_token_configured_server() {
+    let app = token_router("secret");
+    // The ticket is minted WITH the bearer (the UI holds the token); the stream
+    // request deliberately carries no header at all.
+    let ticket = mint_ticket(&app, Some("secret")).await;
+    assert_eq!(
+        status_of(&app, get_events(&format!("?ticket={ticket}"))).await,
+        StatusCode::OK,
+    );
+}
+
+/// Why: the exemption that makes the ticket reachable must not weaken the
+/// negative case — a bogus ticket and no header is still 401 with a token set.
+/// Test: this test.
+#[tokio::test]
+async fn bogus_ticket_is_rejected_on_a_token_configured_server() {
+    assert_eq!(
+        status_of(&token_router("secret"), get_events("?ticket=forged")).await,
+        StatusCode::UNAUTHORIZED,
+    );
+}
+
+/// Why: an EXPIRED ticket must not survive the exemption either. Exercised
+/// against `EventStreamAuth` directly — the router hides its ticket store in a
+/// request extension, and the decision under test is the auth one, not routing.
+/// Test: this test.
+#[test]
+fn expired_ticket_is_rejected_by_stream_auth_with_a_token_configured() {
+    let auth = EventStreamAuth::new(Some("secret".to_string()));
+    let ticket = auth.mint().ticket;
+    let no_headers = HeaderMap::new();
+
+    assert!(auth.authorize(&no_headers, Some(&ticket)), "fresh ticket");
+    auth.store().expire_all_for_test();
+    assert!(
+        !auth.authorize(&no_headers, Some(&ticket)),
+        "expired ticket must be refused even though a token is configured"
+    );
+
+    // The bearer path is unaffected by ticket expiry.
+    let mut bearer = HeaderMap::new();
+    bearer.insert(
+        header::AUTHORIZATION,
+        "Bearer secret".parse().expect("header value"),
+    );
+    assert!(auth.authorize(&bearer, None));
+    // And a wrong bearer with no ticket is still refused.
+    let mut wrong = HeaderMap::new();
+    wrong.insert(
+        header::AUTHORIZATION,
+        "Bearer wrong!".parse().expect("header value"),
+    );
+    assert!(!auth.authorize(&wrong, None));
+}
+
 // -- the mint endpoint's own gates --
 
 /// Why: with a token configured, minting must require it — otherwise the ticket
@@ -328,6 +401,25 @@ fn store_is_capacity_bounded() {
         let _ = store.mint();
     }
     assert!(store.len() <= 32, "live tickets: {}", store.len());
+}
+
+/// Why: SECURITY (#5052, critic MEDIUM-1) — the sliding window must not be able
+/// to renew a ticket past its absolute lifetime, or a ticket recovered from an
+/// access log and polled every few minutes becomes a permanent credential.
+/// Test: this test.
+#[test]
+fn sliding_ttl_cannot_outlive_the_absolute_cap() {
+    let store = EventTicketStore::default();
+    let ticket = store.mint().ticket;
+    // Redeem once (which slides the idle window), then push only the ABSOLUTE
+    // deadline into the past while leaving the idle window wide open.
+    assert!(store.redeem(&ticket));
+    store.expire_hard_deadline_for_test();
+    assert!(
+        !store.redeem(&ticket),
+        "a refreshed idle window must not outlive MAX_TICKET_LIFETIME"
+    );
+    assert_eq!(store.len(), 0, "hard-expired tickets are pruned");
 }
 
 /// Why: the obvious negative case — an unrelated string is not a ticket.

--- a/crates/trusty-agents/src/api/server/tests/events_sse.rs
+++ b/crates/trusty-agents/src/api/server/tests/events_sse.rs
@@ -12,8 +12,9 @@
 //! decision is the whole contract and it is directly observable here.
 //! Test: this module IS the test.
 
+use axum::Router;
 use axum::body::Body;
-use axum::http::{Request, StatusCode};
+use axum::http::{Method, Request, StatusCode};
 use tower::ServiceExt;
 
 use crate::api::server::events_sse::event_passes;
@@ -115,15 +116,36 @@ fn event_passes_still_scopes_by_session() {
 
 // -- #3760: a mistyped filter must fail LOUD, never fail open ----------------
 
+/// Mint a live stream ticket through `POST /api/events/ticket` (#5052).
+async fn mint_ticket(app: &Router) -> String {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/events/ticket")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    v["ticket"].as_str().unwrap().to_string()
+}
+
 /// Open `/api/events` with the given query string and return the status.
 ///
 /// The SSE handler streams forever once it is entered, so we only ever assert
 /// on the response STATUS here — reaching a 200 means the `Query<EventsQuery>`
 /// extractor accepted the parameters, which is the whole contract under test.
+///
+/// #5052: the stream is authenticated now, so every call carries a freshly
+/// minted ticket. Without one the route 401s, which `is_client_error()` would
+/// happily accept — the rejection cases below would then pass for the wrong
+/// reason. The auth gate itself is covered by `super::event_tickets`.
 async fn get_events(query: &str) -> StatusCode {
     let app = build_router(AppState::default());
+    let ticket = mint_ticket(&app).await;
+    let sep = if query.is_empty() { '?' } else { '&' };
     let req = Request::builder()
-        .uri(format!("/api/events{query}"))
+        .uri(format!("/api/events{query}{sep}ticket={ticket}"))
         .body(Body::empty())
         .unwrap();
     app.oneshot(req).await.unwrap().status()

--- a/crates/trusty-agents/src/api/server/tests/mod.rs
+++ b/crates/trusty-agents/src/api/server/tests/mod.rs
@@ -17,6 +17,8 @@ mod attendance;
 mod cancel;
 mod costs;
 mod ctrl_sessions;
+// #5052: `/api/events` stream authentication (ticket mint + redeem + CORS).
+mod event_tickets;
 mod events_sse;
 mod guard;
 mod listener_events;

--- a/crates/trusty-agents/ui/src-tauri/src/sse_bridge.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/sse_bridge.rs
@@ -10,8 +10,9 @@
 //! sidecar's `/api/events`, parses frames, and re-emits each streaming delta
 //! as a Tauri `task-delta` event — exactly the payload the browser bridge
 //! emits, so `ChatView` handles both transports with identical code.
-//! What: [`start_event_bridge`] spawns a supervised background task that
-//! (re)connects to `{api_base}/api/events`, incrementally parses the SSE
+//! What: [`start_event_bridge`] spawns a supervised background task that mints
+//! a stream ticket (#5052 — `/api/events` is no longer unauthenticated) and
+//! (re)connects to `{api_base}/api/events?ticket=…`, incrementally parses the SSE
 //! `event:`/`data:` framing off `Response::chunk()` (no extra deps — reqwest's
 //! chunk reader is available without the `stream` feature), and for every
 //! `agent_message_delta` frame emits `app.emit("task-delta", DeltaPayload)`.
@@ -56,9 +57,9 @@ struct DeltaPayload {
 /// `RECONNECT_BACKOFF`, repeat. Errors are logged, never fatal.
 pub fn start_event_bridge(app: AppHandle, port: u16) {
     tauri::async_runtime::spawn(async move {
-        let url = format!("{}/api/events", api_base(port));
+        let base = api_base(port);
         loop {
-            if let Err(e) = pump_stream(&app, &url).await {
+            if let Err(e) = pump_stream(&app, &base).await {
                 tracing::debug!(?e, "event bridge stream ended; will reconnect");
             }
             tokio::time::sleep(RECONNECT_BACKOFF).await;
@@ -66,11 +67,41 @@ pub fn start_event_bridge(app: AppHandle, port: u16) {
     });
 }
 
-/// Connect to `url` and pump SSE frames until the stream ends.
-async fn pump_stream(app: &AppHandle, url: &str) -> Result<(), String> {
+/// Mint a stream ticket from the sidecar. (#5052)
+///
+/// Why: `GET /api/events` is no longer unauthenticated — it streams conversation
+/// content, and any page in the user's browser could previously read it from
+/// `127.0.0.1`. This bridge is a same-machine, server-side client, so it sends
+/// no `Origin` and the mint endpoint's same-origin write guard admits it.
+/// What: `POST /api/events/ticket` → the `ticket` field of the JSON body.
+/// Test: covered end-to-end by launching the desktop shell against a live
+/// sidecar; the server side is `trusty-agents`' `api::server::tests::event_tickets`.
+async fn mint_ticket(client: &reqwest::Client, base: &str) -> Result<String, String> {
+    let body: serde_json::Value = client
+        .post(format!("{base}/api/events/ticket"))
+        .send()
+        .await
+        .map_err(|e| format!("mint: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("mint status: {e}"))?
+        .json()
+        .await
+        .map_err(|e| format!("mint body: {e}"))?;
+    body.get("ticket")
+        .and_then(|t| t.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| "mint response had no ticket".to_string())
+}
+
+/// Connect to the sidecar's event stream and pump SSE frames until it ends.
+async fn pump_stream(app: &AppHandle, base: &str) -> Result<(), String> {
     let client = reqwest::Client::new();
+    // #5052: a fresh ticket per connection attempt — cheaper and more robust
+    // than caching one across the reconnect backoff and discovering it expired.
+    let ticket = mint_ticket(&client, base).await?;
+    let url = format!("{base}/api/events?ticket={ticket}");
     let mut resp = client
-        .get(url)
+        .get(&url)
         .send()
         .await
         .map_err(|e| format!("connect: {e}"))?

--- a/crates/trusty-agents/ui/src-tauri/src/sse_bridge.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/sse_bridge.rs
@@ -58,9 +58,20 @@ struct DeltaPayload {
 pub fn start_event_bridge(app: AppHandle, port: u16) {
     tauri::async_runtime::spawn(async move {
         let base = api_base(port);
+        // #5052 (critic MEDIUM-2): the sidecar inherits this process's
+        // environment, so when the operator configured a token it reads the
+        // same var we do — that is the credential this bridge must present.
+        let token = std::env::var("TAGENT_API_TOKEN")
+            .or_else(|_| std::env::var("OPEN_MPM_API_TOKEN"))
+            .ok()
+            .filter(|t| !t.is_empty());
         loop {
-            if let Err(e) = pump_stream(&app, &base).await {
-                tracing::debug!(?e, "event bridge stream ended; will reconnect");
+            if let Err(e) = pump_stream(&app, &base, token.as_deref()).await {
+                // #5052 (critic MEDIUM-2): `debug!` hid a PERMANENT failure —
+                // a token-guarded sidecar 401s every attempt and the desktop
+                // stream dies silently, looking like "the assistant stopped
+                // streaming". A dead stream must be visible in default logs.
+                tracing::warn!(?e, "event bridge stream failed; retrying");
             }
             tokio::time::sleep(RECONNECT_BACKOFF).await;
         }
@@ -76,32 +87,48 @@ pub fn start_event_bridge(app: AppHandle, port: u16) {
 /// What: `POST /api/events/ticket` → the `ticket` field of the JSON body.
 /// Test: covered end-to-end by launching the desktop shell against a live
 /// sidecar; the server side is `trusty-agents`' `api::server::tests::event_tickets`.
-async fn mint_ticket(client: &reqwest::Client, base: &str) -> Result<String, String> {
-    let body: serde_json::Value = client
-        .post(format!("{base}/api/events/ticket"))
-        .send()
-        .await
-        .map_err(|e| format!("mint: {e}"))?
-        .error_for_status()
-        .map_err(|e| format!("mint status: {e}"))?
-        .json()
-        .await
-        .map_err(|e| format!("mint body: {e}"))?;
+async fn mint_ticket(
+    client: &reqwest::Client,
+    base: &str,
+    token: Option<&str>,
+) -> Result<String, String> {
+    let body: serde_json::Value =
+        with_bearer(client.post(format!("{base}/api/events/ticket")), token)
+            .send()
+            .await
+            .map_err(|e| format!("mint: {e}"))?
+            .error_for_status()
+            .map_err(|e| format!("mint status: {e}"))?
+            .json()
+            .await
+            .map_err(|e| format!("mint body: {e}"))?;
     body.get("ticket")
         .and_then(|t| t.as_str())
         .map(str::to_string)
         .ok_or_else(|| "mint response had no ticket".to_string())
 }
 
+/// Attach `Authorization: Bearer <token>` when the operator configured one.
+///
+/// Both the mint call and the stream call need it: `/api/events/ticket` is
+/// bearer-gated by `auth_middleware`, and `/api/events` accepts the bearer
+/// directly (which is why a server-side client never depends on the ticket
+/// round-trip succeeding).
+fn with_bearer(req: reqwest::RequestBuilder, token: Option<&str>) -> reqwest::RequestBuilder {
+    match token {
+        Some(t) => req.bearer_auth(t),
+        None => req,
+    }
+}
+
 /// Connect to the sidecar's event stream and pump SSE frames until it ends.
-async fn pump_stream(app: &AppHandle, base: &str) -> Result<(), String> {
+async fn pump_stream(app: &AppHandle, base: &str, token: Option<&str>) -> Result<(), String> {
     let client = reqwest::Client::new();
     // #5052: a fresh ticket per connection attempt — cheaper and more robust
     // than caching one across the reconnect backoff and discovering it expired.
-    let ticket = mint_ticket(&client, base).await?;
+    let ticket = mint_ticket(&client, base, token).await?;
     let url = format!("{base}/api/events?ticket={ticket}");
-    let mut resp = client
-        .get(&url)
+    let mut resp = with_bearer(client.get(&url), token)
         .send()
         .await
         .map_err(|e| format!("connect: {e}"))?

--- a/crates/trusty-agents/ui/src-tauri/src/sse_bridge.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/sse_bridge.rs
@@ -61,10 +61,13 @@ pub fn start_event_bridge(app: AppHandle, port: u16) {
         // #5052 (critic MEDIUM-2): the sidecar inherits this process's
         // environment, so when the operator configured a token it reads the
         // same var we do — that is the credential this bridge must present.
+        // No `.filter(|t| !t.is_empty())`: the server's own resolution
+        // (`runtime::mode_dispatch`) does not drop an empty value either, so
+        // filtering here would make an empty `TAGENT_API_TOKEN` configure a
+        // token server-side that this bridge then never presents.
         let token = std::env::var("TAGENT_API_TOKEN")
             .or_else(|_| std::env::var("OPEN_MPM_API_TOKEN"))
-            .ok()
-            .filter(|t| !t.is_empty());
+            .ok();
         loop {
             if let Err(e) = pump_stream(&app, &base, token.as_deref()).await {
                 // #5052 (critic MEDIUM-2): `debug!` hid a PERMANENT failure —
@@ -96,16 +99,33 @@ async fn mint_ticket(
         with_bearer(client.post(format!("{base}/api/events/ticket")), token)
             .send()
             .await
-            .map_err(|e| format!("mint: {e}"))?
+            .map_err(|e| redacted("mint", e))?
             .error_for_status()
-            .map_err(|e| format!("mint status: {e}"))?
+            .map_err(|e| redacted("mint status", e))?
             .json()
             .await
-            .map_err(|e| format!("mint body: {e}"))?;
+            .map_err(|e| redacted("mint body", e))?;
     body.get("ticket")
         .and_then(|t| t.as_str())
         .map(str::to_string)
         .ok_or_else(|| "mint response had no ticket".to_string())
+}
+
+/// Render a `reqwest::Error` for logging WITHOUT the request URL. (#5052)
+///
+/// Why: SECURITY. The stream URL carries `?ticket=<live credential>`, and
+/// `reqwest::Error`'s `Display` appends the full URL including its query string
+/// (reqwest documents this on the type). Every error here reaches
+/// `tracing::warn!` in `start_event_bridge`, so formatting one verbatim would
+/// write a still-valid ticket into the default log on every routine stream drop
+/// — exactly the leak channel the ticket design exists to avoid, which is why
+/// #5052 rejected a `?token=<bearer>` scheme in the first place.
+/// What: prefixes the caller's label and formats `e.without_url()`, which
+/// returns the same error with its URL stripped. The failure CAUSE is
+/// unchanged, so the log keeps all of its diagnostic value.
+/// Test: `redacted_error_does_not_leak_the_ticket`.
+fn redacted(context: &str, e: reqwest::Error) -> String {
+    format!("{context}: {}", e.without_url())
 }
 
 /// Attach `Authorization: Bearer <token>` when the operator configured one.
@@ -131,12 +151,12 @@ async fn pump_stream(app: &AppHandle, base: &str, token: Option<&str>) -> Result
     let mut resp = with_bearer(client.get(&url), token)
         .send()
         .await
-        .map_err(|e| format!("connect: {e}"))?
+        .map_err(|e| redacted("connect", e))?
         .error_for_status()
-        .map_err(|e| format!("status: {e}"))?;
+        .map_err(|e| redacted("status", e))?;
 
     let mut parser = SseParser::default();
-    while let Some(chunk) = resp.chunk().await.map_err(|e| format!("read: {e}"))? {
+    while let Some(chunk) = resp.chunk().await.map_err(|e| redacted("read", e))? {
         for data in parser.push(&chunk) {
             dispatch_frame(app, &data);
         }
@@ -256,6 +276,37 @@ fn field_str(value: &serde_json::Value, key: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Why: SECURITY (#5052) — `reqwest::Error`'s Display appends the request
+    /// URL, and this bridge's stream URL carries a LIVE ticket in its query
+    /// string. Since these errors are logged at `warn!` on every routine stream
+    /// drop, a verbatim format would publish a working credential to the
+    /// default log. The raw assertion below is deliberate: it proves reqwest
+    /// really does embed the URL, so this test would catch a regression rather
+    /// than passing vacuously.
+    /// Test: this test.
+    #[tokio::test]
+    async fn redacted_error_does_not_leak_the_ticket() {
+        const TICKET: &str = "s3cret-ticket-value";
+        // Port 1 is privileged and unbound, so this fails to connect
+        // immediately — no server, no network, no timing dependence.
+        let err = reqwest::Client::new()
+            .get(format!("http://127.0.0.1:1/api/events?ticket={TICKET}"))
+            .send()
+            .await
+            .expect_err("connecting to a closed port must fail");
+
+        assert!(
+            format!("{err}").contains(TICKET),
+            "precondition: reqwest embeds the URL, so redaction is load-bearing"
+        );
+        let logged = redacted("connect", err);
+        assert!(
+            !logged.contains(TICKET),
+            "a live ticket must never reach the log: {logged}"
+        );
+        assert!(logged.starts_with("connect: "), "context is kept: {logged}");
+    }
 
     #[test]
     fn parse_dispatches_agent_message_delta() {

--- a/crates/trusty-agents/ui/src/App.svelte
+++ b/crates/trusty-agents/ui/src/App.svelte
@@ -31,7 +31,14 @@
   // so it is unit-testable; it used to be an inline `bridgeEventToWebBus`
   // here, with no automated coverage at all.
   import { bridgeEventToWebBus } from './lib/eventBridge';
-  import { invoke, isDesktop, connectEventSource, listenEvent, type AppEvent } from './lib/transport';
+  import {
+    invoke,
+    isDesktop,
+    connectEventSource,
+    listenEvent,
+    type AppEvent,
+    type EventStreamHandle,
+  } from './lib/transport';
   import { shouldRefetchCatalogs } from './lib/catalogRefetch';
   import {
     apiAuthRequired,
@@ -92,9 +99,14 @@
   // on, so existing components light up without changes. Stored at module
   // scope so it survives Svelte's hot-reload re-renders during dev.
   // What: Opens on first apiReady=true, stays open until the page is closed.
-  // The EventSource API auto-reconnects on transport failure with browser-
-  // native exponential backoff so we don't have to.
-  let eventSource: EventSource | null = null;
+  // #5052: the stream is authenticated by a short-lived ticket now, so opening
+  // it is asynchronous (mint, then connect) and `connectEventSource` owns the
+  // reconnect loop — the browser's native retry would re-use an expired ticket.
+  // `wantEventStream` guards the mint round-trip against a stop that lands
+  // while it is in flight.
+  let eventStream: EventStreamHandle | null = null;
+  let eventStreamStarting = false;
+  let wantEventStream = false;
 
   // Why: Make the active transport visible at a glance so contributors and
   // testers can tell whether they're in the Tauri desktop shell (full IPC)
@@ -249,24 +261,37 @@
   }
 
   function startEventStream() {
-    if (eventSource || isDesktop()) {
+    if (eventStream || eventStreamStarting || isDesktop()) {
       // Tauri has its own listen() bridge already; web-only path needs SSE.
       return;
     }
-    eventSource = connectEventSource(
+    wantEventStream = true;
+    eventStreamStarting = true;
+    connectEventSource(
       undefined,
       (ev) => {
         bridgeEventToWebBus(ev);
       },
       () => {
-        // The browser will reconnect automatically — nothing to tear down.
+        // `connectEventSource` re-mints and reconnects with backoff (#5052).
       },
-    );
+    )
+      .then((handle) => {
+        eventStreamStarting = false;
+        // A stop that landed while the ticket mint was in flight wins.
+        if (wantEventStream) eventStream = handle;
+        else handle.close();
+      })
+      .catch((e) => {
+        eventStreamStarting = false;
+        console.error('[App] event stream failed to start:', e);
+      });
   }
 
   function stopEventStream() {
-    eventSource?.close();
-    eventSource = null;
+    wantEventStream = false;
+    eventStream?.close();
+    eventStream = null;
   }
 
   // Re-run the start/stop logic whenever apiReady flips so we don't open

--- a/crates/trusty-agents/ui/src/lib/transport.test.ts
+++ b/crates/trusty-agents/ui/src/lib/transport.test.ts
@@ -12,7 +12,18 @@
 // and the ONLY narrative-delivery path in that mode.
 
 import { describe, expect, it, vi } from 'vitest';
-import { FAST_POLL_MS, SLOW_POLL_MS, invoke, listenEvent, pollIntervalMs } from './transport';
+import {
+  FAST_POLL_MS,
+  SLOW_POLL_MS,
+  SSE_RECONNECT_MAX_MS,
+  SSE_RECONNECT_MIN_MS,
+  connectEventSource,
+  invoke,
+  listenEvent,
+  mintEventTicket,
+  pollIntervalMs,
+  sseReconnectDelayMs,
+} from './transport';
 
 describe('pollIntervalMs (#3745)', () => {
   it('uses 250ms for the first ~20 polls, then 500ms — incl. the 19/20 boundary', () => {
@@ -113,5 +124,123 @@ describe('send_message error framing (#4320 browser fallback)', () => {
     unlistenError();
     unlistenComplete();
     vi.unstubAllGlobals();
+  });
+});
+
+// #5052: the `/api/events` SSE stream is authenticated by a short-lived ticket
+// minted at `POST /api/events/ticket`, because `EventSource` cannot send an
+// `Authorization` header. Before the fix the stream was exempt from auth
+// outright and any page in the user's browser could read live conversation
+// content off `127.0.0.1`. These cases pin the client half: the mint call, the
+// ticket reaching the EventSource URL, and the re-mint-on-error reconnect (the
+// browser's own retry would re-use an expired ticket forever).
+
+describe('event-stream ticket auth (#5052)', () => {
+  it('mints a ticket and returns null rather than throwing on failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ ticket: 'tkt-1' }), { status: 200 })),
+    );
+    await expect(mintEventTicket()).resolves.toBe('tkt-1');
+
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('nope', { status: 401 })));
+    await expect(mintEventTicket()).resolves.toBeNull();
+
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));
+    await expect(mintEventTicket()).resolves.toBeNull();
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('server down');
+      }),
+    );
+    await expect(mintEventTicket()).resolves.toBeNull();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('mints via POST and puts the ticket on the EventSource URL', async () => {
+    const calls: Array<{ url: string; method?: string }> = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: unknown, init?: RequestInit) => {
+        calls.push({ url: String(url), method: init?.method });
+        return new Response(JSON.stringify({ ticket: 'tkt-2', expires_in_secs: 300 }), {
+          status: 200,
+        });
+      }),
+    );
+    const opened: string[] = [];
+    vi.stubGlobal(
+      'EventSource',
+      class {
+        constructor(url: string) {
+          opened.push(url);
+        }
+        addEventListener() {}
+        close() {}
+        onerror: ((e: Event) => void) | null = null;
+      },
+    );
+
+    const handle = await connectEventSource('sess-1');
+
+    expect(calls).toEqual([{ url: '/api/events/ticket', method: 'POST' }]);
+    expect(opened).toHaveLength(1);
+    const params = new URL(opened[0], 'http://localhost').searchParams;
+    expect(params.get('ticket')).toBe('tkt-2');
+    expect(params.get('session_id')).toBe('sess-1');
+
+    handle.close();
+    vi.unstubAllGlobals();
+  });
+
+  it('re-mints a fresh ticket on a transport error instead of retrying the old one', async () => {
+    vi.useFakeTimers();
+    let minted = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        minted += 1;
+        return new Response(JSON.stringify({ ticket: `tkt-${minted}` }), { status: 200 });
+      }),
+    );
+    const opened: string[] = [];
+    let live: { onerror: ((e: Event) => void) | null } | null = null;
+    vi.stubGlobal(
+      'EventSource',
+      class {
+        onerror: ((e: Event) => void) | null = null;
+        constructor(url: string) {
+          opened.push(url);
+          live = this;
+        }
+        addEventListener() {}
+        close() {}
+      },
+    );
+
+    const handle = await connectEventSource();
+    expect(opened).toHaveLength(1);
+
+    // Transport failure: the handle must close the socket and re-mint.
+    live!.onerror?.(new Event('error'));
+    await vi.advanceTimersByTimeAsync(SSE_RECONNECT_MIN_MS);
+    await vi.waitFor(() => expect(opened).toHaveLength(2));
+    expect(opened[1]).toContain('ticket=tkt-2');
+    expect(opened[1]).not.toContain('ticket=tkt-1');
+
+    handle.close();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('backs off exponentially and caps the reconnect delay', () => {
+    expect(sseReconnectDelayMs(0)).toBe(SSE_RECONNECT_MIN_MS);
+    expect(sseReconnectDelayMs(1)).toBe(2 * SSE_RECONNECT_MIN_MS);
+    expect(sseReconnectDelayMs(2)).toBe(4 * SSE_RECONNECT_MIN_MS);
+    expect(sseReconnectDelayMs(50)).toBe(SSE_RECONNECT_MAX_MS);
+    expect(sseReconnectDelayMs(-1)).toBe(SSE_RECONNECT_MIN_MS);
   });
 });

--- a/crates/trusty-agents/ui/src/lib/transport.ts
+++ b/crates/trusty-agents/ui/src/lib/transport.ts
@@ -341,18 +341,8 @@ export async function listenEvent<T>(
 
 /**
  * Why: #192 Phase B replaces 2-second polling of `/api/tasks` with a
- * persistent Server-Sent Events stream from the Rust API server. Browsers
- * reconnect dropped EventSources automatically, so we get free resilience —
- * we just need a small wrapper to route incoming `event:` payloads to a
- * typed callback and surface errors to the caller for UI status feedback.
- * What: Opens an `EventSource` against `/api/events` (optionally filtered by
- * `session_id`), parses every `event:`-named SSE message as JSON `AppEvent`,
- * and invokes `onEvent`. `onError` fires on transport errors; the browser
- * keeps trying to reconnect in the background. Returns the raw EventSource
- * so callers can `close()` on unmount.
- * Test: Run `cargo run -- --api --port 7654` then open the browser; observe
- * that submitted tasks emit `session_started`, `pm_thinking`, etc. without
- * any polling network activity.
+ * persistent Server-Sent Events stream from the Rust API server.
+ * What: Shape of one decoded server event.
  */
 export interface AppEvent {
   type: string;
@@ -373,42 +363,152 @@ export interface AppEvent {
   [key: string]: unknown;
 }
 
-export function connectEventSource(
+/**
+ * Why (#5052): `GET /api/events` used to be exempt from auth entirely, because
+ * `EventSource` cannot set an `Authorization` header — which meant any page in
+ * the user's browser could open the stream against `127.0.0.1` and read live
+ * conversation content. The stream is authenticated now, and this is how the
+ * browser obtains a credential it CAN put in the URL: `POST
+ * /api/events/ticket`, which is same-origin-guarded server-side (and
+ * token-gated when a token is configured), returns a short-lived opaque ticket.
+ * What: mints one ticket and returns it, or `null` when the endpoint is
+ * unreachable/unauthorized. Never throws — the caller connects anyway and lets
+ * the resulting 401 drive the normal retry path, so a stubbed or older server
+ * degrades to the pre-existing failure mode instead of a hard crash.
+ * Test: `transport.test.ts` — `mintEventTicket` returns the ticket, and `null`
+ * on a 401 / malformed body.
+ */
+export async function mintEventTicket(): Promise<string | null> {
+  try {
+    const r = await fetch(`${apiBase()}/api/events/ticket`, {
+      method: 'POST',
+      headers: authHeaders(),
+    });
+    if (!r.ok) return null;
+    const body = (await r.json()) as { ticket?: unknown };
+    return typeof body.ticket === 'string' && body.ticket ? body.ticket : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Reconnect backoff bounds for the authenticated event stream (#5052). */
+export const SSE_RECONNECT_MIN_MS = 1_000;
+export const SSE_RECONNECT_MAX_MS = 15_000;
+
+/**
+ * Why (#5052): a ticket expires, so a stream that has been down longer than its
+ * TTL must come back with a NEW one. The browser's built-in `EventSource`
+ * reconnect re-uses the original URL and would therefore 401 forever. Naming
+ * the backoff schedule separately keeps that contract unit-testable.
+ * What: doubles from `SSE_RECONNECT_MIN_MS`, capped at `SSE_RECONNECT_MAX_MS`.
+ * Test: `transport.test.ts` — `sseReconnectDelayMs` table incl. the cap.
+ */
+export function sseReconnectDelayMs(attempt: number): number {
+  const delay = SSE_RECONNECT_MIN_MS * 2 ** Math.max(0, attempt);
+  return Math.min(delay, SSE_RECONNECT_MAX_MS);
+}
+
+/**
+ * Handle returned by `connectEventSource` — the caller's only lever is
+ * `close()`, which also cancels any pending reconnect.
+ */
+export interface EventStreamHandle {
+  close(): void;
+}
+
+/**
+ * Why: #192 Phase B replaces 2-second polling of `/api/tasks` with a persistent
+ * Server-Sent Events stream. #5052 added a credential to that stream, so this
+ * wrapper now owns the reconnect loop as well: it mints a ticket, opens the
+ * `EventSource`, and on transport failure closes it and re-mints rather than
+ * letting the browser retry the same (possibly expired) ticket forever.
+ * What: opens `/api/events?ticket=<t>` (optionally `&session_id=`), parses every
+ * `event:`-named SSE message as JSON `AppEvent`, and invokes `onEvent`.
+ * `onError` still fires on every transport error for UI status feedback.
+ * Resolves once the first connection attempt has been made; returns a handle
+ * whose `close()` tears down the stream and stops reconnecting.
+ * Test: Run `cargo run -- --api --port 7654` then open the browser; observe
+ * that submitted tasks emit `session_started`, `pm_thinking`, etc. without any
+ * polling network activity. Unit: `transport.test.ts`.
+ */
+export async function connectEventSource(
   sessionId?: string,
   onEvent?: (event: AppEvent) => void,
   onError?: (e: Event) => void,
-): EventSource {
-  const base = apiBase();
-  const url = sessionId
-    ? `${base}/api/events?session_id=${encodeURIComponent(sessionId)}`
-    : `${base}/api/events`;
-  const es = new EventSource(url);
-  es.addEventListener('event', (e: MessageEvent) => {
-    if (!onEvent) return;
-    try {
-      const parsed = JSON.parse(e.data) as AppEvent;
-      onEvent(parsed);
-    } catch {
-      // Malformed payload — ignore. The server normally emits valid JSON;
-      // a bad line is most likely a transient proxy mangling that fixes
-      // itself on the next event.
-    }
-  });
-  // The server also sends `event: ping` keepalives and `event: lag` notices;
-  // both are diagnostic-only so we wire them through `onEvent` with their
-  // raw type tag for callers that want to react.
-  es.addEventListener('ping', () => {
-    onEvent?.({ type: 'ping' });
-  });
-  es.addEventListener('lag', (e: MessageEvent) => {
-    if (!onEvent) return;
-    try {
-      const parsed = JSON.parse(e.data) as { skipped?: number };
-      onEvent({ type: 'lag', skipped: parsed.skipped });
-    } catch {
-      // ignore
-    }
-  });
-  if (onError) es.onerror = onError;
-  return es;
+): Promise<EventStreamHandle> {
+  let current: EventSource | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let attempt = 0;
+  let closed = false;
+
+  const open = async (): Promise<void> => {
+    if (closed) return;
+    const ticket = await mintEventTicket();
+    if (closed) return;
+
+    const params = new URLSearchParams();
+    if (sessionId) params.set('session_id', sessionId);
+    if (ticket) params.set('ticket', ticket);
+    const query = params.toString();
+    const es = new EventSource(`${apiBase()}/api/events${query ? `?${query}` : ''}`);
+    current = es;
+
+    es.addEventListener('open', () => {
+      attempt = 0;
+    });
+    es.addEventListener('event', (e: MessageEvent) => {
+      if (!onEvent) return;
+      try {
+        onEvent(JSON.parse(e.data) as AppEvent);
+      } catch {
+        // Malformed payload — ignore. The server normally emits valid JSON;
+        // a bad line is most likely a transient proxy mangling that fixes
+        // itself on the next event.
+      }
+    });
+    // The server also sends `event: ping` keepalives and `event: lag` notices;
+    // both are diagnostic-only so we wire them through `onEvent` with their
+    // raw type tag for callers that want to react.
+    es.addEventListener('ping', () => {
+      onEvent?.({ type: 'ping' });
+    });
+    es.addEventListener('lag', (e: MessageEvent) => {
+      if (!onEvent) return;
+      try {
+        const parsed = JSON.parse(e.data) as { skipped?: number };
+        onEvent({ type: 'lag', skipped: parsed.skipped });
+      } catch {
+        // ignore
+      }
+    });
+    es.onerror = (e: Event) => {
+      onError?.(e);
+      if (closed) return;
+      // #5052: take the reconnect over from the browser — its retry re-uses
+      // this URL, and once the ticket has expired that can only ever 401.
+      es.close();
+      if (current === es) current = null;
+      const delay = sseReconnectDelayMs(attempt);
+      attempt += 1;
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        void open();
+      }, delay);
+    };
+  };
+
+  await open();
+
+  return {
+    close() {
+      closed = true;
+      if (retryTimer !== null) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+      current?.close();
+      current = null;
+    },
+  };
 }

--- a/crates/trusty-agents/ui/tests/config-takeover.spec.ts
+++ b/crates/trusty-agents/ui/tests/config-takeover.spec.ts
@@ -59,6 +59,9 @@ test.beforeEach(async ({ page }) => {
 
     if (!path.startsWith('/api/')) {
       route.continue(); // HTML, JS bundle, CSS, fonts
+    } else if (path === '/api/events/ticket') {
+      // #5052: the app mints a stream ticket before opening EventSource.
+      json({ ticket: 'test-ticket', expires_in_secs: 300 });
     } else if (path.startsWith('/api/events')) {
       route.fulfill({
         status: 200,

--- a/crates/trusty-agents/ui/tests/smoke.spec.ts
+++ b/crates/trusty-agents/ui/tests/smoke.spec.ts
@@ -60,7 +60,16 @@ test.beforeEach(async ({ page }) => {
   // pattern is the only reliable way to intercept all URLs.
   await page.route('**', (route) => {
     const url = route.request().url();
-    if (url.includes('/api/events')) {
+    if (url.includes('/api/events/ticket')) {
+      // #5052: the SSE stream is authenticated by a short-lived ticket the app
+      // mints here before opening EventSource. Must be checked BEFORE the
+      // `/api/events` branch below, which would otherwise swallow it.
+      route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: '{"ticket":"test-ticket","expires_in_secs":300}',
+      });
+    } else if (url.includes('/api/events')) {
       // SSE endpoint — return a closed stream. EventSource is mocked anyway via
       // addInitScript; this catches any code path that bypasses the mock.
       route.fulfill({

--- a/crates/trusty-common/changelog.d/5052-same-origin-cors.md
+++ b/crates/trusty-common/changelog.d/5052-same-origin-cors.md
@@ -1,0 +1,11 @@
+Added
+
+- **`same_origin_cors` and `with_guarded_middleware_same_origin_cors`** — the
+  standard daemon middleware stack with the permissive CORS policy swapped for
+  one that reflects only same-machine origins: loopback,
+  a local webview shell (`origin_is_local_webview`), or the daemon's own
+  resolved non-loopback bind ([#5052](https://github.com/bobmatnyc/trusty-tools/issues/5052)).
+  `with_guarded_middleware`'s write guard is method-gated, so it never covered
+  cross-origin READS; a daemon whose GET surface carries sensitive content opts
+  into this variant instead. trusty-agents is the first consumer; the other
+  daemons keep `with_guarded_middleware` until each is reviewed on its own.

--- a/crates/trusty-common/src/server/mod.rs
+++ b/crates/trusty-common/src/server/mod.rs
@@ -115,9 +115,11 @@ where
 /// [`origin_matches_self`] against `self_origins`. Methods and headers stay
 /// `Any`; credentials are NOT allowed, so no ambient cookie/auth is ever
 /// attached cross-origin.
-/// Test: `same_origin_cors_predicate_*` below;
-/// `cross_origin_event_stream_is_not_cors_readable` in trusty-agents'
-/// `api::server::tests::guard`.
+/// Test: `same_origin_cors_predicate_allows_local`,
+/// `same_origin_cors_predicate_rejects_remote` below; end-to-end in
+/// trusty-agents' `api::server::tests::event_tickets` —
+/// `cross_origin_request_gets_no_cors_reflection` and
+/// `loopback_origin_is_cors_reflected`.
 pub fn same_origin_cors(self_origins: SelfOrigins) -> CorsLayer {
     CorsLayer::new()
         .allow_origin(AllowOrigin::predicate(move |origin, _parts| {
@@ -200,7 +202,7 @@ where
 /// guard uses.
 /// Test: `with_guarded_middleware_same_origin_cors_composes` below; the
 /// end-to-end behaviour is covered by trusty-agents'
-/// `api::server::tests::guard`.
+/// `api::server::tests::event_tickets`.
 pub fn with_guarded_middleware_same_origin_cors<S>(
     router: Router<S>,
     self_origins: SelfOrigins,

--- a/crates/trusty-common/src/server/mod.rs
+++ b/crates/trusty-common/src/server/mod.rs
@@ -10,6 +10,10 @@
 //!   - [`with_guarded_middleware`] additionally applies the router-wide
 //!     same-origin write guard ([`origin_guard`], #3304) so destructive daemon
 //!     write routes are not exposed to cross-origin CSRF.
+//!   - [`with_guarded_middleware_same_origin_cors`] is the same stack with the
+//!     permissive CORS policy swapped for [`same_origin_cors`], so a browser
+//!     page on an untrusted origin cannot READ the daemon's responses either
+//!     (#5052).
 //!   - [`daemon_http_client`] builds a reqwest client with short timeouts so
 //!     CLI commands never hang on a missing daemon.
 //!
@@ -26,13 +30,16 @@ use tower_http::{
         CompressionLayer,
         predicate::{DefaultPredicate, NotForContentType, Predicate},
     },
-    cors::{Any, CorsLayer},
+    cors::{AllowOrigin, Any, CorsLayer},
     trace::TraceLayer,
 };
 
 pub mod origin_guard;
 
-pub use origin_guard::{SelfOrigins, guard_write_origin};
+pub use origin_guard::{
+    SelfOrigins, guard_write_origin, origin_is_local_webview, origin_is_loopback,
+    origin_matches_self,
+};
 
 /// Apply the standard trusty-* middleware stack to an axum router.
 ///
@@ -62,12 +69,81 @@ where
         .allow_origin(Any)
         .allow_methods(Any)
         .allow_headers(Any);
+    with_middleware_stack(router, cors)
+}
+
+/// The trace + gzip half of the standard stack, plus a caller-chosen CORS policy.
+///
+/// Why: `with_standard_middleware` and
+/// [`with_guarded_middleware_same_origin_cors`] differ in exactly one layer —
+/// the CORS policy. Keeping the layer ORDER (and the SSE compression carve-out
+/// documented on `with_standard_middleware`) in one function means a future fix
+/// to that order lands once rather than twice.
+/// What: layers compression (innermost), trace, then `cors` (outermost).
+/// Test: `with_standard_middleware_composes`,
+/// `with_guarded_middleware_same_origin_cors_composes`.
+fn with_middleware_stack<S>(router: Router<S>, cors: CorsLayer) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
     let compress =
         CompressionLayer::new().compress_when(DefaultPredicate::new().and(NotForContentType::SSE));
     router
         .layer(compress)
         .layer(TraceLayer::new_for_http())
         .layer(cors)
+}
+
+/// A CORS policy that reflects ONLY same-machine origins. (#5052)
+///
+/// Why: `allow_origin(Any)` lets any page the operator happens to have open
+/// READ a loopback daemon's responses. A loopback bind does not contain that —
+/// the attacker's JavaScript runs inside the operator's own browser, which can
+/// reach `127.0.0.1` — so for a daemon whose GET surface carries conversation
+/// content (`trusty-agents`' `/api/events`, `/api/tasks`, `/api/sessions/*`),
+/// permissive CORS is the difference between "unreachable off-host" and
+/// "readable by any web page". Reflecting only same-machine origins keeps every
+/// legitimate consumer working: the daemon's own SPA (same-origin), a `pnpm dev`
+/// Vite server on `http://localhost:5173`, a Tauri webview, and the daemon's own
+/// resolved non-loopback bind (#3269). Server-side callers (the console reverse
+/// proxy, `curl`, MCP stdio bridges) send no `Origin` at all and are unaffected
+/// — CORS is a browser-enforced policy, never a server-side access control,
+/// which is why this is defence in depth BEHIND per-route auth, not a
+/// replacement for it.
+/// What: builds a [`CorsLayer`] whose allowed origin is a predicate —
+/// [`origin_is_loopback`] OR [`origin_is_local_webview`] OR
+/// [`origin_matches_self`] against `self_origins`. Methods and headers stay
+/// `Any`; credentials are NOT allowed, so no ambient cookie/auth is ever
+/// attached cross-origin.
+/// Test: `same_origin_cors_predicate_*` below;
+/// `cross_origin_event_stream_is_not_cors_readable` in trusty-agents'
+/// `api::server::tests::guard`.
+pub fn same_origin_cors(self_origins: SelfOrigins) -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::predicate(move |origin, _parts| {
+            origin
+                .to_str()
+                .map(|value| same_origin_cors_allows(value, &self_origins))
+                .unwrap_or(false)
+        }))
+        .allow_methods(Any)
+        .allow_headers(Any)
+}
+
+/// Whether [`same_origin_cors`] reflects `origin`.
+///
+/// Why: the predicate closure handed to `AllowOrigin::predicate` is not
+/// reachable from a unit test; naming the decision separately makes the policy
+/// directly testable, including the DNS-rebinding lookalikes
+/// (`127.0.0.1.evil.com`) that [`origin_is_loopback`] already rejects.
+/// What: `true` for a loopback host, a local webview origin, or one of the
+/// daemon's own resolved non-loopback bind addresses.
+/// Test: `same_origin_cors_predicate_allows_local`,
+/// `same_origin_cors_predicate_rejects_remote`.
+pub fn same_origin_cors_allows(origin: &str, self_origins: &SelfOrigins) -> bool {
+    origin_is_loopback(origin)
+        || origin_is_local_webview(origin)
+        || origin_matches_self(origin, self_origins)
 }
 
 /// Apply the standard middleware stack PLUS the router-wide same-origin write
@@ -107,6 +183,36 @@ where
         guard_write_origin,
     ));
     with_standard_middleware(guarded)
+}
+
+/// [`with_guarded_middleware`], but with [`same_origin_cors`] in place of the
+/// permissive CORS policy. (#5052)
+///
+/// Why: the write guard stops a cross-origin page from DRIVING a daemon; it does
+/// nothing about a cross-origin page READING one, because reads are `GET` and
+/// the guard is method-gated. For a daemon whose GET surface is telemetry that
+/// is fine. For one whose GET surface is conversation content it is not — see
+/// [`same_origin_cors`]. This entry point exists so such a daemon opts into the
+/// tighter policy with a one-line change instead of assembling the stack itself
+/// (and drifting from the layer order in [`with_middleware_stack`]).
+/// What: layers [`guard_write_origin`] innermost, then compression/trace, then
+/// the same-origin CORS policy built from the SAME `self_origins` allowlist the
+/// guard uses.
+/// Test: `with_guarded_middleware_same_origin_cors_composes` below; the
+/// end-to-end behaviour is covered by trusty-agents'
+/// `api::server::tests::guard`.
+pub fn with_guarded_middleware_same_origin_cors<S>(
+    router: Router<S>,
+    self_origins: SelfOrigins,
+) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    let guarded = router.layer(axum::middleware::from_fn_with_state(
+        self_origins.clone(),
+        guard_write_origin,
+    ));
+    with_middleware_stack(guarded, same_origin_cors(self_origins))
 }
 
 /// Build a `reqwest::Client` configured for daemon-to-daemon calls.
@@ -172,6 +278,60 @@ mod tests {
         // stateless router with a default (loopback-only) allowlist.
         let router: Router = Router::new().route("/ping", get(|| async { "pong" }));
         let _wrapped = with_guarded_middleware(router, SelfOrigins::default());
+    }
+
+    #[test]
+    fn with_guarded_middleware_same_origin_cors_composes() {
+        // #5052 smoke test: the tightened stack layers and finalizes.
+        let router: Router = Router::new().route("/ping", get(|| async { "pong" }));
+        let _wrapped = with_guarded_middleware_same_origin_cors(router, SelfOrigins::default());
+    }
+
+    /// Why: #5052 — every legitimate same-machine consumer must keep working
+    /// after the policy stops being `Any`: the daemon's own SPA, a Vite dev
+    /// server, the Tauri shell, and the daemon's own non-loopback bind (#3269).
+    /// Test: this test.
+    #[test]
+    fn same_origin_cors_predicate_allows_local() {
+        let self_origins =
+            SelfOrigins::from_bind_addrs(&[std::net::SocketAddr::from(([100, 64, 1, 2], 7654))]);
+        for origin in [
+            "http://127.0.0.1:7654",
+            "http://localhost:5173",
+            "http://[::1]:7654",
+            "tauri://localhost",
+            "http://tauri.localhost",
+            "http://100.64.1.2:7654",
+        ] {
+            assert!(
+                same_origin_cors_allows(origin, &self_origins),
+                "{origin} must be reflected"
+            );
+        }
+    }
+
+    /// Why: SECURITY (#5052) — the whole point of the policy is that a page on
+    /// a remote origin cannot read the daemon's responses, including the
+    /// DNS-rebinding lookalikes that a naive prefix match would accept.
+    /// Test: this test.
+    #[test]
+    fn same_origin_cors_predicate_rejects_remote() {
+        let self_origins =
+            SelfOrigins::from_bind_addrs(&[std::net::SocketAddr::from(([100, 64, 1, 2], 7654))]);
+        for origin in [
+            "https://evil.example",
+            "http://127.0.0.1.evil.com",
+            "http://localhost.evil.com",
+            "https://tauri.localhost.evil.com",
+            "http://100.64.9.9:7654",
+            "http://10.0.0.5:7654",
+            "",
+        ] {
+            assert!(
+                !same_origin_cors_allows(origin, &self_origins),
+                "{origin} must NOT be reflected"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/trusty-common/src/server/origin_guard.rs
+++ b/crates/trusty-common/src/server/origin_guard.rs
@@ -127,6 +127,34 @@ pub fn origin_is_loopback(origin: &str) -> bool {
     }
 }
 
+/// Classify whether an `Origin` header value is a native webview shell running
+/// on this machine. (#5052)
+///
+/// Why: a Tauri desktop shell serves its own frontend from a synthetic origin
+/// rather than an `http://127.0.0.1` URL, so a same-machine-origins policy that
+/// only knew about loopback would break the packaged app's cross-origin reads
+/// against the sidecar. The origin is minted by the webview runtime, not by any
+/// page — a remote site cannot claim it — so trusting these exact three strings
+/// is equivalent in strength to trusting loopback. Kept next to
+/// [`origin_is_loopback`] because they answer the same question ("is this
+/// origin the operator's own machine?") and must not drift apart.
+/// What: EXACT match (never a prefix or suffix test) against the three origins
+/// Tauri v2 uses: `tauri://localhost` (macOS/iOS), `http://tauri.localhost`
+/// (Windows/Android), and `https://tauri.localhost`. Anything else — including
+/// `https://tauri.localhost.evil.com` — is `false`.
+///
+/// This is deliberately NOT wired into [`guard_write_origin`]: widening the
+/// CSRF guard is a separate decision with a different blast radius, and #5052
+/// is a read-disclosure fix. See `same_origin_cors` for the sole consumer.
+/// Test: `origin_is_local_webview_accepts_tauri_origins`,
+/// `origin_is_local_webview_rejects_lookalikes`.
+pub fn origin_is_local_webview(origin: &str) -> bool {
+    matches!(
+        origin,
+        "tauri://localhost" | "http://tauri.localhost" | "https://tauri.localhost"
+    )
+}
+
 /// Check whether an `Origin` header value matches one of the daemon's own
 /// bind-derived, non-loopback addresses (#3269).
 ///
@@ -309,6 +337,33 @@ mod tests {
         assert!(!origin_is_loopback("127.0.0.1:7070")); // no scheme
         assert!(!origin_is_loopback(""));
         assert!(!origin_is_loopback("garbage"));
+    }
+
+    /// Why: #5052 — the packaged Tauri shell's own webview origin must count as
+    /// same-machine, or the desktop app loses every cross-origin read against
+    /// its sidecar the moment the CORS policy stops being `Any`.
+    /// Test: this test.
+    #[test]
+    fn origin_is_local_webview_accepts_tauri_origins() {
+        assert!(origin_is_local_webview("tauri://localhost"));
+        assert!(origin_is_local_webview("http://tauri.localhost"));
+        assert!(origin_is_local_webview("https://tauri.localhost"));
+    }
+
+    /// Why: SECURITY — the check must be an exact match. A `contains`/
+    /// `starts_with` test would accept the attacker-registrable
+    /// `https://tauri.localhost.evil.com`, handing a remote page the same trust
+    /// as the desktop shell.
+    /// Test: this test.
+    #[test]
+    fn origin_is_local_webview_rejects_lookalikes() {
+        assert!(!origin_is_local_webview("https://tauri.localhost.evil.com"));
+        assert!(!origin_is_local_webview("http://tauri.localhost:1234"));
+        assert!(!origin_is_local_webview(
+            "https://evil.com/tauri://localhost"
+        ));
+        assert!(!origin_is_local_webview("tauri://evil.com"));
+        assert!(!origin_is_local_webview(""));
     }
 
     /// Why: #3269 regression guard — a Tailscale bind's own resolved address

--- a/docs/trusty-agents/user/cli-reference.md
+++ b/docs/trusty-agents/user/cli-reference.md
@@ -38,7 +38,7 @@ Used with `--api` / `--serve`.
 | Flag | Description |
 |---|---|
 | `--port <N>` | TCP port (default `8080`) |
-| `--api-token <TOK>` | Require this bearer token on every `/api/*` request (except `/api/health` and `/api/config`). Falls back to `TAGENT_API_TOKEN` env var |
+| `--api-token <TOK>` | Require this bearer token on every `/api/*` request. Falls back to the `TAGENT_API_TOKEN` env var. `/api/health` and `/api/config` are exempt (liveness probe and pre-auth UI bootstrap). `/api/events` is NOT exempt — it accepts this bearer token **or** a short-lived ticket from `POST /api/events/ticket`, because a browser `EventSource` cannot send headers ([#5052](https://github.com/bobmatnyc/trusty-tools/issues/5052)). The stream requires one of the two whether or not a token is configured |
 
 ## Diagnostic / maintenance flags
 


### PR DESCRIPTION
Closes https://github.com/bobmatnyc/trusty-tools/issues/5052

## The defect

`GET /api/events` was exempt from bearer auth before the token was compared
([`auth.rs:149-151`](https://github.com/bobmatnyc/trusty-tools/blob/352fe5d6/crates/trusty-agents/src/api/server/auth.rs#L149-L151)),
and the router carried `CorsLayer::new().allow_origin(Any)`
([`trusty-common/src/server/mod.rs:61-64`](https://github.com/bobmatnyc/trusty-tools/blob/352fe5d6/crates/trusty-common/src/server/mod.rs#L61-L64)).
Those two compose into a cross-origin disclosure of live conversation content.

A loopback bind does not contain it. The attacker's JavaScript runs inside the
operator's own browser, which can reach `127.0.0.1`: any page could call
`new EventSource("http://127.0.0.1:7654/api/events")` and read
`Event::PmThinking.text`, `Event::AgentMessage.text`, and
`Event::PmDelegating.task_preview` — no shell access, no token, no non-loopback
opt-in, and no log entry. The shipped Tauri sidecar starts that port by default
([`mode_dispatch.rs:483`](https://github.com/bobmatnyc/trusty-tools/blob/352fe5d6/crates/trusty-agents/src/runtime/mode_dispatch.rs#L483)).

Remote network access was never broken and is unchanged: `serve_with_config`
still refuses a non-loopback bind without a token.

## Mechanism: a short-lived ticket, not a query-param token

`EventSource` cannot set an `Authorization` header, so removing the exemption
alone breaks the UI. Of the three options in the issue:

- **Query-param bearer token — rejected.** The URL is the part of the request
  that leaks: access logs, `Referer`, browser history. A leaked bearer token
  grants the whole `/api/*` write surface, which can spawn arbitrary
  subprocesses, and never expires.
- **Cookie — rejected.** Ambient authority, and the Tauri webview reaches the
  sidecar cross-origin, which would force `allow-credentials` and a
  reflected-origin CORS policy anyway.
- **Ticket — chosen.** `POST /api/events/ticket` returns a 256-bit opaque
  value with a 5-minute TTL that slides on redemption. Redeemable more than
  once, because `EventSource` reconnects to the *same* URL and a single-use
  ticket would make any transient blip a permanently dead stream. A leaked
  ticket buys five minutes of read-only stream access.

**Why minting is a POST.** That places it behind the existing router-wide
same-origin write guard, which fires even when no operator token is configured.
That is what closes the *shipped default* (sidecar on `127.0.0.1:7654`, no
token): `https://evil.example` gets 403 at the mint endpoint and so never
obtains a ticket. When a token *is* configured, `auth_middleware` gates the mint
route on top, since it is not an exempt path.

`GET /api/events` accepts a matching `Authorization: Bearer` **or** a live
ticket — the header path keeps `curl`, the reverse proxy, and the desktop
shell's Rust SSE bridge working. It is gated whether or not a token is
configured; the token-less default is precisely the configuration that was
attacked.

Constant-time comparison reuses `auth::bearer_token_matches` (#3761) and every
live ticket is compared even after a hit, so timing reveals neither a prefix
nor which ticket matched.

## Exemption decision, per route

| Route | Decision | Why |
|---|---|---|
| `/api/health` | **stays exempt** | Liveness probe; the Tauri sidecar polls it *before* it holds any credential. Body is `{status, version, pid, ppid}` — no conversation content. |
| `/api/config` | **stays exempt** | Its entire purpose is pre-auth bootstrap. Body is the single boolean `auth_required`, which any caller already infers from whether an `/api/*` request 401s — gating it removes no information from an attacker while removing the browser's only way to learn it needs a token. |
| `/api/events` | **exemption removed** | Streams conversation content. |

This diverges from the issue's suggested "bring `/api/config` under the
middleware"; the reasoning is above rather than silent.

## CORS decision: tightened, and it is load-bearing

The auth fix alone is **not** sufficient, and the issue's framing understates
the surface. `/api/tasks`, `/api/task/{id}`, `/api/sessions/{id}/recap` and
`/api/listener-events` are all GET, all carry task narratives and conversation
content, and all were cross-origin readable under `allow_origin(Any)` in the
default config. The same-origin write guard never covered them — it is
method-gated, and reads are GET.

So trusty-agents now takes a new
`trusty_common::server::with_guarded_middleware_same_origin_cors`, which
reflects only same-machine origins: loopback (`origin_is_loopback`, which
already rejects `127.0.0.1.evil.com`-style lookalikes), a local webview shell
(new `origin_is_local_webview` — the three exact Tauri v2 origins), and the
daemon's own resolved non-loopback bind (#3269). `pnpm dev` on
`localhost:5173` keeps working; server-side callers send no `Origin` and are
unaffected.

CORS is browser-enforced, never a server-side access control — it is defence in
depth *behind* the ticket gate, not a replacement for it. The sibling daemons
keep `with_guarded_middleware`; their GET surfaces deserve the same review, but
on their own tickets, not smuggled into a security fix.

## Client side (both transports, in this PR)

- `ui/src/lib/transport.ts` — `mintEventTicket()`, and `connectEventSource`
  now mints before connecting and **owns the reconnect loop**: on transport
  error it closes the socket and re-mints with exponential backoff (1s→15s).
  The browser's native retry re-uses the original URL, so once a ticket expired
  it could only ever 401 forever.
- `ui/src/App.svelte` — the start path is async now, with a `wantEventStream`
  guard so a stop landing during the mint round-trip wins.
- `ui/src-tauri/src/sse_bridge.rs` — the desktop shell's Rust bridge mints a
  fresh ticket per connection attempt.
- Both Playwright specs stub `/api/events/ticket`.

## Regression proof — fails before, passes after

Rung 5 requires a test that fails against the pre-fix code. Both pre-fix states
were restored in place and the suite re-run.

**BEFORE — handler gate disabled + `with_guarded_middleware` (permissive CORS) restored:**

```
running 16 tests
test ...::cross_origin_request_gets_no_cors_reflection ... FAILED
test ...::loopback_origin_is_cors_reflected ... FAILED
test ...::event_stream_without_credential_is_rejected ... FAILED
test ...::event_stream_with_unknown_ticket_is_rejected ... FAILED

---- ...::event_stream_without_credential_is_rejected stdout ----
assertion `left == right` failed
  left: 200
 right: 401

---- ...::cross_origin_request_gets_no_cors_reflection stdout ----
a remote origin must not be reflected

---- ...::loopback_origin_is_cors_reflected stdout ----
assertion `left == right` failed: http://localhost:5173 must be reflected
  left: Some("*")
 right: Some("http://localhost:5173")

test result: FAILED. 12 passed; 4 failed; 0 ignored; 0 measured; 3398 filtered out
```

**BEFORE (2) — `|| path == "/api/events"` also restored in `auth_middleware`,** to
prove the issue's own claim (unauthenticated *even when a token is configured*):

```
running 2 tests
test ...::event_stream_without_credential_is_rejected_with_token_configured ... FAILED
test ...::event_stream_without_credential_is_rejected ... FAILED

---- ...::event_stream_without_credential_is_rejected_with_token_configured stdout ----
assertion `left == right` failed
  left: 200
 right: 401

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 3412 filtered out
```

**AFTER:**

```
running 23 tests
test api::server::tests::event_tickets::event_stream_without_credential_is_rejected ... ok
test api::server::tests::event_tickets::event_stream_without_credential_is_rejected_with_token_configured ... ok
test api::server::tests::event_tickets::event_stream_with_unknown_ticket_is_rejected ... ok
test api::server::tests::event_tickets::minted_ticket_opens_event_stream ... ok
test api::server::tests::event_tickets::minted_ticket_is_redeemable_more_than_once ... ok
test api::server::tests::event_tickets::bearer_token_opens_event_stream ... ok
test api::server::tests::event_tickets::ticket_does_not_unlock_the_rest_of_the_api ... ok
test api::server::tests::event_tickets::mint_route_requires_bearer_token_when_configured ... ok
test api::server::tests::event_tickets::mint_route_rejects_cross_origin_caller ... ok
test api::server::tests::event_tickets::mint_route_allows_loopback_origin ... ok
test api::server::tests::event_tickets::cross_origin_request_gets_no_cors_reflection ... ok
test api::server::tests::event_tickets::loopback_origin_is_cors_reflected ... ok
test api::server::tests::event_tickets::mint_returns_distinct_unguessable_tickets ... ok
test api::server::tests::event_tickets::redeem_rejects_expired_ticket ... ok
test api::server::tests::event_tickets::redeem_rejects_unknown_ticket ... ok
test api::server::tests::event_tickets::store_is_capacity_bounded ... ok
test api::server::tests::events_sse::events_query_rejects_unknown_parameter ... ok
test api::server::tests::events_sse::events_query_accepts_known_parameters ... ok
...
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 3391 filtered out; finished in 0.02s
```

The pre-existing `events_sse` query tests were **kept, not narrowed** — their
helper now mints a ticket, because a bare 401 would have satisfied their
`is_client_error()` assertions for the wrong reason.

## Live binary smoke — `tagent --api --port 7699`, no token (the shipped default)

```
=== health (exempt):
200
=== UNAUTH /api/events:
{"error":"unauthorized"}
HTTP 401
=== cross-origin EventSource simulation (Origin: https://evil.example):
HTTP/1.1 401 Unauthorized
=== cross-origin ticket mint:
{"error":"cross-origin write requests are not allowed"}
HTTP 403
=== same-origin mint (as the UI does):
{"ticket":"fUROku4_vY7szvDhDaYWkavC-1092UaRN_eiI4hpXb4","expires_in_secs":300}
=== AUTHENTICATED stream with that ticket:
HTTP/1.1 200 OK
content-type: text/event-stream
cache-control: no-cache
vary: origin, access-control-request-method, access-control-request-headers
access-control-allow-origin: http://127.0.0.1:7699
transfer-encoding: chunked
=== stream with a forged ticket:
{"error":"unauthorized"}
HTTP 401
```

## Gates — test ladder rung 5 (security) + rung 6 (UI/API surface)

```
cargo fmt --check                                                → FMT=0
cargo check -p trusty-agents -p trusty-common                    → CHECK=0
cargo clippy -p trusty-common --all-targets --features axum-server -- -D warnings
                                                                 → CLIPPY_COMMON=0
cargo clippy -p trusty-agents --all-targets -- -D warnings       → CLIPPY_AGENTS=0
```

```
cargo test -p trusty-common --features axum-server
test result: ok. 312 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.98s
TCOMMON=0
```

```
cargo test -p trusty-agents
test result: ok. 3403 passed; 0 failed; 11 ignored; 0 measured; 0 filtered out; finished in 34.15s
test result: ok. 6 passed; 0 failed; 3 ignored
test result: ok. 4 passed; 0 failed; 0 ignored
test result: ok. 3 passed; 0 failed; 0 ignored
test result: ok. 2 passed; 0 failed; 0 ignored
test result: ok. 1 passed; 0 failed; 0 ignored
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.82s   # plain_cli_repl
test result: ok. 2 passed; 0 failed; 0 ignored
test result: ok. 2 passed; 0 failed; 0 ignored
```

The `plain_cli_repl` integration binary timed out (7× `tagent did not exit
within 120s`) on the first pass, while the `tagent` debug binary was still
linking inside the spawn window under a constrained-parallelism build. It
passes in 3.82s on a warm re-run, shown above. It spawns the CLI REPL and
touches no `/api/*`, CORS, or SSE code path in this diff.

**UI (rung 6):**

```
pnpm test:unit    → 442 passed / 443 (1 pre-existing failure, below)
npx vitest run src/lib/transport.test.ts
                  → Test Files 1 passed (1);  Tests 8 passed (8)
pnpm check        → COMPLETED 1776 FILES 0 ERRORS 3 WARNINGS   (all 3 pre-existing a11y warnings)
pnpm build        → ✓ built in 6.03s
```

`ProjectFilesPanel.test.ts > loads markdown into the editor` fails with
"timed out waiting for the editor to mount", standalone as well as in the full
run. It imports only `ProjectFilesPanel.svelte` → svelte / lucide-svelte /
`MarkdownEditor.svelte` / `lib/projectFiles.ts`; not one file in this diff is in
that graph. A CodeMirror mount timeout, pre-existing.

**Repo gates:**

```
scripts/check_line_cap.sh          → 3801 files, 4 allowlisted, 0 violations — OK
scripts/check_test_pointers.sh     → 22626 citations, 0 dangling — OK
scripts/check_sld.sh               → 56 specs + 5771 code files, 0 errors, 0 warnings
scripts/check_changelog_fragment.sh→ trusty-agents OK, trusty-common OK
```

`cargo check --workspace` is **not** run: it fails on `trusty-code-gui` and
`trusty-mpm-gui` with `frontendDist "ui/dist" doesn't exist` — the reason CI
excludes both. Neither is in this diff, and building unrelated Tauri frontends
to turn a gate green is not a fix.

## Follow-up worth its own ticket

The sibling daemons (trusty-search, trusty-memory, trusty-analyze,
trusty-review, trusty-code) still serve `allow_origin(Any)`. `trusty-memory` in
particular exposes palace content over GET. `with_guarded_middleware_same_origin_cors`
is now a one-line adoption for each, but each needs its own review of what its
GET surface actually discloses.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
