### PR TITLE
docs: batch SLOC-cap splits with the next change to the file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,11 +170,19 @@ still counted, as is any test module whose brace balance is skewed by a brace
 inside a string literal. The matcher is line-based and fails closed: it can
 raise a false cap violation, never silently drop production code.
 
+🟡 **No standalone SLOC-cap fix.** Never open a PR whose only purpose is bringing
+a file back under cap — the split ships inside the PR that next adds to that
+file, which is the PR the gate blocks anyway, so it costs one CI cycle instead of
+two. That is not licence to leave a red gate red: if your PR trips the cap, split
+in that PR. Example — a rebase pushed `bin/tm/main.rs` to 505 SLOC while the
+branch was adding a third `RepairAction` arm, and that same PR moved the match
+into a submodule.
+
 🔴 Mechanically enforced by `scripts/check_line_cap.sh` in CI and the pre-commit
 hook (#610) — a new tracked file over its cap **cannot merge**. Never turn this
 gate green by deleting, `#[ignore]`-ing, or excluding a file from the count;
-split it instead. Counting definition, the split pattern, ratchet-allowlist
-mechanics, and refactor history:
+split it instead. Counting definition, the split pattern, when a violation gets
+fixed, ratchet-allowlist mechanics, and refactor history:
 [docs/reference/sloc-cap.md](docs/reference/sloc-cap.md).
 
 🔴 **`thiserror` for libraries, `anyhow` for binaries** — library crates

--- a/docs/reference/sloc-cap.md
+++ b/docs/reference/sloc-cap.md
@@ -2,9 +2,9 @@
 
 > **The cap numbers, classification rule, and merge-blocking prohibition are
 > in [`CLAUDE.md`](../../CLAUDE.md)** (Key Conventions). This page is the counting definition, the
-> ratchet-allowlist mechanics, and the resolved-refactor history — consult it
-> when running the gate locally or updating the allowlist, not to decide
-> whether a file needs splitting.
+> batch-with-the-next-change scheduling rule, the ratchet-allowlist mechanics,
+> and the resolved-refactor history — consult it when running the gate locally,
+> updating the allowlist, or deciding which PR carries a split.
 
 ## Enforcement
 
@@ -13,9 +13,42 @@ As of issue #610 the production cap is no longer advice: it is gated by
 and the local pre-commit hook (`line-cap`). A new tracked production `.rs` file
 over 500 SLOC **cannot merge**; a new test/benchmark `.rs` file over 3000 SLOC
 **cannot merge**. Files approaching their limit are a signal to split into
-focused submodules before the next feature lands on them. When splitting, prefer:
+focused submodules as part of the next change that lands on them — see "When a
+Violation Gets Fixed" below for why the split rides along. When splitting, prefer:
 one public module per logical concept, a thin `mod.rs` that re-exports, and
 sibling files with clear single responsibilities.
+
+## When a Violation Gets Fixed — Batch, Never Standalone
+
+A file can cross its cap without anyone touching it: main grows the file under a
+branch, a rebase lands both halves, and the gate goes red on a diff that never
+added those lines. The fix is a split, and the question is *which PR carries it*.
+
+**It is the PR that next adds to that file, always.** Never open a PR — or
+dispatch an agent — whose only deliverable is bringing a file back under cap.
+That PR pays a full CI cycle, a review pass, and a merge for zero behavior
+change, and it conflicts with whatever branch is already editing the file. Since
+a PR that adds to an over-cap file is blocked by the gate regardless, folding the
+split into it lands the same work at the same moment for one CI cycle instead of
+two.
+
+The rule is about *scheduling* the split, not skipping it. A red gate never
+merges (see the ratchet rules below), so if your PR trips the cap, you split in
+your PR — the pressure to split arrives exactly when someone is already in the
+file and best placed to choose the seam.
+
+Worked example: a rebase pushed `crates/trusty-mpm/src/bin/tm/main.rs` to 505
+SLOC because main had grown the file while the branch was adding a third
+`RepairAction` arm. The split shipped inside that PR — the dispatch match moved
+into a `commands` submodule and `main.rs`'s arm became one line. What the rule
+forbids is the opposite shape: a separate PR splitting `main.rs` while nobody is
+otherwise touching it.
+
+Two cases sit outside this rule. A file that is genuinely un-growable without a
+split (every pending change to it is blocked) is a refactor ticket in its own
+right — that is a planned restructuring, not a cap fix. And an allowlisted file
+that drops below its budget only needs `check_line_cap.sh --update`, which is a
+line in whatever PR shrank it.
 
 ## SLOC Counting Definition
 


### PR DESCRIPTION
Owner ask, this session: "let's make a rule that we don't fix SINGLE SLOC violations, we batch them with the NEXT addition to that file to be more efficient." No issue — this PR is the record.

The cap is mechanically enforced, so the rule cannot be "leave violations unfixed." It is about which PR carries the split: the one that next adds to that file, which is the PR the gate blocks anyway. One CI cycle instead of two, and the person choosing the seam is already in the file.

`CLAUDE.md` gets the 🟡 rule in the SLOC block — six lines, one shorter than the inline-`#[cfg(test)]` rule beside it. That file is resident in every prompt here, so the reasoning, the worked example, and the two cases outside the rule (a planned refactor ticket for an un-growable file; an allowlist `--update`) go to `docs/reference/sloc-cap.md`, which is already where cap mechanics live. The existing pointer line picks up "when a violation gets fixed" at no extra line.

One consistency fix: the reference doc's Enforcement section said to split "before the next feature lands," which is the shape the new rule forbids. It now says "as part of the next change."

Gates (rung 1, docs-only): `check_sld.sh`, `check_doc_numbers.sh`, `check_public_docs.sh`, `check_line_cap.sh` — all pass, `EXIT=0`. No changelog fragment: no crate `src/**` touched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools