### PR TITLE
ci: scope embedder CUDA check to trusty-common

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      embedder_cuda_relevant: ${{ steps.detect-cuda.outputs.embedder_cuda_relevant }}
     steps:
       # fetch-depth: 0 — the detector needs `git merge-base` against the base
       # branch, which a shallow checkout cannot resolve.
@@ -229,6 +230,31 @@ jobs:
             exit 0
           fi
           DOCS_ONLY_BASE="$before" bash scripts/detect-docs-only.sh > /dev/null
+
+      - name: Classify embedder CUDA relevance
+        id: detect-cuda
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ github.event.action }}" = "edited" ] && \
+             [ "${{ toJSON(github.event.changes.base) }}" = "null" ]; then
+            echo "metadata-only PR edit — no CUDA-relevant change"
+            echo "embedder_cuda_relevant=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CUDA_SCOPE_BASE="origin/${{ github.event.pull_request.base.ref }}" \
+              bash scripts/detect-embedder-cuda-relevant.sh > /dev/null
+            exit 0
+          fi
+
+          before="${{ github.event.before }}"
+          if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
+            echo "push has no usable before SHA — running CUDA check fail closed"
+            echo "embedder_cuda_relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CUDA_SCOPE_BASE="$before" bash scripts/detect-embedder-cuda-relevant.sh > /dev/null
 
   # --------------------------------------------------------------------------
   # fmt: enforce cargo fmt --all --check (stable toolchain + rustfmt component)
@@ -1076,13 +1102,10 @@ jobs:
   embedder-cuda-check:
     name: embedder-cuda compile check (#3508)
     needs: [changes]
-    # #4179: `needs:` alone would make this job SKIP when `changes` fails, and
-    # GitHub reports a skipped required check as PASSING — reintroducing the
-    # fail-open hole this PR exists to close. `!cancelled()` overrides the
-    # implicit success() so the job still runs; `docs_only` then resolves to
-    # '' and every gated step runs, i.e. a broken classifier costs a FULL
-    # build, never a silent skip.
-    if: ${{ !cancelled() }}
+    # This is not a required branch-protection context, so unlike the five
+    # workspace-wide required jobs it can skip at job level without leaving a
+    # PR pending. An absent classifier output still runs the job (fail closed).
+    if: ${{ !cancelled() && needs.changes.outputs.embedder_cuda_relevant != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -1091,11 +1114,9 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install stable toolchain
-        if: needs.changes.outputs.docs_only != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install system dependencies
-        if: needs.changes.outputs.docs_only != 'true'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
@@ -1106,7 +1127,6 @@ jobs:
       # nvcc ONLY — see the job-level comment above for why the compiler
       # (not a GPU, not a driver) is a genuine, unavoidable requirement here.
       - name: Install nvcc (CUDA 12.8 compiler only; no driver, no GPU)
-        if: needs.changes.outputs.docs_only != 'true'
         run: |
           wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
@@ -1116,17 +1136,14 @@ jobs:
           echo "/usr/local/cuda-12.8/bin" >> "$GITHUB_PATH"
 
       - name: Verify nvcc is on PATH
-        if: needs.changes.outputs.docs_only != 'true'
         run: nvcc --version
 
       - name: Cache cargo artifacts
-        if: needs.changes.outputs.docs_only != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           key: embedder-cuda-check
 
       - name: cargo check -p trusty-common --features embedder-cuda --all-targets
-        if: needs.changes.outputs.docs_only != 'true'
         run: cargo check -p trusty-common --features embedder-cuda --all-targets
 
   # --------------------------------------------------------------------------
@@ -1456,6 +1473,7 @@ jobs:
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
       [
+        changes,
         fmt,
         clippy,
         test,
@@ -1481,7 +1499,7 @@ jobs:
             test=${{ needs.test.result }}
             msrv=${{ needs.msrv.result }}
             agents-ui=${{ needs['agents-ui'].result }}
-            embedder-cuda-check=${{ needs['embedder-cuda-check'].result }}
+            embedder-cuda-check=${{ needs.changes.outputs.embedder_cuda_relevant != 'false' && needs['embedder-cuda-check'].result || 'success' }}
             ui-checks=${{ needs['ui-checks'].result }}
             search-daemon-smoke=${{ needs['search-daemon-smoke'].result }}
         run: bash scripts/classify-ci-results.sh > /dev/null

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -130,6 +130,40 @@ crates/trusty-mpm/src/lib.rs')"
 assert_eq "empty (fail closed)"   "false" "$(docs_only_of '')"
 
 # ---------------------------------------------------------------------------
+# detect-embedder-cuda-relevant.sh
+# ---------------------------------------------------------------------------
+cuda_relevant_of() {
+  printf '%s' "$1" | bash scripts/detect-embedder-cuda-relevant.sh 2>/dev/null |
+    sed -n 's/^embedder_cuda_relevant=//p'
+}
+
+echo
+echo "detect-embedder-cuda-relevant:"
+assert_eq "trusty-common source"     "true"  "$(cuda_relevant_of 'crates/trusty-common/src/embedder/mod.rs')"
+assert_eq "trusty-common manifest"   "true"  "$(cuda_relevant_of 'crates/trusty-common/Cargo.toml')"
+assert_eq "workspace manifest"       "true"  "$(cuda_relevant_of 'Cargo.toml')"
+assert_eq "workspace lockfile"       "true"  "$(cuda_relevant_of 'Cargo.lock')"
+assert_eq "Cargo configuration"      "true"  "$(cuda_relevant_of '.cargo/config.toml')"
+assert_eq "CI workflow"              "true"  "$(cuda_relevant_of '.github/workflows/ci.yml')"
+assert_eq "scope detector"           "true"  "$(cuda_relevant_of 'scripts/detect-embedder-cuda-relevant.sh')"
+assert_eq "unrelated Rust crate"     "false" "$(cuda_relevant_of 'crates/trusty-mpm/src/main.rs')"
+assert_eq "trusty-search CUDA code"  "false" "$(cuda_relevant_of 'crates/trusty-search/src/main.rs')"
+assert_eq "documentation"            "false" "$(cuda_relevant_of 'docs/adr/0001-example.md')"
+assert_eq "mixed relevant changes"   "true"  "$(cuda_relevant_of 'docs/adr/0001-example.md
+crates/trusty-common/src/lib.rs')"
+assert_eq "empty diff (fail closed)" "true"  "$(cuda_relevant_of '')"
+
+cuda_job="$(sed -n '/^  embedder-cuda-check:/,/^  # ui-checks:/p' .github/workflows/ci.yml)"
+assert_eq "CI exports CUDA relevance" "1" \
+  "$(grep -c '^      embedder_cuda_relevant:.*steps.detect-cuda' .github/workflows/ci.yml || true)"
+assert_eq "CUDA job is gated by crate relevance" "1" \
+  "$(grep -c "needs.changes.outputs.embedder_cuda_relevant != 'false'" <<<"$cuda_job" || true)"
+assert_eq "CUDA job no longer uses broad docs-only gate" "0" \
+  "$(grep -c 'needs.changes.outputs.docs_only' <<<"$cuda_job" || true)"
+assert_eq "main notifier treats an intentional CUDA skip as green" "1" \
+  "$(grep -c "embedder-cuda-check=.*embedder_cuda_relevant != 'false'" .github/workflows/ci.yml || true)"
+
+# ---------------------------------------------------------------------------
 # check-pr-version-bump.sh — decision branches with the registry stubbed.
 # ---------------------------------------------------------------------------
 echo

--- a/scripts/detect-embedder-cuda-relevant.sh
+++ b/scripts/detect-embedder-cuda-relevant.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Decide whether a change can affect the trusty-common embedder-cuda build.
+
+set -euo pipefail
+
+is_relevant_path() {
+  case "$1" in
+    Cargo.toml | \
+      Cargo.lock | \
+      rust-toolchain | \
+      rust-toolchain.toml | \
+      .cargo/* | \
+      crates/trusty-common/* | \
+      .github/workflows/ci.yml | \
+      scripts/detect-embedder-cuda-relevant.sh)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+main() {
+  local input
+  if [[ -n "${CUDA_SCOPE_BASE:-}" ]]; then
+    local merge_base
+    if ! merge_base="$(git merge-base "$CUDA_SCOPE_BASE" HEAD)"; then
+      echo "detect-embedder-cuda-relevant: cannot resolve merge-base against '${CUDA_SCOPE_BASE}'" >&2
+      return 2
+    fi
+    input="$(git diff --name-only --no-renames "$merge_base" HEAD)"
+  else
+    input="$(cat)"
+  fi
+
+  local relevant=false
+  local count=0
+  local path
+  while IFS= read -r path; do
+    [[ -n "$path" ]] || continue
+    count=$((count + 1))
+    if is_relevant_path "$path"; then
+      echo "  cuda-relevant: $path" >&2
+      relevant=true
+    else
+      echo "  cuda-inert   : $path" >&2
+    fi
+  done <<<"$input"
+
+  # A missing diff must never suppress the specialized compile check.
+  if ((count == 0)); then
+    echo "detect-embedder-cuda-relevant: empty change set — running fail closed" >&2
+    relevant=true
+  fi
+
+  echo "detect-embedder-cuda-relevant: ${count} changed path(s) -> embedder_cuda_relevant=${relevant}" >&2
+  echo "embedder_cuda_relevant=${relevant}"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "embedder_cuda_relevant=${relevant}" >>"$GITHUB_OUTPUT"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add a dedicated change classifier for the `trusty-common` embedder-CUDA compile check.
- Run the CUDA job only when `crates/trusty-common/**`, workspace Cargo inputs, Cargo configuration, or the CI definition changes.
- Skip the job entirely for documentation and unrelated crate changes.
- Fail closed: an empty or unresolvable diff still runs the CUDA check.
- Preserve main-branch failure notification semantics by treating only an intentional scope skip as green.

## Why

The job executes `cargo check -p trusty-common --features embedder-cuda --all-targets`, but it was previously gated only by the broad Cargo-inert classifier. That meant any Rust change anywhere in the workspace installed nvcc and compiled the CUDA feature even when it could not affect `trusty-common`.

The CUDA check is not a required branch-protection context, so it can safely use a job-level scope condition. Required workspace checks retain their existing lightweight reporting wrappers.

## Validation

- `scripts/check-ci-helpers-selftest.sh` — all 97 cases pass
- `actionlint .github/workflows/ci.yml`
- `shellcheck scripts/detect-embedder-cuda-relevant.sh`
- `scripts/check_line_cap.sh`
- `scripts/check_changelog_fragment.sh --base origin/main`
- explicit classifier probes: ADR change → false; `trusty-common` embedder change → true
- `git diff --check origin/main`