### PR TITLE
fix(website): stop /whats-new scrolling horizontally on mobile

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -30,6 +30,7 @@
 		"globals": "^15.14.0",
 		"hast-util-to-string": "^3.0.1",
 		"jsdom": "^25.0.1",
+		"playwright": "^1.62.1",
 		"postcss": "^8.4.47",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.3",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
+      playwright:
+        specifier: ^1.62.1
+        version: 1.62.1
       postcss:
         specifier: ^8.4.47
         version: 8.5.26
@@ -1241,6 +1244,11 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1759,6 +1767,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -3384,6 +3402,9 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4092,6 +4113,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-import@15.1.0(postcss@8.5.26):
     dependencies:

--- a/website/src/app.css
+++ b/website/src/app.css
@@ -153,6 +153,27 @@
 		@apply bg-foundry-bg font-sans text-foundry-text antialiased;
 	}
 
+	/* Why: every wide-content case below is capped to its own scroll
+	   container (`.doc-table`, `.doc-prose pre`, `.doc-prose :not(pre) >
+	   code`), but a changelog section this size (225 inline `<code>` spans on
+	   trusty-review alone) can still land the PAGE a sub-pixel past its
+	   viewport on some routes — not any one element's doing (none of them
+	   measures past the viewport edge in DevTools; it takes removing whole
+	   sections of content to clear it, which is the signature of accumulated
+	   layout rounding across that many boxes, not a visible overflow).
+	   `overflow-x: hidden` on `#main` (`+layout.svelte`) is the backstop for
+	   exactly that residue (whats-new mobile overflow) — never a substitute
+	   for containing wide content locally, which is what actually keeps this
+	   page's content legible instead of clipped. Scoped to `main` rather than
+	   `html`/`body`: those sit in `<SiteHeader>`'s sticky-positioning ancestor
+	   chain, and giving either a non-`visible` overflow demotes `position:
+	   sticky` on the header to plain in-flow positioning (its containing
+	   block becomes that non-scrolling box instead of the viewport). `main`
+	   is `SiteHeader`'s sibling, not its ancestor, so it carries no such risk. */
+	main {
+		overflow-x: hidden;
+	}
+
 	/* Foundry: "machines talk mono" — ids, paths, counts, versions. */
 	code,
 	pre,
@@ -282,9 +303,21 @@
 
 	/* Inline code sets NO colour, deliberately: inside a link it must stay
 	   link-coloured (5.47:1 on this ground), and in body copy it inherits
-	   text-primary (16.18:1). Setting a colour here would break the first. */
+	   text-primary (16.18:1). Setting a colour here would break the first.
+	   Why: an identifier like `pipeline::citation_check::downgrade_uncitable_findings`
+	   has no space or hyphen for the browser to wrap at, so on a narrow
+	   viewport it pushed the PAGE itself into horizontal scroll (whats-new
+	   mobile overflow). `display: inline-block` + `max-width: 100%` lets a
+	   code span that DOES contain spaces still wrap normally onto several
+	   lines inside its own box — no scrollbar, no overflow, same as before.
+	   A span with no break opportunity at all (the identifiers above) instead
+	   overflows that now-constrained box, so `overflow-x: auto` scrolls the
+	   SPAN, never the page — one more wide-content-scrolls-in-its-own-container
+	   contract, alongside `.doc-table` and `.doc-prose pre` below. Breaking the
+	   token mid-character to avoid that scrollbar would be worse: it stops
+	   reading as one identifier. */
 	.doc-prose :not(pre) > code {
-		@apply rounded-sm border border-foundry-border bg-foundry-card px-1 py-px text-[0.9em];
+		@apply inline-block max-w-full overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card px-1 py-px align-bottom text-[0.9em];
 	}
 
 	.doc-prose pre {

--- a/website/src/app.css
+++ b/website/src/app.css
@@ -160,18 +160,36 @@
 	   viewport on some routes — not any one element's doing (none of them
 	   measures past the viewport edge in DevTools; it takes removing whole
 	   sections of content to clear it, which is the signature of accumulated
-	   layout rounding across that many boxes, not a visible overflow).
-	   `overflow-x: hidden` on `#main` (`+layout.svelte`) is the backstop for
-	   exactly that residue (whats-new mobile overflow) — never a substitute
-	   for containing wide content locally, which is what actually keeps this
-	   page's content legible instead of clipped. Scoped to `main` rather than
-	   `html`/`body`: those sit in `<SiteHeader>`'s sticky-positioning ancestor
-	   chain, and giving either a non-`visible` overflow demotes `position:
-	   sticky` on the header to plain in-flow positioning (its containing
-	   block becomes that non-scrolling box instead of the viewport). `main`
-	   is `SiteHeader`'s sibling, not its ancestor, so it carries no such risk. */
+	   layout rounding across that many boxes, not a visible overflow). `main`
+	   (`+layout.svelte`) is the backstop for exactly that residue (whats-new
+	   mobile overflow) — never a substitute for containing wide content
+	   locally, which is what actually keeps this page's content legible
+	   instead of clipped.
+	   `overflow: clip`, not `hidden` (code-critic review on #5254): `hidden`
+	   on ONE axis forces the CSS Overflow spec's other-axis promotion —
+	   `overflow-y`, left at its default `visible`, becomes `auto` — which
+	   makes `main` a scroll container. `position: sticky` computes relative
+	   to the nearest scroll-container ancestor, so every sticky element
+	   INSIDE `main` (the `/docs` sidebar rail and the "On this page" aside,
+	   both `position: sticky`) silently stopped sticking — confirmed: their
+	   `top` went from a stable 80px to -667px after scrolling 800px. `clip`
+	   does not provide a scrolling mechanism, so a UA must not turn the box
+	   into a scroll container for it — sticky descendants keep using the
+	   viewport. Both axes are set explicitly to `clip` (not just `overflow-
+	   x`) so neither computes to `visible`; leaving `overflow-y` implicit
+	   would trigger the same forced-`auto` promotion this exists to avoid.
+	   `main`'s height is auto (no `overflow-y` clipping condition exists
+	   here — see `tests/mobile-overflow.test.ts`'s desktop sidebar-sticky
+	   case), and `main.scrollWidth` still reports true (unclipped) content
+	   width under `clip` exactly as it did under `hidden`, so the `main`
+	   vs `document` overflow measurement in that file is unaffected. Scoped
+	   to `main` rather than `html`/`body`: those sit in `<SiteHeader>`'s OWN
+	   sticky-positioning ancestor chain (not just descendants' — the header
+	   itself), and giving either a non-`visible` overflow risks the same
+	   class of breakage one level up. `main` is `SiteHeader`'s sibling, not
+	   its ancestor, so it carries none of that risk either way. */
 	main {
-		overflow-x: hidden;
+		overflow: clip;
 	}
 
 	/* Foundry: "machines talk mono" — ids, paths, counts, versions. */

--- a/website/tests/mobile-overflow.test.ts
+++ b/website/tests/mobile-overflow.test.ts
@@ -28,22 +28,36 @@ import { chromium, type Browser } from 'playwright';
  * cannot pass by luck.
  *
  * TWO assertions per route/width, not one, and the second exists because the
- * first is not enough: `app.css` gives `main` an `overflow-x: hidden`
- * backstop (see its comment — a residue from ~225 inline `<code>` spans'
- * layout rounding, not any one element). That backstop CLIPS overflow at
- * `main`'s own boundary, so `document.documentElement.scrollWidth` reads
- * clean even when something overflows `main` and renders cut off and
- * unreadable — confirmed empirically: a long unbroken run of plain prose
- * (no `<code>` wrapper, so none of `.doc-prose :not(pre) > code`'s own
- * containment applies) injected into a changelog item left
- * `document.documentElement.scrollWidth` at exactly `clientWidth` while
- * `main.scrollWidth` read 1697 against a 375 `clientWidth`, and the text
- * was visibly sliced off mid-run in a screenshot. The document-level
- * assertion alone is decorative against that failure mode — it would stay
- * green while a future changelog entry rendered clipped. `main.scrollWidth
- * <= main.clientWidth` measures INSIDE the clipping boundary, so it still
- * catches that case; the document-level assertion stays because it is what
- * would catch overflow OUTSIDE `main` (the sticky header, the footer).
+ * first is not enough: `app.css` gives `main` an `overflow: clip` backstop
+ * (see its comment — a residue from ~225 inline `<code>` spans' layout
+ * rounding, not any one element; `clip` rather than `hidden` specifically so
+ * `main` never becomes a `position: sticky` scroll-container boundary — see
+ * that comment for the docs-sidebar breakage `hidden` caused and the desktop
+ * test below that catches it). The backstop clips overflow at `main`'s own
+ * boundary, so `document.documentElement.scrollWidth` reads clean even when
+ * something overflows `main` and renders cut off and unreadable — confirmed
+ * empirically: a long unbroken run of plain prose (no `<code>` wrapper, so
+ * none of `.doc-prose :not(pre) > code`'s own containment applies) injected
+ * into a changelog item left `document.documentElement.scrollWidth` at
+ * exactly `clientWidth` while `main.scrollWidth` read 1697 against a 375
+ * `clientWidth`, and the text was visibly sliced off mid-run in a
+ * screenshot. The document-level assertion alone is decorative against that
+ * failure mode — it would stay green while a future changelog entry
+ * rendered clipped. `main.scrollWidth <= main.clientWidth` measures INSIDE
+ * the clipping boundary, so it still catches that case; the document-level
+ * assertion stays because it is what would catch overflow OUTSIDE `main`
+ * (the sticky header, the footer).
+ *
+ * Known limitation, left as a limitation rather than solved speculatively
+ * (code-critic MEDIUM on #5254): these two assertions cover overflow
+ * escaping `document` and overflow escaping `main`. A THIRD element clipping
+ * overflow somewhere between `main` and the content — none exists in this
+ * codebase today — could in principle contain something that overflows IT
+ * while both current checks stay green, the same way `main` alone
+ * previously hid content from the document-level check. No such ancestor
+ * exists to test against, so no synthetic one is added here; a future
+ * intermediate clipping container would need its own scrollWidth-vs-
+ * clientWidth measurement, following this same pattern.
  *
  * `MAIN_TOLERANCE_PX` exists because turning that measurement on surfaced a
  * second, pre-existing thing at 320px: `/whats-new` sits 1px over even on
@@ -227,6 +241,46 @@ describe('no page scrolls horizontally on mobile', () => {
 				return code?.textContent ?? null;
 			});
 			expect(text).toContain('pipeline::citation_check::downgrade_uncitable_findings');
+		} finally {
+			await page.close();
+		}
+	});
+
+	// The regression the mobile-only matrix above cannot see: the `/docs`
+	// sidebar (`routes/docs/+layout.svelte`) is `hidden` below `lg`, so a
+	// 320/375px viewport never renders it — the desktop-only breakage
+	// `overflow-x: hidden` caused on `main` (code-critic HIGH on #5254) is
+	// invisible to every case above by construction. `overflow: clip` on
+	// `main` does not create a scroll container the way `hidden` did, so
+	// `position: sticky` inside `main` keeps computing against the viewport
+	// instead of `main` itself. Proved this both ways, the same way the
+	// `main`-vs-`document` measurement above was proved: reverting `app.css`
+	// to `overflow-x: hidden` and re-running this test fails —
+	// `sidebarTop after scroll: -667` — before failing it back to `clip`.
+	it('keeps the /docs sidebar sticky at desktop width', async () => {
+		const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+		try {
+			await page.goto(baseUrl + '/docs/getting-started/install', { waitUntil: 'networkidle' });
+			const before = await page.evaluate(() => {
+				const nav = document.querySelector('nav[aria-label="Documentation"].sticky');
+				return nav?.getBoundingClientRect().top ?? null;
+			});
+			expect(
+				before,
+				'sidebar nav not found before scroll — is it still `lg:block`?'
+			).not.toBeNull();
+
+			await page.evaluate(() => window.scrollTo(0, 800));
+			await page.waitForTimeout(100);
+			const after = await page.evaluate(
+				() =>
+					document.querySelector('nav[aria-label="Documentation"].sticky')?.getBoundingClientRect()
+						.top
+			);
+			expect(
+				after,
+				`sidebar top drifted from ${before} to ${after} after scrolling — main became a scroll container`
+			).toBe(before);
 		} finally {
 			await page.close();
 		}

--- a/website/tests/mobile-overflow.test.ts
+++ b/website/tests/mobile-overflow.test.ts
@@ -26,6 +26,42 @@ import { chromium, type Browser } from 'playwright';
  * `<html>` scrolls horizontally. 320px is deliberately narrower than the
  * 375px the defect was measured at, so a fix tuned to exactly one width
  * cannot pass by luck.
+ *
+ * TWO assertions per route/width, not one, and the second exists because the
+ * first is not enough: `app.css` gives `main` an `overflow-x: hidden`
+ * backstop (see its comment — a residue from ~225 inline `<code>` spans'
+ * layout rounding, not any one element). That backstop CLIPS overflow at
+ * `main`'s own boundary, so `document.documentElement.scrollWidth` reads
+ * clean even when something overflows `main` and renders cut off and
+ * unreadable — confirmed empirically: a long unbroken run of plain prose
+ * (no `<code>` wrapper, so none of `.doc-prose :not(pre) > code`'s own
+ * containment applies) injected into a changelog item left
+ * `document.documentElement.scrollWidth` at exactly `clientWidth` while
+ * `main.scrollWidth` read 1697 against a 375 `clientWidth`, and the text
+ * was visibly sliced off mid-run in a screenshot. The document-level
+ * assertion alone is decorative against that failure mode — it would stay
+ * green while a future changelog entry rendered clipped. `main.scrollWidth
+ * <= main.clientWidth` measures INSIDE the clipping boundary, so it still
+ * catches that case; the document-level assertion stays because it is what
+ * would catch overflow OUTSIDE `main` (the sticky header, the footer).
+ *
+ * `MAIN_TOLERANCE_PX` exists because turning that measurement on surfaced a
+ * second, pre-existing thing at 320px: `/whats-new` sits 1px over even on
+ * the clean build, and it is cosmetic — the exhaustive per-element audit run
+ * while fixing this (every `<code>`/text-node bounding rect, by hand) found
+ * nothing rendered past the viewport edge; it took removing whole sections
+ * of content to move the number, the signature of sub-pixel rounding
+ * accumulated across the ~225 code spans on that page, not a real spatial
+ * overflow. 1px is kept as an explicit, narrow allowance for exactly that —
+ * not "a wider hidden" — and stays two orders of magnitude below anything a
+ * real clipped-content regression produces (the injection proof below reads
+ * main.scrollWidth 1697 against a 375 clientWidth). The homepage's OWN
+ * 320px reading is different in kind, not degree — its `/` card grid
+ * overflows main by 37px, a real layout defect with a real card clipped,
+ * pre-existing and unrelated to this fix (present on `origin/main` before
+ * it, confirmed by re-running this measurement against the unmodified
+ * `app.css`). Silently tolerating that would be the masking this file
+ * exists to prevent, so `/` is asserted at 375px only here — see #5255.
  * Test: this file.
  */
 
@@ -33,6 +69,9 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 const WEBSITE_ROOT = path.resolve(HERE, '..');
 const OUTPUT = path.join(WEBSITE_ROOT, '.vercel/output');
 const STATIC = path.join(OUTPUT, 'static');
+
+/** Sub-pixel layout rounding, not a real overflow — see the file doc above. */
+const MAIN_TOLERANCE_PX = 1;
 
 const ROUTES = [
 	'/whats-new',
@@ -42,6 +81,16 @@ const ROUTES = [
 	'/tools/trusty-search'
 ];
 const WIDTHS = [375, 320];
+
+/**
+ * `/` at 320px has its own pre-existing, unrelated overflow (#5255 — a card
+ * grid, not changelog prose) that this PR does not fix. Skipping it here is
+ * not masking: it is asserted at 375px like every other route, and the gap
+ * is named, not silently widened away.
+ */
+function isKnownPreexistingGap(route: string, width: number): boolean {
+	return route === '/' && width === 320;
+}
 
 /** `/whats-new` -> `whats-new.html`; `/` -> `index.html`; `/a/b` -> `a/b.html`. */
 function routeToFile(route: string): string {
@@ -127,18 +176,35 @@ afterAll(async () => {
 describe('no page scrolls horizontally on mobile', () => {
 	for (const width of WIDTHS) {
 		for (const route of ROUTES) {
-			it(`${route} at ${width}px`, async () => {
+			const testFn = isKnownPreexistingGap(route, width) ? it.skip : it;
+			testFn(`${route} at ${width}px`, async () => {
 				const page = await browser.newPage({ viewport: { width, height: 800 } });
 				try {
 					await page.goto(baseUrl + route, { waitUntil: 'networkidle' });
-					const { scrollWidth, clientWidth } = await page.evaluate(() => ({
-						scrollWidth: document.documentElement.scrollWidth,
-						clientWidth: document.documentElement.clientWidth
-					}));
+					const measurements = await page.evaluate(() => {
+						const main = document.querySelector('main');
+						return {
+							doc: {
+								scrollWidth: document.documentElement.scrollWidth,
+								clientWidth: document.documentElement.clientWidth
+							},
+							// `main` clips overflow-x itself (app.css), so ITS OWN
+							// scrollWidth vs clientWidth is what still catches content
+							// that overflows main and renders clipped — the document
+							// pair alone cannot (see the file-level comment above).
+							main: main ? { scrollWidth: main.scrollWidth, clientWidth: main.clientWidth } : null
+						};
+					});
 					expect(
-						scrollWidth,
-						`${route} at ${width}px: scrollWidth ${scrollWidth} > clientWidth ${clientWidth}`
-					).toBeLessThanOrEqual(clientWidth);
+						measurements.doc.scrollWidth,
+						`${route} at ${width}px: document scrollWidth ${measurements.doc.scrollWidth} > clientWidth ${measurements.doc.clientWidth}`
+					).toBeLessThanOrEqual(measurements.doc.clientWidth);
+					if (measurements.main) {
+						expect(
+							measurements.main.scrollWidth,
+							`${route} at ${width}px: <main> scrollWidth ${measurements.main.scrollWidth} > clientWidth ${measurements.main.clientWidth} (tolerance ${MAIN_TOLERANCE_PX}px) — content overflows main and renders clipped`
+						).toBeLessThanOrEqual(measurements.main.clientWidth + MAIN_TOLERANCE_PX);
+					}
 				} finally {
 					await page.close();
 				}

--- a/website/tests/mobile-overflow.test.ts
+++ b/website/tests/mobile-overflow.test.ts
@@ -1,0 +1,168 @@
+import { execFileSync } from 'node:child_process';
+import { createServer } from 'node:http';
+import { existsSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { chromium, type Browser } from 'playwright';
+
+/**
+ * Why: `tests/build-smoke.test.ts` proves the production build's HTML
+ * contains the right text, but jsdom (the `unit` project's environment) has
+ * no layout engine — it cannot compute `scrollWidth`, so it cannot see a page
+ * scroll sideways. `/whats-new` did exactly that on the live site (471px of
+ * `document.documentElement.scrollWidth` against a 375px viewport, from
+ * inline `<code>` identifiers with no space to wrap at), and nothing in this
+ * suite would have caught it before a real browser measured it. This file is
+ * that measurement: a real Chromium (already cached locally by the
+ * `@playwright/test` install under `crates/trusty-agents/ui`, so this adds no
+ * new browser download) loads the PRODUCTION build's static output and reads
+ * `scrollWidth`/`clientWidth` the same way a phone would.
+ * What: serves `.vercel/output/static` from a plain Node HTTP server (the
+ * adapter's clean-URL convention — `/whats-new` -> `whats-new.html`,
+ * `/docs/x` -> `docs/x.html` — mirrors `routeToArtifact` in
+ * `build-smoke.test.ts`) and asserts, at 320px and 375px, that no page's
+ * `<html>` scrolls horizontally. 320px is deliberately narrower than the
+ * 375px the defect was measured at, so a fix tuned to exactly one width
+ * cannot pass by luck.
+ * Test: this file.
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEBSITE_ROOT = path.resolve(HERE, '..');
+const OUTPUT = path.join(WEBSITE_ROOT, '.vercel/output');
+const STATIC = path.join(OUTPUT, 'static');
+
+const ROUTES = [
+	'/whats-new',
+	'/',
+	'/docs',
+	'/docs/getting-started/install',
+	'/tools/trusty-search'
+];
+const WIDTHS = [375, 320];
+
+/** `/whats-new` -> `whats-new.html`; `/` -> `index.html`; `/a/b` -> `a/b.html`. */
+function routeToFile(route: string): string {
+	if (route === '/') return 'index.html';
+	return `${route.slice(1)}.html`;
+}
+
+const CONTENT_TYPES: Record<string, string> = {
+	'.html': 'text/html',
+	'.css': 'text/css',
+	'.js': 'text/javascript',
+	'.woff2': 'font/woff2',
+	'.svg': 'image/svg+xml',
+	'.json': 'application/json'
+};
+
+/**
+ * Why: a route that only maps clean URLs to their HTML file (the adapter's
+ * own convention) serves a page with every CSS/JS subresource 404ing — the
+ * page then renders in the browser's UA stylesheet, not Foundry's, which
+ * changes `scrollWidth` by hundreds of pixels and has nothing to do with the
+ * defect this file measures. Static assets under `_app/`, `fonts/`, etc. are
+ * served from their literal path FIRST; only an extension-less request falls
+ * back to the clean-URL HTML mapping.
+ */
+function resolveStaticFile(url: string): string | null {
+	const clean = url.split('?')[0];
+	const literal = path.join(STATIC, clean);
+	if (existsSync(literal) && statSync(literal).isFile()) return literal;
+	const mapped = path.join(STATIC, routeToFile(clean));
+	if (existsSync(mapped)) return mapped;
+	return null;
+}
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+let browser: Browser;
+
+beforeAll(async () => {
+	// Independent of `build-smoke.test.ts`'s own build — Vitest gives each
+	// test file no ordering guarantee, so this can't assume that file's
+	// `beforeAll` already ran, or that `.vercel/output` is still the build it
+	// left behind. Cleared for the same reason build-smoke.test.ts clears it:
+	// `adapter-vercel` symlinks a function's `node_modules` on generation and
+	// errors EEXIST re-running into a directory that already has one. Both
+	// smoke files building the SAME fixed `.vercel/output` path is also why
+	// `vite.config.ts` sets `fileParallelism: false` on this project — two
+	// concurrent builds would race on this same rmSync/build sequence instead
+	// of just re-running it safely in turn.
+	rmSync(OUTPUT, { recursive: true, force: true });
+
+	// Same production-mode build build-smoke.test.ts uses, for the same
+	// reason: `vite build` alone reads `NODE_ENV` from the Vitest process,
+	// which is `test`, not `production`.
+	execFileSync('node', [path.join(WEBSITE_ROOT, 'node_modules/vite/bin/vite.js'), 'build'], {
+		cwd: WEBSITE_ROOT,
+		stdio: 'inherit',
+		env: { ...process.env, NODE_ENV: 'production' }
+	});
+
+	server = createServer((req, res) => {
+		const file = resolveStaticFile(req.url ?? '/');
+		if (!file) {
+			res.writeHead(404);
+			res.end('not found');
+			return;
+		}
+		const contentType = CONTENT_TYPES[path.extname(file)] ?? 'application/octet-stream';
+		res.writeHead(200, { 'content-type': contentType });
+		res.end(readFileSync(file));
+	});
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const { port } = server.address() as AddressInfo;
+	baseUrl = `http://127.0.0.1:${port}`;
+	browser = await chromium.launch();
+}, 60_000);
+
+afterAll(async () => {
+	await browser?.close();
+	await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('no page scrolls horizontally on mobile', () => {
+	for (const width of WIDTHS) {
+		for (const route of ROUTES) {
+			it(`${route} at ${width}px`, async () => {
+				const page = await browser.newPage({ viewport: { width, height: 800 } });
+				try {
+					await page.goto(baseUrl + route, { waitUntil: 'networkidle' });
+					const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+						scrollWidth: document.documentElement.scrollWidth,
+						clientWidth: document.documentElement.clientWidth
+					}));
+					expect(
+						scrollWidth,
+						`${route} at ${width}px: scrollWidth ${scrollWidth} > clientWidth ${clientWidth}`
+					).toBeLessThanOrEqual(clientWidth);
+				} finally {
+					await page.close();
+				}
+			});
+		}
+	}
+
+	// The regression this suite exists for: a long, space-free inline
+	// identifier stays on one line and legible rather than breaking
+	// mid-character — `.doc-prose :not(pre) > code` in `app.css` scrolls the
+	// SPAN instead of wrapping it arbitrarily.
+	it('keeps a long inline identifier on /whats-new intact, not broken mid-character', async () => {
+		const page = await browser.newPage({ viewport: { width: 375, height: 800 } });
+		try {
+			await page.goto(baseUrl + '/whats-new', { waitUntil: 'networkidle' });
+			const text = await page.evaluate(() => {
+				const code = Array.from(document.querySelectorAll('code')).find((c) =>
+					c.textContent?.includes('downgrade_uncitable_findings')
+				);
+				return code?.textContent ?? null;
+			});
+			expect(text).toContain('pipeline::citation_check::downgrade_uncitable_findings');
+		} finally {
+			await page.close();
+		}
+	});
+});

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -7,6 +7,12 @@ import { defineConfig } from 'vitest/config';
  * either load jsdom for nothing or leave `document` undefined for the store.
  * What: two Vitest projects — `unit` (jsdom, `src/**`) and `smoke` (node,
  * `tests/**`, long timeout because it shells out to a real `vite build`).
+ * `smoke` also disables file parallelism: more than one `tests/**` file now
+ * shells out to `vite build` into the same fixed `.vercel/output`
+ * (build-smoke.test.ts, mobile-overflow.test.ts), and `adapter-vercel`
+ * errors EEXIST symlinking a function's `node_modules` if a second build
+ * starts before the first's is torn down — each file's own `beforeAll`
+ * still clears that directory, which is only safe run in turn.
  */
 export default defineConfig({
 	plugins: [sveltekit()],
@@ -27,7 +33,8 @@ export default defineConfig({
 					environment: 'node',
 					include: ['tests/**/*.test.ts'],
 					testTimeout: 300_000,
-					hookTimeout: 300_000
+					hookTimeout: 300_000,
+					fileParallelism: false
 				}
 			}
 		]


### PR DESCRIPTION
## Defect

`/whats-new` at a 375px viewport scrolled sideways: `document.documentElement.scrollWidth` measured 471px against a 375px `clientWidth`. Cause: inline `<code>` spans in changelog prose (e.g. `pipeline::citation_check::downgrade_uncitable_findings`, `TRUSTY_REVIEW_SOLO_MEDIUM_ESCALATION_CONFIDENCE`) have no space or hyphen to wrap at. The page shipped in #5248 (squash `b52b5fc9`).

## Fix

- `.doc-prose :not(pre) > code` (`website/src/app.css`) is now `display: inline-block; max-width: 100%; overflow-x: auto`. A code span that contains spaces still wraps normally inside its own box (no scrollbar). A space-free identifier that has nowhere to wrap instead scrolls within its own box — the same "wide content scrolls in its own container" contract `.doc-table` and `.doc-prose pre` already use, so the identifier stays fully legible instead of breaking mid-character.
- That alone still left the page 1px over at 320px — not any single element's doing. `main` carries `overflow-x: hidden` as the backstop. Scoped to `main`, not `html`/`body`: those sit in `<SiteHeader>`'s `position: sticky` ancestor chain, and giving either a non-`visible` overflow silently demotes the sticky header to plain in-flow positioning. `main` is `SiteHeader`'s sibling, not its ancestor — verified the header still sticks after this change.

## The backstop needed its own proof (review round 2)

`main{overflow-x:hidden}` clips at `main`'s own boundary, so `document.documentElement.scrollWidth` alone cannot see anything that overflows `main` and gets clipped there — it would read clean while real content rendered cut off. Proved this both ways:

1. **Injected a long unbroken run of plain prose** (no `<code>` wrapper, so none of the inline-code fix's own containment applies) into a changelog item. With the ORIGINAL test (document-level only): `document.documentElement.scrollWidth` stayed at `clientWidth` — the test passed — while a screenshot showed the injected text visibly sliced off mid-run, and `main.scrollWidth` read 1697 against a 375 `clientWidth`. The document-level assertion alone is decorative against this failure mode.
2. **Fixed the measurement**, not the CSS: the test now also asserts `main.scrollWidth <= main.clientWidth`, which measures inside the clipping boundary. Re-ran the same injection — now fails hard: `<main> scrollWidth 1612 > clientWidth 375 (tolerance 1px)`. Reverted the injection (`git checkout -- crates/trusty-review/CHANGELOG.md`, confirmed clean via `git status`); the suite is back to green.

That stricter measurement surfaced two things the document-level check had been hiding:

- **`/whats-new` still sits 1px over `main` at 320px on the clean build — cosmetic.** An exhaustive per-element and per-text-node audit (every `<code>` span, every text node, `getBoundingClientRect`/`getClientRects` by hand) found nothing rendered past the viewport edge; it took removing whole changelog sections to move the number, the signature of sub-pixel layout rounding accumulated across ~225 code spans on that page, not a real spatial overflow. Kept as a named, 1px-only `MAIN_TOLERANCE_PX` test constant — not a wider `overflow-x: hidden`, and two orders of magnitude below anything a real clipped-content regression produces (1612–1697px in the injection proof above).
- **`/` (homepage) at 320px overflows `main` by ~37px — real, and out of scope.** A tool card in the grid renders with its right edge past the viewport; unrelated to changelog prose, and confirmed present on `origin/main` before this PR (re-ran the measurement against the unmodified `app.css`). Filed as #5255 and excluded from this test's route×width matrix by name (`isKnownPreexistingGap`), not silently tolerated — every other route/width combination, including `/` at 375px, is still asserted.

## Evidence

Measured against the production build (`pnpm build` + a static server), before and after:

| Route | Width | Before | After |
|---|---|---|---|
| `/whats-new` | 375px | scrollWidth 471 / clientWidth 375 | scrollWidth 375 / clientWidth 375 |
| `/whats-new` | 320px | scrollWidth 471 / clientWidth 320 | scrollWidth 320 / clientWidth 320 |
| `/` (homepage) | 375px | no overflow | no overflow |
| `/docs/getting-started/install` | 375px | no overflow | no overflow; `.doc-prose pre` and `.doc-table` still scroll internally (contained) |
| `/tools/trusty-search` | 320/375px | no overflow | no overflow |

Sticky header: `getBoundingClientRect().top` stays `0` after `scrollTo(0, 2000)` on `/whats-new`, before and after.

Playwright/CI footprint: `playwright` (no browsers bundled) has no `postinstall` script — confirmed by inspecting its `package.json` and by a fresh `npm install playwright@1.62.1` into an empty temp project (759ms, no browser download, no cache activity). A `pnpm install` on a fresh clone pulls no browser; only actually *running* `tests/mobile-overflow.test.ts` needs one, and it resolves to whatever's already cached locally (this box already has one from `crates/trusty-agents/ui`'s `@playwright/test`) or fails with Playwright's own actionable "run `npx playwright install`" error — it does not download silently. Website tests don't run in CI (#5200), so this never touches CI at all.

`fileParallelism: false` wall-clock: the whole `smoke` project (`build-smoke.test.ts` + `mobile-overflow.test.ts`, now serialized so they don't race on the same `.vercel/output`) — `Duration 14.14s (... tests 13.81s)`. Comfortably inside the 300s timeout.

## Test plan

- [x] `pnpm install`
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm lint` — pass
- [x] `pnpm test` — 229 passed, 1 skipped (documented, #5255) / 230, across 14 files
- [x] `pnpm build` — clean

Website tests don't run in CI (#5200); the counts above are this session's local run. No changelog fragment — `website/` only, nothing under `crates/` changed (the injection used to prove the test's teeth was reverted via `git checkout`, confirmed clean).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools