### PR TITLE
test(trusty-memory): each test seeds its own mock embedder

### DIFF
--- a/crates/trusty-memory/changelog.d/5378-tests-seed-own-embedder.md
+++ b/crates/trusty-memory/changelog.d/5378-tests-seed-own-embedder.md
@@ -1,0 +1,22 @@
+Fixed
+
+- 64 tests no longer depend on a mock embedder another test happened to seed
+  ([#5378](https://github.com/bobmatnyc/trusty-tools/pull/5378); same defect
+  class as [#4413](https://github.com/bobmatnyc/trusty-tools/issues/4413)).
+  `retrieval::shared_embedder()` is a process-wide `OnceCell`, so under
+  `cargo test` — one process per binary — whichever sibling seeded it first
+  satisfied every other test for free. Under nextest's process-per-test
+  isolation each test got a virgin cell, reached for the real ONNX model, and
+  failed on the HuggingFace download (HTTP 429 in CI), which is what reddened
+  CI run 31438217228 shard 1. Every test that embeds now calls
+  `seed_shared_embedder_with_mock()` itself — from the shared fixture where one
+  exists (`tools::tests::test_state`/`test_state_warming`,
+  `web::tests::test_state`, `messaging::tests::fresh_palace`,
+  `prompt_context::tests::spin_up_test_daemon_with_palace`,
+  `mcp_stdio_tools`'s `Fixture::new`/`seed_palace`) and inline in the eight
+  tests that build `AppState` directly. CI reported 17 failures, but that was
+  the subset that lost the HuggingFace lottery on one run rather than the
+  population; measuring with the embedder made deterministically unavailable
+  found 64. With the embedder unavailable, `cargo nextest run -p trusty-memory`
+  goes from 655 passed / 64 failed to 719/719, so the suite no longer needs a
+  model download at all.

--- a/crates/trusty-memory/src/commands/kg_rebuild.rs
+++ b/crates/trusty-memory/src/commands/kg_rebuild.rs
@@ -200,6 +200,25 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// Pre-seed the process-wide shared embedder with `MockEmbedder`.
+    ///
+    /// Why: both tests below seed fixture drawers via `memory_remember`, which
+    /// resolves `retrieval::shared_embedder()` — a process-wide `OnceCell`
+    /// where the first caller wins for the rest of the process. Under
+    /// `cargo test` a sibling test's seed silently satisfied these two; under
+    /// per-test process isolation (`cargo nextest run`) each gets a virgin
+    /// cell, reaches for the real ONNX model, and fails on the HuggingFace
+    /// download (HTTP 429 in CI). Same defect class as #4413: passing only
+    /// because a sibling ran first. Neither test builds state through a shared
+    /// fixture, so each establishes the precondition itself.
+    /// What: delegates to `seed_shared_embedder_with_mock`, which is idempotent
+    /// (`OnceCell::set`), so order does not matter.
+    /// Test: `kg_rebuild_processes_all_drawers`,
+    ///       `kg_rebuild_processes_named_palace_only`.
+    fn seed_embedder() {
+        trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock();
+    }
+
     /// Why: Validate the back-fill end-to-end against a freshly-created
     /// palace with a known drawer count.
     /// What: Build a tempdir-rooted `AppState`, create two palaces, drop a
@@ -209,6 +228,7 @@ mod tests {
     /// Test: This test.
     #[tokio::test]
     async fn kg_rebuild_processes_all_drawers() -> Result<()> {
+        seed_embedder();
         let tmp = tempfile::tempdir()?;
         // Issue #88: bypass palace-slug enforcement for test palaces.
         // SAFETY: tests using TRUSTY_SKIP_PALACE_ENFORCEMENT set a constant
@@ -279,6 +299,7 @@ mod tests {
     /// Test: This test.
     #[tokio::test]
     async fn kg_rebuild_processes_named_palace_only() -> Result<()> {
+        seed_embedder();
         let tmp = tempfile::tempdir()?;
         // Issue #88: bypass palace-slug enforcement for test palaces.
         // SAFETY: idempotent constant write "1"; safe across test threads.

--- a/crates/trusty-memory/src/commands/prompt_context/tests.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/tests.rs
@@ -696,6 +696,14 @@ async fn spin_up_test_daemon_with_palace(
     String,
     DaemonHandle,
 ) {
+    // Seed the process-wide `retrieval::shared_embedder()` OnceCell with
+    // `MockEmbedder`: every caller of this helper writes fixture drawers via
+    // `memory_remember`, which embeds. The cell is first-writer-wins for the
+    // whole process, so under `cargo test` a sibling test's seed satisfied
+    // these; under per-test process isolation (`cargo nextest run`) each gets a
+    // virgin cell and reaches for the real ONNX model (HTTP 429 in CI) — same
+    // defect class as #4413. The call is idempotent, so order does not matter.
+    trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock();
     let data_tmp = tempfile::tempdir().expect("data tempdir");
     let project_tmp = tempfile::tempdir().expect("project tempdir");
     // Build a project directory whose basename equals the palace slug.

--- a/crates/trusty-memory/src/lib_tests.rs
+++ b/crates/trusty-memory/src/lib_tests.rs
@@ -219,6 +219,14 @@ fn open_activity_log_with_fallback_returns_discard_when_unwritable() {
 /// `palace` argument and confirm it resolves to the default.
 #[tokio::test]
 async fn default_palace_used_when_arg_omitted() {
+    // This test builds its `AppState` inline rather than through a shared
+    // fixture, so it seeds the process-wide `retrieval::shared_embedder()`
+    // OnceCell itself. `memory_remember` below embeds; the cell is
+    // first-writer-wins, so under `cargo test` a sibling's seed satisfied this
+    // test, while under per-test process isolation (`cargo nextest run`) it got
+    // a virgin cell and reached for the real ONNX model (HTTP 429 in CI).
+    // Same defect class as #4413. Idempotent, so order does not matter.
+    trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock();
     let tmp = tempfile::tempdir().expect("tempdir");
     let root = tmp.path().to_path_buf();
 

--- a/crates/trusty-memory/src/messaging/mod.rs
+++ b/crates/trusty-memory/src/messaging/mod.rs
@@ -107,7 +107,16 @@ mod tests {
     }
 
     /// Helper: build a registry + palace under a tempdir and return both.
+    ///
+    /// Seeds the process-wide `retrieval::shared_embedder()` OnceCell with
+    /// `MockEmbedder` first: `send_message_to_palace` writes a drawer, which
+    /// embeds. That cell is first-writer-wins for the whole process, so under
+    /// `cargo test` a sibling's seed satisfied these tests; under per-test
+    /// process isolation (`cargo nextest run`) each gets a virgin cell and
+    /// reaches for the real ONNX model (HTTP 429 in CI) — same defect class as
+    /// #4413. The call is idempotent, so order does not matter.
     fn fresh_palace(id: &str) -> (PalaceRegistry, Arc<PalaceHandle>, PathBuf) {
+        trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock();
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = tmp.path().to_path_buf();
         std::mem::forget(tmp);

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -59,8 +59,29 @@ fn skip_palace_enforcement() {
     });
 }
 
+/// Pre-seed the process-wide shared embedder with `MockEmbedder`.
+///
+/// Why: `memory_remember` / `memory_recall` resolve
+/// `retrieval::shared_embedder()`, a process-wide `OnceCell`. Whichever caller
+/// seeds it first wins for the rest of the process, so under `cargo test` — one
+/// process for this whole binary — a single sibling's seed silently satisfied
+/// every other test. Under per-test process isolation (`cargo nextest run`)
+/// each test gets a virgin cell instead, reaches for the real ONNX model, and
+/// fails on the HuggingFace download (HTTP 429 in CI). Same defect class as
+/// [`skip_palace_enforcement`] / #4413: a test that passes only because a
+/// sibling ran first. Establishing the precondition in the fixtures every test
+/// already calls is what makes each test self-sufficient.
+/// What: delegates to `seed_shared_embedder_with_mock`, which is idempotent
+/// (`OnceCell::set`, first caller wins), so calling it from both fixtures is
+/// free and order-independent.
+/// Test: every test in this module that constructs state.
+fn seed_embedder() {
+    trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock();
+}
+
 fn test_state() -> (AppState, tempfile::TempDir) {
     skip_palace_enforcement();
+    seed_embedder();
     let tmp = tempfile::tempdir().expect("tempdir");
     let root = tmp.path().to_path_buf();
     let state = AppState::new(root);
@@ -78,6 +99,7 @@ fn test_state() -> (AppState, tempfile::TempDir) {
 ///       `note_returns_warming_error_while_state_is_warming`.
 fn test_state_warming() -> (crate::AppState, tempfile::TempDir) {
     skip_palace_enforcement();
+    seed_embedder();
     let tmp = tempfile::tempdir().expect("tempdir");
     let root = tmp.path().to_path_buf();
     let state = crate::AppState::new(root);
@@ -1875,10 +1897,15 @@ async fn bm25_index_queue_drops_when_full() {
 /// `handle.vector_store` returns a hit for the drawer id. This proves the
 /// deferred embed job is not just fired but actually completes.
 ///
-/// Deliberately does NOT seed a mock embedder: this unit-test binary also
-/// runs `dispatch_remember_then_recall` against the real, process-wide
-/// `shared_embedder()` singleton, and seeding a mock here would race with
-/// (and potentially poison) that test depending on execution order.
+/// Runs against the seeded `MockEmbedder` (via [`test_state_warming`] →
+/// [`seed_embedder`]). It used to deliberately skip the seed, on the reasoning
+/// that seeding would race `dispatch_remember_then_recall`'s use of the real
+/// embedder — but the cell is process-wide and first-writer-wins, so that
+/// reasoning made this test depend on whichever sibling happened to initialise
+/// it, and under `cargo nextest run` (a virgin cell per test) the
+/// `shared_embedder()` call below failed outright. The mock is a deterministic
+/// hash, so the backfilled vector and the query vector below match exactly;
+/// `dispatch_remember_then_recall` passes on the mock as well.
 /// Test: this test.
 #[tokio::test]
 async fn remember_succeeds_and_defers_embedding_while_state_is_warming() {

--- a/crates/trusty-memory/src/web/tests/attribution_tests.rs
+++ b/crates/trusty-memory/src/web/tests/attribution_tests.rs
@@ -9,6 +9,24 @@ use serde_json::{json, Value};
 use tower::util::ServiceExt;
 use trusty_common::memory_core::palace::PalaceId;
 
+/// Pre-seed the process-wide shared embedder with `MockEmbedder`.
+///
+/// Why: the attribution tests below build `AppState` INLINE (each needs its own
+/// pre-created palace), so they never run [`test_state`]'s seed. Their writes
+/// resolve `retrieval::shared_embedder()`, a process-wide `OnceCell` where the
+/// first caller wins for the rest of the process — so under `cargo test` a
+/// sibling test's seed silently satisfied them, while under per-test process
+/// isolation (`cargo nextest run`) each gets a virgin cell, reaches for the real
+/// ONNX model, and fails on the HuggingFace download (HTTP 429 in CI). Same
+/// defect class as #4413.
+/// What: delegates to `seed_shared_embedder_with_mock`, which is idempotent
+/// (`OnceCell::set`), so order does not matter.
+/// Test: the five `drawer_creator_attribution_*` /
+///       `mcp_writes_carry_distinct_ws_tags_per_caller_over_rpc` tests below.
+fn seed_embedder() {
+    trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock();
+}
+
 /// Why (submission-logging Part A): every hook firing must produce an
 /// activity-feed entry tagged `source=hook` so a normal Claude Code
 /// session that only triggers hooks no longer leaves the TUI feed
@@ -88,6 +106,7 @@ async fn hook_fired_activity_emit_smoke() {
 /// Test: itself.
 #[tokio::test]
 async fn drawer_creator_attribution_http_default() {
+    seed_embedder();
     let tmp = tempfile::tempdir().expect("tempdir");
     let root = tmp.path().to_path_buf();
     let state = AppState::new(root);
@@ -170,6 +189,7 @@ async fn drawer_creator_attribution_http_default() {
 /// Test: itself.
 #[tokio::test]
 async fn drawer_creator_attribution_http_header() {
+    seed_embedder();
     let tmp = tempfile::tempdir().expect("tempdir");
     let root = tmp.path().to_path_buf();
     let state = AppState::new(root);
@@ -244,6 +264,7 @@ async fn drawer_creator_attribution_http_header() {
 /// Test: itself.
 #[tokio::test]
 async fn drawer_creator_attribution_http_workstream_header() {
+    seed_embedder();
     let tmp = tempfile::tempdir().expect("tempdir");
     let root = tmp.path().to_path_buf();
     let state = AppState::new(root);
@@ -317,6 +338,7 @@ async fn drawer_creator_attribution_http_workstream_header() {
 /// Test: itself.
 #[tokio::test]
 async fn drawer_creator_attribution_mcp_default() {
+    seed_embedder();
     let tmp = tempfile::tempdir().expect("tempdir");
     let root = tmp.path().to_path_buf();
     std::mem::forget(tmp);
@@ -405,6 +427,7 @@ async fn drawer_creator_attribution_mcp_default() {
 /// Test: itself.
 #[tokio::test]
 async fn mcp_writes_carry_distinct_ws_tags_per_caller_over_rpc() {
+    seed_embedder();
     let tmp = tempfile::tempdir().expect("tempdir");
     let root = tmp.path().to_path_buf();
     let state = AppState::new(root);

--- a/crates/trusty-memory/src/web/tests/mod.rs
+++ b/crates/trusty-memory/src/web/tests/mod.rs
@@ -21,6 +21,16 @@ use crate::AppState;
 /// "warming" error.
 /// Test: Every test that calls `test_state()`.
 pub(crate) fn test_state() -> AppState {
+    // Pre-seed the process-wide `retrieval::shared_embedder()` OnceCell with
+    // `MockEmbedder`. Handlers that write or recall drawers resolve that cell;
+    // whichever caller seeds it first wins for the whole process, so under
+    // `cargo test` a sibling test's seed silently satisfied every test here.
+    // Under per-test process isolation (`cargo nextest run`) each test gets a
+    // virgin cell, reaches for the real ONNX model, and fails on the
+    // HuggingFace download (HTTP 429 in CI) — same defect class as #4413.
+    // `seed_shared_embedder_with_mock` is idempotent, so calling it from the
+    // fixture every test already uses is free and order-independent.
+    trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock();
     let tmp = tempfile::tempdir().expect("tempdir");
     let root = tmp.path().to_path_buf();
     std::mem::forget(tmp);

--- a/crates/trusty-memory/tests/mcp_stdio_tools.rs
+++ b/crates/trusty-memory/tests/mcp_stdio_tools.rs
@@ -38,6 +38,24 @@ use trusty_memory::AppState;
 // Fixtures
 // ---------------------------------------------------------------------------
 
+/// Pre-seed the process-wide shared embedder with `MockEmbedder`.
+///
+/// Why: `memory_remember` / `memory_recall` resolve `retrieval::shared_embedder()`,
+/// a process-wide `OnceCell`. Whichever test seeds it first wins for the whole
+/// process, so under `cargo test` — one process per binary — a single sibling's
+/// seed silently satisfied every other test here. Under per-test process
+/// isolation (`cargo nextest run`) each test gets a virgin cell instead, reaches
+/// for the real ONNX model, and fails on the HuggingFace download (HTTP 429 in
+/// CI). Same defect class as #4413: a test that passes only because a sibling
+/// ran first.
+/// What: delegates to `seed_shared_embedder_with_mock`, which is idempotent
+/// (`OnceCell::set`, first caller wins), so calling it from every fixture is
+/// free and safe regardless of order.
+/// Test: every test in this file, via `Fixture::new` or `seed_palace`.
+fn seed_embedder() {
+    trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock();
+}
+
 /// Hold an `AppState` together with the tempdir that backs it so cleanup
 /// happens at the end of the test instead of on `AppState` drop.
 ///
@@ -53,6 +71,7 @@ struct Fixture {
 
 impl Fixture {
     fn new() -> Self {
+        seed_embedder();
         let tmp = tempfile::tempdir().expect("tempdir");
         // Issue #88: bypass palace-slug enforcement so integration tests that
         // use arbitrary palace names keep passing. The env var is idempotent
@@ -608,6 +627,7 @@ where
     F: FnOnce(AppState, String) -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
+    seed_embedder();
     // Issue #88: bypass palace-slug enforcement so these tests can use
     // arbitrary palace names without a matching project root on disk.
     // SAFETY: constant idempotent write "1"; benign across threads.


### PR DESCRIPTION
Blocks nextest adoption (#5325). 17 `trusty-memory` tests failed on CI run [31438217228](https://github.com/bobmatnyc/trusty-tools/actions/runs/31438217228) shard 1 — not on assertions, but on HuggingFace rate-limiting a model download:

```
Caused by:
    0: acquire shared embedder for remember
    1: init shared FastEmbedder
    2: failed to initialise fastembed (tried AllMiniLML6V2 and AllMiniLML6V2Q)
    4: request error: http status: 429
```

Under `cargo test` the whole binary shares one process, so `retrieval::shared_embedder()`'s `OnceCell` was set once — by whichever sibling got there first — and every other test rode along. Under nextest's process-per-test isolation each test gets a virgin cell and reaches for the real ONNX model. Same defect class as #4413.

## The fix

Every test that embeds establishes the precondition itself, via `seed_shared_embedder_with_mock()`: in the shared fixture where one exists (`tools::tests::test_state` / `test_state_warming`, `web::tests::test_state`, `messaging::tests::fresh_palace`, `prompt_context::tests::spin_up_test_daemon_with_palace`, `mcp_stdio_tools`'s `Fixture::new` / `seed_palace`), and inline in the eight tests that build `AppState` directly. The call is idempotent, so order does not matter.

## Scope: 64, not 17

The reported 17 are the subset that lost the HuggingFace lottery on that run, not the population — the model lands on disk after the first successful download, so which tests 429 varies run to run. Measured rather than assumed, by making the embedder deterministically unavailable (`TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS=0`) so every test reaching `FastEmbedder::new()` fails instead of only the unlucky ones: 64 tests, a superset containing all 17. Fixing only the 17 would leave the next nextest run red on a different subset.

`remember_succeeds_and_defers_embedding_while_state_is_warming` documented the coupling as deliberate — it skipped the seed so as not to race `dispatch_remember_then_recall`'s real embedder. The cell is process-wide and first-writer-wins, so that made it depend on whichever sibling initialised it, and under isolation its `shared_embedder()` call failed outright. It now uses the mock (a deterministic hash, so the backfilled and query vectors match exactly); `dispatch_remember_then_recall` passes on the mock too. The doc comment now says that instead of the opposite.

## Gates

Rung 3 on `trusty-memory`, plus a red-first demonstration under process isolation.

Red-first, both runs `cargo nextest run -p trusty-memory --no-fail-fast` with the embedder made unavailable:

```
before:  Summary [ 32.608s] 719 tests run: 655 passed, 64 failed, 21 skipped
after:   Summary [ 36.403s] 719 tests run: 719 passed (2 leaky),  21 skipped
```

The suite no longer needs a model download at all. With the embedder available:

```
cargo nextest run -p trusty-memory   719 tests run: 719 passed (1 leaky), 21 skipped
cargo test -p trusty-memory          test result: ok. 629 passed; 0 failed; 4 ignored (lib), all 27 targets ok
cargo fmt --check                    clean
cargo check -p trusty-memory --all-targets   clean
cargo clippy -p trusty-memory --all-targets -- -D warnings   clean
scripts/check_line_cap.sh            3882 files, 0 violations
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools