### PR TITLE
fix(trusty-agents): resolve workflow-mode config hierarchically, not from cwd

### DIFF
--- a/crates/trusty-agents/changelog.d/5227-preflight-hierarchical.md
+++ b/crates/trusty-agents/changelog.d/5227-preflight-hierarchical.md
@@ -1,0 +1,20 @@
+Fixed
+
+- Workflow mode no longer refuses to start when the process CWD has no
+  `.trusty-agents/agents/`. The pre-flight check consulted the CWD alone while
+  agent resolution walked the project → `$HOME` → bundled hierarchy, so the
+  macOS `.app` sidecar (`cwd = /`) loaded its full agent roster and then bailed
+  with ``no `.trusty-agents/agents/` found in /`` — every Implementation task
+  launched from the GUI failed this way. The pre-flight now routes through
+  `agents::registry::agent_search_paths`, the same resolver the registry uses,
+  and its error lists every path that was searched instead of naming one.
+- `--workflow <name>` resolves `<name>.json` hierarchically too. It previously
+  read a single CWD-relative `.trusty-agents/workflows`, so widening only the
+  pre-flight would have traded the bail for a `WorkflowNotFound` two steps
+  later. Workflow resume resolves the same way.
+- The bundled workflow definitions (`prescriptive.json`, `prescriptive-gpt.json`)
+  now deploy to `~/.trusty-agents/workflows/` at startup, alongside the bundled
+  agent roster. They previously existed only inside a checkout of this repo, so
+  a `cargo install`ed `tagent` had no workflow definition on any search tier.
+  The deploy reuses the agent roster's stamp/lock/refresh path rather than
+  copying it.

--- a/crates/trusty-agents/src/agents/bundled/mod.rs
+++ b/crates/trusty-agents/src/agents/bundled/mod.rs
@@ -61,7 +61,7 @@
 //! subsequent `stamp::write` — is one critical section under a SINGLE
 //! pass-level advisory lock ([`lock`]), acquired ONCE by the caller
 //! ([`ensure_bundled_agents_deployed_in`], [`force_reprovision_bundled_agents`])
-//! and threaded down into [`reprovision_bundled_agents_locked`] (the MEDIUM
+//! and threaded down into [`reprovision_embedded_locked`] (the MEDIUM
 //! follow-up: an earlier version acquired the lock only INSIDE the refresh
 //! loop, leaving the stamp read/decide/write outside it — two concurrent
 //! passes could both observe the same stale stamp, both refresh, then race
@@ -88,6 +88,21 @@ mod stamp;
 #[derive(rust_embed::RustEmbed)]
 #[folder = ".trusty-agents/agents/"]
 struct BundledAgents;
+
+/// Embeds this crate's own `.trusty-agents/workflows/` tree — the prescriptive
+/// pipeline definitions `--workflow <name>` loads — into the compiled binary
+/// at build time (#5227).
+///
+/// Why: agents were the only config kind ever deployed to the `$HOME` tier, so
+/// `tagent --workflow prescriptive` launched from a directory with no
+/// `.trusty-agents/` (the macOS `.app` sidecar runs with `cwd = /`) resolved
+/// every agent hierarchically and then had no workflow definition to read.
+/// What: same `rust-embed` mechanism as [`BundledAgents`], deployed by
+/// [`ensure_bundled_workflows_deployed`] through the SAME stamp/lock/refresh
+/// path — see [`reprovision_embedded_locked`].
+#[derive(rust_embed::RustEmbed)]
+#[folder = ".trusty-agents/workflows/"]
+struct BundledWorkflows;
 
 /// Outcome of one (re)provision pass over the bundled agent set (#3556).
 ///
@@ -151,15 +166,15 @@ pub fn deploy_bundled_agents(target_dir: &Path) -> Result<usize> {
 /// Callers that DO have a stamp step to keep in the same critical section
 /// (`ensure_bundled_agents_deployed_in`, `force_reprovision_bundled_agents`)
 /// acquire the lock themselves and call
-/// [`reprovision_bundled_agents_locked`] directly instead of this wrapper —
+/// [`reprovision_embedded_locked`] directly instead of this wrapper —
 /// see that function's docs for why (#3556 code-critic follow-up, MEDIUM).
 /// What: acquires the pass-level lock, then delegates to
-/// [`reprovision_bundled_agents_locked`].
+/// [`reprovision_embedded_locked`].
 /// Test: `deploy_writes_missing_files_only`, `deploy_never_overwrites_existing_file`,
 /// `deploy_is_idempotent_on_rerun`, `deploy_writes_directory_package_agents` (tests.rs).
 fn reprovision_bundled_agents(target_dir: &Path, refresh_stale: bool) -> Result<ReprovisionReport> {
     let guard = lock::acquire(target_dir)?;
-    reprovision_bundled_agents_locked(&guard, target_dir, refresh_stale)
+    reprovision_embedded_locked::<BundledAgents>(&guard, target_dir, refresh_stale)
 }
 
 /// The actual write-side loop over `BundledAgents::iter()`, REQUIRING an
@@ -197,16 +212,16 @@ fn reprovision_bundled_agents(target_dir: &Path, refresh_stale: bool) -> Result<
 /// `existing_stale_backup_is_never_clobbered` (tests.rs);
 /// `pass_lock_serializes_concurrent_reprovision_calls` (`lock`'s own tests)
 /// pins the underlying mutual-exclusion primitive.
-fn reprovision_bundled_agents_locked(
+fn reprovision_embedded_locked<E: rust_embed::RustEmbed>(
     _guard: &lock::ProvisionLock,
     target_dir: &Path,
     refresh_stale: bool,
 ) -> Result<ReprovisionReport> {
     let mut report = ReprovisionReport::default();
-    for rel in BundledAgents::iter() {
+    for rel in E::iter() {
         let dest = target_dir.join(rel.as_ref());
-        let file = BundledAgents::get(&rel)
-            .with_context(|| format!("embedded bundled-agent asset vanished: {rel}"))?;
+        let file =
+            E::get(&rel).with_context(|| format!("embedded bundled asset vanished: {rel}"))?;
 
         if dest.exists() {
             if !refresh_stale {
@@ -267,11 +282,11 @@ fn stale_backup_path(dest: &Path) -> PathBuf {
 /// [`stamp::compute`] for the order-independent hash.
 /// Test: `stamp_changes_when_content_changes`,
 /// `stamp_stable_regardless_of_input_order` (`stamp`'s own tests).
-fn current_bundle_stamp() -> Result<String> {
+fn current_bundle_stamp<E: rust_embed::RustEmbed>() -> Result<String> {
     let mut entries: Vec<(String, Vec<u8>)> = Vec::new();
-    for rel in BundledAgents::iter() {
-        let file = BundledAgents::get(&rel)
-            .with_context(|| format!("embedded bundled-agent asset vanished: {rel}"))?;
+    for rel in E::iter() {
+        let file =
+            E::get(&rel).with_context(|| format!("embedded bundled asset vanished: {rel}"))?;
         entries.push((rel.to_string(), file.data.into_owned()));
     }
     Ok(stamp::compute(entries))
@@ -287,12 +302,12 @@ fn current_bundle_stamp() -> Result<String> {
 /// (#3556 code-critic follow-up, MEDIUM), and holds it across the ENTIRE
 /// read-decide-refresh-write sequence so two concurrent callers over the
 /// same `target_dir` can never both observe the same stale stamp and race
-/// writing it back — see [`reprovision_bundled_agents_locked`]'s docs for
+/// writing it back — see [`reprovision_embedded_locked`]'s docs for
 /// the full rationale.
 /// What: computes the current binary's bundle stamp, compares it to the
 /// stamp on disk (`target_dir/.bundled-stamp`, via [`stamp::read`]) — a
 /// missing or differing stamp means "stale", triggering
-/// `reprovision_bundled_agents_locked(&guard, target_dir, true)` (refresh
+/// `reprovision_embedded_locked(&guard, target_dir, true)` (refresh
 /// path) followed by writing the new stamp; a matching stamp takes the fast
 /// never-overwrite path (`refresh_stale = false`) and leaves the stamp file
 /// untouched. A lock-acquire failure propagates as `Err` (unchanged
@@ -304,17 +319,58 @@ fn current_bundle_stamp() -> Result<String> {
 /// `concurrent_ensure_calls_over_stale_target_converge_to_one_consistent_refresh`,
 /// `ensure_deployed_blocks_on_externally_held_pass_lock` (tests.rs).
 pub fn ensure_bundled_agents_deployed_in(target_dir: &Path) -> Result<ReprovisionReport> {
+    ensure_embedded_deployed_in::<BundledAgents>(target_dir)
+}
+
+/// Stamp-aware deploy/refresh of one embedded config tree into `target_dir`
+/// (#5227 generalisation of `ensure_bundled_agents_deployed_in`).
+///
+/// Why: agents and workflows need byte-identical deploy semantics — the
+/// pass-level lock, the content-hash staleness check, the `.stale.bak` archive
+/// of a differing on-disk copy. Duplicating that for a second config kind
+/// would guarantee the two drift; parameterising over the embed keeps one
+/// implementation. `stamp` and `lock` are already per-`target_dir`, so the two
+/// trees never share a stamp file.
+/// What: identical to what `ensure_bundled_agents_deployed_in` did before,
+/// with `BundledAgents` lifted to a type parameter.
+/// Test: the whole existing bundled-agent suite exercises this through
+/// `ensure_bundled_agents_deployed_in`; `bundled_workflows_deploy_to_target`
+/// pins the workflows instantiation.
+fn ensure_embedded_deployed_in<E: rust_embed::RustEmbed>(
+    target_dir: &Path,
+) -> Result<ReprovisionReport> {
     let guard = lock::acquire(target_dir)?;
 
-    let current_stamp = current_bundle_stamp()?;
+    let current_stamp = current_bundle_stamp::<E>()?;
     let on_disk_stamp = stamp::read(target_dir);
     let is_stale = on_disk_stamp.as_deref() != Some(current_stamp.as_str());
 
-    let report = reprovision_bundled_agents_locked(&guard, target_dir, is_stale)?;
+    let report = reprovision_embedded_locked::<E>(&guard, target_dir, is_stale)?;
     if is_stale {
         stamp::write(target_dir, &current_stamp)?;
     }
     Ok(report)
+}
+
+/// Production entry point: deploy/refresh the bundled workflow definitions at
+/// `$HOME/.trusty-agents/workflows/` (#5227).
+///
+/// Why: `--workflow prescriptive` reads `<workflows-dir>/prescriptive.json`,
+/// and until this the only copy on any machine lived inside a checkout of this
+/// repo. A `cargo install`ed `tagent` — or the GUI's `.app` sidecar, whose CWD
+/// is `/` — had no workflow definition anywhere on its search hierarchy, so
+/// making the pre-flight hierarchical alone would only have moved the failure
+/// from the pre-flight to `WorkflowNotFound`.
+/// What: mirrors [`ensure_bundled_agents_deployed`] exactly — no-op when
+/// `$HOME` is unresolvable, otherwise stamp-aware deploy into
+/// `$HOME/.trusty-agents/workflows`. Best-effort at the call site.
+/// Test: `bundled_workflows_deploy_to_target` covers the hermetic core.
+pub fn ensure_bundled_workflows_deployed() -> Result<ReprovisionReport> {
+    let Some(home) = dirs::home_dir() else {
+        return Ok(ReprovisionReport::default());
+    };
+    let target = home.join(".trusty-agents").join("workflows");
+    ensure_embedded_deployed_in::<BundledWorkflows>(&target)
 }
 
 /// Production entry point: deploy/refresh the bundled agent set at
@@ -360,7 +416,7 @@ pub fn ensure_bundled_agents_deployed() -> Result<ReprovisionReport> {
 /// concurrent `ensure_*`/`repair` pair over the same `target_dir` can never
 /// interleave.
 /// What: unconditionally runs the refresh path
-/// (`reprovision_bundled_agents_locked(&guard, target_dir, true)`), then
+/// (`reprovision_embedded_locked(&guard, target_dir, true)`), then
 /// writes the current bundle stamp so a subsequent automatic startup check
 /// treats the roster as up to date. Errors (including a lock-acquire
 /// failure) propagate loudly to the caller — this function has no fail-soft
@@ -370,8 +426,8 @@ pub fn ensure_bundled_agents_deployed() -> Result<ReprovisionReport> {
 /// `existing_stale_backup_is_never_clobbered` (tests.rs).
 pub fn force_reprovision_bundled_agents(target_dir: &Path) -> Result<ReprovisionReport> {
     let guard = lock::acquire(target_dir)?;
-    let report = reprovision_bundled_agents_locked(&guard, target_dir, true)?;
-    let current_stamp = current_bundle_stamp()?;
+    let report = reprovision_embedded_locked::<BundledAgents>(&guard, target_dir, true)?;
+    let current_stamp = current_bundle_stamp::<BundledAgents>()?;
     stamp::write(target_dir, &current_stamp)?;
     Ok(report)
 }

--- a/crates/trusty-agents/src/agents/bundled/tests.rs
+++ b/crates/trusty-agents/src/agents/bundled/tests.rs
@@ -134,7 +134,7 @@ fn stale_stamp_triggers_refresh() {
     let new_stamp = stamp::read(tmp.path());
     assert_eq!(
         new_stamp.as_deref(),
-        Some(current_bundle_stamp().unwrap().as_str()),
+        Some(current_bundle_stamp::<BundledAgents>().unwrap().as_str()),
         "stamp must be updated to the current bundle content hash"
     );
 }
@@ -368,7 +368,7 @@ fn concurrent_ensure_calls_over_stale_target_converge_to_one_consistent_refresh(
     );
     assert_eq!(
         stamp::read(tmp.path()).as_deref(),
-        Some(current_bundle_stamp().unwrap().as_str()),
+        Some(current_bundle_stamp::<BundledAgents>().unwrap().as_str()),
         "final stamp must match the current bundle content hash"
     );
 }
@@ -528,4 +528,40 @@ fn bundled_personas_grant_vector_search() {
             "{file} binds an OKG store but does not grant vector_search"
         );
     }
+}
+
+/// Why (#5227): making the workflow-mode pre-flight hierarchical only helps if
+/// a workflow definition actually reaches a tier on that hierarchy. The
+/// bundled `prescriptive.json` used to exist only inside a checkout of this
+/// repo, so a `cargo install`ed binary (or the GUI sidecar, `cwd = /`) had
+/// none anywhere. Pin that the workflows tree deploys through the same
+/// stamp-aware path the agent roster uses, and that `prescriptive.json` is in
+/// it — that file name is what `--workflow` defaults to.
+/// Test: itself.
+#[test]
+fn bundled_workflows_deploy_to_target() {
+    let tmp = tempfile::tempdir().unwrap();
+    let report = ensure_embedded_deployed_in::<BundledWorkflows>(tmp.path()).unwrap();
+
+    assert!(report.written > 0, "no bundled workflow files written");
+    assert!(
+        tmp.path().join("prescriptive.json").is_file(),
+        "prescriptive.json missing from the deployed workflows tree"
+    );
+
+    // Stamp-aware: a second pass over an unchanged bundle writes nothing.
+    let again = ensure_embedded_deployed_in::<BundledWorkflows>(tmp.path()).unwrap();
+    assert_eq!(again.total_touched(), 0, "re-deploy was not a no-op");
+}
+
+/// Why (#5227): agents and workflows share the deploy machinery but must never
+/// share a stamp — a workflows-tree deploy that wrote the agents stamp would
+/// make the next agent refresh believe it was up to date.
+/// Test: itself.
+#[test]
+fn agent_and_workflow_bundles_hash_differently() {
+    assert_ne!(
+        current_bundle_stamp::<BundledAgents>().unwrap(),
+        current_bundle_stamp::<BundledWorkflows>().unwrap()
+    );
 }

--- a/crates/trusty-agents/src/agents/registry/mod.rs
+++ b/crates/trusty-agents/src/agents/registry/mod.rs
@@ -440,22 +440,58 @@ fn resolve_extends_in_map(
     errors
 }
 
+/// Compute the search paths for one `.trusty-agents/<leaf>` config kind, in
+/// priority order (highest first).
+///
+/// Why: The project → user → bundled tier order is one discovery policy, not
+/// one per config kind. `agent_search_paths` was the only expression of it,
+/// so anything else that needed the same hierarchy (the workflow-mode
+/// pre-flight, workflow-definition lookup) either re-walked the tiers itself
+/// or — as in #5227 — consulted the process CWD alone and disagreed with the
+/// registry about whether a config existed.
+/// What: Returns, in order: `.trusty-agents/<leaf>`, `.claude/<leaf>`,
+/// `~/.trusty-agents/<leaf>`, `~/.claude/<leaf>`, `<config_dir>/<leaf>`.
+/// Paths are returned whether or not they exist; callers filter.
+/// Test: `agent_search_paths_order`, `workflow_search_paths_uses_the_workflows_leaf`
+/// — one per leaf, asserting the same five tiers in the same order.
+pub fn config_search_paths(config_dir: &Path, leaf: &str) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    paths.push(PathBuf::from(".trusty-agents").join(leaf));
+    paths.push(PathBuf::from(".claude").join(leaf));
+    if let Some(home) = std::env::var_os("HOME") {
+        paths.push(
+            PathBuf::from(home.clone())
+                .join(".trusty-agents")
+                .join(leaf),
+        );
+        paths.push(PathBuf::from(home).join(".claude").join(leaf));
+    }
+    paths.push(config_dir.join(leaf));
+    paths
+}
+
 /// Compute the agent search paths in priority order (highest first).
 ///
 /// Why: Centralizes the discovery policy — project-level overrides beat
 /// user-level overrides beat bundled defaults — so every call site
 /// (`main.rs`, `tagent agents list`, tests) sees the same order.
-/// What: Returns, in order: `.trusty-agents/agents`, `.claude/agents`,
-/// `~/.trusty-agents/agents`, `~/.claude/agents`, `<config_dir>/agents`.
+/// What: [`config_search_paths`] with the `agents` leaf — in order:
+/// `.trusty-agents/agents`, `.claude/agents`, `~/.trusty-agents/agents`,
+/// `~/.claude/agents`, `<config_dir>/agents`.
 /// Test: `agent_search_paths_order`.
 pub fn agent_search_paths(config_dir: &Path) -> Vec<PathBuf> {
-    let mut paths = Vec::new();
-    paths.push(PathBuf::from(".trusty-agents/agents"));
-    paths.push(PathBuf::from(".claude/agents"));
-    if let Some(home) = std::env::var_os("HOME") {
-        paths.push(PathBuf::from(home.clone()).join(".trusty-agents/agents"));
-        paths.push(PathBuf::from(home).join(".claude/agents"));
-    }
-    paths.push(config_dir.join("agents"));
-    paths
+    config_search_paths(config_dir, "agents")
+}
+
+/// Compute the workflow-definition search paths in priority order.
+///
+/// Why (#5227): `--workflow <name>` resolved `<name>.json` under a single
+/// CWD-relative `.trusty-agents/workflows`, while agents resolved
+/// hierarchically. A process whose CWD has no `.trusty-agents/` — the macOS
+/// `.app` sidecar runs with `cwd = /` — could therefore load 28 agents and
+/// still fail to find any workflow.
+/// What: [`config_search_paths`] with the `workflows` leaf.
+/// Test: `workflow_search_paths_uses_the_workflows_leaf`.
+pub fn workflow_search_paths(config_dir: &Path) -> Vec<PathBuf> {
+    config_search_paths(config_dir, "workflows")
 }

--- a/crates/trusty-agents/src/agents/registry/tests.rs
+++ b/crates/trusty-agents/src/agents/registry/tests.rs
@@ -557,6 +557,44 @@ fn agent_search_paths_order() {
     }
 }
 
+/// Why (#5227): `workflow_search_paths` and `agent_search_paths` must be the
+/// SAME hierarchy with a different leaf — if they ever diverge, the pre-flight
+/// starts disagreeing with resolution again, which is the defect this
+/// consolidation exists to prevent.
+/// Test: itself.
+#[test]
+fn workflow_search_paths_uses_the_workflows_leaf() {
+    // HOME_LOCK serializes with other tests that mutate $HOME process-wide.
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let prev_home = std::env::var_os("HOME");
+    // SAFETY: test-only; we restore HOME at the end.
+    unsafe {
+        std::env::set_var("HOME", "/tmp/home-test");
+    }
+
+    let config = Path::new("/opt/trusty-agents/config");
+    let agents = agent_search_paths(config);
+    let workflows = super::workflow_search_paths(config);
+
+    assert_eq!(agents.len(), workflows.len());
+    for (a, w) in agents.iter().zip(workflows.iter()) {
+        assert_eq!(
+            a.parent(),
+            w.parent(),
+            "tier order diverged: {a:?} vs {w:?}"
+        );
+        assert_eq!(a.file_name().unwrap(), "agents");
+        assert_eq!(w.file_name().unwrap(), "workflows");
+    }
+
+    unsafe {
+        match prev_home {
+            Some(h) => std::env::set_var("HOME", h),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+}
+
 #[test]
 fn build_roster_section_includes_all_registered_agents() {
     let tmp = TempDir::new().unwrap();

--- a/crates/trusty-agents/src/runtime/startup.rs
+++ b/crates/trusty-agents/src/runtime/startup.rs
@@ -172,6 +172,17 @@ pub(super) async fn run_startup_init(_args: &[String]) -> Result<bool> {
         .inspect_err(|e| tracing::warn!(error = %e, "failed to deploy bundled agents to $HOME"))
         .unwrap_or_default();
 
+    // #5227: same treatment for the bundled WORKFLOW definitions. Agents were
+    // the only config kind that ever reached the `$HOME` tier, so
+    // `--workflow prescriptive` launched from a directory with no
+    // `.trusty-agents/` (the GUI sidecar runs with `cwd = /`) had no
+    // definition to read anywhere on its search hierarchy. Same best-effort
+    // posture as the roster deploy above: a read-only `$HOME` degrades to the
+    // pre-fix "workflow not found", it does not crash the harness.
+    let _bundled_workflows_report = agents::bundled::ensure_bundled_workflows_deployed()
+        .inspect_err(|e| tracing::warn!(error = %e, "failed to deploy bundled workflows to $HOME"))
+        .unwrap_or_default();
+
     // #4325: create each Assistant INSTANCE's home directory
     // (`~/trusty-agents/<instance>/`) so the layout exists before anything
     // reaches for it. Placed here, immediately after the bundled roster is on

--- a/crates/trusty-agents/src/runtime/workflow_mode/helpers.rs
+++ b/crates/trusty-agents/src/runtime/workflow_mode/helpers.rs
@@ -44,7 +44,8 @@ pub(super) async fn build_runner_for_workflow(
     let path = if workflow_name.ends_with(".json") || workflow_name.contains('/') {
         PathBuf::from(workflow_name)
     } else {
-        PathBuf::from(".trusty-agents/workflows").join(format!("{workflow_name}.json"))
+        // #5227: resolve hierarchically, not from the CWD alone.
+        resolve_workflows_dir(workflow_name).join(format!("{workflow_name}.json"))
     };
 
     // Soft failure: if we can't read the workflow yet, just return the
@@ -289,23 +290,52 @@ pub(super) async fn build_init_context() -> Option<crate::init::InitContext> {
     }
 }
 
-/// Pre-flight check that the project's `.trusty-agents/{agents,workflows}/` dirs
-/// exist, emitting actionable bootstrap errors when they don't (#218).
+/// Pre-flight check that `agents/` and `workflows/` config directories are
+/// reachable somewhere on the search hierarchy (#218, #5227).
 ///
 /// Why: Extracted from `run_workflow` so the orchestration body stays focused;
 /// failing here with a clear message beats a cryptic sub-agent spawn panic.
-/// What: Bails with copy-paste bootstrap instructions when either dir is absent.
-/// Test: Exercised via the workflow integration tests (missing-dir path).
+/// What: Thin wrapper that resolves the same hierarchical search paths agent
+/// and workflow resolution use, then delegates to
+/// [`check_workflow_project_dirs_in`].
+/// Test: `check_workflow_project_dirs_in`'s hermetic tests carry the coverage;
+/// this wrapper only resolves the paths.
 pub(super) fn check_workflow_project_dirs() -> Result<()> {
+    // #5227: consult the registry's hierarchy, not the process CWD alone.
+    let config_dir = crate::default_bundled_config_dir();
+    check_workflow_project_dirs_in(
+        &agents::registry::agent_search_paths(&config_dir),
+        &agents::registry::workflow_search_paths(&config_dir),
+    )
+}
+
+/// Hermetic core of [`check_workflow_project_dirs`] — takes the resolved
+/// search paths explicitly (#5227).
+///
+/// Why: The pre-flight used to test one CWD-derived path while the registry
+/// loaded agents hierarchically, so a process launched with a CWD that has no
+/// `.trusty-agents/` — the macOS `.app` sidecar runs with `cwd = /` — bailed
+/// with ``no `.trusty-agents/agents/` found in /`` moments after logging
+/// `agent registry loaded … count=28`. Taking the paths as a parameter also
+/// makes this testable without mutating the process-global CWD or `$HOME`.
+/// What: Succeeds as soon as ANY path in each list is a directory; otherwise
+/// bails naming every path that was searched, so the next reader does not have
+/// to guess which tier was missing.
+/// Test: `preflight_accepts_a_global_agents_dir_when_cwd_has_none`,
+/// `preflight_error_names_every_searched_agent_path`,
+/// `preflight_requires_a_workflows_dir_somewhere`.
+pub(super) fn check_workflow_project_dirs_in(
+    agent_paths: &[PathBuf],
+    workflow_paths: &[PathBuf],
+) -> Result<()> {
     use anyhow::bail;
-    let cwd_for_check = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let agents_dir_check = cwd_for_check.join(".trusty-agents").join("agents");
-    if !agents_dir_check.exists() {
+    if !agent_paths.iter().any(|p| p.is_dir()) {
         bail!(
-            "no `.trusty-agents/agents/` found in {}.\n\n\
-             trusty-agents needs an agent config directory in the current project.\n\
-             To bootstrap a new project, copy bundled defaults from your \
-             trusty-agents install:\n\n  \
+            "no `agents/` config directory found on any search path.\n\n\
+             Searched (highest priority first):\n{}\n\n\
+             trusty-agents needs an agent config directory in the current \
+             project or under `$HOME`. To bootstrap a project, copy bundled \
+             defaults from your trusty-agents install:\n\n  \
                mkdir -p .trusty-agents\n  \
                cp -r <trusty-agents-source>/.trusty-agents/agents .trusty-agents/\n  \
                cp -r <trusty-agents-source>/.trusty-agents/workflows .trusty-agents/\n  \
@@ -313,20 +343,61 @@ pub(super) fn check_workflow_project_dirs() -> Result<()> {
              Also ensure `.env.local` (or the env) contains `OPENROUTER_API_KEY=...`.\n\
              A future `tagent init` subcommand will automate this; \
              see GitHub issue #218.",
-            cwd_for_check.display()
+            render_searched_paths(agent_paths)
         );
     }
-    let workflows_dir_check = cwd_for_check.join(".trusty-agents").join("workflows");
-    if !workflows_dir_check.exists() {
+    if !workflow_paths.iter().any(|p| p.is_dir()) {
         bail!(
-            "no `.trusty-agents/workflows/` found in {}.\n\n\
-             Copy bundled workflow definitions from your trusty-agents install:\n\n  \
+            "no `workflows/` config directory found on any search path.\n\n\
+             Searched (highest priority first):\n{}\n\n\
+             Copy bundled workflow definitions from your trusty-agents \
+             install:\n\n  \
                cp -r <trusty-agents-source>/.trusty-agents/workflows .trusty-agents/\n\n\
              See GitHub issue #218.",
-            cwd_for_check.display()
+            render_searched_paths(workflow_paths)
         );
     }
     Ok(())
+}
+
+/// Resolve the workflows directory that should serve `<name>.json` (#5227).
+///
+/// Why: `--workflow <name>` used a single CWD-relative
+/// `.trusty-agents/workflows`, so a process whose CWD has no `.trusty-agents/`
+/// could resolve every agent hierarchically and still fail `WorkflowNotFound`.
+/// Agents already fall back to `~/.trusty-agents/agents`; workflows now fall
+/// back the same way, and `runtime::startup` deploys the bundled definitions
+/// into `~/.trusty-agents/workflows` so that tier is populated.
+/// What: Returns the highest-priority search path that actually holds
+/// `<name>.json`; failing that, the highest-priority path that exists at all
+/// (so the engine's own error names a real directory); failing that, the
+/// legacy CWD-relative default.
+/// Test: `resolve_workflows_dir_prefers_the_tier_holding_the_definition`,
+/// `resolve_workflows_dir_falls_back_to_the_legacy_default`.
+pub(super) fn resolve_workflows_dir(name: &str) -> PathBuf {
+    let paths = agents::registry::workflow_search_paths(&crate::default_bundled_config_dir());
+    resolve_workflows_dir_in(&paths, name)
+}
+
+/// Hermetic core of [`resolve_workflows_dir`] — takes the candidate tiers
+/// explicitly so tests need not touch `$HOME` or the process CWD.
+fn resolve_workflows_dir_in(paths: &[PathBuf], name: &str) -> PathBuf {
+    let file = format!("{name}.json");
+    paths
+        .iter()
+        .find(|p| p.join(&file).is_file())
+        .or_else(|| paths.iter().find(|p| p.is_dir()))
+        .cloned()
+        .unwrap_or_else(|| PathBuf::from(".trusty-agents/workflows"))
+}
+
+/// Render a search-path list as indented `  - <path>` lines for an error body.
+fn render_searched_paths(paths: &[PathBuf]) -> String {
+    paths
+        .iter()
+        .map(|p| format!("  - {}", p.display()))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Resolve the workflow artifacts directory, auto-generating one when the
@@ -459,4 +530,111 @@ pub(super) async fn load_user_memory_suffix() -> Option<String> {
 /// Test: Exercised via the workflow integration tests.
 pub(super) async fn refresh_global_skills_cache(cwd_for_skills: &Path) {
     crate::skills::global_cache::refresh_global_cache(cwd_for_skills).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why (#5227): the defect. Agent resolution walks the hierarchy, so a
+    /// process whose CWD holds no `.trusty-agents/agents/` still resolves
+    /// agents from `~/.trusty-agents/agents/` — the macOS `.app` sidecar runs
+    /// with `cwd = /` and hits exactly this. The pre-flight consulted the CWD
+    /// alone and bailed anyway, killing every Implementation task launched
+    /// from the GUI. Pinning the fix: a lower-priority tier that exists is
+    /// enough.
+    /// Test: itself.
+    #[test]
+    fn preflight_accepts_a_global_agents_dir_when_cwd_has_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let global_agents = tmp.path().join("home/.trusty-agents/agents");
+        let global_workflows = tmp.path().join("home/.trusty-agents/workflows");
+        std::fs::create_dir_all(&global_agents).unwrap();
+        std::fs::create_dir_all(&global_workflows).unwrap();
+
+        // Highest-priority tier (the CWD-relative one) is absent, exactly as
+        // it is under `cwd = /`.
+        let missing_project = tmp.path().join("cwd/.trusty-agents");
+        let agent_paths = vec![missing_project.join("agents"), global_agents];
+        let workflow_paths = vec![missing_project.join("workflows"), global_workflows];
+
+        check_workflow_project_dirs_in(&agent_paths, &workflow_paths).unwrap();
+    }
+
+    /// Why: the old message named only the CWD, which is what made the failure
+    /// hard to diagnose — the reader could not tell which tiers were consulted.
+    /// Test: itself.
+    #[test]
+    fn preflight_error_names_every_searched_agent_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = tmp.path().join("one/agents");
+        let b = tmp.path().join("two/agents");
+        let err = check_workflow_project_dirs_in(&[a.clone(), b.clone()], &[])
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            err.contains(&a.display().to_string()),
+            "missing {a:?}: {err}"
+        );
+        assert!(
+            err.contains(&b.display().to_string()),
+            "missing {b:?}: {err}"
+        );
+    }
+
+    /// Why: a `workflows/` tier that exists nowhere must still fail loudly —
+    /// widening the agent search must not silently drop the workflow check.
+    /// Test: itself.
+    #[test]
+    fn preflight_requires_a_workflows_dir_somewhere() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        let workflows = tmp.path().join("nowhere/workflows");
+
+        let err = check_workflow_project_dirs_in(&[agents], std::slice::from_ref(&workflows))
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("`workflows/`"), "{err}");
+        assert!(err.contains(&workflows.display().to_string()), "{err}");
+    }
+
+    /// Why (#5227): a lower-priority tier holding the definition must beat a
+    /// higher-priority tier that merely exists — otherwise deploying the
+    /// bundled workflows to `$HOME` would be shadowed by any project that has
+    /// a `.trusty-agents/workflows/` directory for unrelated reasons.
+    /// Test: itself.
+    #[test]
+    fn resolve_workflows_dir_prefers_the_tier_holding_the_definition() {
+        let tmp = tempfile::tempdir().unwrap();
+        let empty = tmp.path().join("project/workflows");
+        let populated = tmp.path().join("home/workflows");
+        std::fs::create_dir_all(&empty).unwrap();
+        std::fs::create_dir_all(&populated).unwrap();
+        std::fs::write(populated.join("prescriptive.json"), "{}").unwrap();
+
+        let resolved =
+            resolve_workflows_dir_in(&[empty.clone(), populated.clone()], "prescriptive");
+        assert_eq!(resolved, populated);
+
+        // With no tier holding it, the highest-priority EXISTING tier wins so
+        // the engine's own error names a real directory.
+        let resolved = resolve_workflows_dir_in(&[empty.clone(), populated], "absent");
+        assert_eq!(resolved, empty);
+    }
+
+    /// Why: when no tier exists at all the caller still needs a path to report;
+    /// keep the pre-#5227 default rather than an empty one.
+    /// Test: itself.
+    #[test]
+    fn resolve_workflows_dir_falls_back_to_the_legacy_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("nothing/here");
+        assert_eq!(
+            resolve_workflows_dir_in(&[missing], "prescriptive"),
+            PathBuf::from(".trusty-agents/workflows")
+        );
+    }
 }

--- a/crates/trusty-agents/src/runtime/workflow_mode/mod.rs
+++ b/crates/trusty-agents/src/runtime/workflow_mode/mod.rs
@@ -116,7 +116,7 @@ mod resume;
 use helpers::{
     build_init_context, build_runner_for_workflow, check_workflow_project_dirs,
     collect_modified_files, load_skill_registry, load_tag_skill_registry, load_user_memory_suffix,
-    read_current_build_number, refresh_global_skills_cache, resolve_out_dir,
+    read_current_build_number, refresh_global_skills_cache, resolve_out_dir, resolve_workflows_dir,
 };
 
 pub(super) use resume::run_resume_subcommand;
@@ -324,7 +324,12 @@ pub(super) async fn run_workflow(
     // bundled+local skills.
     let tag_skill_registry = load_tag_skill_registry();
 
-    let mut engine = WorkflowEngine::new(runner, PathBuf::from(".trusty-agents/workflows"))
+    // #5227: the workflows dir resolves hierarchically (project -> $HOME ->
+    // bundled), so a process whose CWD has no `.trusty-agents/` still finds
+    // the definition instead of failing `WorkflowNotFound`.
+    let workflows_dir = resolve_workflows_dir(name);
+
+    let mut engine = WorkflowEngine::new(runner, workflows_dir.clone())
         .with_build(build_num)
         .with_perf_dir(Some(perf_dir))
         .with_indexer(Some(indexer))
@@ -343,7 +348,7 @@ pub(super) async fn run_workflow(
         let wf_path = if name.ends_with(".json") || name.contains('/') {
             PathBuf::from(name)
         } else {
-            PathBuf::from(".trusty-agents/workflows").join(format!("{name}.json"))
+            workflows_dir.join(format!("{name}.json"))
         };
         if let Ok(def) = workflow::WorkflowDef::load(&wf_path)
             && let Some(tm_cfg) = def.ticket_management.clone()

--- a/crates/trusty-agents/src/runtime/workflow_mode/resume.rs
+++ b/crates/trusty-agents/src/runtime/workflow_mode/resume.rs
@@ -96,13 +96,19 @@ pub(crate) async fn run_resume_subcommand(args: &[String]) -> Result<()> {
     let tag_skill_registry = load_tag_skill_registry();
     let user_memory_suffix = load_user_memory_suffix().await;
 
-    let engine = WorkflowEngine::new(runner, PathBuf::from(".trusty-agents/workflows"))
-        .with_build(build_num)
-        .with_perf_dir(Some(perf_dir))
-        .with_skill_registry(Some(skill_registry))
-        .with_tag_skill_registry(Some(tag_skill_registry))
-        .with_user_memory(user_memory_suffix)
-        .with_progress(Some(Arc::new(crate::progress::ProgressReporter::new())));
+    // #5227: resume must resolve the workflows dir the same hierarchical way
+    // the original run did, or a resume from a different CWD reads no
+    // definition at all.
+    let engine = WorkflowEngine::new(
+        runner,
+        super::helpers::resolve_workflows_dir(&record.workflow),
+    )
+    .with_build(build_num)
+    .with_perf_dir(Some(perf_dir))
+    .with_skill_registry(Some(skill_registry))
+    .with_tag_skill_registry(Some(tag_skill_registry))
+    .with_user_memory(user_memory_suffix)
+    .with_progress(Some(Arc::new(crate::progress::ProgressReporter::new())));
 
     match engine.resume_with_perf_and_dirs(&run_id).await? {
         ResumeOutcome::AlreadyDone { run_id } => {


### PR DESCRIPTION
## Problem

The workflow-mode pre-flight read only `std::env::current_dir()`. The macOS `.app` sidecar's cwd is `/`, and the GUI sends `project_path: project.path ?? null`, so the child inherited `/`. The pre-flight bailed with ``no `.trusty-agents/agents/` found in /`` moments after the registry had already resolved agents hierarchically from `~/.trusty-agents/agents/`. Every Implementation task submitted from the GUI failed.

## Fix

The pre-flight now consults the same project → `$HOME` → bundled search paths the agent registry uses, via `config_search_paths` extracted from the existing `agent_search_paths` (`crates/trusty-agents/src/agents/registry/mod.rs:456`); `agent_search_paths` is now a pure delegate with byte-identical output. The error message lists every searched path instead of one.

## Why it also embeds workflows

Workflows do NOT ship in the bundled tree (`crates/trusty-agents/src/agents/bundled/mod.rs:88` embeds only `.trusty-agents/agents/`), and the engine reads `{config_dir}/{name}.json` at runtime. Fixing only the agents lookup would have moved the failure two steps later into `WorkflowNotFound`. So the change embeds `.trusty-agents/workflows/` and deploys it to `~/.trusty-agents/workflows/` at startup, reusing the agent deploy machinery generically (`ensure_embedded_deployed_in::<E>`) rather than copying it.

## Test ladder rung

Rung 4 (adds two `pub` fns). Commands run after rebasing onto current `origin/main`:

```
SKIP_UI_BUILD=1 cargo fmt --check
  → exit 0

SKIP_UI_BUILD=1 cargo clippy -p trusty-agents --all-targets -- -D warnings
  → exit 0

SKIP_UI_BUILD=1 cargo test -p trusty-agents
  → test result: ok. 3415 passed; 0 failed; 11 ignored; 0 measured; 0 filtered out
  → (plus additional test binaries, all: ok, 0 failed)

SKIP_UI_BUILD=1 cargo check -p trusty-agents-local --all-targets
  → exit 0

SKIP_UI_BUILD=1 cargo test -p trusty-agents-local
  → all green (consumer gate)

bash scripts/check_line_cap.sh
  → line-cap: measured 3818 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.

bash scripts/check_changelog_fragment.sh
  → OK   trusty-agents: changelog.d fragment present and valid
```

## Proof it failed before

(a) End-to-end: a rebuilt `origin/main` binary in the same sandbox errors ``no `.trusty-agents/agents/` found``, while this branch gets past pre-flight and reads `prescriptive.json`.

(b) Three unit tests transcribed onto main's cwd-only logic fail 3/3, pass 3/3 on this branch.

## Deploy behavior

First deploy skips files that already exist; a stale-stamp refresh archives differing content to `<file>.stale.bak` before writing via `atomic_write`. A user-authored workflow is never silently destroyed.

## Known follow-ups

`VERSIONING.md` ships in the embedded tree and lands in `~/.trusty-agents/workflows/`; the `RustEmbed` folder attribute has no include/exclude filter (pre-existing, mirrors `BundledAgents`).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
