### PR TITLE
docs(trusty-mpm): tm-workflow rule for keeping the main checkout fresh

### DIFF
--- a/crates/trusty-mpm/changelog.d/5432-main-checkout-ff-only-refresh.md
+++ b/crates/trusty-mpm/changelog.d/5432-main-checkout-ff-only-refresh.md
@@ -1,0 +1,7 @@
+Added
+
+- `tm-workflow`'s "Worktree Discipline" section now tells sessions to keep the main checkout fresh: `git fetch` then `git pull --ff-only` at session start and after a PR this session merged lands on `origin/main`. Worktrees branch off `origin/main` and stay current, but nothing refreshes the main checkout, so it drifts and inspection reads start answering from old code
+  - fast-forward only, so the refresh cannot create a merge commit or rewrite history, and a dirty tree only blocks it when the incoming commits touch the same files
+  - when `--ff-only` is blocked by another session's uncommitted changes, the rule is preserve rather than discard — commit the orphaned work to a throwaway branch, then switch back and fast-forward. Committing reaches the same clean tree as discarding, costs the same number of steps, and cannot lose anything
+  - `git stash` stays banned (repo-level, shared across every worktree), as do `git checkout --`, `restore`, `reset --hard`, and `clean` — the main-checkout guard blocks those and hunting for an unblocked equivalent is routing around a safety control. A file showing ` M` in `git status --porcelain` was never staged, so nothing recovers it once discarded
+  - stated as inspection hygiene: the main checkout stays read-only for work, all edits still happen in a worktree, and `git pull` is already on the PM's allowlist so this needs no new authority

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -223,6 +223,53 @@ cd .claude/worktrees/<dirname>
 Always `git fetch origin main` first and branch off `origin/main`, never local
 `main` — local `main` can be stale and branching from it has caused lost commits.
 
+**Keep the main checkout fresh.** Worktrees branch off `origin/main` and stay
+current; nothing refreshes the main checkout, so it drifts — and then every
+inspection read (`git log`, opening a file to answer a question, checking
+whether a fix already landed) silently answers from old code. At session start,
+and after a PR this session merged lands on `origin/main`:
+
+```bash
+git -C /path/to/main-checkout fetch origin
+git -C /path/to/main-checkout pull --ff-only
+```
+
+Fast-forward only — it cannot create a merge commit, cannot rewrite history, and
+fails loudly instead of resolving anything silently. A dirty tree does not block
+a fast-forward unless the incoming commits touch the same files, so the common
+case just works.
+
+🔴 **If `--ff-only` fails, never clear the way by discarding.** The usual cause
+is another session's uncommitted work. Do not `git stash` — repo-level and
+shared across every worktree, so it yanks state out from under sessions running
+right now. Do not `git checkout --`, `restore`, `reset --hard`, or `clean`: the
+main-checkout guard blocks these, correctly, and hunting for an unblocked
+equivalent is routing around a safety control. A file showing ` M` in
+`git status --porcelain` was never staged, so nothing recovers it once
+discarded.
+
+Identify the owner first — `git status --porcelain` for staged-vs-unstaged, file
+mtimes, and the session log for who was alive in that window — and ask live
+peers before assuming the work is abandoned. If it is unowned, **preserve rather
+than discard**: commit it out of the way, which is permitted and destroys
+nothing.
+
+```bash
+git checkout -b orphan/main-checkout-$(date +%Y%m%d)
+git add -u && git commit -m "wip: orphaned main-checkout changes"
+git checkout main && git pull --ff-only
+```
+
+Committing reaches the same clean tree as discarding, costs the same number of
+steps, and cannot lose anything — the guard exists to prevent loss, not to
+prevent refreshing, so the compliant path and the safe path are the same path.
+If the checkout has genuinely diverged instead, report it and stop.
+
+This is inspection hygiene only, so reads are not answered from stale code. The
+main checkout stays read-only for work; every edit still happens in a worktree.
+`git pull` is already on the PM's allowlist — no new authority, not a budgeted
+direct action.
+
 **A worktree is a writer; the branch is the workstream.** The durable unit is
 the branch — one branch per workstream, one session per workstream. A worktree
 is only the checkout that lets you write to that branch: ephemeral, disposable,


### PR DESCRIPTION
## Why

Worktrees branch off `origin/main`, so they stay current. The main checkout does not — nothing refreshes it. Measured this session: the checkout sat at `b9b99d316` while `origin/main` moved 15+ commits, and when the rule was first exercised it was **61 commits behind**. Every inspection read (`git log`, opening a file to answer a question, checking whether a fix already landed) silently answers from old code.

No prior text existed. Searched all bundled skills and agents for `ff-only|git pull|fast-forward|stale checkout|main checkout|refresh` — the only hits were `tm-cli-operations`'s `tm update` (a different subject: loaded aliases) and `tm-workflow`'s existing inspection-only/stash-escape-hatch material. This adds to that section rather than competing with it.

## What

One addition to `tm-workflow`'s "Worktree Discipline" section, placed directly after the existing "local `main` can be stale" paragraph so it reads as part of that discipline:

- `git fetch` then `git pull --ff-only`, at session start and after a PR this session merged lands on `origin/main`. Fast-forward only cannot create a merge commit, cannot rewrite history, and fails loudly instead of resolving anything silently. A dirty tree does not block a fast-forward unless the incoming commits touch the same files, so the common case just works.
- **The failure branch is what makes it usable.** When another session's uncommitted work blocks the fast-forward, the rule is preserve rather than discard: commit the orphaned work to a throwaway branch, switch back, fast-forward. Identify the owner first via `git status --porcelain`, mtimes, and the session log, and ask live peers before assuming abandonment.
- `git stash` stays banned — the stash is repo-level and shared across every worktree, so stashing in the main checkout yanks state out from under concurrently running sessions. `git checkout --`, `restore`, `reset --hard`, and `clean` stay banned because the main-checkout guard blocks them, correctly, and hunting for an unblocked equivalent is routing around a safety control. A file showing ` M` in `git status --porcelain` was never staged, so nothing recovers it once discarded.
- Framed as inspection hygiene only: the main checkout stays read-only for work, every edit still happens in a worktree branched off `origin/main`. `git pull` is already on the PM's allowlist, so this needs no new authority and is not a budgeted direct action.

The principle stated once: committing the work reaches the same clean tree as discarding it, costs the same number of steps, and cannot lose anything. The guard exists to prevent loss, not to prevent refreshing, so the compliant path and the safe path are the same path.

## Test

Rung 1–2 (bundled asset content, no Rust behavior change). `bundle_tests.rs` asserts only that `TM_WORKFLOW` is non-empty and that `skills/tm-workflow.md` stays registered; the `ALL.len() == 178` count is unaffected because this edits an existing asset rather than adding one.

| Gate | Result |
|---|---|
| `cargo test -p trusty-mpm` | `EXIT=0` — `4913 passed; 0 failed; 7 ignored`, `1602 passed; 0 failed; 1 ignored` (×2), all remaining suites `0 failed` |
| `cargo fmt --check` | `EXIT=0` |
| `scripts/check_line_cap.sh` | `EXIT=0` |
| `scripts/check_changelog_fragment.sh` | `EXIT=0` |
| `scripts/check_capabilities.sh` | `EXIT=0` |
| `scripts/check_agent_assets.sh` | `EXIT=0` |
| `scripts/check_sld.sh` | `EXIT=0` |

Changelog fragment: `crates/trusty-mpm/changelog.d/5432-main-checkout-ff-only-refresh.md`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools