### PR TITLE
fix(ci): SemVer gate reads its own evidence through ANSI colour

### DIFF
--- a/scripts/check_semver.sh
+++ b/scripts/check_semver.sh
@@ -99,9 +99,10 @@
 #   No summary line means no comparison happened, whatever the exit status was —
 #   including exit 0 — and that is reported as NO VERDICT on its own exit code.
 #   Absence of evidence is never a pass; same rule as the scan floor below.
-#   The line is matched with ANSI colour stripped, because CI forces colour into
-#   the middle of the marker token and the check went blind to every run —
-#   see verdict_computed below for the bytes and for PR #5458's two casualties.
+#   The line is matched with ANSI colour stripped (issue #5500), because CI
+#   forces colour into the middle of the marker token and the check went blind
+#   to every run — see verdict_computed below for the bytes and for PR #5458's
+#   two casualties.
 #
 # Toolchain (issue #5289): cargo-semver-checks re-resolves the dependency graph
 #   in a scratch project that IGNORES this workspace's Cargo.lock, so it can pick
@@ -161,7 +162,7 @@
 #   inventory instead of a skip. Cases 13-15 pin pre-release handling: the
 #   reproduction on record is `["0.9.9", "1.0.0-rc1", "1.0.0", "1.0.1-beta"]`
 #   declared 1.0.1, which selected 1.0.0-rc1 before the rank element existed.
-#   Cases 16-18 replay PR #5458's own CI bytes, where forced colour hid the
+#   Cases 16-18 (#5500) replay PR #5458's own CI bytes, where forced colour hid the
 #   summary line and both a clean run and a four-failure run were reported as
 #   never having happened.
 #   The catch itself is demonstrated in PR #5051 against #4088's real shape.
@@ -677,7 +678,7 @@ PY
 #   that it finished comparing, so requiring it means the gate concludes only
 #   from evidence that the comparison happened.
 #
-# THE MARKER ARRIVES COLOURED IN CI, AND THE COLOUR LANDS MID-TOKEN.
+# THE MARKER ARRIVES COLOURED IN CI, AND THE COLOUR LANDS MID-TOKEN (issue #5500).
 #   `dtolnay/rust-toolchain` writes CARGO_TERM_COLOR=always into $GITHUB_ENV
 #   when it is unset, so every step after it inherits forced colour even though
 #   this gate redirects the tool to a file. cargo-semver-checks then emits
@@ -709,7 +710,7 @@ PY
 #   so text that did not say `Checked … N checks:` still does not.
 # ---------------------------------------------------------------------------
 verdict_computed() {
-  # PR #5458: CARGO_TERM_COLOR=always splits `Checked` from its trailing space.
+  # #5500: CARGO_TERM_COLOR=always splits `Checked` from its trailing space (PR #5458).
   local plain="${1}.plain"
   LC_ALL=C sed -E $'s/\033\\[[0-9;]*[A-Za-z]//g' "$1" > "$plain" || return 1
   grep -Eq '(^|[[:space:]])Checked[[:space:]].*[0-9]+ checks:' "$plain"

--- a/scripts/check_semver.sh
+++ b/scripts/check_semver.sh
@@ -695,8 +695,25 @@ PY
 #
 #   The escapes are therefore stripped before matching. Stripping is done on a
 #   COPY: the log echoed to the operator keeps its colour, and the regex keeps
-#   the exact shape #5289 gave it. The strip is deliberately confined to CSI
-#   sequences, which is everything cargo tooling emits.
+#   the exact shape #5289 gave it.
+#
+#   The strip covers the WHOLE ECMA-48 CSI grammar, not just the SGR colour
+#   sequences observed: ESC [, parameter bytes 0x30-0x3F (`0-9:;<=>?`),
+#   intermediate bytes 0x20-0x2F (` -/`), one final byte 0x40-0x7E (`@-~`).
+#   Narrowing it to `[0-9;]*[A-Za-z]` — the observed shape — would leave a
+#   private-mode sequence like `ESC[?25l` (cursor hide, emitted by spinner
+#   renderers) unstripped, and that is the same defect again: an escape between
+#   `Checked` and its space. Pinned by self-test case 19.
+#
+#   `[ -/]`, NOT `[ -\/]`. POSIX makes the backslash literal inside a bracket
+#   expression, so `[ -\/]` is the range 0x20-0x5C and deletes digits and
+#   uppercase letters: `KEEP-ME-A` strips to the empty string under it, and to
+#   `KEEPMEA` under the correct form. An over-wide strip is the one way this
+#   function could invent a marker rather than miss one.
+#
+#   Non-CSI escape families (OSC hyperlinks, two-byte sequences) are out of
+#   scope deliberately: none appears in cargo-semver-checks 0.50.0's output,
+#   and an unhandled one fails CLOSED to NO VERDICT rather than to a pass.
 #
 #   Written to a file rather than piped into `grep -q`, because `grep -q` exits
 #   at the first match and SIGPIPEs the producer — under `set -o pipefail` that
@@ -712,7 +729,7 @@ PY
 verdict_computed() {
   # #5500: CARGO_TERM_COLOR=always splits `Checked` from its trailing space (PR #5458).
   local plain="${1}.plain"
-  LC_ALL=C sed -E $'s/\033\\[[0-9;]*[A-Za-z]//g' "$1" > "$plain" || return 1
+  LC_ALL=C sed -E $'s/\033\\[[0-9:;<=>?]*[ -/]*[@-~]//g' "$1" > "$plain" || return 1
   grep -Eq '(^|[[:space:]])Checked[[:space:]].*[0-9]+ checks:' "$plain"
 }
 

--- a/scripts/check_semver.sh
+++ b/scripts/check_semver.sh
@@ -99,6 +99,9 @@
 #   No summary line means no comparison happened, whatever the exit status was —
 #   including exit 0 — and that is reported as NO VERDICT on its own exit code.
 #   Absence of evidence is never a pass; same rule as the scan floor below.
+#   The line is matched with ANSI colour stripped, because CI forces colour into
+#   the middle of the marker token and the check went blind to every run —
+#   see verdict_computed below for the bytes and for PR #5458's two casualties.
 #
 # Toolchain (issue #5289): cargo-semver-checks re-resolves the dependency graph
 #   in a scratch project that IGNORES this workspace's Cargo.lock, so it can pick
@@ -158,6 +161,9 @@
 #   inventory instead of a skip. Cases 13-15 pin pre-release handling: the
 #   reproduction on record is `["0.9.9", "1.0.0-rc1", "1.0.0", "1.0.1-beta"]`
 #   declared 1.0.1, which selected 1.0.0-rc1 before the rank element existed.
+#   Cases 16-18 replay PR #5458's own CI bytes, where forced colour hid the
+#   summary line and both a clean run and a four-failure run were reported as
+#   never having happened.
 #   The catch itself is demonstrated in PR #5051 against #4088's real shape.
 #
 # Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
@@ -671,12 +677,42 @@ PY
 #   that it finished comparing, so requiring it means the gate concludes only
 #   from evidence that the comparison happened.
 #
+# THE MARKER ARRIVES COLOURED IN CI, AND THE COLOUR LANDS MID-TOKEN.
+#   `dtolnay/rust-toolchain` writes CARGO_TERM_COLOR=always into $GITHUB_ENV
+#   when it is unset, so every step after it inherits forced colour even though
+#   this gate redirects the tool to a file. cargo-semver-checks then emits
+#
+#       ESC[1m ESC[32m     Checked ESC[0m [   0.871s] 196 checks: 196 pass, ...
+#
+#   with the reset sequence BETWEEN `Checked` and the space that follows it. A
+#   pattern anchored on `Checked<space>` therefore matches nothing, and a run
+#   that compared 196 checks is announced as one that never ran. Both halves of
+#   PR #5458 are that single defect: tga exited 0 having found no break, and
+#   trusty-review exited 100 having listed four real ones, and the gate called
+#   both "without completing a run". No exit status was misread — the exit-status
+#   handling below is correct and unchanged; only the evidence test was blind.
+#
+#   The escapes are therefore stripped before matching. Stripping is done on a
+#   COPY: the log echoed to the operator keeps its colour, and the regex keeps
+#   the exact shape #5289 gave it. The strip is deliberately confined to CSI
+#   sequences, which is everything cargo tooling emits.
+#
+#   Written to a file rather than piped into `grep -q`, because `grep -q` exits
+#   at the first match and SIGPIPEs the producer — under `set -o pipefail` that
+#   turns a FOUND marker into a non-zero pipeline, i.e. a verdict reported as a
+#   non-verdict. That is the same lie in the other direction.
+#
 # Fails CLOSED by construction: if a future cargo-semver-checks renames this
 #   line, every run becomes NO VERDICT — loud and non-zero — rather than a
-#   silent green. That is the correct direction for the failure to point.
+#   silent green. That is the correct direction for the failure to point. The
+#   strip cannot manufacture a marker either: it only deletes escape sequences,
+#   so text that did not say `Checked … N checks:` still does not.
 # ---------------------------------------------------------------------------
 verdict_computed() {
-  grep -Eq '(^|[[:space:]])Checked[[:space:]].*[0-9]+ checks:' "$1"
+  # PR #5458: CARGO_TERM_COLOR=always splits `Checked` from its trailing space.
+  local plain="${1}.plain"
+  LC_ALL=C sed -E $'s/\033\\[[0-9;]*[A-Za-z]//g' "$1" > "$plain" || return 1
+  grep -Eq '(^|[[:space:]])Checked[[:space:]].*[0-9]+ checks:' "$plain"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/check_semver_selftest.sh
+++ b/scripts/check_semver_selftest.sh
@@ -62,7 +62,8 @@
 #   9, 11 and 12 fail against the pre-#5296 gate, which is what makes them
 #   regression tests rather than descriptions of current behaviour.
 #
-#   Cases 16-18 pin the gate against ANSI-COLOURED tool output. Every fixture
+#   Cases 16-18 (issue #5500) pin the gate against ANSI-COLOURED tool output.
+#   Every fixture
 #   above was captured by redirecting to a file on a workstation, where
 #   cargo-semver-checks emits plain text — so `Checked` was always followed by a
 #   space and the marker matched. In GitHub Actions it is not:

--- a/scripts/check_semver_selftest.sh
+++ b/scripts/check_semver_selftest.sh
@@ -84,6 +84,17 @@
 #   16 and 17 ride the cases 5-8 table; 18 has its own block below. All three
 #   fail against the pre-fix gate.
 #
+#     19. private-mode CSI — pins the strip to the WHOLE ECMA-48 CSI grammar
+#                            rather than the SGR shape that was observed. Its
+#                            fixture puts `ESC[?25l` (cursor hide, emitted by
+#                            spinner renderers) between `Checked` and its space,
+#                            which a `[0-9;]*[A-Za-z]` strip leaves in place —
+#                            reintroducing this very defect. Synthetic, and
+#                            labelled so: no cargo-semver-checks 0.50.0 output
+#                            carries it. It rides the cases 5-8 table at exit
+#                            100, so it also proves a private-mode-laden BREAK
+#                            is still reported as a break rather than swallowed.
+#
 #   Cases 13-15 pin pre-release handling. `key()` used to strip the pre-release
 #   suffix, so 1.0.0-rc1 and 1.0.0 both keyed to (1, 0, 0) and the tie went to
 #   whichever the index listed first — the reproduction on record picked
@@ -341,7 +352,8 @@ rustdoc build error${TAB}build-error.out${TAB}101${TAB}3${TAB}NO SEMVER VERDICT 
 silent no-op at exit 0${TAB}silent-noop.out${TAB}0${TAB}3${TAB}NO SEMVER VERDICT WAS COMPUTED${TAB}requires a matching version bump
 clean${TAB}clean.out${TAB}0${TAB}0${TAB}crate(s) checked${TAB}NO SEMVER VERDICT
 ANSI-coloured clean (case 16)${TAB}clean-colored.out${TAB}0${TAB}0${TAB}crate(s) checked${TAB}NO SEMVER VERDICT
-ANSI-coloured break (case 17)${TAB}break-colored.out${TAB}100${TAB}1${TAB}VERDICT: BREAK${TAB}NO SEMVER VERDICT"
+ANSI-coloured break (case 17)${TAB}break-colored.out${TAB}100${TAB}1${TAB}VERDICT: BREAK${TAB}NO SEMVER VERDICT
+private-mode CSI break (case 19)${TAB}private-mode.out${TAB}100${TAB}1${TAB}VERDICT: BREAK${TAB}NO SEMVER VERDICT"
 
 while IFS="$TAB" read -r name fixture stub_rc want_exit must_have must_not; do
   [[ -z "$name" ]] && continue

--- a/scripts/check_semver_selftest.sh
+++ b/scripts/check_semver_selftest.sh
@@ -62,6 +62,27 @@
 #   9, 11 and 12 fail against the pre-#5296 gate, which is what makes them
 #   regression tests rather than descriptions of current behaviour.
 #
+#   Cases 16-18 pin the gate against ANSI-COLOURED tool output. Every fixture
+#   above was captured by redirecting to a file on a workstation, where
+#   cargo-semver-checks emits plain text — so `Checked` was always followed by a
+#   space and the marker matched. In GitHub Actions it is not:
+#   `dtolnay/rust-toolchain` exports CARGO_TERM_COLOR=always into $GITHUB_ENV,
+#   every later step inherits it, and the summary line arrives as
+#   `ESC[1mESC[32m     CheckedESC[0m [ 0.871s] 196 checks: ...`. The reset
+#   sequence sits between `Checked` and the space, so a marker regex anchored on
+#   `Checked<space>` sees nothing and reports a completed comparison as NO
+#   VERDICT. Both new fixtures are verbatim CI captures of that shape:
+#     16. coloured clean   — the tga run of PR #5458: exit 0, 196 pass. Reported
+#                            as "exited 0 without completing a check run".
+#     17. coloured break   — the same bytes at exit 100 through the PASS/FAIL
+#                            arm. Must still be a BREAK, so the colour fix
+#                            cannot be mistaken for a weakened gate.
+#     18. coloured inventory — the trusty-review run of PR #5458: exit 100 with
+#                            4 real failures, through the already-breaking arm.
+#                            Reported as "exited 100 without completing a run".
+#   16 and 17 ride the cases 5-8 table; 18 has its own block below. All three
+#   fail against the pre-fix gate.
+#
 #   Cases 13-15 pin pre-release handling. `key()` used to strip the pre-release
 #   suffix, so 1.0.0-rc1 and 1.0.0 both keyed to (1, 0, 0) and the tie went to
 #   whichever the index listed first — the reproduction on record picked
@@ -317,7 +338,9 @@ TAB="$(printf '\t')"
 VERDICT_CASES="real break${TAB}break.out${TAB}100${TAB}1${TAB}VERDICT: BREAK${TAB}NO SEMVER VERDICT
 rustdoc build error${TAB}build-error.out${TAB}101${TAB}3${TAB}NO SEMVER VERDICT WAS COMPUTED${TAB}requires a matching version bump
 silent no-op at exit 0${TAB}silent-noop.out${TAB}0${TAB}3${TAB}NO SEMVER VERDICT WAS COMPUTED${TAB}requires a matching version bump
-clean${TAB}clean.out${TAB}0${TAB}0${TAB}crate(s) checked${TAB}NO SEMVER VERDICT"
+clean${TAB}clean.out${TAB}0${TAB}0${TAB}crate(s) checked${TAB}NO SEMVER VERDICT
+ANSI-coloured clean (case 16)${TAB}clean-colored.out${TAB}0${TAB}0${TAB}crate(s) checked${TAB}NO SEMVER VERDICT
+ANSI-coloured break (case 17)${TAB}break-colored.out${TAB}100${TAB}1${TAB}VERDICT: BREAK${TAB}NO SEMVER VERDICT"
 
 while IFS="$TAB" read -r name fixture stub_rc want_exit must_have must_not; do
   [[ -z "$name" ]] && continue
@@ -429,6 +452,21 @@ elif [[ "$out" == *"no breaking changes found"* ]]; then
   fail_case "inventory/blind: a run that produced nothing was reported as clean" "$out"
 else
   pass_case "an inventory that could not run says so, in the line and in the summary"
+fi
+
+# --- 18. The inventory arm over ANSI-coloured output. This is the trusty-review
+#         half of PR #5458 verbatim: a completed run with 4 real failures that
+#         the gate announced as "exited 100 without completing a run".
+rc=0
+out="$(gate_with_index "${STUB_OLD_MINOR}" "${STUB_OLD_MINOR}=break-colored.out:100")" || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  fail_case "inventory/coloured: an advisory run over coloured output must stay green (exit ${rc})" "$out"
+elif [[ "$out" == *"NO INVENTORY ${STUB_CRATE}"* ]]; then
+  fail_case "inventory/coloured: a completed run was reported as never having run — the marker did not survive the colour codes" "$out"
+elif [[ "$out" != *"breaking change(s) listed above"* ]]; then
+  fail_case "inventory/coloured: exit 0 but the breaks were never reported" "$out"
+else
+  pass_case "a coloured inventory run is recognised as completed"
 fi
 
 # ===========================================================================

--- a/scripts/test-data/semver-gate/README.md
+++ b/scripts/test-data/semver-gate/README.md
@@ -28,6 +28,7 @@ untouched, because those escapes are the whole point of the fixture.
 | `silent-noop.out` | 0 | **Synthetic.** No real invocation produces exit 0 with no `checks:` summary today. It pins the fail-closed rule: "the tool said nothing" must never be read as "the tool said pass". |
 | `clean-colored.out` | 0 | The `tga` 2.16.0 -> 2.17.0 run of PR #5458, [job 93874563097](https://github.com/bobmatnyc/trusty-tools/actions/runs/31520044458/job/93874563097). 196 pass, no break — and the gate announced it as "exited 0 without completing a check run". |
 | `break-colored.out` | 100 | The `trusty-review` 0.14.1 -> 0.15.0 run of the same job: 4 real major failures, announced as "exited 100 without completing a run". |
+| `private-mode.out` | 100 | **Synthetic.** A break-shaped run carrying private-mode CSI sequences — `ESC[?25l` / `ESC[?25h` (cursor hide/show, what a spinner renderer emits) plus `ESC[2K\r`. The hide sits between `Checked` and its space, where an SGR-only strip leaves it and the marker check goes blind again. No cargo-semver-checks 0.50.0 output carries these; it pins the strip to the ECMA-48 CSI grammar rather than to the shape that happened to be observed. |
 
 Both `*-colored.out` files exist (issue #5500) because every fixture above was captured by
 redirecting to a file on a workstation, where cargo-semver-checks emits plain

--- a/scripts/test-data/semver-gate/README.md
+++ b/scripts/test-data/semver-gate/README.md
@@ -13,7 +13,12 @@ than on what the gate decided. That mistake was made once while writing these
 and the self-test caught it.
 
 The one edit applied to a captured file: absolute paths rewritten to `/REPO`, so
-no author's worktree path is committed.
+no author's worktree path is committed. The two `*-colored.out` files were taken
+from a GitHub Actions log rather than a shell, so they carry two more mechanical
+rewrites: the runner's `CARGO_HOME` becomes `/CARGO_HOME`, and each line's
+leading `2026-08-11T17:55:29.5352927Z ` timestamp — added by the Actions log
+service, never printed by the tool — is removed. Their ANSI escapes are
+untouched, because those escapes are the whole point of the fixture.
 
 | File | Stub exit | Captured from |
 |---|---|---|
@@ -21,6 +26,17 @@ no author's worktree path is committed.
 | `clean.out` | 0 | `cargo semver-checks -p trusty-progress --baseline-version 0.2.0 --only-explicit-features`. Already a major bump, so 0 lints apply — the tool's "nothing to compare, and that is fine" shape. |
 | `build-error.out` | 101 | The same `trusty-mpm` command under the repo MSRV 1.94.1, where the scratch resolution takes `takecell` 0.1.2 (`rust-version` 1.96) and rustdoc refuses to build. This is the defect #5289 was filed for. |
 | `silent-noop.out` | 0 | **Synthetic.** No real invocation produces exit 0 with no `checks:` summary today. It pins the fail-closed rule: "the tool said nothing" must never be read as "the tool said pass". |
+| `clean-colored.out` | 0 | The `tga` 2.16.0 -> 2.17.0 run of PR #5458, [job 93874563097](https://github.com/bobmatnyc/trusty-tools/actions/runs/31520044458/job/93874563097). 196 pass, no break — and the gate announced it as "exited 0 without completing a check run". |
+| `break-colored.out` | 100 | The `trusty-review` 0.14.1 -> 0.15.0 run of the same job: 4 real major failures, announced as "exited 100 without completing a run". |
+
+Both `*-colored.out` files exist because every fixture above was captured by
+redirecting to a file on a workstation, where cargo-semver-checks emits plain
+text. CI is not that environment: `dtolnay/rust-toolchain` exports
+`CARGO_TERM_COLOR=always` into `$GITHUB_ENV`, so the summary line arrives as
+`ESC[1mESC[32m     CheckedESC[0m [   0.871s] 196 checks: …` and the reset
+sequence sits between `Checked` and its trailing space. Refreshing either one
+means re-capturing under `CARGO_TERM_COLOR=always`; a plain-text capture would
+still pass its case while testing nothing.
 
 ## Replayed by baseline (#5296)
 

--- a/scripts/test-data/semver-gate/README.md
+++ b/scripts/test-data/semver-gate/README.md
@@ -29,7 +29,7 @@ untouched, because those escapes are the whole point of the fixture.
 | `clean-colored.out` | 0 | The `tga` 2.16.0 -> 2.17.0 run of PR #5458, [job 93874563097](https://github.com/bobmatnyc/trusty-tools/actions/runs/31520044458/job/93874563097). 196 pass, no break — and the gate announced it as "exited 0 without completing a check run". |
 | `break-colored.out` | 100 | The `trusty-review` 0.14.1 -> 0.15.0 run of the same job: 4 real major failures, announced as "exited 100 without completing a run". |
 
-Both `*-colored.out` files exist because every fixture above was captured by
+Both `*-colored.out` files exist (issue #5500) because every fixture above was captured by
 redirecting to a file on a workstation, where cargo-semver-checks emits plain
 text. CI is not that environment: `dtolnay/rust-toolchain` exports
 `CARGO_TERM_COLOR=always` into `$GITHUB_ENV`, so the summary line arrives as

--- a/scripts/test-data/semver-gate/break-colored.out
+++ b/scripts/test-data/semver-gate/break-colored.out
@@ -1,0 +1,59 @@
+[1m[32m    Building[0m trusty-review v0.15.0 (current)
+[1m[32m       Built[0m [ 162.750s] (current)
+[1m[32m     Parsing[0m trusty-review v0.15.0 (current)
+[1m[32m      Parsed[0m [   0.187s] (current)
+[1m[32m    Building[0m trusty-review v0.14.1 (baseline)
+[1m[32m       Built[0m [ 163.161s] (baseline)
+[1m[32m     Parsing[0m trusty-review v0.14.1 (baseline)
+[1m[32m      Parsed[0m [   0.177s] (baseline)
+[1m[32m    Checking[0m trusty-review v0.14.1 -> v0.15.0 (assume minor change)
+[1m[31m     Checked[0m [   1.197s] 196 checks: 192 pass, 4 fail, 0 warn, 58 skip
+
+--- failure enum_missing: pub enum removed or renamed ---
+
+[1mDescription:[0m
+A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_missing.ron
+
+[1mFailed in:[0m
+  enum trusty_review::report::synthesize::SynthesisStatus, previously in file /CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-review-0.14.1/src/report/synthesize.rs:74
+  enum trusty_review::report::SynthesisStatus, previously in file /CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-review-0.14.1/src/report/synthesize.rs:74
+
+--- failure enum_variant_added: enum variant added on exhaustive enum ---
+
+[1mDescription:[0m
+A publicly-visible enum without #[non_exhaustive] has a new variant.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_added.ron
+
+[1mFailed in:[0m
+  variant ReportError:SynthesisRequired in /REPO/crates/trusty-review/src/report/error.rs:116
+  variant ReportError:SynthesisRequired in /REPO/crates/trusty-review/src/report/error.rs:116
+
+--- failure inherent_method_missing: pub method removed or renamed ---
+
+[1mDescription:[0m
+A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/inherent_method_missing.ron
+
+[1mFailed in:[0m
+  Synthesis::unavailable, previously in file /CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-review-0.14.1/src/report/synthesize.rs:141
+  Synthesis::is_available, previously in file /CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-review-0.14.1/src/report/synthesize.rs:153
+  Synthesis::unavailable, previously in file /CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-review-0.14.1/src/report/synthesize.rs:141
+  Synthesis::is_available, previously in file /CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-review-0.14.1/src/report/synthesize.rs:153
+
+--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---
+
+[1mDescription:[0m
+A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/struct_pub_field_missing.ron
+
+[1mFailed in:[0m
+  field status of struct Synthesis, previously in file /CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-review-0.14.1/src/report/synthesize.rs:50
+  field status of struct Synthesis, previously in file /CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-review-0.14.1/src/report/synthesize.rs:50
+
+[1m[31m     Summary[0m semver requires new major version: 4 major and 0 minor checks failed
+[1m[32m    Finished[0m [ 330.534s] trusty-review

--- a/scripts/test-data/semver-gate/clean-colored.out
+++ b/scripts/test-data/semver-gate/clean-colored.out
@@ -1,0 +1,12 @@
+[1m[32m    Building[0m tga v2.17.0 (current)
+[1m[32m       Built[0m [ 149.220s] (current)
+[1m[32m     Parsing[0m tga v2.17.0 (current)
+[1m[32m      Parsed[0m [   0.180s] (current)
+[1m[32m    Building[0m tga v2.16.0 (baseline)
+[1m[32m       Built[0m [ 148.121s] (baseline)
+[1m[32m     Parsing[0m tga v2.16.0 (baseline)
+[1m[32m      Parsed[0m [   0.179s] (baseline)
+[1m[32m    Checking[0m tga v2.16.0 -> v2.17.0 (minor change)
+[1m[32m     Checked[0m [   0.871s] 196 checks: 196 pass, 58 skip
+[1m[32m     Summary[0m no semver update required
+[1m[32m    Finished[0m [ 302.779s] tga

--- a/scripts/test-data/semver-gate/private-mode.out
+++ b/scripts/test-data/semver-gate/private-mode.out
@@ -1,0 +1,20 @@
+[?25l[1m[32m    Building[0m stub v9.9.9 (current)
+[1m[32m       Built[0m [   1.204s] (current)
+[1m[32m     Parsing[0m stub v9.9.9 (current)
+[1m[32m      Parsed[0m [   0.061s] (current)
+[1m[32m    Building[0m stub v9.9.8 (baseline)
+[1m[32m       Built[0m [   1.190s] (baseline)
+[2K[1m[32m    Checking[0m stub v9.9.8 -> v9.9.9 (minor change)
+[1m[31m     Checked[?25l[0m [   0.418s] 196 checks: 195 pass, 1 fail, 0 warn, 58 skip
+
+--- failure enum_missing: pub enum removed or renamed ---
+
+[1mDescription:[0m
+A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
+        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
+
+[1mFailed in:[0m
+  enum stub::Removed, previously in file /REPO/src/lib.rs:12
+
+[1m[31m     Summary[0m semver requires new major version: 1 major and 0 minor checks failed
+[1m[32m    Finished[0m [   3.902s] stub[?25h


### PR DESCRIPTION
## What broke

`dtolnay/rust-toolchain` writes `CARGO_TERM_COLOR=always` into `$GITHUB_ENV`
when it is unset, so every step after it inherits forced colour even though the
gate redirects `cargo-semver-checks` to a file. The summary line the gate keys
on arrives as

```
ESC[1mESC[32m     CheckedESC[0m [   0.871s] 196 checks: 196 pass, 58 skip
```

The reset sequence sits between `Checked` and its trailing space, so
`verdict_computed`'s `Checked<space>` anchor matched nothing and a run that
compared 196 checks was reported as one that never ran.

## One defect, not two

PR #5458's `Public API / SemVer` failure looked like two problems. It is one.

- `tga` exited **0** having found no break.
- `trusty-review` exited **100** having listed four real ones.

The gate called both "without completing a run". **No exit status was
misread** — the exit-status handling is correct and is unchanged by this PR.
Only the evidence test was blind, and it was blind to every run in CI
regardless of outcome.

## The fix

Strip ANSI CSI sequences before matching, on a copy: the log echoed to the
operator keeps its colour, and the regex keeps the shape #5289 gave it.

The strip writes a file rather than piping into `grep -q`. `grep -q` exits at
the first match and SIGPIPEs its producer, which under `set -o pipefail` would
turn a FOUND marker into a non-verdict — the same lie in the other direction.

Fails closed as before: the strip only deletes escape sequences, so text that
did not say `Checked … N checks:` still does not, and a renamed marker still
becomes a loud NO VERDICT rather than a silent green.

## Not a weakening

The gate must still fail a genuinely insufficient bump, and self-test case 17
pins exactly that — the same coloured bytes at exit 100 through the PASS/FAIL
arm must exit 1 with `VERDICT: BREAK`. Cases 6 and 7 (rustdoc build error,
silent no-op) still exit 3 unchanged.

## #5458's own bump is correct — the gate was wrong, not the PR

`trusty-review` 0.14.1 → 0.15.0 puts the break in the MINOR position, which is
Cargo's breaking position for a `0.y.z` crate. The four failures
(`enum_missing`, `enum_variant_added`, `inherent_method_missing`,
`struct_pub_field_missing`) are all major-tier and all covered. `tga` 2.16.0 →
2.17.0 had no break to cover. Nothing in #5458 needs changing.

## Test ladder

Rung 5 (release tooling). Scripts-only — no crate `src/**`, so no changelog
fragment is owed.

Red-before-green, twice over:

- **Fixture path.** Cases 16-18 replay #5458's own CI bytes. Against the
  pre-fix gate: `15 passed, 3 FAILED`. After: `18 passed, 0 failed`.
- **Live path, real tool.** `origin/main`'s script, real `cargo-semver-checks`
  0.50.0, `CARGO_TERM_COLOR=always`:

  ```
  ESC[1mESC[32m     CheckedESC[0m [   0.047s] 196 checks: 196 pass, 58 skip
  NO VERDICT tga: cargo semver-checks exited 0 without completing a check run.
  PREFIX_TGA_EXIT=3
  ```

  Same input, this branch's script:

  ```
  CHECK tga: 2.15.0 -> 2.16.0 (minor release), 1 feature(s)
       Checked [   0.059s] 196 checks: 196 pass, 58 skip
  semver gate: scanned (explicit); 1 crate(s) checked, 0 skipped — OK.
  TGA_EXIT=0
  ```

Gates: all 17 runnable `scripts/check_*.sh` pass; `check_semver.sh --crate tga`
and `--crate trusty-review` both exit 0 against the live registry;
`cargo fmt --check` clean; `shellcheck -S warning` clean on both changed
scripts. No Rust touched.

## Scope

Closes #5500.

Deliberately NOT fixed here: #5501 — `check_semver_selftest.sh` is gated on
`have_work == 'true'` at `.github/workflows/semver-checks.yml:218`, so a
gate-fix PR declares no version bump and the self-test does not run on it. That
includes this PR: the red-before-green above is local. Fixing it is not a
one-liner, because `scripts/check-ci-helpers-selftest.sh:628` asserts that
condition string appears exactly 5 times. Separate ticket, separate PR.

Refs #5289, #5311. Reproduction: PR #5458, run 31520044458.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
