### PR TITLE
fix(ci): diff the changelog gate against the live base branch, not a pinned base.sha

### DIFF
--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -63,7 +63,32 @@ jobs:
       - name: Fragment-validation selftest (must reject a malformed fragment)
         run: bash scripts/assemble_changelog_selftest.sh
 
+      # Stale-base selftest (#5018): replays the false failure on a synthetic
+      # repo — a branch touching crate A only, with crate B released (and B's
+      # fragments consumed) on main since the fork point. Proves the gate
+      # refuses the stale base, passes against the live branch naming only A,
+      # and still fails a genuinely missing fragment. Without it the base
+      # handling is untested code and a later edit can silently restore the
+      # blame-innocent-crates behaviour.
+      - name: Stale-base selftest (must refuse a pinned base.sha)
+        run: bash scripts/check_changelog_base_selftest.sh
+
+      # #4688: diff against the base branch AS IT IS NOW, not the frozen
+      # `base.sha` snapshot. checkout leaves refs/remotes/origin/<base> at
+      # whatever it fetched; re-fetching pins it to the live tip so the merge
+      # base cannot lag behind the merge ref's own first parent. Matches
+      # version-parity.yml and ci.yml. See the ATTRIBUTION note in
+      # scripts/check_changelog_fragment.sh for the failure this removes
+      # (PR #5018 / run 31431273762).
+      - name: Refresh the base branch ref
+        run: |
+          git fetch --no-tags --quiet origin \
+            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          git rev-parse --verify "refs/remotes/origin/${BASE_REF}"
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+
       - name: Enforce per-PR changelog fragment
         env:
-          CHANGELOG_GATE_BASE: ${{ github.event.pull_request.base.sha }}
+          CHANGELOG_GATE_BASE: origin/${{ github.event.pull_request.base.ref }}
         run: bash scripts/check_changelog_fragment.sh

--- a/scripts/check_changelog_base_selftest.sh
+++ b/scripts/check_changelog_base_selftest.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#
+# check_changelog_base_selftest.sh — base-attribution regressions for
+# scripts/check_changelog_fragment.sh (issue #5018).
+#
+# Why: the gate blames whatever `git merge-base BASE HEAD`..HEAD contains, so
+#   the base ref alone decides which commits count as "this PR's". Its workflow
+#   passed `github.event.pull_request.base.sha`, a snapshot frozen when the PR
+#   event fired, while `actions/checkout` resolved the same event to
+#   `refs/pull/N/merge` — a merge commit whose first parent is the base
+#   branch's CURRENT tip. The stale SHA is an ancestor of that merge ref, so
+#   `git merge-base` returns it unchanged and the diff spans every commit main
+#   took in between. A release inside that window assembles a crate's fragments
+#   into CHANGELOG.md and DELETES `changelog.d/*.md`, and the gate excludes
+#   deletions from evidence, so an untouched crate reads as "source changed, no
+#   fragment". PR #5018 changed one crate and was failed for three others.
+#
+#   Neither the base handling nor the fix had a test. This is it.
+#
+# What: builds a throwaway git repo carrying the exact shape — crate A touched
+#   by the branch, crate B released on main since the fork point — checks out a
+#   GitHub-shaped merge ref, and asserts the gate's verdict under each base.
+#
+#   Cases:
+#     stale-base-refused        a bare fork-point SHA under a merge ref is
+#                               REFUSED naming the base, and crate B is never
+#                               blamed. This is the case that goes red against
+#                               the pre-#5018 script, which instead reported
+#                               "crate-b: src/** changed with no changelog
+#                               record" for a crate the branch never touched.
+#     live-base-passes          the base BRANCH passes, scanning only the
+#                               branch's own paths and naming only crate A.
+#     missing-fragment-fails    crate A's src/** changed with no fragment still
+#                               FAILS. The fix must not weaken the gate.
+#     exact-base-parent-allowed a bare SHA that IS the merge ref's base parent
+#                               is exact, not stale, and still runs.
+#     plain-head-sha-allowed    a bare SHA base against a NON-merge HEAD is the
+#                               true fork point and still runs. The guard is
+#                               scoped to the merge-ref shape it was written
+#                               for, and must not fire outside it.
+#
+# Test: this IS the test. Run directly:
+#   bash scripts/check_changelog_base_selftest.sh
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
+#   only. Same constraints as the script under test.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/changelog-base-selftest.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+REPO="$TMP_ROOT/repo"
+GATE="scripts/check_changelog_fragment.sh"
+fail=0
+
+g() { git -C "$REPO" "$@"; }
+
+# ---------------------------------------------------------------------------
+# Fixture: two crates, a branch that touches only crate-a, and a release on
+# main that changes crate-b's source and CONSUMES its fragments.
+# ---------------------------------------------------------------------------
+mkdir -p "$REPO/scripts"
+cp "$SCRIPT_DIR/check_changelog_fragment.sh" "$REPO/scripts/"
+cp "$SCRIPT_DIR/assemble-changelog.sh" "$REPO/scripts/"
+
+new_crate() {
+  local name="$1" dir="$REPO/crates/$1"
+  mkdir -p "$dir/src" "$dir/changelog.d"
+  printf 'pub fn v() -> u32 { 1 }\n' >"$dir/src/lib.rs"
+  printf '[package]\nname = "%s"\nversion = "0.1.0"\n' "$name" >"$dir/Cargo.toml"
+  printf '# Changelog\n\n---\n' >"$dir/CHANGELOG.md"
+  printf 'Placeholder keeping changelog.d/ tracked between releases.\n' \
+    >"$dir/changelog.d/README.md"
+}
+
+fragment() {
+  # crate, filename, category
+  printf '%s\n\n- a user-visible change in %s\n' "$3" "$1" \
+    >"$REPO/crates/$1/changelog.d/$2"
+}
+
+g init -q -b main
+g config user.email selftest@example.invalid
+g config user.name "changelog base self-test"
+
+new_crate crate-a
+new_crate crate-b
+# crate-b enters the window with unreleased fragments, exactly as a real crate
+# does between releases.
+fragment crate-b 4100-b-earlier.md Fixed
+fragment crate-b 4200-b-later.md Added
+g add -A
+g commit -qm "M0: two crates, crate-b carrying unreleased fragments"
+FORK_POINT="$(g rev-parse HEAD)"
+
+# The branch. Touches crate-a's source and records it — a correct, complete PR.
+g checkout -q -b pr
+printf 'pub fn v() -> u32 { 2 }\n' >"$REPO/crates/crate-a/src/lib.rs"
+fragment crate-a 5018-a-change.md Fixed
+g add -A
+g commit -qm "PR: change crate-a source, add crate-a fragment"
+PR_HEAD="$(g rev-parse HEAD)"
+
+# Main moves on without the branch: crate-b's source changes, and a release
+# folds its fragments into CHANGELOG.md and deletes them. This is assembly, not
+# omission — and it is what a stale base misreads.
+g checkout -q main
+printf 'pub fn v() -> u32 { 7 }\n' >"$REPO/crates/crate-b/src/lib.rs"
+g rm -q "crates/crate-b/changelog.d/4100-b-earlier.md" \
+  "crates/crate-b/changelog.d/4200-b-later.md"
+printf '# Changelog\n\n---\n\n## [0.1.1]\n\n### Fixed\n\n- released bullet\n' \
+  >"$REPO/crates/crate-b/CHANGELOG.md"
+g add -A
+g commit -qm "M1: crate-b source change + release consuming crate-b fragments"
+MAIN_TIP="$(g rev-parse HEAD)"
+
+# The merge ref GitHub builds for a pull_request event: first parent is the
+# CURRENT base tip, second is the PR head. `actions/checkout` checks this out,
+# which is what lets a stale base outrank the fork point.
+g checkout -q --detach main
+g merge -q --no-ff -m "Merge ${PR_HEAD} into ${MAIN_TIP}" pr
+MERGE_REF="$(g rev-parse HEAD)"
+
+# ---------------------------------------------------------------------------
+# assert_case: name, base ref, expected exit status, ERE the output must match,
+# ERE the output must NOT match ("" to skip either match).
+# ---------------------------------------------------------------------------
+assert_case() {
+  local name="$1" base="$2" want_rc="$3" want_re="$4" deny_re="$5" out rc=0
+  # Capture, then match. NOT `... | grep -q`: under `set -o pipefail` the gate's
+  # own (expected) non-zero exit becomes the pipeline's status even when grep
+  # matched, so every rejection assertion would read as a miss.
+  out="$(cd "$REPO" && CHANGELOG_GATE_BASE="$base" bash "$GATE" 2>&1)" || rc=$?
+  if [ "$rc" -ne "$want_rc" ]; then
+    echo "FAIL: $name -> exit $rc (expected $want_rc)" >&2
+    printf '%s\n' "$out" | sed 's/^/       /' >&2
+    fail=1
+    return
+  fi
+  if [ -n "$want_re" ] && ! grep -qE "$want_re" <<<"$out"; then
+    echo "FAIL: $name -> exit $rc as expected, but output does not match /$want_re/" >&2
+    printf '%s\n' "$out" | sed 's/^/       /' >&2
+    fail=1
+    return
+  fi
+  if [ -n "$deny_re" ] && grep -qE "$deny_re" <<<"$out"; then
+    echo "FAIL: $name -> exit $rc as expected, but output MATCHES forbidden /$deny_re/" >&2
+    printf '%s\n' "$out" | sed 's/^/       /' >&2
+    fail=1
+    return
+  fi
+  echo "PASS: $name -> exit $rc${want_re:+, matched /$want_re/}"
+}
+
+# 1. THE #5018 DEFECT. A pinned fork-point SHA under the merge ref must be
+#    refused, and crate-b — which this branch never touched — must never be
+#    named. The pre-fix script fails here by blaming crate-b instead.
+assert_case stale-base-refused "$FORK_POINT" 1 \
+  'STALE BASE' \
+  'crate-b'
+
+# 2. THE FIX. Against the base BRANCH the merge base is the merge ref's own
+#    first parent, so the diff is exactly the branch's contribution.
+assert_case live-base-passes main 0 \
+  'OK   crate-a: changelog.d fragment present and valid' \
+  'crate-b'
+
+# 3. STILL A GATE. Drop crate-a's fragment and the same live base must fail.
+g checkout -q pr
+g rm -q crates/crate-a/changelog.d/5018-a-change.md
+g commit -qm "PR: drop the crate-a fragment"
+NOFRAG_HEAD="$(g rev-parse HEAD)"
+g checkout -q --detach main
+g merge -q --no-ff -m "Merge ${NOFRAG_HEAD} into ${MAIN_TIP}" pr
+assert_case missing-fragment-fails main 1 \
+  'FAIL crate-a: crates/crate-a/src/\*\* changed with no changelog record' \
+  ''
+
+# 4. NOT OVER-BROAD. A bare SHA that IS the merge ref's base parent is exact,
+#    not stale, so the guard must let it through and reach the real verdict.
+assert_case exact-base-parent-allowed "$MAIN_TIP" 1 \
+  'FAIL crate-a: crates/crate-a/src/\*\* changed with no changelog record' \
+  'STALE BASE'
+
+# 5. NOT OVER-BROAD. Against a plain (non-merge) HEAD the same fork-point SHA
+#    IS the fork point, so it stays correct and must not be refused.
+g checkout -q --detach "$PR_HEAD"
+assert_case plain-head-sha-allowed "$FORK_POINT" 0 \
+  'OK   crate-a: changelog.d fragment present and valid' \
+  'STALE BASE'
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "check_changelog_base_selftest: FAILED — the gate mis-attributes changes." >&2
+  echo "  Merge ref under test: ${MERGE_REF}" >&2
+  exit 1
+fi
+echo "check_changelog_base_selftest: all base-attribution cases passed."

--- a/scripts/check_changelog_fragment.sh
+++ b/scripts/check_changelog_fragment.sh
@@ -83,6 +83,34 @@
 #   where it reports SUCCESS. A `paths:`-filtered required check never reports on
 #   the PRs it skips and leaves them permanently pending.
 #
+# ATTRIBUTION (#5018). The base must name the base BRANCH as it exists NOW
+#   (`origin/main`), never a frozen commit SHA. The base ref decides which
+#   commits count as "this PR's", so a wrong base blames the wrong author.
+#
+#   `actions/checkout` resolves a `pull_request` event to `refs/pull/N/merge`, a
+#   GitHub-built merge commit whose FIRST parent is the base branch's CURRENT
+#   tip, refreshed continuously. `github.event.pull_request.base.sha` — what
+#   this gate's workflow originally passed — is a snapshot taken when the event
+#   fired, and goes stale the moment anything else merges. The stale SHA is an
+#   ANCESTOR of the merge ref, so `git merge-base` hands it straight back
+#   instead of finding a fork point, and the diff sweeps in every commit main
+#   took in between.
+#
+#   That is what turns an unrelated crate red. A release assembles a crate's
+#   fragments into CHANGELOG.md and DELETES `changelog.d/*.md`; deletions are
+#   excluded from evidence (see PRESENT below). So any crate that both changed
+#   and shipped a release inside that window reads as "source changed, no
+#   fragment" — release-time fragment CONSUMPTION misread as this PR's
+#   OMISSION. Live instance: PR #5018 changed one crate (trusty-installer) and
+#   was failed for trusty-analyze, trusty-git-analytics and trusty-review, none
+#   of which it touches (run 31431273762). Against the live branch tip the
+#   merge base IS the merge ref's first parent, so the diff is exactly what the
+#   PR contributes — 9 paths and 1 crate, not 1279 and 16.
+#
+#   Same failure and same fix as #4688 (check-pr-version-bump.sh) and #4960
+#   (detect-docs-only.sh); this gate was the last one still pinned to base.sha.
+#   `main()` refuses the broken shape rather than guessing — see STALE BASE.
+#
 # Usage:
 #   bash scripts/check_changelog_fragment.sh                  # base: origin/main
 #   bash scripts/check_changelog_fragment.sh --base <ref>     # explicit base
@@ -91,9 +119,13 @@
 # Exit: 0 when every crate with source changes has evidence (or is exempt);
 #   non-zero with a per-crate summary on stderr when one does not.
 #
-# Test: exercised in both directions in the PR that introduced it (#4476) — a
-#   tree with fragments exits 0; the same tree with the fragments deleted fails
-#   and names the crates. Pure path/diff logic; no unit-test harness.
+# Test: scripts/check_changelog_base_selftest.sh replays the #5018 shape on a
+#   synthetic repo — a branch touching crate A only, with crate B's src/**
+#   changed and B's fragments consumed by a release on main since the fork
+#   point — and asserts the stale base is refused, the live branch base passes
+#   naming only A, and a genuinely missing fragment still fails. Fragment
+#   validation is covered by scripts/assemble_changelog_selftest.sh and the
+#   scan floor by scripts/check_scan_floor_selftest.sh.
 #
 # Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
 #   only — `git`, `grep`, `sed`, `sort`.
@@ -129,6 +161,49 @@ if ! MERGE_BASE="$(git merge-base "$BASE" HEAD 2>/dev/null)"; then
   echo "ERROR: cannot find a merge base between '$BASE' and HEAD." >&2
   echo "       Fetch the base ref first (CI must check out with fetch-depth: 0):" >&2
   echo "         git fetch origin main" >&2
+  exit 1
+fi
+
+# #5018 STALE BASE. A ref resolves to a symbolic full name; a bare SHA resolves
+# to empty output. That distinction is the whole test: `origin/main` tracks the
+# base branch and self-corrects as main moves, a pinned SHA cannot.
+if [[ -n "$(git rev-parse --symbolic-full-name "$BASE" 2>/dev/null)" ]]; then
+  BASE_IS_REF=1
+else
+  BASE_IS_REF=0
+fi
+
+# Refuse a bare-SHA base that lags the merge ref's own base parent. Comparing
+# (BASE, HEAD) cannot distinguish a stale base from a correct one — both are
+# ancestors of HEAD — so the gate does not try to guess which commits are the
+# PR's. It rejects the one configuration where the mis-attribution is provable
+# and names the fix, instead of silently blaming crates the PR never touched.
+#
+# All four conditions are required, and each one rules out a legitimate caller:
+#   - bare SHA: `--base origin/main` is a ref and is always allowed;
+#   - HEAD has a second parent: only the merge-ref checkout has one, so a run
+#     against a plain branch head is untouched (there the same stale SHA still
+#     resolves to the true fork point, which is correct);
+#   - BASE is an ancestor of HEAD^1: a base that is not behind the base parent
+#     is not stale;
+#   - BASE differs from HEAD^1: passing the merge ref's own base parent by SHA
+#     is exact, not stale, and stays allowed.
+if [[ "$BASE_IS_REF" -eq 0 ]] &&
+  git rev-parse --verify --quiet 'HEAD^2' >/dev/null &&
+  git merge-base --is-ancestor "$BASE" 'HEAD^1' &&
+  [[ "$(git rev-parse "$BASE")" != "$(git rev-parse 'HEAD^1')" ]]; then
+  BASE_PARENT="$(git rev-parse 'HEAD^1')"
+  BEHIND="$(git rev-list --count "${BASE}..${BASE_PARENT}")"
+  echo "FAIL: STALE BASE — '${BASE}' is a bare commit SHA ${BEHIND} commit(s) behind" >&2
+  echo "      HEAD's base parent ${BASE_PARENT:0:10}, and HEAD is a merge ref." >&2
+  echo "      The diff against it would span every commit merged in between and" >&2
+  echo "      report other authors' crates as this PR's missing fragments — a" >&2
+  echo "      release in that window CONSUMES changelog.d/*.md, which reads as an" >&2
+  echo "      omission. That is the #5018 false failure; refusing to repeat it." >&2
+  echo "      Pass the base BRANCH instead, so the merge base tracks it:" >&2
+  echo "        CHANGELOG_GATE_BASE=origin/main bash scripts/check_changelog_fragment.sh" >&2
+  echo "      In a workflow, use origin/\${{ github.event.pull_request.base.ref }}" >&2
+  echo "      after re-fetching that branch (the #4688 pattern)." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## The false failure

The per-PR changelog-fragment gate failed PR #5018 for `trusty-analyze`,
`trusty-git-analytics` and `trusty-review`. PR #5018 changes one crate,
`trusty-installer`, and touches none of those three.

From the failing run ([31431273762](https://github.com/bobmatnyc/trusty-tools/actions/runs/31431273762/job/93595012131)):

```
env:
  CHANGELOG_GATE_BASE: 8ab2c147af49bcecbea06a4c395a3f88e4c233cb
...
HEAD is now at 8d7b3796 Merge 85b2576174a10b49eebe6506e7cb3708749af350 into fad89dc586f9d1a4ef592c36791048ffefdaaa11
...
OK   tc-services: changelog.d fragment present and valid
OK   trusty-agents: changelog.d fragment present and valid
FAIL trusty-analyze: crates/trusty-analyze/src/** changed with no changelog record
OK   trusty-bm25-daemon: changelog.d fragment present and valid
...
FAIL trusty-git-analytics: crates/trusty-git-analytics/src/** changed with no changelog record
...
FAIL trusty-review: crates/trusty-review/src/** changed with no changelog record
```

Sixteen crates evaluated for a PR that changes one.

## Reproduction

Checked out #5018's merge ref detached, ran the gate against the base the
workflow pins:

```
$ CHANGELOG_GATE_BASE=8ab2c147af49bcecbea06a4c395a3f88e4c233cb bash scripts/check_changelog_fragment.sh
FAIL trusty-git-analytics: crates/trusty-git-analytics/src/** changed with no changelog record
FAIL trusty-review: crates/trusty-review/src/** changed with no changelog record
EXIT=1
```

Two of the three reproduce today rather than three: `trusty-analyze` picked up
a new fragment on main (`4980-ui-base-hash-routing.md`) between the CI run and
now, which happens to cover it. The mechanism is the same for all three.

The two diffs, same HEAD, different base:

```
$ git diff --name-only 8ab2c147 pr/5018/head   ->    9 paths
$ git diff --name-only 8ab2c147 pr/5018/merge  -> 1279 paths
```

## The mechanism

The description this work started from named the fork point as the culprit.
That is not it — `8ab2c147` **is** #5018's fork point
(`git merge-base 8ab2c147 pr/5018/head` returns `8ab2c147`). Against the PR
head that base is correct and yields the right 9 paths. The rest of the
diagnosis holds exactly, and here is the missing link.

`actions/checkout` resolves a `pull_request` event to `refs/pull/N/merge`, a
GitHub-built merge commit whose **first parent is the base branch's current
tip** — the CI log line above shows it merging into `fad89dc5`, not into
`8ab2c147`. `github.event.pull_request.base.sha` is a snapshot taken when the
PR event fired and goes stale the moment anything else merges. Pair the two and
the stale SHA is an *ancestor* of HEAD, so `git merge-base` hands it straight
back instead of finding a fork point, and the diff spans every commit main took
in between.

That is what turns an unrelated crate red. A release assembles a crate's
fragments into `CHANGELOG.md` and **deletes** `changelog.d/*.md`; the gate
excludes deletions from evidence (`--diff-filter=d`, by design — `git rm`-ing a
fragment must not count as recording one). So a crate that both changed and
shipped a release inside that window reads as "source changed, no fragment".
Release-time **consumption** misread as this PR's **omission**:

```
M	crates/trusty-review/CHANGELOG.md
D	crates/trusty-review/changelog.d/4476-migrated-changed.md
D	crates/trusty-review/changelog.d/4476-migrated-fixed.md
D	crates/trusty-review/changelog.d/4733-git-failopen-corpus.md
D	crates/trusty-review/changelog.d/4868-canonical-launchd-label.md
D	crates/trusty-review/changelog.d/4868-uninstall-evicts-legacy.md

trusty-review:        fragments at base=5  at merge-ref=0
trusty-git-analytics: fragments at base=4  at merge-ref=0
```

This repo has fixed this exact failure twice before, for two sibling gates:
#4688 (`check-pr-version-bump.sh`, PR #4666 blamed for `trusty-common 0.27.0`)
and #4960 (`detect-docs-only.sh`, a 4-file docs PR classified as 23 paths).
The changelog-fragment gate was the last one still pinned to `base.sha`.

## What changes

`.github/workflows/changelog-fragment.yml` re-fetches the base branch right
before diffing and passes it, matching `version-parity.yml` and `ci.yml`:

```diff
-          CHANGELOG_GATE_BASE: ${{ github.event.pull_request.base.sha }}
+          CHANGELOG_GATE_BASE: origin/${{ github.event.pull_request.base.ref }}
```

Against the live branch tip the merge base is the merge ref's own first parent,
so the diff is exactly what the PR contributes. It also self-corrects as main
moves, which a pinned SHA cannot.

`scripts/check_changelog_fragment.sh` additionally refuses a bare-SHA base that
lags HEAD's base parent, so a future workflow edit reintroducing `base.sha`
fails loudly naming the base instead of silently blaming untouched crates.

Comparing `(BASE, HEAD)` alone cannot distinguish a stale base from a correct
one — both are ancestors of HEAD — so the guard does not guess which commits
are the PR's. It rejects the one shape where the mis-attribution is provable,
scoped by four conditions that each rule out a legitimate caller: the base is a
bare SHA (a ref is always allowed), HEAD has a second parent (only the merge-ref
checkout does), the base is an ancestor of `HEAD^1`, and the base differs from
`HEAD^1` (passing the merge parent by SHA is exact, not stale).

### Why it still catches the real defect

The gate's evidence logic is untouched. Only the set of crates it examines
changes, and it changes to *this PR's* crates. `missing-fragment-fails` and
`exact-base-parent-allowed` below both pin a crate whose `src/**` changed with
no fragment still failing. Docs-only, CI-only, test-only and `testdata/`
exemptions are unchanged. A consumed fragment can no longer read as a missing
one because a release on main is no longer inside the diff at all.

## Regression test

`scripts/check_changelog_base_selftest.sh` builds the shape on a synthetic
repo: crate A touched by the branch and recorded; crate B's `src/**` changed on
main since the fork point with B's fragments consumed by a release; a
GitHub-shaped merge ref checked out. It runs in CI ahead of the gate, alongside
the existing scan-floor and fragment-validation selftests.

**Red, against the pre-fix script** (`git show origin/main:scripts/check_changelog_fragment.sh`):

```
FAIL: stale-base-refused -> exit 1 as expected, but output does not match /STALE BASE/
       OK   crate-a: changelog.d fragment present and valid
       FAIL crate-b: crates/crate-b/src/** changed with no changelog record
PASS: live-base-passes -> exit 0, matched /OK   crate-a: changelog.d fragment present and valid/
PASS: missing-fragment-fails -> exit 1, matched /FAIL crate-a: crates/crate-a/src/\*\* changed with no changelog record/
PASS: exact-base-parent-allowed -> exit 1, matched /FAIL crate-a: crates/crate-a/src/\*\* changed with no changelog record/
PASS: plain-head-sha-allowed -> exit 0, matched /OK   crate-a: changelog.d fragment present and valid/
check_changelog_base_selftest: FAILED — the gate mis-attributes changes.
EXIT=1
```

`FAIL crate-b` is the #5018 defect in miniature — a crate the branch never
touched. The other four cases pass before and after; they exist to prove the
fix does not weaken the gate.

**Green, against this branch:**

```
PASS: stale-base-refused -> exit 1, matched /STALE BASE/
PASS: live-base-passes -> exit 0, matched /OK   crate-a: changelog.d fragment present and valid/
PASS: missing-fragment-fails -> exit 1, matched /FAIL crate-a: crates/crate-a/src/\*\* changed with no changelog record/
PASS: exact-base-parent-allowed -> exit 1, matched /FAIL crate-a: crates/crate-a/src/\*\* changed with no changelog record/
PASS: plain-head-sha-allowed -> exit 0, matched /OK   crate-a: changelog.d fragment present and valid/
check_changelog_base_selftest: all base-attribution cases passed.
EXIT=0
```

## Live re-run against real PRs

Fixed script, each PR's merge ref checked out, both bases:

```
===== PR #5018 : pinned base.sha=8ab2c147  vs  live origin/main=a5a87763 =====
----- base = PINNED base.sha (old workflow) -----
FAIL: STALE BASE — '8ab2c147af49bcecbea06a4c395a3f88e4c233cb' is a bare commit SHA 173 commit(s) behind
      HEAD's base parent aeaf0130e7, and HEAD is a merge ref.
EXIT=1

----- base = origin/main (new workflow) -----
OK   trusty-installer: changelog.d fragment present and valid
changelog-fragment gate: scanned 9 changed path(s); all 1 crate(s) with source changes are recorded.
EXIT=0

===== PR #5334 : pinned base.sha=fad89dc5  vs  live origin/main=a5a87763 =====
----- base = PINNED base.sha (old workflow) -----
FAIL: STALE BASE — 'fad89dc586f9d1a4ef592c36791048ffefdaaa11' is a bare commit SHA 51 commit(s) behind
      HEAD's base parent aeaf0130e7, and HEAD is a merge ref.
EXIT=1

----- base = origin/main (new workflow) -----
OK   trusty-common: changelog.d fragment present and valid
changelog-fragment gate: scanned 5 changed path(s); all 1 crate(s) with source changes are recorded.
EXIT=0
```

#5018 goes from 3 false failures to green. #5334 was 51 commits behind and had
the same exposure.

## Gates

Rung 1 (CI/scripts only — `git diff --name-only origin/main...HEAD` lists
`.github/workflows/changelog-fragment.yml`,
`scripts/check_changelog_base_selftest.sh`,
`scripts/check_changelog_fragment.sh`; no `crates/*/src/**`, so no changelog
fragment and no Cargo gates).

```
bash scripts/check_changelog_base_selftest.sh                                    EXIT=0  (5 cases)
bash scripts/check_scan_floor_selftest.sh changelog_fragment \
     changelog_fragment_tool_error                                               EXIT=0  (2 gates)
bash scripts/assemble_changelog_selftest.sh                                      EXIT=0  (21 cases)
bash scripts/check_changelog_fragment.sh                                         EXIT=0
     -> scanned 3 changed path(s); no crate source changed (CI-only) — OK.
bash scripts/check_sld.sh                                                        EXIT=0
     -> scanned 57 spec doc(s) + 3211 code file(s); 0 error(s), 0 warning(s)
bash scripts/check_line_cap.sh                                                   EXIT=0
     -> measured 3903 tracked .rs file(s); 4 allowlisted, 0 violations — OK.
shellcheck -S warning (both changed scripts)                                     EXIT=0
```

The scan-floor and fragment-validation selftests are re-run because the new
guard sits ahead of both in the gate's control flow.

## No issue filed

Owner rule #1: "file and fix" collapses to "fix, and make the PR
self-describing." This PR is the record.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
