### PR TITLE
fix(trusty-common): surface KG count-read failures instead of reporting zero

### DIFF
--- a/crates/trusty-common/changelog.d/5384-count-active-triples-fallible.md
+++ b/crates/trusty-common/changelog.d/5384-count-active-triples-fallible.md
@@ -1,0 +1,6 @@
+Changed
+
+- `KgStoreRedb::count_active_triples` and `KnowledgeGraph::count_active_triples` return `Result` instead of failing open to `0` ([#5384](https://github.com/bobmatnyc/trusty-tools/issues/5384))
+  - `begin_read`, `open_table`, `iter`, and a per-row read each logged a warning and returned `0`, so a caller could not tell an empty graph from a storage read that never completed. `open_table` cannot mean "not written yet" here — `open_with_intent` creates every table on open — so the failure is always real.
+  - A dropped-row read no longer `continue`s past the error and undercounts.
+  - Breaking for callers that consumed the bare `u64` / `usize`; `trusty-memory`'s call sites are updated in the same change.

--- a/crates/trusty-common/src/memory_core/store/kg/ops.rs
+++ b/crates/trusty-common/src/memory_core/store/kg/ops.rs
@@ -68,14 +68,16 @@ impl KnowledgeGraph {
 
     /// Count currently active triples.
     ///
-    /// Why: Dashboard tally of live facts. Returns 0 on internal error so it
-    /// stays diagnostic-grade (matches prior behavior).
+    /// Why: Dashboard tally of live facts. Fallible since #5384 — swallowing
+    /// the store's read error here would hand every caller a `0` that reads
+    /// as "the graph is empty".
     /// What: Delegates to `KgStoreRedb::count_active_triples` and clamps the
-    /// u64 to `usize` for backward compatibility with existing callers.
-    /// Test: `count_active_triples_returns_live_only`.
-    pub fn count_active_triples(&self) -> usize {
-        let n = self.store.count_active_triples();
-        usize::try_from(n).unwrap_or(usize::MAX)
+    /// u64 to `usize`, which is what the existing callers consume.
+    /// Test: `count_active_triples_returns_live_only`,
+    /// `count_active_triples_surfaces_read_failure`.
+    pub fn count_active_triples(&self) -> Result<usize> {
+        let n = self.store.count_active_triples()?;
+        Ok(usize::try_from(n).unwrap_or(usize::MAX))
     }
 
     /// Number of distinct entities (nodes) in the in-memory adjacency.

--- a/crates/trusty-common/src/memory_core/store/kg/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/kg/tests.rs
@@ -291,7 +291,7 @@ async fn upsert_drawer_replaces_existing_row() {
 async fn count_active_triples_returns_live_only() {
     let dir = tempdir().unwrap();
     let kg = KnowledgeGraph::open(&dir.path().join("kg.db")).unwrap();
-    assert_eq!(kg.count_active_triples(), 0);
+    assert_eq!(kg.count_active_triples().unwrap(), 0);
 
     kg.assert(Triple {
         subject: "alice".into(),
@@ -304,7 +304,7 @@ async fn count_active_triples_returns_live_only() {
     })
     .await
     .unwrap();
-    assert_eq!(kg.count_active_triples(), 1);
+    assert_eq!(kg.count_active_triples().unwrap(), 1);
 
     // Superseding triple closes the prior interval — count stays at 1.
     // #4810: only because `is_alias_for` is a functional predicate.
@@ -319,7 +319,7 @@ async fn count_active_triples_returns_live_only() {
     })
     .await
     .unwrap();
-    assert_eq!(kg.count_active_triples(), 1);
+    assert_eq!(kg.count_active_triples().unwrap(), 1);
 }
 
 /// Why: The Dreamer cycle calls `checkpoint()` to keep the WAL bounded;

--- a/crates/trusty-common/src/memory_core/store/kg_redb/read_ops.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/read_ops.rs
@@ -177,42 +177,35 @@ impl KgStoreRedb {
     /// Count currently active triples (sum of ACTIVE_SUBJECT_COUNTS).
     ///
     /// Why: Dashboard tally of live facts. Maintained incrementally so it is
-    /// O(distinct subjects) rather than O(history).
-    /// What: Iterate ACTIVE_SUBJECT_COUNTS, sum values.
-    /// Test: `count_active_triples_returns_live_only`.
-    pub fn count_active_triples(&self) -> u64 {
-        let rtx = match self.db().begin_read() {
-            Ok(t) => t,
-            Err(e) => {
-                tracing::warn!("count_active_triples: begin_read failed: {e:#}");
-                return 0;
-            }
-        };
-        let counts = match rtx.open_table(ACTIVE_SUBJECT_COUNTS) {
-            Ok(t) => t,
-            Err(e) => {
-                tracing::warn!("count_active_triples: open table failed: {e:#}");
-                return 0;
-            }
-        };
+    /// O(distinct subjects) rather than O(history). Every read step used to
+    /// log a warning and return `0` (#5384); a caller then could not tell an
+    /// empty graph from a storage read it never completed, and `kg_query`
+    /// turned that `0` into `graph_state: "graph_empty"` — the false claim
+    /// #4775 exists to prevent. The count is now fallible so each caller
+    /// decides what a failed read means for its own payload.
+    /// What: Opens a read txn, iterates ACTIVE_SUBJECT_COUNTS, and sums the
+    /// values. `begin_read`, `open_table`, `iter`, and a per-row read all
+    /// propagate — `open_table` cannot mean "not written yet" because
+    /// `open_with_intent` creates every table on open.
+    /// Test: `count_active_triples_returns_live_only`,
+    /// `count_active_triples_surfaces_read_failure`.
+    pub fn count_active_triples(&self) -> Result<u64> {
+        // #5384: propagate instead of returning 0 — a failed read must not be
+        // reportable as an empty graph.
+        let rtx = self
+            .db()
+            .begin_read()
+            .context("begin count_active_triples txn")?;
+        let counts = rtx
+            .open_table(ACTIVE_SUBJECT_COUNTS)
+            .context("open active_subject_counts table for count_active_triples")?;
         let mut total: u64 = 0;
-        let iter = match counts.iter() {
-            Ok(i) => i,
-            Err(e) => {
-                tracing::warn!("count_active_triples: iter failed: {e:#}");
-                return 0;
-            }
-        };
+        let iter = counts.iter().context("iter active_subject_counts")?;
         for entry in iter {
-            match entry {
-                Ok((_, v)) => total = total.saturating_add(decode_u64(v.value())),
-                Err(e) => {
-                    tracing::warn!("count_active_triples: row read failed: {e:#}");
-                    continue;
-                }
-            }
+            let (_, v) = entry.context("read active_subject_counts row")?;
+            total = total.saturating_add(decode_u64(v.value()));
         }
-        total
+        Ok(total)
     }
 
     /// No-op checkpoint hook.

--- a/crates/trusty-common/src/memory_core/store/kg_redb/tests.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/tests.rs
@@ -125,20 +125,51 @@ mod tests {
     #[test]
     fn count_active_triples_returns_live_only() {
         let (_d, kg) = open_kg();
-        assert_eq!(kg.count_active_triples(), 0);
+        assert_eq!(kg.count_active_triples().unwrap(), 0);
 
         kg.assert(&t("alice", "is_alias_for", "Acme")).unwrap();
-        assert_eq!(kg.count_active_triples(), 1);
+        assert_eq!(kg.count_active_triples().unwrap(), 1);
 
         // #4810: functional predicate — the supersede keeps the count at 1.
         kg.assert(&t("alice", "is_alias_for", "Beta")).unwrap();
-        assert_eq!(kg.count_active_triples(), 1);
+        assert_eq!(kg.count_active_triples().unwrap(), 1);
 
         kg.assert(&t("bob", "is_alias_for", "Gamma")).unwrap();
-        assert_eq!(kg.count_active_triples(), 2);
+        assert_eq!(kg.count_active_triples().unwrap(), 2);
 
         kg.retract("alice", "is_alias_for").unwrap();
-        assert_eq!(kg.count_active_triples(), 1);
+        assert_eq!(kg.count_active_triples().unwrap(), 1);
+    }
+
+    /// Why (#5384): a failed read used to come back as `0`, and `kg_query`
+    /// turns a whole-graph `0` into `graph_state: "graph_empty"` — so a broken
+    /// storage read claimed the graph held nothing while three live triples
+    /// sat in it. Dropping ACTIVE_SUBJECT_COUNTS is the cheapest way to make
+    /// `open_table` fail for real; before the fix this assertion read
+    /// `assert_ne!(kg.count_active_triples(), 0)` and failed with `0 == 0`.
+    #[test]
+    fn count_active_triples_surfaces_read_failure() {
+        let (_d, kg) = open_kg();
+        kg.assert(&t("alice", "is_alias_for", "Acme")).unwrap();
+        kg.assert(&t("bob", "is_alias_for", "Beta")).unwrap();
+        kg.assert(&t("carol", "is_alias_for", "Gamma")).unwrap();
+        assert_eq!(kg.count_active_triples().unwrap(), 3);
+
+        let wtx = kg.db().begin_write().unwrap();
+        assert!(
+            wtx.delete_table(crate::memory_core::store::kg_store::ACTIVE_SUBJECT_COUNTS)
+                .unwrap(),
+            "the count table must have existed to be dropped"
+        );
+        wtx.commit().unwrap();
+
+        let err = kg
+            .count_active_triples()
+            .expect_err("a failed count read must not be reported as a count");
+        assert!(
+            format!("{err:#}").contains("active_subject_counts"),
+            "error names the table it could not read: {err:#}"
+        );
     }
 
     #[test]
@@ -876,7 +907,7 @@ mod tests {
         let mut objects: Vec<_> = active.iter().map(|x| x.object.as_str()).collect();
         objects.sort_unstable();
         assert_eq!(objects, vec!["drawer:a", "drawer:b", "drawer:c"]);
-        assert_eq!(kg.count_active_triples(), 3);
+        assert_eq!(kg.count_active_triples().unwrap(), 3);
 
         // Nothing was demoted to history — no object was superseded.
         let all = kg.dump_all_triples().unwrap();
@@ -900,7 +931,7 @@ mod tests {
         let active = kg.query_active("tga").unwrap();
         assert_eq!(active.len(), 1, "functional predicate holds one object");
         assert_eq!(active[0].object, "trusty-git-analytics-v2");
-        assert_eq!(kg.count_active_triples(), 1);
+        assert_eq!(kg.count_active_triples().unwrap(), 1);
 
         let all = kg.dump_all_triples().unwrap();
         assert_eq!(all.len(), 2, "the superseded object is kept as history");
@@ -918,7 +949,7 @@ mod tests {
 
         let active = kg.query_active("room:General").unwrap();
         assert_eq!(active.len(), 1);
-        assert_eq!(kg.count_active_triples(), 1);
+        assert_eq!(kg.count_active_triples().unwrap(), 1);
         assert_eq!(kg.dump_all_triples().unwrap().len(), 2, "one history row");
     }
 
@@ -934,7 +965,7 @@ mod tests {
         }
         assert_eq!(kg.retract("room:General", "contains").unwrap(), 3);
         assert!(kg.query_active("room:General").unwrap().is_empty());
-        assert_eq!(kg.count_active_triples(), 0);
+        assert_eq!(kg.count_active_triples().unwrap(), 0);
         // Second retract is a no-op.
         assert_eq!(kg.retract("room:General", "contains").unwrap(), 0);
     }
@@ -968,7 +999,7 @@ mod tests {
             vec!["drawer:a".to_string(), "drawer:c".to_string()],
             "the good siblings must survive"
         );
-        assert_eq!(kg.count_active_triples(), 2);
+        assert_eq!(kg.count_active_triples().unwrap(), 2);
 
         // The retracted object is closed, not erased.
         let closed: Vec<_> = kg
@@ -1009,7 +1040,7 @@ mod tests {
             "unknown predicate"
         );
         assert_eq!(kg.query_active("room:General").unwrap().len(), 1);
-        assert_eq!(kg.count_active_triples(), 1);
+        assert_eq!(kg.count_active_triples().unwrap(), 1);
     }
 
     /// Why (#5396): `retract_triple` addresses one row by its full key, so a
@@ -1034,7 +1065,7 @@ mod tests {
             1
         );
         assert!(kg.query_active("tga").unwrap().is_empty());
-        assert_eq!(kg.count_active_triples(), 0);
+        assert_eq!(kg.count_active_triples().unwrap(), 0);
     }
 
     /// Why (#5396): the last object at a pair is the boundary case for the
@@ -1052,7 +1083,7 @@ mod tests {
             1
         );
         assert!(kg.query_active("room:General").unwrap().is_empty());
-        assert_eq!(kg.count_active_triples(), 0);
+        assert_eq!(kg.count_active_triples().unwrap(), 0);
 
         assert_eq!(
             kg.retract_triple("room:General", "contains", "drawer:a")
@@ -1060,7 +1091,7 @@ mod tests {
             0,
             "second call is a no-op"
         );
-        assert_eq!(kg.count_active_triples(), 0);
+        assert_eq!(kg.count_active_triples().unwrap(), 0);
     }
 
     /// Why (#4810): `delete_by_subject` collects pairs, and one pair can now
@@ -1075,7 +1106,7 @@ mod tests {
         kg.assert(&t("drawer:x", "is_alias_for", "y")).unwrap();
         assert_eq!(kg.delete_by_subject("drawer:x").unwrap(), 4);
         assert!(kg.query_active("drawer:x").unwrap().is_empty());
-        assert_eq!(kg.count_active_triples(), 0);
+        assert_eq!(kg.count_active_triples().unwrap(), 0);
     }
 
     /// Why (#4810): the write path reads the `(subject, predicate)` range and
@@ -1107,7 +1138,7 @@ mod tests {
 
         let active = primary.query_active("room:General").unwrap();
         assert_eq!(active.len(), 8, "no concurrent assert overwrote another");
-        assert_eq!(primary.count_active_triples(), 8);
+        assert_eq!(primary.count_active_triples().unwrap(), 8);
     }
 
     /// Why (#5396): `retract_triple` reads the `(subject, predicate)` range,
@@ -1135,7 +1166,11 @@ mod tests {
                 .assert(&t("room:General", "contains", &format!("drawer:{i}")))
                 .unwrap();
         }
-        assert_eq!(primary.count_active_triples(), 8, "seeded eight active");
+        assert_eq!(
+            primary.count_active_triples().unwrap(),
+            8,
+            "seeded eight active"
+        );
 
         let handles: Vec<_> = (0..8)
             .map(|i| {
@@ -1162,7 +1197,7 @@ mod tests {
             "every object closed"
         );
         assert_eq!(
-            primary.count_active_triples(),
+            primary.count_active_triples().unwrap(),
             0,
             "the counter absorbed all eight decrements"
         );
@@ -1231,7 +1266,7 @@ mod tests {
             "the asserted objects survived and the retracted ones did not"
         );
         assert_eq!(
-            primary.count_active_triples(),
+            primary.count_active_triples().unwrap(),
             8,
             "the counter agrees with the rows after eight closes and eight opens"
         );

--- a/crates/trusty-common/tests/kg_triple_key_migration_tests.rs
+++ b/crates/trusty-common/tests/kg_triple_key_migration_tests.rs
@@ -107,7 +107,7 @@ async fn legacy_palace_migrates_on_open_and_accepts_multi_valued_writes() {
 
     // Hydration ran over the migrated rows, so the graph sees all three edges.
     assert_eq!(kg.edge_count(), 3);
-    assert_eq!(kg.count_active_triples(), 3);
+    assert_eq!(kg.count_active_triples().unwrap(), 3);
 
     // Multi-valued predicate: the new member joins the room.
     kg.assert(triple("room:General", "contains", "drawer:b"))

--- a/crates/trusty-memory/changelog.d/5384-kg-query-graph-state.md
+++ b/crates/trusty-memory/changelog.d/5384-kg-query-graph-state.md
@@ -1,0 +1,6 @@
+Fixed
+
+- `kg_query` no longer reports `graph_state: "graph_empty"` when the whole-graph triple count could not be read ([#5384](https://github.com/bobmatnyc/trusty-tools/issues/5384))
+  - The count failed open to `0` in `trusty-common`, and #4775's classifier reads `0` as an empty graph — so a redb read failure produced the exact false claim #4775 exists to prevent. `kg_query` now returns the error.
+  - `GET /api/v1/palaces/{id}/kg/count` answers 500 instead of `{"active": 0}`, and `kg_graph`'s `truncated` flag no longer computes against a `0` that would make every payload look complete.
+  - The status, console-metrics, and palace-info roll-ups still degrade to `0` — they have no field for "unknown", per #4637 — but do it at a single named call site (`kg_triple_count_or_zero`) that logs the palace and the error. The chat prompt prints `unknown (read failed)` rather than a `0` the model would repeat.

--- a/crates/trusty-memory/src/chat/handler.rs
+++ b/crates/trusty-memory/src/chat/handler.rs
@@ -135,7 +135,15 @@ pub(crate) async fn chat_handler(
             // Live counts from the opened handle.
             let drawer_count = handle.drawers.read().len();
             let vector_count = handle.vector_store.index_size();
-            let kg_triple_count = handle.kg.count_active_triples();
+            // #5384: the prompt claims to be an honest view of the palace, so a
+            // failed count says so rather than printing a 0 the model repeats.
+            let kg_triple_count = match handle.kg.count_active_triples() {
+                Ok(n) => n.to_string(),
+                Err(e) => {
+                    tracing::warn!(palace = %palace_id, "kg_triple_count unavailable: {e:#}");
+                    "unknown (read failed)".to_string()
+                }
+            };
 
             // Prefer the on-disk palace.json name/description; fall back to id.
             let (name, description) = match &selected_palace_meta {

--- a/crates/trusty-memory/src/console_metrics.rs
+++ b/crates/trusty-memory/src/console_metrics.rs
@@ -180,7 +180,9 @@ fn collect_palace_stats(
             Some(handle) => {
                 let drawer_count = handle.drawers.read().len();
                 let vector_count = handle.vector_store.index_size();
-                let kg_triple_count = handle.kg.count_active_triples();
+                // #5384: same diagnostic degrade the status roll-up uses — the
+                // report has no field for "count unavailable".
+                let kg_triple_count = crate::service::helpers::kg_triple_count_or_zero(&handle);
 
                 total_drawers += drawer_count;
                 total_vectors += vector_count;
@@ -217,7 +219,7 @@ fn collect_palace_stats(
         if let Some(handle) = registry.peek(&info.id) {
             total_drawers += handle.drawers.read().len();
             total_vectors += handle.vector_store.index_size();
-            total_kg_triples += handle.kg.count_active_triples();
+            total_kg_triples += crate::service::helpers::kg_triple_count_or_zero(&handle);
             cached_palace_count += 1;
         }
     }

--- a/crates/trusty-memory/src/service/core_kg.rs
+++ b/crates/trusty-memory/src/service/core_kg.rs
@@ -158,9 +158,15 @@ impl MemoryService {
     }
 
     /// Return the count of currently-active triples.
+    ///
+    /// #5384: a failed count read is a 500, not `{"active": 0}` — the badge
+    /// this feeds cannot tell those apart.
     pub async fn kg_count(&self, id: &str) -> ServiceResult<usize> {
         let handle = self.open_handle(id)?;
-        Ok(handle.kg.count_active_triples())
+        handle
+            .kg
+            .count_active_triples()
+            .map_err(|e| ServiceError::internal(format!("kg count_active_triples: {e:#}")))
     }
 
     /// Build the per-palace visual graph payload.
@@ -202,7 +208,13 @@ impl MemoryService {
             .map_err(|e| ServiceError::internal(format!("kg list_active: {e:#}")))?;
         // #4670: compare against the true active count, not the cap, so a
         // palace sitting exactly on the cap is not falsely flagged.
-        let active_triple_count = handle.kg.count_active_triples() as u64;
+        // #5384: a failed read would come back as 0 and make `truncated` false
+        // for every payload, which is the flag's exact failure mode.
+        let active_triple_count = handle
+            .kg
+            .count_active_triples()
+            .map_err(|e| ServiceError::internal(format!("kg count_active_triples: {e:#}")))?
+            as u64;
         let returned_triple_count = triples.len() as u64;
         Ok(KgGraphPayload {
             triples,

--- a/crates/trusty-memory/src/service/core_kg.rs
+++ b/crates/trusty-memory/src/service/core_kg.rs
@@ -163,10 +163,9 @@ impl MemoryService {
     /// this feeds cannot tell those apart.
     pub async fn kg_count(&self, id: &str) -> ServiceResult<usize> {
         let handle = self.open_handle(id)?;
-        handle
-            .kg
-            .count_active_triples()
-            .map_err(|e| ServiceError::internal(format!("kg count_active_triples: {e:#}")))
+        handle.kg.count_active_triples().map_err(|e| {
+            ServiceError::internal(format!("kg count_active_triples for palace {id}: {e:#}"))
+        })
     }
 
     /// Build the per-palace visual graph payload.
@@ -210,11 +209,9 @@ impl MemoryService {
         // palace sitting exactly on the cap is not falsely flagged.
         // #5384: a failed read would come back as 0 and make `truncated` false
         // for every payload, which is the flag's exact failure mode.
-        let active_triple_count = handle
-            .kg
-            .count_active_triples()
-            .map_err(|e| ServiceError::internal(format!("kg count_active_triples: {e:#}")))?
-            as u64;
+        let active_triple_count = handle.kg.count_active_triples().map_err(|e| {
+            ServiceError::internal(format!("kg count_active_triples for palace {id}: {e:#}"))
+        })? as u64;
         let returned_triple_count = triples.len() as u64;
         Ok(KgGraphPayload {
             triples,

--- a/crates/trusty-memory/src/service/helpers.rs
+++ b/crates/trusty-memory/src/service/helpers.rs
@@ -190,7 +190,7 @@ where
         if let Some(handle) = state.registry.peek(id) {
             total_drawers = total_drawers.saturating_add(handle.drawers.read().len());
             total_vectors = total_vectors.saturating_add(handle.vector_store.index_size());
-            total_kg_triples = total_kg_triples.saturating_add(handle.kg.count_active_triples());
+            total_kg_triples = total_kg_triples.saturating_add(kg_triple_count_or_zero(&handle));
             cached_palace_count += 1;
         }
     }
@@ -318,6 +318,29 @@ fn wing_registry_count(handle: &Arc<PalaceHandle>) -> Option<usize> {
     }
 }
 
+/// Active-triple count for a diagnostic roll-up, or `0` when the read fails.
+///
+/// Why (#5384): `count_active_triples` is fallible so the callers whose answer
+/// depends on it — `kg_query`'s `graph_state`, `kg_graph`'s `truncated`, the
+/// REST count — surface a broken read instead of reporting an empty graph. The
+/// status/metrics roll-ups have no field to carry "unknown", and #4637 already
+/// fixed 0 as "unknown, never empty" for those totals, so they degrade. Keeping
+/// the degrade in one named helper is what stops it from sinking back into the
+/// store where no caller can see it.
+/// What: logs the error at warn with the palace id and returns 0.
+/// Test: `status_does_not_open_uncached_palaces`,
+/// `trusty_common::…::count_active_triples_surfaces_read_failure` (the error
+/// this converts).
+pub(crate) fn kg_triple_count_or_zero(handle: &Arc<PalaceHandle>) -> usize {
+    match handle.kg.count_active_triples() {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::warn!(palace = %handle.id, "kg_triple_count unavailable: {e:#}");
+            0
+        }
+    }
+}
+
 pub fn palace_info_from(palace: &Palace, handle: Option<&Arc<PalaceHandle>>) -> PalaceInfo {
     let (
         drawer_count,
@@ -355,7 +378,7 @@ pub fn palace_info_from(palace: &Palace, handle: Option<&Arc<PalaceHandle>>) -> 
         (
             drawers.len(),
             h.vector_store.index_size(),
-            h.kg.count_active_triples(),
+            kg_triple_count_or_zero(h),
             rooms,
             wings,
             last_write,

--- a/crates/trusty-memory/src/tools/kg_ops.rs
+++ b/crates/trusty-memory/src/tools/kg_ops.rs
@@ -246,7 +246,7 @@ pub(crate) async fn handle_kg_query(state: &AppState, args: Value) -> Result<Val
     let total_active = handle
         .kg
         .count_active_triples()
-        .context("kg.count_active_triples")?;
+        .with_context(|| format!("kg.count_active_triples for palace {palace}"))?;
     let mut response = json!({
         "subject": subject,
         "triples": payload,

--- a/crates/trusty-memory/src/tools/kg_ops.rs
+++ b/crates/trusty-memory/src/tools/kg_ops.rs
@@ -207,7 +207,9 @@ pub(crate) async fn handle_remove_prompt_fact(state: &AppState, args: Value) -> 
 /// hits and misses alike. On a miss it adds `graph_state` —
 /// `"subject_not_found"` or `"graph_empty"` — and the matching `hint`; a hit
 /// carries neither, so their absence means the subject was found. See
-/// [`crate::bootstrap::KgMiss`] for the classification.
+/// [`crate::bootstrap::KgMiss`] for the classification. A failed count read is
+/// an error (#5384), never a `graph_empty` verdict — the classifier only ever
+/// sees a total it actually read.
 /// Test: `kg_query_reports_subject_not_found_when_graph_has_other_subjects`,
 /// `kg_query_reports_graph_empty_when_graph_has_no_triples`,
 /// `dispatch_kg_assert_then_query`.
@@ -239,7 +241,12 @@ pub(crate) async fn handle_kg_query(state: &AppState, args: Value) -> Result<Val
         .collect();
     // #4775: read the whole-graph total so a miss can name which miss it is
     // instead of asserting emptiness the handler can disprove.
-    let total_active = handle.kg.count_active_triples();
+    // #5384: propagate a failed count read — classifying on a fail-open 0
+    // would report `graph_empty`, the claim #4775 exists to prevent.
+    let total_active = handle
+        .kg
+        .count_active_triples()
+        .context("kg.count_active_triples")?;
     let mut response = json!({
         "subject": subject,
         "triples": payload,

--- a/crates/trusty-memory/src/web/kg_routes.rs
+++ b/crates/trusty-memory/src/web/kg_routes.rs
@@ -184,7 +184,8 @@ pub(super) async fn kg_list_all(
 /// Why: The KG Explorer header shows a quick "N triples" badge; computing the
 /// count server-side avoids fetching every triple to count them.
 /// What: returns `{ "active": N }` where N is `count_active_triples()` on the
-/// palace's KG.
+/// palace's KG. A failed store read is a 500 (#5384): the badge cannot tell
+/// `{"active": 0}` apart from a count that was never read.
 /// Test: indirectly via the same palace counts surfaced on `/api/v1/status`.
 pub(super) async fn kg_count(
     State(state): State<AppState>,


### PR DESCRIPTION
## Outcome

Closes #5384

## What changed / out of scope

`KgStoreRedb::count_active_triples` returned `u64`, logging a warning and returning `0` from four separate arms, so a failed read was indistinguishable from an empty graph. It now returns `Result<u64>`; `KnowledgeGraph::count_active_triples` returns `Result<usize>`.

The reasoning that makes this a real fix rather than a signature change: `open_table` failing cannot mean "table not written yet", because `open_with_intent` creates every table on open — so every one of those arms was a genuine failure being swallowed. The per-row `continue` that silently undercounted is gone too.

Callers now decide what a failed read means for their own payload. `handle_kg_query`, `kg_graph_with_cap`'s `truncated` computation, and `GET /kg/count` propagate. Status, console-metrics and palace-info still degrade to 0 — they have no wire field for "unknown", and #4637 already established 0 as "unknown, never empty" there — but through one named helper, `service::helpers::kg_triple_count_or_zero`, which logs palace id and error, so the degrade is visible at the call site instead of hidden in the store. The chat prompt now prints `unknown (read failed)` rather than a `0` the model would repeat as fact.

Out of scope, deliberately: issue #5424 (redb commits before the in-memory adjacency syncs, so a poisoned lock returns `Err` on an already-committed retraction) is separately tracked and untouched.

## Risk

Cross-crate public API change in `trusty-common`, consumed by `trusty-memory`. `cargo check --workspace` passing is itself the proof no other crate consumed the old signature. No version bump owed — trusty-common is at 0.31.1, unpublished (crates.io max 0.31.0).

## Test evidence — rung 5

`count_active_triples_surfaces_read_failure` seeds three live triples then drops `ACTIVE_SUBJECT_COUNTS` in a write txn so `open_table` fails for real. Pre-fix, with the assertion in its pre-fix-compatible form, three live triples are reported as `0`:

`assertion left != right failed: a failed count read must not be reported as a count — left: 0, right: 0`

Post-fix, three tests pass and the error names `active_subject_counts`.

The committed assertion cannot be byte-identical to the red one because the signature changed — the red run proves the fail-open, the green run proves the error surfaces.

Gates, all exit 0: `fmt --check`; `clippy` on both `-p trusty-common` and `-p trusty-memory` `--all-targets -- -D warnings`; `test -p trusty-common --features memory-core` (995 passed); `test -p trusty-memory` (708 passed, 18 integration binaries); `check --workspace`; line-cap, SLD, changelog fragments all clean.

## Baseline failures

None.

## Docs/changelog

Fragments present for both trusty-common and trusty-memory.

## Review disposition

No critic round yet; one is being dispatched. One open question for the reviewer: the roll-up sites keep a 0-on-failure degrade — now logged and centralized, but still a degrade. Making them carry an explicit "unavailable" on the wire is a payload change and belongs in its own ticket.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
