### PR TITLE
docs: ADR-0030 point 7 and DOC-66 §5 say parentage, not path containment

### DIFF
--- a/docs/adr/0030-sessions-own-many-workstreams-from-the-tm-checkout.md
+++ b/docs/adr/0030-sessions-own-many-workstreams-from-the-tm-checkout.md
@@ -43,7 +43,7 @@ We will make a session a container of workstreams, and give it a home that is no
 
 6. **Roughly five active workstreams per session, advisory and configurable.** The limit exists because each workstream's conversation surfaces to the user, and more than about five exceeds what one person can attend to. It is an **attention** limit. It is not WIP reduction — prior analysis in this repo refuted that framing, and re-justifying the cap as throughput control would be a regression to a rejected argument. Exceeding it nudges; it never blocks.
 
-7. **Agent worktrees are children of a workstream, not workstreams.** They are created under the workstream that dispatched them, reaped when the agent exits, and never consume a slot.
+7. **Agent worktrees are children of a workstream by record, not by location.** "Child" here names a recorded parent id — the dispatching workstream's id, carried in the agent worktree's sentinel as `parent_workstream_id` (DOC-66 §5) — and nothing about where the directory sits. The worktree itself is a flat sibling under `.claude/worktrees/`, never nested inside its parent's checkout, per [ADR-0036](0036-all-worktrees-are-siblings-under-claude-worktrees.md). What the parent id buys is reapability: a child is reaped when its agent exits, is reclaimed with its parent if that workstream reaches `Reclaimed` first, and never consumes a slot. Children are not workstreams.
 
 8. **Working directly on the default branch stays available.** The `worktree: false` override already exists and is not re-designed here; only its shape changes, from a per-project config key to a per-session-overridable flag targeting the tm checkout (DOC-66 §3.5).
 

--- a/docs/specs/DOC-66-session-workstream-model.md
+++ b/docs/specs/DOC-66-session-workstream-model.md
@@ -24,6 +24,7 @@ spec_refs:
 - [`docs/adr/0030-sessions-own-many-workstreams-from-the-tm-checkout.md`](../adr/0030-sessions-own-many-workstreams-from-the-tm-checkout.md) — the decision this spec encodes
 - [`docs/adr/0023-worktree-authority-existence-vs-ownership.md`](../adr/0023-worktree-authority-existence-vs-ownership.md) — git owns existence; a rebuildable record owns ownership
 - [`docs/adr/0020-session-owned-worktrees.md`](../adr/0020-session-owned-worktrees.md) — the `.trusty-mpm-worktree` sentinel this spec extends
+- [`docs/adr/0036-all-worktrees-are-siblings-under-claude-worktrees.md`](../adr/0036-all-worktrees-are-siblings-under-claude-worktrees.md) — every worktree is a flat sibling under `.claude/worktrees/`; §5's parent/child relation is a recorded id, never containment
 - [`docs/specs/DOC-52-shared-workstream-definition.md`](./DOC-52-shared-workstream-definition.md) — the cross-product glossary
 
 **Cross-ref (code):** `crates/trusty-mpm/src/session_manager/record.rs:190-270`; `crates/trusty-mpm/src/driver/correlation.rs:33-43`; `crates/trusty-mpm/src/core/worktree_naming.rs:33-35`; `crates/trusty-mpm/src/core/session_launch/workstream_label.rs:93-136`; `crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs:349-418`; `crates/trusty-mpm/src/daemon/managed_routes/launch_on_main.rs:64-69,93-229`; `crates/trusty-mpm/src/daemon/managed_routes/inproject.rs:56,134-136`; `crates/trusty-mpm/src/daemon/managed_routes/inproject_hygiene.rs:291-303,405-437`; `crates/trusty-mpm/src/daemon/mod.rs:149`; `crates/trusty-mpm/src/core/harness_root.rs:47-59`; `crates/trusty-mpm/src/provisioner/workspace.rs:13-22`; `crates/trusty-mpm/src/project/record.rs:165-177`; `crates/trusty-mpm/src/project/worktree_policy.rs:84-106`; `crates/trusty-mpm/src/session_manager/manager.rs:1125`; `crates/trusty-mpm/src/session_manager/worktree_reclaim.rs:91-125`
@@ -267,7 +268,7 @@ Covered in §5. They are children, not workstreams.
 
 ---
 
-## 5. Agent worktrees as children {#SPEC-SESSWS-05~draft}
+## 5. Agent worktrees are children by record, not by location {#SPEC-SESSWS-05~draft}
 
 **ID:** SPEC-SESSWS-05~draft
 **Status:** Draft
@@ -276,7 +277,8 @@ Parallel engineers inside one workstream legitimately need their own checkouts �
 
 **NORMATIVE:**
 
-- An agent worktree is a **child** of the workstream that dispatched the agent. Its sentinel carries `parent_workstream_id`.
+- An agent worktree is a **child** of the workstream that dispatched the agent. "Child" is a **recorded parent id and nothing more**: its sentinel carries `parent_workstream_id`, naming the dispatching workstream. It is a statement about lifetime and reclamation authority, never about where the directory sits.
+- **A child is not contained by its parent.** It is a flat sibling under `.claude/worktrees/`, alongside every other worktree, per [ADR-0036](../adr/0036-all-worktrees-are-siblings-under-claude-worktrees.md). A worktree nested inside another worktree's checkout is the defect ADR-0036 exists to prevent — the parent's dirty-tree report cannot see a gitignored worktree living inside it — so parentage must be resolved by reading `parent_workstream_id`, never by inspecting a path prefix.
 - It is **reaped when the agent exits**. Its lifetime is the agent's, not the workstream's and not the session's.
 - It **never consumes a slot** (§4.5) and never appears in the session's workstream set.
 - A child whose parent workstream reaches `Reclaimed` is reclaimed with it, whether or not its agent exited cleanly.


### PR DESCRIPTION
## Why

ADR-0036 (merged, `b98950a3`) made every worktree a flat sibling under `.claude/worktrees/`. Its vetting pass flagged two passages that predate it and could be read as asserting the nesting it forbids. Owner authorized the wording fix.

ADR-0030 is **Proposed**, verified on `origin/main` before editing, so its body is editable — the immutability rule that forced ADR-0020's header-only amendment does not apply.

## ADR-0030 point 7

Before:

> 7. **Agent worktrees are children of a workstream, not workstreams.** They are created under the workstream that dispatched them, reaped when the agent exits, and never consume a slot.

After:

> 7. **Agent worktrees are children of a workstream by record, not by location.** "Child" here names a recorded parent id — the dispatching workstream's id, carried in the agent worktree's sentinel as `parent_workstream_id` (DOC-66 §5) — and nothing about where the directory sits. The worktree itself is a flat sibling under `.claude/worktrees/`, never nested inside its parent's checkout, per [ADR-0036](0036-all-worktrees-are-siblings-under-claude-worktrees.md). What the parent id buys is reapability: a child is reaped when its agent exits, is reclaimed with its parent if that workstream reaches `Reclaimed` first, and never consumes a slot. Children are not workstreams.

## DOC-66 §5

Heading, before → after:

> `## 5. Agent worktrees as children` → `## 5. Agent worktrees are children by record, not by location`

First normative bullet, before:

> - An agent worktree is a **child** of the workstream that dispatched the agent. Its sentinel carries `parent_workstream_id`.

After (one bullet becomes two):

> - An agent worktree is a **child** of the workstream that dispatched the agent. "Child" is a **recorded parent id and nothing more**: its sentinel carries `parent_workstream_id`, naming the dispatching workstream. It is a statement about lifetime and reclamation authority, never about where the directory sits.
> - **A child is not contained by its parent.** It is a flat sibling under `.claude/worktrees/`, alongside every other worktree, per [ADR-0036](../adr/0036-all-worktrees-are-siblings-under-claude-worktrees.md). A worktree nested inside another worktree's checkout is the defect ADR-0036 exists to prevent — the parent's dirty-tree report cannot see a gitignored worktree living inside it — so parentage must be resolved by reading `parent_workstream_id`, never by inspecting a path prefix.

DOC-66's "Builds on" list gains ADR-0036, which its normative text now cites.

## What did not change

Reapability semantics: reaped when the agent exits, reclaimed with a parent that reaches `Reclaimed`, never consumes a slot, never appears in the session's workstream set. §5's closing paragraph ("Giving them a parent is what makes them reapable at all") stands. Neither decision changed — this is disambiguation.

The SLD anchor `{#SPEC-SESSWS-05~draft}` is unchanged, and no document outside DOC-66 references the §5 heading text or that anchor (checked across `docs/` and `crates/`).

## Out of scope, flagged

`docs/specs/DOC-66-session-workstream-model.md:53` still describes worktrees at `<base>/.worktrees/<name>`. That is a topology statement, accurate for today's shape, and it goes stale when ADR-0036's migration lands — ADR-0036 already records reconciling the prose files as follow-up. Not touched here. `CLAUDE.md` and `tm-workflow.md` are likewise untouched (PR #5269 is live on them).

## Gates

Rung 1, docs only. No crate `src/**`, so no changelog fragment — the gate says so itself.

```
check_doc_numbers self-test: OK (duplicate DOC/ADR numbers caught via filename and self-label, label mismatch caught, dangling catalog row caught, stale next-free hint caught, consistent/cataloged docs and prose cross-references stay silent, allowlist ratchet suppresses and prunes correctly by (code,key)).
doc-numbers: scanned 109 doc(s) / 103 claim(s) (floors 20/20); 4 grandfathered, 0 violations — OK.
sld-lint: scanned 57 spec doc(s) + 3174 code file(s); 0 error(s), 0 warning(s)
public-docs gate: 27 page(s) across 5 section(s) — all resolve inside the public boundary.
changelog-fragment gate: scanned 2 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
