### PR TITLE
fix(trusty-search): drive the lazy load on the write path, not a 503 (#5349)

### DIFF
--- a/crates/trusty-search/CLAUDE.md
+++ b/crates/trusty-search/CLAUDE.md
@@ -114,11 +114,14 @@ pub struct CodeChunk {
   | `vector_unavailable` | 503 | per `reason` | Semantic lane cannot serve this query — see `POST /indexes/:id/search`. |
   | `contrib_not_merged` | 503 | earned | `POST /indexes/:id/graph` only (#5505). The contributed graph was stored durably (`persisted: true`, plus `producer` / `replaced` / `reason`) but could not be folded into the serving graph, so it is not queryable yet. One unreadable `kg_contrib` row fails the whole load, so `blocking_producer` names the row to fix when one is to blame: `retryable` is `true` only when no row is implicated or when the blocker is THIS producer's row (a re-send replaces it), and `false` when another producer's row is the blocker — retrying then fails identically forever. |
 
-  `restore_via` on `index_not_resident` names `POST /indexes/{id}/search`, the
-  only endpoint that reloads a cold-parked index. `status`, `chunks`, `grep`,
-  `index-file`, and `remove-file` report the state truthfully but cannot clear
-  it themselves; a search against the same id does, after which they answer
-  normally.
+  `restore_via` on `index_not_resident` names `POST /indexes/{id}/search`.
+  `search`, `index-file`, and `remove-file` all RELOAD a cold-parked index
+  themselves (#5349), so none of them returns `index_not_resident` at all — a
+  cold-but-not-failed index is loaded and the request served, and only a load
+  that fails produces a verdict (`index_restore_failed`, `index_loading`, or
+  `embedder_initializing`). `status`, `chunks`, and `grep` report the state
+  truthfully but cannot clear it themselves; any of the three reloading
+  endpoints does, after which they answer normally.
 
   **The MCP surface relays this contract as data (#5350).** A `503` whose body
   is a JSON object with an `error` field becomes a structured MCP error rather

--- a/crates/trusty-search/changelog.d/5349-write-path-drives-lazy-load.md
+++ b/crates/trusty-search/changelog.d/5349-write-path-drives-lazy-load.md
@@ -1,0 +1,16 @@
+Fixed
+
+- `POST /indexes/{id}/index-file` and `POST /indexes/{id}/remove-file` now load a
+  cold-parked index and apply the write, instead of answering
+  `503 index_not_resident` and pointing the caller at
+  `POST /indexes/{id}/search` to warm the index as a side effect (#5349). Both
+  handlers route through the same resolve-or-lazy-load function `search` uses, so
+  a write and a read against identical daemon state can no longer disagree about
+  whether an index is reachable — which mattered most for network-mounted roots
+  (#3408), where these two endpoints are the only thing keeping the index
+  current. A load that genuinely fails still refuses the write: the caller gets
+  the residency verdict (`index_restore_failed` / `index_loading` / `404`), never
+  a `200` for a write no index received. `index_not_resident` is now unreachable
+  from these two endpoints, so a caller branching on it should branch on
+  `index_restore_failed` instead; `status`, `chunks`, and `grep` still report it
+  and still name `search` as the way to clear it.

--- a/crates/trusty-search/src/service/server/degraded.rs
+++ b/crates/trusty-search/src/service/server/degraded.rs
@@ -126,10 +126,11 @@ pub(super) async fn corpus_failure_response(
 ///
 /// What: checks the failed set FIRST (a permanently-failed restore never clears
 /// on its own, so "retry later" would be a lie for it), then the cold store,
-/// then falls through to 404. `restore_via` on the not-resident arm is the
-/// load-bearing field: `POST /indexes/{id}/search` is the only endpoint that
-/// drives `get_or_load_index`, so it is how a caller un-sticks the 503 without
-/// waiting for a sweep that may never come.
+/// then falls through to 404. `restore_via` on the not-resident arm names
+/// `POST /indexes/{id}/search`: it is how a caller un-sticks the 503 without
+/// waiting for a sweep that may never come. Since #5349 the two write endpoints
+/// drive `get_or_load_index` too, so an endpoint that CAN load only ever reaches
+/// the failed or unknown arm here — never the not-resident one.
 ///
 /// Callers MUST have already missed the hot registry — this never checks it.
 /// Test: `residency_miss_is_404_only_when_absent_everywhere`,

--- a/crates/trusty-search/src/service/server/files.rs
+++ b/crates/trusty-search/src/service/server/files.rs
@@ -33,26 +33,23 @@ use super::state::SearchAppState;
 /// anywhere". Told "unknown index" for an index that exists, such a caller
 /// deregisters it or gives up, and the writes stop arriving — silently, since
 /// nothing else drives that index.
-/// What: shares [`super::degraded::residency_miss_response`] with the read
-/// path, so a cold-parked index answers `503 index_not_resident` with the
-/// `restore_via` hint instead of a bodyless 404.
-/// Test: `write_path_cold_parked_index_is_503_with_restore_hint`.
+/// What: resolves the handle through
+/// [`super::index_resolve::resolve_or_load_index`], the same function the read
+/// path uses, so a cold-parked index is LOADED and the write applied (#5349)
+/// rather than refused with a hint to go issue a search first. A load that
+/// genuinely fails propagates as the 503/404 residency verdict — never as a
+/// successful write.
+/// Test: `cold_parked_index_accepts_a_write_by_driving_the_load`,
+/// `write_against_an_unloadable_cold_index_fails_loudly`.
 pub(super) async fn index_file_handler(
     State(state): State<Arc<SearchAppState>>,
     Path(id): Path<String>,
     Json(req): Json<IndexFileRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     let index_id = IndexId::new(id);
-    // #5061: the write path owes the same residency verdict as the read path.
-    let handle = match state.registry.get(&index_id) {
-        Some(h) => h,
-        None => {
-            return Err(super::degraded::residency_miss_response(
-                &state.cold_store,
-                &index_id,
-            ))
-        }
-    };
+    // #5349: the write path drives the same lazy load the read path drives —
+    // a cold-parked index is reloaded here, not reported as unwritable.
+    let handle = super::index_resolve::resolve_or_load_index(&state, &index_id).await?;
     // #3049: hold the teardown lock's shared side across the write so a
     // concurrent DELETE cannot remove_dir_all this index's data mid-write.
     let _teardown_guard = crate::service::reindex::acquire_index_teardown_read(&index_id).await;
@@ -90,24 +87,18 @@ pub(super) async fn index_file_handler(
 /// `POST /indexes/:id/remove-file` — drop one file's chunks from an index.
 ///
 /// Why and What: the delete half of [`index_file_handler`]'s contract — same
-/// callers, same network-mount motivation, same residency verdict.
-/// Test: `write_path_cold_parked_index_is_503_with_restore_hint`.
+/// callers, same network-mount motivation, same lazy load, same residency
+/// verdict when that load fails.
+/// Test: `cold_parked_index_accepts_a_delete_by_driving_the_load`.
 pub(super) async fn remove_file_handler(
     State(state): State<Arc<SearchAppState>>,
     Path(id): Path<String>,
     Json(req): Json<RemoveFileRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     let index_id = IndexId::new(id);
-    // #5061: same residency verdict as its `index_file` twin.
-    let handle = match state.registry.get(&index_id) {
-        Some(h) => h,
-        None => {
-            return Err(super::degraded::residency_miss_response(
-                &state.cold_store,
-                &index_id,
-            ))
-        }
-    };
+    // #5349: see the sibling handler — a delete drives the load too, so the two
+    // halves of the incremental contract cannot disagree about reachability.
+    let handle = super::index_resolve::resolve_or_load_index(&state, &index_id).await?;
     // #3049: see the sibling handler — same guard, same reason.
     let _teardown_guard = crate::service::reindex::acquire_index_teardown_read(&index_id).await;
     let indexer = handle.indexer.read().await;

--- a/crates/trusty-search/src/service/server/index_resolve.rs
+++ b/crates/trusty-search/src/service/server/index_resolve.rs
@@ -1,0 +1,133 @@
+//! The one place a request turns an index id into a live `IndexHandle`,
+//! loading a cold-parked index on the way (#993, #5349).
+//!
+//! Why: this flow used to exist only inside `search_handler`, so `search` was
+//! the only endpoint that could bring a cold-parked index back. `index-file`
+//! and `remove-file` did a bare hot-registry lookup and answered
+//! `503 index_not_resident` against the identical daemon state (#5349) — the
+//! caller was told to issue an unrelated `search` purely for its side effect,
+//! then retry the write. On a network-mounted root those two endpoints are the
+//! ONLY thing keeping the index current (#3408), so the endpoint that must
+//! never stall was the one that could not help itself.
+//!
+//! What: [`resolve_or_load_index`] — hot registry, then the residency verdict,
+//! then `get_or_load_index`. Every failure is an `Err`, so a caller written as
+//! `resolve_or_load_index(..).await?` cannot advance its own state on a load
+//! that did not happen.
+//!
+//! Test: `service::server::tests_5349`.
+
+use std::sync::Arc;
+
+use axum::http::StatusCode;
+use axum::Json;
+
+use crate::core::registry::{IndexHandle, IndexId};
+use crate::service::lazy_loader::{cold_reload_timeout, get_or_load_index, LazyLoadError};
+use crate::service::lazy_restore::restore_index_on_demand;
+use crate::service::warm_boot::restore_one_index_bounded;
+
+use super::state::SearchAppState;
+
+/// Resolve `index_id` to a live handle, restoring it from the cold store if it
+/// is parked.
+///
+/// Why: see the module header. One implementation means a write and a read
+/// against the same cold-parked index can never disagree about whether that
+/// index is reachable.
+///
+/// What: (1) hot registry; (2) `503 index_restore_failed` / `404` for the two
+/// verdicts reachable without attempting a load, via the shared
+/// [`super::degraded::residency_miss_response`] builder; (3)
+/// `503 embedder_initializing` when no embedder is installed yet, since
+/// rebuilding the vector lane needs one; (4) `get_or_load_index`, whose
+/// per-index loading gate serialises concurrent callers so N simultaneous
+/// requests drive at most one restore — the losers re-check the hot registry
+/// after the gate and get the handle the winner registered.
+///
+/// A failed load NEVER yields `Ok`: `RestoreFailed` and `NotFound` render the
+/// residency verdict, and a load still in flight renders
+/// `503 index_loading` with `retry_after_secs`. Callers propagate with `?`
+/// before touching the index, so a write against an index that could not be
+/// loaded is refused rather than reported as applied.
+///
+/// Test: `cold_parked_index_accepts_a_write_by_driving_the_load`,
+/// `write_against_an_unloadable_cold_index_fails_loudly`,
+/// `concurrent_writes_on_a_cold_index_both_land_in_one_loaded_index`.
+pub(super) async fn resolve_or_load_index(
+    state: &Arc<SearchAppState>,
+    index_id: &IndexId,
+) -> Result<Arc<IndexHandle>, (StatusCode, Json<serde_json::Value>)> {
+    // Hot path first — a warm index never pays for the embedder check.
+    if let Some(handle) = state.registry.get(index_id) {
+        return Ok(handle);
+    }
+    // #1106 / #5061: permanently-failed and genuinely-unknown are the two
+    // residency verdicts reachable without attempting a load. The remaining
+    // verdict (`index_not_resident`) is unreachable from here by construction:
+    // a cold-but-not-failed index falls through to the lazy load below.
+    if state.cold_store.is_failed(index_id) || !state.cold_store.contains(index_id) {
+        return Err(super::degraded::residency_miss_response(
+            &state.cold_store,
+            index_id,
+        ));
+    }
+    let Some(embedder) = state.current_embedder().await else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "embedder_initializing",
+                // #5061: every 5xx on this path carries `retryable` and
+                // `index_id`. A client branching on `retryable` must never meet
+                // a body that omits it — absent reads as undefined, and both
+                // interpretations are wrong for some state.
+                "index_id": index_id.0,
+                "retryable": true,
+                "message": "embedder not yet ready — retry after /health reports embedder:ready",
+            })),
+        ));
+    };
+    let s = Arc::clone(state);
+    let load_result = get_or_load_index(
+        index_id,
+        &state.registry,
+        &state.cold_store,
+        cold_reload_timeout(),
+        move |entry| async move {
+            let e = Arc::clone(&embedder);
+            // #4087 review follow-up: `is_complete()` preserves the exact prior
+            // contract — anything short of a finished restore is a lazy-load
+            // failure, surfaced loudly as a 503 below.
+            restore_one_index_bounded(entry, move |en| async move {
+                restore_index_on_demand(&s, &e, en).await;
+            })
+            .await
+            .is_complete()
+        },
+    )
+    .await;
+    match load_result {
+        Ok(handle) => Ok(handle),
+        // #5061: both terminal load outcomes are residency verdicts and go
+        // through the shared builder. `RestoreFailed` lands on its
+        // `index_restore_failed` arm rather than a 404 because BOTH paths that
+        // produce this variant guarantee the entry is in the failed set —
+        // `loader.rs` returns it *because* `is_failed` is already true, or
+        // calls `mark_failed` immediately before returning it.
+        Err(LazyLoadError::NotFound) | Err(LazyLoadError::RestoreFailed) => Err(
+            super::degraded::residency_miss_response(&state.cold_store, index_id),
+        ),
+        // A load in flight is not a residency miss — the index is neither
+        // absent nor failed, it is arriving. Its own body carries the same
+        // `retryable` / `index_id` contract.
+        Err(LazyLoadError::Loading { retry_after_secs }) => Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "index_loading",
+                "index_id": index_id.0,
+                "retryable": true,
+                "retry_after_secs": retry_after_secs,
+            })),
+        )),
+    }
+}

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -22,6 +22,9 @@ mod files;
 mod health;
 pub(crate) mod helpers;
 mod index_config;
+// #5349: the single resolve-or-lazy-load path every index-scoped endpoint that
+// can restore a cold-parked index routes through.
+mod index_resolve;
 mod indexes;
 mod indexes_relocate;
 mod reindex_handlers;
@@ -69,6 +72,10 @@ mod tests_4951;
 // rather than degrade to "trusted".
 #[cfg(test)]
 mod tests_5357;
+// #5349: a write against a cold-parked index drives the load the read path
+// drives, and a load that fails refuses the write instead of absorbing it.
+#[cfg(test)]
+mod tests_5349;
 // #4250: timeout-parked index recovery and the /health un-latch.
 #[cfg(test)]
 mod tests_4250;

--- a/crates/trusty-search/src/service/server/search.rs
+++ b/crates/trusty-search/src/service/server/search.rs
@@ -16,11 +16,7 @@ use serde::Deserialize;
 use std::sync::Arc;
 
 use crate::core::{classifier::QueryClassifier, indexer::SearchQuery, registry::IndexId};
-use crate::service::lazy_loader::{
-    cold_reload_timeout, get_or_load_index, LazyLoadError, LAST_QUERIED_WRITE_INTERVAL_SECS,
-};
-use crate::service::lazy_restore::restore_index_on_demand;
-use crate::service::warm_boot::restore_one_index_bounded;
+use crate::service::lazy_loader::LAST_QUERIED_WRITE_INTERVAL_SECS;
 
 use super::helpers::file_is_within_root;
 use super::state::{DaemonEvent, SearchAppState};
@@ -374,98 +370,10 @@ pub(super) async fn search_handler(
         ));
     }
     let index_id = IndexId::new(id);
-    // Issue #993: try hot registry first, fall back to cold-store lazy load.
-    // Short-circuit with 503 when the embedder has not finished initializing:
-    // `restore_index_on_demand` requires a live embedder to rebuild the HNSW
-    // lane. Callers should retry once `/health` reports `embedder: "ready"`.
-    let handle = {
-        // Try hot path first — avoids the embedder check for warm indexes.
-        if let Some(h) = state.registry.get(&index_id) {
-            h
-        } else if state.cold_store.is_failed(&index_id) || !state.cold_store.contains(&index_id) {
-            // Issue #1106 / #5061: permanently-failed and genuinely-unknown are
-            // the two residency verdicts this handler can reach without
-            // attempting a load. Both go through the shared builder — this
-            // endpoint is the one every other endpoint's `restore_via` hint
-            // points at, so a body here that omits `retryable`/`index_id` is
-            // the one place the contract most needs to hold. The remaining
-            // verdict (`index_not_resident`) is unreachable from here by
-            // construction: a cold-but-not-failed index falls through to the
-            // lazy load below rather than erroring.
-            return Err(super::degraded::residency_miss_response(
-                &state.cold_store,
-                &index_id,
-            ));
-        } else {
-            // Cold index: need the embedder to restore.
-            let Some(embedder) = state.current_embedder().await else {
-                return Err((
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    Json(serde_json::json!({
-                        "error": "embedder_initializing",
-                        // #5061: every 5xx this handler emits carries
-                        // `retryable` and `index_id`. A client branching on
-                        // `retryable` must never meet a body that omits it —
-                        // absent reads as undefined, and both interpretations
-                        // are wrong for some state.
-                        "index_id": index_id.0,
-                        "retryable": true,
-                        "message": "embedder not yet ready — retry after /health reports embedder:ready",
-                    })),
-                ));
-            };
-            let s = Arc::clone(&state);
-            let load_result = get_or_load_index(
-                &index_id,
-                &state.registry,
-                &state.cold_store,
-                cold_reload_timeout(),
-                move |entry| async move {
-                    let e = Arc::clone(&embedder);
-                    // #4087 review follow-up: `is_complete()` preserves the
-                    // exact prior contract — anything short of a finished
-                    // restore is a lazy-load failure, which this handler
-                    // already surfaces loudly as a 503 below.
-                    restore_one_index_bounded(entry, move |en| async move {
-                        restore_index_on_demand(&s, &e, en).await;
-                    })
-                    .await
-                    .is_complete()
-                },
-            )
-            .await;
-            match load_result {
-                Ok(h) => h,
-                // #5061: both terminal load outcomes are residency verdicts and
-                // go through the shared builder. `RestoreFailed` lands on its
-                // `index_restore_failed` arm rather than a 404 because BOTH
-                // paths that produce this variant guarantee the entry is in the
-                // failed set — `loader.rs:116` returns it *because* `is_failed`
-                // is already true, and `loader.rs:148` calls `mark_failed`
-                // immediately before returning it.
-                Err(LazyLoadError::NotFound) | Err(LazyLoadError::RestoreFailed) => {
-                    return Err(super::degraded::residency_miss_response(
-                        &state.cold_store,
-                        &index_id,
-                    ));
-                }
-                // A load in flight is not a residency miss — the index is
-                // neither absent nor failed, it is arriving. Its own body
-                // carries the same `retryable` / `index_id` contract.
-                Err(LazyLoadError::Loading { retry_after_secs }) => {
-                    return Err((
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        Json(serde_json::json!({
-                            "error": "index_loading",
-                            "index_id": index_id.0,
-                            "retryable": true,
-                            "retry_after_secs": retry_after_secs,
-                        })),
-                    ));
-                }
-            }
-        }
-    };
+    // Issue #993: hot registry first, then the cold-store lazy load. #5349 moved
+    // that flow into `index_resolve` so the write endpoints drive the identical
+    // load instead of 503-ing against the same daemon state.
+    let handle = super::index_resolve::resolve_or_load_index(&state, &index_id).await?;
     // #4087: a registered index whose durable corpus failed to open holds no
     // chunks at all, so every search against it returned HTTP 200 with
     // `results: []` — a total outage presented as "no matches". Fail loudly

--- a/crates/trusty-search/src/service/server/tests_5349.rs
+++ b/crates/trusty-search/src/service/server/tests_5349.rs
@@ -1,0 +1,312 @@
+//! #5349 — a write against a cold-parked index drives the lazy load the read
+//! path drives, and a load that fails refuses the write.
+//!
+//! Why: `index-file` / `remove-file` answered `503 index_not_resident` for an
+//! index a plain `search` would have restored on the spot, telling the caller
+//! to issue an unrelated search purely for its side effect and then retry. On a
+//! network-mounted root those two endpoints are the only thing keeping the
+//! index current (#3408), so the writes simply stopped. The tests here drive
+//! the real mechanism — a genuine colocated redb corpus on disk, a real park, a
+//! real restore — because a fake handle would prove only that the code compiles.
+//!
+//! The failure arm gets equal weight: making the write path load an index is
+//! only safe if a load that CANNOT succeed still refuses the write instead of
+//! absorbing the failure into a `200`.
+//!
+//! Test: this file.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use tokio::sync::RwLock;
+
+use super::state::SearchAppState;
+use crate::core::registry::{IndexHandle, IndexId, IndexRegistry};
+use crate::core::Embedder;
+use crate::service::lazy_loader::cold_park_index;
+use crate::service::persistence::PersistedIndex;
+use crate::service::persistence_loader::build_indexer_from_entry;
+
+/// Daemon state with a mock embedder installed — the cold-load path refuses to
+/// run without one, so every test here needs it.
+async fn mock_state() -> Arc<SearchAppState> {
+    let state = SearchAppState::new(IndexRegistry::new());
+    let embedder: Arc<dyn Embedder> = Arc::new(crate::core::embed::MockEmbedder::new(8));
+    state.install_embedder(embedder).await;
+    Arc::new(state)
+}
+
+/// A colocated entry, so the restore finds its corpus under `<root>/.trusty-search/`.
+fn colocated_entry(id: &str, root: PathBuf) -> PersistedIndex {
+    let mut entry = PersistedIndex::new(id.to_string(), root);
+    entry.colocated = true;
+    entry
+}
+
+fn index_request(path: &str, content: &str) -> super::router::IndexFileRequest {
+    serde_json::from_value(serde_json::json!({ "path": path, "content": content }))
+        .expect("IndexFileRequest")
+}
+
+fn remove_request(path: &str) -> super::router::RemoveFileRequest {
+    serde_json::from_value(serde_json::json!({ "path": path })).expect("RemoveFileRequest")
+}
+
+/// Files currently represented in the index's chunk corpus, deduped and sorted.
+///
+/// Chunks materialised from the durable corpus carry the file path resolved
+/// against the index root, so these are absolute; callers match on the relative
+/// suffix they wrote via [`contains_file`].
+async fn indexed_files(state: &Arc<SearchAppState>, id: &str) -> Vec<String> {
+    let handle = state
+        .registry
+        .get(&IndexId::new(id.to_string()))
+        .expect("index must be resident");
+    let indexer = handle.indexer.read().await;
+    let (_total, chunks) = indexer.enumerate_chunks(0, 1_000).await;
+    let mut files: Vec<String> = chunks.into_iter().map(|c| c.file).collect();
+    files.sort();
+    files.dedup();
+    files
+}
+
+/// Whether `files` holds an entry for the relative path `rel`.
+fn contains_file(files: &[String], rel: &str) -> bool {
+    files.iter().any(|f| f == rel || f.ends_with(rel))
+}
+
+/// A write against a cold-parked index loads it and lands, exactly as a read
+/// against the same state would.
+///
+/// Why (#5349): pre-fix this handler did a bare hot-registry lookup and
+/// returned `503 index_not_resident`, so `expect` below fails against the
+/// pre-fix commit. Asserting the CHUNK landed — not merely that the call
+/// returned `200` — is what keeps a future "load it, then forget to write"
+/// regression from passing.
+/// Test: this test.
+#[tokio::test]
+async fn cold_parked_index_accepts_a_write_by_driving_the_load() {
+    let state = mock_state().await;
+    let (_dir, root) = super::test_support::allowlisted_index_root("ts-5349-write-");
+    let id = "cold-accepts-write";
+    state
+        .cold_store
+        .register_cold_entries(vec![colocated_entry(id, root)]);
+
+    let axum::Json(body) = super::files::index_file_handler(
+        State(Arc::clone(&state)),
+        axum::extract::Path(id.to_string()),
+        axum::Json(index_request(
+            "src/auth.rs",
+            "fn authenticate() -> bool { true }",
+        )),
+    )
+    .await
+    .expect("a cold-parked index must accept the write by loading itself");
+
+    assert_eq!(body["indexed"], true);
+    assert_eq!(body["path"], "src/auth.rs");
+    assert!(
+        state.registry.get(&IndexId::new(id.to_string())).is_some(),
+        "the write must have driven the load, leaving the index resident"
+    );
+    assert!(
+        !state.cold_store.contains(&IndexId::new(id.to_string())),
+        "a completed load consumes the cold entry"
+    );
+    let files = indexed_files(&state, id).await;
+    assert!(
+        contains_file(&files, "src/auth.rs"),
+        "reporting `indexed: true` without the chunk landing is the failure this \
+         test exists for; corpus holds {files:?}"
+    );
+}
+
+/// The delete half drives the load too, and actually removes the chunks.
+///
+/// Why (#5349): `index-file` and `remove-file` are one contract. A caller
+/// replaying a `git diff` against a network mount issues both, so a delete that
+/// still 503s would leave stale chunks behind for every file removed while the
+/// index was parked. Pre-fix `expect` fails here for the same reason as the
+/// write test.
+/// Test: this test.
+#[tokio::test]
+async fn cold_parked_index_accepts_a_delete_by_driving_the_load() {
+    let state = mock_state().await;
+    let (_dir, root) = super::test_support::allowlisted_index_root("ts-5349-delete-");
+    let id = "cold-accepts-delete";
+    let index_id = IndexId::new(id.to_string());
+    let entry = colocated_entry(id, root);
+
+    // Populate a real on-disk corpus, register it live, then park it — the
+    // exact state `TRUSTY_MAX_RESIDENT_INDEXES` produces at runtime.
+    {
+        let embedder = state.current_embedder().await.expect("mock embedder");
+        let indexer = build_indexer_from_entry(&entry, &embedder)
+            .await
+            .expect("build indexer");
+        indexer
+            .index_file("src/auth.rs", "fn authenticate() -> bool { true }")
+            .await
+            .expect("seed the corpus");
+        state.registry.register(IndexHandle::bare(
+            index_id.clone(),
+            Arc::new(RwLock::new(indexer)),
+            entry.root_path.clone(),
+        ));
+    }
+    assert!(
+        cold_park_index(&index_id, &state.registry, &state.cold_store, entry.clone()).await,
+        "the index must be cold-parked before the delete is issued"
+    );
+
+    let axum::Json(body) = super::files::remove_file_handler(
+        State(Arc::clone(&state)),
+        axum::extract::Path(id.to_string()),
+        axum::Json(remove_request("src/auth.rs")),
+    )
+    .await
+    .expect("a cold-parked index must accept the delete by loading itself");
+
+    assert!(
+        body["removed_chunks"].as_u64().unwrap_or(0) >= 1,
+        "the delete must reach real chunks, not an empty freshly-built index: {body}"
+    );
+    assert!(
+        indexed_files(&state, id).await.is_empty(),
+        "the removed file must be gone from the loaded index"
+    );
+}
+
+/// A load that cannot succeed refuses the write — it never reports success.
+///
+/// Why (#5349): this is the arm that makes the change safe. The cold entry
+/// points at a root that no longer exists, so `restore_index_on_demand` marks
+/// it permanently failed and registers nothing. The handler must surface that
+/// verdict rather than returning `200` for a write no index ever received.
+/// Pre-fix the same call answered `index_not_resident` with `retryable: true` —
+/// the wrong verdict, and one that would send this caller into a retry loop
+/// against an index that can never come back — so the two assertions on `error`
+/// and `retryable` fail against the pre-fix commit.
+/// Test: this test.
+#[tokio::test]
+async fn write_against_an_unloadable_cold_index_fails_loudly() {
+    let state = mock_state().await;
+    let (_dir, root) = super::test_support::allowlisted_index_root("ts-5349-gone-");
+    let id = "cold-unloadable";
+    let missing_root = root.join("deleted-since-it-was-parked");
+    state
+        .cold_store
+        .register_cold_entries(vec![colocated_entry(id, missing_root)]);
+
+    let (code, axum::Json(body)) = super::files::index_file_handler(
+        State(Arc::clone(&state)),
+        axum::extract::Path(id.to_string()),
+        axum::Json(index_request("src/auth.rs", "fn authenticate() {}")),
+    )
+    .await
+    .expect_err("a write whose index could not be loaded must not report success");
+
+    assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(body["error"], "index_restore_failed");
+    assert_eq!(
+        body["retryable"], false,
+        "a deleted root never comes back on its own — advising a retry would loop forever"
+    );
+    assert!(
+        state.registry.get(&IndexId::new(id.to_string())).is_none(),
+        "a failed load must leave no half-built index behind for the next write to land in"
+    );
+    assert!(
+        state.cold_store.is_failed(&IndexId::new(id.to_string())),
+        "the failure must be recorded so the next write fails fast instead of retrying the restore"
+    );
+}
+
+/// A genuinely unknown id is still a 404 on the write path.
+///
+/// Why (#5349): driving the load must not widen the status code. #4715's
+/// invariant — a 404 from an index-scoped endpoint rules out every store — is
+/// what stops the MCP layer classifying an unknown index as "not built yet".
+/// Test: this test.
+#[tokio::test]
+async fn unknown_index_is_still_404_after_the_write_path_learned_to_load() {
+    let state = mock_state().await;
+    let (code, axum::Json(body)) = super::files::index_file_handler(
+        State(Arc::clone(&state)),
+        axum::extract::Path("never-existed".to_string()),
+        axum::Json(index_request("src/auth.rs", "fn authenticate() {}")),
+    )
+    .await
+    .expect_err("genuinely unknown");
+
+    assert_eq!(code, StatusCode::NOT_FOUND);
+    assert_eq!(body["error"], "unknown index: never-existed");
+}
+
+/// Two writes arriving together on a cold index both land in ONE loaded index.
+///
+/// Why (#5349): `get_or_load_index`'s per-index loading gate serialises the
+/// restore, so the second caller re-checks the hot registry after the gate and
+/// gets the handle the first one registered. Without that, both would build an
+/// indexer over the same colocated redb — the loser hits `DatabaseAlreadyOpen`
+/// and one of the two writes lands in a handle nobody ever reads. Asserting
+/// BOTH files are present in the ONE resident index is what distinguishes those
+/// two outcomes; a pair of `200`s alone would not.
+/// Test: this test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_writes_on_a_cold_index_both_land_in_one_loaded_index() {
+    let state = mock_state().await;
+    let (_dir, root) = super::test_support::allowlisted_index_root("ts-5349-race-");
+    let id = "cold-concurrent-writes";
+    state
+        .cold_store
+        .register_cold_entries(vec![colocated_entry(id, root)]);
+
+    let first = tokio::spawn({
+        let state = Arc::clone(&state);
+        async move {
+            super::files::index_file_handler(
+                State(state),
+                axum::extract::Path(id.to_string()),
+                axum::Json(index_request("src/one.rs", "fn one() -> u8 { 1 }")),
+            )
+            .await
+            .map(|axum::Json(body)| body)
+        }
+    });
+    let second = tokio::spawn({
+        let state = Arc::clone(&state);
+        async move {
+            super::files::index_file_handler(
+                State(state),
+                axum::extract::Path(id.to_string()),
+                axum::Json(index_request("src/two.rs", "fn two() -> u8 { 2 }")),
+            )
+            .await
+            .map(|axum::Json(body)| body)
+        }
+    });
+
+    let (first, second) = (
+        first.await.expect("first task"),
+        second.await.expect("second task"),
+    );
+    assert!(
+        first.is_ok() && second.is_ok(),
+        "both concurrent writes must succeed: {first:?} / {second:?}"
+    );
+    assert_eq!(
+        state.registry.list().len(),
+        1,
+        "a second load would mean two indexers over one redb, and one lost write"
+    );
+    let files = indexed_files(&state, id).await;
+    assert!(
+        contains_file(&files, "src/one.rs") && contains_file(&files, "src/two.rs"),
+        "every write that answered 200 must be present in the index that survived; \
+         corpus holds {files:?}"
+    );
+}

--- a/crates/trusty-search/src/service/server/tests_index_routing.rs
+++ b/crates/trusty-search/src/service/server/tests_index_routing.rs
@@ -286,20 +286,28 @@ async fn chunks_and_status_agree_on_a_cold_parked_index() {
     assert_eq!(status_body["restore_via"], chunks_body["restore_via"]);
 }
 
-/// The WRITE path answers a cold-parked index the same way the read path does.
+/// The WRITE path never answers `index_not_resident` — it loads instead.
 ///
-/// Why (#5061): `index_file` / `remove_file` are the supported incremental
-/// path for network-mounted roots (#3408), where nothing else keeps the index
-/// current — so a caller told "unknown index" for an index that merely is not
-/// resident deregisters it or gives up, and the writes stop arriving with no
-/// other signal. Pre-fix both handlers did a bare hot-registry lookup and
-/// returned `StatusCode::NOT_FOUND` with no body, which under #4715's rule
-/// asserts the index exists nowhere. The `expect_err` still passes pre-fix —
-/// it is the 503, the `restore_via` hint, and the body itself that do not.
+/// Why (#5061 → #5349): #5061 gave these two handlers the shared residency
+/// body, which made a cold-parked index a `503 index_not_resident` carrying a
+/// `restore_via` hint. #5349 went further: the write path now drives the same
+/// lazy load the read path drives, so `index_not_resident` is unreachable from
+/// here by construction — a cold-but-not-failed index is loaded, and only a
+/// load that FAILS produces a verdict. This test pins the negative half of
+/// that; the positive half (the write lands) lives in `tests_5349`.
+///
+/// The entry here points at `/tmp/trusty-5061-cold-write`, which does not
+/// exist, so the restore marks it permanently failed — which is why the verdict
+/// is `index_restore_failed` and not the `index_not_resident` this test
+/// asserted before #5349.
 /// Test: this test.
 #[tokio::test]
-async fn write_path_cold_parked_index_is_503_with_restore_hint() {
+async fn write_path_cold_parked_index_reports_only_a_failed_load() {
     let state = state_with_cold_index("cold-write");
+    let embedder: Arc<dyn crate::core::Embedder> =
+        Arc::new(crate::core::embed::MockEmbedder::new(8));
+    state.install_embedder(embedder).await;
+
     let index_req: super::router::IndexFileRequest = serde_json::from_value(
         serde_json::json!({ "path": "src/auth.rs", "content": "fn authenticate() {}" }),
     )
@@ -310,17 +318,21 @@ async fn write_path_cold_parked_index_is_503_with_restore_hint() {
         axum::Json(index_req),
     )
     .await
-    .expect_err("a non-resident index cannot accept a write");
+    .expect_err("the root is gone, so the load cannot succeed");
 
     assert_eq!(
         code,
         StatusCode::SERVICE_UNAVAILABLE,
-        "a cold-parked index EXISTS — 404 would tell the caller to stop pushing"
+        "a registered index EXISTS — 404 would tell the caller to stop pushing"
     );
-    assert_eq!(body["error"], "index_not_resident");
     assert_eq!(
-        body["restore_via"], "POST /indexes/cold-write/search",
-        "the writer must learn how to bring the index back"
+        body["error"], "index_restore_failed",
+        "the write attempted the load; a cold-parked index is never reported as \
+         un-writable without one"
+    );
+    assert!(
+        body.get("restore_via").is_none(),
+        "no endpoint restores a permanently-failed index; naming one would mislead"
     );
 
     let remove_req: super::router::RemoveFileRequest =
@@ -332,14 +344,13 @@ async fn write_path_cold_parked_index_is_503_with_restore_hint() {
         axum::Json(remove_req),
     )
     .await
-    .expect_err("a non-resident index cannot accept a delete");
+    .expect_err("the delete half sees the same failed load");
 
     assert_eq!(
         rm_code, code,
         "the delete half must not diverge from the add"
     );
     assert_eq!(rm_body["error"], body["error"]);
-    assert_eq!(rm_body["restore_via"], body["restore_via"]);
 }
 
 /// A genuinely unknown id keeps its 404 on the write path too.


### PR DESCRIPTION
Closes #5349.

`index-file` and `remove-file` answered `503 index_not_resident` for a cold-parked index while a `search` against the same id restored it inline. Both write handlers now resolve their handle through the same function the read path uses, extracted verbatim from `search_handler` into `crates/trusty-search/src/service/server/index_resolve.rs` — one implementation, no second copy of the load.

**Failure path.** A load that cannot succeed refuses the write. `resolve_or_load_index` returns `Result<Arc<IndexHandle>, (StatusCode, Json)>` and the handlers propagate with `?` before touching the index, so `index_restore_failed` / `index_loading` / `embedder_initializing` / `404` reach the caller and no write is reported as applied. `write_against_an_unloadable_cold_index_fails_loudly` pins that arm.

**Concurrency.** `get_or_load_index`'s per-index loading gate serialises callers: the loser re-checks the hot registry after the gate and gets the handle the winner registered, so N simultaneous writes drive at most one restore. `concurrent_writes_on_a_cold_index_both_land_in_one_loaded_index` asserts one resident index and both files present in it — a pair of `200`s alone would not distinguish a safe double-load from a lost write.

**Contract change.** `index_not_resident` is now unreachable from these two endpoints. A caller branching on it should branch on `index_restore_failed`; `status`, `chunks`, and `grep` still report it and still name `search` as the way to clear it. `crates/trusty-search/CLAUDE.md`'s error table says so.

`write_path_cold_parked_index_is_503_with_restore_hint` (#5061) pinned the behavior this PR changes; it is rewritten as `write_path_cold_parked_index_reports_only_a_failed_load`.

## Gates — rung 3

```
cargo fmt --check                                        clean
cargo check -p trusty-search --all-targets               EXIT=0
cargo clippy -p trusty-search --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-search                              1642 passed; 0 failed; 1 ignored (lib)
                                                         423 passed; 0 failed; 3 ignored (integration)
                                                         all other targets ok, 0 failed
scripts/check_line_cap.sh                                OK
scripts/check_test_pointers.sh                           OK (23994 citations, 0 dangling)
scripts/check_sld.sh                                     OK
scripts/check_teardown_guard.sh                          OK
scripts/check_changelog_fragment.sh                      OK
```

Pre-fix proof: with the two handlers reverted to their bare `registry.get`, 4 of the 5 new tests fail — `cold_parked_index_accepts_a_write_by_driving_the_load`, `cold_parked_index_accepts_a_delete_by_driving_the_load`, `concurrent_writes_on_a_cold_index_both_land_in_one_loaded_index`, and `write_against_an_unloadable_cold_index_fails_loudly` (`left: "index_not_resident"`, `right: "index_restore_failed"`). The fifth, `unknown_index_is_still_404_after_the_write_path_learned_to_load`, passes both sides by design — it guards #4715's invariant against widening.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
