### PR TITLE
docs(trusty-mpm): state the "honest" ban in the output styles, covering "stated honestly"

### DIFF
--- a/crates/trusty-code/changelog.d/5420-honest-ban-into-output-styles.md
+++ b/crates/trusty-code/changelog.d/5420-honest-ban-into-output-styles.md
@@ -1,0 +1,6 @@
+Changed
+
+- `BASE-AGENT.md` states the "honest" ban it previously only referenced,
+  covering the word in every position including a heading modifier such as
+  `<noun>, stated honestly:`, and folds the never-announce-your-register bullet
+  into it. Byte-parity with trusty-mpm's copy is preserved (#5420).

--- a/crates/trusty-code/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-code/src/assets/agents/BASE-AGENT.md
@@ -376,11 +376,6 @@ nor its output style.
   adds no fact and underlines a point that already landed. Same shape as
   "…, not the other way around" or "…, never X" appended to a sentence that
   already said it.
-- Never announce the register you're writing in. No heading or preamble labelling
-  the writing plain, honest, direct, candid, blunt, or unvarnished — the label
-  implies the alternative was on the table. Wrong: "What remains unknown, stated
-  plainly:" before a list, or "To be direct about the limitations:". Right: "The
-  retry path is untested." — said where the reader needs it.
 
 **No praise for the user.** When the user makes a point, corrects you, or offers
 a framing: acknowledge with "OK", or disagree and say why. Never praise the
@@ -412,8 +407,14 @@ above, never this list:
 - "One thing it caught that I'd have missed:"
 - "a question I shouldn't assume the answer to"
 
-Both rules are the same family as the banned word "honest": a word or phrase
-that manages the reader instead of informing them.
+**Banned word — "honest", and every variation.** Banned in every position —
+adjective, adverb, heading modifier, parenthetical — as is any other label on
+your own register: plainly, candidly, bluntly, unvarnished. The label implies
+the alternative was on the table, which is the doubt it was reached for to
+dispel. Wrong: "Distribution, stated honestly:" Right: "Distribution:"
+
+All three rules are one family: a word or phrase that manages the reader
+instead of informing them.
 
 **No borrowed-metaphor jargon.** "Load-bearing" is the instance that prompted
 this rule. The metaphor sounds precise, carries no fact the plain sentence would

--- a/crates/trusty-mpm/changelog.d/5420-honest-ban-into-output-styles.md
+++ b/crates/trusty-mpm/changelog.d/5420-honest-ban-into-output-styles.md
@@ -1,0 +1,9 @@
+Changed
+
+- The ban on "honest" moved out of the composed system prompt's
+  `pm-instruction-package.json` block and into the three output styles'
+  `Communication — Write Plainly` section and both `BASE-AGENT.md` copies — the
+  channel a manual `claude` launch keeps. It now names every position the word
+  takes (adjective, adverb, heading modifier, parenthetical), so it reaches
+  `<noun>, stated honestly:` as a heading, and it absorbs `BASE-AGENT.md`'s
+  separate never-announce-your-register bullet. One copy, resident once (#5420).

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -376,11 +376,6 @@ nor its output style.
   adds no fact and underlines a point that already landed. Same shape as
   "…, not the other way around" or "…, never X" appended to a sentence that
   already said it.
-- Never announce the register you're writing in. No heading or preamble labelling
-  the writing plain, honest, direct, candid, blunt, or unvarnished — the label
-  implies the alternative was on the table. Wrong: "What remains unknown, stated
-  plainly:" before a list, or "To be direct about the limitations:". Right: "The
-  retry path is untested." — said where the reader needs it.
 
 **No praise for the user.** When the user makes a point, corrects you, or offers
 a framing: acknowledge with "OK", or disagree and say why. Never praise the
@@ -412,8 +407,14 @@ above, never this list:
 - "One thing it caught that I'd have missed:"
 - "a question I shouldn't assume the answer to"
 
-Both rules are the same family as the banned word "honest": a word or phrase
-that manages the reader instead of informing them.
+**Banned word — "honest", and every variation.** Banned in every position —
+adjective, adverb, heading modifier, parenthetical — as is any other label on
+your own register: plainly, candidly, bluntly, unvarnished. The label implies
+the alternative was on the table, which is the doubt it was reached for to
+dispel. Wrong: "Distribution, stated honestly:" Right: "Distribution:"
+
+All three rules are one family: a word or phrase that manages the reader
+instead of informing them.
 
 **No borrowed-metaphor jargon.** "Load-bearing" is the instance that prompted
 this rule. The metaphor sounds precise, carries no fact the plain sentence would

--- a/crates/trusty-mpm/src/assets/instructions/pm-instruction-package.json
+++ b/crates/trusty-mpm/src/assets/instructions/pm-instruction-package.json
@@ -75,14 +75,6 @@
       }
     },
     {
-      "section": "core",
-      "join_before": "blank",
-      "body": {
-        "kind": "text",
-        "text": "### Banned Word — \"honest\"\n\n\"Honest\" and every variation — honestly, honesty, dishonest, \"to be honest\", \"the honest answer\" — is banned from PM responses, delegation briefs, and review instructions. A report states facts; labelling them honest implies the alternative was considered, which is the doubt the word was reached for to dispel.\n\n- Wrong: \"The honest answer is that the merge didn't happen.\"\n- Right: \"The merge didn't happen.\""
-      }
-    },
-    {
       "section": "memory",
       "join_before": "blank",
       "body": {

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
@@ -213,8 +213,14 @@ above, never this list:
 - "One thing it caught that I'd have missed:"
 - "a question I shouldn't assume the answer to"
 
-Both rules are the same family as the banned word "honest": a word or phrase
-that manages the reader instead of informing them.
+**Banned word — "honest", and every variation.** Banned in every position —
+adjective, adverb, heading modifier, parenthetical — as is any other label on
+your own register: plainly, candidly, bluntly, unvarnished. The label implies
+the alternative was on the table, which is the doubt it was reached for to
+dispel. Wrong: "Distribution, stated honestly:" Right: "Distribution:"
+
+All three rules are one family: a word or phrase that manages the reader
+instead of informing them.
 
 **No borrowed-metaphor jargon.** "Load-bearing" is the instance that prompted
 this rule. The metaphor sounds precise, carries no fact the plain sentence would

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
@@ -208,8 +208,14 @@ above, never this list:
 - "One thing it caught that I'd have missed:"
 - "a question I shouldn't assume the answer to"
 
-Both rules are the same family as the banned word "honest": a word or phrase
-that manages the reader instead of informing them.
+**Banned word — "honest", and every variation.** Banned in every position —
+adjective, adverb, heading modifier, parenthetical — as is any other label on
+your own register: plainly, candidly, bluntly, unvarnished. The label implies
+the alternative was on the table, which is the doubt it was reached for to
+dispel. Wrong: "Distribution, stated honestly:" Right: "Distribution:"
+
+All three rules are one family: a word or phrase that manages the reader
+instead of informing them.
 
 **No borrowed-metaphor jargon.** "Load-bearing" is the instance that prompted
 this rule. The metaphor sounds precise, carries no fact the plain sentence would

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
@@ -190,8 +190,14 @@ above, never this list:
 - "One thing it caught that I'd have missed:"
 - "a question I shouldn't assume the answer to"
 
-Both rules are the same family as the banned word "honest": a word or phrase
-that manages the reader instead of informing them.
+**Banned word — "honest", and every variation.** Banned in every position —
+adjective, adverb, heading modifier, parenthetical — as is any other label on
+your own register: plainly, candidly, bluntly, unvarnished. The label implies
+the alternative was on the table, which is the doubt it was reached for to
+dispel. Wrong: "Distribution, stated honestly:" Right: "Distribution:"
+
+All three rules are one family: a word or phrase that manages the reader
+instead of informing them.
 
 **No borrowed-metaphor jargon.** "Load-bearing" is the instance that prompted
 this rule. The metaphor sounds precise, carries no fact the plain sentence would

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -1281,7 +1281,7 @@ fn output_styles_mirror_the_pm_prose_rules() {
         "**No praise for the user.**",
         "**If you are saying it, its worth is implied.**",
         "**Do not embellish.**",
-        "the banned word \"honest\"",
+        "**Banned word — \"honest\", and every variation.**",
         "**Ticket and PR bodies**",
         "never whether it is said",
     ];
@@ -1340,6 +1340,46 @@ fn the_borrowed_metaphor_ban_reaches_both_prose_channels() {
         assert!(
             composed.contains(needle),
             "composed agent is missing the borrowed-metaphor ban {needle:?}"
+        );
+    }
+}
+
+#[test]
+fn the_honest_ban_reaches_both_prose_channels() {
+    // The word ban used to live only in the manifest block the composed prompt
+    // carries, so a manual `claude` launch never received it and the output
+    // styles pointed at a rule they did not state. It now states the rule, in
+    // every position the word can take — the owner's flagged instance was the
+    // heading modifier "Distribution, stated honestly", not a bare "honest".
+    use crate::core::agent_builder::compose_agent;
+    use std::path::Path;
+
+    const REQUIRED: &[&str] = &[
+        "**Banned word — \"honest\", and every variation.**",
+        "adjective, adverb, heading modifier, parenthetical",
+        "\"Distribution, stated honestly:\"",
+    ];
+
+    for style in OUTPUT_STYLES {
+        for needle in REQUIRED {
+            assert!(
+                style.content.contains(needle),
+                "{} is missing the \"honest\" ban {needle:?}",
+                style.id
+            );
+        }
+    }
+
+    let assets_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("assets")
+        .join("agents");
+    let composed =
+        compose_agent("version-control", &assets_dir).expect("compose_agent must succeed");
+    for needle in REQUIRED {
+        assert!(
+            composed.contains(needle),
+            "composed agent is missing the \"honest\" ban {needle:?}"
         );
     }
 }

--- a/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
@@ -620,7 +620,10 @@ fn pm_instructions_is_its_three_sections() {
         assert!(body.contains(expected), "a section source went missing");
     }
     assert!(body.contains("### Clickable References"));
-    assert!(body.contains("### Banned Word"));
+    // The "honest" ban now lives only in the output styles' `Communication —
+    // Write Plainly` section, the one channel a manual `claude` launch keeps.
+    // A copy here is the second statement that move exists to prevent.
+    assert!(!body.contains("### Banned Word"));
 
     // The paragraph break is `Join::Blank`'s literal, which is what makes
     // this string byte-identical to what the packaged composer emits.
@@ -706,11 +709,7 @@ fn the_installed_prompt_carries_the_manifest_authored_rules() {
     // manifest-authored rule missing here is a rule half the launch paths never
     // see.
     let prompt = assemble_system_prompt();
-    for marker in [
-        "### Clickable References",
-        "### Banned Word",
-        "## Opportunistic Fixes",
-    ] {
+    for marker in ["### Clickable References", "## Opportunistic Fixes"] {
         assert!(
             prompt.contains(marker),
             "the installed prompt must carry {marker:?}"

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -239,13 +239,6 @@ Every reference to an issue, PR, ticket, or commit renders as a clickable markdo
 - Commits: `[d027ef1](https://github.com/<owner>/<repo>/commit/d027ef1)`. A bare short SHA is acceptable only inside a table of many.
 - Tickets in another tracker: link to that tracker's issue URL.
 
-### Banned Word — "honest"
-
-"Honest" and every variation — honestly, honesty, dishonest, "to be honest", "the honest answer" — is banned from PM responses, delegation briefs, and review instructions. A report states facts; labelling them honest implies the alternative was considered, which is the doubt the word was reached for to dispel.
-
-- Wrong: "The honest answer is that the merge didn't happen."
-- Right: "The merge didn't happen."
-
 ## Memory Protocol (Context-First)
 
 The `UserPromptSubmit` hook already injects a baseline palace-context block into

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
@@ -239,13 +239,6 @@ Every reference to an issue, PR, ticket, or commit renders as a clickable markdo
 - Commits: `[d027ef1](https://github.com/<owner>/<repo>/commit/d027ef1)`. A bare short SHA is acceptable only inside a table of many.
 - Tickets in another tracker: link to that tracker's issue URL.
 
-### Banned Word — "honest"
-
-"Honest" and every variation — honestly, honesty, dishonest, "to be honest", "the honest answer" — is banned from PM responses, delegation briefs, and review instructions. A report states facts; labelling them honest implies the alternative was considered, which is the doubt the word was reached for to dispel.
-
-- Wrong: "The honest answer is that the merge didn't happen."
-- Right: "The merge didn't happen."
-
 ## Memory Protocol (Context-First)
 
 The `UserPromptSubmit` hook already injects a baseline palace-context block into

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -239,13 +239,6 @@ Every reference to an issue, PR, ticket, or commit renders as a clickable markdo
 - Commits: `[d027ef1](https://github.com/<owner>/<repo>/commit/d027ef1)`. A bare short SHA is acceptable only inside a table of many.
 - Tickets in another tracker: link to that tracker's issue URL.
 
-### Banned Word — "honest"
-
-"Honest" and every variation — honestly, honesty, dishonest, "to be honest", "the honest answer" — is banned from PM responses, delegation briefs, and review instructions. A report states facts; labelling them honest implies the alternative was considered, which is the doubt the word was reached for to dispel.
-
-- Wrong: "The honest answer is that the merge didn't happen."
-- Right: "The merge didn't happen."
-
 ## Memory Protocol (Context-First)
 
 The `UserPromptSubmit` hook already injects a baseline palace-context block into


### PR DESCRIPTION
## Owner feedback

> "this wording: 'Distribution, stated honestly' is forbidden"
> "(tm output style)"

## Where the ban actually lived

The PM's hypothesis held. `git grep -n honest` over the asset trees found the
ban stated in exactly one place: an inline `"kind": "text"` block in
`crates/trusty-mpm/src/assets/instructions/pm-instruction-package.json`,
section `core`. That block reaches a session only through the tm-composed
system prompt, so a `claude` launched by hand never received it.

All five prose carriers then referred to a rule they did not state:

> Both rules are the same family as the banned word "honest": …

`sections/core.md`'s `Prose Style — Write Plainly` was already a pointer at the
output style, so the manifest block was the divergent second statement, not
the pointer.

## What changed

The ban now lives in the output styles' `Communication — Write Plainly`
section — the copy the style itself declares canonical — grouped with the
sycophancy and significance-framing bans rather than added as a fourth block:

```
**Banned word — "honest", and every variation.** Banned in every position —
adjective, adverb, heading modifier, parenthetical — as is any other label on
your own register: plainly, candidly, bluntly, unvarnished. The label implies
the alternative was on the table, which is the doubt it was reached for to
dispel. Wrong: "Distribution, stated honestly:" Right: "Distribution:"

All three rules are one family: a word or phrase that manages the reader
instead of informing them.
```

Naming the positions is what reaches the flagged construction: `<noun>, stated
honestly:` is a heading modifier, and the old ban's example list ("to be
honest", "the honest answer") did not cover it.

All five carriers, per [#5404](https://github.com/bobmatnyc/trusty-tools/pull/5404)'s set:

| Carrier | Why it qualifies |
|---|---|
| `output-styles/trusty-mpm.md` | PM voice, the channel that survives a manual launch (#2647) |
| `output-styles/trusty-mpm-research.md` | same, research style |
| `output-styles/trusty-mpm-teacher.md` | same, teacher style |
| `trusty-mpm/src/assets/agents/BASE-AGENT.md` | subagents get no output style; this is their copy |
| `trusty-code/src/assets/agents/BASE-AGENT.md` | byte-parity copy held by `check_agent_assets.sh` |

`pm-instruction-package.json`'s block is deleted. Both `BASE-AGENT.md` copies
also lose their separate never-announce-your-register bullet, whose label list
("plain, honest, direct, candid, blunt, or unvarnished") stated the same rule a
second time; its content folds into the sentence above.

## Net line change

| Surface | Δ |
|---|---|
| 3 output styles | +6 each = **+18** |
| 2 `BASE-AGENT.md` (ban added, register bullet folded in) | +1 each = **+2** |
| `pm-instruction-package.json` | **−8** |
| **Total prose carriers** | **+12** |

Per resident prompt, which is the cost that matters: a tm PM session is **−1**
(output style +6, composed prompt −7 — see the golden diffs). An agent is +1. A
manual `claude` launch is +6 and receives the rule for the first time. #5404
took −6 by consolidating; this one buys coverage of a construction the rule
missed, and pays for most of it by deleting the duplicate.

## Tests

`bundle_tests.rs` gains `the_honest_ban_reaches_both_prose_channels`, the
sibling of #5404's `the_borrowed_metaphor_ban_reaches_both_prose_channels`: it
asserts the rule text, the position list, and the flagged instance in all three
styles and in a composed agent. `output_styles_mirror_the_pm_prose_rules`'s
needle moves from the dangling reference to the rule itself.
`instruction_pipeline_tests.rs` now asserts the composed prompt does **not**
carry `### Banned Word` — the no-second-copy property. Goldens regenerated with
`UPDATE_GOLDEN=1`.

Provably-failing-before check, reverting one style only:

```
trusty-mpm-teacher is missing the "honest" ban "**Banned word — \"honest\", and every variation.**"
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4919 filtered out
```

## Gates — rung 3 (`crates/*/src/**` in the diff)

```
cargo fmt --check && cargo check -p trusty-mpm \
  && cargo clippy -p trusty-mpm --all-targets -- -D warnings \
  && cargo test -p trusty-mpm && cargo check -p trusty-code && cargo test -p trusty-code
EXIT=0        # 10109 passed; 0 failed across both crates
```

```
sld-lint: scanned 57 spec doc(s) + 3211 code file(s); 0 error(s), 0 warning(s)
line-cap: measured 3903 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
agent-assets: scanned 30 byte-parity file(s) (floor 20), all match; 4 pinned deviation(s) match upstream — OK.
tm-capabilities: up to date (7 generated files).
```

No issue — the owner flagged the phrase and named the surface; this PR is the
record.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
