### PR TITLE
fix(scripts): assemble-changelog gains --merge so a stale section cannot strand fragments (#5298)

### DIFF
--- a/docs/reference/changelog-fragments.md
+++ b/docs/reference/changelog-fragments.md
@@ -61,6 +61,33 @@ heading between releases. At release time `scripts/bump-version.sh` calls
 fragments by category, writes one `## [<version>] — <date>` section, and deletes
 the consumed fragments in the same operation.
 
+## Recovering a Stale Section (`--merge`)
+
+Assembling is not coupled to publishing, so a `## [<version>]` section can exist
+for a cut that never shipped. PR #4824 wrote `## [1.3.5]` into trusty-mpm and
+`## [0.5.0]` into trusty-agents-common that way, consuming 40 fragments; 77 more
+accumulated behind those sections over the next six days, and the assembler
+refused every subsequent run.
+
+The assembler still refuses by default — merging rewrites a section that may
+already be published and tagged, and the script cannot tell a phantom cut from a
+shipped one. What it now does is name every stranded fragment in the refusal and
+offer the two ways out (#5298):
+
+```bash
+# 1. fold the pending fragments into the existing section
+bash scripts/assemble-changelog.sh <crate-dir> <version> --merge
+
+# 2. or cut the next version instead, leaving the stale section as history
+```
+
+`--merge` appends to the `### <Category>` subsections the section already has,
+inserts missing categories in the canonical order, deletes the consumed
+fragments in the same operation, and exits nonzero without touching anything if
+any category could not be placed. It refuses outright when there is no
+`## [<version>]` section to merge into. Hand-editing `CHANGELOG.md` remains
+banned either way.
+
 ## git-cliff No Longer Touches `CHANGELOG.md`
 
 `scripts/generate-changelog.sh` is deleted; it ran `git cliff --unreleased

--- a/scripts/assemble-changelog.sh
+++ b/scripts/assemble-changelog.sh
@@ -82,7 +82,8 @@
 # empty, nested, and the bullet-starting-with-a-category-word false-positive
 # guard) against a throwaway workspace copy, plus the #5298 stale-section cases
 # (refusal names the stranded fragments; `--merge` appends to an existing
-# category, inserts a missing one in order, and never duplicates a heading).
+# category, inserts a missing one in order, never duplicates a heading, and
+# rejects a fragment body line that forges the plan-file marker).
 # `bash -n` for syntax. Functionally,
 # `scripts/assemble-changelog.sh <crate-dir> --stdout` renders the pending
 # fragments without touching any file, and `--check` also validates the target
@@ -111,6 +112,13 @@ WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # Omitting them would have made the assembler reject real, already-written
 # content.
 CATEGORY_ORDER="Breaking Added Fixed Performance Changed Removed Security Documentation"
+
+# The --merge plan file's category-boundary marker: this token, a tab, then the
+# category name. Defined once so the writer (render_merge_plan), the reader (the
+# awk in merge_into_section) and the fragment guard (plan_marker_lines) cannot
+# drift apart — a guard that stopped matching the marker it protects would be
+# worse than no guard.
+PLAN_MARKER="@@CATEGORY"
 
 usage() {
   echo "Usage: scripts/assemble-changelog.sh <crate-dir> <version> [--check|--merge]" >&2
@@ -235,6 +243,53 @@ stray_category_lines() {
   ' "${path}"
 }
 
+# Why: --merge hands fragment bodies to awk in a plan file whose category
+# boundaries are lines beginning with PLAN_MARKER + a tab. A body line that
+# begins with that same 11-byte sequence is read as a boundary, so every bullet
+# below it is filed under the smuggled category instead of the fragment's own —
+# and --merge then DELETES the fragment, which is the only other copy.
+#
+# The placed-vs-expected set check in merge_fragments() does not catch this on
+# its own: when the smuggled name is a category that is ALSO independently
+# pending, the placed set and the expected set are the same either way. The
+# misfiled bullets are written and the fragments removed, exit 0.
+#
+# Rejected in EVERY mode, not only --merge, because whether a given release runs
+# --merge is unknowable when the fragment is authored; catching it at --stdout
+# and --check costs the author one edit, catching it at release time costs the
+# operator their inputs. Rejected inside code fences too — unlike
+# stray_category_lines(), which may exempt fences because a HUMAN reads the
+# rendered markdown, the plan reader is line-based awk that does not track fence
+# state, so a fenced marker collides exactly as hard as a bare one.
+#
+# What: prints "<file-line-number>\t<text>" for every line after the category
+# line that begins with PLAN_MARKER + a tab. A line where the token is followed
+# by a space, or one where it appears anywhere but column 0, is not the marker
+# and is not flagged.
+# Test: the `plan-marker-*` cases in scripts/assemble_changelog_selftest.sh.
+plan_marker_lines() {
+  local path="$1"
+  awk -v marker="${PLAN_MARKER}" '
+    BEGIN { mark = marker "\t"; n = length(mark) }
+    {
+      line = $0
+      sub(/\r$/, "", line)
+    }
+    !seen && line ~ /[^[:space:]]/ { seen = 1; next }   # the category line
+    !seen { next }                                       # leading blank lines
+    substr(line, 1, n) == mark {
+      text = line
+      sub(/[[:space:]]+$/, "", text)
+      # Render the tab as <TAB>. It is the whole reason the line is the marker
+      # rather than ordinary prose, and a raw tab is indistinguishable from
+      # spaces in a terminal — it would also split the caller`s tab-delimited
+      # report field and swallow the smuggled category name.
+      gsub(/\t/, "<TAB>", text)
+      printf "%d\t%s\n", NR, text
+    }
+  ' "${path}"
+}
+
 # Why: fragments must emit in a deterministic order so two people assembling the
 # same set get byte-identical output.
 # What: prints the fragment's leading issue/PR number, or 0 when the name has no
@@ -277,6 +332,21 @@ parse_fragment() {
   if ! grep -qE '^-[[:space:]]' <<<"${body}"; then
     echo "ERROR: ${base} has a category but no bullet — expected at least one" >&2
     echo "       line starting with '- ' after the category line." >&2
+    return 1
+  fi
+
+  local marked
+  marked="$(plan_marker_lines "${path}")"
+  if [[ -n "${marked}" ]]; then
+    echo "ERROR: ${base} has a line that collides with the --merge plan-file" >&2
+    echo "       marker '${PLAN_MARKER}' + tab:" >&2
+    printf '%s\n' "${marked}" \
+      | awk -F'\t' -v b="${base}" '{ printf "         %s:%s: %s\n", b, $1, $2 }' >&2
+    echo "       A --merge run would read that line as a category boundary and file" >&2
+    echo "       every bullet below it under the smuggled category, then DELETE this" >&2
+    echo "       fragment. Rejected in every mode, and inside code fences too — the" >&2
+    echo "       plan reader is line-based and does not track fences." >&2
+    echo "       Indent the line by two spaces, or break up the token." >&2
     return 1
   fi
 
@@ -355,15 +425,16 @@ render_section() {
 }
 
 # Why: awk cannot take a multi-line value per category through -v, so --merge
-# hands it the new bullets as a file.
-# What: prints the plan — a `@@CATEGORY<TAB><name>` marker line followed by that
+# hands it the new bullets as a file. A fragment body cannot forge a boundary
+# here — parse_fragment() has already rejected any body line carrying the marker.
+# What: prints the plan — a `<PLAN_MARKER><TAB><name>` line followed by that
 # category's verbatim bullet lines, for every category with pending fragments.
 render_merge_plan() {
   local parsed="$1" cat body
   for cat in ${CATEGORY_ORDER}; do
     body="$(category_body "${cat}" "${parsed}")"
     [[ -z "${body}" ]] && continue
-    printf '@@CATEGORY\t%s\n' "${cat}"
+    printf '%s\t%s\n' "${PLAN_MARKER}" "${cat}"
     printf '%s\n' "${body}"
   done
 }
@@ -392,7 +463,7 @@ merge_into_section() {
   local changelog="$1" version="$2" plan="$3" out="$4" report="$5"
   : >"${report}"
   awk -v planfile="${plan}" -v want="## [${version}]" -v cats="${CATEGORY_ORDER}" \
-    -v repfile="${report}" '
+    -v repfile="${report}" -v marker="${PLAN_MARKER}" '
     function record(c) { done[c] = 1; printf "PLACED\t%s\n", c > repfile }
     function emit_new(c) {
       print ""
@@ -453,13 +524,15 @@ merge_into_section() {
     BEGIN {
       nc = split(cats, order, " ")
       for (i = 1; i <= nc; i++) rank[order[i]] = i
+      mark = marker "\t"
+      marklen = length(mark)
       phase = 0
       cur = ""
       nb = 0
       pass = 0
     }
     FILENAME == planfile {
-      if (index($0, "@@CATEGORY\t") == 1) { pc = substr($0, length("@@CATEGORY\t") + 1); next }
+      if (substr($0, 1, marklen) == mark) { pc = substr($0, marklen + 1); next }
       if (pc != "") pend[pc] = pend[pc] $0 "\n"
       next
     }

--- a/scripts/assemble-changelog.sh
+++ b/scripts/assemble-changelog.sh
@@ -580,6 +580,42 @@ merge_into_section() {
 # PLACED report to list every category that had pending fragments. Any shortfall
 # leaves CHANGELOG.md and changelog.d/ untouched and exits nonzero.
 # Test: the #5298 `--merge` cases in scripts/assemble_changelog_selftest.sh.
+# Why: both write paths end with `rm -f "${fragments[@]}"` AFTER CHANGELOG.md has
+# already been replaced, and a bare `rm` there is a silent-partial arm. If it
+# fails — a read-only changelog.d/, a permissions change, an immutable flag —
+# `set -e` aborts before the success message, so the operator sees NO output at
+# all: the section is written, the fragments are still pending, and nothing says
+# so. The next run then re-adds those bullets. --merge is the more damaging of
+# the two, because its re-run appends the survivor to a section that already
+# contains it; the default-write path's re-run at least hits the
+# already-has-a-section refusal.
+#
+# What: deletes the consumed fragments and verifies each one is gone. Any
+# survivor is reported by name, together with the fact that CHANGELOG.md is
+# ALREADY updated and that re-running would duplicate the bullets, and returns
+# nonzero so the caller's success message never prints. Existence is the ground
+# truth here, not `rm`'s exit status — one status covers N files.
+# Test: the `undeletable-fragment-*` cases in scripts/assemble_changelog_selftest.sh.
+delete_consumed_fragments() {
+  local crate_dir="$1" what="$2"
+  shift 2
+  local fragments=("$@") survivors=() f
+
+  rm -f "${fragments[@]}" || true
+  for f in "${fragments[@]}"; do
+    if [[ -e "${f}" ]]; then survivors+=("${f}"); fi
+  done
+  [[ "${#survivors[@]}" -eq 0 ]] && return 0
+
+  echo "ERROR: crates/${crate_dir}/CHANGELOG.md WAS ALREADY UPDATED (${what}), but" >&2
+  echo "       ${#survivors[@]} of ${#fragments[@]} fragment(s) could not be deleted:" >&2
+  printf '%s\n' "${survivors[@]}" | sed 's#^.*/changelog\.d/#         changelog.d/#' >&2
+  echo "       Do NOT re-run: those bullets are in CHANGELOG.md already, and a" >&2
+  echo "       second run would add them a second time. Delete these by hand," >&2
+  echo "       then review and commit the CHANGELOG.md change." >&2
+  return 1
+}
+
 merge_fragments() {
   local crate_dir="$1" changelog="$2" version="$3" parsed="$4"
   shift 4
@@ -614,7 +650,7 @@ merge_fragments() {
   rm -f "${plan}" "${report}"
   trap - EXIT
 
-  rm -f "${fragments[@]}"
+  delete_consumed_fragments "${crate_dir}" "merged into [${version}]" "${fragments[@]}" || exit 1
 
   echo "Merged ${#fragments[@]} fragment(s) into the existing [${version}] section of" >&2
   echo "crates/${crate_dir}/CHANGELOG.md and removed them from changelog.d/." >&2
@@ -808,7 +844,7 @@ main() {
   # with no such directory sends the next PR straight back to editing
   # `## [Unreleased]` — which is both the conflict this change removes and, one
   # release later, a hard stop in the leftover-[Unreleased] check above.
-  rm -f "${fragments[@]}"
+  delete_consumed_fragments "${crate_dir}" "assembled as [${version}]" "${fragments[@]}" || exit 1
 
   echo "Assembled ${#fragments[@]} fragment(s) into crates/${crate_dir}/CHANGELOG.md as [${version}]" >&2
   echo "and removed them from crates/${crate_dir}/changelog.d/." >&2

--- a/scripts/assemble-changelog.sh
+++ b/scripts/assemble-changelog.sh
@@ -42,6 +42,8 @@
 #   (default)   assemble into CHANGELOG.md and delete the consumed fragments
 #   --check     validate only — no writes, no deletions (use in a release
 #               pre-flight BEFORE anything else is mutated)
+#   --merge     fold the pending fragments INTO an existing `## [<version>]`
+#               section instead of inserting a second one (issue #5298)
 #   --stdout    render the section to stdout as `## [Unreleased]` for preview —
 #               no writes, no deletions
 #
@@ -49,6 +51,26 @@
 # tracked README.md placeholder, so a second run inserts nothing rather than an
 # empty section. A run refuses outright when the target version heading is
 # already present.
+#
+# STRANDED FRAGMENTS (issue #5298). A `## [<version>]` section can already exist
+# for the version being cut, because assembling is not coupled to publishing: PR
+# #4824 wrote `## [1.3.5]` into trusty-mpm and `## [0.5.0]` into
+# trusty-agents-common for a cut that never published, consuming 40 fragments in
+# the act. Over the next six days 77 more fragments accumulated behind those
+# sections. The default refusal below is correct and loud, but on its own it is a
+# dead end: it names neither the fragments now stranded nor a way forward, and
+# hand-splicing CHANGELOG.md is banned by repo policy. Recovery took a manual
+# reverse-apply of #4824's changelog write.
+#
+# So the refusal now enumerates every pending fragment, and `--merge` makes the
+# recovery a supported operation: new bullets are appended to the matching
+# `### <Category>` subsections of the existing section, missing categories are
+# inserted in CATEGORY_ORDER position, and the consumed fragments are deleted in
+# the same operation. Merge stays OPT-IN rather than the default because it
+# rewrites a section that may already be published and tagged — this script
+# cannot tell a phantom cut from a shipped one, so that call stays with the
+# operator. What is NOT acceptable either way is fragments going nowhere without
+# a nonzero exit.
 #
 # An empty changelog.d/ is NOT an error — it is the steady state after a release,
 # and a crate with no user-visible change since its last release has nothing to
@@ -58,17 +80,21 @@
 # Test: `bash scripts/assemble_changelog_selftest.sh` — fixture-driven coverage of
 # every validation branch (multi-category fragment, unknown category, bodyless,
 # empty, nested, and the bullet-starting-with-a-category-word false-positive
-# guard) against a throwaway workspace copy. `bash -n` for syntax. Functionally,
+# guard) against a throwaway workspace copy, plus the #5298 stale-section cases
+# (refusal names the stranded fragments; `--merge` appends to an existing
+# category, inserts a missing one in order, and never duplicates a heading).
+# `bash -n` for syntax. Functionally,
 # `scripts/assemble-changelog.sh <crate-dir> --stdout` renders the pending
 # fragments without touching any file, and `--check` also validates the target
 # CHANGELOG.md state (leftover `## [Unreleased]`, version already released).
 #
 # Usage:
-#   scripts/assemble-changelog.sh <crate-dir> <version> [--check]
+#   scripts/assemble-changelog.sh <crate-dir> <version> [--check|--merge]
 #   scripts/assemble-changelog.sh <crate-dir> --stdout
 #
 # Example:
 #   scripts/assemble-changelog.sh trusty-mpm 1.3.2
+#   scripts/assemble-changelog.sh trusty-mpm 1.3.5 --merge
 #   scripts/assemble-changelog.sh trusty-mpm --stdout
 
 set -euo pipefail
@@ -87,12 +113,13 @@ WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CATEGORY_ORDER="Breaking Added Fixed Performance Changed Removed Security Documentation"
 
 usage() {
-  echo "Usage: scripts/assemble-changelog.sh <crate-dir> <version> [--check]" >&2
+  echo "Usage: scripts/assemble-changelog.sh <crate-dir> <version> [--check|--merge]" >&2
   echo "       scripts/assemble-changelog.sh <crate-dir> --stdout" >&2
   echo "" >&2
   echo "  <crate-dir>   directory under crates/ (e.g. trusty-mpm)" >&2
   echo "  <version>     released version for the new heading (e.g. 1.3.2)" >&2
   echo "  --check       validate fragments only; write nothing, delete nothing" >&2
+  echo "  --merge       fold the fragments into an EXISTING [<version>] section" >&2
   echo "  --stdout      preview the pending section as [Unreleased]; no writes" >&2
   exit 2
 }
@@ -293,28 +320,231 @@ fragment_body() {
     | awk '{ lines[NR] = $0 } END { last = NR; while (last > 0 && lines[last] ~ /^[[:space:]]*$/) last--; for (i = 1; i <= last; i++) print lines[i] }'
 }
 
+# Why: the fresh-section renderer and the --merge planner must group fragments
+# identically, or a merged section would drift in shape from an assembled one.
+# What: prints the concatenated verbatim bodies of every fragment whose category
+# is $1, in the order the caller already sorted them, or nothing.
+category_body() {
+  local cat="$1" parsed="$2" group path
+  group="$(printf '%s\n' "${parsed}" | awk -F'\t' -v c="${cat}" '$1 == c { print $2 }')"
+  [[ -z "${group}" ]] && return 0
+  while IFS= read -r path; do
+    [[ -z "${path}" ]] && continue
+    fragment_body "${path}"
+  done <<<"${group}"
+}
+
 # Why: keep rendering in one place so --stdout preview and the real write can
 # never diverge.
 # What: prints the assembled section (heading + grouped bullets) for the given
-# heading text, reading the tab-separated "<category>\t<path>" list on stdin.
+# heading text, reading the tab-separated "<category>\t<path>" list in $2.
 render_section() {
-  local heading="$1" parsed="$2" cat path first_group=1
+  local heading="$1" parsed="$2" cat body first_group=1
   printf '%s\n' "${heading}"
   for cat in ${CATEGORY_ORDER}; do
-    local group
-    group="$(printf '%s\n' "${parsed}" | awk -F'\t' -v c="${cat}" '$1 == c { print $2 }')"
-    [[ -z "${group}" ]] && continue
+    body="$(category_body "${cat}" "${parsed}")"
+    [[ -z "${body}" ]] && continue
     printf '\n### %s\n\n' "${cat}"
     first_group=0
-    while IFS= read -r path; do
-      [[ -z "${path}" ]] && continue
-      fragment_body "${path}"
-    done <<<"${group}"
+    printf '%s\n' "${body}"
   done
   if [[ "${first_group}" -eq 1 ]]; then
     echo "ERROR: no category groups rendered — refusing to write an empty section." >&2
     return 1
   fi
+}
+
+# Why: awk cannot take a multi-line value per category through -v, so --merge
+# hands it the new bullets as a file.
+# What: prints the plan — a `@@CATEGORY<TAB><name>` marker line followed by that
+# category's verbatim bullet lines, for every category with pending fragments.
+render_merge_plan() {
+  local parsed="$1" cat body
+  for cat in ${CATEGORY_ORDER}; do
+    body="$(category_body "${cat}" "${parsed}")"
+    [[ -z "${body}" ]] && continue
+    printf '@@CATEGORY\t%s\n' "${cat}"
+    printf '%s\n' "${body}"
+  done
+}
+
+# Why: --merge must place every pending bullet inside the EXISTING
+# `## [<version>]` section without duplicating a `### <Category>` heading and
+# without disturbing any other section. Insertion position matters: a new
+# category belongs where CATEGORY_ORDER puts it, and a category the section
+# already carries must be APPENDED to, not restated.
+#
+# What: rewrites $1 into $4, folding the plan file $3 into the section headed by
+# `## [$2]`. Three passes over two files — the plan builds the per-category
+# bullet map, changelog pass 1 records which `### <Category>` headings the
+# target section already has, changelog pass 2 emits the rewrite. Every category
+# it actually places is recorded in the report file $5 as `PLACED<TAB><name>`,
+# which is what lets the caller prove nothing was dropped before it deletes a
+# single fragment.
+#
+# Heading matching is `index($0, want) == 1`, not a regex: the version is
+# operator-supplied and would otherwise need escaping twice (once for the shell,
+# once through awk -v's own escape processing), and `## [1.3.5]` as a literal
+# prefix already matches `## [1.3.5] — 2026-08-04` exactly as intended.
+#
+# Test: the #5298 cases in scripts/assemble_changelog_selftest.sh.
+merge_into_section() {
+  local changelog="$1" version="$2" plan="$3" out="$4" report="$5"
+  : >"${report}"
+  awk -v planfile="${plan}" -v want="## [${version}]" -v cats="${CATEGORY_ORDER}" \
+    -v repfile="${report}" '
+    function record(c) { done[c] = 1; printf "PLACED\t%s\n", c > repfile }
+    function emit_new(c) {
+      print ""
+      print "### " c
+      print ""
+      printf "%s", pend[c]
+      record(c)
+    }
+    # Emits the subsection just walked (heading, its authored body with the
+    # blank padding normalised, then any pending bullets for that category).
+    # cur == "" is the pre-heading remainder of the section, emitted verbatim.
+    function finalize(   i, first, last) {
+      first = 1
+      last = nb
+      while (first <= last && body[first] ~ /^[[:space:]]*$/) first++
+      while (last >= first && body[last] ~ /^[[:space:]]*$/) last--
+      if (cur == "") {
+        if (last >= first) {
+          print ""
+          for (i = first; i <= last; i++) print body[i]
+        }
+      } else {
+        print ""
+        print "### " cur
+        print ""
+        for (i = first; i <= last; i++) print body[i]
+        if ((cur in pend) && !(cur in done)) {
+          printf "%s", pend[cur]
+          record(cur)
+        }
+      }
+      nb = 0
+      cur = ""
+    }
+    # A pending category with no heading of its own goes in ahead of the first
+    # existing heading that outranks it. One the section already carries is
+    # skipped here and appended at its own heading by finalize().
+    function flush_before(h,   i, c) {
+      if (!(h in rank)) return
+      for (i = 1; i <= nc; i++) {
+        c = order[i]
+        if (rank[c] >= rank[h]) return
+        if ((c in pend) && !(c in done) && !(c in hashead)) emit_new(c)
+      }
+    }
+    function flush_rest(   i, c) {
+      for (i = 1; i <= nc; i++) {
+        c = order[i]
+        if ((c in pend) && !(c in done)) emit_new(c)
+      }
+    }
+    function heading_text(line,   h) {
+      h = line
+      sub(/^#+[[:space:]]*/, "", h)
+      sub(/[[:space:]]*#*[[:space:]]*$/, "", h)
+      return h
+    }
+    BEGIN {
+      nc = split(cats, order, " ")
+      for (i = 1; i <= nc; i++) rank[order[i]] = i
+      phase = 0
+      cur = ""
+      nb = 0
+      pass = 0
+    }
+    FILENAME == planfile {
+      if (index($0, "@@CATEGORY\t") == 1) { pc = substr($0, length("@@CATEGORY\t") + 1); next }
+      if (pc != "") pend[pc] = pend[pc] $0 "\n"
+      next
+    }
+    FNR == 1 { pass++ }
+    pass == 1 {
+      if (index($0, want) == 1) { scan = 1; next }
+      if (scan && index($0, "## ") == 1) scan = 0
+      if (scan && index($0, "### ") == 1) hashead[heading_text($0)] = 1
+      next
+    }
+    phase == 0 {
+      print
+      if (index($0, want) == 1) { phase = 1; cur = ""; nb = 0 }
+      next
+    }
+    phase == 2 { print; next }
+    index($0, "## ") == 1 {
+      finalize()
+      flush_rest()
+      print ""
+      print
+      phase = 2
+      next
+    }
+    index($0, "### ") == 1 {
+      h = heading_text($0)
+      finalize()
+      flush_before(h)
+      cur = h
+      nb = 0
+      next
+    }
+    { body[++nb] = $0; next }
+    END {
+      if (phase == 1) { finalize(); flush_rest() }
+    }
+  ' "${plan}" "${changelog}" "${changelog}" >"${out}"
+}
+
+# Why: --merge is the one path that rewrites text a human already reviewed, so
+# it owes a proof that the rewrite placed everything before it deletes the only
+# other copy of those bullets. Deleting fragments on the strength of "the awk
+# exited 0" is exactly the fail-open shape #5298 is about.
+# What: renders the plan, merges into a temp file, and requires the merger's
+# PLACED report to list every category that had pending fragments. Any shortfall
+# leaves CHANGELOG.md and changelog.d/ untouched and exits nonzero.
+# Test: the #5298 `--merge` cases in scripts/assemble_changelog_selftest.sh.
+merge_fragments() {
+  local crate_dir="$1" changelog="$2" version="$3" parsed="$4"
+  shift 4
+  local fragments=("$@")
+
+  local plan="${changelog}.merge-plan.$$"
+  local report="${changelog}.merge-report.$$"
+  local tmp="${changelog}.merge.$$"
+  # shellcheck disable=SC2064  # expand the paths now so the trap targets these files
+  trap "rm -f '${plan}' '${report}' '${tmp}'" EXIT
+
+  render_merge_plan "${parsed}" >"${plan}"
+  if [[ ! -s "${plan}" ]]; then
+    echo "ERROR: no category groups rendered — refusing to merge nothing." >&2
+    exit 1
+  fi
+
+  merge_into_section "${changelog}" "${version}" "${plan}" "${tmp}" "${report}"
+
+  local want_cats got_cats
+  want_cats="$(printf '%s\n' "${parsed}" | cut -f1 | LC_ALL=C sort -u)"
+  got_cats="$(cut -f2 "${report}" | LC_ALL=C sort -u)"
+  if [[ "${want_cats}" != "${got_cats}" ]]; then
+    echo "ERROR: merge into '## [${version}]' did not place every pending category." >&2
+    echo "       Expected: $(printf '%s' "${want_cats}" | tr '\n' ' ')" >&2
+    echo "       Placed:   $(printf '%s' "${got_cats}" | tr '\n' ' ')" >&2
+    echo "       crates/${crate_dir}/CHANGELOG.md and changelog.d/ are UNCHANGED." >&2
+    exit 1
+  fi
+
+  mv "${tmp}" "${changelog}"
+  rm -f "${plan}" "${report}"
+  trap - EXIT
+
+  rm -f "${fragments[@]}"
+
+  echo "Merged ${#fragments[@]} fragment(s) into the existing [${version}] section of" >&2
+  echo "crates/${crate_dir}/CHANGELOG.md and removed them from changelog.d/." >&2
 }
 
 main() {
@@ -328,7 +558,7 @@ main() {
     version=""
   else
     case "${mode}" in
-      write | --check) ;;
+      write | --check | --merge) ;;
       *) usage ;;
     esac
     if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
@@ -430,9 +660,37 @@ main() {
     return 0
   fi
 
+  local has_section=0
   if grep -qE "^## \[${version//./\\.}\]" "${changelog}"; then
-    echo "ERROR: ${changelog} already has a '## [${version}]' section." >&2
-    echo "       Refusing to insert a second one. Nothing has been modified." >&2
+    has_section=1
+  fi
+
+  # --merge folds into the existing section; every other mode refuses to touch
+  # one. See the STRANDED FRAGMENTS note at the top of this file (#5298).
+  if [[ "${mode}" == "--merge" ]]; then
+    if [[ "${has_section}" -eq 0 ]]; then
+      echo "ERROR: ${changelog} has no '## [${version}]' section to merge into." >&2
+      echo "       --merge exists to recover a section that was assembled for a cut" >&2
+      echo "       that never published; there is nothing here to recover. Drop" >&2
+      echo "       --merge to assemble a fresh section. Nothing has been modified." >&2
+      exit 1
+    fi
+    merge_fragments "${crate_dir}" "${changelog}" "${version}" "${parsed}" "${fragments[@]}"
+    return 0
+  fi
+
+  if [[ "${has_section}" -eq 1 ]]; then
+    echo "ERROR: ${changelog} already has a '## [${version}]' section, and these" >&2
+    echo "       ${#fragments[@]} fragment(s) are still pending behind it:" >&2
+    printf '%s\n' "${fragments[@]}" | sed "s#^${crate_path}/#         #" >&2
+    echo "       Refusing to insert a second section. Nothing has been modified." >&2
+    echo "" >&2
+    echo "       This is the #5298 state: an earlier run assembled [${version}] for a" >&2
+    echo "       cut that did not publish, and work accumulated behind it. Two ways" >&2
+    echo "       forward — never hand-edit CHANGELOG.md:" >&2
+    echo "         1. Fold the pending fragments into that section:" >&2
+    echo "              scripts/assemble-changelog.sh ${crate_dir} ${version} --merge" >&2
+    echo "         2. Cut the next version instead, leaving [${version}] as history." >&2
     exit 1
   fi
 

--- a/scripts/assemble_changelog_selftest.sh
+++ b/scripts/assemble_changelog_selftest.sh
@@ -699,6 +699,95 @@ else
   fail=1
 fi
 
+# ===========================================================================
+# 14. UNDELETABLE FRAGMENT — the silent-partial arm, both write paths.
+#
+# Both paths delete the consumed fragments AFTER CHANGELOG.md is replaced. A
+# bare `rm` there aborts under `set -e` with no message: section written,
+# fragments still pending, nothing said so, and the next run re-adds the
+# bullets. --merge is the worse of the two — its re-run appends the survivor to
+# a section that already contains it, where the write path's re-run at least
+# hits the already-has-a-section refusal.
+#
+# Lever: chmod a-w on changelog.d/, since unlink needs write permission on the
+# DIRECTORY. Root defeats that, so the cases are skipped there rather than
+# reported as passing — a spurious pass is worse than an honest skip.
+# ===========================================================================
+
+if [ "$(id -u)" = "0" ]; then
+  echo "SKIP: undeletable-fragment cases — running as root, chmod a-w does not"
+  echo "      stop unlink, so the failure cannot be provoked deterministically."
+else
+  # 14a. --merge path.
+  undel_dir="$(new_stale_crate undeletable-fragment-merge)"
+  cat >"$undel_dir/changelog.d/4920-undeletable.md" <<'EOF'
+Fixed
+
+- a bullet whose fragment cannot be removed (#4920)
+EOF
+  chmod a-w "$undel_dir/changelog.d"
+  undel_rc=0
+  undel_out="$(bash "$ASSEMBLER" undeletable-fragment-merge 1.3.5 --merge 2>&1)" || undel_rc=$?
+  chmod u+w "$undel_dir/changelog.d"
+
+  if [ "$undel_rc" -eq 1 ]; then
+    echo "PASS: undeletable-fragment-merge -> exit 1"
+  else
+    echo "FAIL: undeletable-fragment-merge -> exit $undel_rc (expected 1)" >&2
+    printf '%s\n' "$undel_out" | sed 's/^/       /' >&2
+    fail=1
+  fi
+  # The diagnostic owes three things: that CHANGELOG.md is already updated, the
+  # name of each survivor, and "do not re-run".
+  for want in 'WAS ALREADY UPDATED' 'changelog.d/4920-undeletable.md' 'Do NOT re-run'; do
+    if grep -qF -- "$want" <<<"$undel_out"; then
+      echo "PASS: undeletable-fragment-merge diagnostic states $want"
+    else
+      echo "FAIL: undeletable-fragment-merge diagnostic omits $want" >&2
+      printf '%s\n' "$undel_out" | sed 's/^/       /' >&2
+      fail=1
+    fi
+  done
+  # The success message is keyed to the DELETION, not to the mv — the whole
+  # point is that a half-applied release never reads as a completed one.
+  if grep -qF 'Merged 1 fragment' <<<"$undel_out"; then
+    echo "FAIL: undeletable-fragment-merge printed the success message anyway" >&2
+    fail=1
+  else
+    echo "PASS: undeletable-fragment-merge suppressed the success message"
+  fi
+  # CHANGELOG.md really was written — this is a partial, not a rollback, and the
+  # message has to be true when it says so.
+  if grep -qF -- '- a bullet whose fragment cannot be removed (#4920)' "$undel_dir/CHANGELOG.md"; then
+    echo "PASS: undeletable-fragment-merge left CHANGELOG.md updated, as reported"
+  else
+    echo "FAIL: undeletable-fragment-merge reported an update that did not happen" >&2
+    fail=1
+  fi
+
+  # 14b. Default-write path — the same shape, inherited from origin/main.
+  d="$(new_crate undeletable-fragment-write)"
+  cat >"$d/4921-undeletable.md" <<'EOF'
+Added
+
+- a bullet whose fragment cannot be removed (#4921)
+EOF
+  chmod a-w "$d"
+  wr_rc=0
+  wr_out="$(bash "$ASSEMBLER" undeletable-fragment-write 3.0.0 2>&1)" || wr_rc=$?
+  chmod u+w "$d"
+
+  if [ "$wr_rc" -eq 1 ] \
+    && grep -qF -- 'changelog.d/4921-undeletable.md' <<<"$wr_out" \
+    && ! grep -qF 'Assembled 1 fragment' <<<"$wr_out"; then
+    echo "PASS: undeletable-fragment-write -> exit 1, names the survivor, no success line"
+  else
+    echo "FAIL: undeletable-fragment-write -> exit $wr_rc" >&2
+    printf '%s\n' "$wr_out" | sed 's/^/       /' >&2
+    fail=1
+  fi
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "assemble_changelog_selftest: one or more fragment-validation cases FAILED." >&2
   exit 1

--- a/scripts/assemble_changelog_selftest.sh
+++ b/scripts/assemble_changelog_selftest.sh
@@ -622,6 +622,83 @@ else
   fail=1
 fi
 
+# ===========================================================================
+# 13. PLAN-FILE MARKER COLLISION (#5298 review, LOW/Promote).
+#
+# `--merge` hands fragment bodies to awk in a plan file whose category
+# boundaries are `@@CATEGORY` + a tab. A body line beginning with that sequence
+# is read as a boundary, so the bullets below it are filed under the smuggled
+# category — and --merge then deletes the fragment, the only other copy.
+#
+# The placed-vs-expected set check in merge_fragments() cannot see this when the
+# smuggled name is a category that is ALSO independently pending: the two sets
+# match either way. Case 13c replays exactly that shape, which on the pre-guard
+# branch head merged, misfiled a bullet, and exited 0 having deleted both
+# fragments.
+# ===========================================================================
+
+# Literal tabs via printf, not a heredoc — an invisible tab in a fixture is the
+# kind of thing an editor silently converts and nobody notices.
+d="$(new_crate plan-marker-collision)"
+printf 'Fixed\n\n- a real Fixed bullet (#1243)\n@@CATEGORY\tRemoved\n- authored as Fixed prose, below that line\n' \
+  >"$d/1243-plan-marker.md"
+assert_case plan-marker-collision 1 'collides with the --merge plan-file'
+# The diagnostic must name the line AND the smuggled category, with the tab
+# rendered visibly — tab-versus-space is the entire difference between the
+# marker and ordinary prose.
+assert_case plan-marker-collision 1 '1243-plan-marker.md:4: @@CATEGORY<TAB>Removed'
+
+# A fenced marker collides exactly as hard — the plan reader does not track
+# fence state — so unlike stray_category_lines() this guard does NOT exempt
+# fences. Pinned because the two guards sit next to each other and read alike.
+d="$(new_crate plan-marker-in-fence)"
+# `~~~` rather than a backtick fence: both are fences to the validator, and this
+# one does not read as a command substitution to shellcheck (SC2016).
+printf 'Documentation\n\n- documents the plan format (#1244)\n\n~~~\n@@CATEGORY\tRemoved\n~~~\n' \
+  >"$d/1244-fenced-marker.md"
+assert_case plan-marker-in-fence 1 'collides with the --merge plan-file'
+
+# FALSE-POSITIVE GUARD. Only the token at column 0 followed by a TAB is the
+# marker. Prose mentioning it, an indented occurrence, and the token followed by
+# a space are all legitimate content.
+d="$(new_crate plan-marker-false-positive)"
+printf 'Fixed\n\n- prose mentioning @@CATEGORY in passing (#1245)\n  @@CATEGORY\tindented, so not at column 0\n@@CATEGORY followed by a space is not the marker\n' \
+  >"$d/1245-not-the-marker.md"
+assert_case plan-marker-false-positive 0 '^### Fixed$'
+assert_case plan-marker-false-positive 0 'followed by a space is not the marker'
+
+# 13c. END-TO-END: the shape that slips past the set-equality guard. Two
+#      fragments, and the smuggled category is the other one's, so
+#      placed == expected. Must be refused before any file is touched.
+marker_dir="$(new_stale_crate plan-marker-merge)"
+printf 'Fixed\n\n- a real Fixed bullet (#4910)\n@@CATEGORY\tRemoved\n- authored as Fixed prose, below that line\n' \
+  >"$marker_dir/changelog.d/4910-marker.md"
+printf 'Removed\n\n- a genuinely Removed bullet (#4911)\n' \
+  >"$marker_dir/changelog.d/4911-removed.md"
+
+cp "$marker_dir/CHANGELOG.md" "$TMP_ROOT/plan-marker-before.md"
+mk_rc=0
+mk_out="$(bash "$ASSEMBLER" plan-marker-merge 1.3.5 --merge 2>&1)" || mk_rc=$?
+if [ "$mk_rc" -eq 1 ] && grep -qF 'collides with the --merge plan-file' <<<"$mk_out"; then
+  echo "PASS: plan-marker --merge -> exit 1 before any write"
+else
+  echo "FAIL: plan-marker --merge -> exit $mk_rc (expected 1 with the marker diagnostic)" >&2
+  printf '%s\n' "$mk_out" | sed 's/^/       /' >&2
+  fail=1
+fi
+# Fail CLOSED: the file untouched and BOTH fragments still on disk. On the
+# pre-guard head this merged, misfiled the bullet under `### Removed`, and
+# deleted both fragments.
+if diff -q "$TMP_ROOT/plan-marker-before.md" "$marker_dir/CHANGELOG.md" >/dev/null \
+  && [ "$(find "$marker_dir/changelog.d" -maxdepth 1 -name '*.md' | wc -l | tr -d ' ')" = "2" ]; then
+  echo "PASS: plan-marker --merge left CHANGELOG.md and both fragments untouched"
+else
+  echo "FAIL: plan-marker --merge mutated CHANGELOG.md or consumed a fragment" >&2
+  diff -u "$TMP_ROOT/plan-marker-before.md" "$marker_dir/CHANGELOG.md" | sed 's/^/       /' >&2
+  find "$marker_dir/changelog.d" -maxdepth 1 -name '*.md' | sed 's/^/       /' >&2
+  fail=1
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "assemble_changelog_selftest: one or more fragment-validation cases FAILED." >&2
   exit 1

--- a/scripts/assemble_changelog_selftest.sh
+++ b/scripts/assemble_changelog_selftest.sh
@@ -36,6 +36,18 @@
 #     - wrapped-continuation: pinned as a deliberate KNOWN LIMITATION (still
 #       rejected), including the assertion that the error states the remedy.
 #
+#   Issue #5298 adds the stale-section family, replayed from PR #4824 — a
+#   `## [1.3.5]` section assembled for a cut that never published, with newer
+#   fragments accumulating behind it. Against the pre-#5298 script the refusal
+#   named neither the stranded fragments nor a way forward, and `--merge` did
+#   not exist, so every case below FAILS on that script. Covered: the refusal
+#   enumerates the pending fragments and points at `--merge`; `--merge` appends
+#   to a category the section already has; `--merge` inserts a missing category
+#   in CATEGORY_ORDER position without duplicating an existing heading; sections
+#   above and below are untouched; fragments are consumed; and `--merge` against
+#   a section that does not exist is refused rather than silently downgraded to
+#   a fresh insert.
+#
 # Test: this IS the test. Run directly:
 #   bash scripts/assemble_changelog_selftest.sh
 #
@@ -292,6 +304,323 @@ Removed
 Changed
 EOF
 assert_case readme-placeholder-only 0 'no changelog fragments pending'
+
+# ===========================================================================
+# ISSUE #5298 — a stale `## [<version>]` section must never strand fragments.
+#
+# Replays PR #4824: `## [1.3.5]` was assembled for a cut that never published,
+# consuming its fragments, and newer fragments then accumulated behind it. The
+# fixture below carries all three placement shapes in one section — a category
+# the section already has (Fixed, appended to), one that sorts BEFORE an
+# existing heading (Breaking), and one that sorts after every existing heading
+# (Security, appended at the section end).
+# ===========================================================================
+
+# Creates crates/<name>/ carrying the stale [1.3.5] section plus an already
+# released [1.3.4] section below it, and prints the crate directory.
+new_stale_crate() {
+  local name="$1" dir="$TMP_ROOT/crates/$1"
+  mkdir -p "$dir/changelog.d"
+  cat >"$dir/CHANGELOG.md" <<'EOF'
+# Changelog
+
+---
+
+## [1.3.5] — 2026-08-04
+
+### Added
+
+- an entry consumed by the cut that never published (#4824)
+
+### Fixed
+
+- another entry consumed by that cut (#4824)
+
+## [1.3.4] — 2026-08-03
+
+### Breaking
+
+- a heading that belongs to a DIFFERENT section; the scan for "which headings
+  does the target section already have" must not see it, or `### Breaking`
+  would be deferred to the end of [1.3.5] instead of leading it
+
+### Fixed
+
+- older, already released and tagged
+EOF
+  echo "$dir"
+}
+
+# Same stale [1.3.5] section, but it is the LAST thing in the file — the shape a
+# crate's first release has. The merger reaches it through END rather than
+# through the next `## ` heading.
+new_stale_eof_crate() {
+  local name="$1" dir="$TMP_ROOT/crates/$1"
+  mkdir -p "$dir/changelog.d"
+  cat >"$dir/CHANGELOG.md" <<'EOF'
+# Changelog
+
+---
+
+## [1.3.5] — 2026-08-04
+
+### Added
+
+- an entry consumed by the cut that never published (#4824)
+EOF
+  echo "$dir"
+}
+
+seed_stale_fragments() {
+  local d="$1/changelog.d"
+  cat >"$d/4900-later-fixed.md" <<'EOF'
+Fixed
+
+- a bullet that accumulated AFTER the stale section was written (#4900)
+EOF
+  cat >"$d/4901-later-security.md" <<'EOF'
+Security
+
+- a category the stale section does not carry at all (#4901)
+EOF
+  cat >"$d/4902-later-breaking.md" <<'EOF'
+Breaking
+
+- a category that sorts ahead of every heading the section has (#4902)
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# 9. The default refusal must ENUMERATE the stranded fragments and name the way
+#    forward. A bare "refusing to insert a second one" is the dead end that made
+#    #4824 cost a manual reverse-apply of a merged commit.
+# ---------------------------------------------------------------------------
+stale_dir="$(new_stale_crate stale-refusal)"
+seed_stale_fragments "$stale_dir"
+
+stale_rc=0
+stale_out="$(bash "$ASSEMBLER" stale-refusal 1.3.5 2>&1)" || stale_rc=$?
+if [ "$stale_rc" -ne 1 ]; then
+  echo "FAIL: stale-refusal -> exit $stale_rc (expected 1)" >&2
+  fail=1
+else
+  echo "PASS: stale-refusal -> exit 1"
+fi
+for want in \
+  'changelog.d/4900-later-fixed.md' \
+  'changelog.d/4901-later-security.md' \
+  'changelog.d/4902-later-breaking.md' \
+  '--merge'; do
+  if grep -qF -- "$want" <<<"$stale_out"; then
+    echo "PASS: stale-refusal diagnostic names $want"
+  else
+    echo "FAIL: stale-refusal diagnostic does not name $want" >&2
+    printf '%s\n' "$stale_out" | sed 's/^/       /' >&2
+    fail=1
+  fi
+done
+
+# The refusal must also change nothing — neither the file nor the fragments.
+if [ "$(find "$stale_dir/changelog.d" -maxdepth 1 -name '*.md' | wc -l | tr -d ' ')" = "3" ]; then
+  echo "PASS: stale-refusal leaves all 3 fragments in place"
+else
+  echo "FAIL: stale-refusal consumed or lost fragments" >&2
+  fail=1
+fi
+
+# `--check` is what bump-version.sh runs as its pre-flight, so it owes the same
+# diagnostic rather than a bare refusal.
+check_rc=0
+check_out="$(bash "$ASSEMBLER" stale-refusal 1.3.5 --check 2>&1)" || check_rc=$?
+if [ "$check_rc" -eq 1 ] && grep -qF -- '--merge' <<<"$check_out"; then
+  echo "PASS: stale-refusal --check -> exit 1 and points at --merge"
+else
+  echo "FAIL: stale-refusal --check -> exit $check_rc without the --merge remedy" >&2
+  printf '%s\n' "$check_out" | sed 's/^/       /' >&2
+  fail=1
+fi
+
+# ---------------------------------------------------------------------------
+# 10. `--merge` folds the pending fragments INTO the existing section. The whole
+#     file is diffed against the expected result: appending to `### Fixed` must
+#     not duplicate that heading, `### Breaking` must land ahead of `### Added`,
+#     `### Security` at the section end, and the already-released [1.3.4]
+#     section below must come through byte-identical.
+# ---------------------------------------------------------------------------
+stale_dir="$(new_stale_crate stale-merge)"
+seed_stale_fragments "$stale_dir"
+
+merge_rc=0
+merge_out="$(bash "$ASSEMBLER" stale-merge 1.3.5 --merge 2>&1)" || merge_rc=$?
+if [ "$merge_rc" -ne 0 ]; then
+  echo "FAIL: stale-merge -> exit $merge_rc (expected 0)" >&2
+  printf '%s\n' "$merge_out" | sed 's/^/       /' >&2
+  fail=1
+else
+  echo "PASS: stale-merge -> exit 0"
+fi
+
+cat >"$TMP_ROOT/expected-merge.md" <<'EOF'
+# Changelog
+
+---
+
+## [1.3.5] — 2026-08-04
+
+### Breaking
+
+- a category that sorts ahead of every heading the section has (#4902)
+
+### Added
+
+- an entry consumed by the cut that never published (#4824)
+
+### Fixed
+
+- another entry consumed by that cut (#4824)
+- a bullet that accumulated AFTER the stale section was written (#4900)
+
+### Security
+
+- a category the stale section does not carry at all (#4901)
+
+## [1.3.4] — 2026-08-03
+
+### Breaking
+
+- a heading that belongs to a DIFFERENT section; the scan for "which headings
+  does the target section already have" must not see it, or `### Breaking`
+  would be deferred to the end of [1.3.5] instead of leading it
+
+### Fixed
+
+- older, already released and tagged
+EOF
+
+if diff -u "$TMP_ROOT/expected-merge.md" "$stale_dir/CHANGELOG.md" >"$TMP_ROOT/merge.diff" 2>&1; then
+  echo "PASS: stale-merge produces the expected CHANGELOG.md byte-for-byte"
+else
+  echo "FAIL: stale-merge CHANGELOG.md differs from expected" >&2
+  sed 's/^/       /' "$TMP_ROOT/merge.diff" >&2
+  fail=1
+fi
+
+# The fragments must be consumed in the SAME operation, exactly as the fresh
+# insert path does — a merge that leaves them pending would strand them again.
+if [ "$(find "$stale_dir/changelog.d" -maxdepth 1 -name '*.md' | wc -l | tr -d ' ')" = "0" ]; then
+  echo "PASS: stale-merge consumed all 3 fragments"
+else
+  echo "FAIL: stale-merge left fragments in changelog.d/" >&2
+  find "$stale_dir/changelog.d" -maxdepth 1 -name '*.md' | sed 's/^/       /' >&2
+  fail=1
+fi
+
+# And a second --merge is a clean no-op rather than a duplicate write.
+rerun_rc=0
+rerun_out="$(bash "$ASSEMBLER" stale-merge 1.3.5 --merge 2>&1)" || rerun_rc=$?
+if [ "$rerun_rc" -eq 0 ] && grep -qF 'no changelog fragments pending' <<<"$rerun_out" \
+  && diff -q "$TMP_ROOT/expected-merge.md" "$stale_dir/CHANGELOG.md" >/dev/null; then
+  echo "PASS: a second --merge is a no-op"
+else
+  echo "FAIL: a second --merge was not a no-op (exit $rerun_rc)" >&2
+  printf '%s\n' "$rerun_out" | sed 's/^/       /' >&2
+  fail=1
+fi
+
+# ---------------------------------------------------------------------------
+# 10b. The target section as the LAST section in the file — a crate's first
+#      release. The merger reaches the end of the section through END, not
+#      through a following `## ` heading.
+# ---------------------------------------------------------------------------
+eof_dir="$(new_stale_eof_crate stale-merge-eof)"
+cat >"$eof_dir/changelog.d/4903-eof-fixed.md" <<'EOF'
+Fixed
+
+- a bullet merged into the last section in the file (#4903)
+EOF
+
+eof_rc=0
+eof_out="$(bash "$ASSEMBLER" stale-merge-eof 1.3.5 --merge 2>&1)" || eof_rc=$?
+cat >"$TMP_ROOT/expected-eof.md" <<'EOF'
+# Changelog
+
+---
+
+## [1.3.5] — 2026-08-04
+
+### Added
+
+- an entry consumed by the cut that never published (#4824)
+
+### Fixed
+
+- a bullet merged into the last section in the file (#4903)
+EOF
+# The diff runs unconditionally so the failure branch always has a file to
+# print — short-circuiting it behind $eof_rc left `sed` reading a missing file
+# and, under `set -e`, aborted the whole selftest before its summary line.
+diff -u "$TMP_ROOT/expected-eof.md" "$eof_dir/CHANGELOG.md" >"$TMP_ROOT/eof.diff" 2>&1 || true
+if [ "$eof_rc" -eq 0 ] && [ ! -s "$TMP_ROOT/eof.diff" ]; then
+  echo "PASS: --merge into the last section in the file"
+else
+  echo "FAIL: --merge into the last section in the file (exit $eof_rc)" >&2
+  printf '%s\n' "$eof_out" | sed 's/^/       /' >&2
+  sed 's/^/       /' "$TMP_ROOT/eof.diff" >&2
+  fail=1
+fi
+
+# ---------------------------------------------------------------------------
+# 11. `--merge` against a version that has NO section is refused, never
+#     downgraded to a fresh insert. Silently doing something other than what was
+#     asked is the same fail-open shape this issue is about.
+# ---------------------------------------------------------------------------
+d="$(new_crate merge-without-section)"
+cat >"$d/1250-nothing-to-merge.md" <<'EOF'
+Added
+
+- a bullet with no existing section to merge into (#1250)
+EOF
+noseg_rc=0
+noseg_out="$(bash "$ASSEMBLER" merge-without-section 9.9.9 --merge 2>&1)" || noseg_rc=$?
+if [ "$noseg_rc" -eq 1 ] && grep -qF "has no '## [9.9.9]' section to merge into" <<<"$noseg_out"; then
+  echo "PASS: --merge without a target section -> exit 1"
+else
+  echo "FAIL: --merge without a target section -> exit $noseg_rc" >&2
+  printf '%s\n' "$noseg_out" | sed 's/^/       /' >&2
+  fail=1
+fi
+if [ -f "$d/1250-nothing-to-merge.md" ]; then
+  echo "PASS: --merge without a target section left the fragment in place"
+else
+  echo "FAIL: --merge without a target section deleted the fragment" >&2
+  fail=1
+fi
+
+# ---------------------------------------------------------------------------
+# 12. The fresh-insert path is unchanged by the #5298 refactor: a crate with no
+#     matching section still gets one written below the `---` separator, and its
+#     fragments consumed.
+# ---------------------------------------------------------------------------
+d="$(new_crate fresh-insert)"
+cat >"$d/1251-fresh.md" <<'EOF'
+Added
+
+- a bullet for a version that has no section yet (#1251)
+EOF
+fresh_rc=0
+fresh_out="$(bash "$ASSEMBLER" fresh-insert 2.0.0 2>&1)" || fresh_rc=$?
+fresh_log="$TMP_ROOT/crates/fresh-insert/CHANGELOG.md"
+if [ "$fresh_rc" -eq 0 ] \
+  && grep -qE '^## \[2\.0\.0\] — [0-9]{4}-[0-9]{2}-[0-9]{2}$' "$fresh_log" \
+  && grep -qF -- '- a bullet for a version that has no section yet (#1251)' "$fresh_log" \
+  && [ ! -f "$d/1251-fresh.md" ]; then
+  echo "PASS: fresh insert still writes the section and consumes the fragment"
+else
+  echo "FAIL: fresh insert regressed (exit $fresh_rc)" >&2
+  printf '%s\n' "$fresh_out" | sed 's/^/       /' >&2
+  sed 's/^/       /' "$fresh_log" >&2
+  fail=1
+fi
 
 if [ "$fail" -ne 0 ]; then
   echo "assemble_changelog_selftest: one or more fragment-validation cases FAILED." >&2


### PR DESCRIPTION
Closes #5298. Context and the #4824 incident are in the issue; not restated here.

## Direction chosen

Both arms the issue asked for, with the merge opt-in. Two review rounds folded in below.

The refusal was already loud (exit 1) — it was never a silent drop. What it was
is a dead end: it named neither the stranded fragments nor a way forward, and
hand-splicing `CHANGELOG.md` is banned. So:

- the refusal enumerates every pending fragment and states the two remedies
- `--merge` folds them into the existing section — appends to the
  `### <Category>` subsections it already has, inserts missing categories in
  `CATEGORY_ORDER` position, deletes the consumed fragments in the same operation
- `--merge` against a version with no section exits 1 rather than silently
  downgrading to a fresh insert

Merge is not the default because it rewrites a section that may already be
published and tagged, and the script cannot tell a phantom cut from a shipped
one. That call stays with the operator.

**Fail-open check.** The one new arm that could go fail-open is deleting
fragments on the strength of "awk exited 0". It does not: the merger records
every category it places, and `merge_fragments` refuses to delete anything
unless that report covers every pending category — `CHANGELOG.md` and
`changelog.d/` are left untouched on any shortfall, exit nonzero.

## Review round — plan-file marker collision (LOW, Promote)

`--merge` hands fragment bodies to awk in a plan file whose category boundaries
are `@@CATEGORY` + a tab. A body line beginning with that sequence is read as a
boundary, so bullets below it are filed under the smuggled category — and
`--merge` then deletes the fragment, the only other copy.

The placed-vs-expected set check does **not** catch this alone. When the
smuggled name is a category that is also independently pending, the placed set
and the expected set match either way. Reproduced on the pre-fix head
`c0bdea1f8` — two fragments, one `Fixed` carrying `@@CATEGORY<TAB>Removed`, one
genuinely `Removed`:

```
=== assemble-changelog.sh marker 1.3.5 --merge ===
Merged 2 fragment(s) into the existing [1.3.5] section of
crates/marker/CHANGELOG.md and removed them from changelog.d/.
EXIT=0

### Fixed

- a real Fixed bullet (#4910)

### Removed

- authored as Fixed prose, below that line     <-- misfiled
- a genuinely Removed bullet (#4911)

=== fragments remaining ===
0
```

**Severity correction.** The critic scored this LOW on "needs adversarial
content." The reproduction above is worse than that: the placed-vs-expected set
guard does not catch it, so the outcome is exit 0 with a misfiled bullet and
both fragments deleted. That is what justified fixing it in-PR rather than
deferring.

**Rejects rather than escapes.** Escaping would let malformed content through
and make the round-trip lossy — what ships would differ from what the author
wrote and reviewed, with no signal. A rejection costs one edit and says exactly
what to change.

Two choices worth stating:

- **Fires in every mode, not only `--merge`.** Whether a given release runs
  `--merge` is unknowable when the fragment is authored. Catching it at
  `--stdout`/`--check` costs the author one indent; catching it at release time
  costs the operator their inputs.
- **Fences are not exempt**, unlike `stray_category_lines()`. That guard may
  exempt fences because a human reads the rendered markdown; the plan reader is
  line-based awk that does not track fence state, so a fenced marker collides
  exactly as hard.

`PLAN_MARKER` is now one constant driving the writer, the awk reader, and the
guard, so they cannot drift.

## Rung

Rung 5 (release tooling). The diff contains **zero `.rs` files**
(`scripts/assemble-changelog.sh`, its selftest, `docs/reference/changelog-fragments.md`),
so rung 4's `cargo check --workspace` / per-consumer `cargo test` observe
nothing here — no Rust target references this script. Gates actually run, on the
rebased tree:

```
bash scripts/assemble_changelog_selftest.sh   -> EXIT=0  (51 assertions)
bash scripts/check_changelog_base_selftest.sh -> EXIT=0
bash scripts/check_changelog_fragment.sh      -> EXIT=0
bash scripts/check_line_cap.sh                -> EXIT=0
bash scripts/check_line_cap_selftest.sh       -> EXIT=0
bash scripts/check_sld.sh                     -> EXIT=0
bash scripts/check_public_docs.sh             -> EXIT=0
bash scripts/check_public_docs_selftest.sh    -> EXIT=0
shellcheck scripts/assemble-changelog.sh scripts/assemble_changelog_selftest.sh -> EXIT=0
cargo fmt --check                             -> EXIT=0
```

`code-critic` round: done, APPROVE with the one LOW above, fixed here.

## Regression evidence

**#5298 cases** against `origin/main`'s assembler (`2b0786a01`) — `--merge` is
not a recognised mode there (exit 2 = usage):

```
FAIL: stale-refusal diagnostic does not name changelog.d/4900-later-fixed.md
FAIL: stale-refusal diagnostic does not name changelog.d/4901-later-security.md
FAIL: stale-refusal diagnostic does not name changelog.d/4902-later-breaking.md
FAIL: stale-refusal diagnostic does not name --merge
FAIL: stale-refusal --check -> exit 1 without the --merge remedy
FAIL: stale-merge -> exit 2 (expected 0)
FAIL: stale-merge CHANGELOG.md differs from expected
FAIL: stale-merge left fragments in changelog.d/
FAIL: a second --merge was not a no-op (exit 2)
FAIL: --merge into the last section in the file (exit 2)
FAIL: --merge without a target section -> exit 2
```

**Marker cases** against the pre-fix branch head `c0bdea1f8`:

```
FAIL: plan-marker-collision -> exit 0 (expected 1)
FAIL: plan-marker-collision -> exit 0 (expected 1)
FAIL: plan-marker-in-fence -> exit 0 (expected 1)
FAIL: plan-marker --merge -> exit 0 (expected 1 with the marker diagnostic)
FAIL: plan-marker --merge mutated CHANGELOG.md or consumed a fragment
```

Against this branch, all 51 pass. The merge cases diff the whole `CHANGELOG.md`
byte-for-byte, so heading duplication, insertion order, and the untouched
sections above and below are all asserted at once. The false-positive cases
(marker in prose, indented, or followed by a space) pass on both revisions —
they assert non-regression, not the fix.

Rendering is byte-identical to `origin/main` across every crate with pending
fragments — 23 crates, 254 fragments, 6294 rendered lines, 0 differing. No live
fragment trips the new guard.

## Pre-existing reds on main — BOTH, not one

My first push disclosed one of two failures in run `31501782805`. Correcting
that; neither is from this branch, which touches zero `.rs` files.

**Shard 2** — `trusty-common`, `launchd_labels::tests::no_stray_launchd_label_literals_in_workspace_sources`:

```
launchd label literals not owned by `trusty_common::launchd_labels`:
  scripts/install-trusty-memory-signed.sh: com.trusty.trusty-memory
  scripts/install-trusty-memory-signed.sh: com.trusty.trusty-bm25-daemon
  scripts/install-trusty-memory-signed.sh: com.trusty.trusty-memory-mcp-bridge
test result: FAILED. 16 passed; 1 failed
```

That test scans `*.sh`, so the crate boundary alone is not the proof: the only
file it names is `scripts/install-trusty-memory-signed.sh`, which this branch
does not touch, and `git diff origin/main -- scripts/` contains no
`com.trusty.*` / `com.bobmatnyc.*` literal. A separate PR owns the fix.

**Shard 1** — `trusty-mpm`, `commands::managed::tests::session_resume_headless_dead_runtime_reconciles_and_restarts`:

```
thread 'commands::managed::tests::session_resume_headless_dead_runtime_reconciles_and_restarts'
panicked at crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs:613:5:
failed to create the real scratch tmux session
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1599 filtered out
```

Catalogued flake #4407 — a tmux scratch session the runner could not create.

## Changelog

No fragment owed — `scripts/**` is release tooling and the rest is docs. No
crate `src/**` changed, and the gate agrees: `changelog-fragment gate: scanned 3
changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.`

## Second review item — undeletable fragment, both write paths

Folded in rather than filed, per CLAUDE.md's Opportunistic Fixes rule.

Both write paths delete the consumed fragments *after* `CHANGELOG.md` is
replaced. Stating the old behaviour precisely: the bare `rm -f` did exit
nonzero, via a `set -e` abort carrying only rm's own `Permission denied`. What
it never said is the fact the operator actually needs — the section is
**already written**, so re-running adds those bullets a second time.

`delete_consumed_fragments()` now owns the step for both paths. It verifies each
fragment is gone by existence (not rm's single exit status for N files), and on
any survivor names it, states `CHANGELOG.md WAS ALREADY UPDATED`, and says not
to re-run. The success message is gated on its return, so a half-applied release
can never read as a completed one.

**Fixed in both paths deliberately.** The identical shape was already in the
default-write path on `origin/main`. Fixing only the merge path would leave the
same bug in the sibling and make the file inconsistent — worse to reason about
than either state alone.

**The asymmetry, on record:** `--merge` is the more damaging of the two. Its
re-run appends the surviving fragment to a section that *already contains* it;
the default-write path's re-run hits the already-has-a-section refusal instead.

Test lever is `chmod a-w` on `changelog.d/` — unlink needs write permission on
the directory. Root defeats that, so the cases **skip with a stated reason**
rather than reporting a spurious pass. Against the pre-fix head `8a174172b`:

```
FAIL: undeletable-fragment-merge diagnostic omits WAS ALREADY UPDATED
FAIL: undeletable-fragment-merge diagnostic omits Do NOT re-run
```

Only two assertions separate the revisions, and that is the honest measure of
this fix: the old path already exited 1 and rm already named the file. The
change is that the operator is now told the write landed and that re-running
duplicates.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
