### PR TITLE
feat(trusty-mpm): tm ls -a lists only attached sessions

### DIFF
--- a/crates/trusty-mpm/changelog.d/5547-tm-ls-attached-only.md
+++ b/crates/trusty-mpm/changelog.d/5547-tm-ls-attached-only.md
@@ -1,0 +1,8 @@
+Added
+
+- `tm ls -a` / `tm ls --attached` lists only the sessions a tmux client is attached to right now
+  - "attached" is tmux's own `#{session_attached}`, surfaced by the daemon as the per-session `attached` flag — a session that is live and reported `active` with nobody connected to it is EXCLUDED, which is the whole point of the flag
+  - forces the static table for the same reason `--all` does: a session you already have a client on is the one target the picker cannot usefully connect you to
+  - matching nothing prints `no attached sessions` (or `no attached sessions for <slug>` when scoped) and exits 0 — an empty result reads as a real answer, not a failure or an empty table
+  - no effect on `--json` (the raw daemon response stays complete, matching `--all` and the filter terms) or on `--projects`; `tm sessions ls` and `tm f` are unchanged
+  - `-a` NARROWS here, inverting the `ls -a` / `docker ps -a` convention where it widens; `--all` remains long-only and the two flags are independent

--- a/crates/trusty-mpm/src/assets/skills/tm-cli-operations.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-cli-operations.md
@@ -285,6 +285,19 @@ session picker — a numbered menu of live managed sessions. Actions:
   (never block on stdin). `tm ls --projects` (`-p`) shows the repo-alias /
   project registry instead of sessions.
 
+**`tm ls -a` / `--attached` — only what you're actually looking at.** Lists the
+sessions with a tmux client attached RIGHT NOW, and nothing else. A session can
+be live and reported `active` with nobody connected to it; `-a` drops those.
+The signal is tmux's own `#{session_attached}`, not the lifecycle state word.
+
+- Forces the static table (like `--all`) — a session you already have a client
+  on is the one thing the picker cannot usefully connect you to.
+- Nothing attached prints `no attached sessions` and exits 0.
+- No effect on `--json` (raw daemon response is always complete, matching
+  `--all` and the filter terms) or on `--projects`.
+- ⚠️ `-a` here NARROWS; it does not mean "all" as in `ls -a` / `docker ps -a`.
+  `--all` (tombstones included) stays long-only.
+
 ### Delete / teardown semantics — pick the right verb
 
 | Verb | Runtime | Workspace on disk | Record | Resumable? |

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -877,11 +877,13 @@ pub(crate) enum Command {
     /// What: with `--projects`/`-p`, prints the local-project + managed-fleet alias
     /// registry (`--json` = combined JSON, `--root` overrides the managed root).
     /// Without `--projects`, it is the session connector: a TTY with ≥1 session
-    /// opens the picker; `--json`, `--all`, a non-TTY, or 0 sessions print the
-    /// static table. `--source-id`/`--current`/`--all` mirror `tm sessions ls`.
+    /// opens the picker; `--json`, `--all`, `--attached`/`-a`, a non-TTY, or 0
+    /// sessions print the static table. `--source-id`/`--current`/`--all` mirror
+    /// `tm sessions ls`.
     /// Test: `cli_parses_ls_connector_bare`, `cli_parses_ls_projects`,
     /// `cli_parses_ls_projects_short`, `cli_parses_ls_json`, `cli_parses_ls_current`,
-    /// `cli_ls_source_id_and_current_conflict`, `cli_parses_ls_terms_*`.
+    /// `cli_ls_source_id_and_current_conflict`, `cli_parses_ls_terms_*`,
+    /// `cli_parses_ls_attached_short`, `cli_parses_ls_attached_long`.
     #[command(name = "ls")]
     Ls {
         /// Sort keyword and/or filter term(s) (session mode only; ignored with
@@ -927,8 +929,32 @@ pub(crate) enum Command {
         /// Include decommissioned tombstone sessions (session mode only).
         ///
         /// Forces static output (the full forensic list is not a connect target).
+        /// Note: the short `-a` is `--attached`, NOT this flag — `--all` is
+        /// long-only and always has been.
         #[arg(long)]
         all: bool,
+        /// List ONLY sessions with a tmux client attached right now (session
+        /// mode only).
+        ///
+        /// Why: "which sessions am I actually looking at?" is a different
+        /// question from "which sessions are running". A session can be live —
+        /// its tmux entity exists and the daemon reports `active` — with nobody
+        /// connected to it; `-a` keeps only the ones a client is attached to.
+        /// The signal is the daemon's per-session `attached` flag, which comes
+        /// from tmux's own `#{session_attached}` (see
+        /// `session_manager::driver::TmuxDriver::attached_session_names`), not
+        /// from the lifecycle `state` word.
+        /// What: forces static output for the same reason `--all` does — a
+        /// session you already have a client on is the one target where the
+        /// picker's "connect" action is a no-op, so `-a` is a listing question,
+        /// not a connect one. Matching zero sessions prints `no attached
+        /// sessions` and exits 0. No effect on `--json` (raw daemon response is
+        /// always complete, matching `--all` and the filter terms) or on
+        /// `--projects` (the alias registry has no sessions).
+        /// Test: `cli_parses_ls_attached_short`, `cli_parses_ls_attached_long`,
+        /// `filter_attached_*`, `ls_connector_should_show_picker_attached_static`.
+        #[arg(long, short = 'a')]
+        attached: bool,
         /// Override the managed root (default: `~/.trusty-mpm`). `--projects` only.
         ///
         /// Precedence: this flag > `TRUSTY_MPM_ROOT` env var >

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -205,18 +205,24 @@ pub(crate) fn filter_live_sessions(
 /// `picker_filter_excludes_decommissioned_keeps_active`; sort/filter logic by
 /// `sort_sessions_*` / `filter_sessions_by_term_*` in `session_picker.rs`; the
 /// prune coverage by `session_ls_prunes_dead_records_on_piped_invocation` and
-/// `session_ls_json_passthrough_prunes_dead_records`.
+/// `session_ls_json_passthrough_prunes_dead_records`; the `attached` filter by
+/// `filter_attached_*`.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn session_ls(
     client: &reqwest::Client,
     url: &str,
     json: bool,
     source_id: Option<&str>,
     all: bool,
+    attached: bool,
     sort: crate::commands::session_picker::SessionSortArg,
     term: Option<crate::commands::session_picker::SessionFilter>,
 ) -> anyhow::Result<()> {
     let ctx = crate::commands::session_picker_prune::PruneContext::production();
-    session_ls_at(client, url, json, source_id, all, sort, term, &ctx).await
+    session_ls_at(
+        client, url, json, source_id, all, attached, sort, term, &ctx,
+    )
+    .await
 }
 
 /// [`session_ls`] with an injected auto-prune context — the testable core
@@ -256,6 +262,7 @@ pub(crate) async fn session_ls_at(
     json: bool,
     source_id: Option<&str>,
     all: bool,
+    attached: bool,
     sort: crate::commands::session_picker::SessionSortArg,
     term: Option<crate::commands::session_picker::SessionFilter>,
     ctx: &crate::commands::session_picker_prune::PruneContext,
@@ -291,11 +298,44 @@ pub(crate) async fn session_ls_at(
         all,
         &listing.dead_ids,
     );
-    let mut sessions =
+    let sessions =
         crate::commands::session_picker::filter_sessions_by_term(sessions, term.as_ref());
+    // `tm ls -a`: keep only what a tmux client is on RIGHT NOW.
+    let mut sessions = filter_attached(sessions, attached);
     crate::commands::session_picker::sort_sessions(&mut sessions, sort);
+    if attached && sessions.is_empty() {
+        // An empty table under `-a` is a real answer, not a failure — say so
+        // explicitly and exit 0 rather than printing a bare header.
+        crate::commands::managed_render::render_no_attached_sessions(source_id);
+        return Ok(());
+    }
     crate::commands::managed_render::render_session_table(&sessions, source_id);
     Ok(())
+}
+
+/// Keep only sessions with a tmux client attached (`tm ls -a`).
+///
+/// Why: "attached" and "running" are different states, and only the first
+/// answers "which session am I looking at?". A session whose tmux entity is
+/// live but has no client is reported by the daemon as `active` with
+/// `attached == false` — this filter must drop it, or `-a` degrades into a
+/// second spelling of the default listing.
+/// What: `attached_only == false` returns `sessions` untouched (so every
+/// caller that does not pass `-a` is byte-identically unaffected); otherwise
+/// keeps exactly the summaries whose `attached` flag is set. That flag
+/// originates in tmux's `#{session_attached}`, reconciled by the daemon's list
+/// endpoint — it is never inferred from the lifecycle `state` word.
+/// Test: `filter_attached_keeps_only_attached`,
+/// `filter_attached_excludes_running_but_detached`,
+/// `filter_attached_disabled_is_noop`.
+pub(crate) fn filter_attached(
+    sessions: Vec<trusty_mpm::client::ManagedSessionSummary>,
+    attached_only: bool,
+) -> Vec<trusty_mpm::client::ManagedSessionSummary> {
+    if !attached_only {
+        return sessions;
+    }
+    sessions.into_iter().filter(|s| s.attached).collect()
 }
 
 // The `tm ls` table renderer — `render_session_table` and its pure row/column

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_render.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_render.rs
@@ -73,6 +73,35 @@ fn pad_visible(text: &str, width: usize, color: StateColor, use_color: bool) -> 
     format!("{}{}", colorize(text, color, use_color), " ".repeat(pad))
 }
 
+/// Report that `tm ls -a` matched nothing.
+///
+/// Why: an empty table under `-a` is a legitimate answer — nobody is attached
+/// to anything — and printing a bare header (or nothing) leaves the operator
+/// unable to tell that apart from a broken filter or an unreachable daemon.
+/// The distinct wording also keeps it from reading as "you have no sessions",
+/// which `render_session_table`'s "no managed sessions" would wrongly imply
+/// while a dozen detached sessions are running.
+/// What: prints `no attached sessions[ for <slug>]`, mirroring
+/// [`render_session_table`]'s empty-list phrasing. The caller returns `Ok(())`,
+/// so the exit status is 0.
+/// Test: `render_no_attached_sessions_*` in `tests_behavior_d_tests.rs`.
+pub(crate) fn render_no_attached_sessions(source_id: Option<&str>) {
+    println!("{}", no_attached_sessions_line(source_id));
+}
+
+/// The exact line [`render_no_attached_sessions`] prints, as a pure value.
+///
+/// Why: splitting the string from the `println!` is what makes the message
+/// assertable in a unit test without capturing stdout.
+/// Test: `render_no_attached_sessions_line_unscoped`,
+/// `render_no_attached_sessions_line_scoped_to_source_id`.
+pub(crate) fn no_attached_sessions_line(source_id: Option<&str>) -> String {
+    match source_id {
+        Some(sid) => format!("no attached sessions for {sid}"),
+        None => "no attached sessions".to_string(),
+    }
+}
+
 /// Render the static `tm session ls` / `tm ls` table for a scoped session list.
 ///
 /// Why: both the static list command and the `tm ls` connector's non-picker path

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -373,6 +373,8 @@ pub(crate) async fn session(
                 json,
                 sid.as_deref(),
                 all,
+                // `-a` is a `tm ls` flag only; `tm sessions ls` is unchanged.
+                false,
                 sort,
                 filter,
             )

--- a/crates/trusty-mpm/src/bin/tm/commands/session_ls_connector.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_ls_connector.rs
@@ -27,23 +27,27 @@ use super::session_picker::{
 /// Decide whether `tm ls` should open the interactive picker or print statically.
 ///
 /// Why: a testable seam that folds every gate into one pure decision so the
-/// non-TTY / `--json` / `--all` / empty-list branches are unit-testable without a
-/// live terminal or daemon. Requiring BOTH stdin and stdout to be TTYs is the
-/// anti-hang guarantee: a piped input (would EOF) or a piped output (must stay a
-/// clean pipeable table) both fall through to static output.
-/// What: returns `true` only when stdin AND stdout are TTYs, neither `--json` nor
-/// `--all` was requested, and at least one session exists. `--all` forces static
-/// output because its purpose is the forensic full list (including
-/// decommissioned tombstones), not connecting.
+/// non-TTY / `--json` / `--all` / `--attached` / empty-list branches are
+/// unit-testable without a live terminal or daemon. Requiring BOTH stdin and
+/// stdout to be TTYs is the anti-hang guarantee: a piped input (would EOF) or a
+/// piped output (must stay a clean pipeable table) both fall through to static
+/// output.
+/// What: returns `true` only when stdin AND stdout are TTYs, none of `--json`,
+/// `--all`, or `--attached` was requested, and at least one session exists.
+/// `--all` forces static output because its purpose is the forensic full list
+/// (including decommissioned tombstones), not connecting; `--attached` forces it
+/// because the sessions it keeps are exactly the ones a client is already on, so
+/// the picker's connect action has nothing left to do.
 /// Test: `ls_connector_should_show_picker_*` in `tests_behavior_d_tests.rs`.
 pub(crate) fn should_show_picker(
     stdin_tty: bool,
     stdout_tty: bool,
     json: bool,
     all: bool,
+    attached: bool,
     session_count: usize,
 ) -> bool {
-    stdin_tty && stdout_tty && !json && !all && session_count > 0
+    stdin_tty && stdout_tty && !json && !all && !attached && session_count > 0
 }
 
 /// `tm ls` — the interactive managed-session connector (top-level).
@@ -52,12 +56,15 @@ pub(crate) fn should_show_picker(
 /// managed fleet: on a real terminal it opens the session picker; piped or
 /// scripted it degrades to the same static, pipeable list as `tm session ls`.
 /// What: resolves the scope (`--current` derives `owner/repo` from the cwd git
-/// remote, mirroring `tm session ls`); routes `--json`, `--all`, or any non-TTY
-/// invocation straight to the static [`super::managed::session_ls`] renderer
-/// (preserving its raw `--json` passthrough byte-for-byte); otherwise fetches the
-/// live sessions once and either renders the static table (0 sessions) or opens
-/// [`run_tty_picker`] (≥1 session). Launch-new inside the picker targets the cwd
-/// project only when it is a GitHub-backed git checkout.
+/// remote, mirroring `tm session ls`); routes `--json`, `--all`, `--attached`, or
+/// any non-TTY invocation straight to the static [`super::managed::session_ls`]
+/// renderer (preserving its raw `--json` passthrough byte-for-byte); otherwise
+/// fetches the live sessions once and either renders the static table (0
+/// sessions) or opens [`run_tty_picker`] (≥1 session). Launch-new inside the
+/// picker targets the cwd project only when it is a GitHub-backed git checkout.
+/// `attached` is a pure listing filter and never reaches the picker — see
+/// [`should_show_picker`] — so the static renderer is the single place it is
+/// applied.
 /// Test: parse tests `cli_parses_ls_*` and the gate tests
 /// `ls_connector_should_show_picker_*` in `tests_behavior_d_tests.rs`.
 #[allow(clippy::too_many_arguments)]
@@ -68,6 +75,7 @@ pub(crate) async fn run_ls_connector(
     source_id: Option<String>,
     current: bool,
     all: bool,
+    attached: bool,
     sort: SessionSortArg,
     term: Option<SessionFilter>,
 ) -> anyhow::Result<()> {
@@ -83,14 +91,24 @@ pub(crate) async fn run_ls_connector(
     let stdin_tty = std::io::stdin().is_terminal();
     let stdout_tty = std::io::stdout().is_terminal();
 
-    // Cheap pre-gate: `--json`, `--all`, or any non-interactive stream never
-    // fetches for the picker — delegate straight to the static renderer, which
-    // owns the raw `--json` passthrough and the `--all` tombstone sort. `sort`/
-    // `term` ride along (the static renderer applies them; `--json` ignores
-    // them, matching `--all`'s existing "no effect on --json" precedent).
-    if json || all || !stdin_tty || !stdout_tty {
-        return super::managed::session_ls(client, url, json, sid.as_deref(), all, sort, term)
-            .await;
+    // Cheap pre-gate: `--json`, `--all`, `--attached`, or any non-interactive
+    // stream never fetches for the picker — delegate straight to the static
+    // renderer, which owns the raw `--json` passthrough, the `--all` tombstone
+    // sort, and the `-a` attached-only filter. `sort`/`term` ride along (the
+    // static renderer applies them; `--json` ignores them, matching `--all`'s
+    // existing "no effect on --json" precedent).
+    if json || all || attached || !stdin_tty || !stdout_tty {
+        return super::managed::session_ls(
+            client,
+            url,
+            json,
+            sid.as_deref(),
+            all,
+            attached,
+            sort,
+            term,
+        )
+        .await;
     }
 
     // Interactive stream: fetch the live sessions once. On any fetch error
@@ -105,6 +123,7 @@ pub(crate) async fn run_ls_connector(
                 false,
                 sid.as_deref(),
                 false,
+                false,
                 sort,
                 term,
             )
@@ -114,7 +133,7 @@ pub(crate) async fn run_ls_connector(
     let mut sessions = filter_sessions_by_term(sessions, term.as_ref());
     sort_sessions(&mut sessions, sort);
 
-    if !should_show_picker(stdin_tty, stdout_tty, json, all, sessions.len()) {
+    if !should_show_picker(stdin_tty, stdout_tty, json, all, attached, sessions.len()) {
         // 0 sessions on a TTY: print the static "no managed sessions" line rather
         // than an empty picker.
         super::managed_render::render_session_table(&sessions, sid.as_deref());

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_filter.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_filter.rs
@@ -300,6 +300,8 @@ pub(crate) async fn run_f_command(
             json,
             sid.as_deref(),
             all,
+            // `-a` is a `tm ls` flag only; `tm f`'s fallback is unchanged.
+            false,
             SessionSortArg::Recent,
             filter,
         )

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -560,6 +560,7 @@ async fn main() -> anyhow::Result<()> {
             source_id,
             current,
             all,
+            attached,
             root,
         }) => {
             if projects {
@@ -574,7 +575,7 @@ async fn main() -> anyhow::Result<()> {
                 // #3483 scope: `tm ls <term>` matches every visible column.
                 let filter = term.map(commands::session_picker::SessionFilter::visible);
                 commands::session_ls_connector::run_ls_connector(
-                    &client, &url, json, source_id, current, all, sort, filter,
+                    &client, &url, json, source_id, current, all, attached, sort, filter,
                 )
                 .await
             }

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -781,6 +781,7 @@ fn cli_parses_ls_connector_bare() {
             source_id,
             current,
             all,
+            attached,
             root,
         } => {
             assert!(
@@ -792,6 +793,7 @@ fn cli_parses_ls_connector_bare() {
             assert!(source_id.is_none());
             assert!(!current);
             assert!(!all);
+            assert!(!attached, "bare `tm ls` must not set --attached");
             assert!(root.is_none());
         }
         other => panic!("expected top-level ls, got {other:?}"),
@@ -828,6 +830,66 @@ fn cli_parses_ls_json() {
             assert!(!projects, "--json alone must not imply --projects");
         }
         other => panic!("expected top-level ls --json, got {other:?}"),
+    }
+}
+
+/// `tm ls -a` parses as attached-only, and does NOT set `--all`.
+///
+/// Why: `-a` conventionally means "all" (`ls -a`, `docker ps -a`), and `--all`
+/// is a real neighbouring flag on this very command. This asserts the short
+/// binds to `--attached` and leaves `--all` alone, so a future reader cannot
+/// quietly swap them.
+#[test]
+fn cli_parses_ls_attached_short() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "ls", "-a"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Ls {
+            attached,
+            all,
+            projects,
+            ..
+        } => {
+            assert!(attached, "-a must parse to --attached");
+            assert!(!all, "-a must NOT set --all");
+            assert!(!projects, "-a alone must not imply --projects");
+        }
+        other => panic!("expected top-level ls -a, got {other:?}"),
+    }
+}
+
+/// `tm ls --attached` is the long spelling of `-a`.
+#[test]
+fn cli_parses_ls_attached_long() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "ls", "--attached"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Ls { attached, all, .. } => {
+            assert!(attached, "--attached must parse to true");
+            assert!(!all);
+        }
+        other => panic!("expected top-level ls --attached, got {other:?}"),
+    }
+}
+
+/// `--all` stays long-only: it and `-a` are independent flags that can coexist.
+#[test]
+fn cli_parses_ls_all_and_attached_are_independent() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "ls", "--all"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Ls { all, attached, .. } => {
+            assert!(all, "--all must parse to true");
+            assert!(!attached, "--all must NOT imply --attached");
+        }
+        other => panic!("expected top-level ls --all, got {other:?}"),
+    }
+    let both = Cli::try_parse_from(["trusty-mpm", "ls", "--all", "-a"]).unwrap();
+    match both.command.unwrap() {
+        Command::Ls { all, attached, .. } => {
+            assert!(
+                all && attached,
+                "--all -a must parse as both, not a conflict"
+            );
+        }
+        other => panic!("expected top-level ls --all -a, got {other:?}"),
     }
 }
 
@@ -879,8 +941,8 @@ use crate::commands::session_ls_connector::should_show_picker;
 /// The picker opens only on a fully-interactive terminal with ≥1 session.
 #[test]
 fn ls_connector_should_show_picker_interactive_with_sessions() {
-    assert!(should_show_picker(true, true, false, false, 1));
-    assert!(should_show_picker(true, true, false, false, 5));
+    assert!(should_show_picker(true, true, false, false, false, 1));
+    assert!(should_show_picker(true, true, false, false, false, 5));
 }
 
 /// A non-TTY stdin OR stdout forces the static (pipeable) list path — never a
@@ -888,14 +950,14 @@ fn ls_connector_should_show_picker_interactive_with_sessions() {
 #[test]
 fn ls_connector_should_show_picker_non_tty_static() {
     assert!(
-        !should_show_picker(false, true, false, false, 3),
+        !should_show_picker(false, true, false, false, false, 3),
         "piped stdin -> static"
     );
     assert!(
-        !should_show_picker(true, false, false, false, 3),
+        !should_show_picker(true, false, false, false, false, 3),
         "piped stdout -> static"
     );
-    assert!(!should_show_picker(false, false, false, false, 3));
+    assert!(!should_show_picker(false, false, false, false, false, 3));
 }
 
 /// `--json` and `--all` force static output even on a TTY, and 0 sessions never
@@ -903,16 +965,33 @@ fn ls_connector_should_show_picker_non_tty_static() {
 #[test]
 fn ls_connector_should_show_picker_flags_and_empty_static() {
     assert!(
-        !should_show_picker(true, true, true, false, 3),
+        !should_show_picker(true, true, true, false, false, 3),
         "--json -> static"
     );
     assert!(
-        !should_show_picker(true, true, false, true, 3),
+        !should_show_picker(true, true, false, true, false, 3),
         "--all -> static"
     );
     assert!(
-        !should_show_picker(true, true, false, false, 0),
+        !should_show_picker(true, true, false, false, false, 0),
         "0 sessions -> static"
+    );
+}
+
+/// `-a` forces the static listing even on a full TTY with sessions present.
+///
+/// Why: the sessions `-a` keeps are exactly the ones a client is already on, so
+/// opening the picker to "connect" to one is a no-op. The flag is a listing
+/// question, and it must answer in a pipeable table like `--all` does.
+#[test]
+fn ls_connector_should_show_picker_attached_static() {
+    assert!(
+        !should_show_picker(true, true, false, false, true, 3),
+        "--attached -> static even with sessions on a TTY"
+    );
+    assert!(
+        should_show_picker(true, true, false, false, false, 3),
+        "the same invocation WITHOUT -a still opens the picker"
     );
 }
 
@@ -1049,6 +1128,106 @@ fn ls_test_session(
         slot: 0,
         deleted: false,
     }
+}
+
+// ── `tm ls -a` — attached-only listing ──────────────────────────────────────
+
+/// `-a` keeps exactly the sessions a tmux client is on.
+#[test]
+fn filter_attached_keeps_only_attached() {
+    let mut connected = ls_test_session("connected", "active", None, None, None, None);
+    connected.attached = true;
+    let mut also_connected = ls_test_session("also-connected", "active", None, None, None, None);
+    also_connected.attached = true;
+    let lonely = ls_test_session("lonely", "active", None, None, None, None);
+
+    let out =
+        crate::commands::managed::filter_attached(vec![connected, lonely, also_connected], true);
+
+    let names: Vec<&str> = out.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, vec!["connected", "also-connected"]);
+}
+
+/// A session that is RUNNING but has no client attached must NOT appear under
+/// `-a`.
+///
+/// Why: this is the whole feature. `state == "active"` means the tmux entity is
+/// live; `attached` means somebody is looking at it. If a detached-but-running
+/// session survived this filter, `-a` would just be a slower spelling of the
+/// default listing.
+#[test]
+fn filter_attached_excludes_running_but_detached() {
+    // Identical in every respect EXCEPT the attach flag — so nothing but
+    // `attached` can be what separates them.
+    let mut watched = ls_test_session("running", "active", None, None, None, None);
+    watched.attached = true;
+    let mut unwatched = ls_test_session("running", "active", None, None, None, None);
+    unwatched.attached = false;
+
+    let out = crate::commands::managed::filter_attached(vec![watched, unwatched], true);
+
+    assert_eq!(
+        out.len(),
+        1,
+        "the detached `active` session must be dropped"
+    );
+    assert!(out[0].attached);
+}
+
+/// With `-a` off, the listing is byte-identical to today's — the filter is a
+/// no-op, not a reorder or a dedupe.
+#[test]
+fn filter_attached_disabled_is_noop() {
+    let mut connected = ls_test_session("connected", "active", None, None, None, None);
+    connected.attached = true;
+    let sessions = vec![
+        ls_test_session("stopped-one", "stopped", None, None, None, None),
+        connected,
+        ls_test_session("detached-active", "active", None, None, None, None),
+    ];
+    let before: Vec<String> = sessions.iter().map(|s| s.name.clone()).collect();
+
+    let out = crate::commands::managed::filter_attached(sessions, false);
+
+    let after: Vec<String> = out.iter().map(|s| s.name.clone()).collect();
+    assert_eq!(before, after, "-a off must leave the list untouched");
+}
+
+/// Zero attached sessions is an ANSWER, not an error: `-a` says so in words.
+#[test]
+fn filter_attached_zero_matches_yields_the_explicit_line() {
+    let running_but_detached = vec![
+        ls_test_session("a", "active", None, None, None, None),
+        ls_test_session("b", "active", None, None, None, None),
+    ];
+
+    let out = crate::commands::managed::filter_attached(running_but_detached, true);
+
+    assert!(out.is_empty(), "no session in the fixture is attached");
+    // The caller renders this line and returns Ok(()) — exit 0, never an error.
+    assert_eq!(
+        crate::commands::managed_render::no_attached_sessions_line(None),
+        "no attached sessions"
+    );
+}
+
+/// The zero-attached line, unscoped.
+#[test]
+fn render_no_attached_sessions_line_unscoped() {
+    assert_eq!(
+        crate::commands::managed_render::no_attached_sessions_line(None),
+        "no attached sessions"
+    );
+}
+
+/// The zero-attached line names the scope when one was given, mirroring
+/// `render_session_table`'s "no managed sessions for <slug>".
+#[test]
+fn render_no_attached_sessions_line_scoped_to_source_id() {
+    assert_eq!(
+        crate::commands::managed_render::no_attached_sessions_line(Some("owner/repo")),
+        "no attached sessions for owner/repo"
+    );
 }
 
 /// The filter matches a substring of the `name` column, case-insensitively.
@@ -2746,6 +2925,7 @@ async fn session_ls_prunes_dead_records_on_piped_invocation() {
             false, // json = false: the piped/scripted table path
             None,
             false,
+            false, // attached = false: unfiltered, as `tm ls` is by default
             crate::commands::session_picker::SessionSortArg::Recent,
             None,
             ctx,
@@ -2796,6 +2976,7 @@ async fn session_ls_json_passthrough_prunes_dead_records() {
             true, // json = true
             None,
             false,
+            false, // attached = false
             crate::commands::session_picker::SessionSortArg::Recent,
             None,
             ctx,
@@ -3467,6 +3648,7 @@ async fn session_ls_json_never_refetches_after_pruning() {
         true,
         None,
         false,
+        false, // attached = false
         crate::commands::session_picker::SessionSortArg::Recent,
         None,
         &hermetic_prune_ctx(&marker_path),


### PR DESCRIPTION
`tm ls -a` (long form `--attached`) lists only the sessions a tmux client is
connected to right now.

## What "attached" means here

Not "running". The daemon already ships a per-session `attached` flag on
`ManagedSessionSummary`, sourced from tmux's own `#{session_attached}` via
`TmuxDriver::attached_session_names` — the same signal the picker uses to render
the `attached` state word and the same one `sort_sessions`' `group_rank` already
sorts to the top. A session whose tmux entity is live but has nobody looking at
it reports `state == "active"` with `attached == false`, and `-a` drops it.

That exclusion is the whole feature, and it has its own test:
`filter_attached_excludes_running_but_detached` builds two sessions identical in
every field *except* `attached`, so nothing but the attach flag can be what
separates them.

## Where the flag applies

| Path | `-a` applies? | Why |
|---|---|---|
| static / piped listing | **yes** | this is the listing question `-a` asks |
| TTY picker | **no — `-a` forces static** | the sessions `-a` keeps are exactly the ones you already have a client on, so the picker's "connect" action has nothing to do. Same reasoning `--all` already uses to force static output. |
| `--json` | no | raw daemon passthrough stays byte-complete, matching the documented precedent for `--all` and the filter terms |
| `--projects` | no | the alias/project registry has no sessions |

`tm sessions ls` and `tm f` pass `false` and are byte-identically unchanged.

Because `-a` forces static, the filter is applied in exactly one place
(`session_ls_at`) rather than duplicated across the picker and table paths, and
`PickerScope` needs no new field.

## Zero attached

Prints `no attached sessions` (or `no attached sessions for <slug>` when scoped)
and exits 0. An empty result under `-a` is a real answer — printing a bare table
header, or reusing "no managed sessions" while a dozen detached sessions are
running, would both misreport it.

## Note on the spelling of `-a`

`-a` conventionally *widens* (`ls -a`, `docker ps -a`). Here it **narrows**, and
it sits next to a real `--all` flag on the same command. The owner asked for `-a`
explicitly and that is what ships, but the alternative spellings are worth naming
so the choice stays visible and reversible: `--attached` with no short at all, or
a different short such as `-A`. `--all` remains long-only and the two are
independent flags — `cli_parses_ls_all_and_attached_are_independent` pins that
`-a` does not set `--all` and that `--all -a` parses as both rather than a
conflict.

## Test ladder

Rung 3 — localized behavior inside one crate.

```
cargo fmt --check                                     EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-mpm                              4910 passed; 3 failed (pre-existing, see below); 7 ignored
scripts/check_line_cap.sh        measured 3940 tracked .rs file(s); 4 allowlisted, 0 violations — OK
scripts/check_changelog_fragment.sh  scanned 10 changed path(s); all 1 crate(s) with source changes are recorded
scripts/check_capabilities.sh    tm-capabilities: up to date (7 generated files)
scripts/check_test_pointers.sh   14 dangling pointer(s) — all in crates/trusty-search, 0 in trusty-mpm (pre-existing, see below)
```

New coverage (8 tests, all passing):
`cli_parses_ls_attached_short`, `cli_parses_ls_attached_long`,
`cli_parses_ls_all_and_attached_are_independent`,
`ls_connector_should_show_picker_attached_static`,
`filter_attached_keeps_only_attached`,
`filter_attached_excludes_running_but_detached`,
`filter_attached_disabled_is_noop`,
`filter_attached_zero_matches_yields_the_explicit_line`,
plus `render_no_attached_sessions_line_{unscoped,scoped_to_source_id}`.

`scripts/check_capabilities.sh` is green without a regeneration: the generated
CLI catalog records each command's summary line, not its flags, and this PR does
not change `ls`'s summary.

## Pre-existing baseline failures — NOT caused by this branch

Both red CI checks live entirely in `crates/trusty-search`, and both are red on
`main` itself — `gh run list --branch main` shows the two most recent runs of
each workflow already failing. `git diff --name-only origin/main...HEAD --
crates/trusty-search/` returns 0 paths: this branch touches no file in that
crate.

**1. `Test pointers` — 14 dangling pointers, all in `crates/trusty-search`.**
Zero are in `trusty-mpm`. Every `Test:` pointer this PR adds resolves to a test
that exists and passes.

**1b. `Teardown guard` — undeclared `save_contrib_graph()` calls in
`crates/trusty-search/src/core/corpus/contrib.rs`.** Same crate, same story.

**2. Three `core::pm_prompt_golden_tests` fail on `origin/main` as of a4de90740:**

```
core::pm_prompt_golden_tests::golden_bundled_fallback_prompt
core::pm_prompt_golden_tests::golden_claude_md_override_prompt
core::pm_prompt_golden_tests::golden_roster_absent_assembly_prompt
```

The diverging bytes are the `search_health` wording added to
`crates/trusty-mpm/src/assets/instructions/sections/non-overridable-rules.md` by
a4de90740 (#5536), which changed that prompt section without regenerating
`src/core/testdata/pm-prompt-*.md`. This branch touches none of those files.
Deliberately not regenerating the goldens here — that snapshot is #5536's
missing artifact, and folding an unrelated delivered-prompt diff into this PR
would hide it rather than surface it.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
