### PR TITLE
fix(trusty-memory): reject stopword tokens in KG pattern extraction

### DIFF
--- a/crates/trusty-memory/changelog.d/4678-kg-extraction-precision-added.md
+++ b/crates/trusty-memory/changelog.d/4678-kg-extraction-precision-added.md
@@ -9,4 +9,9 @@ Added
   all. Selection is deliberately narrow — a subject is skipped if it sits under
   the `drawer:`/`tag:`/`topic:`/`room:` namespaces, or if any of its active
   triples was not stamped `auto:remember`, so one hand-asserted fact protects
-  the whole subject.
+  the whole subject. A subject whose delete fails is reported as `[purge-FAILED]`
+  on stderr, kept out of the deleted count, and makes the command exit non-zero —
+  a failure is never printed as a deletion. `--dry-run` reaches the graph without
+  hydrating any palace, so the preview cannot trigger the issue-#61 expired-drawer
+  reclamation sweep that `PalaceHandle::open` performs; it genuinely writes
+  nothing.

--- a/crates/trusty-memory/changelog.d/4678-kg-extraction-precision-added.md
+++ b/crates/trusty-memory/changelog.d/4678-kg-extraction-precision-added.md
@@ -1,0 +1,12 @@
+Added
+- **`kg-rebuild --purge-stale-subjects`** deletes auto-extracted subjects the
+  new filter would now reject. The forward filter only stops new garbage:
+  `rebuild_one` re-asserts and never retracts, and the four pattern predicates
+  are not in `FUNCTIONAL_PREDICATES`, so an `assert` supersedes only an
+  identical object and every triple already in the graph would otherwise stay
+  there permanently. The flag is off by default, prints every subject it
+  removes, and takes `--dry-run` to report the list while writing nothing at
+  all. Selection is deliberately narrow — a subject is skipped if it sits under
+  the `drawer:`/`tag:`/`topic:`/`room:` namespaces, or if any of its active
+  triples was not stamped `auto:remember`, so one hand-asserted fact protects
+  the whole subject.

--- a/crates/trusty-memory/changelog.d/4678-kg-extraction-precision-fixed.md
+++ b/crates/trusty-memory/changelog.d/4678-kg-extraction-precision-fixed.md
@@ -1,0 +1,16 @@
+Fixed
+
+- **KG pattern extraction no longer turns function words into entities
+  (issue #4678).** A `PATTERN_TABLE` marker hit (`is a`, `works at`, `uses`,
+  `depends on`) took the token on each side as subject and object with no test
+  applied, so "calling them is a no-op" asserted `them --is-a--> no-op` into the
+  live graph. Tokens are now screened by `is_stop_token`: a closed-class
+  function word (article, pronoun, preposition, conjunction, copula, auxiliary,
+  discourse adverb) or anything shorter than three characters is refused, and
+  refusing either side drops the whole triple rather than half of it. Short
+  names this workspace actually discusses — `Go`, `C`, `C#`, `AI`, `KG`, `PR`,
+  `CI`, plus the crate aliases `tm`/`ts`/`tc`/`ta` — are allowlisted past the
+  length floor, so the filter costs no recall on them. The filter is lexical
+  and judges one token at a time, so it does not reach a bad triple whose two
+  tokens are both ordinary words (`squash --is-a--> ancestor`); that residue is
+  pinned by a test rather than left unstated.

--- a/crates/trusty-memory/changelog.d/4678-kg-extraction-precision-fixed.md
+++ b/crates/trusty-memory/changelog.d/4678-kg-extraction-precision-fixed.md
@@ -14,3 +14,12 @@ Fixed
   and judges one token at a time, so it does not reach a bad triple whose two
   tokens are both ordinary words (`squash --is-a--> ancestor`); that residue is
   pinned by a test rather than left unstated.
+- **Entity tokens no longer keep the punctuation wrapped around them
+  (issue #4678).** `first_token` trimmed a TRAILING run of punctuation while its
+  doc promised it stripped the leading one, and the set both token helpers used
+  omitted backticks, brackets and asterisks — the characters drawer content
+  actually wraps names in. So "trusty-memory uses `redb` for persistence"
+  asserted the object as `` `redb` ``, a second node for an entity that already
+  had one. Both helpers now strip punctuation from both edges through one shared
+  `clean_token`, and interior characters are untouched so `no-op`, `c#` and
+  `src/main.rs` survive whole.

--- a/crates/trusty-memory/src/commands/kg_rebuild.rs
+++ b/crates/trusty-memory/src/commands/kg_rebuild.rs
@@ -533,6 +533,28 @@ mod tests {
         );
     }
 
+    /// Why: the #4678 `first_token` fix cleans tokens on the way IN, so it only
+    /// helps content extracted from now on. Subjects already in redb were
+    /// written by the old extractor with the punctuation welded on. If
+    /// `is_stop_token` stopped normalising, those would stop being recognised
+    /// and the purge would walk straight past the rows it exists to remove.
+    /// What: a stored `("the` subject is still selected.
+    /// Test: This test.
+    #[test]
+    fn purge_selects_a_legacy_subject_with_welded_punctuation() {
+        let active = vec![
+            active_triple("(\"the", Some(AUTO_PROVENANCE)),
+            active_triple("`it`", Some(AUTO_PROVENANCE)),
+            active_triple("`redb`", Some(AUTO_PROVENANCE)),
+        ];
+        assert_eq!(
+            stale_subject_candidates(&active),
+            vec!["(\"the".to_string(), "`it`".to_string()],
+            "legacy punctuated stopword subjects must still be selected, \
+             and a legacy punctuated real entity must not be"
+        );
+    }
+
     /// Why: `delete_by_subject` closes EVERY active triple under the subject,
     /// so one hand-asserted fact must protect the whole subject — a purge is
     /// not allowed to take a manual assertion with it.

--- a/crates/trusty-memory/src/commands/kg_rebuild.rs
+++ b/crates/trusty-memory/src/commands/kg_rebuild.rs
@@ -186,14 +186,13 @@ async fn report_purge(state: &AppState, palace_filter: Option<&str>, apply: bool
     let summaries = purge_palaces(state, palace_filter, apply).await?;
     let mut total_subjects = 0usize;
     let mut total_rows = 0usize;
-    let mut failures = 0usize;
+    let failures = count_purge_failures(&summaries);
     for s in &summaries {
         if let Some(e) = &s.error {
             eprintln!("[purge-error] palace={} error={}", s.palace_id, e);
-            // A palace that could not be opened or scanned reported no
-            // per-subject failures, so count it once here.
+            // A palace that could not be opened or scanned has nothing
+            // per-subject to print.
             if s.failed.is_empty() {
-                failures += 1;
                 continue;
             }
         }
@@ -208,7 +207,6 @@ async fn report_purge(state: &AppState, palace_filter: Option<&str>, apply: bool
                 );
             }
             total_subjects += s.deleted.len();
-            failures += s.failed.len();
         } else {
             for subject in &s.selected {
                 println!(
@@ -228,6 +226,36 @@ async fn report_purge(state: &AppState, palace_filter: Option<&str>, apply: bool
         println!("kg-rebuild purge: {total_subjects} subjects would be deleted (dry run)");
     }
     Ok(failures)
+}
+
+/// How many failures a purge run must report.
+///
+/// Why: the count drives the `anyhow::bail!` that gives the command its
+/// non-zero exit, so it is the operator-visible half of CRITICAL 1. It also
+/// carries the one piece of arithmetic that is easy to get wrong: a palace with
+/// per-subject failures ALSO has `error` set (it summarises those same
+/// failures), so counting both would report every such palace one time too many.
+/// Pulled out of `report_purge` so both arms can be tested directly — a
+/// per-subject delete failure is not reachable deterministically through the
+/// real pipeline, because an applying run opens with `Writer` intent and
+/// therefore either opens and deletes cleanly or fails at the open.
+/// What: per palace, per-subject failures when there are any, otherwise one for
+/// a palace-level `error`, otherwise zero. Never both.
+/// Test: `count_purge_failures_never_double_counts_a_palace`,
+/// `purge_counts_an_unopenable_palace_as_exactly_one_failure`.
+pub fn count_purge_failures(summaries: &[PalacePurgeSummary]) -> usize {
+    summaries
+        .iter()
+        .map(|s| {
+            if !s.failed.is_empty() {
+                s.failed.len()
+            } else if s.error.is_some() {
+                1
+            } else {
+                0
+            }
+        })
+        .sum()
 }
 
 /// Per-palace result of a `--purge-stale-subjects` pass.
@@ -739,6 +767,134 @@ mod tests {
             outcome.rows_closed, 4,
             "a failed delete must contribute no closed rows"
         );
+    }
+
+    /// Build a summary for the counting tests.
+    fn summary_of(
+        palace_id: &str,
+        selected: &[&str],
+        deleted: &[&str],
+        failed: &[(&str, &str)],
+        error: Option<&str>,
+    ) -> PalacePurgeSummary {
+        PalacePurgeSummary {
+            palace_id: palace_id.to_string(),
+            selected: selected.iter().map(|s| s.to_string()).collect(),
+            deleted: deleted.iter().map(|s| s.to_string()).collect(),
+            failed: failed
+                .iter()
+                .map(|(s, e)| (s.to_string(), e.to_string()))
+                .collect(),
+            rows_closed: deleted.len(),
+            error: error.map(|e| e.to_string()),
+        }
+    }
+
+    /// Why: a palace with per-subject failures ALSO carries a palace-level
+    /// `error` summarising those same failures. Counting both would report one
+    /// extra failure for every such palace, inflating the number the operator
+    /// sees and the one the non-zero exit is justified by.
+    /// What: per-subject failures count once each; a palace-level error counts
+    /// once ONLY when there are no per-subject failures behind it; a clean
+    /// palace counts zero.
+    /// Test: This test.
+    #[test]
+    fn count_purge_failures_never_double_counts_a_palace() {
+        let open_failed = summary_of("a", &[], &[], &[], Some("open kg for palace a: bad file"));
+        let subject_failed = summary_of(
+            "b",
+            &["them", "the"],
+            &["them"],
+            &[("the", "store is read-only")],
+            Some("1 of 2 selected subject(s) failed to delete"),
+        );
+        let clean = summary_of("c", &["it"], &["it"], &[], None);
+
+        assert_eq!(
+            count_purge_failures(std::slice::from_ref(&open_failed)),
+            1,
+            "a palace that could not be opened is one failure"
+        );
+        assert_eq!(
+            count_purge_failures(std::slice::from_ref(&subject_failed)),
+            1,
+            "the error merely summarises the one subject failure; it must not add a second"
+        );
+        assert_eq!(count_purge_failures(std::slice::from_ref(&clean)), 0);
+        assert_eq!(
+            count_purge_failures(&[open_failed, subject_failed, clean]),
+            2,
+            "aggregate must be 1 + 1 + 0"
+        );
+    }
+
+    /// Why: `report_purge` is what turns a failure into something the operator
+    /// can see — the stderr line, the count in the aggregate, and the value
+    /// that drives the non-zero exit. `apply_deletions` covers the injected
+    /// closure; this drives a REAL failure through
+    /// `purge_palaces` → `purge_one` → `report_purge`.
+    /// What: corrupts the palace's `kg.redb` so `KnowledgeGraph::open_with_intent`
+    /// fails, then asserts the summary records it as a palace-level error with
+    /// no per-subject entries, and that `report_purge` counts it exactly once.
+    /// Deterministic: the failure is a malformed file, not a lock race.
+    /// Test: This test.
+    #[tokio::test]
+    async fn purge_counts_an_unopenable_palace_as_exactly_one_failure() -> Result<()> {
+        seed_embedder();
+        let tmp = tempfile::tempdir()?;
+        let data_root = tmp.path().to_path_buf();
+        // SAFETY: idempotent constant write "1"; safe across test threads.
+        unsafe {
+            std::env::set_var("TRUSTY_SKIP_PALACE_ENFORCEMENT", "1");
+        }
+        {
+            let state = AppState::new(data_root.clone());
+            state.set_ready();
+            let _ =
+                crate::tools::dispatch_tool(&state, "palace_create", json!({"name": "a"})).await?;
+        }
+
+        // Build a SECOND palace on disk that this process never opens, by
+        // cloning the created palace's metadata. The store keeps a
+        // process-wide cache of open databases keyed by path, so a palace
+        // already opened in this test would be served from that cache and
+        // never touch the filesystem at all — an earlier version of this
+        // fixture corrupted `a/kg.redb` and the open still succeeded.
+        let mut record: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(data_root.join("a/palace.json"))?)?;
+        if let Some(obj) = record.as_object_mut() {
+            obj.insert("id".to_string(), json!("b"));
+            if obj.contains_key("name") {
+                obj.insert("name".to_string(), json!("b"));
+            }
+        }
+        let b_dir = data_root.join("b");
+        std::fs::create_dir_all(&b_dir)?;
+        std::fs::write(b_dir.join("palace.json"), serde_json::to_string(&record)?)?;
+        // A DIRECTORY where the store file belongs. Opening a directory as a
+        // database file fails at the OS layer on every platform and every redb
+        // version, and cannot be silently recreated underneath us. No lock, no
+        // race, no timing.
+        std::fs::create_dir(b_dir.join("kg.redb"))?;
+
+        let state = AppState::new(data_root.clone());
+        let summaries = purge_palaces(&state, Some("b"), true).await?;
+
+        assert!(
+            summaries[0].error.is_some(),
+            "an unopenable palace must set the palace-level error"
+        );
+        assert!(
+            summaries[0].failed.is_empty() && summaries[0].deleted.is_empty(),
+            "nothing was attempted per-subject, so both lists stay empty"
+        );
+
+        let failures = report_purge(&state, Some("b"), true).await?;
+        assert_eq!(
+            failures, 1,
+            "an unopenable palace is exactly one failure, and a non-zero count is what makes the command exit non-zero"
+        );
+        Ok(())
     }
 
     /// Why: `--dry-run` promises it writes nothing, but the scan reached the KG

--- a/crates/trusty-memory/src/commands/kg_rebuild.rs
+++ b/crates/trusty-memory/src/commands/kg_rebuild.rs
@@ -14,10 +14,33 @@
 //! `kg_rebuild_processes_named_palace_only`.
 
 use anyhow::{Context, Result};
+use std::collections::BTreeMap;
 use trusty_common::memory_core::palace::PalaceId;
+use trusty_common::memory_core::store::kg::Triple;
 
-use crate::kg_extract::{extract_triples, ExtractInput};
+use crate::kg_extract::{
+    extract_triples, is_stop_token, ExtractInput, AUTO_PROVENANCE, DRAWER_SUBJECT_PREFIX,
+    ROOM_SUBJECT_PREFIX, TAG_SUBJECT_PREFIX, TOPIC_SUBJECT_PREFIX,
+};
 use crate::{resolve_palace_registry_dir, AppState};
+
+/// Subject namespaces the extractor owns and the purge must never touch.
+///
+/// Why: #4678's purge targets the bare tokens the pattern pass invents. A
+/// `tag:the` subject is a tag the user actually wrote, not extraction debris,
+/// and deleting it would destroy real membership edges.
+/// What: the four prefixes `kg_extract` emits. A subject carrying any of them
+/// is skipped before the stopword test runs.
+/// Test: `purge_skips_namespaced_subjects`.
+const STRUCTURAL_PREFIXES: &[&str] = &[
+    DRAWER_SUBJECT_PREFIX,
+    TAG_SUBJECT_PREFIX,
+    TOPIC_SUBJECT_PREFIX,
+    ROOM_SUBJECT_PREFIX,
+];
+
+/// How many active triples to pull per `list_active` page during a purge scan.
+const PURGE_SCAN_PAGE: usize = 1000;
 
 /// Summary returned to the CLI per palace.
 ///
@@ -35,7 +58,41 @@ pub struct PalaceRebuildSummary {
     pub error: Option<String>,
 }
 
+/// What a `kg-rebuild` invocation was asked to do.
+///
+/// Why: #4678 added two flags to a command that had one. Bundling them keeps
+/// [`handle_kg_rebuild`]'s existing one-argument signature intact — that
+/// function is public API of a crate `trusty-agents` links against, so
+/// widening it in place would be a breaking change for a bug fix.
+/// What: the palace filter plus the two purge switches. `Default` is an
+/// ordinary rebuild of every palace, which is the pre-#4678 behaviour.
+/// Test: `purge_is_off_by_default`.
+#[derive(Debug, Clone, Default)]
+pub struct KgRebuildOptions {
+    /// Restrict the run to a single palace id. `None` processes every palace.
+    pub palace: Option<String>,
+    /// Delete auto-extracted subjects the #4678 token filter now rejects.
+    pub purge_stale_subjects: bool,
+    /// Report the purge candidates and write nothing at all.
+    pub dry_run: bool,
+}
+
 /// CLI entry point for `trusty-memory kg-rebuild`.
+///
+/// Why: preserved unchanged as the crate's public one-argument entry point
+/// (see [`KgRebuildOptions`]).
+/// What: delegates to [`handle_kg_rebuild_with`] with both purge switches off,
+/// which is exactly the pre-#4678 behaviour.
+/// Test: covered through `handle_kg_rebuild_with`.
+pub async fn handle_kg_rebuild(palace: Option<String>) -> Result<()> {
+    handle_kg_rebuild_with(KgRebuildOptions {
+        palace,
+        ..Default::default()
+    })
+    .await
+}
+
+/// Run `kg-rebuild` with the full #4678 option set.
 ///
 /// Why: A thin shim that resolves the standard data dir, builds an
 /// `AppState`, loads every palace, and dispatches to `rebuild_palaces`. Kept
@@ -44,10 +101,12 @@ pub struct PalaceRebuildSummary {
 /// What: Resolves `~/Library/Application Support/trusty-memory` (or the
 /// platform equivalent) via `resolve_data_dir`, calls `rebuild_palaces` with
 /// the optional palace filter, then prints a human-readable summary to
-/// stdout. Returns the aggregate error count as the exit code (0 on success).
-/// Test: not unit-tested (process-level entry point); the inner
-/// `rebuild_palaces` is the testable surface.
-pub async fn handle_kg_rebuild(palace: Option<String>) -> Result<()> {
+/// stdout. With `purge_stale_subjects` it then deletes the stale subjects;
+/// with `dry_run` it skips the rebuild entirely and only reports what the
+/// purge would delete, so the whole invocation writes nothing.
+/// Test: not unit-tested (process-level entry point); `rebuild_palaces` and
+/// `purge_palaces` are the testable surfaces.
+pub async fn handle_kg_rebuild_with(opts: KgRebuildOptions) -> Result<()> {
     let data_dir = trusty_common::resolve_data_dir("trusty-memory")
         .context("resolve trusty-memory data dir")?;
     let data_root = resolve_palace_registry_dir(data_dir);
@@ -57,6 +116,14 @@ pub async fn handle_kg_rebuild(palace: Option<String>) -> Result<()> {
         .await
         .context("load palaces from disk")?;
     tracing::info!(palaces_loaded = loaded, "kg-rebuild: palaces opened");
+
+    let palace = opts.palace.clone();
+    if opts.dry_run {
+        // Report-only: no re-assert pass, no deletion. Nothing is written.
+        println!("kg-rebuild: DRY RUN — no triples will be asserted or deleted");
+        report_purge(&state, palace.as_deref(), false).await?;
+        return Ok(());
+    }
 
     let summaries = rebuild_palaces(&state, palace.as_deref()).await?;
     let mut total_drawers = 0usize;
@@ -85,7 +152,190 @@ pub async fn handle_kg_rebuild(palace: Option<String>) -> Result<()> {
         total_triples,
         total_errors
     );
+    if opts.purge_stale_subjects {
+        report_purge(&state, palace.as_deref(), true).await?;
+    }
     Ok(())
+}
+
+/// Print every stale subject, then optionally delete it.
+///
+/// Why: the purge is destructive against real data, so the subject list is
+/// printed in both modes — an operator sees exactly what was (or would be)
+/// removed rather than a bare count.
+/// What: runs [`purge_palaces`] and prints one line per subject plus an
+/// aggregate. `apply` selects deletion versus report-only.
+/// Test: covered through `purge_palaces`.
+async fn report_purge(state: &AppState, palace_filter: Option<&str>, apply: bool) -> Result<()> {
+    let summaries = purge_palaces(state, palace_filter, apply).await?;
+    let verb = if apply { "deleted" } else { "would delete" };
+    let mut total_subjects = 0usize;
+    let mut total_rows = 0usize;
+    for s in &summaries {
+        if let Some(e) = &s.error {
+            eprintln!("[error] purge palace={} error={}", s.palace_id, e);
+            continue;
+        }
+        for subject in &s.subjects {
+            println!(
+                "[purge] palace={} {} subject={}",
+                s.palace_id, verb, subject
+            );
+        }
+        total_subjects += s.subjects.len();
+        total_rows += s.rows_closed;
+    }
+    if apply {
+        println!("kg-rebuild purge: {total_subjects} subjects deleted, {total_rows} rows closed");
+    } else {
+        println!("kg-rebuild purge: {total_subjects} subjects would be deleted (dry run)");
+    }
+    Ok(())
+}
+
+/// Per-palace result of a `--purge-stale-subjects` pass.
+///
+/// Why: mirrors [`PalaceRebuildSummary`] so one bad palace is reported without
+/// aborting the rest of the run.
+/// What: the subjects selected, how many triple rows were closed (always 0 in
+/// report-only mode), and any per-palace error.
+/// Test: `purge_selects_only_stopword_subjects`.
+#[derive(Debug, Clone)]
+pub struct PalacePurgeSummary {
+    pub palace_id: String,
+    pub subjects: Vec<String>,
+    pub rows_closed: usize,
+    pub error: Option<String>,
+}
+
+/// Select — and optionally delete — stale auto-extracted subjects.
+///
+/// Why: #4678's forward filter only stops NEW garbage. `rebuild_one` re-asserts
+/// and never retracts, and the four pattern predicates are absent from
+/// `FUNCTIONAL_PREDICATES`, so `assert` supersedes only an identical object.
+/// Without this pass every triple already in the graph stays there forever.
+/// What: per palace, scans every active triple, picks the subjects
+/// [`stale_subject_candidates`] returns, and (when `apply`) calls the existing
+/// `delete_by_subject` on each. Errors are captured per palace.
+/// Test: `purge_selects_only_stopword_subjects`, `purge_skips_namespaced_subjects`.
+pub async fn purge_palaces(
+    state: &AppState,
+    palace_filter: Option<&str>,
+    apply: bool,
+) -> Result<Vec<PalacePurgeSummary>> {
+    let mut out: Vec<PalacePurgeSummary> = Vec::new();
+    let palaces = trusty_common::memory_core::PalaceRegistry::list_palaces(&state.data_root)
+        .unwrap_or_default();
+    for palace in palaces {
+        let id = palace.id.0.clone();
+        if let Some(filter) = palace_filter {
+            if filter != id {
+                continue;
+            }
+        }
+        let summary = purge_one(state, &id, apply)
+            .await
+            .unwrap_or_else(|e| PalacePurgeSummary {
+                palace_id: id.clone(),
+                subjects: Vec::new(),
+                rows_closed: 0,
+                error: Some(format!("{e:#}")),
+            });
+        out.push(summary);
+    }
+    Ok(out)
+}
+
+/// Purge a single palace.
+///
+/// Why: keeps the per-palace work in one focused function, matching
+/// `rebuild_one`.
+/// What: pages `list_active` into one vec, runs [`stale_subject_candidates`],
+/// then deletes each match through `KgStoreRedb::delete_by_subject` on the
+/// blocking pool. The in-memory adjacency is not resynced — this runs in a
+/// one-shot CLI process that exits immediately afterwards.
+/// Test: `purge_selects_only_stopword_subjects`.
+async fn purge_one(state: &AppState, palace_id: &str, apply: bool) -> Result<PalacePurgeSummary> {
+    let pid = PalaceId::new(palace_id);
+    let handle = state
+        .registry
+        .open_palace(&state.data_root, &pid)
+        .with_context(|| format!("open palace {palace_id}"))?;
+
+    let mut active: Vec<Triple> = Vec::new();
+    let mut offset = 0usize;
+    loop {
+        let page = handle
+            .kg
+            .list_active(PURGE_SCAN_PAGE, offset)
+            .await
+            .with_context(|| format!("scan active triples in {palace_id}"))?;
+        let n = page.len();
+        active.extend(page);
+        if n < PURGE_SCAN_PAGE {
+            break;
+        }
+        offset += n;
+    }
+
+    let subjects = stale_subject_candidates(&active);
+    let mut rows_closed = 0usize;
+    if apply {
+        for subject in &subjects {
+            let store = handle.kg.store();
+            let s = subject.clone();
+            match tokio::task::spawn_blocking(move || store.delete_by_subject(&s)).await {
+                Ok(Ok(n)) => rows_closed += n,
+                Ok(Err(e)) => tracing::warn!(
+                    palace = %palace_id,
+                    subject = %subject,
+                    "kg-rebuild purge: delete failed (non-fatal): {e:#}",
+                ),
+                Err(e) => tracing::warn!(
+                    palace = %palace_id,
+                    subject = %subject,
+                    "kg-rebuild purge: delete task join error: {e:#}",
+                ),
+            }
+        }
+    }
+    Ok(PalacePurgeSummary {
+        palace_id: palace_id.to_string(),
+        subjects,
+        rows_closed,
+        error: None,
+    })
+}
+
+/// Pick the subjects a purge may delete.
+///
+/// Why: `delete_by_subject` removes EVERY active triple under a subject, so
+/// selection has to be conservative on two axes at once — the subject must be
+/// one the extractor invented (not a user's tag or room, not a hand-asserted
+/// fact), and it must be one the #4678 filter would now reject.
+/// What: a subject qualifies only when all three hold: it carries none of
+/// [`STRUCTURAL_PREFIXES`]; every one of its active triples is stamped
+/// `auto:remember`, so a single manual assert protects it; and
+/// `is_stop_token` rejects it. Returns distinct subjects, sorted.
+/// Test: `purge_selects_only_stopword_subjects`, `purge_skips_namespaced_subjects`,
+/// `purge_spares_a_subject_with_a_manual_triple`.
+pub fn stale_subject_candidates(active: &[Triple]) -> Vec<String> {
+    let mut by_subject: BTreeMap<&str, bool> = BTreeMap::new();
+    for t in active {
+        if STRUCTURAL_PREFIXES.iter().any(|p| t.subject.starts_with(p)) {
+            continue;
+        }
+        if !is_stop_token(&t.subject) {
+            continue;
+        }
+        let all_auto = by_subject.entry(t.subject.as_str()).or_insert(true);
+        *all_auto &= t.provenance.as_deref() == Some(AUTO_PROVENANCE);
+    }
+    by_subject
+        .into_iter()
+        .filter(|(_, all_auto)| *all_auto)
+        .map(|(s, _)| s.to_string())
+        .collect()
 }
 
 /// Run KG back-fill across one or every palace in an `AppState`.
@@ -217,6 +467,172 @@ mod tests {
     ///       `kg_rebuild_processes_named_palace_only`.
     fn seed_embedder() {
         trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock();
+    }
+
+    /// Build an active triple for the purge-selection tests.
+    ///
+    /// Why: only subject and provenance drive selection; the rest is noise the
+    /// fixtures should not have to restate.
+    /// What: an active (`valid_to: None`) triple with the given subject and
+    /// provenance.
+    /// Test: used by the purge selection tests below.
+    fn active_triple(subject: &str, provenance: Option<&str>) -> Triple {
+        Triple {
+            subject: subject.to_string(),
+            predicate: "is-a".to_string(),
+            object: "thing".to_string(),
+            valid_from: chrono::Utc::now(),
+            valid_to: None,
+            confidence: 0.6,
+            provenance: provenance.map(|p| p.to_string()),
+        }
+    }
+
+    /// Why: the purge deletes real data, so selection must pick exactly the
+    /// #4678 garbage and nothing adjacent to it.
+    /// What: stopword and too-short auto-extracted subjects are selected;
+    /// ordinary entity subjects are not, whatever their provenance.
+    /// Test: This test.
+    #[test]
+    fn purge_selects_only_stopword_subjects() {
+        let active = vec![
+            active_triple("them", Some(AUTO_PROVENANCE)),
+            active_triple("the", Some(AUTO_PROVENANCE)),
+            active_triple("x", Some(AUTO_PROVENANCE)),
+            active_triple("rustc", Some(AUTO_PROVENANCE)),
+            active_triple("trusty-memory", Some(AUTO_PROVENANCE)),
+            active_triple("go", Some(AUTO_PROVENANCE)),
+        ];
+        let got = stale_subject_candidates(&active);
+        assert_eq!(
+            got,
+            vec!["the".to_string(), "them".to_string(), "x".to_string()],
+            "selection must be the stopword/short subjects only, sorted"
+        );
+    }
+
+    /// Why: `tag:the` is a tag the user wrote, not extraction debris, and
+    /// `delete_by_subject` would take every membership edge with it.
+    /// What: subjects under the drawer/tag/topic/room namespaces are skipped
+    /// even when their local part is a stopword.
+    /// Test: This test.
+    #[test]
+    fn purge_skips_namespaced_subjects() {
+        let active = vec![
+            active_triple("tag:the", Some(AUTO_PROVENANCE)),
+            active_triple("topic:it", Some(AUTO_PROVENANCE)),
+            active_triple("room:a", Some(AUTO_PROVENANCE)),
+            active_triple(
+                &format!("{DRAWER_SUBJECT_PREFIX}{}", uuid::Uuid::new_v4()),
+                Some(AUTO_PROVENANCE),
+            ),
+        ];
+        assert!(
+            stale_subject_candidates(&active).is_empty(),
+            "namespaced subjects must never be purged"
+        );
+    }
+
+    /// Why: `delete_by_subject` closes EVERY active triple under the subject,
+    /// so one hand-asserted fact must protect the whole subject — a purge is
+    /// not allowed to take a manual assertion with it.
+    /// What: a stopword subject carrying one non-`auto:remember` triple is not
+    /// selected; the same subject with only auto triples is.
+    /// Test: This test.
+    #[test]
+    fn purge_spares_a_subject_with_a_manual_triple() {
+        let mixed = vec![
+            active_triple("them", Some(AUTO_PROVENANCE)),
+            active_triple("them", Some("kg_assert")),
+        ];
+        assert!(
+            stale_subject_candidates(&mixed).is_empty(),
+            "a manual triple must protect the subject"
+        );
+
+        let unprovenanced = vec![active_triple("them", None)];
+        assert!(
+            stale_subject_candidates(&unprovenanced).is_empty(),
+            "an unstamped triple is not provably auto-extracted"
+        );
+
+        let auto_only = vec![active_triple("them", Some(AUTO_PROVENANCE))];
+        assert_eq!(
+            stale_subject_candidates(&auto_only),
+            vec!["them".to_string()]
+        );
+    }
+
+    /// Why: the purge must never fire as a side effect of an ordinary rebuild.
+    /// What: the default options carry both switches off, so
+    /// `handle_kg_rebuild`'s one-argument form cannot delete anything.
+    /// Test: This test.
+    #[test]
+    fn purge_is_off_by_default() {
+        let opts = KgRebuildOptions::default();
+        assert!(!opts.purge_stale_subjects, "purge must be opt-in");
+        assert!(!opts.dry_run);
+    }
+
+    /// Why: the selection tests are pure; this one proves the purge actually
+    /// reaches `delete_by_subject` and that `--dry-run` writes nothing — the
+    /// two claims that matter when the flag is pointed at a real palace.
+    /// What: seeds `them --is-a--> no-op` (the live #4678 triple) plus a real
+    /// `rustc --is-a--> compiler` into a tempdir palace. A dry run lists the
+    /// stale subject and leaves both in place; an applied run closes the stale
+    /// one and leaves the real one untouched.
+    /// Test: This test.
+    #[tokio::test]
+    async fn purge_deletes_stale_subjects_only_when_applied() -> Result<()> {
+        seed_embedder();
+        let tmp = tempfile::tempdir()?;
+        // Issue #88: bypass palace-slug enforcement for test palaces.
+        // SAFETY: idempotent constant write "1"; safe across test threads.
+        unsafe {
+            std::env::set_var("TRUSTY_SKIP_PALACE_ENFORCEMENT", "1");
+        }
+        let state = AppState::new(tmp.path().to_path_buf());
+        state.set_ready();
+        let _ = crate::tools::dispatch_tool(&state, "palace_create", json!({"name": "a"})).await?;
+
+        let handle = state
+            .registry
+            .open_palace(&state.data_root, &PalaceId::new("a"))?;
+        handle
+            .kg
+            .assert(active_triple("them", Some(AUTO_PROVENANCE)))
+            .await?;
+        handle
+            .kg
+            .assert(active_triple("rustc", Some(AUTO_PROVENANCE)))
+            .await?;
+
+        // Dry run: reports the stale subject, deletes nothing.
+        let dry = purge_palaces(&state, Some("a"), false).await?;
+        assert_eq!(dry.len(), 1);
+        assert_eq!(dry[0].subjects, vec!["them".to_string()]);
+        assert_eq!(dry[0].rows_closed, 0, "a dry run must not close any row");
+        assert!(
+            !handle.kg.query_active("them").await?.is_empty(),
+            "dry run must leave the stale triple in place"
+        );
+
+        // Applied: closes the stale subject and spares the real one.
+        let applied = purge_palaces(&state, Some("a"), true).await?;
+        assert_eq!(applied[0].subjects, vec!["them".to_string()]);
+        assert!(
+            applied[0].rows_closed > 0,
+            "applied purge must close at least one row"
+        );
+        assert!(
+            handle.kg.query_active("them").await?.is_empty(),
+            "applied purge must remove the stale triple"
+        );
+        assert!(
+            !handle.kg.query_active("rustc").await?.is_empty(),
+            "applied purge must not touch a real entity subject"
+        );
+        Ok(())
     }
 
     /// Why: Validate the back-fill end-to-end against a freshly-created

--- a/crates/trusty-memory/src/commands/kg_rebuild.rs
+++ b/crates/trusty-memory/src/commands/kg_rebuild.rs
@@ -16,7 +16,8 @@
 use anyhow::{Context, Result};
 use std::collections::BTreeMap;
 use trusty_common::memory_core::palace::PalaceId;
-use trusty_common::memory_core::store::kg::Triple;
+use trusty_common::memory_core::store::kg::{KnowledgeGraph, Triple};
+use trusty_common::memory_core::store::OpenIntent;
 
 use crate::kg_extract::{
     extract_triples, is_stop_token, ExtractInput, AUTO_PROVENANCE, DRAWER_SUBJECT_PREFIX,
@@ -111,19 +112,26 @@ pub async fn handle_kg_rebuild_with(opts: KgRebuildOptions) -> Result<()> {
         .context("resolve trusty-memory data dir")?;
     let data_root = resolve_palace_registry_dir(data_dir);
     let state = AppState::new(data_root);
+    let palace = opts.palace.clone();
+
+    // #4678: the dry-run branch returns before ANY palace is hydrated.
+    // `load_palaces_from_disk` opens every palace through `PalaceHandle::open`,
+    // whose issue-#61 reclamation sweep hard-deletes expired non-Tier-C
+    // drawers — a write, and precisely the thing --dry-run promises not to do.
+    if opts.dry_run {
+        println!("kg-rebuild: DRY RUN — nothing is written: no palace is hydrated, no triple is asserted, no subject is deleted");
+        let failures = report_purge(&state, palace.as_deref(), false).await?;
+        if failures > 0 {
+            anyhow::bail!("kg-rebuild purge: {failures} palace(s) could not be scanned");
+        }
+        return Ok(());
+    }
+
     let loaded = state
         .load_palaces_from_disk()
         .await
         .context("load palaces from disk")?;
     tracing::info!(palaces_loaded = loaded, "kg-rebuild: palaces opened");
-
-    let palace = opts.palace.clone();
-    if opts.dry_run {
-        // Report-only: no re-assert pass, no deletion. Nothing is written.
-        println!("kg-rebuild: DRY RUN — no triples will be asserted or deleted");
-        report_purge(&state, palace.as_deref(), false).await?;
-        return Ok(());
-    }
 
     let summaries = rebuild_palaces(&state, palace.as_deref()).await?;
     let mut total_drawers = 0usize;
@@ -153,7 +161,12 @@ pub async fn handle_kg_rebuild_with(opts: KgRebuildOptions) -> Result<()> {
         total_errors
     );
     if opts.purge_stale_subjects {
-        report_purge(&state, palace.as_deref(), true).await?;
+        let failures = report_purge(&state, palace.as_deref(), true).await?;
+        if failures > 0 {
+            anyhow::bail!(
+                "kg-rebuild purge: {failures} subject deletion(s) failed — see the [purge-FAILED] lines above"
+            );
+        }
     }
     Ok(())
 }
@@ -163,49 +176,125 @@ pub async fn handle_kg_rebuild_with(opts: KgRebuildOptions) -> Result<()> {
 /// Why: the purge is destructive against real data, so the subject list is
 /// printed in both modes — an operator sees exactly what was (or would be)
 /// removed rather than a bare count.
-/// What: runs [`purge_palaces`] and prints one line per subject plus an
-/// aggregate. `apply` selects deletion versus report-only.
-/// Test: covered through `purge_palaces`.
-async fn report_purge(state: &AppState, palace_filter: Option<&str>, apply: bool) -> Result<()> {
+/// What: runs [`purge_palaces`] and prints DELETED and FAILED subjects on
+/// separate, differently-tagged channels — deletions on stdout, failures on
+/// stderr — then an aggregate carrying the failure count. Returns that count so
+/// the caller can exit non-zero. `apply` selects deletion versus report-only.
+/// Test: `purge_reports_a_failed_delete_as_failed_not_deleted` covers the
+/// outcome split this prints.
+async fn report_purge(state: &AppState, palace_filter: Option<&str>, apply: bool) -> Result<usize> {
     let summaries = purge_palaces(state, palace_filter, apply).await?;
-    let verb = if apply { "deleted" } else { "would delete" };
     let mut total_subjects = 0usize;
     let mut total_rows = 0usize;
+    let mut failures = 0usize;
     for s in &summaries {
         if let Some(e) = &s.error {
-            eprintln!("[error] purge palace={} error={}", s.palace_id, e);
-            continue;
+            eprintln!("[purge-error] palace={} error={}", s.palace_id, e);
+            // A palace that could not be opened or scanned reported no
+            // per-subject failures, so count it once here.
+            if s.failed.is_empty() {
+                failures += 1;
+                continue;
+            }
         }
-        for subject in &s.subjects {
-            println!(
-                "[purge] palace={} {} subject={}",
-                s.palace_id, verb, subject
-            );
+        if apply {
+            for subject in &s.deleted {
+                println!("[purge] palace={} deleted subject={}", s.palace_id, subject);
+            }
+            for (subject, err) in &s.failed {
+                eprintln!(
+                    "[purge-FAILED] palace={} subject={} error={}",
+                    s.palace_id, subject, err
+                );
+            }
+            total_subjects += s.deleted.len();
+            failures += s.failed.len();
+        } else {
+            for subject in &s.selected {
+                println!(
+                    "[purge] palace={} would delete subject={}",
+                    s.palace_id, subject
+                );
+            }
+            total_subjects += s.selected.len();
         }
-        total_subjects += s.subjects.len();
         total_rows += s.rows_closed;
     }
     if apply {
-        println!("kg-rebuild purge: {total_subjects} subjects deleted, {total_rows} rows closed");
+        println!(
+            "kg-rebuild purge: {total_subjects} subjects deleted, {total_rows} rows closed, {failures} failed"
+        );
     } else {
         println!("kg-rebuild purge: {total_subjects} subjects would be deleted (dry run)");
     }
-    Ok(())
+    Ok(failures)
 }
 
 /// Per-palace result of a `--purge-stale-subjects` pass.
 ///
 /// Why: mirrors [`PalaceRebuildSummary`] so one bad palace is reported without
 /// aborting the rest of the run.
-/// What: the subjects selected, how many triple rows were closed (always 0 in
-/// report-only mode), and any per-palace error.
-/// Test: `purge_selects_only_stopword_subjects`.
+/// What: `selected` is what the scan picked; `deleted` and `failed` split what
+/// actually happened, so a caller can never read a failure as a success.
+/// `rows_closed` counts only rows a SUCCEEDING delete closed, and `error` is
+/// set whenever anything failed — the failure is therefore visible without
+/// reading a tracing log.
+/// Test: `purge_selects_only_stopword_subjects`,
+/// `purge_reports_a_failed_delete_as_failed_not_deleted`.
 #[derive(Debug, Clone)]
 pub struct PalacePurgeSummary {
     pub palace_id: String,
-    pub subjects: Vec<String>,
+    /// Subjects the scan picked as purge candidates.
+    pub selected: Vec<String>,
+    /// Subjects whose delete returned `Ok`. Empty in report-only mode.
+    pub deleted: Vec<String>,
+    /// Subjects whose delete returned `Err`, with the error rendered.
+    pub failed: Vec<(String, String)>,
     pub rows_closed: usize,
     pub error: Option<String>,
+}
+
+/// Result of running the deletions for one palace.
+///
+/// Why: a delete that fails must not be counted, printed, or summarised as one
+/// that succeeded — the whole of CRITICAL 1. Keeping the three outputs in one
+/// value makes it impossible to update the count without also recording which
+/// side the subject landed on.
+/// What: succeeded subjects, failed subjects with their error text, and the
+/// rows closed by the successes only.
+/// Test: `purge_reports_a_failed_delete_as_failed_not_deleted`.
+#[derive(Debug, Clone, Default)]
+pub struct PurgeOutcome {
+    pub deleted: Vec<String>,
+    pub failed: Vec<(String, String)>,
+    pub rows_closed: usize,
+}
+
+/// Run `delete` over every subject, recording each outcome separately.
+///
+/// Why: the deletion loop is the one place a fail-open branch could report a
+/// failure as a success, and it needs an error-arm test. Taking the delete as a
+/// closure gives that test a seam — it can fail a chosen subject deterministically
+/// without needing a read-only store or a live lock contender.
+/// What: calls `delete` per subject; `Ok(n)` appends to `deleted` and adds `n`
+/// to `rows_closed`, `Err` appends `(subject, error)` to `failed` and adds
+/// nothing. Never short-circuits — one bad subject must not strand the rest.
+/// Test: `purge_reports_a_failed_delete_as_failed_not_deleted`.
+pub fn apply_deletions<F>(subjects: &[String], mut delete: F) -> PurgeOutcome
+where
+    F: FnMut(&str) -> Result<usize>,
+{
+    let mut out = PurgeOutcome::default();
+    for subject in subjects {
+        match delete(subject) {
+            Ok(n) => {
+                out.rows_closed += n;
+                out.deleted.push(subject.clone());
+            }
+            Err(e) => out.failed.push((subject.clone(), format!("{e:#}"))),
+        }
+    }
+    out
 }
 
 /// Select — and optionally delete — stale auto-extracted subjects.
@@ -237,7 +326,9 @@ pub async fn purge_palaces(
             .await
             .unwrap_or_else(|e| PalacePurgeSummary {
                 palace_id: id.clone(),
-                subjects: Vec::new(),
+                selected: Vec::new(),
+                deleted: Vec::new(),
+                failed: Vec::new(),
                 rows_closed: 0,
                 error: Some(format!("{e:#}")),
             });
@@ -250,23 +341,36 @@ pub async fn purge_palaces(
 ///
 /// Why: keeps the per-palace work in one focused function, matching
 /// `rebuild_one`.
-/// What: pages `list_active` into one vec, runs [`stale_subject_candidates`],
-/// then deletes each match through `KgStoreRedb::delete_by_subject` on the
-/// blocking pool. The in-memory adjacency is not resynced — this runs in a
-/// one-shot CLI process that exits immediately afterwards.
-/// Test: `purge_selects_only_stopword_subjects`.
+/// What: opens the palace's `kg.db` DIRECTLY rather than through
+/// `PalaceRegistry::open_palace`, pages `list_active`, runs
+/// [`stale_subject_candidates`], then (when `apply`) hands the matches to
+/// [`apply_deletions`] on the blocking pool. The in-memory adjacency is not
+/// resynced — this runs in a one-shot CLI process that exits immediately after.
+///
+/// The direct open is the #4678 fix for the dry run that wrote:
+/// `PalaceHandle::open` runs the issue-#61 expired-drawer sweep, which
+/// hard-deletes every expired non-Tier-C row before the caller ever sees the
+/// handle. `KnowledgeGraph::open_with_intent` only opens, runs the (no-op)
+/// legacy migration, and hydrates the adjacency, so a scan cannot mutate what
+/// it is reporting on. Intent follows the mode: a report-only pass asks for
+/// `ReadOnlyClient`, an applying pass asks for `Writer` so it fails loud
+/// against a running daemon rather than silently deleting from a snapshot.
+/// Test: `purge_selects_only_stopword_subjects`,
+/// `purge_dry_run_does_not_prune_expired_drawers`.
 async fn purge_one(state: &AppState, palace_id: &str, apply: bool) -> Result<PalacePurgeSummary> {
-    let pid = PalaceId::new(palace_id);
-    let handle = state
-        .registry
-        .open_palace(&state.data_root, &pid)
-        .with_context(|| format!("open palace {palace_id}"))?;
+    let kg_path = state.data_root.join(palace_id).join("kg.db");
+    let intent = if apply {
+        OpenIntent::Writer
+    } else {
+        OpenIntent::ReadOnlyClient
+    };
+    let kg = KnowledgeGraph::open_with_intent(&kg_path, intent)
+        .with_context(|| format!("open kg for palace {palace_id}"))?;
 
     let mut active: Vec<Triple> = Vec::new();
     let mut offset = 0usize;
     loop {
-        let page = handle
-            .kg
+        let page = kg
             .list_active(PURGE_SCAN_PAGE, offset)
             .await
             .with_context(|| format!("scan active triples in {palace_id}"))?;
@@ -278,32 +382,35 @@ async fn purge_one(state: &AppState, palace_id: &str, apply: bool) -> Result<Pal
         offset += n;
     }
 
-    let subjects = stale_subject_candidates(&active);
-    let mut rows_closed = 0usize;
-    if apply {
-        for subject in &subjects {
-            let store = handle.kg.store();
-            let s = subject.clone();
-            match tokio::task::spawn_blocking(move || store.delete_by_subject(&s)).await {
-                Ok(Ok(n)) => rows_closed += n,
-                Ok(Err(e)) => tracing::warn!(
-                    palace = %palace_id,
-                    subject = %subject,
-                    "kg-rebuild purge: delete failed (non-fatal): {e:#}",
-                ),
-                Err(e) => tracing::warn!(
-                    palace = %palace_id,
-                    subject = %subject,
-                    "kg-rebuild purge: delete task join error: {e:#}",
-                ),
-            }
-        }
-    }
+    let selected = stale_subject_candidates(&active);
+    let outcome = if apply {
+        let store = kg.store();
+        let subjects = selected.clone();
+        tokio::task::spawn_blocking(move || {
+            apply_deletions(&subjects, |s| store.delete_by_subject(s))
+        })
+        .await
+        .with_context(|| format!("purge delete task for palace {palace_id}"))?
+    } else {
+        PurgeOutcome::default()
+    };
+
+    let error = if outcome.failed.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "{} of {} selected subject(s) failed to delete",
+            outcome.failed.len(),
+            selected.len()
+        ))
+    };
     Ok(PalacePurgeSummary {
         palace_id: palace_id.to_string(),
-        subjects,
-        rows_closed,
-        error: None,
+        selected,
+        deleted: outcome.deleted,
+        failed: outcome.failed,
+        rows_closed: outcome.rows_closed,
+        error,
     })
 }
 
@@ -596,6 +703,104 @@ mod tests {
         assert!(!opts.dry_run);
     }
 
+    /// Why: the deletion loop downgraded a failed `delete_by_subject` to a
+    /// `tracing::warn!` and carried on, then returned the unfiltered candidate
+    /// list as the result with `error: None`. The report printed
+    /// `deleted subject=X` for a subject still in the graph and counted it in
+    /// the total, so the only trace of a failure was a log line an operator had
+    /// no reason to read. A purge that cannot delete must not claim it did.
+    /// What: with one subject's delete failing, that subject appears in
+    /// `failed` with its error text and NOT in `deleted`, and its rows are not
+    /// added to `rows_closed`. The loop still completes the other subjects.
+    /// Test: This test.
+    #[test]
+    fn purge_reports_a_failed_delete_as_failed_not_deleted() {
+        let subjects = vec!["them".to_string(), "the".to_string(), "it".to_string()];
+        let outcome = apply_deletions(&subjects, |s| {
+            if s == "the" {
+                anyhow::bail!("store is read-only")
+            } else {
+                Ok(2)
+            }
+        });
+        assert_eq!(
+            outcome.deleted,
+            vec!["them".to_string(), "it".to_string()],
+            "only subjects whose delete returned Ok may be reported as deleted"
+        );
+        assert_eq!(outcome.failed.len(), 1, "the failing subject must be kept");
+        assert_eq!(outcome.failed[0].0, "the");
+        assert!(
+            outcome.failed[0].1.contains("store is read-only"),
+            "the failure must carry its error text, got {:?}",
+            outcome.failed[0].1
+        );
+        assert_eq!(
+            outcome.rows_closed, 4,
+            "a failed delete must contribute no closed rows"
+        );
+    }
+
+    /// Why: `--dry-run` promises it writes nothing, but the scan reached the KG
+    /// through `PalaceHandle::open`, whose issue-#61 reclamation sweep
+    /// hard-deletes every expired non-Tier-C drawer before the caller sees the
+    /// handle. `SessionEvent` drawers carry a 7-day TTL, so a live palace
+    /// always has candidates — a careful operator previewing a destructive flag
+    /// with the daemon stopped got an uncontended read-write open and lost
+    /// drawer rows to the preview itself.
+    /// What: seeds an expired non-Tier-C drawer, runs the dry-run purge from a
+    /// COLD `AppState` (the registry's warm-handle fast path skips the sweep,
+    /// so a shared state would not reproduce it), and asserts the drawer row
+    /// count is unchanged.
+    /// Test: This test.
+    #[tokio::test]
+    async fn purge_dry_run_does_not_prune_expired_drawers() -> Result<()> {
+        use trusty_common::memory_core::palace::{Drawer, DrawerType};
+        use trusty_common::memory_core::store::kg::KnowledgeGraph;
+
+        seed_embedder();
+        let tmp = tempfile::tempdir()?;
+        let data_root = tmp.path().to_path_buf();
+        // SAFETY: idempotent constant write "1"; safe across test threads.
+        unsafe {
+            std::env::set_var("TRUSTY_SKIP_PALACE_ENFORCEMENT", "1");
+        }
+
+        let before = {
+            let state = AppState::new(data_root.clone());
+            state.set_ready();
+            let _ =
+                crate::tools::dispatch_tool(&state, "palace_create", json!({"name": "a"})).await?;
+            let handle = state
+                .registry
+                .open_palace(&state.data_root, &PalaceId::new("a"))?;
+            let mut drawer = Drawer::new(uuid::Uuid::new_v4(), "an expired session event");
+            drawer.drawer_type = DrawerType::SessionEvent;
+            drawer.expires_at = Some(chrono::Utc::now() - chrono::Duration::days(1));
+            drawer.fact_key = None; // not Tier C, so the sweep considers it
+            handle.kg.upsert_drawer(&drawer).await?;
+            let n = handle.kg.load_drawers()?.len();
+            drop(handle);
+            n
+        };
+        assert!(before > 0, "fixture must seed at least one drawer");
+
+        // Cold state: this is the CLI's own situation with the daemon stopped.
+        {
+            let state = AppState::new(data_root.clone());
+            let summaries = purge_palaces(&state, Some("a"), false).await?;
+            assert_eq!(summaries.len(), 1, "palace 'a' must be scanned");
+        }
+
+        let kg = KnowledgeGraph::open(&data_root.join("a").join("kg.db"))?;
+        let after = kg.load_drawers()?.len();
+        assert_eq!(
+            before, after,
+            "a dry run must not delete drawer rows; {before} before, {after} after"
+        );
+        Ok(())
+    }
+
     /// Why: the selection tests are pure; this one proves the purge actually
     /// reaches `delete_by_subject` and that `--dry-run` writes nothing — the
     /// two claims that matter when the flag is pointed at a real palace.
@@ -632,7 +837,8 @@ mod tests {
         // Dry run: reports the stale subject, deletes nothing.
         let dry = purge_palaces(&state, Some("a"), false).await?;
         assert_eq!(dry.len(), 1);
-        assert_eq!(dry[0].subjects, vec!["them".to_string()]);
+        assert_eq!(dry[0].selected, vec!["them".to_string()]);
+        assert!(dry[0].deleted.is_empty(), "a dry run deletes nothing");
         assert_eq!(dry[0].rows_closed, 0, "a dry run must not close any row");
         assert!(
             !handle.kg.query_active("them").await?.is_empty(),
@@ -641,7 +847,10 @@ mod tests {
 
         // Applied: closes the stale subject and spares the real one.
         let applied = purge_palaces(&state, Some("a"), true).await?;
-        assert_eq!(applied[0].subjects, vec!["them".to_string()]);
+        assert_eq!(applied[0].selected, vec!["them".to_string()]);
+        assert_eq!(applied[0].deleted, vec!["them".to_string()]);
+        assert!(applied[0].failed.is_empty(), "no delete should have failed");
+        assert!(applied[0].error.is_none(), "a clean purge sets no error");
         assert!(
             applied[0].rows_closed > 0,
             "applied purge must close at least one row"

--- a/crates/trusty-memory/src/kg_extract.rs
+++ b/crates/trusty-memory/src/kg_extract.rs
@@ -601,18 +601,26 @@ const TOKEN_EDGE_PUNCT: &[char] = &[
 /// live graph. This is the single gate both the extractor and the
 /// `--purge-stale-subjects` back-fill consult, so forward extraction and
 /// historical clean-up can never disagree about what counts as garbage.
-/// What: normalises `tok` (trim whitespace, strip [`TOKEN_EDGE_PUNCT`] from
-/// both edges, lower-case) and rejects it when the result is empty, appears in
-/// [`STOPWORDS`], or is shorter than [`MIN_ENTITY_TOKEN_LEN`] without being in
-/// [`SHORT_ENTITY_ALLOWLIST`]. Length is counted in `char`s, not bytes, so a
-/// multi-byte token is not mis-measured. Purely lexical: it judges the token
-/// alone and knows nothing of the sentence, so it cannot catch a triple whose
-/// tokens are both ordinary words (see #4678 for the residue).
+/// What: normalises `tok` through [`clean_token`], lower-cases it, and rejects
+/// it when the result is empty, appears in [`STOPWORDS`], or is shorter than
+/// [`MIN_ENTITY_TOKEN_LEN`] without being in [`SHORT_ENTITY_ALLOWLIST`].
+/// Length is counted in `char`s, not bytes, so a multi-byte token is not
+/// mis-measured. Purely lexical: it judges the token alone and knows nothing of
+/// the sentence, so it cannot catch a triple whose tokens are both ordinary
+/// words (see #4678 for the residue).
+///
+/// The normalisation step is NOT redundant with `clean_token`'s use in
+/// `first_token` / `last_token`. Those clean tokens on the way IN, which only
+/// helps content extracted from now on. The `--purge-stale-subjects` path calls
+/// this on subjects read back out of redb, and those were written by the old
+/// extractor with the punctuation already welded on — normalising here is what
+/// lets a stored `("the` be recognised as the stopword it is.
 /// Test: `is_stop_token_rejects_every_stopword`,
 /// `is_stop_token_accepts_ordinary_entities`,
-/// `is_stop_token_normalises_surrounding_punctuation`.
+/// `is_stop_token_normalises_surrounding_punctuation`,
+/// `purge_selects_a_legacy_subject_with_welded_punctuation`.
 pub fn is_stop_token(tok: &str) -> bool {
-    let norm = tok.trim().trim_matches(TOKEN_EDGE_PUNCT).to_lowercase();
+    let norm = clean_token(tok).to_lowercase();
     if norm.is_empty() {
         return true;
     }
@@ -664,12 +672,14 @@ fn extract_patterns(content: &str) -> Vec<(String, String, String)> {
 ///
 /// Why: The left side of a pattern hit can contain arbitrary preamble; the
 /// entity we care about is the noun immediately before the marker.
-/// What: Trims trailing punctuation off the last whitespace-delimited token.
-/// Test: indirectly via `extract_triples_extracts_is_a_pattern`.
+/// What: Returns the last whitespace-delimited token with [`TOKEN_EDGE_PUNCT`]
+/// stripped from both edges.
+/// Test: `extract_triples_extracts_is_a_pattern`,
+/// `extract_triples_strips_punctuation_from_both_token_edges`.
 fn last_token(s: &str) -> String {
     s.split_whitespace()
         .last()
-        .map(|t| t.trim_end_matches([',', '.', ';', ':', '!', '?', '"', '\'']))
+        .map(clean_token)
         .unwrap_or("")
         .to_string()
 }
@@ -677,14 +687,31 @@ fn last_token(s: &str) -> String {
 /// Pull the first whitespace-delimited token from a fragment.
 ///
 /// Why: Mirror of `last_token` for the right side of a pattern hit.
-/// What: Trims leading punctuation off the first whitespace-delimited token.
-/// Test: indirectly via `extract_triples_extracts_is_a_pattern`.
+/// What: Returns the first whitespace-delimited token, cleaned identically.
+/// Test: `extract_triples_extracts_is_a_pattern`,
+/// `extract_triples_strips_punctuation_from_both_token_edges`.
 fn first_token(s: &str) -> String {
     s.split_whitespace()
         .next()
-        .map(|t| t.trim_end_matches([',', '.', ';', ':', '!', '?', '"', '\'']))
+        .map(clean_token)
         .unwrap_or("")
         .to_string()
+}
+
+/// Strip surrounding punctuation from one raw token.
+///
+/// Why: #4678 — `first_token` trimmed a TRAILING run while its doc promised a
+/// leading one, and both helpers used a set that omitted the characters drawer
+/// content actually wraps names in (backticks, brackets, asterisks). So
+/// `` `redb` `` reached the graph verbatim and became a second node for an
+/// entity that already had one. Which SIDE of the marker a token sits on says
+/// nothing about which edge carries punctuation, so both helpers clean both
+/// edges through this one function rather than each guessing.
+/// What: trims whitespace, then [`TOKEN_EDGE_PUNCT`] from both ends. Interior
+/// characters are untouched, so `no-op`, `c#`, and `src/main.rs` survive whole.
+/// Test: `extract_triples_strips_punctuation_from_both_token_edges`.
+fn clean_token(raw: &str) -> &str {
+    raw.trim().trim_matches(TOKEN_EDGE_PUNCT)
 }
 
 #[cfg(test)]
@@ -1033,6 +1060,58 @@ mod tests {
         }
     }
 
+    /// Why: `first_token` trimmed only a TRAILING run while its doc promised it
+    /// stripped the leading one, so an entity quoted the way drawer content
+    /// actually quotes things — markdown backticks, brackets, an opening
+    /// quote — entered the graph with the punctuation welded on: `` `redb ``
+    /// rather than `redb`. Two spellings of one entity are two nodes that never
+    /// join up.
+    /// What: pins the emitted strings. Both helpers strip punctuation from BOTH
+    /// edges, so the subject side (`last_token`) is covered too, and no emitted
+    /// token may retain an edge character.
+    /// Test: This test.
+    #[test]
+    fn extract_triples_strips_punctuation_from_both_token_edges() {
+        let cases: &[(&str, (&str, &str, &str))] = &[
+            // Object side, markdown backticks — the common shape in drawers.
+            (
+                "trusty-memory uses `redb` for persistence",
+                ("trusty-memory", "uses", "redb"),
+            ),
+            // Object side, parenthesised.
+            (
+                "the daemon uses (tantivy) for search",
+                ("daemon", "uses", "tantivy"),
+            ),
+            // Subject side, opening quote with no closing one before the marker.
+            (
+                "he said \"rustc is a compiler for rust",
+                ("rustc", "is-a", "compiler"),
+            ),
+            // Object side, bold markdown.
+            (
+                "trusty-search depends on **trusty-common** for helpers",
+                ("trusty-search", "depends-on", "trusty-common"),
+            ),
+        ];
+        for (content, (s, p, o)) in cases {
+            let got = patterns_for(content);
+            let want = ((*s).to_string(), (*p).to_string(), (*o).to_string());
+            assert!(
+                got.contains(&want),
+                "content {content:?} must emit {want:?}, got {got:?}"
+            );
+            for (subject, _, object) in &got {
+                for tok in [subject, object] {
+                    assert!(
+                        !tok.starts_with(TOKEN_EDGE_PUNCT) && !tok.ends_with(TOKEN_EDGE_PUNCT),
+                        "emitted token {tok:?} still carries edge punctuation"
+                    );
+                }
+            }
+        }
+    }
+
     /// Why: a duplicated entry is dead weight and a sign the categories drifted
     /// apart during editing.
     /// What: every [`STOPWORDS`] entry appears exactly once and is already
@@ -1134,10 +1213,15 @@ mod tests {
     /// cannot reach the other two: `exhaustiveness`, `hard`, `squash` and
     /// `ancestor` are all ordinary content words, indistinguishable token-wise
     /// from the `rustc --is-a--> compiler` the extractor is supposed to keep.
-    /// What: pins that residue as CURRENT behaviour rather than leaving it
-    /// unstated — these two still extract. A future change that rejects them
-    /// (sentence-level context, head-noun selection) must delete this test on
-    /// purpose, not discover the gap by accident.
+    /// Rejecting them needs sentence-level context or head-noun selection,
+    /// which is a different change from this one.
+    ///
+    /// The owner has ruled that lexical filtering alone therefore does NOT
+    /// satisfy ADR-0038 precondition 3. This test is the standing record of
+    /// that open gate, tracked as its own issue — not a temporary note. Do not
+    /// delete it because it looks like it asserts a bug: it does, deliberately,
+    /// and the gate closes with the issue, not with this file.
+    /// What: pins the residue as CURRENT behaviour — these two still extract.
     /// Test: This test.
     #[test]
     fn lexical_filter_does_not_reach_the_two_content_word_regressions() {

--- a/crates/trusty-memory/src/kg_extract.rs
+++ b/crates/trusty-memory/src/kg_extract.rs
@@ -317,6 +317,311 @@ const PATTERN_TABLE: &[(&str, &[&str])] = &[
     ("depends-on", &[" depends on ", " requires "]),
 ];
 
+/// Function words that can never be a KG entity.
+///
+/// Why: #4678 — a [`PATTERN_TABLE`] marker hit says a marker phrase appeared,
+/// not that the tokens either side of it name anything. "calling them is a
+/// no-op" put `them --is-a--> no-op` into the live palace. Grouped by part of
+/// speech because the boundary is grammatical, not statistical: these are the
+/// closed word classes English never coins new members of, so the list is
+/// finite and stable rather than a frequency cut-off that needs re-tuning.
+/// What: a flat lower-case slice, matched exactly against a normalised token
+/// by [`is_stop_token`]. Membership is checked with a linear scan — it runs at
+/// most twice per pattern hit and at most four hits exist per drawer.
+/// Test: `stopwords_are_unique`, `is_stop_token_rejects_every_stopword`.
+const STOPWORDS: &[&str] = &[
+    // Articles and determiners.
+    "a",
+    "an",
+    "the",
+    "this",
+    "that",
+    "these",
+    "those",
+    "some",
+    "any",
+    "each",
+    "every",
+    "all",
+    "both",
+    "either",
+    "neither",
+    "another",
+    "such",
+    "same",
+    "no",
+    "none",
+    // Pronouns.
+    "i",
+    "me",
+    "my",
+    "mine",
+    "myself",
+    "we",
+    "us",
+    "our",
+    "ours",
+    "ourselves",
+    "you",
+    "your",
+    "yours",
+    "yourself",
+    "he",
+    "him",
+    "his",
+    "himself",
+    "she",
+    "her",
+    "hers",
+    "herself",
+    "it",
+    "its",
+    "itself",
+    "they",
+    "them",
+    "their",
+    "theirs",
+    "themselves",
+    "who",
+    "whom",
+    "whose",
+    "which",
+    "what",
+    "one",
+    "ones",
+    "someone",
+    "something",
+    "anyone",
+    "anything",
+    "everyone",
+    "everything",
+    "nobody",
+    "nothing",
+    "others",
+    // Prepositions.
+    "of",
+    "in",
+    "on",
+    "at",
+    "to",
+    "for",
+    "with",
+    "by",
+    "from",
+    "about",
+    "into",
+    "onto",
+    "over",
+    "under",
+    "below",
+    "above",
+    "between",
+    "among",
+    "through",
+    "during",
+    "before",
+    "after",
+    "across",
+    "against",
+    "within",
+    "without",
+    "upon",
+    "per",
+    "via",
+    "than",
+    "toward",
+    "towards",
+    "off",
+    "out",
+    "up",
+    "down",
+    "near",
+    "around",
+    "behind",
+    "beyond",
+    "beside",
+    "along",
+    "past",
+    "throughout",
+    // Conjunctions and subordinators.
+    "and",
+    "or",
+    "but",
+    "nor",
+    "so",
+    "yet",
+    "if",
+    "then",
+    "else",
+    "because",
+    "while",
+    "when",
+    "where",
+    "whether",
+    "though",
+    "although",
+    "since",
+    "as",
+    "unless",
+    "until",
+    "whereas",
+    // Copulas, auxiliaries and modals.
+    "is",
+    "are",
+    "was",
+    "were",
+    "be",
+    "been",
+    "being",
+    "am",
+    "do",
+    "does",
+    "did",
+    "done",
+    "doing",
+    "has",
+    "have",
+    "had",
+    "having",
+    "can",
+    "could",
+    "will",
+    "would",
+    "shall",
+    "should",
+    "may",
+    "might",
+    "must",
+    "ought",
+    "need",
+    "needs",
+    "let",
+    "lets",
+    "get",
+    "gets",
+    "got",
+    "gotten",
+    // Degree, negation and discourse adverbs — closed-class fillers that sit
+    // next to a marker often and name nothing.
+    "not",
+    "only",
+    "just",
+    "also",
+    "very",
+    "too",
+    "still",
+    "already",
+    "always",
+    "never",
+    "often",
+    "again",
+    "here",
+    "there",
+    "now",
+    "actually",
+    "really",
+    "simply",
+    "merely",
+    "quite",
+    "rather",
+    "even",
+    "ever",
+    "once",
+    "yes",
+    "well",
+    "much",
+    "many",
+    "more",
+    "most",
+    "less",
+    "least",
+    "few",
+    "several",
+    "enough",
+    "almost",
+    "perhaps",
+    "maybe",
+    "instead",
+    "otherwise",
+    "hence",
+    "therefore",
+    "however",
+    "thus",
+    "moreover",
+];
+
+/// Minimum character length for a token to be accepted as an entity.
+///
+/// Why: one- and two-character tokens are overwhelmingly punctuation debris,
+/// initials, or list markers rather than entities.
+/// What: `3`. Tokens shorter than this are rejected unless they appear in
+/// [`SHORT_ENTITY_ALLOWLIST`].
+/// Test: `extract_triples_rejects_short_token_off_allowlist`.
+pub const MIN_ENTITY_TOKEN_LEN: usize = 3;
+
+/// Short tokens that are real entities in this workspace's subject matter.
+///
+/// Why: [`MIN_ENTITY_TOKEN_LEN`] would otherwise reject the languages, crate
+/// aliases, and infrastructure abbreviations these palaces actually discuss —
+/// a precision filter that silently drops `Go` and `C` costs recall for
+/// nothing. The crate aliases (`tm`, `ts`, `tc`, `ta`) come from this repo's
+/// own abbreviation table.
+/// What: lower-case tokens of fewer than [`MIN_ENTITY_TOKEN_LEN`] characters
+/// that bypass the length floor. The stopword check still applies first, so an
+/// entry here cannot resurrect a function word.
+/// Test: `extract_triples_keeps_allowlisted_go`,
+/// `extract_triples_keeps_allowlisted_c`,
+/// `short_entity_allowlist_entries_survive_the_length_floor`.
+pub const SHORT_ENTITY_ALLOWLIST: &[&str] = &[
+    // Languages and language-shaped tokens.
+    "go", "c", "c#", "js", "ts", "py", "ml", // Domains and infrastructure.
+    "ai", "kg", "db", "ui", "os", "io", "vm", "ip", // Process and workspace aliases.
+    "pr", "ci", "qa", "pm", "tm", "tc", "ta",
+];
+
+/// Punctuation stripped from a token's edges before it is classified.
+///
+/// Why: `last_token` / `first_token` only strip a trailing run, so a token can
+/// still arrive as `("the` or `` `redb` ``. Comparing that against
+/// [`STOPWORDS`] would miss, and the filter would leak exactly the tokens it
+/// exists to catch.
+/// What: the edge characters [`is_stop_token`] trims before matching. Interior
+/// characters are untouched, so `no-op` and `c#` survive intact.
+/// Test: `is_stop_token_normalises_surrounding_punctuation`.
+const TOKEN_EDGE_PUNCT: &[char] = &[
+    '(', ')', '[', ']', '{', '}', '<', '>', '"', '\'', '`', ',', '.', ';', ':', '!', '?', '*', '_',
+    '-', '/', '\\', '|', '—', '–', '…', '“', '”', '‘', '’',
+];
+
+/// Whether `tok` must be refused as a KG entity.
+///
+/// Why: #4678 — the pattern pass treated any whitespace-delimited token beside
+/// a marker as an entity, which is how `them --is-a--> no-op`,
+/// `exhaustiveness --is-a--> hard`, and `squash --is-a--> ancestor` reached the
+/// live graph. This is the single gate both the extractor and the
+/// `--purge-stale-subjects` back-fill consult, so forward extraction and
+/// historical clean-up can never disagree about what counts as garbage.
+/// What: normalises `tok` (trim whitespace, strip [`TOKEN_EDGE_PUNCT`] from
+/// both edges, lower-case) and rejects it when the result is empty, appears in
+/// [`STOPWORDS`], or is shorter than [`MIN_ENTITY_TOKEN_LEN`] without being in
+/// [`SHORT_ENTITY_ALLOWLIST`]. Length is counted in `char`s, not bytes, so a
+/// multi-byte token is not mis-measured. Purely lexical: it judges the token
+/// alone and knows nothing of the sentence, so it cannot catch a triple whose
+/// tokens are both ordinary words (see #4678 for the residue).
+/// Test: `is_stop_token_rejects_every_stopword`,
+/// `is_stop_token_accepts_ordinary_entities`,
+/// `is_stop_token_normalises_surrounding_punctuation`.
+pub fn is_stop_token(tok: &str) -> bool {
+    let norm = tok.trim().trim_matches(TOKEN_EDGE_PUNCT).to_lowercase();
+    if norm.is_empty() {
+        return true;
+    }
+    if STOPWORDS.contains(&norm.as_str()) {
+        return true;
+    }
+    norm.chars().count() < MIN_ENTITY_TOKEN_LEN && !SHORT_ENTITY_ALLOWLIST.contains(&norm.as_str())
+}
+
 /// Apply the pattern table to a single content blob.
 ///
 /// Why: Keeps the matching loop out of `extract_triples` so the dispatcher
@@ -324,8 +629,13 @@ const PATTERN_TABLE: &[(&str, &[&str])] = &[
 /// What: For every `(predicate, markers)` row, scan every marker against the
 /// lower-cased content; on the first hit emit `(left_token, predicate,
 /// right_token)` and move on to the next predicate. Only the first hit per
-/// predicate is taken to avoid combinatorial output on long texts.
-/// Test: `extract_triples_extracts_is_a_pattern`.
+/// predicate is taken to avoid combinatorial output on long texts. A hit whose
+/// subject or object fails [`is_stop_token`] emits nothing and still consumes
+/// the predicate's turn, so one rejected hit never cascades into a scan for a
+/// second, lower-quality match later in the blob.
+/// Test: `extract_triples_extracts_is_a_pattern`,
+/// `extract_triples_rejects_pronoun_subject`,
+/// `extract_triples_rejects_stopword_object`.
 fn extract_patterns(content: &str) -> Vec<(String, String, String)> {
     let lower = content.to_lowercase();
     let mut out: Vec<(String, String, String)> = Vec::new();
@@ -337,7 +647,10 @@ fn extract_patterns(content: &str) -> Vec<(String, String, String)> {
                 let right = lower[right_start..].trim();
                 let subject_tok = last_token(left);
                 let object_tok = first_token(right);
-                if !subject_tok.is_empty() && !object_tok.is_empty() {
+                // #4678: a marker hit is not evidence of two entities — reject
+                // the whole triple when either side is a function word or too
+                // short, never half of it.
+                if !is_stop_token(&subject_tok) && !is_stop_token(&object_tok) {
                     out.push((subject_tok, (*predicate).to_string(), object_tok));
                 }
                 break;
@@ -577,6 +890,273 @@ mod tests {
         assert!(
             triples.is_empty(),
             "upper-cased deny tag must still be blocked"
+        );
+    }
+
+    /// Collect only the triples produced by the [`PATTERN_TABLE`] pass.
+    ///
+    /// Why: every assertion about extraction precision is about the pattern
+    /// pass; the tag / room / hashtag passes always fire and would otherwise
+    /// mask a "zero triples" assertion.
+    /// What: filters by predicate against [`PATTERN_TABLE`].
+    /// Test: used by every precision test below.
+    fn pattern_triples(triples: &[Triple]) -> Vec<(String, String, String)> {
+        let predicates: Vec<&str> = PATTERN_TABLE.iter().map(|(p, _)| *p).collect();
+        triples
+            .iter()
+            .filter(|t| predicates.contains(&t.predicate.as_str()))
+            .map(|t| (t.subject.clone(), t.predicate.clone(), t.object.clone()))
+            .collect()
+    }
+
+    /// Run the extractor over bare content with no tags and no room.
+    ///
+    /// Why: the precision fixtures care only about content; tags and rooms
+    /// would add noise triples to every assertion.
+    /// What: builds an `ExtractInput` with empty tags and no room.
+    /// Test: used by every precision test below.
+    fn patterns_for(content: &str) -> Vec<(String, String, String)> {
+        let triples = extract_triples(&ExtractInput {
+            drawer_id: Uuid::new_v4(),
+            content,
+            tags: &[],
+            room: None,
+        });
+        pattern_triples(&triples)
+    }
+
+    /// Why: `them --is-a--> no-op` is live in the real trusty-tools palace
+    /// (asserted 2026-08-04). A marker hit is not evidence that the tokens
+    /// either side of it are entities; a pronoun never is one.
+    /// What: "calling them is a no-op ..." must yield zero pattern triples.
+    /// Test: This test.
+    #[test]
+    fn extract_triples_rejects_pronoun_subject() {
+        let got = patterns_for("calling them is a no-op when the flag is off");
+        assert!(
+            got.is_empty(),
+            "pronoun subject must reject the whole triple, got {got:?}"
+        );
+    }
+
+    /// Why: a stopword can land on either side of a marker, so filtering only
+    /// the subject would still admit `libpq --depends-on--> the`.
+    /// What: "libpq depends on the license" must yield zero pattern triples —
+    /// the triple is rejected whole, never truncated to a half-triple.
+    /// Test: This test.
+    #[test]
+    fn extract_triples_rejects_stopword_object() {
+        let got = patterns_for("libpq depends on the license header");
+        assert!(
+            got.is_empty(),
+            "stopword object must reject the whole triple, got {got:?}"
+        );
+    }
+
+    /// Why: a one- or two-character token is almost never an entity, and the
+    /// extractor had no length floor at all.
+    /// What: "x is a thing" must yield zero pattern triples.
+    /// Test: This test.
+    #[test]
+    fn extract_triples_rejects_short_token_off_allowlist() {
+        let got = patterns_for("x is a thing worth recording");
+        assert!(
+            got.is_empty(),
+            "short token off the allowlist must be rejected, got {got:?}"
+        );
+    }
+
+    /// Why: the length floor must not swallow the short names this repo
+    /// genuinely discusses — without the allowlist, `Go` and `C` would be
+    /// rejected as noise and the filter would cost real recall.
+    /// What: "Go is a language" still extracts `go --is-a--> language`.
+    /// Test: This test.
+    #[test]
+    fn extract_triples_keeps_allowlisted_go() {
+        let got = patterns_for("Go is a language with green threads");
+        assert!(
+            got.contains(&("go".into(), "is-a".into(), "language".into())),
+            "allowlisted `Go` must survive the length floor, got {got:?}"
+        );
+    }
+
+    /// Why: `C` is the single-character case — the length floor's worst
+    /// false positive if the allowlist is not consulted.
+    /// What: "C is a language" still extracts `c --is-a--> language`.
+    /// Test: This test.
+    #[test]
+    fn extract_triples_keeps_allowlisted_c() {
+        let got = patterns_for("C is a language without a runtime");
+        assert!(
+            got.contains(&("c".into(), "is-a".into(), "language".into())),
+            "allowlisted `C` must survive the length floor, got {got:?}"
+        );
+    }
+
+    /// Why: the filter must not cost recall on ordinary, well-formed content.
+    /// A rejection filter that also rejects the good cases is a regression,
+    /// so every predicate in [`PATTERN_TABLE`] keeps a worked example.
+    /// What: table-driven — each row is `(content, expected triple)` and must
+    /// appear in the extracted pattern set.
+    /// Test: This test.
+    #[test]
+    fn extract_triples_keeps_real_entities_across_all_predicates() {
+        let cases: &[(&str, (&str, &str, &str))] = &[
+            (
+                "tokio is an executor for async rust",
+                ("tokio", "is-a", "executor"),
+            ),
+            (
+                "masa works at duetto research today",
+                ("masa", "works-at", "duetto"),
+            ),
+            (
+                "trusty-memory uses redb for persistence",
+                ("trusty-memory", "uses", "redb"),
+            ),
+            (
+                "trusty-search depends on trusty-common for shared helpers",
+                ("trusty-search", "depends-on", "trusty-common"),
+            ),
+            (
+                "the embedder requires onnxruntime at startup",
+                ("embedder", "depends-on", "onnxruntime"),
+            ),
+        ];
+        for (content, (s, p, o)) in cases {
+            let got = patterns_for(content);
+            let want = ((*s).to_string(), (*p).to_string(), (*o).to_string());
+            assert!(
+                got.contains(&want),
+                "content {content:?} must still extract {want:?}, got {got:?}"
+            );
+        }
+    }
+
+    /// Why: a duplicated entry is dead weight and a sign the categories drifted
+    /// apart during editing.
+    /// What: every [`STOPWORDS`] entry appears exactly once and is already
+    /// lower-case, which is what [`is_stop_token`] compares against.
+    /// Test: This test.
+    #[test]
+    fn stopwords_are_unique() {
+        let mut seen: HashSet<&str> = HashSet::new();
+        for w in STOPWORDS {
+            assert!(seen.insert(w), "duplicate stopword {w:?}");
+            assert_eq!(*w, w.to_lowercase(), "stopword {w:?} must be lower-case");
+        }
+    }
+
+    /// Why: the rejection contract is only as good as the list behind it.
+    /// What: every [`STOPWORDS`] entry is rejected, in its own case and
+    /// upper-cased, since content reaches the filter lower-cased but the purge
+    /// path reads subjects straight out of the store.
+    /// Test: This test.
+    #[test]
+    fn is_stop_token_rejects_every_stopword() {
+        for w in STOPWORDS {
+            assert!(is_stop_token(w), "{w:?} must be rejected");
+            assert!(
+                is_stop_token(&w.to_uppercase()),
+                "{w:?} must be rejected case-insensitively"
+            );
+        }
+    }
+
+    /// Why: an over-broad filter costs recall, which is the failure mode that
+    /// would make this change a net loss.
+    /// What: ordinary multi-character entity names are accepted.
+    /// Test: This test.
+    #[test]
+    fn is_stop_token_accepts_ordinary_entities() {
+        for tok in [
+            "rustc",
+            "compiler",
+            "trusty-memory",
+            "redb",
+            "no-op",
+            "onnxruntime",
+            "duetto",
+        ] {
+            assert!(!is_stop_token(tok), "{tok:?} must be accepted");
+        }
+    }
+
+    /// Why: `first_token` / `last_token` strip only a trailing run, so a token
+    /// can still carry an opening bracket or backtick. Comparing that raw
+    /// against the list would miss the stopword it is meant to catch.
+    /// What: edge punctuation is stripped before matching, interior characters
+    /// are not, and a token that is nothing but punctuation is rejected.
+    /// Test: This test.
+    #[test]
+    fn is_stop_token_normalises_surrounding_punctuation() {
+        assert!(
+            is_stop_token("(the"),
+            "leading bracket must not hide a stopword"
+        );
+        assert!(is_stop_token("`it`"), "backticks must not hide a stopword");
+        assert!(
+            is_stop_token("---"),
+            "punctuation-only token must be rejected"
+        );
+        assert!(
+            is_stop_token("   "),
+            "whitespace-only token must be rejected"
+        );
+        assert!(
+            !is_stop_token("`redb`"),
+            "interior name must survive trimming"
+        );
+        assert!(
+            !is_stop_token("no-op"),
+            "interior hyphen must survive trimming"
+        );
+    }
+
+    /// Why: the allowlist is the length floor's escape hatch; if an entry stops
+    /// working the floor silently starts eating real entities.
+    /// What: every [`SHORT_ENTITY_ALLOWLIST`] entry is accepted, and no entry
+    /// collides with [`STOPWORDS`] (which is checked first and would win).
+    /// Test: This test.
+    #[test]
+    fn short_entity_allowlist_entries_survive_the_length_floor() {
+        for tok in SHORT_ENTITY_ALLOWLIST {
+            assert!(
+                !STOPWORDS.contains(tok),
+                "{tok:?} is on both lists; the stopword check runs first and wins"
+            );
+            assert!(!is_stop_token(tok), "allowlisted {tok:?} must be accepted");
+        }
+    }
+
+    /// Why: #4678 names three live regressions. This filter is lexical — it
+    /// judges one token at a time — so it reaches the first and provably
+    /// cannot reach the other two: `exhaustiveness`, `hard`, `squash` and
+    /// `ancestor` are all ordinary content words, indistinguishable token-wise
+    /// from the `rustc --is-a--> compiler` the extractor is supposed to keep.
+    /// What: pins that residue as CURRENT behaviour rather than leaving it
+    /// unstated — these two still extract. A future change that rejects them
+    /// (sentence-level context, head-noun selection) must delete this test on
+    /// purpose, not discover the gap by accident.
+    /// Test: This test.
+    #[test]
+    fn lexical_filter_does_not_reach_the_two_content_word_regressions() {
+        assert!(
+            !is_stop_token("exhaustiveness")
+                && !is_stop_token("hard")
+                && !is_stop_token("squash")
+                && !is_stop_token("ancestor"),
+            "these are ordinary words; no lexical filter may reject them"
+        );
+        let exhaustiveness = patterns_for("match exhaustiveness is a hard requirement here");
+        assert!(
+            exhaustiveness.contains(&("exhaustiveness".into(), "is-a".into(), "hard".into())),
+            "known #4678 residue; got {exhaustiveness:?}"
+        );
+        let squash = patterns_for("confirm the squash is an ancestor of origin main");
+        assert!(
+            squash.contains(&("squash".into(), "is-a".into(), "ancestor".into())),
+            "known #4678 residue; got {squash:?}"
         );
     }
 

--- a/crates/trusty-memory/src/kg_extract.rs
+++ b/crates/trusty-memory/src/kg_extract.rs
@@ -1034,8 +1034,8 @@ mod tests {
                 ("tokio", "is-a", "executor"),
             ),
             (
-                "masa works at duetto research today",
-                ("masa", "works-at", "duetto"),
+                "alice works at initech today",
+                ("alice", "works-at", "initech"),
             ),
             (
                 "trusty-memory uses redb for persistence",
@@ -1155,7 +1155,7 @@ mod tests {
             "redb",
             "no-op",
             "onnxruntime",
-            "duetto",
+            "initech",
         ] {
             assert!(!is_stop_token(tok), "{tok:?} must be accepted");
         }

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -339,6 +339,21 @@ enum Command {
         /// palace under the data root is processed.
         #[arg(long, value_name = "ID")]
         palace: Option<String>,
+
+        /// Also DELETE auto-extracted subjects the #4678 token filter now
+        /// rejects (pronouns, prepositions, one- and two-character tokens).
+        ///
+        /// Destructive and off by default. The forward filter only stops new
+        /// garbage; a plain rebuild re-asserts and never retracts, so triples
+        /// already in the graph need this pass to leave. Every subject is
+        /// printed as it goes. Pair with --dry-run to see the list first.
+        #[arg(long = "purge-stale-subjects")]
+        purge_stale_subjects: bool,
+
+        /// Report what --purge-stale-subjects would delete and write nothing
+        /// at all — the re-assert pass is skipped too.
+        #[arg(long = "dry-run", requires = "purge_stale_subjects")]
+        dry_run: bool,
     },
 
     /// Inspect or apply the ADR-0027 room registry back-fill.
@@ -690,8 +705,19 @@ async fn main() -> Result<()> {
             palace,
             tags,
         } => handle_note(content, palace, tags).await,
-        Command::KgRebuild { palace } => {
-            trusty_memory::commands::kg_rebuild::handle_kg_rebuild(palace).await
+        Command::KgRebuild {
+            palace,
+            purge_stale_subjects,
+            dry_run,
+        } => {
+            trusty_memory::commands::kg_rebuild::handle_kg_rebuild_with(
+                trusty_memory::commands::kg_rebuild::KgRebuildOptions {
+                    palace,
+                    purge_stale_subjects,
+                    dry_run,
+                },
+            )
+            .await
         }
         Command::Rooms {
             action: RoomsAction::Backfill { palace, apply, .. },
@@ -910,231 +936,10 @@ async fn run_serve(
     }
 }
 
-/// Why: startup tasks (palace hydration, alias discovery, pin scan, and the
-///      issue-#1529 autonomous dream scheduler) are the same regardless of
-///      whether HTTP binds to a fixed or dynamic port; keeping the logic in
-///      a single helper means a new startup task only has to be added in one
-///      place. Previously, `load_palaces_from_disk` was awaited synchronously
-///      before binding the HTTP listener — a single broken `kg.db` (stale WAL
-///      sidecar, corrupt file, permissions) could stall hydration for seconds
-///      per palace, deferring `/health` becoming reachable until every palace
-///      had been visited. The dashboard, MCP clients, and `launchctl`
-///      health-probes all interpret that as "the daemon is dead", so the launchd
-///      job thrashes and operators see no useful output. Spawning hydration as a
-///      background task lets the HTTP server bind immediately; palaces appear in
-///      `palace_list` and the dashboard as each one finishes opening.
-///      Per-palace failures are already logged and skipped inside
-///      `load_palaces_from_disk` so a single bad `kg.db` can never abort the
-///      daemon.
-/// What: clones `state` (cheap — `AppState` derives `Clone` with `Arc`-wrapped
-///       internals) and spawns a background task that:
-///       (1) hydrates persisted palaces from disk with timing logs;
-///       (2) once palaces are live, kicks off issue-#42 alias auto-discovery
-///           against the cwd targeting the default palace (if configured);
-///       (3) runs the issue-#470 single-pass pin scan and populates
-///           `AppState::pin_project_map` (scan-only — NO palace opens);
-///       (4) [issue #1529] spawns per-palace autonomous dream loops via
-///           `dream_scheduler::spawn_dream_scheduler` wired to a watch channel
-///           that the `spawn_shutdown_bridge` task flips on SIGTERM/SIGINT.
-///       Returns immediately — all spawned tasks run concurrently with the HTTP
-///       listener bind.
-/// Test: `spawn_startup_tasks_populates_pin_map` verifies the scan path runs
-///       and populates the map; the log emission is confirmed by the throwaway
-///       daemon run documented in the session notes.
-fn spawn_startup_tasks(state: &AppState) {
-    // Issue #1529: build watch channel for the autonomous dream scheduler.
-    // The sender (`dtx`) is intentionally held here and moved into the
-    // hydration task — the shutdown bridge is only wired AFTER
-    // `spawn_dream_scheduler` returns. This ordering guarantee prevents a
-    // shutdown-race where a SIGTERM that arrives during hydration could flip
-    // the watch to `true` before any dream loops are spawned, causing every
-    // newly-spawned loop to exit immediately on its first iteration. By
-    // spawning the bridge after the loops exist, early-SIGTERM during hydration
-    // is still safe: the loops will see the `true` value on their first poll
-    // and shut down cleanly, which is the correct behaviour. Normal startup
-    // (no early SIGTERM) is unaffected because the bridge task cannot fire
-    // until `trusty_common::shutdown_signal()` resolves.
-    let (dtx, dream_shutdown_rx) = trusty_memory::dream_scheduler::make_shutdown_watch();
-    // Issue #906 / #910 / #911: eager embedder warm-up.
-    // Spawn BEFORE the palace hydration task so the CoreML / CUDA cold compile
-    // (30-120 s on first run) races ahead concurrently and the warm embedder
-    // is likely ready by the time the first `memory_remember` / `memory_recall`
-    // arrives.
-    //
-    // On SUCCESS flip `daemon_readiness` to `Ready` so the recall handlers in
-    // `tools/memory_ops.rs` switch from the BM25/L0/L1-only fallback to full
-    // vector-backed recall (issue #1970; formerly issue #911's hard-error
-    // preflight, which blocked writes/reads outright while Warming — replaced
-    // by graceful degradation that mirrors trusty-search's staged pipeline).
-    //
-    // On FAILURE: log at ERROR, leave state as `Warming`.  The lazy-init path
-    // in `shared_embedder()` will retry on the first real request (and the
-    // bounded timeout there means it will fail fast, not hang). Writes still
-    // succeed while Warming — they defer embedding to a background task
-    // (see `PalaceHandle::remember_with_options` / `defer_embedding`).
-    let warmup_state = state.clone();
-    tokio::spawn(async move {
-        let ws = std::time::Instant::now();
-        tracing::info!("starting background embedder warm-up (issues #906/#910)");
-        match trusty_common::memory_core::retrieval::shared_embedder().await {
-            Ok(_) => {
-                let elapsed_ms = ws.elapsed().as_millis() as u64;
-                tracing::info!(
-                    elapsed_ms,
-                    "background embedder warm-up complete; daemon is now Ready (issues #910/#911)"
-                );
-                warmup_state.set_ready();
-            }
-            Err(e) => tracing::error!(
-                elapsed_ms = ws.elapsed().as_millis() as u64,
-                "background embedder warm-up failed (daemon stays Warming; \
-                 memory ops will return a bounded error on first request): {e:#}"
-            ),
-        }
-    });
-
-    let bg_state = state.clone();
-    tokio::spawn(async move {
-        let started = std::time::Instant::now();
-        tracing::info!("starting background palace hydration");
-        match bg_state.load_palaces_from_disk().await {
-            Ok(count) => tracing::info!(
-                elapsed_ms = started.elapsed().as_millis() as u64,
-                "background palace hydration complete: {count} palaces loaded"
-            ),
-            Err(e) => tracing::error!(
-                elapsed_ms = started.elapsed().as_millis() as u64,
-                "background palace hydration failed: {e:#}"
-            ),
-        }
-
-        // Issue #1529: spawn per-palace autonomous dream loops after hydration.
-        // ORDERING GUARANTEE: spawn_dream_scheduler is called first, then the
-        // shutdown bridge is wired. This ensures the bridge cannot pre-cancel
-        // the loops: loops are created with receivers pointing to a watch that
-        // is still `false`, so they will do their first sleep before the bridge
-        // could ever flip the value.
-        // Spawn all background maintenance loops (dream scheduler + idle-to-disk
-        // eviction ticker) and the shutdown bridge in one call — see
-        // `spawn_background_maintenance` for the #1529 ordering guarantee and the
-        // idle-to-disk RAM-reclaim rationale.
-        let n = trusty_memory::dream_scheduler::spawn_background_maintenance(
-            &bg_state.registry,
-            dream_shutdown_rx,
-            dtx,
-        );
-        tracing::info!(loops = n, "dream_scheduler: {n} loop(s) running (#1529)");
-
-        // BM25 backfill sweep. A no-op while the lexical lane is off, which is
-        // every deployment until the default is flipped: `spawn_startup_backfill`
-        // returns immediately when `bm25_client` is `None`.
-        trusty_memory::bm25_backfill::spawn_startup_backfill(&bg_state);
-
-        // BM25 coverage repair sweep. The write path drops on a full queue,
-        // and before this the only thing that repaired a drop was the next
-        // daemon restart — so the "drops are recoverable" trade was not true
-        // of the running process. Also a no-op while the lane is off.
-        trusty_memory::bm25_repair::spawn_repair_sweep(&bg_state);
-
-        // Issue #42: once palaces are live, kick off auto-discovery against
-        // cwd targeting the default palace (if configured). Without a default
-        // palace there's no obvious destination, so skip — explicit MCP
-        // `discover_aliases` calls still work.
-        if let Some(palace) = bg_state.default_palace.clone() {
-            if let Ok(cwd) = std::env::current_dir() {
-                bg_state.spawn_alias_discovery(palace, cwd);
-            }
-        }
-        // Issue #537: throttled startup update check. Runs once per 24h (on-disk
-        // cache). Result stored in AppState::update_available for /health.
-        // Non-blocking: failure degrades to "no update info" — never aborts startup.
-        {
-            let update_available = bg_state.update_available.clone();
-            tokio::spawn(async move {
-                let crate_name = env!("CARGO_PKG_NAME");
-                let current = env!("CARGO_PKG_VERSION");
-                if let Some(info) =
-                    trusty_common::update::check_throttled(crate_name, current).await
-                {
-                    tracing::info!(
-                        latest = %info.latest,
-                        "update available: {}",
-                        trusty_common::update::notice(&info)
-                    );
-                    eprintln!("{}", trusty_common::update::notice(&info));
-                    if let Ok(mut guard) = update_available.lock() {
-                        *guard = Some(info.latest);
-                    }
-                }
-            });
-        }
-
-        // Issue #470 / #474: single-pass scan-only pin discovery — NO palace
-        // opens. Run on the blocking pool because readdir is blocking I/O;
-        // the scan is bounded (one level under each search root) so it
-        // completes quickly. We populate `pin_project_map` on the shared
-        // `AppState` arc so handlers can look up palace_id → project_path
-        // cheaply.
-        //
-        // Fix #474: the completion log is emitted at `info!` level AND via
-        // `eprintln!` to stderr directly. The `info!` is visible under
-        // `RUST_LOG=info`; the `eprintln!` is visible regardless of the
-        // tracing filter and matches the pattern used by `run_http_on` for
-        // the bind-address announcement. This dual-emit guarantees the
-        // operator can always confirm the scan ran, even when the daemon is
-        // started via launchd (stderr → log file) or with the default
-        // `RUST_LOG=warn` level.
-        let pin_scan_started = std::time::Instant::now();
-        let pin_map_ref = bg_state.pin_project_map.clone();
-        // Fix #880: when a data-dir override is active the daemon is running
-        // in an isolated environment (test rig, CI, parallel run). The
-        // default_search_dirs() scan walks the REAL user environment
-        // (~/Projects, ~/Developer, …) and would import palaces from the
-        // live system into the isolated data root, defeating isolation.
-        // Use an empty search list so the scan is a no-op; the pin map stays
-        // empty for the lifetime of this isolated instance.
-        let override_active = trusty_memory::is_data_dir_override_active();
-        let scan_result = tokio::task::spawn_blocking(move || {
-            let search_dirs = if override_active {
-                Vec::new()
-            } else {
-                trusty_memory::startup_scan::default_search_dirs()
-            };
-            trusty_memory::startup_scan::scan_pin_map(&search_dirs)
-        })
-        .await;
-        match scan_result {
-            Ok(map) => {
-                let count = map.len();
-                let elapsed_ms = pin_scan_started.elapsed().as_millis() as u64;
-                for (palace_id, project_path) in map {
-                    pin_map_ref.insert(palace_id, project_path);
-                }
-                // Dual-emit: tracing INFO (visible under RUST_LOG=info) +
-                // eprintln! to stderr (visible at any filter level, matching
-                // the `run_http_on` bind-address announcement pattern).
-                // Root cause of #474: when the daemon is started via
-                // `trusty-memory start`, the child's stderr is redirected to
-                // /dev/null and tracing output is silently lost; when started
-                // via launchd the default RUST_LOG=warn suppresses info!.
-                // eprintln! bypasses the tracing filter so the completion is
-                // always visible in launchd logs and on the operator's
-                // terminal when run in the foreground.
-                tracing::info!(
-                    pins_found = count,
-                    elapsed_ms,
-                    "startup pin scan complete: {count} pin(s) discovered in {elapsed_ms}ms"
-                );
-                eprintln!("startup pin scan complete: {count} pin(s) discovered in {elapsed_ms}ms");
-            }
-            Err(e) => {
-                // spawn_blocking join error — should not happen in practice.
-                tracing::warn!("startup pin scan task panicked or was cancelled: {e}");
-                eprintln!("startup pin scan task panicked or was cancelled: {e}");
-            }
-        }
-    });
-}
+// #4678: moved out of this file to keep it under the 500 SLOC cap.
+#[path = "startup_tasks.rs"]
+mod startup_tasks;
+use startup_tasks::spawn_startup_tasks;
 
 // CLI parse tests: `serve --http` / `--stdio` semantics (#914 PR4)
 #[cfg(test)]

--- a/crates/trusty-memory/src/startup_tasks.rs
+++ b/crates/trusty-memory/src/startup_tasks.rs
@@ -1,0 +1,237 @@
+//! Background startup tasks for the `trusty-memory` daemon binary.
+//!
+//! Why: split out of `main.rs` in #4678, which pushed that file to 510 SLOC
+//! against the 500 cap. This function was the largest self-contained unit
+//! there and depends only on the public `trusty_memory` surface, so it moves
+//! without touching the CLI definition or the dispatch table.
+//! What: `spawn_startup_tasks` — embedder warm-up, palace hydration, dream
+//! scheduler, BM25 sweeps, alias discovery, update check, and the pin scan.
+//! Test: `startup_task_tests::spawn_startup_tasks_populates_pin_map`.
+
+use trusty_memory::AppState;
+
+/// Why: startup tasks (palace hydration, alias discovery, pin scan, and the
+///      issue-#1529 autonomous dream scheduler) are the same regardless of
+///      whether HTTP binds to a fixed or dynamic port; keeping the logic in
+///      a single helper means a new startup task only has to be added in one
+///      place. Previously, `load_palaces_from_disk` was awaited synchronously
+///      before binding the HTTP listener — a single broken `kg.db` (stale WAL
+///      sidecar, corrupt file, permissions) could stall hydration for seconds
+///      per palace, deferring `/health` becoming reachable until every palace
+///      had been visited. The dashboard, MCP clients, and `launchctl`
+///      health-probes all interpret that as "the daemon is dead", so the launchd
+///      job thrashes and operators see no useful output. Spawning hydration as a
+///      background task lets the HTTP server bind immediately; palaces appear in
+///      `palace_list` and the dashboard as each one finishes opening.
+///      Per-palace failures are already logged and skipped inside
+///      `load_palaces_from_disk` so a single bad `kg.db` can never abort the
+///      daemon.
+/// What: clones `state` (cheap — `AppState` derives `Clone` with `Arc`-wrapped
+///       internals) and spawns a background task that:
+///       (1) hydrates persisted palaces from disk with timing logs;
+///       (2) once palaces are live, kicks off issue-#42 alias auto-discovery
+///           against the cwd targeting the default palace (if configured);
+///       (3) runs the issue-#470 single-pass pin scan and populates
+///           `AppState::pin_project_map` (scan-only — NO palace opens);
+///       (4) [issue #1529] spawns per-palace autonomous dream loops via
+///           `dream_scheduler::spawn_dream_scheduler` wired to a watch channel
+///           that the `spawn_shutdown_bridge` task flips on SIGTERM/SIGINT.
+///       Returns immediately — all spawned tasks run concurrently with the HTTP
+///       listener bind.
+/// Test: `spawn_startup_tasks_populates_pin_map` verifies the scan path runs
+///       and populates the map; the log emission is confirmed by the throwaway
+///       daemon run documented in the session notes.
+pub(crate) fn spawn_startup_tasks(state: &AppState) {
+    // Issue #1529: build watch channel for the autonomous dream scheduler.
+    // The sender (`dtx`) is intentionally held here and moved into the
+    // hydration task — the shutdown bridge is only wired AFTER
+    // `spawn_dream_scheduler` returns. This ordering guarantee prevents a
+    // shutdown-race where a SIGTERM that arrives during hydration could flip
+    // the watch to `true` before any dream loops are spawned, causing every
+    // newly-spawned loop to exit immediately on its first iteration. By
+    // spawning the bridge after the loops exist, early-SIGTERM during hydration
+    // is still safe: the loops will see the `true` value on their first poll
+    // and shut down cleanly, which is the correct behaviour. Normal startup
+    // (no early SIGTERM) is unaffected because the bridge task cannot fire
+    // until `trusty_common::shutdown_signal()` resolves.
+    let (dtx, dream_shutdown_rx) = trusty_memory::dream_scheduler::make_shutdown_watch();
+    // Issue #906 / #910 / #911: eager embedder warm-up.
+    // Spawn BEFORE the palace hydration task so the CoreML / CUDA cold compile
+    // (30-120 s on first run) races ahead concurrently and the warm embedder
+    // is likely ready by the time the first `memory_remember` / `memory_recall`
+    // arrives.
+    //
+    // On SUCCESS flip `daemon_readiness` to `Ready` so the recall handlers in
+    // `tools/memory_ops.rs` switch from the BM25/L0/L1-only fallback to full
+    // vector-backed recall (issue #1970; formerly issue #911's hard-error
+    // preflight, which blocked writes/reads outright while Warming — replaced
+    // by graceful degradation that mirrors trusty-search's staged pipeline).
+    //
+    // On FAILURE: log at ERROR, leave state as `Warming`.  The lazy-init path
+    // in `shared_embedder()` will retry on the first real request (and the
+    // bounded timeout there means it will fail fast, not hang). Writes still
+    // succeed while Warming — they defer embedding to a background task
+    // (see `PalaceHandle::remember_with_options` / `defer_embedding`).
+    let warmup_state = state.clone();
+    tokio::spawn(async move {
+        let ws = std::time::Instant::now();
+        tracing::info!("starting background embedder warm-up (issues #906/#910)");
+        match trusty_common::memory_core::retrieval::shared_embedder().await {
+            Ok(_) => {
+                let elapsed_ms = ws.elapsed().as_millis() as u64;
+                tracing::info!(
+                    elapsed_ms,
+                    "background embedder warm-up complete; daemon is now Ready (issues #910/#911)"
+                );
+                warmup_state.set_ready();
+            }
+            Err(e) => tracing::error!(
+                elapsed_ms = ws.elapsed().as_millis() as u64,
+                "background embedder warm-up failed (daemon stays Warming; \
+                 memory ops will return a bounded error on first request): {e:#}"
+            ),
+        }
+    });
+
+    let bg_state = state.clone();
+    tokio::spawn(async move {
+        let started = std::time::Instant::now();
+        tracing::info!("starting background palace hydration");
+        match bg_state.load_palaces_from_disk().await {
+            Ok(count) => tracing::info!(
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "background palace hydration complete: {count} palaces loaded"
+            ),
+            Err(e) => tracing::error!(
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "background palace hydration failed: {e:#}"
+            ),
+        }
+
+        // Issue #1529: spawn per-palace autonomous dream loops after hydration.
+        // ORDERING GUARANTEE: spawn_dream_scheduler is called first, then the
+        // shutdown bridge is wired. This ensures the bridge cannot pre-cancel
+        // the loops: loops are created with receivers pointing to a watch that
+        // is still `false`, so they will do their first sleep before the bridge
+        // could ever flip the value.
+        // Spawn all background maintenance loops (dream scheduler + idle-to-disk
+        // eviction ticker) and the shutdown bridge in one call — see
+        // `spawn_background_maintenance` for the #1529 ordering guarantee and the
+        // idle-to-disk RAM-reclaim rationale.
+        let n = trusty_memory::dream_scheduler::spawn_background_maintenance(
+            &bg_state.registry,
+            dream_shutdown_rx,
+            dtx,
+        );
+        tracing::info!(loops = n, "dream_scheduler: {n} loop(s) running (#1529)");
+
+        // BM25 backfill sweep. A no-op while the lexical lane is off, which is
+        // every deployment until the default is flipped: `spawn_startup_backfill`
+        // returns immediately when `bm25_client` is `None`.
+        trusty_memory::bm25_backfill::spawn_startup_backfill(&bg_state);
+
+        // BM25 coverage repair sweep. The write path drops on a full queue,
+        // and before this the only thing that repaired a drop was the next
+        // daemon restart — so the "drops are recoverable" trade was not true
+        // of the running process. Also a no-op while the lane is off.
+        trusty_memory::bm25_repair::spawn_repair_sweep(&bg_state);
+
+        // Issue #42: once palaces are live, kick off auto-discovery against
+        // cwd targeting the default palace (if configured). Without a default
+        // palace there's no obvious destination, so skip — explicit MCP
+        // `discover_aliases` calls still work.
+        if let Some(palace) = bg_state.default_palace.clone() {
+            if let Ok(cwd) = std::env::current_dir() {
+                bg_state.spawn_alias_discovery(palace, cwd);
+            }
+        }
+        // Issue #537: throttled startup update check. Runs once per 24h (on-disk
+        // cache). Result stored in AppState::update_available for /health.
+        // Non-blocking: failure degrades to "no update info" — never aborts startup.
+        {
+            let update_available = bg_state.update_available.clone();
+            tokio::spawn(async move {
+                let crate_name = env!("CARGO_PKG_NAME");
+                let current = env!("CARGO_PKG_VERSION");
+                if let Some(info) =
+                    trusty_common::update::check_throttled(crate_name, current).await
+                {
+                    tracing::info!(
+                        latest = %info.latest,
+                        "update available: {}",
+                        trusty_common::update::notice(&info)
+                    );
+                    eprintln!("{}", trusty_common::update::notice(&info));
+                    if let Ok(mut guard) = update_available.lock() {
+                        *guard = Some(info.latest);
+                    }
+                }
+            });
+        }
+
+        // Issue #470 / #474: single-pass scan-only pin discovery — NO palace
+        // opens. Run on the blocking pool because readdir is blocking I/O;
+        // the scan is bounded (one level under each search root) so it
+        // completes quickly. We populate `pin_project_map` on the shared
+        // `AppState` arc so handlers can look up palace_id → project_path
+        // cheaply.
+        //
+        // Fix #474: the completion log is emitted at `info!` level AND via
+        // `eprintln!` to stderr directly. The `info!` is visible under
+        // `RUST_LOG=info`; the `eprintln!` is visible regardless of the
+        // tracing filter and matches the pattern used by `run_http_on` for
+        // the bind-address announcement. This dual-emit guarantees the
+        // operator can always confirm the scan ran, even when the daemon is
+        // started via launchd (stderr → log file) or with the default
+        // `RUST_LOG=warn` level.
+        let pin_scan_started = std::time::Instant::now();
+        let pin_map_ref = bg_state.pin_project_map.clone();
+        // Fix #880: when a data-dir override is active the daemon is running
+        // in an isolated environment (test rig, CI, parallel run). The
+        // default_search_dirs() scan walks the REAL user environment
+        // (~/Projects, ~/Developer, …) and would import palaces from the
+        // live system into the isolated data root, defeating isolation.
+        // Use an empty search list so the scan is a no-op; the pin map stays
+        // empty for the lifetime of this isolated instance.
+        let override_active = trusty_memory::is_data_dir_override_active();
+        let scan_result = tokio::task::spawn_blocking(move || {
+            let search_dirs = if override_active {
+                Vec::new()
+            } else {
+                trusty_memory::startup_scan::default_search_dirs()
+            };
+            trusty_memory::startup_scan::scan_pin_map(&search_dirs)
+        })
+        .await;
+        match scan_result {
+            Ok(map) => {
+                let count = map.len();
+                let elapsed_ms = pin_scan_started.elapsed().as_millis() as u64;
+                for (palace_id, project_path) in map {
+                    pin_map_ref.insert(palace_id, project_path);
+                }
+                // Dual-emit: tracing INFO (visible under RUST_LOG=info) +
+                // eprintln! to stderr (visible at any filter level, matching
+                // the `run_http_on` bind-address announcement pattern).
+                // Root cause of #474: when the daemon is started via
+                // `trusty-memory start`, the child's stderr is redirected to
+                // /dev/null and tracing output is silently lost; when started
+                // via launchd the default RUST_LOG=warn suppresses info!.
+                // eprintln! bypasses the tracing filter so the completion is
+                // always visible in launchd logs and on the operator's
+                // terminal when run in the foreground.
+                tracing::info!(
+                    pins_found = count,
+                    elapsed_ms,
+                    "startup pin scan complete: {count} pin(s) discovered in {elapsed_ms}ms"
+                );
+                eprintln!("startup pin scan complete: {count} pin(s) discovered in {elapsed_ms}ms");
+            }
+            Err(e) => {
+                // spawn_blocking join error — should not happen in practice.
+                tracing::warn!("startup pin scan task panicked or was cancelled: {e}");
+                eprintln!("startup pin scan task panicked or was cancelled: {e}");
+            }
+        }
+    });
+}

--- a/crates/trusty-memory/tests/kg_rebuild_cli.rs
+++ b/crates/trusty-memory/tests/kg_rebuild_cli.rs
@@ -45,6 +45,84 @@ fn kg_rebuild_help_is_accepted() {
     );
 }
 
+/// Why: #4678's purge is destructive against real palaces, so the two switches
+/// that gate it have to be reachable and self-describing at the CLI.
+/// What: `--help` advertises both `--purge-stale-subjects` and `--dry-run`.
+/// Test: This test.
+#[test]
+fn kg_rebuild_help_advertises_purge_flags() {
+    let bin = locate_binary();
+    let out = Command::new(&bin)
+        .arg("kg-rebuild")
+        .arg("--help")
+        .output()
+        .expect("spawn trusty-memory kg-rebuild --help");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--purge-stale-subjects"),
+        "kg-rebuild --help must advertise --purge-stale-subjects, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("--dry-run"),
+        "kg-rebuild --help must advertise --dry-run, got:\n{stdout}"
+    );
+}
+
+/// Why: `--dry-run` on its own would read as "rebuild without writing", which
+/// this command does not offer. Letting it parse would hand an operator a
+/// silent full rebuild when they asked for a preview.
+/// What: `--dry-run` without `--purge-stale-subjects` is a clap parse error
+/// (exit code 2).
+/// Test: This test.
+#[test]
+fn kg_rebuild_dry_run_requires_the_purge_flag() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin = locate_binary();
+    let out = Command::new(&bin)
+        .arg("kg-rebuild")
+        .arg("--dry-run")
+        .env("TRUSTY_DATA_DIR_OVERRIDE", tmp.path())
+        .env("RUST_LOG", "warn")
+        .output()
+        .expect("spawn trusty-memory kg-rebuild --dry-run");
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "--dry-run alone must be refused by clap; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Why: the safe preview path is the one an operator reaches for first against
+/// live data, so it must actually run end to end rather than parse and die.
+/// What: `--purge-stale-subjects --dry-run` against an empty data dir exits 0
+/// and announces the dry run on stdout.
+/// Test: This test.
+#[test]
+fn kg_rebuild_purge_dry_run_runs_clean() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin = locate_binary();
+    let out = Command::new(&bin)
+        .arg("kg-rebuild")
+        .arg("--purge-stale-subjects")
+        .arg("--dry-run")
+        .env("TRUSTY_DATA_DIR_OVERRIDE", tmp.path())
+        .env("RUST_LOG", "warn")
+        .output()
+        .expect("spawn trusty-memory kg-rebuild purge dry run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "purge dry run must exit 0; status {:?}, stderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("DRY RUN"),
+        "purge dry run must announce itself, got:\n{stdout}"
+    );
+}
+
 #[test]
 fn kg_rebuild_palace_arg_is_accepted_by_clap() {
     let tmp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Closes #4678

🔴 This does NOT close ADR-0038 precondition 3. See #5399.

The filter here is LEXICAL — it judges one token with no sentence context — so it reaches only
garbage whose tokens are function words. Verified against the live `trusty-tools` palace:

| Live triple | Reached by this PR |
|---|---|
| `them --is-a--> no-op` | yes — `them` is a pronoun |
| `exhaustiveness --is-a--> hard` | no — ordinary noun, ordinary adjective |
| `squash --is-a--> ancestor` | no — two ordinary nouns |

`squash`/`ancestor` are token-indistinguishable from `rustc`/`compiler` in `rustc is a compiler`,
which the extractor must keep. No word list separates them; that needs head-noun selection or
sentence context. The test `lexical_filter_does_not_reach_the_two_content_word_regressions` pins
that residue deliberately, so the fix for #5399 has to delete it rather than discover the gap by
accident.

## What ships

- A ~190-entry `STOPWORDS` const grouped by closed word class — the classes English never coins new
  members of, so the list is finite rather than a frequency cut-off needing re-tuning — plus a
  3-character minimum with a short-entity allowlist (`go`, `c`, `c#`, `js`, `ts`, `py`, `ml`, `ai`,
  `kg`, `db`, `ui`, `os`, `io`, `vm`, `ip`, `pr`, `ci`, `qa`, `pm`, `tm`, `tc`, `ta`). Applied to
  BOTH tokens; either side failing rejects the whole triple. A test asserts no allowlist entry
  collides with a stopword, since the stopword check runs first and would silently win.
- `kg-rebuild --purge-stale-subjects`, opt-in, with `--dry-run`. Needed because `rebuild_one` only
  re-asserts and never retracts, and these four predicates are absent from `FUNCTIONAL_PREDICATES`,
  so a forward-only fix would leave every existing bad triple asserted forever. Selection is
  narrower than "stopword subject": it skips `drawer:`/`tag:`/`topic:`/`room:` prefixes, and skips
  any subject where even one triple is not `auto:remember`, because `delete_by_subject` closes every
  row under a subject and one hand-asserted fact must protect the whole subject.
- A token-edge fix. The old trim set was `[',', '.', ';', ':', '!', '?', '"', '\'']` — backtick,
  bracket and asterisk were absent, so markdown-wrapped names in drawer prose kept their wrapping on
  BOTH edges. `first_token` also called `trim_end_matches` while documenting itself as trimming the
  leading edge. Both helpers now route through one `clean_token`; interior characters are untouched
  (`no-op`, `c#`, `src/main.rs` asserted intact).

`is_stop_token` keeps its own edge normalization and it is NOT redundant with `clean_token`: the
latter cleans on the way IN, affecting future extraction only, while `--purge-stale-subjects` reads
subjects back out of redb that the old extractor wrote with punctuation welded on. Without it the
purge walks straight past `("the`.

## Deviations worth review

- `main.rs` hit 510 SLOC from the two new flags, so `spawn_startup_tasks` (102 SLOC, depends only on
  the public `trusty_memory` surface) moved to `src/startup_tasks.rs` per the ships-in-the-tripping-PR
  rule. `main.rs` is now 411.
- `handle_kg_rebuild(palace)`'s signature is unchanged — trusty-agents links this crate, so widening
  that `pub fn` would force a minor bump on a bug fix. New options go through `KgRebuildOptions` +
  `handle_kg_rebuild_with`.
- The changelog fragment is split in two because the assembler enforces one category per file.

## Test ladder

Rung 3 — localized behavior inside one crate. No public signature change, no MCP tool schema touched.

    SKIP_UI_BUILD=1 cargo fmt --check
    SKIP_UI_BUILD=1 cargo check -p trusty-memory --all-targets
    SKIP_UI_BUILD=1 cargo clippy -p trusty-memory --all-targets -- -D warnings
    SKIP_UI_BUILD=1 cargo test -p trusty-memory

746 passed / 0 failed / 21 ignored (the 21 are pre-existing ONNX gating). Re-run green after
rebasing onto cef92768. `check_line_cap.sh` 0 violations, `check_sld.sh` 0 errors,
`check_changelog_fragment.sh` OK.

Every negative fixture was proved RED first. The token-edge test was written before the fix and run
against committed `ca81166b`'s parent directly rather than a reconstructed revert.

## Surfaced, not fixed

- #5399 — context-aware extraction. The real ADR-0038 precondition 3 gate.
- #5401 — the token-edge fix changes emitted entity strings, so `kg-rebuild` will assert cleaned
  spellings alongside old punctuated ones rather than replacing them. A merge, not a delete.
- #5396 — object-side retraction, likely a prerequisite for #5401.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
