### PR TITLE
fix(ci): clear a stale asset-less release before softprops runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1823,6 +1823,47 @@ jobs:
         env:
           OUTPUT: RELEASE_NOTES.md
 
+      # ── Clear a stale, asset-less release before softprops runs (issue #5455) ──
+      # WHY: GitHub's "Immutable Releases" enforcement rejects ANY update to an
+      #   already-published release that includes `target_commitish` —
+      #   softprops/action-gh-release@v2 submits it on its update-existing-
+      #   release path unconditionally (upstream: softprops/action-gh-release
+      #   issues #653 and #641, "Incompatible with immutable releases"). If a
+      #   release object for this tag ALREADY exists when this job runs — from
+      #   an earlier partial/failed run of this same workflow, a manual
+      #   `gh release create`, or any retry/re-dispatch — softprops's own GET
+      #   finds it, tries to reconcile fields via PATCH, and dies with:
+      #     "target_commitish cannot be changed when release is immutable"
+      #   *before ever uploading assets*. That is exactly what happened to
+      #   trusty-installer-v0.5.0 (run 30961682562, 2026-08-04): all three
+      #   build legs succeeded and produced valid tarballs, but the release
+      #   was left with ZERO assets because this step failed first — breaking
+      #   install.sh for every new user with a 404 on the checksum download.
+      #
+      # WHAT: if a release already exists for this tag AND it currently has no
+      #   assets attached, delete the release OBJECT only (never the git tag —
+      #   `--cleanup-tag` is intentionally omitted) so softprops's normal
+      #   create → upload-assets → publish path runs unobstructed on a clean
+      #   slate. A release that already carries real assets is left
+      #   completely untouched — this only clears the specific "empty stale
+      #   release" collision, never a legitimate published release.
+      - name: Clear a stale asset-less release for this tag, if present
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          ASSET_COUNT="$(gh api "repos/${{ github.repository }}/releases/tags/${TAG}" \
+            --jq '.assets | length' 2>/dev/null || echo "")"
+          if [[ -z "$ASSET_COUNT" ]]; then
+            echo "No existing release for tag '${TAG}' — nothing to clear."
+          elif [[ "$ASSET_COUNT" == "0" ]]; then
+            echo "::warning::Found an existing release for '${TAG}' with 0 assets — deleting the release object (tag left intact) so softprops/action-gh-release can recreate it cleanly. See #5455."
+            gh release delete "${TAG}" --yes
+          else
+            echo "Existing release for '${TAG}' already has ${ASSET_COUNT} asset(s) attached — leaving it in place."
+          fi
+
       - name: Create / update GitHub Release and upload assets
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary

Fixes #5455 — `install.sh` 404s downloading the checksum for `trusty-installer-v0.5.0` because that release has zero assets attached.

## Root cause (evidence, not guesswork)

Run [30961682562](https://github.com/bobmatnyc/trusty-tools/actions/runs/30961682562) is the `Binary Release` workflow run for the `trusty-installer-v0.5.0` tag push. It is the only workflow run recorded against that tag ref.

- `setup`, `preflight` (tag-ancestry check), and all three `build` legs (`aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`) **succeeded** and produced valid `.tar.gz` + `.tar.gz.sha256` artifacts — confirmed from the job's own "Strip, package, and checksum" and "Upload assets as workflow artifacts" steps, all green.
- The `Create / update GitHub Release and upload assets` job's final step (`softprops/action-gh-release@v2`) **failed** — this is where assets get attached — with:
  ```
  ⚠️ Unexpected error fetching GitHub release for tag refs/tags/trusty-installer-v0.5.0: HttpError: Validation Failed: {"resource":"Release","code":"custom","field":"target_commitish","message":"target_commitish cannot be changed when release is immutable"}
  ```
- `gh api repos/bobmatnyc/trusty-tools/releases/tags/trusty-installer-v0.5.0` confirms the release exists with `"assets":[]` and `"immutable":true`.

So the tarballs were built correctly and are sitting in the run's workflow-artifact storage, but were never uploaded to the GitHub Release because softprops's own `GET` found a release for this tag **already existing**, attempted to reconcile it via `PATCH` (which unconditionally includes `target_commitish`), and GitHub's Immutable Releases enforcement rejected that PATCH before any asset upload happened. This is a known upstream interaction (softprops/action-gh-release#653, #641 — "Incompatible with immutable releases"): the action's update-existing-release path was never adapted for GitHub's immutable-release rollout.

I could not determine from the available Actions history exactly what created the pre-existing release object ahead of this run (no other `release.yml` run is recorded for this tag, and the timestamps on the release object don't line up with this run's own timeline — its `created_at` matches the tagged commit's author date, which is a documented GitHub Release API quirk for releases created against a pre-existing tag, not the object's real creation time). What's fully evidenced is the failure mechanism itself, and that it will recur identically any time a release object for a tag exists before this job runs — a retry, a re-dispatch, or another out-of-band `gh release create` all reach the same wall.

`install.sh`'s `download_and_install()` requests exactly `${RELEASE_DL_BASE}/${TAG_PREFIX}${_version}/${CRATE}-${_version}-${_target}.tar.gz(.sha256)`, i.e. `.../releases/download/trusty-installer-v0.5.0/trusty-installer-0.5.0-<target>.tar.gz` — which matches the asset names the build legs actually produced; the naming isn't the problem, the upload never happened.

## Fix

Add a step immediately before the `softprops/action-gh-release` step: if a release already exists for the tag **and has zero assets**, delete the release object only (`gh release delete <tag> --yes`, `--cleanup-tag` intentionally omitted so the git tag is untouched) so softprops's normal create → upload → publish path runs on a clean slate. A release that already carries real assets is left completely untouched.

This is scoped to the exact collision observed — it never touches a legitimate published release with real assets, and it doesn't depend on an upstream fix that may not land in `softprops/action-gh-release@v2`.

## Test plan

- Rung 1 (CI-only change, no crate `src/**` touched): `bash scripts/check_changelog_fragment.sh` confirms no fragment required (docs/CI-only path).
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — YAML parses.
- `actionlint .github/workflows/release.yml` — exit 0, no findings.
- Not exercised against a real tag push in this PR (that would require cutting a release, out of scope here — see the issue's explicit "no re-cut, no asset upload" instruction). The next real `*-v*` tag push exercises this path for real.

Does **not** touch the `trusty-installer-v0.5.0` release itself — no assets uploaded, no tag re-pushed, no crates.io publish. That remains a separate, explicitly-authorized follow-up.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools