### PR TITLE
fix(trusty-review): give the Data gaps line a real count of its own list

### DIFF
--- a/crates/trusty-review/changelog.d/5319-data-gaps-count.md
+++ b/crates/trusty-review/changelog.d/5319-data-gaps-count.md
@@ -1,0 +1,9 @@
+Fixed
+
+- The report's `Data gaps:` line now states how many gaps it lists and then lists
+  exactly that many. It used to comma-join the labels straight after the colon, so
+  a label carrying its template section number rendered as
+  `Data gaps: 2. Executive Summary, …` — read as a count of two ahead of sixteen
+  names. The count is now the length of the same slice the line joins, and items
+  are separated with `;` so a label's own comma or leading section number cannot be
+  read as a count or a list boundary (#5319).

--- a/crates/trusty-review/src/report/polish.rs
+++ b/crates/trusty-review/src/report/polish.rs
@@ -513,9 +513,9 @@ fn collapse_recursive(lines: &[String], gaps: &mut Vec<String>) -> (Vec<String>,
 /// Why: instead of a wall of `not stated` bullets, one compact line names every
 /// omitted field so a reader sees the gaps at a glance while the body stays lean.
 /// What: locates the Gaps & Caveats heading, replaces every line from after it up
-/// to the next `---` / heading / EOF with a one-line "Data gaps: …" summary (or a
-/// "no material gaps" note when the list is empty).  When the section is absent
-/// (a custom template), the body is returned unchanged.
+/// to the next `---` / heading / EOF with [`render_gaps_line`]'s one-line summary
+/// (or a "no material gaps" note when the list is empty).  When the section is
+/// absent (a custom template), the body is returned unchanged.
 /// Test: `polish_tests.rs::gaps_section_lists_dropped_fields`.
 fn render_gaps_section(text: &str, gaps: &[String], declared: &[String]) -> String {
     let lines: Vec<&str> = text.lines().collect();
@@ -558,11 +558,39 @@ fn render_gaps_section(text: &str, gaps: &[String], declared: &[String]) -> Stri
     if gaps.is_empty() {
         out.push("No material data gaps: every templated field was populated from measured, declared, or inferred data.".to_string());
     } else {
-        out.push(format!("Data gaps: {}.", gaps.join(", ")));
+        out.push(render_gaps_line(gaps));
     }
     out.push(String::new());
     out.extend(lines[end..].iter().map(|s| s.to_string()));
     out.join("\n")
+}
+
+/// Render the one-line gap summary: how many gaps, then those same gaps.
+///
+/// Why: #5319 — gap labels keep their template numbering ("2. Executive
+/// Summary"), so comma-joining them straight after `Data gaps:` produced
+/// `Data gaps: 2. Executive Summary, …` and a diligence reader parsed the "2."
+/// as a count of two ahead of a sixteen-name list. Nothing had counted
+/// anything; the number was the first label's own section number. A report
+/// whose stated count disagrees with the list beneath it costs the reader
+/// confidence in every other figure in the document.
+/// What: states the count as `gaps.len()` of the very slice it then joins, so
+/// the two cannot drift, and separates the items with `;` — a label may
+/// contain a comma or open with a section number, neither of which may be
+/// readable as a list boundary or a count.
+/// Test: `polish_tests.rs::{gaps_line_count_matches_its_own_list,
+/// collapses_empty_section}`.
+fn render_gaps_line(gaps: &[String]) -> String {
+    let noun = if gaps.len() == 1 {
+        "field/section"
+    } else {
+        "fields/sections"
+    };
+    format!(
+        "Data gaps: {} unpopulated {noun} — {}.",
+        gaps.len(),
+        gaps.join("; ")
+    )
 }
 
 // ─── Line/cell helpers ──────────────────────────────────────────────────────

--- a/crates/trusty-review/src/report/polish.rs
+++ b/crates/trusty-review/src/report/polish.rs
@@ -595,8 +595,14 @@ fn render_gaps_line(gaps: &[String]) -> String {
 
 // ─── Line/cell helpers ──────────────────────────────────────────────────────
 
-/// Return the heading text (after the `#`s and any leading section number) for a
-/// markdown heading line, or `None` when the line is not a heading.
+/// Return the heading text (after the leading `#`s only) for a markdown heading
+/// line, or `None` when the line is not a heading.
+///
+/// A template section number is part of the returned text: `## 2. Executive
+/// Summary` yields `2. Executive Summary`, not `Executive Summary`. Callers that
+/// render the result into prose must not let that number read as a value of
+/// their own — see #5319, where joining it behind `Data gaps:` produced a count
+/// the report never computed.
 fn heading_text(trimmed: &str) -> Option<&str> {
     let rest = trimmed.trim_start_matches('#');
     if rest.len() == trimmed.len() {

--- a/crates/trusty-review/src/report/polish_tests.rs
+++ b/crates/trusty-review/src/report/polish_tests.rs
@@ -160,7 +160,7 @@ fn drops_marker_rows() {
     let out = polish(&input);
     assert!(out.contains("| Vendor | trusty-review |"));
     assert!(!out.contains(&format!("Client | {HONESTY_MARKER}")));
-    assert!(out.contains("Data gaps: Client."));
+    assert!(out.contains("Data gaps: 1 unpopulated field/section — Client."));
 }
 
 /// Why: a section left with no data after row/block dropping must collapse to a
@@ -173,7 +173,8 @@ fn collapses_empty_section() {
     let input = "## 6. Risk Registers\n\n## 7. Appendix\n\ncontent\n\n## 8. Gaps & Caveats\n\nplaceholder\n";
     let out = polish(input);
     assert!(out.contains("_No data available"));
-    assert!(out.contains("Data gaps: 6. Risk Registers"));
+    // One gap, so the line counts it in the singular (#5319).
+    assert!(out.contains("Data gaps: 1 unpopulated field/section — 6. Risk Registers."));
     // Section 7 has content and is preserved.
     assert!(out.contains("content"));
 }
@@ -198,6 +199,60 @@ fn gaps_section_lists_dropped_fields() {
     assert!(gaps_line.contains("Client"));
     assert!(gaps_line.contains("Analyst"));
     assert!(!out.contains(HONESTY_MARKER));
+}
+
+/// Parse the `Data gaps:` line into its declared count and its listed items.
+///
+/// Why: #5319's whole point is that those two must agree, so the regression test
+/// reads them back out of the rendered line exactly as a reader would.
+/// What: returns `(declared_count, items)` from the single `Data gaps:` line.
+fn parse_gaps_line(out: &str) -> (usize, Vec<&str>) {
+    let line = out
+        .lines()
+        .find(|l| l.starts_with("Data gaps:"))
+        .expect("gaps line");
+    let (count_part, list_part) = line
+        .trim_start_matches("Data gaps:")
+        .split_once('—')
+        .expect("count and list are separated by an em dash");
+    let count = count_part
+        .split_whitespace()
+        .next()
+        .expect("count token")
+        .parse::<usize>()
+        .expect("count token parses as a number");
+    let items: Vec<&str> = list_part
+        .trim()
+        .trim_end_matches('.')
+        .split(';')
+        .map(str::trim)
+        .collect();
+    (count, items)
+}
+
+/// Why: #5319 — the line rendered as `Data gaps: 2. Executive Summary, …`, whose
+/// leading section number a diligence reader parses as a count of two ahead of a
+/// sixteen-name list. Nothing counted anything; the "2" was the first label's own
+/// template numbering, and comma-joining it behind a colon manufactured a number
+/// that contradicted the list.
+/// What: collapses three numbered template sections, then asserts the declared
+/// count equals the number of items the same line goes on to list.
+/// Test: this test itself.
+#[test]
+fn gaps_line_count_matches_its_own_list() {
+    let input = "## 2. Executive Summary\n\n## 6.2 Open-Source / CVE Exposure\n\n\
+                 ## 6.3 License / IP Risk\n\n## 7. Graph-Ready Data Appendix\n\ncontent\n\n\
+                 ## 8. Gaps & Caveats\n\nplaceholder\n";
+    let out = polish(input);
+    let (count, items) = parse_gaps_line(&out);
+    assert_eq!(
+        count,
+        items.len(),
+        "declared count must equal the listed items: {out}"
+    );
+    assert_eq!(count, 3, "three sections collapsed: {out}");
+    // The section that supplied the misread "2." is still named in full.
+    assert!(items.contains(&"2. Executive Summary"), "{out}");
 }
 
 /// Why: with no gaps at all, the section states so rather than an empty list.

--- a/docs/trusty-review/spec/report-generation.md
+++ b/docs/trusty-review/spec/report-generation.md
@@ -647,8 +647,12 @@ deterministic fill and before the appended status notes):
    collapses instead of rendering with nothing beneath it (live-QA wave-2 defect
    #4).
 4. **Gaps list** — every dropped field/section is collected into a compact
-   `Data gaps: client, native scale, …` line in the Gaps & Caveats section,
-   replacing the wall of `not stated` rows.
+   `Data gaps: 2 unpopulated fields/sections — client; native scale.` line in the
+   Gaps & Caveats section, replacing the wall of `not stated` rows. The count is
+   the length of the same slice the line goes on to join, so the two can never
+   disagree; items are `;`-separated because a label may itself contain a comma
+   or open with its template section number ("2. Executive Summary"), which
+   comma-joining rendered as a bogus leading count (#5319).
 
 This **deliberately changes default rendering** — the M2/M3 byte-identical-when-off
 guarantees apply to *their* flags (`--synthesize`, `--benchmark`), not to this


### PR DESCRIPTION
Closes #5319.

The issue's premise was that a count contradicted its list. There was never a count: `polish.rs` rendered `format!("Data gaps: {}.", gaps.join(", "))`, and the apparent "2" was the first label's own section number — `heading_text` strips `#` but not a leading `2. `, so the template's `## 2. Executive Summary` yields the label `2. Executive Summary`.

`render_gaps_line` now derives the count as `gaps.len()` of the same slice it joins, so the two cannot drift, and separates items with `;` because a label may contain a comma:

    Data gaps: 3 unpopulated fields/sections — 2. Executive Summary; 6.2 Open-Source / CVE Exposure; 6.3 License / IP Risk.

## Test ladder — rung 3 (localized to one crate)

    cargo fmt --check
    cargo check -p trusty-review
    cargo clippy -p trusty-review --all-targets -- -D warnings
    cargo test -p trusty-review

Green: 1593 passed, 0 failed, 5 ignored (+68 and 8 integration binaries). Plus `check_line_cap.sh` (0 violations) and `check_sld.sh` (0 errors).

The regression test was written before the fix and proved red against unmodified production code.

## Review

code-critic: APPROVE. It independently re-derived the refutation against `origin/main` — `gaps.len()` appears nowhere there — rather than accepting it. One MEDIUM finding fixed in this PR: `heading_text`'s doc comment claimed to strip leading section numbers and never did, which is the false claim that allowed this bug. Comment corrected with a worked example; the implementation is deliberately unchanged, since altering it would move gap labels and collapse-pass display text.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools