### PR TITLE
fix(trusty-common): withhold the index id when the create was not confirmed (#5091)

### DIFF
--- a/crates/trusty-common/changelog.d/5091-pin-only-confirmed-index.md
+++ b/crates/trusty-common/changelog.d/5091-pin-only-confirmed-index.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `search_index::ensure_project_indexed` and `ensure_project_indexed_with` no
+  longer return an index id when the daemon never confirmed the index
+  ([#5091](https://github.com/bobmatnyc/trusty-tools/issues/5091)). A refused
+  `POST /indexes`, a transport error, an undiscoverable daemon, or the #4255
+  test-harness suppression all yield `None` and a `warn` line, so a caller
+  cannot pin an index that does not exist. `ensure_project_indexed_reporting`
+  is unchanged and still carries the derived id in every case, beside the
+  `IndexRegistration` that says what the daemon actually did. Errors are still
+  never propagated — a search outage never blocks a session launch or a task
+  run.

--- a/crates/trusty-common/src/search_index.rs
+++ b/crates/trusty-common/src/search_index.rs
@@ -17,10 +17,12 @@
 //! the daemon is discoverable — best-effort registers the index (`POST
 //! /indexes`, ~1s cap) then best-effort triggers a freshness-gated reindex
 //! (`POST /indexes/{id}/reindex`, ~2s cap, skipped when the index already holds
-//! chunks indexed within the last hour). Every step is fail-open: failures are
-//! logged at warn/debug and swallowed, never propagated, so the caller (a
+//! chunks indexed within the last hour). Every step is fail-open in the sense
+//! that failures are logged at warn/debug and never propagated, so the caller (a
 //! session launch or a task run) is never blocked or aborted by an
-//! unreachable/slow search daemon. The blocking HTTP calls run on dedicated OS
+//! unreachable/slow search daemon. What it is NOT (#5091) is fail-open in its
+//! RETURN: the id comes back only when the daemon confirmed the index, so a
+//! failed create cannot advance a caller's pin. The blocking HTTP calls run on dedicated OS
 //! threads so the function is safe to call from inside a tokio runtime.
 //!
 //! Mid-task incremental re-indexing: [`ensure_project_indexed`] runs once, at
@@ -53,7 +55,8 @@
 //! now takes `allow_sensitive_path` as an explicit parameter so each caller
 //! states its own intent instead of inheriting trusty-code's opt-in for free.
 //!
-//! Test: `ensure_project_indexed_returns_derived_id_when_daemon_down`,
+//! Test: `create_rejected_by_the_daemon_withholds_the_pinnable_id`,
+//! `ensure_project_indexed_withholds_id_when_nothing_was_registered`,
 //! `ensure_project_indexed_none_for_root`, the `index_is_fresh_*` predicate
 //! tests, the `index_files_inner_*` / `relative_index_path_*` /
 //! `index_file_request_body_*` tests, and the incremental-hardening tests
@@ -95,12 +98,12 @@ use std::path::Path;
 /// when the id is non-empty AND the trusty-search daemon address is discoverable
 /// — POSTs `{id, root_path, allow_sensitive_path}` to `/indexes` then
 /// best-effort triggers a reindex (skipping it when the index is already
-/// fresh; see [`best_effort_trigger_reindex`]). ALWAYS returns the derived id
-/// (`None` only when derivation yields an empty string) so the caller can
-/// still pin the id even if the daemon is unreachable; every failed/skipped
-/// step is logged at warn/debug and never propagates (the caller must still
-/// make progress).
-/// Test: `ensure_project_indexed_returns_derived_id_when_daemon_down`,
+/// fresh; see [`best_effort_trigger_reindex`]). Returns the id ONLY when that
+/// POST came back 2xx — see [`pinnable_index_id`] for why an unconfirmed create
+/// must yield `None`. Errors still never propagate: a refusing or absent daemon
+/// is logged at warn and the caller makes progress unindexed.
+/// Test: `create_rejected_by_the_daemon_withholds_the_pinnable_id`,
+/// `ensure_project_indexed_withholds_id_when_nothing_was_registered`,
 /// `ensure_project_indexed_none_for_root`,
 /// `ensure_project_indexed_sends_allow_sensitive_path_through_to_create_body`.
 pub fn ensure_project_indexed(project_root: &Path, allow_sensitive_path: bool) -> Option<String> {
@@ -189,8 +192,11 @@ impl IndexOptions {
 /// logging `worktree index registered` for the second case — announcing a
 /// success it never observed, in the one code path whose stated purpose is to
 /// make outcomes distinguishable. Reporting the registration outcome beside the
-/// id fixes that without touching the fail-open contract: the id is still
-/// always returned and nothing here ever propagates an error.
+/// id fixes that without making the call fallible: nothing here ever propagates
+/// an error. #5091 then wired this enum into the return rather than leaving it
+/// advisory: the id-only entry points hand back an id only when it says
+/// `Confirmed` (see [`pinnable_index_id`]), while this report still carries the
+/// derived id in every case.
 /// What: the four terminal states of the `POST /indexes` attempt. Only
 /// `Confirmed` means the index is known to exist daemon-side.
 /// Test: `reporting_says_skipped_under_test_harness`,
@@ -234,17 +240,53 @@ pub struct EnsureIndexReport {
 /// can never drift between the session-launch, task-start, and
 /// worktree-creation callers.
 /// What: identical to [`ensure_project_indexed`] in every respect except that
-/// `opts.skip_vector` is threaded into the `POST /indexes` body. Same
-/// fail-open contract: every failed step is logged and swallowed, and the
-/// derived id is always returned so the caller can pin it even when the daemon
-/// is unreachable. A caller that needs to know whether the daemon actually
-/// confirmed the index — rather than pin an id — must use
-/// [`ensure_project_indexed_reporting`] instead.
-/// Test: `ensure_project_indexed_returns_derived_id_when_daemon_down`,
+/// `opts.skip_vector` is threaded into the `POST /indexes` body. Failures are
+/// still logged and swallowed rather than propagated, and the returned id is
+/// still gated on a confirmed registration ([`pinnable_index_id`]). A caller
+/// that needs the DERIVED id whether or not the daemon confirmed it — to name
+/// the index in a log line, or to GC it — must use
+/// [`ensure_project_indexed_reporting`], where the adjacent `registration`
+/// field makes ignoring the failure a visible choice.
+/// Test: `create_rejected_by_the_daemon_withholds_the_pinnable_id`,
 /// `ensure_project_indexed_none_for_root`,
 /// `create_index_request_body_sets_skip_vector`.
 pub fn ensure_project_indexed_with(project_root: &Path, opts: IndexOptions) -> Option<String> {
-    ensure_project_indexed_reporting(project_root, opts).index_id
+    pinnable_index_id(ensure_project_indexed_reporting(project_root, opts))
+}
+
+/// The id a caller may PIN, or `None` when nothing observed the index (#5091).
+///
+/// Why: `POST /indexes` can fail — a non-2xx, a transport error, a daemon that
+/// is not running — and the id-only entry points used to hand the derived id
+/// back anyway. Session launch writes that id into `.mcp.json` as
+/// `trusty-search serve --index <id>`, so a create that silently failed left the
+/// session pinned to an index the daemon has never heard of: every `search`
+/// answers `404 unknown index` for the life of the session, while
+/// `search_health` and the `search` doctor probe both stay green because they
+/// ask about the daemon, not the pin (#5045 measured 4 of 75 live worktrees
+/// actually indexed). Withholding the id leaves the pin unadvanced, which is the
+/// one outcome that cannot lie: an unpinned stub is visibly unpinned, and
+/// `tm doctor`'s `search_index_pin` check says so.
+/// What: returns `report.index_id` for [`IndexRegistration::Confirmed`] — the
+/// only variant that means the daemon acknowledged the index, and since `POST
+/// /indexes` is find-or-create it covers "already existed" too. Every other
+/// variant, including the #4255 test-harness suppression (which sends nothing,
+/// so it registers nothing), logs at warn and returns `None`.
+/// Test: `create_rejected_by_the_daemon_withholds_the_pinnable_id`,
+/// `ensure_project_indexed_withholds_id_when_nothing_was_registered`.
+fn pinnable_index_id(report: EnsureIndexReport) -> Option<String> {
+    if report.registration == IndexRegistration::Confirmed {
+        return report.index_id;
+    }
+    if let Some(id) = &report.index_id {
+        // #5091: an unconfirmed create must not advance the caller's pin.
+        tracing::warn!(
+            "trusty-search index '{id}' was NOT confirmed ({:?}); withholding it so the \
+             caller cannot pin an index that may not exist",
+            report.registration
+        );
+    }
+    None
 }
 
 /// [`ensure_project_indexed_with`], but reporting what the daemon actually did
@@ -289,9 +331,10 @@ pub fn ensure_project_indexed_reporting(
 
     // Discover the running daemon's address (issue #2033: via the shared
     // `resolve_daemon_base_url` helper — never a hardcoded port). Absent /
-    // unreadable file ⇒ daemon not started: skip registration (best-effort) but
-    // still return the id so the caller can pin it — the daemon will create the
-    // index on first reindex.
+    // unreadable file ⇒ daemon not started, so nothing is sent and nothing is
+    // registered. #5091: the earlier claim here — that the daemon would create
+    // the index on first reindex — was false; no later step retries, which is
+    // why `DaemonUnreachable` is not a pinnable outcome.
     let registration = match crate::resolve_daemon_base_url("trusty-search") {
         Some(base) => {
             let outcome = best_effort_create_index(&base, &index_id, &root, opts);
@@ -300,8 +343,8 @@ pub fn ensure_project_indexed_reporting(
         }
         None => {
             tracing::warn!(
-                "trusty-search daemon address not found; pinning index '{index_id}' \
-                 without pre-registering it (it will be created on first reindex)"
+                "trusty-search daemon address not found; index '{index_id}' was NOT \
+                 registered and nothing will retry it"
             );
             IndexRegistration::DaemonUnreachable
         }

--- a/crates/trusty-common/src/search_index_tests.rs
+++ b/crates/trusty-common/src/search_index_tests.rs
@@ -29,16 +29,24 @@ fn scratch_dir(tag: &str) -> PathBuf {
     p
 }
 
+/// Derivation still walks to the git root, and nothing registered means nothing
+/// pinnable (#1373, #5091).
+///
+/// Why: this test used to be called
+/// `ensure_project_indexed_returns_derived_id_when_daemon_down` and asserted the
+/// id came back regardless. It was wrong twice over. The contract it pinned is
+/// the #5091 defect — an id handed to a caller that will pin it, for an index
+/// nothing created. And its name never matched what it ran: under `cargo test`
+/// the #4255 harness guard short-circuits before daemon discovery, so the
+/// daemon-down branch it claims to exercise is never reached (the branch that
+/// IS reached, `SkippedUnderTest`, sends nothing either — same conclusion).
+/// What: keeps the derivation assertion — the id is the git-root basename even
+/// from a nested directory, read off the reporting entry point which still
+/// carries it — and adds the #5091 one: the id-only entry point withholds it,
+/// because no registration was observed.
+/// Test: this test.
 #[test]
-fn ensure_project_indexed_returns_derived_id_when_daemon_down() {
-    // Why (#1373): the helper must derive the project's index id (git-root
-    // basename, via `derive_index_id`) AND stay graceful when the
-    // trusty-search daemon is unreachable — it still returns the id so the
-    // caller can pin it. We force the daemon-down path by pointing the data
-    // dir at an empty temp dir so `resolve_daemon_base_url` finds no address
-    // file (and thus issues no HTTP POST). `ENV_LOCK` serialises the
-    // process-global override against sibling env-mutating tests (the same
-    // guard `daemon_addr`/`data_dir` tests use).
+fn ensure_project_indexed_withholds_id_when_nothing_was_registered() {
     let _guard = crate::data_dir::ENV_LOCK
         .lock()
         .unwrap_or_else(|e| e.into_inner());
@@ -55,7 +63,11 @@ fn ensure_project_indexed_returns_derived_id_when_daemon_down() {
     let nested = project.join("crates/inner");
     fs::create_dir_all(&nested).unwrap();
 
-    let id = ensure_project_indexed(&nested, true);
+    let report = ensure_project_indexed_reporting(
+        &nested,
+        IndexOptions::default().with_allow_sensitive_path(true),
+    );
+    let pinnable = ensure_project_indexed(&nested, true);
     let expected = crate::derive_index_id(&project);
 
     unsafe {
@@ -64,7 +76,20 @@ fn ensure_project_indexed_returns_derived_id_when_daemon_down() {
     let _ = fs::remove_dir_all(&project);
     let _ = fs::remove_dir_all(&data_dir);
 
-    assert_eq!(id, Some(expected), "id is the git-root basename");
+    assert_eq!(
+        report.index_id,
+        Some(expected),
+        "id is the git-root basename"
+    );
+    assert_ne!(
+        report.registration,
+        IndexRegistration::Confirmed,
+        "no daemon was contacted, so nothing can be confirmed"
+    );
+    assert_eq!(
+        pinnable, None,
+        "an unregistered index must not come back as a pinnable id (#5091)"
+    );
 }
 
 /// A test process gets `SkippedUnderTest`, never a claim of registration
@@ -78,10 +103,17 @@ fn ensure_project_indexed_returns_derived_id_when_daemon_down() {
 /// What: calls the reporting entry point on a real git-rooted temp project
 /// under the default (test-harness-detected) environment and asserts the id
 /// still comes back while `registration` is `SkippedUnderTest` — not
-/// `Confirmed`.
+/// `Confirmed`. Holds `ENV_LOCK` for the same reason
+/// `running_under_test_harness_is_true_in_this_test_binary` does: the verdict
+/// reads `ALLOW_PRODUCTION_ENV`, which sibling tests set and clear, so without
+/// the lock this asserts on whatever another thread happened to leave in the
+/// process env.
 /// Test: this test.
 #[test]
 fn reporting_says_skipped_under_test_harness() {
+    let _guard = crate::data_dir::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     let project = scratch_dir("report-skip");
     fs::create_dir_all(project.join(".git")).unwrap();
 
@@ -759,8 +791,9 @@ fn daemon_was_contacted_during(body: impl FnOnce()) -> bool {
 /// only prior guard) is switched off on that path, so nothing else stands
 /// between the fixture and the operator's registry.
 /// What: with a discoverable stand-in daemon, calls `ensure_project_indexed`
-/// on a temp fixture root; asserts no connection was made and the id still
-/// came back (the fail-open contract is unchanged).
+/// on a temp fixture root; asserts no connection was made, and — since a
+/// suppressed write registers nothing — that no pinnable id came back either
+/// (#5091; before that fix this arm asserted the opposite).
 /// Test: this test.
 #[test]
 fn ensure_project_indexed_never_writes_to_a_daemon_under_test() {
@@ -778,9 +811,9 @@ fn ensure_project_indexed_never_writes_to_a_daemon_under_test() {
          process — that is the issue #4255 registry leak"
     );
     assert!(
-        id.is_some(),
-        "the derived index id must still be returned; the guard suppresses the \
-         daemon write, not the caller's contract"
+        id.is_none(),
+        "the guard suppressed the write, so no index was registered — handing \
+         back a pinnable id anyway is the #5091 fail-open shape"
     );
     let _ = fs::remove_dir_all(&root);
 }
@@ -852,5 +885,155 @@ fn index_options_builders_match_field_construction() {
             allow_sensitive_path: true,
             skip_vector: true,
         }
+    );
+}
+
+/// Stand up a one-shot fake trusty-search daemon answering with `status_line`.
+///
+/// Why: the #5091 error arm is only reachable against a daemon that is
+/// REACHABLE and REFUSES — pointing discovery at a dead port lands in
+/// `DaemonUnreachable`, a different branch. Accepting exactly one connection and
+/// then dropping the listener also makes the follow-up reindex probes fail fast
+/// with connection-refused instead of idling in the accept backlog until their
+/// own multi-second timeouts elapse (the trick
+/// `ensure_project_indexed_sends_allow_sensitive_path_through_to_create_body`
+/// already uses).
+/// What: binds `127.0.0.1:0`, spawns a thread that accepts ONE connection, reads
+/// the request, replies `status_line` with an empty body, and exits. Returns the
+/// bound address and the thread handle.
+/// Test: used by `create_rejected_by_the_daemon_withholds_the_pinnable_id`.
+fn one_shot_daemon(
+    status_line: &'static str,
+) -> (std::net::SocketAddr, std::thread::JoinHandle<()>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind fake daemon");
+    let addr = listener.local_addr().expect("fake daemon local_addr");
+    let handle = std::thread::spawn(move || {
+        use std::io::{Read, Write};
+        let Ok((mut stream, _)) = listener.accept() else {
+            return;
+        };
+        drop(listener);
+        let mut buf = [0u8; 4096];
+        let _ = stream.read(&mut buf);
+        let _ = stream.write_all(
+            format!("{status_line}\r\ncontent-length: 0\r\nconnection: close\r\n\r\n").as_bytes(),
+        );
+        let _ = stream.flush();
+    });
+    (addr, handle)
+}
+
+/// Publish `addr` where `resolve_daemon_base_url("trusty-search")` will find it.
+///
+/// Why: mirrors `write_daemon_addr`'s on-disk discovery contract so a test's own
+/// loopback socket stands in for the daemon.
+/// What: creates `<data_dir>/trusty-search/` and writes `http_addr`.
+/// Test: used by `create_rejected_by_the_daemon_withholds_the_pinnable_id`.
+fn publish_daemon_addr(data_dir: &Path, addr: std::net::SocketAddr) {
+    let search_data_dir = data_dir.join("trusty-search");
+    fs::create_dir_all(&search_data_dir).unwrap();
+    fs::write(search_data_dir.join("http_addr"), addr.to_string()).unwrap();
+}
+
+/// Run `body` with discovery pointed at a fake daemon that answers `status_line`.
+///
+/// Why: the three arms of the #5091 regression need the identical arrangement —
+/// `ENV_LOCK`, an isolated data dir, the #4255 opt-out, a fake daemon, and a
+/// git-rooted project — and repeating it three times is where a missed env
+/// restore leaks into a sibling serial test.
+/// What: locks `ENV_LOCK`, points `DATA_DIR_OVERRIDE_ENV` at a scratch dir, sets
+/// `ALLOW_PRODUCTION_ENV=1` (safe: discovery points at this test's OWN loopback
+/// socket, never the operator's daemon), creates a git-rooted scratch project,
+/// runs `body(&project)`, then restores the env and removes both scratch dirs
+/// before returning `body`'s value.
+/// Test: used by `create_rejected_by_the_daemon_withholds_the_pinnable_id`.
+fn with_refusing_daemon<T>(
+    tag: &str,
+    status_line: &'static str,
+    body: impl FnOnce(&Path) -> T,
+) -> T {
+    let _guard = crate::data_dir::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let data_dir = scratch_dir(&format!("5091-data-{tag}"));
+    fs::create_dir_all(&data_dir).unwrap();
+    // SAFETY: guarded by ENV_LOCK; both vars are removed below before returning.
+    unsafe {
+        std::env::set_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV, &data_dir);
+        std::env::set_var(crate::test_harness::ALLOW_PRODUCTION_ENV, "1");
+    }
+
+    let (addr, server) = one_shot_daemon(status_line);
+    publish_daemon_addr(&data_dir, addr);
+
+    let project = scratch_dir(&format!("5091-project-{tag}"));
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    let out = body(&project);
+
+    let _ = server.join();
+    unsafe {
+        std::env::remove_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV);
+        std::env::remove_var(crate::test_harness::ALLOW_PRODUCTION_ENV);
+    }
+    let _ = fs::remove_dir_all(&project);
+    let _ = fs::remove_dir_all(&data_dir);
+    out
+}
+
+/// Regression for #5091: a `POST /indexes` the daemon REFUSES must not yield a
+/// pinnable index id.
+///
+/// Why: this is the fail-open shape the ticket names. The create failed — the
+/// daemon answered 500, so no index exists under the derived id — yet
+/// `ensure_project_indexed` handed the id back anyway, session launch pinned it
+/// into `.mcp.json`, and every later `search` in that session answered
+/// `404 unknown index` while `search_health` stayed green. Withholding the id
+/// leaves the pin unadvanced, which is the fix; the derived id itself stays
+/// reachable through `ensure_project_indexed_reporting` for callers that need it
+/// to log or to GC, where the adjacent `registration` field makes ignoring the
+/// failure a visible choice rather than the default.
+/// What: three arms against a fake daemon that 500s the create — the two id-only
+/// entry points must return `None`, and the reporting entry point must still
+/// carry the derived id alongside `NotConfirmed`.
+/// Test: this test.
+#[test]
+fn create_rejected_by_the_daemon_withholds_the_pinnable_id() {
+    let refused = "HTTP/1.1 500 Internal Server Error";
+
+    let id = with_refusing_daemon("ensure", refused, |project| {
+        ensure_project_indexed(project, false)
+    });
+    assert_eq!(
+        id, None,
+        "ensure_project_indexed returned a pinnable id after the daemon REFUSED \
+         the create (HTTP 500) — pinning it makes every later search 404 (#5091)"
+    );
+
+    let id = with_refusing_daemon("ensure-with", refused, |project| {
+        ensure_project_indexed_with(project, IndexOptions::default().with_skip_vector(true))
+    });
+    assert_eq!(
+        id, None,
+        "ensure_project_indexed_with returned a pinnable id after the daemon \
+         REFUSED the create (HTTP 500) — #5091"
+    );
+
+    let (report, expected) = with_refusing_daemon("report", refused, |project| {
+        (
+            ensure_project_indexed_reporting(project, IndexOptions::default()),
+            crate::derive_index_id(project),
+        )
+    });
+    assert_eq!(
+        report.registration,
+        IndexRegistration::NotConfirmed,
+        "a 500 on the create is not a registration"
+    );
+    assert_eq!(
+        report.index_id,
+        Some(expected),
+        "the derived id stays available for logging and GC — it is the PIN that \
+         is withheld, not the id"
     );
 }

--- a/crates/trusty-mpm/changelog.d/5091-unpinned-stub-when-unconfirmed.md
+++ b/crates/trusty-mpm/changelog.d/5091-unpinned-stub-when-unconfirmed.md
@@ -1,0 +1,10 @@
+Fixed
+
+- Session launch writes the UNPINNED `trusty-search` MCP stub when index
+  registration was not confirmed, instead of pinning `serve --index <id>` to an
+  index the daemon never created
+  ([#5091](https://github.com/bobmatnyc/trusty-tools/issues/5091)). Previously
+  every `search`/`grep` in such a session answered `404 unknown index` for the
+  session's whole life while the `search` health check stayed green. The
+  `search_index_pin` doctor check reports the unpinned stub as a warning naming
+  the relaunch fix, and still fails on a pin that has since gone stale.

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -1019,10 +1019,11 @@ fn prepare_session_inner(
     // running daemon, then inject the `trusty-search` MCP stub PINNED to that id
     // (`serve --index <id>`). Pinning makes a bare `search`/`grep` resolve to
     // the session's OWN project index instead of letting the LLM guess (and
-    // routinely pick the wrong `claude-mpm` index). The daemon-unreachable case
-    // is handled inside `register_project_index` (logged, non-fatal) and still
-    // returns the id so the stub is pinned; a `None` id (empty derivation) falls
-    // back to the unpinned stub. Either way the session launches.
+    // routinely pick the wrong `claude-mpm` index). #5091: an id comes back only
+    // when the daemon CONFIRMED the index — an unreachable daemon, a refused
+    // create, or an empty derivation all yield `None` and the unpinned stub,
+    // because pinning an index that does not exist 404s every later search.
+    // Either way the session launches.
     // Gated by the manifest's `[mcp] trusty_search` toggle (default on).
     // `trusty_search_injected` mirrors `trusty_memory_injected` above (#3950).
     let mut trusty_search_injected = false;

--- a/crates/trusty-mpm/src/core/session_launch/search_index.rs
+++ b/crates/trusty-mpm/src/core/session_launch/search_index.rs
@@ -90,11 +90,18 @@ pub(crate) fn inject_trusty_search_mcp(
 /// register-and-populate logic was PROMOTED into
 /// [`trusty_common::search_index::ensure_project_indexed`] so trusty-code can
 /// reuse the ONE implementation (common entry-point rule); this wrapper keeps
-/// the session-launch call site and name stable. Behaviour is unchanged: derive
-/// the canonical index id, best-effort `POST /indexes` + freshness-gated reindex
-/// when the daemon is reachable, always return the derived id so the stub is
-/// pinned even when the daemon is down, and never propagate an error (the
-/// session must still launch).
+/// the session-launch call site and name stable. Derive the canonical index id,
+/// best-effort `POST /indexes` + freshness-gated reindex when the daemon is
+/// reachable, and never propagate an error (the session must still launch).
+///
+/// `None` on an unconfirmed registration (#5091): the shared helper used to hand
+/// the derived id back even when the create failed or never happened, so this
+/// wrapper pinned `.mcp.json` to an index the daemon had never heard of and
+/// every `search` in that session answered `404 unknown index` — permanently,
+/// invisibly, with the `search` health check still green. It now returns the id
+/// only when the daemon confirmed it; otherwise the caller writes the unpinned
+/// stub, which `tm doctor`'s `search_index_pin` check reports as a warning
+/// instead of a silent dead end.
 /// What: delegates to [`trusty_common::search_index::ensure_project_indexed`]
 /// with `allow_sensitive_path: false` (issue #2914). A trusty-mpm session
 /// workspace is always either the user's checked-out repository or a
@@ -112,8 +119,8 @@ pub(crate) fn inject_trusty_search_mcp(
 /// cannot undo the BM25+KG-only decision worktree creation made. See that
 /// function for why the ordering made this a real drift and not a theoretical
 /// one.
-/// Test: `register_project_index_returns_derived_id` (derivation + daemon-down
-/// graceful path) and `register_project_index_never_bypasses_sensitive_path_denylist`
+/// Test: `register_project_index_withholds_id_when_registration_is_unconfirmed`
+/// (#5091) and `register_project_index_never_bypasses_sensitive_path_denylist`
 /// (issue #2914 regression) in `tests.rs`; the promoted logic is unit-tested in
 /// `trusty_common::search_index::tests`.
 pub(crate) fn register_project_index(project_root: &Path) -> Option<String> {

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -1656,16 +1656,24 @@ fn inject_trusty_search_mcp_pins_index() {
     );
 }
 
+/// Nothing registered means nothing to pin (#5091; was
+/// `register_project_index_returns_derived_id`).
+///
+/// Why: this test used to assert the opposite — that with no daemon the id came
+/// back anyway "so the stub can be pinned". That is the defect #5091 reports:
+/// `.mcp.json` then pins `trusty-search serve --index <id>` for an index nothing
+/// created, and every `search` in that session answers `404 unknown index` while
+/// the `search` health check stays green. The launch caller already handles
+/// `None` by writing the unpinned stub, so the honest outcome costs nothing.
+/// What: points the data dir at an empty temp dir so no `http_addr` file exists
+/// and no POST is issued, then asserts `register_project_index` returns `None`
+/// while the shared reporting entry point still derives the git-root basename
+/// from a nested directory — the derivation this test has always covered.
+/// `#[serial]` because the override env var is process-global.
+/// Test: this test.
 #[test]
 #[serial_test::serial]
-fn register_project_index_returns_derived_id() {
-    // Why (#1373): registration must derive the project's index id (git-root
-    // basename, via the shared `trusty_common::derive_index_id`) AND remain
-    // graceful when the trusty-search daemon is unreachable — it still returns
-    // the id so the stub can be pinned. We force the daemon-down path by
-    // pointing the data dir at an empty temp dir so `read_daemon_addr` finds no
-    // `http_addr` file (and thus issues no HTTP POST). `#[serial]` because the
-    // override env var is process-global.
+fn register_project_index_withholds_id_when_registration_is_unconfirmed() {
     let data_dir = tempdir().unwrap();
     // Panic-safe restore: the guard restores/removes the override env var in its
     // `Drop`, so a panic in the assertions below never leaks it to sibling
@@ -1681,9 +1689,21 @@ fn register_project_index_returns_derived_id() {
     let nested = project.path().join("crates/inner");
     std::fs::create_dir_all(&nested).unwrap();
 
-    let id = register_project_index(&nested);
+    let report = trusty_common::search_index::ensure_project_indexed_reporting(
+        &nested,
+        trusty_common::search_index::IndexOptions::default(),
+    );
     let expected = trusty_common::derive_index_id(project.path());
-    assert_eq!(id, Some(expected), "id is the git-root basename");
+    assert_eq!(
+        report.index_id,
+        Some(expected),
+        "id is the git-root basename"
+    );
+    assert_eq!(
+        register_project_index(&nested),
+        None,
+        "no registration was confirmed, so the stub must not be pinned (#5091)"
+    );
 }
 
 // Issue #2914 regression (`register_project_index_never_bypasses_sensitive_path_denylist`)

--- a/crates/trusty-mpm/src/daemon/doctor_search_pin.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_search_pin.rs
@@ -2,17 +2,21 @@
 //!
 //! Why: session launch pins a trusty-search index id into the project's
 //! `.mcp.json` (`trusty-search serve --index <id>`) and registers that index
-//! best-effort. Every step of the registration is fail-open —
-//! `trusty_common::search_index::ensure_project_indexed` "ALWAYS returns the
-//! derived id … even if the daemon is unreachable", and both
-//! `best_effort_create_index` and `best_effort_trigger_reindex` swallow their
-//! failures at `tracing::warn!`. So the pin advances whether or not the index
-//! was ever created, and the existing `search` probe — which asks the daemon
-//! whether it is healthy and whether the *derived* id appears in `/indexes` —
-//! keeps reporting fine. Measured on 2026-08-07: 4 of 75 live worktrees had a
-//! registered index, and `POST /indexes/<pinned-id>/search` returned
+//! best-effort, swallowing every failure at `tracing::warn!`. Until #5091 the
+//! shared helper handed the derived id back regardless, so the pin advanced
+//! whether or not the index was ever created, while the existing `search`
+//! probe — which asks the daemon whether it is healthy and whether the
+//! *derived* id appears in `/indexes` — kept reporting fine. Measured on
+//! 2026-08-07: 4 of 75 live worktrees had a registered index, and
+//! `POST /indexes/<pinned-id>/search` returned
 //! `404 Not Found: {"error":"unknown index"}` in a worktree whose `search`
 //! check was green.
+//!
+//! #5091 stops NEW pins from advancing on an unconfirmed create, and this check
+//! stays: a pin already written by an older `tm` is still on disk, and an index
+//! that existed when the pin was written can be deleted, GC'd, or lost when the
+//! daemon's registry is rebuilt. A pin is a claim about the daemon's state at
+//! one past moment; only resolving it says whether it still holds.
 //!
 //! What: [`check_search_index_pin`] reads the id the session is ACTUALLY
 //! pinned to out of `.mcp.json` and resolves it against the daemon with
@@ -270,10 +274,11 @@ pub(super) fn build_pin_check(pin: &PinState, probe: Option<&PinProbe>) -> Docto
             CheckStatus::Fail,
             format!(
                 "this session is pinned to trusty-search index `{id}` but the daemon has NO such \
-                 index — every `search`/`grep` call in this session returns 404 \"unknown index\". \
-                 Index registration is best-effort and swallows its failures, so the pin advanced \
-                 anyway and the `search` health check stays green (issue #5045). Run \
-                 `trusty-search index create` for this project, or relaunch the session"
+                 index — every `search`/`grep` call in this session returns 404 \"unknown index\", \
+                 and the `search` health check stays green because it reports the daemon, not the \
+                 pin (issue #5045). Either the index was deleted since the pin was written, or the \
+                 pin predates #5091. Run `trusty-search index create` for this project, or \
+                 relaunch the session"
             ),
         ),
         Some(PinProbe::HttpStatus(code)) => DoctorCheck::new(


### PR DESCRIPTION
Closes #5091. Third of the three fail-open fixes in the ts 0.45.0 cut, alongside #5344 and #5357.

## What was wrong

`ensure_project_indexed` / `ensure_project_indexed_with` returned the derived index id whatever `POST /indexes` did with it. Session launch writes that id into `.mcp.json` as `trusty-search serve --index <id>`, so a create that failed — refused, transport error, or a daemon that was not running — left the session pinned to an index the daemon had never heard of. Every `search` in that session then answered `404 unknown index` for its whole life, while `search_health` and the `search` doctor probe both stayed green because they report the daemon, not the pin. #5045 measured 4 of 75 live worktrees with an index.

## The behavior I chose, and why

**Leave the pin unadvanced. Do not propagate.**

The id-only entry points now route through `pinnable_index_id`, which returns the id only for `IndexRegistration::Confirmed` — a 2xx on the find-or-create POST, which also covers "the index already existed". Every other outcome (non-2xx, transport error, panicked worker, no discoverable daemon, and the #4255 test-harness suppression) logs at warn and returns `None`. The session-launch caller then writes the unpinned stub it already wrote for an empty derivation.

Not propagating is deliberate. All three call sites — session launch, task start, worktree creation — must not fail because trusty-search is down, and that never-block guarantee is correct. What was wrong was not swallowing the error; it was advancing the pin on the back of it. Withholding the id makes the failure express itself in the one place that matters, without letting a search outage abort a session.

Not "leave it to the caller" either. #5065 already added `ensure_project_indexed_reporting` + `IndexRegistration`, and one caller (worktree creation) uses it. But the default API still handed back a success-shaped value on failure, and both remaining callers took it. A fail-open default that each caller must remember to opt out of is the defect, not the cure. After this change the honest path is the default; getting the derived id regardless means reading `EnsureIndexReport::index_id`, where the adjacent `registration` field makes ignoring the failure a visible choice. `ensure_project_indexed_reporting` itself is unchanged — it still carries the derived id in every case, so logging and GC keep working.

`SkippedUnderTest` gets no carve-out. Under the harness nothing is sent, so nothing is registered, so nothing may be pinned. An exception there would preserve the defect shape in miniature behind a test flag.

The one claim I deleted rather than reworded: the `DaemonUnreachable` branch said the daemon "will create the index on first reindex". Nothing retries — that was never true.

## Existing tests that asserted the old contract

Three tests pinned "the id always comes back". Each is rewritten to assert the new contract while keeping the coverage it actually had:

- `ensure_project_indexed_returns_derived_id_when_daemon_down` → `ensure_project_indexed_withholds_id_when_nothing_was_registered`. Its name never matched what it ran: under `cargo test` the #4255 guard short-circuits before daemon discovery, so the daemon-down branch was never reached. It keeps the derivation assertion (git-root basename from a nested dir), now read off the reporting entry point.
- `ensure_project_indexed_never_writes_to_a_daemon_under_test` — the primary "no connection was made" assertion is untouched; the secondary `id.is_some()` flips to `id.is_none()`.
- trusty-mpm's `register_project_index_returns_derived_id` → `register_project_index_withholds_id_when_registration_is_unconfirmed`, same treatment.

Also holds `ENV_LOCK` in `reporting_says_skipped_under_test_harness`. It reads `TRUSTY_ALLOW_PRODUCTION_STATE`, which the new error-arm test sets and clears; without the lock it asserts on whatever a sibling thread happened to leave in the process env. It failed once that way on the first full-suite run.

## Error-arm regression test — pre-fix failure

`create_rejected_by_the_daemon_withholds_the_pinnable_id` stands up a loopback socket that answers the create POST with `500`, which is the only way to reach the error arm (a dead port lands in `DaemonUnreachable` instead). Against the pre-fix commit:

```
$ cargo test -p trusty-common --features search-index --lib -- \
    search_index::tests::create_rejected_by_the_daemon_withholds_the_pinnable_id --exact

thread 'search_index::tests::create_rejected_by_the_daemon_withholds_the_pinnable_id' panicked at
crates/trusty-common/src/search_index_tests.rs:970:5:
assertion `left == right` failed: ensure_project_indexed returned a pinnable id after the daemon
REFUSED the create (HTTP 500) — pinning it makes every later search 404 (#5091)
  left: Some("trusty-search-index-5091-project-ensure-43897-1786410767313120000")
 right: None

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 343 filtered out
```

Post-fix, same command's module:

```
test search_index::tests::create_rejected_by_the_daemon_withholds_the_pinnable_id ... ok
test search_index::tests::ensure_project_indexed_withholds_id_when_nothing_was_registered ... ok
test search_index::tests::ensure_project_indexed_never_writes_to_a_daemon_under_test ... ok
test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 319 filtered out; finished in 0.29s
```

## Gates — Rust test ladder rung 4 (shared library, cross-crate)

Rung 3 on the library:

```
cargo fmt --check                                                        # clean
cargo check -p trusty-common --features search-index                     # EXIT=0
cargo clippy -p trusty-common --all-targets --features search-index -- -D warnings   # EXIT=0
cargo test -p trusty-common --features search-index                      # ok. 338 passed; 0 failed; 6 ignored
```

Then cross-crate. `search_index` is behind the `search-index` feature, which only trusty-code and trusty-mpm enable — those are the direct dependents this change can reach; every other trusty-common dependent is covered by the workspace check.

```
cargo check --workspace --all-targets    # EXIT=0
cargo test -p trusty-code                # ok — 1602 lib + 15 integration targets, 0 failed
cargo test -p trusty-mpm                 # ok. 4998 lib passed, 0 failed; all integration targets green
```

Repo gates:

```
bash scripts/check_line_cap.sh              # 3889 files, 0 violations
bash scripts/check_sld.sh                   # 0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh    # both crates recorded
```

No `cargo test --workspace` — that is keyed to the publish boundary, not to rung 4.

### One flake, pre-existing

The first `cargo test -p trusty-mpm` run failed `core::managed_config::tests::ensure_managed_config_dir_emits_the_frozen_skill_warning`:

```
thread '...ensure_managed_config_dir_emits_the_frozen_skill_warning' panicked at
crates/trusty-mpm/src/core/managed_config_tests.rs:544:9:
provisioning declined `probe-skill` but emitted no warning naming it — the emit block in
`ensure_managed_config_dir_with_root` is missing or unreachable. Captured lines: []

test result: FAILED. 4997 passed; 1 failed; 7 ignored
```

That is #4931, already diagnosed and marked "do not re-derive": the test captures through `tracing::subscriber::with_default`, a thread-local subscriber that loses to any globally-installed one another test in the binary sets. `git diff --name-only` shows this branch touches four trusty-mpm files, none of them `managed_config`. It passes in isolation (`1 passed`) and the full re-run above is green at 4998/0.

## Not in scope

`best_effort_create_index` still makes one attempt with a 1s cap and no retry. Adding one would cut the miss rate but would not change the contract this ticket is about, and a bouncing daemon does not come back inside a 200 ms backoff.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
