### PR TITLE
fix(website): scheme allowlist for docs/changelog links

### DIFF
--- a/website/src/lib/changelog/parse.test.ts
+++ b/website/src/lib/changelog/parse.test.ts
@@ -291,6 +291,26 @@ describe('links and metavariables inside an item', () => {
 		);
 	});
 
+	it('leaves an http:// URL alone', () => {
+		const { releases, failures } = withProbe(item('see [x](http://example.com/a)'), []);
+		expect(failures).toEqual([]);
+		expect(releases[0].categories[0].items[0].html).toContain('href="http://example.com/a"');
+	});
+
+	it('fails the build on a javascript: link, the same as any other bad link', () => {
+		const { failures } = withProbe(item('[click me](javascript:alert(1))'), []);
+		expect(failures).toHaveLength(1);
+		expect(failures[0].code).toBe('CHANGELOG-BAD-LINK');
+		expect(failures[0].problem).toContain('javascript:');
+	});
+
+	it('fails the build on a file:// link', () => {
+		const { failures } = withProbe(item('[passwd](file:///etc/passwd)'), []);
+		expect(failures).toHaveLength(1);
+		expect(failures[0].code).toBe('CHANGELOG-BAD-LINK');
+		expect(failures[0].problem).toContain('file:');
+	});
+
 	// `<path>` outside backticks parses as an unknown element and renders as
 	// NOTHING. Eight of these sit in the corpus, and a changelog is history
 	// this site must not edit — so the text is recovered, never dropped.

--- a/website/src/lib/changelog/parse.ts
+++ b/website/src/lib/changelog/parse.ts
@@ -46,6 +46,7 @@ import { toString as hastToString } from 'hast-util-to-string';
 import { visit } from 'unist-util-visit';
 import type { Element, Root, RootContent } from 'hast';
 
+import { classifyAbsoluteHref } from '../docs/links';
 import { ALLOWED_ELEMENTS, parsePage, stringifyHast } from '../docs/render';
 import { GITHUB_REPO } from '../docs/repo';
 import { CHANGELOG_CODES, type ChangelogFailure } from './errors';
@@ -127,8 +128,6 @@ const RELEASE_HEADING = /^\[([^\]]+)\](.*)$/s;
 /** A separator between the version and the rest: em dash, en dash, or hyphen. */
 const LEADING_SEPARATOR = /^[\s—–·-]+/;
 const TRAILING_SEPARATOR = /[\s—–·-]+$/;
-/** Anything with a scheme, or a protocol-relative URL, already leaves the repo. */
-const ABSOLUTE = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
 
 /**
  * Why: see THE LINK-REFERENCE TRAP in the module header.
@@ -301,7 +300,7 @@ export function parseChangelog(
 }
 
 /**
- * Why: three problems in changelog prose would each ship a defect quietly.
+ * Why: four problems in changelog prose would each ship a defect quietly.
  *
  *   1. A RELATIVE link (`[spec](../../docs/specs/foo.md)`) is written to be
  *      followed on GitHub. Rendered verbatim on `/whats-new` it resolves
@@ -313,6 +312,10 @@ export function parseChangelog(
  *      renders as NOTHING — `run trusty-search index <path>` would publish as
  *      `run trusty-search index`. Eight of these are in the corpus right now.
  *   3. An image would be a third-party request from a site that makes none.
+ *   4. An absolute link using a scheme this site refuses to publish
+ *      (`javascript:`, `file:`, …) would render as a live href. Checked via
+ *      `classifyAbsoluteHref` — the same allowlist the doc reader applies, so
+ *      the two never drift (`../docs/links.ts`).
  *
  * What: rewrites every relative link into a `blob/main` link on the crate's
  * own path, and fails the build on anything it cannot resolve. Mutates the
@@ -366,7 +369,20 @@ function harden(
 
 		if (node.tagName !== 'a') return;
 		const href = node.properties?.href;
-		if (typeof href !== 'string' || href === '' || ABSOLUTE.test(href)) return;
+		if (typeof href !== 'string' || href === '') return;
+
+		const absolute = classifyAbsoluteHref(href);
+		if (absolute.kind === 'unsafe-scheme') {
+			failures.push({
+				code: CHANGELOG_CODES.BAD_LINK,
+				file,
+				line,
+				problem: `\`${href}\` uses the \`${absolute.scheme}\` scheme, which this site will not publish as a link`,
+				remedy: 'use an https:// (or http://) URL, or a path relative to the changelog'
+			});
+			return;
+		}
+		if (absolute.kind === 'allowed') return;
 
 		const hash = href.indexOf('#');
 		const rawTarget = hash === -1 ? href : href.slice(0, hash);

--- a/website/src/lib/docs/README.md
+++ b/website/src/lib/docs/README.md
@@ -44,14 +44,16 @@ A relative link resolves to a **site route** when its target is on the manifest,
 to a **commit-pinned GitHub permalink** when its target exists anywhere else in
 the repository, and **fails the build** otherwise.
 
-| Target                                    | Becomes                                          |
-| ----------------------------------------- | ------------------------------------------------ |
-| on the manifest                           | `/docs<route>`, fragment preserved               |
-| elsewhere in the repository — file        | `…/blob/<sha>/<path>`                            |
-| elsewhere in the repository — directory   | `…/tree/<sha>/<path>`                            |
-| `#fragment`                               | unchanged, checked against this page's headings  |
-| `other.md#fragment`                       | as above, fragment checked against `other.md`    |
-| does not exist, or outside the repository | `BROKEN-LINK` / `ESCAPES-REPO` — the build fails |
+| Target                                       | Becomes                                          |
+| -------------------------------------------- | ------------------------------------------------ |
+| on the manifest                              | `/docs<route>`, fragment preserved               |
+| elsewhere in the repository — file           | `…/blob/<sha>/<path>`                            |
+| elsewhere in the repository — directory      | `…/tree/<sha>/<path>`                            |
+| `#fragment`                                  | unchanged, checked against this page's headings  |
+| `other.md#fragment`                          | as above, fragment checked against `other.md`    |
+| does not exist, or outside the repository    | `BROKEN-LINK` / `ESCAPES-REPO` — the build fails |
+| absolute, `http:`/`https:`/protocol-relative | unchanged, `external: true`                      |
+| absolute, any other scheme                   | `UNSAFE-SCHEME` — the build fails                |
 
 Both "elsewhere in the repository" rows cover unpublished `docs/` pages **and**
 targets outside `docs/` (`../../README.md`, `../../crates/…`) — neither can be a
@@ -72,26 +74,27 @@ Every code stops the build and prints one line:
 `scripts/check_public_docs.sh`. Findings accumulate, so one build reports all of
 them.
 
-| Code                 | Meaning                                                      |
-| -------------------- | ------------------------------------------------------------ |
-| `MISSING-SOURCE`     | A `PAGE` row names a file that does not exist                |
-| `DUP-ROUTE`          | Two rows claim the same URL                                  |
-| `DUP-SOURCE`         | One source published twice                                   |
-| `BAD-ROUTE`          | A route not starting with `/`                                |
-| `ESCAPES-DOCS`       | A source outside `docs/`                                     |
-| `ORPHAN-PAGE`        | A `PAGE` row before any `SECTION`                            |
-| `SECTION-MISMATCH`   | A `PAGE` naming a section it does not follow                 |
-| `DUP-SECTION`        | Two `SECTION` rows with one id                               |
-| `BAD-RECORD`         | Unknown record type, or wrong field count                    |
-| `BROKEN-LINK`        | A relative link resolving to nothing                         |
-| `BROKEN-ANCHOR`      | An anchor naming no heading on the target page               |
-| `ESCAPES-REPO`       | A link resolving outside the repository                      |
-| `ABSOLUTE-PATH-LINK` | A root-relative link, which means different things on GitHub |
-| `EMPTY-LINK`         | A link with no destination                                   |
-| `RAW-HTML`           | An unknown element — see below                               |
-| `OFF-SITE-IMAGE`     | An image this site does not serve                            |
-| `NO-COMMIT-SHA`      | No commit to pin permalinks to                               |
-| `NO-REPO-ROOT`       | No `docs/public-manifest.tsv` above the build directory      |
+| Code                 | Meaning                                                                                                                     |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `MISSING-SOURCE`     | A `PAGE` row names a file that does not exist                                                                               |
+| `DUP-ROUTE`          | Two rows claim the same URL                                                                                                 |
+| `DUP-SOURCE`         | One source published twice                                                                                                  |
+| `BAD-ROUTE`          | A route not starting with `/`                                                                                               |
+| `ESCAPES-DOCS`       | A source outside `docs/`                                                                                                    |
+| `ORPHAN-PAGE`        | A `PAGE` row before any `SECTION`                                                                                           |
+| `SECTION-MISMATCH`   | A `PAGE` naming a section it does not follow                                                                                |
+| `DUP-SECTION`        | Two `SECTION` rows with one id                                                                                              |
+| `BAD-RECORD`         | Unknown record type, or wrong field count                                                                                   |
+| `BROKEN-LINK`        | A relative link resolving to nothing                                                                                        |
+| `BROKEN-ANCHOR`      | An anchor naming no heading on the target page                                                                              |
+| `ESCAPES-REPO`       | A link resolving outside the repository                                                                                     |
+| `ABSOLUTE-PATH-LINK` | A root-relative link, which means different things on GitHub                                                                |
+| `EMPTY-LINK`         | A link with no destination                                                                                                  |
+| `UNSAFE-SCHEME`      | An absolute link using a scheme this site won't publish (`javascript:`, `file:`, …) — only `http:`/`https:` are allowlisted |
+| `RAW-HTML`           | An unknown element — see below                                                                                              |
+| `OFF-SITE-IMAGE`     | An image this site does not serve                                                                                           |
+| `NO-COMMIT-SHA`      | No commit to pin permalinks to                                                                                              |
+| `NO-REPO-ROOT`       | No `docs/public-manifest.tsv` above the build directory                                                                     |
 
 `RAW-HTML` exists because `<crate>` written in prose instead of `` `<crate>` ``
 parses as an unknown HTML element and renders as **nothing** — the text

--- a/website/src/lib/docs/links.test.ts
+++ b/website/src/lib/docs/links.test.ts
@@ -162,13 +162,53 @@ describe('class 5 — links that stop the build', () => {
 });
 
 describe('external links', () => {
-	it('passes http(s) and mailto through untouched', () => {
+	it('passes https:// through untouched', () => {
 		expect(link('https://example.com/x')).toEqual({
 			class: 'external',
 			href: 'https://example.com/x',
 			external: true
 		});
-		expect(link('mailto:someone@example.com').class).toBe('external');
+	});
+
+	it('passes http:// through untouched', () => {
+		expect(link('http://example.com/x')).toEqual({
+			class: 'external',
+			href: 'http://example.com/x',
+			external: true
+		});
+	});
+
+	it('passes a protocol-relative URL through untouched — it carries no scheme of its own', () => {
+		expect(link('//example.com/x')).toEqual({
+			class: 'external',
+			href: '//example.com/x',
+			external: true
+		});
+	});
+});
+
+describe('class 6 — disallowed scheme', () => {
+	it('fails the build on a javascript: link', () => {
+		const found = failure('javascript:alert(1)');
+		expect(found.code).toBe('UNSAFE-SCHEME');
+		expect(found.problem).toContain('javascript:');
+		expect(found.remedy).toContain('https://');
+	});
+
+	it('fails the build on a file:// link', () => {
+		const found = failure('file:///etc/passwd');
+		expect(found.code).toBe('UNSAFE-SCHEME');
+		expect(found.problem).toContain('file:');
+	});
+
+	it('fails the build on mailto:, which this site does not allowlist', () => {
+		expect(failure('mailto:someone@example.com').code).toBe('UNSAFE-SCHEME');
+	});
+
+	it('fails the build on data: and vbscript: as well as any unrecognised scheme', () => {
+		for (const href of ['data:text/html,<script>1</script>', 'vbscript:msgbox(1)', 'ftp://x/y']) {
+			expect(failure(href).code, href).toBe('UNSAFE-SCHEME');
+		}
 	});
 });
 

--- a/website/src/lib/docs/links.ts
+++ b/website/src/lib/docs/links.ts
@@ -22,6 +22,11 @@
  *   4. `other.md#fragment`          → case 1 or 2, and when case 1 the fragment
  *      is checked against the TARGET page's headings
  *   5. missing, or outside the repo → BROKEN-LINK / ESCAPES-REPO, build fails
+ *   6. absolute with a disallowed scheme (`javascript:`, `file:`, `data:`, …)
+ *      → UNSAFE-SCHEME, build fails. Committing to a published doc or changelog
+ *      is the only way to reach this site's readers with one, so the guard is
+ *      against a mistake or a compromised commit, not an untrusted visitor —
+ *      still worth stopping the way a broken relative link already does.
  *
  * Permalink rather than dropping the link: dropping keeps the sentence ("see
  * `docs/specs/foo.md`") while removing every way to act on it, so the reader is
@@ -32,9 +37,13 @@
  * What: `resolveLink`, a pure function from one raw href plus context to either
  * a resolved destination or a `DocFailure`. It performs no I/O; existence is a
  * caller-supplied probe, which is what makes every class testable from fixtures.
+ * `classifyAbsoluteHref` is the scheme allowlist behind class 6 — exported so
+ * the changelog reader (`../changelog/parse.ts`) applies the identical check
+ * rather than carrying its own copy.
  *
  * Test: `links.test.ts` — one case per class above, plus the anchor cases and
- * the two build-failing ones.
+ * the build-failing ones. `../changelog/parse.test.ts` covers the same check
+ * through the changelog reader.
  */
 
 import path from 'node:path';
@@ -71,8 +80,41 @@ export interface LinkContext {
 
 export type LinkOutcome = { link: ResolvedLink } | { failure: DocFailure };
 
-/** Anything with a scheme, or a protocol-relative URL, leaves the repository. */
-const ABSOLUTE = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+/** Matches a leading `scheme:`, capturing the scheme (RFC 3986 `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`). */
+const SCHEME = /^([a-z][a-z0-9+.-]*):/i;
+
+/**
+ * Schemes this site will render as a live, followable href. Everything else —
+ * `javascript:`, `file:`, `data:`, `vbscript:`, `mailto:`, any unknown scheme —
+ * fails the build rather than being published. This is an ALLOWLIST, not a
+ * denylist: a scheme is safe only once someone decided it is, never by default.
+ */
+const ALLOWED_SCHEMES = new Set(['http:', 'https:']);
+
+export type AbsoluteHref =
+	| { kind: 'not-absolute' }
+	/** Protocol-relative (`//host/…`) or an allowlisted scheme. */
+	| { kind: 'allowed' }
+	| { kind: 'unsafe-scheme'; scheme: string };
+
+/**
+ * Why: see class 6 in the module header — the single scheme check both the
+ * doc reader and the changelog reader (`../changelog/parse.ts`) apply, so a
+ * scheme decision made here never drifts between the two.
+ * What: classifies a raw href as scheme-less/relative, absolute-and-safe, or
+ * absolute-with-a-scheme-this-site-refuses-to-publish. A protocol-relative URL
+ * has no scheme of its own — it inherits whatever scheme served the page,
+ * which this site only ever serves as https — so it is `allowed` without an
+ * allowlist lookup.
+ * Test: `links.test.ts`, `../changelog/parse.test.ts`.
+ */
+export function classifyAbsoluteHref(href: string): AbsoluteHref {
+	if (href.startsWith('//')) return { kind: 'allowed' };
+	const match = SCHEME.exec(href);
+	if (!match) return { kind: 'not-absolute' };
+	const scheme = `${match[1].toLowerCase()}:`;
+	return ALLOWED_SCHEMES.has(scheme) ? { kind: 'allowed' } : { kind: 'unsafe-scheme', scheme };
+}
 
 function fail(
 	ctx: LinkContext,
@@ -101,8 +143,17 @@ export function resolveLink(raw: string, ctx: LinkContext): LinkOutcome {
 		);
 	}
 
-	if (ABSOLUTE.test(href)) {
+	const absolute = classifyAbsoluteHref(href);
+	if (absolute.kind === 'allowed') {
 		return { link: { class: 'external', href, external: true } };
+	}
+	if (absolute.kind === 'unsafe-scheme') {
+		return fail(
+			ctx,
+			'UNSAFE-SCHEME',
+			`\`${href}\` uses the \`${absolute.scheme}\` scheme, which this site will not publish as a link`,
+			'use an https:// (or http://) URL, or a path relative to this file'
+		);
 	}
 
 	if (href.startsWith('#')) {


### PR DESCRIPTION
Closes #5256

## Defect

`website/src/lib/docs/links.ts`'s `ABSOLUTE` regex matched any URL scheme and passed it through unrewritten, so `[click me](javascript:alert(1))` or `file:///etc/passwd` committed to a published doc or flagship CHANGELOG would render as a live href on the site. `website/src/lib/changelog/parse.ts` carried an identical copy of the same regex.

Threat model, stated honestly: this needs commit access to a published doc or changelog — not a path from an untrusted visitor. It's a guard against a mistake or compromised commit, not a live vulnerability. Worth closing because the build already fails on an unresolvable relative link; a `javascript:` URL sailing through unchecked was the actual asymmetry.

## Evidence

Red (defect present, fix reverted, new tests only):

```
❯ |unit| src/lib/docs/links.test.ts (24 tests | 4 failed)
    × fails the build on a javascript: link
    × fails the build on a file:// link
    × fails the build on mailto:, which this site does not allowlist
    × fails the build on data: and vbscript: as well as any unrecognised scheme
❯ |unit| src/lib/changelog/parse.test.ts (32 tests | 2 failed)
    × fails the build on a javascript: link, the same as any other bad link
    × fails the build on a file:// link
 Test Files  2 failed (2)
      Tests  6 failed | 50 passed (56)
```

Green (fix restored):

```
 Test Files  2 passed (2)
      Tests  56 passed (56)
```

Full gate chain, from inside `website/`:

```
pnpm check → 487 FILES 0 ERRORS 0 WARNINGS
pnpm lint  → prettier + eslint clean
pnpm test  → Test Files 14 passed (14), Tests 239 passed | 1 skipped (240)
pnpm build → succeeds (real corpus has no non-http(s) scheme link today)
```

Website tests don't run in CI (#5200) — the above is local output, not a CI artifact.

## Resolution

- Added `classifyAbsoluteHref` to `website/src/lib/docs/links.ts`: allowlists `http:`/`https:` (and protocol-relative `//host/…`, which carries no scheme of its own); everything else is `unsafe-scheme`.
- `resolveLink` now fails the build with `UNSAFE-SCHEME` on a disallowed scheme.
- `website/src/lib/changelog/parse.ts` dropped its duplicate `ABSOLUTE` regex and imports the same `classifyAbsoluteHref`, failing with `CHANGELOG-BAD-LINK` (its existing catch-all) on a disallowed scheme — one implementation, both readers.
- Anchor-only, site-relative, and protocol-relative link handling is unchanged in both readers (confirmed before/after).
- Updated `website/src/lib/docs/README.md`'s link-rule and failure-code tables.
- Nothing under `crates/` changed — no changelog fragment needed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
