### PR TITLE
docs(trusty-mpm): ban borrowed-metaphor jargon in PM and agent prose

### DIFF
--- a/crates/trusty-code/changelog.d/5372-ban-borrowed-metaphor-jargon.md
+++ b/crates/trusty-code/changelog.d/5372-ban-borrowed-metaphor-jargon.md
@@ -1,0 +1,5 @@
+Changed
+
+- The embedded `BASE-AGENT.md` copy tracks trusty-mpm's new ban on
+  borrowed-metaphor jargon — "load-bearing" and its category — keeping the two
+  byte-identical (#5372).

--- a/crates/trusty-code/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-code/src/assets/agents/BASE-AGENT.md
@@ -415,6 +415,21 @@ above, never this list:
 Both rules are the same family as the banned word "honest": a word or phrase
 that manages the reader instead of informing them.
 
+**No borrowed-metaphor jargon.** "Load-bearing" is the instance that prompted
+this rule. The metaphor sounds precise, carries no fact the plain sentence would
+not, and stands in for the cause and effect the reader actually needs. Say the
+mechanism.
+
+- Wrong: "that section is load-bearing"
+- Right: "deleting that section breaks X"
+
+This bans the CATEGORY — an engineering metaphor borrowed to signal precision —
+not a list of words, which only invites the next synonym. Non-exhaustive
+examples: "surface area", "impedance mismatch", "first-class", "orthogonal".
+
+Scope: PM and agent prose. It does not reach code, an ADR quoting prior art, or
+a record of what someone else said.
+
 **Ticket and PR bodies you draft** are sparse: point at a spec, issue, or PR
 instead of restating it, and never paste a source-file table or a diff in. You do
 not file the issue or open the PR — hand the text to the dispatching PM, which

--- a/crates/trusty-mpm/changelog.d/5372-ban-borrowed-metaphor-jargon.md
+++ b/crates/trusty-mpm/changelog.d/5372-ban-borrowed-metaphor-jargon.md
@@ -1,0 +1,6 @@
+Changed
+
+- The `Communication — Write Plainly` section of every bundled output style, and
+  the agent-facing mirror in `BASE-AGENT.md`, now ban borrowed-metaphor
+  jargon — "load-bearing" and its category — and require the mechanism be
+  stated instead (#5372).

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -415,6 +415,21 @@ above, never this list:
 Both rules are the same family as the banned word "honest": a word or phrase
 that manages the reader instead of informing them.
 
+**No borrowed-metaphor jargon.** "Load-bearing" is the instance that prompted
+this rule. The metaphor sounds precise, carries no fact the plain sentence would
+not, and stands in for the cause and effect the reader actually needs. Say the
+mechanism.
+
+- Wrong: "that section is load-bearing"
+- Right: "deleting that section breaks X"
+
+This bans the CATEGORY — an engineering metaphor borrowed to signal precision —
+not a list of words, which only invites the next synonym. Non-exhaustive
+examples: "surface area", "impedance mismatch", "first-class", "orthogonal".
+
+Scope: PM and agent prose. It does not reach code, an ADR quoting prior art, or
+a record of what someone else said.
+
 **Ticket and PR bodies you draft** are sparse: point at a spec, issue, or PR
 instead of restating it, and never paste a source-file table or a diff in. You do
 not file the issue or open the PR — hand the text to the dispatching PM, which

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
@@ -218,6 +218,21 @@ above, never this list:
 Both rules are the same family as the banned word "honest": a word or phrase
 that manages the reader instead of informing them.
 
+**No borrowed-metaphor jargon.** "Load-bearing" is the instance that prompted
+this rule. The metaphor sounds precise, carries no fact the plain sentence would
+not, and stands in for the cause and effect the reader actually needs. Say the
+mechanism.
+
+- Wrong: "that section is load-bearing"
+- Right: "deleting that section breaks X"
+
+This bans the CATEGORY — an engineering metaphor borrowed to signal precision —
+not a list of words, which only invites the next synonym. Non-exhaustive
+examples: "surface area", "impedance mismatch", "first-class", "orthogonal".
+
+Scope: PM and agent prose. It does not reach code, an ADR quoting prior art, or
+a record of what someone else said.
+
 **Ticket and PR bodies** are sparse: point at a spec or issue instead of
 restating it, and never paste a source-file table or a diff in. The binding form
 for an issue body — including whether to cite a line number — belongs to

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
@@ -213,6 +213,21 @@ above, never this list:
 Both rules are the same family as the banned word "honest": a word or phrase
 that manages the reader instead of informing them.
 
+**No borrowed-metaphor jargon.** "Load-bearing" is the instance that prompted
+this rule. The metaphor sounds precise, carries no fact the plain sentence would
+not, and stands in for the cause and effect the reader actually needs. Say the
+mechanism.
+
+- Wrong: "that section is load-bearing"
+- Right: "deleting that section breaks X"
+
+This bans the CATEGORY — an engineering metaphor borrowed to signal precision —
+not a list of words, which only invites the next synonym. Non-exhaustive
+examples: "surface area", "impedance mismatch", "first-class", "orthogonal".
+
+Scope: PM and agent prose. It does not reach code, an ADR quoting prior art, or
+a record of what someone else said.
+
 **Ticket and PR bodies** are sparse: point at a spec or issue instead of
 restating it, and never paste a source-file table or a diff in. The binding form
 for an issue body — including whether to cite a line number — belongs to

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
@@ -195,6 +195,21 @@ above, never this list:
 Both rules are the same family as the banned word "honest": a word or phrase
 that manages the reader instead of informing them.
 
+**No borrowed-metaphor jargon.** "Load-bearing" is the instance that prompted
+this rule. The metaphor sounds precise, carries no fact the plain sentence would
+not, and stands in for the cause and effect the reader actually needs. Say the
+mechanism.
+
+- Wrong: "that section is load-bearing"
+- Right: "deleting that section breaks X"
+
+This bans the CATEGORY — an engineering metaphor borrowed to signal precision —
+not a list of words, which only invites the next synonym. Non-exhaustive
+examples: "surface area", "impedance mismatch", "first-class", "orthogonal".
+
+Scope: PM and agent prose. It does not reach code, an ADR quoting prior art, or
+a record of what someone else said.
+
 **Ticket and PR bodies** are sparse: point at a spec or issue instead of
 restating it, and never paste a source-file table or a diff in. The binding form
 for an issue body — including whether to cite a line number — belongs to

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -1305,6 +1305,46 @@ fn output_styles_mirror_the_pm_prose_rules() {
 }
 
 #[test]
+fn the_borrowed_metaphor_ban_reaches_both_prose_channels() {
+    // The owner banned "load-bearing" on 2026-08-10 as an instance of a
+    // category. It has to bind PM prose (the output styles, #2647) and agent
+    // prose (BASE-AGENT.md composition) alike, and it has to state the
+    // CATEGORY — asserting only the word would rebuild the phrase-list failure
+    // the sycophancy and framing-opener rules were rewritten to avoid.
+    use crate::core::agent_builder::compose_agent;
+    use std::path::Path;
+
+    const REQUIRED: &[&str] = &[
+        "**No borrowed-metaphor jargon.**",
+        "an engineering metaphor borrowed to signal precision",
+        "Scope: PM and agent prose.",
+    ];
+
+    for style in OUTPUT_STYLES {
+        for needle in REQUIRED {
+            assert!(
+                style.content.contains(needle),
+                "{} is missing the borrowed-metaphor ban {needle:?}",
+                style.id
+            );
+        }
+    }
+
+    let assets_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("assets")
+        .join("agents");
+    let composed =
+        compose_agent("version-control", &assets_dir).expect("compose_agent must succeed");
+    for needle in REQUIRED {
+        assert!(
+            composed.contains(needle),
+            "composed agent is missing the borrowed-metaphor ban {needle:?}"
+        );
+    }
+}
+
+#[test]
 fn base_agent_graduated_verbosity_survives_composition() {
     // Output styles do NOT apply to subagents (they run their own system
     // prompt), so the sparse-on-success rule has to reach agents through


### PR DESCRIPTION
The owner, on the phrase "the load-bearing section": "this is too jargony. Do not use language like this (in tm output style)." No issue was filed — the request and the fix ship in the same session.

## What the rule says

Adds **No borrowed-metaphor jargon.** to `Communication — Write Plainly`. It bans the category, not a word list, the same shape as the neighbouring sycophancy and framing-opener rules:

- Wrong: "that section is load-bearing"
- Right: "deleting that section breaks X"

"Load-bearing" is named as the instance that prompted it; "surface area", "impedance mismatch", "first-class", "orthogonal" appear as non-exhaustive illustration. Scope is PM and agent prose — not code, not an ADR quoting prior art, not a record of what someone else said.

## Where it lands

`Communication — Write Plainly` is the canonical home: the output style is the only channel that survives a manual `claude` launch with no tm-appended system prompt (#2647), and `assets/instructions/sections/core.md` already points here and states no prose rules of its own. It is untouched.

All three output styles carry a verbatim copy of that section, so the rule goes in all three. `BASE-AGENT.md` carries the agent-facing mirror — and exists in two places, since `crates/trusty-code/src/assets/agents/BASE-AGENT.md` is held byte-identical to the trusty-mpm source by `scripts/check_agent_assets.sh`. Both get the identical text; no deviation is registered, because a rule that governs trusty-mpm agents but not trusty-code agents is the drift that gate exists to prevent.

- `crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md`
- `crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md`
- `crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md`
- `crates/trusty-mpm/src/assets/agents/BASE-AGENT.md`
- `crates/trusty-code/src/assets/agents/BASE-AGENT.md`

The output styles have no mirrored copy anywhere — `git ls-files | grep output-style` returns the three trusty-mpm files only.

## Test

`the_borrowed_metaphor_ban_reaches_both_prose_channels` in `bundle_tests.rs` asserts the rule statement, the category clause, and the scope line reach every output style and a composed agent. It fails on `origin/main` — none of those strings exist there. The trusty-code copy is left to `check_agent_assets.sh`, which enforces byte parity mechanically and already caught this drift; a second assertion reading trusty-code's file from trusty-mpm's suite would duplicate that gate across a crate boundary.

## Gates — test ladder rung 3, both crates

```
bash scripts/check_agent_assets.sh
  agent-assets: scanned 30 byte-parity file(s) (floor 20), all match;
  4 pinned deviation(s) match upstream — OK.                                       # EXIT=0

cargo fmt --check && cargo check -p trusty-mpm  && cargo clippy -p trusty-mpm  --all-targets -- -D warnings   # EXIT=0
cargo fmt --check && cargo check -p trusty-code && cargo clippy -p trusty-code --all-targets -- -D warnings   # EXIT=0
cargo test -p trusty-mpm    # test result: ok. 4908 passed; 0 failed; 7 ignored (lib), all other targets ok
cargo test -p trusty-code   # test result: ok. 1602 passed; 0 failed; 4 ignored (lib), all other targets ok
bash scripts/check_sld.sh && check_line_cap.sh && check_doc_numbers.sh                                       # EXIT=0
bash scripts/check_capabilities.sh && bash scripts/check_changelog_fragment.sh                               # EXIT=0
```

The known non-deterministic `trusty-mpm` parallel-execution flakes did not appear in either run of that suite.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools