### PR TITLE
fix(trusty-review,trusty-analyze): stop rendering refactor hints as critical and a top-N as a distribution (#5317, #5320)

### DIFF
--- a/crates/trusty-analyze/CLAUDE.md
+++ b/crates/trusty-analyze/CLAUDE.md
@@ -408,7 +408,7 @@ GET  /indexes/:id/clusters?k=N&method=bow
 Parity rule: every HTTP endpoint has an MCP tool equivalent.
 
 <!-- BEGIN GENERATED: mcp-tools -->
-The MCP server registers **19 tools** with default features, **22 tools** with `--features review`. Authoritative source: `trusty_analyze::mcp::tool_descriptors + trusty_analyze::mcp::descriptors::review_tool_descriptors` —
+The MCP server registers **20 tools** with default features, **23 tools** with `--features review`. Authoritative source: `trusty_analyze::mcp::tool_descriptors + trusty_analyze::mcp::descriptors::review_tool_descriptors` —
 this table is generated from it, not maintained by hand.
 
 | Tool | Available | Arguments | Summary |
@@ -416,6 +416,7 @@ this table is generated from it, not maintained by hand.
 | `analyze_quality` | always | `index?`, `index_id?` | Aggregate quality stats: avg cyclomatic, %A, smell count |
 | `analyzer_health` | always | — | Probe analyzer daemon liveness and version |
 | `cluster_concepts` | always | `index?`, `index_id?`, `k?`, `method?` | Group chunks into concept clusters using k-means over hashed bag-of-words embeddings |
+| `complexity_distribution` | always | `index?`, `index_id?` | Full A-F cyclomatic-complexity histogram over the whole index corpus, with the counted total. |
 | `complexity_hotspots` | always | `index?`, `index_id?`, `top_n?` | Top-N chunks ranked by cyclomatic complexity |
 | `console_metrics` | always | — | Return health and operational metrics for trusty-console polling. |
 | `deep_analysis` | always | `index_id`, `model?` | Run an LLM-augmented deep analysis pass over an index: synthesises a deterministic review report from the indexed corpus, looks up detected… |

--- a/crates/trusty-analyze/README.md
+++ b/crates/trusty-analyze/README.md
@@ -177,7 +177,7 @@ unreachable.
 ## MCP Tools
 
 <!-- BEGIN GENERATED: mcp-tools -->
-The MCP server registers **19 tools** with default features, **22 tools** with `--features review`. Authoritative source: `trusty_analyze::mcp::tool_descriptors + trusty_analyze::mcp::descriptors::review_tool_descriptors` —
+The MCP server registers **20 tools** with default features, **23 tools** with `--features review`. Authoritative source: `trusty_analyze::mcp::tool_descriptors + trusty_analyze::mcp::descriptors::review_tool_descriptors` —
 this table is generated from it, not maintained by hand.
 
 | Tool | Available | Arguments | Summary |
@@ -185,6 +185,7 @@ this table is generated from it, not maintained by hand.
 | `analyze_quality` | always | `index?`, `index_id?` | Aggregate quality stats: avg cyclomatic, %A, smell count |
 | `analyzer_health` | always | — | Probe analyzer daemon liveness and version |
 | `cluster_concepts` | always | `index?`, `index_id?`, `k?`, `method?` | Group chunks into concept clusters using k-means over hashed bag-of-words embeddings |
+| `complexity_distribution` | always | `index?`, `index_id?` | Full A-F cyclomatic-complexity histogram over the whole index corpus, with the counted total. |
 | `complexity_hotspots` | always | `index?`, `index_id?`, `top_n?` | Top-N chunks ranked by cyclomatic complexity |
 | `console_metrics` | always | — | Return health and operational metrics for trusty-console polling. |
 | `deep_analysis` | always | `index_id`, `model?` | Run an LLM-augmented deep analysis pass over an index: synthesises a deterministic review report from the indexed corpus, looks up detected… |

--- a/crates/trusty-analyze/changelog.d/5317-non-code-refactor-filter.md
+++ b/crates/trusty-analyze/changelog.d/5317-non-code-refactor-filter.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `GET /indexes/{id}/refactor-suggestions` no longer suggests refactors for files with no mapped language. Documents, FAQs, and CI workflow YAML were scored by the keyword text heuristic, graded F, and returned as critical "extract method" suggestions (#5317).

--- a/crates/trusty-analyze/changelog.d/5320-complexity-distribution-endpoint.md
+++ b/crates/trusty-analyze/changelog.d/5320-complexity-distribution-endpoint.md
@@ -1,0 +1,3 @@
+Added
+
+- `GET /indexes/{id}/complexity_distribution` and the matching `complexity_distribution` MCP tool return the full A-F cyclomatic-complexity histogram over an index, with the counted total, in a payload bounded at five rows regardless of corpus size (#5320).

--- a/crates/trusty-analyze/src/core/quality.rs
+++ b/crates/trusty-analyze/src/core/quality.rs
@@ -79,6 +79,103 @@ pub fn complexity_hotspots(chunks: &[CodeChunk], top_n: usize) -> Vec<HotspotIte
     scored
 }
 
+/// One grade band of a full-corpus complexity histogram.
+///
+/// Why: the report renderer needs a stable label per band so its chart axis and
+/// the analyzer's own A–F grading say the same thing.
+/// What: the letter grade, the human label carrying the band's cyclomatic
+/// range, and how many code chunks fall in it (zero included — an empty band is
+/// a measurement, not an absence).
+/// Test: `distribution_covers_every_band`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct DistributionBucket {
+    pub grade: String,
+    pub label: String,
+    pub count: usize,
+}
+
+/// The complete cyclomatic-complexity histogram over a chunk corpus.
+///
+/// Why: `/complexity_hotspots` answers "which are the worst N?" and can never
+/// answer "how is the codebase distributed?" — it is sorted descending and
+/// truncated, so on a large repository its top 1000 are all grade D and F. A
+/// report that renders that truncation as a distribution states, of a 1.37M-line
+/// codebase, that it contains zero simple functions (#5320). This type is the
+/// separate, exhaustive answer: every band, counted over the whole corpus.
+/// What: `total` is the number of code chunks counted (the honest percentage
+/// denominator), `skipped_non_code` the number excluded for having no mapped
+/// language, and `buckets` always carries all five bands in ascending order.
+/// Test: `distribution_covers_every_band`, `distribution_excludes_non_code`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ComplexityDistributionReport {
+    pub total: usize,
+    pub skipped_non_code: usize,
+    pub buckets: Vec<DistributionBucket>,
+}
+
+/// Human label per grade, carrying the band's cyclomatic range.
+fn grade_label(grade: ComplexityGrade) -> &'static str {
+    match grade {
+        ComplexityGrade::A => "A: simple (0-5)",
+        ComplexityGrade::B => "B: moderate (6-10)",
+        ComplexityGrade::C => "C: elevated (11-15)",
+        ComplexityGrade::D => "D: high (16-20)",
+        ComplexityGrade::F => "F: very high (>20)",
+    }
+}
+
+/// Compute the full A–F cyclomatic-complexity histogram over `chunks`.
+///
+/// Why: see [`ComplexityDistributionReport`] — this is the exhaustive
+/// counterpart to [`complexity_hotspots`], and the only source from which an
+/// honest percentage can be computed (#5320).
+/// What: scores every chunk whose file maps to a known language via
+/// [`metrics_of`], buckets it by [`ComplexityGrade::from_cyclomatic`], and
+/// returns all five bands in ascending order plus the counted and skipped
+/// totals. Non-code files (docs, workflows, lockfiles) are excluded rather than
+/// scored by the text heuristic (#5317).
+/// Test: `distribution_covers_every_band`, `distribution_excludes_non_code`.
+pub fn complexity_distribution(chunks: &[CodeChunk]) -> ComplexityDistributionReport {
+    let grades = [
+        ComplexityGrade::A,
+        ComplexityGrade::B,
+        ComplexityGrade::C,
+        ComplexityGrade::D,
+        ComplexityGrade::F,
+    ];
+    let mut counts = [0usize; 5];
+    let mut total = 0usize;
+    let mut skipped_non_code = 0usize;
+
+    for c in chunks {
+        if !crate::lang::ext_map::is_code_file(&c.file) {
+            skipped_non_code += 1;
+            continue;
+        }
+        let grade = ComplexityGrade::from_cyclomatic(metrics_of(c).cyclomatic);
+        let idx = grades
+            .iter()
+            .position(|g| *g == grade)
+            .unwrap_or(grades.len() - 1);
+        counts[idx] += 1;
+        total += 1;
+    }
+
+    ComplexityDistributionReport {
+        total,
+        skipped_non_code,
+        buckets: grades
+            .iter()
+            .zip(counts)
+            .map(|(grade, count)| DistributionBucket {
+                grade: grade.to_string(),
+                label: grade_label(*grade).to_string(),
+                count,
+            })
+            .collect(),
+    }
+}
+
 /// Return chunks that have at least one detected smell.
 pub fn smelly_chunks(chunks: &[CodeChunk]) -> Vec<CodeChunk> {
     chunks
@@ -180,6 +277,50 @@ mod tests {
         assert_eq!(v["id"], "f:1:5"); // flattened chunk field at top level
         assert!(v.get("cyclomatic").is_some());
         assert!(v.get("cognitive").is_some());
+    }
+
+    fn chunk_in(id: &str, file: &str, content: &str) -> CodeChunk {
+        let mut c = chunk(id, content);
+        c.file = file.into();
+        c
+    }
+
+    /// #5320: every band is present even when empty, and `total` is the counted
+    /// population — the two properties a percentage column needs to be honest.
+    #[test]
+    fn distribution_covers_every_band() {
+        let simple = chunk("s", "/// doc\nfn s() {}\n");
+        let mut messy_src = String::from("/// doc\nfn m(a: u32) {\n");
+        for _ in 0..30 {
+            messy_src.push_str("    if a == 1 { return; }\n");
+        }
+        messy_src.push_str("}\n");
+        let messy = chunk("m", &messy_src);
+
+        let d = complexity_distribution(&[simple, messy]);
+        assert_eq!(d.buckets.len(), 5, "all five bands render, empty included");
+        let grades: Vec<&str> = d.buckets.iter().map(|b| b.grade.as_str()).collect();
+        assert_eq!(grades, vec!["A", "B", "C", "D", "F"]);
+        assert_eq!(d.total, 2);
+        assert_eq!(d.skipped_non_code, 0);
+        assert_eq!(
+            d.buckets.iter().map(|b| b.count).sum::<usize>(),
+            d.total,
+            "band counts must sum to the stated denominator"
+        );
+        assert_eq!(d.buckets[0].count, 1, "the trivial fn grades A");
+        assert_eq!(d.buckets[4].count, 1, "the 30-branch fn grades F");
+    }
+
+    /// #5317: a CHANGELOG has no cyclomatic complexity — scoring it with the
+    /// text heuristic is what put `CHANGELOG.md` in a report's RED band.
+    #[test]
+    fn distribution_excludes_non_code() {
+        let doc = chunk_in("d", "/repo/CHANGELOG.md", "# 1.0\n- if this then that\n");
+        let code = chunk_in("c", "/repo/src/lib.rs", "/// doc\nfn f() {}\n");
+        let d = complexity_distribution(&[doc, code]);
+        assert_eq!(d.total, 1, "only the .rs chunk is counted");
+        assert_eq!(d.skipped_non_code, 1);
     }
 
     #[test]

--- a/crates/trusty-analyze/src/lang/ext_map.rs
+++ b/crates/trusty-analyze/src/lang/ext_map.rs
@@ -162,6 +162,22 @@ pub fn lang_for_linter(path: &str) -> Option<&'static str> {
         .map(|e| e.linter)
 }
 
+/// Whether `path` is a source file in one of the languages this analyzer parses.
+///
+/// Why: complexity, smells, and refactor suggestions are only meaningful for
+/// code. `compute_complexity_for` falls back to a whitespace/keyword text
+/// heuristic for an unrecognized extension, which scores a `CHANGELOG.md` or a
+/// `release.yml` as grade F and emits "Extract method" against a document that
+/// has no method to extract (#5317). Callers gate on this so a non-code file
+/// never enters a code-quality result set in the first place.
+/// What: true when [`lang_for_extension`] resolves to a real language tag —
+/// i.e. the path matched an [`EXT_MAP`] row — and false for `"unknown"`.
+/// Test: `is_code_file_rejects_docs_and_configs`,
+/// `is_code_file_accepts_mapped_source_extensions`.
+pub fn is_code_file(path: &str) -> bool {
+    lang_for_extension(path) != "unknown"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,6 +290,27 @@ mod tests {
     fn lang_for_linter_unknown_is_none() {
         assert_eq!(lang_for_linter("Makefile"), None);
         assert_eq!(lang_for_linter("data.json"), None);
+    }
+
+    // ── is_code_file (#5317) ─────────────────────────────────────────────────
+
+    #[test]
+    fn is_code_file_rejects_docs_and_configs() {
+        // #5317: these three appeared as the Component of an "Extract method"
+        // finding in the RED band of two generated due-diligence reports.
+        assert!(!is_code_file("/repo/CHANGELOG.md"));
+        assert!(!is_code_file("/repo/FAQ.md"));
+        assert!(!is_code_file("/repo/.github/workflows/release.yml"));
+        assert!(!is_code_file("Makefile"));
+        assert!(!is_code_file("Cargo.toml"));
+    }
+
+    #[test]
+    fn is_code_file_accepts_mapped_source_extensions() {
+        assert!(is_code_file("src/main.rs"));
+        assert!(is_code_file("App.tsx"));
+        assert!(is_code_file("mod.py"));
+        assert!(is_code_file("HEADER.H"));
     }
 
     // ── table integrity ──────────────────────────────────────────────────────

--- a/crates/trusty-analyze/src/mcp/descriptors.rs
+++ b/crates/trusty-analyze/src/mcp/descriptors.rs
@@ -38,6 +38,17 @@ pub fn base_tool_descriptors() -> Value {
             }
         },
         {
+            "name": "complexity_distribution",
+            "description": "Full A-F cyclomatic-complexity histogram over the whole index corpus, with the counted total. Unlike complexity_hotspots (a descending top-N), this is exhaustive, so its counts are the only honest denominator for a percentage.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "index": { "type": "string" },
+                    "index_id": { "type": "string" }
+                }
+            }
+        },
+        {
             "name": "find_smells",
             "description": "Chunks with at least one detected code smell. Results are paginated (default limit 500) and content is omitted by default to keep responses bounded. Use limit/offset to page through large result sets; set omit_content=false to include raw source text.",
             "inputSchema": {

--- a/crates/trusty-analyze/src/mcp/mod.rs
+++ b/crates/trusty-analyze/src/mcp/mod.rs
@@ -336,6 +336,7 @@ impl AnalyzerMcpServer {
     async fn call_tool(&self, tool: &str, args: &Value) -> Result<Value, DispatchError> {
         match tool {
             "complexity_hotspots" => self.handle_complexity_hotspots(args).await,
+            "complexity_distribution" => self.handle_complexity_distribution(args).await,
             "find_smells" => self.handle_find_smells(args).await,
             "analyze_quality" => self.handle_analyze_quality(args).await,
             "run_diagnostics" => self.handle_run_diagnostics(args).await,
@@ -374,6 +375,15 @@ impl AnalyzerMcpServer {
             "/indexes/{index_id}/complexity_hotspots?top_n={top_n}"
         ))
         .await
+    }
+
+    /// #5320: the exhaustive counterpart to `complexity_hotspots` — forwards to
+    /// `GET /indexes/{id}/complexity_distribution`, which returns all five A–F
+    /// bands plus the counted total.
+    async fn handle_complexity_distribution(&self, args: &Value) -> Result<Value, DispatchError> {
+        let index_id = index_id_or_default(args);
+        self.get(&format!("/indexes/{index_id}/complexity_distribution"))
+            .await
     }
 
     async fn handle_find_smells(&self, args: &Value) -> Result<Value, DispatchError> {

--- a/crates/trusty-analyze/src/mcp/tests.rs
+++ b/crates/trusty-analyze/src/mcp/tests.rs
@@ -32,6 +32,8 @@ async fn tools_list_contains_full_surface() {
         .collect();
     for required in [
         "complexity_hotspots",
+        // #5320 — the parity partner of the new HTTP distribution endpoint.
+        "complexity_distribution",
         "find_smells",
         "analyze_quality",
         "run_diagnostics",

--- a/crates/trusty-analyze/src/service/handlers/analysis.rs
+++ b/crates/trusty-analyze/src/service/handlers/analysis.rs
@@ -126,6 +126,34 @@ pub async fn complexity_hotspots(
     })))
 }
 
+/// `GET /indexes/{id}/complexity_distribution` — the full A–F histogram over
+/// the whole corpus.
+///
+/// Why: `/complexity_hotspots` is a descending, truncated top-N; a consumer that
+/// buckets its response is describing the worst N functions, not the codebase.
+/// On a large repository that reads as "zero simple functions", which is what
+/// reached a due-diligence report (#5320). This endpoint answers the
+/// distribution question exhaustively and returns a payload bounded at five
+/// rows regardless of corpus size, so no caller has to trade honesty for
+/// bandwidth.
+/// What: delegates to `quality::complexity_distribution`, which counts only
+/// files with a mapped language and reports the counted total plus the number
+/// of non-code chunks it skipped.
+/// Test: `super::super::tests::complexity_distribution_endpoint_returns_all_bands`.
+pub async fn complexity_distribution(
+    State(state): State<Arc<AnalyzerAppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let chunks = fetch_chunks(&state, &id).await?;
+    let report = quality::complexity_distribution(&chunks);
+    Ok(Json(serde_json::json!({
+        "index_id": id,
+        "total": report.total,
+        "skipped_non_code": report.skipped_non_code,
+        "buckets": report.buckets,
+    })))
+}
+
 /// `GET /indexes/{id}/smells` — return chunks with at least one detected smell.
 ///
 /// Why: #917 — the unbounded result set (full `content` per chunk) caused MCP
@@ -204,6 +232,13 @@ pub async fn refactor_suggestions(
             if chunk.file != file {
                 continue;
             }
+        }
+        // #5317: "extract method" against a CHANGELOG.md is not a suggestion a
+        // caller can act on. Without a mapped language `compute_complexity_for`
+        // falls back to the keyword text heuristic, which grades prose F and
+        // emitted refactor suggestions for docs, FAQs, and CI workflow YAML.
+        if !crate::lang::ext_map::is_code_file(&chunk.file) {
+            continue;
         }
         let lang = super::lang_for_extension(&chunk.file);
         let metrics = compute_complexity_for(&chunk.content, lang);

--- a/crates/trusty-analyze/src/service/routes.rs
+++ b/crates/trusty-analyze/src/service/routes.rs
@@ -79,6 +79,10 @@ pub fn build_router_with_self_origins(
             "/indexes/{id}/complexity_hotspots",
             get(handlers::analysis::complexity_hotspots),
         )
+        .route(
+            "/indexes/{id}/complexity_distribution",
+            get(handlers::analysis::complexity_distribution),
+        )
         .route("/indexes/{id}/smells", get(handlers::analysis::smells))
         .route(
             "/indexes/{id}/refactor-suggestions",

--- a/crates/trusty-analyze/src/service/tests.rs
+++ b/crates/trusty-analyze/src/service/tests.rs
@@ -567,6 +567,135 @@ async fn spawn_empty_chunk_search() -> String {
     format!("http://{addr}")
 }
 
+/// Stand-in trusty-search serving one code chunk and one Markdown chunk.
+///
+/// Why (#5317/#5320): both defects are about what the analyzer does with a
+/// non-code file and how a caller reads a truncated result, and neither is
+/// observable without a corpus that mixes the two.
+/// What: binds an ephemeral loopback port answering
+/// `GET /indexes/{id}/chunks` with a `.rs` chunk holding 30 branches (grade F)
+/// and a `CHANGELOG.md` chunk of prose.
+/// Test: used by `complexity_distribution_endpoint_returns_all_bands` and
+/// `refactor_suggestions_skip_non_code_files`.
+async fn spawn_mixed_corpus_search() -> String {
+    let mut branchy = String::from("/// doc\nfn m(a: u32) {\n");
+    for _ in 0..30 {
+        branchy.push_str("    if a == 1 { return; }\n");
+    }
+    branchy.push_str("}\n");
+    // Release-note prose in the shape that actually reached a report's RED
+    // band: enough conditional English for the keyword text heuristic — the
+    // fallback for an unmapped extension — to grade it as complex code.
+    let mut changelog_prose = String::from("# Changelog\n\n## 1.0\n");
+    for i in 0..30 {
+        changelog_prose.push_str(&format!(
+            "- Fixed a case where, if the cache was cold and the token had expired, \
+             the retry loop would spin for each queued item while the lock was held ({i})\n"
+        ));
+    }
+    let body = serde_json::json!({ "chunks": [
+        {
+            "id": "code:1", "file": "/repo/src/lib.rs", "start_line": 1, "end_line": 40,
+            "content": branchy, "score": 0.0, "match_reason": "test"
+        },
+        {
+            "id": "doc:1", "file": "/repo/CHANGELOG.md", "start_line": 1, "end_line": 40,
+            "content": changelog_prose,
+            "score": 0.0, "match_reason": "test"
+        }
+    ]});
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    // The client pages the corpus with a concurrent window, so the stub must
+    // honour `offset` — answering every offset with the same page would
+    // multiply the corpus by the window width.
+    let stub = Router::new().route(
+        "/indexes/{id}/chunks",
+        axum::routing::get(
+            move |axum::extract::Query(q): axum::extract::Query<HashMap<String, String>>| {
+                let body = body.clone();
+                async move {
+                    let first = q.get("offset").map(|o| o == "0").unwrap_or(true);
+                    axum::response::Json(if first {
+                        body
+                    } else {
+                        serde_json::json!({ "chunks": [] })
+                    })
+                }
+            },
+        ),
+    );
+    tokio::spawn(async move {
+        axum::serve(listener, stub).await.ok();
+    });
+    format!("http://{addr}")
+}
+
+/// Why (#5320): the report's §7 complexity table was a bucketed top-N hotspot
+/// slice rendered as a distribution, so a 1.37M-line repository reported zero
+/// simple functions. The endpoint that replaces it must answer with every band
+/// and with the denominator those percentages are shares of.
+/// What: asserts all five A–F bands are present, that the counts sum to the
+/// stated `total`, and that the Markdown chunk is reported as skipped rather
+/// than silently counted.
+/// Test: this test.
+#[tokio::test]
+async fn complexity_distribution_endpoint_returns_all_bands() {
+    let tmp = TempDir::new().unwrap();
+    let search_base = spawn_mixed_corpus_search().await;
+    let app = build_router(state_in_with_search(tmp.path(), &search_base));
+
+    let (status, body) = json_get(app, "/indexes/myidx/complexity_distribution").await;
+    assert_eq!(status, StatusCode::OK);
+
+    let buckets = body["buckets"].as_array().expect("buckets array");
+    let grades: Vec<&str> = buckets
+        .iter()
+        .map(|b| b["grade"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        grades,
+        vec!["A", "B", "C", "D", "F"],
+        "every band renders, empty included: {body}"
+    );
+    assert_eq!(body["total"], 1, "only the .rs chunk is counted: {body}");
+    assert_eq!(body["skipped_non_code"], 1, "the .md chunk is skipped");
+    let summed: u64 = buckets.iter().map(|b| b["count"].as_u64().unwrap()).sum();
+    assert_eq!(
+        summed, 1,
+        "band counts must sum to the stated denominator: {body}"
+    );
+}
+
+/// Why (#5317): `CHANGELOG.md`, `FAQ.md`, and `.github/workflows/release.yml`
+/// were rendered as the Component of an "Extract method" finding, because the
+/// text-heuristic fallback grades prose F.
+/// What: asserts every returned suggestion names a file with a mapped language,
+/// and that the code chunk itself still produces one — the filter must not
+/// silence real signal.
+/// Test: this test.
+#[tokio::test]
+async fn refactor_suggestions_skip_non_code_files() {
+    let tmp = TempDir::new().unwrap();
+    let search_base = spawn_mixed_corpus_search().await;
+    let app = build_router(state_in_with_search(tmp.path(), &search_base));
+
+    let (status, body) = json_get(app, "/indexes/myidx/refactor-suggestions").await;
+    assert_eq!(status, StatusCode::OK);
+    let suggestions = body["suggestions"].as_array().expect("suggestions array");
+    assert!(
+        suggestions
+            .iter()
+            .all(|s| s["file"].as_str().unwrap().ends_with(".rs")),
+        "a refactor suggestion may only name a code file: {body}"
+    );
+    assert_eq!(
+        suggestions.len(),
+        1,
+        "the grade-F .rs chunk must still be suggested: {body}"
+    );
+}
+
 async fn graph_overlay_header(app: Router, index_id: &str) -> (StatusCode, String) {
     let resp = app
         .oneshot(

--- a/crates/trusty-review/changelog.d/5317-red-band-mapping.md
+++ b/crates/trusty-review/changelog.d/5317-red-band-mapping.md
@@ -1,0 +1,3 @@
+Fixed
+
+- Refactor suggestions from trusty-analyze no longer render in the report's RED/CRITICAL band, and analyze-derived findings now carry the daemon's own rationale and suggested action instead of showing `not stated in source data` in every prose slot. A finding that would still render as a bare title and path is dropped, and a repository whose analysis ran with no external static-analysis tool installed is named under Gaps & Caveats so an empty RED band reads as unassessed rather than clean (#5317).

--- a/crates/trusty-review/changelog.d/5320-full-complexity-distribution.md
+++ b/crates/trusty-review/changelog.d/5320-full-complexity-distribution.md
@@ -1,0 +1,3 @@
+Fixed
+
+- The §7 complexity distribution is fetched from trusty-analyze's new full-corpus histogram instead of being bucketed from a truncated top-1000 hotspot list, so its bands and percentages describe the whole codebase. On a daemon that serves no histogram the table is omitted and the reason stated under Gaps & Caveats, rather than rendering shares of a truncation as if they were shares of the codebase (#5320).

--- a/crates/trusty-review/src/report/analyze_adapter.rs
+++ b/crates/trusty-review/src/report/analyze_adapter.rs
@@ -33,17 +33,6 @@ use super::metrics::{
 
 // ─── Tunables ──────────────────────────────────────────────────────────────
 
-/// How many complexity hotspots to request when building the distribution.
-///
-/// Why: `/complexity_hotspots` returns the top-N chunks ranked by descending
-/// cyclomatic complexity; a large N gives a representative distribution. The
-/// buckets therefore describe the N MOST complex functions, not the entire
-/// corpus (a documented, honest sampling limit — the endpoint exposes no
-/// full-corpus histogram).
-/// What: passed as `?top_n=` to the hotspots endpoint.
-/// Test: the value is not asserted; mapping tests drive fixtures directly.
-const HOTSPOT_SAMPLE: usize = 1000;
-
 /// Per-request HTTP timeout for analyze fetches (fail-open on timeout).
 const FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -92,19 +81,30 @@ struct IndexInfo {
     id: String,
 }
 
-/// `GET /indexes/{id}/complexity_hotspots` envelope (post-#2446).
+/// `GET /indexes/{id}/complexity_distribution` envelope (#5320).
+///
+/// Why: the exhaustive A–F histogram over the whole corpus. Its predecessor
+/// here bucketed a `complexity_hotspots` top-N, which is sorted descending and
+/// truncated — on a large repository the top 1000 are all grade D and F, so the
+/// report stated that a 1.37M-line codebase contains no simple functions.
+/// What: `total` is the counted code-chunk population (the percentage
+/// denominator the renderer needs) and `buckets` carries every band.
+/// Test: `analyze_adapter_tests.rs::distribution_maps_every_band`.
 #[derive(Debug, Deserialize)]
-struct HotspotsEnvelope {
+struct DistributionEnvelope {
     #[serde(default)]
-    hotspots: Vec<WireHotspot>,
+    total: u64,
+    #[serde(default)]
+    buckets: Vec<WireBucket>,
 }
 
-/// One hotspot — the flattened `CodeChunk` plus the #2446 complexity numbers.
-/// Only the fields the mapping needs are declared; the rest are ignored.
+/// One A–F band of the full distribution.
 #[derive(Debug, Deserialize)]
-struct WireHotspot {
+struct WireBucket {
     #[serde(default)]
-    cyclomatic: u32,
+    label: String,
+    #[serde(default)]
+    count: u64,
 }
 
 /// `GET /indexes/{id}/diagnostics` envelope.
@@ -112,6 +112,11 @@ struct WireHotspot {
 struct DiagnosticsEnvelope {
     #[serde(default)]
     diagnostics: Vec<WireDiagnostic>,
+    /// Which external linters actually ran. Empty means none was installed —
+    /// which is why the RED band can be empty without the code being clean
+    /// (#5317).
+    #[serde(default)]
+    tools_run: Vec<String>,
 }
 
 /// One external-tool diagnostic (`ToolDiagnostic`).
@@ -126,6 +131,9 @@ struct WireDiagnostic {
     severity: String,
     #[serde(default)]
     code: Option<String>,
+    /// The linter's own message. Verbatim tool output, not synthesis.
+    #[serde(default)]
+    message: String,
 }
 
 /// `GET /indexes/{id}/refactor-suggestions` envelope.
@@ -148,6 +156,13 @@ struct WireRefactor {
     /// `low` | `medium` | `high` | `critical` (lowercase).
     #[serde(default)]
     severity: String,
+    /// Why the rule fired, e.g. `cyclomatic complexity 31 (grade F)`.
+    #[serde(default)]
+    rationale: String,
+    /// The concrete action, e.g. `Extract the body of 'f' into 2-3 smaller
+    /// functions`.
+    #[serde(default)]
+    suggested_action: String,
 }
 
 // ─── Severity mapping (BINDING convention, epic #2445) ───────────────────────
@@ -172,57 +187,51 @@ fn map_diagnostic_severity(s: &str) -> Severity {
 /// Map a trusty-analyze refactor severity onto the report's RED/AMBER/GREEN
 /// band.
 ///
-/// Why: refactor suggestions use a `low/medium/high/critical` scale; the same
-/// balanced convention applies.
-/// What (convention): `critical → Red`, `high → Amber`, `medium`/`low`/unknown
-/// → `Green`.
-/// Test: `severity_map_refactors` in the tests module.
+/// Why (#5317): a refactor suggestion is not a defect. Its severity is derived
+/// from the chunk's complexity grade alone (`Severity::from_grade` in
+/// trusty-analyze), so `critical` there means "grade F", not "a critical risk".
+/// Routing that into RED put twenty "Extract method" entries into the most
+/// severe band of an acquirer-facing report, which reads code hygiene as
+/// business risk. The RED band is reserved for defect-class findings — external
+/// static-analysis errors — so a refactor suggestion tops out at AMBER however
+/// severe the analyzer graded it.
+/// What (convention): `critical`/`high` → `Amber`; `medium`, `low`, and unknown
+/// → `Green` (dropped from the rendered bands).
+/// Test: `severity_map_refactors`, `refactor_never_reaches_red`.
 fn map_refactor_severity(s: &str) -> Severity {
     match s.trim().to_ascii_lowercase().as_str() {
-        "critical" | "error" => Severity::Red,
-        "high" | "warning" => Severity::Amber,
+        "critical" | "error" | "high" | "warning" => Severity::Amber,
         _ => Severity::Green,
     }
 }
 
-// ─── Complexity bucketing (mirrors trusty-analyze ComplexityGrade) ───────────
+// ─── Complexity distribution ─────────────────────────────────────────────────
 
-/// Compute the cyclomatic-complexity distribution from per-hotspot cyclomatic
-/// counts, using the same bands as trusty-analyze's `ComplexityGrade`.
+/// Map the daemon's full A–F histogram onto the report's bucket list.
 ///
-/// Why: the §7 chart needs labelled buckets; trusty-analyze exposes no
-/// full-corpus histogram, so the adapter buckets the hotspot sample client-side
-/// against the canonical grade thresholds so the labels line up with the
-/// analyzer's own A–F grading.
-/// What (threshold table): `A: 0–5`, `B: 6–10`, `C: 11–15`, `D: 16–20`,
-/// `F: >20` — one bucket per band, in ascending order, empty buckets omitted so
-/// a sparse sample yields a compact chart.
-/// Test: `buckets_follow_grade_thresholds` asserts each boundary lands in the
-/// right band.
-fn complexity_buckets(cyclomatics: &[u32]) -> ComplexityDistribution {
-    // Ordered bands: (label, inclusive-lower, inclusive-upper).  u32::MAX is the
-    // open upper bound for the F band.
-    let bands: [(&str, u32, u32); 5] = [
-        ("A: simple (0-5)", 0, 5),
-        ("B: moderate (6-10)", 6, 10),
-        ("C: elevated (11-15)", 11, 15),
-        ("D: high (16-20)", 16, 20),
-        ("F: very high (>20)", 21, u32::MAX),
-    ];
-    let buckets = bands
-        .iter()
-        .filter_map(|(label, lo, hi)| {
-            let count = cyclomatics
-                .iter()
-                .filter(|c| **c >= *lo && **c <= *hi)
-                .count() as u64;
-            (count > 0).then(|| ComplexityBucket {
-                label: (*label).to_string(),
-                count,
+/// Why (#5320): the distribution is fetched whole and rendered whole. The
+/// percentage column the renderer computes is a share of the bucket sum, so the
+/// sum must be the counted population — which it is, exactly because this is
+/// the exhaustive histogram rather than a truncated top-N sample.
+/// What: preserves the daemon's ascending band order and its zero-count bands
+/// (an empty band is a measurement); returns an empty distribution when the
+/// envelope carried no counted chunks, which the renderer omits rather than
+/// charting a row of zeroes.
+/// Test: `distribution_maps_every_band`, `empty_distribution_maps_to_nothing`.
+fn map_distribution(env: &DistributionEnvelope) -> ComplexityDistribution {
+    if env.total == 0 {
+        return ComplexityDistribution::default();
+    }
+    ComplexityDistribution {
+        buckets: env
+            .buckets
+            .iter()
+            .map(|b| ComplexityBucket {
+                label: b.label.clone(),
+                count: b.count,
             })
-        })
-        .collect();
-    ComplexityDistribution { buckets }
+            .collect(),
+    }
 }
 
 // ─── Finding synthesis (prose-free, deterministic) ───────────────────────────
@@ -236,8 +245,8 @@ fn complexity_buckets(cyclomatics: &[u32]) -> ComplexityDistribution {
 /// What: `title` = the rule code when present, else a synthesised
 /// `"{tool} diagnostic"`; `category` = the producing tool (a stable provenance
 /// category, not the prose message); `component` = the file; `severity` via the
-/// diagnostic map. The human message is intentionally dropped (prose belongs to
-/// M2 synthesis).
+/// diagnostic map; `description` = the linter's own message, verbatim (#5317 —
+/// dropping it left every rendered prose slot reading the honesty marker).
 /// Test: `diagnostic_finding_synthesises_title` and `..._drops_green`.
 fn diagnostic_finding(d: &WireDiagnostic) -> Option<MetricFinding> {
     let severity = map_diagnostic_severity(&d.severity);
@@ -260,6 +269,8 @@ fn diagnostic_finding(d: &WireDiagnostic) -> Option<MetricFinding> {
             d.tool.clone()
         },
         component: d.file.clone(),
+        description: d.message.clone(),
+        remediation: String::new(),
     })
 }
 
@@ -267,13 +278,16 @@ fn diagnostic_finding(d: &WireDiagnostic) -> Option<MetricFinding> {
 /// to GREEN (omitted, as above).
 ///
 /// Why: high/critical refactor suggestions are actionable maintainability
-/// findings that belong in the RED/AMBER bands even with no synthesis.
+/// findings that belong in the AMBER band even with no synthesis — never RED,
+/// see [`map_refactor_severity`].
 /// What: `title` = the humanised refactor type plus the function name when
 /// known (e.g. `"Extract method — parse_config"`); `category` =
 /// `"maintainability"` (refactors are maintainability by construction);
-/// `component` = the file; `severity` via the refactor map. Prose (`rationale`,
-/// `suggested_action`) is dropped.
-/// Test: `refactor_finding_synthesises_title`.
+/// `component` = the file; `severity` via the refactor map; `description` =
+/// the analyzer's `rationale` and `remediation` = its `suggested_action`, both
+/// verbatim (#5317 — dropping them is what made the entries contentless).
+/// Test: `refactor_finding_synthesises_title`,
+/// `refactor_finding_carries_rationale_and_action`.
 fn refactor_finding(r: &WireRefactor) -> Option<MetricFinding> {
     let severity = map_refactor_severity(&r.severity);
     if severity == Severity::Green {
@@ -289,6 +303,8 @@ fn refactor_finding(r: &WireRefactor) -> Option<MetricFinding> {
         severity,
         category: "maintainability".to_string(),
         component: r.file.clone(),
+        description: r.rationale.clone(),
+        remediation: r.suggested_action.clone(),
     })
 }
 
@@ -319,32 +335,35 @@ fn humanise_refactor_type(t: &str) -> String {
 
 // ─── Pure mapping ────────────────────────────────────────────────────────────
 
-/// Map the three fetched analyze datasets onto a v0 [`AnalyzeMetrics`].
+/// Map the fetched analyze datasets onto a v0 [`AnalyzeMetrics`].
 ///
 /// Why: a single pure function makes the whole adapter unit-testable against
 /// fixture JSON with no live daemon — the HTTP layer only feeds it deserialized
 /// wire values.
-/// What: leaves `loc`/`counts` empty (the built-in scanner owns those);
-/// computes `complexity.buckets` from the hotspot cyclomatic sample; builds
-/// `findings` from RED/AMBER diagnostics then refactor suggestions.
-/// `schema_version` is tagged so the JSON twin records its provenance.
-/// Test: `map_metrics_populates_complexity_and_findings`.
+/// What: leaves `loc`/`counts` empty (the built-in scanner owns those); takes
+/// `complexity` from the daemon's full histogram; builds `findings` from
+/// RED/AMBER diagnostics then refactor suggestions, dropping any that would
+/// render as a title and a path with no stated observation or action
+/// ([`MetricFinding::is_contentless`], #5317). `schema_version` is tagged so the
+/// JSON twin records its provenance.
+/// Test: `map_metrics_populates_complexity_and_findings`,
+/// `contentless_findings_are_dropped`.
 fn map_metrics(
-    hotspots: &[WireHotspot],
+    distribution: Option<&DistributionEnvelope>,
     diagnostics: &[WireDiagnostic],
     refactors: &[WireRefactor],
 ) -> AnalyzeMetrics {
-    let cyclomatics: Vec<u32> = hotspots.iter().map(|h| h.cyclomatic).collect();
     let mut findings: Vec<MetricFinding> = Vec::new();
     findings.extend(diagnostics.iter().filter_map(diagnostic_finding));
     findings.extend(refactors.iter().filter_map(refactor_finding));
+    findings.retain(|f| !f.is_contentless());
 
     AnalyzeMetrics {
         schema_version: "analyze-live-v0".to_string(),
         repository: String::new(),
         loc: Default::default(),
         counts: Default::default(),
-        complexity: complexity_buckets(&cyclomatics),
+        complexity: distribution.map(map_distribution).unwrap_or_default(),
         findings,
     }
 }
@@ -377,8 +396,58 @@ pub trait AnalyzeMetricsSource: Send + Sync {
     /// Test: `analyze_adapter_tests.rs::default_fetch_named_reports_unavailable`.
     async fn fetch_named(&self, index_id: &str) -> AnalyzeFetch {
         match self.fetch(index_id).await {
-            Some(m) => AnalyzeFetch::Fetched(Box::new(m)),
+            Some(m) => AnalyzeFetch::Fetched {
+                metrics: Box::new(m),
+                caveats: Vec::new(),
+            },
             None => AnalyzeFetch::Missing(AnalyzeGap::Unavailable),
+        }
+    }
+}
+
+/// A dimension the daemon answered incompletely, for one repository (#5317,
+/// #5320).
+///
+/// Why: a fetch that succeeds is not the same as a fetch that answered
+/// everything, and the difference is invisible on the page. An empty RED band
+/// because no linter was installed reads exactly like a clean codebase; a
+/// missing complexity table reads like a rendering slip. Both are facts the
+/// report owes its reader, and both travel the same Gaps & Caveats path
+/// [`AnalyzeGap`] already uses.
+/// What: one variant per condition the fetch can distinguish, each with a fixed
+/// report-facing phrase carrying no run-specific detail.
+/// Test: `analyze_adapter_tests.rs::caveat_labels_are_stable`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum AnalyzeCaveat {
+    /// The daemon serves no full-corpus histogram, so the §7 complexity
+    /// distribution was left out rather than filled from a truncated top-N.
+    ComplexityDistributionUnavailable,
+    /// No external static-analysis tool was installed, so nothing could
+    /// populate the RED/defect band.
+    NoStaticAnalysisTools,
+}
+
+impl AnalyzeCaveat {
+    /// The report-facing sentence for this caveat.
+    ///
+    /// Why: read by a stranger to this toolchain, so it names the condition and
+    /// what it means for the section, not the variant.
+    /// What: a fixed string per variant — deterministic across runs.
+    /// Test: `analyze_adapter_tests.rs::caveat_labels_are_stable`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ComplexityDistributionUnavailable => {
+                "complexity distribution not available — the analysis daemon serves no \
+                 full-corpus histogram, and the truncated top-N hotspot sample it does serve \
+                 is not a distribution. The §7 complexity table is omitted rather than \
+                 filled with shares of a truncation"
+            }
+            Self::NoStaticAnalysisTools => {
+                "no external static-analysis tool was available to the analysis daemon — the \
+                 RED/CRITICAL band is populated only from such tools, so an empty band here \
+                 means unassessed, not clean"
+            }
         }
     }
 }
@@ -431,8 +500,14 @@ impl AnalyzeGap {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum AnalyzeFetch {
-    /// Live metrics were fetched and mapped.
-    Fetched(Box<AnalyzeMetrics>),
+    /// Live metrics were fetched and mapped, along with any dimension the
+    /// daemon could not answer completely (#5317, #5320).
+    Fetched {
+        /// The mapped metrics.
+        metrics: Box<AnalyzeMetrics>,
+        /// Dimensions answered incompletely; empty on a full answer.
+        caveats: Vec<AnalyzeCaveat>,
+    },
     /// No metrics; this is the reason, for the report's gap list.
     Missing(AnalyzeGap),
 }
@@ -507,9 +582,18 @@ impl HttpAnalyzeMetricsSource {
     }
 
     /// The success path behind [`AnalyzeMetricsSource::fetch`]: probe readiness,
-    /// pull the three datasets, and map them. Returns `Err` on any failure; the
+    /// pull the datasets, and map them. Returns `Err` on any failure; the
     /// public `fetch` swallows it to `None`.
-    async fn try_fetch(&self, index_id: &str) -> AdapterResult<Option<AnalyzeMetrics>> {
+    ///
+    /// The complexity distribution is the one dataset whose absence is
+    /// tolerated rather than fatal (#5320): a daemon predating
+    /// `/complexity_distribution` answers 404, and the honest response to that
+    /// is to omit the §7 table and say so, not to abandon the findings that DID
+    /// come back.
+    async fn try_fetch(
+        &self,
+        index_id: &str,
+    ) -> AdapterResult<Option<(AnalyzeMetrics, Vec<AnalyzeCaveat>)>> {
         if !self.index_served(index_id).await? {
             tracing::warn!(
                 index_id,
@@ -522,21 +606,42 @@ impl HttpAnalyzeMetricsSource {
             );
             return Ok(None);
         }
-        let hotspots: HotspotsEnvelope = self
-            .get_json(&format!(
-                "/indexes/{index_id}/complexity_hotspots?top_n={HOTSPOT_SAMPLE}"
-            ))
-            .await?;
+        let mut caveats: Vec<AnalyzeCaveat> = Vec::new();
+
+        let distribution: Option<DistributionEnvelope> = match self
+            .get_json(&format!("/indexes/{index_id}/complexity_distribution"))
+            .await
+        {
+            Ok(d) => Some(d),
+            Err(e) => {
+                tracing::warn!(index_id, error = %e, "--analyze: no complexity distribution");
+                eprintln!(
+                    "[trusty-review report] --analyze: '{index_id}' complexity distribution \
+                     unavailable ({e}); the §7 table is omitted"
+                );
+                caveats.push(AnalyzeCaveat::ComplexityDistributionUnavailable);
+                None
+            }
+        };
+
         let diagnostics: DiagnosticsEnvelope = self
             .get_json(&format!("/indexes/{index_id}/diagnostics"))
             .await?;
+        if diagnostics.tools_run.is_empty() {
+            caveats.push(AnalyzeCaveat::NoStaticAnalysisTools);
+        }
+
         let refactors: RefactorEnvelope = self
             .get_json(&format!("/indexes/{index_id}/refactor-suggestions"))
             .await?;
-        Ok(Some(map_metrics(
-            &hotspots.hotspots,
-            &diagnostics.diagnostics,
-            &refactors.suggestions,
+
+        Ok(Some((
+            map_metrics(
+                distribution.as_ref(),
+                &diagnostics.diagnostics,
+                &refactors.suggestions,
+            ),
+            caveats,
         )))
     }
 }
@@ -545,7 +650,7 @@ impl HttpAnalyzeMetricsSource {
 impl AnalyzeMetricsSource for HttpAnalyzeMetricsSource {
     async fn fetch(&self, index_id: &str) -> Option<AnalyzeMetrics> {
         match self.fetch_named(index_id).await {
-            AnalyzeFetch::Fetched(m) => Some(*m),
+            AnalyzeFetch::Fetched { metrics, .. } => Some(*metrics),
             AnalyzeFetch::Missing(_) => None,
         }
     }
@@ -554,7 +659,10 @@ impl AnalyzeMetricsSource for HttpAnalyzeMetricsSource {
     /// produced an empty result so the report can say so.
     async fn fetch_named(&self, index_id: &str) -> AnalyzeFetch {
         match self.try_fetch(index_id).await {
-            Ok(Some(m)) => AnalyzeFetch::Fetched(Box::new(m)),
+            Ok(Some((metrics, caveats))) => AnalyzeFetch::Fetched {
+                metrics: Box::new(metrics),
+                caveats,
+            },
             Ok(None) => AnalyzeFetch::Missing(AnalyzeGap::NotIndexed),
             Err(e) => {
                 tracing::warn!(
@@ -622,12 +730,14 @@ pub async fn enrich_with_analyze(
 /// renders from the built-in scan.
 /// What: walks the same repositories [`enrich_with_analyze`] does, using
 /// [`AnalyzeMetricsSource::fetch_named`]; returns at most one line per
-/// [`AnalyzeGap`] kind, each naming the affected repositories in model order so
-/// two runs over the same state produce identical lines. Repositories with a
-/// declared metrics file, and remote entries, are skipped — neither is a gap.
-/// Returns an empty vec when every eligible repository was populated.
+/// [`AnalyzeGap`] kind and one per [`AnalyzeCaveat`] kind, each naming the
+/// affected repositories in model order so two runs over the same state produce
+/// identical lines. Repositories with a declared metrics file, and remote
+/// entries, are skipped — neither is a gap. Returns an empty vec when every
+/// eligible repository was populated completely.
 /// Test: `analyze_adapter_tests.rs::{enrich_names_unreachable_repositories,
-/// enrich_reports_no_gaps_when_every_repo_is_populated}`.
+/// enrich_reports_no_gaps_when_every_repo_is_populated,
+/// enrich_reports_caveats_for_partially_answered_repositories}`.
 pub async fn enrich_with_analyze_gaps(
     model: &mut super::model::ReportModel,
     source: &dyn AnalyzeMetricsSource,
@@ -635,6 +745,7 @@ pub async fn enrich_with_analyze_gaps(
     // BTreeMap, not HashMap: the rendered line order must not depend on hash
     // iteration order (DOC-67 §9's determinism requirement).
     let mut missing: std::collections::BTreeMap<AnalyzeGap, Vec<String>> = Default::default();
+    let mut partial: std::collections::BTreeMap<AnalyzeCaveat, Vec<String>> = Default::default();
 
     for repo in &mut model.repositories {
         // Precedence: a declared metrics file always wins.
@@ -649,12 +760,15 @@ pub async fn enrich_with_analyze_gaps(
             continue;
         };
         match source.fetch_named(&index_id).await {
-            AnalyzeFetch::Fetched(metrics) => {
+            AnalyzeFetch::Fetched { metrics, caveats } => {
                 eprintln!(
                     "[trusty-review report] --analyze: populated metrics for '{}' from index '{index_id}'",
                     repo.name
                 );
                 repo.metrics = Some(*metrics);
+                for caveat in caveats {
+                    partial.entry(caveat).or_default().push(repo.name.clone());
+                }
             }
             AnalyzeFetch::Missing(gap) => {
                 missing.entry(gap).or_default().push(repo.name.clone());
@@ -662,7 +776,7 @@ pub async fn enrich_with_analyze_gaps(
         }
     }
 
-    missing
+    let mut lines: Vec<String> = missing
         .into_iter()
         .map(|(gap, repos)| {
             format!(
@@ -674,7 +788,13 @@ pub async fn enrich_with_analyze_gaps(
                 repos.join(", ")
             )
         })
-        .collect()
+        .collect();
+    lines.extend(
+        partial
+            .into_iter()
+            .map(|(caveat, repos)| format!("{} — affects: {}.", caveat.as_str(), repos.join(", "))),
+    );
+    lines
 }
 
 #[cfg(test)]

--- a/crates/trusty-review/src/report/analyze_adapter_tests.rs
+++ b/crates/trusty-review/src/report/analyze_adapter_tests.rs
@@ -21,41 +21,67 @@ fn severity_map_diagnostics() {
 
 #[test]
 fn severity_map_refactors() {
-    assert_eq!(map_refactor_severity("critical"), Severity::Red);
+    assert_eq!(map_refactor_severity("critical"), Severity::Amber);
     assert_eq!(map_refactor_severity("high"), Severity::Amber);
     assert_eq!(map_refactor_severity("medium"), Severity::Green);
     assert_eq!(map_refactor_severity("low"), Severity::Green);
 }
 
-// ─── Complexity buckets ──────────────────────────────────────────────────────
-
+/// Why (#5317): the report's most severe band is a statement about business
+/// risk. A refactor suggestion's severity is derived from a complexity grade
+/// alone, so `critical` there means "grade F" and must never be promoted to
+/// RED — twenty "Extract method" entries did exactly that in two generated
+/// due-diligence reports.
+/// Test: itself.
 #[test]
-fn buckets_follow_grade_thresholds() {
-    // One value at each band boundary: 5→A, 6→B, 15→C, 16→D, 21→F.
-    let dist = complexity_buckets(&[5, 6, 15, 16, 21, 3]);
-    let by_label: std::collections::HashMap<&str, u64> = dist
-        .buckets
-        .iter()
-        .map(|b| (b.label.as_str(), b.count))
-        .collect();
-    assert_eq!(by_label.get("A: simple (0-5)"), Some(&2)); // 5 and 3
-    assert_eq!(by_label.get("B: moderate (6-10)"), Some(&1));
-    assert_eq!(by_label.get("C: elevated (11-15)"), Some(&1));
-    assert_eq!(by_label.get("D: high (16-20)"), Some(&1));
-    assert_eq!(by_label.get("F: very high (>20)"), Some(&1));
+fn refactor_never_reaches_red() {
+    for severity in [
+        "critical", "CRITICAL", "error", "high", "warning", "low", "medium", "?",
+    ] {
+        assert_ne!(
+            map_refactor_severity(severity),
+            Severity::Red,
+            "refactor severity {severity:?} reached the RED band"
+        );
+    }
 }
 
+// ─── Complexity distribution ─────────────────────────────────────────────────
+
+/// Why (#5320): the distribution is rendered as a table whose percentage column
+/// is a share of the bucket sum. It is only honest if the buckets are the whole
+/// population — which means every band the daemon reports, zero-count bands
+/// included, arrives intact.
+/// Test: itself.
 #[test]
-fn buckets_omit_empty_bands() {
-    let dist = complexity_buckets(&[2, 3, 4]);
-    assert_eq!(dist.buckets.len(), 1);
+fn distribution_maps_every_band() {
+    let env: DistributionEnvelope = serde_json::from_str(
+        r#"{ "index_id": "demo", "total": 1000, "skipped_non_code": 7, "buckets": [
+             { "grade": "A", "label": "A: simple (0-5)", "count": 800 },
+             { "grade": "B", "label": "B: moderate (6-10)", "count": 150 },
+             { "grade": "C", "label": "C: elevated (11-15)", "count": 0 },
+             { "grade": "D", "label": "D: high (16-20)", "count": 30 },
+             { "grade": "F", "label": "F: very high (>20)", "count": 20 }
+           ]}"#,
+    )
+    .unwrap();
+    let dist = map_distribution(&env);
+    assert_eq!(dist.buckets.len(), 5, "no band is dropped");
     assert_eq!(dist.buckets[0].label, "A: simple (0-5)");
-    assert_eq!(dist.buckets[0].count, 3);
+    assert_eq!(dist.buckets[0].count, 800);
+    assert_eq!(dist.buckets[2].count, 0, "an empty band is a measurement");
+    assert_eq!(
+        dist.buckets.iter().map(|b| b.count).sum::<u64>(),
+        env.total,
+        "the rendered percentages must be shares of the counted population"
+    );
 }
 
 #[test]
-fn buckets_empty_input_yields_no_buckets() {
-    assert!(complexity_buckets(&[]).buckets.is_empty());
+fn empty_distribution_maps_to_nothing() {
+    let env: DistributionEnvelope =
+        serde_json::from_str(r#"{ "total": 0, "buckets": [] }"#).unwrap();
+    assert!(map_distribution(&env).buckets.is_empty());
 }
 
 // ─── Finding synthesis ───────────────────────────────────────────────────────
@@ -99,11 +125,51 @@ fn refactor_finding_synthesises_title() {
              "refactor_type": "extract_method", "severity": "critical" }"#,
     )
     .unwrap();
-    let f = refactor_finding(&r).expect("critical → red");
+    let f = refactor_finding(&r).expect("critical → amber");
     assert_eq!(f.title, "Extract method — parse_config");
-    assert_eq!(f.severity, Severity::Red);
+    assert_eq!(f.severity, Severity::Amber);
     assert_eq!(f.category, "maintainability");
     assert_eq!(f.component, "src/cfg.rs");
+}
+
+/// Why (#5317): every field but the component rendered as
+/// `not stated in source data`, because the adapter dropped the rationale and
+/// the suggested action the daemon had already returned. A finding that states
+/// neither an observation nor an action is not worth a numbered slot.
+/// Test: itself.
+#[test]
+fn refactor_finding_carries_rationale_and_action() {
+    let r: WireRefactor = serde_json::from_str(
+        r#"{ "file": "src/cfg.rs", "function_name": "parse_config",
+             "refactor_type": "extract_method", "severity": "critical",
+             "rationale": "cyclomatic complexity 31 (grade F)",
+             "suggested_action": "Extract the body of 'parse_config' into 2-3 smaller functions" }"#,
+    )
+    .unwrap();
+    let f = refactor_finding(&r).expect("critical → amber");
+    assert_eq!(f.description, "cyclomatic complexity 31 (grade F)");
+    assert!(f.remediation.starts_with("Extract the body of"));
+    assert!(!f.is_contentless());
+}
+
+/// Why (#5317): a finding carrying only a title and a path renders as three
+/// honesty markers in a row. Dropping it is the honest outcome; the count that
+/// remains is what the reader can act on.
+/// Test: itself.
+#[test]
+fn contentless_findings_are_dropped() {
+    let refactors: Vec<WireRefactor> = serde_json::from_str(
+        r#"[
+             { "file": "a.rs", "refactor_type": "extract_method", "severity": "critical" },
+             { "file": "b.rs", "refactor_type": "extract_method", "severity": "critical",
+               "rationale": "cyclomatic complexity 40 (grade F)",
+               "suggested_action": "Split b" }
+           ]"#,
+    )
+    .unwrap();
+    let m = map_metrics(None, &[], &refactors);
+    assert_eq!(m.findings.len(), 1, "the bare-title entry is dropped");
+    assert_eq!(m.findings[0].component, "b.rs");
 }
 
 #[test]
@@ -119,13 +185,14 @@ fn refactor_finding_drops_green() {
 
 #[test]
 fn map_metrics_populates_complexity_and_findings() {
-    // Real-shaped envelopes: hotspots carry the #2446 numbers.
-    let hotspots: HotspotsEnvelope = serde_json::from_str(
-        r#"{ "index_id": "demo", "top_n": 1000, "hotspots": [
-             { "id": "a:1:9", "file": "a.rs", "start_line": 1, "end_line": 9,
-               "content": "fn a() {}", "cyclomatic": 25, "cognitive": 30 },
-             { "id": "b:1:4", "file": "b.rs", "start_line": 1, "end_line": 4,
-               "content": "fn b() {}", "cyclomatic": 4, "cognitive": 1 }
+    // Real-shaped envelopes: the distribution is the whole-corpus histogram.
+    let distribution: DistributionEnvelope = serde_json::from_str(
+        r#"{ "index_id": "demo", "total": 2, "skipped_non_code": 0, "buckets": [
+             { "grade": "A", "label": "A: simple (0-5)", "count": 1 },
+             { "grade": "B", "label": "B: moderate (6-10)", "count": 0 },
+             { "grade": "C", "label": "C: elevated (11-15)", "count": 0 },
+             { "grade": "D", "label": "D: high (16-20)", "count": 0 },
+             { "grade": "F", "label": "F: very high (>20)", "count": 1 }
            ]}"#,
     )
     .unwrap();
@@ -149,7 +216,7 @@ fn map_metrics_populates_complexity_and_findings() {
     .unwrap();
 
     let m = map_metrics(
-        &hotspots.hotspots,
+        Some(&distribution),
         &diagnostics.diagnostics,
         &refactors.suggestions,
     );
@@ -158,13 +225,14 @@ fn map_metrics_populates_complexity_and_findings() {
     assert_eq!(m.loc.total, 0);
     assert_eq!(m.counts.files, 0);
 
-    // Two complexity buckets (F for 25, A for 4).
+    // Every band from the daemon's histogram, in its order.
     let labels: Vec<&str> = m
         .complexity
         .buckets
         .iter()
         .map(|b| b.label.as_str())
         .collect();
+    assert_eq!(labels.len(), 5);
     assert!(labels.contains(&"F: very high (>20)"));
     assert!(labels.contains(&"A: simple (0-5)"));
 
@@ -227,7 +295,7 @@ struct StubSource(fn() -> AnalyzeFetch);
 impl AnalyzeMetricsSource for StubSource {
     async fn fetch(&self, _index_id: &str) -> Option<AnalyzeMetrics> {
         match (self.0)() {
-            AnalyzeFetch::Fetched(m) => Some(*m),
+            AnalyzeFetch::Fetched { metrics, .. } => Some(*metrics),
             AnalyzeFetch::Missing(_) => None,
         }
     }
@@ -288,6 +356,53 @@ fn gap_labels_are_stable() {
     );
 }
 
+/// Why (#5317, #5320): the caveat phrasing reaches a third party's desk on the
+/// same page as the gap lines; it must be fixed prose and must say what the
+/// incompleteness means for the section it affects.
+/// Test: itself.
+#[test]
+fn caveat_labels_are_stable() {
+    let dist = AnalyzeCaveat::ComplexityDistributionUnavailable.as_str();
+    assert!(dist.contains("not a distribution"), "{dist}");
+    assert!(dist.contains("omitted"), "{dist}");
+    let tools = AnalyzeCaveat::NoStaticAnalysisTools.as_str();
+    assert!(tools.contains("unassessed, not clean"), "{tools}");
+}
+
+/// Why (#5320): a fetch that returns metrics is not a fetch that answered
+/// everything. When the daemon serves no full-corpus histogram the §7 table is
+/// left out — and a table that is simply absent reads as a rendering slip
+/// unless the report says why.
+/// Test: itself.
+#[tokio::test]
+async fn enrich_reports_caveats_for_partially_answered_repositories() {
+    let mut model = model_with_local_repo("Northwind Web");
+    let source = StubSource(|| AnalyzeFetch::Fetched {
+        metrics: Box::new(map_metrics(None, &[], &[])),
+        caveats: vec![
+            AnalyzeCaveat::ComplexityDistributionUnavailable,
+            AnalyzeCaveat::NoStaticAnalysisTools,
+        ],
+    });
+
+    let gaps = enrich_with_analyze_gaps(&mut model, &source).await;
+
+    assert_eq!(gaps.len(), 2, "one line per caveat kind: {gaps:?}");
+    assert!(gaps.iter().all(|g| g.contains("Northwind Web")), "{gaps:?}");
+    assert!(
+        gaps.iter().any(|g| g.contains("not a distribution")),
+        "the truncated-distribution caveat must be stated: {gaps:?}"
+    );
+    assert!(
+        gaps.iter().any(|g| g.contains("unassessed, not clean")),
+        "an empty RED band must not read as a clean pass: {gaps:?}"
+    );
+    assert!(
+        model.repositories[0].metrics.is_some(),
+        "a caveat does not discard the metrics that did arrive"
+    );
+}
+
 /// Why: the trait's default `fetch_named` is what keeps every existing
 /// implementor compiling; it must still produce a NAMED outcome rather than
 /// silently dropping the fact that nothing was fetched.
@@ -296,7 +411,7 @@ fn gap_labels_are_stable() {
 async fn default_fetch_named_reports_unavailable() {
     match MinimalSource.fetch_named("demo").await {
         AnalyzeFetch::Missing(gap) => assert_eq!(gap, AnalyzeGap::Unavailable),
-        AnalyzeFetch::Fetched(_) => panic!("MinimalSource never fetches"),
+        AnalyzeFetch::Fetched { .. } => panic!("MinimalSource never fetches"),
     }
 }
 
@@ -331,12 +446,9 @@ async fn enrich_names_unreachable_repositories() {
 #[tokio::test]
 async fn enrich_reports_no_gaps_when_every_repo_is_populated() {
     let mut model = model_with_local_repo("Northwind Web");
-    let source = StubSource(|| {
-        AnalyzeFetch::Fetched(Box::new(map_metrics(
-            &[WireHotspot { cyclomatic: 3 }],
-            &[],
-            &[],
-        )))
+    let source = StubSource(|| AnalyzeFetch::Fetched {
+        metrics: Box::new(map_metrics(None, &[], &[])),
+        caveats: Vec::new(),
     });
 
     let gaps = enrich_with_analyze_gaps(&mut model, &source).await;

--- a/crates/trusty-review/src/report/benchmark_tests.rs
+++ b/crates/trusty-review/src/report/benchmark_tests.rs
@@ -57,6 +57,7 @@ fn metrics(
                 severity,
                 category: "c".to_string(),
                 component: "x".to_string(),
+                ..Default::default()
             })
             .collect(),
     }

--- a/crates/trusty-review/src/report/investigate/mod.rs
+++ b/crates/trusty-review/src/report/investigate/mod.rs
@@ -336,6 +336,11 @@ pub fn apply_investigation(model: &mut ReportModel, inv: &Investigation) {
                 severity: f.severity,
                 category: f.dimension.clone(),
                 component: component_ref(f),
+                // #5317: a verified finding already carries its own one-line
+                // description and remediation — carrying them through means the
+                // rendered entry states something even before synthesis runs.
+                description: f.description.clone(),
+                remediation: f.remediation.clone(),
             });
         }
     }

--- a/crates/trusty-review/src/report/metrics.rs
+++ b/crates/trusty-review/src/report/metrics.rs
@@ -119,6 +119,18 @@ pub enum Severity {
 }
 
 /// A single deterministic finding from trusty-analyze (no LLM prose in M1).
+///
+/// Why (#5317): `description` and `remediation` were absent, so every
+/// analyze-derived finding rendered with `not stated in source data` in all
+/// three prose slots — an entry carrying a title and a path and nothing else.
+/// The data was never missing: the daemon returns a rationale and a suggested
+/// action per refactor suggestion and a message per diagnostic, and the adapter
+/// discarded both. These two fields carry them. They are deterministic tool
+/// output, not synthesis, and synthesis still overwrites them when it runs.
+/// What: `title`/`severity`/`category`/`component` as before, plus the two
+/// prose-slot fields, each defaulting to empty so an older metrics JSON still
+/// parses.
+/// Test: `analyze_adapter_tests.rs::refactor_finding_carries_rationale_and_action`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct MetricFinding {
     /// Short finding title.
@@ -133,6 +145,29 @@ pub struct MetricFinding {
     /// Affected component/path, if known.
     #[serde(default)]
     pub component: String,
+    /// What the tool observed, verbatim (e.g. `cyclomatic complexity 31
+    /// (grade F)`). Empty when the source stated none.
+    #[serde(default)]
+    pub description: String,
+    /// The action the tool suggested, verbatim. Empty when the source stated
+    /// none.
+    #[serde(default)]
+    pub remediation: String,
+}
+
+impl MetricFinding {
+    /// Whether this finding would render as nothing but a title and a path.
+    ///
+    /// Why (#5317): a findings entry whose every prose slot falls through to
+    /// the honesty marker tells a reader nothing they can act on while
+    /// occupying a numbered slot in a severity band. Such an entry is dropped
+    /// rather than rendered.
+    /// What: true when both [`Self::description`] and [`Self::remediation`] are
+    /// empty after trimming.
+    /// Test: `analyze_adapter_tests.rs::contentless_findings_are_dropped`.
+    pub fn is_contentless(&self) -> bool {
+        self.description.trim().is_empty() && self.remediation.trim().is_empty()
+    }
 }
 
 impl AnalyzeMetrics {

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -40,8 +40,8 @@ pub mod template;
 // ── Re-exports for convenience ─────────────────────────────────────────────
 
 pub use analyze_adapter::{
-    AnalyzeAdapterError, AnalyzeFetch, AnalyzeGap, AnalyzeMetricsSource, HttpAnalyzeMetricsSource,
-    derive_index_id, enrich_with_analyze, enrich_with_analyze_gaps,
+    AnalyzeAdapterError, AnalyzeCaveat, AnalyzeFetch, AnalyzeGap, AnalyzeMetricsSource,
+    HttpAnalyzeMetricsSource, derive_index_id, enrich_with_analyze, enrich_with_analyze_gaps,
 };
 pub use benchmark::{
     BenchmarkReport, BenchmarkStatus, CorpusSnapshot, LoadedCorpus, MetricPlacement,

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -377,16 +377,23 @@ impl FindingRow {
     /// A bare deterministic row from one `metrics.findings` entry.
     ///
     /// Why: title/category/component are verbatim, always-available facts from
-    /// trusty-analyze; the prose-only fields (description/evidence/business
-    /// impact/remediation/cost) are synthesis's job and start unset so they
-    /// render as the honesty marker until (and unless) synthesis fills them.
-    /// What: copies `title`/`category`/`component`, mapping an empty source
-    /// string to `None`.
+    /// trusty-analyze, and so — since #5317 — are the tool's own observation and
+    /// suggested action. Those two were previously left unset and rendered as
+    /// the honesty marker even though the daemon had returned them, which made
+    /// every analyze-derived entry read as contentless. They are deterministic
+    /// tool output, not synthesis, and [`FindingRow::merge_prose`] still
+    /// overwrites them when synthesis runs. Business impact and cost/effort stay
+    /// unset: nothing in the metrics states either.
+    /// What: copies `title`/`category`/`component`/`description`/`remediation`,
+    /// mapping an empty source string to `None`.
+    /// Test: `reporter_tests.rs::reporter_renders_metric_description_and_remediation`.
     fn from_metric(f: &super::metrics::MetricFinding) -> Self {
         FindingRow {
             title: f.title.clone(),
             category: non_empty(&f.category),
             component: dedupe_field(&f.component),
+            description: dedupe_field(&f.description),
+            remediation: dedupe_field(&f.remediation),
             ..Default::default()
         }
     }

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -726,6 +726,57 @@ fn finding_fields_have_own_labeled_lines() {
     assert!(md.contains("- **Remediation:**"));
 }
 
+/// Why (#5317): every analyze-derived finding rendered its description and
+/// remediation as `not stated in source data` even when the daemon had returned
+/// both. Those two are deterministic tool output — the row must state them
+/// without waiting for synthesis.
+/// What: renders a metrics fixture carrying `description` and `remediation` and
+/// asserts both reach the page, and that neither slot falls to the marker.
+/// Test: this test itself.
+#[test]
+fn reporter_renders_metric_description_and_remediation() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let metrics = r#"{
+      "findings": [
+        { "title": "Extract method", "severity": "amber", "category": "maintainability",
+          "component": "src/hiargs.rs",
+          "description": "cyclomatic complexity 31 (grade F)",
+          "remediation": "Extract the body of 'from_low_args' into 2-3 smaller functions" }
+      ]
+    }"#;
+    std::fs::write(tmp.path().join("acme.json"), metrics).expect("write metrics");
+    let toml = r#"
+        [report]
+        title = "Acme Due Diligence"
+
+        [[repositories]]
+        name = "Acme Web"
+        path = "/nonexistent/acme-web"
+        metrics = "acme.json"
+    "#;
+    let manifest_path = tmp.path().join("manifest.toml");
+    let manifest = parse_manifest(toml, &manifest_path).expect("manifest parse");
+    let model = ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None)
+        .expect("build model");
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(
+        md.contains("cyclomatic complexity 31 (grade F)"),
+        "the tool's own observation must render: {md}"
+    );
+    assert!(
+        md.contains("Extract the body of 'from_low_args' into 2-3 smaller functions"),
+        "the tool's own suggested action must render: {md}"
+    );
+    assert!(
+        !md.contains(&format!("**Remediation:** {HONESTY_MARKER}")),
+        "remediation must not fall to the honesty marker when the source stated it: {md}"
+    );
+}
+
 /// Why: with no findings metrics, the RED/AMBER/GREEN sections must not be
 /// fabricated — under the #2342 omit-empty default they collapse to a single line
 /// (no wall of honesty markers) and the empty sections are recorded under gaps.

--- a/crates/trusty-review/src/report/synthesize_digest_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_digest_tests.rs
@@ -22,6 +22,7 @@ fn mf(title: &str, severity: Severity, category: &str, component: &str) -> Metri
         severity,
         category: category.to_string(),
         component: component.to_string(),
+        ..Default::default()
     }
 }
 

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -186,6 +186,7 @@ fn red(title: &str) -> MetricFinding {
         severity: Severity::Red,
         category: "security".to_string(),
         component: "auth".to_string(),
+        ..Default::default()
     }
 }
 
@@ -195,6 +196,7 @@ fn green(title: &str) -> MetricFinding {
         severity: Severity::Green,
         category: "maintainability".to_string(),
         component: "core".to_string(),
+        ..Default::default()
     }
 }
 

--- a/crates/trusty-review/tests/report_analyze_e2e.rs
+++ b/crates/trusty-review/tests/report_analyze_e2e.rs
@@ -30,19 +30,21 @@ fn indexes_body() -> String {
     format!(r#"[{{"id":"{INDEX_ID}","root_path":null}}]"#)
 }
 
-/// Body for `/complexity_hotspots` — hotspots carrying the #2446 numbers.
-fn hotspots_body() -> String {
-    r#"{"index_id":"acme-core","top_n":1000,"hotspots":[
-        {"id":"a:1:9","file":"src/a.rs","start_line":1,"end_line":9,"content":"fn a(){}","cyclomatic":25,"cognitive":30},
-        {"id":"b:1:9","file":"src/b.rs","start_line":1,"end_line":9,"content":"fn b(){}","cyclomatic":12,"cognitive":8},
-        {"id":"c:1:9","file":"src/c.rs","start_line":1,"end_line":9,"content":"fn c(){}","cyclomatic":3,"cognitive":1}
+/// Body for `/complexity_distribution` — the whole-corpus A-F histogram (#5320).
+fn distribution_body() -> String {
+    r#"{"index_id":"acme-core","total":3,"skipped_non_code":1,"buckets":[
+        {"grade":"A","label":"A: simple (0-5)","count":1},
+        {"grade":"B","label":"B: moderate (6-10)","count":0},
+        {"grade":"C","label":"C: elevated (11-15)","count":1},
+        {"grade":"D","label":"D: high (16-20)","count":0},
+        {"grade":"F","label":"F: very high (>20)","count":1}
     ]}"#
     .to_string()
 }
 
 /// Body for `/diagnostics` — one error (RED) + one hint (dropped GREEN).
 fn diagnostics_body() -> String {
-    r#"{"index_id":"acme-core","total":2,"diagnostics":[
+    r#"{"index_id":"acme-core","total":2,"tools_run":["clippy"],"diagnostics":[
         {"tool":"clippy","file":"src/a.rs","line":1,"col":1,"severity":"error","code":"E0001","message":"boom"},
         {"tool":"clippy","file":"src/b.rs","line":2,"col":1,"severity":"hint","code":"H1","message":"meh"}
     ]}"#
@@ -59,8 +61,8 @@ fn refactor_body() -> String {
 
 /// Route the request path to the right fixture body.
 fn body_for(path: &str) -> String {
-    if path.starts_with("/indexes/") && path.contains("/complexity_hotspots") {
-        hotspots_body()
+    if path.starts_with("/indexes/") && path.contains("/complexity_distribution") {
+        distribution_body()
     } else if path.contains("/diagnostics") {
         diagnostics_body()
     } else if path.contains("/refactor-suggestions") {
@@ -162,15 +164,27 @@ async fn analyze_populates_complexity_and_findings() {
         .expect("analyze filled metrics");
     // loc/counts stay empty (scanner owns them).
     assert_eq!(metrics.loc.total, 0);
-    // Buckets computed client-side: F (25), C (12), A (3).
+    // Every band from the daemon's full histogram (#5320) — not a bucketed
+    // top-N sample.
     let labels: Vec<&str> = metrics
         .complexity
         .buckets
         .iter()
         .map(|b| b.label.as_str())
         .collect();
+    assert_eq!(labels.len(), 5, "every band renders: {labels:?}");
     assert!(labels.contains(&"F: very high (>20)"), "{labels:?}");
     assert!(labels.contains(&"C: elevated (11-15)"), "{labels:?}");
+    assert_eq!(
+        metrics
+            .complexity
+            .buckets
+            .iter()
+            .map(|b| b.count)
+            .sum::<u64>(),
+        3,
+        "the percentage denominator is the counted population"
+    );
 
     let reporter = Reporter::new(tmp.path().join("reports"));
     let md = reporter.render(&model, &template);


### PR DESCRIPTION
## Outcome

Closes #5317, Closes #5320. Both defects were found by the first real `tga audit` runs and block the release by owner decision.

- https://github.com/bobmatnyc/trusty-tools/issues/5317
- https://github.com/bobmatnyc/trusty-tools/issues/5320

## What changed

#5317 was three defects in three layers:

- **Severity mapping** — `analyze_adapter.rs:180` mapped refactor `critical` -> RED, but a refactor suggestion's severity comes from complexity grade alone (`Severity::from_grade`, `refactor.rs:69`, `F -> Critical`), so "critical" meant "grade F", not "critical risk". Refactor findings now cap at AMBER.
- **Non-code components** — fixed at the analyze layer, where the suggestion was manufactured: an unmapped extension fell back to a keyword heuristic that graded a CHANGELOG at cyclomatic 121. New `is_code_file` in `lang/ext_map.rs`.
- **Empty fields** — `rationale`/`suggested_action`/`message` were being *discarded* by the adapter, so they are now populated rather than suppressed.

#5320: `HOTSPOT_SAMPLE = 1000` fed a `top_n` query that sorts descending and truncates, so the rendered "distribution" was the top 1000 rows with percentages computed against the truncation. Raising the limit isn't viable — the full payload measures 70 MB — so trusty-analyze gains `GET /indexes/{id}/complexity_distribution`, computing the histogram server-side.

Out of scope: [#5318](https://github.com/bobmatnyc/trusty-tools/issues/5318), [#5319](https://github.com/bobmatnyc/trusty-tools/issues/5319), [#5321](https://github.com/bobmatnyc/trusty-tools/issues/5321) remain open by owner decision.

## Risk / blast radius

Three crates: `trusty-review`, `trusty-analyze`, and the `tga` report path.

**trusty-review has a BREAKING public API change** — `AnalyzeFetch::Fetched` went tuple -> struct variant, `MetricFinding` gained two public fields, new public `AnalyzeCaveat`. It rides in the unpublished 0.13.0. `check_semver.sh` SKIPS trusty-review (0.12 -> 0.13 already crosses a breaking boundary), so this break is reported from reading the diff and is NOT tool-confirmed.

trusty-analyze's changes are additive apart from the `is_code_file` behaviour filter, which returns fewer refactor suggestions for corpora containing non-code files. trusty-analyze 0.8.0 is unpublished, so no bump was needed — note the standing comment in its `Cargo.toml` that its next release must be 0.9.0.

## Test evidence

`cargo fmt --check`, `cargo check --workspace`, clippy `-D warnings` on trusty-review / tga / trusty-analyze, `cargo test` on all three:

- trusty-review: 1572 passed
- tga: 1051 passed
- trusty-analyze: 473 passed
- 0 failed

All ten applicable `scripts/check_*.sh` pass, including `check_test_pointers.sh` (23,198 citations, 0 dangling). Five regression tests, all proven red pre-fix.

Real-run verification, the evidence that matters: a live `tga audit` against the ripgrep demo produced RED entries 20 -> 0, AMBER 0 -> 20 each carrying real numbers, non-code components 2 -> 0, and a complexity table whose five buckets now sum to the counted total of 4,328 instead of to 1,000.

## Baseline failures

None. `bootstrap::tests::bounded_python_check_classifies_timeout_apart_from_failure` in `trusty-embedderd-py` flaked once earlier today and passed on rerun — unrelated to this diff.

## Docs/changelog

Fragments in `trusty-review` and `trusty-analyze`.

## Review disposition

Two things found beyond the issues' scope and fixed here:

- An empty RED band was indistinguishable from an unassessed one, so the adapter now reads `tools_run` and emits a Gaps & Caveats line when no linter was installed.
- The ripgrep demo's complexity numbers were equally wrong before this fix, just less visibly — its top-1000 reached into the A band, so "A: 515 / 52%" looked plausible while the true figure is 3,862 / 89%.

Not done: the trusty-tools-side audit was not re-run, because verifying it means indexing a 50,929-chunk corpus through an alternate daemon, and the ripgrep run exercises every changed path. The trusty-tools figures cited come from querying the live daemon directly, not from a regenerated report.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
