### PR TITLE
fix(trusty-mpm): derive validate_and_repair's repaired flag from the outcome

### DIFF
--- a/crates/trusty-mpm/changelog.d/4781-validate-repair-fail-open.md
+++ b/crates/trusty-mpm/changelog.d/4781-validate-repair-fail-open.md
@@ -1,0 +1,15 @@
+Fixed
+
+- `validate_and_repair` no longer reports `repaired: true` for a repair that
+  failed (closes [#4781](https://github.com/bobmatnyc/trusty-tools/issues/4781)).
+  The flag was set unconditionally on the repair path, so a workspace whose
+  repair was refused outright — `prepare_session_with_repo_url` returning the
+  fatal `PrepError::Instructions` (#4752) — still reported itself repaired next
+  to a populated `repair_error`. It is now derived from the re-validation:
+  `true` only when the pipeline returned no error AND the post-repair report has
+  no gaps.
+- `tm validate --repair` prints the attempt's diagnostics again. It gated them
+  on `repaired`, which under the new meaning would have silenced the error
+  message on exactly the runs that produce one; it now gates on whether the
+  pre-repair report had gaps, and says so when the repair did not restore the
+  workspace.

--- a/crates/trusty-mpm/src/bin/tm/commands/misc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/misc.rs
@@ -246,13 +246,19 @@ pub(crate) async fn validate(path: Option<std::path::PathBuf>, repair: bool) -> 
 
     let complete = if repair {
         let outcome = validate_and_repair(&fw, &workspace, None);
-        if outcome.repaired {
+        // #4781: an attempt ran exactly when the pre-repair report had gaps;
+        // `repaired` now reports whether it SUCCEEDED, so it can no longer gate
+        // the attempt's own diagnostics — a failed repair used to print nothing.
+        if !outcome.before.is_complete() {
             println!(
                 "auto-repair ran ({} gap(s) found before repair)",
                 outcome.before.gaps.len()
             );
             if let Some(err) = &outcome.repair_error {
-                eprintln!("repair pipeline reported an error (non-fatal): {err}");
+                eprintln!("repair pipeline reported an error: {err}");
+            }
+            if !outcome.repaired {
+                eprintln!("auto-repair did NOT restore the workspace");
             }
         }
         print_gaps(&outcome.after.gaps);

--- a/crates/trusty-mpm/src/core/deploy_validate/mod.rs
+++ b/crates/trusty-mpm/src/core/deploy_validate/mod.rs
@@ -300,11 +300,13 @@ fn validate_settings(fw: &FrameworkPaths, gaps: &mut Vec<DeploymentGap>) {
 /// Why: callers (the spawn/resume gate, `tm validate --repair`) need to know
 /// not just the final state but whether a repair was attempted and whether it
 /// actually closed the gaps found before it ran.
-/// What: the pre-repair and post-repair [`ValidationReport`]s, whether a
-/// repair attempt ran at all, and the repair error (if any).
+/// What: the pre-repair and post-repair [`ValidationReport`]s, whether the
+/// repair succeeded, and the repair error (if any). Whether a repair was
+/// ATTEMPTED is `!before.is_complete()` — an attempt runs exactly when the
+/// pre-repair report had gaps.
 /// Test: `repair_closes_gaps_on_incomplete_workspace`,
 /// `repair_is_a_noop_on_already_complete_workspace`,
-/// `repair_reports_error_when_prepare_session_fails`.
+/// `repair_is_not_reported_when_the_pipeline_fails_fatally`.
 #[derive(Debug)]
 pub struct RepairOutcome {
     /// Validation result before any repair attempt.
@@ -312,7 +314,11 @@ pub struct RepairOutcome {
     /// Validation result after the repair attempt (equals `before` when no
     /// repair ran).
     pub after: ValidationReport,
-    /// Whether a repair attempt actually ran (only when `before` was incomplete).
+    /// Whether the repair SUCCEEDED — it ran, the pipeline returned no error,
+    /// and it left the workspace complete.
+    ///
+    /// #4781: this used to mean "an attempt ran", set unconditionally on the
+    /// repair path, so a fatally-refused repair still reported `true`.
     pub repaired: bool,
     /// The repair pipeline's error, if [`crate::core::session_launch::prepare_session_with_repo_url`]
     /// returned `Err`. A repair that ran but left gaps (a partial repair) is
@@ -349,9 +355,12 @@ impl RepairOutcome {
 /// `repaired: false`. Otherwise calls
 /// [`crate::core::session_launch::prepare_session_with_repo_url`]`(fw,
 /// workspace, repo_url)` (the #2149 roster/output-style/hooks pipeline),
-/// re-validates, and returns both reports plus any repair error.
+/// re-validates, and returns both reports plus any repair error. `repaired` is
+/// derived from the re-validation, so it is `true` only when the repair left no
+/// error and no gaps (#4781).
 /// Test: `repair_closes_gaps_on_incomplete_workspace`,
-/// `repair_is_a_noop_on_already_complete_workspace`.
+/// `repair_is_a_noop_on_already_complete_workspace`,
+/// `repair_is_not_reported_when_the_pipeline_fails_fatally`.
 pub fn validate_and_repair(
     fw: &FrameworkPaths,
     workspace: &Path,
@@ -375,10 +384,14 @@ pub fn validate_and_repair(
         };
 
     let after = validate_workspace(fw);
+    // #4781: `repaired` is a statement about the OUTCOME, never about the
+    // attempt — a fatally-refused repair left the workspace exactly as broken
+    // as it found it.
+    let repaired = repair_error.is_none() && after.is_complete();
     RepairOutcome {
         before,
         after,
-        repaired: true,
+        repaired,
         repair_error,
     }
 }

--- a/crates/trusty-mpm/src/core/deploy_validate/tests.rs
+++ b/crates/trusty-mpm/src/core/deploy_validate/tests.rs
@@ -473,3 +473,57 @@ fn repair_closes_gaps_on_incomplete_workspace() {
         outcome.after.gaps
     );
 }
+
+#[test]
+#[serial_test::serial]
+fn repair_is_not_reported_when_the_pipeline_fails_fatally() {
+    // Why (#4781): `repaired` was set unconditionally on the repair path, so a
+    // repair that was REFUSED still reported `repaired: true` next to a
+    // `repair_error` — a caller reading the flag alone concluded the workspace
+    // had been fixed while it was left exactly as broken as it was found.
+    //
+    // FIXTURE: the same one `prepare_session_refuses_when_the_instructions_cannot_be_built`
+    // uses — a directory planted where `<workspace>/CLAUDE.md` goes, so the
+    // instruction pipeline's load-or-create step fails and
+    // `prepare_session_with_repo_url` returns the fatal `PrepError::Instructions`
+    // (#4752) before settings/output-style/hooks are ever written.
+    // #3965: `#[serial]` + `$HOME` override — see `HomeGuard` above.
+    let fake_home = TempDir::new().unwrap();
+    let _home_guard = {
+        let prior = std::env::var("HOME").ok();
+        // SAFETY: serialized via `#[serial_test::serial]`.
+        unsafe { std::env::set_var("HOME", fake_home.path()) };
+        HomeGuard(prior)
+    };
+    let tmp = TempDir::new().unwrap();
+    let workspace = tmp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let mut fw = FrameworkPaths::for_managed_project(tmp.path(), &workspace);
+    fw.trusty_mpm_root = None;
+    seed_agent_source(&fw, &["engineer"]);
+    seed_skill_source(&fw, &["tm-doctor"]);
+    std::fs::create_dir_all(workspace.join("CLAUDE.md"))
+        .expect("plant a directory where CLAUDE.md goes");
+
+    assert!(
+        !validate_workspace(&fw).is_complete(),
+        "fixture must start incomplete so the repair path runs"
+    );
+
+    let outcome = validate_and_repair(&fw, &workspace, None);
+
+    assert!(
+        outcome.repair_error.is_some(),
+        "the planted directory must make the repair pipeline fail"
+    );
+    assert!(
+        !outcome.is_complete(),
+        "a refused repair leaves gaps, remaining: {:?}",
+        outcome.after.gaps
+    );
+    assert!(
+        !outcome.repaired,
+        "a repair that failed fatally must NOT report repaired: true (error was {:?})",
+        outcome.repair_error
+    );
+}


### PR DESCRIPTION
`core::deploy_validate::validate_and_repair` set `repaired: true`
unconditionally on its repair path. When `prepare_session_with_repo_url`
returned the fatal `PrepError::Instructions` (#4752), the outcome reported
`repaired: true` alongside a populated `repair_error` — the workspace was left
exactly as broken as it was found, and a caller reading the flag alone
concluded it had been fixed.

`repaired` is now derived from the re-validation:
`repair_error.is_none() && after.is_complete()`. Whether an attempt RAN is
`!before.is_complete()`, which is what the one in-tree reader now uses.

`tm validate --repair` gated its "auto-repair ran" block on `repaired`. Under
the new meaning that would have silenced the error message on exactly the runs
that produce one, so it moved to the attempt condition and now also says when
the repair did not restore the workspace. `session_manager::reconcile` reads
`is_complete()` and is unaffected.

Closes #4781

## Regression proof — RED against pre-fix, GREEN with the fix

New test `repair_is_not_reported_when_the_pipeline_fails_fatally` plants a
directory where `<workspace>/CLAUDE.md` goes (the fixture
`prepare_session_refuses_when_the_instructions_cannot_be_built` already uses),
so the instruction pipeline fails and the repair is refused. It touches only
fields that exist on both sides of the fix, so the pre-fix file compiles
against it.

`git checkout origin/main -- crates/trusty-mpm/src/core/deploy_validate/mod.rs`
then `cargo test -p trusty-mpm --lib core::deploy_validate::tests::repair`:

```
running 3 tests
test core::deploy_validate::tests::repair_is_a_noop_on_already_complete_workspace ... ok
test core::deploy_validate::tests::repair_is_not_reported_when_the_pipeline_fails_fatally ... FAILED
test core::deploy_validate::tests::repair_closes_gaps_on_incomplete_workspace ... ok

---- core::deploy_validate::tests::repair_is_not_reported_when_the_pipeline_fails_fatally stdout ----
panicked at crates/trusty-mpm/src/core/deploy_validate/tests.rs:524:5:
a repair that failed fatally must NOT report repaired: true (error was Some("could not establish the session instructions at /var/folders/.../workspace/CLAUDE.md: Is a directory (os error 21)\nThe session was NOT started: it depends on those instructions. ..."))

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 4950 filtered out; finished in 2.19s
```

With the fix restored, same command:

```
running 3 tests
test core::deploy_validate::tests::repair_is_a_noop_on_already_complete_workspace ... ok
test core::deploy_validate::tests::repair_closes_gaps_on_incomplete_workspace ... ok
test core::deploy_validate::tests::repair_is_not_reported_when_the_pipeline_fails_fatally ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 4950 filtered out; finished in 0.92s
```

## Gate — test ladder rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                     # exit 0
cargo check -p trusty-mpm                             # exit 0
cargo clippy -p trusty-mpm --all-targets -- -D warnings  # exit 0
cargo test -p trusty-mpm                              # exit 0
```

`cargo test -p trusty-mpm` lib run:
`test result: ok. 4946 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 86.16s`,
with every integration suite also `ok` and zero `FAILED` lines in the run.

Also green: `scripts/check_line_cap.sh` (0 violations),
`scripts/check_changelog_fragment.sh`, `scripts/check_sld.sh`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
