### PR TITLE
fix(ci): classify docs-only from the diff, not the PR activity type (#5407)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,12 @@ on:
 # alone and it still reaches a conclusion. Costs an extra run per description
 # edit; throws away no completed work. Observed on this PR: two body edits
 # produced two extra runs and the in-flight run completed `success` regardless.
+#
+# That extra run has to be a REAL one. Uncancelled, it shares every context
+# name with the run it coexists with, and GitHub surfaces only the
+# later-completing check-run per name — so anything that lets the edit-run
+# report without testing rewrites the PR's visible verdict. Do not reintroduce
+# a skip keyed on `github.event.action` in the `changes` job below; see #5407.
 concurrency:
   group: ci-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
@@ -211,17 +217,23 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
 
+      # #5407: this step and the CUDA one below each used to short-circuit to
+      # "nothing to build" whenever the activity type was `edited` and
+      # `changes.base` was null — a decision about the EVENT, never about the
+      # diff. Any retitle or body rewrite therefore claimed Cargo-inert for a
+      # PR full of Rust, every gated step no-opped, and `Test` reported SUCCESS
+      # in ~14 s. `cancel-in-progress` excludes `edited` by design, so that run
+      # coexisted with the real one, and GitHub surfaces only the
+      # later-completing check-run per context name — a retitle three seconds
+      # after a push could bury a genuine failure behind a green that never
+      # compiled anything (live pair on PR #5403: runs 31459286344 and
+      # 31459288334). Classifying from the diff is what makes the answer true;
+      # the base ref refreshed above is available on every pull_request
+      # activity type, `edited` included, so there is nothing extra to resolve.
+      # The cost is one honest re-run of the suite per body edit on a code PR.
       - name: Classify changed paths
         id: detect
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ] && \
-             [ "${{ github.event.action }}" = "edited" ] && \
-             [ "${{ toJSON(github.event.changes.base) }}" = "null" ]; then
-            echo "title/body-only PR edit — retaining required contexts without repeating Cargo"
-            echo "docs_only=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             DOCS_ONLY_BASE="origin/${{ github.event.pull_request.base.ref }}" \
               bash scripts/detect-docs-only.sh > /dev/null
@@ -236,17 +248,13 @@ jobs:
           fi
           DOCS_ONLY_BASE="$before" bash scripts/detect-docs-only.sh > /dev/null
 
+      # #5407 again — the same event-type short-circuit was written twice, so
+      # it is removed twice. `embedder-cuda-check` is the cheaper of the two
+      # victims, but the mechanics are identical: a retitle claimed no
+      # trusty-common change and the compile check reported green unrun.
       - name: Classify embedder CUDA relevance
         id: detect-cuda
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ] && \
-             [ "${{ github.event.action }}" = "edited" ] && \
-             [ "${{ toJSON(github.event.changes.base) }}" = "null" ]; then
-            echo "metadata-only PR edit — no CUDA-relevant change"
-            echo "embedder_cuda_relevant=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             CUDA_SCOPE_BASE="origin/${{ github.event.pull_request.base.ref }}" \
               bash scripts/detect-embedder-cuda-relevant.sh > /dev/null

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # check-ci-helpers-selftest.sh — regression fixtures for the CI helper scripts
-# (issues #4179, #4468, #4421, #4688).
+# (issues #4179, #4468, #4421, #4688, #5407).
 #
 # Why: the three helpers this covers each encode a decision that is invisible
 #   until it is WRONG in production — a cancelled run reported as green, a
@@ -19,6 +19,9 @@
 #                        from a frozen stale base (misattributes) and once from
 #                        the live base branch (does not) — and the workflow
 #                        wiring that decides which of the two CI gets.
+#   ci.yml `changes` job: that every gate verdict comes from a diff, never from
+#                        the PR activity type, and that the push path's
+#                        no-before-SHA arms still fail closed (#5407).
 #
 # Usage: bash scripts/check-ci-helpers-selftest.sh
 # Exit: 0 when every case matches; 1 on the first mismatch, printing both sides.
@@ -335,8 +338,28 @@ assert_eq "ci.yml no longer passes the frozen base.sha" "0" \
 assert_eq "ci.yml classifies the push range instead of forcing full Cargo" "1" \
   "$(grep -c 'DOCS_ONLY_BASE="\$before" bash scripts/detect-docs-only.sh' \
     "${ci_wf}" || true)"
-assert_eq "ci.yml no-ops Cargo for title/body-only edits" "1" \
-  "$(grep -c 'title/body-only PR edit' "${ci_wf}" || true)"
+
+# #5407: the `changes` job decided from the EVENT, not the diff — activity type
+# `edited` with a null `changes.base` short-circuited to `docs_only=true` and
+# `embedder_cuda_relevant=false`, so a retitle on a Rust PR no-opped every gated
+# step and still reported `Test` SUCCESS in ~14 s. `cancel-in-progress` excludes
+# `edited`, so that run coexisted with the real one, and GitHub shows only the
+# later-completing check-run per context name: the unrun green superseded the
+# real verdict everywhere, `gh pr checks` included. The two guards below are
+# deliberately structural rather than string-matched on the old wording — the
+# short-circuit was written twice, and a third detector would inherit it.
+changes_job="$(sed -n '/^  changes:/,/^  fmt:/p' "${ci_wf}")"
+assert_eq "changes job never branches on the activity type (#5407)" "0" \
+  "$(grep -c 'github\.event\.action' <<<"${changes_job}" || true)"
+# Only the FAIL-OPEN verdicts are banned as literals: a skip must be something a
+# detector concluded from a diff. The fail-CLOSED literals on the push path
+# (docs_only=false, embedder_cuda_relevant=true) stay, and are asserted below.
+assert_eq "no hardcoded skip verdict in the changes job (#5407)" "0" \
+  "$(grep -cE 'docs_only=true|embedder_cuda_relevant=false' <<<"${changes_job}" || true)"
+assert_eq "a push with no before SHA still fails closed" "1" \
+  "$(grep -c 'echo "docs_only=false" >> "\$GITHUB_OUTPUT"' <<<"${changes_job}" || true)"
+assert_eq "a push with no before SHA still runs the CUDA check" "1" \
+  "$(grep -c 'echo "embedder_cuda_relevant=true" >> "\$GITHUB_OUTPUT"' <<<"${changes_job}" || true)"
 
 # capabilities-drift is optional, so it can use exact trigger paths instead of
 # paying for a duplicate checkout/classifier job on every PR.


### PR DESCRIPTION
Closes #5407.

The `changes` job decided from the event, not the diff: activity type `edited`
with a null `changes.base` short-circuited to `docs_only=true` and
`embedder_cuda_relevant=false`. A retitle on a Rust PR therefore no-opped every
gated step and still reported `Test` SUCCESS in ~14s, and since
`cancel-in-progress` excludes `edited` that run coexisted with the real one —
GitHub shows only the later-completing check-run per context name, so the unrun
green superseded the true verdict in `gh pr checks` and `statusCheckRollup`.

Both classify steps now take the diff-based path for every `pull_request`
activity type. The base ref refreshed one step earlier (the #4688 pattern) is
present on `edited` events too, so there is nothing extra to resolve. It adds no
fail-open arm: the push path's no-before-SHA arms still emit `docs_only=false`
and `embedder_cuda_relevant=true`, and those are now asserted.

The short-circuit was written twice — docs-only and embedder-CUDA — so the fix
removes both, and the selftest guard is structural rather than matched on the
old wording, which is what a third detector would otherwise inherit.

## Test — rung 5 (CI gate mechanism)

`scripts/check-ci-helpers-selftest.sh` runs inside the `changes` job itself, so
this is a live CI gate, not a local-only check. The new cases fail against
pre-existing behaviour and pass on the fix.

```
$ git show origin/main:.github/workflows/ci.yml > .github/workflows/ci.yml
$ bash scripts/check-ci-helpers-selftest.sh
  FAIL: changes job never branches on the activity type (#5407): expected '0', got '2'
  FAIL: no hardcoded skip verdict in the changes job (#5407): expected '0', got '2'
check-ci-helpers-selftest: 2/100 case(s) FAILED          # EXIT=1
```

`got '2'` is the duplication: one short-circuit per detector.

```
$ git checkout HEAD -- .github/workflows/ci.yml
$ bash scripts/check-ci-helpers-selftest.sh
  ok   changes job never branches on the activity type (#5407)    -> 0
  ok   no hardcoded skip verdict in the changes job (#5407)       -> 0
  ok   a push with no before SHA still fails closed               -> 1
  ok   a push with no before SHA still runs the CUDA check        -> 1
check-ci-helpers-selftest: all 100 cases passed          # EXIT=0
```

Other gates, all EXIT=0: `actionlint .github/workflows/ci.yml`;
`python3 -c "yaml.safe_load(...)"` (11 jobs intact); `bash -n` on the selftest;
`bash scripts/check_line_cap.sh` (3909 files, 0 violations);
`bash scripts/check_sld.sh`; `cargo fmt --check`.
`CHANGELOG_GATE_BASE=origin/main bash scripts/check_changelog_fragment.sh` →
"scanned 2 changed path(s); no crate source changed (docs-only / CI-only /
test-only) — OK", so no changelog fragment is owed.

Verify the run itself rather than the rollup, since the rollup is the instrument
under repair: read the `synchronize`-triggered run by ID and confirm the cargo
steps executed instead of no-opping.

## Pre-existing red on main

`launchd_labels::tests::no_stray_launchd_label_literals_in_workspace_sources`
is red on `main` over stray label literals in
`scripts/install-trusty-memory-signed.sh`, fixed by a separate PR. Not this
branch: `git diff --name-only origin/main...HEAD -- crates/trusty-common/
scripts/install-trusty-memory-signed.sh` is empty. This PR changes two files,
neither of them Rust.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
