### PR TITLE
fix(trusty-agents-common): point the SM at the relay marker tcode emits (#5129)

### DIFF
--- a/crates/trusty-agents-common/changelog.d/5129-harness-event-marker.md
+++ b/crates/trusty-agents-common/changelog.d/5129-harness-event-marker.md
@@ -1,0 +1,10 @@
+Fixed
+
+- `events::EVENT_LINE_PREFIX` is now `"__OMPM_EVENT__ "` — the prefix trusty-code
+  and trusty-agents have always written to stderr. It read `"__HARNESS_EVENT__ "`,
+  and the bundled harness-understanding assets repeated that value, so the
+  trusty-mpm session manager was told to watch for a marker no harness emits
+  ([#5129](https://github.com/bobmatnyc/trusty-tools/issues/5129)). The constant
+  is now the single declaration both harness crates re-export, and
+  `harness_doc_names_the_relay_prefix` pins the assets to it instead of to a copy
+  of its text.

--- a/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_AGNOSTIC.md
+++ b/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_AGNOSTIC.md
@@ -40,7 +40,7 @@ Different harnesses show different idle prompt shapes:
 |---------|------------|-------|
 | Claude Code | `> ` (bare `>` at start of line) | Single `>` alone on the line |
 | Shell | `$ ` or `# ` | Standard Unix shell prompts |
-| tcode | No pane prompt (event-driven) | Uses `__HARNESS_EVENT__` NDJSON events |
+| tcode | No pane prompt (event-driven) | Uses `__OMPM_EVENT__` NDJSON events |
 
 An idle prompt on the **last line** of the pane (or the last non-empty line)
 is the strongest signal that a harness is Idle and waiting for input.
@@ -52,8 +52,8 @@ When a harness executes tools, the pane shows structured patterns:
 - **Claude Code**: Tool calls appear as bracketed blocks with tool name and
   arguments, followed by a result block. The `✻` glyph often appears during
   tool execution. Example: `✻ Running bash...` or `✻ Reading file...`
-- **tcode**: Emits structured NDJSON event lines prefixed with `__HARNESS_EVENT__`.
-  Example: `__HARNESS_EVENT__ {"type":"tool_use","tool":"bash","input":{...}}`
+- **tcode**: Emits structured NDJSON event lines prefixed with `__OMPM_EVENT__`.
+  Example: `__OMPM_EVENT__ {"type":"tool_use","tool":"bash","input":{...}}`
   These lines are parseable as JSON after stripping the prefix.
 - **Shell**: Raw command output; no structured wrapper.
 

--- a/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_OVERSEER.md
+++ b/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_OVERSEER.md
@@ -34,13 +34,13 @@ WHEN-TO-INTERVENE protocol:
 | Unexpected tool call (out-of-scope) | `Block { reason }` | Scope enforcement |
 | Long silence (>5 min) in Working state | `FlagForHuman` | Possible hang |
 
-## `__HARNESS_EVENT__` as Structured Input
+## `__OMPM_EVENT__` as Structured Input
 
-For a t-code overseer, `__HARNESS_EVENT__` lines are the primary structured
+For a t-code overseer, `__OMPM_EVENT__` lines are the primary structured
 input (vs. pane text for Claude Code). The overseer SHOULD prefer event-stream
 classification over pane-text heuristics when events are available.
 
-Parse events as `HarnessEvent` (strip `__HARNESS_EVENT__ ` prefix, parse JSON).
+Parse events as `HarnessEvent` (strip `__OMPM_EVENT__ ` prefix, parse JSON).
 Filter on `source == HarnessSource::Code` and the session ID being overseen.
 
 ## `FlagForHuman` Escalation Policy

--- a/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_TCODE.md
+++ b/crates/trusty-agents-common/src/assets/harness_understanding/HARNESS_TCODE.md
@@ -5,16 +5,17 @@
 tcode (the `trusty-code` harness, binary `tcode`) differs from Claude Code
 in that it emits **structured NDJSON event lines** in addition to pane text.
 
-## `__HARNESS_EVENT__` NDJSON Events
+## `__OMPM_EVENT__` NDJSON Events
 
-tcode emits events as NDJSON lines prefixed with `__HARNESS_EVENT__ `:
+tcode emits events as NDJSON lines prefixed with `__OMPM_EVENT__ `:
 
 ```
-__HARNESS_EVENT__ {"source":"code","seq":1,"payload":{"domain":"lifecycle","event":{"type":"session_started","session_id":"s1","project":"my-repo"}}}
+__OMPM_EVENT__ {"session_id":"s1","seq":1,"at":"2026-08-12T09:00:00Z","kind":"session_started","event":{"type":"session_started","session_id":"s1","project":"my-repo"}}
 ```
 
-To parse: strip the `__HARNESS_EVENT__ ` prefix (21 chars including trailing
-space), then parse the remainder as JSON as a `HarnessEvent` envelope.
+To parse: strip the `__OMPM_EVENT__ ` prefix (15 chars including the trailing
+space), then parse the remainder as JSON — a `SessionEventEnvelope`, whose
+top-level `kind` mirrors the tagged `event.type` for cheap filtering.
 
 Key event types to watch:
 - `session_started` / `session_ended` — lifecycle transitions
@@ -53,7 +54,7 @@ These patterns are completion evidence for "edit made" claims.
 
 ## State Classification for tcode
 
-Apply the agnostic model, but prefer `__HARNESS_EVENT__` events over pane text
+Apply the agnostic model, but prefer `__OMPM_EVENT__` events over pane text
 when available:
 
 | Event / pane signal | State |

--- a/crates/trusty-agents-common/src/events/bus.rs
+++ b/crates/trusty-agents-common/src/events/bus.rs
@@ -12,7 +12,7 @@
 //! What: Defines `HarnessPayload` (the domain-tagged inner union),
 //!       `HarnessEvent` (the envelope), the process-global `EVENT_BUS`, a
 //!       monotonic `SEQ` counter, `bus`/`subscribe`/`publish`/`emit` helpers,
-//!       the `__HARNESS_EVENT__` stderr relay prefix, and a `Lag` notice with
+//!       the `__OMPM_EVENT__` stderr relay prefix, and a `Lag` notice with
 //!       `recv_with_lag` so a lagged subscriber is told how many events it
 //!       skipped and can resume instead of tearing down its stream.
 //! Test: `super::tests` covers serde round-trips of each payload arm, seq
@@ -31,16 +31,25 @@ use super::lifecycle::{HarnessSource, LifecycleEvent};
 
 /// Stderr line prefix used to relay events from a child process to its parent.
 ///
+/// THE one declaration of this wire marker. `trusty_code::events` and
+/// `trusty_agents::events` re-export it rather than declaring their own, and
+/// the harness-understanding assets in this crate document this exact value —
+/// so the producer, the parent-side parser, and the session manager's
+/// instructions cannot drift apart (#5129).
+///
 /// Why: A harness may spawn workflow / agent work in a child process whose
 ///      events must still reach the parent's bus. Reusing stderr as the IPC
 ///      channel (the parent already reads child stderr) avoids inventing a new
 ///      transport. A stable, unambiguous prefix lets the parent detect relay
 ///      lines and re-publish them rather than mirroring them to the terminal.
 /// What: Match by exact byte prefix; the payload after the space is one JSON
-///       object decodable as `HarnessEvent`.
-/// Test: `super::tests::event_line_prefix_is_stable` and
-///       `super::tests::emit_line_has_prefix_and_parses`.
-pub const EVENT_LINE_PREFIX: &str = "__HARNESS_EVENT__ ";
+///       object decodable as the emitting crate's event envelope.
+/// Test: `super::tests::event_line_prefix_is_stable`,
+///       `super::tests::emit_line_has_prefix_and_parses`, and
+///       `crate::harness_doc::tests::harness_doc_names_the_relay_prefix`.
+// #5129: value is the one tcode and tagent have always written to stderr;
+// renaming the producers would break parent/child relay across binary versions.
+pub const EVENT_LINE_PREFIX: &str = "__OMPM_EVENT__ ";
 
 /// Broadcast channel capacity for the global bus.
 ///

--- a/crates/trusty-agents-common/src/events/mod.rs
+++ b/crates/trusty-agents-common/src/events/mod.rs
@@ -236,7 +236,9 @@ mod tests {
 
     #[test]
     fn event_line_prefix_is_stable() {
-        assert_eq!(EVENT_LINE_PREFIX, "__HARNESS_EVENT__ ");
+        // #5129: this is the value tcode and tagent write to stderr, and the
+        // one the harness-understanding assets tell the SM to watch for.
+        assert_eq!(EVENT_LINE_PREFIX, "__OMPM_EVENT__ ");
     }
 
     #[test]

--- a/crates/trusty-agents-common/src/harness_doc.rs
+++ b/crates/trusty-agents-common/src/harness_doc.rs
@@ -13,7 +13,8 @@
 //!       `tcode()`, `overseer()` — plus a `harness_understanding()` convenience
 //!       that concatenates all four sections for consumers that want the full doc.
 //! Test: `harness_doc::tests` verifies non-empty content, canonical marker
-//!       presence (`✻`, `__HARNESS_EVENT__`), and the structured-accessor sum
+//!       presence (`✻`, and the `events::EVENT_LINE_PREFIX` relay marker the
+//!       emitting harness actually writes), and the structured-accessor sum
 //!       equals the full-doc output.
 
 /// Harness-agnostic mental model: session lifecycle, pane/IO model, prompt
@@ -25,7 +26,7 @@
 /// What: Returns the full text of `HARNESS_AGNOSTIC.md`, compiled in at build
 ///       time via `include_str!`.
 /// Test: `agnostic_non_empty`, `agnostic_contains_claude_code_glyph`,
-///       `agnostic_contains_harness_event`.
+///       `harness_doc_names_the_relay_prefix`.
 pub fn agnostic() -> &'static str {
     include_str!("assets/harness_understanding/HARNESS_AGNOSTIC.md")
 }
@@ -42,20 +43,20 @@ pub fn mpm_session_manager() -> &'static str {
     include_str!("assets/harness_understanding/HARNESS_MPM_SM.md")
 }
 
-/// tcode-specific signals: task banners, `__HARNESS_EVENT__` NDJSON lines,
+/// tcode-specific signals: task banners, `__OMPM_EVENT__` NDJSON lines,
 /// agent-delegation patterns, and diff/edit confirmation output.
 ///
 /// Why: tcode emits structured NDJSON events that differ from Claude Code's
 ///      pane-text signals; both consumers need the tcode specifics.
 /// What: Returns the full text of `HARNESS_TCODE.md`.
-/// Test: `tcode_non_empty`, `tcode_contains_harness_event`.
+/// Test: `tcode_non_empty`, `harness_doc_names_the_relay_prefix`.
 pub fn tcode() -> &'static str {
     include_str!("assets/harness_understanding/HARNESS_TCODE.md")
 }
 
 /// Forward-looking t-code-as-overseer contract: the `Overseer` trait +
 /// `HarnessSource::Code` filter seam, event-to-decision mapping, and
-/// `__HARNESS_EVENT__` as structured overseer input.
+/// `__OMPM_EVENT__` as structured overseer input.
 ///
 /// Why: The overseer seam is already defined (`Overseer` trait,
 ///      `HarnessSource::Code`); this section codifies the behavioral contract
@@ -105,13 +106,26 @@ mod tests {
         );
     }
 
+    /// #5129: these sections are the session manager's instructions for which
+    /// stderr marker to watch, so they are pinned to the constant tcode and
+    /// tagent actually emit — never to a copy of its text, which is how the
+    /// doc and the producer drifted apart unnoticed.
     #[test]
-    fn agnostic_contains_harness_event() {
-        // __HARNESS_EVENT__ is the canonical tcode NDJSON event prefix (DOC-21 §5.2)
-        assert!(
-            agnostic().contains("__HARNESS_EVENT__"),
-            "agnostic section must document __HARNESS_EVENT__ prefix"
-        );
+    fn harness_doc_names_the_relay_prefix() {
+        let marker = crate::events::EVENT_LINE_PREFIX.trim_end();
+        let full = harness_understanding();
+        for (section, text) in [
+            ("agnostic", agnostic()),
+            ("tcode", tcode()),
+            ("overseer", overseer()),
+            ("full doc", full.as_str()),
+        ] {
+            assert!(
+                text.contains(marker),
+                "{section} must document the `{marker}` NDJSON relay prefix \
+                 (DOC-21 §5.2) — it is what the emitting harness writes"
+            );
+        }
     }
 
     #[test]
@@ -135,14 +149,6 @@ mod tests {
     }
 
     #[test]
-    fn tcode_contains_harness_event() {
-        assert!(
-            tcode().contains("__HARNESS_EVENT__"),
-            "tcode section must document __HARNESS_EVENT__ NDJSON prefix"
-        );
-    }
-
-    #[test]
     fn overseer_non_empty() {
         assert!(!overseer().trim().is_empty());
     }
@@ -159,10 +165,6 @@ mod tests {
     fn full_doc_contains_all_markers() {
         let doc = harness_understanding();
         assert!(doc.contains('✻'), "full doc must contain ✻ glyph");
-        assert!(
-            doc.contains("__HARNESS_EVENT__"),
-            "full doc must contain __HARNESS_EVENT__"
-        );
         assert!(
             doc.contains("FlagForHuman") || doc.contains("flag_for_human"),
             "full doc must contain FlagForHuman"

--- a/crates/trusty-agents/changelog.d/5129-harness-event-marker.md
+++ b/crates/trusty-agents/changelog.d/5129-harness-event-marker.md
@@ -1,0 +1,6 @@
+Changed
+
+- `events::EVENT_LINE_PREFIX` is re-exported from
+  `trusty_agents_common::events` rather than declared here. The emitted and
+  parsed value is unchanged (`__OMPM_EVENT__ `)
+  ([#5129](https://github.com/bobmatnyc/trusty-tools/issues/5129)).

--- a/crates/trusty-agents/src/events.rs
+++ b/crates/trusty-agents/src/events.rs
@@ -30,8 +30,13 @@ use tokio::sync::broadcast;
 /// channel that already carries `__OMPM_PROGRESS__` (the legacy 2s-poll
 /// path) avoids inventing yet another IPC mechanism.
 /// What: Match by exact byte prefix; payload after the space is one JSON
-/// object decodable as `Event`.
-pub const EVENT_LINE_PREFIX: &str = "__OMPM_EVENT__ ";
+/// object decodable as `Event`. Re-exported, not declared — the marker is a
+/// cross-crate wire format with exactly one declaration, in
+/// `trusty_agents_common::events`.
+/// Test: `tests::event_line_prefix_is_stable`.
+// #5129: a per-crate copy of this marker is what let the documented value
+// drift off the emitted one; a re-export makes that divergence unwritable.
+pub use trusty_agents_common::events::EVENT_LINE_PREFIX;
 
 /// Capacity of the broadcast channel. Larger than `bus`'s 256 because event
 /// volume is much higher (every PM thought, every agent line). 1024 keeps

--- a/crates/trusty-code/changelog.d/5129-harness-event-marker.md
+++ b/crates/trusty-code/changelog.d/5129-harness-event-marker.md
@@ -1,0 +1,9 @@
+Changed
+
+- `events::EVENT_LINE_PREFIX` is re-exported from
+  `trusty_agents_common::events` rather than declared here. The emitted value is
+  unchanged (`__OMPM_EVENT__ `); the second copy is what let the session
+  manager's instructions drift onto a marker nothing emits
+  ([#5129](https://github.com/bobmatnyc/trusty-tools/issues/5129)).
+- `events::format_event_line` is now public, so the exact line `emit` writes to
+  stderr is testable without capturing real stderr.

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -51,8 +51,15 @@ use tokio::sync::broadcast;
 /// channel that already carries `__OMPM_PROGRESS__` (the legacy 2s-poll
 /// path) avoids inventing yet another IPC mechanism.
 /// What: Match by exact byte prefix; payload after the space is one JSON
-/// object decodable as `Event`.
-pub const EVENT_LINE_PREFIX: &str = "__OMPM_EVENT__ ";
+/// object decodable as `Event`. Re-exported, not declared — the marker is a
+/// cross-crate wire format, so it has exactly one declaration, in
+/// `trusty_agents_common::events`, which the harness-understanding assets
+/// document and the session-manager prompt is built from.
+/// Test: `events_tests::event_line_prefix_is_stable` and
+/// `events_tests::sm_harness_doc_documents_the_prefix_tcode_emits`.
+// #5129: a second copy here is what let the documented marker drift off the
+// emitted one; a re-export makes that divergence impossible to write.
+pub use trusty_agents_common::events::EVENT_LINE_PREFIX;
 
 /// Capacity of the broadcast channel. Larger than `bus`'s 256 because event
 /// volume is much higher (every PM thought, every agent line). 1024 keeps
@@ -1253,12 +1260,33 @@ pub fn publish(envelope: SessionEventEnvelope) {
 /// writes one NDJSON line to stderr prefixed with `__OMPM_EVENT__ `. The
 /// parent's stderr reader (in `api::server::run_task`) detects the prefix
 /// and re-publishes on its own bus.
-/// Test: Indirect — exercised by the workflow integration path.
+/// Test: `events_tests::sm_harness_doc_documents_the_prefix_tcode_emits`
+/// covers the wire line via `format_event_line`; the stderr write itself is
+/// exercised by the workflow integration path.
 pub fn emit(envelope: SessionEventEnvelope) {
-    publish(envelope.clone());
-    if let Ok(line) = serde_json::to_string(&envelope) {
-        eprintln!("{EVENT_LINE_PREFIX}{line}");
+    let line = format_event_line(&envelope);
+    publish(envelope);
+    if let Some(line) = line {
+        eprintln!("{line}");
     }
+}
+
+/// Format the single stderr relay line `emit` writes for `envelope`, or `None`
+/// if it cannot be serialised.
+///
+/// Why: the relay line is a cross-process wire format, and the session
+/// manager's harness-understanding doc tells an operator which prefix to look
+/// for. Splitting formatting out of `emit` lets a test compare the REAL
+/// emitted line against that doc instead of against a copy of the literal —
+/// the divergence #5129 recorded was invisible precisely because every test
+/// pinned a constant to itself.
+/// What: returns `EVENT_LINE_PREFIX` concatenated with the compact JSON of the
+/// envelope; `None` only on the (practically impossible) serde failure.
+/// Test: `events_tests::sm_harness_doc_documents_the_prefix_tcode_emits`.
+pub fn format_event_line(envelope: &SessionEventEnvelope) -> Option<String> {
+    serde_json::to_string(envelope)
+        .ok()
+        .map(|json| format!("{EVENT_LINE_PREFIX}{json}"))
 }
 
 /// Truncate a string to at most `max` characters, appending an ellipsis

--- a/crates/trusty-code/src/events_tests.rs
+++ b/crates/trusty-code/src/events_tests.rs
@@ -692,6 +692,53 @@ fn preview_truncates_at_char_boundary() {
 #[test]
 fn event_line_prefix_is_stable() {
     // Lock in the wire constant — changing it breaks the parent/child
-    // relay protocol.
+    // relay protocol. #5129: the constant now lives in trusty-agents-common
+    // and is re-exported here, so this also catches an upstream crate version
+    // whose value has drifted off the wire format.
     assert_eq!(EVENT_LINE_PREFIX, "__OMPM_EVENT__ ");
+}
+
+/// #5129: the session manager is told which prefix to watch for by the
+/// harness-understanding doc; tcode decides which prefix it writes. Nothing
+/// bound the two, and they disagreed — the doc said `__HARNESS_EVENT__`, the
+/// producer wrote `__OMPM_EVENT__`. This takes the line `emit` actually puts
+/// on stderr and asserts the SM's own instructions name that prefix, so a
+/// future divergence on either side fails here rather than in production.
+#[test]
+fn sm_harness_doc_documents_the_prefix_tcode_emits() {
+    let envelope = SessionEventEnvelope::new(
+        "s1".into(),
+        1,
+        Utc::now(),
+        Event::PmThinking {
+            session_id: "s1".into(),
+            text: "considering options".into(),
+        },
+    );
+
+    let line = format_event_line(&envelope).expect("envelope serialises");
+    let emitted_prefix = line
+        .split_once('{')
+        .map(|(prefix, _)| prefix)
+        .expect("relay line carries a JSON payload");
+    assert_eq!(
+        emitted_prefix, EVENT_LINE_PREFIX,
+        "the emitted line must start with the shared relay constant"
+    );
+
+    // The consumer side: the instruction text trusty-mpm assembles into the
+    // session-manager prompt, read straight from the crate that owns it.
+    let marker = emitted_prefix.trim_end();
+    for (section, text) in [
+        ("agnostic", trusty_agents_common::harness_doc::agnostic()),
+        ("tcode", trusty_agents_common::harness_doc::tcode()),
+        ("overseer", trusty_agents_common::harness_doc::overseer()),
+    ] {
+        assert!(
+            text.contains(marker),
+            "harness_understanding `{section}` section must name the prefix \
+             tcode emits ({marker}); the session manager watches for whatever \
+             this doc says"
+        );
+    }
 }

--- a/crates/trusty-mpm/changelog.d/5129-harness-event-marker.md
+++ b/crates/trusty-mpm/changelog.d/5129-harness-event-marker.md
@@ -1,0 +1,8 @@
+Fixed
+
+- The assembled session-manager prompt told the SM to watch tcode for
+  `__HARNESS_EVENT__`; tcode emits `__OMPM_EVENT__`. The harness-understanding
+  sections now carry the emitted marker, and the prompt tests assert against
+  `trusty_agents_common::events::EVENT_LINE_PREFIX` instead of a literal — they
+  previously passed by agreeing with the wrong instruction text
+  ([#5129](https://github.com/bobmatnyc/trusty-tools/issues/5129)).

--- a/crates/trusty-mpm/src/core/sm/prompt.rs
+++ b/crates/trusty-mpm/src/core/sm/prompt.rs
@@ -259,9 +259,13 @@ mod tests {
         assert!(prompt.contains("You MAY do directly (Allowlist)"));
         // The harness-understanding section (DOC-21) canonical markers.
         assert!(prompt.contains('✻'), "harness ✻ glyph must be present");
+        // #5129: pinned to the emitting harness's constant, not a literal —
+        // the SM watches for whatever this prompt names, so the prompt must
+        // name what tcode/tagent actually write.
+        let marker = trusty_agents_common::events::EVENT_LINE_PREFIX.trim_end();
         assert!(
-            prompt.contains("__HARNESS_EVENT__"),
-            "harness __HARNESS_EVENT__ must be present"
+            prompt.contains(marker),
+            "harness relay marker `{marker}` must be present"
         );
         // The 6-phase loop + verification gate.
         assert!(prompt.contains("# SM Workflow -- the delegation loop"));
@@ -358,9 +362,13 @@ mod tests {
             prompt.contains('✻'),
             "assembled SM prompt must contain ✻ (harness understanding glyph marker)"
         );
+        // #5129: the marker comes from the constant tcode emits, so a rename
+        // on either side fails here instead of silently telling the SM to
+        // watch for a string no harness ever writes.
+        let marker = trusty_agents_common::events::EVENT_LINE_PREFIX.trim_end();
         assert!(
-            prompt.contains("__HARNESS_EVENT__"),
-            "assembled SM prompt must contain __HARNESS_EVENT__ (tcode event marker)"
+            prompt.contains(marker),
+            "assembled SM prompt must contain `{marker}` (tcode event marker)"
         );
     }
 

--- a/docs/adr/0005-harness-event-bus.md
+++ b/docs/adr/0005-harness-event-bus.md
@@ -63,8 +63,11 @@ submodules to respect the 500-line cap (`mod.rs` facade + `lifecycle.rs` +
   (`Utc::now()`) automatically. `publish` is best-effort (ignores `SendError`
   when there are no subscribers) and returns the assigned `seq`.
 - `emit` = `publish` + one NDJSON stderr line prefixed with the public
-  `EVENT_LINE_PREFIX = "__HARNESS_EVENT__ "`. The line formatting is factored
-  into `format_event_line` so it is unit-testable without capturing real stderr.
+  `EVENT_LINE_PREFIX`. The line formatting is factored into `format_event_line`
+  so it is unit-testable without capturing real stderr. The constant read
+  `"__HARNESS_EVENT__ "` as landed; #5129 changed it to `"__OMPM_EVENT__ "` —
+  the value trusty-code and trusty-agents were already writing — and made both
+  crates re-export it instead of declaring their own.
 - A lagged-receiver helper `recv_with_lag` that translates
   `broadcast::error::RecvError::Lagged(n)` into a public typed `Lag { skipped }`
   notice (returned as the `Err` arm of an inner `Result`) and resumes the stream

--- a/docs/architecture/harnesses.md
+++ b/docs/architecture/harnesses.md
@@ -288,9 +288,10 @@ That principle holds in all three. The *unification* does not yet.
 | **trusty-mpm** | Daemon-held `tokio::sync::broadcast` (`src/daemon/state/`) | Untyped `serde_json::Value` | SSE at `/events` and `/sessions/{id}/events`; a poll endpoint at `/events/poll` |
 
 trusty-agents and trusty-code each also relay events from a child process to
-their parent by prefixing NDJSON lines on stderr. Both use the same prefix,
-`__OMPM_EVENT__ `, each from its own crate-local constant rather than a shared
-one.
+their parent by prefixing NDJSON lines on stderr with `__OMPM_EVENT__ `. Both
+now re-export that prefix from the one declaration in
+`trusty_agents_common::events::EVENT_LINE_PREFIX` (#5129); each previously kept
+its own crate-local copy.
 
 ### The unified envelope, and why it is not yet the wire format
 
@@ -299,12 +300,16 @@ one.
 together with the process-global bus and a subscription `Filter`. It was landed
 as a foundation with no emit sites migrated onto it.
 
-That is still the state. No harness crate imports
-`trusty_agents_common::events`: the three buses above each carry their own
-payload type, and the envelope's own relay prefix, `__HARNESS_EVENT__ `, is not
-the one either subprocess relay actually emits. Consuming the unified envelope
-is the outstanding work, and until it lands, an event crossing a harness
-boundary is re-encoded rather than forwarded.
+That is still the state for the *payload*: the three buses above each carry
+their own type, so an event crossing a harness boundary is re-encoded rather
+than forwarded. Consuming the unified envelope is the outstanding work.
+
+The *framing* is now shared. `EVENT_LINE_PREFIX` used to read
+`__HARNESS_EVENT__ ` here while both subprocess relays wrote `__OMPM_EVENT__ `,
+and the session manager was told to watch for the former — a marker nothing
+emitted (#5129). The constant now carries the emitted value and trusty-code and
+trusty-agents re-export it, so the producers, the parent-side parser, and the
+harness-understanding doc cannot drift apart again.
 
 ---
 

--- a/docs/specs/harness-understanding.md
+++ b/docs/specs/harness-understanding.md
@@ -58,14 +58,14 @@ Key facts:
 |---------|------------|-------|
 | Claude Code | `> ` (bare `>` at start of line) | Single `>` alone on the line |
 | Shell | `$ ` or `# ` | Standard Unix shell prompts |
-| tcode | No pane prompt (event-driven) | Uses `__HARNESS_EVENT__` NDJSON events |
+| tcode | No pane prompt (event-driven) | Uses `__OMPM_EVENT__` NDJSON events |
 
 An idle prompt on the **last line** of the pane is the strongest signal that a harness is Idle.
 
 ### 2.4 Tool-Call Patterns
 
 - **Claude Code**: Tool calls appear as bracketed blocks. The `✻` glyph appears during tool execution (`✻ Running bash...`, `✻ Reading file...`).
-- **tcode**: Emits structured NDJSON event lines prefixed with `__HARNESS_EVENT__`. Example: `__HARNESS_EVENT__ {"type":"tool_use","tool":"bash","input":{...}}`. Parseable as JSON after stripping the prefix.
+- **tcode**: Emits structured NDJSON event lines prefixed with `__OMPM_EVENT__`. Example: `__OMPM_EVENT__ {"type":"tool_use","tool":"bash","input":{...}}`. Parseable as JSON after stripping the prefix.
 - **Shell**: Raw command output; no structured wrapper.
 
 ### 2.5 Approval / Decision Gates
@@ -171,10 +171,10 @@ This directly addresses the `ActivityState::Unknown` fallback gap (issue #875).
 ### 5.2 tcode
 
 - **Task banners**: `=== Task: <description> ===` (start), `=== Done ===` (end)
-- **Event prefix**: `__HARNESS_EVENT__` NDJSON lines — parseable events
+- **Event prefix**: `__OMPM_EVENT__` NDJSON lines — parseable events
 - **Agent-delegation output**: `[agent-name] <output>` prefixed lines
 - **Diff/edit confirmation**: `Edit: src/foo.rs (+15, -3)`, `Write: src/bar.rs`
-- **State classification**: Prefer `__HARNESS_EVENT__` events over pane text
+- **State classification**: Prefer `__OMPM_EVENT__` events over pane text
 
 ---
 
@@ -240,9 +240,9 @@ A t-code overseer maps `HarnessEvent`s (filtered on `HarnessSource::Code`) to `O
 | Unexpected tool call | `Block { reason }` | Scope enforcement |
 | Long silence (>5 min) in Working state | `FlagForHuman` | Possible hang |
 
-### 7.3 `__HARNESS_EVENT__` Lines as Structured Overseer Input
+### 7.3 `__OMPM_EVENT__` Lines as Structured Overseer Input
 
-For a t-code overseer, `__HARNESS_EVENT__` lines are the primary structured input (vs. pane text for Claude Code). Strip the prefix, parse as `HarnessEvent`, filter on `source == HarnessSource::Code`.
+For a t-code overseer, `__OMPM_EVENT__` lines are the primary structured input (vs. pane text for Claude Code). Strip the prefix, parse as `HarnessEvent`, filter on `source == HarnessSource::Code`.
 
 ### 7.4 Reserved `HarnessSource::Code` Slot
 


### PR DESCRIPTION
Closes #5129.

## What was actually wrong

The issue named two sites; there were three. `EVENT_LINE_PREFIX` was declared
independently in `trusty_agents_common::events` (`__HARNESS_EVENT__ `),
`trusty_code::events` (`__OMPM_EVENT__ `), and `trusty_agents::events`
(`__OMPM_EVENT__ `). The harness-understanding assets — the text trusty-mpm
assembles into the session-manager prompt — repeated the first value, so the SM
was told to watch for a marker no harness writes.

Nothing in trusty-mpm parses the marker; the consumer is the session-manager
model reading that prompt. `trusty_agents_common::events::emit`, the only code
that ever wrote `__HARNESS_EVENT__ `, has no caller in the workspace.

## Why the docs moved and not the producers

`__OMPM_EVENT__ ` is the live wire value. `task_runner.rs:118` strips it from
child-process stderr, and the surrounding code explicitly keeps a fallback for
older child binaries — parent and child are separately published crates whose
versions differ in the field. Renaming a producer breaks that relay; renaming
the documentation breaks nothing.

## Why the tests were green

They asserted the doc against a literal copied from the doc — a constant pinned
to itself, agreeing with the consumer text and never reaching a producer. The
new `sm_harness_doc_documents_the_prefix_tcode_emits` takes the line
`trusty_code::events::emit` really writes and requires the SM's own instruction
text to name its prefix. Against the pre-fix tree:

```
test events::tests::sm_harness_doc_documents_the_prefix_tcode_emits ... FAILED
panicked at crates/trusty-code/src/events_tests.rs:737:9:
harness_understanding `agnostic` section must name the prefix tcode emits
(__OMPM_EVENT__); the session manager watches for whatever this doc says
test result: FAILED. 0 passed; 1 failed
```

After: `test result: ok. 1 passed; 0 failed`.

A genuine end-to-end test is not reachable — the consumer is a model reading a
prompt, not a parser. What this covers instead is the full mechanical chain:
the producer's real serialized line, the shared constant, and the instruction
text, with the constant re-exported so a producer/parser divergence is a
compile-time impossibility rather than a test.

## Consolidation

One `pub const` in `trusty_agents_common::events`; trusty-code and trusty-agents
re-export it. No dependency added — all three crates already depended on
trusty-agents-common. The per-crate `assert_eq!(EVENT_LINE_PREFIX,
"__OMPM_EVENT__ ")` pins are kept: they now guard against an upstream crate
version whose value has drifted off the wire format.

Also corrected in `HARNESS_TCODE.md`, since the rename made them visibly wrong:
the prefix length (said 21 chars, is 15) and the worked example, which showed
`HarnessEvent`'s shape while tcode serializes a `SessionEventEnvelope`.

## Gates — test ladder rung 4

The constant is public API of a shared library with three direct dependents.

Rung 3 on the owning crate:

```
cargo fmt --check                                              # EXIT=0
cargo check -p trusty-agents-common                            # EXIT=0
cargo clippy -p trusty-agents-common --all-targets -- -D warnings   # EXIT=0
cargo test -p trusty-agents-common
  test events::tests::event_line_prefix_is_stable ... ok
  test harness_doc::tests::harness_doc_names_the_relay_prefix ... ok
  test result: ok. 486 passed; 0 failed; 0 ignored
```

Rung 4 leg — workspace check plus every direct dependent:

```
cargo check --workspace                                        # EXIT=0
cargo test -p trusty-code      # ok. 1608 passed; 0 failed; 4 ignored (+16 suites ok)
cargo test -p trusty-agents    # ok. 3498 passed; 0 failed; 13 ignored (+11 suites ok)
cargo test -p trusty-mpm       # 47 suites, all ok; 0 failed
cargo clippy -p trusty-code -p trusty-agents -p trusty-mpm --all-targets -- -D warnings   # EXIT=0
```

Repo gates:

```
bash scripts/check_line_cap.sh
  3997 tracked .rs file(s); 4 allowlisted, 0 violations — OK
bash scripts/check_changelog_fragment.sh
  scanned 17 changed path(s); all 4 crate(s) with source changes are recorded
bash scripts/check_sld.sh
  59 spec doc(s) + 5901 code file(s); 0 error(s), 0 warning(s)
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
