### PR TITLE
fix(trusty-search): restore main — tests_4715 asserts vs #5345's tuple error type (#3717)

### DIFF
--- a/crates/trusty-search/changelog.d/3717-restore-tests-4715-compile.md
+++ b/crates/trusty-search/changelog.d/3717-restore-tests-4715-compile.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `cargo test -p trusty-search` compiles again. #5345 gave `index_status` and
+  `chunks` a JSON body, changing their error type from `StatusCode` to
+  `(StatusCode, Json<Value>)`, but two `assert_eq!` calls in
+  `deleted_cold_parked_index_is_404_not_a_permanent_503` still compared the
+  whole tuple against a bare `StatusCode`, so the lib-test target failed to
+  build and took every gate on `main` with it. The three guards that test pins
+  now destructure the response and assert both the 404 and the
+  `unknown index: <id>` body, so a regression that returns 404 while still
+  advertising `restore_via` is caught rather than passing on the code alone.

--- a/crates/trusty-search/src/service/server/tests_4715.rs
+++ b/crates/trusty-search/src/service/server/tests_4715.rs
@@ -220,8 +220,9 @@ async fn restore_failed_index_grep_says_restart_not_retry() {
 /// delete-then-reindex case (#4715).
 /// What: parks an index cold, deletes it through the real handler, then drives
 /// `index_status_handler`, `get_index_chunks_handler`, and `grep_handler` —
-/// the same three guards this file pins — asserting 404 from each. Pre-fix all
-/// three return 503.
+/// the same three guards this file pins — asserting from each both the 404 and
+/// the `unknown index: <id>` body that names the absent-everywhere verdict.
+/// Pre-fix all three return 503.
 /// Test: this test.
 #[tokio::test]
 async fn deleted_cold_parked_index_is_404_not_a_permanent_503() {
@@ -240,20 +241,29 @@ async fn deleted_cold_parked_index_is_404_not_a_permanent_503() {
          real registration. Body: {body}"
     );
 
-    let status_err = super::status::index_status_handler(
+    // #5345 gave `status` and `chunks` a JSON body alongside the status code,
+    // so both arrive as `(StatusCode, Json<Value>)`. Assert the body too: the
+    // code alone cannot tell the 404 verdict apart from a 503 body that still
+    // advertises `restore_via`, which is the exact regression #5075 is about.
+    let (status_code, axum::Json(status_body)) = super::status::index_status_handler(
         State(Arc::clone(&state)),
         axum::extract::Path("cold-deleted".to_string()),
     )
     .await
     .expect_err("a deleted index cannot be reported");
     assert_eq!(
-        status_err,
+        status_code,
         StatusCode::NOT_FOUND,
         "#5075: /status must say the index is gone, not that it is still \
-         restoring — the 503 never clears"
+         restoring — the 503 never clears. Body: {status_body}"
+    );
+    assert_eq!(
+        status_body["error"], "unknown index: cold-deleted",
+        "#5075: /status must render the absent-everywhere verdict, not a \
+         residency miss. Body: {status_body}"
     );
 
-    let chunks_err = super::files::get_index_chunks_handler(
+    let (chunks_code, axum::Json(chunks_body)) = super::files::get_index_chunks_handler(
         State(Arc::clone(&state)),
         axum::extract::Path("cold-deleted".to_string()),
         axum::extract::Query(chunks_params()),
@@ -261,12 +271,17 @@ async fn deleted_cold_parked_index_is_404_not_a_permanent_503() {
     .await
     .expect_err("a deleted index has no chunks");
     assert_eq!(
-        chunks_err,
+        chunks_code,
         StatusCode::NOT_FOUND,
-        "#5075: /chunks must be 404"
+        "#5075: /chunks must be 404. Body: {chunks_body}"
+    );
+    assert_eq!(
+        chunks_body["error"], "unknown index: cold-deleted",
+        "#5075: /chunks must render the absent-everywhere verdict, not a \
+         residency miss. Body: {chunks_body}"
     );
 
-    let grep_err = super::files::grep_handler(
+    let (grep_code, axum::Json(grep_body)) = super::files::grep_handler(
         State(Arc::clone(&state)),
         axum::extract::Path("cold-deleted".to_string()),
         axum::Json(grep_request()),
@@ -274,9 +289,13 @@ async fn deleted_cold_parked_index_is_404_not_a_permanent_503() {
     .await
     .expect_err("a deleted index has nothing to grep");
     assert_eq!(
-        grep_err.0,
+        grep_code,
         StatusCode::NOT_FOUND,
-        "#5075: /grep must be 404, got body {:?}",
-        grep_err.1 .0
+        "#5075: /grep must be 404. Body: {grep_body}"
+    );
+    assert_eq!(
+        grep_body["error"], "unknown index: cold-deleted",
+        "#5075: /grep must render the absent-everywhere verdict, not a \
+         residency miss. Body: {grep_body}"
     );
 }


### PR DESCRIPTION
Unblocks #3717. `origin/main` (`6a8071591`) does not compile.

#5345 (merge `364aba420`) changed `index_status_handler` and `get_index_chunks_handler` to return `(StatusCode, Json<Value>)` so a residency miss carries a body. Two `assert_eq!` calls in `deleted_cold_parked_index_is_404_not_a_permanent_503` still compared the whole tuple against a bare `StatusCode`, so `trusty-search`'s lib-test target failed to build — which fails `cargo check --workspace --all-targets` and every CI run on main.

```
error[E0369]: binary operation `==` cannot be applied to type `(StatusCode, axum::Json<serde_json::Value>)`
   --> crates/trusty-search/src/service/server/tests_4715.rs:249:5
error[E0369]: binary operation `==` cannot be applied to type `(StatusCode, axum::Json<serde_json::Value>)`
   --> crates/trusty-search/src/service/server/tests_4715.rs:263:5
error: could not compile `trusty-search` (lib test) due to 2 previous errors
```

## What the asserts now check

All three guards the test pins — `index_status`, `chunks`, `grep` — destructure the response and assert the status code AND the body's `error`, matching the existing pattern at `tests_index_routing.rs:384-385`.

The body assertion is what keeps the test saying what it was written to say. #5075's failure mode is that `DELETE` leaves the id in the cold store, so the endpoints answer `503 index_not_resident` with a `restore_via` field pointing at an index that no longer exists — a 503 that never clears. Asserting only the code would still catch that, but the code alone cannot distinguish a correct 404 from a 404 rendered with the wrong verdict body, and the error text now names the offending body instead of just `left: 503 / right: 404`. The `grep` arm was already tuple-shaped and compiled; it gained the same body assertion so all three read identically.

No test was deleted, ignored, cfg-gated, or excluded. Test-attribute count is 2058 in `crates/trusty-search` on both `origin/main` and this branch.

## Proof the test kept its teeth

Temporarily removed `state.cold_store.purge(&index_id)` from `delete_index_handler` (`service/server/search.rs:132`) and re-ran the test:

```
assertion `left == right` failed: #5075: /status must say the index is gone, not that it is
still restoring — the 503 never clears. Body: {"error":"index_not_resident","index_id":
"cold-deleted","message":"index 'cold-deleted' is registered and built but is not currently
resident ...","restore_via":"POST /indexes/cold-deleted/search","retryable":true}
  left: 503
 right: 404
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1554 filtered out
```

Mutation reverted; the diff touches `tests_4715.rs` and one changelog fragment only.

## Gates — test ladder rung 4

```
cargo fmt --check                                            → EXIT=0
cargo check -p trusty-search --all-targets                   → EXIT=0
cargo clippy -p trusty-search --all-targets -- -D warnings   → EXIT=0
cargo test -p trusty-search                                  → EXIT=0
cargo check --workspace --all-targets                        → EXIT=0
```

`cargo check --workspace --all-targets` is the command that exits 101 on `origin/main`; it exits 0 here. That is the unblock.

`cargo test -p trusty-search`: 1976 passed, 0 failed, 41 ignored across 27 targets — lib alone `test result: ok. 1554 passed; 0 failed; 1 ignored`, integration `test result: ok. 372 passed; 0 failed; 3 ignored`. All 7 `tests_4715` tests pass, including `deleted_cold_parked_index_is_404_not_a_permanent_503`.

Repo gates: `check_line_cap.sh` 3871 files, 4 allowlisted, 0 violations; `check_changelog_fragment.sh` OK; `check_sld.sh` 0 errors, 0 warnings.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools