### PR TITLE
feat(trusty-memory): kg_list_subjects exposes KG subject discovery over MCP (#4776)

### DIFF
--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -246,7 +246,7 @@ per-palace conversation store: turns are stored verbatim and bypass the
 `memory_remember` signal/noise and dedup gates.
 
 <!-- BEGIN GENERATED: mcp-tools -->
-The MCP server registers **45 tools**. Authoritative source: `trusty_memory::tools::tool_definitions` —
+The MCP server registers **46 tools**. Authoritative source: `trusty_memory::tools::tool_definitions` —
 this table is generated from it, not maintained by hand.
 
 | Tool | Arguments | Summary |
@@ -266,6 +266,7 @@ this table is generated from it, not maintained by hand.
 | `kg_assert` | `palace`, `subject`, `predicate`, `object`, `confidence?`, `provenance?` | Assert a fact in the temporal knowledge graph. |
 | `kg_bootstrap` | `palace?`, `project_path?` | Seed the knowledge graph from well-known project files (Cargo.toml, package.json, pyproject.toml, go.mod, CLAUDE.md, .git/config). |
 | `kg_gaps` | `palace?` | List knowledge gaps detected in the memory palace graph. |
+| `kg_list_subjects` | `palace`, `limit?`, `with_counts?` | List the subjects this palace's knowledge graph actually holds, alphabetically. |
 | `kg_query` | `palace`, `subject` | Query active knowledge-graph triples for a subject. |
 | `list_prompt_facts` | — | List every active prompt-fact triple (aliases, conventions, facts, shorthands) across all palaces. |
 | `memory_forget` | `palace`, `drawer_id` | Delete a drawer from a palace by its UUID. |

--- a/crates/trusty-memory/changelog.d/4776-kg-list-subjects-mcp-tool.md
+++ b/crates/trusty-memory/changelog.d/4776-kg-list-subjects-mcp-tool.md
@@ -1,0 +1,16 @@
+Added
+
+- **`kg_list_subjects` MCP tool — discover a palace's KG subjects instead of
+  guessing at them** (closes [#4776](https://github.com/bobmatnyc/trusty-tools/issues/4776)).
+  `kg_query` needs a subject the caller already knows, and a subject that does
+  not exist returns the same empty result as an empty graph, so a guess was
+  indistinguishable from a miss. The enumeration already existed at the HTTP
+  layer (`GET /api/v1/palaces/{id}/kg/subjects`); this exposes it over MCP.
+  Returns `{palace, subjects, with_counts, truncated}` — bare subject strings,
+  or `{subject, count}` pairs under `with_counts: true` — alphabetically, with
+  `limit` defaulting to 50 and clamped to `1..=200`. `truncated` is set when
+  the page filled to the effective limit, so a partial view is never mistaken
+  for the whole graph. The two page-size bounds moved to
+  `service::core_kg` so the tool and the HTTP routes read one definition; they
+  previously lived in `web::kg_routes`, which is not compiled without the
+  `axum-server` feature.

--- a/crates/trusty-memory/src/lib_tests.rs
+++ b/crates/trusty-memory/src/lib_tests.rs
@@ -98,8 +98,9 @@ async fn tools_list_returns_all_tools() {
     // issue #1722 adds `task_add`, `task_list`, `task_complete`;
     // ADR-0027 T6 (#4805) adds `room_list`, `room_create`, `room_rename`;
     // ADR-0027 T9 (#4809) adds `wing_list`, `wing_create`, `wing_rename`;
-    // #4906 adds `palace_reembed`; #5005 adds `palace_unalias`.
-    assert_eq!(tools.len(), 45);
+    // #4906 adds `palace_reembed`; #5005 adds `palace_unalias`;
+    // #4776 adds `kg_list_subjects`.
+    assert_eq!(tools.len(), 46);
 }
 
 #[tokio::test]

--- a/crates/trusty-memory/src/mcp_service.rs
+++ b/crates/trusty-memory/src/mcp_service.rs
@@ -87,8 +87,8 @@ mod tests {
         let tools = svc.tools();
         assert_eq!(
             tools.len(),
-            45,
-            "expected 45 memory tools (chat-session + dream-ops + palace_dream + the ADR-0027 room and wing surfaces + #4906 palace_reembed + #5005 palace_unalias), got {}",
+            46,
+            "expected 46 memory tools (chat-session + dream-ops + palace_dream + the ADR-0027 room and wing surfaces + #4906 palace_reembed + #5005 palace_unalias + #4776 kg_list_subjects), got {}",
             tools.len()
         );
     }
@@ -111,7 +111,7 @@ mod tests {
         //      so we must confirm dynamic dispatch resolves correctly here.
         let svc: Box<dyn ServiceDescriptor> = Box::new(MemoryMcpService);
         assert_eq!(svc.name(), "trusty-memory");
-        assert_eq!(svc.tools().len(), 45);
+        assert_eq!(svc.tools().len(), 46);
         assert_eq!(svc.scopes_for("palace_create"), vec!["memory.write"]);
         // #5005: the repair deletes vector keys, so it must classify as a write.
         assert_eq!(svc.scopes_for("palace_unalias"), vec!["memory.write"]);

--- a/crates/trusty-memory/src/openrpc.rs
+++ b/crates/trusty-memory/src/openrpc.rs
@@ -60,6 +60,8 @@ pub fn scopes_for_tool(name: &str) -> Vec<String> {
         | "palace_list"
         | "palace_info"
         | "kg_query"
+        // #4776: subject enumeration reads the KG and writes nothing.
+        | "kg_list_subjects"
         | "kg_gaps"
         | "list_prompt_facts"
         | "get_prompt_context"

--- a/crates/trusty-memory/src/service/core_kg.rs
+++ b/crates/trusty-memory/src/service/core_kg.rs
@@ -23,6 +23,28 @@ use super::types::{
 };
 use super::MemoryService;
 
+// ---------------------------------------------------------------------------
+// KG list bounds
+// ---------------------------------------------------------------------------
+//
+// #4776: these live on the service layer, not on either consumer, because both
+// readers of the subject list must agree on them — the HTTP explorer routes in
+// `web::kg_routes` (compiled only under `axum-server`) and the MCP
+// `kg_list_subjects` tool in `tools::kg_ops` (always compiled). Defining them
+// in `web` would put them on the far side of that feature gate from the tool.
+
+/// Default page size for KG subject listings when the caller omits `limit`.
+///
+/// Why: 50 is large enough to feel responsive in the KG Explorer and to answer
+/// "what is in this graph?" in one call, without dumping a full graph.
+pub(crate) const DEFAULT_KG_LIST_LIMIT: usize = 50;
+
+/// Hard ceiling on `limit` for KG subject listings.
+///
+/// Why: prevent a misconfigured client from asking the daemon to materialize
+/// thousands of rows in one go; matches the spec's max=200.
+pub(crate) const MAX_KG_LIST_LIMIT: usize = 200;
+
 impl MemoryService {
     // -----------------------------------------------------------------
     // Knowledge graph

--- a/crates/trusty-memory/src/tools/definitions.rs
+++ b/crates/trusty-memory/src/tools/definitions.rs
@@ -79,6 +79,9 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
     } else {
         vec!["palace", "subject"]
     };
+    // #4776: subject enumeration takes no argument of its own, so `palace` is
+    // the whole `required` list when no server default is configured.
+    let kg_list_subjects_required: Vec<&str> = if has_default { vec![] } else { vec!["palace"] };
     let memory_list_required: Vec<&str> = if has_default { vec![] } else { vec!["palace"] };
     let memory_forget_required: Vec<&str> = if has_default {
         vec!["drawer_id"]
@@ -243,6 +246,19 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
                         "subject": {"type": "string"}
                     },
                     "required": kg_query_required,
+                }
+            },
+            {
+                "name": "kg_list_subjects",
+                "description": "List the subjects this palace's knowledge graph actually holds, alphabetically. Call this BEFORE kg_query instead of guessing a subject: kg_query needs a subject you already know, and a subject that does not exist returns the same empty result as an empty graph, so a guess tells you nothing. Subjects are namespaced by kind — `tag:<name>`, `topic:<name>`, `drawer:<uuid>`, `room:<name>` — alongside bare entity names asserted by kg_assert. Returns {palace, subjects, with_counts, truncated}. `truncated: true` means the page filled to `limit` and more subjects may exist; raise `limit` to see them.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "palace":      {"type": "string", "description": "Palace ID (optional if server started with --palace)"},
+                        "limit":       {"type": "integer", "description": "Max subjects to return. Default 50, clamped to 1..=200.", "default": 50},
+                        "with_counts": {"type": "boolean", "description": "Return {subject, count} objects carrying each subject's active-triple count instead of bare subject strings. Use it to find the densest subjects to query first.", "default": false}
+                    },
+                    "required": kg_list_subjects_required,
                 }
             },
             {

--- a/crates/trusty-memory/src/tools/kg_ops.rs
+++ b/crates/trusty-memory/src/tools/kg_ops.rs
@@ -11,6 +11,7 @@
 //! Test: `dispatch_kg_assert_then_query`, `dispatch_discover_aliases_*`,
 //! `dispatch_kg_gaps_returns_cached` in `tools::tests`.
 
+use crate::service::core_kg::{DEFAULT_KG_LIST_LIMIT, MAX_KG_LIST_LIMIT};
 use crate::AppState;
 use anyhow::{anyhow, Context, Result};
 use serde_json::{json, Value};
@@ -261,6 +262,60 @@ pub(crate) async fn handle_kg_gaps(state: &AppState, args: Value) -> Result<Valu
         })
         .collect();
     Ok(json!({ "palace": palace, "gaps": payload }))
+}
+
+/// MCP `kg_list_subjects` tool — enumerate the subjects a palace's KG holds.
+///
+/// Why (#4776): `kg_query` requires a subject the caller must already know, and
+/// a guessed subject that misses returns the same empty result as a genuinely
+/// empty graph. The enumeration existed at the HTTP layer
+/// (`GET /api/v1/palaces/{id}/kg/subjects`) but had no MCP equivalent, so a
+/// model could only discover subjects by guessing.
+/// What: resolves the palace, clamps `limit` into `[1, MAX_KG_LIST_LIMIT]`
+/// (default [`DEFAULT_KG_LIST_LIMIT`]), and reads the alphabetically-ordered
+/// subject list — bare strings, or `{subject, count}` objects when
+/// `with_counts` is true. `truncated` reports that the page filled to the
+/// effective limit, which is the only signal the caller has that more subjects
+/// may exist beyond it.
+/// Test: `dispatch_kg_list_subjects_returns_distinct_subjects`,
+/// `dispatch_kg_list_subjects_with_counts_returns_pairs`.
+pub(crate) async fn handle_kg_list_subjects(state: &AppState, args: Value) -> Result<Value> {
+    let palace = resolve_palace(state, &args, "kg_list_subjects")?;
+    let handle = open_palace_handle(state, &palace)?;
+    let limit = args
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .map_or(DEFAULT_KG_LIST_LIMIT, |n| n as usize)
+        .clamp(1, MAX_KG_LIST_LIMIT);
+    let with_counts = args
+        .get("with_counts")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let subjects: Vec<Value> = if with_counts {
+        handle
+            .kg
+            .list_subjects_with_counts(limit)
+            .context("kg.list_subjects_with_counts")?
+            .into_iter()
+            .map(|(subject, count)| json!({ "subject": subject, "count": count }))
+            .collect()
+    } else {
+        handle
+            .kg
+            .list_subjects(limit)
+            .context("kg.list_subjects")?
+            .into_iter()
+            .map(Value::String)
+            .collect()
+    };
+
+    Ok(json!({
+        "palace": palace,
+        "truncated": subjects.len() == limit,
+        "with_counts": with_counts,
+        "subjects": subjects,
+    }))
 }
 
 pub(crate) async fn handle_get_prompt_context(state: &AppState, args: Value) -> Result<Value> {

--- a/crates/trusty-memory/src/tools/kg_ops.rs
+++ b/crates/trusty-memory/src/tools/kg_ops.rs
@@ -274,11 +274,15 @@ pub(crate) async fn handle_kg_gaps(state: &AppState, args: Value) -> Result<Valu
 /// What: resolves the palace, clamps `limit` into `[1, MAX_KG_LIST_LIMIT]`
 /// (default [`DEFAULT_KG_LIST_LIMIT`]), and reads the alphabetically-ordered
 /// subject list — bare strings, or `{subject, count}` objects when
-/// `with_counts` is true. `truncated` reports that the page filled to the
-/// effective limit, which is the only signal the caller has that more subjects
-/// may exist beyond it.
+/// `with_counts` is true. `truncated` cannot be `subjects.len() == limit`: a
+/// palace that holds exactly `limit` subjects would report `true` with no
+/// more subjects to page to. Instead the store is asked for one row past
+/// `limit` (#4810); if that extra row comes back it is dropped and
+/// `truncated` is `true`, otherwise every row returned is real and
+/// `truncated` is `false`.
 /// Test: `dispatch_kg_list_subjects_returns_distinct_subjects`,
-/// `dispatch_kg_list_subjects_with_counts_returns_pairs`.
+/// `dispatch_kg_list_subjects_with_counts_returns_pairs`,
+/// `dispatch_kg_list_subjects_exact_limit_is_not_truncated`.
 pub(crate) async fn handle_kg_list_subjects(state: &AppState, args: Value) -> Result<Value> {
     let palace = resolve_palace(state, &args, "kg_list_subjects")?;
     let handle = open_palace_handle(state, &palace)?;
@@ -291,28 +295,36 @@ pub(crate) async fn handle_kg_list_subjects(state: &AppState, args: Value) -> Re
         .get("with_counts")
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    // #4810: over-fetch by one so the extra row's presence — not a
+    // length-equals-limit coincidence — is the truncation signal.
+    let fetch_limit = limit + 1;
 
-    let subjects: Vec<Value> = if with_counts {
-        handle
+    let (subjects, truncated): (Vec<Value>, bool) = if with_counts {
+        let mut rows = handle
             .kg
-            .list_subjects_with_counts(limit)
-            .context("kg.list_subjects_with_counts")?
+            .list_subjects_with_counts(fetch_limit)
+            .context("kg.list_subjects_with_counts")?;
+        let truncated = rows.len() > limit;
+        rows.truncate(limit);
+        let subjects = rows
             .into_iter()
             .map(|(subject, count)| json!({ "subject": subject, "count": count }))
-            .collect()
+            .collect();
+        (subjects, truncated)
     } else {
-        handle
+        let mut rows = handle
             .kg
-            .list_subjects(limit)
-            .context("kg.list_subjects")?
-            .into_iter()
-            .map(Value::String)
-            .collect()
+            .list_subjects(fetch_limit)
+            .context("kg.list_subjects")?;
+        let truncated = rows.len() > limit;
+        rows.truncate(limit);
+        let subjects = rows.into_iter().map(Value::String).collect();
+        (subjects, truncated)
     };
 
     Ok(json!({
         "palace": palace,
-        "truncated": subjects.len() == limit,
+        "truncated": truncated,
         "with_counts": with_counts,
         "subjects": subjects,
     }))

--- a/crates/trusty-memory/src/tools/mod.rs
+++ b/crates/trusty-memory/src/tools/mod.rs
@@ -21,6 +21,7 @@
 //! - `room_rename(palace, room, new_label)`         -> renamed room
 //! - `kg_assert(palace, subject, predicate, object, confidence?, provenance?)` -> ()
 //! - `kg_query(palace, subject)`                    -> Vec<Triple>
+//! - `kg_list_subjects(palace, limit?, with_counts?)` -> subjects (#4776)
 //! - `wing_list(palace)`                            -> Vec<WingSummary>
 //! - `wing_create(palace, label)`                   -> wing_id (idempotent)
 //! - `wing_rename(palace, wing, new_label)`         -> WingSummary
@@ -68,8 +69,8 @@ use chat_ops::{
 use dream_ops::{handle_dream_consolidate_room, handle_palace_dream};
 use kg_ops::{
     handle_add_alias, handle_discover_aliases, handle_get_prompt_context, handle_kg_assert,
-    handle_kg_bootstrap, handle_kg_gaps, handle_kg_query, handle_list_prompt_facts,
-    handle_remove_prompt_fact, handle_upgrade_tool,
+    handle_kg_bootstrap, handle_kg_gaps, handle_kg_list_subjects, handle_kg_query,
+    handle_list_prompt_facts, handle_remove_prompt_fact, handle_upgrade_tool,
 };
 use memory_ops::{
     handle_memory_forget, handle_memory_list, handle_memory_note, handle_memory_recall,
@@ -110,6 +111,9 @@ pub async fn dispatch_tool(state: &AppState, name: &str, args: Value) -> Result<
         "list_prompt_facts" => handle_list_prompt_facts(state, args).await,
         "remove_prompt_fact" => handle_remove_prompt_fact(state, args).await,
         "kg_query" => handle_kg_query(state, args).await,
+        // #4776: subject discovery — the read that makes `kg_query` usable
+        // without already knowing a subject.
+        "kg_list_subjects" => handle_kg_list_subjects(state, args).await,
         "memory_list" => handle_memory_list(state, args).await,
         "memory_forget" => handle_memory_forget(state, args).await,
         "palace_info" => handle_palace_info(state, args).await,

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -643,6 +643,93 @@ async fn dispatch_kg_list_subjects_with_counts_returns_pairs() {
     );
 }
 
+/// Why: #4810 — `truncated = subjects.len() == limit` cannot distinguish "the
+/// page filled and more subjects exist" from "the palace holds exactly
+/// `limit` subjects in total"; a caller that trusted the old flag would raise
+/// `limit` and get back an identical page for nothing.
+/// What: asserts three subjects, then discovers the palace's real total
+/// subject count with a wide-open `kg_list_subjects` call — `palace_create`
+/// auto-bootstraps its own `project_subject` triple (see
+/// `bootstrap::bootstrap_palace`), so the total is not simply the three
+/// asserted names. Requests `limit: <that total>` and confirms `truncated`
+/// is `false` — the case the length-equality check got wrong. Then requests
+/// `limit: 1` over the same palace and confirms `truncated` still comes back
+/// `true` there.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_kg_list_subjects_exact_limit_is_not_truncated() {
+    let (state, _tmp) = test_state();
+    let _ = dispatch_tool(&state, "palace_create", json!({"name": "exactlimit"}))
+        .await
+        .expect("palace_create");
+
+    for subject in ["alpha", "beta", "gamma"] {
+        let _ = dispatch_tool(
+            &state,
+            "kg_assert",
+            json!({
+                "palace": "exactlimit",
+                "subject": subject,
+                "predicate": "works_at",
+                "object": "Acme",
+            }),
+        )
+        .await
+        .expect("kg_assert");
+    }
+
+    let wide_open = dispatch_tool(
+        &state,
+        "kg_list_subjects",
+        json!({"palace": "exactlimit", "limit": 200}),
+    )
+    .await
+    .expect("kg_list_subjects wide-open baseline");
+    let total = wide_open["subjects"]
+        .as_array()
+        .expect("subjects array")
+        .len();
+    assert!(
+        total >= 3,
+        "the three asserted subjects should all be present: total={total}"
+    );
+    assert_eq!(
+        wide_open["truncated"], false,
+        "a limit well above the real total is never truncated"
+    );
+
+    let listed = dispatch_tool(
+        &state,
+        "kg_list_subjects",
+        json!({"palace": "exactlimit", "limit": total}),
+    )
+    .await
+    .expect("kg_list_subjects");
+
+    let subjects = listed["subjects"].as_array().expect("subjects array");
+    assert_eq!(
+        subjects.len(),
+        total,
+        "every subject should come back: {subjects:?}"
+    );
+    assert_eq!(
+        listed["truncated"], false,
+        "exactly `limit` subjects total is not truncation"
+    );
+
+    let capped = dispatch_tool(
+        &state,
+        "kg_list_subjects",
+        json!({"palace": "exactlimit", "limit": 1}),
+    )
+    .await
+    .expect("kg_list_subjects");
+    assert_eq!(
+        capped["truncated"], true,
+        "limit below the subject count should still report truncated"
+    );
+}
+
 /// Why: Issue #53 — verify the MCP `kg_gaps` tool returns whatever was
 /// last cached on the registry. Two cases: empty cache returns an empty
 /// array, and a seeded cache returns the cached entries verbatim.

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -194,6 +194,8 @@ fn tool_definitions_lists_all_tools() {
         "palace_unalias",
         "kg_assert",
         "kg_query",
+        // #4776: subject enumeration over MCP.
+        "kg_list_subjects",
         "memory_recall_all",
         "kg_gaps",
         "add_alias",
@@ -532,6 +534,113 @@ async fn dispatch_kg_assert_then_query() {
     assert_eq!(triples.len(), 1);
     assert_eq!(triples[0]["object"], "Acme");
     assert_eq!(triples[0]["predicate"], "works_at");
+}
+
+/// Why: #4776 — `kg_list_subjects` is the discovery read that makes `kg_query`
+/// usable without already knowing a subject, so the contract that matters is
+/// that every asserted subject comes back, once, in alphabetical order.
+/// What: asserts two triples under distinct subjects, dispatches
+/// `kg_list_subjects`, and checks the envelope plus the ordering.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_kg_list_subjects_returns_distinct_subjects() {
+    let (state, _tmp) = test_state();
+    let _ = dispatch_tool(&state, "palace_create", json!({"name": "subjects"}))
+        .await
+        .expect("palace_create");
+
+    for (subject, object) in [("zeta", "Acme"), ("alpha", "Globex")] {
+        let _ = dispatch_tool(
+            &state,
+            "kg_assert",
+            json!({
+                "palace": "subjects",
+                "subject": subject,
+                "predicate": "works_at",
+                "object": object,
+            }),
+        )
+        .await
+        .expect("kg_assert");
+    }
+
+    let listed = dispatch_tool(&state, "kg_list_subjects", json!({"palace": "subjects"}))
+        .await
+        .expect("kg_list_subjects");
+
+    assert_eq!(listed["palace"], "subjects");
+    assert_eq!(listed["with_counts"], false);
+    assert_eq!(listed["truncated"], false);
+    let subjects: Vec<&str> = listed["subjects"]
+        .as_array()
+        .expect("subjects array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert!(
+        subjects.contains(&"alpha") && subjects.contains(&"zeta"),
+        "both asserted subjects should be listed: {subjects:?}"
+    );
+    let mut sorted = subjects.clone();
+    sorted.sort_unstable();
+    assert_eq!(subjects, sorted, "subjects should be alphabetical");
+}
+
+/// Why: #4776 — `with_counts` is what lets a caller pick the densest subject to
+/// query first, so the count has to be a real per-subject active-triple count,
+/// not a placeholder.
+/// What: asserts two triples on one subject and one on another, then checks the
+/// `{subject, count}` pairs the tool returns.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_kg_list_subjects_with_counts_returns_pairs() {
+    let (state, _tmp) = test_state();
+    let _ = dispatch_tool(&state, "palace_create", json!({"name": "counts"}))
+        .await
+        .expect("palace_create");
+
+    for (subject, predicate) in [
+        ("alpha", "works_at"),
+        ("alpha", "lives_in"),
+        ("beta", "owns"),
+    ] {
+        let _ = dispatch_tool(
+            &state,
+            "kg_assert",
+            json!({
+                "palace": "counts",
+                "subject": subject,
+                "predicate": predicate,
+                "object": "Acme",
+            }),
+        )
+        .await
+        .expect("kg_assert");
+    }
+
+    let listed = dispatch_tool(
+        &state,
+        "kg_list_subjects",
+        json!({"palace": "counts", "with_counts": true}),
+    )
+    .await
+    .expect("kg_list_subjects");
+
+    assert_eq!(listed["with_counts"], true);
+    let pairs: Vec<(&str, u64)> = listed["subjects"]
+        .as_array()
+        .expect("subjects array")
+        .iter()
+        .filter_map(|v| Some((v["subject"].as_str()?, v["count"].as_u64()?)))
+        .collect();
+    assert!(
+        pairs.contains(&("alpha", 2)),
+        "alpha should carry both of its triples: {pairs:?}"
+    );
+    assert!(
+        pairs.contains(&("beta", 1)),
+        "beta should carry its single triple: {pairs:?}"
+    );
 }
 
 /// Why: Issue #53 — verify the MCP `kg_gaps` tool returns whatever was

--- a/crates/trusty-memory/src/web/kg_routes.rs
+++ b/crates/trusty-memory/src/web/kg_routes.rs
@@ -19,6 +19,10 @@ use serde_json::{json, Value};
 use trusty_common::memory_core::store::kg::{ExpandDirection, Triple};
 
 use crate::AppState;
+// #4776: the page-size bounds moved to the service layer so the MCP
+// `kg_list_subjects` tool reads the same two literals these routes do; `tools`
+// is compiled without the `axum-server` feature that gates this module.
+use crate::service::core_kg::{DEFAULT_KG_LIST_LIMIT, MAX_KG_LIST_LIMIT};
 
 use super::error::ApiError;
 
@@ -76,18 +80,6 @@ pub(super) async fn kg_assert(
 // ---------------------------------------------------------------------------
 // KG list helpers
 // ---------------------------------------------------------------------------
-
-/// Default page size for KG explorer list endpoints when caller omits `limit`.
-///
-/// Why: 50 is large enough to feel responsive in the SPA without dumping a
-/// full graph in one request; matches the default the spec calls for.
-const DEFAULT_KG_LIST_LIMIT: usize = 50;
-
-/// Hard ceiling on `limit` for KG explorer list endpoints.
-///
-/// Why: prevent a misconfigured client from asking the daemon to materialize
-/// thousands of rows in one go; matches the spec's max=200.
-const MAX_KG_LIST_LIMIT: usize = 200;
 
 fn default_kg_list_limit() -> usize {
     DEFAULT_KG_LIST_LIMIT


### PR DESCRIPTION
**What** — a new `kg_list_subjects` MCP tool. The capability already existed at the store, service and HTTP layers; this wires it through MCP, which was the only surface missing it. Closes #4776.

**Why it matters** — `kg_query` needs a subject you already know, and a subject that does not exist returns the same empty result as an empty graph. Without enumeration a caller cannot discover what to ask for. This is precondition 2 of the three ADR-0038 names before a KG recall lane is viable; precondition 1 (#4810) merged as `b5f968ca3`.

**Scope note** — no `trusty-common` changes, so this stays inside one crate. `DEFAULT_KG_LIST_LIMIT`/`MAX_KG_LIST_LIMIT` moved from `web/kg_routes.rs` to `service/core_kg.rs` because `web/` is behind `#[cfg(feature = "axum-server")]` while `tools/` is not, and `trusty-agents` takes `trusty-memory` with `default-features = false`. Verified with `cargo check -p trusty-memory --no-default-features --lib`.

**Second commit** — `54652e54` fixes a `truncated` flag that could not distinguish "the page filled and more exist" from "the palace holds exactly `limit` subjects". Now over-fetches by one. Its regression test was proven to fail against `65dcd674` by reverting the fix, observing `assertion left == right failed: exactly limit subjects total is not truncation`, and restoring byte-identically.

**Test rung 6** — MCP tool schemas are rung 6 per CLAUDE.md, which requires direct API evidence, not just crate tests. A binary built from this branch was driven over real MCP stdio against an isolated daemon (port 7099, scratch data dir, real palaces untouched):
- `tools/list` returns 46 tools including `kg_list_subjects` with `palace`/`limit`/`with_counts`
- no limit → `["apple","mango","qa-scratch-4776","zebra"]`, alphabetical, `truncated: false`
- `with_counts: true` → `[{"count":1,"subject":"apple"},{"count":2,"subject":"mango"},…]`
- `limit: 1` → one row, `truncated: true`
- `limit: 999` → clamped, no error
- unknown palace → clean JSON-RPC error, no panic
Scratch palace deleted, daemon stopped, real data confirmed untouched.

**Gates — all 11 check scripts plus the cargo chain:**
```
cargo fmt --check / check / clippy -D warnings          clean
SKIP_UI_BUILD=1 cargo test -p trusty-memory            632 passed, 0 failed, 4 ignored
check_capabilities         tm-capabilities: up to date (7 generated files)
check_generated_regions    OK (5 file(s) claimed by a generated_docs test)
check_generation_artifacts 17 stylesheets + 1266 prose files, 0 leaked
check_buildrs_sync         in sync across 4 + 3 crates
check_agent_assets         30 byte-parity files match; 4 pinned deviations match upstream
check_doc_numbers          114 docs / 108 claims, 0 violations
check_public_docs          27 pages / 5 sections, all inside the boundary
check_line_cap             3884 files, 0 violations
check_test_pointers        23501 citations, 0 dangling
check_changelog_fragment   present and valid
check_sld                  57 spec docs + code, 0 errors
```

**Known leftover, deliberate** — `crates/trusty-agents/src/api/server/agent_kg.rs:80` has a prose comment pointing at `kg_routes::MAX_KG_LIST_LIMIT`, now one module stale. Fixing it would pull a second crate in and require a `trusty-agents` changelog fragment for a comment change. Left for a follow-up.

**Surfaced, not fixed here** — the smoke run found that an unknown palace returns JSON-RPC `-32603` INTERNAL_ERROR and leaks the daemon's absolute filesystem path. Pre-existing, shared by every KG tool via `resolve_palace`/`open_palace_handle`. Filed as [#5381](https://github.com/bobmatnyc/trusty-tools/issues/5381).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools