### PR TITLE
docs(trusty-common): file #5272 under Breaking, not Fixed

### DIFF
--- a/crates/trusty-common/changelog.d/5272-session-snapshot-crosstalk.md
+++ b/crates/trusty-common/changelog.d/5272-session-snapshot-crosstalk.md
@@ -1,4 +1,4 @@
-Fixed
+Breaking
 
 - `catchup::session_finder::latest_trusty_mpm_snapshot` no longer resolves across session boundaries ([#5272](https://github.com/bobmatnyc/trusty-tools/issues/5272))
   - it now requires a session id and resolves only snapshots that `sessions-log.jsonl` attributes to it, via the new `session_log::resolve_session_snapshot`. Passing `None` returns `None` instead of the newest snapshot overall


### PR DESCRIPTION
`#5272`'s changelog fragment was filed under `Fixed`. The change narrows behaviour: `latest_trusty_mpm_snapshot` used to return the newest snapshot overall when given `None`, and now returns `None`. A consumer upgrading trusty-common has to know that, so it belongs in the Breaking section of the assembled 0.30.0 changelog.

Fragment category line only — one word, `Fixed` → `Breaking`. No source change.

Test ladder rung 1 (docs only):

```
scripts/check_changelog_fragment.sh  → scanned 1 changed path(s); no crate source changed — OK.  (exit 0)
scripts/check_sld.sh                 → 57 spec doc(s) + 3174 code file(s); 0 error(s), 0 warning(s)  (exit 0)
```

Blocks the tm 1.3.5 changelog assembly.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools