### PR TITLE
feat(trusty-agents): record and serve per-assistant task streams, and harden state-file permissions

### DIFF
--- a/crates/trusty-agents/changelog.d/4355-server-side-assistant-streams.md
+++ b/crates/trusty-agents/changelog.d/4355-server-side-assistant-streams.md
@@ -1,0 +1,32 @@
+Added
+
+- Tasks now record which assistant they were addressed to, and the API can
+  return one assistant's task stream in a single call (refs
+  [#4355](https://github.com/bobmatnyc/trusty-tools/issues/4355),
+  [#4278](https://github.com/bobmatnyc/trusty-tools/issues/4278)). Selecting a
+  roster entry on `POST /api/task` used to be consumed at dispatch to pick a
+  code path and then discarded, so nothing downstream could say which
+  conversation a task belonged to. `PmResponse` now carries `addressed_agent` —
+  who was ASKED, distinct from the existing `responder_agent`, which records who
+  ANSWERED and is populated only when a turn delegated. A turn addressed to
+  `assistant` that delegates to `izzie` stays in the `assistant` stream while
+  the bubble is still labelled `izzie`. A submission with no roster selection
+  is attributed to the Concierge (`ctrl`), matching what a null selection
+  already means in the desktop client.
+  - `GET /api/tasks` accepts `?agent=<name>` and `?limit=<n>`. Omitting both
+    returns the previous unfiltered listing unchanged; a blank `agent` is
+    treated as absent, and an assistant with no history returns `[]` rather
+    than an error.
+  - Retention is now per assistant rather than server-wide. The old single cap
+    of 20 would have divided across the roster once streams were split — about
+    three turns of history each for six assistants — so each stream keeps its
+    own 20, with a 200-row server-wide backstop that bounds memory when a
+    client mints unbounded distinct agent names. A single-assistant user sees
+    exactly the depth they saw before. Eviction still never takes a running
+    task, and cancelling a task no longer moves it out of its own stream.
+  - A `tasks.json` written by an earlier version still loads: the new field
+    defaults rather than failing, so upgrading does not discard task history.
+    Its rows land in the Concierge stream.
+
+Note: this is the server half only. Wiring the desktop client to load a stream
+on assistant switch is a separate change.

--- a/crates/trusty-agents/changelog.d/4355-state-file-permissions.md
+++ b/crates/trusty-agents/changelog.d/4355-state-file-permissions.md
@@ -16,10 +16,11 @@ Security
     (`interactions.jsonl`, `runs.jsonl`) created before this change keeps its
     mode until it is rotated — it cannot be recreated without discarding the
     log.
-  - `tasks.json` was writing itself through a private copy of the tmp+rename
-    logic and so was the one state file skipping this path entirely. It now
-    goes through the shared writer, which also gives it the cross-process
-    advisory lock the GUI, the API sidecar, and a source build need when they
-    share `.trusty-agents/`.
+  - `tasks.json` and the per-session recap files were each writing themselves
+    directly and so were the two state files skipping this path entirely. Both
+    now go through the shared writer, which also gives `tasks.json` the
+    cross-process advisory lock the GUI, the API sidecar, and a source build
+    need when they share `.trusty-agents/`. A recap summarises task
+    narratives, so it was exactly as sensitive as the file it derives from.
   - No behavior change on Windows, where these paths already sit inside a
     per-user profile directory.

--- a/crates/trusty-agents/changelog.d/4355-state-file-permissions.md
+++ b/crates/trusty-agents/changelog.d/4355-state-file-permissions.md
@@ -1,0 +1,25 @@
+Security
+
+- State files under `.trusty-agents/` are now created owner-only (`0600`)
+  instead of at the process umask, which typically left them world-readable
+  (refs [#4355](https://github.com/bobmatnyc/trusty-tools/issues/4355)). These
+  files hold prompts, task narratives, session records, and captured
+  child-process stderr that is credential-scrubbed but not proven secret-free,
+  so on a shared host they were readable by every local account.
+  - The mode is set when the file is created rather than by a follow-up
+    `chmod`, so there is no window in which the content exists at the wider
+    mode. A temp file orphaned by an earlier crashed write is removed before
+    the new one is created, so a stale `0644` temp can no longer carry its
+    mode onto the published file through the rename.
+  - An existing world-readable file is tightened by the next write, because
+    the rename publishes the owner-only temp over it. An append-only log
+    (`interactions.jsonl`, `runs.jsonl`) created before this change keeps its
+    mode until it is rotated — it cannot be recreated without discarding the
+    log.
+  - `tasks.json` was writing itself through a private copy of the tmp+rename
+    logic and so was the one state file skipping this path entirely. It now
+    goes through the shared writer, which also gives it the cross-process
+    advisory lock the GUI, the API sidecar, and a source build need when they
+    share `.trusty-agents/`.
+  - No behavior change on Windows, where these paths already sit inside a
+    per-user profile directory.

--- a/crates/trusty-agents/src/api/builder.rs
+++ b/crates/trusty-agents/src/api/builder.rs
@@ -108,6 +108,12 @@ pub fn build_from_workflow(
         // signal to attribute; the in-process chat path sets this in
         // `api/server/handlers.rs::submit_task` instead.
         responder_agent: None,
+        // #4355: this envelope is built inside the workflow subprocess, which
+        // is never told which roster entry the user had selected. The API
+        // server stamps the stream on the way to the store
+        // (`api/server/handlers.rs::submit_task`), so the Concierge default is
+        // only ever observed by the `--json` CLI path, where it is correct.
+        addressed_agent: crate::api::types::DEFAULT_ADDRESSED_AGENT.to_string(),
     }
 }
 

--- a/crates/trusty-agents/src/api/server/handlers.rs
+++ b/crates/trusty-agents/src/api/server/handlers.rs
@@ -17,9 +17,9 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::state::{AppState, state_dir};
+use super::state::{AppState, MAX_RETAINED_TOTAL, state_dir};
 use super::task_runner::{maybe_emit_recap, run_task};
-use crate::api::types::{PmResponse, PmStatus};
+use crate::api::types::{DEFAULT_ADDRESSED_AGENT, PmResponse, PmStatus};
 use crate::events::{self, Event};
 use crate::recap;
 
@@ -205,6 +205,24 @@ fn agent_override(req: &TaskRequest) -> Option<String> {
         .map(str::to_string)
 }
 
+/// Resolve which assistant's stream a submission belongs to (#4355).
+///
+/// Why: `agent_override` answers a routing question and legitimately returns
+/// `None`; a task stream cannot. Every task belongs to exactly one assistant,
+/// and a submission with no roster selection belongs to the Concierge —
+/// `ui/src/lib/roster.ts` renders Concierge for a `null` selection, so `null`
+/// already MEANS `ctrl` to the user. This differs from
+/// `resolve_agent_for_chat` on purpose: a CTRL management command typed while
+/// a roster entry is selected is dispatched through the session path
+/// (`resolve_agent_for_chat` → `None`) but still belongs in the stream the
+/// user was looking at when they typed it.
+/// What: `agent_override(req)`, or `DEFAULT_ADDRESSED_AGENT`.
+/// Test: `addressed_agent_records_the_selected_roster_entry`,
+/// `addressed_agent_for_defaults_to_ctrl`.
+fn addressed_agent_for(req: &TaskRequest) -> String {
+    agent_override(req).unwrap_or_else(|| DEFAULT_ADDRESSED_AGENT.to_string())
+}
+
 /// Resolve which Conversational/Research dispatch path a request should
 /// take (#3223; extracted as a pure function during the PR #3279
 /// code-critic regression fix).
@@ -317,7 +335,12 @@ pub(super) async fn submit_task(
     Json(req): Json<TaskRequest>,
 ) -> impl IntoResponse {
     let id = uuid::Uuid::new_v4().to_string();
-    let placeholder = PmResponse::running(&id);
+    // #4355: stamp the stream on the placeholder, not just on the final
+    // result — a task is listed and polled from the moment it is accepted, so
+    // an unstamped placeholder would show up in the Concierge stream and then
+    // jump to another assistant's when it finished.
+    let addressed_agent = addressed_agent_for(&req);
+    let placeholder = PmResponse::running(&id).addressed_to(&addressed_agent);
     state.upsert(id.clone(), placeholder).await;
 
     // #4652: this request is a person typing in the GUI/WebUI, which is the
@@ -330,7 +353,9 @@ pub(super) async fn submit_task(
     // to assert on without writing into the developer's real home.
     crate::attendance::note_command_turn_in(
         state.attendance_root.as_deref(),
-        agent_override(&req).as_deref().unwrap_or("ctrl"),
+        // #4355: the same resolution the stream uses — one answer to "which
+        // assistant did the human address", not two that can drift.
+        &addressed_agent,
         crate::attendance::TurnOrigin::Human,
         // The API sidecar's "sender is entitled to assert presence" check: a
         // request that reached this handler is already past the server's auth
@@ -418,6 +443,7 @@ pub(super) async fn submit_task(
                 .map(std::path::PathBuf::from)
                 .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
             let agent_bg = agent_for_chat.clone();
+            let addressed_bg = addressed_agent.clone();
             let overrides_bg = overrides.clone();
             let intent_label = match intent {
                 IntentClass::Conversational => "conversational",
@@ -463,9 +489,12 @@ pub(super) async fn submit_task(
                 // GUI keeps its request-time speaker stamp.
                 let responder = drain_last_responder(&mut ev_rx, &id_bg);
 
+                // #4355: both terminal shapes re-stamp the stream — these are
+                // fresh envelopes, not edits to the stored placeholder, so an
+                // unstamped one would land in the Concierge stream on finalize.
                 let resp = match result {
                     Ok(content) => {
-                        let mut r = PmResponse::running(&id_bg);
+                        let mut r = PmResponse::running(&id_bg).addressed_to(&addressed_bg);
                         r.response_type = crate::api::types::PmResponseType::AgentResponse;
                         r.status = PmStatus::Success;
                         r.narrative = content;
@@ -474,6 +503,7 @@ pub(super) async fn submit_task(
                     }
                     Err(e) => {
                         PmResponse::error(&id_bg, format!("{intent_label} handler failed: {e:#}"))
+                            .addressed_to(&addressed_bg)
                     }
                 };
 
@@ -497,12 +527,17 @@ pub(super) async fn submit_task(
             // the child inherits full env/init (build counter, tracing, run_id).
             let state_bg = state.clone();
             let id_bg = id.clone();
+            let addressed_bg = addressed_agent.clone();
             let join = tokio::spawn(async move {
+                // #4355: `run_task` builds its envelope from the subprocess's
+                // own JSON and knows nothing about the roster, so the stream is
+                // stamped here, on the way to the store.
                 let resp = run_task(&id_bg, req, state_bg.clone())
                     .await
                     .unwrap_or_else(|e| {
                         PmResponse::error(&id_bg, format!("server failed to run task: {e:#}"))
-                    });
+                    })
+                    .addressed_to(&addressed_bg);
                 let status_str = resp.status.as_str().to_string();
                 // #3063: see the Conversational/Research branch above for why
                 // finalize_task (not upsert) is used here.
@@ -573,9 +608,52 @@ pub(super) async fn get_session_recap(
     }
 }
 
-/// `GET /api/tasks` — list up to `MAX_RETAINED` recent responses, newest first.
-pub(super) async fn list_tasks(State(state): State<AppState>) -> Json<Vec<PmResponse>> {
-    Json(state.list().await)
+/// Query string for `GET /api/tasks` (#4355).
+///
+/// Why: the per-assistant stream extends this route rather than minting a
+/// parallel one — the response element type is unchanged (`PmResponse`), the
+/// ordering contract is unchanged (newest first), and only the row set
+/// narrows, so a second route would duplicate the auth, envelope, and client
+/// plumbing to return the same thing. Both parameters are optional and
+/// omitting them reproduces the pre-#4355 response byte for byte.
+/// What: `agent` selects one assistant's stream (blank/whitespace is treated
+/// as absent, matching `agent_override`'s normalization of the same value on
+/// the submit side); `limit` caps the row count, clamped to
+/// `MAX_RETAINED_TOTAL` so a client cannot ask for more than the store holds.
+/// Test: `tasks_filtered_by_agent_returns_only_that_stream_newest_first`,
+/// `tasks_query_defaults_match_the_unfiltered_listing`.
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct ListTasksQuery {
+    #[serde(default)]
+    agent: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+/// `GET /api/tasks[?agent=<name>][&limit=<n>]` — recent responses, newest
+/// first; one assistant's stream when `agent` is given (#4355).
+///
+/// Why: "the most recent task stream for assistant X" must be answerable in a
+/// single call, server-side — see `AppState::list_stream` for why the server
+/// rather than the client owns that association.
+/// What: normalizes the query (see `ListTasksQuery`) and delegates to
+/// `list_stream`. An unknown agent name is not an error: it returns `[]`,
+/// which is the truthful answer for an assistant that has no history yet and
+/// the shape a freshly-added roster entry needs.
+/// Test: `tasks_filtered_by_agent_returns_only_that_stream_newest_first`,
+/// `list_tasks_empty_store_returns_empty_array`.
+pub(super) async fn list_tasks(
+    State(state): State<AppState>,
+    axum::extract::Query(q): axum::extract::Query<ListTasksQuery>,
+) -> Json<Vec<PmResponse>> {
+    let agent = q
+        .agent
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let limit = q.limit.map(|n| n.min(MAX_RETAINED_TOTAL));
+    Json(state.list_stream(agent.as_deref(), limit).await)
 }
 
 /// Response body for `DELETE /api/tasks`.
@@ -737,6 +815,39 @@ mod tests {
             text: "thinking".to_string(),
         });
         assert_eq!(drain_last_responder(&mut rx2, sid), None);
+    }
+
+    /// #4355: an explicit roster selection is the stream the task belongs to,
+    /// trimmed the same way `agent_override` trims it on the routing side.
+    #[test]
+    fn addressed_agent_records_the_selected_roster_entry() {
+        assert_eq!(addressed_agent_for(&base_request(Some("izzie"))), "izzie");
+        assert_eq!(
+            addressed_agent_for(&base_request(Some("  cto-assistant  "))),
+            "cto-assistant"
+        );
+    }
+
+    /// #4355: no selection, or a cleared one, is not "unattributed" — a null
+    /// roster selection MEANS the Concierge (`ui/src/lib/roster.ts`), so those
+    /// tasks belong to the `ctrl` stream and are retrievable there.
+    #[test]
+    fn addressed_agent_for_defaults_to_ctrl() {
+        assert_eq!(addressed_agent_for(&base_request(None)), "ctrl");
+        assert_eq!(addressed_agent_for(&base_request(Some(""))), "ctrl");
+        assert_eq!(addressed_agent_for(&base_request(Some("   "))), "ctrl");
+    }
+
+    /// #4355: "who was asked" and "which dispatch path" are different
+    /// questions. A CTRL management command typed with a roster entry selected
+    /// runs through the session path (`resolve_agent_for_chat` → `None`, the
+    /// only path wired to CTRL's project tools) but still belongs in the
+    /// stream the user was looking at when they typed it.
+    #[test]
+    fn ctrl_command_keeps_its_stream_while_changing_dispatch_path() {
+        let req = base_request(Some("cto-assistant"));
+        assert_eq!(resolve_agent_for_chat(&req, true), None);
+        assert_eq!(addressed_agent_for(&req), "cto-assistant");
     }
 
     #[test]

--- a/crates/trusty-agents/src/api/server/state.rs
+++ b/crates/trusty-agents/src/api/server/state.rs
@@ -637,25 +637,26 @@ async fn load_persisted_tasks() -> Option<TaskStore> {
 
 /// Persist the given task map to disk atomically.
 ///
-/// Why: A naive `write` to the live file risks readers (or a crash) seeing
-/// a half-written file. Writing to a sibling temp path and renaming is
-/// atomic on the same filesystem on POSIX, so observers either see the old
-/// snapshot or the new one — never a corrupt one.
-/// What: Ensures the parent directory exists, writes JSON to
-/// `tasks.json.tmp`, then `rename`s onto `tasks.json`. Logs (but does not
-/// fail) on I/O errors — losing a snapshot is preferable to crashing the
-/// running server.
-/// Test: Call with a sample map, assert the target file parses back to the
-/// same map; force the parent dir to be missing and assert no panic.
+/// Why: A naive `write` to the live file risks readers (or a crash) seeing a
+/// half-written file. This used to open-code its own tmp+rename, which was a
+/// second implementation of what `state_writer` — the crate's entry point for
+/// exactly this — already owned, and it is how this file ended up as the one
+/// state file written without the owner-only mode `state_writer` now applies:
+/// `tasks.json` holds task narratives, including credential-scrubbed but not
+/// provably secret-free child-process stderr (#5230). Routing through the
+/// shared writer also buys the cross-process advisory lock the GUI, the
+/// `--api` sidecar, and a `cargo run` build need when they share
+/// `.trusty-agents/`.
+/// What: Serializes the map, then hands the write to
+/// `state_writer::atomic_write` (parent-dir creation, lock, `0600` tmp,
+/// fsync, rename) on a blocking worker — `fs4`'s lock syscalls block, the same
+/// reason `interaction_log` and `session_record` bridge through
+/// `spawn_blocking`. Logs (but does not fail) on I/O errors: losing a snapshot
+/// is preferable to crashing the running server.
+/// Test: `atomic_write_creates_an_owner_only_file`,
+/// `atomic_write_tightens_an_existing_world_readable_file`.
 async fn persist_tasks(responses: &HashMap<String, PmResponse>) {
     let path = tasks_persistence_path();
-    let tmp = path.with_extension("json.tmp");
-    if let Some(parent) = path.parent()
-        && let Err(e) = tokio::fs::create_dir_all(parent).await
-    {
-        tracing::warn!(?e, "failed to create state dir for tasks.json");
-        return;
-    }
     let json = match serde_json::to_vec(responses) {
         Ok(j) => j,
         Err(e) => {
@@ -663,11 +664,10 @@ async fn persist_tasks(responses: &HashMap<String, PmResponse>) {
             return;
         }
     };
-    if let Err(e) = tokio::fs::write(&tmp, &json).await {
-        tracing::warn!(?e, "failed to write tasks.json.tmp");
-        return;
-    }
-    if let Err(e) = tokio::fs::rename(&tmp, &path).await {
-        tracing::warn!(?e, "failed to rename tasks.json.tmp -> tasks.json");
+    match tokio::task::spawn_blocking(move || crate::state_writer::atomic_write(&path, &json)).await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::warn!(?e, "failed to persist tasks.json"),
+        Err(e) => tracing::warn!(?e, "tasks.json persist worker failed to join"),
     }
 }

--- a/crates/trusty-agents/src/api/server/state.rs
+++ b/crates/trusty-agents/src/api/server/state.rs
@@ -20,8 +20,36 @@ use crate::events::{self, Event};
 use crate::recap::{RecapConfig, RecapTracker};
 use crate::tm::TmManager;
 
-/// Maximum number of terminal responses retained in memory.
-pub(super) const MAX_RETAINED: usize = 20;
+/// Maximum number of responses retained in memory PER addressed assistant
+/// (#4355).
+///
+/// Why: this used to be a single server-wide cap of 20. Once tasks are split
+/// into per-assistant streams a server-wide cap divides across the roster —
+/// six assistants would get roughly three turns of history each, which makes
+/// "switch assistant, see its stream" useless the moment it works. The bound
+/// that matters to a user is "how far back does MY assistant's stream go", so
+/// that is the bound the server enforces. The number is unchanged from the old
+/// global one, so a single-assistant user sees exactly the depth they saw
+/// before.
+/// What: `insert_and_trim` evicts the oldest non-`Running` row of an
+/// assistant's own stream once that stream exceeds this.
+/// Test: `per_agent_retention_keeps_n_for_each_assistant`.
+pub(super) const MAX_RETAINED_PER_AGENT: usize = 20;
+
+/// Server-wide backstop across all assistants (#4355).
+///
+/// Why: per-assistant retention alone is unbounded in the number of DISTINCT
+/// assistant ids — `TaskRequest.agent` is a free-form string, so a buggy or
+/// hostile client can mint a new stream per request and grow the store
+/// forever. This caps total memory (and the size of `tasks.json`, rewritten in
+/// full on every upsert) at 10× the old global bound regardless of roster
+/// size. At a ~4 KB typical `PmResponse` that is ~800 KB; a pathological
+/// 64 KB-narrative store would be ~13 MB, which is the ceiling this constant
+/// buys and the reason it is not larger.
+/// What: after per-stream trimming, `insert_and_trim` evicts the oldest
+/// non-`Running` row overall while the store exceeds this.
+/// Test: `global_backstop_caps_total_across_many_assistants`.
+pub(super) const MAX_RETAINED_TOTAL: usize = 200;
 
 /// Filesystem location for runtime state (recaps, tasks.json, etc.).
 ///
@@ -236,16 +264,26 @@ impl AppState {
     pub(super) async fn try_cancel(&self, id: &str) -> CancelOutcome {
         let (outcome, handle) = {
             let mut store = self.inner.lock().await;
-            match store.responses.get(id) {
+            // Snapshot the two facts needed about the existing row so the read
+            // borrow ends before the write below.
+            let existing = store
+                .responses
+                .get(id)
+                .map(|r| (r.status.clone(), r.addressed_agent.clone()));
+            match existing {
                 None => (CancelOutcome::NotFound, None),
-                Some(r) if r.status != PmStatus::Running => {
-                    (CancelOutcome::AlreadyTerminal(r.status.clone()), None)
+                Some((status, _)) if status != PmStatus::Running => {
+                    (CancelOutcome::AlreadyTerminal(status), None)
                 }
-                Some(_) => {
+                Some((_, agent)) => {
+                    // #4355: `cancelled()` starts from the Concierge default,
+                    // so carry the original stream over — otherwise cancelling
+                    // a task silently moves it into another assistant's history.
                     let handle = store.handles.remove(id);
-                    store
-                        .responses
-                        .insert(id.to_string(), PmResponse::cancelled(id));
+                    store.responses.insert(
+                        id.to_string(),
+                        PmResponse::cancelled(id).addressed_to(agent),
+                    );
                     (CancelOutcome::Cancelled, handle)
                 }
             }
@@ -304,18 +342,42 @@ impl AppState {
 
     /// List all stored responses, newest first.
     ///
-    /// Why: `GET /api/tasks` and recap assembly both need a recency-ordered
-    /// snapshot.
-    /// What: Walks the insertion order in reverse, cloning each response.
+    /// Why: recap assembly needs a recency-ordered snapshot of everything,
+    /// unfiltered.
+    /// What: `list_stream(None, None)`.
     /// Test: `list_tasks_empty_store_returns_empty_array`.
     pub(super) async fn list(&self) -> Vec<PmResponse> {
+        self.list_stream(None, None).await
+    }
+
+    /// One assistant's task stream (or the whole store), newest first (#4355).
+    ///
+    /// Why: this is the server-side half of "switching assistants loads that
+    /// assistant's most recent task stream" — the owner's decision was that the
+    /// association lives on the server, not in a per-client filter, so that all
+    /// clients attached to one running agent see the same stream. Answering it
+    /// here rather than by shipping every task to the client also means a
+    /// client never has to receive another assistant's conversation to decide
+    /// it should not display it.
+    /// What: walks insertion order in reverse (newest first), keeping rows
+    /// whose `addressed_agent` matches `agent` when one is given, and stops
+    /// after `limit` rows when one is given. `agent = None` reproduces the
+    /// pre-#4355 full listing exactly.
+    /// Test: `tasks_filtered_by_agent_returns_only_that_stream_newest_first`.
+    pub(super) async fn list_stream(
+        &self,
+        agent: Option<&str>,
+        limit: Option<usize>,
+    ) -> Vec<PmResponse> {
         let store = self.inner.lock().await;
-        // Newest first.
         store
             .order
             .iter()
             .rev()
-            .filter_map(|id| store.responses.get(id).cloned())
+            .filter_map(|id| store.responses.get(id))
+            .filter(|r| agent.is_none_or(|a| r.addressed_agent == a))
+            .take(limit.unwrap_or(usize::MAX))
+            .cloned()
             .collect()
     }
 
@@ -449,61 +511,95 @@ pub(super) enum CancelOutcome {
     Cancelled,
 }
 
-/// Insert `resp` for `id`, tracking insertion order and trimming to
-/// `MAX_RETAINED`. Returns a clone of the resulting map for the caller to
-/// persist outside the lock.
+/// Insert `resp` for `id`, tracking insertion order and trimming the store
+/// to its per-assistant and server-wide bounds. Returns a clone of the
+/// resulting map for the caller to persist outside the lock.
 ///
 /// Why: Shared by `upsert` (always overwrites) and `finalize_task` (which
 /// adds a cancellation guard before calling this). Keeping the
 /// insert/track/trim logic in one place avoids the two call sites drifting.
 /// A naive index-0 FIFO eviction would silently orphan a genuinely
-/// `Running` task once `MAX_RETAINED` unrelated tasks churn through the
+/// `Running` task once the cap's worth of unrelated tasks churn through the
 /// store: its `responses`/`order` row disappears while its `AbortHandle`
 /// stays in `handles` forever, and `try_cancel` (which looks the id up in
 /// `responses` first) then 404s a task that is very much still alive
 /// (issue #3063 code review).
-/// What: Inserts, appends to `order` iff the key was previously absent,
-/// then evicts entries past `MAX_RETAINED` — walking forward from the
-/// oldest to find the first entry whose status isn't `Running` and
-/// evicting that one instead of blindly evicting index 0, removing its
-/// `handles` entry too so the maps stay in lockstep. If every retained row
-/// happens to be `Running`, eviction is skipped entirely for this call
-/// (never kill a live task to make room) — in practice this only lets the
-/// store grow transiently, since concurrently `Running` tasks are rare.
-/// Test: `app_state_trims_to_max_retained` (via `upsert`, all-terminal
-/// case); `cancel_survives_fifo_eviction_pressure` (a `Running` task
-/// planted before `MAX_RETAINED` terminal tasks must still be reachable).
+/// What: Inserts, appends to `order` iff the key was previously absent, then
+/// trims twice (#4355) — first the touched assistant's own stream down to
+/// `MAX_RETAINED_PER_AGENT`, then the whole store down to
+/// `MAX_RETAINED_TOTAL`. Trimming the touched stream FIRST is what keeps one
+/// busy assistant from evicting an idle assistant's history: the global pass
+/// only fires when the roster as a whole is oversized. Both passes go through
+/// `evict_oldest_terminal`, which never evicts a `Running` row; if nothing is
+/// evictable the pass stops (never kill a live task to make room), so the
+/// store may grow transiently — concurrently `Running` tasks are rare.
+/// Test: `app_state_trims_to_max_retained` (single-stream case, via `upsert`);
+/// `per_agent_retention_keeps_n_for_each_assistant`;
+/// `global_backstop_caps_total_across_many_assistants`;
+/// `cancel_survives_fifo_eviction_pressure` (a `Running` task planted before a
+/// cap's worth of terminal tasks must still be reachable).
 fn insert_and_trim(
     store: &mut TaskStore,
     id: String,
     resp: PmResponse,
 ) -> HashMap<String, PmResponse> {
+    let agent = resp.addressed_agent.clone();
     let was_absent = !store.responses.contains_key(&id);
     store.responses.insert(id.clone(), resp);
     if was_absent {
         store.order.push(id);
     }
-    while store.order.len() > MAX_RETAINED {
-        let mut evict_idx = None;
-        for (i, oid) in store.order.iter().enumerate() {
-            let is_running = matches!(
-                store.responses.get(oid),
-                Some(r) if r.status == PmStatus::Running
-            );
-            if !is_running {
-                evict_idx = Some(i);
-                break;
-            }
-        }
-        let Some(idx) = evict_idx else {
-            // Every retained row is Running — don't evict a live task.
-            break;
-        };
-        let old = store.order.remove(idx);
-        store.responses.remove(&old);
-        store.handles.remove(&old);
-    }
+    while stream_len(store, &agent) > MAX_RETAINED_PER_AGENT
+        && evict_oldest_terminal(store, Some(&agent))
+    {}
+    while store.order.len() > MAX_RETAINED_TOTAL && evict_oldest_terminal(store, None) {}
     store.responses.clone()
+}
+
+/// Number of retained rows addressed to `agent` (#4355).
+fn stream_len(store: &TaskStore, agent: &str) -> usize {
+    store
+        .order
+        .iter()
+        .filter(|id| {
+            store
+                .responses
+                .get(*id)
+                .is_some_and(|r| r.addressed_agent == agent)
+        })
+        .count()
+}
+
+/// Evict the oldest non-`Running` row, optionally restricted to one
+/// assistant's stream; `false` when there is nothing evictable (#4355).
+///
+/// Why: both trim passes in `insert_and_trim` need the same "oldest terminal
+/// row wins, never a live task" rule, differing only in whether they look at
+/// one stream or all of them. Splitting it out keeps that rule stated once —
+/// a second copy is exactly how the `handles` map drifts out of lockstep with
+/// `responses` and resurrects the #3063 orphaned-`AbortHandle` bug.
+/// What: scans `order` oldest-first for the first row whose status isn't
+/// `Running` (and, when `agent` is `Some`, whose `addressed_agent` matches),
+/// then removes it from `order`, `responses`, and `handles` together.
+/// Test: `per_agent_retention_keeps_n_for_each_assistant`,
+/// `cancel_survives_fifo_eviction_pressure`.
+fn evict_oldest_terminal(store: &mut TaskStore, agent: Option<&str>) -> bool {
+    let TaskStore {
+        responses,
+        order,
+        handles,
+    } = store;
+    let Some(idx) = order.iter().position(|oid| {
+        responses.get(oid).is_some_and(|r| {
+            r.status != PmStatus::Running && agent.is_none_or(|a| r.addressed_agent == a)
+        })
+    }) else {
+        return false;
+    };
+    let old = order.remove(idx);
+    responses.remove(&old);
+    handles.remove(&old);
+    true
 }
 
 /// Path where the task snapshot is persisted.

--- a/crates/trusty-agents/src/api/server/tests/assistant_streams.rs
+++ b/crates/trusty-agents/src/api/server/tests/assistant_streams.rs
@@ -1,0 +1,257 @@
+//! Per-assistant task-stream attribution, retention, and retrieval (#4355).
+//!
+//! Why: "switching assistants loads that assistant's most recent task stream"
+//! is a server-side guarantee (owner decision), so the association, the
+//! retention bound, and the query that reads them back all need pinning here
+//! rather than in a client. The retention tests matter most: a server-wide cap
+//! divided across a six-assistant roster leaves ~3 turns of history each, which
+//! is the failure mode that makes the feature useless the moment it ships.
+//! What: route-level assertions against the axum router for the `?agent=`
+//! query, plus `AppState`-level assertions for per-stream and global eviction.
+//! Test: This module IS the test.
+
+use super::super::routes::build_router;
+use crate::api::server::state::{AppState, MAX_RETAINED_PER_AGENT, MAX_RETAINED_TOTAL};
+use crate::api::types::{PmResponse, PmStatus};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+/// Store one terminal (`Success`) task addressed to `agent`.
+async fn store_task(state: &AppState, id: &str, agent: &str) {
+    let mut r = PmResponse::running(id).addressed_to(agent);
+    r.status = PmStatus::Success;
+    state.upsert(id.to_string(), r).await;
+}
+
+/// `GET /api/tasks<query>` against `state` → the returned ids, in order.
+async fn task_ids(state: &AppState, query: &str) -> Vec<String> {
+    let app = build_router(state.clone());
+    let req = Request::builder()
+        .uri(format!("/api/tasks{query}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 8 * 1024 * 1024)
+        .await
+        .unwrap();
+    let rows: Vec<serde_json::Value> = serde_json::from_slice(&bytes).unwrap();
+    rows.iter()
+        .map(|r| r["id"].as_str().unwrap().to_string())
+        .collect()
+}
+
+/// A store holding two interleaved streams: `ctrl-1`, `izzie-1`, `ctrl-2`,
+/// `izzie-2`, oldest first.
+async fn two_stream_state() -> AppState {
+    let state = AppState::default();
+    store_task(&state, "ctrl-1", "ctrl").await;
+    store_task(&state, "izzie-1", "izzie").await;
+    store_task(&state, "ctrl-2", "ctrl").await;
+    store_task(&state, "izzie-2", "izzie").await;
+    state
+}
+
+/// #4355: an `agent=` filter returns ONLY that assistant's stream, newest
+/// first — the one call the client makes when the user switches assistants.
+/// The router is exercised end to end (not `list_stream` directly) because the
+/// query-parameter decoding and the `Query` extractor are part of the contract
+/// a client depends on.
+#[tokio::test]
+async fn tasks_filtered_by_agent_returns_only_that_stream_newest_first() {
+    let state = two_stream_state().await;
+    assert_eq!(
+        task_ids(&state, "?agent=izzie").await,
+        vec!["izzie-2", "izzie-1"],
+        "only izzie's stream, newest first"
+    );
+    assert_eq!(
+        task_ids(&state, "?agent=ctrl").await,
+        vec!["ctrl-2", "ctrl-1"]
+    );
+    // The rows carry the stream they were returned for, so a client never has
+    // to re-derive the attribution it just queried by.
+    assert!(
+        state
+            .list_stream(Some("izzie"), None)
+            .await
+            .iter()
+            .all(|r| r.addressed_agent == "izzie")
+    );
+}
+
+/// #4355: submitting a task records the assistant it was addressed to. This is
+/// the association the pre-#4355 server discarded — `TaskRequest.agent` was
+/// read once to choose a dispatch path and never written anywhere. Asserted
+/// end to end through `POST /api/task` because the stamp has to survive both
+/// the accepted placeholder and whatever the background turn finalizes.
+#[tokio::test]
+async fn submitting_with_an_agent_records_it_as_the_addressed_assistant() {
+    let state = AppState::default();
+    let app = build_router(state.clone());
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/task")
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"task":"hello","agent":"izzie"}"#))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+
+    let rows = state.list_stream(Some("izzie"), None).await;
+    assert_eq!(rows.len(), 1, "the task belongs to izzie's stream");
+    assert!(
+        state.list_stream(Some("ctrl"), None).await.is_empty(),
+        "and not to the Concierge's"
+    );
+}
+
+/// #4355: submitting with NO roster selection is not unattributed — it belongs
+/// to the Concierge, which is what a null selection already means in the
+/// client. Without this the default assistant, whose turns are the common
+/// case, would have no stream at all.
+#[tokio::test]
+async fn submitting_without_an_agent_records_the_concierge() {
+    let state = AppState::default();
+    let app = build_router(state.clone());
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/task")
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"task":"hello"}"#))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+
+    assert_eq!(state.list_stream(Some("ctrl"), None).await.len(), 1);
+}
+
+/// #4355: an assistant with no history is not an error — a roster entry the
+/// user just added, or one they have never talked to, gets an empty stream so
+/// the client renders an empty conversation rather than an error state.
+#[tokio::test]
+async fn tasks_for_an_unknown_agent_returns_an_empty_stream() {
+    let state = two_stream_state().await;
+    assert!(task_ids(&state, "?agent=never-used").await.is_empty());
+}
+
+/// #4355: omitting the query, or sending a blank `agent` (a cleared roster
+/// selection serialized as `agent=`), must reproduce the unfiltered listing —
+/// this is what every pre-#4355 caller sends and its response must not change.
+#[tokio::test]
+async fn tasks_query_defaults_match_the_unfiltered_listing() {
+    let state = two_stream_state().await;
+    let unfiltered = vec!["izzie-2", "ctrl-2", "izzie-1", "ctrl-1"];
+    assert_eq!(task_ids(&state, "").await, unfiltered);
+    assert_eq!(task_ids(&state, "?agent=").await, unfiltered);
+    assert_eq!(task_ids(&state, "?agent=%20%20").await, unfiltered);
+    assert_eq!(task_ids(&state, "?limit=99").await, unfiltered);
+}
+
+/// #4355: `limit` caps the returned rows without disturbing recency ordering,
+/// so a client can ask for just the tail of a stream.
+#[tokio::test]
+async fn tasks_limit_returns_the_newest_n_of_a_stream() {
+    let state = AppState::default();
+    for i in 0..5 {
+        store_task(&state, &format!("t-{i}"), "izzie").await;
+    }
+    let rows = state.list_stream(Some("izzie"), Some(2)).await;
+    let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
+    assert_eq!(ids, vec!["t-4", "t-3"]);
+}
+
+/// 🔴 The load-bearing retention assertion (#4355). Before this change the cap
+/// was a single server-wide 20, so these two assistants would have shared it —
+/// 40 submissions would leave 20 rows total and the older assistant's stream
+/// would be almost entirely gone. Retention is now per-stream: each assistant
+/// keeps its own `MAX_RETAINED_PER_AGENT`, and a busy assistant cannot evict an
+/// idle one's history.
+#[tokio::test]
+async fn per_agent_retention_keeps_n_for_each_assistant() {
+    let state = AppState::default();
+    // Interleaved, so a global cap would evict from both streams rather than
+    // conveniently truncating one.
+    for i in 0..(MAX_RETAINED_PER_AGENT + 5) {
+        store_task(&state, &format!("ctrl-{i}"), "ctrl").await;
+        store_task(&state, &format!("izzie-{i}"), "izzie").await;
+    }
+
+    let ctrl = state.list_stream(Some("ctrl"), None).await;
+    let izzie = state.list_stream(Some("izzie"), None).await;
+    assert_eq!(ctrl.len(), MAX_RETAINED_PER_AGENT);
+    assert_eq!(izzie.len(), MAX_RETAINED_PER_AGENT);
+    assert_eq!(
+        state.list_stream(None, None).await.len(),
+        MAX_RETAINED_PER_AGENT * 2,
+        "two assistants retain 2N rows, not the old server-wide N"
+    );
+    // Each stream kept its own newest rows.
+    assert_eq!(ctrl[0].id, format!("ctrl-{}", MAX_RETAINED_PER_AGENT + 4));
+    assert_eq!(izzie[0].id, format!("izzie-{}", MAX_RETAINED_PER_AGENT + 4));
+}
+
+/// #4355: per-assistant retention is unbounded in the number of DISTINCT
+/// assistant ids — `TaskRequest.agent` is free-form, so a client minting a new
+/// name per request would grow the store forever. The global backstop bounds
+/// total memory (and the `tasks.json` rewritten in full on every upsert)
+/// regardless of how many streams exist.
+#[tokio::test]
+async fn global_backstop_caps_total_across_many_assistants() {
+    let state = AppState::default();
+    // One task each for far more assistants than the backstop allows rows.
+    for i in 0..(MAX_RETAINED_TOTAL + 25) {
+        store_task(&state, &format!("t-{i}"), &format!("agent-{i}")).await;
+    }
+    let all = state.list_stream(None, None).await;
+    assert_eq!(all.len(), MAX_RETAINED_TOTAL);
+    // Oldest streams were dropped; the newest survives.
+    assert_eq!(all[0].id, format!("t-{}", MAX_RETAINED_TOTAL + 24));
+    assert!(
+        state.list_stream(Some("agent-0"), None).await.is_empty(),
+        "the oldest stream is the one evicted"
+    );
+}
+
+/// #4355 regression guard: eviction must never take a `Running` row, and the
+/// per-stream pass must not change that. A live task in a full stream stays
+/// reachable — the #3063 contract, restated for the per-agent trim.
+#[tokio::test]
+async fn per_agent_trim_never_evicts_a_running_task() {
+    let state = AppState::default();
+    state
+        .upsert(
+            "live".to_string(),
+            PmResponse::running("live").addressed_to("izzie"),
+        )
+        .await;
+    for i in 0..(MAX_RETAINED_PER_AGENT + 5) {
+        store_task(&state, &format!("izzie-{i}"), "izzie").await;
+    }
+    let live = state.get("live").await.expect("running task must survive");
+    assert_eq!(live.status, PmStatus::Running);
+    assert_eq!(live.addressed_agent, "izzie");
+}
+
+/// #4355: cancelling a task must not move it between streams. `cancelled()`
+/// starts from the Concierge default, so `try_cancel` carries the original
+/// stream over; without that, cancelling an Izzie task would make it vanish
+/// from Izzie's history and appear in the Concierge's.
+#[tokio::test]
+async fn cancelling_a_task_keeps_it_in_its_own_stream() {
+    let state = AppState::default();
+    state
+        .upsert(
+            "izzie-live".to_string(),
+            PmResponse::running("izzie-live").addressed_to("izzie"),
+        )
+        .await;
+    state.try_cancel("izzie-live").await;
+
+    let stored = state.get("izzie-live").await.unwrap();
+    assert_eq!(stored.status, PmStatus::Cancelled);
+    assert_eq!(stored.addressed_agent, "izzie");
+    assert_eq!(state.list_stream(Some("izzie"), None).await.len(), 1);
+    assert!(state.list_stream(Some("ctrl"), None).await.is_empty());
+}

--- a/crates/trusty-agents/src/api/server/tests/cancel.rs
+++ b/crates/trusty-agents/src/api/server/tests/cancel.rs
@@ -24,7 +24,7 @@ use axum::http::{Method, Request, StatusCode};
 use tower::ServiceExt;
 
 use crate::api::server::routes::build_router;
-use crate::api::server::state::{AppState, MAX_RETAINED};
+use crate::api::server::state::{AppState, MAX_RETAINED_PER_AGENT};
 use crate::api::types::{PmResponse, PmStatus};
 
 fn router(state: AppState) -> Router {
@@ -202,7 +202,7 @@ async fn clear_recent_tasks_removes_terminal_only() {
 /// Regression test for the FIFO-eviction bug found in code review (#3063):
 /// `insert_and_trim` used to evict strictly by insertion order (index 0),
 /// so a long-running task submitted first and left running while
-/// `MAX_RETAINED` unrelated tasks completed would get silently evicted from
+/// `MAX_RETAINED_PER_AGENT` unrelated tasks completed would get silently evicted from
 /// `responses`/`order` — orphaning its `AbortHandle` in `handles` forever
 /// and making `DELETE /api/task/:id` 404 a task that was genuinely still
 /// running. `insert_and_trim` now walks forward past `Running` rows to
@@ -212,10 +212,10 @@ async fn cancel_survives_fifo_eviction_pressure() {
     let state = AppState::default();
     let completed = spawn_fake_running_task(&state, "long-runner").await;
 
-    // Push MAX_RETAINED more terminal tasks after it. Under naive index-0
+    // Push MAX_RETAINED_PER_AGENT more terminal tasks after it. Under naive index-0
     // FIFO this alone would already have evicted "long-runner" (the oldest
     // entry) before we ever get a chance to cancel it.
-    for i in 0..MAX_RETAINED {
+    for i in 0..MAX_RETAINED_PER_AGENT {
         let id = format!("filler-{i}");
         let mut r = PmResponse::running(&id);
         r.status = PmStatus::Success;

--- a/crates/trusty-agents/src/api/server/tests/mod.rs
+++ b/crates/trusty-agents/src/api/server/tests/mod.rs
@@ -13,6 +13,8 @@ mod agent_permissions;
 mod agent_skills;
 mod agent_stores;
 mod agent_subagents;
+// #4355: per-assistant task-stream attribution, retention, and retrieval.
+mod assistant_streams;
 mod attendance;
 mod cancel;
 mod costs;
@@ -27,7 +29,7 @@ mod models;
 mod relay;
 
 use super::routes::{build_router, build_router_with_config};
-use super::state::{AppState, MAX_RETAINED};
+use super::state::{AppState, MAX_RETAINED_PER_AGENT};
 use crate::api::types::{PmResponse, PmStatus};
 use crate::registry::ProjectRegistry;
 use axum::Router;
@@ -178,22 +180,22 @@ async fn tm_tell_returns_503_without_manager() {
 #[tokio::test]
 async fn app_state_trims_to_max_retained() {
     let state = AppState::default();
-    // Push MAX_RETAINED + 5 terminal (non-Running) responses. #3063: FIFO
+    // Push MAX_RETAINED_PER_AGENT + 5 terminal (non-Running) responses. #3063: FIFO
     // trimming now exempts `Running` rows from eviction (see
     // `insert_and_trim`'s doc comment), so this fixture uses `Success` to
     // keep exercising the trim path rather than the "everything is running,
     // skip eviction" edge case covered by
     // `cancel::cancel_survives_fifo_eviction_pressure`.
-    for i in 0..(MAX_RETAINED + 5) {
+    for i in 0..(MAX_RETAINED_PER_AGENT + 5) {
         let id = format!("id-{i}");
         let mut r = PmResponse::running(&id);
         r.status = PmStatus::Success;
         state.upsert(id, r).await;
     }
     let list = state.list().await;
-    assert_eq!(list.len(), MAX_RETAINED);
+    assert_eq!(list.len(), MAX_RETAINED_PER_AGENT);
     // Newest should be at the front.
-    assert_eq!(list[0].id, format!("id-{}", MAX_RETAINED + 4));
+    assert_eq!(list[0].id, format!("id-{}", MAX_RETAINED_PER_AGENT + 4));
 }
 
 // -- #181: auth middleware --

--- a/crates/trusty-agents/src/api/types.rs
+++ b/crates/trusty-agents/src/api/types.rs
@@ -11,6 +11,24 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The assistant a task belongs to when the client selected no roster entry.
+///
+/// Why (#4355): a null roster selection is not "unattributed" — in the GUI it
+/// MEANS the Concierge (`ui/src/lib/roster.ts` defaults `activeAgentId` to
+/// `null` and renders Concierge for it). Naming that default once here keeps
+/// the server, the attendance hook, and the per-assistant task query from
+/// each inventing their own idea of what "no agent" resolves to.
+/// What: the `ctrl` agent id.
+/// Test: `addressed_agent_defaults_to_ctrl_when_no_selection`.
+pub const DEFAULT_ADDRESSED_AGENT: &str = "ctrl";
+
+/// serde default for [`PmResponse::addressed_agent`] — see
+/// [`DEFAULT_ADDRESSED_AGENT`]. Also the value an older `tasks.json` (written
+/// before #4355) deserializes to.
+fn default_addressed_agent() -> String {
+    DEFAULT_ADDRESSED_AGENT.to_string()
+}
+
 /// Canonical response envelope returned by every PM/workflow invocation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PmResponse {
@@ -64,6 +82,30 @@ pub struct PmResponse {
     /// Test: `responder_agent_defaults_to_none_and_omits_when_absent`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub responder_agent: Option<String>,
+    /// #4355: the assistant this task was ADDRESSED to — the roster entry the
+    /// user had selected when they submitted it, or [`DEFAULT_ADDRESSED_AGENT`]
+    /// when they had selected none.
+    ///
+    /// Why: switching assistants must load that assistant's own task stream,
+    /// and the server owns that association (owner decision: "per assistant
+    /// loading should be at the server level"). Before this field the routing
+    /// choice made from `TaskRequest.agent` was consumed at dispatch and thrown
+    /// away, so nothing downstream could say which stream a task belonged to.
+    /// Distinct from [`PmResponse::responder_agent`], which records who
+    /// ANSWERED: `responder_agent` is populated post-hoc only when the turn
+    /// delegated and is `None` in the common case, so it cannot key a stream.
+    /// A turn addressed to `assistant` that delegates to `izzie` has
+    /// `addressed_agent = "assistant"` and `responder_agent = Some("izzie")` —
+    /// it stays in the stream the user was looking at, while the bubble is
+    /// still labelled with who really replied.
+    /// What: a non-optional `String` (every task belongs to exactly one
+    /// stream), always serialized, and `#[serde(default = …)]` so a
+    /// `tasks.json` written before this field existed still loads, with its
+    /// rows landing in the Concierge stream.
+    /// Test: `addressed_agent_defaults_to_ctrl_when_no_selection`,
+    /// `legacy_tasks_json_without_addressed_agent_loads_as_ctrl`.
+    #[serde(default = "default_addressed_agent")]
+    pub addressed_agent: String,
 }
 
 /// One entry in the live progress stream returned by `GET /api/task/:id`.
@@ -180,6 +222,7 @@ impl PmResponse {
             errors: Vec::new(),
             phases_completed: Vec::new(),
             responder_agent: None,
+            addressed_agent: default_addressed_agent(),
         }
     }
 
@@ -199,6 +242,7 @@ impl PmResponse {
             errors: vec![m],
             phases_completed: Vec::new(),
             responder_agent: None,
+            addressed_agent: default_addressed_agent(),
         }
     }
 
@@ -227,7 +271,24 @@ impl PmResponse {
             errors: Vec::new(),
             phases_completed: Vec::new(),
             responder_agent: None,
+            addressed_agent: default_addressed_agent(),
         }
+    }
+
+    /// Attribute this response to the assistant it was addressed to (#4355).
+    ///
+    /// Why: every constructor above defaults to the Concierge, but the three
+    /// producers in `api::server::handlers` know the real roster selection and
+    /// must stamp it before the response reaches the store — a task that lands
+    /// in the wrong stream is invisible in the UI it belongs to. A builder
+    /// keeps that stamp a single expression at each of those sites rather than
+    /// a `let mut` dance around `PmResponse::error(…)`.
+    /// What: sets `addressed_agent` and returns `self`.
+    /// Test: `addressed_to_overrides_the_default_stream`.
+    #[must_use]
+    pub fn addressed_to(mut self, agent: impl Into<String>) -> Self {
+        self.addressed_agent = agent.into();
+        self
     }
 }
 
@@ -323,6 +384,55 @@ mod tests {
         let legacy = r#"{"id":"x","timestamp":"t","type":"task_submitted","status":"running","narrative":"","metadata":{"processing_time_ms":0,"total_tokens_in":0,"total_tokens_out":0,"cache_read_tokens":0,"cache_creation_tokens":0,"total_cost_usd":0.0,"model":null,"workflow":null,"build_number":null},"phases":[],"files_modified":[],"out_dir":null,"errors":[]}"#;
         let parsed: PmResponse = serde_json::from_str(legacy).unwrap();
         assert_eq!(parsed.responder_agent, None);
+    }
+
+    /// #4355: with no roster selection the response belongs to the Concierge
+    /// stream, and — unlike `responder_agent` — the field is always on the
+    /// wire, because a client keying a stream off it must never see it absent.
+    #[test]
+    fn addressed_agent_defaults_to_ctrl_when_no_selection() {
+        for r in [
+            PmResponse::running("a"),
+            PmResponse::error("b", "boom"),
+            PmResponse::cancelled("c"),
+        ] {
+            assert_eq!(r.addressed_agent, DEFAULT_ADDRESSED_AGENT);
+            let j = serde_json::to_string(&r).unwrap();
+            assert!(j.contains("\"addressed_agent\":\"ctrl\""), "got: {j}");
+        }
+    }
+
+    /// #4355: "who was asked" and "who answered" are independent facts. A turn
+    /// addressed to `assistant` that delegates to `izzie` stays in the
+    /// `assistant` stream while the bubble is labelled `izzie`.
+    #[test]
+    fn addressed_to_overrides_the_default_stream() {
+        let r = PmResponse::running("x").addressed_to("assistant");
+        assert_eq!(r.addressed_agent, "assistant");
+        assert_eq!(r.responder_agent, None);
+
+        let mut delegated = r.clone();
+        delegated.responder_agent = Some("izzie".to_string());
+        let back: PmResponse =
+            serde_json::from_str(&serde_json::to_string(&delegated).unwrap()).unwrap();
+        assert_eq!(back.addressed_agent, "assistant");
+        assert_eq!(back.responder_agent.as_deref(), Some("izzie"));
+    }
+
+    /// #4355 upgrade safety: a `tasks.json` written by the pre-#4355 server has
+    /// no `addressed_agent` key at all. It must still deserialize — a hard
+    /// error here would drop the user's whole task history on upgrade — and its
+    /// rows land in the Concierge stream, which is where an unattributed task
+    /// belonged all along.
+    #[test]
+    fn legacy_tasks_json_without_addressed_agent_loads_as_ctrl() {
+        let legacy = r#"{"t1":{"id":"t1","timestamp":"2026-08-08T00:00:00Z","type":"agent_response","status":"success","narrative":"hello","metadata":{"processing_time_ms":0,"total_tokens_in":0,"total_tokens_out":0,"cache_read_tokens":0,"cache_creation_tokens":0,"total_cost_usd":0.0,"model":null,"workflow":null,"build_number":null},"phases":[],"files_modified":[],"out_dir":null,"errors":[],"phases_completed":[],"responder_agent":"izzie"}}"#;
+        let map: std::collections::HashMap<String, PmResponse> =
+            serde_json::from_str(legacy).expect("pre-#4355 tasks.json must still load");
+        let r = &map["t1"];
+        assert_eq!(r.addressed_agent, DEFAULT_ADDRESSED_AGENT);
+        assert_eq!(r.responder_agent.as_deref(), Some("izzie"));
+        assert_eq!(r.narrative, "hello");
     }
 
     #[test]

--- a/crates/trusty-agents/src/recap/mod.rs
+++ b/crates/trusty-agents/src/recap/mod.rs
@@ -183,17 +183,27 @@ fn capitalise(s: &str) -> String {
 /// Persist a recap to `state_dir/recaps/{session_id}.json`.
 ///
 /// Why: Recaps must survive process restart so the GUI can backfill the
-/// RecapPanel after reload. Writing a per-session JSON file keeps the
-/// storage trivial and inspectable.
-/// What: Creates the `recaps/` subdir if missing, then writes pretty JSON.
-/// Test: covered by integration; unit test would require a temp dir.
+/// RecapPanel after reload. A recap is a summary built from task narratives,
+/// so it is exactly as sensitive as the `tasks.json` it is derived from — and
+/// it used to be written with a bare `std::fs::write` at the process umask,
+/// landing world-readable, which is the same gap `persist_tasks` had (#4355).
+/// Routing through `state_writer` puts it under the one owner-only,
+/// lock + tmp + rename contract every other state file already uses.
+/// What: Serializes pretty JSON and hands it to
+/// [`crate::state_writer::atomic_write`], which creates the `recaps/` subdir
+/// itself — hence no separate `create_dir_all` here. Still returns `Result`
+/// and still blocks: the caller (`api::server::task_runner::maybe_emit_recap`)
+/// already invoked this synchronously and already logs-and-continues on error,
+/// so neither its error handling nor its blocking behavior changes. The
+/// advisory lock is per-session (`recaps/{session_id}.json.lock`), not a
+/// shared path, so it is effectively uncontended.
+/// Test: `save_and_load_recap_roundtrip`, `save_recap_writes_an_owner_only_file`.
 pub fn save_recap(state_dir: &Path, recap: &Recap) -> Result<()> {
-    let dir = state_dir.join("recaps");
-    std::fs::create_dir_all(&dir)?;
-    let path = dir.join(format!("{}.json", recap.session_id));
+    let path = state_dir
+        .join("recaps")
+        .join(format!("{}.json", recap.session_id));
     let json = serde_json::to_string_pretty(recap)?;
-    std::fs::write(path, json)?;
-    Ok(())
+    crate::state_writer::atomic_write(&path, json.as_bytes())
 }
 
 /// Load the most recent recap for a session, if any.
@@ -333,5 +343,33 @@ mod tests {
         assert_eq!(loaded.session_id, "sess1");
         assert_eq!(loaded.rows.len(), 1);
         assert_eq!(loaded.rows[0].result, "abc1234");
+    }
+
+    /// #4355: a recap summarises task narratives, so it is as sensitive as the
+    /// `tasks.json` it is derived from. Written with a bare `std::fs::write` it
+    /// landed at the process umask (0644 — world-readable on a shared host);
+    /// routed through `state_writer::atomic_write` it inherits the owner-only
+    /// contract every other state file now has.
+    #[cfg(unix)]
+    #[test]
+    fn save_recap_writes_an_owner_only_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let recap = Recap {
+            session_id: "sess-perm".into(),
+            summary: "sensitive narrative summary".into(),
+            rows: Vec::new(),
+            generated_at: chrono::Utc::now().to_rfc3339(),
+            task_count: 1,
+        };
+        save_recap(dir.path(), &recap).unwrap();
+
+        let path = dir.path().join("recaps").join("sess-perm.json");
+        let mode = std::fs::metadata(&path)
+            .expect("recap file must exist")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "recap must not be world-readable");
     }
 }

--- a/crates/trusty-agents/src/state_writer.rs
+++ b/crates/trusty-agents/src/state_writer.rs
@@ -41,6 +41,36 @@ fn lock_path_for(path: &Path) -> PathBuf {
     PathBuf::from(s)
 }
 
+/// Restrict `opts` so a file it CREATES is owner-only (`0600`) (#4355).
+///
+/// Why: every file this module writes is per-user state under
+/// `~/.trusty-agents/` — prompts, task narratives, session records, and
+/// captured child-process stderr that is credential-scrubbed but explicitly not
+/// proven secret-free (#5230). Created at the process umask they land
+/// world-readable (0644 on a typical host), which is wrong for all of them on a
+/// shared machine. The mode is applied AT CREATION rather than by a follow-up
+/// `set_permissions` because create-then-chmod leaves a window, however narrow,
+/// in which the content is readable at the wider mode.
+/// What: on unix adds `.mode(0o600)`; elsewhere returns `opts` untouched —
+/// `OpenOptionsExt::mode` is unix-only, and on Windows these paths sit inside a
+/// per-user profile directory whose ACL already excludes other users. Note the
+/// mode applies only when the open actually creates the file; callers that must
+/// guarantee it (see `write_tmp_and_rename`) remove a stale file first, and
+/// treat a removal they could not complete as fatal rather than writing at a
+/// mode they no longer control.
+/// Test: `atomic_write_creates_an_owner_only_file`,
+/// `atomic_write_tightens_an_existing_world_readable_file`,
+/// `atomic_append_line_creates_an_owner_only_file`,
+/// `atomic_write_fails_when_a_stale_tmp_cannot_be_removed`.
+fn private_mode(opts: &mut OpenOptions) -> &mut OpenOptions {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    opts
+}
+
 /// Open (or create) the sibling lock file for `path`.
 ///
 /// Why: `fs4`'s lock methods need an open `File`. Centralizing the open-with-
@@ -110,10 +140,24 @@ fn write_tmp_and_rename(path: &Path, contents: &[u8]) -> Result<()> {
         PathBuf::from(s)
     };
     {
-        let mut f = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
+        // #4355: a tmp left behind by a crashed write (see this module's doc)
+        // would be REOPENED at its existing mode, and the rename below would
+        // then carry that mode onto the target. Removing it first makes the
+        // open below always a creation, so `private_mode` always applies.
+        // Absence is the normal case; ANY other error means the stale tmp is
+        // still there, so the open would truncate in place at its mode and
+        // publish it — abort instead of writing at an unknown mode.
+        match std::fs::remove_file(&tmp) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("removing stale tmp file {}", tmp.display()));
+            }
+        }
+        let mut opts = OpenOptions::new();
+        opts.create(true).write(true).truncate(true);
+        let mut f = private_mode(&mut opts)
             .open(&tmp)
             .with_context(|| format!("opening tmp file {}", tmp.display()))?;
         f.write_all(contents)
@@ -196,9 +240,13 @@ pub fn atomic_append_line(path: &Path, line: &str) -> Result<()> {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("creating parent dir {}", parent.display()))?;
         }
-        let mut f = OpenOptions::new()
-            .create(true)
-            .append(true)
+        // #4355: owner-only on creation. An append target cannot be removed
+        // and recreated the way `write_tmp_and_rename` does — that would
+        // discard the log — so a file created before this change keeps its
+        // original mode until it is rotated.
+        let mut opts = OpenOptions::new();
+        opts.create(true).append(true);
+        let mut f = private_mode(&mut opts)
             .open(path)
             .with_context(|| format!("opening append target {}", path.display()))?;
         f.write_all(line.as_bytes())
@@ -403,5 +451,125 @@ mod tests {
         atomic_write(&path, b"second").unwrap();
         atomic_write(&path, b"third").unwrap();
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "third");
+    }
+
+    /// The permission bits of `path`, masked to the usual rwx triples.
+    #[cfg(unix)]
+    fn mode_of(path: &Path) -> u32 {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path)
+            .expect("stat written file")
+            .permissions()
+            .mode()
+            & 0o777
+    }
+
+    /// #4355: state files carry prompts, task narratives, and captured
+    /// child-process stderr that is credential-scrubbed but not proven
+    /// secret-free (#5230). At the process umask they land 0644 —
+    /// world-readable on a shared host. Both the published file and the tmp it
+    /// is renamed from must be owner-only; a 0644 tmp would simply carry its
+    /// mode onto the target through the rename.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_creates_an_owner_only_file() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().join("state").join("tasks.json");
+        atomic_write(&path, b"{\"narrative\":\"secret-ish\"}").unwrap();
+        assert_eq!(mode_of(&path), 0o600, "published state file must be 0600");
+    }
+
+    /// #4355: the mode has to reach files that ALREADY exist at the old wide
+    /// mode — a user upgrading has a 0644 `tasks.json` on disk right now, and
+    /// it is never recreated, only rewritten. The rename publishes the 0600
+    /// tmp over it, so the next write is what tightens it.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_tightens_an_existing_world_readable_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().join("tasks.json");
+        std::fs::write(&path, b"old").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(mode_of(&path), 0o644, "fixture starts world-readable");
+
+        atomic_write(&path, b"new").unwrap();
+        assert_eq!(mode_of(&path), 0o600);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new");
+    }
+
+    /// #4355: a tmp orphaned by a crashed write (this module's documented
+    /// failure mode) must not be reopened at ITS mode and renamed over the
+    /// target — that would silently republish a world-readable file.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_ignores_a_stale_world_readable_tmp() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().join("tasks.json");
+        let stale = tmp_dir.path().join("tasks.json.tmp");
+        std::fs::write(&stale, b"crashed").unwrap();
+        std::fs::set_permissions(&stale, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        atomic_write(&path, b"fresh").unwrap();
+        assert_eq!(mode_of(&path), 0o600);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "fresh");
+    }
+
+    /// #4355: if the stale tmp cannot be removed, the write must ABORT. Left in
+    /// place it would be truncated and rewritten in place — `create(true)` does
+    /// not re-apply a mode to an existing file — and the rename would publish
+    /// its wide mode onto the target, so the 0600 guarantee would silently not
+    /// engage. Discarding that error was the fail-open shape: a security
+    /// control bypassed with nothing reported.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_fails_when_a_stale_tmp_cannot_be_removed() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("tasks.json");
+        // A first successful write, so the sibling `.lock` already exists and
+        // the read-only directory below cannot fail us earlier than intended.
+        atomic_write(&path, b"first").unwrap();
+
+        let stale = dir.path().join("tasks.json.tmp");
+        std::fs::write(&stale, b"crashed").unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        // root ignores directory permissions, so the restriction this test
+        // depends on would not hold there. Detect and skip rather than fail.
+        let unrestricted = std::fs::remove_file(dir.path().join("probe")).is_ok()
+            || std::fs::write(dir.path().join("probe"), b"x").is_ok();
+        let result = if unrestricted {
+            None
+        } else {
+            Some(atomic_write(&path, b"second"))
+        };
+
+        // Restore before the TempDir drops, or cleanup fails.
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let Some(result) = result else { return };
+        let err = result.expect_err("a stale tmp that cannot be removed must abort the write");
+        assert!(
+            format!("{err:#}").contains("removing stale tmp file"),
+            "error must name the failing step, got: {err:#}"
+        );
+        // The target keeps its previous contents — nothing was published.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "first");
+    }
+
+    /// #4355: NDJSON logs (`interactions.jsonl`, `runs.jsonl`) hold prompt and
+    /// response text, so a file this helper CREATES is owner-only too. An
+    /// append target that predates this change keeps its mode — it cannot be
+    /// recreated without discarding the log — which is why this asserts the
+    /// creation case only.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_append_line_creates_an_owner_only_file() {
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().join("logs").join("interactions.jsonl");
+        atomic_append_line(&path, "{\"prompt\":\"secret-ish\"}").unwrap();
+        assert_eq!(mode_of(&path), 0o600);
     }
 }


### PR DESCRIPTION
## Problem

Switching assistants in the GUI did not load that assistant's history, and could not: the server never recorded which assistant a task was addressed to. `POST /api/task` consumed the `agent` field purely to route and discarded it. `responder_agent` records who ANSWERED and is `None` whenever no delegation fired, so it cannot key a stream.

## Owner decision

Per-assistant loading is SERVER-level, not a per-client filter. This PR is the server half; the Tauri client half is a separate PR.

## What changed

Three commits:
1. `PmResponse.addressed_agent` plus per-assistant retention and an agent filter on `GET /api/tasks`
2. State files created owner-only, with `persist_tasks` routed through the shared `state_writer`
3. `recap::save_recap` routed through the same writer

## `addressed_agent` vs `responder_agent`

Who was asked vs who answered. A turn addressed to `assistant` that delegates to `izzie` records `addressed_agent = "assistant"`, `responder_agent = Some("izzie")` — it stays in the stream the user was viewing while the bubble still credits Izzie. Non-optional `String`; the null case resolves to `ctrl` through one function, `addressed_agent_for`.

## Retention

20 per assistant with a 200-row global backstop. Per-agent alone is unbounded in distinct names (`TaskRequest.agent` is free-form), hence the ceiling. Cost: 200 rows × ~4 KB ≈ 800 KB typical, ~13 MB pathological. A single-assistant user sees the same depth as before.

## Query

`GET /api/tasks?agent=<name>&limit=<n>`, extending the existing route rather than minting a parallel one. Blank agent treated as absent, `limit` clamped, unknown agent returns `[]`. Omitting both reproduces the previous response.

## Backward compatibility

An existing `tasks.json` written by the current code still loads (`#[serde(default)]`), pinned by a test.

## Permissions hardening

`persist_tasks` was a second bespoke copy of the atomic-write capability `state_writer` already owned, which is why it was the one state file missing the shared path. The permission contract now lives in `state_writer` and the duplicate is gone. Mode is set at creation (not chmod-after-open), a stale `.tmp` is removed first so the mode always applies, and a removal that cannot be completed is fatal rather than writing at an uncontrolled mode.

## Deliberate widening

Every `state_writer` caller now writes at 0600: attendance, bundled agent installs, agent backups, the bundled stamp, workflow checkpoints, skills registry, session records, interaction log, and recaps. All verified to resolve under `~/.trusty-agents/` as per-user private state read only by the same local user.

## Known limitations, stated not buried

- `GET /api/tasks?agent=` widens what an unauthenticated local caller can read — auth applies only when a token is configured. Same trust boundary as the rest of the API, which already exposes task content and cancellation.
- Eviction never takes a `Running` row, so the store can transiently exceed 200. Pre-existing property of the old single-cap design, carried forward.
- `atomic_append_line` cannot tighten a log file that predates this change — append-mode opens never create an existing file. Those get 0600 on rotation.
- `tasks.json` persistence now takes a blocking `fs4` advisory lock with no timeout on a blocking worker. Same exposure every other `state_writer` caller already carries; new for this path.

## Test ladder

Rung 6 (API surface). Rust-side gates, re-run after rebasing onto `origin/main` (`12e5446ee`):

```
SKIP_UI_BUILD=1 cargo fmt --check
EXIT=0

SKIP_UI_BUILD=1 cargo clippy -p trusty-agents --all-targets -- -D warnings
EXIT=0

SKIP_UI_BUILD=1 cargo test -p trusty-agents
test result: ok. 3448 passed; 0 failed; 11 ignored; 0 measured; 0 filtered out; finished in 37.30s
EXIT=0

bash scripts/check_test_pointers.sh
test-pointers: resolved 22913 Test: citation(s) (floor 200) — 0 dangling pointers — OK.
```

`check_line_cap.sh`, `check_changelog_fragment.sh`, and `check_sld.sh` were run prior to rebase and are unaffected by it. Two security scans passed.

The UI half of rung 6 is NOT discharged here — the Tauri client is a separate PR.

## Refs

Refs #4355, Refs #4278. Not `Closes` — the UI half is outstanding.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
