### PR TITLE
ci: name the test jobs for what they run and when they gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,11 +140,16 @@ jobs:
   # every job below to consult.
   #
   # WHY THIS IS A JOB AND NOT A `paths:` FILTER. Five of this workflow's checks
-  # are REQUIRED by branch protection (Format check, Clippy, Test, MSRV check
-  # (1.94), trusty-search daemon smoke test). GitHub does not create check runs
-  # for a workflow its path/branch filters skipped, so a required context would
-  # sit pending forever and a docs-only PR would become unmergeable instead of
-  # fast — the trap #4468 calls out and the one
+  # are REQUIRED by branch protection: Format check, 500-line file-size cap,
+  # Clippy, trusty-search daemon smoke test, MSRV check. "Rust tests
+  # (pre-publish gate)" (the `test` aggregate below) is NOT currently
+  # required — see #5407. This list is a convenience snapshot, not the source
+  # of truth; the authoritative list is always
+  # `gh api repos/bobmatnyc/trusty-tools/branches/main/protection`, since a
+  # hardcoded list in a comment is exactly what went stale here. GitHub does
+  # not create check runs for a workflow its path/branch filters skipped, so a
+  # required context would sit pending forever and a docs-only PR would become
+  # unmergeable instead of fast — the trap #4468 calls out and the one
   # .github/workflows/changelog-fragment.yml already documents. So every job
   # still RUNS and still REPORTS; the exemption lives inside the jobs, on the
   # steps that cost money. A docs-only PR therefore gets a green required check
@@ -360,7 +365,9 @@ jobs:
   # --------------------------------------------------------------------------
   # test-shard: run all unit + integration tests (stable, no --include-ignored),
   # split four ways by nextest partition. The `test` job below aggregates these
-  # into the single required check named "Test".
+  # into a single roll-up row, "Rust tests (pre-publish gate)" — see that
+  # job's own comment for why, and that it is not currently a required
+  # branch-protection context.
   #
   # Why sharded: the unsharded job ran 16–24 minutes and was the critical path
   # of every CI run — ~45% of it executing tests one binary at a time.
@@ -416,7 +423,7 @@ jobs:
   # config files pulled by fastembed are also captured.
   # --------------------------------------------------------------------------
   test-shard:
-    name: Test shard ${{ matrix.shard }}
+    name: Rust tests (pre-publish gate) — shard ${{ matrix.shard }} of 4
     needs: [changes]
     # #4179: `needs:` alone would make this job SKIP when `changes` fails, and
     # GitHub reports a skipped required check as PASSING — reintroducing the
@@ -982,12 +989,14 @@ jobs:
   # --------------------------------------------------------------------------
   # test: the aggregate gate over the sharded suite above.
   #
-  # This job exists to keep ONE stable required-check name. Branch protection
-  # requires the literal context "Test"; sharding alone would rename the check
-  # to "Test (shard-N)" and silently drop the requirement, leaving main
-  # unprotected. Repointing branch protection at N shard names would work but
-  # would have to be re-edited every time the shard count changes — this job
-  # makes the shard count an implementation detail instead.
+  # This job exists to give the shard matrix ONE roll-up row instead of N,
+  # so the shard count stays an implementation detail — resharding never
+  # requires touching anything downstream of this job. It runs no cargo
+  # command itself; it only checks that every `test-shard` leg succeeded.
+  #
+  # It is NOT currently a required branch-protection context (see the
+  # `changes` job comment above for the live list) — it exists so a roll-up
+  # context is available to become required later without a workflow change.
   #
   # `needs.test-shard.result` is the AGGREGATE of the matrix: it is 'success'
   # only when every leg succeeded, and 'failure' / 'cancelled' / 'skipped'
@@ -997,7 +1006,7 @@ jobs:
   # closed for this job's `if:` condition.
   # --------------------------------------------------------------------------
   test:
-    name: Test
+    name: Rust tests (pre-publish gate)
     needs: [changes, test-shard]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
@@ -1010,7 +1019,7 @@ jobs:
           set -euo pipefail
           echo "test-shard matrix aggregate result: ${SHARDS_RESULT}"
           if [ "${SHARDS_RESULT}" != "success" ]; then
-            echo "::error::Test is red: the test-shard matrix reported '${SHARDS_RESULT}'. Open the individual 'Test shard N' jobs — nextest names the owning crate for every failing test."
+            echo "::error::Rust tests (pre-publish gate) is red: the test-shard matrix reported '${SHARDS_RESULT}'. Open the individual 'Rust tests (pre-publish gate) — shard N of 4' jobs — nextest names the owning crate for every failing test."
             exit 1
           fi
           echo "every test shard succeeded"
@@ -1028,7 +1037,7 @@ jobs:
   # guaranteed to compile on the declared minimum.
   # --------------------------------------------------------------------------
   msrv:
-    name: MSRV check (1.94)
+    name: MSRV check
     needs: [changes]
     # #4179: `needs:` alone would make this job SKIP when `changes` fails, and
     # GitHub reports a skipped required check as PASSING — reintroducing the

--- a/.github/workflows/test-pointers.yml
+++ b/.github/workflows/test-pointers.yml
@@ -46,7 +46,7 @@ concurrency:
 
 jobs:
   test-pointers:
-    name: "Test: doc-comment pointer lint"
+    name: "Doc-comment pointer lint (Why/What/Test)"
     if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     # #4882: was 5. Measured 2026-08-05: the lint itself legitimately took

--- a/docs/reference/test-ladder-baseline.md
+++ b/docs/reference/test-ladder-baseline.md
@@ -96,11 +96,12 @@ places it at the publish boundary; rungs 4–6 are named there only because they
 are the rungs that reach that boundary. A rung-4 PR does not owe a workspace test
 run to merge.
 
-**Branch protection follows from this.** The CI `Test` job is a pre-build /
-pre-publish gate, not a pre-merge one, and it is not among `main`'s required
-status contexts (`Format check`, `500-line file-size cap`, `Clippy`,
-`trusty-search daemon smoke test`, `MSRV check (1.94)`). Merges proceed with
-`Test` still pending; a **failing** check blocks at every stage.
+**Branch protection follows from this.** The CI `Rust tests (pre-publish gate)`
+job is a pre-build / pre-publish gate, not a pre-merge one, and it is not among
+`main`'s required status contexts (`Format check`, `500-line file-size cap`,
+`Clippy`, `trusty-search daemon smoke test`, `MSRV check`). Merges proceed
+with `Rust tests (pre-publish gate)` still pending; a **failing** check blocks
+at every stage.
 
 🔴 **Scoping down by stage is a claim you must be able to prove**, exactly as
 scoping down by rung is. It is never licence to make a red gate green by


### PR DESCRIPTION
## What changed

Four job renames, no behavior change:

- `Test shard N` → `Rust tests (pre-publish gate) — shard N of 4`
- `Test` (the aggregate job, which runs no cargo command) → `Rust tests (pre-publish gate)`
- `MSRV check (1.94)` → `MSRV check`
- `Test: doc-comment pointer lint` → `Doc-comment pointer lint (Why/What/Test)` — this is a separate workflow that lints `/// Test:` doc-comment pointers and never runs `cargo test`; the shared `Test:` prefix was coincidental, not a relationship.

## The two stale comments this fixes

These matter more than the renames themselves. `ci.yml` claimed the required contexts were `(Format check, Clippy, Test, MSRV check (1.94), trusty-search daemon smoke test)`. `Test` is not a required context — live branch protection is `Format check`, `500-line file-size cap`, `Clippy`, `trusty-search daemon smoke test`, `MSRV check (1.94)`. The same false premise appeared in the aggregate job's own comment, which justified the job's existence as "branch protection requires the literal context 'Test'".

Both comments now point to `gh api repos/bobmatnyc/trusty-tools/branches/main/protection` as the authoritative source, since a hardcoded list is exactly what went stale here.

This overlaps with [#5407](https://github.com/bobmatnyc/trusty-tools/issues/5407), which independently documents the same discrepancy. This PR does not fully resolve that issue.

## Why MSRV drops its version from the job name

`MSRV check (1.94)` is a required context with the toolchain version baked into the name, so every MSRV bump silently breaks the gate — it already happened once, at 1.91→1.94.

## 🔴 Merge sequencing — read before merging

Branch protection currently requires the literal context `MSRV check (1.94)`, which this branch no longer produces, so this PR cannot satisfy its own required gate and will sit pending indefinitely as-is. Merging this needs a three-step lockstep, in order:

1. Remove `MSRV check (1.94)` from required contexts.
2. Merge this PR.
3. Add `MSRV check` to required contexts and verify enforcement.

There is a brief window where MSRV is not required at all — that is the smallest available exposure. The alternative (adding the new name before removing the old, or merging first) leaves protection pointing at a job name that no longer exists, which fails permanently rather than briefly.

Also: after this lands, every other open PR still carries the old job name in its check run until it rebases onto the new main, so each needs a rebase before its gate can pass. `strict: true` on branch protection already requires that rebase anyway.

## Gates

No Rust source changed, so no cargo gates apply.

- Both workflow YAML files parse-validated.
- `scripts/check_changelog_fragment.sh` exit 0 — CI/docs-only change, no fragment required.
- `git grep` for the old job names across `.github`, `docs`, `scripts`, `CLAUDE.md` returns zero hits.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
