### PR TITLE
docs(trusty-mpm): claim-then-populate ADR numbering protocol

### DIFF
--- a/crates/trusty-mpm/changelog.d/5336-adr-numbering-claim-then-populate.md
+++ b/crates/trusty-mpm/changelog.d/5336-adr-numbering-claim-then-populate.md
@@ -1,0 +1,10 @@
+Documentation
+
+- The `tm-adr` bundled skill's numbering convention now names a claim-then-populate
+  protocol: check `docs/adr/` on `origin/main` (not a possibly-stale local
+  checkout) and any in-flight branch or open PR before picking a number, create
+  the ADR file first as a stub reserving that number, then populate it. Also
+  states what to do on discovering a collision — report it, never silently
+  renumber another author's ADR. Closes a gap two same-day collisions exposed:
+  ADR-0021 (pre-existing, out of scope here) and a same-day ADR-0038 collision
+  caught only by an alert author.

--- a/crates/trusty-mpm/src/assets/skills/tm-adr.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-adr.md
@@ -60,7 +60,7 @@ If unsure, ask: "Would a new contributor in six months need to understand
 
 `docs/adr/` already exists in this repo (see `docs/adr/README.md` and
 `docs/adr/template.md`) with decisions numbered through the 0013 range as of
-this writing — always check the actual latest file before picking a number.
+this writing — see "Numbering Convention" below before picking a number.
 
 ---
 

--- a/crates/trusty-mpm/src/assets/skills/tm-adr.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-adr.md
@@ -64,16 +64,35 @@ this writing — always check the actual latest file before picking a number.
 
 ---
 
-## Numbering Convention
+## Numbering Convention — Claim, Then Populate
 
-Sequential, zero-padded four-digit integers. Find the next number:
+Sequential, zero-padded four-digit integers. Concurrent worktrees each
+guessing "the next number" from a stale or dirty local checkout is exactly
+how two ADRs land on the same number — several can be in flight at once.
 
-```bash
-ls docs/adr/*.md | grep -E '^docs/adr/[0-9]{4}' | sort | tail -3
-```
+1. **Check before choosing** — list `docs/adr/` on `origin/main`, not your
+   local working tree:
+   ```bash
+   git fetch origin
+   git ls-tree -r --name-only origin/main -- docs/adr/ | grep -E '/[0-9]{4}-' | sort | tail -5
+   ```
+   Also check for a number already claimed by an in-flight branch or open PR
+   that hasn't merged yet (e.g. `gh pr list --search "docs/adr"`, or ask
+   whoever is coordinating concurrent work) — `origin/main` alone won't show
+   it.
+2. **Create the file, then stage it immediately** — a stub carrying at least
+   the title and `Status:` line, at `docs/adr/NNNN-your-title.md` (copy
+   `docs/adr/template.md`), followed by `git add docs/adr/NNNN-your-title.md`.
+   An untracked stub reserves nothing: a duplicate-number lint that reads
+   `git ls-files` (this repo's `scripts/check_doc_numbers.sh` is one) is blind
+   to it, and so is a peer session running the same check-before-choosing step
+   you just did. Staging it is what actually claims the number.
+3. **Then populate** Context, Decision, Consequences, and Related Decisions.
 
-Copy `docs/adr/template.md` to `docs/adr/NNNN-your-title.md` with the next
-available number.
+**On discovering a collision** — your number, or someone else's, is already
+taken — report it and pick a different number. Never silently renumber
+another author's ADR; that call belongs to them or whoever is coordinating
+the collision.
 
 ---
 


### PR DESCRIPTION
## Summary

- Two same-day ADR-numbering collisions surfaced: `ADR-0021` (pre-existing,
  grandfathered in `.doc-number-allowlist.tsv`, out of scope here) and a
  same-day `ADR-0038` collision caught before merge. Nothing told an author
  to check `origin/main` and in-flight work before picking a number.
- Adds a claim-then-populate protocol to the `tm-adr` bundled skill's
  Numbering Convention section — the doc an agent actually loads at the
  moment it writes an ADR: check `origin/main` (not a possibly-stale local
  checkout) and in-flight branches/PRs, create the stub and `git add` it
  immediately (an untracked file is invisible to `scripts/check_doc_numbers.sh`,
  which enumerates via `git ls-files`), then populate. States what to do on
  discovering a collision: report it, never silently renumber someone else's
  ADR.
- No gate or script added — the owner explicitly declined one; this repo's
  `scripts/check_doc_numbers.sh` already covers `docs/adr/` (`DUP-ADR`) as a
  mechanical backstop, described accordingly rather than duplicated.

## Test plan

Rung 1 (docs only), plus the bundled-asset check since this touches
`crates/trusty-mpm/src/assets/skills/`:

- [x] `bash scripts/check_agent_assets.sh` — exit 0
- [x] `bash scripts/check_doc_numbers.sh` — exit 0
- [x] `bash scripts/check_sld.sh` — `sld-lint: scanned 57 spec doc(s) + 3188 code file(s); 0 error(s), 0 warning(s)`
- [x] `bash scripts/check_line_cap.sh` — exit 0
- [x] `bash scripts/check_changelog_fragment.sh --base origin/main` — exit 0
- [x] `cargo fmt --check` — exit 0

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools