### PR TITLE
test(trusty-search): pin serve's TRUSTY_INDEX precedence for ADR-0042 (no fix needed)

### DIFF
--- a/crates/trusty-search/changelog.d/4181-serve-reads-trusty-index.md
+++ b/crates/trusty-search/changelog.d/4181-serve-reads-trusty-index.md
@@ -1,0 +1,7 @@
+Added
+
+- **`trusty-search serve`'s `TRUSTY_INDEX` precedence is now pinned by tests, so one argless `["serve"]` MCP declaration can be shared across projects** ([#4181](https://github.com/bobmatnyc/trusty-tools/issues/4181)). No behaviour change: `serve` already read `TRUSTY_INDEX`, with an explicit `--index` outranking it and the `--project` fallback of [#1373](https://github.com/bobmatnyc/trusty-tools/issues/1373) intact when neither is set. Verified end to end against the binary on all four combinations before anything was written
+  - the source read as though it did not work, which is what earned the tests: `Serve` declares `#[arg(long)] index` with no `env`, looking like a second argument that shadows the `global = true, env = "TRUSTY_INDEX"` field on `Cli`. Both spell the same clap id, so clap propagates the one argument, environment value included
+  - dropping `global` from `Cli::index`, renaming either field, or giving `Serve` an id of its own would break the argless declaration silently; `commands::serve::index_env_tests` now fails instead — confirmed by making that exact edit and watching `env_alone_pins_the_index` report `left: None`
+  - the environment rows run in a child process, because clap reads `env` from the live process environment and mutating it in-process would race the rest of the binary's tests
+  - `main`'s `Serve` arm now calls `commands::serve::resolve_pinned_index`, so the precedence is one function the tests can call rather than a match arm they would have to re-implement

--- a/crates/trusty-search/src/commands/serve.rs
+++ b/crates/trusty-search/src/commands/serve.rs
@@ -5,6 +5,31 @@ use anyhow::Result;
 use colored::Colorize;
 use trusty_common::mcp::DaemonBridgeConfig;
 
+/// Resolve the index an MCP session pins to (issue #1373), from the `serve`
+/// subcommand's parsed `--index` and `--project`.
+///
+/// Why: precedence here decides which index every tool call in the session
+/// defaults to, and getting it wrong is exactly the wrong-index defect #1373
+/// fixed. Holding it in one function keeps `main`'s match arm thin and lets the
+/// precedence be asserted directly rather than re-implemented in a test.
+/// What: an index from any source wins; otherwise the id is derived from
+/// `--project` the same way the CLI and trusty-mpm derive it; otherwise the
+/// session is unpinned and callers must supply `index_id`. `index` carries the
+/// `TRUSTY_INDEX` environment value as well as the explicit flag — clap
+/// resolves that precedence at parse time, flag over environment.
+/// Test: `commands::serve::index_env_tests`.
+pub(crate) fn resolve_pinned_index(
+    index: Option<String>,
+    project: Option<String>,
+) -> Option<String> {
+    index.or_else(|| {
+        project.map(|p| {
+            let root = trusty_common::resolve_project_root(&std::path::PathBuf::from(&p));
+            trusty_common::derive_index_id(&root)
+        })
+    })
+}
+
 /// Why: extracted from `main()`. The HTTP path involves a discovery file
 /// (`~/.trusty-search/mcp_http_addr`) and cleanup-on-exit logic that's easier
 /// to follow in isolation.
@@ -173,3 +198,8 @@ async fn serve_http(server: crate::mcp::McpServer, addr: String, daemon_url: &st
     serve_result?;
     Ok(())
 }
+
+/// Index-pin precedence tests — see `serve_index_env_tests.rs`.
+#[cfg(test)]
+#[path = "serve_index_env_tests.rs"]
+mod index_env_tests;

--- a/crates/trusty-search/src/commands/serve_index_env_tests.rs
+++ b/crates/trusty-search/src/commands/serve_index_env_tests.rs
@@ -1,0 +1,233 @@
+//! Precedence tests for the index the `serve` subcommand pins its MCP session
+//! to (issue #4181).
+//!
+//! Why: ADR-0042 wants one MCP server declaration, `["serve"]` with no baked
+//! `--index`, shared across every project, with `TRUSTY_INDEX` in the
+//! declaration's `env` block naming the per-project index. That works today,
+//! but nothing proved it and the source reads as though it does not: `Serve`
+//! declares `#[arg(long)] index` with no `env`, which looks like a second arg
+//! shadowing the `global = true, env = "TRUSTY_INDEX"` field on `Cli`. It is
+//! not — both spell the same clap id, so clap propagates the one arg, env value
+//! included, into the subcommand's matches. Two readers have now misread that,
+//! so the behaviour ADR-0042 rests on is pinned here rather than left to be
+//! re-derived. Removing `global` from `Cli::index`, renaming either field, or
+//! giving `Serve` a distinct id would silently break the argless declaration;
+//! these tests turn that into a failure.
+//!
+//! What: parses real `Cli` argument vectors, feeds the parsed fields through
+//! [`super::resolve_pinned_index`] — the same function `main`'s `Serve` arm
+//! calls — and asserts the result across all four combinations of `--index`
+//! present/absent and `TRUSTY_INDEX` set/unset. The rows that need a real
+//! environment run in a child process: clap reads `env` from the live process
+//! environment during `try_parse_from`, and mutating it in-process would race
+//! the other tests in this binary. The child is this same test binary re-run
+//! with a single-test filter, so no daemon is contacted, no port is bound, and
+//! the machine's live `trusty-search` is never touched.
+//!
+//! These tests live here rather than in `main.rs` because that file sits near
+//! its `check_line_cap` budget; `Cli` stays reachable because this module is a
+//! descendant of the binary's crate root.
+//!
+//! Test: `cargo test -p trusty-search --bin trusty-search index_env`
+
+use super::resolve_pinned_index;
+use crate::{Cli, Commands};
+use clap::Parser;
+use std::process::Command;
+
+/// Set on the child process to tell [`probe_child`] to actually run. Its value
+/// is the argument vector (space-separated, without the `trusty-search`
+/// argv[0]) that the child should parse.
+const PROBE_ARGV: &str = "TRUSTY_SERVE_INDEX_PROBE_ARGV";
+
+/// Filter naming [`probe_child`] to libtest, exactly.
+const PROBE_TEST: &str = "commands::serve::index_env_tests::probe_child";
+
+/// Prefix of the single line [`probe_child`] prints for the parent to read.
+const PROBE_PREFIX: &str = "PROBE_RESOLVED=";
+
+/// Stand-in for `None` in the probe line, so the encoding stays free of
+/// quoting rules.
+const NONE: &str = "-";
+
+/// What the `serve` arm sees after parsing: the global `Cli::index`, the
+/// subcommand's own `index`, and the pin those resolve to.
+#[derive(Debug, PartialEq, Eq)]
+struct Parsed {
+    global: Option<String>,
+    subcommand: Option<String>,
+    pin: Option<String>,
+}
+
+/// Parse `args` as a full argv and report both `index` fields plus the pin
+/// `main`'s `Serve` arm would compute from them.
+fn parse(args: &[&str]) -> Parsed {
+    let cli = Cli::try_parse_from(args).expect("argument vector must parse");
+    let global = cli.index;
+    match cli.command {
+        Commands::Serve { index, project, .. } => Parsed {
+            global,
+            subcommand: index.clone(),
+            pin: resolve_pinned_index(index, project),
+        },
+        _ => panic!("expected Commands::Serve"),
+    }
+}
+
+fn encode(v: &Option<String>) -> &str {
+    v.as_deref().unwrap_or(NONE)
+}
+
+fn decode(v: &str) -> Option<String> {
+    (v != NONE).then(|| v.to_string())
+}
+
+/// Child half of the probe: parse the argv handed over in [`PROBE_ARGV`] and
+/// print the outcome on one line. A no-op when the variable is absent, which is
+/// every ordinary run of this test.
+#[test]
+fn probe_child() {
+    let Ok(argv) = std::env::var(PROBE_ARGV) else {
+        return;
+    };
+    let mut args = vec!["trusty-search"];
+    args.extend(argv.split_whitespace());
+    let p = parse(&args);
+    println!(
+        "{PROBE_PREFIX}{};{};{}",
+        encode(&p.global),
+        encode(&p.subcommand),
+        encode(&p.pin)
+    );
+}
+
+/// Parent half of the probe: re-run this test binary with `TRUSTY_INDEX` set to
+/// `env_value` (or removed, when `None`) and `argv` as the arguments to parse,
+/// then return what the child observed.
+fn parse_with_env(env_value: Option<&str>, argv: &str) -> Parsed {
+    let exe = std::env::current_exe().expect("locate this test binary");
+    let mut cmd = Command::new(exe);
+    cmd.args([PROBE_TEST, "--exact", "--nocapture"])
+        .env(PROBE_ARGV, argv)
+        .env_remove("TRUSTY_INDEX");
+    if let Some(v) = env_value {
+        cmd.env("TRUSTY_INDEX", v);
+    }
+
+    let out = cmd
+        .output()
+        .expect("re-run this test binary as a probe child");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "probe child failed (TRUSTY_INDEX={env_value:?}, argv {argv:?}):\n{stdout}{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let line = stdout
+        .lines()
+        .find_map(|l| l.trim().strip_prefix(PROBE_PREFIX))
+        .unwrap_or_else(|| {
+            panic!("probe child printed no {PROBE_PREFIX} line; stdout was:\n{stdout}")
+        });
+    let mut parts = line.split(';');
+    let mut next = || decode(parts.next().expect("probe line has three fields"));
+    Parsed {
+        global: next(),
+        subcommand: next(),
+        pin: next(),
+    }
+}
+
+/// Why (issue #4181): the row ADR-0042 rests on. An argless `["serve"]`
+/// declaration carries the project's index only in `TRUSTY_INDEX`; if that
+/// stopped reaching the pin, every tool call in the session would fall back to
+/// fan-out across all 40-odd indexes on the machine — slower, and answering
+/// from the wrong repo.
+/// What: asserts an unset `--index` with `TRUSTY_INDEX` set pins the
+/// environment value, and that it arrives via the propagated global arg rather
+/// than a separate subcommand-local one.
+/// Test: this function.
+#[test]
+fn env_alone_pins_the_index() {
+    let p = parse_with_env(Some("env-index"), "serve");
+    assert_eq!(
+        p.pin,
+        Some("env-index".to_string()),
+        "`serve` must pin to TRUSTY_INDEX when no --index is given (#4181)"
+    );
+    assert_eq!(
+        p.global, p.subcommand,
+        "`Serve::index` and the global `Cli::index` are one clap arg; if these \
+         ever diverge, the subcommand has gained an id of its own and the \
+         argless MCP declaration ADR-0042 needs has stopped working"
+    );
+}
+
+/// Why: an explicit flag is the operator's direct instruction and must outrank
+/// an inherited environment, which an MCP client or a parent shell can set
+/// without the operator ever seeing it.
+/// What: asserts `--index` wins with `TRUSTY_INDEX` also set.
+/// Test: this function.
+#[test]
+fn explicit_flag_beats_the_environment() {
+    assert_eq!(
+        parse_with_env(Some("env-index"), "serve --index flag-index").pin,
+        Some("flag-index".to_string()),
+        "an explicit --index must outrank TRUSTY_INDEX"
+    );
+}
+
+/// Why: an explicit `--index` is what every existing baked MCP declaration
+/// relies on, and it must keep working whether or not the environment is
+/// involved.
+/// What: asserts `--index` resolves with `TRUSTY_INDEX` unset, both in-process
+/// and in a child whose environment is provably clean.
+/// Test: this function.
+#[test]
+fn explicit_flag_alone_pins_the_index() {
+    assert_eq!(
+        parse(&["trusty-search", "serve", "--index", "flag-index"]).pin,
+        Some("flag-index".to_string())
+    );
+    assert_eq!(
+        parse_with_env(None, "serve --index flag-index").pin,
+        Some("flag-index".to_string())
+    );
+}
+
+/// Why (issue #1373): the regression guard. #1373 was a wrong-index bug, and
+/// the fix for it is the `--project`-derived fallback in `main`'s `Serve` arm.
+/// A source that resolved to anything other than `None` here would pin the
+/// wrong index for every caller relying on that fallback — the same defect
+/// class, reintroduced.
+/// What: asserts neither source resolves anything when both are absent, so the
+/// arm still falls through to the `--project` derivation, and that the
+/// derivation itself still runs.
+/// Test: this function.
+#[test]
+fn neither_source_leaves_the_project_fallback_intact() {
+    assert_eq!(parse(&["trusty-search", "serve"]).pin, None);
+    assert_eq!(parse_with_env(None, "serve").pin, None);
+
+    let derived = parse(&["trusty-search", "serve", "--project", "/tmp/some-project"]).pin;
+    assert!(
+        derived.is_some(),
+        "--project must still derive an index id when nothing else pins one (#1373)"
+    );
+}
+
+/// Why: `--project` is the fallback the arm applies only when no index
+/// resolved, so an environment-sourced index must suppress it exactly as an
+/// explicit `--index` does.
+/// What: asserts `TRUSTY_INDEX` wins over a `--project` that would derive a
+/// different id.
+/// Test: this function.
+#[test]
+fn env_index_outranks_project() {
+    assert_eq!(
+        parse_with_env(Some("env-index"), "serve --project /tmp/some-project").pin,
+        Some("env-index".to_string()),
+        "an index from any source wins over --project"
+    );
+}

--- a/crates/trusty-search/src/main.rs
+++ b/crates/trusty-search/src/main.rs
@@ -588,6 +588,15 @@ enum Commands {
         /// `list_indexes` and guess. Without this flag, behaviour is unchanged
         /// (callers must supply `index_id`; fan-out sweeps all). Wins over
         /// `--project` when both are given.
+        ///
+        /// Also reads `TRUSTY_INDEX`, which is what lets ADR-0042 share one
+        /// argless `["serve"]` MCP declaration across projects. The `env` is
+        /// declared once on the global `Cli::index`; this field spells the same
+        /// clap id, so clap fills it from that one arg rather than treating it
+        /// as a second, environment-blind one.
+        // #4181: the shared id is what carries TRUSTY_INDEX here — renaming
+        // either field, or dropping `global` from Cli::index, breaks it.
+        // Precedence is pinned by `commands::serve::index_env_tests`.
         #[arg(long)]
         index: Option<String>,
 
@@ -1419,16 +1428,7 @@ async fn run() -> Result<()> {
             index,
             project,
         } => {
-            // Resolve the pinned index id (#1373): `--index` wins; otherwise
-            // derive it from `--project` via the shared derivation so it
-            // matches the CLI / trusty-mpm.
-            let pinned_index = index.or_else(|| {
-                project.map(|p| {
-                    let start = std::path::PathBuf::from(&p);
-                    let root = trusty_common::resolve_project_root(&start);
-                    trusty_common::derive_index_id(&root)
-                })
-            });
+            let pinned_index = commands::serve::resolve_pinned_index(index, project);
             commands::serve::handle_serve(with_http, port, http, pinned_index).await?;
         }
 


### PR DESCRIPTION
## The bug this PR was opened to fix does not exist

`trusty-search serve` already reads `TRUSTY_INDEX`, with exactly the precedence
ADR-0042 needs. I verified all four rows against the binary built from pristine
`origin/main` (41ca5c64) before writing a line, so this PR changes no behaviour.
It ships the tests that pin the behaviour, and a comment at the site that reads
misleadingly.

### Observed precedence, `origin/main`, real binary

Each row is `trusty-search serve` with stdin closed, attaching to the live daemon
(no spawn, no port bound, nothing written):

| `--index` | `TRUSTY_INDEX` | stderr from `origin/main` |
|---|---|---|
| `e2e-flag-index` | `e2e-env-index` | `◉ MCP session pinned to index e2e-flag-index` |
| `e2e-flag-index` | unset | `◉ MCP session pinned to index e2e-flag-index` |
| unset | `e2e-env-index` | `◉ MCP session pinned to index e2e-env-index` |
| unset | unset | *(no pin line — falls through to `project.map(...)`)* |

```
$ TRUSTY_INDEX=e2e-env-index ./target/debug/trusty-search serve < /dev/null
◉ MCP session pinned to index e2e-env-index
◉ MCP stdio (no HTTP) -> daemon http://127.0.0.1:7878

$ TRUSTY_INDEX=e2e-env-index ./target/debug/trusty-search serve --index e2e-flag-index < /dev/null
◉ MCP session pinned to index e2e-flag-index
◉ MCP stdio (no HTTP) -> daemon http://127.0.0.1:7878

$ ./target/debug/trusty-search serve --index e2e-flag-index < /dev/null
◉ MCP session pinned to index e2e-flag-index
◉ MCP stdio (no HTTP) -> daemon http://127.0.0.1:7878

$ ./target/debug/trusty-search serve < /dev/null
◉ MCP stdio (no HTTP) -> daemon http://127.0.0.1:7878
```

At parse level, printing `Cli::index`, `Serve::index`, and the resolved pin
(`-` is `None`), also against `origin/main`:

```
--index flag-index, TRUSTY_INDEX=env-index   PROBE_RESOLVED=flag-index;flag-index;flag-index
--index flag-index, TRUSTY_INDEX unset       PROBE_RESOLVED=flag-index;flag-index;flag-index
no --index,         TRUSTY_INDEX=env-index   PROBE_RESOLVED=env-index;env-index;env-index
no --index,         TRUSTY_INDEX unset       PROBE_RESOLVED=-;-;-
```

### Why the code reads as though it is broken

`Serve` declares `#[arg(long)] index` with no `env`, next to a `Cli::index`
declared `global = true, env = "TRUSTY_INDEX"`. That looks like a second
argument shadowing the first. It is not: both spell the same clap id `index`, so
clap propagates the one argument — environment value included — into the
subcommand's matches, and `Serve`'s derive reads it. Nothing shadows anything.
Two readers have misread it, which is what earns the tests.

Neither candidate fix was needed. `.or(cli.index)` would be a no-op, since
`Serve::index` already holds the value; adding `env = "TRUSTY_INDEX"` to the
`Serve` field would be a second `env` declaration on the same clap id.

### What ships instead

- `commands::serve::index_env_tests` — all four rows plus the `--project`
  interaction. The environment rows run in a child process: clap reads `env`
  from the live process environment, and mutating it in-process would race the
  rest of the binary's tests (the same reason `service_unit_cli_tests` leaves
  the env path alone and `no_auto_discover_env.rs` spawns a child).
- `main`'s `Serve` arm now calls `commands::serve::resolve_pinned_index`, so the
  precedence is one function the tests call rather than a match arm they would
  have to re-implement.
- A `// #4181:` pointer at `Serve::index` naming the shared clap id as the thing
  that carries `TRUSTY_INDEX`.

### The tests have teeth

No test here can be red on `origin/main`, because `origin/main` is correct. What
I can show is that the guard catches the regression it exists for. Dropping
`global = true` from `Cli::index` — the silent break ADR-0042 is exposed to —
gives:

```
test commands::serve::index_env_tests::env_alone_pins_the_index ... FAILED
test commands::serve::index_env_tests::env_index_outranks_project ... FAILED

assertion `left == right` failed: `serve` must pin to TRUSTY_INDEX when no --index is given (#4181)
  left: None
 right: Some("env-index")

assertion `left == right` failed: an index from any source wins over --project
  left: Some("some-project")
 right: Some("env-index")

test result: FAILED. 4 passed; 2 failed; 0 ignored; 0 measured; 375 filtered out
```

Mutation reverted; the committed tree has `global = true` intact.

### #1373 regression guard

`neither_source_leaves_the_project_fallback_intact` asserts the unset/unset row
resolves `None` so the arm still falls through to the `--project` derivation,
and separately that the derivation still produces an id. #1373 was a wrong-index
bug; a source that resolved to anything here would reintroduce that class.

### Consequence for ADR-0042

The argless shared MCP declaration works against `trusty-search` today. PR A of
the three-PR sequence needs no code change, and ADR-0042 can proceed on the
current behaviour rather than waiting on one.

### Gates — test ladder rung 3

```
cargo fmt --check                                        EXIT=0
cargo check -p trusty-search --all-targets               EXIT=0
cargo clippy -p trusty-search --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-search                              EXIT=0
bash scripts/check_line_cap.sh                           EXIT=0
bash scripts/check_sld.sh                                EXIT=0
bash scripts/check_changelog_fragment.sh                 EXIT=0
```

```
test result: ok. 1554 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 52.92s
test result: ok. 378 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 2.99s
(+ 25 further integration binaries, all ok, 0 failed)

line-cap: measured 3890 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
sld-lint: scanned 57 spec doc(s) + 3204 code file(s); 0 error(s), 0 warning(s)
OK   trusty-search: changelog.d fragment present and valid
```

`main.rs` net −10 lines, so the file moves away from its cap rather than toward
it.

Refs #4181.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
