### PR TITLE
fix(ci): semver-checks selftest guard count must be 6, not 5

### DIFF
--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -625,7 +625,13 @@ assert_eq "no gate in semver-checks branches on the activity type" "0" \
   "$(grep -c 'github\.event\.action' <<<"$(sed -n '/^jobs:/,$p' .github/workflows/semver-checks.yml)" || true)"
 # The expensive half of the SemVer gate stays behind the diff verdict — this is
 # what keeps #5149's "not 20 minutes on every PR" true while the context reports.
-assert_eq "semver-checks gates its costly steps on there being work" "5" \
+# #5440 added a sixth guarded step (libdbus install, needed for trusty-common's
+# keyring-store feature): Install stable toolchain, Install system dependencies
+# (libdbus for keyring-store), Install cargo-semver-checks (pinned prebuilt),
+# Cache cargo artifacts, SemVer gate selftest, Enforce public-API SemVer against
+# crates.io. All six belong behind have_work — none of them has a reason to run
+# when nothing is being released.
+assert_eq "semver-checks gates its costly steps on there being work" "6" \
   "$(grep -c "if: steps.crate.outputs.have_work == 'true'" .github/workflows/semver-checks.yml || true)"
 
 echo


### PR DESCRIPTION
## Summary

Fix-forward on #5440: `main` is red on "Detect Cargo-inert change set" since
PR #5564's squash `f9f1c546`. That PR added a sixth `have_work`-guarded step
to `.github/workflows/semver-checks.yml` (libdbus-1-dev install, needed for
`trusty-common`'s `keyring-store` feature under cargo-semver-checks) but left
the selftest's expected guard count at 5.

## Guard count — counted directly in the workflow

Six steps carry `if: steps.crate.outputs.have_work == 'true'` in
`semver-checks.yml`:

1. Install stable toolchain
2. Install system dependencies (libdbus for keyring-store) — added by #5564
3. Install cargo-semver-checks (pinned prebuilt)
4. Cache cargo artifacts
5. SemVer gate selftest (must refuse a blind run)
6. Enforce public-API SemVer against crates.io

That matches the failure message's own `grep -c` output (6), so there's no
disagreement between the manually-counted value and what the script reports —
the fix updates the expected value to the number counted, not just to make
the message go away.

The new guard is correct: the semver-checking path — and the libdbus
dependency it needs — only runs when a PR bumps a crate version, which is
exactly what `have_work` tracks. Confirmed by reading the step's own comment
in the workflow (`#5440: trusty-common's keyring-store feature pulls in
libdbus-sys...`).

Checked the rest of the selftest's assertions about this workflow (pull_request
trigger has no paths filter, no job-level `if:`, has a no-op step, runs on PRs,
selects crates from the diff, doesn't branch on activity type) — all still
hold against the current file; only the guard-count assertion was stale.

## Process question — was PR #5564's own head red?

**Yes.** The "Detect Cargo-inert change set" job failed on PR #5564's own head
(`c4d480b3b7f4e9d69ec0c37a9ab023ca155ce591`), well before the PR merged:

- Job `Detect Cargo-inert change set` (run `31560647279`, job
  `94002030894`): `conclusion: failure`, completed `2026-08-12T03:37:38Z`.
- PR #5564 merged at `2026-08-12T03:44:15Z` — about 6.5 minutes later.

Enumerated via `check-suites` → `check-runs` (not the combined-status
endpoint): the `github-actions` check-suite `85611733050` on that head shows
one `failure` (this job) among otherwise-green runs.

Branch protection's `required_status_checks.contexts` is: `Format check`,
`500-line file-size cap`, `Clippy`, `trusty-search daemon smoke test`,
`MSRV check`, `PR version bump vs crates.io (issue #4421)`. "Detect
Cargo-inert change set" is not on that list, so the merge protocol verified
only the six required contexts and let a real failing non-required check
through unexamined. That's a merge-protocol gap, not a merge-ref discrepancy —
the selftest failure was visible on the PR's own head at merge time.

## Test ladder

Rung 1 (CI config, docs/scripts only).

- `bash scripts/check-ci-helpers-selftest.sh` → `check-ci-helpers-selftest: all 135 cases passed`
- `bash scripts/check_changelog_fragment.sh` → `changelog-fragment gate: scanned 1 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.` (fragment exempt, CI-only change)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
