### PR TITLE
fix(trusty-memory): merge punctuated KG twins onto their cleaned nodes

### DIFF
--- a/crates/trusty-memory/changelog.d/5401-punctuated-twin-merge.md
+++ b/crates/trusty-memory/changelog.d/5401-punctuated-twin-merge.md
@@ -19,6 +19,14 @@ Added
   either maintenance flag rather than on `--purge-stale-subjects` alone) to
   report the list while writing nothing. Selection is as narrow as the purge's: a
   term under the `drawer:`/`tag:`/`topic:`/`room:` namespaces never moves, only
-  triples stamped `auto:remember` are rewritten, and a punctuated stopword is
-  left to the purge — `is_stop_token` partitions the two passes so no term is
-  both deleted and re-pointed. Re-running is a no-op.
+  triples stamped `auto:remember` are rewritten, and a triple carrying a
+  punctuated stopword at EITHER end is left alone — so `is_stop_token` partitions
+  the two passes in the object position too, and the merge cannot hang a `("the`
+  off the cleaned node where the subject-selecting purge could never reach it.
+  Re-running is a no-op.
+
+  A re-point that cannot write is reported as failed rather than merged and
+  exits non-zero, the cleaned node is written before the punctuated row is
+  closed so a failure mid-way leaves the fact readable at one node or the other,
+  and a data root that cannot be listed fails the run instead of reporting an
+  empty one.

--- a/crates/trusty-memory/changelog.d/5401-punctuated-twin-merge.md
+++ b/crates/trusty-memory/changelog.d/5401-punctuated-twin-merge.md
@@ -1,0 +1,24 @@
+Added
+- **`kg-rebuild --merge-punctuated-twins`** folds a pre-#4678 punctuated entity
+  node onto its cleaned twin, so `` `redb` `` and `redb` stop being two nodes for
+  one thing. #4678's edge trim fixed extraction going forward and split every
+  entity already in the graph; nothing removed the old node, because the four
+  pattern predicates are absent from `FUNCTIONAL_PREDICATES` (an `assert` adds
+  the cleaned spelling beside the punctuated one) and `--purge-stale-subjects`
+  only selects subjects `is_stop_token` rejects, which a real entity never trips.
+  Each rebuild over the same drawer content widened the split.
+
+  This is a merge, not a delete: every auto-extracted triple is re-asserted under
+  the cleaned identity and only then retracted at the punctuated one, in BOTH the
+  subject and the object position, so the merged node keeps its own pre-existing
+  triples and gains the re-pointed ones. Object-position re-pointing is what
+  needed #5396's `retract_triple` — closing the whole `(subject, predicate)` pair
+  would have taken the punctuated object's correct siblings with it.
+
+  Off by default, prints every move, and takes `--dry-run` (which now gates on
+  either maintenance flag rather than on `--purge-stale-subjects` alone) to
+  report the list while writing nothing. Selection is as narrow as the purge's: a
+  term under the `drawer:`/`tag:`/`topic:`/`room:` namespaces never moves, only
+  triples stamped `auto:remember` are rewritten, and a punctuated stopword is
+  left to the purge — `is_stop_token` partitions the two passes so no term is
+  both deleted and re-pointed. Re-running is a no-op.

--- a/crates/trusty-memory/src/commands/kg_rebuild.rs
+++ b/crates/trusty-memory/src/commands/kg_rebuild.rs
@@ -19,6 +19,7 @@ use trusty_common::memory_core::palace::PalaceId;
 use trusty_common::memory_core::store::kg::{KnowledgeGraph, Triple};
 use trusty_common::memory_core::store::OpenIntent;
 
+use super::kg_twin_merge::report_merge;
 use crate::kg_extract::{
     extract_triples, is_stop_token, ExtractInput, AUTO_PROVENANCE, DRAWER_SUBJECT_PREFIX,
     ROOM_SUBJECT_PREFIX, TAG_SUBJECT_PREFIX, TOPIC_SUBJECT_PREFIX,
@@ -33,7 +34,7 @@ use crate::{resolve_palace_registry_dir, AppState};
 /// What: the four prefixes `kg_extract` emits. A subject carrying any of them
 /// is skipped before the stopword test runs.
 /// Test: `purge_skips_namespaced_subjects`.
-const STRUCTURAL_PREFIXES: &[&str] = &[
+pub(crate) const STRUCTURAL_PREFIXES: &[&str] = &[
     DRAWER_SUBJECT_PREFIX,
     TAG_SUBJECT_PREFIX,
     TOPIC_SUBJECT_PREFIX,
@@ -65,8 +66,9 @@ pub struct PalaceRebuildSummary {
 /// [`handle_kg_rebuild`]'s existing one-argument signature intact — that
 /// function is public API of a crate `trusty-agents` links against, so
 /// widening it in place would be a breaking change for a bug fix.
-/// What: the palace filter plus the two purge switches. `Default` is an
-/// ordinary rebuild of every palace, which is the pre-#4678 behaviour.
+/// What: the palace filter plus the maintenance switches — #4678's purge,
+/// #5401's twin merge, and the shared dry run. `Default` is an ordinary rebuild
+/// of every palace, which is the pre-#4678 behaviour.
 /// Test: `purge_is_off_by_default`.
 #[derive(Debug, Clone, Default)]
 pub struct KgRebuildOptions {
@@ -74,7 +76,10 @@ pub struct KgRebuildOptions {
     pub palace: Option<String>,
     /// Delete auto-extracted subjects the #4678 token filter now rejects.
     pub purge_stale_subjects: bool,
-    /// Report the purge candidates and write nothing at all.
+    /// Re-point auto-extracted triples off a punctuated entity node onto its
+    /// cleaned twin (#5401).
+    pub merge_punctuated_twins: bool,
+    /// Report what the selected maintenance passes would do and write nothing.
     pub dry_run: bool,
 }
 
@@ -103,8 +108,10 @@ pub async fn handle_kg_rebuild(palace: Option<String>) -> Result<()> {
 /// platform equivalent) via `resolve_data_dir`, calls `rebuild_palaces` with
 /// the optional palace filter, then prints a human-readable summary to
 /// stdout. With `purge_stale_subjects` it then deletes the stale subjects;
-/// with `dry_run` it skips the rebuild entirely and only reports what the
-/// purge would delete, so the whole invocation writes nothing.
+/// with `merge_punctuated_twins` it re-points each punctuated entity's triples
+/// onto the cleaned twin (#5401); with `dry_run` it skips the rebuild entirely
+/// and only reports what the selected passes would do, so the whole invocation
+/// writes nothing.
 /// Test: not unit-tested (process-level entry point); `rebuild_palaces` and
 /// `purge_palaces` are the testable surfaces.
 pub async fn handle_kg_rebuild_with(opts: KgRebuildOptions) -> Result<()> {
@@ -120,9 +127,15 @@ pub async fn handle_kg_rebuild_with(opts: KgRebuildOptions) -> Result<()> {
     // drawers — a write, and precisely the thing --dry-run promises not to do.
     if opts.dry_run {
         println!("kg-rebuild: DRY RUN — nothing is written: no palace is hydrated, no triple is asserted, no subject is deleted");
-        let failures = report_purge(&state, palace.as_deref(), false).await?;
+        let mut failures = 0usize;
+        if opts.purge_stale_subjects {
+            failures += report_purge(&state, palace.as_deref(), false).await?;
+        }
+        if opts.merge_punctuated_twins {
+            failures += report_merge(&state, palace.as_deref(), false).await?;
+        }
         if failures > 0 {
-            anyhow::bail!("kg-rebuild purge: {failures} palace(s) could not be scanned");
+            anyhow::bail!("kg-rebuild: {failures} palace(s) could not be scanned");
         }
         return Ok(());
     }
@@ -165,6 +178,17 @@ pub async fn handle_kg_rebuild_with(opts: KgRebuildOptions) -> Result<()> {
         if failures > 0 {
             anyhow::bail!(
                 "kg-rebuild purge: {failures} subject deletion(s) failed — see the [purge-FAILED] lines above"
+            );
+        }
+    }
+    // #5401: merge after the purge — the purge deletes the stopword subjects
+    // this pass is required to leave alone, so a merged palace never inherits
+    // one of them as a target.
+    if opts.merge_punctuated_twins {
+        let failures = report_merge(&state, palace.as_deref(), true).await?;
+        if failures > 0 {
+            anyhow::bail!(
+                "kg-rebuild merge: {failures} re-point(s) failed — see the [merge-FAILED] lines above"
             );
         }
     }
@@ -395,21 +419,7 @@ async fn purge_one(state: &AppState, palace_id: &str, apply: bool) -> Result<Pal
     let kg = KnowledgeGraph::open_with_intent(&kg_path, intent)
         .with_context(|| format!("open kg for palace {palace_id}"))?;
 
-    let mut active: Vec<Triple> = Vec::new();
-    let mut offset = 0usize;
-    loop {
-        let page = kg
-            .list_active(PURGE_SCAN_PAGE, offset)
-            .await
-            .with_context(|| format!("scan active triples in {palace_id}"))?;
-        let n = page.len();
-        active.extend(page);
-        if n < PURGE_SCAN_PAGE {
-            break;
-        }
-        offset += n;
-    }
-
+    let active = scan_active_triples(&kg, palace_id).await?;
     let selected = stale_subject_candidates(&active);
     let outcome = if apply {
         let store = kg.store();
@@ -440,6 +450,37 @@ async fn purge_one(state: &AppState, palace_id: &str, apply: bool) -> Result<Pal
         rows_closed: outcome.rows_closed,
         error,
     })
+}
+
+/// Page every active triple in `kg` into one vec.
+///
+/// Why: both maintenance passes — the #4678 purge and the #5401 twin merge —
+/// decide from the whole active set, and `list_active` is a windowed read. One
+/// scan means the page size and the last-page condition cannot drift between
+/// them.
+/// What: repeats `list_active` at [`PURGE_SCAN_PAGE`] until a short page ends
+/// the walk.
+/// Test: `purge_selects_only_stopword_subjects` (through `purge_one`),
+/// `merge_repoints_both_positions_and_keeps_the_cleaned_nodes_triples`.
+pub(crate) async fn scan_active_triples(
+    kg: &KnowledgeGraph,
+    palace_id: &str,
+) -> Result<Vec<Triple>> {
+    let mut active: Vec<Triple> = Vec::new();
+    let mut offset = 0usize;
+    loop {
+        let page = kg
+            .list_active(PURGE_SCAN_PAGE, offset)
+            .await
+            .with_context(|| format!("scan active triples in {palace_id}"))?;
+        let n = page.len();
+        active.extend(page);
+        if n < PURGE_SCAN_PAGE {
+            break;
+        }
+        offset += n;
+    }
+    Ok(active)
 }
 
 /// Pick the subjects a purge may delete.
@@ -720,14 +761,17 @@ mod tests {
         );
     }
 
-    /// Why: the purge must never fire as a side effect of an ordinary rebuild.
-    /// What: the default options carry both switches off, so
-    /// `handle_kg_rebuild`'s one-argument form cannot delete anything.
+    /// Why: neither maintenance pass may fire as a side effect of an ordinary
+    /// rebuild.
+    /// What: the default options carry every switch off, so
+    /// `handle_kg_rebuild`'s one-argument form cannot delete or re-point
+    /// anything.
     /// Test: This test.
     #[test]
     fn purge_is_off_by_default() {
         let opts = KgRebuildOptions::default();
         assert!(!opts.purge_stale_subjects, "purge must be opt-in");
+        assert!(!opts.merge_punctuated_twins, "the merge must be opt-in");
         assert!(!opts.dry_run);
     }
 

--- a/crates/trusty-memory/src/commands/kg_twin_merge.rs
+++ b/crates/trusty-memory/src/commands/kg_twin_merge.rs
@@ -119,7 +119,7 @@ pub fn twin_repoints(active: &[Triple]) -> Vec<TwinRepoint> {
             new,
         });
     }
-    out.sort_by(|a, b| key(&a.old).cmp(&key(&b.old)));
+    out.sort_by_key(|a| key(&a.old));
     out
 }
 

--- a/crates/trusty-memory/src/commands/kg_twin_merge.rs
+++ b/crates/trusty-memory/src/commands/kg_twin_merge.rs
@@ -17,7 +17,8 @@
 //! the punctuated object's correct siblings with it.
 //! Test: `twin_repoints_moves_both_positions`, `twin_repoints_skips_namespaces`,
 //! `twin_repoints_leaves_the_purge_its_stopwords`,
-//! `merge_repoints_both_positions_and_keeps_the_cleaned_nodes_triples`.
+//! `merge_repoints_both_positions_and_keeps_the_cleaned_nodes_triples`,
+//! `merge_reports_a_failed_repoint_and_leaves_the_fact_readable`.
 
 use anyhow::{Context, Result};
 use std::collections::HashSet;
@@ -25,7 +26,7 @@ use trusty_common::memory_core::store::kg::{KnowledgeGraph, Triple};
 use trusty_common::memory_core::store::OpenIntent;
 
 use super::kg_rebuild::{scan_active_triples, STRUCTURAL_PREFIXES};
-use crate::kg_extract::{canonical_entity, AUTO_PROVENANCE};
+use crate::kg_extract::{canonical_entity, is_stop_token, AUTO_PROVENANCE};
 use crate::AppState;
 
 /// One fact's move from a punctuated node onto the cleaned one.
@@ -73,12 +74,16 @@ fn canonical_term(term: &str) -> Option<&str> {
 /// Every re-point the active set calls for.
 ///
 /// Why: selection is the half worth testing without a store, and it carries the
-/// two guardrails that keep the pass from touching data it does not own — a
-/// namespaced term, and a triple a human asserted.
+/// three guardrails that keep the pass from touching data it does not own — a
+/// namespaced term, a triple a human asserted, and a stopword.
 /// What: for each active triple stamped [`AUTO_PROVENANCE`], canonicalises the
 /// subject and the object independently and emits a [`TwinRepoint`] when either
-/// moves. Sorted by the stored triple so the report and the write order are
-/// deterministic.
+/// moves. A triple is skipped when the term that would STAY is a stopword:
+/// [`canonical_entity`] rejects `("the` in whichever position it sits, so
+/// without this check `` `redb` --is-a--> ("the `` would be selected on its
+/// subject alone and hang the object garbage off the node users query — and
+/// the purge, which selects by subject, could never reach it there. Sorted by
+/// the stored triple so the report and the write order are deterministic.
 /// Test: `twin_repoints_moves_both_positions`, `twin_repoints_skips_namespaces`,
 /// `twin_repoints_spares_a_manual_triple`,
 /// `twin_repoints_leaves_the_purge_its_stopwords`.
@@ -92,6 +97,14 @@ pub fn twin_repoints(active: &[Triple]) -> Vec<TwinRepoint> {
         let subject = canonical_term(&t.subject);
         let object = canonical_term(&t.object);
         if subject.is_none() && object.is_none() {
+            continue;
+        }
+        // #5401: a stopword in EITHER position keeps the triple out of this
+        // pass, so the partition with `--purge-stale-subjects` holds for the
+        // object position too, not just the subject one.
+        if (subject.is_none() && is_stop_token(&t.subject))
+            || (object.is_none() && is_stop_token(&t.object))
+        {
             continue;
         }
         let mut new = t.clone();
@@ -198,19 +211,26 @@ pub async fn report_merge(
 
 /// Select — and optionally apply — punctuated-twin merges across palaces.
 ///
-/// Why: same per-palace error containment as `purge_palaces`.
+/// Why: same per-palace error containment as `purge_palaces`. Containment stops
+/// at the palace: a registry read that fails yields no palaces to contain, and
+/// swallowing it printed `0 triples repointed, 0 failed` over data the pass
+/// never read. A TCC denial on the data dir makes that `read_dir` return EPERM,
+/// so the clean-looking exit-0 is reachable, not theoretical.
 /// What: iterates the registry, filters to one palace when asked, and captures
-/// a failing palace as a summary carrying `error` rather than propagating.
+/// a failing palace as a summary carrying `error` rather than propagating. A
+/// failure to list the palaces at all propagates instead.
 /// Test: `merge_repoints_both_positions_and_keeps_the_cleaned_nodes_triples`,
-/// `merge_dry_run_writes_nothing`.
+/// `merge_dry_run_writes_nothing`,
+/// `merge_palaces_propagates_an_unreadable_data_root`.
 pub async fn merge_palaces(
     state: &AppState,
     palace_filter: Option<&str>,
     apply: bool,
 ) -> Result<Vec<PalaceMergeSummary>> {
     let mut out: Vec<PalaceMergeSummary> = Vec::new();
+    // #5401: an unreadable data root is a failed run, never an empty one.
     let palaces = trusty_common::memory_core::PalaceRegistry::list_palaces(&state.data_root)
-        .unwrap_or_default();
+        .with_context(|| format!("list palaces under {}", state.data_root.display()))?;
     for palace in palaces {
         let id = palace.id.0.clone();
         if palace_filter.is_some_and(|filter| filter != id) {
@@ -297,8 +317,15 @@ async fn merge_one(state: &AppState, palace_id: &str, apply: bool) -> Result<Pal
 /// take `x`'s other `uses` objects with it.
 /// What: asserts `new` unless that exact `(subject, predicate, object)` is
 /// already live, then closes the punctuated row. Naming a row that is not there
-/// is a no-op in both directions, so a re-run is idempotent.
-/// Test: `merge_repoints_both_positions_and_keeps_the_cleaned_nodes_triples`.
+/// is a no-op in both directions, so a re-run is idempotent. A retract that
+/// closes nothing is that no-op arriving one step too late — the assert has
+/// already landed, so the fact now sits on both nodes, which is the split this
+/// pass exists to remove. It becomes a per-re-point failure: the operator sees
+/// the pair on `[merge-FAILED]` and the command exits non-zero. An exclusive
+/// `OpenIntent::Writer` lock means nothing else can close the row underneath
+/// this loop, so it is unreachable today rather than merely unlikely.
+/// Test: `merge_repoints_both_positions_and_keeps_the_cleaned_nodes_triples`,
+/// `merge_reports_a_failed_repoint_and_leaves_the_fact_readable`.
 async fn repoint(
     kg: &KnowledgeGraph,
     r: &TwinRepoint,
@@ -310,9 +337,15 @@ async fn repoint(
             .await
             .with_context(|| format!("assert cleaned twin {}", render(r)))?;
     }
-    kg.retract_triple(&r.old.subject, &r.old.predicate, &r.old.object)
+    let closed = kg
+        .retract_triple(&r.old.subject, &r.old.predicate, &r.old.object)
         .await
         .with_context(|| format!("retract punctuated twin {}", render(r)))?;
+    anyhow::ensure!(
+        closed > 0,
+        "punctuated row vanished before its retract, so the fact now stands at both nodes: {}",
+        render(r)
+    );
     Ok(())
 }
 
@@ -423,21 +456,34 @@ mod tests {
 
     /// Why: the purge deletes and this merges, so a term both passes claimed
     /// would be deleted and re-pointed in the same run. `is_stop_token` is the
-    /// one gate that separates them.
+    /// one gate that separates them, and it has to hold in the object position
+    /// too: a triple selected on its subject alone once carried `("the` along
+    /// as an object and hung it off the cleaned node, where the purge — which
+    /// selects by subject — could never reach it again.
     /// What: `("the` is the purge's and not this pass's; `` `redb` `` is this
-    /// pass's and not the purge's.
+    /// pass's and not the purge's; and a triple with a stopword at either end
+    /// moves neither end.
     /// Test: This test.
     #[test]
     fn twin_repoints_leaves_the_purge_its_stopwords() {
         let active = vec![
             triple("(\"the", "is-a", "thing", Some(AUTO_PROVENANCE)),
             triple("`redb`", "is-a", "database", Some(AUTO_PROVENANCE)),
+            // The subject moves, the object is a stopword: selecting this would
+            // create `redb --is-a--> ("the`, unreachable garbage on a real node.
+            triple("`redb`", "is-a", "(\"the", Some(AUTO_PROVENANCE)),
+            // The mirror image — the purge already claims this subject.
+            triple("(\"the", "uses", "`redb`", Some(AUTO_PROVENANCE)),
         ];
-        let merged: Vec<String> = twin_repoints(&active)
+        let merged: Vec<(String, String)> = twin_repoints(&active)
             .iter()
-            .map(|r| r.old.subject.clone())
+            .map(|r| (r.new.subject.clone(), r.new.object.clone()))
             .collect();
-        assert_eq!(merged, vec!["`redb`".to_string()]);
+        assert_eq!(
+            merged,
+            vec![("redb".to_string(), "database".to_string())],
+            "a stopword in either position keeps the whole triple out of this pass"
+        );
         assert_eq!(
             stale_subject_candidates(&active),
             vec!["(\"the".to_string()],
@@ -587,6 +633,114 @@ mod tests {
             "a dry run must not create the cleaned node either"
         );
         assert_eq!(report_merge(&state, Some("a"), false).await?, 0);
+        Ok(())
+    }
+
+    /// Why: `list_palaces` was called with `unwrap_or_default()`, so a registry
+    /// read that failed became zero palaces and the run printed
+    /// `0 triples repointed, 0 failed` and exited 0 over data it never read. A
+    /// macOS TCC denial on the data dir is exactly that failure — `read_dir`
+    /// returns EPERM — and the operator's evidence that the merge ran clean
+    /// would be a pass that never opened a single palace.
+    /// What: a `data_root` whose listing fails makes the pass return `Err`.
+    /// A regular file stands in for the denial: both reach the same `read_dir`
+    /// error arm, and this one reproduces without depending on the uid the
+    /// suite runs as.
+    /// Test: This test.
+    #[tokio::test]
+    async fn merge_palaces_propagates_an_unreadable_data_root() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let data_root = tmp.path().join("not-a-directory");
+        std::fs::write(&data_root, b"")?;
+        let state = AppState::new(data_root);
+
+        let err = merge_palaces(&state, None, false)
+            .await
+            .expect_err("an unlistable data root must fail the run, not report an empty one");
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("list palaces"),
+            "the error must name what could not be read, got {rendered}"
+        );
+        Ok(())
+    }
+
+    /// Why: assert-before-retract is this pass's whole crash-safety argument,
+    /// and until this test nothing ran a re-point that failed — the ordering
+    /// was verified only by reading the source. A failed write must leave the
+    /// fact readable SOMEWHERE, be reported as failed rather than merged, and
+    /// reach the non-zero exit at `kg_rebuild.rs`.
+    /// What: seeds `` `redb` --uses--> mmap ``, then hands the merge a store
+    /// whose writes are rejected — the live redb file is held open, so the
+    /// process-wide store cache is primed with a read-only snapshot and the
+    /// merge's `Writer` open picks it up. Asserts the failure is recorded, that
+    /// `report_merge` returns a non-zero count, and that the fact is still at
+    /// the punctuated node afterwards.
+    /// Test: This test.
+    #[tokio::test]
+    async fn merge_reports_a_failed_repoint_and_leaves_the_fact_readable() -> Result<()> {
+        let seed_root = tempfile::tempdir()?;
+        let seeded = palace_fixture(seed_root.path().to_path_buf()).await?;
+        let handle = seeded
+            .registry
+            .open_palace(&seeded.data_root, &PalaceId::new("a"))?;
+        handle
+            .kg
+            .assert(triple("`redb`", "uses", "mmap", Some(AUTO_PROVENANCE)))
+            .await?;
+
+        // Copy the committed palace onto a second data root the registry has
+        // never opened, so this test owns every handle on that redb file.
+        let tmp = tempfile::tempdir()?;
+        let palace_dir = tmp.path().join("a");
+        std::fs::create_dir_all(&palace_dir)?;
+        for entry in std::fs::read_dir(seeded.data_root.join("a"))? {
+            let entry = entry?;
+            if entry.file_type()?.is_file() {
+                std::fs::copy(entry.path(), palace_dir.join(entry.file_name()))?;
+            }
+        }
+        let kg_path = palace_dir.join("kg.db");
+        let state = AppState::new(tmp.path().to_path_buf());
+        state.set_ready();
+
+        // Holding the live file makes the next open fall back to a read-only
+        // snapshot, which the store cache then hands to the merge.
+        let live = redb::Database::create(palace_dir.join("kg.redb"))
+            .context("hold the palace's redb lock")?;
+        let read_only = KnowledgeGraph::open_with_intent(&kg_path, OpenIntent::ReadOnlyClient)?;
+
+        let applied = merge_palaces(&state, Some("a"), true).await?;
+        assert_eq!(applied.len(), 1);
+        assert_eq!(applied[0].selected.len(), 1, "the twin must still be found");
+        assert!(
+            applied[0].merged.is_empty(),
+            "a re-point that could not write must never be reported as merged"
+        );
+        assert_eq!(applied[0].failed.len(), 1, "the failure must be recorded");
+        assert!(
+            applied[0].failed[0].1.contains("read-only"),
+            "the failure must carry its error text, got {:?}",
+            applied[0].failed[0].1
+        );
+        assert!(
+            applied[0].error.is_some(),
+            "a palace with a failed re-point must carry an error"
+        );
+        assert!(
+            report_merge(&state, Some("a"), true).await? > 0,
+            "the failure must reach the count kg_rebuild bails on"
+        );
+
+        // Assert-before-retract: the fact is still where it was.
+        drop(read_only);
+        drop(live);
+        let after = KnowledgeGraph::open_with_intent(&kg_path, OpenIntent::Writer)?;
+        assert_eq!(
+            objects_of(&after, "`redb`").await?,
+            vec!["mmap".to_string()],
+            "a re-point that failed must leave the fact readable at the punctuated node"
+        );
         Ok(())
     }
 }

--- a/crates/trusty-memory/src/commands/kg_twin_merge.rs
+++ b/crates/trusty-memory/src/commands/kg_twin_merge.rs
@@ -1,0 +1,592 @@
+//! `kg-rebuild --merge-punctuated-twins` — fold a pre-#4678 punctuated entity
+//! node onto its cleaned twin.
+//!
+//! Why: #4678 taught the extractor to trim edge punctuation, so a drawer that
+//! once yielded `` `redb` `` now yields `redb` and both nodes stand in the same
+//! palace. Nothing removes the old one: `is-a`, `uses`, `works-at` and
+//! `depends-on` are absent from `kg_store::FUNCTIONAL_PREDICATES`, so a rebuild's
+//! assert adds the cleaned spelling beside the punctuated one, and
+//! `--purge-stale-subjects` only selects subjects `is_stop_token` rejects —
+//! which a real entity never trips. Every rebuild over the same content widens
+//! the split (#5401).
+//! What: a MERGE, not a delete. Each auto-extracted triple whose subject or
+//! object carries edge punctuation is re-asserted under the cleaned identity and
+//! only then retracted at its punctuated one, so both positions move and no fact
+//! is dropped. Object-position re-pointing is what needed #5396's
+//! `retract_triple`: closing the whole `(subject, predicate)` pair would take
+//! the punctuated object's correct siblings with it.
+//! Test: `twin_repoints_moves_both_positions`, `twin_repoints_skips_namespaces`,
+//! `twin_repoints_leaves_the_purge_its_stopwords`,
+//! `merge_repoints_both_positions_and_keeps_the_cleaned_nodes_triples`.
+
+use anyhow::{Context, Result};
+use std::collections::HashSet;
+use trusty_common::memory_core::store::kg::{KnowledgeGraph, Triple};
+use trusty_common::memory_core::store::OpenIntent;
+
+use super::kg_rebuild::{scan_active_triples, STRUCTURAL_PREFIXES};
+use crate::kg_extract::{canonical_entity, AUTO_PROVENANCE};
+use crate::AppState;
+
+/// One fact's move from a punctuated node onto the cleaned one.
+///
+/// Why: the merge has to name both endpoints — what is retracted and what is
+/// asserted — because a re-point that only knew the target could not undo the
+/// source, and one that only knew the source would delete the fact.
+/// What: the stored triple and the same fact under the cleaned identity.
+/// `new` differs from `old` in the subject, the object, or both.
+/// Test: `twin_repoints_moves_both_positions`.
+#[derive(Debug, Clone)]
+pub struct TwinRepoint {
+    pub old: Triple,
+    pub new: Triple,
+}
+
+/// Render one re-point for the operator-facing report.
+fn render(r: &TwinRepoint) -> String {
+    format!(
+        "({} {} {}) => ({} {} {})",
+        r.old.subject, r.old.predicate, r.old.object, r.new.subject, r.new.predicate, r.new.object
+    )
+}
+
+/// The `(subject, predicate, object)` identity a triple occupies (#4810).
+fn key(t: &Triple) -> (String, String, String) {
+    (t.subject.clone(), t.predicate.clone(), t.object.clone())
+}
+
+/// The cleaned spelling `term` belongs under, if any.
+///
+/// Why: `tag:the` and `topic:v1.` are namespaces the user's own tags and rooms
+/// live in, not extractor debris — trimming their trailing punctuation would
+/// rewrite a membership edge into one pointing at a node nobody wrote.
+/// What: [`canonical_entity`] with the [`STRUCTURAL_PREFIXES`] exemption in
+/// front of it.
+/// Test: `twin_repoints_skips_namespaces`.
+fn canonical_term(term: &str) -> Option<&str> {
+    if STRUCTURAL_PREFIXES.iter().any(|p| term.starts_with(p)) {
+        return None;
+    }
+    canonical_entity(term)
+}
+
+/// Every re-point the active set calls for.
+///
+/// Why: selection is the half worth testing without a store, and it carries the
+/// two guardrails that keep the pass from touching data it does not own — a
+/// namespaced term, and a triple a human asserted.
+/// What: for each active triple stamped [`AUTO_PROVENANCE`], canonicalises the
+/// subject and the object independently and emits a [`TwinRepoint`] when either
+/// moves. Sorted by the stored triple so the report and the write order are
+/// deterministic.
+/// Test: `twin_repoints_moves_both_positions`, `twin_repoints_skips_namespaces`,
+/// `twin_repoints_spares_a_manual_triple`,
+/// `twin_repoints_leaves_the_purge_its_stopwords`.
+pub fn twin_repoints(active: &[Triple]) -> Vec<TwinRepoint> {
+    let mut out: Vec<TwinRepoint> = Vec::new();
+    for t in active {
+        // A hand-asserted fact spells its entity the way its author meant to.
+        if t.provenance.as_deref() != Some(AUTO_PROVENANCE) {
+            continue;
+        }
+        let subject = canonical_term(&t.subject);
+        let object = canonical_term(&t.object);
+        if subject.is_none() && object.is_none() {
+            continue;
+        }
+        let mut new = t.clone();
+        if let Some(s) = subject {
+            new.subject = s.to_string();
+        }
+        if let Some(o) = object {
+            new.object = o.to_string();
+        }
+        out.push(TwinRepoint {
+            old: t.clone(),
+            new,
+        });
+    }
+    out.sort_by(|a, b| key(&a.old).cmp(&key(&b.old)));
+    out
+}
+
+/// Per-palace result of a `--merge-punctuated-twins` pass.
+///
+/// Why: mirrors `PalacePurgeSummary` so one bad palace is reported rather than
+/// aborting the run, and so a failed re-point can never be read as a success.
+/// What: `selected` is what the scan picked, rendered; `merged` and `failed`
+/// split what actually happened. `error` is set whenever anything failed.
+/// Test: `merge_summary_counts_each_failure_once`.
+#[derive(Debug, Clone)]
+pub struct PalaceMergeSummary {
+    pub palace_id: String,
+    pub selected: Vec<String>,
+    pub merged: Vec<String>,
+    pub failed: Vec<(String, String)>,
+    pub error: Option<String>,
+}
+
+impl PalaceMergeSummary {
+    /// How many failures this palace contributes to the command's exit code.
+    ///
+    /// Why: `error` summarises the per-re-point failures when there are any, so
+    /// counting both would report every such palace one time too many — the
+    /// arithmetic `count_purge_failures` exists to get right on the purge side.
+    /// What: the per-re-point failures when there are any, otherwise one for a
+    /// palace-level error, otherwise zero. Never both.
+    /// Test: `merge_summary_counts_each_failure_once`.
+    pub fn failure_count(&self) -> usize {
+        if !self.failed.is_empty() {
+            self.failed.len()
+        } else {
+            usize::from(self.error.is_some())
+        }
+    }
+}
+
+/// Print every re-point, then optionally apply it.
+///
+/// Why: the pass rewrites real facts, so the moves are printed in both modes —
+/// an operator sees exactly what moved (or would move) rather than a bare count.
+/// What: runs [`merge_palaces`] and prints applied moves on stdout and failures
+/// on stderr, then an aggregate. Returns the failure count so the caller can
+/// exit non-zero.
+/// Test: `merge_dry_run_writes_nothing`.
+pub async fn report_merge(
+    state: &AppState,
+    palace_filter: Option<&str>,
+    apply: bool,
+) -> Result<usize> {
+    let summaries = merge_palaces(state, palace_filter, apply).await?;
+    let mut total = 0usize;
+    let failures: usize = summaries
+        .iter()
+        .map(PalaceMergeSummary::failure_count)
+        .sum();
+    for s in &summaries {
+        if let Some(e) = &s.error {
+            eprintln!("[merge-error] palace={} error={}", s.palace_id, e);
+            if s.failed.is_empty() {
+                continue;
+            }
+        }
+        if apply {
+            for moved in &s.merged {
+                println!("[merge] palace={} repointed {}", s.palace_id, moved);
+            }
+            for (moved, err) in &s.failed {
+                eprintln!(
+                    "[merge-FAILED] palace={} repoint={} error={}",
+                    s.palace_id, moved, err
+                );
+            }
+            total += s.merged.len();
+        } else {
+            for moved in &s.selected {
+                println!("[merge] palace={} would repoint {}", s.palace_id, moved);
+            }
+            total += s.selected.len();
+        }
+    }
+    if apply {
+        println!("kg-rebuild merge: {total} triples repointed, {failures} failed");
+    } else {
+        println!("kg-rebuild merge: {total} triples would be repointed (dry run)");
+    }
+    Ok(failures)
+}
+
+/// Select — and optionally apply — punctuated-twin merges across palaces.
+///
+/// Why: same per-palace error containment as `purge_palaces`.
+/// What: iterates the registry, filters to one palace when asked, and captures
+/// a failing palace as a summary carrying `error` rather than propagating.
+/// Test: `merge_repoints_both_positions_and_keeps_the_cleaned_nodes_triples`,
+/// `merge_dry_run_writes_nothing`.
+pub async fn merge_palaces(
+    state: &AppState,
+    palace_filter: Option<&str>,
+    apply: bool,
+) -> Result<Vec<PalaceMergeSummary>> {
+    let mut out: Vec<PalaceMergeSummary> = Vec::new();
+    let palaces = trusty_common::memory_core::PalaceRegistry::list_palaces(&state.data_root)
+        .unwrap_or_default();
+    for palace in palaces {
+        let id = palace.id.0.clone();
+        if palace_filter.is_some_and(|filter| filter != id) {
+            continue;
+        }
+        let summary = merge_one(state, &id, apply)
+            .await
+            .unwrap_or_else(|e| PalaceMergeSummary {
+                palace_id: id.clone(),
+                selected: Vec::new(),
+                merged: Vec::new(),
+                failed: Vec::new(),
+                error: Some(format!("{e:#}")),
+            });
+        out.push(summary);
+    }
+    Ok(out)
+}
+
+/// Merge one palace's twins.
+///
+/// Why: the direct `kg.db` open is the #4678 rule this pass inherits — going
+/// through `PalaceHandle::open` would run the issue-#61 expired-drawer sweep,
+/// and a preview that deletes drawer rows is not a preview. Intent follows the
+/// mode so an applying run fails loud against a running daemon instead of
+/// writing into a read-only snapshot.
+/// What: scans the active set, selects with [`twin_repoints`], and (when
+/// `apply`) re-points each through [`repoint`]. The in-memory adjacency is not
+/// resynced — this runs in a one-shot CLI process.
+/// Test: `merge_repoints_both_positions_and_keeps_the_cleaned_nodes_triples`,
+/// `merge_dry_run_writes_nothing`.
+async fn merge_one(state: &AppState, palace_id: &str, apply: bool) -> Result<PalaceMergeSummary> {
+    let kg_path = state.data_root.join(palace_id).join("kg.db");
+    let intent = if apply {
+        OpenIntent::Writer
+    } else {
+        OpenIntent::ReadOnlyClient
+    };
+    let kg = KnowledgeGraph::open_with_intent(&kg_path, intent)
+        .with_context(|| format!("open kg for palace {palace_id}"))?;
+
+    let active = scan_active_triples(&kg, palace_id).await?;
+    let selected = twin_repoints(&active);
+    let mut summary = PalaceMergeSummary {
+        palace_id: palace_id.to_string(),
+        selected: selected.iter().map(render).collect(),
+        merged: Vec::new(),
+        failed: Vec::new(),
+        error: None,
+    };
+    if !apply {
+        return Ok(summary);
+    }
+
+    // What the cleaned identity already holds. Re-asserting one of those rows
+    // would close its interval and reopen it at the punctuated row's older
+    // `valid_from`, leaving a history row whose end precedes its start.
+    let mut live: HashSet<(String, String, String)> = active.iter().map(key).collect();
+    for r in &selected {
+        match repoint(&kg, r, &live).await {
+            Ok(()) => {
+                live.insert(key(&r.new));
+                summary.merged.push(render(r));
+            }
+            Err(e) => summary.failed.push((render(r), format!("{e:#}"))),
+        }
+    }
+    if !summary.failed.is_empty() {
+        summary.error = Some(format!(
+            "{} of {} re-point(s) failed",
+            summary.failed.len(),
+            selected.len()
+        ));
+    }
+    Ok(summary)
+}
+
+/// Move one triple onto the cleaned identity.
+///
+/// Why: assert BEFORE retract. A crash between the two leaves the punctuated
+/// twin standing, which the next run merges again; the reverse order loses the
+/// fact outright. The retract must be `retract_triple` (#5396) — `retract`
+/// closes every object at the pair, so re-pointing `x --uses--> ``redb``` would
+/// take `x`'s other `uses` objects with it.
+/// What: asserts `new` unless that exact `(subject, predicate, object)` is
+/// already live, then closes the punctuated row. Naming a row that is not there
+/// is a no-op in both directions, so a re-run is idempotent.
+/// Test: `merge_repoints_both_positions_and_keeps_the_cleaned_nodes_triples`.
+async fn repoint(
+    kg: &KnowledgeGraph,
+    r: &TwinRepoint,
+    live: &HashSet<(String, String, String)>,
+) -> Result<()> {
+    // #5401: the cleaned node absorbs the fact before the punctuated one drops it.
+    if !live.contains(&key(&r.new)) {
+        kg.assert(r.new.clone())
+            .await
+            .with_context(|| format!("assert cleaned twin {}", render(r)))?;
+    }
+    kg.retract_triple(&r.old.subject, &r.old.predicate, &r.old.object)
+        .await
+        .with_context(|| format!("retract punctuated twin {}", render(r)))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::kg_rebuild::stale_subject_candidates;
+    use serde_json::json;
+    use trusty_common::memory_core::palace::PalaceId;
+
+    /// Build an active triple for the selection tests.
+    fn triple(subject: &str, predicate: &str, object: &str, provenance: Option<&str>) -> Triple {
+        Triple {
+            subject: subject.to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+            valid_from: chrono::Utc::now(),
+            valid_to: None,
+            confidence: 0.6,
+            provenance: provenance.map(|p| p.to_string()),
+        }
+    }
+
+    /// Why: the whole ticket is that an object-position twin is as real as a
+    /// subject-position one, and a fix that only re-points subjects leaves half
+    /// the split standing.
+    /// What: both positions are canonicalised, independently and together.
+    /// Test: This test.
+    #[test]
+    fn twin_repoints_moves_both_positions() {
+        let active = vec![
+            triple("`redb`", "uses", "mmap", Some(AUTO_PROVENANCE)),
+            triple("trusty-memory", "uses", "`redb`", Some(AUTO_PROVENANCE)),
+            triple("(sled)", "is-a", "*store*", Some(AUTO_PROVENANCE)),
+            triple("redb", "is-a", "database", Some(AUTO_PROVENANCE)),
+        ];
+        let got = twin_repoints(&active);
+        let moved: Vec<(String, String)> = got
+            .iter()
+            .map(|r| {
+                (
+                    format!("{} {}", r.old.subject, r.old.object),
+                    format!("{} {}", r.new.subject, r.new.object),
+                )
+            })
+            .collect();
+        assert_eq!(
+            moved,
+            vec![
+                ("(sled) *store*".to_string(), "sled store".to_string()),
+                ("`redb` mmap".to_string(), "redb mmap".to_string()),
+                (
+                    "trusty-memory `redb`".to_string(),
+                    "trusty-memory redb".to_string()
+                ),
+            ],
+            "subject-only, object-only and both-position twins must all move, \
+             and an already-clean triple must not"
+        );
+        assert!(
+            got.iter().all(|r| r.old.predicate == r.new.predicate
+                && r.old.confidence == r.new.confidence
+                && r.old.provenance == r.new.provenance),
+            "a re-point changes identity, never the fact's metadata"
+        );
+    }
+
+    /// Why: `tag:v1.` is a tag the user wrote. Trimming its trailing dot would
+    /// re-point a real membership edge onto a node nobody asserted.
+    /// What: terms under the drawer/tag/topic/room namespaces never move, in
+    /// either position.
+    /// Test: This test.
+    #[test]
+    fn twin_repoints_skips_namespaces() {
+        let drawer = format!("drawer:{}", uuid::Uuid::new_v4());
+        let active = vec![
+            triple("tag:v1.", "tags", &drawer, Some(AUTO_PROVENANCE)),
+            triple(
+                "topic:(beta)",
+                "mentioned-in",
+                &drawer,
+                Some(AUTO_PROVENANCE),
+            ),
+            triple("room:*general*", "contains", &drawer, Some(AUTO_PROVENANCE)),
+        ];
+        assert!(
+            twin_repoints(&active).is_empty(),
+            "namespaced terms must never be re-pointed"
+        );
+    }
+
+    /// Why: a human who asserted `` `redb` `` spelled it that way on purpose;
+    /// only extractor output is this pass's to rewrite.
+    /// What: a punctuated triple stamped anything other than `auto:remember` —
+    /// including nothing at all — is not selected.
+    /// Test: This test.
+    #[test]
+    fn twin_repoints_spares_a_manual_triple() {
+        let active = vec![
+            triple("`redb`", "is-a", "database", Some("kg_assert")),
+            triple("`sled`", "is-a", "database", None),
+        ];
+        assert!(
+            twin_repoints(&active).is_empty(),
+            "only auto-extracted triples may be re-pointed"
+        );
+    }
+
+    /// Why: the purge deletes and this merges, so a term both passes claimed
+    /// would be deleted and re-pointed in the same run. `is_stop_token` is the
+    /// one gate that separates them.
+    /// What: `("the` is the purge's and not this pass's; `` `redb` `` is this
+    /// pass's and not the purge's.
+    /// Test: This test.
+    #[test]
+    fn twin_repoints_leaves_the_purge_its_stopwords() {
+        let active = vec![
+            triple("(\"the", "is-a", "thing", Some(AUTO_PROVENANCE)),
+            triple("`redb`", "is-a", "database", Some(AUTO_PROVENANCE)),
+        ];
+        let merged: Vec<String> = twin_repoints(&active)
+            .iter()
+            .map(|r| r.old.subject.clone())
+            .collect();
+        assert_eq!(merged, vec!["`redb`".to_string()]);
+        assert_eq!(
+            stale_subject_candidates(&active),
+            vec!["(\"the".to_string()],
+            "the two passes must partition the punctuated subjects, not overlap"
+        );
+    }
+
+    /// Why: the count drives the command's non-zero exit.
+    /// What: per-re-point failures count once each; a palace-level error counts
+    /// once only when nothing per-re-point failed behind it.
+    /// Test: This test.
+    #[test]
+    fn merge_summary_counts_each_failure_once() {
+        let mut s = PalaceMergeSummary {
+            palace_id: "a".to_string(),
+            selected: vec!["x".to_string(), "y".to_string()],
+            merged: vec!["x".to_string()],
+            failed: vec![("y".to_string(), "store is read-only".to_string())],
+            error: Some("1 of 2 re-point(s) failed".to_string()),
+        };
+        assert_eq!(s.failure_count(), 1, "the error merely summarises the one");
+        s.failed.clear();
+        assert_eq!(s.failure_count(), 1, "a palace-level error is one failure");
+        s.error = None;
+        assert_eq!(s.failure_count(), 0);
+    }
+
+    /// Seed a palace in a tempdir and return its `AppState`.
+    async fn palace_fixture(data_root: std::path::PathBuf) -> Result<AppState> {
+        trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock();
+        // Issue #88: bypass palace-slug enforcement for test palaces.
+        // SAFETY: idempotent constant write "1"; safe across test threads.
+        unsafe {
+            std::env::set_var("TRUSTY_SKIP_PALACE_ENFORCEMENT", "1");
+        }
+        let state = AppState::new(data_root);
+        state.set_ready();
+        let _ = crate::tools::dispatch_tool(&state, "palace_create", json!({"name": "a"})).await?;
+        Ok(state)
+    }
+
+    /// Every active object at `subject`, sorted.
+    async fn objects_of(kg: &KnowledgeGraph, subject: &str) -> Result<Vec<String>> {
+        let mut got: Vec<String> = kg
+            .query_active(subject)
+            .await?
+            .into_iter()
+            .map(|t| t.object)
+            .collect();
+        got.sort();
+        Ok(got)
+    }
+
+    /// Why: the closure bar #5401 sets. A pass that deletes the punctuated node
+    /// satisfies "there is only one node" while silently dropping every fact
+    /// that node participated in, and one that re-points only the subject side
+    /// leaves the object-position twin behind. This asserts the merged node
+    /// holds BOTH its own pre-existing triples and the re-pointed ones, on both
+    /// sides of the edge.
+    /// What: seeds `redb --is-a--> database` (already clean), `` `redb`
+    /// --uses--> mmap `` (subject-position twin) and `trusty-memory --uses-->
+    /// ``redb``` (object-position twin) plus a manual `` `sled` `` triple, then
+    /// applies the merge and reads every position back.
+    /// Test: This test.
+    #[tokio::test]
+    async fn merge_repoints_both_positions_and_keeps_the_cleaned_nodes_triples() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let state = palace_fixture(tmp.path().to_path_buf()).await?;
+        let handle = state
+            .registry
+            .open_palace(&state.data_root, &PalaceId::new("a"))?;
+        for t in [
+            triple("redb", "is-a", "database", Some(AUTO_PROVENANCE)),
+            triple("`redb`", "uses", "mmap", Some(AUTO_PROVENANCE)),
+            triple("trusty-memory", "uses", "`redb`", Some(AUTO_PROVENANCE)),
+            triple("trusty-memory", "uses", "tokio", Some(AUTO_PROVENANCE)),
+            triple("`sled`", "is-a", "store", Some("kg_assert")),
+        ] {
+            handle.kg.assert(t).await?;
+        }
+
+        let applied = merge_palaces(&state, Some("a"), true).await?;
+        assert_eq!(applied.len(), 1);
+        assert!(
+            applied[0].failed.is_empty(),
+            "no re-point should have failed"
+        );
+        assert!(applied[0].error.is_none());
+        assert_eq!(applied[0].merged.len(), 2, "two twins must have moved");
+
+        assert_eq!(
+            objects_of(&handle.kg, "redb").await?,
+            vec!["database".to_string(), "mmap".to_string()],
+            "the merged node must keep its OWN pre-existing triple and gain the re-pointed one"
+        );
+        assert!(
+            handle.kg.query_active("`redb`").await?.is_empty(),
+            "the punctuated node must be gone from the subject position"
+        );
+        assert_eq!(
+            objects_of(&handle.kg, "trusty-memory").await?,
+            vec!["redb".to_string(), "tokio".to_string()],
+            "the object position must move onto the cleaned node without \
+             taking its sibling objects at the same predicate down"
+        );
+        assert_eq!(
+            objects_of(&handle.kg, "`sled`").await?,
+            vec!["store".to_string()],
+            "a manually asserted punctuated triple must be untouched"
+        );
+
+        // Re-running must be a no-op rather than a second round of writes.
+        let again = merge_palaces(&state, Some("a"), true).await?;
+        assert!(
+            again[0].selected.is_empty(),
+            "the merge must be idempotent, got {:?}",
+            again[0].selected
+        );
+        Ok(())
+    }
+
+    /// Why: the preview an operator reaches for first must not be the thing
+    /// that rewrites their graph.
+    /// What: a report-only run lists the twin and leaves both nodes in place.
+    /// Test: This test.
+    #[tokio::test]
+    async fn merge_dry_run_writes_nothing() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let state = palace_fixture(tmp.path().to_path_buf()).await?;
+        let handle = state
+            .registry
+            .open_palace(&state.data_root, &PalaceId::new("a"))?;
+        handle
+            .kg
+            .assert(triple("`redb`", "uses", "mmap", Some(AUTO_PROVENANCE)))
+            .await?;
+
+        let dry = merge_palaces(&state, Some("a"), false).await?;
+        assert_eq!(dry[0].selected.len(), 1, "the twin must be reported");
+        assert!(dry[0].merged.is_empty(), "a dry run repoints nothing");
+        assert!(
+            !handle.kg.query_active("`redb`").await?.is_empty(),
+            "a dry run must leave the punctuated node standing"
+        );
+        assert!(
+            handle.kg.query_active("redb").await?.is_empty(),
+            "a dry run must not create the cleaned node either"
+        );
+        assert_eq!(report_merge(&state, Some("a"), false).await?, 0);
+        Ok(())
+    }
+}

--- a/crates/trusty-memory/src/commands/mod.rs
+++ b/crates/trusty-memory/src/commands/mod.rs
@@ -19,6 +19,8 @@ pub mod daemon_lock;
 pub mod doctor;
 pub mod inbox_check;
 pub mod kg_rebuild;
+// #5401: fold pre-#4678 punctuated entity nodes onto their cleaned twins.
+pub mod kg_twin_merge;
 pub mod kuzu_migrate;
 pub mod link;
 pub mod migrate;

--- a/crates/trusty-memory/src/kg_extract.rs
+++ b/crates/trusty-memory/src/kg_extract.rs
@@ -661,6 +661,15 @@ pub fn is_stop_token(tok: &str) -> bool {
 /// what keeps this disjoint from `--purge-stale-subjects`: a punctuated
 /// stopword such as `("the` is garbage the purge deletes, never a twin some
 /// real node should absorb.
+///
+/// The merge therefore inherits [`clean_token`]'s normalisation whole,
+/// dotfiles included: `.env` names `env`, `--verbose` names `verbose`, and the
+/// leading punctuation that IS the identity is collapsed with the decorative
+/// kind. That is the point of reusing `clean_token` — the extractor already
+/// emits `env` for content saying `.env`, so the merge aligns stored nodes
+/// with current extraction instead of preserving a spelling nothing produces
+/// any more. `close_active_row` keeps the punctuated row under its `hist:`
+/// key, so the original spelling is not lost.
 /// Test: `canonical_entity_names_the_cleaned_twin`.
 pub fn canonical_entity(term: &str) -> Option<&str> {
     // #5401: the merge pass and the extractor must agree on one spelling.
@@ -1419,7 +1428,10 @@ mod tests {
     /// under, and its three answers are the pass's whole selection rule.
     /// What: a punctuated real entity names its cleaned twin; an already-clean
     /// term and a punctuated stopword both name nothing — the second because it
-    /// is `--purge-stale-subjects`'s to delete, not this pass's to re-point.
+    /// is `--purge-stale-subjects`'s to delete, not this pass's to re-point. A
+    /// name whose leading punctuation IS the identity — `.env`, `--verbose` —
+    /// names the same twin as decorative punctuation does, because the merge
+    /// inherits [`clean_token`] rather than re-deciding.
     /// Test: This test.
     #[test]
     fn canonical_entity_names_the_cleaned_twin() {
@@ -1442,6 +1454,17 @@ mod tests {
         );
         assert_eq!(canonical_entity("`it`"), None);
         assert_eq!(canonical_entity("---"), None);
+
+        // The dotfile class: the leading punctuation is part of the name, and
+        // it is collapsed anyway. Deliberate — today's extractor already emits
+        // `env` for a drawer that says `.env`, so the merge aligns the stored
+        // node with what extraction now produces rather than inventing a
+        // second normalisation that could drift from it.
+        assert_eq!(canonical_entity(".env"), Some("env"));
+        assert_eq!(canonical_entity(".git"), Some("git"));
+        assert_eq!(canonical_entity(".gitignore"), Some("gitignore"));
+        assert_eq!(canonical_entity("_private"), Some("private"));
+        assert_eq!(canonical_entity("--verbose"), Some("verbose"));
     }
 
     /// Why: the allowlist is the length floor's escape hatch; if an entry stops

--- a/crates/trusty-memory/src/kg_extract.rs
+++ b/crates/trusty-memory/src/kg_extract.rs
@@ -647,6 +647,30 @@ pub fn is_stop_token(tok: &str) -> bool {
     norm.chars().count() < MIN_ENTITY_TOKEN_LEN && !SHORT_ENTITY_ALLOWLIST.contains(&norm.as_str())
 }
 
+/// The cleaned spelling a stored entity term must be merged onto, or `None`
+/// when the term is already canonical.
+///
+/// Why: #4678's edge trim fixed extraction going forward and split every
+/// pre-fix entity in two — a palace holds both `` `redb` `` and `redb`, and
+/// each `kg-rebuild` over the same drawer content widens the gap (#5401).
+/// Deciding the canonical spelling next to the filter that produced the split
+/// is what stops the merge pass from inventing a second normalisation that can
+/// drift away from the extractor's.
+/// What: `Some(cleaned)` when [`clean_token`] changes `term`; `None` when it
+/// does not, or when [`is_stop_token`] rejects the term. That second arm is
+/// what keeps this disjoint from `--purge-stale-subjects`: a punctuated
+/// stopword such as `("the` is garbage the purge deletes, never a twin some
+/// real node should absorb.
+/// Test: `canonical_entity_names_the_cleaned_twin`.
+pub fn canonical_entity(term: &str) -> Option<&str> {
+    // #5401: the merge pass and the extractor must agree on one spelling.
+    if is_stop_token(term) {
+        return None;
+    }
+    let cleaned = clean_token(term);
+    (cleaned != term).then_some(cleaned)
+}
+
 /// Apply the pattern table to a single content blob.
 ///
 /// Why: Keeps the matching loop out of `extract_triples` so the dispatcher
@@ -1389,6 +1413,35 @@ mod tests {
             !is_stop_token("no-op"),
             "interior hyphen must survive trimming"
         );
+    }
+
+    /// Why: #5401's merge asks this function which node a stored term belongs
+    /// under, and its three answers are the pass's whole selection rule.
+    /// What: a punctuated real entity names its cleaned twin; an already-clean
+    /// term and a punctuated stopword both name nothing — the second because it
+    /// is `--purge-stale-subjects`'s to delete, not this pass's to re-point.
+    /// Test: This test.
+    #[test]
+    fn canonical_entity_names_the_cleaned_twin() {
+        assert_eq!(canonical_entity("`redb`"), Some("redb"));
+        assert_eq!(canonical_entity("(sled)"), Some("sled"));
+        assert_eq!(canonical_entity("*trusty-memory*"), Some("trusty-memory"));
+        assert_eq!(
+            canonical_entity("src/main.rs,"),
+            Some("src/main.rs"),
+            "only edge punctuation moves; the interior path must survive"
+        );
+
+        assert_eq!(canonical_entity("redb"), None, "a clean term is canonical");
+        assert_eq!(canonical_entity("no-op"), None);
+
+        assert_eq!(
+            canonical_entity("(\"the"),
+            None,
+            "a punctuated stopword belongs to the purge, not the merge"
+        );
+        assert_eq!(canonical_entity("`it`"), None);
+        assert_eq!(canonical_entity("---"), None);
     }
 
     /// Why: the allowlist is the length floor's escape hatch; if an entry stops

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -333,7 +333,14 @@ enum Command {
     /// an aggregate total. Failures on individual asserts are logged but
     /// never abort the run.
     /// Test: `commands::kg_rebuild::tests::kg_rebuild_processes_all_drawers`.
-    #[command(name = "kg-rebuild")]
+    // #5401: --dry-run previews whichever maintenance pass was asked for, so it
+    // requires the GROUP rather than one named flag.
+    #[command(
+        name = "kg-rebuild",
+        group = clap::ArgGroup::new("kg_maintenance")
+            .args(["purge_stale_subjects", "merge_punctuated_twins"])
+            .multiple(true)
+    )]
     KgRebuild {
         /// Restrict the rebuild to a single palace id. When omitted, every
         /// palace under the data root is processed.
@@ -350,9 +357,20 @@ enum Command {
         #[arg(long = "purge-stale-subjects")]
         purge_stale_subjects: bool,
 
-        /// Report what --purge-stale-subjects would delete and write nothing
+        /// Also MERGE each auto-extracted triple off a punctuated entity node
+        /// (`` `redb` ``) onto its cleaned twin (`redb`), in both the subject
+        /// and the object position.
+        ///
+        /// Destructive and off by default. #4678's trim fixed extraction going
+        /// forward and left every pre-fix entity split across two nodes; a
+        /// plain rebuild only widens the split. Each move is printed. Pair with
+        /// --dry-run to see the list first.
+        #[arg(long = "merge-punctuated-twins")]
+        merge_punctuated_twins: bool,
+
+        /// Report what the selected maintenance pass would do and write nothing
         /// at all — the re-assert pass is skipped too.
-        #[arg(long = "dry-run", requires = "purge_stale_subjects")]
+        #[arg(long = "dry-run", requires = "kg_maintenance")]
         dry_run: bool,
     },
 
@@ -708,12 +726,14 @@ async fn main() -> Result<()> {
         Command::KgRebuild {
             palace,
             purge_stale_subjects,
+            merge_punctuated_twins,
             dry_run,
         } => {
             trusty_memory::commands::kg_rebuild::handle_kg_rebuild_with(
                 trusty_memory::commands::kg_rebuild::KgRebuildOptions {
                     palace,
                     purge_stale_subjects,
+                    merge_punctuated_twins,
                     dry_run,
                 },
             )

--- a/crates/trusty-memory/tests/kg_rebuild_cli.rs
+++ b/crates/trusty-memory/tests/kg_rebuild_cli.rs
@@ -71,8 +71,8 @@ fn kg_rebuild_help_advertises_purge_flags() {
 /// Why: `--dry-run` on its own would read as "rebuild without writing", which
 /// this command does not offer. Letting it parse would hand an operator a
 /// silent full rebuild when they asked for a preview.
-/// What: `--dry-run` without `--purge-stale-subjects` is a clap parse error
-/// (exit code 2).
+/// What: `--dry-run` without a maintenance flag (`--purge-stale-subjects` or
+/// #5401's `--merge-punctuated-twins`) is a clap parse error (exit code 2).
 /// Test: This test.
 #[test]
 fn kg_rebuild_dry_run_requires_the_purge_flag() {
@@ -120,6 +120,49 @@ fn kg_rebuild_purge_dry_run_runs_clean() {
     assert!(
         stdout.contains("DRY RUN"),
         "purge dry run must announce itself, got:\n{stdout}"
+    );
+}
+
+/// Why: #5401's merge is the second destructive pass on this subcommand, and
+/// `--dry-run` now gates on the GROUP rather than on the purge flag alone — a
+/// preview of the merge that clap refused would send an operator straight to
+/// the applying form.
+/// What: `--help` advertises `--merge-punctuated-twins`, and
+/// `--merge-punctuated-twins --dry-run` against an empty data dir exits 0.
+/// Test: This test.
+#[test]
+fn kg_rebuild_merge_dry_run_runs_clean() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin = locate_binary();
+    let help = Command::new(&bin)
+        .arg("kg-rebuild")
+        .arg("--help")
+        .output()
+        .expect("spawn trusty-memory kg-rebuild --help");
+    let help_out = String::from_utf8_lossy(&help.stdout);
+    assert!(
+        help_out.contains("--merge-punctuated-twins"),
+        "kg-rebuild --help must advertise --merge-punctuated-twins, got:\n{help_out}"
+    );
+
+    let out = Command::new(&bin)
+        .arg("kg-rebuild")
+        .arg("--merge-punctuated-twins")
+        .arg("--dry-run")
+        .env("TRUSTY_DATA_DIR_OVERRIDE", tmp.path())
+        .env("RUST_LOG", "warn")
+        .output()
+        .expect("spawn trusty-memory kg-rebuild merge dry run");
+    assert!(
+        out.status.success(),
+        "merge dry run must exit 0; status {:?}, stderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("DRY RUN"),
+        "merge dry run must announce itself, got:\n{stdout}"
     );
 }
 


### PR DESCRIPTION
## Outcome

Closes #5401

Blocked until PR #5412 landed the `retract_triple` primitive it depends on.

## What changed / out of scope

Punctuated entity nodes (e.g. `` `redb` ``) accumulate alongside their cleaned twins (`redb`). This adds a `kg-rebuild --merge-punctuated-twins` pass that identifies twins via a new `canonical_entity(term)`, re-points triples in BOTH subject and object position onto the cleaned node, and retracts the twin's originals.

The pass is opt-in, mirroring #4678's `--purge-stale-subjects`; it does not fire during a plain rebuild. A punctuated node with no existing cleaned twin is still merged — that is a rename, and restricting to "both nodes already exist" would leave singletons that become twins on the next rebuild, which is the growth the issue describes.

Two properties that shape the implementation, worth stating: it asserts before retracting, so a crash between the two leaves the twin standing and the next run merges it again, where the reverse order would lose the fact. And `is_stop_token` partitions this pass from the purge — `canonical_entity` returns `None` for a punctuated stopword, so `("the` belongs to the purge and `` `redb` `` to the merge, and no term is ever both.

New file `commands/kg_twin_merge.rs`; also touches `kg_extract.rs`, `commands/kg_rebuild.rs`, `main.rs`, `tests/kg_rebuild_cli.rs`. `--dry-run` now takes a clap `ArgGroup` so it previews either pass.

## Risk

Mutates persisted KG state, opt-in only. `KgRebuildOptions` gains a public field — semver-breaking, covered by trusty-memory's unpublished 0.22.0 (crates.io tops out at 0.21.2).

## Test evidence — rung 5

Red-to-green proven by three separate neuterings of the implementation, each against the same command that is green on the committed tree:

- no merge pass (the pre-fix state): `two twins must have moved — left: 0, right: 2`
- delete-only "merge", assert dropped: `the merged node must keep its OWN pre-existing triple and gain the re-pointed one — left: ["database"], right: ["database", "mmap"]`
- pair-wide `retract` instead of #5396's `retract_triple`: `left: [], right: ["redb", "tokio"]`

The third is the direct evidence for the #5396 dependency — a pair-wide retract silently drops `trusty-memory --uses--> tokio` while re-pointing the punctuated object beside it.

Gates, all exit 0: `fmt --check`; `clippy -p trusty-memory --all-targets -- -D warnings`; `test -p trusty-memory` (716 lib passed, 27 binaries, 0 failures); `test -p trusty-common --features memory-core` (994 passed); `check --workspace`; line-cap (0 violations), SLD (0 errors), changelog fragment valid, test-pointers (23748 citations, 0 dangling), and `check-pr-version-bump.sh` reporting `[ OK ] trusty-memory 0.22.0 — src changed, version not yet published`.

## Baseline failures

None.

## Docs/changelog

Fragment at `crates/trusty-memory/changelog.d/5401-punctuated-twin-merge.md`. The fragment is in trusty-memory, not trusty-common — the change is trusty-memory-only; the issue's `trusty-common` label reflected a pre-#5396 suspicion that the storage primitive was missing.

## Review disposition

No critic round yet; one is being dispatched. The test-pointer lint caught a real defect pre-push (a doc citing three test names after they were folded into one), fixed and amended.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
