### PR TITLE
fix(trusty-common): propagate filesystem and decode failures in the list_palaces walk

### DIFF
--- a/crates/trusty-common/changelog.d/5543-list-palaces-loop-coercions.md
+++ b/crates/trusty-common/changelog.d/5543-list-palaces-loop-coercions.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `PalaceStore::list_palaces` no longer returns a short list and reports success when it cannot classify an entry. A denied stat on a registry child, a `palace.json` it cannot stat, an undecodable `palace.json`, and a directory entry that fails mid-enumeration now propagate an error naming the offending path instead of dropping that palace from the listing. Genuine absence — a subdirectory holding no `palace.json`, a dangling symlink, an entry unlinked mid-walk — still skips silently. The destructive callers (`purge_palaces`, `rebuild_palaces`, `merge_palaces`) already propagate, so they no longer report a clean pass over a palace they never read (#5543).

--- a/crates/trusty-common/src/memory_core/registry.rs
+++ b/crates/trusty-common/src/memory_core/registry.rs
@@ -605,7 +605,10 @@ impl PalaceRegistry {
     /// and for each persisted palace builds a `PalaceHandle` via
     /// `PalaceHandle::open` and registers it. Errors hydrating a single palace
     /// are logged and skipped so one corrupt palace doesn't take the whole
-    /// registry down — matches the resiliency choice in `PalaceStore::list_palaces`.
+    /// registry down. Enumeration is stricter than hydration: since #5543
+    /// `PalaceStore::list_palaces` fails rather than return a short list, so a
+    /// palace missing from this warmup was skipped by `PalaceHandle::open`, not
+    /// lost before it was ever seen.
     /// Test: `open_hydrates_persisted_palaces` exercises restart by writing,
     /// dropping, and reopening.
     pub fn open(data_root: &Path) -> Result<Self> {

--- a/crates/trusty-common/src/memory_core/store/palace_store.rs
+++ b/crates/trusty-common/src/memory_core/store/palace_store.rs
@@ -162,25 +162,37 @@ impl PalaceStore {
     /// palaces.
     ///
     /// Why: `palace list` and the daemon startup path both need to enumerate
-    /// every palace on disk. Skipping unreadable subdirs keeps a single broken
-    /// palace from taking the whole registry down.
-    /// What: For each immediate child directory containing a `palace.json`,
-    /// loads and pushes the `Palace`. Subdirs without metadata are silently
-    /// skipped.
-    /// Test: `list_palaces_finds_saved_palaces` (registry tests cover the full
-    /// stack); `list_palaces_missing_dir_is_empty` pins the absent-root arm and
-    /// `list_palaces_propagates_an_unstattable_registry_dir` the denied one.
+    /// every palace on disk, and the destructive passes (`purge_palaces`,
+    /// `rebuild_palaces`, `merge_palaces`) act on whatever this returns. A
+    /// short listing reads exactly like a complete one, so any palace dropped
+    /// here is one those passes skip while reporting a clean run.
+    /// What: For each immediate child directory holding a `palace.json`, loads
+    /// and pushes the `Palace`. A child that is genuinely not a palace is
+    /// skipped; a child that cannot be classified aborts the walk with the
+    /// underlying error, which names the offending path.
+    /// Test: `list_palaces_finds_saved_palaces` and
+    /// `list_palaces_missing_dir_is_empty` pin the benign arms;
+    /// `list_palaces_propagates_an_unstattable_registry_dir`,
+    /// `list_palaces_propagates_an_unstattable_entry`,
+    /// `list_palaces_propagates_an_unstattable_palace_json` and
+    /// `list_palaces_propagates_an_undecodable_palace` pin the error arms.
     ///
-    /// The absence guard uses `try_exists` rather than `exists`, because
-    /// `Path::exists` is `fs::metadata(..).is_ok()` and so coerces *every* stat
-    /// failure to `false` — a registry we are forbidden to stat would read as a
-    /// registry that is not there, and callers on the destructive paths
-    /// (`purge_palaces`, `rebuild_palaces`, `merge_palaces`) would report a
-    /// clean zero-palace run over data they never read. `try_exists` keeps
-    /// "absent" (`Ok(false)`, including a broken symlink or any missing parent)
-    /// distinct from "cannot determine" (`Err`), so only the former still
-    /// yields an empty list. A first run against a data root that does not
-    /// exist yet is normal and must not error.
+    /// Absence and failure-to-determine stay distinct at every step, which is
+    /// why the guards are `try_exists` and `metadata` rather than `exists` and
+    /// `is_dir`: the latter are `fs::metadata(..).is_ok()`-shaped and coerce
+    /// *every* stat failure to `false`, so a path we are forbidden to stat
+    /// reads as a path that is not there. Only genuine absence still skips
+    /// silently — `Ok(false)`, a dangling symlink, an entry unlinked mid-walk,
+    /// or a subdirectory that simply holds no `palace.json`. A first run
+    /// against a data root that does not exist yet is normal and must not
+    /// error.
+    ///
+    /// Failing the whole walk on one corrupt palace and skipping it are both
+    /// bad, and this picks failing (#5543): the error names the broken path, so
+    /// an operator can repair or remove it in one step, whereas a silent skip
+    /// makes that palace permanently invisible with no diagnostic while the
+    /// destructive callers quietly pass over it. `bm25_backfill`'s private
+    /// enumeration already made the same call for the same reason.
     pub fn list_palaces(registry_dir: &Path) -> Result<Vec<Palace>> {
         // #5532: `exists()` reports a stat we are denied as "absent", silently
         // turning an unreadable registry into an empty one.
@@ -195,20 +207,38 @@ impl PalaceStore {
 
         let mut palaces = Vec::new();
         for entry in read_dir {
-            let entry = match entry {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
+            // #5543: an entry failing mid-enumeration truncated the walk.
+            let entry = entry.map_err(|e| PalaceStoreError::io(registry_dir, e))?;
             let path = entry.path();
-            if !path.is_dir() {
+
+            // #5543: `is_dir()` coerced a denied stat to "not a directory".
+            let meta = match std::fs::metadata(&path) {
+                Ok(m) => m,
+                // Unlinked mid-walk, or a dangling symlink: genuinely absent,
+                // the one arm `try_exists` also reports as `Ok(false)`.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(PalaceStoreError::io(&path, e)),
+            };
+            if !meta.is_dir() {
                 continue;
             }
-            if !path.join(PALACE_JSON).exists() {
+
+            // #5543: `exists()` coerced a denied stat to "holds no metadata".
+            let metadata_path = path.join(PALACE_JSON);
+            let has_metadata = metadata_path
+                .try_exists()
+                .map_err(|e| PalaceStoreError::io(&metadata_path, e))?;
+            if !has_metadata {
                 continue;
             }
+
             match Self::load_palace(&path) {
                 Ok(p) => palaces.push(p),
-                Err(_) => continue,
+                // Raced away between the guard above and the read.
+                Err(PalaceStoreError::NotFound(_)) => continue,
+                // #5543: a denied read or an undecodable `palace.json` used to
+                // drop the palace and still report success.
+                Err(e) => return Err(e),
             }
         }
         Ok(palaces)
@@ -407,6 +437,166 @@ mod tests {
                 );
             }
             other => panic!("expected an Io error carrying the denial, got {other:?}"),
+        }
+    }
+
+    /// Why (#5543): the directory guard was `path.is_dir()`, which is
+    /// `fs::metadata(..)` with every error coerced to `false`. A child we are
+    /// forbidden to stat therefore read as "not a directory" and was skipped,
+    /// so the listing came back `Ok` and one palace shorter — which the
+    /// destructive callers cannot tell from a registry that never held it.
+    /// What: strips the registry itself to `r--`. Read permission keeps
+    /// `read_dir` enumerating names, while the missing execute bit denies stat
+    /// of any child. That isolates the per-entry stat from the registry-level
+    /// one `list_palaces_propagates_an_unstattable_registry_dir` already pins,
+    /// which a mode-000 registry could not do.
+    /// Test: This test.
+    #[cfg(unix)]
+    #[test]
+    fn list_palaces_propagates_an_unstattable_entry() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().unwrap();
+        let registry = tmp.path().join("registry");
+        let dir = registry.join("alpha");
+        PalaceStore::save_palace(&make_palace("alpha", &dir)).unwrap();
+
+        assert_eq!(
+            PalaceStore::list_palaces(&registry).unwrap().len(),
+            1,
+            "the palace must list cleanly before the registry is locked"
+        );
+
+        std::fs::set_permissions(&registry, std::fs::Permissions::from_mode(0o400)).unwrap();
+        let _restore = RestoreMode(registry.clone());
+
+        // Root bypasses the mode bits outright, and some filesystems ignore
+        // them, so confirm the denial actually took hold. A vacuous pass on a
+        // fail-open guard is worse than no test at all.
+        match std::fs::metadata(&dir) {
+            Ok(_) => panic!(
+                "cannot exercise #5543: stat of {} still succeeds with the registry at \
+                 mode 400. Run this suite as a non-root user on a filesystem that honours \
+                 POSIX permission bits.",
+                dir.display()
+            ),
+            Err(e) => assert_eq!(
+                e.kind(),
+                std::io::ErrorKind::PermissionDenied,
+                "expected the un-traversable registry to deny stat of its child, got {e}"
+            ),
+        }
+
+        let err = PalaceStore::list_palaces(&registry)
+            .expect_err("an entry that cannot be stat'd must not drop out of the listing");
+
+        match err {
+            PalaceStoreError::Io { path, source } => {
+                assert_eq!(path, dir, "the error must name the entry it could not stat");
+                assert_eq!(
+                    source.kind(),
+                    std::io::ErrorKind::PermissionDenied,
+                    "the denial must survive into the error, got {source}"
+                );
+            }
+            other => panic!("expected an Io error carrying the denial, got {other:?}"),
+        }
+    }
+
+    /// Why (#5543): the metadata guard was `path.join(PALACE_JSON).exists()`,
+    /// the same `is_ok()`-shaped coercion. A `palace.json` we are forbidden to
+    /// stat read as a subdirectory that simply holds no metadata, so a real
+    /// palace was silently reclassified as a stray directory.
+    /// What: leaves the registry traversable and strips the palace's own
+    /// directory to mode 000. Stat of the directory still succeeds, clearing
+    /// the entry guard above, while stat of `palace.json` inside it is denied —
+    /// so the failure lands on this site and not the previous one.
+    /// Test: This test.
+    #[cfg(unix)]
+    #[test]
+    fn list_palaces_propagates_an_unstattable_palace_json() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().unwrap();
+        let registry = tmp.path().join("registry");
+        let dir = registry.join("alpha");
+        PalaceStore::save_palace(&make_palace("alpha", &dir)).unwrap();
+
+        assert_eq!(
+            PalaceStore::list_palaces(&registry).unwrap().len(),
+            1,
+            "the palace must list cleanly before its directory is locked"
+        );
+
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let _restore = RestoreMode(dir.clone());
+
+        // The directory itself must still stat, or this would merely re-test
+        // the entry arm above instead of the metadata guard.
+        std::fs::metadata(&dir).expect("the palace dir itself must remain stattable");
+
+        let target = dir.join(PALACE_JSON);
+        match std::fs::metadata(&target) {
+            Ok(_) => panic!(
+                "cannot exercise #5543: stat of {} still succeeds with its parent at \
+                 mode 000. Run this suite as a non-root user on a filesystem that honours \
+                 POSIX permission bits.",
+                target.display()
+            ),
+            Err(e) => assert_eq!(
+                e.kind(),
+                std::io::ErrorKind::PermissionDenied,
+                "expected the locked palace dir to deny stat of its metadata, got {e}"
+            ),
+        }
+
+        let err = PalaceStore::list_palaces(&registry)
+            .expect_err("a palace.json that cannot be stat'd must not read as a non-palace dir");
+
+        match err {
+            PalaceStoreError::Io { path, source } => {
+                assert_eq!(path, target, "the error must name the metadata file");
+                assert_eq!(
+                    source.kind(),
+                    std::io::ErrorKind::PermissionDenied,
+                    "the denial must survive into the error, got {source}"
+                );
+            }
+            other => panic!("expected an Io error carrying the denial, got {other:?}"),
+        }
+    }
+
+    /// Why (#5543): `load_palace` failures were swallowed by `Err(_) =>
+    /// continue`, so a truncated or hand-edited `palace.json` dropped its
+    /// palace from the listing while the call still reported success.
+    /// `purge_palaces` and friends then ran over the remaining palaces and
+    /// reported a clean pass across data one member of which they never read.
+    /// What: writes one good palace beside one whose `palace.json` does not
+    /// decode, and asserts the walk fails rather than quietly returning just
+    /// the good one — the partial-listing case, not merely the empty one. Uses
+    /// no permission bits, so unlike its two siblings it exercises the arm
+    /// under any uid.
+    /// Test: This test.
+    #[test]
+    fn list_palaces_propagates_an_undecodable_palace() {
+        let tmp = tempdir().unwrap();
+        let registry = tmp.path().join("registry");
+
+        PalaceStore::save_palace(&make_palace("alpha", &registry.join("alpha"))).unwrap();
+
+        let broken = registry.join("beta");
+        std::fs::create_dir_all(&broken).unwrap();
+        let target = broken.join(PALACE_JSON);
+        std::fs::write(&target, b"{ this is not palace metadata").unwrap();
+
+        let err = PalaceStore::list_palaces(&registry)
+            .expect_err("an undecodable palace must not silently shorten the listing");
+
+        match err {
+            PalaceStoreError::Json { path, .. } => {
+                assert_eq!(path, target, "the error must name the undecodable file");
+            }
+            other => panic!("expected a Json error naming the broken palace, got {other:?}"),
         }
     }
 }

--- a/crates/trusty-common/src/memory_core/store/palace_store.rs
+++ b/crates/trusty-common/src/memory_core/store/palace_store.rs
@@ -170,12 +170,13 @@ impl PalaceStore {
     /// and pushes the `Palace`. A child that is genuinely not a palace is
     /// skipped; a child that cannot be classified aborts the walk with the
     /// underlying error, which names the offending path.
-    /// Test: `list_palaces_finds_saved_palaces` and
-    /// `list_palaces_missing_dir_is_empty` pin the benign arms;
+    /// Test: `list_palaces_finds_saved_palaces`,
+    /// `list_palaces_missing_dir_is_empty`,
     /// `list_palaces_propagates_an_unstattable_registry_dir`,
     /// `list_palaces_propagates_an_unstattable_entry`,
     /// `list_palaces_propagates_an_unstattable_palace_json` and
-    /// `list_palaces_propagates_an_undecodable_palace` pin the error arms.
+    /// `list_palaces_propagates_an_undecodable_palace` — the first two pin the
+    /// benign arms, the other four the error arms.
     ///
     /// Absence and failure-to-determine stay distinct at every step, which is
     /// why the guards are `try_exists` and `metadata` rather than `exists` and


### PR DESCRIPTION
Closes #5543

**The defect.** Four sites in `PalaceRegistry::list_palaces`'s per-entry loop coerced failures into "not a palace" and continued, so the function returned a SHORTER list than reality and reported success. Callers include the destructive `purge_palaces`, `rebuild_palaces`, `merge_palaces` — a palace that silently vanishes from the listing is one those passes skip while reporting a clean run.

**The design call, and why it isn't "fail hard vs skip".** That framing dissolves once failures are separated by kind. Present it as a table:

| Failure | Kind | Disposition |
|---|---|---|
| entry `Err` mid-enumeration | filesystem-level | propagate |
| `is_dir()` stat denied | filesystem-level (the parent was just `read_dir`'d) | propagate |
| `palace.json` stat denied | filesystem-level | propagate |
| `load_palace` Io/Json | palace-local — the corrupt-palace case | propagate |
| no `palace.json`, non-dir, dangling symlink, unlinked mid-walk | genuinely not a palace | skip, unchanged |

The denial-of-service worry — one corrupt file making the whole registry unusable — applies only to the corrupt-palace row, and it is weaker than it looks: the current silent skip makes a palace **permanently invisible with no diagnostic**, while the error carries `PalaceStoreError::Json { path, .. }` naming the exact broken file. "You see 9 of 10 and never learn about the 10th" is the worse failure.

**Precedent that settled it, and state this prominently:** `crates/trusty-memory/src/bm25_backfill.rs:644` already contains a private reimplementation of this walk, written because `list_palaces` fails open, whose doc says *"An errored directory entry fails the whole enumeration rather than shrinking it, because a partial list is indistinguishable from a short one."* This fix removes the reason that duplicate exists.

**No public API change, deliberately.** An additive `list_palaces_partial` + `PalaceListing`/`PalaceSkip` was considered and rejected — no in-tree consumer wants it, and every public item on a published crate is a permanent SemVer commitment. A new error variant was also rejected: `PalaceStoreError` is not `#[non_exhaustive]`, so adding one would itself be breaking. `Io`/`Json` already carry the actionable path. **No version bump owed** — behaviour change, not API break.

**A fourth site, not in the issue.** `Err(_) => continue` on the `read_dir` iterator itself, same defect, same loop. Fixed here rather than left to become a sixth instance. State plainly that it has NO test: it needs a directory to fail mid-iteration after a successful open, which could not be driven deterministically.

**Test ladder: rung 5.** Three red→green pairs, raw:
```
an entry that cannot be stat'd must not drop out of the listing: []
a palace.json that cannot be stat'd must not read as a non-palace dir: []
an undecodable palace must not silently shorten the listing: [Palace { id: PalaceId("alpha"), ... }]
```
Pre-fix `FAILED. 1 passed; 3 failed`; post-fix `ok. 9 passed; 0 failed`.

Call out the third message specifically — `Ok([alpha])` is a **partial** listing reported as success, which is the issue's exact hazard caught live rather than an empty-list stand-in.

Both permission tests assert the denial took hold and panic with a run-as-non-root message otherwise (#5541's pattern), so neither can pass vacuously under root. Site 1 uses mode `0o400` on the registry — readable so `read_dir` works, non-traversable so the child stat is denied — which isolates it from the registry-level stat #5541 pins. Site 3 uses no permission bits, so it exercises under any uid.

**Also updated:** `crates/trusty-common/src/memory_core/registry.rs` — its `open()` doc claimed hydration "matches the resiliency choice in `PalaceStore::list_palaces`", no longer true; it now states enumeration is stricter than hydration.

**Gates:**
```
cargo fmt --check                                        EXIT=0
cargo test -p trusty-common --features memory-core       EXIT=0  (999 passed, 0 failed, 13 ignored, + 6 suites)
cargo test -p trusty-memory  (rung-4 dependent)          EXIT=0  (729 passed, 0 failed, + 26 suites)
cargo check --workspace                                  EXIT=0
clippy 0.1.97, CI's workspace invocation                 EXIT=0
check_line_cap / check_changelog_fragment / check_sld    EXIT=0
check_test_pointers.sh                                   EXIT=1  — pre-existing, not this diff
```

**On the pointer lint:** 14 dangling pointers, ALL in `crates/trusty-search`. `git diff --name-only origin/main...HEAD -- crates/trusty-search/` returns zero paths; this diff is three files, all under `crates/trusty-common`. One cited pointer is byte-identical at `origin/main`. Zero failures in `trusty-common`, which also confirms this PR's four new `Test:` pointers resolve. A sibling branch is already on it.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools