### PR TITLE
chore(trusty-common): bump 0.32.0 -> 0.33.0 (breaking count_active_triples)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11398,7 +11398,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ trusty-code = { path = "crates/trusty-code" }
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.5.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.32" }
+trusty-common = { path = "crates/trusty-common", version = "0.33" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.10" }

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.32.0"
+version = "0.33.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -15,7 +15,7 @@ name = "trusty-gworkspace-mcp"
 path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.32", features = ["mcp"] }
+trusty-common = { path = "../trusty-common", version = "0.33", features = ["mcp"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -83,7 +83,7 @@ path = "src/bin/mcp_bridge.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.32", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "uds-supervisor", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config"] }
+trusty-common = { path = "../trusty-common", version = "0.33", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "uds-supervisor", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside
@@ -180,7 +180,7 @@ serial_test = { workspace = true }
 # the production library (mirrors the trusty-mpm and trusty-search pattern).
 # `docgen` (#5205 follow-up): `tests/generated_docs.rs` renders the MCP tool
 # section of README.md from `tool_definitions()`.
-trusty-common = { path = "../trusty-common", version = "0.32", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
+trusty-common = { path = "../trusty-common", version = "0.33", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
 chrono = { workspace = true }
 
 [features]

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -54,7 +54,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.32", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "crate-config", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "codex-config"] }  # `config-cli` (#2405): implies `credentials`, giving both the shared `.env.local` loader `load_env_local_once` (retiring trusty-search's ad hoc dotenvy call) AND the embeddable `ConfigKeysCommand` nested under `trusty-search config keys …`  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
+trusty-common = { version = "0.33", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "crate-config", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "codex-config"] }  # `config-cli` (#2405): implies `credentials`, giving both the shared `.env.local` loader `load_env_local_once` (retiring trusty-search's ad hoc dotenvy call) AND the embeddable `ConfigKeysCommand` nested under `trusty-search config keys …`  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
 
 # ── Bundled sidecars ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue
@@ -258,7 +258,7 @@ filetime = "0.2"
 # docgen (#5205 follow-up): `tests/generated_docs.rs` renders the MCP tool
 # section of README.md / CLAUDE.md from `tool_descriptors()`. Test-facing
 # only, so the feature is enabled here rather than on the production dep.
-trusty-common = { version = "0.32", default-features = false, features = ["docgen"] }
+trusty-common = { version = "0.33", default-features = false, features = ["docgen"] }
 
 [features]
 # Default: bundle ORT static libs via trusty-embedder. Works on macOS and


### PR DESCRIPTION
## Summary

Bumps `trusty-common` **0.32.0 -> 0.33.0** to unblock publishing `trusty-memory`.

Published `trusty-common` 0.32.0 (squash `8e6ca079dffc8eaac8d83e080282edc62b7dc71c`) has diverged from in-tree "0.32.0": PR #5489 (`0bbbb394d`, "surface KG count-read failures instead of reporting zero") changed `count_active_triples()` from a bare return value to `Result<_, _>` — in `crates/trusty-common/src/memory_core/store/kg/ops.rs:78` and `kg_redb/read_ops.rs:192` — without a version bump. Published 0.32.0 and in-tree "0.32.0" therefore disagree, and `trusty-memory` 0.22.0 fails to build against the published crate (7 `E0308` errors in `src/chat/handler.rs:141-142`, `src/service/core_kg.rs:166,212`, `src/tools/kg_ops.rs:317`, `src/service/helpers.rs:336-337`).

A return-type change is breaking. Cargo's 0.x rule puts the breaking position at MINOR for a `0.y.z` crate, so the correct target is **0.33.0**, not 0.32.1 — a breaking change on a patch bump is the #4088 failure mode that cost `trusty-analyze` 0.7.3 a yank.

`cargo-semver-checks` / `scripts/check_semver.sh` could not verify this bump — known-broken for this crate (#5440) and a multi-minute compile that has wedged agents on this chain. This rests on manual review: `git diff 8e6ca079d..origin/main -- crates/trusty-common/src/` shows `count_active_triples` (both the `KnowledgeGraph` facade and the underlying `KgStoreRedb` impl) as the **only** public-API change in that range — #5489 is the sole divergence, not one of several.

## Changes

- `crates/trusty-common/Cargo.toml`: `version = "0.33.0"`
- Six version pins moved `"0.32"` -> `"0.33"`:
  - root `Cargo.toml` `[workspace.dependencies]`
  - `crates/trusty-gworkspace/Cargo.toml:18`
  - `crates/trusty-memory/Cargo.toml:86,183`
  - `crates/trusty-search/Cargo.toml:57,261`
- `Cargo.lock`: minimal update via `cargo update -p trusty-common` — one entry moved (0.32.0 -> 0.33.0), no transitive churn.
- No changelog fragment: version bumps with no `src/**` behavior change are out of scope for the fragment gate; changelog assembly is a separate PR by repo precedent.

## Test plan (Rung 4 — cross-crate library change)

- [x] `cargo fmt --check` — EXIT=0
- [x] `cargo check --workspace` — EXIT=0
- [x] `cargo test -p trusty-common` — 323 passed; 0 failed; 6 ignored
- [x] `cargo check -p trusty-memory` — EXIT=0, compiles clean in-tree against `trusty-common v0.33.0`
- [ ] `cargo-semver-checks` — intentionally skipped (#5440, known-broken for this crate)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools