### PR TITLE
ci: run version-parity on every PR so pr-version-bump can be a required check

### DIFF
--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -44,9 +44,24 @@
 #    not "loudly".
 name: Version parity
 
-# Optional workflow: PR and push events are limited to crate source/manifests
-# and the checkers themselves. The scheduled authority remains unfiltered and
-# re-asks the complete crates.io parity question every three hours.
+# `push` stays path-filtered to crate source/manifests and the checkers
+# themselves — the scheduled authority below remains unfiltered and re-asks
+# the complete crates.io parity question every three hours, so a filtered
+# push trigger can never open a coverage gap on main.
+#
+# `pull_request` carries NO path filter (issue #4421 follow-up). It used to —
+# first a `paths-ignore: [website/**, docs/**]`, later narrowed to a
+# `paths:` allowlist of crate/manifest/checker globs — but `pr-version-bump`
+# is about to become a REQUIRED branch-protection context, and a required
+# context that a path filter can skip goes permanently pending on any PR
+# that doesn't touch the allowlisted globs (proven on #5415/#5416: zero
+# `Version parity` runs against either head SHA). A required check must run
+# on every PR unconditionally, so the filter is gone rather than widened
+# again. This is cheap on unrelated PRs: `scripts/check-pr-version-bump.sh`
+# exits 0 with "[ OK ] ... none under crates/<crate>/src/**" the moment its
+# scan floor sees changed paths but zero of them under `crates/*/src/`, so a
+# docs-only or website-only PR still costs one shell scan-floor check, not a
+# skipped-forever gate.
 on:
   push:
     branches: [main]
@@ -70,17 +85,10 @@ on:
     # fires, so without it a stacked PR retargeted onto main never re-triggers
     # and can merge with zero checks — PR #3838 did exactly that.
     # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    #
+    # No `paths` / `paths-ignore` here — see the header comment above.
     types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
-    paths:
-      - "crates/*/src/**"
-      - "crates/*/Cargo.toml"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "scripts/check-version-parity.sh"
-      - "scripts/check-pr-version-bump.sh"
-      - "scripts/check_scan_floor_selftest.sh"
-      - ".github/workflows/version-parity.yml"
   workflow_dispatch: {}
 
 # Per-COMMIT concurrency group on push so a merge never cancels the previous


### PR DESCRIPTION
**Why.** `pr-version-bump` (display name `PR version bump vs crates.io (issue #4421)`) is to become a required branch-protection context. It cannot be today: the `pull_request` trigger carried a `paths:` allowlist (`crates/*/src/**`, manifests, the parity scripts), so a docs-only or website-only PR never triggers the workflow at all — the check does not appear, and a required-but-absent context is permanently pending. Verified empirically: [#5415](https://github.com/bobmatnyc/trusty-tools/issues/5415) (website-only) and [#5416](https://github.com/bobmatnyc/trusty-tools/issues/5416) have ZERO Version parity workflow runs against their head SHAs, confirmed through the Checks API.

**What changed.** The `paths:` block is removed from the `pull_request` trigger only; the `push` trigger's allowlist is untouched, since main's post-merge parity job is separately covered by the unfiltered 3-hourly `schedule` trigger, so filtering push opens no coverage gap. The header comment is rewritten: it previously asserted the filter was safe *because* this workflow is not required, an invariant this PR inverts.

**Cost on unrelated PRs is near zero**, verified in `scripts/check-pr-version-bump.sh`:
```
if [ -z "${touched}" ]; then
  echo "[ OK ] ${changed_count} changed path(s) examined; none under crates/<crate>/src/**"
  return 0
```

**Motivating incident.** [#5334](https://github.com/bobmatnyc/trusty-tools/issues/5334) edited `crates/trusty-common/src/mcp/{mod,openrpc}.rs` doc comments without bumping trusty-common, whose 0.31.0 was already published. `pr-version-bump` RAN and reported FAIL — and the PR merged anyway, because the check is advisory. Main went red on version-parity and needed [#5435](https://github.com/bobmatnyc/trusty-tools/issues/5435) to clear it. Tracked in [#5432](https://github.com/bobmatnyc/trusty-tools/issues/5432); [#5094](https://github.com/bobmatnyc/trusty-tools/issues/5094) is where the check was deliberately kept advisory, so this reverses that call knowingly.

**🔴 FOLLOW-UP REQUIRED AFTER MERGE.** Merging this alone changes no gate. Branch protection must then be patched to add `PR version bump vs crates.io (issue #4421)` to `required_status_checks.contexts`, via the narrow `.../protection/required_status_checks` endpoint, resending `strict: true` and all five existing contexts verbatim (the array replaces, it does not merge). Before patching, confirm the check now appears on a docs-only PR — this PR's own run does not prove that, since it touches `.github/**`.

**Gates.** No Rust source changed, so no cargo gates apply. YAML parse-validated. `scripts/check_changelog_fragment.sh` exit 0 (CI-only, exempt).

References: [#5432](https://github.com/bobmatnyc/trusty-tools/issues/5432), [#5334](https://github.com/bobmatnyc/trusty-tools/issues/5334), [#5094](https://github.com/bobmatnyc/trusty-tools/issues/5094), [#5395](https://github.com/bobmatnyc/trusty-tools/issues/5395).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
