### PR TITLE
fix(trusty-mpm): seed builtin MCP servers into user scope (#4181, PR C1 of 3)

### DIFF
--- a/crates/trusty-mpm/changelog.d/4181-seed-builtin-mcp-servers.md
+++ b/crates/trusty-mpm/changelog.d/4181-seed-builtin-mcp-servers.md
@@ -1,0 +1,17 @@
+Changed
+
+- The four framework MCP servers (`trusty-memory`, `trusty-mpm`,
+  `trusty-review`, `trusty-search`) are now declared once in the user-scope
+  `mcpServers` map of the tm-owned `.claude.json`, seeded on every launch by
+  `mcp_config::seed_builtin_servers`. Seeding is insert-if-absent: an entry the
+  operator registered under one of those names via `tm mcp add` is never
+  overwritten, reordered, or removed. This replaces the write to
+  `<CLAUDE_CONFIG_DIR>/.mcp.json`, which no session ever read — Claude Code
+  discovers a `.mcp.json` by walking up from the session's cwd, and cwd is
+  always the repo (#4181, ADR-0042).
+- Seeding never quarantines. A malformed `.claude.json`, or one whose
+  `mcpServers` is not an object, makes it warn and return without renaming or
+  writing anything; a failure of any kind is absorbed so the agent and skill
+  deploy that follows still runs. The per-launch injectors and the
+  `enabledMcpjsonServers` approval are untouched here and are deleted together
+  in the next PR of the ADR-0042 sequence.

--- a/crates/trusty-mpm/src/core/managed_config_tests.rs
+++ b/crates/trusty-mpm/src/core/managed_config_tests.rs
@@ -89,7 +89,9 @@ fn ensure_managed_config_dir_deploys_full_roster() {
 
     // Scaffolding landed.
     assert!(config_dir.join("settings.json").exists());
-    assert!(config_dir.join(".mcp.json").exists());
+    // #4181: the MCP declaration is seeded into `.claude.json`'s user-scope
+    // `mcpServers` map now, not into a `.mcp.json` no session discovers.
+    assert!(config_dir.join(".claude.json").exists());
 
     // Every seeded specialist must be present AND spawnable (has a
     // `description` in its deployed frontmatter).

--- a/crates/trusty-mpm/src/core/mcp_config.rs
+++ b/crates/trusty-mpm/src/core/mcp_config.rs
@@ -296,6 +296,102 @@ pub fn add_server(config_dir: &Path, name: &str, entry: Value) -> Result<bool> {
     Ok(true)
 }
 
+/// Seed the framework builtin MCP servers into the user-scope `mcpServers`
+/// map of `<config_dir>/.claude.json`, **inserting only the names that are
+/// absent**.
+///
+/// Why (#4181, [ADR-0042]): a server declared in this map connects with no
+/// approval prompt, while the same server declared in a workspace `.mcp.json`
+/// comes up `⏸ Pending approval`. ADR-0042 moves the framework builtins' one
+/// declaration here so it is written once and persists, instead of being
+/// re-injected into every ephemeral worktree. That declaration must be seeded
+/// on a path that runs before every spawn, which is
+/// [`crate::core::standalone::global_config::ensure_global_config_dir`].
+///
+/// What: reads `<config_dir>/.claude.json`, and for each name in
+/// [`BUILTIN_MANAGED_MCP_SERVERS`] that the top-level `mcpServers` map does
+/// NOT already contain, inserts [`builtin_server_entry`]'s canonical entry.
+/// Returns the names actually inserted; an empty vector means nothing was
+/// written. Holds [`crate::core::claude_json_guard::lock`] across the whole
+/// read-mutate-write cycle, because the daemon runs other `.claude.json`
+/// seeders concurrently (#4072).
+///
+/// **Insert-if-absent is the contract, not an optimisation.** An entry already
+/// under a builtin name is the operator's — `tm mcp add` is the supported edit
+/// path (ADR-0042 decision item 3) and must win. This function never
+/// overwrites, never reorders, and never removes.
+///
+/// **It also never quarantines.** Unlike [`read_config`], a `.claude.json`
+/// that is malformed, or whose `mcpServers` is not an object, makes this
+/// function warn and return `Ok(vec![])` with the file untouched — no rename,
+/// no write. Seeding runs on every launch now, so a quarantine here would turn
+/// a convenience into a per-launch data-loss event against a file that also
+/// holds OAuth state. `standalone::trust_seed::preseed_managed_trust` still
+/// owns that decision (and still logs it at `ERROR` with a timestamped
+/// quarantine path, #4206); once it has replaced the unparseable file, the
+/// next launch seeds normally.
+///
+/// [ADR-0042]: ../../../../docs/adr/0042-mcp-configuration-is-static-and-persistent.md
+///
+/// Test: `seed_builtin_servers_inserts_every_builtin_when_absent`,
+/// `seed_builtin_servers_never_overwrites_an_existing_entry`,
+/// `seed_builtin_servers_is_idempotent`,
+/// `seed_builtin_servers_preserves_unrelated_keys`,
+/// `seed_builtin_servers_declines_a_malformed_config_without_quarantining`,
+/// `seed_builtin_servers_declines_a_non_object_mcp_servers_map`,
+/// `seed_builtin_servers_creates_the_config_when_the_dir_is_absent`,
+/// `seed_builtin_servers_errors_when_claude_json_is_unreadable`,
+/// `seeding_and_workspace_injection_coexist_without_clobbering`.
+pub fn seed_builtin_servers(config_dir: &Path) -> Result<Vec<String>> {
+    // #4181: the guard spans read → mutate → write, not just the write.
+    let _guard = crate::core::claude_json_guard::lock();
+
+    let path = config_dir.join(CLAUDE_JSON);
+    let Some(mut config) = read_config_for_seeding(&path)? else {
+        return Ok(Vec::new());
+    };
+
+    let root = config
+        .as_object_mut()
+        .expect("read_config_for_seeding only yields objects");
+
+    // #4181: a non-object `mcpServers` is operator state this function is not
+    // entitled to destroy — `mcp_servers_mut` would replace it with `{}`.
+    if let Some(existing) = root.get("mcpServers")
+        && !existing.is_object()
+    {
+        tracing::warn!(
+            "skipping builtin MCP seed: {}'s mcpServers is not an object — leaving it untouched",
+            path.display()
+        );
+        return Ok(Vec::new());
+    }
+
+    let servers = root
+        .entry("mcpServers")
+        .or_insert_with(|| Value::Object(Map::new()))
+        .as_object_mut()
+        .expect("mcpServers is an object — checked immediately above");
+
+    let mut seeded: Vec<String> = Vec::new();
+    for name in BUILTIN_MANAGED_MCP_SERVERS {
+        if servers.contains_key(*name) {
+            continue;
+        }
+        let Some(entry) = builtin_server_entry(name) else {
+            continue;
+        };
+        servers.insert((*name).to_string(), entry);
+        seeded.push((*name).to_string());
+    }
+
+    if seeded.is_empty() {
+        return Ok(Vec::new());
+    }
+    write(&path, &config)?;
+    Ok(seeded)
+}
+
 /// Remove a user-scope MCP server.
 ///
 /// Why: `tm mcp remove` drops a server the operator no longer wants injected
@@ -378,8 +474,16 @@ pub fn list_servers(config_dir: &Path) -> Result<Map<String, Value>> {
 /// repo's `.mcp.json` declares. (`session_launch::settings::preseed_workspace_trust`'s
 /// identical `.mcp.json`-trusting behavior for the interactive path predates
 /// this fix and was NOT in scope here — reported separately.)
+/// **Security (issue #4181, ADR-0042):** the `mcpServers` map this function
+/// unions is the same map [`seed_builtin_servers`] now writes the four
+/// builtins into, on every launch. Their keys are therefore SUBTRACTED from
+/// the registry half below — otherwise a seeded builtin would enter the
+/// approved set with no `_pinned` evidence at all, which is exactly the #3950
+/// state the four flags exist to prevent. A builtin's membership comes from
+/// its flag and nothing else.
 /// What: takes an already-parsed `.claude.json` value, collects the top-level
-/// `mcpServers` object keys, unions them with the two names in
+/// `mcpServers` object keys EXCEPT those in [`BUILTIN_MANAGED_MCP_SERVERS`],
+/// unions them with the two names in
 /// [`UNCONDITIONAL_BUILTIN_MCP_SERVERS`] (only the ones whose
 /// `trusty_mpm_pinned` / `trusty_review_pinned` flag is `true`) and
 /// [`CONDITIONAL_BUILTIN_MCP_SERVERS`] (only the names whose
@@ -435,7 +539,19 @@ pub fn managed_mcp_server_names(
         names.push(CONDITIONAL_BUILTIN_TRUSTY_SEARCH.to_string());
     }
     if let Some(servers) = config.get("mcpServers").and_then(Value::as_object) {
-        names.extend(servers.keys().cloned());
+        // #4181: a builtin name's membership is decided ONLY by its `_pinned`
+        // flag above. ADR-0042 seeds the builtins INTO this very map, so a
+        // wholesale union would re-admit a name whose force-overwrite failed
+        // this run — #3950's exploit, reopened by the seeding rather than by a
+        // code change to the trust derivation. Caught by
+        // `prepare_managed_config_excludes_builtins_when_mcp_json_write_fails`,
+        // which went red the moment seeding landed.
+        names.extend(
+            servers
+                .keys()
+                .filter(|name| !BUILTIN_MANAGED_MCP_SERVERS.contains(&name.as_str()))
+                .cloned(),
+        );
     }
     names.sort();
     names.dedup();
@@ -682,6 +798,53 @@ fn read_config(config_dir: &Path) -> Result<(PathBuf, Value)> {
                 ),
             }
             Ok((path, Value::Object(Map::new())))
+        }
+    }
+}
+
+/// Read `<config_dir>/.claude.json` for [`seed_builtin_servers`], never
+/// quarantining.
+///
+/// Why (#4181): [`read_config`] backs the operator-invoked `tm mcp` commands,
+/// where a malformed file must not permanently wedge the command and the
+/// operator is present to see the `ERROR` line. Seeding is neither — it runs
+/// unattended on every launch, so the same rename would destroy OAuth state as
+/// a side effect of a convenience. See [`seed_builtin_servers`]'s doc for why
+/// declining is the safe half of that trade.
+/// What: returns `Ok(Some(object))` for a missing file (an empty `{}`) or a
+/// well-formed JSON object; `Ok(None)` — after a warning — for a file that is
+/// malformed or is valid JSON but not an object; `Err` only for a real read
+/// error (permissions, a directory in the file's place).
+/// Test: `seed_builtin_servers_declines_a_malformed_config_without_quarantining`,
+/// `seed_builtin_servers_creates_the_config_when_the_dir_is_absent`,
+/// `seed_builtin_servers_errors_when_claude_json_is_unreadable`.
+fn read_config_for_seeding(path: &Path) -> Result<Option<Value>> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Some(Value::Object(Map::new())));
+        }
+        Err(e) => {
+            return Err(e).with_context(|| format!("failed to read {}", path.display()));
+        }
+    };
+
+    match serde_json::from_str::<Value>(&text) {
+        Ok(v) if v.is_object() => Ok(Some(v)),
+        Ok(_) => {
+            tracing::warn!(
+                "skipping builtin MCP seed: {} is valid JSON but not an object — \
+                 leaving it untouched",
+                path.display()
+            );
+            Ok(None)
+        }
+        Err(err) => {
+            tracing::warn!(
+                "skipping builtin MCP seed: {} is not valid JSON ({err}) — leaving it untouched",
+                path.display()
+            );
+            Ok(None)
         }
     }
 }

--- a/crates/trusty-mpm/src/core/mcp_config_tests.rs
+++ b/crates/trusty-mpm/src/core/mcp_config_tests.rs
@@ -326,16 +326,20 @@ fn managed_mcp_server_names_excludes_unconditional_builtin_when_pin_failed() {
 }
 
 #[test]
-fn managed_mcp_server_names_registry_collision_is_a_separate_trusted_source() {
-    // Documents the (correct, unrelated) behaviour a naive reading of the
-    // #3934 fix might expect to change: the `config` parameter is the
-    // operator's OWN `tm mcp add` registry (`<config_dir>/.claude.json`'s
-    // top-level `mcpServers`), a source this module's existing security
-    // model already treats as trusted (see the module doc) — NOT the
-    // workspace's `.mcp.json` a cloned repo controls. A registry entry
-    // happening to be named `trusty-memory` is unioned in regardless of
-    // the conditional-injector toggle, exactly like any other registry
-    // name; the toggle only gates the FRAMEWORK BUILTIN union member.
+fn managed_mcp_server_names_registry_collision_does_not_bypass_the_pin_flags() {
+    // #4181 REVERSED THIS ASSERTION. It used to read: a registry entry named
+    // `trusty-memory` is unioned in regardless of the conditional toggle,
+    // because the registry is operator-controlled and therefore trusted.
+    //
+    // Two things make that wrong now. Narrowly: ADR-0042 seeds all four
+    // builtins into the registry, so under the old rule the four `_pinned`
+    // flags would become dead parameters and every builtin would be approved
+    // on every launch — #3950 with no code change to the derivation.
+    // Broadly: it was never sound anyway. This approval is content-blind and
+    // resolves against the WORKSPACE `.mcp.json`, and `custom_mcp`'s registry
+    // loop skips reserved names, so a registry entry named `trusty-memory` is
+    // never what pins the workspace entry. Only `inject_trusty_memory_mcp`
+    // does — the very injector the toggle gates.
     let config = serde_json::json!({
         "mcpServers": {
             "trusty-memory": { "type": "stdio", "command": "trusty-memory", "args": [] }
@@ -343,8 +347,19 @@ fn managed_mcp_server_names_registry_collision_is_a_separate_trusted_source() {
     });
     let names = managed_mcp_server_names(&config, true, true, false, false);
     assert!(
-        names.contains(&"trusty-memory".to_string()),
-        "a registry-sourced name is trusted independently of the conditional-builtin toggle: {names:?}"
+        !names.contains(&"trusty-memory".to_string()),
+        "a registry entry under a builtin name must not bypass that builtin's pin flag: {names:?}"
+    );
+    // A non-builtin registry name is untouched — that union is the point.
+    let config = serde_json::json!({
+        "mcpServers": {
+            "slack-mcp": { "type": "stdio", "command": "slack-mcp", "args": [] }
+        }
+    });
+    assert!(
+        managed_mcp_server_names(&config, false, false, false, false)
+            .contains(&"slack-mcp".to_string()),
+        "an operator's non-builtin registration must still be trusted"
     );
 }
 
@@ -497,4 +512,263 @@ fn resolve_conditional_mcp_toggles_honors_project_manifest_toggle() {
     let (memory, search) = resolve_conditional_mcp_toggles(&fw, tmp_project.path());
     assert!(!memory, "project manifest toggle must be honored");
     assert!(search, "untouched toggle must keep its default");
+}
+
+// ─── #4181 / ADR-0042: seed_builtin_servers ───────────────────────────────
+//
+// Seeding declares the framework builtins ONCE in the user-scope `mcpServers`
+// map, insert-if-absent, on a path that runs before every launch. The contract
+// these tests pin: it inserts what is missing, it never touches what is already
+// there, and it never destroys the file it reads — which also holds OAuth state.
+
+/// The four builtin names, sorted, as `seed_builtin_servers` reports them.
+fn all_builtins() -> Vec<String> {
+    let mut names: Vec<String> = BUILTIN_MANAGED_MCP_SERVERS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    names.sort();
+    names
+}
+
+fn read_servers(config_dir: &std::path::Path) -> Map<String, Value> {
+    let text = std::fs::read_to_string(config_dir.join(".claude.json")).unwrap();
+    let val: Value = serde_json::from_str(&text).unwrap();
+    val["mcpServers"].as_object().cloned().unwrap_or_default()
+}
+
+#[test]
+fn seed_builtin_servers_inserts_every_builtin_when_absent() {
+    let tmp = TempDir::new().unwrap();
+    let seeded = seed_builtin_servers(tmp.path()).unwrap();
+
+    assert_eq!(seeded, all_builtins(), "every builtin must be reported");
+    let servers = read_servers(tmp.path());
+    for name in BUILTIN_MANAGED_MCP_SERVERS {
+        assert_eq!(
+            servers.get(*name),
+            builtin_server_entry(name).as_ref(),
+            "{name} must be written as its canonical builtin entry"
+        );
+    }
+}
+
+#[test]
+fn seed_builtin_servers_never_overwrites_an_existing_entry() {
+    let tmp = TempDir::new().unwrap();
+    // The operator's own declaration, under a builtin name, with a different
+    // binary and a pinned index — exactly what `tm mcp add` writes.
+    let operator = stdio("/opt/operator/trusty-search", &["serve", "--index", "cto"]);
+    add_server(tmp.path(), "trusty-search", operator.clone()).unwrap();
+
+    let seeded = seed_builtin_servers(tmp.path()).unwrap();
+
+    assert_eq!(
+        seeded,
+        strings(&["trusty-memory", "trusty-mpm", "trusty-review"]),
+        "the occupied name must not be reported as seeded"
+    );
+    assert_eq!(
+        read_servers(tmp.path()).get("trusty-search"),
+        Some(&operator),
+        "the operator's entry must survive verbatim — tm mcp add wins"
+    );
+}
+
+#[test]
+fn seed_builtin_servers_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let claude_json = tmp.path().join(".claude.json");
+
+    assert_eq!(seed_builtin_servers(tmp.path()).unwrap(), all_builtins());
+    let first = std::fs::read(&claude_json).unwrap();
+
+    let second_run = seed_builtin_servers(tmp.path()).unwrap();
+    assert!(
+        second_run.is_empty(),
+        "a second run must insert nothing, got {second_run:?}"
+    );
+    assert_eq!(
+        first,
+        std::fs::read(&claude_json).unwrap(),
+        "a no-op run must not rewrite the file"
+    );
+}
+
+#[test]
+fn seed_builtin_servers_preserves_unrelated_keys() {
+    let tmp = TempDir::new().unwrap();
+    // `.claude.json` also holds OAuth state and every project's trust — seeding
+    // shares the file and must leave the rest of it alone.
+    std::fs::write(
+        tmp.path().join(".claude.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "oauthAccount": { "emailAddress": "op@example.com" },
+            "projects": { "/w": { "hasTrustDialogAccepted": true } }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    seed_builtin_servers(tmp.path()).unwrap();
+
+    let text = std::fs::read_to_string(tmp.path().join(".claude.json")).unwrap();
+    let val: Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+        val["oauthAccount"]["emailAddress"].as_str(),
+        Some("op@example.com"),
+        "OAuth state must survive seeding"
+    );
+    assert_eq!(val["projects"]["/w"]["hasTrustDialogAccepted"], true);
+    assert!(val["mcpServers"]["trusty-mpm"].is_object());
+}
+
+#[test]
+fn seed_builtin_servers_declines_a_malformed_config_without_quarantining() {
+    let tmp = TempDir::new().unwrap();
+    let claude_json = tmp.path().join(".claude.json");
+    let malformed = br#"{"oauthAccount": {"emailAddress": "op@example.com"},"#;
+    std::fs::write(&claude_json, malformed).unwrap();
+
+    let seeded = seed_builtin_servers(tmp.path()).unwrap();
+
+    assert!(seeded.is_empty(), "a malformed config must seed nothing");
+    assert_eq!(
+        std::fs::read(&claude_json).unwrap(),
+        malformed,
+        "the file must be byte-identical — no rename, no write"
+    );
+    // `read_config` (the `tm mcp` path) renames to a timestamped `.corrupt`
+    // sibling. Seeding runs unattended on every launch, so it must not.
+    let strays: Vec<String> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n != ".claude.json")
+        .collect();
+    assert!(
+        strays.is_empty(),
+        "seeding must leave no siblings behind: {strays:?}"
+    );
+}
+
+#[test]
+fn seed_builtin_servers_declines_a_non_object_config() {
+    let tmp = TempDir::new().unwrap();
+    let claude_json = tmp.path().join(".claude.json");
+    std::fs::write(&claude_json, b"[1, 2, 3]").unwrap();
+
+    assert!(seed_builtin_servers(tmp.path()).unwrap().is_empty());
+    assert_eq!(std::fs::read(&claude_json).unwrap(), b"[1, 2, 3]");
+}
+
+#[test]
+fn seed_builtin_servers_declines_a_non_object_mcp_servers_map() {
+    let tmp = TempDir::new().unwrap();
+    let claude_json = tmp.path().join(".claude.json");
+    // `mcp_servers_mut` (the `tm mcp` path) replaces this with `{}`, discarding
+    // it. Seeding must decline instead — it is not entitled to destroy operator
+    // state it merely failed to understand.
+    let hand_edited = br#"{"mcpServers": ["trusty-mpm"]}"#;
+    std::fs::write(&claude_json, hand_edited).unwrap();
+
+    assert!(seed_builtin_servers(tmp.path()).unwrap().is_empty());
+    assert_eq!(
+        std::fs::read(&claude_json).unwrap(),
+        hand_edited,
+        "a non-object mcpServers must be left exactly as found"
+    );
+}
+
+#[test]
+fn seed_builtin_servers_creates_the_config_when_the_dir_is_absent() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("never").join("created");
+
+    assert_eq!(seed_builtin_servers(&config_dir).unwrap(), all_builtins());
+    assert!(config_dir.join(".claude.json").is_file());
+}
+
+#[test]
+fn seed_builtin_servers_errors_when_claude_json_is_unreadable() {
+    let tmp = TempDir::new().unwrap();
+    // A directory where the file belongs: a read error that is neither
+    // NotFound nor uid-dependent, so it reproduces for root too.
+    std::fs::create_dir_all(tmp.path().join(".claude.json")).unwrap();
+
+    let err = seed_builtin_servers(tmp.path()).unwrap_err().to_string();
+    assert!(
+        err.contains("failed to read"),
+        "the read failure must be reported, got: {err}"
+    );
+    assert!(
+        tmp.path().join(".claude.json").is_dir(),
+        "an unreadable path must be left alone"
+    );
+}
+
+#[test]
+fn a_seeded_builtin_is_not_approved_when_its_pin_failed() {
+    // #4181 × #3950. Seeding writes the builtins into the SAME `mcpServers`
+    // map `managed_mcp_server_names` unions for `enabledMcpjsonServers`. Union
+    // it wholesale and every builtin is approved regardless of whether its
+    // workspace `.mcp.json` force-overwrite succeeded — approving a name whose
+    // project-scope content was never verified, which is the whole exploit.
+    let tmp = TempDir::new().unwrap();
+    seed_builtin_servers(tmp.path()).unwrap();
+
+    let approved = launch_trusted_mcp_names_from(tmp.path(), false, false, false, false);
+    assert!(
+        approved.is_empty(),
+        "no builtin may be approved when every pin failed, got {approved:?}"
+    );
+
+    // An operator's own non-builtin registration is unaffected — it still
+    // enters via the registry, which is the union's actual purpose.
+    add_server(tmp.path(), "slack-mcp", stdio("slack-mcp", &["serve"])).unwrap();
+    assert_eq!(
+        launch_trusted_mcp_names_from(tmp.path(), false, false, false, false),
+        strings(&["slack-mcp"])
+    );
+    // And a successful pin still approves its builtin.
+    assert_eq!(
+        launch_trusted_mcp_names_from(tmp.path(), true, false, false, false),
+        strings(&["slack-mcp", "trusty-mpm"])
+    );
+}
+
+#[test]
+fn seeding_and_workspace_injection_coexist_without_clobbering() {
+    // Until PR C2 deletes the injectors, both provision the builtins: seeding
+    // into user scope, `inject_trusty_mpm_mcp` into the workspace `.mcp.json`.
+    // They target different files, so double-provisioning can produce neither a
+    // duplicate nor a clobber — this pins that.
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("claude-config");
+    let workspace = tmp.path().join("workspace");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    seed_builtin_servers(&config_dir).unwrap();
+    crate::core::session_launch::inject_trusty_mpm_mcp(&workspace).unwrap();
+    let after_inject = seed_builtin_servers(&config_dir).unwrap();
+    assert!(
+        after_inject.is_empty(),
+        "the injector must not have disturbed user scope"
+    );
+
+    let user_scope = read_servers(&config_dir);
+    assert_eq!(user_scope.len(), BUILTIN_MANAGED_MCP_SERVERS.len());
+    assert_eq!(
+        user_scope.get("trusty-mpm"),
+        builtin_server_entry("trusty-mpm").as_ref(),
+        "the user-scope entry must be the canonical builtin, unduplicated"
+    );
+
+    // The workspace copy is the injector's and stays intact.
+    assert_eq!(
+        mcp_server_names(&workspace),
+        strings(&["trusty-mpm"]),
+        "the workspace .mcp.json must still declare exactly what was injected"
+    );
 }

--- a/crates/trusty-mpm/src/core/standalone/global_config.rs
+++ b/crates/trusty-mpm/src/core/standalone/global_config.rs
@@ -11,8 +11,9 @@
 //! #2214 defense-in-depth — see that module's doc comment), merges the MPM hook
 //! triad, seeds `.credentials.json` from `~/.claude/.credentials.json` if it
 //! exists (NOTE: this file holds MCP OAuth tokens, NOT the primary session auth
-//! — see WI-10 for the auth model), writes a minimal `.mcp.json` with
-//! trusty-memory, trusty-review, and trusty-search server stubs, and (WI-2)
+//! — see WI-10 for the auth model), declares the framework builtin MCP servers
+//! in the user-scope `mcpServers` map of `.claude.json` (#4181 / ADR-0042 —
+//! see [`seed_builtin_mcp_servers`]), and (WI-2)
 //! deploys bundled agents and skills from `<managed_root>/framework/{agents,skills}`
 //! into the managed config dir so that every tm-launched session starts with
 //! the full agent/skill set.
@@ -50,14 +51,15 @@ use std::path::{Path, PathBuf};
 /// non-destructive — never overwrites an already-set value), merges the MPM
 /// hook triad into `settings.json` via [`super::hooks::ensure_managed_hooks`]
 /// (WI-3), copies `~/.claude/.credentials.json` if found (silently skips
-/// otherwise), writes `.mcp.json` with trusty-memory, trusty-review, and
-/// trusty-search stubs (idempotent via the inject pattern; WI-8 adds
-/// trusty-review), then deploys bundled agents and skills via
-/// [`deploy_agents_and_skills`].
+/// otherwise), declares the framework builtin MCP servers in `.claude.json`'s
+/// user-scope `mcpServers` map (#4181 / ADR-0042 — insert-if-absent, non-fatal;
+/// see [`seed_builtin_mcp_servers`]), then deploys bundled agents and skills
+/// via [`deploy_agents_and_skills`].
 /// Test: `test_global_config_dir_ensure_idempotent`,
 /// `test_deploy_agents_and_skills_populates_config_dir`,
 /// `test_deploy_agents_and_skills_missing_source_is_ok`,
-/// `test_global_config_dir_seeds_output_style_and_status_line`.
+/// `test_global_config_dir_seeds_output_style_and_status_line`,
+/// `test_global_config_dir_seeds_builtin_mcp_servers`.
 pub fn ensure_global_config_dir(
     managed_root: &Path,
     claude_config_dir: &Path,
@@ -74,7 +76,7 @@ pub fn ensure_global_config_dir(
     super::hooks::ensure_managed_hooks(claude_config_dir)?;
 
     seed_credentials(claude_config_dir);
-    ensure_mcp_config(claude_config_dir)?;
+    seed_builtin_mcp_servers(claude_config_dir);
     deploy_agents_and_skills(managed_root, claude_config_dir)?;
 
     Ok(claude_config_dir.to_path_buf())
@@ -281,88 +283,38 @@ fn seed_credentials(claude_config_dir: &Path) {
     }
 }
 
-/// Write a minimal `.mcp.json` with trusty-memory, trusty-review, and trusty-search stubs.
+/// Declare the framework builtin MCP servers in USER scope, non-fatally.
 ///
-/// Why: the tm-global config dir must carry the global MCP server definitions
-/// so every tm-launched session can use memory, review, and search tools without
-/// per-project wiring. `trusty-review` was added in WI-8 (refs #1548).
-/// What: reads `<claude_config_dir>/.mcp.json` (starts from `{}` when absent),
-/// injects `trusty-memory`, `trusty-review`, and `trusty-search` entries under
-/// `mcpServers` using the same idempotent merge used by `inject_mcp_server` in
-/// settings.rs. To avoid spurious mtime bumps on every `tm run`, the on-disk
-/// content is parsed into a `serde_json::Value` and compared structurally
-/// (not byte-wise) to the merged value; the file is only written when the
-/// parsed Values differ (closes #1550 item 3). Byte-wise comparison would be
-/// defeated by any trailing newline or whitespace difference left by editors or
-/// prior writes; structural comparison is immune to those formatting variations.
-/// Secrets/env: trusty-review reads its config from the environment
-/// (OPENROUTER_API_KEY, AWS credentials, TRUSTY_SEARCH_URL etc.) — no secrets
-/// are injected here; the managed session inherits the daemon env, matching the
-/// pattern used for trusty-memory and trusty-search.
-/// Palace pinning (issue #1651): the trusty-memory entry here is DELIBERATELY a
-/// bare `serve --stdio` stub with NO `env.TRUSTY_MEMORY_PALACE`. This is the
-/// SINGLE tm-global config dir (SPEC-STANDALONE-MPM-08), shared as the
-/// user-level MCP layer across EVERY alias, so it cannot carry any one project's
-/// palace slug. The per-project palace pin lives in the cloned repo's
-/// `repo/.mcp.json` (written by `load_alias` → `run_prepare_session` →
-/// `prepare_session_with_repo_url`, threading the registry clone URL), which
-/// Claude Code layers OVER this global stub (project-local precedence, A4). So
-/// the correct slug is always applied at the project layer; this global stub
-/// only declares server availability and must stay bare.
-/// Test: `test_global_config_dir_ensure_idempotent`,
-/// `test_mcp_config_contains_all_three_servers`,
-/// `test_mcp_config_no_spurious_write_when_unchanged`,
-/// `test_mcp_config_trailing_newline_does_not_trigger_rewrite`.
-fn ensure_mcp_config(claude_config_dir: &Path) -> anyhow::Result<()> {
-    let mcp_path = claude_config_dir.join(".mcp.json");
-
-    // Parse the on-disk value for structural comparison.  On parse failure
-    // (malformed file) or absence we treat the existing state as "empty object"
-    // so the merge proceeds and the file is (re)written correctly.
-    let existing_value: Option<serde_json::Value> = std::fs::read_to_string(&mcp_path)
-        .ok()
-        .and_then(|t| serde_json::from_str::<serde_json::Value>(&t).ok())
-        .filter(|v| v.is_object());
-
-    let mut config = existing_value
-        .clone()
-        .unwrap_or_else(|| serde_json::json!({}));
-
-    let servers = config
-        .as_object_mut()
-        .expect("config is an object")
-        .entry("mcpServers")
-        .or_insert_with(|| serde_json::json!({}));
-    if !servers.is_object() {
-        *servers = serde_json::json!({});
+/// Why (#4181, ADR-0042): this replaced `ensure_mcp_config`, which wrote the
+/// same four servers into `<claude_config_dir>/.mcp.json`. Claude Code
+/// discovers a `.mcp.json` only by walking UP from the session's cwd, and cwd
+/// is always the repo (`standalone::run` sets `current_dir(repo_path)`; the
+/// daemon spawns in the workspace), so that file was never on any session's
+/// search path — a server declared there reached nothing. The top-level
+/// `mcpServers` map of `<claude_config_dir>/.claude.json` is the map that does
+/// reach a session, and reaches it with no approval prompt.
+/// What: calls [`crate::core::mcp_config::seed_builtin_servers`] and swallows
+/// the outcome into a log line. **Non-fatal by construction** — this runs
+/// between `seed_credentials` and [`deploy_agents_and_skills`], so a `?` here
+/// would let an unwritable `.claude.json` skip the agent and skill deploy and
+/// leave the session with no roster. A seeding failure costs MCP servers for
+/// one launch; it must cost nothing else.
+/// Test: `test_global_config_dir_seeds_builtin_mcp_servers`,
+/// `test_global_config_dir_never_overwrites_an_operator_mcp_entry`,
+/// `test_global_config_dir_survives_a_malformed_claude_json`.
+fn seed_builtin_mcp_servers(claude_config_dir: &Path) {
+    match crate::core::mcp_config::seed_builtin_servers(claude_config_dir) {
+        Ok(seeded) if !seeded.is_empty() => tracing::info!(
+            config_dir = %claude_config_dir.display(),
+            servers = %seeded.join(", "),
+            "declared builtin MCP servers in user scope"
+        ),
+        Ok(_) => {}
+        Err(e) => tracing::warn!(
+            config_dir = %claude_config_dir.display(),
+            "builtin MCP server seeding failed (non-fatal): {e}"
+        ),
     }
-    let servers = servers.as_object_mut().expect("mcpServers is an object");
-
-    // The three built-in framework servers' launch definitions live in a single
-    // catalog (`core::mcp_config::builtin_server_entry`) so this managed-config
-    // wiring and `tm mcp test`'s probe can never disagree on how a server starts.
-    // trusty-review reads its LLM credentials (OPENROUTER_API_KEY, AWS credentials)
-    // and TRUSTY_SEARCH_URL from the environment — no secrets are injected here;
-    // the managed session inherits the daemon env, matching the memory/search pattern.
-    for name in crate::core::mcp_config::BUILTIN_MANAGED_MCP_SERVERS {
-        if let Some(entry) = crate::core::mcp_config::builtin_server_entry(name) {
-            servers.entry(*name).or_insert(entry);
-        }
-    }
-
-    // Compare structurally (Value == Value) rather than byte-wise so that
-    // trailing newlines, editor-inserted whitespace, or any other formatting
-    // difference in the on-disk file does NOT trigger a spurious rewrite.
-    // A byte comparison of `existing_text` vs the fresh serialization would
-    // fail whenever the on-disk file has a trailing newline, defeating the
-    // idempotency guarantee this function is supposed to provide.
-    let needs_write = existing_value.as_ref() != Some(&config);
-
-    if needs_write {
-        let serialized = serde_json::to_string_pretty(&config)?;
-        std::fs::write(&mcp_path, &serialized)?;
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -378,7 +330,9 @@ mod tests {
 
         ensure_global_config_dir(&managed_root, &claude_config).unwrap();
         assert!(claude_config.join("settings.json").exists());
-        assert!(claude_config.join(".mcp.json").exists());
+        // #4181: the MCP declaration moved from `.mcp.json` (never on a
+        // session's discovery path) to `.claude.json`'s user-scope map.
+        assert!(claude_config.join(".claude.json").exists());
 
         // Second call must not fail (idempotent).
         ensure_global_config_dir(&managed_root, &claude_config).unwrap();
@@ -435,45 +389,38 @@ mod tests {
         );
     }
 
-    // WI-3 + WI-8: ensure_mcp_config must define all three managed MCP servers,
-    // including trusty-review added in WI-8 (refs #1548).
+    // WI-3 + WI-8 + #3918, retargeted by #4181: the four framework builtins
+    // must be declared in `.claude.json`'s user-scope `mcpServers` map — the
+    // map that reaches a session without an approval prompt. This assertion
+    // used to read the `.mcp.json` `ensure_mcp_config` wrote, which no session
+    // ever discovered (cwd is always the repo, and discovery walks up from cwd).
     #[test]
-    fn test_mcp_config_contains_all_three_servers() {
+    fn test_global_config_dir_seeds_builtin_mcp_servers() {
         let tmp = TempDir::new().unwrap();
-        let cfg = tmp.path().to_path_buf();
-        ensure_mcp_config(&cfg).unwrap();
-        let text = std::fs::read_to_string(cfg.join(".mcp.json")).unwrap();
+        let managed_root = tmp.path().join("managed");
+        let cfg = managed_root.join("claude-config");
+
+        ensure_global_config_dir(&managed_root, &cfg).unwrap();
+
+        let text = std::fs::read_to_string(cfg.join(".claude.json")).unwrap();
         let val: serde_json::Value = serde_json::from_str(&text).unwrap();
         let servers = val["mcpServers"].as_object().unwrap();
-        assert!(
-            servers.contains_key("trusty-memory"),
-            "trusty-memory must be defined in .mcp.json"
-        );
-        assert!(
-            servers.contains_key("trusty-review"),
-            "trusty-review must be defined in .mcp.json (WI-8)"
-        );
-        assert!(
-            servers.contains_key("trusty-search"),
-            "trusty-search must be defined in .mcp.json"
-        );
-        // Issue #3918: trusty-mpm joined BUILTIN_MANAGED_MCP_SERVERS, so the
-        // standalone driver's own global .mcp.json now also self-declares it
-        // (previously the standalone `tm run` driver could not connect to its
-        // own trusty-mpm MCP server either).
-        assert!(
-            servers.contains_key("trusty-mpm"),
-            "trusty-mpm must be defined in .mcp.json (#3918)"
-        );
+        for name in crate::core::mcp_config::BUILTIN_MANAGED_MCP_SERVERS {
+            assert!(
+                servers.contains_key(*name),
+                "{name} must be declared in .claude.json's user-scope mcpServers map"
+            );
+        }
     }
 
-    // WI-8: trusty-review server entry must use stdio transport and the correct command/args.
+    // WI-8, retargeted: the trusty-review entry keeps its stdio transport and
+    // canonical command/args in its new home.
     #[test]
-    fn test_mcp_config_review_server_entry() {
+    fn test_seeded_review_server_entry() {
         let tmp = TempDir::new().unwrap();
         let cfg = tmp.path().to_path_buf();
-        ensure_mcp_config(&cfg).unwrap();
-        let text = std::fs::read_to_string(cfg.join(".mcp.json")).unwrap();
+        seed_builtin_mcp_servers(&cfg);
+        let text = std::fs::read_to_string(cfg.join(".claude.json")).unwrap();
         let val: serde_json::Value = serde_json::from_str(&text).unwrap();
         let review = &val["mcpServers"]["trusty-review"];
         assert_eq!(
@@ -499,11 +446,11 @@ mod tests {
         );
     }
 
-    // WI-8 ISOLATION: ensure_mcp_config must write the review entry without
-    // touching any file outside the given claude_config_dir.
+    // WI-8 ISOLATION, retargeted: seeding must touch nothing outside the given
+    // config dir — in particular never the operator's real `$HOME`.
     #[serial_test::serial]
     #[test]
-    fn test_mcp_config_review_no_home_write() {
+    fn test_seed_builtin_mcp_servers_no_home_write() {
         /// RAII guard restoring $HOME on drop (including panic).
         struct HomeGuard(Option<String>);
         impl Drop for HomeGuard {
@@ -527,103 +474,178 @@ mod tests {
             HomeGuard(prev)
         };
 
-        ensure_mcp_config(&cfg).unwrap();
+        seed_builtin_mcp_servers(&cfg);
 
-        // .mcp.json must exist inside cfg.
         assert!(
-            cfg.join(".mcp.json").exists(),
-            "ensure_mcp_config must write .mcp.json inside the given dir"
+            cfg.join(".claude.json").exists(),
+            "seeding must write .claude.json inside the given dir"
         );
         // Nothing must land directly under root (outside cfg).
         assert!(
-            !root.path().join(".mcp.json").exists(),
-            "ensure_mcp_config must NOT write .mcp.json outside the given dir (isolation)"
+            !root.path().join(".claude.json").exists(),
+            "seeding must NOT write .claude.json outside the given dir (isolation)"
         );
         // $HOME must remain empty — no .claude.json or .claude/ created.
         assert!(
-            !fake_home.path().join(".mcp.json").exists(),
-            "ensure_mcp_config must NOT write .mcp.json to $HOME (isolation)"
+            !fake_home.path().join(".claude.json").exists(),
+            "seeding must NOT write .claude.json to $HOME (isolation)"
         );
         assert!(
             !fake_home.path().join(".claude").exists(),
-            "ensure_mcp_config must NOT create $HOME/.claude/ (isolation)"
+            "seeding must NOT create $HOME/.claude/ (isolation)"
         );
         // _home_guard drops here and restores HOME.
     }
 
-    // #1550 item 3: ensure_mcp_config must NOT rewrite .mcp.json when the
-    // content is already correct.  We detect a write by comparing the raw bytes
-    // before and after — if the guard regresses the bytes will change.
-    // (mtime-based assertions are unreliable on coarse-grained CI filesystems.)
+    // #1550 item 3, retargeted by #4181: re-provisioning must not rewrite
+    // `.claude.json` when every builtin is already declared. Byte comparison,
+    // because mtime is unreliable on coarse-grained CI filesystems.
     #[test]
-    fn test_mcp_config_no_spurious_write_when_unchanged() {
+    fn test_seeding_no_spurious_write_when_unchanged() {
         let tmp = TempDir::new().unwrap();
         let cfg = tmp.path().to_path_buf();
-        let mcp_path = cfg.join(".mcp.json");
+        let claude_json = cfg.join(".claude.json");
 
-        // First call writes the canonical file.
-        ensure_mcp_config(&cfg).unwrap();
-        let bytes_after_first = std::fs::read(&mcp_path).unwrap();
+        seed_builtin_mcp_servers(&cfg);
+        let bytes_after_first = std::fs::read(&claude_json).unwrap();
 
-        // Second call must leave the file byte-identical (no write occurred).
-        ensure_mcp_config(&cfg).unwrap();
-        let bytes_after_second = std::fs::read(&mcp_path).unwrap();
+        seed_builtin_mcp_servers(&cfg);
+        let bytes_after_second = std::fs::read(&claude_json).unwrap();
 
         assert_eq!(
             bytes_after_first, bytes_after_second,
-            "ensure_mcp_config must not rewrite .mcp.json when content is unchanged (#1550 item 3)"
+            "seeding must not rewrite .claude.json when every builtin is already present"
         );
     }
 
-    // #1550 item 3 regression: a file with a trailing newline (left by an
-    // editor or a prior write) is logically identical to the same JSON without
-    // the newline.  The structural comparison must treat them as equal and must
-    // NOT rewrite the file.  A byte-wise comparison would fail here, defeating
-    // idempotency.  This test directly covers the Finding-1 regression scenario.
+    // #1550 Finding-1, retargeted by #4181: a trailing newline left by an
+    // editor is a formatting difference, not a content difference. Seeding
+    // decides by parsed key membership, so such a file must come back
+    // byte-identical — a serialize-and-compare implementation would silently
+    // reformat the operator's `.claude.json` on every single launch.
     #[test]
-    fn test_mcp_config_trailing_newline_does_not_trigger_rewrite() {
+    fn test_seeding_trailing_newline_does_not_trigger_rewrite() {
         let tmp = TempDir::new().unwrap();
         let cfg = tmp.path().to_path_buf();
-        let mcp_path = cfg.join(".mcp.json");
+        let claude_json = cfg.join(".claude.json");
 
-        // Write the canonical content, then append a trailing newline to
-        // simulate what an editor or prior implementation might have left.
-        ensure_mcp_config(&cfg).unwrap();
-        let canonical = std::fs::read_to_string(&mcp_path).unwrap();
-        let with_trailing_newline = format!("{canonical}\n");
-        std::fs::write(&mcp_path, with_trailing_newline.as_bytes()).unwrap();
+        seed_builtin_mcp_servers(&cfg);
+        let canonical = std::fs::read_to_string(&claude_json).unwrap();
+        std::fs::write(&claude_json, format!("{canonical}\n").as_bytes()).unwrap();
+        let bytes_before = std::fs::read(&claude_json).unwrap();
 
-        // Capture the bytes as they are now (with the extra newline).
-        let bytes_before = std::fs::read(&mcp_path).unwrap();
+        seed_builtin_mcp_servers(&cfg);
 
-        // ensure_mcp_config must recognise the file is structurally up-to-date
-        // and must NOT rewrite it.
-        ensure_mcp_config(&cfg).unwrap();
-
-        let bytes_after = std::fs::read(&mcp_path).unwrap();
+        let bytes_after = std::fs::read(&claude_json).unwrap();
         assert_eq!(
             bytes_before, bytes_after,
-            "trailing newline in .mcp.json must not trigger a spurious rewrite \
-             (structural comparison must tolerate formatting differences, refs #1550 Finding-1)"
+            "a trailing newline must not trigger a spurious rewrite of .claude.json \
+             (refs #1550 Finding-1)"
         );
     }
 
-    // #1550 item 3: ensure_mcp_config is idempotent across two calls — content
-    // must be byte-identical after both calls.
+    // #4181: an entry the operator registered under a builtin name via
+    // `tm mcp add` is the supported edit path (ADR-0042 decision item 3) and
+    // must survive re-provisioning verbatim. Insert-if-absent, observed through
+    // the real `ensure_global_config_dir` entry point.
     #[test]
-    fn test_mcp_config_idempotent_content() {
+    fn test_global_config_dir_never_overwrites_an_operator_mcp_entry() {
         let tmp = TempDir::new().unwrap();
-        let cfg = tmp.path().to_path_buf();
+        let managed_root = tmp.path().join("managed");
+        let cfg = managed_root.join("claude-config");
+        std::fs::create_dir_all(&cfg).unwrap();
 
-        ensure_mcp_config(&cfg).unwrap();
-        let text_first = std::fs::read_to_string(cfg.join(".mcp.json")).unwrap();
+        let operator = serde_json::json!({
+            "type": "stdio",
+            "command": "/opt/operator/trusty-search",
+            "args": ["serve", "--index", "pinned"]
+        });
+        std::fs::write(
+            cfg.join(".claude.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "mcpServers": { "trusty-search": operator.clone() }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
 
-        ensure_mcp_config(&cfg).unwrap();
-        let text_second = std::fs::read_to_string(cfg.join(".mcp.json")).unwrap();
+        ensure_global_config_dir(&managed_root, &cfg).unwrap();
+
+        let text = std::fs::read_to_string(cfg.join(".claude.json")).unwrap();
+        let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            val["mcpServers"]["trusty-search"], operator,
+            "seeding must never overwrite an operator-registered entry"
+        );
+        assert!(
+            val["mcpServers"]["trusty-mpm"].is_object(),
+            "the remaining builtins must still be seeded alongside it"
+        );
+    }
+
+    // #4181 FAIL-OPEN: seeding runs on every launch now, so a malformed
+    // `.claude.json` must neither fail provisioning nor be quarantined by the
+    // seeder — that file also holds OAuth state. `deploy_agents_and_skills`
+    // runs AFTER the seed, so the output-styles assertion is what proves the
+    // failure did not short-circuit the rest of provisioning.
+    #[test]
+    fn test_global_config_dir_survives_a_malformed_claude_json() {
+        let tmp = TempDir::new().unwrap();
+        let managed_root = tmp.path().join("managed");
+        let cfg = managed_root.join("claude-config");
+        std::fs::create_dir_all(&cfg).unwrap();
+
+        // Truncated mid-object — what a crash or a full disk leaves behind.
+        // Built rather than written as a literal: an unbalanced brace inside a
+        // string literal skews `check_line_cap.sh`'s brace matcher and makes it
+        // count this whole inline test module against the 500-SLOC prod cap.
+        let complete = serde_json::to_string(&serde_json::json!({
+            "oauthAccount": { "emailAddress": "op@example.com" }
+        }))
+        .unwrap();
+        let malformed = complete.as_bytes()[..complete.len() - 1].to_vec();
+        std::fs::write(cfg.join(".claude.json"), &malformed).unwrap();
+
+        ensure_global_config_dir(&managed_root, &cfg)
+            .expect("a malformed .claude.json must not fail provisioning");
 
         assert_eq!(
-            text_first, text_second,
-            "ensure_mcp_config must produce byte-identical output on repeated calls (#1550 item 3)"
+            std::fs::read(cfg.join(".claude.json")).unwrap(),
+            malformed,
+            "the seeder must leave a malformed .claude.json byte-identical — no rename, no write"
+        );
+        let quarantined = std::fs::read_dir(&cfg)
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|e| e.file_name().to_string_lossy().contains("corrupt"));
+        assert!(!quarantined, "the seeder must not quarantine .claude.json");
+        assert!(
+            cfg.join("output-styles").exists(),
+            "provisioning steps after the seed must still have run"
+        );
+    }
+
+    // #4181 FAIL-OPEN: an unreadable `.claude.json` makes `seed_builtin_servers`
+    // return `Err`, and the wrapper must absorb it so the agent/skill deploy
+    // below still runs. A directory standing where the file belongs is the
+    // read error that reproduces without depending on the test user's uid.
+    #[test]
+    fn test_global_config_dir_survives_an_unreadable_claude_json() {
+        let tmp = TempDir::new().unwrap();
+        let managed_root = tmp.path().join("managed");
+        let cfg = managed_root.join("claude-config");
+        std::fs::create_dir_all(cfg.join(".claude.json")).unwrap();
+
+        ensure_global_config_dir(&managed_root, &cfg)
+            .expect("an unreadable .claude.json must not fail provisioning");
+
+        assert!(
+            cfg.join(".claude.json").is_dir(),
+            "the seeder must not have disturbed what it could not read"
+        );
+        assert!(
+            cfg.join("output-styles").exists(),
+            "provisioning steps after the seed must still have run"
         );
     }
 


### PR DESCRIPTION
PR C1 of the ADR-0042 sequence for #4181. It adds the user-scope declaration. It deletes no injector.

## What seeding does

`mcp_config::seed_builtin_servers(config_dir)` writes the four names in `BUILTIN_MANAGED_MCP_SERVERS` into the top-level `mcpServers` map of `<config_dir>/.claude.json`, using the existing `builtin_server_entry`, under `claude_json_guard::lock()` across the whole read-mutate-write cycle. `ensure_global_config_dir` calls it at the point that used to call `ensure_mcp_config`, which reaches `ensure_managed_config_dir` (every daemon spawn, resume, and in-place relaunch) and the standalone `tm run` driver.

**Insert-if-absent is the contract, not an optimisation.** An entry already sitting under a builtin name is the operator's — `tm mcp add` is the supported edit path under ADR-0042 decision item 3 — so seeding never overwrites, reorders, or removes it. It reports the names it inserted; an empty result means no write happened at all, so a fully-seeded config is left byte-identical (`test_seeding_no_spurious_write_when_unchanged`, `test_seeding_trailing_newline_does_not_trigger_rewrite`).

## `ensure_mcp_config` is gone, and why that is not an injector deletion

It wrote the same four servers into `<CLAUDE_CONFIG_DIR>/.mcp.json`. ADR-0042 measured that Claude Code discovers a `.mcp.json` only by walking up from the session's cwd, and cwd is always the repo — `standalone::run.rs:65` calls `cmd.current_dir(repo_path)`, and the daemon spawns in the workspace. That file was on no session's search path, so nothing read what it wrote. Its six tests were retargeted onto the new home rather than dropped: server set, review entry shape, `$HOME` isolation, no-spurious-write, trailing-newline tolerance.

It is not one of the injectors this PR is forbidden to touch. `native_mcp.rs`, `custom_mcp.rs`, every `inject_*`, `exclude_mcp_json_from_git`, `launch_trusted_mcp_names`, `preseed_workspace_trust`, and every `enabledMcpjsonServers` write are all still here and still called. The #3926 coupling does not reach `ensure_mcp_config` either: an `enabledMcpjsonServers` approval resolves against the `.mcp.json` discovered from cwd, never against the config dir's copy.

## The double-provisioning interval

Until C2, both mechanisms provision the builtins — seeding into user scope, the injectors into the workspace `.mcp.json`. They are different files, so no duplicate and no clobber is possible. `seeding_and_workspace_injection_coexist_without_clobbering` runs seed → `inject_trusty_mpm_mcp` → seed and asserts the second seed inserts nothing, the user-scope entry is the unduplicated canonical builtin, and the workspace file still declares exactly what was injected.

One collision was possible and is closed by construction: `inject_native_trusty_mcps_from` iterates a fixed allowlist (`slack-mcp`, `telegram-mcp`, `gworkspace-mcp`, `trusty-analyze`) that contains no builtin, and `custom_mcp`'s registry loop skips `is_reserved_name`. So seeding the builtins into the registry cannot make either loop overwrite `inject_trusty_search_mcp`'s `--index` pin. #1373 is unaffected.

## The regression seeding caused, found by an existing test

Seeding writes the builtins into the same `mcpServers` map `managed_mcp_server_names` unions into `enabledMcpjsonServers`. That union was wholesale, so a seeded builtin entered the approved set with no `_pinned` evidence — approving a name whose workspace content was never verified this run. That is #3950, reopened by the seeding rather than by any change to the trust derivation.

Red, on this branch before the fix:

```
test runtime::claude_code::tests::prepare_managed_config_excludes_builtins_when_mcp_json_write_fails ... FAILED

thread '...' panicked at crates/trusty-mpm/src/runtime/claude_code_tests.rs:2159:9:
trusty-mpm must not be approved when its pin write failed this run (headless resume
path, no human to decline a consent dialog): ["trusty-memory", "trusty-mpm", "trusty-review", "trusty-search"]

test result: FAILED. 5018 passed; 1 failed; 7 ignored; 0 measured; 0 filtered out; finished in 67.87s
```

The fix subtracts `BUILTIN_MANAGED_MCP_SERVERS` from the registry half of the union, so a builtin's membership comes from its `_pinned` flag and nothing else. `a_seeded_builtin_is_not_approved_when_its_pin_failed` pins it: a freshly seeded config dir with all four flags false approves nothing, a non-builtin registration still enters, and a successful pin still approves its builtin.

**This reverses a documented assertion.** `managed_mcp_server_names_registry_collision_is_a_separate_trusted_source` said a registry entry named `trusty-memory` is trusted regardless of the conditional toggle, on the grounds that the registry is operator-controlled. Narrowly, that rule cannot survive seeding — it would make all four `_pinned` parameters dead. Separately it was already wrong: the approval is content-blind and resolves against the workspace `.mcp.json`, and `custom_mcp` skips reserved names, so a registry entry under a builtin name is never what pins the workspace entry — only the toggle-gated injector is. The test is renamed and inverted with that reasoning in it.

## Fail-open analysis

Seeding runs on every launch now, so each failure arm was traced to what the operator actually experiences.

| Arm | Seeding | Session |
|---|---|---|
| Config dir absent | Creates the dir and the file with all four builtins | starts |
| `.claude.json` unreadable | `Err`, absorbed by the wrapper into a `warn!` | starts |
| `.claude.json` malformed | `warn!`, returns having written and renamed nothing | starts |
| `mcpServers` present but not an object | `warn!`, returns having written nothing | starts |

Two design decisions carry that table.

**Seeding does not go through `read_config`.** That reader quarantines by renaming, and `.claude.json` holds OAuth state. It is right for `tm mcp add`, where the operator is present and is explicitly asking to write the file; it is wrong for something that runs unattended before every launch. `read_config_for_seeding` declines instead — no rename, no write, file byte-identical.

**The call site does not use `?`.** `seed_builtin_mcp_servers` swallows the outcome into a log line, because it sits between `seed_credentials` and `deploy_agents_and_skills` in `ensure_global_config_dir`. A `?` there would let an unwritable `.claude.json` skip the agent and skill deploy and hand the session an empty roster. A seeding failure costs MCP servers for one launch and nothing else — which is what the `output-styles` assertion in both fail-open tests actually checks.

### What a malformed-config user experiences the first time they launch after this ships

No change from today. `preseed_managed_trust` already quarantines that file on every launch — it renames it to a timestamped `.corrupt` sibling, logs at `ERROR`, and writes a fresh config, and it has done so since #4206. It runs a few milliseconds after seeding in `prepare_managed_config`. So the OAuth state is lost either way; declining in the seeder does not save it. What declining does buy is that this PR adds no second writer to that failure, and the next launch — reading the valid file trust-seeding just wrote — seeds normally.

### Red-then-green per arm

Two of the four new `ensure_global_config_dir` tests fail against `origin/main`, run there verbatim against main's production code:

```
test core::standalone::global_config::tests::red_demo_seeds_builtin_mcp_servers ... FAILED
test core::standalone::global_config::tests::red_demo_never_overwrites_an_operator_mcp_entry ... FAILED
test core::standalone::global_config::tests::red_demo_survives_a_malformed_claude_json ... ok
test core::standalone::global_config::tests::red_demo_survives_an_unreadable_claude_json ... ok

thread '...red_demo_seeds_builtin_mcp_servers' panicked at global_config.rs:383:70
thread '...red_demo_never_overwrites_an_operator_mcp_entry' panicked at global_config.rs:413:9:
assertion failed: val["mcpServers"]["trusty-mpm"].is_object()

test result: FAILED. 2 passed; 2 failed; 0 ignored; 0 measured; 5014 filtered out; finished in 0.01s
```

The two fail-open tests pass on main, and would on any additive change: main's `ensure_global_config_dir` never opens `.claude.json`, so there is nothing there to break. Reporting them as red-on-main would be false.

They are not vacuous, though. Against the naive design — seeding through the quarantining `read_config`, one line different — both go red:

```
test core::mcp_config::tests::seed_builtin_servers_declines_a_malformed_config_without_quarantining ... FAILED
test core::standalone::global_config::tests::test_global_config_dir_survives_a_malformed_claude_json ... FAILED

thread '...declines_a_malformed_config_without_quarantining' panicked at mcp_config_tests.rs:635:5:
a malformed config must seed nothing

test result: FAILED. 30 passed; 2 failed; 0 ignored; 0 measured; 4995 filtered out; finished in 0.03s
```

Green on this branch, all four:

```
test core::standalone::global_config::tests::test_global_config_dir_seeds_builtin_mcp_servers ... ok
test core::standalone::global_config::tests::test_global_config_dir_never_overwrites_an_operator_mcp_entry ... ok
test core::standalone::global_config::tests::test_global_config_dir_survives_a_malformed_claude_json ... ok
test core::standalone::global_config::tests::test_global_config_dir_survives_an_unreadable_claude_json ... ok
```

## Gates — rung 5 (persisted state, process lifecycle, security)

```
cargo fmt --check                                      EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings EXIT=0
cargo test -p trusty-mpm                               EXIT=0
cargo check --workspace                                EXIT=0
bash scripts/check_line_cap.sh                         EXIT=0
bash scripts/check_sld.sh                              EXIT=0
bash scripts/check_capabilities.sh                     EXIT=0
bash scripts/check_changelog_fragment.sh               EXIT=0
```

```
test result: ok. 5020 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 51.10s
line-cap: measured 3898 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
changelog-fragment gate: scanned 5 changed path(s); all 1 crate(s) with source changes are recorded.
```

Two gate failures were fixed rather than worked around, both worth naming because they are non-obvious:

`check_line_cap.sh` failed at 534 SLOC for `global_config.rs`. The cause was not size — it was the `br#"{"oauthAccount": ..."#` literal in the new test, whose unbalanced brace skews the script's matcher and makes it count the whole inline `#[cfg(test)]` module against the 500-SLOC production cap, exactly the fail-closed behavior CLAUDE.md documents. Building the malformed JSON instead of writing it as a literal restores the exclusion. Nothing was ignored, excluded, or allowlisted.

`cargo clippy` then failed on that replacement (`as_bytes` after slicing a string). Fixed in place.

`cargo check --workspace` rebuilt the embedded UIs and dirtied `crates/trusty-analyze/ui/dist/` and `crates/trusty-memory/ui/package-lock.json`. Both restored; `git diff --name-only origin/main...HEAD` lists five paths, all under `crates/trusty-mpm/`.

Refs #4181, [ADR-0042](docs/adr/0042-mcp-configuration-is-static-and-persistent.md).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
