### PR TITLE
docs(website): port the tga audit page onto the trusty-git-analytics flagship

### DIFF
--- a/website/src/app.css
+++ b/website/src/app.css
@@ -236,6 +236,38 @@
 		@apply inline-block rounded-sm border border-foundry-border-strong px-2 py-0.5 font-mono text-[11px] uppercase tracking-wider text-foundry-secondary;
 	}
 
+	/* Severity modifiers for the tga audit page's RED/AMBER/GREEN stamps. The
+	   badge is 11px text, so its foreground owes the 4.5:1 AA minimum for
+	   normal text, not the 3:1 non-text one.
+
+	   Red and green carry the semantic token in the TEXT because both clear
+	   that in both themes on both grounds the badge sits on (danger 4.85 light
+	   / 5.36 dark on content-bg, 5.46 / 4.97 on card-bg; success 5.22 / 8.29
+	   and 5.87 / 7.69).
+
+	   Amber does not, and that is why it is written differently rather than
+	   consistently: `--color-warning` on the page ground is 3.18:1 in light
+	   mode — one of the three pairs `prose-contrast.test.ts` pins as
+	   KNOWN_FAILING. So amber keeps text-primary (14.39:1 / 14.45:1) and
+	   carries its colour on the border only, where 3.18:1 clears WCAG 1.4.11's
+	   3:1 non-text minimum. These three rules sit ABOVE the documentation-prose
+	   block on purpose: that test slices app.css from that block's opening
+	   comment onward and asserts the warning token appears nowhere in the
+	   slice. Do not repeat that comment's text here — the slice is found by
+	   indexOf, so quoting it verbatim moves the slice's start onto this
+	   comment and drags these rules into it. */
+	.badge-red {
+		@apply border-foundry-danger text-foundry-danger;
+	}
+
+	.badge-amber {
+		@apply border-foundry-warning text-foundry-text;
+	}
+
+	.badge-green {
+		@apply border-foundry-success text-foundry-success;
+	}
+
 	/* Foundry's mono uppercase section label. Uses text-secondary, not
 	   text-muted: at this size the light-mode muted token is 3.87:1 and fails
 	   AA (see tokens.test.ts / README). */

--- a/website/src/app.css
+++ b/website/src/app.css
@@ -255,7 +255,12 @@
 	   comment onward and asserts the warning token appears nowhere in the
 	   slice. Do not repeat that comment's text here — the slice is found by
 	   indexOf, so quoting it verbatim moves the slice's start onto this
-	   comment and drags these rules into it. */
+	   comment and drags these rules into it.
+
+	   Test: `tokens.test.ts`, "the tga audit severity badges" — it recomputes
+	   every ratio above from the canonical tokens and asserts the threshold
+	   each rule depends on, so a token edit fails there rather than quietly
+	   falsifying this comment. */
 	.badge-red {
 		@apply border-foundry-danger text-foundry-danger;
 	}

--- a/website/src/lib/theme/tokens.test.ts
+++ b/website/src/lib/theme/tokens.test.ts
@@ -187,4 +187,48 @@ describe('contrast facts the layout depends on', () => {
 		// body text.
 		expect(ratio(light('accent'), light('surface-raised'))).toBeLessThan(4.5);
 	});
+
+	/**
+	 * Why: `.badge-red` / `.badge-amber` / `.badge-green` in `app.css` are
+	 * written asymmetrically — red and green colour the LABEL, amber colours
+	 * only its BORDER — and the reason is a contrast measurement that lived
+	 * solely in a comment. A later edit to `--trusty-danger`, `--trusty-success`
+	 * or `--trusty-warning` in the canonical tokens would silently falsify it
+	 * (code-critic on #5415). These derive the ratios from the tokens and
+	 * assert the threshold each rule actually depends on.
+	 */
+	describe('the tga audit severity badges', () => {
+		// The stamps sit in a table on the page ground and, for the plain
+		// `.badge`, on a card — so both grounds are asserted.
+		const grounds = ['content-bg', 'card-bg'];
+
+		it('red and green badge labels clear AA as normal text', () => {
+			// 11px text, so 4.5:1 — not the 3:1 non-text minimum.
+			for (const token of ['danger', 'success']) {
+				for (const ground of grounds) {
+					expect(ratio(light(token), light(ground))).toBeGreaterThanOrEqual(4.5);
+					expect(ratio(dark(token), dark(ground))).toBeGreaterThanOrEqual(4.5);
+				}
+			}
+		});
+
+		it('the amber badge border clears the 3:1 non-text minimum', () => {
+			// `.badge-amber` puts warning on the border only, so WCAG 1.4.11
+			// governs it rather than the 4.5:1 text rule.
+			expect(ratio(light('warning'), light('content-bg'))).toBeGreaterThanOrEqual(3);
+			expect(ratio(dark('warning'), dark('content-bg'))).toBeGreaterThanOrEqual(3);
+		});
+
+		it('light warning still fails AA, which is why amber colours no label', () => {
+			// If this ever starts passing, `.badge-amber` can carry its colour
+			// in the text like the other two and the asymmetry can be dropped.
+			expect(ratio(light('warning'), light('content-bg'))).toBeLessThan(4.5);
+			expect(ratio(dark('warning'), dark('content-bg'))).toBeGreaterThanOrEqual(4.5);
+		});
+
+		it('the amber badge label uses text-primary, which clears AA', () => {
+			expect(ratio(light('text-primary'), light('content-bg'))).toBeGreaterThanOrEqual(4.5);
+			expect(ratio(dark('text-primary'), dark('content-bg'))).toBeGreaterThanOrEqual(4.5);
+		});
+	});
 });

--- a/website/src/routes/tools/trusty-git-analytics/+page.svelte
+++ b/website/src/routes/tools/trusty-git-analytics/+page.svelte
@@ -10,6 +10,15 @@
 		{ label: 'Store', value: 'SQLite, on disk' },
 		{ label: 'Output', value: 'CSV, JSON, Markdown' }
 	];
+
+	/** The `tga audit` sweep's own facts strip, rendered inside the body. */
+	const auditFacts = [
+		{ label: 'Binary', value: 'tga' },
+		{ label: 'Stages', value: '8' },
+		{ label: 'Flags', value: '6, all optional' },
+		{ label: 'Output', value: 'up to 18 files' },
+		{ label: 'Prompts', value: 'none' }
+	];
 </script>
 
 <ToolPage {tool} {facts}>
@@ -117,5 +126,582 @@
 			has a default. Note the package and binary are both <code class="text-sm">tga</code>, not the
 			crate directory's longer name.
 		</p>
+	</div>
+
+	<!-- ============ tga audit ============ -->
+	<div>
+		<p class="eyebrow">Acquisition due diligence</p>
+		<h2 id="audit" class="mt-3 scroll-mt-24 font-display text-2xl font-bold sm:text-3xl">
+			<code>tga audit</code>
+		</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			One command walks the git history of the repositories your config already names, and renders a
+			technical due-diligence report for someone deciding whether to buy the codebase. The report
+			has eight sections, and the parts it cannot fill are named as gaps rather than scored.
+		</p>
+		<dl class="mt-8 flex flex-wrap gap-x-10 gap-y-4">
+			{#each auditFacts as fact (fact.label)}
+				<div>
+					<dt class="eyebrow">{fact.label}</dt>
+					<dd class="mt-1 font-mono text-sm text-foundry-text">{fact.value}</dd>
+				</div>
+			{/each}
+		</dl>
+	</div>
+
+	<!-- ============ thesis ============ -->
+	<div class="min-w-0">
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">The gaps are printed, not filled in</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			A due-diligence report is read by someone deciding whether to buy the thing it describes. The
+			failure that matters there is not a missing number. It is a number nobody measured, printed as
+			though somebody had.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			<code class="text-sm">tga audit</code> has no PERFORMANCE dimension and no COST dimension — nothing
+			in the pipeline measures either one. So the report declares both as gaps rather than scoring them
+			off a proxy.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Failure works the same way. Point the sweep at a config with no JIRA project key and the
+			<code class="text-sm">jira sync</code> stage fails. That failure becomes a named line in
+			<strong class="font-semibold text-foundry-text">Gaps &amp; Caveats</strong>. The alternative —
+			a zero in a cell — is indistinguishable from a project that genuinely had no JIRA activity,
+			and the reader has no way to tell which one they are looking at.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Every report-quality bug fixed in the last milestone was that same shape: a partial signal
+			rendered as an authoritative statement.
+		</p>
+
+		<div class="card mt-8 max-w-3xl min-w-0">
+			<p class="eyebrow">The failure you will actually hit</p>
+			<pre
+				class="mt-3 overflow-x-auto rounded-sm border border-foundry-border bg-foundry-raised p-3 text-xs leading-relaxed text-foundry-text">no JIRA project scope: pass --project &lt;KEY&gt; or set jira.project_key in config.yaml</pre>
+			<p class="mt-3 text-sm text-foundry-secondary">
+				This is the stage that most often fails on an unattended run. It does not stop the sweep,
+				and it does not become a zero.
+			</p>
+		</div>
+	</div>
+
+	<!-- ============ running it ============ -->
+	<div class="min-w-0">
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Running it</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Six flags, all optional, nothing interactive. Configure your repository set first;
+			<code class="text-sm">tga audit</code> reads it and goes.
+		</p>
+
+		<div class="mt-6 max-w-xl min-w-0">
+			<p class="eyebrow">shell — named engagement</p>
+			<pre
+				class="mt-2 overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-3 text-xs leading-relaxed text-foundry-text">tga --config config.yaml audit \
+  --org acme --client "Acme Holdings" --analyst "J. Reviewer" \
+  --weeks 26 --output ./acme-dd</pre>
+		</div>
+
+		<div class="mt-6 max-w-xl min-w-0">
+			<p class="eyebrow">shell — defaults</p>
+			<pre
+				class="mt-2 overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-3 text-xs leading-relaxed text-foundry-text">tga audit</pre>
+		</div>
+
+		<p class="mt-6 max-w-3xl text-sm text-foundry-secondary">
+			Bare, it reads <code class="text-sm">./config.yaml</code> and writes
+			<code class="text-sm">./audit-output</code>.
+			<code class="text-sm">-c, --config &lt;FILE&gt;</code>
+			is global on <code class="text-sm">tga</code>; a missing config logs a warning and runs on
+			defaults rather than failing.
+		</p>
+
+		<div class="doc-prose doc-table max-w-3xl">
+			<table>
+				<caption class="eyebrow px-3 py-2 text-left">Flags</caption>
+				<thead>
+					<tr>
+						<th scope="col">Flag</th>
+						<th scope="col">Effect</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code class="whitespace-nowrap">--org &lt;ORG&gt;</code></td>
+						<td class="text-foundry-secondary"
+							>The organisation under audit. Metadata only — it titles the report and nothing else.</td
+						>
+					</tr>
+					<tr>
+						<td><code class="whitespace-nowrap">--title &lt;TITLE&gt;</code></td>
+						<td class="text-foundry-secondary"
+							>Defaults to <code>&lt;org&gt; — Technical Due Diligence</code>, or
+							<code>Technical Due Diligence</code> with no <code>--org</code>.</td
+						>
+					</tr>
+					<tr>
+						<td><code class="whitespace-nowrap">--analyst &lt;NAME&gt;</code></td>
+						<td class="text-foundry-secondary">Renders as <em>not stated</em> if omitted.</td>
+					</tr>
+					<tr>
+						<td><code class="whitespace-nowrap">--client &lt;NAME&gt;</code></td>
+						<td class="text-foundry-secondary">Same — absent is recorded as absent.</td>
+					</tr>
+					<tr>
+						<td><code class="whitespace-nowrap">-o, --output &lt;DIR&gt;</code></td>
+						<td class="text-foundry-secondary"
+							>Where the audit writes. Defaults to <code>./audit-output</code>.</td
+						>
+					</tr>
+					<tr>
+						<td><code class="whitespace-nowrap">--weeks &lt;N&gt;</code></td>
+						<td class="text-foundry-secondary">Limit collection to the last N ISO weeks.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+		<div class="card max-w-3xl">
+			<p class="eyebrow">What <code class="text-sm">--org</code> is not</p>
+			<p class="mt-3 text-foundry-secondary">
+				It does not discover repositories. The sweep audits whatever local checkouts the resolved
+				config already names, and <code class="text-sm">--org</code> only reaches the report's title block.
+			</p>
+		</div>
+	</div>
+
+	<!-- ============ stages ============ -->
+	<div class="min-w-0">
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">
+			Eight stages, in the order the data flows
+		</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			The numbering is real: each stage writes what the next one reads, which is why they run in
+			this order and not another. A stage that fails is recorded and named in
+			<strong class="font-semibold text-foundry-text">Gaps &amp; Caveats</strong>, and the run
+			continues.
+		</p>
+		<!-- Numbered rather than the page's usual bullet dot: the copy above
+		     states the ordering is load-bearing, so the reader needs the index. -->
+		<ol class="mt-6 max-w-3xl list-none space-y-3 text-foundry-secondary">
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">1</span
+				>
+				<span
+					><code class="text-sm">collect</code> — walks the configured repositories into
+					<code class="text-sm">commits</code> via git2.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">2</span
+				>
+				<span
+					><code class="text-sm">classify</code> — runs the four-tier classification cascade over those
+					commits.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">3</span
+				>
+				<span><code class="text-sm">jira sync</code> — ingests JIRA transitions and comments.</span>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">4</span
+				>
+				<span
+					><code class="text-sm">deployments collect</code> — deploy events into
+					<code class="text-sm">fact_deployments</code>.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">5</span
+				>
+				<span
+					><code class="text-sm">incidents collect</code> — incidents into
+					<code class="text-sm">fact_incidents</code>.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">6</span
+				>
+				<span
+					><code class="text-sm">dora</code> — reduces those two fact tables to the four DORA keys.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">7</span
+				>
+				<span
+					><code class="text-sm">pr-metrics</code> — per-engineer pull-request metrics; writes
+					<code class="text-sm">pr-metrics.csv</code>.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="w-5 shrink-0 font-mono text-sm text-foundry-primary">8</span
+				>
+				<span><code class="text-sm">report</code> — renders tga's own CSV, JSON and Markdown.</span>
+			</li>
+		</ol>
+
+		<div class="card mt-8 max-w-3xl">
+			<p class="eyebrow">No stage aborts the run</p>
+			<p class="mt-3 text-foundry-secondary">
+				Every stage's result is recorded, never propagated. A stage that fails is marked failed, the
+				sweep moves to the next one, and the failure surfaces as a named gap in the report instead
+				of a halt. One thing stops a sweep: a pre-flight failure creating the output directory.
+			</p>
+			<p class="mt-3 text-sm text-foundry-secondary">
+				That is what makes an unattended run worth starting. A pipeline that stops on the first
+				unreachable source produces nothing; this one produces a report whose missing pieces are
+				labelled.
+			</p>
+		</div>
+	</div>
+
+	<!-- ============ output directory ============ -->
+	<div class="min-w-0">
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">What lands in the output directory</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">Up to 18 files, from three producers.</p>
+
+		<div class="doc-prose doc-table max-w-3xl">
+			<table>
+				<thead>
+					<tr>
+						<th scope="col">From</th>
+						<th scope="col" class="text-right">Files</th>
+						<th scope="col">What</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code class="whitespace-nowrap">report</code> stage</td>
+						<td class="text-right font-mono tabular-nums">14</td>
+						<td class="text-foundry-secondary">9 CSV, 4 JSON, 1 Markdown.</td>
+					</tr>
+					<tr>
+						<td><code class="whitespace-nowrap">pr-metrics</code> stage</td>
+						<td class="text-right font-mono tabular-nums">1</td>
+						<td class="text-foundry-secondary"><code>pr-metrics.csv</code>.</td>
+					</tr>
+					<tr>
+						<td>the seam</td>
+						<td class="text-right font-mono tabular-nums">1</td>
+						<td class="text-foundry-secondary"
+							><code>manifest.toml</code> — what tga hands to trusty-review.</td
+						>
+					</tr>
+					<tr>
+						<td>trusty-review</td>
+						<td class="text-right font-mono tabular-nums">2</td>
+						<td class="text-foundry-secondary"
+							><code>&#123;slug&#125;.md</code> and <code>&#123;slug&#125;.json</code> — the due-diligence
+							report itself.</td
+						>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+
+	<!-- ============ report sections ============ -->
+	<div class="min-w-0">
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">The report, section by section</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Eight sections, in this order. Section 2 renders deterministically —
+			<code class="text-sm">tga audit</code> never passes <code class="text-sm">--synthesize</code>,
+			so no model writes the executive summary.
+		</p>
+
+		<div class="doc-prose doc-table max-w-3xl">
+			<table>
+				<thead>
+					<tr>
+						<th scope="col" class="w-10 text-right">§</th>
+						<th scope="col">Section</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td class="text-right font-mono tabular-nums">1</td>
+						<td>Report Metadata</td>
+					</tr>
+					<tr>
+						<td class="text-right font-mono tabular-nums">2</td>
+						<td>Executive Summary, with Top Risks</td>
+					</tr>
+					<tr>
+						<td class="text-right font-mono tabular-nums">3</td>
+						<td>Scoring Model Normalization</td>
+					</tr>
+					<tr>
+						<td class="text-right font-mono tabular-nums">4</td>
+						<td>Per-Application Scorecard</td>
+					</tr>
+					<tr>
+						<td class="text-right font-mono tabular-nums">5</td>
+						<td>
+							Findings by Severity
+							<ul class="mt-2 text-sm text-foundry-secondary">
+								<li>5.1 RED / CRITICAL — full detail</li>
+								<li>5.2 AMBER / MEDIUM — compact</li>
+								<li>5.3 GREEN / POSITIVE — topic list only</li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-right font-mono tabular-nums">6</td>
+						<td>
+							Risk Registers
+							<ul class="mt-2 text-sm text-foundry-secondary">
+								<li>6.1 Security Violations</li>
+								<li>6.2 Open-Source / CVE Exposure</li>
+								<li>6.3 License / IP Risk</li>
+								<li>6.4 Obsolescence</li>
+								<li>6.5 Cloud Readiness Blockers</li>
+								<li>6.6 Technical-Debt / Remediation Economics</li>
+							</ul>
+						</td>
+					</tr>
+					<tr>
+						<td class="text-right font-mono tabular-nums">7</td>
+						<td>Graph-Ready Data Appendix</td>
+					</tr>
+					<tr>
+						<td class="text-right font-mono tabular-nums">8</td>
+						<td>Gaps &amp; Caveats</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+		<div class="mt-6 grid gap-4 sm:grid-cols-3">
+			<div class="card">
+				<span class="badge">From tga</span>
+				<p class="mt-3 text-sm text-foundry-secondary">
+					§1 in full, and §4's tech stack, lines of code, and frameworks.
+				</p>
+			</div>
+			<div class="card">
+				<span class="badge">From trusty-analyze</span>
+				<p class="mt-3 text-sm text-foundry-secondary">
+					§5, §6.1, and §7's <code class="text-xs">complexity_distribution</code> and
+					<code class="text-xs">loc_by_technology</code>.
+				</p>
+			</div>
+			<div class="card">
+				<span class="badge">Declared gap</span>
+				<p class="mt-3 text-sm text-foundry-secondary">
+					§4 Benchmark Position, §6.2, §6.3, §6.4, §6.5, §6.6 — no data source behind any of them,
+					and the report says so rather than scoring them.
+				</p>
+			</div>
+		</div>
+	</div>
+
+	<!-- ============ severity ============ -->
+	<div class="min-w-0">
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">
+			Red, amber, green — and what routes a finding there
+		</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			The colours are the report's own convention, and the mapping is mechanical: the diagnostic's
+			own severity decides, nothing else.
+		</p>
+
+		<div class="doc-prose doc-table max-w-3xl">
+			<table>
+				<thead>
+					<tr>
+						<th scope="col">Band</th>
+						<th scope="col">Diagnostic severity</th>
+						<th scope="col">How it renders</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><span class="badge badge-red">Red</span></td>
+						<td><code>error</code> · <code>critical</code></td>
+						<td class="text-foundry-secondary">§5.1, full detail.</td>
+					</tr>
+					<tr>
+						<td><span class="badge badge-amber">Amber</span></td>
+						<td><code>warning</code> · <code>high</code></td>
+						<td class="text-foundry-secondary">§5.2, compact.</td>
+					</tr>
+					<tr>
+						<td><span class="badge badge-green">Green</span></td>
+						<td class="text-foundry-secondary">everything else</td>
+						<td class="text-foundry-secondary">§5.3, topic list only.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+		<div class="card max-w-3xl">
+			<p class="eyebrow">The ceiling that matters</p>
+			<p class="mt-3 text-foundry-secondary">
+				A refactor suggestion caps at Amber. It can never come out Red, no matter what the
+				underlying tool called it — because "extract this method" is advice, and a buyer reading a
+				RED line is entitled to assume something is broken.
+			</p>
+		</div>
+	</div>
+
+	<!-- ============ before / after ============ -->
+	<div class="min-w-0">
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">What the last fix actually changed</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Measured on one run, over the ripgrep repository, before and after the report stage was
+			corrected.
+		</p>
+
+		<div class="doc-prose doc-table max-w-3xl">
+			<table>
+				<thead>
+					<tr>
+						<th scope="col">Measure</th>
+						<th scope="col" class="text-right">Before</th>
+						<th scope="col" class="text-right">After</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>RED findings</td>
+						<td class="text-right font-mono tabular-nums">20</td>
+						<td class="text-right font-mono tabular-nums">0</td>
+					</tr>
+					<tr>
+						<td>AMBER findings, each carrying real numbers</td>
+						<td class="text-right font-mono tabular-nums">0</td>
+						<td class="text-right font-mono tabular-nums">20</td>
+					</tr>
+					<tr>
+						<td>Non-code components scored</td>
+						<td class="text-right font-mono tabular-nums">2</td>
+						<td class="text-right font-mono tabular-nums">0</td>
+					</tr>
+					<tr>
+						<td>Complexity buckets sum to</td>
+						<td class="text-right font-mono tabular-nums">1,000</td>
+						<td class="text-right font-mono tabular-nums">4,328</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+		<p class="mt-6 max-w-3xl text-foundry-secondary">
+			The 20 pre-fix RED entries were all "Extract method" refactor suggestions misrouted into RED.
+			The two non-code components were <code class="text-sm">CHANGELOG.md</code> and
+			<code class="text-sm">FAQ.md</code>, scored as if they were applications. The complexity
+			buckets summed to a round 1,000 instead of the 4,328 units actually counted.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			All three are the same defect wearing different clothes: output that looked like a measurement
+			and was not one.
+		</p>
+
+		<div class="card mt-8 max-w-3xl">
+			<p class="eyebrow">Scope of that evidence</p>
+			<p class="mt-3 text-foundry-secondary">
+				These numbers are the ripgrep run only. The trusty-tools audit was not re-run after the fix,
+				so nothing here says the same before-and-after holds on a second codebase.
+			</p>
+		</div>
+	</div>
+
+	<!-- ============ limitations ============ -->
+	<div class="min-w-0">
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">What this does not do</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			The buyer's alternative is a tool that would have guessed at all six of these. Read this
+			section as part of the pitch, not as a disclaimer at the bottom.
+		</p>
+
+		<div class="mt-6 grid gap-4 sm:grid-cols-2">
+			<div class="card">
+				<h3 class="font-display text-lg font-semibold text-foundry-text">
+					It does not find or clone repositories
+				</h3>
+				<p class="mt-3 text-sm text-foundry-secondary">
+					Every entry in the sweep is a local checkout that the resolved config already names.
+					Discovery is open work (#5215); until it lands, naming a GitHub organisation or a
+					Bitbucket workspace in <code class="text-xs">--org</code> gets you a report title, not a repository
+					list.
+				</p>
+			</div>
+
+			<div class="card">
+				<h3 class="font-display text-lg font-semibold text-foundry-text">
+					There is no engineering-velocity section
+				</h3>
+				<p class="mt-3 text-sm text-foundry-secondary">
+					DOC-67 §8 specifies one; it is not implemented (#5241, #5242). DORA is computed at stage 6
+					and never reaches the report. If you need deployment frequency or change failure rate in
+					the deliverable, this does not produce it today.
+				</p>
+			</div>
+
+			<div class="card">
+				<h3 class="font-display text-lg font-semibold text-foundry-text">
+					§6.1 is linter output, not a security scan
+				</h3>
+				<p class="mt-3 text-sm text-foundry-secondary">
+					It carries general-purpose linter findings — clippy, ruff, biome, rubocop, PMD. A linter
+					flagging an <code class="text-xs">unwrap()</code> is a different claim from a scanner flagging
+					SQL injection or a hardcoded credential, and this section is only ever making the first one.
+				</p>
+			</div>
+
+			<div class="card">
+				<h3 class="font-display text-lg font-semibold text-foundry-text">
+					Six registers have no data source
+				</h3>
+				<p class="mt-3 text-sm text-foundry-secondary">
+					§4 Benchmark Position, and §6.2 through §6.6 — CVE exposure, license and IP risk,
+					obsolescence, cloud readiness, remediation economics. Each is declared a gap. None is
+					estimated.
+				</p>
+			</div>
+
+			<div class="card">
+				<h3 class="font-display text-lg font-semibold text-foundry-text">
+					<code class="text-base">agentic_pct</code> counts markers, not AI
+				</h3>
+				<p class="mt-3 text-sm text-foundry-secondary">
+					The undercount that made this figure unquotable is fixed (#5249, #5403): measured against
+					tga's own history the catch rate went from 47.70% to 91.04%. What the number
+					<em>means</em> did not change. Detection is marker-based only — the run's own disclosure line
+					says so — so commits whose trailers or footers were stripped, squashed, or rewritten are indistinguishable
+					from human commits, and a low share means "no markers emitted", not "no AI assistance". Twelve
+					markers cover seven tool labels, and five of those (Devin, OpenHands, Aider, Copilot, Cursor)
+					are exercised only by synthetic tests, because this repository's history contains none of their
+					markers. Read it as a floor on marker-emitting work, not as a provenance figure.
+				</p>
+			</div>
+
+			<div class="card">
+				<h3 class="font-display text-lg font-semibold text-foundry-text">
+					No PERFORMANCE or COST dimension exists
+				</h3>
+				<p class="mt-3 text-sm text-foundry-secondary">
+					Nothing in the pipeline measures runtime behaviour or spend, so neither is scored. Both
+					appear in Gaps &amp; Caveats, which is the whole design: the report would rather be
+					visibly incomplete than quietly wrong.
+				</p>
+			</div>
+		</div>
+	</div>
+
+	<!-- ============ close ============ -->
+	<div class="min-w-0">
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Start here</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Configure your repository set, then run the sweep. Nothing in it will prompt you, and nothing
+			in it will stop halfway.
+		</p>
+		<div class="mt-6 max-w-xl min-w-0">
+			<p class="eyebrow">shell</p>
+			<pre
+				class="mt-2 overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-3 text-xs leading-relaxed text-foundry-text">tga audit --org acme --output ./acme-dd</pre>
+		</div>
 	</div>
 </ToolPage>

--- a/website/tests/mobile-overflow.test.ts
+++ b/website/tests/mobile-overflow.test.ts
@@ -87,12 +87,16 @@ const STATIC = path.join(OUTPUT, 'static');
 /** Sub-pixel layout rounding, not a real overflow — see the file doc above. */
 const MAIN_TOLERANCE_PX = 1;
 
+// `/tools/trusty-git-analytics` carries the `tga audit` port: five tables and
+// three shell blocks, the two shapes that actually scroll a page sideways.
+// `/tools/trusty-search` is the plain-prose flagship and stays as the control.
 const ROUTES = [
 	'/whats-new',
 	'/',
 	'/docs',
 	'/docs/getting-started/install',
-	'/tools/trusty-search'
+	'/tools/trusty-search',
+	'/tools/trusty-git-analytics'
 ];
 const WIDTHS = [375, 320];
 


### PR DESCRIPTION
Ports the standalone `tga audit` page onto the existing public flagship page at `/tools/trusty-git-analytics`. The page's original four sections are untouched; the audit material is appended, because it describes `tga audit` specifically rather than tga generally.

No new route, no new slug, no seventh `TOOLS` entry.

## What was ported, section by section

Every section of the source, including all of its examples.

| Source section | Landed as |
|---|---|
| Hero — 5-item facts strip | An `Acquisition due diligence` eyebrow, the lede, and the same 5 facts (Binary / Stages / Flags / Output / Prompts) as a `<dl>`, rendered in the body. The page-level hero strip belongs to tga as a whole and is unchanged. |
| The gaps are printed, not filled in | All 4 paragraphs, plus the callout carrying the real `no JIRA project scope: …` CLI error string. |
| Running it | Both shell blocks (named engagement, defaults), the defaults note, the full 6-row flags table (`--org`, `--title`, `--analyst`, `--client`, `-o/--output`, `--weeks`), and the "what `--org` is not" callout. |
| Eight stages | All 8 stages with their one-line descriptions, plus the fail-open-but-recorded callout. Numbered rather than bulleted — the copy states the ordering is real, so the reader needs the index. |
| What lands in the output directory | The 4-row producers table. |
| The report, section by section | The 8-row table including the §5 and §6 sub-lists, plus the 3-card provenance grid. |
| Red, amber, green | The 3-row severity table with coloured stamps, plus the refactor-caps-at-Amber callout. |
| What the last fix actually changed | The 4-row ripgrep before/after table, both explanatory paragraphs, and the scope-limitation callout. |
| What this does not do | All 6 limitation cards. |
| Start here | The closing shell block. |

## The one content correction

The source's §9 card said the [#5249](https://github.com/bobmatnyc/trusty-tools/issues/5249) `agentic_pct` fix "is in flight". That is stale — [#5403](https://github.com/bobmatnyc/trusty-tools/pull/5403) merged 2026-08-11 and raised the catch rate from 47.70% to 91.04%.

It is not flipped to "fixed", because fixed and quotable are different claims. Verified against `detection_disclosure()` at `crates/trusty-git-analytics/src/collect/ai_markers.rs:116-141` on `origin/main`, which still emits, on every `tga collect` run:

> detection is marker-based only — commits whose trailers or footers were stripped, squashed, or rewritten are indistinguishable from human commits, so a low agentic share means "no markers emitted", not "no AI assistance"

Also read off that file's `markers()` table: 12 markers across 7 distinct tool labels (`claude`, `trusty-mpm`, `devin`, `openhands`, `aider`, `copilot`, `cursor`). Five of those seven are proven only by synthetic tests — `git log --all -i --grep` over this repository's history returns 0 real commits for Aider and only doc/test mentions for Devin and OpenHands.

The card now says the undercount is fixed, that what the number *means* did not change, and that it should be read as a floor on marker-emitting work rather than as a provenance figure.

## Commands run, with raw output

Website tests do not run in CI ([#5200](https://github.com/bobmatnyc/trusty-tools/issues/5200)), so these were run by hand from inside `website/`.

`pnpm install` → `EXIT=0`. `pnpm run build` → `EXIT=0`:

```
.svelte-kit/output/server/entries/pages/tools/trusty-git-analytics/_page.svelte.js   25.60 kB
✓ built in 26.19s
> Using @sveltejs/adapter-vercel
  ✔ done
```

`pnpm test`:

```
 Test Files  2 failed | 12 passed (14)
      Tests  3 failed | 238 passed | 1 skipped (242)
```

`pnpm lint` → `EXIT=0`. `pnpm check` → `0 ERRORS 0 WARNINGS` over 487 files.

### The 3 failures are pre-existing, and this branch adds none

Measured by stashing the whole diff and re-running `pnpm test` on a clean tree at the same base commit. Baseline:

```
 FAIL  |smoke| tests/mobile-overflow.test.ts > … > / at 375px
AssertionError: / at 375px: <main> scrollWidth 433 > clientWidth 375 (tolerance 1px) — content overflows main and renders clipped: expected 433 to be less than or equal to 376
 FAIL  |smoke| tests/mobile-overflow.test.ts > … > keeps a long inline identifier on /whats-new intact, not broken mid-character
AssertionError: the given combination of arguments (null and string) is invalid for this assertion. …
 FAIL  |unit| src/lib/changelog/parse.test.ts > the link-reference trap > leaves every real trusty-search version heading as plain text, not an anchor
AssertionError: expected '[0.44.0] — 2026-08-10' to be '[0.42.3] — 2026-08-05' // Object.is equality
 Test Files  2 failed | 12 passed (14)
      Tests  3 failed | 236 passed | 1 skipped (240)
```

Same three, byte-identical assertions, before and after. The count moves 240 → 242: the two added tests are this page's own mobile measurements, both passing. None of the three touches `website/src/routes/tools/`; the homepage grid one is [#5255](https://github.com/bobmatnyc/trusty-tools/issues/5255), and the changelog one is a hardcoded version expectation that drifted when trusty-search released 0.44.0. Left alone rather than folded into a content port.

One failure WAS mine and is fixed in this branch: my `app.css` comment quoted the literal `Documentation prose (#5098)` marker string, and `prose-contrast.test.ts` locates its scan region with `indexOf` on exactly that string — so the slice started on my comment and swallowed the new rules. The comment no longer quotes it, and now says why not.

### `TOOLS.length` is untouched

`src/lib/tools.ts` is not in the diff. The assertion at `tools.test.ts:30` passes:

```
 ✓ |unit| src/lib/tools.test.ts > … > names a crate directory that exists 2ms
 ✓ |unit| src/lib/tools.test.ts > … > cargoPackage matches that crate's Cargo.toml name field 2ms
 ✓ |unit| src/lib/tools.test.ts > … > every install command targets a stable-set member 1ms
 ✓ |unit| src/lib/tools.test.ts > … > links only to doc pages the manifest actually publishes 1ms
 ✓ |unit| src/lib/tools.test.ts > … > has a route directory for every slug, and no duplicate slugs 0ms
 ✓ |unit| src/lib/tools.test.ts > … > never names a retired binary or a `cp` install 0ms
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

## Mobile verification

`/tools/trusty-git-analytics` is added to `tests/mobile-overflow.test.ts`'s route list — it now carries five tables and three shell blocks, the two shapes that actually scroll a page sideways, while `/tools/trusty-search` stays as the plain-prose control. Real Chromium, two assertions per route/width:

```
 ✓ … > /tools/trusty-git-analytics at 375px 578ms
 ✓ … > /tools/trusty-git-analytics at 320px 773ms
```

Separately measured and screenshotted at 375px in both themes and at 1280px:

```
mobile-light   doc=375/375  main=375/375
mobile-dark    doc=375/375  main=375/375
desktop-light  doc=1280/1280  main=1280/1280
```

Screenshots were read, not just captured: tables scroll inside their own `.doc-table` container, the long `tga --config … audit` line scrolls inside its `<pre>`, the §5/§6 sub-lists render inside their cells, and the three severity stamps stay legible and distinct in dark mode.

## New CSS

Three rules, `badge-red` / `badge-amber` / `badge-green`, following the existing `.btn-primary` / `.btn-secondary` pattern. Everything else reuses what `app.css` already has — `.card` for the callouts and both grids, `.badge`, `.eyebrow`, `.doc-table` + `.doc-prose` for tables, and `ToolPage.svelte`'s own `<pre>` pattern for code blocks.

Amber is written differently from the other two on purpose. The badge is 11px text, so it owes 4.5:1. Red and green clear that in both themes on both grounds they sit on (danger 4.85 light / 5.36 dark on the page ground; success 5.22 / 8.29), so they carry the semantic token in the text. `--color-warning` on the light ground is 3.18:1 — one of the three pairs `prose-contrast.test.ts` already pins as known-failing — so amber keeps `text-primary` at 14.39:1 and carries its colour on the border, where 3.18:1 clears the 3:1 non-text minimum.

## Notes

- No `crates/*/src/**` file is touched (`git diff --name-only origin/main -- 'crates/*/src/**'` → 0), so no changelog fragment is required.
- This diff touches `website/`, so merging it **will trigger a Vercel rebuild**.
- Test ladder: rung 6 (UI surface), satisfied by the UI package's own test and build plus the direct rendering evidence above.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
