### PR TITLE
feat(trusty-memory): expose kg_retract_triple on the MCP tool surface

### DIFF
--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -246,7 +246,7 @@ per-palace conversation store: turns are stored verbatim and bypass the
 `memory_remember` signal/noise and dedup gates.
 
 <!-- BEGIN GENERATED: mcp-tools -->
-The MCP server registers **46 tools**. Authoritative source: `trusty_memory::tools::tool_definitions` —
+The MCP server registers **47 tools**. Authoritative source: `trusty_memory::tools::tool_definitions` —
 this table is generated from it, not maintained by hand.
 
 | Tool | Arguments | Summary |
@@ -266,8 +266,9 @@ this table is generated from it, not maintained by hand.
 | `kg_assert` | `palace`, `subject`, `predicate`, `object`, `confidence?`, `provenance?` | Assert a fact in the temporal knowledge graph. |
 | `kg_bootstrap` | `palace?`, `project_path?` | Seed the knowledge graph from well-known project files (Cargo.toml, package.json, pyproject.toml, go.mod, CLAUDE.md, .git/config). |
 | `kg_gaps` | `palace?` | List knowledge gaps detected in the memory palace graph. |
-| `kg_list_subjects` | `palace`, `limit?`, `with_counts?` | List the subjects this palace's knowledge graph actually holds, alphabetically. |
+| `kg_list_subjects` | `palace`, `limit?`, `with_counts?` | List the subjects this palace's knowledge graph actually holds, ordered by subject. |
 | `kg_query` | `palace`, `subject` | Query active knowledge-graph triples for a subject. |
+| `kg_retract_triple` | `palace`, `subject`, `predicate`, `object` | Retract one fact from the temporal knowledge graph — the inverse of kg_assert. |
 | `list_prompt_facts` | — | List every active prompt-fact triple (aliases, conventions, facts, shorthands) across all palaces. |
 | `memory_forget` | `palace`, `drawer_id` | Delete a drawer from a palace by its UUID. |
 | `memory_list` | `palace`, `limit?`, `room?`, `tag?`, `wing?` | List drawers in a palace, optionally filtered by wing, room type, or tag. |

--- a/crates/trusty-memory/changelog.d/kg-list-subjects-description-drift.md
+++ b/crates/trusty-memory/changelog.d/kg-list-subjects-description-drift.md
@@ -1,0 +1,12 @@
+Fixed
+
+- **`kg_list_subjects`' tool description told callers two things that stopped
+  being true.** It claimed a `kg_query` miss "returns the same empty result as
+  an empty graph, so a guess tells you nothing" — but since
+  [#5385](https://github.com/bobmatnyc/trusty-tools/issues/5385) a miss carries
+  `graph_state: subject_not_found` or `graph_empty` plus a hint. It also
+  claimed `truncated: true` means "the page filled to `limit` and more subjects
+  may exist" — but since
+  [#4810](https://github.com/bobmatnyc/trusty-tools/issues/4810) the handler
+  over-fetches one row, so `truncated` is set only when a further subject was
+  actually seen, and a page that exactly fills `limit` reports `false`.

--- a/crates/trusty-memory/changelog.d/kg-retract-triple-mcp-tool.md
+++ b/crates/trusty-memory/changelog.d/kg-retract-triple-mcp-tool.md
@@ -1,0 +1,14 @@
+Added
+
+- **`kg_retract_triple` MCP tool — the inverse of `kg_assert`.** A triple
+  asserted over MCP could not be taken back over MCP: `remove_prompt_fact` is
+  scoped to hot predicates and closes the whole `(subject, predicate)` pair,
+  and re-asserting adds an object rather than replacing it for any predicate
+  outside the functional set. The tool takes the full
+  `(subject, predicate, object)` key, closes exactly that triple, and leaves
+  every sibling object at the pair active. It returns
+  `{palace, subject, predicate, object, closed, retracted}` — `closed` is 1 for
+  a retraction and 0 when nothing matched, so a miss is a legible no-op rather
+  than a silent one, and a repeat call is safe. `object` is required: omitting
+  it is an error, not a pair-wide retraction. Retracting a hot-predicate triple
+  rebuilds the prompt cache so the fact stops being injected.

--- a/crates/trusty-memory/src/lib_tests.rs
+++ b/crates/trusty-memory/src/lib_tests.rs
@@ -99,8 +99,9 @@ async fn tools_list_returns_all_tools() {
     // ADR-0027 T6 (#4805) adds `room_list`, `room_create`, `room_rename`;
     // ADR-0027 T9 (#4809) adds `wing_list`, `wing_create`, `wing_rename`;
     // #4906 adds `palace_reembed`; #5005 adds `palace_unalias`;
-    // #4776 adds `kg_list_subjects`.
-    assert_eq!(tools.len(), 46);
+    // #4776 adds `kg_list_subjects`; `kg_retract_triple` adds the inverse of
+    // `kg_assert`.
+    assert_eq!(tools.len(), 47);
 }
 
 #[tokio::test]

--- a/crates/trusty-memory/src/mcp_service.rs
+++ b/crates/trusty-memory/src/mcp_service.rs
@@ -87,8 +87,8 @@ mod tests {
         let tools = svc.tools();
         assert_eq!(
             tools.len(),
-            46,
-            "expected 46 memory tools (chat-session + dream-ops + palace_dream + the ADR-0027 room and wing surfaces + #4906 palace_reembed + #5005 palace_unalias + #4776 kg_list_subjects), got {}",
+            47,
+            "expected 47 memory tools (chat-session + dream-ops + palace_dream + the ADR-0027 room and wing surfaces + #4906 palace_reembed + #5005 palace_unalias + #4776 kg_list_subjects + kg_retract_triple), got {}",
             tools.len()
         );
     }
@@ -111,7 +111,7 @@ mod tests {
         //      so we must confirm dynamic dispatch resolves correctly here.
         let svc: Box<dyn ServiceDescriptor> = Box::new(MemoryMcpService);
         assert_eq!(svc.name(), "trusty-memory");
-        assert_eq!(svc.tools().len(), 46);
+        assert_eq!(svc.tools().len(), 47);
         assert_eq!(svc.scopes_for("palace_create"), vec!["memory.write"]);
         // #5005: the repair deletes vector keys, so it must classify as a write.
         assert_eq!(svc.scopes_for("palace_unalias"), vec!["memory.write"]);

--- a/crates/trusty-memory/src/mcp_service.rs
+++ b/crates/trusty-memory/src/mcp_service.rs
@@ -15,9 +15,9 @@
 //! functions guarantees the host-merged manifest and the standalone one
 //! stay byte-identical.
 //!
-//! Test: `tests` below assert the tool count (44), the name string, and
-//! that the read/write scope split matches what `scopes_for_tool` returns
-//! for representative tools (`memory_recall` → `memory.read`,
+//! Test: `tests` below assert the tool count, the name string, and that
+//! the read/write scope split matches what `scopes_for_tool` returns for
+//! representative tools (`memory_recall` → `memory.read`,
 //! `memory_remember` → `memory.write`).
 
 use trusty_common::mcp::ServiceDescriptor;
@@ -25,7 +25,7 @@ use trusty_common::mcp::ServiceDescriptor;
 use crate::openrpc::scopes_for_tool;
 use crate::tools::tool_definitions_with;
 
-/// `ServiceDescriptor` impl that advertises this crate's 44 memory tools.
+/// `ServiceDescriptor` impl that advertises this crate's memory tools.
 ///
 /// Why: Lets trusty-agents link trusty-memory-mcp directly and include its
 /// tools in a unified `rpc.discover` document without bespoke glue code.

--- a/crates/trusty-memory/src/openrpc.rs
+++ b/crates/trusty-memory/src/openrpc.rs
@@ -83,6 +83,9 @@ pub fn scopes_for_tool(name: &str) -> Vec<String> {
         // #5005: dry-run is read-only but the repair deletes vector keys.
         | "palace_unalias"
         | "kg_assert"
+        // Retraction closes an interval — a KG write, same scope as the
+        // assertion it undoes.
+        | "kg_retract_triple"
         | "add_alias"
         | "remove_prompt_fact"
         | "discover_aliases"

--- a/crates/trusty-memory/src/openrpc.rs
+++ b/crates/trusty-memory/src/openrpc.rs
@@ -8,7 +8,7 @@
 //! discovery surface; no new transport is needed.
 //!
 //! What: A thin wrapper around `trusty_mcp_core::openrpc::discover_response`
-//! that supplies the 11 trusty-memory tools and the per-tool scope mapping.
+//! that supplies the trusty-memory tools and the per-tool scope mapping.
 //! Read-only tools (lookups, queries, info) require `memory.read`; tools
 //! that mutate palace state require `memory.write`.
 //!

--- a/crates/trusty-memory/src/tools/definitions.rs
+++ b/crates/trusty-memory/src/tools/definitions.rs
@@ -74,6 +74,9 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
     } else {
         vec!["palace", "subject", "predicate", "object"]
     };
+    // Retraction takes the same full triple key as the assertion it undoes, so
+    // its `required` list is `kg_assert`'s by construction.
+    let kg_retract_triple_required: Vec<&str> = kg_assert_required.clone();
     let kg_query_required: Vec<&str> = if has_default {
         vec!["subject"]
     } else {
@@ -237,6 +240,20 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
                 }
             },
             {
+                "name": "kg_retract_triple",
+                "description": "Retract one fact from the temporal knowledge graph — the inverse of kg_assert. Targets the FULL (subject, predicate, object) key, so every other object at the same (subject, predicate) pair stays active; use it to take back a single wrong assertion. Re-asserting is not a substitute: for predicates outside the functional set (is-a, works-at, uses, depends-on among them) a new object joins the wrong one rather than replacing it. Returns {closed, retracted}: `closed` is how many active triples were closed — 1 for a retraction, 0 when nothing matched that exact triple. A 0 is a real no-op, not an error, so calling twice is safe; the response carries `reason` to say so.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "palace":    {"type": "string", "description": "Palace ID (optional if server started with --palace)"},
+                        "subject":   {"type": "string"},
+                        "predicate": {"type": "string"},
+                        "object":    {"type": "string", "description": "The exact object to retract. Required: omitting it does NOT retract the whole (subject, predicate) pair, it is an error — pair-wide retraction is deliberately not on this tool."}
+                    },
+                    "required": kg_retract_triple_required,
+                }
+            },
+            {
                 "name": "kg_query",
                 "description": "Query active knowledge-graph triples for a subject.",
                 "inputSchema": {
@@ -250,7 +267,7 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
             },
             {
                 "name": "kg_list_subjects",
-                "description": "List the subjects this palace's knowledge graph actually holds, alphabetically. Call this BEFORE kg_query instead of guessing a subject: kg_query needs a subject you already know, and a subject that does not exist returns the same empty result as an empty graph, so a guess tells you nothing. Subjects are namespaced by kind — `tag:<name>`, `topic:<name>`, `drawer:<uuid>`, `room:<name>` — alongside bare entity names asserted by kg_assert. Returns {palace, subjects, with_counts, truncated}. `truncated: true` means the page filled to `limit` and more subjects may exist; raise `limit` to see them.",
+                "description": "List the subjects this palace's knowledge graph actually holds, ordered by subject. Call this BEFORE kg_query instead of guessing a subject: kg_query needs a subject you already know, and a guessed name that misses costs a round trip that this call spends better. (A kg_query miss does say which miss it was — `graph_state: subject_not_found` vs `graph_empty` — so an empty result is never ambiguous.) Subjects are namespaced by kind — `tag:<name>`, `topic:<name>`, `drawer:<uuid>`, `room:<name>` — alongside bare entity names asserted by kg_assert. Returns {palace, subjects, with_counts, truncated}. `truncated: true` means a subject beyond this page was actually seen, so raising `limit` will show more; a page that exactly fills `limit` with nothing behind it reports `false`.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {

--- a/crates/trusty-memory/src/tools/kg_ops.rs
+++ b/crates/trusty-memory/src/tools/kg_ops.rs
@@ -81,6 +81,74 @@ pub(crate) async fn handle_kg_assert(state: &AppState, args: Value) -> Result<Va
     Ok(json!({ "status": "asserted" }))
 }
 
+/// MCP `kg_retract_triple` tool — close exactly one active triple.
+///
+/// Why: `kg_assert` had no inverse on the MCP surface. The only retraction a
+/// tool caller could reach was `remove_prompt_fact`, which is scoped to hot
+/// predicates, spans every palace, and closes the whole `(subject, predicate)`
+/// pair — so an agent that asserted a wrong object could not take it back.
+/// Re-asserting is not an escape either: outside `FUNCTIONAL_PREDICATES` a new
+/// object joins the wrong one instead of displacing it.
+/// What: resolves the palace, then calls
+/// [`trusty_common::memory_core::store::kg::KnowledgeGraph::retract_triple`],
+/// which targets the full `(subject, predicate, object)` key and leaves every
+/// sibling object at that pair active. Returns the `closed` count so a caller
+/// can tell a retraction (`1`) from a miss (`0`); a miss is a genuine no-op,
+/// carries `reason`, and is not an error, which makes the call idempotent.
+/// Rebuilds the prompt cache when a hot-predicate triple was actually closed —
+/// otherwise a retracted Tier S fact keeps being injected until the next write.
+/// Test: `dispatch_kg_retract_triple_closes_one_object_and_keeps_siblings`,
+/// `dispatch_kg_retract_triple_missing_triple_is_a_legible_noop`,
+/// `dispatch_kg_retract_triple_requires_object`.
+pub(crate) async fn handle_kg_retract_triple(state: &AppState, args: Value) -> Result<Value> {
+    let palace = resolve_palace(state, &args, "kg_retract_triple")?;
+    let subject = args
+        .get("subject")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("kg_retract_triple: missing 'subject'"))?
+        .to_string();
+    let predicate = args
+        .get("predicate")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("kg_retract_triple: missing 'predicate'"))?
+        .to_string();
+    let object = args
+        .get("object")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("kg_retract_triple: missing 'object'"))?
+        .to_string();
+
+    let handle = open_palace_handle(state, &palace)?;
+    let closed = handle
+        .kg
+        .retract_triple(&subject, &predicate, &object)
+        .await
+        .context("kg.retract_triple")?;
+
+    if closed > 0 && crate::prompt_facts::is_hot_predicate(&predicate) {
+        // Mirrors `handle_kg_assert`: the write landed either way, the cache is
+        // only a denormalisation, so a rebuild failure is logged, not fatal.
+        if let Err(e) = crate::prompt_facts::rebuild_prompt_cache(state).await {
+            tracing::warn!("rebuild_prompt_cache after kg_retract_triple failed: {e:#}");
+        }
+    }
+
+    let mut response = json!({
+        "palace": palace,
+        "subject": subject,
+        "predicate": predicate,
+        "object": object,
+        "closed": closed,
+        "retracted": closed > 0,
+    });
+    if closed == 0 {
+        response["reason"] = Value::String(
+            "no active triple with that exact (subject, predicate, object)".to_string(),
+        );
+    }
+    Ok(response)
+}
+
 pub(crate) async fn handle_add_alias(state: &AppState, args: Value) -> Result<Value> {
     let short = args
         .get("short")

--- a/crates/trusty-memory/src/tools/mod.rs
+++ b/crates/trusty-memory/src/tools/mod.rs
@@ -20,6 +20,7 @@
 //! - `room_create(palace, label, description?)`     -> room_id (idempotent)
 //! - `room_rename(palace, room, new_label)`         -> renamed room
 //! - `kg_assert(palace, subject, predicate, object, confidence?, provenance?)` -> ()
+//! - `kg_retract_triple(palace, subject, predicate, object)` -> closed count
 //! - `kg_query(palace, subject)`                    -> Vec<Triple>
 //! - `kg_list_subjects(palace, limit?, with_counts?)` -> subjects (#4776)
 //! - `wing_list(palace)`                            -> Vec<WingSummary>
@@ -70,7 +71,8 @@ use dream_ops::{handle_dream_consolidate_room, handle_palace_dream};
 use kg_ops::{
     handle_add_alias, handle_discover_aliases, handle_get_prompt_context, handle_kg_assert,
     handle_kg_bootstrap, handle_kg_gaps, handle_kg_list_subjects, handle_kg_query,
-    handle_list_prompt_facts, handle_remove_prompt_fact, handle_upgrade_tool,
+    handle_kg_retract_triple, handle_list_prompt_facts, handle_remove_prompt_fact,
+    handle_upgrade_tool,
 };
 use memory_ops::{
     handle_memory_forget, handle_memory_list, handle_memory_note, handle_memory_recall,
@@ -107,6 +109,9 @@ pub async fn dispatch_tool(state: &AppState, name: &str, args: Value) -> Result<
         "palace_delete" => handle_palace_delete(state, args).await,
         "palace_update" => handle_palace_update(state, args).await,
         "kg_assert" => handle_kg_assert(state, args).await,
+        // The inverse of `kg_assert`: closes one (subject, predicate, object)
+        // and leaves the pair's other objects live.
+        "kg_retract_triple" => handle_kg_retract_triple(state, args).await,
         "add_alias" => handle_add_alias(state, args).await,
         "list_prompt_facts" => handle_list_prompt_facts(state, args).await,
         "remove_prompt_fact" => handle_remove_prompt_fact(state, args).await,

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -193,6 +193,8 @@ fn tool_definitions_lists_all_tools() {
         "palace_reembed",
         "palace_unalias",
         "kg_assert",
+        // The inverse of `kg_assert`, on the full triple key.
+        "kg_retract_triple",
         "kg_query",
         // #4776: subject enumeration over MCP.
         "kg_list_subjects",
@@ -535,6 +537,13 @@ async fn dispatch_kg_assert_then_query() {
     assert_eq!(triples[0]["object"], "Acme");
     assert_eq!(triples[0]["predicate"], "works_at");
 }
+
+/// Why: this file is at the 3000-SLOC test cap, so a new tool's dispatch tests
+/// live in a child module rather than pushing it over.
+/// What: `kg_retract_triple`'s tests; they read `super::*` for `test_state` and
+/// the imports above.
+/// Test: the module itself.
+mod kg_retract_tests;
 
 /// Why: #4776 — `kg_list_subjects` is the discovery read that makes `kg_query`
 /// usable without already knowing a subject, so the contract that matters is

--- a/crates/trusty-memory/src/tools/tests/kg_retract_tests.rs
+++ b/crates/trusty-memory/src/tools/tests/kg_retract_tests.rs
@@ -151,3 +151,69 @@ async fn dispatch_kg_retract_triple_requires_object() {
         "unexpected error: {err}"
     );
 }
+
+/// Why: every other test in this module retracts under `works_at`, which
+/// `is_hot_predicate` rejects — so the prompt-cache-rebuild branch in
+/// `handle_kg_retract_triple` (`kg_ops.rs:128-134`) never actually runs in
+/// this suite. The branch is correct as written, but nothing stops a later
+/// edit from inverting the condition or dropping the call while every
+/// existing test stays green, and the hazard is exactly the one the
+/// handler's own doc names: a retracted Tier S fact kept being injected
+/// into every session's prompt.
+/// What: asserts a fact under the hot predicate `is_fact`, confirms
+/// `get_prompt_context` surfaces it, retracts it, and confirms a second
+/// `get_prompt_context` call no longer contains the retracted object —
+/// which only happens if the retraction path rebuilds the cache.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_kg_retract_triple_rebuilds_prompt_cache_for_hot_predicate() {
+    let (state, _tmp) = test_state();
+    let _ = dispatch_tool(&state, "palace_create", json!({"name": "hot"}))
+        .await
+        .expect("palace_create");
+
+    let _ = dispatch_tool(
+        &state,
+        "kg_assert",
+        json!({
+            "palace": "hot",
+            "subject": "msrv-rule",
+            "predicate": "is_fact",
+            "object": "MSRV is 1.94",
+        }),
+    )
+    .await
+    .expect("kg_assert");
+
+    let before = dispatch_tool(&state, "get_prompt_context", json!({}))
+        .await
+        .expect("get_prompt_context after assert");
+    let before_text = before.as_str().expect("string body");
+    assert!(
+        before_text.contains("MSRV is 1.94"),
+        "hot fact should be in the prompt cache before retraction: {before_text}"
+    );
+
+    let retracted = dispatch_tool(
+        &state,
+        "kg_retract_triple",
+        json!({
+            "palace": "hot",
+            "subject": "msrv-rule",
+            "predicate": "is_fact",
+            "object": "MSRV is 1.94",
+        }),
+    )
+    .await
+    .expect("kg_retract_triple");
+    assert_eq!(retracted["closed"], 1);
+
+    let after = dispatch_tool(&state, "get_prompt_context", json!({}))
+        .await
+        .expect("get_prompt_context after retract");
+    let after_text = after.as_str().expect("string body");
+    assert!(
+        !after_text.contains("MSRV is 1.94"),
+        "retracted hot fact must not still be injected into the prompt: {after_text}"
+    );
+}

--- a/crates/trusty-memory/src/tools/tests/kg_retract_tests.rs
+++ b/crates/trusty-memory/src/tools/tests/kg_retract_tests.rs
@@ -1,0 +1,153 @@
+//! Dispatch tests for the `kg_retract_triple` MCP tool.
+//!
+//! Why: `tools/tests.rs` sits against the 3000-SLOC test cap, so a new tool's
+//! tests ship as a child module rather than pushing that file over it.
+//! What: `use super::*` inherits the parent test module's imports and its
+//! `test_state` helper, so each test reads exactly as it would in-place.
+//! Test: this IS the test module.
+
+use super::*;
+
+/// Why: `kg_retract_triple` exists to take back ONE wrong object, so the
+/// contract that matters is that the named object goes and its siblings at the
+/// same `(subject, predicate)` pair stay — the exact over-deletion that made
+/// pair-level `retract` unusable as an undo.
+/// What: asserts two objects under one pair, retracts one over the dispatcher,
+/// and reads the survivors back through `kg_query`.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_kg_retract_triple_closes_one_object_and_keeps_siblings() {
+    let (state, _tmp) = test_state();
+    let _ = dispatch_tool(&state, "palace_create", json!({"name": "retract"}))
+        .await
+        .expect("palace_create");
+    for object in ["Acme", "Globex"] {
+        let _ = dispatch_tool(
+            &state,
+            "kg_assert",
+            json!({
+                "palace": "retract",
+                "subject": "alice",
+                "predicate": "works_at",
+                "object": object,
+            }),
+        )
+        .await
+        .expect("kg_assert");
+    }
+
+    let retracted = dispatch_tool(
+        &state,
+        "kg_retract_triple",
+        json!({
+            "palace": "retract",
+            "subject": "alice",
+            "predicate": "works_at",
+            "object": "Acme",
+        }),
+    )
+    .await
+    .expect("kg_retract_triple");
+    assert_eq!(retracted["closed"], 1);
+    assert_eq!(retracted["retracted"], true);
+    assert!(
+        retracted.get("reason").is_none(),
+        "a successful retraction carries no no-op reason: {retracted}"
+    );
+
+    let queried = dispatch_tool(
+        &state,
+        "kg_query",
+        json!({"palace": "retract", "subject": "alice"}),
+    )
+    .await
+    .expect("kg_query");
+    let triples = queried["triples"].as_array().expect("triples array");
+    assert_eq!(triples.len(), 1, "sibling object survived: {queried}");
+    assert_eq!(triples[0]["object"], "Globex");
+}
+
+/// Why: a retraction that matches nothing must be legible rather than silent —
+/// a caller cannot otherwise tell "removed it" from "there was nothing there",
+/// which is what makes the second call of an idempotent retry safe to read.
+/// What: retracts a triple that was never asserted, then retracts a real one
+/// twice, and checks `closed` reports 0 with a `reason` both times.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_kg_retract_triple_missing_triple_is_a_legible_noop() {
+    let (state, _tmp) = test_state();
+    let _ = dispatch_tool(&state, "palace_create", json!({"name": "noop"}))
+        .await
+        .expect("palace_create");
+
+    let never_asserted = dispatch_tool(
+        &state,
+        "kg_retract_triple",
+        json!({
+            "palace": "noop",
+            "subject": "ghost",
+            "predicate": "works_at",
+            "object": "Nowhere",
+        }),
+    )
+    .await
+    .expect("kg_retract_triple on an absent triple is not an error");
+    assert_eq!(never_asserted["closed"], 0);
+    assert_eq!(never_asserted["retracted"], false);
+    assert!(
+        never_asserted["reason"].as_str().is_some(),
+        "the no-op says why: {never_asserted}"
+    );
+
+    let _ = dispatch_tool(
+        &state,
+        "kg_assert",
+        json!({
+            "palace": "noop",
+            "subject": "alice",
+            "predicate": "works_at",
+            "object": "Acme",
+        }),
+    )
+    .await
+    .expect("kg_assert");
+    let args = json!({
+        "palace": "noop",
+        "subject": "alice",
+        "predicate": "works_at",
+        "object": "Acme",
+    });
+    let first = dispatch_tool(&state, "kg_retract_triple", args.clone())
+        .await
+        .expect("first retract");
+    let second = dispatch_tool(&state, "kg_retract_triple", args)
+        .await
+        .expect("second retract");
+    assert_eq!(first["closed"], 1);
+    assert_eq!(second["closed"], 0, "retraction is idempotent: {second}");
+}
+
+/// Why: omitting `object` must fail loudly. The neighbouring pair-level
+/// `KnowledgeGraph::retract` would close every object at the pair, so a
+/// silently-defaulted object is the one mistake that turns an undo into data
+/// loss.
+/// What: dispatches without `object` and checks the error names the argument.
+/// Test: this test.
+#[tokio::test]
+async fn dispatch_kg_retract_triple_requires_object() {
+    let (state, _tmp) = test_state();
+    let _ = dispatch_tool(&state, "palace_create", json!({"name": "strict"}))
+        .await
+        .expect("palace_create");
+    let err = dispatch_tool(
+        &state,
+        "kg_retract_triple",
+        json!({"palace": "strict", "subject": "alice", "predicate": "works_at"}),
+    )
+    .await
+    .expect_err("missing object must error");
+    assert!(
+        err.to_string().contains("missing 'object'"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
**Outcome.** No `Closes` line — there is no issue for this, by owner instruction ("don't file, just fix"). The gap was found empirically: a daemon verification created a KG test triple and could not retract it through any exposed MCP tool.

**What changed / out of scope.** Adds `kg_retract_triple`, wired to `KnowledgeGraph::retract_triple` (the trusty-common primitive that landed in #5412). Response is `{palace, subject, predicate, object, closed, retracted}`, plus `reason` when `closed == 0`. `object` is required — omitting it errors rather than silently widening to the whole pair. A hot-predicate retraction rebuilds the prompt cache, mirroring what `handle_kg_assert` does on the write side; without it a retracted Tier S fact keeps being injected.

Name choice: `_triple` names the key it takes. In this codebase `retract` means the whole `(subject, predicate)` pair, so a tool called `kg_retract` beside `kg_assert` would read as the pair-level operation and invite the over-deletion #5396 was about.

**`MemoryService::kg_retract_triple` (`service/core_kg.rs:108`) does not do what its name says.** It calls `handle.kg.retract(subject, predicate)` — the pair-level close — takes no `object`, and returns `bool`. It backs the HTTP route `kg_delete_triple` (`web/kg_routes.rs:284`), so an HTTP caller asking to delete one triple closes every object at that pair. That is the over-deletion #5396 exists to prevent, on a shipped endpoint. This PR does not fix it — the handler deliberately bypasses that method and calls `handle.kg.retract_triple` directly, which is also how `handle_kg_assert`, `handle_kg_query` and `handle_kg_list_subjects` already work (`MemoryService` is the HTTP adapter, not a tool-layer dependency). The HTTP path is being fixed separately.

A second, deliberate consequence: the diff does not touch `service/core_kg.rs` at all, so it cannot conflict with `fix/5384-count-active-triples-fail-open`. The only shared file is `tools/kg_ops.rs`, where this change is one self-contained inserted function.

**Also in this PR — a standing owner-ruled doc fix.** The `kg_list_subjects` description at `tools/definitions.rs` carried two stale claims, both required to be corrected by the next PR touching that file:
- "a subject that does not exist returns the same empty result as an empty graph" — false since #5385 (`41ca5c647`); `handle_kg_query` now returns `graph_state: "subject_not_found"` or `"graph_empty"` with a hint.
- "`truncated: true` means the page filled to `limit`" — false since #4810; the handler over-fetches `limit + 1` and sets `truncated` only when the extra row comes back, so a page that exactly fills `limit` reports `false`. `dispatch_kg_list_subjects_exact_limit_is_not_truncated` already proves it.

Also changed "alphabetically" to "ordered by subject" — the store iterates redb key order over raw subject bytes, which is not alphabetical for mixed case.

**Risk / blast radius.** MCP tool-schema addition, a public API surface. Tool count 46 → 47. No behaviour change to any existing tool.

**Test evidence — rung 6.** Rung 6 is owed because this is an API-surface change, and it was met with direct evidence rather than crate tests alone: an isolated throwaway daemon on `127.0.0.1:53852` under `TRUSTY_DATA_DIR_OVERRIDE`, real JSON-RPC `initialize` → `tools/list` handshake showing the served schema, then end-to-end — assert two objects at one pair, retract one (`closed: 1`), retract again (`closed: 0` with `reason`), and `kg_query` confirming the sibling `Globex` still active. The live `com.trusty.memory` daemon was neither contacted nor restarted.

Gates all exit 0: `fmt --check`; `clippy -p trusty-memory --all-targets -- -D warnings`; `check --workspace`; `test -p trusty-memory` → 711 passed, 0 failed, 4 ignored, 27 binaries; line-cap 0 violations; SLD 0 errors; changelog fragments valid.

**Documentation / changelog.** Two fragments (the changelog gate rejects a single fragment carrying two categories). `README.md` regenerated via `UPDATE_DOCS=1 cargo test -p trusty-memory --test generated_docs`.

Note the SLOC-cap handling: the new tests pushed `tools/tests.rs` to 3005 SLOC, over the 3000 test cap, so the split happened in this PR per the no-standalone-cap-fix rule — the tests moved to `tools/tests/kg_retract_tests.rs` as a child module with `use super::*`. No coverage moved or disappeared.

**Review disposition.** No critic round yet.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
