### PR TITLE
feat(tga,trusty-review): render the audit DD report and name every gap (#5236, #5238, #5239, #5244)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10316,6 +10316,7 @@ dependencies = [
  "tera",
  "thiserror 1.0.69",
  "tokio",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
  "tracing-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11762,7 +11762,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "1.0.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.12" }
+trusty-review = { path = "crates/trusty-review", version = "0.13" }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -52,6 +52,9 @@ clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+# #5236: the DD manifest handed to trusty-review is a TOML file (DOC-67 §6);
+# the file IS the seam, so tga serializes it rather than taking a Cargo edge.
+toml = { workspace = true }
 # Database
 # Bumped from 0.31 to align with trusty-memory-core / trusty-cto-db
 # (rusqlite 0.39, libsqlite3-sys 0.37). Cargo's `links = "sqlite3"`

--- a/crates/trusty-git-analytics/changelog.d/5236-audit-dd-report.md
+++ b/crates/trusty-git-analytics/changelog.d/5236-audit-dd-report.md
@@ -1,0 +1,7 @@
+Added
+
+- `tga audit` now produces the report, not just the data. After the sweep it writes a `manifest.toml` into the output directory and invokes `trusty-review report --manifest <path> --analyze --out <dir>`, then prints the rendered artifact paths (#5236, #5238, DOC-67 §6).
+- `tga::report::dd_manifest::build_dd_manifest` — the DD-manifest adapter, a pure function mapping the resolved config onto trusty-review's manifest schema per DOC-67 §6's field table. Writing the file is the caller's job, so the mapping, its determinism (the same config yields byte-identical TOML), and its credential handling are all unit-testable. Every string it emits is scrubbed of the credentials the config holds, so a token that reached a repository name, a report title, or a stage's error message cannot reach the artifact.
+- A collection stage that did not complete is now named in the report's Gaps & Caveats section instead of only on stderr, so a missing dimension reads as unassessed rather than clean (#5239, DOC-67 §9).
+- The report carries a placeholder data-handling statement recording that a formal data-retention attestation is pending (#5244, #5218, DOC-67 §10).
+- A missing `trusty-review` binary is reported as a named, actionable error naming `TRUSTY_REVIEW_BIN`, the install command, and the manifest that was already written — never a panic or a silent skip. `TRUSTY_REVIEW_BIN` overrides the PATH lookup.

--- a/crates/trusty-git-analytics/changelog.d/5239-scrub-before-truncate.md
+++ b/crates/trusty-git-analytics/changelog.d/5239-scrub-before-truncate.md
@@ -1,0 +1,3 @@
+Security
+
+- `tga audit` now redacts a failed stage's error text before excerpting it, so a credential that spans the 160-character excerpt boundary can no longer survive as a prefix fragment in the generated `manifest.toml` or the due-diligence report handed to a third party. `sweep_gap_lines` takes the credential set as a required argument, and `report::dd_manifest::configured_secrets` is public so the sweep and the manifest builder redact against the same values.

--- a/crates/trusty-git-analytics/changelog.d/5308-audit-test-soundness.md
+++ b/crates/trusty-git-analytics/changelog.d/5308-audit-test-soundness.md
@@ -1,0 +1,3 @@
+Changed
+
+- The `trusty-review` binary AUDIT invokes is resolved by a pure function over the `TRUSTY_REVIEW_BIN` value, and `run_review_report` reads the environment exactly once at its entry point. Behaviour is unchanged — an override wins unless it is empty, otherwise `trusty-review` is looked up on PATH — but the resolution rule and the spawn path are now testable without mutating the process environment, which `std::env::set_var` cannot do soundly under a parallel test harness.

--- a/crates/trusty-git-analytics/src/audit/gaps.rs
+++ b/crates/trusty-git-analytics/src/audit/gaps.rs
@@ -39,7 +39,7 @@ use super::stage::{AuditSweepStats, StageStatus};
 /// transport detail that means nothing to the report's reader, and the Gaps
 /// section is read under time pressure. The full message is already on stderr
 /// and in the sweep's own record; this is the reader's excerpt.
-const MAX_REASON_CHARS: usize = 160;
+pub(crate) const MAX_REASON_CHARS: usize = 160;
 
 /// The placeholder data-retention statement AUDIT carries until #5218 ships.
 ///

--- a/crates/trusty-git-analytics/src/audit/gaps.rs
+++ b/crates/trusty-git-analytics/src/audit/gaps.rs
@@ -9,6 +9,27 @@
 //! What: [`sweep_gap_lines`] (one line per failed stage) and
 //! [`DATA_HANDLING_NOTE`] (§10's placeholder attestation, #5244).
 //! Test: `super::tests`.
+//!
+//! ## Redaction happens here, before the excerpt is cut
+//!
+//! A stage failure carries an `anyhow` cause chain the process did not author,
+//! so it can quote a credential back at us. This module both scrubs and
+//! truncates that text, in that order and in one function, because doing them
+//! in the other order leaks: [`trusty_common::credentials::scrub_secrets`]
+//! matches a credential's *whole* value, so a token that starts before the
+//! excerpt boundary and ends after it survives the cut as an unmatchable prefix
+//! fragment, and every later scrub — including
+//! [`crate::report::dd_manifest::build_dd_manifest`]'s — sees only that
+//! fragment and passes it through into `manifest.toml` and the delivered report.
+//!
+//! The invariant is therefore structural rather than a convention: the needle
+//! set is a required argument of [`sweep_gap_lines`], so there is no way to
+//! obtain a truncated stage message without having supplied the credentials to
+//! remove from it first. `build_dd_manifest` still scrubs everything it emits —
+//! that stays the manifest-wide guarantee, and re-scrubbing an already-clean
+//! string is a no-op.
+
+use trusty_common::credentials::scrub_secrets;
 
 use super::stage::{AuditSweepStats, StageStatus};
 
@@ -46,20 +67,24 @@ verbatim and carry whatever their authors wrote into them.";
 /// from an empty table. The sweep deliberately does not abort on a stage
 /// failure (§2, one shot), which is exactly why the failure has to reappear
 /// here.
-/// What: for each failure in execution order, a line naming the stage, an
-/// excerpt of the reason, and the fact that the affected area is unassessed.
-/// Returns an empty vec when every stage succeeded — a clean run adds no line.
-/// The reason is passed through verbatim (truncated); scrubbing credentials out
-/// of it is [`crate::report::dd_manifest::build_dd_manifest`]'s job, applied to
-/// every string that reaches the manifest rather than to this one channel.
+/// What: for each failure in execution order, a line naming the stage, a
+/// redacted excerpt of the reason, and the fact that the affected area is
+/// unassessed. Returns an empty vec when every stage succeeded — a clean run
+/// adds no line.
+///
+/// `secrets` are the credential values to remove from each stage message —
+/// [`crate::report::dd_manifest::configured_secrets`] derives the set the same
+/// audit run's manifest uses. It is a required argument, not a convenience: see
+/// the module docs for why truncating before scrubbing leaks a prefix fragment.
 /// Test: `super::tests::{sweep_gap_lines_name_each_failed_stage,
-/// sweep_gap_lines_are_empty_for_a_clean_run}`.
-pub fn sweep_gap_lines(stats: &AuditSweepStats) -> Vec<String> {
+/// sweep_gap_lines_are_empty_for_a_clean_run}`, and
+/// `crate::report::dd_manifest_tests::a_token_straddling_the_excerpt_boundary_leaves_no_fragment`.
+pub fn sweep_gap_lines<S: AsRef<str>>(stats: &AuditSweepStats, secrets: &[S]) -> Vec<String> {
     stats
         .failures()
         .map(|outcome| {
             let reason = match &outcome.status {
-                StageStatus::Failed(msg) => excerpt(msg),
+                StageStatus::Failed(msg) => redacted_excerpt(msg, secrets),
                 _ => String::new(),
             };
             format!(
@@ -72,14 +97,27 @@ pub fn sweep_gap_lines(stats: &AuditSweepStats) -> Vec<String> {
         .collect()
 }
 
-/// A single-line excerpt of `msg`, capped at [`MAX_REASON_CHARS`] characters.
+/// A single-line, credential-free excerpt of `msg`, capped at
+/// [`MAX_REASON_CHARS`] characters.
 ///
-/// Why/What: newlines would break the Gaps bullet, and the cap keeps one
-/// verbose transport error from dominating the section. Truncation is by
-/// character, so the same message always yields the same excerpt.
+/// Why: newlines would break the Gaps bullet, and the cap keeps one verbose
+/// transport error from dominating the section. Redaction and truncation are
+/// one operation rather than two so their order cannot be got wrong at a call
+/// site — see the module docs.
+/// What: scrubs `secrets` out of the raw message first, then flattens
+/// whitespace, then truncates. Scrubbing precedes flattening because a needle
+/// is matched against the text as the failing stage produced it; flattening only
+/// collapses whitespace runs, so it can never rejoin a split credential. The cap
+/// applies to the redacted text, so `[REDACTED]` being longer than what it
+/// replaces cannot push the excerpt over budget. Truncation is by character, so
+/// the same message always yields the same excerpt.
 /// Test: `super::tests::long_stage_reasons_are_truncated`.
-fn excerpt(msg: &str) -> String {
-    let flat = msg.split_whitespace().collect::<Vec<_>>().join(" ");
+fn redacted_excerpt<S: AsRef<str>>(msg: &str, secrets: &[S]) -> String {
+    // #5239: scrub the full message, THEN cut. Cutting first would leave a
+    // credential that spans the boundary behind as a prefix no later scrub can
+    // match.
+    let clean = scrub_secrets(msg, secrets);
+    let flat = clean.split_whitespace().collect::<Vec<_>>().join(" ");
     if flat.chars().count() <= MAX_REASON_CHARS {
         return flat;
     }

--- a/crates/trusty-git-analytics/src/audit/gaps.rs
+++ b/crates/trusty-git-analytics/src/audit/gaps.rs
@@ -1,0 +1,88 @@
+//! What the audit could not assess, in the words the report uses (#5239, #5244).
+//!
+//! Why: DOC-67 §9 turns on one distinction — a dimension missing because a
+//! stage failed must not look, on the page, like a dimension that came back
+//! clean. The sweep already records every stage's fate ([`AuditSweepStats`]);
+//! this module is where those records become sentences an acquirer's reviewer
+//! reads, so the wording lives in one place instead of being formatted at the
+//! call site.
+//! What: [`sweep_gap_lines`] (one line per failed stage) and
+//! [`DATA_HANDLING_NOTE`] (§10's placeholder attestation, #5244).
+//! Test: `super::tests`.
+
+use super::stage::{AuditSweepStats, StageStatus};
+
+/// Longest stage-failure message carried into the report, in characters.
+///
+/// Why: an `anyhow` cause chain can run to several hundred characters of
+/// transport detail that means nothing to the report's reader, and the Gaps
+/// section is read under time pressure. The full message is already on stderr
+/// and in the sweep's own record; this is the reader's excerpt.
+const MAX_REASON_CHARS: usize = 160;
+
+/// The placeholder data-retention statement AUDIT carries until #5218 ships.
+///
+/// Why: DOC-67 §10 — an acquirer's counterparty asks what the tool retained
+/// before granting access, and #5218 is the authoritative mechanism for that
+/// answer. Until it ships, the report must say an attestation is *pending*
+/// rather than assert one, and must not paraphrase a claim it cannot yet
+/// enforce.
+/// What: states that the formal attestation is pending, and states §10's
+/// verified scope claim exactly as §10 words it — "no file content, diffs,
+/// patches, hunks, or blobs", never the broader "no code", because free-text
+/// columns can carry whatever an author pasted into them.
+/// Test: `super::tests::data_handling_note_is_a_pending_claim`.
+pub const DATA_HANDLING_NOTE: &str = "Data handling: a formal data-retention attestation for \
+this run is pending (#5218) and is not asserted here. tga's database records commit, \
+pull-request, and ticket metadata; it stores no file content, diffs, patches, hunks, or blobs. \
+Free-text fields it does store — commit messages, pull-request and ticket titles — are retained \
+verbatim and carry whatever their authors wrote into them.";
+
+/// One Gaps & Caveats line per stage that did not complete.
+///
+/// Why: a stage that failed took a whole class of data with it — no `dora` run
+/// means no delivery-health figures, no `jira sync` means no ticket
+/// correlation — and DOC-67 §9 requires that absence be stated, not inferred
+/// from an empty table. The sweep deliberately does not abort on a stage
+/// failure (§2, one shot), which is exactly why the failure has to reappear
+/// here.
+/// What: for each failure in execution order, a line naming the stage, an
+/// excerpt of the reason, and the fact that the affected area is unassessed.
+/// Returns an empty vec when every stage succeeded — a clean run adds no line.
+/// The reason is passed through verbatim (truncated); scrubbing credentials out
+/// of it is [`crate::report::dd_manifest::build_dd_manifest`]'s job, applied to
+/// every string that reaches the manifest rather than to this one channel.
+/// Test: `super::tests::{sweep_gap_lines_name_each_failed_stage,
+/// sweep_gap_lines_are_empty_for_a_clean_run}`.
+pub fn sweep_gap_lines(stats: &AuditSweepStats) -> Vec<String> {
+    stats
+        .failures()
+        .map(|outcome| {
+            let reason = match &outcome.status {
+                StageStatus::Failed(msg) => excerpt(msg),
+                _ => String::new(),
+            };
+            format!(
+                "Collection stage `{}` did not complete ({reason}) — the data it produces is \
+                 not assessed in this report. Read the affected sections as unassessed, not as \
+                 a clean result.",
+                outcome.stage
+            )
+        })
+        .collect()
+}
+
+/// A single-line excerpt of `msg`, capped at [`MAX_REASON_CHARS`] characters.
+///
+/// Why/What: newlines would break the Gaps bullet, and the cap keeps one
+/// verbose transport error from dominating the section. Truncation is by
+/// character, so the same message always yields the same excerpt.
+/// Test: `super::tests::long_stage_reasons_are_truncated`.
+fn excerpt(msg: &str) -> String {
+    let flat = msg.split_whitespace().collect::<Vec<_>>().join(" ");
+    if flat.chars().count() <= MAX_REASON_CHARS {
+        return flat;
+    }
+    let head: String = flat.chars().take(MAX_REASON_CHARS).collect();
+    format!("{head}…")
+}

--- a/crates/trusty-git-analytics/src/audit/mod.rs
+++ b/crates/trusty-git-analytics/src/audit/mod.rs
@@ -21,11 +21,18 @@
 //! running it third would render a mostly empty report. The executed order is
 //! therefore data-flow order — see [`SweepStage`].
 
+mod gaps;
+mod review;
 mod stage;
 mod sweep;
 
 #[cfg(test)]
 mod tests;
 
+pub use gaps::{sweep_gap_lines, DATA_HANDLING_NOTE};
+pub use review::{
+    artifact_paths, resolve_review_binary, run_review_report, ReviewRun, ReviewRunError,
+    DEFAULT_REVIEW_BIN, ENV_REVIEW_BIN,
+};
 pub use stage::{AuditSweepStats, StageOutcome, StageStatus, SweepStage};
 pub use sweep::{run_full_sweep, SweepOptions};

--- a/crates/trusty-git-analytics/src/audit/mod.rs
+++ b/crates/trusty-git-analytics/src/audit/mod.rs
@@ -29,6 +29,11 @@ mod sweep;
 #[cfg(test)]
 mod tests;
 
+/// The excerpt cap, visible to `report::dd_manifest_tests` so its
+/// boundary-straddle tests position a credential against the real value instead
+/// of a copy that can drift away from it (#5308 review).
+#[cfg(test)]
+pub(crate) use gaps::MAX_REASON_CHARS;
 pub use gaps::{sweep_gap_lines, DATA_HANDLING_NOTE};
 pub use review::{
     artifact_paths, resolve_review_binary, run_review_report, ReviewRun, ReviewRunError,

--- a/crates/trusty-git-analytics/src/audit/review.rs
+++ b/crates/trusty-git-analytics/src/audit/review.rs
@@ -1,0 +1,207 @@
+//! Invoking `trusty-review report` as a subprocess (#5238, DOC-67 §6 step 3).
+//!
+//! Why: tga and trusty-review meet at a file, not at a Cargo edge (DOC-67 §5) —
+//! which leaves someone to actually run the renderer. trusty-review already
+//! treats a sibling trusty-* binary as an invocable subprocess
+//! (`SubprocessAnalyzeClient`, closing #632); AUDIT follows that same house
+//! pattern in the other direction rather than inventing a second idiom or
+//! taking a dependency edge that would risk an import cycle.
+//! What: [`resolve_review_binary`], [`run_review_report`], and the
+//! [`ReviewRun`] record of one invocation. The binary is `TRUSTY_REVIEW_BIN`
+//! when set, else `trusty-review` on PATH — the same override-then-PATH
+//! resolution `SubprocessAnalyzeClient` uses for `trusty-analyze`.
+//! Test: `super::tests`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Environment variable that overrides the `trusty-review` binary path.
+///
+/// Why: lets an operator or a test pin the exact binary without touching PATH,
+/// matching `TRUSTY_ANALYZE_BIN`'s role on the trusty-review side.
+pub const ENV_REVIEW_BIN: &str = "TRUSTY_REVIEW_BIN";
+
+/// Default binary name searched on PATH.
+pub const DEFAULT_REVIEW_BIN: &str = "trusty-review";
+
+/// Failures invoking the renderer.
+///
+/// Why: a library module, so a typed error. The distinction that matters to an
+/// operator is "you have not installed the renderer" versus "the renderer ran
+/// and failed" — the first is a one-line fix, the second needs the child's own
+/// output, which the caller has already printed.
+/// What: binary-not-found (carrying the remediation), any other spawn failure,
+/// and a join failure from the blocking pool.
+/// Test: `super::tests::missing_binary_is_a_named_actionable_error`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ReviewRunError {
+    /// The binary is not installed, or not where the override points.
+    #[error(
+        "`{binary}` was not found on PATH. Install it (`cargo install trusty-review`) or set \
+         TRUSTY_REVIEW_BIN to its full path. The manifest is already written to {manifest}, so \
+         nothing is lost — render it with `{binary} report --manifest {manifest} --analyze --out \
+         <dir>` once the binary is available."
+    )]
+    BinaryNotFound {
+        /// The binary name or path that was tried.
+        binary: String,
+        /// The manifest that was written and can still be rendered by hand.
+        manifest: PathBuf,
+    },
+
+    /// The process could not be started for some other reason.
+    #[error("failed to run `{binary}`: {source}")]
+    Spawn {
+        /// The binary name or path that was tried.
+        binary: String,
+        /// The underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The blocking task carrying the child process did not join.
+    #[error("the `{binary}` subprocess task did not complete: {message}")]
+    Join {
+        /// The binary name or path that was tried.
+        binary: String,
+        /// The join error, rendered.
+        message: String,
+    },
+}
+
+/// The result of one `trusty-review report` invocation.
+///
+/// Why: DOC-67 §6 step 4 requires the child's exit code and both streams to
+/// reach the operator, and step 5 requires the artifact paths — so the whole
+/// invocation is one value the caller reports on, rather than side effects the
+/// caller has to reconstruct.
+/// What: the artifact paths trusty-review printed to stdout, both captured
+/// streams, and the exit status. A non-zero exit is recorded here, not raised —
+/// the caller decides what a failed render means for the run.
+/// Test: `super::tests::artifact_paths_are_parsed_from_stdout`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ReviewRun {
+    /// Whether the child exited successfully.
+    pub success: bool,
+    /// The child's exit code, or `None` if it was killed by a signal.
+    pub code: Option<i32>,
+    /// Captured stdout — trusty-review prints one written path per line.
+    pub stdout: String,
+    /// Captured stderr — trusty-review's progress and warning lines.
+    pub stderr: String,
+    /// The artifact paths parsed from stdout, in the order printed.
+    pub artifacts: Vec<PathBuf>,
+}
+
+/// The `trusty-review` binary this process will invoke.
+///
+/// Why/What: `TRUSTY_REVIEW_BIN` when set to a non-empty value, else
+/// [`DEFAULT_REVIEW_BIN`] resolved on PATH by the OS.
+/// Test: `super::tests::binary_resolution_prefers_the_env_override`.
+pub fn resolve_review_binary() -> String {
+    std::env::var(ENV_REVIEW_BIN)
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_REVIEW_BIN.to_string())
+}
+
+/// Render `manifest` into `out_dir` by invoking `trusty-review report`.
+///
+/// Why: the last step of DOC-67 §6's orchestration, and the only one that
+/// produces the deliverable. It runs on the blocking pool because the child can
+/// take minutes on a large repository set and must not occupy an async worker.
+/// What: spawns `<binary> report --manifest <manifest> --analyze --out
+/// <out_dir>`, captures both streams and the exit status, and parses the
+/// artifact paths from stdout. A non-zero exit returns `Ok` with
+/// [`ReviewRun::success`] false — only a failure to *start* the child is an
+/// `Err`, because that is the one case where the caller has nothing to report.
+///
+/// The `--analyze` flag is always passed: an AUDIT report without the live
+/// analysis pass has no findings, no complexity distribution, and no health
+/// factors (DOC-67 §8), and its absence is reported as a gap by trusty-review
+/// rather than being silently accepted here.
+/// Test: `super::tests::{missing_binary_is_a_named_actionable_error,
+/// artifact_paths_are_parsed_from_stdout}`.
+///
+/// # Errors
+///
+/// [`ReviewRunError::BinaryNotFound`] when the binary is not installed,
+/// [`ReviewRunError::Spawn`] for any other start failure, and
+/// [`ReviewRunError::Join`] if the blocking task is cancelled.
+pub async fn run_review_report(
+    manifest: &Path,
+    out_dir: &Path,
+) -> Result<ReviewRun, ReviewRunError> {
+    let binary = resolve_review_binary();
+    let (bin, manifest_owned, out_owned) = (
+        binary.clone(),
+        manifest.to_path_buf(),
+        out_dir.to_path_buf(),
+    );
+
+    tokio::task::spawn_blocking(move || invoke(&bin, &manifest_owned, &out_owned))
+        .await
+        .map_err(|e| ReviewRunError::Join {
+            binary,
+            message: e.to_string(),
+        })?
+}
+
+/// The synchronous half of [`run_review_report`].
+///
+/// Why: isolated so it carries no async context into the blocking pool, the
+/// same split `SubprocessAnalyzeClient` uses.
+/// What: builds the command, runs it to completion, maps `NotFound` onto the
+/// actionable error, and parses stdout.
+/// Test: exercised through [`run_review_report`].
+fn invoke(binary: &str, manifest: &Path, out_dir: &Path) -> Result<ReviewRun, ReviewRunError> {
+    let output = Command::new(binary)
+        .arg("report")
+        .arg("--manifest")
+        .arg(manifest)
+        .arg("--analyze")
+        .arg("--out")
+        .arg(out_dir)
+        .output()
+        .map_err(|source| {
+            if source.kind() == std::io::ErrorKind::NotFound {
+                ReviewRunError::BinaryNotFound {
+                    binary: binary.to_string(),
+                    manifest: manifest.to_path_buf(),
+                }
+            } else {
+                ReviewRunError::Spawn {
+                    binary: binary.to_string(),
+                    source,
+                }
+            }
+        })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    Ok(ReviewRun {
+        success: output.status.success(),
+        code: output.status.code(),
+        artifacts: artifact_paths(&stdout),
+        stdout,
+        stderr,
+    })
+}
+
+/// Parse the written-artifact paths from trusty-review's stdout.
+///
+/// Why: trusty-review prints its progress to stderr and the written paths to
+/// stdout precisely so a caller can consume them; DOC-67 §6 step 5 is that
+/// caller.
+/// What: every non-blank stdout line, trimmed, in order.
+/// Test: `super::tests::artifact_paths_are_parsed_from_stdout`.
+pub fn artifact_paths(stdout: &str) -> Vec<PathBuf> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(PathBuf::from)
+        .collect()
+}

--- a/crates/trusty-git-analytics/src/audit/review.rs
+++ b/crates/trusty-git-analytics/src/audit/review.rs
@@ -98,13 +98,28 @@ pub struct ReviewRun {
 /// The `trusty-review` binary this process will invoke.
 ///
 /// Why/What: `TRUSTY_REVIEW_BIN` when set to a non-empty value, else
-/// [`DEFAULT_REVIEW_BIN`] resolved on PATH by the OS.
+/// [`DEFAULT_REVIEW_BIN`] resolved on PATH by the OS. Reading the variable is
+/// all this function does; the rule itself lives in [`binary_from_override`] so
+/// it can be tested without mutating the process environment.
 /// Test: `super::tests::binary_resolution_prefers_the_env_override`.
 pub fn resolve_review_binary() -> String {
-    std::env::var(ENV_REVIEW_BIN)
-        .ok()
+    binary_from_override(std::env::var(ENV_REVIEW_BIN).ok().as_deref())
+}
+
+/// The resolution rule itself: an override wins unless it is empty.
+///
+/// Why: taking the override as a parameter keeps the rule a pure function, so
+/// the tests never call `std::env::set_var`. That call is `unsafe` in edition
+/// 2024 because another thread reading the environment concurrently is UB, and
+/// `cargo test` runs tests in parallel — a test-only guarantee of
+/// single-threadedness does not exist (#5308 review).
+/// What: `None` and `Some("")` both fall back to [`DEFAULT_REVIEW_BIN`].
+/// Test: `super::tests::binary_resolution_prefers_the_env_override`.
+pub(super) fn binary_from_override(override_value: Option<&str>) -> String {
+    override_value
         .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| DEFAULT_REVIEW_BIN.to_string())
+        .unwrap_or(DEFAULT_REVIEW_BIN)
+        .to_string()
 }
 
 /// Render `manifest` into `out_dir` by invoking `trusty-review report`.
@@ -134,7 +149,21 @@ pub async fn run_review_report(
     manifest: &Path,
     out_dir: &Path,
 ) -> Result<ReviewRun, ReviewRunError> {
-    let binary = resolve_review_binary();
+    run_review_report_with(resolve_review_binary(), manifest, out_dir).await
+}
+
+/// [`run_review_report`] with the binary already resolved.
+///
+/// Why: the environment is read exactly once, at the public entry point, so a
+/// test can drive the whole spawn-and-map path at a binary that certainly does
+/// not exist without touching the process environment (#5308 review).
+/// What: everything `run_review_report` does apart from resolution.
+/// Test: `super::tests::missing_binary_is_a_named_actionable_error`.
+pub(super) async fn run_review_report_with(
+    binary: String,
+    manifest: &Path,
+    out_dir: &Path,
+) -> Result<ReviewRun, ReviewRunError> {
     let (bin, manifest_owned, out_owned) = (
         binary.clone(),
         manifest.to_path_buf(),

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -298,6 +298,12 @@ fn audit_args_expose_a_complete_clap_command() {
 // Gaps & Caveats lines from the sweep's own record (#5239, #5244)
 // ---------------------------------------------------------------------------
 
+/// A config holding no credentials. The redaction path itself is proved end to
+/// end against a real token in
+/// `crate::report::dd_manifest_tests::a_token_straddling_the_excerpt_boundary_leaves_no_fragment`;
+/// these tests are about the wording and ordering of the lines.
+const NO_SECRETS: &[&str] = &[];
+
 #[test]
 fn sweep_gap_lines_name_each_failed_stage() {
     let mut stats = AuditSweepStats::default();
@@ -313,7 +319,7 @@ fn sweep_gap_lines_name_each_failed_stage() {
         Err(anyhow::anyhow!("fact_deployments is empty")),
     );
 
-    let lines = crate::audit::sweep_gap_lines(&stats);
+    let lines = crate::audit::sweep_gap_lines(&stats, NO_SECRETS);
 
     assert_eq!(lines.len(), 2, "one line per failure, none for success");
     assert!(lines[0].contains("`jira sync`"), "{}", lines[0]);
@@ -328,7 +334,7 @@ fn sweep_gap_lines_name_each_failed_stage() {
         assert!(line.contains("not assessed"), "{line}");
     }
     // Execution order, so two runs over the same failures read identically.
-    assert_eq!(lines, crate::audit::sweep_gap_lines(&stats));
+    assert_eq!(lines, crate::audit::sweep_gap_lines(&stats, NO_SECRETS));
 }
 
 #[test]
@@ -337,7 +343,7 @@ fn sweep_gap_lines_are_empty_for_a_clean_run() {
     for stage in EXPECTED_ORDER {
         stats.record(stage, Instant::now(), Ok(()));
     }
-    assert!(crate::audit::sweep_gap_lines(&stats).is_empty());
+    assert!(crate::audit::sweep_gap_lines(&stats, NO_SECRETS).is_empty());
 }
 
 #[test]
@@ -349,7 +355,7 @@ fn long_stage_reasons_are_truncated() {
         Err(anyhow::anyhow!("x".repeat(4000))),
     );
 
-    let line = crate::audit::sweep_gap_lines(&stats).remove(0);
+    let line = crate::audit::sweep_gap_lines(&stats, NO_SECRETS).remove(0);
 
     assert!(line.contains('…'), "a long reason is excerpted: {line}");
     assert!(

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -406,19 +406,14 @@ async fn missing_binary_is_a_named_actionable_error() {
     let manifest = dir.path().join("manifest.toml");
     std::fs::write(&manifest, "[report]\ntitle = \"T\"\n").expect("write");
 
-    // SAFETY: single-threaded test process mutating its own env before use.
-    unsafe {
-        std::env::set_var(
-            crate::audit::ENV_REVIEW_BIN,
-            dir.path().join("definitely-not-installed"),
-        );
-    }
-    let err = crate::audit::run_review_report(&manifest, dir.path())
-        .await
-        .expect_err("a missing binary must be an error");
-    unsafe {
-        std::env::remove_var(crate::audit::ENV_REVIEW_BIN);
-    }
+    // The binary is passed in, never installed through the environment: this is
+    // the same path `run_review_report` takes once resolution has happened, and
+    // it stays sound under the parallel harness (#5308 review).
+    let missing = dir.path().join("definitely-not-installed");
+    let err =
+        super::review::run_review_report_with(missing.display().to_string(), &manifest, dir.path())
+            .await
+            .expect_err("a missing binary must be an error");
 
     let msg = err.to_string();
     assert!(
@@ -436,29 +431,26 @@ async fn missing_binary_is_a_named_actionable_error() {
     );
 }
 
+/// The rule is exercised as a pure function over the override value, which is
+/// what `resolve_review_binary` reads `TRUSTY_REVIEW_BIN` into. Mutating the
+/// process environment to test it would be unsound under the parallel test
+/// harness, and no `unsafe` block can make it sound (#5308 review).
 #[test]
 fn binary_resolution_prefers_the_env_override() {
-    // SAFETY: single-threaded test process mutating its own env before use.
-    unsafe {
-        std::env::set_var(crate::audit::ENV_REVIEW_BIN, "/opt/bin/trusty-review");
-    }
+    use super::review::binary_from_override;
+
     assert_eq!(
-        crate::audit::resolve_review_binary(),
+        binary_from_override(Some("/opt/bin/trusty-review")),
         "/opt/bin/trusty-review"
     );
-    unsafe {
-        std::env::set_var(crate::audit::ENV_REVIEW_BIN, "");
-    }
     assert_eq!(
-        crate::audit::resolve_review_binary(),
+        binary_from_override(Some("")),
         crate::audit::DEFAULT_REVIEW_BIN,
         "an empty override falls back to the PATH lookup"
     );
-    unsafe {
-        std::env::remove_var(crate::audit::ENV_REVIEW_BIN);
-    }
-    assert_eq!(
-        crate::audit::resolve_review_binary(),
-        crate::audit::DEFAULT_REVIEW_BIN
-    );
+    assert_eq!(binary_from_override(None), crate::audit::DEFAULT_REVIEW_BIN);
+    // The public entry point returns one of the two, whatever this machine's
+    // environment happens to hold — read only, never written.
+    let resolved = crate::audit::resolve_review_binary();
+    assert!(!resolved.is_empty(), "{resolved}");
 }

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -293,3 +293,166 @@ fn audit_args_expose_a_complete_clap_command() {
     let args = AuditArgs::from_arg_matches(&matches).expect("from_arg_matches");
     assert_eq!(args.analyst.as_deref(), Some("me"));
 }
+
+// ---------------------------------------------------------------------------
+// Gaps & Caveats lines from the sweep's own record (#5239, #5244)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sweep_gap_lines_name_each_failed_stage() {
+    let mut stats = AuditSweepStats::default();
+    stats.record(SweepStage::Collect, Instant::now(), Ok(()));
+    stats.record(
+        SweepStage::JiraSync,
+        Instant::now(),
+        Err(anyhow::anyhow!("no JIRA project configured")),
+    );
+    stats.record(
+        SweepStage::Dora,
+        Instant::now(),
+        Err(anyhow::anyhow!("fact_deployments is empty")),
+    );
+
+    let lines = crate::audit::sweep_gap_lines(&stats);
+
+    assert_eq!(lines.len(), 2, "one line per failure, none for success");
+    assert!(lines[0].contains("`jira sync`"), "{}", lines[0]);
+    assert!(
+        lines[0].contains("no JIRA project configured"),
+        "{}",
+        lines[0]
+    );
+    assert!(lines[1].contains("`dora`"), "{}", lines[1]);
+    // DOC-67 §9: the line must refuse to read as a clean result.
+    for line in &lines {
+        assert!(line.contains("not assessed"), "{line}");
+    }
+    // Execution order, so two runs over the same failures read identically.
+    assert_eq!(lines, crate::audit::sweep_gap_lines(&stats));
+}
+
+#[test]
+fn sweep_gap_lines_are_empty_for_a_clean_run() {
+    let mut stats = AuditSweepStats::default();
+    for stage in EXPECTED_ORDER {
+        stats.record(stage, Instant::now(), Ok(()));
+    }
+    assert!(crate::audit::sweep_gap_lines(&stats).is_empty());
+}
+
+#[test]
+fn long_stage_reasons_are_truncated() {
+    let mut stats = AuditSweepStats::default();
+    stats.record(
+        SweepStage::Collect,
+        Instant::now(),
+        Err(anyhow::anyhow!("x".repeat(4000))),
+    );
+
+    let line = crate::audit::sweep_gap_lines(&stats).remove(0);
+
+    assert!(line.contains('…'), "a long reason is excerpted: {line}");
+    assert!(
+        line.chars().count() < 400,
+        "one verbose error must not dominate the Gaps section ({} chars)",
+        line.chars().count()
+    );
+}
+
+#[test]
+fn data_handling_note_is_a_pending_claim() {
+    let note = crate::audit::DATA_HANDLING_NOTE;
+    // DOC-67 §10: pending, never asserted — and #5218 is where the real one comes from.
+    assert!(note.contains("pending"), "{note}");
+    assert!(note.contains("#5218"), "{note}");
+    // §10's exact scope claim; the broader "no code" claim is wrong and must
+    // not appear, because free-text columns can carry pasted snippets.
+    assert!(note.contains("no file content, diffs, patches, hunks, or blobs"));
+    assert!(!note.contains("no code"), "{note}");
+}
+
+// ---------------------------------------------------------------------------
+// Invoking trusty-review as a subprocess (#5238)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn artifact_paths_are_parsed_from_stdout() {
+    // trusty-review prints one written path per line on stdout; blank lines and
+    // trailing whitespace must not become phantom artifacts.
+    let stdout = "  /out/acme.md\n\n/out/acme.json\n";
+    let paths = crate::audit::artifact_paths(stdout);
+    assert_eq!(
+        paths,
+        vec![
+            std::path::PathBuf::from("/out/acme.md"),
+            std::path::PathBuf::from("/out/acme.json")
+        ]
+    );
+    assert!(crate::audit::artifact_paths("").is_empty());
+}
+
+#[tokio::test]
+async fn missing_binary_is_a_named_actionable_error() {
+    // A renderer that is not installed must produce a message an operator can
+    // act on — never a panic, and never a silent skip that leaves the run
+    // looking successful with no report.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let manifest = dir.path().join("manifest.toml");
+    std::fs::write(&manifest, "[report]\ntitle = \"T\"\n").expect("write");
+
+    // SAFETY: single-threaded test process mutating its own env before use.
+    unsafe {
+        std::env::set_var(
+            crate::audit::ENV_REVIEW_BIN,
+            dir.path().join("definitely-not-installed"),
+        );
+    }
+    let err = crate::audit::run_review_report(&manifest, dir.path())
+        .await
+        .expect_err("a missing binary must be an error");
+    unsafe {
+        std::env::remove_var(crate::audit::ENV_REVIEW_BIN);
+    }
+
+    let msg = err.to_string();
+    assert!(
+        matches!(err, crate::audit::ReviewRunError::BinaryNotFound { .. }),
+        "{msg}"
+    );
+    assert!(
+        msg.contains("TRUSTY_REVIEW_BIN"),
+        "names the override: {msg}"
+    );
+    assert!(msg.contains("cargo install"), "names the fix: {msg}");
+    assert!(
+        msg.contains(&manifest.display().to_string()),
+        "the written manifest is still usable and must be named: {msg}"
+    );
+}
+
+#[test]
+fn binary_resolution_prefers_the_env_override() {
+    // SAFETY: single-threaded test process mutating its own env before use.
+    unsafe {
+        std::env::set_var(crate::audit::ENV_REVIEW_BIN, "/opt/bin/trusty-review");
+    }
+    assert_eq!(
+        crate::audit::resolve_review_binary(),
+        "/opt/bin/trusty-review"
+    );
+    unsafe {
+        std::env::set_var(crate::audit::ENV_REVIEW_BIN, "");
+    }
+    assert_eq!(
+        crate::audit::resolve_review_binary(),
+        crate::audit::DEFAULT_REVIEW_BIN,
+        "an empty override falls back to the PATH lookup"
+    );
+    unsafe {
+        std::env::remove_var(crate::audit::ENV_REVIEW_BIN);
+    }
+    assert_eq!(
+        crate::audit::resolve_review_binary(),
+        crate::audit::DEFAULT_REVIEW_BIN
+    );
+}

--- a/crates/trusty-git-analytics/src/commands/audit.rs
+++ b/crates/trusty-git-analytics/src/commands/audit.rs
@@ -22,7 +22,7 @@ use tga::audit::{
 };
 use tga::core::config::Config;
 use tga::core::db::Database;
-use tga::report::dd_manifest::{build_dd_manifest, DdManifestOptions};
+use tga::report::dd_manifest::{build_dd_manifest, configured_secrets, DdManifestOptions};
 
 /// Arguments for `tga audit`.
 ///
@@ -144,7 +144,12 @@ pub async fn run(config: Config, db: &mut Database, args: AuditArgs) -> anyhow::
     // engagement metadata, the repository set, and — #5239/#5244 — the areas
     // this run could not assess, so a failed stage reaches the report as a
     // stated gap instead of an empty table.
-    let mut gaps = sweep_gap_lines(&stats);
+    //
+    // #5239: the gap lines excerpt a stage's `anyhow` cause chain, which can
+    // quote a credential back at us, so they are redacted before they are cut —
+    // against the same needles the manifest builder uses.
+    let secrets = configured_secrets(&config);
+    let mut gaps = sweep_gap_lines(&stats, &secrets);
     gaps.push(DATA_HANDLING_NOTE.to_string());
     let manifest = build_dd_manifest(
         &config,

--- a/crates/trusty-git-analytics/src/commands/audit.rs
+++ b/crates/trusty-git-analytics/src/commands/audit.rs
@@ -12,13 +12,17 @@
 //! `audit_command_needs_no_positional_arguments` cover the clap wiring; the
 //! sweep's own behavior is covered alongside it.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Args;
 
-use tga::audit::{run_full_sweep, AuditSweepStats, SweepOptions};
+use tga::audit::{
+    resolve_review_binary, run_full_sweep, run_review_report, sweep_gap_lines, AuditSweepStats,
+    SweepOptions, DATA_HANDLING_NOTE,
+};
 use tga::core::config::Config;
 use tga::core::db::Database;
+use tga::report::dd_manifest::{build_dd_manifest, DdManifestOptions};
 
 /// Arguments for `tga audit`.
 ///
@@ -130,18 +134,77 @@ pub async fn run(config: Config, db: &mut Database, args: AuditArgs) -> anyhow::
     );
 
     let options = SweepOptions {
-        output: Some(output),
+        output: Some(output.clone()),
         weeks: args.weeks,
     };
     let stats = run_full_sweep(&config, db, &options, None).await?;
     print_stage_report(&stats);
 
-    // PR B (#5236/#5238/#5239) plugs in here: build the DD manifest from
-    // `config` plus `args` (§6's field mapping), spawn `trusty-review report
-    // --manifest <path> --analyze --output <dir>`, and turn `stats.failures()`
-    // into the report's Gaps & Caveats lines. Nothing above needs to change
-    // for that — the manifest reads `config`, and the gap list is already
-    // carried by `stats`.
+    // #5236: the manifest is the whole tga→trusty-review seam. It carries the
+    // engagement metadata, the repository set, and — #5239/#5244 — the areas
+    // this run could not assess, so a failed stage reaches the report as a
+    // stated gap instead of an empty table.
+    let mut gaps = sweep_gap_lines(&stats);
+    gaps.push(DATA_HANDLING_NOTE.to_string());
+    let manifest = build_dd_manifest(
+        &config,
+        &DdManifestOptions {
+            title: args.resolved_title(),
+            analyst: args.analyst.clone(),
+            client: args.client.clone(),
+            gaps,
+            // #5236: the renderer resolves a relative repository path against
+            // the MANIFEST's directory, not ours; anchoring here is what keeps
+            // it pointed at the checkout tga actually collected from.
+            base_dir: std::env::current_dir().unwrap_or_default(),
+        },
+    )?;
+
+    let manifest_path = output.join(MANIFEST_FILE);
+    std::fs::write(&manifest_path, manifest.to_toml()?)?;
+    println!("\nManifest: {}", manifest_path.display());
+
+    render_report(&manifest_path, &output).await
+}
+
+/// Filename of the DD manifest written into the audit's output directory.
+const MANIFEST_FILE: &str = "manifest.toml";
+
+/// Invoke `trusty-review report` and report what it produced.
+///
+/// Why: #5238 — the manifest is not the deliverable; the rendered report is.
+/// The child's own streams are surfaced verbatim (DOC-67 §6 step 4) because
+/// they carry the per-repository analyze warnings an operator needs, and its
+/// artifact paths are printed last (step 5) so the run ends with the thing the
+/// reader was promised.
+/// What: spawns the renderer, echoes stderr, prints the artifact paths, and
+/// turns a failed render into an error — the sweep's own results are already
+/// printed by then, so nothing is lost by exiting non-zero.
+/// Test: `crate::audit::tests::missing_binary_is_a_named_actionable_error`
+/// covers the not-installed path; the rendered output is covered by the
+/// end-to-end smoke run.
+async fn render_report(manifest_path: &Path, output: &Path) -> anyhow::Result<()> {
+    println!("Rendering: {} report --manifest …", resolve_review_binary());
+    let run = run_review_report(manifest_path, output).await?;
+
+    if !run.stderr.trim().is_empty() {
+        eprintln!("{}", run.stderr.trim_end());
+    }
+    if !run.success {
+        anyhow::bail!(
+            "`{} report` exited with {}; no due-diligence report was produced. The manifest at \
+             {} is intact and can be rendered again once the cause is fixed.",
+            resolve_review_binary(),
+            run.code
+                .map_or_else(|| "a signal".to_string(), |c| format!("code {c}")),
+            manifest_path.display()
+        );
+    }
+
+    println!("\nReport artifacts:");
+    for path in &run.artifacts {
+        println!("  {}", path.display());
+    }
     Ok(())
 }
 

--- a/crates/trusty-git-analytics/src/report/dd_manifest.rs
+++ b/crates/trusty-git-analytics/src/report/dd_manifest.rs
@@ -21,6 +21,12 @@
 //! title, or a stage's error message is removed rather than merely unlikely to
 //! be there. It is a guarantee about the output, not a claim about the inputs.
 //!
+//! That guarantee has one precondition the caller owes, because `scrub_secrets`
+//! matches a credential's whole value: nothing may shorten a string between the
+//! moment it is captured and the moment it arrives here. Stage messages are the
+//! one channel that shortens — [`crate::audit::sweep_gap_lines`] excerpts them —
+//! so it redacts first, using [`configured_secrets`] on the same config (#5239).
+//!
 //! **The same input yields the same bytes** (DOC-67 §9). Nothing here reads the
 //! clock, the environment, or the filesystem, and every collection is an
 //! ordered `Vec` walked in config order. The one machine-dependent value is the
@@ -244,12 +250,16 @@ fn repo_name(configured: Option<&str>, path: &Path) -> String {
 /// Why: `scrub_secrets` can only remove values the caller already knows, so the
 /// needle set decides how much the guarantee is worth. These are the fields tga
 /// itself reads to authenticate — the ones an error message or an expanded
-/// `${GITHUB_TOKEN}` can carry into text this module emits.
+/// `${GITHUB_TOKEN}` can carry into text this module emits. Public since #5239
+/// because [`crate::audit::sweep_gap_lines`] must redact a stage message
+/// *before* it excerpts it, and it has to redact against the same needles this
+/// builder does — a second derivation here would be the drift the
+/// common-entry-point rule exists to prevent.
 /// What: the GitHub / Bitbucket / JIRA / Linear / Azure-DevOps / OpenRouter
-/// credentials, skipping absent and empty values. Never logged or serialized —
-/// the return value's only use is as a needle set.
+/// credentials, skipping absent and empty values. Returns raw secrets: the only
+/// correct use is as a needle set, never logged, displayed, or serialized.
 /// Test: `super::dd_manifest_tests::configured_token_never_reaches_the_manifest`.
-fn configured_secrets(cfg: &Config) -> Vec<String> {
+pub fn configured_secrets(cfg: &Config) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let mut push = |v: Option<&String>| {
         if let Some(v) = v.filter(|v| !v.is_empty()) {

--- a/crates/trusty-git-analytics/src/report/dd_manifest.rs
+++ b/crates/trusty-git-analytics/src/report/dd_manifest.rs
@@ -1,0 +1,280 @@
+//! The tga → trusty-review DD-manifest adapter (DOC-67 §6, #5236).
+//!
+//! Why: `tga audit` and trusty-review are separate processes with no Cargo edge
+//! between them (DOC-67 §5). One TOML file is the entire contract: tga names the
+//! engagement and the repositories, trusty-review renders. Keeping the builder
+//! pure — data in, structure out, the caller writes the file — is what makes the
+//! field mapping provable in unit tests instead of only observable by running a
+//! full audit.
+//! What: [`DdManifest`] and its two sections, [`DdManifestOptions`] for the
+//! run-scoped engagement metadata, and [`build_dd_manifest`], which maps a
+//! resolved tga [`Config`] onto trusty-review's manifest schema per §6's
+//! field table. [`DdManifest::to_toml`] serializes.
+//! Test: `super::dd_manifest_tests`.
+//!
+//! ## Two properties a reviewer should check first
+//!
+//! **No credential reaches the file.** The manifest is handed to a third party.
+//! Every string this module emits passes through
+//! [`trusty_common::credentials::scrub_secrets`] with the credentials the
+//! config holds as needles, so a token that reached a repository name, a CLI
+//! title, or a stage's error message is removed rather than merely unlikely to
+//! be there. It is a guarantee about the output, not a claim about the inputs.
+//!
+//! **The same input yields the same bytes** (DOC-67 §9). Nothing here reads the
+//! clock, the environment, or the filesystem, and every collection is an
+//! ordered `Vec` walked in config order. The one machine-dependent value is the
+//! repository path, which is load-bearing — trusty-review scans that checkout —
+//! and so is emitted as configured.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use trusty_common::credentials::scrub_secrets;
+
+use crate::core::config::Config;
+
+/// Failures the DD-manifest adapter can report.
+///
+/// Why: a library module, so a typed error rather than `anyhow` — the caller
+/// (`tga audit`) turns these into operator-facing text.
+/// What: an empty repository set (the manifest schema requires at least one
+/// entry, so producing it would only move the failure into trusty-review with a
+/// less actionable message), and TOML serialization failure.
+/// Test: `super::dd_manifest_tests::empty_config_is_an_actionable_error`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum DdManifestError {
+    /// The resolved config names no repositories.
+    #[error(
+        "no repositories to audit: add entries under `repositories:` in config.yaml \
+         (or let `tga install` discover them) before running `tga audit`"
+    )]
+    NoRepositories,
+
+    /// The manifest could not be serialized as TOML.
+    #[error("failed to serialize the DD manifest as TOML: {0}")]
+    Serialize(#[from] toml::ser::Error),
+}
+
+/// Engagement metadata for one audit run.
+///
+/// Why: DOC-67 §6 maps the report's title/analyst/client from CLI flags, and §2
+/// forbids obtaining any of them interactively — so each is simply absent when
+/// not supplied and the template renders its own fallback. `gaps` is the channel
+/// §9 requires: areas the sweep could not assess, carried into the report rather
+/// than left in the orchestrator's stderr.
+/// What: the four run-scoped values; everything else comes from [`Config`].
+/// Test: `super::dd_manifest_tests::maps_engagement_metadata`.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct DdManifestOptions {
+    /// Report title, e.g. `"Acme — Technical Due Diligence"`.
+    pub title: String,
+    /// Analyst producing the report; `None` renders the template's fallback.
+    pub analyst: Option<String>,
+    /// Client the report is produced for; `None` renders the fallback.
+    pub client: Option<String>,
+    /// Gaps & Caveats lines for areas this run could not assess.
+    pub gaps: Vec<String>,
+    /// Directory a relative `RepositoryConfig.path` is relative to.
+    ///
+    /// Why: tga resolves a relative repository path against the process's
+    /// working directory, and trusty-review resolves one against the MANIFEST's
+    /// directory — and the manifest is written into the audit's output
+    /// directory, which is a different place. Copying the path through verbatim
+    /// therefore points the renderer at a checkout that does not exist, and its
+    /// only symptom is a report with no analysis and no stated reason. The
+    /// caller supplies its working directory; the builder does the join, so it
+    /// still performs no I/O.
+    /// What: prefixed onto every relative repository path. Absolute paths pass
+    /// through untouched. Empty (the default) leaves paths as configured.
+    /// Test: `super::dd_manifest_tests::relative_paths_are_anchored_to_base_dir`.
+    pub base_dir: PathBuf,
+}
+
+/// A trusty-review report manifest, as tga produces it.
+///
+/// Why: mirrors `trusty_review::report::manifest`'s TOML shape without a Cargo
+/// dependency on that crate (DOC-67 §5 — the file is the seam). Only the four
+/// fields §6's table maps are declared; every other key trusty-review accepts is
+/// deliberately absent so its own defaults apply.
+/// What: the `[report]` section plus one `[[repositories]]` entry per configured
+/// repository, in config order.
+/// Test: `super::dd_manifest_tests::round_trips_through_the_review_schema`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DdManifest {
+    /// The `[report]` metadata section.
+    pub report: DdReportSection,
+    /// One entry per audited repository, in config order.
+    pub repositories: Vec<DdRepositoryEntry>,
+}
+
+/// The `[report]` section of a DD manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DdReportSection {
+    /// Report title (also the output slug seed).
+    pub title: String,
+    /// Analyst name; omitted from the TOML when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub analyst: Option<String>,
+    /// Client name; omitted from the TOML when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client: Option<String>,
+    /// Named unassessed areas; omitted from the TOML when empty.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub gaps: Vec<String>,
+}
+
+/// One audited repository.
+///
+/// Why: §6 fixes the mapping — every AUDIT repo is a local checkout by
+/// construction, `slug` is trusty-review's to derive, `git_ref` is whatever HEAD
+/// is at collection time, and `metrics` must stay unset so the live `--analyze`
+/// fetch is not blocked by a declared file.
+/// What: the name and the checkout path, and nothing else.
+/// Test: `super::dd_manifest_tests::names_fall_back_to_the_directory_basename`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DdRepositoryEntry {
+    /// Display name for the application section.
+    pub name: String,
+    /// Local checkout path trusty-review scans.
+    pub path: PathBuf,
+}
+
+impl DdManifest {
+    /// Serialize to the TOML text trusty-review's `load_manifest` reads.
+    ///
+    /// Why: the caller writes the file; keeping serialization here means the
+    /// determinism property is testable without touching disk.
+    /// What: `toml::to_string_pretty` over the declared field order.
+    /// Test: `super::dd_manifest_tests::two_builds_are_byte_identical`.
+    ///
+    /// # Errors
+    ///
+    /// [`DdManifestError::Serialize`] if a value cannot be represented in TOML
+    /// (a non-UTF-8 repository path is the only realistic case).
+    pub fn to_toml(&self) -> Result<String, DdManifestError> {
+        Ok(toml::to_string_pretty(self)?)
+    }
+}
+
+/// Build the DD manifest for one audit run.
+///
+/// Why: this is the whole tga→trusty-review seam (DOC-67 §6). It exists as a
+/// pure function so the field mapping, the determinism property, and the
+/// no-credential property are provable from unit tests rather than from a live
+/// audit — none of which would be true if it wrote the file itself.
+///
+/// What: maps `cfg.repositories` onto `[[repositories]]` in config order, taking
+/// each entry's `name` or falling back to its directory basename, and fills
+/// `[report]` from `opts`. Every emitted string is scrubbed of the credentials
+/// `cfg` holds, so a token that leaked into a name, a title, or a gap line is
+/// removed before it can reach an artifact. No I/O, no clock, no environment
+/// read: two calls on the same input produce equal values.
+///
+/// Test: `super::dd_manifest_tests` — the field mapping, the basename fallback,
+/// `two_builds_are_byte_identical`, and `configured_token_never_reaches_the_manifest`.
+///
+/// # Errors
+///
+/// [`DdManifestError::NoRepositories`] when the config names none.
+pub fn build_dd_manifest(
+    cfg: &Config,
+    opts: &DdManifestOptions,
+) -> Result<DdManifest, DdManifestError> {
+    if cfg.repositories.is_empty() {
+        return Err(DdManifestError::NoRepositories);
+    }
+
+    // #5236: the needle set is derived once, then applied to every string that
+    // leaves this function — the guarantee is about the output, not about which
+    // input fields we happened to remember are sensitive.
+    let secrets = configured_secrets(cfg);
+    let clean = |s: &str| scrub_secrets(s, &secrets);
+
+    let repositories = cfg
+        .repositories
+        .iter()
+        .map(|repo| DdRepositoryEntry {
+            name: clean(&repo_name(repo.name.as_deref(), &repo.path)),
+            path: anchor(&opts.base_dir, &repo.path),
+        })
+        .collect();
+
+    Ok(DdManifest {
+        report: DdReportSection {
+            title: clean(&opts.title),
+            analyst: opts.analyst.as_deref().map(&clean),
+            client: opts.client.as_deref().map(&clean),
+            gaps: opts.gaps.iter().map(|g| clean(g)).collect(),
+        },
+        repositories,
+    })
+}
+
+/// Anchor a possibly-relative repository path to `base`.
+///
+/// Why/What: see [`DdManifestOptions::base_dir`]. An absolute path, or an empty
+/// `base`, is returned unchanged; a pure join otherwise, with no filesystem
+/// access and therefore no canonicalization.
+/// Test: `super::dd_manifest_tests::relative_paths_are_anchored_to_base_dir`.
+fn anchor(base: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() || base.as_os_str().is_empty() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    }
+}
+
+/// The display name for a repository: its configured name, else the directory
+/// basename (`config/mod.rs`'s own documented fallback).
+fn repo_name(configured: Option<&str>, path: &Path) -> String {
+    match configured.map(str::trim).filter(|n| !n.is_empty()) {
+        Some(name) => name.to_string(),
+        None => path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.display().to_string()),
+    }
+}
+
+/// Every credential the resolved config holds, as scrub needles.
+///
+/// Why: `scrub_secrets` can only remove values the caller already knows, so the
+/// needle set decides how much the guarantee is worth. These are the fields tga
+/// itself reads to authenticate — the ones an error message or an expanded
+/// `${GITHUB_TOKEN}` can carry into text this module emits.
+/// What: the GitHub / Bitbucket / JIRA / Linear / Azure-DevOps / OpenRouter
+/// credentials, skipping absent and empty values. Never logged or serialized —
+/// the return value's only use is as a needle set.
+/// Test: `super::dd_manifest_tests::configured_token_never_reaches_the_manifest`.
+fn configured_secrets(cfg: &Config) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut push = |v: Option<&String>| {
+        if let Some(v) = v.filter(|v| !v.is_empty()) {
+            out.push(v.clone());
+        }
+    };
+
+    push(cfg.github.as_ref().and_then(|g| g.token.as_ref()));
+    push(cfg.bitbucket.as_ref().and_then(|b| b.token.as_ref()));
+    push(cfg.bitbucket.as_ref().and_then(|b| b.app_password.as_ref()));
+    push(cfg.jira.as_ref().and_then(|j| j.token.as_ref()));
+    push(cfg.linear.as_ref().and_then(|l| l.api_key.as_ref()));
+    push(
+        cfg.classification
+            .as_ref()
+            .and_then(|c| c.openrouter_api_key.as_ref()),
+    );
+    if let Some(azdo) = cfg.pm.as_ref().and_then(|p| p.azure_devops.as_ref()) {
+        if !azdo.pat.is_empty() {
+            out.push(azdo.pat.clone());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "dd_manifest_tests.rs"]
+mod dd_manifest_tests;

--- a/crates/trusty-git-analytics/src/report/dd_manifest_tests.rs
+++ b/crates/trusty-git-analytics/src/report/dd_manifest_tests.rs
@@ -204,11 +204,14 @@ fn configured_token_never_reaches_the_manifest() {
 // across the excerpt boundary (#5239)
 // ---------------------------------------------------------------------------
 
-/// `audit::gaps::MAX_REASON_CHARS` — private there, restated here because these
-/// tests exist to position a credential relative to it. A change to one without
-/// the other makes the straddle stop straddling, and the assertions below still
-/// hold, so the duplication costs no correctness.
-const EXCERPT_BOUNDARY: usize = 160;
+/// The excerpt cap these tests position a credential across, taken from the
+/// production constant rather than copied.
+///
+/// Why: a copy that drifted would not fail — the token would land wholly inside
+/// a wider excerpt, the straddle would stop straddling, and
+/// `a_token_straddling_the_excerpt_boundary_leaves_no_fragment` would keep
+/// passing while guarding nothing (#5308 review).
+const EXCERPT_BOUNDARY: usize = crate::audit::MAX_REASON_CHARS;
 
 /// Run one failed stage through the pipeline `tga audit` actually uses.
 ///
@@ -250,16 +253,55 @@ fn config_with_tokens(github: &str, jira: &str) -> Config {
     cfg
 }
 
-/// Assert that not even an 8-character prefix of `token` appears in `toml`.
+/// `scrub_secrets`'s shortest scrubbable needle, in characters.
 ///
-/// The 8 is deliberate: `scrub_secrets` refuses needles shorter than that, so a
-/// surviving 8-char prefix is precisely a fragment no downstream scrub could
-/// ever remove. Any longer fragment contains this one, so one assertion covers
-/// every fragment length.
+/// Why: it is private to `trusty_common::credentials::redact`, and exporting it
+/// would add a public item to a crate every other crate depends on for the sake
+/// of one assertion here. `scrub_min_chars_is_what_the_fragment_assertions_assume`
+/// pins this value against the real behaviour instead, so a change over there
+/// fails a test rather than silently weakening every assertion below (#5308
+/// review).
+const SCRUB_MIN_CHARS: usize = 8;
+
+/// The shortest leading fragment of `token` that no later `scrub_secrets` call
+/// could remove — measured in characters, because `scrub_secrets`'s own guard
+/// counts characters and a byte slice would panic mid-codepoint.
+fn unscrubbable_fragment(token: &str) -> String {
+    token.chars().take(SCRUB_MIN_CHARS).collect()
+}
+
+/// Why: [`SCRUB_MIN_CHARS`] is a restatement of a constant in another crate, and
+/// the fragment assertions are only as strong as that number is right. A needle
+/// of exactly this length must be scrubbable and one character shorter must not
+/// be — which is what makes a surviving fragment of this length unremovable by
+/// anything downstream.
+/// Test: itself.
+#[test]
+fn scrub_min_chars_is_what_the_fragment_assertions_assume() {
+    let needle: String = "abcdefghijklmnop".chars().take(SCRUB_MIN_CHARS).collect();
+    assert_eq!(
+        trusty_common::credentials::scrub_secrets(&format!("value {needle} here"), &[&needle]),
+        "value [REDACTED] here",
+        "a needle of exactly SCRUB_MIN_CHARS must be scrubbable"
+    );
+
+    let shorter: String = needle.chars().take(SCRUB_MIN_CHARS - 1).collect();
+    let text = format!("value {shorter} here");
+    assert_eq!(
+        trusty_common::credentials::scrub_secrets(&text, &[&shorter]),
+        text,
+        "one character shorter must be refused"
+    );
+}
+
+/// Assert that not even an unscrubbable prefix of `token` appears in `toml`.
+///
+/// Any longer fragment contains [`unscrubbable_fragment`]'s, so one assertion
+/// covers every fragment length.
 fn assert_no_fragment(toml: &str, token: &str, label: &str) {
     assert!(!toml.contains(token), "{label}: full token leaked:\n{toml}");
     assert!(
-        !toml.contains(&token[..8]),
+        !toml.contains(&unscrubbable_fragment(token)),
         "{label}: a prefix fragment survived:\n{toml}"
     );
 }
@@ -345,7 +387,7 @@ fn redaction_before_truncation_keeps_the_excerpt_within_budget() {
         "one verbose error must not dominate the Gaps section ({} chars)",
         line.chars().count()
     );
-    assert!(!line.contains(&token[..8]), "{line}");
+    assert!(!line.contains(&unscrubbable_fragment(token)), "{line}");
 }
 
 /// Why: trusty-review rejects a manifest with no repositories, and a message

--- a/crates/trusty-git-analytics/src/report/dd_manifest_tests.rs
+++ b/crates/trusty-git-analytics/src/report/dd_manifest_tests.rs
@@ -10,7 +10,7 @@
 use std::path::PathBuf;
 
 use super::*;
-use crate::core::config::{GithubConfig, RepositoryConfig};
+use crate::core::config::{GithubConfig, JiraConfig, RepositoryConfig};
 
 /// A config naming `n` repositories, with no credentials.
 fn config_with_repos(entries: &[(&str, Option<&str>)]) -> Config {
@@ -197,6 +197,155 @@ fn configured_token_never_reaches_the_manifest() {
     );
     // The surrounding diagnostic survives — scrubbing must not destroy the gap.
     assert!(toml.contains("Stage `collect` did not complete"), "{toml}");
+}
+
+// ---------------------------------------------------------------------------
+// The real sweep → gap-line → manifest path, with a credential positioned
+// across the excerpt boundary (#5239)
+// ---------------------------------------------------------------------------
+
+/// `audit::gaps::MAX_REASON_CHARS` — private there, restated here because these
+/// tests exist to position a credential relative to it. A change to one without
+/// the other makes the straddle stop straddling, and the assertions below still
+/// hold, so the duplication costs no correctness.
+const EXCERPT_BOUNDARY: usize = 160;
+
+/// Run one failed stage through the pipeline `tga audit` actually uses.
+///
+/// `configured_token_never_reaches_the_manifest` hands `build_dd_manifest`
+/// short gap strings it wrote itself, which is why it cannot see this class of
+/// bug: the excerpt never runs. This helper drives the real
+/// `sweep_gap_lines` → `build_dd_manifest` path instead.
+fn manifest_from_stage_failure(cfg: &Config, message: String) -> String {
+    let mut stats = crate::audit::AuditSweepStats::default();
+    stats.record(
+        crate::audit::SweepStage::Collect,
+        std::time::Instant::now(),
+        Err(anyhow::anyhow!(message)),
+    );
+
+    let secrets = configured_secrets(cfg);
+    let opts = DdManifestOptions {
+        title: "Acme — Technical Due Diligence".to_string(),
+        gaps: crate::audit::sweep_gap_lines(&stats, &secrets),
+        ..Default::default()
+    };
+    build_dd_manifest(cfg, &opts)
+        .expect("builds")
+        .to_toml()
+        .expect("serializes")
+}
+
+/// A config whose GitHub and JIRA tokens are the two given values.
+fn config_with_tokens(github: &str, jira: &str) -> Config {
+    let mut cfg = config_with_repos(&[("/src/a", Some("A"))]);
+    cfg.github = Some(GithubConfig {
+        token: Some(github.to_string()),
+        ..Default::default()
+    });
+    cfg.jira = Some(JiraConfig {
+        token: Some(jira.to_string()),
+        ..Default::default()
+    });
+    cfg
+}
+
+/// Assert that not even an 8-character prefix of `token` appears in `toml`.
+///
+/// The 8 is deliberate: `scrub_secrets` refuses needles shorter than that, so a
+/// surviving 8-char prefix is precisely a fragment no downstream scrub could
+/// ever remove. Any longer fragment contains this one, so one assertion covers
+/// every fragment length.
+fn assert_no_fragment(toml: &str, token: &str, label: &str) {
+    assert!(!toml.contains(token), "{label}: full token leaked:\n{toml}");
+    assert!(
+        !toml.contains(&token[..8]),
+        "{label}: a prefix fragment survived:\n{toml}"
+    );
+}
+
+/// Why: `scrub_secrets` matches a credential's whole value, so truncating a
+/// stage message before scrubbing it leaves a token that spans the boundary
+/// behind as a prefix no later scrub can match — and the manifest is handed to a
+/// third party. Found by security review of #5239's gap reporting.
+/// Test: itself.
+#[test]
+fn a_token_straddling_the_excerpt_boundary_leaves_no_fragment() {
+    let token = "ghp_STRADDLE0123456789abcdefGHIJKLMNOPQR"; // pragma: allowlist secret
+    let lead = "GET /orgs/acme/repos returned 401 for ";
+    // Start the token 10 chars short of the cut, so it begins inside the excerpt
+    // and ends outside it — the exact geometry that produced the leak.
+    let pad = "x".repeat(EXCERPT_BOUNDARY - 10 - lead.chars().count());
+    let message = format!(
+        "{lead}{pad}{token}: bad credentials. The remainder of this cause chain exists to \
+         carry the message past 200 characters so the excerpt is guaranteed to truncate."
+    );
+    assert!(message.chars().count() > 200, "the excerpt must truncate");
+
+    let cfg = config_with_tokens(token, "unused-jira-token-000");
+    let toml = manifest_from_stage_failure(&cfg, message);
+
+    assert_no_fragment(&toml, token, "straddling token");
+    // Scrubbing must remove the value, not the diagnostic around it.
+    assert!(toml.contains("[REDACTED]"), "{toml}");
+    assert!(toml.contains("not assessed"), "{toml}");
+}
+
+/// Why: the opposite geometry, and a distinct path. A token sitting entirely
+/// beyond the boundary was safe before this fix only by accident — truncation
+/// dropped it. Redacting first shortens the text, so text that used to fall
+/// outside the excerpt now moves inside it; a second credential must survive
+/// that shift as `[REDACTED]`, not as itself.
+/// Test: itself.
+#[test]
+fn a_token_beyond_the_boundary_survives_the_shift_scrubbing_causes() {
+    // `early` sits near the start; `late` sits past char 160 in the raw text but
+    // moves under it once `early` collapses to `[REDACTED]`.
+    let early = "ghp_EARLY0123456789abcdefGHIJKLMNOPQRSTUV"; // pragma: allowlist secret
+    let late = "jira_LATE0123456789abcdefGHIJKLMNOPQRSTUV"; // pragma: allowlist secret
+    let message = format!(
+        "GET /rest/api/3/search failed for {early}; retried with {} and got 401 for {late}, \
+         then gave up.",
+        "y".repeat(EXCERPT_BOUNDARY)
+    );
+
+    let cfg = config_with_tokens(early, late);
+    let toml = manifest_from_stage_failure(&cfg, message);
+
+    assert_no_fragment(&toml, early, "early token");
+    assert_no_fragment(&toml, late, "late token");
+}
+
+/// Why: `[REDACTED]` is longer than most of what it replaces, so scrubbing
+/// before truncating could push the excerpt over its budget if the cap were
+/// applied to the pre-redaction text. The cap must bind the string that is
+/// actually emitted.
+/// Test: itself.
+#[test]
+fn redaction_before_truncation_keeps_the_excerpt_within_budget() {
+    // Twelve occurrences, each expanding to `[REDACTED]`, in a message far
+    // longer than the cap.
+    let token = "ghp_BUDGET0123456789abcdefGHIJKLMNOPQRST"; // pragma: allowlist secret
+    let message = std::iter::repeat_n(format!("401 for {token}"), 12)
+        .collect::<Vec<_>>()
+        .join(" and ");
+
+    let cfg = config_with_tokens(token, "unused-jira-token-000");
+    let mut stats = crate::audit::AuditSweepStats::default();
+    stats.record(
+        crate::audit::SweepStage::Collect,
+        std::time::Instant::now(),
+        Err(anyhow::anyhow!(message)),
+    );
+    let line = crate::audit::sweep_gap_lines(&stats, &configured_secrets(&cfg)).remove(0);
+
+    assert!(line.contains('…'), "must still truncate: {line}");
+    assert!(
+        line.chars().count() < 400,
+        "one verbose error must not dominate the Gaps section ({} chars)",
+        line.chars().count()
+    );
+    assert!(!line.contains(&token[..8]), "{line}");
 }
 
 /// Why: trusty-review rejects a manifest with no repositories, and a message

--- a/crates/trusty-git-analytics/src/report/dd_manifest_tests.rs
+++ b/crates/trusty-git-analytics/src/report/dd_manifest_tests.rs
@@ -1,0 +1,278 @@
+//! Tests for the DD-manifest adapter (#5236, DOC-67 §6).
+//!
+//! Why: the adapter is pure precisely so its three obligations can be proved
+//! here rather than by running an audit — the §6 field mapping, §9's byte-level
+//! determinism, and the hard requirement that no configured credential reaches
+//! an artifact handed to a third party.
+//! What: drives `build_dd_manifest` against fixture `Config` values.
+//! Test: this file.
+
+use std::path::PathBuf;
+
+use super::*;
+use crate::core::config::{GithubConfig, RepositoryConfig};
+
+/// A config naming `n` repositories, with no credentials.
+fn config_with_repos(entries: &[(&str, Option<&str>)]) -> Config {
+    Config {
+        repositories: entries
+            .iter()
+            .map(|(path, name)| RepositoryConfig {
+                path: PathBuf::from(path),
+                name: name.map(str::to_string),
+                ..Default::default()
+            })
+            .collect(),
+        ..Default::default()
+    }
+}
+
+fn options(title: &str) -> DdManifestOptions {
+    DdManifestOptions {
+        title: title.to_string(),
+        ..Default::default()
+    }
+}
+
+/// Why: §6's table is the contract between two processes; every row it fixes
+/// must actually appear, and every field it says to omit must stay absent so
+/// trusty-review's own defaults (slug derivation, git_ref, live `--analyze`)
+/// apply.
+/// Test: itself.
+#[test]
+fn maps_engagement_metadata() {
+    let cfg = config_with_repos(&[("/src/northwind-web", Some("Northwind Web"))]);
+    let opts = DdManifestOptions {
+        title: "Acme — Technical Due Diligence".to_string(),
+        analyst: Some("J. Reviewer".to_string()),
+        client: Some("Acme Holdings".to_string()),
+        gaps: vec!["Stage `dora` did not complete.".to_string()],
+        ..Default::default()
+    };
+
+    let manifest = build_dd_manifest(&cfg, &opts).expect("builds");
+
+    assert_eq!(manifest.report.title, "Acme — Technical Due Diligence");
+    assert_eq!(manifest.report.analyst.as_deref(), Some("J. Reviewer"));
+    assert_eq!(manifest.report.client.as_deref(), Some("Acme Holdings"));
+    assert_eq!(manifest.report.gaps.len(), 1);
+    assert_eq!(
+        manifest.repositories,
+        vec![DdRepositoryEntry {
+            name: "Northwind Web".to_string(),
+            path: PathBuf::from("/src/northwind-web"),
+        }]
+    );
+
+    // Omitted-by-design keys never appear: `slug` is trusty-review's to derive,
+    // `ref` follows HEAD, and a declared `metrics` file would block the live
+    // `--analyze` fetch every AUDIT run depends on (§6).
+    let toml = manifest.to_toml().expect("serializes");
+    for absent in ["slug", "ref =", "metrics", "template"] {
+        assert!(!toml.contains(absent), "{absent} must not appear:\n{toml}");
+    }
+}
+
+/// Why: absent metadata must stay absent rather than becoming an empty string —
+/// the template's own fallback ("not stated in source report") is what §2's
+/// no-interactivity rule relies on.
+/// Test: itself.
+#[test]
+fn absent_metadata_is_omitted_not_blanked() {
+    let cfg = config_with_repos(&[("/src/a", Some("A"))]);
+    let toml = build_dd_manifest(&cfg, &options("T"))
+        .expect("builds")
+        .to_toml()
+        .expect("serializes");
+
+    assert!(!toml.contains("analyst"), "{toml}");
+    assert!(!toml.contains("client"), "{toml}");
+    assert!(!toml.contains("gaps"), "{toml}");
+}
+
+/// Why: `RepositoryConfig.name` is optional and its documented fallback is the
+/// directory basename; an audit of an org-discovered repo set relies on it.
+/// Test: itself.
+#[test]
+fn names_fall_back_to_the_directory_basename() {
+    let cfg = config_with_repos(&[
+        ("/src/northwind-web", None),
+        ("/src/billing", Some("  ")),
+        ("/src/ledger", Some("Ledger Service")),
+    ]);
+
+    let manifest = build_dd_manifest(&cfg, &options("T")).expect("builds");
+    let names: Vec<&str> = manifest
+        .repositories
+        .iter()
+        .map(|r| r.name.as_str())
+        .collect();
+
+    assert_eq!(names, vec!["northwind-web", "billing", "Ledger Service"]);
+}
+
+/// Why: repository order is the report's application order; a set that reorders
+/// between runs would make two audits of the same state incomparable.
+/// Test: itself.
+#[test]
+fn repositories_keep_config_order() {
+    let cfg = config_with_repos(&[("/src/c", None), ("/src/a", None), ("/src/b", None)]);
+    let manifest = build_dd_manifest(&cfg, &options("T")).expect("builds");
+    let names: Vec<&str> = manifest
+        .repositories
+        .iter()
+        .map(|r| r.name.as_str())
+        .collect();
+    assert_eq!(names, vec!["c", "a", "b"], "config order, never sorted");
+}
+
+/// Why: DOC-67 §9 — the same DB and config must produce a byte-identical
+/// manifest. A clock read, an environment read, or a hash-ordered collection in
+/// the builder would break this and nothing else would catch it.
+/// Test: itself.
+#[test]
+fn two_builds_are_byte_identical() {
+    let cfg = config_with_repos(&[
+        ("/src/northwind-web", Some("Northwind Web")),
+        ("/src/billing", None),
+    ]);
+    let opts = DdManifestOptions {
+        title: "Acme — Technical Due Diligence".to_string(),
+        analyst: Some("J. Reviewer".to_string()),
+        client: None,
+        gaps: vec!["a".to_string(), "b".to_string()],
+        ..Default::default()
+    };
+
+    let first = build_dd_manifest(&cfg, &opts).expect("builds");
+    let second = build_dd_manifest(&cfg, &opts).expect("builds");
+
+    assert_eq!(first, second);
+    assert_eq!(
+        first.to_toml().expect("serializes"),
+        second.to_toml().expect("serializes"),
+        "same input, same bytes"
+    );
+}
+
+/// Why: the manifest is handed to a third party. A credential reaching it is
+/// the one failure in this module that cannot be walked back, so the guarantee
+/// is tested at the boundary a token can realistically cross — an expanded
+/// `${GITHUB_TOKEN}` echoed into a stage's error message, and from there into a
+/// gap line.
+/// Test: itself.
+#[test]
+fn configured_token_never_reaches_the_manifest() {
+    let token = "ghp_TESTONLYtoken0123456789abcdef"; // pragma: allowlist secret
+    let mut cfg = config_with_repos(&[("/src/a", Some("A"))]);
+    cfg.github = Some(GithubConfig {
+        token: Some(token.to_string()),
+        ..Default::default()
+    });
+
+    // Every string channel that reaches the file, each carrying the token the
+    // way a real failure would: an API error body quoted into a stage message.
+    let opts = DdManifestOptions {
+        title: format!("Acme ({token})"),
+        analyst: Some(format!("analyst {token}")),
+        client: Some(format!("client {token}")),
+        gaps: vec![format!(
+            "Stage `collect` did not complete: GET /orgs/acme/repos returned 401 for {token}"
+        )],
+        ..Default::default()
+    };
+
+    let toml = build_dd_manifest(&cfg, &opts)
+        .expect("builds")
+        .to_toml()
+        .expect("serializes");
+
+    assert!(
+        !toml.contains(token),
+        "token leaked into the manifest:\n{toml}"
+    );
+    assert!(
+        toml.contains("[REDACTED]"),
+        "the value must be replaced, not merely dropped:\n{toml}"
+    );
+    // The surrounding diagnostic survives — scrubbing must not destroy the gap.
+    assert!(toml.contains("Stage `collect` did not complete"), "{toml}");
+}
+
+/// Why: trusty-review rejects a manifest with no repositories, and a message
+/// naming `config.yaml` is far more actionable than that rejection.
+/// Test: itself.
+#[test]
+fn empty_config_is_an_actionable_error() {
+    let err = build_dd_manifest(&Config::default(), &options("T")).expect_err("no repositories");
+    assert!(matches!(err, DdManifestError::NoRepositories));
+    assert!(err.to_string().contains("config.yaml"), "{err}");
+}
+
+/// Why: the file is only useful if the consumer parses it, and the consumer is
+/// a different crate with its own validation. Serializing text that
+/// trusty-review would reject is a defect this crate can catch alone.
+/// Test: itself.
+#[test]
+fn round_trips_through_the_review_schema() {
+    let cfg = config_with_repos(&[("/src/a", Some("A")), ("/src/b", None)]);
+    let opts = DdManifestOptions {
+        title: "T".to_string(),
+        analyst: Some("An".to_string()),
+        client: None,
+        gaps: vec!["one gap".to_string()],
+        ..Default::default()
+    };
+    let toml = build_dd_manifest(&cfg, &opts)
+        .expect("builds")
+        .to_toml()
+        .expect("serializes");
+
+    // The shape trusty-review's `load_manifest` requires: a `[report]` table
+    // with a title, and one `[[repositories]]` entry per repo carrying exactly
+    // one source key (`path`).
+    let parsed: toml::Value = toml::from_str(&toml).expect("valid TOML");
+    assert_eq!(parsed["report"]["title"].as_str(), Some("T"));
+    assert_eq!(parsed["report"]["gaps"].as_array().map(Vec::len), Some(1));
+    let repos = parsed["repositories"].as_array().expect("array of tables");
+    assert_eq!(repos.len(), 2);
+    for repo in repos {
+        assert!(repo.get("path").is_some(), "local source key required");
+        assert!(repo.get("remote").is_none(), "exactly one source key");
+        assert!(repo.get("name").is_some());
+    }
+}
+
+/// Why: tga resolves a relative repository path against its working directory
+/// and trusty-review resolves one against the manifest's directory — and the
+/// manifest lands in the output directory, somewhere else entirely. Copying the
+/// path through verbatim silently points the renderer at a checkout that does
+/// not exist, and the only symptom is a report with no analysis and no stated
+/// reason. Caught by the end-to-end smoke run for #5238.
+/// Test: itself.
+#[test]
+fn relative_paths_are_anchored_to_base_dir() {
+    let cfg = config_with_repos(&[("./small-repo", Some("Small")), ("/abs/other", Some("Abs"))]);
+    let opts = DdManifestOptions {
+        title: "T".to_string(),
+        base_dir: PathBuf::from("/work/audit"),
+        ..Default::default()
+    };
+
+    let manifest = build_dd_manifest(&cfg, &opts).expect("builds");
+
+    assert_eq!(
+        manifest.repositories[0].path,
+        PathBuf::from("/work/audit/./small-repo"),
+        "a relative path is anchored, never passed through"
+    );
+    assert_eq!(
+        manifest.repositories[1].path,
+        PathBuf::from("/abs/other"),
+        "an absolute path is untouched"
+    );
+
+    // An empty base leaves paths exactly as configured.
+    let bare = build_dd_manifest(&cfg, &options("T")).expect("builds");
+    assert_eq!(bare.repositories[0].path, PathBuf::from("./small-repo"));
+}

--- a/crates/trusty-git-analytics/src/report/mod.rs
+++ b/crates/trusty-git-analytics/src/report/mod.rs
@@ -11,6 +11,7 @@
 //! - [`models`] — aggregated data structures
 //! - [`period_trends`] — N-week period roll-up for contributor profiles (#558)
 pub mod aggregator;
+pub mod dd_manifest;
 pub mod drilldown;
 pub mod errors;
 pub mod formatters;
@@ -21,6 +22,10 @@ pub mod pipeline;
 pub mod templates;
 pub mod ticketed_stats;
 
+pub use dd_manifest::{
+    build_dd_manifest, DdManifest, DdManifestError, DdManifestOptions, DdReportSection,
+    DdRepositoryEntry,
+};
 pub use errors::{ReportError, Result};
 pub use models::ReportData;
 pub use period_trends::{query_author_period_trends, AuthorPeriodSummary};

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -6,6 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.13.0] — 2026-08-10
+
+### Added
+
+- `report --analyze` now names every repository it could not enrich, in the report's Gaps & Caveats section, instead of only warning on stderr. A findings table that renders empty because the analyze daemon was unreachable no longer looks like a codebase with no findings (#5239, DOC-67 §9). The fetch contract is unchanged — still fail-open, still never aborts the report.
+- `AnalyzeMetricsSource::fetch_named` returns the reason a fetch yielded nothing (`AnalyzeGap::NotIndexed`, `Unreachable`, or `Unavailable`) rather than a bare `None`. It has a default implementation, so existing implementors are unaffected; `HttpAnalyzeMetricsSource` distinguishes the two conditions it can tell apart. The raw transport error stays on stderr — the report gets the category only, so a URL or a response body never reaches an artifact handed to a third party.
+- `enrich_with_analyze_gaps` is the enrichment entry point that returns those lines; `enrich_with_analyze` is unchanged and now delegates to it.
+- A manifest may declare `[report] gaps = [...]` — Gaps & Caveats lines from whoever produced the manifest. `tga audit` uses this to carry the stages its sweep could not complete into the report (#5236).
+- `polish_with_gaps` renders declared gaps as their own bullets ahead of the auto-collected `Data gaps:` list. A template with no Gaps & Caveats heading gets one appended rather than dropping the lines.
+
 ## [0.12.0] — 2026-08-10
 
 ### Breaking

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.12.0"
+version     = "0.13.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/5239-audit-gap-reporting.md
+++ b/crates/trusty-review/changelog.d/5239-audit-gap-reporting.md
@@ -1,0 +1,7 @@
+Added
+
+- `report --analyze` now names every repository it could not enrich, in the report's Gaps & Caveats section, instead of only warning on stderr. A findings table that renders empty because the analyze daemon was unreachable no longer looks like a codebase with no findings (#5239, DOC-67 §9). The fetch contract is unchanged — still fail-open, still never aborts the report.
+- `AnalyzeMetricsSource::fetch_named` returns the reason a fetch yielded nothing (`AnalyzeGap::NotIndexed`, `Unreachable`, or `Unavailable`) rather than a bare `None`. It has a default implementation, so existing implementors are unaffected; `HttpAnalyzeMetricsSource` distinguishes the two conditions it can tell apart. The raw transport error stays on stderr — the report gets the category only, so a URL or a response body never reaches an artifact handed to a third party.
+- `enrich_with_analyze_gaps` is the enrichment entry point that returns those lines; `enrich_with_analyze` is unchanged and now delegates to it.
+- A manifest may declare `[report] gaps = [...]` — Gaps & Caveats lines from whoever produced the manifest. `tga audit` uses this to carry the stages its sweep could not complete into the report (#5236).
+- `polish_with_gaps` renders declared gaps as their own bullets ahead of the auto-collected `Data gaps:` list. A template with no Gaps & Caveats heading gets one appended rather than dropping the lines.

--- a/crates/trusty-review/changelog.d/5239-audit-gap-reporting.md
+++ b/crates/trusty-review/changelog.d/5239-audit-gap-reporting.md
@@ -1,7 +1,0 @@
-Added
-
-- `report --analyze` now names every repository it could not enrich, in the report's Gaps & Caveats section, instead of only warning on stderr. A findings table that renders empty because the analyze daemon was unreachable no longer looks like a codebase with no findings (#5239, DOC-67 §9). The fetch contract is unchanged — still fail-open, still never aborts the report.
-- `AnalyzeMetricsSource::fetch_named` returns the reason a fetch yielded nothing (`AnalyzeGap::NotIndexed`, `Unreachable`, or `Unavailable`) rather than a bare `None`. It has a default implementation, so existing implementors are unaffected; `HttpAnalyzeMetricsSource` distinguishes the two conditions it can tell apart. The raw transport error stays on stderr — the report gets the category only, so a URL or a response body never reaches an artifact handed to a third party.
-- `enrich_with_analyze_gaps` is the enrichment entry point that returns those lines; `enrich_with_analyze` is unchanged and now delegates to it.
-- A manifest may declare `[report] gaps = [...]` — Gaps & Caveats lines from whoever produced the manifest. `tga audit` uses this to carry the stages its sweep could not complete into the report (#5236).
-- `polish_with_gaps` renders declared gaps as their own bullets ahead of the auto-collected `Data gaps:` list. A template with no Gaps & Caveats heading gets one appended rather than dropping the lines.

--- a/crates/trusty-review/changelog.d/5239-review-gaps-field-breaking-bump.md
+++ b/crates/trusty-review/changelog.d/5239-review-gaps-field-breaking-bump.md
@@ -1,0 +1,3 @@
+Breaking
+
+- `ReportSection` and `ReportModel` gain a public `gaps` field (added for #5239's Gaps & Caveats reporting). Both structs are externally constructible, so an exhaustive struct literal built against 0.12.0 no longer compiles — `cargo-semver-checks` flags this as `constructible_struct_adds_field`. Version bumped 0.12.0 -> 0.13.0 per Cargo's 0.x rule (the breaking bump lands in the MINOR position). No in-workspace crate needed a source change: `trusty-analyze` and `trusty-mpm` both reference `trusty-review` via `workspace = true`, so bumping the workspace-level `version = "0.13"` pin in the root `Cargo.toml` was sufficient.

--- a/crates/trusty-review/src/cli_report.rs
+++ b/crates/trusty-review/src/cli_report.rs
@@ -201,12 +201,29 @@ pub async fn cmd_report(config: ReviewConfig, args: ReportArgs) -> Result<()> {
         eprintln!("[trusty-review report] --analyze: fetching from {analyze_url}");
         match trusty_review::report::HttpAnalyzeMetricsSource::new(analyze_url) {
             Ok(source) => {
-                trusty_review::report::enrich_with_analyze(&mut model, &source).await;
+                // #5239: every repo the fetch could not populate is named in the
+                // report, not only warned about on stderr — a dimension missing
+                // because the daemon was down must not read as a clean pass.
+                let gaps =
+                    trusty_review::report::enrich_with_analyze_gaps(&mut model, &source).await;
+                for gap in &gaps {
+                    eprintln!("[trusty-review report] --analyze gap: {gap}");
+                }
+                model.gaps.extend(gaps);
             }
             Err(e) => {
                 eprintln!(
                     "[trusty-review report] --analyze: could not build HTTP client ({e}); \
                      falling back to scan"
+                );
+                // #5239: the client never existed, so no repo was assessed —
+                // that is a whole-report gap, not a per-repo one.
+                model.gaps.push(
+                    "trusty-analyze data unavailable — the analysis client could not be \
+                     built, so no application in this report was assessed against \
+                     trusty-analyze. Findings, complexity, and health factors are not \
+                     assessed, not clean."
+                        .to_string(),
                 );
             }
         }

--- a/crates/trusty-review/src/report/analyze_adapter.rs
+++ b/crates/trusty-review/src/report/analyze_adapter.rs
@@ -363,6 +363,78 @@ fn map_metrics(
 pub trait AnalyzeMetricsSource: Send + Sync {
     /// Fetch and map metrics for `index_id`, fail-open to `None`.
     async fn fetch(&self, index_id: &str) -> Option<AnalyzeMetrics>;
+
+    /// The same fetch, with the reason named when it yields no metrics (#5239).
+    ///
+    /// Why: [`Self::fetch`]'s `None` is correct as a control-flow signal and
+    /// useless as a report fact — a reader cannot tell an unassessed dimension
+    /// from a clean one. This variant preserves the fail-open contract (it
+    /// still never returns `Err`) while carrying the reason far enough to be
+    /// rendered under Gaps & Caveats.
+    /// What: the default implementation delegates to [`Self::fetch`] and, since
+    /// it cannot see why, reports [`AnalyzeGap::Unavailable`]. Implementations
+    /// that know more override it.
+    /// Test: `analyze_adapter_tests.rs::default_fetch_named_reports_unavailable`.
+    async fn fetch_named(&self, index_id: &str) -> AnalyzeFetch {
+        match self.fetch(index_id).await {
+            Some(m) => AnalyzeFetch::Fetched(Box::new(m)),
+            None => AnalyzeFetch::Missing(AnalyzeGap::Unavailable),
+        }
+    }
+}
+
+/// Why one repository has no live analyze metrics (#5239, DOC-67 §9).
+///
+/// Why: "the daemon was down" and "this repo was never indexed" are different
+/// facts to an acquirer reading the gap list — the first says nothing about the
+/// codebase, the second says the operator skipped a setup step — so they are
+/// distinct variants rather than one opaque string. The variant is also what
+/// keeps a raw transport error, which can quote a URL or a response body, out
+/// of the generated artifact: the detail stays on stderr, the category is what
+/// reaches the report.
+/// What: the two reasons [`HttpAnalyzeMetricsSource`] can distinguish, plus the
+/// catch-all a source that cannot tell them apart reports.
+/// Test: `analyze_adapter_tests.rs::gap_labels_are_stable`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum AnalyzeGap {
+    /// The daemon answered, but serves no index for this repository.
+    NotIndexed,
+    /// The daemon could not be reached, or its answer could not be used.
+    Unreachable,
+    /// No metrics, and the source could not say why.
+    Unavailable,
+}
+
+impl AnalyzeGap {
+    /// The report-facing phrase for this gap, e.g. `"trusty-analyze unreachable"`.
+    ///
+    /// Why: the Gaps & Caveats line is read by a stranger to this toolchain, so
+    /// it names the condition in plain words rather than a variant name.
+    /// What: a fixed string per variant — deterministic, and free of any
+    /// run-specific detail.
+    /// Test: `analyze_adapter_tests.rs::gap_labels_are_stable`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NotIndexed => "trusty-analyze index not built",
+            Self::Unreachable => "trusty-analyze unreachable",
+            Self::Unavailable => "trusty-analyze data unavailable",
+        }
+    }
+}
+
+/// The outcome of one named fetch.
+///
+/// Why/What: see [`AnalyzeMetricsSource::fetch_named`]. `Fetched` is boxed
+/// because [`AnalyzeMetrics`] dwarfs the gap variant.
+/// Test: `analyze_adapter_tests.rs::default_fetch_named_reports_unavailable`.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum AnalyzeFetch {
+    /// Live metrics were fetched and mapped.
+    Fetched(Box<AnalyzeMetrics>),
+    /// No metrics; this is the reason, for the report's gap list.
+    Missing(AnalyzeGap),
 }
 
 /// Live HTTP implementation of [`AnalyzeMetricsSource`] over the analyze daemon.
@@ -472,8 +544,18 @@ impl HttpAnalyzeMetricsSource {
 #[async_trait]
 impl AnalyzeMetricsSource for HttpAnalyzeMetricsSource {
     async fn fetch(&self, index_id: &str) -> Option<AnalyzeMetrics> {
+        match self.fetch_named(index_id).await {
+            AnalyzeFetch::Fetched(m) => Some(*m),
+            AnalyzeFetch::Missing(_) => None,
+        }
+    }
+
+    /// #5239: the same fail-open fetch, naming which of the two conditions
+    /// produced an empty result so the report can say so.
+    async fn fetch_named(&self, index_id: &str) -> AnalyzeFetch {
         match self.try_fetch(index_id).await {
-            Ok(m) => m,
+            Ok(Some(m)) => AnalyzeFetch::Fetched(Box::new(m)),
+            Ok(None) => AnalyzeFetch::Missing(AnalyzeGap::NotIndexed),
             Err(e) => {
                 tracing::warn!(
                     index_id,
@@ -484,7 +566,10 @@ impl AnalyzeMetricsSource for HttpAnalyzeMetricsSource {
                     "[trusty-review report] --analyze: fetch for '{index_id}' failed \
                      ({e}); falling back to scan"
                 );
-                None
+                // The error text stays here, on stderr: it can quote a URL or a
+                // response body, neither of which belongs in an artifact handed
+                // to a third party. The report gets the category only.
+                AnalyzeFetch::Missing(AnalyzeGap::Unreachable)
             }
         }
     }
@@ -523,6 +608,34 @@ pub async fn enrich_with_analyze(
     model: &mut super::model::ReportModel,
     source: &dyn AnalyzeMetricsSource,
 ) {
+    let _ = enrich_with_analyze_gaps(model, source).await;
+}
+
+/// Same enrichment, returning one Gaps & Caveats line per degraded condition
+/// (#5239, DOC-67 §9).
+///
+/// Why: fail-open is the right contract and fail-SILENT is not. A findings
+/// table that renders empty because the daemon was down is indistinguishable,
+/// on the page, from a codebase with no findings — so every repository the
+/// fetch could not populate is named, grouped by reason, in the report itself.
+/// The fetch contract is unchanged: nothing here aborts, and the report still
+/// renders from the built-in scan.
+/// What: walks the same repositories [`enrich_with_analyze`] does, using
+/// [`AnalyzeMetricsSource::fetch_named`]; returns at most one line per
+/// [`AnalyzeGap`] kind, each naming the affected repositories in model order so
+/// two runs over the same state produce identical lines. Repositories with a
+/// declared metrics file, and remote entries, are skipped — neither is a gap.
+/// Returns an empty vec when every eligible repository was populated.
+/// Test: `analyze_adapter_tests.rs::{enrich_names_unreachable_repositories,
+/// enrich_reports_no_gaps_when_every_repo_is_populated}`.
+pub async fn enrich_with_analyze_gaps(
+    model: &mut super::model::ReportModel,
+    source: &dyn AnalyzeMetricsSource,
+) -> Vec<String> {
+    // BTreeMap, not HashMap: the rendered line order must not depend on hash
+    // iteration order (DOC-67 §9's determinism requirement).
+    let mut missing: std::collections::BTreeMap<AnalyzeGap, Vec<String>> = Default::default();
+
     for repo in &mut model.repositories {
         // Precedence: a declared metrics file always wins.
         if repo.metrics.is_some() {
@@ -535,14 +648,33 @@ pub async fn enrich_with_analyze(
         let Some(index_id) = derive_index_id(path) else {
             continue;
         };
-        if let Some(metrics) = source.fetch(&index_id).await {
-            eprintln!(
-                "[trusty-review report] --analyze: populated metrics for '{}' from index '{index_id}'",
-                repo.name
-            );
-            repo.metrics = Some(metrics);
+        match source.fetch_named(&index_id).await {
+            AnalyzeFetch::Fetched(metrics) => {
+                eprintln!(
+                    "[trusty-review report] --analyze: populated metrics for '{}' from index '{index_id}'",
+                    repo.name
+                );
+                repo.metrics = Some(*metrics);
+            }
+            AnalyzeFetch::Missing(gap) => {
+                missing.entry(gap).or_default().push(repo.name.clone());
+            }
         }
     }
+
+    missing
+        .into_iter()
+        .map(|(gap, repos)| {
+            format!(
+                "{} — no analysis pass ran for: {}. \
+                 Those applications are described from the repository scan alone; \
+                 their findings, complexity, and health factors are not assessed, \
+                 not clean.",
+                gap.as_str(),
+                repos.join(", ")
+            )
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/trusty-review/src/report/analyze_adapter_tests.rs
+++ b/crates/trusty-review/src/report/analyze_adapter_tests.rs
@@ -216,3 +216,147 @@ fn error_display() {
     };
     assert!(e.to_string().contains("503"));
 }
+
+// ─── Named gaps (#5239) ──────────────────────────────────────────────────────
+
+/// A source that answers with a fixed outcome, so the enrichment walk can be
+/// driven without a daemon.
+struct StubSource(fn() -> AnalyzeFetch);
+
+#[async_trait::async_trait]
+impl AnalyzeMetricsSource for StubSource {
+    async fn fetch(&self, _index_id: &str) -> Option<AnalyzeMetrics> {
+        match (self.0)() {
+            AnalyzeFetch::Fetched(m) => Some(*m),
+            AnalyzeFetch::Missing(_) => None,
+        }
+    }
+
+    async fn fetch_named(&self, _index_id: &str) -> AnalyzeFetch {
+        (self.0)()
+    }
+}
+
+/// A source that implements ONLY `fetch`, exercising the trait's default
+/// `fetch_named` — the shape an out-of-crate implementor keeps compiling with.
+struct MinimalSource;
+
+#[async_trait::async_trait]
+impl AnalyzeMetricsSource for MinimalSource {
+    async fn fetch(&self, _index_id: &str) -> Option<AnalyzeMetrics> {
+        None
+    }
+}
+
+/// Build a one-repository model whose single entry is an unpopulated local
+/// checkout — the only shape the enrichment walk acts on.
+fn model_with_local_repo(name: &str) -> crate::report::model::ReportModel {
+    let manifest = crate::report::manifest::parse_manifest(
+        &format!("[report]\ntitle = \"T\"\n\n[[repositories]]\nname = \"{name}\"\npath = \".\"\n"),
+        std::path::Path::new("m.toml"),
+    )
+    .expect("fixture manifest parses");
+    let mut model = crate::report::model::ReportModel::build(
+        &manifest,
+        std::path::Path::new("m.toml"),
+        "report-technical-dd",
+        None,
+    )
+    .expect("model builds");
+    // `.` always resolves to a directory, so `local_path` is populated; pin it
+    // to a stable name so the derived index id does not depend on the CWD.
+    model.repositories[0].local_path = Some(std::path::PathBuf::from("/tmp/northwind-web"));
+    model
+}
+
+/// Why: the gap phrasing reaches a third party's desk; it must be fixed prose,
+/// never a variant name and never run-specific detail.
+/// Test: itself.
+#[test]
+fn gap_labels_are_stable() {
+    assert_eq!(
+        AnalyzeGap::NotIndexed.as_str(),
+        "trusty-analyze index not built"
+    );
+    assert_eq!(
+        AnalyzeGap::Unreachable.as_str(),
+        "trusty-analyze unreachable"
+    );
+    assert_eq!(
+        AnalyzeGap::Unavailable.as_str(),
+        "trusty-analyze data unavailable"
+    );
+}
+
+/// Why: the trait's default `fetch_named` is what keeps every existing
+/// implementor compiling; it must still produce a NAMED outcome rather than
+/// silently dropping the fact that nothing was fetched.
+/// Test: itself.
+#[tokio::test]
+async fn default_fetch_named_reports_unavailable() {
+    match MinimalSource.fetch_named("demo").await {
+        AnalyzeFetch::Missing(gap) => assert_eq!(gap, AnalyzeGap::Unavailable),
+        AnalyzeFetch::Fetched(_) => panic!("MinimalSource never fetches"),
+    }
+}
+
+/// Why: #5239's core claim — a repository the daemon could not serve is named
+/// in the report, and the line says "not assessed", not nothing at all.
+/// Test: itself.
+#[tokio::test]
+async fn enrich_names_unreachable_repositories() {
+    let mut model = model_with_local_repo("Northwind Web");
+    let source = StubSource(|| AnalyzeFetch::Missing(AnalyzeGap::Unreachable));
+
+    let gaps = enrich_with_analyze_gaps(&mut model, &source).await;
+
+    assert_eq!(gaps.len(), 1, "one line per gap kind: {gaps:?}");
+    assert!(
+        gaps[0].starts_with("trusty-analyze unreachable"),
+        "{}",
+        gaps[0]
+    );
+    assert!(gaps[0].contains("Northwind Web"), "{}", gaps[0]);
+    assert!(
+        gaps[0].contains("not assessed, not clean"),
+        "the line must refuse to read as a clean pass: {}",
+        gaps[0]
+    );
+    assert!(model.repositories[0].metrics.is_none());
+}
+
+/// Why: the fail-open contract is unchanged — a populated repo yields metrics
+/// and NO gap line, so a clean report stays clean.
+/// Test: itself.
+#[tokio::test]
+async fn enrich_reports_no_gaps_when_every_repo_is_populated() {
+    let mut model = model_with_local_repo("Northwind Web");
+    let source = StubSource(|| {
+        AnalyzeFetch::Fetched(Box::new(map_metrics(
+            &[WireHotspot { cyclomatic: 3 }],
+            &[],
+            &[],
+        )))
+    });
+
+    let gaps = enrich_with_analyze_gaps(&mut model, &source).await;
+
+    assert!(gaps.is_empty(), "populated repo is not a gap: {gaps:?}");
+    assert!(model.repositories[0].metrics.is_some());
+}
+
+/// Why: a remote entry was never eligible for a local index, so calling it an
+/// unassessed gap would be a false alarm in every report with a remote repo.
+/// Test: itself.
+#[tokio::test]
+async fn enrich_ignores_repositories_with_no_local_checkout() {
+    let mut model = model_with_local_repo("Northwind Web");
+    model.repositories[0].local_path = None;
+    let source = StubSource(|| AnalyzeFetch::Missing(AnalyzeGap::Unreachable));
+
+    assert!(
+        enrich_with_analyze_gaps(&mut model, &source)
+            .await
+            .is_empty()
+    );
+}

--- a/crates/trusty-review/src/report/manifest.rs
+++ b/crates/trusty-review/src/report/manifest.rs
@@ -90,6 +90,22 @@ pub struct ReportSection {
     /// report is byte-identical to the pre-wave-4 output.
     #[serde(default)]
     pub mermaid: Option<bool>,
+    /// Gaps & Caveats lines declared by whoever produced this manifest (#5239).
+    ///
+    /// Why: an orchestrator that ran BEFORE this process knows about areas it
+    /// could not assess and nothing inside trusty-review can observe — `tga
+    /// audit`'s collection stages fail individually without aborting the run
+    /// (DOC-67 §9), so a dimension missing because a stage failed would
+    /// otherwise be indistinguishable, on the page, from a dimension that is
+    /// genuinely clean. Carrying the lines in the manifest keeps that knowledge
+    /// attached to the report instead of stranded in the orchestrator's stderr.
+    /// What: zero or more prose lines rendered as bullets at the top of the
+    /// Gaps & Caveats section, ahead of the auto-collected `Data gaps:` summary.
+    /// Absent (the default) leaves output byte-identical to a manifest without
+    /// the key.
+    /// Test: `manifest_tests.rs::parse_declared_gaps`.
+    #[serde(default)]
+    pub gaps: Vec<String>,
     /// Optional base URL of the trusty-analyze daemon for the `--analyze` live
     /// deterministic-metrics fetch (epic #2445).
     ///

--- a/crates/trusty-review/src/report/manifest_tests.rs
+++ b/crates/trusty-review/src/report/manifest_tests.rs
@@ -161,3 +161,30 @@ fn slug_derivation() {
     assert_eq!(slugify("!!!"), "report");
     assert_eq!(slugify("Already-slugged"), "already-slugged");
 }
+
+/// Why: #5239 — an orchestrator's unassessed areas travel to the report through
+/// the manifest, and a manifest that declares none must behave exactly as before.
+/// Test: itself.
+#[test]
+fn parse_declared_gaps() {
+    let m = parse_manifest(
+        "[report]\ntitle = \"T\"\ngaps = [\"Stage `dora` did not complete.\", \"No CVE scan.\"]\n\n\
+         [[repositories]]\nname = \"A\"\npath = \"/x\"\n",
+        Path::new("m.toml"),
+    )
+    .expect("parses");
+    assert_eq!(
+        m.report.gaps,
+        vec![
+            "Stage `dora` did not complete.".to_string(),
+            "No CVE scan.".to_string()
+        ]
+    );
+
+    let none = parse_manifest(
+        "[report]\ntitle = \"T\"\n\n[[repositories]]\nname = \"A\"\npath = \"/x\"\n",
+        Path::new("m.toml"),
+    )
+    .expect("parses");
+    assert!(none.report.gaps.is_empty(), "absent key defaults to empty");
+}

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -40,8 +40,8 @@ pub mod template;
 // ── Re-exports for convenience ─────────────────────────────────────────────
 
 pub use analyze_adapter::{
-    AnalyzeAdapterError, AnalyzeMetricsSource, HttpAnalyzeMetricsSource, derive_index_id,
-    enrich_with_analyze,
+    AnalyzeAdapterError, AnalyzeFetch, AnalyzeGap, AnalyzeMetricsSource, HttpAnalyzeMetricsSource,
+    derive_index_id, enrich_with_analyze, enrich_with_analyze_gaps,
 };
 pub use benchmark::{
     BenchmarkReport, BenchmarkStatus, CorpusSnapshot, LoadedCorpus, MetricPlacement,
@@ -61,7 +61,7 @@ pub use manifest::{
 pub use mermaid::inject as inject_mermaid;
 pub use metrics::{AnalyzeMetrics, MetricFinding, Severity, load_metrics};
 pub use model::{ReportModel, RepositoryReport};
-pub use polish::{polish, strip_template_comments};
+pub use polish::{polish, polish_with_gaps, strip_template_comments};
 pub use provenance::{Provenance, tag};
 pub use reporter::Reporter;
 pub use scan::{Framework, RepoScan, scan_repo};

--- a/crates/trusty-review/src/report/model.rs
+++ b/crates/trusty-review/src/report/model.rs
@@ -69,6 +69,22 @@ pub struct ReportModel {
     pub manifest_path: String,
     /// One report per repository, in manifest order.
     pub repositories: Vec<RepositoryReport>,
+    /// Named Gaps & Caveats lines for areas this report did not assess (#5239).
+    ///
+    /// Why: fail-open enrichment must not be fail-silent. A repository whose
+    /// metrics are absent because the analyze daemon was unreachable, and a
+    /// repository that is genuinely clean, must not look the same to a reader
+    /// (DOC-67 §9). Recording the lines on the model — not only in the rendered
+    /// markdown — also keeps the JSON twin a faithful record of what was NOT
+    /// assessed.
+    /// What: seeded from the manifest's `[report].gaps` (an upstream
+    /// orchestrator's own unassessed areas) and appended to at run time by
+    /// [`super::analyze_adapter::enrich_with_analyze_gaps`]. Empty is the
+    /// common case and renders exactly as before.
+    /// Test: `analyze_adapter_tests.rs::enrich_names_unreachable_repositories`,
+    /// `polish_tests.rs::declared_gaps_render_as_bullets`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub gaps: Vec<String>,
     /// Optional M2 LLM synthesis result (present only under `--synthesize`).
     ///
     /// Why: recording the synthesis outcome on the model keeps the JSON twin a
@@ -188,6 +204,9 @@ impl ReportModel {
             generated_date: today,
             manifest_path: manifest_path.display().to_string(),
             repositories,
+            // #5239: the manifest author's own unassessed areas travel with the
+            // report; the analyze pass appends its named gaps to the same list.
+            gaps: manifest.report.gaps.clone(),
             synthesis: None,
             benchmark: None,
             investigation: None,

--- a/crates/trusty-review/src/report/polish.rs
+++ b/crates/trusty-review/src/report/polish.rs
@@ -33,9 +33,28 @@ const GAPS_HEADING_NEEDLE: &str = "Gaps & Caveats";
 /// the Gaps & Caveats section body with the compact gap list.
 /// Test: `polish_tests.rs::polish_end_to_end`.
 pub fn polish(rendered: &str) -> String {
+    polish_with_gaps(rendered, &[])
+}
+
+/// Run the polish pass and lead the Gaps & Caveats section with `declared`.
+///
+/// Why: some unassessed areas are known only to the caller — an upstream
+/// orchestrator whose collection stage failed, or a live analyze fetch that
+/// came back empty because the daemon was unreachable (#5239, DOC-67 §9).
+/// Those are substantive statements about what the report does NOT cover, so
+/// they render as their own bullets rather than being folded into the
+/// auto-collected `Data gaps:` field list.
+/// What: identical to [`polish`], plus one bullet per `declared` line at the
+/// top of the Gaps & Caveats section. An empty `declared` produces byte-
+/// identical output to [`polish`]. When the template has no Gaps & Caveats
+/// heading at all, a section is appended so a named gap is never dropped.
+/// Test: `polish_tests.rs::{declared_gaps_render_as_bullets,
+/// declared_gaps_appended_when_template_has_no_section,
+/// empty_declared_gaps_are_byte_identical}`.
+pub fn polish_with_gaps(rendered: &str, declared: &[String]) -> String {
     let stripped = strip_template_comments(rendered);
     let (body, gaps) = omit_empty(&stripped);
-    let out = render_gaps_section(&body, &gaps);
+    let out = render_gaps_section(&body, &gaps, declared);
     // The line-based passes join with `\n` and drop the trailing newline; restore
     // it when the input had one so exact-output expectations hold.
     if rendered.ends_with('\n') && !out.ends_with('\n') {
@@ -498,13 +517,24 @@ fn collapse_recursive(lines: &[String], gaps: &mut Vec<String>) -> (Vec<String>,
 /// "no material gaps" note when the list is empty).  When the section is absent
 /// (a custom template), the body is returned unchanged.
 /// Test: `polish_tests.rs::gaps_section_lists_dropped_fields`.
-fn render_gaps_section(text: &str, gaps: &[String]) -> String {
+fn render_gaps_section(text: &str, gaps: &[String], declared: &[String]) -> String {
     let lines: Vec<&str> = text.lines().collect();
     let Some(head_idx) = lines
         .iter()
         .position(|l| heading_text(l.trim()).is_some_and(|h| h.contains(GAPS_HEADING_NEEDLE)))
     else {
-        return text.to_string();
+        // #5239: a custom template with no Gaps & Caveats heading must still
+        // carry a named gap — dropping it is exactly the silent omission the
+        // caller passed it in to prevent.
+        if declared.is_empty() {
+            return text.to_string();
+        }
+        let mut out = text.trim_end().to_string();
+        out.push_str(&format!("\n\n## {GAPS_HEADING_NEEDLE}\n\n"));
+        for line in declared {
+            out.push_str(&format!("- {line}\n"));
+        }
+        return out;
     };
 
     // Find the end of the section body (next `---` or heading, else EOF).
@@ -519,6 +549,12 @@ fn render_gaps_section(text: &str, gaps: &[String]) -> String {
 
     let mut out: Vec<String> = lines[..=head_idx].iter().map(|s| s.to_string()).collect();
     out.push(String::new());
+    // #5239: named gaps lead — they say what was not assessed, which outranks
+    // the field-level list of what was merely not stated.
+    if !declared.is_empty() {
+        out.extend(declared.iter().map(|line| format!("- {line}")));
+        out.push(String::new());
+    }
     if gaps.is_empty() {
         out.push("No material data gaps: every templated field was populated from measured, declared, or inferred data.".to_string());
     } else {

--- a/crates/trusty-review/src/report/polish_tests.rs
+++ b/crates/trusty-review/src/report/polish_tests.rs
@@ -6,7 +6,7 @@
 //! What: exercises `strip_template_comments` and `polish` on crafted markdown.
 //! Test: included as `#[cfg(test)] mod tests` from `polish.rs`.
 
-use super::{polish, strip_template_comments};
+use super::{polish, polish_with_gaps, strip_template_comments};
 use crate::report::fill::HONESTY_MARKER;
 
 /// Why: inline instructional comments must never reach the output.
@@ -285,4 +285,60 @@ fn heading_with_only_pseudo_heading_content_not_collapsed() {
         .expect("region under the ### heading");
     assert!(!between.contains("No data available"));
     assert!(between.contains("Rust"));
+}
+
+// ─── Declared (named) gaps — #5239 ──────────────────────────────────────────
+
+/// A minimal document carrying the Gaps & Caveats heading the polish pass
+/// rewrites.
+fn doc_with_gaps_section() -> &'static str {
+    "# R\n\n## 1. Metadata\n\n| Field | Value |\n|---|---|\n| Client | Acme |\n\n\
+     ## 8. Gaps & Caveats\n\n- {{gap_1}}\n\n---\n*footer*\n"
+}
+
+/// Why: a stage that did not run must appear in the report as its own
+/// statement, not be folded into the field-level `Data gaps:` list where it
+/// would read as a missing table cell.
+/// Test: itself.
+#[test]
+fn declared_gaps_render_as_bullets() {
+    let declared = vec![
+        "Stage `jira sync` did not complete — ticket correlation is not assessed.".to_string(),
+        "trusty-analyze unreachable — no analysis pass ran for: Northwind Web.".to_string(),
+    ];
+    let out = polish_with_gaps(doc_with_gaps_section(), &declared);
+
+    for line in &declared {
+        assert!(out.contains(&format!("- {line}")), "missing {line}: {out}");
+    }
+    // The auto-collected list still renders, after the named bullets.
+    let bullet_at = out.find("- Stage `jira sync`").expect("bullet present");
+    if let Some(list_at) = out.find("Data gaps:") {
+        assert!(bullet_at < list_at, "named gaps lead the section: {out}");
+    }
+}
+
+/// Why: every existing caller passes no declared gaps; their output must not
+/// move by a single byte.
+/// Test: itself.
+#[test]
+fn empty_declared_gaps_are_byte_identical() {
+    let doc = doc_with_gaps_section();
+    assert_eq!(polish(doc), polish_with_gaps(doc, &[]));
+}
+
+/// Why: a custom template with no Gaps & Caveats heading must not silently
+/// swallow a named gap — that is the exact failure mode #5239 exists to close.
+/// Test: itself.
+#[test]
+fn declared_gaps_appended_when_template_has_no_section() {
+    let doc = "# R\n\n## 1. Metadata\n\nnothing here\n";
+    let declared = vec!["Stage `collect` did not complete.".to_string()];
+
+    let out = polish_with_gaps(doc, &declared);
+
+    assert!(out.contains("## Gaps & Caveats"), "{out}");
+    assert!(out.contains("- Stage `collect` did not complete."), "{out}");
+    // Unchanged when nothing was declared.
+    assert_eq!(polish_with_gaps(doc, &[]), polish(doc));
 }

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -20,7 +20,7 @@ use super::fill::{Scope, render, strip_leading_comment};
 use super::manifest::slugify;
 use super::metrics::Severity;
 use super::model::{ReportModel, RepositoryReport};
-use super::polish::polish;
+use super::polish::polish_with_gaps;
 use super::provenance::{self, Provenance, tag};
 use super::reporter_fill::{crate_version, fill_profile, instructions_block, set_scoring_model};
 use super::reporter_graph_datasets::{
@@ -88,7 +88,10 @@ impl Reporter {
         // pre-fill step so the header's literal `{{…}}`/BEGIN-END examples are
         // never mistaken for real placeholders by the fill engine.
         let filled = render(strip_leading_comment(template), &scope);
-        let mut out = polish(&filled);
+        // #5239: the model's named gaps (an upstream orchestrator's unassessed
+        // areas, plus any repo the live analyze fetch could not populate) lead
+        // the Gaps & Caveats section.
+        let mut out = polish_with_gaps(&filled, &model.gaps);
         // #2366 wave-4: render a ```mermaid chart under every populated dataset
         // table.  Runs AFTER polish (so it sees the omit-empty'd tables and never
         // charts a dropped/empty dataset) and BEFORE the appended status notes.

--- a/crates/trusty-review/src/report/synthesize_digest_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_digest_tests.rs
@@ -56,6 +56,7 @@ fn model_with(repos: Vec<RepositoryReport>, investigation: Option<Investigation>
         generated_date: "2026-07-10".to_string(),
         manifest_path: "m.toml".to_string(),
         repositories: repos,
+        gaps: Vec::new(),
         synthesis: None,
         benchmark: None,
         investigation,

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -172,6 +172,7 @@ fn fixture_model(findings: Vec<MetricFinding>) -> ReportModel {
             scan: None,
             metrics: Some(metrics),
         }],
+        gaps: Vec::new(),
         synthesis: None,
         benchmark: None,
         investigation: None,


### PR DESCRIPTION
`tga audit` now builds a DD manifest from the sweep and spawns `trusty-review` to render it, with every unassessed dimension named in the report rather than silently missing. Closes #5236, Closes #5238, Closes #5239, Closes #5244. Stacks on [#5303](https://github.com/bobmatnyc/trusty-tools/pull/5303).

## What changed / out of scope

New in tga: `report/dd_manifest.rs` (pure `build_dd_manifest`), `audit/review.rs` (subprocess invocation), `audit/gaps.rs`. New in trusty-review: `AnalyzeGap`/`AnalyzeFetch`/`enrich_with_analyze_gaps`, plus `gaps` fields on `ReportSection` and `ReportModel`. Out of scope: the `/quality` fetch ([#5240](https://github.com/bobmatnyc/trusty-tools/issues/5240)) and the velocity section ([#5241](https://github.com/bobmatnyc/trusty-tools/issues/5241)/[#5242](https://github.com/bobmatnyc/trusty-tools/issues/5242)) — those render as named gaps, per DOC-67's design.

## Risk / blast radius

Cross-crate. **trusty-review has a BREAKING public-API change** — `constructible_struct_adds_field` on `ReportSection.gaps` and `ReportModel.gaps`; both structs are externally constructible and `#[non_exhaustive]` is not an escape because applying it now is itself a major lint. Bumped 0.12.0 → 0.13.0, and the root `Cargo.toml` `[workspace.dependencies]` pin went `"0.12"` → `"0.13"`, which was the actual blocker for `cargo update`. tga bumped to 2.13.0 on the parent branch.

## Test evidence — rung 4

`cargo fmt --check`, `cargo check --workspace`, `cargo clippy -p tga`/`-p trusty-review` both `-D warnings`, `cargo test -p tga` → 1047 passed, `cargo test -p trusty-review` → 1567 passed, `check_line_cap.sh` 0 violations, `check_changelog_fragment.sh` both crates recorded, `check_semver.sh --crate trusty-review` clean after the bump. End-to-end smoke run: a real repo with two genuinely failing stages, exit 0, manifest plus `.md`/`.json` artifacts, and a Gaps & Caveats section naming each unassessed dimension.

## Baseline failures

None.

## Docs/changelog

Fragments in both crates.

## Review-finding disposition

Two fixed in this PR:

- **A security review found a credential-leak ordering defect, fixed here.** Stage-failure text was truncated to 160 chars BEFORE being scrubbed, and `scrub_secrets` is an exact full-value substring match — so a credential straddling the boundary survived as an unmatched prefix fragment and would have reached `manifest.toml`, then the rendered report handed to third parties. `sweep_gap_lines` now takes the credential set as a required parameter and `redacted_excerpt` scrubs before truncating, so the ordering is unreachable rather than merely correct. Regression test proven red against the pre-fix commit with fragment `ghp_STRADD`.
- **The smoke run caught a path-resolution defect unit tests could not.** tga resolves a relative repo path against its working directory; trusty-review resolves one against the manifest's directory, and the manifest lands in the output directory — so `local_path` came back `None` and the repo was silently skipped as ineligible without even being counted as a gap. Fixed with an explicit `base_dir`, covered by `relative_paths_are_anchored_to_base_dir`.

Spec deviations, tracked in [#5306](https://github.com/bobmatnyc/trusty-tools/issues/5306): DOC-67 §6 says `--output` but the real trusty-review flag is `--out`; `RepositoryEntry.path` must be absolute because the renderer scans it; [#5244](https://github.com/bobmatnyc/trusty-tools/issues/5244)'s note went into Gaps & Caveats rather than the metadata block, which has no free-form slot (§10 permits either); stage-failure reasons truncate at 160 chars with full text on stderr; and a failed *render* exits non-zero because §9's continue-on-failure governs stages within the sweep, not the absence of the deliverable itself.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
