### PR TITLE
feat(tga): port the contributor-profiling pipeline from trusty-review (#5463)

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/5463-profile-pipeline.md
+++ b/crates/trusty-git-analytics/changelog.d/5463-profile-pipeline.md
@@ -1,0 +1,9 @@
+Added
+- `tga::profile` — longitudinal contributor profiling: identity resolution
+  (`ContributorSelector`), period-batch assembly (`assemble_period_batches`),
+  category-stratified diff sampling (`sample_diffs_for_batches`), deterministic
+  cross-period trend tagging (`synthesize_deterministic`), and JSON/Markdown
+  rendering (`Reporter`). Ported from trusty-review so profiling lives with the
+  data it reads (#5463, epic #5468). The model-written narrative (#5464) and
+  GitHub issue publishing (#5465) are not part of this change — nothing here
+  makes a network or model call.

--- a/crates/trusty-git-analytics/src/lib.rs
+++ b/crates/trusty-git-analytics/src/lib.rs
@@ -10,6 +10,7 @@
 //! - [`collect`] — Stage 1: git extraction and external-system fetches
 //! - [`classify`] — Stage 2: four-tier commit classification cascade
 //! - [`report`] — Stage 3: CSV / JSON / Markdown report generation
+//! - [`profile`] — longitudinal contributor profiling over the collected data
 //! - [`commands`] — the subcommand handlers `main.rs` dispatches into
 //! - [`audit`] — the one-shot AUDIT sweep that drives those handlers end to end
 
@@ -28,4 +29,7 @@ pub mod classify;
 pub mod collect;
 pub mod commands;
 pub mod core;
+// #5463: contributor profiling is tga's domain, so it lives beside the data it
+// reads rather than in a crate that then has to depend on tga (epic #5468).
+pub mod profile;
 pub mod report;

--- a/crates/trusty-git-analytics/src/profile/batch.rs
+++ b/crates/trusty-git-analytics/src/profile/batch.rs
@@ -1,0 +1,291 @@
+//! Period-batch assembly for the contributor-profile pipeline.
+//!
+//! Why: the profile reasons in periods, not commits — "how did Q1 compare to
+//! Q2" is the question it answers. This module turns tga's period-trend rows
+//! into the batch shape the rest of the pipeline consumes.
+//! What: [`assemble_period_batches`] calls
+//! [`query_author_period_trends`](crate::report::period_trends::query_author_period_trends)
+//! at the requested window size and wraps each summary in a [`PeriodBatch`].
+//! Diff population is a separate pass — see [`crate::profile::diff_sampler`].
+//! Test: the `tests` module seeds an in-memory database with weekly commits and
+//! asserts the bucketing for every window variant.
+
+use tracing::debug;
+
+use crate::core::db::Database;
+use crate::report::period_trends::query_author_period_trends;
+
+use super::error::{ProfileError, Result};
+use super::types::PeriodBatch;
+
+// ─── Window enum ─────────────────────────────────────────────────────────────
+
+/// Granularity of the period windows used for batching.
+///
+/// Why: the useful granularity depends on the reader — quarterly for a
+/// management summary, weekly for a detailed audit.
+/// What: maps to the `window_weeks` integer `query_author_period_trends` takes.
+/// Test: `tests::window_to_weeks`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Window {
+    /// 13-week (roughly quarterly) periods.
+    Quarterly,
+    /// 4-week (roughly monthly) periods.
+    Monthly,
+    /// 1-week periods.
+    Weekly,
+    /// Custom window size in weeks.
+    Custom(u32),
+}
+
+impl Window {
+    /// Map the variant to its `window_weeks` value.
+    ///
+    /// Why: keeps 13/4/1 out of every call site.
+    /// What: returns 13/4/1 for Quarterly/Monthly/Weekly; `Custom(n)` returns
+    /// `n` with a floor of 1, since a zero-week window would divide by zero
+    /// downstream.
+    /// Test: `tests::window_to_weeks`.
+    pub fn window_weeks(self) -> u32 {
+        match self {
+            Window::Quarterly => 13,
+            Window::Monthly => 4,
+            Window::Weekly => 1,
+            Window::Custom(n) => n.max(1),
+        }
+    }
+}
+
+// ─── Public entry point ──────────────────────────────────────────────────────
+
+/// Assemble period batches for one contributor.
+///
+/// Why: every later stage — diff sampling, trend tagging, rendering — operates
+/// per period, so the period split is the pipeline's first real step.
+/// What: queries the period trends for `canonical_email` at `window`
+/// granularity within the optional `[since, until]` bounds, and wraps each
+/// summary in a diff-less [`PeriodBatch`]. A contributor with no commits in
+/// scope yields an empty `Vec`, not an error — an unproductive window is a
+/// valid answer.
+///
+/// # Parameters
+///
+/// - `db` — open tga database (read-only use)
+/// - `canonical_email` — as stored in `authors.canonical_email`
+/// - `window` — period granularity
+/// - `since` / `until` — optional inclusive ISO 8601 date bounds
+///
+/// # Errors
+///
+/// [`ProfileError::Report`] when the underlying trend query fails.
+///
+/// Test: `tests::assemble_quarterly_batches`, `tests::assemble_monthly_batches`,
+/// `tests::assemble_with_date_filter`, `tests::assemble_empty_for_no_commits`.
+pub fn assemble_period_batches(
+    db: &Database,
+    canonical_email: &str,
+    window: Window,
+    since: Option<&str>,
+    until: Option<&str>,
+) -> Result<Vec<PeriodBatch>> {
+    let window_weeks = window.window_weeks();
+    debug!(
+        canonical_email,
+        window_weeks, since, until, "assembling period batches"
+    );
+
+    let summaries = query_author_period_trends(db, canonical_email, window_weeks, since, until)
+        .map_err(ProfileError::Report)?;
+
+    Ok(summaries.into_iter().map(PeriodBatch::from_stats).collect())
+}
+
+// ─── Unit tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+
+    fn seed_author(db: &Database, name: &str, email: &str) -> i64 {
+        db.connection()
+            .execute(
+                "INSERT INTO authors (canonical_name, canonical_email, aliases) \
+                 VALUES (?1, ?2, '[]')",
+                params![name, email],
+            )
+            .expect("insert author");
+        db.connection().last_insert_rowid()
+    }
+
+    fn seed_commit(db: &Database, sha: &str, author_id: i64, timestamp: &str) {
+        db.connection()
+            .execute(
+                "INSERT INTO commits (sha, author_id, author_name, author_email, \
+                 timestamp, message, repository, insertions, deletions) \
+                 VALUES (?1, ?2, 'n', 'e', ?3, 'm', 'repo-a', 5, 2)",
+                params![sha, author_id, timestamp],
+            )
+            .expect("insert commit");
+    }
+
+    /// One commit per week for `n` weeks starting 2024-01-01.
+    fn weekly_timestamps(n: usize) -> Vec<String> {
+        (0..n)
+            .map(|i| {
+                let day = chrono::NaiveDate::from_ymd_opt(2024, 1, 1).expect("valid date")
+                    + chrono::Duration::weeks(i as i64);
+                format!("{day}T00:00:00Z")
+            })
+            .collect()
+    }
+
+    /// Why: the window-to-weeks mapping is what every batch boundary depends
+    /// on, and a zero-week custom window would divide by zero downstream.
+    /// What: asserts 13/4/1 for the named variants and that `Custom(0)` floors
+    /// to 1.
+    /// Test: this test itself.
+    #[test]
+    fn window_to_weeks() {
+        assert_eq!(Window::Quarterly.window_weeks(), 13);
+        assert_eq!(Window::Monthly.window_weeks(), 4);
+        assert_eq!(Window::Weekly.window_weeks(), 1);
+        assert_eq!(Window::Custom(8).window_weeks(), 8);
+        assert_eq!(Window::Custom(0).window_weeks(), 1, "Custom(0) floors to 1");
+    }
+
+    /// Why: a quarterly window must collect a full 13 weeks into one batch —
+    /// splitting them would misreport the contributor's cadence.
+    /// What: seeds 13 weekly commits and asserts one batch holding all 13, with
+    /// no diffs attached yet.
+    /// Test: this test itself.
+    #[test]
+    fn assemble_quarterly_batches() {
+        let db = Database::open_in_memory().expect("open");
+        let aid = seed_author(&db, "Alice", "alice@example.com");
+        for (i, ts) in weekly_timestamps(13).iter().enumerate() {
+            seed_commit(&db, &format!("sha{i}"), aid, ts);
+        }
+
+        let batches =
+            assemble_period_batches(&db, "alice@example.com", Window::Quarterly, None, None)
+                .expect("assemble");
+
+        assert_eq!(batches.len(), 1, "13 weeks in one quarterly bucket");
+        assert_eq!(batches[0].stats.commit_count, 13);
+        assert!(
+            batches[0].sampled_diffs.is_empty(),
+            "sampled_diffs must stay empty until the diff sampler runs"
+        );
+    }
+
+    /// Why: the same commits must split differently at a finer granularity —
+    /// that is the whole point of the window parameter.
+    /// What: seeds 8 weekly commits and asserts two monthly batches summing to
+    /// 8 commits.
+    /// Test: this test itself.
+    #[test]
+    fn assemble_monthly_batches() {
+        let db = Database::open_in_memory().expect("open");
+        let aid = seed_author(&db, "Bob", "bob@example.com");
+        for (i, ts) in weekly_timestamps(8).iter().enumerate() {
+            seed_commit(&db, &format!("bsha{i}"), aid, ts);
+        }
+
+        let batches = assemble_period_batches(&db, "bob@example.com", Window::Monthly, None, None)
+            .expect("assemble");
+
+        assert_eq!(batches.len(), 2, "8 weeks → 2 monthly batches");
+        assert_eq!(
+            batches[0].stats.commit_count + batches[1].stats.commit_count,
+            8
+        );
+    }
+
+    /// Why: a profile is always bounded to a window the caller asked for;
+    /// commits outside it must not leak in.
+    /// What: seeds commits in January and February, filters to January, and
+    /// asserts only the two January commits are counted.
+    /// Test: this test itself.
+    #[test]
+    fn assemble_with_date_filter() {
+        let db = Database::open_in_memory().expect("open");
+        let aid = seed_author(&db, "Carol", "carol@example.com");
+        seed_commit(&db, "c1", aid, "2024-01-08T00:00:00Z");
+        seed_commit(&db, "c2", aid, "2024-01-15T00:00:00Z");
+        seed_commit(&db, "c3", aid, "2024-02-05T00:00:00Z");
+
+        let batches = assemble_period_batches(
+            &db,
+            "carol@example.com",
+            Window::Monthly,
+            Some("2024-01-01"),
+            Some("2024-01-31"),
+        )
+        .expect("assemble");
+
+        let total: u64 = batches.iter().map(|b| b.stats.commit_count).sum();
+        assert_eq!(total, 2, "only the two January commits are in range");
+    }
+
+    /// Why: profiling someone with no commits in the window is a normal
+    /// request; erroring would abort a whole-org sweep on the first quiet
+    /// month.
+    /// What: seeds an author with no commits and asserts an empty `Vec`.
+    /// Test: this test itself.
+    #[test]
+    fn assemble_empty_for_no_commits() {
+        let db = Database::open_in_memory().expect("open");
+        seed_author(&db, "Dave", "dave@example.com");
+
+        let batches =
+            assemble_period_batches(&db, "dave@example.com", Window::Quarterly, None, None)
+                .expect("assemble");
+
+        assert!(batches.is_empty(), "no commits → empty Vec");
+    }
+
+    /// Why: the diff sampler queries commits using the batch's `since`/`until`,
+    /// so malformed period metadata would silently sample nothing.
+    /// What: asserts the propagated label carries a week marker and both bounds
+    /// are `YYYY-MM-DD`.
+    /// Test: this test itself.
+    #[test]
+    fn assemble_period_label_propagated() {
+        let db = Database::open_in_memory().expect("open");
+        let aid = seed_author(&db, "Eve", "eve@example.com");
+        seed_commit(&db, "e1", aid, "2024-01-08T00:00:00Z");
+
+        let batches = assemble_period_batches(&db, "eve@example.com", Window::Weekly, None, None)
+            .expect("assemble");
+
+        assert!(!batches.is_empty());
+        let p = &batches[0].stats;
+        assert!(
+            p.period_label.contains("-W"),
+            "period_label must contain '-W': {}",
+            p.period_label
+        );
+        assert_eq!(p.since.len(), 10, "since must be YYYY-MM-DD: {}", p.since);
+        assert_eq!(p.until.len(), 10, "until must be YYYY-MM-DD: {}", p.until);
+    }
+
+    /// Why: a custom window has to reach the query unchanged, otherwise the
+    /// variant is decorative.
+    /// What: seeds 4 weekly commits with `Custom(2)` and asserts 2 batches.
+    /// Test: this test itself.
+    #[test]
+    fn assemble_custom_window() {
+        let db = Database::open_in_memory().expect("open");
+        let aid = seed_author(&db, "Frank", "frank@example.com");
+        for (i, ts) in weekly_timestamps(4).iter().enumerate() {
+            seed_commit(&db, &format!("fsha{i}"), aid, ts);
+        }
+
+        let batches =
+            assemble_period_batches(&db, "frank@example.com", Window::Custom(2), None, None)
+                .expect("assemble");
+
+        assert_eq!(batches.len(), 2, "4 weeks with Custom(2) → 2 batches");
+    }
+}

--- a/crates/trusty-git-analytics/src/profile/diff_sampler/config.rs
+++ b/crates/trusty-git-analytics/src/profile/diff_sampler/config.rs
@@ -1,0 +1,76 @@
+//! Configuration and limits for the diff sampler.
+//!
+//! Why: the sampler's two tunables — how many diffs per period and where the
+//! repositories live on disk — belong to the caller, not the function
+//! signature.
+//! What: defines [`DiffSamplerConfig`] plus the [`MAX_DIFF_CHARS`] and
+//! [`DEFAULT_MAX_DIFFS`] limits.
+//! Test: `config_repo_path_resolution` in the sibling `tests` module.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Maximum characters of diff text kept per sampled commit.
+///
+/// Why: one 40,000-line refactor would otherwise consume the entire budget a
+/// downstream narrative pass has for the whole profile.
+/// What: 20,000 UTF-8 characters, applied on top of the byte cap
+/// [`diff_for_commit`](crate::collect::git::diff::diff_for_commit) already
+/// enforces.
+/// Test: `diff_sampler_truncates_long_diff`.
+pub const MAX_DIFF_CHARS: usize = 20_000;
+
+/// Default number of diffs sampled per period batch.
+///
+/// Why: enough commits to see a pattern, few enough that a busy period does not
+/// dominate the profile.
+/// What: 5. Override via [`DiffSamplerConfig::max_diffs`].
+/// Test: `diff_sampler_respects_max_diffs` exercises a non-default value.
+pub const DEFAULT_MAX_DIFFS: usize = 5;
+
+/// Configuration for the diff sampler.
+///
+/// Why: see the module doc.
+/// What: holds the per-period diff cap and the mapping from the repository
+/// name stored in `commits.repository` to a local checkout. Repositories with
+/// no resolvable path are skipped.
+/// Test: `config_repo_path_resolution`.
+#[derive(Debug, Clone)]
+pub struct DiffSamplerConfig {
+    /// Maximum diffs sampled per period batch. Defaults to
+    /// [`DEFAULT_MAX_DIFFS`].
+    pub max_diffs: usize,
+
+    /// Explicit repository-name → local-path map. Takes precedence over
+    /// [`repos_root`](Self::repos_root).
+    pub repo_paths: HashMap<String, PathBuf>,
+
+    /// Root directory under which repositories are laid out by name.
+    pub repos_root: Option<PathBuf>,
+}
+
+impl Default for DiffSamplerConfig {
+    fn default() -> Self {
+        Self {
+            max_diffs: DEFAULT_MAX_DIFFS,
+            repo_paths: HashMap::new(),
+            repos_root: None,
+        }
+    }
+}
+
+impl DiffSamplerConfig {
+    /// Resolve the local path for a repository name.
+    ///
+    /// Why: callers configure either an explicit map or a root directory, and
+    /// the precedence between them has to be stated once.
+    /// What: returns the explicit entry if present, else `repos_root/<name>`,
+    /// else `None`.
+    /// Test: `config_repo_path_resolution`.
+    pub fn repo_path(&self, repo_name: &str) -> Option<PathBuf> {
+        if let Some(p) = self.repo_paths.get(repo_name) {
+            return Some(p.clone());
+        }
+        self.repos_root.as_ref().map(|root| root.join(repo_name))
+    }
+}

--- a/crates/trusty-git-analytics/src/profile/diff_sampler/mod.rs
+++ b/crates/trusty-git-analytics/src/profile/diff_sampler/mod.rs
@@ -1,0 +1,23 @@
+//! Diff sampler for contributor-profile period batches.
+//!
+//! Why: statistics say how much a contributor shipped; only diff text shows how
+//! they wrote it. Fetching diffs is expensive (a libgit2 open plus a tree diff
+//! per commit), so it runs as its own pass that a statistics-only profile can
+//! skip entirely.
+//! What: [`sample_diffs_for_batches`] walks each batch, selects up to
+//! [`DiffSamplerConfig::max_diffs`] commits stratified by category, fetches
+//! each diff, truncates it to [`MAX_DIFF_CHARS`], and attaches the result. A
+//! repository that is not checked out locally is skipped with a warning rather
+//! than aborting the run — a profile spanning ten repos should not fail because
+//! one is missing.
+//! Test: `tests` uses temp git repos and an in-memory database to cover
+//! stratification, truncation, missing-repo skipping, and the `max_diffs` cap.
+
+pub mod config;
+pub mod sampler;
+
+#[cfg(test)]
+mod tests;
+
+pub use config::{DiffSamplerConfig, DEFAULT_MAX_DIFFS, MAX_DIFF_CHARS};
+pub use sampler::sample_diffs_for_batches;

--- a/crates/trusty-git-analytics/src/profile/diff_sampler/sampler.rs
+++ b/crates/trusty-git-analytics/src/profile/diff_sampler/sampler.rs
@@ -1,0 +1,281 @@
+//! Sampling logic for the diff sampler.
+//!
+//! Why: see [`crate::profile::diff_sampler`] — this file holds the selection
+//! and truncation rules that decide which commits represent a period.
+//! What: [`sample_diffs_for_batches`] (the entry point), `query_commits_in_period`
+//! (the DB read), [`stratify_and_select`] (category-stratified selection), and
+//! [`truncate_diff`] (the length limiter).
+//! Test: every test in the sibling `tests` module.
+
+use std::cmp::Reverse;
+use std::collections::HashSet;
+
+use rusqlite::params;
+use tracing::{debug, warn};
+
+use crate::collect::git::diff::diff_for_commit;
+use crate::core::db::Database;
+use crate::profile::error::{ProfileError, Result};
+use crate::profile::types::period::{PeriodBatch, SampledDiff};
+
+use super::config::{DiffSamplerConfig, MAX_DIFF_CHARS};
+
+// ─── Commit record ───────────────────────────────────────────────────────────
+
+/// One commit row as the sampler needs it, with the effort label pre-ranked.
+#[derive(Debug, Clone)]
+pub(super) struct CommitRecord {
+    pub sha: String,
+    pub repository: String,
+    pub message: String,
+    pub category: Option<String>,
+    pub effort: Option<String>,
+    /// Effort sort key: XS=1, S=2, M=3, L=4, XL=5, unscored=0.
+    pub effort_rank: u8,
+}
+
+// ─── Public entry point ──────────────────────────────────────────────────────
+
+/// Sample representative diffs for each period batch, attaching them in place.
+///
+/// Why: see [`crate::profile::diff_sampler`].
+/// What: for each batch, reads the author's commits in that period, selects up
+/// to `config.max_diffs` of them via [`stratify_and_select`], fetches and
+/// truncates each diff, and pushes the result onto `batch.sampled_diffs`.
+///
+/// A commit whose repository is unmapped, whose mapped path does not exist, or
+/// whose diff cannot be read is logged and skipped: a missing checkout degrades
+/// the profile's evidence, it does not invalidate the run.
+///
+/// # Errors
+///
+/// [`ProfileError::Db`] when the commit query fails. Per-commit git failures
+/// are skipped, not propagated.
+///
+/// Test: `diff_sampler_fetches_real_diff`, `diff_sampler_skips_missing_repo`,
+/// `diff_sampler_respects_max_diffs`.
+pub fn sample_diffs_for_batches(
+    batches: &mut [PeriodBatch],
+    db: &Database,
+    canonical_email: &str,
+    config: &DiffSamplerConfig,
+) -> Result<()> {
+    for batch in batches.iter_mut() {
+        let since = batch.stats.since.clone();
+        let until = batch.stats.until.clone();
+
+        let commits = query_commits_in_period(db, canonical_email, &since, &until)?;
+        let selected = stratify_and_select(&commits, config.max_diffs);
+
+        for commit in selected {
+            let Some(repo_path) = config.repo_path(&commit.repository) else {
+                warn!(
+                    sha = %commit.sha,
+                    repository = %commit.repository,
+                    "diff sampler: repository not configured locally — skipping"
+                );
+                continue;
+            };
+
+            if !repo_path.exists() {
+                warn!(
+                    sha = %commit.sha,
+                    repository = %commit.repository,
+                    path = %repo_path.display(),
+                    "diff sampler: repository path does not exist — skipping"
+                );
+                continue;
+            }
+
+            match diff_for_commit(&repo_path, &commit.sha) {
+                Ok(diff_text) => {
+                    let truncated = truncate_diff(&diff_text);
+                    debug!(
+                        sha = %commit.sha,
+                        diff_len = diff_text.len(),
+                        truncated_len = truncated.len(),
+                        "sampled diff"
+                    );
+                    batch.sampled_diffs.push(SampledDiff {
+                        sha: commit.sha.clone(),
+                        repository: commit.repository.clone(),
+                        message: commit.message.clone(),
+                        diff_text: truncated,
+                        category: commit.category.clone(),
+                        effort: commit.effort.clone(),
+                    });
+                }
+                Err(e) => {
+                    warn!(
+                        sha = %commit.sha,
+                        repository = %commit.repository,
+                        error = %e,
+                        "diff sampler: diff_for_commit failed — skipping"
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// ─── Private helpers ─────────────────────────────────────────────────────────
+
+/// Read the commits authored by `email` within `[since, until]`.
+///
+/// Why: the sampler needs sha, repository, message, category, and effort
+/// together; no existing report query returns that shape.
+/// What: joins `commits` to `authors`, left-joins `classifications` and
+/// `fact_commit_effort`, and orders newest first. The `until` bound is widened
+/// to end-of-day so a date-only bound includes that day's commits.
+/// Test: exercised by every `sample_diffs_for_batches` test.
+fn query_commits_in_period(
+    db: &Database,
+    email: &str,
+    since: &str,
+    until: &str,
+) -> Result<Vec<CommitRecord>> {
+    let conn = db.connection();
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.sha, c.repository, c.message, \
+                    cl.category, fce.size \
+             FROM commits c \
+             JOIN authors a ON a.id = c.author_id \
+             LEFT JOIN classifications cl ON cl.id = c.classification_id \
+             LEFT JOIN fact_commit_effort fce ON fce.sha = c.sha \
+             WHERE LOWER(a.canonical_email) = LOWER(?1) \
+               AND c.timestamp >= ?2 \
+               AND c.timestamp <= ?3 || 'T23:59:59Z' \
+             ORDER BY c.timestamp DESC",
+        )
+        .map_err(db_err)?;
+
+    let rows = stmt
+        .query_map(params![email, since, until], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+            ))
+        })
+        .map_err(db_err)?;
+
+    let mut commits = Vec::new();
+    for r in rows {
+        let (sha, repository, message, category, effort) = r.map_err(db_err)?;
+        let effort_rank = effort_to_rank(effort.as_deref());
+        commits.push(CommitRecord {
+            sha,
+            repository,
+            message,
+            category,
+            effort,
+            effort_rank,
+        });
+    }
+    Ok(commits)
+}
+
+/// Wrap a rusqlite error as a [`ProfileError::Db`].
+fn db_err(e: rusqlite::Error) -> ProfileError {
+    ProfileError::Db(crate::core::TgaError::from(e))
+}
+
+/// Map an effort-size label to a sort rank (higher = larger commit).
+fn effort_to_rank(size: Option<&str>) -> u8 {
+    match size {
+        Some("XS") => 1,
+        Some("S") => 2,
+        Some("M") => 3,
+        Some("L") => 4,
+        Some("XL") => 5,
+        _ => 0,
+    }
+}
+
+/// Categories guaranteed a slot in the sample when present.
+const PRIORITY_CATEGORIES: &[&str] = &["bugfix", "feature", "refactor"];
+
+/// Select up to `max_diffs` commits using category-stratified sampling.
+///
+/// Why: taking the newest or largest commits would systematically miss whole
+/// categories — a sprint heavy in features would show no bugfixes at all, and
+/// bugfix quality is exactly what a profile is asked about.
+/// What: fills one slot per priority category first, in
+/// [`PRIORITY_CATEGORIES`] order, then fills the remainder with the
+/// highest-effort commits not yet chosen.
+/// Test: `diff_sampler_stratification`,
+/// `diff_sampler_falls_back_to_effort_ordering`.
+pub(super) fn stratify_and_select(
+    commits: &[CommitRecord],
+    max_diffs: usize,
+) -> Vec<&CommitRecord> {
+    if max_diffs == 0 || commits.is_empty() {
+        return Vec::new();
+    }
+
+    let mut selected: Vec<&CommitRecord> = Vec::with_capacity(max_diffs);
+    let mut used_indices: HashSet<usize> = HashSet::new();
+
+    // Pass 1: one commit per priority category.
+    for cat in PRIORITY_CATEGORIES {
+        if selected.len() >= max_diffs {
+            break;
+        }
+        if let Some((idx, commit)) = commits
+            .iter()
+            .enumerate()
+            .find(|(i, c)| !used_indices.contains(i) && c.category.as_deref() == Some(cat))
+        {
+            selected.push(commit);
+            used_indices.insert(idx);
+        }
+    }
+
+    // Pass 2: fill the remaining slots with the highest-effort commits left.
+    if selected.len() < max_diffs {
+        let mut remaining: Vec<(usize, &CommitRecord)> = commits
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !used_indices.contains(i))
+            .collect();
+        remaining.sort_by_key(|b| Reverse(b.1.effort_rank));
+
+        for (_, commit) in remaining {
+            if selected.len() >= max_diffs {
+                break;
+            }
+            selected.push(commit);
+        }
+    }
+
+    selected
+}
+
+/// Truncate diff text to [`MAX_DIFF_CHARS`] on a UTF-8 character boundary.
+///
+/// Why: see [`MAX_DIFF_CHARS`]. Cutting on a byte index would panic on
+/// multi-byte content, which real diffs contain.
+/// What: returns the input unchanged when it is within the cap; otherwise cuts
+/// at the character boundary and appends a marker so a reader knows the diff
+/// continues.
+/// Test: `diff_sampler_truncates_long_diff`, `diff_sampler_short_diff_unchanged`.
+pub(super) fn truncate_diff(diff_text: &str) -> String {
+    let char_count = diff_text.chars().count();
+    if char_count <= MAX_DIFF_CHARS {
+        return diff_text.to_string();
+    }
+    let byte_end = diff_text
+        .char_indices()
+        .nth(MAX_DIFF_CHARS)
+        .map(|(i, _)| i)
+        .unwrap_or(diff_text.len());
+    format!(
+        "{}\n[... diff truncated at {} chars ...]",
+        &diff_text[..byte_end],
+        MAX_DIFF_CHARS
+    )
+}

--- a/crates/trusty-git-analytics/src/profile/diff_sampler/tests.rs
+++ b/crates/trusty-git-analytics/src/profile/diff_sampler/tests.rs
@@ -1,0 +1,391 @@
+//! Tests for the diff sampler.
+//!
+//! Why: the sampler touches real git repositories and a live SQLite schema, so
+//! its scaffolding is bulky enough to keep out of `sampler.rs`.
+//! What: covers stratification, effort-ordering fallback, truncation,
+//! missing-repo skipping, a real diff fetch, the `max_diffs` cap, and config
+//! path resolution.
+//! Test: every test here is self-contained — temp git repos and in-memory DBs.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use rusqlite::params;
+
+use super::config::{DiffSamplerConfig, DEFAULT_MAX_DIFFS};
+use super::sampler::{sample_diffs_for_batches, stratify_and_select, truncate_diff, CommitRecord};
+use super::MAX_DIFF_CHARS;
+use crate::core::db::Database;
+use crate::profile::types::period::PeriodBatch;
+
+// ── DB seed helpers ──────────────────────────────────────────────────────────
+
+fn seed_author(db: &Database, name: &str, email: &str) -> i64 {
+    db.connection()
+        .execute(
+            "INSERT INTO authors (canonical_name, canonical_email, aliases) \
+             VALUES (?1, ?2, '[]')",
+            params![name, email],
+        )
+        .expect("insert author");
+    db.connection().last_insert_rowid()
+}
+
+fn seed_commit_with_category_effort(
+    db: &Database,
+    sha: &str,
+    author_id: i64,
+    repository: &str,
+    timestamp: &str,
+    category: Option<&str>,
+    effort: Option<&str>,
+) {
+    let cls_id: Option<i64> = category.map(|cat| {
+        db.connection()
+            .execute(
+                "INSERT OR IGNORE INTO classifications (id, category, confidence, method) \
+                 VALUES (NULL, ?1, 0.9, 'rule')",
+                params![cat],
+            )
+            .expect("insert classification");
+        db.connection()
+            .query_row(
+                "SELECT id FROM classifications WHERE category = ?1 LIMIT 1",
+                params![cat],
+                |r| r.get(0),
+            )
+            .expect("get classification id")
+    });
+
+    db.connection()
+        .execute(
+            "INSERT INTO commits (sha, author_id, author_name, author_email, \
+             timestamp, message, repository, insertions, deletions, classification_id) \
+             VALUES (?1, ?2, 'n', 'e', ?3, ?1, ?4, 5, 2, ?5)",
+            params![sha, author_id, timestamp, repository, cls_id],
+        )
+        .expect("insert commit");
+
+    if let Some(sz) = effort {
+        db.connection()
+            .execute(
+                "INSERT INTO fact_commit_effort \
+                 (sha, repository, size, score, loc, files, test_loc, tests_factor, computed_at) \
+                 VALUES (?1, ?2, ?3, 1.0, 10, 1, 0, 1.0, 0)",
+                params![sha, repository, sz],
+            )
+            .expect("insert effort");
+    }
+}
+
+fn batches_for(db: &Database, email: &str) -> Vec<PeriodBatch> {
+    let stats = crate::report::period_trends::query_author_period_trends(db, email, 4, None, None)
+        .expect("query trends");
+    stats.into_iter().map(PeriodBatch::from_stats).collect()
+}
+
+fn record(sha: &str, category: &str, effort: &str, effort_rank: u8) -> CommitRecord {
+    CommitRecord {
+        sha: sha.to_string(),
+        repository: "r".to_string(),
+        message: format!("{category} commit"),
+        category: Some(category.to_string()),
+        effort: Some(effort.to_string()),
+        effort_rank,
+    }
+}
+
+// ── Git repo helpers ─────────────────────────────────────────────────────────
+
+fn make_repo_with_initial_commit(dir: &Path, filename: &str, content: &str) -> String {
+    let repo = git2::Repository::init(dir).expect("init repo");
+    let mut config = repo.config().expect("config");
+    config.set_str("user.name", "Test User").expect("set name");
+    config
+        .set_str("user.email", "test@example.com")
+        .expect("set email");
+
+    std::fs::write(dir.join(filename), content).expect("write file");
+
+    let mut index = repo.index().expect("index");
+    index.add_path(Path::new(filename)).expect("add path");
+    index.write().expect("write index");
+
+    let tree_id = index.write_tree().expect("write tree");
+    let tree = repo.find_tree(tree_id).expect("find tree");
+    let sig = git2::Signature::now("Test User", "test@example.com").expect("sig");
+    repo.commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[])
+        .expect("initial commit")
+        .to_string()
+}
+
+fn add_commit(dir: &Path, filename: &str, new_content: &str) -> String {
+    let repo = git2::Repository::open(dir).expect("open repo");
+
+    std::fs::write(dir.join(filename), new_content).expect("write file");
+
+    let mut index = repo.index().expect("index");
+    index.add_path(Path::new(filename)).expect("add path");
+    index.write().expect("write index");
+
+    let tree_id = index.write_tree().expect("write tree");
+    let tree = repo.find_tree(tree_id).expect("find tree");
+    let sig = git2::Signature::now("Test User", "test@example.com").expect("sig");
+    let head = repo.head().expect("head").peel_to_commit().expect("peel");
+    repo.commit(
+        Some("HEAD"),
+        &sig,
+        &sig,
+        "Follow-up commit",
+        &tree,
+        &[&head],
+    )
+    .expect("follow-up commit")
+    .to_string()
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// Why: a sample that shows only features would let bugfix quality — the thing
+/// a profile is most often asked about — go unexamined.
+/// What: offers five commits across three categories with `max_diffs = 3` and
+/// asserts both a bugfix and a feature are chosen.
+/// Test: this test itself.
+#[test]
+fn diff_sampler_stratification() {
+    let commits = vec![
+        record("f1", "feature", "S", 2),
+        record("f2", "feature", "M", 3),
+        record("b1", "bugfix", "XS", 1),
+        record("b2", "bugfix", "S", 2),
+        record("r1", "refactor", "L", 4),
+    ];
+
+    let selected = stratify_and_select(&commits, 3);
+    assert_eq!(selected.len(), 3);
+
+    let cats: Vec<Option<&str>> = selected.iter().map(|c| c.category.as_deref()).collect();
+    assert!(
+        cats.contains(&Some("bugfix")),
+        "includes a bugfix: {cats:?}"
+    );
+    assert!(
+        cats.contains(&Some("feature")),
+        "includes a feature: {cats:?}"
+    );
+}
+
+/// Why: with no priority category present the sampler still has to pick
+/// something informative, and the largest commits carry the most signal.
+/// What: offers only `chore` commits and asserts the XL one is picked first.
+/// Test: this test itself.
+#[test]
+fn diff_sampler_falls_back_to_effort_ordering() {
+    let commits = vec![
+        record("c1", "chore", "XS", 1),
+        record("c2", "chore", "XL", 5),
+        record("c3", "chore", "M", 3),
+    ];
+
+    let selected = stratify_and_select(&commits, 2);
+    assert_eq!(selected.len(), 2);
+    assert_eq!(selected[0].sha, "c2");
+}
+
+/// Why: an untruncated giant diff would crowd out every other period's
+/// evidence, and a reader must be able to tell a diff was cut.
+/// What: truncates a string well over the cap and asserts both the marker and
+/// the length bound.
+/// Test: this test itself.
+#[test]
+fn diff_sampler_truncates_long_diff() {
+    let big = "x".repeat(MAX_DIFF_CHARS + 5000);
+    let result = truncate_diff(&big);
+    assert!(
+        result.contains("[... diff truncated"),
+        "must carry the truncation marker"
+    );
+    let content_chars = result.chars().count();
+    assert!(
+        content_chars <= MAX_DIFF_CHARS + 60,
+        "truncated diff too long: {content_chars}"
+    );
+}
+
+/// Why: the common case is a diff under the cap, and appending a marker to an
+/// intact diff would be a lie.
+/// What: passes a short diff and asserts it comes back byte-identical.
+/// Test: this test itself.
+#[test]
+fn diff_sampler_short_diff_unchanged() {
+    let short = "+fn hello() { println!(\"hi\"); }";
+    assert_eq!(truncate_diff(short), short);
+}
+
+/// Why: a profile spanning ten repositories must not fail because one is not
+/// checked out on this machine.
+/// What: points the config at a path that does not exist and asserts the run
+/// succeeds with zero diffs collected.
+/// Test: this test itself.
+#[test]
+fn diff_sampler_skips_missing_repo() {
+    let db = Database::open_in_memory().expect("open");
+    let aid = seed_author(&db, "Alice", "alice@example.com");
+    seed_commit_with_category_effort(
+        &db,
+        "sha_missing_repo",
+        aid,
+        "nonexistent-repo",
+        "2024-01-08T00:00:00Z",
+        Some("feature"),
+        Some("M"),
+    );
+
+    let mut batches = batches_for(&db, "alice@example.com");
+    assert!(!batches.is_empty(), "should have at least one period");
+
+    let config = DiffSamplerConfig {
+        max_diffs: 3,
+        repo_paths: HashMap::from([(
+            "nonexistent-repo".to_string(),
+            PathBuf::from("/tmp/this-path-absolutely-does-not-exist-tga-profile"),
+        )]),
+        repos_root: None,
+    };
+
+    sample_diffs_for_batches(&mut batches, &db, "alice@example.com", &config)
+        .expect("a missing repo must not fail the run");
+
+    let total_diffs: usize = batches.iter().map(|b| b.sampled_diffs.len()).sum();
+    assert_eq!(total_diffs, 0, "no diffs collected for a missing repo");
+}
+
+/// Why: the whole pass exists to attach real diff text; a green unit test over
+/// mocks would not prove libgit2 is wired to the right commit.
+/// What: builds a real temp repository, records its second commit in the
+/// database, samples, and asserts the added line appears in the diff text.
+/// Test: this test itself.
+#[test]
+fn diff_sampler_fetches_real_diff() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo_path = tmp.path().to_path_buf();
+
+    make_repo_with_initial_commit(tmp.path(), "hello.txt", "hello world\n");
+    let sha = add_commit(tmp.path(), "hello.txt", "hello universe\n");
+
+    let db = Database::open_in_memory().expect("open");
+    let aid = seed_author(&db, "Alice", "alice@example.com");
+    let repo_name = "test-repo";
+    seed_commit_with_category_effort(
+        &db,
+        &sha,
+        aid,
+        repo_name,
+        "2024-01-08T00:00:00Z",
+        Some("feature"),
+        Some("S"),
+    );
+
+    let mut batches = batches_for(&db, "alice@example.com");
+    assert!(!batches.is_empty());
+
+    let config = DiffSamplerConfig {
+        max_diffs: 3,
+        repo_paths: HashMap::from([(repo_name.to_string(), repo_path)]),
+        repos_root: None,
+    };
+
+    sample_diffs_for_batches(&mut batches, &db, "alice@example.com", &config)
+        .expect("sample_diffs");
+
+    let total_diffs: usize = batches.iter().map(|b| b.sampled_diffs.len()).sum();
+    assert_eq!(total_diffs, 1, "one diff sampled");
+
+    let diff = &batches[0].sampled_diffs[0];
+    assert_eq!(diff.sha, sha);
+    assert!(
+        diff.diff_text.contains("+hello universe"),
+        "diff text must contain the added line"
+    );
+    assert_eq!(diff.category, Some("feature".to_string()));
+}
+
+/// Why: the cap is the sampler's only defence against a period with hundreds of
+/// commits, so it has to hold per period, not per run.
+/// What: seeds five commits in one period with `max_diffs = 2` and asserts no
+/// batch exceeds two diffs.
+/// Test: this test itself.
+#[test]
+fn diff_sampler_respects_max_diffs() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo_path = tmp.path().to_path_buf();
+
+    make_repo_with_initial_commit(tmp.path(), "f.txt", "v0\n");
+    let shas: Vec<String> = (1..=5)
+        .map(|i| add_commit(tmp.path(), "f.txt", &format!("v{i}\n")))
+        .collect();
+
+    let db = Database::open_in_memory().expect("open");
+    let aid = seed_author(&db, "Alice", "alice@example.com");
+    let repo_name = "myrepo";
+
+    for (i, sha) in shas.iter().enumerate() {
+        seed_commit_with_category_effort(
+            &db,
+            sha,
+            aid,
+            repo_name,
+            &format!("2024-01-{:02}T00:00:00Z", i + 8),
+            Some("feature"),
+            None,
+        );
+    }
+
+    let mut batches = batches_for(&db, "alice@example.com");
+    let config = DiffSamplerConfig {
+        max_diffs: 2,
+        repo_paths: HashMap::from([(repo_name.to_string(), repo_path)]),
+        repos_root: None,
+    };
+
+    sample_diffs_for_batches(&mut batches, &db, "alice@example.com", &config)
+        .expect("sample_diffs");
+
+    for batch in &batches {
+        assert!(
+            batch.sampled_diffs.len() <= 2,
+            "max_diffs=2 must cap each period, got {}",
+            batch.sampled_diffs.len()
+        );
+    }
+}
+
+/// Why: a caller that names an explicit checkout for one repository expects it
+/// to win over the generic root, otherwise the explicit map is decorative.
+/// What: sets both, then asserts the explicit path, the root fallback, and the
+/// `None` result when neither is configured.
+/// Test: this test itself.
+#[test]
+fn config_repo_path_resolution() {
+    let config = DiffSamplerConfig {
+        repos_root: Some(PathBuf::from("/repos")),
+        repo_paths: HashMap::from([("acme".to_string(), PathBuf::from("/explicit/acme"))]),
+        max_diffs: DEFAULT_MAX_DIFFS,
+    };
+
+    assert_eq!(
+        config.repo_path("acme"),
+        Some(PathBuf::from("/explicit/acme")),
+        "explicit entry wins over repos_root"
+    );
+    assert_eq!(
+        config.repo_path("other"),
+        Some(PathBuf::from("/repos/other")),
+        "repos_root fallback applies"
+    );
+    assert_eq!(
+        DiffSamplerConfig::default().repo_path("anything"),
+        None,
+        "nothing configured → None"
+    );
+}

--- a/crates/trusty-git-analytics/src/profile/error.rs
+++ b/crates/trusty-git-analytics/src/profile/error.rs
@@ -1,0 +1,64 @@
+//! Error types for the contributor-profile pipeline.
+//!
+//! Why: the pipeline spans DB queries, git diff extraction, and report-layer
+//! calls, each with a different failure mode. A dedicated enum lets callers
+//! pattern-match on the failure kind — a missing identity is a user error with
+//! an actionable hint, a SQLite failure is not.
+//! What: defines [`ProfileError`] and the [`Result`] alias used throughout
+//! `profile::`.
+//! Test: `crate::profile::selector::tests::selector_not_found_returns_error`
+//! covers the `ContributorNotFound` hint text; the remaining variants are
+//! exercised by the batch and diff-sampler tests.
+
+use thiserror::Error;
+
+/// Errors that can occur in the contributor-profile pipeline.
+///
+/// Why: typed variants let callers surface actionable messages — a
+/// `ContributorNotFound` tells the user to run `tga aliases list`, while `Db`
+/// surfaces the underlying SQLite failure verbatim.
+/// What: covers identity resolution, database access, git diff extraction,
+/// configuration, and report-layer failures. `#[non_exhaustive]` so the LLM
+/// narrative pass (#5464) can add variants without a major version bump.
+/// Test: `crate::profile::selector::tests::selector_not_found_returns_error`.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ProfileError {
+    /// The requested contributor could not be resolved to a canonical identity
+    /// in the tga database. Carries a hint for the user.
+    #[error(
+        "contributor '{query}' not found in the tga database. \
+         Try `tga aliases list` to see known identities, or provide the canonical email directly."
+    )]
+    ContributorNotFound {
+        /// The name, email, or GitHub login the caller supplied.
+        query: String,
+    },
+
+    /// A `rusqlite` / core DB-layer error occurred.
+    #[error("tga database error: {0}")]
+    Db(#[from] crate::core::TgaError),
+
+    /// A report-layer error (`query_author_period_trends`, …).
+    #[error("tga report error: {0}")]
+    Report(#[from] crate::report::errors::ReportError),
+
+    /// A git error while computing commit diffs.
+    #[error("git error while sampling diffs: {0}")]
+    Git(#[from] crate::collect::errors::CollectError),
+
+    /// A configuration error (e.g. an invalid window size).
+    #[error("profile configuration error: {0}")]
+    Config(String),
+
+    /// An I/O error (e.g. writing the report to an unwritable directory).
+    #[error("I/O error in profile pipeline: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Convenience `Result` alias for the profile pipeline.
+///
+/// Why: avoids repeating `Result<T, ProfileError>` at every call site.
+/// What: aliases `std::result::Result<T, ProfileError>`.
+/// Test: used transitively by every profile-pipeline function.
+pub type Result<T> = std::result::Result<T, ProfileError>;

--- a/crates/trusty-git-analytics/src/profile/mod.rs
+++ b/crates/trusty-git-analytics/src/profile/mod.rs
@@ -1,0 +1,41 @@
+//! Longitudinal contributor profiling.
+//!
+//! Why: a single code review is a snapshot. Aggregating months of a
+//! contributor's commits into period batches is what makes recurring issues,
+//! resolved ones, and quality direction visible at all — none of which any
+//! individual diff shows. Profiling reads git history, identity, effort, and
+//! classification data, all of which tga already owns, which is why it lives
+//! here (#5463, epic #5468).
+//! What: the pipeline runs
+//! [`selector`] → [`batch`] → [`diff_sampler`] → [`synthesizer`] → [`reporter`]:
+//! resolve who the contributor is, split their history into periods, attach
+//! representative diffs, tag findings with their cross-period trend, and write
+//! JSON and Markdown.
+//!
+//! Two stages are deliberately absent and land in follow-on work: the
+//! model-written narrative (#5464) and publishing the profile to a GitHub issue
+//! (#5465). Everything here is deterministic and makes no network calls.
+//! Test: each submodule carries its own tests; start with
+//! `synthesizer::tests::synthesize_deterministic_writes_narrative` for the
+//! end-to-end deterministic shape.
+
+pub mod batch;
+pub mod diff_sampler;
+pub mod error;
+pub mod reporter;
+pub mod selector;
+pub mod synthesizer;
+pub mod types;
+
+pub use batch::{assemble_period_batches, Window};
+pub use diff_sampler::{sample_diffs_for_batches, DiffSamplerConfig, MAX_DIFF_CHARS};
+pub use error::{ProfileError, Result};
+pub use reporter::{render_markdown, ReportFormat, Reporter};
+pub use selector::{resolve_contributor, ContributorSelector, ResolvedIdentity};
+pub use synthesizer::{
+    assign_trend_tags, derive_trajectory, deterministic_narrative, synthesize_deterministic,
+};
+pub use types::{
+    AuthorPeriodSummary, ContributorProfile, FindingEffort, LongitudinalFinding, PeriodBatch,
+    ProfileFinding, SampledDiff, TokenCostSummary, Trajectory, TrendTag, PROFILE_VERSION,
+};

--- a/crates/trusty-git-analytics/src/profile/reporter.rs
+++ b/crates/trusty-git-analytics/src/profile/reporter.rs
@@ -1,0 +1,454 @@
+//! JSON and Markdown rendering for a finished contributor profile.
+//!
+//! Why: the profile has two audiences — a program reading `profile.json` and a
+//! person reading `profile.md` — and neither should have to run the pipeline
+//! again to get its own format.
+//! What: [`Reporter`] writes the configured formats into an output directory;
+//! [`render_markdown`] produces the human-readable document (header, quality
+//! trend, strengths, weaknesses, findings table, narrative, cost). Publishing
+//! the profile to a GitHub issue is #5465 and is deliberately absent here.
+//! Test: the `tests` module covers JSON round-tripping, every Markdown
+//! section, format parsing, and the file-stem sanitisation.
+
+use std::path::PathBuf;
+
+use tracing::info;
+
+use super::types::{ContributorProfile, Trajectory, TrendTag};
+
+// ─── Output format ───────────────────────────────────────────────────────────
+
+/// Which files a profile run writes.
+///
+/// Why: a dashboard wants only JSON, a manager only Markdown, and a CLI run
+/// usually wants both.
+/// What: three-variant enum consumed by [`Reporter::write_profile`], parsable
+/// from a CLI string via `FromStr`.
+/// Test: `report_format_from_str`, `reporter_both_format_writes_two_files`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportFormat {
+    /// Write only the JSON profile.
+    Json,
+    /// Write only the Markdown profile.
+    Markdown,
+    /// Write both.
+    Both,
+}
+
+impl std::str::FromStr for ReportFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "json" => Ok(Self::Json),
+            "markdown" | "md" => Ok(Self::Markdown),
+            "both" => Ok(Self::Both),
+            other => Err(format!("unknown format: {other}")),
+        }
+    }
+}
+
+// ─── Reporter ────────────────────────────────────────────────────────────────
+
+/// Writes a finished profile to disk.
+///
+/// Why: keeping I/O out of the pipeline means the rendering can be tested
+/// without a filesystem and the pipeline without a renderer.
+/// What: holds the output directory and the format; [`Reporter::write_profile`]
+/// creates the directory and writes the files, returning their paths.
+/// Test: `reporter_json_output`, `reporter_both_format_writes_two_files`.
+pub struct Reporter {
+    output_dir: PathBuf,
+    format: ReportFormat,
+}
+
+impl Reporter {
+    /// Create a reporter writing `format` into `output_dir`.
+    ///
+    /// Why: both settings are fixed for a run, so they belong on the reporter
+    /// rather than on every call.
+    /// What: stores the directory and format; the directory is created lazily
+    /// on the first write.
+    /// Test: used by every reporter test.
+    pub fn new(output_dir: impl Into<PathBuf>, format: ReportFormat) -> Self {
+        Self {
+            output_dir: output_dir.into(),
+            format,
+        }
+    }
+
+    /// Write the profile in the configured format.
+    ///
+    /// Why: this is the pipeline's last step, and the caller needs the paths
+    /// back so it can print or publish them.
+    /// What: creates the output directory if needed, writes `<stem>.json`
+    /// and/or `<stem>.md` where the stem is derived from the contributor and
+    /// window, and returns the paths written in that order.
+    /// Test: `reporter_json_output`, `reporter_both_format_writes_two_files`.
+    ///
+    /// # Errors
+    ///
+    /// [`std::io::Error`] when the directory cannot be created, a file cannot
+    /// be written, or the profile cannot be serialised.
+    pub fn write_profile(
+        &self,
+        profile: &ContributorProfile,
+    ) -> std::result::Result<Vec<PathBuf>, std::io::Error> {
+        std::fs::create_dir_all(&self.output_dir)?;
+
+        let mut written = Vec::new();
+        let stem = profile_file_stem(profile);
+
+        if matches!(self.format, ReportFormat::Json | ReportFormat::Both) {
+            let json_path = self.output_dir.join(format!("{stem}.json"));
+            let json = serde_json::to_string_pretty(profile)
+                .map_err(|e| std::io::Error::other(format!("JSON serialise: {e}")))?;
+            std::fs::write(&json_path, &json)?;
+            info!(path = %json_path.display(), "profile JSON written");
+            written.push(json_path);
+        }
+
+        if matches!(self.format, ReportFormat::Markdown | ReportFormat::Both) {
+            let md_path = self.output_dir.join(format!("{stem}.md"));
+            std::fs::write(&md_path, render_markdown(profile))?;
+            info!(path = %md_path.display(), "profile Markdown written");
+            written.push(md_path);
+        }
+
+        Ok(written)
+    }
+}
+
+// ─── File stem helper ────────────────────────────────────────────────────────
+
+/// Build a filesystem-safe stem for a profile's output files.
+///
+/// Why: the email plus the window is the natural unique key, but an email is
+/// not a safe filename on every platform.
+/// What: replaces `@`, `.`, `/`, and spaces with `_`, then appends the first
+/// ten characters of each window bound.
+/// Test: `profile_file_stem_safe`.
+fn profile_file_stem(profile: &ContributorProfile) -> String {
+    let email_safe = profile.canonical_email.replace(['@', '.', '/', ' '], "_");
+    format!(
+        "profile_{}_{}_{}",
+        email_safe,
+        &profile.profiled_since[..10.min(profile.profiled_since.len())],
+        &profile.profiled_until[..10.min(profile.profiled_until.len())],
+    )
+}
+
+// ─── Markdown renderer ───────────────────────────────────────────────────────
+
+/// Render a profile as a Markdown document.
+///
+/// Why: Markdown is what a person reads and what a tracker comment accepts, so
+/// one renderer serves both.
+/// What: emits the identity header, a quality-trend table with an ASCII bar,
+/// strengths and weaknesses, the trend-tagged findings table, the narrative,
+/// and — only when a model was actually called — the token/cost table. Empty
+/// sections are omitted rather than rendered blank.
+/// Test: `reporter_markdown_contains_sections`,
+/// `reporter_markdown_no_cost_section_when_zero`.
+pub fn render_markdown(profile: &ContributorProfile) -> String {
+    use std::fmt::Write as _;
+
+    let mut md = String::with_capacity(4096);
+
+    let _ = write!(
+        md,
+        "# Developer Profile: {} ({})\n\n",
+        profile.canonical_name, profile.canonical_email
+    );
+    // The two trailing spaces are a Markdown hard line break.
+    let _ = writeln!(
+        md,
+        "**Window**: {} → {}  ",
+        profile.profiled_since, profile.profiled_until
+    );
+    if !profile.repositories.is_empty() {
+        let _ = writeln!(
+            md,
+            "**Repositories**: {}  ",
+            profile.repositories.join(", ")
+        );
+    }
+    let traj_str = match profile.improvement_trajectory {
+        Trajectory::Improving => "Improving",
+        Trajectory::Stable => "Stable",
+        Trajectory::Declining => "Declining",
+    };
+    let _ = writeln!(md, "**Trajectory**: {traj_str}  ");
+    let _ = writeln!(md, "**Generated**: {}  \n", profile.generated_at);
+
+    if !profile.quality_trend.is_empty() {
+        md.push_str("## Quality Trend\n\n");
+        md.push_str("| Period | Score |\n|--------|:-----:|\n");
+        for (label, score) in &profile.quality_trend {
+            let bar = quality_bar(*score, 5.0);
+            let _ = writeln!(md, "| {label} | {score:.2} {bar} |");
+        }
+        md.push('\n');
+    }
+
+    if !profile.strengths.is_empty() {
+        md.push_str("## Strengths\n\n");
+        for s in &profile.strengths {
+            let _ = writeln!(md, "- {s}");
+        }
+        md.push('\n');
+    }
+
+    if !profile.recurring_weaknesses.is_empty() {
+        md.push_str("## Areas for Improvement\n\n");
+        for w in &profile.recurring_weaknesses {
+            let _ = writeln!(md, "- {w}");
+        }
+        md.push('\n');
+    }
+
+    if !profile.all_findings.is_empty() {
+        md.push_str("## Findings\n\n");
+        md.push_str(
+            "| Period | Kind | Trend | Description |\n\
+             |--------|------|-------|-------------|\n",
+        );
+        for lf in &profile.all_findings {
+            // Escape pipes so a description can never break the table.
+            let desc = lf.finding.description.replace('|', "\\|");
+            let _ = writeln!(
+                md,
+                "| {} | {} | {} | {} |",
+                lf.period_label,
+                lf.finding.kind,
+                trend_tag_str(lf.trend_tag),
+                desc
+            );
+        }
+        md.push('\n');
+    }
+
+    if !profile.narrative.is_empty() {
+        md.push_str("## Engineering Assessment\n\n");
+        md.push_str(&profile.narrative);
+        md.push_str("\n\n");
+    }
+
+    let tc = &profile.token_cost;
+    if tc.input_tokens > 0 || tc.output_tokens > 0 {
+        md.push_str("## Token & Cost Summary\n\n");
+        let _ = write!(
+            md,
+            "| Metric | Value |\n|--------|-------|\n\
+             | Input tokens | {} |\n\
+             | Output tokens | {} |\n\
+             | Estimated cost | ${:.6} |\n\
+             | Total latency | {}ms |\n\n",
+            tc.input_tokens, tc.output_tokens, tc.cost_usd, tc.latency_ms
+        );
+    }
+
+    let _ = write!(
+        md,
+        "---\n*Generated by tga {} — {}*\n",
+        profile.review_version, profile.generated_at
+    );
+
+    md
+}
+
+/// Render a five-cell ASCII bar for a score out of `max`.
+fn quality_bar(score: f64, max: f64) -> String {
+    let filled = ((score / max) * 5.0).round().clamp(0.0, 5.0) as usize;
+    let empty = 5usize.saturating_sub(filled);
+    format!("{}{}", "▓".repeat(filled), "░".repeat(empty))
+}
+
+/// Render a trend tag for the Markdown findings table.
+fn trend_tag_str(tag: Option<TrendTag>) -> &'static str {
+    match tag {
+        Some(TrendTag::Recurring) => "🔁 Recurring",
+        Some(TrendTag::New) => "🆕 New",
+        Some(TrendTag::Resolved) => "✅ Resolved",
+        Some(TrendTag::Worsening) => "📈 Worsening",
+        None => "—",
+    }
+}
+
+// ─── Unit tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profile::types::{
+        FindingEffort, LongitudinalFinding, ProfileFinding, TokenCostSummary,
+    };
+
+    fn make_profile() -> ContributorProfile {
+        let mut p = ContributorProfile::new(
+            "alice@example.com",
+            "Alice Smith",
+            "2026-01-01",
+            "2026-06-30",
+        );
+        p.repositories = vec!["acme/api".to_string()];
+        p.improvement_trajectory = Trajectory::Improving;
+        p.quality_trend = vec![("2026-Q1".to_string(), 3.0), ("2026-Q2".to_string(), 3.8)];
+        p.strengths = vec!["Consistent ticket coverage".to_string()];
+        p.recurring_weaknesses = vec!["Missing error handling".to_string()];
+        p.all_findings = vec![LongitudinalFinding {
+            period_label: "2026-Q1".to_string(),
+            finding: ProfileFinding::new(
+                "src/lib.rs",
+                "error_handling",
+                "Missing propagation",
+                "Use ?",
+                0.8,
+                FindingEffort::Medium,
+            ),
+            trend_tag: Some(TrendTag::Recurring),
+        }];
+        p.narrative = "Alice shows strong improvement.".to_string();
+        p.token_cost = TokenCostSummary {
+            input_tokens: 500,
+            output_tokens: 200,
+            cost_usd: 0.005,
+            latency_ms: 1500,
+        };
+        p
+    }
+
+    /// Why: the JSON file is the machine-readable contract, so it must parse
+    /// back into the same profile rather than merely being written.
+    /// What: writes to a temp directory, reads the file back, and asserts the
+    /// identity survived.
+    /// Test: this test itself.
+    #[test]
+    fn reporter_json_output() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let reporter = Reporter::new(tmp.path(), ReportFormat::Json);
+
+        let paths = reporter.write_profile(&make_profile()).expect("write");
+        assert_eq!(paths.len(), 1);
+        assert!(paths[0].extension().is_some_and(|e| e == "json"));
+
+        let content = std::fs::read_to_string(&paths[0]).expect("read");
+        let back: ContributorProfile = serde_json::from_str(&content).expect("parse");
+        assert_eq!(back.canonical_email, "alice@example.com");
+    }
+
+    /// Why: the Markdown document is what a manager actually reads; a silently
+    /// dropped section loses evidence without failing anything.
+    /// What: renders a fully-populated profile and asserts every section
+    /// heading and one piece of its content.
+    /// Test: this test itself.
+    #[test]
+    fn reporter_markdown_contains_sections() {
+        let md = render_markdown(&make_profile());
+
+        assert!(md.contains("# Developer Profile: Alice Smith"), "header");
+        assert!(md.contains("## Quality Trend"), "quality trend section");
+        assert!(md.contains("2026-Q1"), "period label");
+        assert!(md.contains("## Strengths"), "strengths section");
+        assert!(md.contains("Consistent ticket coverage"), "strength text");
+        assert!(md.contains("## Areas for Improvement"), "weaknesses");
+        assert!(md.contains("## Findings"), "findings section");
+        assert!(md.contains("error_handling"), "finding kind");
+        assert!(md.contains("Recurring"), "trend tag");
+        assert!(
+            md.contains("## Engineering Assessment"),
+            "narrative section"
+        );
+        assert!(md.contains("Alice shows strong improvement"), "narrative");
+        assert!(md.contains("## Token & Cost Summary"), "cost section");
+        assert!(md.contains("500"), "input tokens");
+        assert!(md.contains("Generated by tga"), "footer names tga");
+    }
+
+    /// Why: `Both` is the CLI default shape, and writing one file while
+    /// reporting two paths would be a silent data loss.
+    /// What: writes with `Both` and asserts one `.json` and one `.md`.
+    /// Test: this test itself.
+    #[test]
+    fn reporter_both_format_writes_two_files() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let reporter = Reporter::new(tmp.path(), ReportFormat::Both);
+
+        let paths = reporter.write_profile(&make_profile()).expect("write");
+        assert_eq!(paths.len(), 2, "Both writes two files");
+        assert!(paths
+            .iter()
+            .any(|p| p.extension().is_some_and(|e| e == "json")));
+        assert!(paths
+            .iter()
+            .any(|p| p.extension().is_some_and(|e| e == "md")));
+    }
+
+    /// Why: an email contains `@` and `.`, which make for a hostile filename;
+    /// the stem is also how a later run finds the previous profile.
+    /// What: asserts the stem is prefixed and carries no `@`.
+    /// Test: this test itself.
+    #[test]
+    fn profile_file_stem_safe() {
+        let stem = profile_file_stem(&make_profile());
+        assert!(!stem.contains('@'), "stem must not contain @: {stem}");
+        assert!(stem.starts_with("profile_"), "stem prefix: {stem}");
+    }
+
+    /// Why: the format comes from a CLI flag, so unknown input must be rejected
+    /// rather than silently defaulted.
+    /// What: parses each accepted spelling and asserts an unknown one errors.
+    /// Test: this test itself.
+    #[test]
+    fn report_format_from_str() {
+        use std::str::FromStr;
+        assert_eq!(
+            ReportFormat::from_str("json").expect("json"),
+            ReportFormat::Json
+        );
+        assert_eq!(
+            ReportFormat::from_str("markdown").expect("markdown"),
+            ReportFormat::Markdown
+        );
+        assert_eq!(
+            ReportFormat::from_str("both").expect("both"),
+            ReportFormat::Both
+        );
+        assert_eq!(
+            ReportFormat::from_str("md").expect("md"),
+            ReportFormat::Markdown
+        );
+        assert!(ReportFormat::from_str("xml").is_err());
+    }
+
+    /// Why: a deterministic run makes no model calls, and a cost table full of
+    /// zeros would imply one was made and was free.
+    /// What: zeroes the telemetry and asserts the section is absent.
+    /// Test: this test itself.
+    #[test]
+    fn reporter_markdown_no_cost_section_when_zero() {
+        let mut profile = make_profile();
+        profile.token_cost = TokenCostSummary::default();
+        let md = render_markdown(&profile);
+        assert!(
+            !md.contains("## Token & Cost Summary"),
+            "zero cost omits the cost section"
+        );
+    }
+
+    /// Why: a description containing a pipe would break the Markdown table and
+    /// silently corrupt every column after it.
+    /// What: renders a finding whose description contains `|` and asserts the
+    /// pipe was escaped.
+    /// Test: this test itself.
+    #[test]
+    fn reporter_markdown_escapes_pipes_in_description() {
+        let mut profile = make_profile();
+        profile.all_findings[0].finding.description = "matches a|b in the regex".to_string();
+        let md = render_markdown(&profile);
+        assert!(
+            md.contains("matches a\\|b in the regex"),
+            "pipe must be escaped: {md}"
+        );
+    }
+}

--- a/crates/trusty-git-analytics/src/profile/selector.rs
+++ b/crates/trusty-git-analytics/src/profile/selector.rs
@@ -1,0 +1,369 @@
+//! Contributor identity resolution against the tga database.
+//!
+//! Why: a caller naming a contributor supplies whatever they have — a GitHub
+//! login, a display name, an old work email — while every downstream query
+//! keys on `authors.canonical_email`. This module owns that translation so no
+//! caller has to know the `authors` schema or the resolver's matching tiers.
+//! What: [`ContributorSelector`] opens the database, queries `authors`
+//! directly, and falls back to
+//! [`IdentityResolver`](crate::collect::identity::IdentityResolver) fuzzy
+//! matching. An unmatched query returns
+//! [`ProfileError::ContributorNotFound`] carrying the `tga aliases list` hint.
+//! Test: the `tests` module seeds an in-memory database with known authors and
+//! aliases, then asserts exact, name, alias, and not-found resolution.
+
+use tracing::{debug, warn};
+
+use crate::collect::identity::IdentityResolver;
+use crate::core::db::Database;
+
+use super::error::{ProfileError, Result};
+
+// ─── Resolved identity ───────────────────────────────────────────────────────
+
+/// A contributor identity resolved against the `authors` table.
+///
+/// Why: the email keys every later query and the name is what the report
+/// header prints, so resolution must return both rather than making the caller
+/// look the other one up.
+/// What: the two canonical columns of the matched `authors` row.
+/// Test: asserted by every positive-path selector test.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedIdentity {
+    /// Canonical email, as stored in `authors.canonical_email`.
+    pub canonical_email: String,
+    /// Canonical display name, as stored in `authors.canonical_name`.
+    pub canonical_name: String,
+}
+
+// ─── ContributorSelector ─────────────────────────────────────────────────────
+
+/// Opens a tga database and resolves contributor identities against it.
+///
+/// Why: the resolver is expensive to build (it reads every author row), so a
+/// profile run builds it once and reuses it for every lookup.
+/// What: holds an open [`Database`] plus an [`IdentityResolver`] seeded from
+/// the `authors` rows, so partial-name and old-email queries resolve the same
+/// way `tga collect` resolves them.
+/// Test: see the `tests` module below.
+pub struct ContributorSelector {
+    db: Database,
+    resolver: IdentityResolver,
+}
+
+impl ContributorSelector {
+    /// Open the tga database at `db_path` and build the resolver from it.
+    ///
+    /// Why: opening once per run keeps every later `resolve` call in memory.
+    /// What: opens the database (the migration runner is idempotent, so
+    /// opening an existing database is safe) and seeds the resolver from
+    /// `authors`.
+    /// Test: `tests::selector_resolves_canonical_email`.
+    ///
+    /// # Errors
+    ///
+    /// [`ProfileError::Db`] when the database cannot be opened or read.
+    pub fn open(db_path: &std::path::Path) -> Result<Self> {
+        let db = Database::open(db_path).map_err(ProfileError::Db)?;
+        let resolver = build_resolver_from_db(&db)?;
+        Ok(Self { db, resolver })
+    }
+
+    /// Open an in-memory database. Test-only.
+    ///
+    /// Why: the selector tests need to seed a known author set without touching
+    /// the filesystem.
+    /// What: opens `Database::open_in_memory()` and seeds the resolver from it.
+    /// Test: used by every test in this module.
+    ///
+    /// # Errors
+    ///
+    /// [`ProfileError::Db`] on SQLite failure.
+    #[cfg(test)]
+    pub(crate) fn open_in_memory() -> Result<Self> {
+        let db = Database::open_in_memory().map_err(ProfileError::Db)?;
+        let resolver = build_resolver_from_db(&db)?;
+        Ok(Self { db, resolver })
+    }
+
+    /// Borrow the underlying database.
+    ///
+    /// Why: batch assembly and diff sampling query the same database the
+    /// selector already has open; handing out a borrow avoids a second
+    /// connection and a second migration run.
+    /// What: a shared borrow of the internal [`Database`].
+    /// Test: used by `tests::selector_resolves_canonical_email` via the seed
+    /// helper, and transitively by the batch and diff-sampler tests.
+    pub fn database(&self) -> &Database {
+        &self.db
+    }
+
+    /// Resolve a caller-supplied query to a canonical identity.
+    ///
+    /// Why: see the module doc — the caller has one of several identifiers and
+    /// the pipeline needs exactly one.
+    /// What: tries four strategies in order and returns the first hit —
+    /// canonical email (case-insensitive), canonical name (case-insensitive),
+    /// a substring hit in the `aliases` JSON column, then
+    /// [`IdentityResolver`] fuzzy matching.
+    /// Test: `tests::selector_resolves_canonical_email`,
+    /// `tests::selector_resolves_by_name`, `tests::selector_resolves_via_alias`,
+    /// `tests::selector_not_found_returns_error`.
+    ///
+    /// # Errors
+    ///
+    /// - [`ProfileError::ContributorNotFound`] when no strategy matches.
+    /// - [`ProfileError::Db`] on SQLite failure.
+    pub fn resolve(&self, query: &str) -> Result<ResolvedIdentity> {
+        let query_lc = query.to_lowercase();
+        debug!(query, "ContributorSelector::resolve");
+
+        if let Some(id) = self.lookup_by_email(&query_lc)? {
+            return Ok(id);
+        }
+        if let Some(id) = self.lookup_by_name(query)? {
+            return Ok(id);
+        }
+        if let Some(id) = self.lookup_by_alias_json(query)? {
+            return Ok(id);
+        }
+
+        // Fuzzy resolution: passing the query as both name and email triggers
+        // every matching tier. A returned pair that differs from the input is
+        // the resolver's signal that it matched something.
+        let (resolved_name, resolved_email) = self.resolver.resolve(query, query);
+        if resolved_email != query || resolved_name != query {
+            debug!(
+                resolved_name,
+                resolved_email, "ContributorSelector: fuzzy match"
+            );
+            return Ok(ResolvedIdentity {
+                canonical_email: resolved_email,
+                canonical_name: resolved_name,
+            });
+        }
+
+        warn!(query, "ContributorSelector: no identity found");
+        Err(ProfileError::ContributorNotFound {
+            query: query.to_string(),
+        })
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────
+
+    fn lookup_by_email(&self, email_lc: &str) -> Result<Option<ResolvedIdentity>> {
+        self.query_one(
+            "SELECT canonical_email, canonical_name \
+             FROM authors WHERE LOWER(canonical_email) = ?1 LIMIT 1",
+            email_lc,
+        )
+    }
+
+    fn lookup_by_name(&self, name: &str) -> Result<Option<ResolvedIdentity>> {
+        self.query_one(
+            "SELECT canonical_email, canonical_name \
+             FROM authors WHERE LOWER(canonical_name) = LOWER(?1) LIMIT 1",
+            name,
+        )
+    }
+
+    /// Search the `authors.aliases` JSON column for `query` as a substring.
+    ///
+    /// Why: GitHub logins and old emails live in the `aliases` JSON array, and
+    /// a `LIKE` scan covers the common case without parsing every row's JSON.
+    /// What: escapes `%` and `_` in the query, then matches the serialised
+    /// array with `LIKE … ESCAPE '\'`.
+    /// Test: `tests::selector_resolves_via_alias`.
+    fn lookup_by_alias_json(&self, query: &str) -> Result<Option<ResolvedIdentity>> {
+        let escaped = query.replace('%', "\\%").replace('_', "\\_");
+        let pattern = format!("%{escaped}%");
+        self.query_one(
+            "SELECT canonical_email, canonical_name \
+             FROM authors WHERE aliases LIKE ?1 ESCAPE '\\' LIMIT 1",
+            &pattern,
+        )
+    }
+
+    /// Run a one-parameter, one-row identity query.
+    ///
+    /// Why: the three lookup strategies differ only in their WHERE clause; one
+    /// helper keeps the "no rows is not an error" handling in a single place.
+    /// What: maps `QueryReturnedNoRows` to `Ok(None)` and any other rusqlite
+    /// error to [`ProfileError::Db`].
+    /// Test: exercised by every selector lookup test.
+    fn query_one(&self, sql: &str, param: &str) -> Result<Option<ResolvedIdentity>> {
+        let conn = self.db.connection();
+        let result: rusqlite::Result<(String, String)> =
+            conn.query_row(sql, [param], |row| Ok((row.get(0)?, row.get(1)?)));
+        match result {
+            Ok((canonical_email, canonical_name)) => Ok(Some(ResolvedIdentity {
+                canonical_email,
+                canonical_name,
+            })),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(ProfileError::Db(crate::core::TgaError::from(e))),
+        }
+    }
+}
+
+/// Build an [`IdentityResolver`] seeded from the `authors` table.
+///
+/// Why: fuzzy matching has to see every known identity, and re-reading the
+/// table per query would make resolution O(queries × authors).
+/// What: reads `(canonical_name, canonical_email, aliases)` for every author,
+/// puts the canonical email first in each alias list so the resolver picks it
+/// as canonical, and hands the map to `IdentityResolver::from_alias_map`.
+/// Test: exercised by every selector test.
+fn build_resolver_from_db(db: &Database) -> Result<IdentityResolver> {
+    use std::collections::HashMap;
+
+    let conn = db.connection();
+    let mut stmt = conn
+        .prepare("SELECT canonical_name, canonical_email, aliases FROM authors")
+        .map_err(|e| ProfileError::Db(crate::core::TgaError::from(e)))?;
+
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(|e| ProfileError::Db(crate::core::TgaError::from(e)))?;
+
+    let mut alias_map: HashMap<String, Vec<String>> = HashMap::new();
+    for r in rows {
+        let (name, email, aliases_json) =
+            r.map_err(|e| ProfileError::Db(crate::core::TgaError::from(e)))?;
+        let mut aliases: Vec<String> = serde_json::from_str(&aliases_json).unwrap_or_default();
+        if !email.is_empty() {
+            aliases.insert(0, email);
+        }
+        alias_map.insert(name, aliases);
+    }
+
+    Ok(IdentityResolver::from_alias_map(&alias_map))
+}
+
+/// Resolve a contributor query against the database at `db_path`.
+///
+/// Why: a one-shot caller (a CLI invocation that resolves and exits) should not
+/// have to keep a selector alive.
+/// What: opens a selector, resolves, and drops the database on return.
+/// Test: `tests::resolve_contributor_opens_and_resolves`.
+///
+/// # Errors
+///
+/// As [`ContributorSelector::resolve`], plus [`ProfileError::Db`] on open.
+pub fn resolve_contributor(db_path: &std::path::Path, query: &str) -> Result<ResolvedIdentity> {
+    let sel = ContributorSelector::open(db_path)?;
+    sel.resolve(query)
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+
+    fn seed_author(db: &Database, name: &str, email: &str, aliases_json: &str) {
+        db.connection()
+            .execute(
+                "INSERT INTO authors (canonical_name, canonical_email, aliases) \
+                 VALUES (?1, ?2, ?3)",
+                params![name, email, aliases_json],
+            )
+            .expect("insert author");
+    }
+
+    fn make_selector_with_authors() -> ContributorSelector {
+        let mut sel = ContributorSelector::open_in_memory().expect("open");
+        seed_author(sel.database(), "Alice Smith", "alice@example.com", r#"[]"#);
+        seed_author(
+            sel.database(),
+            "Bob Jones",
+            "bob@example.com",
+            r#"["bob-gh", "bob.jones@old.example.com"]"#,
+        );
+        // The resolver was built before the seed, so rebuild it.
+        sel.resolver = build_resolver_from_db(sel.database()).expect("rebuild resolver");
+        sel
+    }
+
+    /// Why: an exact canonical email is the cheapest and most common query, and
+    /// it must never fall through to fuzzy matching.
+    /// What: resolves a known canonical email and asserts both fields.
+    /// Test: this test itself.
+    #[test]
+    fn selector_resolves_canonical_email() {
+        let sel = make_selector_with_authors();
+        let id = sel.resolve("alice@example.com").expect("resolve");
+        assert_eq!(id.canonical_email, "alice@example.com");
+        assert_eq!(id.canonical_name, "Alice Smith");
+    }
+
+    /// Why: people name colleagues by display name far more often than by
+    /// canonical email, and casing is not something a caller should have to get
+    /// right.
+    /// What: resolves a display name and asserts the canonical pair.
+    /// Test: this test itself.
+    #[test]
+    fn selector_resolves_by_name() {
+        let sel = make_selector_with_authors();
+        let id = sel.resolve("Bob Jones").expect("resolve by name");
+        assert_eq!(id.canonical_email, "bob@example.com");
+        assert_eq!(id.canonical_name, "Bob Jones");
+    }
+
+    /// Why: a GitHub login is stored only in the `aliases` JSON, so without the
+    /// alias scan the most natural identifier a user has would not resolve.
+    /// What: resolves `bob-gh`, which appears only inside Bob's alias array.
+    /// Test: this test itself.
+    #[test]
+    fn selector_resolves_via_alias() {
+        let sel = make_selector_with_authors();
+        let id = sel.resolve("bob-gh").expect("resolve via alias");
+        assert_eq!(id.canonical_email, "bob@example.com");
+        assert_eq!(id.canonical_name, "Bob Jones");
+    }
+
+    /// Why: an unknown contributor is a user error, and the error has to tell
+    /// the user how to find the right identifier rather than just failing.
+    /// What: resolves an unknown email and asserts both the error variant and
+    /// the `tga aliases list` hint in its message.
+    /// Test: this test itself.
+    #[test]
+    fn selector_not_found_returns_error() {
+        let sel = make_selector_with_authors();
+        let err = sel.resolve("nobody@nowhere.test").expect_err("should fail");
+        assert!(
+            matches!(err, ProfileError::ContributorNotFound { .. }),
+            "expected ContributorNotFound, got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("tga aliases list"),
+            "error message should mention 'tga aliases list': {msg}"
+        );
+    }
+
+    /// Why: `resolve_contributor` is the one-shot path a CLI takes, and it has
+    /// to behave identically to the long-lived selector.
+    /// What: writes a seeded database to a temp file, resolves through the free
+    /// function, and asserts the canonical pair.
+    /// Test: this test itself.
+    #[test]
+    fn resolve_contributor_opens_and_resolves() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("tga.db");
+        {
+            let db = Database::open(&db_path).expect("open");
+            seed_author(&db, "Carol King", "carol@example.com", r#"["carol-gh"]"#);
+        }
+
+        let id = resolve_contributor(&db_path, "carol@example.com").expect("resolve");
+        assert_eq!(id.canonical_name, "Carol King");
+    }
+}

--- a/crates/trusty-git-analytics/src/profile/synthesizer.rs
+++ b/crates/trusty-git-analytics/src/profile/synthesizer.rs
@@ -1,0 +1,518 @@
+//! Deterministic cross-period synthesis for the contributor-profile pipeline.
+//!
+//! Why: per-period findings are independent snapshots. Merging them is what
+//! produces the profile's only genuinely longitudinal signal — that the same
+//! issue keeps coming back, or stopped. That merge is arithmetic, not
+//! judgement, so it runs without a model and stays reproducible.
+//! What: [`synthesize_deterministic`] fills the quality trend, clusters
+//! findings by Jaccard token-set similarity, assigns a [`TrendTag`] per
+//! cluster, derives the [`Trajectory`] from the quality-score slope, and writes
+//! a factual narrative. The model-written narrative that replaces that text is
+//! #5464 and is deliberately absent here.
+//! Test: the `tests` module covers similarity, each trend tag, slope-derived
+//! trajectory, and the narrative text.
+
+use tracing::debug;
+
+use super::types::{ContributorProfile, LongitudinalFinding, PeriodBatch, Trajectory, TrendTag};
+
+/// Token-set similarity at or above which two findings are treated as the same
+/// underlying issue.
+const JACCARD_THRESHOLD: f64 = 0.7;
+
+/// Quality-score slope beyond which a trend counts as directional rather than
+/// noise.
+const TRAJECTORY_SLOPE_EPSILON: f64 = 0.1;
+
+// ─── Public entry point ──────────────────────────────────────────────────────
+
+/// Run the deterministic half of synthesis over a profile, in place.
+///
+/// Why: a profile is useful without any model call — the quality trend, the
+/// recurring-issue count, and the trajectory are all computable from the data
+/// alone, and computing them here means the narrative pass (#5464) can fail
+/// without costing the caller the whole profile.
+/// What: populates `quality_trend` from the period statistics, flattens and
+/// trend-tags every finding, derives `improvement_trajectory` from the slope of
+/// the quality trend, and writes [`deterministic_narrative`] into `narrative`.
+/// Strengths and weaknesses are left empty — those are judgements, not
+/// derivations.
+/// Test: `synthesize_deterministic_populates_quality_trend`,
+/// `synthesize_deterministic_writes_narrative`.
+pub fn synthesize_deterministic(
+    profile: &mut ContributorProfile,
+    all_period_findings: Vec<Vec<LongitudinalFinding>>,
+    periods: &[PeriodBatch],
+) {
+    profile.quality_trend = periods
+        .iter()
+        .map(|b| (b.stats.period_label.clone(), b.stats.quality_score))
+        .collect();
+
+    let flat: Vec<LongitudinalFinding> = all_period_findings.into_iter().flatten().collect();
+    debug!(
+        findings = flat.len(),
+        periods = periods.len(),
+        "synthesize_deterministic"
+    );
+    profile.all_findings = assign_trend_tags(flat);
+    profile.improvement_trajectory = derive_trajectory(&profile.quality_trend);
+    profile.narrative = deterministic_narrative(profile);
+}
+
+// ─── Jaccard dedup + trend-tag assignment ────────────────────────────────────
+
+/// Assign a [`TrendTag`] to every finding in a flat, all-periods list.
+///
+/// Why: raw per-period findings carry no trend; without clustering, the same
+/// issue reported in four periods reads as four unrelated problems.
+/// What: clusters findings whose descriptions have Jaccard similarity ≥ 0.7,
+/// then tags each cluster by which periods it spans — present in the latest
+/// period and in an earlier one is `Recurring` (or `Worsening` when the latest
+/// occurrence's confidence rose by more than 0.1), latest only is `New`,
+/// earlier only is `Resolved`.
+/// Test: `synthesizer_dedup_assigns_recurring`,
+/// `synthesizer_dedup_assigns_new`, `synthesizer_dedup_assigns_resolved`,
+/// `synthesizer_dedup_assigns_worsening`.
+pub fn assign_trend_tags(findings: Vec<LongitudinalFinding>) -> Vec<LongitudinalFinding> {
+    if findings.is_empty() {
+        return findings;
+    }
+
+    // Period order is insertion order — the caller feeds periods oldest first.
+    let mut period_order: Vec<&str> = Vec::new();
+    for f in &findings {
+        if !period_order.contains(&f.period_label.as_str()) {
+            period_order.push(f.period_label.as_str());
+        }
+    }
+    let latest_period = period_order.last().unwrap_or(&"").to_string();
+
+    let clusters = cluster_by_similarity(&findings);
+
+    let mut tagged = findings;
+    for cluster in &clusters {
+        let in_latest = cluster
+            .iter()
+            .any(|&idx| tagged[idx].period_label == latest_period);
+        let in_earlier = cluster
+            .iter()
+            .any(|&idx| tagged[idx].period_label != latest_period);
+
+        // Confidence stands in for severity: findings arrive from a review pass
+        // that does not carry an explicit severity field.
+        let worsening = in_latest && in_earlier && cluster.len() >= 2 && {
+            let first_conf = tagged[cluster[0]].finding.confidence;
+            let last_conf = tagged[cluster[cluster.len() - 1]].finding.confidence;
+            last_conf > first_conf + 0.1
+        };
+
+        let tag = match (worsening, in_latest, in_earlier) {
+            (true, _, _) => TrendTag::Worsening,
+            (_, true, true) => TrendTag::Recurring,
+            (_, true, false) => TrendTag::New,
+            _ => TrendTag::Resolved,
+        };
+
+        for &idx in cluster {
+            tagged[idx].trend_tag = Some(tag);
+        }
+    }
+
+    tagged
+}
+
+/// Group finding indices into clusters of mutually similar descriptions.
+///
+/// Why: keeps [`assign_trend_tags`] readable by separating "which findings are
+/// the same issue" from "what does that imply".
+/// What: greedy single-pass clustering — each unassigned finding seeds a
+/// cluster and absorbs every later finding within [`JACCARD_THRESHOLD`] of it.
+/// Test: exercised by every `synthesizer_dedup_*` test.
+fn cluster_by_similarity(findings: &[LongitudinalFinding]) -> Vec<Vec<usize>> {
+    let mut clusters: Vec<Vec<usize>> = Vec::new();
+    let mut assigned = vec![false; findings.len()];
+
+    for i in 0..findings.len() {
+        if assigned[i] {
+            continue;
+        }
+        let mut cluster = vec![i];
+        assigned[i] = true;
+        for j in (i + 1)..findings.len() {
+            if assigned[j] {
+                continue;
+            }
+            if jaccard_similarity(
+                &findings[i].finding.description,
+                &findings[j].finding.description,
+            ) >= JACCARD_THRESHOLD
+            {
+                cluster.push(j);
+                assigned[j] = true;
+            }
+        }
+        clusters.push(cluster);
+    }
+
+    clusters
+}
+
+/// Jaccard similarity between two finding descriptions.
+///
+/// Why: finding descriptions are short technical phrases whose wording varies
+/// between periods; token overlap tracks "same issue" well enough without
+/// pulling in an embedding model.
+/// What: tokenises both strings into lowercase alphanumeric words and returns
+/// `|intersection| / |union|`. Two empty strings are identical (1.0); one empty
+/// string shares nothing (0.0).
+/// Test: `jaccard_similarity_basic`, `jaccard_similarity_similar_descriptions`.
+pub fn jaccard_similarity(a: &str, b: &str) -> f64 {
+    let tokens_a = tokenize(a);
+    let tokens_b = tokenize(b);
+    if tokens_a.is_empty() && tokens_b.is_empty() {
+        return 1.0;
+    }
+    if tokens_a.is_empty() || tokens_b.is_empty() {
+        return 0.0;
+    }
+    let intersection = tokens_a.iter().filter(|t| tokens_b.contains(t)).count();
+    let union = tokens_a.len() + tokens_b.len() - intersection;
+    intersection as f64 / union as f64
+}
+
+/// Tokenise a string into lowercase alphanumeric tokens.
+fn tokenize(s: &str) -> Vec<String> {
+    s.split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .map(|t| t.to_lowercase())
+        .collect()
+}
+
+// ─── Trajectory derivation ───────────────────────────────────────────────────
+
+/// Derive a [`Trajectory`] from the quality-score series.
+///
+/// Why: comparing only the first and last period would let one bad quarter
+/// dictate the verdict; a least-squares slope uses every period.
+/// What: fits a line over the `(index, score)` pairs and classifies the slope —
+/// above +0.1 is `Improving`, below −0.1 is `Declining`, anything between is
+/// `Stable`. Fewer than two points is `Stable` by definition.
+/// Test: `synthesizer_trajectory_from_slope`.
+pub fn derive_trajectory(quality_trend: &[(String, f64)]) -> Trajectory {
+    if quality_trend.len() < 2 {
+        return Trajectory::Stable;
+    }
+    let n = quality_trend.len() as f64;
+    let sum_x: f64 = (0..quality_trend.len()).map(|i| i as f64).sum();
+    let sum_y: f64 = quality_trend.iter().map(|(_, s)| s).sum();
+    let sum_xy: f64 = quality_trend
+        .iter()
+        .enumerate()
+        .map(|(i, (_, s))| i as f64 * s)
+        .sum();
+    let sum_xx: f64 = (0..quality_trend.len())
+        .map(|i| (i as f64) * (i as f64))
+        .sum();
+    let denom = n * sum_xx - sum_x * sum_x;
+    if denom.abs() < f64::EPSILON {
+        return Trajectory::Stable;
+    }
+    let slope = (n * sum_xy - sum_x * sum_y) / denom;
+    if slope > TRAJECTORY_SLOPE_EPSILON {
+        Trajectory::Improving
+    } else if slope < -TRAJECTORY_SLOPE_EPSILON {
+        Trajectory::Declining
+    } else {
+        Trajectory::Stable
+    }
+}
+
+// ─── Narrative ───────────────────────────────────────────────────────────────
+
+/// Build a factual narrative from the deterministic parts of a profile.
+///
+/// Why: a profile whose narrative section is empty reads as broken. This text
+/// states only what was computed, so it is also the correct fallback when the
+/// narrative pass (#5464) fails.
+/// What: names the contributor and window, the trajectory, and how many
+/// findings carry the `Recurring` tag. That count is occurrences, not distinct
+/// issues — one issue seen in three periods contributes three — so the wording
+/// says "finding(s) tagged recurring" rather than "recurring issues".
+/// Test: `synthesize_deterministic_writes_narrative`.
+pub fn deterministic_narrative(profile: &ContributorProfile) -> String {
+    let traj_str = match profile.improvement_trajectory {
+        Trajectory::Improving => "improving",
+        Trajectory::Stable => "stable",
+        Trajectory::Declining => "declining",
+    };
+    let n_recurring = profile
+        .all_findings
+        .iter()
+        .filter(|f| f.trend_tag == Some(TrendTag::Recurring))
+        .count();
+    format!(
+        "Longitudinal profile for {} ({} to {}). \
+         Quality trajectory: {}. \
+         {} finding(s) tagged recurring across {} period(s).",
+        profile.canonical_name,
+        profile.profiled_since,
+        profile.profiled_until,
+        traj_str,
+        n_recurring,
+        profile.quality_trend.len(),
+    )
+}
+
+// ─── Unit tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profile::types::{FindingEffort, ProfileFinding};
+    use std::collections::HashMap;
+
+    fn make_finding(period: &str, description: &str) -> LongitudinalFinding {
+        make_finding_with_confidence(period, description, 0.8)
+    }
+
+    fn make_finding_with_confidence(
+        period: &str,
+        description: &str,
+        confidence: f32,
+    ) -> LongitudinalFinding {
+        LongitudinalFinding {
+            period_label: period.to_string(),
+            finding: ProfileFinding::new(
+                "src/lib.rs",
+                "error_handling",
+                description,
+                "fix it",
+                confidence,
+                FindingEffort::Medium,
+            ),
+            trend_tag: None,
+        }
+    }
+
+    fn make_profile() -> ContributorProfile {
+        ContributorProfile::new("alice@example.com", "Alice", "2026-01-01", "2026-12-31")
+    }
+
+    fn make_period(label: &str, score: f64) -> PeriodBatch {
+        PeriodBatch::from_stats(crate::report::period_trends::AuthorPeriodSummary {
+            period_label: label.to_string(),
+            since: "2026-01-01".to_string(),
+            until: "2026-03-31".to_string(),
+            commit_count: 3,
+            categories: HashMap::new(),
+            effort_histogram: HashMap::new(),
+            quality_score: score,
+            ticketed_pct: 0.5,
+            pr_metrics: crate::report::drilldown::PrMetrics {
+                total: 1,
+                merged: 1,
+                avg_cycle_time_hours: None,
+                median_cycle_time_hours: None,
+                p95_cycle_time_hours: None,
+            },
+            repositories: vec!["acme/api".to_string()],
+        })
+    }
+
+    // ── Jaccard ──────────────────────────────────────────────────────────
+
+    /// Why: clustering is only as good as the similarity measure, so its three
+    /// boundary cases have to be pinned.
+    /// What: asserts identity scores 1.0, unrelated phrases score below 0.5,
+    /// two empty strings score 1.0, and one empty string scores 0.0.
+    /// Test: this test itself.
+    #[test]
+    fn jaccard_similarity_basic() {
+        assert!(
+            (jaccard_similarity("error handling in async", "error handling in async") - 1.0).abs()
+                < 1e-10
+        );
+        assert!(jaccard_similarity("error handling", "completely different concept") < 0.5);
+        assert!((jaccard_similarity("", "") - 1.0).abs() < 1e-10);
+        assert!((jaccard_similarity("foo", "") - 0.0).abs() < 1e-10);
+    }
+
+    /// Why: the same issue is rarely described in the same words twice, so
+    /// near-matches must score high enough to cluster.
+    /// What: two rewordings of one issue must score at least 0.6.
+    /// Test: this test itself.
+    #[test]
+    fn jaccard_similarity_similar_descriptions() {
+        let a = "missing error propagation in async function";
+        let b = "missing error propagation async function handler";
+        let sim = jaccard_similarity(a, b);
+        assert!(sim >= 0.6, "similar descriptions: sim={sim:.3}");
+    }
+
+    // ── Trend tags ───────────────────────────────────────────────────────
+
+    /// Why: an issue present in the latest period and an earlier one is the
+    /// recurring case the whole feature exists to surface.
+    /// What: tags two identically-described findings in different periods and
+    /// asserts both come back `Recurring`.
+    /// Test: this test itself.
+    #[test]
+    fn synthesizer_dedup_assigns_recurring() {
+        let findings = vec![
+            make_finding("2026-Q1", "missing error propagation in async handler"),
+            make_finding("2026-Q2", "missing error propagation in async handler"),
+        ];
+        let tagged = assign_trend_tags(findings);
+        assert_eq!(tagged.len(), 2);
+        for f in &tagged {
+            assert_eq!(f.trend_tag, Some(TrendTag::Recurring));
+        }
+    }
+
+    /// Why: a first-time issue must not be reported as a pattern.
+    /// What: tags a single finding in the only period and asserts `New`.
+    /// Test: this test itself.
+    #[test]
+    fn synthesizer_dedup_assigns_new() {
+        let findings = vec![make_finding(
+            "2026-Q2",
+            "newly introduced SQL injection risk",
+        )];
+        let tagged = assign_trend_tags(findings);
+        assert_eq!(tagged[0].trend_tag, Some(TrendTag::New));
+    }
+
+    /// Why: an issue that stopped appearing is a positive signal, and reporting
+    /// it as still-recurring would be actively misleading.
+    /// What: puts one issue in Q1 only and an unrelated one in Q2, then asserts
+    /// the Q1 finding is `Resolved`.
+    /// Test: this test itself.
+    #[test]
+    fn synthesizer_dedup_assigns_resolved() {
+        let findings = vec![
+            make_finding("2026-Q1", "unreachable panic in fallback path"),
+            make_finding("2026-Q2", "completely unrelated memory allocation issue"),
+        ];
+        let tagged = assign_trend_tags(findings);
+        let q1 = tagged
+            .iter()
+            .find(|f| f.period_label == "2026-Q1")
+            .expect("Q1 finding present");
+        assert_eq!(q1.trend_tag, Some(TrendTag::Resolved));
+    }
+
+    /// Why: a recurring issue reported with rising confidence is a different
+    /// signal from one holding steady, and only `Worsening` says so.
+    /// What: repeats one issue across two periods with confidence rising from
+    /// 0.5 to 0.9 and asserts `Worsening` rather than `Recurring`.
+    /// Test: this test itself.
+    #[test]
+    fn synthesizer_dedup_assigns_worsening() {
+        let findings = vec![
+            make_finding_with_confidence("2026-Q1", "unchecked index into the buffer", 0.5),
+            make_finding_with_confidence("2026-Q2", "unchecked index into the buffer", 0.9),
+        ];
+        let tagged = assign_trend_tags(findings);
+        for f in &tagged {
+            assert_eq!(f.trend_tag, Some(TrendTag::Worsening));
+        }
+    }
+
+    /// Why: a contributor with no findings is the good case, and it must not
+    /// panic on the empty-period-list path.
+    /// What: tags an empty vector and asserts it stays empty.
+    /// Test: this test itself.
+    #[test]
+    fn synthesizer_dedup_empty_findings() {
+        assert!(assign_trend_tags(Vec::new()).is_empty());
+    }
+
+    // ── Trajectory ───────────────────────────────────────────────────────
+
+    /// Why: the trajectory is the profile's headline, and a noisy-but-flat
+    /// series must not read as a trend.
+    /// What: asserts ascending → `Improving`, descending → `Declining`, jittery
+    /// → `Stable`, and that one or zero points is `Stable`.
+    /// Test: this test itself.
+    #[test]
+    fn synthesizer_trajectory_from_slope() {
+        let up = vec![
+            ("Q1".to_string(), 2.0),
+            ("Q2".to_string(), 3.0),
+            ("Q3".to_string(), 4.0),
+        ];
+        assert_eq!(derive_trajectory(&up), Trajectory::Improving);
+
+        let down = vec![
+            ("Q1".to_string(), 4.0),
+            ("Q2".to_string(), 3.0),
+            ("Q3".to_string(), 2.0),
+        ];
+        assert_eq!(derive_trajectory(&down), Trajectory::Declining);
+
+        let flat = vec![
+            ("Q1".to_string(), 3.0),
+            ("Q2".to_string(), 3.1),
+            ("Q3".to_string(), 2.9),
+        ];
+        assert_eq!(derive_trajectory(&flat), Trajectory::Stable);
+
+        assert_eq!(
+            derive_trajectory(&[("Q1".to_string(), 3.0)]),
+            Trajectory::Stable
+        );
+        assert_eq!(derive_trajectory(&[]), Trajectory::Stable);
+    }
+
+    // ── Deterministic synthesis ──────────────────────────────────────────
+
+    /// Why: the quality trend is what the renderer charts and what the
+    /// trajectory is derived from, so it has to come straight from the period
+    /// statistics in order.
+    /// What: synthesises over two periods and asserts labels, scores, and the
+    /// resulting `Improving` trajectory.
+    /// Test: this test itself.
+    #[test]
+    fn synthesize_deterministic_populates_quality_trend() {
+        let mut profile = make_profile();
+        let periods = vec![make_period("2026-Q1", 3.0), make_period("2026-Q2", 3.8)];
+        synthesize_deterministic(&mut profile, vec![], &periods);
+
+        assert_eq!(profile.quality_trend.len(), 2);
+        assert_eq!(profile.quality_trend[0].0, "2026-Q1");
+        assert!((profile.quality_trend[0].1 - 3.0).abs() < f64::EPSILON);
+        assert_eq!(profile.improvement_trajectory, Trajectory::Improving);
+        assert!(
+            profile.strengths.is_empty(),
+            "strengths are a judgement, not a derivation"
+        );
+    }
+
+    /// Why: the report renders the narrative section only when it is non-empty,
+    /// so a deterministic run that left it blank would produce a profile with a
+    /// hole where its summary belongs.
+    /// What: synthesises with one issue recurring across two periods and
+    /// asserts the narrative names the contributor, the trajectory, and the
+    /// recurring count — which is occurrences (2), not distinct issues (1).
+    /// Test: this test itself.
+    #[test]
+    fn synthesize_deterministic_writes_narrative() {
+        let mut profile = make_profile();
+        let periods = vec![make_period("2026-Q1", 3.0), make_period("2026-Q2", 3.8)];
+        let findings = vec![
+            vec![make_finding("2026-Q1", "missing error propagation")],
+            vec![make_finding("2026-Q2", "missing error propagation")],
+        ];
+        synthesize_deterministic(&mut profile, findings, &periods);
+
+        assert!(profile.narrative.contains("Alice"), "names the contributor");
+        assert!(profile.narrative.contains("improving"), "states trajectory");
+        assert!(
+            profile.narrative.contains("2 finding(s) tagged recurring"),
+            "counts recurring findings: {}",
+            profile.narrative
+        );
+        assert_eq!(profile.all_findings.len(), 2);
+    }
+}

--- a/crates/trusty-git-analytics/src/profile/types/core.rs
+++ b/crates/trusty-git-analytics/src/profile/types/core.rs
@@ -1,0 +1,134 @@
+//! The top-level [`ContributorProfile`] and its version stamp.
+//!
+//! Why: the profile is the pipeline's whole output — identity, per-period data,
+//! trend-tagged findings, narrative, and telemetry in one serialisable value
+//! that can be written to disk, posted to a tracker, or fed to a dashboard.
+//! What: defines [`ContributorProfile`] and [`PROFILE_VERSION`].
+//! Test: `contributor_profile_serde_roundtrip` in the parent `tests` module.
+
+use serde::{Deserialize, Serialize};
+
+use super::finding::LongitudinalFinding;
+use super::period::PeriodBatch;
+use super::token::{TokenCostSummary, Trajectory};
+
+/// Schema version stamped into every [`ContributorProfile`].
+///
+/// Why: a consumer reading an old `profile.json` has to be able to tell which
+/// schema produced it. The `tga-` prefix distinguishes tga-produced profiles
+/// from the `tr-profile-0.1` files trusty-review emitted before profiling moved
+/// here (#5463, epic #5468).
+/// What: a string constant written to `ContributorProfile::review_version`.
+/// Test: asserted in `contributor_profile_serde_roundtrip`.
+pub const PROFILE_VERSION: &str = "tga-profile-0.1";
+
+/// A full longitudinal contributor profile.
+///
+/// Why: the profile has to stand alone — a reader who has only the JSON must
+/// be able to reconstruct who it describes, over what window, and on what
+/// evidence, without re-querying the database it came from.
+/// What: aggregates identity, the profile window, per-period batches,
+/// trend-tagged findings, strengths/weaknesses, a trajectory, a narrative, and
+/// token telemetry. `#[non_exhaustive]` so later passes can add fields without
+/// a major bump; construct it with [`ContributorProfile::new`].
+/// Test: `contributor_profile_serde_roundtrip`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ContributorProfile {
+    // ── Identity ──────────────────────────────────────────────────────────
+    /// Canonical email, as stored in `authors.canonical_email`.
+    pub canonical_email: String,
+
+    /// Canonical display name, as stored in `authors.canonical_name`.
+    pub canonical_name: String,
+
+    /// GitHub login, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_login: Option<String>,
+
+    // ── Profile window ────────────────────────────────────────────────────
+    /// Inclusive start of the profiled window (ISO 8601 date).
+    pub profiled_since: String,
+
+    /// Inclusive end of the profiled window (ISO 8601 date).
+    pub profiled_until: String,
+
+    /// Repositories included in this profile.
+    pub repositories: Vec<String>,
+
+    // ── Per-period data ───────────────────────────────────────────────────
+    /// Period-level batches (statistics plus sampled diffs), one per window.
+    pub periods: Vec<PeriodBatch>,
+
+    // ── Synthesised findings ──────────────────────────────────────────────
+    /// Every finding across every period, annotated with its trend.
+    pub all_findings: Vec<LongitudinalFinding>,
+
+    /// Recurring strengths identified across periods.
+    pub strengths: Vec<String>,
+
+    /// Recurring weaknesses / areas for improvement.
+    pub recurring_weaknesses: Vec<String>,
+
+    // ── Trend summary ─────────────────────────────────────────────────────
+    /// Overall quality-trajectory direction.
+    pub improvement_trajectory: Trajectory,
+
+    /// Per-period quality scores as `(period_label, score)` pairs.
+    pub quality_trend: Vec<(String, f64)>,
+
+    // ── Narrative ─────────────────────────────────────────────────────────
+    /// Free-text assessment of the profile. The deterministic pass writes a
+    /// factual summary here; the narrative pass (#5464) replaces it.
+    pub narrative: String,
+
+    // ── Telemetry ─────────────────────────────────────────────────────────
+    /// Aggregate model token usage and cost for this run. All-zero when the
+    /// run was purely deterministic.
+    pub token_cost: TokenCostSummary,
+
+    // ── Metadata ──────────────────────────────────────────────────────────
+    /// ISO 8601 UTC timestamp at which the profile was generated.
+    pub generated_at: String,
+
+    /// Schema version — always [`PROFILE_VERSION`] for a freshly built profile.
+    pub review_version: String,
+}
+
+impl ContributorProfile {
+    /// Construct an empty profile skeleton for a contributor and window.
+    ///
+    /// Why: every later stage fills in a different part of the profile, so it
+    /// has to be constructible from identity and window alone.
+    /// What: stamps `review_version` with [`PROFILE_VERSION`] and
+    /// `generated_at` with the current UTC time; every collection starts empty
+    /// and the trajectory starts at [`Trajectory::Stable`].
+    /// Test: `contributor_profile_serde_roundtrip`.
+    pub fn new(
+        canonical_email: impl Into<String>,
+        canonical_name: impl Into<String>,
+        profiled_since: impl Into<String>,
+        profiled_until: impl Into<String>,
+    ) -> Self {
+        Self {
+            canonical_email: canonical_email.into(),
+            canonical_name: canonical_name.into(),
+            github_login: None,
+            profiled_since: profiled_since.into(),
+            profiled_until: profiled_until.into(),
+            repositories: Vec::new(),
+            periods: Vec::new(),
+            all_findings: Vec::new(),
+            strengths: Vec::new(),
+            recurring_weaknesses: Vec::new(),
+            improvement_trajectory: Trajectory::Stable,
+            quality_trend: Vec::new(),
+            narrative: String::new(),
+            token_cost: TokenCostSummary::default(),
+            // #5463: tga already depends on chrono, so the port drops
+            // trusty-review's hand-rolled civil-date arithmetic here.
+            generated_at: chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+            review_version: PROFILE_VERSION.to_string(),
+        }
+    }
+}

--- a/crates/trusty-git-analytics/src/profile/types/finding.rs
+++ b/crates/trusty-git-analytics/src/profile/types/finding.rs
@@ -1,0 +1,168 @@
+//! Finding DTO, trend-tag, and longitudinal-finding types.
+//!
+//! Why: the profile narrative must say which findings are new, recurring, or
+//! resolved across periods. The finding itself arrives as JSON produced by an
+//! external code-review pass, so tga defines its OWN structurally-equivalent
+//! DTO rather than importing a review crate's type — #5463 exists precisely to
+//! stop the profiling code depending on trusty-review, and a `use
+//! trusty_review::models::Finding` here would rebuild the cycle it removes.
+//! What: defines [`FindingEffort`], [`ProfileFinding`], [`TrendTag`], and
+//! [`LongitudinalFinding`]. Field names and serde representations match the
+//! review-side JSON exactly, so a serialised review finding deserialises into
+//! `ProfileFinding` with the extra review-only fields ignored.
+//! Test: `trend_tag_serde_roundtrip`, `longitudinal_finding_serde_roundtrip`,
+//! and `profile_finding_parses_review_json` in the parent `tests` module.
+
+use serde::{Deserialize, Serialize};
+
+// ─── FindingEffort ───────────────────────────────────────────────────────────
+
+/// Estimated remediation effort for a finding.
+///
+/// Why: effort is the axis a manager reads a longitudinal profile along — a
+/// recurring `High` finding is a very different signal from a recurring `Low`
+/// one.
+/// What: three-variant enum serialised as lowercase strings, matching the
+/// review-side `effort` field so the JSON round-trips.
+/// Test: `profile_finding_parses_review_json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FindingEffort {
+    /// Small change, typically under an hour.
+    Low,
+    /// Moderate change, typically a few hours.
+    Medium,
+    /// Large refactoring or cross-cutting change.
+    High,
+}
+
+impl std::fmt::Display for FindingEffort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FindingEffort::Low => write!(f, "low"),
+            FindingEffort::Medium => write!(f, "medium"),
+            FindingEffort::High => write!(f, "high"),
+        }
+    }
+}
+
+// ─── ProfileFinding ──────────────────────────────────────────────────────────
+
+/// A single code-review finding as the profile pipeline consumes it.
+///
+/// Why: the profile pipeline needs a finding's file, kind, description, and
+/// effort to cluster findings across periods and render them. It does NOT need
+/// the review pipeline's transient state (verification outcome, issue
+/// eligibility, suggested replacement), so this DTO carries the durable subset
+/// and nothing else (#5463).
+/// What: a serde type whose field names match the review-side finding JSON.
+/// Unknown fields are ignored on deserialisation, which is what lets a
+/// full review finding be read straight into this type.
+/// Test: `profile_finding_parses_review_json`,
+/// `profile_finding_clamps_confidence`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileFinding {
+    /// Path of the file this finding refers to.
+    pub file: String,
+
+    /// Line number within the file, when the finding is line-anchored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+
+    /// Finding type / category (e.g. `"security"`, `"logic-error"`).
+    pub kind: String,
+
+    /// Human-readable description of the issue.
+    pub description: String,
+
+    /// What goes wrong if the finding is left unaddressed.
+    #[serde(default)]
+    pub consequence: String,
+
+    /// Proposed fix or remediation, as prose.
+    pub suggestion: String,
+
+    /// Confidence score in `[0.0, 1.0]`.
+    pub confidence: f32,
+
+    /// Estimated remediation effort.
+    pub effort: FindingEffort,
+}
+
+impl ProfileFinding {
+    /// Construct a finding, clamping `confidence` into `[0.0, 1.0]`.
+    ///
+    /// Why: confidence usually originates from a model's JSON output, which can
+    /// be out of range; clamping keeps every downstream comparison meaningful
+    /// without an error path for malformed input.
+    /// What: sets `line` to `None` and `consequence` to the empty string; every
+    /// other field comes from the arguments.
+    /// Test: `profile_finding_clamps_confidence`.
+    pub fn new(
+        file: impl Into<String>,
+        kind: impl Into<String>,
+        description: impl Into<String>,
+        suggestion: impl Into<String>,
+        confidence: f32,
+        effort: FindingEffort,
+    ) -> Self {
+        Self {
+            file: file.into(),
+            line: None,
+            kind: kind.into(),
+            description: description.into(),
+            consequence: String::new(),
+            suggestion: suggestion.into(),
+            confidence: confidence.clamp(0.0, 1.0),
+            effort,
+        }
+    }
+}
+
+// ─── TrendTag ────────────────────────────────────────────────────────────────
+
+/// Longitudinal trend classification for a finding across periods.
+///
+/// Why: the profile must distinguish findings that persist, appear for the
+/// first time, or stop appearing, so the narrative can give targeted feedback
+/// instead of restating the same list every period.
+/// What: four-variant enum serialised as `snake_case` strings.
+/// Test: `trend_tag_serde_roundtrip`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrendTag {
+    /// The same finding class appeared in multiple periods.
+    Recurring,
+    /// The finding appeared for the first time in the latest period.
+    New,
+    /// The finding appeared in earlier periods but not the latest one.
+    Resolved,
+    /// The finding's confidence rose materially between its first and latest
+    /// occurrence.
+    Worsening,
+}
+
+// ─── LongitudinalFinding ─────────────────────────────────────────────────────
+
+/// A code-review finding annotated with the period it was observed in and its
+/// cross-period trend.
+///
+/// Why: a finding alone says nothing longitudinal; pairing it with a period
+/// label and a trend tag is what turns a pile of per-period findings into a
+/// profile.
+/// What: pairs a [`ProfileFinding`] with its period label and an optional
+/// [`TrendTag`]. `trend_tag` is `None` until
+/// [`assign_trend_tags`](crate::profile::synthesizer::assign_trend_tags) runs.
+/// Test: `longitudinal_finding_serde_roundtrip`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LongitudinalFinding {
+    /// Human-readable period label (e.g. `"2026-W01..W04"`).
+    pub period_label: String,
+
+    /// The underlying code-review finding.
+    pub finding: ProfileFinding,
+
+    /// Trend classification relative to the other periods.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trend_tag: Option<TrendTag>,
+}

--- a/crates/trusty-git-analytics/src/profile/types/mod.rs
+++ b/crates/trusty-git-analytics/src/profile/types/mod.rs
@@ -1,0 +1,315 @@
+//! Data models for the contributor-profile pipeline.
+//!
+//! Why: profiling introduces several serde types that no other tga stage uses;
+//! keeping them in one submodule makes the profile's data contract auditable in
+//! isolation and keeps `core::models` free of them.
+//! What: re-exports [`ContributorProfile`], [`PeriodBatch`], [`SampledDiff`],
+//! [`ProfileFinding`], [`LongitudinalFinding`], [`TrendTag`],
+//! [`TokenCostSummary`], and [`Trajectory`] from their per-type submodules.
+//! Every type round-trips through JSON.
+//! Test: the `tests` module at the bottom of this file.
+
+pub mod core;
+pub mod finding;
+pub mod period;
+pub mod token;
+
+pub use core::{ContributorProfile, PROFILE_VERSION};
+pub use finding::{FindingEffort, LongitudinalFinding, ProfileFinding, TrendTag};
+pub use period::{AuthorPeriodSummary, PeriodBatch, SampledDiff};
+pub use token::{TokenCostSummary, Trajectory};
+
+// ─── Unit tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn make_stats() -> AuthorPeriodSummary {
+        AuthorPeriodSummary {
+            period_label: "2026-W01..W04".to_string(),
+            since: "2026-01-05".to_string(),
+            until: "2026-02-01".to_string(),
+            commit_count: 12,
+            categories: HashMap::from([
+                ("feature".to_string(), 8u64),
+                ("bugfix".to_string(), 4u64),
+            ]),
+            effort_histogram: HashMap::from([("S".to_string(), 5u32), ("M".to_string(), 7u32)]),
+            quality_score: 3.7,
+            ticketed_pct: 0.75,
+            pr_metrics: crate::report::drilldown::PrMetrics {
+                total: 3,
+                merged: 3,
+                avg_cycle_time_hours: Some(18.0),
+                median_cycle_time_hours: Some(16.0),
+                p95_cycle_time_hours: None,
+            },
+            repositories: vec!["acme/api".to_string()],
+        }
+    }
+
+    /// Why: a sampled diff is written to `profile.json` and read back by the
+    /// renderer, so a lossy round-trip would silently drop diff evidence.
+    /// What: serialises a fully-populated `SampledDiff` and asserts every field
+    /// survives deserialisation.
+    /// Test: this test itself.
+    #[test]
+    fn sampled_diff_serde_roundtrip() {
+        let diff = SampledDiff {
+            sha: "abc123".to_string(),
+            repository: "acme/api".to_string(),
+            message: "feat: add user endpoint".to_string(),
+            diff_text: "+fn add_user() {}".to_string(),
+            category: Some("feature".to_string()),
+            effort: Some("M".to_string()),
+        };
+        let json = serde_json::to_string(&diff).expect("serialise");
+        let back: SampledDiff = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(back.sha, "abc123");
+        assert_eq!(back.repository, "acme/api");
+        assert_eq!(back.category, Some("feature".to_string()));
+        assert_eq!(back.effort, Some("M".to_string()));
+    }
+
+    /// Why: unclassified commits are common, and writing `"category": null` for
+    /// every one of them bloats the profile JSON.
+    /// What: serialises a `SampledDiff` with both optional fields `None` and
+    /// asserts neither key appears.
+    /// Test: this test itself.
+    #[test]
+    fn sampled_diff_none_fields_omitted() {
+        let diff = SampledDiff {
+            sha: "def456".to_string(),
+            repository: "repo".to_string(),
+            message: "fix: something".to_string(),
+            diff_text: "-old\n+new".to_string(),
+            category: None,
+            effort: None,
+        };
+        let json = serde_json::to_string(&diff).expect("serialise");
+        assert!(!json.contains("\"category\""), "None category is omitted");
+        assert!(!json.contains("\"effort\""), "None effort is omitted");
+    }
+
+    /// Why: `PeriodBatch` embeds tga's own `AuthorPeriodSummary`; a round-trip
+    /// proves that embedding stays serialisable as the summary type evolves.
+    /// What: builds a batch with one sampled diff, round-trips it, and asserts
+    /// both halves survive.
+    /// Test: this test itself.
+    #[test]
+    fn period_batch_serde_roundtrip() {
+        let mut batch = PeriodBatch::from_stats(make_stats());
+        batch.sampled_diffs.push(SampledDiff {
+            sha: "aaa".to_string(),
+            repository: "r".to_string(),
+            message: "msg".to_string(),
+            diff_text: "+line".to_string(),
+            category: Some("feature".to_string()),
+            effort: None,
+        });
+
+        let json = serde_json::to_string(&batch).expect("serialise");
+        let back: PeriodBatch = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(back.stats.period_label, "2026-W01..W04");
+        assert_eq!(back.stats.commit_count, 12);
+        assert_eq!(back.sampled_diffs.len(), 1);
+        assert_eq!(back.sampled_diffs[0].sha, "aaa");
+    }
+
+    /// Why: the trend tag is the profile's headline signal, so its wire form is
+    /// part of the data contract, not an implementation detail.
+    /// What: asserts each variant serialises to its exact snake_case string and
+    /// reads back as the same variant.
+    /// Test: this test itself.
+    #[test]
+    fn trend_tag_serde_roundtrip() {
+        for (tag, expected) in [
+            (TrendTag::Recurring, "\"recurring\""),
+            (TrendTag::New, "\"new\""),
+            (TrendTag::Resolved, "\"resolved\""),
+            (TrendTag::Worsening, "\"worsening\""),
+        ] {
+            let json = serde_json::to_string(&tag).expect("serialise");
+            assert_eq!(json, expected, "variant {tag:?} serialised incorrectly");
+            let back: TrendTag = serde_json::from_str(&json).expect("deserialise");
+            assert_eq!(back, tag);
+        }
+    }
+
+    /// Why: `ProfileFinding` exists to read JSON produced by an external review
+    /// pass; if the extra review-only fields broke deserialisation, the whole
+    /// DTO would be useless (#5463).
+    /// What: parses a finding payload carrying the review-side extras
+    /// (`suggested_replacement`, `category`, `code_provable`, `verified`,
+    /// `issue_eligible`) and asserts the shared fields land correctly.
+    /// Test: this test itself.
+    #[test]
+    fn profile_finding_parses_review_json() {
+        let review_json = r#"{
+            "file": "src/main.rs",
+            "line": 42,
+            "kind": "security",
+            "description": "SQL injection",
+            "consequence": "attacker reads the whole table",
+            "suggestion": "use a parameterised query",
+            "suggested_replacement": "conn.execute(sql, params![id])",
+            "confidence": 0.95,
+            "effort": "medium",
+            "category": "correctness",
+            "source_citation": "SPEC-1 §2",
+            "code_provable": true,
+            "issue_eligible": false
+        }"#;
+        let f: ProfileFinding = serde_json::from_str(review_json).expect("parse review finding");
+        assert_eq!(f.file, "src/main.rs");
+        assert_eq!(f.line, Some(42));
+        assert_eq!(f.kind, "security");
+        assert_eq!(f.consequence, "attacker reads the whole table");
+        assert_eq!(f.effort, FindingEffort::Medium);
+        assert!((f.confidence - 0.95).abs() < 1e-6);
+    }
+
+    /// Why: model-produced confidence values are routinely out of range, and an
+    /// unclamped value would distort the worsening comparison in trend tagging.
+    /// What: constructs findings with confidence above 1.0 and below 0.0 and
+    /// asserts both are clamped.
+    /// Test: this test itself.
+    #[test]
+    fn profile_finding_clamps_confidence() {
+        let high = ProfileFinding::new("f", "k", "d", "s", 4.2, FindingEffort::Low);
+        assert!((high.confidence - 1.0).abs() < f32::EPSILON);
+        let low = ProfileFinding::new("f", "k", "d", "s", -1.0, FindingEffort::High);
+        assert!((low.confidence - 0.0).abs() < f32::EPSILON);
+        assert_eq!(low.effort.to_string(), "high");
+    }
+
+    /// Why: the finding plus its period label and trend tag is what the report
+    /// renders, so the nesting has to survive a round-trip intact.
+    /// What: round-trips a `LongitudinalFinding` carrying a `TrendTag`.
+    /// Test: this test itself.
+    #[test]
+    fn longitudinal_finding_serde_roundtrip() {
+        let lf = LongitudinalFinding {
+            period_label: "2026-W01..W04".to_string(),
+            finding: ProfileFinding::new(
+                "src/main.rs",
+                "security",
+                "SQL injection",
+                "Use parameterised query",
+                0.95,
+                FindingEffort::Medium,
+            ),
+            trend_tag: Some(TrendTag::Recurring),
+        };
+        let json = serde_json::to_string(&lf).expect("serialise");
+        let back: LongitudinalFinding = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(back.period_label, "2026-W01..W04");
+        assert_eq!(back.finding.kind, "security");
+        assert_eq!(back.trend_tag, Some(TrendTag::Recurring));
+    }
+
+    /// Why: the trajectory string is read by dashboards, so its wire form is
+    /// part of the contract.
+    /// What: round-trips all three variants against their exact JSON strings.
+    /// Test: this test itself.
+    #[test]
+    fn trajectory_serde_roundtrip() {
+        for (t, expected) in [
+            (Trajectory::Improving, "\"improving\""),
+            (Trajectory::Stable, "\"stable\""),
+            (Trajectory::Declining, "\"declining\""),
+        ] {
+            let json = serde_json::to_string(&t).expect("serialise");
+            assert_eq!(json, expected);
+            let back: Trajectory = serde_json::from_str(&json).expect("deserialise");
+            assert_eq!(back, t);
+        }
+    }
+
+    /// Why: the profile is written to disk and read back by later runs and by
+    /// the renderer; a lossy round-trip anywhere in the nested tree would lose
+    /// evidence silently.
+    /// What: populates every field, round-trips through pretty JSON, and
+    /// asserts identity, periods, findings, trajectory, version, and telemetry.
+    /// Test: this test itself.
+    #[test]
+    fn contributor_profile_serde_roundtrip() {
+        let mut profile = ContributorProfile::new(
+            "alice@example.com",
+            "Alice Smith",
+            "2026-01-01",
+            "2026-05-31",
+        );
+        profile.github_login = Some("alice-dev".to_string());
+        profile.repositories = vec!["acme/api".to_string()];
+        profile.periods.push(PeriodBatch::from_stats(make_stats()));
+        profile.all_findings.push(LongitudinalFinding {
+            period_label: "2026-W01..W04".to_string(),
+            finding: ProfileFinding::new(
+                "src/lib.rs",
+                "logic",
+                "off-by-one",
+                "use exclusive range",
+                0.8,
+                FindingEffort::Low,
+            ),
+            trend_tag: Some(TrendTag::New),
+        });
+        profile.strengths = vec!["consistent ticket coverage".to_string()];
+        profile.recurring_weaknesses = vec!["missing error handling".to_string()];
+        profile.improvement_trajectory = Trajectory::Improving;
+        profile.quality_trend = vec![("2026-W01..W04".to_string(), 3.7)];
+        profile.token_cost = TokenCostSummary {
+            input_tokens: 1000,
+            output_tokens: 200,
+            cost_usd: 0.012,
+            latency_ms: 850,
+        };
+
+        let json = serde_json::to_string_pretty(&profile).expect("serialise");
+        let back: ContributorProfile = serde_json::from_str(&json).expect("deserialise");
+
+        assert_eq!(back.canonical_email, "alice@example.com");
+        assert_eq!(back.canonical_name, "Alice Smith");
+        assert_eq!(back.github_login, Some("alice-dev".to_string()));
+        assert_eq!(back.periods.len(), 1);
+        assert_eq!(back.periods[0].stats.commit_count, 12);
+        assert_eq!(back.all_findings.len(), 1);
+        assert_eq!(back.all_findings[0].trend_tag, Some(TrendTag::New));
+        assert_eq!(back.improvement_trajectory, Trajectory::Improving);
+        assert_eq!(back.quality_trend.len(), 1);
+        assert!((back.quality_trend[0].1 - 3.7).abs() < f64::EPSILON);
+        assert_eq!(back.review_version, PROFILE_VERSION);
+        assert_eq!(back.token_cost.input_tokens, 1000);
+    }
+
+    /// Why: a fresh summary must read as "no model call was made", which is what
+    /// the renderer keys the cost section off.
+    /// What: asserts every field of `TokenCostSummary::default()` is zero.
+    /// Test: this test itself.
+    #[test]
+    fn token_cost_summary_defaults_to_zero() {
+        let tcs = TokenCostSummary::default();
+        assert_eq!(tcs.input_tokens, 0);
+        assert_eq!(tcs.output_tokens, 0);
+        assert!((tcs.cost_usd - 0.0).abs() < f64::EPSILON);
+        assert_eq!(tcs.latency_ms, 0);
+    }
+
+    /// Why: the summary is the sum over many calls, so accumulation must be
+    /// additive in every field including the float cost.
+    /// What: accumulates twice and asserts each field is the sum.
+    /// Test: this test itself.
+    #[test]
+    fn token_cost_summary_accumulate() {
+        let mut tcs = TokenCostSummary::default();
+        tcs.accumulate(100, 50, 0.001, 500);
+        tcs.accumulate(200, 80, 0.002, 700);
+        assert_eq!(tcs.input_tokens, 300);
+        assert_eq!(tcs.output_tokens, 130);
+        assert!((tcs.cost_usd - 0.003).abs() < 1e-10);
+        assert_eq!(tcs.latency_ms, 1200);
+    }
+}

--- a/crates/trusty-git-analytics/src/profile/types/period.rs
+++ b/crates/trusty-git-analytics/src/profile/types/period.rs
@@ -1,0 +1,88 @@
+//! Period batch and sampled-diff types for the profile pipeline.
+//!
+//! Why: a period's statistics alone cannot support qualitative commentary —
+//! "quality_score fell to 2.8" says nothing about what changed. Pairing the
+//! statistics with a handful of representative diffs is what makes the period
+//! reviewable.
+//! What: defines [`SampledDiff`] and [`PeriodBatch`], the latter wrapping tga's
+//! own [`AuthorPeriodSummary`] rather than redefining it.
+//! Test: `sampled_diff_serde_roundtrip`, `sampled_diff_none_fields_omitted`,
+//! and `period_batch_serde_roundtrip` in the parent `tests` module.
+
+use serde::{Deserialize, Serialize};
+
+pub use crate::report::period_trends::AuthorPeriodSummary;
+
+// ─── SampledDiff ─────────────────────────────────────────────────────────────
+
+/// A representative commit diff sampled from a contributor's history.
+///
+/// Why: statistics describe volume and cadence; only the diff text shows how
+/// the code was actually written, which is what a quality assessment rests on.
+/// What: pairs a commit's metadata (sha, repository, message, category, effort)
+/// with the unified diff text produced by
+/// [`diff_for_commit`](crate::collect::git::diff::diff_for_commit), truncated
+/// to [`MAX_DIFF_CHARS`](crate::profile::diff_sampler::MAX_DIFF_CHARS).
+/// Test: `sampled_diff_serde_roundtrip`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SampledDiff {
+    /// Full 40-char commit SHA.
+    pub sha: String,
+
+    /// Repository name, as stored in the `commits.repository` column.
+    pub repository: String,
+
+    /// Commit message.
+    pub message: String,
+
+    /// Unified diff text, already truncated.
+    pub diff_text: String,
+
+    /// Commit category (e.g. `"feature"`, `"bugfix"`, `"refactor"`), or `None`
+    /// when the commit was never classified.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+
+    /// Effort size label (`"XS"` … `"XL"`), or `None` when the commit was
+    /// never scored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+}
+
+// ─── PeriodBatch ─────────────────────────────────────────────────────────────
+
+/// Combined statistics and sampled diffs for a single N-week period.
+///
+/// Why: the profile is assembled one period at a time, and every consumer
+/// (renderer, narrative pass) wants the statistics and the diff samples
+/// together rather than as two parallel collections it has to zip.
+/// What: embeds tga's [`AuthorPeriodSummary`] unchanged and appends the diffs
+/// the sampler selected. `sampled_diffs` stays empty until
+/// [`sample_diffs_for_batches`](crate::profile::diff_sampler::sample_diffs_for_batches)
+/// runs, which is what lets a statistics-only run skip the git work entirely.
+/// Test: `period_batch_serde_roundtrip`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PeriodBatch {
+    /// Statistical summary for this period.
+    pub stats: AuthorPeriodSummary,
+
+    /// Representative commit diffs sampled from this period.
+    #[serde(default)]
+    pub sampled_diffs: Vec<SampledDiff>,
+}
+
+impl PeriodBatch {
+    /// Construct a `PeriodBatch` from statistics, with no diffs attached yet.
+    ///
+    /// Why: batch assembly runs before diff sampling, so the batch must exist
+    /// in a diff-less state.
+    /// What: wraps `stats` with an empty `sampled_diffs`.
+    /// Test: `period_batch_serde_roundtrip` plus every batch-assembly test.
+    pub fn from_stats(stats: AuthorPeriodSummary) -> Self {
+        Self {
+            stats,
+            sampled_diffs: Vec::new(),
+        }
+    }
+}

--- a/crates/trusty-git-analytics/src/profile/types/token.rs
+++ b/crates/trusty-git-analytics/src/profile/types/token.rs
@@ -1,0 +1,74 @@
+//! Token-cost telemetry and trajectory types.
+//!
+//! Why: profiling a whole org means one narrative call per contributor per
+//! period, so the run's token cost has to be visible in the output rather than
+//! discovered on next month's invoice.
+//! What: defines [`TokenCostSummary`] and [`Trajectory`].
+//! Test: `token_cost_summary_defaults_to_zero`, `token_cost_summary_accumulate`,
+//! and `trajectory_serde_roundtrip` in the parent `tests` module.
+
+use serde::{Deserialize, Serialize};
+
+// ─── TokenCostSummary ────────────────────────────────────────────────────────
+
+/// Aggregate model token usage and cost for one profile run.
+///
+/// Why: see the module doc — cost per profile run is an operational number the
+/// report must carry.
+/// What: accumulates input/output tokens, estimated USD cost, and summed
+/// wall-clock latency. Zero on every field means no model call was made, which
+/// is what the renderer keys the cost section off.
+/// Test: `token_cost_summary_defaults_to_zero`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TokenCostSummary {
+    /// Total input tokens consumed.
+    pub input_tokens: u64,
+    /// Total output tokens produced.
+    pub output_tokens: u64,
+    /// Total estimated cost in USD.
+    pub cost_usd: f64,
+    /// Summed wall-clock latency in milliseconds.
+    pub latency_ms: u64,
+}
+
+impl TokenCostSummary {
+    /// Add one call's usage into this summary.
+    ///
+    /// Why: the narrative pass (#5464) makes several calls per profile; the
+    /// report wants their total, not a list.
+    /// What: adds each field in place.
+    /// Test: `token_cost_summary_accumulate`.
+    pub fn accumulate(
+        &mut self,
+        input_tokens: u64,
+        output_tokens: u64,
+        cost_usd: f64,
+        latency_ms: u64,
+    ) {
+        self.input_tokens += input_tokens;
+        self.output_tokens += output_tokens;
+        self.cost_usd += cost_usd;
+        self.latency_ms += latency_ms;
+    }
+}
+
+// ─── Trajectory ──────────────────────────────────────────────────────────────
+
+/// Overall quality-trajectory direction across the profile window.
+///
+/// Why: a manager reading the profile needs one routing signal — coach, leave
+/// alone, or commend — before reading any detail.
+/// What: three-variant enum serialised as `snake_case`, derived from the
+/// quality-score slope by
+/// [`derive_trajectory`](crate::profile::synthesizer::derive_trajectory).
+/// Test: `trajectory_serde_roundtrip`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Trajectory {
+    /// Quality metrics trend upward across periods.
+    Improving,
+    /// Quality metrics are flat within noise.
+    Stable,
+    /// Quality metrics trend downward across periods.
+    Declining,
+}


### PR DESCRIPTION
Child 1 of #5468. Moves the data and orchestration half of contributor profiling into tga, where the git history, identity, effort, and classification data it reads already live. See #5463 for scope and #5468 for the ownership ruling.

Additive to tga only. trusty-review is untouched — its copy stays until #5466, so there is no window where the capability is missing.

## What landed

`tga::profile`, ported from `crates/trusty-review/src/profile/`:

- `selector` — identity resolution against `authors` (email / name / alias / fuzzy)
- `batch` — period-batch assembly over `query_author_period_trends`
- `diff_sampler` — category-stratified diff sampling with per-diff truncation
- `synthesizer` — the deterministic half only: Jaccard clustering, `TrendTag` assignment, slope-derived `Trajectory`, factual narrative
- `reporter` — JSON and Markdown rendering
- `types` — profile, period, telemetry, and a tga-native `ProfileFinding` DTO

Deliberately absent: the model-written narrative (#5464) and GitHub issue publishing (#5465). Nothing here calls a model or the network.

## The finding DTO

`Finding`/`Effort` stay in trusty-review — 30 files there depend on them. tga defines `ProfileFinding` + `FindingEffort` with field names and serde representations matching the review-side JSON, so a serialised review finding deserialises straight into it and the review-only fields are ignored (`profile_finding_parses_review_json`). Importing `trusty_review::models::Finding` would rebuild the cycle this epic removes.

## Deviations from a literal port

- `resolve_db_path` (and its `TRUSTY_REVIEW_TGA_DB` env var) was NOT ported — tga already owns DB-path resolution in `core::config::database_path`, and a second resolver would violate the common-entry-point rule. The CLI in #5465 resolves the path through `Config`.
- `PROFILE_VERSION` is `tga-profile-0.1` (was `tr-profile-0.1`) and the Markdown footer says "Generated by tga". A tga-produced profile should not claim to come from trusty-review.
- `Synthesizer` (an LLM-holding struct) became the free function `synthesize_deterministic`; the fail-safe narrative became `deterministic_narrative`, worded factually instead of claiming an LLM call failed.
- The narrative counts findings tagged `Recurring`, which is occurrences, not distinct issues — one issue in three periods counts three. The port keeps the count and fixes the wording to "N finding(s) tagged recurring".
- `now_iso8601`'s hand-rolled civil-date arithmetic was dropped for `chrono`, which tga already depends on.
- `#[non_exhaustive]` on `ProfileError`, `ContributorProfile`, and `PeriodBatch` so #5464/#5465 can extend them without a major bump.

No new dependency: `rusqlite`, `git2`, `chrono`, `serde`, `tempfile` were all already tga's.

## Tests

Ported the deterministic tests and dropped the `LlmProvider`-mocking ones (they belong to #5464). Added coverage the original lacked: `ProfileFinding` parsing review JSON, confidence clamping, `TrendTag::Worsening`, `resolve_contributor` on a real file-backed DB, and Markdown pipe escaping.

## Gates — rung 4

```
cargo fmt --check                                  EXIT=0
cargo clippy -p tga --all-targets -- -D warnings   EXIT=0
cargo test -p tga                                  test result: ok. 1135 passed; 0 failed; 1 ignored
SKIP_UI_BUILD=1 cargo check --workspace            EXIT=0
```

All 18 `scripts/check_*.sh` pass. `check_semver.sh`: `196 checks: 196 pass, 58 skip — no semver update required`, confirming the change is purely additive.

Closes #5463

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools