### PR TITLE
fix(trusty-review): mark refuted findings in inline PR comments (#5312)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11763,7 +11763,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.14.0"
+version     = "0.14.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/5312-refuted-inline-comments.md
+++ b/crates/trusty-review/changelog.d/5312-refuted-inline-comments.md
@@ -1,0 +1,7 @@
+Fixed
+
+- Inline PR comments now lead with a verification caveat when the finding's own
+  `verified` outcome owes one, so a refuted finding no longer reads exactly like
+  a surviving one (#5312). A clean `refuted` says it was disproved and is not a
+  merge blocker; `error_refuted` / `truncation_refuted` say the verifier was
+  never reached and the claim is unverified, not disproved.

--- a/crates/trusty-review/src/integrations/github/inline.rs
+++ b/crates/trusty-review/src/integrations/github/inline.rs
@@ -20,16 +20,29 @@
 //!     comments to post plus the findings that fell back to the summary — surfaced
 //!     verbatim in dry-run so the MCP response shows exactly what *would* be posted.
 //!   * [`build_inline_plan`] is the pure mapping from findings → plan.
-//!   * [`render_finding_comment`] renders one finding's inline-comment markdown.
+//!   * [`render_finding_comment`] renders one finding's inline-comment markdown,
+//!     led by a verification caveat when the finding's own `verified` outcome
+//!     owes the reader one (#5312) — a refuted claim must not read like a
+//!     surviving one.
 //!
 //! Test: `inline_tests.rs` (sibling) — covers diff-index construction, the
 //! finding→comment mapping, and off-diff fallback.
 
 use std::collections::HashSet;
 
-use crate::models::{Effort, Finding};
+use crate::models::{Effort, Finding, VerifyOutcome};
 
 // ─── Tuning constants ─────────────────────────────────────────────────────────
+
+/// Blockquote lead-in for the per-finding verification caveat (#5312).
+///
+/// Why: the summary banner already opens with `> **Verification notice:**`
+/// (`pipeline::verification_notice`); using the same blockquote shape inline
+/// means a reader meets one recognisable marker wherever the pipeline qualifies
+/// a claim, and a distinct suffix keeps the two greppable apart.
+/// What: prefixes the caveat returned by [`VerifyOutcome::reader_caveat`].
+/// Test: `render_marks_refuted_finding`.
+const VERIFICATION_CAVEAT_PREFIX: &str = "> **Verification:**";
 
 /// Confidence below which a finding is hedged rather than asserted (#1416).
 ///
@@ -338,12 +351,29 @@ pub fn build_inline_plan(findings: &[Finding], commentable: &CommentableLines) -
 /// line when the finding carries a consequence, then appends either a fenced
 /// ```suggestion block (when [`suggestion_replacement`] accepts the finding's
 /// `suggested_replacement`) or a `_Fix:_ <prose>` line.  A malformed or non-code
-/// replacement degrades to prose, never a broken suggestion block.
+/// replacement degrades to prose, never a broken suggestion block.  When the
+/// finding's own `verified` outcome owes the reader a caveat
+/// ([`VerifyOutcome::reader_caveat`]) that caveat is prepended as a blockquote
+/// ABOVE the claim, so a refuted or unverified finding can never read as a
+/// surviving one (#5312).
 /// Test: `render_finding_comment_includes_kind_and_fix`,
 /// `render_emits_suggestion_block`, `render_falls_back_to_prose_fix`,
-/// `render_includes_consequence`, `low_confidence_finding_is_hedged`.
+/// `render_includes_consequence`, `low_confidence_finding_is_hedged`,
+/// `render_marks_refuted_finding`, `render_marks_error_refuted_as_unverified`,
+/// `render_leaves_confirmed_and_unjudged_findings_unmarked`.
 pub fn render_finding_comment(finding: &Finding) -> String {
     let mut out = String::with_capacity(256);
+
+    // #5312: a finding the pipeline does not stand behind must say so before it
+    // says anything else — keyed on the finding's own recorded outcome, never on
+    // a per-surface list of outcomes someone remembered to enumerate here.
+    if let Some(caveat) = finding
+        .verified
+        .as_ref()
+        .and_then(VerifyOutcome::reader_caveat)
+    {
+        out.push_str(&format!("{VERIFICATION_CAVEAT_PREFIX} {caveat}\n\n"));
+    }
 
     // Lead line: kind + description, hedged for low confidence (#1416).
     let hedged = if finding.confidence < UNCERTAINTY_THRESHOLD {

--- a/crates/trusty-review/src/integrations/github/inline_tests.rs
+++ b/crates/trusty-review/src/integrations/github/inline_tests.rs
@@ -8,7 +8,7 @@
 //! Test: this module.
 
 use super::*;
-use crate::models::{Effort, Finding};
+use crate::models::{Effort, Finding, VerifyOutcome};
 
 /// A small two-file unified diff with added, context, and removed lines.
 fn sample_diff() -> &'static str {
@@ -392,4 +392,86 @@ fn suppressed_nits_line_singular() {
 fn max_inline_nits_is_five() {
     // Lock the documented cap so a silent change is caught.
     assert_eq!(MAX_INLINE_NITS, 5);
+}
+
+// ─── Verification caveat on the rendered comment (#5312) ──────────────────────
+
+/// A verifier-refuted finding renders with a caveat above the claim (#5312).
+///
+/// Why: before this, a finding carrying `verified: "refuted"` rendered
+/// byte-identically to a surviving one, so a reader of the PR could not tell the
+/// pipeline had disproved it.
+/// What: renders a `Refuted` finding, asserts the body opens with the
+/// verification blockquote and names the refutation, and asserts the same
+/// finding reaching `build_inline_plan` carries the marker into the plan.
+/// Test: this test itself.
+#[test]
+fn render_marks_refuted_finding() {
+    let mut f = finding_at("src/db.rs", Some(11));
+    f.verified = Some(VerifyOutcome::Refuted);
+
+    let body = render_finding_comment(&f);
+    assert!(
+        body.starts_with("> **Verification:**"),
+        "the caveat must lead the comment, not trail it: {body}"
+    );
+    assert!(
+        body.contains("REFUTED"),
+        "a refuted claim must say so: {body}"
+    );
+
+    let c = CommentableLines::from_unified_diff(sample_diff());
+    let plan = build_inline_plan(std::slice::from_ref(&f), &c);
+    assert_eq!(plan.comments.len(), 1, "still posted, but marked");
+    assert!(
+        plan.comments[0].body.contains("REFUTED"),
+        "the plan must carry the marked body: {}",
+        plan.comments[0].body
+    );
+}
+
+/// A verifier-failure finding reads as unverified, never as disproved (#5312).
+///
+/// Why: `ErrorRefuted` means the verifier was never reached (#726, #1876) and
+/// the verdict deliberately keeps the escalation, so calling the claim refuted
+/// inline would contradict the verdict the same review reports.
+/// What: renders an `ErrorRefuted` finding and asserts the caveat says
+/// UNVERIFIED and names the error class rather than claiming a disproof.
+/// Test: this test itself.
+#[test]
+fn render_marks_error_refuted_as_unverified() {
+    let mut f = finding_at("src/db.rs", Some(11));
+    f.verified = Some(VerifyOutcome::ErrorRefuted {
+        error_class: "RateLimited".to_string(),
+    });
+    let body = render_finding_comment(&f);
+    assert!(body.contains("UNVERIFIED"), "{body}");
+    assert!(body.contains("RateLimited"), "{body}");
+    assert!(
+        !body.contains("REFUTED it"),
+        "an unreachable verifier disproved nothing: {body}"
+    );
+}
+
+/// Confirmed and unjudged findings render exactly as before (#5312).
+///
+/// Why: the caveat is owed only where the pipeline does not stand behind the
+/// claim; adding it anywhere else would put a hedge on every comment.
+/// What: renders a `Confirmed` finding and a finding with no outcome, asserting
+/// neither carries the verification blockquote.
+/// Test: this test itself.
+#[test]
+fn render_leaves_confirmed_and_unjudged_findings_unmarked() {
+    let unjudged = finding_at("src/db.rs", Some(11));
+    assert!(
+        !render_finding_comment(&unjudged).contains("**Verification:**"),
+        "no outcome recorded → no caveat"
+    );
+
+    let mut confirmed = finding_at("src/db.rs", Some(11));
+    confirmed.verified = Some(VerifyOutcome::Confirmed);
+    assert!(
+        !render_finding_comment(&confirmed).contains("**Verification:**"),
+        "a confirmed finding stands unqualified"
+    );
 }

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -206,6 +206,54 @@ pub enum VerifyOutcome {
     },
 }
 
+impl VerifyOutcome {
+    /// The caveat a reader is owed when a finding carrying this outcome is
+    /// shown to them, or `None` when the finding stands unqualified (#5312).
+    ///
+    /// Why: every surface that renders a finding to a human — the summary
+    /// banner (#5316), the inline PR comment (#5312) — needs the same answer to
+    /// "does the pipeline stand behind this claim?", and each surface that
+    /// answered it locally got it wrong once. #4212 keyed the earlier fix on the
+    /// claim's *subject*, which covered only the subjects already burned; the
+    /// recurrence on the inline surface is what that costs. Keying on the
+    /// finding's own recorded epistemic outcome is subject-agnostic, and living
+    /// on the outcome itself means a new renderer asks the finding rather than
+    /// reimplementing the judgment.
+    /// What: exhaustive match — deliberately no `_` arm, so a new
+    /// `VerifyOutcome` variant cannot render as an unqualified claim by
+    /// default; the compiler forces the decision here. `Refuted` is the only
+    /// disproof; the two error variants mean "unable to verify" (#726, #1876)
+    /// and say so rather than claiming the finding is wrong. `Confirmed` and
+    /// `Skipped` return `None` — `Skipped` means the finding never cleared the
+    /// candidate-confidence floor, the same state as the `verified: None`
+    /// majority, and marking it would mark nearly every finding.
+    /// Test: `caveat_refuted_is_a_disproof`,
+    /// `caveat_error_refuted_is_unable_to_verify`,
+    /// `caveat_confirmed_and_skipped_are_unqualified`.
+    pub(crate) fn reader_caveat(&self) -> Option<String> {
+        match self {
+            Self::Confirmed | Self::Skipped => None,
+            Self::Refuted => Some(
+                "the verifier examined this claim and REFUTED it — it does not support the \
+                 verdict and is not a merge blocker."
+                    .to_string(),
+            ),
+            Self::ErrorRefuted { error_class } => Some(format!(
+                "the verifier could not be reached ({error_class}), so this claim is \
+                 UNVERIFIED — it was not disproved, and it was not confirmed either."
+            )),
+            Self::TruncationRefuted => Some(
+                "the verifier's response was truncated, so this claim is UNVERIFIED — it was \
+                 not disproved, and it was not confirmed either."
+                    .to_string(),
+            ),
+            Self::Unverifiable { reason } => {
+                Some(format!("this claim was never verified — {reason}"))
+            }
+        }
+    }
+}
+
 // ─── Finding category ──────────────────────────────────────────────────────────
 
 /// The axis a finding speaks to: code correctness vs. intent/method conformance.

--- a/crates/trusty-review/src/models/tests.rs
+++ b/crates/trusty-review/src/models/tests.rs
@@ -379,3 +379,82 @@ fn verify_outcome_serde() {
         matches!(back, VerifyOutcome::ErrorRefuted { error_class } if error_class == "ModelNotFound")
     );
 }
+
+/// A clean `Refuted` outcome reads as a disproof, not as "unchecked" (#5312).
+///
+/// Why: the two states carry opposite weight for a reader — a refuted claim does
+/// not support the verdict, an unverified one may still be real — so the caveat
+/// must not blur them.
+/// What: asserts the `Refuted` caveat says REFUTED and calls out that it is not a
+/// merge blocker.
+/// Test: this test itself.
+#[test]
+fn caveat_refuted_is_a_disproof() {
+    let caveat = VerifyOutcome::Refuted
+        .reader_caveat()
+        .expect("owed a caveat");
+    assert!(
+        caveat.contains("REFUTED"),
+        "caveat must name the disproof: {caveat}"
+    );
+    assert!(
+        caveat.contains("not a merge blocker"),
+        "caveat must say it does not block: {caveat}"
+    );
+}
+
+/// The two verifier-failure outcomes read as "unable to verify" (#726, #1876).
+///
+/// Why: `ErrorRefuted` / `TruncationRefuted` mean the verifier was never reached;
+/// `rederive_verdict` path (c) deliberately preserves the escalation for them, so
+/// telling the reader the claim was disproved would contradict the verdict the
+/// same review reports.
+/// What: asserts both caveats say UNVERIFIED, and that the error class reaches
+/// the reader.
+/// Test: this test itself.
+#[test]
+fn caveat_error_refuted_is_unable_to_verify() {
+    let caveat = VerifyOutcome::ErrorRefuted {
+        error_class: "RateLimited".to_string(),
+    }
+    .reader_caveat()
+    .expect("owed a caveat");
+    assert!(
+        caveat.contains("UNVERIFIED"),
+        "must not claim disproof: {caveat}"
+    );
+    assert!(
+        caveat.contains("RateLimited"),
+        "must name the error class: {caveat}"
+    );
+
+    let truncated = VerifyOutcome::TruncationRefuted
+        .reader_caveat()
+        .expect("owed a caveat");
+    assert!(
+        truncated.contains("UNVERIFIED"),
+        "must not claim disproof: {truncated}"
+    );
+}
+
+/// `Confirmed` and `Skipped` are owed no caveat (#5312).
+///
+/// Why: a confirmed finding stands on its own, and `Skipped` means the finding
+/// never cleared the candidate-confidence floor — the same state as the
+/// `verified: None` majority, so marking it would mark nearly every finding.
+/// What: asserts both return `None`, and that `Unverifiable` carries its reason.
+/// Test: this test itself.
+#[test]
+fn caveat_confirmed_and_skipped_are_unqualified() {
+    assert!(VerifyOutcome::Confirmed.reader_caveat().is_none());
+    assert!(VerifyOutcome::Skipped.reader_caveat().is_none());
+    let unverifiable = VerifyOutcome::Unverifiable {
+        reason: "no registry lookup performed".to_string(),
+    }
+    .reader_caveat()
+    .expect("owed a caveat");
+    assert!(
+        unverifiable.contains("no registry lookup performed"),
+        "must carry the recorded reason: {unverifiable}"
+    );
+}

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -1805,6 +1805,58 @@ diff --git a/src/db.rs b/src/db.rs
     assert_eq!(result.inline_comments[0].line, 2);
 }
 
+/// A refuted finding cannot reach the PR as an unmarked inline comment (#5312).
+///
+/// Why: verification runs before `attach_inline_comments` on both pipeline paths
+/// (`runner.rs` `maybe_verify` → `attach_inline_comments`, and the same order in
+/// `runner_mapreduce.rs`), so the `verified` outcome IS on the finding by the
+/// time the inline plan is built — it was simply never read. A reader of the PR
+/// saw a claim the verifier had disproved rendered exactly like a surviving one.
+/// What: runs the real runner-side glue over two on-diff findings — one refuted,
+/// one unjudged — and asserts the refuted one's inline body carries the
+/// verification caveat while the unjudged one does not.
+/// Test: this test itself (no network).
+#[test]
+fn attach_inline_comments_marks_refuted_finding() {
+    use crate::models::{Effort, Finding, VerifyOutcome};
+    use crate::pipeline::runner_helpers::attach_inline_comments;
+
+    let raw_diff = "\
+diff --git a/src/db.rs b/src/db.rs
+--- a/src/db.rs
++++ b/src/db.rs
+@@ -1,1 +1,3 @@
+ fn a() {}
++fn b() {}
++fn c() {}
+";
+    let mut result = crate::models::ReviewResult::new("o", "r", 1, "t", "u");
+    let mut refuted = Finding::new("src/db.rs", "bug", "desc", "fix", 0.1, Effort::High);
+    refuted.line = Some(2);
+    refuted.verified = Some(VerifyOutcome::Refuted);
+    let mut surviving = Finding::new("src/db.rs", "bug2", "desc2", "fix2", 0.9, Effort::Medium);
+    surviving.line = Some(3);
+    result.findings = vec![refuted, surviving];
+
+    attach_inline_comments(&mut result, raw_diff);
+
+    assert_eq!(
+        result.inline_comments.len(),
+        2,
+        "both findings anchor inline"
+    );
+    assert!(
+        result.inline_comments[0].body.contains("REFUTED"),
+        "a refuted finding must be marked inline: {}",
+        result.inline_comments[0].body
+    );
+    assert!(
+        !result.inline_comments[1].body.contains("Verification:"),
+        "a surviving finding must stay unqualified: {}",
+        result.inline_comments[1].body
+    );
+}
+
 /// `build_author_rationale` returns None when neither input is present (#1618).
 ///
 /// Why: with no caller context the verifier prompt must be unchanged.


### PR DESCRIPTION
Closes #5312

## What changed

`render_finding_comment` (`crates/trusty-review/src/integrations/github/inline.rs`) now leads with the caveat the finding's own `verified` outcome owes the reader. Before, a finding carrying `verified: "refuted"` rendered byte-identically to a surviving one, so a PR reader had no way to tell the pipeline had disproved it.

The judgment itself lives on the outcome: `VerifyOutcome::reader_caveat` (`crates/trusty-review/src/models/mod.rs`). A clean `Refuted` says it was REFUTED and is not a merge blocker. `ErrorRefuted` / `TruncationRefuted` say the verifier was never reached and the claim is UNVERIFIED, not disproved — calling those refuted would contradict `rederive_verdict` path (c), which deliberately preserves the escalation (#726, #1876). `Unverifiable` carries its recorded reason. `Confirmed` and `Skipped` render exactly as before.

Refuted findings are marked, not dropped — the same choice #5316's summary banner and spec REV-606 make. Dropping one from the inline set would move it, unmarked, into the summary's off-diff findings list.

## Ordering: this surface did not have the write-before-verify bug

The summary/grade fix (#5316) had to work around `review_body` being written before verification ran. The inline path does not: `maybe_verify` runs at `runner.rs:634` and `attach_inline_comments` at `:727`, and the map-reduce path has the same order (`runner_mapreduce.rs:321` then `:353`). The `verified` outcome was on the finding the whole time. Nothing read it.

## Subject-keyed vs epistemic-keyed

Epistemic-keyed. The fix reads the finding's own recorded outcome, not a list of kinds, subjects, or known surfaces. #4212 keyed this class of fix on the claim's subject (registry vocabulary), which covered only the subjects already burned — this recurrence on a new surface is what that cost.

`reader_caveat` is an exhaustive match with no `_` arm. A new `VerifyOutcome` variant cannot silently render as an unqualified claim; the compiler forces the decision at that one site.

## Fail-open check

No fail-open branch exists here and none was added. `render_finding_comment`, `build_inline_plan`, and `attach_inline_comments` are all infallible — no `Result`, no `unwrap_or`, no error downgraded to a default while state advances. `reader_caveat` is total. There is therefore no error-arm regression test to write; the two verifier-*failure* outcomes are data reaching the renderer, not a failure branch inside it, and both are covered by `render_marks_error_refuted_as_unverified` and `caveat_error_refuted_is_unable_to_verify`.

## Test ladder: rung 3

Localized behavior inside one crate. No public API change — `reader_caveat` is `pub(crate)`, and `render_finding_comment`'s signature is unchanged — so no rung-4 escalation. `trusty-analyze` (the only dependent, behind its `review` feature) touches `trusty_review::mcp` only.

```
cargo fmt --check                                       # EXIT=0
cargo check -p trusty-review                            # EXIT=0
cargo clippy -p trusty-review --all-targets -- -D warnings   # EXIT=0
cargo test -p trusty-review                             # EXIT=0
```

`cargo test -p trusty-review`: `test result: ok. 1611 passed; 0 failed; 5 ignored` (lib), plus 9 further binaries all `0 failed`. The 5 ignored are pre-existing.

### Regression test, proven against the pre-fix tree

Restoring `origin/main`'s `inline.rs` under the new tests, with everything else in place:

```
running 4 tests
test integrations::github::inline::tests::render_leaves_confirmed_and_unjudged_findings_unmarked ... ok
test integrations::github::inline::tests::render_marks_error_refuted_as_unverified ... FAILED
test integrations::github::inline::tests::render_marks_refuted_finding ... FAILED
test pipeline::runner::tests::attach_inline_comments_marks_refuted_finding ... FAILED

---- integrations::github::inline::tests::render_marks_refuted_finding stdout ----
panicked at crates/trusty-review/src/integrations/github/inline_tests.rs:414:5:
the caveat must lead the comment, not trail it: **security** — SQL injection via string interpolation

_Fix:_ Use a parameterised query

---- pipeline::runner::tests::attach_inline_comments_marks_refuted_finding stdout ----
panicked at crates/trusty-review/src/pipeline/runner_tests.rs:1848:5:
a refuted finding must be marked inline: **bug** — This may be an issue: desc

_Fix:_ fix

test result: FAILED. 1 passed; 3 failed; 0 ignored; 0 measured; 1612 filtered out
```

The panic output is the bug: a refuted finding rendered as an ordinary inline comment. With the fix restored:

```
running 8 tests
test models::tests::caveat_error_refuted_is_unable_to_verify ... ok
test models::tests::caveat_confirmed_and_skipped_are_unqualified ... ok
test models::tests::caveat_refuted_is_a_disproof ... ok
test integrations::github::inline::tests::render_marks_error_refuted_as_unverified ... ok
test integrations::github::inline::tests::render_leaves_confirmed_and_unjudged_findings_unmarked ... ok
test integrations::github::inline::tests::render_marks_refuted_finding ... ok
test pipeline::runner::tests::attach_inline_comments_marks_refuted_finding ... ok
test result: ok. 8 passed; 0 failed
```

`render_leaves_confirmed_and_unjudged_findings_unmarked` passes on both trees by design — it pins the no-regression half.

## Repo gate scripts — every one dispositioned

| Script | Disposition |
|---|---|
| `check_sld.sh` | ran, exit 0 |
| `check_line_cap.sh` | ran, exit 0 |
| `check_changelog_fragment.sh` | ran, exit 0 (fragment `crates/trusty-review/changelog.d/5312-refuted-inline-comments.md`) |
| `check_test_pointers.sh` | ran, exit 0 |
| `check_doc_numbers.sh` | ran, exit 0 |
| `check_generated_regions.sh` | ran, exit 0 |
| `check_generation_artifacts.sh` | ran, exit 0 |
| `check_public_docs.sh` | ran, exit 0 |
| `check_capabilities.sh` | ran, exit 0 |
| `check_buildrs_sync.sh` | ran, exit 0 |
| `check_agent_assets.sh` | ran, exit 0 |
| `check-pr-version-bump.sh` (#4421) | ran; failed, then fixed — see below |
| `check_semver.sh` | not run — release-time gate by policy, and no public API changed (`reader_caveat` is `pub(crate)`) |
| `check_line_cap_selftest.sh`, `check_public_docs_selftest.sh`, `check_scan_floor_selftest.sh`, `check_semver_selftest.sh` | not applicable — they self-test gate scripts, and this diff touches no `scripts/` file |

## Version bump to 0.14.1

`trusty-review` 0.14.0 is published on crates.io, so `check-pr-version-bump.sh` fails any `src/**` change made under it — merging one turns main's version-parity workflow red. Second commit bumps `crates/trusty-review/Cargo.toml` to 0.14.1 (patch: behavior fix, no API change) and refreshes `Cargo.lock`; the guard then exits 0.

Coordination note: #5323 is in flight on the same crate. If it also bumps, the two conflict on that one line and whichever merges second rebases onto the other's version.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
