### PR TITLE
docs(trusty-mpm): state the significance-framing ban as one principle

### DIFF
--- a/crates/trusty-code/changelog.d/ban-significance-framing-openers.md
+++ b/crates/trusty-code/changelog.d/ban-significance-framing-openers.md
@@ -1,0 +1,5 @@
+Changed
+
+- The embedded `BASE-AGENT.md` copy tracks trusty-mpm's consolidation of the
+  throat-clearing and framing-opener prose rules into one significance-framing
+  ban, keeping the two byte-identical.

--- a/crates/trusty-code/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-code/src/assets/agents/BASE-AGENT.md
@@ -397,16 +397,16 @@ banned however it is worded. Non-exhaustive examples:
 
 Right: "OK." Or: "That's wrong, because X."
 
-**Delete the framing opener; lead with the fact.** The banned template is
+**If you are saying it, its worth is implied.** Any opener that announces a
+fact's significance instead of stating the fact is banned, however it is
+worded. `One <noun> that <its significance, or your relation to it>:` is one
+shape of it, not the whole ban. Delete the opener and lead with the fact.
 
-> `One <noun> that <its significance, or your relation to it>:`
-
-placed in front of a fact. It announces that something matters instead of saying
-the thing. The fix is general: delete the opener, start at the fact.
-
-Instances observed so far, as illustration only — the rule is the template
+Instances observed so far, as illustration only — the rule is the sentence
 above, never this list:
 
+- "Worth naming what just happened:" / "Worth naming, since…"
+- "Two things worth knowing…" / "The thing to understand here is…"
 - "What remains unknown, stated plainly:"
 - "One distinction worth being precise about before I push…"
 - "One thing it caught that I'd have missed:"

--- a/crates/trusty-mpm/changelog.d/ban-significance-framing-openers.md
+++ b/crates/trusty-mpm/changelog.d/ban-significance-framing-openers.md
@@ -1,0 +1,9 @@
+Changed
+
+- The `Communication — Write Plainly` section of every bundled output style, and
+  the agent-facing mirror in `BASE-AGENT.md`, now state one rule where three
+  overlapped: an opener that announces a fact's significance instead of stating
+  the fact is banned however it is worded. The separate "no throat-clearing
+  openers" bullet and the "delete the framing opener" template block are folded
+  into it, and their strings survive as illustrations alongside the owner's new
+  instance, "Worth naming what just happened:". Net 6 lines shorter.

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -397,16 +397,16 @@ banned however it is worded. Non-exhaustive examples:
 
 Right: "OK." Or: "That's wrong, because X."
 
-**Delete the framing opener; lead with the fact.** The banned template is
+**If you are saying it, its worth is implied.** Any opener that announces a
+fact's significance instead of stating the fact is banned, however it is
+worded. `One <noun> that <its significance, or your relation to it>:` is one
+shape of it, not the whole ban. Delete the opener and lead with the fact.
 
-> `One <noun> that <its significance, or your relation to it>:`
-
-placed in front of a fact. It announces that something matters instead of saying
-the thing. The fix is general: delete the opener, start at the fact.
-
-Instances observed so far, as illustration only — the rule is the template
+Instances observed so far, as illustration only — the rule is the sentence
 above, never this list:
 
+- "Worth naming what just happened:" / "Worth naming, since…"
+- "Two things worth knowing…" / "The thing to understand here is…"
 - "What remains unknown, stated plainly:"
 - "One distinction worth being precise about before I push…"
 - "One thing it caught that I'd have missed:"

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
@@ -151,8 +151,6 @@ Lead with the point: what happened, then why it matters.
 - End options as a bare enumeration: "Two options: A, or B."
 - Short sentences, one idea each. Split anything carrying three commas and a
   dash.
-- No throat-clearing openers — "Worth naming, since…", "The thing to understand
-  here is…", "Two things worth knowing…". State the fact.
 - No closing aphorisms. Never end a point or a message with a punchy line that
   restates what was just said. Stop at the last useful sentence.
 - Don't justify the restraint. "I don't know yet" is the whole answer — the
@@ -200,16 +198,16 @@ banned however it is worded. Non-exhaustive examples:
 
 Right: "OK." Or: "That's wrong, because X."
 
-**Delete the framing opener; lead with the fact.** The banned template is
+**If you are saying it, its worth is implied.** Any opener that announces a
+fact's significance instead of stating the fact is banned, however it is
+worded. `One <noun> that <its significance, or your relation to it>:` is one
+shape of it, not the whole ban. Delete the opener and lead with the fact.
 
-> `One <noun> that <its significance, or your relation to it>:`
-
-placed in front of a fact. It announces that something matters instead of saying
-the thing. The fix is general: delete the opener, start at the fact.
-
-Instances observed so far, as illustration only — the rule is the template
+Instances observed so far, as illustration only — the rule is the sentence
 above, never this list:
 
+- "Worth naming what just happened:" / "Worth naming, since…"
+- "Two things worth knowing…" / "The thing to understand here is…"
 - "What remains unknown, stated plainly:"
 - "One distinction worth being precise about before I push…"
 - "One thing it caught that I'd have missed:"

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
@@ -146,8 +146,6 @@ Lead with the point: what happened, then why it matters.
 - End options as a bare enumeration: "Two options: A, or B."
 - Short sentences, one idea each. Split anything carrying three commas and a
   dash.
-- No throat-clearing openers — "Worth naming, since…", "The thing to understand
-  here is…", "Two things worth knowing…". State the fact.
 - No closing aphorisms. Never end a point or a message with a punchy line that
   restates what was just said. Stop at the last useful sentence.
 - Don't justify the restraint. "I don't know yet" is the whole answer — the
@@ -195,16 +193,16 @@ banned however it is worded. Non-exhaustive examples:
 
 Right: "OK." Or: "That's wrong, because X."
 
-**Delete the framing opener; lead with the fact.** The banned template is
+**If you are saying it, its worth is implied.** Any opener that announces a
+fact's significance instead of stating the fact is banned, however it is
+worded. `One <noun> that <its significance, or your relation to it>:` is one
+shape of it, not the whole ban. Delete the opener and lead with the fact.
 
-> `One <noun> that <its significance, or your relation to it>:`
-
-placed in front of a fact. It announces that something matters instead of saying
-the thing. The fix is general: delete the opener, start at the fact.
-
-Instances observed so far, as illustration only — the rule is the template
+Instances observed so far, as illustration only — the rule is the sentence
 above, never this list:
 
+- "Worth naming what just happened:" / "Worth naming, since…"
+- "Two things worth knowing…" / "The thing to understand here is…"
 - "What remains unknown, stated plainly:"
 - "One distinction worth being precise about before I push…"
 - "One thing it caught that I'd have missed:"

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
@@ -128,8 +128,6 @@ Lead with the point: what happened, then why it matters.
 - End options as a bare enumeration: "Two options: A, or B."
 - Short sentences, one idea each. Split anything carrying three commas and a
   dash.
-- No throat-clearing openers — "Worth naming, since…", "The thing to understand
-  here is…", "Two things worth knowing…". State the fact.
 - No closing aphorisms. Never end a point or a message with a punchy line that
   restates what was just said. Stop at the last useful sentence.
 - Don't justify the restraint. "I don't know yet" is the whole answer — the
@@ -177,16 +175,16 @@ banned however it is worded. Non-exhaustive examples:
 
 Right: "OK." Or: "That's wrong, because X."
 
-**Delete the framing opener; lead with the fact.** The banned template is
+**If you are saying it, its worth is implied.** Any opener that announces a
+fact's significance instead of stating the fact is banned, however it is
+worded. `One <noun> that <its significance, or your relation to it>:` is one
+shape of it, not the whole ban. Delete the opener and lead with the fact.
 
-> `One <noun> that <its significance, or your relation to it>:`
-
-placed in front of a fact. It announces that something matters instead of saying
-the thing. The fix is general: delete the opener, start at the fact.
-
-Instances observed so far, as illustration only — the rule is the template
+Instances observed so far, as illustration only — the rule is the sentence
 above, never this list:
 
+- "Worth naming what just happened:" / "Worth naming, since…"
+- "Two things worth knowing…" / "The thing to understand here is…"
 - "What remains unknown, stated plainly:"
 - "One distinction worth being precise about before I push…"
 - "One thing it caught that I'd have missed:"

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -1279,7 +1279,7 @@ fn output_styles_mirror_the_pm_prose_rules() {
         "## Communication — Write Plainly",
         "issue #2647",
         "**No praise for the user.**",
-        "**Delete the framing opener; lead with the fact.**",
+        "**If you are saying it, its worth is implied.**",
         "**Do not embellish.**",
         "the banned word \"honest\"",
         "**Ticket and PR bodies**",

--- a/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
@@ -1744,15 +1744,15 @@ fn the_prose_rules_ban_categories_not_phrase_lists() {
         );
 
         assert!(
-            body.contains("**Delete the framing opener; lead with the fact.**"),
-            "{id}: must carry the framing-opener rule"
+            body.contains("**If you are saying it, its worth is implied.**"),
+            "{id}: must carry the significance-framing rule"
         );
         assert!(
             body.contains("`One <noun> that <its significance, or your relation to it>:`"),
-            "{id}: the framing-opener rule must state the TEMPLATE"
+            "{id}: the significance-framing rule must keep the TEMPLATE as one shape"
         );
         assert!(
-            body.contains("the rule is the template\nabove, never this list"),
+            body.contains("the rule is the sentence\nabove, never this list"),
             "{id}: the observed instances must be marked as illustration only"
         );
 
@@ -1791,7 +1791,7 @@ fn the_prose_rules_live_in_the_output_style_not_core() {
 
     for restated in [
         "**No praise for the user.**",
-        "**Delete the framing opener; lead with the fact.**",
+        "**If you are saying it, its worth is implied.**",
         "bans the CATEGORY",
         "**Do not embellish.**",
     ] {


### PR DESCRIPTION
## Owner feedback, verbatim

> "This is useless phrasing that should be dropped in tm output style: 'Worth naming what just happened:' if you name it it's because you thought it was worth it."

## Why this is a consolidation, not a fourth rule

The prose rules already covered this family twice over. `Communication — Write Plainly` carried a bullet (`No throat-clearing openers — "Worth naming, since…", "The thing to understand here is…", "Two things worth knowing…"`) and, forty lines later, a block naming the template `One <noun> that <its significance, or your relation to it>:`. Both were resident and in force when the PM emitted "One thing worth flagging", "The thing I'd flag if you're deciding where to spend attention next", and "Worth naming what just happened".

The owner has flagged this family four separate times across sessions. Three of those flags produced another string in a list; the fourth produced the same failure. Adding a fifth string is the move that has already failed three times, so the three overlapping statements collapse into one that states the generalization:

> **If you are saying it, its worth is implied.** Any opener that announces a fact's significance instead of stating the fact is banned, however it is worded. `One <noun> that <its significance, or your relation to it>:` is one shape of it, not the whole ban. Delete the opener and lead with the fact.

Every string from both old rules survives underneath it, marked as illustration with the device the block already used ("the rule is the sentence above, never this list"), plus the owner's new instance `"Worth naming what just happened:"`. The template is kept inline as one shape rather than as the definition, so a variant that does not match it is still banned.

## Files changed

| File | Why it qualifies |
|---|---|
| `crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md` | Canonical PM voice rules — the section the composed prompt points at |
| `crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md` | Second output style, carries the same mirrored block |
| `crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md` | Third output style, same |
| `crates/trusty-mpm/src/assets/agents/BASE-AGENT.md` | Agent-facing variant governing a subagent's report |
| `crates/trusty-code/src/assets/agents/BASE-AGENT.md` | Embedded copy, byte-identical by `scripts/check_agent_assets.sh` |
| `crates/trusty-mpm/src/core/bundle_tests.rs`, `claude_md_sections_tests.rs` | Assert on the rule's literal heading and on "the rule is the sentence above" |
| `crates/{trusty-mpm,trusty-code}/changelog.d/ban-significance-framing-openers.md` | New fragments |

`assets/instructions/sections/core.md` and the `testdata/pm-prompt-*.md` snapshots point at the output style and restate none of it, so they needed no change — `the_prose_rules_live_in_the_output_style_not_core` proves that, and it passes against the new string.

## Net line change

41 insertions, 47 deletions: **-6**. Per file, each output style loses 2 lines (the throat-clearing bullet goes, the block stays the same length with three more illustrations packed two-per-line); each `BASE-AGENT.md` is net 0; the test edits are net 0. Nothing grew.

## Gates — rung 3 (`src/**` touched, so not rung 1)

```
$ bash scripts/check_sld.sh
sld-lint: scanned 57 spec doc(s) + 3209 code file(s); 0 error(s), 0 warning(s)

$ bash scripts/check_line_cap.sh
line-cap: measured 3898 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.

$ bash scripts/check_agent_assets.sh
agent-assets: scanned 30 byte-parity file(s) (floor 20), all match; 4 pinned deviation(s) match upstream — OK.

$ bash scripts/check_changelog_fragment.sh --base origin/main
OK   trusty-code: changelog.d fragment present and valid
OK   trusty-mpm: changelog.d fragment present and valid
changelog-fragment gate: scanned 9 changed path(s); all 2 crate(s) with source changes are recorded.

$ cargo fmt --check                                      # EXIT=0
$ cargo clippy -p trusty-mpm --all-targets -- -D warnings # EXIT=0

$ cargo test -p trusty-mpm --lib
test result: ok. 5007 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 58.04s

$ cargo test -p trusty-code --lib
test result: ok. 1602 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 1.64s
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
