### PR TITLE
docs: align ADR corpus with DOC-46

### DIFF
--- a/.github/workflows/doc-numbers.yml
+++ b/.github/workflows/doc-numbers.yml
@@ -83,5 +83,8 @@ jobs:
       - name: Enforce DOC-N / ADR number allocation (ratcheted allowlist)
         run: bash scripts/check_doc_numbers.sh
 
+      - name: Test ADR consistency checker
+        run: scripts/check_adr.sh --self-test
+
       - name: Check ADR corpus consistency
         run: bash scripts/check_adr.sh

--- a/docs/adr/0014-native-mcp-support.md
+++ b/docs/adr/0014-native-mcp-support.md
@@ -3,6 +3,12 @@
 - **Status:** Amended by [0040](0040-trusty-mcp-services-absorbs-trusty-gworkspace.md), [0041](0041-trusty-okg-native-crate-search-absorbs-okf-indexing.md)
 - **Date:** 2026-07-14
 - **Scope:** Workspace-wide
+- **Reversibility Cost:** High — MCP service packaging, shared protocol
+  primitives, and the single-language distribution model affect multiple
+  crates and installed integrations.
+- **Decision Drivers:** Single Rust toolchain, one installation and signing
+  path, shared MCP contracts and observability, avoidance of third-party
+  runtime dependencies
 - **Supersedes / Superseded by:** ADR-0040 changes the MCP framework and service
   packaging; ADR-0041 applies that consumer-boundary rule to trusty-okg. The
   native, in-workspace Rust decision remains in force.

--- a/docs/adr/0015-three-product-agent-composition-model.md
+++ b/docs/adr/0015-three-product-agent-composition-model.md
@@ -3,6 +3,11 @@
 - **Status:** Proposed
 - **Date:** 2026-07-18
 - **Scope:** Workspace-wide (trusty-agents, trusty-mpm, trusty-code)
+- **Reversibility Cost:** High — the source format, inheritance semantics, and
+  cross-product composition model shape three products and their shared parser.
+- **Decision Drivers:** Eliminate parser duplication, preserve product-specific
+  composition semantics, share deterministic `extends` resolution, keep
+  cross-product delegation behind explicit proxies
 - **Supersedes / Superseded by:** — (complements DOC-37, issues #2791/#2792)
 
 ## Context

--- a/docs/adr/0016-orchestration-hierarchy-lead-pm-assistant.md
+++ b/docs/adr/0016-orchestration-hierarchy-lead-pm-assistant.md
@@ -3,6 +3,11 @@
 - **Status:** Proposed
 - **Date:** 2026-07-18
 - **Scope:** Workspace-wide (trusty-agents, trusty-mpm, trusty-code)
+- **Reversibility Cost:** High — role cardinality and authority boundaries shape
+  control-bus addressing, session ownership, and cross-product orchestration.
+- **Decision Drivers:** Single-workstream PM ownership, explicit consolidation
+  scope, preservation of Assistant-only user authority, alignment with DOC-36
+  and DOC-41
 - **Supersedes / Superseded by:** — (consolidates DOC-36 tm-manager-vision;
   to be reconciled with DOC-42 / PR #3006)
 

--- a/docs/adr/0017-shared-ingress-via-console-tailscale-funnel.md
+++ b/docs/adr/0017-shared-ingress-via-console-tailscale-funnel.md
@@ -3,6 +3,12 @@
 - **Status:** Proposed
 - **Date:** 2026-07-19
 - **Scope:** Workspace-wide (trusty-mpm, trusty-console, integrations)
+- **Reversibility Cost:** Medium — ingress routing and public exposure are
+  localized, but changing them affects every webhook integration and its
+  security boundary.
+- **Decision Drivers:** One externally auditable ingress seam, console-owned
+  HTTP exposure, localhost containment for trusty-mpm, zero-cloud default,
+  managed TLS without inbound firewall configuration
 - **Supersedes / Superseded by:** —
 - **Related Specs:** DOC-47 (external event ingestion); ADR-0005 (event bus); ADR-0011 (console as single HTTP surface)
 

--- a/docs/adr/0022-knowledge-tree-sync-model.md
+++ b/docs/adr/0022-knowledge-tree-sync-model.md
@@ -5,6 +5,7 @@
 - **Scope:** Workspace-wide (trusty-agents multi-machine sync, trusty-tools monorepo policy)
 - **Reversibility Cost:** Low — the decision defers knowledge-tree sync to a follow-up; implementations of config-only (Phase 1–4 of DOC-56) are unaffected and remain shippable
 - **Decision Drivers:** Knowledge tree growth profile (unbounded, per DOC-55 extractors/connectors), storage coupling (config vs. corpus have opposite constraints), merge semantics (append-only ledgers produce multi-machine conflicts), data sensitivity (distinct content classes require distinct repos), independent lifecycle (knowledge trees are regenerable by ingest; configs are hand-curated)
+- **Supersedes / Superseded by:** —
 - **Closes DOC-56 §5.3:** Open question left for owner sign-off
 
 ## Context

--- a/docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md
+++ b/docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md
@@ -6,9 +6,9 @@
   three-tool-call router and assistant-to-assistant communication primitive;
   acceptance records the architectural choice, not implementation completion.
   See "Implementation status" for the clause-by-clause state.
-- **Date:** 2026-07-28 (ratification of the L0-assistant clause recorded
-  2026-07-28; ratification of the editable-whitelist clause recorded
-  2026-07-29)
+- **Date:** 2026-07-28
+- **Ratification:** L0-assistant clause recorded 2026-07-28;
+  editable-whitelist clause recorded 2026-07-29
 - **Scope:** crate `trusty-agents` (the `delegate_to_agent` / `dispatch_task` boundary; the L0/L1 tier model, #4167/#4200; touches the `trusty-code` cross-product bridge target and the Sub-agents API/pane, `#4029`/`#4211`)
 - **Reversibility Cost:** High — reverses/re-scopes shipped, tested, owner-directed machinery from epic #4021 (#4026/#4027/#4028/#4211, merged within 48 hours of this ADR), INVERTS the population assignment of the L0/L1 tier model merged the SAME DAY as this decision (PR #4200, squash `ada4d351`), and requires new, currently nonexistent machinery (an editable sub-agent whitelist, an assistant-to-assistant messaging primitive, and a tool-call-counted skill/delegate router)
 - **Decision Drivers:** Product framing clarity (the Sub-agents pane could not honestly present a name that means two different things), the owner's rejection of a UI-only fix, the owner's explicit generalization of the YOLO risk posture to every assistant, a documentation gap (DOC-57 does not yet cover Sub-agents at all, #4182), the owner's own PM/trusty-mpm prior art as an explicit analogy with an owner-named limit, and — underlying all of the above — the owner's virtual-twin authority principle (see "Rationale" below): each assistant must take authority over its own actions, and that authority is not transferable between assistants

--- a/docs/adr/0029-msrv-1-94-and-edition-policy.md
+++ b/docs/adr/0029-msrv-1-94-and-edition-policy.md
@@ -3,6 +3,12 @@
 - **Status:** Accepted
 - **Date:** 2026-08-05
 - **Scope:** Workspace-wide
+- **Reversibility Cost:** High — lowering the floor would require dependency
+  pinning or feature-boundary changes across every crate that consumes the AWS
+  SDK, while raising it changes the supported compiler contract workspace-wide.
+- **Decision Drivers:** AWS SDK MSRV constraints, reproducible `cargo install`
+  behavior without `--locked`, continued access to dependency security and
+  model updates, one workspace compiler floor
 - **Supersedes / Superseded by:** Supersedes [0003](./0003-msrv-and-edition-policy.md)
 
 ## Context

--- a/docs/adr/0040-trusty-mcp-services-absorbs-trusty-gworkspace.md
+++ b/docs/adr/0040-trusty-mcp-services-absorbs-trusty-gworkspace.md
@@ -356,6 +356,30 @@ integration is real follow-up, not built here. `#4644` (no CI gate for
 skill byte-parity) is made more urgent by this design's copy-multiplication
 at scale — not resolved, not edited here.
 
+## Consequences
+
+**Easier / positive:**
+
+- MCP-only consumers depend on the focused `trusty-mcp` protocol crate rather
+  than pulling the full `trusty-common` feature surface.
+- Agent-consumed services gain one publishable, registry-driven host while
+  keeping service-owned dependencies and bundled skills together.
+- The agent-consumer/framework-consumer rule gives later capability work a
+  repeatable boundary test instead of deciding from crate names.
+
+**Harder / negative:**
+
+- Removing `trusty_common::mcp` is a breaking change and requires coordinated
+  import migration across ten verified consumers.
+- `trusty-mcp-services` adds registry and packaging machinery, and its skill
+  assets still need an explicit cross-crate deployment path.
+- The native future of `trusty-channels`, `trusty-kb`'s final disposition, and
+  a normative spec home for the consumer rule remain follow-up decisions.
+
+**Neutral / deferred:** WASM isolation remains deferred until a third-party
+service cannot be compiled into the host or native build-health pressure makes
+the link-time registry insufficient.
+
 ## Where the agent-consumer / framework-consumer rule lives
 
 The owner: "We should include this distinction in the spec." This makes the

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,12 @@ ADR; its Context, Decision, and Consequences remain historical. We use the
 (Title, Status, Context, Decision, Consequences) plus a **"Related Decisions"**
 section documenting consistency vetting (see DOC-46 §3).
 
+ADR-0001..0013 predate DOC-46's modern metadata and Related Decisions
+template. They are structurally grandfathered: their historical sections are
+not rewritten for template conformity, while their statuses, successor links,
+numbering, and index entries remain governed. ADR-0014 and later must satisfy
+the current template fields and core-section checks.
+
 ## When to write one (the bar)
 
 Write an ADR when a decision is **architecturally significant *and* costly to
@@ -51,7 +57,7 @@ maintain **independent** numbering sequences. Never renumber an existing ADR.
 ## Status lifecycle
 
 ```
-Proposed ──► Accepted ──► Superseded by NNNN
+Proposed ──► Accepted ──► Superseded by linked NNNN
        └────► Rejected
 
        ┌────────────────┐
@@ -63,8 +69,9 @@ Proposed ──► Accepted ──► Superseded by NNNN
 - **Proposed** — drafted, under discussion. Consistency vetting is optional while Proposed, but required before acceptance.
 - **Accepted** — agreed and in force. All Accepted ADRs form the current decision set.
 - **Rejected** — considered but not adopted (kept for the record).
-- **Superseded by NNNN** — replaced by a later ADR; links to the new ADR. Old decision no longer in force.
-- **Amended by NNNN[, NNNN…]** — refined (not replaced) by one or more later
+- **Superseded by linked NNNN** — replaced by a later ADR; the Status value
+  links to the new ADR. Old decision no longer in force.
+- **Amended by linked NNNN[, NNNN…]** — refined (not replaced) by one or more later
   ADRs. The prior decision remains in force together with every listed amendment.
 
 ## Writing a new ADR

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,6 +1,8 @@
 # NNNN. <Short Title of Decision>
 
 - **Status:** Proposed
+<!-- Later lifecycle targets must be links: `Superseded by [MMMM](MMMM-title.md)`
+or `Amended by [MMMM](MMMM-title.md)`. -->
 - **Date:** YYYY-MM-DD
 - **Scope:** Workspace-wide (or: crate `<name>` or subsystem `<name>`)
 - **Reversibility Cost:** (Low | Medium | High) — cost to undo this choice later

--- a/docs/specs/DOC-46-adr-standard.md
+++ b/docs/specs/DOC-46-adr-standard.md
@@ -74,18 +74,23 @@ Operationally: ADRs remain **high-bar** (rare). A typical quarter may produce 1�
 
 ### Required Frontmatter & Fields
 
-Every ADR must carry:
+Every ADR created after the grandfathered ADR-0001..0013 baseline must carry:
 
 ```markdown
 # NNNN. <Short Title of Decision>
 
-- **Status:** Proposed | Accepted | Rejected | Superseded by MMMM | Amended by MMMM[, NNNN…]
+- **Status:** Proposed | Accepted | Rejected | Superseded by [MMMM](MMMM-title.md) | Amended by [MMMM](MMMM-title.md)[, [NNNN](NNNN-title.md)…]
 - **Date:** YYYY-MM-DD
 - **Scope:** Workspace-wide (or: crate `<name>` or subsystem `<name>`)
 - **Reversibility Cost:** (Low | Medium | High) — cost to undo this later
 - **Decision Drivers:** (Comma-separated list of forces: e.g., "MSRV constraint, performance ceiling, cross-crate boundary")
-- **Cross-ref to related decisions:** (see "Related Decisions" section below)
+- **Supersedes / Superseded by:** (link each lifecycle relationship, or `—`)
 ```
+
+ADR-0001..0013 predate this metadata block and are structurally
+grandfathered. Their historical Context, Decision, and Consequences are not
+rewritten merely to match a later template. Their status and successor
+backlinks still participate in lifecycle and consistency checks.
 
 ### Core Sections (Nygard Format)
 
@@ -115,8 +120,10 @@ No prior decisions contradict this choice. Summary: Consistent with existing dec
 **Verdict codes:**
 - **Consistent** — aligns with prior decision; no conflict.
 - **Extends** — builds on a prior decision; compatible evolution.
-- **Supersedes** — replaces a prior decision. **Action:** flip old ADR's status to `Superseded by NNNN`.
-- **Amended by** — refines (rather than replaces) a prior decision. **Action:** old ADR status becomes `Amended by NNNN`.
+- **Supersedes** — replaces a prior decision. **Action:** flip the old ADR's
+  status to a linked `Superseded by [NNNN](NNNN-title.md)` target.
+- **Amended by** — refines (rather than replaces) a prior decision. **Action:**
+  the old ADR status becomes linked `Amended by [NNNN](NNNN-title.md)`.
 - **Conflict (resolved)** — contradicts a prior decision. **Action:** must document *how* the conflict was resolved (e.g., which takes precedence, or both are valid in different scopes). **Note:** shipping an ADR that conflicts with an accepted one without resolving the conflict is a lint failure and blocks PR merge.
 
 **Vetting scope:**
@@ -159,8 +166,9 @@ No prior decisions contradict this choice. Summary: Consistent with existing dec
 
 - **Proposed** — draft, under review. Consistency vetting is optional while Proposed, but required before acceptance.
 - **Accepted** — approved, in force. All Accepted ADRs form the current decision set; they govern system architecture and future decisions.
-- **Superseded by NNNN** — replaced by a later ADR. Links to the new ADR. Old decision is no longer in force; the new one takes precedence.
-- **Amended by NNNN[, NNNN…]** — refined (not replaced) by one or more later
+- **Superseded by linked NNNN** — replaced by a later ADR. The Status value
+  links to the new ADR. Old decision is no longer in force; the new one takes precedence.
+- **Amended by linked NNNN[, NNNN…]** — refined (not replaced) by one or more later
   ADRs. The prior decision is still in force together with every amendment.
 - **Rejected** — considered but not adopted. Kept for the record so the same choice is not re-litigated.
 
@@ -173,7 +181,7 @@ No prior decisions contradict this choice. Summary: Consistent with existing dec
 The index is the **single source of truth** for the ADR corpus and the **cheap surface for vetting**.
 
 ```markdown
-# ADR Index — Accepted Decisions
+# ADR Index — All Decisions
 
 Last updated: 2026-07-19 | Format version: 1.0
 
@@ -210,19 +218,23 @@ documentation lint workflow.
 
 1. **Unique numbering:** each file matches pattern `docs/adr/NNNN-*.md` with NNNN in 0000–9999 range; no duplicates.
 2. **Sequential continuity:** if files are numbered 0001–0013, there are no gaps (e.g., no 0002 missing).
-3. **Status field validity:** Status is one of {Proposed, Accepted, Rejected, Superseded by NNNN, Amended by NNNN}.
+3. **Status field validity:** Status is one of {Proposed, Accepted, Rejected,
+   Superseded by linked NNNN, Amended by one or more linked NNNN targets}.
 4. **Supersedes bidirectionality:** if ADR-0003 says "Superseded by 0010", then ADR-0010 must cite ADR-0003 in its "Related Decisions" section. (Detect orphaned supersedes links.)
 5. **INDEX.md in sync:** every ADR file in `docs/adr/` with number NNNN ≥ 0001 must have an entry in `docs/adr/INDEX.md`; conversely, every index entry must have a corresponding file on disk.
+6. **Modern record shape:** ADR-0014 and later use lowercase kebab-case
+   filenames, carry the Date, Scope, Reversibility Cost, Decision Drivers, and
+   lifecycle-link fields, and have non-empty Context, Decision, and
+   Consequences sections. ADR-0001..0013 retain the grandfathering above.
 
 **Phase 2 (Human/LLM Review, NOT Mechanical Check):**
 - **Semantic consistency:** if two Accepted ADRs make mutually exclusive claims, identify the contradiction and require manual resolution in "Related Decisions" or status change. This check is advisory and requires human or LLM judgment — not automated.
 
-**Recommended command-line interface:**
+**Command-line interface:**
 
 ```bash
 bash scripts/check_adr.sh               # exit 0 if all checks pass
-bash scripts/check_adr.sh --index-only  # only verify INDEX.md sync
-bash scripts/check_adr.sh --verbose     # detailed per-ADR report
+bash scripts/check_adr_selftest.sh      # mutation-test the gate itself
 ```
 
 **CI integration:** Add to `.github/workflows/` as a gated check (fail on violation). The check runs on all PRs that touch `docs/adr/` or `docs/specs/`.
@@ -298,7 +310,10 @@ Write an ADR when:
 
 ### Existing ADRs (0001–0013)
 
-Current ADRs are **grandfathered as Accepted** without re-vetting. They form the baseline decision set.
+ADRs 0001–0013 are **grandfathered without structural backfill or retrospective
+vetting**. They form the baseline decision set while retaining the lifecycle
+status each file currently records; grandfathering does not change a rejected,
+superseded, or amended record into Accepted.
 
 **Action (Phase 1, this PR):**
 - Seed `docs/adr/INDEX.md` from existing ADR files
@@ -400,7 +415,7 @@ This spec is successful when:
 2. **Consistency is enforced** — new ADRs are vetted against priors before acceptance; "Related Decisions" section prevents silent contradictions
 3. **Discovery is cheap** — `docs/adr/INDEX.md` is the quick reference; anyone can scan for related decisions in seconds
 4. **Workflow is clear** — PMs and architects follow a consistent process: draft → vet (consistency check) → approve → accept
-5. **CI catches violations** — `scripts/check_adr.sh` runs on all ADR PRs and fails if numbering, status, or bidirectional-link rules are broken (checks 1–5 in §6)
+5. **CI catches violations** — `scripts/check_adr.sh` runs on all ADR PRs and fails if numbering, modern metadata/sections, status, or bidirectional-link rules are broken (checks 1–6 in §6)
 
 ---
 
@@ -414,7 +429,7 @@ This spec is successful when:
 | `docs/reference/documentation-layout.md` | Update: mention ADRs alongside Specs and Reqs as first-class artifacts |
 | `crates/trusty-mpm/src/assets/skills/tm-adr.md` | Update: remove "opt-in" framing; link to DOC-46 for formal standard (bundled asset v2.0.0) |
 | `CHANGELOG.md` | Entry (per CHANGELOG-per-PR convention): "docs(spec): DOC-46 — formalize ADRs as first-class artifact with consistency-vetting protocol" |
-| `scripts/check_adr.sh` | FUTURE (follow-up issue): implement linting checks |
+| `scripts/check_adr.sh` | Implemented: structural, lifecycle-link, metadata, section, numbering, and index checks |
 
 ---
 
@@ -424,4 +439,4 @@ This spec is successful when:
 - `docs/adr/README.md` — existing ADR convention for trusty-tools
 - DOC-38 — Spec-Linked Documentation (SLD) standard
 - DOC-30 — Project Manager vision & lifecycle orchestration
-- The tm-adr bundled skill — current opt-in convention
+- The tm-adr bundled skill — current formal authoring workflow

--- a/scripts/check_adr.sh
+++ b/scripts/check_adr.sh
@@ -3,10 +3,13 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="${ADR_CHECK_REPO_ROOT:-$SCRIPT_REPO_ROOT}"
 ADR_DIR="$REPO_ROOT/docs/adr"
 INDEX="$ADR_DIR/INDEX.md"
 errors=0
+
+shopt -s nullglob
 
 fail() {
   printf 'adr-check: %s\n' "$*" >&2
@@ -16,6 +19,131 @@ fail() {
 canonical_status() {
   sed -E 's/\[([^]]+)\]\([^)]+\)/\1/g' <<<"$1"
 }
+
+field_value() {
+  local label="$1"
+  local file="$2"
+  awk -v prefix="- **${label}:** " '
+    /^## Context$/ { exit }
+    index($0, prefix) == 1 { print substr($0, length(prefix) + 1); exit }
+  ' "$file"
+}
+
+section_has_body() {
+  local section="$1"
+  local file="$2"
+  awk -v heading="## ${section}" '
+    $0 == heading { inside=1; next }
+    inside && /^## / { exit }
+    inside && $0 !~ /^[[:space:]]*$/ { found=1 }
+    END { exit(found ? 0 : 1) }
+  ' "$file"
+}
+
+run_selftest() {
+  local tmp_root passes failures
+  tmp_root="$(mktemp -d)"
+  trap 'rm -rf "$tmp_root"' RETURN
+  passes=0
+  failures=0
+
+  fixture() {
+    local name="$1"
+    local root="$tmp_root/$name"
+    mkdir -p "$root/docs"
+    cp -R "$SCRIPT_REPO_ROOT/docs/adr" "$root/docs/adr"
+    printf '%s\n' "$root"
+  }
+
+  expect_rejects() {
+    local label="$1"
+    local root="$2"
+    local expected="$3"
+    local output
+    if output="$(ADR_CHECK_REPO_ROOT="$root" bash "$SCRIPT_REPO_ROOT/scripts/check_adr.sh" 2>&1)"; then
+      printf 'FAIL: %s unexpectedly passed\n' "$label" >&2
+      failures=$((failures + 1))
+    elif grep -qF "$expected" <<<"$output"; then
+      printf '  ok   %s\n' "$label"
+      passes=$((passes + 1))
+    else
+      printf 'FAIL: %s rejected for the wrong reason; expected %q in:\n%s\n' \
+        "$label" "$expected" "$output" >&2
+      failures=$((failures + 1))
+    fi
+  }
+
+  local baseline metadata date_case section vetting filename
+  baseline="$(fixture baseline)"
+  if ADR_CHECK_REPO_ROOT="$baseline" bash "$SCRIPT_REPO_ROOT/scripts/check_adr.sh" >/dev/null; then
+    printf '  ok   clean corpus passes\n'
+    passes=$((passes + 1))
+  else
+    printf 'FAIL: clean corpus did not pass\n' >&2
+    failures=$((failures + 1))
+  fi
+
+  metadata="$(fixture metadata)"
+  sed '/^- \*\*Reversibility Cost:\*\*/d' \
+    "$metadata/docs/adr/0014-native-mcp-support.md" >"$metadata/adr.tmp"
+  mv "$metadata/adr.tmp" "$metadata/docs/adr/0014-native-mcp-support.md"
+  expect_rejects "missing modern metadata" "$metadata" \
+    "0014-native-mcp-support.md has no non-empty Reversibility Cost field"
+
+  date_case="$(fixture date)"
+  sed 's/^- \*\*Date:\*\* 2026-07-14$/- **Date:** July 14, 2026/' \
+    "$date_case/docs/adr/0014-native-mcp-support.md" >"$date_case/adr.tmp"
+  mv "$date_case/adr.tmp" "$date_case/docs/adr/0014-native-mcp-support.md"
+  expect_rejects "non-ISO date" "$date_case" \
+    "0014-native-mcp-support.md Date is not YYYY-MM-DD"
+
+  section="$(fixture section)"
+  sed 's/^## Consequences$/## Outcomes/' \
+    "$section/docs/adr/0040-trusty-mcp-services-absorbs-trusty-gworkspace.md" \
+    >"$section/adr.tmp"
+  mv "$section/adr.tmp" \
+    "$section/docs/adr/0040-trusty-mcp-services-absorbs-trusty-gworkspace.md"
+  expect_rejects "missing core section" "$section" \
+    "0040-trusty-mcp-services-absorbs-trusty-gworkspace.md has no Consequences section"
+
+  vetting="$(fixture vetting)"
+  sed 's/^## Related Decisions$/## Prior Decisions/' \
+    "$vetting/docs/adr/0044-main-checkout-write-boundary-and-agent-worktree-ownership.md" \
+    >"$vetting/adr.tmp"
+  mv "$vetting/adr.tmp" \
+    "$vetting/docs/adr/0044-main-checkout-write-boundary-and-agent-worktree-ownership.md"
+  expect_rejects "missing accepted-ADR vetting" "$vetting" \
+    "0044-main-checkout-write-boundary-and-agent-worktree-ownership.md is in force but has no Related Decisions section"
+
+  filename="$(fixture filename)"
+  mv "$filename/docs/adr/0014-native-mcp-support.md" \
+    "$filename/docs/adr/0014-Native-MCP-support.md"
+  sed 's/0014-native-mcp-support.md/0014-Native-MCP-support.md/' \
+    "$filename/docs/adr/INDEX.md" >"$filename/index.tmp"
+  mv "$filename/index.tmp" "$filename/docs/adr/INDEX.md"
+  expect_rejects "non-kebab filename" "$filename" \
+    "0014-Native-MCP-support.md does not use NNNN-lowercase-kebab.md naming"
+
+  if ((failures > 0)); then
+    printf 'check_adr self-test: %d/%d mutation case(s) failed\n' \
+      "$failures" "$((passes + failures))" >&2
+    return 1
+  fi
+
+  printf 'check_adr self-test: all %d cases passed\n' "$passes"
+}
+
+case "${1:-}" in
+  --self-test)
+    run_selftest
+    exit
+    ;;
+  "") ;;
+  *)
+    printf 'usage: %s [--self-test]\n' "${0##*/}" >&2
+    exit 2
+    ;;
+esac
 
 mapfile -t files < <(find "$ADR_DIR" -maxdepth 1 -type f \
   -name '[0-9][0-9][0-9][0-9]-*.md' -print | sort)
@@ -31,6 +159,10 @@ for file in "${files[@]}"; do
   base="${file##*/}"
   number="${base%%-*}"
   numeric=$((10#$number))
+
+  if [[ ! "$base" =~ ^[0-9]{4}-[a-z0-9]+(-[a-z0-9]+)*[.]md$ ]]; then
+    fail "$base does not use NNNN-lowercase-kebab.md naming"
+  fi
 
   if [[ -n "${seen[$number]:-}" ]]; then
     fail "duplicate ADR number $number: ${seen[$number]} and $base"
@@ -48,9 +180,34 @@ for file in "${files[@]}"; do
     fail "$base heading does not self-identify as $number"
   fi
 
-  status="$(sed -n '1,20p' "$file" | sed -nE 's/^- \*\*Status:\*\* (.*)$/\1/p' | head -1)"
+  for section in Context Decision Consequences; do
+    if ! grep -q "^## ${section}$" "$file"; then
+      fail "$base has no ${section} section"
+    elif ! section_has_body "$section" "$file"; then
+      fail "$base has an empty ${section} section"
+    fi
+  done
+
+  # DOC-46 grandfathered ADR-0001..0013 without structural backfill. Every
+  # record created after that baseline must carry the modern metadata block.
+  if ((numeric >= 14)); then
+    for label in Date Scope "Reversibility Cost" "Decision Drivers" \
+      "Supersedes / Superseded by"; do
+      value="$(field_value "$label" "$file")"
+      if [[ -z "$value" ]]; then
+        fail "$base has no non-empty $label field before Context"
+      fi
+    done
+
+    date="$(field_value Date "$file")"
+    if [[ -n "$date" && ! "$date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+      fail "$base Date is not YYYY-MM-DD: $date"
+    fi
+  fi
+
+  status="$(field_value Status "$file")"
   if [[ -z "$status" ]]; then
-    fail "$base has no Status field in its first 20 lines"
+    fail "$base has no Status field before Context"
     continue
   fi
 
@@ -75,12 +232,7 @@ for file in "${files[@]}"; do
   if ((numeric >= 14)) && [[ "$status" != "Proposed" && "$status" != "Rejected" ]]; then
     if ! grep -q '^## Related Decisions$' "$file"; then
       fail "$base is in force but has no Related Decisions section"
-    elif ! awk '
-      /^## Related Decisions$/ { inside=1; next }
-      inside && /^## / { exit }
-      inside && /^- / { found=1 }
-      END { exit(found ? 0 : 1) }
-    ' "$file"; then
+    elif ! section_has_body "Related Decisions" "$file"; then
       fail "$base has an empty Related Decisions section"
     fi
   fi


### PR DESCRIPTION
## Summary

- Compare all 44 workspace ADRs against DOC-46 and align post-baseline records with the modern metadata and core-section requirements.
- Clarify that ADR-0001 through ADR-0013 are structurally grandfathered without changing their recorded lifecycle statuses.
- Add missing decision metadata to ADR-0014, 0015, 0016, 0017, and 0029; add the missing lifecycle field to ADR-0022; normalize ADR-0024 date handling; and add the canonical Consequences section to ADR-0040.
- Align DOC-46, the ADR README, and the template on linked successor statuses, live-index numbering, supported checker commands, and the actual all-status index.
- Strengthen scripts/check_adr.sh to enforce lowercase kebab filenames, modern metadata, ISO dates, and non-empty Context/Decision/Consequences sections.
- Add an integrated mutation-test mode and run it in the documentation workflow.
- Keep the complete PR diff Cargo-inert so documentation changes do not run Rust, MSRV, Clippy, or CUDA work.

## Root cause

DOC-46 described more structure than the checker enforced, while also containing stale implementation notes and an ambiguous grandfathering statement. Several ADRs after the grandfather boundary therefore lacked required fields or a canonical core section even though the existing consistency check was green.

The first version of this PR also changed a compiled bundled asset and central CI-classifier tests. Those paths intentionally fail closed to the full suite. The revised patch removes those triggers and keeps validation in the existing docs-only ADR checker.

## Impact

The ADR corpus, authoring guidance, specification, and CI gate now describe and enforce the same contract. Historical ADR-0001 through ADR-0013 remain intact; ADR-0014 and later are mechanically checked against the modern shape.

All 13 changed paths classify as docs_only=true. Required Format and MSRV check contexts may still appear for branch protection, but their Cargo work is skipped. The capabilities-drift workflow no longer matches this PR.

## Validation

- scripts/check_adr.sh --self-test — all 6 mutation cases pass
- scripts/check_adr.sh — 44 ADRs consistent
- scripts/check_doc_numbers.sh
- scripts/check_sld.sh
- scripts/check-ci-helpers-selftest.sh — all 81 cases pass
- actionlint .github/workflows/doc-numbers.yml
- shellcheck scripts/check_adr.sh
- exact PR diff through scripts/detect-docs-only.sh — docs_only=true
- git diff --check