### PR TITLE
fix(trusty-mpm): release a decommissioned session's tm ls slot in a day, not a week

### DIFF
--- a/crates/trusty-mpm/changelog.d/5327-slot-retention-window.md
+++ b/crates/trusty-mpm/changelog.d/5327-slot-retention-window.md
@@ -1,0 +1,11 @@
+Changed
+
+- A decommissioned or deleted session releases its `tm ls` `NUM` after 24 hours
+  instead of 7 days (`TERMINAL_RECORD_RETENTION_DAYS`, 7 → 1).
+- The retention guard that spared a record whose workspace directory still
+  existed now spares only a record whose workspace is a session WORKTREE —
+  recognised by the `.worktrees/<leaf>` shape or a `.trusty-mpm-worktree`
+  ownership sentinel. A session launched on a project's main checkout records
+  that checkout as its workspace, and the old guard read it as a worktree to
+  protect, so such records were never evicted at any window. Records from
+  `tm launch --worktree` are protected exactly as before, at any age.

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -123,7 +123,26 @@ pub(crate) const GIT_WORKTREE_REMOVE_TIMEOUT: std::time::Duration =
 pub(crate) fn is_session_worktree(path: &Path) -> bool {
     // #5204: detection matches the configured base OR the built-in `.worktrees`,
     // so retargeting never orphans worktrees already on disk.
-    let names = worktree_dir_names();
+    is_session_worktree_with(path, &worktree_dir_names())
+}
+
+/// [`is_session_worktree`] against ALREADY-RESOLVED base names.
+///
+/// Why: [`worktree_dir_names`] calls `TrustyToolsConfig::load()`, which re-reads
+/// and re-parses config files on every call and re-emits its unknown-key warning
+/// (#5207). That is fine once, but a caller asking the question per item in a
+/// loop pays it per item — and on a repeating timer it also multiplies that
+/// one-shot warning into a per-item, per-tick log flood. `WorktreeDirNames`'s own
+/// docs prescribe the remedy: resolve once at the top of a scan and pass the
+/// value down (#5204). #5327's retention sweep is the first such loop caller.
+/// What: the pure path-shape predicate — is the immediate parent a base name.
+/// [`is_session_worktree`] is this function plus a per-call resolve.
+/// Test: `is_session_worktree_detects_dot_worktrees_component` (through the
+/// delegating wrapper), `workspace_needs_protection_covers_a_session_worktree`.
+pub(crate) fn is_session_worktree_with(
+    path: &Path,
+    names: &trusty_common::workspace_layout::WorktreeDirNames,
+) -> bool {
     path.parent()
         .and_then(|p| p.file_name())
         .and_then(|n| n.to_str())

--- a/crates/trusty-mpm/src/session_manager/retention.rs
+++ b/crates/trusty-mpm/src/session_manager/retention.rs
@@ -87,11 +87,11 @@ pub enum RetentionVerdict {
 /// Why: every record written before `terminal_at` existed lacks it, and that is
 /// the entire pre-existing backlog — 76 of 116 records on the reporting
 /// machine, holding 76 of the slot numbers that put `NUM` in three digits.
-/// Stamping those with `now` would grandfather them for a further seven days,
-/// so the fix the owner asked for would not arrive until a week after he
-/// installed it. Clearing that backlog is the point, and a record whose last
-/// sign of life was two months ago has had its retention window many times
-/// over.
+/// Stamping those with `now` would grandfather them for another full retention
+/// window, so the fix the owner asked for would not arrive until a day after he
+/// installed it (and, pre-#5327, a week). Clearing that backlog is the point,
+/// and a record whose last sign of life was two months ago has had its
+/// retention window many times over.
 ///
 /// The earlier reasoning against inference was right about the mechanism and
 /// wrong about the goal: yes, the auto-prune (#4384/#4702) decommissions
@@ -244,6 +244,7 @@ impl RetentionOutcome {
 /// `workspace_needs_protection_ignores_a_plain_main_checkout`.
 fn workspace_needs_protection(
     path: Option<&std::path::Path>,
+    names: &trusty_common::workspace_layout::WorktreeDirNames,
     probe: impl Fn(&std::path::Path) -> std::io::Result<bool>,
 ) -> bool {
     let Some(p) = path else {
@@ -255,7 +256,7 @@ fn workspace_needs_protection(
         Ok(false) => return false,
         Ok(true) => {}
     }
-    super::decommission::is_session_worktree(p)
+    super::decommission::is_session_worktree_with(p, names)
         || probe(&p.join(super::decommission::WORKTREE_SENTINEL_FILE)).unwrap_or(true)
 }
 
@@ -310,10 +311,11 @@ impl SessionManager {
     /// hard-deletes a record without an operator asking for that specific
     /// record by id, so its scope is deliberately narrow: `sessions.json`, and
     /// the in-memory slot registry. Nothing on disk outside the store file is
-    /// read for deletion, opened for writing, or removed. Its only filesystem
-    /// calls are [`workspace_needs_protection`]'s two `try_exists` probes, and
-    /// every answer they can give other than "the workspace is gone" or "it is
-    /// a plain directory with no ownership sentinel" means KEEP.
+    /// read for deletion, opened for writing, or removed. It reads the config
+    /// once per sweep to resolve the worktree base names, and otherwise its only
+    /// filesystem calls are [`workspace_needs_protection`]'s two `try_exists`
+    /// probes — every answer they can give other than "the workspace is gone" or
+    /// "it is a plain directory with no ownership sentinel" means KEEP.
     /// What: three phases, mirroring `prune_orphaned_worktrees`'s #1845 item-9
     /// shape.
     ///
@@ -356,10 +358,15 @@ impl SessionManager {
         self.store.write().await.reload_if_changed().await?;
         let all = self.store.read().await.cached_all();
 
+        // Resolve the worktree base names ONCE for the whole sweep. Doing it per
+        // record would re-read config per record per 60s tick — see
+        // `decommission::is_session_worktree_with`.
+        let names = super::decommission::worktree_dir_names();
+
         let mut stamped: Vec<SessionRecord> = Vec::new();
         let mut candidates: Vec<ManagedSessionId> = Vec::new();
         for record in all {
-            match self.verdict_for(&record, now, retention) {
+            match self.verdict_for(&record, &names, now, retention) {
                 RetentionVerdict::Keep => {}
                 RetentionVerdict::Stamp(inferred) => {
                     let mut dated = record;
@@ -388,7 +395,7 @@ impl SessionManager {
         // Phase 3 — re-validate against the CURRENT store immediately before
         // deleting.
         let evicted = self
-            .revalidate_for_eviction(confirmed, now, retention)
+            .revalidate_for_eviction(confirmed, &names, now, retention)
             .await;
 
         if !evicted.is_empty() {
@@ -442,6 +449,7 @@ impl SessionManager {
     async fn revalidate_for_eviction(
         &self,
         confirmed: Vec<ManagedSessionId>,
+        names: &trusty_common::workspace_layout::WorktreeDirNames,
         now: DateTime<Utc>,
         retention: Duration,
     ) -> Vec<ManagedSessionId> {
@@ -449,7 +457,8 @@ impl SessionManager {
         for id in confirmed {
             match self.get(&id).await {
                 Ok(fresh)
-                    if self.verdict_for(&fresh, now, retention) == RetentionVerdict::Evict =>
+                    if self.verdict_for(&fresh, names, now, retention)
+                        == RetentionVerdict::Evict =>
                 {
                     evicted.push(id);
                 }
@@ -483,14 +492,19 @@ impl SessionManager {
     }
 
     /// [`retention_verdict`] with the production existence probes applied.
+    ///
+    /// `names` is resolved ONCE per sweep by the caller rather than per record —
+    /// see [`super::decommission::is_session_worktree_with`] for why a per-record
+    /// resolve would re-read config and re-log on every tick.
     fn verdict_for(
         &self,
         record: &SessionRecord,
+        names: &trusty_common::workspace_layout::WorktreeDirNames,
         now: DateTime<Utc>,
         retention: Duration,
     ) -> RetentionVerdict {
         let protected =
-            workspace_needs_protection(record.workspace_path.as_deref(), |p| p.try_exists());
+            workspace_needs_protection(record.workspace_path.as_deref(), names, |p| p.try_exists());
         retention_verdict(record, protected, now, retention)
     }
 }

--- a/crates/trusty-mpm/src/session_manager/retention.rs
+++ b/crates/trusty-mpm/src/session_manager/retention.rs
@@ -19,15 +19,16 @@
 //! Records written before `terminal_at` existed — the whole pre-existing
 //! backlog, which is what put `NUM` in three digits — are backfilled from
 //! [`inferred_terminal_at`] rather than from the current time, so one already
-//! weeks past the window is eligible on the next sweep instead of seven days
+//! weeks past the window is eligible on the next sweep instead of a full window
 //! after this ships.
 //!
 //! Scope, and the reason it is drawn this tightly: this sweep touches
 //! `sessions.json` and nothing else. It never removes a worktree, a workspace
 //! directory, a git branch, or any other file — see [`retention_verdict`]'s
-//! `workspace_on_disk` parameter for the guard that keeps a record-only
-//! eviction from becoming a filesystem deletion by proxy, and
-//! [`workspace_present`] for why an undetermined path counts as present.
+//! `workspace_needs_protection` parameter for the guard that keeps a
+//! record-only eviction from becoming a filesystem deletion by proxy, and
+//! [`workspace_needs_protection`] for which workspaces that guard now covers
+//! and why an undetermined answer counts as protected.
 //!
 //! Test: `retention_tests.rs`.
 
@@ -39,15 +40,23 @@ use super::record::{ManagedSessionId, SessionRecord};
 
 /// How long a record stays in the store after entering a terminal state.
 ///
-/// Why: the owner's ruling on the inflated-`NUM` report — "evict old records,
-/// 7 days". Long enough that a tombstone an operator captured a number from is
-/// still there days later (#3034's guarantee, which in practice never survived
-/// a daemon restart anyway); short enough that the store stops being an
-/// append-only log of every session ever run.
+/// Why (#5327): protecting a worktree is [`workspace_needs_protection`]'s job,
+/// and it holds a record for as long as there is one, at any age. All the clock
+/// has to buy is the span in which an operator can still act on a record that
+/// is already dead — a `NUM` read off a listing, or the #2777 in-pane revive,
+/// which reads the record out of the store. Both are same-working-day actions
+/// that must survive an overnight gap. 24 hours is also how long this crate
+/// already waits before an automatic sweep acts on a session with no operator
+/// present ([`super::MAX_EPHEMERAL_AGE_HOURS`]), and retention does strictly
+/// less than that sweep: it deletes a record, never a process or a directory.
+///
+/// The unit stays days because the NAME is published API on a 1.x crate.
+/// Renaming it to hours to write `24` instead of `1` is a major-version break
+/// for a cosmetic gain.
 /// What: the retention window in days, applied to
 /// [`SessionRecord::terminal_at`].
-/// Test: `retention_window_is_seven_days`.
-pub const TERMINAL_RECORD_RETENTION_DAYS: i64 = 7;
+/// Test: `retention_window_is_twenty_four_hours`.
+pub const TERMINAL_RECORD_RETENTION_DAYS: i64 = 1;
 
 /// What the sweep should do with one record.
 ///
@@ -120,7 +129,7 @@ pub fn inferred_terminal_at(record: &SessionRecord, now: DateTime<Utc>) -> DateT
 ///    record is live work — a `stopped` session is explicitly resumable, with
 ///    its workspace intact.
 ///
-/// 2. **A record whose workspace still exists on disk is never evicted**,
+/// 2. **A record whose workspace is a worktree on disk is never evicted**,
 ///    however old. This is not tidiness, it is the load-bearing guard.
 ///    `prune_orphaned_worktrees` protects a worktree from deletion by finding
 ///    its path in the set of `workspace_path`s read from the store — a set that
@@ -130,9 +139,10 @@ pub fn inferred_terminal_at(record: &SessionRecord, now: DateTime<Utc>) -> DateT
 ///    two independent reads of the protected set come from the store, so
 ///    deleting the record removes the path from BOTH at once — collapsing a
 ///    defense-in-depth pair into nothing and handing the worktree to an
-///    unattended, `dry_run: false` timer. `workspace_on_disk` keeps the record,
-///    and therefore the protection, alive for exactly as long as there is a
-///    directory to protect.
+///    unattended, `dry_run: false` timer. `workspace_needs_protection` keeps
+///    the record, and therefore the protection, alive for exactly as long as
+///    there is a worktree to protect — see that function for why a plain
+///    main-checkout path (#5274) is not one and what it costs to be wrong.
 ///
 /// 3. **`terminal_at == None` is backfilled, never evicted directly.** A record
 ///    predating the field is dated from [`inferred_terminal_at`] and written
@@ -142,23 +152,23 @@ pub fn inferred_terminal_at(record: &SessionRecord, now: DateTime<Utc>) -> DateT
 ///    absence. It also means an old legacy record still passes through the
 ///    two-observation debounce and phase-3 re-validation like any other.
 ///
-/// What: `Keep` unless the record is terminal AND its workspace is not on
-/// disk; then `Stamp(inferred)` when undated, `Evict` when `now - terminal_at
-/// >= retention`, `Keep` otherwise. `workspace_on_disk` is supplied by the
-/// caller (via [`workspace_present`], which resolves an undetermined path to
-/// `true`) so this function stays pure and does no I/O.
+/// What: `Keep` unless the record is terminal AND its workspace needs no
+/// protection; then `Stamp(inferred)` when undated, `Evict` when `now -
+/// terminal_at >= retention`, `Keep` otherwise. `workspace_needs_protection` is
+/// supplied by the caller (via the function of the same name, which resolves an
+/// undetermined probe to `true`) so this function stays pure and does no I/O.
 /// Test: `retention_verdict_keeps_live_states`,
-/// `retention_verdict_keeps_record_whose_workspace_still_exists`,
+/// `retention_verdict_keeps_record_whose_worktree_still_exists`,
 /// `retention_verdict_stamps_undated_terminal_record`,
 /// `retention_verdict_keeps_record_inside_window`,
 /// `retention_verdict_evicts_record_outside_window`.
 pub fn retention_verdict(
     record: &SessionRecord,
-    workspace_on_disk: bool,
+    workspace_needs_protection: bool,
     now: DateTime<Utc>,
     retention: Duration,
 ) -> RetentionVerdict {
-    if !record.state.is_terminal() || workspace_on_disk {
+    if !record.state.is_terminal() || workspace_needs_protection {
         return RetentionVerdict::Keep;
     }
     match record.terminal_at {
@@ -189,23 +199,64 @@ impl RetentionOutcome {
     }
 }
 
-/// Is this record's workspace directory still on disk?
+/// Would evicting this record expose a worktree to `prune_orphaned_worktrees`?
 ///
-/// Why: `Path::exists()` maps EVERY stat error to `false` — a permission error
-/// on an ancestor, a stale NFS/SMB handle, `EIO` from a departed volume — so
-/// "cannot determine" and "not there" produce the same answer, and that answer
-/// evicts. The guard this feeds is the one keeping a record's `workspace_path`
-/// in `prune_orphaned_worktrees`'s protected set, so failing open here means a
-/// transient stat error can hand a live worktree to an unattended sweep.
-/// What: `probe` is `Path::try_exists` in production. An `Err` — undetermined —
-/// counts as PRESENT, so an unreadable path is never evicted. A `None` path is
-/// absent: there is nothing to protect and nothing to fail on.
-/// Test: `workspace_present_treats_an_undetermined_path_as_present`.
-fn workspace_present(
+/// Why: a record's `workspace_path` is what puts a directory in that sweep's
+/// protected set, so evicting the record is what can get the directory deleted.
+/// Until #5327 the question asked here was the broader "is the workspace still
+/// on disk", which was the right question when every session provisioned a
+/// worktree. Under ADR-0037 as amended (#5274) the default session runs on the
+/// project's own main checkout and records it as its `workspace_path` — a
+/// directory that never goes away — so the broad form pinned every such record
+/// in the store permanently, at any window. That is the measured cause of
+/// #5327's unbounded `NUM`, and shortening the window alone would not have
+/// moved it.
+///
+/// The narrowing is tied to what the sweep can actually reach. A candidate must
+/// carry a `.trusty-mpm-worktree` ownership sentinel naming a resolvable owner
+/// (#3649); an absent sentinel is reported and never removed. The sentinel has
+/// exactly two write sites — `provisioner::workspace` and
+/// `managed_routes::inproject` — and each writes it immediately after its own
+/// `git worktree add`. A path with no sentinel was therefore not provisioned as
+/// a session worktree, and the sweep will not delete it however the record
+/// changes.
+///
+/// What: `probe` is `Path::try_exists` in production and answers both reads.
+/// Protected when ANY of:
+///
+/// - the workspace path cannot be probed (`Err`) — `Path::exists()` collapses a
+///   permission error, a stale NFS/SMB handle, and `EIO` from a departed volume
+///   into "not there", and "not there" is what evicts;
+/// - the path's immediate parent is a worktree base
+///   ([`super::decommission::is_session_worktree`], a deliberate superset of
+///   creation since #5204);
+/// - a sentinel file exists at the path, or its existence cannot be determined.
+///
+/// The sentinel and shape clauses are independent on purpose. The sweep reads
+/// the sentinel at deletion time, this reads it now, and a read that fails
+/// transiently here would drop the protection for good while the sweep's own
+/// later read succeeds; the shape clause covers that for the standard
+/// `.worktrees` layout, and treating an undetermined sentinel probe as present
+/// covers it for the rest. Unprotected only when there is no path, the path is
+/// gone, or it is a plain directory with no sentinel — the main-checkout case.
+/// Test: `workspace_needs_protection_treats_an_undetermined_path_as_protected`,
+/// `workspace_needs_protection_covers_a_session_worktree`,
+/// `workspace_needs_protection_ignores_a_plain_main_checkout`.
+fn workspace_needs_protection(
     path: Option<&std::path::Path>,
     probe: impl Fn(&std::path::Path) -> std::io::Result<bool>,
 ) -> bool {
-    path.is_some_and(|p| probe(p).unwrap_or(true))
+    let Some(p) = path else {
+        return false;
+    };
+    match probe(p) {
+        // Undetermined: never evict on the strength of an answer we do not have.
+        Err(_) => return true,
+        Ok(false) => return false,
+        Ok(true) => {}
+    }
+    super::decommission::is_session_worktree(p)
+        || probe(&p.join(super::decommission::WORKTREE_SENTINEL_FILE)).unwrap_or(true)
 }
 
 /// Two-observation gate before a record may be evicted.
@@ -214,18 +265,21 @@ fn workspace_present(
 /// (`orphan_gc::OrphanGc`, `core::pid_registry::PidOrphanGc`) each require a
 /// candidate to survive TWO consecutive observations before acting, and
 /// retention deletes something no less permanent. The condition it reads is not
-/// purely a persisted timestamp: "the workspace directory is gone" is a live
+/// purely a persisted timestamp: "no worktree behind this workspace" is a live
 /// filesystem observation, and an external volume that unmounts between ticks
 /// answers `Ok(false)` — genuinely absent, indistinguishable from deleted —
-/// which [`workspace_present`]'s error handling cannot catch. Requiring the
-/// same verdict on two ticks ~60s apart costs nothing against a 7-day window
-/// and rules that case out.
+/// which [`workspace_needs_protection`]'s error handling cannot catch.
+/// Requiring the same verdict on two ticks ~60s apart costs one to two minutes
+/// against a 24-hour window and rules that case out. #5327 kept it unchanged
+/// and unrelaxed: shortening the window makes this sweep act sooner, which
+/// raises what a single stale observation costs rather than lowering it.
 /// What: [`Self::confirm`] returns the candidates that were ALSO candidates on
 /// the previous call, then re-arms with the current set — so a record that
 /// stops being a candidate (reactivated, workspace remounted) disarms itself.
 /// Owned by the caller across ticks, exactly like its two siblings.
 /// Test: `debounce_requires_two_consecutive_observations`,
-/// `debounce_disarms_a_candidate_that_lapses`.
+/// `debounce_disarms_a_candidate_that_lapses`,
+/// `sweep_spares_a_record_whose_worktree_appears_between_sweeps`.
 #[derive(Debug, Default)]
 pub struct RetentionDebounce {
     armed: std::collections::HashSet<ManagedSessionId>,
@@ -257,9 +311,9 @@ impl SessionManager {
     /// record by id, so its scope is deliberately narrow: `sessions.json`, and
     /// the in-memory slot registry. Nothing on disk outside the store file is
     /// read for deletion, opened for writing, or removed. Its only filesystem
-    /// call is [`workspace_present`]'s `try_exists`, whose two non-`Ok(false)`
-    /// answers — present, or undetermined — both mean KEEP, so it can only ever
-    /// make the sweep evict fewer records.
+    /// calls are [`workspace_needs_protection`]'s two `try_exists` probes, and
+    /// every answer they can give other than "the workspace is gone" or "it is
+    /// a plain directory with no ownership sentinel" means KEEP.
     /// What: three phases, mirroring `prune_orphaned_worktrees`'s #1845 item-9
     /// shape.
     ///
@@ -281,11 +335,11 @@ impl SessionManager {
     /// the clock and a global so tests are deterministic.
     /// Test: `sweep_evicts_only_records_past_the_window`,
     /// `sweep_releases_the_evicted_slot`,
-    /// `sweep_never_touches_the_filesystem`,
+    /// `sweep_never_touches_a_worktree_on_the_filesystem`,
     /// `sweep_backfills_an_old_legacy_record_and_evicts_it_without_waiting`,
     /// `sweep_gives_a_recent_legacy_record_its_full_window`,
     /// `sweep_stamps_now_when_a_legacy_record_has_no_usable_signal`,
-    /// `sweep_backfill_still_spares_a_legacy_record_whose_workspace_exists`,
+    /// `sweep_backfill_still_spares_a_legacy_record_whose_worktree_exists`,
     /// `sweep_spares_a_record_reactivated_between_sweeps` (which the debounce
     /// and phase 1 protect — phase 3's own arms are covered by
     /// [`Self::revalidate_for_eviction`]'s `revalidate_*` tests) in
@@ -322,9 +376,9 @@ impl SessionManager {
             info!(
                 stamped = n,
                 "retention: backfilled `terminal_at` on {n} record(s) that predate the field, \
-                 from their last evidence of life; any already older than {} day(s) become \
+                 from their last evidence of life; any already older than {} hour(s) become \
                  evictable on the next sweep",
-                retention.num_days()
+                retention.num_hours()
             );
         }
 
@@ -345,8 +399,8 @@ impl SessionManager {
             }
             info!(
                 evicted = evicted.len(),
-                "retention: evicted terminal record(s) older than {} day(s) and freed their slots",
-                retention.num_days()
+                "retention: evicted terminal record(s) older than {} hour(s) and freed their slots",
+                retention.num_hours()
             );
         }
 
@@ -383,6 +437,7 @@ impl SessionManager {
     /// skipped — a concurrent prune beating us to it is not an error.
     /// Test: `revalidate_keeps_a_still_evictable_record`,
     /// `revalidate_drops_a_record_reactivated_after_the_snapshot`,
+    /// `revalidate_drops_a_record_whose_worktree_appeared_after_the_snapshot`,
     /// `revalidate_drops_a_record_a_concurrent_prune_already_removed`.
     async fn revalidate_for_eviction(
         &self,
@@ -427,15 +482,16 @@ impl SessionManager {
             .await
     }
 
-    /// [`retention_verdict`] with the production existence probe applied.
+    /// [`retention_verdict`] with the production existence probes applied.
     fn verdict_for(
         &self,
         record: &SessionRecord,
         now: DateTime<Utc>,
         retention: Duration,
     ) -> RetentionVerdict {
-        let on_disk = workspace_present(record.workspace_path.as_deref(), |p| p.try_exists());
-        retention_verdict(record, on_disk, now, retention)
+        let protected =
+            workspace_needs_protection(record.workspace_path.as_deref(), |p| p.try_exists());
+        retention_verdict(record, protected, now, retention)
     }
 }
 

--- a/crates/trusty-mpm/src/session_manager/retention_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/retention_tests.rs
@@ -36,6 +36,14 @@ fn window() -> Duration {
     Duration::days(TERMINAL_RECORD_RETENTION_DAYS)
 }
 
+/// The worktree base names the sweep resolves once per tick, built hermetically.
+///
+/// `from_configured(None)` yields the built-in `.worktrees` without reading the
+/// machine's config, which is what every fixture below builds its paths under.
+fn names() -> trusty_common::workspace_layout::WorktreeDirNames {
+    trusty_common::workspace_layout::WorktreeDirNames::from_configured(None)
+}
+
 /// A terminal record with no workspace, dated `age_hours` ago.
 fn terminal_record(state: ManagedSessionState, age_hours: i64) -> SessionRecord {
     let mut r = base_record();
@@ -409,8 +417,8 @@ async fn sweep_never_touches_a_worktree_on_the_filesystem() {
 
 /// Why: the backlog this feature exists to clear is entirely legacy records —
 /// 76 of 116 on the reporting machine. Stamping them `now` would grandfather
-/// every one for a further seven days, so the owner would install the fix and
-/// still see the same `NUM`. An old record must be dated from its own history
+/// every one for another full retention window, so the owner would install the
+/// fix and still see the same `NUM`. An old record must be dated from its own history
 /// and become eligible on the very next sweep.
 /// What: seeds a legacy record whose last activity was 400 days ago, asserts
 /// sweep 1 backfills that date rather than deleting outright (so the inference
@@ -452,7 +460,7 @@ async fn sweep_backfills_an_old_legacy_record_and_evicts_it_without_waiting() {
     );
 
     // Already past the window, so it arms on the next sweep and goes on the one
-    // after — no seven-day wait.
+    // after — no fresh 24-hour wait.
     let second = mgr
         .sweep_terminal_records(Utc::now(), window(), &mut gate)
         .await
@@ -623,7 +631,7 @@ async fn revalidate_keeps_a_still_evictable_record() {
     let stale = seed_terminal(&mgr, "stale", ManagedSessionState::Decommissioned, 30).await;
 
     let survivors = mgr
-        .revalidate_for_eviction(vec![stale], Utc::now(), window())
+        .revalidate_for_eviction(vec![stale], &names(), Utc::now(), window())
         .await;
     assert_eq!(
         survivors,
@@ -649,7 +657,7 @@ async fn revalidate_drops_a_record_reactivated_after_the_snapshot() {
     let id = seed_terminal(&mgr, "stale", ManagedSessionState::Decommissioned, 30).await;
     // The snapshot said Evict…
     assert_eq!(
-        mgr.revalidate_for_eviction(vec![id], Utc::now(), window())
+        mgr.revalidate_for_eviction(vec![id], &names(), Utc::now(), window())
             .await,
         vec![id]
     );
@@ -661,7 +669,7 @@ async fn revalidate_drops_a_record_reactivated_after_the_snapshot() {
     mgr.mark_reactivated(&id).await.expect("reactivate");
 
     let survivors = mgr
-        .revalidate_for_eviction(vec![id], Utc::now(), window())
+        .revalidate_for_eviction(vec![id], &names(), Utc::now(), window())
         .await;
     assert!(
         survivors.is_empty(),
@@ -694,7 +702,7 @@ async fn revalidate_drops_a_record_whose_worktree_appeared_after_the_snapshot() 
 
     // The snapshot said Evict — a plain directory protects nothing…
     assert_eq!(
-        mgr.revalidate_for_eviction(vec![id], Utc::now(), window())
+        mgr.revalidate_for_eviction(vec![id], &names(), Utc::now(), window())
             .await,
         vec![id]
     );
@@ -709,7 +717,7 @@ async fn revalidate_drops_a_record_whose_worktree_appeared_after_the_snapshot() 
     .expect("sentinel");
 
     let survivors = mgr
-        .revalidate_for_eviction(vec![id], Utc::now(), window())
+        .revalidate_for_eviction(vec![id], &names(), Utc::now(), window())
         .await;
     assert!(
         survivors.is_empty(),
@@ -777,7 +785,7 @@ async fn revalidate_drops_a_record_a_concurrent_prune_already_removed() {
     mgr.compact_record(&id).await.expect("concurrent prune");
 
     let survivors = mgr
-        .revalidate_for_eviction(vec![id], Utc::now(), window())
+        .revalidate_for_eviction(vec![id], &names(), Utc::now(), window())
         .await;
     assert!(
         survivors.is_empty(),
@@ -806,14 +814,14 @@ async fn revalidate_drops_a_record_a_concurrent_prune_already_removed() {
 fn workspace_needs_protection_treats_an_undetermined_path_as_protected() {
     let path = PathBuf::from("/definitely/unreadable/plain-checkout");
     assert!(
-        workspace_needs_protection(Some(&path), |_| Err(std::io::Error::new(
+        workspace_needs_protection(Some(&path), &names(), |_| Err(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
             "EACCES"
         ))),
         "an undetermined workspace path must count as PROTECTED so the record is kept"
     );
     assert!(
-        workspace_needs_protection(Some(&path), |p| if p == path {
+        workspace_needs_protection(Some(&path), &names(), |p| if p == path {
             Ok(true)
         } else {
             Err(std::io::Error::other("EIO"))
@@ -821,11 +829,11 @@ fn workspace_needs_protection_treats_an_undetermined_path_as_protected() {
         "an undetermined SENTINEL probe must also count as PROTECTED"
     );
     assert!(
-        !workspace_needs_protection(Some(&path), |_| Ok(false)),
+        !workspace_needs_protection(Some(&path), &names(), |_| Ok(false)),
         "a workspace that is gone protects nothing"
     );
     assert!(
-        !workspace_needs_protection(None, |_| Ok(true)),
+        !workspace_needs_protection(None, &names(), |_| Ok(true)),
         "no path, nothing to protect"
     );
 
@@ -833,7 +841,7 @@ fn workspace_needs_protection_treats_an_undetermined_path_as_protected() {
     let mut r = terminal_record(ManagedSessionState::Decommissioned, 24 * 400);
     r.workspace_path = Some(path.clone());
     let undetermined =
-        workspace_needs_protection(Some(&path), |_| Err(std::io::Error::other("EIO")));
+        workspace_needs_protection(Some(&path), &names(), |_| Err(std::io::Error::other("EIO")));
     assert_eq!(
         retention_verdict(&r, undetermined, Utc::now(), window()),
         RetentionVerdict::Keep,
@@ -856,7 +864,7 @@ fn workspace_needs_protection_covers_a_session_worktree() {
     std::fs::remove_file(wt.join(super::super::decommission::WORKTREE_SENTINEL_FILE))
         .expect("strip sentinel");
     assert!(
-        workspace_needs_protection(Some(&wt), |p| p.try_exists()),
+        workspace_needs_protection(Some(&wt), &names(), |p| p.try_exists()),
         "a `.worktrees/<leaf>` path is protected on its shape alone, with no sentinel to read"
     );
 
@@ -868,7 +876,7 @@ fn workspace_needs_protection_covers_a_session_worktree() {
     )
     .expect("sentinel");
     assert!(
-        workspace_needs_protection(Some(&odd), |p| p.try_exists()),
+        workspace_needs_protection(Some(&odd), &names(), |p| p.try_exists()),
         "an ownership sentinel protects whatever the path's shape is"
     );
 }
@@ -892,7 +900,7 @@ fn workspace_needs_protection_ignores_a_plain_main_checkout() {
     std::fs::write(checkout.path().join("README.md"), b"a real repo").expect("write");
 
     assert!(
-        !workspace_needs_protection(Some(checkout.path()), |p| p.try_exists()),
+        !workspace_needs_protection(Some(checkout.path()), &names(), |p| p.try_exists()),
         "a main checkout carries no ownership sentinel and no sweep can delete it"
     );
     std::fs::write(
@@ -903,7 +911,7 @@ fn workspace_needs_protection_ignores_a_plain_main_checkout() {
     )
     .expect("sentinel");
     assert!(
-        workspace_needs_protection(Some(checkout.path()), |p| p.try_exists()),
+        workspace_needs_protection(Some(checkout.path()), &names(), |p| p.try_exists()),
         "…and the sentinel is what decides it, not the directory's existence"
     );
 }

--- a/crates/trusty-mpm/src/session_manager/retention_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/retention_tests.rs
@@ -3,17 +3,16 @@
 //! Why: this is the only path that hard-deletes a session record without an
 //! operator naming it, so every guard that decides NOT to delete needs a test
 //! as much as the deletion itself does. Two of them are load-bearing beyond
-//! the display bug this feature exists for: the workspace-still-on-disk guard
-//! keeps the record in `prune_orphaned_worktrees`'s protected set, and the
-//! undated-record guard stops a legacy tombstone being evicted the first time
-//! the new code sees it.
+//! the display bug this feature exists for: the worktree guard keeps the record
+//! in `prune_orphaned_worktrees`'s protected set, and the undated-record guard
+//! stops a legacy tombstone being evicted the first time the new code sees it.
 //! What: pure [`super::retention_verdict`] cases, then end-to-end sweeps
 //! through a real `SessionManager` covering eviction, slot release and reuse,
 //! the no-duplicate-`NUM` invariant across that cycle, and a filesystem
 //! no-touch assertion.
 //! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use chrono::{Duration, Utc};
 use tempfile::TempDir;
@@ -22,26 +21,48 @@ use super::super::record::{ManagedSessionState, SessionRecord};
 use super::super::tests::make_manager;
 use super::{
     RetentionDebounce, RetentionVerdict, TERMINAL_RECORD_RETENTION_DAYS, retention_verdict,
-    workspace_present,
+    workspace_needs_protection,
 };
 
 /// The window the daemon actually applies. Pinned so a silent change to the
-/// constant fails a test rather than quietly shortening retention.
+/// constant fails a test rather than quietly shortening — or lengthening —
+/// retention.
 #[test]
-fn retention_window_is_seven_days() {
-    assert_eq!(TERMINAL_RECORD_RETENTION_DAYS, 7);
+fn retention_window_is_twenty_four_hours() {
+    assert_eq!(TERMINAL_RECORD_RETENTION_DAYS, 1);
 }
 
 fn window() -> Duration {
     Duration::days(TERMINAL_RECORD_RETENTION_DAYS)
 }
 
-/// A terminal record with no workspace, dated `age_days` ago.
-fn terminal_record(state: ManagedSessionState, age_days: i64) -> SessionRecord {
+/// A terminal record with no workspace, dated `age_hours` ago.
+fn terminal_record(state: ManagedSessionState, age_hours: i64) -> SessionRecord {
     let mut r = base_record();
     r.state = state;
-    r.terminal_at = Some(Utc::now() - Duration::days(age_days));
+    r.terminal_at = Some(Utc::now() - Duration::hours(age_hours));
     r
+}
+
+/// A directory shaped like a real SM-provisioned session worktree: a leaf whose
+/// immediate parent is `.worktrees`, carrying the ownership sentinel both
+/// provisioners write immediately after `git worktree add`.
+///
+/// Why: `.worktrees` is always in the detection set (#5204 keeps the built-in
+/// name alongside any configured one), so this fixture is recognised whatever
+/// `worktrees_dirname` the host machine has configured.
+/// What: creates `<root>/.worktrees/<leaf>` plus its `.trusty-mpm-worktree`
+/// file, and returns the leaf path.
+/// Test: used by the worktree-protection cases below.
+fn session_worktree(root: &Path, leaf: &str) -> PathBuf {
+    let wt = root.join(".worktrees").join(leaf);
+    std::fs::create_dir_all(&wt).expect("create worktree dir");
+    std::fs::write(
+        wt.join(super::super::decommission::WORKTREE_SENTINEL_FILE),
+        b"",
+    )
+    .expect("write sentinel");
+    wt
 }
 
 fn base_record() -> SessionRecord {
@@ -101,15 +122,15 @@ fn retention_verdict_keeps_live_states() {
 /// its path among the store's `workspace_path`s; dropping the record drops the
 /// path from every read of that set at once.
 #[test]
-fn retention_verdict_keeps_record_whose_workspace_still_exists() {
-    let mut r = terminal_record(ManagedSessionState::Decommissioned, 400);
+fn retention_verdict_keeps_record_whose_worktree_still_exists() {
+    let mut r = terminal_record(ManagedSessionState::Decommissioned, 24 * 400);
     r.workspace_path = Some(PathBuf::from("/tmp/some-worktree"));
     assert_eq!(
         retention_verdict(&r, true, Utc::now(), window()),
         RetentionVerdict::Keep,
         "a record whose worktree is still on disk keeps protecting it"
     );
-    // Same record, directory gone: now it is safe to evict.
+    // Same record, nothing behind the path to protect: now it is safe to evict.
     assert_eq!(
         retention_verdict(&r, false, Utc::now(), window()),
         RetentionVerdict::Evict
@@ -142,12 +163,12 @@ fn retention_verdict_stamps_undated_terminal_record() {
 /// where the retention change must be invisible.
 #[test]
 fn retention_verdict_keeps_record_inside_window() {
-    for age in [0, 1, 6] {
+    for age in [0, 1, 12, 23] {
         let r = terminal_record(ManagedSessionState::Decommissioned, age);
         assert_eq!(
             retention_verdict(&r, false, Utc::now(), window()),
             RetentionVerdict::Keep,
-            "{age}-day-old tombstone is inside the window"
+            "{age}-hour-old tombstone is inside the window"
         );
     }
 }
@@ -158,11 +179,11 @@ fn retention_verdict_evicts_record_outside_window() {
         ManagedSessionState::Decommissioned,
         ManagedSessionState::Deleted,
     ] {
-        let mut r = terminal_record(state.clone(), 8);
+        let mut r = terminal_record(state.clone(), 25);
         assert_eq!(
             retention_verdict(&r, false, Utc::now(), window()),
             RetentionVerdict::Evict,
-            "{state} 8 days past terminal is evictable"
+            "{state} 25 hours past terminal is evictable"
         );
         // Exactly at the boundary evicts too — `now - at >= retention`.
         r.terminal_at = Some(Utc::now() - window());
@@ -174,12 +195,12 @@ fn retention_verdict_evicts_record_outside_window() {
 }
 
 /// Seed a manager with one session, force it into `state`, and date its
-/// `terminal_at` `age_days` ago. Returns the record's id.
+/// `terminal_at` `age_hours` ago. Returns the record's id.
 async fn seed_terminal(
     mgr: &super::super::manager::SessionManager,
     task: &str,
     state: ManagedSessionState,
-    age_days: i64,
+    age_hours: i64,
 ) -> super::super::record::ManagedSessionId {
     let rec = mgr
         .create(task.into(), None, None, None, None, None)
@@ -187,8 +208,8 @@ async fn seed_terminal(
         .expect("create");
     let mut updated = mgr.get(&rec.id).await.expect("get");
     updated.state = state;
-    updated.terminal_at = Some(Utc::now() - Duration::days(age_days));
-    // Clear any provisioned workspace so the on-disk guard is not what the
+    updated.terminal_at = Some(Utc::now() - Duration::hours(age_hours));
+    // Clear any provisioned workspace so the worktree guard is not what the
     // eviction assertions are actually measuring.
     updated.workspace_path = None;
     mgr.store
@@ -227,7 +248,7 @@ async fn sweep_evicts_only_records_past_the_window() {
 
     let fresh = seed_terminal(&mgr, "fresh", ManagedSessionState::Decommissioned, 1).await;
     let stale = seed_terminal(&mgr, "stale", ManagedSessionState::Decommissioned, 30).await;
-    let deleted_stale = seed_terminal(&mgr, "gone", ManagedSessionState::Deleted, 9).await;
+    let deleted_stale = seed_terminal(&mgr, "gone", ManagedSessionState::Deleted, 25).await;
     let live = mgr
         .create("live".into(), None, None, None, None, None)
         .await
@@ -346,32 +367,38 @@ async fn sweep_releases_the_evicted_slot() {
 
 /// Why: the hard requirement. Eviction is a record-store operation; a retention
 /// sweep that reached the filesystem would be a data-loss defect. This seeds a
-/// stale terminal record whose workspace directory still exists and asserts BOTH
+/// stale terminal record whose session WORKTREE still exists and asserts BOTH
 /// that the sweep leaves the directory alone AND that it declines to evict the
-/// record while the directory is there — the guard that keeps
+/// record while the worktree is there — the guard that keeps
 /// `prune_orphaned_worktrees`'s protected set intact.
+///
+/// #5327: the workspace is a real worktree shape (`.worktrees/<leaf>` plus its
+/// ownership sentinel) rather than a bare directory. A bare directory is the
+/// main-checkout case this issue deliberately stopped protecting, so seeding
+/// one here would have tested the opposite of what the name claims.
 #[tokio::test]
-async fn sweep_never_touches_the_filesystem() {
+async fn sweep_never_touches_a_worktree_on_the_filesystem() {
     let dir = crate::test_support::hermetic_temp_dir();
     let (mgr, _fake) = make_manager(&dir).await;
 
-    let workspace = TempDir::new().expect("workspace");
-    let canary = workspace.path().join("unsaved-work.txt");
+    let base = TempDir::new().expect("base");
+    let workspace = session_worktree(base.path(), "tm-retention-01");
+    let canary = workspace.join("unsaved-work.txt");
     std::fs::write(&canary, b"do not delete me").expect("write canary");
 
-    let id = seed_terminal(&mgr, "stale", ManagedSessionState::Decommissioned, 400).await;
+    let id = seed_terminal(&mgr, "stale", ManagedSessionState::Decommissioned, 24 * 400).await;
     let mut rec = mgr.get(&id).await.expect("get");
-    rec.workspace_path = Some(workspace.path().to_path_buf());
+    rec.workspace_path = Some(workspace.clone());
     mgr.store.write().await.upsert(rec).await.expect("re-seed");
 
     let outcome = sweep_twice(&mgr, Utc::now()).await;
 
     assert!(
         outcome.evicted.is_empty(),
-        "a record whose workspace is still on disk is never evicted: {outcome:?}"
+        "a record whose worktree is still on disk is never evicted: {outcome:?}"
     );
-    assert!(workspace.path().exists(), "workspace directory survives");
-    assert!(canary.exists(), "file inside the workspace survives");
+    assert!(workspace.exists(), "worktree directory survives");
+    assert!(canary.exists(), "file inside the worktree survives");
     assert_eq!(
         std::fs::read(&canary).expect("read canary"),
         b"do not delete me",
@@ -442,11 +469,11 @@ async fn sweep_backfills_an_old_legacy_record_and_evicts_it_without_waiting() {
     );
 }
 
-/// Why: the inference must not sweep away a session decommissioned yesterday
+/// Why: the inference must not sweep away a session decommissioned an hour ago
 /// just because it also predates the field. A recent legacy record keeps its
 /// full window, which is the #3034 tombstone guarantee.
-/// What: seeds a legacy record active two days ago, asserts it is backfilled to
-/// that date and survives repeated sweeps, then that it goes once the window
+/// What: seeds a legacy record active two hours ago, asserts it is backfilled
+/// to that date and survives repeated sweeps, then that it goes once the window
 /// has genuinely elapsed.
 /// Test: this test.
 #[tokio::test]
@@ -460,8 +487,8 @@ async fn sweep_gives_a_recent_legacy_record_its_full_window() {
         .expect("create");
     let mut legacy = mgr.get(&rec.id).await.expect("get");
     legacy.state = ManagedSessionState::Decommissioned;
-    legacy.created_at = Utc::now() - Duration::days(2);
-    legacy.last_activity_at = Some(Utc::now() - Duration::days(2));
+    legacy.created_at = Utc::now() - Duration::hours(2);
+    legacy.last_activity_at = Some(Utc::now() - Duration::hours(2));
     legacy.terminal_at = None;
     legacy.workspace_path = None;
     mgr.store.write().await.upsert(legacy).await.expect("seed");
@@ -474,13 +501,13 @@ async fn sweep_gives_a_recent_legacy_record_its_full_window() {
             .expect("sweep");
         assert!(
             outcome.evicted.is_empty(),
-            "a 2-day-old tombstone must survive (pass {pass}): {outcome:?}"
+            "a 2-hour-old tombstone must survive (pass {pass}): {outcome:?}"
         );
     }
     assert!(mgr.get(&rec.id).await.is_ok(), "still in the store");
 
     // …and it does go once its own window has actually elapsed.
-    let later = sweep_twice(&mgr, Utc::now() + Duration::days(6)).await;
+    let later = sweep_twice(&mgr, Utc::now() + Duration::hours(23)).await;
     assert_eq!(later.evicted, vec![rec.id]);
 }
 
@@ -529,25 +556,26 @@ async fn sweep_stamps_now_when_a_legacy_record_has_no_usable_signal() {
     assert!(second.evicted.is_empty(), "and it gets a full window");
 }
 
-/// Why: the backfill must not open a path around the workspace guard. An old
-/// legacy record whose directory still exists is exactly the shape that guard
+/// Why: the backfill must not open a path around the worktree guard. An old
+/// legacy record whose worktree still exists is exactly the shape that guard
 /// exists for — its `workspace_path` is what keeps `prune_orphaned_worktrees`
 /// from deleting the worktree — and the inference gives it a date old enough to
 /// evict if the guard were checked in the wrong order.
-/// What: seeds a 400-day legacy record with a real directory and a canary file,
+/// What: seeds a 400-day legacy record with a real worktree and a canary file,
 /// sweeps three times, and asserts nothing is stamped or evicted and the
 /// directory survives intact.
 /// Test: this test.
 #[tokio::test]
-async fn sweep_backfill_still_spares_a_legacy_record_whose_workspace_exists() {
+async fn sweep_backfill_still_spares_a_legacy_record_whose_worktree_exists() {
     let dir = crate::test_support::hermetic_temp_dir();
     let (mgr, _fake) = make_manager(&dir).await;
-    let workspace = TempDir::new().expect("workspace");
-    let canary = workspace.path().join("unsaved-work.txt");
+    let base = TempDir::new().expect("base");
+    let workspace = session_worktree(base.path(), "tm-legacy-01");
+    let canary = workspace.join("unsaved-work.txt");
     std::fs::write(&canary, b"do not delete me").expect("write canary");
 
     let rec = mgr
-        .create("legacy-with-workspace".into(), None, None, None, None, None)
+        .create("legacy-with-worktree".into(), None, None, None, None, None)
         .await
         .expect("create");
     let mut legacy = mgr.get(&rec.id).await.expect("get");
@@ -555,7 +583,7 @@ async fn sweep_backfill_still_spares_a_legacy_record_whose_workspace_exists() {
     legacy.created_at = Utc::now() - Duration::days(400);
     legacy.last_activity_at = Some(Utc::now() - Duration::days(400));
     legacy.terminal_at = None;
-    legacy.workspace_path = Some(workspace.path().to_path_buf());
+    legacy.workspace_path = Some(workspace.clone());
     mgr.store.write().await.upsert(legacy).await.expect("seed");
 
     let mut gate = RetentionDebounce::new();
@@ -566,11 +594,11 @@ async fn sweep_backfill_still_spares_a_legacy_record_whose_workspace_exists() {
             .expect("sweep");
         assert!(
             outcome.is_empty(),
-            "the workspace guard runs BEFORE the backfill (pass {pass}): {outcome:?}"
+            "the worktree guard runs BEFORE the backfill (pass {pass}): {outcome:?}"
         );
     }
     assert!(mgr.get(&rec.id).await.is_ok(), "record survives");
-    assert!(canary.exists(), "and so does the work inside its workspace");
+    assert!(canary.exists(), "and so does the work inside its worktree");
 }
 
 // ── phase 3: re-validation against the current store ────────────────────────
@@ -642,6 +670,99 @@ async fn revalidate_drops_a_record_reactivated_after_the_snapshot() {
     assert!(mgr.get(&id).await.is_ok(), "and it is still in the store");
 }
 
+/// Why (#5327): the new guard reads the filesystem, so it has a stale-snapshot
+/// failure mode the timestamp guards do not. A record can be an eviction
+/// candidate at snapshot time and acquire a worktree before the delete —
+/// `mark_reactivated` followed by a `--worktree` relaunch, or an external volume
+/// remounting under the recorded path. Phase 3 must re-read the sentinel, not
+/// reuse the earlier answer.
+/// What: builds a candidate list from a record whose workspace is a plain
+/// directory (evictable), then turns that directory into a worktree by writing
+/// the ownership sentinel — the same write both provisioners perform — before
+/// calling re-validation, and asserts the candidate is dropped.
+/// Test: this test.
+#[tokio::test]
+async fn revalidate_drops_a_record_whose_worktree_appeared_after_the_snapshot() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let workspace = TempDir::new().expect("workspace");
+
+    let id = seed_terminal(&mgr, "stale", ManagedSessionState::Decommissioned, 30).await;
+    let mut rec = mgr.get(&id).await.expect("get");
+    rec.workspace_path = Some(workspace.path().to_path_buf());
+    mgr.store.write().await.upsert(rec).await.expect("re-seed");
+
+    // The snapshot said Evict — a plain directory protects nothing…
+    assert_eq!(
+        mgr.revalidate_for_eviction(vec![id], Utc::now(), window())
+            .await,
+        vec![id]
+    );
+
+    // …then a worktree appears at that path.
+    std::fs::write(
+        workspace
+            .path()
+            .join(super::super::decommission::WORKTREE_SENTINEL_FILE),
+        b"",
+    )
+    .expect("sentinel");
+
+    let survivors = mgr
+        .revalidate_for_eviction(vec![id], Utc::now(), window())
+        .await;
+    assert!(
+        survivors.is_empty(),
+        "phase 3 must re-read the sentinel, not reuse the snapshot's answer: {survivors:?}"
+    );
+    assert!(mgr.get(&id).await.is_ok(), "and the record is still there");
+}
+
+/// Why (#5327): the debounce's stated job is to rule out a single misleading
+/// filesystem observation, and the guard's new sentinel read is exactly such an
+/// observation. A candidate armed on tick one whose worktree is visible again on
+/// tick two must disarm rather than be deleted on the strength of the first
+/// reading.
+/// What: seeds a stale record on a plain directory, sweeps once to arm it, makes
+/// the directory a worktree, and asserts the deleting sweep evicts nothing.
+/// Test: this test.
+#[tokio::test]
+async fn sweep_spares_a_record_whose_worktree_appears_between_sweeps() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let workspace = TempDir::new().expect("workspace");
+
+    let id = seed_terminal(&mgr, "stale", ManagedSessionState::Decommissioned, 30).await;
+    let mut rec = mgr.get(&id).await.expect("get");
+    rec.workspace_path = Some(workspace.path().to_path_buf());
+    mgr.store.write().await.upsert(rec).await.expect("re-seed");
+
+    let mut gate = RetentionDebounce::new();
+    let first = mgr
+        .sweep_terminal_records(Utc::now(), window(), &mut gate)
+        .await
+        .expect("first sweep");
+    assert!(first.evicted.is_empty(), "armed, not yet evicted");
+
+    std::fs::write(
+        workspace
+            .path()
+            .join(super::super::decommission::WORKTREE_SENTINEL_FILE),
+        b"",
+    )
+    .expect("sentinel");
+
+    let second = mgr
+        .sweep_terminal_records(Utc::now(), window(), &mut gate)
+        .await
+        .expect("second sweep");
+    assert!(
+        second.evicted.is_empty(),
+        "one stale observation must never be enough to delete: {second:?}"
+    );
+    assert!(mgr.get(&id).await.is_ok());
+}
+
 /// Why: the other non-evicting arm. A concurrent prune removing the record
 /// first is a race we lose harmlessly, not an error — but it must drop out of
 /// the delete list rather than being counted as evicted, or the sweep reports
@@ -671,35 +792,200 @@ async fn revalidate_drops_a_record_a_concurrent_prune_already_removed() {
 /// deleting the worktree. The probe is injected rather than provoked with real
 /// filesystem permissions so this is deterministic on every platform and under
 /// any uid, including root.
-/// What: asserts an `Err` probe reports PRESENT, so the verdict is `Keep`;
-/// `Ok(true)` is present, `Ok(false)` absent, and a `None` path is absent.
+///
+/// #5327 gave the same treatment to the SECOND probe. The sentinel read decides
+/// whether a directory is a worktree at all, and it happens at a different
+/// moment from the sweep's own read of the same file — so an `Err` there must
+/// also mean PROTECTED, or a transient failure here permanently drops a
+/// protection the sweep's later, successful read would have honoured.
+/// What: asserts an `Err` on the workspace probe reports PROTECTED, so the
+/// verdict is `Keep`; that an `Err` on the sentinel probe alone does too; and
+/// that a `None` path protects nothing.
 /// Test: this test.
 #[test]
-fn workspace_present_treats_an_undetermined_path_as_present() {
-    let path = PathBuf::from("/definitely/unreadable");
+fn workspace_needs_protection_treats_an_undetermined_path_as_protected() {
+    let path = PathBuf::from("/definitely/unreadable/plain-checkout");
     assert!(
-        workspace_present(Some(&path), |_| Err(std::io::Error::new(
+        workspace_needs_protection(Some(&path), |_| Err(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
             "EACCES"
         ))),
-        "an undetermined path must count as PRESENT so the record is kept"
+        "an undetermined workspace path must count as PROTECTED so the record is kept"
     );
-    assert!(workspace_present(Some(&path), |_| Ok(true)));
-    assert!(!workspace_present(Some(&path), |_| Ok(false)));
     assert!(
-        !workspace_present(None, |_| Ok(true)),
+        workspace_needs_protection(Some(&path), |p| if p == path {
+            Ok(true)
+        } else {
+            Err(std::io::Error::other("EIO"))
+        }),
+        "an undetermined SENTINEL probe must also count as PROTECTED"
+    );
+    assert!(
+        !workspace_needs_protection(Some(&path), |_| Ok(false)),
+        "a workspace that is gone protects nothing"
+    );
+    assert!(
+        !workspace_needs_protection(None, |_| Ok(true)),
         "no path, nothing to protect"
     );
 
     // …and the verdict that consumes it keeps the record.
-    let mut r = terminal_record(ManagedSessionState::Decommissioned, 400);
+    let mut r = terminal_record(ManagedSessionState::Decommissioned, 24 * 400);
     r.workspace_path = Some(path.clone());
-    let undetermined = workspace_present(Some(&path), |_| Err(std::io::Error::other("EIO")));
+    let undetermined =
+        workspace_needs_protection(Some(&path), |_| Err(std::io::Error::other("EIO")));
     assert_eq!(
         retention_verdict(&r, undetermined, Utc::now(), window()),
         RetentionVerdict::Keep,
         "a stat error must never evict"
     );
+}
+
+/// Why: this is the clause that must NOT relax. `tm launch --worktree` still
+/// provisions a worktree, and its record's `workspace_path` is the only thing
+/// keeping that directory out of `prune_orphaned_worktrees`'s reach.
+/// What: exercises both protecting clauses independently against the real
+/// filesystem — the `.worktrees/<leaf>` shape with its sentinel stripped, and a
+/// directory of any shape carrying the sentinel.
+/// Test: this test.
+#[test]
+fn workspace_needs_protection_covers_a_session_worktree() {
+    let base = TempDir::new().expect("base");
+
+    let wt = session_worktree(base.path(), "tm-shape-01");
+    std::fs::remove_file(wt.join(super::super::decommission::WORKTREE_SENTINEL_FILE))
+        .expect("strip sentinel");
+    assert!(
+        workspace_needs_protection(Some(&wt), |p| p.try_exists()),
+        "a `.worktrees/<leaf>` path is protected on its shape alone, with no sentinel to read"
+    );
+
+    let odd = base.path().join("not-under-a-worktree-base");
+    std::fs::create_dir_all(&odd).expect("create");
+    std::fs::write(
+        odd.join(super::super::decommission::WORKTREE_SENTINEL_FILE),
+        b"",
+    )
+    .expect("sentinel");
+    assert!(
+        workspace_needs_protection(Some(&odd), |p| p.try_exists()),
+        "an ownership sentinel protects whatever the path's shape is"
+    );
+}
+
+/// Why (#5327): the narrowing itself. Under ADR-0037 as amended (#5274) a
+/// session runs on the project's main checkout and records THAT as its
+/// `workspace_path` — a directory that never disappears. The pre-#5327 guard
+/// asked only "does this exist", so every such record was pinned in the store
+/// permanently and its `NUM` never came back, at any retention window.
+/// `prune_orphaned_worktrees` cannot delete such a path: with no ownership
+/// sentinel it classifies the candidate `SentinelOwner::Unknown` and never
+/// auto-deletes, so the record's presence in the protected set buys nothing.
+/// What: a real, existing, plainly-shaped directory with no sentinel is not
+/// protected — and the sibling assertion pins that adding the sentinel flips it
+/// back, so this is a statement about the sentinel and not about the directory
+/// merely being reachable.
+/// Test: this test.
+#[test]
+fn workspace_needs_protection_ignores_a_plain_main_checkout() {
+    let checkout = TempDir::new().expect("checkout");
+    std::fs::write(checkout.path().join("README.md"), b"a real repo").expect("write");
+
+    assert!(
+        !workspace_needs_protection(Some(checkout.path()), |p| p.try_exists()),
+        "a main checkout carries no ownership sentinel and no sweep can delete it"
+    );
+    std::fs::write(
+        checkout
+            .path()
+            .join(super::super::decommission::WORKTREE_SENTINEL_FILE),
+        b"",
+    )
+    .expect("sentinel");
+    assert!(
+        workspace_needs_protection(Some(checkout.path()), |p| p.try_exists()),
+        "…and the sentinel is what decides it, not the directory's existence"
+    );
+}
+
+/// Why (#5327): the end-to-end statement of the fix, on the exact record shape
+/// `spawn_managed_on_main` writes — `workspace_path` set to a live main
+/// checkout. Before this change such a record was `Keep` forever; the whole
+/// measured symptom (130 slots fronting 42 sessions) is this case accumulating.
+/// What: seeds two decommissioned records past the window, one on a main
+/// checkout and one on a session worktree, sweeps, and asserts the sweep evicts
+/// the first, releases its slot, spares the second, and leaves both directories
+/// on disk.
+/// Test: this test.
+#[tokio::test]
+async fn sweep_evicts_a_main_checkout_session_but_spares_a_worktree_one() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let project = TempDir::new().expect("project");
+    let checkout = project.path().join("owner").join("repo");
+    std::fs::create_dir_all(&checkout).expect("create checkout");
+    let worktree = session_worktree(&checkout, "tm-isolated-01");
+
+    let on_main = seed_terminal(&mgr, "on-main", ManagedSessionState::Decommissioned, 25).await;
+    let isolated = seed_terminal(&mgr, "isolated", ManagedSessionState::Decommissioned, 25).await;
+    for (id, path) in [(on_main, checkout.clone()), (isolated, worktree.clone())] {
+        let mut rec = mgr.get(&id).await.expect("get");
+        rec.workspace_path = Some(path);
+        mgr.store.write().await.upsert(rec).await.expect("re-seed");
+    }
+
+    let before = mgr.numbered_snapshot(&mgr.list().await).await;
+    let main_slot = before
+        .iter()
+        .find(|s| s.record.as_ref().map(|r| r.id) == Some(on_main))
+        .expect("observed")
+        .slot;
+
+    let outcome = sweep_twice(&mgr, Utc::now()).await;
+
+    assert_eq!(
+        outcome.evicted,
+        vec![on_main],
+        "only the main-checkout record is evicted: {outcome:?}"
+    );
+    assert!(
+        mgr.get(&isolated).await.is_ok(),
+        "`tm launch --worktree`'s record still protects its worktree"
+    );
+    assert!(checkout.exists(), "the main checkout is untouched");
+    assert!(worktree.exists(), "and so is the worktree");
+
+    let after = mgr.numbered_snapshot(&mgr.list().await).await;
+    assert!(
+        after.iter().all(|s| s.slot != main_slot),
+        "the freed NUM leaves the listing"
+    );
+}
+
+/// Why (#5327): the window's own boundary, end to end. The pre-#5327 seven-day
+/// window kept both of these; a record decommissioned yesterday morning should
+/// be gone by the next working day, and one decommissioned an hour ago must
+/// not be.
+/// What: seeds a 12-hour-old and a 25-hour-old decommissioned record with no
+/// workspace at all, and asserts exactly the older one is evicted.
+/// Test: this test.
+#[tokio::test]
+async fn sweep_evicts_across_the_twenty_four_hour_boundary() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let inside = seed_terminal(&mgr, "inside", ManagedSessionState::Decommissioned, 12).await;
+    let outside = seed_terminal(&mgr, "outside", ManagedSessionState::Decommissioned, 25).await;
+
+    let outcome = sweep_twice(&mgr, Utc::now()).await;
+
+    assert_eq!(
+        outcome.evicted,
+        vec![outside],
+        "12 hours survives, 25 hours does not: {outcome:?}"
+    );
+    assert!(mgr.get(&inside).await.is_ok());
 }
 
 /// Why: the two sibling destructive sweeps in the same orphan-GC tick each


### PR DESCRIPTION
Closes #5327.

## The window alone would have fixed nothing

`spawn_managed_on_main` sets `workspace_path` to the project's main checkout
(`launch_on_main.rs:151-162`). The pre-#5327 guard asked "does the workspace
still exist", and a main checkout never stops existing — so every
main-checkout record was `Keep` at any age and at any retention window. Under
ADR-0037 as amended (#5274) that is the DEFAULT placement, so it is the shape
the store fills up with. 130 slots fronting 42 live sessions, nothing ever
released, is that guard never firing negative.

So this PR changes both things the issue asked about, and the second is the
one that moves the measured number.

## Decision 1 — the window: 24 hours, still a fixed duration

`TERMINAL_RECORD_RETENTION_DAYS` 7 → 1.

Once decision 2 lands, protecting a worktree is the guard's job and it holds a
record for as long as there is one, at any age. What is left for the clock is
narrower: the span in which an operator can still act on a record that is
already dead. Two such actions exist.

1. A `NUM` read off a listing must not point at a different session later. The
   registry is in-memory and resets on daemon restart, so this only ever had to
   hold for one daemon lifetime.
2. `mark_reactivated` accepts `Decommissioned → Active` (#2777) for the operator
   sitting in a lingering bare pane. That revive reads the record out of the
   store, so the record has to be there.

Both are same-working-day actions that must survive an overnight gap — a
session decommissioned last night is one you pick up this morning. 24 hours is
also what this crate already waits before an automatic sweep acts on a session
with no operator present (`MAX_EPHEMERAL_AGE_HOURS = 24`, the ephemeral
auto-reap). Retention does strictly less than that sweep: it deletes a record,
never a process or a directory. It had no business being the one path waiting
seven times longer.

**Still a fixed duration.** The alternative considered was capacity-based
eviction — hold at most N terminal records, drop the oldest. It couples record
lifetime to display numbering, makes eviction order-dependent, and leaves "when
does my record disappear" unanswerable. A per-record window (short without a
worktree, long with one) was also considered and is dead weight: under decision
2 a record with a worktree is kept indefinitely anyway, so the longer window
would never bind.

**The unit stays days** because the NAME is published API on a 1.x crate
(`trusty-mpm` 1.3.5, and this is milestoned 1.3.7). Renaming it to
`..._HOURS` to write `24` instead of `1` is a `constant_missing` major break
for a cosmetic gain.

## Decision 2 — the precondition becomes conditional; the debounce does not move

### The workspace guard

`workspace_present` → `workspace_needs_protection`. It is not deleted and it is
not weakened for the case it exists for; it is pointed at what the orphan sweep
can actually reach.

`prune_orphaned_worktrees` needs a candidate to carry a `.trusty-mpm-worktree`
ownership sentinel naming a resolvable owner (#3649, `prune.rs:806-820`); a
`SentinelOwner::Unknown` candidate is logged and never auto-deleted. The
sentinel has exactly two write sites — `provisioner/workspace.rs:832` and
`managed_routes/inproject.rs:534` — and each writes it immediately after its own
`git worktree add`. **A path with no sentinel was therefore never provisioned as
a session worktree, and the sweep will not delete it however this record
changes.** A main checkout is exactly that path.

Protected when ANY of:

- the workspace path cannot be probed (`Err`) — unchanged, and for the same
  reason: `Path::exists()` collapses EACCES / stale NFS / EIO into "not there",
  and "not there" is what evicts;
- the immediate parent is a worktree base (`is_session_worktree`, a deliberate
  detection superset since #5204);
- a sentinel file exists at the path, **or its existence cannot be determined**.

The last two clauses are independent on purpose. The sweep reads the sentinel at
deletion time and this reads it now; a read that failed transiently here would
drop the protection permanently while the sweep's own later read succeeds. The
shape clause covers that for the standard `.worktrees` layout, and treating an
undetermined sentinel probe as present covers it elsewhere. `tm launch
--worktree` provisions under `.worktrees` and writes a sentinel, so it clears
both.

### The debounce and the phase-3 re-validate: unchanged, and not relaxed

Neither moved. Both now guard a change that acts sooner, which raises what one
stale observation costs rather than lowering it — and the guard's new sentinel
read is itself a live filesystem observation with the same transient-failure
exposure the debounce was written for. Two ticks ~60s apart against a 24h window
is a rounding error. Phase 3 still re-reads each candidate from the current
store immediately before deleting, and now re-reads the sentinel with it; two
new tests pin that it does.

## What this does NOT do

Nothing weakens. The record-only scope is unchanged: this sweep writes
`sessions.json` and the in-memory slot registry, and its only filesystem calls
are two `try_exists` probes. Slot-per-project and the `tm-<leaf>-NN` name serial
are untouched, per the issue.

## Gates — rung 5 (record persistence, irreversible deletion)

```
cargo fmt --check && cargo check -p trusty-mpm --all-targets \
  && cargo clippy -p trusty-mpm --all-targets -- -D warnings
EXIT=0
```

```
cargo test -p trusty-mpm -- --include-ignored
test result: FAILED. 4867 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out; finished in 929.34s
```

The 5 are the known environmental flake class (#5328 — wall-clock racing a
subprocess spawn), hit here because three `cargo test` binaries were competing
for CPU on this machine:

```
core::gh_account::enforce::tests::ensure_gh_account_in_dir_noop_when_already_active
core::gh_account::enforce::tests::ensure_gh_account_in_dir_self_heals_mismatch
core::gh_account::enforce::tests::ensure_gh_account_in_dir_switch_failure_is_err
core::git_identity::tests::resolve_for_config_enforced_fails_closed_on_switch_failure
core::git_identity::tests::resolve_for_config_enforced_self_heals_mismatch

panicked at core/gh_account_enforce.rs:682:
  already-active must be a no-op Ok: Err(failed to run `gh auth status` scoped to
  the project's GH_CONFIG_DIR
  Caused by: `gh` did not respond within 5s)
```

Not caused by this branch, and not hidden: `git diff --name-only
origin/main...HEAD -- crates/trusty-mpm/src/core/` returns zero files — the
diff is three files, all under `session_manager/`. All 5 pass in isolation:

```
cargo test -p trusty-mpm --lib -- --include-ignored --test-threads=1 \
  core::gh_account::enforce::tests core::git_identity::tests
test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 4840 filtered out
EXIT=0
```

The retention suite itself:

```
cargo test -p trusty-mpm --lib session_manager::retention
test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 4843 filtered out
EXIT=0
```

Lint scripts, all `EXIT=0`:

| script | result |
|---|---|
| `check_line_cap.sh` | 3859 files, 4 allowlisted, 0 violations |
| `check_sld.sh` | 57 specs + 3184 code files, 0 errors, 0 warnings |
| `check_doc_numbers.sh` | 110 docs / 104 claims, 0 violations |
| `check_test_pointers.sh` | 23202 citations, 0 dangling |
| `check_changelog_fragment.sh` | fragment present and valid |
| `check_capabilities.sh` | up to date |
| `check_generation_artifacts.sh` | 0 leaked artifacts |
| `check_agent_assets.sh` | 30 byte-parity files match |
| `check_buildrs_sync.sh` | in sync across 3 crates |
| `check_public_docs.sh` | 27 pages resolve inside the boundary |

## Regression tests, proved by mutation

Each new test was run against a mutated tree and observed to FAIL. Four
mutations, on the fixed tree, one at a time.

**M1 — restore `TERMINAL_RECORD_RETENTION_DAYS = 7`** (keeps the guard fix):

```
test result: FAILED. 17 passed; 10 failed
  sweep_evicts_across_the_twenty_four_hour_boundary ... FAILED
  assertion `left == right` failed: 12 hours survives, 25 hours does not:
    RetentionOutcome { stamped: 0, evicted: [] }
    left: []   right: [ManagedSessionId(e35b2f78-…)]
  sweep_evicts_a_main_checkout_session_but_spares_a_worktree_one ... FAILED
  retention_window_is_twenty_four_hours ... FAILED
  (+ 7 pre-existing sweep/revalidate cases whose fixture ages are now hours)
```

**M2 — restore the pre-fix guard body** (`path.is_some_and(|p| probe(p).unwrap_or(true))`),
keeping the 24h window:

```
test result: FAILED. 25 passed; 2 failed
  workspace_needs_protection_ignores_a_plain_main_checkout ... FAILED
    a main checkout carries no ownership sentinel and no sweep can delete it
  sweep_evicts_a_main_checkout_session_but_spares_a_worktree_one ... FAILED
    assertion `left == right` failed: only the main-checkout record is evicted:
      RetentionOutcome { stamped: 0, evicted: [] }
      left: []   right: [ManagedSessionId(2411a5a4-…)]
```

M2 is the load-bearing one: it is the pre-#5327 behavior with the new window
already applied, and the main-checkout record still is not evicted.

**M3 / M4 — the safety direction.** Guard replaced with `false` (over-relaxed,
protecting nothing):

```
test result: FAILED. 21 passed; 8 failed
  sweep_never_touches_a_worktree_on_the_filesystem ... FAILED
  sweep_backfill_still_spares_a_legacy_record_whose_worktree_exists ... FAILED
  sweep_evicts_a_main_checkout_session_but_spares_a_worktree_one ... FAILED
  workspace_needs_protection_covers_a_session_worktree ... FAILED
  workspace_needs_protection_treats_an_undetermined_path_as_protected ... FAILED
  workspace_needs_protection_ignores_a_plain_main_checkout ... FAILED
  revalidate_drops_a_record_whose_worktree_appeared_after_the_snapshot ... FAILED
  sweep_spares_a_record_whose_worktree_appears_between_sweeps ... FAILED
```

That covers the three cases the brief named — a record that should be evicted
is, one that should not be is not, and a session that DID have a worktree is
protected — plus the two new failure-path/concurrency cases.

### New coverage

| test | what it pins |
|---|---|
| `sweep_evicts_a_main_checkout_session_but_spares_a_worktree_one` | end-to-end on the two real record shapes; slot released, both directories still on disk |
| `sweep_evicts_across_the_twenty_four_hour_boundary` | 12h survives, 25h does not |
| `workspace_needs_protection_ignores_a_plain_main_checkout` | and that adding the sentinel flips it back — so it is a statement about the sentinel, not about reachability |
| `workspace_needs_protection_covers_a_session_worktree` | both protecting clauses independently, against the real filesystem |
| `workspace_needs_protection_treats_an_undetermined_path_as_protected` | `Err` on EITHER probe means protected |
| `revalidate_drops_a_record_whose_worktree_appeared_after_the_snapshot` | phase 3 re-reads the sentinel rather than reusing the snapshot |
| `sweep_spares_a_record_whose_worktree_appears_between_sweeps` | the debounce covers the new live read too |

Two existing tests changed fixture, not intent:
`sweep_never_touches_the_filesystem` and
`sweep_backfill_still_spares_a_legacy_record_whose_workspace_exists` seeded a
bare `TempDir`, which is now the main-checkout case. Both were reseeded as real
worktrees (`.worktrees/<leaf>` + sentinel) and renamed to say `worktree`; M3/M4
shows both still go red when the guard is removed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

## Correction: the sentinel is not the only deleter, and not the strongest argument

The section above named `prune_orphaned_worktrees` as the sweep to satisfy. It
is not the only one that treats the store's `workspace_path` set as protection.
Both of these do too:

- `reclaim_merged_pr_worktrees` (#2919, `worktree_reclaim_sweep.rs`), fed from
  `managed_routes/prune.rs:220`. **It does not read the ownership sentinel at
  all**, so the sentinel argument does not cover it.
- `search_gc.rs:298`, which deletes trusty-search indexes — scoped by its own
  doc to `.worktrees/`-rooted indexes for managed worktrees.

The argument that covers all of them is structural, not sentinel-based. Every
one of these sweeps enumerates candidates from the same git-authoritative
registry (`worktree_registry.rs`: `scan_registered_worktrees` /
`enumerate_registered_worktrees`), and that enumeration drops records that are
"bare, **main**, already prunable, or git-`locked`", plus anything failing the
`scan_from_anchor` containment rule (`worktree_registry.rs:231-233`). A
project's main checkout IS git's main worktree, and is the project directory
rather than a strict descendant of it. **It can never become a candidate for
any of these sweeps**, so its record leaving the store costs no protection —
independent of any sentinel.

The sentinel clause in `workspace_needs_protection` still earns its place: it is
the belt for a path that is not main and not `.worktrees`-shaped, where the
structural argument alone would not decide. Two independent boundaries, which is
this file's existing pattern.

## Review status

`code-critic`: **APPROVE**, with three findings, all fixed in this PR
(no follow-ups filed).

- **MEDIUM** — `workspace_needs_protection` reached `TrustyToolsConfig::load()`
  once per record with a live workspace, every 60s tick, via
  `is_session_worktree`. Two file reads, two YAML parses, and — for a config
  carrying one unrecognised key — a `report_unknown_keys` warning, each time.
  At ~130 records that is ~130 identical warn lines per tick, ~187k/day,
  burying the one-shot startup warning #5207 added the mechanism to deliver.
  CPU was never the issue; the log was. Fixed by resolving `WorktreeDirNames`
  once at the top of `sweep_terminal_records` and threading it through
  `verdict_for` / `revalidate_for_eviction` / `workspace_needs_protection` —
  which is what that type's own docs prescribe (#5204, "resolve once at the top
  of a scan and pass this value down"). New
  `decommission::is_session_worktree_with` takes pre-resolved names;
  `is_session_worktree` delegates to it, so the other eight call sites are
  untouched.
- **LOW** — the sweep's doc claimed "its only filesystem calls are
  `workspace_needs_protection`'s two `try_exists` probes", which the guard
  change had made false. Now states the once-per-sweep config read.
- **LOW** — three "seven days" / "no seven-day wait" comments described the
  window this PR removes. Reworded; `retention_tests.rs:966` already said
  "pre-#5327 seven-day" and was left alone.

Mutation proofs re-run after the refactor, against the threaded guard:
**M1** (window back to 7) 11 failed; **M2** (pre-#5327 guard, window still 1)
3 failed; **M3** (guard always `false`) 8 failed; restored, 29 passed.
These are the critic's counts — my first report said 10 and 2 for M1/M2, which
was wrong; no conclusion changes.

Post-fix gates: `cargo fmt --check` clean, `cargo check -p trusty-mpm
--all-targets` clean, `cargo clippy -p trusty-mpm --all-targets -- -D warnings`
clean, retention suite `29 passed; 0 failed`, and the `is_session_worktree`
consumers (`decommission`, `search_gc`, `workspace_liveness`) `43 passed; 0
failed`. Four lint scripts OK.
