### PR TITLE
ci: report on every PR so the pointer lint and SemVer gate can be required (#5311)

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -43,6 +43,23 @@
 # therefore produces a real verdict wherever in the sequence it lands, and no
 # ordering between tag and publish needs to hold for it to mean anything.
 #
+# AND IT ALSO RUNS ON PULL REQUESTS, WITHOUT RESTORING WHAT #5149 REMOVED
+# (#5311). `Public API / SemVer` is meant to be a required branch-protection
+# context. Tag-push-only means the context does not exist on a pull request at
+# all, and GitHub waits forever on a required context that never reports — so
+# requiring it today makes every PR in the repo unmergeable. The workflow
+# therefore runs on `pull_request` too, unfiltered, and decides INSIDE the job
+# whether there is anything to compare: `scripts/detect-version-bumps.sh` reads
+# the diff and answers "does this branch declare a version it did not start
+# with". No, on the overwhelming majority of PRs — one git diff, then a success
+# that says so. #5149's cost is untouched: the pinned tool and the cold rustdoc
+# cache are installed only once the answer is yes.
+#
+# Yes is a release PR, and running there is the point. This workspace bumps a
+# crate's version in a PR and cuts the `<crate>-v<version>` tag from merged main
+# afterwards, so the bump PR is strictly EARLIER than the trigger above — a
+# break surfaces while the release can still be reworked, with no tag in flight.
+#
 # ON-DEMAND: workflow_dispatch takes a crate name so a break can be checked
 # without cutting a release. `bash scripts/check_semver.sh --crate <crate>`
 # does the same thing locally.
@@ -52,6 +69,12 @@ on:
   push:
     tags:
       - "*-v*"
+  pull_request:
+    # Explicit activity types (#4179), matching ci.yml and version-parity.yml:
+    # `edited` is not in GitHub's default set and is the event a base-branch
+    # RETARGET fires. No `paths` / `paths-ignore` — see #5311 above.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+    branches: [main]
   workflow_dispatch:
     inputs:
       crate:
@@ -61,45 +84,93 @@ on:
 
 concurrency:
   group: semver-checks-${{ github.ref }}
-  cancel-in-progress: true
+  # `edited` is excluded on pull requests (#4179 shape): that run is not
+  # cancelled, so it must be a real one rather than a cheaper answer racing the
+  # run it coexists with.
+  cancel-in-progress: ${{ github.event_name != 'pull_request' || github.event.action != 'edited' }}
 
 jobs:
   semver-checks:
     name: Public API / SemVer
+    # #5311: NO job-level `if:`. A job whose `if:` is false concludes `skipped`,
+    # and a skipped conclusion does not satisfy a required context — the PR waits
+    # on it forever. Whether this gate does any work is decided per-step below,
+    # from the diff.
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    # #5311: was 40. The tag path checks one crate; a release PR can declare
+    # several, and they are compared serially in this one job.
+    timeout-minutes: 60
     steps:
+      # fetch-depth: 0 — the pull-request path needs `git merge-base` and
+      # `git show <merge-base>:crates/<X>/Cargo.toml`, neither of which a
+      # shallow checkout can resolve.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
-      # The tag prefix is whichever accepted form the tagger used —
-      # `tga-v1.4.2` and `trusty-git-analytics-v1.4.2` are both valid tags for
-      # the same crate (#1128). check_semver.sh's `--crate` accepts either, so
-      # no alias table is duplicated here.
-      - name: Resolve crate to check
+      # #4688: diff against the base branch AS IT IS NOW, not the frozen
+      # `base.sha` snapshot, so the merge base cannot lag behind the merge ref's
+      # own first parent and sweep another author's bump into this PR's diff.
+      - name: Refresh the base branch ref
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch --no-tags --quiet origin \
+            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          git rev-parse --verify "refs/remotes/origin/${BASE_REF}"
+
+      # Three triggers, three ways to name what is under test:
+      #   tag push          — the tag prefix, in whichever accepted form the
+      #                       tagger used. `tga-v1.4.2` and
+      #                       `trusty-git-analytics-v1.4.2` are both valid tags
+      #                       for the same crate (#1128), and `--crate` accepts
+      #                       either, so no alias table is duplicated here.
+      #   workflow_dispatch — the crate the operator typed.
+      #   pull_request      — #5311: every crate whose declared version this
+      #                       branch changed, read from the diff by
+      #                       scripts/detect-version-bumps.sh. None is the
+      #                       normal answer and means no release is under test.
+      - name: Select crates to check
         id: crate
         env:
           TAG: ${{ github.ref_name }}
           INPUT_CRATE: ${{ inputs.crate }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            NAME="$INPUT_CRATE"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            NAMES="$(
+              VERSION_BUMP_BASE="origin/${BASE_REF}" \
+                bash scripts/detect-version-bumps.sh | sed -n 's/^bumped_crates=//p'
+            )"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            NAMES="$INPUT_CRATE"
           else
-            NAME="$(printf '%s' "$TAG" | sed -E 's/-v[0-9].*$//')"
+            NAMES="$(printf '%s' "$TAG" | sed -E 's/-v[0-9].*$//')"
             # An unchanged string means the sed matched nothing, i.e. the ref is
             # not <crate>-v<version>. Resolving it would hand check_semver.sh a
             # crate name that does not exist and read as a tooling error.
-            if [[ "$NAME" == "$TAG" ]]; then
+            if [[ "$NAMES" == "$TAG" ]]; then
               echo "::error::Ref '${TAG}' is not a <crate>-v<version> release tag."
               exit 1
             fi
           fi
-          if [[ -z "$NAME" ]]; then
+          # An empty selection is a legitimate verdict on a pull request and a
+          # tooling error anywhere else — a tag push or a manual dispatch names
+          # its crate by construction, so nothing there can leave this blank.
+          if [[ -z "$NAMES" && "${{ github.event_name }}" != "pull_request" ]]; then
             echo "::error::Empty crate name — nothing to check."
             exit 1
           fi
-          echo "crate=${NAME}" >> "$GITHUB_OUTPUT"
-          echo "Checking crate: ${NAME}"
+          echo "crates=${NAMES}" >> "$GITHUB_OUTPUT"
+          if [[ -n "$NAMES" ]]; then
+            echo "have_work=true" >> "$GITHUB_OUTPUT"
+            echo "Checking crate(s): ${NAMES}"
+          else
+            echo "have_work=false" >> "$GITHUB_OUTPUT"
+            echo "No crate declares a new version in this diff."
+          fi
 
       # STABLE, DELIBERATELY NOT THE MSRV 1.94 THIS REPO PINS (#5289).
       # cargo-semver-checks builds rustdoc in a scratch project that ignores this
@@ -110,7 +181,13 @@ jobs:
       # costs no coverage; MSRV compliance is ci.yml's job and is untouched.
       # check_semver.sh makes the same choice locally by picking the newest
       # installed toolchain, so CI and a developer's machine agree.
+      #
+      # #5311: this step and the three below are the 20+ minutes #5149 refused
+      # to pay on every PR, so they are gated on there being a release under
+      # test. STEP-level, never job-level: a skipped JOB does not satisfy a
+      # required context.
       - name: Install stable toolchain
+        if: steps.crate.outputs.have_work == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       # A prebuilt binary, PINNED. `cargo install cargo-semver-checks` compiles
@@ -120,11 +197,13 @@ jobs:
       # also never touches this workspace's Cargo.lock — refreshing that turns
       # the MSRV 1.94 job red (see CLAUDE.md).
       - name: Install cargo-semver-checks (pinned prebuilt)
+        if: steps.crate.outputs.have_work == 'true'
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-semver-checks@0.50.0
 
       - name: Cache cargo artifacts
+        if: steps.crate.outputs.have_work == 'true'
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: semver-checks
@@ -135,6 +214,7 @@ jobs:
       # Runs BEFORE the real gate, matching line-cap.yml's selftest-then-gate
       # ordering: a gate that cannot fail makes the real run's green meaningless.
       - name: SemVer gate selftest (must refuse a blind run)
+        if: steps.crate.outputs.have_work == 'true'
         run: bash scripts/check_semver_selftest.sh
 
       # The two nonzero statuses are annotated differently ON PURPOSE (#5289).
@@ -144,18 +224,39 @@ jobs:
       # pass — but a reader must be able to tell which one they are looking at
       # from the annotation alone.
       - name: Enforce public-API SemVer against crates.io
+        if: steps.crate.outputs.have_work == 'true'
         env:
           SKIP_UI_BUILD: '1'
-          CRATE: ${{ steps.crate.outputs.crate }}
+          CRATES: ${{ steps.crate.outputs.crates }}
         run: |
+          # One `--crate` per selected crate: check_semver.sh accumulates them
+          # and reports a single verdict over the whole set, so a release PR
+          # that bumps several gets one pass through the tool rather than N.
+          args=()
+          for c in $CRATES; do
+            args+=(--crate "$c")
+          done
           rc=0
-          bash scripts/check_semver.sh --crate "$CRATE" || rc=$?
+          bash scripts/check_semver.sh "${args[@]}" || rc=$?
           if [[ "$rc" -eq 0 ]]; then
             exit 0
           fi
           if [[ "$rc" -eq 3 ]]; then
-            echo "::error title=SemVer gate could not run::No verdict was computed for ${CRATE}. cargo-semver-checks never completed a comparison (see the log), so whether this release breaks the public API is UNKNOWN. Do not read this as a required version bump, and do not publish on it."
+            echo "::error title=SemVer gate could not run::No verdict was computed for ${CRATES}. cargo-semver-checks never completed a comparison (see the log), so whether this release breaks the public API is UNKNOWN. Do not read this as a required version bump, and do not publish on it."
           else
-            echo "::error title=SemVer break::${CRATE} has a breaking public-API change without a breaking version bump. See the failing lints in the log."
+            echo "::error title=SemVer break::${CRATES} has a breaking public-API change without a breaking version bump. See the failing lints in the log."
           fi
           exit "$rc"
+
+      # #5311: the no-op path, and it must EXECUTE rather than be skipped —
+      # `skipped` does not satisfy a required context. Nothing in this diff
+      # declares a version, so nothing is being released and there is nothing to
+      # compare against the registry. The verdict for the release itself is
+      # still owned by scripts/preflight-publish.sh CHECK 5 and by the tag-push
+      # run of this same workflow; neither is weakened by this branch.
+      - name: No release under test — nothing to compare
+        if: steps.crate.outputs.have_work != 'true'
+        run: |
+          echo "No crate's declared version changed against the base branch, so this"
+          echo "branch releases nothing and there is no registry baseline to compare."
+          echo "Reporting success rather than not reporting at all — see #5311."

--- a/.github/workflows/test-pointers.yml
+++ b/.github/workflows/test-pointers.yml
@@ -95,10 +95,10 @@ jobs:
 
       # #5311: the `paths:` filter this replaces on the pull_request trigger.
       # Asked here, the job still reports on a PR that changes none of the
-      # lint's inputs — which is what a required context needs. Every other
-      # event (`push` is already path-filtered, `workflow_dispatch` is a
-      # deliberate manual run) resolves to `true`, so the only direction this
-      # step can take is toward running the gate.
+      # lint's inputs — which is what a required context needs. The `else` arm
+      # is the `push` trigger, the only other one this workflow has: it keeps
+      # its `paths:` filter, so a push that reaches this job already changed a
+      # lint input and the answer is `true` by construction.
       - name: Classify pointer-lint inputs from the diff
         id: detect
         env:

--- a/.github/workflows/test-pointers.yml
+++ b/.github/workflows/test-pointers.yml
@@ -11,8 +11,20 @@
 # its own lightweight job (matches ci.yml / line-cap.yml's checkout style).
 name: Test pointers
 
-# This optional gate scans tracked Rust files only, so use an allowlist of its
-# actual inputs rather than making every new repository path opt in by default.
+# `push` stays path-filtered to the lint's actual inputs.
+#
+# #5311: `pull_request` no longer is. This gate is meant to become a REQUIRED
+# branch-protection context — a red pointer lint nearly merged during the 1.3.5
+# train and was caught only because the merge agent had been told to treat it as
+# blocking regardless of what GitHub showed. A required context that a path
+# filter can skip is unmergeable rather than fast: GitHub never creates the check
+# run for a workflow its filters skipped, so the context stays pending forever
+# (proven on #5415/#5416 for the sibling `Version parity` workflow — zero runs
+# against either head SHA). The same globs still decide whether the lint does any
+# work; they moved from this trigger into
+# `scripts/detect-pointer-lint-inputs.sh`, which the always-running job below
+# consults. A PR that changes none of them costs a checkout and one git diff and
+# still REPORTS, instead of never reporting at all.
 on:
   push:
     branches: [main]
@@ -21,6 +33,7 @@ on:
       - ".test-pointer-allowlist.tsv"
       - "scripts/check_test_pointers.sh"
       - "scripts/check_scan_floor_selftest.sh"
+      - "scripts/detect-pointer-lint-inputs.sh"
       - ".github/workflows/test-pointers.yml"
   pull_request:
     # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
@@ -28,14 +41,10 @@ on:
     # fires, so without it a stacked PR retargeted onto main never re-triggers
     # and can merge with zero checks — PR #3838 did exactly that.
     # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    #
+    # No `paths` / `paths-ignore` here — see the header comment above.
     types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
-    paths:
-      - "**/*.rs"
-      - ".test-pointer-allowlist.tsv"
-      - "scripts/check_test_pointers.sh"
-      - "scripts/check_scan_floor_selftest.sh"
-      - ".github/workflows/test-pointers.yml"
 
 # Per-COMMIT concurrency group on push so a merge never cancels the previous
 # merge's verification (#4179); per-ref group on pull_request so a new push
@@ -47,7 +56,12 @@ concurrency:
 jobs:
   test-pointers:
     name: "Doc-comment pointer lint (Why/What/Test)"
-    if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
+    # #5311: NO job-level `if:`. A job whose `if:` is false concludes `skipped`,
+    # and a skipped conclusion does not satisfy a required context — the PR waits
+    # on it forever. The condition that used to live here also decided from the
+    # ACTIVITY TYPE (`edited` with a null changes.base), which is the #5407 defect
+    # shape: a decision about the event, never about the diff. Whether this gate
+    # does any work is now decided per-step, from the diff, below.
     runs-on: ubuntu-latest
     # #4882: was 5. Measured 2026-08-05: the lint itself legitimately took
     # 352s locally (close to CI's observed 303s the run that got cancelled),
@@ -60,7 +74,42 @@ jobs:
     # margin. 10 minutes gives ~3x headroom over the post-fix measurement.
     timeout-minutes: 10
     steps:
+      # fetch-depth: 0 — the relevance classifier below needs `git merge-base`
+      # against the base branch, which a shallow checkout cannot resolve.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      # #4688: diff against the base branch AS IT IS NOW, not the frozen
+      # `base.sha` snapshot. checkout leaves refs/remotes/origin/<base> at
+      # whatever it fetched; re-fetching pins it to the live tip so the merge
+      # base cannot lag behind the merge ref's own first parent.
+      - name: Refresh the base branch ref
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch --no-tags --quiet origin \
+            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          git rev-parse --verify "refs/remotes/origin/${BASE_REF}"
+
+      # #5311: the `paths:` filter this replaces on the pull_request trigger.
+      # Asked here, the job still reports on a PR that changes none of the
+      # lint's inputs — which is what a required context needs. Every other
+      # event (`push` is already path-filtered, `workflow_dispatch` is a
+      # deliberate manual run) resolves to `true`, so the only direction this
+      # step can take is toward running the gate.
+      - name: Classify pointer-lint inputs from the diff
+        id: detect
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            POINTER_LINT_BASE="origin/${BASE_REF}" \
+              bash scripts/detect-pointer-lint-inputs.sh > /dev/null
+          else
+            echo "pointer_inputs_changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       # Scan-floor mutation self-test (issue #4618): re-proves in CI that this
       # gate REFUSES a vacuous scan. Without it the floor is untested code and a
@@ -68,7 +117,21 @@ jobs:
       # Runs before the real gate — a gate that cannot fail makes the real run's
       # green meaningless. Mirrors line-cap.yml's selftest-then-gate ordering.
       - name: Scan-floor selftest (must refuse an empty scan)
+        if: steps.detect.outputs.pointer_inputs_changed == 'true'
         run: bash scripts/check_scan_floor_selftest.sh test_pointers
 
       - name: "Lint Test: doc-comment pointers against real test names"
+        if: steps.detect.outputs.pointer_inputs_changed == 'true'
         run: bash scripts/check_test_pointers.sh
+
+      # #5311: the no-op path, and it must EXECUTE rather than be skipped —
+      # `skipped` does not satisfy a required context. The job runs, this step
+      # runs, and the check reports success on a PR the lint cannot have an
+      # opinion about.
+      - name: No pointer-lint input changed — nothing to lint
+        if: steps.detect.outputs.pointer_inputs_changed != 'true'
+        run: |
+          echo "No changed path is a Test:-pointer input (**/*.rs, the allowlist,"
+          echo "the gate scripts, or this workflow), so scripts/check_test_pointers.sh"
+          echo "would report exactly what it reported on the base branch."
+          echo "Reporting success rather than not reporting at all — see #5311."

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -549,7 +549,11 @@ git -C "${added_repo}" commit -qm "add gamma"
 assert_eq "crate added by the branch"       "gamma" "$(bumps_of "${added_repo}")"
 
 # An inherited version declares nothing in the crate's own manifest, so there is
-# nothing here to compare — and the workspace-level bump is its own diff entry.
+# nothing here to compare. Nothing else picks the crate up either: the loop only
+# inspects `crates/*/Cargo.toml`, so a root-manifest change is never examined.
+# That gap is unreachable in this workspace — #343 removed the workspace
+# `version` field and every crate declares a literal one — and this case pins the
+# behavior in case one ever starts inheriting.
 inherit_repo="${BUMP_DIR}/inherited"
 make_bump_repo "${inherit_repo}" ""
 printf '[package]\nname = "alpha"\nversion.workspace = true\n' \

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -435,6 +435,195 @@ assert_eq "ci.yml has no inlined SDK purge left" "0" \
 assert_eq "all four disk-reclaim jobs call the helper" "4" \
   "$(grep -c 'bash scripts/ci-free-disk-space.sh' "${ci_wf}" || true)"
 
+# ---------------------------------------------------------------------------
+# detect-pointer-lint-inputs.sh (#5311)
+# ---------------------------------------------------------------------------
+pointer_inputs_of() {
+  printf '%s' "$1" | bash scripts/detect-pointer-lint-inputs.sh 2>/dev/null |
+    sed -n 's/^pointer_inputs_changed=//p'
+}
+
+echo
+echo "detect-pointer-lint-inputs:"
+assert_eq "crate source"              "true"  "$(pointer_inputs_of 'crates/trusty-mpm/src/lib.rs')"
+assert_eq "integration test"          "true"  "$(pointer_inputs_of 'crates/trusty-mpm/tests/x.rs')"
+assert_eq "build script"              "true"  "$(pointer_inputs_of 'crates/trusty-mpm/build.rs')"
+assert_eq "the allowlist"             "true"  "$(pointer_inputs_of '.test-pointer-allowlist.tsv')"
+assert_eq "the gate itself"           "true"  "$(pointer_inputs_of 'scripts/check_test_pointers.sh')"
+assert_eq "the scan-floor selftest"   "true"  "$(pointer_inputs_of 'scripts/check_scan_floor_selftest.sh')"
+assert_eq "this classifier"           "true"  "$(pointer_inputs_of 'scripts/detect-pointer-lint-inputs.sh')"
+assert_eq "the workflow wiring"       "true"  "$(pointer_inputs_of '.github/workflows/test-pointers.yml')"
+assert_eq "documentation"             "false" "$(pointer_inputs_of 'docs/adr/0001-example.md')"
+assert_eq "website"                   "false" "$(pointer_inputs_of 'website/src/routes/+page.svelte')"
+assert_eq "an unrelated workflow"     "false" "$(pointer_inputs_of '.github/workflows/ci.yml')"
+assert_eq "a manifest"                "false" "$(pointer_inputs_of 'crates/trusty-mpm/Cargo.toml')"
+assert_eq "mixed docs + Rust"         "true"  "$(pointer_inputs_of 'docs/a.md
+crates/trusty-mpm/src/lib.rs')"
+assert_eq "empty diff (fail closed)"  "true"  "$(pointer_inputs_of '')"
+
+# The trap this classifier exists to avoid, asserted as a difference: the
+# Cargo-inert helper calls the lint's own inputs inert (true for a cargo build),
+# so reusing it here would skip the gate on exactly the PR that removes a fixed
+# allowlist entry — the failure mode check_test_pointers.sh is built to catch.
+assert_eq "detect-docs-only calls the allowlist inert" "true" \
+  "$(docs_only_of '.test-pointer-allowlist.tsv')"
+assert_eq "this classifier does not"                   "true" \
+  "$(pointer_inputs_of '.test-pointer-allowlist.tsv')"
+
+# ---------------------------------------------------------------------------
+# detect-version-bumps.sh (#5311)
+# ---------------------------------------------------------------------------
+# Under STUB_DIR so the EXIT trap set above still cleans it up — a second
+# `trap ... EXIT` would replace the first and leak the earlier fixtures.
+BUMP_DIR="${STUB_DIR}/versionbumps"
+mkdir -p "${BUMP_DIR}"
+
+# make_bump_repo <dir> <head-version-or-DELETE> [extra-crate-head-version]
+make_bump_repo() {
+  local dir="$1" head_version="$2" extra="${3:-}"
+  rm -rf "${dir}"
+  mkdir -p "${dir}/crates/alpha/src" "${dir}/crates/beta/src" "${dir}/docs"
+  git -C "${dir}" init -q -b base-ref
+  git -C "${dir}" config user.email ci@example.com
+  git -C "${dir}" config user.name ci
+  printf '[package]\nname = "alpha"\nversion = "1.0.0"\n' >"${dir}/crates/alpha/Cargo.toml"
+  printf '[package]\nname = "beta"\nversion = "2.0.0"\n' >"${dir}/crates/beta/Cargo.toml"
+  echo "// base" >"${dir}/crates/alpha/src/lib.rs"
+  echo "// base" >"${dir}/crates/beta/src/lib.rs"
+  echo "docs" >"${dir}/docs/readme.md"
+  git -C "${dir}" add -A
+  git -C "${dir}" commit -qm base
+  git -C "${dir}" checkout -q -b pr-branch
+
+  # Every branch changes crate source; only the version line varies. That is the
+  # whole point — "source changed" must NOT be what selects a crate here.
+  echo "// changed" >>"${dir}/crates/alpha/src/lib.rs"
+  if [ "${head_version}" = "DELETE" ]; then
+    rm -rf "${dir}/crates/alpha"
+  elif [ -n "${head_version}" ]; then
+    printf '[package]\nname = "alpha"\nversion = "%s"\n' "${head_version}" \
+      >"${dir}/crates/alpha/Cargo.toml"
+  fi
+  if [ -n "${extra}" ]; then
+    printf '[package]\nname = "beta"\nversion = "%s"\n' "${extra}" \
+      >"${dir}/crates/beta/Cargo.toml"
+  fi
+  git -C "${dir}" add -A
+  git -C "${dir}" commit -qm head
+}
+
+# bumps_of <dir> — the emitted crate list, or `ERR<exit>` when it fails closed.
+bumps_of() {
+  local dir="$1" out rc=0
+  mkdir -p "${dir}/scripts"
+  cp scripts/detect-version-bumps.sh "${dir}/scripts/detect-version-bumps.sh"
+  out="$(cd "${dir}" && VERSION_BUMP_BASE=base-ref bash scripts/detect-version-bumps.sh 2>/dev/null)" || rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "ERR${rc}"
+    return 0
+  fi
+  printf '%s' "${out}" | sed -n 's/^bumped_crates=//p'
+}
+
+echo
+echo "detect-version-bumps:"
+make_bump_repo "${BUMP_DIR}/unbumped" ""
+assert_eq "source changed, no version bump" "" "$(bumps_of "${BUMP_DIR}/unbumped")"
+make_bump_repo "${BUMP_DIR}/bumped" "1.0.1"
+assert_eq "version bumped"                  "alpha" "$(bumps_of "${BUMP_DIR}/bumped")"
+make_bump_repo "${BUMP_DIR}/multi" "1.0.1" "2.1.0"
+assert_eq "two crates bumped"               "alpha beta" "$(bumps_of "${BUMP_DIR}/multi")"
+make_bump_repo "${BUMP_DIR}/removed" "DELETE"
+assert_eq "crate deleted by the branch"     "" "$(bumps_of "${BUMP_DIR}/removed")"
+
+# A crate this branch ADDS has no base manifest to compare, and that is a bump:
+# check_semver.sh then records its own "never published — no baseline" skip
+# rather than this classifier guessing on its behalf.
+added_repo="${BUMP_DIR}/added"
+make_bump_repo "${added_repo}" ""
+mkdir -p "${added_repo}/crates/gamma/src"
+printf '[package]\nname = "gamma"\nversion = "0.1.0"\n' >"${added_repo}/crates/gamma/Cargo.toml"
+echo "// new" >"${added_repo}/crates/gamma/src/lib.rs"
+git -C "${added_repo}" add -A
+git -C "${added_repo}" commit -qm "add gamma"
+assert_eq "crate added by the branch"       "gamma" "$(bumps_of "${added_repo}")"
+
+# An inherited version declares nothing in the crate's own manifest, so there is
+# nothing here to compare — and the workspace-level bump is its own diff entry.
+inherit_repo="${BUMP_DIR}/inherited"
+make_bump_repo "${inherit_repo}" ""
+printf '[package]\nname = "alpha"\nversion.workspace = true\n' \
+  >"${inherit_repo}/crates/alpha/Cargo.toml"
+git -C "${inherit_repo}" add -A
+git -C "${inherit_repo}" commit -qm "inherit version"
+assert_eq "version.workspace = true"        "" "$(bumps_of "${inherit_repo}")"
+
+# SCAN FLOOR: an empty diff means the base ref is wrong or the checkout is
+# shallow. "No release under test" must never be the conclusion drawn from a
+# lookup that failed, so this exits non-zero instead of reporting a clean set.
+empty_repo="${BUMP_DIR}/empty"
+make_bump_repo "${empty_repo}" "1.0.1"
+git -C "${empty_repo}" checkout -q base-ref
+assert_eq "empty diff fails closed"         "ERR2" "$(bumps_of "${empty_repo}")"
+
+# ---------------------------------------------------------------------------
+# #5311 wiring: a required context must RUN and REPORT on every PR.
+#
+# Two ways to break that, and both are invisible in a diff review until a PR
+# hangs: a `paths:` filter on the pull_request trigger (GitHub creates no check
+# run at all, so the context stays pending forever — observed on #5415/#5416 for
+# version-parity) and a job-level `if:` (the job concludes `skipped`, which does
+# not satisfy the requirement). Assert the absence of both, structurally.
+# ---------------------------------------------------------------------------
+echo
+echo "required-context wiring (#5311):"
+
+# pr_trigger_block <workflow> — the pull_request trigger's own lines, from
+# `  pull_request:` to the next top-level `on:` key or the `concurrency:` block.
+#
+# awk, not a `sed` range: `\|` alternation is a GNU BRE extension, so a
+# sed-range end pattern silently never matches under BSD sed and the "block"
+# becomes the whole file — an assertion that passes for the wrong reason on a
+# developer's machine and a different one in CI.
+pr_trigger_block() {
+  awk '
+    /^  pull_request:/ { inblk = 1; next }
+    inblk && /^[^[:space:]]/ { exit }   # a new top-level key (concurrency:, jobs:)
+    inblk && /^  [^[:space:]]/ { exit } # a sibling trigger (push:, workflow_dispatch:)
+    inblk { print }
+  ' "$1"
+}
+
+for wf in .github/workflows/test-pointers.yml .github/workflows/semver-checks.yml; do
+  assert_eq "${wf##*/}: pull_request trigger has no paths filter" "0" \
+    "$(grep -cE '^    paths(-ignore)?:' <<<"$(pr_trigger_block "${wf}")" || true)"
+  # `    if:` at four-space indent is a JOB-level condition; step-level ones are
+  # indented six and are the prescribed mechanism, so they must not be counted.
+  assert_eq "${wf##*/}: no job-level if: can skip the gate" "0" \
+    "$(grep -cE '^    if:' "${wf}" || true)"
+  assert_eq "${wf##*/}: has a no-op step that reports success" "1" \
+    "$(grep -cE "^      - name: No .* — nothing to (lint|compare)$" "${wf}" || true)"
+done
+
+assert_eq "semver-checks runs on pull requests at all" "1" \
+  "$(grep -c '^  pull_request:' .github/workflows/semver-checks.yml || true)"
+assert_eq "semver-checks selects crates from the diff, not the event" "1" \
+  "$(grep -c 'bash scripts/detect-version-bumps.sh' .github/workflows/semver-checks.yml || true)"
+assert_eq "test-pointers classifies from the diff, not the event" "1" \
+  "$(grep -c 'bash scripts/detect-pointer-lint-inputs.sh' .github/workflows/test-pointers.yml || true)"
+# Structural, not string-matched on the old condition: the banned thing is any
+# gate verdict taken from the ACTIVITY TYPE (#5407). `concurrency:` may still
+# name it — that decides what gets cancelled, never what gets checked — so the
+# assertion is scoped to the jobs the checks report from.
+assert_eq "no gate in test-pointers branches on the activity type" "0" \
+  "$(grep -c 'github\.event\.action' <<<"$(sed -n '/^jobs:/,$p' .github/workflows/test-pointers.yml)" || true)"
+assert_eq "no gate in semver-checks branches on the activity type" "0" \
+  "$(grep -c 'github\.event\.action' <<<"$(sed -n '/^jobs:/,$p' .github/workflows/semver-checks.yml)" || true)"
+# The expensive half of the SemVer gate stays behind the diff verdict — this is
+# what keeps #5149's "not 20 minutes on every PR" true while the context reports.
+assert_eq "semver-checks gates its costly steps on there being work" "5" \
+  "$(grep -c "if: steps.crate.outputs.have_work == 'true'" .github/workflows/semver-checks.yml || true)"
+
 echo
 if [ "${FAILURES}" -gt 0 ]; then
   echo "check-ci-helpers-selftest: ${FAILURES}/${CASES} case(s) FAILED"

--- a/scripts/detect-pointer-lint-inputs.sh
+++ b/scripts/detect-pointer-lint-inputs.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# detect-pointer-lint-inputs.sh — does a change set touch anything the
+# doc-comment pointer lint reads? (issue #5311)
+#
+# Why: `.github/workflows/test-pointers.yml` used a `paths:` trigger filter to
+#   stay off PRs that cannot change its verdict. GitHub never creates the check
+#   runs for a workflow its filters skipped, so the moment
+#   `Doc-comment pointer lint (Why/What/Test)` becomes a REQUIRED
+#   branch-protection context, every PR that does not match those globs goes
+#   permanently pending and cannot merge. Proven on #5415/#5416 for the sibling
+#   `Version parity` workflow: zero runs against either head SHA. The filter
+#   therefore moves OFF the trigger and INTO the job, where the same question is
+#   asked and the job still reports. Same remedy, same reasoning, as
+#   scripts/detect-docs-only.sh's header.
+#
+# What: reads a newline-separated list of changed paths on stdin (or resolves
+#   one itself from git when given a base ref) and answers ONE question: could
+#   any changed path change what `scripts/check_test_pointers.sh` reports?
+#   Emits `pointer_inputs_changed=true|false` on stdout, and appends the same
+#   line to $GITHUB_OUTPUT when that is set.
+#
+#   The lint reads exactly four kinds of input, so those are the four rules:
+#     **/*.rs                              both the `/// Test:` pointers and the
+#                                          `fn <name>(` definitions they cite
+#     .test-pointer-allowlist.tsv          the grandfathered set, whose entries
+#                                          FAIL once they stop dangling
+#     scripts/check_test_pointers.sh       the gate itself
+#     scripts/check_scan_floor_selftest.sh the gate's scan-floor proof
+#     .github/workflows/test-pointers.yml  the wiring that runs both
+#     scripts/detect-pointer-lint-inputs.sh  this classifier — a change to the
+#                                          decision must be checked by the gate
+#                                          it decides for
+#
+#   DO NOT substitute scripts/detect-docs-only.sh for this. That helper answers
+#   "is this Cargo-inert", and it deliberately classifies
+#   `.test-pointer-allowlist.tsv`, `scripts/check_test_pointers.sh` and
+#   `.github/workflows/test-pointers.yml` as INERT — true for a cargo build, and
+#   exactly wrong here, since a PR that only removes an allowlist entry is the
+#   PR this gate most needs to run on.
+#
+#   An EMPTY change set is relevant, not irrelevant: it means the diff could not
+#   be resolved, and a skip must never be the consequence of a lookup failure.
+#   Anything unrecognised is likewise treated as irrelevant only because it
+#   matched none of the rules above, which are the lint's complete input set.
+#
+# Usage:
+#   git diff --name-only --no-renames "$MERGE_BASE" HEAD | scripts/detect-pointer-lint-inputs.sh
+#   POINTER_LINT_BASE=origin/main scripts/detect-pointer-lint-inputs.sh
+#
+# Exit: 0 on a successful classification; 2 when a requested base ref cannot be
+#   resolved (fail closed — the caller must not guess).
+#
+# Test: scripts/check-ci-helpers-selftest.sh (`detect-pointer-lint-inputs:`
+#   cases) runs this against Rust, allowlist, gate-script, unrelated, mixed and
+#   empty change sets and asserts the emitted verdict for each.
+
+set -euo pipefail
+
+# is_lint_input <path> — true when the path can change the lint's verdict.
+is_lint_input() {
+  case "$1" in
+    *.rs) return 0 ;;
+    .test-pointer-allowlist.tsv) return 0 ;;
+    scripts/check_test_pointers.sh) return 0 ;;
+    scripts/check_scan_floor_selftest.sh) return 0 ;;
+    scripts/detect-pointer-lint-inputs.sh) return 0 ;;
+    .github/workflows/test-pointers.yml) return 0 ;;
+  esac
+  return 1
+}
+
+main() {
+  local input
+  if [ -n "${POINTER_LINT_BASE:-}" ]; then
+    local merge_base
+    if ! merge_base="$(git merge-base "${POINTER_LINT_BASE}" HEAD 2>/dev/null)"; then
+      echo "detect-pointer-lint-inputs: cannot resolve merge-base against '${POINTER_LINT_BASE}'" >&2
+      return 2
+    fi
+    input="$(git diff --name-only --no-renames "${merge_base}" HEAD)"
+  else
+    input="$(cat)"
+  fi
+
+  local changed=false
+  local count=0
+  local path
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    count=$((count + 1))
+    if is_lint_input "$path"; then
+      echo "  lint input: ${path}" >&2
+      changed=true
+    fi
+  done <<<"$input"
+
+  if [ "$count" -eq 0 ]; then
+    echo "detect-pointer-lint-inputs: empty change set — treating as relevant (fail closed)" >&2
+    changed=true
+  fi
+
+  echo "detect-pointer-lint-inputs: ${count} changed path(s) -> pointer_inputs_changed=${changed}" >&2
+  echo "pointer_inputs_changed=${changed}"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "pointer_inputs_changed=${changed}" >>"${GITHUB_OUTPUT}"
+  fi
+}
+
+main "$@"

--- a/scripts/detect-version-bumps.sh
+++ b/scripts/detect-version-bumps.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# detect-version-bumps.sh — which crates does this change set declare a NEW
+# version for? (issue #5311)
+#
+# Why: `.github/workflows/semver-checks.yml` fired on tag pushes only, so on a
+#   pull request the `Public API / SemVer` context did not exist at all. A
+#   required branch-protection context that never reports leaves every PR
+#   permanently pending, which is why #5311 could not be closed by a
+#   required-checks toggle. The workflow now runs on pull requests too — and
+#   this script is what tells it whether there is anything to compare, so the
+#   no-op path is a fact about the DIFF rather than about the event type
+#   (#5407, the defect that shape produced in ci.yml).
+#
+#   The predicate is "a crate declares a version this branch did not start
+#   with", not "a crate's source changed", and #5149 is why. Installing the
+#   pinned `cargo-semver-checks` and warming a cold `target/semver-checks`
+#   cache costs 20+ minutes; paying that on every PR that touches Rust is the
+#   cost #5149 removed, and this must not restore it. A SemVer break becomes a
+#   defect when something is PUBLISHED, and in this workspace the version bump
+#   that precedes a publish lands in its own PR before the `<crate>-v<version>`
+#   tag is cut. Keying on the bump therefore costs an ordinary PR one git diff,
+#   and moves the verdict for a release PR one step earlier than the tag push —
+#   while the release can still be reworked without a tag in flight.
+#
+# What: resolves the merge base against $VERSION_BUMP_BASE, then for every
+#   changed `crates/<dir>/Cargo.toml` compares the `[package]` table's `version`
+#   at the merge base against the one at HEAD. Emits, on stdout and to
+#   $GITHUB_OUTPUT when set:
+#     bumped=true|false
+#     bumped_crates=<space-separated crates/ DIRECTORY names>
+#
+#   Directory names, not package names, are deliberate: `check_semver.sh
+#   --crate` accepts either form (#1128), so no alias table is duplicated here.
+#
+#   Decision table:
+#     manifest absent at the merge base -> BUMPED (a crate this branch adds;
+#                                          check_semver.sh then records the
+#                                          "never published" skip itself)
+#     manifest absent at HEAD           -> not bumped (deleted by this branch)
+#     `version.workspace = true` / no
+#       readable `[package]` version    -> not bumped (nothing is declared here)
+#     version differs from the base     -> BUMPED
+#     version identical                 -> not bumped
+#
+#   SCAN FLOOR (#4618 shape, same wording as check_semver.sh). A diff listing
+#   zero paths means the base ref is wrong or the checkout is shallow — never
+#   that the branch is clean. Reporting "nothing to check" off a failed lookup
+#   is the exact way a gate turns into a rubber stamp, so that case exits
+#   non-zero instead.
+#
+# Usage:
+#   VERSION_BUMP_BASE=origin/main bash scripts/detect-version-bumps.sh
+#
+# Exit: 0 on a successful classification; 2 when the merge base cannot be
+#   resolved or the diff is empty (fail closed).
+#
+# Test: scripts/check-ci-helpers-selftest.sh (`detect-version-bumps:` cases)
+#   drives it against throwaway repos covering bumped, unbumped, source-only,
+#   added, removed and multi-crate branches.
+
+set -euo pipefail
+
+BASE="${VERSION_BUMP_BASE:-origin/main}"
+
+# package_version — read the `[package]` table's literal `version = "..."` from
+# a manifest on stdin. Prints nothing when the crate inherits the version or
+# declares none, which the caller reads as "declares nothing here".
+package_version() {
+  awk '
+    /^[[:space:]]*\[/ { in_pkg = ($0 ~ /^[[:space:]]*\[package\][[:space:]]*$/); next }
+    in_pkg && /^[[:space:]]*version[[:space:]]*=/ {
+      if (match($0, /"[^"]*"/)) { print substr($0, RSTART + 1, RLENGTH - 2); exit }
+    }
+  '
+}
+
+main() {
+  local merge_base
+  if ! merge_base="$(git merge-base "$BASE" HEAD 2>/dev/null)"; then
+    echo "detect-version-bumps: cannot resolve merge-base against '${BASE}'" >&2
+    return 2
+  fi
+
+  local changed count
+  changed="$(git diff --name-only --no-renames "$merge_base" HEAD)"
+  count="$(printf '%s\n' "$changed" | grep -c '[^[:space:]]' || true)"
+  if [ "${count:-0}" -lt 1 ]; then
+    echo "detect-version-bumps: SCAN FLOOR — the diff ${merge_base}..HEAD lists 0 changed path(s)." >&2
+    echo "      Nothing was examined, so 'no release under test' would be a guess. Check that" >&2
+    echo "      '${BASE}' is the right base and that CI checked out with fetch-depth: 0." >&2
+    return 2
+  fi
+
+  local bumped_crates="" path dir head_version base_version
+  while IFS= read -r path; do
+    case "$path" in
+      crates/*/Cargo.toml) ;;
+      *) continue ;;
+    esac
+    dir="${path#crates/}"
+    dir="${dir%/Cargo.toml}"
+    # A nested manifest (crates/<a>/<b>/Cargo.toml) is not a workspace member.
+    case "$dir" in */*) continue ;; esac
+
+    head_version=""
+    if [ -f "$path" ]; then
+      head_version="$(package_version <"$path")"
+    fi
+    if [ -z "$head_version" ]; then
+      echo "  no declared version at HEAD: ${path}" >&2
+      continue
+    fi
+
+    base_version="$(git show "${merge_base}:${path}" 2>/dev/null | package_version || true)"
+    if [ "$head_version" = "$base_version" ]; then
+      echo "  unchanged: ${dir} ${head_version}" >&2
+      continue
+    fi
+    echo "  bumped: ${dir} ${base_version:-<absent>} -> ${head_version}" >&2
+    bumped_crates="${bumped_crates}${bumped_crates:+ }${dir}"
+  done <<<"$changed"
+
+  local bumped=false
+  [ -n "$bumped_crates" ] && bumped=true
+
+  echo "detect-version-bumps: ${count} changed path(s) -> bumped=${bumped} (${bumped_crates:-none})" >&2
+  echo "bumped=${bumped}"
+  echo "bumped_crates=${bumped_crates}"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      echo "bumped=${bumped}"
+      echo "bumped_crates=${bumped_crates}"
+    } >>"${GITHUB_OUTPUT}"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Refs #5311. Step 1 of 3 — see "Not in this PR" below.

## The problem

`Doc-comment pointer lint (Why/What/Test)` and `Public API / SemVer` both report
today but structurally cannot block. `test-pointers.yml` filtered its
`pull_request` trigger on `paths:`; `semver-checks.yml` had no `pull_request`
trigger at all. On most PRs neither check run exists, and GitHub waits forever on
a required context that never reports — so adding either to branch protection as
it stood would have made every open PR unmergeable. #5300 is the recorded
deadlock scenario; the 1.3.5 near-miss (a red pointer lint that nearly merged, and
was caught only because the merge agent had been told to treat it as blocking
regardless of what GitHub showed) is the recorded cost of it not being required.

## What changed, and which constraint each piece satisfies

The design is the one #5311 settled on: **no-op-on-skip**. The job always runs and
always reports; the skip moved off the trigger and into the steps.

**Report SUCCESS, never SKIPPED.** Job-level `if:` is gone from both jobs — a
skipped conclusion does not satisfy a required context. Each job ends in a no-op
step that *executes* and exits 0 (`No pointer-lint input changed — nothing to
lint`, `No release under test — nothing to compare`). The condition removed from
`test-pointers.yml` was `github.event.action != 'edited' || github.event.changes.base != null`.

**Key off the diff, not the event type** (#5407, PR #5442's pattern). Two new
classifiers, both fail-closed, both consulted by an always-running job:

- `scripts/detect-pointer-lint-inputs.sh` — is any changed path one the lint
  reads (`**/*.rs`, the allowlist, the gate scripts, the workflow)? These are the
  same globs that were on the trigger. It deliberately does **not** reuse
  `detect-docs-only.sh`, which classifies `.test-pointer-allowlist.tsv`,
  `check_test_pointers.sh` and `test-pointers.yml` as Cargo-inert — true for a
  build, and exactly wrong here, since a PR that only removes a fixed allowlist
  entry is the PR this gate most needs to run on. The selftest asserts that
  difference directly.
- `scripts/detect-version-bumps.sh` — does any crate declare a version this
  branch did not start with? Empty diff is a SCAN FLOOR error, not "nothing to
  check".

**#5149 is not reversed.** The 20+ minutes (pinned `cargo-semver-checks` + cold
`target/semver-checks`) sit behind `have_work == 'true'` at *step* level, so an
ordinary PR pays one `git diff`. Where it now does run is a release PR: this
workspace bumps the version in a PR and cuts the `<crate>-v<version>` tag from
merged main afterwards, so the verdict lands one step earlier than the tag push,
with the release still reworkable. `timeout-minutes` 40 → 60 because a release PR
can carry several crates serially where the tag path carries one.

`preflight-publish.sh` CHECK 5 remains the blocking gate for a publish; nothing
here weakens it.

## Test ladder

Rung 1 by class (CI/docs-only, no crate `src/**`), but the change is executable
CI configuration, so it ships with the fixture coverage that class of change owes.
Changelog fragment deliberately omitted — CI-only, no crate source.

```
$ bash scripts/check-ci-helpers-selftest.sh
check-ci-helpers-selftest: all 135 cases passed          # 106 before

$ actionlint .github/workflows/test-pointers.yml .github/workflows/semver-checks.yml
ACTIONLINT_EXIT=0

$ shellcheck scripts/detect-pointer-lint-inputs.sh scripts/detect-version-bumps.sh
NEW_SCRIPTS_SHELLCHECK_EXIT=0
```

29 new cases: the two classifiers' verdicts (Rust, allowlist, gate scripts,
unrelated, mixed, empty), `detect-version-bumps` against throwaway repos covering
bumped / unbumped / source-only / added / removed / multi-crate /
`version.workspace = true` / empty-diff-fails-closed, and structural wiring guards
that fail if a `paths:` filter or a job-level `if:` is ever reintroduced on either
workflow, or if either job starts branching on `github.event.action` again.

## Evidence the no-op path reports success

Both classifiers, run against a real branch off `origin/main` carrying a single
docs change:

```
$ git diff --name-only origin/main HEAD
docs/reference/semver-gate.md

$ POINTER_LINT_BASE=origin/main bash scripts/detect-pointer-lint-inputs.sh
detect-pointer-lint-inputs: 1 changed path(s) -> pointer_inputs_changed=false
pointer_inputs_changed=false
EXIT=0

$ VERSION_BUMP_BASE=origin/main bash scripts/detect-version-bumps.sh
detect-version-bumps: 1 changed path(s) -> bumped=false (none)
bumped=false
bumped_crates=
EXIT=0
```

`false` routes to the no-op step, which runs and exits 0 — success, not skipped.

The positive direction, against the real historical bump in #5435
(`trusty-common` 0.31.0 → 0.31.1):

```
$ VERSION_BUMP_BASE=2b0786a01^ bash scripts/detect-version-bumps.sh
  bumped: trusty-common 0.31.0 -> 0.31.1
detect-version-bumps: 2 changed path(s) -> bumped=true (trusty-common)
bumped_crates=trusty-common
```

### On this PR's own checks

**`Public API / SemVer`, [run 31515859033](https://github.com/bobmatnyc/trusty-tools/actions/runs/31515859033)** — the first time this
context has reported on a pull request at all. Job conclusion `success`, reached
through the no-op step, with every expensive step skipped at *step* level:

```
job "Public API / SemVer"                      -> success
  Refresh the base branch ref                  -> success
  Select crates to check                       -> success
  Install stable toolchain                     -> skipped
  Install cargo-semver-checks (pinned prebuilt)-> skipped
  Cache cargo artifacts                        -> skipped
  SemVer gate selftest                         -> skipped
  Enforce public-API SemVer against crates.io  -> skipped
  No release under test — nothing to compare   -> success
```

**`Doc-comment pointer lint (Why/What/Test)`, [run 31515859049](https://github.com/bobmatnyc/trusty-tools/actions/runs/31515859049)** — takes the *real*
path here, because this PR edits `test-pointers.yml` and the classifier, both lint
inputs. The gate still does its work:

```
job "Doc-comment pointer lint (Why/What/Test)" -> success
  Classify pointer-lint inputs from the diff   -> success
  Scan-floor selftest                          -> success
  Lint Test: doc-comment pointers              -> success
  No pointer-lint input changed                -> skipped
```

Its no-op path is proven above against a real docs-only branch and in the
fixtures; the next docs-only PR is its live case, and that is step 2 below.

## Not in this PR

Adding the required status contexts. The order matters and reversing it deadlocks
every open PR:

1. **This PR** — land the workflows.
2. Confirm on a merged PR that does not trigger either gate that both contexts
   report success rather than going pending.
3. Only then add `Doc-comment pointer lint (Why/What/Test)` and
   `Public API / SemVer` to `main`'s required contexts.

Current required contexts, read live before writing any of this (PR #5416 renamed
job names, so older lists are stale): `Format check`, `500-line file-size cap`,
`Clippy`, `trusty-search daemon smoke test`, `MSRV check`,
`PR version bump vs crates.io (issue #4421)`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
