### PR TITLE
fix(trusty-review): compose the Executive Summary deterministically so §2 is never empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11763,7 +11763,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "1.0.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.13" }
+trusty-review = { path = "crates/trusty-review", version = "0.14" }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.13.0"
+version     = "0.14.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/5318-exec-summary-deterministic.md
+++ b/crates/trusty-review/changelog.d/5318-exec-summary-deterministic.md
@@ -11,3 +11,7 @@ Fixed
   - When nothing measurable was supplied, §2 now names the specific missing
     inputs (no `metrics` file, no `--analyze` fetch, no scannable checkout)
     instead of collapsing to the generic Gaps & Caveats pointer.
+  - The Top Risks table caps at five rows and now says so in the table itself
+    ("**Top 5 of 7** — 2 further RED/AMBER finding(s) are not listed here…"), so
+    a reader who skims the table without the paragraph above it cannot mistake
+    five rows for the whole risk picture.

--- a/crates/trusty-review/changelog.d/5318-exec-summary-deterministic.md
+++ b/crates/trusty-review/changelog.d/5318-exec-summary-deterministic.md
@@ -1,0 +1,13 @@
+Fixed
+
+- The technical-DD report's §2 Executive Summary no longer renders
+  `_No data available — see Gaps & Caveats._` on a run without `--synthesize`
+  (issue #5318). It was filled only from LLM synthesis prose, so every
+  `tga audit` report collapsed the first section a diligence reader opens while
+  listing real RED/AMBER findings in §5. §2 and its Top Risks table now roll up
+  from the report's own data — applications, size, language mix, severity counts
+  by dimension, and the application risk concentrates in — with the provenance of
+  the figures used. Verified synthesis prose still wins when `--synthesize` runs.
+  - When nothing measurable was supplied, §2 now names the specific missing
+    inputs (no `metrics` file, no `--analyze` fetch, no scannable checkout)
+    instead of collapsing to the generic Gaps & Caveats pointer.

--- a/crates/trusty-review/src/report/exec_summary.rs
+++ b/crates/trusty-review/src/report/exec_summary.rs
@@ -1,0 +1,458 @@
+//! Deterministic Executive Summary + Top Risks for §2 (#5318).
+//!
+//! Why: §2 is the first section a due-diligence reader opens, and it was the
+//! only section of the report with no deterministic source — `reporter.rs`
+//! filled it exclusively from `--synthesize` LLM prose. `tga audit` never
+//! passes `--synthesize` (see `tga::audit::review`'s `invoke`), so every AUDIT
+//! report collapsed §2 to `_No data available — see Gaps & Caveats._` while
+//! carrying real RED/AMBER findings two sections below. The measured data the
+//! report already renders answers the scope-and-posture questions §2 exists to
+//! answer; rolling it up here removes §2's dependence on an LLM without
+//! inventing anything.
+//! What: [`compose`] returns [`ExecSummary::Composed`] — a roll-up paragraph
+//! (applications, size, language mix, RED/AMBER counts, the dimensions and the
+//! application they concentrate in) with the provenance of the figures it used
+//! — or [`ExecSummary::Unavailable`], which names the specific inputs that were
+//! missing instead of leaving the reader the generic Gaps & Caveats pointer.
+//! [`top_risks`] derives the accompanying risk rows from the same findings,
+//! highest severity first. Verified synthesis prose still overwrites both when
+//! `--synthesize` runs and passes the guardrail (see `reporter::build_scope`).
+//! Test: `exec_summary_tests.rs`.
+//!
+//! # Spec References
+//! - [`SPEC-TGAUDIT-08~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-08~draft)
+
+use std::collections::BTreeMap;
+
+use super::metrics::{MetricFinding, Severity};
+use super::model::{ReportModel, RepositoryReport};
+use super::provenance::Provenance;
+
+/// Max application names spelled out before the list is elided.
+const MAX_APP_NAMES: usize = 4;
+/// Max languages named in the scope sentence.
+const MAX_LANGUAGES: usize = 3;
+/// Max finding dimensions named in the posture sentence.
+const MAX_DIMENSIONS: usize = 3;
+/// Max deterministic Top Risks rows.
+const MAX_RISK_ROWS: usize = 5;
+/// Max characters kept from a finding's description in a risk row.
+const MAX_RISK_DESCRIPTION_CHARS: usize = 160;
+
+/// The closing sentence: what this paragraph is, so it is never mistaken for
+/// an analyst's judgement.
+const ROLLUP_NOTE: &str = "This summary is a deterministic roll-up of the data in the sections below, not an analyst judgement.";
+
+/// The §2 paragraph this report can honestly render.
+///
+/// Why: the two outcomes are genuinely different for a reader — a roll-up is
+/// report content and carries provenance; an unavailability statement is a
+/// statement ABOUT the report and carries none. Keeping them distinct stops the
+/// caller from tagging a "not generated" line as measured data.
+/// What: `Composed` carries the paragraph and the provenance of the figures it
+/// was built from; `Unavailable` carries a sentence naming the missing inputs.
+/// Test: `exec_summary_tests.rs::{composes_from_metrics_findings,
+/// unavailable_names_the_missing_inputs}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ExecSummary {
+    /// A roll-up paragraph over the report's own measured/declared data.
+    Composed {
+        /// The rendered paragraph.
+        text: String,
+        /// Where the figures in it came from.
+        provenance: Provenance,
+    },
+    /// Nothing to roll up; the text names which inputs were absent.
+    Unavailable(String),
+}
+
+impl ExecSummary {
+    /// The rendered text either way.
+    pub fn text(&self) -> &str {
+        match self {
+            ExecSummary::Composed { text, .. } => text,
+            ExecSummary::Unavailable(text) => text,
+        }
+    }
+}
+
+/// Compose the deterministic executive-summary paragraph for `model`.
+///
+/// Why: the single entry point `reporter.rs` calls before (and independently
+/// of) synthesis injection, so §2 always renders something a reader can act on.
+/// What: gathers per-repository size/language/finding facts, then renders the
+/// scope, posture, concentration, and roll-up sentences. A manifest with no
+/// repositories, or one where no repository yielded a scan, a metrics file, or
+/// a live analyze fetch, returns [`ExecSummary::Unavailable`] naming exactly
+/// those inputs.
+/// Test: `exec_summary_tests.rs::{composes_from_metrics_findings,
+/// composes_from_scan_only, unavailable_with_no_repositories,
+/// unavailable_names_the_missing_inputs}`.
+pub fn compose(model: &ReportModel) -> ExecSummary {
+    if model.repositories.is_empty() {
+        return ExecSummary::Unavailable(
+            "Executive summary not generated: the manifest declared no repositories, so this \
+             report has nothing to summarize."
+                .to_string(),
+        );
+    }
+
+    let facts = Facts::gather(&model.repositories);
+    if !facts.has_data() {
+        return ExecSummary::Unavailable(format!(
+            "Executive summary not generated: none of the {} application(s) in this report \
+             carries size or findings data — no repository supplied a `metrics` file, no \
+             trusty-analyze fetch (`--analyze`) populated one, and no local checkout was \
+             scannable. What that leaves unassessed is listed under Gaps & Caveats.",
+            model.repositories.len()
+        ));
+    }
+
+    ExecSummary::Composed {
+        text: render(&facts),
+        provenance: facts.provenance,
+    }
+}
+
+/// One deterministic Top Risks row.
+///
+/// Why: the Top Risks table sits inside §2 and collapsed for the same reason
+/// the paragraph did — it was synthesis-only. The report's own RED/AMBER
+/// findings are exactly what the table asks for, minus a cost estimate, which
+/// nothing deterministic states.
+/// What: `description`/`severity`/`apps` are verbatim finding data;
+/// `cost` has no deterministic source and is left to the caller (it renders as
+/// the honesty marker).
+/// Test: `exec_summary_tests.rs::top_risks_are_red_first_and_capped`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DeterministicRisk {
+    /// The risk statement: finding title, plus its observation and component.
+    pub description: String,
+    /// `RED` or `AMBER`.
+    pub severity: String,
+    /// The owning application's display name.
+    pub apps: String,
+}
+
+/// Derive the Top Risks rows from the report's own RED/AMBER findings.
+///
+/// Why: same defect as the paragraph — an empty table in the first section
+/// reads as "no risks found" when the report lists findings two sections down.
+/// What: every non-GREEN finding across all repositories, RED before AMBER
+/// (stable within a band, so manifest and analyzer order are preserved), capped
+/// at [`MAX_RISK_ROWS`]. Empty when no repository carries findings.
+/// Test: `exec_summary_tests.rs::top_risks_are_red_first_and_capped`.
+pub fn top_risks(model: &ReportModel) -> Vec<DeterministicRisk> {
+    let mut rows: Vec<(u8, DeterministicRisk)> = Vec::new();
+    for repo in &model.repositories {
+        let Some(metrics) = &repo.metrics else {
+            continue;
+        };
+        for f in &metrics.findings {
+            let rank = match f.severity {
+                Severity::Red => 0,
+                Severity::Amber => 1,
+                Severity::Green => continue,
+            };
+            rows.push((
+                rank,
+                DeterministicRisk {
+                    description: risk_description(f),
+                    severity: if rank == 0 { "RED" } else { "AMBER" }.to_string(),
+                    apps: repo.name.clone(),
+                },
+            ));
+        }
+    }
+    rows.sort_by_key(|(rank, _)| *rank);
+    rows.into_iter()
+        .take(MAX_RISK_ROWS)
+        .map(|(_, risk)| risk)
+        .collect()
+}
+
+/// The risk statement for one finding: title, the tool's observation, and the
+/// component, skipping whichever of the last two the source left empty.
+fn risk_description(f: &MetricFinding) -> String {
+    let mut out = f.title.trim().to_string();
+    let description = truncate(f.description.trim(), MAX_RISK_DESCRIPTION_CHARS);
+    if !description.is_empty() {
+        out.push_str(" — ");
+        out.push_str(&description);
+    }
+    let component = f.component.trim();
+    if !component.is_empty() {
+        out.push_str(&format!(" ({component})"));
+    }
+    out
+}
+
+/// Truncate to `max_chars` on a char boundary, appending `…` when cut.
+fn truncate(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    format!("{}…", s.chars().take(max_chars).collect::<String>())
+}
+
+/// The measured/declared facts the paragraph is rendered from.
+///
+/// Why: gathering first keeps every sentence a pure function of counted data,
+/// so a test can pin the wording without building a template render.
+/// What: application names, aggregate size, aggregate language mix, RED/AMBER
+/// counts by dimension and by application, and the provenance of the figures.
+#[derive(Debug)]
+struct Facts {
+    app_names: Vec<String>,
+    total_loc: u64,
+    total_files: u64,
+    /// LoC per language, aggregated across applications.
+    by_language: BTreeMap<String, u64>,
+    red: usize,
+    amber: usize,
+    /// Non-GREEN finding counts per dimension/category.
+    by_dimension: BTreeMap<String, usize>,
+    /// Non-GREEN finding counts per application, RED-weighted for ranking.
+    red_by_app: BTreeMap<String, usize>,
+    amber_by_app: BTreeMap<String, usize>,
+    /// True when at least one figure came from a declared metrics document
+    /// rather than this tool's own scan.
+    provenance: Provenance,
+}
+
+impl Facts {
+    /// Gather the roll-up facts across every repository in the report.
+    ///
+    /// Why: declared metrics and the built-in scan carry the same figures with
+    /// different provenance; the paragraph must state which it used, and the
+    /// weaker claim wins when both contributed (mirrors
+    /// `reporter_fill::fill_profile`'s declared-over-measured precedence).
+    /// What: prefers a repository's metrics document over its scan for size and
+    /// language mix; findings only ever come from metrics (the scan produces
+    /// none).
+    fn gather(repos: &[RepositoryReport]) -> Self {
+        let mut f = Facts {
+            app_names: Vec::new(),
+            total_loc: 0,
+            total_files: 0,
+            by_language: BTreeMap::new(),
+            red: 0,
+            amber: 0,
+            by_dimension: BTreeMap::new(),
+            red_by_app: BTreeMap::new(),
+            amber_by_app: BTreeMap::new(),
+            provenance: Provenance::Measured,
+        };
+        for repo in repos {
+            f.app_names.push(repo.name.clone());
+
+            match (&repo.metrics, &repo.scan) {
+                (Some(m), _) if m.loc.total > 0 || !m.loc.by_language.is_empty() => {
+                    f.total_loc += m.loc.total;
+                    f.total_files += m.counts.files;
+                    for l in &m.loc.by_language {
+                        *f.by_language.entry(l.language.clone()).or_default() += l.loc;
+                    }
+                    f.provenance = Provenance::Declared;
+                }
+                (_, Some(s)) => {
+                    f.total_loc += s.total_loc;
+                    f.total_files += s.file_count;
+                    for l in &s.by_language {
+                        *f.by_language.entry(l.language.clone()).or_default() += l.loc;
+                    }
+                }
+                _ => {}
+            }
+
+            let Some(metrics) = &repo.metrics else {
+                continue;
+            };
+            for finding in &metrics.findings {
+                match finding.severity {
+                    Severity::Red => {
+                        f.red += 1;
+                        *f.red_by_app.entry(repo.name.clone()).or_default() += 1;
+                    }
+                    Severity::Amber => {
+                        f.amber += 1;
+                        *f.amber_by_app.entry(repo.name.clone()).or_default() += 1;
+                    }
+                    Severity::Green => continue,
+                }
+                let dimension = finding.category.trim();
+                if !dimension.is_empty() {
+                    *f.by_dimension.entry(dimension.to_string()).or_default() += 1;
+                }
+                f.provenance = Provenance::Declared;
+            }
+        }
+        f
+    }
+
+    /// True when anything measurable was gathered.
+    ///
+    /// Why: an unavailability statement is only honest when there genuinely was
+    /// no input — a report over remote-only entries with no metrics.
+    fn has_data(&self) -> bool {
+        self.total_loc > 0 || self.total_files > 0 || self.red + self.amber > 0
+    }
+
+    /// How many distinct applications contributed a RED or AMBER finding.
+    ///
+    /// Why: naming where risk concentrates only says anything when more than
+    /// one application carries findings — "Acme carries the most RED findings
+    /// (1 of 1)" on a single-application report is noise.
+    fn apps_with_findings(&self) -> usize {
+        self.red_by_app
+            .keys()
+            .chain(self.amber_by_app.keys())
+            .collect::<std::collections::BTreeSet<_>>()
+            .len()
+    }
+
+    /// The application carrying the most findings, RED before AMBER.
+    fn worst_app(&self) -> Option<(&str, usize, &'static str)> {
+        if let Some((name, count)) = max_entry(&self.red_by_app) {
+            return Some((name, count, "RED"));
+        }
+        max_entry(&self.amber_by_app).map(|(name, count)| (name, count, "AMBER"))
+    }
+}
+
+/// The highest-count entry, ties broken by the alphabetically first key so the
+/// sentence is stable across runs.
+fn max_entry(map: &BTreeMap<String, usize>) -> Option<(&str, usize)> {
+    let mut best: Option<(&str, usize)> = None;
+    for (name, count) in map {
+        if best.is_none_or(|(_, best_count)| *count > best_count) {
+            best = Some((name.as_str(), *count));
+        }
+    }
+    best
+}
+
+/// Render the paragraph from gathered facts.
+///
+/// Why: one place composes the sentences, so their order and separators are
+/// pinned by a single test rather than assembled at three call sites.
+/// What: scope sentence, posture sentence, an optional concentration sentence
+/// (only when more than one application carries findings), and [`ROLLUP_NOTE`].
+/// Test: `exec_summary_tests.rs::composes_from_metrics_findings`.
+fn render(f: &Facts) -> String {
+    let mut sentences = vec![scope_sentence(f), posture_sentence(f)];
+    if let Some(s) = concentration_sentence(f) {
+        sentences.push(s);
+    }
+    sentences.push(ROLLUP_NOTE.to_string());
+    sentences.join(" ")
+}
+
+/// "Repository inspection covered 2 applications (A, B), totalling 8200 lines
+/// of code across Rust and TypeScript, in 120 files."
+fn scope_sentence(f: &Facts) -> String {
+    let n = f.app_names.len();
+    let noun = if n == 1 {
+        "application"
+    } else {
+        "applications"
+    };
+    let mut out = format!(
+        "Repository inspection covered {n} {noun} ({})",
+        name_list(&f.app_names)
+    );
+    if f.total_loc > 0 {
+        out.push_str(&format!(", totalling {} lines of code", f.total_loc));
+        let langs = top_languages(f);
+        if !langs.is_empty() {
+            out.push_str(&format!(" across {}", join_and(&langs)));
+        }
+    }
+    if f.total_files > 0 {
+        out.push_str(&format!(", in {} files", f.total_files));
+    }
+    out.push('.');
+    out
+}
+
+/// "The analysis raised 1 RED (critical) and 1 AMBER (medium-risk) finding(s),
+/// concentrated in security (1) and maintainability (1)."
+fn posture_sentence(f: &Facts) -> String {
+    if f.red + f.amber == 0 {
+        return "The analysis raised no RED or AMBER findings against the data available for \
+                this run."
+            .to_string();
+    }
+    let mut out = format!(
+        "The analysis raised {} RED (critical) and {} AMBER (medium-risk) findings",
+        f.red, f.amber
+    );
+    let dims = top_dimensions(f);
+    if !dims.is_empty() {
+        out.push_str(&format!(", concentrated in {}", join_and(&dims)));
+    }
+    out.push('.');
+    out
+}
+
+/// "Repro App carries the most RED findings (3 of 5)." — only meaningful when
+/// more than one application contributed findings.
+fn concentration_sentence(f: &Facts) -> Option<String> {
+    if f.apps_with_findings() < 2 {
+        return None;
+    }
+    let (name, count, band) = f.worst_app()?;
+    let total = if band == "RED" { f.red } else { f.amber };
+    Some(format!(
+        "{name} carries the most {band} findings ({count} of {total})."
+    ))
+}
+
+/// The application names, eliding past [`MAX_APP_NAMES`].
+fn name_list(names: &[String]) -> String {
+    if names.len() <= MAX_APP_NAMES {
+        return names.join(", ");
+    }
+    format!(
+        "{}, and {} more",
+        names[..MAX_APP_NAMES].join(", "),
+        names.len() - MAX_APP_NAMES
+    )
+}
+
+/// The largest languages by aggregate LoC, up to [`MAX_LANGUAGES`].
+fn top_languages(f: &Facts) -> Vec<String> {
+    let mut langs: Vec<(&String, &u64)> =
+        f.by_language.iter().filter(|(_, loc)| **loc > 0).collect();
+    langs.sort_by_key(|(name, loc)| (std::cmp::Reverse(**loc), (*name).clone()));
+    langs
+        .into_iter()
+        .take(MAX_LANGUAGES)
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
+/// The most-hit finding dimensions with their counts, up to [`MAX_DIMENSIONS`].
+fn top_dimensions(f: &Facts) -> Vec<String> {
+    let mut dims: Vec<(&String, &usize)> = f.by_dimension.iter().collect();
+    dims.sort_by_key(|(name, count)| (std::cmp::Reverse(**count), (*name).clone()));
+    dims.into_iter()
+        .take(MAX_DIMENSIONS)
+        .map(|(name, count)| format!("{name} ({count})"))
+        .collect()
+}
+
+/// Join with commas and a final "and".
+fn join_and(items: &[String]) -> String {
+    match items {
+        [] => String::new(),
+        [one] => one.clone(),
+        [head @ .., last] => format!("{} and {last}", head.join(", ")),
+    }
+}
+
+#[cfg(test)]
+#[path = "exec_summary_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/exec_summary.rs
+++ b/crates/trusty-review/src/report/exec_summary.rs
@@ -136,16 +136,59 @@ pub struct DeterministicRisk {
     pub apps: String,
 }
 
+/// The capped Top Risks rows plus how many were eligible before the cap.
+///
+/// Why: the table shows at most [`MAX_RISK_ROWS`], and a reader who reads the
+/// table without the paragraph above it would otherwise take five rows as the
+/// whole risk picture. Carrying the pre-cap count is what lets the renderer say
+/// so in the table itself. A capped top-risks table has already shipped as a
+/// defect once (#2373); this time the truncation is stated.
+/// What: `rows` is what renders; `eligible` counts every non-GREEN finding that
+/// qualified for a row, so `eligible - rows.len()` is exactly what was dropped.
+/// Test: `exec_summary_tests.rs::{top_risks_are_red_first_and_capped,
+/// truncation_note_absent_when_nothing_was_dropped}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct TopRisks {
+    /// The rows to render, RED first, at most [`MAX_RISK_ROWS`].
+    pub rows: Vec<DeterministicRisk>,
+    /// How many findings qualified for a row before the cap was applied.
+    pub eligible: usize,
+}
+
+impl TopRisks {
+    /// The table's truncation caption, or `None` when nothing was dropped.
+    ///
+    /// Why: it must be legible to someone reading only the table, so it leads
+    /// with the ratio and points at the section that carries every finding.
+    /// What: `Some` only when the cap actually dropped rows.
+    /// Test: `exec_summary_tests.rs::{top_risks_are_red_first_and_capped,
+    /// truncation_note_absent_when_nothing_was_dropped}`.
+    pub fn truncation_note(&self) -> Option<String> {
+        let hidden = self.eligible.saturating_sub(self.rows.len());
+        (hidden > 0).then(|| {
+            format!(
+                "**Top {} of {}** — {hidden} further RED/AMBER finding(s) are not listed here; \
+                 section 5, Findings by Severity, lists all {} unabridged.",
+                self.rows.len(),
+                self.eligible,
+                self.eligible,
+            )
+        })
+    }
+}
+
 /// Derive the Top Risks rows from the report's own RED/AMBER findings.
 ///
 /// Why: same defect as the paragraph — an empty table in the first section
 /// reads as "no risks found" when the report lists findings two sections down.
 /// What: every non-GREEN finding across all repositories, RED before AMBER
 /// (stable within a band, so manifest and analyzer order are preserved), capped
-/// at [`MAX_RISK_ROWS`]. Empty when no repository carries findings.
+/// at [`MAX_RISK_ROWS`] with the pre-cap count retained for
+/// [`TopRisks::truncation_note`]. Empty when no repository carries findings.
 /// Test: `exec_summary_tests.rs::top_risks_are_red_first_and_capped`.
-pub fn top_risks(model: &ReportModel) -> Vec<DeterministicRisk> {
-    let mut rows: Vec<(u8, DeterministicRisk)> = Vec::new();
+pub fn top_risks(model: &ReportModel) -> TopRisks {
+    let mut ranked: Vec<(u8, DeterministicRisk)> = Vec::new();
     for repo in &model.repositories {
         let Some(metrics) = &repo.metrics else {
             continue;
@@ -156,7 +199,7 @@ pub fn top_risks(model: &ReportModel) -> Vec<DeterministicRisk> {
                 Severity::Amber => 1,
                 Severity::Green => continue,
             };
-            rows.push((
+            ranked.push((
                 rank,
                 DeterministicRisk {
                     description: risk_description(f),
@@ -166,11 +209,16 @@ pub fn top_risks(model: &ReportModel) -> Vec<DeterministicRisk> {
             ));
         }
     }
-    rows.sort_by_key(|(rank, _)| *rank);
-    rows.into_iter()
-        .take(MAX_RISK_ROWS)
-        .map(|(_, risk)| risk)
-        .collect()
+    ranked.sort_by_key(|(rank, _)| *rank);
+    let eligible = ranked.len();
+    TopRisks {
+        rows: ranked
+            .into_iter()
+            .take(MAX_RISK_ROWS)
+            .map(|(_, risk)| risk)
+            .collect(),
+        eligible,
+    }
 }
 
 /// The risk statement for one finding: title, the tool's observation, and the

--- a/crates/trusty-review/src/report/exec_summary_tests.rs
+++ b/crates/trusty-review/src/report/exec_summary_tests.rs
@@ -239,11 +239,25 @@ fn names_the_application_carrying_the_most_red_findings() {
     );
 }
 
+/// The single-application risks manifest used by the cap tests.
+const RISKS_MANIFEST: &str = r#"
+    [report]
+    title = "Risks"
+
+    [[repositories]]
+    name = "Acme Web"
+    path = "/nonexistent/acme-web"
+    metrics = "risks.json"
+"#;
+
 /// Why: the Top Risks table sits inside §2 and collapsed for the same reason
-/// the paragraph did; its rows come from the same findings, worst first.
-/// What: six RED + AMBER findings across one application; asserts RED-first
-/// ordering, the five-row cap, that GREENs never appear, and that the row text
-/// carries the finding's observation and component.
+/// the paragraph did; its rows come from the same findings, worst first, and a
+/// truncated table must say so.
+/// What: SEVEN non-GREEN findings (2 RED + 5 AMBER) against a cap of five, so
+/// two are provably dropped — a fixture sized exactly at the cap could not tell
+/// a working cap from no cap at all. Asserts RED-first ordering, the dropped
+/// findings' absence by title, the pre-cap `eligible` count, the truncation
+/// caption, that GREENs never appear, and the row text.
 /// Test: this test itself.
 #[test]
 fn top_risks_are_red_first_and_capped() {
@@ -253,32 +267,73 @@ fn top_risks_are_red_first_and_capped() {
         { "title": "A1", "severity": "amber", "category": "x", "component": "a1.rs" },
         { "title": "A2", "severity": "amber", "category": "x", "component": "a2.rs" },
         { "title": "A3", "severity": "amber", "category": "x", "component": "a3.rs" },
+        { "title": "A4", "severity": "amber", "category": "x", "component": "a4.rs" },
+        { "title": "A5", "severity": "amber", "category": "x", "component": "a5.rs" },
         { "title": "R1", "severity": "red", "category": "security", "component": "r1.rs",
           "description": "leaks a key" },
         { "title": "R2", "severity": "red", "category": "security", "component": "r2.rs" },
         { "title": "G1", "severity": "green", "category": "quality", "component": "" }
       ]
     }"#;
-    let toml = r#"
-        [report]
-        title = "Risks"
-
-        [[repositories]]
-        name = "Acme Web"
-        path = "/nonexistent/acme-web"
-        metrics = "risks.json"
-    "#;
-    let m = model(tmp.path(), &[("risks.json", metrics)], toml);
+    let m = model(tmp.path(), &[("risks.json", metrics)], RISKS_MANIFEST);
 
     let risks = top_risks(&m);
-    assert_eq!(risks.len(), 5, "cap not applied: {risks:?}");
-    assert_eq!(risks[0].severity, "RED");
-    assert_eq!(risks[1].severity, "RED");
-    assert!(risks[2..].iter().all(|r| r.severity == "AMBER"));
-    assert_eq!(risks[0].description, "R1 — leaks a key (r1.rs)");
-    assert_eq!(risks[0].apps, "Acme Web");
+    assert_eq!(risks.eligible, 7, "pre-cap count wrong: {risks:?}");
+    assert_eq!(risks.rows.len(), 5, "cap not applied: {risks:?}");
+
+    // The cap actually dropped rows: the two lowest-priority AMBERs are gone.
+    let titles: Vec<&str> = risks
+        .rows
+        .iter()
+        .map(|r| r.description.split(' ').next().unwrap_or(""))
+        .collect();
     assert!(
-        !risks.iter().any(|r| r.description.starts_with("G1")),
-        "a GREEN finding must never become a top risk: {risks:?}"
+        !titles.contains(&"A4") && !titles.contains(&"A5"),
+        "the cap kept findings it should have dropped: {titles:?}"
     );
+    assert_eq!(titles, vec!["R1", "R2", "A1", "A2", "A3"]);
+
+    assert_eq!(risks.rows[0].severity, "RED");
+    assert_eq!(risks.rows[1].severity, "RED");
+    assert!(risks.rows[2..].iter().all(|r| r.severity == "AMBER"));
+    assert_eq!(risks.rows[0].description, "R1 — leaks a key (r1.rs)");
+    assert_eq!(risks.rows[0].apps, "Acme Web");
+    assert!(
+        !titles.contains(&"G1"),
+        "a GREEN finding must never become a top risk: {titles:?}"
+    );
+
+    let note = risks
+        .truncation_note()
+        .expect("truncated table needs a note");
+    assert!(note.contains("Top 5 of 7"), "note wording: {note}");
+    assert!(note.contains("2 further"), "hidden count wrong: {note}");
+}
+
+/// Why: the truncation caption must appear only when something was actually
+/// dropped — a caption on a complete table would misinform in the other
+/// direction.
+/// What: exactly five non-GREEN findings, so nothing is cut; asserts every row
+/// survives and no note is produced. The GREEN finding proves `eligible` counts
+/// eligible ROWS, not total findings.
+/// Test: this test itself.
+#[test]
+fn truncation_note_absent_when_nothing_was_dropped() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let metrics = r#"{
+      "findings": [
+        { "title": "A1", "severity": "amber", "category": "x", "component": "a1.rs" },
+        { "title": "A2", "severity": "amber", "category": "x", "component": "a2.rs" },
+        { "title": "A3", "severity": "amber", "category": "x", "component": "a3.rs" },
+        { "title": "R1", "severity": "red", "category": "security", "component": "r1.rs" },
+        { "title": "R2", "severity": "red", "category": "security", "component": "r2.rs" },
+        { "title": "G1", "severity": "green", "category": "quality", "component": "" }
+      ]
+    }"#;
+    let m = model(tmp.path(), &[("risks.json", metrics)], RISKS_MANIFEST);
+
+    let risks = top_risks(&m);
+    assert_eq!(risks.eligible, 5, "the GREEN must not count as eligible");
+    assert_eq!(risks.rows.len(), 5);
+    assert_eq!(risks.truncation_note(), None);
 }

--- a/crates/trusty-review/src/report/exec_summary_tests.rs
+++ b/crates/trusty-review/src/report/exec_summary_tests.rs
@@ -1,0 +1,284 @@
+//! Tests for the deterministic Executive Summary roll-up (#5318).
+//!
+//! Why: §2 renders whatever this module returns, so the wording, the counting,
+//! and — most of all — the two-way split between "here is the roll-up" and
+//! "here is exactly which input was missing" are pinned here rather than
+//! through a template render.
+//! What: composes over models built from in-memory manifests + metrics
+//! documents, and asserts the sentences, the provenance, the unavailable
+//! statements, and the Top Risks derivation.
+//! Test: included as `#[cfg(test)] mod tests` from `exec_summary.rs`.
+
+use super::{ExecSummary, compose, top_risks};
+use crate::report::manifest::parse_manifest;
+use crate::report::model::ReportModel;
+use crate::report::provenance::Provenance;
+
+/// Build a model from a manifest TOML, writing each `(filename, json)` metrics
+/// document into `dir` first so relative manifest paths resolve.
+fn model(dir: &std::path::Path, metrics: &[(&str, &str)], toml: &str) -> ReportModel {
+    for (name, json) in metrics {
+        std::fs::write(dir.join(name), json).expect("write metrics");
+    }
+    let manifest_path = dir.join("manifest.toml");
+    let manifest = parse_manifest(toml, &manifest_path).expect("manifest parse");
+    ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None).expect("build model")
+}
+
+const ACME_METRICS: &str = r#"{
+  "loc": { "total": 8200, "by_language": [
+    { "language": "Rust", "loc": 6000 },
+    { "language": "TypeScript", "loc": 2200 }
+  ]},
+  "counts": { "files": 120, "functions": 640 },
+  "findings": [
+    { "title": "Hardcoded credential", "severity": "red", "category": "security",
+      "component": "src/config.rs:42", "description": "literal API key on a static" },
+    { "title": "Cyclomatic complexity 31", "severity": "amber", "category": "maintainability",
+      "component": "src/router.rs:118" },
+    { "title": "Strong coverage", "severity": "green", "category": "quality", "component": "" }
+  ]
+}"#;
+
+const ACME_MANIFEST: &str = r#"
+    [report]
+    title = "Acme Due Diligence"
+
+    [[repositories]]
+    name = "Acme Web"
+    path = "/nonexistent/acme-web"
+    metrics = "acme.json"
+"#;
+
+/// Why: the exact defect in #5318 — a run carrying RED/AMBER findings must
+/// produce a paragraph, never a placeholder.
+/// What: composes over one application with size, languages, and findings, and
+/// asserts every clause plus the declared provenance (the figures came from a
+/// metrics document, not this tool's own scan).
+/// Test: this test itself.
+#[test]
+fn composes_from_metrics_findings() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let m = model(tmp.path(), &[("acme.json", ACME_METRICS)], ACME_MANIFEST);
+
+    let ExecSummary::Composed { text, provenance } = compose(&m) else {
+        panic!("expected a composed summary, got {:?}", compose(&m));
+    };
+    assert_eq!(provenance, Provenance::Declared);
+    assert!(
+        text.contains("covered 1 application (Acme Web)"),
+        "scope sentence missing: {text}"
+    );
+    assert!(
+        text.contains("8200 lines of code across Rust and TypeScript"),
+        "size/language clause missing: {text}"
+    );
+    assert!(text.contains("in 120 files"), "file count missing: {text}");
+    assert!(
+        text.contains("1 RED (critical) and 1 AMBER (medium-risk) findings"),
+        "severity counts missing: {text}"
+    );
+    assert!(
+        text.contains("concentrated in maintainability (1) and security (1)"),
+        "dimension breakdown missing: {text}"
+    );
+    assert!(
+        text.contains("deterministic roll-up"),
+        "roll-up note missing: {text}"
+    );
+    // GREEN findings never inflate the counts (the no-green-analysis rule).
+    assert!(!text.contains("GREEN"), "greens leaked into §2: {text}");
+    // With one application there is no concentration to point at.
+    assert!(
+        !text.contains("carries the most"),
+        "single-application report needs no concentration sentence: {text}"
+    );
+}
+
+/// Why: a local checkout with no metrics document still has measured size, and
+/// the paragraph must say so with `measured` provenance rather than claiming a
+/// declared input it never had.
+/// What: points a repository at this crate's own source tree (a real, scannable
+/// directory) with no `metrics` key and asserts a composed, measured summary
+/// with no findings claim.
+/// Test: this test itself.
+#[test]
+fn composes_from_scan_only() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let crate_dir = env!("CARGO_MANIFEST_DIR");
+    let toml = format!(
+        r#"
+        [report]
+        title = "Scan Only"
+
+        [[repositories]]
+        name = "Self"
+        path = "{crate_dir}"
+    "#
+    );
+    let m = model(tmp.path(), &[], &toml);
+
+    let ExecSummary::Composed { text, provenance } = compose(&m) else {
+        panic!("expected a composed summary for a scannable checkout");
+    };
+    assert_eq!(provenance, Provenance::Measured);
+    assert!(text.contains("lines of code"), "no measured size: {text}");
+    assert!(
+        text.contains("raised no RED or AMBER findings"),
+        "posture sentence missing: {text}"
+    );
+}
+
+/// Why: closure condition 2 of #5318 — when §2 genuinely cannot be produced,
+/// the reader must be told which input was absent, not pointed at Gaps.
+/// What: a remote-only repository (no metrics file, no local checkout to scan)
+/// and asserts each named input appears in the statement.
+/// Test: this test itself.
+#[test]
+fn unavailable_names_the_missing_inputs() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let toml = r#"
+        [report]
+        title = "Remote Only"
+
+        [[repositories]]
+        name = "Remote App"
+        remote = "acme/remote-app"
+    "#;
+    let m = model(tmp.path(), &[], toml);
+
+    let ExecSummary::Unavailable(text) = compose(&m) else {
+        panic!("a remote-only report has nothing to roll up");
+    };
+    assert!(
+        text.contains("`metrics` file"),
+        "metrics input unnamed: {text}"
+    );
+    assert!(
+        text.contains("`--analyze`"),
+        "analyze input unnamed: {text}"
+    );
+    assert!(
+        text.contains("no local checkout was scannable"),
+        "scan input unnamed: {text}"
+    );
+    assert!(
+        !text.contains("No data available"),
+        "must not fall back to the generic placeholder: {text}"
+    );
+}
+
+/// Why: a report with zero repositories is a different missing input from an
+/// unmeasured one and must say so — otherwise it reads "none of the 0
+/// application(s)". The manifest loader rejects an empty `[[repositories]]`
+/// list, so this state is only reachable through the public [`ReportModel`]
+/// struct, which is exactly why the guard exists.
+/// What: empties a built model's repository list and composes over it.
+/// Test: this test itself.
+#[test]
+fn unavailable_with_no_repositories() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut m = model(tmp.path(), &[("acme.json", ACME_METRICS)], ACME_MANIFEST);
+    m.repositories.clear();
+
+    let ExecSummary::Unavailable(text) = compose(&m) else {
+        panic!("a report with no repositories has nothing to summarize");
+    };
+    assert!(text.contains("declared no repositories"), "got: {text}");
+}
+
+/// Why: with several applications a reader wants to know where the risk sits,
+/// and the sentence must be stable across runs.
+/// What: two applications with different RED counts; asserts the concentration
+/// sentence names the heavier one with its share.
+/// Test: this test itself.
+#[test]
+fn names_the_application_carrying_the_most_red_findings() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let heavy = r#"{
+      "loc": { "total": 100, "by_language": [{ "language": "Rust", "loc": 100 }] },
+      "findings": [
+        { "title": "A", "severity": "red", "category": "security", "component": "a.rs" },
+        { "title": "B", "severity": "red", "category": "security", "component": "b.rs" }
+      ]
+    }"#;
+    let light = r#"{
+      "loc": { "total": 50, "by_language": [{ "language": "Go", "loc": 50 }] },
+      "findings": [
+        { "title": "C", "severity": "red", "category": "security", "component": "c.go" }
+      ]
+    }"#;
+    let toml = r#"
+        [report]
+        title = "Two Apps"
+
+        [[repositories]]
+        name = "Heavy"
+        path = "/nonexistent/heavy"
+        metrics = "heavy.json"
+
+        [[repositories]]
+        name = "Light"
+        path = "/nonexistent/light"
+        metrics = "light.json"
+    "#;
+    let m = model(
+        tmp.path(),
+        &[("heavy.json", heavy), ("light.json", light)],
+        toml,
+    );
+
+    let text = compose(&m).text().to_string();
+    assert!(
+        text.contains("Heavy carries the most RED findings (2 of 3)"),
+        "concentration sentence wrong: {text}"
+    );
+    assert!(
+        text.contains("covered 2 applications (Heavy, Light)"),
+        "scope sentence wrong: {text}"
+    );
+}
+
+/// Why: the Top Risks table sits inside §2 and collapsed for the same reason
+/// the paragraph did; its rows come from the same findings, worst first.
+/// What: six RED + AMBER findings across one application; asserts RED-first
+/// ordering, the five-row cap, that GREENs never appear, and that the row text
+/// carries the finding's observation and component.
+/// Test: this test itself.
+#[test]
+fn top_risks_are_red_first_and_capped() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let metrics = r#"{
+      "findings": [
+        { "title": "A1", "severity": "amber", "category": "x", "component": "a1.rs" },
+        { "title": "A2", "severity": "amber", "category": "x", "component": "a2.rs" },
+        { "title": "A3", "severity": "amber", "category": "x", "component": "a3.rs" },
+        { "title": "R1", "severity": "red", "category": "security", "component": "r1.rs",
+          "description": "leaks a key" },
+        { "title": "R2", "severity": "red", "category": "security", "component": "r2.rs" },
+        { "title": "G1", "severity": "green", "category": "quality", "component": "" }
+      ]
+    }"#;
+    let toml = r#"
+        [report]
+        title = "Risks"
+
+        [[repositories]]
+        name = "Acme Web"
+        path = "/nonexistent/acme-web"
+        metrics = "risks.json"
+    "#;
+    let m = model(tmp.path(), &[("risks.json", metrics)], toml);
+
+    let risks = top_risks(&m);
+    assert_eq!(risks.len(), 5, "cap not applied: {risks:?}");
+    assert_eq!(risks[0].severity, "RED");
+    assert_eq!(risks[1].severity, "RED");
+    assert!(risks[2..].iter().all(|r| r.severity == "AMBER"));
+    assert_eq!(risks[0].description, "R1 — leaks a key (r1.rs)");
+    assert_eq!(risks[0].apps, "Acme Web");
+    assert!(
+        !risks.iter().any(|r| r.description.starts_with("G1")),
+        "a GREEN finding must never become a top risk: {risks:?}"
+    );
+}

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -16,6 +16,7 @@
 pub mod analyze_adapter;
 pub mod benchmark;
 pub mod error;
+pub mod exec_summary;
 pub mod fill;
 pub mod git_info;
 pub mod instructions;
@@ -48,6 +49,7 @@ pub use benchmark::{
     RepositoryBenchmark, build_benchmark_report, corpus_dir, load_corpus, write_snapshot,
 };
 pub use error::{ManifestError, ReportError, Result};
+pub use exec_summary::{DeterministicRisk, ExecSummary, compose as compose_exec_summary};
 pub use fill::{HONESTY_MARKER, Scope, render, strip_leading_comment};
 pub use git_info::{GitInfo, gather_git_info};
 pub use instructions::{Instructions, load_instructions};

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -49,7 +49,7 @@ pub use benchmark::{
     RepositoryBenchmark, build_benchmark_report, corpus_dir, load_corpus, write_snapshot,
 };
 pub use error::{ManifestError, ReportError, Result};
-pub use exec_summary::{DeterministicRisk, ExecSummary, compose as compose_exec_summary};
+pub use exec_summary::{DeterministicRisk, ExecSummary, TopRisks, compose as compose_exec_summary};
 pub use fill::{HONESTY_MARKER, Scope, render, strip_leading_comment};
 pub use git_info::{GitInfo, gather_git_info};
 pub use instructions::{Instructions, load_instructions};

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -22,7 +22,9 @@ use super::metrics::Severity;
 use super::model::{ReportModel, RepositoryReport};
 use super::polish::polish_with_gaps;
 use super::provenance::{self, Provenance, tag};
-use super::reporter_fill::{crate_version, fill_profile, instructions_block, set_scoring_model};
+use super::reporter_fill::{
+    crate_version, fill_profile, instructions_block, set_executive_summary, set_scoring_model,
+};
 use super::reporter_graph_datasets::{
     inject_complexity_distribution_dataset, inject_loc_by_technology_dataset,
 };
@@ -292,9 +294,14 @@ fn build_scope(model: &ReportModel) -> Scope {
     // never synthesized — filled independent of synthesis availability.
     push_green_topics(&mut root, model);
 
-    // M2: the executive summary and top-risk rationale have no deterministic M1
-    // source; fill them only from verified synthesis.  Absent/unavailable
-    // synthesis leaves both to the M1 honesty marker (unchanged behaviour).
+    // #5318: §2 has a deterministic source now.  It used to be filled ONLY from
+    // verified synthesis, so a run without `--synthesize` — which is every
+    // `tga audit` run — collapsed the first section a diligence reader opens
+    // while the report listed real RED/AMBER findings two sections below.  The
+    // roll-up counts what the report already contains; synthesis prose still
+    // overwrites it below when it runs and passes the guardrail.
+    let synthesized_risks = available_synthesis.is_some_and(|s| !s.top_risks.is_empty());
+    set_executive_summary(&mut root, model, !synthesized_risks);
     if let Some(syn) = available_synthesis {
         inject_synthesis_summary(&mut root, syn);
     }

--- a/crates/trusty-review/src/report/reporter_fill.rs
+++ b/crates/trusty-review/src/report/reporter_fill.rs
@@ -47,6 +47,53 @@ pub(super) fn instructions_block(model: &ReportModel) -> String {
     )
 }
 
+/// Fill §2 from the report's own data, with no LLM involved (#5318).
+///
+/// Why: the executive summary was the report's only synthesis-gated section, so
+/// a deterministic run rendered `_No data available — see Gaps & Caveats._`
+/// where a diligence reader looks first. The counts, size, and severity mix it
+/// needs are already in the model.
+/// What: sets `executive_summary_paragraph` from
+/// [`super::exec_summary::compose`] — tagged with the provenance of the figures
+/// when composed, untagged when it is instead a statement naming which inputs
+/// were missing (a statement about the report, not a report value). When
+/// `with_risks` is set, also pushes one `top_risk_row` per deterministic risk;
+/// the caller clears it when synthesis has rows of its own, so the two never
+/// stack into one table.
+/// Test: `reporter_tests.rs::{reporter_fills_executive_summary_without_synthesis,
+/// reporter_names_missing_inputs_when_nothing_measured,
+/// reporter_prefers_synthesis_over_deterministic_summary}`.
+pub(super) fn set_executive_summary(root: &mut Scope, model: &ReportModel, with_risks: bool) {
+    match super::exec_summary::compose(model) {
+        super::exec_summary::ExecSummary::Composed { text, provenance } => {
+            root.set("executive_summary_paragraph", tag(text, provenance));
+        }
+        super::exec_summary::ExecSummary::Unavailable(text) => {
+            root.set("executive_summary_paragraph", text);
+        }
+    }
+
+    if !with_risks {
+        return;
+    }
+    for (i, risk) in super::exec_summary::top_risks(model)
+        .into_iter()
+        .enumerate()
+    {
+        let mut row = Scope::new();
+        row.set("risk_rank", (i + 1).to_string());
+        row.set(
+            "risk_description",
+            tag(risk.description, Provenance::Declared),
+        );
+        row.set("risk_severity", risk.severity);
+        row.set("risk_apps", risk.apps);
+        // `risk_cost` is deliberately unset: nothing deterministic states a
+        // remediation cost, so it falls through to the honesty marker.
+        root.push_block("top_risk_row", row);
+    }
+}
+
 /// Fill Section 3 with trusty-review's own normalized scoring model (#2342.2).
 ///
 /// Why: the scoring model is defined BY the tool — rendering it as "not stated"

--- a/crates/trusty-review/src/report/reporter_fill.rs
+++ b/crates/trusty-review/src/report/reporter_fill.rs
@@ -57,12 +57,15 @@ pub(super) fn instructions_block(model: &ReportModel) -> String {
 /// [`super::exec_summary::compose`] — tagged with the provenance of the figures
 /// when composed, untagged when it is instead a statement naming which inputs
 /// were missing (a statement about the report, not a report value). When
-/// `with_risks` is set, also pushes one `top_risk_row` per deterministic risk;
-/// the caller clears it when synthesis has rows of its own, so the two never
-/// stack into one table.
+/// `with_risks` is set, also pushes one `top_risk_row` per deterministic risk,
+/// plus a final caption row when the cap dropped any — a reader who reads the
+/// table and not the paragraph must still see that it is a top-N view. The
+/// caller clears `with_risks` when synthesis has rows of its own, so the two
+/// never stack into one table.
 /// Test: `reporter_tests.rs::{reporter_fills_executive_summary_without_synthesis,
 /// reporter_names_missing_inputs_when_nothing_measured,
-/// reporter_prefers_synthesis_over_deterministic_summary}`.
+/// reporter_prefers_synthesis_over_deterministic_summary,
+/// reporter_captions_a_truncated_top_risks_table}`.
 pub(super) fn set_executive_summary(root: &mut Scope, model: &ReportModel, with_risks: bool) {
     match super::exec_summary::compose(model) {
         super::exec_summary::ExecSummary::Composed { text, provenance } => {
@@ -76,20 +79,31 @@ pub(super) fn set_executive_summary(root: &mut Scope, model: &ReportModel, with_
     if !with_risks {
         return;
     }
-    for (i, risk) in super::exec_summary::top_risks(model)
-        .into_iter()
-        .enumerate()
-    {
+    let risks = super::exec_summary::top_risks(model);
+    for (i, risk) in risks.rows.iter().enumerate() {
         let mut row = Scope::new();
         row.set("risk_rank", (i + 1).to_string());
         row.set(
             "risk_description",
-            tag(risk.description, Provenance::Declared),
+            tag(risk.description.clone(), Provenance::Declared),
         );
-        row.set("risk_severity", risk.severity);
-        row.set("risk_apps", risk.apps);
+        row.set("risk_severity", risk.severity.clone());
+        row.set("risk_apps", risk.apps.clone());
         // `risk_cost` is deliberately unset: nothing deterministic states a
         // remediation cost, so it falls through to the honesty marker.
+        root.push_block("top_risk_row", row);
+    }
+    if let Some(note) = risks.truncation_note() {
+        // A caption row rather than a note beneath the table: the table is what
+        // an acquirer skims, and the polish pass only keeps a row when some
+        // value cell is real, so the three em-dashes also keep it from being
+        // dropped as empty scaffolding.
+        let mut row = Scope::new();
+        row.set("risk_rank", "—");
+        row.set("risk_description", note);
+        row.set("risk_severity", "—");
+        row.set("risk_cost", "—");
+        row.set("risk_apps", "—");
         root.push_block("top_risk_row", row);
     }
 }

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -1645,3 +1645,152 @@ fn stem_is_date_slug() {
     assert!(stem.ends_with("-acme-due-diligence"));
     assert_eq!(stem, format!("{}-acme-due-diligence", model.generated_date));
 }
+
+// ─── #5318: §2 renders without synthesis ─────────────────────────────────────
+
+/// The rendered §2 body, from its heading up to the next `##` heading
+/// (so it includes the `### Top Risks` child).
+fn executive_summary_section(md: &str) -> String {
+    let start = md
+        .find("## 2. Executive Summary")
+        .unwrap_or_else(|| panic!("no §2 heading in:\n{md}"));
+    let rest = &md[start..];
+    let end = rest[3..].find("\n## ").map(|i| i + 3).unwrap_or(rest.len());
+    rest[..end].to_string()
+}
+
+/// Just the §2 paragraph — the heading through the `### Top Risks` child, which
+/// has its own data source and its own emptiness verdict.
+fn executive_summary_paragraph(md: &str) -> String {
+    let section = executive_summary_section(md);
+    match section.find("\n### ") {
+        Some(i) => section[..i].to_string(),
+        None => section,
+    }
+}
+
+/// Why: issue #5318 — every `tga audit` report collapsed §2 to
+/// `_No data available — see Gaps & Caveats._` because the executive summary
+/// was filled ONLY from `--synthesize` prose, while the same report listed a
+/// RED and an AMBER finding in §5. This is the regression guard: a
+/// deterministic run over findings data must populate §2.
+/// What: renders the findings fixture with NO synthesis attached and asserts
+/// the paragraph, the severity counts, the Top Risks rows, and the absence of
+/// the collapse line anywhere in §2.
+/// Test: this test itself.
+#[test]
+fn reporter_fills_executive_summary_without_synthesis() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = fixture_model_with_findings(tmp.path());
+    assert!(model.synthesis.is_none(), "fixture must be synthesis-free");
+
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+    let section = executive_summary_section(&md);
+
+    assert!(
+        !section.contains("No data available"),
+        "§2 collapsed on a run that had findings:\n{section}"
+    );
+    assert!(
+        section.contains("Repository inspection covered 1 application (Acme Web)"),
+        "no roll-up paragraph:\n{section}"
+    );
+    assert!(
+        section.contains("1 RED (critical) and 1 AMBER (medium-risk) findings"),
+        "severity counts missing:\n{section}"
+    );
+    // Top Risks fills from the same findings, RED first.
+    assert!(
+        section.contains("SQL injection"),
+        "RED finding missing from Top Risks:\n{section}"
+    );
+    assert!(
+        section.contains("Stale dependency"),
+        "AMBER finding missing from Top Risks:\n{section}"
+    );
+    assert!(!md.contains("{{"), "no raw placeholder survives");
+}
+
+/// Why: closure condition 2 of #5318 — when §2 genuinely cannot be produced the
+/// report must name the missing input rather than pointing at Gaps & Caveats.
+/// What: renders a remote-only manifest (nothing to scan, no metrics) and
+/// asserts the §2 paragraph names each absent input instead of collapsing. The
+/// `### Top Risks` child legitimately stays empty here — a report with no
+/// findings has no risks to rank — so the assertion is scoped to the paragraph.
+/// Test: this test itself.
+#[test]
+fn reporter_names_missing_inputs_when_nothing_measured() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let toml = r#"
+        [report]
+        title = "Remote Only"
+
+        [[repositories]]
+        name = "Remote App"
+        remote = "acme/remote-app"
+    "#;
+    let manifest_path = tmp.path().join("manifest.toml");
+    let manifest = parse_manifest(toml, &manifest_path).expect("manifest parse");
+    let model = ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None)
+        .expect("model builds");
+
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+    let paragraph = executive_summary_paragraph(&md);
+
+    assert!(
+        !paragraph.contains("No data available"),
+        "§2 must state the missing input, not collapse:\n{paragraph}"
+    );
+    assert!(paragraph.contains("`metrics` file"), "got:\n{paragraph}");
+    assert!(paragraph.contains("`--analyze`"), "got:\n{paragraph}");
+}
+
+/// Why: the deterministic roll-up is a floor, never a replacement — verified
+/// synthesis prose must still win, and the Top Risks table must never carry
+/// both sets of rows.
+/// What: attaches an available synthesis with its own exec summary and one top
+/// risk over a fixture that also has findings, then asserts the synthesized
+/// prose renders, the roll-up does not, and exactly one risk row is present.
+/// Test: this test itself.
+#[test]
+fn reporter_prefers_synthesis_over_deterministic_summary() {
+    use crate::report::synthesize::{RiskRow, Synthesis, SynthesisStatus};
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut model = fixture_model_with_findings(tmp.path());
+    model.synthesis = Some(Synthesis {
+        status: SynthesisStatus::Available,
+        executive_summary: Some("An acquirer-relevant judgement.".to_string()),
+        top_risks: vec![RiskRow {
+            description: "Credential exposure".to_string(),
+            severity: "RED".to_string(),
+            cost: "2 weeks".to_string(),
+            apps: "Acme Web".to_string(),
+        }],
+        findings: vec![],
+        notes: vec![],
+    });
+
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+    let section = executive_summary_section(&md);
+
+    assert!(section.contains("An acquirer-relevant judgement."));
+    assert!(
+        !section.contains("Repository inspection covered"),
+        "synthesis must overwrite the roll-up:\n{section}"
+    );
+    assert!(section.contains("Credential exposure"));
+    assert!(
+        !section.contains("SQL injection"),
+        "deterministic rows must not stack under synthesized rows:\n{section}"
+    );
+}

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -1794,3 +1794,68 @@ fn reporter_prefers_synthesis_over_deterministic_summary() {
         "deterministic rows must not stack under synthesized rows:\n{section}"
     );
 }
+
+/// Why: the Top Risks table is capped at five rows, and an acquirer who skims
+/// the table without the paragraph above it would otherwise read those five as
+/// the entire risk picture. A silently capped top-risks table has shipped as a
+/// defect once already (#2373).
+/// What: renders seven RED/AMBER findings and asserts the rendered table carries
+/// the "Top 5 of 7" caption row; then renders a fixture with two findings and
+/// asserts no caption appears.
+/// Test: this test itself.
+#[test]
+fn reporter_captions_a_truncated_top_risks_table() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let metrics = r#"{
+      "findings": [
+        { "title": "A1", "severity": "amber", "category": "x", "component": "a1.rs" },
+        { "title": "A2", "severity": "amber", "category": "x", "component": "a2.rs" },
+        { "title": "A3", "severity": "amber", "category": "x", "component": "a3.rs" },
+        { "title": "A4", "severity": "amber", "category": "x", "component": "a4.rs" },
+        { "title": "A5", "severity": "amber", "category": "x", "component": "a5.rs" },
+        { "title": "R1", "severity": "red", "category": "security", "component": "r1.rs" },
+        { "title": "R2", "severity": "red", "category": "security", "component": "r2.rs" }
+      ]
+    }"#;
+    std::fs::write(tmp.path().join("acme.json"), metrics).expect("write metrics");
+    let toml = r#"
+        [report]
+        title = "Acme Due Diligence"
+
+        [[repositories]]
+        name = "Acme Web"
+        path = "/nonexistent/acme-web"
+        metrics = "acme.json"
+    "#;
+    let manifest_path = tmp.path().join("manifest.toml");
+    let manifest = parse_manifest(toml, &manifest_path).expect("manifest parse");
+    let model = ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None)
+        .expect("model builds");
+
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let section = executive_summary_section(&Reporter::new(tmp.path()).render(&model, &template));
+
+    assert!(
+        section.contains("**Top 5 of 7**"),
+        "truncated table must caption itself:\n{section}"
+    );
+    assert!(
+        section.contains("2 further RED/AMBER finding(s) are not listed here"),
+        "caption must name what is missing:\n{section}"
+    );
+    assert!(
+        !section.contains("| 6 |"),
+        "the caption row must not be numbered as a sixth risk:\n{section}"
+    );
+
+    // A fixture the cap never touches must carry no caption.
+    let untruncated = fixture_model_with_findings(tmp.path());
+    let plain =
+        executive_summary_section(&Reporter::new(tmp.path()).render(&untruncated, &template));
+    assert!(
+        !plain.contains("Top 5 of"),
+        "an untruncated table must not claim truncation:\n{plain}"
+    );
+}

--- a/docs/specs/DOC-67-tga-audit-mode.md
+++ b/docs/specs/DOC-67-tga-audit-mode.md
@@ -367,7 +367,7 @@ section with source and v1 status:
 | Template section | v1 status | Source |
 |---|---|---|
 | §1 Report Metadata | **Populated** | Manifest (`ReportSection` fields, §6) |
-| §2 Executive Summary + Top Risks | **Populated**, unchanged mechanism | trusty-review's existing LLM synthesis (`synthesize.rs`) over the RED/AMBER findings trusty-analyze supplies. Does **not** incorporate tga's DORA/velocity data in v1 (§12 Q3) |
+| §2 Executive Summary + Top Risks | **Populated** | Deterministic roll-up (`exec_summary.rs`) over the RED/AMBER findings and size data trusty-analyze supplies — AUDIT invokes `trusty-review report` without `--synthesize`, so the LLM path this row originally named never ran and §2 rendered empty until #5318. LLM synthesis (`synthesize.rs`) still overwrites both when a caller opts into it. Does **not** incorporate tga's DORA/velocity data in v1 (§12 Q3) |
 | §3 Scoring Model Normalization | **Populated**, unchanged mechanism | The fixed RED/AMBER/GREEN and A–F conventions already encoded in `analyze_adapter.rs:164-226` |
 | §4 Per-Application Scorecard — Profile (tech stack, LoC, frameworks, file counts) | **Populated**, unchanged mechanism | `report/scan.rs`'s `RepoScan` — computed directly from the local checkout (`git ls-files`, manifest detection), independent of trusty-analyze, already runs for any `RepositoryEntry::LocalPath` (`model.rs`) |
 | §4 Health-Factor Scores | **Populated, new call site** | trusty-analyze `/quality` (`avg_cyclomatic`/`pct_grade_a`/`grade`) — architecture factor; diagnostics/refactor rollup — security-proxy factor, captioned per §3's limitation |

--- a/docs/trusty-review/spec/report-generation.md
+++ b/docs/trusty-review/spec/report-generation.md
@@ -256,6 +256,35 @@ the template needs but the metrics omit falls through to the honesty marker.
 Scoring, health-factor, and benchmark placeholders have no deterministic M1
 source and therefore render as `not stated in source data` until M2/M3 land.
 
+### §2 Executive Summary — deterministic floor (#5318)
+
+The executive summary used to be the one section with no deterministic source at
+all: `reporter.rs` filled it only from M2 synthesis prose, so a run without
+`--synthesize` — which is every `tga audit` run, since the sweep invokes
+`trusty-review report --manifest … --analyze --out …` — collapsed §2 to
+`_No data available — see Gaps & Caveats._` while listing real RED/AMBER findings
+in §5.
+
+`exec_summary.rs` gives §2 a floor built from data the report already carries:
+applications and their aggregate size and language mix, RED/AMBER counts with the
+dimensions they fall in, and — when more than one application carries findings —
+which one they concentrate in. The paragraph closes by saying what it is ("a
+deterministic roll-up … not an analyst judgement") and carries the provenance of
+the figures it used: `declared` when any came from a metrics document, `measured`
+when all came from the built-in scan. The Top Risks table fills from the same
+findings, RED first, capped at five rows; `Est. cost/effort` has no deterministic
+source and stays honesty-marked.
+
+Synthesis is unchanged and still wins: `inject_synthesis_summary` runs after the
+deterministic fill and overwrites the paragraph, and the deterministic risk rows
+are suppressed entirely when synthesis produced rows of its own, so the two never
+stack into one table.
+
+When nothing measurable was supplied — a remote-only manifest, or every repository
+unscannable with no metrics — §2 states which inputs were absent (no `metrics`
+file, no `--analyze` fetch, no scannable checkout) rather than collapsing to the
+generic Gaps & Caveats pointer.
+
 ## Synthesis (M2)
 
 M2 layers **opt-in** LLM prose on top of the M1 deterministic fill. It is OFF by


### PR DESCRIPTION
Closes #5318.

`tga audit` invokes `report --manifest <m> --analyze --out <dir>` with no `--synthesize`, so `model.synthesis` is `None` on every AUDIT run and §2 — the first section a diligence reader sees — was set only from synthesis, then collapsed as empty.

§2 is now composed deterministically from data the report already carries: applications, LoC and language mix, RED/AMBER counts and their dimensions, and where risk concentrates. Synthesis still overwrites it when present. When nothing is measurable the section names the missing inputs instead of collapsing, so "no data" and "no findings" stay distinguishable.

## Test ladder — rung 3 (localized to one crate)

    cargo fmt --check
    cargo check -p trusty-review --all-targets
    cargo clippy -p trusty-review --all-targets -- -D warnings
    cargo test -p trusty-review

Green: 1603 passed, 0 failed, 5 ignored (+68 and 9 integration binaries). Plus `check_line_cap.sh` (0 violations) and `check_sld.sh` (0 errors).

The regression test was proved red by restoring the pre-fix injection — §2 collapsed to `_No data available — see Gaps & Caveats._` on a run that had findings.

## Review

code-critic: APPROVE, two MEDIUM findings, both fixed in this PR:
- the cap test now uses 7 eligible findings against `MAX_RISK_ROWS = 5` and asserts the dropped two are absent, so it fails if `.take()` is removed
- the Top Risks table carries a caption row stating `Top 5 of N` and points at section 5 for the unabridged list

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools