### PR TITLE
fix(trusty-memory): key the BM25 lexical lane on the resolved palace, not the requested slug (#5036)

### DIFF
--- a/crates/trusty-memory/changelog.d/5036-palace-alias-lane-keying.md
+++ b/crates/trusty-memory/changelog.d/5036-palace-alias-lane-keying.md
@@ -1,0 +1,21 @@
+Fixed
+
+- **The BM25 lexical lane addressed the wrong palace, for reads and for writes
+  (part of issue #5036).** Two independent keying faults compounded.
+  `AppState::bm25_client` was built once as `Bm25Client::for_palace(default_palace)`
+  (`src/lib.rs:767`) and holds one fixed socket path, so every search and every
+  live index write went to the DEFAULT palace's socket no matter which palace
+  was being queried. And the recall handlers passed the palace slug the caller
+  REQUESTED while the vector lane used the handle `open_palace` had resolved —
+  which differ whenever an alias is involved. `palace_aliases.json` maps
+  `bobmatnyc-trusty-tools → trusty-tools`, and the alias directory holds no
+  `palace.json`, so `palace_ids_on_disk` (`src/bm25_backfill.rs:667`) never
+  enumerates it: the backfill wrote the canonical palace's corpus, reported full
+  coverage, and the search read a corpus nobody had written to. On the write
+  path the drawer landed in another palace's corpus and the call SUCCEEDED, so
+  nothing marked the palace dirty and the repair sweep never ran. Search and
+  index now resolve a client bound to the palace's own socket
+  (`bm25_client_for_palace`), and every call site keys on `handle.id`.
+  `recall_without_embedder` no longer takes a `palace` parameter at all — it
+  reads the id off the handle, so the two lanes cannot disagree by construction.
+  With `TRUSTY_BM25_DAEMON` unset the lane is off and behaviour is unchanged.

--- a/crates/trusty-memory/src/tools/bm25.rs
+++ b/crates/trusty-memory/src/tools/bm25.rs
@@ -11,6 +11,7 @@
 
 use crate::AppState;
 use serde_json::{json, Value};
+use trusty_common::bm25_client::Bm25Client;
 use uuid::Uuid;
 
 /// Per-palace BM25 data directory derived from the daemon's data root.
@@ -29,37 +30,49 @@ pub(crate) fn bm25_data_dir_for_palace(state: &AppState, palace: &str) -> std::p
     state.data_root.join(palace).join("bm25")
 }
 
-/// Try to ensure the BM25 daemon for `palace` is running. Returns `true`
-/// when the daemon is (now) reachable.
+/// Resolve a BM25 client bound to **this palace's** socket, starting the
+/// daemon if necessary. `None` means "do not use the lexical lane".
 ///
-/// Why (issue #193): callers want a single yes/no — should I send a BM25
-/// op to this palace right now? — without each having to thread the
-/// supervisor's `Result` through every code path. When the supervisor
-/// returns an error (binary not found, spawn rejected, socket never
-/// appeared) we log and return `false` so the caller degrades to
-/// vector-only behaviour, exactly as it did before #193 when the daemon
-/// simply wasn't running.
-/// What: when `state.bm25_supervisor` is `None`, returns `true` (the
-/// caller falls back to the original "use the env-var-only socket path"
-/// behaviour). When `Some`, delegates to `ensure_running` and treats any
-/// error as a soft failure — the supervisor's logs explain why.
-/// Test: covered indirectly by the spawn supervisor's unit tests and the
-/// `bm25_supervisor_e2e` integration test.
-pub(crate) async fn ensure_bm25_running_for_palace(state: &AppState, palace: &str) -> bool {
+/// Why (#5036): the lane is per-palace everywhere except the client. Each
+/// palace gets its own daemon, its own snapshot, and its own socket
+/// (`socket_path_for_palace`), and `bm25_backfill` indexes each palace through
+/// the socket the supervisor hands back. `AppState::bm25_client`, though, is
+/// built exactly once — `Bm25Client::for_palace(default_palace)` — so every
+/// search and every live index op went to the DEFAULT palace's socket no
+/// matter which palace was being queried. The predecessor of this function
+/// returned a bare `bool` and threw the supervisor's socket away, which is how
+/// the two drifted apart. The consequence is worse than a miss: a search for
+/// palace X reads a corpus the backfill never wrote to (silently empty), while
+/// a write for palace X lands in the default palace's corpus (silently
+/// cross-indexed). Handing back the socket the supervisor actually resolved is
+/// what keeps read, write, and backfill pointed at one index.
+/// What: `None` when the lane is off (`bm25_client` is `None` — the
+/// `TRUSTY_BM25_DAEMON=1` gate) or when the supervisor could not start the
+/// daemon, in which case the caller degrades to vector-only exactly as before.
+/// With no supervisor (`TRUSTY_BM25_EXTERNAL=1`), falls back to the canonical
+/// per-palace socket path, which is the convention an out-of-band operator
+/// follows anyway.
+/// Test: `bm25_alias_recall.rs::an_aliased_recall_reads_the_corpus_the_backfill_wrote`
+/// exercises it against a non-default, aliased palace — the case the old code
+/// got wrong twice over.
+pub(crate) async fn bm25_client_for_palace(state: &AppState, palace: &str) -> Option<Bm25Client> {
+    // The lane gate. The client's own socket is deliberately unused — it is
+    // pinned to the default palace and is only a proxy for "lane enabled".
+    state.bm25_client.as_ref()?;
     let Some(supervisor) = state.bm25_supervisor.as_ref() else {
-        // No supervisor — the client (if present) connects to whatever
-        // socket happens to be live. This matches pre-#193 behaviour.
-        return true;
+        // No supervisor (TRUSTY_BM25_EXTERNAL=1) — address the palace's
+        // canonical socket, which is where an out-of-band operator puts it.
+        return Some(Bm25Client::for_palace(palace));
     };
     let data_dir = bm25_data_dir_for_palace(state, palace);
     match supervisor.ensure_running(palace, &data_dir).await {
-        Ok(_socket) => true,
+        Ok(socket) => Some(Bm25Client::new(socket)),
         Err(e) => {
             tracing::warn!(
                 palace = %palace,
                 "bm25 supervisor could not start daemon (degrading to vector-only): {e:#}"
             );
-            false
+            None
         }
     }
 }
@@ -120,7 +133,9 @@ pub struct Bm25IndexRequest {
 /// What: takes ownership of the receiver and the optional BM25 client +
 /// supervisor `Arc`s, then loops on `rx.recv().await`. For each request,
 /// `ensure_running`s the per-palace daemon (logging + skipping on failure)
-/// and calls `client.index()`. Errors are logged at `warn!` and dropped —
+/// and calls `index()` on a client bound to THAT palace's socket — the
+/// captured `client` is only the lane's on/off gate (#5036), because it is
+/// pinned to the default palace. Errors are logged at `warn!` and dropped —
 /// BM25 indexing is best-effort and the drawer is durable in redb regardless.
 /// If `client` is `None` (env var not set at startup) the worker still runs
 /// and silently drops every request, which keeps the channel drained — that is
@@ -141,26 +156,34 @@ pub fn spawn_bm25_index_worker(
         while let Some(req) = rx.recv().await {
             // No client means the BM25 lane is disabled — drain the queue
             // (so senders never block) and silently drop every request.
-            let Some(client) = client.as_ref() else {
+            if client.is_none() {
                 continue;
-            };
+            }
             // Issue #193: try to start the daemon before the first index
             // call. If the supervisor returns an error we skip this op;
             // the daemon will be retried on the next request.
-            if let Some(sup) = supervisor.as_ref() {
-                if let Err(e) = sup.ensure_running(&req.palace, &req.data_dir).await {
-                    // The write did not land. Same reasoning as the dropped
-                    // enqueue: queue the palace so a repair pass re-runs the
-                    // backfill rather than leaving the gap until restart.
-                    dirty.insert(req.palace.clone());
-                    tracing::warn!(
-                        palace = %req.palace,
-                        "bm25 supervisor failed to start daemon for index (non-fatal): {e:#}"
-                    );
-                    continue;
+            // #5036: index through the socket the supervisor resolved for THIS
+            // palace. The captured `client` is pinned to the default palace, so
+            // using it here filed every palace's drawers into one corpus.
+            let per_palace = if let Some(sup) = supervisor.as_ref() {
+                match sup.ensure_running(&req.palace, &req.data_dir).await {
+                    Ok(socket) => Bm25Client::new(socket),
+                    Err(e) => {
+                        // The write did not land. Same reasoning as the dropped
+                        // enqueue: queue the palace so a repair pass re-runs the
+                        // backfill rather than leaving the gap until restart.
+                        dirty.insert(req.palace.clone());
+                        tracing::warn!(
+                            palace = %req.palace,
+                            "bm25 supervisor failed to start daemon for index (non-fatal): {e:#}"
+                        );
+                        continue;
+                    }
                 }
-            }
-            if let Err(e) = client.index(&req.drawer_id, &req.content).await {
+            } else {
+                Bm25Client::for_palace(&req.palace)
+            };
+            if let Err(e) = per_palace.index(&req.drawer_id, &req.content).await {
                 dirty.insert(req.palace.clone());
                 tracing::warn!(
                     palace = %req.palace,
@@ -240,21 +263,23 @@ pub(crate) fn bm25_index_enqueue(state: &AppState, palace: &str, drawer_id: Uuid
 /// to vector-only results). Otherwise ensures the daemon is running via the
 /// spawn supervisor (issue #193), then returns the BM25 hits the daemon
 /// served. `top_k` is forwarded verbatim.
-/// Test: integration coverage via the daemon's `tests/bm25_daemon.rs`; the
-/// `None` path is covered by `bm25_client_disabled_by_default`.
+/// #5036: `palace` must be the RESOLVED palace id (`handle.id`), not the slug
+/// the caller asked for — `open_palace` follows aliases, so the two differ for
+/// an aliased palace and the corpus the backfill wrote is the resolved one's.
+/// Test: integration coverage via the daemon's `tests/bm25_daemon.rs` and
+/// `bm25_alias_recall.rs`; the `None` path is covered by
+/// `bm25_client_disabled_by_default`.
 pub(crate) async fn bm25_search_optional(
     state: &AppState,
     palace: &str,
     query: &str,
     top_k: usize,
 ) -> Option<Vec<trusty_common::bm25_client::BM25Hit>> {
-    let client = state.bm25_client.as_ref()?;
     // Issue #193: spawn the daemon if it isn't already running. On error
     // we fall through to vector-only behaviour exactly as we did before
     // #193 when the operator forgot to start the daemon manually.
-    if !ensure_bm25_running_for_palace(state, palace).await {
-        return None;
-    }
+    // #5036: and search the socket belonging to `palace`, not the default one.
+    let client = bm25_client_for_palace(state, palace).await?;
     match client.search(query, top_k).await {
         Ok(hits) => Some(hits),
         Err(e) => {

--- a/crates/trusty-memory/src/tools/helpers.rs
+++ b/crates/trusty-memory/src/tools/helpers.rs
@@ -482,7 +482,10 @@ pub(crate) async fn write_drawer(state: &AppState, params: WriteDrawerParams<'_>
     // a full queue is dropped + logged rather than allowed to grow
     // unbounded behind a slow daemon (#231). Daemon errors observed
     // by the worker are logged but never block the MCP response.
-    bm25_index_enqueue(state, palace_id, drawer_id, &content_for_kg);
+    // #5036: index under the RESOLVED palace id. `open_palace` follows
+    // aliases, so writing under the requested slug files the drawer into a
+    // palace the reader never searches.
+    bm25_index_enqueue(state, handle.id.as_str(), drawer_id, &content_for_kg);
     // Issue #96: emit a DrawerAdded so the activity feed shows
     // MCP-origin writes with `source = Mcp`.
     let palace_name = lookup_palace_name(state, palace_id);

--- a/crates/trusty-memory/src/tools/memory_ops.rs
+++ b/crates/trusty-memory/src/tools/memory_ops.rs
@@ -359,16 +359,22 @@ fn vector_lane_available(state: &AppState) -> bool {
 /// scopes L2/L3 — a caller who narrowed to one room must never be handed
 /// another room's drawer just because the daemon happened to be warming. L0/L1
 /// are deliberately left unfiltered, matching `retrieval::recall_in_room`.
+/// #5036: the palace is read off `handle`, never passed in. This is the one
+/// path where the lexical lane is the ONLY lane, so keying it on a caller's
+/// slug — which `open_palace` may have redirected through an alias — searched a
+/// socket the backfill never writes and left the caller with L0/L1 alone.
+/// Taking no `palace` parameter makes that disagreement unrepresentable.
 /// Test: `recall_degrades_to_l0_l1_when_the_embedder_is_genuinely_cold`,
-/// `recall_deep_degrades_to_l0_l1_when_the_embedder_is_genuinely_cold`.
+/// `recall_deep_degrades_to_l0_l1_when_the_embedder_is_genuinely_cold`,
+/// `bm25_alias_recall.rs::an_aliased_recall_reads_the_corpus_the_backfill_wrote`.
 async fn recall_without_embedder(
     state: &AppState,
     handle: &trusty_common::memory_core::retrieval::PalaceHandle,
-    palace: &str,
     query: &str,
     scope: &RecallScope,
     top_k: usize,
 ) -> Vec<trusty_common::memory_core::retrieval::RecallResult> {
+    let palace = handle.id.as_str();
     let mut results = trusty_common::memory_core::retrieval::retrieve_l0_l1(handle);
     // ADR-0027 T7 filtered this lane by room; T9 (#4809) widens it to the whole
     // scope so a WING-scoped recall issued while the embedder is warming is
@@ -464,7 +470,7 @@ pub(crate) async fn handle_memory_recall(state: &AppState, args: Value) -> Resul
     // this fallback ignores the query, so entering it while the embedder is live
     // makes every query return the same drawers.
     if !vector_lane_available(state) {
-        let results = recall_without_embedder(state, &handle, &palace, query, &scope, top_k).await;
+        let results = recall_without_embedder(state, &handle, query, &scope, top_k).await;
         return Ok(serialize_recall(&palace, query, results));
     }
 
@@ -481,7 +487,10 @@ pub(crate) async fn handle_memory_recall(state: &AppState, args: Value) -> Resul
     // lane. The warming path above is different: it hydrates BM25-only hits,
     // which is why it filters explicitly.
     let vector_fut = recall_scoped(&handle, embedder.as_ref(), query, &scope, top_k);
-    let bm25_fut = bm25_search_optional(state, &palace, query, top_k);
+    // #5036: key the lexical lane on the RESOLVED palace id. `open_palace`
+    // follows aliases, so the requested slug can address a different palace
+    // than the vector lane just searched.
+    let bm25_fut = bm25_search_optional(state, handle.id.as_str(), query, top_k);
     let (vector_res, bm25_res) = tokio::join!(vector_fut, bm25_fut);
     let mut results = vector_res.context("recall")?;
     if let Some(bm25_hits) = bm25_res {
@@ -507,7 +516,7 @@ pub(crate) async fn handle_memory_recall_deep(state: &AppState, args: Value) -> 
     // Issue #1970: same warming-fallback posture as memory_recall.
     // #4836: and the same embedder-state gate, for the same reason.
     if !vector_lane_available(state) {
-        let results = recall_without_embedder(state, &handle, &palace, query, &scope, top_k).await;
+        let results = recall_without_embedder(state, &handle, query, &scope, top_k).await;
         return Ok(serialize_recall(&palace, query, results));
     }
 
@@ -596,9 +605,7 @@ async fn recall_all_without_embedder(
     let mut merged = Vec::new();
     for handle in handles {
         let palace_id = handle.id.as_str().to_string();
-        let hits =
-            recall_without_embedder(state, handle, &palace_id, query, &RecallScope::All, top_k)
-                .await;
+        let hits = recall_without_embedder(state, handle, query, &RecallScope::All, top_k).await;
         merged.extend(hits.into_iter().map(|result| {
             trusty_common::memory_core::retrieval::CrossPalaceResult {
                 palace_id: palace_id.clone(),

--- a/crates/trusty-memory/tests/alias_lane/mod.rs
+++ b/crates/trusty-memory/tests/alias_lane/mod.rs
@@ -1,0 +1,155 @@
+//! Shared fixture for the two #5036 palace-alias lane tests.
+//!
+//! Why: the read test and the write test need the identical split-brain shape
+//! — a slug with no directory of its own pointing at a palace that has one —
+//! but they cannot share a test BINARY. The write test seeds the process-wide
+//! mock embedder, and `shared_embedder_initialized()` is monotonic, so a seed
+//! anywhere in the process would move the read test off the embedder-warming
+//! path it depends on. Two binaries, one fixture.
+//! What: daemon-binary discovery, the lane's env gate, and an `Aliased`
+//! fixture that creates the canonical palace, registers the alias, and asserts
+//! the redirect fires before a test starts.
+//! Test: used by `bm25_alias_recall.rs` and `bm25_alias_write.rs`.
+
+use std::path::PathBuf;
+
+use trusty_common::memory_core::palace::{Palace, PalaceId};
+use trusty_common::palace_alias::PalaceAliasStore;
+use trusty_memory::AppState;
+
+/// Resolve the freshly-built `trusty-bm25-daemon` binary.
+///
+/// Why: the supervisor discovers the daemon as a sibling of `current_exe()`,
+/// which for an integration test is the test binary under `target/*/deps/`.
+/// Pointing `TRUSTY_BM25_DAEMON_BIN` at the real build output sidesteps that.
+/// What: honours the env var if already set, else walks up from the test
+/// binary looking for the daemon next to it or one level up.
+/// Test: this is the test bootstrap.
+fn discover_daemon_binary() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("TRUSTY_BM25_DAEMON_BIN") {
+        let pb = PathBuf::from(p);
+        if pb.is_file() {
+            return Some(pb);
+        }
+    }
+    let exe = std::env::current_exe().ok()?;
+    let mut p = exe.as_path();
+    while let Some(parent) = p.parent() {
+        let candidate = parent.join("trusty-bm25-daemon");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        let candidate = parent.join("..").join("trusty-bm25-daemon");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        p = parent;
+    }
+    None
+}
+
+/// Turn the lane on and pin the supervisor's locator at the built daemon.
+///
+/// Why: a missing binary used to be a silent skip, which reads as a pass. These
+/// tests are about a lane that fails quietly, so their bootstrap must not.
+/// What: panics with the build command when the daemon is absent; otherwise
+/// sets `TRUSTY_BM25_DAEMON=1`, pins `TRUSTY_BM25_DAEMON_BIN`, and clears
+/// `TRUSTY_BM25_EXTERNAL` so the real supervisor runs.
+/// Test: this is the test bootstrap.
+fn arm_lane() {
+    let binary = discover_daemon_binary().expect(
+        "trusty-bm25-daemon binary not found — build it first \
+         (`cargo build -p trusty-memory --bin trusty-bm25-daemon`) or set \
+         TRUSTY_BM25_DAEMON_BIN=<path>",
+    );
+    // SAFETY: test-only env mutation. Every test in a given binary sets the
+    // same three values, so a concurrent sibling cannot observe a different
+    // lane state.
+    unsafe {
+        std::env::set_var("TRUSTY_BM25_DAEMON_BIN", &binary);
+        std::env::set_var("TRUSTY_BM25_DAEMON", "1");
+        std::env::remove_var("TRUSTY_BM25_EXTERNAL");
+    }
+}
+
+/// A canonical palace on disk plus an alias that redirects to it.
+///
+/// Why: getting the shape wrong in either direction — an alias directory that
+/// exists, or a target that does not — silently disables the redirect, and the
+/// test would then pass against the bug. The constructor asserts the redirect
+/// rather than assuming it.
+/// What: creates `<data_root>/<canonical>/palace.json` through the real
+/// registry and registers `alias -> canonical` in `palace_aliases.json`.
+/// Test: used by both alias-lane tests.
+pub struct Aliased {
+    _tmp: tempfile::TempDir,
+    pub state: AppState,
+    pub canonical: String,
+    pub alias: String,
+}
+
+impl Aliased {
+    pub fn new(tag: &str) -> Self {
+        arm_lane();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_root = tmp.path().to_path_buf();
+        // Short names: the socket path must stay inside `sun_path` (~104
+        // bytes) and macOS `$TMPDIR` already spends about half of it.
+        let suffix = format!("{tag}{:x}", std::process::id() & 0xffff);
+        let canonical = format!("c{suffix}");
+        let alias = format!("a{suffix}");
+
+        let state = AppState::new(data_root.clone()).with_bm25_client_from_env();
+        assert!(
+            state.bm25_client.is_some() && state.bm25_supervisor.is_some(),
+            "the lexical lane must be armed, or this test proves nothing"
+        );
+
+        state
+            .registry
+            .create_palace(
+                &data_root,
+                Palace {
+                    id: PalaceId::new(canonical.clone()),
+                    name: canonical.clone(),
+                    description: None,
+                    created_at: chrono::Utc::now(),
+                    data_dir: data_root.join(&canonical),
+                },
+            )
+            .expect("create canonical palace");
+        PalaceAliasStore::register_alias(&data_root, &alias, &canonical)
+            .expect("register palace alias");
+
+        // Preconditions. The alias owns no directory — that absence is exactly
+        // what keeps `palace_ids_on_disk` from ever enumerating it — and the
+        // registry redirects a lookup for it to the canonical palace.
+        assert!(
+            !data_root.join(&alias).join("palace.json").exists(),
+            "the alias must have no palace directory of its own"
+        );
+        let resolved = state
+            .registry
+            .open_palace(&data_root, &PalaceId::new(alias.clone()))
+            .expect("open through the alias");
+        assert_eq!(
+            resolved.id.as_str(),
+            canonical,
+            "the registry must resolve the alias to the canonical palace"
+        );
+
+        Self {
+            _tmp: tmp,
+            state,
+            canonical,
+            alias,
+        }
+    }
+
+    /// Reap the daemons this fixture's supervisor started.
+    pub async fn shutdown(&self) {
+        if let Some(sup) = self.state.bm25_supervisor.as_ref() {
+            sup.shutdown().await;
+        }
+    }
+}

--- a/crates/trusty-memory/tests/bm25_alias_recall.rs
+++ b/crates/trusty-memory/tests/bm25_alias_recall.rs
@@ -1,0 +1,98 @@
+//! #5036 (read half): an ALIASED palace's lexical lane must read the corpus
+//! the backfill actually wrote.
+//!
+//! Why: `palace_aliases.json` on this host maps `bobmatnyc-trusty-tools →
+//! trusty-tools`. `open_palace` follows that redirect, so the recall handler
+//! held a handle on `trusty-tools` while passing the requested slug to the
+//! BM25 lane. `palace_ids_on_disk` only enumerates directories holding a
+//! `palace.json`, and the alias has none — so the startup sweep indexes the
+//! canonical palace, logs full coverage, and the search reads a corpus nobody
+//! ever wrote to.
+//!
+//! The divergence is between a RESOLVED handle and a REQUESTED slug, so a mock
+//! cannot show it: this test registers a real alias, resolves it through the
+//! real registry, and drives a real `trusty-bm25-daemon` over its real socket.
+//!
+//! What: `#[ignore]`d because it needs the daemon binary. Run with
+//! `cargo test -p trusty-memory --test bm25_alias_recall -- --include-ignored`.
+//!
+//! Test: this *is* the test file.
+
+mod alias_lane;
+
+use serde_json::json;
+use trusty_common::bm25_client::socket_path_for_palace;
+use trusty_common::memory_core::palace::{Drawer, PalaceId};
+use trusty_memory::bm25_backfill::run_startup_sweep;
+use trusty_memory::tools::dispatch_tool;
+
+/// Why: the startup sweep writes the CANONICAL palace's corpus and never sees
+/// the alias. A recall issued against the alias slug therefore has to reach
+/// that same corpus, or the lane is a no-op that reports success.
+/// What: seeds one drawer, sweeps, then recalls THROUGH THE ALIAS on the
+/// embedder-warming path — where the lexical lane is the only lane, so a
+/// vector hit cannot mask its result — and asserts the drawer comes back.
+/// Test: this test itself. Against the parent commit the lane addresses the
+/// default palace's socket and the recall returns nothing.
+#[ignore = "requires trusty-bm25-daemon binary on disk; run with --include-ignored"]
+#[tokio::test(flavor = "multi_thread")]
+async fn an_aliased_recall_reads_the_corpus_the_backfill_wrote() {
+    let fx = alias_lane::Aliased::new("r");
+    let handle = fx
+        .state
+        .registry
+        .open_palace(&fx.state.data_root, &PalaceId::new(fx.canonical.clone()))
+        .expect("open canonical palace");
+
+    // A drawer nothing but the lexical lane can reach: pushed onto the served
+    // table (so a BM25 hit has something to hydrate from) but absent from
+    // `l1_drawers`, and the palace has no identity row, so `retrieve_l0_l1`
+    // returns nothing at all.
+    let token = "zqxjrollout";
+    let drawer = Drawer::new(uuid::Uuid::new_v4(), format!("{token} staging plan"));
+    let drawer_id = drawer.id.to_string();
+    handle.drawers.write().push(drawer);
+    assert!(
+        handle.identity.is_empty() && handle.l1_drawers.is_empty(),
+        "L0/L1 must be empty, or the drawer could surface without the lexical lane"
+    );
+
+    // The sweep is the writer. It enumerates the canonical palace only.
+    let outcome = run_startup_sweep(&fx.state).await;
+    assert!(
+        outcome.all_verified() && outcome.swept == 1,
+        "precondition: the sweep must verify the canonical palace's coverage; got {outcome:?}"
+    );
+
+    let payload = dispatch_tool(
+        &fx.state,
+        "memory_recall",
+        json!({ "palace": fx.alias, "query": token, "top_k": 5 }),
+    )
+    .await
+    .expect("memory_recall through the alias");
+
+    let ids: Vec<String> = payload["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .filter_map(|r| r["drawer_id"].as_str().map(str::to_string))
+        .collect();
+    assert!(
+        ids.contains(&drawer_id),
+        "#5036: a recall through alias '{}' must read the corpus the backfill wrote \
+         for '{}'. Got {ids:?}",
+        fx.alias,
+        fx.canonical,
+    );
+
+    // And the lane must never have addressed the requested slug: a daemon
+    // spawned under the alias name is the bug, even when it happens to be empty.
+    assert!(
+        !socket_path_for_palace(&fx.alias).exists(),
+        "#5036: no BM25 daemon may be started for the alias slug — the lane is \
+         keyed on the resolved palace id"
+    );
+
+    fx.shutdown().await;
+}

--- a/crates/trusty-memory/tests/bm25_alias_write.rs
+++ b/crates/trusty-memory/tests/bm25_alias_write.rs
@@ -1,0 +1,94 @@
+//! #5036 (write half): a write through an ALIASED palace must be indexed into
+//! the resolved palace's corpus.
+//!
+//! Why: this half is worse than the read half. A write filed into the wrong
+//! palace's corpus usually SUCCEEDS, so nothing marks the palace dirty and the
+//! repair sweep never runs — the drawer is durable in redb and permanently
+//! absent from the index the reader consults.
+//!
+//! What: `#[ignore]`d because it needs the `trusty-bm25-daemon` binary. Run
+//! with `cargo test -p trusty-memory --test bm25_alias_write -- --include-ignored`.
+//! It lives in its own binary because it seeds the process-wide mock embedder
+//! and `shared_embedder_initialized()` is monotonic — a seed here would move
+//! the sibling recall test off the embedder-warming path it depends on.
+//!
+//! Test: this *is* the test file.
+
+mod alias_lane;
+
+use std::time::Duration;
+
+use serde_json::json;
+use trusty_common::bm25_client::{socket_path_for_palace, Bm25Client};
+use trusty_memory::tools::dispatch_tool;
+
+/// Poll a palace's own BM25 socket until `query` returns a hit.
+///
+/// Why: the live write path is asynchronous by design (#231) — the drawer is
+/// durable in redb before the index request leaves the queue — so the corpus
+/// is eventually, not immediately, consistent.
+/// What: retries the search for up to ~5 s. Returns the matching doc ids, or
+/// an empty vec once the deadline passes (including when the socket never
+/// appears, which is itself the pre-fix symptom).
+/// Test: used by the test below.
+async fn poll_corpus_for(palace: &str, query: &str) -> Vec<String> {
+    let client = Bm25Client::new(socket_path_for_palace(palace));
+    for _ in 0..100 {
+        if let Ok(hits) = client.search(query, 10).await {
+            if !hits.is_empty() {
+                return hits.into_iter().map(|h| h.doc_id).collect();
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    Vec::new()
+}
+
+/// Why: `write_drawer` enqueued the index request under the slug the caller
+/// asked for, and the index worker sent it over a client pinned to the default
+/// palace. Two independent ways to miss the palace the drawer actually lives in.
+/// What: writes through the alias slug and asserts the drawer shows up in the
+/// CANONICAL palace's own corpus, read over that palace's socket by a client
+/// this test builds itself.
+/// Test: this test itself. Against the parent commit the canonical socket never
+/// even appears.
+#[ignore = "requires trusty-bm25-daemon binary on disk; run with --include-ignored"]
+#[tokio::test(flavor = "multi_thread")]
+async fn an_aliased_write_indexes_into_the_resolved_palaces_corpus() {
+    // The write path embeds; the mock keeps that off the ONNX model-download
+    // path. It has no bearing on which socket the index request is sent to,
+    // which is the only thing this test measures.
+    trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock();
+    let fx = alias_lane::Aliased::new("w");
+
+    let token = "zqxjrollback";
+    let payload = dispatch_tool(
+        &fx.state,
+        "memory_remember",
+        json!({
+            "palace": fx.alias,
+            "text": format!("{token} procedure for the staged deployment plan"),
+            "force": true,
+        }),
+    )
+    .await
+    .expect("memory_remember through the alias");
+    let drawer_id = payload["drawer_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("the write was skipped, not stored: {payload}"))
+        .to_string();
+
+    let indexed = poll_corpus_for(&fx.canonical, token).await;
+    assert!(
+        indexed.contains(&drawer_id),
+        "#5036: a write through alias '{}' must be indexed into '{}'s corpus. Got {indexed:?}",
+        fx.alias,
+        fx.canonical,
+    );
+    assert!(
+        !socket_path_for_palace(&fx.alias).exists(),
+        "#5036: no BM25 daemon may be started for the alias slug on the write path"
+    );
+
+    fx.shutdown().await;
+}


### PR DESCRIPTION
Part of #5036.

## The defect

Two keying faults that compound, both in the BM25 lexical lane.

**The client was pinned to one palace.** `AppState::bm25_client` is built exactly once — `Bm25Client::for_palace(default_palace)` (`src/lib.rs:767`) — and a `Bm25Client` holds one fixed socket path. Every search and every live index write therefore went to the *default* palace's socket regardless of which palace was being queried, while `bm25_backfill` correctly used the socket the supervisor returned per palace.

**The recall handlers keyed on the slug the caller asked for.** `bm25_search_optional` was called with the REQUESTED palace while the vector lane used the handle `open_palace` had resolved. `open_palace` follows aliases, so for an aliased slug the two lanes address different palaces. On this host `palace_aliases.json` maps `bobmatnyc-trusty-tools → trusty-tools`, and `palaces/bobmatnyc-trusty-tools/` holds no `palace.json` — so `palace_ids_on_disk` (`src/bm25_backfill.rs:667`) never enumerates it and the backfill never writes the corpus the search reads, while the startup sweep still logs full coverage.

The write path was worse than a miss: palace X's drawers were filed into the default palace's corpus, and because the write usually *succeeded* it never even marked the palace dirty for repair.

With `TRUSTY_BM25_DAEMON` unset the lane is off and behaviour is byte-identical.

## What changed

- `bm25_client_for_palace` replaces the `bool`-returning `ensure_bm25_running_for_palace`: it hands back a client bound to the socket the supervisor resolved for that palace, instead of throwing the socket away. `bm25_search_optional` and the index worker both use it.
- Every call site keys on `handle.id`. `recall_without_embedder` no longer takes a `palace` parameter at all — it reads the id off the handle, so the two lanes cannot disagree by construction. Three call sites follow.
- The write path (`tools/helpers.rs`) enqueues under `handle.id`, not the requested slug.

## Scoring is out of scope

The scoring half of #5036 — fusion normalisation, the `ceiling` derivation, `max(cosine, lexical)`, the L0/L2/L3 layer filter, and BM25-only promotion — is deferred to milestone **1.3.6** by owner decision and is not in this change. Nothing here touches `fuse_bm25_into_recall`. #5036 stays open for that work.

## The regression tests fail against the parent commit

`tests/bm25_alias_recall.rs` and `tests/bm25_alias_write.rs` register a real alias, resolve it through the real registry, and drive a real `trusty-bm25-daemon` over its real socket. The divergence under test is between a resolved handle and a requested slug, so a mock cannot show it. The read test drives the embedder-warming path, where the lexical lane is the only lane and a vector hit cannot mask its result; its fixture asserts the redirect actually fires before the test proper starts.

They live in two binaries because the write test seeds the process-wide mock embedder and `shared_embedder_initialized()` is monotonic — a seed anywhere in the process would move the read test off the warming path.

Parent commit (`git checkout origin/main -- crates/trusty-memory/src`, tests kept):

```
---- an_aliased_recall_reads_the_corpus_the_backfill_wrote stdout ----
panicked at crates/trusty-memory/tests/bm25_alias_recall.rs:81:5:
#5036: a recall through alias 'ar38e9' must read the corpus the backfill wrote for 'cr38e9'. Got []

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.60s

---- an_aliased_write_indexes_into_the_resolved_palaces_corpus stdout ----
panicked at crates/trusty-memory/tests/bm25_alias_write.rs:82:5:
#5036: a write through alias 'aw39aa' must be indexed into 'cw39aa's corpus. Got []

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.60s
```

With the fix, both pass.

## Test ladder

**Rung 5** — cross-crate contract and process lifecycle (the index worker's daemon routing changed), so rung 4 plus `--include-ignored` integration coverage.

```
cargo fmt --check                                            EXIT=0
cargo clippy -p trusty-memory --all-targets -- -D warnings   EXIT=0
cargo check --workspace --all-targets                        EXIT=0
cargo test -p trusty-memory        629 passed; 0 failed; 4 ignored (+ 24 further binaries, 0 failed)
cargo test -p trusty-common        294 passed; 0 failed; 6 ignored
cargo test -p trusty-agents        3484 passed; 0 failed; 13 ignored   (the only direct dependent)
cargo test -p trusty-memory --test bm25_alias_recall --test bm25_alias_write \
    --test bm25_backfill_e2e --test bm25_supervisor_e2e \
    --test bm25_supervisor_concurrency -- --include-ignored    13 passed; 0 failed
scripts/check_test_pointers.sh   resolved 23064 citations — 0 dangling pointers — OK
scripts/check_line_cap.sh / check_changelog_fragment.sh / check_sld.sh   all OK
```

An exhaustive grep confirms no production call site remains keyed on a requested slug: `bm25_search_optional` is reached from `memory_ops.rs:385` (inside `recall_without_embedder`, whose `palace` is `handle.id`) and `memory_ops.rs:493` (`handle.id.as_str()`); `bm25_index_enqueue` from `helpers.rs:488` (`handle.id.as_str()`). The remaining hits are test literals.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
