### PR TITLE
fix(trusty-mpm): retry an ETXTBSY spawn instead of failing the exec (#5391)

### DIFF
--- a/crates/trusty-mpm/changelog.d/5391-etxtbsy-spawn-retry.md
+++ b/crates/trusty-mpm/changelog.d/5391-etxtbsy-spawn-retry.md
@@ -1,0 +1,10 @@
+Fixed
+
+- `core::spawn_disclaim::disclaimed_output` retries a spawn that fails with
+  `ETXTBSY` ("Text file busy") up to three times with exponential back-off,
+  instead of surfacing it as a hard error. `ETXTBSY` is raised while any
+  process holds a writable fd to the target inode, so a sibling thread that
+  forks between this process's write and close of a freshly created
+  executable can make an otherwise valid exec fail — the race that made the
+  `tmux` fake-binary tests flaky in CI. A permanently busy target still fails
+  after the third attempt (#5391, epic #3451).

--- a/crates/trusty-mpm/src/core/spawn_disclaim/mod.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/mod.rs
@@ -84,6 +84,52 @@
 /// the private-SPI-based spawn.
 pub const DISABLE_ENV: &str = "TM_DISABLE_SPAWN_DISCLAIM";
 
+/// How many times [`retry_on_etxtbsy`] will attempt a spawn before giving up.
+const ETXTBSY_MAX_ATTEMPTS: u32 = 3;
+
+/// Base back-off between [`retry_on_etxtbsy`] attempts; doubles each retry.
+const ETXTBSY_BACKOFF_MS: u64 = 5;
+
+/// Run `attempt` until it stops failing with `ETXTBSY` ("Text file busy"),
+/// up to [`ETXTBSY_MAX_ATTEMPTS`] times with exponential back-off.
+///
+/// Why: `execve` refuses a file with `ETXTBSY` while ANY process holds a
+/// writable fd to that inode. A sibling thread that forks between this
+/// process's `open` and `close` of a freshly written executable hands the
+/// child an inherited copy of that fd, and the exec in between is refused —
+/// a transient the caller can only wait out. Issue #5391 is the fifth
+/// recorded instance of that race in this workspace (epic #3451); #1634 and
+/// #3570 settled on this bounded retry as the fix, in `trusty-agents` and
+/// `trusty-common` respectively.
+/// What: calls `attempt`, returns its `Ok` immediately, returns any non-
+/// `ETXTBSY` `Err` immediately, and on `ETXTBSY` sleeps
+/// `ETXTBSY_BACKOFF_MS << attempt` before trying again. After
+/// `ETXTBSY_MAX_ATTEMPTS` `ETXTBSY` results it returns the last one, so a
+/// genuinely busy target still fails loudly rather than silently.
+/// Callers must only pass a closure whose `ETXTBSY` can come from the spawn
+/// itself — a retry must never re-run a child that already started.
+/// Test: `retry_on_etxtbsy_returns_first_success`,
+/// `retry_on_etxtbsy_recovers_after_two_busy_attempts`,
+/// `retry_on_etxtbsy_gives_up_after_max_attempts`,
+/// `retry_on_etxtbsy_does_not_retry_other_errors`.
+fn retry_on_etxtbsy<T>(mut attempt: impl FnMut() -> std::io::Result<T>) -> std::io::Result<T> {
+    let mut last_err = None;
+    for n in 0..ETXTBSY_MAX_ATTEMPTS {
+        match attempt() {
+            Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                last_err = Some(e);
+                std::thread::sleep(std::time::Duration::from_millis(ETXTBSY_BACKOFF_MS << n));
+            }
+            other => return other,
+        }
+    }
+    // Unreachable unless the loop ran, and every loop iteration that does not
+    // return stores an error — so `last_err` is always `Some` here.
+    Err(last_err.unwrap_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::ExecutableFileBusy, "Text file busy")
+    }))
+}
+
 /// Spawn `program` with `args`, capture stdout/stderr, and — on macOS —
 /// disclaim TCC responsibility so the child is its own responsible process.
 ///
@@ -96,19 +142,26 @@ pub const DISABLE_ENV: &str = "TM_DISABLE_SPAWN_DISCLAIM";
 /// with the `responsibility_spawnattrs_setdisclaim` attribute set. There is
 /// exactly ONE spawn regardless of whether the disclaim SPI is present, so a
 /// missing SPI never causes a double-run. On non-macOS it delegates straight to
-/// `Command::output`.
+/// `Command::output`. A failure to spawn with `ETXTBSY` is retried by
+/// [`retry_on_etxtbsy`]; `ETXTBSY` cannot arrive once a child exists, so no
+/// retry ever re-runs a command that already started.
 /// Test: `disclaimed_output_captures_stdout`,
 /// `disclaimed_output_captures_stderr_and_nonzero_exit`,
 /// `disclaimed_output_saturates_stdout_and_stderr_without_deadlock`,
-/// `disclaimed_output_reports_spawn_error_for_missing_binary`.
+/// `disclaimed_output_reports_spawn_error_for_missing_binary`; the retry
+/// itself by [`retry_on_etxtbsy`]'s own tests.
 pub fn disclaimed_output(program: &str, args: &[String]) -> std::io::Result<std::process::Output> {
-    #[cfg(target_os = "macos")]
-    {
-        if std::env::var_os(DISABLE_ENV).is_none() {
-            return macos::spawn_capture_disclaimed(program, args);
+    // #5391: a sibling thread's fork can hold a writable fd to a
+    // freshly-written binary, so exec it with a bounded ETXTBSY retry.
+    retry_on_etxtbsy(|| {
+        #[cfg(target_os = "macos")]
+        {
+            if std::env::var_os(DISABLE_ENV).is_none() {
+                return macos::spawn_capture_disclaimed(program, args);
+            }
         }
-    }
-    std::process::Command::new(program).args(args).output()
+        std::process::Command::new(program).args(args).output()
+    })
 }
 
 /// Spawn an already-built `Command` connected to the current process's
@@ -671,6 +724,76 @@ mod tests {
         let result = disclaimed_spawn_detached("/usr/bin/true", &[]);
         unsafe { std::env::remove_var(DISABLE_ENV) };
         assert!(result.is_ok());
+    }
+}
+
+/// #5391: pins [`retry_on_etxtbsy`]'s contract with an injected result
+/// sequence, so the retry is proven on every platform without needing to
+/// provoke a real kernel `ETXTBSY` (which only Linux raises for an inherited
+/// writable fd, and only under a race that cannot be scheduled on demand).
+#[cfg(test)]
+mod etxtbsy_retry_tests {
+    use super::*;
+    use std::cell::Cell;
+
+    fn busy() -> std::io::Error {
+        std::io::Error::from_raw_os_error(26)
+    }
+
+    /// The injected `busy()` must actually classify as `ExecutableFileBusy`,
+    /// otherwise every other test here would pass vacuously.
+    #[test]
+    fn raw_os_error_26_is_executable_file_busy() {
+        assert_eq!(busy().kind(), std::io::ErrorKind::ExecutableFileBusy);
+    }
+
+    #[test]
+    fn retry_on_etxtbsy_returns_first_success() {
+        let calls = Cell::new(0);
+        let got = retry_on_etxtbsy(|| {
+            calls.set(calls.get() + 1);
+            Ok::<_, std::io::Error>(7)
+        });
+        assert_eq!(got.unwrap(), 7);
+        assert_eq!(calls.get(), 1, "a success must not be retried");
+    }
+
+    #[test]
+    fn retry_on_etxtbsy_recovers_after_two_busy_attempts() {
+        let calls = Cell::new(0);
+        let got = retry_on_etxtbsy(|| {
+            calls.set(calls.get() + 1);
+            if calls.get() < 3 { Err(busy()) } else { Ok(7) }
+        });
+        assert_eq!(got.unwrap(), 7);
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[test]
+    fn retry_on_etxtbsy_gives_up_after_max_attempts() {
+        let calls = Cell::new(0);
+        let got = retry_on_etxtbsy(|| {
+            calls.set(calls.get() + 1);
+            Err::<(), _>(busy())
+        });
+        // A permanently busy target still fails loudly — the retry hides a
+        // transient, never a real failure.
+        assert_eq!(
+            got.unwrap_err().kind(),
+            std::io::ErrorKind::ExecutableFileBusy
+        );
+        assert_eq!(calls.get(), ETXTBSY_MAX_ATTEMPTS as i32);
+    }
+
+    #[test]
+    fn retry_on_etxtbsy_does_not_retry_other_errors() {
+        let calls = Cell::new(0);
+        let got = retry_on_etxtbsy(|| {
+            calls.set(calls.get() + 1);
+            Err::<(), _>(std::io::Error::from(std::io::ErrorKind::NotFound))
+        });
+        assert_eq!(got.unwrap_err().kind(), std::io::ErrorKind::NotFound);
+        assert_eq!(calls.get(), 1, "a missing binary must fail on attempt 1");
     }
 }
 

--- a/crates/trusty-mpm/src/core/tmux_tests.rs
+++ b/crates/trusty-mpm/src/core/tmux_tests.rs
@@ -86,15 +86,33 @@ fn managed_session_command_sequence_applies_options_before_new_session() {
 /// Write an executable shell script at `dir/name` with body `body`,
 /// returning its path as a `String` suitable for `create_managed_session`
 /// / `run_tmux_with_bin`'s `bin` parameter.
+///
+/// #5391: the script is created already executable and the write handle is
+/// dropped before it is returned, so no caller can exec it while this thread
+/// still holds a writable fd — the same shape `trusty-agents`'
+/// `test_env::write_executable_script` settled on for #1528. That closes the
+/// self-inflicted half of the ETXTBSY race; the other half — a sibling
+/// thread forking mid-write and handing its child an inherited copy of the
+/// fd — is covered by the bounded retry in `core::spawn_disclaim`.
 fn write_fake_tmux(dir: &std::path::Path, name: &str, body: &str) -> String {
-    use std::os::unix::fs::PermissionsExt;
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt as _;
+
     let path = dir.join(name);
-    std::fs::write(&path, body).expect("write fake tmux script");
-    let mut perms = std::fs::metadata(&path)
-        .expect("stat fake tmux script")
-        .permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(&path, perms).expect("chmod fake tmux script");
+    {
+        // `create_new` so the 0o755 mode is guaranteed to apply: `mode` is
+        // honoured only when the open actually creates the file, and every
+        // caller writes its script name once into its own temp dir.
+        let mut f = std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(0o755)
+            .open(&path)
+            .expect("create fake tmux script");
+        f.write_all(body.as_bytes())
+            .expect("write fake tmux script");
+        // `f` drops here — the writable fd is closed before any exec.
+    }
     path.to_string_lossy().into_owned()
 }
 


### PR DESCRIPTION
Closes #5391 (5th instance of the ETXTBSY class under epic #3451).

`std::fs::write` already closed the write fd before the chmod, so the
self-inflicted window the issue describes was only half the story. The
remaining window is a sibling test thread forking between this process's
`open` and `close` of the fake `tmux` script: the child inherits the
writable fd, and Linux refuses the exec while any process holds one.
That window is transient and can only be waited out, which is why #1634
and #3570 both landed a bounded retry at the spawn rather than a
write-side change.

- `core::spawn_disclaim::disclaimed_output` spawns through
  `retry_on_etxtbsy`: 3 attempts, 5 ms back-off doubling, ETXTBSY only.
  ETXTBSY can only come from the spawn, so a retry never re-runs a child
  that already started; a permanently busy target still fails.
- `write_fake_tmux` creates the script already executable and drops the
  handle before returning — no post-close chmod.

Platform caveat: CI is `ubuntu-latest` and this is Linux exec semantics.
Measured on this macOS host, `execve` of a script with a writable fd
still open (own or child-inherited) succeeds, so the race does not
reproduce locally and the repeated local runs below are a regression
check, not a reproduction of the fix. The retry itself is pinned
platform-independently by 5 injected-result unit tests
(`etxtbsy_retry_tests`), including that a non-ETXTBSY error is not
retried and that a permanent ETXTBSY still fails after 3 attempts.

**Test ladder: rung 3** (localized behavior inside one crate — the fix
moved into `src/**`, so this is not the test-only rung 2 the ticket
anticipated; a changelog fragment ships with it).

```
cargo fmt --check                                     # EXIT=0
cargo check -p trusty-mpm --all-targets               # EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings  # EXIT=0
cargo test -p trusty-mpm
  test result: ok. 4918 passed; 0 failed; 7 ignored   (+ 46 further green targets)
```

Repeated-run evidence — 20x targeted, then 5x the full parallel lib run
(the shape that produced the CI failure):

```
run 1..20:  cargo test -p trusty-mpm --lib -- core::tmux core::spawn_disclaim
            test result: ok. 62 passed; 0 failed; 0 ignored   (all 20 runs)

full-lib run 1: test result: ok. 4918 passed; 0 failed; 7 ignored; finished in 46.85s
full-lib run 2: test result: ok. 4918 passed; 0 failed; 7 ignored; finished in 45.68s
full-lib run 3: test result: ok. 4918 passed; 0 failed; 7 ignored; finished in 46.32s
full-lib run 4: test result: ok. 4918 passed; 0 failed; 7 ignored; finished in 45.89s
full-lib run 5: test result: ok. 4918 passed; 0 failed; 7 ignored; finished in 46.11s
```

Follow-up worth a ticket, not done here: this is the fourth independent
ETXTBSY-retry implementation in the workspace (`trusty-agents`
`claude_code_runner` and `test_env`, `trusty-common`
`embedder_client::spawn_retry`, now this). They differ in sync/async and
in return type, so consolidating into one `trusty-common` entry point is
its own change.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools