### PR TITLE
feat(trusty-common,trusty-agents): honour per-agent inference-provider pins at dispatch

### DIFF
--- a/crates/trusty-agents/changelog.d/3765-atlascloud-adapter-and-prefix-handling.md
+++ b/crates/trusty-agents/changelog.d/3765-atlascloud-adapter-and-prefix-handling.md
@@ -1,0 +1,8 @@
+Fixed
+
+- A keyless AtlasCloud call reported "openrouter credential not found" — the
+  wrong provider, env var, and config command. It now names AtlasCloud.
+- Routing-prefix stripping and the own-endpoint raw-HTTP requirement moved from
+  a hardcoded `ollama/`/`fireworks/` list in the chat loop onto the adapters
+  themselves, so a provider added later inherits both instead of rediscovering
+  the bug.

--- a/crates/trusty-agents/changelog.d/3765-per-agent-provider-pinning.md
+++ b/crates/trusty-agents/changelog.d/3765-per-agent-provider-pinning.md
@@ -1,0 +1,19 @@
+Added
+
+- `[agent].provider_id` now pins an agent's inference provider for real. The
+  key was accepted and persisted by `PATCH /api/agents/:name` but read by
+  nothing — `AgentInfo` had no provider field, so the loader dropped it and
+  every turn re-probed the ambient environment instead. Setting a provider
+  looked like it worked and changed nothing
+  ([#3765](https://github.com/bobmatnyc/trusty-tools/issues/3765)).
+  A pin takes precedence over whatever provider the model slug implies, and
+  fails closed: an unknown provider, a provider chat dispatch cannot reach, or
+  a provider with no resolvable credential each abort the agent load with a
+  message naming the provider and the env var that would fix it, instead of
+  silently falling back to another provider's key. An agent with no pin keeps
+  its previous behaviour unchanged.
+- AtlasCloud is reachable at dispatch. `atlascloud/*` model slugs previously
+  fell through to the OpenRouter endpoint carrying a model id OpenRouter does
+  not serve; they now route to `api.atlascloud.ai` with `ATLASCLOUD_API_KEY`.
+  `GET /api/models` reports `reachable_today: true` for AtlasCloud and for the
+  registry's `local` provider to match.

--- a/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
+++ b/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
@@ -71,6 +71,8 @@ fn test_agent_config(name: &str, model: &str, system_prompt: &str) -> AgentConfi
             prompt_label: None,
             extends: None,
             tier: None,
+            // #3765: no provider pin on this construction path.
+            provider_id: None,
         },
         llm: LlmParams {
             temperature: 0.0,

--- a/crates/trusty-agents/src/agents/claude_mpm_loader.rs
+++ b/crates/trusty-agents/src/agents/claude_mpm_loader.rs
@@ -122,6 +122,8 @@ impl ClaudeMpmAgent {
                 prompt_label: None,
                 extends: None,
                 tier: None,
+                // #3765: no provider pin on this construction path.
+                provider_id: None,
             },
             llm: LlmParams {
                 temperature: 0.3,

--- a/crates/trusty-agents/src/agents/config.rs
+++ b/crates/trusty-agents/src/agents/config.rs
@@ -731,6 +731,35 @@ pub struct AgentInfo {
     /// `agent_tier_explicit_declaration_overrides_the_derived_kind`.
     #[serde(default)]
     pub tier: Option<String>,
+
+    /// Pin this agent's inference provider (#3765).
+    ///
+    /// Why: before this field existed, `[agent].provider_id` was written by
+    /// `PATCH /api/agents/:name` (#3243) and read by NOTHING — `AgentInfo` had
+    /// no provider slot, so the loader dropped the key and every turn instead
+    /// re-probed the ambient environment through
+    /// `llm::credentials::pick_credentials` in fixed priority order. Choosing
+    /// a provider in the GUI looked like it worked and changed nothing. This
+    /// field is that same TOML key promoted to a real, enforced one — the name
+    /// is deliberately unchanged so every already-written agent TOML starts
+    /// taking effect rather than needing a migration.
+    /// What: a provider name from `trusty_common::inference::registry`
+    /// (`openrouter`, `anthropic`, `bedrock`, `fireworks`, `atlascloud`,
+    /// `local`). Absent or blank means UNPINNED and preserves today's ambient
+    /// behaviour exactly. When set, [`crate::llm::provider_pin::resolve`]
+    /// validates it at load and FAILS CLOSED — unknown name, provider the chat
+    /// loop cannot dispatch to, or a missing credential each abort the load
+    /// with an actionable message instead of quietly falling back. The pin
+    /// then rewrites `model` via
+    /// [`crate::llm::provider_pin::pinned_model_slug`] so it beats whatever
+    /// provider the model slug would otherwise imply, and forces
+    /// `[llm].use_anthropic_direct` to agree with the pin.
+    /// Test: `agent_config_honours_a_provider_pin`,
+    /// `agent_config_pin_beats_the_model_slug_prefix`,
+    /// `agent_config_without_a_pin_is_unchanged`,
+    /// `agent_config_rejects_a_pin_with_no_credential`.
+    #[serde(default)]
+    pub provider_id: Option<String>,
 }
 
 /// Persona privilege tier (#4168, epic #4167 — L0/L1 orchestration model).

--- a/crates/trusty-agents/src/agents/in_process_runner.rs
+++ b/crates/trusty-agents/src/agents/in_process_runner.rs
@@ -287,11 +287,14 @@ impl InProcessAgentRunner {
             .with_context(|| format!("failed to load agent config for '{agent_name}'"))?;
 
         // Apply per-call model override (carried via RunContext).
+        // #3765: routed through `override_model` so a PINNED agent re-pins the
+        // override onto its provider instead of silently escaping the pin —
+        // this path is reachable for a pinned agent via a workflow phase's
+        // `model` field and via retry escalation.
         if let Some(model) = &ctx.model
             && !model.is_empty()
         {
-            cfg.agent.model = model.clone();
-            cfg.adapter = Arc::from(crate::llm::adapter::adapter_for_model(&cfg.agent.model));
+            cfg.override_model(model)?;
         }
 
         // Resolve the effective max_turns: ctx > runner_config.max_tool_calls > llm.max_turns.

--- a/crates/trusty-agents/src/agents/loader.rs
+++ b/crates/trusty-agents/src/agents/loader.rs
@@ -350,6 +350,40 @@ impl AgentConfig {
         Ok(())
     }
 
+    /// Replace this config's model AFTER load, re-applying the provider pin.
+    ///
+    /// Why (#3765): four call sites replaced `cfg.agent.model` post-load and
+    /// rebuilt the adapter from the raw string — the in-process runner's
+    /// `RunContext.model` (workflow phase model / retry escalation) and the
+    /// three ctrl dispatch paths' `/model` session override, which is
+    /// reachable from an HTTP request body via `TaskRequest.model_id`. Each
+    /// one silently discarded the pin: a pinned agent handed
+    /// `claude-sonnet-4-6` would route to Anthropic no matter what its
+    /// `provider_id` said. A fail-closed guarantee with four bypasses is not a
+    /// guarantee, so every post-load model change now goes through this one
+    /// function instead of assigning the field directly.
+    ///
+    /// A model override is RE-PINNED rather than refused, because the two
+    /// statements are compatible and specific: the operator pinned a PROVIDER,
+    /// the caller chose a MODEL on it. Refusing would break the workflow
+    /// engine's retry escalation for every pinned agent while adding no
+    /// safety — a re-pinned override still cannot reach an unpinned provider,
+    /// which is the property that matters. A PROVIDER override is the opposite
+    /// case and IS refused; see `ctrl::config::resolve_overridden_credentials`.
+    /// What: assigns `model`, re-runs [`Self::apply_provider_pin`] (which also
+    /// re-validates the pinned provider's credential, so the fail-closed check
+    /// applies at dispatch and not only at load), then rebuilds `adapter` from
+    /// the resulting slug. For an UNPINNED agent this is exactly the old
+    /// behaviour: assign, rebuild, no validation.
+    /// Test: `override_model_repins_a_pinned_agent`,
+    /// `override_model_leaves_an_unpinned_agent_alone`.
+    pub(crate) fn override_model(&mut self, model: &str) -> Result<()> {
+        self.agent.model = model.to_string();
+        self.apply_provider_pin()?;
+        self.adapter = Arc::from(adapter_for_model(&self.agent.model));
+        Ok(())
+    }
+
     /// Built-in default `ctrl` agent config used when no `ctrl.toml` /
     /// `pm.toml` is found on disk (#240, standalone mode).
     ///

--- a/crates/trusty-agents/src/agents/loader.rs
+++ b/crates/trusty-agents/src/agents/loader.rs
@@ -103,7 +103,7 @@ impl AgentConfig {
         }
         let lookup = |n: &str| Self::by_name_unresolved_in(dirs, n).ok();
         match crate::agents::extends::resolve(name, &lookup) {
-            Ok(resolved) => Ok(resolved.finalize_extends()),
+            Ok(resolved) => resolved.finalize_extends(),
             Err(e) => Self::extends_shadow_fallback_in(dirs, name, from_package, e),
         }
     }
@@ -271,7 +271,7 @@ impl AgentConfig {
         let resolved = crate::agents::extends::resolve(name, &lookup).with_context(|| {
             format!("failed to resolve flat `<name>.toml` extends for '{name}'")
         })?;
-        Ok(resolved.finalize_extends())
+        resolved.finalize_extends()
     }
 
     /// Re-run model + adapter resolution after an `extends` merge (#3055).
@@ -283,18 +283,71 @@ impl AgentConfig {
     /// through `resolve_model` (for `TAGENT_MODEL_*` / default-env overrides
     /// keyed on the FINAL agent name) and re-derive the provider adapter so it
     /// matches a normally-loaded config.
-    /// What: resolves `agent.model` via [`resolve_model`] and rebuilds
-    /// `adapter` from the result. Idempotent for an already-resolved model.
+    /// What: resolves `agent.model` via [`resolve_model`], re-applies the
+    /// provider pin ([`AgentConfig::apply_provider_pin`], #3765 — the merged
+    /// `provider_id` may have come from the base) and rebuilds `adapter` from
+    /// the result. Idempotent for an already-resolved model and an
+    /// already-pinned slug. Returns `Err` when the merged config declares a
+    /// pin that cannot be honoured — the same fail-closed contract a directly
+    /// loaded agent gets, rather than a silently unpinned child.
     /// Test: `extends_resolved_child_inherits_base_model` (registry tests).
-    pub(crate) fn finalize_extends(mut self) -> Self {
+    pub(crate) fn finalize_extends(mut self) -> Result<Self> {
         let (resolved, _src) = resolve_model(
             &self.agent.name,
             &self.agent.model,
             self.llm.model_override.as_deref(),
         );
         self.agent.model = resolved;
+        self.apply_provider_pin()?;
         self.adapter = Arc::from(adapter_for_model(&self.agent.model));
-        self
+        Ok(self)
+    }
+
+    /// Apply `[agent].provider_id` to this config's routing (#3765).
+    ///
+    /// Why: the pin has to change something the dispatch path actually reads,
+    /// or it is the same inert key #3765 was filed about. Two things carry
+    /// provider identity through this crate: the model slug (which
+    /// [`adapter_for_model`] resolves an adapter from, at a dozen call sites)
+    /// and `[llm].use_anthropic_direct` (which decides whether the Anthropic
+    /// adapter dials api.anthropic.com or falls back to OpenRouter). A pin
+    /// that set only one of the two would leave the other free to contradict
+    /// it, so this sets both, together, in one place.
+    /// What: no-ops for an unpinned agent — its model and
+    /// `use_anthropic_direct` are left exactly as loaded, so #3765 changes
+    /// nothing for agents that do not opt in. For a pinned agent,
+    /// [`crate::llm::provider_pin::resolve`] validates the pin (unknown /
+    /// undispatchable / uncredentialed all fail closed with an actionable
+    /// message), [`crate::llm::provider_pin::pinned_model_slug`] rewrites the
+    /// model so the pinned provider's routing marker leads it, and
+    /// `use_anthropic_direct` is forced to `pin == Anthropic` — a pin to any
+    /// other provider can no longer be hijacked by an ambient
+    /// `ANTHROPIC_API_KEY`, and a pin TO Anthropic no longer depends on one
+    /// being noticed.
+    /// Test: `agent_config_honours_a_provider_pin`,
+    /// `agent_config_pin_beats_the_model_slug_prefix`,
+    /// `agent_config_without_a_pin_is_unchanged`,
+    /// `agent_config_rejects_a_pin_with_no_credential`.
+    pub(crate) fn apply_provider_pin(&mut self) -> Result<()> {
+        let Some(pin) =
+            crate::llm::provider_pin::resolve(&self.agent.name, self.agent.provider_id.as_deref())?
+        else {
+            return Ok(());
+        };
+        let pinned = crate::llm::provider_pin::pinned_model_slug(pin, &self.agent.model);
+        if pinned != self.agent.model {
+            tracing::debug!(
+                agent = %self.agent.name,
+                provider = %pin,
+                from = %self.agent.model,
+                to = %pinned,
+                "provider pin rewrote the model slug"
+            );
+            self.agent.model = pinned;
+        }
+        self.llm.use_anthropic_direct =
+            pin == trusty_common::inference::registry::ProviderId::Anthropic;
+        Ok(())
     }
 
     /// Built-in default `ctrl` agent config used when no `ctrl.toml` /
@@ -347,7 +400,7 @@ impl AgentConfig {
         }
         let lookup = |n: &str| Self::by_name_unresolved_in(&dirs, n).ok();
         match crate::agents::extends::resolve(name, &lookup) {
-            Ok(resolved) => Ok(resolved.finalize_extends()),
+            Ok(resolved) => resolved.finalize_extends(),
             Err(e) => Self::extends_shadow_fallback_in(&dirs, name, from_package, e),
         }
     }
@@ -486,6 +539,12 @@ impl AgentConfig {
             cfg.llm.model_override.as_deref(),
         );
         cfg.agent.model = resolved;
+        // #3765: the pin runs AFTER `resolve_model` (so a `TAGENT_MODEL_*`
+        // override is still honoured for the model NAME) and BEFORE the
+        // adapter is derived (so the adapter is chosen from the pinned slug,
+        // never the pre-pin one).
+        cfg.apply_provider_pin()
+            .with_context(|| format!("in {}", path.display()))?;
         cfg.adapter = Arc::from(adapter_for_model(&cfg.agent.model));
         // Validate stop_sequences against API limits (#327).
         // Anthropic caps at 8 sequences (≤ 8191 chars each); Bedrock at 4.

--- a/crates/trusty-agents/src/agents/mpm_bridge.rs
+++ b/crates/trusty-agents/src/agents/mpm_bridge.rs
@@ -354,6 +354,8 @@ fn project_mpm_agent(default_name: &str, meta: AgentMetadata, body: String) -> A
             extends: None,
             // Derived, never declared: see this function's doc comment.
             tier: None,
+            // #3765: no provider pin on this construction path.
+            provider_id: None,
         },
         llm: LlmParams {
             temperature: 0.2,

--- a/crates/trusty-agents/src/agents/registry/md_agent.rs
+++ b/crates/trusty-agents/src/agents/registry/md_agent.rs
@@ -194,6 +194,10 @@ pub(crate) fn parse_md_agent(path: &Path) -> anyhow::Result<AgentConfig> {
             prompt_label: None,
             extends: fm.extends,
             tier: fm.tier,
+            // #3765: `.md` overlay agents have no `provider_id` frontmatter
+            // key — pinning is a TOML/package-agent feature for now, and an
+            // absent pin is exactly today's ambient behaviour.
+            provider_id: None,
         },
         llm: LlmParams {
             temperature: llm_temperature,

--- a/crates/trusty-agents/src/agents/registry/mod.rs
+++ b/crates/trusty-agents/src/agents/registry/mod.rs
@@ -421,12 +421,25 @@ fn resolve_extends_in_map(
     let mut errors: HashMap<String, String> = HashMap::new();
     for name in to_resolve {
         match crate::agents::extends::resolve(&name, &lookup) {
-            Ok(resolved) => {
-                let resolved = resolved.finalize_extends();
-                if let Some(entry) = agents.get_mut(&name) {
-                    entry.0 = resolved;
+            Ok(resolved) => match resolved.finalize_extends() {
+                Ok(resolved) => {
+                    if let Some(entry) = agents.get_mut(&name) {
+                        entry.0 = resolved;
+                    }
                 }
-            }
+                // #3765: a merged child whose provider pin cannot be honoured
+                // is recorded like any other resolution failure — the
+                // unresolved (and therefore unpinned) agent is NOT substituted
+                // silently into the roster under the resolved agent's name.
+                Err(e) => {
+                    tracing::warn!(
+                        agent = %name,
+                        error = %e,
+                        "failed to finalize agent `extends` chain"
+                    );
+                    errors.insert(name.clone(), e.to_string());
+                }
+            },
             Err(e) => {
                 tracing::warn!(
                     agent = %name,

--- a/crates/trusty-agents/src/agents/tests/mod.rs
+++ b/crates/trusty-agents/src/agents/tests/mod.rs
@@ -1110,3 +1110,216 @@ fn agent_tier_explicit_declaration_overrides_the_derived_kind() {
         "an unrecognized declaration can only ever narrow"
     );
 }
+
+// ── Per-agent provider pinning (#3765) ───────────────────────────────────────
+//
+// `[agent].provider_id` was written by `PATCH /api/agents/:name` and read by
+// nothing: `AgentInfo` had no provider slot, so the loader dropped the key and
+// every turn re-probed the ambient environment instead. Each test below fails
+// on the pre-#3765 tree — the "pin honoured" cases because the model slug came
+// out unchanged and the adapter was chosen from it, and the fail-closed case
+// because loading simply succeeded.
+
+/// Build an agent TOML with an optional `provider_id` line.
+fn agent_toml_with_pin(model: &str, provider_line: &str) -> String {
+    format!(
+        r#"
+[agent]
+name = "pin-fixture"
+role = "assistant"
+model = "{model}"
+description = "x"
+{provider_line}
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "base"
+"#
+    )
+}
+
+fn load_pinned(model: &str, provider: Option<&str>) -> anyhow::Result<AgentConfig> {
+    let line = provider.map_or(String::new(), |p| format!("provider_id = \"{p}\""));
+    AgentConfig::from_toml_str(
+        &agent_toml_with_pin(model, &line),
+        std::path::Path::new("pin-fixture.toml"),
+    )
+}
+
+/// Why: THE regression for #3765's core defect. Bedrock is used because it has
+/// no resolver-managed credential (AWS chain), so the assertion is about
+/// routing alone and runs identically on a laptop and in CI.
+/// Test: itself.
+#[test]
+fn agent_config_honours_a_provider_pin() {
+    let cfg = load_pinned("anthropic.claude-3-5-haiku-20241022-v1:0", Some("bedrock"))
+        .expect("pinned agent loads");
+    assert_eq!(
+        cfg.agent.model, "bedrock/anthropic.claude-3-5-haiku-20241022-v1:0",
+        "the pin must put the provider's routing marker on the slug"
+    );
+    assert_eq!(
+        cfg.adapter.provider(),
+        crate::llm::adapter::Provider::Bedrock,
+        "and the adapter must be derived from the pinned slug"
+    );
+    assert!(!cfg.llm.use_anthropic_direct);
+}
+
+/// Why: "pinning must take precedence over slug inference" is the behavioural
+/// contract. `claude-sonnet-4-6` resolves to the Anthropic adapter on its own;
+/// pinning Bedrock must override that, not lose to it.
+/// Test: itself.
+#[test]
+fn agent_config_pin_beats_the_model_slug_prefix() {
+    let unpinned = load_pinned("claude-sonnet-4-6", None).expect("loads");
+    assert_eq!(
+        unpinned.adapter.provider(),
+        crate::llm::adapter::Provider::Anthropic,
+        "precondition: the bare slug infers Anthropic"
+    );
+
+    let pinned = load_pinned("claude-sonnet-4-6", Some("bedrock")).expect("loads");
+    assert_eq!(pinned.agent.model, "bedrock/claude-sonnet-4-6");
+    assert_eq!(
+        pinned.adapter.provider(),
+        crate::llm::adapter::Provider::Bedrock
+    );
+}
+
+/// Why: #3765 is explicit that an agent with NO pin keeps today's ambient
+/// behaviour exactly — the model slug and `use_anthropic_direct` must come out
+/// of the loader byte-identical to what the TOML declared.
+/// Test: itself.
+#[test]
+fn agent_config_without_a_pin_is_unchanged() {
+    let cfg = load_pinned("anthropic/claude-sonnet-4-6", None).expect("loads");
+    assert_eq!(cfg.agent.provider_id, None);
+    assert_eq!(cfg.agent.model, "anthropic/claude-sonnet-4-6");
+    assert!(
+        !cfg.llm.use_anthropic_direct,
+        "an unpinned agent's use_anthropic_direct stays as declared"
+    );
+    assert_eq!(
+        cfg.adapter.provider(),
+        crate::llm::adapter::Provider::Anthropic
+    );
+}
+
+/// Why: the fail-closed guarantee, exercised through the real loader rather
+/// than only through `provider_pin::resolve`. A pinned provider with no
+/// credential must abort the load with a message naming the provider and its
+/// env var — never load "successfully" onto some other provider's key.
+/// What: sandboxes `$HOME` (secure store → tempdir) and clears every
+/// credential env var, so the assertion holds on a developer machine with real
+/// keys configured as well as on a bare CI runner.
+/// Test: itself.
+#[test]
+#[serial_test::serial]
+fn agent_config_rejects_a_pin_with_no_credential() {
+    let _env = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _home = crate::test_env::HOME_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    crate::test_env::force_env_local_loaded();
+    crate::test_env::clear_all_credential_env_vars();
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let prev_home = std::env::var_os("HOME");
+    // SAFETY: HOME_LOCK held for the entire test body.
+    unsafe { std::env::set_var("HOME", tmp.path()) };
+
+    let err = load_pinned("accounts/fireworks/models/x", Some("fireworks"))
+        .expect_err("must fail closed");
+    let msg = format!("{err:#}");
+
+    // SAFETY: HOME_LOCK still held.
+    unsafe {
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    assert!(msg.contains("fireworks"), "must name the provider: {msg}");
+    assert!(
+        msg.contains("FIREWORKS_API_KEY"),
+        "must name the env var: {msg}"
+    );
+    assert!(
+        msg.contains("pin-fixture.toml"),
+        "must name the offending config: {msg}"
+    );
+}
+
+/// Why: AtlasCloud is the provider #3765 makes reachable; pinning it must
+/// produce the AtlasCloud adapter (not `GenericAdapter`/OpenRouter, which is
+/// where `atlascloud/openai/...` landed before). The key is a fake value set
+/// only to satisfy the fail-closed credential probe — this asserts routing,
+/// never a live call.
+/// Test: itself.
+#[test]
+#[serial_test::serial]
+fn agent_config_pin_routes_atlascloud() {
+    let _env = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    crate::test_env::force_env_local_loaded();
+    let prev = std::env::var_os("ATLASCLOUD_API_KEY");
+    // SAFETY: ENV_LOCK held for the entire test body.
+    unsafe { std::env::set_var("ATLASCLOUD_API_KEY", "ac-FAKE-routing-test") };
+
+    let cfg = load_pinned("openai/gpt-5.6-sol", Some("atlascloud"));
+
+    // SAFETY: ENV_LOCK still held.
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var("ATLASCLOUD_API_KEY", v),
+            None => std::env::remove_var("ATLASCLOUD_API_KEY"),
+        }
+    }
+
+    let cfg = cfg.expect("pinned agent loads");
+    assert_eq!(cfg.agent.model, "atlascloud/openai/gpt-5.6-sol");
+    assert_eq!(
+        cfg.adapter.provider(),
+        crate::llm::adapter::Provider::AtlasCloud,
+        "before #3765 the `openai` substring routed this to OpenRouter"
+    );
+}
+
+/// Why: an anthropic pin must FORCE the direct path rather than depend on
+/// `pick_credentials` noticing an `ANTHROPIC_API_KEY` — and, symmetrically, a
+/// pin to anything else must leave `use_anthropic_direct` off even when that
+/// key is present (see `agent_config_honours_a_provider_pin`).
+/// Test: itself.
+#[test]
+#[serial_test::serial]
+fn agent_config_anthropic_pin_forces_the_direct_path() {
+    let _env = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    crate::test_env::force_env_local_loaded();
+    let prev = std::env::var_os("ANTHROPIC_API_KEY");
+    // SAFETY: ENV_LOCK held for the entire test body.
+    unsafe { std::env::set_var("ANTHROPIC_API_KEY", "sk-ant-api03-FAKE-routing-test") };
+
+    let cfg = load_pinned("claude-sonnet-4-6", Some("anthropic"));
+
+    // SAFETY: ENV_LOCK still held.
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var("ANTHROPIC_API_KEY", v),
+            None => std::env::remove_var("ANTHROPIC_API_KEY"),
+        }
+    }
+
+    let cfg = cfg.expect("pinned agent loads");
+    assert_eq!(cfg.agent.model, "anthropic/claude-sonnet-4-6");
+    assert!(cfg.llm.use_anthropic_direct);
+}

--- a/crates/trusty-agents/src/agents/tests/mod.rs
+++ b/crates/trusty-agents/src/agents/tests/mod.rs
@@ -1323,3 +1323,120 @@ fn agent_config_anthropic_pin_forces_the_direct_path() {
     assert_eq!(cfg.agent.model, "anthropic/claude-sonnet-4-6");
     assert!(cfg.llm.use_anthropic_direct);
 }
+
+// ── Pin bypass via post-load model override (#3765) ──────────────────────────
+//
+// Four call sites replaced `cfg.agent.model` after load and rebuilt the adapter
+// from the raw string, discarding the pin: `in_process_runner::run_inner`
+// (`RunContext.model` — a workflow phase's model, or retry escalation) and the
+// three ctrl dispatch paths' `/model` session override, reachable from an HTTP
+// body via `TaskRequest.model_id`. All four now go through
+// `AgentConfig::override_model`. These tests exercise that function directly,
+// which is the single point every one of them funnels through.
+
+/// Why: the bypass regression. Pre-fix, assigning a model directly left a
+/// pinned agent routed at whatever the override's slug implied — here Bedrock
+/// would have won over an `atlascloud` pin. Bedrock is used as the OVERRIDE
+/// (not the pin) precisely because its slug prefix beats every heuristic, so a
+/// pin that survives it is a pin that survives anything.
+/// Test: itself.
+#[test]
+#[serial_test::serial]
+fn override_model_repins_a_pinned_agent() {
+    let _env = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    crate::test_env::force_env_local_loaded();
+    let prev = std::env::var_os("ATLASCLOUD_API_KEY");
+    // SAFETY: ENV_LOCK held for the entire test body.
+    unsafe { std::env::set_var("ATLASCLOUD_API_KEY", "ac-FAKE-override-test") };
+
+    let result = (|| -> anyhow::Result<AgentConfig> {
+        let mut cfg = load_pinned("openai/gpt-5.6-sol", Some("atlascloud"))?;
+        cfg.override_model("bedrock/anthropic.claude-3-5-haiku-20241022-v1:0")?;
+        Ok(cfg)
+    })();
+
+    // SAFETY: ENV_LOCK still held.
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var("ATLASCLOUD_API_KEY", v),
+            None => std::env::remove_var("ATLASCLOUD_API_KEY"),
+        }
+    }
+
+    let cfg = result.expect("override applies");
+    assert_eq!(
+        cfg.agent.model, "atlascloud/anthropic.claude-3-5-haiku-20241022-v1:0",
+        "the override's bedrock/ marker must be replaced by the pin's"
+    );
+    assert_eq!(
+        cfg.adapter.provider(),
+        crate::llm::adapter::Provider::AtlasCloud,
+        "and the rebuilt adapter must follow the pin, not the override's slug"
+    );
+}
+
+/// Why: the other half of the contract — an UNPINNED agent's override must
+/// behave exactly as it did before #3765 (assign, rebuild adapter, no
+/// validation), or this fix regresses every agent that never opted in.
+/// Test: itself.
+#[test]
+fn override_model_leaves_an_unpinned_agent_alone() {
+    let mut cfg = load_pinned("anthropic/claude-sonnet-4-6", None).expect("loads");
+    cfg.override_model("bedrock/anthropic.claude-3-5-haiku-20241022-v1:0")
+        .expect("override applies");
+    assert_eq!(
+        cfg.agent.model, "bedrock/anthropic.claude-3-5-haiku-20241022-v1:0",
+        "an unpinned override is taken verbatim"
+    );
+    assert_eq!(
+        cfg.adapter.provider(),
+        crate::llm::adapter::Provider::Bedrock
+    );
+}
+
+/// Why: a model override on a pinned agent whose credential has since gone
+/// away must fail closed at DISPATCH too, not just at load — `override_model`
+/// re-runs the same validation rather than trusting the config it was handed.
+/// Test: itself.
+#[test]
+#[serial_test::serial]
+fn override_model_fails_closed_when_the_pinned_credential_vanishes() {
+    let _env = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _home = crate::test_env::HOME_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    crate::test_env::force_env_local_loaded();
+    crate::test_env::clear_all_credential_env_vars();
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let prev_home = std::env::var_os("HOME");
+    // SAFETY: HOME_LOCK held for the entire test body.
+    unsafe { std::env::set_var("HOME", tmp.path()) };
+
+    // Load with the credential present, then take it away before the override.
+    // SAFETY: ENV_LOCK held.
+    unsafe { std::env::set_var("ATLASCLOUD_API_KEY", "ac-FAKE-then-removed") };
+    let loaded = load_pinned("openai/gpt-5.6-sol", Some("atlascloud"));
+    // SAFETY: ENV_LOCK held.
+    unsafe { std::env::remove_var("ATLASCLOUD_API_KEY") };
+    let err = loaded
+        .expect("loads while the key is present")
+        .override_model("some-other-model")
+        .expect_err("must fail closed once the key is gone");
+    let msg = format!("{err:#}");
+
+    // SAFETY: HOME_LOCK still held.
+    unsafe {
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+    assert!(
+        msg.contains("atlascloud") && msg.contains("ATLASCLOUD_API_KEY"),
+        "{msg}"
+    );
+}

--- a/crates/trusty-agents/src/api/server/agent_patch.rs
+++ b/crates/trusty-agents/src/api/server/agent_patch.rs
@@ -348,6 +348,21 @@ pub(super) async fn patch_agent_at(
         // it's the caller's own input.
         let requested_provider_cap = match req.provider_id.as_deref() {
             Some(pid) => match registry::capabilities_for(pid) {
+                // #3765: `provider_id` is no longer inert — the loader now
+                // PINS the agent to it and fails closed. So the write gate
+                // must refuse a provider the loader would refuse, or the GUI
+                // would happily persist a pin that bricks the agent on its
+                // next load. Credential presence is deliberately NOT checked
+                // here: a key can legitimately be added after the agent is
+                // configured, and the load-time check is the enforcement
+                // point. Dispatchability cannot change without a rebuild.
+                Some(cap) if !crate::llm::provider_pin::is_pinnable(cap.id) => {
+                    return bad_request(format!(
+                        "provider_id '{pid}' is a known provider but trusty-agents \
+                         cannot dispatch to it yet, so pinning an agent to it would \
+                         fail at the first turn"
+                    ));
+                }
                 Some(cap) => Some(cap),
                 None => return bad_request(format!("unknown provider_id '{pid}'")),
             },

--- a/crates/trusty-agents/src/api/server/mod.rs
+++ b/crates/trusty-agents/src/api/server/mod.rs
@@ -57,6 +57,11 @@ mod events_sse;
 mod handlers;
 mod listener_events;
 mod models;
+// #3765: the dispatch-reachability predicate is also the pin-eligibility
+// predicate — `llm::provider_pin` asserts the two sets are identical so the
+// GUI cannot offer a provider the agent loader refuses to pin.
+#[cfg(test)]
+pub(crate) use models::reachable_today;
 mod project_registration;
 mod projects;
 mod relay;

--- a/crates/trusty-agents/src/api/server/models.rs
+++ b/crates/trusty-agents/src/api/server/models.rs
@@ -80,26 +80,41 @@ pub struct ModelsCatalogResponse {
 /// OpenRouter endpoint, which then receives each provider's bare
 /// (un-prefixed) model-id slug. OpenRouter doesn't recognize those bare
 /// slugs as its own routes, so the call fails: the gap is a model-ID /
-/// endpoint mismatch, not a missing branch. The registry's `local` entry has
-/// a DIFFERENT gap: its `local/` slug prefix isn't recognized by
-/// `adapter_for_model` at all (only the separate `ollama/` prefix is, via
-/// `OllamaAdapter` — see the synthetic `local` object's own
-/// `reachable_today`, always `true`, below), so it falls all the way to
-/// `GenericAdapter` instead. Surfacing this distinction keeps the picker
-/// honest instead of implying every registry entry is immediately usable.
-/// What: `true` for OpenRouter, Bedrock, Anthropic, Fireworks; `false` for
-/// the remaining providers whose legacy dispatch falls through to OpenRouter
-/// with an unresolvable model-id slug. Flip an entry to `true` here once its
-/// legacy dispatch branch resolves to the correct provider-native endpoint
-/// (tracked by #2410); this function is the one place that needs to change.
-/// Test: `super::tests::models::reachable_today_matches_documented_set`.
-fn reachable_today(id: ProviderId) -> bool {
+/// endpoint mismatch, not a missing branch. Surfacing this distinction keeps
+/// the picker honest instead of implying every registry entry is immediately
+/// usable.
+///
+/// The registry's `local` entry had a DIFFERENT gap until #3765: its `local/`
+/// slug prefix isn't recognized by `adapter_for_model` at all (only the
+/// separate `ollama/` prefix is, via `OllamaAdapter` — see the synthetic
+/// `local` object's own `reachable_today`, always `true`, below), so it fell
+/// through to `GenericAdapter`. `provider_pin::pinned_model_slug` now
+/// normalises a `local` pin onto the `ollama/` marker, so the registry entry
+/// and the synthetic one finally agree: both are reachable.
+/// AtlasCloud joined that set in #3765: `adapter_for_model` now has an
+/// `atlascloud/` branch resolving to `AtlasCloudAdapter` (api.atlascloud.ai +
+/// `ATLASCLOUD_API_KEY`), so it dispatches for real rather than falling
+/// through to OpenRouter with a slug OpenRouter does not serve. OpenAI and
+/// Together still do fall through, and stay `false`.
+/// What: `true` for OpenRouter, Bedrock, Anthropic, Fireworks, AtlasCloud, and
+/// Local (`ollama/` prefix); `false` for the remaining providers whose legacy
+/// dispatch falls through to OpenRouter with an unresolvable model-id slug.
+/// Flip an entry to `true` here once its legacy dispatch branch resolves to
+/// the correct provider-native endpoint (tracked by #2410); this function is
+/// the one place that needs to change — `llm::provider_pin::PINNABLE` is
+/// asserted equal to it by `provider_pin::tests::pinnable_set_matches_reachable_today`,
+/// so the GUI can never offer a provider the loader refuses to pin.
+/// Test: `super::tests::models::reachable_today_matches_documented_set`,
+/// `crate::llm::provider_pin::tests::pinnable_set_matches_reachable_today`.
+pub(crate) fn reachable_today(id: ProviderId) -> bool {
     matches!(
         id,
         ProviderId::OpenRouter
             | ProviderId::Bedrock
             | ProviderId::Anthropic
             | ProviderId::Fireworks
+            | ProviderId::AtlasCloud
+            | ProviderId::Local
     )
 }
 

--- a/crates/trusty-agents/src/api/server/tests/agent_patch.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_patch.rs
@@ -370,6 +370,11 @@ async fn patch_agent_claude_code_accepts_anthropic_provider() {
 
 /// Why: A caller that only wants to switch provider (without hand-typing a
 /// model slug) should get that provider's registry default model.
+///
+/// #3765 changed the provider used here from `openai` to `atlascloud`:
+/// `provider_id` is no longer an inert key, so the write gate now refuses a
+/// provider the agent loader would refuse to pin, and `openai` is one of
+/// those (see `patch_agent_rejects_a_provider_dispatch_cannot_reach`).
 #[tokio::test]
 async fn patch_agent_provider_only_uses_default_model() {
     let tmp = tempfile::tempdir().unwrap();
@@ -380,7 +385,7 @@ async fn patch_agent_provider_only_uses_default_model() {
         "engineer",
         PatchAgentRequest {
             model_id: None,
-            provider_id: Some("openai".to_string()),
+            provider_id: Some("atlascloud".to_string()),
             ..Default::default()
         },
     )
@@ -390,11 +395,49 @@ async fn patch_agent_provider_only_uses_default_model() {
         .await
         .unwrap();
     let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-    let expected_default = trusty_common::inference::registry::capabilities_for("openai")
+    let expected_default = trusty_common::inference::registry::capabilities_for("atlascloud")
         .unwrap()
         .default_model;
     assert_eq!(body["model"], expected_default);
-    assert_eq!(body["provider_id"], "openai");
+    assert_eq!(body["provider_id"], "atlascloud");
+}
+
+/// Why (#3765): `provider_id` used to be written verbatim and read by nothing,
+/// so persisting `openai` was harmless. Now the loader PINS the agent to it
+/// and fails closed, which would turn a successful-looking GUI write into an
+/// agent that cannot load. The write gate must refuse the same providers the
+/// loader refuses — `openai` and `together` still fall through to OpenRouter
+/// with a bare, unroutable slug.
+/// Test: itself.
+#[tokio::test]
+async fn patch_agent_rejects_a_provider_dispatch_cannot_reach() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_fixture(tmp.path(), "engineer", SUBPROCESS_FIXTURE);
+
+    for provider in ["openai", "together"] {
+        let resp = patch_agent_at(
+            &[tmp.path().to_path_buf()],
+            "engineer",
+            PatchAgentRequest {
+                model_id: None,
+                provider_id: Some(provider.to_string()),
+                ..Default::default()
+            },
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "{provider} must be refused"
+        );
+        let bytes = axum::body::to_bytes(resp.into_body(), 4 * 1024)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let err = body["error"].as_str().unwrap_or_default();
+        assert!(err.contains(provider), "error must name it: {err}");
+        assert!(err.contains("cannot dispatch"), "{err}");
+    }
 }
 
 /// Why: `PATCH /api/agents/:name` must actually be registered on the router

--- a/crates/trusty-agents/src/api/server/tests/models.rs
+++ b/crates/trusty-agents/src/api/server/tests/models.rs
@@ -117,11 +117,17 @@ async fn reachable_today_matches_documented_set() {
     assert!(reachable_today("fireworks"));
     assert!(!reachable_today("openai"));
     assert!(!reachable_today("together"));
-    assert!(!reachable_today("atlascloud"));
-    // The registry's `local` provider (#3247) isn't wired into the legacy
+    // #3765 gave AtlasCloud its own `adapter_for_model` branch
+    // (api.atlascloud.ai + `ATLASCLOUD_API_KEY`), so it dispatches for real
+    // instead of falling through to OpenRouter with a slug OpenRouter does
+    // not serve.
+    assert!(reachable_today("atlascloud"));
+    // The registry's `local` provider (#3247) was not wired into the legacy
     // dispatch under its OWN name — only the synthetic `local.provider_id ==
-    // "ollama"` entry below is (via the `ollama/` prefix).
-    assert!(!reachable_today("local"));
+    // "ollama"` entry below was (via the `ollama/` prefix). #3765's
+    // `provider_pin::pinned_model_slug` normalises a `local` pin onto that
+    // same `ollama/` marker, so the two entries no longer disagree.
+    assert!(reachable_today("local"));
 
     assert_eq!(body["local"]["reachable_today"], true);
 }

--- a/crates/trusty-agents/src/ctrl/config.rs
+++ b/crates/trusty-agents/src/ctrl/config.rs
@@ -475,6 +475,21 @@ pub(crate) fn apply_credential_routing(
     creds: &llm::credentials::LlmCredentials,
 ) -> bool {
     use llm::credentials::LlmCredentials;
+    // #3765: a pinned agent has already had its provider decided at load
+    // (`AgentConfig::apply_provider_pin` — validated, credential-checked, and
+    // written into the model slug and `use_anthropic_direct`). Ambient
+    // credential probing must not overwrite that: re-running it here is
+    // exactly the silent-fallback the pin exists to prevent — e.g. an agent
+    // pinned to `atlascloud` would be flipped to Anthropic-direct merely
+    // because an `ANTHROPIC_API_KEY` happens to be present.
+    if cfg.agent.provider_id.is_some() {
+        tracing::debug!(
+            agent = %cfg.agent.name,
+            provider_id = ?cfg.agent.provider_id,
+            "provider pin in effect; skipping ambient credential routing"
+        );
+        return false;
+    }
     match creds {
         LlmCredentials::AnthropicDirect => {
             cfg.llm.use_anthropic_direct = true;

--- a/crates/trusty-agents/src/ctrl/config.rs
+++ b/crates/trusty-agents/src/ctrl/config.rs
@@ -92,6 +92,26 @@ pub(crate) fn resolve_overridden_credentials(
     provider_override: Option<&str>,
 ) -> Result<llm::credentials::LlmCredentials> {
     use llm::credentials::LlmCredentials;
+    // #3765: the `bedrock` and `local` arms below PREPEND a routing marker to
+    // `cfg.agent.model`, which on a pinned agent both defeats the pin and
+    // produces a nonsense double-prefixed slug (`bedrock/atlascloud/…`).
+    // Unlike a MODEL override — which names a model on the pinned provider and
+    // is re-pinned by `AgentConfig::override_model` — a PROVIDER override
+    // directly contradicts the pin, so there is no coherent reading to honour.
+    // Refuse it and say which two providers disagree.
+    if let (Some(pinned), Some(requested)) = (cfg.agent.provider_id.as_deref(), provider_override)
+        && !pinned.eq_ignore_ascii_case(requested)
+    {
+        anyhow::bail!(
+            "agent '{}' pins [agent].provider_id = '{}'; a session provider \
+             override to '{}' contradicts it and is refused. Change the pin in \
+             the agent's TOML, or clear it to allow per-session provider \
+             switching.",
+            cfg.agent.name,
+            pinned,
+            requested
+        );
+    }
     match provider_override {
         Some("claude-code") => Ok(LlmCredentials::ClaudeCode),
         Some("openrouter") => Ok(LlmCredentials::OpenRouter),

--- a/crates/trusty-agents/src/ctrl/ctrl_turn/dispatch.rs
+++ b/crates/trusty-agents/src/ctrl/ctrl_turn/dispatch.rs
@@ -54,7 +54,8 @@ fn resolve_ctrl_turn_credentials(
 ) -> Result<(llm::credentials::LlmCredentials, bool)> {
     if let Some(ref m) = overrides.model {
         tracing::debug!(model = %m, "ctrl_chat_turn: applying /model session override");
-        cfg.agent.model = m.clone();
+        // #3765: re-pins the override when the agent declares a provider.
+        cfg.override_model(m)?;
     }
     let creds = resolve_overridden_credentials(cfg, overrides.provider.as_deref())?;
     let claude_cli_short_circuit = apply_credential_routing(cfg, &creds);

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -85,7 +85,8 @@ pub async fn run_pm_task_with_history(
 
     if let Some(ref m) = overrides.model {
         tracing::debug!(model = %m, "applying /model session override");
-        pm_cfg.agent.model = m.clone();
+        // #3765: re-pins the override when the agent declares a provider.
+        pm_cfg.override_model(m)?;
     }
 
     let creds = resolve_overridden_credentials(&mut pm_cfg, overrides.provider.as_deref())?;

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -103,7 +103,8 @@ pub async fn run_pm_task_with_persona(
 
     if let Some(ref m) = overrides.model {
         tracing::debug!(persona = %persona_name, model = %m, "applying /model override");
-        persona_cfg.agent.model = m.clone();
+        // #3765: re-pins the override when the agent declares a provider.
+        persona_cfg.override_model(m)?;
     }
 
     let creds = resolve_overridden_credentials(&mut persona_cfg, overrides.provider.as_deref())?;

--- a/crates/trusty-agents/src/ctrl/tests/config_tests.rs
+++ b/crates/trusty-agents/src/ctrl/tests/config_tests.rs
@@ -451,3 +451,50 @@ fn build_user_context_prefix_appends_base_content_after_block() {
         );
     });
 }
+
+/// Why (#3765): the fifth pin bypass. `resolve_overridden_credentials`'s
+/// `bedrock`/`local` arms PREPEND a routing marker to `cfg.agent.model`, so a
+/// session `/provider bedrock` on an agent pinned to `atlascloud` both defeated
+/// the pin and produced a nonsense `bedrock/atlascloud/...` slug. Unlike a
+/// model override — which names a model ON the pinned provider and is re-pinned
+/// by `AgentConfig::override_model` — a provider override directly contradicts
+/// the pin, so it is refused rather than silently applied.
+/// Test: itself.
+#[test]
+fn provider_override_is_refused_on_a_pinned_agent() {
+    // Built from the in-crate default rather than a TOML fixture: the guard
+    // reads `agent.provider_id` and `agent.model`, and `from_toml_str` is not
+    // visible outside `agents::`.
+    let mut cfg = AgentConfig::ctrl_default();
+    cfg.agent.provider_id = Some("atlascloud".to_string());
+    cfg.agent.model = "atlascloud/openai/gpt-5.6-sol".to_string();
+
+    let err = super::super::config::resolve_overridden_credentials(&mut cfg, Some("bedrock"))
+        .expect_err("a contradicting provider override must be refused");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("atlascloud") && msg.contains("bedrock"),
+        "{msg}"
+    );
+    assert!(
+        !cfg.agent.model.starts_with("bedrock/"),
+        "the model must not be mutated by a refused override: {}",
+        cfg.agent.model
+    );
+}
+
+/// Why: the same override on an UNPINNED agent must keep working exactly as
+/// before — the guard narrows nothing for agents that never opted in.
+/// Test: itself.
+#[test]
+fn provider_override_still_works_on_an_unpinned_agent() {
+    let mut cfg = AgentConfig::ctrl_default();
+    cfg.agent.provider_id = None;
+    super::super::config::resolve_overridden_credentials(&mut cfg, Some("bedrock"))
+        .expect("unpinned agents keep the pre-#3765 behaviour");
+    assert!(
+        cfg.agent.model.starts_with("bedrock/"),
+        "{}",
+        cfg.agent.model
+    );
+}

--- a/crates/trusty-agents/src/llm/adapter/impls.rs
+++ b/crates/trusty-agents/src/llm/adapter/impls.rs
@@ -10,8 +10,8 @@
 use serde_json::{Value, json};
 
 use super::{
-    AnthropicAdapter, ApiEndpoint, AuthSource, BedrockAdapter, FireworksAdapter, GenericAdapter,
-    ModelAdapter, OllamaAdapter, OpenAiAdapter, Provider, openrouter_endpoint,
+    AnthropicAdapter, ApiEndpoint, AtlasCloudAdapter, AuthSource, BedrockAdapter, FireworksAdapter,
+    GenericAdapter, ModelAdapter, OllamaAdapter, OpenAiAdapter, Provider, openrouter_endpoint,
 };
 use crate::perf::TokenUsage;
 
@@ -20,6 +20,10 @@ use crate::perf::TokenUsage;
 /// established in this module, so an offline mock server can be targeted
 /// end-to-end without touching process-wide defaults.
 const FIREWORKS_BASE_URL_ENV: &str = "FIREWORKS_BASE_URL";
+
+/// Env var overriding the AtlasCloud API base URL (#3765) — same convention as
+/// [`FIREWORKS_BASE_URL_ENV`].
+const ATLASCLOUD_BASE_URL_ENV: &str = "ATLASCLOUD_BASE_URL";
 
 impl ModelAdapter for AnthropicAdapter {
     fn provider(&self) -> Provider {
@@ -241,6 +245,12 @@ impl ModelAdapter for OllamaAdapter {
     fn provider(&self) -> Provider {
         Provider::Generic
     }
+    fn wire_model_id<'a>(&self, model: &'a str) -> &'a str {
+        model.strip_prefix("ollama/").unwrap_or(model)
+    }
+    fn requires_raw_http(&self) -> bool {
+        true
+    }
     fn tool_choice_any(&self) -> Option<Value> {
         // ollama's OpenAI-compat layer accepts "auto"/"required" but not all
         // models honor it. Return None to keep the request payload minimal.
@@ -287,6 +297,12 @@ impl ModelAdapter for FireworksAdapter {
     fn provider(&self) -> Provider {
         Provider::Fireworks
     }
+    fn wire_model_id<'a>(&self, model: &'a str) -> &'a str {
+        model.strip_prefix("fireworks/").unwrap_or(model)
+    }
+    fn requires_raw_http(&self) -> bool {
+        true
+    }
     // Fireworks serves an OpenAI-compatible `/chat/completions` endpoint —
     // same tool_choice shapes as `OpenAiAdapter` ("required"/"auto" strings,
     // not Anthropic's `{"type": ...}` objects).
@@ -324,6 +340,55 @@ impl ModelAdapter for FireworksAdapter {
             auth_header_value: format!("Bearer {key}"),
             extra_headers: vec![],
             auth_source: AuthSource::Fireworks,
+        }
+    }
+}
+
+impl ModelAdapter for AtlasCloudAdapter {
+    fn provider(&self) -> Provider {
+        Provider::AtlasCloud
+    }
+    fn wire_model_id<'a>(&self, model: &'a str) -> &'a str {
+        model.strip_prefix("atlascloud/").unwrap_or(model)
+    }
+    fn requires_raw_http(&self) -> bool {
+        true
+    }
+    // AtlasCloud serves an OpenAI-compatible `/chat/completions` endpoint —
+    // same tool_choice shapes as `OpenAiAdapter`.
+    fn tool_choice_any(&self) -> Option<Value> {
+        Some(json!("required"))
+    }
+    fn tool_choice_auto(&self) -> Option<Value> {
+        Some(json!("auto"))
+    }
+    fn inject_cache_control(&self, _: &mut Value, _: bool) {
+        // No prompt-caching concept — matches this provider's registry seed
+        // (`prompt_caching = false`).
+    }
+    fn parse_usage(&self, response: &Value) -> TokenUsage {
+        let usage = &response["usage"];
+        let prompt = usage["prompt_tokens"].as_u64().unwrap_or(0) as u32;
+        let completion = usage["completion_tokens"].as_u64().unwrap_or(0) as u32;
+        TokenUsage::new(prompt, completion, 0, 0)
+    }
+    fn api_endpoint(&self, _use_direct: bool) -> ApiEndpoint {
+        // Always route to api.atlascloud.ai — an explicit `atlascloud/` prefix
+        // (or a `provider_id = "atlascloud"` pin, which the loader rewrites
+        // into that prefix) means the caller wants AtlasCloud specifically.
+        // Base URL comes from the trusty-common provider module rather than a
+        // second literal here, so the shared-inference adapter and this legacy
+        // one can never disagree about the endpoint.
+        let base_url = std::env::var(ATLASCLOUD_BASE_URL_ENV).unwrap_or_else(|_| {
+            trusty_common::inference::providers::atlascloud::ATLASCLOUD_BASE_URL.to_string()
+        });
+        let key = trusty_common::credentials::resolve_key("atlascloud").unwrap_or_default();
+        ApiEndpoint {
+            base_url,
+            auth_header_name: "Authorization".to_string(),
+            auth_header_value: format!("Bearer {key}"),
+            extra_headers: vec![],
+            auth_source: AuthSource::AtlasCloud,
         }
     }
 }

--- a/crates/trusty-agents/src/llm/adapter/mod.rs
+++ b/crates/trusty-agents/src/llm/adapter/mod.rs
@@ -59,6 +59,9 @@ pub enum AuthSource {
     /// `FireworksAdapter` (#2410 epic #2400, Step 3). Resolved through the
     /// same shared 3-tier resolver every other keyed provider uses.
     Fireworks,
+    /// `ATLASCLOUD_API_KEY` — direct `api.atlascloud.ai` access via
+    /// `AtlasCloudAdapter` (#3765). Same shared 3-tier resolver.
+    AtlasCloud,
 }
 
 impl std::fmt::Display for AuthSource {
@@ -69,6 +72,7 @@ impl std::fmt::Display for AuthSource {
             Self::OpenRouter => write!(f, "openrouter"),
             Self::Bedrock => write!(f, "aws-bedrock"),
             Self::Fireworks => write!(f, "fireworks-api-key"),
+            Self::AtlasCloud => write!(f, "atlascloud-api-key"),
         }
     }
 }
@@ -112,6 +116,10 @@ pub enum Provider {
     /// URL and credential. Activated when the model string starts with
     /// `fireworks/` (#2410, epic #2400, Step 3).
     Fireworks,
+    /// Direct `api.atlascloud.ai` — OpenAI-compatible wire format, own base
+    /// URL and credential. Activated when the model string starts with
+    /// `atlascloud/` (#3765).
+    AtlasCloud,
 }
 
 /// Centralizes all model-provider-specific behavior for the chat loop.
@@ -178,6 +186,41 @@ pub trait ModelAdapter: Send + Sync + std::fmt::Debug {
     fn uses_native_format(&self) -> bool {
         false
     }
+
+    /// The model id to put on THIS provider's wire, given the dispatch slug.
+    ///
+    /// Why: a routing marker (`ollama/`, `fireworks/`, `atlascloud/`) exists
+    /// only to select an adapter here — the provider itself has never heard of
+    /// it and answers 400 if it arrives in the request body. `tool_loop`
+    /// carried a hardcoded `strip_prefix("ollama/").or(strip_prefix("fireworks/"))`
+    /// chain that every new prefixed provider had to remember to extend; #3765
+    /// moves the rule onto the adapter that owns the prefix, so a provider
+    /// added later cannot forget it. Mirrors
+    /// [`trusty_common::inference::registry::ProviderId::wire_model_id`].
+    /// What: default is identity (the slug IS the wire id — true for
+    /// OpenRouter the aggregator, and for the bare-slug heuristic adapters);
+    /// prefixed adapters override to strip their own marker.
+    /// Test: `wire_model_id_strips_routing_prefixes`.
+    fn wire_model_id<'a>(&self, model: &'a str) -> &'a str {
+        model
+    }
+
+    /// Whether requests for this adapter MUST take the raw-HTTP path rather
+    /// than the shared `async-openai` client.
+    ///
+    /// Why: `llm::helpers::create_client` builds one `async-openai` client
+    /// hardwired to OpenRouter's base URL. Any adapter with its OWN base URL
+    /// is silently ignored by that client — the request goes to OpenRouter
+    /// with a provider-native model id and fails. `tool_loop` previously
+    /// tracked this as two ad-hoc `is_ollama`/`is_fireworks` booleans; making
+    /// it an adapter property means "own endpoint ⇒ own transport" holds by
+    /// construction for AtlasCloud (#3765) and anything added after it.
+    /// What: default `false`; `true` for every adapter whose `api_endpoint`
+    /// does not resolve to OpenRouter.
+    /// Test: `requires_raw_http_for_own_endpoint_adapters`.
+    fn requires_raw_http(&self) -> bool {
+        false
+    }
 }
 
 /// Base URL of the local ollama server.
@@ -226,11 +269,20 @@ pub fn openrouter_endpoint() -> ApiEndpoint {
 /// `vendor/model` or loose `claude-...`/`gpt-...`) keeps callers from
 /// knowing the concrete adapter types.
 /// What: Heuristic substring match — Anthropic first (most common), then
-/// OpenAI / o-series, else `GenericAdapter` as a safe default. `bedrock/`,
-/// `ollama/`, and `fireworks/` prefixes are checked first and always win
-/// regardless of what the remainder of the model id looks like.
+/// OpenAI / o-series, else `GenericAdapter` as a safe default. The explicit
+/// routing prefixes (`bedrock/`, `ollama/`, `fireworks/`, `atlascloud/`) are
+/// checked first and always win regardless of what the remainder of the model
+/// id looks like.
+///
+/// This prefix-beats-heuristic ordering is also the MECHANISM by which a
+/// per-agent provider pin takes precedence over slug inference (#3765): the
+/// loader rewrites `[agent].model` through
+/// [`crate::llm::provider_pin::pinned_model_slug`] so the pinned provider's
+/// marker leads the slug, and this factory then resolves it deterministically
+/// — no second argument, and no call site that re-derives an adapter from
+/// `cfg.agent.model` can disagree with the pin.
 /// Test: `adapter_for_model_routes_anthropic`, `adapter_for_model_routes_openai`,
-/// `adapter_for_model_routes_fireworks`.
+/// `adapter_for_model_routes_fireworks`, `adapter_for_model_routes_atlascloud`.
 pub fn adapter_for_model(model: &str) -> Box<dyn ModelAdapter> {
     // Bedrock prefix takes precedence — the model id after `bedrock/` may
     // contain `anthropic` (e.g. `bedrock/anthropic.claude-3-5-haiku-...`),
@@ -256,6 +308,16 @@ pub fn adapter_for_model(model: &str) -> Box<dyn ModelAdapter> {
             .unwrap_or(model)
             .to_string();
         return Box::new(FireworksAdapter { model_id: id });
+    }
+    // AtlasCloud prefix (#3765) — must be checked BEFORE the substring
+    // heuristics: AtlasCloud's own catalog ids are vendor-namespaced
+    // (`openai/gpt-5.6-sol`), so `atlascloud/openai/...` would otherwise match
+    // the `openai` heuristic and route to OpenRouter with an id AtlasCloud
+    // owns and OpenRouter does not.
+    if let Some(id) = model.strip_prefix("atlascloud/") {
+        return Box::new(AtlasCloudAdapter {
+            model_id: id.to_string(),
+        });
     }
     let m = model.to_ascii_lowercase();
     if m.contains("claude") || m.contains("anthropic") {
@@ -337,5 +399,33 @@ pub struct BedrockAdapter {
 pub struct FireworksAdapter {
     /// The provider-native Fireworks model id (everything after the
     /// `fireworks/` routing prefix).
+    pub model_id: String,
+}
+
+/// Direct AtlasCloud adapter (OpenAI-compatible endpoint, own credential).
+///
+/// Why: #3765 — AtlasCloud has been fully seeded in
+/// `trusty_common::inference::registry` since #2536 (base URL, credential
+/// name, default model, capabilities), but `adapter_for_model` had no branch
+/// for it, so an `atlascloud/*` slug fell through to `GenericAdapter` and its
+/// unconditional OpenRouter endpoint — carrying an AtlasCloud catalog id that
+/// OpenRouter does not serve. Exactly the `fireworks/` gap #2410 closed, one
+/// provider over. Modeled on [`FireworksAdapter`] because AtlasCloud is the
+/// same shape: OpenAI-compatible `/chat/completions`, own base URL, own key.
+/// What: activated by `adapter_for_model("atlascloud/<model>")`; the prefix is
+/// stripped for the wire (AtlasCloud's real ids are vendor-namespaced, e.g.
+/// `openai/gpt-5.6-sol`). Tool-choice/usage shapes match `OpenAiAdapter`; no
+/// prompt caching and no detailed-usage directive, matching this provider's
+/// registry seed (`prompt_caching = false`,
+/// `detailed_usage_accounting = false`).
+/// Test: `adapter_for_model_routes_atlascloud`, `atlascloud_adapter_strips_prefix`,
+/// `atlascloud_tool_choice_shapes`, `atlascloud_parse_usage_shape`,
+/// `atlascloud_inject_cache_control_is_noop`,
+/// `atlascloud_api_endpoint_resolves_key_from_store_when_env_absent`,
+/// `atlascloud_api_endpoint_base_url_override`.
+#[derive(Debug)]
+pub struct AtlasCloudAdapter {
+    /// The provider-native AtlasCloud model id (everything after the
+    /// `atlascloud/` routing prefix).
     pub model_id: String,
 }

--- a/crates/trusty-agents/src/llm/adapter/tests.rs
+++ b/crates/trusty-agents/src/llm/adapter/tests.rs
@@ -924,3 +924,196 @@ fn ollama_adapter_endpoint_uses_shared_host() {
     );
     assert!(ep.base_url.ends_with("/v1"), "got {}", ep.base_url);
 }
+
+// ── AtlasCloud (#3765) ───────────────────────────────────────────────────────
+//
+// AtlasCloud is the `fireworks/` gap one provider over: fully seeded in
+// `trusty_common::inference::registry` since #2536, but with no branch in
+// `adapter_for_model`, so an `atlascloud/*` slug reached `GenericAdapter` and
+// OpenRouter's endpoint carrying a model id OpenRouter does not serve. These
+// tests mirror the Fireworks set exactly.
+
+/// Why: the routing branch is the whole fix. Before #3765 this returned
+/// `Provider::OpenAI` — the `openai` substring in AtlasCloud's own catalog id
+/// (`atlascloud/openai/gpt-5.6-sol`) matched the heuristic — which is why the
+/// prefix check must sit ahead of the heuristics, not after them.
+/// Test: itself.
+#[test]
+fn adapter_for_model_routes_atlascloud() {
+    let a = adapter_for_model("atlascloud/openai/gpt-5.6-sol");
+    assert_eq!(a.provider(), Provider::AtlasCloud);
+}
+
+#[test]
+fn atlascloud_adapter_strips_prefix() {
+    let a = AtlasCloudAdapter {
+        model_id: "openai/gpt-5.6-sol".to_string(),
+    };
+    assert_eq!(a.model_id, "openai/gpt-5.6-sol");
+    assert_eq!(
+        a.wire_model_id("atlascloud/openai/gpt-5.6-sol"),
+        "openai/gpt-5.6-sol"
+    );
+}
+
+#[test]
+fn atlascloud_tool_choice_shapes() {
+    let a = AtlasCloudAdapter {
+        model_id: "x".to_string(),
+    };
+    assert_eq!(a.tool_choice_any(), Some(json!("required")));
+    assert_eq!(a.tool_choice_auto(), Some(json!("auto")));
+}
+
+#[test]
+fn atlascloud_inject_cache_control_is_noop() {
+    let a = AtlasCloudAdapter {
+        model_id: "x".to_string(),
+    };
+    let mut body = json!({"system": "hello", "messages": []});
+    let before = body.clone();
+    a.inject_cache_control(&mut body, true);
+    assert_eq!(body, before);
+}
+
+#[test]
+fn atlascloud_parse_usage_shape() {
+    let a = AtlasCloudAdapter {
+        model_id: "x".to_string(),
+    };
+    let resp = json!({"usage": {"prompt_tokens": 11, "completion_tokens": 5}});
+    let usage = a.parse_usage(&resp);
+    assert_eq!(usage.prompt_tokens, 11);
+    assert_eq!(usage.completion_tokens, 5);
+}
+
+#[test]
+fn atlascloud_api_endpoint_resolves_key_from_store_when_env_absent() {
+    let _g = ENDPOINT_ENV_LOCK.lock().unwrap();
+    crate::test_env::force_env_local_loaded();
+    let _env_guard = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _home_guard = crate::test_env::HOME_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
+    let prev_key = std::env::var_os("ATLASCLOUD_API_KEY");
+    let prev_home = std::env::var_os("HOME");
+    // SAFETY: ENDPOINT_ENV_LOCK + ENV_LOCK + HOME_LOCK held for the whole body.
+    unsafe {
+        std::env::remove_var("ATLASCLOUD_API_KEY");
+    }
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    unsafe {
+        std::env::set_var("HOME", tmp.path());
+    }
+    let store = trusty_common::credentials::FileKeyStore::at(tmp.path());
+    trusty_common::credentials::KeyStore::set(
+        &store,
+        "atlascloud",
+        "ac-FAKE-store-value", // pragma: allowlist secret
+    )
+    .expect("seed store");
+
+    let ep = AtlasCloudAdapter {
+        model_id: "openai/gpt-5.6-sol".to_string(),
+    }
+    .api_endpoint(false);
+    assert_eq!(ep.auth_source, AuthSource::AtlasCloud);
+    assert!(ep.base_url.contains("atlascloud.ai"), "{}", ep.base_url);
+    assert_eq!(
+        ep.auth_header_value, "Bearer ac-FAKE-store-value",
+        "a store-only atlascloud key must reach the built ApiEndpoint"
+    );
+
+    // SAFETY: locks still held.
+    unsafe {
+        match prev_key {
+            Some(v) => std::env::set_var("ATLASCLOUD_API_KEY", v),
+            None => std::env::remove_var("ATLASCLOUD_API_KEY"),
+        }
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+}
+
+#[test]
+fn atlascloud_api_endpoint_base_url_override() {
+    with_env(
+        &[
+            ("ATLASCLOUD_API_KEY", Some("ac-test")),
+            ("ATLASCLOUD_BASE_URL", Some("http://127.0.0.1:1/v1")),
+        ],
+        || {
+            let ep = AtlasCloudAdapter {
+                model_id: "x".to_string(),
+            }
+            .api_endpoint(false);
+            assert_eq!(ep.base_url, "http://127.0.0.1:1/v1");
+            assert_eq!(ep.auth_header_value, "Bearer ac-test");
+        },
+    );
+}
+
+/// Why: `tool_loop` used to carry a hardcoded `strip_prefix("ollama/")
+/// .or(strip_prefix("fireworks/"))` chain that a new provider had to remember
+/// to extend. Moving it onto the adapter means the rule travels with the
+/// prefix; this test is what makes that claim checkable.
+/// Test: itself.
+#[test]
+fn wire_model_id_strips_routing_prefixes() {
+    assert_eq!(
+        adapter_for_model("ollama/qwen3:8b").wire_model_id("ollama/qwen3:8b"),
+        "qwen3:8b"
+    );
+    assert_eq!(
+        adapter_for_model("fireworks/accounts/fireworks/models/x")
+            .wire_model_id("fireworks/accounts/fireworks/models/x"),
+        "accounts/fireworks/models/x"
+    );
+    assert_eq!(
+        adapter_for_model("atlascloud/openai/gpt-5.6-sol")
+            .wire_model_id("atlascloud/openai/gpt-5.6-sol"),
+        "openai/gpt-5.6-sol"
+    );
+    // Aggregator and heuristic adapters pass the slug through untouched — an
+    // OpenRouter wire id IS the full `vendor/model` slug.
+    assert_eq!(
+        adapter_for_model("anthropic/claude-sonnet-4-6")
+            .wire_model_id("anthropic/claude-sonnet-4-6"),
+        "anthropic/claude-sonnet-4-6"
+    );
+}
+
+/// Why: an adapter with its own base URL that does NOT force the raw HTTP path
+/// is silently routed to OpenRouter by the shared `async-openai` client — the
+/// exact failure mode #2410 fixed for Fireworks. Asserting the property here
+/// keeps it from regressing for AtlasCloud.
+/// Test: itself.
+#[test]
+fn requires_raw_http_for_own_endpoint_adapters() {
+    for model in [
+        "ollama/qwen3:8b",
+        "fireworks/accounts/fireworks/models/x",
+        "atlascloud/openai/gpt-5.6-sol",
+    ] {
+        assert!(
+            adapter_for_model(model).requires_raw_http(),
+            "{model} has its own base URL and must force the raw path"
+        );
+    }
+    for model in [
+        "anthropic/claude-sonnet-4-6",
+        "openai/gpt-4o-mini",
+        "some-model",
+    ] {
+        assert!(
+            !adapter_for_model(model).requires_raw_http(),
+            "{model} routes through OpenRouter's client"
+        );
+    }
+}

--- a/crates/trusty-agents/src/llm/http/mod.rs
+++ b/crates/trusty-agents/src/llm/http/mod.rs
@@ -303,6 +303,10 @@ fn strip_service_tier(mut json: serde_json::Value) -> serde_json::Value {
 fn credential_hint(auth_source: &adapter::AuthSource) -> (&'static str, &'static str) {
     match auth_source {
         adapter::AuthSource::Fireworks => ("fireworks", "FIREWORKS_API_KEY"),
+        // #3765: same reasoning as Fireworks above — an AtlasCloud-routed call
+        // with no key must not report "openrouter credential not found",
+        // which names the wrong provider AND the wrong env var.
+        adapter::AuthSource::AtlasCloud => ("atlascloud", "ATLASCLOUD_API_KEY"),
         _ => ("openrouter", "OPENROUTER_API_KEY"),
     }
 }

--- a/crates/trusty-agents/src/llm/http/tests.rs
+++ b/crates/trusty-agents/src/llm/http/tests.rs
@@ -575,3 +575,163 @@ fn transport_error_rejects_non_http_error() {
     let err = anyhow::anyhow!("model returned malformed tool call");
     assert!(!super::is_transport_error(&err));
 }
+
+// ── AtlasCloud (#3765) ───────────────────────────────────────────────────────
+
+/// Why: the AtlasCloud counterpart of
+/// `send_raw_completion_fireworks_missing_key_errors_with_fireworks_name`. A
+/// keyless AtlasCloud call previously reported "openrouter credential not
+/// found" — the wrong provider, the wrong env var, and the wrong config
+/// command — because `credential_hint` had no arm for it.
+/// Test: itself.
+#[test]
+fn send_raw_completion_atlascloud_missing_key_errors_with_atlascloud_name() {
+    let _env_guard = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _home_guard = crate::test_env::lock_home();
+    crate::test_env::force_env_local_loaded();
+    let prev_key = std::env::var_os("ATLASCLOUD_API_KEY");
+    let prev_home = std::env::var_os("HOME");
+    // SAFETY: ENV_LOCK + HOME_LOCK held for the whole test body.
+    unsafe {
+        std::env::remove_var("ATLASCLOUD_API_KEY");
+    }
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    unsafe {
+        std::env::set_var("HOME", tmp.path());
+    }
+    // No store seeded — every tier is absent.
+
+    let adapter = crate::llm::adapter::AtlasCloudAdapter {
+        model_id: "openai/gpt-5.6-sol".to_string(),
+    };
+    let body = serde_json::json!({"model": "openai/gpt-5.6-sol", "messages": []});
+    let err = block_on(send_raw_completion(&body, &adapter))
+        .expect_err("no atlascloud credential anywhere must error, not send an empty key");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("atlascloud") && msg.contains("credential not found"),
+        "error must name atlascloud, not openrouter: {msg}"
+    );
+    assert!(
+        msg.contains("ATLASCLOUD_API_KEY"),
+        "error must hint the correct env var: {msg}"
+    );
+
+    // SAFETY: still holding ENV_LOCK + HOME_LOCK.
+    unsafe {
+        match prev_key {
+            Some(v) => std::env::set_var("ATLASCLOUD_API_KEY", v),
+            None => std::env::remove_var("ATLASCLOUD_API_KEY"),
+        }
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+}
+
+/// Live smoke test: one real completion through the AtlasCloud adapter.
+///
+/// Why: every other AtlasCloud assertion in this PR is offline — they prove
+/// the routing, not that `api.atlascloud.ai` actually accepts the body
+/// `send_raw_completion` builds. The OpenAI-compatible shape is INFERRED from
+/// the registry seed and `providers::atlascloud`; this is what turns that
+/// inference into an observation.
+/// What: resolves the credential through the normal 3-tier resolver (never a
+/// hardcoded key) and SKIPS — does not fail — when it is absent, so CI, which
+/// has no AtlasCloud key, stays green. `#[ignore]` for the same reason the
+/// ONNX embedder tests are ignored: it needs an environment CI does not have.
+///
+/// The model comes from `ATLASCLOUD_TEST_MODEL` when set, else the registry
+/// seed default. The override exists because AtlasCloud scopes its catalog by
+/// ACCOUNT PLAN, not just by key validity: a Coding-Plan key answers
+/// `403 {"msg":"invalid token for coding plan, this model not support coding
+/// plan"}` for catalog ids it can see but not call, including the seeded
+/// default. That is a property of the account, not of this adapter, so the
+/// test lets the operator name a model their key can actually reach rather
+/// than pinning the registry seed to one plan's subset.
+/// Run it with:
+/// `cargo test -p trusty-agents --lib atlascloud_live -- --ignored --nocapture`
+/// Test: itself.
+#[test]
+#[ignore = "requires ATLASCLOUD_API_KEY; skipped in CI"]
+fn atlascloud_live_completion_round_trips() {
+    crate::test_env::force_env_local_loaded();
+    if trusty_common::credentials::resolve_key("atlascloud").is_none() {
+        eprintln!("ATLASCLOUD_API_KEY not resolvable — skipping live test");
+        return;
+    }
+    let model = std::env::var("ATLASCLOUD_TEST_MODEL").unwrap_or_else(|_| {
+        trusty_common::inference::registry::capabilities_for("atlascloud")
+            .expect("seeded")
+            .default_model
+            .to_string()
+    });
+    let slug = format!("atlascloud/{model}");
+    let adapter = crate::llm::adapter::adapter_for_model(&slug);
+    assert_eq!(
+        adapter.provider(),
+        crate::llm::adapter::Provider::AtlasCloud
+    );
+    assert_eq!(adapter.wire_model_id(&slug), model);
+    let body = serde_json::json!({
+        "model": adapter.wire_model_id(&slug),
+        "messages": [
+            {"role": "system", "content": "You are a concise assistant."},
+            {"role": "user", "content": "Reply with exactly the word: pong"}
+        ],
+        "max_tokens": 256,
+        "temperature": 0.0,
+    });
+    let (text, _tool_calls, usage) =
+        block_on(send_raw_completion(&body, &*adapter)).expect("live atlascloud completion");
+    assert!(
+        usage.prompt_tokens > 0 && usage.completion_tokens > 0,
+        "usage must parse from the OpenAI-compatible shape: {usage:?}"
+    );
+    eprintln!("live atlascloud ok — model={model} text={text:?} usage={usage:?}");
+}
+
+/// Live control for `atlascloud_live_completion_round_trips`.
+///
+/// Why: Fireworks reached its own endpoint before this PR, so if #3765's
+/// `wire_model_id`/`requires_raw_http` refactor broke the prefix-stripping it
+/// generalised, THIS is where it shows — an unchanged provider failing is a
+/// regression, not a new-provider unknown.
+/// What: same credential-gated skip and `#[ignore]` policy as above.
+/// Test: itself.
+#[test]
+#[ignore = "requires FIREWORKS_API_KEY; skipped in CI"]
+fn fireworks_live_completion_still_round_trips() {
+    crate::test_env::force_env_local_loaded();
+    if trusty_common::credentials::resolve_key("fireworks").is_none() {
+        eprintln!("FIREWORKS_API_KEY not resolvable — skipping live test");
+        return;
+    }
+    // Overridable for the same reason as the AtlasCloud test above, and with
+    // an additional one: Fireworks RETIRES model ids (the long-standing
+    // `llama-v3p1-8b-instruct` fixture now answers 404), so a hardcoded slug
+    // rots into a false failure.
+    let model = std::env::var("FIREWORKS_TEST_MODEL")
+        .unwrap_or_else(|_| "accounts/fireworks/models/gpt-oss-20b".to_string());
+    let slug = format!("fireworks/{model}");
+    let slug = slug.as_str();
+    let adapter = crate::llm::adapter::adapter_for_model(slug);
+    let body = serde_json::json!({
+        "model": adapter.wire_model_id(slug),
+        "messages": [
+            {"role": "system", "content": "You are a concise assistant."},
+            {"role": "user", "content": "Reply with exactly the word: pong"}
+        ],
+        "max_tokens": 64,
+        "temperature": 0.0,
+    });
+    let (text, _tool_calls, usage) =
+        block_on(send_raw_completion(&body, &*adapter)).expect("live fireworks completion");
+    let text = text.expect("assistant text");
+    assert!(!text.trim().is_empty());
+    assert!(usage.prompt_tokens > 0, "{usage:?}");
+    eprintln!("live fireworks ok — model={model} text={text:?} usage={usage:?}");
+}

--- a/crates/trusty-agents/src/llm/mod.rs
+++ b/crates/trusty-agents/src/llm/mod.rs
@@ -26,6 +26,7 @@ mod helpers;
 mod http;
 pub mod inference_bridge;
 pub mod inference_client;
+pub mod provider_pin;
 mod single_turn;
 pub mod stream;
 pub mod thinking_classifier;

--- a/crates/trusty-agents/src/llm/provider_pin.rs
+++ b/crates/trusty-agents/src/llm/provider_pin.rs
@@ -1,0 +1,511 @@
+//! Per-agent inference-provider pinning (#3765).
+//!
+//! Why: `[agent].provider_id` has been accepted and persisted by
+//! `PATCH /api/agents/:name` since #3243, but nothing in the dispatch path
+//! ever read it — the loader ignored the key and
+//! `llm::credentials::pick_credentials` re-probed the ambient environment on
+//! every turn. Setting a provider therefore looked like it worked and silently
+//! did nothing, and an agent meant for one provider quietly ran on whatever
+//! credential happened to exist. This module turns that inert key into a real,
+//! enforced routing decision.
+//! What: [`resolve`] validates a declared pin (known provider → dispatchable
+//! provider → credential present) and FAILS CLOSED on each step;
+//! [`pinned_model_slug`] rewrites the agent's model slug so it carries the
+//! pinned provider's routing marker, which is the mechanism
+//! [`crate::llm::adapter::adapter_for_model`] already uses to select an
+//! adapter. Encoding the pin in the slug (rather than threading a second
+//! argument through a dozen call sites) means every place that re-derives an
+//! adapter from `cfg.agent.model` agrees with the pin by construction.
+//! Test: `tests` below — one case per normalisation rule and one per
+//! fail-closed branch.
+
+use trusty_common::inference::registry::{self, ProviderId};
+
+/// Why a declared `[agent].provider_id` could not be honoured.
+///
+/// Why: #3765's requirement is that a pin whose provider is unusable produces
+/// "a clear, actionable error naming the provider and the env var it needs —
+/// NOT a silent fallback to whatever ambient credential happens to exist".
+/// Each variant names the offending value and what would fix it.
+/// What: three fail-closed branches — unknown name, known-but-undispatchable
+/// provider, and known-and-dispatchable but no credential. Never a warning:
+/// every variant aborts the agent load.
+/// Test: `unknown_provider_is_rejected`, `unpinnable_provider_is_rejected`,
+/// `missing_credential_fails_closed_and_names_the_env_var`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ProviderPinError {
+    /// The string is not any provider in `trusty_common::inference::registry`.
+    #[error(
+        "agent '{agent}': [agent].provider_id = '{value}' is not a known provider \
+         (known: {known})"
+    )]
+    Unknown {
+        agent: String,
+        value: String,
+        known: String,
+    },
+
+    /// A real provider, but this build's chat dispatch cannot reach it — see
+    /// [`is_pinnable`].
+    #[error(
+        "agent '{agent}': [agent].provider_id = '{provider}' is a known provider but \
+         trusty-agents cannot dispatch to it yet, so pinning it would fail at the \
+         first turn (pinnable: {pinnable})"
+    )]
+    Unpinnable {
+        agent: String,
+        provider: &'static str,
+        pinnable: String,
+    },
+
+    /// Dispatchable, but no credential resolves through any tier.
+    #[error(
+        "agent '{agent}': [agent].provider_id = '{provider}' is pinned but no \
+         credential for it resolves. Set {env_var} in the environment or \
+         .env.local, or run `tagent config keys set {provider}`. The pin is \
+         honoured strictly — no other provider's credential is substituted."
+    )]
+    MissingCredential {
+        agent: String,
+        provider: &'static str,
+        env_var: &'static str,
+    },
+}
+
+/// Providers a pin may name, in the order [`is_pinnable`] documents them.
+///
+/// Why: pinning an agent to a provider the chat loop cannot reach is a
+/// guaranteed runtime failure dressed up as configuration. Rejecting it at
+/// load — with the reachable set spelled out — is the fail-closed reading of
+/// #3765, and it keeps this list and
+/// `crate::api::server::models::reachable_today` (what the GUI offers) from
+/// drifting apart: both describe the same property, "chat dispatch resolves a
+/// working adapter for this provider".
+/// What: the six providers `crate::llm::adapter::adapter_for_model` resolves
+/// to a provider-native endpoint. [`ProviderId::OpenAI`] and
+/// [`ProviderId::Together`] are deliberately absent — they still fall through
+/// to the OpenRouter endpoint carrying a bare, unroutable model id (#2410).
+const PINNABLE: [ProviderId; 6] = [
+    ProviderId::OpenRouter,
+    ProviderId::Anthropic,
+    ProviderId::Bedrock,
+    ProviderId::Fireworks,
+    ProviderId::AtlasCloud,
+    ProviderId::Local,
+];
+
+/// Whether `id` may be pinned — i.e. whether chat dispatch reaches it today.
+///
+/// Why: the single predicate both the loader and the `PATCH /api/agents/:name`
+/// write gate consult, so the API cannot persist a pin the loader will reject.
+/// What: membership in [`PINNABLE`].
+/// Test: `pinnable_set_matches_reachable_today`.
+pub fn is_pinnable(id: ProviderId) -> bool {
+    PINNABLE.contains(&id)
+}
+
+/// The `<marker>/` prefix `crate::llm::adapter::adapter_for_model` matches to
+/// select `id`'s adapter, or `None` when `id` has no marker.
+///
+/// Why: [`pinned_model_slug`] needs to know what to prepend, and the answer is
+/// not always `id.as_str()` — the local provider's marker is the historical
+/// `ollama/` (the only spelling `adapter_for_model` matches), and OpenRouter
+/// has no marker at all because it is an AGGREGATOR whose wire model id IS the
+/// full `vendor/model` slug (the same exemption
+/// [`ProviderId::wire_model_id`] documents).
+/// What: `None` for OpenRouter and for every non-pinnable provider; the
+/// literal prefix otherwise.
+/// Test: `routing_marker_covers_every_pinnable_provider`.
+fn routing_marker(id: ProviderId) -> Option<&'static str> {
+    match id {
+        ProviderId::Anthropic => Some("anthropic"),
+        ProviderId::Bedrock => Some("bedrock"),
+        ProviderId::Fireworks => Some("fireworks"),
+        ProviderId::AtlasCloud => Some("atlascloud"),
+        ProviderId::Local => Some("ollama"),
+        // Aggregator (routes by the full slug) or not pinnable at all.
+        ProviderId::OpenRouter | ProviderId::OpenAI | ProviderId::Together => None,
+    }
+}
+
+/// Whether a slug marker naming `id` would steer `adapter_for_model` AWAY from
+/// the OpenRouter endpoint.
+///
+/// Why: when a pin replaces a slug's existing marker, only a marker that
+/// actually changes routing may be stripped. `anthropic/…` and `openai/…` are
+/// ALSO legitimate OpenRouter vendor namespaces (`anthropic/claude-sonnet-4-6`
+/// is the correct OpenRouter id), so stripping them when pinning to OpenRouter
+/// would corrupt a working slug. `bedrock/…`, `fireworks/…`, `ollama/…` and
+/// `atlascloud/…` have no such double meaning — each is a hard routing branch.
+/// What: `true` for exactly the four providers with a prefix branch in
+/// `adapter_for_model`.
+/// Test: `openrouter_pin_strips_a_hard_routing_marker`,
+/// `openrouter_pin_keeps_a_vendor_namespace`.
+fn has_routing_branch(id: ProviderId) -> bool {
+    matches!(
+        id,
+        ProviderId::Bedrock | ProviderId::Fireworks | ProviderId::AtlasCloud | ProviderId::Local
+    )
+}
+
+/// Resolve `provider_id` as declared on `agent`, failing closed at every step.
+///
+/// Why: this is the whole point of #3765. A pin is an operator's explicit
+/// statement about where an agent's turns go; honouring it partially — or
+/// falling back to an ambient credential when it cannot be honoured — is the
+/// defect being fixed.
+/// What: `None`/blank yields `Ok(None)` and the caller keeps today's ambient
+/// behaviour untouched. Otherwise the value must (1) name a registry provider,
+/// (2) be [`is_pinnable`], and (3) have a credential resolving through the
+/// shared 3-tier resolver (process env > `.env.local` > secure store). Only the
+/// PRESENCE of the credential is probed; the value is dropped immediately and
+/// never logged. [`ProviderId::Bedrock`] and [`ProviderId::Local`] have no
+/// resolver-managed key (`credential_name()` is `None` — AWS chain and an
+/// unauthenticated localhost endpoint respectively), so step 3 is skipped for
+/// them; a broken AWS chain still surfaces at the first turn, not here.
+/// Test: `absent_pin_is_none`, `blank_pin_is_none`, `unknown_provider_is_rejected`,
+/// `unpinnable_provider_is_rejected`,
+/// `missing_credential_fails_closed_and_names_the_env_var`,
+/// `keyless_providers_resolve_without_a_credential`.
+pub fn resolve(
+    agent: &str,
+    provider_id: Option<&str>,
+) -> Result<Option<ProviderId>, ProviderPinError> {
+    let Some(raw) = provider_id.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+
+    let Some(caps) = registry::capabilities_for(raw) else {
+        return Err(ProviderPinError::Unknown {
+            agent: agent.to_string(),
+            value: raw.to_string(),
+            known: registry::all()
+                .iter()
+                .map(|c| c.id.as_str())
+                .collect::<Vec<_>>()
+                .join(", "),
+        });
+    };
+
+    if !is_pinnable(caps.id) {
+        return Err(ProviderPinError::Unpinnable {
+            agent: agent.to_string(),
+            provider: caps.id.as_str(),
+            pinnable: PINNABLE
+                .iter()
+                .map(|p| p.as_str())
+                .collect::<Vec<_>>()
+                .join(", "),
+        });
+    }
+
+    if let Some(name) = caps.id.credential_name()
+        && trusty_common::credentials::resolve_key(name).is_none()
+    {
+        return Err(ProviderPinError::MissingCredential {
+            agent: agent.to_string(),
+            provider: caps.id.as_str(),
+            env_var: caps.credential_env.unwrap_or("its API key"),
+        });
+    }
+
+    Ok(Some(caps.id))
+}
+
+/// Rewrite `model` so it carries `pin`'s routing marker — the slug form
+/// `adapter_for_model` selects an adapter from.
+///
+/// Why: the pin must WIN over slug inference. Today the model slug implicitly
+/// carries provider information (`bedrock/…` beats everything, then substring
+/// heuristics on `claude`/`gpt`), and a dozen call sites re-derive the adapter
+/// from `cfg.agent.model`. Normalising the slug once, at load, makes the pin
+/// the thing every one of those sites reads — instead of leaving the pin and
+/// the slug as two competing sources of truth.
+/// What: the precedence rule, in order:
+///
+/// | `model` | `pin` | result |
+/// |---|---|---|
+/// | `claude-sonnet-4-6` | anthropic | `anthropic/claude-sonnet-4-6` |
+/// | `openai/gpt-5.6-sol` | atlascloud | `atlascloud/openai/gpt-5.6-sol` |
+/// | `atlascloud/openai/gpt-5.6-sol` | atlascloud | unchanged |
+/// | `local/qwen3:8b` | local | `ollama/qwen3:8b` (the marker `adapter_for_model` matches) |
+/// | `bedrock/anthropic.claude-3-5` | openrouter | `anthropic.claude-3-5` (hard marker stripped) |
+/// | `anthropic/claude-sonnet-4-6` | openrouter | unchanged (vendor namespace, not a routing marker) |
+///
+/// A marker naming a DIFFERENT provider is removed only when it is a hard
+/// routing branch ([`has_routing_branch`]); a vendor namespace that OpenRouter
+/// itself routes by survives. The result is idempotent: applying it twice
+/// changes nothing.
+/// Test: `pin_prefixes_a_bare_slug`, `pin_beats_a_conflicting_slug_prefix`,
+/// `pin_is_idempotent`, `local_pin_normalises_to_the_ollama_marker`,
+/// `openrouter_pin_strips_a_hard_routing_marker`,
+/// `openrouter_pin_keeps_a_vendor_namespace`.
+pub fn pinned_model_slug(pin: ProviderId, model: &str) -> String {
+    let marker = routing_marker(pin);
+
+    // Already carries THIS provider's exact marker → nothing to do.
+    if let Some(m) = marker
+        && let Some((head, _)) = model.split_once('/')
+        && head.eq_ignore_ascii_case(m)
+    {
+        return model.to_string();
+    }
+
+    // Drop the existing marker only when it would hard-route. The
+    // exact-marker case already returned above, so anything reaching here is
+    // either a different provider or a different SPELLING of this one
+    // (`local/` vs the `ollama/` marker `adapter_for_model` matches) — both
+    // must be replaced.
+    let rest = match ProviderId::from_slug_prefix(model) {
+        Some(other) if has_routing_branch(other) => {
+            model.split_once('/').map_or(model, |(_, rest)| rest)
+        }
+        _ => model,
+    };
+
+    match marker {
+        Some(m) => format!("{m}/{rest}"),
+        None => rest.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    /// Why: an agent with no pin must take the exact path it takes today —
+    /// #3765 is explicit that unpinned agents must not regress.
+    /// Test: itself.
+    #[test]
+    fn absent_pin_is_none() {
+        assert_eq!(resolve("a", None), Ok(None));
+    }
+
+    /// Why: `provider_id = ""` is what a GUI clear-the-field write leaves
+    /// behind; it must read as "unpinned", not as an unknown provider.
+    /// Test: itself.
+    #[test]
+    fn blank_pin_is_none() {
+        assert_eq!(resolve("a", Some("   ")), Ok(None));
+    }
+
+    /// Why: a typo'd provider must be a loud error, never a silent fallback.
+    /// Test: itself.
+    #[test]
+    fn unknown_provider_is_rejected() {
+        let err = resolve("izzie", Some("atlas-cloud")).expect_err("must reject");
+        assert!(matches!(err, ProviderPinError::Unknown { .. }));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("izzie") && msg.contains("atlas-cloud"),
+            "{msg}"
+        );
+        assert!(msg.contains("atlascloud"), "must list the known set: {msg}");
+    }
+
+    /// Why: `openai`/`together` are real registry providers whose dispatch
+    /// still falls through to OpenRouter with an unroutable bare slug. Pinning
+    /// one would fail at the first turn, so it is refused at load with the
+    /// usable set named.
+    /// Test: itself.
+    #[test]
+    fn unpinnable_provider_is_rejected() {
+        for provider in ["openai", "together"] {
+            let err = resolve("a", Some(provider)).expect_err("must reject");
+            assert!(
+                matches!(err, ProviderPinError::Unpinnable { .. }),
+                "{provider}: {err:?}"
+            );
+            assert!(err.to_string().contains("atlascloud"), "{err}");
+        }
+    }
+
+    /// Why: THE core fail-closed guarantee. A pinned provider with no
+    /// resolvable credential must name the provider AND the env var that would
+    /// fix it, and must never silently borrow another provider's key.
+    /// What: sandboxes `$HOME` (so the secure store is a tempdir, never the
+    /// real one) and clears every credential env var, mirroring
+    /// `llm::credentials`' own store-sandboxing tests.
+    /// Test: itself.
+    #[test]
+    #[serial]
+    fn missing_credential_fails_closed_and_names_the_env_var() {
+        let _env = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _home = crate::test_env::HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        crate::test_env::force_env_local_loaded();
+        crate::test_env::clear_all_credential_env_vars();
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let prev_home = std::env::var_os("HOME");
+        // SAFETY: HOME_LOCK held for the entire test body.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+
+        let err = resolve("izzie", Some("atlascloud")).expect_err("must fail closed");
+        let msg = err.to_string();
+
+        // SAFETY: HOME_LOCK still held.
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        assert!(
+            matches!(err, ProviderPinError::MissingCredential { .. }),
+            "{err:?}"
+        );
+        assert!(msg.contains("atlascloud"), "must name the provider: {msg}");
+        assert!(
+            msg.contains("ATLASCLOUD_API_KEY"),
+            "must name the env var: {msg}"
+        );
+        assert!(
+            msg.contains("tagent config keys set"),
+            "must name the store tier: {msg}"
+        );
+    }
+
+    /// Why: Bedrock authenticates via the AWS chain and Local is an
+    /// unauthenticated localhost endpoint — neither has a resolver-managed key,
+    /// so demanding one would make them unpinnable in practice.
+    /// Test: itself.
+    #[test]
+    #[serial]
+    fn keyless_providers_resolve_without_a_credential() {
+        let _env = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        crate::test_env::force_env_local_loaded();
+        crate::test_env::clear_all_credential_env_vars();
+        assert_eq!(resolve("a", Some("bedrock")), Ok(Some(ProviderId::Bedrock)));
+        assert_eq!(resolve("a", Some("local")), Ok(Some(ProviderId::Local)));
+    }
+
+    /// Why: every pinnable provider must have a defined marker policy —
+    /// a `None` that is an oversight rather than the documented aggregator
+    /// exemption would silently drop the pin.
+    /// Test: itself.
+    #[test]
+    fn routing_marker_covers_every_pinnable_provider() {
+        for id in PINNABLE {
+            match id {
+                ProviderId::OpenRouter => assert_eq!(routing_marker(id), None),
+                other => assert!(routing_marker(other).is_some(), "{other} has no marker"),
+            }
+        }
+    }
+
+    /// Why: the pinnable set and `models::reachable_today` describe the same
+    /// property; if they drift, the GUI offers a provider the loader refuses.
+    /// Test: itself.
+    #[test]
+    fn pinnable_set_matches_reachable_today() {
+        for caps in registry::all() {
+            assert_eq!(
+                is_pinnable(caps.id),
+                crate::api::server::reachable_today(caps.id),
+                "{} disagrees between PINNABLE and reachable_today",
+                caps.id
+            );
+        }
+    }
+
+    #[test]
+    fn pin_prefixes_a_bare_slug() {
+        assert_eq!(
+            pinned_model_slug(ProviderId::AtlasCloud, "openai/gpt-5.6-sol"),
+            "atlascloud/openai/gpt-5.6-sol"
+        );
+        assert_eq!(
+            pinned_model_slug(ProviderId::Anthropic, "claude-sonnet-4-6"),
+            "anthropic/claude-sonnet-4-6"
+        );
+        assert_eq!(
+            pinned_model_slug(ProviderId::Fireworks, "accounts/fireworks/models/x"),
+            "fireworks/accounts/fireworks/models/x"
+        );
+    }
+
+    /// Why: the pin must WIN over what the slug implies — that precedence is
+    /// the behavioural contract #3765 asks for.
+    /// Test: itself.
+    #[test]
+    fn pin_beats_a_conflicting_slug_prefix() {
+        assert_eq!(
+            pinned_model_slug(ProviderId::AtlasCloud, "bedrock/anthropic.claude-3-5"),
+            "atlascloud/anthropic.claude-3-5"
+        );
+        assert_eq!(
+            pinned_model_slug(ProviderId::Fireworks, "ollama/qwen3:8b"),
+            "fireworks/qwen3:8b"
+        );
+    }
+
+    #[test]
+    fn pin_is_idempotent() {
+        for (pin, slug) in [
+            (ProviderId::AtlasCloud, "openai/gpt-5.6-sol"),
+            (ProviderId::Anthropic, "claude-sonnet-4-6"),
+            (ProviderId::OpenRouter, "anthropic/claude-sonnet-4-6"),
+            (ProviderId::Local, "qwen3:8b"),
+        ] {
+            let once = pinned_model_slug(pin, slug);
+            assert_eq!(pinned_model_slug(pin, &once), once, "{pin} / {slug}");
+        }
+    }
+
+    /// Why: `ProviderId::from_slug_prefix` accepts `local/` AND `ollama/`, but
+    /// `adapter_for_model` matches only `ollama/` — a `local/` slug would fall
+    /// through to `GenericAdapter` (OpenRouter) and silently ignore the pin.
+    /// Test: itself.
+    #[test]
+    fn local_pin_normalises_to_the_ollama_marker() {
+        assert_eq!(
+            pinned_model_slug(ProviderId::Local, "local/qwen3:8b"),
+            "ollama/qwen3:8b"
+        );
+        assert_eq!(
+            pinned_model_slug(ProviderId::Local, "ollama/qwen3:8b"),
+            "ollama/qwen3:8b"
+        );
+    }
+
+    /// Why: pinning to the aggregator must actually pull a hard-routed slug
+    /// back to OpenRouter rather than leaving it pointing at Bedrock.
+    /// Test: itself.
+    #[test]
+    fn openrouter_pin_strips_a_hard_routing_marker() {
+        assert_eq!(
+            pinned_model_slug(ProviderId::OpenRouter, "bedrock/anthropic.claude-3-5"),
+            "anthropic.claude-3-5"
+        );
+        assert_eq!(
+            pinned_model_slug(
+                ProviderId::OpenRouter,
+                "fireworks/accounts/fireworks/models/x"
+            ),
+            "accounts/fireworks/models/x"
+        );
+    }
+
+    /// Why: `anthropic/claude-sonnet-4-6` IS OpenRouter's own model id —
+    /// stripping the vendor segment would corrupt a working slug.
+    /// Test: itself.
+    #[test]
+    fn openrouter_pin_keeps_a_vendor_namespace() {
+        assert_eq!(
+            pinned_model_slug(ProviderId::OpenRouter, "anthropic/claude-sonnet-4-6"),
+            "anthropic/claude-sonnet-4-6"
+        );
+        assert_eq!(
+            pinned_model_slug(ProviderId::OpenRouter, "openai/gpt-4o-mini"),
+            "openai/gpt-4o-mini"
+        );
+    }
+}

--- a/crates/trusty-agents/src/llm/stream.rs
+++ b/crates/trusty-agents/src/llm/stream.rs
@@ -136,7 +136,14 @@ pub fn streaming_supported(model: &str, use_anthropic_direct: bool) -> bool {
     if use_anthropic_direct || !streaming_enabled() {
         return false;
     }
-    !matches!(adapter_for_model(model).provider(), Provider::Fireworks)
+    !matches!(
+        adapter_for_model(model).provider(),
+        // #3765: AtlasCloud joins Fireworks here for the same reason — its own
+        // base URL and credential, reached through the raw HTTP path, with no
+        // streaming provider behind `stream_reply`'s dispatch. Streaming such
+        // a model would silently send it to OpenRouter instead.
+        Provider::Fireworks | Provider::AtlasCloud
+    )
 }
 
 /// Read the `TAGENT_CHAT_STREAMING` kill switch (default ON).

--- a/crates/trusty-agents/src/llm/tool_loop/mod.rs
+++ b/crates/trusty-agents/src/llm/tool_loop/mod.rs
@@ -178,27 +178,16 @@ pub async fn chat_with_tools_gated(
 
     let openai_tools = registry.openai_tools()?;
     let mut messages = initial_messages;
-    // #287: ollama models are routed via `ollama/<name>` — the prefix is only
-    // used by `adapter_for_model` for selection. Strip it before sending the
-    // request body so ollama's OpenAI-compat layer sees the bare model id
-    // (e.g. `llama3.2:latest`). Force the raw HTTP path for these calls so
-    // they hit the local ollama base URL instead of the async-openai client's
-    // hardwired OpenRouter endpoint.
-    //
-    // #2410 (epic #2400) Step 3: `fireworks/<name>` models follow the exact
-    // same pattern — the prefix selects `FireworksAdapter` in
-    // `adapter_for_model`, is stripped here so Fireworks sees its own
-    // provider-native model id (e.g. `accounts/fireworks/models/...`), and
-    // the raw path is forced so `turn::dispatch_turn` routes through
-    // `adapter.api_endpoint()` (api.fireworks.ai + `FIREWORKS_API_KEY`)
-    // instead of the async-openai client hardwired to OpenRouter.
-    let is_ollama = model.starts_with("ollama/");
-    let is_fireworks = model.starts_with("fireworks/");
-    let model_owned = model
-        .strip_prefix("ollama/")
-        .or_else(|| model.strip_prefix("fireworks/"))
-        .unwrap_or(model)
-        .to_string();
+    // A routing marker (`ollama/` #287, `fireworks/` #2410, `atlascloud/`
+    // #3765) exists only to select an adapter — the provider itself rejects
+    // it in the request body — and any adapter with its own base URL must
+    // take the raw HTTP path, because the shared `async-openai` client is
+    // hardwired to OpenRouter. Both rules used to live here as a per-prefix
+    // list that each new provider had to remember to extend; #3765 moved them
+    // onto the adapter (`wire_model_id` / `requires_raw_http`), so a provider
+    // added later inherits them instead of rediscovering the bug.
+    let provider_needs_raw = adapter.requires_raw_http();
+    let model_owned = adapter.wire_model_id(model).to_string();
     let model = model_owned.as_str();
     // qwen3 supports `/think` and `/no_think` as in-message special tokens.
     // The system prompt sets `/no_think` as the default for speed; we inject
@@ -226,11 +215,8 @@ pub async fn chat_with_tools_gated(
     // caching) or as a raw `serde_json::Value` when we need provider-specific
     // fields (cache_control and/or a non-trivial tool_choice shape) that
     // async-openai 0.28 cannot model.
-    let needs_raw = caching_active
-        || tool_choice.is_some()
-        || route_native_anthropic
-        || is_ollama
-        || is_fireworks;
+    let needs_raw =
+        caching_active || tool_choice.is_some() || route_native_anthropic || provider_needs_raw;
     let routing = TurnRouting {
         caching_active,
         route_native_anthropic,

--- a/crates/trusty-common/changelog.d/3765-atlascloud-default-model.md
+++ b/crates/trusty-common/changelog.d/3765-atlascloud-default-model.md
@@ -1,0 +1,14 @@
+Changed
+
+- AtlasCloud's seeded `default_model` is now `deepseek-ai/deepseek-v4-flash`,
+  replacing `openai/gpt-5.6-sol`
+  ([#3765](https://github.com/bobmatnyc/trusty-tools/issues/3765)).
+  A live probe found AtlasCloud gates its catalog by account PLAN, not only by
+  key validity: a Coding-Plan key answers `403 invalid token for coding plan`
+  for `openai/gpt-5.6-sol` and most of the catalog even though `GET /v1/models`
+  lists them, so "just pick AtlasCloud" failed on a valid key. The replacement
+  was verified live on such a key — a real completion and a real OpenAI-style
+  `tool_calls` response — and has a 1,048,576-token context with the cheapest
+  rates of the callable set. It is Coding-Plan-informed, which the seed comment
+  records; `max_context_window` is unchanged at 1,050,000 because it is the
+  provider-level fallback, not this model's own window.

--- a/crates/trusty-common/src/inference/registry/mod.rs
+++ b/crates/trusty-common/src/inference/registry/mod.rs
@@ -338,8 +338,24 @@ const SEED: [ProviderCapabilities; 8] = [
     // place `cache_control` breakpoints) and `detailed_usage_accounting = false`
     // (the `usage:{include:true}` directive is OpenRouter-specific — a live probe
     // is confirming AtlasCloud's `usage` shape; flip this only if it reports
-    // cost/cache fields). Default model + context window are AtlasCloud's own
-    // catalog numbers for `openai/gpt-5.6-sol` (1.05M-token window).
+    // cost/cache fields).
+    //
+    // #3765: `default_model` was `openai/gpt-5.6-sol`, taken from AtlasCloud's
+    // published catalog. A live probe found that AtlasCloud gates its catalog
+    // by ACCOUNT PLAN, not only by key validity: a Coding-Plan key answers
+    // `403 {"msg":"invalid token for coding plan, this model not support
+    // coding plan"}` for `openai/gpt-5.6-sol` and for most of the catalog,
+    // even though `GET /v1/models` lists them all. So the published default
+    // was not callable and made "just pick AtlasCloud" fail on a valid key.
+    // `deepseek-ai/deepseek-v4-flash` was verified live on such a key: a real
+    // completion plus a real OpenAI-style `tool_calls` response, 1,048,576-token
+    // context, and the cheapest prompt/completion rates of the callable set —
+    // the same cheap-but-capable posture as OpenRouter's `gpt-4o-mini` default
+    // above. Read this as Coding-Plan-oriented: it is informed by one account's
+    // plan because that is the only evidence available, and a different plan
+    // may well be able to call a stronger model. `max_context_window` stays
+    // 1_050_000 — it is the PROVIDER-level fallback for a model `context_window`
+    // does not recognise, not this model's own window.
     ProviderCapabilities {
         id: ProviderId::AtlasCloud,
         native_tool_calling: true,
@@ -350,7 +366,7 @@ const SEED: [ProviderCapabilities; 8] = [
         vision: false,
         detailed_usage_accounting: false,
         max_context_window: 1_050_000,
-        default_model: "openai/gpt-5.6-sol",
+        default_model: "deepseek-ai/deepseek-v4-flash",
         credential_env: Some("ATLASCLOUD_API_KEY"),
     },
     // Local / OpenAI-compatible (#3247) — a thin config over the shared
@@ -653,9 +669,12 @@ mod tests {
     /// Why: AtlasCloud (#2536) must resolve by id, by name, and by slug prefix,
     /// carry its OpenAI-compat capability posture (native tools, OpenAI dialect,
     /// `ATLASCLOUD_API_KEY` credential env), and expose its catalog defaults
-    /// (`openai/gpt-5.6-sol`, 1.05M-token window). The nested `openai/`-shaped
-    /// default model must NOT trip the prefix resolver — the routing prefix is
-    /// `atlascloud/`, not the model id.
+    /// (`deepseek-ai/deepseek-v4-flash` since #3765 — see the seed entry for why
+    /// the published `openai/gpt-5.6-sol` was not callable — and the 1.05M-token
+    /// provider-level window). The nested `vendor/model`-shaped default must NOT
+    /// trip the prefix resolver — the routing prefix is `atlascloud/`, not the
+    /// model id, and `openai/gpt-5.6-sol` is retained in the slug assertions
+    /// below precisely because its `openai/` head is the adversarial case.
     /// Test: itself.
     #[test]
     fn atlascloud_seeded_with_openai_compat_posture() {
@@ -673,7 +692,14 @@ mod tests {
         assert_eq!(caps.tool_dialect, ToolDialect::OpenAiFunctions);
         assert!(!caps.detailed_usage_accounting);
         assert_eq!(caps.credential_env, Some("ATLASCLOUD_API_KEY"));
-        assert_eq!(caps.default_model, "openai/gpt-5.6-sol");
+        assert_eq!(caps.default_model, "deepseek-ai/deepseek-v4-flash");
+        // #3765: the default is itself `vendor/model`, so it must survive the
+        // one-marker strip intact — the same property `openai/gpt-5.6-sol`
+        // guarded before it.
+        assert_eq!(
+            ProviderId::AtlasCloud.wire_model_id("atlascloud/deepseek-ai/deepseek-v4-flash"),
+            "deepseek-ai/deepseek-v4-flash"
+        );
         assert_eq!(caps.max_context_window, 1_050_000);
         assert_eq!(
             capabilities_for("AtlasCloud").map(|c| c.id),


### PR DESCRIPTION
**Problem** — `PATCH /api/agents/:name` accepted and persisted `[agent].provider_id`, but nothing at dispatch ever read it (zero references across `src/llm/**`). Setting it was a silent no-op that looked like it worked. Real routing was process-global, recomputed every turn from ambient credentials. `Closes #3765`.

**Fix** — `provider_id` is now a real `AgentInfo` field. The pin rewrites the model slug at load (`llm/provider_pin.rs`), so it wins at every site that derives an adapter from `cfg.agent.model` rather than at one. It also forces `use_anthropic_direct` to match and makes `apply_credential_routing` early-return for pinned agents, so a stray `ANTHROPIC_API_KEY` cannot hijack an agent pinned elsewhere.

**Fail-closed** — a pinned agent whose credential does not resolve aborts the load, naming the provider and the env var it needs. No silent fallback. `override_model` re-validates, so this holds at dispatch too, not only at load.

**Pins are refused where dispatch cannot honour them** — `openai` and `together` are registry providers that still fall through to OpenRouter with an unroutable slug, so pinning to one is refused at load AND at the PATCH write gate. A test asserts `provider_pin::PINNABLE == models::reachable_today()`, so the GUI cannot offer a provider the loader rejects.

**AtlasCloud is now reachable, verified live** — `GET /v1/models` 200 and a real completion through the new adapter returned parsed token usage. Fireworks was used as a control to confirm no regression to a provider that already worked.

**Seed default changed** — `openai/gpt-5.6-sol` → `deepseek-ai/deepseek-v4-flash`. 16 candidates probed; 11 returned `403 invalid token for coding plan`, including the incumbent. Of the 5 callable, flash was chosen on 1M context, 3× max output, live-verified tool-calling, and 10–15× lower cost. This was measured against ONE Coding Plan key and is therefore plan-informed, not broadly measured.

**Five pin-bypass sites closed** — `in_process_runner.rs`, three `ctrl` dispatch paths, and `resolve_overridden_credentials` (whose bedrock/local arms prepended a marker, producing `bedrock/atlascloud/…`). One was reachable from a request body via `TaskRequest.model_id` → `SessionOverrides.model`. Model overrides are re-pinned through `override_model`; provider overrides are refused. Rationale: the operator pinned a provider, the caller chose a model on it — refusing would break workflow retry escalation for every pinned agent while adding no safety.

**What the pin does NOT cover:**
- `.md` overlay agents have no `provider_id` frontmatter key and are always unpinned.
- The `claude-code` runner path is Anthropic-only by construction and takes no pin.
- Bedrock and Local pins skip the credential probe — no resolver-managed key — so a broken AWS chain surfaces at first turn, not at load.
- `effective_ctrl_turn_model` routes "local-qualifying" conversational turns to ollama regardless of `provider_id`. PRE-EXISTING, predates #3765, untouched by this PR — but it is a real gap in the pin's coverage and is named here so nobody trusts the guarantee further than it goes. Candidate follow-up.

**Test ladder** — Rung 4 (touches `trusty-common`).

```
cargo fmt --check                                                              → EXIT 0
cargo clippy -p trusty-agents --all-targets -- -D warnings                     → EXIT 0
cargo test -p trusty-agents                                                    → 3462 passed / 0 failed
cargo test -p trusty-common --features config-cli,inference-client,axum-server → 530 + 17 + 9 + 13 passed
scripts/check_test_pointers.sh                                                 → EXIT 0
```

`cargo test -p trusty-common` with DEFAULT features does not compile the inference/credentials module — the feature-enabled run above is the real gate. `cargo test -p trusty-mpm`, the heaviest `default_model` consumer, was NOT run: a release build is active in that crate and the owner elected to merge on the five consumers that did pass (trusty-agents, trusty-console, tga, trusty-review, trusty-code). The consumer sweep is not presented as complete.

**SemVer** — additive; `cargo semver-checks` against the commit parent: 196 pass, no update required. No manifest touched; `trusty-common` stays `0.30.0`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
