### PR TITLE
test(trusty-code): route every spawned tcode child through one guarded constructor

### DIFF
--- a/crates/trusty-code/changelog.d/3036-hermetic-tcode-spawns.md
+++ b/crates/trusty-code/changelog.d/3036-hermetic-tcode-spawns.md
@@ -1,0 +1,22 @@
+Fixed
+
+- **The test suite no longer registers its fixture directories in the
+  developer's live trusty-search daemon, which was writing index files back
+  into the sandbox and failing unrelated `run_task` tests
+  ([#3036](https://github.com/bobmatnyc/trusty-tools/issues/3036),
+  [#3195](https://github.com/bobmatnyc/trusty-tools/issues/3195)).**
+  `trusty_common::search_index` refuses daemon writes while
+  `running_under_test_harness()` holds (#4255), but that answers for the
+  running process, and `env!("CARGO_BIN_EXE_tcode")` is `target/<profile>/tcode`
+  — outside `deps/` — so a spawned child looked like a real user invocation and
+  warmed its `--project` into whatever daemon it discovered. The daemon then
+  wrote `.gitignore` and `.trusty-search/{index.redb,hnsw.usearch,…}` into the
+  test's own tempdir, at a moment nobody controlled, breaking whichever
+  before/after diff assertion was open — which is why a different test failed
+  each run, only on a machine with a daemon, and never under
+  `--test-threads=1`. `tests/support/mod.rs` set `TRUSTY_TEST_HARNESS=1` on the
+  two children it owned; 26 tests built their own `Command` and did not. All of
+  them now go through the one guarded constructor `support::tcode_command()`,
+  and `no_test_spawns_the_tcode_binary_unguarded` fails the build if a new test
+  names the binary directly. One `cargo test -p trusty-code` used to leave 3
+  new indexes behind in the operator's daemon; it now leaves none.

--- a/crates/trusty-code/changelog.d/3036-hermetic-tcode-spawns.md
+++ b/crates/trusty-code/changelog.d/3036-hermetic-tcode-spawns.md
@@ -15,8 +15,9 @@ Fixed
   before/after diff assertion was open — which is why a different test failed
   each run, only on a machine with a daemon, and never under
   `--test-threads=1`. `tests/support/mod.rs` set `TRUSTY_TEST_HARNESS=1` on the
-  two children it owned; 26 tests built their own `Command` and did not. All of
-  them now go through the one guarded constructor `support::tcode_command()`,
+  two children it owned; 28 call sites across 24 test functions built their own
+  `Command` and did not. All of them now go through
+  the one guarded constructor `support::tcode_command()`,
   and `no_test_spawns_the_tcode_binary_unguarded` fails the build if a new test
   names the binary directly. One `cargo test -p trusty-code` used to leave 3
   new indexes behind in the operator's daemon; it now leaves none.

--- a/crates/trusty-code/src/daemon_isolation_tests.rs
+++ b/crates/trusty-code/src/daemon_isolation_tests.rs
@@ -1,0 +1,111 @@
+//! Source-level guard keeping every spawned `tcode` child hermetic against a
+//! live trusty-search daemon (#3036, #3195).
+//!
+//! Why: `trusty_common::search_index` refuses daemon writes while
+//! `running_under_test_harness()` holds (#4255), but that answers for the
+//! RUNNING process. `env!("CARGO_BIN_EXE_tcode")` resolves to
+//! `target/<profile>/tcode`, outside `deps/`, so a child this suite spawns
+//! looks exactly like a user's real invocation: it warms its `--project` into
+//! whatever trusty-search daemon it discovers, and on a developer machine
+//! that is the operator's live one. The daemon then registers the test's
+//! `$TMPDIR/.tmpXXXXXX` fixture and writes `.gitignore` and
+//! `.trusty-search/{index.redb,hnsw.usearch,hnsw.keys.json,schema_version.json}`
+//! back INSIDE the sandbox, at a moment nobody controls — the warm-up is
+//! detached and the daemon walks the tree asynchronously. Whichever
+//! before/after diff assertion is open when those files land fails, which is
+//! why a different `run_task` test broke each run, why only a machine with a
+//! daemon saw it, and why `--test-threads=1` looked green.
+//!
+//! `tests/support/mod.rs` set `TRUSTY_TEST_HARNESS=1` on the two children it
+//! owns, but 26 tests built their own `Command` and inherited none of it.
+//! Fixing those 26 call sites alone would leave the 27th to the next author's
+//! memory — the same bet that produced #3036, then #3195. This guard makes
+//! naming the binary outside the shared helper a test failure instead.
+//!
+//! What: reads this crate's own `tests/` sources and fails if any file other
+//! than `tests/support/mod.rs` names the `CARGO_BIN_EXE_tcode` env var in
+//! code. Lexical rather than runtime because a raw `Command::new` has no hook
+//! to gate — the only moment the mistake is observable is in the source.
+//! Test: this module IS the guard.
+
+/// The one file allowed to name the binary: the shared, guarded constructor
+/// and the two async spawners beside it.
+const SPAWN_ENTRY_POINT: &str = "support/mod.rs";
+
+/// Every test source spawns `tcode` through `support::tcode_command` (or the
+/// `StdioSession`/`HttpDaemon` helpers beside it), never by naming the
+/// binary itself.
+///
+/// A violation is not cosmetic: the child skips
+/// `trusty_common`'s test-harness gate and mutates the operator's live
+/// trusty-search registry, writing daemon storage into the fixture directory
+/// whose contents another test is asserting on.
+#[test]
+fn no_test_spawns_the_tcode_binary_unguarded() {
+    // Split so this guard does not match itself.
+    let needle = concat!("CARGO_BIN_EXE", "_tcode");
+    let tests_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+
+    let mut offenders = Vec::new();
+    for (path, source) in rust_sources(&tests_dir) {
+        if path.ends_with(SPAWN_ENTRY_POINT) {
+            continue;
+        }
+        for (lineno, line) in source.lines().enumerate() {
+            // Prose may still name it; only code is a spawn.
+            if line.contains(needle) && !line.trim_start().starts_with("//") {
+                offenders.push(format!("{path}:{}: {}", lineno + 1, line.trim()));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "these test sites spawn the `tcode` binary without the ambient-daemon \
+         guard, so the child registers its fixture directory in the operator's \
+         LIVE trusty-search daemon and the daemon writes `.trusty-search/` back \
+         into the sandbox (#3036, #3195). Call `support::tcode_command()` \
+         instead — it sets `TRUSTY_TEST_HARNESS=1` on the child:\n{}",
+        offenders.join("\n")
+    );
+}
+
+/// The guard is only meaningful if it actually found the `tests/` tree — an
+/// empty scan would pass vacuously after any directory rename.
+#[test]
+fn the_spawn_guard_actually_scans_the_test_sources() {
+    let tests_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let sources = rust_sources(&tests_dir);
+
+    assert!(
+        sources.len() > 5,
+        "expected this crate's `tests/` tree; found {} sources under {}",
+        sources.len(),
+        tests_dir.display()
+    );
+    assert!(
+        sources.iter().any(|(p, _)| p.ends_with(SPAWN_ENTRY_POINT)),
+        "the one allowed spawn entry point `{SPAWN_ENTRY_POINT}` was not found — \
+         the exemption in `no_test_spawns_the_tcode_binary_unguarded` would be \
+         checking a path that no longer exists"
+    );
+}
+
+/// Every `.rs` file under `dir`, recursively, as `(display path, contents)`.
+fn rust_sources(dir: &std::path::Path) -> Vec<(String, String)> {
+    let mut found = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return found;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            found.extend(rust_sources(&path));
+        } else if path.extension().is_some_and(|e| e == "rs")
+            && let Ok(source) = std::fs::read_to_string(&path)
+        {
+            found.push((path.display().to_string(), source));
+        }
+    }
+    found
+}

--- a/crates/trusty-code/src/daemon_isolation_tests.rs
+++ b/crates/trusty-code/src/daemon_isolation_tests.rs
@@ -17,47 +17,43 @@
 //! daemon saw it, and why `--test-threads=1` looked green.
 //!
 //! `tests/support/mod.rs` set `TRUSTY_TEST_HARNESS=1` on the two children it
-//! owns, but 26 tests built their own `Command` and inherited none of it.
-//! Fixing those 26 call sites alone would leave the 27th to the next author's
-//! memory — the same bet that produced #3036, then #3195. This guard makes
-//! naming the binary outside the shared helper a test failure instead.
+//! owns, but 28 call sites across 24 test functions built their own `Command`
+//! and inherited none of it. Fixing those call sites alone would leave the
+//! next one to the author's memory — the same bet that produced #3036, then
+//! #3195. This guard makes naming the binary outside the shared helper a test
+//! failure instead.
 //!
 //! What: reads this crate's own `tests/` sources and fails if any file other
 //! than `tests/support/mod.rs` names the `CARGO_BIN_EXE_tcode` env var in
 //! code. Lexical rather than runtime because a raw `Command::new` has no hook
 //! to gate — the only moment the mistake is observable is in the source.
-//! Test: this module IS the guard.
+//! Test: `no_test_spawns_the_tcode_binary_unguarded`,
+//! `only_the_exact_support_mod_path_is_exempt`.
 
-/// The one file allowed to name the binary: the shared, guarded constructor
-/// and the two async spawners beside it.
-const SPAWN_ENTRY_POINT: &str = "support/mod.rs";
+use std::path::{Path, PathBuf};
+
+/// The one file allowed to name the binary, as path COMPONENTS relative to
+/// `tests/`: the shared guarded constructor and the two async spawners beside
+/// it.
+///
+/// Components rather than a string suffix on purpose. `str::ends_with` does
+/// not respect path boundaries, so a `tests/cli_support/mod.rs` would have
+/// been silently exempted too — an accidental, innocuous-looking way to add
+/// the next unguarded spawn while this guard still reported green.
+const SPAWN_ENTRY_POINT: [&str; 2] = ["support", "mod.rs"];
 
 /// Every test source spawns `tcode` through `support::tcode_command` (or the
 /// `StdioSession`/`HttpDaemon` helpers beside it), never by naming the
 /// binary itself.
 ///
-/// A violation is not cosmetic: the child skips
-/// `trusty_common`'s test-harness gate and mutates the operator's live
-/// trusty-search registry, writing daemon storage into the fixture directory
-/// whose contents another test is asserting on.
+/// A violation is not cosmetic: the child skips `trusty_common`'s
+/// test-harness gate and mutates the operator's live trusty-search registry,
+/// writing daemon storage into the fixture directory whose contents another
+/// test is asserting on.
 #[test]
 fn no_test_spawns_the_tcode_binary_unguarded() {
-    // Split so this guard does not match itself.
-    let needle = concat!("CARGO_BIN_EXE", "_tcode");
-    let tests_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
-
-    let mut offenders = Vec::new();
-    for (path, source) in rust_sources(&tests_dir) {
-        if path.ends_with(SPAWN_ENTRY_POINT) {
-            continue;
-        }
-        for (lineno, line) in source.lines().enumerate() {
-            // Prose may still name it; only code is a spawn.
-            if line.contains(needle) && !line.trim_start().starts_with("//") {
-                offenders.push(format!("{path}:{}: {}", lineno + 1, line.trim()));
-            }
-        }
-    }
+    let tests_dir = crate_tests_dir();
+    let offenders = unguarded_spawn_sites(&tests_dir, spawn_needle());
 
     assert!(
         offenders.is_empty(),
@@ -70,11 +66,58 @@ fn no_test_spawns_the_tcode_binary_unguarded() {
     );
 }
 
+/// Only the exact path `tests/support/mod.rs` is exempt — a sibling whose
+/// directory merely ENDS in `support` is still caught.
+///
+/// Why this is pinned: the exemption used `str::ends_with`, which ignores
+/// path boundaries. Under that version a `tests/cli_support/mod.rs` was
+/// exempted by accident, which is precisely the un-guarded spawn this module
+/// exists to make impossible.
+#[test]
+fn only_the_exact_support_mod_path_is_exempt() {
+    let needle = spawn_needle();
+    let unguarded = format!("    let out = Command::new(env!(\"{needle}\"))");
+    let root = tempfile::tempdir().expect("fixture root");
+
+    for dir in ["support", "cli_support", "support/nested"] {
+        std::fs::create_dir_all(root.path().join(dir)).expect("mkdir fixture");
+        std::fs::write(root.path().join(dir).join("mod.rs"), &unguarded).expect("write fixture");
+    }
+    // A guarded caller must never be reported, wherever it lives.
+    std::fs::write(
+        root.path().join("guarded_e2e.rs"),
+        "    let out = support::tcode_command()",
+    )
+    .expect("write guarded fixture");
+
+    let offenders = unguarded_spawn_sites(root.path(), needle);
+    let root_prefix = format!("{}/", root.path().display());
+    let mut flagged: Vec<String> = offenders
+        .iter()
+        .map(|o| {
+            o.trim_start_matches(&root_prefix)
+                .split(':')
+                .next()
+                .unwrap_or(o)
+                .to_string()
+        })
+        .collect();
+    flagged.sort();
+
+    assert_eq!(
+        flagged,
+        vec!["cli_support/mod.rs", "support/nested/mod.rs"],
+        "only `<tests>/support/mod.rs` may be exempt; a directory that merely \
+         ends in `support`, and a `support/` nested deeper, must both be \
+         caught. Got: {offenders:?}"
+    );
+}
+
 /// The guard is only meaningful if it actually found the `tests/` tree — an
 /// empty scan would pass vacuously after any directory rename.
 #[test]
 fn the_spawn_guard_actually_scans_the_test_sources() {
-    let tests_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let tests_dir = crate_tests_dir();
     let sources = rust_sources(&tests_dir);
 
     assert!(
@@ -84,15 +127,65 @@ fn the_spawn_guard_actually_scans_the_test_sources() {
         tests_dir.display()
     );
     assert!(
-        sources.iter().any(|(p, _)| p.ends_with(SPAWN_ENTRY_POINT)),
-        "the one allowed spawn entry point `{SPAWN_ENTRY_POINT}` was not found — \
-         the exemption in `no_test_spawns_the_tcode_binary_unguarded` would be \
-         checking a path that no longer exists"
+        sources
+            .iter()
+            .any(|(p, _)| is_spawn_entry_point(p, &tests_dir)),
+        "the one allowed spawn entry point `tests/{}` was not found — the \
+         exemption in `no_test_spawns_the_tcode_binary_unguarded` would be \
+         checking a path that no longer exists",
+        SPAWN_ENTRY_POINT.join("/")
     );
 }
 
-/// Every `.rs` file under `dir`, recursively, as `(display path, contents)`.
-fn rust_sources(dir: &std::path::Path) -> Vec<(String, String)> {
+/// The env var whose appearance in a test source means "this spawns the real
+/// binary", split so this guard never matches its own source.
+fn spawn_needle() -> &'static str {
+    concat!("CARGO_BIN_EXE", "_tcode")
+}
+
+/// This crate's `tests/` directory.
+fn crate_tests_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests")
+}
+
+/// `"<path>:<lineno>: <line>"` for every place under `tests_dir` that names
+/// the binary outside the one exempt entry point.
+fn unguarded_spawn_sites(tests_dir: &Path, needle: &str) -> Vec<String> {
+    let mut offenders = Vec::new();
+    for (path, source) in rust_sources(tests_dir) {
+        if is_spawn_entry_point(&path, tests_dir) {
+            continue;
+        }
+        for (lineno, line) in source.lines().enumerate() {
+            // Prose may still name it; only code is a spawn.
+            if line.contains(needle) && !line.trim_start().starts_with("//") {
+                offenders.push(format!(
+                    "{}:{}: {}",
+                    path.display(),
+                    lineno + 1,
+                    line.trim()
+                ));
+            }
+        }
+    }
+    offenders
+}
+
+/// Is `path` exactly `<tests_dir>/support/mod.rs`?
+///
+/// Compares path COMPONENTS, so `cli_support/mod.rs` and
+/// `support/nested/mod.rs` are both non-exempt.
+fn is_spawn_entry_point(path: &Path, tests_dir: &Path) -> bool {
+    path.strip_prefix(tests_dir).is_ok_and(|relative| {
+        relative
+            .components()
+            .map(|c| c.as_os_str())
+            .eq(SPAWN_ENTRY_POINT.iter().map(std::ffi::OsStr::new))
+    })
+}
+
+/// Every `.rs` file under `dir`, recursively, as `(path, contents)`.
+fn rust_sources(dir: &Path) -> Vec<(PathBuf, String)> {
     let mut found = Vec::new();
     let Ok(entries) = std::fs::read_dir(dir) else {
         return found;
@@ -104,7 +197,7 @@ fn rust_sources(dir: &std::path::Path) -> Vec<(String, String)> {
         } else if path.extension().is_some_and(|e| e == "rs")
             && let Ok(source) = std::fs::read_to_string(&path)
         {
-            found.push((path.display().to_string(), source));
+            found.push((path, source));
         }
     }
     found

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -642,6 +642,11 @@ pub(crate) mod test_support {
     }
 }
 
+// #3036, #3195: keeps every spawned `tcode` child hermetic against the
+// developer's live trusty-search daemon.
+#[cfg(test)]
+mod daemon_isolation_tests;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/trusty-code/tests/agent_fallback_e2e.rs
+++ b/crates/trusty-code/tests/agent_fallback_e2e.rs
@@ -32,8 +32,6 @@
 
 mod support;
 
-use std::process::Command;
-
 use serde_json::json;
 
 /// A bare project tempdir with NO `.claude/agents/` directory — the exact
@@ -61,7 +59,7 @@ fn bare_project() -> tempfile::TempDir {
 #[test]
 fn run_task_engineer_direct_embedded_agent_dispatches_successfully() {
     let project = bare_project();
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .args([
             "run-task",
             "engineer",
@@ -101,7 +99,7 @@ fn run_task_engineer_direct_embedded_agent_dispatches_successfully() {
 #[test]
 fn run_task_rust_engineer_composed_embedded_agent_dispatches_successfully() {
     let project = bare_project();
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .args([
             "run-task",
             "rust-engineer",

--- a/crates/trusty-code/tests/cli_e2e.rs
+++ b/crates/trusty-code/tests/cli_e2e.rs
@@ -6,14 +6,16 @@
 //! directly against `tcode serve` or via the small test-only `StdioSession`
 //! helper. This ticket's own deliverable — the `tcode` BINARY's subcommands
 //! — needs its OWN black-box proof: spawn the compiled `tcode` binary
-//! (`env!("CARGO_BIN_EXE_tcode")`) exactly as a user's shell would, let it
+//! (via `support::tcode_command`) exactly as a user's shell would, let it
 //! do whatever it does internally (which, per #2060, is spawn its OWN
 //! nested `tcode serve --stdio` child and speak JSON-RPC to it — this test
 //! never touches that nested layer directly), and assert only on the
 //! OUTER process's stdout/stderr/exit code. `TCODE_MOCK_LLM=echo` keeps
 //! `run-task` deterministic and offline (env propagates from this outer
 //! process to the CLI's own spawned nested daemon child, since it inherits
-//! the environment by default).
+//! the environment by default). #3036, #3195: every spawn here goes through
+//! `support::tcode_command`, so the child cannot reach the developer's live
+//! trusty-search daemon and have it write index files into the fixture dir.
 //! What: [`run_task_streams_live_events_and_reports_final_status`] is the
 //! REQUIRED case — `tcode run-task python-engineer "<task>" --project <tmp>`
 //! must print live tool events and a final `status=finished` line, exit 0.
@@ -55,8 +57,6 @@
 
 mod support;
 
-use std::process::Command;
-
 use support::project_with_agents;
 
 /// `tcode run-task <agent> "<task>" --project <tmp>` (`TCODE_MOCK_LLM=echo`)
@@ -65,7 +65,7 @@ use support::project_with_agents;
 #[test]
 fn run_task_streams_live_events_and_reports_final_status() {
     let project = project_with_agents();
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .args([
             "run-task",
             "pm",
@@ -107,7 +107,7 @@ fn run_task_streams_live_events_and_reports_final_status() {
 #[test]
 fn run_task_json_mode_prints_only_the_final_session() {
     let project = project_with_agents();
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .args([
             "run-task",
             "pm",
@@ -156,7 +156,7 @@ fn run_task_resolved_mode(
         args.push(m.to_string());
     }
 
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_tcode"));
+    let mut cmd = support::tcode_command();
     cmd.args(&args).env("TCODE_MOCK_LLM", "echo");
     if let Some(m) = env_mode {
         cmd.env("TRUSTY_CODE_MODE", m);
@@ -222,7 +222,7 @@ fn run_task_mode_precedence_over_the_wire() {
 #[test]
 fn session_list_on_fresh_project_reports_no_sessions() {
     let project = tempfile::tempdir().expect("project tempdir");
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .args([
             "session",
             "list",
@@ -246,7 +246,7 @@ fn session_list_on_fresh_project_reports_no_sessions() {
 #[test]
 fn transcript_unknown_session_errors_cleanly() {
     let project = tempfile::tempdir().expect("project tempdir");
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .args([
             "transcript",
             "nonexistent-id",
@@ -272,7 +272,7 @@ fn transcript_unknown_session_errors_cleanly() {
 #[test]
 fn attach_unknown_session_errors_cleanly() {
     let project = tempfile::tempdir().expect("project tempdir");
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .args([
             "attach",
             "nonexistent-id",
@@ -295,7 +295,7 @@ fn attach_unknown_session_errors_cleanly() {
 #[test]
 fn cancel_unknown_session_errors_cleanly() {
     let project = tempfile::tempdir().expect("project tempdir");
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .args([
             "cancel",
             "nonexistent-id",
@@ -326,7 +326,7 @@ fn cancel_unknown_session_errors_cleanly() {
 /// matching the compiled-in constants.
 #[test]
 fn version_flag_reports_build_provenance() {
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .arg("--version")
         .output()
         .expect("spawn tcode --version");
@@ -361,7 +361,7 @@ fn version_flag_reports_build_provenance() {
 /// workstream to act on; factored out so each test's setup is one line
 /// instead of a repeated Command/parse block.
 fn create_workstream(home: &std::path::Path, project_arg: &str, name: &str) -> String {
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .args([
             "workstream",
             "create",
@@ -390,7 +390,7 @@ fn create_workstream(home: &std::path::Path, project_arg: &str, name: &str) -> S
 fn workstream_list_on_fresh_project_reports_no_workstreams() {
     let home = tempfile::tempdir().expect("home tempdir");
     let project = tempfile::tempdir().expect("project tempdir");
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .args([
             "workstream",
             "list",
@@ -421,7 +421,7 @@ fn workstream_create_persists_and_ws_alias_lists_it() {
 
     create_workstream(home.path(), &project_arg, "Token rotation hardening");
 
-    let list_output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let list_output = support::tcode_command()
         .args(["ws", "list", "--project", &project_arg])
         .env("HOME", home.path())
         .output()
@@ -447,7 +447,7 @@ fn workstream_create_persists_and_ws_alias_lists_it() {
 fn workstream_get_unknown_id_errors_cleanly() {
     let home = tempfile::tempdir().expect("home tempdir");
     let project = tempfile::tempdir().expect("project tempdir");
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .args([
             "workstream",
             "get",
@@ -481,7 +481,7 @@ fn workstream_activate_conflict_names_active_and_suggests_force() {
     let id_a = create_workstream(home.path(), &project_arg, "A");
     let id_b = create_workstream(home.path(), &project_arg, "B");
 
-    let activate_a = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let activate_a = support::tcode_command()
         .args(["workstream", "activate", &id_a, "--project", &project_arg])
         .env("HOME", home.path())
         .output()
@@ -491,7 +491,7 @@ fn workstream_activate_conflict_names_active_and_suggests_force() {
         "activating a with no prior active must succeed: {activate_a:?}"
     );
 
-    let activate_b = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let activate_b = support::tcode_command()
         .args(["workstream", "activate", &id_b, "--project", &project_arg])
         .env("HOME", home.path())
         .output()
@@ -515,7 +515,7 @@ fn workstream_activate_conflict_names_active_and_suggests_force() {
 fn workstream_deactivate_with_none_active_is_a_clean_noop() {
     let home = tempfile::tempdir().expect("home tempdir");
     let project = tempfile::tempdir().expect("project tempdir");
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .args([
             "workstream",
             "deactivate",
@@ -545,7 +545,7 @@ fn workstream_close_hides_from_default_list_but_include_closed_shows_it() {
 
     let id = create_workstream(home.path(), &project_arg, "Old spike");
 
-    let close_output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let close_output = support::tcode_command()
         .args(["workstream", "close", &id, "--project", &project_arg])
         .env("HOME", home.path())
         .output()
@@ -555,7 +555,7 @@ fn workstream_close_hides_from_default_list_but_include_closed_shows_it() {
         "close must exit 0: {close_output:?}"
     );
 
-    let default_list = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let default_list = support::tcode_command()
         .args(["workstream", "list", "--project", &project_arg])
         .env("HOME", home.path())
         .output()
@@ -566,7 +566,7 @@ fn workstream_close_hides_from_default_list_but_include_closed_shows_it() {
         "closed workstream must be hidden from the default list: {default_stdout}"
     );
 
-    let include_closed_list = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let include_closed_list = support::tcode_command()
         .args([
             "workstream",
             "list",
@@ -590,7 +590,7 @@ fn workstream_close_hides_from_default_list_but_include_closed_shows_it() {
 /// and only this CLI surface was missing.
 #[test]
 fn tui_subcommand_is_listed_in_help() {
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .arg("--help")
         .output()
         .expect("spawn tcode --help");
@@ -627,7 +627,7 @@ fn tui_subcommand_is_listed_in_help() {
 #[tokio::test]
 async fn tui_auto_spawns_a_daemon_that_outlives_it() {
     let data_dir = tempfile::tempdir().expect("data dir tempdir");
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .arg("tui")
         .env("TRUSTY_DATA_DIR_OVERRIDE", data_dir.path())
         .env_remove("TCODE_DAEMON_URL")
@@ -694,7 +694,7 @@ async fn tui_refuses_a_daemon_bound_to_a_different_project() {
     let daemon_data = tempfile::tempdir().expect("daemon data dir");
     let tui_data = tempfile::tempdir().expect("tui data dir");
 
-    let mut daemon = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let mut daemon = support::tcode_command()
         .args(["serve", "--http", "--port", "0", "--project"])
         .arg(their_project.path())
         .env("TRUSTY_DATA_DIR_OVERRIDE", daemon_data.path())
@@ -716,7 +716,7 @@ async fn tui_refuses_a_daemon_bound_to_a_different_project() {
         }
     };
 
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .arg("tui")
         .arg("--project")
         .arg(our_project.path())
@@ -762,7 +762,7 @@ async fn tui_refuses_a_daemon_bound_to_a_different_project() {
 #[test]
 fn tui_refuses_to_spawn_for_an_unreachable_explicit_daemon_url() {
     let data_dir = tempfile::tempdir().expect("data dir tempdir");
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .arg("tui")
         .env("TRUSTY_DATA_DIR_OVERRIDE", data_dir.path())
         .env("TCODE_DAEMON_URL", "http://127.0.0.1:1")

--- a/crates/trusty-code/tests/config_mount.rs
+++ b/crates/trusty-code/tests/config_mount.rs
@@ -5,20 +5,18 @@
 //! on every primary binary; this asserts the mount actually wired up HERE by
 //! driving the real built binary — `config --help` parses and `config keys
 //! list` runs fully offline (no key required, no value is ever printed).
-//! What: spawns the binary via the Cargo-provided `CARGO_BIN_EXE_*` path and
-//! checks the two offline invocations exit success with the expected surface
-//! text.
+//! What: spawns the binary via `support::tcode_command` — the one guarded
+//! entry point (#3036, #3195) — and checks the two offline invocations exit
+//! success with the expected surface text.
 //! Test: this file IS the test.
 
-use std::process::Command;
+mod support;
 
-/// Absolute path to the freshly built binary (Cargo sets this for integration
-/// tests). Using it guarantees we exercise the real mounted CLI, not a stub.
-const BIN: &str = env!("CARGO_BIN_EXE_tcode");
+use support::tcode_command;
 
 #[test]
 fn config_help_advertises_keys_feature() {
-    let out = Command::new(BIN)
+    let out = tcode_command()
         .args(["config", "--help"])
         .output()
         .expect("spawn `config --help`");
@@ -36,7 +34,7 @@ fn config_help_advertises_keys_feature() {
 
 #[test]
 fn config_keys_list_runs_offline() {
-    let out = Command::new(BIN)
+    let out = tcode_command()
         .args(["config", "keys", "list"])
         .output()
         .expect("spawn `config keys list`");

--- a/crates/trusty-code/tests/m1_cutline_e2e.rs
+++ b/crates/trusty-code/tests/m1_cutline_e2e.rs
@@ -46,7 +46,6 @@
 mod support;
 
 use std::collections::HashSet;
-use std::process::Command;
 use std::time::Duration;
 
 use serde_json::json;
@@ -566,7 +565,7 @@ async fn m1_cutline_cancel_path() {
 #[test]
 fn m1_cutline_replay_via_thin_cli() {
     let project = project_with_agents();
-    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+    let output = support::tcode_command()
         .args([
             "run-task",
             "pm",

--- a/crates/trusty-code/tests/support/mod.rs
+++ b/crates/trusty-code/tests/support/mod.rs
@@ -45,6 +45,39 @@ use tokio::time::timeout;
 /// test in seconds rather than hanging the suite.
 const WIRE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// The ONLY way an integration test may name the `tcode` binary — a
+/// `Command` for the freshly-built executable with ambient-daemon isolation
+/// already installed (#3036, #3195).
+///
+/// Why: `trusty_common::search_index` refuses daemon writes when
+/// `running_under_test_harness()` holds (#4255), but that reads the RUNNING
+/// process's own path. `env!("CARGO_BIN_EXE_tcode")` is
+/// `target/<profile>/tcode` — outside `deps/` — so a spawned child is
+/// indistinguishable from a user's real invocation and warms its
+/// `--project` into whatever trusty-search daemon it discovers. On a
+/// developer machine that is the OPERATOR's live daemon, which registers the
+/// test's `$TMPDIR/.tmpXXXXXX` fixture and writes `.gitignore` plus
+/// `.trusty-search/{index.redb,hnsw.usearch,…}` back INSIDE the sandbox.
+/// Those files land at an unpredictable moment — the warm-up is a detached
+/// thread and the daemon walks the tree asynchronously — so they corrupt
+/// whichever `run_task` before/after diff assertion happens to be open,
+/// which is why a different test failed each run and why `--test-threads=1`
+/// looked green. `spawn_inner`/`spawn_http_daemon_with_env` already set this
+/// on the two children they own; the ~26 tests that built their own
+/// `Command` did not, and that residue is #3036/#3195.
+/// What: `std::process::Command` for the binary, with
+/// `TRUSTY_TEST_HARNESS=1` set so the child reports itself as a test process
+/// and every `search_index` write is refused at the source. Pinning `HOME`
+/// is NOT a substitute: macOS resolves the data dir through `NSFileManager`,
+/// which ignores `$HOME`.
+/// Test: `no_test_spawns_the_tcode_binary_unguarded` (in the lib suite)
+/// fails if any test file names the binary directly instead of calling this.
+pub fn tcode_command() -> std::process::Command {
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_tcode"));
+    cmd.env(trusty_common::test_harness::FORCE_ENV, "1");
+    cmd
+}
+
 /// Provision a throwaway project with `.claude/agents/{pm,python-engineer}.md`.
 ///
 /// Why: shared by `tests/task_e2e.rs` (drives the daemon directly) and

--- a/crates/trusty-code/tests/support/mod.rs
+++ b/crates/trusty-code/tests/support/mod.rs
@@ -63,8 +63,8 @@ const WIRE_TIMEOUT: Duration = Duration::from_secs(5);
 /// whichever `run_task` before/after diff assertion happens to be open,
 /// which is why a different test failed each run and why `--test-threads=1`
 /// looked green. `spawn_inner`/`spawn_http_daemon_with_env` already set this
-/// on the two children they own; the ~26 tests that built their own
-/// `Command` did not, and that residue is #3036/#3195.
+/// on the two children they own; the 28 call sites across 24 test functions
+/// that built their own `Command` did not, and that residue is #3036/#3195.
 /// What: `std::process::Command` for the binary, with
 /// `TRUSTY_TEST_HARNESS=1` set so the child reports itself as a test process
 /// and every `search_index` write is refused at the source. Pinning `HOME`


### PR DESCRIPTION
Closes #3036
Closes #3195

Both issues are one bug. See the commit message for the mechanism; this is the evidence.

## Reproduced first

With the operator's live trusty-search daemon up (port 7878, 42 indexes), one `cargo test -p trusty-code` created **3 new indexes** in it, rooted at test tempdirs that no longer exist:

```
before 42 after 45
NEW: ['.tmpILUyUh', '.tmpLe4VmH', '.tmpMVwW1d']
```

`GET /indexes/.tmpRMzDCU/status` on one already-present leftover confirms the root:

```
"root_path":"/private/var/folders/7s/g9twvy8j0wl58ffgzsmrccv40000gp/T/.tmpRMzDCU"
```

Bisected per test binary: `cli_e2e` and `m1_cutline_e2e` leak; the lib suite and the other 13 binaries do not.

Symptom confirmed directly — registering a directory the way trusty-code does, then reindexing, writes into that directory:

```
/tmp/tc3036probe/proj:
.gitignore   .trusty-search   main.rs
/tmp/tc3036probe/proj/.trusty-search:
hnsw.keys.json  hnsw.usearch  index.redb  schema_version.json
```

`index.redb` is the exact file #3036 names. Two files appearing in the fixture at an uncontrolled moment is what corrupts a "no file changes" diff assertion.

A/B on the hypothesis, before writing any fix:

```
[unguarded] LEAK exit=0 new=1 cli_e2e ['.tmpocGGot']
[guarded]     ok exit=0 new=0 cli_e2e
```

**Failure rate:** the daemon-write leak is 100% deterministic and directly observable. The downstream *test* failure it causes is not — it needs the stray files to land inside another test's snapshot window. A 10× pre-fix run of the lib suite showed 2/10 red, but both were a different, unrelated flake (`run_task::redelegation::tests::*_is_logged_at_warn_level`, a `tracing` interest-cache race — `Captured: []`). I did not fix that here; it is a separate root cause and out of scope.

## The guard fails on the pre-fix tree

`no_test_spawns_the_tcode_binary_unguarded` run against the unfixed `tests/` tree reports all 28 sites (across 24 test functions):

```
crates/trusty-code/tests/m1_cutline_e2e.rs:569: let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
crates/trusty-code/tests/cli_e2e.rs:68: let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
crates/trusty-code/tests/cli_e2e.rs:110: let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
...
```

## Gates — rung 2/3, crate-scoped

```
cargo fmt --check                                      → exit 0, 0 diffs
cargo check -p trusty-code --all-targets               → exit 0
cargo clippy -p trusty-code --all-targets -- -D warnings → exit 0
bash scripts/check_line_cap.sh                         → 0 violations
bash scripts/check_sld.sh                              → 0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh               → OK
```

`cargo test -p trusty-code`, clean run:

```
test result: ok. 1604 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
test result: ok. 21 passed; 0 failed; ...
(15 further binaries, all ok)
```

## 10× with the live daemon running

```
run  1: exit=101 leaked=0 failed=['cli::daemon_autospawn::daemon_autospawn_tests::spawns_projectless_when_the_tui_is_projectless']
run  2: exit=0 leaked=0 failed=none
run  3: exit=0 leaked=0 failed=none
run  4: exit=0 leaked=0 failed=none
run  5: exit=0 leaked=0 failed=none
run  6: exit=0 leaked=0 failed=none
run  7: exit=0 leaked=0 failed=none
run  8: exit=0 leaked=0 failed=none
run  9: exit=0 leaked=0 failed=none
run 10: exit=0 leaked=0 failed=none
```

Zero leaked indexes across all ten. `run_task` alone, 10×: `FAILED_RUNS=0/10`.

## Pre-existing failure, not from this branch

Run 1's failure is `spawns_projectless_when_the_tui_is_projectless` — the test named in the title of open issue **#5073** ("fails under parallel execution, passes in isolation"), same file, same `stub must have recorded its argv` panic. It is a race between `ensure_daemon_with` returning and the stub writing its argv log, in `src/cli/daemon_autospawn_tests.rs`, which this branch does not touch.

Measured on a **stashed, clean tree with none of these changes**:

```
FAILED=6/20   # clean pre-fix tree, full --bin tcode target
FAILED=1/15   # this branch, same binary
FAILED=0/15   # that test alone, in isolation
```

Pre-existing and unrelated. Left for #5073 rather than mixed into this PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools


---

## Review round 2 (commit `fecccbafb`)

**MEDIUM fixed — exemption is now a path-COMPONENT check.** `str::ends_with`
ignores path boundaries, so `tests/cli_support/mod.rs` was exempted along with
`tests/support/mod.rs`. The exemption now compares components against
`["support", "mod.rs"]` relative to `tests/`.

`only_the_exact_support_mod_path_is_exempt` pins it against a fixture tree of
`support/mod.rs` (exempt), `cli_support/mod.rs` (must be caught), and
`support/nested/mod.rs` (must be caught). Reverted to the old `ends_with`, it
fails exactly as predicted:

```
  left: ["support/nested/mod.rs"]
 right: ["cli_support/mod.rs", "support/nested/mod.rs"]
```

`cli_support/mod.rs` is missing from the left — silently exempted.

**LOW fixed — count corrected to 28 call sites across 24 test functions**, here
and in `tests/support/mod.rs` and the changelog fragment. Verified by script,
not by re-reading the earlier grep.

### Gates re-run

```
cargo fmt --check                                        → exit 0, 0 diffs
cargo check -p trusty-code --all-targets                 → exit 0
cargo clippy -p trusty-code --all-targets -- -D warnings  → exit 0
cargo test -p trusty-code                                → exit 0
bash scripts/check_line_cap.sh   → 3953 files, 0 violations
bash scripts/check_sld.sh        → 0 errors, 0 warnings
```

```
test result: ok. 1605 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
test result: ok. 21 passed; 0 failed; ...
(15 further binaries, all ok)
```

1605 in the lib, up from 1604 — the new pinning test.

### Leak re-verification, with attribution

An early post-fix run showed 2 new indexes I could not attribute, so I stopped
trusting the raw before/after diff on this machine — other sessions write to the
same daemon. Two controls:

- **Null control**, same 40s window with no `cargo test` at all: `new=0` on 5/5.
- **Attributed runs**, with `TMPDIR` pointed at a private root so any index
  rooted there is provably from this suite:

```
run 1: exit=0 new=0 OURS=0 OTHER=0
run 2: exit=101 new=0 OURS=0 OTHER=0
run 3: exit=0 new=0 OURS=0 OTHER=0
run 4: exit=0 new=0 OURS=0 OTHER=0
run 5: exit=0 new=0 OURS=0 OTHER=0
run 6: exit=0 new=0 OURS=0 OTHER=0
```

Zero indexes attributable to this suite across 6 attributed runs. Stated
plainly: the 2 unattributed indexes from the earlier batch were most likely
concurrent activity from another session on this machine, but I did not prove
that — I proved instead that no leak traces back to this suite when
attribution is enforced.

Run 2's failure is `spawns_a_daemon_when_none_is_running`, the #5073 sibling
already documented above (6/20 on a clean tree, 0/15 in isolation), in
`src/cli/daemon_autospawn_tests.rs` which this branch does not touch.
