### PR TITLE
feat(trusty-mpm): a session starts on the project's main checkout, with an explicit --worktree override

### DIFF
--- a/crates/trusty-memory/ui/package-lock.json
+++ b/crates/trusty-memory/ui/package-lock.json
@@ -597,9 +597,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -614,9 +611,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -631,9 +625,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -648,9 +639,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -665,9 +653,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -682,9 +667,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -699,9 +681,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -716,9 +695,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -733,9 +709,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -750,9 +723,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -767,9 +737,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -784,9 +751,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -801,9 +765,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/crates/trusty-mpm/changelog.d/5274-launch-worktree-flag.md
+++ b/crates/trusty-mpm/changelog.d/5274-launch-worktree-flag.md
@@ -1,0 +1,6 @@
+Added
+
+- `tm launch --worktree`, and the matching `worktree` field on
+  `POST /api/v1/sessions/managed`: the launch-time request that puts one
+  specific session in its own protected clone plus worktree, overriding the
+  main-checkout default.

--- a/crates/trusty-mpm/changelog.d/5274-pm-session-on-main-checkout.md
+++ b/crates/trusty-mpm/changelog.d/5274-pm-session-on-main-checkout.md
@@ -1,0 +1,6 @@
+Changed
+
+- A session now starts in the project's main checkout instead of provisioning
+  its own git worktree. The project's `worktree` setting no longer decides this
+  — it decides whether the AGENTS a session dispatches get isolated, and a
+  project registered `worktree: true` still isolates them exactly as before.

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -599,6 +599,17 @@ pub(crate) enum Command {
         /// to the default.
         #[arg(long)]
         style: Option<String>,
+        /// Run this session in its own git worktree instead of the project's
+        /// main checkout (#5274).
+        ///
+        /// By default a session launches in the project's own checkout: the PM
+        /// works where you work, and only the agents it dispatches are isolated
+        /// (governed separately by the project's `worktree` setting). Pass
+        /// `--worktree` when you want THIS session provisioned into a protected
+        /// managed clone plus a per-session worktree, leaving the live checkout
+        /// untouched.
+        #[arg(long)]
+        worktree: bool,
     },
     /// Start or attach to a session without running the deployment sequence.
     ///

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -1289,5 +1289,8 @@ async fn launch_protected_workspace(
     .await?;
 
     let dir = workspace.path().to_string_lossy().to_string();
-    super::launch::launch(client, url, Some(dir), None).await
+    // #5274: the fallback already provisioned the protected worktree it
+    // wants this session to run in, and passes it as `dir`; `launch` must not
+    // provision a SECOND one on top, so the worktree request stays `false`.
+    super::launch::launch(client, url, Some(dir), None, false).await
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -92,13 +92,19 @@ impl Drop for LaunchSessionGuard {
 /// session with the daemon, prints the banner, creates a detached tmux session
 /// running `claude` in the managed clone, and `attach`es to it. Errors with a
 /// `tm connect` hint when the directory has no parseable GitHub remote.
+///
+/// #5274: `worktree` is the operator's explicit request for isolation
+/// (`tm launch --worktree`). Without it the session runs in the project's own
+/// checkout and no clone is made — the sentence above about the live checkout
+/// never being touched describes the `--worktree` branch only.
 /// Test: `cli_parses_launch`, `cli_parses_launch_with_dir`,
-/// `cli_parses_launch_with_style`.
+/// `cli_parses_launch_with_style`, `cli_parses_launch_with_worktree`.
 pub(crate) async fn launch(
     client: &reqwest::Client,
     url: &str,
     dir: Option<String>,
     style: Option<String>,
+    worktree: bool,
 ) -> anyhow::Result<()> {
     // 1. Resolve the live source directory (absolute, so the banner is unambiguous).
     let live_path = resolve_dir(dir)?;
@@ -166,20 +172,22 @@ pub(crate) async fn launch(
     //    via the daemon's `spawn_managed_inproject` path — both converge on the
     //    SAME base clone at `~/trusty-mpm-projects/<owner>/<repo>/` and the SAME
     //    per-session worktree at `<base>/.worktrees/<session-id>/`.
-    //    #4300: `provision_for_launch` consults the per-project `worktree`
-    //    opt-out (#3455) FIRST — a project registered with `worktree: false`
-    //    gets neither a base clone nor a worktree here, exactly as the daemon's
-    //    `spawn_managed_on_main` gives it neither. It also resolves the repo
-    //    ROOT of `live_path` (so `tm launch` from a subdirectory of an
-    //    opted-out project deploys to the project, not the subdirectory) and
-    //    owns the uncommitted-changes notice, which only applies when there
-    //    IS a clone.
+    //    #5274: the base clone and worktree are provisioned ONLY when the
+    //    operator passed `--worktree`. Without it the session runs in the
+    //    project's main checkout, matching what the daemon's
+    //    `spawn_managed_routed` does for a spawn carrying no worktree request —
+    //    the project's `worktree` flag is deliberately not consulted here, since
+    //    it governs agent isolation rather than session placement.
+    //    `provision_for_launch` also resolves the repo ROOT of `live_path` (so
+    //    `tm launch` from a subdirectory deploys to the project, not the
+    //    subdirectory) and owns the uncommitted-changes notice, which only
+    //    applies when there IS a clone.
     let session_uuid = trusty_mpm::session_manager::ManagedSessionId::new();
     let workspace = super::managed_workspace::provision_for_launch(
-        &trusty_mpm::project::registry_data_dir(),
         &origin_url,
         &project_dir,
         &live_path,
+        worktree,
         &session_uuid,
     )
     .await?;

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_workspace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_workspace.rs
@@ -17,19 +17,23 @@
 //! [`provision_for_launch`] serves `tm launch` (which has already resolved
 //! the base-clone path) and [`provision_for_fallback`] serves the guided
 //! fallback (which parses `owner/repo` itself and reports daemon-specific
-//! remediation). Each entry point reads the registry EXACTLY once, via
-//! [`trusty_mpm::project::worktree_enabled_for_origin_at`], and passes the
-//! answer down — so the operator-facing notice and the filesystem action can
+//! remediation). Each entry point resolves the decision EXACTLY once and passes
+//! the answer down — so the operator-facing notice and the filesystem action can
 //! never disagree.
-//! Known redundancy, accepted: the daemon-unreachable fallback ends by
-//! calling `launch()`, so on that composed path the registry is read twice —
-//! once by [`provision_for_fallback`] and once by [`provision_for_launch`].
-//! Collapsing it would mean threading a pre-resolved `ManagedWorkspace`
-//! through `launch()`'s signature, a restructure that buys one avoided
-//! `read_to_string` of an atomically-published file whose read path takes no
-//! lock and fails open to isolation-ON. Both reads see the same bytes; the
-//! only operator-visible symptom was a duplicated notice, and that is fixed
-//! in [`provision_for_fallback`] directly.
+//!
+//! The two entry points answer DIFFERENT questions, and #5274 separated them.
+//! [`provision_for_launch`] decides SESSION PLACEMENT, which since #5274 is the
+//! main checkout unless the operator passed `tm launch --worktree`; it takes
+//! that request as a parameter and consults no registry at all. Only
+//! [`provision_for_fallback`] still reads
+//! [`trusty_mpm::project::worktree_enabled_for_origin_at`], because it is
+//! answering #1724's question instead — may bare `tm`, with the daemon down,
+//! deploy `CLAUDE.md` / `.mcp.json` / `.claude/` into whatever checkout the
+//! operator happens to be standing in? — where the registry's `worktree: false`
+//! is the project TELLING it yes. The two paths still compose: the fallback ends
+//! by calling `launch()` with its already-provisioned worktree as the cwd, so
+//! `provision_for_launch` names that protected directory rather than the live
+//! checkout.
 //! Scope note: this deliberately does NOT change #3455's concurrency
 //! behaviour. `spawn_managed_on_main` WARNS (never refuses) on a second
 //! session against one main checkout, and that stays the rule here — nothing
@@ -48,8 +52,9 @@ use trusty_mpm::session_manager::ManagedSessionId;
 /// so callers are forced to distinguish them rather than receiving a bare
 /// `PathBuf` that hides which one they got.
 /// What: `Worktree` carries `<base>/.worktrees/<session-id>`; `MainCheckout`
-/// carries the operator's own checkout root, returned only when the project is
-/// registered with `worktree: false`.
+/// carries the checkout root the session will run in — since #5274 the default
+/// outcome for `tm launch`, and still the #4300 outcome for a project that
+/// registered `worktree: false` on the daemon-unreachable fallback.
 /// Test: `managed_workspace_tests.rs`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ManagedWorkspace {
@@ -107,7 +112,7 @@ async fn provision(
         tracing::info!(
             origin = %origin_url,
             path = %main_checkout.display(),
-            "project has worktree isolation disabled (#3455); no base clone, no worktree"
+            "session runs in the main checkout; no base clone, no worktree (#5274)"
         );
         return Ok(ManagedWorkspace::MainCheckout(main_checkout.to_path_buf()));
     }
@@ -122,42 +127,50 @@ async fn provision(
     Ok(ManagedWorkspace::Worktree(worktree))
 }
 
-/// Provision the workspace for `tm launch` (#4300 call site 1).
+/// Provision the workspace for `tm launch` (#4300 call site 1, #5274).
 ///
-/// Why: `tm launch` runs the whole provisioning flow in-process and never
-/// asks the daemon, so it is the CLI path that most visibly ignored the
-/// opt-out before this.
-/// What: resolves the REPO ROOT of `cwd` and reads the opt-out from the
-/// registry at `registry_dir`, prints the notice for whichever branch applies,
-/// then delegates to [`provision`] with the caller-resolved `base_path`
+/// Why: `tm launch` runs the whole provisioning flow in-process and never asks
+/// the daemon, so it decides placement itself and must reach the SAME answer
+/// the daemon's `spawn_managed_routed` would. Since #5274 that answer is the
+/// project's main checkout unless the operator asked otherwise, so this takes
+/// the request as a parameter (`tm launch --worktree`) rather than reading the
+/// registry: the project's `worktree` flag governs AGENT isolation, and letting
+/// it decide session placement here would put the CLI and the daemon back on
+/// two different rules.
+/// What: resolves the REPO ROOT of `cwd`, prints the notice for whichever branch
+/// applies, then delegates to [`provision`] with the caller-resolved `base_path`
 /// (`inproject::base_clone_path(owner, repo)`). Errors are mapped to `tm
 /// launch`'s wording.
 ///
-/// The root resolution matters and is not incidental: `get_origin_url`
-/// succeeds at ANY depth, so `cd repo/src && tm launch` on an opted-out
-/// project would otherwise deploy `.claude`, the project hooks and the tmux
-/// cwd into `repo/src` rather than `repo` — landing tm's furniture exactly
-/// where the operator did not ask for it, which is the failure mode the
-/// opt-out exists to prevent. [`super::guided::find_git_root`] is the SAME
-/// helper the daemon-unreachable fallback's classifier uses, so both CLI
-/// entry points cannot disagree about which directory the project is. A `cwd`
-/// that is not inside a working tree (or a machine with no `git` on PATH)
-/// falls back to `cwd` itself — the pre-#4300 behaviour, never worse.
-/// Test: `provision_for_launch_opted_out_creates_no_clone_and_no_worktree`,
+/// The root resolution matters and is not incidental: `get_origin_url` succeeds
+/// at ANY depth, so `cd repo/src && tm launch` would otherwise deploy `.claude`,
+/// the project hooks and the tmux cwd into `repo/src` rather than `repo` —
+/// landing tm's furniture exactly where the operator did not ask for it.
+/// [`super::guided::find_git_root`] is the SAME helper the daemon-unreachable
+/// fallback's classifier uses, so both CLI entry points cannot disagree about
+/// which directory the project is. A `cwd` that is not inside a working tree (or
+/// a machine with no `git` on PATH) falls back to `cwd` itself — the pre-#4300
+/// behaviour, never worse.
+///
+/// #1724 survives the change unchanged, and by construction. The guided
+/// daemon-unreachable fallback composes onto this function: it provisions a
+/// protected worktree itself via [`provision_for_fallback`] and then calls
+/// `launch()` WITH that worktree as `cwd`, so `find_git_root` resolves to the
+/// worktree and `MainCheckout` here names the already-protected directory, never
+/// the operator's live checkout. The three `tests_behavior_b` cases cover it.
+/// Test: `provision_for_launch_without_a_request_uses_the_main_checkout`,
 /// `provision_for_launch_from_subdirectory_targets_repo_root`,
-/// `provision_for_launch_unset_creates_worktree`,
-/// `provision_for_launch_unregistered_origin_creates_worktree`.
+/// `provision_for_launch_explicit_request_creates_worktree`,
+/// `provision_for_launch_ignores_a_registered_worktree_true_project`.
 pub(crate) async fn provision_for_launch(
-    registry_dir: &Path,
     origin_url: &str,
     base_path: &Path,
     cwd: &Path,
+    worktree_requested: bool,
     session_id: &ManagedSessionId,
 ) -> anyhow::Result<ManagedWorkspace> {
     let main_checkout = super::guided::find_git_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
-    let isolate =
-        trusty_mpm::project::worktree_enabled_for_origin_at(registry_dir, origin_url).await;
-    if isolate {
+    if worktree_requested {
         eprintln!(
             "note: uncommitted local changes are not carried into the managed clone. \
              Use `tm connect` if you need to work from the live checkout."
@@ -165,15 +178,21 @@ pub(crate) async fn provision_for_launch(
         eprintln!("provisioning managed workspace...");
     } else {
         eprintln!(
-            "tm: worktree isolation is disabled for this project (#3455) — \
-             launching directly in {} (no managed clone, no worktree)",
+            "tm: launching in {} (no managed clone, no worktree) — \
+             pass `--worktree` to provision an isolated one instead",
             main_checkout.display()
         );
     }
 
-    provision(isolate, origin_url, base_path, &main_checkout, session_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to provision managed workspace: {e}"))
+    provision(
+        worktree_requested,
+        origin_url,
+        base_path,
+        &main_checkout,
+        session_id,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("failed to provision managed workspace: {e}"))
 }
 
 /// Provision the workspace for the daemon-unreachable guided fallback

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_workspace_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_workspace_tests.rs
@@ -175,20 +175,89 @@ fn expected_worktree(base: &Path, session_id: &ManagedSessionId) -> PathBuf {
 }
 
 // ── Path (a): `tm launch` ────────────────────────────────────────────────────
+//
+// #5274 rewrote this group. Before it, these four tests asked "did the CLI read
+// the project's opt-out?"; that question is now wrong at the root, because the
+// project's `worktree` flag no longer decides where a SESSION runs — it decides
+// whether the AGENTS that session dispatches get isolated. What the tests ask
+// instead is the placement contract's own two rules: the project cannot move a
+// session (rows 1 and 2), and an explicit request can (row 3).
 
-/// `tm launch` against a project registered with `worktree: false` must create
-/// NEITHER a base clone NOR a worktree, and must run in the live checkout.
+/// Contract row 1 — a project registered `worktree: true` does NOT get its
+/// session moved into a worktree (#5274).
 ///
-/// Why (#4300): `tm launch` provisions in-process and never asks the daemon,
-/// so before this fix the opt-out was ignored outright on this path.
-/// What: registers `worktree: false`, calls the exact function `launch()`
-/// calls, and asserts the returned workspace is the live checkout while the
-/// caller-supplied base-clone path stays untouched.
-/// Test: itself. RED with the guard reverted (a clone + worktree appear).
+/// Why: this is the whole point of the change, and the one row that used to
+/// resolve the other way. `tm launch` read `worktree_enabled_for_origin_at`,
+/// so a `worktree: true` registration (or, before it, the built-in `true`
+/// default that 31 of 33 registered projects fall through to) provisioned a base
+/// clone plus a per-session worktree and ran the session there. The owner ruling
+/// of 2026-08-09 separates the two questions: the PM works in the project's own
+/// checkout, and `worktree: true` means the AGENTS it dispatches are isolated.
+/// A machine-global `projects.json` must not be able to relocate a human's
+/// session.
+/// What: registers the launch origin with an EXPLICIT `worktree: true` — the
+/// strongest statement the project layer can make — passes no request, and
+/// asserts the returned workspace is the live checkout with nothing provisioned
+/// at the base-clone path.
+/// Test: itself. RED before #5274: the registry lookup returned `true` and the
+/// function returned `Worktree(<base>/.worktrees/<id>)`.
 #[tokio::test]
-async fn provision_for_launch_opted_out_creates_no_clone_and_no_worktree() {
+async fn provision_for_launch_ignores_a_registered_worktree_true_project() {
+    let origin = "https://github.invalid/fixture-owner/isolated-repo";
+    // Registered, and registered the "isolating" way. Kept deliberately: the
+    // fixture is the assertion. `provision_for_launch` no longer takes a
+    // registry directory at all, so a project cannot reach this decision even
+    // in principle — this test pins that the signature stays that way.
+    let _registry = registry_with(
+        "https://github.invalid/fixture-owner/isolated-repo",
+        Some(true),
+    )
+    .await;
+
+    let repos_root = tempfile::tempdir().unwrap();
+    let base = repos_root
+        .path()
+        .join("fixture-owner")
+        .join("isolated-repo");
+    init_git_repo(&base);
+    let live = tempfile::tempdir().unwrap();
+    let session_id = ManagedSessionId::new();
+
+    let workspace = provision_for_launch(origin, &base, live.path(), false, &session_id)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        workspace,
+        ManagedWorkspace::MainCheckout(live.path().to_path_buf()),
+        "#5274 row 1: a `worktree: true` project must not relocate the session"
+    );
+    assert!(
+        !expected_worktree(&base, &session_id).exists(),
+        "#5274: no per-session worktree may be created without an explicit request: {}",
+        expected_worktree(&base, &session_id).display()
+    );
+}
+
+/// Contract row 2 — a project registered `worktree: false` also runs its
+/// session in the main checkout (#5274, preserving #4300).
+///
+/// Why: rows 1 and 2 resolve the SAME way, and that identity is the contract's
+/// substance — placement does not consult the project at all, rather than
+/// consulting it and usually agreeing. Asserting only row 1 would leave the
+/// weaker reading ("the flag still decides, we just changed its default")
+/// indistinguishable from the real one. This row also keeps #4300's original
+/// acceptance intact: an opted-out project gets neither a clone nor a worktree.
+/// What: registers `worktree: false`, passes no request, and asserts both the
+/// main-checkout outcome and that the caller-supplied base-clone path is
+/// untouched — no directory, no `.git`, no `.worktrees`.
+/// Test: itself. Green before and after by construction; it goes RED the moment
+/// `provision_for_launch` provisions unconditionally, which is the mistake it
+/// exists to catch.
+#[tokio::test]
+async fn provision_for_launch_without_a_request_uses_the_main_checkout() {
     let origin = "git@github.invalid:fixture-owner/optout-repo.git";
-    let registry = registry_with(
+    let _registry = registry_with(
         "https://github.invalid/fixture-owner/optout-repo",
         Some(false),
     )
@@ -199,17 +268,17 @@ async fn provision_for_launch_opted_out_creates_no_clone_and_no_worktree() {
     let live = tempfile::tempdir().unwrap();
     let session_id = ManagedSessionId::new();
 
-    let workspace = provision_for_launch(registry.path(), origin, &base, live.path(), &session_id)
+    let workspace = provision_for_launch(origin, &base, live.path(), false, &session_id)
         .await
         .expect(
-            "#4300: an opted-out project must not attempt a clone at all — a clone \
-             error here means the opt-out was never consulted",
+            "no worktree request must not attempt a clone at all — a clone error \
+             here means the request was never consulted",
         );
 
     assert_eq!(
         workspace,
         ManagedWorkspace::MainCheckout(live.path().to_path_buf()),
-        "#4300: an opted-out project must launch in its own checkout"
+        "#5274 row 2: a session with no worktree request runs in its own checkout"
     );
     assert_nothing_provisioned(&base);
     assert!(
@@ -218,31 +287,69 @@ async fn provision_for_launch_opted_out_creates_no_clone_and_no_worktree() {
     );
 }
 
-/// `tm launch` from a SUBDIRECTORY of an opted-out project must deploy into
-/// the repo ROOT, never the subdirectory.
+/// Contract row 3 — an EXPLICIT request (`tm launch --worktree`) provisions the
+/// base clone and the per-session worktree (#5274).
 ///
-/// Why (code-critic MEDIUM on PR #4303): `get_origin_url` succeeds at any
-/// depth, so `cd repo/src && tm launch` on an opted-out project passed `cwd`
-/// straight through as the workspace — `.claude`, the project hooks, the tmux
-/// cwd and the daemon's `project_path` all landed in `repo/src`. That is
-/// precisely the "tm furniture somewhere the operator did not intend" failure
-/// the opt-out exists to prevent, and it was introduced by this PR: the
-/// pre-#4300 code always redirected to a worktree, so `cwd` never became a
-/// deploy target. The daemon-unreachable fallback already resolved the root
-/// via `classify_cwd_project`; this pins that `tm launch` agrees.
+/// Why: rule 2 of the contract is only real if the request actually reaches the
+/// filesystem. The revision of this change that preceded #5274's rewrite
+/// expressed the override as a `const fn`, which no user could reach — that is
+/// the failure mode this test rules out. It is also the only remaining way to
+/// get a worktree from `tm launch`, so it guards the capability from being
+/// quietly lost along with the default.
+/// What: passes `worktree_requested = true` against a real git base clone and
+/// asserts the returned variant is `Worktree` at its exact expected path AND
+/// that the directory exists on disk.
+/// Test: itself. RED with the request ignored (the function returns
+/// `MainCheckout` and no directory is created).
+#[tokio::test]
+async fn provision_for_launch_explicit_request_creates_worktree() {
+    let origin = "https://github.invalid/fixture-owner/isolated-repo";
+
+    let repos_root = tempfile::tempdir().unwrap();
+    let base = repos_root
+        .path()
+        .join("fixture-owner")
+        .join("isolated-repo");
+    init_git_repo(&base);
+    let live = tempfile::tempdir().unwrap();
+    let session_id = ManagedSessionId::new();
+
+    let workspace = provision_for_launch(origin, &base, live.path(), true, &session_id)
+        .await
+        .unwrap();
+
+    let expected = expected_worktree(&base, &session_id);
+    assert_eq!(
+        workspace,
+        ManagedWorkspace::Worktree(expected.clone()),
+        "#5274 row 3: an explicit `--worktree` request must provision one"
+    );
+    assert!(
+        expected.is_dir(),
+        "the worktree directory must exist at {}",
+        expected.display()
+    );
+}
+
+/// `tm launch` from a SUBDIRECTORY must deploy into the repo ROOT, never the
+/// subdirectory.
+///
+/// Why (code-critic MEDIUM on PR #4303): `get_origin_url` succeeds at any depth,
+/// so `cd repo/src && tm launch` passed `cwd` straight through as the workspace
+/// — `.claude`, the project hooks, the tmux cwd and the daemon's `project_path`
+/// all landed in `repo/src`. #5274 makes the main-checkout branch the DEFAULT
+/// rather than a rarely-taken opt-out, so every launch now runs through this
+/// resolution and the consequence of getting it wrong went from two projects to
+/// all of them. The daemon-unreachable fallback already resolved the root via
+/// `classify_cwd_project`; this pins that `tm launch` agrees.
 /// What: builds a REAL git repo (so `git rev-parse --show-toplevel` has a root
-/// to find), registers it opted-out, calls `provision_for_launch` with a
-/// nested subdirectory as `cwd`, and asserts the returned workspace is the
-/// canonical repo root and explicitly NOT the subdirectory.
+/// to find), calls `provision_for_launch` with a nested subdirectory as `cwd`,
+/// and asserts the returned workspace is the canonical repo root and explicitly
+/// NOT the subdirectory.
 /// Test: itself. RED if `provision_for_launch` passes `cwd` through.
 #[tokio::test]
 async fn provision_for_launch_from_subdirectory_targets_repo_root() {
     let origin = "https://github.invalid/fixture-owner/optout-repo.git";
-    let registry = registry_with(
-        "https://github.invalid/fixture-owner/optout-repo",
-        Some(false),
-    )
-    .await;
 
     let repos_root = tempfile::tempdir().unwrap();
     let base = repos_root.path().join("fixture-owner").join("optout-repo");
@@ -257,22 +364,19 @@ async fn provision_for_launch_from_subdirectory_targets_repo_root() {
     let repo_root = live.path().canonicalize().unwrap();
     let session_id = ManagedSessionId::new();
 
-    let workspace = provision_for_launch(registry.path(), origin, &base, &subdir, &session_id)
+    let workspace = provision_for_launch(origin, &base, &subdir, false, &session_id)
         .await
-        .expect(
-            "#4300: an opted-out project must not attempt a clone at all — a clone \
-             error here means the opt-out was never consulted",
-        );
+        .expect("no worktree request must not attempt a clone at all");
 
     assert_eq!(
         workspace,
         ManagedWorkspace::MainCheckout(repo_root.clone()),
-        "#4300: `tm launch` from a subdirectory must target the repo ROOT"
+        "`tm launch` from a subdirectory must target the repo ROOT"
     );
     assert_ne!(
         workspace.path(),
         subdir.as_path(),
-        "#4300: the subdirectory must NEVER become the deploy target"
+        "the subdirectory must NEVER become the deploy target"
     );
     assert!(
         !subdir.join(".claude").exists(),
@@ -280,88 +384,6 @@ async fn provision_for_launch_from_subdirectory_targets_repo_root() {
         subdir.display()
     );
     assert_nothing_provisioned(&base);
-}
-
-/// A project with NO `worktree` key still gets a worktree — the `unwrap_or(true)`
-/// default must not regress.
-///
-/// Why: 31 of the 33 registered projects carry no `worktree` key; a fix that
-/// silently flipped them to main-checkout mode would be far worse than the bug.
-/// What: registers the project with `worktree: None`, provisions, and asserts
-/// the worktree exists at its exact expected path inside the base clone.
-/// Test: itself.
-#[tokio::test]
-async fn provision_for_launch_unset_creates_worktree() {
-    let origin = "https://github.invalid/fixture-owner/isolated-repo";
-    let registry = registry_with("https://github.invalid/fixture-owner/isolated-repo", None).await;
-
-    let repos_root = tempfile::tempdir().unwrap();
-    let base = repos_root
-        .path()
-        .join("fixture-owner")
-        .join("isolated-repo");
-    init_git_repo(&base);
-    let live = tempfile::tempdir().unwrap();
-    let session_id = ManagedSessionId::new();
-
-    let workspace = provision_for_launch(registry.path(), origin, &base, live.path(), &session_id)
-        .await
-        .unwrap();
-
-    let expected = expected_worktree(&base, &session_id);
-    assert_eq!(
-        workspace,
-        ManagedWorkspace::Worktree(expected.clone()),
-        "a project with no `worktree` key must still get a worktree"
-    );
-    assert!(
-        expected.is_dir(),
-        "the worktree directory must exist at {}",
-        expected.display()
-    );
-}
-
-/// An UNREGISTERED origin also keeps worktree isolation — the default applies
-/// to projects the registry has never heard of, not just to unset keys.
-///
-/// Why: the registry holds 33 of the machine's projects; every other repo the
-/// operator runs `tm launch` in resolves through the "no match" branch.
-/// What: builds a registry holding a DIFFERENT project's opt-out, then
-/// provisions for an unrelated origin and asserts the worktree is created.
-/// Test: itself.
-#[tokio::test]
-async fn provision_for_launch_unregistered_origin_creates_worktree() {
-    let registry = registry_with(
-        "https://github.invalid/fixture-owner/optout-repo",
-        Some(false),
-    )
-    .await;
-
-    let origin = "https://github.invalid/fixture-owner/never-registered";
-    let repos_root = tempfile::tempdir().unwrap();
-    let base = repos_root
-        .path()
-        .join("fixture-owner")
-        .join("never-registered");
-    init_git_repo(&base);
-    let live = tempfile::tempdir().unwrap();
-    let session_id = ManagedSessionId::new();
-
-    let workspace = provision_for_launch(registry.path(), origin, &base, live.path(), &session_id)
-        .await
-        .unwrap();
-
-    let expected = expected_worktree(&base, &session_id);
-    assert_eq!(
-        workspace,
-        ManagedWorkspace::Worktree(expected.clone()),
-        "another project's opt-out must not leak onto an unrelated origin"
-    );
-    assert!(
-        expected.is_dir(),
-        "worktree must exist at {}",
-        expected.display()
-    );
 }
 
 // ── Path (b): the daemon-unreachable bare-`tm` fallback ─────────────────────

--- a/crates/trusty-mpm/src/bin/tm/commands/run_target.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/run_target.rs
@@ -218,11 +218,14 @@ async fn run_managed(
         );
     }
 
+    // #5274: `tm run` targets an already-resolved managed checkout, so the
+    // session runs there directly; it carries no operator worktree request.
     super::launch::launch(
         client,
         url,
         Some(checkout.base_path.to_string_lossy().into_owned()),
         None,
+        false,
     )
     .await
 }

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -491,7 +491,11 @@ async fn main() -> anyhow::Result<()> {
             auto_resume,
             no_classify,
         }) => commands::supervisor::run_supervisor(addr, interval, auto_resume, no_classify).await,
-        Some(Command::Launch { dir, style }) => launch(&client, &url, dir, style).await,
+        Some(Command::Launch {
+            dir,
+            style,
+            worktree,
+        }) => launch(&client, &url, dir, style, worktree).await,
         Some(Command::Connect { dir }) => connect(&client, &url, dir).await,
         Some(Command::Attach { target, json }) => attach_cmd(&client, &url, &target, json).await,
         Some(Command::Optimizer { action }) => optimizer(&client, &url, action).await,

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -610,9 +610,14 @@ fn cli_meta_requires_action() {
 fn cli_parses_launch() {
     let cli = Cli::try_parse_from(["trusty-mpm", "launch"]).unwrap();
     match cli.command.unwrap() {
-        Command::Launch { dir, style } => {
+        Command::Launch {
+            dir,
+            style,
+            worktree,
+        } => {
             assert_eq!(dir, None);
             assert_eq!(style, None);
+            assert!(!worktree, "#5274: a bare `tm launch` requests no worktree");
         }
         other => panic!("expected launch, got {other:?}"),
     }
@@ -622,9 +627,14 @@ fn cli_parses_launch() {
 fn cli_parses_launch_with_dir() {
     let cli = Cli::try_parse_from(["trusty-mpm", "launch", "/work/p"]).unwrap();
     match cli.command.unwrap() {
-        Command::Launch { dir, style } => {
+        Command::Launch {
+            dir,
+            style,
+            worktree,
+        } => {
             assert_eq!(dir.as_deref(), Some("/work/p"));
             assert_eq!(style, None);
+            assert!(!worktree);
         }
         other => panic!("expected launch, got {other:?}"),
     }
@@ -636,9 +646,46 @@ fn cli_parses_launch_with_style() {
     let cli =
         Cli::try_parse_from(["trusty-mpm", "launch", "--style", "trusty-mpm-teacher"]).unwrap();
     match cli.command.unwrap() {
-        Command::Launch { dir, style } => {
+        Command::Launch {
+            dir,
+            style,
+            worktree,
+        } => {
             assert_eq!(dir, None);
             assert_eq!(style.as_deref(), Some("trusty-mpm-teacher"));
+            assert!(!worktree);
+        }
+        other => panic!("expected launch, got {other:?}"),
+    }
+}
+
+/// `tm launch --worktree` must reach the parser as a real, distinct request
+/// (#5274 — contract row 3).
+///
+/// Why: rule 2 of the #5274 placement contract says an EXPLICIT user request
+/// can put a session in a worktree, and rule 1 says nothing else can. That only
+/// holds if such a request is expressible at launch time. Without this flag the
+/// contract's third row has no way to be entered at all, and the earlier attempt
+/// at this change reached for a `const fn` that no user could override.
+/// What: parses `tm launch --worktree` and asserts the flag arrives `true`,
+/// while `cli_parses_launch` above pins the bare form at `false`. The pair is
+/// what makes "explicit" mean explicit rather than "always on".
+/// Test: itself.
+#[test]
+fn cli_parses_launch_with_worktree() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "launch", "--worktree"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Launch {
+            dir,
+            style,
+            worktree,
+        } => {
+            assert_eq!(dir, None);
+            assert_eq!(style, None);
+            assert!(
+                worktree,
+                "`--worktree` must surface as an explicit worktree request (#5274)"
+            );
         }
         other => panic!("expected launch, got {other:?}"),
     }

--- a/crates/trusty-mpm/src/daemon/managed_routes/launch_on_main.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/launch_on_main.rs
@@ -11,12 +11,20 @@
 //! (`write_task_md`/`prepare_inproject_session`/`front_gate_or_escalate`/
 //! `resolve_gh_env`) stay owned by `lifecycle` and are called back into.
 //! What: [`has_concurrent_main_checkout_session`] (pure collision detector)
-//! and [`spawn_managed_on_main`] (the no-worktree spawn flow). The registry
-//! lookup that DECIDES whether isolation is on used to live here too, as a
-//! `pub(super)` `worktree_enabled_for_origin`; #4300 moved it to
-//! [`crate::project::worktree_policy`] because the `tm` CLI provisions
-//! worktrees in its OWN process and could not reach a `daemon::`-scoped
-//! function — the daemon now calls the shared one.
+//! and [`spawn_managed_on_main`] (the no-worktree spawn flow).
+//!
+//! #5274 made this the DEFAULT placement for a session rather than a
+//! per-project opt-out, and with that the registry lookup that used to gate it
+//! left this module for good. It was `worktree_enabled_for_origin` here, then
+//! `worktree_isolated` (a thin `DaemonState` → [`crate::project::worktree_policy`]
+//! adapter) after #4300 hoisted the policy out of `daemon::` so the `tm` CLI
+//! could reach it. `spawn_managed_routed` now branches on
+//! `SpawnParams::worktree` — an explicit launch-time request — because the
+//! project's `worktree` flag answers a DIFFERENT question: whether the agents a
+//! session dispatches get isolated. That flag and its resolver family
+//! ([`crate::project::worktree_enabled_for_project`] and friends) are untouched
+//! and still authoritative for agent isolation; they simply have no say in where
+//! the session itself runs.
 //! Test: `spawn_managed_on_main_creates_record_without_worktree` and
 //! `spawn_managed_on_main_warns_on_concurrent_main_checkout_session` in
 //! `lifecycle_tests.rs` (this module's tests live with `lifecycle`'s, since
@@ -33,31 +41,6 @@ use super::lifecycle::{
 use crate::daemon::state::DaemonState;
 use crate::runtime::RuntimeKind;
 use crate::session_manager::{ManagedSessionId, ManagedSessionState, SessionRecord};
-
-/// Does this project's next managed session get its own git worktree? (#5207)
-///
-/// Why: the decision needs a live [`ProjectRegistry`] from [`DaemonState`], and
-/// [`crate::project::worktree_policy`] must not depend on `daemon::` to get one
-/// — that coupling is exactly what #4300 unpicked. This is the daemon-side
-/// adapter: it supplies the registry, the shared policy decides. Keeping it
-/// here rather than inline in `lifecycle::spawn_managed_routed` also honours
-/// this module's reason for existing (see the module doc — `lifecycle.rs` is
-/// frozen at its allowlisted SLOC budget).
-/// What: delegates to [`crate::project::worktree_enabled_for_project`], which
-/// resolves the project's committed `.trusty-mpm.toml` ABOVE the machine-global
-/// registry, and the built-in `true` below both. Only the in-project spawn
-/// branch can call this — the clone-based branch has no project directory yet
-/// and uses [`crate::project::worktree_enabled_for_origin`] instead.
-/// Test: `worktree_project_config_overrides_registry` and the rest of the
-/// project-layer cases in `project::worktree_policy_tests`.
-pub(super) async fn worktree_isolated(
-    state: &Arc<DaemonState>,
-    local_path: &std::path::Path,
-    origin_url: &str,
-) -> bool {
-    let registry = state.project_registry().await;
-    crate::project::worktree_enabled_for_project(local_path, &registry, origin_url).await
-}
 
 /// Return the FIRST already-`Active` session whose cwd is EXACTLY
 /// `local_path`, if any (#3455 collision detector).

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -148,6 +148,32 @@ pub struct SpawnParams {
     /// `session_new`, the SM-STDIO adapter, the chat surfaces — keep
     /// reconnecting) preserves #1707.
     pub force_new: bool,
+    /// Whether the CALLER EXPLICITLY ASKED for a per-session git worktree (#5274).
+    ///
+    /// Why: a PM session runs on the project's main checkout, and the project's
+    /// `worktree` flag cannot change that — that flag governs whether the AGENTS
+    /// a PM dispatches get isolated, which is a different question with a
+    /// different answer (owner ruling, 2026-08-09: "`worktree: false` means that
+    /// the entire project works on the main checkout"). Placement therefore needs
+    /// an input that only a person can supply, and this is it: a launch-time
+    /// request carried from `tm launch --worktree` / a `"worktree": true` HTTP
+    /// spawn body down to [`spawn_managed_routed`]'s branch point. Reading the
+    /// registry there instead is the defect this field exists to prevent — it
+    /// would let a machine-global config decide where a human's session runs.
+    /// What: `true` provisions the per-session worktree (the pre-#5274 in-project
+    /// behaviour); `false` — the default for every programmatic caller — spawns
+    /// on the main checkout via
+    /// [`super::launch_on_main::spawn_managed_on_main`]. Only the in-project
+    /// branch reads it; a remote `repo_url` has no main checkout to sit on and
+    /// still clones.
+    /// Test: `super::tests::spawn_request_worktree_wire_shape` pins the wire
+    /// shape this field is fed from; the placement behaviour it selects is
+    /// covered on the CLI twin of the same rule by
+    /// `provision_for_launch_ignores_a_registered_worktree_true_project`,
+    /// `provision_for_launch_without_a_request_uses_the_main_checkout`, and
+    /// `provision_for_launch_explicit_request_creates_worktree` in
+    /// `bin/tm/commands/managed_workspace_tests.rs`.
+    pub worktree: bool,
 }
 
 /// Spawn a managed session, shared by the HTTP handler and the MCP tool.
@@ -365,26 +391,31 @@ async fn spawn_managed_routed(
         // through to the existing local-path spawn.
         let local_path = std::path::Path::new(&params.repo_url);
 
-        // #3455 "launch on main" opt-out: checked BEFORE `try_inproject_spawn`
-        // (which would otherwise establish a base clone as a side effect even
-        // when it's never going to be used) so a project with worktree
-        // isolation disabled never gets a base clone OR a worktree at all —
-        // the exact wasted-disk-space complaint the issue raises. Only a
-        // GitHub-remote-having local checkout can match a registered project
-        // (mirrors `try_inproject_spawn`'s own detection).
+        // #5274: a PM session runs on the project's main checkout. Decided
+        // BEFORE `try_inproject_spawn` (which would otherwise establish a base
+        // clone as a side effect even when it's never going to be used) so the
+        // default placement creates neither a base clone NOR a worktree — the
+        // wasted-disk-space complaint #3455 raised, now the common case rather
+        // than an opt-out. Only a GitHub-remote-having local checkout can reach
+        // `spawn_managed_on_main` (it needs `owner`/`repo` for the source id),
+        // which mirrors `try_inproject_spawn`'s own detection.
         if let Some(origin_url) = super::inproject::get_origin_url(local_path)
             && let Some(gh) = trusty_common::github_path::parse_github_path(&origin_url)
         {
-            // #5207: the project dir is already resolved here, so this branch
-            // consults the project's own committed `.trusty-mpm.toml` ABOVE the
-            // machine-global registry. The clone-based branch below has no
-            // project dir yet and keeps using the registry-only entry point.
-            if !super::launch_on_main::worktree_isolated(state, local_path, &origin_url).await {
+            // #5274: `params.worktree` is the ONLY input here, and that is the
+            // point. The project's `worktree` flag (`.trusty-mpm.toml`, then the
+            // registry — `project::worktree_enabled_for_project`) governs whether
+            // the AGENTS this session dispatches get isolated; it does not decide
+            // where the session itself runs. Consulting it here is what let a
+            // machine-global config silently relocate a human's session, so the
+            // branch reads the launch-time request instead — see
+            // `SpawnParams::worktree`.
+            if !params.worktree {
                 info!(
                     id = %session_id,
                     path = %local_path.display(),
-                    "spawn_managed: project has worktree isolation disabled (#3455); \
-                     launching directly in the main checkout"
+                    "spawn_managed: no explicit worktree request (#5274); \
+                     launching the session in the main checkout"
                 );
                 // Same reconnect pre-flight the worktree branch runs below
                 // (#1707 + `force_new` opt-out, #2450): a live session for

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle_tests.rs
@@ -432,6 +432,9 @@ async fn reserve_inproject_worktree_uses_semantic_name_not_uuid() {
         inject_task: None,
         deliverable_id: None,
         force_new: false,
+        // #5274: this test drives `reserve_inproject_worktree` directly — the
+        // branch an explicit worktree request routes to.
+        worktree: true,
     };
 
     let config = crate::core::trusty_tools_config::TrustyToolsConfig::default();
@@ -741,6 +744,9 @@ async fn spawn_managed_on_main_creates_record_without_worktree() {
         inject_task: None,
         deliverable_id: None,
         force_new: false,
+        // #5274: this test drives `spawn_managed_on_main` directly, which is
+        // the branch a spawn carrying no worktree request lands on.
+        worktree: false,
     };
 
     let record = spawn_managed_on_main(

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -159,6 +159,18 @@ pub struct SpawnRequest {
     /// mismatch (400), not tolerated as `false`.
     #[serde(default)]
     pub background: bool,
+    /// Optional EXPLICIT worktree request (#5274): `true` provisions the session
+    /// its own per-session git worktree; absent/`false` runs it in the project's
+    /// main checkout.
+    ///
+    /// Why: this is the wire form of the only input allowed to decide session
+    /// placement — see [`lifecycle::SpawnParams::worktree`] for why the project's
+    /// `worktree` flag deliberately cannot. `tm launch --worktree` sets it; every
+    /// other client omits it and gets the main checkout. Like `force_new` and
+    /// `background` it is a plain `#[serde(default)]` bool, so an explicit
+    /// `"worktree": null` is a 400 rather than a silently-tolerated `false`.
+    #[serde(default)]
+    pub worktree: bool,
 }
 
 /// Response body for POST /api/v1/sessions/managed (spawn, 201 Created).
@@ -456,6 +468,10 @@ pub async fn spawn_session(
         // session", `tm session new`) sets `force_new: true` to skip the
         // in-project reconnect pre-flight and always spawn fresh.
         force_new: req.force_new,
+        // #5274: the explicit "give this session its own worktree" request. Only
+        // a human-driven surface sets it (`tm launch --worktree`); absent, the
+        // session runs in the project's main checkout.
+        worktree: req.worktree,
     };
 
     // Async path (#2605): provision on a detached task and return the job id

--- a/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
@@ -1329,3 +1329,44 @@ async fn stale_assets_for_many_keeps_per_session_verdicts_correct_under_concurre
         );
     }
 }
+
+/// The `worktree` spawn request survives the wire in all three shapes (#5274).
+///
+/// Why: `SpawnRequest::worktree` is the ONLY way a person's "give this session
+/// its own worktree" reaches the daemon — `tm launch --worktree` posts it and
+/// nothing else does. A dropped `#[serde(default)]`, a rename, or an
+/// `Option<bool>` would each fail silently in a different direction: the first
+/// makes every existing client's body a 400, the second makes the flag a no-op,
+/// the third makes `"worktree": null` mean main-checkout instead of rejecting a
+/// malformed body. None of those is visible from a behaviour test, so the wire
+/// shape is pinned here directly.
+/// What: deserializes three bodies — key absent, `true`, and `null` — and
+/// asserts `false` / `true` / a parse error respectively. The `null` case is the
+/// deliberate consequence of a plain `bool` over `Option<bool>`, the same choice
+/// `force_new` and `background` make and for the same reason.
+/// Test: itself.
+#[test]
+fn spawn_request_worktree_wire_shape() {
+    let base = r#"{"repo_url":"https://github.invalid/o/r","ref":"main","task":"t""#;
+
+    let absent: super::SpawnRequest = serde_json::from_str(&format!("{base}}}")).expect("absent");
+    assert!(
+        !absent.worktree,
+        "#5274: a body with no `worktree` key must mean the main checkout, so \
+         every pre-existing client keeps working unchanged"
+    );
+
+    let asked: super::SpawnRequest =
+        serde_json::from_str(&format!(r#"{base},"worktree":true}}"#)).expect("true");
+    assert!(
+        asked.worktree,
+        "#5274: `\"worktree\": true` must arrive as an explicit worktree request"
+    );
+
+    assert!(
+        serde_json::from_str::<super::SpawnRequest>(&format!(r#"{base},"worktree":null}}"#))
+            .is_err(),
+        "an explicit null is a malformed body, not a tolerated `false` — same \
+         rule as `force_new` and `background`"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/manager/actuator.rs
+++ b/crates/trusty-mpm/src/daemon/manager/actuator.rs
@@ -196,6 +196,10 @@ impl SessionLauncher for DaemonLauncher {
             deliverable_id: None,
             // A confirmed "launch" is an explicit new-session intent.
             force_new: true,
+            // #5274: a confirmed manager launch says NEW session, not ISOLATED
+            // session — the two are separate requests. It runs in the project's
+            // main checkout like every other unrequested placement.
+            worktree: false,
         };
         let record = spawn_managed(&self.state, ManagedSessionId::new(), params).await?;
         Ok(LaunchOutcome {

--- a/crates/trusty-mpm/src/daemon/mcp_session.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_session.rs
@@ -88,6 +88,12 @@ pub async fn session_new(
         // duplicate — idempotent reconnect is the safe default for automated
         // callers (prevents LLM-driven session proliferation).
         force_new: false,
+        // #5274: the MCP tool surface does not expose the worktree request, the
+        // same boundary `deliverable_id` above draws — an explicit request for
+        // isolation is a person's decision, and this is the surface an LLM
+        // caller drives. An MCP-spawned session runs in the main checkout;
+        // `tm launch --worktree` is how a human asks for the other placement.
+        worktree: false,
     };
     let record = spawn_managed(
         state,

--- a/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
+++ b/crates/trusty-mpm/src/daemon/sm_stdio/control.rs
@@ -149,6 +149,10 @@ impl SessionControl for DaemonSessionControl {
             // programmatic driver; an idempotent reconnect for a project that
             // already has a live session is the safe default here too.
             force_new: false,
+            // #5274: `sm.sessions.launch` carries no worktree request in its
+            // `LaunchParams` wire shape, so the session runs in the project's
+            // main checkout — the same default every programmatic caller gets.
+            worktree: false,
         };
         let record = spawn_managed(
             &self.state,

--- a/crates/trusty-mpm/src/project/worktree_policy_tests.rs
+++ b/crates/trusty-mpm/src/project/worktree_policy_tests.rs
@@ -465,3 +465,68 @@ async fn worktree_clone_branch_resolves_without_a_project_dir() {
         "a non-existent project dir must fall through to the registry"
     );
 }
+
+/// Contract row 4 — AGENT isolation survives #5274 intact on a `worktree: true`
+/// project, whether that `true` is explicit or the built-in default.
+///
+/// Why: #5274 took PM SESSION PLACEMENT away from this resolver family, and the
+/// first attempt at that change took agent isolation with it — it flipped
+/// `Project::worktree_enabled` and `worktree_enabled_in` from `unwrap_or(true)`
+/// to `unwrap_or(false)`, which silently disabled agent worktrees on every one
+/// of the 31-of-33 registered projects carrying no explicit key. CI caught one
+/// consequence (`patch_round_trips_worktree_opt_out`); nothing asserted the
+/// rule itself. The owner ruling keeps the flag with a specific meaning —
+/// "`worktree: false` means that the entire project works on the main
+/// checkout" — so `true`, however it is reached, must still mean the agents
+/// this project dispatches are isolated.
+/// What: drives [`worktree_enabled_for_project`], the resolver an
+/// agent-isolation consumer reads, across both routes to `true` — an explicit
+/// `worktree: true` registration, and a project the registry has never heard of
+/// — and asserts both resolve isolation ON. The third assertion pins that
+/// `false` is still reachable, so a resolver hard-wired to `true` fails here
+/// too rather than passing the first two by accident.
+/// Test: itself. RED on the reverted `adf4faf76` default flip: assertions 1 and
+/// 2 both fail.
+#[tokio::test]
+async fn agent_isolation_stays_enabled_for_a_worktree_true_project() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let registry = ProjectRegistry::load(dir.path()).await.expect("load");
+    registry
+        .register(project(
+            "isolated",
+            "https://github.com/acme/isolated",
+            Some(true),
+        ))
+        .await
+        .expect("register");
+    registry
+        .register(project(
+            "on-main",
+            "https://github.com/acme/on-main",
+            Some(false),
+        ))
+        .await
+        .expect("register");
+
+    // No `.trusty-mpm.toml` anywhere here: this asserts the registry + built-in
+    // layers, which are the two the flip broke.
+    let proj = tempfile::TempDir::new().expect("tempdir");
+
+    assert!(
+        worktree_enabled_for_project(proj.path(), &registry, "https://github.com/acme/isolated")
+            .await,
+        "#5274 row 4: an explicit `worktree: true` must keep agent isolation ON"
+    );
+    assert!(
+        worktree_enabled_for_project(proj.path(), &registry, "https://github.com/acme/unheard-of")
+            .await,
+        "#5274 row 4: a project with no registry entry must default to agent \
+         isolation ON — flipping this default is the defect this test guards"
+    );
+    assert!(
+        !worktree_enabled_for_project(proj.path(), &registry, "https://github.com/acme/on-main")
+            .await,
+        "`worktree: false` must still reach the main-checkout answer, or the two \
+         assertions above would pass for a resolver hard-wired to `true`"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/search_gc.rs
+++ b/crates/trusty-mpm/src/session_manager/search_gc.rs
@@ -455,6 +455,50 @@ mod tests {
         assert_eq!(disposable_workspace_index_id(Some(path), false), None);
     }
 
+    /// A PM session launched ON the project's main checkout must never have
+    /// that checkout's trusty-search index reclaimed (ADR-0036).
+    ///
+    /// Why: ADR-0036 made the main checkout the DEFAULT workspace for a PM
+    /// session rather than a rarely-taken opt-out, so the population reaching
+    /// this predicate with a real, long-lived directory went from a handful of
+    /// projects to all of them. The index rooted at a main checkout is the
+    /// PROJECT's index — the one every search in that repo resolves to — not a
+    /// disposable per-session index, and decommissioning a session must not
+    /// reclaim it. The existing guard covers this by construction
+    /// (`spawn_managed_on_main` records `workspace_owned = false` and a path
+    /// that is not a `.worktrees/` leaf), but nothing asserted it for a real
+    /// git checkout: `disposable_index_id_none_for_unowned_non_worktree` uses a
+    /// bare non-existent path, so it would pass even if the predicate returned
+    /// early on "no `.git` here" rather than on the ownership rule.
+    /// What: builds a real checkout — a `.git` DIRECTORY at its root, which is
+    /// what `resolve_project_root` looks for and what would otherwise yield a
+    /// derivable index id — and asserts the predicate still returns `None`.
+    /// Deleting either half of the `workspace_owned || is_session_worktree`
+    /// guard turns this red.
+    /// Test: itself.
+    #[test]
+    fn disposable_index_id_none_for_a_main_checkout_pm_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let main_checkout = tmp.path().join("bobmatnyc").join("trusty-tools");
+        std::fs::create_dir_all(main_checkout.join(".git")).unwrap();
+
+        // Precondition: this path IS resolvable to an index id — so a `None`
+        // below is the ownership guard firing, not a failure to resolve.
+        assert_eq!(
+            disposable_workspace_index_id(Some(&main_checkout), true).as_deref(),
+            Some("trusty-tools"),
+            "fixture precondition: the path must be index-id-resolvable, or the \
+             assertion below would pass for the wrong reason"
+        );
+
+        assert_eq!(
+            disposable_workspace_index_id(Some(&main_checkout), false),
+            None,
+            "a PM session on the project's main checkout must never have the \
+             project's own search index reclaimed (ADR-0036)"
+        );
+    }
+
     #[test]
     fn disposable_index_id_derives_from_worktree_path() {
         // In-project worktree (workspace_owned = false, but IS a `.worktrees/`

--- a/crates/trusty-mpm/tests/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/tests/mcp_spawn_gate.rs
@@ -78,6 +78,9 @@ fn base_params(repo_url: &str, mcp_initiated: bool) -> SpawnParams {
         inject_task: None,
         deliverable_id: None,
         force_new: false,
+        // #5274: the gate runs before any placement decision, so these cases
+        // are indifferent to it; `false` is the default every caller gets.
+        worktree: false,
     }
 }
 


### PR DESCRIPTION
The PM sits on the project's main checkout. The project's `worktree` setting keeps its meaning — it decides whether the AGENTS a session dispatches get isolated — and no longer decides where the session itself runs.

Owner ruling, verbatim: "`worktree: false` means that the entire project works on the main checkout, more typical for writing projects."

## Precedence

| Case | Placement | Code path |
|---|---|---|
| Session, project `worktree: true`, no request | main checkout | `spawn_managed_routed` branches on `params.worktree` alone (`lifecycle.rs:390`); `provision_for_launch` has no registry parameter |
| Session, project `worktree: false`, no request | main checkout | same branch, same input |
| Session, explicit user request | worktree | `tm launch --worktree` → `provision_for_launch(worktree_requested = true)`; `"worktree": true` → `SpawnRequest.worktree` → `SpawnParams.worktree` |
| Agent dispatch, project `worktree: true` | its own worktree | `project::worktree_enabled_for_project` and family, untouched from `origin/main` |

Rows 1 and 2 resolving identically is the substance: placement does not consult the project at all, rather than consulting it and usually agreeing.

## The user-override path is new

No launch-time worktree request existed. Added, following `deliverable_id`'s precedent for how far a spawn input travels:

- `SpawnParams::worktree` — the threaded decision, read at the one branch point.
- `SpawnRequest.worktree` — `#[serde(default)]` plain `bool`, so an absent key is the main checkout and `"worktree": null` is a 400. Same rule as `force_new` and `background`.
- `tm launch --worktree`.

Not added to MCP `session_new` or `sm.sessions.launch`: both are automated callers, and `deliverable_id` already draws that boundary in the same struct ("#2379's CLI surface is `tm sessions new --deliverable`, HTTP-only"). An explicit request for isolation is a person's decision; those surfaces pass `worktree: false`.

`launch_on_main::worktree_isolated` — the `DaemonState` → `worktree_policy` adapter that fed the old placement decision — loses its only caller and is deleted. The resolver family it wrapped is byte-identical to `origin/main`.

## #1724 survives by construction

`provision_for_fallback` is unchanged. It still reads `worktree_enabled_for_origin_at`, because it answers a different question: may bare `tm`, with the daemon down, deploy `CLAUDE.md` / `.mcp.json` / `.claude/` into whatever checkout the operator is standing in? A registered `worktree: false` is the project telling it yes; nothing else is.

The two paths compose. The fallback provisions its protected worktree and then calls `launch()` with THAT as the cwd, so `find_git_root` resolves to the worktree and `provision_for_launch`'s `MainCheckout` names the already-protected directory. Verified: the three `tests_behavior_b` cases pass, and `provision_for_launch_from_subdirectory_targets_repo_root` pins the root resolution that makes it hold.

## Regression tests, with before/after

Every neutered run below is the named change applied to this branch, then reverted.

**Row 4 — `agent_isolation_stays_enabled_for_a_worktree_true_project`.** Neuter: the `adf4faf7` flip, `unwrap_or(true)` → `unwrap_or(false)` in `Project::worktree_enabled` and `worktree_enabled_in`.

```
test project::worktree_policy::tests::agent_isolation_stays_enabled_for_a_worktree_true_project ... FAILED
panicked at crates/trusty-mpm/src/project/worktree_policy_tests.rs:520:5:
#5274 row 4: a project with no registry entry must default to agent isolation ON — flipping this default is the defect this test guards
test result: FAILED. 0 passed; 1 failed
```

The same neuter reproduces the CI failure this PR arrived with:

```
test patch_round_trips_worktree_opt_out ... FAILED
assertion failed: fetched.worktree_enabled()
```

**Row 1 — `provision_for_launch_ignores_a_registered_worktree_true_project`.** Neuter: the pre-change rule, `worktree_requested = worktree_enabled_for_origin_at(registry_dir, origin_url)`.

```
test ..._without_a_request_uses_the_main_checkout ... ok
test ..._from_subdirectory_targets_repo_root ... FAILED
test ..._explicit_request_creates_worktree ... ok
test ..._ignores_a_registered_worktree_true_project ... FAILED
assertion `left == right` failed: #5274 row 1: a `worktree: true` project must not relocate the session
test result: FAILED. 2 passed; 2 failed
```

**Row 2 — `provision_for_launch_without_a_request_uses_the_main_checkout`.** Neuter: `worktree_requested = true`.

```
test ..._without_a_request_uses_the_main_checkout ... FAILED
test ..._from_subdirectory_targets_repo_root ... FAILED
test ..._explicit_request_creates_worktree ... ok
test ..._ignores_a_registered_worktree_true_project ... FAILED
test result: FAILED. 1 passed; 3 failed
```

**Row 3 — `provision_for_launch_explicit_request_creates_worktree`.** Neuter: `worktree_requested = false`.

```
test ..._without_a_request_uses_the_main_checkout ... ok
test ..._from_subdirectory_targets_repo_root ... ok
test ..._explicit_request_creates_worktree ... FAILED
test ..._ignores_a_registered_worktree_true_project ... ok
test result: FAILED. 3 passed; 1 failed
```

Also `cli_parses_launch_with_worktree` (the flag reaches the parser as `true` while bare `tm launch` stays `false`) and `spawn_request_worktree_wire_shape` (absent → `false`, `true` → `true`, `null` → parse error).

## `error: Unrecognized option: 'agent'` — pre-existing, not a failure

It is not why the `Test` job failed. That job failed on `patch_round_trips_worktree_opt_out` (`/tmp/ci.txt:21108`), caused by the default flip, now reverted.

The line is stray stderr from `runtime::tool_registry::registry_tests::assistant_tier_registry_delegation_honors_the_reachable_whitelist` in `trusty-agents`, attributed by a `--test-threads=1` run and reproduced in isolation:

```
$ cargo test -p trusty-agents --lib assistant_tier_registry_delegation_honors_the_reachable_whitelist
error: Unrecognized option: 'agent'
test runtime::tool_registry::registry_tests::assistant_tier_registry_delegation_honors_the_reachable_whitelist ... ok
test result: ok. 1 passed; 0 failed
```

Mechanism: that test drives the real delegation path into `subprocess::spawn::spawn_and_run_inner`, which spawns `std::env::current_exe()` with `--agent <name>` (`spawn.rs:229-233`). Under `cargo test`, `current_exe()` is the libtest binary; its getopts parser rejects `--agent` and prints to the inherited stderr (inherited because `repl::is_tty()` is false off a TTY). The child exits nonzero, the test asserts the delegation error path, and it passes.

Disposition: pre-existing, cosmetic, out of scope. `git diff origin/main --name-only -- crates/trusty-agents/` is 0 files, and `cargo test -p trusty-agents` exits 0 with the line present. Worth a low-priority issue for the noise; not filed here.

## Gates — rung 5

```
cargo fmt --check                                     EXIT=0
cargo check --workspace                               EXIT=0
cargo clippy -p trusty-mpm --all-targets -D warnings  EXIT=0
line-cap        3846 tracked .rs files, 4 allowlisted, 0 violations — OK
sld-lint        57 specs + 5807 files, 0 errors, 0 warnings
test-pointers   resolved 23062 Test: citations — 0 dangling pointers — OK
changelog       OK trusty-mpm; scanned 22 changed paths
```

```
cargo test -p trusty-mpm -- --test-threads=1          EXIT=0
test result: ok. 4839 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
test result: ok. 1547 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
test result: ok. 1547 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
```

Parallel — what CI runs — also passed:

```
cargo test -p trusty-mpm                              EXIT=0
```

An earlier `--lib`-only parallel run failed once on `stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet`. That test is named in `docs/reference/test-ladder-baseline.md`'s known-environmental table for this machine ("Fails 3 of 5 runs on a clean baseline worktree with no branch changes. Passes under `-- --test-threads=1`"), it passed in isolation, and it did not recur on the full parallel run. It passed in CI on the previous head.

`--include-ignored` fails only `meta_run_demo_writes_and_verifies_artifact` with `launch_outcome: "timed-out"` at 184.11s — the same table's entry for it verbatim. It launches a real Claude Code session.

```
cargo test -p trusty-mpm -- --include-ignored --test-threads=1
test result: ok. 4846 passed; 0 failed; 0 ignored
test result: ok. 1548 passed; 0 failed; 0 ignored
test result: ok. 1548 passed; 0 failed; 0 ignored
test result: FAILED. 0 passed; 1 failed      (meta_run_demo_writes_and_verifies_artifact)
```

## Changed from the previous head

`adf4faf7` flipped `Project::worktree_enabled` and `worktree_enabled_in` from `unwrap_or(true)` to `unwrap_or(false)`, which disabled agent worktrees on every project carrying no explicit flag — 31 of 33 registered ones. Reverted: `crates/trusty-mpm/src/project/` is byte-identical to `origin/main` apart from the added row-4 test. Rebased onto `1a75111a1` (#5269, #5271, #5273 landed since the branch was cut).

That commit also attributed the change to ADR-0036. ADR-0036 decides that all worktrees are siblings under `.claude/worktrees/`; it says nothing about where a PM session runs. The attribution is dropped.

Closes #5274

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
