### PR TITLE
chore(trusty-search): patch bump to 0.45.1, republish trusty-common dependents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11802,7 +11802,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.45.0"
+version = "0.45.1"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary

trusty-common 0.32.0 is live on crates.io. Three dependents pin `version = "0.32"` in-tree but were never republished after their own version fields moved:

| Crate | In-tree | Published (crates.io) | Target | Action |
|---|---|---|---|---|
| trusty-search | 0.45.0 | 0.45.0 | 0.45.1 | real patch bump (this PR) |
| trusty-memory | 0.22.0 | 0.21.2 | 0.22.0 | already ahead (#4210 bumped, never published) — publish as-is, no PR change |
| trusty-gworkspace | 0.2.2 | none live (only 0.1.0, yanked) | 0.2.2 | already ahead — publish as-is, no PR change |

Only trusty-search needed a Cargo.toml edit — trusty-memory and trusty-gworkspace are already at their target versions on main, so publishing them is a tag+publish operation with no code change (tracked separately, not in this PR).

`trusty-search-v0.45.0`'s tag and `trusty-gworkspace-v0.2.2`'s tag are already pushed to origin; `trusty-memory-v0.22.0` was tagged and pushed directly (Cargo.toml already carried that version on merged main, so no PR change was needed for it either).

Checked every direct `version = "..."` requirement on these three crates elsewhere in the workspace (`grep -rn 'trusty-gworkspace\|trusty-memory\|trusty-search' --include=Cargo.toml .`): `trusty-agents` pins `trusty-search` with the caret range `"0.45"`, which already covers `0.45.1` — no other pin needed to move.

## Gate rung

Rung 3 (localized, version-only change):

- `cargo fmt --check`: pass
- `cargo check --workspace`: pass
- `cargo test -p trusty-search`: 1582 + 387 + ... all ok, 0 failed
- `cargo test -p trusty-memory`: 708 + ... all ok, 0 failed
- `cargo test -p trusty-gworkspace`: 259 + ... all ok, 0 failed

`Cargo.lock`: targeted `cargo update -p trusty-search --precise 0.45.1` only — single entry moved (verified via `git diff Cargo.lock`), no transitive drift.

No `CHANGELOG.md` hand-edits — fragment/assembly is a separate PR near publish time, per repo precedent.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
