### PR TITLE
fix(trusty-mpm): regenerate stale PM-prompt golden fixtures after #5536

### DIFF
--- a/crates/trusty-mpm/changelog.d/5536-golden-prompt-fixture-regen.md
+++ b/crates/trusty-mpm/changelog.d/5536-golden-prompt-fixture-regen.md
@@ -1,0 +1,8 @@
+Fixed
+
+- Regenerated the three committed PM-prompt golden fixtures
+  (`pm-prompt-bundled-fallback.md`, `pm-prompt-claude-md-override.md`,
+  `pm-prompt-roster-absent.md`) that went stale when #5536 updated the
+  `search_health` liveness doc text without updating the snapshots, which left
+  `golden_bundled_fallback_prompt`, `golden_claude_md_override_prompt`, and
+  `golden_roster_absent_assembly_prompt` failing on every run.

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -514,7 +514,9 @@ with `curl`/`lsof`/`ps`/`netstat`.
 - `mcp__trusty-search__search` before Read/Grep. **Omit `index_id`** — your
   `.mcp.json` pins this session to its own index, and a guessed id fails with
   `404 unknown index` (#1373).
-- `mcp__trusty-search__search_health` for liveness, not a shell command.
+- `mcp__trusty-search__search_health` for liveness, not a shell command — it
+  returns `Ok` even when the daemon is down, so branch on `healthy`, not on
+  the call succeeding.
 
 Full per-tool tables: `Skill(skill="tm-tool-usage-guide")`. A tool missing from
 your loaded list is not unavailable — load its schema with `ToolSearch` first.

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
@@ -409,7 +409,9 @@ with `curl`/`lsof`/`ps`/`netstat`.
 - `mcp__trusty-search__search` before Read/Grep. **Omit `index_id`** — your
   `.mcp.json` pins this session to its own index, and a guessed id fails with
   `404 unknown index` (#1373).
-- `mcp__trusty-search__search_health` for liveness, not a shell command.
+- `mcp__trusty-search__search_health` for liveness, not a shell command — it
+  returns `Ok` even when the daemon is down, so branch on `healthy`, not on
+  the call succeeding.
 
 Full per-tool tables: `Skill(skill="tm-tool-usage-guide")`. A tool missing from
 your loaded list is not unavailable — load its schema with `ToolSearch` first.

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -500,7 +500,9 @@ with `curl`/`lsof`/`ps`/`netstat`.
 - `mcp__trusty-search__search` before Read/Grep. **Omit `index_id`** — your
   `.mcp.json` pins this session to its own index, and a guessed id fails with
   `404 unknown index` (#1373).
-- `mcp__trusty-search__search_health` for liveness, not a shell command.
+- `mcp__trusty-search__search_health` for liveness, not a shell command — it
+  returns `Ok` even when the daemon is down, so branch on `healthy`, not on
+  the call succeeding.
 
 Full per-tool tables: `Skill(skill="tm-tool-usage-guide")`. A tool missing from
 your loaded list is not unavailable — load its schema with `ToolSearch` first.


### PR DESCRIPTION
## Summary

Main was red on Rust test shards 3 and 4: three deterministic failures in
`crates/trusty-mpm/src/core/pm_prompt_golden_tests.rs` — `golden_bundled_fallback_prompt`,
`golden_claude_md_override_prompt`, `golden_roster_absent_assembly_prompt`.

Cause: #5536 added a sentence to the `search_health` liveness doc text across
three bundled agent docs — it returns `Ok` even when the daemon is down, so
callers branch on `healthy`, not on the call succeeding — but never
regenerated the golden fixtures under `crates/trusty-mpm/src/core/testdata/`
that byte-diff the composed PM prompt. The doc change is correct and stays;
only the fixtures were stale. Not flaky — failed on every run since #5536
merged, invisible to `cargo test -p trusty-search` and outside the six
required contexts, which is why the PR that introduced it never saw it.

Regenerated with `UPDATE_GOLDEN=1 cargo test -p trusty-mpm golden` (env var
and filter confirmed from `pm_prompt_golden_tests.rs` line 31/73).

## Regenerated fixture diff

Identical single-hunk change in all three fixtures, every line tracing to
#5536's doc edit — nothing else changed:

```diff
diff --git a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -514,7 +514,9 @@ with `curl`/`lsof`/`ps`/`netstat`.
 - `mcp__trusty-search__search` before Read/Grep. **Omit `index_id`** — your
   `.mcp.json` pins this session to its own index, and a guessed id fails with
   `404 unknown index` (#1373).
-- `mcp__trusty-search__search_health` for liveness, not a shell command.
+- `mcp__trusty-search__search_health` for liveness, not a shell command — it
+  returns `Ok` even when the daemon is down, so branch on `healthy`, not on
+  the call succeeding.
 
 Full per-tool tables: `Skill(skill="tm-tool-usage-guide")`. A tool missing from
 your loaded list is not unavailable — load its schema with `ToolSearch` first.
```

The same four-line hunk appears at the corresponding location in
`pm-prompt-claude-md-override.md` and `pm-prompt-roster-absent.md`.

## Test ladder

**Rung 2** — test-fixture stabilization (golden snapshot regeneration, no
production behavior change).

```
cargo fmt --check                                        # PASS
cargo check -p trusty-mpm                                 # PASS
cargo clippy -p trusty-mpm --all-targets -- -D warnings    # PASS, 0 warnings
cargo test -p trusty-mpm                                   # PASS, 4913 passed; 0 failed; 7 ignored (lib target)
bash scripts/check_line_cap.sh                              # PASS
bash scripts/check_sld.sh                                   # PASS
bash scripts/check_test_pointers.sh                         # PASS
bash scripts/check_changelog_fragment.sh                    # PASS
```

Previously-failing tests now passing (raw output):

```
test core::pm_prompt_golden_tests::golden_bundled_fallback_prompt ... ok
test core::pm_prompt_golden_tests::golden_roster_absent_assembly_prompt ... ok
test core::pm_prompt_golden_tests::golden_claude_md_override_prompt ... ok
```

## Notes

- No issue exists for this; #5536 referenced above in prose only.
- No `Cargo.toml` version touched — trusty-mpm in-tree is already 1.3.6
  against published 1.3.5.
- Checked `crates/trusty-mpm/src/assets/` (a sibling session's active area)
  for overlap — untouched by this PR, only `src/core/testdata/` and the new
  changelog fragment changed.
- Final gate counts came from the staged/committed tree (`git add` run before
  `check_line_cap.sh` / `check_test_pointers.sh`).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
