### PR TITLE
docs: correct trusty-memory storage claims — redb not SQLite, hnsw_rs not usearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [crates/trusty-search/README.md](crates/trusty-search/README.md) for full do
 Long-term memory storage with semantic search, persistent embedding index, and embedded Svelte UI. Store development context, notes, snippets, and retrieve them via natural language.
 
 **What you get:**
-- HNSW vector index (usearch) + SQLite persistent storage + fastembed embeddings
+- Pure-Rust HNSW vector index (`hnsw_rs`) persisted in `redb` + fastembed embeddings
 - Semantic search over all stored memories
 - Collection organization (notes, snippets, code patterns, decisions)
 - Svelte UI for browsing and editing

--- a/crates/trusty-common/README.md
+++ b/crates/trusty-common/README.md
@@ -46,7 +46,7 @@ trusty-common = { version = "0.8", features = ["axum-server", "mcp", "rpc", "emb
 | `symgraph-server` | HTTP server frontend for the symbol graph (implies `symgraph-parser`) |
 | `bm25` | Zero-dependency BM25 lexical index + code-aware tokenizer (issue #156) |
 | `bm25-client` | UDS JSON-RPC client for the per-palace `trusty-bm25-daemon` subprocess |
-| `memory-core` | Memory Palace storage engine — HNSW (usearch), SQLite metadata + KG, dream cycle (formerly `trusty-memory-core`) |
+| `memory-core` | Memory Palace storage engine — HNSW (`hnsw_rs`), redb metadata + KG, dream cycle (formerly `trusty-memory-core`) |
 | `memory-core-kuzu` | Read-only Kùzu graph-DB integration on top of `memory-core` |
 | `tickets` | Unified ticketing MCP server (GitHub / JIRA / Linear backends; formerly `trusty-tickets`) |
 | `monitor-tui` | ratatui + crossterm dashboard TUI for the trusty-search/trusty-memory daemons (formerly `trusty-monitor-tui`) |

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -3,7 +3,7 @@
 [![crates.io](https://img.shields.io/crates/v/trusty-memory.svg)](https://crates.io/crates/trusty-memory)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Memory palace MCP server (HTTP/SSE) backed by `usearch` (HNSW) vector store,
+Memory palace MCP server (HTTP/SSE) backed by `hnsw_rs` (HNSW) vector store,
 `redb` metadata and knowledge-graph stores, and `fastembed` embeddings. Stores
 and retrieves natural-language memories organized into named "palaces"
 (namespaces), with an optional knowledge-graph layer for structured triples.
@@ -26,7 +26,7 @@ long-term memory backend.
 ## System Requirements
 
 - **RAM**: 512 MB minimum; 1 GB+ recommended (ONNX embedding model loads ~22 MB,
-  usearch index scales with corpus size)
+  hnsw_rs index scales with corpus size)
 - **Disk**: ~100 MB for the model cache on first run
   (`~/Library/Application Support/trusty-memory/` on macOS,
   `~/.local/share/trusty-memory/` on Linux)
@@ -581,7 +581,7 @@ Memories and vector indexes persist under the OS-standard data directory:
 
 Each palace directory contains:
 - `kg.redb` — redb store for drawer metadata and knowledge-graph triples
-- `index.usearch` — usearch vector index (approximate nearest-neighbour)
+- `index.usearch` — HNSW vector index (`hnsw_rs`, approximate nearest-neighbour)
 - `recall.redb` — recall analytics log (redb; migrated from `recall.db` on first open)
 - `l1_cache.json` — top-15 drawers by importance (L1 hot cache, rebuilt at each write)
 - `palace.json` — palace metadata (name, description, created_at)
@@ -591,7 +591,7 @@ Each palace directory contains:
 ```
 trusty-memory (this crate)          trusty-common `memory-core` feature
   axum HTTP/SSE server     ──────►  PalaceRegistry
-  serve --stdio (JSON-RPC) ──────►  usearch vector index (index.usearch)
+  serve --stdio (JSON-RPC) ──────►  HNSW vector index (index.usearch)
   embedded Svelte UI               redb metadata + KG (kg.redb)
   MCP tool surface                 fastembed (AllMiniLML6V2Q)
 
@@ -599,7 +599,7 @@ Claude Code stdio ◄──JSON-RPC──► `trusty-memory serve --stdio`
                                   ──POST /rpc (HTTP)──► trusty-memory daemon
 ```
 
-The `memory-core` feature of `trusty-common` owns the storage engine: `usearch` for approximate
+The `memory-core` feature of `trusty-common` owns the storage engine: `hnsw_rs` for approximate
 nearest-neighbor search, `redb` for drawer metadata and knowledge-graph triples, and
 `fastembed` for 384-dim text embeddings. The MCP server (`trusty-memory`) is a
 thin protocol layer on top.


### PR DESCRIPTION
## The error

Docs described trusty-memory as an "HNSW vector index over SQLite." Both nouns are wrong as of `origin/main`.

- **Store is `redb`, not SQLite.** `crates/trusty-common/src/memory_core/store/kg_redb/` and `store/redb_open.rs` implement the KG, chat-session, payload, and analytics stores on `redb::Database`; `redb` is declared under the `memory-core` feature. SQLite was removed under issues #44–#57 and #989 — every remaining SQLite mention inside `memory_core` is a doc comment describing the pre-migration legacy, and `migrate_from_sqlite_if_needed` is now a documented no-op.
- **HNSW implementation is the pure-Rust `hnsw_rs` crate, not `usearch`.** `crates/trusty-common/src/memory_core/store/hnsw_store.rs` uses `hnsw_rs::prelude::{DistCosine, Hnsw}`; the C++ `usearch` FFI was replaced in issue #50 Phase 3 to enable pure-Rust cross-compiles. `usearch` still exists in the workspace, but only for `trusty-search` and `trusty-agents` — those mentions are correct and untouched.
- Vectors persist as postcard-encoded `Vec<f32>` in a redb `VECTORS` table (`crates/trusty-common/src/memory_core/store/kg_store.rs:159`); the in-memory `hnsw_rs` graph rebuilds from that table when a palace opens.
- Lexical search is separate: a per-palace `trusty-bm25-daemon` subprocess reached over UDS.

## The three fixes

1. `README.md` — "HNSW vector index (usearch) + SQLite persistent storage + fastembed embeddings" → "Pure-Rust HNSW vector index (`hnsw_rs`) persisted in `redb` + fastembed embeddings"
2. `crates/trusty-common/README.md` — `memory-core` feature table row: "HNSW (usearch), SQLite metadata + KG" → "HNSW (`hnsw_rs`), redb metadata + KG"
3. `crates/trusty-memory/README.md` — the `redb` references were already correct and are unchanged. Fixed every remaining `usearch`-as-technology mention: the intro line, the RAM sizing note, the data-directory listing, the architecture diagram, and the closing storage-engine paragraph. Left `~/.claude-mpm/messaging.db` (a different, legacy Python subsystem) and the literal `index.usearch` path token alone — that logical filename is still what the code translates to `<path>.redb` internally (`crates/trusty-common/src/memory_core/store/vector.rs:296`), so it's a real on-disk artifact name, not a technology claim.

Also grepped `README.md` and both crate READMEs for every other `SQLite`/`sqlite`/`usearch` occurrence. Two are correct and untouched: `README.md`'s `trusty-cto-db` row (real SQLite + rusqlite for ops data) and `crates/trusty-memory/README.md`'s note on the retired claude-mpm `/mpm-message` skill, which really did write to a process-local SQLite file before migration.

## Why this keeps recurring

This exact error was fixed once before — `crates/trusty-memory/CHANGELOG.md:114` and `crates/trusty-common/CHANGELOG.md:428` log [PR #1704](https://github.com/bobmatnyc/trusty-tools/pull/1704), "correct stale SQLite references to redb in comments and README" — and drifted back. Two reasons, still true after this PR:

- The type is still named `UsearchStore` (`crates/trusty-common/src/memory_core/store/vector.rs:229`), preserved as a public API name while it now wraps `HnswStore` internally. Anyone reading the code to write docs will faithfully copy the wrong word.
- `trusty-common` really does depend on `rusqlite`, under the `catchup` feature, for claude-mpm's session registry (`~/.claude-mpm/session-registry.db`) — a different subsystem that sits close enough in the same crate to cause exactly this confusion.

Neither is touched in this PR — docs-only, no Rust source changes, no renames.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
