### PR TITLE
fix(trusty-mpm): default tmux.alternate_screen to false for working scrollback

### DIFF
--- a/crates/trusty-agents/changelog.d/5364-alternate-screen-default.md
+++ b/crates/trusty-agents/changelog.d/5364-alternate-screen-default.md
@@ -1,0 +1,9 @@
+Changed
+
+- `tagent`-created tmux sessions now set `alternate-screen off`, inheriting the
+  `DEFAULT_TMUX_ALTERNATE_SCREEN` flip in
+  [#5364](https://github.com/bobmatnyc/trusty-tools/issues/5364). Both
+  session-creation call sites (`tmux::orchestrator`, `debugger::tmux`) pass the
+  shared constant through unchanged, so they stay consistent with trusty-mpm on
+  the tmux server both drive. Full-screen programs no longer restore the
+  terminal's prior screen on exit; their output lands in scrollback instead.

--- a/crates/trusty-agents/src/debugger/tmux.rs
+++ b/crates/trusty-agents/src/debugger/tmux.rs
@@ -273,11 +273,12 @@ mod tests {
             ]
         );
         assert_eq!(tmux_argv(&cmds[1]), ["set-option", "-g", "mouse", "on"]);
-        // #5151: window scope (`-wg`), and `on` — the factory default this
-        // adapter passes through unchanged.
+        // #5364: window scope (`-wg`), and `off` — this adapter passes the
+        // shared default through unchanged, and that default flipped from
+        // tmux's factory `on` so managed sessions get working scrollback.
         assert_eq!(
             tmux_argv(&cmds[2]),
-            ["set-option", "-wg", "alternate-screen", "on"]
+            ["set-option", "-wg", "alternate-screen", "off"]
         );
         assert_eq!(
             tmux_argv(&cmds[3]),

--- a/crates/trusty-agents/src/tmux/orchestrator.rs
+++ b/crates/trusty-agents/src/tmux/orchestrator.rs
@@ -458,11 +458,15 @@ mod tests {
             ]
         );
         assert_eq!(tmux_argv(&cmds[1]), ["set-option", "-g", "mouse", "on"]);
-        // #5151: window scope (`-wg`), and `on` — the factory default this
-        // orchestrator passes through unchanged.
+        // #5364: window scope (`-wg`), and `off` — this orchestrator passes
+        // the shared default through unchanged, and that default flipped from
+        // tmux's factory `on` so managed sessions get working scrollback.
+        // Both crates must agree: they drive the same tmux server, and
+        // `alternate-screen` is global, so a disagreement would have each
+        // crate's session creation revert the other's.
         assert_eq!(
             tmux_argv(&cmds[2]),
-            ["set-option", "-wg", "alternate-screen", "on"]
+            ["set-option", "-wg", "alternate-screen", "off"]
         );
         // No `-A`: this orchestrator preserves its pre-#3004 fail-if-exists
         // semantics, unlike trusty-mpm's idempotent creation.

--- a/crates/trusty-common/changelog.d/5364-alternate-screen-default.md
+++ b/crates/trusty-common/changelog.d/5364-alternate-screen-default.md
@@ -1,0 +1,10 @@
+Changed
+
+- `tmux::DEFAULT_TMUX_ALTERNATE_SCREEN` flipped from `true` to `false`
+  ([#5364](https://github.com/bobmatnyc/trusty-tools/issues/5364)). Both
+  consumers — trusty-mpm's config resolution and trusty-agents' two
+  session-creation call sites — inherit it, which is what keeps them from
+  fighting over the shared tmux server's global `alternate-screen` option.
+  Managed sessions now get working scrollback by default; the cost is that
+  `vim`, `less`, `htop` and `man` no longer restore the screen they covered.
+  Callers passing an explicit value are unaffected.

--- a/crates/trusty-common/src/tmux.rs
+++ b/crates/trusty-common/src/tmux.rs
@@ -329,15 +329,33 @@ pub const DEFAULT_TMUX_HISTORY_LIMIT: u32 = 100_000;
 pub const DEFAULT_TMUX_MOUSE: bool = true;
 
 /// Built-in default for whether panes may use the terminal alternate screen
-/// buffer (tmux `alternate-screen`) (#5151).
+/// buffer (tmux `alternate-screen`) (#5151, flipped to `false` by #5364).
 ///
-/// Why: `true` is tmux's own factory default AND the behaviour every existing
-/// managed session already has, so this knob changes nothing until an operator
-/// opts out. Defaulting to `false` would silently rewrite how every full-screen
-/// program in every pane on the shared server behaves — see
-/// [`scrollback_option_commands`] for what turning it off actually costs.
-/// What: `true`.
-pub const DEFAULT_TMUX_ALTERNATE_SCREEN: bool = true;
+/// Why: when a full-screen TUI draws into tmux's alternate screen, tmux does
+/// not append that output to the pane's scrollback at all — `history-limit` is
+/// irrelevant in that state, which is why a managed session can hold a
+/// 100,000-line history and still have nothing to scroll back through. #5151
+/// added this knob to fix that, but shipped it defaulting to `true` — tmux's
+/// factory value and the pre-fix behaviour — so the original bug persisted for
+/// every operator who never found the knob. `false` makes the fix the default:
+/// a managed session has working scrollback out of the box.
+///
+/// **The accepted tradeoff.** `alternate-screen` is server-global and every
+/// trusty-* managed session shares one tmux server, so this governs every pane
+/// on it, not just the ones running an agent. `vim`, `less`, `htop` and `man`
+/// stop restoring the screen they covered: each leaves its final frame behind,
+/// smeared into the scrollback on exit, sometimes with redraw garbage from
+/// partial repaints. The repo owner accepted that cost in exchange for working
+/// scrollback (#5364). Setting `tmux.alternate_screen: true` in
+/// `~/.trusty-tools/trusty-mpm/config.yaml` restores the old behaviour.
+/// What: `false`. Both consumers of this constant — trusty-mpm's config
+/// resolution and trusty-agents' two session-creation call sites — inherit it,
+/// so they cannot fight each other over the shared server's global option.
+/// Test: `scrollback_option_commands_alternate_screen_defaults_off`;
+/// trusty-mpm's `tmux_options_alternate_screen_defaults_off` covers the
+/// config-resolution half.
+// #5364: default flipped true -> false so scrollback works without opt-in.
+pub const DEFAULT_TMUX_ALTERNATE_SCREEN: bool = false;
 
 /// Render a [`TmuxCommand`] into an argv vector suitable for `Command::args`.
 ///
@@ -508,15 +526,16 @@ pub fn tmux_argv(cmd: &TmuxCommand) -> Vec<String> {
 /// not from here, so this function stays free of any config/file-system
 /// dependency and is testable with plain arguments.
 ///
-/// **What `alternate_screen: false` costs.** tmux's alternate screen is what
-/// gives a full-screen program its own buffer: the pane's prior contents
-/// reappear untouched when the program exits, and nothing the program drew is
-/// added to the pane's scrollback. Turning it off is why a TUI's output
-/// becomes scrollable — and the price is paid by EVERY pane on the shared
-/// tmux server, not just the one running an agent TUI. `vim`, `less`, `htop`
-/// and `man` all leave their final frame behind, smeared into the scrollback
-/// on exit, sometimes with redraw garbage. It is also not retroactive: history
-/// already lost to the alt screen stays lost.
+/// **What `alternate_screen: false` costs** — the default since #5364, so this
+/// is what a caller passing [`DEFAULT_TMUX_ALTERNATE_SCREEN`] now gets. tmux's
+/// alternate screen is what gives a full-screen program its own buffer: the
+/// pane's prior contents reappear untouched when the program exits, and nothing
+/// the program drew is added to the pane's scrollback. Turning it off is why a
+/// TUI's output becomes scrollable — and the price is paid by EVERY pane on the
+/// shared tmux server, not just the one running an agent TUI. `vim`, `less`,
+/// `htop` and `man` all leave their final frame behind, smeared into the
+/// scrollback on exit, sometimes with redraw garbage. It is also not
+/// retroactive: history already lost to the alt screen stays lost.
 ///
 /// What: three entries in the order the caller must run them, all of which
 /// must land before the caller's subsequent `new-session` —
@@ -527,7 +546,7 @@ pub fn tmux_argv(cmd: &TmuxCommand) -> Vec<String> {
 /// measured reason the server/pane scopes silently do nothing here.
 /// Test: `scrollback_option_commands_uses_configured_values`,
 /// `scrollback_option_commands_mouse_off`,
-/// `scrollback_option_commands_alternate_screen_defaults_on`,
+/// `scrollback_option_commands_alternate_screen_defaults_off`,
 /// `scrollback_option_commands_alternate_screen_off_uses_window_scope`.
 pub fn scrollback_option_commands(
     history_limit: u32,

--- a/crates/trusty-common/src/tmux_tests.rs
+++ b/crates/trusty-common/src/tmux_tests.rs
@@ -255,16 +255,17 @@ fn scrollback_option_commands_mouse_off() {
 }
 
 #[test]
-fn scrollback_option_commands_alternate_screen_defaults_on() {
-    // #5151: `on` is tmux's factory default and today's behaviour — the
-    // knob is opt-IN, so the default must never alter an operator's
-    // terminal.
+fn scrollback_option_commands_alternate_screen_defaults_off() {
+    // #5364: the default is `off` so a managed session gets working
+    // scrollback without the operator finding the knob first. #5151 shipped
+    // it as `on` (tmux's factory value), which left the original bug in
+    // place for everyone who never opted in.
     // Compile-time tripwire: flipping the default is a deliberate act.
-    const { assert!(DEFAULT_TMUX_ALTERNATE_SCREEN) };
+    const { assert!(!DEFAULT_TMUX_ALTERNATE_SCREEN) };
     let cmds = scrollback_option_commands(100_000, true, DEFAULT_TMUX_ALTERNATE_SCREEN);
     assert_eq!(
         tmux_argv(&cmds[2]),
-        ["set-option", "-wg", "alternate-screen", "on"]
+        ["set-option", "-wg", "alternate-screen", "off"]
     );
 }
 

--- a/crates/trusty-mpm/changelog.d/5364-alternate-screen-default.md
+++ b/crates/trusty-mpm/changelog.d/5364-alternate-screen-default.md
@@ -1,0 +1,16 @@
+Changed
+
+- `tmux.alternate_screen` now defaults to `false`, so a tm-managed session has
+  working scrollback out of the box ([#5364](https://github.com/bobmatnyc/trusty-tools/issues/5364)).
+  [#5151](https://github.com/bobmatnyc/trusty-tools/issues/5151) added the knob
+  to fix missing scrollback but shipped it defaulting to `true` — tmux's factory
+  value and the pre-fix behaviour — so the original bug persisted for every
+  operator who never found the knob. A full-screen TUI draws into tmux's
+  alternate screen, and tmux does not append that output to the pane's
+  scrollback at all; `history-limit` is irrelevant in that state.
+- **Tradeoff, accepted deliberately:** `alternate-screen` is server-global and
+  every trusty-* managed session shares one tmux server, so `vim`, `less`,
+  `htop` and `man` no longer restore the terminal's prior screen on exit
+  server-wide — each leaves its final frame in the scrollback. Set
+  `tmux.alternate_screen: true` in `~/.trusty-tools/trusty-mpm/config.yaml` to
+  restore the old behaviour.

--- a/crates/trusty-mpm/src/core/trusty_tools_config.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config.rs
@@ -169,8 +169,9 @@ pub struct TrustyToolsConfig {
     /// #2398).
     ///
     /// `None` → the built-in defaults apply: a 100,000-line `history-limit`,
-    /// `mouse on`, and `alternate-screen on`. See [`resolve_tmux_options`] for
-    /// the full precedence and [`TmuxConfig`] for the field-level docs.
+    /// `mouse on`, and `alternate-screen off` (#5364). See
+    /// [`resolve_tmux_options`] for the full precedence and [`TmuxConfig`] for
+    /// the field-level docs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tmux: Option<TmuxConfig>,
 }
@@ -275,26 +276,29 @@ pub struct TmuxConfig {
 
     /// Whether programs in a pane may use the terminal alternate screen
     /// buffer (tmux `alternate-screen`). `None` →
-    /// [`DEFAULT_TMUX_ALTERNATE_SCREEN`] (`true`), which is tmux's own
-    /// factory default — set `alternate_screen: false` to turn it off (#5151).
+    /// [`DEFAULT_TMUX_ALTERNATE_SCREEN`], which is `false` since #5364 — set
+    /// `alternate_screen: true` to restore tmux's factory behaviour.
     ///
-    /// **Why you would set this to `false`.** A full-screen TUI (Claude Code
+    /// **Why the default is `false`.** A full-screen TUI (Claude Code
     /// included) draws into the alternate screen, and tmux discards that
     /// buffer instead of appending it to the pane's scrollback. That is why a
     /// `tm` session can hold tens of thousands of lines of `history-limit` and
     /// still show you nothing to scroll back through: the history is not
     /// missing, it was never written to the pane. `false` makes the TUI draw
-    /// into the normal buffer, so its output lands in scrollback.
+    /// into the normal buffer, so its output lands in scrollback. #5151 added
+    /// this knob but defaulted it to `true`, leaving the bug in place for
+    /// anyone who never found it; #5364 flipped the default so a managed
+    /// session scrolls out of the box.
     ///
-    /// **What that costs — read before setting it.** The effect is
+    /// **What that costs — the accepted tradeoff.** The effect is
     /// server-wide, and every trusty-* managed session shares ONE tmux server,
     /// so this changes every pane on it, not just the ones running an agent.
     /// `vim`, `less`, `htop` and `man` all stop restoring the screen they
     /// covered: each leaves its final frame behind, smeared into the
     /// scrollback on exit, sometimes with redraw garbage from partial
-    /// repaints. It is also not retroactive — anything already written while
-    /// the alternate screen was up stays unrecoverable, and only panes created
-    /// after the option lands are affected at all.
+    /// repaints. The repo owner accepted that in exchange for working
+    /// scrollback (#5364). It is also not retroactive — anything already
+    /// written while the alternate screen was up stays unrecoverable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub alternate_screen: Option<bool>,
 }
@@ -337,12 +341,14 @@ pub struct ResolvedTmuxOptions {
 /// clamps `history_limit` up to [`MIN_TMUX_HISTORY_LIMIT`] — a configured `0`
 /// (or any other near-zero value) does NOT mean "unlimited" in tmux, so it is
 /// corrected rather than honoured verbatim (#2398 QA finding).
-/// `alternate_screen` is NOT clamped or corrected: both values are legitimate
-/// and the default matches tmux's own, so an absent config leaves the
-/// operator's terminal behaving exactly as it does today (#5151).
+/// `alternate_screen` is NOT clamped or corrected: both values are legitimate,
+/// so a configured value is honoured verbatim. Its default is `false` (#5364),
+/// which is deliberately NOT tmux's factory value — see
+/// [`TmuxConfig::alternate_screen`] for the scrollback it buys and the
+/// screen-restore behaviour it gives up server-wide.
 /// Test: `tmux_options_default_when_no_config`, `tmux_options_config_override`,
 /// `tmux_options_clamps_zero_history_limit`, `tmux_options_clamps_below_minimum`,
-/// `tmux_options_alternate_screen_defaults_on`,
+/// `tmux_options_alternate_screen_defaults_off`,
 /// `tmux_options_alternate_screen_config_override`.
 pub fn resolve_tmux_options(config: &TrustyToolsConfig) -> ResolvedTmuxOptions {
     let section = config.tmux.as_ref();
@@ -353,7 +359,8 @@ pub fn resolve_tmux_options(config: &TrustyToolsConfig) -> ResolvedTmuxOptions {
     ResolvedTmuxOptions {
         history_limit,
         mouse: section.and_then(|t| t.mouse).unwrap_or(DEFAULT_TMUX_MOUSE),
-        // #5151: opt-in knob — absent config keeps tmux's factory `on`.
+        // #5364: absent config now resolves to `off` so scrollback works
+        // without the operator opting in; `true` restores tmux's factory value.
         alternate_screen: section
             .and_then(|t| t.alternate_screen)
             .unwrap_or(DEFAULT_TMUX_ALTERNATE_SCREEN),

--- a/crates/trusty-mpm/src/core/trusty_tools_config_tests.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config_tests.rs
@@ -379,7 +379,7 @@ fn tmux_config_yaml_round_trip() {
 
 /// Why: with no `tmux:` section at all, resolution must fall back to the
 /// built-in defaults (100,000-line history-limit, mouse on,
-/// alternate-screen on).
+/// alternate-screen off since #5364).
 /// Test: itself.
 #[test]
 fn tmux_options_default_when_no_config() {
@@ -389,17 +389,18 @@ fn tmux_options_default_when_no_config() {
     assert_eq!(opts.alternate_screen, DEFAULT_TMUX_ALTERNATE_SCREEN);
 }
 
-/// Why (#5151): `alternate_screen` is an OPT-IN knob. `on` is tmux's
-/// factory default and today's behaviour, so an absent section — and an
-/// absent field within a present section — must both resolve to `true`.
-/// Defaulting the other way would silently change how every full-screen
-/// program in every pane on the shared server behaves.
+/// Why (#5364): the alternate screen is OFF by default, so a managed session
+/// has working scrollback without the operator finding the knob first. An
+/// absent section — and an absent field within a present section — must both
+/// resolve to `false`. #5151 shipped this defaulting to `true` (tmux's factory
+/// value), which left the unscrollable-session bug in place for everyone who
+/// never opted in; that is the regression this test exists to catch.
 /// Test: itself.
 #[test]
-fn tmux_options_alternate_screen_defaults_on() {
+fn tmux_options_alternate_screen_defaults_off() {
     // Compile-time tripwire: flipping the default is a deliberate act.
-    const { assert!(DEFAULT_TMUX_ALTERNATE_SCREEN) };
-    assert!(resolve_tmux_options(&TrustyToolsConfig::default()).alternate_screen);
+    const { assert!(!DEFAULT_TMUX_ALTERNATE_SCREEN) };
+    assert!(!resolve_tmux_options(&TrustyToolsConfig::default()).alternate_screen);
 
     // A `tmux:` section that sets other fields but not this one still
     // falls back per-field.
@@ -411,7 +412,7 @@ fn tmux_options_alternate_screen_defaults_on() {
         }),
         ..Default::default()
     };
-    assert!(resolve_tmux_options(&partial).alternate_screen);
+    assert!(!resolve_tmux_options(&partial).alternate_screen);
 }
 
 /// Why (#5151): a configured `false` is the ONLY thing that turns the

--- a/crates/trusty-mpm/src/daemon/tmux.rs
+++ b/crates/trusty-mpm/src/daemon/tmux.rs
@@ -330,7 +330,8 @@ impl TmuxDriver {
     /// What: loads [`crate::core::trusty_tools_config::TrustyToolsConfig`],
     /// resolves the `tmux:` section via
     /// [`crate::core::trusty_tools_config::resolve_tmux_options`] (defaults:
-    /// 100,000-line history-limit, mouse on, alternate-screen on), and runs
+    /// 100,000-line history-limit, mouse on, alternate-screen off since
+    /// #5364), and runs
     /// each [`crate::core::tmux::scrollback_option_commands`] entry via
     /// [`Self::run`] — including the `-wg`-scoped `alternate-screen` entry
     /// (#5151). Best-effort: `set-option` is idempotent (safe to


### PR DESCRIPTION
Closes #5364

## What changed

`DEFAULT_TMUX_ALTERNATE_SCREEN` flips `true` → `false`.

#5151 added the `tmux.alternate_screen` knob to fix missing scrollback, but shipped it defaulting to `true` — tmux's factory value and the pre-fix behaviour — so the original bug persisted for every operator who never found the knob. When a full-screen TUI draws into tmux's alternate screen, tmux does not append that output to the pane's scrollback at all; `history-limit` is irrelevant in that state. That is why a session can verify a 100,000-line history and still have nothing to scroll back through.

## Scope correction: the constant is in trusty-common, not trusty-mpm

The issue and my brief both place the default in `crates/trusty-mpm/src/core/trusty_tools_config.rs`. It is only re-exported there — it is **defined** at `crates/trusty-common/src/tmux.rs:340`, and `trusty-agents` reads it directly at two session-creation call sites (`tmux/orchestrator.rs:140`, `debugger/tmux.rs:132`).

Neither crate passes `-L`/`-S`, so both drive the **same** tmux server, and `alternate-screen` is set `-wg` (global) immediately before every `new-session`. A trusty-mpm-only default would therefore be reverted server-wide by the next `tagent` session creation. Flipping the shared constant is what makes the fix hold. **This deliberately changes trusty-agents behavior too** — that is in scope, not a side effect.

Live corroboration that the thrash is real: with a `tagent` process running on the shared server, session `tm-cto-02` measures `alternate_on=1` while every tm-created session measures `0`.

## The tradeoff

`vim`, `less`, `htop` and `man` no longer restore the terminal's prior screen on exit, **server-wide** — each leaves its final frame in the scrollback, sometimes with redraw garbage. The repo owner accepted this in exchange for working scrollback. Setting `tmux.alternate_screen: true` restores the old behaviour.

## Proof no path can still emit `on`

`git grep -n 'alternate-screen'` → 60 hits workspace-wide, all accounted for:

| Category | Count | Note |
|---|---|---|
| Comments / doc comments | 41 | prose only |
| `CHANGELOG.md` history | 2 | historical record of #5151, correctly left alone |
| Test assertions + fixtures | 15 | updated to `off` where they asserted the default |
| Option-name constant | 1 | `ALTERNATE_SCREEN_OPTION` — the name, not a value |
| Error-message strings | 2 | `core::tmux` verification diagnostics |
| **Production code emitting a value** | **0** | — |

The bool becomes a string in exactly one place, `trusty-common/src/tmux.rs:568`: `if alternate_screen { "on" } else { "off" }`. Every production caller feeds it from the constant.

The two literals flagged as a possible hardcoded `"on"` (`orchestrator.rs:465`, `debugger/tmux.rs:280`) are **test assertions** — `#[cfg(test)]` begins at `orchestrator.rs:421` and `debugger/tmux.rs:235`, above both. They asserted `"on"` because the constant was `true`; they now assert `"off"`.

Two fixtures still echo `alternate-screen on` (`trusty-mpm/src/core/tmux_tests.rs:341,370`). Those are fake-tmux stubs simulating a server *reporting* a value, and their tests pass explicit `true` literals rather than the constant — default-agnostic, unchanged.

## Docs swept

`docs/`, all `README.md`, `website/`, and config samples carry **no** statement of the old default — the only `docs/` hit is an unrelated ratatui note. Stale statements were confined to Rust doc comments, all corrected: `trusty_tools_config.rs` (section doc, field doc, resolver doc, inline comment), `daemon/tmux.rs`, and `trusty-common/src/tmux.rs`.

One inaccuracy fixed along the way: the old field doc claimed "only panes created after the option lands are affected at all." That is `history-limit`'s latching behaviour, not `alternate-screen`'s — the latter is re-applied before every `new-session` and takes effect globally. Removed.

## Gates — rung 4 (cross-crate, shared library)

Rung 3 on `trusty-common`, then workspace check plus each direct dependent. Only trusty-mpm and trusty-agents reference the tmux module.

```
cargo fmt --check                                        EXIT=0
cargo check -p trusty-common                             EXIT=0
cargo clippy -p trusty-common --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-common      test result: ok. 304 passed; 0 failed; 6 ignored
cargo check --workspace                                  EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings      EXIT=0
cargo clippy -p trusty-agents --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-agents      test result: ok. 3484 passed; 0 failed; 13 ignored
cargo test -p trusty-mpm         test result: FAILED. 4878 passed; 1 failed; 7 ignored
```

Repo gates: `check_line_cap.sh` 0 violations, `check_changelog_fragment.sh` all 3 crates recorded, `check_sld.sh` 0 errors.

### The one trusty-mpm failure is pre-existing (#4931)

`core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning` — unrelated to tmux; my diff touches zero files in `managed_config`.

Verified by stashing the change and re-running the same suite on the unmodified `origin/main` tree:

```
with my change:   test result: FAILED. 4878 passed; 1 failed; 7 ignored
on origin/main:   test result: FAILED. 4878 passed; 1 failed; 7 ignored
in isolation:     test result: ok. 1 passed; 0 failed
```

Identical test, identical counts, passes alone — the order-dependent parallel-execution failure tracked by #4931. Change-specific gates pass.

## Behaviour proof

```
cargo test -p trusty-common alternate_screen   ok. 2 passed
  scrollback_option_commands_alternate_screen_defaults_off ... ok
cargo test -p trusty-mpm alternate_screen      ok. 10 passed
  tmux_options_alternate_screen_defaults_off ... ok
```

Both crates keep a compile-time tripwire (`const { assert!(!DEFAULT_TMUX_ALTERNATE_SCREEN) }`) so the next flip is deliberate.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools