### PR TITLE
docs(trusty-mpm): scope unit tests by delivery stage, not only by rung

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,11 @@ Read that page's rung entry before running the gate, and paste the command you
 actually ran into the PR body.
 
 🔴 **`cargo test --workspace` is not the default inner-loop proof for a localized
-change.** It belongs at the hardening boundaries (rungs 4–6). Making every narrow
-PR depend on the whole workspace turns unrelated flakes into an issue factory
-without adding one line of coverage for your change.
+change.** It is keyed to the stage, not the rung: it belongs at the publish
+boundary, and rungs 4–6 are the ones that reach it — a rung-4 PR does not owe a
+workspace run to merge. Making every narrow PR depend on the whole workspace
+turns unrelated flakes into an issue factory without adding one line of coverage
+for your change.
 
 🔴 **Scope down, never scope away.** Choosing a lower rung is a statement about
 blast radius, and you must be able to prove it (see the baseline-failure rules

--- a/crates/trusty-mpm/changelog.d/5377-staged-test-scope.md
+++ b/crates/trusty-mpm/changelog.d/5377-staged-test-scope.md
@@ -1,0 +1,9 @@
+Changed
+
+- `tm-workflow` gains a `Test Scope Widens by Stage` section, placed after the Sprint/Harden doctrine it refines ([#5377](https://github.com/bobmatnyc/trusty-tools/pull/5377))
+  - unit tests run on the new or changed code only while developing, on the full test files that changed when merging, and on the full corpus only when publishing
+  - merging widens to whole files, never to the whole repository — including cases you did not edit and any normally-skipped test in those files. A change to a public interface or to shared test infrastructure makes a dependent package's test files count as changed even though the diff never opened them
+  - stated stack-agnostic, since `tm-workflow` governs every project: the section names no build-tool command
+  - stage and rigour are named as separate axes that both bind — the stage decides how wide a gate runs, the project's risk labels and test ladder decide how hard it is applied and which gates run at all
+  - a project may leave a full-corpus CI job off its required pre-merge contexts, since that job is a publish gate. A *failing* check still blocks the merge at every stage; only *pending* is tolerated
+  - the hard line is restated in place: choosing the narrower scope is a blast-radius claim you must be able to prove, never licence to make a red gate green by deleting a test, marking it skipped, gating it out of the build, or excluding it from the run

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -159,6 +159,49 @@ derived rules live here because they apply only at a specific moment:
 Slow feature release *causes* too many things in flight. Shortening time-to-land
 is the fix; capping WIP treats the symptom.
 
+## Test Scope Widens by Stage
+
+Unit tests run on the new or changed code only while developing, on the full
+test files that changed when merging, and on the full corpus only when
+publishing.
+
+| Stage | Scope |
+|---|---|
+| Developing | tests covering the new or changed code only |
+| Merging | the full test files that changed |
+| Publishing | the full corpus |
+
+- **Developing** is the inner loop: the targeted test that proves the change,
+  re-run as you edit. Nothing wider is owed while the code is still moving.
+- **Merging** widens to whole files, never to the whole repository. Every test
+  file the diff touched runs in full — including the cases you did not edit, and
+  any normally-skipped test that lives in one of those files. A change to a
+  public interface or to shared test infrastructure alters what a dependent
+  package's test files mean, so those files count as changed even though the
+  diff never opened them.
+- **Publishing** is the only stage that owes the whole corpus, plus whatever
+  release gates the project defines.
+
+This is the two-phase doctrine at finer grain: developing is SPRINT; merging and
+publishing are two different widths inside HARDEN, and merging is the narrower.
+A green merge gate is therefore not a release gate.
+
+Stage and rigour are separate axes and both bind. The stage decides how *wide* a
+gate runs; the project's risk labels and test ladder decide how *hard* it is
+applied and which gates run at all. Pick the rung from the project's `CLAUDE.md`,
+then read the stage off where you are in the delivery chain.
+
+A consequence for branch protection: a full-corpus CI job is a publish gate, so a
+project may leave it off the required pre-merge contexts and merge while it is
+still pending. A **failing** check blocks the merge at every stage — only
+*pending* is tolerated.
+
+🔴 **Widening by stage is never licence to skip.** Choosing the narrower scope is
+a claim about blast radius that you must be able to prove. It is never licence to
+make a red gate green by deleting a test, marking it skipped or ignored, gating
+it out of the build, or excluding it from the run. That hard line ("Sprint, then
+Harden") is unchanged.
+
 ## Worktree Discipline (Mandatory Before Any Edit)
 
 The main checkout is **inspection-only** — read-only `git status`/`log`/`diff`/

--- a/docs/reference/test-ladder-baseline.md
+++ b/docs/reference/test-ladder-baseline.md
@@ -28,6 +28,86 @@ Why `cargo test --workspace` is absent from rungs 1–3, and the "scope down,
 never scope away" line that constrains picking a lower rung, are stated with the
 ladder itself in [`CLAUDE.md`](../../CLAUDE.md) — not repeated here.
 
+## The Three Stages in Cargo Terms
+
+`Skill(skill="tm-workflow")` ("Test Scope Widens by Stage") sets the framework
+rule for every project: developing runs the tests covering the new or changed
+code only, merging runs the full test files that changed, publishing runs the
+full corpus. This is what each stage is in this workspace.
+
+| Stage | Cargo scope | Command |
+|---|---|---|
+| Developing | the changed code's own tests | `cargo test -p <crate> <test-or-module> -- --exact --nocapture` |
+| Merging | every crate whose test files the diff changed | `cargo test -p <crate>` for each, alongside the `fmt`/`check`/`clippy` gates the rung calls for |
+| Publishing | the workspace | `cargo test --workspace` && `cargo clippy --workspace --all-targets -- -D warnings`, plus `cargo audit` and the publish preflight scripts |
+
+**Why merging is `-p <crate>` and not a per-file run.** Cargo has no "run this
+file" unit. A `#[cfg(test)] mod tests` compiles into its crate's test binary, and
+an integration test under `crates/<crate>/tests/` is its own binary but is still
+only addressable through its crate. `cargo test -p <crate>` is the smallest run
+that contains every test file the diff touched, so for this workspace it **is**
+the merge scope rather than an over-run of it.
+
+## How the Three Stages Compose With the Six Rungs
+
+Two axes, both binding. The rung says how much rigour the change earns — which
+gates run at all, whether ignored tests count, whether a `code-critic` round is
+owed. The stage says how wide each of those gates runs. Pick the rung from
+[`CLAUDE.md`](../../CLAUDE.md), then read the stage off where you are in the
+delivery chain.
+
+The per-rung table above already encodes the stages column by column:
+
+- **Development proof** is the developing stage.
+- **PR gate** is the merging stage.
+- **Hardening / release gate** is the publishing stage.
+
+**A rung-3 change: `cargo test -p <crate>` is the MERGE scope, not the develop
+scope.** While developing, run only the targeted regression test that provably
+fails before the change — `cargo test -p <crate> <test> -- --exact`. Before
+merging, run the crate in full: `cargo fmt --check` && `cargo check -p <crate>`
+&& `cargo clippy -p <crate> --all-targets -- -D warnings` && `cargo test -p
+<crate>`. A rung-3 change owes the workspace nothing at either stage.
+
+**Rung 4's `cargo check --workspace` stays at merge.** It is a compile gate, not
+a test run, so "full corpus only when publishing" does not reach it. Its
+companion `cargo test -p <consumer>` for each direct dependent is also merge
+scope, for the reason the framework rule gives: changing a shared library's
+public API changes what every dependent's test files mean, which makes those
+files changed even though the diff never opened them. Rung 4's `cargo test
+--workspace` sits in the hardening column precisely because it is the publish
+stage.
+
+**Rung 5's `--include-ignored` stays at merge too.** It is crate-scoped, and an
+`#[ignore]`d test living in a test file your diff changed is part of that file —
+the merge stage runs changed files *in full*, which is exactly what
+`--include-ignored` does for a crate. What rung 5 defers to publishing is the
+workspace run, `cargo audit`, and `scripts/check-publish-ready.sh` /
+`scripts/preflight-publish.sh`.
+
+**Rung 2's shared-test-infrastructure caveat is the one place merge scope can
+reach the workspace.** Same logic as rung 4's dependents: a change to a shared
+fixture or test harness changes what every test file using it means. When that
+happens the workspace run is a merge obligation, not a deferral to publish — the
+table's "only when shared test infrastructure changed" is the trigger.
+
+**`cargo test --workspace` is keyed to the stage, not the rung.** `CLAUDE.md`
+places it at the publish boundary; rungs 4–6 are named there only because they
+are the rungs that reach that boundary. A rung-4 PR does not owe a workspace test
+run to merge.
+
+**Branch protection follows from this.** The CI `Test` job is a pre-build /
+pre-publish gate, not a pre-merge one, and it is not among `main`'s required
+status contexts (`Format check`, `500-line file-size cap`, `Clippy`,
+`trusty-search daemon smoke test`, `MSRV check (1.94)`). Merges proceed with
+`Test` still pending; a **failing** check blocks at every stage.
+
+🔴 **Scoping down by stage is a claim you must be able to prove**, exactly as
+scoping down by rung is. It is never licence to make a red gate green by
+deleting, `#[ignore]`-ing, `cfg`-gating, `--exclude`-ing, or `--lib`-narrowing
+coverage. A red gate blocks at every stage; only a *pending* full-corpus check is
+tolerated at merge, never a failing one.
+
 ## How Much Gate Output the PR Body Owes
 
 A PR body may summarise a **passing** gate as command + counts + scope —


### PR DESCRIPTION
## Outcome

Adds the owner's staged test-scope rule to the bundled `tm-workflow` skill, and maps it onto this repo's six-rung ladder in the reference doc. No linked issue — the owner asked for this in the session it ships, so this PR is the record.

The rule, verbatim as it now reads in the skill:

> Unit tests run on the new or changed code only while developing, on the full test files that changed when merging, and on the full corpus only when publishing.

## What changed

- **`crates/trusty-mpm/src/assets/skills/tm-workflow.md`** — new section "Test Scope Widens by Stage", placed right after the Sprint/Harden doctrine it refines. Stack-agnostic: `tm-workflow` governs Rust, TypeScript, Python and everything else, so it names no cargo command and speaks of "test files" and "the run", not `-p <crate>`.
- **`docs/reference/test-ladder-baseline.md`** — two new sections carrying the Rust half: "The Three Stages in Cargo Terms" and "How the Three Stages Compose With the Six Rungs".
- **`CLAUDE.md`** — one sentence, re-keyed. Deliberately nothing else; the rule itself is framework-level and does not belong in a per-project override.

## How the two axes compose

They are different questions, and both bind. The rung says how much rigour a change earns — which gates run at all, whether ignored tests count, whether a critic round is owed. The stage says how wide each of those gates runs. The per-rung table's three columns already were the three stages, unnamed:

| Column | Stage |
|---|---|
| Development proof | Developing |
| PR gate | Merging |
| Hardening / release gate | Publishing |

**A rung-3 change: `cargo test -p <crate>` is the merge scope, not the develop scope.** Developing runs only the targeted regression test that provably fails before the change (`-- --exact`). Merging runs the crate in full. A rung-3 change owes the workspace nothing at either stage.

**Why merging is `-p <crate>` and not per-file:** cargo has no "run this file" unit — a `#[cfg(test)]` module compiles into its crate's test binary. `cargo test -p <crate>` is the *smallest* run containing every test file the diff touched, so it is the merge scope rather than an over-run of it.

**Rung 4's `cargo check --workspace` stays at merge** — it is a compile gate, not a test run, so "full corpus only when publishing" never reaches it. Its companion `cargo test -p <consumer>` per dependent is also merge scope: changing a shared library's public API changes what every dependent's test files *mean*, which makes those files changed even though the diff never opened them.

**Rung 5's `--include-ignored` stays at merge too** — it is crate-scoped, and an `#[ignore]`d test living in a changed test file is part of that file. The merge stage runs changed files in full, which is what `--include-ignored` does. What rung 5 defers to publishing is the workspace run, `cargo audit`, and the publish preflight scripts.

**Rung 2's shared-test-infrastructure caveat is the one place merge scope legitimately reaches the workspace**, by the same logic as rung 4's dependents.

### The `CLAUDE.md` contradiction, and the minimum edit

The line was:

> It belongs at the hardening boundaries (rungs 4–6).

That parenthetical reads as though a rung-4 PR owes `cargo test --workspace` to merge, which contradicts "full corpus only when publishing". The baseline table already disagreed with that reading — rung 4's workspace run sits in the *hardening* column, not the PR-gate column — so this was loose wording rather than a real conflict. Re-keyed to the stage, with rungs 4–6 kept as the rungs that reach it.

No genuine conflict between the staged rule and the ladder was found, so nothing was escalated.

## Out of scope

The rule is not restated in `CLAUDE.md`. It is a framework rule that applies to every project, and duplicating it into a per-project file is how the two drift.

## Risk

Docs and one bundled skill asset. No behavior change; `check_capabilities.sh` reports no drift, so no regeneration was needed.

## Test evidence

Rung 3 for `trusty-mpm` (the change lands under `crates/trusty-mpm/src/**`):

- `cargo fmt --check` && `cargo check -p trusty-mpm` && `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — EXIT=0
- `cargo test -p trusty-mpm` — 4906 passed; 1 failed; 7 ignored (the failure is pre-existing, below)
- `bash scripts/check_sld.sh` && `check_doc_numbers.sh` && `check_line_cap.sh` && `check_public_docs.sh` — EXIT=0
- `bash scripts/check_capabilities.sh` — `tm-capabilities: up to date (7 generated files).`

## Baseline failures

`client::executor::tests::execute_doctor_against_test_daemon` — the known-environmental failure documented in `docs/reference/test-ladder-baseline.md` ("takes 9–13 s against a 10 s client timeout"). Confirmed pre-existing, not caused by this branch:

```
$ cargo test -p trusty-mpm execute_doctor_against_test_daemon -- --exact ... --nocapture
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4913 filtered out; finished in 8.08s
```

Passes alone in 8.08 s, inside the 10 s timeout by the documented margin. Path evidence — this branch touches no Rust at all:

```
$ git diff --name-only origin/main...HEAD
CLAUDE.md
crates/trusty-mpm/src/assets/skills/tm-workflow.md
docs/reference/test-ladder-baseline.md
```

change-specific gates pass; `cargo test -p trusty-mpm` blocked by the documented environmental flake `execute_doctor_against_test_daemon`.

## Changelog

Fragment added in this PR: `crates/trusty-mpm/changelog.d/`.

## Collision check

PR #5373 also edits `CLAUDE.md` (`docs/sloc-cap-batch-rule`). It touches the SLOC-cap section around line 170; this touches the test-ladder section at line 79. No overlapping lines, no duplicated rule.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools