### PR TITLE
docs: fix stale claims in README and CLAUDE.md files across six crates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,6 +429,37 @@ Quick: VS Code needs `rust-analyzer` + `Even Better TOML` extensions; RustRover 
 
 Quick: `RUST_LOG=info cargo run -p trusty-search -- start` (daemon), `cargo run -p trusty-search -- serve` (MCP stdio mode).
 
+## Public Website (`website/`)
+
+SvelteKit + `adapter-vercel`, deployed to Vercel from `main`. Two page
+families with DIFFERENT update semantics:
+
+- **`/docs/**`** — generated at build time from files listed in
+  `docs/public-manifest.tsv`. Edit a listed `docs/` file, merge to main, and
+  the live site updates automatically. A `PAGE` row naming a missing file
+  FAILS the build; a `docs/` file absent from the manifest is simply never
+  public (an allowlist boundary, not a bug).
+- **`/tools/<crate>`** — six hand-authored flagship pages (search, memory,
+  mpm, analyze, review, tga). Their copy is static prose in
+  `website/src/lib/tools.ts` and `website/src/routes/tools/*/+page.svelte`,
+  verified against crate source when written. 🔴 **Editing a crate README does
+  NOT update its flagship page** — nothing in the build reads crate READMEs.
+  Update those files by hand.
+
+Vercel rebuilds only when a push touches `website/`, `docs/`, `Cargo.lock`, or
+`crates/*/Cargo.toml`. A `crates/*/README.md` or root `README.md` change
+triggers no rebuild — nor does a `CLAUDE.md` edit, which is expected.
+
+🔴 There is no `vercel.json`. Root Directory, "Include source files outside of
+the Root Directory", and the Ignored Build Step are configured in the Vercel
+dashboard only — dashboard drift leaves no trace in git. Setup and the full
+path table: [website/README.md](website/README.md).
+
+🔴 Website tests do not run in CI (#5200). Run them by hand: `pnpm test` from
+INSIDE `website/` — pnpm is pinned there (`packageManager` field); a shell at
+the repo root has no such pin and its resolved pnpm can require a Node version
+newer than what's installed.
+
 ## Common Pitfalls — Quick Checklist
 
 For extended explanations, see [docs/reference/common-pitfalls.md](docs/reference/common-pitfalls.md).

--- a/crates/trusty-analyze/CLAUDE.md
+++ b/crates/trusty-analyze/CLAUDE.md
@@ -406,13 +406,19 @@ GET  /indexes/:id/clusters?k=N&method=bow
 ## MCP Tools
 
 Parity rule: every HTTP endpoint has an MCP tool equivalent. The MCP server
-registers **17 tools** (authoritative source: `src/mcp/mod.rs`
-`tool_definitions`):
+assembles its tool list from three sources (authoritative source:
+`src/mcp/mod.rs` `tool_descriptors`): 18 base descriptors always present
+(`src/mcp/descriptors.rs` `base_tool_descriptors`), plus `console_metrics`
+(always appended), plus three `tr_review_*` tools appended only when built
+with the `review` Cargo feature. The exact count depends on the build — read
+`tool_descriptors()` rather than a fixed number.
 
 `complexity_hotspots`, `find_smells`, `analyze_quality`, `run_diagnostics`,
 `list_facts`, `upsert_fact`, `delete_fact`, `analyzer_health`, `extract_graph`,
 `cluster_concepts`, `ingest_scip`, `extract_ner`, `suggest_refactors`,
-`review_diff`, `deep_analysis`, `review_github_pr`, `list_entities`.
+`review_diff`, `deep_analysis`, `review_github_pr`, `list_entities`,
+`list_analyze_indexes`, `console_metrics`, and — with `--features review` —
+`tr_review_pr`, `tr_review_diff`, `tr_review_health`.
 
 ### Transports
 
@@ -502,7 +508,7 @@ trusty-common must never depend on trusty-search or trusty-analyze.
 
 ```bash
 # Step 1 — start trusty-search first (REQUIRED; analyzer will not start without it)
-trusty-search daemon   # port 7878
+trusty-search start   # port 7878
 
 # Step 2 — build everything
 cargo build
@@ -575,8 +581,9 @@ tree-sitter adapters are all functional.
   `blame.rs`, `quality.rs`, `facts.rs`, `concept_cluster.rs`, `linker.rs`,
   `explain.rs`, `github.rs`
 - axum HTTP sidecar (`src/service/`) on port 7879
-- MCP stdio + HTTP/SSE server (`src/mcp/`) — 17 tools (authoritative source:
-  `src/mcp/mod.rs` `tool_definitions`)
+- MCP stdio + HTTP/SSE server (`src/mcp/`) — 18 base tools + `console_metrics`,
+  plus 3 more under `--features review` (authoritative source: `src/mcp/mod.rs`
+  `tool_descriptors`)
 - CLI subcommands: `serve`, `analyze`, `facts list/upsert`, `health`
 - Daemon PID lockfile (fs4), graceful shutdown, `--search-url` flag
 - `LanguageAnalyzer` trait + 15 tree-sitter adapters, all implemented:

--- a/crates/trusty-analyze/README.md
+++ b/crates/trusty-analyze/README.md
@@ -97,7 +97,7 @@ Homebrew provides:
 
 ```bash
 # trusty-search must be running first (hard runtime dependency)
-trusty-search daemon
+trusty-search start
 
 # Run the analyzer sidecar
 trusty-analyze serve --search-url http://127.0.0.1:7878
@@ -176,8 +176,13 @@ unreachable.
 
 ## MCP Tools
 
-The MCP server registers **17 tools** (authoritative source: `src/mcp/mod.rs`
-`tool_definitions`):
+The MCP server assembles its tool list from three sources (authoritative
+source: `src/mcp/mod.rs` `tool_descriptors`): 18 base descriptors always
+present (`src/mcp/descriptors.rs` `base_tool_descriptors`), plus
+`console_metrics` (always appended), plus three `tr_review_*` tools appended
+only when built with the `review` Cargo feature. The exact count therefore
+depends on how the binary was built — read `tool_descriptors()` rather than
+relying on a fixed number here.
 
 | Tool | HTTP equivalent |
 |------|-----------------|
@@ -194,10 +199,16 @@ The MCP server registers **17 tools** (authoritative source: `src/mcp/mod.rs`
 | `extract_graph` | knowledge-graph extraction |
 | `extract_ner` | named-entity extraction (optional ONNX) |
 | `list_entities` | enumerate extracted entities |
+| `list_analyze_indexes` | `GET /indexes` (used by the trusty-console dashboard) |
 | `suggest_refactors` | refactor suggestions |
 | `review_diff` | review a unified diff |
 | `review_github_pr` | review a GitHub pull request |
 | `deep_analysis` | combined deep-analysis pass |
+| `console_metrics` | daemon health + index stats for the trusty-console dashboard |
+
+Built with `--features review`, three more tools are registered:
+`tr_review_pr`, `tr_review_diff`, `tr_review_health` — see
+`src/mcp/review.rs`.
 
 ## HTTP API
 

--- a/crates/trusty-git-analytics/README.md
+++ b/crates/trusty-git-analytics/README.md
@@ -23,15 +23,19 @@ This README and the rustdoc stay in-crate; everything else lives under `docs/`.
 
 Prebuilt binaries are available for macOS (Apple Silicon) and Linux (x86_64).
 
-1. Download the latest release from [GitHub Releases](https://github.com/bobmatnyc/trusty-tools/releases):
-   - Look for assets tagged `tga-v2.7.0`
+1. Find the latest `tga` release — this repo tags every crate independently
+   (`<crate>-v<version>`), so use the
+   [filtered releases view](https://github.com/bobmatnyc/trusty-tools/releases?q=tga-v)
+   rather than the repo's overall "Latest" badge, which tracks whichever
+   crate released most recently:
+   - Look for the highest-numbered asset tagged `tga-vX.Y.Z`
    - Download the archive for your platform:
-     - **macOS arm64 (Apple Silicon)**: `tga-v2.7.0-aarch64-apple-darwin.tar.gz`
-     - **Linux x86_64**: `tga-v2.7.0-x86_64-unknown-linux-gnu.tar.gz`
+     - **macOS arm64 (Apple Silicon)**: `tga-vX.Y.Z-aarch64-apple-darwin.tar.gz`
+     - **Linux x86_64**: `tga-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz`
 
 2. Extract and install:
    ```bash
-   tar xzf tga-v2.7.0-*.tar.gz
+   tar xzf tga-vX.Y.Z-*.tar.gz
    chmod +x tga
    sudo mv tga /usr/local/bin/    # or ~/.local/bin/ if you prefer user install
    ```
@@ -51,9 +55,11 @@ cargo install --git https://github.com/bobmatnyc/trusty-tools tga --locked
 
 This builds from the latest commit on `main` and installs the binary to `~/.cargo/bin/`. Make sure `~/.cargo/bin/` is on your PATH.
 
-To install a specific version:
+To install a specific version, substitute the tag you want (see the
+[filtered releases view](https://github.com/bobmatnyc/trusty-tools/releases?q=tga-v)
+above for the full list):
 ```bash
-cargo install --git https://github.com/bobmatnyc/trusty-tools --tag tga-v2.7.0 tga --locked
+cargo install --git https://github.com/bobmatnyc/trusty-tools --tag tga-vX.Y.Z tga --locked
 ```
 
 ### With Homebrew (recommended)

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -241,12 +241,10 @@ The MCP server registers **45 tools** (authoritative source:
 `tool_definitions_lists_all_tools` test). All are exposed via both the MCP
 protocol (over the `serve --stdio` path) and the HTTP API (`/api/v1/`). The
 `palace` argument is required unless the server was started with `--palace
-<name>`. The tables below cover the primary surface; the full roster also
-includes `memory_note`, `memory_recall_all`, `palace_delete`,
-`palace_update`, `palace_compact`, `kg_gaps`, `kg_bootstrap`, `add_alias`,
-`discover_aliases`, `list_prompt_facts`, `remove_prompt_fact`,
-`get_prompt_context`, `memory_send_message`, `upgrade`, and
-`console_metrics`.
+<name>`. The tables below cover the primary surface, not all 45 — for the
+complete, current list of tool names read `tool_definitions()` in
+`src/tools/definitions.rs`, or the exhaustive name list asserted by
+`tool_definitions_lists_all_tools` in `src/tools/tests.rs`.
 
 ### Memory tools
 
@@ -290,9 +288,12 @@ conversation session manager. Turns are stored verbatim and bypass the
 
 | Tool | Arguments | Description |
 |---|---|---|
-| `memory_dream` | `palace?` | Run a consolidation cycle (merge near-duplicates, prune, compact). |
 | `dream_consolidate_room` | `palace, room?, max_age_days?=7` | On-demand, synchronous LLM consolidation scoped to one room (omit `room` for all rooms). Summarises facts older than `max_age_days` into canonical drawers, then evicts the superseded originals. `Task` drawers are always skipped. No-op when no inference backend is configured. Returns `{ summary_facts_created, facts_evicted }`. |
-| `memory_status` | — | Global statistics (total drawers, vectors, KG triples). |
+| `palace_dream` | `palace, room?, max_age_days?=7` | Alias for `dream_consolidate_room`, exposed under the `palace_*` naming convention. Same behaviour and return shape. |
+
+Global daemon statistics (total drawers, vectors, KG triples) are available
+via `GET /api/v1/status` — an HTTP-only endpoint (`StatusPayload` in
+`src/service/types.rs`); there is no corresponding MCP tool.
 
 ### Task drawers (protected memory)
 
@@ -307,7 +308,7 @@ will survive every subsequent dream cycle until explicitly deleted.
 
 ## Dream Cycle: Semantic Consolidation (issue #87)
 
-The `memory_dream` tool (and the background idle-dream timer) now includes an
+The `palace_dream` / `dream_consolidate_room` tools (and the background idle-dream timer) now include an
 **inference-backed semantic consolidation phase** after the existing NLP passes
 (dedup, prune, closet-refresh):
 

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -236,7 +236,7 @@ running (started either by `trusty-memory setup`'s LaunchAgent or by
 
 ## Available MCP Tools
 
-The MCP server registers **25 tools** (authoritative source:
+The MCP server registers **45 tools** (authoritative source:
 `src/tools/definitions.rs` `tool_definitions`, asserted by the
 `tool_definitions_lists_all_tools` test). All are exposed via both the MCP
 protocol (over the `serve --stdio` path) and the HTTP API (`/api/v1/`). The
@@ -581,12 +581,12 @@ Each palace directory contains:
 ```
 trusty-memory (this crate)          trusty-common `memory-core` feature
   axum HTTP/SSE server     ──────►  PalaceRegistry
-  Unix domain socket       ──────►  usearch vector index (index.usearch)
+  serve --stdio (JSON-RPC) ──────►  usearch vector index (index.usearch)
   embedded Svelte UI               redb metadata + KG (kg.redb)
-  30 MCP tools                     fastembed (AllMiniLML6V2Q)
+  45 MCP tools                     fastembed (AllMiniLML6V2Q)
 
-trusty-memory-mcp-bridge (separate binary, PR #149)
-  Claude Code stdio  ◄──pipe──►  trusty-memory UDS
+Claude Code stdio ◄──JSON-RPC──► `trusty-memory serve --stdio`
+                                  ──POST /rpc (HTTP)──► trusty-memory daemon
 ```
 
 The `memory-core` feature of `trusty-common` owns the storage engine: `usearch` for approximate

--- a/crates/trusty-search/CLAUDE.md
+++ b/crates/trusty-search/CLAUDE.md
@@ -533,8 +533,8 @@ Serves the embedded Svelte admin UI. Not part of the integration contract.
 
 ### MCP Tools
 
-The MCP server registers **18 tools** (authoritative source:
-`src/mcp/tools.rs` `tool_definitions`):
+The MCP server registers **21 tools** (authoritative source:
+`src/mcp/tools/descriptors.rs` `tool_definitions`):
 
 - `search` — hybrid search (BM25 + vector + KG, RRF-fused)
 - `search_lexical` — BM25-only lexical search
@@ -554,6 +554,9 @@ The MCP server registers **18 tools** (authoritative source:
 - `get_call_chain` — KG caller/callee chain for a symbol
 - `grep` — literal/regex grep fallback over the corpus
 - `chat` — OpenRouter conversational Q&A
+- `upgrade` — check for / install a new trusty-search version
+- `console_metrics` — daemon health + index aggregate stats for the trusty-console dashboard
+- `typeahead` — per-keystroke autocomplete suggestions for an index
 
 ## Stack
 
@@ -1043,7 +1046,7 @@ via `cargo install trusty-search`.
 - `EntityExtractor` Phase A structural entities (functions, classes, imports)
 - `SymbolGraph` KG expansion (callers_of / callees_of, 1–2 hop, EdgeKind multipliers)
 - `FileWatcher` with notify-debouncer-mini, 500ms debounce
-- MCP server: full JSON-RPC 2.0 stdio + HTTP/SSE transport, 18 tools (per `src/mcp/tools.rs`)
+- MCP server: full JSON-RPC 2.0 stdio + HTTP/SSE transport, 21 tools (per `src/mcp/tools/descriptors.rs`)
 - Daemon: auto-port, fs4 PID lockfile, graceful shutdown, persistent model cache
 - Svelte 5 admin UI embedded in binary via `include_dir`
 - OpenRouter chat proxy with search context injection

--- a/crates/trusty-search/CLAUDE.md
+++ b/crates/trusty-search/CLAUDE.md
@@ -534,7 +534,7 @@ Serves the embedded Svelte admin UI. Not part of the integration contract.
 ### MCP Tools
 
 The MCP server registers **21 tools** (authoritative source:
-`src/mcp/tools/descriptors.rs` `tool_definitions`):
+`src/mcp/tools/descriptors.rs` `tool_descriptors`):
 
 - `search` — hybrid search (BM25 + vector + KG, RRF-fused)
 - `search_lexical` — BM25-only lexical search

--- a/crates/trusty-search/README.md
+++ b/crates/trusty-search/README.md
@@ -269,7 +269,7 @@ Once connected, Claude Code can call `search`, `index_file`, `list_indexes`, and
   LRU embedding cache (256+ entries) skips re-embedding on repeat queries
 - **Native multi-request** — `Arc<SearchAppState>`, reader-priority `RwLock`,
   axum HTTP/2 — many concurrent searches against the same index never block
-- **MCP server** — stdio + HTTP/SSE transports, 18 tools (per `src/mcp/tools.rs`), drop-in for Claude Code
+- **MCP server** — stdio + HTTP/SSE transports, 21 tools (per `src/mcp/tools/descriptors.rs`), drop-in for Claude Code
 - **Embedded Svelte 5 admin UI** — Collections, Search, Chat, Admin panels
   compiled into the binary via `include_dir!`; open with `trusty-search ui`
 - **Migration path** — `trusty-search convert` reads `mcp-vector-search`
@@ -423,13 +423,13 @@ be registered (via `POST /indexes`, `trusty-search index`, or any MCP tool), it
 must appear in the allowlist file at:
 
 ```
-~/.config/trusty-search/indexes.toml   # macOS / Linux (XDG config dir)
+~/.config/trusty-search/allowlist.toml   # macOS / Linux (XDG config dir)
 ```
 
 ### Format
 
 ```toml
-# ~/.config/trusty-search/indexes.toml
+# ~/.config/trusty-search/allowlist.toml
 
 [[index]]
 path = "/Users/me/Projects/myproj"
@@ -504,7 +504,7 @@ trusty-search service install --no-auto-discover     # macOS: bake the above int
                                                      # `--auto-discover` turns the scan back on
 trusty-search stop                                   # stop daemon (SIGTERM via PID lockfile)
 trusty-search index [path] [--name <id>] [--force]   # register + index (primary command)
-                                                     # also writes ~/.config/trusty-search/indexes.toml
+                                                     # also writes ~/.config/trusty-search/allowlist.toml
                                                      # auto-detects ./trusty-search.yaml
 trusty-search index add <path> [--name <id>]         # add path to allowlist + index
 trusty-search index list [--json]                    # list all allowlisted roots
@@ -526,8 +526,8 @@ trusty-search reindex [path]                         # alias for index --force
 
 ## MCP tools
 
-The MCP server registers **18 tools** (authoritative source: `src/mcp/tools.rs`
-`tool_definitions`):
+The MCP server registers **21 tools** (authoritative source:
+`src/mcp/tools/descriptors.rs` `tool_definitions`):
 
 | Tool            | Description                                          |
 |-----------------|------------------------------------------------------|
@@ -549,6 +549,9 @@ The MCP server registers **18 tools** (authoritative source: `src/mcp/tools.rs`
 | `grep`          | Literal/regex grep fallback over the corpus          |
 | `search_health` | Daemon liveness probe                                |
 | `chat`          | OpenRouter Q&A with auto-injected search context     |
+| `upgrade`       | Check for or install a new trusty-search version     |
+| `console_metrics` | Daemon health + index aggregate stats for the trusty-console dashboard |
+| `typeahead`     | Per-keystroke autocomplete suggestions for an index  |
 
 ### `search_kg` — `refine_query` parameter (issue #147)
 

--- a/crates/trusty-search/README.md
+++ b/crates/trusty-search/README.md
@@ -527,7 +527,7 @@ trusty-search reindex [path]                         # alias for index --force
 ## MCP tools
 
 The MCP server registers **21 tools** (authoritative source:
-`src/mcp/tools/descriptors.rs` `tool_definitions`):
+`src/mcp/tools/descriptors.rs` `tool_descriptors`):
 
 | Tool            | Description                                          |
 |-----------------|------------------------------------------------------|


### PR DESCRIPTION
Fixes documentation across six files that asserted things which do not exist. Every claim was verified against source before and after.

Closes #5193
Closes #5194
Closes #5195
Closes #5196

## The four filed issues

| File | Was | Is |
|---|---|---|
| `crates/trusty-search/README.md` | "18 tools" citing `src/mcp/tools.rs` | 21, citing `src/mcp/tools/descriptors.rs` (that path is a directory) |
| " | allowlist at `indexes.toml` | `allowlist.toml` — `allowlist/mod.rs`'s own doc says so explicitly |
| `crates/trusty-memory/README.md` | "25 tools" in prose, "30" in its own diagram | **45**, per `tool_definitions_lists_all_tools` |
| " | diagram drew a Unix domain socket bridge | corrected to `serve --stdio` → `POST /rpc`, matching the file's own prose ("No Unix domain socket is involved") |
| `crates/trusty-analyze/README.md` | `trusty-search daemon` | `trusty-search start` — no `Daemon` variant exists in `Commands` |
| " | "17 tools" | feature-dependent: 18 base + `console_metrics` + 3 `tr_review_*` under `--features review` |
| `crates/trusty-git-analytics/README.md` | pinned `tga-v2.7.0` | version-agnostic release link (crate is at 2.11.0) |

## Found during the sweep, fixed in the same work

Per this repo's opportunistic-fix rule, not filed separately:

- `memory_dream` → the registered tool is `palace_dream` (`chat_definitions.rs`); args corrected too.
- `memory_status` was listed as an MCP tool. It is **not** one — but it names a real capability, `GET /api/v1/status` (`StatusPayload`, `service/types.rs`), which is HTTP-only with no MCP counterpart. Reworded rather than deleted.
- The "full roster" list enumerated 32 of 45 tools. Replaced with a pointer to `tool_definitions()` rather than completing it — a hand-maintained list of 45 names re-rots at the next addition.
- 🔴 `crates/trusty-search/CLAUDE.md` and `crates/trusty-analyze/CLAUDE.md` carried the **same** stale claims as their READMEs. Fixing only the READMEs would have left the identical falsehood one file over, with no way for a reader to tell which was current. Both corrected.

Two apparent matches were deliberately left alone: `trusty-analyze/CLAUDE.md`'s line-23 "17 tools" describes the Python `mcp-vector-search` predecessor, not this crate; its line-265 "trusty-search daemon (port 7878)" is an architecture-diagram box label, not a CLI invocation.

## Why several fixes are pointers rather than numbers

Four separate files drifted from source the same way. Where a claim can be expressed without a magic number or a pinned version — by citing the descriptor source, the test that asserts the count, or a latest-release link — it now is. Writing today's correct number just resets the clock on the same failure.

## `CLAUDE.md` — new "Public Website" section

Records what the website is and, more importantly, what does **not** propagate to it:

- `/docs/**` regenerates from `docs/public-manifest.tsv` on any `docs/` change — automatic.
- `/tools/<crate>` flagship pages are static hand-authored prose in `website/src/lib/tools.ts` and the `.svelte` files. **Editing a crate README does not update its flagship page**, and a `crates/*/README.md` change does not even trigger a Vercel rebuild.
- No `vercel.json` exists — Root Directory, the outside-files toggle, and the Ignored Build Step are dashboard-only, so drift there leaves no trace in git.
- Website tests do not run in CI (#5200); run `pnpm test` from inside `website/`.

Every claim in that section was verified against the repo, including reproducing the pnpm/Node failure directly (root shim needs Node ≥22.13 against installed v20.20.2; from inside `website/` the pinned 9.15.9 resolves cleanly).

## Gates — rung 1 (docs-only)

\`\`\`
scripts/check_sld.sh                → exit 0
scripts/check_line_cap.sh           → exit 0
scripts/check_changelog_fragment.sh → exit 0
  scanned 7 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
\`\`\`

No `.rs` touched, so no Cargo gate applies. Note #5200 means CI does not test \`website/\`; this PR does not change \`website/\`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools