### PR TITLE
fix(ci): SemVer gate must not read zero executed checks as a pass (#5440)

### DIFF
--- a/docs/reference/semver-gate.md
+++ b/docs/reference/semver-gate.md
@@ -159,12 +159,36 @@ checks: …`). No summary line means no comparison happened — whatever the exi
 status was, *including exit 0* — and that is reported as `NO VERDICT` on its own
 exit status.
 
+### Zero checks executed is not a pass ([#5440](https://github.com/bobmatnyc/trusty-tools/issues/5440))
+
+The summary line alone was not enough. `cargo-semver-checks` skips its whole lint
+set when the baseline → current delta already permits breakage, and prints a
+summary saying so at exit 0:
+
+```
+Checking trusty-common v0.31.0 -> v0.30.1 (major change)
+ Checked [   0.000s] 0 checks: 0 pass, 254 skip
+ Summary no semver update required
+```
+
+The leading `0 checks:` is the number of lints that **ran**; the trailing
+`254 skip` is what the tool declined to run. Keying on the line's presence read
+that as a pass, so `preflight-publish.sh` CHECK 5 approved the publish having
+verified nothing. Measured on `trusty-common` under rustc 1.94.1; the gate failed
+closed on that machine only because a newer installed toolchain crashed rustdoc
+instead, which produced no summary at all.
+
+The gate now parses the count and requires it to be at least 1. A summary whose
+count is zero, or does not parse, is `NO VERDICT` (exit 3) and says which of the
+two happened — "executed no checks" and "never completed a check run" have
+different remedies.
+
 | Exit | Meaning |
 |---|---|
 | 0 | every checked crate is clean, or is a recorded skip |
 | 1 | a verdict was computed **and it says break** — the only status that means "the API changed" |
 | 2 | usage error |
-| 3 | **no verdict** — rustdoc build failure, unreachable registry, missing tool, or a diff that scanned nothing. Nothing was compared, so nothing may be concluded. |
+| 3 | **no verdict** — rustdoc build failure, a run that executed zero checks, unreachable registry, missing tool, or a diff that scanned nothing. Nothing was compared, so nothing may be concluded. |
 
 `scripts/preflight-publish.sh` CHECK 5 and `.github/workflows/semver-checks.yml`
 both report exit 3 separately from exit 1. Both still stop the publish: a
@@ -313,6 +337,14 @@ never reach the version-bump remediation; an exit-0 run that compared nothing
 must still fail; and a genuinely clean run must exit 0, which is what proves the
 other three fail on classification rather than because the gate is broken
 outright.
+
+Cases 20-21 (#5440) pin the other way a completed run says nothing: a summary
+reporting `0 checks: 0 pass, 254 skip` at exit 0 must be `NO VERDICT` in the
+pass/fail arm and a blind inventory in the advisory one, never "no breaking
+changes found". Both fail against the pre-fix gate, which exits 0 on the first
+and reports an empty inventory on the second. Their fixture, `all-skipped.out`,
+is the former `clean.out` — the case that was supposed to prove the gate can pass
+a crate was itself being satisfied by a run that checked nothing.
 
 Those four replace only the `cargo semver-checks` subprocess, via a stub `cargo`
 on `PATH` that forwards everything else to the real one — so crate resolution,

--- a/scripts/check_semver.sh
+++ b/scripts/check_semver.sh
@@ -95,7 +95,10 @@
 #   requires a matching version bump" remediation below, so a rustdoc error was
 #   presented as a SemVer verdict and the two were indistinguishable from the
 #   output. The gate now classifies on POSITIVE EVIDENCE instead: a verdict
-#   exists only when the tool printed its own per-crate `N checks:` summary line.
+#   exists only when the tool printed its own per-crate `N checks:` summary line
+#   AND that line says at least one check RAN (issue #5440 — a summary reporting
+#   `0 checks: 0 pass, 254 skip` is the tool declining to compare, and the gate
+#   used to read it as a pass).
 #   No summary line means no comparison happened, whatever the exit status was —
 #   including exit 0 — and that is reported as NO VERDICT on its own exit code.
 #   Absence of evidence is never a pass; same rule as the scan floor below.
@@ -164,7 +167,9 @@
 #   declared 1.0.1, which selected 1.0.0-rc1 before the rank element existed.
 #   Cases 16-18 (#5500) replay PR #5458's own CI bytes, where forced colour hid the
 #   summary line and both a clean run and a four-failure run were reported as
-#   never having happened.
+#   never having happened. Cases 20-21 (#5440) pin the zero-check false pass:
+#   a summary that says `0 checks: 0 pass, 254 skip` at exit 0 is NO VERDICT in
+#   the PASS/FAIL arm and a BLIND inventory in the advisory one.
 #   The catch itself is demonstrated in PR #5051 against #4088's real shape.
 #
 # Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
@@ -666,9 +671,33 @@ PY
 
 # ---------------------------------------------------------------------------
 # verdict_computed <output-file> — succeed only when cargo-semver-checks printed
-# its own per-crate check summary, e.g.
-#     Checked [   0.388s] 223 checks: 214 pass, 9 fail, 0 warn, 31 skip
-#     Checked [   0.000s] 0 checks: 0 pass, 254 skip
+# its own per-crate check summary AND that summary says it actually EXECUTED at
+# least one check, e.g.
+#     Checked [   0.388s] 223 checks: 214 pass, 9 fail, 0 warn, 31 skip   <- verdict
+#     Checked [   0.000s] 0 checks: 0 pass, 254 skip                      <- NOT one
+#
+# ZERO CHECKS EXECUTED IS NOT A PASS (issue #5440). The leading `N checks:` count
+#   is the number of lints the tool RAN; the trailing `N skip` is what it declined
+#   to run. When the version delta is one that permits breakage — a major bump
+#   under Cargo's rules, which for a 0.y.z crate is any change to the MINOR
+#   position — every lint is skipped, the tool prints
+#
+#       Checked [   0.000s] 0 checks: 0 pass, 254 skip
+#       Summary no semver update required
+#
+#   and exits 0. Until this fix the presence of that summary line WAS the verdict
+#   test, so the gate read "the tool declined to check anything" as "the tool
+#   found nothing wrong" and preflight-publish.sh CHECK 5 passed having verified
+#   nothing. Measured on trusty-common under rustc 1.94.1: 0 of 254 checks run,
+#   gate exit 0. It failed closed on this machine only by accident — under the
+#   newest installed toolchain the same crate crashed rustdoc, printed no summary
+#   at all, and was correctly classified NO VERDICT. Removing that toolchain
+#   would have turned the gate green for every publish.
+#
+#   Same family as `cargo test -- <name> --exact` printing `running 0 tests` and
+#   exiting 0: work not done must never read as work passed. So the count is
+#   asserted, not merely the marker. A summary whose count does not parse is also
+#   NO VERDICT — this fails closed, like every other branch here.
 #
 # Why a MARKER and not the exit status: the tool's statuses are not a contract
 #   the gate can lean on, and observation shows they collide. 101 is a rustdoc
@@ -726,11 +755,50 @@ PY
 #   strip cannot manufacture a marker either: it only deletes escape sequences,
 #   so text that did not say `Checked … N checks:` still does not.
 # ---------------------------------------------------------------------------
+# Set by verdict_computed on every refusal, read by no_verdict_because. Three
+# shapes: `no-summary`, `zero-checks:<the line>`, `unparsable-count:<the line>`.
+VERDICT_REASON=""
+
 verdict_computed() {
   # #5500: CARGO_TERM_COLOR=always splits `Checked` from its trailing space (PR #5458).
-  local plain="${1}.plain"
+  local plain="${1}.plain" summary executed
+  VERDICT_REASON="no-summary"
   LC_ALL=C sed -E $'s/\033\\[[0-9:;<=>?]*[ -/]*[@-~]//g' "$1" > "$plain" || return 1
-  grep -Eq '(^|[[:space:]])Checked[[:space:]].*[0-9]+ checks:' "$plain"
+
+  # `tail -1` and not `grep -q`: the header explains why a short-circuiting
+  # reader is wrong here, and the LAST summary is the conservative one to judge.
+  summary="$(grep -E '(^|[[:space:]])Checked[[:space:]].*[0-9]+ checks:' "$plain" | tail -1 || true)"
+  [[ -z "$summary" ]] && return 1
+
+  # #5440: assert on the CHECK COUNT, not merely on the summary's presence.
+  executed="$(printf '%s\n' "$summary" | sed -E 's/.*[^0-9]([0-9]+) checks:.*/\1/')"
+  if ! printf '%s\n' "$executed" | grep -Eq '^[0-9]+$'; then
+    VERDICT_REASON="unparsable-count:${summary}"
+    return 1
+  fi
+  if [[ "$executed" -lt 1 ]]; then
+    VERDICT_REASON="zero-checks:${summary}"
+    return 1
+  fi
+  VERDICT_REASON=""
+  return 0
+}
+
+# no_verdict_because — one clause naming why verdict_computed refused, so the two
+# causes never share a message. "it never ran" and "it ran and skipped every
+# lint" have different remedies, and #5440 is the second one.
+no_verdict_because() {
+  case "${VERDICT_REASON%%:*}" in
+    zero-checks)
+      printf '%s\n' "completed a run that EXECUTED NO CHECKS — '$(printf '%s' "${VERDICT_REASON#*:}" | sed 's/^[[:space:]]*//')'"
+      ;;
+    unparsable-count)
+      printf '%s\n' "printed a summary whose check count did not parse — '$(printf '%s' "${VERDICT_REASON#*:}" | sed 's/^[[:space:]]*//')'"
+      ;;
+    *)
+      printf '%s\n' "never completed a check run"
+      ;;
+  esac
 }
 
 # ---------------------------------------------------------------------------
@@ -937,7 +1005,7 @@ while IFS= read -r crate; do
       # Loud, and counted. The release still proceeds — the permitted-break fact
       # is decided by the version numbers, not by this run — but "no inventory"
       # must never read as "inventory clean".
-      echo "NO INVENTORY ${crate}: cargo semver-checks exited ${rc} without completing a run." >&2
+      echo "NO INVENTORY ${crate}: cargo semver-checks exited ${rc} and $(no_verdict_because)." >&2
       echo "             The release is still permitted (${baseline} -> ${current} already carries the break)," >&2
       echo "             but WHAT it breaks is unknown. Fix the run above to get the list." >&2
       inventory_blind=$((inventory_blind + 1))
@@ -968,7 +1036,7 @@ while IFS= read -r crate; do
   # An exit 0 with no summary line is a no-op, not a pass, and must not reach the
   # clean branch — that is the fail-closed half of this check.
   if ! verdict_computed "$RUN_LOG"; then
-    echo "NO VERDICT ${crate}: cargo semver-checks exited ${rc} without completing a check run." >&2
+    echo "NO VERDICT ${crate}: cargo semver-checks exited ${rc} and $(no_verdict_because)." >&2
     echo "           No public API comparison against baseline ${baseline} was performed." >&2
     noverdict=$((noverdict + 1))
     continue
@@ -1014,6 +1082,13 @@ known either way about this crate's public API.
 
 The tool's own output is above. The usual causes:
 
+  * IT RAN AND CHECKED NOTHING — `0 checks: 0 pass, N skip` (issue #5440). The
+    tool skips its whole lint set when the baseline -> current delta already
+    permits breakage, which under Cargo's 0.x rules is ANY change to the MINOR
+    position of a 0.y.z crate. Exit 0 and "no semver update required" there mean
+    "nothing was examined", not "nothing is wrong". Check the baseline on the
+    `CHECK`/`INVENTORY` line above: if it is not the release you meant to compare
+    against, fix that first.
   * rustdoc failed to build. cargo-semver-checks resolves dependencies in a
     scratch project that IGNORES this workspace's Cargo.lock, so it can pick a
     newer transitive dependency whose `rust-version` exceeds the rustc running

--- a/scripts/check_semver.sh
+++ b/scripts/check_semver.sh
@@ -398,6 +398,15 @@ PY
 # versions are equal, or current is older than baseline; since #5296 the caller
 # selects a baseline STRICTLY BELOW the declared version, so `none` is now
 # unreachable from the gate and survives only as a total function's zero case.
+#
+# 0.0.z IS ALWAYS MAJOR (#5440, code-critic on PR #5522). Cargo gives a 0.0.z
+# crate NO compatible range at all — every 0.0.z bump is breaking. Classified
+# `minor`, such a crate lands in the PASS/FAIL arm, where cargo-semver-checks
+# reads the same pair as a permitted break, runs 0 of 254 checks, and the gate
+# correctly refuses the non-verdict — a publish blocked by an exit 3 that nothing
+# can clear. `major` routes it to the advisory INVENTORY arm instead, which is
+# what every other permitted break gets. Latent today: the lowest declared
+# version in this workspace is 0.1.0.
 # ---------------------------------------------------------------------------
 release_type() {
   python3 - "$1" "$2" <<'PY'
@@ -413,7 +422,11 @@ c = parse(sys.argv[2])
 if c <= b:
     print("none")
 elif b[0] == 0 and c[0] == 0:
-    print("major" if c[1] != b[1] else ("minor" if c[2] != b[2] else "none"))
+    # #5440: a 0.0.z baseline has no compatible range, so any bump off it breaks.
+    if b[1] == 0:
+        print("major")
+    else:
+        print("major" if c[1] != b[1] else ("minor" if c[2] != b[2] else "none"))
 elif c[0] != b[0]:
     print("major")
 elif c[1] != b[1]:
@@ -1083,12 +1096,19 @@ known either way about this crate's public API.
 The tool's own output is above. The usual causes:
 
   * IT RAN AND CHECKED NOTHING — `0 checks: 0 pass, N skip` (issue #5440). The
-    tool skips its whole lint set when the baseline -> current delta already
-    permits breakage, which under Cargo's 0.x rules is ANY change to the MINOR
-    position of a 0.y.z crate. Exit 0 and "no semver update required" there mean
-    "nothing was examined", not "nothing is wrong". Check the baseline on the
-    `CHECK`/`INVENTORY` line above: if it is not the release you meant to compare
-    against, fix that first.
+    tool skips its whole lint set when IT reads the baseline -> current delta as
+    already permitting breakage. Exit 0 and "no semver update required" there
+    mean "nothing was examined", not "nothing is wrong".
+    A NORMAL 0.x MINOR BUMP DOES NOT LAND HERE. The gate classifies 0.28.1 ->
+    0.29.0 as major itself and sends it to the advisory INVENTORY arm, which
+    passes --release-type minor and gets a full lint run. Do not weaken this
+    check on the theory that a routine bump tripped it.
+    What reaches this arm is a BASELINE AT OR ABOVE the declared version: the
+    gate reads that pair as no change while the tool reads it by position and
+    calls it a permitted break. Read the baseline off the `CHECK` line above. If
+    it is not below the version you are publishing, the declared version is
+    behind the registry — preflight-publish.sh CHECK 4 is the check that says
+    so — and that is what to fix.
   * rustdoc failed to build. cargo-semver-checks resolves dependencies in a
     scratch project that IGNORES this workspace's Cargo.lock, so it can pick a
     newer transitive dependency whose `rust-version` exceeds the rustc running

--- a/scripts/check_semver_selftest.sh
+++ b/scripts/check_semver_selftest.sh
@@ -95,6 +95,24 @@
 #                            100, so it also proves a private-mode-laden BREAK
 #                            is still reported as a break rather than swallowed.
 #
+#   Cases 20-21 (issue #5440) pin the OTHER way a completed run says nothing.
+#   cargo-semver-checks skips its whole lint set when the baseline -> current
+#   delta already permits breakage, and prints
+#       Checked [   0.000s] 0 checks: 0 pass, 254 skip
+#       Summary no semver update required
+#   at exit 0. The gate keyed its verdict on the summary line EXISTING, so it
+#   read "254 lints declined" as "254 lints satisfied" and preflight-publish.sh
+#   CHECK 5 passed having verified nothing:
+#     20. zero checks / PASS-FAIL arm — must be NO VERDICT, exit 3, and must say
+#                            it executed no checks rather than blaming rustdoc.
+#     21. zero checks / INVENTORY arm — must be a BLIND inventory, never "no
+#                            breaking changes found".
+#   Both fail against the pre-fix gate, which exits 0 on 20 and reports an empty
+#   inventory on 21. The fixture is `all-skipped.out`, which is this file's own
+#   former `clean.out`: the case that was supposed to prove the gate can pass a
+#   crate was being satisfied by a run that checked nothing. `clean.out` is now a
+#   real 196-pass capture, so "a real pass still exits 0" is still covered.
+#
 #   Cases 13-15 pin pre-release handling. `key()` used to strip the pre-release
 #   suffix, so 1.0.0-rc1 and 1.0.0 both keyed to (1, 0, 0) and the tie went to
 #   whichever the index listed first — the reproduction on record picked
@@ -353,7 +371,8 @@ silent no-op at exit 0${TAB}silent-noop.out${TAB}0${TAB}3${TAB}NO SEMVER VERDICT
 clean${TAB}clean.out${TAB}0${TAB}0${TAB}crate(s) checked${TAB}NO SEMVER VERDICT
 ANSI-coloured clean (case 16)${TAB}clean-colored.out${TAB}0${TAB}0${TAB}crate(s) checked${TAB}NO SEMVER VERDICT
 ANSI-coloured break (case 17)${TAB}break-colored.out${TAB}100${TAB}1${TAB}VERDICT: BREAK${TAB}NO SEMVER VERDICT
-private-mode CSI break (case 19)${TAB}private-mode.out${TAB}100${TAB}1${TAB}VERDICT: BREAK${TAB}NO SEMVER VERDICT"
+private-mode CSI break (case 19)${TAB}private-mode.out${TAB}100${TAB}1${TAB}VERDICT: BREAK${TAB}NO SEMVER VERDICT
+zero checks executed (case 20)${TAB}all-skipped.out${TAB}0${TAB}3${TAB}NO SEMVER VERDICT WAS COMPUTED${TAB}requires a matching version bump"
 
 while IFS="$TAB" read -r name fixture stub_rc want_exit must_have must_not; do
   [[ -z "$name" ]] && continue
@@ -379,6 +398,27 @@ while IFS="$TAB" read -r name fixture stub_rc want_exit must_have must_not; do
     pass_case "${name} -> exit ${rc}, says '${must_have}'"
   fi
 done <<<"$VERDICT_CASES"
+
+# --- 20b. The zero-check refusal must name its own cause. "it never ran" and
+#          "it ran and skipped every lint" have different remedies, and a shared
+#          message would send whoever hits #5440 hunting a rustdoc error that
+#          does not exist.
+rc=0
+out="$(cd "$REPO_ROOT" && \
+  PATH="${STUB_DIR}:${PATH}" \
+  SEMVER_GATE_TOOLCHAIN_BIN='' \
+  SEMVER_SELFTEST_REAL_CARGO="$REAL_CARGO" \
+  SEMVER_SELFTEST_FIXTURE="${FIXTURES}/all-skipped.out" \
+  SEMVER_SELFTEST_RC=0 \
+  SEMVER_GATE_INDEX_BASE="http://127.0.0.1:${PORT}/v/${STUB_PREV}" \
+  bash "$GATE" --crate "$STUB_CRATE" 2>&1)" || rc=$?
+if [[ "$out" != *"EXECUTED NO CHECKS"* ]]; then
+  fail_case "zero-checks/diagnosis: the refusal did not say the run executed no checks, so it is indistinguishable from a rustdoc failure" "$out"
+elif [[ "$out" != *"0 checks: 0 pass, 254 skip"* ]]; then
+  fail_case "zero-checks/diagnosis: the refusal did not quote the summary line it judged" "$out"
+else
+  pass_case "a zero-check refusal names the cause and quotes the summary (#5440)"
+fi
 
 # ===========================================================================
 # 9-12. Which release is the baseline, and what happens when the bump is already
@@ -465,6 +505,24 @@ elif [[ "$out" == *"no breaking changes found"* ]]; then
   fail_case "inventory/blind: a run that produced nothing was reported as clean" "$out"
 else
   pass_case "an inventory that could not run says so, in the line and in the summary"
+fi
+
+# --- 21. The inventory arm over a run that executed no checks (#5440). Exit 0
+#         with a summary, so the pre-fix gate reported "no breaking changes found
+#         against vX" from a run that examined nothing — the advisory half of the
+#         same false pass. It must land in the blind arm instead.
+rc=0
+out="$(gate_with_index "${STUB_OLD_MINOR}" "${STUB_OLD_MINOR}=all-skipped.out:0")" || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  fail_case "inventory/zero-checks: an advisory run must not block an already-permitted release (exit ${rc})" "$out"
+elif [[ "$out" == *"no breaking changes found"* ]]; then
+  fail_case "inventory/zero-checks: a run that executed 0 of 254 checks was reported as an empty inventory (#5440)" "$out"
+elif [[ "$out" != *"NO INVENTORY ${STUB_CRATE}"* ]]; then
+  fail_case "inventory/zero-checks: a run that examined nothing was not reported as such" "$out"
+elif [[ "$out" != *"inventory NOT computed"* ]]; then
+  fail_case "inventory/zero-checks: the summary line hid the missing inventory" "$out"
+else
+  pass_case "an inventory that executed no checks is blind, not empty (#5440)"
 fi
 
 # --- 18. The inventory arm over ANSI-coloured output. This is the trusty-review

--- a/scripts/check_semver_selftest.sh
+++ b/scripts/check_semver_selftest.sh
@@ -107,6 +107,13 @@
 #                            it executed no checks rather than blaming rustdoc.
 #     21. zero checks / INVENTORY arm — must be a BLIND inventory, never "no
 #                            breaking changes found".
+#   Case 22 pins the classification that decides WHICH arm a crate reaches:
+#   every 0.0.z bump is breaking under Cargo's rules, so `release_type` must
+#   call it major and route it to the advisory INVENTORY arm. Called `minor` it
+#   lands in the PASS/FAIL arm, where the tool runs 0 of 254 checks and the gate
+#   — correctly, per cases 20-21 — blocks the publish with an exit 3 that nothing
+#   can clear.
+#
 #   Both fail against the pre-fix gate, which exits 0 on 20 and reports an empty
 #   inventory on 21. The fixture is `all-skipped.out`, which is this file's own
 #   former `clean.out`: the case that was supposed to prove the gate can pass a
@@ -598,6 +605,43 @@ elif [[ "$out" == *"CHECK ${STUB_CRATE}:"* ]]; then
 else
   pass_case "the only-a-pre-release skip names what it refused"
 fi
+
+# ===========================================================================
+# 22. release_type() over a 0.0.z crate (#5440, code-critic on PR #5522).
+#
+# Cargo gives a 0.0.z crate no compatible range, so every 0.0.z bump is
+# breaking. Classified `minor`, such a crate lands in the PASS/FAIL arm, where
+# cargo-semver-checks reads the same pair as a permitted break and runs 0 of 254
+# checks — and since #5440 that is a correct NO VERDICT, i.e. a publish blocked
+# by an exit 3 nothing can clear. `major` routes it to the advisory INVENTORY
+# arm like every other permitted break.
+#
+# No crate in this workspace declares 0.0.z, so the end-to-end arms cannot reach
+# it. The function is lifted out of the gate BY PATTERN rather than copied here,
+# so this case exercises the shipped definition and not a stale duplicate of it.
+# ===========================================================================
+eval "$(awk '/^release_type\(\) \{/,/^\}/' "$GATE")"
+
+# baseline  current  expected
+RELEASE_TYPE_CASES="0.0.5 0.0.6 major
+0.0.5 0.1.0 major
+0.30.1 0.31.0 major
+0.31.0 0.31.1 minor
+1.3.4 2.0.0 major
+1.3.4 1.4.0 minor
+1.3.4 1.3.5 patch"
+
+rt_failed=0
+while read -r rt_base rt_cur rt_want; do
+  [[ -z "$rt_base" ]] && continue
+  rt_got="$(release_type "$rt_base" "$rt_cur")"
+  if [[ "$rt_got" != "$rt_want" ]]; then
+    fail_case "release_type/${rt_base}->${rt_cur}: expected ${rt_want}, got ${rt_got}" \
+      "A 0.0.z bump classified anything but 'major' lands in the PASS/FAIL arm, where the tool runs 0 checks and the gate blocks the publish with a NO VERDICT nothing can clear (#5440)."
+    rt_failed=1
+  fi
+done <<<"$RELEASE_TYPE_CASES"
+[[ "$rt_failed" -eq 0 ]] && pass_case "release_type calls every 0.0.z bump major, and still ranks 0.x/1.x correctly (#5440)"
 
 rm -rf "$STUB_DIR"
 

--- a/scripts/preflight-publish.sh
+++ b/scripts/preflight-publish.sh
@@ -82,7 +82,8 @@
 #
 #     A NON-VERDICT IS NOT A VERDICT (#5289). check_semver.sh exits 1 only when
 #     it computed a verdict that says break, and 3 when it could not compute one
-#     at all (rustdoc build failure, unreachable registry, missing tool). Both
+#     at all (rustdoc build failure, a run that executed ZERO checks (#5440),
+#     unreachable registry, missing tool). Both
 #     stop the publish; only the first is reported as "your API changed". The
 #     remedy above applies to exit 1 — for exit 3 the remedy is to fix the gate
 #     and re-run, never to bump a version on evidence that does not exist.

--- a/scripts/test-data/semver-gate/README.md
+++ b/scripts/test-data/semver-gate/README.md
@@ -23,7 +23,8 @@ untouched, because those escapes are the whole point of the fixture.
 | File | Stub exit | Captured from |
 |---|---|---|
 | `break.out` | 100 | `cargo semver-checks -p trusty-mpm --baseline-version 1.3.4 --only-explicit-features` + the 11 default-set features, under rustc 1.97.1. The real 1.3.4 -> 1.3.5 break: 9 major failures. |
-| `clean.out` | 0 | `cargo semver-checks -p trusty-progress --baseline-version 0.2.0 --only-explicit-features`. Already a major bump, so 0 lints apply — the tool's "nothing to compare, and that is fine" shape. |
+| `clean.out` | 0 | `cargo semver-checks -p trusty-progress --baseline-version 0.2.0 --only-explicit-features --release-type minor`. A real all-pass verdict: `196 checks: 196 pass, 58 skip`. |
+| `all-skipped.out` | 0 | The same command WITHOUT `--release-type`, so the tool infers "major change" from 0.2.0 -> 0.3.0 and skips its entire lint set: `0 checks: 0 pass, 254 skip` + `Summary no semver update required`, at exit 0. This file used to be named `clean.out` and drove the gate's "clean" case — which is the #5440 defect exactly: zero work done was the fixture for a pass. |
 | `build-error.out` | 101 | The same `trusty-mpm` command under the repo MSRV 1.94.1, where the scratch resolution takes `takecell` 0.1.2 (`rust-version` 1.96) and rustdoc refuses to build. This is the defect #5289 was filed for. |
 | `silent-noop.out` | 0 | **Synthetic.** No real invocation produces exit 0 with no `checks:` summary today. It pins the fail-closed rule: "the tool said nothing" must never be read as "the tool said pass". |
 | `clean-colored.out` | 0 | The `tga` 2.16.0 -> 2.17.0 run of PR #5458, [job 93874563097](https://github.com/bobmatnyc/trusty-tools/actions/runs/31520044458/job/93874563097). 196 pass, no break — and the gate announced it as "exited 0 without completing a check run". |

--- a/scripts/test-data/semver-gate/all-skipped.out
+++ b/scripts/test-data/semver-gate/all-skipped.out
@@ -1,0 +1,12 @@
+    Building trusty-progress v0.3.0 (current)
+       Built [   2.766s] (current)
+     Parsing trusty-progress v0.3.0 (current)
+      Parsed [   0.001s] (current)
+    Building trusty-progress v0.2.0 (baseline)
+       Built [   2.108s] (baseline)
+     Parsing trusty-progress v0.2.0 (baseline)
+      Parsed [   0.001s] (baseline)
+    Checking trusty-progress v0.2.0 -> v0.3.0 (major change)
+     Checked [   0.000s] 0 checks: 0 pass, 254 skip
+     Summary no semver update required
+    Finished [   5.613s] trusty-progress

--- a/scripts/test-data/semver-gate/clean.out
+++ b/scripts/test-data/semver-gate/clean.out
@@ -1,12 +1,12 @@
     Building trusty-progress v0.3.0 (current)
-       Built [   2.766s] (current)
+       Built [   4.552s] (current)
      Parsing trusty-progress v0.3.0 (current)
-      Parsed [   0.001s] (current)
+      Parsed [   0.006s] (current)
     Building trusty-progress v0.2.0 (baseline)
-       Built [   2.108s] (baseline)
+       Built [   5.832s] (baseline)
      Parsing trusty-progress v0.2.0 (baseline)
-      Parsed [   0.001s] (baseline)
-    Checking trusty-progress v0.2.0 -> v0.3.0 (major change)
-     Checked [   0.000s] 0 checks: 0 pass, 254 skip
+      Parsed [   0.002s] (baseline)
+    Checking trusty-progress v0.2.0 -> v0.3.0 (assume minor change)
+     Checked [   0.011s] 196 checks: 196 pass, 58 skip
      Summary no semver update required
-    Finished [   5.613s] trusty-progress
+    Finished [  11.773s] trusty-progress


### PR DESCRIPTION
Fixes the false-pass path in the SemVer gate reported on #5440, and answers two
of that issue's three open questions. Part (a) — the false pass — is fixed here.
The rustdoc crash under rustc 1.97.1 is **not** fixed and stays on #5440.

## What was wrong

`cargo-semver-checks` skips its entire lint set when the baseline → current
delta already permits breakage, and reports that at exit 0:

```
Checking trusty-common v0.31.0 -> v0.30.1 (major change)
 Checked [   0.000s] 0 checks: 0 pass, 254 skip
 Summary no semver update required
```

`scripts/check_semver.sh`'s `verdict_computed` keyed on the summary line
*existing*, so it read "254 lints declined" as "254 lints satisfied" and exited
0. `scripts/preflight-publish.sh` CHECK 5 then passed having verified nothing.

The gate failed closed on the reporting machine only by accident: under the
newest installed toolchain the same crate crashed rustdoc, printed no summary,
and was correctly classified NO VERDICT. `check_semver.sh` auto-selects the
highest installed rustc, so removing that toolchain would have turned the gate
green for every publish.

## The change

`scripts/check_semver.sh:771-799` — `verdict_computed` now parses the leading
`N checks:` count (the number of lints that RAN; the trailing `N skip` is what
was declined) and requires it to be at least 1. Zero, or a count that does not
parse, is NO VERDICT → exit 3, the same status a rustdoc failure already gets.
A new `no_verdict_because` gives the two causes different messages, because
"it never ran" and "it ran and skipped every lint" have different remedies.

## Regression tests

`scripts/check_semver_selftest.sh` (runs in CI via `semver-checks.yml`) gains
cases 20, 20b and 21. The fixture is the self-test's own former `clean.out`,
renamed to `all-skipped.out`: the case that was supposed to prove the gate can
pass a crate was itself being satisfied by a run that checked nothing.
`clean.out` is now a real 196-pass capture, so "a genuine pass still exits 0"
stays covered.

Against the **pre-fix** gate (`git show HEAD~1:scripts/check_semver.sh` in
place, new fixtures and cases):

```
SELF-TEST FAIL: verdict/zero checks executed (case 20): expected exit 3, got 0
       CHECK trusty-agents: 0.38.5 -> 0.38.6 (minor release), 0 feature(s)
            Checked [   0.000s] 0 checks: 0 pass, 254 skip
            Summary no semver update required
       semver gate: scanned (explicit); 1 crate(s) checked, 0 skipped — OK.
SELF-TEST FAIL: zero-checks/diagnosis: the refusal did not say the run executed no checks
SELF-TEST FAIL: inventory/zero-checks: a run that executed 0 of 254 checks was reported as an empty inventory (#5440)
       INVENTORY trusty-agents: no breaking changes found against v0.37.0.

check_semver_selftest: 19 passed, 3 FAILED.
```

Post-fix: `check_semver_selftest: 22 passed, 0 failed.`

## Part B findings

Measured with `cargo semver-checks -p trusty-progress --baseline-version 0.2.0
--only-explicit-features`, same crate, three flag settings:

| `--release-type` | tool's own reading | checks executed |
|---|---|---|
| *(omitted)* | `(major change)` | **0** — `0 checks: 0 pass, 254 skip` |
| `minor` | `(assume minor change)` | 196 — `196 checks: 196 pass, 58 skip` |
| `patch` | `(assume patch change)` | 223 — `223 checks: 223 pass, 31 skip` |

So the mass skip is not a rustdoc problem and not toolchain-specific: it is the
tool declining to lint a delta that already permits breakage. The INVENTORY arm
already passes `--release-type minor` and is unaffected — that flag works as
its comment claims.

The PASS/FAIL arm passes no `--release-type`, so the tool re-derives it from the
version pair. The gate reaches that arm only when its own `release_type()` says
`patch`, `minor`, or `none` — and `none` (current ≤ baseline) is the one value
that can disagree with the tool, which reads the same pair by position and calls
it major. That is exactly the recorded run: `1 crate(s) checked, 0 skipped — OK`
is the PASS/FAIL arm's summary, and only `none` routes a major-shaped delta
there.

On the baseline question: selection on current `main` is correct, measured —

```
$ bash scripts/check_semver.sh --probe trusty-common
probe trusty-common: baseline=0.32.0 (declared=0.33.0, latest on crates.io=0.33.0, pre-release below=NONE)
$ bash scripts/check_semver.sh --probe trusty-common --probe-version 0.30.1
probe trusty-common: baseline=0.30.0 (declared=0.30.1, latest on crates.io=0.33.0, pre-release below=NONE)
```

The `#5296` ceiling makes baseline < declared by construction, so the recorded
inversion (baseline 0.31.0 above current 0.30.1) cannot be reproduced through
today's selection code. It is the shape a pre-#5296 gate produced (baseline =
crates.io *latest*), or a tree whose declared version sat at or below its
registry baseline. No `none` branch is added here: it is unreachable through
`registry_probe`, and this PR's fix already converts every such run into a
correct exit-3 block rather than a green one. Left as a note on #5440.

## Gates (rung 5 — release tooling; scripts and docs only, no crate `src/**`)

```
bash scripts/check_semver_selftest.sh     → check_semver_selftest: 22 passed, 0 failed.   (exit 0)
bash scripts/check-ci-helpers-selftest.sh → check-ci-helpers-selftest: all 135 cases passed (exit 0)
shellcheck scripts/check_semver.sh scripts/check_semver_selftest.sh → exit 0, no findings
bash scripts/check_semver.sh              → scanned 7 changed path(s); no crate source changed — OK. (exit 0)
bash scripts/check_changelog_fragment.sh  → no crate source changed — OK. (exit 0)
bash scripts/check_sld.sh                 → exit 0
bash scripts/check_doc_numbers.sh         → exit 0
bash scripts/check_public_docs.sh         → exit 0
bash scripts/check_line_cap.sh            → exit 0
```

No changelog fragment: no crate `src/**` is touched. No workflow files changed,
so no `actionlint` run. `shellcheck scripts/preflight-publish.sh` reports 8
pre-existing SC2001/SC2181 style findings on lines this PR does not touch (the
only edit there is a comment).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
