### PR TITLE
chore(trusty-common): bump to 0.31.0 — the 0.30.1 patch bump contained breaking API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11398,7 +11398,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ trusty-code = { path = "crates/trusty-code" }
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.5.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.30" }
+trusty-common = { path = "crates/trusty-common", version = "0.31" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.10" }

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.30.1"
+version = "0.31.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -15,7 +15,7 @@ name = "trusty-gworkspace-mcp"
 path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.30", features = ["mcp"] }
+trusty-common = { path = "../trusty-common", version = "0.31", features = ["mcp"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -83,7 +83,7 @@ path = "src/bin/mcp_bridge.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.30", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "uds-supervisor", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config"] }
+trusty-common = { path = "../trusty-common", version = "0.31", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "uds-supervisor", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside
@@ -180,7 +180,7 @@ serial_test = { workspace = true }
 # the production library (mirrors the trusty-mpm and trusty-search pattern).
 # `docgen` (#5205 follow-up): `tests/generated_docs.rs` renders the MCP tool
 # section of README.md from `tool_definitions()`.
-trusty-common = { path = "../trusty-common", version = "0.30", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
+trusty-common = { path = "../trusty-common", version = "0.31", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
 chrono = { workspace = true }
 
 [features]

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -54,7 +54,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.30", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "crate-config", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "codex-config"] }  # `config-cli` (#2405): implies `credentials`, giving both the shared `.env.local` loader `load_env_local_once` (retiring trusty-search's ad hoc dotenvy call) AND the embeddable `ConfigKeysCommand` nested under `trusty-search config keys …`  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
+trusty-common = { version = "0.31", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "crate-config", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "codex-config"] }  # `config-cli` (#2405): implies `credentials`, giving both the shared `.env.local` loader `load_env_local_once` (retiring trusty-search's ad hoc dotenvy call) AND the embeddable `ConfigKeysCommand` nested under `trusty-search config keys …`  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
 
 # ── Bundled sidecars ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue
@@ -258,7 +258,7 @@ filetime = "0.2"
 # docgen (#5205 follow-up): `tests/generated_docs.rs` renders the MCP tool
 # section of README.md / CLAUDE.md from `tool_descriptors()`. Test-facing
 # only, so the feature is enabled here rather than on the production dep.
-trusty-common = { version = "0.30", default-features = false, features = ["docgen"] }
+trusty-common = { version = "0.31", default-features = false, features = ["docgen"] }
 
 [features]
 # Default: bundle ORT static libs via trusty-embedder. Works on macOS and


### PR DESCRIPTION
**Why:** `scripts/preflight-publish.sh trusty-common` CHECK 5 (`cargo-semver-checks` vs the live 0.30.0 release) reported BREAK on the in-tree 0.30.1. Two intentional breaking changes are the cause:

- `encode_triple_key` and `encode_predicate_index_key` (`crates/trusty-common/src/memory_core/store/kg_store.rs:391` and `:479`) gained a third parameter, from the (subject,predicate,object) keying work in [#4810](https://github.com/bobmatnyc/trusty-tools/issues/4810).
- `PausedSessionJson` (`crates/trusty-common/src/catchup/json.rs:54`) gained `#[non_exhaustive]`.

Both changes stay — the version was wrong, not the code. Cargo's 0.x rule puts the breaking bump at MINOR, so 0.31.0.

**What:** version bump plus every trusty-common version requirement across the workspace updated 0.30 → 0.31 — root `Cargo.toml`, `crates/trusty-memory/Cargo.toml` (2 sites), `crates/trusty-gworkspace/Cargo.toml`, `crates/trusty-search/Cargo.toml` (2 sites), and `Cargo.lock`. `crates/trusty-search/Cargo.toml`'s own version stays 0.45.0.

**Blocks:** unblocks publishing trusty-common 0.31.0 and then trusty-search 0.45.0. trusty-search currently cannot publish — `cargo publish --dry-run -p trusty-search` fails because 0.45.0 needs trusty-common's `codex-config` feature and crates.io only has 0.30.0.

**Test rung:** rung 4 (cross-crate manifest change).
- `cargo check --workspace` — exit 0
- `cargo test -p trusty-common` — 312 passed / 0 failed / 6 ignored
- `cargo fmt --check` — exit 0
- `scripts/check_changelog_fragment.sh` — exit 0 (Cargo.toml/lock only, no crate source changed, so no fragment required)
- `scripts/preflight-publish.sh trusty-common` CHECK 5 — now passes, precisely by SKIP: "0.30.0 -> 0.31.0 is already a major release — every lint is inapplicable" (a pass by skip, not an affirmative API scan)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
