### PR TITLE
docs: track the root AGENTS.md agent-instructions file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Project Instructions
+
+## Code Search
+
+- Start codebase discovery with `trusty-search` when the command is available.
+  Use it first for conceptual questions, unfamiliar features, and relationship
+  tracing (for example, `trusty-search search "<question>"`).
+- If `trusty-search` is unavailable, unhealthy, or has no usable index for this
+  checkout, fall back immediately to direct workspace search rather than
+  blocking the task.
+- Use `rg`, Git, and direct file inspection for exact identifiers, exhaustive
+  matches, uncommitted changes, and final verification. Treat the current
+  working tree—not the search index—as the source of truth before editing.


### PR DESCRIPTION
## Summary

`AGENTS.md` at the repo root has been sitting untracked in the working tree
and is absent from `main`. It defines the cross-tool code-search convention
for agents working in this repo: prefer `trusty-search` for conceptual
questions and relationship tracing, fall back to direct workspace search
(`rg`, git, file inspection) when `trusty-search` is unavailable or unhealthy,
and treat the current working tree — not the search index — as the source of
truth before editing.

This PR adds the file to version control with no content changes. Docs-only,
no crate `src/**` touched — no changelog fragment required.

## Test plan

- N/A — docs-only addition, no code changes.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools