### PR TITLE
ci: scope checks to relevant changes

### DIFF
--- a/.github/workflows/capabilities-drift.yml
+++ b/.github/workflows/capabilities-drift.yml
@@ -5,25 +5,22 @@
 # exactly what `tm generate capabilities` produces right now — a stale
 # generated file fails the job instead of silently rotting.
 #
-# DOCS-ONLY GATING (issue #4468 follow-up): this job's only inputs are the
-# harness's own in-process data — clap's CLI tree, the MCP tool catalog, the
-# bundled agent/skill rosters, a maintained doctor-check list (see
-# crates/trusty-mpm/src/core/bundle_tm_capabilities.rs's own doc comment) —
-# none of which lives under docs/. A change confined to docs/ therefore cannot
-# make this check's verdict differ, yet it previously ran a full Rust
-# toolchain install + `cargo run -p trusty-mpm` on every single PR (verified:
-# PR #4960, five files all under docs/, still paid this job's ~90s build).
-# Reuses the SAME classification ci.yml computes (`scripts/detect-docs-only.sh`,
-# via a `changes` job identical in shape to ci.yml's) rather than growing a
-# second definition of "docs-only" — this repo's common-entry-point doctrine.
-# This job is NOT in branch protection's required-checks list (verified via
-# `gh api repos/.../branches/main/protection`), so gating its steps costs
-# nothing risk-wise even in the worst case.
+# This optional gate's generated output is owned by trusty-mpm. Explicit path
+# filters avoid a second checkout/classifier job and prevent unrelated script,
+# workflow, documentation, UI, and crate changes from installing Rust merely
+# to regenerate an unchanged catalog. Workspace manifests stay in scope so a
+# dependency/build-input change still exercises the command fail closed.
 name: Capabilities drift
 
 on:
   push:
     branches: [main]
+    paths:
+      - "crates/trusty-mpm/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "scripts/check_capabilities.sh"
+      - ".github/workflows/capabilities-drift.yml"
   pull_request:
     # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
     # (opened/synchronize/reopened) and is the event a base-branch RETARGET
@@ -32,6 +29,12 @@ on:
     # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
     types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
+    paths:
+      - "crates/trusty-mpm/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "scripts/check_capabilities.sh"
+      - ".github/workflows/capabilities-drift.yml"
 
 # Per-COMMIT concurrency group on push so a merge never cancels the previous
 # merge's verification (#4179); per-ref group on pull_request so a new push
@@ -41,48 +44,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 jobs:
-  # Classify the diff as docs-only or not, mirroring ci.yml's `changes` job
-  # exactly (same script, same base-ref-refresh fix for #4688-class staleness)
-  # so this workflow never grows its own, second definition of "docs-only".
-  changes:
-    name: Detect docs-only change set
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      docs_only: ${{ steps.detect.outputs.docs_only }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Refresh the base branch ref (#4688 pattern — avoid a stale merge-base)
-        if: github.event_name == 'pull_request'
-        run: |
-          git fetch --no-tags --quiet origin \
-            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
-          git rev-parse --verify "refs/remotes/origin/${BASE_REF}"
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-
-      - name: Classify changed paths
-        id: detect
-        env:
-          DOCS_ONLY_BASE: origin/${{ github.event.pull_request.base.ref }}
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "push to ${{ github.ref }} — verifying in full, no docs-only exemption"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          bash scripts/detect-docs-only.sh > /dev/null
-
   capabilities-drift:
     name: tm-capabilities generated-skill drift check
-    needs: [changes]
-    # `needs:` alone would SKIP this job when `changes` fails, and GitHub
-    # reports a skipped job as passing — a broken classifier must cost a full
-    # run, never a silent skip. Matches ci.yml's #4179 reasoning.
-    if: ${{ !cancelled() }}
+    if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -92,15 +56,12 @@ jobs:
 
       # MSRV floor is 1.94 (root Cargo.toml rust-version), matching ci.yml.
       - name: Install Rust toolchain (1.94)
-        if: needs.changes.outputs.docs_only != 'true'
         uses: dtolnay/rust-toolchain@1.94
 
       - name: Cache cargo build
-        if: needs.changes.outputs.docs_only != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: capabilities-drift
 
       - name: Check tm-capabilities generated skill for drift
-        if: needs.changes.outputs.docs_only != 'true'
         run: bash scripts/check_capabilities.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # CI workflow for the trusty-tools Cargo workspace.
 #
 # Jobs:
-#   changes  – classify the diff as docs-only or not, once, for every job
+#   changes  – classify the diff as Cargo-inert or not, once, for every job
 #              below to consult (issue #4468: docs-only PRs ran the full Rust
 #              build). The exemption is applied to STEPS, never to the trigger
 #              or to the job, so required checks always report.
@@ -136,7 +136,7 @@ env:
 
 jobs:
   # --------------------------------------------------------------------------
-  # changes: classify the diff as docs-only or not (issue #4468), once, for
+  # changes: classify the diff as Cargo-inert or not (issue #4468), once, for
   # every job below to consult.
   #
   # WHY THIS IS A JOB AND NOT A `paths:` FILTER. Five of this workflow's checks
@@ -155,11 +155,12 @@ jobs:
   # the failure mode if that is wrong is every docs PR blocked forever, so the
   # jobs are kept unconditional and only their steps are gated.
   #
-  # PUSH TO MAIN never takes the exemption: main is the branch everything is
-  # cut from, so it is verified in full regardless of what the diff touched.
+  # PUSH TO MAIN compares the pushed range too. Re-running the complete Rust
+  # suite after a Cargo-inert PR has already passed adds cost but no signal.
+  # A missing/invalid before SHA still fails closed into the full suite.
   # --------------------------------------------------------------------------
   changes:
-    name: Detect docs-only change set
+    name: Detect Cargo-inert change set
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -206,15 +207,28 @@ jobs:
 
       - name: Classify changed paths
         id: detect
-        env:
-          DOCS_ONLY_BASE: origin/${{ github.event.pull_request.base.ref }}
         run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "push to ${{ github.ref }} — verifying in full, no docs-only exemption"
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.action }}" = "edited" ] && \
+             [ "${{ toJSON(github.event.changes.base) }}" = "null" ]; then
+            echo "title/body-only PR edit — retaining required contexts without repeating Cargo"
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            DOCS_ONLY_BASE="origin/${{ github.event.pull_request.base.ref }}" \
+              bash scripts/detect-docs-only.sh > /dev/null
+            exit 0
+          fi
+
+          before="${{ github.event.before }}"
+          if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
+            echo "push has no usable before SHA — verifying in full"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          bash scripts/detect-docs-only.sh > /dev/null
+          DOCS_ONLY_BASE="$before" bash scripts/detect-docs-only.sh > /dev/null
 
   # --------------------------------------------------------------------------
   # fmt: enforce cargo fmt --all --check (stable toolchain + rustfmt component)

--- a/.github/workflows/doc-numbers.yml
+++ b/.github/workflows/doc-numbers.yml
@@ -17,18 +17,20 @@
 name: Doc numbers
 
 #
-# NOT in branch protection's required-checks list (verified via
-# `gh api repos/.../branches/main/protection`, #5094), so a `paths-ignore` here
-# carries none of the "required check skipped -> pending forever" risk that
-# rules it out for ci.yml / line-cap.yml. `website/**` is excluded because the
-# gate only scans `docs/specs/**` and `docs/trusty-installer/research/02-design/**`
-# (scripts/check_doc_numbers.sh) — a website-only PR can never move its
-# verdict. `docs/**` itself stays IN scope; excluding it would defeat the gate.
+# Optional and pure shell: run only when the document-number or ADR corpora,
+# their allowlist/checkers, or this workflow changes.
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "website/**"
+    paths:
+      - "docs/specs/**"
+      - "docs/adr/**"
+      - "docs/trusty-installer/research/02-design/**"
+      - ".doc-number-allowlist.tsv"
+      - "scripts/check_doc_numbers.sh"
+      - "scripts/check_adr.sh"
+      - "scripts/check_scan_floor_selftest.sh"
+      - ".github/workflows/doc-numbers.yml"
   pull_request:
     # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
     # (opened/synchronize/reopened) and is the event a base-branch RETARGET
@@ -37,8 +39,15 @@ on:
     # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
     types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
-    paths-ignore:
-      - "website/**"
+    paths:
+      - "docs/specs/**"
+      - "docs/adr/**"
+      - "docs/trusty-installer/research/02-design/**"
+      - ".doc-number-allowlist.tsv"
+      - "scripts/check_doc_numbers.sh"
+      - "scripts/check_adr.sh"
+      - "scripts/check_scan_floor_selftest.sh"
+      - ".github/workflows/doc-numbers.yml"
 
 # Per-COMMIT concurrency group on push so a merge never cancels the previous
 # merge's verification (#4179); per-ref group on pull_request so a new push
@@ -49,7 +58,8 @@ concurrency:
 
 jobs:
   doc-numbers:
-    name: DOC-N / ADR number allocation lint
+    name: DOC-N allocation and ADR consistency lint
+    if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -72,3 +82,6 @@ jobs:
 
       - name: Enforce DOC-N / ADR number allocation (ratcheted allowlist)
         run: bash scripts/check_doc_numbers.sh
+
+      - name: Check ADR corpus consistency
+        run: bash scripts/check_adr.sh

--- a/.github/workflows/sld-lint.yml
+++ b/.github/workflows/sld-lint.yml
@@ -8,18 +8,32 @@
 # specs — so it passes on the current tree while the retrofit (§10 F5/F6) lands.
 name: SLD lint
 
-# NOT in branch protection's required-checks list (verified via
-# `gh api repos/.../branches/main/protection`, #5094), so a `paths-ignore` here
-# carries none of the "required check skipped -> pending forever" risk that
-# rules it out for ci.yml / line-cap.yml. `website/**` is excluded because
-# spec references live in `crates/**` doc comments and `docs/specs/**/*.md`
-# frontmatter, never under website/ — a website-only PR can't move the
-# verdict. `docs/**` itself stays IN scope: it is this gate's direct target.
+# This optional workflow is limited to inputs the SLD verdict can observe:
+# spec documents, crate source/doc comments, the linter implementation, and
+# its wrapper/configuration. ADR-only and other prose changes do not install a
+# Rust toolchain just to discover that SLD had nothing relevant to inspect.
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "website/**"
+    paths:
+      - "docs/specs/**"
+      - "crates/**/*.rs"
+      - "crates/**/*.py"
+      - "crates/**/*.ts"
+      - "crates/**/*.tsx"
+      - "crates/**/*.js"
+      - "crates/**/*.mjs"
+      - "crates/**/*.cjs"
+      - "crates/**/*.sh"
+      - "crates/**/*.bash"
+      - "crates/**/*.toml"
+      - "crates/**/*.yaml"
+      - "crates/**/*.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".sld-lint-allowlist.tsv"
+      - "scripts/check_sld.sh"
+      - ".github/workflows/sld-lint.yml"
   pull_request:
     # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
     # (opened/synchronize/reopened) and is the event a base-branch RETARGET
@@ -28,8 +42,25 @@ on:
     # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
     types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
-    paths-ignore:
-      - "website/**"
+    paths:
+      - "docs/specs/**"
+      - "crates/**/*.rs"
+      - "crates/**/*.py"
+      - "crates/**/*.ts"
+      - "crates/**/*.tsx"
+      - "crates/**/*.js"
+      - "crates/**/*.mjs"
+      - "crates/**/*.cjs"
+      - "crates/**/*.sh"
+      - "crates/**/*.bash"
+      - "crates/**/*.toml"
+      - "crates/**/*.yaml"
+      - "crates/**/*.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".sld-lint-allowlist.tsv"
+      - "scripts/check_sld.sh"
+      - ".github/workflows/sld-lint.yml"
 
 # Per-COMMIT concurrency group on push so a merge never cancels the previous
 # merge's verification (#4179); per-ref group on pull_request so a new push
@@ -41,6 +72,7 @@ concurrency:
 jobs:
   sld-lint:
     name: SLD (DOC-38) reference + spec-doc lint
+    if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -57,6 +89,3 @@ jobs:
 
       - name: Run SLD linter (default / grandfathering mode)
         run: bash scripts/check_sld.sh
-
-      - name: Check ADR corpus consistency
-        run: bash scripts/check_adr.sh

--- a/.github/workflows/test-pointers.yml
+++ b/.github/workflows/test-pointers.yml
@@ -11,18 +11,17 @@
 # its own lightweight job (matches ci.yml / line-cap.yml's checkout style).
 name: Test pointers
 
-# NOT in branch protection's required-checks list (verified via
-# `gh api repos/.../branches/main/protection`, #5094), so a `paths-ignore` here
-# carries none of the "required check skipped -> pending forever" risk that
-# rules it out for ci.yml / line-cap.yml. The gate only scans tracked `.rs`
-# files (scripts/check_test_pointers.sh), so neither `website/**` nor
-# `docs/**` can move its verdict — both are excluded.
+# This optional gate scans tracked Rust files only, so use an allowlist of its
+# actual inputs rather than making every new repository path opt in by default.
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "website/**"
-      - "docs/**"
+    paths:
+      - "**/*.rs"
+      - ".test-pointer-allowlist.tsv"
+      - "scripts/check_test_pointers.sh"
+      - "scripts/check_scan_floor_selftest.sh"
+      - ".github/workflows/test-pointers.yml"
   pull_request:
     # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
     # (opened/synchronize/reopened) and is the event a base-branch RETARGET
@@ -31,9 +30,12 @@ on:
     # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
     types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
-    paths-ignore:
-      - "website/**"
-      - "docs/**"
+    paths:
+      - "**/*.rs"
+      - ".test-pointer-allowlist.tsv"
+      - "scripts/check_test_pointers.sh"
+      - "scripts/check_scan_floor_selftest.sh"
+      - ".github/workflows/test-pointers.yml"
 
 # Per-COMMIT concurrency group on push so a merge never cancels the previous
 # merge's verification (#4179); per-ref group on pull_request so a new push
@@ -45,6 +47,7 @@ concurrency:
 jobs:
   test-pointers:
     name: "Test: doc-comment pointer lint"
+    if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     # #4882: was 5. Measured 2026-08-05: the lint itself legitimately took
     # 352s locally (close to CI's observed 303s the run that got cancelled),

--- a/.github/workflows/token-drift.yml
+++ b/.github/workflows/token-drift.yml
@@ -24,17 +24,23 @@
 # verdict on the real crates isn't trustworthy either.
 name: Token drift
 
-# NOT in branch protection's required-checks list (verified via
-# `gh api repos/.../branches/main/protection`, #5094), so a `paths-ignore` here
-# carries none of the "required check skipped -> pending forever" risk that
-# rules it out for ci.yml / line-cap.yml. `website/**` is excluded because it
-# is not one of the 7 enforced UI crates. `docs/**` stays IN scope:
-# docs/design/UI/design-system/tokens.css is this gate's canonical source.
+# Optional and dependency-free: trigger only for the canonical tokens, the
+# seven enforced consumer stylesheets, or the checker/workflow itself.
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "website/**"
+    paths:
+      - "docs/design/UI/design-system/tokens.css"
+      - "crates/trusty-agents/ui/src/app.css"
+      - "crates/trusty-code-gui/ui/src/app.css"
+      - "crates/trusty-mpm-gui/ui/src/app.css"
+      - "crates/trusty-console/ui/src/theme.css"
+      - "crates/trusty-analyze/ui/src/lib/styles/tokens.css"
+      - "crates/trusty-search/ui/src/lib/styles/tokens.css"
+      - "crates/trusty-memory/ui/src/lib/styles/tokens.css"
+      - "scripts/check_token_drift.mjs"
+      - "scripts/check_token_drift.test.mjs"
+      - ".github/workflows/token-drift.yml"
   pull_request:
     # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
     # (opened/synchronize/reopened) and is the event a base-branch RETARGET
@@ -43,8 +49,18 @@ on:
     # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
     types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
-    paths-ignore:
-      - "website/**"
+    paths:
+      - "docs/design/UI/design-system/tokens.css"
+      - "crates/trusty-agents/ui/src/app.css"
+      - "crates/trusty-code-gui/ui/src/app.css"
+      - "crates/trusty-mpm-gui/ui/src/app.css"
+      - "crates/trusty-console/ui/src/theme.css"
+      - "crates/trusty-analyze/ui/src/lib/styles/tokens.css"
+      - "crates/trusty-search/ui/src/lib/styles/tokens.css"
+      - "crates/trusty-memory/ui/src/lib/styles/tokens.css"
+      - "scripts/check_token_drift.mjs"
+      - "scripts/check_token_drift.test.mjs"
+      - ".github/workflows/token-drift.yml"
 
 # Per-COMMIT concurrency group on push so a merge never cancels the previous
 # merge's verification (#4179); per-ref group on pull_request so a new push
@@ -56,6 +72,7 @@ concurrency:
 jobs:
   token-drift:
     name: Foundry token drift check (all 7 UI crates)
+    if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -44,20 +44,21 @@
 #    not "loudly".
 name: Version parity
 
-# NOT in branch protection's required-checks list (verified via
-# `gh api repos/.../branches/main/protection`, #5094), so a `paths-ignore` here
-# carries none of the "required check skipped -> pending forever" risk that
-# rules it out for ci.yml / line-cap.yml. Both jobs compare `crates/*/Cargo.toml`
-# / `crates/*/src/**` against crates.io only — neither `website/**` nor
-# `docs/**` can move either verdict, so both are excluded. The push trigger's
-# exclusion cannot open a coverage gap: the `schedule` trigger below re-asks
-# the same question every 3 hours independent of what (if anything) pushed.
+# Optional workflow: PR and push events are limited to crate source/manifests
+# and the checkers themselves. The scheduled authority remains unfiltered and
+# re-asks the complete crates.io parity question every three hours.
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "website/**"
-      - "docs/**"
+    paths:
+      - "crates/*/src/**"
+      - "crates/*/Cargo.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "scripts/check-version-parity.sh"
+      - "scripts/check-pr-version-bump.sh"
+      - "scripts/check_scan_floor_selftest.sh"
+      - ".github/workflows/version-parity.yml"
   # Every three hours. Fine-grained enough that a publish is caught in one
   # working session, coarse enough to stay well inside crates.io's API-usage
   # policy (~21 sparse-index GETs + a tarball per published crate, per run).
@@ -71,9 +72,15 @@ on:
     # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
     types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
-    paths-ignore:
-      - "website/**"
-      - "docs/**"
+    paths:
+      - "crates/*/src/**"
+      - "crates/*/Cargo.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "scripts/check-version-parity.sh"
+      - "scripts/check-pr-version-bump.sh"
+      - "scripts/check_scan_floor_selftest.sh"
+      - ".github/workflows/version-parity.yml"
   workflow_dispatch: {}
 
 # Per-COMMIT concurrency group on push so a merge never cancels the previous
@@ -91,7 +98,7 @@ jobs:
   # minutes the post-merge job costs.
   pr-version-bump:
     name: "PR version bump vs crates.io (issue #4421)"
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && (github.event.action != 'edited' || github.event.changes.base != null)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -110,6 +110,14 @@ assert_eq "Cargo.toml"            "false" "$(docs_only_of 'Cargo.toml')"
 assert_eq "Cargo.lock"            "false" "$(docs_only_of 'Cargo.lock')"
 assert_eq "workflow file"         "false" "$(docs_only_of '.github/workflows/ci.yml')"
 assert_eq "script"                "false" "$(docs_only_of 'scripts/check_line_cap.sh')"
+assert_eq "ADR checker"           "true"  "$(docs_only_of 'scripts/check_adr.sh')"
+assert_eq "doc-number checker"    "true"  "$(docs_only_of 'scripts/check_doc_numbers.sh')"
+assert_eq "doc-number allowlist"  "true"  "$(docs_only_of '.doc-number-allowlist.tsv')"
+assert_eq "doc-number workflow"   "true"  "$(docs_only_of '.github/workflows/doc-numbers.yml')"
+assert_eq "SLD workflow wiring"   "true"  "$(docs_only_of '.github/workflows/sld-lint.yml')"
+assert_eq "SLD checker"           "true"  "$(docs_only_of 'scripts/check_sld.sh')"
+assert_eq "optional token gate"   "true"  "$(docs_only_of '.github/workflows/token-drift.yml')"
+assert_eq "capabilities wrapper"  "true"  "$(docs_only_of 'scripts/check_capabilities.sh')"
 assert_eq "UI source"             "false" "$(docs_only_of 'crates/trusty-agents/ui/src/App.svelte')"
 # The trap this denylist exists to avoid: markdown UNDER a crate's src/ is a
 # bundled agent/skill/instruction asset compiled in via include_dir!.
@@ -285,25 +293,31 @@ assert_eq "main-side parity also runs on a schedule (#4688)" "1" \
 # isolation.
 ci_wf=".github/workflows/ci.yml"
 assert_eq "ci.yml passes a base BRANCH, not base.sha" "1" \
-  "$(grep -c 'DOCS_ONLY_BASE: origin/\${{ github.event.pull_request.base.ref }}' \
+  "$(grep -c 'DOCS_ONLY_BASE="origin/\${{ github.event.pull_request.base.ref }}"' \
     "${ci_wf}" || true)"
 assert_eq "ci.yml no longer passes the frozen base.sha" "0" \
   "$(grep -c 'DOCS_ONLY_BASE: \${{ github.event.pull_request.base.sha }}' \
     "${ci_wf}" || true)"
+assert_eq "ci.yml classifies the push range instead of forcing full Cargo" "1" \
+  "$(grep -c 'DOCS_ONLY_BASE="\$before" bash scripts/detect-docs-only.sh' \
+    "${ci_wf}" || true)"
+assert_eq "ci.yml no-ops Cargo for title/body-only edits" "1" \
+  "$(grep -c 'title/body-only PR edit' "${ci_wf}" || true)"
 
-# capabilities-drift.yml grew its own `changes` job (reusing detect-docs-only.sh,
-# not a second predicate) so the tm-capabilities cargo build stops running
-# unconditionally on every PR. Same wiring guard, same reason: the script being
-# correct proves nothing if the workflow never passes it a live base.
+# capabilities-drift is optional, so it can use exact trigger paths instead of
+# paying for a duplicate checkout/classifier job on every PR.
 capabilities_wf=".github/workflows/capabilities-drift.yml"
-# 3 = every cargo-touching step in the job (toolchain install, cache, the
-# actual `check_capabilities.sh` run) — update this count if a step is added
-# or removed, the same way the count itself would need a human to notice.
-assert_eq "capabilities-drift.yml gates its cargo run on docs_only" "3" \
-  "$(grep -c "if: needs.changes.outputs.docs_only != 'true'" "${capabilities_wf}" || true)"
-assert_eq "capabilities-drift.yml passes a base BRANCH, not base.sha" "1" \
-  "$(grep -c 'DOCS_ONLY_BASE: origin/\${{ github.event.pull_request.base.ref }}' \
-    "${capabilities_wf}" || true)"
+assert_eq "capabilities-drift.yml has no duplicate classifier" "0" \
+  "$(grep -c '^  changes:' "${capabilities_wf}" || true)"
+assert_eq "capabilities-drift.yml scopes both events to trusty-mpm" "2" \
+  "$(grep -c '      - "crates/trusty-mpm/\*\*"' "${capabilities_wf}" || true)"
+
+# ADR consistency is a pure-shell document gate. Keep it beside document
+# allocation rather than installing Rust in the SLD workflow for ADR-only PRs.
+assert_eq "doc-numbers owns the ADR consistency step" "1" \
+  "$(grep -c 'run: bash scripts/check_adr.sh' .github/workflows/doc-numbers.yml || true)"
+assert_eq "SLD no longer runs the ADR consistency step" "0" \
+  "$(grep -c 'run: bash scripts/check_adr.sh' .github/workflows/sld-lint.yml || true)"
 
 # ---------------------------------------------------------------------------
 # ci-free-disk-space.sh (#5325)

--- a/scripts/detect-docs-only.sh
+++ b/scripts/detect-docs-only.sh
@@ -15,7 +15,9 @@
 # What: reads a newline-separated list of changed paths on stdin (or resolves
 #   one itself from git when given a base ref) and answers ONE question: does
 #   every changed path match a pattern that provably cannot affect a cargo
-#   build, test, clippy, or rustfmt result? Emits `docs_only=true|false` on
+#   build, test, clippy, or rustfmt result? Despite the legacy output name,
+#   `docs_only=true` therefore means "Cargo-inert", not literally "only files
+#   below docs/". Emits `docs_only=true|false` on
 #   stdout, and appends the same line to $GITHUB_OUTPUT when that is set.
 #
 #   The classification is a DENYLIST-of-inert, not an allowlist-of-code: a path
@@ -38,14 +40,17 @@
 #     crates/*/README.md
 #     crates/*/CHANGELOG.md
 #     crates/*/changelog.d/*       per-PR changelog fragments (#4476)
+#     selected docs-governance      pure shell gates and their configuration;
+#                                   these validate prose but cannot affect a
+#                                   Cargo result
 #
 #   Deliberately NOT inert, though they look like documentation:
 #     crates/*/src/**/*.md   — bundled agent/skill/instruction assets that are
 #                              compiled into binaries via include_dir!/
 #                              include_str!. Editing one changes program
 #                              output and breaks asset-pin and drift tests.
-#     scripts/**             — invoked by integration tests and by CI itself.
-#     .github/workflows/**   — a CI change must re-verify against real CI.
+#     other scripts/**       — may be invoked by integration tests or builds.
+#     other workflows/**     — unknown workflow changes fail closed.
 #     crates/*/changelog.d/*/*  — a NESTED fragment is already a defect the
 #                              changelog gate rejects; do not also exempt it.
 #
@@ -73,6 +78,31 @@ is_inert_path() {
   local -a seg
   IFS='/' read -r -a seg <<<"$p"
   local n=${#seg[@]}
+
+  # Documentation-governance inputs are executable CI configuration, but they
+  # are pure shell/text checks and cannot change a Rust build. Their own
+  # focused workflows still run, so treating them as Cargo-inert avoids
+  # Clippy/Test/MSRV/UI/CUDA work without weakening their verification.
+  case "$p" in
+    .doc-number-allowlist.tsv | \
+      .sld-lint-allowlist.tsv | \
+      .test-pointer-allowlist.tsv | \
+      scripts/check_adr.sh | \
+      scripts/check_doc_numbers.sh | \
+      scripts/check_sld.sh | \
+      scripts/check_test_pointers.sh | \
+      scripts/check_token_drift.mjs | \
+      scripts/check_token_drift.test.mjs | \
+      scripts/check_capabilities.sh | \
+      .github/workflows/doc-numbers.yml | \
+      .github/workflows/sld-lint.yml | \
+      .github/workflows/test-pointers.yml | \
+      .github/workflows/token-drift.yml | \
+      .github/workflows/capabilities-drift.yml | \
+      .github/workflows/version-parity.yml)
+      return 0
+      ;;
+  esac
 
   # docs/** — the project documentation tree, at any depth.
   if [ "$n" -ge 2 ] && [ "${seg[0]}" = "docs" ]; then


### PR DESCRIPTION
## Summary

- Treat documentation-governance scripts and workflow wiring as Cargo-inert while preserving every required CI context.
- Classify pushes to `main` instead of unconditionally repeating the complete Rust suite after Cargo-inert merges.
- Keep title/body-only PR edits from restarting expensive Cargo work; base retargets still run normally.
- Move the pure-shell ADR consistency check from the Rust SLD job into the document-number workflow.
- Replace broad optional-workflow exclusions with explicit input paths for SLD, test pointers, token drift, capabilities drift, and version parity.

## Root cause

The shared classifier exposed one coarse `docs_only` verdict and treated every script or workflow edit as code. A documentation PR that added or adjusted its own validation therefore triggered Clippy, tests, MSRV, CUDA, seven UI matrix legs, search smoke, and unrelated optional workflows. Several optional workflows also used broad `paths-ignore` rules, so unrelated new repository paths opted into them automatically.

## Impact

Required check names continue to report. Unknown central CI inputs still fail closed into the complete suite. Focused optional gates run only when their observed inputs change, and ADR-only work no longer installs Rust for SLD. The merged ADR change from #5392 classifies as Cargo-inert under these rules.

## Validation

- `actionlint` on all seven changed workflows
- `bash scripts/check-ci-helpers-selftest.sh` (81 cases)
- `shellcheck scripts/detect-docs-only.sh`
- `bash scripts/check_adr.sh`
- `bash scripts/check_doc_numbers.sh`
- simulated classification of #5392: `docs_only=true`
- `git diff --check`