### PR TITLE
chore(trusty-search): bump to 0.46.0 for pending breaking API change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11802,7 +11802,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.45.1"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -66,7 +66,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.22", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.45" }
+trusty-search = { path = "../trusty-search", version = "0.46" }
 # Gmail/Calendar eventstream listeners (#3820, DOC-54 SPEC-AGENTS-06) call
 # trusty-gworkspace's connector layer (`api::client::BaseClient` +
 # `api::services::gmail::*`) DIRECTLY as library functions — the same code

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.45.1"
+version = "0.46.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Why

trusty-search 0.45.1 is published on crates.io (confirmed via the
crates.io API, published 2026-08-11T19:41:36Z). PR #5514 (closes #5505)
makes a breaking library-API change: `save_then_merge_contrib` and
`CodeIndexer::rebuild_symbol_graph_now` both change their return-type
signature, and both are reachable from `lib.rs` — confirmed by reading
the signatures directly, branch vs. main:

- `save_then_merge_contrib`: `Arc<SymbolGraph>` -> `(Option<Arc<SymbolGraph>>, ContribMergeOutcome)`
- `CodeIndexer::rebuild_symbol_graph_now`: `()` -> `ContribMergeOutcome`

Reachability: `lib.rs` has `pub mod core`; `core/mod.rs` has `pub mod
symbol_graph` and re-exports `CodeIndexer`; `symbol_graph/mod.rs` has
`pub use contrib::{save_then_merge_contrib, ...}`. Both symbols are on
the public path.

Under Cargo's 0.x rule the breaking bump is the minor position, so
0.45.1 -> 0.46.0.

## Why a standalone version-only PR, off main, not on #5514's branch

#5506, #5504, #5507, and #5510 all touch `crates/trusty-search/src/**`
and are all currently at 0.45.1 — now that 0.45.1 is the published
version, the PR-version-vs-crates.io gate fails on all of them. This PR
merges first so those four rebase onto main and inherit 0.46.0 in one
move, rather than each depending on #5514 (still under review) merging
first. Mirrors #5508's shape for the prior 0.45.1 bump.

## Semver-gate evidence and its limits

`scripts/check_semver.sh --crate trusty-search` gives **NO VERDICT**
(exit 3) on this machine: it builds rustdoc with every declared
feature, including `cuda`, and `nvcc` is absent here. That is a
fail-open, not a pass — not cited as evidence for this bump.

Ran it again with a local (uncommitted, not part of this PR) addition
to `scripts/semver-checks-feature-exclusions.tsv` excluding
`trusty-search`'s `cuda` feature, against PR #5514's branch (commit
782448acc, declared version still 0.45.1 there). That produced a real
verdict — `Checked 196 checks: 196 pass, 0 fail, 58 skip` — but did
**not** flag the two return-type changes above. Reported for
completeness; not treated as contradicting the manual signature
reading, since the automated tool evidently doesn't catch this
particular class of change (a function's return type changing to a
different, larger type) under its current lint set. The signature
reading is the load-bearing evidence for this bump, not the tool.

## What's in this PR

- `crates/trusty-search/Cargo.toml`: `0.45.1` -> `0.46.0`
- `Cargo.lock`: only the matching `trusty-search` package entry
  (verified: single-line diff, no `cargo update` run)
- `crates/trusty-agents/Cargo.toml:69`: `version = "0.45"` ->
  `version = "0.46"` (caret requirement that 0.46.0 would not satisfy
  otherwise) — the only other version-requirement site found; searched
  every `Cargo.toml` in the workspace for a `trusty-search = { ...
  version = ... }` dependency line

No `crates/trusty-search/src/**` changes, so no changelog fragment is
owed (docs/CI-only-shaped change; matches the version-bump-PR
precedent in #5508).

## Verification

- `cargo check -p trusty-search --locked`: exit 0
- `cargo check -p trusty-agents --locked`: exit 0 (`Finished` dev
  profile, 3m23s) — confirms the workspace resolves `trusty-search`
  0.46.0 through the `trusty-agents` path dependency's updated version
  requirement with no lockfile drift
- `cargo fmt --check -p trusty-search -p trusty-agents`: exit 0

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools