### PR TITLE
fix(ci): gate-integrity — real scan floor, wire build.rs sync into CI

### DIFF
--- a/.github/workflows/buildrs-sync.yml
+++ b/.github/workflows/buildrs-sync.yml
@@ -1,0 +1,63 @@
+# build.rs canonical-block sync gate for the trusty-tools workspace (#5528).
+#
+# Cargo cannot share a build script as a library, so the daemon family
+# (trusty-memory, trusty-analyze, trusty-console, trusty-search — #987) and the
+# tauri-ui family (trusty-code-gui, trusty-mpm-gui, trusty-agents-ui — #4699)
+# each duplicate their canonical build.rs block by necessity. This gate fails
+# CI whenever a family's copies drift apart. See scripts/check_buildrs_sync.sh
+# for the two families' differing failure semantics.
+#
+# Pure text extraction/diff — no Rust toolchain or build needed, so this runs
+# as its own lightweight job (matches line-cap.yml / sld-lint.yml's checkout
+# style/auth).
+name: build.rs sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/trusty-memory/build.rs"
+      - "crates/trusty-analyze/build.rs"
+      - "crates/trusty-console/build.rs"
+      - "crates/trusty-search/build.rs"
+      - "crates/trusty-code-gui/build.rs"
+      - "crates/trusty-mpm-gui/build.rs"
+      - "crates/trusty-agents/ui/src-tauri/build.rs"
+      - "scripts/check_buildrs_sync.sh"
+      - ".github/workflows/buildrs-sync.yml"
+  pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+    branches: [main]
+    paths:
+      - "crates/trusty-memory/build.rs"
+      - "crates/trusty-analyze/build.rs"
+      - "crates/trusty-console/build.rs"
+      - "crates/trusty-search/build.rs"
+      - "crates/trusty-code-gui/build.rs"
+      - "crates/trusty-mpm-gui/build.rs"
+      - "crates/trusty-agents/ui/src-tauri/build.rs"
+      - "scripts/check_buildrs_sync.sh"
+      - ".github/workflows/buildrs-sync.yml"
+
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
+concurrency:
+  group: buildrs-sync-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
+
+jobs:
+  buildrs-sync:
+    name: build.rs canonical-block sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Assert build.rs canonical blocks are in sync
+        run: bash scripts/check_buildrs_sync.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,6 +80,21 @@ repos:
         pass_filenames: false
         always_run: true
 
+  # build.rs canonical-block sync lint (issue #5528). Fails the commit when
+  # the daemon family (trusty-memory, trusty-analyze, trusty-console,
+  # trusty-search) or the tauri-ui family (trusty-code-gui, trusty-mpm-gui,
+  # trusty-agents-ui) carry a build.rs whose canonical block has drifted from
+  # its siblings. Runs against the whole tracked tree (pass_filenames: false),
+  # matching the line-cap hook's holistic scan.
+  - repo: local
+    hooks:
+      - id: buildrs-sync
+        name: "build.rs canonical-block sync lint"
+        entry: scripts/check_buildrs_sync.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+
   # Document-number allocation lint. Fails the commit when two files claim the
   # same DOC-N or ADR-NNNN (by filename or by their own header self-label), when
   # a file's filename and self-label disagree, when a spec-catalog row points at

--- a/scripts/check_test_pointers.sh
+++ b/scripts/check_test_pointers.sh
@@ -927,7 +927,18 @@ scan "$VIOL" "$STALE" "$ERR" "$CHECKED"
 # all — and this gate's true positives are additionally masked by 920
 # grandfathered allowlist rows. CITATIONS_CHECKED is the number that can tell
 # them apart. The floor sits far below the current reality and far above zero.
-MIN_CITATIONS=200
+#
+# #5529: 200 was 0.74% of the real corpus (~26,874 per the issue; measured
+# locally and across five 2026-08-12 CI runs at 24,281-24,325) — a scan that
+# resolved barely 200 citations before reporting "0 dangling pointers" would
+# have been a catastrophic collapse, not a clean tree, and this floor let it
+# through. 5000 sits at ~20% of the measured baseline: comfortably above what
+# a collapse to a handful of the workspace's 21 crates would resolve (the
+# per-crate average is ~1,150), and comfortably below what legitimate corpus
+# shrinkage (crate removal, doc-comment consolidation) could plausibly cost
+# in one PR. Matches this repo's house convention for a #4618-style floor —
+# see MIN_RS_FILES in check_line_cap.sh, set to ~14% of its tracked-file count.
+MIN_CITATIONS=5000
 CITATIONS_CHECKED="$(awk 'END{print NR}' "$CHECKED")"
 if [ "${CITATIONS_CHECKED:-0}" -lt "$MIN_CITATIONS" ]; then
   echo "FAIL: SCAN FLOOR — only ${CITATIONS_CHECKED} Test: citation(s) were resolved, below the" >&2


### PR DESCRIPTION
## #5529 — scan floor

Premise verified: `MIN_CITATIONS=200` (line 930) against a real corpus of ~24,281-24,325 citations, confirmed three ways — a local `check_test_pointers.sh` run, and five separate CI runs of `test-pointers.yml` today (2026-08-12). That's ~0.8% of reality, in the same range the issue's ~26,874 estimate implies.

Raised to `5000` (~20% of the measured baseline). Reasoning: high enough that a collapse to a handful of the workspace's 21 crates (per-crate average ~1,150 citations) still fails; low enough that legitimate corpus shrinkage (a crate removal, a doc-comment consolidation) has real headroom before tripping it. Matches this repo's existing #4618-style floor convention — `MIN_RS_FILES=500` in `check_line_cap.sh` sits at ~14% of its 3571-file baseline.

Rung 1 (docs/scripts-only) — no Cargo gate owed.

## #5528 — check_buildrs_sync.sh wired to nothing

Premise verified: the script exists, runs clean, but no `.github/workflows/*.yml` and no `.pre-commit-config.yaml` hook invoked it.

Wired it in two places, matching sibling gates:
- `.github/workflows/buildrs-sync.yml` — new dedicated workflow, path-filtered to the 7 build.rs files it compares plus its own script/workflow file (matches `sld-lint.yml`'s targeted-paths pattern; no Rust toolchain needed, matches `line-cap.yml`'s no-toolchain lightweight-job style).
- `.pre-commit-config.yaml` — new local hook, `pass_filenames: false` / `always_run: true`, matching the `line-cap` / `test-pointers` / `sld-lint` hooks already there.

Proof it runs through the wired path (not a direct call):
```
$ pre-commit run buildrs-sync --all-files --verbose
build.rs canonical-block sync lint.......................................Passed
- hook id: buildrs-sync
- duration: 0.1s

daemon: build.rs canonical blocks are in sync across 4 crates.
tauri-ui: build.rs canonical blocks are in sync across 3 crates.
```
`actionlint` and a YAML parse both pass clean on the new workflow file.

## Gates run

```
$ bash scripts/check_line_cap.sh
line-cap: measured 3996 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
EXIT=0

$ CHANGELOG_GATE_BASE=origin/main bash scripts/check_changelog_fragment.sh
changelog-fragment gate: scanned 3 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
EXIT=0

$ bash scripts/check_sld.sh
sld-lint: scanned 58 spec doc(s) + 3268 code file(s); resolved 40 frontmatter + 37 inline reference(s); 0 error(s), 0 warning(s)
EXIT=0

$ bash scripts/check_test_pointers.sh   # confirms the new floor doesn't break the live tree
test-pointers: resolved 24311 Test: citation(s) (floor 5000) — 0 dangling pointers — OK.
EXIT=0

$ shellcheck -s bash scripts/check_test_pointers.sh
EXIT=1 (3 pre-existing findings at lines 161/246/754, outside this PR's diff — confirmed identical on origin/main)

$ shellcheck -s bash scripts/check_buildrs_sync.sh
EXIT=0
```

No Rust touched — no `cargo` gates owed.

Closes #5529
Closes #5528

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools