### PR TITLE
fix(trusty-memory): restore 39 lines dropped from ui/package-lock.json

### DIFF
--- a/crates/trusty-memory/ui/package-lock.json
+++ b/crates/trusty-memory/ui/package-lock.json
@@ -597,6 +597,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -611,6 +614,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -625,6 +631,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -639,6 +648,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -653,6 +665,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -667,6 +682,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -681,6 +699,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -695,6 +716,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -709,6 +733,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -723,6 +750,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -737,6 +767,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -751,6 +784,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,6 +801,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Summary

Squash `5a0553802` accidentally dropped 39 lines from
`crates/trusty-memory/ui/package-lock.json`: the `"libc": [...]` array
(glibc/musl) on each `optional: true` `@rollup/rollup-linux-*` platform
entry. `cargo check --workspace` ran `build.rs`, which builds the embedded
Svelte UI; that invocation caused npm to rewrite the lockfile in place, and
the agent staged with `git add -A`, sweeping the unrelated npm rewrite into
that otherwise-unrelated commit. Prevention: stage explicit paths, never
`git add -A`, in a workspace whose `build.rs` mutates tracked files during
`cargo check`/`cargo build`.

Loss is dev-only optional-dependency metadata with no runtime effect — UI
checks passed on the original squash — but the file should not carry an
accidental npm rewrite. Release blocker for tm 1.3.5.

## Changes

- Restored `crates/trusty-memory/ui/package-lock.json` to its
  pre-`5a0553802` state (`a223b5b00`). Verified byte-identical:
  `git diff a223b5b00 -- crates/trusty-memory/ui/package-lock.json` is empty.

## Changelog

No changelog fragment — this touches no crate `src/**`, only
`ui/package-lock.json` (dependency lockfile metadata restore).

## Test plan

- [x] Diffed the file between `a223b5b00` and `5a0553802`: exactly 13
      hunks, 3 lines each = 39 lines, all identical in shape (a `"libc"`
      array removed from an `optional: true` linux-arch rollup entry) —
      nothing else changed.
- [x] Restored via `git show a223b5b00:<path> > <path>`; confirmed
      byte-identical to `a223b5b00`.
- [x] `corepack pnpm install --frozen-lockfile` from inside
      `crates/trusty-memory/ui` (pinned pnpm 9.15.9) — exit 0, lockfile
      up to date.
- [x] `corepack pnpm run build` from the same directory — `vite build`
      succeeded, 137 modules transformed, `dist/` produced cleanly.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools