### PR TITLE
fix(trusty-agents): fail closed when a relocation presence probe is undeterminable (#5551)

### DIFF
--- a/crates/trusty-agents/changelog.d/5551-fail-closed-relocation-probes.md
+++ b/crates/trusty-agents/changelog.d/5551-fail-closed-relocation-probes.md
@@ -1,0 +1,18 @@
+Fixed
+
+- The workflow engine's post-plan and post-code relocation helpers no longer
+  treat a failed existence probe as "the destination is absent"
+  (closes [#5551](https://github.com/bobmatnyc/trusty-tools/issues/5551)).
+  Eight `try_exists(...).unwrap_or(false)` gates in
+  `workflow/engine/helpers.rs` collapsed *undeterminable* into *absent*, so a
+  transient `EIO`/`ETIMEDOUT`/`ESTALE` on the destination could rename a stray
+  file from the project root over a real generated output, over `out_dir`'s
+  authoritative `assignments.json`, or merge-copy over `out_dir/stubs/` and
+  then `remove_dir_all` the source tree — each one logged as a successful
+  relocation. An undeterminable probe now aborts that item's relocation
+  (nothing moved, overwritten, or deleted) and surfaces as an error; a genuine
+  "does not exist" is unchanged. The same pass stops counting an unresolvable
+  file as a clean skip: it is reported instead of vanishing from both `moved`
+  and `skipped_too_old`. A failed `copy_dir_all` fallback on `stubs/` also
+  stops firing the "relocated to out_dir" warning it never earned. Governed by
+  ADR-0045.

--- a/crates/trusty-agents/changelog.d/5551-fail-closed-relocation-probes.md
+++ b/crates/trusty-agents/changelog.d/5551-fail-closed-relocation-probes.md
@@ -16,3 +16,7 @@ Fixed
   and `skipped_too_old`. A failed `copy_dir_all` fallback on `stubs/` also
   stops firing the "relocated to out_dir" warning it never earned. Governed by
   ADR-0045.
+- An unstattable stray at the project root is recorded the same way rather than
+  skipped silently: `metadata` failing there means the recency gate cannot be
+  evaluated, so the file was previously counted in neither `moved` nor
+  `skipped_too_old`.

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/mod.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/mod.rs
@@ -30,6 +30,7 @@ mod checkpoint_resume;
 mod parallel_merge;
 mod phase_order;
 mod relocate;
+mod relocate_fail_closed;
 mod retry;
 mod skill_discovery;
 mod wave_loop;

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/relocate.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/relocate.rs
@@ -11,7 +11,9 @@
 
 use super::*;
 
-use crate::workflow::engine::helpers::{reconcile_code_outputs_from, relocate_plan_outputs_from};
+use crate::workflow::engine::helpers::{
+    FsExistsProbe, reconcile_code_outputs_from, relocate_plan_outputs_from,
+};
 
 /// #160: Regression test — if the plan-agent writes `assignments.json`
 /// at the git project root (because its claude CLI anchors relative
@@ -41,7 +43,7 @@ async fn post_plan_relocates_assignments_json_from_git_root() {
         .unwrap();
 
     // Act: run the relocation logic against the simulated project root.
-    relocate_plan_outputs_from(&project_root, &out_dir)
+    relocate_plan_outputs_from(&project_root, &out_dir, &FsExistsProbe)
         .await
         .expect("relocation should succeed");
 
@@ -94,7 +96,7 @@ async fn post_plan_relocation_is_noop_when_out_dir_has_assignments() {
     let stale = project_root.join("assignments.json");
     tokio::fs::write(&stale, b"STALE").await.unwrap();
 
-    relocate_plan_outputs_from(&project_root, &out_dir)
+    relocate_plan_outputs_from(&project_root, &out_dir, &FsExistsProbe)
         .await
         .expect("noop relocation ok");
 
@@ -147,7 +149,7 @@ async fn post_code_reconciles_files_from_project_root() {
         .unwrap();
 
     // Act: run reconciliation with the simulated project_root.
-    reconcile_code_outputs_from(&project_root, &out_dir)
+    reconcile_code_outputs_from(&project_root, &out_dir, &FsExistsProbe)
         .await
         .expect("reconciliation should succeed");
 
@@ -190,7 +192,7 @@ async fn post_code_reconcile_is_noop_without_assignments() {
         .await
         .unwrap();
 
-    reconcile_code_outputs_from(&project_root, &out_dir)
+    reconcile_code_outputs_from(&project_root, &out_dir, &FsExistsProbe)
         .await
         .expect("noop reconcile ok");
 

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/relocate_fail_closed.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/relocate_fail_closed.rs
@@ -6,10 +6,21 @@
 //! unblocked a rename over a real output followed by deletion of the source,
 //! logged as a success. ADR-0045 requires absent and undeterminable to be
 //! distinguished before a destructive filesystem operation.
-//! What: Injects an `ExistsProbe` that fails for one chosen path and defers
-//! every other path to the real filesystem, then asserts the DIRECTION of the
-//! outcome — the destination stays byte-identical, the source still exists,
-//! and the caller sees an error rather than a clean summary.
+//! What: Two techniques, both asserting the DIRECTION of the outcome — the
+//! destination stays byte-identical, the source still exists, and the caller
+//! sees an error rather than a clean summary.
+//!
+//! 1. A real-filesystem fixture: the destination is a symlink into a mode-000
+//!    directory, so `stat` is denied `EACCES` while `rename` onto it still
+//!    succeeds (`rename(2)` does not dereference its target). That reaches the
+//!    destructive branch with no injected probe at all, and is how the three
+//!    plain-file destinations are covered.
+//! 2. An injected `ExistsProbe` that fails for one chosen path. This is needed
+//!    for the `out_stubs` DIRECTORY site: its fallback runs `copy_dir_all`,
+//!    whose own `create_dir_all` hits the same `EACCES` wall, so a symlink
+//!    fixture there fails safe even pre-fix and proves nothing. The seam also
+//!    keeps the other sites' error arms deterministic under `EIO`/`ESTALE`,
+//!    which no fixture can produce on demand.
 //! Test: This file IS the test body.
 
 use super::*;
@@ -338,4 +349,214 @@ async fn fs_probe_reports_missing_path_as_absent_not_error() {
         matches!(answer, Ok(false)),
         "a missing path must answer Ok(false), got {answer:?}"
     );
+}
+
+// ── Real-filesystem fixtures: no seam, no injected probe ───────────────────
+//
+// #5551: the three plain-file destinations are renamed onto directly, and
+// `rename(2)` does not dereference the destination. So a destination symlink
+// pointing into a mode-000 directory denies `stat` while leaving the rename
+// path intact — exactly the pre-fix trigger, produced by the real filesystem.
+// These tests exercise the same sites as the injected-probe tests above and
+// hold against the fix with no production seam involved.
+
+#[cfg(unix)]
+mod real_fs {
+    use super::*;
+    use std::fs::Permissions;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    /// Restore a directory's mode on drop, including while unwinding.
+    ///
+    /// Without this, an assertion failure leaves a mode-000 directory that
+    /// `TempDir` cannot delete.
+    struct RestoreMode(PathBuf);
+
+    impl Drop for RestoreMode {
+        fn drop(&mut self) {
+            let _ = std::fs::set_permissions(&self.0, Permissions::from_mode(0o700));
+        }
+    }
+
+    /// A destination whose presence probe is denied while a rename onto it
+    /// still succeeds.
+    ///
+    /// Field order is drop order: `_restore` must run before `_tmp`, or
+    /// `TempDir` cannot delete a tree that still holds a mode-000 directory.
+    struct DeniedDest {
+        _restore: RestoreMode,
+        _tmp: TempDir,
+        locked: PathBuf,
+        dest: PathBuf,
+    }
+
+    impl DeniedDest {
+        /// What the destination resolves to now, read with the denial lifted.
+        ///
+        /// Pre-fix this returns the stray's bytes, because `rename` replaced
+        /// the symlink; post-fix it still returns the real output.
+        fn resolved(&self) -> Vec<u8> {
+            self.unlock();
+            let bytes = std::fs::read(&self.dest).expect("destination must still be readable");
+            self.relock();
+            bytes
+        }
+
+        fn unlock(&self) {
+            std::fs::set_permissions(&self.locked, Permissions::from_mode(0o700)).unwrap();
+        }
+
+        fn relock(&self) {
+            std::fs::set_permissions(&self.locked, Permissions::from_mode(0o000)).unwrap();
+        }
+    }
+
+    /// Point `dest` at a real file inside a directory the process may not
+    /// search, so probing `dest` is denied but renaming onto it is not.
+    ///
+    /// Panics rather than passes when the denial does not take hold — as root,
+    /// or on a filesystem that ignores POSIX mode bits, every test here would
+    /// otherwise pass vacuously, which on a fail-open guard is worse than no
+    /// test at all.
+    fn deny_presence_of(tmp: TempDir, dest: PathBuf, content: &[u8]) -> DeniedDest {
+        let locked = tmp.path().join("locked");
+        std::fs::create_dir_all(&locked).unwrap();
+        let real = locked.join("real-output");
+        std::fs::write(&real, content).unwrap();
+        std::os::unix::fs::symlink(&real, &dest).unwrap();
+        assert_eq!(
+            std::fs::read(&dest).unwrap(),
+            content,
+            "fixture is wrong — {} must resolve to the real output before the denial",
+            dest.display()
+        );
+
+        std::fs::set_permissions(&locked, Permissions::from_mode(0o000)).unwrap();
+        let restore = RestoreMode(locked.clone());
+
+        match std::fs::metadata(&dest) {
+            Ok(_) => panic!(
+                "cannot exercise #5551: stat of {} still succeeds through a mode-000 parent. \
+                 Run this suite as a non-root user on a filesystem that honours POSIX \
+                 permission bits.",
+                dest.display()
+            ),
+            Err(e) => assert_eq!(
+                e.kind(),
+                std::io::ErrorKind::PermissionDenied,
+                "expected the locked parent to deny the probe, got {e}"
+            ),
+        }
+        assert!(
+            dest.parent().is_some_and(|p| std::fs::metadata(p).is_ok()),
+            "fixture is wrong — the destination's own directory must stay writable, \
+             or the pre-fix rename would fail for the wrong reason"
+        );
+
+        DeniedDest {
+            _restore: restore,
+            _tmp: tmp,
+            locked,
+            dest,
+        }
+    }
+
+    /// #5551 (helpers.rs:116), real filesystem: the code-target destination
+    /// cannot be stat-ed, so pre-fix the project-root stray is renamed over it
+    /// and deleted. Uses no injected probe.
+    #[tokio::test]
+    async fn reconcile_against_leaves_an_unstattable_destination_intact() {
+        let tmp = TempDir::new().unwrap();
+        let project_root = canonical_dir(tmp.path(), "project").await;
+        let code_target = canonical_dir(tmp.path(), "code").await;
+        let assignments_dir = canonical_dir(tmp.path(), "artifacts").await;
+        tokio::fs::write(
+            assignments_dir.join("assignments.json"),
+            assignments_json("src/app.py"),
+        )
+        .await
+        .unwrap();
+
+        let dest = code_target.join("src/app.py");
+        tokio::fs::create_dir_all(dest.parent().unwrap())
+            .await
+            .unwrap();
+        let stray = project_root.join("src/app.py");
+        tokio::fs::create_dir_all(stray.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&stray, b"STRAY").await.unwrap();
+
+        let fx = deny_presence_of(tmp, dest, b"REAL OUTPUT");
+        let result = reconcile_code_outputs_against_from(
+            &project_root,
+            &assignments_dir,
+            &code_target,
+            &FsExistsProbe,
+        )
+        .await;
+
+        assert_eq!(
+            fx.resolved(),
+            b"REAL OUTPUT",
+            "the destination must still resolve to the real output"
+        );
+        assert!(stray.exists(), "the source must not be deleted");
+        assert!(result.is_err(), "an unstattable destination must error");
+    }
+
+    /// #5551 (helpers.rs:210), real filesystem: the `out_dir` twin.
+    #[tokio::test]
+    async fn reconcile_from_leaves_an_unstattable_destination_intact() {
+        let tmp = TempDir::new().unwrap();
+        let project_root = canonical_dir(tmp.path(), "project").await;
+        let out_dir = canonical_dir(tmp.path(), "out").await;
+        tokio::fs::write(
+            out_dir.join("assignments.json"),
+            assignments_json("src/app.py"),
+        )
+        .await
+        .unwrap();
+
+        let dest = out_dir.join("src/app.py");
+        tokio::fs::create_dir_all(dest.parent().unwrap())
+            .await
+            .unwrap();
+        let stray = project_root.join("src/app.py");
+        tokio::fs::create_dir_all(stray.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&stray, b"STRAY").await.unwrap();
+
+        let fx = deny_presence_of(tmp, dest, b"REAL OUTPUT");
+        let result = reconcile_code_outputs_from(&project_root, &out_dir, &FsExistsProbe).await;
+
+        assert_eq!(fx.resolved(), b"REAL OUTPUT");
+        assert!(stray.exists(), "the source must not be deleted");
+        assert!(result.is_err(), "an unstattable destination must error");
+    }
+
+    /// #5551 (helpers.rs:304), real filesystem: the destination is the plan
+    /// manifest the code phase and QA read.
+    #[tokio::test]
+    async fn relocate_plan_leaves_an_unstattable_manifest_intact() {
+        let tmp = TempDir::new().unwrap();
+        let project_root = canonical_dir(tmp.path(), "project").await;
+        let out_dir = canonical_dir(tmp.path(), "out").await;
+
+        let root_asg = project_root.join("assignments.json");
+        tokio::fs::write(&root_asg, b"STRAY").await.unwrap();
+
+        let fx = deny_presence_of(tmp, out_dir.join("assignments.json"), b"AUTHORITATIVE");
+        let result = relocate_plan_outputs_from(&project_root, &out_dir, &FsExistsProbe).await;
+
+        assert_eq!(
+            fx.resolved(),
+            b"AUTHORITATIVE",
+            "the plan manifest must not be overwritten"
+        );
+        assert!(root_asg.exists(), "the stray must not be deleted");
+        assert!(result.is_err(), "an unstattable manifest must error");
+    }
 }

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/relocate_fail_closed.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/relocate_fail_closed.rs
@@ -1,0 +1,341 @@
+//! #5551: Error-arm regression tests for the relocation presence probes.
+//!
+//! Why: `helpers.rs` gated every destructive relocation on
+//! `try_exists(...).unwrap_or(false)`, which answers "the probe failed" as
+//! "the destination is absent" — so a transient `EIO`/`ETIMEDOUT`/`ESTALE`
+//! unblocked a rename over a real output followed by deletion of the source,
+//! logged as a success. ADR-0045 requires absent and undeterminable to be
+//! distinguished before a destructive filesystem operation.
+//! What: Injects an `ExistsProbe` that fails for one chosen path and defers
+//! every other path to the real filesystem, then asserts the DIRECTION of the
+//! outcome — the destination stays byte-identical, the source still exists,
+//! and the caller sees an error rather than a clean summary.
+//! Test: This file IS the test body.
+
+use super::*;
+
+use crate::workflow::engine::helpers::{
+    ExistsProbe, FsExistsProbe, reconcile_code_outputs_against_from, reconcile_code_outputs_from,
+    relocate_plan_outputs_from,
+};
+use std::path::{Path, PathBuf};
+
+/// Probe that answers one path with a transient I/O error and every other
+/// path from the real filesystem.
+struct FailingProbe {
+    fail_on: PathBuf,
+}
+
+impl FailingProbe {
+    fn new(fail_on: impl Into<PathBuf>) -> Self {
+        Self {
+            fail_on: fail_on.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl ExistsProbe for FailingProbe {
+    async fn try_exists(&self, path: &Path) -> std::io::Result<bool> {
+        if path == self.fail_on {
+            // Not NotFound: an unanswerable probe, the shape a network mount
+            // produces mid-hiccup.
+            return Err(std::io::Error::other("simulated transient I/O failure"));
+        }
+        tokio::fs::try_exists(path).await
+    }
+}
+
+/// One declared file in a single wave.
+fn assignments_json(rel_path: &str) -> String {
+    format!(
+        r#"{{"error_convention":"exceptions","waves":[{{"wave":1,"files":[{{"path":"{rel_path}","stub":null,"purpose":"test","depends_on":[],"max_lines":100}}]}}]}}"#
+    )
+}
+
+/// Create `tmp/<name>` and return its CANONICAL path.
+///
+/// `safe_join` canonicalizes its base before joining, so a destination derived
+/// from a non-canonical temp dir (macOS `/var` → `/private/var`) would never
+/// equal the path the probe is asked about.
+async fn canonical_dir(tmp: &Path, name: &str) -> PathBuf {
+    let p = tmp.join(name);
+    tokio::fs::create_dir_all(&p).await.unwrap();
+    p.canonicalize().unwrap()
+}
+
+/// Simulated project root + a second directory, both created and canonical.
+async fn two_dirs(tmp: &Path, a: &str, b: &str) -> (PathBuf, PathBuf) {
+    (canonical_dir(tmp, a).await, canonical_dir(tmp, b).await)
+}
+
+// ── HIGH sites: the probe gates a rename/copy plus a source delete ─────────
+
+/// #5551 (helpers.rs:116): an undeterminable probe on the code-target
+/// destination must not be read as "absent" — the stray at the project root
+/// would otherwise be renamed over a real generated output and then deleted.
+#[tokio::test]
+async fn reconcile_against_aborts_when_destination_probe_is_undeterminable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (project_root, code_target) = two_dirs(tmp.path(), "project", "code").await;
+    let assignments_dir = canonical_dir(tmp.path(), "artifacts").await;
+    tokio::fs::write(
+        assignments_dir.join("assignments.json"),
+        assignments_json("src/app.py"),
+    )
+    .await
+    .unwrap();
+
+    let dest = code_target.join("src/app.py");
+    tokio::fs::create_dir_all(dest.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&dest, b"REAL OUTPUT").await.unwrap();
+
+    let stray = project_root.join("src/app.py");
+    tokio::fs::create_dir_all(stray.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&stray, b"STRAY").await.unwrap();
+
+    let probe = FailingProbe::new(&dest);
+    let result =
+        reconcile_code_outputs_against_from(&project_root, &assignments_dir, &code_target, &probe)
+            .await;
+
+    assert_eq!(
+        tokio::fs::read(&dest).await.unwrap(),
+        b"REAL OUTPUT",
+        "destination must be byte-identical after an undeterminable probe"
+    );
+    assert!(stray.exists(), "the source must not be deleted");
+    assert_eq!(tokio::fs::read(&stray).await.unwrap(), b"STRAY");
+    assert!(
+        result.is_err(),
+        "an undeterminable destination probe must surface as an error"
+    );
+}
+
+/// #5551 (helpers.rs:210): same shape against `out_dir`.
+#[tokio::test]
+async fn reconcile_from_aborts_when_destination_probe_is_undeterminable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (project_root, out_dir) = two_dirs(tmp.path(), "project", "out").await;
+    tokio::fs::write(
+        out_dir.join("assignments.json"),
+        assignments_json("src/app.py"),
+    )
+    .await
+    .unwrap();
+
+    let dest = out_dir.join("src/app.py");
+    tokio::fs::create_dir_all(dest.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&dest, b"REAL OUTPUT").await.unwrap();
+
+    let stray = project_root.join("src/app.py");
+    tokio::fs::create_dir_all(stray.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&stray, b"STRAY").await.unwrap();
+
+    let probe = FailingProbe::new(&dest);
+    let result = reconcile_code_outputs_from(&project_root, &out_dir, &probe).await;
+
+    assert_eq!(tokio::fs::read(&dest).await.unwrap(), b"REAL OUTPUT");
+    assert!(stray.exists(), "the source must not be deleted");
+    assert!(result.is_err(), "undeterminable destination must error");
+}
+
+/// #5551 (helpers.rs:304): the destination here is `assignments.json`, the
+/// plan manifest that drives which files the code phase writes and QA reads.
+#[tokio::test]
+async fn relocate_plan_aborts_when_out_assignments_probe_is_undeterminable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (project_root, out_dir) = two_dirs(tmp.path(), "project", "out").await;
+
+    let out_asg = out_dir.join("assignments.json");
+    tokio::fs::write(&out_asg, b"AUTHORITATIVE").await.unwrap();
+    let root_asg = project_root.join("assignments.json");
+    tokio::fs::write(&root_asg, b"STRAY").await.unwrap();
+
+    let probe = FailingProbe::new(&out_asg);
+    let result = relocate_plan_outputs_from(&project_root, &out_dir, &probe).await;
+
+    assert_eq!(
+        tokio::fs::read(&out_asg).await.unwrap(),
+        b"AUTHORITATIVE",
+        "the plan manifest must not be overwritten"
+    );
+    assert!(root_asg.exists(), "the stray must not be deleted");
+    assert!(result.is_err(), "undeterminable destination must error");
+}
+
+/// #5551 (helpers.rs:359): the `out_stubs` half of the `&&`. A coerced `Err`
+/// makes the condition true, `rename` fails `ENOTEMPTY`, the `copy_dir_all`
+/// fallback merge-overwrites, and `remove_dir_all` then deletes the source
+/// tree outright.
+#[tokio::test]
+async fn relocate_stubs_aborts_when_out_stubs_probe_is_undeterminable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (project_root, out_dir) = two_dirs(tmp.path(), "project", "out").await;
+
+    // No assignments.json in out_dir, a recent one at the root: the manifest
+    // relocation runs and the stubs branch is reached.
+    tokio::fs::write(project_root.join("assignments.json"), b"{}")
+        .await
+        .unwrap();
+
+    let root_stubs = project_root.join("stubs");
+    tokio::fs::create_dir_all(&root_stubs).await.unwrap();
+    tokio::fs::write(root_stubs.join("main.py"), b"STRAY STUB")
+        .await
+        .unwrap();
+
+    let out_stubs = out_dir.join("stubs");
+    tokio::fs::create_dir_all(&out_stubs).await.unwrap();
+    tokio::fs::write(out_stubs.join("main.py"), b"REAL STUB")
+        .await
+        .unwrap();
+
+    let probe = FailingProbe::new(&out_stubs);
+    let result = relocate_plan_outputs_from(&project_root, &out_dir, &probe).await;
+
+    assert_eq!(
+        tokio::fs::read(out_stubs.join("main.py")).await.unwrap(),
+        b"REAL STUB",
+        "existing stubs must not be merge-overwritten"
+    );
+    assert!(
+        root_stubs.join("main.py").is_file(),
+        "the source stubs tree must not be recursively deleted"
+    );
+    assert!(result.is_err(), "undeterminable destination must error");
+}
+
+// ── MEDIUM sites: the coercion picks SKIP, and the skip goes unaccounted ───
+
+/// #5551 (helpers.rs:120): a failed probe on the stray must not be recorded as
+/// a clean skip — the file goes unaccounted in `moved` and `skipped_too_old`.
+#[tokio::test]
+async fn reconcile_against_reports_unresolved_when_stray_probe_is_undeterminable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (project_root, code_target) = two_dirs(tmp.path(), "project", "code").await;
+    let assignments_dir = canonical_dir(tmp.path(), "artifacts").await;
+    tokio::fs::write(
+        assignments_dir.join("assignments.json"),
+        assignments_json("src/app.py"),
+    )
+    .await
+    .unwrap();
+
+    let stray = project_root.join("src/app.py");
+    tokio::fs::create_dir_all(stray.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&stray, b"STRAY").await.unwrap();
+
+    let probe = FailingProbe::new(&stray);
+    let result =
+        reconcile_code_outputs_against_from(&project_root, &assignments_dir, &code_target, &probe)
+            .await;
+
+    assert!(
+        result.is_err(),
+        "an unaccounted-for file must not read as a clean pass"
+    );
+    assert!(
+        stray.exists(),
+        "nothing was relocated, so nothing is deleted"
+    );
+    assert!(!code_target.join("src/app.py").exists());
+}
+
+/// #5551 (helpers.rs:217): the `out_dir` twin of the case above.
+#[tokio::test]
+async fn reconcile_from_reports_unresolved_when_stray_probe_is_undeterminable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (project_root, out_dir) = two_dirs(tmp.path(), "project", "out").await;
+    tokio::fs::write(
+        out_dir.join("assignments.json"),
+        assignments_json("src/app.py"),
+    )
+    .await
+    .unwrap();
+
+    let stray = project_root.join("src/app.py");
+    tokio::fs::create_dir_all(stray.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&stray, b"STRAY").await.unwrap();
+
+    let probe = FailingProbe::new(&stray);
+    let result = reconcile_code_outputs_from(&project_root, &out_dir, &probe).await;
+
+    assert!(result.is_err(), "unaccounted file must not read as clean");
+    assert!(stray.exists());
+    assert!(!out_dir.join("src/app.py").exists());
+}
+
+/// #5551 (helpers.rs:310): a failed probe on the root `assignments.json` must
+/// not be reported as "nothing misrouted".
+#[tokio::test]
+async fn relocate_plan_reports_unresolved_when_root_probe_is_undeterminable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (project_root, out_dir) = two_dirs(tmp.path(), "project", "out").await;
+
+    let root_asg = project_root.join("assignments.json");
+    tokio::fs::write(&root_asg, b"STRAY").await.unwrap();
+
+    let probe = FailingProbe::new(&root_asg);
+    let result = relocate_plan_outputs_from(&project_root, &out_dir, &probe).await;
+
+    assert!(
+        result.is_err(),
+        "an undeterminable source probe must not read as 'nothing misrouted'"
+    );
+    assert!(root_asg.exists());
+    assert!(!out_dir.join("assignments.json").exists());
+}
+
+/// #5551 (helpers.rs:358): the `root_stubs` half of the `&&`.
+#[tokio::test]
+async fn relocate_stubs_reports_unresolved_when_root_stubs_probe_is_undeterminable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (project_root, out_dir) = two_dirs(tmp.path(), "project", "out").await;
+
+    tokio::fs::write(project_root.join("assignments.json"), b"{}")
+        .await
+        .unwrap();
+    let root_stubs = project_root.join("stubs");
+    tokio::fs::create_dir_all(&root_stubs).await.unwrap();
+    tokio::fs::write(root_stubs.join("main.py"), b"STRAY STUB")
+        .await
+        .unwrap();
+
+    let probe = FailingProbe::new(&root_stubs);
+    let result = relocate_plan_outputs_from(&project_root, &out_dir, &probe).await;
+
+    assert!(
+        result.is_err(),
+        "an undeterminable stubs probe must not be a silent skip"
+    );
+    assert!(root_stubs.join("main.py").is_file());
+}
+
+// ── NotFound stays benign ──────────────────────────────────────────────────
+
+/// #5551: a genuine "does not exist" is a definite answer and must keep
+/// returning `Ok(false)`, so the fix cannot turn every missing destination
+/// into a hard failure.
+#[tokio::test]
+async fn fs_probe_reports_missing_path_as_absent_not_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("nope").join("still-nope.json");
+    let answer = FsExistsProbe.try_exists(&missing).await;
+    assert!(
+        matches!(answer, Ok(false)),
+        "a missing path must answer Ok(false), got {answer:?}"
+    );
+}

--- a/crates/trusty-agents/src/workflow/engine/helpers.rs
+++ b/crates/trusty-agents/src/workflow/engine/helpers.rs
@@ -17,6 +17,34 @@
 use crate::agents::AgentConfig;
 use crate::workflow::config::{Assignments, safe_join};
 
+/// #5551: Filesystem-presence probe used by every relocation gate here.
+///
+/// Why: These helpers ask "is the destination already there?" before renaming
+/// or copying over it and then deleting the source. The question has three
+/// answers — present, absent, and *undeterminable* — and the live trigger for
+/// the third is a transient `EIO`/`ETIMEDOUT`/`ESTALE` on a network mount,
+/// which no real-filesystem fixture can produce on demand. Routing every probe
+/// through this trait is what makes the error arm reachable from a test.
+/// What: `try_exists` mirrors `tokio::fs::try_exists` exactly — `NotFound` is a
+/// definite answer and comes back as `Ok(false)`; only an unanswerable probe
+/// yields `Err`.
+/// Test: `reconcile_against_aborts_when_destination_probe_is_undeterminable`
+/// and its siblings in `executor::tests::relocate`.
+#[async_trait::async_trait]
+pub(crate) trait ExistsProbe: Send + Sync {
+    async fn try_exists(&self, path: &std::path::Path) -> std::io::Result<bool>;
+}
+
+/// The real-filesystem probe; every production call path uses this one.
+pub(crate) struct FsExistsProbe;
+
+#[async_trait::async_trait]
+impl ExistsProbe for FsExistsProbe {
+    async fn try_exists(&self, path: &std::path::Path) -> std::io::Result<bool> {
+        tokio::fs::try_exists(path).await
+    }
+}
+
 /// #160: Max age of a stray `assignments.json` at the project root that we
 /// will still treat as belonging to the just-finished plan phase. Anything
 /// older is presumed to be a stale leftover from a prior run (possibly
@@ -39,35 +67,6 @@ pub(crate) fn agent_uses_claude_code(agent_name: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// #123: After the code phase, move files that the code agent (claude-code
-/// runner) wrote to the project root into `out_dir`.
-///
-/// Why: Even with `current_dir(out_dir)` and `--add-dir out_dir`, the claude
-/// CLI occasionally anchors relative `write_file` paths to the git repo root
-/// (its inherited CWD). The QA agent runs pytest against `out_dir` (or the
-/// `{{project_dir}}` discovered inside it), so files at the project root are
-/// invisible to QA and produce false-negative test failures. This routine
-/// reads `assignments.json` from `out_dir`, and for each listed path that is
-/// (a) missing in `out_dir` and (b) present at the project root with a recent
-/// mtime, moves it into `out_dir`.
-/// What: Best-effort. Skips silently when no `assignments.json` is present
-/// (legacy monolithic path), when the project root cannot be read, or when
-/// individual moves fail. Recency check uses the same 10-minute window as
-/// `POST_PLAN_RELOCATION_MAX_AGE` to avoid picking up stale leftovers.
-/// Test: `post_code_reconciles_files_from_project_root` exercises the move.
-async fn reconcile_code_outputs_from_project_root(
-    out_dir: &std::path::Path,
-) -> std::io::Result<()> {
-    let project_root = match std::env::current_dir() {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::debug!(error = %e, "reconcile_code_outputs: cannot read CWD");
-            return Ok(());
-        }
-    };
-    reconcile_code_outputs_from(&project_root, out_dir).await
-}
-
 /// #222: Reconcile code outputs against an explicit code target.
 ///
 /// Why: When `--project-dir` is set, generated files belong in `code_dir`,
@@ -77,18 +76,14 @@ async fn reconcile_code_outputs_from_project_root(
 /// What: Loads `assignments.json` from `assignments_dir`; for each listed
 /// file, if it's missing in `code_target` but present at the git project
 /// root (CWD) with a recent mtime, moves it into `code_target`. When
-/// `assignments_dir == code_target` (legacy mode) delegates to the
-/// pre-#222 `reconcile_code_outputs_from_project_root`.
-/// Test: Indirect — covered by the existing
-/// `post_code_reconciles_files_from_project_root` path when paths align;
-/// the divergent path is exercised by manual smoke for `--project-dir .`.
+/// `assignments_dir == code_target` (legacy mode) delegates to
+/// [`reconcile_code_outputs_from`].
+/// Test: `reconcile_code_outputs_against_divergent_dirs`,
+/// `reconcile_against_aborts_when_destination_probe_is_undeterminable`.
 pub(crate) async fn reconcile_code_outputs_against(
     assignments_dir: &std::path::Path,
     code_target: &std::path::Path,
 ) -> std::io::Result<()> {
-    if assignments_dir == code_target {
-        return reconcile_code_outputs_from_project_root(code_target).await;
-    }
     let project_root = match std::env::current_dir() {
         Ok(p) => p,
         Err(e) => {
@@ -96,6 +91,29 @@ pub(crate) async fn reconcile_code_outputs_against(
             return Ok(());
         }
     };
+    reconcile_code_outputs_against_from(&project_root, assignments_dir, code_target, &FsExistsProbe)
+        .await
+}
+
+/// Testable inner routine for [`reconcile_code_outputs_against`], with the
+/// project root and the presence probe supplied explicitly.
+///
+/// Why: The outer function reads the project root from the process-wide CWD
+/// and always probes the real filesystem, so neither the divergent-directory
+/// layout nor the undeterminable-probe arm is reachable from a test without
+/// this seam.
+/// What: Same behavior as the outer function; `probe` answers every
+/// destination/stray presence question.
+/// Test: `reconcile_against_aborts_when_destination_probe_is_undeterminable`.
+pub(crate) async fn reconcile_code_outputs_against_from(
+    project_root: &std::path::Path,
+    assignments_dir: &std::path::Path,
+    code_target: &std::path::Path,
+    probe: &dyn ExistsProbe,
+) -> std::io::Result<()> {
+    if assignments_dir == code_target {
+        return reconcile_code_outputs_from(project_root, code_target, probe).await;
+    }
     let assignments = match Assignments::load(assignments_dir) {
         Some(a) => a,
         None => {
@@ -113,11 +131,11 @@ pub(crate) async fn reconcile_code_outputs_against(
                 Some(p) => p,
                 None => continue,
             };
-            if tokio::fs::try_exists(&dest).await.unwrap_or(false) {
+            if probe.try_exists(&dest).await.unwrap_or(false) {
                 continue;
             }
             let stray = project_root.join(&file.path);
-            if !tokio::fs::try_exists(&stray).await.unwrap_or(false) {
+            if !probe.try_exists(&stray).await.unwrap_or(false) {
                 continue;
             }
             // When code_target effectively == project_root (e.g.
@@ -178,6 +196,7 @@ pub(crate) async fn reconcile_code_outputs_against(
 pub(crate) async fn reconcile_code_outputs_from(
     project_root: &std::path::Path,
     out_dir: &std::path::Path,
+    probe: &dyn ExistsProbe,
 ) -> std::io::Result<()> {
     let assignments = match Assignments::load(out_dir) {
         Some(a) => a,
@@ -207,14 +226,14 @@ pub(crate) async fn reconcile_code_outputs_from(
                     continue;
                 }
             };
-            if tokio::fs::try_exists(&dest).await.unwrap_or(false) {
+            if probe.try_exists(&dest).await.unwrap_or(false) {
                 // Happy path — claude-code wrote it where we expected.
                 continue;
             }
 
             // Misroute candidate: same relative path under the project root.
             let stray = project_root.join(&file.path);
-            if !tokio::fs::try_exists(&stray).await.unwrap_or(false) {
+            if !probe.try_exists(&stray).await.unwrap_or(false) {
                 continue;
             }
 
@@ -288,7 +307,7 @@ pub(crate) async fn relocate_plan_outputs_from_project_root(
             return Ok(());
         }
     };
-    relocate_plan_outputs_from(&project_root, out_dir).await
+    relocate_plan_outputs_from(&project_root, out_dir, &FsExistsProbe).await
 }
 
 /// Testable inner routine: same behavior as
@@ -299,15 +318,16 @@ pub(crate) async fn relocate_plan_outputs_from_project_root(
 pub(crate) async fn relocate_plan_outputs_from(
     project_root: &std::path::Path,
     out_dir: &std::path::Path,
+    probe: &dyn ExistsProbe,
 ) -> std::io::Result<()> {
     let out_asg = out_dir.join("assignments.json");
-    if tokio::fs::try_exists(&out_asg).await.unwrap_or(false) {
+    if probe.try_exists(&out_asg).await.unwrap_or(false) {
         // Happy path — plan-agent wrote it where we expected. Nothing to do.
         return Ok(());
     }
 
     let root_asg = project_root.join("assignments.json");
-    let root_asg_exists = tokio::fs::try_exists(&root_asg).await.unwrap_or(false);
+    let root_asg_exists = probe.try_exists(&root_asg).await.unwrap_or(false);
     if !root_asg_exists {
         // Nothing misrouted. plan-agent just didn't produce assignments.json
         // at all — the code phase's existing "legacy monolithic" fallback
@@ -355,8 +375,8 @@ pub(crate) async fn relocate_plan_outputs_from(
     // Also relocate stubs/ if the plan-agent put it at the project root.
     let root_stubs = project_root.join("stubs");
     let out_stubs = out_dir.join("stubs");
-    if tokio::fs::try_exists(&root_stubs).await.unwrap_or(false)
-        && !tokio::fs::try_exists(&out_stubs).await.unwrap_or(false)
+    if probe.try_exists(&root_stubs).await.unwrap_or(false)
+        && !probe.try_exists(&out_stubs).await.unwrap_or(false)
     {
         // Only relocate if recent, using directory mtime as a proxy.
         let stubs_meta = tokio::fs::metadata(&root_stubs).await?;

--- a/crates/trusty-agents/src/workflow/engine/helpers.rs
+++ b/crates/trusty-agents/src/workflow/engine/helpers.rs
@@ -12,7 +12,9 @@
 //! into `out_dir`; `copy_dir_all` is a symlink-refusing recursive copy.
 //! Test: `post_code_reconciles_files_from_project_root`,
 //! `post_plan_relocates_assignments_json_from_git_root`,
-//! `reconcile_code_outputs_against_divergent_dirs` in `executor`'s test module.
+//! `reconcile_code_outputs_against_divergent_dirs` in `executor`'s test module;
+//! the undeterminable-probe arms (#5551) in
+//! `executor::tests::relocate_fail_closed`.
 
 use crate::agents::AgentConfig;
 use crate::workflow::config::{Assignments, safe_join};
@@ -29,7 +31,7 @@ use crate::workflow::config::{Assignments, safe_join};
 /// definite answer and comes back as `Ok(false)`; only an unanswerable probe
 /// yields `Err`.
 /// Test: `reconcile_against_aborts_when_destination_probe_is_undeterminable`
-/// and its siblings in `executor::tests::relocate`.
+/// and its siblings in `executor::tests::relocate_fail_closed`.
 #[async_trait::async_trait]
 pub(crate) trait ExistsProbe: Send + Sync {
     async fn try_exists(&self, path: &std::path::Path) -> std::io::Result<bool>;
@@ -43,6 +45,31 @@ impl ExistsProbe for FsExistsProbe {
     async fn try_exists(&self, path: &std::path::Path) -> std::io::Result<bool> {
         tokio::fs::try_exists(path).await
     }
+}
+
+/// #5551: Name the path an undeterminable probe was asked about, preserving
+/// the underlying `ErrorKind` so a caller can still tell EIO from ELOOP.
+fn undeterminable(path: &std::path::Path, e: std::io::Error) -> std::io::Error {
+    std::io::Error::new(
+        e.kind(),
+        format!(
+            "presence of {} could not be determined ({e}); refusing to relocate over it",
+            path.display()
+        ),
+    )
+}
+
+/// #5551: Fail the whole pass when any item was left unrelocated because its
+/// presence was undeterminable, so a caller cannot read the summary as clean.
+fn unresolved_result(op: &str, unresolved: Vec<String>) -> std::io::Result<()> {
+    if unresolved.is_empty() {
+        return Ok(());
+    }
+    Err(std::io::Error::other(format!(
+        "{op}: {} path(s) left unrelocated because their presence could not be determined: {}",
+        unresolved.len(),
+        unresolved.join(", ")
+    )))
 }
 
 /// #160: Max age of a stray `assignments.json` at the project root that we
@@ -125,18 +152,34 @@ pub(crate) async fn reconcile_code_outputs_against_from(
         }
     };
     let mut moved = 0usize;
+    let mut unresolved: Vec<String> = Vec::new();
     for wave in &assignments.waves {
         for file in &wave.files {
             let dest = match safe_join(code_target, &file.path) {
                 Some(p) => p,
                 None => continue,
             };
-            if probe.try_exists(&dest).await.unwrap_or(false) {
-                continue;
+            // #5551: an undeterminable destination probe would otherwise read
+            // as "absent" and rename the stray over a real generated output.
+            match probe.try_exists(&dest).await {
+                Ok(true) => continue,
+                Ok(false) => {}
+                Err(e) => {
+                    tracing::error!(error = %undeterminable(&dest, e), "aborting this file's relocation");
+                    unresolved.push(file.path.clone());
+                    continue;
+                }
             }
             let stray = project_root.join(&file.path);
-            if !probe.try_exists(&stray).await.unwrap_or(false) {
-                continue;
+            // #5551: a failed stray probe is not a clean skip — account for it.
+            match probe.try_exists(&stray).await {
+                Ok(true) => {}
+                Ok(false) => continue,
+                Err(e) => {
+                    tracing::error!(error = %undeterminable(&stray, e), "aborting this file's relocation");
+                    unresolved.push(file.path.clone());
+                    continue;
+                }
             }
             // When code_target effectively == project_root (e.g.
             // `--project-dir .`), the file is already where it belongs.
@@ -164,7 +207,10 @@ pub(crate) async fn reconcile_code_outputs_against_from(
             if let Err(rename_err) = tokio::fs::rename(&stray, &dest).await {
                 tracing::debug!(error = %rename_err, "rename failed; copy+delete");
                 tokio::fs::copy(&stray, &dest).await?;
-                let _ = tokio::fs::remove_file(&stray).await;
+                if let Err(e) = tokio::fs::remove_file(&stray).await {
+                    tracing::debug!(error = %e, path = %stray.display(),
+                        "could not remove stray file after copy");
+                }
             }
             tracing::warn!(
                 from = %stray.display(),
@@ -174,13 +220,14 @@ pub(crate) async fn reconcile_code_outputs_against_from(
             moved += 1;
         }
     }
-    if moved > 0 {
+    if moved > 0 || !unresolved.is_empty() {
         tracing::info!(
             moved,
+            unresolved = unresolved.len(),
             "reconcile_code_outputs_against: relocated files into code_dir"
         );
     }
-    Ok(())
+    unresolved_result("reconcile_code_outputs_against", unresolved)
 }
 
 /// Testable inner routine for `reconcile_code_outputs_from_project_root`.
@@ -211,6 +258,7 @@ pub(crate) async fn reconcile_code_outputs_from(
 
     let mut moved = 0usize;
     let mut skipped_recent = 0usize;
+    let mut unresolved: Vec<String> = Vec::new();
     for wave in &assignments.waves {
         for file in &wave.files {
             // #114: Refuse to act on any path that escapes out_dir, even if
@@ -226,15 +274,30 @@ pub(crate) async fn reconcile_code_outputs_from(
                     continue;
                 }
             };
-            if probe.try_exists(&dest).await.unwrap_or(false) {
+            // #5551: an undeterminable destination probe would otherwise read
+            // as "absent" and rename the stray over a real generated output.
+            match probe.try_exists(&dest).await {
                 // Happy path — claude-code wrote it where we expected.
-                continue;
+                Ok(true) => continue,
+                Ok(false) => {}
+                Err(e) => {
+                    tracing::error!(error = %undeterminable(&dest, e), "aborting this file's relocation");
+                    unresolved.push(file.path.clone());
+                    continue;
+                }
             }
 
             // Misroute candidate: same relative path under the project root.
             let stray = project_root.join(&file.path);
-            if !probe.try_exists(&stray).await.unwrap_or(false) {
-                continue;
+            // #5551: a failed stray probe is not a clean skip — account for it.
+            match probe.try_exists(&stray).await {
+                Ok(true) => {}
+                Ok(false) => continue,
+                Err(e) => {
+                    tracing::error!(error = %undeterminable(&stray, e), "aborting this file's relocation");
+                    unresolved.push(file.path.clone());
+                    continue;
+                }
             }
 
             // Recency gate: only move if mtime is recent enough to plausibly
@@ -287,14 +350,15 @@ pub(crate) async fn reconcile_code_outputs_from(
         }
     }
 
-    if moved > 0 || skipped_recent > 0 {
+    if moved > 0 || skipped_recent > 0 || !unresolved.is_empty() {
         tracing::info!(
             moved = moved,
             skipped_too_old = skipped_recent,
+            unresolved = unresolved.len(),
             "reconcile_code_outputs: post-code reconciliation summary"
         );
     }
-    Ok(())
+    unresolved_result("reconcile_code_outputs", unresolved)
 }
 
 pub(crate) async fn relocate_plan_outputs_from_project_root(
@@ -321,13 +385,23 @@ pub(crate) async fn relocate_plan_outputs_from(
     probe: &dyn ExistsProbe,
 ) -> std::io::Result<()> {
     let out_asg = out_dir.join("assignments.json");
-    if probe.try_exists(&out_asg).await.unwrap_or(false) {
+    // #5551: `assignments.json` is the plan manifest the code phase and QA
+    // read; an undeterminable probe must never unblock overwriting it.
+    if probe
+        .try_exists(&out_asg)
+        .await
+        .map_err(|e| undeterminable(&out_asg, e))?
+    {
         // Happy path — plan-agent wrote it where we expected. Nothing to do.
         return Ok(());
     }
 
     let root_asg = project_root.join("assignments.json");
-    let root_asg_exists = probe.try_exists(&root_asg).await.unwrap_or(false);
+    // #5551: a failed source probe is not "nothing misrouted".
+    let root_asg_exists = probe
+        .try_exists(&root_asg)
+        .await
+        .map_err(|e| undeterminable(&root_asg, e))?;
     if !root_asg_exists {
         // Nothing misrouted. plan-agent just didn't produce assignments.json
         // at all — the code phase's existing "legacy monolithic" fallback
@@ -375,8 +449,16 @@ pub(crate) async fn relocate_plan_outputs_from(
     // Also relocate stubs/ if the plan-agent put it at the project root.
     let root_stubs = project_root.join("stubs");
     let out_stubs = out_dir.join("stubs");
-    if probe.try_exists(&root_stubs).await.unwrap_or(false)
-        && !probe.try_exists(&out_stubs).await.unwrap_or(false)
+    // #5551: both probes gate a rename whose ENOTEMPTY fallback merge-copies
+    // over `out_stubs` and then `remove_dir_all`s the whole source tree.
+    if probe
+        .try_exists(&root_stubs)
+        .await
+        .map_err(|e| undeterminable(&root_stubs, e))?
+        && !probe
+            .try_exists(&out_stubs)
+            .await
+            .map_err(|e| undeterminable(&out_stubs, e))?
     {
         // Only relocate if recent, using directory mtime as a proxy.
         let stubs_meta = tokio::fs::metadata(&root_stubs).await?;
@@ -390,10 +472,12 @@ pub(crate) async fn relocate_plan_outputs_from(
             if let Err(e) = tokio::fs::rename(&root_stubs, &out_stubs).await {
                 // Cross-device or non-empty-target; try recursive copy.
                 tracing::debug!(error = %e, "stubs rename failed, copying recursively");
-                if let Err(copy_err) = copy_dir_all(&root_stubs, &out_stubs) {
-                    tracing::warn!(error = %copy_err, "failed to copy stubs/ from project root");
-                } else {
-                    let _ = std::fs::remove_dir_all(&root_stubs);
+                // #5551: a failed copy left the "relocated" WARN below to fire
+                // anyway, reporting a move that did not happen.
+                copy_dir_all(&root_stubs, &out_stubs)?;
+                if let Err(e) = std::fs::remove_dir_all(&root_stubs) {
+                    tracing::debug!(error = %e, path = %root_stubs.display(),
+                        "could not remove stray stubs/ after copy");
                 }
             }
             tracing::warn!(

--- a/crates/trusty-agents/src/workflow/engine/helpers.rs
+++ b/crates/trusty-agents/src/workflow/engine/helpers.rs
@@ -188,9 +188,15 @@ pub(crate) async fn reconcile_code_outputs_against_from(
             {
                 continue;
             }
+            // #5551: an unstattable stray is not a clean skip either — the
+            // recency gate cannot be evaluated, so the file goes unaccounted.
             let meta = match tokio::fs::metadata(&stray).await {
                 Ok(m) => m,
-                Err(_) => continue,
+                Err(e) => {
+                    tracing::error!(error = %undeterminable(&stray, e), "aborting this file's relocation");
+                    unresolved.push(file.path.clone());
+                    continue;
+                }
             };
             let is_recent = meta
                 .modified()
@@ -304,9 +310,10 @@ pub(crate) async fn reconcile_code_outputs_from(
             // belong to the just-finished code phase.
             let meta = match tokio::fs::metadata(&stray).await {
                 Ok(m) => m,
+                // #5551: same as above — record it rather than skipping silently.
                 Err(e) => {
-                    tracing::debug!(error = %e, path = %stray.display(),
-                        "reconcile_code_outputs: stat failed");
+                    tracing::error!(error = %undeterminable(&stray, e), "aborting this file's relocation");
+                    unresolved.push(file.path.clone());
                     continue;
                 }
             };

--- a/crates/trusty-memory/ui/package-lock.json
+++ b/crates/trusty-memory/ui/package-lock.json
@@ -597,9 +597,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -614,9 +611,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -631,9 +625,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -648,9 +639,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -665,9 +653,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -682,9 +667,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -699,9 +681,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -716,9 +695,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -733,9 +709,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -750,9 +723,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -767,9 +737,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -784,9 +751,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -801,9 +765,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/crates/trusty-memory/ui/package-lock.json
+++ b/crates/trusty-memory/ui/package-lock.json
@@ -597,6 +597,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -611,6 +614,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -625,6 +631,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -639,6 +648,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -653,6 +665,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -667,6 +682,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -681,6 +699,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -695,6 +716,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -709,6 +733,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -723,6 +750,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -737,6 +767,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -751,6 +784,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,6 +801,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/crates/trusty-mpm/changelog.d/5551-prune-vanished-doc-accuracy.md
+++ b/crates/trusty-mpm/changelog.d/5551-prune-vanished-doc-accuracy.md
@@ -1,0 +1,8 @@
+Documentation
+
+- Corrected `prune_vanished`'s doc comment in `core/mcp_provenance.rs`, which
+  claimed the sweep "retains only entries whose path still exists"
+  ([#5551](https://github.com/bobmatnyc/trusty-tools/issues/5551)). It also
+  retains an entry it could not probe — a deliberate fail-open, since dropping
+  an uncertain provenance claim risks misattributing a later `.mcp.json` at the
+  same path. Doc-only; the behavior is unchanged.

--- a/crates/trusty-mpm/src/core/mcp_provenance.rs
+++ b/crates/trusty-mpm/src/core/mcp_provenance.rs
@@ -290,9 +290,11 @@ pub fn record_write(
 /// entry and this is called from the session-launch write path: an
 /// unconditional sweep would put thousands of `stat` calls on every launch to
 /// reclaim bytes nobody is short of.
-/// What: when the map exceeds [`PRUNE_THRESHOLD`], retains only entries whose
-/// path still exists. The entry just inserted always survives — its file was
-/// written moments earlier.
+/// What: when the map exceeds [`PRUNE_THRESHOLD`], drops entries whose path is
+/// confirmed gone and retains everything else — including an entry whose path
+/// could not be probed, since dropping an uncertain claim risks misattributing
+/// a later `.mcp.json` at the same path (#5551). The entry just inserted
+/// always survives — its file was written moments earlier.
 /// Test: `record_prunes_vanished_entries_above_the_threshold`,
 /// `record_keeps_every_entry_below_the_threshold`.
 fn prune_vanished(ledger: &mut McpProvenanceLedger) {


### PR DESCRIPTION
Fixes #5551. Governed by ADR-0045 (PR #5559), "distinguish absent from
undeterminable before a destructive filesystem operation".

## Abort the item, not the run

Two levels, decided separately:

- **Per item** — a probe that cannot answer aborts that one file's relocation.
  Nothing is moved, overwritten, or deleted; the item is recorded as unresolved
  and the loop continues with the rest of the manifest.
- **Per call** — the function returns `Err` rather than a clean summary, because
  the current failure mode is a WARN reading `relocated to code_dir` and a
  `moved` count that includes a destination it never inspected.

That does not abort a run. Both callers — `phase_loop.rs:540` and
`post_phase.rs:205` — already log an `Err` at WARN and continue, so a transient
network-mount blip costs one file's relocation and a visible error line, not the
workflow.

`NotFound` is untouched: `tokio::fs::try_exists` already answers it `Ok(false)`,
and `fs_probe_reports_missing_path_as_absent_not_error` pins that.

## Coverage: real filesystem where it reaches, seam where it does not

The three plain-file destinations are renamed onto directly, and `rename(2)`
does not dereference its target. So a destination symlink pointing into a
mode-000 directory denies `stat` (`EACCES`) while the rename still succeeds —
the destructive branch, reached with no seam at all. That is #5566's technique
and it covers `reconcile_code_outputs_against`'s `dest`,
`reconcile_code_outputs_from`'s `dest`, and `relocate_plan_outputs_from`'s
`out_asg`. The fixture panics rather than passes if the denial does not take
hold (root, or a filesystem ignoring mode bits), and its mode-restoring guard
drops before the `TempDir`.

The fourth HIGH site, `out_stubs`, genuinely needs the seam: its fallback runs
`copy_dir_all`, whose own `create_dir_all` hits the same `EACCES` wall, so a
symlink fixture there fails safe even pre-fix and proves nothing. An earlier
revision of this PR claimed no real-filesystem fixture could reach ANY of the
four; that was true for one site, not four, and the injected-probe tests for the
other three were passing against "pre-fix plus my seam" rather than pre-fix.
Both sets are kept — the seam ones also make the `EIO`/`ESTALE` arm deterministic.

### Against TRUE `origin/main` (`bf08d7c83`), no seam, `--test-threads=1`

```
running 3 tests
test prefix_demo::reconcile_against_leaves_an_unstattable_destination_intact ... FAILED
test prefix_demo::reconcile_from_leaves_an_unstattable_destination_intact ... FAILED
test prefix_demo::relocate_plan_leaves_an_unstattable_manifest_intact ... FAILED

---- prefix_demo::reconcile_against_leaves_an_unstattable_destination_intact stdout ----
assertion `left == right` failed: the destination must still resolve to the real output
  left: [83, 84, 82, 65, 89]                                  # "STRAY"
 right: [82, 69, 65, 76, 32, 79, 85, 84, 80, 85, 84]          # "REAL OUTPUT"

---- prefix_demo::reconcile_from_leaves_an_unstattable_destination_intact stdout ----
assertion `left == right` failed
  left: [83, 84, 82, 65, 89]
 right: [82, 69, 65, 76, 32, 79, 85, 84, 80, 85, 84]

---- prefix_demo::relocate_plan_leaves_an_unstattable_manifest_intact stdout ----
assertion `left == right` failed: the plan manifest must not be overwritten
  left: [83, 84, 82, 65, 89]
 right: [65, 85, 84, 72, 79, 82, 73, 84, 65, 84, 73, 86, 69]  # "AUTHORITATIVE"

test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 3497 filtered out
```

The `origin/main` copy differs from the committed one only in call spelling —
no `probe` argument, and CWD set for `reconcile_code_outputs_against`, which
reads the project root from CWD there. On this branch, all twelve:

```
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 3497 filtered out
```

### Seam tests, against the seam-only commit `2fecec58b`

`2fecec58b` threads `ExistsProbe` through with `.unwrap_or(false)` left exactly
as it was — behaviour-identical to `origin/main`, all 39 pre-existing executor
tests pass on it. `cargo test -p trusty-agents --lib relocate_fail_closed`:

```
test result: FAILED. 1 passed; 8 failed; 0 ignored; 0 measured; 3497 filtered out

---- relocate_fail_closed::relocate_stubs_aborts_when_out_stubs_probe_is_undeterminable stdout ----
assertion `left == right` failed: existing stubs must not be merge-overwritten
  left: [83, 84, 82, 65, 89, 32, 83, 84, 85, 66]              # "STRAY STUB"
 right: [82, 69, 65, 76, 32, 83, 84, 85, 66]                  # "REAL STUB"

failures:
    reconcile_against_aborts_when_destination_probe_is_undeterminable
    reconcile_against_reports_unresolved_when_stray_probe_is_undeterminable
    reconcile_from_aborts_when_destination_probe_is_undeterminable
    reconcile_from_reports_unresolved_when_stray_probe_is_undeterminable
    relocate_plan_aborts_when_out_assignments_probe_is_undeterminable
    relocate_plan_reports_unresolved_when_root_probe_is_undeterminable
    relocate_stubs_aborts_when_out_stubs_probe_is_undeterminable
    relocate_stubs_reports_unresolved_when_root_stubs_probe_is_undeterminable
```

## Rung 5

```
cargo fmt --check
cargo check   -p trusty-agents --all-targets
cargo clippy  -p trusty-agents --all-targets -- -D warnings
cargo test    -p trusty-agents            # 3496 lib + 27 integration passed, 0 failed, 13 ignored
cargo check   --workspace --all-targets   # clean
cargo test    -p trusty-agents-local      # only direct dependent; 0 tests
cargo test    -p trusty-mpm --lib core::mcp_provenance   # 21 passed (doc-only touch)
bash scripts/check_line_cap.sh            # 3953 files, 0 violations; helpers.rs 368/500 SLOC
bash scripts/check_sld.sh                 # 0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh  # both crates recorded
bash scripts/check-version-parity.sh      # 0 drift
bash scripts/check-pr-version-bump.sh     # clear — neither version is published yet
```

`cargo test -p trusty-agents -- --include-ignored` adds two environmental
failures this branch does not touch:
`llm::bedrock::client::tests::bedrock_smoke_test` ("no providers in chain
provided credentials") and `tools::izzie::metro_north::tests::live_alerts_smoke`
(MTA API 403). Both are live-network/credential smokes.

`code-critic` returned APPROVE on `b9ce9596e`; the two MEDIUMs it raised — the
untestability claim above, and `metadata(&stray)`'s silent skip — are fixed in
`7fcbbed44`. Branch is merged up to `bf08d7c83`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
