### PR TITLE
chore(trusty-common): bump to 0.32.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,7 +6535,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11398,7 +11398,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ trusty-code = { path = "crates/trusty-code" }
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.5.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.31" }
+trusty-common = { path = "crates/trusty-common", version = "0.32" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.10" }

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.31.1"
+version = "0.32.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -15,7 +15,7 @@ name = "trusty-gworkspace-mcp"
 path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.31", features = ["mcp"] }
+trusty-common = { path = "../trusty-common", version = "0.32", features = ["mcp"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -83,7 +83,7 @@ path = "src/bin/mcp_bridge.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.31", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "uds-supervisor", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config"] }
+trusty-common = { path = "../trusty-common", version = "0.32", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "uds-supervisor", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside
@@ -180,7 +180,7 @@ serial_test = { workspace = true }
 # the production library (mirrors the trusty-mpm and trusty-search pattern).
 # `docgen` (#5205 follow-up): `tests/generated_docs.rs` renders the MCP tool
 # section of README.md from `tool_definitions()`.
-trusty-common = { path = "../trusty-common", version = "0.31", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
+trusty-common = { path = "../trusty-common", version = "0.32", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
 chrono = { workspace = true }
 
 [features]

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -54,7 +54,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.31", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "crate-config", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "codex-config"] }  # `config-cli` (#2405): implies `credentials`, giving both the shared `.env.local` loader `load_env_local_once` (retiring trusty-search's ad hoc dotenvy call) AND the embeddable `ConfigKeysCommand` nested under `trusty-search config keys …`  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
+trusty-common = { version = "0.32", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "crate-config", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "codex-config"] }  # `config-cli` (#2405): implies `credentials`, giving both the shared `.env.local` loader `load_env_local_once` (retiring trusty-search's ad hoc dotenvy call) AND the embeddable `ConfigKeysCommand` nested under `trusty-search config keys …`  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
 
 # ── Bundled sidecars ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue
@@ -258,7 +258,7 @@ filetime = "0.2"
 # docgen (#5205 follow-up): `tests/generated_docs.rs` renders the MCP tool
 # section of README.md / CLAUDE.md from `tool_descriptors()`. Test-facing
 # only, so the feature is enabled here rather than on the production dep.
-trusty-common = { version = "0.31", default-features = false, features = ["docgen"] }
+trusty-common = { version = "0.32", default-features = false, features = ["docgen"] }
 
 [features]
 # Default: bundle ORT static libs via trusty-embedder. Works on macOS and


### PR DESCRIPTION
## Summary

trusty-common 0.31.1 was merged to main (PR #5435) but never published — crates.io still tops out at 0.31.0, so **the real baseline for this bump is the published 0.31.0**, not 0.31.1.

Since that 0.31.0 baseline, main accumulated three additive public-API changes:
- 0.31.1's own change (PR #5435 — doc-comment drift fix, no logic change)
- PR #5412 — new public `retract_triple` function
- PR #5450 — new public ETXTBSY spawn-retry entry point

All additive, no removals or signature breaks identified in review. Cargo's 0.x rule places the additive/breaking position at MINOR for a `0.y.z` crate, so this is 0.31.1 → **0.32.0**.

🔴 **`cargo-semver-checks` could NOT verify this bump.** It fails to build rustdoc for the 0.31.0 baseline and exits 101 with no verdict — known open bug #5440. The MINOR choice above rests on manual review of the public delta between 0.31.0 and main, not on tool confirmation. Do not read the gates below as having covered semver correctness — they only cover compile/resolve/test health at the new version.

## What changed

- `crates/trusty-common/Cargo.toml`: `version = "0.31.1"` → `"0.32.0"` (only line touched).
- Every direct `version = "0.31"` requirement on trusty-common moved to `"0.32"` in the same PR, so the workspace actually resolves against the new version instead of leaving five dependents pinned to the old one:
  - root `Cargo.toml` `[workspace.dependencies]` (`trusty-common = { path = ..., version = "0.31" }`)
  - `crates/trusty-gworkspace/Cargo.toml`
  - `crates/trusty-memory/Cargo.toml` (two occurrences — default and no-default-features requirement)
  - `crates/trusty-search/Cargo.toml` (two occurrences)

  The `[patch.crates-io]` entry for trusty-common (root `Cargo.toml` line ~411) is path-only with no version requirement and needed no change.

- `Cargo.lock`: minimal update via `cargo update -p trusty-common --precise 0.32.0` (also verified with `--workspace`, identical result). The only two hunks:
  ```diff
   [[package]]
   name = "num_enum_derive"
   version = "0.7.6"
   ...
   dependencies = [
  -  "proc-macro-crate 1.3.1",
  +  "proc-macro-crate 2.0.0",
     "proc-macro2",
     "quote",
     "syn 2.0.117",
   ]
   ...
   [[package]]
   name = "trusty-common"
  -version = "0.31.1"
  +version = "0.32.0"
  ```
  The `proc-macro-crate` line is not a broad `cargo update` side-effect — it reproduced identically across two different narrow invocations (`--workspace` and `--precise 0.32.0`), so it is a deterministic resolver consequence of the trusty-common version bump itself, the same class of drift PR #5435 flagged and verified deterministic in the opposite direction. `num_enum_derive` itself does not depend on trusty-common. No other package moved.

## Changelog

Not touched. `crates/trusty-common/changelog.d/` holds 14 unassembled fragments (including #5396 for `retract_triple` and #5446 for the ETXTBSY spawn-retry entry point — the two additive changes cited above). Per repo precedent, changelog assembly for trusty-common has consistently been its own dedicated PR, separate from the version-bump PR and done at/near publish time — e.g. PR #4710 ("assemble changelog for 0.28.0 release") landed independently of the version-bump commit (PR #4564). Following that precedent rather than guessing; flagging explicitly per instructions in case assembly should happen here instead.

## Gates run (rung 4 — shared-library / cross-crate manifest change)

`cargo fmt --check` — exit 0, no diff.

`cargo check -p trusty-common` — exit 0:
```
Checking trusty-common v0.32.0 (.../crates/trusty-common)
Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.72s
```

`cargo check --workspace` — exit 0, every dependent resolves and compiles against 0.32.0:
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 32s
```

`cargo test -p trusty-common` — exit 0:
```
test result: ok. 323 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 2.12s
```
(plus 5 empty integration-test binaries, 0 doc-tests — all `ok`)

## Not done (per instructions)

No `cargo publish`, no tag, no merge, no branch-protection changes.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools