### PR TITLE
fix(trusty-mpm): scope tm-ticketing's confidence-state marker to defect issues

### DIFF
--- a/crates/trusty-mpm/changelog.d/ticketing-confidence-line-defects-only.md
+++ b/crates/trusty-mpm/changelog.d/ticketing-confidence-line-defects-only.md
@@ -1,0 +1,10 @@
+Fixed
+
+- The `tm-ticketing` skill's confidence-state marker (`Observed` /
+  `Reproduced` / `Inferred` / `Speculative`) is now scoped to defect (`bug`)
+  issue bodies. It used to be required on every filed issue, which produced
+  lines like `Confidence: Observed … — accepted feature work` on feature
+  tickets — a restatement of the type label that carries no information,
+  since a feature ticket has no "reproduced vs. suspected" axis to report.
+  Bug tickets are unaffected: the marker still distinguishes a reproduced
+  defect from a suspected one there, which changes what a reader does next.

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -107,9 +107,11 @@ disposition in `code-review-standards`. A reviewer marking `Promote` has
 recommended, not filed — the finding still has to clear the criteria above, and
 an APPROVE verdict never files a ticket on its own.
 
-### 3. Label the confidence state
+### 3. Label the confidence state — defects only
 
-Every filed issue states which of these it is, in the body:
+This distinguishes a reproduced defect from a suspected one, which changes
+what a reader does next: a `bug`-typed issue states which of these it is, in
+the body.
 
 | State | Meaning | Default disposition |
 |---|---|---|
@@ -121,6 +123,12 @@ Every filed issue states which of these it is, in the body:
 If your own draft says "not confirmed", "possible", or "same risk class", the
 state is Inferred or Speculative — keep it on the parent unless severity
 justifies escalation.
+
+🔴 **A feature, task, epic, or spec issue carries no confidence line.** The
+table above is written in defect language (behaviour, reproduction, risk) and
+has nothing to distinguish on a feature: the type label already says why the
+issue exists, and a line like "Confidence: Observed — accepted feature work"
+restates the type label under a different name. Omit it there entirely.
 
 ### 4. Size issues by outcome, not by finding
 
@@ -149,9 +157,11 @@ Ticket Bodies") — no structured headings, point rather than restate, cite file
 and symbol rather than line numbers, and stop when the body fills a short screen.
 Most tickets do all of it in under ten lines.
 
-Alongside the closure conditions a reader must be able to tell the confidence
-state (§3) and the relationship to parent work, including the search/dispatch
-outcome. Those are facts to convey, not headings to fill in.
+Alongside the closure conditions, a **defect** ticket must let the reader tell
+the confidence state (§3); a feature, task, epic, or spec ticket carries none.
+Every ticket, defect or not, conveys its relationship to parent work,
+including the search/dispatch outcome — a fact about the issue, not a heading
+to fill in.
 
 **Bounded exceptions.** Three shapes may exceed the short-body form, and only
 these:


### PR DESCRIPTION
## What

Scopes the `tm-ticketing` skill's confidence-state marker (`Observed` /
`Reproduced` / `Inferred` / `Speculative`) to defect (`bug`) issues. It was
mandatory on every filed issue, which produced lines like `Confidence:
Observed (…) — accepted feature work` on feature tickets — a restatement of
the type label under a different name, since the state table (behaviour,
reproduction, risk) has nothing to distinguish once a feature is already
accepted via promotion criterion (b).

Bug tickets are unaffected: `Observed` vs. `Inferred` still separates a
reproduced defect from a suspected one there, and still changes what a
reader does next.

## Where it came from

(a) — mandated by the skill's own template, not invented by the filing
agent. `crates/trusty-mpm/src/assets/skills/tm-ticketing.md` said "Every
filed issue states which of these it is, in the body" (§3), and "What a
Ticket Says" separately required every ticket's body to convey the
confidence state. Neither line scoped the requirement to defects, so it
applied uniformly to features and tasks too.

## Before / after

Before (§3 header + intro):
```
### 3. Label the confidence state

Every filed issue states which of these it is, in the body:
```
and ("What a Ticket Says"):
```
Alongside the closure conditions a reader must be able to tell the confidence
state (§3) and the relationship to parent work, including the search/dispatch
outcome. Those are facts to convey, not headings to fill in.
```

After (§3 header + intro, plus a new closing rule):
```
### 3. Label the confidence state — defects only

This distinguishes a reproduced defect from a suspected one, which changes
what a reader does next: a `bug`-typed issue states which of these it is, in
the body.
...
🔴 **A feature, task, epic, or spec issue carries no confidence line.** The
table above is written in defect language (behaviour, reproduction, risk) and
has nothing to distinguish on a feature: the type label already says why the
issue exists, and a line like "Confidence: Observed — accepted feature work"
restates the type label under a different name. Omit it there entirely.
```
and ("What a Ticket Says"):
```
Alongside the closure conditions, a **defect** ticket must let the reader tell
the confidence state (§3); a feature, task, epic, or spec ticket carries none.
Every ticket, defect or not, conveys its relationship to parent work,
including the search/dispatch outcome — a fact about the issue, not a heading
to fill in.
```

## Sibling check

Searched `tm-ticketing.md`, the `ticketing` agent asset
(`assets/agents/ticketing.md`), and `tm-bug-reporting.md` for any other field
of the same shape — reporting the filer's process or epistemic state rather
than the ticket's content. Found none: the confidence marker was the only
such field. "The relationship to parent work, including the search/dispatch
outcome" (also in "What a Ticket Says") is left as-is — it reports a
connection between issues (e.g. "distinct from #X, a verified fix"), which is
content the reader needs, not the filer's process.

## Skill-staleness / deployment consequence

This edits the bundled asset at `crates/trusty-mpm/src/assets/skills/tm-ticketing.md`,
embedded into the `tm` binary via `include_str!` (`InstallPolicy::Overwrite`
in `bundle_all.rs`). Merging this PR does **not** by itself change any
already-deployed skill copy in any project — `tm doctor`'s `skill_staleness`
check compares a deployed copy's checksum against the *currently installed
binary's* bundled source, and that binary is unchanged until it's rebuilt.

What an operator must run for this to take effect:
1. Get a `tm` binary built from a commit that includes this change — the
   normal release path (`cargo-publish` skill / `local-ops`), or for
   immediate local testing, `cargo install --path crates/trusty-mpm --locked`
   from this branch.
2. Run `tm install`, or just launch/resume a session. Every one of those
   paths calls `deploy_all_skill_tiers`, which is an unconditional overwrite
   for a framework-owned skill — no `--reconcile-skills` or other flag
   needed (that flag is for a different failure class, #4605's orphaned
   bundled-skill case, not this one).
3. After that redeploy, `tm doctor`'s `skill_staleness` check is green again
   for every tier that was redeployed.

Until step 1–2 happen on a given machine, `tm doctor` may legitimately report
`tm-ticketing` as stale wherever it's deployed — that is the expected
self-heal window this check exists to surface, not a broken state this PR
leaves behind.

## Gates run (rung 1 — docs/skill-asset only, no `.rs` changed)

```
cargo fmt --check                        → EXIT=0
cargo check -p trusty-mpm                → EXIT=0
bash scripts/check_sld.sh                → EXIT=0
bash scripts/check_doc_numbers.sh        → EXIT=0
bash scripts/check_line_cap.sh           → EXIT=0
bash scripts/check_changelog_fragment.sh → EXIT=0
bash scripts/check_agent_assets.sh       → EXIT=0
bash scripts/check_capabilities.sh       → EXIT=0
bash scripts/check_test_pointers.sh      → EXIT=0 ("resolved 23972 Test: citation(s) — 0 dangling pointers — OK")
```

Changelog fragment: `crates/trusty-mpm/changelog.d/ticketing-confidence-line-defects-only.md`
(required — the asset lives under `crates/trusty-mpm/src/**`).

No issue filed for this — same-session fix per the owner's standing
preference; context is in this PR body.

**Known unrelated CI failure inherited from `main`:** `Teardown guard` is red
on `main` for a pre-existing false positive in `crates/trusty-search/`, not
touched by this PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
