### PR TITLE
fix(trusty-mpm): make the shared-tree dispatch guard record while it answers (#5324)

### DIFF
--- a/crates/trusty-mpm/changelog.d/4480-shared-worktree-dispatch-guard.md
+++ b/crates/trusty-mpm/changelog.d/4480-shared-worktree-dispatch-guard.md
@@ -10,6 +10,6 @@ Added
   everywhere else: a read-only dispatch, an unknown agent name, an unresolvable
   working directory, and an unreachable daemon all allow the dispatch (#4480).
   - Delegation records now carry the `isolation` mode a dispatch declared, and the
-    daemon serves `GET /api/v1/sessions/{id}/delegations/shared-tree-writers` so the
-    guard can ask which agents are already writing in a directory rather than guess
-    from a timer.
+    daemon serves `POST /api/v1/sessions/{id}/delegations/shared-tree-dispatch` so
+    the guard can learn which agents are already writing in a directory rather than
+    guess from a timer.

--- a/crates/trusty-mpm/changelog.d/5324-dispatch-reservation.md
+++ b/crates/trusty-mpm/changelog.d/5324-dispatch-reservation.md
@@ -1,0 +1,15 @@
+Fixed
+
+- Two `Agent`/`Task` dispatches issued in one PM turn could both be admitted into
+  the same working directory. The `#4480` guard asked the daemon who was already
+  writing there and acted on the answer, with nothing claiming the directory in
+  between, so both could ask before either was recorded and both see an empty
+  set. `POST /api/v1/sessions/{id}/delegations/shared-tree-dispatch` now answers
+  and claims in one critical section, so the second of two simultaneous
+  dispatches finds the first and is denied. The claim is the delegation record
+  the daemon's own `PreToolUse` hook would have written a moment later — same
+  correlation key, same liveness, same staleness sweep — so nothing new has to be
+  released. Every fail-open branch is unchanged: an unreachable daemon, a
+  malformed answer, an unresolvable working directory, an unknown agent, and a
+  read-only or isolated dispatch all still allow the call and claim nothing
+  (#5324).

--- a/crates/trusty-mpm/changelog.d/5324-dispatch-reservation.md
+++ b/crates/trusty-mpm/changelog.d/5324-dispatch-reservation.md
@@ -13,3 +13,12 @@ Fixed
   malformed answer, an unresolvable working directory, an unknown agent, and a
   read-only or isolated dispatch all still allow the call and claim nothing
   (#5324).
+- The claim POST forwards only `subagent_type`, `isolation` and `description` —
+  the fields the daemon actually reads — instead of the whole dispatch prompt.
+  The record it writes is unchanged, and the request body can no longer grow
+  past a size limit and fail the guard open on the largest dispatches (#5324).
+- `tm hook --pm-guard` now warns on stderr when the daemon reports no live
+  writers but claims nothing, which only happens when a running daemon predates
+  the `tm` on PATH and does not recognise the agent being dispatched. The
+  dispatch is still allowed — this path fails open deliberately — but the guard
+  no longer goes silently unenforced (#5324).

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_dispatch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_dispatch.rs
@@ -33,22 +33,27 @@
 //! liveness from real `SubagentStop` signals, so it is asked rather than
 //! guessed at.
 //!
-//! **Known gap — this is check-then-decide, with no reservation step.** The
-//! daemon is queried and the verdict computed from the answer; nothing claims
-//! the directory in between. Two dispatches that both query before either's
-//! `on_dispatch` recording lands both see an empty set and are both ALLOWED.
-//! `pm_guard_admits_both_dispatches_that_query_before_either_is_recorded`
-//! (`tests/tm_hook_pm_guard.rs`) pins that behaviour deterministically, by
-//! blocking the mock daemon's replies until both queries have arrived.
+//! **The question and the claim are one daemon operation (#5324).** This used
+//! to be check-then-decide: the daemon was queried and the verdict computed
+//! from the answer, with nothing claiming the directory in between, so two
+//! dispatches issued in one PM turn could both query before either's
+//! `on_dispatch` recording landed, both see an empty set, and both be ALLOWED —
+//! and a PM dispatching several agents in one message is the framework's own
+//! documented pattern for parallel work, so that was the common shape, not an
+//! edge case. [`claim_shared_tree`] now POSTs the dispatch instead of asking
+//! about it: the daemon answers and, when the answer is empty, records this
+//! dispatch inside the same critical section. The second of two simultaneous
+//! dispatches therefore sees the first and is denied.
 //!
-//! Whether the harness ever produces that interleaving is NOT established here.
-//! Claude Code's hooks reference states that multiple handlers matching ONE
-//! event run in parallel, and says nothing about `PreToolUse` across
-//! simultaneous `tool_use` blocks; nothing in this repo can observe it. So the
-//! guard is reliable for a dispatch issued after a sibling is already recorded,
-//! and indeterminate for two issued in the same turn. Closing that needs a
-//! reservation step — a record-and-answer that is atomic in the daemon — which
-//! is a design change, deliberately not made here (#4480).
+//! What the daemon records is not a new kind of state — it is the delegation
+//! record its own `matcher: "*"` PreToolUse hook would have written for the
+//! same dispatch a moment later, and that hook is idempotent on `tool_use_id`,
+//! so exactly one record exists either way and its lifecycle is unchanged.
+//!
+//! Residual, unchanged from #4480: if the daemon's tracker records BOTH
+//! dispatches before either guard's claim arrives, each guard sees the other and
+//! both are denied. That ordering predates this module and is not made more
+//! likely by it; the remedy the deny prints (declare isolation) resolves it.
 //!
 //! **This guard FAILS OPEN at every step.** A down, slow, or unreachable daemon
 //! answers "nobody else is here" and the dispatch proceeds; so does an
@@ -67,7 +72,7 @@
 //! `allows_a_read_only_agent`, `allows_when_the_agent_is_unknown`,
 //! `allows_every_non_dispatch_tool` below. The six declared fail-open branches
 //! each have an error-arm test: unreachable daemon
-//! (`live_shared_tree_writers_is_empty_when_the_daemon_is_unreachable`),
+//! (`claim_shared_tree_is_empty_when_the_daemon_is_unreachable`),
 //! malformed response (`pm_guard_allows_when_the_daemon_answer_is_malformed`),
 //! unresolvable cwd (`evaluate_allows_when_the_cwd_cannot_be_resolved`),
 //! unknown agent (`allows_when_the_agent_is_unknown`), untyped dispatch (same),
@@ -80,6 +85,8 @@ use trusty_mpm::core::agent::is_subagent_dispatch_tool;
 use trusty_mpm::core::dispatch_isolation::{
     dispatch_agent, dispatch_isolation, shares_the_callers_tree,
 };
+
+use crate::commands::hook_payload::build_hook_payload;
 
 /// Build the deny message for a blocked concurrent dispatch.
 ///
@@ -116,7 +123,7 @@ fn deny_reason(agent: &str, cwd: &Path, live: &[String]) -> String {
 ///
 /// Why: kept pure — it takes the daemon's answer as a slice rather than fetching
 /// it — so the whole policy is exhaustively unit-testable with no network, and
-/// the I/O lives in [`live_shared_tree_writers`] next door.
+/// the I/O lives in [`claim_shared_tree`] next door.
 /// What: `Some(reason)` (DENY) when `tool_name` is a dispatch tool, the dispatch
 /// [`shares_the_callers_tree`], and `live` is non-empty. `None` (ALLOW) in every
 /// other case, including every non-dispatch tool.
@@ -195,22 +202,29 @@ pub(crate) fn resolve_dispatch_cwd(
     })
 }
 
-/// Ask the daemon which agents are already writing unisolated in `cwd`.
+/// Claim `cwd` for this dispatch, and learn who already holds it (#5324).
 ///
 /// Why: see the module doc — liveness is the daemon's to answer, and it is the
-/// only process that resolves it from real terminal signals.
-/// What: `GET <url>/api/v1/sessions/{session}/delegations/shared-tree-writers`
-/// with the caller's own `tool_use_id` excluded, under the same tight
-/// connect/total bounds `pm_guard`'s audit POSTs use (500 ms / 2 s) — this call
-/// sits inside a `PreToolUse` budget, so a slow daemon must cost a bounded wait
-/// and nothing more. EVERY failure — client build, transport, non-2xx, malformed
-/// body — returns an empty vec, which the pure policy above reads as ALLOW.
-/// Test: `live_shared_tree_writers_is_empty_when_the_daemon_is_unreachable`.
-pub(crate) async fn live_shared_tree_writers(
+/// only process that resolves it from real terminal signals. It is also the only
+/// place the answer and the claim can be made indivisible: a hook process that
+/// asked and then acted would leave the window two same-turn dispatches slip
+/// through.
+/// What: `POST <url>/api/v1/sessions/{session}/delegations/shared-tree-dispatch`
+/// carrying this dispatch in the daemon's own forwarded hook shape (built by the
+/// one [`build_hook_payload`], so the record the daemon writes is the record its
+/// own `matcher: "*"` hook would write) with `cwd` stamped to the directory the
+/// guard resolved. Sent under the same tight connect/total bounds `pm_guard`'s
+/// audit POSTs use (500 ms / 2 s) — this call sits inside a `PreToolUse` budget,
+/// so a slow daemon must cost a bounded wait and nothing more. EVERY failure —
+/// client build, transport, non-2xx, malformed body — returns an empty vec,
+/// which the pure policy above reads as ALLOW; nothing is claimed, and the
+/// verdict degrades to exactly the behaviour that shipped before #4480.
+/// Test: `claim_shared_tree_is_empty_when_the_daemon_is_unreachable`.
+pub(crate) async fn claim_shared_tree(
     url: &str,
     session_id: &str,
     cwd: &Path,
-    exclude_tool_use_id: Option<&str>,
+    payload: &Value,
 ) -> Vec<String> {
     if session_id.is_empty() {
         return Vec::new();
@@ -222,12 +236,11 @@ pub(crate) async fn live_shared_tree_writers(
     else {
         return Vec::new();
     };
-    let endpoint = format!("{url}/api/v1/sessions/{session_id}/delegations/shared-tree-writers");
-    let mut query: Vec<(&str, String)> = vec![("cwd", cwd.display().to_string())];
-    if let Some(id) = exclude_tool_use_id {
-        query.push(("exclude_tool_use_id", id.to_string()));
-    }
-    let Ok(response) = client.get(&endpoint).query(&query).send().await else {
+    let endpoint = format!("{url}/api/v1/sessions/{session_id}/delegations/shared-tree-dispatch");
+    let body = serde_json::json!({
+        "payload": build_hook_payload(&cwd.display().to_string(), Some(payload), None),
+    });
+    let Ok(response) = client.post(&endpoint).json(&body).send().await else {
         return Vec::new();
     };
     let Ok(response) = response.error_for_status() else {
@@ -253,10 +266,10 @@ pub(crate) async fn live_shared_tree_writers(
 /// daemon off the hot path — classify first, ask second — lives here rather
 /// than being re-derived at the call site.
 /// What: returns `None` immediately unless [`dispatch_shares_the_tree`] and a
-/// resolvable [`dispatch_cwd`]; only then queries the daemon and runs
-/// [`evaluate_shared_tree_dispatch`].
+/// resolvable [`dispatch_cwd`]; only then claims the tree through the daemon and
+/// runs [`evaluate_shared_tree_dispatch`] on the answer.
 /// Test: the pure half is covered exhaustively below; the network half's
-/// fail-open is `live_shared_tree_writers_is_empty_when_the_daemon_is_unreachable`,
+/// fail-open is `claim_shared_tree_is_empty_when_the_daemon_is_unreachable`,
 /// and the end-to-end path runs through the real binary in
 /// `tests/tm_hook_pm_guard.rs`.
 pub(crate) async fn evaluate(
@@ -297,11 +310,7 @@ pub(crate) async fn evaluate_with_cwd(
         return None;
     }
     let cwd = cwd?;
-    let tool_use_id = payload
-        .get("tool_use_id")
-        .and_then(Value::as_str)
-        .filter(|s| !s.is_empty());
-    let live = live_shared_tree_writers(url, session_id, &cwd, tool_use_id).await;
+    let live = claim_shared_tree(url, session_id, &cwd, payload).await;
     evaluate_shared_tree_dispatch(tool_name, tool_input, &cwd, &live)
 }
 
@@ -562,17 +571,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn live_shared_tree_writers_is_empty_when_the_daemon_is_unreachable() {
+    async fn claim_shared_tree_is_empty_when_the_daemon_is_unreachable() {
         // Fail-open on the network path: an unroutable daemon must resolve to
-        // "nobody else is here", never hang and never deny.
-        let live = live_shared_tree_writers(
+        // "nobody else is here", never hang and never deny. Nothing is claimed
+        // either, so the verdict degrades to the pre-#4480 behaviour rather
+        // than to a directory nobody can release.
+        let live = claim_shared_tree(
             "http://127.0.0.1:1",
             "11111111-1111-1111-1111-111111111111",
             Path::new("/repo"),
-            Some("toolu_X"),
+            &serde_json::json!({"tool_use_id": "toolu_X"}),
         )
         .await;
         assert!(live.is_empty());
+    }
+
+    #[tokio::test]
+    async fn claim_shared_tree_is_empty_without_a_session_id() {
+        // A hook payload with no `session_id` cannot address a session's
+        // delegations at all. Fail open before dialling anything — an unroutable
+        // URL would cost a real (bounded) wait if this branch were removed.
+        let started = std::time::Instant::now();
+        let live = claim_shared_tree(
+            "http://127.0.0.1:1",
+            "",
+            Path::new("/repo"),
+            &serde_json::json!({}),
+        )
+        .await;
+        assert!(live.is_empty());
+        assert!(started.elapsed() < std::time::Duration::from_millis(400));
     }
 
     #[tokio::test]

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_dispatch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_dispatch.rs
@@ -202,6 +202,43 @@ pub(crate) fn resolve_dispatch_cwd(
     })
 }
 
+/// Narrow `payload["input"]` to the three fields the daemon actually reads.
+///
+/// Why: an `Agent` dispatch's `tool_input` carries the whole subagent prompt,
+/// which is unbounded — a long brief is ordinary, not pathological. Forwarding
+/// it verbatim would put this POST under axum's default 2 MB body limit and
+/// create a failure arm the old read-only GET could not have: a 413 returns an
+/// empty answer, so the dispatch is admitted having claimed nothing, and the
+/// guard is silently off for exactly the largest dispatches. Rather than test
+/// that arm, this removes it — the body is now bounded by an agent name, an
+/// isolation mode, and a description.
+///
+/// The record stays byte-identical: the route reads only `subagent_type`
+/// ([`dispatch_agent`]) and `isolation` ([`dispatch_isolation`]), and
+/// `delegation_tracker::on_dispatch` stores only those two plus `description`.
+/// Nothing downstream reads another key of `input`, so dropping the rest cannot
+/// change what is written.
+/// What: replaces `input` with an object of just those three keys, each copied
+/// only when present. A payload with no `input`, or a non-object one, is left
+/// exactly as it is — there is nothing to narrow and inventing a shape here
+/// could only make the daemon's classification disagree with the guard's.
+/// Test: `claim_payload_carries_only_the_fields_the_daemon_reads`,
+/// `claim_payload_projection_leaves_a_non_object_input_alone`.
+fn project_dispatch_input(forwarded: &mut Value) {
+    const FORWARDED_INPUT_FIELDS: [&str; 3] = ["subagent_type", "isolation", "description"];
+
+    let Some(input) = forwarded.get("input").filter(|i| i.is_object()) else {
+        return;
+    };
+    let mut projected = serde_json::Map::new();
+    for key in FORWARDED_INPUT_FIELDS {
+        if let Some(value) = input.get(key) {
+            projected.insert(key.to_string(), value.clone());
+        }
+    }
+    forwarded["input"] = Value::Object(projected);
+}
+
 /// Claim `cwd` for this dispatch, and learn who already holds it (#5324).
 ///
 /// Why: see the module doc — liveness is the daemon's to answer, and it is the
@@ -213,7 +250,10 @@ pub(crate) fn resolve_dispatch_cwd(
 /// carrying this dispatch in the daemon's own forwarded hook shape (built by the
 /// one [`build_hook_payload`], so the record the daemon writes is the record its
 /// own `matcher: "*"` hook would write) with `cwd` stamped to the directory the
-/// guard resolved. Sent under the same tight connect/total bounds `pm_guard`'s
+/// guard resolved and `input` narrowed by [`project_dispatch_input`] to the
+/// three fields the daemon reads — the dispatch prompt never travels, so the
+/// body stays small enough that a size limit is not a reachable failure arm.
+/// Sent under the same tight connect/total bounds `pm_guard`'s
 /// audit POSTs use (500 ms / 2 s) — this call sits inside a `PreToolUse` budget,
 /// so a slow daemon must cost a bounded wait and nothing more. EVERY failure —
 /// client build, transport, non-2xx, malformed body — returns an empty vec,
@@ -237,9 +277,9 @@ pub(crate) async fn claim_shared_tree(
         return Vec::new();
     };
     let endpoint = format!("{url}/api/v1/sessions/{session_id}/delegations/shared-tree-dispatch");
-    let body = serde_json::json!({
-        "payload": build_hook_payload(&cwd.display().to_string(), Some(payload), None),
-    });
+    let mut forwarded = build_hook_payload(&cwd.display().to_string(), Some(payload), None);
+    project_dispatch_input(&mut forwarded);
+    let body = serde_json::json!({ "payload": forwarded });
     let Ok(response) = client.post(&endpoint).json(&body).send().await else {
         return Vec::new();
     };
@@ -249,7 +289,8 @@ pub(crate) async fn claim_shared_tree(
     let Ok(body) = response.json::<Value>().await else {
         return Vec::new();
     };
-    body.get("agents")
+    let live: Vec<String> = body
+        .get("agents")
         .and_then(Value::as_array)
         .map(|rows| {
             rows.iter()
@@ -257,7 +298,59 @@ pub(crate) async fn claim_shared_tree(
                 .map(str::to_owned)
                 .collect()
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+    warn_on_eligibility_divergence(&body, &live);
+    live
+}
+
+/// Warn when the daemon answered "nobody here" but claimed nothing (#5324).
+///
+/// Why: this combination is always a disagreement, never a normal outcome. The
+/// guard does not call this route at all unless it has already classified the
+/// dispatch as tree-sharing, so an empty answer means the daemon declined to
+/// claim a directory the guard believes needs claiming — and it re-derives
+/// eligibility from its own `core::bundle::ALL`. A running daemon built before
+/// an agent was added to that table sees an agent it does not know, classifies
+/// it ineligible, and claims nothing. Both dispatches are then admitted with the
+/// guard silently disabled, and `claimed` is the only evidence anything is
+/// wrong. Discarding it discards the one signal.
+/// What: one stderr line — `pm_guard` writes to stderr, which Claude Code
+/// surfaces without it reaching the hook's stdout JSON verdict. It does NOT
+/// deny: denying here would fail CLOSED on version skew, the exact opposite of
+/// the degradation this whole path is built for, and a stale daemon would then
+/// block every dispatch instead of merely failing to guard it.
+/// Test: `eligibility_divergence_is_an_empty_answer_that_claimed_nothing` and
+/// siblings.
+fn warn_on_eligibility_divergence(body: &Value, live: &[String]) {
+    if !eligibility_diverged(body, live) {
+        return;
+    }
+    eprintln!(
+        "tm hook --pm-guard: the daemon reported no live writers but claimed nothing (#5324). \
+         The guard classified this dispatch as sharing the working tree and the daemon did not, \
+         so concurrent shared-worktree dispatch is NOT being enforced for this agent. The usual \
+         cause is a running daemon older than the `tm` on PATH, built before this agent was \
+         added to its bundled table — restart the daemon (`tm restart`) to clear it. Allowing \
+         the dispatch: this path fails open by design."
+    );
+}
+
+/// Did the daemon answer "nobody here" while claiming nothing?
+///
+/// Why: split from the `eprintln!` so the condition is assertable without
+/// capturing stderr — the decision is the part worth pinning, not the plumbing.
+/// What: true only when the answer is EMPTY and `claimed` is not `true`. A
+/// missing `claimed` counts as not-claimed, which is the conservative read: an
+/// older daemon that never sends the field is exactly the skew this warns about.
+/// A non-empty answer is never divergence — the daemon deliberately claims
+/// nothing when it is about to deny.
+/// Test: `eligibility_divergence_is_an_empty_answer_that_claimed_nothing`.
+fn eligibility_diverged(body: &Value, live: &[String]) -> bool {
+    let claimed = body
+        .get("claimed")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    live.is_empty() && !claimed
 }
 
 /// Resolve the full verdict for one `PreToolUse` call: `Some(reason)` denies.
@@ -601,6 +694,90 @@ mod tests {
         .await;
         assert!(live.is_empty());
         assert!(started.elapsed() < std::time::Duration::from_millis(400));
+    }
+
+    #[test]
+    fn claim_payload_carries_only_the_fields_the_daemon_reads() {
+        // #5324: the dispatch prompt must not travel to the daemon. Forwarding
+        // it verbatim puts an unbounded body under axum's 2 MB limit, and a 413
+        // is an empty answer — the dispatch admitted, unclaimed, guard silently
+        // off for exactly the biggest dispatches. Projecting removes that arm
+        // rather than testing it.
+        let mut forwarded = serde_json::json!({
+            "cwd": "/repo",
+            "tool": "Agent",
+            "input": {
+                "subagent_type": "rust-engineer",
+                "isolation": "worktree",
+                "description": "short label",
+                "prompt": "x".repeat(4096),
+                "extra": {"nested": true},
+            },
+        });
+        project_dispatch_input(&mut forwarded);
+
+        let input = forwarded.get("input").expect("input survives");
+        let keys: Vec<&String> = input
+            .as_object()
+            .expect("input stays an object")
+            .keys()
+            .collect();
+        assert_eq!(
+            keys,
+            vec!["description", "isolation", "subagent_type"],
+            "only the three fields the route and the tracker read may be sent"
+        );
+        // The three that remain must be untouched — the record the daemon
+        // writes has to stay byte-identical to the tracker's own.
+        assert_eq!(input["subagent_type"], "rust-engineer");
+        assert_eq!(input["isolation"], "worktree");
+        assert_eq!(input["description"], "short label");
+        // Sibling keys outside `input` are not this function's business.
+        assert_eq!(forwarded["tool"], "Agent");
+        assert_eq!(forwarded["cwd"], "/repo");
+    }
+
+    #[test]
+    fn claim_payload_projection_leaves_a_non_object_input_alone() {
+        // Nothing to narrow, and inventing a shape here could only make the
+        // daemon's classification disagree with the guard's. Absent stays
+        // absent; a non-object stays whatever it was.
+        let mut absent = serde_json::json!({"cwd": "/repo", "tool": "Agent"});
+        project_dispatch_input(&mut absent);
+        assert!(absent.get("input").is_none(), "absent input stays absent");
+
+        let mut scalar = serde_json::json!({"cwd": "/repo", "input": "not-an-object"});
+        project_dispatch_input(&mut scalar);
+        assert_eq!(scalar["input"], "not-an-object");
+    }
+
+    #[test]
+    fn eligibility_divergence_is_an_empty_answer_that_claimed_nothing() {
+        // #5324: the guard never asks unless it already classified the dispatch
+        // as tree-sharing, so "nobody here" AND "claimed nothing" is always the
+        // daemon disagreeing about eligibility — the one observable symptom of
+        // a daemon older than the `tm` on PATH. It must warn, and must NOT deny:
+        // denying would fail closed on version skew.
+        let empty: Vec<String> = Vec::new();
+        assert!(
+            eligibility_diverged(&serde_json::json!({"agents": [], "claimed": false}), &empty),
+            "empty answer that claimed nothing is divergence"
+        );
+        assert!(
+            eligibility_diverged(&serde_json::json!({"agents": []}), &empty),
+            "a daemon too old to send `claimed` reads as not-claimed"
+        );
+        assert!(
+            !eligibility_diverged(&serde_json::json!({"agents": [], "claimed": true}), &empty),
+            "the ordinary first dispatch claims, and is silent"
+        );
+        assert!(
+            !eligibility_diverged(
+                &serde_json::json!({"claimed": false}),
+                &["rust-engineer".to_string()]
+            ),
+            "a non-empty answer is a deny, where claiming nothing is correct"
+        );
     }
 
     #[tokio::test]

--- a/crates/trusty-mpm/src/daemon/delegation_routes.rs
+++ b/crates/trusty-mpm/src/daemon/delegation_routes.rs
@@ -1,5 +1,6 @@
-//! `GET /api/v1/sessions/{id}/delegations/shared-tree-writers` — who else is
-//! already writing into this working directory (#4480).
+//! `POST /api/v1/sessions/{id}/delegations/shared-tree-dispatch` — who else is
+//! already writing into this working directory, answered while claiming it
+//! (#4480, made atomic by #5324).
 //!
 //! Why: `tm hook --pm-guard` decides, per `Agent`/`Task` dispatch, whether the
 //! PM is about to put a SECOND file-mutating subagent into a working directory
@@ -14,59 +15,94 @@
 //! daemon already receives every dispatch through the `matcher: "*"` PreToolUse
 //! hook; this exposes what it already knows.
 //!
-//! What: one read-only GET, no body, no side effects. It answers with the agent
-//! names of this session's LIVE delegations that are running in the queried
-//! `cwd` without a working tree of their own. The caller passes its own
-//! `tool_use_id` so its own in-flight dispatch is excluded — the daemon's hook
-//! and the guard's hook race on the same event, and without that exclusion the
-//! very first dispatch of a session could find itself and be denied.
+//! Why POST and not GET (#5324): a read-only query cannot close the window it
+//! opens. Asking "is anyone writing here?" and acting on the answer are two
+//! steps, and two dispatches issued in ONE PM turn — the framework's own
+//! documented pattern for parallel work — can both ask before either is
+//! recorded, both see an empty set, and both be admitted. So the answer and the
+//! record are one operation: this route claims the directory for the asking
+//! dispatch in the same critical section that produced its answer. It mutates,
+//! so it is a POST.
+//!
+//! What the claim IS: the delegation record the tracker would have written
+//! anyway. The route hands the posted payload to
+//! [`crate::daemon::services::delegation_tracker::observe`] — the tracker's own
+//! `PreToolUse` observer — so the record is byte-identical to the one the
+//! daemon's `matcher: "*"` hook produces for the same dispatch, and whichever
+//! of the two hooks arrives second is a no-op (that observer is idempotent on
+//! `tool_use_id`). No second kind of state, no new expiry, and nothing new to
+//! clean up: the claim ends when the delegation ends.
+//!
+//! The caller passes its own `tool_use_id` so its own in-flight dispatch is
+//! excluded — the daemon's hook and the guard's hook race on the same event, and
+//! without that exclusion the very first dispatch of a session could find itself
+//! and be denied.
+//!
+//! **Version skew fails open in both directions.** A new `tm hook` against an
+//! old daemon POSTs to a path that does not exist; an old `tm hook` against a
+//! new daemon GETs one that no longer does. Both get a 404, which the guard
+//! reads as "nobody else is here" — the behaviour that shipped before #4480.
 //!
 //! It lives in its own module, merged as a sub-router, because `api.rs` is over
 //! 1,100 SLOC and frozen at its line-cap budget — the same reason
 //! [`super::managed_routes::reconcile`] gives.
-//! Test: `shared_tree_writers_route_*` below.
+//! Test: `shared_tree_dispatch_route_*` below.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use axum::{Json, Router, extract::Path, extract::Query, extract::State, routing::get};
+use axum::{Json, Router, extract::Path, extract::State, routing::post};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
+use crate::core::agent::is_subagent_dispatch_tool;
+use crate::core::dispatch_isolation::{
+    dispatch_agent, dispatch_isolation, shares_the_callers_tree,
+};
+use crate::core::hook::HookEvent;
 use crate::core::session::SessionId;
 use crate::daemon::error::DaemonError;
 use crate::daemon::state::DaemonState;
 
-/// Query string of [`shared_tree_writers_route`].
+/// Request body of [`shared_tree_dispatch_route`].
 ///
-/// Why: `cwd` is required because the guard asks about ONE directory — the one
-/// its dispatch would land in — and a session may legitimately have delegations
-/// running in several. `exclude_tool_use_id` is the caller's own dispatch; see
-/// the module doc for why omitting it would make the answer race-dependent.
-/// What: `cwd` (required) and `exclude_tool_use_id` (optional).
-/// Test: `shared_tree_writers_route_excludes_the_callers_own_dispatch`.
+/// Why: the route both answers and records, and the recording is done by the
+/// delegation tracker's own observer — so the body is simply the payload that
+/// observer already consumes, built by `tm hook`'s single
+/// `build_hook_payload`. Re-describing the same dispatch in a bespoke schema
+/// here would be a second construction of one record, which is exactly the
+/// drift the daemon-side route exists to avoid.
+/// What: `payload` carries `cwd`, `tool`, `input` (with `subagent_type` and
+/// `isolation`), `tool_use_id`, and `transcript_path`. `cwd` is read from the
+/// payload rather than taken separately so the directory that is compared is
+/// the same one that is recorded.
+/// Test: `shared_tree_dispatch_route_reserves_the_tree_on_an_empty_answer`.
 #[derive(Debug, Deserialize)]
-pub struct SharedTreeWritersQuery {
-    /// Working directory to ask about.
-    pub cwd: PathBuf,
-    /// The asking dispatch's own `tool_use_id`, excluded from the answer.
-    #[serde(default)]
-    pub exclude_tool_use_id: Option<String>,
+pub struct SharedTreeDispatchRequest {
+    /// The `PreToolUse` hook payload, in the daemon's own forwarded shape.
+    pub payload: Value,
 }
 
-/// Response of [`shared_tree_writers_route`].
+/// Response of [`shared_tree_dispatch_route`].
 ///
 /// Why: the guard needs a count to decide and names to explain — a deny that
 /// cannot say which agent it is protecting reads as arbitrary and gets retried.
 /// What: `agents` holds one entry per live unisolated writer, deduplicated with
 /// a count so two concurrent `rust-engineer`s render as one row rather than a
 /// repeated name. `total` is the number of delegations, not of distinct names.
+/// `claimed` reports whether this call took the directory; it is diagnostic —
+/// the guard decides on `agents` alone, so an older guard that ignores the field
+/// behaves identically.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct SharedTreeWritersResponse {
     /// Distinct agent names, each with how many of its delegations are live.
     pub agents: Vec<SharedTreeWriter>,
     /// Total live unisolated writers, across all names.
     pub total: usize,
+    /// Whether this call claimed the directory for the asking dispatch.
+    #[serde(default)]
+    pub claimed: bool,
 }
 
 /// One agent name with its live unisolated delegation count.
@@ -83,36 +119,68 @@ pub struct SharedTreeWriter {
 /// Why: see the module doc — `api.rs` is grandfathered at a frozen line-cap
 /// budget, so a new route is registered here and merged rather than appended
 /// there.
-/// What: one GET on a literal-suffixed path under `/sessions/{id}`.
-/// Test: `shared_tree_writers_route_reports_live_unisolated_writers`.
+/// What: one POST on a literal-suffixed path under `/sessions/{id}`.
+/// Test: `shared_tree_dispatch_route_reports_live_unisolated_writers`.
 pub fn router() -> Router<Arc<DaemonState>> {
     Router::new().route(
-        "/api/v1/sessions/{id}/delegations/shared-tree-writers",
-        get(shared_tree_writers_route),
+        "/api/v1/sessions/{id}/delegations/shared-tree-dispatch",
+        post(shared_tree_dispatch_route),
     )
 }
 
-/// `GET /api/v1/sessions/{id}/delegations/shared-tree-writers` (#4480).
+/// `POST /api/v1/sessions/{id}/delegations/shared-tree-dispatch` (#4480, #5324).
 ///
 /// Why: see the module doc.
-/// What: parses the session id, delegates to
-/// [`DaemonState::live_shared_tree_writers`], and folds the agent names into a
-/// deduplicated count. A malformed session id is a 400; an unknown session is
-/// an EMPTY answer, not a 404 — a session the daemon has no record of has no
-/// delegations, and a 404 would read to the guard as an error rather than as
-/// "nobody else is here".
-/// Test: `shared_tree_writers_route_reports_live_unisolated_writers`,
-/// `shared_tree_writers_route_excludes_the_callers_own_dispatch`,
-/// `shared_tree_writers_route_rejects_a_malformed_session_id`.
-pub async fn shared_tree_writers_route(
+/// What: parses the session id, then hands the whole scan-and-claim to
+/// [`DaemonState::claim_shared_tree_dispatch`], which holds one mutex across
+/// both halves. The claim is taken only when the answer is empty AND this
+/// dispatch would itself [`shares_the_callers_tree`] — the daemon re-derives
+/// that from the payload rather than trusting the caller to have checked, so a
+/// read-only or isolated dispatch can never occupy a directory. A malformed
+/// session id is a 400; an unknown session is an EMPTY answer, not a 404 — a
+/// session the daemon has no record of has no delegations, and a 404 would read
+/// to the guard as an error rather than as "nobody else is here".
+///
+/// A payload with no `cwd` is answered empty and claims nothing: there is no
+/// directory to compare against, and inventing one would be the only way this
+/// route could produce a false deny.
+/// Test: `shared_tree_dispatch_route_reports_live_unisolated_writers`,
+/// `shared_tree_dispatch_route_excludes_the_callers_own_dispatch`,
+/// `shared_tree_dispatch_route_rejects_a_malformed_session_id`,
+/// `shared_tree_dispatch_route_denies_the_second_claim`,
+/// `shared_tree_dispatch_route_does_not_reserve_a_read_only_agent`,
+/// `shared_tree_dispatch_route_is_empty_without_a_cwd`.
+pub async fn shared_tree_dispatch_route(
     State(state): State<Arc<DaemonState>>,
     Path(id): Path<String>,
-    Query(q): Query<SharedTreeWritersQuery>,
+    Json(req): Json<SharedTreeDispatchRequest>,
 ) -> Result<Json<SharedTreeWritersResponse>, DaemonError> {
     let session = uuid::Uuid::parse_str(&id)
         .map(SessionId)
         .map_err(|_| DaemonError::InvalidRequest(format!("malformed session id: {id}")))?;
-    let names = state.live_shared_tree_writers(session, &q.cwd, q.exclude_tool_use_id.as_deref());
+
+    let payload = &req.payload;
+    let Some(cwd) = str_field(payload, "cwd").map(PathBuf::from) else {
+        return Ok(Json(SharedTreeWritersResponse::default()));
+    };
+    let exclude = str_field(payload, "tool_use_id");
+    let input = payload.get("input");
+    // Re-derived here, never taken on trust: the caller says which agent it is
+    // dispatching, but whether that dispatch may occupy a directory is this
+    // daemon's policy call, shared with the guard through one classifier.
+    let eligible = str_field(payload, "tool").is_some_and(is_subagent_dispatch_tool)
+        && dispatch_agent(input)
+            .is_some_and(|agent| shares_the_callers_tree(agent, dispatch_isolation(input)));
+
+    let (names, claimed) =
+        state.claim_shared_tree_dispatch(session, &cwd, exclude, eligible, |s| {
+            crate::daemon::services::delegation_tracker::observe(
+                s,
+                session,
+                HookEvent::PreToolUse,
+                payload,
+            );
+        });
 
     let mut counts: BTreeMap<String, usize> = BTreeMap::new();
     for name in &names {
@@ -124,7 +192,16 @@ pub async fn shared_tree_writers_route(
             .map(|(agent, count)| SharedTreeWriter { agent, count })
             .collect(),
         total: names.len(),
+        claimed,
     }))
+}
+
+/// Read a non-empty string field from the forwarded hook payload.
+fn str_field<'a>(payload: &'a Value, key: &str) -> Option<&'a str> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/delegation_routes_tests.rs
+++ b/crates/trusty-mpm/src/daemon/delegation_routes_tests.rs
@@ -1,7 +1,10 @@
-//! Tests for the shared-tree-writers route (#4480).
+//! Tests for the shared-tree dispatch route (#4480, #5324).
 //!
 //! Why: the guard's whole decision rests on this answer, and each filter it
-//! applies is a separate way to false-deny the PM. Each gets its own case.
+//! applies is a separate way to false-deny the PM. Each gets its own case. Since
+//! #5324 the route also CLAIMS the directory, so each way it could claim one it
+//! should not have — a read-only agent, an isolated dispatch, a non-dispatch
+//! tool, a payload with no directory — is its own case too.
 //! Test: this *is* the test module.
 
 use super::*;
@@ -33,8 +36,39 @@ fn insert(
     state.upsert_delegation(d);
 }
 
+/// One dispatch in the daemon's forwarded hook shape — what the guard POSTs.
+fn dispatch(
+    cwd: &str,
+    agent: &str,
+    isolation: Option<&str>,
+    tool_use_id: Option<&str>,
+) -> SharedTreeDispatchRequest {
+    let mut input = serde_json::json!({"subagent_type": agent, "description": "go"});
+    if let Some(i) = isolation {
+        input["isolation"] = Value::String(i.to_string());
+    }
+    let mut payload = serde_json::json!({"cwd": cwd, "tool": "Agent", "input": input});
+    if let Some(id) = tool_use_id {
+        payload["tool_use_id"] = Value::String(id.to_string());
+    }
+    SharedTreeDispatchRequest { payload }
+}
+
+/// Drive the route and unwrap its body.
+async fn call(
+    state: &Arc<DaemonState>,
+    session: SessionId,
+    req: SharedTreeDispatchRequest,
+) -> SharedTreeWritersResponse {
+    let Json(body) =
+        shared_tree_dispatch_route(State(state.clone()), Path(session.0.to_string()), Json(req))
+            .await
+            .expect("route succeeds");
+    body
+}
+
 #[tokio::test]
-async fn shared_tree_writers_route_reports_live_unisolated_writers() {
+async fn shared_tree_dispatch_route_reports_live_unisolated_writers() {
     let (state, _dir, session) = hermetic();
     // The one that matters: a live engineer in the shared tree with no
     // isolation. This is the record that makes a second dispatch dangerous.
@@ -110,25 +144,22 @@ async fn shared_tree_writers_route_reports_live_unisolated_writers() {
         DelegationStatus::Running,
     );
 
-    let Json(body) = shared_tree_writers_route(
-        State(state),
-        Path(session.0.to_string()),
-        Query(SharedTreeWritersQuery {
-            cwd: PathBuf::from("/repo"),
-            exclude_tool_use_id: None,
-        }),
+    let body = call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_NEW")),
     )
-    .await
-    .expect("route succeeds");
+    .await;
 
     assert_eq!(body.total, 1, "only the live unisolated engineer counts");
     assert_eq!(body.agents.len(), 1);
     assert_eq!(body.agents[0].agent, "rust-engineer");
     assert_eq!(body.agents[0].count, 1);
+    assert!(!body.claimed, "a denied dispatch must not claim the tree");
 }
 
 #[tokio::test]
-async fn shared_tree_writers_route_excludes_the_callers_own_dispatch() {
+async fn shared_tree_dispatch_route_excludes_the_callers_own_dispatch() {
     // Causality: the daemon's `matcher: "*"` hook and `tm hook --pm-guard`
     // race on the same PreToolUse. If the tracker wins, the asking dispatch is
     // already recorded — and without this exclusion the FIRST dispatch of a
@@ -144,22 +175,21 @@ async fn shared_tree_writers_route_excludes_the_callers_own_dispatch() {
         DelegationStatus::Running,
     );
 
-    let Json(body) = shared_tree_writers_route(
-        State(state),
-        Path(session.0.to_string()),
-        Query(SharedTreeWritersQuery {
-            cwd: PathBuf::from("/repo"),
-            exclude_tool_use_id: Some("toolu_SELF".into()),
-        }),
+    let body = call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_SELF")),
     )
-    .await
-    .expect("route succeeds");
+    .await;
 
     assert_eq!(body.total, 0, "the caller must not find itself");
+    // Redelivery of the same dispatch must not add a second record either —
+    // the tracker's observer is idempotent on `tool_use_id`.
+    assert_eq!(state.delegations_for(session).len(), 1);
 }
 
 #[tokio::test]
-async fn shared_tree_writers_route_counts_concurrent_same_agent_dispatches() {
+async fn shared_tree_dispatch_route_counts_concurrent_same_agent_dispatches() {
     let (state, _dir, session) = hermetic();
     for id in ["toolu_1", "toolu_2"] {
         insert(
@@ -173,16 +203,12 @@ async fn shared_tree_writers_route_counts_concurrent_same_agent_dispatches() {
         );
     }
 
-    let Json(body) = shared_tree_writers_route(
-        State(state),
-        Path(session.0.to_string()),
-        Query(SharedTreeWritersQuery {
-            cwd: PathBuf::from("/repo"),
-            exclude_tool_use_id: None,
-        }),
+    let body = call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_3")),
     )
-    .await
-    .expect("route succeeds");
+    .await;
 
     assert_eq!(body.total, 2);
     assert_eq!(body.agents.len(), 1, "one row per distinct name");
@@ -190,17 +216,14 @@ async fn shared_tree_writers_route_counts_concurrent_same_agent_dispatches() {
 }
 
 #[tokio::test]
-async fn shared_tree_writers_route_is_empty_for_an_unknown_session() {
+async fn shared_tree_dispatch_route_is_empty_for_an_unknown_session() {
     // An unknown session has no delegations. Answering 404 would read to the
     // guard as an error rather than as "nobody else is here".
     let (state, _dir, _session) = hermetic();
-    let Json(body) = shared_tree_writers_route(
+    let Json(body) = shared_tree_dispatch_route(
         State(state),
         Path(uuid::Uuid::new_v4().to_string()),
-        Query(SharedTreeWritersQuery {
-            cwd: PathBuf::from("/repo"),
-            exclude_tool_use_id: None,
-        }),
+        Json(dispatch("/repo", "rust-engineer", None, Some("toolu_X"))),
     )
     .await
     .expect("route succeeds");
@@ -208,17 +231,183 @@ async fn shared_tree_writers_route_is_empty_for_an_unknown_session() {
 }
 
 #[tokio::test]
-async fn shared_tree_writers_route_rejects_a_malformed_session_id() {
+async fn shared_tree_dispatch_route_rejects_a_malformed_session_id() {
     let (state, _dir, _session) = hermetic();
-    let err = shared_tree_writers_route(
+    let err = shared_tree_dispatch_route(
         State(state),
         Path("not-a-uuid".to_string()),
-        Query(SharedTreeWritersQuery {
-            cwd: PathBuf::from("/repo"),
-            exclude_tool_use_id: None,
-        }),
+        Json(dispatch("/repo", "rust-engineer", None, Some("toolu_X"))),
     )
     .await
     .expect_err("a malformed id is a client error");
     assert!(matches!(err, DaemonError::InvalidRequest(_)));
+}
+
+// ---------------------------------------------------------------------------
+// #5324 — the claim
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn shared_tree_dispatch_route_denies_the_second_claim() {
+    // THE regression case. Two dispatches into one directory, neither recorded
+    // by anything else. Pre-#5324 this route only answered, so BOTH calls saw an
+    // empty set and both were admitted. The claim taken by the first is what
+    // the second now finds.
+    let (state, _dir, session) = hermetic();
+
+    let first = call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_A")),
+    )
+    .await;
+    assert_eq!(first.total, 0, "the first dispatch must be admitted");
+    assert!(first.claimed, "and it must take the directory");
+
+    let second = call(
+        &state,
+        session,
+        dispatch("/repo", "python-engineer", None, Some("toolu_B")),
+    )
+    .await;
+    assert_eq!(second.total, 1, "the second must find the first");
+    assert_eq!(second.agents[0].agent, "rust-engineer");
+    assert!(!second.claimed);
+}
+
+#[tokio::test]
+async fn shared_tree_dispatch_route_reserves_the_tree_on_an_empty_answer() {
+    // The claim is not a new kind of state: it is the delegation record the
+    // tracker's own PreToolUse observer writes, carrying the same correlation
+    // key, directory, and isolation — so it is released by the same
+    // `SubagentStop` and swept by the same staleness sweep.
+    let (state, _dir, session) = hermetic();
+    call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_A")),
+    )
+    .await;
+
+    let records = state.delegations_for(session);
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].agent, "rust-engineer");
+    assert_eq!(records[0].tool_use_id.as_deref(), Some("toolu_A"));
+    assert_eq!(
+        records[0].cwd.as_deref(),
+        Some(PathBuf::from("/repo").as_path())
+    );
+    assert_eq!(records[0].status, DelegationStatus::Running);
+}
+
+#[tokio::test]
+async fn shared_tree_dispatch_route_does_not_reserve_when_it_denies() {
+    // A denied dispatch never runs, so recording it would occupy the directory
+    // for a subagent that does not exist — a false-deny generator.
+    let (state, _dir, session) = hermetic();
+    insert(
+        &state,
+        session,
+        "rust-engineer",
+        "/repo",
+        None,
+        Some("toolu_A"),
+        DelegationStatus::Running,
+    );
+
+    let body = call(
+        &state,
+        session,
+        dispatch("/repo", "python-engineer", None, Some("toolu_B")),
+    )
+    .await;
+
+    assert!(!body.claimed);
+    assert_eq!(
+        state.delegations_for(session).len(),
+        1,
+        "the denied dispatch must leave no record of its own"
+    );
+}
+
+#[tokio::test]
+async fn shared_tree_dispatch_route_does_not_reserve_a_read_only_agent() {
+    // The daemon re-derives eligibility rather than trusting the caller: a
+    // research/review dispatch, or one that declared isolation, must never
+    // occupy a directory even if something asked it to.
+    for (agent, isolation) in [
+        ("research", None),
+        ("code-critic", None),
+        ("rust-engineer", Some("worktree")),
+        ("rust-engineer", Some("remote")),
+        ("some-project-agent", None),
+    ] {
+        let (state, _dir, session) = hermetic();
+        let body = call(
+            &state,
+            session,
+            dispatch("/repo", agent, isolation, Some("toolu_A")),
+        )
+        .await;
+        assert!(
+            !body.claimed,
+            "{agent}/{isolation:?} must not claim the tree"
+        );
+        assert!(state.delegations_for(session).is_empty());
+    }
+}
+
+#[tokio::test]
+async fn shared_tree_dispatch_route_does_not_reserve_a_non_dispatch_tool() {
+    // The recording path is the tracker's, which acts only on a dispatch tool.
+    // Reporting a claim it did not take would be a lie the response tells.
+    let (state, _dir, session) = hermetic();
+    let mut req = dispatch("/repo", "rust-engineer", None, Some("toolu_A"));
+    req.payload["tool"] = Value::String("Read".into());
+    let body = call(&state, session, req).await;
+    assert!(!body.claimed);
+    assert!(state.delegations_for(session).is_empty());
+}
+
+#[tokio::test]
+async fn shared_tree_dispatch_route_is_empty_without_a_cwd() {
+    // Declared fail-open branch: with no directory in the payload there is
+    // nothing to compare against and nothing to claim. Seeding a live writer
+    // makes the assertion causal — only the missing-cwd short-circuit can keep
+    // the answer empty.
+    let (state, _dir, session) = hermetic();
+    insert(
+        &state,
+        session,
+        "rust-engineer",
+        "/repo",
+        None,
+        Some("toolu_A"),
+        DelegationStatus::Running,
+    );
+    let mut req = dispatch("/repo", "rust-engineer", None, Some("toolu_B"));
+    req.payload["cwd"] = Value::String(String::new());
+
+    let body = call(&state, session, req).await;
+    assert_eq!(body.total, 0);
+    assert!(!body.claimed);
+    assert_eq!(state.delegations_for(session).len(), 1);
+}
+
+#[tokio::test]
+async fn shared_tree_dispatch_route_claim_is_idempotent_on_redelivery() {
+    // A redelivered hook must not deny the dispatch it already admitted, and
+    // must not double-record it. Both follow from excluding the caller's own
+    // `tool_use_id` and from the observer's own idempotence.
+    let (state, _dir, session) = hermetic();
+    for _ in 0..3 {
+        let body = call(
+            &state,
+            session,
+            dispatch("/repo", "rust-engineer", None, Some("toolu_A")),
+        )
+        .await;
+        assert_eq!(body.total, 0, "a redelivery must stay admitted");
+    }
+    assert_eq!(state.delegations_for(session).len(), 1);
 }

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -377,6 +377,23 @@ pub struct DaemonState {
     /// Test: `daemon::idle_nudge` unit tests exercise the decide→record→prune
     /// path; the ledger's own semantics are covered by `core::idle_nudge` tests.
     pub(super) nudge_ledger: parking_lot::Mutex<crate::core::idle_nudge::NudgeLedger>,
+    /// Serializes the shared-working-tree dispatch claim (#5324).
+    ///
+    /// Why: `tm hook --pm-guard` used to ASK which agents were already writing
+    /// in a directory and record the answer's consequence later, so two
+    /// dispatches issued in one PM turn could both ask before either was
+    /// recorded, both see an empty set, and both be admitted — the collision the
+    /// guard exists to prevent. Closing that needs the question and the record
+    /// to be one indivisible step, and `delegations` is a `DashMap`: it makes
+    /// each entry atomic, never a scan-then-insert pair. This mutex is what
+    /// makes that pair atomic.
+    /// What: guards nothing itself — it is held across the scan-and-record in
+    /// [`DaemonState::claim_shared_tree_dispatch`], which is its only taker.
+    /// Held for an in-memory scan of one session's delegations and at most one
+    /// insert; no I/O, no await, no other lock nested inside it.
+    /// Test: `shared_tree_dispatch_route_denies_the_second_claim`,
+    /// `pm_guard_denies_the_second_of_two_simultaneous_dispatches`.
+    pub(super) shared_tree_claim: parking_lot::Mutex<()>,
 }
 
 impl Default for DaemonState {
@@ -473,6 +490,7 @@ impl DaemonState {
             manager,
             provisioning: crate::daemon::provisioning::ProvisioningRegistry::default(),
             nudge_ledger: parking_lot::Mutex::new(crate::core::idle_nudge::NudgeLedger::new()),
+            shared_tree_claim: parking_lot::Mutex::new(()),
         }
     }
 
@@ -546,6 +564,7 @@ impl DaemonState {
             manager,
             provisioning: crate::daemon::provisioning::ProvisioningRegistry::default(),
             nudge_ledger: parking_lot::Mutex::new(crate::core::idle_nudge::NudgeLedger::new()),
+            shared_tree_claim: parking_lot::Mutex::new(()),
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/state/sessions.rs
+++ b/crates/trusty-mpm/src/daemon/state/sessions.rs
@@ -537,7 +537,7 @@ impl DaemonState {
     /// share one: it is indeterminate, and this whole guard fails toward ALLOW.
     /// `Stale` is deliberately not live — a record tracking has given up on
     /// must not block a dispatch for the remaining hours of its retention.
-    /// Test: `shared_tree_writers_route_reports_live_unisolated_writers` and
+    /// Test: `shared_tree_dispatch_route_reports_live_unisolated_writers` and
     /// siblings in [`crate::daemon::delegation_routes`], which drive every
     /// filter here through the route that is this method's only caller.
     pub fn live_shared_tree_writers(
@@ -562,6 +562,53 @@ impl DaemonState {
             })
             .map(|e| e.value().agent.clone())
             .collect()
+    }
+
+    /// Answer [`Self::live_shared_tree_writers`] and claim the tree in one step
+    /// (#5324).
+    ///
+    /// Why: [`Self::live_shared_tree_writers`] alone is a question, and
+    /// `tm hook --pm-guard` used to act on the answer without anything having
+    /// claimed the directory in between. Two dispatches issued in one PM turn
+    /// could both ask before either was recorded, both see an empty set, and
+    /// both be admitted. Asking and claiming have to be indivisible, and a
+    /// `DashMap` makes each entry atomic but never a scan-then-insert pair — so
+    /// [`shared_tree_claim`](Self::shared_tree_claim) is held across both here.
+    ///
+    /// What: under that mutex, computes the live-writer answer and, when it is
+    /// EMPTY and `eligible` says this dispatch would itself share the tree, runs
+    /// `record` before releasing. Returns the answer the caller decides on plus
+    /// whether the claim was taken. A second caller arriving concurrently blocks
+    /// until the first has recorded, so it sees a non-empty answer and is denied
+    /// — exactly one of two simultaneous dispatches is admitted.
+    ///
+    /// `record` is a closure rather than an inlined write so this method keeps
+    /// no opinion about what a delegation record looks like: the only caller
+    /// passes the delegation tracker's own `PreToolUse` observer, so the claim
+    /// IS the record that tracker would have written milliseconds later, with
+    /// the same lifecycle, the same liveness, and the same staleness sweep. No
+    /// second kind of state and no new expiry are introduced.
+    ///
+    /// `record` must not take this lock again (it is not reentrant), must not
+    /// block, and must not await.
+    /// Test: `shared_tree_dispatch_route_denies_the_second_claim`,
+    /// `shared_tree_dispatch_route_reserves_the_tree_on_an_empty_answer`,
+    /// `shared_tree_dispatch_route_does_not_reserve_when_it_denies`.
+    pub fn claim_shared_tree_dispatch<F: FnOnce(&Self)>(
+        &self,
+        session: SessionId,
+        cwd: &std::path::Path,
+        exclude_tool_use_id: Option<&str>,
+        eligible: bool,
+        record: F,
+    ) -> (Vec<String>, bool) {
+        let _claim = self.shared_tree_claim.lock();
+        let live = self.live_shared_tree_writers(session, cwd, exclude_tool_use_id);
+        let claimed = eligible && live.is_empty();
+        if claimed {
+            record(self);
+        }
+        (live, claimed)
     }
 
     /// Find one session's delegation matching `pred`, returning its id (#2864).

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -1082,6 +1082,18 @@ async fn pm_guard_denies_the_second_of_two_simultaneous_dispatches() {
     // Which of the two is denied is genuinely arbitrary — that is the point of a
     // mutual exclusion — so the assertion counts verdicts rather than ordering
     // them.
+    //
+    // What this pins, precisely: that a claim is taken at all, end to end,
+    // through the real binary and the real router. It does NOT pin atomicity.
+    // The barrier releases both requests into the handler and stops there, so
+    // how far each gets before the other resumes is the scheduler's business —
+    // moving `record` back outside the mutex fails this test at a 300 ms
+    // handler gap but PASSED at 50 ms. Atomicity is pinned deterministically by
+    // `shared_tree_dispatch_route_denies_the_second_claim`
+    // (`src/daemon/delegation_routes_tests.rs`), which drives the two claims
+    // through `claim_shared_tree_dispatch` directly with no scheduler in the
+    // way. Treat the two as a pair: this one proves the wiring, that one proves
+    // the mutual exclusion.
     let (url, _dir) = serve_delegation_router_behind_a_barrier(2);
     let cwd = tempfile::tempdir().expect("tempdir");
 

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -872,7 +872,7 @@ fn run_pm_guard_at(stdin_json: &str, url: &str, cwd: &std::path::Path) -> String
     String::from_utf8(output.stdout).expect("stdout is utf8")
 }
 
-/// A one-shot HTTP stand-in for the daemon's shared-tree-writers route.
+/// A one-shot HTTP stand-in for the daemon's shared-tree-dispatch route.
 ///
 /// Why: the DENY arm cannot be reached without a daemon that answers, and a
 /// real daemon is far too much machinery for one route's wire contract. A raw
@@ -1009,69 +1009,80 @@ fn pm_guard_allows_when_the_daemon_answer_is_malformed() {
     }
 }
 
-/// An HTTP mock that answers only once BOTH expected requests have arrived.
+/// Serve the REAL delegation router, releasing requests only once `expected` of
+/// them have arrived (#5324).
 ///
-/// Why: the race this probes is "two guards both query before either dispatch
-/// is recorded". Creating that window with a sleep would make the test's
-/// outcome depend on scheduling; blocking the responder until both requests are
-/// in makes it a property of the mock's control flow instead. The first
-/// response cannot be written until `accept()` + `read()` has returned for the
-/// second connection, so the interleaving is forced, not raced for. No clock,
-/// virtual or real, is involved — deliberately, since tokio's `start_paused`
-/// auto-advances virtual time whenever all tasks are idle and would make an
-/// inserted delay evaporate (#3494).
-/// What: binds an ephemeral port, accepts and fully reads `expected`
-/// connections, and only then writes `body` to each. Returns the base URL.
-fn spawn_barrier_writers_mock(expected: usize, body: &'static str) -> String {
-    use std::io::Read;
-    use std::net::{TcpListener, TcpStream};
+/// Why: the race this probes is "two dispatches both reach the daemon before
+/// either is recorded". Creating that window with a sleep would make the test's
+/// outcome depend on scheduling; holding every request at a barrier until all
+/// `expected` are in makes it a property of the harness's control flow instead.
+/// No clock, virtual or real, is involved — deliberately, since tokio's
+/// `start_paused` auto-advances virtual time whenever all tasks are idle and
+/// would make an inserted delay evaporate (#3494).
+///
+/// Why the real router and not a canned mock: before #5324 the whole decision
+/// lived in the guard, so a mock that always answered "nobody here" was enough
+/// to pin it. The fix moved the deciding half into the daemon — the answer and
+/// the record are now one operation — so a mock could only re-implement the
+/// thing under test. This stands up `delegation_routes::router()` over a real
+/// [`DaemonState`], which is what actually holds the claim.
+///
+/// What: binds an ephemeral port, serves the delegation sub-router behind a
+/// [`tokio::sync::Barrier`] applied with `route_layer` — matched routes only, so
+/// the deny path's best-effort audit POST to the unrouted `/hooks` 404s
+/// immediately instead of waiting on a barrier no one else will reach. Returns
+/// the base URL and the temp dir backing the hermetic state.
+fn serve_delegation_router_behind_a_barrier(expected: usize) -> (String, tempfile::TempDir) {
+    use std::future::IntoFuture;
+    use std::sync::Arc;
 
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
-    let url = format!("http://{}", listener.local_addr().expect("addr"));
-    std::thread::spawn(move || {
-        let mut held: Vec<TcpStream> = Vec::with_capacity(expected);
-        for _ in 0..expected {
-            let Ok((mut socket, _)) = listener.accept() else {
-                return;
-            };
-            let mut buf = [0u8; 4096];
-            let _ = socket.read(&mut buf);
-            held.push(socket);
-        }
-        // Barrier passed: every guard has issued its query and none has an
-        // answer yet. This is the exact state the race needs.
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-            body.len()
-        );
-        for mut socket in held {
-            let _ = socket.write_all(response.as_bytes());
-        }
-    });
-    url
+    use trusty_mpm::core::paths::FrameworkPaths;
+    use trusty_mpm::daemon::{delegation_routes, state::DaemonState};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let state = Arc::new(DaemonState::with_paths(&FrameworkPaths::under(dir.path())));
+    let barrier = Arc::new(tokio::sync::Barrier::new(expected));
+
+    let app = delegation_routes::router()
+        .route_layer(axum::middleware::from_fn(
+            move |req: axum::extract::Request, next: axum::middleware::Next| {
+                let barrier = Arc::clone(&barrier);
+                async move {
+                    // Barrier passed: every guard's claim has reached the
+                    // daemon and none has been served. This is the exact state
+                    // the race needs; only the daemon's own critical section
+                    // decides what happens next.
+                    barrier.wait().await;
+                    next.run(req).await
+                }
+            },
+        ))
+        .with_state(state);
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    listener.set_nonblocking(true).expect("nonblocking");
+    let addr = listener.local_addr().expect("addr");
+    let listener = tokio::net::TcpListener::from_std(listener).expect("tokio listener");
+    tokio::spawn(axum::serve(listener, app).into_future());
+    (format!("http://{addr}"), dir)
 }
 
-#[test]
-fn pm_guard_admits_both_dispatches_that_query_before_either_is_recorded() {
-    // #4480, the check-then-decide window. `evaluate` reads the daemon's
-    // shared-tree-writers answer and decides; it takes no reservation. When two
-    // dispatches both query before either's `on_dispatch` recording lands, both
-    // see an empty set and both are ALLOWED — the collision the guard exists to
-    // prevent, in the shape the framework's own parallel-dispatch pattern
-    // produces.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pm_guard_denies_the_second_of_two_simultaneous_dispatches() {
+    // #5324, the window #4480 left open. Two `Agent` dispatches issued in one PM
+    // turn — the framework's own documented pattern for parallel work — both
+    // reach the daemon before either is recorded. Pre-fix the daemon only
+    // ANSWERED, so both saw an empty set and both were ALLOWED, which is the
+    // collision the guard exists to prevent. The claim is now taken inside the
+    // same critical section that produced the answer, so exactly one is
+    // admitted.
     //
-    // The window is forced, not timed: `spawn_barrier_writers_mock` cannot
-    // answer the first guard until the second's request has been read, so this
-    // interleaving is deterministic.
-    //
-    // What this test does NOT establish: whether Claude Code ever produces it.
-    // Whether PreToolUse admission is serialized across simultaneous `tool_use`
-    // blocks is a harness property, not observable from this repo — the hooks
-    // reference states only that multiple handlers for ONE event run in
-    // parallel, and is silent on hooks across parallel tool calls. If a
-    // reservation step is ever added, this test flips to one ALLOW + one DENY
-    // and must be updated deliberately.
-    let url = spawn_barrier_writers_mock(2, r#"{"agents":[],"total":0}"#);
+    // The interleaving is forced, not timed: the barrier holds both claims until
+    // both have arrived, so the pre-fix code cannot pass by winning a race.
+    // Which of the two is denied is genuinely arbitrary — that is the point of a
+    // mutual exclusion — so the assertion counts verdicts rather than ordering
+    // them.
+    let (url, _dir) = serve_delegation_router_behind_a_barrier(2);
     let cwd = tempfile::tempdir().expect("tempdir");
 
     let mut children = Vec::new();
@@ -1091,10 +1102,21 @@ fn pm_guard_admits_both_dispatches_that_query_before_either_is_recorded() {
         .map(|h| h.join().expect("guard thread").trim().to_string())
         .collect();
 
+    let allowed = verdicts.iter().filter(|v| v.is_empty()).count();
+    let denied: Vec<&String> = verdicts.iter().filter(|v| !v.is_empty()).collect();
     assert_eq!(
-        verdicts,
-        vec![String::new(), String::new()],
-        "both dispatches querying before either is recorded are currently ALLOWED — \
-         if this changed, a reservation step was added and the module doc must say so"
+        allowed, 1,
+        "exactly one of two simultaneous dispatches may be admitted, got: {verdicts:?}"
+    );
+    assert_eq!(denied.len(), 1, "and exactly one must be denied");
+    assert_denied(denied[0]);
+    let reason: serde_json::Value =
+        serde_json::from_str(denied[0]).expect("deny stdout must be valid JSON");
+    let reason = reason["hookSpecificOutput"]["permissionDecisionReason"]
+        .as_str()
+        .expect("reason is a string");
+    assert!(
+        reason.contains("#4480") && reason.contains("rust-engineer"),
+        "the deny must name the rule and the sibling already in the tree, got: {reason}"
     );
 }


### PR DESCRIPTION
Closes #5324

## Mechanism

The `#4480` guard's read-only `GET .../delegations/shared-tree-writers` becomes `POST .../delegations/shared-tree-dispatch`: the daemon answers *and* claims the working directory inside one critical section (`DaemonState::claim_shared_tree_dispatch`, holding the new `shared_tree_claim` mutex across the scan and the record), so the second of two dispatches issued in one PM turn finds the first and is denied. What it claims is not a new kind of state — the route hands the posted payload to the delegation tracker's own `PreToolUse` observer, so the claim *is* the record the daemon's `matcher: "*"` hook would have written a moment later, with the same correlation key, liveness, and staleness sweep; that observer is idempotent on `tool_use_id`, so exactly one record exists either way and nothing new has to be released.

Eligibility is re-derived daemon-side from the payload rather than trusted from the caller, so a read-only, isolated, non-dispatch, or cwd-less dispatch can never occupy a directory. Version skew 404s in both directions (new hook → old daemon, old hook → new daemon), which the guard reads as "nobody here" — degrading to exactly the behaviour that shipped before #4480.

## The inverted test

`pm_guard_admits_both_dispatches_that_query_before_either_is_recorded` was **inverted, not deleted** — renamed to `pm_guard_denies_the_second_of_two_simultaneous_dispatches`, now asserting one ALLOW + one DENY and checking the deny names both the rule (`#4480`) and the sibling agent already in the tree. Its previous comment explicitly predicted this flip: *"If a reservation step is ever added, this test flips to one ALLOW + one DENY and must be updated deliberately."*

The barrier mock was replaced with the **real** `delegation_routes::router()` over a real `DaemonState`. Before this change the whole decision lived in the guard, so a mock that always answered "nobody here" was enough to pin it; the fix moves the deciding half into the daemon, so a canned mock could now only re-implement the thing under test. The interleaving stays forced rather than timed — a `tokio::sync::Barrier` holds both claims until both have arrived, so the pre-fix code cannot pass by winning a race.

## Fail-Open count: still 6, none regressed

All six declared branches keep their error-arm test: unreachable daemon, malformed answer, unresolvable cwd, unknown agent, untyped dispatch, non-dispatch tool. On the new POST path, **claim contention** is covered by `shared_tree_dispatch_route_denies_the_second_claim` plus the integration test above.

The other two candidate branches **do not exist**, which is worth stating rather than papering over with unreachable tests:

- **Mutex poisoning** — `shared_tree_claim` is a `parking_lot::Mutex`, which does not poison. There is no arm to test.
- **Tracker rejection** — `delegation_tracker::observe` returns `()`. Its recording precondition (`dispatch_tool(payload).is_some()`, i.e. `is_subagent_dispatch_tool`) is a strict subset of the route's `eligible` predicate, so `eligible` implies recorded; `on_dispatch` inserts even when `tool_use_id` is absent. The residual risk — claim reported as taken while nothing was recorded — is closed empirically instead: `shared_tree_dispatch_route_reserves_the_tree_on_an_empty_answer` asserts the record actually lands, and `..._claim_is_idempotent_on_redelivery` covers the double-record path.

## Review round (code-critic APPROVE, three fixes landed)

- **MEDIUM — claim payload was unbounded.** The POST forwarded `tool_input` verbatim, carrying the whole subagent prompt, which put an unbounded body under axum's default 2 MB limit — a **new** fail-open arm the read-only GET it replaced could not have had, where a 413 reads as an empty answer and the dispatch is admitted unclaimed. It now sends only `subagent_type`, `isolation` and `description`. Those three are the complete read-set (route: `dispatch_agent` + `dispatch_isolation`; `on_dispatch`: those two plus `description`), so the record is unchanged and the arm is **unreachable rather than untested** — no error-arm test, because the branch no longer exists. Covered by `claim_payload_carries_only_the_fields_the_daemon_reads` and `claim_payload_projection_leaves_a_non_object_input_alone`.
- **MEDIUM — `claimed` was write-only.** An empty answer that claimed nothing is always an eligibility divergence, since the guard never asks unless it has already classified the dispatch as tree-sharing. It fires when a running daemon predates the on-PATH `tm` for an agent added between builds: both dispatches admitted, nothing claimed, guard silently unenforced. `claim_shared_tree` now **warns to stderr** and still allows — denying would fail closed on version skew, the opposite of this path's designed degradation. The decision is split into a pure `eligibility_diverged` predicate so it is assertable without capturing stderr; covered by `eligibility_divergence_is_an_empty_answer_that_claimed_nothing`.
- **LOW — race-test sensitivity documented.** The barrier does not extend into the handler, so the end-to-end test's sensitivity to lost atomicity is scheduling-dependent (moving `record` outside the mutex fails at a 300 ms handler gap, passed at 50 ms). It now states that it pins *a claim is taken* end to end, while `shared_tree_dispatch_route_denies_the_second_claim` pins the mutual exclusion deterministically with no scheduler involved. Treat them as a pair.

## SemVer: this PR carries no public-API break; `main` already does

`bash scripts/check_semver.sh --crate trusty-mpm` → **BREAK**, but not from this branch:

```
Checking trusty-mpm v1.3.5 -> v1.3.6 (patch change)
 Checked 223 checks: 222 pass, 1 fail, 0 warn, 31 skip
--- failure constructible_struct_adds_field ---
Failed in:
  field Delegation.isolation in crates/trusty-mpm/src/core/agent.rs:275
 Summary semver requires new major version: 1 major and 0 minor checks failed
```

The single failure is `Delegation.isolation` in `core/agent.rs`, **a file this diff does not touch** (`git diff --name-only origin/main...HEAD -- crates/trusty-mpm/src/core/agent.rs` is empty) and which already carries `pub isolation` on `origin/main`. It was added by #4480 and is inherited, not introduced here.

The review round's concern about `SharedTreeWritersResponse::claimed`, `SharedTreeWritersQuery` and `shared_tree_writers_route` is **moot**: #4480 landed after 1.3.5 was published, so `daemon::delegation_routes` does not exist in the published baseline at all — nothing that never shipped can be broken by removing it. cargo-semver-checks confirms this directly by not flagging any of them across its 223 checks.

Worth flagging for release: `trusty-mpm` is at **1.3.6, not `0.y.z`**, so under normal SemVer this inherited break needs the **MAJOR** position, not minor. No version was changed here — that is `local-ops`'s call.

## Gates (re-run after the review fixes)

| Gate | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo check -p trusty-mpm --all-targets` | clean |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | pass |
| `cargo test -p trusty-mpm --no-fail-fast` | 45 targets green; 3 new tests pass |

`--no-fail-fast` is required or the lib target aborts the run and the integration tests never execute ([#5354](https://github.com/bobmatnyc/trusty-tools/issues/5354)).

Repo gates after staging: line-cap 0 violations, SLD 0 errors, doc-numbers 0 violations, test-pointers 23284 resolved / 0 dangling, changelog fragment valid.

**Pre-existing failure — [#4931](https://github.com/bobmatnyc/trusty-tools/issues/4931).** Rebased onto `2d964aefc` (picks up `trusty-mpm` 1.3.6 from #5348, which clears the version-bump gate). One order-dependent test fails per full run and it is a *different* one each time — `ensure_managed_config_dir_emits_the_frozen_skill_warning`, then `stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet`, now `stale_assets_for_many_sees_an_agent_change_on_the_very_next_call` — all in the shared-global-state cluster #4931 tracks, and all passing in isolation. Proven not caused by this branch: a clean `origin/main` worktree reproduces it identically (`4872 passed; 1 failed`). Nothing was ignored, `cfg`-gated, or excluded.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
