### PR TITLE
fix(trusty-mpm): doctor must not read a timed-out gh probe as unauthenticated

### DIFF
--- a/crates/trusty-mpm/changelog.d/5032-doctor-gh-token-probe.md
+++ b/crates/trusty-mpm/changelog.d/5032-doctor-gh-token-probe.md
@@ -1,0 +1,13 @@
+Fixed
+
+- `tm doctor`'s `gh_account` check no longer reports "gh is not authenticated"
+  for a working `GH_TOKEN` / `GITHUB_TOKEN` login. Its `gh auth status` probe
+  was bounded at 250 ms — a constant inherited from the statusline's render
+  path — while validating an env token takes a network round trip that measured
+  281–389 ms, so every probe timed out and the timeout rendered as a definite
+  negative. The doctor now probes under its own 5 s bound, and a probe that
+  still does not finish reports the auth state as UNKNOWN with the reason,
+  instead of claiming the account does not exist.
+- The doctor reads the active login and the logged-in list from ONE
+  `gh auth status` invocation (previously two, one of them `--active`), so the
+  check costs a single network round trip.

--- a/crates/trusty-mpm/src/core/gh_account.rs
+++ b/crates/trusty-mpm/src/core/gh_account.rs
@@ -16,14 +16,15 @@
 //! parses `github.com.user` (the active login) plus the `github.com.users` map
 //! (every logged-in login). [`gh_account_status_local`] returns both from one
 //! file read with no subprocess — safe for the statusline's hot render path.
-//! [`active_gh_account`] falls back to a bounded `gh auth status --active`
-//! subprocess when the local file is absent, and [`logged_in_gh_accounts`]
-//! parses `gh auth status` for the full multi-account list. Every entry point is
-//! fail-soft: a missing `gh`, absent config, or parse error yields `None` /
-//! an empty vec, never an error or panic.
+//! `tm doctor` instead runs one bounded `gh auth status` via [`probe_gh_auth`]:
+//! that is the only source that sees env-token auth (`GH_TOKEN` /
+//! `GITHUB_TOKEN`), which writes no config file at all (#5032). Every entry
+//! point is fail-soft: a missing `gh`, absent config, or parse error yields
+//! `None` / [`GhAuthProbe::Inconclusive`], never an error or panic.
 //!
 //! Test: the pure parsers (`parse_active_account_from_hosts_yml`,
-//! `parse_logged_in_accounts`, `parse_gh_account_status_from_hosts_yml`) are
+//! `parse_logged_in_accounts`, `parse_gh_account_status_from_hosts_yml`,
+//! `parse_gh_account_status_from_auth_status`) are
 //! unit-tested against sample `hosts.yml` and `gh auth status` strings in the
 //! inline `tests` module; the subprocess wrappers are thin bounded glue.
 //!
@@ -41,15 +42,22 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-/// Bounded wall-clock timeout for any `gh` subprocess this module spawns.
+/// Bound for the `gh auth status` probe `tm doctor` runs (#5032).
 ///
-/// Why: both the statusline (hot render path) and `tm doctor` must never block
-/// on a wedged `gh` (stuck credential helper, slow keyring, network). A short
-/// bound turns "hung" into a clean "omit the segment / warn".
-/// What: 250 ms — generous enough for a local `gh auth status` yet short enough
-/// to never stall a render cycle.
-/// Test: covered indirectly (the parsers are the tested surface).
-pub const GH_PROBE_TIMEOUT: Duration = Duration::from_millis(250);
+/// Why: the bound this replaced was 250 ms, inherited from the statusline's hot
+/// render path. `gh auth status` validates an env token (`GH_TOKEN` /
+/// `GITHUB_TOKEN`) over the network, which measured 281–389 ms across eight runs
+/// on the reporter's machine and 366–373 ms here — so every probe timed out and
+/// the doctor reported a fully authenticated `gh` as unauthenticated. The
+/// statusline never used this path (it reads `hosts.yml` directly, see
+/// [`gh_account_status_local`]), so nothing latency-sensitive is left to protect.
+/// What: 5 s, matching [`GH_ENFORCE_TIMEOUT`] — an order of magnitude above the
+/// measured token round trip, with headroom for a slow network, while still
+/// bounding a wedged `gh`. A probe that exceeds it reports UNKNOWN, never
+/// "unauthenticated" (see [`GhAuthProbe`]).
+/// Test: `doctor_probe_tolerates_token_auth_latency`,
+/// `probe_beyond_bound_is_inconclusive`.
+pub const GH_DOCTOR_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// A snapshot of the local `gh` github.com account state.
 ///
@@ -272,47 +280,90 @@ where
     rx.recv_timeout(timeout).ok().flatten()
 }
 
-/// Resolve the active github.com login, preferring the cheap local path.
+/// Parse both the active login and every logged-in login from `gh auth status`.
 ///
-/// Why: the one call every surface uses to answer "which account is active?".
-/// Reads `hosts.yml` first (no subprocess) and only falls back to a bounded
-/// `gh auth status --active` when the local file cannot answer, so it is fast in
-/// the common case yet still correct when config lives only in the keyring.
-/// What: returns the active login from `hosts.yml`, else the first account
-/// parsed from a bounded `gh auth status --active`; `None` when `gh` is
-/// unconfigured/unauthenticated/absent.
-/// Test: the local parse is covered by `parse_active_account_*`; the subprocess
-/// fallback is thin bounded glue.
-pub fn active_gh_account() -> Option<String> {
-    if let Some(status) = gh_account_status_local()
-        && let Some(active) = status.active
-    {
-        return Some(active);
+/// Why: `gh auth status` is the only source that sees ALL auth modes — keyring,
+/// `hosts.yml`, and an env token (`GH_TOKEN` / `GITHUB_TOKEN`), which writes no
+/// config file at all (#5032). Reading active + logged-in from ONE invocation
+/// also means one network round trip instead of two.
+/// What: `logged_in` comes from [`parse_logged_in_accounts`]; `active` is the
+/// login of the block whose `- Active account: true` line follows it. A single
+/// logged-in account with no such marker (older `gh`) is taken as active.
+/// Test: `parse_auth_status_active_from_marker`,
+/// `parse_auth_status_token_auth`, `parse_auth_status_unauthenticated`.
+pub fn parse_gh_account_status_from_auth_status(auth_status: &str) -> GhAccountStatus {
+    let logged_in = parse_logged_in_accounts(auth_status);
+    let mut active: Option<String> = None;
+    let mut current: Option<String> = None;
+    for line in auth_status.lines() {
+        if let Some((_, rest)) = line.split_once("Logged in to") {
+            current = extract_login_token(rest);
+        } else if active.is_none() && line.contains("Active account: true") {
+            active = current.clone();
+        }
     }
-    run_bounded(GH_PROBE_TIMEOUT, || {
-        let out = std::process::Command::new("gh")
-            .args(["auth", "status", "--active"])
-            .output()
-            .ok()?;
-        let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
-        text.push('\n');
-        text.push_str(&String::from_utf8_lossy(&out.stderr));
-        parse_logged_in_accounts(&text).into_iter().next()
+    if active.is_none() && logged_in.len() == 1 {
+        active = logged_in.first().cloned();
+    }
+    GhAccountStatus { active, logged_in }
+}
+
+/// Outcome of a bounded `gh auth status` probe (#5032).
+///
+/// Why: "`gh` says no account" and "I could not tell within the bound" are
+/// different facts, and collapsing them is the defect this type exists to
+/// prevent — the doctor reported a working `GH_TOKEN` login as "not
+/// authenticated" because a timed-out probe was indistinguishable from an empty
+/// answer.
+/// What: `Answered` carries what `gh` reported (an empty `logged_in` IS a
+/// definitive "not authenticated"); `Inconclusive` carries why the state is
+/// unknown — the bound elapsed, or `gh` could not be run.
+/// Test: `probe_answered_parses_accounts`, `probe_beyond_bound_is_inconclusive`,
+/// `probe_missing_gh_is_inconclusive`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GhAuthProbe {
+    /// `gh` answered within the bound; an empty `logged_in` means unauthenticated.
+    Answered(GhAccountStatus),
+    /// Auth state is UNKNOWN, for the carried reason — not a negative answer.
+    Inconclusive(String),
+}
+
+/// Probe `gh`'s github.com auth state with an injectable runner (#5032).
+///
+/// Why: the seam lets the timeout arm — the one that produced the false
+/// "not authenticated" — be tested hermetically, with no live `gh` and no
+/// network.
+/// What: runs `run` on a bounded thread; `Some(text)` is parsed via
+/// [`parse_gh_account_status_from_auth_status`], `None` means `gh` could not be
+/// executed, and an elapsed bound yields [`GhAuthProbe::Inconclusive`].
+/// Test: `doctor_probe_tolerates_token_auth_latency`,
+/// `probe_beyond_bound_is_inconclusive`, `probe_missing_gh_is_inconclusive`.
+pub fn probe_gh_auth_with<F>(timeout: Duration, run: F) -> GhAuthProbe
+where
+    F: FnOnce() -> Option<String> + Send + 'static,
+{
+    run_bounded(timeout, move || {
+        Some(match run() {
+            Some(text) => GhAuthProbe::Answered(parse_gh_account_status_from_auth_status(&text)),
+            None => GhAuthProbe::Inconclusive("`gh` could not be run (is it on PATH?)".to_string()),
+        })
+    })
+    .unwrap_or_else(|| {
+        GhAuthProbe::Inconclusive(format!(
+            "`gh auth status` did not answer within {timeout:?}"
+        ))
     })
 }
 
-/// List every logged-in github.com account via a bounded `gh auth status`.
+/// Probe `gh`'s github.com auth state by running the real `gh auth status`.
 ///
-/// Why: detecting the MULTIPLE-accounts ambiguity (the condition that caused the
-/// admin-merge bug) is the authoritative signal `tm doctor` warns on. `gh auth
-/// status` is the definitive source across all storage backends (keyring or
-/// file), so the doctor uses it rather than trusting only `hosts.yml`.
-/// What: runs `gh auth status` (bounded by [`GH_PROBE_TIMEOUT`]) and parses its
-/// stdout+stderr via [`parse_logged_in_accounts`]; returns an empty vec on
-/// timeout, a missing `gh`, or when not authenticated.
-/// Test: the parse is covered by `parse_logged_in_*`; this is thin bounded glue.
-pub fn logged_in_gh_accounts() -> Vec<String> {
-    run_bounded(GH_PROBE_TIMEOUT, || {
+/// Why: the single entry point every caller that needs an authoritative,
+/// all-auth-modes answer uses — `hosts.yml` alone cannot see env-token auth.
+/// What: delegates to [`probe_gh_auth_with`] with a runner that returns
+/// `gh auth status`'s stdout+stderr, or `None` when the spawn itself fails.
+/// Test: covered via [`probe_gh_auth_with`]'s fake-runner tests.
+pub fn probe_gh_auth(timeout: Duration) -> GhAuthProbe {
+    probe_gh_auth_with(timeout, || {
         let out = std::process::Command::new("gh")
             .args(["auth", "status"])
             .output()
@@ -320,18 +371,17 @@ pub fn logged_in_gh_accounts() -> Vec<String> {
         let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
         text.push('\n');
         text.push_str(&String::from_utf8_lossy(&out.stderr));
-        Some(parse_logged_in_accounts(&text))
+        Some(text)
     })
-    .unwrap_or_default()
 }
 
 /// Bound for the `gh auth status` / `gh auth switch` calls the [`enforce`]
 /// module's `ensure_gh_account_for_project` makes, and that
 /// [`gh_token_via_cli`] below also uses for its `gh auth token` call.
 ///
-/// Why: unlike [`GH_PROBE_TIMEOUT`] (tuned for the statusline's hot render
-/// path), these calls are explicit, occasional pre-flights — generous enough
-/// for a keyring-backed `gh` to respond without hanging the caller indefinitely.
+/// Why: like [`GH_DOCTOR_TIMEOUT`], these calls are explicit, occasional
+/// pre-flights — generous enough for a keyring-backed or network-validated `gh`
+/// to respond without hanging the caller indefinitely.
 const GH_ENFORCE_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[path = "gh_account_enforce.rs"]
@@ -686,6 +736,106 @@ github.com
     fn parse_logged_in_empty() {
         assert!(parse_logged_in_accounts("").is_empty());
         assert!(parse_logged_in_accounts("You are not logged into any GitHub hosts.").is_empty());
+    }
+
+    /// `gh auth status` for an env-token login — the #5032 reporter's exact
+    /// output shape, including the `(GH_TOKEN)` annotation.
+    const TOKEN_AUTH_STATUS: &str = "\
+github.com
+  ✓ Logged in to github.com account mac-duetto (GH_TOKEN)
+  - Active account: true
+  - Git operations protocol: https
+  - Token scopes: 'repo', 'workflow'
+";
+
+    /// Why: the doctor reads the active login out of `gh auth status`, so the
+    /// `- Active account: true` marker must bind to the login above it.
+    /// Test: itself.
+    #[test]
+    fn parse_auth_status_active_from_marker() {
+        let status = parse_gh_account_status_from_auth_status(MULTI_AUTH_STATUS);
+        assert_eq!(status.active.as_deref(), Some("bob-duetto"));
+        assert_eq!(
+            status.logged_in,
+            vec!["bob-duetto".to_string(), "bobmatnyc".to_string()]
+        );
+        assert!(status.is_ambiguous());
+    }
+
+    /// Why: env-token auth writes no `hosts.yml`, so `gh auth status` is the
+    /// ONLY place this login is visible (#5032).
+    /// Test: itself.
+    #[test]
+    fn parse_auth_status_token_auth() {
+        let status = parse_gh_account_status_from_auth_status(TOKEN_AUTH_STATUS);
+        assert_eq!(status.active.as_deref(), Some("mac-duetto"));
+        assert_eq!(status.logged_in, vec!["mac-duetto".to_string()]);
+        assert!(!status.is_ambiguous());
+    }
+
+    /// Why: a genuinely unauthenticated `gh` must parse to an empty status —
+    /// that is the one state the doctor may report as "not authenticated".
+    /// Test: itself.
+    #[test]
+    fn parse_auth_status_unauthenticated() {
+        let status =
+            parse_gh_account_status_from_auth_status("You are not logged into any GitHub hosts.");
+        assert_eq!(status, GhAccountStatus::default());
+    }
+
+    /// #5032 regression: `gh auth status` validates an env token over the
+    /// network — measured 281–389 ms by the reporter and 366–373 ms locally.
+    /// Under the old 250 ms bound every such probe timed out and the doctor
+    /// reported a working login as "not authenticated". This pins the doctor's
+    /// bound above realistic token-auth latency; it FAILS if
+    /// [`GH_DOCTOR_TIMEOUT`] is ever lowered below the simulated 400 ms probe.
+    #[test]
+    fn doctor_probe_tolerates_token_auth_latency() {
+        let probe = probe_gh_auth_with(GH_DOCTOR_TIMEOUT, || {
+            std::thread::sleep(Duration::from_millis(400));
+            Some(TOKEN_AUTH_STATUS.to_string())
+        });
+        let GhAuthProbe::Answered(status) = probe else {
+            panic!("token-auth probe must answer under GH_DOCTOR_TIMEOUT, got {probe:?}");
+        };
+        assert_eq!(status.active.as_deref(), Some("mac-duetto"));
+    }
+
+    /// Why: a probe that outruns its bound must report UNKNOWN, never an empty
+    /// (i.e. "unauthenticated") answer (#5032).
+    /// Test: itself.
+    #[test]
+    fn probe_beyond_bound_is_inconclusive() {
+        let probe = probe_gh_auth_with(Duration::from_millis(50), || {
+            std::thread::sleep(Duration::from_millis(500));
+            Some(TOKEN_AUTH_STATUS.to_string())
+        });
+        match probe {
+            GhAuthProbe::Inconclusive(reason) => assert!(reason.contains("did not answer")),
+            other => panic!("expected Inconclusive, got {other:?}"),
+        }
+    }
+
+    /// Why: a `gh` that cannot be executed is also an unknown auth state, not a
+    /// negative one.
+    /// Test: itself.
+    #[test]
+    fn probe_missing_gh_is_inconclusive() {
+        match probe_gh_auth_with(GH_DOCTOR_TIMEOUT, || None) {
+            GhAuthProbe::Inconclusive(reason) => assert!(reason.contains("could not be run")),
+            other => panic!("expected Inconclusive, got {other:?}"),
+        }
+    }
+
+    /// Why: the happy path must parse straight through the seam.
+    /// Test: itself.
+    #[test]
+    fn probe_answered_parses_accounts() {
+        let probe = probe_gh_auth_with(GH_DOCTOR_TIMEOUT, || Some(MULTI_AUTH_STATUS.to_string()));
+        assert_eq!(
+            probe,
+            GhAuthProbe::Answered(parse_gh_account_status_from_auth_status(MULTI_AUTH_STATUS))
+        );
     }
 
     /// Why: `is_ambiguous` is the load-bearing predicate for the warnings; assert

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -100,6 +100,12 @@ use doctor_skill_unmanaged::check_skill_unmanaged;
 mod doctor_agent_skills;
 use doctor_agent_skills::check_agent_skills;
 
+// #5032: the `gh_account` probe, split out when its tri-state outcome
+// (authenticated / unauthenticated / could-not-tell) pushed this file over cap.
+#[path = "doctor_gh_account.rs"]
+mod doctor_gh_account;
+use doctor_gh_account::check_gh_account;
+
 // Split out to keep this file under the 500-SLOC production cap (issue #2940
 // — the tm hook contamination / foreign claude-mpm hook conflict probe).
 #[path = "doctor_hooks_hygiene.rs"]
@@ -456,83 +462,6 @@ fn build_oauth_token_check(
             CheckStatus::Ok,
             "managed-session auth looks configured",
         )
-    }
-}
-
-/// Probe the active `gh` github.com account and warn on ambiguity.
-///
-/// Why (#gh-account-awareness): `tm` shells to `gh` for PR merges, issue edits,
-/// and managed spawn, but had no awareness of WHICH github.com identity was
-/// active. When several accounts are logged in, `gh` uses whichever is active —
-/// and a non-admin active account silently broke `gh pr merge --admin` with
-/// "1 approving review required". This probe makes the active account visible in
-/// `tm doctor` and warns when the dangerous multi-account ambiguity exists.
-/// What: off-loads the two bounded `gh`/`hosts.yml` reads to `spawn_blocking`
-/// (so the async executor is not stalled), then folds the result via
-/// [`build_gh_account_check`]. Advisory only: `Warn` when multiple accounts are
-/// logged in or `gh` is unauthenticated, `Ok` for a single clear account — never
-/// a hard `Fail`, since a missing/other `gh` identity is not a broken stack.
-/// Test: `build_gh_account_check` covers every branch;
-/// `gh_account_check_is_advisory_only` asserts it never returns `Fail`.
-async fn check_gh_account() -> DoctorCheck {
-    let (active, accounts) = tokio::task::spawn_blocking(|| {
-        let active = crate::core::gh_account::active_gh_account();
-        let accounts = crate::core::gh_account::logged_in_gh_accounts();
-        (active, accounts)
-    })
-    .await
-    .unwrap_or((None, Vec::new()));
-    build_gh_account_check(active, accounts)
-}
-
-/// Fold the resolved gh-account state into a [`DoctorCheck`] (pure).
-///
-/// Why: keeping the verdict logic pure makes every branch — single account,
-/// multi-account ambiguity, active-unknown, and unauthenticated — unit-testable
-/// without a live `gh`.
-/// What: returns `Warn` when `accounts` holds more than one login (naming them
-/// and pointing at `gh auth switch`), `Warn` when no account is detected, `Warn`
-/// when accounts exist but none is marked active, and `Ok` for a single clear
-/// active account. Never `Fail` — this is advisory.
-/// Test: `build_gh_account_check_single_ok`, `build_gh_account_check_multi_warn`,
-/// `build_gh_account_check_unauthenticated_warn`,
-/// `gh_account_check_is_advisory_only`.
-fn build_gh_account_check(active: Option<String>, accounts: Vec<String>) -> DoctorCheck {
-    if accounts.len() > 1 {
-        let list = accounts.join(", ");
-        let active_str = active.as_deref().unwrap_or("unknown");
-        return DoctorCheck::new(
-            "gh_account",
-            CheckStatus::Warn,
-            format!(
-                "{} github.com accounts logged in ({list}); active is `{active_str}`. \
-                 `gh` (and `gh pr merge --admin`) uses the ACTIVE account — if merges \
-                 fail on permissions, run `gh auth switch` to the repo owner.",
-                accounts.len()
-            ),
-        );
-    }
-    match active {
-        Some(login) => DoctorCheck::new(
-            "gh_account",
-            CheckStatus::Ok,
-            format!("active gh account: `{login}`"),
-        ),
-        None if accounts.is_empty() => DoctorCheck::new(
-            "gh_account",
-            CheckStatus::Warn,
-            "gh is not authenticated (no github.com account) — `gh` calls will fail; \
-             run `gh auth login`"
-                .to_string(),
-        ),
-        None => DoctorCheck::new(
-            "gh_account",
-            CheckStatus::Warn,
-            format!(
-                "gh authenticated ({}) but no active account is set — run `gh auth switch`",
-                accounts.join(", ")
-            ),
-        ),
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/doctor_gh_account.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_gh_account.rs
@@ -1,0 +1,114 @@
+//! The `tm doctor` `gh_account` check — which github.com identity `gh` will use.
+//!
+//! Why: `tm` shells to `gh` for PR merges, issue edits, and managed spawn, and
+//! the identity it picks is invisible until something fails on permissions. This
+//! check surfaces it, and flags the multi-account ambiguity that once made
+//! `gh pr merge --admin` fail with "1 approving review required".
+//! What: [`check_gh_account`] runs one bounded `gh auth status` off the async
+//! executor; [`build_gh_account_check`] folds the outcome into a
+//! [`DoctorCheck`].
+//! Test: `doctor_gh_account_tests.rs` covers every branch of the fold.
+//!
+//! Split out of `doctor.rs` by #5032 — the tri-state probe pushed that file
+//! past the 500-SLOC production cap.
+
+use crate::core::doctor::{CheckStatus, DoctorCheck};
+use crate::core::gh_account::{GhAccountStatus, GhAuthProbe};
+
+/// Probe the active `gh` github.com account and warn on ambiguity.
+///
+/// Why: see the module header — the active identity is otherwise invisible.
+/// What: off-loads ONE bounded `gh auth status` to `spawn_blocking` (so the
+/// async executor is not stalled), then folds the result via
+/// [`build_gh_account_check`]. Advisory only: `Warn` when multiple accounts are
+/// logged in or `gh` is unauthenticated, `Ok` for a single clear account — never
+/// a hard `Fail`, since a missing/other `gh` identity is not a broken stack.
+/// Test: `build_gh_account_check` covers every branch;
+/// `gh_account_check_is_advisory_only` asserts it never returns `Fail`.
+pub(super) async fn check_gh_account() -> DoctorCheck {
+    // #5032: `gh auth status` is the only source that sees env-token auth, and
+    // doctor is not latency-sensitive — so probe it under the doctor's own bound
+    // instead of the statusline-era 250 ms one that timed out on every token.
+    let probe = tokio::task::spawn_blocking(|| {
+        crate::core::gh_account::probe_gh_auth(crate::core::gh_account::GH_DOCTOR_TIMEOUT)
+    })
+    .await
+    .unwrap_or_else(|e| GhAuthProbe::Inconclusive(format!("gh probe task failed: {e}")));
+    build_gh_account_check(probe)
+}
+
+/// Fold a [`GhAuthProbe`] into a [`DoctorCheck`] (pure).
+///
+/// Why: keeping the verdict logic pure makes every branch — single account,
+/// multi-account ambiguity, active-unknown, unauthenticated, and inconclusive —
+/// unit-testable without a live `gh`.
+/// What: an [`GhAuthProbe::Inconclusive`] probe reports the state as UNKNOWN and
+/// never as a negative (#5032 — a timed-out probe used to render as "not
+/// authenticated"). For an answered probe: `Warn` when it holds more than one
+/// login (naming them and pointing at `gh auth switch`), `Warn` when no account
+/// is present, `Warn` when accounts exist but none is marked active, and `Ok`
+/// for a single clear active account. Never `Fail` — this is advisory.
+/// Test: `build_gh_account_check_single_ok`, `build_gh_account_check_multi_warn`,
+/// `build_gh_account_check_unauthenticated_warn`,
+/// `build_gh_account_check_inconclusive_is_not_unauthenticated`,
+/// `gh_account_check_is_advisory_only`.
+pub(super) fn build_gh_account_check(probe: GhAuthProbe) -> DoctorCheck {
+    let GhAccountStatus {
+        active,
+        logged_in: accounts,
+    } = match probe {
+        GhAuthProbe::Answered(status) => status,
+        // #5032: an unfinished probe is not a negative answer — say so.
+        GhAuthProbe::Inconclusive(reason) => {
+            return DoctorCheck::new(
+                "gh_account",
+                CheckStatus::Warn,
+                format!(
+                    "could not determine the gh account — auth state UNKNOWN, \
+                     not necessarily unauthenticated ({reason}). Run `gh auth status` \
+                     by hand to see the real state."
+                ),
+            );
+        }
+    };
+    if accounts.len() > 1 {
+        let list = accounts.join(", ");
+        let active_str = active.as_deref().unwrap_or("unknown");
+        return DoctorCheck::new(
+            "gh_account",
+            CheckStatus::Warn,
+            format!(
+                "{} github.com accounts logged in ({list}); active is `{active_str}`. \
+                 `gh` (and `gh pr merge --admin`) uses the ACTIVE account — if merges \
+                 fail on permissions, run `gh auth switch` to the repo owner.",
+                accounts.len()
+            ),
+        );
+    }
+    match active {
+        Some(login) => DoctorCheck::new(
+            "gh_account",
+            CheckStatus::Ok,
+            format!("active gh account: `{login}`"),
+        ),
+        None if accounts.is_empty() => DoctorCheck::new(
+            "gh_account",
+            CheckStatus::Warn,
+            "gh is not authenticated (no github.com account) — `gh` calls will fail; \
+             run `gh auth login`"
+                .to_string(),
+        ),
+        None => DoctorCheck::new(
+            "gh_account",
+            CheckStatus::Warn,
+            format!(
+                "gh authenticated ({}) but no active account is set — run `gh auth switch`",
+                accounts.join(", ")
+            ),
+        ),
+    }
+}
+
+#[cfg(test)]
+#[path = "doctor_gh_account_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/doctor_gh_account_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_gh_account_tests.rs
@@ -1,0 +1,81 @@
+//! Unit tests for the `gh_account` doctor check — every branch of
+//! `build_gh_account_check`, driven by a constructed [`GhAuthProbe`] so no live
+//! `gh` is needed.
+//! Test: this module IS the test suite for `super`.
+
+use super::*;
+
+/// An answered probe carrying `active` and `logged_in` — the shape
+/// [`build_gh_account_check`] folds (#5032 changed it from two loose arguments).
+fn answered(active: Option<&str>, logged_in: &[&str]) -> GhAuthProbe {
+    GhAuthProbe::Answered(GhAccountStatus {
+        active: active.map(str::to_string),
+        logged_in: logged_in.iter().map(|s| s.to_string()).collect(),
+    })
+}
+
+#[test]
+fn build_gh_account_check_single_ok() {
+    // A single clear active account is healthy (Ok), naming the login.
+    let check = build_gh_account_check(answered(Some("bobmatnyc"), &["bobmatnyc"]));
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert_eq!(check.name, "gh_account");
+    assert!(check.message.contains("bobmatnyc"));
+}
+
+#[test]
+fn build_gh_account_check_multi_warn() {
+    // Multiple logged-in accounts is the ambiguity that hid the admin-merge
+    // bug: Warn, name both accounts, and point at `gh auth switch`.
+    let check = build_gh_account_check(answered(Some("bob-duetto"), &["bob-duetto", "bobmatnyc"]));
+    assert_eq!(check.status, CheckStatus::Warn);
+    assert!(check.message.contains("bob-duetto"));
+    assert!(check.message.contains("bobmatnyc"));
+    assert!(check.message.contains("gh auth switch"));
+}
+
+#[test]
+fn build_gh_account_check_unauthenticated_warn() {
+    // No account at all: Warn (advisory), not Fail, pointing at `gh auth login`.
+    let check = build_gh_account_check(answered(None, &[]));
+    assert_eq!(check.status, CheckStatus::Warn);
+    assert!(check.message.contains("not authenticated"));
+    assert!(check.message.contains("gh auth login"));
+}
+
+#[test]
+fn build_gh_account_check_inconclusive_is_not_unauthenticated() {
+    // #5032: a probe that could not finish must read as UNKNOWN. It must not
+    // claim the definite negative the unauthenticated arm claims.
+    let check = build_gh_account_check(GhAuthProbe::Inconclusive(
+        "`gh auth status` did not answer within 5s".to_string(),
+    ));
+    assert_eq!(check.status, CheckStatus::Warn);
+    assert!(check.message.contains("UNKNOWN"));
+    assert!(check.message.contains("did not answer"));
+    assert!(!check.message.contains("gh is not authenticated"));
+    assert!(!check.message.contains("gh auth login"));
+    // The two states must be distinguishable in the rendered output.
+    assert_ne!(
+        check.message,
+        build_gh_account_check(answered(None, &[])).message
+    );
+}
+
+#[test]
+fn gh_account_check_is_advisory_only() {
+    // Every branch must be advisory — never a hard Fail.
+    for check in [
+        build_gh_account_check(answered(Some("a"), &["a"])),
+        build_gh_account_check(answered(Some("a"), &["a", "b"])),
+        build_gh_account_check(answered(None, &[])),
+        build_gh_account_check(answered(None, &["a"])),
+        build_gh_account_check(GhAuthProbe::Inconclusive("timed out".to_string())),
+    ] {
+        assert_ne!(
+            check.status,
+            CheckStatus::Fail,
+            "gh_account must never Fail"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/daemon/doctor_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_tests.rs
@@ -4,8 +4,9 @@
 //! `hooks_foreign_conflict` probes).
 //! What: exercises `index_present`, the memory/search reachability probes,
 //! the managed-workspace-scoped `agents` probe, the full `run_doctor` check
-//! roster, the `gh_account` / `oauth_token` advisory checks, and the
-//! worktree-orphan scan.
+//! roster, the `oauth_token` advisory check, and the worktree-orphan scan.
+//! The `gh_account` check has its own suite in `doctor_gh_account_tests.rs`
+//! (#5032).
 //! Test: this module IS the test suite for `super`.
 
 use super::*;
@@ -201,59 +202,6 @@ async fn run_doctor_produces_thirty_two_checks() {
     // Count derived from the list above, never a standalone literal:
     // adding a check is then a one-line edit here (#4090 review LOW-1).
     assert_eq!(report.checks.len(), expected.len());
-}
-
-#[test]
-fn build_gh_account_check_single_ok() {
-    // A single clear active account is healthy (Ok), naming the login.
-    let check =
-        build_gh_account_check(Some("bobmatnyc".to_string()), vec!["bobmatnyc".to_string()]);
-    assert_eq!(check.status, CheckStatus::Ok);
-    assert_eq!(check.name, "gh_account");
-    assert!(check.message.contains("bobmatnyc"));
-}
-
-#[test]
-fn build_gh_account_check_multi_warn() {
-    // Multiple logged-in accounts is the ambiguity that hid the admin-merge
-    // bug: Warn, name both accounts, and point at `gh auth switch`.
-    let check = build_gh_account_check(
-        Some("bob-duetto".to_string()),
-        vec!["bob-duetto".to_string(), "bobmatnyc".to_string()],
-    );
-    assert_eq!(check.status, CheckStatus::Warn);
-    assert!(check.message.contains("bob-duetto"));
-    assert!(check.message.contains("bobmatnyc"));
-    assert!(check.message.contains("gh auth switch"));
-}
-
-#[test]
-fn build_gh_account_check_unauthenticated_warn() {
-    // No account at all: Warn (advisory), not Fail, pointing at `gh auth login`.
-    let check = build_gh_account_check(None, Vec::new());
-    assert_eq!(check.status, CheckStatus::Warn);
-    assert!(check.message.contains("not authenticated"));
-    assert!(check.message.contains("gh auth login"));
-}
-
-#[test]
-fn gh_account_check_is_advisory_only() {
-    // Every branch must be advisory — never a hard Fail.
-    for check in [
-        build_gh_account_check(Some("a".to_string()), vec!["a".to_string()]),
-        build_gh_account_check(
-            Some("a".to_string()),
-            vec!["a".to_string(), "b".to_string()],
-        ),
-        build_gh_account_check(None, Vec::new()),
-        build_gh_account_check(None, vec!["a".to_string()]),
-    ] {
-        assert_ne!(
-            check.status,
-            CheckStatus::Fail,
-            "gh_account must never Fail"
-        );
-    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #5032

`tm doctor` bounded its `gh auth status` probe at 250 ms — a constant taken
from the statusline's render path — while validating a `GH_TOKEN` /
`GITHUB_TOKEN` login costs a network round trip. Measured 281–389 ms by the
reporter, 366–373 ms on this machine. Every probe timed out, and the timeout
was folded into the same `None` an unauthenticated `gh` produces, so the check
told a fully authenticated operator "gh is not authenticated".

Both failure modes named in the issue are addressed:

- **The bound.** The doctor now uses its own `GH_DOCTOR_TIMEOUT` (5 s, matching
  the existing `GH_ENFORCE_TIMEOUT`) instead of the shared 250 ms one. Nothing
  latency-sensitive is left on this path: the statusline reads `hosts.yml`
  directly via `gh_account_status_local` and never spawns `gh`, so the render
  argument for a short bound no longer applies. Five seconds is an order of
  magnitude above the measured round trip and still bounds a wedged `gh`.
- **The wrong fact.** The probe returns a tri-state `GhAuthProbe`: `Answered`
  (an empty account list IS a definite "not authenticated") or `Inconclusive`
  carrying the reason. An inconclusive probe renders as "auth state UNKNOWN,
  not necessarily unauthenticated (…)" — a different message from the
  unauthenticated arm, and it no longer points at `gh auth login`.

Active login and the logged-in list now come from ONE `gh auth status` (the
old code ran `--active` and then the full status), so the check costs a single
round trip. `doctor.rs` hit 515 SLOC, so the check moved to
`doctor_gh_account.rs` with its own test file, in this PR.

## Regression proof — RED before, GREEN after

`doctor_probe_tolerates_token_auth_latency` drives the production seam with the
production constant and a runner that takes 400 ms, the measured token-auth
latency. With the pre-fix 250 ms bound restored:

```
thread 'core::gh_account::tests::doctor_probe_tolerates_token_auth_latency' panicked at
crates/trusty-mpm/src/core/gh_account.rs:799:13:
token-auth probe must answer under GH_DOCTOR_TIMEOUT, got Inconclusive("`gh auth status` did not answer within 250ms")

test result: FAILED. 41 passed; 1 failed; 0 ignored; 0 measured; 4918 filtered out
```

With the fix:

```
test core::gh_account::tests::doctor_probe_tolerates_token_auth_latency ... ok
test result: ok. 42 passed; 0 failed; 0 ignored; 0 measured; 4918 filtered out
```

Live check against the reporter's environment shape — `hosts.yml` absent, env
token only — through the real production probe:

```
LIVE PROBE: Answered(GhAccountStatus { active: Some("bobmatnyc"), logged_in: ["bobmatnyc"] })
```

## Gates — test ladder rung 3 (localized behavior inside `trusty-mpm`)

```
cargo fmt --check                                    # EXIT=0
cargo check -p trusty-mpm --all-targets              # EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   # EXIT=0
cargo test -p trusty-mpm                             # EXIT=0 — 4953 passed; 0 failed; 7 ignored (lib)
bash scripts/check_line_cap.sh                       # 3998 files, 0 violations
bash scripts/check_changelog_fragment.sh             # fragment present and valid
bash scripts/check_sld.sh                            # 0 errors, 0 warnings
```

Rung 3 and not 4: the change stays inside `trusty-mpm`, and no crate in the
workspace depends on it as a library.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
