### PR TITLE
fix(tga): surface repos that fell back to stale local refs instead of reporting a clean collect

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/5321-stale-refs-reach-the-report.md
+++ b/crates/trusty-git-analytics/changelog.d/5321-stale-refs-reach-the-report.md
@@ -8,4 +8,5 @@ Fixed
   a report over months-old refs was indistinguishable from a current one (#5321,
   DOC-67 §9). `commands::collect::run_reporting_fetch` is the new entry point
   that returns those outcomes — `run` and `run_with_progress` are unchanged and
-  still return `()`.
+  still return `()`. The sweep's terminal table qualifies the same stage as
+  `ok (N stale)`; a run where every remote was reached renders as before.

--- a/crates/trusty-git-analytics/changelog.d/5321-stale-refs-reach-the-report.md
+++ b/crates/trusty-git-analytics/changelog.d/5321-stale-refs-reach-the-report.md
@@ -1,0 +1,11 @@
+Fixed
+
+- A repository `tga audit` collected from stale local refs is now named in the
+  report's Gaps & Caveats section, with its remote and the fetch error, and
+  states that its data may be behind the true remote state. The sweep hard-codes
+  `--allow-stale`, so an unreachable remote leaves the `collect` stage reporting
+  `ok`; the per-repository fetch outcomes were printed to stderr and dropped, and
+  a report over months-old refs was indistinguishable from a current one (#5321,
+  DOC-67 §9). `commands::collect::run_reporting_fetch` is the new entry point
+  that returns those outcomes — `run` and `run_with_progress` are unchanged and
+  still return `()`.

--- a/crates/trusty-git-analytics/src/audit/gaps.rs
+++ b/crates/trusty-git-analytics/src/audit/gaps.rs
@@ -59,42 +59,62 @@ pull-request, and ticket metadata; it stores no file content, diffs, patches, hu
 Free-text fields it does store — commit messages, pull-request and ticket titles — are retained \
 verbatim and carry whatever their authors wrote into them.";
 
-/// One Gaps & Caveats line per stage that did not complete.
+/// One Gaps & Caveats line per stage that did not complete, then one per
+/// repository collected from stale local refs.
 ///
 /// Why: a stage that failed took a whole class of data with it — no `dora` run
 /// means no delivery-health figures, no `jira sync` means no ticket
 /// correlation — and DOC-67 §9 requires that absence be stated, not inferred
 /// from an empty table. The sweep deliberately does not abort on a stage
 /// failure (§2, one shot), which is exactly why the failure has to reappear
-/// here.
+/// here. A stale-refs fallback (#5321) is the same obligation one step
+/// further in: the stage SUCCEEDED, so nothing about the data's age is visible
+/// anywhere on the page unless it is stated here.
 /// What: for each failure in execution order, a line naming the stage, a
 /// redacted excerpt of the reason, and the fact that the affected area is
-/// unassessed. Returns an empty vec when every stage succeeded — a clean run
-/// adds no line.
+/// unassessed; then, for each unreachable remote, a line naming the repository,
+/// the remote, and that its figures may be behind the true remote state.
+/// Returns an empty vec when every stage succeeded and every remote was
+/// reached — a clean run adds no line.
 ///
 /// `secrets` are the credential values to remove from each stage message —
 /// [`crate::report::dd_manifest::configured_secrets`] derives the set the same
 /// audit run's manifest uses. It is a required argument, not a convenience: see
 /// the module docs for why truncating before scrubbing leaks a prefix fragment.
+/// A fetch error is scrubbed on the same path, and needs it just as much: git2
+/// quotes the remote URL back, which for an HTTPS remote carries whatever
+/// credential was embedded in it.
 /// Test: `super::tests::{sweep_gap_lines_name_each_failed_stage,
-/// sweep_gap_lines_are_empty_for_a_clean_run}`, and
+/// sweep_gap_lines_are_empty_for_a_clean_run,
+/// a_repo_that_fell_back_to_stale_local_refs_is_named_in_the_gap_lines}`, and
 /// `crate::report::dd_manifest_tests::a_token_straddling_the_excerpt_boundary_leaves_no_fragment`.
 pub fn sweep_gap_lines<S: AsRef<str>>(stats: &AuditSweepStats, secrets: &[S]) -> Vec<String> {
-    stats
-        .failures()
-        .map(|outcome| {
-            let reason = match &outcome.status {
-                StageStatus::Failed(msg) => redacted_excerpt(msg, secrets),
-                _ => String::new(),
-            };
-            format!(
-                "Collection stage `{}` did not complete ({reason}) — the data it produces is \
-                 not assessed in this report. Read the affected sections as unassessed, not as \
-                 a clean result.",
-                outcome.stage
-            )
-        })
-        .collect()
+    let failed_stages = stats.failures().map(|outcome| {
+        let reason = match &outcome.status {
+            StageStatus::Failed(msg) => redacted_excerpt(msg, secrets),
+            _ => String::new(),
+        };
+        format!(
+            "Collection stage `{}` did not complete ({reason}) — the data it produces is \
+             not assessed in this report. Read the affected sections as unassessed, not as \
+             a clean result.",
+            outcome.stage
+        )
+    });
+
+    // #5321: worded from the collector's own log line, because an operator who
+    // has the run log needs to match the two up without translating.
+    let stale = stats.stale_fetches.iter().map(|fetch| {
+        let reason = redacted_excerpt(&fetch.error, secrets);
+        format!(
+            "Repository `{}` could not be fetched from remote `{}` ({reason}) — collection \
+             continued on stale local refs, so its data may be behind the true remote state. \
+             Read its figures as a snapshot of the local clone, not of the remote.",
+            fetch.repo, fetch.remote
+        )
+    });
+
+    failed_stages.chain(stale).collect()
 }
 
 /// A single-line, credential-free excerpt of `msg`, capped at

--- a/crates/trusty-git-analytics/src/audit/mod.rs
+++ b/crates/trusty-git-analytics/src/audit/mod.rs
@@ -39,5 +39,5 @@ pub use review::{
     artifact_paths, resolve_review_binary, run_review_report, ReviewRun, ReviewRunError,
     DEFAULT_REVIEW_BIN, ENV_REVIEW_BIN,
 };
-pub use stage::{AuditSweepStats, StageOutcome, StageStatus, SweepStage};
+pub use stage::{AuditSweepStats, StageOutcome, StageStatus, StaleFetch, SweepStage};
 pub use sweep::{run_full_sweep, SweepOptions};

--- a/crates/trusty-git-analytics/src/audit/stage.rs
+++ b/crates/trusty-git-analytics/src/audit/stage.rs
@@ -102,6 +102,29 @@ pub struct StageOutcome {
     pub elapsed: Duration,
 }
 
+/// A repository the sweep walked on stale local refs because its remote could
+/// not be fetched (#5321).
+///
+/// Why: this is the degradation a [`StageStatus`] cannot express. The sweep
+/// hard-codes `--allow-stale` (DOC-67 §9), so an unreachable remote does not
+/// fail the `collect` stage — it silently narrows what the stage collected. A
+/// separate record is what lets the report distinguish "no stale repositories"
+/// from "this repository's figures describe a local clone of unknown age".
+/// What: the repository's display name, the remote that could not be reached,
+/// and the fetch error verbatim. The error is redacted and excerpted later, by
+/// [`super::sweep_gap_lines`], for the same reason a stage message is.
+/// Test: `super::tests::a_repo_that_fell_back_to_stale_local_refs_is_named_in_the_gap_lines`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct StaleFetch {
+    /// Display name of the repository, as the collection pipeline reported it.
+    pub repo: String,
+    /// The remote that could not be fetched (usually `origin`).
+    pub remote: String,
+    /// The fetch error, unredacted and untruncated.
+    pub error: String,
+}
+
 /// The ordered outcome of a full AUDIT sweep.
 ///
 /// Why: DOC-67 §9 requires that a repo or dimension missing because a stage
@@ -117,6 +140,10 @@ pub struct StageOutcome {
 pub struct AuditSweepStats {
     /// Every stage that was attempted, in execution order.
     pub outcomes: Vec<StageOutcome>,
+    /// Repositories collected from stale local refs because their remote could
+    /// not be fetched, in collection order (#5321). Empty when every configured
+    /// remote was reached — a clean run adds no entry.
+    pub stale_fetches: Vec<StaleFetch>,
 }
 
 impl AuditSweepStats {
@@ -143,6 +170,24 @@ impl AuditSweepStats {
             status,
             elapsed: started.elapsed(),
         });
+    }
+
+    /// Record that `fetch`'s repository was walked on stale local refs.
+    ///
+    /// Why: the stage this happened inside reports `Succeeded`, so without an
+    /// explicit record the fact has nowhere to go — #5321 is precisely that it
+    /// went nowhere. Logging it here as well as storing it keeps the terminal
+    /// and the report saying the same thing.
+    /// What: warns, then appends. Order of arrival is collection order.
+    /// Test: `super::tests::a_repo_that_fell_back_to_stale_local_refs_is_named_in_the_gap_lines`.
+    pub fn record_stale_fetch(&mut self, fetch: StaleFetch) {
+        tracing::warn!(
+            repo = %fetch.repo,
+            remote = %fetch.remote,
+            error = %fetch.error,
+            "collected from stale local refs; data may be behind the remote"
+        );
+        self.stale_fetches.push(fetch);
     }
 
     /// Every stage that failed, in execution order.

--- a/crates/trusty-git-analytics/src/audit/sweep.rs
+++ b/crates/trusty-git-analytics/src/audit/sweep.rs
@@ -13,6 +13,7 @@
 use std::path::PathBuf;
 use std::time::Instant;
 
+use crate::collect::collector::{FetchOutcome, PerRepoFetch};
 use crate::commands::args::{ClassifyArgs, CollectArgs, ReportArgs};
 use crate::commands::deployments::DeploymentsCollectArgs;
 use crate::commands::incidents::IncidentsCollectArgs;
@@ -23,7 +24,7 @@ use crate::core::config::Config;
 use crate::core::db::Database;
 use crate::core::progress::{ProgressBus, ProgressEvent, Stage};
 
-use super::stage::{AuditSweepStats, SweepStage};
+use super::stage::{AuditSweepStats, StaleFetch, SweepStage};
 
 /// How many stages [`run_full_sweep`] drives.
 ///
@@ -124,7 +125,10 @@ pub async fn run_full_sweep(
         allow_stale: true,
         ..CollectArgs::default()
     };
-    let result = collect::run_with_progress(config.clone(), db, args, &collect_bus).await;
+    let result = collect::run_reporting_fetch(config.clone(), db, args, &collect_bus).await;
+    // #5321: do this BEFORE `finish` — the stage is about to be recorded as
+    // succeeded, and a succeeded stage produces no gap line of its own.
+    let result = record_stale_fetches(&mut stats, result);
     finish(progress, &mut stats, SweepStage::Collect, t, result);
 
     let t = begin(progress, &stats, SweepStage::Classify);
@@ -177,6 +181,35 @@ pub async fn run_full_sweep(
 
     tracing::info!(summary = %stats.summary(), "audit sweep finished");
     Ok(stats)
+}
+
+/// Keep every unreachable remote from collection, and hand back the bare result.
+///
+/// Why: `--allow-stale` is fixed on for the sweep (DOC-67 §9), so a repository
+/// whose remote is unreachable is walked on whatever its local clone already
+/// held and collection still returns `Ok`. That is the right behaviour for a
+/// one-shot org sweep and the wrong thing to keep to ourselves: without this
+/// step the only trace is a stderr line, and the report reads as if every
+/// repository were current (#5321).
+/// What: records one [`StaleFetch`] per [`FetchOutcome::Failed`] outcome, then
+/// discards the outcome list so the caller has the `Result<()>` that
+/// [`finish`] takes. An `Err` passes straight through with nothing recorded —
+/// a stage that failed already reaches the report through its own gap line.
+/// Test: `super::tests::a_repo_that_fell_back_to_stale_local_refs_is_named_in_the_gap_lines`.
+fn record_stale_fetches(
+    stats: &mut AuditSweepStats,
+    result: anyhow::Result<Vec<PerRepoFetch>>,
+) -> anyhow::Result<()> {
+    for fetch in result? {
+        if let FetchOutcome::Failed { remote, error } = fetch.outcome {
+            stats.record_stale_fetch(StaleFetch {
+                repo: fetch.repo,
+                remote,
+                error,
+            });
+        }
+    }
+    Ok(())
 }
 
 /// Announce that `stage` is starting, and return the instant to time it from.

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -437,6 +437,135 @@ fn sweep_gap_lines_name_each_failed_stage() {
     assert_eq!(lines, crate::audit::sweep_gap_lines(&stats, NO_SECRETS));
 }
 
+/// #5321: a `collect` stage that fell back to stale local refs used to reach
+/// the report as nothing at all.
+///
+/// The sweep hard-codes `--allow-stale` (DOC-67 §9), so an unreachable remote
+/// is not an error: the pipeline walks whatever the local clone already had and
+/// the stage records `Succeeded`. `sweep_gap_lines` only reads
+/// [`AuditSweepStats::failures`], so a succeeded stage contributed no line and
+/// the manifest carried no note — the reader could not tell "no stale refs" from
+/// "the data may be months behind". Before the fix this test fails on the final
+/// assertion: the gap lines name the failed `jira sync` stage and nothing else.
+#[tokio::test]
+async fn a_repo_that_fell_back_to_stale_local_refs_is_named_in_the_gap_lines() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo_path = dir.path().join("acme-service");
+    // An `origin` whose scheme has no transport: the fetch fails without
+    // touching the network, exactly as the reported run's SSH remote did
+    // ("unsupported URL protocol"), so the test is offline and deterministic.
+    init_repo_with_dead_origin(
+        &repo_path,
+        "sshx://git@example.invalid/acme/acme-service.git",
+    );
+
+    let mut config = Config::default();
+    config
+        .repositories
+        .push(crate::core::config::RepositoryConfig {
+            name: Some("acme-service".to_string()),
+            path: repo_path,
+            branch: None,
+            since_date: None,
+            until_date: None,
+            org: None,
+            head_only: false,
+            fetch_timeout_secs: None,
+        });
+
+    let mut db = Database::open(&dir.path().join("tga.db")).expect("open db");
+    let options = SweepOptions {
+        output: Some(dir.path().join("out")),
+        weeks: Some(1),
+    };
+    let stats = run_full_sweep(&config, &mut db, &options, None)
+        .await
+        .expect("sweep");
+
+    // The defect's own shape: the stage reports `ok`. That is correct — the
+    // sweep must not abort — which is exactly why the degradation needs its own
+    // channel to the report.
+    let collect = stats
+        .outcomes
+        .iter()
+        .find(|o| o.stage == SweepStage::Collect)
+        .expect("collect stage ran");
+    assert_eq!(
+        collect.status,
+        StageStatus::Succeeded,
+        "collect should still report ok under --allow-stale: {:?}",
+        collect.status
+    );
+
+    let lines = crate::audit::sweep_gap_lines(&stats, NO_SECRETS);
+    let stale = lines
+        .iter()
+        .find(|l| l.contains("acme-service"))
+        .unwrap_or_else(|| {
+            panic!("no Gaps & Caveats line names the repo that fell back to stale refs: {lines:#?}")
+        });
+    assert!(
+        stale.contains("origin"),
+        "the line must name the affected remote: {stale}"
+    );
+    assert!(
+        stale.contains("behind the true remote state"),
+        "the line must say the data may be out of date: {stale}"
+    );
+}
+
+/// A git repository with one commit and an `origin` that cannot be fetched.
+fn init_repo_with_dead_origin(path: &std::path::Path, remote_url: &str) {
+    std::fs::create_dir_all(path).expect("mkdir");
+    let repo = git2::Repository::init(path).expect("git init");
+    repo.remote("origin", remote_url).expect("add origin");
+
+    std::fs::write(path.join("README.md"), "acme").expect("write file");
+    let mut index = repo.index().expect("index");
+    index
+        .add_path(std::path::Path::new("README.md"))
+        .expect("index add");
+    index.write().expect("index write");
+    let tree = repo
+        .find_tree(index.write_tree().expect("write_tree"))
+        .expect("find_tree");
+    let sig = git2::Signature::now("Test", "t@example.com").expect("signature");
+    repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+        .expect("commit");
+}
+
+/// The stale-refs line travels the same redaction path a stage message does,
+/// and it needs to: git2 quotes the remote URL back in the error, so an HTTPS
+/// remote with an embedded token puts that token in the manifest and the
+/// delivered report. Also pins the ordering — failed stages first, then the
+/// repositories that were collected anyway.
+#[test]
+fn a_credential_in_a_fetch_error_never_reaches_the_gap_line() {
+    let mut stats = AuditSweepStats::default();
+    stats.record(
+        SweepStage::Dora,
+        Instant::now(),
+        Err(anyhow::anyhow!("fact_deployments is empty")),
+    );
+    stats.record_stale_fetch(crate::audit::StaleFetch {
+        repo: "acme-service".to_string(),
+        remote: "origin".to_string(),
+        error: "failed to connect to https://x-access-token:ghp_SECRETVALUE@github.com/acme/svc"
+            .to_string(),
+    });
+
+    let lines = crate::audit::sweep_gap_lines(&stats, &["ghp_SECRETVALUE"]);
+
+    assert_eq!(lines.len(), 2, "{lines:#?}");
+    assert!(lines[0].contains("`dora`"), "{}", lines[0]);
+    assert!(lines[1].contains("acme-service"), "{}", lines[1]);
+    assert!(
+        !lines[1].contains("ghp_SECRETVALUE"),
+        "the token survived into the report: {}",
+        lines[1]
+    );
+}
+
 #[test]
 fn sweep_gap_lines_are_empty_for_a_clean_run() {
     let mut stats = AuditSweepStats::default();

--- a/crates/trusty-git-analytics/src/commands/audit.rs
+++ b/crates/trusty-git-analytics/src/commands/audit.rs
@@ -18,7 +18,7 @@ use clap::Args;
 
 use tga::audit::{
     resolve_review_binary, run_full_sweep, run_review_report, sweep_gap_lines, AuditSweepStats,
-    SweepOptions, DATA_HANDLING_NOTE,
+    SweepOptions, SweepStage, DATA_HANDLING_NOTE,
 };
 use tga::core::config::Config;
 use tga::core::db::Database;
@@ -244,7 +244,7 @@ fn print_stage_report(stats: &AuditSweepStats) {
 /// unobservable from a test — this split is the whole fix.
 /// What: identical output to `print_stage_report`, written through `out`/`err`
 /// instead of `stdout()`/`stderr()`.
-/// Test: `audit_command_reports_each_stage`.
+/// Test: `audit_command_reports_each_stage`, `collect_row_counts_stale_repositories`.
 fn write_stage_report(
     stats: &AuditSweepStats,
     out: &mut impl std::io::Write,
@@ -252,16 +252,11 @@ fn write_stage_report(
 ) -> std::io::Result<()> {
     writeln!(out, "\nStages:")?;
     for outcome in &stats.outcomes {
-        let mark = if outcome.status.is_failure() {
-            "FAILED"
-        } else {
-            "ok"
-        };
         writeln!(
             out,
             "  {:<20} {:>6}  {:.1}s",
             outcome.stage.as_str(),
-            mark,
+            stage_mark(stats, outcome),
             outcome.elapsed.as_secs_f64()
         )?;
     }
@@ -281,11 +276,32 @@ fn write_stage_report(
     Ok(())
 }
 
+/// One stage's status cell in the table.
+///
+/// Why: #5321 — `collect` succeeds when a repository falls back to stale local
+/// refs, so the bare `ok` it earned is a status the operator cannot act on. The
+/// report's Gaps & Caveats section states the same fact, but the person
+/// watching the run has not got the report yet.
+/// What: `FAILED` for a failed stage; `ok (N stale)` for the collect stage when
+/// N repositories were collected from stale refs; `ok` otherwise — so a run
+/// with no stale repository renders exactly as it did before.
+/// Test: `collect_row_counts_stale_repositories`.
+fn stage_mark(stats: &AuditSweepStats, outcome: &tga::audit::StageOutcome) -> String {
+    if outcome.status.is_failure() {
+        return "FAILED".to_string();
+    }
+    let stale = stats.stale_fetches.len();
+    if outcome.stage == SweepStage::Collect && stale > 0 {
+        return format!("ok ({stale} stale)");
+    }
+    "ok".to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Instant;
 
-    use tga::audit::{AuditSweepStats, SweepStage};
+    use tga::audit::{AuditSweepStats, StaleFetch, SweepStage};
 
     use super::write_stage_report;
 
@@ -338,6 +354,55 @@ mod tests {
         assert!(
             err.contains("jira sync") && err.contains("no JIRA project configured"),
             "missing the named failure detail on stderr: {err}"
+        );
+    }
+
+    /// #5321 follow-up: the terminal table said a bare `ok` for a collect stage
+    /// that fell back to stale refs on N repositories — success it had not fully
+    /// earned, the same defect one surface over from the one this PR fixes.
+    /// Pins both directions: the qualifier appears when repositories went stale,
+    /// and a run with none renders the row exactly as it did before, right-
+    /// aligned `ok` and no mention of staleness anywhere in the output.
+    #[test]
+    fn collect_row_counts_stale_repositories() {
+        let render = |stats: &AuditSweepStats| {
+            let (mut out, mut err) = (Vec::new(), Vec::new());
+            write_stage_report(stats, &mut out, &mut err).expect("write to an in-memory buffer");
+            String::from_utf8(out).expect("stdout is UTF-8")
+        };
+        let collect_row = |rendered: &str| {
+            rendered
+                .lines()
+                .find(|l| l.contains("collect"))
+                .expect("collect row present")
+                .to_string()
+        };
+
+        let mut clean = AuditSweepStats::default();
+        clean.record(SweepStage::Collect, Instant::now(), Ok(()));
+        let clean_out = render(&clean);
+        assert!(
+            collect_row(&clean_out).contains("    ok  "),
+            "a run with no stale repository must render the row unchanged: {clean_out}"
+        );
+        assert!(
+            !clean_out.contains("stale"),
+            "nothing about staleness belongs in a clean run: {clean_out}"
+        );
+
+        let mut stale = AuditSweepStats::default();
+        stale.record(SweepStage::Collect, Instant::now(), Ok(()));
+        for repo in ["acme-service", "acme-web"] {
+            stale.record_stale_fetch(StaleFetch {
+                repo: repo.to_string(),
+                remote: "origin".to_string(),
+                error: "unsupported URL protocol".to_string(),
+            });
+        }
+        let stale_row = collect_row(&render(&stale));
+        assert!(
+            stale_row.contains("ok (2 stale)"),
+            "the row must count the repositories that fell back: {stale_row}"
         );
     }
 }

--- a/crates/trusty-git-analytics/src/commands/collect.rs
+++ b/crates/trusty-git-analytics/src/commands/collect.rs
@@ -1,6 +1,6 @@
 //! `tga collect` — stage 1 (git extraction) entry point.
 
-use tga::collect::collector::FetchOutcome;
+use tga::collect::collector::{FetchOutcome, PerRepoFetch};
 use tga::collect::CollectionPipeline;
 use tga::core::config::Config;
 use tga::core::db::Database;
@@ -44,6 +44,36 @@ pub async fn run_with_progress(
     args: CollectArgs,
     progress: &ProgressBus,
 ) -> anyhow::Result<()> {
+    run_reporting_fetch(config, db, args, progress)
+        .await
+        .map(|_| ())
+}
+
+/// Run the collection stage and hand back what happened to each remote.
+///
+/// Why: #5321 — under `--allow-stale` a repository whose remote is unreachable
+/// is walked on its stale local refs and collection returns `Ok`, so a caller
+/// that only sees the `Result` cannot tell fresh data from data that may be
+/// months behind. The per-repo outcomes exist already; they were printed to
+/// stderr and dropped. `tga audit` needs them as values, because DOC-67 §9's
+/// obligation is to say so in the report, not on a terminal nobody keeps.
+/// What: identical to [`run_with_progress`] — same overrides, same warnings,
+/// same stderr summary, same strict-fetch bail — except that the successful
+/// return carries [`tga::collect::collector::CollectionStats::fetch_outcomes`]
+/// instead of `()`. An `Err`
+/// return carries no outcomes: a stage that failed is already a named gap.
+/// Test: `crate::audit::tests::a_repo_that_fell_back_to_stale_local_refs_is_named_in_the_gap_lines`.
+///
+/// # Errors
+///
+/// Propagates date-range resolution and pipeline errors, and — unless
+/// `--allow-stale` or `--no-fetch` was passed — a fetch failure on any repo.
+pub async fn run_reporting_fetch(
+    config: Config,
+    db: &mut Database,
+    args: CollectArgs,
+    progress: &ProgressBus,
+) -> anyhow::Result<Vec<PerRepoFetch>> {
     let mut cfg = config;
 
     // Filter repositories by name when --repos is supplied.
@@ -192,7 +222,7 @@ pub async fn run_with_progress(
         }
     }
 
-    Ok(())
+    Ok(stats.fetch_outcomes)
 }
 
 /// Print the end-of-collect fetch summary to stderr.


### PR DESCRIPTION
Closes #5321.

A fail-open. `audit::run_full_sweep` hard-codes `allow_stale: true`, so an unreachable remote never became an `Err`; the failure was printed to stderr, `CollectionStats` was dropped, and `sweep_gap_lines` — which iterates failures only — emitted nothing. The audit then collected on stale local refs of unknown age and recorded the stage as succeeded, so the report's figures described a local clone while presenting as a description of the remote.

Each unreachable remote is now recorded as a `StaleFetch` before the stage outcome is written, and named in Gaps & Caveats. The fetch error goes through the existing `redacted_excerpt` (scrub, then cut) because git2 quotes the remote URL back and an HTTPS remote can carry a token.

The stage still records `Succeeded`: `collect` walks N repos, and failing the whole stage for one stale repo would overstate the gap for the other N-1.

## Test ladder — rung 3 (localized to one crate)

    cargo fmt --check
    cargo check -p tga --all-targets
    cargo clippy -p tga --all-targets -- -D warnings
    cargo test -p tga

Green: 1057 passed, 0 failed, 1 ignored (+4 integration/doc targets). Plus `check_line_cap.sh` (0 violations) and `check_sld.sh` (0 errors).

The regression test was written first and run against unmodified `origin/main` — it uses only pre-fix API, and failed with `no Gaps & Caveats line names the repo that fell back to stale refs`. A second test proves a credential embedded in a fetch error is scrubbed before the excerpt is cut.

## Review

code-critic: APPROVE. It traced every path through the sweep to confirm the fail-open is closed, including that the one path discarding fetch outcomes surfaces as a stage failure rather than silently. One LOW finding fixed in this PR: the terminal table showed a bare `ok` while repos fell back, so the operator saw nothing during the run — the collect row now reads `ok (N stale)`, and a clean run renders byte-identically.

Public API additions are additive: `run_reporting_fetch`, plus a `stale_fetches` field and `StaleFetch` struct on the already-`#[non_exhaustive]` `AuditSweepStats`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools