### PR TITLE
test(website): assert each flagship page renders its own tool record

### DIFF
--- a/website/tests/build-smoke.test.ts
+++ b/website/tests/build-smoke.test.ts
@@ -158,6 +158,34 @@ describe('production build', () => {
 		}
 	});
 
+	// Why: the assertion above proves only that a FILE exists. A page whose
+	// component threw during prerender, or one wired to the wrong `Tool` record,
+	// still writes an HTML shell and still passes it — and with six hand-authored
+	// pages, a copy/paste that leaves two routes rendering the same crate is the
+	// realistic failure, not a missing file. Nothing else in this suite reads a
+	// tool page's body.
+	// What: for each `TOOLS` entry, re-derives what that page must contain from
+	// the same record the page renders from, and pins it to the route's own
+	// artifact — the `<h1>` must name THAT crate, and the unit stamp, tagline,
+	// lede, install command, and docs link must all be present.
+	it('renders each flagship page from its own tool record, not a shell', () => {
+		for (const tool of TOOLS) {
+			const file = `tools/${tool.slug}.html`;
+			const html = readFileSync(path.join(STATIC, file), 'utf8');
+
+			const heading = html.match(/<h1\b[^>]*>([\s\S]*?)<\/h1>/);
+			expect(heading, `${file} has no <h1>`).not.toBeNull();
+			expect(heading?.[1], `${file} <h1>`).toContain(tool.name);
+
+			for (const copy of [tool.unit, tool.tagline, tool.lede, tool.install]) {
+				expect(html, `${file} is missing ${JSON.stringify(copy)}`).toContain(copy);
+			}
+			if (tool.docsPath) {
+				expect(html, `${file} does not link ${tool.docsPath}`).toContain(`href="${tool.docsPath}"`);
+			}
+		}
+	});
+
 	it('loads no subresource from a third-party origin', () => {
 		for (const name of ['index.html', 'docs.html', ...docPages(), ...toolPages()]) {
 			const html = readFileSync(path.join(STATIC, name), 'utf8');


### PR DESCRIPTION
## What changed

One test in `website/tests/build-smoke.test.ts`. The suite already asserted that
each `/tools/<slug>` page prerenders to a file; it never read the body. A page
wired to the wrong `Tool` record, or one whose component threw during prerender,
writes an HTML shell and passes `existsSync`. With six hand-authored pages, a
copy/paste that leaves two routes rendering the same crate is the realistic
failure, and nothing in the suite would have caught it.

The new test re-derives each page's expected content from the same `TOOLS`
record the page renders from, and pins it to that route's own artifact: the
`<h1>` must name **that** crate, and the unit stamp, tagline, lede, install
command, and docs link must all be present.

## The gap was real, not hypothetical

Temporarily pointing `/tools/trusty-review` at the `trusty-mpm` record:

```
 × renders each flagship page from its own tool record, not a shell 3ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: tools/trusty-review.html <h1>: expected 'trusty-mpm' to contain 'trusty-review'
    177|    expect(heading, `${file} has no <h1>`).not.toBeNull();
    178|    expect(heading?.[1], `${file} <h1>`).toContain(tool.name);
 Test Files  1 failed (1)
      Tests  1 failed | 12 passed (13)
```

Only the new assertion failed. Every pre-existing test passed against a page
rendering the wrong crate. The mutation was reverted before commit.

## 🔴 CI does not run these tests

Per #5200, `detect-docs-only.sh` classifies `website/**` as inert and the
`ui-checks` matrix covers `crates/*/ui` only. **No CI job runs `website/`'s test
suite.** A green check rollup on this PR proves nothing about the website — the
local output below is the only gate.

## Local gate evidence (raw)

Run from inside `website/` (pnpm is pinned there via `packageManager`):

`( pnpm test && pnpm build && pnpm check && pnpm lint )` → `EXIT=0`

```
 Test Files  11 passed (11)
      Tests  169 passed (169)
   Duration  4.01s (transform 424ms, setup 0ms, import 818ms, tests 4.20s, environment 5.48s)
```

```
✓ built in 2.91s
> Using @sveltejs/adapter-vercel
  ✔ done
```

```
1786212317381 COMPLETED 470 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
```

```
Checking formatting...
All matched files use Prettier code style!
```

Test count went 168 → 169; the added test is the only delta.

All six routes were also inspected in the built output — each renders a real
page (14.8–18.1 kB) with its own `<h1>`, not a shell.

## Provenance

This session recovered two unpushed branches from a local worktree,
`feat/website-vercel-analytics` (9495dd0b7) and
`feat/website-flagship-crate-pages` (ca3ca9ad1). Both were pushed to origin for
preservation and then found **fully redundant** — every file each touched is
byte-identical to `origin/main`, landed earlier by #5189/#5190. This PR carries
the one thing that was genuinely missing: per-route content coverage.

Refs #5200

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
