### PR TITLE
docs(trusty-memory): name the cross-crate test in prose so the pointer lint resolves

### DIFF
--- a/crates/trusty-memory/changelog.d/5489-cross-crate-test-pointer.md
+++ b/crates/trusty-memory/changelog.d/5489-cross-crate-test-pointer.md
@@ -1,0 +1,4 @@
+Documentation
+
+- `kg_triple_count_or_zero`'s `Test:` pointer now names its cross-crate coverage in prose ([#5489](https://github.com/bobmatnyc/trusty-tools/pull/5489))
+  - The citation of `count_active_triples_surfaces_read_failure` sat in the leading backtick run, where `scripts/check_test_pointers.sh` resolves names only against the citing crate. The test is real and lives in `trusty-common`, so the pointer lint read it as dangling and went red on main.

--- a/crates/trusty-memory/src/service/helpers.rs
+++ b/crates/trusty-memory/src/service/helpers.rs
@@ -328,9 +328,12 @@ fn wing_registry_count(handle: &Arc<PalaceHandle>) -> Option<usize> {
 /// the degrade in one named helper is what stops it from sinking back into the
 /// store where no caller can see it.
 /// What: logs the error at warn with the palace id and returns 0.
-/// Test: `status_does_not_open_uncached_palaces`,
-/// `trusty_common::…::count_active_triples_surfaces_read_failure` (the error
-/// this converts).
+/// Test: `status_does_not_open_uncached_palaces`. The read error this converts
+/// is covered cross-crate, in
+/// `crates/trusty-common/src/memory_core/store/kg_redb/tests.rs`, by
+/// `count_active_triples_surfaces_read_failure` — named in prose because
+/// `scripts/check_test_pointers.sh` resolves a cited name only within the
+/// citing crate.
 pub(crate) fn kg_triple_count_or_zero(handle: &Arc<PalaceHandle>) -> usize {
     match handle.kg.count_active_triples() {
         Ok(n) => n,


### PR DESCRIPTION
**What was red.** The Doc-comment pointer lint workflow has been failing on main since `0bbbb394d` (#5489):

```
FAIL: crates/trusty-memory/src/service/helpers.rs:331: Test: pointer cites
`count_active_triples_surfaces_read_failure` — no `fn …(` or `mod …` found in
crate `crates/trusty-memory`.
test-pointers: 1 dangling pointer(s), 0 stale allowlist entries — FAILED.
```

Not a required context, which is why it sat red.

**The cited test exists.** `count_active_triples_surfaces_read_failure` is a real `#[test] fn` at `crates/trusty-common/src/memory_core/store/kg_redb/tests.rs:151`. #5489 shipped the coverage it claimed — this is a citation-placement problem, not a phantom test and not a rename.

**Why it could never resolve.** `check_test_pointers.sh` splits a `::`-qualified citation, keeps only the final segment, and resolves it against the citing file's own crate (nearest ancestor `Cargo.toml` = `crates/trusty-memory`). The `trusty_common::…::` prefix is discarded, so a cross-crate citation inside a backtick span is unresolvable by construction. That is documented behaviour, not a script bug — the PRECISION LIMITS block at `scripts/check_test_pointers.sh:82-88` states it and names the accepted alternative: cross-crate citations name the crate **in prose**, outside the leading backtick run so it is never scanned.

**The fix.** The annotation now ends its scannable run after the in-crate citation and names the cross-crate test, with its file path, in prose after the terminating `.`. `status_does_not_open_uncached_palaces` still resolves and is still checked. Nothing deleted, nothing allowlisted, no test moved, and the scan floor untouched.

**State the residual limitation plainly, do not bury it:** the prose form is unverified by construction. If the trusty-common test is renamed, nothing catches it. Teaching the gate to resolve a crate-qualified citation against the named crate is a real option, deliberately out of scope here because it changes a gate that resolves 23,733 citations.

**Gates:**
```
check_test_pointers.sh (clean clone @ 28e93489, PRE-fix)  EXIT=1  1 dangling pointer — FAILED
check_test_pointers.sh (this branch)                      EXIT=0  resolved 23733 citations (floor 200), 0 dangling — OK
check_scan_floor_selftest.sh test_pointers                EXIT=0  1 gate correctly refuses a vacuous scan
check_sld.sh                                              EXIT=0  57 spec docs + 3218 code files, 0 errors
cargo fmt --check                                         EXIT=0
cargo check -p trusty-memory                              EXIT=0
check_changelog_fragment.sh                               EXIT=0
```

Add this note verbatim, it is worth recording: the first baseline run was contaminated — the edit landed mid-scan, before the scanner reached `trusty-memory` alphabetically, and printed a false green. The PRE-fix row above is a re-run in a throwaway clone checked out at the pre-fix commit.

**A changelog fragment was owed** and is included (`crates/trusty-memory/changelog.d/5489-cross-crate-test-pointer.md`, category Documentation) — `helpers.rs` is under `crates/trusty-memory/src/**` and the fragment gate has no comment-only exemption.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
