### PR TITLE
fix(tga): thread the ProgressBus through every run_full_sweep stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10288,7 +10288,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.13.0"
+version = "2.14.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.13.0"
+version = "2.14.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for

--- a/crates/trusty-git-analytics/changelog.d/5361-sweep-progress-bus.md
+++ b/crates/trusty-git-analytics/changelog.d/5361-sweep-progress-bus.md
@@ -1,0 +1,8 @@
+Fixed
+
+- `audit::run_full_sweep` now reports every stage on the `ProgressBus` it is
+  given, instead of discarding the parameter. Each of the eight stages emits a
+  start event (naming the stage and its position in the run) and a
+  completed/failed event under the new `Stage::Audit`, and the collection stage
+  is handed that same bus so its per-repository events land there too. A `None`
+  or disabled bus stays a no-op.

--- a/crates/trusty-git-analytics/src/audit/sweep.rs
+++ b/crates/trusty-git-analytics/src/audit/sweep.rs
@@ -21,9 +21,18 @@ use crate::commands::{classify, collect, deployments, dora, incidents, jira, pr_
 use crate::commands::{dora::DoraArgs, pr_metrics::PrMetricsArgs};
 use crate::core::config::Config;
 use crate::core::db::Database;
-use crate::core::progress::ProgressBus;
+use crate::core::progress::{ProgressBus, ProgressEvent, Stage};
 
 use super::stage::{AuditSweepStats, SweepStage};
+
+/// How many stages [`run_full_sweep`] drives.
+///
+/// Why: the per-stage start event says "stage 3 of 8", and that denominator has
+/// to come from one place or it drifts the next time a stage is added.
+/// What: `8`.
+/// Test: `super::tests::sweep_runs_every_stage_in_order_and_survives_failures`
+/// asserts the sweep records exactly this many outcomes.
+pub(crate) const TOTAL_STAGES: usize = 8;
 
 /// The knobs `tga audit` (or a TUI action) hands the sweep.
 ///
@@ -58,10 +67,15 @@ pub struct SweepOptions {
 /// → pr-metrics → report by calling each subcommand's own `run`, recording
 /// every outcome into an [`AuditSweepStats`]. No stage result is propagated
 /// with `?`, so no stage can abort the run. `--allow-stale` is applied to
-/// collection as a fixed default (§9) — not an operator choice. `progress`,
-/// when supplied, is the existing bus the collection pipeline emits into; the
-/// remaining stages have no progress instrumentation of their own today and
-/// are silent on it.
+/// collection as a fixed default (§9) — not an operator choice.
+///
+/// `progress`, when supplied, receives a [`Stage::Audit`] start event before
+/// each of the eight stages and a completed/failed event after it, with
+/// [`SweepStage::as_str`] as the target — so a ten-minute sweep is observable
+/// even though seven of the eight subcommands have no instrumentation of their
+/// own (#5361). The collection stage additionally gets the SAME bus handed to
+/// its pipeline, so its per-repository [`Stage::Collect`] events land there
+/// too. `None` emits nothing at all.
 ///
 /// A failed STAGE is reported inside `AuditSweepStats`, never as `Err` —
 /// `Err` means the run could not be started at all. Callers must therefore check
@@ -76,7 +90,8 @@ pub struct SweepOptions {
 /// fail identically, which is noise rather than a gap list.
 ///
 /// Test: `super::tests::sweep_runs_every_stage_in_order_and_survives_failures`,
-/// `super::tests::failed_stage_is_recorded_and_does_not_stop_the_sweep`.
+/// `super::tests::failed_stage_is_recorded_and_does_not_stop_the_sweep`,
+/// `super::tests::sweep_emits_progress_for_non_collection_stages`.
 ///
 /// # Spec References
 /// - [`SPEC-TGAUDIT-02~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-02~draft)
@@ -88,12 +103,6 @@ pub async fn run_full_sweep(
     options: &SweepOptions,
     progress: Option<&ProgressBus>,
 ) -> anyhow::Result<AuditSweepStats> {
-    // The bus is accepted but not yet threaded past collection: only
-    // `CollectionPipeline` emits events today, and it reads the bus off the
-    // config-carrying pipeline rather than off the command wrapper. Kept in the
-    // signature per DOC-67 §7 so the TUI caller does not need a second one.
-    let _ = progress;
-
     // Created once, up front, so the stages that write into it do not each
     // race to create it — and so an unwritable path fails as a precondition
     // rather than as eight identical stage failures.
@@ -102,8 +111,11 @@ pub async fn run_full_sweep(
     }
 
     let mut stats = AuditSweepStats::default();
+    // #5361: the collection pipeline wants an owned bus and an absent one is
+    // the disabled bus, on which every emit is a no-op.
+    let collect_bus = progress.cloned().unwrap_or_default();
 
-    let t = Instant::now();
+    let t = begin(progress, &stats, SweepStage::Collect);
     let args = CollectArgs {
         weeks: options.weeks,
         // #5217: DOC-67 §9 — a one-shot org sweep cannot inherit `tga
@@ -112,55 +124,37 @@ pub async fn run_full_sweep(
         allow_stale: true,
         ..CollectArgs::default()
     };
-    stats.record(
-        SweepStage::Collect,
-        t,
-        collect::run(config.clone(), db, args).await,
-    );
+    let result = collect::run_with_progress(config.clone(), db, args, &collect_bus).await;
+    finish(progress, &mut stats, SweepStage::Collect, t, result);
 
-    let t = Instant::now();
+    let t = begin(progress, &stats, SweepStage::Classify);
     let args = ClassifyArgs {
         weeks: options.weeks,
         ..ClassifyArgs::default()
     };
-    stats.record(
-        SweepStage::Classify,
-        t,
-        classify::run(config.clone(), db, args).await,
-    );
+    let result = classify::run(config.clone(), db, args).await;
+    finish(progress, &mut stats, SweepStage::Classify, t, result);
 
-    let t = Instant::now();
-    stats.record(
-        SweepStage::JiraSync,
-        t,
-        jira::run_sync(config.clone(), db, JiraSyncArgs::default()).await,
-    );
+    let t = begin(progress, &stats, SweepStage::JiraSync);
+    let result = jira::run_sync(config.clone(), db, JiraSyncArgs::default()).await;
+    finish(progress, &mut stats, SweepStage::JiraSync, t, result);
 
     // Deployments and incidents populate `fact_deployments` / `fact_incidents`,
     // which `dora` reduces — so they precede it here even though DOC-67 §5's
     // prose lists dora first. See the module-level note in `super`.
-    let t = Instant::now();
-    stats.record(
-        SweepStage::Deployments,
-        t,
-        deployments::run(config.clone(), db, DeploymentsCollectArgs::default()).await,
-    );
+    let t = begin(progress, &stats, SweepStage::Deployments);
+    let result = deployments::run(config.clone(), db, DeploymentsCollectArgs::default()).await;
+    finish(progress, &mut stats, SweepStage::Deployments, t, result);
 
-    let t = Instant::now();
-    stats.record(
-        SweepStage::Incidents,
-        t,
-        incidents::run(config.clone(), db, IncidentsCollectArgs::default()),
-    );
+    let t = begin(progress, &stats, SweepStage::Incidents);
+    let result = incidents::run(config.clone(), db, IncidentsCollectArgs::default());
+    finish(progress, &mut stats, SweepStage::Incidents, t, result);
 
-    let t = Instant::now();
-    stats.record(
-        SweepStage::Dora,
-        t,
-        dora::run(config.clone(), db, DoraArgs::default()),
-    );
+    let t = begin(progress, &stats, SweepStage::Dora);
+    let result = dora::run(config.clone(), db, DoraArgs::default());
+    finish(progress, &mut stats, SweepStage::Dora, t, result);
 
-    let t = Instant::now();
+    let t = begin(progress, &stats, SweepStage::PrMetrics);
     // `pr-metrics --output` names a FILE, not a directory (unlike `report
     // --output`), so it gets a path inside the run directory rather than the
     // directory itself — passing the directory makes it write a regular file
@@ -170,19 +164,65 @@ pub async fn run_full_sweep(
         csv: true,
         output: options.output.as_ref().map(|d| d.join("pr-metrics.csv")),
     };
-    stats.record(
-        SweepStage::PrMetrics,
-        t,
-        pr_metrics::run(config.clone(), db, args),
-    );
+    let result = pr_metrics::run(config.clone(), db, args);
+    finish(progress, &mut stats, SweepStage::PrMetrics, t, result);
 
-    let t = Instant::now();
+    let t = begin(progress, &stats, SweepStage::Report);
     let args = ReportArgs {
         output: options.output.clone(),
         ..ReportArgs::default()
     };
-    stats.record(SweepStage::Report, t, report::run(config.clone(), db, args));
+    let result = report::run(config.clone(), db, args);
+    finish(progress, &mut stats, SweepStage::Report, t, result);
 
     tracing::info!(summary = %stats.summary(), "audit sweep finished");
     Ok(stats)
+}
+
+/// Announce that `stage` is starting, and return the instant to time it from.
+///
+/// Why: a stage with no instrumentation of its own is indistinguishable from a
+/// hang until it ends, which for `collect` against a large org is minutes of
+/// frozen screen (#5302). The start event is what puts the row on screen.
+/// What: emits [`ProgressEvent::started`] on `progress` under
+/// [`Stage::Audit`], targeted at the stage name and detailed with its position
+/// in the run, then returns `Instant::now()`. A `None` bus emits nothing; the
+/// returned instant is unaffected either way.
+/// Test: `super::tests::sweep_emits_progress_for_non_collection_stages`.
+fn begin(progress: Option<&ProgressBus>, stats: &AuditSweepStats, stage: SweepStage) -> Instant {
+    if let Some(bus) = progress {
+        let position = stats.outcomes.len() + 1;
+        bus.emit(
+            ProgressEvent::started(Stage::Audit, stage.as_str(), Some(1))
+                .with_detail(format!("stage {position} of {TOTAL_STAGES}")),
+        );
+    }
+    Instant::now()
+}
+
+/// Publish `stage`'s verdict, then record it in `stats`.
+///
+/// Why: the bus and the stats must never disagree about how a stage ended, so
+/// one function owns both writes — a caller cannot record an outcome without
+/// announcing it, or announce one it did not record.
+/// What: emits [`ProgressEvent::completed`] or [`ProgressEvent::failed`]
+/// (carrying the full `{e:#}` cause chain, the same text
+/// [`AuditSweepStats::record`] stores), then hands `result` to
+/// [`AuditSweepStats::record`]. Never propagates: a stage failure is a recorded
+/// fact, per DOC-67 §9.
+/// Test: `super::tests::sweep_emits_progress_for_non_collection_stages`.
+fn finish(
+    progress: Option<&ProgressBus>,
+    stats: &mut AuditSweepStats,
+    stage: SweepStage,
+    started: Instant,
+    result: anyhow::Result<()>,
+) {
+    if let Some(bus) = progress {
+        bus.emit(match &result {
+            Ok(()) => ProgressEvent::completed(Stage::Audit, stage.as_str(), 1),
+            Err(e) => ProgressEvent::failed(Stage::Audit, stage.as_str(), format!("{e:#}")),
+        });
+    }
+    stats.record(stage, started, result);
 }

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -8,6 +8,7 @@ use crate::audit::{run_full_sweep, AuditSweepStats, StageStatus, SweepOptions, S
 use crate::commands::audit::AuditArgs;
 use crate::core::config::Config;
 use crate::core::db::Database;
+use crate::core::progress::{ProgressBus, Stage};
 
 /// The order `run_full_sweep` is contracted to execute in.
 ///
@@ -122,6 +123,9 @@ async fn sweep_runs_every_stage_in_order_and_survives_failures() {
 
     let stages: Vec<_> = stats.outcomes.iter().map(|o| o.stage).collect();
     assert_eq!(stages, EXPECTED_ORDER.to_vec());
+    // The "stage N of 8" denominator in the progress start events is this
+    // constant; a stage added without updating it would lie to the operator.
+    assert_eq!(stages.len(), super::sweep::TOTAL_STAGES);
 
     // JIRA is unconfigured here, so that stage must have failed — and the
     // seven stages after it must still have run.
@@ -206,6 +210,102 @@ async fn sweep_writes_reports_into_the_requested_directory() {
             out.display()
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Progress reporting from every stage, not just collection (#5361)
+// ---------------------------------------------------------------------------
+
+/// #5361: `run_full_sweep` used to bind and discard its `progress` parameter,
+/// so a caller that supplied a bus saw nothing for classify, report, pr-metrics,
+/// jira sync, dora, deployments, or incidents — a ~10-minute sweep behind a
+/// frozen screen. This asserts the non-collection stages reach the bus the
+/// caller passed in; before the fix the drained event list is empty.
+#[tokio::test]
+async fn sweep_emits_progress_for_non_collection_stages() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut db = Database::open(&dir.path().join("tga.db")).expect("open db");
+    let options = SweepOptions {
+        output: Some(dir.path().join("out")),
+        weeks: Some(1),
+    };
+    let bus = ProgressBus::new();
+
+    let stats = run_full_sweep(&Config::default(), &mut db, &options, Some(&bus))
+        .await
+        .expect("sweep");
+
+    let events = bus.drain();
+    assert_eq!(bus.dropped(), 0, "the run must fit in the default ring");
+    assert!(
+        !events.is_empty(),
+        "a bus handed to run_full_sweep received nothing at all"
+    );
+
+    // Report and classify are the stages furthest from collection: neither has
+    // any instrumentation of its own, so if the parameter is not threaded they
+    // are silent no matter what the collection pipeline does.
+    for stage in [SweepStage::Classify, SweepStage::Report] {
+        let mine: Vec<_> = events
+            .iter()
+            .filter(|e| e.stage == Stage::Audit && e.target == stage.as_str())
+            .collect();
+        assert!(
+            mine.iter().any(|e| !e.is_terminal()),
+            "no start event for the {stage} stage: {events:#?}"
+        );
+        assert!(
+            mine.iter().any(|e| e.is_terminal()),
+            "no completion event for the {stage} stage: {events:#?}"
+        );
+    }
+
+    // Every stage, not just those two — and the bus's verdict agrees with the
+    // recorded one, so a stage cannot report green on screen and red in stats.
+    for outcome in &stats.outcomes {
+        let terminal = events
+            .iter()
+            .find(|e| {
+                e.stage == Stage::Audit && e.target == outcome.stage.as_str() && e.is_terminal()
+            })
+            .unwrap_or_else(|| panic!("no terminal event for {}", outcome.stage));
+        let announced_failure = terminal
+            .outcome
+            .as_ref()
+            .is_some_and(|o| matches!(o, crate::core::progress::Outcome::Failed { .. }));
+        assert_eq!(
+            announced_failure,
+            outcome.status.is_failure(),
+            "{} announced and recorded different verdicts",
+            outcome.stage
+        );
+    }
+}
+
+/// An inactive bus must change nothing — the `None` caller's contract, proved
+/// through the one shape that is observable from outside.
+#[tokio::test]
+async fn a_disabled_bus_stays_a_no_op() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut db = Database::open(&dir.path().join("tga.db")).expect("open db");
+    let options = SweepOptions {
+        output: Some(dir.path().join("out")),
+        weeks: Some(1),
+    };
+    let bus = ProgressBus::disabled();
+
+    let stats = run_full_sweep(&Config::default(), &mut db, &options, Some(&bus))
+        .await
+        .expect("sweep");
+
+    assert!(bus.drain().is_empty(), "a disabled bus queued events");
+    assert_eq!(bus.dropped(), 0);
+    let stages: Vec<_> = stats.outcomes.iter().map(|o| o.stage).collect();
+    assert_eq!(
+        stages,
+        EXPECTED_ORDER.to_vec(),
+        "sequencing must not depend on whether anybody is watching"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/trusty-git-analytics/src/commands/collect.rs
+++ b/crates/trusty-git-analytics/src/commands/collect.rs
@@ -4,6 +4,7 @@ use tga::collect::collector::FetchOutcome;
 use tga::collect::CollectionPipeline;
 use tga::core::config::Config;
 use tga::core::db::Database;
+use tga::core::progress::ProgressBus;
 
 use crate::commands::args::CollectArgs;
 use crate::commands::date_range::resolve_date_range;
@@ -17,10 +18,32 @@ use crate::commands::date_range::resolve_date_range;
 /// of the loaded YAML config, runs [`CollectionPipeline::run`], then prints
 /// the fetch summary and collection totals to stderr/stdout.  Since tga
 /// 2.6.0, fetch failures are fatal by default (exit non-zero) unless
-/// `--allow-stale` or `--no-fetch` is passed.
+/// `--allow-stale` or `--no-fetch` is passed. Collects with progress
+/// reporting off; see [`run_with_progress`] for the bus-carrying form.
 /// Test: integration test in `tests/integration_test.rs`; fetch summary paths
 /// are unit-tested in `commands::collect::tests`.
 pub async fn run(config: Config, db: &mut Database, args: CollectArgs) -> anyhow::Result<()> {
+    run_with_progress(config, db, args, &ProgressBus::disabled()).await
+}
+
+/// Run the collection stage, publishing pipeline progress onto `progress`.
+///
+/// Why: #5361 — `audit::run_full_sweep` accepts a [`ProgressBus`] but had no
+/// way to hand it to collection, because [`run`] built the pipeline with a
+/// disabled bus of its own. A caller that supplies a bus at the sweep entry
+/// point must get the pipeline's per-repository events on THAT bus, not on one
+/// the command wrapper constructed and threw away.
+/// What: identical to [`run`] in every other respect; `progress` is attached to
+/// the [`CollectionPipeline`] via `with_progress`. Passing
+/// [`ProgressBus::disabled`] makes every emit a no-op, which is what [`run`]
+/// does, so the CLI path is byte-identical.
+/// Test: `crate::audit::tests::sweep_emits_progress_for_non_collection_stages`.
+pub async fn run_with_progress(
+    config: Config,
+    db: &mut Database,
+    args: CollectArgs,
+    progress: &ProgressBus,
+) -> anyhow::Result<()> {
     let mut cfg = config;
 
     // Filter repositories by name when --repos is supplied.
@@ -86,6 +109,7 @@ pub async fn run(config: Config, db: &mut Database, args: CollectArgs) -> anyhow
     let effective_strict = !args.allow_stale && !args.no_fetch;
 
     let pipeline = CollectionPipeline::new(cfg)
+        .with_progress(progress.clone())
         .with_force(args.force)
         .with_no_fetch(args.no_fetch)
         .with_force_refresh_prs(args.force_refresh_prs)

--- a/crates/trusty-git-analytics/src/commands/tui/render.rs
+++ b/crates/trusty-git-analytics/src/commands/tui/render.rs
@@ -16,8 +16,6 @@ use ratatui::widgets::{Gauge, List, ListItem, Paragraph, Wrap};
 use ratatui::Frame;
 use trusty_common::monitor::tui_common::{panel_block, render_help_overlay, truncate};
 
-use tga::core::progress::Stage;
-
 use super::state::{RepoSource, TuiState, View, WorkStatus};
 
 /// Key reference shown in the status bar and the help overlay.
@@ -117,9 +115,15 @@ pub fn repo_line(state: &TuiState, index: usize) -> String {
 /// One progress line for a stage's target row.
 ///
 /// Why/What/Test: see `super::tests::progress_lines_show_counts_and_outcome`.
+///
+/// #5361: driven by the stages that actually emitted, not by
+/// [`Stage::all`](tga::core::progress::Stage::all) — the audit sweep reports
+/// under `Stage::Audit`, which `all()` excludes, so a fixed skeleton would drop
+/// its rows on the floor. Unstarted stages were already skipped, so the three
+/// pipeline stages render exactly as before.
 pub fn progress_lines(state: &TuiState) -> Vec<String> {
     let mut out = Vec::new();
-    for stage in Stage::all() {
+    for stage in state.progress.stages() {
         let summary = state.progress.summary(stage);
         if !summary.is_started() {
             continue;

--- a/crates/trusty-git-analytics/src/core/progress/aggregate.rs
+++ b/crates/trusty-git-analytics/src/core/progress/aggregate.rs
@@ -210,6 +210,21 @@ impl ProgressAggregate {
         self.rows.get(&stage).map_or(&[], Vec::as_slice)
     }
 
+    /// Every stage that has produced at least one row, in [`Stage`] order.
+    ///
+    /// Why: a renderer driven by [`Stage::all`] can only ever show the three
+    /// pipeline stages, so #5361's audit-sweep rows would be folded into the
+    /// aggregate and never drawn. Iterating what actually arrived keeps the
+    /// display honest for any stage, including ones added later.
+    /// What: the keys of the row map that hold rows, ascending.
+    /// Test: `super::tests::aggregate_lists_only_stages_that_produced_rows`.
+    pub fn stages(&self) -> impl Iterator<Item = Stage> + '_ {
+        self.rows
+            .iter()
+            .filter(|(_, rows)| !rows.is_empty())
+            .map(|(stage, _)| *stage)
+    }
+
     /// Roll-up for one stage.
     ///
     /// Why/What/Test: see [`StageSummary`] and

--- a/crates/trusty-git-analytics/src/core/progress/event.rs
+++ b/crates/trusty-git-analytics/src/core/progress/event.rs
@@ -28,27 +28,41 @@ pub enum Stage {
     Correlate,
     /// Stage 2 — the classification cascade (`classify/`).
     Classify,
+    /// The AUDIT sweep (`crate::audit`), one target per sweep stage.
+    ///
+    /// #5361: the sweep drives eight subcommands, most of which have no
+    /// progress instrumentation of their own — so the sweep itself reports
+    /// their start and finish, with [`crate::audit::SweepStage::as_str`] as the
+    /// target. Its own collection stage still emits [`Stage::Collect`] rows on
+    /// the same bus, so the coarse and fine views coexist rather than merge.
+    Audit,
 }
 
 impl Stage {
     /// Short display label for this stage.
     ///
     /// Why: renderers and log lines both need one canonical spelling.
-    /// What: `"Collect"` / `"Correlate"` / `"Classify"`.
+    /// What: `"Collect"` / `"Correlate"` / `"Classify"` / `"Audit"`.
     /// Test: `super::tests::stage_label_is_stable`.
     pub fn label(self) -> &'static str {
         match self {
             Self::Collect => "Collect",
             Self::Correlate => "Correlate",
             Self::Classify => "Classify",
+            Self::Audit => "Audit",
         }
     }
 
-    /// Every stage, in pipeline order.
+    /// The three long-running data stages, in pipeline order.
     ///
-    /// Why: the aggregate view lists stages in a stable order even before any
-    /// event for a stage has arrived.
-    /// What: `[Collect, Correlate, Classify]`.
+    /// Why: a consumer that wants a fixed skeleton — every pipeline stage
+    /// listed even before its first event — reads this list.
+    /// What: `[Collect, Correlate, Classify]`. [`Stage::Audit`] is deliberately
+    /// absent: it is not a pipeline stage but a wrapper whose rows are the
+    /// sweep's own stages, so a skeleton built from it would show eight empty
+    /// rows on every `tga tui` run. A consumer that wants whatever actually
+    /// ran, including `Audit`, iterates
+    /// [`super::ProgressAggregate::stages`] instead.
     /// Test: `super::tests::stage_label_is_stable`.
     pub fn all() -> [Stage; 3] {
         [Self::Collect, Self::Correlate, Self::Classify]

--- a/crates/trusty-git-analytics/src/core/progress/tests.rs
+++ b/crates/trusty-git-analytics/src/core/progress/tests.rs
@@ -13,7 +13,11 @@ fn stage_label_is_stable() {
     assert_eq!(Stage::Collect.label(), "Collect");
     assert_eq!(Stage::Correlate.label(), "Correlate");
     assert_eq!(Stage::Classify.label(), "Classify");
+    assert_eq!(Stage::Audit.label(), "Audit");
+    // #5361: `all()` is the pipeline skeleton, so the audit wrapper stays out
+    // of it — a `tga tui` run would otherwise show eight rows that never fill.
     assert_eq!(Stage::all().len(), 3);
+    assert!(!Stage::all().contains(&Stage::Audit));
 }
 
 #[test]
@@ -197,6 +201,24 @@ fn aggregate_starts_empty() {
     assert!(agg.rows(Stage::Collect).is_empty());
     assert_eq!(agg.summary(Stage::Collect), StageSummary::default());
     assert!(!agg.summary(Stage::Collect).is_started());
+}
+
+/// #5361: a renderer driven by `Stage::all()` can never show audit-sweep rows,
+/// so the aggregate must be able to report what actually emitted.
+#[test]
+fn aggregate_lists_only_stages_that_produced_rows() {
+    let mut agg = ProgressAggregate::new();
+    assert_eq!(agg.stages().count(), 0);
+
+    agg.apply(ProgressEvent::started(Stage::Audit, "jira sync", Some(1)));
+    agg.apply(ProgressEvent::completed(Stage::Collect, "api", 1));
+
+    // Ascending `Stage` order, and nothing for the stage that never emitted.
+    assert_eq!(
+        agg.stages().collect::<Vec<_>>(),
+        vec![Stage::Collect, Stage::Audit]
+    );
+    assert!(!agg.stages().any(|s| s == Stage::Classify));
 }
 
 #[test]


### PR DESCRIPTION
Closes #5361. Unblocks #5302.

`run_full_sweep` accepted `progress: Option<&ProgressBus>` and discarded it, so only the collection stage emitted progress. All eight stages now emit a start and a terminal (completed/failed) event on the caller's bus.

## Test ladder — rung 3 (localized behaviour inside one crate)

    cargo fmt --check
    cargo check -p tga
    cargo clippy -p tga --all-targets -- -D warnings
    cargo test -p tga

All green: 1054 passed, 0 failed, 1 ignored. Plus `scripts/check_line_cap.sh` (0 violations) and `scripts/check_sld.sh` (0 errors).

New tests: `sweep_emits_progress_for_non_collection_stages`, `a_disabled_bus_stays_a_no_op`, `aggregate_lists_only_stages_that_produced_rows`. The first was proved red against pre-fix behaviour (empty bus → `a bus handed to run_full_sweep received nothing at all`).

## Notes for the reviewer

- `Stage::Audit` is additive on a `#[non_exhaustive]` enum; `Stage::all()` still returns `[Stage; 3]` deliberately, so `tga tui` does not paint empty rows.
- `commands/tui/render.rs` now iterates `ProgressAggregate::stages()` so audit rows render; the three pipeline stages render byte-identically.
- code-critic: APPROVE. Credential scan: CLEAN.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools