### PR TITLE
docs(trusty-mpm): deduplicate worktree discipline into tm-workflow, trim CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,73 +286,16 @@ Publish-time `[patch.crates-io]` semantics are in
 
 ## Parallel Worktree Discipline
 
-**CRITICAL RULES FOR CONCURRENT SESSIONS:**
-
-🔴 **SOURCE OF TRUTH = `origin/main:HEAD`.** Local `main` may be stale. **Always `git fetch origin main` and branch worktrees off `origin/main`** (not local main). Stale local main has caused lost commits and missed features. This is not optional.
-
-🔴 **The main checkout is inspection-only.** From the repo root
-(`/path/to/trusty-tools/`), the only allowed operations are read-only: `git status`,
-`git log`, `git diff`, `git show`, file reads. **FORBIDDEN**: edits, `git reset --hard`,
-`git checkout .`, `git stash`, `git restore .`, `cargo build`/`cargo test`,
-`sed`/`awk`/`patch`, or any command that mutates the working tree, index, or `target/`.
-
-🔴 **All write-side work happens in a dedicated git worktree branched off
-`origin/main`.** Provision one before starting any edit, build, or test:
-
-```bash
-git fetch origin main
-git worktree add -b <feature-or-fix-branch> \
-                  .claude/worktrees/<dirname> origin/main
-cd .claude/worktrees/<dirname>
-# … edit, build, test, commit, push from here …
-```
+Generic worktree discipline — main checkout inspection-only, provisioning off
+`origin/main`, branch-is-the-workstream, subagent confinement, cleanup — lives in
+`Skill(skill="tm-workflow")`. It applies here in full. What follows is only what
+this repo adds.
 
 **End-to-end delivery chain:** accepted outcome → optional issue → worktree
 branch → one cohesive PR → applicable Rust gates → trusty-review gate →
-squash-merge → worktree cleanup. The framework skill `tm-workflow` owns the
-full sequence, and `tm-ticketing` owns whether the optional issue exists; this
-file adds only the Rust-specific gates (see the Rust Test Ladder above). *(This
-project-instruction host was `.trusty-mpm/INSTRUCTIONS.md` until #4286 retired
-it; the delivery chain moved to `tm-pr-workflow` and then into `tm-workflow`
-when #5202 consolidated the two.)*
-
-🔴 **A worktree is a writer; the branch is the workstream.** The durable unit is
-the **branch** — one branch per workstream, and a session owns exactly one
-workstream. A worktree is only the checkout that lets you write to that branch:
-ephemeral, disposable, and recreatable at any time with `git worktree add`.
-Never treat a worktree as the thing being preserved; losing one loses nothing
-the branch does not still hold.
-
-What follows from that:
-
-- **One branch and worktree per independently reviewable PR outcome** — not per
-  ticket, per refactor step, or per experiment. Several related tickets may
-  share one worktree when a single coherent change satisfies them
-  (`Closes #A`, `Closes #B`).
-- **Everything that outcome owes stays in the same worktree and PR:** the
-  implementation, its regression tests, necessary local refactoring, docs, the
-  changelog fragment, and in-scope review fixes. Do not open a second worktree
-  for the tests you still owe the first one.
-- **Experiments stay session-local.** Promote an experiment to a branch and
-  worktree only once its result is accepted for implementation.
-- **Cleanup:** `git worktree remove --force <path>` once the PR has merged, then
-  `git branch -D <branch>` and `git push origin --delete <branch>` — the branch
-  goes last, because until the squash-merge has landed it is the only durable
-  copy of the workstream.
-
-🟡 **If you absolutely must run a command from the main checkout** — for
-example `cargo install --path crates/<name> --locked` after a merge —
-stash first, operate, then restore:
-
-```bash
-git -C /path/to/main-checkout stash push -u \
-    -m "claude: pre-op-safety $(date +%s)"
-# … do the op …
-git -C /path/to/main-checkout stash pop
-```
-
-Surface the stash name in your report if popping fails so the human can
-restore manually.
+squash-merge → worktree cleanup. `tm-workflow` owns the full sequence and
+`tm-ticketing` owns whether the optional issue exists; this file adds only the
+Rust-specific gates (see the Rust Test Ladder above).
 
 🟡 **`cargo install` from a worktree, not the main checkout.** The preferred
 pattern for installing a freshly-built binary onto your PATH is:
@@ -363,20 +306,9 @@ cargo install --path .claude/worktrees/<dirname>/crates/<name> --locked
 
 Cargo writes atomically to a temp file and renames into `~/.cargo/bin/`,
 which keeps the macOS kernel's cdhash cache consistent (see the
-release-workflow note above). The main checkout never needs to be involved.
-
-🟢 **Subagents inherit these rules.** Every `Agent`/`Task` dispatch prompt
-**must** name the exact worktree path the agent should operate from and forbid
-leaving that worktree into the main checkout, `git reset --hard`, `git checkout .`,
-and `git stash` against the main checkout, and touching files outside the assigned worktree.
-
-The pattern of instructing an agent to "operate from the main checkout" is banned.
-QA agents get their own worktree (`.claude/worktrees/qa-<ticket-or-pass>`) just
-like engineering agents.
-
-🟢 **Worktree cleanup is safe.** `git worktree remove --force <path>` deletes
-the worktree directory but never the main checkout. Use `git branch -D <branch>`
-and `git push origin --delete <branch>` to clean up refs after a squash-merge.
+release-workflow note above). A plain `cp` over an on-PATH binary leaves a stale
+cdhash cache and the next exec is SIGKILL'd. The main checkout never needs to be
+involved.
 
 > **Extended discipline rationale and cleanup details:** see [docs/reference/worktree-discipline.md](docs/reference/worktree-discipline.md).
 

--- a/crates/trusty-mpm/changelog.d/5269-dedupe-worktree-discipline.md
+++ b/crates/trusty-mpm/changelog.d/5269-dedupe-worktree-discipline.md
@@ -1,0 +1,5 @@
+Documentation
+
+- the bundled `tm-workflow` skill now carries the full generic worktree discipline, so a project's `CLAUDE.md` no longer has to restate it ([#5269](https://github.com/bobmatnyc/trusty-tools/pull/5269))
+  - moved in from this repo's `CLAUDE.md`: branch off `origin/main` never local `main`, "experiments stay session-local", the stash-first escape hatch for a one-off main-checkout command, `git push origin --delete` as the manual cleanup case, QA agents getting their own worktree, and the note that worktree cleanup never touches the main checkout
+  - `tm-cli-operations`' `prune-worktrees` line keeps its `.worktrees/` path — that is `tm`'s own session provisioning, which still writes there — and now says so, so it is not mistaken for the canonical `.claude/worktrees/` home

--- a/crates/trusty-mpm/src/assets/skills/tm-cli-operations.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-cli-operations.md
@@ -300,6 +300,12 @@ tm session decommission-ephemeral               # tear down all test/throwaway s
 tm session prune-worktrees [--force]            # remove orphaned .worktrees/ dirs (default dry-run)
 ```
 
+The `.worktrees/` path above is what `tm`'s own session provisioning writes
+today; it is NOT the canonical worktree home. Hand-provisioned and
+harness-provisioned worktrees live under `.claude/worktrees/` (see
+`tm-workflow`). Migrating tm's provisioning path is pending — until it lands,
+`prune-worktrees` only sees `.worktrees/`.
+
 `prune-worktrees` defaults to a safe preview (pass `--force` to act);
 `prune`/`prune-idle` act immediately unless you pass `--dry-run` yourself.
 `prune --include-active` is the only explicit override to also touch RUNNING

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -174,12 +174,34 @@ git worktree add -b <feature-or-fix-branch> \
 cd .claude/worktrees/<dirname>
 ```
 
+Always `git fetch origin main` first and branch off `origin/main`, never local
+`main` — local `main` can be stale and branching from it has caused lost commits.
+
+**Experiments stay session-local.** Promote an experiment to a branch and
+worktree only once its result is accepted for implementation.
+
 Every subagent dispatch must name the exact worktree path it is confined to, and
 must forbid leaving it into the main checkout, `git reset --hard`,
-`git checkout .`, and `git stash` against main. Clean up after merge with
-`git worktree remove --force <path>` then `git branch -D <branch>` — the branch
-goes last, because until the squash-merge lands it is the only durable copy of
-the workstream.
+`git checkout .`, and `git stash` against main. QA agents get their own worktree
+(e.g. `.claude/worktrees/qa-<ticket-or-pass>`), same as engineering agents.
+
+Clean up after merge with `git worktree remove --force <path>` (which deletes the
+worktree directory and never the main checkout), then `git branch -D <branch>`
+and, when the squash-merge did not already do it, `git push origin --delete
+<branch>` — the branch goes last, because until the squash-merge lands it is the
+only durable copy of the workstream.
+
+**Escape hatch — stash first.** If you genuinely must run one command from the
+main checkout, stash, operate, restore:
+
+```bash
+git -C /path/to/main-checkout stash push -u -m "pre-op-safety $(date +%s)"
+# … do the op …
+git -C /path/to/main-checkout stash pop
+```
+
+Surface the stash name in your report if popping fails, so a human can restore
+it manually.
 
 ## Git Security Review (Mandatory Before Push)
 


### PR DESCRIPTION
## What moved

Generic worktree discipline moved from `CLAUDE.md` into
`crates/trusty-mpm/src/assets/skills/tm-workflow.md`. `CLAUDE.md` is resident in
every prompt and costs tokens every turn; a skill loads only on its trigger, and
worktree discipline is needed when provisioning or landing work, not every turn.

Added to the skill (generic, previously only in `CLAUDE.md`):

- branch off `origin/main`, never local `main` — local `main` can be stale
- "Experiments stay session-local" (verbatim)
- the stash-first escape hatch for an occasional main-checkout command, as a
  named escape hatch
- `git push origin --delete <branch>`, folded into the existing cleanup sentence
  as the manual case (squash-merge's `--delete-branch` covers the normal one)
- QA agents get their own worktree, same as engineering agents
- "cleanup never touches the main checkout", as a parenthetical on that same
  cleanup sentence

Deleted from `CLAUDE.md` because the skill already said it: the inspection-only
rule and its Rust-specific forbidden-command list, the `git worktree add …
.claude/worktrees/<dirname> origin/main` + `cd` block, the
worktree-is-a-writer / one-branch-per-outcome / everything-in-one-PR bullets,
the subagent-confinement paragraph, and the restatement of the
"operate from the main checkout is banned" rule.

## What stayed, and why

Repo-specific, so it does not belong in a skill that ships to Python/TypeScript/
Go projects:

- `cargo install --path .claude/worktrees/<dirname>/crates/<name> --locked` and
  the macOS `cp`/cdhash SIGKILL hazard — Rust- and macOS-specific
- the delivery-chain pointer, trimmed to two sentences
- the pointer to `docs/reference/worktree-discipline.md`

The section goes from ~95 lines to ~25.

**No path changed anywhere.** `.claude/worktrees/` was already the name in both
files. `crates/trusty-mpm/src/assets/skills/tm-cli-operations.md:303` keeps its
`.worktrees/` path — that describes `tm`'s own session provisioning, which still
writes there and is not migrated by this PR — and gains a marker saying the
provisioning-path migration is pending, so it is not read as the canonical home.

## Rung and gates

Rung 1 (docs/skill prose), but `tm-workflow.md` lives under
`crates/trusty-mpm/src/**` and is `include_str!`'d into the binary, so a
changelog fragment is required and `cargo test -p trusty-mpm` was run anyway.

```
$ bash scripts/check_sld.sh
GATE_SLD_EXIT=0

$ bash scripts/check_line_cap.sh
GATE_LINECAP_EXIT=0

$ bash scripts/check_changelog_fragment.sh
GATE_FRAGMENT_EXIT=0

$ cargo test -p trusty-mpm
TEST_EXIT=0
test result: ok. 4835 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
test result: ok. 1546 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
... 44 more binaries, all `ok`, 0 failed
```

The `tm-capabilities` generated-skill drift check does not apply — it diffs only
`tm-capabilities*`, and `tm-workflow.md` is hand-authored, so no regeneration is
needed. `crates/trusty-mpm/src/core/bundle_tests.rs` asserts frontmatter shape
and non-empty content, not the worktree text.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

