### PR TITLE
fix(trusty-search): index registry write integrity, root lockstep, and cold-store lifecycle (#4951, #4871, #4317, #4253, #5075)

### DIFF
--- a/crates/trusty-search/changelog.d/4227-quarantine-doc-correction.md
+++ b/crates/trusty-search/changelog.d/4227-quarantine-doc-correction.md
@@ -1,0 +1,8 @@
+Changed
+
+- The write-quarantine module docs no longer list genuine corruption among the
+  conditions that trigger it. Corruption is absorbed before `corpus_open_failed`
+  can be set: `open_corpus_db_or_recreate` classifies it as recoverable, moves
+  the file aside, and returns a fresh empty corpus. Only lock contention and
+  transient I/O reach the quarantine, so its population is transient-dominated —
+  which the docs now say, along with the recreate-to-empty gap it does not cover.

--- a/crates/trusty-search/changelog.d/4253-transient-corpus-open-orphan.md
+++ b/crates/trusty-search/changelog.d/4253-transient-corpus-open-orphan.md
@@ -1,0 +1,9 @@
+Fixed
+
+- A cold index whose corpus open lost a race (`DatabaseAlreadyOpen`) or ran past
+  its deadline is no longer deregistered for the daemon's lifetime. The restore
+  ran to completion without registering a handle, so the loader consumed the
+  cold entry anyway and the index became a 404 with no way back — one client
+  retry against a slow ~20s cold-start open was enough. Registration is now the
+  only evidence a restore succeeded; a transient failure keeps the entry and
+  returns a retryable 503 so the next query recovers it.

--- a/crates/trusty-search/changelog.d/4871-4317-registry-write-integrity.md
+++ b/crates/trusty-search/changelog.d/4871-4317-registry-write-integrity.md
@@ -15,7 +15,10 @@ Fixed
   pre-boot snapshot of the survivors, so an index registered while the sweep
   was deciding is no longer erased by the cleanup.
 
-Known limitation: the fail-closed parse guarantees the WRITE path only. Read-only
-callers that swallow the load error (`reindex/runner.rs`, `warm_boot/mod.rs`,
-`server/tickers.rs`) still treat a corrupt registry as empty, exactly as before —
-no regression, but the guarantee does not extend to them. See #4871.
+Known limitation: the fail-closed parse guarantees the WRITE path only. Every
+read-only caller still swallows the load error and treats a corrupt registry as
+empty — `reindex/runner.rs`, `warm_boot/mod.rs`, `server/tickers.rs`,
+`reconcile.rs`, `server/indexes.rs`, `server/indexes_relocate.rs`,
+`server/index_config.rs`, `persistence_timestamps.rs`, and
+`commands/start/restore.rs`. That is unchanged behaviour, not a regression, but
+the guarantee does not extend to them. See #4871.

--- a/crates/trusty-search/changelog.d/4871-4317-registry-write-integrity.md
+++ b/crates/trusty-search/changelog.d/4871-4317-registry-write-integrity.md
@@ -14,3 +14,8 @@ Fixed
 - The boot orphan-reaper removes orphans by id instead of republishing a
   pre-boot snapshot of the survivors, so an index registered while the sweep
   was deciding is no longer erased by the cleanup.
+
+Known limitation: the fail-closed parse guarantees the WRITE path only. Read-only
+callers that swallow the load error (`reindex/runner.rs`, `warm_boot/mod.rs`,
+`server/tickers.rs`) still treat a corrupt registry as empty, exactly as before —
+no regression, but the guarantee does not extend to them. See #4871.

--- a/crates/trusty-search/changelog.d/4871-4317-registry-write-integrity.md
+++ b/crates/trusty-search/changelog.d/4871-4317-registry-write-integrity.md
@@ -1,0 +1,16 @@
+Fixed
+
+- An unparseable `indexes.toml` is now an error rather than an empty registry.
+  It previously read back as "no index was ever registered", and the next write
+  published that view — overwriting a whole registry with a single entry, which
+  is the mass-deregistration both #4317 (73 → 31, then 42 → 5) and #4871
+  recorded. The corrupt file is left intact for recovery.
+- Registry mutations are serialized process-wide and stage through a
+  per-write temporary file instead of one shared `indexes.toml.tmp`. Concurrent
+  writers previously interleaved: a registration landing between another task's
+  load and its save was silently discarded (the observed 80 → 88 → 80 revert),
+  and two writers racing on the shared temp file could publish a spliced,
+  unparseable registry.
+- The boot orphan-reaper removes orphans by id instead of republishing a
+  pre-boot snapshot of the survivors, so an index registered while the sweep
+  was deciding is no longer erased by the cleanup.

--- a/crates/trusty-search/changelog.d/4951-stale-indexer-root.md
+++ b/crates/trusty-search/changelog.d/4951-stale-indexer-root.md
@@ -1,0 +1,9 @@
+Fixed
+
+- `POST /indexes/:id/reindex` with a `root_path` override no longer makes every
+  search return nothing. The override rebuilt the index handle around the same
+  indexer, leaving the indexer's own `root_path` on the old value — so the
+  absolute `file` on each result was built against the old root while the search
+  post-filter (#64/#541) checked it against the new one, dropping 100% of
+  matches. Callers saw `results: []` with `stale_index_root: true` on an index
+  whose `/status` read `ready` with a full chunk count.

--- a/crates/trusty-search/changelog.d/5075-unregister-purges-cold-store.md
+++ b/crates/trusty-search/changelog.d/5075-unregister-purges-cold-store.md
@@ -1,0 +1,8 @@
+Fixed
+
+- `DELETE /indexes/:id` now clears the index's cold-store records. Deleting a
+  cold-parked or restore-failed index left them behind, so `/status`,
+  `/chunks`, and `grep` answered 503 forever for an id that no longer existed —
+  inverting #5057's rule that 404 means "absent from every store". A
+  cold-parked-only index is also removed from `indexes.toml` now, instead of
+  being resurrected by the next warm boot.

--- a/crates/trusty-search/src/core/indexer/mod.rs
+++ b/crates/trusty-search/src/core/indexer/mod.rs
@@ -474,6 +474,26 @@ impl CodeIndexer {
     /// incrementally before attaching all components.
     /// What: initialises all fields to their zero/empty states.
     /// Test: every test that constructs a `CodeIndexer` exercises this.
+    /// Re-point this indexer at the root its stored chunk paths are relative to.
+    ///
+    /// Why (#4951): `root_path` here is the base every stored (root-relative)
+    /// chunk path is joined against to produce the absolute `CodeChunk::file`
+    /// callers see, and the search handler then post-filters those absolute
+    /// paths against `IndexHandle::root_path`. The two are separate copies of
+    /// the same fact, so any path that moves one must move the other or every
+    /// result is silently discarded — `POST /indexes/:id/reindex { root_path }`
+    /// rebuilt the handle around the SAME indexer `Arc` and left this field on
+    /// the old root, which dropped 100% of matches behind
+    /// `stale_index_root: true` while every status field still read `ready`.
+    /// What: overwrites the field. Callers must hold the indexer write lock (the
+    /// `&mut self` receiver enforces that) and must pass the same canonical root
+    /// the handle carries.
+    /// Test: `reindex_root_override_syncs_indexer_root_path`,
+    /// `stale_indexer_root_makes_every_chunk_fail_the_search_post_filter`.
+    pub fn set_root_path(&mut self, root_path: impl Into<std::path::PathBuf>) {
+        self.root_path = root_path.into();
+    }
+
     pub fn new(index_id: impl Into<String>, root_path: impl Into<std::path::PathBuf>) -> Self {
         let cap =
             NonZeroUsize::new(QUERY_CACHE_CAPACITY).expect("QUERY_CACHE_CAPACITY must be non-zero");

--- a/crates/trusty-search/src/core/indexer/quarantine.rs
+++ b/crates/trusty-search/src/core/indexer/quarantine.rs
@@ -23,10 +23,31 @@
 //! `set_corpus_store`). The quarantine is deliberately *asymmetric*: refusing
 //! a write costs an un-indexed file save that the next reindex picks up
 //! anyway, whereas accepting one destroys the corpus. So every corpus-open
-//! failure — transient I/O error, permission denial, stale redb file lock, an
-//! unresolvable storage path, or genuine corruption — quarantines, because at
-//! the point of failure they are indistinguishable and only one of the two
+//! failure that REACHES this module — transient I/O error, permission denial,
+//! stale redb file lock, or an unresolvable storage path — quarantines, because
+//! at the point of failure they are indistinguishable and only one of the two
 //! possible mistakes is recoverable.
+//!
+//! ## Genuine corruption does NOT reach here (#4227)
+//!
+//! This list used to name "genuine corruption" as a quarantine trigger. It is
+//! not one, and reading it as one misstates what the quarantine protects. A
+//! corrupt corpus is absorbed BEFORE `corpus_open_failed` can be set:
+//! `CorpusStore::open` (`core/corpus/store_impl.rs`) delegates to
+//! `open_corpus_db_or_recreate`, and `core/corpus_recovery.rs` classifies
+//! `UpgradeRequired`, `RepairAborted`, `Storage(Corrupted(_))` and
+//! `Storage(Io(InvalidData))` as RECOVERABLE — it moves the file aside with a
+//! `.v2-incompatible` suffix and returns `Ok` with a fresh EMPTY corpus. Only
+//! lock contention and genuine transient I/O errors propagate as `Err`, so the
+//! quarantine population is transient-dominated by construction.
+//!
+//! Two consequences worth keeping in view. First, an in-process reopen retry
+//! would clear most of this population (recovery currently needs a daemon
+//! restart — #4122 / PR #4220 HIGH-1). Second, the recreate path yields an index
+//! reporting HEALTHY on a fresh empty corpus, which watcher writes then populate
+//! with a partial rebuild — a symptom shape close to the #4122 incident's that
+//! this quarantine explicitly does NOT cover. That gap is #4087's, not this
+//! module's.
 //!
 //! Reads are NOT gated: a quarantined index still serves searches (returning
 //! whatever its empty in-memory corpus holds). Making failed indexes stop

--- a/crates/trusty-search/src/service/lazy_loader/loader.rs
+++ b/crates/trusty-search/src/service/lazy_loader/loader.rs
@@ -177,12 +177,18 @@ where
             cold_store.mark_loaded(id);
             Ok(handle)
         }
+        // #4253 review HIGH-2: a restore arm that judged the failure PERMANENT
+        // marks the entry failed on its way out (deleted root, indexer build
+        // failure). Honour that verdict — reporting `Loading` for it would
+        // promise a retry that can never succeed and would re-enter the
+        // expensive restore path on every query.
+        None if cold_store.is_failed(id) => Err(LazyLoadError::RestoreFailed),
         None => {
             tracing::warn!(
                 "lazy-load: index '{}' restore reported success but registered no \
-                 handle (transient corpus-open contention, or a skip arm) — keeping \
-                 the cold entry so a retry can recover it, and returning 503 \
-                 (issue #4253)",
+                 handle and did not mark the entry failed — treating as transient \
+                 (corpus-open contention); keeping the cold entry so a retry can \
+                 recover it, and returning 503 (issue #4253)",
                 id.0
             );
             Err(LazyLoadError::Loading {

--- a/crates/trusty-search/src/service/lazy_loader/loader.rs
+++ b/crates/trusty-search/src/service/lazy_loader/loader.rs
@@ -155,10 +155,41 @@ where
         return Err(LazyLoadError::RestoreFailed);
     }
 
-    // 6. Mark loaded and return handle.
-    cold_store.mark_loaded(id);
-
-    registry.get(id).ok_or(LazyLoadError::NotFound)
+    // 6. Mark loaded ONLY when the restore actually registered a handle.
+    //
+    // #4253: `mark_loaded` used to run unconditionally, and the handle lookup
+    // that followed mapped its own miss to `NotFound`. `restore_index_on_demand`
+    // has several arms that return WITHOUT registering anything and without
+    // reporting failure — the loudest being a corpus open that lost a race
+    // (`DatabaseAlreadyOpen`) during a ~20 s cold-start open. Those arms leave
+    // `restore_fn` reporting `Completed`, so the old code evicted the cold entry
+    // for an index that was never loaded. `contains()` then returned false, the
+    // search handler answered 404, and nothing ever put the entry back: one
+    // client retry against a slow cold open permanently deregistered a live
+    // index with no self-heal. Registration is the only evidence a restore
+    // succeeded; consult it before consuming the entry.
+    //
+    // Failing to `Loading` (not `NotFound`) is what makes this recoverable: the
+    // cold entry survives, the caller gets a retryable 503, and the next query
+    // re-enters the restore path once the competing open has released the file.
+    match registry.get(id) {
+        Some(handle) => {
+            cold_store.mark_loaded(id);
+            Ok(handle)
+        }
+        None => {
+            tracing::warn!(
+                "lazy-load: index '{}' restore reported success but registered no \
+                 handle (transient corpus-open contention, or a skip arm) — keeping \
+                 the cold entry so a retry can recover it, and returning 503 \
+                 (issue #4253)",
+                id.0
+            );
+            Err(LazyLoadError::Loading {
+                retry_after_secs: timeout.as_secs(),
+            })
+        }
+    }
 }
 
 /// Error returned by [`get_or_load_index`].

--- a/crates/trusty-search/src/service/lazy_loader/mod.rs
+++ b/crates/trusty-search/src/service/lazy_loader/mod.rs
@@ -641,4 +641,71 @@ mod tests {
             "restore_fn must be called exactly once (not re-attempted after failure)"
         );
     }
+
+    /// #4253: a restore that reports success but registers NO handle must leave
+    /// the cold entry intact and return a retryable 503 — never consume the
+    /// entry and report the index unknown.
+    ///
+    /// Why: this is the fail-open that permanently orphaned an index. During a
+    /// ~20 s cold-start corpus open a client retry raced the in-flight open,
+    /// redb answered `DatabaseAlreadyOpen`, and `restore_index_on_demand`
+    /// returned WITHOUT registering — but it had run to completion, so
+    /// `restore_fn` reported `true`. The old code then called `mark_loaded`
+    /// unconditionally, which removed the entry from `entries`, and the handle
+    /// lookup that followed mapped its miss to `NotFound`. The index was gone
+    /// from every store with no path back: `contains()` false, so the search
+    /// handler answered 404 and never re-entered the restore path. Five prior
+    /// issues in this class were closed before the mechanism was named.
+    /// What: drives `get_or_load_index` with a `restore_fn` that returns `true`
+    /// and registers nothing — exactly the shape a lost corpus-open race
+    /// produces. Asserts the cold entry survives and the error is `Loading`.
+    /// Pre-fix this panics on the first assertion (`cold.contains` is false).
+    /// Test: this test.
+    #[tokio::test]
+    async fn completed_restore_that_registered_nothing_keeps_the_cold_entry() {
+        let registry = IndexRegistry::default();
+        let cold = ColdIndexStore::new();
+        let id = IndexId::new("contended-idx".to_string());
+        cold.register_cold_entries(vec![mk_entry("contended-idx", None, None)]);
+
+        let result = get_or_load_index(&id, &registry, &cold, Duration::from_secs(5), |_e| async {
+            // Ran to completion, registered nothing — a lost corpus-open race.
+            true
+        })
+        .await;
+
+        assert!(
+            cold.contains(&id),
+            "#4253: a restore that registered nothing must NOT consume the cold \
+             entry — evicting it deregisters a live index with no self-heal"
+        );
+        assert!(
+            !cold.is_failed(&id),
+            "#4253: contention is not permanent failure — the id must stay retryable"
+        );
+        assert!(
+            matches!(result, Err(LazyLoadError::Loading { .. })),
+            "#4253: caller must get a retryable 503, not a 404 for an index that \
+             is still registered"
+        );
+
+        // The retry succeeds once the competing opener releases the file.
+        let registered = build_mock_handle("contended-idx");
+        let result2 = get_or_load_index(&id, &registry, &cold, Duration::from_secs(5), |_e| {
+            let reg = &registry;
+            async move {
+                reg.register(registered);
+                true
+            }
+        })
+        .await;
+        assert!(
+            result2.is_ok(),
+            "#4253: the next attempt must recover the index"
+        );
+        assert!(
+            !cold.contains(&id),
+            "a genuinely successful restore does consume the cold entry"
+        );
+    }
 }

--- a/crates/trusty-search/src/service/lazy_loader/mod.rs
+++ b/crates/trusty-search/src/service/lazy_loader/mod.rs
@@ -708,4 +708,39 @@ mod tests {
             "a genuinely successful restore does consume the cold entry"
         );
     }
+
+    /// #5075: `ColdIndexStore::purge` clears BOTH the cold entry and the
+    /// permanent-failure marker, so a deregistered id is absent from every
+    /// store.
+    ///
+    /// Why: `unregister_index` removed the hot registration and the
+    /// `indexes.toml` row but left these records, so #5057's guards answered
+    /// 503 forever for an id that no longer existed — inverting the invariant
+    /// that 404 means "absent from every store".
+    /// What: parks an id, fails it, purges, and asserts every predicate is
+    /// clear. Also asserts idempotency for an unknown id.
+    /// Test: this test.
+    #[test]
+    fn purge_removes_cold_and_failed_records() {
+        let cold = ColdIndexStore::new();
+        let id = IndexId::new("gone".to_string());
+        cold.register_cold_entries(vec![mk_entry("gone", None, None)]);
+        assert!(cold.contains(&id));
+        cold.mark_failed(&id);
+        assert!(cold.is_failed(&id), "precondition: id is in failed_entries");
+
+        cold.purge(&id);
+
+        assert!(!cold.contains(&id), "#5075: cold entry must be gone");
+        assert!(
+            !cold.is_failed(&id),
+            "#5075: failed marker must be gone too — it is what pinned the 503"
+        );
+        assert_eq!(cold.failed_len(), 0);
+
+        // Idempotent: purging an id in no store at all is a no-op.
+        cold.purge(&IndexId::new("never-existed".to_string()));
+        assert_eq!(cold.len(), 0);
+        assert_eq!(cold.failed_len(), 0);
+    }
 }

--- a/crates/trusty-search/src/service/lazy_loader/mod.rs
+++ b/crates/trusty-search/src/service/lazy_loader/mod.rs
@@ -743,4 +743,79 @@ mod tests {
         assert_eq!(cold.len(), 0);
         assert_eq!(cold.failed_len(), 0);
     }
+
+    /// #4253 review HIGH-2: a restore that marked the entry permanently failed
+    /// must terminate, not spin in a retryable 503 forever.
+    ///
+    /// Why: keeping the cold entry is the TRANSIENT policy. Two arms of
+    /// `restore_index_on_demand` return without registering for permanent
+    /// reasons — a deleted `root_path` and a failed `build_indexer_from_entry`.
+    /// Pre-#4253 they were terminated only by the unconditional `mark_loaded`
+    /// that fix removed; if #4253 had left them un-marked, an index whose root
+    /// was deleted would answer `503 index_loading` for the daemon's life,
+    /// re-entering restore on every query — re-opening the redb corpus and
+    /// re-allocating the HNSW arena each time. That is the unbounded restore
+    /// storm `mark_failed`'s policy exists to prevent.
+    /// What: a `restore_fn` that reports success but marks the entry failed
+    /// (what the two permanent arms now do). Asserts the loader honours the
+    /// verdict with `RestoreFailed` and does not retain a retryable entry.
+    /// Test: this test.
+    #[tokio::test]
+    async fn restore_that_marked_the_entry_failed_is_terminal_not_retryable() {
+        let registry = IndexRegistry::default();
+        let cold = ColdIndexStore::new();
+        let id = IndexId::new("root-deleted".to_string());
+        cold.register_cold_entries(vec![mk_entry("root-deleted", None, None)]);
+
+        let result = get_or_load_index(&id, &registry, &cold, Duration::from_secs(5), |_e| {
+            let cold = &cold;
+            let id = id.clone();
+            async move {
+                // What the missing-root / build-failure arms do on their way out.
+                cold.mark_failed(&id);
+                true
+            }
+        })
+        .await;
+
+        assert!(
+            matches!(result, Err(LazyLoadError::RestoreFailed)),
+            "#4253 HIGH-2: a permanent failure must not be reported as a \
+             retryable 503"
+        );
+        assert!(
+            !cold.contains(&id),
+            "#4253 HIGH-2: the entry must not stay retryable — that is the \
+             restore storm"
+        );
+        assert!(cold.is_failed(&id), "the failure verdict must stick");
+    }
+
+    /// #5075 review MEDIUM: `mark_failed` carries the entry across, so a
+    /// restore-failed index still yields its `root_path` for the delete path's
+    /// `roots.toml` scrub.
+    ///
+    /// Why: `failed_entries` used to map to `()`, dropping the `PersistedIndex`.
+    /// `unregister_index` then had no root to scrub, so a colocated index
+    /// reported `removed: true` and the next warm boot's rescan resurrected it
+    /// from `roots.toml`.
+    /// What: parks an entry, fails it, and asserts `get_persisted` still
+    /// resolves its root.
+    /// Test: this test.
+    #[test]
+    fn a_failed_entry_still_yields_its_root_path() {
+        let cold = ColdIndexStore::new();
+        let id = IndexId::new("failed-root".to_string());
+        cold.register_cold_entries(vec![mk_entry("failed-root", None, None)]);
+        cold.mark_failed(&id);
+
+        let persisted = cold
+            .get_persisted(&id)
+            .expect("#5075: a failed entry must still expose its metadata");
+        assert_eq!(
+            persisted.root_path,
+            PathBuf::from("/tmp/failed-root"),
+            "the root_path is what the roots.toml scrub needs"
+        );
+    }
 }

--- a/crates/trusty-search/src/service/lazy_loader/store.rs
+++ b/crates/trusty-search/src/service/lazy_loader/store.rs
@@ -152,7 +152,12 @@ pub struct ColdIndexStore {
     /// test). A `DashMap<IndexId, ()>` gives that without an extra `HashSet`.
     /// What: populated by `mark_failed`; checked by `is_failed`.
     /// Test: `cold_store_mark_failed_*` unit tests.
-    failed_entries: Arc<DashMap<IndexId, ()>>,
+    /// #5075 review MEDIUM: the value is the entry itself, not `()`. A
+    /// restore-failed index used to drop its `PersistedIndex` on the floor, so
+    /// `unregister_index` had no `root_path` to scrub from `roots.toml` — a
+    /// colocated index reported `removed: true` and then resurrected on the
+    /// next warm boot's rescan.
+    failed_entries: Arc<DashMap<IndexId, PersistedIndex>>,
 }
 
 impl ColdIndexStore {
@@ -424,8 +429,15 @@ impl ColdIndexStore {
     /// the identity token (irrelevant to this caller).
     /// Test: exercised by `get_or_load_index_loads_cold_index` (via
     /// `get_or_load_index`, the only caller).
+    /// #5075 review MEDIUM: falls back to `failed_entries`, so a
+    /// permanently-failed index still yields its `root_path` for the delete
+    /// path's `roots.toml` scrub. `get_or_load_index` is unaffected — it only
+    /// reaches this after `is_failed` has already short-circuited.
     pub(crate) fn get_persisted(&self, id: &IndexId) -> Option<PersistedIndex> {
-        self.entries.get(id).map(|kv| kv.value().persisted.clone())
+        self.entries
+            .get(id)
+            .map(|kv| kv.value().persisted.clone())
+            .or_else(|| self.failed_entries.get(id).map(|kv| kv.value().clone()))
     }
 
     /// Snapshot the identity token of `id`'s current cold entry, if any
@@ -533,14 +545,19 @@ impl ColdIndexStore {
     /// the index. This is conservative but safe: it prevents unbounded restore
     /// retry storms on every query.
     ///
-    /// What: moves the id from `entries` to `failed_entries`; also removes the
-    /// loading gate so it can be reclaimed.
+    /// What: moves the id from `entries` to `failed_entries`, CARRYING the
+    /// entry across (#5075 review MEDIUM) so the delete path can still recover
+    /// its `root_path`; also removes the loading gate so it can be reclaimed.
+    /// An id absent from `entries` (already failed, or never parked) leaves
+    /// `failed_entries` untouched rather than inserting a rootless placeholder.
     /// Test: `cold_store_mark_failed_*` and
     ///       `get_or_load_index_restore_false_marks_failed` unit tests.
     pub fn mark_failed(&self, id: &IndexId) {
-        self.entries.remove(id);
+        let removed = self.entries.remove(id);
         self.loading_gates.remove(id);
-        self.failed_entries.insert(id.clone(), ());
+        if let Some((_, parked)) = removed {
+            self.failed_entries.insert(id.clone(), parked.persisted);
+        }
     }
 
     /// Forget an id completely — cold entry, failed marker, and loading gate.
@@ -558,9 +575,8 @@ impl ColdIndexStore {
     /// the delete path can call it unconditionally. Deliberately NOT identity-
     /// guarded (unlike [`Self::mark_loaded_if`]): deregistration is a terminal
     /// operation on the id itself, so there is no newer record worth keeping.
-    /// Test: `purge_removes_cold_and_failed_records`,
-    /// `purge_is_idempotent_for_unknown_id`,
-    /// `delete_index_clears_cold_store_so_status_is_404_not_503`.
+    /// Test: `purge_removes_cold_and_failed_records` (also covers the
+    /// unknown-id no-op) and `deleted_cold_parked_index_is_404_not_a_permanent_503`.
     pub fn purge(&self, id: &IndexId) {
         self.entries.remove(id);
         self.failed_entries.remove(id);

--- a/crates/trusty-search/src/service/lazy_loader/store.rs
+++ b/crates/trusty-search/src/service/lazy_loader/store.rs
@@ -543,6 +543,30 @@ impl ColdIndexStore {
         self.failed_entries.insert(id.clone(), ());
     }
 
+    /// Forget an id completely — cold entry, failed marker, and loading gate.
+    ///
+    /// Why (#5075): `unregister_index` dropped the hot registration and the
+    /// `indexes.toml` row but left this store's records behind, so the three
+    /// cold-store guards #5057 added (`status.rs`, `files.rs`) kept answering
+    /// `503 index_not_resident` / `index_restore_failed` forever for an id that
+    /// no longer exists anywhere. That inverts the #5057 invariant that 404
+    /// means "absent from every store" — after a DELETE the index IS absent, so
+    /// a later `create_index` + reindex could never be reported as
+    /// `INDEX_NOT_READY` again (the #4715 scenario).
+    /// What: removes the id from `entries`, `failed_entries`, and
+    /// `loading_gates`. Idempotent — an id in none of the three is a no-op, so
+    /// the delete path can call it unconditionally. Deliberately NOT identity-
+    /// guarded (unlike [`Self::mark_loaded_if`]): deregistration is a terminal
+    /// operation on the id itself, so there is no newer record worth keeping.
+    /// Test: `purge_removes_cold_and_failed_records`,
+    /// `purge_is_idempotent_for_unknown_id`,
+    /// `delete_index_clears_cold_store_so_status_is_404_not_503`.
+    pub fn purge(&self, id: &IndexId) {
+        self.entries.remove(id);
+        self.failed_entries.remove(id);
+        self.loading_gates.remove(id);
+    }
+
     /// Acquire or create the per-index loading gate.
     ///
     /// Why: double-checked lock — two concurrent queries for the same cold index

--- a/crates/trusty-search/src/service/lazy_restore.rs
+++ b/crates/trusty-search/src/service/lazy_restore.rs
@@ -150,6 +150,29 @@ pub(crate) async fn restore_index_on_demand(
     // treatment exactly, and reuses the existing #1106 `mark_failed` outcome
     // so a repeat query fails fast instead of retrying a doomed restore.
     if indexer.corpus_open_failed {
+        // #4253: a corpus open that lost a race (`DatabaseAlreadyOpen`) or ran
+        // past its deadline is CONTENTION, not breakage — the file was never
+        // read, so the corpus is presumed intact. Marking those permanently
+        // failed is how a ~20 s cold-start open plus one client retry turned a
+        // healthy 200k-chunk index into an unreachable one for the rest of the
+        // daemon's life. Reuse #4333's classification, which already draws
+        // exactly this line, instead of treating every open failure as fatal.
+        let transient = indexer
+            .corpus_open_failure
+            .map(|kind| kind.is_transient())
+            .unwrap_or(false);
+        if transient {
+            tracing::warn!(
+                "lazy-load: corpus open for cold index '{}' at {} failed transiently \
+                 ({:?}) — NOT registering a handle, but keeping the cold entry so the \
+                 next query retries once the competing opener releases the file \
+                 (issue #4253)",
+                entry.id,
+                entry.root_path.display(),
+                indexer.corpus_open_failure,
+            );
+            return;
+        }
         tracing::error!(
             "lazy-load: corpus open failed for cold index '{}' at {} — refusing to \
              register a broken index handle (issue #3993); marking permanently failed",

--- a/crates/trusty-search/src/service/lazy_restore.rs
+++ b/crates/trusty-search/src/service/lazy_restore.rs
@@ -98,11 +98,19 @@ pub(crate) async fn restore_index_on_demand(
     // they were parked; if it disappeared we skip gracefully (non-colocated path
     // used here — the relocation scan from issue #484 is a warm-boot-only flow).
     if !entry.root_path.exists() {
+        // #4253 review HIGH-2: this arm MUST mark the entry failed. Before
+        // #4253 it was terminated only by `get_or_load_index`'s unconditional
+        // `mark_loaded`; now that keeping the entry is the transient policy, a
+        // deleted root would otherwise return `503 index_loading` forever,
+        // re-entering restore on every query and staying counted in
+        // `/health`'s `indexes_lazy` for the daemon's life. A root that no
+        // longer exists is exactly the permanent case #1106 named.
         tracing::warn!(
-            "lazy-load: skipping index '{}' — root_path {} no longer exists",
+            "lazy-load: index '{}' permanently failed — root_path {} no longer exists",
             entry.id,
             entry.root_path.display(),
         );
+        state.cold_store.mark_failed(&id);
         return;
     }
 
@@ -121,10 +129,17 @@ pub(crate) async fn restore_index_on_demand(
     let mut indexer = match build_indexer_from_entry(&entry, embedder).await {
         Ok(idx) => idx,
         Err(e) => {
+            // #4253 review HIGH-2: same reasoning as the missing-root arm
+            // above. Left retryable, this re-opens the redb corpus and
+            // re-allocates the HNSW arena on EVERY query — the unbounded
+            // restore storm `ColdIndexStore::mark_failed`'s policy exists to
+            // prevent. The operator's remedy (restart or re-register) is the
+            // one `search_handler`'s 503 already names.
             tracing::error!(
-                "lazy-load: index '{}' HNSW allocator failed: {e} — skipping",
+                "lazy-load: index '{}' permanently failed — indexer build failed: {e}",
                 entry.id
             );
+            state.cold_store.mark_failed(&id);
             return;
         }
     };

--- a/crates/trusty-search/src/service/orphan_reaper.rs
+++ b/crates/trusty-search/src/service/orphan_reaper.rs
@@ -31,7 +31,7 @@
 
 use std::path::Path;
 
-use crate::service::persistence::{save_index_registry, PersistedIndex};
+use crate::service::persistence::PersistedIndex;
 
 /// Environment variable overriding the reaper cadence, in seconds. `0` disables
 /// the runtime reaper entirely; any unparseable value falls back to the default.
@@ -123,9 +123,14 @@ pub fn heal_boot_orphans(entries: Vec<PersistedIndex>) -> Vec<PersistedIndex> {
         return kept;
     }
 
-    // `entries` was the full contents of `indexes.toml`, so `kept` is exactly
-    // "everything minus the orphans" — a single atomic rewrite is correct.
-    if let Err(e) = save_index_registry(&kept) {
+    // #4317: remove BY ID rather than republishing `kept` wholesale. `entries`
+    // was read before the daemon started serving, so a whole-file rewrite from
+    // it erases any index registered in between — the reaper reporting a clean
+    // self-heal while silently deregistering live indexes is exactly the
+    // incident this issue tracks. Removing by id re-reads the current file under
+    // the registry write lock and drops only what was judged orphaned.
+    let orphan_ids: Vec<&str> = orphans.iter().map(|o| o.id.as_str()).collect();
+    if let Err(e) = crate::service::persistence::remove_index_registry_entries(&orphan_ids) {
         tracing::warn!(
             "orphan-reaper(boot): could not rewrite indexes.toml ({e}); {} orphaned \
              registration(s) left on disk (they will be retried next boot)",

--- a/crates/trusty-search/src/service/persistence.rs
+++ b/crates/trusty-search/src/service/persistence.rs
@@ -664,14 +664,57 @@ pub fn load_index_registry_at(path: &Path) -> Result<Vec<PersistedIndex>> {
     };
     match toml::from_str::<IndexRegistryFile>(&content) {
         Ok(file) => Ok(file.indexes),
+        // #4317 / #4871: this arm used to return `Ok(Vec::new())` — an
+        // unreadable registry read back as "no index was ever registered". The
+        // very next write then went load(empty) → push one → save, overwriting a
+        // real N-entry registry with a 1-entry file. That is the mass-
+        // deregistration signature both incidents recorded (73 → 31, then 42 →
+        // 5), and it is silent: every caller saw a successful write. An
+        // unparseable registry is now an ERROR, so `upsert`/`remove` propagate
+        // it and no save runs on top of a view that was never really read.
         Err(e) => {
-            tracing::warn!(
-                "indexes.toml at {} is corrupt ({e}); starting with empty registry",
+            anyhow::bail!(
+                "indexes.toml at {} could not be parsed ({e}); refusing to treat it as \
+                 an empty registry — a write on top of that view would deregister every \
+                 real index (#4317, #4871). Inspect or restore the file, then retry",
                 path.display()
-            );
-            Ok(Vec::new())
+            )
         }
     }
+}
+
+/// Serializes every `indexes.toml` read-modify-write in this process (#4871).
+///
+/// Why: each mutation is a load → mutate → whole-file save, and nothing
+/// ordered them. `search_handler` alone spawns a fire-and-forget
+/// `update_last_queried_unix` per query, so a busy daemon runs many of these
+/// concurrently against the same file, alongside registration handlers and the
+/// boot reaper. Any write landing between another task's load and its save was
+/// discarded with no error — the observed 80 → 88 → byte-identical-80 revert,
+/// where 8 real registrations vanished and every caller reported success. The
+/// original report blamed five concurrent daemons; the process census refuted
+/// that, and this is the mechanism that survives it: one daemon racing itself.
+/// What: a plain `Mutex<()>`. This is the one sanctioned `Lazy` static besides
+/// the tracing subscriber — the lock must be process-wide to mean anything, and
+/// threading it through every persistence caller would be a far larger change
+/// for identical semantics.
+/// Test: `concurrent_upserts_lose_no_entries`.
+static REGISTRY_WRITE_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
+/// Run `f` holding the process-wide registry write lock (#4871).
+///
+/// Why: see [`REGISTRY_WRITE_LOCK`]. Callers must hold it across BOTH the load
+/// and the save, never just the save — the discarded-write window is between
+/// them.
+/// What: acquires the lock (recovering a poisoned guard, since the data is a
+/// unit and a panicking holder cannot have corrupted it) and runs `f`.
+/// Test: `concurrent_upserts_lose_no_entries`.
+fn with_registry_write_lock<T>(f: impl FnOnce() -> Result<T>) -> Result<T> {
+    let _guard = REGISTRY_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    f()
 }
 
 /// Persist the registry atomically (write-tmp + rename) so a crash mid-write
@@ -681,14 +724,26 @@ pub fn save_index_registry(entries: &[PersistedIndex]) -> Result<()> {
 }
 
 /// Path-injectable variant of [`save_index_registry`].
+///
+/// #4317: the staging file is now unique per write (pid + a monotonic counter)
+/// instead of the single shared `indexes.toml.tmp`. Two writers racing on one
+/// fixed tmp path interleave their `write` calls, and the rename then publishes
+/// a spliced, unparseable registry — which, before the fail-closed load above,
+/// read back as an empty registry and took every real index with it.
 pub fn save_index_registry_at(path: &Path, entries: &[PersistedIndex]) -> Result<()> {
     let file = IndexRegistryFile {
         indexes: entries.to_vec(),
     };
     let serialized = toml::to_string_pretty(&file).context("serialize indexes.toml")?;
-    let tmp = path.with_extension("toml.tmp");
+    static WRITE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = WRITE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("toml.tmp.{}.{seq}", std::process::id()));
     std::fs::write(&tmp, serialized).context("write indexes.toml tmp")?;
-    std::fs::rename(&tmp, path).context("rename indexes.toml")?;
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        // Never leave a uniquely-named staging file behind on a failed publish.
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e).context("rename indexes.toml");
+    }
     Ok(())
 }
 
@@ -707,16 +762,20 @@ pub fn upsert_index_registry_entry(entry: PersistedIndex) -> Result<()> {
 /// supplied TOML path. Used by the persistence tests (issue #118) to assert
 /// that re-registering the same id never produces a duplicate `[[index]]`.
 pub fn upsert_index_registry_entry_at(path: &Path, entry: PersistedIndex) -> Result<()> {
-    let mut entries = load_index_registry_at(path)?;
-    if let Some(existing) = entries.iter_mut().find(|e| e.id == entry.id) {
-        // Overwrite the whole record (not just root_path) so updated
-        // `include_paths`/`exclude_globs`/`extensions`/`domain_terms` from
-        // `trusty-search.yaml` flow through to disk on re-registration.
-        *existing = entry;
-    } else {
-        entries.push(entry);
-    }
-    save_index_registry_at(path, &entries)
+    // #4871: load and save must be one critical section — a registration that
+    // lands between them is otherwise overwritten out of existence, silently.
+    with_registry_write_lock(|| {
+        let mut entries = load_index_registry_at(path)?;
+        if let Some(existing) = entries.iter_mut().find(|e| e.id == entry.id) {
+            // Overwrite the whole record (not just root_path) so updated
+            // `include_paths`/`exclude_globs`/`extensions`/`domain_terms` from
+            // `trusty-search.yaml` flow through to disk on re-registration.
+            *existing = entry;
+        } else {
+            entries.push(entry);
+        }
+        save_index_registry_at(path, &entries)
+    })
 }
 
 /// Remove an entry from the registry file. Silently no-ops when the id is
@@ -737,13 +796,43 @@ pub fn remove_index_registry_entry(id: &str) -> Result<()> {
 
 /// Path-injectable variant of [`remove_index_registry_entry`].
 pub fn remove_index_registry_entry_at(path: &Path, id: &str) -> Result<()> {
-    let mut entries = load_index_registry_at(path)?;
-    let before = entries.len();
-    entries.retain(|e| e.id != id);
-    if entries.len() == before {
+    remove_index_registry_entries_at(path, std::slice::from_ref(&id))
+}
+
+/// Remove many entries by id in ONE read-modify-write (#4317).
+///
+/// Why: the boot orphan-reaper used to publish its survivors with
+/// `save_index_registry(&kept)` — a whole-file overwrite from a snapshot taken
+/// before the daemon began serving. Any index registered while the reaper was
+/// deciding was erased by that write, with the reaper's own log line reporting a
+/// successful self-heal. Removing BY ID re-reads the current file under the lock
+/// and drops only the ids actually judged orphaned, so a concurrent registration
+/// survives the sweep instead of being collateral.
+/// What: loads under the write lock, retains everything whose id is not in
+/// `ids`, and saves only when something was actually dropped. Ids that are
+/// absent are a no-op (idempotent delete).
+/// Test: `remove_entries_by_id_preserves_concurrent_registration`,
+/// `remove_entries_by_id_is_idempotent`.
+pub fn remove_index_registry_entries_at(path: &Path, ids: &[&str]) -> Result<()> {
+    if ids.is_empty() {
         return Ok(());
     }
-    save_index_registry_at(path, &entries)
+    with_registry_write_lock(|| {
+        let mut entries = load_index_registry_at(path)?;
+        let before = entries.len();
+        entries.retain(|e| !ids.iter().any(|id| *id == e.id));
+        if entries.len() == before {
+            return Ok(());
+        }
+        save_index_registry_at(path, &entries)
+    })
+}
+
+/// Remove many entries by id from the process-resolved registry path (#4317).
+///
+/// Why/What/Test: see [`remove_index_registry_entries_at`].
+pub fn remove_index_registry_entries(ids: &[&str]) -> Result<()> {
+    remove_index_registry_entries_at(&indexes_toml_path()?, ids)
 }
 
 /// Delete the on-disk data directory for an index (HNSW + chunks).

--- a/crates/trusty-search/src/service/persistence.rs
+++ b/crates/trusty-search/src/service/persistence.rs
@@ -738,6 +738,7 @@ pub fn save_index_registry_at(path: &Path, entries: &[PersistedIndex]) -> Result
     static WRITE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let seq = WRITE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = path.with_extension(format!("toml.tmp.{}.{seq}", std::process::id()));
+    reap_stale_staging_files(path);
     std::fs::write(&tmp, serialized).context("write indexes.toml tmp")?;
     if let Err(e) = std::fs::rename(&tmp, path) {
         // Never leave a uniquely-named staging file behind on a failed publish.
@@ -745,6 +746,54 @@ pub fn save_index_registry_at(path: &Path, entries: &[PersistedIndex]) -> Result
         return Err(e).context("rename indexes.toml");
     }
     Ok(())
+}
+
+/// How long an abandoned `indexes.toml.tmp.*` survives before a later write
+/// sweeps it. Comfortably longer than any real write, short enough that a crash
+/// does not leave litter for the machine's lifetime.
+const STAGING_STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(3600);
+
+/// Delete `indexes.toml.tmp.*` files older than [`STAGING_STALE_AFTER`] (#4317).
+///
+/// Why (review LOW): per-write staging names fixed the shared-tmp collision but
+/// removed the accidental cleanup the single fixed name provided — a crash
+/// between `write` and `rename` now leaks a uniquely-named file that nothing
+/// ever reclaims. Sweeping on write keeps the data dir bounded without adding a
+/// boot-time pass or a ticker.
+/// What: best-effort. Scans the registry file's parent for siblings whose name
+/// starts with `<stem>.toml.tmp.` and unlinks those older than the window.
+/// Every failure is swallowed — this is tidiness, and it must never fail a
+/// registry write. Live files are protected by the age window, so a concurrent
+/// writer's staging file is never removed out from under it.
+/// Test: `stale_staging_files_are_reaped_fresh_ones_are_not`.
+fn reap_stale_staging_files(registry_path: &Path) {
+    let (Some(dir), Some(stem)) = (
+        registry_path.parent(),
+        registry_path.file_stem().and_then(|s| s.to_str()),
+    ) else {
+        return;
+    };
+    let prefix = format!("{stem}.toml.tmp.");
+    let Ok(read_dir) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let now = std::time::SystemTime::now();
+    for entry in read_dir.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with(&prefix) {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|modified| now.duration_since(modified).ok())
+            .is_some_and(|age| age > STAGING_STALE_AFTER);
+        if stale {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
 }
 
 /// Append (or upsert) one entry to the registry file. Idempotent — re-adding
@@ -811,7 +860,7 @@ pub fn remove_index_registry_entry_at(path: &Path, id: &str) -> Result<()> {
 /// What: loads under the write lock, retains everything whose id is not in
 /// `ids`, and saves only when something was actually dropped. Ids that are
 /// absent are a no-op (idempotent delete).
-/// Test: `remove_entries_by_id_preserves_concurrent_registration`,
+/// Test: `boot_orphan_reap_preserves_a_registration_made_after_its_snapshot`,
 /// `remove_entries_by_id_is_idempotent`.
 pub fn remove_index_registry_entries_at(path: &Path, ids: &[&str]) -> Result<()> {
     if ids.is_empty() {
@@ -833,6 +882,36 @@ pub fn remove_index_registry_entries_at(path: &Path, ids: &[&str]) -> Result<()>
 /// Why/What/Test: see [`remove_index_registry_entries_at`].
 pub fn remove_index_registry_entries(ids: &[&str]) -> Result<()> {
     remove_index_registry_entries_at(&indexes_toml_path()?, ids)
+}
+
+/// Patch one existing entry in place, entirely inside the write lock (#4871).
+///
+/// Why (review MEDIUM): the LRU timestamp writers loaded the registry, found
+/// their entry, mutated the clone, and only THEN called `upsert…`, which loads
+/// again under the lock. The find happened OUTSIDE the critical section, so a
+/// concurrent writer's change to a DIFFERENT field of the same entry (e.g.
+/// `last_indexed_unix` while this one writes `last_queried_unix`) was
+/// overwritten by the stale clone. Reading and writing under one lock makes
+/// the read-modify-write actually atomic.
+/// What: loads under the lock, applies `patch` to the entry whose id matches,
+/// and saves. A missing id is `Ok(())` with no write — the entry may have been
+/// deleted between the caller's decision and this call, which is harmless.
+/// `patch` must not itself touch the registry (it runs while the lock is held).
+/// Test: `patch_entry_is_atomic_against_a_concurrent_field_write`,
+/// `patch_entry_for_a_missing_id_is_a_no_op`.
+pub fn patch_index_registry_entry_at(
+    path: &Path,
+    id: &str,
+    patch: impl FnOnce(&mut PersistedIndex),
+) -> Result<()> {
+    with_registry_write_lock(|| {
+        let mut entries = load_index_registry_at(path)?;
+        let Some(entry) = entries.iter_mut().find(|e| e.id == id) else {
+            return Ok(());
+        };
+        patch(entry);
+        save_index_registry_at(path, &entries)
+    })
 }
 
 /// Delete the on-disk data directory for an index (HNSW + chunks).

--- a/crates/trusty-search/src/service/persistence_tests.rs
+++ b/crates/trusty-search/src/service/persistence_tests.rs
@@ -849,35 +849,95 @@ fn concurrent_upserts_lose_no_entries() {
     }
 }
 
-/// #4317: the boot reaper removes orphans BY ID, so an index registered while
-/// it was deciding survives the sweep.
+/// #4317: the boot reaper's own partition + removal must not erase an index
+/// registered after its snapshot was taken.
 ///
-/// Why: the reaper published its survivors with `save_index_registry(&kept)` —
-/// a whole-file overwrite from a snapshot taken before the daemon began serving.
-/// Anything registered in between was erased, while the reaper logged a clean
-/// self-heal. That is registry loss caused by the cleanup, not by the orphans.
-/// What: models the window directly — snapshot two entries, register a third
-/// out of band, then remove one of the original two by id. Asserts the newcomer
-/// survives. Pre-fix, replaying the snapshot's survivors would drop it.
+/// Why (review MEDIUM): the previous version of this test called
+/// `remove_index_registry_entries_at` directly, so at the parent commit it
+/// failed only because that symbol did not exist — proving nothing about the
+/// reaper. The defect is in `heal_boot_orphans`, which used to publish its
+/// survivors with a whole-file `save_index_registry(&kept)` built from a
+/// pre-boot snapshot: anything registered while it was deciding was erased,
+/// while the reaper logged a clean self-heal.
+/// What: drives the reaper's real partition (`partition_boot_orphans`, the
+/// same call `heal_boot_orphans` makes) over a snapshot, registers a third
+/// index out of band the way a concurrent `POST /indexes` would, then removes
+/// the judged orphans by id — the sequence the fixed reaper performs. Asserts
+/// the newcomer survives. Replaying `kept` instead, which is what the code did
+/// before, drops it.
 /// Test: this test.
 #[test]
-fn remove_entries_by_id_preserves_concurrent_registration() {
+fn boot_orphan_reap_preserves_a_registration_made_after_its_snapshot() {
+    use crate::service::orphan_reaper::partition_boot_orphans;
+
     let tmp = tempfile::tempdir().expect("tempdir");
     let path = tmp.path().join("indexes.toml");
-    save_index_registry_at(&path, &[reg_entry("keep-me"), reg_entry("orphan")])
-        .expect("seed registry");
+    // A live root (this temp dir) and a reapable orphan (deleted child whose
+    // parent still exists — `is_reapable_orphan`'s exact shape).
+    let live = PersistedIndex {
+        id: "keep-me".to_string(),
+        root_path: tmp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let orphan = PersistedIndex {
+        id: "orphan".to_string(),
+        root_path: tmp.path().join("deleted-worktree"),
+        ..Default::default()
+    };
+    let snapshot = vec![live.clone(), orphan.clone()];
+    save_index_registry_at(&path, &snapshot).expect("seed registry");
 
-    // A registration lands after the reaper read the file but before it writes.
-    upsert_index_registry_entry_at(&path, reg_entry("registered-mid-sweep"))
-        .expect("concurrent registration");
+    // The reaper's decision, taken over the snapshot it read at boot.
+    let (orphans, kept) = partition_boot_orphans(snapshot);
+    assert_eq!(
+        orphans.iter().map(|o| o.id.as_str()).collect::<Vec<_>>(),
+        vec!["orphan"],
+        "precondition: exactly the deleted root is judged orphaned"
+    );
+    assert_eq!(kept.len(), 1, "precondition: one survivor in the snapshot");
 
-    remove_index_registry_entries_at(&path, &["orphan"]).expect("reap the orphan");
+    // A registration lands after that snapshot but before the reaper writes.
+    upsert_index_registry_entry_at(
+        &path,
+        PersistedIndex {
+            id: "registered-mid-sweep".to_string(),
+            root_path: tmp.path().to_path_buf(),
+            ..Default::default()
+        },
+    )
+    .expect("concurrent registration");
+
+    // The OLD reaper republished its snapshot's survivors wholesale. Run that
+    // against an identical copy to show the defect directly, rather than
+    // relying on which commit this test happens to run at — the by-id fix is
+    // already an ancestor of this one, so a bare pre-fix run would pass.
+    let old_way = tmp.path().join("old-way.toml");
+    std::fs::copy(&path, &old_way).expect("copy registry");
+    save_index_registry_at(&old_way, &kept).expect("replay the survivors snapshot");
+    let old_ids: Vec<String> = load_index_registry_at(&old_way)
+        .expect("load")
+        .into_iter()
+        .map(|e| e.id)
+        .collect();
+    assert!(
+        !old_ids.iter().any(|id| id == "registered-mid-sweep"),
+        "#4317 precondition: republishing the pre-boot snapshot is what ERASED \
+         the concurrent registration. If this no longer holds, the assertion \
+         below proves nothing. Got {old_ids:?}"
+    );
+
+    // What the fixed reaper does: remove the judged orphans BY ID.
+    let orphan_ids: Vec<&str> = orphans.iter().map(|o| o.id.as_str()).collect();
+    remove_index_registry_entries_at(&path, &orphan_ids).expect("reap");
 
     let entries = load_index_registry_at(&path).expect("load");
     let ids: Vec<&str> = entries.iter().map(|e| e.id.as_str()).collect();
     assert!(
         ids.contains(&"registered-mid-sweep"),
-        "#4317: an index registered during the sweep must not be collateral; got {ids:?}"
+        "#4317: an index registered during the sweep must not be collateral. \
+         Republishing the reaper's `kept` snapshot ({} entries) instead of \
+         removing by id is what erased it. Got {ids:?}",
+        kept.len(),
     );
     assert!(
         ids.contains(&"keep-me"),
@@ -907,4 +967,125 @@ fn remove_entries_by_id_is_idempotent() {
 
     let entries = load_index_registry_at(&path).expect("load");
     assert_eq!(entries.len(), 2, "an unknown id must remove nothing");
+}
+
+/// #4317 review LOW: an abandoned staging file is reaped once it ages out, and
+/// a fresh one is never touched.
+///
+/// Why: per-write staging names fixed the shared-tmp collision but removed the
+/// accidental cleanup a single fixed name gave — a crash between `write` and
+/// `rename` now leaks a uniquely-named file nothing reclaims. The age window is
+/// what keeps the sweep from deleting a concurrent writer's live staging file.
+/// What: plants one stale and one fresh `indexes.toml.tmp.*`, performs a normal
+/// save, and asserts only the stale one is gone.
+/// Test: this test.
+#[test]
+fn stale_staging_files_are_reaped_fresh_ones_are_not() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("indexes.toml");
+    save_index_registry_at(&path, &[reg_entry("live")]).expect("seed");
+
+    let stale = tmp.path().join("indexes.toml.tmp.999.0");
+    let fresh = tmp.path().join("indexes.toml.tmp.999.1");
+    let unrelated = tmp.path().join("indexes.toml.bak-something");
+    std::fs::write(&stale, "junk").expect("write stale");
+    std::fs::write(&fresh, "junk").expect("write fresh");
+    std::fs::write(&unrelated, "junk").expect("write unrelated");
+    // Age the stale one past the window.
+    let old =
+        std::time::SystemTime::now() - STAGING_STALE_AFTER - std::time::Duration::from_secs(60);
+    filetime::set_file_mtime(&stale, filetime::FileTime::from_system_time(old))
+        .expect("backdate stale staging file");
+
+    save_index_registry_at(&path, &[reg_entry("live"), reg_entry("second")]).expect("save");
+
+    assert!(
+        !stale.exists(),
+        "#4317: an aged-out staging file must be reaped"
+    );
+    assert!(
+        fresh.exists(),
+        "#4317: a fresh staging file may belong to a concurrent writer — never reap it"
+    );
+    assert!(
+        unrelated.exists(),
+        "#4317: only `indexes.toml.tmp.*` is in scope; a backup must survive"
+    );
+    let entries = load_index_registry_at(&path).expect("registry still parses");
+    assert_eq!(entries.len(), 2, "the save itself must still have worked");
+}
+
+/// #4871 review MEDIUM: `patch_index_registry_entry_at` does its find-and-patch
+/// inside the write lock, so a concurrent write to a DIFFERENT field of the
+/// same entry is not clobbered.
+///
+/// Why: the LRU timestamp writers used to load, find their entry, mutate a
+/// clone, and only then upsert — and the upsert re-loaded under the lock. The
+/// find happened outside the critical section, so `update_last_queried_unix`
+/// and `update_last_indexed_unix` racing on one entry could each persist a copy
+/// that had never seen the other's field.
+/// What: hammers one entry from two thread pools, one setting
+/// `last_queried_unix` and the other `last_indexed_unix`, then asserts BOTH
+/// fields survived. A load-clone-upsert implementation drops one of them.
+/// Test: this test.
+#[test]
+fn patch_entry_is_atomic_against_a_concurrent_field_write() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("indexes.toml");
+    save_index_registry_at(&path, &[reg_entry("hot")]).expect("seed");
+
+    const ROUNDS: u64 = 40;
+    std::thread::scope(|scope| {
+        scope.spawn(|| {
+            for n in 1..=ROUNDS {
+                patch_index_registry_entry_at(&path, "hot", |e| e.last_queried_unix = Some(n))
+                    .expect("queried patch");
+            }
+        });
+        scope.spawn(|| {
+            for n in 1..=ROUNDS {
+                patch_index_registry_entry_at(&path, "hot", |e| e.last_indexed_unix = Some(n))
+                    .expect("indexed patch");
+            }
+        });
+    });
+
+    let entries = load_index_registry_at(&path).expect("registry must still parse");
+    assert_eq!(entries.len(), 1, "no entry may be lost: {entries:?}");
+    let hot = &entries[0];
+    assert_eq!(
+        hot.last_queried_unix,
+        Some(ROUNDS),
+        "#4871: the last `last_queried_unix` write must survive — a stale clone \
+         from outside the lock is what overwrote it"
+    );
+    assert_eq!(
+        hot.last_indexed_unix,
+        Some(ROUNDS),
+        "#4871: and the concurrent `last_indexed_unix` write must survive too; \
+         losing either field is the clobber this patch helper exists to prevent"
+    );
+}
+
+/// A patch for an id that is not in the registry is a silent no-op.
+///
+/// Why: the timestamp writers fire after a query, and the index may have been
+/// deleted in between — that must not error or create a rootless entry.
+/// What: patches a missing id, asserts `Ok` and an unchanged file.
+/// Test: this test.
+#[test]
+fn patch_entry_for_a_missing_id_is_a_no_op() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("indexes.toml");
+    save_index_registry_at(&path, &[reg_entry("present")]).expect("seed");
+    let before = std::fs::read_to_string(&path).expect("read");
+
+    patch_index_registry_entry_at(&path, "absent", |e| e.last_queried_unix = Some(7))
+        .expect("a missing id must not be an error");
+
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read"),
+        before,
+        "a no-op patch must not rewrite the file"
+    );
 }

--- a/crates/trusty-search/src/service/persistence_tests.rs
+++ b/crates/trusty-search/src/service/persistence_tests.rs
@@ -749,3 +749,162 @@ fn production_data_dir_is_the_real_user_location() {
         "the production data dir must stay the operator's real location"
     );
 }
+
+// ─── #4317 / #4871: registry read-modify-write integrity ─────────────────────
+
+/// Build a minimal entry for the registry-integrity tests below.
+fn reg_entry(id: &str) -> PersistedIndex {
+    PersistedIndex {
+        id: id.to_string(),
+        root_path: PathBuf::from(format!("/tmp/{id}")),
+        ..Default::default()
+    }
+}
+
+/// #4317 / #4871: an unparseable `indexes.toml` must be an ERROR, and the write
+/// that follows must not run — the file is left byte-for-byte intact.
+///
+/// Why: this is the fail-open at the centre of both incidents. The loader mapped
+/// a TOML parse failure to `Ok(vec![])`, so an unreadable registry read back as
+/// "no index was ever registered". `upsert_index_registry_entry_at` then went
+/// load(empty) → push one → save, publishing a 1-entry file over a real N-entry
+/// registry and reporting success to its caller. That is the mass-deregistration
+/// signature both issues recorded (73 → 31; 42 → 5 across six restarts).
+/// What: writes a corrupt registry, asserts the load errors, drives an upsert,
+/// asserts it errors and that the on-disk bytes are unchanged. Pre-fix the load
+/// returns `Ok([])`, the upsert returns `Ok(())`, and the file is replaced by a
+/// single `[[index]]` block — so all three assertions fail.
+/// Test: this test.
+#[test]
+fn corrupt_registry_is_an_error_and_is_never_overwritten() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("indexes.toml");
+    let corrupt = "[[index]]\nid = \"real-one\"\nroot_pa";
+    std::fs::write(&path, corrupt).expect("write corrupt registry");
+
+    let loaded = load_index_registry_at(&path);
+    assert!(
+        loaded.is_err(),
+        "#4317: a corrupt registry must NOT read back as an empty one — that view \
+         is what every subsequent save deregisters the whole fleet from"
+    );
+
+    let upsert = upsert_index_registry_entry_at(&path, reg_entry("newcomer"));
+    assert!(
+        upsert.is_err(),
+        "#4871: a write on top of an unreadable registry must fail loudly, not \
+         report success while discarding every real entry"
+    );
+
+    let after = std::fs::read_to_string(&path).expect("registry still readable");
+    assert_eq!(
+        after, corrupt,
+        "#4317: the corrupt file must be left intact for recovery, not replaced"
+    );
+}
+
+/// #4871: concurrent registrations must all survive — none may be discarded by
+/// another writer's stale snapshot.
+///
+/// Why: every mutation is load → mutate → whole-file save and nothing ordered
+/// them. A busy daemon runs many concurrently (`search_handler` spawns a
+/// fire-and-forget `update_last_queried_unix` per query alongside the
+/// registration handlers), so a write landing between another task's load and
+/// its save was silently erased — the observed 80 → 88 → byte-identical-80
+/// revert where 8 real registrations vanished and every caller saw success.
+/// What: 16 threads each upsert a distinct id into one registry file, then
+/// assert all 16 are present. Pre-fix this drops entries nondeterministically.
+/// Test: this test.
+#[test]
+fn concurrent_upserts_lose_no_entries() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("indexes.toml");
+    save_index_registry_at(&path, &[]).expect("seed empty registry");
+
+    const WRITERS: usize = 16;
+    std::thread::scope(|scope| {
+        for n in 0..WRITERS {
+            let path = path.clone();
+            scope.spawn(move || {
+                upsert_index_registry_entry_at(&path, reg_entry(&format!("idx-{n}")))
+                    .expect("upsert must succeed");
+            });
+        }
+    });
+
+    let entries = load_index_registry_at(&path).expect("registry must still parse");
+    assert_eq!(
+        entries.len(),
+        WRITERS,
+        "#4871: every concurrent registration must survive; lost {} of {WRITERS}. \
+         A discarded write is indistinguishable from a successful one to its caller",
+        WRITERS - entries.len(),
+    );
+    for n in 0..WRITERS {
+        let want = format!("idx-{n}");
+        assert!(
+            entries.iter().any(|e| e.id == want),
+            "#4871: '{want}' was written but is absent from the registry"
+        );
+    }
+}
+
+/// #4317: the boot reaper removes orphans BY ID, so an index registered while
+/// it was deciding survives the sweep.
+///
+/// Why: the reaper published its survivors with `save_index_registry(&kept)` —
+/// a whole-file overwrite from a snapshot taken before the daemon began serving.
+/// Anything registered in between was erased, while the reaper logged a clean
+/// self-heal. That is registry loss caused by the cleanup, not by the orphans.
+/// What: models the window directly — snapshot two entries, register a third
+/// out of band, then remove one of the original two by id. Asserts the newcomer
+/// survives. Pre-fix, replaying the snapshot's survivors would drop it.
+/// Test: this test.
+#[test]
+fn remove_entries_by_id_preserves_concurrent_registration() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("indexes.toml");
+    save_index_registry_at(&path, &[reg_entry("keep-me"), reg_entry("orphan")])
+        .expect("seed registry");
+
+    // A registration lands after the reaper read the file but before it writes.
+    upsert_index_registry_entry_at(&path, reg_entry("registered-mid-sweep"))
+        .expect("concurrent registration");
+
+    remove_index_registry_entries_at(&path, &["orphan"]).expect("reap the orphan");
+
+    let entries = load_index_registry_at(&path).expect("load");
+    let ids: Vec<&str> = entries.iter().map(|e| e.id.as_str()).collect();
+    assert!(
+        ids.contains(&"registered-mid-sweep"),
+        "#4317: an index registered during the sweep must not be collateral; got {ids:?}"
+    );
+    assert!(
+        ids.contains(&"keep-me"),
+        "healthy entry must survive: {ids:?}"
+    );
+    assert!(
+        !ids.contains(&"orphan"),
+        "the judged orphan must actually be removed: {ids:?}"
+    );
+}
+
+/// #4317: removing ids that are absent is a no-op, and the file is untouched.
+///
+/// Why: the reaper calls this on every boot; an idempotent delete keeps a
+/// repeated sweep from churning the file (and from being a second write window).
+/// What: removes two unknown ids from a two-entry registry, asserts both entries
+/// remain.
+/// Test: this test.
+#[test]
+fn remove_entries_by_id_is_idempotent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("indexes.toml");
+    save_index_registry_at(&path, &[reg_entry("a"), reg_entry("b")]).expect("seed");
+
+    remove_index_registry_entries_at(&path, &["nope", "also-nope"]).expect("no-op remove");
+    remove_index_registry_entries_at(&path, &[]).expect("empty remove");
+
+    let entries = load_index_registry_at(&path).expect("load");
+    assert_eq!(entries.len(), 2, "an unknown id must remove nothing");
+}

--- a/crates/trusty-search/src/service/persistence_timestamps.rs
+++ b/crates/trusty-search/src/service/persistence_timestamps.rs
@@ -11,7 +11,7 @@
 use anyhow::Result;
 
 use super::persistence::{
-    indexes_toml_path, load_index_registry_at, upsert_index_registry_entry_at, PersistedIndex,
+    indexes_toml_path, load_index_registry_at, patch_index_registry_entry_at, PersistedIndex,
 };
 
 /// Compute the LRU sort key for lazy warm-boot ordering (issue #993).
@@ -57,15 +57,15 @@ pub fn read_last_queried_unix(index_id: &str) -> Option<u64> {
 /// What: upserts the entry in `indexes.toml` with the updated timestamp.
 /// No-op when the index_id is not found (the entry may have been deleted).
 /// Test: `update_last_queried_unix_roundtrip` in persistence::tests.
+/// #4871 review MEDIUM: the find happens INSIDE the registry write lock now.
+/// Loading, patching a clone, and only then upserting let a concurrent
+/// `update_last_indexed_unix` on the same entry be overwritten by this one's
+/// stale copy.
 pub fn update_last_queried_unix(index_id: &str, now_unix: u64) -> Result<()> {
     let path = indexes_toml_path()?;
-    let mut entries = load_index_registry_at(&path).unwrap_or_default();
-    let Some(entry) = entries.iter_mut().find(|e| e.id == index_id) else {
-        return Ok(()); // Deleted between query and write — harmless.
-    };
-    entry.last_queried_unix = Some(now_unix);
-    let updated = entry.clone();
-    upsert_index_registry_entry_at(&path, updated)
+    patch_index_registry_entry_at(&path, index_id, |entry| {
+        entry.last_queried_unix = Some(now_unix);
+    })
 }
 
 /// Write `now_unix` into the `last_indexed_unix` field of an existing entry.
@@ -75,15 +75,12 @@ pub fn update_last_queried_unix(index_id: &str, now_unix: u64) -> Result<()> {
 /// What: upserts the entry in `indexes.toml` with the updated timestamp.
 /// No-op when the index_id is not found.
 /// Test: `update_last_indexed_unix_roundtrip` in persistence::tests.
+/// #4871 review MEDIUM: see [`update_last_queried_unix`] — same atomicity fix.
 pub fn update_last_indexed_unix(index_id: &str, now_unix: u64) -> Result<()> {
     let path = indexes_toml_path()?;
-    let mut entries = load_index_registry_at(&path).unwrap_or_default();
-    let Some(entry) = entries.iter_mut().find(|e| e.id == index_id) else {
-        return Ok(());
-    };
-    entry.last_indexed_unix = Some(now_unix);
-    let updated = entry.clone();
-    upsert_index_registry_entry_at(&path, updated)
+    patch_index_registry_entry_at(&path, index_id, |entry| {
+        entry.last_indexed_unix = Some(now_unix);
+    })
 }
 
 #[cfg(test)]

--- a/crates/trusty-search/src/service/reindex/mod.rs
+++ b/crates/trusty-search/src/service/reindex/mod.rs
@@ -70,7 +70,9 @@ mod hash_cache;
 mod prune;
 pub mod quarantine;
 mod staging;
-mod validate;
+// #4951: `reindex_handlers` mirrors this module's #2178 trust gate at the HTTP
+// boundary so an accepted root override always gets the walk it depends on.
+pub(crate) mod validate;
 
 // ── public re-exports (external crate::service::reindex::* paths) ────────────
 

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -59,6 +59,9 @@ mod tests_4123;
 // Issue #4715: an index-scoped 404 must rule out the cold store.
 #[cfg(test)]
 mod tests_4715;
+// #4951: a reindex root_path override must not empty every search result.
+#[cfg(test)]
+mod tests_4951;
 // #4250: timeout-parked index recovery and the /health un-latch.
 #[cfg(test)]
 mod tests_4250;

--- a/crates/trusty-search/src/service/server/reindex_handlers.rs
+++ b/crates/trusty-search/src/service/server/reindex_handlers.rs
@@ -20,7 +20,9 @@ use std::time::Duration;
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::core::registry::{IndexHandle, IndexId};
-use crate::service::reindex::{spawn_reindex_with_cleanup, ReindexProgress, ReindexStatus};
+use crate::service::reindex::{
+    spawn_reindex_with_cleanup, validate, ReindexProgress, ReindexStatus,
+};
 
 use super::helpers::{find_root_path_collision, validate_root_path};
 use super::state::SearchAppState;
@@ -170,6 +172,60 @@ pub(super) async fn reindex_handler(
                     })),
                 ));
             }
+            // #4951 review HIGH-1: refuse an override the reindex runner will
+            // refuse anyway. Syncing the indexer root below is only sound if
+            // the walk that re-relativizes the corpus against `new_root`
+            // actually runs. When the corpus's `indexed_root` disagrees with
+            // `new_root`, `runner.rs` re-checks `root_move_is_trusted` against
+            // the PERSISTED `indexes.toml` root and aborts before walking
+            // (#2178) — leaving chunks relative to the old root while the
+            // indexer resolves them against the new one. `file_is_within_root`
+            // is a lexical prefix test with no existence check, so every such
+            // path would pass it and `stale_index_root` would read `false`:
+            // a dangling (or wrong-file) result reported as healthy. Mirroring
+            // the runner's own gate here keeps the two decisions identical, so
+            // an accepted override always gets its walk.
+            let prior_indexed_root = handle.read_indexed_root().await.unwrap_or(None);
+            if validate::needs_path_relativization(prior_indexed_root.as_deref(), &new_root) {
+                let persisted_root = match &state.registry_path_override {
+                    Some(path) => crate::service::persistence::load_index_registry_at(path),
+                    None => crate::service::persistence::load_index_registry(),
+                }
+                .ok()
+                .and_then(|entries| entries.into_iter().find(|e| e.id == index_id.0))
+                .map(|e| e.root_path);
+                if !validate::root_move_is_trusted(persisted_root.as_deref(), &new_root) {
+                    tracing::warn!(
+                        "reindex_handler: refusing root_path override for '{}' to {} — the \
+                         corpus was last relativized against {:?} and the persisted \
+                         indexes.toml root_path is {:?}; the reindex would abort at the \
+                         #2178 guard, leaving chunk paths relative to a root the index no \
+                         longer claims (issue #4951)",
+                        index_id.0,
+                        new_root.display(),
+                        prior_indexed_root,
+                        persisted_root,
+                    );
+                    return Err((
+                        StatusCode::CONFLICT,
+                        Json(serde_json::json!({
+                            "error": format!(
+                                "root_path {:?} disagrees with this index's last-indexed root \
+                                 {:?} and its persisted indexes.toml root_path {:?}; a reindex \
+                                 override cannot durably move an index — use POST \
+                                 /indexes/{}/relocate for an explicit, persisted move \
+                                 (issues #2178, #4951)",
+                                new_root.display(),
+                                prior_indexed_root,
+                                persisted_root,
+                                index_id.0,
+                            ),
+                            "indexed_root": prior_indexed_root,
+                            "persisted_root": persisted_root,
+                        })),
+                    ));
+                }
+            }
             if handle.root_path.as_os_str().is_empty() || handle.root_path != new_root {
                 let indexer = Arc::clone(&handle.indexer);
                 // #4951: the override rebuilds the handle around this SAME
@@ -181,7 +237,16 @@ pub(super) async fn reindex_handler(
                 // against the NEW one, so every candidate was discarded and
                 // search returned `results: []` with `stale_index_root: true`
                 // on an index reporting `status: ready` and 85k chunks.
-                indexer.write().await.set_root_path(new_root.clone());
+                //
+                // Review MEDIUM: the guard is held across `registry.register`
+                // below, not dropped right after the write. A search that grabs
+                // the indexer read lock in between would otherwise materialize
+                // against the NEW indexer root while `search_handler`'s
+                // post-filter still holds the OLD handle — the same divergence,
+                // narrowed to a race window instead of made permanent.
+                let indexer_for_guard = Arc::clone(&indexer);
+                let mut indexer_guard = indexer_for_guard.write().await;
+                indexer_guard.set_root_path(new_root.clone());
                 // Preserve the filter set / domain vocabulary recorded on the
                 // existing handle — only the root_path is being overridden.
                 let new_handle = IndexHandle {
@@ -240,6 +305,8 @@ pub(super) async fn reindex_handler(
                 // `relocate_index_handler`. See `mark_loaded_if` below.
                 let cold_entry_before_register = state.cold_store.entry_token(&index_id);
                 handle = state.registry.register(new_handle);
+                // Both roots are now the new one; readers may proceed.
+                drop(indexer_guard);
                 // Issue #3993 review round 3 (HIGH, applied here for
                 // consistency with create/relocate): reap any stale
                 // `state.cold_store` record parked under this SAME id. Same

--- a/crates/trusty-search/src/service/server/reindex_handlers.rs
+++ b/crates/trusty-search/src/service/server/reindex_handlers.rs
@@ -172,6 +172,16 @@ pub(super) async fn reindex_handler(
             }
             if handle.root_path.as_os_str().is_empty() || handle.root_path != new_root {
                 let indexer = Arc::clone(&handle.indexer);
+                // #4951: the override rebuilds the handle around this SAME
+                // indexer Arc, so the indexer's own `root_path` — the base
+                // every root-relative chunk path is joined against to produce
+                // the absolute `CodeChunk::file` — must move with it. Left
+                // stale, materialization joined against the OLD root while
+                // `search_handler`'s `file_is_within_root` post-filter compared
+                // against the NEW one, so every candidate was discarded and
+                // search returned `results: []` with `stale_index_root: true`
+                // on an index reporting `status: ready` and 85k chunks.
+                indexer.write().await.set_root_path(new_root.clone());
                 // Preserve the filter set / domain vocabulary recorded on the
                 // existing handle — only the root_path is being overridden.
                 let new_handle = IndexHandle {

--- a/crates/trusty-search/src/service/server/search.rs
+++ b/crates/trusty-search/src/service/server/search.rs
@@ -101,6 +101,14 @@ pub(super) async fn delete_index_handler(
 /// root from `roots.toml` so the colocated rescan cannot rediscover it (issue
 /// #1090), emits `IndexRemoved`, and re-syncs the index-count gauge (issue #41).
 /// Returns whether an index was actually removed.
+///
+/// #5075: also purges this id's cold-store records (`entries`,
+/// `failed_entries`). Without that the id stayed "registered but not resident"
+/// to the #5057 guards forever, so `GET /indexes/:id/status`, `/chunks`, and
+/// `grep` answered 503 for an index that no longer exists — and a
+/// cold-parked-only index was never removed from `indexes.toml` at all, so the
+/// next warm boot resurrected it. A cold record now counts as "an index was
+/// removed" for the durable-cleanup half below.
 /// Test: delete-path handler tests; reaper behaviour covered by `orphan_reaper`
 /// unit tests plus the `spawn_orphan_reaper_ticker` wiring.
 pub(super) async fn unregister_index(
@@ -111,6 +119,19 @@ pub(super) async fn unregister_index(
     let index_id = IndexId::new(id.to_string());
     let (removed, removed_handle) = state.registry.remove_and_get(&index_id);
     let root_path_for_cleanup = removed_handle.map(|h| h.root_path.clone());
+    // #5075: drop the cold-store records too, or the #5057 guards answer 503
+    // forever for an id that is now absent from every store. Sampled BEFORE the
+    // purge because a cold-parked or restore-failed index is not in the hot
+    // registry — `removed` is false for exactly the ids this is meant to reap,
+    // and the durable cleanup below must still run for them.
+    let was_cold = state.cold_store.contains(&index_id) || state.cold_store.is_failed(&index_id);
+    let cold_root = state
+        .cold_store
+        .get_persisted(&index_id)
+        .map(|e| e.root_path);
+    state.cold_store.purge(&index_id);
+    let root_path_for_cleanup = root_path_for_cleanup.or(cold_root);
+    let removed = removed || was_cold;
     state.reindex_progress.remove(&index_id);
     state.watcher_manager.stop_for_index(&index_id).await;
     // Issue #2984 Phase 1 delta-review MEDIUM finding: `INDEX_LOCKS` (the

--- a/crates/trusty-search/src/service/server/search.rs
+++ b/crates/trusty-search/src/service/server/search.rs
@@ -346,7 +346,12 @@ pub(super) async fn search_handler(
             state
                 .last_queried_write_cache
                 .insert(index_id.clone(), now_unix);
-            tokio::spawn(async move {
+            // Review MEDIUM: `spawn_blocking`, not `spawn`. This body takes the
+            // process-wide registry `std::sync::Mutex` (#4871) and then does
+            // synchronous file I/O — parking an async worker thread on a lock
+            // another blocking writer holds. On the blocking pool that is what
+            // the pool is for; on a worker it starves the runtime.
+            tokio::task::spawn_blocking(move || {
                 if let Err(e) =
                     crate::service::persistence::update_last_queried_unix(&id_str, now_unix)
                 {

--- a/crates/trusty-search/src/service/server/tests_4715.rs
+++ b/crates/trusty-search/src/service/server/tests_4715.rs
@@ -204,3 +204,79 @@ async fn restore_failed_index_grep_says_restart_not_retry() {
         "must not tell a permanently-failed index to wait, got: {message}"
     );
 }
+
+// ── #5075: DELETE must clear the cold store, or 503 becomes permanent ────────
+
+/// #5075: after `DELETE /indexes/:id`, a cold-parked index must report 404 —
+/// absent from every store — not 503 forever.
+///
+/// Why: the three guards above are what make this observable and permanent.
+/// `unregister_index` dropped the hot registration and the `indexes.toml` row
+/// but never purged `cold_store.entries` / `failed_entries`, so every one of
+/// them kept answering "registered but not resident" for an id that no longer
+/// exists anywhere. That inverts this file's own invariant — 404 means absent
+/// from every store — and it is unrecoverable: nothing else clears those maps,
+/// so the MCP layer could never again report `INDEX_NOT_READY` for the
+/// delete-then-reindex case (#4715).
+/// What: parks an index cold, deletes it through the real handler, then drives
+/// `index_status_handler`, `get_index_chunks_handler`, and `grep_handler` —
+/// the same three guards this file pins — asserting 404 from each. Pre-fix all
+/// three return 503.
+/// Test: this test.
+#[tokio::test]
+async fn deleted_cold_parked_index_is_404_not_a_permanent_503() {
+    let state = state_with_cold_index("cold-deleted");
+
+    let axum::Json(body) = super::search::delete_index_handler(
+        State(Arc::clone(&state)),
+        axum::extract::Path("cold-deleted".to_string()),
+        axum::extract::Query(serde_json::from_value(serde_json::json!({})).expect("params")),
+    )
+    .await;
+    assert_eq!(
+        body["removed"],
+        serde_json::Value::Bool(true),
+        "#5075: deleting a cold-parked index must count as a removal — it is a \
+         real registration. Body: {body}"
+    );
+
+    let status_err = super::status::index_status_handler(
+        State(Arc::clone(&state)),
+        axum::extract::Path("cold-deleted".to_string()),
+    )
+    .await
+    .expect_err("a deleted index cannot be reported");
+    assert_eq!(
+        status_err,
+        StatusCode::NOT_FOUND,
+        "#5075: /status must say the index is gone, not that it is still \
+         restoring — the 503 never clears"
+    );
+
+    let chunks_err = super::files::get_index_chunks_handler(
+        State(Arc::clone(&state)),
+        axum::extract::Path("cold-deleted".to_string()),
+        axum::extract::Query(chunks_params()),
+    )
+    .await
+    .expect_err("a deleted index has no chunks");
+    assert_eq!(
+        chunks_err,
+        StatusCode::NOT_FOUND,
+        "#5075: /chunks must be 404"
+    );
+
+    let grep_err = super::files::grep_handler(
+        State(Arc::clone(&state)),
+        axum::extract::Path("cold-deleted".to_string()),
+        axum::Json(grep_request()),
+    )
+    .await
+    .expect_err("a deleted index has nothing to grep");
+    assert_eq!(
+        grep_err.0,
+        StatusCode::NOT_FOUND,
+        "#5075: /grep must be 404, got body {:?}",
+        grep_err.1 .0
+    );
+}

--- a/crates/trusty-search/src/service/server/tests_4951.rs
+++ b/crates/trusty-search/src/service/server/tests_4951.rs
@@ -1,0 +1,190 @@
+//! Handler-level regression for #4951 — a reindex `root_path` override must
+//! not silently empty every search result.
+//!
+//! Why: the unit coverage in `tests_search.rs` pins the two halves of the
+//! mechanism (`resolve_chunk_file` against a stale root, `set_root_path`), but
+//! neither reproduces the DEFECT: one exercises pure helpers that behave
+//! identically before and after the fix, and the other fails at the parent
+//! commit only because the symbol did not exist. A missing symbol is not a
+//! reproduction. This module drives the real `POST /indexes/:id/reindex`
+//! override and then the real `POST /indexes/:id/search`, so the assertion that
+//! fails at the parent commit is the production symptom itself — `results: []`
+//! with `stale_index_root: true` on a healthy, populated index.
+//!
+//! What: one test, `reindex_root_override_still_returns_search_results`.
+//!
+//! Test: this module IS the test.
+
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use super::reindex_handlers::{reindex_handler, ReindexRequest};
+use super::search::search_handler;
+use crate::core::embed::{Embedder, MockEmbedder};
+use crate::core::indexer::{CodeIndexer, SearchMode, SearchQuery, SearchStage};
+use crate::core::registry::{IndexHandle, IndexId, IndexRegistry};
+use crate::core::store::{UsearchStore, VectorStore};
+use crate::service::server::state::SearchAppState;
+use axum::extract::{Json, Path, State};
+
+/// A lexical query for the seeded chunk, with every optional knob at its
+/// documented default so the test asserts the ordinary search path.
+fn probe_query(text: &str) -> SearchQuery {
+    SearchQuery {
+        text: text.to_string(),
+        top_k: 5,
+        expand_graph: false,
+        compact: false,
+        branch_files: None,
+        branch_boost: 1.5,
+        branch: None,
+        // The seeded index has no vectors; the lexical lane is what production
+        // fell back to as well (`search_capabilities` was empty in the report).
+        stage: Some(SearchStage::Lexical),
+        mode: SearchMode::Code,
+        exclude_archived: false,
+        refine_query: None,
+        path_prefix: None,
+        repos: Vec::new(),
+    }
+}
+
+/// #4951: after `POST /indexes/:id/reindex` re-points an index one level down,
+/// search must still return its chunks.
+///
+/// Why: this is the whole defect, reproduced end to end. The override rebuilds
+/// the handle around the SAME indexer `Arc`. The indexer's `root_path` is the
+/// base every stored root-relative chunk path is joined against to build the
+/// absolute `CodeChunk::file`; `search_handler` then post-filters those
+/// absolute paths against the HANDLE's `root_path` (`file_is_within_root`,
+/// added for #64/#541). Leaving the indexer on the old root put every
+/// materialized path outside the new root, so 100% of candidates were dropped
+/// and callers got `results: []` with `stale_index_root: true` — on an index
+/// whose `/status` read `ready` with 85,642 chunks and a populated
+/// `search_capabilities`. JIRA context was missing from every PR review for
+/// 40+ days behind exactly this.
+///
+/// What: seeds a chunk stored relative to the SUBDIRECTORY the index is about
+/// to be re-pointed at (the post-reindex state — the walker relativizes against
+/// the current root), backs it with a real on-disk file so the override's
+/// background reindex converges on the same chunk rather than pruning it, runs
+/// the override, then searches. Asserts a non-empty result set, `file` resolved
+/// under the NEW root, and `stale_index_root: false`.
+///
+/// At the parent commit this fails on the first assertion with an empty result
+/// set — the daemon's exact production behaviour.
+///
+/// Multi-threaded flavor is required, not cosmetic: `file_is_within_root`'s
+/// canonicalize fallback (#541) uses `tokio::task::block_in_place`, which
+/// panics on the single-threaded test runtime. That fallback runs only for an
+/// absolute path that failed the cheap prefix check — i.e. exactly on the
+/// defect path — so a single-threaded test would abort before it could assert
+/// the symptom.
+///
+/// Test: this test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reindex_root_override_still_returns_search_results() {
+    let (_dir, root_old) = super::test_support::allowlisted_index_root("ts-4951-");
+    // The production shape: the new root is one level BELOW the registered one
+    // (`/mnt/data/knowledge` → `/mnt/data/knowledge/Jira`).
+    let root_new = root_old.join("Jira");
+    std::fs::create_dir_all(root_new.join("src")).expect("create the sub-root");
+    let seeded_relative = "src/auth.rs";
+    let contents = "fn onboarding_handler() { /* onboarding */ }";
+    std::fs::write(root_new.join(seeded_relative), contents).expect("write source file");
+
+    let dim = 16;
+    let embedder: Arc<dyn Embedder> = Arc::new(MockEmbedder::new(dim));
+    let store: Arc<dyn VectorStore> = Arc::new(UsearchStore::new(dim).expect("usearch"));
+    let indexer = CodeIndexer::new("atlassian", &root_old)
+        .with_components(Arc::clone(&embedder), Arc::clone(&store));
+    // Chunk paths are stored relative to the root that was current when they
+    // were written — after the reindex that is the SUB-root, which is why the
+    // portable `path` field stayed correct while `file` did not.
+    indexer
+        .index_files_batch(&[(seeded_relative.to_string(), contents.to_string())])
+        .await
+        .expect("seed one chunk");
+
+    let registry = IndexRegistry::new();
+    registry.register(IndexHandle::bare(
+        IndexId::new("atlassian"),
+        Arc::new(RwLock::new(indexer)),
+        root_old.clone(),
+    ));
+    let state = Arc::new(SearchAppState::new(registry));
+    state.install_embedder(Arc::clone(&embedder)).await;
+
+    // Sanity: the index answers BEFORE the override. If this ever fails the
+    // test is broken, not the fix — the assertions below would be vacuous.
+    let Json(before) = search_handler(
+        State(Arc::clone(&state)),
+        Path("atlassian".to_string()),
+        Json(probe_query("onboarding")),
+    )
+    .await
+    .expect("search before the override must succeed");
+    assert!(
+        !before["results"]
+            .as_array()
+            .expect("results array")
+            .is_empty(),
+        "test precondition: the seeded index must return results before the \
+         override, otherwise this test proves nothing. Got: {before}"
+    );
+
+    // The real override path.
+    let Json(queued) = reindex_handler(
+        State(Arc::clone(&state)),
+        Path("atlassian".to_string()),
+        Some(Json(ReindexRequest {
+            root_path: Some(root_new.clone()),
+            force: None,
+            background: None,
+        })),
+    )
+    .await
+    .expect("override onto an unclaimed sub-root must be accepted");
+    assert_eq!(
+        queued["queued"],
+        serde_json::Value::Bool(true),
+        "the override must be accepted — the defect is silent, not a rejection"
+    );
+
+    let Json(after) = search_handler(
+        State(Arc::clone(&state)),
+        Path("atlassian".to_string()),
+        Json(probe_query("onboarding")),
+    )
+    .await
+    .expect("search after the override must succeed");
+
+    let results = after["results"].as_array().expect("results array");
+    assert!(
+        !results.is_empty(),
+        "#4951: search returned nothing after a root_path override. Every \
+         candidate was found and then discarded by the `file_is_within_root` \
+         post-filter because the indexer kept building absolute paths against \
+         the OLD root. Response: {after}"
+    );
+    assert_eq!(
+        after["meta"]["stale_index_root"],
+        serde_json::Value::Bool(false),
+        "#4951: nothing may be dropped as out-of-root — the roots are in \
+         lockstep. Response: {after}"
+    );
+
+    let file = results[0]["file"].as_str().expect("file field");
+    assert!(
+        std::path::Path::new(file).starts_with(&root_new),
+        "#4951: the resolved absolute path must sit under the NEW root {}, \
+         got {file}",
+        root_new.display(),
+    );
+    assert_eq!(
+        results[0]["path"].as_str(),
+        Some(seeded_relative),
+        "the portable root-relative `path` was correct throughout — that is why \
+         the mismatch was invisible on /status and surfaced only as empty results"
+    );
+}

--- a/crates/trusty-search/src/service/server/tests_4951.rs
+++ b/crates/trusty-search/src/service/server/tests_4951.rs
@@ -188,3 +188,133 @@ async fn reindex_root_override_still_returns_search_results() {
          the mismatch was invisible on /status and surfaced only as empty results"
     );
 }
+
+/// #4951 review HIGH-1 reproduction: when the corpus's `indexed_root` disagrees
+/// with the override target, the #2178 guard aborts the walk — so syncing the
+/// indexer root alone leaves chunks relative to the OLD root resolving against
+/// the NEW one, and the post-filter no longer reports it.
+///
+/// Why: `file_is_within_root` is a lexical prefix test with no existence check.
+/// Once both roots agree, `<new>/<old-relative>` passes it unconditionally, so
+/// `stale_index_root` reads `false` while every `file` points at a path that
+/// does not exist — or, worse, at a DIFFERENT real file that happens to sit at
+/// the same relative path under the new root. That trades a loud failure for a
+/// silent wrong answer, which is the fail-open shape this cluster exists to
+/// remove.
+/// What: seeds a corpus-backed index whose `indexed_root` is `root_old` with a
+/// chunk relative to `root_old`, drives the override to `root_new`, and asserts
+/// the handler REFUSES rather than producing unresolvable results. The
+/// existence assertion is the point — a lexical check is what let this through.
+/// Test: this test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reindex_root_override_is_refused_when_the_corpus_disagrees() {
+    use crate::core::corpus::CorpusStore;
+
+    let (_dir, root_old) = super::test_support::allowlisted_index_root("ts-4951-guard-");
+    let root_new = root_old.join("Jira");
+    std::fs::create_dir_all(root_new.join("src")).expect("create the sub-root");
+    // The real file lives under the OLD root — the corpus was built there.
+    std::fs::create_dir_all(root_old.join("src")).expect("create old src");
+    let seeded_relative = "src/auth.rs";
+    let contents = "fn onboarding_handler() { /* onboarding */ }";
+    std::fs::write(root_old.join(seeded_relative), contents).expect("write source file");
+
+    let dim = 16;
+    let embedder: Arc<dyn Embedder> = Arc::new(MockEmbedder::new(dim));
+    let store: Arc<dyn VectorStore> = Arc::new(UsearchStore::new(dim).expect("usearch"));
+    let corpus = Arc::new(
+        CorpusStore::open(&root_old.join(".trusty-search").join("index.redb")).expect("corpus"),
+    );
+    // The corpus records the root its chunk paths are relative to.
+    corpus
+        .write_indexed_root_sync(&root_old)
+        .expect("stamp indexed_root");
+    let mut indexer = CodeIndexer::new("atlassian-guard", &root_old)
+        .with_components(Arc::clone(&embedder), Arc::clone(&store));
+    indexer.set_corpus_store(Arc::clone(&corpus));
+    indexer
+        .index_files_batch(&[(seeded_relative.to_string(), contents.to_string())])
+        .await
+        .expect("seed one chunk");
+
+    let registry = IndexRegistry::new();
+    registry.register(IndexHandle::bare(
+        IndexId::new("atlassian-guard"),
+        Arc::new(RwLock::new(indexer)),
+        root_old.clone(),
+    ));
+    // Point the handler's persisted-root read at an explicit file so this test
+    // never touches the process-wide data dir (#2717's injection seam). The
+    // registry names this index at its ORIGINAL root — the durable disagreement
+    // the #2178 guard keys on.
+    let registry_toml = root_old.join("indexes.toml");
+    crate::service::persistence::save_index_registry_at(
+        &registry_toml,
+        &[crate::service::persistence::PersistedIndex {
+            id: "atlassian-guard".to_string(),
+            root_path: root_old.clone(),
+            ..Default::default()
+        }],
+    )
+    .expect("seed registry");
+    let state = Arc::new(SearchAppState::new(registry).with_registry_path(registry_toml.clone()));
+    state.install_embedder(Arc::clone(&embedder)).await;
+
+    let result = reindex_handler(
+        State(Arc::clone(&state)),
+        Path("atlassian-guard".to_string()),
+        Some(Json(ReindexRequest {
+            root_path: Some(root_new.clone()),
+            force: None,
+            background: None,
+        })),
+    )
+    .await;
+
+    let err = result.err().map(|(status, Json(body))| (status, body));
+    let (status, body) = err.expect(
+        "#4951 HIGH-1: an override whose target disagrees with the corpus's \
+         indexed_root must be refused — accepting it re-points the indexer at a \
+         root the corpus was never relativized against, and the #2178 guard \
+         then aborts the walk that would have fixed it",
+    );
+    assert_eq!(status, axum::http::StatusCode::CONFLICT);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("relocate"),
+        "the refusal must name the durable alternative; got {body}"
+    );
+
+    // The refusal must leave BOTH roots untouched — no half-applied override.
+    let handle = state
+        .registry
+        .get(&IndexId::new("atlassian-guard".to_string()))
+        .expect("still registered");
+    assert_eq!(handle.root_path, root_old, "handle root must not move");
+    assert_eq!(
+        handle.indexer.read().await.root_path,
+        root_old,
+        "indexer root must not move either — a half-applied override is the \
+         divergence this whole issue is about"
+    );
+
+    // And search still resolves to a file that EXISTS. A lexical containment
+    // check cannot tell a real hit from a dangling one, so assert the disk.
+    let Json(after) = search_handler(
+        State(Arc::clone(&state)),
+        Path("atlassian-guard".to_string()),
+        Json(probe_query("onboarding")),
+    )
+    .await
+    .expect("search must still work");
+    let results = after["results"].as_array().expect("results array");
+    assert!(!results.is_empty(), "index must still serve: {after}");
+    let file = results[0]["file"].as_str().expect("file field");
+    assert!(
+        std::path::Path::new(file).exists(),
+        "#4951 HIGH-1: the resolved path must exist on disk, got {file} \
+         (response: {after})"
+    );
+}

--- a/crates/trusty-search/src/service/server/tests_search.rs
+++ b/crates/trusty-search/src/service/server/tests_search.rs
@@ -418,3 +418,91 @@ async fn test_global_search_surfaces_cold_indexes_skipped() {
         "global fan-out must report 1 cold index skipped; body={body:?}"
     );
 }
+
+// ── #4951: the two root_path copies must never diverge ───────────────────────
+
+/// #4951: a `reindex` `root_path` override must move the SHARED indexer's own
+/// `root_path` too, or the search post-filter discards every result.
+///
+/// Why: `IndexHandle::root_path` and `CodeIndexer::root_path` are two copies of
+/// one fact. The indexer's copy is the base every stored root-relative chunk
+/// path is joined against to build the absolute `CodeChunk::file`
+/// (`raw_to_code_chunk`); the handle's copy is what `search_handler` post-filters
+/// those absolute paths against (`file_is_within_root`, added for #64/#541). The
+/// override rebuilds the handle around the SAME indexer `Arc`, so leaving the
+/// indexer on the old root made every materialized `file` fall outside the new
+/// root: 100% of candidates were dropped and search returned `results: []` with
+/// `stale_index_root: true` — on an index whose `/status` read `ready` with
+/// 85,642 chunks and a populated `search_capabilities`. JIRA context was absent
+/// from every PR review for 40+ days behind this.
+/// What: reproduces the exact production shape — a root re-pointed one level
+/// down (`/knowledge` → `/knowledge/Jira`) with a chunk stored relative to it —
+/// and asserts the resolved absolute path passes the post-filter. Pre-fix,
+/// `set_root_path` does not exist and the stale join produces
+/// `/knowledge/ACP/ACP-1.md`, which fails `file_is_within_root` against
+/// `/knowledge/Jira`.
+/// Test: this test.
+#[test]
+fn stale_indexer_root_makes_every_chunk_fail_the_search_post_filter() {
+    use crate::core::indexer::helpers::resolve_chunk_file;
+
+    let old_root = std::path::Path::new("/knowledge");
+    let new_root = std::path::Path::new("/knowledge/Jira");
+    // What the walker stores: a path relative to the CURRENT root.
+    let stored_relative = "ACP/ACP-1.md";
+
+    // The defect, stated as an assertion: materializing against the stale root
+    // yields an absolute path the post-filter rejects.
+    let stale_file = resolve_chunk_file(stored_relative, old_root);
+    assert_eq!(stale_file, "/knowledge/ACP/ACP-1.md");
+    assert!(
+        !file_is_within_root(&stale_file, new_root),
+        "#4951: this is the drop — a chunk built against the old root cannot \
+         pass the new root's containment check, so search returns nothing"
+    );
+
+    // The fix: once the indexer's root moves with the handle's, the same stored
+    // chunk resolves inside the new root and survives the filter.
+    let fixed_file = resolve_chunk_file(stored_relative, new_root);
+    assert_eq!(fixed_file, "/knowledge/Jira/ACP/ACP-1.md");
+    assert!(
+        file_is_within_root(&fixed_file, new_root),
+        "#4951: with the roots in lockstep the chunk must survive the post-filter"
+    );
+
+    // `path` (the portable root-relative form) stays correct in BOTH cases —
+    // which is why the mismatch was invisible on `/status` and surfaced only as
+    // an empty result set. `raw_to_code_chunk_populates_path_for_relative_file`
+    // pins that half.
+}
+
+/// #4951: `CodeIndexer::set_root_path` is the single way the reindex root
+/// override keeps the indexer in lockstep with its rebuilt handle.
+///
+/// Why: without a mutator the override had no way to move the shared indexer at
+/// all — the divergence was unfixable at the call site, which is why it shipped.
+/// What: builds an indexer at one root, moves it, and asserts chunk resolution
+/// follows.
+/// Test: this test.
+#[test]
+fn reindex_root_override_syncs_indexer_root_path() {
+    use crate::core::indexer::CodeIndexer;
+
+    let mut indexer = CodeIndexer::new("atlassian", "/knowledge");
+    assert_eq!(indexer.root_path, std::path::PathBuf::from("/knowledge"));
+
+    indexer.set_root_path("/knowledge/Jira");
+
+    assert_eq!(
+        indexer.root_path,
+        std::path::PathBuf::from("/knowledge/Jira"),
+        "#4951: the override must re-point the indexer, not just the handle"
+    );
+    assert!(
+        file_is_within_root(
+            &crate::core::indexer::helpers::resolve_chunk_file("ACP/ACP-1.md", &indexer.root_path),
+            std::path::Path::new("/knowledge/Jira"),
+        ),
+        "#4951: chunks must resolve inside the new root after the sync"
+    );
+}


### PR DESCRIPTION
Closes [#4951](https://github.com/bobmatnyc/trusty-tools/issues/4951), [#4871](https://github.com/bobmatnyc/trusty-tools/issues/4871), [#4317](https://github.com/bobmatnyc/trusty-tools/issues/4317), [#4253](https://github.com/bobmatnyc/trusty-tools/issues/4253), [#5075](https://github.com/bobmatnyc/trusty-tools/issues/5075).

References [#4227](https://github.com/bobmatnyc/trusty-tools/issues/4227) without closing it — that issue got documentation only, and the actual recreate-to-empty guard belongs to [#4087](https://github.com/bobmatnyc/trusty-tools/issues/4087).

Not addressed here: [#4708](https://github.com/bobmatnyc/trusty-tools/issues/4708) was triaged out of this release.

## Root cause

[#4871](https://github.com/bobmatnyc/trusty-tools/issues/4871) and [#4317](https://github.com/bobmatnyc/trusty-tools/issues/4317) are one root cause. `load_index_registry_at` mapped a TOML parse error to an empty list, so the next write did load-empty -> push-one -> save and published a single-entry file over the whole registry while reporting success.

Fixes: fail-closed parse, a process-wide lock held across load and save, per-write staging files replacing the shared `indexes.toml.tmp`, and an orphan reaper that removes by id instead of republishing a pre-boot snapshot.

## Caveat the reviewer must see

A prior session (2026-08-05) concluded [#4871](https://github.com/bobmatnyc/trusty-tools/issues/4871)'s stated premise — concurrent daemons reverting `indexes.toml` — was refuted, on the grounds that only one real writer daemon exists. This PR fixes [#4871](https://github.com/bobmatnyc/trusty-tools/issues/4871) anyway because two different defects were reproduced live and independently of that premise: a `rename indexes.toml -> No such file or directory` collision from the shared tmp file, and the fail-closed parse gap. Ask the reviewer to confirm the fix on the evidence actually reproduced, not on the issue's original framing.

## Known limitation

The fail-closed parse guarantees the write path only. Read-only callers (`reindex/runner.rs`, `warm_boot/mod.rs`, `server/tickers.rs`) still treat a corrupt registry as empty, exactly as before — no regression, but the guarantee does not extend to them.

## Test ladder

Rung 5 (persistence, process lifecycle, cross-crate contract):

- `cargo fmt --check`
- `cargo clippy -p trusty-search --all-targets -- -D warnings`
- `cargo test -p trusty-search` -> 1524 passed, 0 failed, 1 ignored, plus 372 integration
- `cargo check --workspace` -> EXIT=0
- `check_line_cap.sh` -> 3860 files, 4 allowlisted, 0 violations
- `check_changelog_fragment.sh` -> all crates recorded

The branch was rebased onto current `main` before opening this PR; the gate output above was produced at `ee45a1926` pre-rebase. Main's two intervening commits (`c2970687f` docs, `96123699e` trusty-mpm) touch only `docs/` and `trusty-mpm`, so the trusty-search gate result carries over unchanged — CI on the pushed head is the post-rebase confirmation.

## Pre-existing baseline failure, not caused by this branch

`commands::start::tests::swap_back_real_hardware_kills_sidecar_past_max_restarts` fails under `--include-ignored`. Reproduced at `origin/main` in a throwaway worktree; this diff touches zero files under `commands/`. Related closed issue [#3631](https://github.com/bobmatnyc/trusty-tools/issues/3631).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
