### PR TITLE
docs(trusty-mpm): search_health branches on healthy, not call success

### DIFF
--- a/crates/trusty-mpm/changelog.d/5534-search-health-branch-on-healthy-field.md
+++ b/crates/trusty-mpm/changelog.d/5534-search-health-branch-on-healthy-field.md
@@ -1,0 +1,3 @@
+Fixed
+
+- Injected agent docs (`tm-tool-usage-guide.md`, `tm-circuit-breaker.md` CB#7, and the non-overridable "Trusty Tool Priority" rules) described `search_health` as a bare liveness check and never mentioned that a successful call no longer means the daemon is up, once PR #5534 lands. Each site now says to branch on the response's `healthy` field, not on the call succeeding, so an agent doesn't read a dead daemon as a false all-clear

--- a/crates/trusty-mpm/src/assets/instructions/sections/non-overridable-rules.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/non-overridable-rules.md
@@ -42,7 +42,9 @@ with `curl`/`lsof`/`ps`/`netstat`.
 - `mcp__trusty-search__search` before Read/Grep. **Omit `index_id`** — your
   `.mcp.json` pins this session to its own index, and a guessed id fails with
   `404 unknown index` (#1373).
-- `mcp__trusty-search__search_health` for liveness, not a shell command.
+- `mcp__trusty-search__search_health` for liveness, not a shell command — it
+  returns `Ok` even when the daemon is down, so branch on `healthy`, not on
+  the call succeeding.
 
 Full per-tool tables: `Skill(skill="tm-tool-usage-guide")`. A tool missing from
 your loaded list is not unavailable — load its schema with `ToolSearch` first.

--- a/crates/trusty-mpm/src/assets/skills/tm-circuit-breaker.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-circuit-breaker.md
@@ -209,7 +209,9 @@ ps`, `make`, `pytest`, `npm test` directly via Bash.
 targets) or **QA** (test suites, endpoint checks). Service liveness for
 trusty-* daemons specifically routes through MCP health tools, never Bash —
 see `tm-tool-usage-guide` (`mcp__trusty-search__search_health`,
-`mcp__trusty-memory__memory_recall`).
+`mcp__trusty-memory__memory_recall`). `search_health` returns `Ok` whether or
+not the daemon is up — branch on the response's `healthy` field, not on the
+call succeeding.
 
 **Violation:** `PM: Bash(curl http://localhost:7878/health)`
 

--- a/crates/trusty-mpm/src/assets/skills/tm-tool-usage-guide.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-tool-usage-guide.md
@@ -65,7 +65,7 @@ is CB#2 / CB#10 in `tm-circuit-breaker`.
 | `search_similar` | Find code semantically similar to a known snippet |
 | `search_kg` / `get_call_chain` | Structural queries — call graphs, symbol relationships |
 | `grep` / `typeahead` | Lexical lookup once you already know the token to find |
-| `search_health` | Liveness check — **use instead of `curl`/`lsof`** (CB#7) |
+| `search_health` | Health check — **use instead of `curl`/`lsof`** (CB#7). Returns `Ok` even when the daemon is down; branch on the response's `healthy` field, never on the call succeeding |
 | `list_indexes` / `index_status` | Discover what projects are indexed and their freshness |
 
 **Example:**


### PR DESCRIPTION
## Summary
PR #5534 changes the `search_health` MCP tool to return `Ok` even when the daemon is DOWN, with the verdict moved into the response body (`status`, `healthy`, `message`, `remediation`, `daemon`, `index`). The tool's schema says this, but the bundled agent docs injected into every PM/agent session still described `search_health` as a bare liveness check and never named the `healthy` field — an agent that called it, saw no error, and moved on would get a false all-clear for a dead daemon.

## Changes
- `crates/trusty-mpm/src/assets/skills/tm-tool-usage-guide.md` — the `search_health` tool-table row now says it returns `Ok` even when the daemon is down and to branch on `healthy`
- `crates/trusty-mpm/src/assets/skills/tm-circuit-breaker.md` (CB#7) — adds the same branch-on-`healthy` clause after the existing `search_health` pointer
- `crates/trusty-mpm/src/assets/instructions/sections/non-overridable-rules.md` — the "Trusty Tool Priority" rule for `search_health` now carries the same one-clause caveat

## Test plan
Docs-only change, rung 1 of the test ladder.
- `bash scripts/check_sld.sh` — PASS
- `bash scripts/check_line_cap.sh` — PASS
- `bash scripts/check_changelog_fragment.sh` — PASS (scanned 4 changed paths, fragment present)
- `cargo test -p trusty-mpm --lib core::bundle::tests::` — 42 passed (golden bundle test covering these assets)
- `cargo test -p trusty-mpm --lib core::claude_md_sections::tests::` — 53 passed (pins `non-overridable-rules.md` content)
- `cargo test -p trusty-mpm --lib core::instruction_pipeline::tests::` — 40 passed

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools