### PR TITLE
fix(gui): build the Svelte bundle in build.rs so a clean clone compiles

### DIFF
--- a/crates/trusty-agents/changelog.d/4699-agents-ui-build-dist.md
+++ b/crates/trusty-agents/changelog.d/4699-agents-ui-build-dist.md
@@ -1,0 +1,11 @@
+Fixed
+
+- **`trusty-agents-ui`'s `build.rs` now builds the Svelte bundle**, so a clean
+  clone compiles. Its `frontendDist` (`../dist`) is gitignored and nothing built
+  it, so `tauri::generate_context!()` panicked with a bare "this path doesn't
+  exist". This crate enables `tauri/custom-protocol` by default, which is what
+  turns that check on for every Tauri crate in a workspace-wide build — it
+  failed on its own `-p` build too. `build.rs` now runs `pnpm install` +
+  `pnpm run build`, honours `SKIP_UI_BUILD=1`, and aborts loudly if pnpm is
+  missing or the build produces no `index.html`
+  ([#4699](https://github.com/bobmatnyc/trusty-tools/issues/4699))

--- a/crates/trusty-agents/ui/src-tauri/build.rs
+++ b/crates/trusty-agents/ui/src-tauri/build.rs
@@ -1,3 +1,257 @@
+//! build.rs — builds the Svelte frontend bundle, then runs `tauri_build::build()`.
+//!
+//! Why: `src/main.rs`'s `tauri::generate_context!()` embeds `../dist` (this
+//! crate lives in `src-tauri/`, so that is `crates/trusty-agents/ui/dist`), the
+//! `frontendDist` declared in `tauri.conf.json`. That directory is gitignored,
+//! so on a fresh clone or worktree it does not exist and the proc macro panics
+//! with a bare "this path doesn't exist" — which took down `cargo test
+//! --workspace` and `cargo clippy --workspace --all-targets` for the ENTIRE
+//! workspace, since neither reaches a single test before the Tauri crates fail
+//! to compile (#4699). Nothing built the bundle; it existed only where someone
+//! had run pnpm by hand.
+//!
+//! This crate is the one that turns the check on for everybody: it enables
+//! `tauri/custom-protocol` by default, and resolver-v2 feature unification
+//! propagates that to every Tauri crate in a workspace-wide build. Its own
+//! `-p` build therefore fails on its own, with no extra feature flag.
+//!
+//! What: emits `cargo:rerun-if-changed` for the UI sources, then runs
+//! `pnpm install` + `pnpm run build` in the parent `ui/` directory unless
+//! `SKIP_UI_BUILD=1` is set. Every failure path — no usable pnpm, a failed
+//! install, a failed build, or a build that exits 0 without producing
+//! `../dist/index.html` — aborts the crate build with a message naming this
+//! crate and the `SKIP_UI_BUILD=1` escape hatch. A stale or empty `dist/` is
+//! never embedded silently.
+//!
+//! NOTE: the block between the CANONICAL BLOCK markers is kept byte-identical
+//! across all three Tauri crates — this one, `crates/trusty-code-gui/build.rs`,
+//! and `crates/trusty-mpm-gui/build.rs`; `scripts/check_buildrs_sync.sh`
+//! asserts it. THIS crate is edition 2021, which is why the block uses no
+//! let-chains. It is deliberately NOT the block the four UI-embedding daemon
+//! crates share (`trusty-memory`, `trusty-analyze`, `trusty-console`,
+//! `trusty-search`): those degrade to a placeholder on any failure, which is
+//! right for an optional web surface and wrong for a desktop app whose entire
+//! window is the bundle.
+//!
+//! Test: `cargo check -p trusty-agents-ui` on a tree with no
+//! `crates/trusty-agents/ui/dist` — the #4699 reproducer. It panics before this
+//! change and builds the real bundle after it.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Names this crate in every diagnostic the shared block emits.
+const CRATE_NAME: &str = "trusty-agents-ui";
+
 fn main() {
-    tauri_build::build()
+    let crate_root = std::path::PathBuf::from(
+        std::env::var("CARGO_MANIFEST_DIR").expect("cargo always sets CARGO_MANIFEST_DIR"),
+    );
+    // Unlike the other two Tauri crates, this manifest sits in `src-tauri/`
+    // inside the frontend package, so the UI root is the PARENT directory.
+    let ui_dir = crate_root
+        .parent()
+        .expect("crate root always has a parent")
+        .to_path_buf();
+    let dist_dir = ui_dir.join("dist");
+
+    println!("cargo:rerun-if-env-changed=SKIP_UI_BUILD");
+    // Only paths that EXIST may be declared: cargo treats a declared-but-absent
+    // path as changed, so one stale entry re-runs the whole pnpm build on every
+    // `cargo check`. `vitest.config.ts`, `playwright.config.ts` and `tests/` are
+    // omitted for the same reason in reverse — they exist, but feed `pnpm test`,
+    // not the `pnpm build` this script runs.
+    for rel in [
+        "../package.json",
+        "../pnpm-lock.yaml",
+        "../pnpm-workspace.yaml",
+        "../index.html",
+        "../vite.config.ts",
+        "../svelte.config.js",
+        "../tailwind.config.js",
+        "../postcss.config.js",
+        "../tsconfig.json",
+        "../src",
+        "../public",
+    ] {
+        println!("cargo:rerun-if-changed={rel}");
+    }
+    // `../dist` is deliberately NOT declared. It is this script's own output,
+    // and cargo's staleness reference is `invoked.timestamp`, stamped BEFORE
+    // the script runs — so declaring it makes the script dirty its own
+    // fingerprint and re-run the pnpm build on every `cargo check` (measured:
+    // 2.5s each). The residual is that deleting `dist/` by hand while `target/`
+    // stays warm does not re-trigger this script; `cargo clean` or a touch of
+    // any UI source recovers.
+
+    // #4699: build the bundle before tauri_build, so a broken UI fails here
+    // rather than as an opaque proc-macro panic in src/main.rs.
+    build_tauri_ui(&ui_dir, &dist_dir, CRATE_NAME);
+
+    tauri_build::build();
 }
+
+// ── TAURI UI CANONICAL BLOCK BEGIN (kept in sync by scripts/check_buildrs_sync.sh) ──
+
+/// Build the Tauri frontend bundle into `dist_dir`, or abort the crate build.
+///
+/// Why: `frontendDist` must exist and be current before `generate_context!()`
+/// runs. Producing it here is what makes a clean clone compile (#4699); failing
+/// loudly is what keeps a half-built bundle from being embedded and shipped.
+/// What: honours `SKIP_UI_BUILD=1`, then requires pnpm and runs
+/// `install` + `run build` inside `ui_dir`. Presence of `dist_dir` is never
+/// treated as proof it is current — the build always runs, and cargo's
+/// `rerun-if-changed` directives are what keep it from running needlessly.
+/// Test: `cargo check -p <gui-crate> --features tauri/custom-protocol` with no
+/// `ui/dist` present; and the same command with `SKIP_UI_BUILD=1`.
+fn build_tauri_ui(ui_dir: &Path, dist_dir: &Path, crate_name: &str) {
+    let index = dist_dir.join("index.html");
+
+    // Step 1: the documented escape hatch for a host with no JS toolchain.
+    // It still has to leave something at `frontendDist` or the proc macro
+    // panics, so write a placeholder and say plainly that the UI is not real.
+    if std::env::var("SKIP_UI_BUILD").as_deref() == Ok("1") {
+        if !index.exists() {
+            println!(
+                "cargo:warning={crate_name}: SKIP_UI_BUILD=1 and {dist} is empty — \
+                 embedding a PLACEHOLDER UI. The resulting binary will not show the \
+                 real interface. Run `pnpm --dir ui install && pnpm --dir ui build` \
+                 and rebuild without SKIP_UI_BUILD to get a working app.",
+                dist = dist_dir.display()
+            );
+            write_placeholder(dist_dir, crate_name);
+        }
+        return;
+    }
+
+    // Step 2: no package.json means the checkout is incomplete. These crates are
+    // `publish = false`, so there is no extracted-tarball case to tolerate.
+    if !ui_dir.join("package.json").exists() {
+        fail(
+            crate_name,
+            &format!("{ui}/package.json is missing.", ui = ui_dir.display()),
+        );
+    }
+
+    // Step 3: pnpm is required, and is probed FROM `ui_dir` — corepack resolves
+    // the `packageManager` pin relative to the working directory, so a probe run
+    // from the workspace root selects a different pnpm (or fails outright).
+    if !probe_ok("pnpm", ui_dir) {
+        fail(
+            crate_name,
+            "`pnpm --version` did not succeed in the `ui/` directory, so pnpm is \
+             unavailable or unusable there.",
+        );
+    }
+
+    // Step 4: install, then build. A non-zero exit from either aborts; neither
+    // result is discarded.
+    let mut install_args = vec!["install"];
+    if ui_dir.join("pnpm-lock.yaml").exists() {
+        install_args.push("--frozen-lockfile");
+    }
+    run(crate_name, &install_args, ui_dir);
+    run(crate_name, &["run", "build"], ui_dir);
+
+    // Step 5: trust the artefact, not the exit code. A build that reports
+    // success but emits no entry point is a failed build.
+    if !index.exists() {
+        fail(
+            crate_name,
+            &format!(
+                "`pnpm run build` exited 0 but produced no {index}.",
+                index = index.display()
+            ),
+        );
+    }
+}
+
+/// Run a pnpm subcommand in `cwd`, aborting the crate build unless it exits 0.
+///
+/// Why: a swallowed `Command` result would let compilation proceed against a
+/// stale or absent bundle — the exact failure mode #4699 asks this script not
+/// to reintroduce.
+/// What: spawns `pnpm <args>` with stdio inherited (so pnpm's own diagnostics
+/// reach the build log) and routes both a non-zero status and a spawn error
+/// into `fail`.
+/// Test: covered by the `pnpm run build` leg of `build_tauri_ui`.
+fn run(crate_name: &str, args: &[&str], cwd: &Path) {
+    match Command::new("pnpm").args(args).current_dir(cwd).status() {
+        Ok(status) if status.success() => {}
+        Ok(status) => fail(
+            crate_name,
+            &format!("`pnpm {}` failed ({status}).", args.join(" ")),
+        ),
+        Err(e) => fail(
+            crate_name,
+            &format!("could not run `pnpm {}`: {e}", args.join(" ")),
+        ),
+    }
+}
+
+/// Report whether `program --version` succeeds when run from `cwd`.
+fn probe_ok(program: &str, cwd: &Path) -> bool {
+    Command::new(program)
+        .arg("--version")
+        .current_dir(cwd)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Write the stub entry point used only under `SKIP_UI_BUILD=1`.
+///
+/// Why: the escape hatch has to leave `frontendDist` populated or the proc
+/// macro panics anyway, defeating the point of the opt-out.
+/// What: creates the parent directory and writes a minimal HTML document that
+/// states, in the window itself, that the real UI was not built. Filesystem
+/// errors abort rather than being discarded.
+/// Test: `SKIP_UI_BUILD=1 cargo check -p <gui-crate>` on a tree with no
+/// `ui/dist` leaves `ui/dist/index.html` in place.
+///
+/// Deliberately free of let-chains: this block is shared verbatim with
+/// `trusty-agents-ui`, which is edition 2021.
+fn write_placeholder(dist_dir: &Path, crate_name: &str) {
+    if let Err(e) = std::fs::create_dir_all(dist_dir) {
+        fail(
+            crate_name,
+            &format!("could not create {}: {e}", dist_dir.display()),
+        );
+    }
+    let index = dist_dir.join("index.html");
+    let html = format!(
+        "<!doctype html><html><body><p>{crate_name}: the UI bundle was not built \
+         (SKIP_UI_BUILD=1). Run <code>pnpm --dir ui install &amp;&amp; pnpm --dir ui \
+         build</code> and rebuild.</p></body></html>"
+    );
+    if let Err(e) = std::fs::write(&index, html) {
+        fail(
+            crate_name,
+            &format!("could not write {}: {e}", index.display()),
+        );
+    }
+}
+
+/// Abort the crate build with a diagnostic that names the crate and the fix.
+///
+/// Why: the failure this replaces was a proc-macro panic pointing at
+/// `src/lib.rs` and complaining about a path, with no hint that a frontend
+/// build was missing — several agents rediscovered the workaround
+/// independently before #4699 was filed.
+/// What: panics, which cargo surfaces as "failed to run custom build command
+/// for <crate>" with this text attached.
+/// Test: every failure leg of `build_tauri_ui` routes here.
+fn fail(crate_name: &str, detail: &str) -> ! {
+    let msg = format!(
+        "\n{crate_name}: could not build the frontend bundle in `ui/`.\n\
+         {detail}\n\
+         `tauri.conf.json` points `frontendDist` at that bundle, so without it \
+         `tauri::generate_context!()` fails with a bare \"this path doesn't \
+         exist\" panic (#4699).\n\
+         Fix: install pnpm (https://pnpm.io/installation) and rebuild, or set \
+         SKIP_UI_BUILD=1 to compile against a placeholder UI.\n"
+    );
+    panic!("{msg}");
+}
+
+// ── TAURI UI CANONICAL BLOCK END ──

--- a/crates/trusty-code-gui/build.rs
+++ b/crates/trusty-code-gui/build.rs
@@ -1,3 +1,249 @@
+//! build.rs — builds the Svelte frontend bundle, then runs `tauri_build::build()`.
+//!
+//! Why: `src/lib.rs`'s `tauri::generate_context!()` embeds `ui/dist`, the
+//! `frontendDist` declared in `tauri.conf.json`. `ui/dist` is gitignored, so on
+//! a fresh clone or worktree it does not exist and the proc macro panics with a
+//! bare "this path doesn't exist" — which took down `cargo test --workspace`
+//! and `cargo clippy --workspace --all-targets` for the ENTIRE workspace, since
+//! neither reaches a single test before this crate fails to compile (#4699).
+//! Nothing built the bundle; it existed only where someone had run pnpm by hand.
+//!
+//! The check fires only when `tauri`'s `custom-protocol` feature is on. A bare
+//! `cargo check -p trusty-code-gui` leaves it off, so the macro falls back to
+//! `devUrl` and passes; a workspace-wide build unifies features with
+//! `trusty-agents-ui` (which enables `custom-protocol` by default) and turns it
+//! on for every member. That is why the failure looked workspace-only.
+//!
+//! What: emits `cargo:rerun-if-changed` for the UI sources, then runs
+//! `pnpm install` + `pnpm run build` inside `ui/` unless `SKIP_UI_BUILD=1` is
+//! set. Every failure path — no usable pnpm, a failed install, a failed build,
+//! or a build that exits 0 without producing `ui/dist/index.html` — aborts the
+//! crate build with a message naming this crate and the `SKIP_UI_BUILD=1`
+//! escape hatch. A stale or empty `dist/` is never embedded silently.
+//!
+//! NOTE: the block between the CANONICAL BLOCK markers is kept byte-identical
+//! across all three Tauri crates — this one, `crates/trusty-mpm-gui/build.rs`,
+//! and `crates/trusty-agents/ui/src-tauri/build.rs`;
+//! `scripts/check_buildrs_sync.sh` asserts it. One of those is edition 2021, so
+//! the block uses no let-chains. It is deliberately NOT the block the four
+//! UI-embedding daemon crates share (`trusty-memory`, `trusty-analyze`,
+//! `trusty-console`, `trusty-search`): those degrade to a placeholder on any
+//! failure, which is right for an optional web surface and wrong for a desktop
+//! app whose entire window is the bundle.
+//!
+//! Test: `cargo check -p trusty-code-gui --features tauri/custom-protocol` on a
+//! tree with no `ui/dist` — the #4699 reproducer. It panics before this change
+//! and builds the real bundle after it.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Names this crate in every diagnostic the shared block emits.
+const CRATE_NAME: &str = "trusty-code-gui";
+
 fn main() {
-    tauri_build::build()
+    let crate_root = std::path::PathBuf::from(
+        std::env::var("CARGO_MANIFEST_DIR").expect("cargo always sets CARGO_MANIFEST_DIR"),
+    );
+    let ui_dir = crate_root.join("ui");
+    let dist_dir = ui_dir.join("dist");
+
+    println!("cargo:rerun-if-env-changed=SKIP_UI_BUILD");
+    // Only paths that EXIST may be declared: cargo treats a declared-but-absent
+    // path as changed, so one stale entry re-runs the whole pnpm build on every
+    // `cargo check`. `vitest.config.ts` is omitted for the same reason in
+    // reverse — it exists but feeds `pnpm test`, not `pnpm build`.
+    for rel in [
+        "ui/package.json",
+        "ui/pnpm-lock.yaml",
+        "ui/pnpm-workspace.yaml",
+        "ui/index.html",
+        "ui/vite.config.ts",
+        "ui/svelte.config.js",
+        "ui/tailwind.config.js",
+        "ui/postcss.config.js",
+        "ui/tsconfig.json",
+        "ui/src",
+        "ui/public",
+    ] {
+        println!("cargo:rerun-if-changed={rel}");
+    }
+    // `ui/dist` is deliberately NOT declared. It is this script's own output,
+    // and cargo's staleness reference is `invoked.timestamp`, stamped BEFORE
+    // the script runs — so declaring it makes the script dirty its own
+    // fingerprint and re-run the pnpm build on every `cargo check` (measured:
+    // 2.5s each). The residual is that deleting `ui/dist` by hand while
+    // `target/` stays warm does not re-trigger this script; `cargo clean` or a
+    // touch of any UI source recovers.
+
+    // #4699: build the bundle before tauri_build, so a broken UI fails here
+    // rather than as an opaque proc-macro panic in src/lib.rs.
+    build_tauri_ui(&ui_dir, &dist_dir, CRATE_NAME);
+
+    tauri_build::build();
 }
+
+// ── TAURI UI CANONICAL BLOCK BEGIN (kept in sync by scripts/check_buildrs_sync.sh) ──
+
+/// Build the Tauri frontend bundle into `dist_dir`, or abort the crate build.
+///
+/// Why: `frontendDist` must exist and be current before `generate_context!()`
+/// runs. Producing it here is what makes a clean clone compile (#4699); failing
+/// loudly is what keeps a half-built bundle from being embedded and shipped.
+/// What: honours `SKIP_UI_BUILD=1`, then requires pnpm and runs
+/// `install` + `run build` inside `ui_dir`. Presence of `dist_dir` is never
+/// treated as proof it is current — the build always runs, and cargo's
+/// `rerun-if-changed` directives are what keep it from running needlessly.
+/// Test: `cargo check -p <gui-crate> --features tauri/custom-protocol` with no
+/// `ui/dist` present; and the same command with `SKIP_UI_BUILD=1`.
+fn build_tauri_ui(ui_dir: &Path, dist_dir: &Path, crate_name: &str) {
+    let index = dist_dir.join("index.html");
+
+    // Step 1: the documented escape hatch for a host with no JS toolchain.
+    // It still has to leave something at `frontendDist` or the proc macro
+    // panics, so write a placeholder and say plainly that the UI is not real.
+    if std::env::var("SKIP_UI_BUILD").as_deref() == Ok("1") {
+        if !index.exists() {
+            println!(
+                "cargo:warning={crate_name}: SKIP_UI_BUILD=1 and {dist} is empty — \
+                 embedding a PLACEHOLDER UI. The resulting binary will not show the \
+                 real interface. Run `pnpm --dir ui install && pnpm --dir ui build` \
+                 and rebuild without SKIP_UI_BUILD to get a working app.",
+                dist = dist_dir.display()
+            );
+            write_placeholder(dist_dir, crate_name);
+        }
+        return;
+    }
+
+    // Step 2: no package.json means the checkout is incomplete. These crates are
+    // `publish = false`, so there is no extracted-tarball case to tolerate.
+    if !ui_dir.join("package.json").exists() {
+        fail(
+            crate_name,
+            &format!("{ui}/package.json is missing.", ui = ui_dir.display()),
+        );
+    }
+
+    // Step 3: pnpm is required, and is probed FROM `ui_dir` — corepack resolves
+    // the `packageManager` pin relative to the working directory, so a probe run
+    // from the workspace root selects a different pnpm (or fails outright).
+    if !probe_ok("pnpm", ui_dir) {
+        fail(
+            crate_name,
+            "`pnpm --version` did not succeed in the `ui/` directory, so pnpm is \
+             unavailable or unusable there.",
+        );
+    }
+
+    // Step 4: install, then build. A non-zero exit from either aborts; neither
+    // result is discarded.
+    let mut install_args = vec!["install"];
+    if ui_dir.join("pnpm-lock.yaml").exists() {
+        install_args.push("--frozen-lockfile");
+    }
+    run(crate_name, &install_args, ui_dir);
+    run(crate_name, &["run", "build"], ui_dir);
+
+    // Step 5: trust the artefact, not the exit code. A build that reports
+    // success but emits no entry point is a failed build.
+    if !index.exists() {
+        fail(
+            crate_name,
+            &format!(
+                "`pnpm run build` exited 0 but produced no {index}.",
+                index = index.display()
+            ),
+        );
+    }
+}
+
+/// Run a pnpm subcommand in `cwd`, aborting the crate build unless it exits 0.
+///
+/// Why: a swallowed `Command` result would let compilation proceed against a
+/// stale or absent bundle — the exact failure mode #4699 asks this script not
+/// to reintroduce.
+/// What: spawns `pnpm <args>` with stdio inherited (so pnpm's own diagnostics
+/// reach the build log) and routes both a non-zero status and a spawn error
+/// into `fail`.
+/// Test: covered by the `pnpm run build` leg of `build_tauri_ui`.
+fn run(crate_name: &str, args: &[&str], cwd: &Path) {
+    match Command::new("pnpm").args(args).current_dir(cwd).status() {
+        Ok(status) if status.success() => {}
+        Ok(status) => fail(
+            crate_name,
+            &format!("`pnpm {}` failed ({status}).", args.join(" ")),
+        ),
+        Err(e) => fail(
+            crate_name,
+            &format!("could not run `pnpm {}`: {e}", args.join(" ")),
+        ),
+    }
+}
+
+/// Report whether `program --version` succeeds when run from `cwd`.
+fn probe_ok(program: &str, cwd: &Path) -> bool {
+    Command::new(program)
+        .arg("--version")
+        .current_dir(cwd)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Write the stub entry point used only under `SKIP_UI_BUILD=1`.
+///
+/// Why: the escape hatch has to leave `frontendDist` populated or the proc
+/// macro panics anyway, defeating the point of the opt-out.
+/// What: creates the parent directory and writes a minimal HTML document that
+/// states, in the window itself, that the real UI was not built. Filesystem
+/// errors abort rather than being discarded.
+/// Test: `SKIP_UI_BUILD=1 cargo check -p <gui-crate>` on a tree with no
+/// `ui/dist` leaves `ui/dist/index.html` in place.
+///
+/// Deliberately free of let-chains: this block is shared verbatim with
+/// `trusty-agents-ui`, which is edition 2021.
+fn write_placeholder(dist_dir: &Path, crate_name: &str) {
+    if let Err(e) = std::fs::create_dir_all(dist_dir) {
+        fail(
+            crate_name,
+            &format!("could not create {}: {e}", dist_dir.display()),
+        );
+    }
+    let index = dist_dir.join("index.html");
+    let html = format!(
+        "<!doctype html><html><body><p>{crate_name}: the UI bundle was not built \
+         (SKIP_UI_BUILD=1). Run <code>pnpm --dir ui install &amp;&amp; pnpm --dir ui \
+         build</code> and rebuild.</p></body></html>"
+    );
+    if let Err(e) = std::fs::write(&index, html) {
+        fail(
+            crate_name,
+            &format!("could not write {}: {e}", index.display()),
+        );
+    }
+}
+
+/// Abort the crate build with a diagnostic that names the crate and the fix.
+///
+/// Why: the failure this replaces was a proc-macro panic pointing at
+/// `src/lib.rs` and complaining about a path, with no hint that a frontend
+/// build was missing — several agents rediscovered the workaround
+/// independently before #4699 was filed.
+/// What: panics, which cargo surfaces as "failed to run custom build command
+/// for <crate>" with this text attached.
+/// Test: every failure leg of `build_tauri_ui` routes here.
+fn fail(crate_name: &str, detail: &str) -> ! {
+    let msg = format!(
+        "\n{crate_name}: could not build the frontend bundle in `ui/`.\n\
+         {detail}\n\
+         `tauri.conf.json` points `frontendDist` at that bundle, so without it \
+         `tauri::generate_context!()` fails with a bare \"this path doesn't \
+         exist\" panic (#4699).\n\
+         Fix: install pnpm (https://pnpm.io/installation) and rebuild, or set \
+         SKIP_UI_BUILD=1 to compile against a placeholder UI.\n"
+    );
+    panic!("{msg}");
+}
+
+// ── TAURI UI CANONICAL BLOCK END ──

--- a/crates/trusty-code-gui/capabilities/default.json
+++ b/crates/trusty-code-gui/capabilities/default.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Grants nothing, deliberately. This crate has always run with zero ACL permissions (its own #[tauri::command] handlers are outside the ACL) and still does; the file exists so the `capabilities` directory tauri_build declares under cargo:rerun-if-changed is present. See build.rs and #4699. Add entries only as a deliberate permission grant.",
+  "windows": ["main"],
+  "permissions": []
+}

--- a/crates/trusty-code-gui/changelog.d/4699-build-ui-dist.md
+++ b/crates/trusty-code-gui/changelog.d/4699-build-ui-dist.md
@@ -1,0 +1,17 @@
+Fixed
+
+- **`build.rs` now builds the Svelte bundle, so a clean clone compiles.**
+  `tauri.conf.json` points `frontendDist` at `ui/dist`, which is gitignored and
+  which nothing built — so `tauri::generate_context!()` panicked with a bare
+  "this path doesn't exist" and took down `cargo test --workspace` and
+  `cargo clippy --workspace` for every crate, not just this one. `build.rs` now
+  runs `pnpm install` + `pnpm run build` in `ui/`, honours `SKIP_UI_BUILD=1`,
+  and aborts loudly (naming the crate and the escape hatch) if pnpm is missing
+  or the build produces no `index.html`
+  ([#4699](https://github.com/bobmatnyc/trusty-tools/issues/4699))
+- **Added `capabilities/default.json`.** `tauri_build` unconditionally declares
+  `cargo:rerun-if-changed=capabilities`; with no such directory cargo treated
+  the build script as stale on every invocation and re-ran it — and now the
+  pnpm build — on every `cargo check`. The file grants no permissions, so
+  runtime behaviour is unchanged
+  ([#4699](https://github.com/bobmatnyc/trusty-tools/issues/4699))

--- a/crates/trusty-code-gui/gen/schemas/capabilities.json
+++ b/crates/trusty-code-gui/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{}
+{"default":{"identifier":"default","description":"Grants nothing, deliberately. This crate has always run with zero ACL permissions (its own #[tauri::command] handlers are outside the ACL) and still does; the file exists so the `capabilities` directory tauri_build declares under cargo:rerun-if-changed is present. See build.rs and #4699. Add entries only as a deliberate permission grant.","local":true,"windows":["main"],"permissions":[]}}

--- a/crates/trusty-mpm-gui/build.rs
+++ b/crates/trusty-mpm-gui/build.rs
@@ -1,3 +1,250 @@
+//! build.rs — builds the Svelte frontend bundle, then runs `tauri_build::build()`.
+//!
+//! Why: `src/lib.rs`'s `tauri::generate_context!()` embeds `ui/dist`, the
+//! `frontendDist` declared in `tauri.conf.json`. `ui/dist` is gitignored, so on
+//! a fresh clone or worktree it does not exist and the proc macro panics with a
+//! bare "this path doesn't exist" — which took down `cargo test --workspace`
+//! and `cargo clippy --workspace --all-targets` for the ENTIRE workspace, since
+//! neither reaches a single test before the Tauri crates fail to compile
+//! (#4699). Nothing built the bundle; it existed only where someone had run
+//! pnpm by hand.
+//!
+//! The check fires only when `tauri`'s `custom-protocol` feature is on. A bare
+//! `cargo check -p trusty-mpm-gui` leaves it off, so the macro falls back to
+//! `devUrl` and passes; a workspace-wide build unifies features with
+//! `trusty-agents-ui` (which enables `custom-protocol` by default) and turns it
+//! on for every member. That is why the failure looked workspace-only.
+//!
+//! What: emits `cargo:rerun-if-changed` for the UI sources, then runs
+//! `pnpm install` + `pnpm run build` inside `ui/` unless `SKIP_UI_BUILD=1` is
+//! set. Every failure path — no usable pnpm, a failed install, a failed build,
+//! or a build that exits 0 without producing `ui/dist/index.html` — aborts the
+//! crate build with a message naming this crate and the `SKIP_UI_BUILD=1`
+//! escape hatch. A stale or empty `dist/` is never embedded silently.
+//!
+//! NOTE: the block between the CANONICAL BLOCK markers is kept byte-identical
+//! across all three Tauri crates — this one, `crates/trusty-code-gui/build.rs`,
+//! and `crates/trusty-agents/ui/src-tauri/build.rs`;
+//! `scripts/check_buildrs_sync.sh` asserts it. One of those is edition 2021, so
+//! the block uses no let-chains. It is deliberately NOT the block the four
+//! UI-embedding daemon crates share (`trusty-memory`, `trusty-analyze`,
+//! `trusty-console`, `trusty-search`): those degrade to a placeholder on any
+//! failure, which is right for an optional web surface and wrong for a desktop
+//! app whose entire window is the bundle.
+//!
+//! Test: `cargo check -p trusty-mpm-gui --features tauri/custom-protocol` on a
+//! tree with no `ui/dist` — the #4699 reproducer. It panics before this change
+//! and builds the real bundle after it.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Names this crate in every diagnostic the shared block emits.
+const CRATE_NAME: &str = "trusty-mpm-gui";
+
 fn main() {
-    tauri_build::build()
+    let crate_root = std::path::PathBuf::from(
+        std::env::var("CARGO_MANIFEST_DIR").expect("cargo always sets CARGO_MANIFEST_DIR"),
+    );
+    let ui_dir = crate_root.join("ui");
+    let dist_dir = ui_dir.join("dist");
+
+    println!("cargo:rerun-if-env-changed=SKIP_UI_BUILD");
+    // Only paths that EXIST may be declared: cargo treats a declared-but-absent
+    // path as changed, so one stale entry re-runs the whole pnpm build on every
+    // `cargo check`. `vitest.config.ts`, `vite.web.config.ts` and `web.html` are
+    // omitted for the same reason in reverse — they exist, but feed `pnpm test`
+    // and `pnpm build:web`, not the `pnpm build` this script runs.
+    for rel in [
+        "ui/package.json",
+        "ui/pnpm-lock.yaml",
+        "ui/pnpm-workspace.yaml",
+        "ui/index.html",
+        "ui/vite.config.ts",
+        "ui/svelte.config.js",
+        "ui/tailwind.config.js",
+        "ui/postcss.config.js",
+        "ui/tsconfig.json",
+        "ui/src",
+    ] {
+        println!("cargo:rerun-if-changed={rel}");
+    }
+    // `ui/dist` is deliberately NOT declared. It is this script's own output,
+    // and cargo's staleness reference is `invoked.timestamp`, stamped BEFORE
+    // the script runs — so declaring it makes the script dirty its own
+    // fingerprint and re-run the pnpm build on every `cargo check` (measured:
+    // 2.5s each). The residual is that deleting `ui/dist` by hand while
+    // `target/` stays warm does not re-trigger this script; `cargo clean` or a
+    // touch of any UI source recovers.
+
+    // #4699: build the bundle before tauri_build, so a broken UI fails here
+    // rather than as an opaque proc-macro panic in src/lib.rs.
+    build_tauri_ui(&ui_dir, &dist_dir, CRATE_NAME);
+
+    tauri_build::build();
 }
+
+// ── TAURI UI CANONICAL BLOCK BEGIN (kept in sync by scripts/check_buildrs_sync.sh) ──
+
+/// Build the Tauri frontend bundle into `dist_dir`, or abort the crate build.
+///
+/// Why: `frontendDist` must exist and be current before `generate_context!()`
+/// runs. Producing it here is what makes a clean clone compile (#4699); failing
+/// loudly is what keeps a half-built bundle from being embedded and shipped.
+/// What: honours `SKIP_UI_BUILD=1`, then requires pnpm and runs
+/// `install` + `run build` inside `ui_dir`. Presence of `dist_dir` is never
+/// treated as proof it is current — the build always runs, and cargo's
+/// `rerun-if-changed` directives are what keep it from running needlessly.
+/// Test: `cargo check -p <gui-crate> --features tauri/custom-protocol` with no
+/// `ui/dist` present; and the same command with `SKIP_UI_BUILD=1`.
+fn build_tauri_ui(ui_dir: &Path, dist_dir: &Path, crate_name: &str) {
+    let index = dist_dir.join("index.html");
+
+    // Step 1: the documented escape hatch for a host with no JS toolchain.
+    // It still has to leave something at `frontendDist` or the proc macro
+    // panics, so write a placeholder and say plainly that the UI is not real.
+    if std::env::var("SKIP_UI_BUILD").as_deref() == Ok("1") {
+        if !index.exists() {
+            println!(
+                "cargo:warning={crate_name}: SKIP_UI_BUILD=1 and {dist} is empty — \
+                 embedding a PLACEHOLDER UI. The resulting binary will not show the \
+                 real interface. Run `pnpm --dir ui install && pnpm --dir ui build` \
+                 and rebuild without SKIP_UI_BUILD to get a working app.",
+                dist = dist_dir.display()
+            );
+            write_placeholder(dist_dir, crate_name);
+        }
+        return;
+    }
+
+    // Step 2: no package.json means the checkout is incomplete. These crates are
+    // `publish = false`, so there is no extracted-tarball case to tolerate.
+    if !ui_dir.join("package.json").exists() {
+        fail(
+            crate_name,
+            &format!("{ui}/package.json is missing.", ui = ui_dir.display()),
+        );
+    }
+
+    // Step 3: pnpm is required, and is probed FROM `ui_dir` — corepack resolves
+    // the `packageManager` pin relative to the working directory, so a probe run
+    // from the workspace root selects a different pnpm (or fails outright).
+    if !probe_ok("pnpm", ui_dir) {
+        fail(
+            crate_name,
+            "`pnpm --version` did not succeed in the `ui/` directory, so pnpm is \
+             unavailable or unusable there.",
+        );
+    }
+
+    // Step 4: install, then build. A non-zero exit from either aborts; neither
+    // result is discarded.
+    let mut install_args = vec!["install"];
+    if ui_dir.join("pnpm-lock.yaml").exists() {
+        install_args.push("--frozen-lockfile");
+    }
+    run(crate_name, &install_args, ui_dir);
+    run(crate_name, &["run", "build"], ui_dir);
+
+    // Step 5: trust the artefact, not the exit code. A build that reports
+    // success but emits no entry point is a failed build.
+    if !index.exists() {
+        fail(
+            crate_name,
+            &format!(
+                "`pnpm run build` exited 0 but produced no {index}.",
+                index = index.display()
+            ),
+        );
+    }
+}
+
+/// Run a pnpm subcommand in `cwd`, aborting the crate build unless it exits 0.
+///
+/// Why: a swallowed `Command` result would let compilation proceed against a
+/// stale or absent bundle — the exact failure mode #4699 asks this script not
+/// to reintroduce.
+/// What: spawns `pnpm <args>` with stdio inherited (so pnpm's own diagnostics
+/// reach the build log) and routes both a non-zero status and a spawn error
+/// into `fail`.
+/// Test: covered by the `pnpm run build` leg of `build_tauri_ui`.
+fn run(crate_name: &str, args: &[&str], cwd: &Path) {
+    match Command::new("pnpm").args(args).current_dir(cwd).status() {
+        Ok(status) if status.success() => {}
+        Ok(status) => fail(
+            crate_name,
+            &format!("`pnpm {}` failed ({status}).", args.join(" ")),
+        ),
+        Err(e) => fail(
+            crate_name,
+            &format!("could not run `pnpm {}`: {e}", args.join(" ")),
+        ),
+    }
+}
+
+/// Report whether `program --version` succeeds when run from `cwd`.
+fn probe_ok(program: &str, cwd: &Path) -> bool {
+    Command::new(program)
+        .arg("--version")
+        .current_dir(cwd)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Write the stub entry point used only under `SKIP_UI_BUILD=1`.
+///
+/// Why: the escape hatch has to leave `frontendDist` populated or the proc
+/// macro panics anyway, defeating the point of the opt-out.
+/// What: creates the parent directory and writes a minimal HTML document that
+/// states, in the window itself, that the real UI was not built. Filesystem
+/// errors abort rather than being discarded.
+/// Test: `SKIP_UI_BUILD=1 cargo check -p <gui-crate>` on a tree with no
+/// `ui/dist` leaves `ui/dist/index.html` in place.
+///
+/// Deliberately free of let-chains: this block is shared verbatim with
+/// `trusty-agents-ui`, which is edition 2021.
+fn write_placeholder(dist_dir: &Path, crate_name: &str) {
+    if let Err(e) = std::fs::create_dir_all(dist_dir) {
+        fail(
+            crate_name,
+            &format!("could not create {}: {e}", dist_dir.display()),
+        );
+    }
+    let index = dist_dir.join("index.html");
+    let html = format!(
+        "<!doctype html><html><body><p>{crate_name}: the UI bundle was not built \
+         (SKIP_UI_BUILD=1). Run <code>pnpm --dir ui install &amp;&amp; pnpm --dir ui \
+         build</code> and rebuild.</p></body></html>"
+    );
+    if let Err(e) = std::fs::write(&index, html) {
+        fail(
+            crate_name,
+            &format!("could not write {}: {e}", index.display()),
+        );
+    }
+}
+
+/// Abort the crate build with a diagnostic that names the crate and the fix.
+///
+/// Why: the failure this replaces was a proc-macro panic pointing at
+/// `src/lib.rs` and complaining about a path, with no hint that a frontend
+/// build was missing — several agents rediscovered the workaround
+/// independently before #4699 was filed.
+/// What: panics, which cargo surfaces as "failed to run custom build command
+/// for <crate>" with this text attached.
+/// Test: every failure leg of `build_tauri_ui` routes here.
+fn fail(crate_name: &str, detail: &str) -> ! {
+    let msg = format!(
+        "\n{crate_name}: could not build the frontend bundle in `ui/`.\n\
+         {detail}\n\
+         `tauri.conf.json` points `frontendDist` at that bundle, so without it \
+         `tauri::generate_context!()` fails with a bare \"this path doesn't \
+         exist\" panic (#4699).\n\
+         Fix: install pnpm (https://pnpm.io/installation) and rebuild, or set \
+         SKIP_UI_BUILD=1 to compile against a placeholder UI.\n"
+    );
+    panic!("{msg}");
+}
+
+// ── TAURI UI CANONICAL BLOCK END ──

--- a/crates/trusty-mpm-gui/changelog.d/4699-build-ui-dist.md
+++ b/crates/trusty-mpm-gui/changelog.d/4699-build-ui-dist.md
@@ -1,0 +1,11 @@
+Fixed
+
+- **`build.rs` now builds the Svelte bundle, so a clean clone compiles.**
+  `tauri.conf.json` points `frontendDist` at `ui/dist`, which is gitignored and
+  which nothing built — so `tauri::generate_context!()` panicked with a bare
+  "this path doesn't exist" and took down `cargo test --workspace` and
+  `cargo clippy --workspace` for every crate, not just this one. `build.rs` now
+  runs `pnpm install` + `pnpm run build` in `ui/`, honours `SKIP_UI_BUILD=1`,
+  and aborts loudly (naming the crate and the escape hatch) if pnpm is missing
+  or the build produces no `index.html`
+  ([#4699](https://github.com/bobmatnyc/trusty-tools/issues/4699))

--- a/scripts/check_buildrs_sync.sh
+++ b/scripts/check_buildrs_sync.sh
@@ -1,74 +1,94 @@
 #!/usr/bin/env bash
 # scripts/check_buildrs_sync.sh
 #
-# Why: trusty-memory, trusty-analyze, trusty-console, and trusty-search each
-# contain an identical "CANONICAL BLOCK" in their build.rs (issue #987). Because
-# Cargo cannot share build scripts as a library, the block is duplicated by
-# necessity; this script is the anti-drift gate that fails CI whenever the
-# copies diverge.
+# Why: Cargo cannot share a build script as a library, so crates that need the
+# same build-time logic duplicate it by necessity. This script is the anti-drift
+# gate that fails CI whenever the copies diverge. Two independent families exist:
 #
-# What: Extracts the text between "CANONICAL BLOCK BEGIN" and
-# "CANONICAL BLOCK END" from each build.rs and asserts they are byte-for-byte
+#   "daemon"  — trusty-memory, trusty-analyze, trusty-console, trusty-search
+#               (issue #987). Embeds an OPTIONAL web UI; degrades to a
+#               placeholder when the JS toolchain is missing.
+#   "tauri-ui" — trusty-code-gui, trusty-mpm-gui, trusty-agents-ui (issue
+#               #4699). Embeds the whole desktop window; ABORTS the crate build
+#               on any UI-build failure, because a placeholder there would ship
+#               a blank app. trusty-agents-ui is edition 2021, so this block
+#               must stay free of let-chains.
+#
+# The two families are deliberately not merged: their failure semantics differ.
+#
+# What: Extracts the text between each family's BEGIN/END markers from every
+# member's build.rs and asserts the members of a family are byte-for-byte
 # identical. Exits 0 on success, 1 on any mismatch with a diff.
 #
 # Test: Run `bash scripts/check_buildrs_sync.sh` from the workspace root.
-# Expected output: "build.rs canonical blocks are in sync across all 4 crates."
+# Expected output: one "in sync" line per family.
 
 set -euo pipefail
 
 WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-FILES=(
+DAEMON_FILES=(
     "crates/trusty-memory/build.rs"
     "crates/trusty-analyze/build.rs"
     "crates/trusty-console/build.rs"
     "crates/trusty-search/build.rs"
 )
 
-extract_canonical_block() {
-    local file="$1"
-    sed -n '/── CANONICAL BLOCK BEGIN/,/── CANONICAL BLOCK END/p' "$file"
-}
+TAURI_UI_FILES=(
+    "crates/trusty-code-gui/build.rs"
+    "crates/trusty-mpm-gui/build.rs"
+    "crates/trusty-agents/ui/src-tauri/build.rs"
+)
 
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 FAILED=0
-REFERENCE=""
-REFERENCE_FILE=""
 
-for rel in "${FILES[@]}"; do
-    abs="$WORKSPACE_ROOT/$rel"
-    if [[ ! -f "$abs" ]]; then
-        echo "ERROR: expected file not found: $rel" >&2
-        FAILED=1
-        continue
-    fi
-    block_file="$TMP_DIR/$(echo "$rel" | tr '/' '_').block"
-    extract_canonical_block "$abs" > "$block_file"
-    if [[ ! -s "$block_file" ]]; then
-        echo "ERROR: no CANONICAL BLOCK found in $rel" >&2
-        FAILED=1
-        continue
-    fi
-    if [[ -z "$REFERENCE" ]]; then
-        REFERENCE="$block_file"
-        REFERENCE_FILE="$rel"
-    else
-        if ! diff -q "$REFERENCE" "$block_file" > /dev/null 2>&1; then
-            echo "FAIL: canonical block in $rel differs from $REFERENCE_FILE:" >&2
-            diff "$REFERENCE" "$block_file" >&2
+# Assert every build.rs in one family carries a byte-identical canonical block.
+#
+# $1 = family name (used in messages and temp filenames)
+# $2 = marker infix, e.g. "" for `── CANONICAL BLOCK BEGIN` or "TAURI UI " for
+#      `── TAURI UI CANONICAL BLOCK BEGIN`
+# $3+ = repo-relative build.rs paths
+check_family() {
+    local family="$1" marker="$2"
+    shift 2
+    local files=("$@")
+    local reference="" reference_file="" rel abs block_file
+
+    for rel in "${files[@]}"; do
+        abs="$WORKSPACE_ROOT/$rel"
+        if [[ ! -f "$abs" ]]; then
+            echo "ERROR: expected file not found: $rel" >&2
+            FAILED=1
+            continue
+        fi
+        block_file="$TMP_DIR/${family}_$(echo "$rel" | tr '/' '_').block"
+        sed -n "/── ${marker}CANONICAL BLOCK BEGIN/,/── ${marker}CANONICAL BLOCK END/p" \
+            "$abs" > "$block_file"
+        if [[ ! -s "$block_file" ]]; then
+            echo "ERROR: no ${marker}CANONICAL BLOCK found in $rel" >&2
+            FAILED=1
+            continue
+        fi
+        if [[ -z "$reference" ]]; then
+            reference="$block_file"
+            reference_file="$rel"
+        elif ! diff -q "$reference" "$block_file" > /dev/null 2>&1; then
+            echo "FAIL: ${family} canonical block in $rel differs from $reference_file:" >&2
+            diff "$reference" "$block_file" >&2
+            echo "To fix: make every ${family} build.rs share $reference_file's block." >&2
             FAILED=1
         fi
-    fi
-done
+    done
 
-if [[ "$FAILED" -eq 0 ]]; then
-    echo "build.rs canonical blocks are in sync across all ${#FILES[@]} crates."
-    exit 0
-else
-    echo "" >&2
-    echo "To fix: update all four build.rs files to share the same canonical block." >&2
-    echo "The reference implementation is in $REFERENCE_FILE." >&2
-    exit 1
-fi
+    if [[ -n "$reference" ]]; then
+        echo "${family}: build.rs canonical blocks are in sync across ${#files[@]} crates."
+    fi
+}
+
+check_family "daemon" "" "${DAEMON_FILES[@]}"
+check_family "tauri-ui" "TAURI UI " "${TAURI_UI_FILES[@]}"
+
+exit "$FAILED"


### PR DESCRIPTION
## Defect

The three Tauri crates declare `frontendDist` pointing at a gitignored `dist/`
directory, and their `build.rs` was a bare `tauri_build::build()` that never
built it. On a clean clone `tauri::generate_context!()` panics with "this path
doesn't exist", stopping `cargo test --workspace` and
`cargo clippy --workspace --all-targets` before a single test runs.

Two things the issue did not have:

- **Three crates, not one.** `trusty-agents-ui`
  (`crates/trusty-agents/ui/src-tauri`) has the same defect. It is also the crate
  that turns the check ON for everyone: it enables `tauri/custom-protocol` by
  default, and resolver-v2 feature unification propagates that to every Tauri
  crate in a workspace-wide build. Fixing only `trusty-code-gui` and
  `trusty-mpm-gui` would leave the release gate unrunnable.
- **The panic is feature-gated.** `tauri-macros` sets `dev: cfg!(not(feature =
  "custom-protocol"))`, and `tauri-codegen` skips the `frontendDist` existence
  check whenever `dev` is true. So `cargo check -p trusty-code-gui` **passes** on
  a tree with no bundle — it falls back to `devUrl`. Only a build that pulls in
  `custom-protocol` fails. That is why this looked workspace-only, and why the
  reproducer below needs `--features tauri/custom-protocol` for the two GUI
  crates (`trusty-agents-ui` fails on its own, `custom-protocol` being its
  default).

## Evidence

All from a fresh worktree off `origin/main` with no `ui/dist` present.

**Before** — `CARGO_BUILD_JOBS=2 cargo check -p trusty-code-gui --features tauri/custom-protocol`, exit 101:

```
   Compiling trusty-code-gui v0.1.0 (.../crates/trusty-code-gui)
error: proc macro panicked
  --> crates/trusty-code-gui/src/lib.rs:35:14
   |
35 |         .run(tauri::generate_context!())
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: The `frontendDist` configuration is set to `"ui/dist"` but this path doesn't exist

error: could not compile `trusty-code-gui` (lib) due to 1 previous error
```

`trusty-mpm-gui` fails identically at `src/lib.rs:42`; `trusty-agents-ui` fails
at `src/main.rs:144` with `frontendDist ... "../dist"`, under a plain
`cargo check -p trusty-agents-ui`.

**After** — `CARGO_BUILD_JOBS=2 cargo check -p trusty-code-gui -p trusty-mpm-gui -p trusty-agents-ui`, all three dists deleted first, exit 0:

```
dists removed:
  crates/trusty-code-gui/ui/dist: ABSENT
  crates/trusty-mpm-gui/ui/dist: ABSENT
  crates/trusty-agents/ui/dist: ABSENT
   Compiling trusty-mpm-gui v0.2.12 (.../crates/trusty-mpm-gui)
   Compiling trusty-code-gui v0.1.0 (.../crates/trusty-code-gui)
   Compiling trusty-agents-ui v0.16.1 (.../crates/trusty-agents/ui/src-tauri)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 17.43s
--- bundles:
  crates/trusty-code-gui/ui/dist: assets fonts index.html
  crates/trusty-mpm-gui/ui/dist: assets index.html
  crates/trusty-agents/ui/dist: assets favicon.svg fonts index.html
```

**pnpm missing** (same command with pnpm off `PATH`), exit 101 — the point of the
change is that this is no longer a bare path panic:

```
thread 'main' panicked at crates/trusty-code-gui/build.rs:242:5:

trusty-code-gui: could not build the frontend bundle in `ui/`.
`pnpm --version` did not succeed in the `ui/` directory, so pnpm is unavailable or unusable there.
`tauri.conf.json` points `frontendDist` at that bundle, so without it `tauri::generate_context!()` fails with a bare "this path doesn't exist" panic (#4699).
Fix: install pnpm (https://pnpm.io/installation) and rebuild, or set SKIP_UI_BUILD=1 to compile against a placeholder UI.
```

**`SKIP_UI_BUILD=1`** (pnpm still off `PATH`), exit 0 — placeholder plus a loud
warning, matching `trusty-search` / `trusty-memory`:

```
warning: trusty-code-gui@0.1.0: trusty-code-gui: SKIP_UI_BUILD=1 and .../ui/dist is empty — embedding a PLACEHOLDER UI. The resulting binary will not show the real interface. Run `pnpm --dir ui install && pnpm --dir ui build` and rebuild without SKIP_UI_BUILD to get a working app.
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.70s
```

**No needless rebuild** — three consecutive checks, `ui/dist/index.html` mtime
unchanged after the first:

```
run1:    Compiling trusty-code-gui v0.1.0 (...)
run1:     Finished `dev` profile in 2.68s
run1 dist mtime: 1786285441
run2:     Finished `dev` profile in 0.19s
run2 dist mtime: 1786285441
run3:     Finished `dev` profile in 0.19s
run3 dist mtime: 1786285441
```

That took a second fix. `trusty-code-gui` had no `capabilities/` directory, but
`tauri_build` unconditionally emits `cargo:rerun-if-changed=capabilities`, and
cargo treats a declared-but-absent path as changed
(`dirty: FsStatusOutdated(StaleItem(MissingFile { path: ".../capabilities" }))`).
The build script re-ran on every invocation — pre-existing, but with this change
it would have re-run the pnpm build every time. The added
`capabilities/default.json` has `"permissions": []`; the regenerated
`gen/schemas/capabilities.json` confirms no permission is granted, so runtime
behaviour is unchanged.

## Resolution

- Each `build.rs` runs `pnpm install` (`--frozen-lockfile` when a lockfile
  exists) + `pnpm run build` in its UI directory, then verifies `index.html`
  actually exists. No `Command` result is discarded; a non-zero exit, a spawn
  error, or a zero exit that produced nothing all abort the crate build.
- `pnpm --version` is probed **from the UI directory**, because corepack resolves
  the `packageManager` pin relative to cwd — probing from the workspace root
  selects a different pnpm and fails on this machine.
- `cargo:rerun-if-changed` covers only paths that exist, and only inputs to
  `pnpm build` (`vitest.config.ts`, `vite.web.config.ts`, `web.html`,
  `playwright.config.ts`, `tests/` are excluded). `dist/` is deliberately not
  declared: cargo's staleness reference is `invoked.timestamp`, stamped before
  the script runs, so declaring the script's own output makes it dirty its own
  fingerprint — measured at a 2.5s pnpm rebuild on every `cargo check`. The
  residual is that deleting `dist/` by hand with a warm `target/` does not
  re-trigger the script; `cargo clean` or touching any UI source recovers.
- The shared logic is a CANONICAL BLOCK kept byte-identical across the three
  crates and gated by `scripts/check_buildrs_sync.sh`, which now checks two
  families. This follows the precedent #987 set for the four UI-embedding daemon
  crates rather than inventing a build-dependency crate mid-release. It is a
  **separate** family from theirs because the failure semantics differ: those
  degrade to a placeholder, which is right for an optional web surface and wrong
  for a desktop app whose entire window is the bundle. `trusty-agents-ui` is
  edition 2021, so the block uses no let-chains.

A shared `[build-dependencies]` path crate would remove the duplication outright
— all three crates are `publish = false`, so nothing blocks it. Left as a
follow-up rather than adding a workspace member during a release cut.

## Test ladder

Rung 3 (localized behavior, per crate) — build scripts only, no library API
changed. Commands run, all exit 0:

```
CARGO_BUILD_JOBS=2 cargo fmt --check
CARGO_BUILD_JOBS=2 cargo clippy -p trusty-code-gui -p trusty-mpm-gui -p trusty-agents-ui --all-targets -- -D warnings
CARGO_BUILD_JOBS=2 cargo test -p trusty-code-gui -p trusty-mpm-gui -p trusty-agents-ui
bash scripts/check_line_cap.sh
bash scripts/check_sld.sh
bash scripts/check_buildrs_sync.sh
bash scripts/check_changelog_fragment.sh
```

```
test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
line-cap: measured 3844 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
sld-lint: scanned 57 spec doc(s) + 3181 code file(s); 0 error(s), 0 warning(s)
daemon: build.rs canonical blocks are in sync across 4 crates.
tauri-ui: build.rs canonical blocks are in sync across 3 crates.
```

`cargo test --workspace` was not run here — it is the 37-minute gate this PR
exists to unblock, and a prior attempt on this machine was SIGKILLed. The
three-crate compile-from-clean above is the evidence that the blocker is gone;
the workspace re-gate belongs to the 1.3.5 cut.

Closes #4699

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
