### PR TITLE
fix(scripts): hoist codesign identifiers so the launchd-label scan exempts them

### DIFF
--- a/scripts/install-trusty-memory-signed.sh
+++ b/scripts/install-trusty-memory-signed.sh
@@ -95,6 +95,19 @@ readonly MEMORY_BIN="$CARGO_BIN_DIR/trusty-memory"
 readonly BM25_BIN="$CARGO_BIN_DIR/trusty-bm25-daemon"
 readonly BRIDGE_BIN="$CARGO_BIN_DIR/trusty-memory-mcp-bridge"
 
+# The CODESIGN identifiers `tctl sign trusty-memory` applies, mirrored here only
+# to narrate the --dry-run plan. These are not launchd labels: they live in the
+# codesign namespace, keep the full binary name on purpose, and must never be
+# normalised onto `com.trusty.<stem>` — renaming one invalidates the binary's
+# designated requirement and re-triggers macOS TCC prompts (#2558). The
+# `*_IDENTIFIER=` naming is what marks them as codesign identifiers, matching
+# install-trusty-mpm-signed.sh and install-trusty-agents-signed.sh.
+# #4868: the previous inline `-> com.trusty.…` narration carried no such marker,
+# so the drift scan read all three as unowned launchd labels.
+readonly MEMORY_IDENTIFIER="com.trusty.trusty-memory"
+readonly BM25_IDENTIFIER="com.trusty.trusty-bm25-daemon"
+readonly BRIDGE_IDENTIFIER="com.trusty.trusty-memory-mcp-bridge"
+
 # Sign identity: auto-detected by `tctl sign` if not overridden. Exported so
 # the child `tctl` process honours the same override this script was given.
 TRUSTY_SIGN_IDENTITY="${TRUSTY_SIGN_IDENTITY:-}"
@@ -192,9 +205,9 @@ run_sign() {
 
     if [[ "$TRUSTY_CODESIGN_DRY_RUN" == "1" ]]; then
         info "[DRY RUN] Would run: tctl sign trusty-memory --dir $CARGO_BIN_DIR"
-        info "[DRY RUN]   trusty-memory            -> com.trusty.trusty-memory"
-        info "[DRY RUN]   trusty-bm25-daemon       -> com.trusty.trusty-bm25-daemon"
-        info "[DRY RUN]   trusty-memory-mcp-bridge -> com.trusty.trusty-memory-mcp-bridge"
+        info "[DRY RUN]   trusty-memory            -> $MEMORY_IDENTIFIER"
+        info "[DRY RUN]   trusty-bm25-daemon       -> $BM25_IDENTIFIER"
+        info "[DRY RUN]   trusty-memory-mcp-bridge -> $BRIDGE_IDENTIFIER"
         return 0
     fi
 


### PR DESCRIPTION
Refs #5437

`main` is red on `trusty-common`'s `launchd_labels::tests::no_stray_launchd_label_literals_in_workspace_sources`, which flagged three strings in `scripts/install-trusty-memory-signed.sh`. This fixes that one blocking instance; the broader derive-from-registry work under #4868 stays open.

**Diagnosis.** The test's own panic message points at the wrong fix. The three flagged strings are codesign identifiers, not launchd labels. They match `codesign_identifier()` exactly (`crates/trusty-installer/src/commands/macos_signing/tests.rs:198-208`) and appear only inside `--dry-run` narration of what `tctl sign trusty-memory` will do. `launchd_labels.rs:46-50` states that codesign identifiers are a separate namespace which deliberately keeps the full binary name and must not be renamed onto `com.trusty.<stem>` — doing so invalidates each binary's designated requirement and re-triggers macOS TCC prompts (#2558).

Following the panic message literally — "derive them from the registry" — would have rewritten `com.trusty.trusty-memory` to `com.trusty.memory` and broken code signing. There is no installer defect and no service-management behaviour change.

The real cause: the scan's codesign exemption keys off two markers, `--identifier` and `IDENTIFIER=` (`tests.rs:746`). The sibling scripts already satisfy it (`install-trusty-mpm-signed.sh:91`, `install-trusty-agents-signed.sh:97`); this script was the lone outlier, inlining its identifiers behind a `->` arrow that carries no marker.

**What changed.** Hoists the three identifiers into `readonly *_IDENTIFIER=` constants and references them from the narration. 16 added, 3 removed. `scripts/` only — no crate `src/**`. Out of scope: deriving labels from the registry (the rest of #4868).

**Risk.** Narration text only; the emitted identifiers are unchanged. Verified by diffing `--dry-run` output before and after: the three identifier lines are byte-identical.

**Test evidence.** Red-to-green on the same command:
- `cargo test -p trusty-common launchd_labels` — before: EXIT=101, `16 passed; 1 failed`. After: EXIT=0, `17 passed; 0 failed`.
- `cargo test -p trusty-common` — EXIT=0, 312 passed, 0 failed, 6 ignored.
- `cargo clippy -p trusty-common --all-targets -- -D warnings` — EXIT=0.
- `cargo fmt --check` — EXIT=0.
- `bash -n scripts/install-trusty-memory-signed.sh` — EXIT=0.
- `shellcheck scripts/install-trusty-memory-signed.sh` — EXIT=0.

The assertion was not weakened: no `#[ignore]`, no cfg-gate, no exclusion, no new `SCAN_EXEMPT_PATHS` entry. The scan still rejects a genuine stray label in this file.

**Baseline failures.** None. This PR fixes the baseline failure that was blocking others.

**Documentation / changelog.** No changelog fragment — the change touches no crate `src/**`, the documented exemption.

**Review-finding disposition.** No review round yet. One follow-up the fix surfaced but deliberately did not take on: the codesign exemption depends on scripts adopting the `*_IDENTIFIER=` naming, which is convention, not enforced — the next script that narrates an identifier inline trips the same red. Teaching the scan about `tctl sign` narration, or asserting the naming convention across `scripts/install-*-signed.sh`, would close it. Out of scope here.

The scan's own source cites `#4868` throughout `crates/trusty-common/src/launchd_labels/tests.rs` — module header, ~15 sites, and the panic message itself. That reference is stale: #4868 is an unrelated merged trusty-search PR. `git blame` traces every citation to `6b9554d71` (2026-08-05), whose own subject cites `#4919`. Tracked separately; this PR does not touch that file.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
