### PR TITLE
fix(repo): .gitignore scoping — nested .claude//.trusty-mpm/ + missing ui/dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,13 +17,25 @@
 # session-manager state, never a deliverable — issue #3972)
 .base/
 
-# Ignore all of .claude/ and .claude-mpm/ by default, then re-include what we want
+# Ignore all of .claude/ and .claude-mpm/ by default, then re-include what we
+# want. `.claude/` has no leading or middle slash (only a trailing one, which
+# doesn't count), so per gitignore's matching rule it already reaches every
+# depth — root AND every crate's `.claude/`.
 .claude/
 .claude-mpm/*
 
-# Re-include tracked files from .claude/
-!.claude/
-!.claude/settings.json
+# Re-include tracked files from .claude/ — root only (#4789). These negations
+# are ANCHORED with a leading slash on purpose: an unanchored `!.claude/` /
+# `!.claude/settings.json` would re-include `.claude/` at every depth just
+# like the ignore above, silently cancelling it out everywhere except the one
+# specific nested path a later rule happens to re-ignore. That was the actual
+# defect — `crates/*/.claude/` re-ignored exactly one level of nesting and
+# missed everything past it (`crates/trusty-mpm/src/.claude/`, `docs/.claude/`,
+# `crates/.claude/`, …). Anchoring the negation to root removes the need for
+# that nested re-ignore rule entirely: nested `.claude/` dirs now simply stay
+# ignored, full stop.
+!/.claude/
+!/.claude/settings.json
 
 # Project-tier agent files are NEVER tracked in this repo. They are deployed
 # artifacts, not source: the bundled roster is the product and lives in
@@ -53,10 +65,13 @@
 .claude/agent-memory/
 
 # trusty-mpm session/worktree runtime state is machine-local (issue #3972).
-# Uses `.trusty-mpm/*` (ignore immediate children only), NOT `.trusty-mpm/` +
-# `!.trusty-mpm/` — the latter un-ignores the directory itself and reproduces
-# the exact `.claude/` bug this issue is about (only the explicitly re-included
-# children survive; every other child falls through as untracked).
+# Uses `**/.trusty-mpm/*` (ignore immediate children only, at every depth —
+# root and every crate's), NOT `**/.trusty-mpm/` + a re-include — an ignored
+# *directory* blocks git from descending into it at all, so any future
+# re-include of a specific child file would silently fail to fire (the same
+# `.claude/` trap called out above). `.trusty-mpm/*` (no `**/`) used to anchor
+# this to the repo root only, which is what left nested project-tier state
+# like `crates/trusty-mpm/ui/.trusty-mpm/x.md` committable (#4789).
 #
 # Nothing here is re-included any more. `INSTRUCTIONS.md` used to be, as the
 # tracked project-instruction host; #4286 retired all five `.trusty-mpm/`
@@ -66,25 +81,17 @@
 # four siblings were correctly ignored — so a session that recreated it got a
 # `??` entry inviting it back, and `tm doctor`'s `legacy_overrides` check now
 # fails on exactly that file.
-.trusty-mpm/*
+**/.trusty-mpm/*
 
 # Harness-generated project tier under a CRATE directory is machine-local and
 # never a deliverable (#4752). Running `tm` inside `crates/<name>/` seeds a full
 # project tier there: a `.claude/settings.json` carrying absolute
 # `/Users/<me>/.cargo/bin/...` hook commands, a `.claude/skills/` roster that
 # SHADOWS the bundled one (the #4448/#4526 hazard, same shape as `agents/`
-# above), and a `.trusty-mpm/` session stash.
-#
-# The root-level rules above do NOT reach these, for two different reasons:
-#   * `!.claude/` (above) has no leading or middle slash, so it un-ignores
-#     `.claude` at EVERY level — including every crate's.
-#   * `.trusty-mpm/*` (below) has a middle slash, so it anchors to the repo
-#     root only.
-# 140 such files reached PR #4759 before this rule existed. Scoped to
-# `crates/*/` rather than `**/` on purpose: a bare `**/.claude/` would re-ignore
-# the root `.claude/settings.json` that the re-includes above deliberately keep.
-crates/*/.claude/
-crates/*/.trusty-mpm/
+# above), and a `.trusty-mpm/` session stash. 140 such files reached PR #4759
+# before any rule existed for this. The `.claude/` and `.trusty-mpm/*` rules
+# above now reach every depth directly (#4789 fix) — no separate `crates/*/`
+# rule is needed here any more.
 
 # Re-include tracked files from .claude-mpm/
 !.claude-mpm/INSTRUCTIONS.md
@@ -102,6 +109,14 @@ crates/*/.trusty-mpm/
 .claude-mpm/pm_skills_registry.yaml
 
 !README.md
+
+# Generated Svelte/Vite build output under any crate's ui/ directory (#5076).
+# `pnpm build` (invoked from `build.rs` unless `SKIP_UI_BUILD=1`) regenerates
+# this on demand — nothing under `dist/` is source, so `git add -A crates/`
+# must never be able to stage it. `crates/*/ui/` (the Svelte SOURCE tree) is
+# deliberately untouched by this rule — only the `dist/` build output beneath
+# it is ignored.
+crates/*/ui/dist/
 
 # trusty-search runtime artifacts
 crates/trusty-search/.claude-mpm/

--- a/.gitignore
+++ b/.gitignore
@@ -110,14 +110,6 @@
 
 !README.md
 
-# Generated Svelte/Vite build output under any crate's ui/ directory (#5076).
-# `pnpm build` (invoked from `build.rs` unless `SKIP_UI_BUILD=1`) regenerates
-# this on demand — nothing under `dist/` is source, so `git add -A crates/`
-# must never be able to stage it. `crates/*/ui/` (the Svelte SOURCE tree) is
-# deliberately untouched by this rule — only the `dist/` build output beneath
-# it is ignored.
-crates/*/ui/dist/
-
 # trusty-search runtime artifacts
 crates/trusty-search/.claude-mpm/
 crates/trusty-search/ui/node_modules/


### PR DESCRIPTION
## Summary

`.gitignore` scoping defect: `.claude/` / `.trusty-mpm/` project-tier state
nested past one level of `crates/<name>/` was committable.

Closes #4789

## #4789 — nested `.claude/` / `.trusty-mpm/` state committable

**Root cause:** `crates/*/.claude/` and `crates/*/.trusty-mpm/` are anchored
one level deep (exactly `crates/<name>/.claude`), so anything nested further
— or outside `crates/` entirely — fell through as untracked/committable.
`.claude/` (bare, no leading/middle slash) already matches at *every* depth
per gitignore's own matching rule; the actual defect was the **unanchored**
`!.claude/` / `!.claude/settings.json` re-include negations, which un-ignore
`.claude/` at every depth too, cancelling the top-level ignore everywhere
except the one specific depth the old `crates/*/.claude/` rule re-ignored.

**Fix:** anchor the negations to root only (`!/.claude/`,
`!/.claude/settings.json`), and change `.trusty-mpm/*` -> `**/.trusty-mpm/*`
(children-only, every depth). This makes the old one-level `crates/*/.claude/`
+ `crates/*/.trusty-mpm/` rules unnecessary; removed.

**`git check-ignore -v` evidence — every path from the issue's bug report, now ignored:**

```
$ git check-ignore -q docs/.claude/settings.json                        && echo IGNORED
$ git check-ignore -q scripts/.claude/settings.json                     && echo IGNORED
$ git check-ignore -q crates/.claude/settings.json                      && echo IGNORED
$ git check-ignore -q crates/trusty-mpm/src/.claude/settings.json       && echo IGNORED
$ git check-ignore -q crates/trusty-mpm/ui/.trusty-mpm/x.md             && echo IGNORED
$ git check-ignore -q crates/anything/.claude/agents/foo.md             && echo IGNORED
```
All six: `IGNORED` (exit 0).

**Over-match check — root-tracked / non-`.claude` paths still correctly NOT ignored:**

```
$ git check-ignore -q .claude/settings.json                        ; echo $?   # 1 (not ignored)
$ git check-ignore -q .claude/skills/cargo-commands/SKILL.md       ; echo $?   # 1 (not ignored)
$ git check-ignore -q .claude/worktrees/foo/bar                    ; echo $?   # 0 (still ignored, unchanged)
$ git check-ignore -q .claude/agent-memory/MEMORY.md               ; echo $?   # 0 (still ignored, unchanged)
$ git check-ignore -q .claude/agents/foo.md                        ; echo $?   # 0 (still ignored, shadowing hazard preserved)
```

**Already-tracked paths this rule cannot retroactively fix** (`.gitignore`
has no effect on already-tracked files):

```
$ git ls-files | grep -E '(^|/)\.claude/'
.claude/skills/cargo-commands/SKILL.md          # root, legitimately tracked
.claude/skills/cargo-publish/SKILL.md           # root, legitimately tracked
crates/trusty-search/.claude/commands/health.md
crates/trusty-search/.claude/scheduled_tasks.lock
crates/trusty-search/.claude/settings.json
```
The three `crates/trusty-search/.claude/*` files were already tracked before
this change and stay tracked — the issue explicitly accepted this ("a
genuinely new file there would be silently dropped [going forward]; confirm
that is acceptable"). No `.trusty-mpm/` paths are currently tracked.

## Not fixed here

#5076 ("`crates/*/ui/dist` build output is not gitignored") is declined, not
fixed. `crates/trusty-memory/src/web/static_assets.rs` carries
`#[derive(RustEmbed)]` over `ui/dist` — the committed bundle is compiled into
the binary by design, and its freshness is already publish-gated
(`scripts/check-ui-bundle-freshness.sh` wired into `preflight-publish.sh`).
Gitignoring the directory would actively break future commits: Vite emits
content-hashed asset filenames, so a rebuild deletes the old hashed file and
writes a new, previously-untracked one — an ignore rule would drop that new
asset from the commit while `index.html` (already tracked) still gets staged,
shipping a bundle whose entry point references an asset that was never
committed.

## Scope

`.gitignore` only. No `.rs`, `Cargo.toml`, or `Cargo.lock` touched. No
changelog fragment (no crate `src/**` touched). Test ladder rung 1 — repo
hygiene, no Cargo gate owed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
