### PR TITLE
fix(trusty-memory): stop injecting provenance tags and cap the rendered tag budget

### DIFF
--- a/crates/trusty-memory/changelog.d/5038-injected-tag-render.md
+++ b/crates/trusty-memory/changelog.d/5038-injected-tag-render.md
@@ -1,0 +1,21 @@
+Fixed
+
+- **The injected drawer preview no longer renders storage provenance or an
+  uncapped tag list (closes [#5038](https://github.com/bobmatnyc/trusty-tools/issues/5038)).**
+  `compose_injection` walked every tag on every recalled drawer, so
+  `creator:client`, `creator:version`, `creator:source` and `creator:cwd` — the
+  last a ~90-character absolute path — rendered on each of ~12 drawers per
+  firing, alongside a median 17-tag topical list. Measured over 17,176 real
+  firings in the enriched-prompt log, the `_(tags: …)_` suffix was **53.0% of
+  every byte the hook injected**, outweighing the content preview it labels on
+  82.3% of drawers. `INJECTION_BYTE_CAP` never fixed that — it only meant the
+  noise evicted real drawers instead of growing the block. Rendering now drops
+  the `creator:*` namespace (via `attribution::is_creator_tag`, the predicate the
+  TUI and dashboard already hide those tags with) and caps the rest at 4 with a
+  `+N more` marker, returning 40.1% of the injection to content. The tags are
+  untouched in storage and still returned by `memory_list` / `memory_recall`.
+- The rendered tag suffix is now bounded in characters as well as count. The
+  4-tag cap was argued from "a label must never outweigh the payload it labels"
+  (220 characters) but enforced only a count, and four long hyphenated tags —
+  `slate-prioritization-in-flight` and friends, both real tags from the live
+  palace — exceed that budget while satisfying the cap.

--- a/crates/trusty-memory/src/commands/prompt_context/format.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/format.rs
@@ -3,12 +3,63 @@
 //! Why: separating the Markdown rendering logic from the fetch and filter
 //! layers keeps each piece independently readable and testable.
 //! What: exports `compose_injection`, `push_section`, `drawer_preview`,
-//! `count_facts`.
+//! `render_tags`, `count_facts`.
 //! Test: `compose_injection_truncates_at_cap`,
 //! `compose_injection_empty_inputs_yields_empty`.
 
 use super::filter::{RawTriple, RecalledDrawer};
 use super::{DRAWER_PREVIEW_CHARS, INJECTION_BYTE_CAP};
+
+/// Most tags rendered on one drawer's injected preview.
+///
+/// Why (issue #5038): tags were rendered in full, uncapped. Over the same
+/// 17,176-firing corpus the `_(tags: …)_` suffix is **53.0% of every byte the
+/// hook injects** (24.9 MB of 47.0 MB) — the label outweighs the content it
+/// labels on 82.3% of drawers, at a mean 333 bytes of tags against 220 bytes of
+/// preview. [`INJECTION_BYTE_CAP`] does not fix that; it just means the noise
+/// evicts real drawers instead of growing the block.
+/// What: `4`. The rule is that a label must never outweigh its payload, so the
+/// cap is the largest one whose *worst observed* tag block stays clear of
+/// [`DRAWER_PREVIEW_CHARS`] (220). Per-drawer tag-block bytes after provenance
+/// filtering, over the corpus:
+///
+/// | cap | p50 | p95 | max |
+/// |---|---|---|---|
+/// | none | 208 | 382 | 903 |
+/// | 6 | 112 | 150 | 244 — over the content budget |
+/// | 5 | 98 | 127 | 204 — 93% of it, effectively equal weight |
+/// | **4** | **82** | **104** | **174** |
+/// | 3 | 67 | 84 | 159 |
+///
+/// Combined with the provenance filter this returns 40.1% of the total
+/// injection to content. Tags are not dropped entirely — they orient a model
+/// that has only a 220-character preview to go on — but the surplus is
+/// announced (`+N more`) rather than rendered, matching the withheld-signal
+/// rule the #5037 ruling sets for drawers.
+///
+/// The count alone does not enforce the rule it is argued from: four 55-char
+/// tags exceed 220 characters, and no cap on *how many* can prevent that.
+/// [`MAX_RENDERED_TAG_CHARS`] enforces the byte side directly; this constant is
+/// the common-case cap, that one is the guarantee (#5038 review).
+/// Test: `injection_caps_rendered_tag_count`.
+pub(super) const MAX_RENDERED_TAGS: usize = 4;
+
+/// Hard character ceiling on one drawer's rendered tag suffix.
+///
+/// Why (#5038 review): [`MAX_RENDERED_TAGS`] is justified by "a label must never
+/// outweigh the payload it labels" but enforces a count, which is only a proxy.
+/// Tag length is not bounded anywhere — a palace using long hyphenated tags
+/// (`slate-prioritization-in-flight`, `trusty-search-reinstall-in-flight`, both
+/// real tags from the corpus) blows the budget at four. This makes the stated
+/// rule the actual invariant rather than an argument for a different one.
+/// What: [`DRAWER_PREVIEW_CHARS`] — the same budget the content preview gets, so
+/// the label can at most equal its payload, never exceed it. Measured in
+/// characters, matching how `DRAWER_PREVIEW_CHARS` measures the content. One
+/// exception, deliberate: a *single* tag longer than the whole budget still
+/// renders whole, because a suffix reading only `_(tags: +1 more)_` tells the
+/// model strictly less than the tag would.
+/// Test: `injection_caps_rendered_tag_bytes`.
+pub(super) const MAX_RENDERED_TAG_CHARS: usize = DRAWER_PREVIEW_CHARS;
 
 /// Compose the final injection block.
 ///
@@ -46,17 +97,9 @@ pub(super) fn compose_injection(
         for d in drawers {
             section.push_str("- ");
             section.push_str(&drawer_preview(&d.content));
-            if !d.tags.is_empty() {
-                section.push_str("  _(tags: ");
-                let tags = d
-                    .tags
-                    .iter()
-                    .map(|t| format!("`{t}`"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
+            // #5038: the tag list used to render whole and unfiltered here.
+            if let Some(tags) = render_tags(&d.tags) {
                 section.push_str(&tags);
-                section.push(')');
-                section.push('_');
             }
             section.push('\n');
         }
@@ -120,6 +163,66 @@ pub(super) fn withheld_notice(withheld: usize, nothing_kept: bool) -> String {
              call `memory_recall` for the full ranked set.)_"
         )
     }
+}
+
+/// Render a drawer's tag suffix, filtered and capped.
+///
+/// Why (issue #5038): the previous inline render walked `d.tags` in full with
+/// no filter and no count cap, so storage provenance and a 20-tag topical list
+/// took more of the injection than the drawer content did. `memory_remember`
+/// stamps every drawer with `creator:client`, `creator:version`,
+/// `creator:source` and `creator:cwd` — the last an absolute path, ~90
+/// characters, repeated on every drawer of every firing. Over 17,176 real
+/// firings in the enriched-prompt log those are 24.2% of rendered tags but
+/// **33.4% of rendered tag bytes**, and on 2.8% of drawers they are the entire
+/// list, producing a `_(tags: …)_` suffix made of nothing but paths and version
+/// numbers. See [`MAX_RENDERED_TAGS`] for the count-cap half.
+/// What: drops the `creator:*` namespace via
+/// [`crate::attribution::is_creator_tag`] — the same predicate the TUI and
+/// dashboard renderers already hide those tags with — keeps at most
+/// [`MAX_RENDERED_TAGS`] of the rest in stored order, and appends `+N more`
+/// when any were held back so the surplus is announced rather than hidden.
+/// Returns `None` (no suffix at all) when nothing survives, the common case for
+/// a drawer whose only tags were provenance. Filtering is render-time only; the
+/// tags stay in storage and stay queryable through `memory_list` /
+/// `memory_recall`.
+/// Test: `injection_drops_provenance_tags`, `injection_caps_rendered_tag_count`,
+/// `injection_caps_rendered_tag_bytes`,
+/// `prompt_context_injection_has_no_provenance_tags`.
+pub(super) fn render_tags(tags: &[String]) -> Option<String> {
+    let topical: Vec<&String> = tags
+        .iter()
+        .filter(|t| !crate::attribution::is_creator_tag(t))
+        .collect();
+    if topical.is_empty() {
+        return None;
+    }
+    // Room the `+N more` marker and the `)_` close will need. Reserving it up
+    // front is what keeps the *finished* suffix inside the budget, rather than
+    // only the part written before the marker.
+    const TRAILER_RESERVE: usize = ", +99 more)_".len();
+    let mut out = String::from("  _(tags: ");
+    let mut shown = 0usize;
+    for tag in &topical {
+        // `, ` separator (after the first) + two backticks + the tag itself.
+        let width = usize::from(shown > 0) * 2 + 2 + tag.chars().count();
+        let projected = out.chars().count() + width + TRAILER_RESERVE;
+        if shown == MAX_RENDERED_TAGS || (shown > 0 && projected > MAX_RENDERED_TAG_CHARS) {
+            break;
+        }
+        if shown > 0 {
+            out.push_str(", ");
+        }
+        out.push('`');
+        out.push_str(tag);
+        out.push('`');
+        shown += 1;
+    }
+    if let Some(hidden) = topical.len().checked_sub(shown).filter(|n| *n > 0) {
+        out.push_str(&format!(", +{hidden} more"));
+    }
+    out.push_str(")_");
+    Some(out)
 }
 
 /// Append `section` to `out` separated by a blank line when `out`

--- a/crates/trusty-memory/src/commands/prompt_context/tests.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/tests.rs
@@ -1200,3 +1200,242 @@ async fn handle_prompt_context_fails_open_on_slow_daemon() {
          (a stalled daemon must never make the hook wait out its own timeout)"
     );
 }
+
+/// Why (issue #5038, symptom 1): `memory_remember` stamps every drawer with the
+/// reserved `creator:*` namespace — `creator:cwd` alone is a ~90-character
+/// absolute path — and the injection rendered all of it. Over 17,176 real
+/// firings those tags are 33.4% of every tag byte injected. They tell a model
+/// nothing about what the drawer says.
+/// What: a drawer carrying provenance tags among topical ones through
+/// `render_tags`; asserts no `creator:` survives and the topical tags do.
+/// Test: itself.
+#[test]
+fn injection_drops_provenance_tags() {
+    use format::render_tags;
+    let tags: Vec<String> = [
+        "rust",
+        "creator:client=trusty-memory-mcp",
+        "tokio",
+        "creator:version=0.21.2",
+        "creator:source=mcp",
+        "creator:cwd=/Users/masa/trusty-mpm-projects/bobmatnyc/trusty-tools/.base",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    let rendered = render_tags(&tags).expect("topical tags must still render");
+    assert!(
+        !rendered.contains("creator:"),
+        "provenance must not reach the injection; got: {rendered}"
+    );
+    assert!(
+        rendered.contains("`rust`") && rendered.contains("`tokio`"),
+        "topical tags must survive; got: {rendered}"
+    );
+
+    // A drawer whose only tags are provenance renders no suffix at all — 2.8%
+    // of drawers in the corpus were exactly this shape.
+    let only_provenance: Vec<String> = tags
+        .iter()
+        .filter(|t| t.starts_with("creator:"))
+        .cloned()
+        .collect();
+    assert_eq!(
+        render_tags(&only_provenance),
+        None,
+        "an all-provenance tag list must render nothing, not an empty suffix"
+    );
+}
+
+/// Why (issue #5038, symptom 2): tag lists rendered in full, uncapped — the
+/// median drawer carried 17 tags and the `_(tags: …)_` suffix was 53.0% of
+/// every byte the hook injected, outweighing the content preview it labels on
+/// 82.3% of drawers.
+/// What: a 12-tag drawer through `render_tags`; asserts exactly
+/// `MAX_RENDERED_TAGS` render, the surplus is announced rather than dropped
+/// silently, and the whole suffix stays under the content budget the cap was
+/// chosen against.
+/// Test: itself.
+#[test]
+fn injection_caps_rendered_tag_count() {
+    use format::{render_tags, MAX_RENDERED_TAGS};
+    // Realistic tag lengths, not `topic-N`. These are the shapes the live
+    // palace actually stores — the 7-character fixture this test used to carry
+    // could not have caught the byte-budget hole the #5038 review found.
+    let tags: Vec<String> = [
+        "slate-prioritization-in-flight",
+        "trusty-search-reinstall-in-flight",
+        "standing-instruction",
+        "session-2eb72dca",
+        "resume-target",
+        "issue-2833",
+        "bob-decision",
+        "trusty-mpm",
+        "status",
+        "kg",
+        "redb",
+        "python",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    let rendered = render_tags(&tags).expect("tags must render");
+    let shown = rendered.matches('`').count() / 2;
+    assert!(
+        shown <= MAX_RENDERED_TAGS,
+        "at most MAX_RENDERED_TAGS tags may render; got {shown}: {rendered}"
+    );
+    assert!(
+        rendered.contains(&format!("+{} more", tags.len() - shown)),
+        "held-back tags must be announced, not dropped silently; got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("python"),
+        "the tail of the tag list must not render; got: {rendered}"
+    );
+}
+
+/// Why (#5038 review): `MAX_RENDERED_TAGS` is argued from "a label must never
+/// outweigh the payload it labels" but enforces a *count*, and a count cannot
+/// bound bytes — four 55-character tags blow a 220-character budget while
+/// satisfying the cap. The old test used 7-character `topic-N` fixtures, so its
+/// length assertion could never fail no matter how wrong the cap was.
+/// What: four tags of 55 characters each — well inside the count cap, well past
+/// the char budget. Asserts the rendered suffix stays within
+/// `MAX_RENDERED_TAG_CHARS`, that fewer than the count cap render as a result,
+/// and that the ones dropped for length are still announced.
+/// Test: itself.
+#[test]
+fn injection_caps_rendered_tag_bytes() {
+    use format::{render_tags, MAX_RENDERED_TAGS, MAX_RENDERED_TAG_CHARS};
+    const TAG_CHARS: usize = 55;
+    let long: Vec<String> = (0..4)
+        .map(|i| {
+            let stem = format!("workstream-{i}-");
+            format!("{stem}{}", "x".repeat(TAG_CHARS - stem.chars().count()))
+        })
+        .collect();
+    assert_eq!(
+        long[0].chars().count(),
+        TAG_CHARS,
+        "fixture must be 55 chars"
+    );
+    let rendered = render_tags(&long).expect("tags must render");
+    assert!(
+        rendered.chars().count() <= MAX_RENDERED_TAG_CHARS,
+        "the tag label must stay inside its {MAX_RENDERED_TAG_CHARS}-char budget; \
+         got {} chars: {rendered}",
+        rendered.chars().count()
+    );
+    let shown = rendered.matches('`').count() / 2;
+    assert!(
+        shown < MAX_RENDERED_TAGS,
+        "with 55-char tags the byte budget must bind before the count cap; \
+         got {shown} tags: {rendered}"
+    );
+    assert!(
+        rendered.contains(&format!("+{} more", long.len() - shown)),
+        "tags held back for length must be announced too; got: {rendered}"
+    );
+
+    // The deliberate exception: one tag longer than the whole budget still
+    // renders, because `_(tags: +1 more)_` communicates strictly less.
+    let huge = vec![format!("w-{}", "y".repeat(400))];
+    let rendered = render_tags(&huge).expect("a single oversized tag still renders");
+    assert!(
+        rendered.contains(&huge[0]),
+        "the lone tag must survive whole"
+    );
+}
+
+/// Why (issue #5038, end to end): the unit tests above pin `render_tags` in
+/// isolation. This one proves the whole chain — real MCP write path stamping
+/// `creator:*`, real HTTP recall, real composition — never puts provenance or
+/// an uncapped tag list into what Claude Code actually receives.
+/// What: seeds a palace through `memory_remember` (which attaches the
+/// attribution namespace exactly as production does) with drawers carrying more
+/// topical tags than the cap, recalls with a matching prompt, and asserts the
+/// rendered injection carries no `creator:` and no bullet over the cap.
+/// Test: itself.
+/// Note (issue #226): gated on `axum-server`; spins up the HTTP daemon.
+#[cfg(feature = "axum-server")]
+#[tokio::test]
+async fn prompt_context_injection_has_no_provenance_tags() {
+    use format::MAX_RENDERED_TAGS;
+    let _guard = crate::commands::env_test_lock().lock().await;
+    unsafe {
+        std::env::remove_var(ENV_MIN_SCORE);
+        std::env::remove_var(ENV_RECALL_DENY_TAGS);
+    }
+    let (state, _data_dir_tmp, _project_dir_tmp, project_dir, slug, addr_handle) =
+        spin_up_test_daemon_with_palace("prompt-ctx-tag-render").await;
+
+    for (text, tags) in [
+        (
+            "Rust integration uses tokio for async tasks and serde for JSON encoding",
+            vec![
+                "rust", "tokio", "serde", "async", "json", "encoding", "runtime", "crate",
+            ],
+        ),
+        (
+            "Rust error handling prefers thiserror in libraries and anyhow in binaries",
+            vec![
+                "rust",
+                "thiserror",
+                "anyhow",
+                "errors",
+                "libraries",
+                "binaries",
+                "convention",
+            ],
+        ),
+    ] {
+        let tags_json: Vec<serde_json::Value> = tags.iter().map(|t| json!(t)).collect();
+        let _ = crate::tools::dispatch_tool(
+            &state,
+            "memory_remember",
+            json!({
+                "palace": slug,
+                "text": text,
+                "room": "General",
+                "tags": tags_json,
+            }),
+        )
+        .await
+        .expect("memory_remember");
+    }
+
+    let payload = json!({
+        "hook_event_name": "UserPromptSubmit",
+        "cwd": project_dir.to_string_lossy(),
+        "prompt": "how does rust integration work with tokio and serde?"
+    })
+    .to_string();
+    let body = build_injection_body(&payload).await;
+
+    assert_ne!(
+        body, EMPTY_PLACEHOLDER,
+        "fixture must actually recall something for this test to mean anything"
+    );
+    assert!(
+        body.contains("_(tags:"),
+        "fixture must render a tag suffix for this test to mean anything; got:\n{body}"
+    );
+    assert!(
+        !body.contains("creator:"),
+        "no provenance tag may reach the injection; got:\n{body}"
+    );
+    for bullet in body.lines().filter(|l| l.contains("_(tags:")) {
+        let shown = bullet
+            .split("_(tags:")
+            .nth(1)
+            .map(|suffix| suffix.matches('`').count() / 2)
+            .unwrap_or(0);
+        assert!(
+            shown <= MAX_RENDERED_TAGS,
+            "bullet renders {shown} tags, over the cap of {MAX_RENDERED_TAGS}: {bullet}"
+        );
+    }
+
+    addr_handle.shutdown().await;
+}


### PR DESCRIPTION
Closes https://github.com/bobmatnyc/trusty-tools/issues/5038

Split out of [#5183](https://github.com/bobmatnyc/trusty-tools/pull/5183), which keeps the [#4972](https://github.com/bobmatnyc/trusty-tools/issues/4972) query-shaping half. The two halves shared a PR because they share a module; the owner ruled them apart because they do not share a risk profile. This half has drawn **zero findings across two independent critic rounds**; the other carries every outstanding HIGH and MEDIUM. It should not stay hostage to the hard one.

Branched fresh off `origin/main`. The diff touches `format.rs` and its tests only — no `query.rs`, no estimator, no envelope stripping, no packing, no `prompt_log/` change.

## Defect

`compose_injection` walked `d.tags` in full with no filter and no cap. `drawer_preview` capped the *content* at `DRAWER_PREVIEW_CHARS`; nothing capped tags.

Measured over the 74,868 drawer bullets in 17,176 real firings logged at `~/Library/Application Support/trusty-memory/logs/enriched-prompts.*.jsonl`:

| | |
|---|---|
| `_(tags: …)_` share of every injected byte | **53.0%** (24.9 MB of 47.0 MB) |
| Mean tag block vs. mean content preview, per drawer | **333 B vs. 220 B** |
| Drawers where tags outweigh their own content | **82.3%** |
| Tags per drawer | p50 17, p95 25, max 43 |
| Provenance (`creator:*`) share of tag *bytes* | **33.4%** (24.2% of tags — `creator:cwd` is a ~90-char path) |
| Drawers whose entire tag list is provenance | 2.8% |

`INJECTION_BYTE_CAP` was never the fix: it only meant the noise evicted real drawers instead of growing the block.

## Resolution

**Provenance filter.** Drops the `creator:*` namespace through `attribution::is_creator_tag` — the existing predicate whose doc says "a single predicate keeps every renderer in lock-step", already used by the TUI and dashboard to hide these tags. The injection is a render path, so it routes through the same one rather than adding a second. Render-time only; tags stay in storage and in `memory_list` / `memory_recall`.

**Two caps, both enforced.** The rule is *a label must never outweigh the payload it labels*, and the payload budget is `DRAWER_PREVIEW_CHARS = 220`.

`MAX_RENDERED_TAGS = 4` is the common case. Per-drawer tag-block bytes after provenance filtering:

| cap | p50 | p95 | max |
|---|---|---|---|
| none | 208 | 382 | 903 |
| 6 | 112 | 150 | 244 — over the content budget |
| 5 | 98 | 127 | 204 — 93% of it, effectively equal weight |
| **4** | **82** | **104** | **174** |
| 3 | 67 | 84 | 159 |

4 is the largest cap whose *worst observed* block stays clear of 220.

`MAX_RENDERED_TAG_CHARS = 220` is the guarantee. A count cannot bound length — four 55-character tags render 246 characters while satisfying the count cap, and tag length is bounded nowhere. This makes the stated rule the actual invariant instead of an argument for a different one. One deliberate exception: a single tag longer than the whole budget still renders whole, because `_(tags: +1 more)_` tells the model strictly less than the tag does.

Whatever either cap holds back is announced as `+N more`, matching the withheld-signal rule the [#5037](https://github.com/bobmatnyc/trusty-tools/issues/5037) ruling sets for drawers.

Combined effect: **40.1% of the injection returned to content.**

## Red before green

Reverted `render_tags` to the pre-fix shape (every tag, unfiltered, uncapped) on this branch, test file untouched. All four fail:

```
running 4 tests
test injection_caps_rendered_tag_count ... FAILED
test injection_caps_rendered_tag_bytes ... FAILED
test injection_drops_provenance_tags ... FAILED
test prompt_context_injection_has_no_provenance_tags ... FAILED

---- injection_drops_provenance_tags ----
provenance must not reach the injection; got:   _(tags: `rust`,
`creator:client=trusty-memory-mcp`, `tokio`, `creator:version=0.21.2`,
`creator:source=mcp`, `creator:cwd=/Users/masa/trusty-mpm-projects/…/.base`)_

---- injection_caps_rendered_tag_count ----
at most MAX_RENDERED_TAGS tags may render; got 12:   _(tags:
`slate-prioritization-in-flight`, `trusty-search-reinstall-in-flight`,
`standing-instruction`, `session-2eb72dca`, `resume-target`, `issue-2833`,
`bob-decision`, `trusty-mpm`, `status`, `kg`, `redb`, `python`)_

---- injection_caps_rendered_tag_bytes ----
the tag label must stay inside its 220-char budget; got 246 chars

---- prompt_context_injection_has_no_provenance_tags ----
no provenance tag may reach the injection; got:
## Relevant memories from palace `prompt-ctx-tag-render`
- Rust integration uses tokio for async tasks and serde for JSON encoding  _(tags: `rust`, `tokio`, `serde`, `async`, `json`, `encoding`, `runtime`, `crate`, `creator:client=trusty-memory-mcp`, `creator:version=0.22.0`, `creator:source=mcp`)_
- Rust error handling prefers thiserror in libraries and anyhow in binaries  _(tags: `rust`, `thiserror`, `anyhow`, `errors`, `libraries`, `binaries`, `convention`, `creator:client=trusty-memory-mcp`, `creator:version=0.22.0`, `creator:source=mcp`)_

test result: FAILED. 0 passed; 4 failed
```

The e2e failure is the reported defect verbatim — `memory_remember` stamps the namespace through the real MCP write path, and it reached the injection. Restored:

```
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 610 filtered out
```

Two fixture notes, since both were review findings on the combined PR: the count test uses real tag shapes from the live palace rather than `topic-N`, and the byte test uses 55-character tags — a 7-character fixture cannot catch a byte-budget hole however wrong the cap is.

## Gates

Scoped per the build-concurrency limits in force — `CARGO_BUILD_JOBS=2`, no workspace build, no Tauri frontend build.

```
( CARGO_BUILD_JOBS=2 cargo fmt --check \
  && CARGO_BUILD_JOBS=2 cargo clippy -p trusty-memory --all-targets -- -D warnings \
  && CARGO_BUILD_JOBS=2 cargo test -p trusty-memory \
  && CARGO_BUILD_JOBS=2 cargo test -p trusty-common ) ; EXIT=0

cargo test -p trusty-memory  — 610 passed; 0 failed; 4 ignored
cargo test -p trusty-common  — 294 passed; 0 failed; 6 ignored
```

Repo gates, run after `git add`:

```
line-cap:          measured 3799 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
sld-lint:          scanned 56 spec doc(s) + 4116 code file(s); 0 error(s), 0 warning(s)
changelog-fragment gate:     scanned 3 changed path(s); all 1 crate(s) with source changes are recorded.
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
