### PR TITLE
fix(trusty-memory): kg_query distinguishes subject_not_found from graph_empty

### DIFF
--- a/crates/trusty-memory/changelog.d/4775-kg-query-honest-miss.md
+++ b/crates/trusty-memory/changelog.d/4775-kg-query-honest-miss.md
@@ -1,0 +1,17 @@
+Fixed
+
+- **`kg_query` no longer reports an empty graph when only the subject is
+  missing (issue #4775).** Any subject with no active triples got the hint
+  "Knowledge graph is empty. Run kg_bootstrap …", including on a graph holding
+  thousands of triples — the handler never consulted a whole-graph total, so it
+  asserted something it could disprove, and sent callers to re-seed an
+  already-seeded graph. The response now always carries `kg_triple_count` (the
+  whole-graph active total, on hits and misses alike), and a miss adds a
+  `graph_state` of `subject_not_found` or `graph_empty` with the matching hint —
+  the `subject_not_found` hint names `kg_list_subjects` so the recovery step is
+  a tool call rather than a second guess. A hit carries neither field, so their
+  absence means the subject was found. The MCP tool schema is unchanged.
+- The test that pinned the old behavior (`kg_query_emits_hint_when_palace_empty`)
+  asserted the falsehood and passed: `palace_create` auto-bootstraps at least two
+  triples, so the graph it called empty never was. It is replaced by one test per
+  outcome, each establishing its own precondition.

--- a/crates/trusty-memory/src/bootstrap/mod.rs
+++ b/crates/trusty-memory/src/bootstrap/mod.rs
@@ -22,8 +22,8 @@ mod types;
 
 pub use scan::scan_project;
 pub use types::{
-    is_kg_empty_for_subject, result_to_json, BootstrapResult, BootstrapTriple, ScannedFile,
-    KG_EMPTY_HINT,
+    result_to_json, BootstrapResult, BootstrapTriple, KgMiss, ScannedFile, KG_EMPTY_HINT,
+    KG_SUBJECT_NOT_FOUND_HINT,
 };
 
 use anyhow::{Context, Result};

--- a/crates/trusty-memory/src/bootstrap/types.rs
+++ b/crates/trusty-memory/src/bootstrap/types.rs
@@ -4,14 +4,13 @@
 //! point. Keeping them in a separate file prevents circular dependencies and
 //! keeps each module under the 500-SLOC cap.
 //! What: `BootstrapTriple`, `ScannedFile`, `BootstrapResult`, plus the
-//! `KG_EMPTY_HINT` constant and the `is_kg_empty_for_subject` / `result_to_json`
-//! helpers that operate directly on these types.
+//! `KG_EMPTY_HINT` / `KG_SUBJECT_NOT_FOUND_HINT` constants, the `KgMiss`
+//! classifier behind `kg_query`'s `graph_state` field, and `result_to_json`.
 //! Test: types are covered by the scanner and integration tests in sibling
 //! modules.
 
 use anyhow::{anyhow, Result};
 use serde::Serialize;
-use trusty_common::memory_core::store::kg::Triple;
 
 /// A single bootstrap discovery before it becomes a Triple.
 ///
@@ -61,32 +60,88 @@ pub struct BootstrapResult {
     pub scanned_files: Vec<ScannedFile>,
 }
 
-/// Hint string returned by `kg_query` when the palace KG is empty.
+/// Hint string returned by `kg_query` when the palace KG holds no triples.
 ///
 /// Why: Issue #60 — when a user calls `kg_query` against a brand-new palace
 /// they get an empty triples array with no indication that `kg_bootstrap` /
 /// `kg_assert` even exist. A short hint embedded in the response solves
 /// this with one line of code at the call site.
 /// What: Static string, kept in this module so tests can pin it.
-/// Test: `kg_query_emits_hint_when_palace_empty` in `tools.rs`.
+/// Test: `kg_query_reports_graph_empty_when_graph_has_no_triples`.
 pub const KG_EMPTY_HINT: &str =
     "Knowledge graph is empty. Run kg_bootstrap to seed it from project files, \
      or use kg_assert to add triples manually.";
 
-/// Convenience: count active triples across an entire palace.
+/// Hint string returned by `kg_query` when the graph has triples but not for
+/// the queried subject.
 ///
-/// Why: `kg_query` is per-subject, so to determine "is the KG empty?" the
-/// `kg_query` handler needs a separate broader check. Centralising the
-/// emptiness check here keeps the hint logic in one place and lets future
-/// changes (e.g. counting across closets) live alongside their consumer.
-/// What: Returns `Ok(true)` iff the palace has zero triples for the queried
-/// subject AND the broader "is_anything_asserted" check is empty. Practical
-/// emptiness: we treat the palace as empty if the queried subject returned
-/// no triples — this is the user's signal that something is wrong, even if
-/// other subjects have data.
-/// Test: covered indirectly through `kg_query_emits_hint_when_palace_empty`.
-pub fn is_kg_empty_for_subject(triples: &[Triple]) -> bool {
-    triples.is_empty()
+/// Why (#4775): the caller guessed a subject the graph does not hold. Telling
+/// them to seed the graph is wrong — it is already seeded — and it sends them
+/// to `kg_assert` when what they need is the list of subjects that do exist.
+/// What: names `kg_list_subjects` (shipped in #4776) so the recovery step is a
+/// tool call, not a second guess.
+/// Test: `kg_query_reports_subject_not_found_when_graph_has_other_subjects`.
+pub const KG_SUBJECT_NOT_FOUND_HINT: &str =
+    "No active triples for this subject. The knowledge graph is not empty — \
+     call kg_list_subjects to see which subjects it holds.";
+
+/// Which of the two distinct "no triples came back" outcomes a `kg_query` hit.
+///
+/// Why (#4775): both outcomes returned the same "Knowledge graph is empty"
+/// hint, and for the common case — a graph with facts, queried for a subject
+/// it does not hold — that hint states something the handler can prove false.
+/// A caller that believes it wastes a `kg_bootstrap` on an already-seeded
+/// graph instead of listing the subjects that are there.
+/// What: the discriminator behind `kg_query`'s `graph_state` response field.
+/// [`Self::classify`] decides which one applies; [`Self::wire_value`] and
+/// [`Self::hint`] are the two strings that reach the caller. Marked
+/// `#[non_exhaustive]` so a future third outcome is not a breaking change.
+/// Test: `kg_miss_classify_distinguishes_empty_graph_from_missing_subject`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum KgMiss {
+    /// The graph holds active triples, just none for the queried subject.
+    SubjectNotFound,
+    /// The graph holds no active triples at all.
+    GraphEmpty,
+}
+
+impl KgMiss {
+    /// Classify a `kg_query` result; `None` means the subject matched.
+    ///
+    /// Why (#4775): emptiness is a whole-graph property, so it cannot be read
+    /// off the per-subject result alone — that conflation is the defect. Both
+    /// counts are required, and taking them as parameters keeps the decision
+    /// pure and directly testable without a live palace.
+    /// What: `None` when `subject_triples > 0`. Otherwise `GraphEmpty` iff the
+    /// whole graph reports zero active triples, else `SubjectNotFound`.
+    /// Test: `kg_miss_classify_distinguishes_empty_graph_from_missing_subject`.
+    pub fn classify(subject_triples: usize, total_active_triples: usize) -> Option<Self> {
+        if subject_triples > 0 {
+            return None;
+        }
+        if total_active_triples == 0 {
+            Some(Self::GraphEmpty)
+        } else {
+            Some(Self::SubjectNotFound)
+        }
+    }
+
+    /// The string emitted as `kg_query`'s `graph_state` field.
+    pub fn wire_value(self) -> &'static str {
+        match self {
+            Self::SubjectNotFound => "subject_not_found",
+            Self::GraphEmpty => "graph_empty",
+        }
+    }
+
+    /// The recovery hint that matches this outcome.
+    pub fn hint(self) -> &'static str {
+        match self {
+            Self::SubjectNotFound => KG_SUBJECT_NOT_FOUND_HINT,
+            Self::GraphEmpty => KG_EMPTY_HINT,
+        }
+    }
 }
 
 /// Helper: bubble up the bootstrap result as the MCP JSON envelope expects.

--- a/crates/trusty-memory/src/tools/kg_ops.rs
+++ b/crates/trusty-memory/src/tools/kg_ops.rs
@@ -196,6 +196,21 @@ pub(crate) async fn handle_remove_prompt_fact(state: &AppState, args: Value) -> 
     }
 }
 
+/// MCP `kg_query` tool — active triples for one subject, plus an honest
+/// account of what a miss means.
+///
+/// Why (#4775): an empty result had exactly one explanation attached — "the
+/// knowledge graph is empty" — even when the graph held thousands of triples
+/// and the caller had simply named a subject it does not carry. The handler
+/// can prove that claim false, so it now says which of the two happened.
+/// What: always returns `kg_triple_count`, the whole-graph active total, on
+/// hits and misses alike. On a miss it adds `graph_state` —
+/// `"subject_not_found"` or `"graph_empty"` — and the matching `hint`; a hit
+/// carries neither, so their absence means the subject was found. See
+/// [`crate::bootstrap::KgMiss`] for the classification.
+/// Test: `kg_query_reports_subject_not_found_when_graph_has_other_subjects`,
+/// `kg_query_reports_graph_empty_when_graph_has_no_triples`,
+/// `dispatch_kg_assert_then_query`.
 pub(crate) async fn handle_kg_query(state: &AppState, args: Value) -> Result<Value> {
     let palace = resolve_palace(state, &args, "kg_query")?;
     let subject = args
@@ -222,14 +237,17 @@ pub(crate) async fn handle_kg_query(state: &AppState, args: Value) -> Result<Val
             })
         })
         .collect();
-    // Issue #60: surface a hint when the requested subject has no
-    // active triples so the model knows `kg_bootstrap` and
-    // `kg_assert` exist. Empty payload is the only signal we have
-    // at the per-subject query layer; that's the user-visible
-    // "nothing here" case the hint is for.
-    let mut response = json!({ "subject": subject, "triples": payload });
-    if crate::bootstrap::is_kg_empty_for_subject(&triples) {
-        response["hint"] = Value::String(crate::bootstrap::KG_EMPTY_HINT.to_string());
+    // #4775: read the whole-graph total so a miss can name which miss it is
+    // instead of asserting emptiness the handler can disprove.
+    let total_active = handle.kg.count_active_triples();
+    let mut response = json!({
+        "subject": subject,
+        "triples": payload,
+        "kg_triple_count": total_active,
+    });
+    if let Some(miss) = crate::bootstrap::KgMiss::classify(triples.len(), total_active) {
+        response["graph_state"] = Value::String(miss.wire_value().to_string());
+        response["hint"] = Value::String(miss.hint().to_string());
     }
     Ok(response)
 }

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -1128,18 +1128,44 @@ async fn palace_create_auto_seeds_temporal_metadata() {
         queried.get("hint").is_none(),
         "hint should be absent when triples exist"
     );
+    // #4775: `graph_state` is the miss discriminator, so its absence is what
+    // marks a hit; `kg_triple_count` is present either way.
+    assert!(
+        queried.get("graph_state").is_none(),
+        "graph_state should be absent when triples exist"
+    );
+    assert!(
+        queried["kg_triple_count"].as_u64().unwrap_or(0) >= 2,
+        "kg_triple_count must be present on a hit; got {}",
+        queried["kg_triple_count"],
+    );
 }
 
-/// Why (issue #60): `kg_query` against a subject with no triples must
-/// surface a `hint` field pointing the user at `kg_bootstrap` /
-/// `kg_assert`. Without the hint, brand-new palaces returned empty
-/// arrays with no breadcrumb back to the seeding tools.
+/// Why (#4775): this is the case the old single-hint behavior got wrong.
+/// `palace_create` auto-bootstraps at least `created_at` + `bootstrapped_at`,
+/// so the graph is provably non-empty; querying a subject it does not hold
+/// used to answer "Knowledge graph is empty" anyway. The replaced test
+/// asserted that falsehood and passed. The `kg_list_subjects` call here is
+/// what makes the non-emptiness a fact of the test rather than an assumption.
 #[tokio::test]
-async fn kg_query_emits_hint_when_palace_empty() {
+async fn kg_query_reports_subject_not_found_when_graph_has_other_subjects() {
     let (state, _tmp) = test_state();
     let _ = dispatch_tool(&state, "palace_create", json!({"name": "hinted"}))
         .await
         .expect("palace_create");
+
+    // Establish the precondition: the graph holds subjects.
+    let subjects = dispatch_tool(&state, "kg_list_subjects", json!({"palace": "hinted"}))
+        .await
+        .expect("kg_list_subjects");
+    assert!(
+        !subjects["subjects"]
+            .as_array()
+            .expect("subjects")
+            .is_empty(),
+        "auto-bootstrap should have seeded at least one subject",
+    );
+
     // Query a subject that auto-bootstrap did NOT seed.
     let queried = dispatch_tool(
         &state,
@@ -1149,9 +1175,73 @@ async fn kg_query_emits_hint_when_palace_empty() {
     .await
     .expect("kg_query");
     assert_eq!(queried["triples"].as_array().unwrap().len(), 0);
+    assert_eq!(queried["graph_state"], "subject_not_found");
+    assert!(
+        queried["kg_triple_count"].as_u64().unwrap_or(0) >= 2,
+        "whole-graph count must reflect the bootstrapped triples; got {}",
+        queried["kg_triple_count"],
+    );
+    let hint = queried["hint"].as_str().expect("hint field present");
+    assert!(
+        hint.contains("kg_list_subjects"),
+        "miss hint must name kg_list_subjects; got {hint:?}",
+    );
+    assert!(
+        !hint.contains("Knowledge graph is empty"),
+        "must not claim emptiness for a non-empty graph; got {hint:?}",
+    );
+}
+
+/// Why (#4775): the `graph_empty` branch is the one the old hint was written
+/// for, and it must still fire — but only when the graph really holds nothing.
+/// The palace is created through the registry directly because
+/// `palace_create` auto-bootstraps, and there is no way to ask it not to.
+#[tokio::test]
+async fn kg_query_reports_graph_empty_when_graph_has_no_triples() {
+    use trusty_common::memory_core::palace::Palace;
+
+    let (state, _tmp) = test_state();
+    let palace = Palace {
+        id: PalaceId::new("barren"),
+        name: "barren".to_string(),
+        description: None,
+        created_at: chrono::Utc::now(),
+        data_dir: state.data_root.join("barren"),
+    };
+    let _ = state
+        .registry
+        .create_palace(&state.data_root, palace)
+        .expect("create_palace");
+
+    let queried = dispatch_tool(
+        &state,
+        "kg_query",
+        json!({"palace": "barren", "subject": "anything"}),
+    )
+    .await
+    .expect("kg_query");
+    assert_eq!(queried["triples"].as_array().unwrap().len(), 0);
+    assert_eq!(queried["kg_triple_count"], 0);
+    assert_eq!(queried["graph_state"], "graph_empty");
     let hint = queried["hint"].as_str().expect("hint field present");
     assert!(hint.contains("kg_bootstrap"));
     assert!(hint.contains("kg_assert"));
+}
+
+/// Why (#4775): the classification is pure, so pin all four combinations of
+/// (subject has triples, graph has triples) without a live palace.
+#[test]
+fn kg_miss_classify_distinguishes_empty_graph_from_missing_subject() {
+    use crate::bootstrap::KgMiss;
+
+    assert_eq!(KgMiss::classify(0, 0), Some(KgMiss::GraphEmpty));
+    assert_eq!(KgMiss::classify(0, 7), Some(KgMiss::SubjectNotFound));
+    assert_eq!(KgMiss::classify(3, 7), None);
+    // A subject with triples in a graph that reports zero is contradictory;
+    // a hit still wins, because the triples are in hand and the count is not.
+    assert_eq!(KgMiss::classify(3, 0), None);
+    assert_eq!(KgMiss::GraphEmpty.wire_value(), "graph_empty");
+    assert_eq!(KgMiss::SubjectNotFound.wire_value(), "subject_not_found");
 }
 
 /// Why (issue #60): `kg_bootstrap` against the live workspace root must


### PR DESCRIPTION
Closes #4775

ADR-0038 precondition 2 of 3, second half. Sequenced behind #4776 so the miss hint can name
`kg_list_subjects` by tool name.

`kg_query` conflated two different misses: `bootstrap/types.rs` computed per-subject emptiness and
`kg_ops.rs` reported it as a whole-graph claim, so an unknown subject produced the hint
"Knowledge graph is empty" — something the code could prove false. The response now carries
`kg_triple_count` unconditionally and, on a miss, a `graph_state` of `subject_not_found` or
`graph_empty`. On a hit `graph_state` is absent, so its absence means the subject was found.

`is_kg_empty_for_subject` is REMOVED rather than kept as a shim: it is a public export of
`bootstrap`, and its documented contract ("zero triples for the queried subject AND the broader
is_anything_asserted check is empty") was false. Nothing else in the workspace called it.
🔴 This is a breaking public-API change. Under Cargo's 0.x rule it forces the MINOR position at the
next trusty-memory release; `preflight-publish.sh` CHECK 5 is the enforcing gate. No version file is
touched in this PR.

The existing test `kg_query_emits_hint_when_palace_empty` enshrined the bug — it asserted the
empty-graph hint fires against a palace that `palace_create` auto-bootstraps to >= 2 triples, and it
passed. Proved lying before the fix by adding one assertion:

    assertion `left == right` failed: hint claims the graph is empty, but the graph reports these subjects
      left: 1
     right: 0

It is replaced by three tests. The `graph_empty` case constructs its palace via
`state.registry.create_palace` directly, because `palace_create` auto-bootstraps and offers no opt-out.

## Test ladder

Rung 3 — localized behavior inside one crate, response body only, no MCP tool schema touched
(`definitions.rs` is not in the diff).

    SKIP_UI_BUILD=1 cargo fmt --check
    SKIP_UI_BUILD=1 cargo check -p trusty-memory
    SKIP_UI_BUILD=1 cargo clippy -p trusty-memory --all-targets -- -D warnings
    SKIP_UI_BUILD=1 cargo test -p trusty-memory

All pass: 634 passed / 0 failed / 4 ignored, plus 26 integration binaries. Re-run green after
rebasing onto 90ce9a2d. `check_line_cap.sh` 0 violations (`kg_ops.rs` 436 → 442 SLOC),
`check_sld.sh` and `check_changelog_fragment.sh` OK.

Changelog fragment: `crates/trusty-memory/changelog.d/4775-kg-query-honest-miss.md`.

## Surfaced, not fixed

`count_active_triples()` (`crates/trusty-common/src/memory_core/store/kg_redb/read_ops.rs:183-205`)
returns 0 when its redb read fails, so a storage failure still yields `graph_empty`. The method
already lives in trusty-common, so any fix is a public-signature change there with dependent-crate
gates — rung 4+. Filed as #5384.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

