### PR TITLE
docs(trusty-review): caption the Security Violations section for linter-only scope (#5243)

### DIFF
--- a/crates/trusty-review/templates/report-technical-dd.md
+++ b/crates/trusty-review/templates/report-technical-dd.md
@@ -175,6 +175,12 @@ report against others normalized through this same template.
 
 ### 6.1 Security Violations
 
+*This table counts findings from general-purpose lint tools (clippy, ruff,
+biome, rubocop, PMD, and similar per language) that happened to be graded
+`error` or `critical`. It is not a SAST scan, not a dependency/CVE scan, and
+not a secrets scan. Treat it as a proxy for code-hygiene risk, not as
+evidence the codebase has been screened for exploitable vulnerabilities.*
+
 <!-- BEGIN security_violations_table -->
 | Application | Domain | Total violations |
 |---|---|---|


### PR DESCRIPTION
## Outcome

Closes [#5243](https://github.com/bobmatnyc/trusty-tools/issues/5243). Adds a disclosure caption to the DD report template's Security Violations section stating the figures come from general-purpose lint tools, not SAST, CVE, or secrets scanning. Part of the DOC-67 tga AUDIT mode delivery (milestone #43).

## What changed / out of scope

One file, `crates/trusty-review/templates/report-technical-dd.md`, +6 lines. No Rust code, no severity mapping, no counting logic.

## Risk

Prose only. GLOBAL scope — the caption renders for every `report-technical-dd.md` consumer, not only AUDIT mode.

## Test evidence — rung 1

`bash scripts/check_sld.sh` → 57 spec docs + 3177 code files, 0 errors, 0 warnings.

## Baseline failures

None.

## Docs/changelog

No changelog fragment — the diff touches no crate `src/**`, confirmed via `git diff --name-only`.

## For reviewer confirmation

DOC-67 §8's draft caption contained a `§3` cross-reference which was deliberately dropped: that pointer resolves inside the spec but not inside a rendered report, where there is no §3.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
