### PR TITLE
fix(website): derive changelog test assertions instead of pinning content that ages out

### DIFF
--- a/website/src/lib/changelog/parse.test.ts
+++ b/website/src/lib/changelog/parse.test.ts
@@ -47,13 +47,21 @@ describe('the link-reference trap', () => {
 	});
 
 	it('leaves every real trusty-search version heading as plain text, not an anchor', () => {
+		// The newest heading, read straight from the untouched source — not a
+		// pinned version string, which ages out on every trusty-search release
+		// (#5417). Deriving the expectation from the same `source` that
+		// `stripped` is computed from means the assertion tracks the corpus
+		// instead of re-drifting from it on the next publish.
+		const newestHeadingText = source.match(/^## (.+)$/m)?.[1];
+		expect(newestHeadingText, 'no `## [version] — date` heading found at all').toBeDefined();
+
 		const stripped = releaseHeadingHtml(stripLinkDefinitions(source));
 		expect(stripped).not.toHaveLength(0);
 		for (const html of stripped) {
 			expect(html).not.toContain('<a ');
 			expect(html).not.toContain('trusty-search/compare');
 		}
-		expect(stripped[0]).toBe('[0.42.3] — 2026-08-05');
+		expect(stripped[0]).toBe(newestHeadingText);
 	});
 
 	/**

--- a/website/tests/mobile-overflow.test.ts
+++ b/website/tests/mobile-overflow.test.ts
@@ -7,6 +7,8 @@ import type { AddressInfo } from 'node:net';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { chromium, type Browser } from 'playwright';
 
+import { whatsNewSections } from '../src/lib/changelog/site';
+
 /**
  * Why: `tests/build-smoke.test.ts` proves the production build's HTML
  * contains the right text, but jsdom (the `unit` project's environment) has
@@ -107,6 +109,43 @@ const ROUTES = [
 	'/tools/trusty-git-analytics/audit'
 ];
 const WIDTHS = [375, 320];
+
+/** No whitespace, and none of the HTML-entity-risky characters (`<`, `>`, `&`,
+ * `"`) that would make `item.html`'s escaped form differ from the browser's
+ * unescaped `textContent` — see `longestInlineCodeIdentifier` below. */
+const SAFE_UNESCAPED_IDENTIFIER = /^[\w./:-]+$/;
+
+/**
+ * Why: pinning one specific identifier (`pipeline::citation_check::…`) broke
+ * the moment its release aged out of `/whats-new`'s `DETAILED_RELEASES`
+ * window (#5461) — trusty-review shipped past 0.11.0, and CI never runs this
+ * suite (#5200), so the drift was silent. `whatsNewSections()` is the exact
+ * data `/whats-new` renders from, so picking a probe out of it can never
+ * target content the page has stopped showing.
+ * What: the longest whitespace-free `<code>` run across every flagship
+ * crate's currently-detailed releases — standing in for "a long inline
+ * identifier", whichever one happens to be current.
+ * Test: this file (`keeps a long inline identifier on /whats-new intact`).
+ */
+function longestInlineCodeIdentifier(): string {
+	const { crates } = whatsNewSections();
+	let longest = '';
+	for (const crate of crates) {
+		for (const release of crate.detailed) {
+			for (const category of release.categories) {
+				for (const item of category.items) {
+					for (const match of item.html.matchAll(/<code>([^<]+)<\/code>/g)) {
+						const candidate = match[1];
+						if (candidate.length > longest.length && SAFE_UNESCAPED_IDENTIFIER.test(candidate)) {
+							longest = candidate;
+						}
+					}
+				}
+			}
+		}
+	}
+	return longest;
+}
 
 /**
  * `/` at 320px has its own pre-existing, unrelated overflow (#5255 — a card
@@ -241,18 +280,26 @@ describe('no page scrolls horizontally on mobile', () => {
 	// The regression this suite exists for: a long, space-free inline
 	// identifier stays on one line and legible rather than breaking
 	// mid-character — `.doc-prose :not(pre) > code` in `app.css` scrolls the
-	// SPAN instead of wrapping it arbitrarily.
+	// SPAN instead of wrapping it arbitrarily. The identifier itself is
+	// derived from the live changelog data below, never pinned — see
+	// `longestInlineCodeIdentifier`.
 	it('keeps a long inline identifier on /whats-new intact, not broken mid-character', async () => {
+		const identifier = longestInlineCodeIdentifier();
+		expect(
+			identifier.length,
+			'no long inline <code> identifier found across any flagship’s currently-detailed releases — this probe needs different content to target'
+		).toBeGreaterThan(20);
+
 		const page = await browser.newPage({ viewport: { width: 375, height: 800 } });
 		try {
 			await page.goto(baseUrl + '/whats-new', { waitUntil: 'networkidle' });
-			const text = await page.evaluate(() => {
+			const text = await page.evaluate((needle) => {
 				const code = Array.from(document.querySelectorAll('code')).find((c) =>
-					c.textContent?.includes('downgrade_uncitable_findings')
+					c.textContent?.includes(needle)
 				);
 				return code?.textContent ?? null;
-			});
-			expect(text).toContain('pipeline::citation_check::downgrade_uncitable_findings');
+			}, identifier);
+			expect(text).toContain(identifier);
 		} finally {
 			await page.close();
 		}


### PR DESCRIPTION
## Summary

Both #5417 and #5461 are the same root shape: a website test assertion
pinned to changelog content that ages out as crates publish. Fixing the
literal in each would just reschedule the next failure, so both are fixed
by deriving the expectation from the same live data the code under test
consumes.

- **#5417** — `website/src/lib/changelog/parse.test.ts` asserted
  trusty-search's newest heading was literally `[0.42.3] — 2026-08-05`.
  Now derives the expected heading from a regex match against the same
  `source` string `stripped` is parsed from, so it always tracks whichever
  release is newest.
- **#5461** — `website/tests/mobile-overflow.test.ts` asserted a specific
  trusty-review identifier stayed intact in an inline `<code>` span on
  `/whats-new`. That identifier's release aged out of
  `buildChangelogSite`'s `DETAILED_RELEASES` window once trusty-review
  passed 0.11.0. Now derives the probe identifier from `whatsNewSections()`
  — the exact data `/whats-new` renders from — picking the longest
  whitespace-free inline `<code>` run across the currently-detailed
  releases, so the probe is always inside the rendered window.

What would now have to break for either assertion to fail again:
- #5417: `stripLinkDefinitions`/`parseChangelog` would have to stop
  preserving the newest heading as plain text, or the regex extracting it
  from raw source would have to diverge from the parser's own extraction —
  never "a release got cut."
- #5461: `whatsNewSections()`/`buildChangelogSite` would have to stop
  surfacing any long inline-code identifier across all six flagships'
  detailed releases, or the CSS/rendering pipeline would have to drop or
  truncate one that's present — never "a release aged past 0.11.0."

## Test plan

Rung: website-only (not a Rust crate change, no changelog fragment — see
below).

- `cd website && pnpm run format` — no changes (both files already
  Prettier-clean)
- `cd website && pnpm run lint` — `prettier --check . && eslint .` — clean
- `cd website && pnpm run check` — `svelte-check` — 0 errors, 0 warnings
- `cd website && pnpm test` (full suite) — **before** the fix (stashed and
  re-run against unmodified origin/main content): 3 failures — the two
  targeted here, plus pre-existing #5255 (`/` at 375px, unrelated card-grid
  overflow). **After** the fix: 1 failure — only #5255, unchanged and
  untouched by this PR (`Test Files 1 failed | 13 passed (14)`,
  `Tests 1 failed | 247 passed | 1 skipped (249)`).
- `cd website && pnpm run build` — exits 0.

Website tests don't run in CI (#5200), so this local run is the only
evidence; raw output captured for both before/after states.

Changelog fragment: not required — this PR only touches `website/**`
(test files), no crate `src/**`.

Closes #5417
Closes #5461

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools