### PR TITLE
fix(trusty-common,trusty-memory): key KG triples on (subject, predicate, object) so membership stops overwriting (#4810)

### DIFF
--- a/crates/trusty-common/changelog.d/4810-kg-triple-key.md
+++ b/crates/trusty-common/changelog.d/4810-kg-triple-key.md
@@ -1,18 +1,9 @@
 Fixed
 
-The knowledge-graph TRIPLES key now includes the object, so a subject can hold
-several objects under one predicate. It previously keyed on
-`(subject, predicate)` alone, which meant `room:General --contains--> drawer:X`
-held ONE row no matter how many drawers the room had — every new member
-silently closed the last one. Predicates listed in
-`kg_store::FUNCTIONAL_PREDICATES` (`is_alias_for`, `has_version`, …) keep the
-one-active-object rule; every other predicate is multi-valued. `upsert_edge`
-in the in-memory adjacency was collapsing the same edges back on every palace
-open and now matches on target as well as predicate.
-
-**Breaking on-disk format.** Palaces are migrated in place at open, once, in a
-single redb transaction, after a size-verified copy of the database is written
-to `<kg>.redb.pre-4810.bak`. A migrated palace cannot be read by an earlier
-version of this crate — downgrading below this version is unsafe. A migration
-that fails is logged at `warn!` and retried on the next open; the palace still
-opens, but its triples do not appear in queries until it succeeds.
+- The knowledge-graph TRIPLES key now includes the object, so a subject can hold several objects under one predicate ([#4810](https://github.com/bobmatnyc/trusty-tools/issues/4810))
+  - It previously keyed on `(subject, predicate)` alone, which meant `room:General --contains--> drawer:X` held ONE row no matter how many drawers the room had — every new member silently closed the last one.
+  - Predicates listed in `kg_store::FUNCTIONAL_PREDICATES` (`is_alias_for`, `has_version`, …) keep the one-active-object rule; every other predicate is multi-valued.
+  - `upsert_edge` in the in-memory adjacency was collapsing the same edges back on every palace open and now matches on target as well as predicate.
+- **Breaking on-disk format.** Palaces are migrated in place at open, once, in a single redb transaction, after a size-verified copy of the database is written to `<kg>.redb.pre-4810.bak`.
+  - A migrated palace cannot be read by an earlier version of this crate — downgrading below this version is unsafe.
+  - A migration that fails is logged at `warn!` and retried on the next open; the palace still opens, but its triples do not appear in queries until it succeeds.

--- a/crates/trusty-common/changelog.d/4810-kg-triple-key.md
+++ b/crates/trusty-common/changelog.d/4810-kg-triple-key.md
@@ -1,0 +1,18 @@
+Fixed
+
+The knowledge-graph TRIPLES key now includes the object, so a subject can hold
+several objects under one predicate. It previously keyed on
+`(subject, predicate)` alone, which meant `room:General --contains--> drawer:X`
+held ONE row no matter how many drawers the room had — every new member
+silently closed the last one. Predicates listed in
+`kg_store::FUNCTIONAL_PREDICATES` (`is_alias_for`, `has_version`, …) keep the
+one-active-object rule; every other predicate is multi-valued. `upsert_edge`
+in the in-memory adjacency was collapsing the same edges back on every palace
+open and now matches on target as well as predicate.
+
+**Breaking on-disk format.** Palaces are migrated in place at open, once, in a
+single redb transaction, after a size-verified copy of the database is written
+to `<kg>.redb.pre-4810.bak`. A migrated palace cannot be read by an earlier
+version of this crate — downgrading below this version is unsafe. A migration
+that fails is logged at `warn!` and retried on the next open; the palace still
+opens, but its triples do not appear in queries until it succeeds.

--- a/crates/trusty-common/src/memory_core/store/kg/adjacency.rs
+++ b/crates/trusty-common/src/memory_core/store/kg/adjacency.rs
@@ -16,6 +16,7 @@ use petgraph::visit::EdgeRef;
 use std::collections::HashMap;
 
 use crate::memory_core::store::kg_redb::KgStoreRedb;
+use crate::memory_core::store::kg_store::is_functional_predicate;
 
 /// In-memory adjacency cache backing the public graph API.
 ///
@@ -61,21 +62,28 @@ impl Adjacency {
     }
 
     /// Why: `assert` must keep the graph in sync with the store; doing it
-    /// here keeps the lock-management in one place.
-    /// What: Removes any prior edge for `(subject, predicate)` between the
-    /// existing subject and object nodes, then inserts the new edge using
-    /// the provided triple's metadata. Nodes are created if absent.
-    /// Test: `assert_adds_edge`, `retract_removes_edge`.
+    /// here keeps the lock-management in one place. #4810: the removal used to
+    /// drop EVERY edge from the subject carrying this predicate, regardless of
+    /// target. Since `hydrate_adjacency` replays each active triple through
+    /// here, a room's parallel `contains` edges collapsed back to one on every
+    /// palace open even once storage kept them — which is what left
+    /// `/kg/graph`, `kg_gaps`, and `expand_neighbors` under-reporting.
+    /// What: mirrors the storage split. For a functional predicate the prior
+    /// edge to any target is removed (one active object per subject); for a
+    /// multi-valued one only the edge to THIS target is, so parallel edges to
+    /// other targets survive. Nodes are created if absent.
+    /// Test: `assert_adds_edge`, `retract_removes_edge`,
+    /// `parallel_edges_survive_hydration`.
     pub(super) fn upsert_edge(&mut self, triple: &Triple) {
         let s_idx = self.ensure_node(&triple.subject);
         let o_idx = self.ensure_node(&triple.object);
-        // Remove any existing edge with the same predicate between the
-        // existing subject and any object (matches the temporal invariant
-        // "at most one active edge per (subject, predicate)").
+        let functional = is_functional_predicate(&triple.predicate);
         let to_remove: Vec<_> = self
             .graph
             .edges(s_idx)
-            .filter(|e| e.weight().predicate == triple.predicate)
+            .filter(|e| {
+                e.weight().predicate == triple.predicate && (functional || e.target() == o_idx)
+            })
             .map(|e| e.id())
             .collect();
         for eid in to_remove {

--- a/crates/trusty-common/src/memory_core/store/kg/mod.rs
+++ b/crates/trusty-common/src/memory_core/store/kg/mod.rs
@@ -9,8 +9,12 @@
 //! What: `Triple` record + `KnowledgeGraph` handle. Every method delegates to
 //! `KgStoreRedb`; async methods run blocking redb work on `tokio::task::
 //! spawn_blocking` so the async reactor isn't stalled.
-//! Test: Asserting (s,p,o) twice closes the first interval and opens a new
-//! one; `query_active` returns only the latest. Tests in kg/tests.rs exercise
+//! Test: Asserting the SAME (s,p,o) twice closes the first interval and opens
+//! a new one; `query_active` returns only the latest. Asserting a DIFFERENT
+//! object under the same (s,p) depends on the predicate (#4810): a functional
+//! predicate — one listed in `kg_store::FUNCTIONAL_PREDICATES`, such as
+//! `is_alias_for` — still supersedes, while every other predicate is
+//! multi-valued and both objects stay active. Tests in kg/tests.rs exercise
 //! the public API; storage-engine tests live in `kg_redb.rs`.
 
 mod adjacency;

--- a/crates/trusty-common/src/memory_core/store/kg/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/kg/tests.rs
@@ -73,13 +73,17 @@ async fn retract_closes_active_interval() {
     assert_eq!(again, 0);
 }
 
+/// #4810: superseding is now a property of the predicate. `is_alias_for` is
+/// functional, so the second object closes the first; a multi-valued
+/// predicate would keep both (covered by
+/// `assert_multiple_objects_for_multivalued_predicate_all_survive`).
 #[tokio::test]
 async fn second_assert_closes_prior_interval() {
     let dir = tempdir().unwrap();
     let kg = KnowledgeGraph::open(&dir.path().join("kg.db")).unwrap();
     let t1 = Triple {
         subject: "alice".to_string(),
-        predicate: "works_at".to_string(),
+        predicate: "is_alias_for".to_string(),
         object: "Acme Corp".to_string(),
         valid_from: Utc::now(),
         valid_to: None,
@@ -90,7 +94,7 @@ async fn second_assert_closes_prior_interval() {
 
     let t2 = Triple {
         subject: "alice".to_string(),
-        predicate: "works_at".to_string(),
+        predicate: "is_alias_for".to_string(),
         object: "Beta Inc".to_string(),
         valid_from: Utc::now(),
         valid_to: None,
@@ -102,6 +106,47 @@ async fn second_assert_closes_prior_interval() {
     let active = kg.query_active("alice").await.unwrap();
     assert_eq!(active.len(), 1, "should have exactly 1 active triple");
     assert_eq!(active[0].object, "Beta Inc");
+}
+
+/// #4810: the counterpart to `second_assert_closes_prior_interval` — an
+/// unlisted predicate is multi-valued, so both objects stay live and the
+/// in-memory adjacency keeps both edges after a re-open.
+#[tokio::test]
+async fn parallel_edges_survive_hydration() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("kg.db");
+    {
+        let kg = KnowledgeGraph::open(&path).unwrap();
+        for object in ["drawer:a", "drawer:b", "drawer:c"] {
+            kg.assert(Triple {
+                subject: "room:General".into(),
+                predicate: "contains".into(),
+                object: object.into(),
+                valid_from: Utc::now(),
+                valid_to: None,
+                confidence: 1.0,
+                provenance: None,
+            })
+            .await
+            .unwrap();
+        }
+        let neighbors = kg.neighbors("room:General").unwrap();
+        assert_eq!(neighbors.len(), 3, "all three edges live before reopen");
+        assert_eq!(kg.edge_count(), 3);
+    }
+
+    // Reopen: `hydrate_adjacency` replays every active triple through
+    // `upsert_edge`, which used to drop the sibling edges on each replay.
+    let kg = KnowledgeGraph::open(&path).unwrap();
+    assert_eq!(kg.edge_count(), 3, "parallel edges survive hydration");
+    let mut neighbors: Vec<String> = kg
+        .neighbors("room:General")
+        .unwrap()
+        .into_iter()
+        .map(|(other, _)| other)
+        .collect();
+    neighbors.sort();
+    assert_eq!(neighbors, vec!["drawer:a", "drawer:b", "drawer:c"]);
 }
 
 #[tokio::test]
@@ -181,7 +226,7 @@ async fn count_active_triples_returns_live_only() {
 
     kg.assert(Triple {
         subject: "alice".into(),
-        predicate: "works_at".into(),
+        predicate: "is_alias_for".into(),
         object: "Acme".into(),
         valid_from: Utc::now(),
         valid_to: None,
@@ -193,9 +238,10 @@ async fn count_active_triples_returns_live_only() {
     assert_eq!(kg.count_active_triples(), 1);
 
     // Superseding triple closes the prior interval — count stays at 1.
+    // #4810: only because `is_alias_for` is a functional predicate.
     kg.assert(Triple {
         subject: "alice".into(),
-        predicate: "works_at".into(),
+        predicate: "is_alias_for".into(),
         object: "Beta".into(),
         valid_from: Utc::now(),
         valid_to: None,

--- a/crates/trusty-common/src/memory_core/store/kg_redb/drawer_ops.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/drawer_ops.rs
@@ -1,0 +1,142 @@
+//! In-transaction drawer helpers plus the `DRAWERS_BY_FACT_KEY` slot index.
+//!
+//! Why: the drawer write path and the triple write path share nothing but a
+//! transaction, and `write_ops.rs` sat at 495 of its 500 permitted SLOC. Moving
+//! the drawer half out is what makes room for the #4810 triple-key work without
+//! either file straddling the cap.
+//! What: `stored_fact_key`, `release_slot_if_owned_by`, `batch_upsert_drawer`,
+//! `batch_delete_drawer` — the single implementation behind both the
+//! `KgStoreRedb::{upsert_drawer, delete_drawer}` single-op methods and
+//! `apply_batch` / `import_all`.
+//! Test: `fact_key_index_tracks_upsert_and_delete`,
+//! `fact_key_index_follows_the_slot_on_reassignment`,
+//! `clearing_a_fact_key_drops_the_index_entry`,
+//! `deleting_a_drawer_that_lost_its_slot_leaves_the_new_owner_indexed`.
+
+use crate::memory_core::palace::Drawer;
+use crate::memory_core::store::kg_store::encode_value;
+use anyhow::{Context, Result};
+use redb::ReadableTable;
+use uuid::Uuid;
+
+use super::types::{Tbl, decode_drawer_record, drawer_to_record};
+
+/// The `fact_key` currently stored on the `DRAWERS` row for `id` (#4884).
+///
+/// Why: index maintenance is a diff, not an overwrite — to drop the entry a
+/// drawer is about to stop owning, the writer must know which slot it owned
+/// before the new record lands. Callers therefore run this BEFORE writing.
+/// What: point-reads the row and decodes it through
+/// [`decode_drawer_record`]'s migration chain. A row that fails every shape is
+/// reported as owning no slot: undecodable rows necessarily predate the field,
+/// and failing the write over one would make a single corrupt drawer block
+/// every unrelated write.
+/// Test: `fact_key_index_follows_the_slot_on_reassignment`,
+/// `clearing_a_fact_key_drops_the_index_entry`.
+fn stored_fact_key(drawers: &Tbl<'_>, id: Uuid) -> Result<Option<String>> {
+    let id_bytes = *id.as_bytes();
+    let Some(guard) = drawers
+        .get(id_bytes.as_slice())
+        .context("read prior drawer row for fact_key index")?
+    else {
+        return Ok(None);
+    };
+    Ok(decode_drawer_record(guard.value())
+        .ok()
+        .and_then(|r| r.fact_key))
+}
+
+/// Release `key` from the slot index, but only if `owner` still holds it
+/// (#4884).
+///
+/// Why: the ownership guard is what makes the index survive reassignment.
+/// Drawer A owns `pr:4818/state`, drawer B takes the slot, then A is deleted —
+/// an unguarded removal would evict B's entry and report a slot as free while a
+/// live drawer occupies it. Checking that the entry still names the drawer
+/// letting go of it makes the stale delete a no-op instead.
+/// What: reads the index at `key`; removes it only when the stored uuid bytes
+/// equal `owner`'s. Absent or differently-owned entries are left alone.
+/// Test: `deleting_a_drawer_that_lost_its_slot_leaves_the_new_owner_indexed`.
+fn release_slot_if_owned_by(by_fact_key: &mut Tbl<'_>, key: &str, owner: Uuid) -> Result<()> {
+    let owned = by_fact_key
+        .get(key.as_bytes())
+        .context("read fact_key index for release")?
+        .is_some_and(|g| g.value() == owner.as_bytes().as_slice());
+    if owned {
+        by_fact_key
+            .remove(key.as_bytes())
+            .context("remove fact_key index entry")?;
+    }
+    Ok(())
+}
+
+/// In-transaction drawer upsert helper.
+///
+/// Why: the single implementation behind both `KgStoreRedb::upsert_drawer` and
+/// `apply_batch`, so the #4884 slot-index maintenance cannot be present in one
+/// path and missing from the other.
+/// What: releases the slot the stored row used to own when the new record names
+/// a different one (or none), writes the record under its UUID key in DRAWERS,
+/// then points `DRAWERS_BY_FACT_KEY` at this drawer for the new key. Writing a
+/// key another drawer already holds moves the index onto the newer drawer —
+/// that is the "one slot, one live fact" shape ADR-0028 D5 needs; retiring the
+/// displaced drawer itself belongs to the Tier C write path, not to storage.
+/// Test: `apply_batch_mixes_drawer_and_triple_ops`,
+/// `fact_key_index_tracks_upsert_and_delete`,
+/// `fact_key_index_follows_the_slot_on_reassignment`.
+pub(super) fn batch_upsert_drawer(
+    drawers: &mut Tbl<'_>,
+    by_fact_key: &mut Tbl<'_>,
+    drawer: &Drawer,
+) -> Result<()> {
+    // #4884: read the prior slot BEFORE overwriting the row — afterwards the
+    // old key is gone and its index entry would be unreachable garbage.
+    let prior = stored_fact_key(drawers, drawer.id)?;
+    if let Some(prev) = prior.as_deref()
+        && drawer.fact_key.as_deref() != Some(prev)
+    {
+        release_slot_if_owned_by(by_fact_key, prev, drawer.id)?;
+    }
+
+    let record = drawer_to_record(drawer);
+    let bytes = encode_value(&record).context("encode drawer record (batch)")?;
+    let id_bytes = *drawer.id.as_bytes();
+    drawers
+        .insert(id_bytes.as_slice(), bytes.as_slice())
+        .context("insert drawer record (batch)")?;
+
+    if let Some(key) = drawer.fact_key.as_deref() {
+        by_fact_key
+            .insert(key.as_bytes(), id_bytes.as_slice())
+            .context("insert fact_key index entry")?;
+    }
+    Ok(())
+}
+
+/// In-transaction drawer delete helper.
+///
+/// Why: the single implementation behind both `KgStoreRedb::delete_drawer` and
+/// `apply_batch`. A delete that removed the row but left the index entry would
+/// leave the occupancy check answering "taken" for a slot whose occupant is
+/// gone — the exact stale-index bug the index is supposed to prevent.
+/// What: releases the deleted drawer's slot (guarded on ownership, so deleting
+/// a drawer that already lost the slot leaves the current owner indexed), then
+/// removes the row keyed by UUID bytes from DRAWERS.
+/// Test: `fact_key_index_tracks_upsert_and_delete`,
+/// `deleting_a_drawer_that_lost_its_slot_leaves_the_new_owner_indexed`.
+pub(super) fn batch_delete_drawer(
+    drawers: &mut Tbl<'_>,
+    by_fact_key: &mut Tbl<'_>,
+    id: Uuid,
+) -> Result<()> {
+    // #4884: same ordering rule as the upsert — the row is the only place the
+    // slot name is recorded, so read it before removing it.
+    if let Some(key) = stored_fact_key(drawers, id)? {
+        release_slot_if_owned_by(by_fact_key, &key, id)?;
+    }
+    let id_bytes = *id.as_bytes();
+    drawers
+        .remove(id_bytes.as_slice())
+        .context("remove drawer record (batch)")?;
+    Ok(())
+}

--- a/crates/trusty-common/src/memory_core/store/kg_redb/import.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/import.rs
@@ -17,9 +17,10 @@ use anyhow::{Context, Result};
 use redb::ReadableTable;
 
 use super::super::kg::Triple;
+use super::drawer_ops::{batch_delete_drawer, batch_upsert_drawer};
 use super::store::KgStoreRedb;
 use super::types::{BatchOpResult, BatchWriteOp};
-use super::write_ops::{batch_assert, batch_delete_drawer, batch_retract, batch_upsert_drawer};
+use super::write_ops::{batch_assert, batch_retract};
 
 impl KgStoreRedb {
     /// Import a batch of historical triples and drawers without disturbing

--- a/crates/trusty-common/src/memory_core/store/kg_redb/import.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/import.rs
@@ -32,12 +32,14 @@ impl KgStoreRedb {
     /// originated from a temporal store and already carry their final
     /// `valid_from` / `valid_to`; we must preserve that history.
     /// What: In a single write transaction, write each triple at either its
-    /// primary `(subject, predicate)` key (when active) or a `hist:`-prefixed
-    /// key (when closed). Secondary indexes and `ACTIVE_SUBJECT_COUNTS` are
-    /// updated only for active rows. Drawers are upserted as-is. If multiple
-    /// triples share `(subject, predicate)`, the last active one wins at the
-    /// primary key — earlier active rows of the same pair are stored under
-    /// `hist:` keys instead so no data is silently dropped.
+    /// primary `(subject, predicate, object)` key (when active) or a
+    /// `hist:`-prefixed key (when closed). Secondary indexes and
+    /// `ACTIVE_SUBJECT_COUNTS` are updated only for active rows. Drawers are
+    /// upserted as-is. Since #4810 put the object in the key, two active rows
+    /// that differ only in object no longer contend for one slot; the
+    /// demote-to-history path below now fires only on an exact
+    /// `(subject, predicate, object)` repeat, where the later row still wins
+    /// and the earlier one is preserved under a `hist:` key.
     /// Test: Covered by the kg_migration integration test in
     /// `crates/trusty-common/tests/kg_migration_tests.rs`.
     pub fn import_all(&self, triples: Vec<Triple>, drawers: Vec<Drawer>) -> Result<()> {
@@ -63,7 +65,7 @@ impl KgStoreRedb {
                     confidence: triple.confidence,
                     provenance: triple.provenance.clone(),
                 };
-                let key = encode_triple_key(&triple.subject, &triple.predicate);
+                let key = encode_triple_key(&triple.subject, &triple.predicate, &triple.object);
                 let bytes = encode_value(&value).context("encode triple value")?;
 
                 if value.valid_to_ms.is_some() {
@@ -121,8 +123,11 @@ impl KgStoreRedb {
                             by_object
                                 .remove(obj_key.as_slice())
                                 .context("remove demoted object index")?;
-                            let pred_key =
-                                encode_predicate_index_key(&triple.predicate, &triple.subject);
+                            let pred_key = encode_predicate_index_key(
+                                &triple.predicate,
+                                &triple.subject,
+                                &prior.object,
+                            );
                             by_predicate
                                 .remove(pred_key.as_slice())
                                 .context("remove demoted predicate index")?;
@@ -153,7 +158,11 @@ impl KgStoreRedb {
                     by_object
                         .insert(obj_key.as_slice(), [].as_slice())
                         .context("insert object index for imported row")?;
-                    let pred_key = encode_predicate_index_key(&triple.predicate, &triple.subject);
+                    let pred_key = encode_predicate_index_key(
+                        &triple.predicate,
+                        &triple.subject,
+                        &value.object,
+                    );
                     by_predicate
                         .insert(pred_key.as_slice(), [].as_slice())
                         .context("insert predicate index for imported row")?;

--- a/crates/trusty-common/src/memory_core/store/kg_redb/migrate.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/migrate.rs
@@ -20,7 +20,7 @@
 //! fails.
 //! Test: `migration_stamps_schema_and_is_idempotent`,
 //! `migration_rewrites_legacy_keys_and_preserves_history`,
-//! `migration_failure_leaves_the_palace_openable_under_old_semantics`.
+//! `migration_failure_leaves_the_palace_openable_and_retries`.
 
 use crate::memory_core::store::kg_store::{
     KG_SCHEMA, KG_SCHEMA_TRIPLE_KEY, KG_TRIPLE_KEY_SCHEMA_VERSION, KgSchemaMarker, TRIPLES,
@@ -318,7 +318,7 @@ fn stamp_only(db: &Database) -> Result<()> {
 /// matches the current file is left alone: a previous attempt failed, rolled
 /// back, and left the source unchanged, so that copy is still a good one and
 /// re-copying only risks replacing it with a worse one.
-/// Test: `migration_failure_leaves_the_palace_openable_under_old_semantics`.
+/// Test: `migration_failure_leaves_the_palace_openable_and_retries`.
 fn ensure_verified_backup(path: &Path) -> Result<PathBuf> {
     let backup = PathBuf::from(format!("{}{BACKUP_SUFFIX}", path.display()));
     let src_len = std::fs::metadata(path)

--- a/crates/trusty-common/src/memory_core/store/kg_redb/migrate.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/migrate.rs
@@ -1,0 +1,347 @@
+//! At-open, per-palace migration of the TRIPLES key from `(subject,
+//! predicate)` to `(subject, predicate, object)` (#4810).
+//!
+//! Why: the old key made the object invisible to storage, so a second object
+//! under one `(subject, predicate)` closed the first. Fixing the encoder alone
+//! would leave every existing palace's rows unreadable at their new key —
+//! `query_active` would return nothing and the next assert would insert a
+//! duplicate alongside the orphan. The rows have to be rewritten, once, and the
+//! only place that reliably happens for every palace on every machine is at
+//! open.
+//! What: gated on the [`KG_SCHEMA`] marker row so it runs at most once per
+//! palace; backs the database file up first and verifies the copy; rewrites
+//! every TRIPLES key (active and `hist:`), rebuilds `TRIPLES_BY_PREDICATE`
+//! (whose key also gained the object), and stamps the marker — the rewrite and
+//! the stamp inside ONE redb write transaction, so a failure part-way through
+//! rolls both back and the next open retries from the original rows.
+//! `TRIPLES_BY_OBJECT` is untouched: its key already carried the object.
+//! Fail-open: any error is logged at `warn!` and the palace opens un-migrated,
+//! matching how `PalaceHandle::open_with_intent` degrades when `load_drawers`
+//! fails.
+//! Test: `migration_stamps_schema_and_is_idempotent`,
+//! `migration_rewrites_legacy_keys_and_preserves_history`,
+//! `migration_failure_leaves_the_palace_openable_under_old_semantics`.
+
+use crate::memory_core::store::kg_store::{
+    KG_SCHEMA, KG_SCHEMA_TRIPLE_KEY, KG_TRIPLE_KEY_SCHEMA_VERSION, KgSchemaMarker, TRIPLES,
+    TRIPLES_BY_PREDICATE, TripleValue, decode_legacy_triple_key, decode_value,
+    encode_predicate_index_key, encode_triple_key, encode_value,
+};
+use anyhow::{Context, Result, bail};
+use redb::{Database, ReadableDatabase, ReadableTable};
+use std::path::{Path, PathBuf};
+
+/// Suffix appended to the redb file name for the pre-migration backup.
+const BACKUP_SUFFIX: &str = ".pre-4810.bak";
+
+/// Run the #4810 migration, logging rather than propagating any failure.
+///
+/// Why: a palace that cannot be migrated must still open. Refusing would take
+/// the whole memory service down over a condition — a full disk, an
+/// unwritable directory — that clears on its own and that the next open
+/// retries. Nothing is lost either: the rows stay on disk in their original
+/// form, and the failed attempt commits nothing.
+/// What: calls [`migrate_triple_keys`] and maps its outcome onto tracing. The
+/// warning states the consequence plainly, because it is not a small one: the
+/// readers decode the new three-component key, so until the migration
+/// succeeds an un-migrated palace's triples do not appear in `query_active` /
+/// `list_active` at all. They are not gone — the next successful open makes
+/// them visible again.
+/// Test: `migration_failure_leaves_the_palace_openable_and_retries`.
+pub(super) fn migrate_triple_keys_fail_open(db: &Database, path: &Path) {
+    match migrate_triple_keys(db, path) {
+        Ok(MigrationOutcome::AlreadyMigrated) => {}
+        Ok(MigrationOutcome::Stamped) => {
+            tracing::debug!(path = %path.display(), "#4810: stamped triple-key schema on an empty KG");
+        }
+        Ok(MigrationOutcome::Migrated { rows, backup }) => {
+            tracing::info!(
+                path = %path.display(),
+                rows,
+                backup = %backup.display(),
+                "#4810: rewrote KG triple keys to (subject, predicate, object)"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                "#4810: KG triple-key migration failed; opening un-migrated. The rows are intact on disk and the next open retries, but until it succeeds this palace's triples will not appear in queries: {e:#}"
+            );
+        }
+    }
+}
+
+/// What a migration attempt did.
+#[derive(Debug)]
+pub(super) enum MigrationOutcome {
+    /// The marker row already names this version or newer — nothing to do.
+    AlreadyMigrated,
+    /// No legacy rows existed (a fresh or empty palace); only the marker was
+    /// written.
+    Stamped,
+    /// `rows` TRIPLES rows were rewritten; the pre-migration file is at
+    /// `backup`.
+    Migrated { rows: usize, backup: PathBuf },
+}
+
+/// One TRIPLES row's rewrite: where it is now, where it belongs, and its value.
+struct Rewrite {
+    old_key: Vec<u8>,
+    new_key: Vec<u8>,
+    value: Vec<u8>,
+    /// Present only for active rows — the predicate index is rebuilt from
+    /// these.
+    index_parts: Option<(String, String, String)>,
+}
+
+/// Migrate this database's triple keys if it has not been migrated already.
+///
+/// Why/What: see the module doc. Returns what it did so the caller can log at
+/// the right level.
+/// Test: `migration_rewrites_legacy_keys_and_preserves_history`.
+fn migrate_triple_keys(db: &Database, path: &Path) -> Result<MigrationOutcome> {
+    if read_schema_version(db)?.is_some_and(|v| v >= KG_TRIPLE_KEY_SCHEMA_VERSION) {
+        return Ok(MigrationOutcome::AlreadyMigrated);
+    }
+
+    let plan = plan_rewrites(db)?;
+    if plan.is_empty() {
+        stamp_only(db)?;
+        return Ok(MigrationOutcome::Stamped);
+    }
+
+    // Back up BEFORE the write transaction. A verified copy of the original is
+    // the only thing that makes a bad rewrite recoverable, and a truncated copy
+    // is worse than none — it looks like a safety net and is not one.
+    let backup = ensure_verified_backup(path)?;
+
+    let rows = plan.len();
+    let wtx = db.begin_write().context("begin #4810 migration txn")?;
+    {
+        // The marker write and the row rewrite ride the SAME transaction:
+        // redb commits it atomically, so a failure anywhere below leaves both
+        // the old rows and the absent marker in place and the next open
+        // retries from scratch. A marker stamped in a separate transaction
+        // could land while the rewrite did not, permanently skipping it.
+        let mut schema = wtx
+            .open_table(KG_SCHEMA)
+            .context("open kg_schema table for migration")?;
+        if let Some(v) = schema
+            .get(KG_SCHEMA_TRIPLE_KEY)
+            .context("re-read schema marker inside migration txn")?
+            .map(|g| decode_value::<KgSchemaMarker>(g.value()))
+            .transpose()
+            .context("decode schema marker inside migration txn")?
+            && v.schema_version >= KG_TRIPLE_KEY_SCHEMA_VERSION
+        {
+            return Ok(MigrationOutcome::AlreadyMigrated);
+        }
+
+        let mut triples = wtx
+            .open_table(TRIPLES)
+            .context("open triples table for migration")?;
+        // Remove every legacy key before inserting any new one: a new key can
+        // equal some other row's legacy key, and interleaving the two would let
+        // an insert land under a key a later remove then deletes.
+        for r in &plan {
+            triples
+                .remove(r.old_key.as_slice())
+                .context("remove legacy triple key")?;
+        }
+        for r in &plan {
+            triples
+                .insert(r.new_key.as_slice(), r.value.as_slice())
+                .context("insert migrated triple key")?;
+        }
+
+        // TRIPLES_BY_PREDICATE's key gained the object too, so every entry in
+        // it is stale. Rebuilding beats rewriting: the table has no readers, so
+        // there is nothing to preserve, and rebuilding from the active rows
+        // cannot inherit an inconsistency the old index already had.
+        let mut by_predicate = wtx
+            .open_table(TRIPLES_BY_PREDICATE)
+            .context("open triples_by_predicate table for migration")?;
+        by_predicate
+            .retain(|_, _| false)
+            .context("clear stale predicate index")?;
+        for r in &plan {
+            if let Some((s, p, o)) = &r.index_parts {
+                by_predicate
+                    .insert(
+                        encode_predicate_index_key(p, s, o).as_slice(),
+                        [].as_slice(),
+                    )
+                    .context("rebuild predicate index entry")?;
+            }
+        }
+
+        let marker = encode_value(&KgSchemaMarker {
+            schema_version: KG_TRIPLE_KEY_SCHEMA_VERSION,
+        })
+        .context("encode KgSchemaMarker")?;
+        schema
+            .insert(KG_SCHEMA_TRIPLE_KEY, marker.as_slice())
+            .context("stamp triple-key schema marker")?;
+    }
+    wtx.commit().context("commit #4810 migration txn")?;
+    Ok(MigrationOutcome::Migrated { rows, backup })
+}
+
+/// The stored triple-key schema version, if any.
+///
+/// Why/What: a palace with no [`KG_SCHEMA`] row predates #4810 and needs
+/// migrating; one whose row names this version or newer does not. A missing
+/// table is reported the same as a missing row — that is a palace whose file
+/// was opened read-only or created before the table existed.
+/// Test: `migration_stamps_schema_and_is_idempotent`.
+fn read_schema_version(db: &Database) -> Result<Option<u32>> {
+    let rtx = db.begin_read().context("begin schema-marker read")?;
+    let table = match rtx.open_table(KG_SCHEMA) {
+        Ok(t) => t,
+        Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+        Err(e) => return Err(anyhow::Error::new(e).context("open kg_schema table")),
+    };
+    let Some(guard) = table
+        .get(KG_SCHEMA_TRIPLE_KEY)
+        .context("read schema marker")?
+    else {
+        return Ok(None);
+    };
+    let marker: KgSchemaMarker =
+        decode_value(guard.value()).context("decode triple-key schema marker")?;
+    Ok(Some(marker.schema_version))
+}
+
+/// Build the full rewrite plan from a read snapshot.
+///
+/// Why: computing the plan outside the write transaction keeps the exclusive
+/// write window short and lets the caller decide whether a backup is even
+/// needed (an empty palace does not earn one).
+/// What: walks TRIPLES, splits each key into its `hist:` prefix / legacy core /
+/// 8-byte timestamp suffix, decodes the core with
+/// [`decode_legacy_triple_key`], and re-encodes it with the object taken from
+/// the row's value. Rows whose key or value will not decode are skipped with a
+/// warning rather than failing the migration — one unreadable row must not
+/// block the rest of the palace.
+/// Test: `migration_rewrites_legacy_keys_and_preserves_history`.
+fn plan_rewrites(db: &Database) -> Result<Vec<Rewrite>> {
+    let rtx = db.begin_read().context("begin migration plan read")?;
+    let triples = match rtx.open_table(TRIPLES) {
+        Ok(t) => t,
+        Err(redb::TableError::TableDoesNotExist(_)) => return Ok(Vec::new()),
+        Err(e) => return Err(anyhow::Error::new(e).context("open triples table for plan")),
+    };
+    let mut plan = Vec::new();
+    for entry in triples.iter().context("iter triples for migration plan")? {
+        let (k, v) = entry.context("read triples row for migration plan")?;
+        let old_key = k.value().to_vec();
+        let value_bytes = v.value().to_vec();
+        let value: TripleValue = match decode_value(&value_bytes) {
+            Ok(val) => val,
+            Err(e) => {
+                tracing::warn!("#4810: skipping undecodable triple value during migration: {e}");
+                continue;
+            }
+        };
+
+        let is_hist = old_key.starts_with(b"hist:");
+        let (core, suffix): (&[u8], &[u8]) = if is_hist {
+            let stripped = &old_key[b"hist:".len()..];
+            if stripped.len() < 8 {
+                tracing::warn!("#4810: skipping truncated history key during migration");
+                continue;
+            }
+            stripped.split_at(stripped.len() - 8)
+        } else {
+            (old_key.as_slice(), &[])
+        };
+
+        let Some((subject, predicate)) = decode_legacy_triple_key(core) else {
+            tracing::warn!("#4810: skipping undecodable triple key during migration");
+            continue;
+        };
+
+        let mut new_key = Vec::new();
+        if is_hist {
+            new_key.extend_from_slice(b"hist:");
+        }
+        new_key.extend_from_slice(&encode_triple_key(&subject, &predicate, &value.object));
+        new_key.extend_from_slice(suffix);
+        if new_key == old_key {
+            continue;
+        }
+
+        let index_parts = (!is_hist && value.valid_to_ms.is_none())
+            .then(|| (subject, predicate, value.object.clone()));
+        plan.push(Rewrite {
+            old_key,
+            new_key,
+            value: value_bytes,
+            index_parts,
+        });
+    }
+    Ok(plan)
+}
+
+/// Stamp the marker on a palace with nothing to rewrite.
+///
+/// Why: a fresh palace must still record which key shape it uses, or every
+/// subsequent open would re-run the plan scan.
+/// Test: `migration_stamps_schema_and_is_idempotent`.
+fn stamp_only(db: &Database) -> Result<()> {
+    let marker = encode_value(&KgSchemaMarker {
+        schema_version: KG_TRIPLE_KEY_SCHEMA_VERSION,
+    })
+    .context("encode KgSchemaMarker")?;
+    let wtx = db.begin_write().context("begin schema-stamp txn")?;
+    {
+        let mut schema = wtx
+            .open_table(KG_SCHEMA)
+            .context("open kg_schema table for stamp")?;
+        schema
+            .insert(KG_SCHEMA_TRIPLE_KEY, marker.as_slice())
+            .context("stamp triple-key schema marker")?;
+    }
+    wtx.commit().context("commit schema-stamp txn")?;
+    Ok(())
+}
+
+/// Produce (or reuse) a size-verified copy of the database file.
+///
+/// Why: the rewrite touches every triple row in the palace. If it goes wrong in
+/// a way redb's transaction cannot undo — a disk filling mid-commit, a bug in
+/// this file — the original bytes are the only recovery path. A backup that was
+/// itself truncated is worse than no backup at all, because an operator will
+/// trust it, so the copy is verified before the rewrite is allowed to start.
+/// What: copies `path` to `<path>.pre-4810.bak` and re-stats the result,
+/// failing when the byte counts disagree. An existing backup whose size already
+/// matches the current file is left alone: a previous attempt failed, rolled
+/// back, and left the source unchanged, so that copy is still a good one and
+/// re-copying only risks replacing it with a worse one.
+/// Test: `migration_failure_leaves_the_palace_openable_under_old_semantics`.
+fn ensure_verified_backup(path: &Path) -> Result<PathBuf> {
+    let backup = PathBuf::from(format!("{}{BACKUP_SUFFIX}", path.display()));
+    let src_len = std::fs::metadata(path)
+        .with_context(|| format!("stat {} for backup", path.display()))?
+        .len();
+
+    if let Ok(meta) = std::fs::metadata(&backup)
+        && meta.len() == src_len
+    {
+        return Ok(backup);
+    }
+
+    std::fs::copy(path, &backup)
+        .with_context(|| format!("copy {} to {}", path.display(), backup.display()))?;
+    let copied = std::fs::metadata(&backup)
+        .with_context(|| format!("stat backup {}", backup.display()))?
+        .len();
+    if copied != src_len {
+        bail!(
+            "backup {} is {copied} bytes but {} is {src_len}; refusing to migrate behind a truncated backup",
+            backup.display(),
+            path.display()
+        );
+    }
+    Ok(backup)
+}

--- a/crates/trusty-common/src/memory_core/store/kg_redb/mod.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/mod.rs
@@ -12,6 +12,8 @@
 //! Test: See `tests` module — round-trips, retract semantics, persistence
 //! across reopen, drawer CRUD, count_active.
 
+// #4884 slot-index maintenance; split out of `write_ops` for the SLOC cap.
+mod drawer_ops;
 mod import;
 mod read_ops;
 // ADR-0027 T1: ROOMS / ROOM_KEYS accessors (insert-only writes).

--- a/crates/trusty-common/src/memory_core/store/kg_redb/mod.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/mod.rs
@@ -15,6 +15,8 @@
 // #4884 slot-index maintenance; split out of `write_ops` for the SLOC cap.
 mod drawer_ops;
 mod import;
+// #4810: at-open rewrite of the TRIPLES key to include the object.
+mod migrate;
 mod read_ops;
 // ADR-0027 T1: ROOMS / ROOM_KEYS accessors (insert-only writes).
 mod room_ops;

--- a/crates/trusty-common/src/memory_core/store/kg_redb/read_ops.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/read_ops.rs
@@ -11,7 +11,7 @@
 use crate::memory_core::palace::Drawer;
 use crate::memory_core::store::kg_store::{
     ACTIVE_SUBJECT_COUNTS, DRAWERS, DRAWERS_BY_FACT_KEY, DrawerRecord, TRIPLES, TripleValue,
-    decode_triple_key, decode_u64, decode_value, subject_prefix,
+    decode_triple_key, decode_u64, decode_value, prefix_range_end, subject_prefix,
 };
 use anyhow::{Context, Result};
 use chrono::DateTime;
@@ -27,12 +27,16 @@ use super::types::{decode_drawer_record, parse_drawer_type, triple_from_parts};
 impl KgStoreRedb {
     /// Return all currently active triples for `subject`.
     ///
-    /// Why: Most queries want "what is true *now*". The primary TRIPLES table
-    /// holds at most one active row per (subject, predicate), so a prefix scan
-    /// on `subject_prefix(subject)` returns at most one row per predicate.
+    /// Why: Most queries want "what is true *now*". Since #4810 the primary
+    /// TRIPLES table holds one active row per `(subject, predicate, object)`,
+    /// so a multi-valued predicate contributes one row per object rather than
+    /// the single row the old `(subject, predicate)` key could hold.
     /// What: Range scan over `[subject_prefix..end_of_prefix]`, filter rows
-    /// whose `valid_to_ms.is_none()`, and map to `Triple`.
-    /// Test: `assert_then_query_returns_triple`.
+    /// whose `valid_to_ms.is_none()`, and map to `Triple`. The object comes
+    /// from the stored value, not the key — the key copy exists only to keep
+    /// rows distinct.
+    /// Test: `assert_then_query_returns_triple`,
+    /// `assert_multiple_objects_for_multivalued_predicate_all_survive`.
     pub fn query_active(&self, subject: &str) -> Result<Vec<Triple>> {
         let prefix = subject_prefix(subject);
         let rtx = self.db().begin_read().context("begin query_active txn")?;
@@ -40,10 +44,7 @@ impl KgStoreRedb {
             .open_table(TRIPLES)
             .context("open triples table for query_active")?;
         let mut out = Vec::new();
-        let mut end = prefix.clone();
-        // Build exclusive end key by appending 0xFF — every valid key with this
-        // subject prefix sorts before it.
-        end.push(0xFF);
+        let end = prefix_range_end(&prefix);
         let range = triples
             .range::<&[u8]>(prefix.as_slice()..end.as_slice())
             .context("range scan for query_active")?;
@@ -59,7 +60,7 @@ impl KgStoreRedb {
             if value.valid_to_ms.is_some() {
                 continue;
             }
-            let (s, p) = match decode_triple_key(k.value()) {
+            let (s, p, _o) = match decode_triple_key(k.value()) {
                 Some(parts) => parts,
                 None => continue,
             };
@@ -159,7 +160,7 @@ impl KgStoreRedb {
             if value.valid_to_ms.is_some() {
                 continue;
             }
-            let (s, p) = match decode_triple_key(k.value()) {
+            let (s, p, _o) = match decode_triple_key(k.value()) {
                 Some(parts) => parts,
                 None => continue,
             };
@@ -392,7 +393,7 @@ impl KgStoreRedb {
                     continue;
                 }
             };
-            let (s, p) = if let Some(stripped) = key_bytes.strip_prefix(b"hist:") {
+            let (s, p, _o) = if let Some(stripped) = key_bytes.strip_prefix(b"hist:") {
                 // History key = `hist:` + original encoded key + 8 byte suffix.
                 if stripped.len() < 8 {
                     continue;

--- a/crates/trusty-common/src/memory_core/store/kg_redb/store.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/store.rs
@@ -10,7 +10,7 @@ use crate::memory_core::store::concurrent_open::{
     OpenIntent, OpenMode, backoff_sleep_ms, try_open_or_snapshot,
 };
 use crate::memory_core::store::kg_store::{
-    ACTIVE_SUBJECT_COUNTS, DRAWERS, DRAWERS_BY_FACT_KEY, ROOM_KEYS, ROOMS, TRIPLES,
+    ACTIVE_SUBJECT_COUNTS, DRAWERS, DRAWERS_BY_FACT_KEY, KG_SCHEMA, ROOM_KEYS, ROOMS, TRIPLES,
     TRIPLES_BY_OBJECT, TRIPLES_BY_PREDICATE, WING_KEYS, WINGS,
 };
 use anyhow::{Context, Result};
@@ -18,6 +18,7 @@ use redb::Database;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use super::migrate::migrate_triple_keys_fail_open;
 use super::types::{KgDbState, READ_ONLY_ERROR_MSG, canonical_key, db_cache};
 
 /// Why: All KG callers go through a single `KnowledgeGraph` handle that is
@@ -172,8 +173,20 @@ impl KgStoreRedb {
                             // without the tables that scope them.
                             let _ = wtx.open_table(WINGS).context("init wings table")?;
                             let _ = wtx.open_table(WING_KEYS).context("init wing_keys table")?;
+                            // #4810: same whole-schema rule — the migration
+                            // gate reads this table on every open, so it must
+                            // exist before anything asks.
+                            let _ = wtx.open_table(KG_SCHEMA).context("init kg_schema table")?;
                         }
                         wtx.commit().context("commit init txn")?;
+
+                        // #4810: rewrite pre-object triple keys once per
+                        // palace. Deliberately fail-open — a palace that cannot
+                        // be migrated still opens and behaves exactly as it did
+                        // before #4810. Snapshot mode never reaches here: a
+                        // migration written into a throw-away snapshot would be
+                        // discarded and re-attempted on every open.
+                        migrate_triple_keys_fail_open(&db, path);
                     }
 
                     let state = Arc::new(KgDbState {

--- a/crates/trusty-common/src/memory_core/store/kg_redb/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/tests.rs
@@ -53,9 +53,11 @@ mod tests {
 
     #[test]
     fn assert_supersedes_prior() {
+        // #4810: `is_alias_for` is functional, so a second object closes the
+        // first. Before #4810 every predicate behaved this way.
         let (_d, kg) = open_kg();
-        kg.assert(&t("alice", "works_at", "Acme")).unwrap();
-        kg.assert(&t("alice", "works_at", "Beta")).unwrap();
+        kg.assert(&t("alice", "is_alias_for", "Acme")).unwrap();
+        kg.assert(&t("alice", "is_alias_for", "Beta")).unwrap();
         let active = kg.query_active("alice").unwrap();
         assert_eq!(active.len(), 1, "exactly one active row");
         assert_eq!(active[0].object, "Beta");
@@ -125,16 +127,17 @@ mod tests {
         let (_d, kg) = open_kg();
         assert_eq!(kg.count_active_triples(), 0);
 
-        kg.assert(&t("alice", "works_at", "Acme")).unwrap();
+        kg.assert(&t("alice", "is_alias_for", "Acme")).unwrap();
         assert_eq!(kg.count_active_triples(), 1);
 
-        kg.assert(&t("alice", "works_at", "Beta")).unwrap();
+        // #4810: functional predicate — the supersede keeps the count at 1.
+        kg.assert(&t("alice", "is_alias_for", "Beta")).unwrap();
         assert_eq!(kg.count_active_triples(), 1);
 
-        kg.assert(&t("bob", "works_at", "Gamma")).unwrap();
+        kg.assert(&t("bob", "is_alias_for", "Gamma")).unwrap();
         assert_eq!(kg.count_active_triples(), 2);
 
-        kg.retract("alice", "works_at").unwrap();
+        kg.retract("alice", "is_alias_for").unwrap();
         assert_eq!(kg.count_active_triples(), 1);
     }
 
@@ -581,10 +584,11 @@ mod tests {
     fn apply_batch_groups_asserts_into_single_commit() {
         let (_d, kg) = open_kg();
         let ops = vec![
-            BatchWriteOp::Assert(t("a", "p1", "v1")),
+            BatchWriteOp::Assert(t("a", "is_alias_for", "v1")),
             BatchWriteOp::Assert(t("a", "p2", "v2")),
-            BatchWriteOp::Assert(t("b", "p1", "v3")),
-            BatchWriteOp::Assert(t("a", "p1", "v1b")), // supersedes a/p1
+            BatchWriteOp::Assert(t("b", "is_alias_for", "v3")),
+            // #4810: supersedes only because `is_alias_for` is functional.
+            BatchWriteOp::Assert(t("a", "is_alias_for", "v1b")),
             BatchWriteOp::Retract {
                 subject: "a".to_string(),
                 predicate: "p2".to_string(),
@@ -596,10 +600,11 @@ mod tests {
         assert!(matches!(results[3], BatchOpResult::Asserted));
         assert_eq!(results[4], BatchOpResult::Retracted(1));
 
-        // Active state: a/p1 = v1b (latest), a/p2 retracted, b/p1 = v3.
+        // Active state: a/is_alias_for = v1b (latest), a/p2 retracted,
+        // b/is_alias_for = v3.
         let a_active = kg.query_active("a").unwrap();
         assert_eq!(a_active.len(), 1);
-        assert_eq!(a_active[0].predicate, "p1");
+        assert_eq!(a_active[0].predicate, "is_alias_for");
         assert_eq!(a_active[0].object, "v1b");
 
         let b_active = kg.query_active("b").unwrap();
@@ -766,5 +771,395 @@ mod tests {
         for h in handles {
             h.join().expect("reader thread panicked");
         }
+    }
+    // ---------------------------------------------------------------------
+    // #4810 — the object joins the TRIPLES key
+    // ---------------------------------------------------------------------
+
+    /// Encode a key in the PRE-#4810 shape: `[subject_len][subject][predicate]`,
+    /// with no length prefix on the predicate and no object.
+    ///
+    /// Why: the migration tests must be able to write a palace that looks
+    /// exactly like one written by the old code. Nothing in production emits
+    /// this shape any more, which is precisely why the test has to.
+    fn legacy_triple_key(subject: &str, predicate: &str) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&(subject.len() as u16).to_be_bytes());
+        out.extend_from_slice(subject.as_bytes());
+        out.extend_from_slice(predicate.as_bytes());
+        out
+    }
+
+    /// Write `rows` into a fresh redb file using the pre-#4810 key shape and
+    /// leave no `KG_SCHEMA` marker, so the next `KgStoreRedb::open` sees a
+    /// palace that predates the fix.
+    fn seed_legacy_palace(path: &std::path::Path, rows: &[(&str, &str, &str, Option<i64>)]) {
+        use crate::memory_core::store::kg_store::{
+            ACTIVE_SUBJECT_COUNTS, TRIPLES, TripleValue, encode_u64, encode_value,
+        };
+        let db = redb::Database::create(path).expect("create legacy palace");
+        let wtx = db.begin_write().unwrap();
+        {
+            let mut triples = wtx.open_table(TRIPLES).unwrap();
+            let mut counts = wtx.open_table(ACTIVE_SUBJECT_COUNTS).unwrap();
+            let mut per_subject: std::collections::BTreeMap<&str, u64> =
+                std::collections::BTreeMap::new();
+            for (s, p, o, valid_to_ms) in rows {
+                let value = TripleValue {
+                    object: (*o).to_string(),
+                    valid_from_ms: 1_700_000_000_000,
+                    valid_to_ms: *valid_to_ms,
+                    confidence: 1.0,
+                    provenance: None,
+                };
+                let core = legacy_triple_key(s, p);
+                let key = if valid_to_ms.is_some() {
+                    let mut k = Vec::new();
+                    k.extend_from_slice(b"hist:");
+                    k.extend_from_slice(&core);
+                    k.extend_from_slice(&value.valid_from_ms.to_be_bytes());
+                    k
+                } else {
+                    *per_subject.entry(s).or_insert(0) += 1;
+                    core
+                };
+                let bytes = encode_value(&value).unwrap();
+                triples.insert(key.as_slice(), bytes.as_slice()).unwrap();
+            }
+            for (s, n) in per_subject {
+                counts
+                    .insert(s.as_bytes(), encode_u64(n).as_slice())
+                    .unwrap();
+            }
+        }
+        wtx.commit().unwrap();
+        drop(db);
+    }
+
+    /// Assert `backup` is a readable redb image that still holds the row at the
+    /// PRE-migration key — the property that makes it a recovery point, and one
+    /// a byte-count comparison cannot check (the live file grows during open).
+    fn assert_backup_holds_legacy_row(backup: &std::path::Path, subject: &str, predicate: &str) {
+        use crate::memory_core::store::kg_store::TRIPLES;
+        use redb::ReadableDatabase;
+        assert!(backup.is_file(), "backup must be a regular file");
+        let db = redb::Database::create(backup).expect("open backup as redb");
+        let rtx = db.begin_read().unwrap();
+        let triples = rtx.open_table(TRIPLES).unwrap();
+        let key = legacy_triple_key(subject, predicate);
+        assert!(
+            triples.get(key.as_slice()).unwrap().is_some(),
+            "the backup must still carry the pre-migration row"
+        );
+        drop(rtx);
+        drop(db);
+    }
+
+    /// Why (#4810): the defect. `room:General --contains--> drawer:N` keyed on
+    /// `(subject, predicate)` alone, so each new member closed the last one and
+    /// a room of any size reported exactly one drawer. This test FAILS on
+    /// `e2ca949a3`.
+    /// What: three `contains` asserts under one subject; all three must be
+    /// active, and the active counter must agree.
+    #[test]
+    fn assert_multiple_objects_for_multivalued_predicate_all_survive() {
+        let (_d, kg) = open_kg();
+        kg.assert(&t("room:General", "contains", "drawer:a"))
+            .unwrap();
+        kg.assert(&t("room:General", "contains", "drawer:b"))
+            .unwrap();
+        kg.assert(&t("room:General", "contains", "drawer:c"))
+            .unwrap();
+
+        let active = kg.query_active("room:General").unwrap();
+        assert_eq!(active.len(), 3, "every member of the room stays active");
+        let mut objects: Vec<_> = active.iter().map(|x| x.object.as_str()).collect();
+        objects.sort_unstable();
+        assert_eq!(objects, vec!["drawer:a", "drawer:b", "drawer:c"]);
+        assert_eq!(kg.count_active_triples(), 3);
+
+        // Nothing was demoted to history — no object was superseded.
+        let all = kg.dump_all_triples().unwrap();
+        assert_eq!(all.len(), 3, "no history rows for a multi-valued predicate");
+    }
+
+    /// Why (#4810): the other half of the split — a functional predicate must
+    /// keep its one-active-object rule, or `is_alias_for` would accumulate
+    /// every alias a subject ever had and prompt-fact injection would grow
+    /// without bound.
+    /// What: two `is_alias_for` asserts under one subject leave one active row
+    /// carrying the newer object, plus one history row.
+    #[test]
+    fn assert_functional_predicate_still_supersedes() {
+        let (_d, kg) = open_kg();
+        kg.assert(&t("tga", "is_alias_for", "trusty-git-analytics"))
+            .unwrap();
+        kg.assert(&t("tga", "is_alias_for", "trusty-git-analytics-v2"))
+            .unwrap();
+
+        let active = kg.query_active("tga").unwrap();
+        assert_eq!(active.len(), 1, "functional predicate holds one object");
+        assert_eq!(active[0].object, "trusty-git-analytics-v2");
+        assert_eq!(kg.count_active_triples(), 1);
+
+        let all = kg.dump_all_triples().unwrap();
+        assert_eq!(all.len(), 2, "the superseded object is kept as history");
+    }
+
+    /// Why (#4810): re-asserting the SAME triple must stay a re-affirmation —
+    /// a new interval over one row — not an accumulation of duplicates.
+    #[test]
+    fn reasserting_the_same_triple_reaffirms_rather_than_duplicates() {
+        let (_d, kg) = open_kg();
+        kg.assert(&t("room:General", "contains", "drawer:a"))
+            .unwrap();
+        kg.assert(&t("room:General", "contains", "drawer:a"))
+            .unwrap();
+
+        let active = kg.query_active("room:General").unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(kg.count_active_triples(), 1);
+        assert_eq!(kg.dump_all_triples().unwrap().len(), 2, "one history row");
+    }
+
+    /// Why (#4810): `retract(subject, predicate)` kept its two-argument shape,
+    /// so its meaning had to widen from "the active row" to "every active
+    /// row" — otherwise retracting a multi-valued pair would leave the other
+    /// objects live and the caller with no way to reach them.
+    #[test]
+    fn retract_closes_every_object_at_the_pair() {
+        let (_d, kg) = open_kg();
+        for object in ["drawer:a", "drawer:b", "drawer:c"] {
+            kg.assert(&t("room:General", "contains", object)).unwrap();
+        }
+        assert_eq!(kg.retract("room:General", "contains").unwrap(), 3);
+        assert!(kg.query_active("room:General").unwrap().is_empty());
+        assert_eq!(kg.count_active_triples(), 0);
+        // Second retract is a no-op.
+        assert_eq!(kg.retract("room:General", "contains").unwrap(), 0);
+    }
+
+    /// Why (#4810): `delete_by_subject` collects pairs, and one pair can now
+    /// span several rows. Without the dedup it would call `retract` once per
+    /// row and double-count what the first call already closed.
+    #[test]
+    fn cascade_delete_closes_every_object_of_a_multivalued_pair() {
+        let (_d, kg) = open_kg();
+        for object in ["a", "b", "c"] {
+            kg.assert(&t("drawer:x", "mentions", object)).unwrap();
+        }
+        kg.assert(&t("drawer:x", "is_alias_for", "y")).unwrap();
+        assert_eq!(kg.delete_by_subject("drawer:x").unwrap(), 4);
+        assert!(kg.query_active("drawer:x").unwrap().is_empty());
+        assert_eq!(kg.count_active_triples(), 0);
+    }
+
+    /// Why (#4810): the write path reads the `(subject, predicate)` range and
+    /// then mutates it. If two writers could interleave that read-modify-write,
+    /// one object would be lost. redb serialises write transactions, and this
+    /// pins that guarantee to the behaviour that depends on it.
+    /// What: eight threads assert a distinct object under one multi-valued
+    /// pair through separate (cache-shared) handles; all eight must survive.
+    #[test]
+    fn concurrent_asserts_to_one_pair_lose_no_object() {
+        use std::thread;
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("kg.redb");
+        let primary = KgStoreRedb::open(&path).unwrap();
+
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let store = KgStoreRedb::open(&path).unwrap();
+                thread::spawn(move || {
+                    store
+                        .assert(&t("room:General", "contains", &format!("drawer:{i}")))
+                        .expect("concurrent assert");
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("writer thread panicked");
+        }
+
+        let active = primary.query_active("room:General").unwrap();
+        assert_eq!(active.len(), 8, "no concurrent assert overwrote another");
+        assert_eq!(primary.count_active_triples(), 8);
+    }
+
+    /// Why (#4810): a fresh palace has nothing to rewrite but must still record
+    /// which key shape it uses, or every open would re-scan every triple.
+    /// What: a new palace carries the marker; a second open is a no-op and
+    /// leaves no backup behind.
+    #[test]
+    fn migration_stamps_schema_and_is_idempotent() {
+        use crate::memory_core::store::kg_store::{
+            KG_SCHEMA, KG_SCHEMA_TRIPLE_KEY, KG_TRIPLE_KEY_SCHEMA_VERSION, KgSchemaMarker,
+            decode_value,
+        };
+        use redb::ReadableDatabase;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("kg.redb");
+        let read_marker = |p: &std::path::Path| -> Option<u32> {
+            let db = redb::Database::create(p).unwrap();
+            let rtx = db.begin_read().unwrap();
+            let table = rtx.open_table(KG_SCHEMA).unwrap();
+            let out = table.get(KG_SCHEMA_TRIPLE_KEY).unwrap().map(|g| {
+                decode_value::<KgSchemaMarker>(g.value())
+                    .unwrap()
+                    .schema_version
+            });
+            drop(rtx);
+            drop(db);
+            out
+        };
+
+        {
+            let kg = KgStoreRedb::open(&path).unwrap();
+            kg.assert(&t("alice", "knows", "bob")).unwrap();
+        }
+        assert_eq!(read_marker(&path), Some(KG_TRIPLE_KEY_SCHEMA_VERSION));
+
+        // An already-migrated palace is not backed up and not rewritten.
+        {
+            let kg = KgStoreRedb::open(&path).unwrap();
+            assert_eq!(kg.query_active("alice").unwrap().len(), 1);
+        }
+        let backup = dir.path().join("kg.redb.pre-4810.bak");
+        assert!(
+            !backup.exists(),
+            "no backup for a palace with nothing to do"
+        );
+    }
+
+    /// Why (#4810): the whole point of the migration — rows written under the
+    /// old key must be readable, and readable as the facts they were, after
+    /// one open. History rows carry the same key and must move with them.
+    /// What: seeds a legacy palace with two active rows and one closed row —
+    /// note that the legacy key physically CANNOT hold two objects for one
+    /// pair, which is the defect — opens it, and checks every row is
+    /// queryable at its new key and the history survived.
+    #[test]
+    fn migration_rewrites_legacy_keys_and_preserves_history() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("kg.redb");
+        seed_legacy_palace(
+            &path,
+            &[
+                ("room:General", "contains", "drawer:a", None),
+                ("alice", "knows", "bob", None),
+                ("alice", "knows", "carol", Some(1_700_000_100_000)),
+            ],
+        );
+
+        let kg = KgStoreRedb::open(&path).unwrap();
+        let room = kg.query_active("room:General").unwrap();
+        assert_eq!(room.len(), 1);
+        assert_eq!(room[0].object, "drawer:a");
+
+        let alice = kg.query_active("alice").unwrap();
+        assert_eq!(alice.len(), 1);
+        assert_eq!(alice[0].object, "bob");
+
+        // The closed row moved with the active ones.
+        let all = kg.dump_all_triples().unwrap();
+        assert_eq!(all.len(), 3);
+        assert!(
+            all.iter()
+                .any(|x| x.object == "carol" && x.valid_to.is_some())
+        );
+
+        // A new member now joins instead of replacing.
+        kg.assert(&t("room:General", "contains", "drawer:b"))
+            .unwrap();
+        assert_eq!(kg.query_active("room:General").unwrap().len(), 2);
+
+        // The pre-migration image was preserved.
+        let backup = dir.path().join("kg.redb.pre-4810.bak");
+        assert_backup_holds_legacy_row(&backup, "room:General", "contains");
+    }
+
+    /// Why (#4810), the fail-open check: the migration rewrites every triple in
+    /// the palace, so its failure branch is the one that must be reviewable.
+    /// A failed attempt must commit nothing, must not stop the palace opening,
+    /// and must be retried on the next open rather than latched off.
+    /// What: makes the backup step fail by putting a DIRECTORY where the `.bak`
+    /// file belongs — `fs::copy` cannot write over it — then asserts the open
+    /// succeeds, the legacy rows are still on disk untouched, and removing the
+    /// blocker lets the next open migrate them for real.
+    #[test]
+    fn migration_failure_leaves_the_palace_openable_and_retries() {
+        use crate::memory_core::store::kg_store::TRIPLES;
+        use redb::ReadableDatabase;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("kg.redb");
+        seed_legacy_palace(
+            &path,
+            &[
+                ("room:General", "contains", "drawer:a", None),
+                ("room:Other", "contains", "drawer:b", None),
+            ],
+        );
+
+        // Block the backup: a directory at the backup path makes `fs::copy`
+        // fail, so the migration aborts before it opens a write transaction.
+        let backup = dir.path().join("kg.redb.pre-4810.bak");
+        std::fs::create_dir(&backup).unwrap();
+
+        {
+            let kg = KgStoreRedb::open(&path).unwrap();
+            assert!(
+                !kg.is_read_only(),
+                "a failed migration must not degrade the handle"
+            );
+            // Un-migrated rows do not decode under the new key, so queries are
+            // empty. That is the documented degraded state — not data loss.
+            assert!(kg.query_active("room:General").unwrap().is_empty());
+        }
+
+        // Nothing was committed: both legacy rows are still there, byte-shaped
+        // exactly as seeded.
+        {
+            let db = redb::Database::create(&path).unwrap();
+            let rtx = db.begin_read().unwrap();
+            let triples = rtx.open_table(TRIPLES).unwrap();
+            let legacy = legacy_triple_key("room:General", "contains");
+            assert!(
+                triples.get(legacy.as_slice()).unwrap().is_some(),
+                "the failed migration must not have removed the legacy row"
+            );
+            drop(rtx);
+            drop(db);
+        }
+
+        // Unblock and reopen: the migration retries rather than staying off.
+        std::fs::remove_dir(&backup).unwrap();
+        let kg = KgStoreRedb::open(&path).unwrap();
+        assert_eq!(kg.query_active("room:General").unwrap().len(), 1);
+        assert_eq!(
+            kg.query_active("room:Other").unwrap().len(),
+            1,
+            "retry migrated every row, not just the first"
+        );
+        assert_backup_holds_legacy_row(&backup, "room:General", "contains");
+    }
+
+    /// Why (#4810): "do not overwrite a `.bak` that verifies good" has a
+    /// mirror obligation — a `.bak` that does NOT verify must be replaced, or
+    /// a truncated leftover would be trusted as the recovery point.
+    #[test]
+    fn migration_replaces_a_backup_that_does_not_verify() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("kg.redb");
+        seed_legacy_palace(&path, &[("alice", "knows", "bob", None)]);
+
+        let backup = dir.path().join("kg.redb.pre-4810.bak");
+        std::fs::write(&backup, b"truncated").unwrap();
+
+        let kg = KgStoreRedb::open(&path).unwrap();
+        assert_eq!(kg.query_active("alice").unwrap().len(), 1);
+        // The short leftover was replaced by a real pre-migration image.
+        assert_backup_holds_legacy_row(&backup, "alice", "knows");
     }
 }

--- a/crates/trusty-common/src/memory_core/store/kg_redb/write_ops.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/write_ops.rs
@@ -4,7 +4,8 @@
 //! operations keeps each file under the 500-SLOC cap.
 //! What: `impl KgStoreRedb` for `assert`, `retract`, `upsert_drawer`,
 //! `delete_drawer`, `delete_by_subject`, plus free-function helpers used
-//! by `apply_batch` in `import.rs`.
+//! by `apply_batch` in `import.rs`. The drawer-side helpers those two methods
+//! delegate to live in the sibling `drawer_ops` module.
 //! Test: `assert_then_query_returns_triple`, `retract_closes_active_interval`,
 //! `delete_drawer_removes_row`, `cascade_delete_removes_triples_for_subject`.
 
@@ -20,8 +21,9 @@ use redb::{ReadableDatabase, ReadableTable};
 use uuid::Uuid;
 
 use super::super::kg::Triple;
+use super::drawer_ops::{batch_delete_drawer, batch_upsert_drawer};
 use super::store::KgStoreRedb;
-use super::types::{Tbl, decode_drawer_record, drawer_to_record, now_ms};
+use super::types::{Tbl, now_ms};
 
 impl KgStoreRedb {
     /// Assert a triple. If an active row exists for `(subject, predicate)` it
@@ -559,124 +561,4 @@ pub(super) fn batch_retract(
             .context("update count after retract (batch)")?;
     }
     Ok(1)
-}
-
-/// The `fact_key` currently stored on the `DRAWERS` row for `id` (#4884).
-///
-/// Why: index maintenance is a diff, not an overwrite — to drop the entry a
-/// drawer is about to stop owning, the writer must know which slot it owned
-/// before the new record lands. Callers therefore run this BEFORE writing.
-/// What: point-reads the row and decodes it through
-/// [`decode_drawer_record`]'s migration chain. A row that fails every shape is
-/// reported as owning no slot: undecodable rows necessarily predate the field,
-/// and failing the write over one would make a single corrupt drawer block
-/// every unrelated write.
-/// Test: `fact_key_index_follows_the_slot_on_reassignment`,
-/// `clearing_a_fact_key_drops_the_index_entry`.
-fn stored_fact_key(drawers: &Tbl<'_>, id: Uuid) -> Result<Option<String>> {
-    let id_bytes = *id.as_bytes();
-    let Some(guard) = drawers
-        .get(id_bytes.as_slice())
-        .context("read prior drawer row for fact_key index")?
-    else {
-        return Ok(None);
-    };
-    Ok(decode_drawer_record(guard.value())
-        .ok()
-        .and_then(|r| r.fact_key))
-}
-
-/// Release `key` from the slot index, but only if `owner` still holds it
-/// (#4884).
-///
-/// Why: the ownership guard is what makes the index survive reassignment.
-/// Drawer A owns `pr:4818/state`, drawer B takes the slot, then A is deleted —
-/// an unguarded removal would evict B's entry and report a slot as free while a
-/// live drawer occupies it. Checking that the entry still names the drawer
-/// letting go of it makes the stale delete a no-op instead.
-/// What: reads the index at `key`; removes it only when the stored uuid bytes
-/// equal `owner`'s. Absent or differently-owned entries are left alone.
-/// Test: `deleting_a_drawer_that_lost_its_slot_leaves_the_new_owner_indexed`.
-fn release_slot_if_owned_by(by_fact_key: &mut Tbl<'_>, key: &str, owner: Uuid) -> Result<()> {
-    let owned = by_fact_key
-        .get(key.as_bytes())
-        .context("read fact_key index for release")?
-        .is_some_and(|g| g.value() == owner.as_bytes().as_slice());
-    if owned {
-        by_fact_key
-            .remove(key.as_bytes())
-            .context("remove fact_key index entry")?;
-    }
-    Ok(())
-}
-
-/// In-transaction drawer upsert helper.
-///
-/// Why: the single implementation behind both `KgStoreRedb::upsert_drawer` and
-/// `apply_batch`, so the #4884 slot-index maintenance cannot be present in one
-/// path and missing from the other.
-/// What: releases the slot the stored row used to own when the new record names
-/// a different one (or none), writes the record under its UUID key in DRAWERS,
-/// then points `DRAWERS_BY_FACT_KEY` at this drawer for the new key. Writing a
-/// key another drawer already holds moves the index onto the newer drawer —
-/// that is the "one slot, one live fact" shape ADR-0028 D5 needs; retiring the
-/// displaced drawer itself belongs to the Tier C write path, not to storage.
-/// Test: `apply_batch_mixes_drawer_and_triple_ops`,
-/// `fact_key_index_tracks_upsert_and_delete`,
-/// `fact_key_index_follows_the_slot_on_reassignment`.
-pub(super) fn batch_upsert_drawer(
-    drawers: &mut Tbl<'_>,
-    by_fact_key: &mut Tbl<'_>,
-    drawer: &Drawer,
-) -> Result<()> {
-    // #4884: read the prior slot BEFORE overwriting the row — afterwards the
-    // old key is gone and its index entry would be unreachable garbage.
-    let prior = stored_fact_key(drawers, drawer.id)?;
-    if let Some(prev) = prior.as_deref()
-        && drawer.fact_key.as_deref() != Some(prev)
-    {
-        release_slot_if_owned_by(by_fact_key, prev, drawer.id)?;
-    }
-
-    let record = drawer_to_record(drawer);
-    let bytes = encode_value(&record).context("encode drawer record (batch)")?;
-    let id_bytes = *drawer.id.as_bytes();
-    drawers
-        .insert(id_bytes.as_slice(), bytes.as_slice())
-        .context("insert drawer record (batch)")?;
-
-    if let Some(key) = drawer.fact_key.as_deref() {
-        by_fact_key
-            .insert(key.as_bytes(), id_bytes.as_slice())
-            .context("insert fact_key index entry")?;
-    }
-    Ok(())
-}
-
-/// In-transaction drawer delete helper.
-///
-/// Why: the single implementation behind both `KgStoreRedb::delete_drawer` and
-/// `apply_batch`. A delete that removed the row but left the index entry would
-/// leave the occupancy check answering "taken" for a slot whose occupant is
-/// gone — the exact stale-index bug the index is supposed to prevent.
-/// What: releases the deleted drawer's slot (guarded on ownership, so deleting
-/// a drawer that already lost the slot leaves the current owner indexed), then
-/// removes the row keyed by UUID bytes from DRAWERS.
-/// Test: `fact_key_index_tracks_upsert_and_delete`,
-/// `deleting_a_drawer_that_lost_its_slot_leaves_the_new_owner_indexed`.
-pub(super) fn batch_delete_drawer(
-    drawers: &mut Tbl<'_>,
-    by_fact_key: &mut Tbl<'_>,
-    id: Uuid,
-) -> Result<()> {
-    // #4884: same ordering rule as the upsert — the row is the only place the
-    // slot name is recorded, so read it before removing it.
-    if let Some(key) = stored_fact_key(drawers, id)? {
-        release_slot_if_owned_by(by_fact_key, &key, id)?;
-    }
-    let id_bytes = *id.as_bytes();
-    drawers
-        .remove(id_bytes.as_slice())
-        .context("remove drawer record (batch)")?;
-    Ok(())
 }

--- a/crates/trusty-common/src/memory_core/store/kg_redb/write_ops.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/write_ops.rs
@@ -1,23 +1,29 @@
-//! Write methods for `KgStoreRedb` plus in-transaction batch helpers.
+//! Write methods for `KgStoreRedb` plus the in-transaction helpers they and
+//! `apply_batch` share.
 //!
 //! Why: Separating write operations from the struct definition and read
 //! operations keeps each file under the 500-SLOC cap.
 //! What: `impl KgStoreRedb` for `assert`, `retract`, `upsert_drawer`,
-//! `delete_drawer`, `delete_by_subject`, plus free-function helpers used
-//! by `apply_batch` in `import.rs`. The drawer-side helpers those two methods
-//! delegate to live in the sibling `drawer_ops` module.
+//! `delete_drawer`, `delete_by_subject`, plus the free-function helpers
+//! `batch_assert` / `batch_retract` that both the single-op methods and
+//! `apply_batch` in `import.rs` route through. The drawer-side helpers live in
+//! the sibling `drawer_ops` module.
 //! Test: `assert_then_query_returns_triple`, `retract_closes_active_interval`,
-//! `delete_drawer_removes_row`, `cascade_delete_removes_triples_for_subject`.
+//! `assert_multiple_objects_for_multivalued_predicate_all_survive`,
+//! `assert_functional_predicate_still_supersedes`,
+//! `cascade_delete_removes_triples_for_subject`.
 
 use crate::memory_core::palace::Drawer;
 use crate::memory_core::store::kg_store::{
     ACTIVE_SUBJECT_COUNTS, DRAWERS, DRAWERS_BY_FACT_KEY, TRIPLES, TRIPLES_BY_OBJECT,
     TRIPLES_BY_PREDICATE, TripleValue, decode_triple_key, decode_u64, decode_value,
     encode_object_index_key, encode_predicate_index_key, encode_triple_key, encode_u64,
-    encode_value, subject_prefix,
+    encode_value, is_functional_predicate, prefix_range_end, subject_predicate_prefix,
+    subject_prefix,
 };
 use anyhow::{Context, Result};
 use redb::{ReadableDatabase, ReadableTable};
+use std::collections::BTreeSet;
 use uuid::Uuid;
 
 use super::super::kg::Triple;
@@ -26,27 +32,23 @@ use super::store::KgStoreRedb;
 use super::types::{Tbl, now_ms};
 
 impl KgStoreRedb {
-    /// Assert a triple. If an active row exists for `(subject, predicate)` it
-    /// is closed (valid_to = now) and removed from secondary indexes; then the
-    /// new triple is inserted and indexed.
+    /// Assert a triple.
     ///
-    /// Why: Temporal model — facts have intervals. New assertion supersedes
-    /// the prior active row instead of overwriting it, preserving history.
+    /// Why: Temporal model — facts have intervals, so a new assertion closes
+    /// what it supersedes instead of overwriting it. #4810 made *what* it
+    /// supersedes depend on the predicate: a functional predicate (see
+    /// `FUNCTIONAL_PREDICATES`) still allows one active object per subject, but
+    /// every other predicate is multi-valued and a second object joins the
+    /// first rather than replacing it. Before that split, three
+    /// `room:General --contains--> drawer:N` asserts left one row.
     /// What: Single write transaction over TRIPLES + secondary indexes +
-    /// ACTIVE_SUBJECT_COUNTS so the invariant "at most one active row per
-    /// (subject, predicate)" can never be observed broken.
-    /// Test: `assert_then_query_returns_triple`, `assert_supersedes_prior`.
+    /// ACTIVE_SUBJECT_COUNTS, delegating to [`batch_assert`] so the single-op
+    /// and batched paths cannot drift.
+    /// Test: `assert_then_query_returns_triple`,
+    /// `assert_functional_predicate_still_supersedes`,
+    /// `assert_multiple_objects_for_multivalued_predicate_all_survive`.
     pub fn assert(&self, triple: &Triple) -> Result<()> {
         self.check_writable()?;
-        let close_ms = triple.valid_from.timestamp_millis();
-        let new_value = TripleValue {
-            object: triple.object.clone(),
-            valid_from_ms: triple.valid_from.timestamp_millis(),
-            valid_to_ms: triple.valid_to.map(|dt| dt.timestamp_millis()),
-            confidence: triple.confidence,
-            provenance: triple.provenance.clone(),
-        };
-
         let wtx = self.db().begin_write().context("begin assert txn")?;
         {
             let mut triples = wtx.open_table(TRIPLES).context("open triples table")?;
@@ -59,129 +61,34 @@ impl KgStoreRedb {
             let mut counts = wtx
                 .open_table(ACTIVE_SUBJECT_COUNTS)
                 .context("open active_subject_counts table")?;
-
-            let key = encode_triple_key(&triple.subject, &triple.predicate);
-
-            // Look up existing active row at this (subject, predicate). Because
-            // we only ever store one row per (subject, predicate) key (the most
-            // recent), checking by direct key is sufficient.
-            let mut closed_any = false;
-            let prior_opt: Option<TripleValue> = {
-                let existing = triples
-                    .get(key.as_slice())
-                    .context("read existing triple")?;
-                match existing {
-                    Some(g) => Some(decode_value(g.value()).context("decode prior triple")?),
-                    None => None,
-                }
-            };
-            if let Some(prior) = prior_opt {
-                if prior.valid_to_ms.is_none() {
-                    // Active — close it by setting valid_to and writing back.
-                    // But since we're about to overwrite with the new row, we
-                    // only need to drop the secondary index entries and
-                    // decrement the active counter.
-                    let obj_key =
-                        encode_object_index_key(&prior.object, &triple.subject, &triple.predicate);
-                    by_object
-                        .remove(obj_key.as_slice())
-                        .context("remove prior object index")?;
-                    let pred_key = encode_predicate_index_key(&triple.predicate, &triple.subject);
-                    by_predicate
-                        .remove(pred_key.as_slice())
-                        .context("remove prior predicate index")?;
-                    closed_any = true;
-                }
-                // History preservation: write the closed prior row into a
-                // history key. We use a synthetic key suffix so it does not
-                // collide with the active row. Format: `[hist:][orig key]
-                // [valid_from_ms BE]`. This keeps dump_all_triples honest.
-                if prior.valid_to_ms.is_none() {
-                    let mut hist_key = Vec::with_capacity(5 + key.len() + 8);
-                    hist_key.extend_from_slice(b"hist:");
-                    hist_key.extend_from_slice(&key);
-                    hist_key.extend_from_slice(&prior.valid_from_ms.to_be_bytes());
-                    let closed = TripleValue {
-                        valid_to_ms: Some(close_ms),
-                        ..prior
-                    };
-                    let closed_bytes = encode_value(&closed).context("encode closed prior")?;
-                    triples
-                        .insert(hist_key.as_slice(), closed_bytes.as_slice())
-                        .context("insert closed history row")?;
-                }
-            }
-
-            // Insert / overwrite active row.
-            let new_bytes = encode_value(&new_value).context("encode new triple")?;
-            triples
-                .insert(key.as_slice(), new_bytes.as_slice())
-                .context("insert new triple")?;
-
-            // Insert secondary indexes for the new active row (only when it
-            // is itself active — `assert` with `valid_to = Some(_)` would be
-            // a closed-on-arrival row that should not appear in indexes).
-            if new_value.valid_to_ms.is_none() {
-                let obj_key =
-                    encode_object_index_key(&new_value.object, &triple.subject, &triple.predicate);
-                by_object
-                    .insert(obj_key.as_slice(), [].as_slice())
-                    .context("insert new object index")?;
-                let pred_key = encode_predicate_index_key(&triple.predicate, &triple.subject);
-                by_predicate
-                    .insert(pred_key.as_slice(), [].as_slice())
-                    .context("insert new predicate index")?;
-
-                // Maintain count: net change is 0 if we just closed one and
-                // opened one; +1 if there was no prior active row.
-                if !closed_any {
-                    let subj_key = triple.subject.as_bytes();
-                    let prev = counts
-                        .get(subj_key)
-                        .context("read prior count")?
-                        .map(|v| decode_u64(v.value()))
-                        .unwrap_or(0);
-                    let next = prev.saturating_add(1);
-                    counts
-                        .insert(subj_key, encode_u64(next).as_slice())
-                        .context("update active count")?;
-                }
-            } else if closed_any {
-                // Closed-on-arrival row replacing an active one — decrement.
-                let subj_key = triple.subject.as_bytes();
-                let prev = counts
-                    .get(subj_key)
-                    .context("read prior count")?
-                    .map(|v| decode_u64(v.value()))
-                    .unwrap_or(0);
-                let next = prev.saturating_sub(1);
-                if next == 0 {
-                    counts.remove(subj_key).context("remove zero count")?;
-                } else {
-                    counts
-                        .insert(subj_key, encode_u64(next).as_slice())
-                        .context("update active count")?;
-                }
-            }
+            batch_assert(
+                &mut triples,
+                &mut by_object,
+                &mut by_predicate,
+                &mut counts,
+                triple,
+            )?;
         }
         wtx.commit().context("commit assert txn")?;
         Ok(())
     }
 
-    /// Close the active triple for `(subject, predicate)` without inserting a
-    /// replacement. Returns the number of rows closed (0 or 1).
+    /// Close every active triple at `(subject, predicate)` without inserting a
+    /// replacement. Returns how many rows were closed.
     ///
-    /// Why: `assert` always closes-and-replaces; retract is the way to say
-    /// "this fact is no longer true and has no successor" — used by
-    /// `remove_prompt_fact`.
-    /// What: Reads the row at `(subject, predicate)`. If active, writes a
-    /// history copy with `valid_to = now`, drops the active row from the
-    /// primary table, removes secondary indexes, and decrements the count.
-    /// Test: `retract_closes_active_interval`.
+    /// Why: `assert` closes-and-replaces; retract is the way to say "this is no
+    /// longer true and has no successor" — used by `remove_prompt_fact`.
+    /// #4810 kept the two-argument signature and widened its meaning from "the
+    /// active row" to "every active row", which is behaviour-preserving for
+    /// every existing caller: before the object joined the key there could
+    /// only ever be one. A three-argument `retract_triple` is a deliberate
+    /// non-goal — no caller wants to retract one object of a set today, and
+    /// adding the surface unused would fix a shape nothing has exercised.
+    /// What: Delegates to [`batch_retract`] inside one write transaction.
+    /// Test: `retract_closes_active_interval`,
+    /// `retract_closes_every_object_at_the_pair`.
     pub fn retract(&self, subject: &str, predicate: &str) -> Result<usize> {
         self.check_writable()?;
-        let key = encode_triple_key(subject, predicate);
-        let close_ms = now_ms();
         let wtx = self.db().begin_write().context("begin retract txn")?;
         let closed;
         {
@@ -195,69 +102,14 @@ impl KgStoreRedb {
             let mut counts = wtx
                 .open_table(ACTIVE_SUBJECT_COUNTS)
                 .context("open active_subject_counts table")?;
-
-            let prior_opt: Option<TripleValue> = {
-                let existing = triples
-                    .get(key.as_slice())
-                    .context("lookup active triple for retract")?;
-                match existing {
-                    Some(g) => Some(decode_value(g.value()).context("decode prior for retract")?),
-                    None => None,
-                }
-            };
-            match prior_opt {
-                Some(prior) => {
-                    if prior.valid_to_ms.is_none() {
-                        // Move to history.
-                        let mut hist_key = Vec::with_capacity(5 + key.len() + 8);
-                        hist_key.extend_from_slice(b"hist:");
-                        hist_key.extend_from_slice(&key);
-                        hist_key.extend_from_slice(&prior.valid_from_ms.to_be_bytes());
-                        let closed_v = TripleValue {
-                            valid_to_ms: Some(close_ms),
-                            ..prior.clone()
-                        };
-                        let bytes = encode_value(&closed_v).context("encode retract history")?;
-                        triples
-                            .insert(hist_key.as_slice(), bytes.as_slice())
-                            .context("insert retract history row")?;
-                        // Remove active row + indexes.
-                        triples
-                            .remove(key.as_slice())
-                            .context("remove active row for retract")?;
-                        let obj_key = encode_object_index_key(&prior.object, subject, predicate);
-                        by_object
-                            .remove(obj_key.as_slice())
-                            .context("remove object index for retract")?;
-                        let pred_key = encode_predicate_index_key(predicate, subject);
-                        by_predicate
-                            .remove(pred_key.as_slice())
-                            .context("remove predicate index for retract")?;
-                        // Decrement count.
-                        let subj_key = subject.as_bytes();
-                        let prev = counts
-                            .get(subj_key)
-                            .context("read prior count for retract")?
-                            .map(|v| decode_u64(v.value()))
-                            .unwrap_or(0);
-                        let next = prev.saturating_sub(1);
-                        if next == 0 {
-                            counts.remove(subj_key).context("remove zero count")?;
-                        } else {
-                            counts
-                                .insert(subj_key, encode_u64(next).as_slice())
-                                .context("update count after retract")?;
-                        }
-                        closed = 1;
-                    } else {
-                        // Row exists but is already closed — nothing to do.
-                        closed = 0;
-                    }
-                }
-                None => {
-                    closed = 0;
-                }
-            }
+            closed = batch_retract(
+                &mut triples,
+                &mut by_object,
+                &mut by_predicate,
+                &mut counts,
+                subject,
+                predicate,
+            )?;
         }
         wtx.commit().context("commit retract txn")?;
         Ok(closed)
@@ -317,17 +169,18 @@ impl KgStoreRedb {
     /// forgotten, every triple extracted from it (identified by the
     /// `drawer:<uuid>` subject prefix) must be removed so the KG does not
     /// accumulate orphaned edges.
-    /// What: Performs a prefix scan over TRIPLES using `subject_prefix(subject)`,
-    /// collects every active (non-history, non-closed) `(subject, predicate)`
-    /// pair, and retracts each via the existing `retract` path so secondary
-    /// indexes and the active count table are kept consistent. Returns the
-    /// number of active rows closed.
-    /// Test: `cascade_delete_removes_triples_for_subject` in this module's
-    /// test section.
+    /// What: Prefix-scans TRIPLES with `subject_prefix(subject)`, collects the
+    /// DISTINCT active `(subject, predicate)` pairs — #4810 put the object in
+    /// the key, so one pair can now span several rows and retracting per row
+    /// would call `retract` N times for the N objects its first call already
+    /// closed — and retracts each pair. Returns the number of rows closed.
+    /// Test: `cascade_delete_removes_triples_for_subject`,
+    /// `cascade_delete_closes_every_object_of_a_multivalued_pair`.
     pub fn delete_by_subject(&self, subject: &str) -> Result<usize> {
         self.check_writable()?;
         let prefix = subject_prefix(subject);
-        let mut to_retract: Vec<(String, String)> = Vec::new();
+        let end = prefix_range_end(&prefix);
+        let mut to_retract: BTreeSet<(String, String)> = BTreeSet::new();
         {
             let rtx = self
                 .db()
@@ -336,8 +189,6 @@ impl KgStoreRedb {
             let triples = rtx
                 .open_table(TRIPLES)
                 .context("open triples for delete_by_subject scan")?;
-            let mut end = prefix.clone();
-            end.push(0xFF);
             let range = triples
                 .range::<&[u8]>(prefix.as_slice()..end.as_slice())
                 .context("range scan for delete_by_subject")?;
@@ -352,8 +203,8 @@ impl KgStoreRedb {
                     // Already closed — skip.
                     continue;
                 }
-                if let Some((s, p)) = decode_triple_key(k.value()) {
-                    to_retract.push((s, p));
+                if let Some((s, p, _o)) = decode_triple_key(k.value()) {
+                    to_retract.insert((s, p));
                 }
             }
         }
@@ -372,25 +223,169 @@ impl KgStoreRedb {
 
 // ----- in-transaction helpers shared by the single-op and batch paths -----
 //
-// Why: The single-op `assert` / `retract` / drawer methods already
-// implement the correct semantics inside their own `begin_write` block.
-// To share that logic with `apply_batch` without duplicating it, we lift
-// the per-op body into a free function that takes already-opened tables.
-// This keeps the txn boundary explicit (one `begin_write` per batch) and
-// avoids logic drift between the two paths. The single-op methods could
-// be migrated to call these helpers in a follow-up; for now we accept
-// the duplication to keep the diff minimal.
+// Why: `assert` and `retract` need identical semantics whether they arrive
+// one at a time or inside an `apply_batch` transaction. Both entry points call
+// the same free function over already-opened tables, so the txn boundary stays
+// explicit (one `begin_write` per call or per batch) and the two paths cannot
+// drift. #4810 collapsed the last of a copy-paste duplication here: the
+// single-op methods used to carry their own copy of this logic.
 
-/// In-transaction assert helper; mirrors `KgStoreRedb::assert`.
+/// Every ACTIVE row at `(subject, predicate)`, whatever the object (#4810).
 ///
-/// Why: Lets `apply_batch` perform N asserts inside one write txn.
-/// What: Same close-prior + insert-new + index-maintenance logic that
-/// the single-op `assert` runs, but takes already-opened tables.
-/// Test: `apply_batch_groups_asserts_into_single_commit`.
-pub(super) fn batch_assert(
-    triples: &mut Tbl<'_>,
-    by_object: &mut Tbl<'_>,
-    by_predicate: &mut Tbl<'_>,
+/// Why: with the object in the key, "what is currently asserted here?" is a
+/// range question, not a point read. Both `batch_assert` and `batch_retract`
+/// ask it, and neither may assume the answer has exactly one element — that
+/// assumption is what the ticket is about.
+/// What: prefix range scan over TRIPLES bounded by
+/// [`subject_predicate_prefix`], skipping `hist:` rows and rows already closed.
+/// Returns owned keys so the caller can mutate the table afterwards.
+/// Test: `assert_multiple_objects_for_multivalued_predicate_all_survive`.
+fn active_rows_for_pair(
+    triples: &Tbl<'_>,
+    subject: &str,
+    predicate: &str,
+) -> Result<Vec<(Vec<u8>, TripleValue)>> {
+    let prefix = subject_predicate_prefix(subject, predicate);
+    let end = prefix_range_end(&prefix);
+    let mut out = Vec::new();
+    let range = triples
+        .range::<&[u8]>(prefix.as_slice()..end.as_slice())
+        .context("range scan for (subject, predicate)")?;
+    for entry in range {
+        let (k, v) = entry.context("read row in (subject, predicate) scan")?;
+        let key = k.value().to_vec();
+        if key.starts_with(b"hist:") {
+            continue;
+        }
+        let value: TripleValue =
+            decode_value(v.value()).context("decode triple in (subject, predicate) scan")?;
+        if value.valid_to_ms.is_some() {
+            continue;
+        }
+        out.push((key, value));
+    }
+    Ok(out)
+}
+
+/// The three tables a triple write mutates together.
+///
+/// Why: `close_active_row` needs all three, and threading them as separate
+/// parameters alongside the row's own identity pushed it past clippy's
+/// argument ceiling. Grouping them also names the real unit — a triple's
+/// primary row and its two indexes move as one or the invariant breaks.
+/// What: borrowed handles into the caller's open write transaction.
+struct TripleTables<'a, 'txn> {
+    triples: &'a mut Tbl<'txn>,
+    by_object: &'a mut Tbl<'txn>,
+    by_predicate: &'a mut Tbl<'txn>,
+}
+
+/// Close one active row: copy it to history, drop it, drop its index entries.
+///
+/// Why: the close half of both `assert` (supersede) and `retract` (no
+/// successor). Keeping it in one place is what makes "closing a row" mean the
+/// same three mutations everywhere.
+/// What: writes `hist:<key><valid_from_ms BE>` carrying the row with
+/// `valid_to = close_ms`, removes the active row, and removes its
+/// `TRIPLES_BY_OBJECT` / `TRIPLES_BY_PREDICATE` entries. The caller owns the
+/// `ACTIVE_SUBJECT_COUNTS` adjustment because it batches several closes into
+/// one net delta.
+/// Test: `assert_supersedes_prior`, `retract_closes_active_interval`.
+fn close_active_row(
+    tables: &mut TripleTables<'_, '_>,
+    key: &[u8],
+    prior: &TripleValue,
+    subject: &str,
+    predicate: &str,
+    close_ms: i64,
+) -> Result<()> {
+    let mut hist_key = Vec::with_capacity(5 + key.len() + 8);
+    hist_key.extend_from_slice(b"hist:");
+    hist_key.extend_from_slice(key);
+    hist_key.extend_from_slice(&prior.valid_from_ms.to_be_bytes());
+    let closed = TripleValue {
+        valid_to_ms: Some(close_ms),
+        ..prior.clone()
+    };
+    let closed_bytes = encode_value(&closed).context("encode closed prior row")?;
+    tables
+        .triples
+        .insert(hist_key.as_slice(), closed_bytes.as_slice())
+        .context("insert closed history row")?;
+    tables
+        .triples
+        .remove(key)
+        .context("remove closed active row")?;
+
+    let obj_key = encode_object_index_key(&prior.object, subject, predicate);
+    tables
+        .by_object
+        .remove(obj_key.as_slice())
+        .context("remove object index for closed row")?;
+    let pred_key = encode_predicate_index_key(predicate, subject, &prior.object);
+    tables
+        .by_predicate
+        .remove(pred_key.as_slice())
+        .context("remove predicate index for closed row")?;
+    Ok(())
+}
+
+/// Apply a net change to `subject`'s active-triple counter.
+///
+/// Why: an assert can close several rows and open one in the same call, so the
+/// counter moves by a net delta rather than a fixed ±1. Doing the arithmetic
+/// once here also keeps the "drop the row at zero" rule in one place.
+/// What: reads the current count, applies `delta` saturating, and either
+/// removes the row (at zero) or writes the new value. `delta == 0` is a no-op.
+/// Test: `count_active_triples_returns_live_only`,
+/// `assert_multiple_objects_for_multivalued_predicate_all_survive`.
+fn adjust_active_count(counts: &mut Tbl<'_>, subject: &str, delta: i64) -> Result<()> {
+    if delta == 0 {
+        return Ok(());
+    }
+    let subj_key = subject.as_bytes();
+    let prev = counts
+        .get(subj_key)
+        .context("read active count")?
+        .map(|v| decode_u64(v.value()))
+        .unwrap_or(0);
+    let next = if delta > 0 {
+        prev.saturating_add(delta.unsigned_abs())
+    } else {
+        prev.saturating_sub(delta.unsigned_abs())
+    };
+    if next == 0 {
+        counts.remove(subj_key).context("remove zero count")?;
+    } else {
+        counts
+            .insert(subj_key, encode_u64(next).as_slice())
+            .context("update active count")?;
+    }
+    Ok(())
+}
+
+/// In-transaction assert; the single implementation behind `KgStoreRedb::assert`
+/// and `apply_batch`'s `Assert` op.
+///
+/// Why: see [`KgStoreRedb::assert`]. #4810: which prior rows a new assertion
+/// closes is a property of the predicate, not a fixed "the one row at this
+/// key".
+/// What: scans the `(subject, predicate)` prefix for active rows. For a
+/// functional predicate it closes EVERY one it finds — plural, because a
+/// palace migrated from the old key, or one whose predicate only just joined
+/// the functional list, can legitimately hold more than one. For a
+/// multi-valued predicate it closes only the row at this exact
+/// `(subject, predicate, object)`, which makes a repeat assertion a
+/// re-affirmation (new interval, same fact) and a different object an addition.
+/// Then it inserts the new row, indexes it when it is itself active, and moves
+/// the active counter by the net delta.
+/// Test: `apply_batch_groups_asserts_into_single_commit`,
+/// `assert_functional_predicate_still_supersedes`,
+/// `assert_multiple_objects_for_multivalued_predicate_all_survive`.
+pub(super) fn batch_assert<'txn>(
+    triples: &mut Tbl<'txn>,
+    by_object: &mut Tbl<'txn>,
+    by_predicate: &mut Tbl<'txn>,
     counts: &mut Tbl<'_>,
     triple: &Triple,
 ) -> Result<()> {
@@ -402,163 +397,89 @@ pub(super) fn batch_assert(
         confidence: triple.confidence,
         provenance: triple.provenance.clone(),
     };
-    let key = encode_triple_key(&triple.subject, &triple.predicate);
+    let key = encode_triple_key(&triple.subject, &triple.predicate, &triple.object);
+    let functional = is_functional_predicate(&triple.predicate);
 
-    let mut closed_any = false;
-    let prior_opt: Option<TripleValue> = {
-        let existing = triples
-            .get(key.as_slice())
-            .context("read existing triple (batch)")?;
-        match existing {
-            Some(g) => Some(decode_value(g.value()).context("decode prior triple (batch)")?),
-            None => None,
-        }
+    let prior_rows = active_rows_for_pair(triples, &triple.subject, &triple.predicate)?;
+    let mut tables = TripleTables {
+        triples,
+        by_object,
+        by_predicate,
     };
-    if let Some(prior) = prior_opt
-        && prior.valid_to_ms.is_none()
-    {
-        let obj_key = encode_object_index_key(&prior.object, &triple.subject, &triple.predicate);
-        by_object
-            .remove(obj_key.as_slice())
-            .context("remove prior object index (batch)")?;
-        let pred_key = encode_predicate_index_key(&triple.predicate, &triple.subject);
-        by_predicate
-            .remove(pred_key.as_slice())
-            .context("remove prior predicate index (batch)")?;
-        closed_any = true;
-
-        let mut hist_key = Vec::with_capacity(5 + key.len() + 8);
-        hist_key.extend_from_slice(b"hist:");
-        hist_key.extend_from_slice(&key);
-        hist_key.extend_from_slice(&prior.valid_from_ms.to_be_bytes());
-        let closed = TripleValue {
-            valid_to_ms: Some(close_ms),
-            ..prior
-        };
-        let closed_bytes = encode_value(&closed).context("encode closed prior (batch)")?;
-        triples
-            .insert(hist_key.as_slice(), closed_bytes.as_slice())
-            .context("insert closed history row (batch)")?;
+    let mut closed: i64 = 0;
+    for (prior_key, prior) in prior_rows {
+        // #4810: a functional predicate supersedes every object; a
+        // multi-valued one supersedes only its own object's prior interval.
+        if !functional && prior_key != key {
+            continue;
+        }
+        close_active_row(
+            &mut tables,
+            &prior_key,
+            &prior,
+            &triple.subject,
+            &triple.predicate,
+            close_ms,
+        )?;
+        closed += 1;
     }
 
-    let new_bytes = encode_value(&new_value).context("encode new triple (batch)")?;
-    triples
+    let new_bytes = encode_value(&new_value).context("encode new triple")?;
+    tables
+        .triples
         .insert(key.as_slice(), new_bytes.as_slice())
-        .context("insert new triple (batch)")?;
+        .context("insert new triple")?;
 
+    // Index the new row only when it is itself active — an assert carrying
+    // `valid_to = Some(_)` is closed on arrival and must not appear in an index
+    // that means "currently true".
+    let mut opened: i64 = 0;
     if new_value.valid_to_ms.is_none() {
         let obj_key =
             encode_object_index_key(&new_value.object, &triple.subject, &triple.predicate);
-        by_object
+        tables
+            .by_object
             .insert(obj_key.as_slice(), [].as_slice())
-            .context("insert new object index (batch)")?;
-        let pred_key = encode_predicate_index_key(&triple.predicate, &triple.subject);
-        by_predicate
+            .context("insert new object index")?;
+        let pred_key =
+            encode_predicate_index_key(&triple.predicate, &triple.subject, &new_value.object);
+        tables
+            .by_predicate
             .insert(pred_key.as_slice(), [].as_slice())
-            .context("insert new predicate index (batch)")?;
-        if !closed_any {
-            let subj_key = triple.subject.as_bytes();
-            let prev = counts
-                .get(subj_key)
-                .context("read prior count (batch)")?
-                .map(|v| decode_u64(v.value()))
-                .unwrap_or(0);
-            let next = prev.saturating_add(1);
-            counts
-                .insert(subj_key, encode_u64(next).as_slice())
-                .context("update active count (batch)")?;
-        }
-    } else if closed_any {
-        let subj_key = triple.subject.as_bytes();
-        let prev = counts
-            .get(subj_key)
-            .context("read prior count for closed-on-arrival (batch)")?
-            .map(|v| decode_u64(v.value()))
-            .unwrap_or(0);
-        let next = prev.saturating_sub(1);
-        if next == 0 {
-            counts
-                .remove(subj_key)
-                .context("remove zero count (batch)")?;
-        } else {
-            counts
-                .insert(subj_key, encode_u64(next).as_slice())
-                .context("update active count (batch)")?;
-        }
+            .context("insert new predicate index")?;
+        opened = 1;
     }
-    Ok(())
+    adjust_active_count(counts, &triple.subject, opened - closed)
 }
 
-/// In-transaction retract helper; mirrors `KgStoreRedb::retract`.
+/// In-transaction retract; the single implementation behind
+/// `KgStoreRedb::retract` and `apply_batch`'s `Retract` op.
 ///
-/// Why: Lets `apply_batch` perform a retract inside one write txn.
-/// What: Same move-to-history + index-removal logic as the single-op
-/// `retract`, but takes already-opened tables.
-/// Test: `apply_batch_groups_asserts_into_single_commit` (Retract variant).
-pub(super) fn batch_retract(
-    triples: &mut Tbl<'_>,
-    by_object: &mut Tbl<'_>,
-    by_predicate: &mut Tbl<'_>,
+/// Why: see [`KgStoreRedb::retract`].
+/// What: closes every active row at `(subject, predicate)` and decrements the
+/// active counter by that many. Returns the number closed; `0` when the pair
+/// has no active row.
+/// Test: `apply_batch_groups_asserts_into_single_commit` (Retract variant),
+/// `retract_closes_every_object_at_the_pair`.
+pub(super) fn batch_retract<'txn>(
+    triples: &mut Tbl<'txn>,
+    by_object: &mut Tbl<'txn>,
+    by_predicate: &mut Tbl<'txn>,
     counts: &mut Tbl<'_>,
     subject: &str,
     predicate: &str,
 ) -> Result<usize> {
-    let key = encode_triple_key(subject, predicate);
     let close_ms = now_ms();
-    let prior_opt: Option<TripleValue> = {
-        let existing = triples
-            .get(key.as_slice())
-            .context("lookup active triple for retract (batch)")?;
-        match existing {
-            Some(g) => Some(decode_value(g.value()).context("decode prior for retract (batch)")?),
-            None => None,
-        }
+    let active = active_rows_for_pair(triples, subject, predicate)?;
+    let mut tables = TripleTables {
+        triples,
+        by_object,
+        by_predicate,
     };
-    let Some(prior) = prior_opt else {
-        return Ok(0);
-    };
-    if prior.valid_to_ms.is_some() {
-        return Ok(0);
+    for (key, prior) in &active {
+        close_active_row(&mut tables, key, prior, subject, predicate, close_ms)?;
     }
-
-    let mut hist_key = Vec::with_capacity(5 + key.len() + 8);
-    hist_key.extend_from_slice(b"hist:");
-    hist_key.extend_from_slice(&key);
-    hist_key.extend_from_slice(&prior.valid_from_ms.to_be_bytes());
-    let closed_v = TripleValue {
-        valid_to_ms: Some(close_ms),
-        ..prior.clone()
-    };
-    let bytes = encode_value(&closed_v).context("encode retract history (batch)")?;
-    triples
-        .insert(hist_key.as_slice(), bytes.as_slice())
-        .context("insert retract history row (batch)")?;
-    triples
-        .remove(key.as_slice())
-        .context("remove active row for retract (batch)")?;
-    let obj_key = encode_object_index_key(&prior.object, subject, predicate);
-    by_object
-        .remove(obj_key.as_slice())
-        .context("remove object index for retract (batch)")?;
-    let pred_key = encode_predicate_index_key(predicate, subject);
-    by_predicate
-        .remove(pred_key.as_slice())
-        .context("remove predicate index for retract (batch)")?;
-    let subj_key = subject.as_bytes();
-    let prev = counts
-        .get(subj_key)
-        .context("read prior count for retract (batch)")?
-        .map(|v| decode_u64(v.value()))
-        .unwrap_or(0);
-    let next = prev.saturating_sub(1);
-    if next == 0 {
-        counts
-            .remove(subj_key)
-            .context("remove zero count (batch)")?;
-    } else {
-        counts
-            .insert(subj_key, encode_u64(next).as_slice())
-            .context("update count after retract (batch)")?;
-    }
-    Ok(1)
+    let closed = active.len();
+    adjust_active_count(counts, subject, -(closed as i64))?;
+    Ok(closed)
 }

--- a/crates/trusty-common/src/memory_core/store/kg_store.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_store.rs
@@ -12,10 +12,17 @@ use serde::{Deserialize, Serialize};
 /// Primary triple store.
 ///
 /// Why: Composite key encoding allows efficient range scans by subject prefix
-///      while preserving Ord semantics for redb's BTreeMap-backed tables.
-/// What: Key = `[subject_len: u16 BE][subject bytes][predicate bytes]`.
-///       Value = postcard-encoded [`TripleValue`].
-/// Test: See `round_trip_triple_key` and `subject_prefix_range_simulation`.
+///      while preserving Ord semantics for redb's BTreeMap-backed tables. The
+///      object is PART of the key (#4810): keying on `(subject, predicate)`
+///      alone meant `room:General --contains--> drawer:X` held one row no
+///      matter how many drawers the room contained, and every further member
+///      silently closed its predecessor.
+/// What: Key = `[subject_len: u16 BE][subject][predicate_len: u16 BE]
+///       [predicate][object bytes]`. Value = postcard-encoded [`TripleValue`],
+///       which still carries the object — the key copy exists to make rows
+///       distinct, the value stays the authoritative read.
+/// Test: See `round_trip_triple_key`, `subject_prefix_range_simulation`, and
+///       `subject_predicate_prefix_excludes_a_longer_predicate`.
 pub const TRIPLES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("triples");
 
 /// Reverse index: object → (subject+predicate key) for O(degree) reverse lookup.
@@ -29,10 +36,16 @@ pub const TRIPLES_BY_OBJECT: TableDefinition<&[u8], &[u8]> =
 
 /// Predicate index for queries like "all triples with predicate P".
 ///
-/// Why: Predicate-first range scans (e.g. all `created_by` edges).
-/// What: Key = `[predicate_len: u16 BE][predicate bytes][subject_len: u16 BE][subject bytes]`.
-///       Value = empty `&[u8]`.
-/// Test: Range-scan simulation in `predicate_index_key_orders_by_predicate`.
+/// Why: Predicate-first range scans (e.g. all `created_by` edges). It carries
+///      the object as of #4810 for the same reason [`TRIPLES`] does: without
+///      it, two active rows sharing `(subject, predicate)` produce ONE index
+///      entry, and retracting either would evict the other's. No reader
+///      consumes this table today, which is exactly why the fix belongs
+///      here — a known-broken index is not something to ship forward.
+/// What: Key = `[predicate_len: u16 BE][predicate][subject_len: u16 BE]
+///       [subject][object bytes]`. Value = empty `&[u8]`.
+/// Test: Range-scan simulation in `predicate_index_key_orders_by_predicate`,
+///       plus `predicate_index_key_separates_objects`.
 pub const TRIPLES_BY_PREDICATE: TableDefinition<&[u8], &[u8]> =
     TableDefinition::new("triples_by_predicate");
 
@@ -203,6 +216,94 @@ pub const VECTOR_ID_SEQ: TableDefinition<&str, u64> = TableDefinition::new("vect
 /// The only key stored in [`VECTOR_ID_SEQ`].
 pub const NEXT_VECTOR_ID: &str = "next_vector_id";
 
+/// Triple-storage schema marker (#4810).
+///
+/// Why: the #4810 key widening is an on-disk format change, and the migration
+/// that performs it must be able to tell a migrated palace from one that has
+/// never been touched. It cannot infer that from the rows: a two-component key
+/// and a three-component key are both just bytes, and guessing wrong either
+/// re-migrates already-correct rows or leaves broken ones alone. A marker table
+/// makes the question a point read. Mirrors `RoomSchemaMarker` /
+/// `WingSchemaMarker`, with one difference — those record which shape wrote the
+/// rows, whereas this one GATES a rewrite, so it is written in the same
+/// transaction as that rewrite.
+/// What: Single-row table. Key = [`KG_SCHEMA_TRIPLE_KEY`], value =
+/// postcard-encoded [`KgSchemaMarker`]. A palace with no row predates #4810.
+/// Test: `store::kg_redb::tests::migration_stamps_schema_and_is_idempotent`.
+pub const KG_SCHEMA: TableDefinition<&str, &[u8]> = TableDefinition::new("kg_schema");
+
+/// The only key stored in [`KG_SCHEMA`] today.
+pub const KG_SCHEMA_TRIPLE_KEY: &str = "triple_key";
+
+/// Current triple-key schema version — 1 is the `(subject, predicate, object)`
+/// key introduced by #4810. Version 0 (no marker row) is the old
+/// `(subject, predicate)` key.
+pub const KG_TRIPLE_KEY_SCHEMA_VERSION: u32 = 1;
+
+/// Value stored under [`KG_SCHEMA_TRIPLE_KEY`].
+///
+/// Why/What: mirrors `RoomSchemaMarker` — a one-field postcard record so the
+/// on-disk triple-key shape is self-describing.
+/// Test: `store::kg_redb::tests::migration_stamps_schema_and_is_idempotent`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct KgSchemaMarker {
+    pub schema_version: u32,
+}
+
+/// Predicates that hold at most ONE active object per subject (#4810).
+///
+/// Why: this list is INVERTED on purpose — multi-valued is the default and
+/// anything absent from it keeps every object asserted against it. The two
+/// failure modes are not symmetric. Forgetting to list a multi-valued
+/// predicate costs silent data loss: that is precisely the #4810 defect, where
+/// `room:General --contains--> drawer:X` overwrote the room's entire
+/// membership on every new drawer. Forgetting to list a functional one costs
+/// one extra queryable row that a reader can see and a human can retract.
+/// Cheap-and-visible beats silent-and-gone, so the default falls that way.
+/// What: a sorted static slice; [`is_functional_predicate`] is a linear scan
+/// over it. The first four entries are trusty-memory's ADR-0028 `HOT_PREDICATES`
+/// (`is_alias_for`, `has_convention`, `is_fact`, `is_shorthand_for`); the rest
+/// are single-valued attributes minted by the bootstrap scanner and the
+/// supersession machinery.
+///
+/// `has_language` is deliberately EXCLUDED even though a project usually has
+/// one primary language: `scan_cargo_toml` and `scan_package_json` derive their
+/// subject independently from their own manifest, so a polyglot repo whose
+/// `Cargo.toml` and `package.json` agree on the package name asserts two
+/// `has_language` triples under one subject. Marking it functional would make
+/// whichever scanner ran second silently erase the other's language.
+/// Test: `functional_predicates_are_sorted_and_unique`,
+/// `is_functional_predicate_defaults_to_multi_valued`.
+pub const FUNCTIONAL_PREDICATES: &[&str] = &[
+    "alias_of",
+    "bootstrapped_at",
+    "created_at",
+    "has_convention",
+    "has_description",
+    "has_edition",
+    "has_module_path",
+    "has_rust_version",
+    "has_version",
+    "is_alias_for",
+    "is_fact",
+    "is_shorthand_for",
+    "requires_python",
+    "source_repo",
+    "superseded_by",
+];
+
+/// Whether asserting `predicate` supersedes the subject's prior object.
+///
+/// Why: the write path branches on this — a functional predicate closes every
+/// active row at `(subject, predicate)` before inserting, a multi-valued one
+/// adds a row alongside them.
+/// What: linear scan over [`FUNCTIONAL_PREDICATES`]; unlisted means
+/// multi-valued.
+/// Test: `is_functional_predicate_defaults_to_multi_valued`.
+pub fn is_functional_predicate(predicate: &str) -> bool {
+    FUNCTIONAL_PREDICATES.contains(&predicate)
+}
+
 /// Chat-session store (for the trusty-memory web UI's chat panel).
 ///
 /// Why: Each chat session is keyed by a UUID string and carries a small
@@ -280,25 +381,63 @@ pub struct DrawerRecord {
 
 /// Why: redb requires Ord-preserving byte keys for range scans. Composite
 ///      string keys are encoded with a u16 BE length prefix per leading
-///      component so prefix-based range scans (`subject..`) work correctly.
-/// What: Encodes `(subject, predicate)` → `Vec<u8>` for TRIPLES table lookup.
-/// Test: `round_trip_triple_key`.
-pub fn encode_triple_key(subject: &str, predicate: &str) -> Vec<u8> {
+///      component so prefix-based range scans (`subject..`, `(subject,
+///      predicate)..`) work correctly. #4810 added the object as the trailing
+///      component so two objects under one `(subject, predicate)` occupy two
+///      rows instead of overwriting each other.
+/// What: Encodes `(subject, predicate, object)` → `Vec<u8>` for TRIPLES table
+///       lookup. The object needs no length prefix — it is the last component.
+/// Test: `round_trip_triple_key`, `triple_key_separates_objects`.
+pub fn encode_triple_key(subject: &str, predicate: &str, object: &str) -> Vec<u8> {
     let s = subject.as_bytes();
     let p = predicate.as_bytes();
-    let mut out = Vec::with_capacity(2 + s.len() + p.len());
+    let o = object.as_bytes();
+    let mut out = Vec::with_capacity(4 + s.len() + p.len() + o.len());
     out.extend_from_slice(&(s.len() as u16).to_be_bytes());
     out.extend_from_slice(s);
+    out.extend_from_slice(&(p.len() as u16).to_be_bytes());
     out.extend_from_slice(p);
+    out.extend_from_slice(o);
     out
 }
 
 /// Why: Round-trip decode for diagnostic/debug paths and tests.
-/// What: Splits an encoded triple key back into `(subject, predicate)`.
-///       Returns `None` if the key is malformed (length prefix exceeds bytes
-///       remaining or interior bytes are not valid UTF-8).
-/// Test: `round_trip_triple_key`.
-pub fn decode_triple_key(bytes: &[u8]) -> Option<(String, String)> {
+/// What: Splits an encoded triple key back into `(subject, predicate, object)`.
+///       Returns `None` if the key is malformed (a length prefix exceeds the
+///       bytes remaining, or an interior span is not valid UTF-8).
+/// Test: `round_trip_triple_key`, `decode_triple_key_rejects_truncated`.
+pub fn decode_triple_key(bytes: &[u8]) -> Option<(String, String, String)> {
+    if bytes.len() < 2 {
+        return None;
+    }
+    let s_len = u16::from_be_bytes([bytes[0], bytes[1]]) as usize;
+    let rest = &bytes[2..];
+    if rest.len() < s_len {
+        return None;
+    }
+    let subject = std::str::from_utf8(&rest[..s_len]).ok()?.to_string();
+    let rest = &rest[s_len..];
+    if rest.len() < 2 {
+        return None;
+    }
+    let p_len = u16::from_be_bytes([rest[0], rest[1]]) as usize;
+    let rest = &rest[2..];
+    if rest.len() < p_len {
+        return None;
+    }
+    let predicate = std::str::from_utf8(&rest[..p_len]).ok()?.to_string();
+    let object = std::str::from_utf8(&rest[p_len..]).ok()?.to_string();
+    Some((subject, predicate, object))
+}
+
+/// Why: The #4810 migration is the one code path that must read a key written
+///      before the object joined it; every other reader uses
+///      [`decode_triple_key`].
+/// What: Splits a pre-#4810 key (`[subject_len][subject][predicate]`) into
+///       `(subject, predicate)`. Returns `None` on the same malformed-input
+///       conditions as [`decode_triple_key`].
+/// Test: `decode_legacy_triple_key_round_trips`.
+pub fn decode_legacy_triple_key(bytes: &[u8]) -> Option<(String, String)> {
     if bytes.len() < 2 {
         return None;
     }
@@ -331,18 +470,22 @@ pub fn encode_object_index_key(object: &str, subject: &str, predicate: &str) -> 
 }
 
 /// Why: Predicate-first index — find all subjects connected via a given
-///      predicate.
-/// What: Encodes `(predicate, subject)` → composite key with two
-///       length-prefixed components.
-/// Test: `predicate_index_key_orders_by_predicate`.
-pub fn encode_predicate_index_key(predicate: &str, subject: &str) -> Vec<u8> {
+///      predicate. #4810 added the object so two objects under one
+///      `(predicate, subject)` no longer collapse into a single entry.
+/// What: Encodes `(predicate, subject, object)` → composite key with two
+///       length-prefixed leading components.
+/// Test: `predicate_index_key_orders_by_predicate`,
+///       `predicate_index_key_separates_objects`.
+pub fn encode_predicate_index_key(predicate: &str, subject: &str, object: &str) -> Vec<u8> {
     let p = predicate.as_bytes();
     let s = subject.as_bytes();
-    let mut out = Vec::with_capacity(4 + p.len() + s.len());
+    let o = object.as_bytes();
+    let mut out = Vec::with_capacity(4 + p.len() + s.len() + o.len());
     out.extend_from_slice(&(p.len() as u16).to_be_bytes());
     out.extend_from_slice(p);
     out.extend_from_slice(&(s.len() as u16).to_be_bytes());
     out.extend_from_slice(s);
+    out.extend_from_slice(o);
     out
 }
 
@@ -356,6 +499,39 @@ pub fn subject_prefix(subject: &str) -> Vec<u8> {
     out.extend_from_slice(&(s.len() as u16).to_be_bytes());
     out.extend_from_slice(s);
     out
+}
+
+/// Why (#4810): `assert` and `retract` both need "every row at this
+///      `(subject, predicate)`, whatever the object" — the question the old
+///      point-read answered by accident when the pair was the whole key.
+/// What: `(subject, predicate)` prefix = `[subject_len: u16 BE][subject]
+///       [predicate_len: u16 BE][predicate]`. Because the predicate carries its
+///       own length prefix, a longer predicate sharing this one's leading bytes
+///       (`has_convention` vs `has_conventions`) does NOT fall inside the
+///       range.
+/// Test: `subject_predicate_prefix_excludes_a_longer_predicate`.
+pub fn subject_predicate_prefix(subject: &str, predicate: &str) -> Vec<u8> {
+    let s = subject.as_bytes();
+    let p = predicate.as_bytes();
+    let mut out = Vec::with_capacity(4 + s.len() + p.len());
+    out.extend_from_slice(&(s.len() as u16).to_be_bytes());
+    out.extend_from_slice(s);
+    out.extend_from_slice(&(p.len() as u16).to_be_bytes());
+    out.extend_from_slice(p);
+    out
+}
+
+/// Why: every prefix range scan over [`TRIPLES`] needs an exclusive upper
+///      bound, and every call site was building it the same way by hand.
+/// What: returns `prefix` with `0xFF` appended. Whatever follows the prefix in
+///       a real key is either UTF-8 text (`0xFF` is never a legal UTF-8 byte)
+///       or the high byte of a u16 length, which reaches `0xFF` only for a
+///       component of 65 280 bytes or more.
+/// Test: `subject_predicate_prefix_excludes_a_longer_predicate`.
+pub fn prefix_range_end(prefix: &[u8]) -> Vec<u8> {
+    let mut end = prefix.to_vec();
+    end.push(0xFF);
+    end
 }
 
 /// Why: The PAYLOADS table is keyed by `(segment, id)`; this helper produces
@@ -431,26 +607,56 @@ mod tests {
 
     #[test]
     fn round_trip_triple_key() {
-        let key = encode_triple_key("user:alice", "knows");
-        let (subject, predicate) = decode_triple_key(&key).expect("decode");
+        let key = encode_triple_key("user:alice", "knows", "user:bob");
+        let (subject, predicate, object) = decode_triple_key(&key).expect("decode");
         assert_eq!(subject, "user:alice");
         assert_eq!(predicate, "knows");
+        assert_eq!(object, "user:bob");
     }
 
     #[test]
-    fn round_trip_triple_key_empty_predicate() {
-        let key = encode_triple_key("subj", "");
-        let (s, p) = decode_triple_key(&key).expect("decode");
+    fn round_trip_triple_key_empty_components() {
+        let key = encode_triple_key("subj", "", "");
+        let (s, p, o) = decode_triple_key(&key).expect("decode");
         assert_eq!(s, "subj");
         assert_eq!(p, "");
+        assert_eq!(o, "");
+    }
+
+    #[test]
+    fn triple_key_separates_objects() {
+        // #4810: the whole point — two objects under one (subject, predicate)
+        // must be two distinct keys, both inside the pair's prefix range.
+        let a = encode_triple_key("room:General", "contains", "drawer:a");
+        let b = encode_triple_key("room:General", "contains", "drawer:b");
+        assert_ne!(a, b);
+        let prefix = subject_predicate_prefix("room:General", "contains");
+        assert!(a.starts_with(&prefix));
+        assert!(b.starts_with(&prefix));
     }
 
     #[test]
     fn decode_triple_key_rejects_truncated() {
         assert!(decode_triple_key(&[]).is_none());
         assert!(decode_triple_key(&[0u8]).is_none());
-        // length prefix says 10 bytes follow but only 2 do
+        // subject length prefix says 10 bytes follow but only 2 do
         assert!(decode_triple_key(&[0, 10, b'a', b'b']).is_none());
+        // subject decodes, but there is no predicate length prefix
+        assert!(decode_triple_key(&[0, 2, b'a', b'b']).is_none());
+        // predicate length prefix says 9 bytes follow but only 1 does
+        assert!(decode_triple_key(&[0, 2, b'a', b'b', 0, 9, b'p']).is_none());
+    }
+
+    #[test]
+    fn decode_legacy_triple_key_round_trips() {
+        // The pre-#4810 shape the migration reads: no predicate length prefix.
+        let mut legacy = Vec::new();
+        legacy.extend_from_slice(&(5u16).to_be_bytes());
+        legacy.extend_from_slice(b"alice");
+        legacy.extend_from_slice(b"knows");
+        let (s, p) = decode_legacy_triple_key(&legacy).expect("decode legacy");
+        assert_eq!(s, "alice");
+        assert_eq!(p, "knows");
     }
 
     #[test]
@@ -459,9 +665,9 @@ mod tests {
         // and no triple for subject "alicia" should — even though "alicia" starts
         // with "alic" — because the length prefix differs.
         let prefix_alice = subject_prefix("alice");
-        let alice_knows = encode_triple_key("alice", "knows");
-        let alice_likes = encode_triple_key("alice", "likes");
-        let alicia_knows = encode_triple_key("alicia", "knows");
+        let alice_knows = encode_triple_key("alice", "knows", "bob");
+        let alice_likes = encode_triple_key("alice", "likes", "tea");
+        let alicia_knows = encode_triple_key("alicia", "knows", "bob");
 
         assert!(alice_knows.starts_with(&prefix_alice));
         assert!(alice_likes.starts_with(&prefix_alice));
@@ -469,14 +675,50 @@ mod tests {
     }
 
     #[test]
+    fn subject_predicate_prefix_excludes_a_longer_predicate() {
+        // The predicate's own length prefix is what keeps `has_convention`'s
+        // range from swallowing `has_conventions` rows.
+        let prefix = subject_predicate_prefix("proj", "has_convention");
+        let end = prefix_range_end(&prefix);
+        let inside = encode_triple_key("proj", "has_convention", "tabs");
+        let outside = encode_triple_key("proj", "has_conventions", "tabs");
+        assert!(inside.starts_with(&prefix));
+        assert!(!outside.starts_with(&prefix));
+        assert!(inside.as_slice() >= prefix.as_slice() && inside.as_slice() < end.as_slice());
+    }
+
+    #[test]
     fn subject_prefix_orders_lexicographically() {
         // BTreeMap-backed redb tables sort keys lexicographically. Length-
         // prefixed keys with the same length sort by content order.
-        let k1 = encode_triple_key("aaa", "p");
-        let k2 = encode_triple_key("aab", "p");
-        let k3 = encode_triple_key("bbb", "p");
+        let k1 = encode_triple_key("aaa", "p", "o");
+        let k2 = encode_triple_key("aab", "p", "o");
+        let k3 = encode_triple_key("bbb", "p", "o");
         assert!(k1 < k2);
         assert!(k2 < k3);
+    }
+
+    #[test]
+    fn functional_predicates_are_sorted_and_unique() {
+        // Sorted-and-unique is what makes the list reviewable; a duplicate
+        // would be a silent no-op and an out-of-order entry hides near-misses.
+        let mut sorted = FUNCTIONAL_PREDICATES.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.as_slice(), FUNCTIONAL_PREDICATES);
+    }
+
+    #[test]
+    fn is_functional_predicate_defaults_to_multi_valued() {
+        assert!(is_functional_predicate("is_alias_for"));
+        assert!(is_functional_predicate("has_version"));
+        // #4810: the defect predicate, and every unlisted predicate, is
+        // multi-valued.
+        assert!(!is_functional_predicate("contains"));
+        assert!(!is_functional_predicate("works_at"));
+        assert!(!is_functional_predicate("knows"));
+        // Deliberately excluded — two manifests can name one subject.
+        assert!(!is_functional_predicate("has_language"));
     }
 
     #[test]
@@ -492,11 +734,20 @@ mod tests {
 
     #[test]
     fn predicate_index_key_orders_by_predicate() {
-        let k1 = encode_predicate_index_key("knows", "s1");
-        let k2 = encode_predicate_index_key("knows", "s2");
-        let k3 = encode_predicate_index_key("likes", "s0");
+        let k1 = encode_predicate_index_key("knows", "s1", "o");
+        let k2 = encode_predicate_index_key("knows", "s2", "o");
+        let k3 = encode_predicate_index_key("likes", "s0", "o");
         assert!(k1 < k2);
         assert!(k2 < k3);
+    }
+
+    #[test]
+    fn predicate_index_key_separates_objects() {
+        // #4810: one entry per (predicate, subject) meant retracting one
+        // object evicted the index entry the other object still needed.
+        let a = encode_predicate_index_key("contains", "room:General", "drawer:a");
+        let b = encode_predicate_index_key("contains", "room:General", "drawer:b");
+        assert_ne!(a, b);
     }
 
     #[test]
@@ -634,6 +885,8 @@ mod tests {
             VECTOR_KEYS.name(),
             DELETED_VECTORS.name(),
             VECTOR_ID_SEQ.name(),
+            DRAWERS_BY_FACT_KEY.name(),
+            KG_SCHEMA.name(),
         ];
         for i in 0..names.len() {
             for j in (i + 1)..names.len() {

--- a/crates/trusty-common/tests/community_tests.rs
+++ b/crates/trusty-common/tests/community_tests.rs
@@ -213,22 +213,27 @@ async fn partition_covers_all_nodes() {
     assert_eq!(total, expected.len(), "no node may be missing");
 }
 
+/// Enough leaves for a star's internal density to fall below the 0.2 gap
+/// threshold — see `knowledge_gaps_on_sparse_graph` for the arithmetic (#4810).
+const LEAVES: [&str; 12] = [
+    "leaf1", "leaf2", "leaf3", "leaf4", "leaf5", "leaf6", "leaf7", "leaf8", "leaf9", "leaf10",
+    "leaf11", "leaf12",
+];
+
 /// Star topology (hub connected to many leaves, no other edges) — leaf-
 /// only communities have density 0.0 (a single node has no possible
 /// internal edges by our convention). With many leaves the partition
 /// should contain at least one community classified as a gap.
+///
+/// #4810: this used to pass with six leaves because `rel` is multi-valued and
+/// every assert closed the previous one — the graph under test was a hub and
+/// ONE edge, not a star. On the real star, six leaves give an internal density
+/// of 6/21 ≈ 0.29, above the 0.2 gap threshold. Twelve leaves (12/78 ≈ 0.15)
+/// restore the sparseness the test is about.
 #[tokio::test]
 async fn knowledge_gaps_on_sparse_graph() {
-    // Hub with 6 leaves.
-    let (_dir, kg) = build_kg(&[
-        ("hub", "rel", "leaf1"),
-        ("hub", "rel", "leaf2"),
-        ("hub", "rel", "leaf3"),
-        ("hub", "rel", "leaf4"),
-        ("hub", "rel", "leaf5"),
-        ("hub", "rel", "leaf6"),
-    ])
-    .await;
+    let edges: Vec<(&str, &str, &str)> = LEAVES.iter().map(|l| ("hub", "rel", *l)).collect();
+    let (_dir, kg) = build_kg(&edges).await;
 
     let gaps = kg.knowledge_gaps();
     assert!(
@@ -241,14 +246,8 @@ async fn knowledge_gaps_on_sparse_graph() {
 /// string for downstream prompt assembly.
 #[tokio::test]
 async fn suggested_exploration_is_non_empty() {
-    let (_dir, kg) = build_kg(&[
-        ("hub", "rel", "leaf1"),
-        ("hub", "rel", "leaf2"),
-        ("hub", "rel", "leaf3"),
-        ("hub", "rel", "leaf4"),
-        ("hub", "rel", "leaf5"),
-    ])
-    .await;
+    let edges: Vec<(&str, &str, &str)> = LEAVES.iter().map(|l| ("hub", "rel", *l)).collect();
+    let (_dir, kg) = build_kg(&edges).await;
     let gaps = find_communities(&kg);
     assert!(!gaps.is_empty(), "expected at least one gap to exist");
     for g in &gaps {

--- a/crates/trusty-common/tests/kg_triple_key_migration_tests.rs
+++ b/crates/trusty-common/tests/kg_triple_key_migration_tests.rs
@@ -1,0 +1,135 @@
+//! End-to-end pre→post migration of the #4810 triple key.
+//!
+//! Why: the unit tests in `kg_redb::tests` drive `KgStoreRedb` directly. This
+//! one goes through the surface a real caller uses — `KnowledgeGraph::open`,
+//! which translates `kg.db` to `kg.redb`, migrates, and hydrates the in-memory
+//! adjacency from the migrated rows — because that hydration step is where the
+//! old key's damage was still visible after storage was fixed.
+//! What: writes a palace file in the pre-#4810 key shape with no schema
+//! marker, opens it through `KnowledgeGraph`, and asserts the facts are
+//! queryable, the adjacency carries them, and a further multi-valued assert
+//! joins the set instead of replacing it.
+//! Test: `cargo test -p trusty-common --features memory-core --test
+//! kg_triple_key_migration_tests -- --include-ignored`.
+
+#![cfg(feature = "memory-core")]
+
+use tempfile::tempdir;
+use trusty_common::memory_core::store::kg::{KnowledgeGraph, Triple};
+use trusty_common::memory_core::store::kg_store::{
+    ACTIVE_SUBJECT_COUNTS, TRIPLES, TripleValue, encode_u64, encode_value,
+};
+
+/// The pre-#4810 key: `[subject_len: u16 BE][subject][predicate]`, no object.
+fn legacy_triple_key(subject: &str, predicate: &str) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&(subject.len() as u16).to_be_bytes());
+    out.extend_from_slice(subject.as_bytes());
+    out.extend_from_slice(predicate.as_bytes());
+    out
+}
+
+fn triple(subject: &str, predicate: &str, object: &str) -> Triple {
+    Triple {
+        subject: subject.into(),
+        predicate: predicate.into(),
+        object: object.into(),
+        valid_from: chrono::Utc::now(),
+        valid_to: None,
+        confidence: 1.0,
+        provenance: None,
+    }
+}
+
+/// Why: proves the migration is complete end to end — storage rewrite,
+/// adjacency hydration, and the write path that follows — rather than proving
+/// each piece in isolation.
+/// What: seeds three legacy-keyed facts under two subjects, opens the palace
+/// through `KnowledgeGraph`, and checks reads, graph neighbours, and a
+/// subsequent multi-valued assert.
+/// Ignored by default: it writes a redb file and re-opens it, which is heavier
+/// than a unit test and unnecessary on every inner-loop run.
+#[tokio::test]
+#[ignore = "writes and re-opens a redb palace; run with --include-ignored"]
+async fn legacy_palace_migrates_on_open_and_accepts_multi_valued_writes() {
+    let dir = tempdir().unwrap();
+    let redb_path = dir.path().join("kg.redb");
+
+    // --- pre: a palace written by the pre-#4810 code ---------------------
+    {
+        let db = redb::Database::create(&redb_path).unwrap();
+        let wtx = db.begin_write().unwrap();
+        {
+            let mut triples = wtx.open_table(TRIPLES).unwrap();
+            // The old code maintained this counter alongside the rows, and the
+            // migration preserves it rather than recomputing it — the rewrite
+            // is one row in, one row out — so a faithful legacy palace has to
+            // carry it too.
+            let mut counts = wtx.open_table(ACTIVE_SUBJECT_COUNTS).unwrap();
+            for (s, p, o) in [
+                ("room:General", "contains", "drawer:a"),
+                ("tga", "is_alias_for", "trusty-git-analytics"),
+                ("alice", "knows", "bob"),
+            ] {
+                counts
+                    .insert(s.as_bytes(), encode_u64(1).as_slice())
+                    .unwrap();
+                let value = TripleValue {
+                    object: o.to_string(),
+                    valid_from_ms: 1_700_000_000_000,
+                    valid_to_ms: None,
+                    confidence: 1.0,
+                    provenance: None,
+                };
+                let bytes = encode_value(&value).unwrap();
+                triples
+                    .insert(legacy_triple_key(s, p).as_slice(), bytes.as_slice())
+                    .unwrap();
+            }
+        }
+        wtx.commit().unwrap();
+        drop(db);
+    }
+
+    // --- post: open through the public handle -----------------------------
+    // Callers pass the legacy `kg.db` name; `KnowledgeGraph` resolves it to the
+    // `kg.redb` file seeded above.
+    let kg = KnowledgeGraph::open(&dir.path().join("kg.db")).unwrap();
+
+    let room = kg.query_active("room:General").await.unwrap();
+    assert_eq!(room.len(), 1, "the migrated fact is queryable");
+    assert_eq!(room[0].object, "drawer:a");
+    assert_eq!(
+        kg.query_active("tga").await.unwrap()[0].object,
+        "trusty-git-analytics"
+    );
+    assert_eq!(kg.query_active("alice").await.unwrap()[0].object, "bob");
+
+    // Hydration ran over the migrated rows, so the graph sees all three edges.
+    assert_eq!(kg.edge_count(), 3);
+    assert_eq!(kg.count_active_triples(), 3);
+
+    // Multi-valued predicate: the new member joins the room.
+    kg.assert(triple("room:General", "contains", "drawer:b"))
+        .await
+        .unwrap();
+    kg.assert(triple("room:General", "contains", "drawer:c"))
+        .await
+        .unwrap();
+    let room = kg.query_active("room:General").await.unwrap();
+    assert_eq!(room.len(), 3, "migrated palace accepts multi-valued writes");
+
+    // Functional predicate: the newer alias still supersedes.
+    kg.assert(triple("tga", "is_alias_for", "trusty-git-analytics-2"))
+        .await
+        .unwrap();
+    let tga = kg.query_active("tga").await.unwrap();
+    assert_eq!(tga.len(), 1);
+    assert_eq!(tga[0].object, "trusty-git-analytics-2");
+
+    // The pre-migration image is on disk next to the palace.
+    assert!(
+        dir.path().join("kg.redb.pre-4810.bak").is_file(),
+        "migration leaves a verified backup"
+    );
+}

--- a/crates/trusty-memory/changelog.d/4810-kg-membership-predicates.md
+++ b/crates/trusty-memory/changelog.d/4810-kg-membership-predicates.md
@@ -1,0 +1,13 @@
+Fixed
+
+Membership-style knowledge-graph facts are recorded correctly (trusty-common
+#4810). A predicate that names several things — a room's drawers, a project's
+dependencies — used to keep only the most recently asserted object; all of them
+are now retained, and `/kg/graph`, `kg_gaps`, and neighbour expansion report the
+real edge set instead of one edge per `(subject, predicate)`.
+
+Expect `kg_count` totals to RISE on existing palaces after the one-time
+migration at first open. That is the previously-hidden data becoming visible,
+not a regression. Alias and convention predicates (`is_alias_for`,
+`has_convention`, `is_fact`, `is_shorthand_for`) are unaffected — they remain
+single-valued, so prompt-fact injection does not grow.

--- a/crates/trusty-memory/changelog.d/4810-kg-membership-predicates.md
+++ b/crates/trusty-memory/changelog.d/4810-kg-membership-predicates.md
@@ -1,13 +1,7 @@
 Fixed
 
-Membership-style knowledge-graph facts are recorded correctly (trusty-common
-#4810). A predicate that names several things — a room's drawers, a project's
-dependencies — used to keep only the most recently asserted object; all of them
-are now retained, and `/kg/graph`, `kg_gaps`, and neighbour expansion report the
-real edge set instead of one edge per `(subject, predicate)`.
-
-Expect `kg_count` totals to RISE on existing palaces after the one-time
-migration at first open. That is the previously-hidden data becoming visible,
-not a regression. Alias and convention predicates (`is_alias_for`,
-`has_convention`, `is_fact`, `is_shorthand_for`) are unaffected — they remain
-single-valued, so prompt-fact injection does not grow.
+- Membership-style knowledge-graph facts are recorded correctly ([#4810](https://github.com/bobmatnyc/trusty-tools/issues/4810))
+  - A predicate that names several things — a room's drawers, a project's dependencies — used to keep only the most recently asserted object; all of them are now retained.
+  - `/kg/graph`, `kg_gaps`, and neighbour expansion report the real edge set instead of one edge per `(subject, predicate)`.
+- Expect `kg_count` totals to RISE on existing palaces after the one-time migration at first open. That is previously-hidden data becoming visible, not a regression.
+- Alias and convention predicates (`is_alias_for`, `has_convention`, `is_fact`, `is_shorthand_for`) are unaffected — they remain single-valued, so prompt-fact injection does not grow.


### PR DESCRIPTION
## What

The redb `TRIPLES` key gains the object component, so `room:General --contains--> drawer:X` stops collapsing to one row. `FUNCTIONAL_PREDICATES` is an inverted list: 15 named single-valued predicates keep supersession, everything else defaults to multi-valued. Closes #4810.

## Why inverted

Forgetting a multi-valued predicate costs silent data loss (this bug); forgetting a functional one costs an extra queryable row. `has_language` is deliberately excluded because `scan_cargo_toml` and `scan_package_json` derive subjects independently.

## Also in scope

`kg/adjacency.rs` `upsert_edge` was collapsing parallel edges in memory regardless of the storage fix; it now filters on target as well as predicate. Without it `/kg/graph` and `kg_gaps` would keep under-reporting.

## Migration

At-open, per-palace, gated by a new `KG_SCHEMA` marker, one redb transaction, backup written to `kg.redb.pre-4810.bak` (note: `.redb`, not `.db` — `KnowledgeGraph::open` translates the path via `redb_path_for`).

## 🔴 Reviewer must weigh: fail-open leaves triples INVISIBLE, not un-migrated

Readers decode the three-component key, so a palace whose migration failed opens cleanly but returns nothing from `query_active`/`list_active` until a later open succeeds. Rows are intact on disk and the next open retries. Making an un-migrated palace readable would need a legacy-decode fallback in every reader — a different design, deliberately not improvised here. This is the main thing to review.

## 🔴 Two existing tests were changed — read this before approving

`knowledge_gaps_on_sparse_graph` and `suggested_exploration_is_non_empty` built a "hub with 6 leaves" using the multi-valued predicate `rel`, so pre-fix they were really testing a hub and ONE edge. On a real 6-leaf star internal density is 6/21 ≈ 0.29, above the 0.2 gap threshold, so no gap is emitted. Both moved to 12 leaves (12/78 ≈ 0.15) with the arithmetic written into the test. The classifier is unchanged. Flagging explicitly because "changed a test to make it pass" is normally a red flag.

## Downgrade hazard

Do not run a `trusty-memory` older than this against a palace this version has opened. The on-disk key format changed and an old binary computes the old key, matching nothing.

## Gate — rung 5

```
cargo fmt --check                                                  → clean
cargo check -p trusty-common --features memory-core --all-targets  → clean
cargo clippy -p trusty-common --features memory-core --all-targets -- -D warnings → clean
cargo test -p trusty-common --features memory-core → ok. 968 passed; 0 failed; 13 ignored
  --test kg_triple_key_migration_tests -- --include-ignored → ok. 1 passed; 0 failed
cargo check --workspace   → clean
cargo test -p trusty-memory → ok. 629 passed; 0 failed; 4 ignored
cargo check -p trusty-agents → clean
bash scripts/check_line_cap.sh → measured 3871 tracked .rs file(s); 4 allowlisted, 0 violations — OK
bash scripts/check_sld.sh → scanned 57 spec doc(s) + 5821 code file(s); 0 error(s), 0 warning(s)
```

## Feature-flag trap worth knowing

Bare `cargo test -p trusty-common` does NOT compile the KG. `memory-core` is not a default feature, so the bare command runs 304 unrelated tests and proves nothing about this change. Every gate above used `--features memory-core`. CI is unaffected because `cargo test --workspace` unifies the feature via trusty-memory.

## Pre-existing failure, not caused here

`cargo test -p trusty-mpm` fails `create_managed_session_confirms_server_before_applying_options` (contends over a live tmux server under parallel execution). `git diff --name-only e2ca949a3...HEAD -- crates/trusty-mpm/` is empty, and the test passes in isolation: `cargo test -p trusty-mpm --lib -- --test-threads=1 create_managed_session_confirms_server_before_applying_options` → ok. 2 passed; 0 failed.

## Changelog fragments

Both `crates/trusty-common/changelog.d/` and `crates/trusty-memory/changelog.d/`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools