### PR TITLE
feat(website): add Vercel Web Analytics

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -82,6 +82,35 @@ page changed: the permalinks move to the commit that was actually released.
 The framework preset is SvelteKit; build command, output directory, and install
 command are all detected — leave them on their defaults.
 
+## Analytics
+
+Vercel Web Analytics, wired in `src/routes/+layout.svelte`:
+
+```ts
+injectAnalytics({ mode: dev ? 'development' : 'production' });
+```
+
+Enable **Web Analytics** on the Vercel project or the beacon 404s — the script
+is served by the platform, not built into the bundle.
+
+Two properties are worth knowing, because both look surprising:
+
+- **Nothing is added to the prerendered HTML.** `injectAnalytics` returns early
+  unless `$app/environment`'s `browser` is true, so the beacon is a `<script>`
+  appended to `document.head` at hydration. The build smoke test's HTML walk
+  cannot see it; a separate assertion reads the JS bundle instead.
+- **The beacon stays first-party.** In `production` mode the script is
+  `/_vercel/insights/script.js`, which Vercel proxies from the site's own
+  origin, so the site still loads no third-party subresource. Only
+  `development` mode reaches off-site, for the debug script on
+  `va.vercel-scripts.com` — that is what `mode` exists to prevent shipping, and
+  what `tests/build-smoke.test.ts` pins.
+
+The `mode` argument is not decoration. Left at its default `auto`, the package
+infers the environment from `process.env.NODE_ENV` inside the browser bundle;
+passing SvelteKit's own `dev` flag keeps the decision at build time where it is
+inspectable.
+
 ## Theme
 
 `docs/design/UI/design-system/tokens.css` is the canonical Foundry v2 source.
@@ -137,10 +166,10 @@ is the whole boundary: the site enumerates it and never walks `docs/`, so an
 unlisted file has no prerendered output and no URL.
 
 Everything is built in Node at build time and prerendered to static HTML —
-there is no runtime filesystem route, and a published page opens no connection
-to any service. Relative links are rewritten to site routes when the target is
-published and to commit-pinned GitHub permalinks when it is not; a link that
-resolves to nothing fails the build.
+there is no runtime filesystem route, and the only connection a published page
+opens is the analytics beacon below. Relative links are rewritten to site routes
+when the target is published and to commit-pinned GitHub permalinks when it is
+not; a link that resolves to nothing fails the build.
 
 `src/lib/docs/README.md` carries the link rule, the failure-code table, and the
 rendering pipeline.

--- a/website/package.json
+++ b/website/package.json
@@ -49,5 +49,8 @@
 		"unist-util-visit": "^5.1.0",
 		"vite": "^6.4.3",
 		"vitest": "^4.1.10"
+	},
+	"dependencies": {
+		"@vercel/analytics": "^2.0.1"
 	}
 }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@6.4.3(@types/node@20.19.43)(jiti@1.21.7)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@5.9.3)(vite@6.4.3(@types/node@20.19.43)(jiti@1.21.7)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.5
@@ -692,6 +696,35 @@ packages:
 
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/nft@0.30.4':
     resolution: {integrity: sha512-wE6eAGSXScra60N2l6jWvNtVK0m+sh873CpfZW4KI2v8EHuUQp+mSEi4T+IcdPCSEDgCdAS/7bizbhQlkjzrSA==}
@@ -2815,6 +2848,11 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.3': {}
+
+  '@vercel/analytics@2.0.1(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@6.4.3(@types/node@20.19.43)(jiti@1.21.7)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@5.9.3)(vite@6.4.3(@types/node@20.19.43)(jiti@1.21.7)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))':
+    optionalDependencies:
+      '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@6.4.3(@types/node@20.19.43)(jiti@1.21.7)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@5.9.3)(vite@6.4.3(@types/node@20.19.43)(jiti@1.21.7))
+      svelte: 5.56.8(@typescript-eslint/types@8.66.0)
 
   '@vercel/nft@0.30.4(rollup@4.62.4)':
     dependencies:

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -1,9 +1,33 @@
 <script lang="ts">
+	import { dev } from '$app/environment';
+	import { injectAnalytics } from '@vercel/analytics/sveltekit';
 	import '../app.css';
 	import SiteHeader from '$lib/components/SiteHeader.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
 
 	let { children } = $props();
+
+	/**
+	 * Why: the site publishes to Vercel and the deploy had no traffic signal at
+	 * all. Web Analytics is the one Vercel provides without a cookie banner or a
+	 * third-party origin — in `production` mode the script is served first-party
+	 * from `/_vercel/insights/script.js`, so the self-contained property the
+	 * build smoke test guards survives (`tests/build-smoke.test.ts`).
+	 * What: registers the client-side pageview beacon. `injectAnalytics` returns
+	 * early unless `$app/environment`'s `browser` is true, so prerendering emits
+	 * no script tag and the beacon attaches at hydration instead.
+	 *
+	 * `mode` picks WHICH script loads, not whether one loads. A dev server still
+	 * gets a tag: `development` selects Vercel's debug script on
+	 * `va.vercel-scripts.com`, which console-logs events and records nothing, and
+	 * is the only third-party origin this package ever reaches for. Passing `dev`
+	 * is therefore what keeps that origin out of the deployed bundle. Leaving
+	 * `mode` at its default `auto` would instead infer the environment from
+	 * `process.env.NODE_ENV` inside the browser bundle — do not.
+	 * Test: `tests/build-smoke.test.ts`, "wires analytics to a first-party path,
+	 * never the third-party debug script".
+	 */
+	injectAnalytics({ mode: dev ? 'development' : 'production' });
 </script>
 
 <!-- Keyboard users land here first; the target must be focusable, hence tabindex. -->

--- a/website/tests/build-smoke.test.ts
+++ b/website/tests/build-smoke.test.ts
@@ -58,11 +58,34 @@ function docPages(): Set<string> {
 	return found;
 }
 
+/** Every built client-side JS chunk, concatenated. */
+function clientBundle(): string {
+	const chunks: string[] = [];
+	const walk = (dir: string) => {
+		if (!existsSync(dir)) return;
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			const full = path.join(dir, entry.name);
+			if (entry.isDirectory()) walk(full);
+			else if (entry.name.endsWith('.js')) chunks.push(readFileSync(full, 'utf8'));
+		}
+	};
+	walk(path.join(STATIC, '_app'));
+	return chunks.join('\n');
+}
+
 beforeAll(() => {
 	rmSync(OUTPUT, { recursive: true, force: true });
 	execFileSync('node', [path.join(WEBSITE_ROOT, 'node_modules/vite/bin/vite.js'), 'build'], {
 		cwd: WEBSITE_ROOT,
-		stdio: 'inherit'
+		stdio: 'inherit',
+		// Vitest exports NODE_ENV=test, which this subprocess inherits, and Vite
+		// derives `isProduction` from `process.env.NODE_ENV || mode`. Left alone,
+		// `import.meta.env.DEV` — and therefore SvelteKit's `dev` — comes out TRUE
+		// in a `vite build`, so this suite validated an artifact Vercel never
+		// produces. Harmless until something branched on `dev`; the analytics
+		// wiring in `+layout.svelte` does, and picks the third-party debug script
+		// when it reads true. Pinned so the build under test is the deployed one.
+		env: { ...process.env, NODE_ENV: 'production' }
 	});
 	landingPage = readFileSync(path.join(STATIC, 'index.html'), 'utf8');
 });
@@ -106,9 +129,17 @@ describe('production build', () => {
 		}
 	});
 
-	// The published site must be fully self-contained: everything is baked at
-	// build time and the page opens no connection to any service. Anchor hrefs
+	// The published site loads everything it renders from its own origin:
+	// content, CSS, fonts and scripts are all baked at build time. Anchor hrefs
 	// are destinations a reader clicks, not requests — only subresources count.
+	//
+	// Vercel Web Analytics (#5097) is the one service the page now talks to, and
+	// it does not appear here: `injectAnalytics` no-ops unless `browser`, so
+	// prerendering emits no tag, and in `production` mode the beacon it appends
+	// at hydration is the FIRST-PARTY `/_vercel/insights/script.js`. That is why
+	// this list is still empty rather than carrying an exception — the assertion
+	// below is deliberately unchanged. The runtime half is pinned by
+	// 'wires analytics to a first-party path…' underneath.
 	it('loads no subresource from a third-party origin', () => {
 		for (const name of ['index.html', 'docs.html', ...docPages()]) {
 			const html = readFileSync(path.join(STATIC, name), 'utf8');
@@ -120,6 +151,19 @@ describe('production build', () => {
 			expect(offSite, `${name} loads ${offSite.join(', ')}`).toEqual([]);
 			expect(html).not.toContain('@import url(http');
 		}
+	});
+
+	// The HTML walk above cannot see this: the analytics beacon is appended by
+	// client JS after hydration, so the only evidence is the bundle. `mode`
+	// decides the origin — `production` selects Vercel's first-party proxy path,
+	// `development` selects va.vercel-scripts.com. Dropping the `mode` argument,
+	// or a build where SvelteKit's `dev` reads true, silently ships the
+	// third-party one, and nothing else in this file would notice.
+	it('wires analytics to a first-party path, never the third-party debug script', () => {
+		const bundle = clientBundle();
+		expect(bundle).toContain('/_vercel/insights/script.js');
+		expect(bundle).toMatch(/\{\s*mode:\s*["']production["']\s*\}/);
+		expect(bundle).not.toMatch(/\{\s*mode:\s*["']development["']\s*\}/);
 	});
 
 	it('renders real documentation, with rewritten links and no blob/main', () => {


### PR DESCRIPTION
Adds Vercel Web Analytics to the marketing site.

## What

`@vercel/analytics` 2.0.1, wired in the root layout with the owner-supplied snippet:

```js
import { dev } from '$app/environment';
import { injectAnalytics } from '@vercel/analytics/sveltekit';

injectAnalytics({ mode: dev ? 'development' : 'production' });
```

## The self-containment gate was NOT weakened

`website/tests/build-smoke.test.ts`'s `'loads no subresource from a third-party origin'` assertion is byte-for-byte unchanged — no allowlist, no exception. It never went red: in production `getScriptSrc` returns `/_vercel/insights/script.js`, which is same-origin and Vercel-proxied. Only `development` mode loads the third-party debug script.

The gate was blind rather than broken — it walks HTML, and the beacon is appended by JS after hydration. Coverage was extended with a bundle-level assertion (`'wires analytics to a first-party path, never the third-party debug script'`), proven to fail against both regressions it claims to catch: removing the NODE_ENV pin, and dropping the `mode` argument.

## Pre-existing bug fixed

Vitest exports `NODE_ENV=test`; the `execFileSync` build subprocess inherited it; Vite computes `isProduction` from `process.env.NODE_ENV || mode`. So `dev` was **true** inside `vite build` and the suite had been validating an artifact Vercel never produces. Harmless until something branched on `dev` — this change does. Fixed by pinning `NODE_ENV: 'production'` in `beforeAll`.

## Dev behaviour, stated explicitly

`mode` selects *which* script loads, not *whether* one loads. Dev pulls Vercel's debug build from `va.vercel-scripts.com`; it console-logs and records nothing. The owner reviewed this and chose to keep the wiring as written.

## Gates — rung 6 (UI surface)

\`\`\`
prettier --check . && eslint .   → All matched files use Prettier code style!
svelte-check                     → 455 FILES 0 ERRORS 0 WARNINGS
pnpm install --frozen-lockfile && pnpm build && pnpm test → EXIT=0
                                    Test Files 10 passed (10)
                                    Tests 161 passed (161)
\`\`\`

Doc reader: 27 prerendered \`docs*.html\`, matching 27 \`PAGE\` rows. No drop.
Changelog fragment: not required — gate confirms no \`crates/*/src/**\` path changed.

## Before this does anything

Web Analytics must be enabled on the Vercel project, or the beacon 404s — the platform serves \`/_vercel/insights/script.js\`, not the bundle.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools