### PR TITLE
fix(trusty-search): use PersistedIndex::new() in the #4227 quarantine test

### DIFF
--- a/crates/trusty-search/changelog.d/5538-quarantine-test-nonexhaustive.md
+++ b/crates/trusty-search/changelog.d/5538-quarantine-test-nonexhaustive.md
@@ -1,0 +1,3 @@
+Fixed
+
+- **`corpus_corruption_quarantine_4227.rs` used a `PersistedIndex` struct literal that no longer compiles.** #5523 marked `PersistedIndex` `#[non_exhaustive]` and converted every struct-literal construction site that existed at the time of its sweep; the #4227 quarantine test file landed in parallel and was never visited, so `cargo check -p trusty-search --tests` failed with `E0639` once both were on `main`. The test now builds through `PersistedIndex::new()`. `finish_reindex`'s teardown helpers (`stop_pollers`, `resolve_corpus_swap`, `resolve_hnsw_swap`, `rebuild_kg`) are also extracted into a new `finish_teardown` module, bringing `finish.rs` back under the 500-SLOC cap after #5514 and #5527 combined pushed it over

--- a/crates/trusty-search/src/service/reindex/finish.rs
+++ b/crates/trusty-search/src/service/reindex/finish.rs
@@ -20,25 +20,23 @@
 use crate::core::memguard::{current_rss_mb, current_rss_mb_for_pid};
 use crate::core::registry::{IndexHandle, IndexId};
 use dashmap::DashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering as AtomicOrdering};
 use std::sync::Arc;
 use std::time::Instant;
 
-use super::completion::{
-    emit_complete_event, rebuild_symbol_graph_for_reindex, KgRebuildOutcome, RunTotals,
-};
-use super::corpus_swap::{abort_staged_corpus_swap, commit_staged_corpus_swap};
+use super::completion::{emit_complete_event, RunTotals};
 use super::defer_embed::spawn_deferred_embed_pass;
+use super::finish_teardown::{rebuild_kg, resolve_corpus_swap, resolve_hnsw_swap, stop_pollers};
 use super::guard::ReindexTerminationGuard;
-use super::hnsw_swap::{abort_staged_hnsw_swap, commit_staged_hnsw_swap, HnswSwapPaths};
+use super::hnsw_swap::HnswSwapPaths;
 use super::progress::{ReindexProgress, ReindexStatus};
 use super::quarantine::ReindexQuarantine;
 use super::stage_timings::StageTimings;
 use super::stages::{
-    mark_graph_failed, mark_graph_ready, mark_lexical_ready_semantic_in_progress,
-    mark_reindex_failed, mark_semantic_ready_graph_in_progress, now_rfc3339,
-    refresh_context_embedding, schedule_progress_cleanup,
+    mark_lexical_ready_semantic_in_progress, mark_reindex_failed,
+    mark_semantic_ready_graph_in_progress, now_rfc3339, refresh_context_embedding,
+    schedule_progress_cleanup,
 };
 use super::staging;
 use super::validate;
@@ -544,188 +542,4 @@ pub(super) async fn finish_reindex(
 
     // Issue #75: GC the progress entry after a short delay.
     schedule_progress_cleanup(cleanup_map, cleanup_id);
-}
-
-/// Stop both RSS pollers and await their join handles.
-///
-/// Why: the same teardown sequence is needed on two code paths (hard failure
-/// exit and the normal success path). Extracted to avoid duplication.
-/// What: sets the stop flag, awaits the join handle. No-ops for `None` handles.
-/// Test: exercised on every `finish_reindex` code path.
-async fn stop_pollers(
-    poller_stop: Arc<AtomicBool>,
-    poller_handle: tokio::task::JoinHandle<()>,
-    embedderd_stop: Option<Arc<AtomicBool>>,
-    embedderd_handle: Option<tokio::task::JoinHandle<()>>,
-) {
-    poller_stop.store(true, AtomicOrdering::Release);
-    let _ = poller_handle.await;
-    if let Some(stop) = embedderd_stop {
-        stop.store(true, AtomicOrdering::Release);
-    }
-    if let Some(h) = embedderd_handle {
-        let _ = h.await;
-    }
-}
-
-/// Resolve the atomic corpus swap: commit, rollback, or write indexed_root only.
-///
-/// Why: extracted from `finish_reindex` to keep line count manageable.
-/// What: if `corpus_swap_tmp` is `Some`, commits or aborts the staged swap;
-/// otherwise writes `indexed_root` when the reindex succeeded without staging.
-/// Test: `reindex_walks_directory_and_emits_events` exercises the commit path.
-async fn resolve_corpus_swap(
-    handle: &IndexHandle,
-    index_id: &IndexId,
-    canonical_root: &Path,
-    corpus_swap_tmp: Option<&Path>,
-    staging_resolution: &staging::StagingResolution,
-    reindex_outcome: &validate::ReindexOutcome,
-    memory_aborted: bool,
-) {
-    if let Some(tmp_path) = corpus_swap_tmp {
-        if staging_resolution.is_commit() {
-            commit_staged_corpus_swap(handle, index_id, tmp_path).await;
-            if let Err(e) = handle.write_indexed_root(canonical_root).await {
-                tracing::warn!(
-                    "reindex[{}]: failed to persist indexed_root {} ({e}) — \
-                     a future root-move may not re-relativize paths",
-                    index_id.0,
-                    canonical_root.display(),
-                );
-            }
-        } else {
-            if let staging::StagingResolution::Rollback { reason } = staging_resolution {
-                tracing::warn!(
-                    "reindex[{}]: rolling back staged corpus — {reason}",
-                    index_id.0,
-                );
-            }
-            abort_staged_corpus_swap(handle, index_id, tmp_path).await;
-        }
-    } else if reindex_outcome.is_ready() && !memory_aborted {
-        if let Err(e) = handle.write_indexed_root(canonical_root).await {
-            tracing::debug!(
-                "reindex[{}]: indexed_root not persisted (no durable corpus): {e}",
-                index_id.0,
-            );
-        }
-    }
-}
-
-/// Resolve the staged HNSW swap: commit or roll back (issue #3970).
-///
-/// Why: extracted so `finish_reindex` stays readable — mirrors
-/// `resolve_corpus_swap`, reusing the SAME `staging_resolution` the corpus
-/// swap already computed (a `Ready` outcome with no memory-abort commits,
-/// anything else rolls back). No-op when `hnsw_swap_paths` is `None` (staging
-/// was never begun, e.g. an unresolvable path at reindex start) — the caller
-/// already fell back to the old detached forced-save-to-live in that case.
-/// What: `Commit` publishes the staged snapshot atomically to the live path;
-/// `Rollback` discards the staged snapshot and leaves the live one untouched.
-/// Test: `hnsw_swap::tests::commit_staged_hnsw_swap_publishes_final_state`,
-/// `hnsw_swap::tests::abort_staged_hnsw_swap_leaves_live_untouched_and_cleans_staging`.
-async fn resolve_hnsw_swap(
-    handle: &IndexHandle,
-    index_id: &IndexId,
-    hnsw_swap_paths: Option<&HnswSwapPaths>,
-    staging_resolution: &staging::StagingResolution,
-) {
-    let Some(paths) = hnsw_swap_paths else {
-        return;
-    };
-    if staging_resolution.is_commit() {
-        commit_staged_hnsw_swap(handle, index_id, paths).await;
-    } else {
-        if let staging::StagingResolution::Rollback { reason } = staging_resolution {
-            tracing::warn!(
-                "reindex[{}]: rolling back staged HNSW snapshot — {reason}",
-                index_id.0,
-            );
-        }
-        abort_staged_hnsw_swap(handle, index_id, paths).await;
-    }
-}
-
-/// Run Phase 3: rebuild the symbol graph and flip the graph stage to Ready.
-///
-/// Why: extracted from `finish_reindex` to reduce function length.
-/// What: emits `kg_start` / `kg_complete` SSE events; rebuilds the KG; flips
-/// the graph stage. Returns the `KgRebuildOutcome` for logging.
-/// Test: `reindex_walks_directory_and_emits_events` exercises KG rebuild.
-#[allow(clippy::too_many_arguments)]
-async fn rebuild_kg(
-    handle: &Arc<IndexHandle>,
-    progress: &Arc<ReindexProgress>,
-    index_id: &IndexId,
-    peak_rss_atomic: &Arc<AtomicU64>,
-    mem_limit: Option<u64>,
-    mem_limit_hit: bool,
-    mem_abort: &Arc<AtomicBool>,
-) -> KgRebuildOutcome {
-    if handle.skip_kg {
-        tracing::info!(
-            "reindex[{}]: KG construction skipped (skip_kg=true)",
-            index_id.0,
-        );
-        return KgRebuildOutcome {
-            symbol_count: 0,
-            edge_count: 0,
-            kg_ms: 0,
-            kg_skipped: true,
-            contrib_merge_error: None,
-        };
-    }
-
-    // Emit `kg_start` so the CLI activates the KG progress bar (issue #401).
-    progress
-        .push(serde_json::json!({
-            "event": "kg_start",
-            "index_id": index_id.0,
-        }))
-        .await;
-
-    let outcome = rebuild_symbol_graph_for_reindex(handle).await;
-
-    // Issue #401: emit `kg_complete` with timing + graph stats.
-    progress
-        .push(serde_json::json!({
-            "event": "kg_complete",
-            "index_id": index_id.0,
-            "kg_ms": outcome.kg_ms,
-            "symbol_count": outcome.symbol_count,
-            "edge_count": outcome.edge_count,
-            // #5505: set ⇒ the counts above are the PREVIOUS graph's.
-            "contrib_merge_error": outcome.contrib_merge_error,
-        }))
-        .await;
-
-    // #5505: a rebuild that installed no graph did not make this index's graph
-    // lane current — flipping it to Ready would report a stale graph as this
-    // reindex's product. Fail the stage with the reason instead.
-    match &outcome.contrib_merge_error {
-        None => mark_graph_ready(handle).await,
-        Some(reason) => {
-            tracing::error!(
-                "reindex[{}]: graph stage NOT ready — contributed overlay not merged \
-                 ({reason}); the serving graph is the one from before this reindex",
-                index_id.0,
-            );
-            mark_graph_failed(handle, reason).await;
-        }
-    }
-    if mem_limit_hit || mem_abort.load(AtomicOrdering::Acquire) {
-        tracing::warn!(
-            "reindex: memory limit was breached during batch processing for \
-             index {} (peak_rss={}MB, limit={:?}MB) — KG was still rebuilt \
-             (symbols={}, edges={}) because graph construction is bounded by \
-             TRUSTY_MAX_KG_NODES and independent of the embedding spike",
-            index_id.0,
-            peak_rss_atomic.load(AtomicOrdering::Acquire),
-            mem_limit,
-            outcome.symbol_count,
-            outcome.edge_count,
-        );
-    }
-    outcome
 }

--- a/crates/trusty-search/src/service/reindex/finish_teardown.rs
+++ b/crates/trusty-search/src/service/reindex/finish_teardown.rs
@@ -1,0 +1,213 @@
+//! Post-loop teardown helpers for `finish_reindex`.
+//!
+//! Why: extracted from `finish.rs` (this repo's 500-SLOC production cap) to
+//! keep `finish_reindex` itself in one file while the swap-resolution and
+//! poller-teardown steps it calls live in another. Splits along the same
+//! seam `finish.rs`'s own module doc already describes: prune → swap commit
+//! → KG rebuild → poller teardown → terminal event.
+//!
+//! What: `stop_pollers` (RSS poller shutdown), `resolve_corpus_swap` /
+//! `resolve_hnsw_swap` (staged-write commit-or-rollback, issues #603 / #3970),
+//! and `rebuild_kg` (Phase 3 symbol-graph rebuild). All four are called from
+//! exactly one place, `finish::finish_reindex`.
+//!
+//! Test: covered by `reindex_walks_directory_and_emits_events` (primary
+//! integration test) and the swap-specific unit tests in `corpus_swap.rs` /
+//! `hnsw_swap.rs`.
+
+use crate::core::registry::{IndexHandle, IndexId};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering as AtomicOrdering};
+use std::sync::Arc;
+
+use super::completion::{rebuild_symbol_graph_for_reindex, KgRebuildOutcome};
+use super::corpus_swap::{abort_staged_corpus_swap, commit_staged_corpus_swap};
+use super::hnsw_swap::{abort_staged_hnsw_swap, commit_staged_hnsw_swap, HnswSwapPaths};
+use super::progress::ReindexProgress;
+use super::stages::{mark_graph_failed, mark_graph_ready};
+use super::staging;
+use super::validate;
+
+/// Stop both RSS pollers and await their join handles.
+///
+/// Why: the same teardown sequence is needed on two code paths (hard failure
+/// exit and the normal success path). Extracted to avoid duplication.
+/// What: sets the stop flag, awaits the join handle. No-ops for `None` handles.
+/// Test: exercised on every `finish_reindex` code path.
+pub(super) async fn stop_pollers(
+    poller_stop: Arc<AtomicBool>,
+    poller_handle: tokio::task::JoinHandle<()>,
+    embedderd_stop: Option<Arc<AtomicBool>>,
+    embedderd_handle: Option<tokio::task::JoinHandle<()>>,
+) {
+    poller_stop.store(true, AtomicOrdering::Release);
+    let _ = poller_handle.await;
+    if let Some(stop) = embedderd_stop {
+        stop.store(true, AtomicOrdering::Release);
+    }
+    if let Some(h) = embedderd_handle {
+        let _ = h.await;
+    }
+}
+
+/// Resolve the atomic corpus swap: commit, rollback, or write indexed_root only.
+///
+/// Why: extracted from `finish_reindex` to keep line count manageable.
+/// What: if `corpus_swap_tmp` is `Some`, commits or aborts the staged swap;
+/// otherwise writes `indexed_root` when the reindex succeeded without staging.
+/// Test: `reindex_walks_directory_and_emits_events` exercises the commit path.
+pub(super) async fn resolve_corpus_swap(
+    handle: &IndexHandle,
+    index_id: &IndexId,
+    canonical_root: &Path,
+    corpus_swap_tmp: Option<&Path>,
+    staging_resolution: &staging::StagingResolution,
+    reindex_outcome: &validate::ReindexOutcome,
+    memory_aborted: bool,
+) {
+    if let Some(tmp_path) = corpus_swap_tmp {
+        if staging_resolution.is_commit() {
+            commit_staged_corpus_swap(handle, index_id, tmp_path).await;
+            if let Err(e) = handle.write_indexed_root(canonical_root).await {
+                tracing::warn!(
+                    "reindex[{}]: failed to persist indexed_root {} ({e}) — \
+                     a future root-move may not re-relativize paths",
+                    index_id.0,
+                    canonical_root.display(),
+                );
+            }
+        } else {
+            if let staging::StagingResolution::Rollback { reason } = staging_resolution {
+                tracing::warn!(
+                    "reindex[{}]: rolling back staged corpus — {reason}",
+                    index_id.0,
+                );
+            }
+            abort_staged_corpus_swap(handle, index_id, tmp_path).await;
+        }
+    } else if reindex_outcome.is_ready() && !memory_aborted {
+        if let Err(e) = handle.write_indexed_root(canonical_root).await {
+            tracing::debug!(
+                "reindex[{}]: indexed_root not persisted (no durable corpus): {e}",
+                index_id.0,
+            );
+        }
+    }
+}
+
+/// Resolve the staged HNSW swap: commit or roll back (issue #3970).
+///
+/// Why: extracted so `finish_reindex` stays readable — mirrors
+/// `resolve_corpus_swap`, reusing the SAME `staging_resolution` the corpus
+/// swap already computed (a `Ready` outcome with no memory-abort commits,
+/// anything else rolls back). No-op when `hnsw_swap_paths` is `None` (staging
+/// was never begun, e.g. an unresolvable path at reindex start) — the caller
+/// already fell back to the old detached forced-save-to-live in that case.
+/// What: `Commit` publishes the staged snapshot atomically to the live path;
+/// `Rollback` discards the staged snapshot and leaves the live one untouched.
+/// Test: `hnsw_swap::tests::commit_staged_hnsw_swap_publishes_final_state`,
+/// `hnsw_swap::tests::abort_staged_hnsw_swap_leaves_live_untouched_and_cleans_staging`.
+pub(super) async fn resolve_hnsw_swap(
+    handle: &IndexHandle,
+    index_id: &IndexId,
+    hnsw_swap_paths: Option<&HnswSwapPaths>,
+    staging_resolution: &staging::StagingResolution,
+) {
+    let Some(paths) = hnsw_swap_paths else {
+        return;
+    };
+    if staging_resolution.is_commit() {
+        commit_staged_hnsw_swap(handle, index_id, paths).await;
+    } else {
+        if let staging::StagingResolution::Rollback { reason } = staging_resolution {
+            tracing::warn!(
+                "reindex[{}]: rolling back staged HNSW snapshot — {reason}",
+                index_id.0,
+            );
+        }
+        abort_staged_hnsw_swap(handle, index_id, paths).await;
+    }
+}
+
+/// Run Phase 3: rebuild the symbol graph and flip the graph stage to Ready.
+///
+/// Why: extracted from `finish_reindex` to reduce function length.
+/// What: emits `kg_start` / `kg_complete` SSE events; rebuilds the KG; flips
+/// the graph stage. Returns the `KgRebuildOutcome` for logging.
+/// Test: `reindex_walks_directory_and_emits_events` exercises KG rebuild.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn rebuild_kg(
+    handle: &Arc<IndexHandle>,
+    progress: &Arc<ReindexProgress>,
+    index_id: &IndexId,
+    peak_rss_atomic: &Arc<AtomicU64>,
+    mem_limit: Option<u64>,
+    mem_limit_hit: bool,
+    mem_abort: &Arc<AtomicBool>,
+) -> KgRebuildOutcome {
+    if handle.skip_kg {
+        tracing::info!(
+            "reindex[{}]: KG construction skipped (skip_kg=true)",
+            index_id.0,
+        );
+        return KgRebuildOutcome {
+            symbol_count: 0,
+            edge_count: 0,
+            kg_ms: 0,
+            kg_skipped: true,
+            contrib_merge_error: None,
+        };
+    }
+
+    // Emit `kg_start` so the CLI activates the KG progress bar (issue #401).
+    progress
+        .push(serde_json::json!({
+            "event": "kg_start",
+            "index_id": index_id.0,
+        }))
+        .await;
+
+    let outcome = rebuild_symbol_graph_for_reindex(handle).await;
+
+    // Issue #401: emit `kg_complete` with timing + graph stats.
+    progress
+        .push(serde_json::json!({
+            "event": "kg_complete",
+            "index_id": index_id.0,
+            "kg_ms": outcome.kg_ms,
+            "symbol_count": outcome.symbol_count,
+            "edge_count": outcome.edge_count,
+            // #5505: set ⇒ the counts above are the PREVIOUS graph's.
+            "contrib_merge_error": outcome.contrib_merge_error,
+        }))
+        .await;
+
+    // #5505: a rebuild that installed no graph did not make this index's graph
+    // lane current — flipping it to Ready would report a stale graph as this
+    // reindex's product. Fail the stage with the reason instead.
+    match &outcome.contrib_merge_error {
+        None => mark_graph_ready(handle).await,
+        Some(reason) => {
+            tracing::error!(
+                "reindex[{}]: graph stage NOT ready — contributed overlay not merged \
+                 ({reason}); the serving graph is the one from before this reindex",
+                index_id.0,
+            );
+            mark_graph_failed(handle, reason).await;
+        }
+    }
+    if mem_limit_hit || mem_abort.load(AtomicOrdering::Acquire) {
+        tracing::warn!(
+            "reindex: memory limit was breached during batch processing for \
+             index {} (peak_rss={}MB, limit={:?}MB) — KG was still rebuilt \
+             (symbols={}, edges={}) because graph construction is bounded by \
+             TRUSTY_MAX_KG_NODES and independent of the embedding spike",
+            index_id.0,
+            peak_rss_atomic.load(AtomicOrdering::Acquire),
+            mem_limit,
+            outcome.symbol_count,
+            outcome.edge_count,
+        );
+    }
+    outcome
+}

--- a/crates/trusty-search/src/service/reindex/mod.rs
+++ b/crates/trusty-search/src/service/reindex/mod.rs
@@ -49,6 +49,7 @@ mod checkpoint;
 mod completion;
 mod corpus_swap;
 mod finish;
+mod finish_teardown;
 mod guard;
 mod hash;
 mod hnsw_swap;

--- a/crates/trusty-search/tests/corpus_corruption_quarantine_4227.rs
+++ b/crates/trusty-search/tests/corpus_corruption_quarantine_4227.rs
@@ -63,12 +63,9 @@ fn mock_embedder() -> Arc<dyn Embedder> {
 
 /// Build a colocated `PersistedIndex` entry rooted at `root`.
 fn entry_at(id: &str, root: &Path) -> PersistedIndex {
-    PersistedIndex {
-        id: id.to_string(),
-        root_path: root.to_path_buf(),
-        colocated: true,
-        ..Default::default()
-    }
+    let mut entry = PersistedIndex::new(id.to_string(), root.to_path_buf());
+    entry.colocated = true;
+    entry
 }
 
 /// Path of the colocated `index.redb` for a root, matching


### PR DESCRIPTION
## What broke (two independent red-main conditions, same class)

Both are combinations of PRs that each passed CI alone against their own base, but broke once merged together onto main. Bundled into one PR since both block every remaining trusty-search PR in the queue and both are "stabilize main" fixes, not feature work.

### 1. Non-exhaustive struct literal in an integration test

`#5523` marked `PersistedIndex` `#[non_exhaustive]` and converted every then-existing struct-literal construction under `tests/` to the `::new()` builder. `#5510` landed in parallel and added a new integration test (`tests/corpus_corruption_quarantine_4227.rs`) using the old struct-literal syntax — a file `#5523`'s sweep could not have seen. `#[non_exhaustive]` only blocks construction from outside the defining crate; an integration test under `tests/` compiles as its own crate, so it's affected even though in-crate (`src/`) construction is not.

Fix: same `::new()` pattern already used by the three sibling fixtures (`residency_cold_park.rs`, `corpus_open_quarantine_4122.rs`, `quarantine_durable_writes_4226.rs`).

### 2. finish.rs crossed the 500-SLOC cap

`#5514` and `#5527` each modified `crates/trusty-search/src/service/reindex/finish.rs` and were each under cap at their own head. Combined on main, the file reached 501 SLOC, tripping the required "500-line file-size cap" check on every subsequent PR's head.

Fix: extracted the four post-loop teardown/completion helpers (`stop_pollers`, `resolve_corpus_swap`, `resolve_hnsw_swap`, `rebuild_kg`) into a new sibling module `finish_teardown.rs` — the same seam `finish.rs`'s own module doc already described. `finish_reindex` and its two context structs stay in `finish.rs`. Pure move, no logic changed.

## Test ladder

Rung 2/3 mix (test-only fix + a pure structural move, no behavior change). No `changelog.d` fragment: fix 1 is test-only; fix 2 is a non-functional split with no user-visible change.

```
bash scripts/check_line_cap.sh                                    → 0 violations (was 1)
cargo fmt --check -p trusty-search                                 → clean
cargo clippy -p trusty-search --all-targets -- -D warnings         → clean
cargo test -p trusty-search --test corpus_corruption_quarantine_4227
  running 3 tests ... test result: ok. 3 passed; 0 failed
cargo test -p trusty-search --lib reindex::
  test result: ok. 148 passed; 0 failed; 0 ignored; 1462 filtered out
```

Also confirmed both breaks exist on `origin/main` today, independent of this PR (verified in a clean worktree at `246e4ca2e`, before either fix).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools