### PR TITLE
feat(tga): AgenticMode gains an 'unknown' state distinct from 'none' (#5250)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10288,7 +10288,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.15.0"
+version = "3.0.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.10" }
 trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon", version = "0.2.0" }
 # tga: trusty-git-analytics — developer productivity analytics.
 # Referenced by trusty-review for contributor-profile data pipeline (#558).
-tga = { path = "crates/trusty-git-analytics", version = "2.10" }
+tga = { path = "crates/trusty-git-analytics", version = "3.0" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.15.0"
+version = "3.0.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for

--- a/crates/trusty-git-analytics/changelog.d/5250-agentic-mode-non-exhaustive.md
+++ b/crates/trusty-git-analytics/changelog.d/5250-agentic-mode-non-exhaustive.md
@@ -1,0 +1,5 @@
+Breaking
+- `AgenticMode` is now `#[non_exhaustive]` and gained a variant, so external
+  `match` sites need a `_ =>` arm. tga goes to 3.0.0: adding a variant to an
+  exhaustive public enum is a major break under `cargo-semver-checks`, and the
+  attribute keeps the next addition (#5251) a minor bump.

--- a/crates/trusty-git-analytics/changelog.d/5250-agentic-unknown.md
+++ b/crates/trusty-git-analytics/changelog.d/5250-agentic-unknown.md
@@ -1,0 +1,16 @@
+Added
+- `AgenticMode::Unknown` — a fourth agentic mode for commits whose message git
+  or a forge composed, so a marker the author emitted was discarded before the
+  commit object existed. It separates "we read the author's message and found
+  no AI marker" from "the message we hold was never the author's".
+  - Detection reaches it only when no marker matched and the message shows a
+    rewrite fingerprint: a git/GitHub merge summary (`Merge branch 'x'`,
+    `Merge pull request #N from …`), or a `(#N)` squash subject whose body was
+    replaced by synthesized trailers. A marker always wins.
+  - No migration: `commits.agentic_mode` is `TEXT NOT NULL DEFAULT 'none'` with
+    no CHECK constraint, so `'unknown'` was already schema-legal.
+  - `agentic_pct` in `fact_weekly_engineer` keeps `unknown` in the
+    `net_commits` denominator and out of both numerators, which makes it an
+    explicit lower bound. `persist_weekly_engineer`'s doc states this.
+  - Reading an unrecognised `agentic_mode` string back from SQLite now yields
+    `Unknown` rather than `None`.

--- a/crates/trusty-git-analytics/src/collect/ai_attribution.rs
+++ b/crates/trusty-git-analytics/src/collect/ai_attribution.rs
@@ -11,6 +11,10 @@
 //! - [`detect_ai_tool`] — the stable tool identifier for the `ai_tool` column.
 //! - [`detect_agentic_mode`] — the canonical [`AgenticMode`] (issue #1113).
 //!
+//! Also [`provenance_possibly_stripped`], the predicate behind
+//! [`AgenticMode::Unknown`] (#5250): it decides whether a message with no
+//! marker is one the author wrote or one git/a forge composed.
+//!
 //! Since #5249 the patterns themselves live in
 //! [`crate::collect::ai_markers`], which is configurable per run and also
 //! matches author/committer emails. Callers that have a commit's identities —
@@ -22,6 +26,10 @@
 //! Test: unit tests in [`tests`] at the bottom of this file, and
 //! `collect::ai_markers::tests` for the marker engine itself.
 
+use std::sync::OnceLock;
+
+use regex::Regex;
+
 use crate::collect::ai_markers::{detect, CommitSignals};
 
 /// Canonical agentic-mode classification for a commit (issue #1113).
@@ -31,10 +39,21 @@ use crate::collect::ai_markers::{detect, CommitSignals};
 /// (autonomous CLI agent) is qualitatively different from a Cursor
 /// inline-completion commit. Downstream analytics (DAAU, agentic %)
 /// need to distinguish these modes without losing the existing columns.
-/// What: three-valued enum, persisted as the TEXT column `agentic_mode`.
+/// What: four-valued enum, persisted as the TEXT column `agentic_mode`. The
+/// column is `TEXT NOT NULL DEFAULT 'none'` with no CHECK constraint, so
+/// `'unknown'` (#5250) needed no migration — the three-value restriction only
+/// ever lived in `as_str`/`FromStr` here.
 /// Test: `tests::detect_agentic_mode_*` below; see also
 /// `core::db::migrations::v21` which adds the column.
+///
+/// `#[non_exhaustive]` because #5250's variant addition cost tga a major bump
+/// (`cargo-semver-checks` `enum_variant_added`, and the crate is 2.x). The
+/// attribute makes the next one — per-tool attribution in
+/// [#5251](https://github.com/bobmatnyc/trusty-tools/issues/5251) — a minor
+/// bump instead. It costs external `match` sites a `_ =>` arm; matches inside
+/// this crate are unaffected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum AgenticMode {
     /// Full-agentic: autonomous CLI agent (Claude Code, Devin, OpenHands,
     /// Aider, or a house wrapper such as trusty-mpm). Which markers imply it
@@ -43,13 +62,27 @@ pub enum AgenticMode {
     /// IDE-assisted: inline AI completions from an IDE plugin
     /// (Cursor, GitHub Copilot).
     IdeAssisted,
-    /// No AI marker was found.
+    /// No AI marker was found in a message the author actually wrote.
     ///
-    /// This is NOT the same claim as "a human wrote it": a commit whose
-    /// trailers were stripped, squashed, or rewritten is indistinguishable
-    /// from one that never had them. #5250 proposes a distinct `unknown`
-    /// state for that case.
+    /// This is still not the same claim as "a human wrote it" — a commit can
+    /// be rewritten in ways this detector cannot see. It is the narrower
+    /// claim that the message carries no rewrite fingerprint either, so the
+    /// absence of a marker is the best evidence available.
     None,
+    /// No AI marker was found, but the message shows a rewrite fingerprint,
+    /// so a marker the author emitted would have been discarded (#5250).
+    ///
+    /// Why: `agentic_pct` is an acquirer-facing figure (DOC-67 §8). A
+    /// git-generated merge summary and a genuinely human commit both used to
+    /// persist as `'none'`, which reports "we checked, there was no AI" for a
+    /// message that never had room to say so.
+    /// What: reached only when no marker matched AND
+    /// [`provenance_possibly_stripped`] holds for the message. It is a
+    /// refinement of [`AgenticMode::None`], never of a positive
+    /// classification: a marker always wins.
+    /// Test: `tests::detect_agentic_mode_merge_summary_is_unknown`,
+    /// `tests::unknown_is_distinct_from_none`.
+    Unknown,
 }
 
 impl AgenticMode {
@@ -64,6 +97,7 @@ impl AgenticMode {
             AgenticMode::FullAgentic => "full_agentic",
             AgenticMode::IdeAssisted => "ide_assisted",
             AgenticMode::None => "none",
+            AgenticMode::Unknown => "unknown",
         }
     }
 }
@@ -80,9 +114,93 @@ impl std::str::FromStr for AgenticMode {
             "full_agentic" => Ok(AgenticMode::FullAgentic),
             "ide_assisted" => Ok(AgenticMode::IdeAssisted),
             "none" => Ok(AgenticMode::None),
+            "unknown" => Ok(AgenticMode::Unknown),
             _ => Err(()),
         }
     }
+}
+
+/// Does this message carry a fingerprint of having been synthesized by git or
+/// a forge, rather than written by the commit's author (#5250)?
+///
+/// Why: [`AgenticMode::None`] is a finding — "we read the author's message and
+/// there was no AI marker in it". That finding is only sound when the message
+/// we hold IS the author's. When git or GitHub composed it, any footer or
+/// trailer the author emitted was discarded before the commit object existed,
+/// and "no marker" says nothing about how the work was done.
+/// What: two fingerprints, both message-only. **(a) a machine merge summary** —
+/// `Merge branch 'x'`, `Merge remote-tracking branch 'x'`, `Merge tag 'x'`,
+/// `Merge commit 'x'`, or `Merge pull request #N from owner/branch`. git and
+/// GitHub compose these in full; none of them can contain an authored footer.
+/// **(b) a forge squash-merge that replaced the body** — a subject ending in
+/// `(#N)` whose every remaining non-blank line is a `Key: value` trailer. This
+/// is what GitHub's "default to PR title" squash setting emits: the branch's
+/// commit bodies, where footers live, are dropped and only synthesized
+/// `Co-authored-by:` trailers remain.
+///
+/// Message-only is a deliberate constraint, not an oversight: `commits` has no
+/// `committer_email` column, so `tga backfill ai-detection-commits` sees only
+/// the message. A predicate reading identities would classify a freshly walked
+/// row differently from a repaired one, breaking the equivalence
+/// [`detect`] promises.
+///
+/// # What this deliberately does NOT catch
+///
+/// A `(#N)` squash whose body is the PR description. On this repo's HEAD
+/// history the predicate claims 16 commits and leaves 128 of these unclaimed —
+/// and at least some of the 128 were agentic: `a92bb941` (#5379) carries no
+/// marker, while the branch commits GitHub squashed into it do.
+///
+/// Separating those needs a signal this function does not have (the pre-squash
+/// commits, or the PR body). The subject shape alone cannot tell a squash from
+/// a hand-written `fix: thing (#12)`, and on a repo that references issues in
+/// subjects by convention it would claim nearly everything — trading a false
+/// `none` for an `unknown` no measurement could refute.
+///
+/// Test: `tests::provenance_possibly_stripped_*`.
+pub fn provenance_possibly_stripped(message: &str) -> bool {
+    let mut lines = message.lines().map(str::trim);
+    let Some(subject) = lines.next() else {
+        return false;
+    };
+    if machine_merge_subject().is_match(subject) {
+        return true;
+    }
+    if !squash_pr_subject().is_match(subject) {
+        return false;
+    }
+    // An empty remainder satisfies this: a `(#N)` subject with no body at all
+    // is the "PR title only" squash in its purest form.
+    lines
+        .filter(|l| !l.is_empty())
+        .all(|l| trailer_shaped().is_match(l))
+}
+
+/// Subjects git and GitHub compose for merge commits. The quoted ref is the
+/// guard: it rejects prose such as `Merge branch handling into the parser`.
+fn machine_merge_subject() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"(?i)^Merge (?:(?:remote-tracking )?branch|tag|commit) '|^Merge pull request #\d+ from \S",
+        )
+        .expect("machine_merge_subject pattern compiles")
+    })
+}
+
+/// The `(#N)` suffix GitHub appends to a squash-merge subject.
+fn squash_pr_subject() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\(#\d+\)$").expect("squash_pr_subject pattern compiles"))
+}
+
+/// A git trailer line — `Key: value`, the only body content GitHub synthesizes
+/// for a title-only squash.
+fn trailer_shaped() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^[A-Za-z][A-Za-z0-9_-]*:\s*\S").expect("trailer_shaped pattern compiles")
+    })
 }
 
 /// Detect the AI tool that produced a commit, from its message alone.
@@ -118,7 +236,7 @@ pub fn detect_ai_tool(message: &str) -> Option<&'static str> {
     detect(&CommitSignals::from_message(message)).tool
 }
 
-/// Classify a commit into one of the three canonical agentic modes.
+/// Classify a commit into one of the four canonical agentic modes.
 ///
 /// Why: distinguishes autonomous CLI-agent commits (Claude Code) from IDE
 /// inline-completion commits (Cursor/Copilot) from plain human commits
@@ -127,9 +245,11 @@ pub fn detect_ai_tool(message: &str) -> Option<&'static str> {
 /// What: runs the shipped marker set (the marker set) over `message`
 /// with no author or committer email. A full-agentic marker (Claude Code, the
 /// trusty-mpm footer, Devin, OpenHands, Aider, the `X-AI-*` trailers) outranks
-/// an IDE marker (Copilot, Cursor); no match is `None`. Callers holding a
-/// commit's identities should call [`detect`] instead so the email
-/// family is not skipped.
+/// an IDE marker (Copilot, Cursor). With no match the result is `None` for a
+/// message the author wrote and `Unknown` when the message carries a rewrite
+/// fingerprint (#5250 — see [`provenance_possibly_stripped`]). Callers holding
+/// a commit's identities should call [`detect`] instead so the email family is
+/// not skipped.
 /// Test: `tests::detect_agentic_mode_*` below.
 ///
 /// # Examples
@@ -254,6 +374,7 @@ mod tests {
         assert_eq!(AgenticMode::FullAgentic.as_str(), "full_agentic");
         assert_eq!(AgenticMode::IdeAssisted.as_str(), "ide_assisted");
         assert_eq!(AgenticMode::None.as_str(), "none");
+        assert_eq!(AgenticMode::Unknown.as_str(), "unknown");
     }
 
     /// Why: `FromStr` must invert `as_str` for lossless DB round-trips.
@@ -270,6 +391,7 @@ mod tests {
             Ok(AgenticMode::IdeAssisted)
         );
         assert_eq!(AgenticMode::from_str("none"), Ok(AgenticMode::None));
+        assert_eq!(AgenticMode::from_str("unknown"), Ok(AgenticMode::Unknown));
         assert!(AgenticMode::from_str("unknown_value").is_err());
         assert!(AgenticMode::from_str("").is_err());
     }
@@ -375,6 +497,97 @@ mod tests {
         let msg = "fix: npe\n\nCo-Authored-By: AI Bot <ai@cursor.sh>";
         assert_eq!(detect_agentic_mode(msg), AgenticMode::IdeAssisted);
         assert_eq!(detect_ai_tool(msg), Some("cursor"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #5250 — the Unknown state
+    // -------------------------------------------------------------------------
+
+    /// Why: git composes these subjects in full, so an author's footer cannot
+    /// survive into them. 117 of this repo's 453 marker-less commits are of
+    /// this shape.
+    /// What: each git/GitHub merge summary form is a rewrite fingerprint.
+    #[test]
+    fn provenance_possibly_stripped_matches_machine_merge_summaries() {
+        for msg in [
+            "Merge branch 'feat/x' into main",
+            "Merge remote-tracking branch 'origin/main'",
+            "Merge tag 'v2.15.0' into develop",
+            "Merge commit 'deadbeef'",
+            "Merge pull request #42 from bobmatnyc/feat-x\n\nfeat: add the thing",
+        ] {
+            assert!(provenance_possibly_stripped(msg), "{msg}");
+        }
+    }
+
+    /// Why: GitHub's "default to PR title" squash discards the branch's commit
+    /// bodies, which is where footers live, and leaves only the trailers it
+    /// synthesizes.
+    /// What: a `(#N)` subject whose remaining lines are all trailers — or which
+    /// has no body at all — is a rewrite fingerprint.
+    #[test]
+    fn provenance_possibly_stripped_matches_body_replacing_squash() {
+        assert!(provenance_possibly_stripped(
+            "docs: align the corpus (#5397)"
+        ));
+        assert!(provenance_possibly_stripped(
+            "ci: scope the check (#5400)\n\n\
+             Co-authored-by: bobmatnyc <bobmatnyc@users.noreply.github.com>"
+        ));
+    }
+
+    /// Why: the predicate is only worth having if it stays narrow. Each of
+    /// these is a message the author actually wrote, so "no marker" there is a
+    /// finding and must stay `None`.
+    /// What: prose that merely starts with "Merge", a squash whose body is the
+    /// PR description, a plain commit, and an empty message.
+    #[test]
+    fn provenance_possibly_stripped_rejects_authored_messages() {
+        for msg in [
+            "Merge branch handling into the parser",
+            "refactor: merge pull request handling into one module",
+            "docs: record a rejected proposal (#5379)\n\n\
+             Docs-only. The linker switch measured slower on this runner.",
+            "feat: add button",
+            "",
+        ] {
+            assert!(!provenance_possibly_stripped(msg), "{msg}");
+        }
+    }
+
+    /// Why: this is the #5250 acceptance — a stripped-provenance commit must
+    /// stop sharing a bucket with a genuinely human one.
+    /// What: a git merge summary is `Unknown`; the same author's hand-written
+    /// commit is `None`; the two are not equal.
+    #[test]
+    fn detect_agentic_mode_merge_summary_is_unknown() {
+        assert_eq!(
+            detect_agentic_mode("Merge branch 'feat/x' into main"),
+            AgenticMode::Unknown
+        );
+    }
+
+    /// Why: `Unknown` is a refinement of `None`, and a report that treated
+    /// them as one value would erase the whole point of the variant.
+    #[test]
+    fn unknown_is_distinct_from_none() {
+        assert_ne!(AgenticMode::Unknown, AgenticMode::None);
+        assert_ne!(AgenticMode::Unknown.as_str(), AgenticMode::None.as_str());
+        assert_ne!(
+            detect_agentic_mode("Merge branch 'feat/x' into main"),
+            detect_agentic_mode("feat: add button")
+        );
+    }
+
+    /// Why: `Unknown` must never displace a positive classification — a merge
+    /// commit an agent authored still carries its footer.
+    /// What: a merge summary plus the house footer stays `FullAgentic`.
+    #[test]
+    fn marker_wins_over_rewrite_fingerprint() {
+        let msg = "Merge branch 'feat/x' into main\n\n\
+                   🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools";
+        assert_eq!(detect_agentic_mode(msg), AgenticMode::FullAgentic);
+        assert_eq!(detect_ai_tool(msg), Some("trusty-mpm"));
     }
 
     /// Why: Claude must win over Cursor when both trailers present.

--- a/crates/trusty-git-analytics/src/collect/ai_markers.rs
+++ b/crates/trusty-git-analytics/src/collect/ai_markers.rs
@@ -17,7 +17,7 @@ use std::sync::OnceLock;
 
 use regex::Regex;
 
-use crate::collect::ai_attribution::AgenticMode;
+use crate::collect::ai_attribution::{provenance_possibly_stripped, AgenticMode};
 
 /// The three text families a commit exposes to detection.
 ///
@@ -52,8 +52,9 @@ impl<'a> CommitSignals<'a> {
 ///
 /// Why: `ai_tool`, `is_ai_assisted` and `agentic_mode` are written from the
 /// same scan so they cannot disagree about whether a commit was AI-assisted.
-/// What: `tool` is the winning marker's label; `mode` is
-/// [`AgenticMode::None`] when nothing matched.
+/// What: `tool` is the winning marker's label; when nothing matched, `mode` is
+/// [`AgenticMode::None`], or [`AgenticMode::Unknown`] if the message shows a
+/// rewrite fingerprint (#5250).
 /// Test: `tests::detects_trusty_mpm_footer`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Detection {
@@ -71,9 +72,12 @@ pub struct Detection {
 /// What: extracts the `Co-Authored-By:` values once, then tests markers in
 /// order. The first `FullAgentic` match returns immediately, so it outranks an
 /// `IdeAssisted` match found earlier in the list; among `IdeAssisted` matches
-/// the earliest supplies the label.
+/// the earliest supplies the label. With no match at all the verdict splits on
+/// [`provenance_possibly_stripped`] (#5250) — the equivalence above is why that
+/// predicate reads the message only, never the identities the backfill lacks.
 /// Test: `tests::detects_trusty_mpm_footer`,
-/// `tests::full_agentic_wins_over_ide_assisted`.
+/// `tests::full_agentic_wins_over_ide_assisted`,
+/// `tests::merge_summary_is_unknown_not_none`.
 pub fn detect(signals: &CommitSignals<'_>) -> Detection {
     let trailers: Vec<&str> = trailer_line()
         .captures_iter(signals.message)
@@ -97,7 +101,7 @@ pub fn detect(signals: &CommitSignals<'_>) -> Detection {
                     ide = Some(marker.tool);
                 }
             }
-            AgenticMode::None => {}
+            AgenticMode::None | AgenticMode::Unknown => {}
         }
     }
 
@@ -105,6 +109,12 @@ pub fn detect(signals: &CommitSignals<'_>) -> Detection {
         Some(tool) => Detection {
             tool: Some(tool),
             mode: AgenticMode::IdeAssisted,
+        },
+        // #5250: a message git or the forge composed never had room for the
+        // author's marker, so "no marker" is not a human-work finding there.
+        None if provenance_possibly_stripped(signals.message) => Detection {
+            tool: None,
+            mode: AgenticMode::Unknown,
         },
         None => Detection {
             tool: None,
@@ -436,6 +446,28 @@ mod tests {
             mode_of("fix: x\n\nCo-authored-by: openhands <openhands@all-hands.dev>"),
             AgenticMode::FullAgentic
         );
+    }
+
+    /// Why: #5250 — the fingerprint split happens inside `detect`, not only in
+    /// the predicate, and the email family must not change the verdict. The
+    /// backfill path sees empty emails, so a merge summary has to classify
+    /// identically with and without them or a repaired row stops matching a
+    /// freshly walked one.
+    #[test]
+    fn merge_summary_is_unknown_not_none() {
+        let msg = "Merge branch 'feat/x' into main";
+        let by_message = detect(&CommitSignals::from_message(msg));
+        assert_eq!(by_message.mode, AgenticMode::Unknown);
+        assert_eq!(by_message.tool, None);
+
+        let with_identities = detect(&CommitSignals {
+            message: msg,
+            author_email: "engineer@example.com",
+            committer_email: "noreply@github.com",
+        });
+        assert_eq!(with_identities, by_message);
+
+        assert_eq!(mode_of("feat: add button"), AgenticMode::None);
     }
 
     /// Why: the disclosure is the answer to "does a low share mean no AI?".

--- a/crates/trusty-git-analytics/src/report/aggregator/accumulate.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/accumulate.rs
@@ -268,7 +268,10 @@ pub(super) fn accumulate_rows(rows: &[CommitRow], flags: &RowFlags) -> Accumulat
         match row.agentic_mode {
             AgenticMode::FullAgentic => w.agentic_count += 1,
             AgenticMode::IdeAssisted => w.ide_assisted_count += 1,
-            AgenticMode::None => {}
+            // #5250: `Unknown` is not a positive classification, so it counts
+            // toward neither numerator — it stays in the `net_commits`
+            // denominator exactly as `None` does. See `persist_weekly_engineer`.
+            AgenticMode::None | AgenticMode::Unknown => {}
         }
         // Issue #445 batch B (request #6): accumulate complexity sum so
         // materialize_weekly_activity can compute avg_complexity without a

--- a/crates/trusty-git-analytics/src/report/aggregator/mod.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/mod.rs
@@ -412,9 +412,13 @@ impl Aggregator {
             let complexity: Option<i64> = row.get(12).unwrap_or(None);
             // Issue #1113: agentic_mode TEXT; defaults to 'none' for pre-v21 rows.
             let agentic_mode_str: String = row.get(13).unwrap_or_else(|_| "none".to_string());
+            // #5250: an unparseable stored value means a newer tga wrote a mode
+            // this build has no name for — that is the "we cannot tell" case,
+            // not a human-work finding. Pre-v21 rows keep reading as 'none'
+            // above, so this fallback only fires on a genuinely foreign value.
             let agentic_mode = agentic_mode_str
                 .parse::<AgenticMode>()
-                .unwrap_or(AgenticMode::None);
+                .unwrap_or(AgenticMode::Unknown);
             Ok(CommitRow {
                 sha: row.get(0)?,
                 author_name: row.get(1)?,

--- a/crates/trusty-git-analytics/src/report/persist.rs
+++ b/crates/trusty-git-analytics/src/report/persist.rs
@@ -190,7 +190,24 @@ pub fn persist_weekly_quality(db: &Database, data: &ReportData) -> Result<usize>
 /// 100` (full-agentic only — excludes `ide_assisted_count`). Rows with
 /// unresolvable author emails are skipped with a `warn!` to preserve
 /// grain-key integrity.
-/// Test: `report::tests::persist_weekly_engineer_upserts_rows`.
+/// Test: `report::tests::persist_weekly_engineer_upserts_rows`,
+/// `report::tests::agentic_pct_keeps_unknown_in_the_denominator`.
+///
+/// # How `agentic_pct` treats `AgenticMode::Unknown` (#5250)
+///
+/// `unknown` commits stay in the `net_commits` DENOMINATOR and contribute to
+/// neither numerator, exactly as `none` does. `agentic_pct` is therefore a
+/// LOWER BOUND on agentic share: a repository whose merge and squash commits
+/// were composed by the forge reports a smaller percentage than the work
+/// warrants, and the size of that deficit is bounded by the unknown count.
+///
+/// Excluding them from the denominator was the alternative, and was rejected:
+/// `fact_weekly_engineer` has no `unknown_count` column, so a reader of the
+/// table could no longer reproduce `agentic_pct` from the columns beside it —
+/// `net_commits` would stop being the denominator it is named for. Reporting
+/// the unknown share needs that column, which is a migration and belongs with
+/// the per-tool attribution work in
+/// [#5251](https://github.com/bobmatnyc/trusty-tools/issues/5251).
 ///
 /// # Errors
 ///
@@ -218,6 +235,8 @@ pub fn persist_weekly_engineer(db: &Database, data: &ReportData) -> Result<usize
             // agentic_pct = agentic_count / net * 100 — intentionally
             // EXCLUDES ide_assisted_count (full-agentic only, per #1113 spec).
             // ide_assisted is tracked separately and must NOT inflate the numerator.
+            // #5250: `unknown` commits are in `net` and in neither numerator, so
+            // this is a lower bound — see the fn doc for why they stay there.
             let agentic_pct = if net > 0 {
                 (wa.agentic_count as f64) / (net as f64) * 100.0
             } else {

--- a/crates/trusty-git-analytics/src/report/tests.rs
+++ b/crates/trusty-git-analytics/src/report/tests.rs
@@ -924,3 +924,65 @@ fn pipeline_author_filter_single_author() {
 
     std::fs::remove_dir_all(&dir).ok();
 }
+
+// =========================================================================
+// agentic_pct treatment of AgenticMode::Unknown (issue #5250)
+// =========================================================================
+
+/// Why: `unknown` and `none` are different findings but must land in the same
+/// place in the `agentic_pct` arithmetic, and nothing in `persist.rs` says so
+/// mechanically. This pins the denominator: `unknown` commits are counted in
+/// `net_commits` and in neither numerator, which is what makes `agentic_pct` a
+/// lower bound rather than a claim.
+/// What: one author-week with one commit of each mode, no reverts, so
+/// `net_commits` is 4. Only `agentic_pct == 25.0` satisfies that — 50.0 would
+/// mean `unknown` was bucketed with `full_agentic`, and 33.3 would mean it was
+/// dropped from the denominator.
+/// Test: this test itself.
+#[test]
+fn agentic_pct_keeps_unknown_in_the_denominator() {
+    let db = Database::open_in_memory().expect("open db");
+    let conn = db.connection();
+    let rows = [
+        ("a1", "feat: agentic work", "full_agentic"),
+        ("a2", "feat: ide completion", "ide_assisted"),
+        ("a3", "Merge branch 'topic' into main", "unknown"),
+        ("a4", "feat: hand written", "none"),
+    ];
+    for (sha, msg, mode) in rows {
+        conn.execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                 repository, files_changed, insertions, deletions, is_merge, ticketed, \
+                 agentic_mode) \
+             VALUES (?1, 'Dana', 'dana@example.com', '2024-01-15T10:00:00+00:00', ?2, \
+                 'repo-a', 1, 5, 1, 0, 0, ?3)",
+            rusqlite::params![sha, msg, mode],
+        )
+        .expect("insert agentic commit");
+    }
+
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+    assert_eq!(data.weekly_activity.len(), 1);
+    let wa = &data.weekly_activity[0];
+    assert_eq!(wa.commit_count_net, 4, "no reverts, so net is all four");
+    assert_eq!(wa.agentic_count, 1, "only full_agentic counts as agentic");
+    assert_eq!(wa.ide_assisted_count, 1, "unknown must not inflate this");
+
+    let (net, agentic, ide, pct): (i64, i64, i64, f64) = db
+        .connection()
+        .query_row(
+            "SELECT net_commits, agentic_count, ide_assisted_count, agentic_pct \
+             FROM fact_weekly_engineer WHERE author_email = 'dana@example.com'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .expect("read persisted engineer row");
+    assert_eq!(net, 4);
+    assert_eq!(agentic, 1);
+    assert_eq!(ide, 1);
+    assert!(
+        (pct - 25.0).abs() < 1e-9,
+        "agentic_pct must be 1/4; 50.0 would bucket unknown as agentic and \
+         33.3 would drop it from the denominator. got {pct}"
+    );
+}

--- a/crates/trusty-git-analytics/tests/agentic_detection_corpus.rs
+++ b/crates/trusty-git-analytics/tests/agentic_detection_corpus.rs
@@ -22,6 +22,7 @@ use std::collections::BTreeMap;
 
 use git2::Repository;
 use regex::Regex;
+use tga::collect::ai_attribution::AgenticMode;
 use tga::collect::ai_markers::{detect, detection_disclosure, CommitSignals};
 
 struct Commit {
@@ -120,6 +121,9 @@ fn catch_rate_on_trusty_tools_history() {
     let mut before = 0usize;
     let mut after = 0usize;
     let mut beyond_baseline = 0usize;
+    // #5250: how much of the marker-less remainder is a message git or the
+    // forge composed, rather than one an author wrote.
+    let mut unknown = 0usize;
     let mut by_tool: BTreeMap<&str, usize> = BTreeMap::new();
 
     for c in &commits {
@@ -143,6 +147,9 @@ fn catch_rate_on_trusty_tools_history() {
                 beyond_baseline += 1;
             }
         }
+        if d.mode == AgenticMode::Unknown {
+            unknown += 1;
+        }
     }
 
     let total = commits.len();
@@ -162,6 +169,28 @@ fn catch_rate_on_trusty_tools_history() {
     );
     let observed: Vec<String> = by_tool.iter().map(|(t, n)| format!("{t}={n}")).collect();
     println!("detections by tool: {}", observed.join(" "));
+    println!(
+        "#5250 unknown (rewrite fingerprint, no marker) = {unknown} ({:.2}% of all commits, \
+         {:.2}% of the {} with no marker)",
+        pct(unknown),
+        unknown as f64 * 100.0 / (total - after) as f64,
+        total - after
+    );
+
+    // #5250: `unknown` is a refinement of the marker-less remainder, so it can
+    // never exceed it. A predicate that started claiming a large share of the
+    // whole corpus would have stopped being the narrow, mechanism-backed rule
+    // this issue asked for.
+    assert!(
+        unknown <= total - after,
+        "unknown must be a subset of the marker-less commits: {unknown} of {}",
+        total - after
+    );
+    assert!(
+        pct(unknown) < 15.0,
+        "the rewrite-fingerprint predicate must stay narrow; got {:.2}% of all commits",
+        pct(unknown)
+    );
 
     assert!(
         pct(after) >= 85.0,

--- a/docs/specs/DOC-67-tga-audit-mode.md
+++ b/docs/specs/DOC-67-tga-audit-mode.md
@@ -431,8 +431,13 @@ indistinguishable from human work — so a low share means "no markers
 emitted", not "no AI assistance". `collect::ai_markers::detection_disclosure()`
 returns the active tool list plus that caveat, and `tga collect` logs it once
 per run; the section renders it verbatim rather than presenting a bare
-percentage. #5250 proposes a distinct `unknown` state so a stripped-marker
-commit stops sharing a bucket with a genuinely human one.
+percentage. #5250 ships a distinct `unknown` state for the part of that
+population detection can prove: a commit whose message git or the forge
+composed, so the author's marker was discarded before the commit object
+existed. `agentic_pct` keeps those commits in its denominator and out of its
+numerator, which makes the figure an explicit lower bound. It does not reach
+a squash whose body is the PR description — that needs the pre-squash commits
+or the PR body, neither of which the commit carries.
 
 The marker set is a fixed list in `collect::ai_markers::BUILTIN`. Detecting a
 target org's own house footer therefore needs a tga release, and an audit of a


### PR DESCRIPTION
Closes [#5250](https://github.com/bobmatnyc/trusty-tools/issues/5250).

## What changed

`AgenticMode` gains a fourth variant, `Unknown`. `detect()` reaches it at exactly one place — the `None` arm of the final `match ide` in `ai_markers.rs` — when no marker matched *and* the message carries a rewrite fingerprint. A marker always wins, so `Unknown` is a refinement of `None` and can never displace a positive classification.

No migration. `commits.agentic_mode` is `TEXT NOT NULL DEFAULT 'none'` with no CHECK constraint (`0021_agentic_mode.sql`, `core/db/migrations/v21.rs:29-36`), so `'unknown'` was already schema-legal; the three-value restriction only ever lived in `as_str`/`FromStr`.

## The design predicate: what "plausibly stripped" means here

`AgenticMode::None` is a *finding* — "we read the author's message and there was no AI marker in it". That finding is only sound when the message we hold **is** the author's. When git or GitHub composed it, any footer the author emitted was discarded before the commit object existed, and "no marker" says nothing about how the work was done.

`provenance_possibly_stripped(message)` recognises two fingerprints:

**(a) a machine merge summary** — `Merge branch 'x'`, `Merge remote-tracking branch 'x'`, `Merge tag 'x'`, `Merge commit 'x'`, `Merge pull request #N from owner/branch`. git and GitHub compose these in full. The quoted ref is the guard: it rejects prose such as `Merge branch handling into the parser`.

**(b) a forge squash that replaced the body** — a subject ending `(#N)` whose every remaining non-blank line is a `Key: value` trailer, or which has no body at all. This is what GitHub's "default to PR title" squash setting emits: the branch's commit bodies, where footers live, are dropped and only synthesized `Co-authored-by:` trailers remain.

**Message-only is a constraint, not an oversight.** `commits` has no `committer_email` column, so `tga backfill ai-detection-commits` passes `committer_email: ""` (`commands/backfill/flags.rs:395-400`). A predicate reading identities — `committer_email == noreply@github.com` was the obvious candidate and is a *stronger* signal — would classify a freshly walked row differently from a repaired one, breaking the equivalence `detect()`'s doc promises. Rejected on that ground.

### What I deliberately did NOT claim

A `(#N)` squash whose body is the PR description. Measured on this repo's HEAD history (2451 commits): the predicate claims **16**, and leaves **128** of these unclaimed. At least some of the 128 *were* agentic — `a92bb941` ([#5379](https://github.com/bobmatnyc/trusty-tools/pull/5379)) carries no marker, while the branch commits GitHub squashed into it do (`gh api .../pulls/5379/commits` shows one carrying a `trusty-mpm` footer).

Separating those needs a signal the commit does not carry (the pre-squash commits, or the PR body). The subject shape alone cannot tell a squash from a hand-written `fix: thing (#12)`, and on a repo that references issues in subjects by convention it would claim nearly everything — trading a false `none` for an `unknown` no measurement could refute. Narrow and falsifiable beat broad and unfalsifiable.

Measured share, from `agentic_detection_corpus` (`--include-ignored`):

```
commits=2451 known_marker_baseline=2231 (91.02%) before=1161 (47.37%) after=2231 (91.02%) beyond_baseline=0
detections by tool: claude=1161 trusty-mpm=1070
#5250 unknown (rewrite fingerprint, no marker) = 16 (0.65% of all commits, 7.27% of the 220 with no marker)
```

That test now asserts `unknown` stays a subset of the marker-less remainder and under 15% of the corpus, so a later widening of the predicate has to argue for itself.

## The `unwrap_or` fallback decision

`report/aggregator/mod.rs:415-420` now reads back `.unwrap_or(AgenticMode::Unknown)` instead of `AgenticMode::None`. An unparseable stored value means a newer tga wrote a mode this build has no name for — that is the "we cannot tell" case by definition, not a human-work finding. Pre-v21 rows are unaffected: the column read one line above already defaults them to `"none"`, which parses. So this fallback only fires on a genuinely foreign value, where `None` would be a claim the data does not support.

## How `agentic_pct` treats `unknown`

**`unknown` stays in the `net_commits` denominator and contributes to neither numerator, exactly as `none` does.** `agentic_pct` is therefore an explicit **lower bound**, with the deficit bounded by the unknown count. `persist_weekly_engineer`'s doc says so under a dedicated heading, and there is an inline `// #5250:` at the formula.

Excluding them from the denominator was the alternative and was rejected: `fact_weekly_engineer` has no `unknown_count` column, so a reader of the table could no longer reproduce `agentic_pct` from the columns beside it — `net_commits` would stop being the denominator it is named for. Reporting the unknown share needs that column, which is a migration and belongs with [#5251](https://github.com/bobmatnyc/trusty-tools/issues/5251).

## 🔴 tga 2.15.0 → 3.0.0, not 2.16.0

The brief said new public API is a MINOR bump for a 2.x crate. That is wrong for this change, and the repo's own gate says so:

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---
Failed in:
  variant AgenticMode:Unknown in .../src/collect/ai_attribution.rs:77
 Summary semver requires new major version: 1 major and 0 minor checks failed
VERDICT: BREAK. A public API change requires a matching version bump.
```

There is no non-breaking way to satisfy the acceptance criteria — `Detection` is a public struct with public fields, so adding a field there is equally breaking, and the criteria name the variant specifically. So: **tga 3.0.0**, and `AgenticMode` is now `#[non_exhaustive]` while the major is being paid, which keeps the next addition ([#5251](https://github.com/bobmatnyc/trusty-tools/issues/5251)) a minor bump. Matches inside the crate are unaffected; external `match` sites need a `_ =>` arm.

The major forced one more edit: the workspace dependency spec `tga = { …, version = "2.10" }` → `"3.0"` in the root `Cargo.toml`. `trusty-review` is the only in-workspace dependent and does not reference `AgenticMode`.

## Rung and gates

That workspace-manifest edit puts this at **rung 4**, not the rung 3 the brief scoped. Exact commands run, all from the worktree:

```bash
cargo fmt --check                                    # EXIT=0
cargo check -p tga --all-targets                     # EXIT=0
cargo clippy -p tga --all-targets -- -D warnings     # EXIT=0
cargo test -p tga                                    # EXIT=0
SKIP_UI_BUILD=1 cargo check --workspace              # EXIT=0
SKIP_UI_BUILD=1 cargo test -p trusty-review          # EXIT=0
bash scripts/check_semver.sh --crate tga             # EXIT=0
bash scripts/check_line_cap.sh                       # EXIT=0
bash scripts/check_sld.sh                            # EXIT=0
```

```
tga:           test result: ok. 1078 passed; 0 failed; 1 ignored   (+ 6 harnesses, all ok)
trusty-review: test result: ok. 1621 passed; 0 failed; 5 ignored   (+ 9 harnesses, all ok)
semver:        SKIP tga: 2.15.0 -> 3.0.0 is already a major release
line-cap:      measured 3903 tracked .rs file(s); 0 violations — OK
sld-lint:      57 spec doc(s) + 3211 code file(s); 0 error(s), 0 warning(s)
```

### Regression test, before and after

Three tests, demonstrated failing with only the branch point removed (`None if provenance_possibly_stripped(…)` deleted from `detect()`, everything else in place):

```
---- collect::ai_attribution::tests::detect_agentic_mode_merge_summary_is_unknown stdout ----
assertion `left == right` failed
  left: None
 right: Unknown

---- collect::ai_attribution::tests::unknown_is_distinct_from_none stdout ----
assertion `left != right` failed
  left: None
 right: None

---- collect::ai_markers::tests::merge_summary_is_unknown_not_none stdout ----
assertion `left == right` failed
  left: None
 right: Unknown

test result: FAILED. 29 passed; 2 failed  (ai_attribution)
test result: FAILED. 0 passed; 1 failed   (ai_markers)
```

With the branch point restored, all three pass inside the 1078 above.

`report::tests::agentic_pct_keeps_unknown_in_the_denominator` covers the distinction end to end: one author-week with one commit of each mode, no reverts. Only `agentic_pct == 25.0` satisfies it — `50.0` would mean `unknown` was bucketed with `full_agentic`, `33.3` would mean it was dropped from the denominator.

## Scope

Untouched, per the brief: the `BUILTIN` list and `markers()` ([#5249](https://github.com/bobmatnyc/trusty-tools/issues/5249)'s territory), any `unknown_count` column ([#5251](https://github.com/bobmatnyc/trusty-tools/issues/5251)), and the [#5252](https://github.com/bobmatnyc/trusty-tools/issues/5252) fabricated test pointer. `ai_markers.rs` carries two lines from this PR — the `match ide` guard and an `AgenticMode::Unknown` arm the compiler requires — plus its tests; a rebase against #5249 is expected.

One docs edit outside the crate: `docs/specs/DOC-67-tga-audit-mode.md` said "#5250 proposes a distinct `unknown` state", which this PR makes false.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
