### PR TITLE
fix(scripts): stop the SemVer gate reporting a build error as a version-bump verdict

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -89,6 +89,15 @@ jobs:
           echo "crate=${NAME}" >> "$GITHUB_OUTPUT"
           echo "Checking crate: ${NAME}"
 
+      # STABLE, DELIBERATELY NOT THE MSRV 1.94 THIS REPO PINS (#5289).
+      # cargo-semver-checks builds rustdoc in a scratch project that ignores this
+      # workspace's Cargo.lock, so the graph it resolves can demand a higher
+      # rustc than we ship under — `takecell` 0.1.2 wants 1.96 where the lock
+      # pins 0.1.1, and under 1.94 the gate could not run at all. Which rustc
+      # renders the rustdoc JSON does not change what our public API is, so this
+      # costs no coverage; MSRV compliance is ci.yml's job and is untouched.
+      # check_semver.sh makes the same choice locally by picking the newest
+      # installed toolchain, so CI and a developer's machine agree.
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -116,7 +125,25 @@ jobs:
       - name: SemVer gate selftest (must refuse a blind run)
         run: bash scripts/check_semver_selftest.sh
 
+      # The two nonzero statuses are annotated differently ON PURPOSE (#5289).
+      # Exit 1 is a computed verdict that says break; exit 3 means the gate never
+      # compared anything, and reporting that as "your API changed" is the lie
+      # this issue was filed for. Both fail the job — a non-verdict is not a
+      # pass — but a reader must be able to tell which one they are looking at
+      # from the annotation alone.
       - name: Enforce public-API SemVer against crates.io
         env:
           SKIP_UI_BUILD: '1'
-        run: bash scripts/check_semver.sh --crate "${{ steps.crate.outputs.crate }}"
+          CRATE: ${{ steps.crate.outputs.crate }}
+        run: |
+          rc=0
+          bash scripts/check_semver.sh --crate "$CRATE" || rc=$?
+          if [[ "$rc" -eq 0 ]]; then
+            exit 0
+          fi
+          if [[ "$rc" -eq 3 ]]; then
+            echo "::error title=SemVer gate could not run::No verdict was computed for ${CRATE}. cargo-semver-checks never completed a comparison (see the log), so whether this release breaks the public API is UNKNOWN. Do not read this as a required version bump, and do not publish on it."
+          else
+            echo "::error title=SemVer break::${CRATE} has a breaking public-API change without a breaking version bump. See the failing lints in the log."
+          fi
+          exit "$rc"

--- a/docs/reference/semver-gate.md
+++ b/docs/reference/semver-gate.md
@@ -94,6 +94,66 @@ malformed index entry exits non-zero and names `TOOL ERROR`.
 Every skip prints its reason, and the final line reports how many crates were
 checked versus skipped, so a run that verified nothing says so.
 
+## A build failure is not a verdict (#5289)
+
+`cargo-semver-checks` must build rustdoc for both sides before it can compare
+anything, and that build has its own ways to fail. Until #5289 every one of them
+exited non-zero into the same "a public API change requires a matching version
+bump" remediation, so a rustdoc error was presented as a SemVer verdict and the
+two were indistinguishable from the output.
+
+The gate now concludes only from **positive evidence**: a verdict exists when
+`cargo-semver-checks` printed its own per-crate summary line (`Checked … N
+checks: …`). No summary line means no comparison happened — whatever the exit
+status was, *including exit 0* — and that is reported as `NO VERDICT` on its own
+exit status.
+
+| Exit | Meaning |
+|---|---|
+| 0 | every checked crate is clean, or is a recorded skip |
+| 1 | a verdict was computed **and it says break** — the only status that means "the API changed" |
+| 2 | usage error |
+| 3 | **no verdict** — rustdoc build failure, unreachable registry, missing tool, or a diff that scanned nothing. Nothing was compared, so nothing may be concluded. |
+
+`scripts/preflight-publish.sh` CHECK 5 and `.github/workflows/semver-checks.yml`
+both report exit 3 separately from exit 1. Both still stop the publish: a
+non-verdict is not a pass. What changes is that neither one tells you to bump a
+version on evidence that does not exist.
+
+## Which toolchain the gate runs under (#5289)
+
+`cargo-semver-checks` resolves dependencies in a scratch project that **ignores
+this workspace's `Cargo.lock`**, so it can pick a newer transitive dependency
+than the lockfile pins and inherit that dependency's MSRV. That is not
+hypothetical: the scratch resolution took `takecell` 0.1.2 (`rust-version` 1.96)
+where `Cargo.lock` pins 0.1.1 via `teloxide-core`, and rustdoc then refused to
+build under this repo's MSRV 1.94. `takecell` reaches every default build of
+`trusty-mpm` through `cli` → `telegram`, so this was the normal case, not an edge
+one — the gate simply could not run.
+
+So the gate runs under the **newest rustc it can find**, not the pinned one:
+`check_semver.sh` scans `$RUSTUP_HOME/toolchains/*/bin` and prepends the highest
+version when it beats the ambient one; CI installs `stable` for the same reason.
+Pinning the offending dependency instead would fix one name until the next
+dependency raises its floor.
+
+This costs no coverage. The gate compares the public API of our source against
+the registry, and which rustc renders the rustdoc JSON does not change what that
+API is. MSRV compliance is a separate CI job (`dtolnay/rust-toolchain@1.94`) and
+is untouched.
+
+It also cannot manufacture a pass, which is the property that matters: the only
+thing a wrong toolchain choice can do is fail the rustdoc build, and that is now
+`NO VERDICT` with a non-zero exit. A machine with no newer toolchain installed
+keeps the ambient one and degrades to exactly that honest path.
+
+`SEMVER_GATE_TOOLCHAIN_BIN=<dir>` pins the rustc/cargo explicitly; set but empty
+keeps the ambient toolchain. Note that `RUSTUP_TOOLCHAIN` does **not** work here
+— where rustc and cargo resolve through mise shims, the shim execs a pinned
+toolchain directly and never consults rustup, so the variable is silently
+ignored. Prepending the toolchain's own `bin` directory is the mechanism that
+works under both mise and a plain rustup install.
+
 ### The already-a-major-bump skip
 
 When the declared version already carries a breaking bump, `cargo-semver-checks`
@@ -160,7 +220,29 @@ gh workflow run semver-checks.yml -f crate=trusty-common
 
 ## Self-test
 
-`scripts/check_semver_selftest.sh` runs first in CI and covers the gate's two
-fail-open surfaces — an unscanned diff and an unreachable or erroring index —
-plus the 404 case, which must stay a clean skip so the other cases are known to
-fail for the right reason.
+`scripts/check_semver_selftest.sh` runs first in CI. Cases 1-4 cover the gate's
+original fail-open surfaces — an unscanned diff and an unreachable or erroring
+index — plus the 404 case, which must stay a clean skip so the other cases are
+known to fail for the right reason.
+
+Cases 5-8 (#5289) pin the verdict/non-verdict split: a real break must report
+`BREAK` and exit 1; a rustdoc build error must report `NO VERDICT`, exit 3, and
+never reach the version-bump remediation; an exit-0 run that compared nothing
+must still fail; and a genuinely clean run must exit 0, which is what proves the
+other three fail on classification rather than because the gate is broken
+outright.
+
+Those four replace only the `cargo semver-checks` subprocess, via a stub `cargo`
+on `PATH` that forwards everything else to the real one — so crate resolution,
+the registry probe, feature enumeration, classification, the messages and the
+exit status are all the gate's own code. The replayed output is captured
+verbatim from real runs; see
+[`scripts/test-data/semver-gate/README.md`](../../scripts/test-data/semver-gate/README.md)
+for how each fixture was taken and how to refresh one.
+
+The self-test is only worth its runtime if it can fail, so it was checked by
+mutation: deleting the classification makes cases 6 and 7 fail (reproducing the
+original defect — a build error reported as a required version bump, and a
+silent no-op reported as a pass); making the no-verdict status 0 fails five
+cases; and forcing the classifier to always answer "no verdict" fails cases 5
+and 8.

--- a/scripts/check_semver.sh
+++ b/scripts/check_semver.sh
@@ -55,6 +55,30 @@
 #   rustdoc trees to be told nothing applies. This is a cost cut, not a coverage
 #   cut: the skipped run had no coverage to give.
 #
+# A BUILD FAILURE IS NOT A VERDICT (issue #5289). cargo-semver-checks has to
+#   build rustdoc for both sides before it can compare anything, and that build
+#   can fail on its own — a broken dependency graph, an MSRV floor a dependency
+#   raised, a baseline the registry would not hand over. Until #5289 every one of
+#   those exited non-zero and fell straight into the "a public API change
+#   requires a matching version bump" remediation below, so a rustdoc error was
+#   presented as a SemVer verdict and the two were indistinguishable from the
+#   output. The gate now classifies on POSITIVE EVIDENCE instead: a verdict
+#   exists only when the tool printed its own per-crate `N checks:` summary line.
+#   No summary line means no comparison happened, whatever the exit status was —
+#   including exit 0 — and that is reported as NO VERDICT on its own exit code.
+#   Absence of evidence is never a pass; same rule as the scan floor below.
+#
+# Toolchain (issue #5289): cargo-semver-checks re-resolves the dependency graph
+#   in a scratch project that IGNORES this workspace's Cargo.lock, so it can pick
+#   a newer transitive dependency than the lockfile pins and inherit that
+#   dependency's MSRV. Observed: the scratch resolution took `takecell` 0.1.2
+#   (rust-version 1.96) where Cargo.lock pins 0.1.1 via teloxide-core, and
+#   rustdoc then refused to build under this repo's MSRV 1.94. `takecell` reaches
+#   every default build of trusty-mpm through `cli` -> `telegram`, so this is the
+#   normal case and not an edge one. The gate therefore runs under the NEWEST
+#   rustc it can find rather than the pinned one — see select_toolchain below for
+#   why that costs no coverage and cannot manufacture a pass.
+#
 # Features: cargo-semver-checks' default heuristic enables every feature, which
 #   here means building CUDA and CoreML backends that no CI runner can build
 #   (`cudarc` panics with "nvcc --version failed"). Passing --default-features
@@ -77,13 +101,24 @@
 #   directory name (`trusty-git-analytics`), so a release tag's prefix can be
 #   handed straight to it in either accepted form (#1128).
 #
-# Exit: 0 when every checked crate is SemVer-clean (or is a recorded skip);
-#   1 when a crate needs a bump it does not have, or when the gate itself could
-#   not do its job.
+#   SEMVER_GATE_TOOLCHAIN_BIN=<dir>  pin the rustc/cargo the check runs under.
+#   SEMVER_GATE_TOOLCHAIN_BIN=       (set but empty) keep the ambient toolchain.
 #
-# Test: `scripts/check_semver_selftest.sh` proves the two ways this gate could
-#   lie — a vacuous scan and an unreachable registry — both exit non-zero. The
-#   catch itself is demonstrated in PR #5051 against #4088's real shape.
+# Exit (#5289 split 1 from 3 — a verdict and a non-verdict are different facts):
+#   0  every checked crate is SemVer-clean, or is a recorded skip.
+#   1  A VERDICT WAS COMPUTED AND IT SAYS BREAK — a crate needs a bump it does
+#      not have. This is the only status that means "the API changed".
+#   2  usage error.
+#   3  NO VERDICT — the gate could not do its job: cargo-semver-checks never
+#      completed a check run (rustdoc build failure, baseline retrieval
+#      failure), the diff scanned nothing, the registry was unreachable, or the
+#      tool is missing. Nothing was compared, so nothing may be concluded.
+#
+# Test: `scripts/check_semver_selftest.sh` proves every way this gate could lie
+#   — a vacuous scan, an unreachable registry, and (since #5289) a rustdoc build
+#   failure or a silent no-op rendered as a SemVer verdict — all exit non-zero,
+#   and that a real break is still reported as a break. The catch itself is
+#   demonstrated in PR #5051 against #4088's real shape.
 #
 # Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
 #   plus `git`, `curl`, `cargo`, `python3` (JSON parsing only).
@@ -98,6 +133,13 @@ EXPLICIT_CRATES=""
 PROBE_ONLY=""
 INDEX_BASE="${SEMVER_GATE_INDEX_BASE:-https://index.crates.io}"
 EXCLUSIONS_FILE="${REPO_ROOT}/scripts/semver-checks-feature-exclusions.tsv"
+
+# Exit statuses. `1` is reserved for a COMPUTED verdict that says break; every
+# way the gate can fail to compute one is `3` (#5289). Callers that only test
+# for zero keep working; callers that want to tell "your API changed" from "the
+# gate is broken" now can — see preflight-publish.sh CHECK 5.
+EXIT_SEMVER_BREAK=1
+EXIT_NO_VERDICT=3
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -126,7 +168,9 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     -h | --help)
-      sed -n '2,89p' "$0" >&2
+      # Prints the contiguous comment block after the shebang, so editing the
+      # header above never silently truncates --help against a stale line range.
+      awk 'NR > 1 && /^#/ { print; next } NR > 1 { exit }' "$0" >&2
       exit 0
       ;;
     *)
@@ -166,7 +210,7 @@ registry_latest() {
     echo "      ${INDEX_BASE}/${path} — curl failed." >&2
     echo "      Whether a baseline exists is UNKNOWN, so no skip may be granted." >&2
     echo "      This is NOT a pass (issue #5050)." >&2
-    exit 1
+    exit "$EXIT_NO_VERDICT"
   }
 
   if [[ "$code" == "404" ]]; then
@@ -182,7 +226,7 @@ registry_latest() {
     echo "      Whether a baseline exists is UNKNOWN, so no skip may be granted." >&2
     echo "      This is NOT a pass (issue #5050)." >&2
     rm -f "$body"
-    exit 1
+    exit "$EXIT_NO_VERDICT"
   fi
 
   local latest rc=0
@@ -218,7 +262,7 @@ PY
     echo "FAIL: TOOL ERROR — the crates.io index entry for '${crate}' did not parse." >&2
     echo "      Whether a baseline exists is UNKNOWN, so no skip may be granted." >&2
     echo "      This is NOT a pass (issue #5050)." >&2
-    exit 1
+    exit "$EXIT_NO_VERDICT"
   fi
   echo "$latest"
 }
@@ -267,7 +311,7 @@ feature_args() {
   fi
   python3 "$PY_HELPER" features "$META_FILE" "$crate" "$excluded" || {
     echo "FAIL: TOOL ERROR — could not resolve the feature set for '${crate}'." >&2
-    exit 1
+    exit "$EXIT_NO_VERDICT"
   }
 }
 
@@ -350,7 +394,7 @@ PY
 if ! cargo metadata --no-deps --format-version 1 > "$META_FILE" 2> "${SCRATCH}/meta-err.txt"; then
   echo "FAIL: TOOL ERROR — 'cargo metadata --no-deps' failed:" >&2
   sed 's/^/       /' "${SCRATCH}/meta-err.txt" >&2
-  exit 1
+  exit "$EXIT_NO_VERDICT"
 fi
 
 # pkg_field <crate> <field> — one line of package metadata. A crate the metadata
@@ -358,7 +402,7 @@ fi
 pkg_field() {
   python3 "$PY_HELPER" field "$META_FILE" "$1" "$2" || {
     echo "FAIL: TOOL ERROR — no workspace metadata for package '${1}' (field '${2}')." >&2
-    exit 1
+    exit "$EXIT_NO_VERDICT"
   }
 }
 
@@ -388,7 +432,7 @@ resolve_crate() {
     return 0
   fi
   echo "FAIL: '${want}' is neither a workspace package name nor a crates/ directory." >&2
-  return 1
+  return "$EXIT_NO_VERDICT"
 }
 
 # require_tool — cargo-semver-checks must be installed, and its absence is a
@@ -404,7 +448,123 @@ require_tool() {
   echo "      Install it before publishing:" >&2
   echo "        cargo install cargo-semver-checks@0.50.0 --locked" >&2
   echo "      A missing tool is NOT a pass (issue #5050)." >&2
-  return 1
+  return "$EXIT_NO_VERDICT"
+}
+
+# ---------------------------------------------------------------------------
+# select_toolchain — put the newest installed rustc/cargo on PATH for the
+# duration of this run, and report which one the check will use.
+#
+# Why: cargo-semver-checks builds rustdoc in a scratch project that ignores this
+#   workspace's Cargo.lock (see "Toolchain" in the header). The re-resolved graph
+#   can therefore demand a HIGHER rustc than the repo's MSRV, and did: `takecell`
+#   0.1.2 requires 1.96, which killed the whole gate under the pinned 1.94.1.
+#   Pinning the offending transitive dependency instead would fix one name until
+#   the next dependency raises its floor — a treadmill, not a fix.
+#
+#   This costs no coverage. The gate compares the PUBLIC API of our source
+#   against the registry; which rustc renders the rustdoc JSON does not change
+#   what that API is. MSRV compliance is a different question answered by a
+#   different CI job (dtolnay/rust-toolchain@1.94), and nothing here weakens it.
+#
+#   It also cannot manufacture a pass, which is the property that matters. The
+#   only thing a wrong toolchain choice can do is fail the rustdoc build, and
+#   since #5289 that is NO VERDICT and exits non-zero. A machine with no newer
+#   toolchain installed keeps the ambient one and degrades to exactly that
+#   honest path — never to a silent green.
+#
+# What: honours SEMVER_GATE_TOOLCHAIN_BIN when it is set (empty disables the
+#   search and keeps the ambient toolchain); otherwise scans
+#   $RUSTUP_HOME/toolchains/*/bin for the highest `rustc -V` and prepends it when
+#   it beats the active one. RUSTUP_TOOLCHAIN is deliberately NOT used: where
+#   rustc/cargo resolve through mise shims, the shim execs a pinned toolchain
+#   directly and never consults rustup, so the variable is silently ignored.
+#   Prepending the toolchain's own bin directory is the mechanism that works
+#   under both mise shims and a plain rustup install.
+# ---------------------------------------------------------------------------
+select_toolchain() {
+  local active best_dir
+
+  active="$(rustc -V 2>/dev/null | awk '{print $2}')"
+  active="${active:-unknown}"
+
+  if [[ -n "${SEMVER_GATE_TOOLCHAIN_BIN+x}" ]]; then
+    if [[ -z "$SEMVER_GATE_TOOLCHAIN_BIN" ]]; then
+      echo "toolchain: ambient rustc ${active} (selection disabled by SEMVER_GATE_TOOLCHAIN_BIN=)"
+      return 0
+    fi
+    PATH="${SEMVER_GATE_TOOLCHAIN_BIN}:${PATH}"
+    export PATH
+    echo "toolchain: rustc $(rustc -V 2>/dev/null | awk '{print $2}') (pinned by SEMVER_GATE_TOOLCHAIN_BIN)"
+    return 0
+  fi
+
+  best_dir="$(python3 - "${RUSTUP_HOME:-${HOME}/.rustup}/toolchains" "$active" <<'PY'
+import os, sys, subprocess
+
+root, active = sys.argv[1], sys.argv[2]
+
+def key(v):
+    parts = (v.split("-")[0].split(".") + ["0", "0", "0"])[:3]
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError:
+        return (0, 0, 0)
+
+best, best_dir = key(active), ""
+try:
+    names = sorted(os.listdir(root))
+except OSError:
+    names = []
+for name in names:
+    binp = os.path.join(root, name, "bin")
+    rustc = os.path.join(binp, "rustc")
+    if not (os.path.isfile(rustc) and os.access(rustc, os.X_OK)):
+        continue
+    if not os.path.isfile(os.path.join(binp, "cargo")):
+        continue  # rustdoc builds need cargo from the same directory
+    try:
+        out = subprocess.run([rustc, "-V"], capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        continue
+    if out.returncode != 0 or len(out.stdout.split()) < 2:
+        continue
+    v = key(out.stdout.split()[1])
+    if v > best:
+        best, best_dir = v, binp
+print(best_dir)
+PY
+  )" || best_dir=""
+
+  if [[ -n "$best_dir" ]]; then
+    PATH="${best_dir}:${PATH}"
+    export PATH
+    echo "toolchain: rustc $(rustc -V 2>/dev/null | awk '{print $2}') (selected over ambient ${active}; the scratch resolution ignores Cargo.lock)"
+  else
+    echo "toolchain: ambient rustc ${active} (no newer toolchain installed)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# verdict_computed <output-file> — succeed only when cargo-semver-checks printed
+# its own per-crate check summary, e.g.
+#     Checked [   0.388s] 223 checks: 214 pass, 9 fail, 0 warn, 31 skip
+#     Checked [   0.000s] 0 checks: 0 pass, 254 skip
+#
+# Why a MARKER and not the exit status: the tool's statuses are not a contract
+#   the gate can lean on, and observation shows they collide. 101 is a rustdoc
+#   build failure AND a "crate not found in registry" baseline failure; 100 is a
+#   real break; 0 is clean. Keying on the status alone would still mix a
+#   non-verdict in with a verdict. The summary line is the tool's own statement
+#   that it finished comparing, so requiring it means the gate concludes only
+#   from evidence that the comparison happened.
+#
+# Fails CLOSED by construction: if a future cargo-semver-checks renames this
+#   line, every run becomes NO VERDICT — loud and non-zero — rather than a
+#   silent green. That is the correct direction for the failure to point.
+# ---------------------------------------------------------------------------
+verdict_computed() {
+  grep -Eq '(^|[[:space:]])Checked[[:space:]].*[0-9]+ checks:' "$1"
 }
 
 # ---------------------------------------------------------------------------
@@ -418,7 +578,7 @@ if [[ -n "$PROBE_ONLY" ]]; then
   # Every caller must re-raise it explicitly. Leaving that to `set -e` is exactly
   # the fail-open shape this gate exists to avoid.
   if ! latest="$(registry_latest "$PROBE_ONLY")"; then
-    exit 1
+    exit "$EXIT_NO_VERDICT"
   fi
   echo "probe ${PROBE_ONLY}: baseline=${latest}"
   exit 0
@@ -433,7 +593,7 @@ if [[ -n "$EXPLICIT_CRATES" ]]; then
   while IFS= read -r want; do
     [[ -z "$want" ]] && continue
     if ! name="$(resolve_crate "$want")"; then
-      exit 1
+      exit "$EXIT_NO_VERDICT"
     fi
     CANDIDATES="${CANDIDATES}${name}"$'\n'
   done <<<"$(printf '%s' "$EXPLICIT_CRATES" | grep -v '^$')"
@@ -444,7 +604,7 @@ else
     echo "FAIL: TOOL ERROR — cannot find a merge base between '${BASE}' and HEAD." >&2
     echo "      Fetch the base ref first (CI must check out with fetch-depth: 0):" >&2
     echo "        git fetch origin main" >&2
-    exit 1
+    exit "$EXIT_NO_VERDICT"
   fi
 
   CHANGED="$(git diff --name-only --no-renames "$MERGE_BASE" HEAD)"
@@ -457,7 +617,7 @@ else
     echo "FAIL: SCAN FLOOR — the diff ${MERGE_BASE}..HEAD lists 0 changed path(s)." >&2
     echo "      Nothing was examined, so this gate could not have failed. Check that" >&2
     echo "      '${BASE}' is the right base and that CI checked out with fetch-depth: 0." >&2
-    exit 1
+    exit "$EXIT_NO_VERDICT"
   fi
   SCANNED="${CHANGED_COUNT} changed path(s)"
 
@@ -499,6 +659,11 @@ fi
 checked=0
 skipped=0
 fail=0
+noverdict=0
+
+# Selected once, not per crate: the PATH edit is process-wide and re-running the
+# scan for every candidate would just re-answer the same question.
+select_toolchain
 
 while IFS= read -r crate; do
   [[ -z "$crate" ]] && continue
@@ -515,12 +680,12 @@ while IFS= read -r crate; do
     continue
   fi
 
-  current="$(pkg_field "$crate" version)" || exit 1
+  current="$(pkg_field "$crate" version)" || exit "$EXIT_NO_VERDICT"
 
   # Subshell re-raise, as at --probe above: a helper's `exit 1` dies with the
   # command substitution unless the caller checks for it.
   if ! baseline="$(registry_latest "$crate")"; then
-    exit 1
+    exit "$EXIT_NO_VERDICT"
   fi
 
   if [[ "$baseline" == "NONE" ]]; then
@@ -531,7 +696,7 @@ while IFS= read -r crate; do
 
   if ! rtype="$(release_type "$baseline" "$current")"; then
     echo "FAIL: TOOL ERROR — could not compare '${baseline}' and '${current}' for ${crate}." >&2
-    exit 1
+    exit "$EXIT_NO_VERDICT"
   fi
   if [[ "$rtype" == "major" ]]; then
     echo "SKIP ${crate}: ${baseline} -> ${current} is already a major release — every lint is inapplicable"
@@ -542,23 +707,38 @@ while IFS= read -r crate; do
   # Checked lazily — a run whose every candidate skipped never needed the tool,
   # and demanding it there would be friction with no coverage behind it.
   if [[ -z "${TOOL_OK:-}" ]]; then
-    require_tool || exit 1
+    require_tool || exit "$EXIT_NO_VERDICT"
     TOOL_OK=1
   fi
 
   if ! feature_args "$crate" > "${SCRATCH}/features.txt"; then
-    exit 1
+    exit "$EXIT_NO_VERDICT"
   fi
 
   # shellcheck disable=SC2046
   set -- $(cat "${SCRATCH}/features.txt")
   echo "CHECK ${crate}: ${baseline} -> ${current} (${rtype} release), $(($# / 2)) feature(s)"
 
+  # Captured rather than streamed so the run can be CLASSIFIED afterwards
+  # (#5289); echoed straight back so a human still sees every lint the tool
+  # printed, and so preflight-publish.sh's captured log is unchanged in content.
   rc=0
+  RUN_LOG="${SCRATCH}/run-${crate}.txt"
   SKIP_UI_BUILD=1 cargo semver-checks \
     --package "$crate" \
     --baseline-version "$baseline" \
-    --only-explicit-features "$@" || rc=$?
+    --only-explicit-features "$@" > "$RUN_LOG" 2>&1 || rc=$?
+  cat "$RUN_LOG"
+
+  # Order matters: "did it compare anything?" is asked BEFORE "what did it say?".
+  # An exit 0 with no summary line is a no-op, not a pass, and must not reach the
+  # clean branch — that is the fail-closed half of this check.
+  if ! verdict_computed "$RUN_LOG"; then
+    echo "NO VERDICT ${crate}: cargo semver-checks exited ${rc} without completing a check run." >&2
+    echo "           No public API comparison against baseline ${baseline} was performed." >&2
+    noverdict=$((noverdict + 1))
+    continue
+  fi
 
   if [[ "$rc" -ne 0 ]]; then
     echo "FAIL ${crate}: cargo semver-checks exited ${rc} against baseline ${baseline}" >&2
@@ -570,7 +750,7 @@ done <<<"$CANDIDATES"
 if [[ "$fail" -ne 0 ]]; then
   cat >&2 <<'EOF'
 
-A public API change requires a matching version bump.
+VERDICT: BREAK. A public API change requires a matching version bump.
 
   0.x crates: a break needs the MINOR position (0.28.1 -> 0.29.0).
   1.x+ crates: a break needs the MAJOR position (1.3.4 -> 2.0.0).
@@ -585,7 +765,34 @@ This is not advisory. #4088: trusty-common 0.22.5 shipped exactly this class of
 break as a patch bump and bricked `cargo install` for every dependent on a
 ^0.22 floor, costing trusty-analyze 0.7.3 a yank.
 EOF
-  exit 1
+  exit "$EXIT_SEMVER_BREAK"
+fi
+
+# Reported AFTER the break block so a run that hit both says both, and exits on
+# the non-verdict — an incomplete run is the one result that must never be read
+# as a conclusion about the API.
+if [[ "$noverdict" -ne 0 ]]; then
+  cat >&2 <<'EOF'
+
+NO SEMVER VERDICT WAS COMPUTED. This is NOT a pass, and it is NOT a report that
+the API changed — cargo-semver-checks never finished comparing, so nothing is
+known either way about this crate's public API.
+
+The tool's own output is above. The usual causes:
+
+  * rustdoc failed to build. cargo-semver-checks resolves dependencies in a
+    scratch project that IGNORES this workspace's Cargo.lock, so it can pick a
+    newer transitive dependency whose `rust-version` exceeds the rustc running
+    the gate. The `toolchain:` line above says which rustc that was. Install a
+    newer one (`rustup toolchain install stable`), or point the gate at one:
+        SEMVER_GATE_TOOLCHAIN_BIN=<dir> bash scripts/check_semver.sh --crate <c>
+  * the baseline could not be fetched from crates.io.
+  * a genuine compile error in the crate — build it directly to see it.
+
+Fix the gate, then re-run it. Do not publish on the strength of this output:
+"the check could not run" is not "the check passed" (issue #5289).
+EOF
+  exit "$EXIT_NO_VERDICT"
 fi
 
 echo "semver gate: scanned ${SCANNED}; ${checked} crate(s) checked, ${skipped} skipped — OK."

--- a/scripts/check_semver_selftest.sh
+++ b/scripts/check_semver_selftest.sh
@@ -21,6 +21,30 @@
 #   Cases 2-4 drive the probe through `--probe`, which reaches the network
 #   without a Cargo build, so the whole file runs in seconds.
 #
+#   Cases 5-8 (issue #5289) cover the defect that mattered more: the gate USED TO
+#   print "a public API change requires a matching version bump" over a
+#   cargo-semver-checks run that had failed to BUILD, so a rustdoc error and a
+#   real SemVer break were indistinguishable from the output. These four pin the
+#   classification apart:
+#     5. real break          — exit 100 with a verdict. Must report BREAK.
+#     6. rustdoc build error — exit 101, no comparison. Must report NO VERDICT
+#                              and must NOT reach the version-bump remediation.
+#     7. silent no-op        — exit 0, no comparison. Must still fail: "the tool
+#                              said nothing" is not "the tool said pass".
+#     8. clean               — exit 0 with a verdict. Must exit 0, which is what
+#                              proves 5-7 fail on classification rather than
+#                              because every path through the gate is broken.
+#
+#   Cases 5-8 replace only the `cargo semver-checks` SUBPROCESS, via a stub
+#   `cargo` on PATH that forwards everything else (`metadata`) to the real one.
+#   Everything under test — crate resolution, the registry probe, feature
+#   enumeration, verdict classification, the messages, the exit status — is the
+#   gate's own unmodified code. The stub replays FIXTURES captured verbatim from
+#   real cargo-semver-checks 0.50.0 runs (only absolute paths rewritten to
+#   /REPO); scripts/test-data/semver-gate/README.md records how each was taken.
+#   silent-noop.out is the one synthetic fixture, because no real invocation
+#   produces that shape today — it is the shape a future regression would take.
+#
 # Usage:  bash scripts/check_semver_selftest.sh
 # Exit:   0 when every case behaves; 1 (naming the case) when one does not.
 #
@@ -71,10 +95,24 @@ fi
 # ===========================================================================
 PORT_FILE="$(mktemp "${TMPDIR:-/tmp}/semver-selftest.XXXXXX")"
 python3 - "$PORT_FILE" > /dev/null 2>&1 <<'PY' &
-import http.server, socketserver, sys, threading
+import http.server, json, socketserver, sys, threading
 
 class H(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
+        # /v/<version>/... serves a one-line sparse-index body naming <version>
+        # as the only non-yanked release, so cases 5-8 get a real baseline
+        # without touching the network. Everything else keeps the original
+        # behaviour: /503 -> 503, anything else -> 404.
+        parts = self.path.split("/")
+        if len(parts) > 2 and parts[1] == "v":
+            body = json.dumps(
+                {"name": "stub", "vers": parts[2], "yanked": False}
+            ).encode() + b"\n"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
         code = 503 if self.path.startswith("/503") else 404
         self.send_response(code)
         self.send_header("Content-Length", "0")
@@ -143,6 +181,85 @@ elif [[ "$out" != *"baseline=NONE"* ]]; then
 else
   pass_case "probe treats HTTP 404 as 'never published' (exit 0, baseline=NONE)"
 fi
+
+# ===========================================================================
+# 5-8. Verdict vs non-verdict (#5289).
+#
+# A stub `cargo` replaces ONLY the semver-checks subprocess; `metadata` and
+# anything else forward to the real binary, so the gate runs its own code end to
+# end. SEMVER_GATE_TOOLCHAIN_BIN= keeps select_toolchain from prepending a real
+# toolchain's bin directory ahead of the stub — and doubles as coverage that the
+# knob works.
+# ===========================================================================
+FIXTURES="${REPO_ROOT}/scripts/test-data/semver-gate"
+STUB_DIR="$(mktemp -d "${TMPDIR:-/tmp}/semver-selftest-bin.XXXXXX")"
+REAL_CARGO="$(command -v cargo)"
+if [[ -z "$REAL_CARGO" ]]; then
+  echo "SELF-TEST FAIL: no cargo on PATH; cases 5-8 need it for 'cargo metadata'." >&2
+  exit 1
+fi
+
+cat > "${STUB_DIR}/cargo" <<'STUB'
+#!/usr/bin/env bash
+# Stub cargo for check_semver_selftest.sh: replays a captured cargo-semver-checks
+# run, forwards everything else to the real cargo.
+if [[ "${1:-}" == "semver-checks" ]]; then
+  case " $* " in
+    *" --version "*) echo "cargo-semver-checks 0.50.0"; exit 0 ;;
+  esac
+  cat "$SEMVER_SELFTEST_FIXTURE"
+  exit "$SEMVER_SELFTEST_RC"
+fi
+exec "$SEMVER_SELFTEST_REAL_CARGO" "$@"
+STUB
+chmod +x "${STUB_DIR}/cargo"
+
+# The stub crate must be publishable, have a lib target, and carry a version the
+# stub index can echo back — echoing the crate's OWN version makes release_type
+# "none", which never trips the already-breaking skip no matter how the crate is
+# versioned later. A crate that starts skipping would silently stop testing
+# anything, so the CHECK line is asserted below.
+STUB_CRATE="trusty-common"
+STUB_VERSION="$("$REAL_CARGO" metadata --no-deps --format-version 1 2>/dev/null \
+  | python3 -c 'import json,sys;m=json.load(sys.stdin);print(next(p["version"] for p in m["packages"] if p["name"]=="trusty-common"))')"
+if [[ -z "$STUB_VERSION" ]]; then
+  echo "SELF-TEST FAIL: could not read ${STUB_CRATE}'s version from cargo metadata." >&2
+  exit 1
+fi
+
+# name  fixture  stub-rc  expected-exit  must-contain  must-NOT-contain ("-" = none)
+TAB="$(printf '\t')"
+VERDICT_CASES="real break${TAB}break.out${TAB}100${TAB}1${TAB}VERDICT: BREAK${TAB}NO SEMVER VERDICT
+rustdoc build error${TAB}build-error.out${TAB}101${TAB}3${TAB}NO SEMVER VERDICT WAS COMPUTED${TAB}requires a matching version bump
+silent no-op at exit 0${TAB}silent-noop.out${TAB}0${TAB}3${TAB}NO SEMVER VERDICT WAS COMPUTED${TAB}requires a matching version bump
+clean${TAB}clean.out${TAB}0${TAB}0${TAB}crate(s) checked${TAB}NO SEMVER VERDICT"
+
+while IFS="$TAB" read -r name fixture stub_rc want_exit must_have must_not; do
+  [[ -z "$name" ]] && continue
+  rc=0
+  out="$(cd "$REPO_ROOT" && \
+    PATH="${STUB_DIR}:${PATH}" \
+    SEMVER_GATE_TOOLCHAIN_BIN='' \
+    SEMVER_SELFTEST_REAL_CARGO="$REAL_CARGO" \
+    SEMVER_SELFTEST_FIXTURE="${FIXTURES}/${fixture}" \
+    SEMVER_SELFTEST_RC="$stub_rc" \
+    SEMVER_GATE_INDEX_BASE="http://127.0.0.1:${PORT}/v/${STUB_VERSION}" \
+    bash "$GATE" --crate "$STUB_CRATE" 2>&1)" || rc=$?
+
+  if [[ "$out" != *"CHECK ${STUB_CRATE}:"* ]]; then
+    fail_case "verdict/${name}: the gate never reached the check — this case proves nothing. Did ${STUB_CRATE} start skipping?" "$out"
+  elif [[ "$rc" -ne "$want_exit" ]]; then
+    fail_case "verdict/${name}: expected exit ${want_exit}, got ${rc}" "$out"
+  elif [[ "$out" != *"$must_have"* ]]; then
+    fail_case "verdict/${name}: exit ${rc} but the output never said '${must_have}'" "$out"
+  elif [[ "$must_not" != "-" && "$out" == *"$must_not"* ]]; then
+    fail_case "verdict/${name}: output wrongly claims '${must_not}'" "$out"
+  else
+    pass_case "${name} -> exit ${rc}, says '${must_have}'"
+  fi
+done <<<"$VERDICT_CASES"
+
+rm -rf "$STUB_DIR"
 
 echo
 if [[ "$FAILED" -ne 0 ]]; then

--- a/scripts/preflight-publish.sh
+++ b/scripts/preflight-publish.sh
@@ -77,6 +77,13 @@
 #     as an already-breaking release and skips. A false positive and a real
 #     break have the same safe remedy.
 #
+#     A NON-VERDICT IS NOT A VERDICT (#5289). check_semver.sh exits 1 only when
+#     it computed a verdict that says break, and 3 when it could not compute one
+#     at all (rustdoc build failure, unreachable registry, missing tool). Both
+#     stop the publish; only the first is reported as "your API changed". The
+#     remedy above applies to exit 1 — for exit 3 the remedy is to fix the gate
+#     and re-run, never to bump a version on evidence that does not exist.
+#
 #     Requires `cargo-semver-checks` (`cargo install cargo-semver-checks@0.50.0
 #     --locked`). Its absence is a FAILURE with that remedy, never a skip.
 #
@@ -387,6 +394,15 @@ check4_version_not_live() {
 # Output goes to a file rather than the terminal because cargo-semver-checks
 # prints a per-lint progress stream; the file is echoed only when the check
 # fails, which is the only time any of it carries information.
+#
+# The two nonzero statuses are DIFFERENT FACTS and are reported as such (#5289).
+# This function used to render every nonzero exit as "public-API check failed …
+# publishing this would ship a breaking change", so a rustdoc build error at the
+# last barrier before `cargo publish` read as a SemVer verdict. Exit 3 means
+# check_semver.sh never computed one; saying "your API changed" there would be
+# inventing a result, and telling the operator to bump the breaking position
+# would be advising a version change on no evidence. Either way the publish
+# still stops — both branches return 1.
 check5_semver() {
   local log="${TMP_SEMVER}" rc=0
 
@@ -396,6 +412,16 @@ check5_semver() {
   if [ "$rc" -eq 0 ]; then
     echo "[PASS] semver: $(tail -1 "$log")" >&2
     return 0
+  fi
+
+  if [ "$rc" -eq 3 ]; then
+    echo "[FAIL] semver: NO VERDICT for ${PKG_NAME} ${VERSION} — the gate could not run:" >&2
+    sed 's/^/       /' "$log" >&2
+    echo "       cargo-semver-checks never completed a comparison, so whether this" >&2
+    echo "       release breaks the public API is UNKNOWN. That is not a reason to" >&2
+    echo "       bump the version and not a reason to publish." >&2
+    echo "       Fix the gate (see the NO SEMVER VERDICT block above), then re-run." >&2
+    return 1
   fi
 
   echo "[FAIL] semver: public-API check failed for ${PKG_NAME} ${VERSION}:" >&2

--- a/scripts/test-data/semver-gate/README.md
+++ b/scripts/test-data/semver-gate/README.md
@@ -1,0 +1,31 @@
+# SemVer-gate fixtures (issue #5289)
+
+Captured `cargo-semver-checks` 0.50.0 output, replayed by
+`scripts/check_semver_selftest.sh` cases 5-8 through a stub `cargo`. They exist
+so the self-test can prove `scripts/check_semver.sh` tells a build failure apart
+from a SemVer verdict without spending minutes building two rustdoc trees per
+case.
+
+Each file is the tool's stdout+stderr **only** — never the gate's own output. A
+fixture that includes the gate's remediation text would let the "must not claim
+a version bump is needed" assertion pass on the fixture's own contents rather
+than on what the gate decided. That mistake was made once while writing these
+and the self-test caught it.
+
+The one edit applied to a captured file: absolute paths rewritten to `/REPO`, so
+no author's worktree path is committed.
+
+| File | Stub exit | Captured from |
+|---|---|---|
+| `break.out` | 100 | `cargo semver-checks -p trusty-mpm --baseline-version 1.3.4 --only-explicit-features` + the 11 default-set features, under rustc 1.97.1. The real 1.3.4 -> 1.3.5 break: 9 major failures. |
+| `clean.out` | 0 | `cargo semver-checks -p trusty-progress --baseline-version 0.2.0 --only-explicit-features`. Already a major bump, so 0 lints apply — the tool's "nothing to compare, and that is fine" shape. |
+| `build-error.out` | 101 | The same `trusty-mpm` command under the repo MSRV 1.94.1, where the scratch resolution takes `takecell` 0.1.2 (`rust-version` 1.96) and rustdoc refuses to build. This is the defect #5289 was filed for. |
+| `silent-noop.out` | 0 | **Synthetic.** No real invocation produces exit 0 with no `checks:` summary today. It pins the fail-closed rule: "the tool said nothing" must never be read as "the tool said pass". |
+
+## Refreshing one
+
+Run the command in the table, redirect stdout+stderr to the file, and rewrite
+your absolute repo path to `/REPO`. Then run
+`bash scripts/check_semver_selftest.sh` — a fixture that no longer carries (or
+wrongly carries) the `Checked … N checks:` marker will fail the case that
+depends on it, which is the point.

--- a/scripts/test-data/semver-gate/break.out
+++ b/scripts/test-data/semver-gate/break.out
@@ -1,0 +1,128 @@
+     Parsing trusty-mpm v1.3.5 (current)
+      Parsed [   0.161s] (current)
+    Building trusty-mpm v1.3.4 (baseline)
+       Built [  46.973s] (baseline)
+     Parsing trusty-mpm v1.3.4 (baseline)
+      Parsed [   0.150s] (baseline)
+    Checking trusty-mpm v1.3.4 -> v1.3.5 (patch change)
+     Checked [   0.388s] 223 checks: 214 pass, 9 fail, 0 warn, 31 skip
+
+--- failure constructible_struct_adds_field: struct exhaustively constructible through public API adds field ---
+
+Description:
+A pub struct that could be exhaustively constructed with a literal using only public API has a new pub field, breaking existing exhaustive literals.
+        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/constructible_struct_adds_field.ron
+
+Failed in:
+  field SpawnParams.worktree in /REPO/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs:176
+  field MpmConfig.hooks in /REPO/crates/trusty-mpm/src/core/config.rs:353
+  field MpmConfig.agent_cost in /REPO/crates/trusty-mpm/src/core/config.rs:406
+  field HarnessManifest.agent_categories in /REPO/crates/trusty-mpm/src/core/manifest/schema.rs:59
+  field HarnessManifest.skill_categories in /REPO/crates/trusty-mpm/src/core/manifest/schema.rs:67
+  field SyncAssetsReport.quarantine_summary in /REPO/crates/trusty-mpm/src/core/session_launch/sync_assets.rs:104
+  field SpawnRequest.worktree in /REPO/crates/trusty-mpm/src/daemon/managed_routes/mod.rs:173
+  field ManifestSources.framework_scope in /REPO/crates/trusty-mpm/src/core/manifest/resolve.rs:72
+  field RepairOutcome.path in /REPO/crates/trusty-mpm/src/core/skill_repair.rs:96
+  field CollectionRow.room_count in /REPO/crates/trusty-mpm/src/tui/health/types.rs:160
+  field CollectionRow.room_count in /REPO/crates/trusty-mpm/src/tui/health/types.rs:160
+  field SessionRecord.terminal_at in /REPO/crates/trusty-mpm/src/session_manager/record.rs:438
+  field SessionRecord.terminal_at in /REPO/crates/trusty-mpm/src/session_manager/record.rs:438
+  field ApplyReport.agents_prune_kept in /REPO/crates/trusty-mpm/src/core/update_check/apply.rs:100
+  field ApplyReport.skills_prune_kept in /REPO/crates/trusty-mpm/src/core/update_check/apply.rs:102
+  field ApplyReport.prune_backup_dir in /REPO/crates/trusty-mpm/src/core/update_check/apply.rs:105
+  field PrepReport.compiled_prompt in /REPO/crates/trusty-mpm/src/core/session_launch/mod.rs:261
+
+--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---
+
+Description:
+A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
+        ref: https://doc.rust-lang.org/reference/items/enumerations.html
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_tuple_variant_changed_kind.ron
+
+Failed in:
+  variant PrepError::Instructions in /REPO/crates/trusty-mpm/src/core/session_launch/mod.rs:376
+
+--- failure enum_variant_added: enum variant added on exhaustive enum ---
+
+Description:
+A publicly-visible enum without #[non_exhaustive] has a new variant.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_added.ron
+
+Failed in:
+  variant RepairAction:WouldRepair in /REPO/crates/trusty-mpm/src/core/skill_repair.rs:71
+
+--- failure function_missing: pub fn removed or renamed ---
+
+Description:
+A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/function_missing.ron
+
+Failed in:
+  function trusty_mpm::core::instruction_pipeline::install_system_prompt, previously in file /Users/masa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-mpm-1.3.4/src/core/instruction_pipeline.rs:313
+  function trusty_mpm::core::instruction_pipeline::install_system_prompt_to, previously in file /Users/masa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-mpm-1.3.4/src/core/instruction_pipeline.rs:297
+
+--- failure function_parameter_count_changed: pub fn parameter count changed ---
+
+Description:
+A publicly-visible function now takes a different number of parameters.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/function_parameter_count_changed.ron
+
+Failed in:
+  trusty_mpm::core::managed_config::ensure_managed_config_dir_with_root now takes 3 parameters instead of 2, in /REPO/crates/trusty-mpm/src/core/managed_config.rs:188
+  trusty_mpm::core::managed_config::ensure_managed_config_dir now takes 2 parameters instead of 1, in /REPO/crates/trusty-mpm/src/core/managed_config.rs:142
+
+--- failure method_parameter_count_changed: pub method parameter count changed ---
+
+Description:
+A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/method_parameter_count_changed.ron
+
+Failed in:
+  trusty_mpm::core::manifest::ManifestSources::resolve takes 3 parameters in /Users/masa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-mpm-1.3.4/src/core/manifest/resolve.rs:77, but now takes 2 parameters in /REPO/crates/trusty-mpm/src/core/manifest/resolve.rs:94
+
+--- failure pub_module_level_const_missing: pub module-level const is missing ---
+
+Description:
+A public const is missing or renamed
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/pub_module_level_const_missing.ron
+
+Failed in:
+  TM_SLACK_CANVAS_DELIVERY in file /Users/masa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-mpm-1.3.4/src/core/bundle_tm_skills.rs:236
+  TM_PR_WORKFLOW in file /Users/masa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-mpm-1.3.4/src/core/bundle_tm_skills.rs:127
+  OPS_AGENT in file /Users/masa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-mpm-1.3.4/src/core/bundle.rs:57
+
+--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---
+
+Description:
+A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/struct_marked_non_exhaustive.ron
+
+Failed in:
+  struct ResolvedTmuxOptions in /REPO/crates/trusty-mpm/src/core/trusty_tools_config.rs:305
+  struct TmuxConfig in /REPO/crates/trusty-mpm/src/core/trusty_tools_config.rs:245
+
+--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---
+
+Description:
+A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/struct_pub_field_missing.ron
+
+Failed in:
+  field merged of struct PipelineOutput, previously in file /Users/masa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-mpm-1.3.4/src/core/instruction_pipeline.rs:502
+  field instructions_loaded of struct PipelineOutput, previously in file /Users/masa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-mpm-1.3.4/src/core/instruction_pipeline.rs:504
+  field wing_count of struct CollectionRow, previously in file /Users/masa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-mpm-1.3.4/src/tui/health/types.rs:156
+  field wing_count of struct CollectionRow, previously in file /Users/masa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-mpm-1.3.4/src/tui/health/types.rs:156
+  field user of struct ManifestSources, previously in file /Users/masa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-mpm-1.3.4/src/core/manifest/resolve.rs:45
+  field language_scope of struct ManifestSources, previously in file /Users/masa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-mpm-1.3.4/src/core/manifest/resolve.rs:56
+  field framework_instructions_path of struct PipelineInput, previously in file /Users/masa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-mpm-1.3.4/src/core/instruction_pipeline.rs:472
+
+     Summary semver requires new major version: 9 major and 0 minor checks failed
+    Finished [ 105.882s] trusty-mpm

--- a/scripts/test-data/semver-gate/build-error.out
+++ b/scripts/test-data/semver-gate/build-error.out
@@ -1,0 +1,27 @@
+    Building trusty-mpm v1.3.5 (current)
+error: running cargo-doc on crate 'trusty-mpm' failed with output:
+-----
+warning: /REPO/crates/trusty-mpm/Cargo.toml: file `/REPO/crates/trusty-mpm/src/bin/tm/main.rs` found to be present in multiple build targets:
+  * `bin` target `tm`
+  * `bin` target `trusty-mpm`
+error: rustc 1.94.1 is not supported by the following package:
+  takecell@0.1.2 requires rustc 1.96
+Either upgrade rustc or select compatible dependency versions with
+`cargo update <name>@<current-ver> --precise <compatible-ver>`
+where `<compatible-ver>` is the latest version supporting rustc 1.94.1
+
+
+-----
+
+error: failed to build rustdoc for crate trusty-mpm v1.3.5
+note: this is usually due to a compilation error in the crate,
+      and is unlikely to be a bug in cargo-semver-checks
+note: the following command can be used to reproduce the error:
+      cargo new --lib example &&
+          cd example &&
+          echo '[workspace]' >> Cargo.toml &&
+          cargo add --path /REPO/crates/trusty-mpm --no-default-features --features bedrock,cli,daemon,gui,manager-memory,mcp,slack,sm-memory,swagger-ui,telegram,tui &&
+          cargo check &&
+          cargo doc
+
+error: aborting due to failure to build rustdoc for crate trusty-mpm v1.3.5

--- a/scripts/test-data/semver-gate/clean.out
+++ b/scripts/test-data/semver-gate/clean.out
@@ -1,0 +1,12 @@
+    Building trusty-progress v0.3.0 (current)
+       Built [   2.766s] (current)
+     Parsing trusty-progress v0.3.0 (current)
+      Parsed [   0.001s] (current)
+    Building trusty-progress v0.2.0 (baseline)
+       Built [   2.108s] (baseline)
+     Parsing trusty-progress v0.2.0 (baseline)
+      Parsed [   0.001s] (baseline)
+    Checking trusty-progress v0.2.0 -> v0.3.0 (major change)
+     Checked [   0.000s] 0 checks: 0 pass, 254 skip
+     Summary no semver update required
+    Finished [   5.613s] trusty-progress

--- a/scripts/test-data/semver-gate/silent-noop.out
+++ b/scripts/test-data/semver-gate/silent-noop.out
@@ -1,0 +1,3 @@
+    Building trusty-mpm v1.3.5 (current)
+       Built [   7.275s] (current)
+    Finished [   7.3s] trusty-mpm


### PR DESCRIPTION
Fixes #5289. Scripts and CI only — no crate `src/**` changes, so **no changelog fragment is owed** (`check_changelog_fragment.sh` agrees: "scanned 10 changed path(s); no crate source changed — OK").

## Defect 1 — the gate could not run under the pinned toolchain

`cargo-semver-checks` re-resolves dependencies in a scratch project that ignores the workspace `Cargo.lock`. It took `takecell` 0.1.2 (`rust-version = 1.96`) where the lock pins 0.1.1 via `teloxide-core`, and rustdoc refused to build under `rustc 1.94.1`. `takecell` reaches every default build of `trusty-mpm` through `cli` → `telegram`, so the gate was simply unusable for that crate.

## Defect 2 — the gate lied

On any nonzero `cargo-semver-checks` exit the script printed its standard "a public API change requires a matching version bump" remediation. A rustdoc build error and a real SemVer break were indistinguishable from the output, and a reader saw a verdict where nothing had been compared. `scripts/preflight-publish.sh:401` — the last barrier before `cargo publish` — repeated it one layer up, advising a version bump on evidence that did not exist.

## Resolution

**Classification on positive evidence, not exit codes.** A verdict exists only when `cargo-semver-checks` printed its own `Checked … N checks:` summary line. Exit-code classification alone is insufficient — 101 is *both* a rustdoc build failure and a "crate not found in registry" baseline failure, both observed here. Absence of that line means no comparison happened whatever the status was, **including exit 0**, and is reported as `NO VERDICT`. If a future tool release renames that line, every run becomes a loud `NO VERDICT` rather than a silent green.

**Fail closed, per the #4618 precedent.** Exit 1 now means only "a verdict was computed and it says break". Every way the gate can fail to compute one — rustdoc failure, unreachable registry, missing tool, a diff that scanned nothing — is exit 3. None can exit 0. `preflight-publish.sh` and the workflow report the two separately; both still stop the publish.

**Toolchain: run under the newest installed rustc, not the pinned one.** Chosen over pinning `takecell`, which would fix one name until the next dependency raises its floor. This costs no coverage — which rustc renders the rustdoc JSON does not change what our public API is — and MSRV compliance remains a separate CI job. Critically, it cannot manufacture a pass: the only thing a wrong toolchain choice can do is fail the rustdoc build, which is now `NO VERDICT` and non-zero. **A machine with no newer toolchain installed keeps the ambient one and degrades to exactly that honest path.** `RUSTUP_TOOLCHAIN` is ineffective because mise shims exec a pinned toolchain directly and never consult rustup, so the toolchain's `bin` directory is prepended to `PATH`. `SEMVER_GATE_TOOLCHAIN_BIN=<dir>` pins it explicitly.

CI already installed `stable`, so the workflow needed no toolchain change — but the reasoning is now recorded there, and the run step annotates exit 3 and exit 1 differently so a build error cannot read as a version-bump verdict in the job log either.

## The real case: trusty-mpm 1.3.4 → 1.3.5

Reported as a **semver verdict**, exit 1 — 9 major failures, not a build error:

```
toolchain: rustc 1.97.1 (selected over ambient 1.94.1; the scratch resolution ignores Cargo.lock)
CHECK trusty-mpm: 1.3.4 -> 1.3.5 (patch release), 11 feature(s)
    Checking trusty-mpm v1.3.4 -> v1.3.5 (patch change)
     Checked [   0.185s] 223 checks: 214 pass, 9 fail, 0 warn, 31 skip

     Summary semver requires new major version: 9 major and 0 minor checks failed
    Finished [  10.016s] trusty-mpm
FAIL trusty-mpm: cargo semver-checks exited 100 against baseline 1.3.4

VERDICT: BREAK. A public API change requires a matching version bump.
```

The 9: `constructible_struct_adds_field`, `enum_tuple_variant_changed_kind` (`PrepError::Instructions`), `enum_variant_added`, `function_missing` (`install_system_prompt`, `install_system_prompt_to`), `function_parameter_count_changed` (`ensure_managed_config_dir` 1→2), `method_parameter_count_changed`, `pub_module_level_const_missing` (`TM_PR_WORKFLOW`, `TM_SLACK_CANVAS_DELIVERY`, `OPS_AGENT`), `struct_marked_non_exhaustive` (`TmuxConfig`, `ResolvedTmuxOptions`), `struct_pub_field_missing` (seven fields incl. `PipelineOutput.merged`).

No bypass flag, allowlist, or crate exemption was added. Shipping 1.3.5 over this verdict is a human decision at release time.

## Tests

Self-test cases 5-8 replay fixtures captured verbatim from real `cargo-semver-checks` 0.50.0 runs through a stub `cargo` that forwards everything except `semver-checks` to the real binary — so crate resolution, the registry probe, feature enumeration, classification, the messages and the exit status are all the gate's own code under test.

```
  ok  scan floor rejects an empty diff (exit 3)
  ok  probe rejects an unreachable index (exit 3)
  ok  probe rejects HTTP 503 (exit 3)
  ok  probe treats HTTP 404 as 'never published' (exit 0, baseline=NONE)
  ok  real break -> exit 1, says 'VERDICT: BREAK'
  ok  rustdoc build error -> exit 3, says 'NO SEMVER VERDICT WAS COMPUTED'
  ok  silent no-op at exit 0 -> exit 3, says 'NO SEMVER VERDICT WAS COMPUTED'
  ok  clean -> exit 0, says 'crate(s) checked'

check_semver_selftest: 8 passed, 0 failed.
```

**Proof it discriminates.** Three mutations, each caught by the right arm:

| Mutation | Result |
|---|---|
| Delete the `verdict_computed` guard (reverts to the original defect) | `rustdoc build error: expected exit 3, got 1` · `silent no-op: expected exit 3, got 0` — **6 passed, 2 FAILED** |
| `EXIT_NO_VERDICT=0` (fail-open) | scan floor, probe/refused, probe/503, build error, silent no-op all fail — **3 passed, 5 FAILED** |
| Classifier always answers "no verdict" | `real break: expected exit 1, got 3` · `clean: expected exit 0, got 3` — **6 passed, 2 FAILED** |

The first reproduces the shipped defect exactly and the self-test catches it. The third shows the `clean` control arm earns its place. The gate was byte-identical to its pre-mutation state afterwards (`diff` clean) and re-ran 8/8.

The self-test also caught a bad fixture during development — my first `build-error.out` cut included the *old gate's own* remediation text, which would have let the "must not claim a version bump is needed" assertion pass on the fixture's contents rather than on what the gate decided.

## Gates

Rung 1 (docs/scripts/CI only; no Rust source changed, so no Cargo gates apply).

| Gate | Result |
|---|---|
| `bash -n` × 3 scripts | 0 |
| `shellcheck check_semver.sh check_semver_selftest.sh` | 0, clean |
| `shellcheck preflight-publish.sh` | 8 style warnings, all pre-existing and identical on `origin/main` (verified) |
| `check_semver_selftest.sh` | 8 passed, 0 failed |
| `check_public_docs.sh` / `check_public_docs_selftest.sh` | 0 / 0 |
| `check_line_cap.sh` | 0 |
| `check_sld.sh` | 0 |
| `check_changelog_fragment.sh` | 0 — "no crate source changed" |
| `check_semver.sh` (diff mode, this branch) | 0 — "no crate source changed" |

No workspace build was run, so `crates/trusty-memory/ui/package-lock.json` is untouched; every path was staged explicitly.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
