### PR TITLE
fix(trusty-common): propagate a stat failure in list_palaces instead of reporting no palaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,7 +6535,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11410,7 +11410,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.33.0"
+version = "0.33.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/5532-list-palaces-stat-guard.md
+++ b/crates/trusty-common/changelog.d/5532-list-palaces-stat-guard.md
@@ -1,0 +1,6 @@
+Fixed
+
+- `PalaceStore::list_palaces` no longer reports a registry it cannot stat as an empty one ([#5532](https://github.com/bobmatnyc/trusty-tools/issues/5532))
+  - The absence guard used `Path::exists`, which is `fs::metadata(..).is_ok()` and coerces every stat failure — `EACCES` from an unsearchable parent directory, `EIO`, `ELOOP` — to `false`. The function then returned `Ok(vec![])` without reaching `read_dir`, so the error propagation added in #5488 and #5526 never ran and the destructive callers (`purge_palaces`, `rebuild_palaces`, `merge_palaces`) reported a clean zero-palace run over data they never read.
+  - It now uses `try_exists`, which keeps "absent" (`Ok(false)`) distinct from "cannot determine" (`Err`). A data root that does not exist yet — including one whose parents are missing, and a broken symlink — still returns an empty list, so first run is unchanged.
+  - A macOS TCC denial is NOT this trigger: measured against real TCC-protected directories, TCC permits `stat` and denies only enumeration, so `read_dir` was always reached and the #5488/#5526 fixes fire as intended.

--- a/crates/trusty-common/src/memory_core/store/palace_store.rs
+++ b/crates/trusty-common/src/memory_core/store/palace_store.rs
@@ -168,9 +168,26 @@ impl PalaceStore {
     /// loads and pushes the `Palace`. Subdirs without metadata are silently
     /// skipped.
     /// Test: `list_palaces_finds_saved_palaces` (registry tests cover the full
-    /// stack).
+    /// stack); `list_palaces_missing_dir_is_empty` pins the absent-root arm and
+    /// `list_palaces_propagates_an_unstattable_registry_dir` the denied one.
+    ///
+    /// The absence guard uses `try_exists` rather than `exists`, because
+    /// `Path::exists` is `fs::metadata(..).is_ok()` and so coerces *every* stat
+    /// failure to `false` — a registry we are forbidden to stat would read as a
+    /// registry that is not there, and callers on the destructive paths
+    /// (`purge_palaces`, `rebuild_palaces`, `merge_palaces`) would report a
+    /// clean zero-palace run over data they never read. `try_exists` keeps
+    /// "absent" (`Ok(false)`, including a broken symlink or any missing parent)
+    /// distinct from "cannot determine" (`Err`), so only the former still
+    /// yields an empty list. A first run against a data root that does not
+    /// exist yet is normal and must not error.
     pub fn list_palaces(registry_dir: &Path) -> Result<Vec<Palace>> {
-        if !registry_dir.exists() {
+        // #5532: `exists()` reports a stat we are denied as "absent", silently
+        // turning an unreadable registry into an empty one.
+        let present = registry_dir
+            .try_exists()
+            .map_err(|e| PalaceStoreError::io(registry_dir, e))?;
+        if !present {
             return Ok(Vec::new());
         }
         let read_dir =
@@ -309,5 +326,87 @@ mod tests {
         let missing = tmp.path().join("does-not-exist");
         let palaces = PalaceStore::list_palaces(&missing).unwrap();
         assert!(palaces.is_empty());
+    }
+
+    /// Restore a directory's mode on drop, including while unwinding.
+    ///
+    /// Why: the denial test below strips a directory to mode 000. If an
+    /// assertion panics before it is restored, `tempfile` cannot delete the
+    /// tree and the run leaks an undeletable directory.
+    #[cfg(unix)]
+    struct RestoreMode(PathBuf);
+
+    #[cfg(unix)]
+    impl Drop for RestoreMode {
+        fn drop(&mut self) {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o700));
+        }
+    }
+
+    /// Why (#5532): the absence guard used `Path::exists`, which is
+    /// `fs::metadata(..).is_ok()` and so reports *any* stat failure as "not
+    /// there". A registry we are forbidden to stat therefore returned
+    /// `Ok(vec![])`, and the propagation #5488/#5526 added one layer down (at
+    /// `read_dir`) never ran, because `read_dir` was never reached. The
+    /// destructive callers would report a clean empty run over data they never
+    /// read.
+    /// What: strips a PARENT of the registry dir to mode 000, so the failure
+    /// lands on `stat` rather than on `read_dir` — the arm the existing
+    /// regular-file/`ENOTDIR` harnesses cannot reach, since a regular file
+    /// stats just fine and only fails once enumeration starts. Asserts the
+    /// error propagates and carries the denial.
+    /// Test: This test.
+    #[cfg(unix)]
+    #[test]
+    fn list_palaces_propagates_an_unstattable_registry_dir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().unwrap();
+        let parent = tmp.path().join("locked");
+        let registry = parent.join("registry");
+        std::fs::create_dir_all(&registry).unwrap();
+
+        // Baseline: listable while the parent is traversable.
+        assert!(
+            PalaceStore::list_palaces(&registry).is_ok(),
+            "the registry must list cleanly before the parent is locked"
+        );
+
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let _restore = RestoreMode(parent.clone());
+
+        // Root bypasses the mode bits outright, and some filesystems ignore
+        // them, so confirm the denial actually took hold. Asserting against a
+        // stat that still succeeds would pass without exercising anything, and
+        // a vacuous pass on a fail-open guard is worse than no test at all.
+        match std::fs::metadata(&registry) {
+            Ok(_) => panic!(
+                "cannot exercise #5532: stat of {} still succeeds at mode 000. \
+                 Run this suite as a non-root user on a filesystem that honours \
+                 POSIX permission bits.",
+                registry.display()
+            ),
+            Err(e) => assert_eq!(
+                e.kind(),
+                std::io::ErrorKind::PermissionDenied,
+                "expected the locked parent to deny stat, got {e}"
+            ),
+        }
+
+        let err = PalaceStore::list_palaces(&registry)
+            .expect_err("a registry dir that cannot be stat'd must not report as empty");
+
+        match err {
+            PalaceStoreError::Io { path, source } => {
+                assert_eq!(path, registry, "the error must name the registry dir");
+                assert_eq!(
+                    source.kind(),
+                    std::io::ErrorKind::PermissionDenied,
+                    "the denial must survive into the error, got {source}"
+                );
+            }
+            other => panic!("expected an Io error carrying the denial, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
Closes #5532

**Lead with the measurement, because it partly refutes the issue that prompted the fix.**

#5532 asked whether a macOS TCC denial short-circuits `PalaceRegistry::list_palaces` at `Path::exists()` before reaching `read_dir` — which, if true, would mean the fail-open fixes in #5488 and #5526 never fire for their stated trigger. Measured on macOS 26.5.2 as uid 502 against real TCC-protected directories:

| Path | `exists()` | `metadata()` | `read_dir()` |
|---|---|---|---|
| `~/Library/Safari` | true | Ok | Err(PermissionDenied, raw=1) |
| `~/Library/Mail` | true | Ok | Err(PermissionDenied, raw=1) |
| `/Library/Application Support/com.apple.TCC` | true | Ok | Err(PermissionDenied, raw=1) |
| parent `chmod 000` (POSIX) | **false** | Err(PermissionDenied, raw=13) | Err(raw=13) |

Genuinely TCC, not POSIX: those directories are `drwxr-xr-x` and world-readable, yet enumeration fails. **TCC denies with EPERM(1) at the operation; POSIX denies with EACCES(13) at `stat`.**

So the hypothesis is refuted for its named trigger — under TCC, `read_dir` is always reached and #5488/#5526 fire as designed. State that plainly: **those three merged fixes are verified sound.**

**What survives, and is what this PR fixes.** `Path::exists()` is `fs::metadata(self).is_ok()` (std source, `library/std/src/path.rs:3429-3431`, toolchain 1.94.1); its docs say it coerces permission errors to `false` and recommend `try_exists()`. So a POSIX `EACCES` from an unsearchable parent collapses to `false` and `list_palaces` returns `Ok(vec![])` — a fail-open feeding destructive passes.

**The fix:** the guard uses `try_exists()`. Boundary verified case by case, not assumed:

| Case | `try_exists()` | Behaviour |
|---|---|---|
| absent, any depth of missing parent | `Ok(false)` | empty list — first run unchanged |
| broken symlink | `Ok(false)` | empty list |
| regular file at the path | `Ok(true)` | falls to `read_dir` → ENOTDIR — existing #5488/#5526 harnesses unaffected |
| TCC-denied dir | `Ok(true)` | falls to `read_dir` → EPERM — those fixes still fire |
| `EACCES` from locked parent | `Err` | **propagates** |

Say explicitly that first-run behaviour is untouched — `Ok(false)` covers every genuinely-absent shape including missing parents.

**Test ladder: rung 5.** Red, pre-fix guard with the new test:
```
panicked at crates/trusty-common/src/memory_core/store/palace_store.rs:393:14:
a registry dir that cannot be stat'd must not report as empty: []
test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 1006 filtered out
```
Green after: `3 passed; 0 failed`.

The test strips a **parent** to mode 000 so the failure lands on `stat`. Two hazards handled — it asserts the denial actually took hold (`metadata()` must return `PermissionDenied`) so it cannot pass vacuously under root, which bypasses permission checks; and it restores the mode from a `Drop` guard so a panicking assertion cannot strand an undeletable temp dir.

**Downstream composition deliberately not re-tested:** the change makes `EACCES` produce the same `PalaceStoreError::Io` variant `ENOTDIR` already produced, and the three existing tests (`purge_palaces_propagates_an_unreadable_data_root` and siblings) already prove purge/rebuild/merge propagate that error. A fourth test would re-prove the second half with a more fragile cross-crate harness.

**Version:** `trusty-common` 0.33.0 → **0.33.1**. Patch — `list_palaces`'s signature is unchanged; only its behaviour on a permission error changes. crates.io `max_version` was 0.33.0, so the `#4421` gate required it. Eight `trusty-common` requirement sites enumerated; only the crate's own `version` field needed changing, as every consumer carries a caret `"0.33"` that already admits `0.33.1`.

**Gates:**
```
cargo fmt --check                                            EXIT=0
cargo test -p trusty-common --features memory-core           EXIT=0  (1017 passed, 0 failed)
cargo check --workspace                                      EXIT=0
clippy 0.1.97, CI's workspace invocation                     EXIT=0
cargo test -p trusty-memory  (rung-4 dependent)              EXIT=0  (729 + 27 targets, 0 failed)
check_line_cap / check_changelog_fragment / check_sld        EXIT=0
check_test_pointers.sh                                       EXIT=0  (23835 citations, 0 dangling)
```

**One gate red and proven pre-existing:** `cargo test -p trusty-common --features memory-core -- --include-ignored` fails `cold_restart_recalls_beyond_l1_snapshot` and `timeout_fires_on_embedder_init_with_tiny_limit`, both ONNX/embedder-backed. Proven not-ours by reverting `palace_store.rs` to base `c898ba67a` and re-running those two — identical `0 passed; 2 failed`. The diff touches two files; the failures live in `retrieval/tests.rs` and `retrieval/timeout_tests.rs`, and `retrieval/handle.rs` never calls `list_palaces`. Closest prior art is #852, same class.

Also note: `Cargo.lock` carries one unrelated resolver-slack flip (`proc-macro-crate` 1.3.1 vs 2.0.0 for `num_enum_derive`, both semver-compatible), an automatic `cargo check` side effect, left as-is rather than hand-edited.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
