### PR TITLE
feat(website): add flagship crate pages under /tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ cargo fmt
 
 ## Workspace Info
 
-**Single source of truth:** This monorepo consolidates seven formerly separate repos. All 21 crates are co-located under `crates/` with one workspace root and one `Cargo.lock` — no more `[patch.crates-io]` dances during active development.
+**Single source of truth:** Every crate is co-located under `crates/` with one workspace root and one `Cargo.lock`, so a change spanning several of them is one commit.
 
 **MSRV:** Rust 1.94+ (required by the `aws-config` / `aws-sdk-bedrockruntime` dependencies)
 

--- a/website/src/lib/components/ToolPage.svelte
+++ b/website/src/lib/components/ToolPage.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+	/**
+	 * Why: the six flagship pages share a hero, an install block, and a
+	 * footer of outbound links. Writing that markup six times would let the
+	 * pages drift apart visually and would repeat the `<svelte:head>` wiring
+	 * six ways. The BODY is not shared — each page writes its own sections
+	 * through the `children` snippet, because the copy is the point.
+	 *
+	 * What: chrome only. Takes the tool's record from `$lib/tools`, plus the
+	 * facts strip that page wants above the fold.
+	 *
+	 * Test: `tests/build-smoke.test.ts` walks every emitted `tools/*.html`
+	 * and asserts it loads no third-party subresource.
+	 */
+	import { GITHUB_URL } from '$lib/site';
+	import type { Tool } from '$lib/tools';
+
+	interface Props {
+		tool: Tool;
+		/** Short label/value pairs rendered under the lede. */
+		facts: { label: string; value: string }[];
+		children: import('svelte').Snippet;
+	}
+
+	let { tool, facts, children }: Props = $props();
+
+	const sourceUrl = $derived(`${GITHUB_URL}/tree/main/crates/${tool.name}`);
+</script>
+
+<svelte:head>
+	<title>{tool.name} — {tool.tagline} — trusty-tools</title>
+	<meta name="description" content={tool.lede} />
+</svelte:head>
+
+<!-- HERO -->
+<section class="border-b border-foundry-border">
+	<div class="mx-auto max-w-content px-4 py-14 sm:px-6 sm:py-20">
+		<p class="eyebrow">{tool.unit} · {tool.tagline}</p>
+		<h1
+			class="mt-4 break-words font-display text-4xl font-bold leading-tight tracking-tight text-foundry-primary sm:text-5xl"
+		>
+			{tool.name}
+		</h1>
+		<p class="mt-6 max-w-2xl text-lg text-foundry-secondary">{tool.lede}</p>
+
+		<div class="mt-8 flex flex-wrap gap-3">
+			<a href="#install" class="btn btn-primary">Install</a>
+			{#if tool.docsPath}
+				<a href={tool.docsPath} class="btn btn-secondary">Read the docs</a>
+			{/if}
+			<a href={sourceUrl} rel="noreferrer noopener" class="btn btn-secondary">Source</a>
+		</div>
+
+		<dl class="mt-12 flex flex-wrap gap-x-10 gap-y-4">
+			{#each facts as fact (fact.label)}
+				<div>
+					<dt class="eyebrow">{fact.label}</dt>
+					<dd class="mt-1 font-mono text-sm text-foundry-text">{fact.value}</dd>
+				</div>
+			{/each}
+		</dl>
+	</div>
+</section>
+
+<!-- BODY — each page's own copy. -->
+<section class="mx-auto max-w-content px-4 py-16 sm:px-6">
+	<div class="flex flex-col gap-12">
+		{@render children()}
+	</div>
+</section>
+
+<!-- INSTALL -->
+<section class="border-y border-foundry-border bg-foundry-raised">
+	<div class="mx-auto max-w-content px-4 py-16 sm:px-6">
+		<h2 id="install" class="scroll-mt-24 font-display text-2xl font-bold sm:text-3xl">Install</h2>
+		<p class="mt-3 max-w-2xl text-foundry-secondary">
+			<code class="text-sm">tctl</code> resolves whatever else this crate needs at runtime and keeps
+			macOS signing grants stable across upgrades. The
+			<a href="/#install" class="text-foundry-primary underline underline-offset-2"
+				>other install paths</a
+			>
+			— Homebrew, or <code class="text-sm">cargo install</code> from source — are on the home page.
+		</p>
+		<!-- `min-w-0`: a `<pre>` never wraps, so without it the flex child
+		     widens to the longest command and the page scrolls sideways. -->
+		<div class="mt-6 max-w-xl min-w-0">
+			<pre
+				class="overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-3 text-xs leading-relaxed text-foundry-text">curl -sSf https://raw.githubusercontent.com/bobmatnyc/trusty-tools/main/install.sh | sh
+{tool.install}</pre>
+		</div>
+		<p class="mt-6 max-w-2xl text-sm text-foundry-secondary">
+			Build and test this crate from a checkout with
+			<code class="text-sm">cargo test -p {tool.cargoPackage}</code>.
+		</p>
+	</div>
+</section>
+
+<!-- NEXT -->
+<section class="mx-auto max-w-content px-4 py-16 sm:px-6">
+	<div class="card flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+		<div>
+			<h2 class="font-display text-xl font-semibold">
+				{#if tool.docsPath}Go deeper{:else}Read the source{/if}
+			</h2>
+			<p class="mt-1 text-sm text-foundry-secondary">
+				{#if tool.docsPath}
+					Reference documentation for {tool.name}, plus every other crate in the workspace.
+				{:else}
+					{tool.name} publishes no documentation page yet — the crate's own README and source are the
+					reference.
+				{/if}
+			</p>
+		</div>
+		<a
+			href={tool.docsPath ?? sourceUrl}
+			rel={tool.docsPath ? undefined : 'noreferrer noopener'}
+			class="btn btn-primary shrink-0"
+		>
+			{tool.docsPath ? 'Browse docs' : 'View on GitHub'}
+		</a>
+	</div>
+	<p class="mt-8">
+		<a href="/#flagships" class="text-sm text-foundry-primary underline underline-offset-2"
+			>← All flagship tools</a
+		>
+	</p>
+</section>

--- a/website/src/lib/site.ts
+++ b/website/src/lib/site.ts
@@ -19,6 +19,8 @@
  * truth.
  */
 
+import { TOOLS, type Tool } from './tools';
+
 export const GITHUB_URL = 'https://github.com/bobmatnyc/trusty-tools';
 
 export const NAV_LINKS: { href: string; label: string }[] = [
@@ -26,91 +28,56 @@ export const NAV_LINKS: { href: string; label: string }[] = [
 	{ href: '/docs', label: 'Docs' }
 ];
 
-export interface Flagship {
-	name: string;
-	unit: string;
-	tagline: string;
-	points: string[];
-}
-
-/** The three flagship MCP servers, per README.md's "Three Flagship MCP Servers". */
-export const FLAGSHIPS: Flagship[] = [
-	{
-		name: 'trusty-search',
-		unit: 'UNIT 01',
-		tagline: 'Hybrid code search',
-		points: [
-			'BM25, vector, and knowledge-graph retrieval fused with Reciprocal Rank Fusion',
-			'One machine-wide daemon, unlimited named project indexes',
-			'Query-intent routing across definition, usage, conceptual, and bug/debt lookups',
-			'Branch-aware ranking and caller/callee chain expansion'
-		]
-	},
-	{
-		name: 'trusty-memory',
-		unit: 'UNIT 02',
-		tagline: 'Memory palace storage',
-		points: [
-			'HNSW vector index over SQLite, embedded with fastembed',
-			'Semantic recall across everything you have stored',
-			'Collections for notes, snippets, code patterns, and decisions',
-			'Svelte UI for browsing and editing, plus an MCP server'
-		]
-	},
-	{
-		name: 'trusty-analyze',
-		unit: 'UNIT 03',
-		tagline: 'Code analysis sidecar',
-		points: [
-			'Cyclomatic and cognitive complexity per chunk, file, and index',
-			'Configurable code-smell categories and A–F quality grading',
-			'Git-blame temporal decay to surface stale, complex code',
-			'Tree-sitter adapters for 14 languages; HTTP and MCP parity'
-		]
-	}
-];
+/**
+ * The six flagship crates, each with a hand-authored page under `/tools/`.
+ * The records live in `./tools` because those pages need more per-crate detail
+ * than a landing-page card does, and a second copy here would drift.
+ */
+export type Flagship = Tool;
+export const FLAGSHIPS: Flagship[] = TOOLS;
 
 export interface CrateGroup {
 	group: string;
 	crates: { name: string; description: string }[];
 }
 
-/** Crate lineup, transcribed from README.md's "Full Crate Index" tables. */
+/**
+ * Why: what a visitor wants below the six flagship cards is "what else can I
+ * install, and what is coming" — not an inventory of every workspace member.
+ * Internal plumbing is deliberately absent: shared libraries (`trusty-common`,
+ * `trusty-progress`), private launchers, release tooling, and sidecars that
+ * are installed BY another crate rather than on their own (`trusty-embedderd`,
+ * whose own README says it is not installed standalone) have nothing to offer
+ * a reader here. The six flagships are carded above and are not repeated.
+ *
+ * What: two groups, split on release state rather than on subject matter.
+ * Placement was checked per crate against crates.io and this repository's
+ * release tags on 2026-08-08, not inferred from version numbers —
+ * `trusty-agents` reads 0.38.6 in its manifest while having no tag and no
+ * crates.io release at all.
+ *
+ * Deliberately omitted, like the crate COUNT above: any per-crate version
+ * number. It would be stale the next time any of them ships.
+ */
 export const CRATE_GROUPS: CrateGroup[] = [
 	{
-		group: 'Daemons & MCP servers',
+		group: 'Also shipped',
 		crates: [
-			{ name: 'trusty-search', description: 'Hybrid code search (BM25 + vector + KG)' },
-			{ name: 'trusty-memory', description: 'Memory palace UI and MCP frontend' },
-			{ name: 'trusty-analyze', description: 'Complexity, smells, and a facts store' },
-			{ name: 'trusty-bm25-daemon', description: 'Standalone BM25 full-text search daemon' }
+			{ name: 'trusty-installer', description: 'The tctl install and upgrade control plane' },
+			{ name: 'trusty-console', description: 'Web dashboard over the trusty services you run' },
+			{ name: 'trusty-code', description: 'Per-project coding harness (tcode)' },
+			{ name: 'trusty-gworkspace', description: 'Google Workspace MCP server' }
 		]
 	},
 	{
-		group: 'Shared libraries',
+		group: 'In development',
 		crates: [
-			{ name: 'trusty-common', description: 'Tracing, daemon helpers, shared utilities' },
-			{ name: 'trusty-embedderd', description: 'fastembed wrapper, 384-dimension output' },
-			{ name: 'trusty-gworkspace', description: 'Google Workspace client' },
-			{ name: 'trusty-cto-db', description: 'SQLite schema and rusqlite bindings' }
-		]
-	},
-	{
-		group: 'Platform & agents',
-		crates: [
-			{ name: 'trusty-mpm', description: 'Multi-agent platform: CLI, daemon, MCP server' },
-			{ name: 'trusty-mpm-gui', description: 'Desktop GUI, built with Tauri' },
-			{ name: 'trusty-agents', description: 'Agent orchestration platform' },
-			{ name: 'trusty-installer', description: 'Install and upgrade orchestrator (tctl)' }
-		]
-	},
-	{
-		group: 'Tools & analytics',
-		crates: [
-			{ name: 'trusty-review', description: 'Code review automation and analysis' },
-			{ name: 'trusty-git-analytics', description: 'Developer analytics from git history' },
-			{ name: 'trusty-console', description: 'Terminal UI for system monitoring' },
-			{ name: 'trusty-code', description: 'Code generation and analysis utilities' }
+			{ name: 'trusty-agents', description: 'Agentic harness with multi-model routing (tagent)' },
+			{ name: 'trusty-channels', description: 'Chat-channel MCP servers, starting with Slack' },
+			{ name: 'trusty-kb', description: 'Personal knowledge base as an MCP server' },
+			{ name: 'trusty-sld-lint', description: 'Linter for spec-linked documentation' },
+			{ name: 'trusty-mpm-gui', description: 'Desktop dashboard for trusty-mpm' },
+			{ name: 'trusty-code-gui', description: 'Desktop shell for the tcode daemon' }
 		]
 	}
 ];

--- a/website/src/lib/tools.test.ts
+++ b/website/src/lib/tools.test.ts
@@ -1,0 +1,92 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { TOOLS } from './tools';
+import { STABLE_SET } from './site';
+
+/**
+ * Why: the flagship pages assert things about crates. The two claims most
+ * likely to rot silently are the ones the reader will act on — the `-p` flag
+ * they paste into `cargo test`, and the `tctl install` target — because both
+ * look plausible while being wrong. `crates/trusty-git-analytics` is package
+ * `tga`, so the directory name is NOT the package name and cannot be assumed.
+ *
+ * What: re-derives each record's crate directory, package name, install
+ * target, and docs route from the repository rather than from prose.
+ *
+ * Not covered here: the page copy itself. Prose claims were verified by hand
+ * against each crate's clap enums and MCP descriptor tables; a unit test
+ * cannot re-derive an English sentence.
+ *
+ * Test: this file.
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '../../..');
+
+describe('flagship tool records are grounded in the repository', () => {
+	it('names a crate directory that exists', () => {
+		expect(TOOLS.length).toBe(6);
+		for (const tool of TOOLS) {
+			expect(existsSync(path.join(REPO_ROOT, 'crates', tool.name, 'Cargo.toml')), tool.name).toBe(
+				true
+			);
+		}
+	});
+
+	it("cargoPackage matches that crate's Cargo.toml name field", () => {
+		for (const tool of TOOLS) {
+			const manifest = readFileSync(
+				path.join(REPO_ROOT, 'crates', tool.name, 'Cargo.toml'),
+				'utf8'
+			);
+			// Anchored: a `[dependencies]` entry further down also matches `name`.
+			const declared = manifest.match(/^name\s*=\s*"([^"]+)"/m)![1];
+			expect(tool.cargoPackage, tool.name).toBe(declared);
+		}
+	});
+
+	it('every install command targets a stable-set member', () => {
+		for (const tool of TOOLS) {
+			const target = tool.install.replace('tctl install', '').trim();
+			expect(STABLE_SET, `${tool.name} installs ${target}`).toContain(target);
+		}
+	});
+
+	it('links only to doc pages the manifest actually publishes', () => {
+		const routes = readFileSync(path.join(REPO_ROOT, 'docs/public-manifest.tsv'), 'utf8')
+			.split('\n')
+			.filter((line) => line.startsWith('PAGE\t'))
+			.map((line) => `/docs${line.split('\t')[3]}`);
+		for (const tool of TOOLS) {
+			if (tool.docsPath === null) continue;
+			expect(routes, tool.name).toContain(tool.docsPath);
+		}
+	});
+
+	it('has a route directory for every slug, and no duplicate slugs', () => {
+		expect(new Set(TOOLS.map((t) => t.slug)).size).toBe(TOOLS.length);
+		for (const tool of TOOLS) {
+			expect(
+				existsSync(path.join(HERE, '../routes/tools', tool.slug, '+page.svelte')),
+				tool.slug
+			).toBe(true);
+		}
+	});
+
+	it('never names a retired binary or a `cp` install', () => {
+		const prose = JSON.stringify(TOOLS);
+		for (const banned of [
+			'open-mpm',
+			'trusty-mpmd',
+			'trusty-mpm-tui',
+			'trusty-mpm-telegram',
+			'trusty-memory-core',
+			'TRUSTY_ALLOW_UNLISTED',
+			'search_code'
+		]) {
+			expect(prose, banned).not.toContain(banned);
+		}
+	});
+});

--- a/website/src/lib/tools.ts
+++ b/website/src/lib/tools.ts
@@ -1,0 +1,142 @@
+/**
+ * Why: the six flagship crates each get a hand-authored page under
+ * `src/routes/tools/`, and the landing page cards link into them. Keeping the
+ * shared per-tool facts here means the card and the page can never disagree
+ * about a crate's name, package flag, install command, or docs link.
+ *
+ * What: one `Tool` record per flagship. Prose that appears on only ONE page
+ * lives in that page's `.svelte` file; only what BOTH surfaces need is here.
+ *
+ * Sourcing rule: every string below was checked against the crate's own
+ * source — `Cargo.toml`, the clap subcommand enums, the MCP tool descriptor
+ * tables — not against a README. The crate READMEs carry several claims that
+ * do not survive that check (a `TRUSTY_ALLOW_UNLISTED` bypass no production
+ * code reads, a `search_code` tool that does not exist, stale tool counts),
+ * so a README sentence is a draft here, never a source.
+ *
+ * Test: `src/lib/tools.test.ts` re-derives the crate directory, the package
+ * name, the docs route, and the install target from the repository.
+ */
+
+export interface Tool {
+	/** Route segment: the page lives at `/tools/<slug>`. */
+	slug: string;
+	/** Crate DIRECTORY name under `crates/` — not always the package name. */
+	name: string;
+	/** `cargo … -p <package>`; `crates/trusty-git-analytics` is package `tga`. */
+	cargoPackage: string;
+	/** Foundry unit stamp shown above the name. */
+	unit: string;
+	tagline: string;
+	/** Landing-page card bullets. */
+	points: string[];
+	/** One-line summary for the page hero and its `<meta name="description">`. */
+	lede: string;
+	/** `tctl install` target. Every entry must be a `STABLE_SET` member. */
+	install: string;
+	/**
+	 * The doc reader's page for this crate, at `/docs/tools/<crate>` — a
+	 * different URL from this page by one path segment. `null` for
+	 * trusty-review, which publishes no doc page.
+	 */
+	docsPath: string | null;
+}
+
+export const TOOLS: Tool[] = [
+	{
+		slug: 'trusty-search',
+		name: 'trusty-search',
+		cargoPackage: 'trusty-search',
+		unit: 'UNIT 01',
+		tagline: 'Hybrid code search',
+		points: [
+			'BM25, vector, and knowledge-graph retrieval fused with Reciprocal Rank Fusion',
+			'One machine-wide daemon, unlimited named project indexes',
+			'Query-intent routing across definition, usage, conceptual, and bug/debt lookups',
+			'Branch-aware ranking and caller/callee chain expansion'
+		],
+		lede: 'Three retrieval lanes over one corpus, fused into a single ranking, served by one daemon for every project on the machine.',
+		install: 'tctl install trusty-search',
+		docsPath: '/docs/tools/trusty-search'
+	},
+	{
+		slug: 'trusty-memory',
+		name: 'trusty-memory',
+		cargoPackage: 'trusty-memory',
+		unit: 'UNIT 02',
+		tagline: 'Memory palace storage',
+		points: [
+			'Named palaces, one per project, with rooms and wings inside them',
+			'Hybrid BM25 + vector recall over an HNSW index and a redb store',
+			'A knowledge graph of subject/predicate/object triples alongside the prose',
+			'A dream cycle that consolidates near-duplicates instead of hoarding them'
+		],
+		lede: 'Long-term memory an assistant can write to and recall from across sessions, organised per project rather than per conversation.',
+		install: 'tctl install trusty-memory',
+		docsPath: '/docs/tools/trusty-memory'
+	},
+	{
+		slug: 'trusty-mpm',
+		name: 'trusty-mpm',
+		cargoPackage: 'trusty-mpm',
+		unit: 'UNIT 03',
+		tagline: 'Multi-agent orchestration',
+		points: [
+			'One `tm` binary: daemon, CLI, TUI dashboard, and MCP server',
+			'Sessions and worktrees per project, tracked across restarts',
+			'Claude Code lifecycle hooks relayed into the daemon',
+			'Remote control from Telegram or Slack when you are away from the terminal'
+		],
+		lede: 'A project manager for coding sessions: it provisions them, watches them, and keeps the roster straight while you work in several at once.',
+		install: 'tctl install trusty-mpm',
+		docsPath: '/docs/tools/trusty-mpm'
+	},
+	{
+		slug: 'trusty-analyze',
+		name: 'trusty-analyze',
+		cargoPackage: 'trusty-analyze',
+		unit: 'UNIT 04',
+		tagline: 'Code analysis sidecar',
+		points: [
+			'Cyclomatic and cognitive complexity per chunk, file, and index',
+			'Code-smell detection with configurable thresholds and named categories',
+			'Git-blame temporal decay, so stale complex code sorts to the top',
+			'Tree-sitter adapters for 14 languages, behind one HTTP API and one MCP server'
+		],
+		lede: 'A second daemon that reads trusty-search’s corpus and answers the question search cannot: not where the code is, but how bad it is.',
+		install: 'tctl install trusty-analyze',
+		docsPath: '/docs/tools/trusty-analyze'
+	},
+	{
+		slug: 'trusty-review',
+		name: 'trusty-review',
+		cargoPackage: 'trusty-review',
+		unit: 'UNIT 05',
+		tagline: 'LLM code review',
+		points: [
+			'Reviews a GitHub PR, a git ref range, or a diff on stdin',
+			'Injects code context from trusty-search and metrics from trusty-analyze',
+			'A letter grade alongside an APPROVE / REQUEST_CHANGES / BLOCK verdict',
+			'Skips a review it cannot ground rather than issue a confident guess'
+		],
+		lede: 'A reviewer that reads the rest of the repository before it reads your diff, and says so plainly when it cannot.',
+		install: 'tctl install trusty-review',
+		docsPath: null
+	},
+	{
+		slug: 'trusty-git-analytics',
+		name: 'trusty-git-analytics',
+		cargoPackage: 'tga',
+		unit: 'UNIT 06',
+		tagline: 'Developer analytics from git',
+		points: [
+			'Walks local repositories into SQLite, then classifies every commit',
+			'A tiered classification cascade, with an optional LLM tier at the end',
+			'Per-author and per-week velocity, quality, and DORA reporting',
+			'CSV, JSON, and Markdown output from one `tga analyze` run'
+		],
+		lede: 'Turns git history into per-author and per-week reporting, with a classification cascade that names the work each commit did.',
+		install: 'tctl install tga',
+		docsPath: '/docs/tools/trusty-git-analytics'
+	}
+];

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -53,27 +53,38 @@
 	<div class="mt-6 grid gap-6 md:grid-cols-2">
 		<p class="text-foundry-secondary">
 			A single Cargo workspace holding the whole trusty-* family — shared libraries, daemons and MCP
-			servers, a multi-agent platform, and an orchestrator. It replaces seven formerly separate
-			repositories, so cross-crate changes are one atomic commit instead of a chain of version bumps
-			and patch tables.
+			servers, a multi-agent platform, and an orchestrator. Everything is co-located under
+			<code class="text-sm">crates/</code>, so a change spanning several of them is one commit
+			against one lockfile.
 		</p>
 		<p class="text-foundry-secondary">
-			Each crate versions, tags, and publishes independently, and everything is MIT licensed. The
-			three flagship services below each speak the Model Context Protocol, so they plug into Claude
-			Code and any other MCP client without a bespoke integration.
+			Each crate versions, tags, and publishes independently, and everything is MIT licensed. Five
+			of the six flagship tools below speak the Model Context Protocol, so they plug into Claude
+			Code and any other MCP client without a bespoke integration; the sixth is a command-line
+			analytics tool.
 		</p>
 	</div>
 </section>
 
-<!-- FLAGSHIP SERVICES -->
+<!-- FLAGSHIP TOOLS -->
 <section class="mx-auto max-w-content px-4 pb-16 sm:px-6">
-	<h2 class="font-display text-2xl font-bold sm:text-3xl">Three flagship MCP servers</h2>
-	<div class="mt-8 grid gap-6 lg:grid-cols-3">
+	<h2 id="flagships" class="scroll-mt-24 font-display text-2xl font-bold sm:text-3xl">
+		Six flagship tools
+	</h2>
+	<p class="mt-3 max-w-2xl text-foundry-secondary">
+		Each one has its own page — what it does, how it works, and how to install it.
+	</p>
+	<div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
 		{#each FLAGSHIPS as flagship (flagship.name)}
 			<article class="card flex flex-col">
 				<p class="eyebrow">{flagship.unit}</p>
-				<h3 class="mt-2 break-words font-display text-xl font-semibold text-foundry-primary">
-					{flagship.name}
+				<h3 class="mt-2 break-words font-display text-xl font-semibold">
+					<a
+						href="/tools/{flagship.slug}"
+						class="text-foundry-primary underline decoration-1 underline-offset-4 hover:decoration-2"
+					>
+						{flagship.name}
+					</a>
 				</h3>
 				<p class="mt-1 text-sm font-semibold text-foundry-text">{flagship.tagline}</p>
 				<ul class="mt-4 space-y-2 text-sm text-foundry-secondary">
@@ -85,6 +96,14 @@
 						</li>
 					{/each}
 				</ul>
+				<p class="mt-6 pt-2">
+					<a
+						href="/tools/{flagship.slug}"
+						class="font-mono text-xs uppercase tracking-wider text-foundry-primary"
+					>
+						{flagship.name} →
+					</a>
+				</p>
 			</article>
 		{/each}
 	</div>
@@ -93,12 +112,14 @@
 <!-- CRATE LINEUP -->
 <section class="border-y border-foundry-border bg-foundry-raised">
 	<div class="mx-auto max-w-content px-4 py-16 sm:px-6">
-		<h2 class="font-display text-2xl font-bold sm:text-3xl">The crate lineup</h2>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">The rest of the lineup</h2>
 		<p class="mt-3 max-w-2xl text-foundry-secondary">
-			A selection of what lives under <code class="text-sm">crates/</code>. The workspace glob in
-			the root <code class="text-sm">Cargo.toml</code> is the authoritative list.
+			What else you can install today, and what is still being built. Shared libraries and internal
+			tooling are left out — the workspace glob in the root
+			<code class="text-sm">Cargo.toml</code> is the authoritative list of everything under
+			<code class="text-sm">crates/</code>.
 		</p>
-		<div class="mt-8 grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
+		<div class="mt-8 grid gap-8 sm:grid-cols-2">
 			{#each CRATE_GROUPS as group (group.group)}
 				<div>
 					<h3 class="eyebrow">{group.group}</h3>

--- a/website/src/routes/tools/trusty-analyze/+page.svelte
+++ b/website/src/routes/tools/trusty-analyze/+page.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import ToolPage from '$lib/components/ToolPage.svelte';
+	import { TOOLS } from '$lib/tools';
+
+	const tool = TOOLS.find((t) => t.slug === 'trusty-analyze')!;
+
+	const facts = [
+		{ label: 'Package', value: 'trusty-analyze' },
+		{ label: 'Default port', value: '7879' },
+		{ label: 'Languages', value: '14 tree-sitter adapters' },
+		{ label: 'Requires', value: 'trusty-search on 7878' }
+	];
+</script>
+
+<ToolPage {tool} {facts}>
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">A sidecar, on purpose</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			trusty-analyze does not index anything. It pulls the chunk corpus trusty-search has already
+			built, runs static analysis over it, and serves the results on its own port. One parse of your
+			repository feeds both, and a crash in either does not take the other down.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			That coupling is explicit rather than best-effort: the analyzer health-checks trusty-search at
+			startup and exits rather than come up half-useful. There is no offline mode to accidentally
+			end up in.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">What it measures</h2>
+		<ul class="mt-6 max-w-3xl space-y-3 text-foundry-secondary">
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Complexity.</span> Cyclomatic and cognitive scores
+					per chunk, per file, and aggregated per index — the second because branch counting alone rewards
+					code that is short and unreadable.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Smells.</span> Named categories — long functions,
+					deep nesting, too many parameters — each with a threshold you can move rather than a hard-coded
+					opinion.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Grades.</span> An A-to-F letter per file and
+					per index, for the times a number is more argument than signal.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Age.</span> A temporal-decay score over git blame,
+					with a half-life of about ten weeks. Complex code touched yesterday is being worked on; complex
+					code nobody has touched in a year is the one to worry about.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Structure.</span> Concept clusters over the corpus,
+					entity extraction, SCIP protobuf ingest for symbol data an LSP already computed, and a facts
+					store of subject/predicate/object triples persisted locally.</span
+				>
+			</li>
+		</ul>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Fourteen languages, one shape</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Tree-sitter adapters cover Rust, Python, TypeScript, JavaScript, Java, Go, Ruby, PHP, C, C++,
+			C#, Kotlin, Swift, and Scala. They all produce the same metric shape, so a polyglot repository
+			gets one comparable report rather than a per-language dialect of the truth.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Two ways in</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			An HTTP API serves complexity hotspots, smells, quality grades, clusters, and the facts store;
+			an MCP server exposes the same analysis to an agent over stdio or SSE. A deep-analysis pass
+			will additionally write a prose narrative over an analyzed index, routed through OpenRouter or
+			AWS Bedrock depending on the model id you configure — it is opt-in, and nothing else in the
+			crate calls an LLM.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			The default build links no ONNX runtime and downloads no model. One install command works on
+			every supported host.
+		</p>
+	</div>
+</ToolPage>

--- a/website/src/routes/tools/trusty-git-analytics/+page.svelte
+++ b/website/src/routes/tools/trusty-git-analytics/+page.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+	import ToolPage from '$lib/components/ToolPage.svelte';
+	import { TOOLS } from '$lib/tools';
+
+	const tool = TOOLS.find((t) => t.slug === 'trusty-git-analytics')!;
+
+	const facts = [
+		{ label: 'Package', value: 'tga' },
+		{ label: 'Binary', value: 'tga' },
+		{ label: 'Store', value: 'SQLite, on disk' },
+		{ label: 'Output', value: 'CSV, JSON, Markdown' }
+	];
+</script>
+
+<ToolPage {tool} {facts}>
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Three stages, one command</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			<code class="text-sm">tga analyze</code> runs the whole pipeline. Each stage is also a subcommand,
+			because on a large history you will want to re-run one without paying for the others.
+		</p>
+		<ul class="mt-6 max-w-3xl space-y-3 text-foundry-secondary">
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><code class="text-sm">tga collect</code> — walk each configured repository, extract commit
+					metadata and diff stats, resolve author identities, and write it all to SQLite. Optionally pull
+					pull-request and issue metadata from GitHub, JIRA, Linear, or Azure DevOps alongside it.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><code class="text-sm">tga classify</code> — run every unclassified commit through the cascade
+					and write the verdict back. Rule tiers run in parallel.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><code class="text-sm">tga report</code> — aggregate per author, per week, and per DORA metric,
+					then write CSV, JSON, and Markdown into the output directory.</span
+				>
+			</li>
+		</ul>
+		<p class="mt-6 max-w-3xl text-foundry-secondary">
+			The database is a local SQLite file, so every number in a report is one you can go and check
+			with a query.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">The classification cascade</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Naming what a commit actually did is the hard part, and a single heuristic gets it wrong often
+			enough to be useless. tga tries tiers in order and takes the first confident answer: a manual
+			override you pinned, the issue type from a linked ticket, a project-key mapping, an
+			Aho-Corasick scan for conventional-commit prefixes, regex patterns, a weighted sum over
+			several independent signals, and fuzzy heuristics for merges and reverts.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			An LLM tier sits at the end for the commits the rules could not place, disabled by default and
+			enabled with <code class="text-sm">--use-llm</code>. Its answers are accepted only above a
+			confidence threshold you set. <code class="text-sm">--no-external</code> skips every network-bound
+			source, which is what you want while iterating on a rule file.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			The rule set is introspectable rather than a black box: <code class="text-sm"
+				>tga rules list</code
+			>
+			enumerates it, <code class="text-sm">tga rules test "&lt;message&gt;"</code> shows you which
+			tier would fire, and <code class="text-sm">tga override</code> pins a verdict that outranks all
+			of them.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">What comes out</h2>
+		<ul class="mt-6 max-w-3xl space-y-2 text-foundry-secondary">
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><code class="text-sm">tga author &lt;email&gt;</code> — a per-engineer drill-down: commits,
+					effort, pull requests, category mix.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><code class="text-sm">tga pr-metrics</code> — pull-request metrics per engineer, once PR fetching
+					is turned on.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><code class="text-sm">tga dora</code> — all four DORA metrics, fed by
+					<code class="text-sm">tga deployments</code> and
+					<code class="text-sm">tga incidents</code>.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><code class="text-sm">tga aliases</code> — merge the four email addresses one person has committed
+					under, so the per-author numbers mean anything at all.</span
+				>
+			</li>
+		</ul>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Getting started</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			<code class="text-sm">tga install</code> is an interactive wizard that writes the config for
+			you. A hand-written one can be as small as a list of repository paths — every other section
+			has a default. Note the package and binary are both <code class="text-sm">tga</code>, not the
+			crate directory's longer name.
+		</p>
+	</div>
+</ToolPage>

--- a/website/src/routes/tools/trusty-memory/+page.svelte
+++ b/website/src/routes/tools/trusty-memory/+page.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+	import ToolPage from '$lib/components/ToolPage.svelte';
+	import { TOOLS } from '$lib/tools';
+
+	const tool = TOOLS.find((t) => t.slug === 'trusty-memory')!;
+
+	const facts = [
+		{ label: 'Package', value: 'trusty-memory' },
+		{ label: 'Default port', value: '7070' },
+		{ label: 'MCP tools', value: '45' },
+		{ label: 'Storage', value: 'usearch + redb, on disk' }
+	];
+</script>
+
+<ToolPage {tool} {facts}>
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">A place to put what was learned</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			An assistant that forgets everything at the end of a session relearns your codebase every
+			morning. trusty-memory is the store that stops that: an MCP server over a local vector index
+			and a key-value store, where an agent writes what it worked out and recalls it by meaning
+			later.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Memories are organised into named <em>palaces</em> — one per project — with rooms and wings
+			inside them. The naming is deliberate: a palace is anchored to a real project directory, so
+			the memories for one repository can never quietly bleed into another's recall. Work outside
+			any project and there is a single <code class="text-sm">personal</code> palace for the notes that
+			belong to you rather than to a codebase.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Recall that does not need the words</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Recall is hybrid — lexical BM25 alongside vector similarity — so a query finds a memory that
+			said the same thing differently. Embeddings are computed on the machine, and both the vector
+			index and the metadata store are ordinary local files. Nothing is shipped to a hosted memory
+			service.
+		</p>
+		<ul class="mt-6 max-w-3xl space-y-2 text-foundry-secondary">
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><code class="text-sm">memory_remember</code> and
+					<code class="text-sm">memory_recall</code>
+					are the whole day-to-day surface; <code class="text-sm">memory_recall_deep</code> trades latency
+					for reach when the fast lane comes up short.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					>A knowledge-graph layer stores subject/predicate/object triples next to the prose, so
+					structured facts can be asserted and queried directly rather than fished back out of a
+					paragraph.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					>A chat-session store keeps conversation turns verbatim, bypassing the signal filters that
+					apply to ordinary memories — a transcript is not a fact and should not be deduplicated
+					like one.</span
+				>
+			</li>
+		</ul>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">The dream cycle</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			A memory store that only ever accumulates degrades into a landfill. trusty-memory runs a
+			consolidation pass — the dream cycle — that merges near-duplicates, prunes what has gone
+			stale, and, when an inference backend is configured, summarises a room's older facts into
+			canonical entries and links the originals to their replacement so the lineage stays traceable.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Task drawers — goals, milestones, checkpoints an application must re-derive across sessions —
+			are exempt. They are never evicted and never consolidated away, however old they get, until
+			something deletes them explicitly.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Wiring it up</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			<code class="text-sm">trusty-memory setup</code> installs the background service, warms the embedding
+			model cache, and patches the Claude settings files it finds with the right server entry. From then
+			on the daemon is just there.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			For a manual configuration, the canonical entry runs
+			<code class="text-sm">trusty-memory serve --stdio</code>, which forwards every request to the
+			running HTTP daemon and returns its answers verbatim. The stdio process never opens the
+			database itself, so it coexists safely with the daemon and with other clients. The same daemon
+			serves a REST API and an embedded browser dashboard on the port it bound.
+		</p>
+	</div>
+</ToolPage>

--- a/website/src/routes/tools/trusty-mpm/+page.svelte
+++ b/website/src/routes/tools/trusty-mpm/+page.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import ToolPage from '$lib/components/ToolPage.svelte';
+	import { TOOLS } from '$lib/tools';
+
+	const tool = TOOLS.find((t) => t.slug === 'trusty-mpm')!;
+
+	const facts = [
+		{ label: 'Package', value: 'trusty-mpm' },
+		{ label: 'Binaries', value: 'tm, trusty-mpm' },
+		{ label: 'Surfaces', value: 'CLI, daemon, TUI, MCP' },
+		{ label: 'Remote', value: 'Telegram, Slack' }
+	];
+</script>
+
+<ToolPage {tool} {facts}>
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">
+			One binary, one daemon, many sessions
+		</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Running one coding session is easy. Running five across three repositories, remembering which
+			worktree each belongs to and which are still waiting on you, is the part that goes wrong.
+			trusty-mpm is the process that keeps that straight.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Everything ships as a single binary installed under two names — <code class="text-sm">tm</code
+			>
+			and <code class="text-sm">trusty-mpm</code> — with each surface behind a subcommand rather than
+			a separate package to install and version-match.
+		</p>
+		<ul class="mt-6 max-w-3xl space-y-2 text-foundry-secondary">
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><code class="text-sm">tm daemon</code> — the background service everything else talks to.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><code class="text-sm">tm tui</code> — a terminal dashboard across every live session.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><code class="text-sm">tm telegram</code> and <code class="text-sm">tm slack</code> — remote
+					control from a phone when you are not at the terminal.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><code class="text-sm">tm gui</code> — an optional desktop shell over the same daemon.</span
+				>
+			</li>
+		</ul>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Sessions you can walk away from</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			<code class="text-sm">tm launch</code> provisions a session with everything it needs already
+			deployed — instructions, agent roster, skills — and starts it.
+			<code class="text-sm">tm ls</code>
+			and <code class="text-sm">tm f</code> find one again by name or by prefix;
+			<code class="text-sm">tm attach</code> reconnects. The daemon holds the roster, so closing a terminal
+			does not lose the session behind it.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Projects are registered rather than inferred, which is what makes the rest work: the same
+			directory resolves to the same project every time, across sessions and across restarts.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">
+			Hooked into the session, not beside it
+		</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			<code class="text-sm">tm hook</code> handles Claude Code lifecycle events — before a tool
+			runs, after it runs, and when a session stops — and relays them to the daemon. That event feed
+			is what makes the dashboards live rather than a periodic poll, and it is readable directly
+			with
+			<code class="text-sm">tm events</code>.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			An MCP server exposes the same orchestration surface to a session itself, so an agent can
+			enumerate sessions, delegate work, and read project state through tool calls rather than by
+			shelling out.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">When it goes wrong</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			<code class="text-sm">tm doctor</code> runs a full diagnostic of the stack.
+			<code class="text-sm">tm validate</code>
+			checks a workspace's deployed agents, skills, and settings against the canonical roster, and
+			<code class="text-sm">tm repair</code> recovers from a deploy state that has drifted.
+			<code class="text-sm">tm health</code> reports daemon reachability and a fleet summary in one line.
+		</p>
+	</div>
+</ToolPage>

--- a/website/src/routes/tools/trusty-review/+page.svelte
+++ b/website/src/routes/tools/trusty-review/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import ToolPage from '$lib/components/ToolPage.svelte';
+	import { TOOLS } from '$lib/tools';
+
+	const tool = TOOLS.find((t) => t.slug === 'trusty-review')!;
+
+	const facts = [
+		{ label: 'Package', value: 'trusty-review' },
+		{ label: 'Default port', value: '7880' },
+		{ label: 'Providers', value: 'AWS Bedrock, OpenRouter' },
+		{ label: 'MCP tools', value: 'review_pr, review_diff, review_health' }
+	];
+</script>
+
+<ToolPage {tool} {facts}>
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Context first, opinion second</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			A model handed a bare diff will find style nits and miss the thing that matters, because the
+			caller it breaks is in a file it never saw. trusty-review fixes the input rather than the
+			prompt: it retrieves code context from trusty-search and complexity data from trusty-analyze
+			before the reviewer model is called at all.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			That is also why it will refuse. A review produced without that context is worse than no
+			review — it reads exactly like a real one. When a required dependency is unreachable, a hosted
+			review is skipped and the caller is told the reason, in a shape distinct from any verdict so
+			it cannot be mistaken for one.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Point it at anything</h2>
+		<ul class="mt-6 max-w-3xl space-y-2 text-foundry-secondary">
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					>A GitHub pull request: <code class="text-sm">trusty-review run owner repo 123</code
+					>.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					>A ref range, with no manual diff step:
+					<code class="text-sm">trusty-review run --base origin/main</code>.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					>A patch on stdin:
+					<code class="text-sm">git diff origin/main...HEAD | trusty-review run --local-diff -</code
+					>.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					>A checkout the search daemon has never seen, via
+					<code class="text-sm">--source-root</code>.</span
+				>
+			</li>
+		</ul>
+		<p class="mt-6 max-w-3xl text-foundry-secondary">
+			Only a GitHub PR review can post a comment, and only once you turn dry-run off. Every other
+			source is dry-run by construction — a local diff cannot reach your repository's review thread
+			however it is invoked.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			<code class="text-sm">trusty-review compare</code> runs the same diff past several models at once,
+			which is the honest way to decide whether a cheaper reviewer is good enough for your codebase.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">A verdict, not a wall of prose</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Every review returns a letter grade, a verdict — APPROVE, APPROVE with reservations,
+			REQUEST_CHANGES, BLOCK, or UNKNOWN when the diff was too truncated to judge — and findings
+			carrying their own severity and confidence. The verdict is derived from the grade, then
+			clamped so it can never come out weaker than the findings' own severity floor already
+			requires. Token counts and an estimated cost ride along in the footer.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			UNKNOWN exists deliberately. A reviewer that cannot see enough to form an opinion should say
+			so, not approve.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Standards that live in the repo</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Drop a <code class="text-sm">.trusty-review.toml</code> at your repository root and every contributor
+			and CI run picks up the same review standards with no per-machine setup — a voice package, and optionally
+			a named template that appends extra scrutiny on top of the stock rubric. Template names are validated
+			as bare identifiers precisely because that file is attacker-controlled: any PR author can add one.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			A template only appends. It never replaces the grade scale, the verdict table, or the severity
+			anchors, so a project cannot quietly redefine what BLOCK means.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Due-diligence reports</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			<code class="text-sm">trusty-review report --manifest &lt;file&gt;</code> generates a structured
+			technical due-diligence report across one or more repositories: executive summary, per-application
+			scorecards, findings by severity, and graph-ready data appendices in Markdown and JSON.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			The default run is fully deterministic — measured from the checkouts themselves, no model
+			involved. <code class="text-sm">--synthesize</code> layers LLM prose over the summary and the non-healthy
+			findings only, and fails closed to the deterministic output rather than emit a partially-trusted
+			result. Every value carries a marker saying whether it was measured, declared, or inferred, and
+			a figure that appears nowhere in the underlying data is rejected before it can reach the page.
+		</p>
+	</div>
+</ToolPage>

--- a/website/src/routes/tools/trusty-search/+page.svelte
+++ b/website/src/routes/tools/trusty-search/+page.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+	import ToolPage from '$lib/components/ToolPage.svelte';
+	import { TOOLS } from '$lib/tools';
+
+	const tool = TOOLS.find((t) => t.slug === 'trusty-search')!;
+
+	const facts = [
+		{ label: 'Package', value: 'trusty-search' },
+		{ label: 'Default port', value: '7878' },
+		{ label: 'Languages parsed', value: '14 tree-sitter grammars' },
+		{ label: 'MCP tools', value: '21' }
+	];
+</script>
+
+<ToolPage {tool} {facts}>
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Three lanes, one ranking</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			A grep knows the token you typed. An embedding knows what you meant. A symbol graph knows what
+			calls what. trusty-search runs all three over the same corpus and merges them with Reciprocal
+			Rank Fusion, so a query lands whether you spelled the identifier right or only described it.
+		</p>
+		<ul class="mt-6 max-w-3xl space-y-3 text-foundry-secondary">
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Lexical.</span> A code-aware BM25 that
+					splits
+					<code class="text-sm">CodeIndexer</code>
+					into <code class="text-sm">code</code> and <code class="text-sm">indexer</code>, so a
+					half-remembered identifier still matches.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Vector.</span> An HNSW index over usearch, holding
+					384-dimension embeddings produced locally — no text leaves the machine to be indexed.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Graph.</span> A petgraph symbol graph built from
+					tree-sitter parses, walked one or two hops to pull in the callers and callees around a hit.</span
+				>
+			</li>
+		</ul>
+		<p class="mt-6 max-w-3xl text-foundry-secondary">
+			Fusion uses a fixed damping constant of 60 — there is no relevance dial to tune wrong.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">The query picks the weighting</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Asking for a definition and asking a conceptual question want opposite rankings. A
+			sub-millisecond regex classifier sorts every query into one of five intents and sets the
+			vector/lexical weights accordingly, before any search runs.
+		</p>
+		<div class="doc-table mt-6 max-w-2xl">
+			<table class="w-full border-collapse text-left text-sm">
+				<thead class="bg-foundry-card">
+					<tr>
+						<th class="border-b-[1.5px] border-foundry-border px-3 py-2 font-semibold">Intent</th>
+						<th class="border-b-[1.5px] border-foundry-border px-3 py-2 font-semibold">Vector</th>
+						<th class="border-b-[1.5px] border-foundry-border px-3 py-2 font-semibold">Lexical</th>
+						<th class="border-b-[1.5px] border-foundry-border px-3 py-2 font-semibold"
+							>Graph-first</th
+						>
+					</tr>
+				</thead>
+				<tbody class="font-mono">
+					<tr>
+						<td class="border-b border-foundry-border px-3 py-2">Definition</td>
+						<td class="border-b border-foundry-border px-3 py-2">0.3</td>
+						<td class="border-b border-foundry-border px-3 py-2">0.7</td>
+						<td class="border-b border-foundry-border px-3 py-2">—</td>
+					</tr>
+					<tr>
+						<td class="border-b border-foundry-border px-3 py-2">Usage</td>
+						<td class="border-b border-foundry-border px-3 py-2">0.5</td>
+						<td class="border-b border-foundry-border px-3 py-2">0.5</td>
+						<td class="border-b border-foundry-border px-3 py-2">yes</td>
+					</tr>
+					<tr>
+						<td class="border-b border-foundry-border px-3 py-2">Conceptual</td>
+						<td class="border-b border-foundry-border px-3 py-2">0.8</td>
+						<td class="border-b border-foundry-border px-3 py-2">0.2</td>
+						<td class="border-b border-foundry-border px-3 py-2">—</td>
+					</tr>
+					<tr>
+						<td class="border-b border-foundry-border px-3 py-2">Bug / debt</td>
+						<td class="border-b border-foundry-border px-3 py-2">0.1</td>
+						<td class="border-b border-foundry-border px-3 py-2">0.9</td>
+						<td class="border-b border-foundry-border px-3 py-2">—</td>
+					</tr>
+					<tr>
+						<td class="px-3 py-2">Unknown</td>
+						<td class="px-3 py-2">0.6</td>
+						<td class="px-3 py-2">0.4</td>
+						<td class="px-3 py-2">—</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Graph expansion is gated to Usage, where caller and callee chains are what you actually asked
+			for. Everywhere else it would just add noise.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">One daemon for the whole machine</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Install once, run one process, register as many named indexes as you have projects. Nothing is
+			per-project except the index itself, and re-running an index is cheap: content fingerprints
+			skip files that have not changed, so only the diff pays for embedding.
+		</p>
+		<ul class="mt-6 max-w-3xl space-y-2 text-foundry-secondary">
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					>Working on a branch? Pass it, and chunks from the files it touched get a 1.5× score
+					multiplier — every result reports whether it was boosted.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					>Don't need semantics? <code class="text-sm">--lexical-only</code> skips embedding entirely
+					and leaves you a daemonised BM25.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					>Don't need call chains? <code class="text-sm">--no-kg</code> skips the symbol-graph rebuild
+					on every reindex.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					>Memory limits — chunk caps, batch sizes, cache sizes — are computed from detected system
+					RAM at startup rather than guessed at compile time.</span
+				>
+			</li>
+		</ul>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Nothing is indexed until you say so</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			A fresh daemon accepts zero indexes. A path has to be added to the allowlist before it can be
+			registered, whether the request arrives over HTTP, from the CLI, or from an MCP tool call.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			On top of that sits a denylist that the allowlist cannot override: credential directories such
+			as <code class="text-sm">.ssh</code>, <code class="text-sm">.aws</code>,
+			<code class="text-sm">.gnupg</code>
+			and <code class="text-sm">.kube</code>, paths carrying secret markers, and the top level of
+			your home directory. Those are refused with the matched pattern named in the error, not
+			silently skipped.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">21 tools over MCP</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			The MCP server speaks stdio and HTTP/SSE and exposes each retrieval lane separately, so an
+			agent can pick the one that fits the question instead of always paying for the fused search.
+		</p>
+		<p class="mt-4 max-w-3xl font-mono text-sm text-foundry-secondary">
+			search · search_lexical · search_semantic · search_kg · search_all · search_similar ·
+			get_call_chain · grep · typeahead · index_file · remove_file · list_indexes · create_index ·
+			delete_index · reindex · index_status · list_chunks · search_health · chat · console_metrics ·
+			upgrade
+		</p>
+	</div>
+</ToolPage>

--- a/website/tests/build-smoke.test.ts
+++ b/website/tests/build-smoke.test.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
+import { TOOLS } from '../src/lib/tools';
 
 /**
  * Why: every other test here reads source files. None of them prove the site
@@ -40,6 +41,17 @@ function routeToArtifact(route: string): string {
 /** The Build Output API v3 config the adapter emitted. */
 function vercelConfig(): { overrides: Record<string, { path: string }>; routes: unknown[] } {
 	return JSON.parse(readFileSync(path.join(OUTPUT, 'config.json'), 'utf8'));
+}
+
+/**
+ * The hand-authored `/tools/<slug>` pages, as emitted static files.
+ *
+ * `docPages()` below is manifest-driven, so it cannot see these — they are
+ * routes, not documentation. Without this the self-containment assertion
+ * would silently skip every flagship page.
+ */
+function toolPages(): string[] {
+	return TOOLS.map((tool) => `tools/${tool.slug}.html`);
 }
 
 /** Prerendered doc artifacts on disk, as paths relative to the static root. */
@@ -140,8 +152,14 @@ describe('production build', () => {
 	// this list is still empty rather than carrying an exception — the assertion
 	// below is deliberately unchanged. The runtime half is pinned by
 	// 'wires analytics to a first-party path…' underneath.
+	it('prerenders every flagship tool page to static HTML', () => {
+		for (const name of toolPages()) {
+			expect(existsSync(path.join(STATIC, name)), name).toBe(true);
+		}
+	});
+
 	it('loads no subresource from a third-party origin', () => {
-		for (const name of ['index.html', 'docs.html', ...docPages()]) {
+		for (const name of ['index.html', 'docs.html', ...docPages(), ...toolPages()]) {
 			const html = readFileSync(path.join(STATIC, name), 'utf8');
 			const subresources = [
 				...html.matchAll(/<(?:script|img|source|iframe)\b[^>]*\bsrc="([^"]+)"/g),
@@ -192,8 +210,11 @@ describe('production build', () => {
 
 	it('renders real landing-page content, not a shell', () => {
 		expect(landingPage).toContain('trusty-search');
-		expect(landingPage).toContain('Three flagship MCP servers');
+		expect(landingPage).toContain('Six flagship tools');
 		expect(landingPage).toContain('brew tap bobmatnyc/trusty');
+		for (const tool of TOOLS) {
+			expect(landingPage, tool.slug).toContain(`/tools/${tool.slug}`);
+		}
 	});
 
 	it('sets the theme class before first paint', () => {


### PR DESCRIPTION
Six flagship crates each get a dedicated page, and the homepage links them.

## Pages

New hand-authored routes under `/tools/<crate>`: trusty-search, trusty-memory, trusty-mpm, trusty-analyze, trusty-review, trusty-git-analytics.

These are NOT doc-reader pages. `docs/public-manifest.tsv` is untouched, and the existing doc-index stubs still serve at `/docs/tools/<crate>` — one path segment away, no collision. Verified live: both `/tools/trusty-mpm` and `/docs/tools/trusty-mpm` return 200.

## Copy is derived from each crate's README, then verified against source

Thirteen README claims did not survive verification and were dropped rather than published. The most consequential:

| Crate | Claim | Source says |
|---|---|---|
| trusty-search | `TRUSTY_ALLOW_UNLISTED=1` operator bypass | Appears only in a test comment. No production read. (#5145) |
| trusty-search | MCP tool `search_code` | Not in `mcp/tools/descriptors.rs`. (#5138) |
| trusty-search | "18 tools" in `src/mcp/tools.rs` | 21 tools; that path is a directory |
| trusty-memory | "25 tools" (and "30" in the same file's diagram) | `tool_definitions_lists_all_tools` asserts **45** |
| trusty-memory | Architecture diagram shows a Unix domain socket bridge | Contradicted by the same README's own prose |
| trusty-review | `report --repo <path>` | `ReportArgs` has required `manifest`, no `repo` |
| trusty-analyze | Quick Start `trusty-search daemon` | No `daemon` variant in trusty-search's `Commands` |
| tga | `cargo install trusty-git-analytics` | Package is `tga` |

A unit test now bans the retired strings (`trusty-mpmd`, `trusty-mpm-tui`, `trusty-mpm-telegram`, `open-mpm`, `search_code`, `TRUSTY_ALLOW_UNLISTED`, `trusty-memory-core`) from page copy, and `tools.ts` values are re-derived from the repo rather than hardcoded.

**The READMEs themselves are not fixed here** — that is separable work.

## Homepage

- "Three flagship MCP servers" → six, each card linked to its page. The six are not all MCP servers; the heading no longer claims they are.
- The seven-repos origin-story sentence is gone, per owner instruction ("not necessary. This is a new project."). Same sentence removed from `README.md:286`. `docs/reference/former-repos.md` and ADR-0014 keep the history — they are records, not positioning.
- The crate lineup now shows **secondary** and **in-development** crates. `trusty-cto-db` removed per owner instruction; shared libraries, sidecars, and `publish = false` internals omitted. Placement was decided from crates.io presence and git tags, not from crate names.
- No crate count appears anywhere — root README says 21 while `crates/` holds 27 directories, so any number ships one of two wrong answers.

## Self-containment coverage was extended, not weakened

The `'loads no subresource from a third-party origin'` assertion is unchanged. Its loop previously walked only `index.html`, `docs.html`, and the manifest-driven doc pages — a hand-authored `/tools/*` page was invisible to it. Added `toolPages()` and spread it into that array.

Proven real, not assumed. Injecting `<img src="https://cdn.example.com/probe.png">` into the trusty-review page:

```
× loads no subresource from a third-party origin
AssertionError: tools/trusty-review.html loads https://cdn.example.com/probe.png:
  expected [ 'https://cdn.example.com/probe.png' ] to deeply equal []
```

Probe reverted; the suite below is post-revert.

## Gates — rung 6 (UI surface)

```
pnpm install → EXIT=0
pnpm build   → EXIT=0    Using @sveltejs/adapter-vercel ✔ done
pnpm lint    → EXIT=0    All matched files use Prettier code style!
pnpm check   → EXIT=0    469 FILES 0 ERRORS 0 WARNINGS
pnpm test    → EXIT=0    Test Files 11 passed (11) / Tests 167 passed (167)

changelog-fragment gate: scanned 13 changed path(s); no crate source changed — OK.
sld-lint: 56 spec doc(s) + 3143 code file(s); 0 error(s), 0 warning(s)
public-docs gate: 27 page(s) across 5 section(s) — all resolve inside the public boundary.
```

Doc reader still publishes 27 pages. All six `/tools/*` routes return 200 on a dev server.

## Note

Touches `website/tests/build-smoke.test.ts`, as does #5189 (Vercel Analytics). Both edits are additive and in different parts of the file; whichever merges second needs a trivial rebase.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools