### PR TITLE
ci(semver-checks): install libdbus-1-dev so cargo-semver-checks can run against trusty-common

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -190,6 +190,22 @@ jobs:
         if: steps.crate.outputs.have_work == 'true'
         uses: dtolnay/rust-toolchain@stable
 
+      # #5440: trusty-common's `keyring-store` feature pulls in libdbus-sys,
+      # whose build.rs shells out to `pkg-config dbus-1`. That package is
+      # absent on the ubuntu-latest runner image, so building rustdoc for
+      # trusty-common under `--only-explicit-features` (which includes every
+      # non-excluded feature, keyring-store among them — see feature_args() in
+      # scripts/check_semver.sh) aborted before cargo-semver-checks ever
+      # compared an API. That is a NO VERDICT (exit 3), not a pass and not a
+      # confirmed-unchanged API — see the "Enforce public-API SemVer" step
+      # below. libdbus-1-dev supplies the `dbus-1` pkg-config package this
+      # build.rs looks for.
+      - name: Install system dependencies (libdbus for keyring-store)
+        if: steps.crate.outputs.have_work == 'true'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libdbus-1-dev
+
       # A prebuilt binary, PINNED. `cargo install cargo-semver-checks` compiles
       # ~2 minutes of tool before a single crate is checked. install-action
       # downloads a release artifact instead, and pinning the version keeps a


### PR DESCRIPTION
## What broke

`trusty-common`'s `keyring-store` feature pulls in `libdbus-sys`, whose `build.rs` shells out to `pkg-config dbus-1`. `libdbus-1-dev` is absent on the `ubuntu-latest` runner, so the rustdoc build for `trusty-common` in `.github/workflows/semver-checks.yml` aborted before `cargo-semver-checks` ever compared an API — a NO VERDICT (exit 3), not a pass and not confirmation the API is unchanged. `scripts/preflight-publish.sh` CHECK 5 then blocks any publish on this, correctly but for the wrong reason. Full root cause: #5440.

## Fix

Added an `apt-get install libdbus-1-dev` step to the one CI job that needs it — `semver-checks.yml`'s `semver-checks` job, gated the same way as the surrounding steps (`if: steps.crate.outputs.have_work == 'true'`).

I searched every workflow under `.github/workflows/` for a job that builds/documents `trusty-common` with `keyring-store` (including implicitly via `--all-features`). No other job does: `ci.yml`'s clippy/test/msrv jobs run `--workspace` without any crate enabling `keyring-store` by default (grepped every `Cargo.toml` — no consumer turns it on), and `release.yml` treats `trusty-common` as library-only (`bundled=true`, build skipped entirely). So `semver-checks.yml` is the only affected job.

No macOS job is affected either way: `cargo tree -p trusty-common --features keyring-store -i libdbus-sys` on this (darwin) machine prints "nothing to print" — `libdbus-sys` is not in the resolved graph for the macOS target at all (`keyring` uses `apple-native`/Security framework there), so no Homebrew step is needed or added.

## Verdict evidence

Reproduced the exact failure and the fix in an `ubuntu:24.04` container (matching the CI runner OS): a minimal crate depending on `libdbus-sys` fails identically without `libdbus-1-dev` (`pkg-config exited with status code 1`, `Package dbus-1 was not found`) and builds cleanly with it installed.

Then ran the real gate, `bash scripts/check_semver.sh --crate trusty-common`, in that same container with `libdbus-1-dev` + `cmake` installed (GitHub's `ubuntu-latest` image ships `cmake` preinstalled; my bare container needed it added for an unrelated feature, `memory-core-kuzu`) — this exercises all 42 of `trusty-common`'s non-excluded features at once, `keyring-store` included:

```
CHECK trusty-common: 0.33.0 -> 0.33.1 (minor release), 42 feature(s)
    Building trusty-common v0.33.1 (current)
       Built [ 148.447s] (current)
    Building trusty-common v0.33.0 (baseline)
       Built [ 159.159s] (baseline)
    Checking trusty-common v0.33.0 -> v0.33.1 (minor change)
     Checked [   0.101s] 196 checks: 196 pass, 58 skip
     Summary no semver update required
    Finished [ 315.028s] trusty-common
semver gate: scanned (explicit); 1 crate(s) checked, 0 skipped — OK.
SCRIPT_EXIT=0
```

`dbus v0.9.12` and `dbus-secret-service v4.1.0` (the `keyring-store` dependents) compiled without error in that run. This is a local Docker reproduction, not the actual GitHub Actions runner — what remains unproven until this PR's own CI runs is whether the real `ubuntu-latest` image behaves identically (expected, since it ships the same apt package and a superset of preinstalled build tools).

## Gates run (rung 1 — CI-configuration only)

- `bash scripts/check_changelog_fragment.sh` → `changelog-fragment gate: scanned 1 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.` (exit 0) — fragment exempt.
- `bash scripts/check_sld.sh` → `sld-lint: scanned 57 spec doc(s) + 3241 code file(s); ... 0 error(s), 0 warning(s)` (exit 0).
- Only `.github/workflows/semver-checks.yml` changed — no `.rs`/`docs/` files touched, so doc-numbers and line-cap don't apply.

#5440 tracks the root cause and this fix.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
