### PR TITLE
fix(trusty-common): load_palace must not read an unstattable palace.json as absent (#5549)

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -222,7 +222,6 @@ crates/trusty-common/src/memory_core/store/kg_redb/write_ops.rs	cascade_delete_r
 crates/trusty-common/src/memory_core/store/kg_writer.rs	writer_reports_error_per_op
 crates/trusty-common/src/memory_core/store/kg/ops.rs	cascade_delete_removes_triples_for_drawer
 crates/trusty-common/src/memory_core/store/kg/ops.rs	palace_handle_read_only_when_kg_snapshotted
-crates/trusty-common/src/memory_core/store/palace_store.rs	load_palace_missing_returns_not_found
 crates/trusty-common/src/rpc/client.rs	parse_args
 crates/trusty-common/src/rpc/transport/http.rs	http_transport_roundtrip
 crates/trusty-common/src/rpc/transport/stdio.rs	stdio_transport_echo

--- a/crates/trusty-common/changelog.d/5549-load-palace-stat-guard.md
+++ b/crates/trusty-common/changelog.d/5549-load-palace-stat-guard.md
@@ -1,3 +1,4 @@
 Fixed
 
 - `PalaceStore::load_palace` no longer reports a palace it cannot stat as one that is not there. Its absence guard was `Path::exists`, which is `fs::metadata(..).is_ok()` and so collapses a permission denial into `NotFound` — the one error `list_palaces` treats as benign and skips, so a palace whose permissions changed mid-walk dropped out of the listing the destructive passes act on. A denied or otherwise undeterminable probe now propagates an `Io` error naming `palace.json`; genuine absence still returns `NotFound` and still skips silently (#5549, ADR-0045).
+- `PalaceStore::load_identity` keeps its `exists()` guard and now says why: an unreadable `identity.txt` reads as absent, the consumer falls back to a default prompt, and nothing destructive or enumerating branches on the answer. Marked `// intentional fail-open` per ADR-0045 decision 4 (#5549).

--- a/crates/trusty-common/changelog.d/5549-load-palace-stat-guard.md
+++ b/crates/trusty-common/changelog.d/5549-load-palace-stat-guard.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `PalaceStore::load_palace` no longer reports a palace it cannot stat as one that is not there. Its absence guard was `Path::exists`, which is `fs::metadata(..).is_ok()` and so collapses a permission denial into `NotFound` — the one error `list_palaces` treats as benign and skips, so a palace whose permissions changed mid-walk dropped out of the listing the destructive passes act on. A denied or otherwise undeterminable probe now propagates an `Io` error naming `palace.json`; genuine absence still returns `NotFound` and still skips silently (#5549, ADR-0045).

--- a/crates/trusty-common/src/memory_core/store/palace_store.rs
+++ b/crates/trusty-common/src/memory_core/store/palace_store.rs
@@ -27,7 +27,9 @@ const IDENTITY_TXT: &str = "identity.txt";
 /// distinguish missing metadata from genuine I/O failure.
 /// What: Wraps `std::io::Error` and `serde_json::Error` plus a "not found"
 /// variant for missing metadata files.
-/// Test: `load_palace_missing_returns_not_found` (implicit via roundtrip test).
+/// Test: `load_palace_missing_returns_not_found` pins which absences earn
+/// `NotFound`; `load_palace_propagates_an_unstattable_palace_json` pins that an
+/// undeterminable one earns `Io` instead.
 #[derive(Debug, Error)]
 pub enum PalaceStoreError {
     #[error("io error at {path}: {source}")]
@@ -145,11 +147,22 @@ impl PalaceStore {
     /// Why: Re-opening a palace requires reconstructing its `Palace` struct
     /// before we can wire up storage handles.
     /// What: Reads `palace.json`, deserializes into `Palace`. Returns
-    /// `NotFound` if the file is missing.
-    /// Test: `palace_store_roundtrip` confirms fields survive a save+load.
+    /// `NotFound` only when the file is genuinely absent; a probe that cannot
+    /// determine whether it is there propagates the underlying error instead
+    /// (ADR-0045). That distinction matters to `list_palaces`, whose caller
+    /// contract treats `NotFound` as "skip this one" — so a denial coerced to
+    /// `NotFound` here drops a real palace out of the listing the destructive
+    /// passes act on.
+    /// Test: `palace_store_roundtrip` confirms fields survive a save+load;
+    /// `load_palace_missing_returns_not_found` pins the benign arm and
+    /// `load_palace_propagates_an_unstattable_palace_json` the error arm.
     pub fn load_palace(data_dir: &Path) -> Result<Palace> {
         let target = data_dir.join(PALACE_JSON);
-        if !target.exists() {
+        // #5549: `exists()` reported a stat we are denied as "no metadata here".
+        let present = target
+            .try_exists()
+            .map_err(|e| PalaceStoreError::io(target.clone(), e))?;
+        if !present {
             return Err(PalaceStoreError::NotFound(target));
         }
         let bytes = std::fs::read(&target).map_err(|e| PalaceStoreError::io(target.clone(), e))?;
@@ -598,6 +611,106 @@ mod tests {
                 assert_eq!(path, target, "the error must name the undecodable file");
             }
             other => panic!("expected a Json error naming the broken palace, got {other:?}"),
+        }
+    }
+
+    /// Why (#5549): `load_palace`'s own guard was `target.exists()`, which is
+    /// `fs::metadata(..).is_ok()`, so a `palace.json` we are forbidden to stat
+    /// returned `NotFound` — the one error `list_palaces` treats as benign and
+    /// skips. The palace dropped out of the listing the destructive passes act
+    /// on, one layer beneath the per-entry guard #5545 hardened, and no caller
+    /// could tell "no palace here" from "could not find out whether there is
+    /// one".
+    /// What: strips the palace's own directory to mode 000, so the directory
+    /// still stats while stat of the `palace.json` inside it is denied — the
+    /// probe fails, and it fails at this call site rather than in a caller.
+    /// Asserts the denial arrives as `Io` and specifically NOT as `NotFound`;
+    /// the direction is the point, not merely that some error came back.
+    /// Test: This test.
+    #[cfg(unix)]
+    #[test]
+    fn load_palace_propagates_an_unstattable_palace_json() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().unwrap();
+        let data_dir = tmp.path().join("alpha");
+        PalaceStore::save_palace(&make_palace("alpha", &data_dir)).unwrap();
+
+        assert!(
+            PalaceStore::load_palace(&data_dir).is_ok(),
+            "the palace must load cleanly before its directory is locked"
+        );
+
+        std::fs::set_permissions(&data_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+        // Declared after `tmp` so it drops first: the mode is restored before
+        // `TempDir` tries to delete the tree, including while unwinding from a
+        // failed assertion below.
+        let _restore = RestoreMode(data_dir.clone());
+
+        // Root bypasses the mode bits outright, and some filesystems ignore
+        // them, so confirm the denial actually took hold. A vacuous pass on a
+        // fail-open guard is worse than no test at all.
+        let target = data_dir.join(PALACE_JSON);
+        match std::fs::metadata(&target) {
+            Ok(_) => panic!(
+                "cannot exercise #5549: stat of {} still succeeds with its parent at \
+                 mode 000. Run this suite as a non-root user on a filesystem that honours \
+                 POSIX permission bits.",
+                target.display()
+            ),
+            Err(e) => assert_eq!(
+                e.kind(),
+                std::io::ErrorKind::PermissionDenied,
+                "expected the locked palace dir to deny stat of its metadata, got {e}"
+            ),
+        }
+
+        let err = PalaceStore::load_palace(&data_dir)
+            .expect_err("a palace.json that cannot be stat'd must not load");
+
+        match err {
+            PalaceStoreError::Io { path, source } => {
+                assert_eq!(path, target, "the error must name the metadata file");
+                assert_eq!(
+                    source.kind(),
+                    std::io::ErrorKind::PermissionDenied,
+                    "the denial must survive into the error, got {source}"
+                );
+            }
+            PalaceStoreError::NotFound(p) => panic!(
+                "a palace whose metadata cannot be stat'd was reported as absent at {} — \
+                 that is the #5549 coercion, and `list_palaces` skips silently on it",
+                p.display()
+            ),
+            other => panic!("expected an Io error carrying the denial, got {other:?}"),
+        }
+    }
+
+    /// Why (#5549): the guard above must not turn a genuine absence into an
+    /// error. `NotFound` keeps its benign behaviour (ADR-0045 decision 3) —
+    /// `list_palaces` skips on it, and a first run against a data root that
+    /// holds no palace yet is normal, so making absence loud has a wider blast
+    /// radius than the bug being fixed.
+    /// What: asserts both absence shapes still read as `NotFound`: a directory
+    /// that exists but holds no `palace.json`, and a directory that is not
+    /// there at all. Uses no permission bits, so it exercises the arm under any
+    /// uid.
+    /// Test: This test.
+    #[test]
+    fn load_palace_missing_returns_not_found() {
+        let tmp = tempdir().unwrap();
+
+        let empty = tmp.path().join("empty");
+        std::fs::create_dir_all(&empty).unwrap();
+        match PalaceStore::load_palace(&empty).expect_err("a dir with no palace.json is absent") {
+            PalaceStoreError::NotFound(p) => assert_eq!(p, empty.join(PALACE_JSON)),
+            other => panic!("expected NotFound for a palace-less directory, got {other:?}"),
+        }
+
+        let missing = tmp.path().join("does-not-exist");
+        match PalaceStore::load_palace(&missing).expect_err("a missing dir is absent") {
+            PalaceStoreError::NotFound(p) => assert_eq!(p, missing.join(PALACE_JSON)),
+            other => panic!("expected NotFound for a missing directory, got {other:?}"),
         }
     }
 }

--- a/crates/trusty-common/src/memory_core/store/palace_store.rs
+++ b/crates/trusty-common/src/memory_core/store/palace_store.rs
@@ -284,6 +284,12 @@ impl PalaceStore {
     /// `None` is exercised by `load_identity_missing_returns_none`.
     pub fn load_identity(data_dir: &Path) -> Result<Option<String>> {
         let target = data_dir.join(IDENTITY_TXT);
+        // intentional fail-open (ADR-0045 decision 4): `exists()` reads a
+        // denied stat as "absent" here as everywhere, and that is the safe
+        // direction for this one. The only consumer treats `None` as "no
+        // identity yet" and falls back to a default prompt, so the worst case
+        // is a thinner prompt — nothing destructive, enumerating, or
+        // operator-reporting branches on this answer.
         if !target.exists() {
             return Ok(None);
         }

--- a/crates/trusty-memory/changelog.d/5549-palace-load-error-mapping.md
+++ b/crates/trusty-memory/changelog.d/5549-palace-load-error-mapping.md
@@ -1,0 +1,4 @@
+Fixed
+
+- `PATCH /api/v1/palaces/{id}` no longer answers 404 when it cannot determine whether the palace exists. Both rename paths mapped every `PalaceStoreError` through `not_found`, so a denied or transient stat of `palace.json` told the client the palace does not exist — erasing, at the caller, the distinction `load_palace` draws. A genuine absence is still 404; anything else is now 500 and says it could not load the palace (#5549, ADR-0045).
+- The startup migration `migrate_default_palace_name` no longer skips silently when it cannot stat `localLLM/palace.json`. Its `exists()` pre-check read a denial as "no default palace on this host" and no-op'd every boot without reaching the propagation below it; the pre-check is gone and only a genuine `NotFound` is a no-op (#5549).

--- a/crates/trusty-memory/src/commands/migrations.rs
+++ b/crates/trusty-memory/src/commands/migrations.rs
@@ -20,7 +20,7 @@
 
 use anyhow::{Context, Result};
 use std::path::Path;
-use trusty_common::memory_core::store::PalaceStore;
+use trusty_common::memory_core::store::{PalaceStore, PalaceStoreError};
 
 /// Stable on-disk identifier for the default unscoped palace.
 const DEFAULT_PALACE_ID: &str = "localLLM";
@@ -35,26 +35,33 @@ const NEW_DEFAULT_NAME: &str = "User Memories";
 /// Why: Issue #98 — refresh the default palace's display label without
 /// touching its `PalaceId`, on-disk directory, or any caller-visible API.
 /// What: Reads `<registry_root>/localLLM/palace.json` via `PalaceStore`. If
-/// the file is missing, the palace has no `localLLM` entry, or the `name`
-/// field already differs from the legacy literal, the function is a no-op.
-/// Otherwise it rewrites `palace.json` atomically with the new name.
+/// the file is genuinely absent, or the `name` field already differs from the
+/// legacy literal, the function is a no-op. Otherwise it rewrites
+/// `palace.json` atomically with the new name. Metadata whose presence cannot
+/// be determined is an error rather than a silent no-op (#5549, ADR-0045) —
+/// startup surfaces it once instead of skipping the rename every boot.
 /// Test: `tests::migrates_when_legacy_name`,
 /// `tests::idempotent_when_already_renamed`,
 /// `tests::leaves_custom_name_untouched`,
-/// `tests::missing_palace_is_noop`.
+/// `tests::missing_palace_is_noop`,
+/// `tests::unstattable_palace_json_is_an_error_not_a_noop`.
 ///
 /// This is an internal migration entrypoint, not a general-purpose rename
 /// API. It is `pub` only so the `trusty-memory` binary crate can invoke it
 /// from `main.rs`; do not call it from other crates.
 pub fn migrate_default_palace_name(registry_root: &Path) -> Result<()> {
     let palace_dir = registry_root.join(DEFAULT_PALACE_ID);
-    if !palace_dir.join("palace.json").exists() {
+    // #5549: the pre-check was `palace.json.exists()`, which read a denied stat
+    // as "no default palace here" and skipped the migration without a word.
+    let mut palace = match PalaceStore::load_palace(&palace_dir) {
+        Ok(p) => p,
         // No default palace on this host — nothing to do.
-        return Ok(());
-    }
-
-    let mut palace = PalaceStore::load_palace(&palace_dir)
-        .with_context(|| format!("load palace metadata at {}", palace_dir.display()))?;
+        Err(PalaceStoreError::NotFound(_)) => return Ok(()),
+        Err(e) => {
+            return Err(e)
+                .with_context(|| format!("load palace metadata at {}", palace_dir.display()))
+        }
+    };
 
     if palace.name != LEGACY_DEFAULT_NAME {
         // Already renamed (either by an earlier migration run or by the user
@@ -187,5 +194,58 @@ mod tests {
             loaded.name, LEGACY_DEFAULT_NAME,
             "non-default palaces must not be touched"
         );
+    }
+
+    /// Restore a directory's mode on drop, including while unwinding, so a
+    /// failed assertion cannot leave `tempfile` an undeletable tree.
+    #[cfg(unix)]
+    struct RestoreMode(std::path::PathBuf);
+
+    #[cfg(unix)]
+    impl Drop for RestoreMode {
+        fn drop(&mut self) {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o700));
+        }
+    }
+
+    /// Why (#5549): the guard here was `palace.json.exists()`, sitting directly
+    /// in front of the `load_palace` this change hardened. A denied stat read
+    /// as "no default palace on this host", so the migration no-op'd every boot
+    /// and never reached the propagation one layer down.
+    /// What: locks the palace directory to mode 000 so stat of its metadata is
+    /// denied, and asserts the migration errors instead of returning `Ok(())`.
+    /// Panics rather than passing vacuously if the denial does not take hold.
+    /// Test: This test itself.
+    #[cfg(unix)]
+    #[test]
+    fn unstattable_palace_json_is_an_error_not_a_noop() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        persist_palace(root, DEFAULT_PALACE_ID, LEGACY_DEFAULT_NAME);
+        let palace_dir = root.join(DEFAULT_PALACE_ID);
+
+        std::fs::set_permissions(&palace_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let _restore = RestoreMode(palace_dir.clone());
+
+        let target = palace_dir.join("palace.json");
+        match std::fs::metadata(&target) {
+            Ok(_) => panic!(
+                "cannot exercise #5549: stat of {} still succeeds with its parent at mode 000. \
+                 Run this suite as a non-root user on a filesystem that honours POSIX \
+                 permission bits.",
+                target.display()
+            ),
+            Err(e) => assert_eq!(
+                e.kind(),
+                std::io::ErrorKind::PermissionDenied,
+                "expected the locked palace dir to deny stat of its metadata, got {e}"
+            ),
+        }
+
+        migrate_default_palace_name(root)
+            .expect_err("a palace.json that cannot be stat'd must not read as no palace at all");
     }
 }

--- a/crates/trusty-memory/src/service/core.rs
+++ b/crates/trusty-memory/src/service/core.rs
@@ -19,6 +19,7 @@ use trusty_common::memory_core::retrieval::{
     recall_across_palaces_with_default_embedder, recall_deep_with_default_embedder,
     recall_with_default_embedder, RememberOptions,
 };
+use trusty_common::memory_core::store::PalaceStoreError;
 use trusty_common::memory_core::PalaceRegistry;
 use uuid::Uuid;
 
@@ -332,7 +333,9 @@ impl MemoryService {
     /// `palace.json` changes — so cached `PalaceHandle`s stay valid and no
     /// registry invalidation is required.
     /// What: 1) loads the palace via `PalaceStore::load_palace` (404 when the
-    /// directory or `palace.json` is missing), 2) trims the new name and
+    /// directory or `palace.json` is genuinely missing; a probe that cannot
+    /// determine whether it is there is a 500, not a 404 — #5549), 2) trims the
+    /// new name and
     /// returns `BadRequest` when empty, 3) mutates `palace.name` and writes
     /// the metadata back through the atomic `PalaceStore::save_palace`
     /// (tmp file + rename), 4) emits an aggregate `StatusChanged` so
@@ -349,7 +352,14 @@ impl MemoryService {
         }
         let palace_dir = self.state.data_root.join(palace_id);
         let mut palace = trusty_common::memory_core::store::PalaceStore::load_palace(&palace_dir)
-            .map_err(|e| anyhow!("palace not found: {palace_id} ({e})"))?;
+            .map_err(|e| {
+            // #5549: only a genuine absence may be reported as "not found".
+            if matches!(&e, PalaceStoreError::NotFound(_)) {
+                anyhow!("palace not found: {palace_id} ({e})")
+            } else {
+                anyhow!("cannot load palace {palace_id}: {e}")
+            }
+        })?;
         palace.name = trimmed.to_string();
         trusty_common::memory_core::store::PalaceStore::save_palace(&palace)
             .with_context(|| format!("save palace metadata for {palace_id}"))?;
@@ -377,11 +387,15 @@ impl MemoryService {
     /// untyped one keeps the wire shape correct on both surfaces without
     /// asking either caller to parse error strings.
     /// What: same as [`Self::update_palace_name`] but returns
-    /// `ServiceError::BadRequest` for empty names and
-    /// `ServiceError::NotFound` for missing palace metadata.
+    /// `ServiceError::BadRequest` for empty names and `ServiceError::NotFound`
+    /// for palace metadata that is genuinely absent. Metadata whose presence
+    /// cannot be determined — a denied or transient stat — is
+    /// `ServiceError::Internal`: a 404 would tell the client the palace does
+    /// not exist when nobody established that (#5549, ADR-0045).
     /// Test: `update_palace_name_renames_palace`,
     /// `update_palace_name_rejects_empty_name`,
-    /// `update_palace_name_returns_not_found_for_missing_id`.
+    /// `update_palace_name_returns_not_found_for_missing_id`,
+    /// `update_palace_name_reports_an_unstattable_palace_as_internal`.
     pub async fn update_palace_name_typed(
         &self,
         palace_id: &str,
@@ -396,7 +410,13 @@ impl MemoryService {
         let palace_dir = self.state.data_root.join(palace_id);
         let mut palace = trusty_common::memory_core::store::PalaceStore::load_palace(&palace_dir)
             .map_err(|e| {
-            ServiceError::not_found(format!("palace not found: {palace_id} ({e})"))
+            // #5549: `not_found` on every variant told the client the palace
+            // does not exist for a stat we were merely denied.
+            if matches!(&e, PalaceStoreError::NotFound(_)) {
+                ServiceError::not_found(format!("palace not found: {palace_id} ({e})"))
+            } else {
+                ServiceError::internal(format!("cannot load palace {palace_id}: {e}"))
+            }
         })?;
         palace.name = trimmed.to_string();
         trusty_common::memory_core::store::PalaceStore::save_palace(&palace).map_err(|e| {

--- a/crates/trusty-memory/src/web/tests/palace_crud_tests.rs
+++ b/crates/trusty-memory/src/web/tests/palace_crud_tests.rs
@@ -267,6 +267,99 @@ async fn update_palace_name_returns_not_found_for_missing_id() {
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
+/// Restore a directory's mode on drop, including while unwinding.
+///
+/// Why: the denial test below strips a palace directory to mode 000. The
+/// fixture's tempdir is deliberately leaked, so a mode-000 directory left
+/// behind by a failed assertion is a permanent undeletable leak rather than a
+/// transient one.
+#[cfg(unix)]
+struct RestoreMode(std::path::PathBuf);
+
+#[cfg(unix)]
+impl Drop for RestoreMode {
+    fn drop(&mut self) {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o700));
+    }
+}
+
+/// Why (#5549): hardening `load_palace` to distinguish absent from
+/// undeterminable buys nothing if the caller flattens the distinction again.
+/// `update_palace_name_typed` mapped EVERY `PalaceStoreError` through
+/// `ServiceError::not_found`, so a palace whose `palace.json` could not be
+/// stat'd was reported to the HTTP client as 404 — "this palace does not
+/// exist" — for a denial or a transient `EIO` that established no such thing.
+/// What: creates a palace, strips its directory to mode 000 so stat of the
+/// metadata inside is denied, and PATCHes it. Asserts the response is 500 and
+/// specifically NOT 404. Panics rather than passing vacuously if the denial
+/// does not take hold.
+/// Test: This test itself.
+#[cfg(unix)]
+#[tokio::test]
+async fn update_palace_name_reports_an_unstattable_palace_as_internal() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let state = test_state();
+    let palace_dir = state.data_root.join("locked-palace");
+    let app = router().with_state(state);
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/palaces")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({"name": "locked-palace"}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    std::fs::set_permissions(&palace_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+    let _restore = RestoreMode(palace_dir.clone());
+
+    // Root bypasses the mode bits outright, and some filesystems ignore them,
+    // so confirm the denial actually took hold. A vacuous pass on a fail-open
+    // guard is worse than no test at all.
+    let target = palace_dir.join("palace.json");
+    match std::fs::metadata(&target) {
+        Ok(_) => panic!(
+            "cannot exercise #5549: stat of {} still succeeds with its parent at mode 000. \
+             Run this suite as a non-root user on a filesystem that honours POSIX \
+             permission bits.",
+            target.display()
+        ),
+        Err(e) => assert_eq!(
+            e.kind(),
+            std::io::ErrorKind::PermissionDenied,
+            "expected the locked palace dir to deny stat of its metadata, got {e}"
+        ),
+    }
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri("/api/v1/palaces/locked-palace")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({"name": "New Display Name"}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_ne!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "a palace whose metadata cannot be stat'd was reported as absent — that is the \
+         #5549 coercion re-created one crate up, at the caller"
+    );
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
 /// Why: The operator TUI's MEMORY tab reads `node_count`, `edge_count`,
 /// `community_count`, and `is_compacting` straight off the
 /// `/api/v1/palaces` payload. If any of those fields disappear or change


### PR DESCRIPTION
Closes #5549.

Governing rule: [ADR-0045](https://github.com/bobmatnyc/trusty-tools/blob/main/docs/adr/0045-distinguish-absent-from-undeterminable-on-destructive-paths.md).

`load_palace`'s guard was `Path::exists()`, which is `fs::metadata(..).is_ok()`, so a denied stat returned `NotFound` — the one error `list_palaces` treats as benign and skips. `try_exists()` now separates the two. Per ADR-0045 decision 3, `NotFound` keeps its benign behaviour: a directory holding no `palace.json`, and a directory that is not there at all, both still return `NotFound` and still skip.

## Three caller sites, because the store fix alone does nothing

Review caught that the distinction was erased one crate up, at the caller this PR originally cited as proof the fix mattered. Fixed here rather than deferred:

- `service/core.rs` — both rename paths mapped **every** `PalaceStoreError` through `ServiceError::not_found` / `anyhow!("palace not found")`. A denied or transient stat told the HTTP client the palace does not exist. Genuine absence stays 404; everything else is 500.
- `commands/migrations.rs` — the startup migration guarded the very `load_palace` this PR hardened with its own `palace.json.exists()`, so an unstattable file no-op'd the migration every boot and never reached the propagation below. Pre-check removed; only `NotFound` is a no-op.
- `palace_store.rs` `load_identity` — keeps `exists()`, and now carries the `// intentional fail-open` marker ADR-0045 decision 4 requires. Its consumer falls back to a default prompt, so absence is the safe direction; the reasoning belongs in the source, not only in a PR body.

## Fail-Open Check

Each error-arm test locks a directory to mode 000, panics rather than passing vacuously if the denial does not take hold, and orders the mode-restoring guard to drop before the `TempDir`.

`load_palace_propagates_an_unstattable_palace_json`, against `origin/main`:

```
running 2 tests
test memory_core::store::palace_store::tests::load_palace_missing_returns_not_found ... ok
test memory_core::store::palace_store::tests::load_palace_propagates_an_unstattable_palace_json ... FAILED

panicked at crates/trusty-common/src/memory_core/store/palace_store.rs:667:46:
a palace whose metadata cannot be stat'd was reported as absent at
/var/folders/.../alpha/palace.json — that is the #5549 coercion, and
`list_palaces` skips silently on it

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 1012 filtered out
```

`update_palace_name_reports_an_unstattable_palace_as_internal`, with the store fixed and the caller mapping still blanket-404 — the state that isolates the caller bug:

```
running 1 test
test web::tests::palace_crud_tests::update_palace_name_reports_an_unstattable_palace_as_internal ... FAILED

panicked at crates/trusty-memory/src/web/tests/palace_crud_tests.rs:354:5:
assertion `left != right` failed: a palace whose metadata cannot be stat'd was
reported as absent — that is the #5549 coercion re-created one crate up, at the caller
  left: 404
 right: 404

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 733 filtered out
```

`unstattable_palace_json_is_an_error_not_a_noop`, against the `exists()` pre-check:

```
running 1 test
test commands::migrations::tests::unstattable_palace_json_is_an_error_not_a_noop ... FAILED

panicked at crates/trusty-memory/src/commands/migrations.rs:251:14:
a palace.json that cannot be stat'd must not read as no palace at all: ()
```

All three pass on this branch:

```
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 1003 filtered out   (palace_store)
test result: ok.  4 passed; 0 failed; 0 ignored; 0 measured;  731 filtered out   (update_palace_name)
test result: ok.  7 passed; 0 failed; 0 ignored; 0 measured;  728 filtered out   (commands::migrations)
```

The benign-arm tests pass on both sides, which is the point of them.

## Rung 5

Rung 5, not 4: the change alters the error contract of a public `trusty-common` function consumed across a crate boundary, and the caller fixes change an HTTP status code. Persisted-state handling on both sides.

`trusty-common`'s default feature set is empty, so every command carries `--features memory-core` — a bare `cargo test -p trusty-common` exits 0 having run zero memory-core tests.

| Gate | Result |
|---|---|
| `cargo fmt --check` | exit 0 |
| `cargo check -p trusty-common --features memory-core` | exit 0 |
| `cargo clippy -p trusty-common --features memory-core --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-common --features memory-core` | 1001 + 6 + 11 + 4 passed, 0 failed, 14 ignored |
| `cargo clippy -p trusty-memory --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-memory` | 731 + 5 + … passed, 0 failed across 27 binaries, 0 FAILED |
| `cargo check --workspace` | exit 0 |
| `cargo test -p trusty-agents` (direct dependent, enables `memory-core`) | 3484 + 27 passed, 0 failed across 11 binaries |
| `cargo check -p trusty-mpm --features sm-memory,manager-memory` | exit 0 |
| `bash scripts/check_line_cap.sh` | 3973 tracked files, 4 allowlisted, 0 violations |
| `bash scripts/check_changelog_fragment.sh` | scanned 6 paths, both crates recorded |
| `bash scripts/check_sld.sh` | 58 specs + 5890 code files, 0 errors, 0 warnings |
| `bash scripts/check_test_pointers.sh` | 24103 citations, 0 dangling, 0 stale |
| `bash scripts/check_doc_numbers.sh` | 118 docs / 112 claims, 3 grandfathered, 0 violations |
| `bash scripts/check-version-parity.sh` | 21 crates, 0 drifted — `trusty-common` 0.33.1 and `trusty-memory` 0.23.0 are both unpublished, so neither owes a bump |

Rung 5's `--include-ignored` step adds nothing here: the 14 ignored tests are the ONNX embedder, `claude_config`, `project_discovery`, and one legacy-palace migration suite, none of which reach `palace_store`. The failure-path coverage comes from the three new tests instead.

`.test-pointer-allowlist.tsv` loses one row. `PalaceStoreError`'s doc comment has cited `load_palace_missing_returns_not_found` since it was written, with the parenthetical "(implicit via roundtrip test)", and no such test existed. This PR adds it, so the allowlist row no longer describes anything.

## What is closed and what is marked

Not "the last instance" — this PR closes the sites it found and marks one deliberately left:

- Fixed: `load_palace`'s guard, both `update_palace_name` error mappings, the `migrations.rs` pre-check.
- Deliberately fail-open, now marked in source: `load_identity`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
