### PR TITLE
docs: fix uninstall instructions

### DIFF
--- a/docs/getting-started/install-and-run-tm.md
+++ b/docs/getting-started/install-and-run-tm.md
@@ -23,9 +23,11 @@ tm
 
 ## What You Just Installed
 
-When you ran `tctl install trusty-mpm`, three binaries were installed to `~/.local/bin`:
+When you ran `tctl install trusty-mpm`, three members were installed —
+normally to `~/.local/bin` (the prebuilt path), or `~/.cargo/bin` if the
+installer fell back to `cargo install` for your platform:
 
-- **`trusty-mpm`** (binary: `tm`) — the session orchestrator. Manages Claude Code sessions, coordinates with daemons, provides the CLI and daemon interface.
+- **`trusty-mpm`** (binaries: `trusty-mpm` and `tm`) — the session orchestrator. Manages Claude Code sessions, coordinates with daemons, provides the CLI and daemon interface.
 - **`trusty-memory`** — long-term memory storage daemon. Stores development context, notes, snippets. Started automatically as a macOS/Linux service.
 - **`trusty-search`** — hybrid code search daemon (BM25 + vector + knowledge graph). Indexes your projects. Started automatically as a macOS/Linux service.
 
@@ -247,21 +249,61 @@ systemctl --user start trusty-search trusty-memory trusty-mpm
 
 ### Q: How do I uninstall?
 
-The binaries live in `~/.local/bin`. Remove them:
+**On macOS, stop the daemons first, while their binaries still exist to do
+it.** Unloading before deleting matters both ways: a daemon left running after
+its binary is gone gets no cleaner, and a plist deleted while its job is still
+registered leaves launchd running a copy you can no longer address by file.
 
 ```bash
-rm ~/.local/bin/trusty-mpm ~/.local/bin/trusty-memory ~/.local/bin/trusty-search ~/.local/bin/tctl
-```
-
-On macOS, also remove the launchd plists:
-```bash
-# Unload first, then remove — a plist deleted while its job is still registered
-# leaves launchd running a daemon you can no longer address by file.
 trusty-search service uninstall 2>/dev/null || true
 launchctl bootout gui/$(id -u)/com.trusty.memory 2>/dev/null || true
 launchctl bootout gui/$(id -u)/com.trusty.mpm 2>/dev/null || true
 rm -f ~/Library/LaunchAgents/com.trusty.*.plist
 ```
+
+**Then remove the binaries.** They can land in either of two directories,
+depending on how they were installed — a prebuilt `tctl install` (or the
+one-liner) uses `~/.local/bin` (overridable via `TRUSTY_INSTALL_DIR`); a
+`cargo install` or build-from-source path uses `~/.cargo/bin` (or
+`$CARGO_HOME/bin` if you've overridden `CARGO_HOME`). Check both — `rm -f` so
+a name missing from one directory doesn't stop the command:
+
+```bash
+rm -f ~/.cargo/bin/{trusty-mpm,tm,trusty-memory,trusty-search,tctl} \
+      ~/.local/bin/{trusty-mpm,tm,trusty-memory,trusty-search,tctl}
+```
+
+(`trusty-mpm` installs two binaries, `trusty-mpm` and `tm` — both need
+removing. Installed an optional member too, e.g. `trusty-analyze` or
+`trusty-console`? Add its name to both brace lists.)
+
+**If you installed via mise** (`mise use -g cargo:trusty-mpm`, or mise's
+automatic reshimming of `~/.cargo/bin` after a plain `cargo install`), the
+command on your `$PATH` may be a shim in `~/.local/share/mise/shims/`, not the
+binary itself — check with `which -a tm` (or any of the other names above). The
+`rm -f` above does not touch that shim file, so run `mise reshim` afterward to
+prune it:
+
+```bash
+mise reshim
+```
+
+Skip that step and the shim lingers on disk; invoking it fails loudly rather
+than silently, e.g.:
+
+```
+mise ERROR trusty-mpm is not a valid shim. This likely means you uninstalled a
+tool and the shim does not point to anything. Run `mise use <TOOL>` to
+reinstall the tool.
+```
+
+Confirm everything is gone:
+
+```bash
+command -v trusty-mpm tm trusty-memory trusty-search tctl
+```
+
+Every name should print nothing.
 
 ### Q: Installation failed. What do I do?
 


### PR DESCRIPTION
The published uninstall instructions do not uninstall. This page is live at `/docs/getting-started/install` on the public site.

## The reported defect

The FAQ said binaries live in `~/.local/bin` and gave:

```bash
rm ~/.local/bin/trusty-mpm ~/.local/bin/trusty-memory ~/.local/bin/trusty-search ~/.local/bin/tctl
```

Measured on a real install: `~/.cargo/bin` holds the current set (`tm`, `trusty-mpm`, `trusty-memory`, `trusty-search`, `tctl`, …). `~/.local/bin` holds only a partial, older set — **no `trusty-mpm`, no `trusty-memory`, no `tm`**. So two of the four paths do not exist, `rm` errors on them, and the real binaries survive. Someone follows the instructions and remains installed.

Both directories are legitimate: the prebuilt `tctl install` path uses `~/.local/bin` (`TRUSTY_INSTALL_DIR`), while `cargo install` / build-from-source uses `~/.cargo/bin` (or `$CARGO_HOME/bin`). `crates/trusty-common/src/update/upgrade.rs`'s `candidate_bin_dirs` is the code's own statement of that precedence. Swapping one path for the other would have been the same defect mirrored, so the fix covers both with `rm -f`.

## Two further defects found in the same FAQ

**Ordering bug.** The plist-removal block ran `trusty-search service uninstall` *after* the binary-removal block had already deleted the `trusty-search` binary. That command could only fail, silently leaving a stale plist and a daemon that can no longer be addressed by file. Daemons are now unloaded first, while their binaries still exist.

**`tm` was never listed.** `trusty-mpm` ships two binaries, `trusty-mpm` and `tm`. The uninstall command removed one. Also corrected "What You Just Installed", which claimed `~/.local/bin` unconditionally while Step 2 three paragraphs later documents the `cargo install` fallback.

## The mise-shim case

On this machine every one of these resolves through a mise shim, not either directory. Verified empirically rather than assumed — isolated `HOME`/`MISE_DATA_DIR`, plus a throwaway binary placed in the real `~/.cargo/bin`, removed, and the resulting behavior observed:

- mise auto-shims executables in a mise-managed toolchain's bin dir; the shim is a symlink to `mise`, not to the target.
- Deleting the target and invoking the shim fails loudly with `mise ERROR ... is not a valid shim ...` — it does not fail silently.
- `mise reshim` prunes the dangling shim.

The doc now says so, quoting that error.

## Verified

Every path claim checked against the filesystem and against `upgrade.rs`, `README.md`'s `TRUSTY_INSTALL_DIR` row, and `crates/trusty-mpm/Cargo.toml`'s two `[[bin]]` entries. The launchd section was re-checked and is accurate: `trusty-search service uninstall` exists, `trusty-memory` has no `uninstall` subcommand, so the raw `launchctl bootout` is correct for memory and mpm.

## Gates — rung 1 (docs-only)

\`\`\`
scripts/check_sld.sh           → exit 0
scripts/check_line_cap.sh      → exit 0
scripts/check_public_docs.sh   → exit 0   (this file is on the public manifest)
scripts/check_changelog_fragment.sh → exit 0
  scanned 1 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
\`\`\`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools