### PR TITLE
fix(scripts): preflight CHECK 5 stops when the SemVer gate compared nothing

### DIFF
--- a/.github/workflows/tag-publish-parity.yml
+++ b/.github/workflows/tag-publish-parity.yml
@@ -13,6 +13,12 @@
 # this job runs the self-test's fixtures, not the gate.
 #
 # Pure git + shell, no Rust toolchain, so it stays a fast standalone job.
+#
+# It carries a second preflight self-test of the same shape (#5620): CHECK 5's
+# decision, which likewise only runs where a publish runs and is likewise worth
+# nothing if it cannot fail. The workflow name stays as it is — renaming it
+# would rename the required checks — and the jobs are separate so a red one
+# names which decision broke.
 name: Tag/publish parity
 
 on:
@@ -22,6 +28,8 @@ on:
       - "scripts/check-tag-publish-parity.sh"
       - "scripts/check-tag-publish-parity-selftest.sh"
       - "scripts/preflight-publish.sh"
+      - "scripts/preflight-check5-selftest.sh"
+      - "scripts/test-data/preflight-check5/**"
       - ".github/workflows/tag-publish-parity.yml"
   pull_request:
     # Explicit activity types, matching line-cap.yml: `edited` catches a
@@ -32,6 +40,8 @@ on:
       - "scripts/check-tag-publish-parity.sh"
       - "scripts/check-tag-publish-parity-selftest.sh"
       - "scripts/preflight-publish.sh"
+      - "scripts/preflight-check5-selftest.sh"
+      - "scripts/test-data/preflight-check5/**"
       - ".github/workflows/tag-publish-parity.yml"
 
 concurrency:
@@ -54,3 +64,21 @@ jobs:
 
       - name: Tag/publish parity self-test
         run: bash scripts/check-tag-publish-parity-selftest.sh
+
+  # Same shape, same reason, different check (#5620). CHECK 5's decision — what
+  # preflight concludes from check_semver.sh's output — can only matter where a
+  # publish runs, and its failing branches are the whole product: reading exit 0
+  # as a pass is what let trusty-review 0.16.0 ship with `0 crate(s) checked,
+  # 0 skipped, 1 inventory NOT computed`. So CI runs the fixtures, not the gate.
+  #
+  # Separate job rather than another step, so a red one names which decision
+  # broke. Pure shell over captured output: no cargo, no rustdoc, no network.
+  check5-decision:
+    name: CHECK 5 decision self-test (0 compared must never print PASS)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Preflight CHECK 5 decision self-test
+        run: bash scripts/preflight-check5-selftest.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,19 @@ path enforces it (#5050, moved to release-time by #5149).**
 `scripts/preflight-publish.sh` CHECK 5 runs `cargo-semver-checks` against the
 crate's latest crates.io release immediately before `cargo publish`, and its
 nonzero exit is the absolute stop — that is what blocks a bad upload, since
-`cargo publish` runs locally and no CI job can stop it. The tag-push workflow
+`cargo publish` runs locally and no CI job can stop it.
+
+🔴 **A zero exit is NOT the mirror of that stop (#5620).** `check_semver.sh`
+exits 0 both when it compared a crate and found nothing wrong and when it
+compared nothing at all, and CHECK 5 used to read only the status — so
+`0 crate(s) checked, 0 skipped, 1 inventory NOT computed` printed `[PASS]` and
+trusty-review 0.16.0 shipped with its public-API delta unexamined by any tool.
+CHECK 5 now reads the counts: **`0 compared` and `[PASS]` are unreachable
+together.** A recorded skip prints `[SKIP]` and permits, a blind gate prints
+`[FAIL]` and stops, and `PREFLIGHT_SEMVER_UNVERIFIED="<reason>"` downgrades a
+blind gate to `[WARN]` — a reason string, never a boolean, and never for a
+standing machine limitation (that belongs in
+`scripts/semver-checks-feature-exclusions.tsv`). The tag-push workflow
 `.github/workflows/semver-checks.yml` reports the same check independently.
 Cargo's 0.x rule applies: for a `0.y.z` crate the breaking bump is the MINOR
 position. A workspace `cargo check` can never catch this class of break — the

--- a/docs/reference/semver-gate.md
+++ b/docs/reference/semver-gate.md
@@ -22,6 +22,12 @@ matters because a crates.io publish is irreversible except by yank, and a gate
 that reported only after the upload would have caught #4088 with nothing left to
 do about it.
 
+A zero exit from `check_semver.sh` is **not** the mirror of that stop, and
+reading it as one is how a blind gate shipped a release
+([#5620](https://github.com/bobmatnyc/trusty-tools/issues/5620)). What CHECK 5
+concludes from a given run is in
+[Reading the gate's result](#reading-the-gates-result).
+
 The tag-push workflow is a second, independent report. In this project's
 sequence the tag is pushed *before* `cargo publish` (steps 4 then 6), so a red
 run there is still visible in time to call the release off. Same
@@ -311,6 +317,18 @@ inventory that could not be computed prints `NO INVENTORY` and is counted
 separately in the summary line, so "no inventory" never reads as "inventory
 clean".
 
+**It cannot fail the gate, but it can stop a publish**
+([#5620](https://github.com/bobmatnyc/trusty-tools/issues/5620)). Those two are
+different questions and used to be answered by the same number. `check_semver.sh`
+exits 0 on a blind inventory and still does: whether an already-breaking release
+is *permitted* is settled by its version numbers, not by an advisory run. But for
+a `0.y.z` crate every minor bump is major under Cargo's rules, so the pass/fail
+arm never fires and **the inventory is the only coverage that release ever gets**
+— and an inventory that did not run is no coverage at all. Whether to publish on
+no coverage is `preflight-publish.sh`'s question, and CHECK 5 now reads the
+gate's counts rather than its exit status alone. See
+[Reading the gate's result](#reading-the-gates-result) below.
+
 What it costs is roughly four minutes of rustdoc, on already-breaking releases
 only. What it buys is the one question the skip could not answer: did an
 unintended break ride along with the intended one?
@@ -338,9 +356,74 @@ construction — the fix #4088 asked for and deferred.
 cargo semver-checks --explain constructible_struct_adds_field
 ```
 
-There is no override flag on CHECK 5, and none is needed. Bumping the breaking
-position turns the run into an advisory inventory, so a false positive and a real
-break have the same safe remedy.
+A break has no override, and none is needed. Bumping the breaking position turns
+the run into an advisory inventory, so a false positive and a real break have the
+same safe remedy. `PREFLIGHT_SEMVER_UNVERIFIED` covers a gate that could not run,
+never one that ran and said no.
+
+## Reading the gate's result
+
+`check_semver.sh` answers "did the API break?". `preflight-publish.sh` CHECK 5
+answers "do we publish?", and those are not the same question — the gate exits 0
+both when it compared a crate and found nothing wrong and when it compared
+nothing at all. Until
+[#5620](https://github.com/bobmatnyc/trusty-tools/issues/5620) CHECK 5 read only
+that status, so the trusty-review 0.16.0 publish printed
+
+```
+[PASS] semver: semver gate: scanned (explicit); 0 crate(s) checked, 0 skipped,
+       1 inventory NOT computed — OK.
+```
+
+and proceeded. `cargo-semver-checks` had exited 101 without comparing anything:
+0.15.0 cannot be documented, because `pipeline/mapreduce/reduce.rs` imports a
+`profile`-gated item unconditionally, so rustdoc never built the baseline. The
+gate said exactly that, on its own line and in its summary. The loss was in the
+decision laid over it, where "0 examined" and "0 wrong" were rendered with the
+same word.
+
+CHECK 5 now reads the gate's counts. **`0 compared` and `[PASS]` are unreachable
+together**, and each outcome gets its own label:
+
+| Label | When | Publish |
+|---|---|---|
+| `[PASS]` | ≥ 1 crate compared — a pass/fail run or an inventory that ran — and no unbumped break | proceeds |
+| `[SKIP]` | 0 compared because no comparison was *possible*: no baseline on crates.io, no library target, or a row in `semver-checks-crate-exclusions.tsv` | proceeds |
+| `[WARN]` | 0 compared because the gate was blind, and `PREFLIGHT_SEMVER_UNVERIFIED` named a reason | proceeds |
+| `[FAIL]` | a computed break, a blind gate with no override, or a gate that malfunctioned | stops |
+
+`[PASS]` states how many crates it compared. `[SKIP]` permits without an override
+because the reason is a fact about the crate that is already recorded in a
+reviewable file — but it says `NOT VERIFIED`, because nothing looked at the API.
+
+### The override, and what it is not for
+
+```bash
+PREFLIGHT_SEMVER_UNVERIFIED="0.15.0 baseline references the profile module removed in #5611" \
+  bash scripts/preflight-publish.sh trusty-review
+```
+
+It takes a **reason, not a boolean**, echoed verbatim into the `[WARN]` line and
+into the run's final summary. `=1` would record that a publish was allowed
+without recording why, and why is the entire content of the disclosure; a stale
+reason string also reads as obviously stale where a stale `1` reads as normal.
+Set with no reason, it is refused rather than honoured.
+
+**A permanent capability gap is not what it is for.** When a machine class can
+never build a crate's feature set — no CUDA for `trusty-search`'s `cuda` feature,
+no libdbus — the lever is a row in
+`scripts/semver-checks-feature-exclusions.tsv`: durable, reviewable in a diff,
+greppable a year later. Route a standing gap through the environment variable and
+within a week it lives in a Makefile target or a shell profile and the `[WARN]`
+scrolls past every publish. An override that is always set is not an override.
+
+This does loosen one arm. A gate that fails for an environmental reason
+([#5440](https://github.com/bobmatnyc/trusty-tools/issues/5440): libdbus absent,
+`cargo-semver-checks` aborts, exit 3) used to block unconditionally — the wrong
+reason, but a safe outcome. It is now override-able, so such a machine can
+publish with a `[WARN]` and an unverified delta. The trade: a gate that blocks
+good publishes for reasons the operator cannot fix gets routed around eventually,
+and a disclosed `[WARN]` beats an undisclosed workaround.
 
 ## Running it locally
 
@@ -364,6 +447,17 @@ gh workflow run semver-checks.yml -f crate=trusty-common
 ```
 
 ## Self-test
+
+Two files, one per side of the seam. `scripts/check_semver_selftest.sh` drives
+the gate over captured `cargo-semver-checks` output;
+`scripts/preflight-check5-selftest.sh` drives CHECK 5's *decision* over captured
+gate output. The second exists because the decision was the half that had no test
+— running the real gate costs four minutes of rustdoc per case — and the half
+that was wrong in #5620. Its twelve cases pin every way the gate can conclude
+against the label and the permit/stop it must produce, including the
+trusty-review 0.16.0 run verbatim as case 3. `PREFLIGHT_SELFTEST_SCRIPT` points
+it at another revision of `preflight-publish.sh`, which is how the red-then-green
+is shown: against `main` before the fix, case 3 permits the publish.
 
 `scripts/check_semver_selftest.sh` runs first in CI. Cases 1-4 cover the gate's
 original fail-open surfaces — an unscanned diff and an unreachable or erroring

--- a/scripts/preflight-check5-selftest.sh
+++ b/scripts/preflight-check5-selftest.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+#
+# preflight-check5-selftest.sh — the decision half of preflight CHECK 5 (#5620).
+#
+# Why: scripts/check_semver.sh has had a self-test since #5050, and it has been
+#   catching real fail-opens ever since. What had none was the DECISION laid over
+#   its output — preflight-publish.sh CHECK 5, which reads the gate's result and
+#   answers the only question that matters at that moment: publish, or stop.
+#   That half was untested because running the real gate costs four minutes of
+#   rustdoc per case, and it is the half that was wrong. On 2026-08-12 the
+#   trusty-review 0.16.0 publish printed
+#
+#       [PASS] semver: semver gate: scanned (explicit); 0 crate(s) checked,
+#              0 skipped, 1 inventory NOT computed — OK.
+#
+#   and proceeded. cargo-semver-checks had exited 101 without comparing
+#   anything: trusty-review 0.15.0 cannot be documented, so rustdoc never built
+#   the baseline. The gate said so on its own line. CHECK 5 read the exit status
+#   alone, and exit 0 was PASS.
+#
+# What: drives semver_decide() — preflight-publish.sh's whole CHECK 5 decision —
+#   over captured check_semver.sh output, asserting the label AND the permit/stop
+#   for every way that gate can conclude. No network, no cargo, no rustdoc; the
+#   file runs in under a second.
+#
+# THE GOVERNING ASSERTION, which every case is a special case of: a reader of
+#   CHECK 5's output can tell "nothing was wrong" from "nothing was examined".
+#   Mechanically, `0 crate(s) compared` and `[PASS]` are unreachable together.
+#
+#   Cases, and the arm each pins:
+#     1.  checked clean       real tga 2.18.0 -> 2.19.0, 196 pass. [PASS], and
+#                             the line states how many crates it compared. This
+#                             is what proves the rest fail on classification
+#                             rather than because every path now stops.
+#     2.  inventory clean     the advisory arm RAN. An inventory is a
+#                             comparison, so [PASS] — the fix must not turn the
+#                             already-breaking arm into a blanket stop.
+#     3.  inventory blind     THE DEFECT, verbatim from the trusty-review
+#                             0.16.0 run. Gate exit 0, nothing compared.
+#                             Must [FAIL] and must NOT print PASS.
+#     4.  recorded skip       real trusty-mpm, excluded by
+#                             semver-checks-crate-exclusions.tsv. Nothing was
+#                             comparable, which is a fact about the crate and
+#                             already recorded in a reviewable file — so it
+#                             permits, and still must not print PASS.
+#     5.  no verdict (exit 3) real registry-unreachable run. Already stopped
+#                             before this change; pinned so the other arm's fix
+#                             does not quietly loosen it.
+#     6.  break (exit 1)      a computed verdict. Must [FAIL] with the
+#                             version-bump remedy.
+#     7.  no summary          gate exit 0 with a summary line this script cannot
+#                             parse. Must [FAIL]: a reworded summary makes CHECK
+#                             5 red, never green.
+#     8.  gate malfunction    an undocumented exit status. Must [FAIL].
+#
+#   Override cases, all against case 3's blind fixture:
+#     9.  reason given        [WARN], permits, and echoes the reason VERBATIM —
+#                             the reason is the entire disclosure, so a run that
+#                             swallowed it would record that a publish was
+#                             allowed without recording why.
+#     10. empty reason        set with nothing in it is REFUSED, not honoured.
+#     11. break + override    a computed break is NOT override-able. The
+#                             override covers a gate that could not run; exit 1
+#                             is the gate running and saying no.
+#     12. skip is unforced    the recorded-skip arm permits with NO override set,
+#                             so trusty-mpm does not need one on every publish.
+#                             An override that is always set is not an override.
+#
+# HOW IT DRIVES THE REAL DECISION: the two functions are lifted out of
+#   preflight-publish.sh BY PATTERN (the same awk-extraction
+#   check_semver_selftest.sh uses for release_type), so this exercises the
+#   shipped definitions rather than a copy that can drift. check5_semver's own
+#   `bash "${REPO_ROOT}/scripts/check_semver.sh"` call is satisfied by pointing
+#   REPO_ROOT at a scratch directory whose scripts/check_semver.sh replays a
+#   fixture at a chosen exit status — so the run under test goes through the
+#   real invocation path, not a shortcut around it.
+#
+#   PREFLIGHT_SELFTEST_SCRIPT points this at a different preflight-publish.sh.
+#   Its purpose is the red-then-green proof: run against
+#   `git show <pre-fix-commit>:scripts/preflight-publish.sh` and case 3 FAILS,
+#   because that revision prints [PASS] over the trusty-review run. A regression
+#   test that passes on both sides of the fix is not testing the fix.
+#
+# Usage:  bash scripts/preflight-check5-selftest.sh
+# Exit:   0 when every case behaves; 1 (naming the case) when one does not.
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). No cargo, no
+# network, no python3.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_TOP="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+UNDER_TEST="${PREFLIGHT_SELFTEST_SCRIPT:-${REPO_TOP}/scripts/preflight-publish.sh}"
+FIXTURES="${REPO_TOP}/scripts/test-data/preflight-check5"
+
+if [[ ! -f "$UNDER_TEST" ]]; then
+  echo "SELF-TEST FAIL: no script to test at ${UNDER_TEST}" >&2
+  exit 1
+fi
+
+PASSED=0
+FAILED=0
+
+fail_case() {
+  echo "SELF-TEST FAIL: $1" >&2
+  shift
+  printf '%s\n' "$@" | sed 's/^/       /' >&2
+  FAILED=$((FAILED + 1))
+}
+
+pass_case() {
+  echo "  ok  $1"
+  PASSED=$((PASSED + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Scratch repo root. check5_semver invokes
+# "${REPO_ROOT}/scripts/check_semver.sh"; this one replays a fixture.
+# ---------------------------------------------------------------------------
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/preflight-check5.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+mkdir -p "${SCRATCH}/scripts"
+cat > "${SCRATCH}/scripts/check_semver.sh" <<'STUB'
+#!/usr/bin/env bash
+# Stub gate for preflight-check5-selftest.sh: replays a captured check_semver.sh
+# run at a chosen exit status. The DECISION is what is under test, not the gate.
+cat "$SELFTEST_FIXTURE"
+exit "${SELFTEST_GATE_RC:-0}"
+STUB
+chmod +x "${SCRATCH}/scripts/check_semver.sh"
+
+# ---------------------------------------------------------------------------
+# run_decision <fixture> <gate-rc> — run the shipped CHECK 5 end to end and
+# print `<return-status>` on the first line, then everything it wrote.
+#
+# The subshell is what lets a case set PREFLIGHT_SEMVER_UNVERIFIED (or not) and
+# have the next case see a clean environment.
+# ---------------------------------------------------------------------------
+run_decision() {
+  local fixture="$1" gate_rc="$2"
+  (
+    set +e
+    # Globals the extracted functions read. MANIFEST appears only in the
+    # break-remedy text; PKG_NAME/VERSION are the crate under test.
+    PKG_NAME="stub-crate"
+    VERSION="9.9.9"
+    MANIFEST="crates/stub-crate/Cargo.toml"
+    REPO_ROOT="$SCRATCH"
+    TMP_SEMVER="$(mktemp "${SCRATCH}/log.XXXXXX")"
+    SELFTEST_FIXTURE="${FIXTURES}/${fixture}"
+    SELFTEST_GATE_RC="$gate_rc"
+    export SELFTEST_FIXTURE SELFTEST_GATE_RC
+
+    # The shipped definitions, lifted by pattern so a drifted copy cannot be
+    # what passes. A missing function is a loud failure, not a silent skip.
+    eval "$(awk '/^semver_decide\(\) \{/,/^\}/' "$UNDER_TEST")"
+    eval "$(awk '/^check5_semver\(\) \{/,/^\}/' "$UNDER_TEST")"
+    if ! declare -f check5_semver > /dev/null; then
+      echo "127"
+      echo "SELF-TEST HARNESS: ${UNDER_TEST} defines no check5_semver()"
+      exit 0
+    fi
+
+    out="$(check5_semver 2>&1)"
+    rc=$?
+    echo "$rc"
+    printf '%s\n' "$out"
+  )
+}
+
+# ---------------------------------------------------------------------------
+# assert_case <name> <fixture> <gate-rc> <want-status> <want-label>
+#             <must-contain> <must-not-contain, or "-">
+# ---------------------------------------------------------------------------
+assert_case() {
+  local name="$1" fixture="$2" gate_rc="$3" want_status="$4" want_label="$5"
+  local must_have="$6" must_not="$7"
+  local raw status body
+
+  raw="$(run_decision "$fixture" "$gate_rc")"
+  status="$(printf '%s\n' "$raw" | sed -n 1p)"
+  body="$(printf '%s\n' "$raw" | sed '1d')"
+
+  if [[ "$status" != "$want_status" ]]; then
+    fail_case "${name}: expected the decision to return ${want_status} (0=permit, 1=stop), got ${status}" "$body"
+  elif [[ "$body" != *"$want_label"* ]]; then
+    fail_case "${name}: expected a ${want_label} line" "$body"
+  elif [[ "$body" != *"$must_have"* ]]; then
+    fail_case "${name}: output never said '${must_have}'" "$body"
+  elif [[ "$must_not" != "-" && "$body" == *"$must_not"* ]]; then
+    fail_case "${name}: output wrongly said '${must_not}'" "$body"
+  else
+    pass_case "${name} -> ${want_label}, decision returns ${status}"
+  fi
+}
+
+# ===========================================================================
+# 1-8. Every way check_semver.sh can conclude.
+#
+# The `[PASS]` in the must-not column of cases 3-8 is the governing assertion:
+# whatever else those arms print, they must not be readable as a verified pass.
+# ===========================================================================
+assert_case "checked clean" \
+  checked-clean.out 0 0 "[PASS]" "1 crate(s) compared" "NOT VERIFIED"
+
+assert_case "inventory clean (advisory arm ran)" \
+  inventory-clean.out 0 0 "[PASS]" "1 crate(s) compared" "NOT VERIFIED"
+
+assert_case "inventory blind (the trusty-review 0.16.0 defect)" \
+  inventory-blind.out 0 1 "[FAIL]" "0 crate(s) were compared" "[PASS]"
+
+assert_case "recorded skip (excluded crate)" \
+  recorded-skip.out 0 0 "[SKIP]" "NOT VERIFIED" "[PASS]"
+
+assert_case "no verdict (gate exit 3)" \
+  no-verdict.out 3 1 "[FAIL]" "0 crate(s) were compared" "[PASS]"
+
+assert_case "computed break (gate exit 1)" \
+  break.out 1 1 "[FAIL]" "without a breaking" "[PASS]"
+
+assert_case "summary line unparsable" \
+  no-summary.out 0 1 "[FAIL]" "no summary line this script could read" "[PASS]"
+
+assert_case "gate malfunction (undocumented exit)" \
+  checked-clean.out 42 1 "[FAIL]" "not one of its documented statuses" "[PASS]"
+
+# ===========================================================================
+# 9-12. The override.
+# ===========================================================================
+REASON="0.15.0 baseline references the profile module removed in #5611"
+
+# --- 9. A reason permits, warns, and is echoed verbatim.
+raw="$(PREFLIGHT_SEMVER_UNVERIFIED="$REASON" run_decision inventory-blind.out 0)"
+status="$(printf '%s\n' "$raw" | sed -n 1p)"
+body="$(printf '%s\n' "$raw" | sed '1d')"
+if [[ "$status" != "0" ]]; then
+  fail_case "override/reason: an explicit reason must permit the publish (got ${status})" "$body"
+elif [[ "$body" != *"[WARN]"* ]]; then
+  fail_case "override/reason: expected a [WARN] line" "$body"
+elif [[ "$body" == *"[PASS]"* ]]; then
+  fail_case "override/reason: an overridden publish printed PASS — it verified nothing" "$body"
+elif [[ "$body" != *"$REASON"* ]]; then
+  fail_case "override/reason: the reason was not echoed verbatim, so the run records THAT a publish was allowed but not WHY" "$body"
+else
+  pass_case "an override with a reason -> [WARN], permits, echoes the reason verbatim"
+fi
+
+# --- 10. Set with nothing in it is refused. A bare flag records no why.
+raw="$(PREFLIGHT_SEMVER_UNVERIFIED="   " run_decision inventory-blind.out 0)"
+status="$(printf '%s\n' "$raw" | sed -n 1p)"
+body="$(printf '%s\n' "$raw" | sed '1d')"
+if [[ "$status" != "1" ]]; then
+  fail_case "override/empty: an override with no reason must be refused, not honoured (got ${status})" "$body"
+elif [[ "$body" != *"set but empty"* ]]; then
+  fail_case "override/empty: stopped without saying the override was empty" "$body"
+else
+  pass_case "an override set with no reason is refused"
+fi
+
+# --- 11. A computed break is not override-able.
+raw="$(PREFLIGHT_SEMVER_UNVERIFIED="$REASON" run_decision break.out 1)"
+status="$(printf '%s\n' "$raw" | sed -n 1p)"
+body="$(printf '%s\n' "$raw" | sed '1d')"
+if [[ "$status" != "1" ]]; then
+  fail_case "override/break: the override cleared a COMPUTED break — it covers a gate that could not run, not one that ran and said no (got ${status})" "$body"
+elif [[ "$body" != *"[FAIL]"* ]]; then
+  fail_case "override/break: expected a [FAIL] line" "$body"
+else
+  pass_case "a computed break is not override-able"
+fi
+
+# --- 12. The recorded-skip arm needs no override. trusty-mpm is excluded and
+#         publishes routinely; if that arm demanded a reason string, the variable
+#         would be set on every one of its publishes and stop being deliberate.
+raw="$(run_decision recorded-skip.out 0)"
+status="$(printf '%s\n' "$raw" | sed -n 1p)"
+body="$(printf '%s\n' "$raw" | sed '1d')"
+if [[ "$status" != "0" ]]; then
+  fail_case "skip/unforced: a recorded skip must permit with NO override set (got ${status})" "$body"
+elif [[ "$body" == *"PREFLIGHT_SEMVER_UNVERIFIED"* ]]; then
+  fail_case "skip/unforced: the skip arm asked for an override, which would make the variable permanent for every excluded crate" "$body"
+else
+  pass_case "a recorded skip permits without an override"
+fi
+
+echo
+if [[ "$FAILED" -ne 0 ]]; then
+  echo "preflight-check5-selftest: ${PASSED} passed, ${FAILED} FAILED." >&2
+  exit 1
+fi
+echo "preflight-check5-selftest: ${PASSED} passed, 0 failed."

--- a/scripts/preflight-check5-selftest.sh
+++ b/scripts/preflight-check5-selftest.sh
@@ -137,6 +137,8 @@ chmod +x "${SCRATCH}/scripts/check_semver.sh"
 # The subshell is what lets a case set PREFLIGHT_SEMVER_UNVERIFIED (or not) and
 # have the next case see a clean environment.
 # ---------------------------------------------------------------------------
+# shellcheck disable=SC2034  # PKG_NAME/VERSION/MANIFEST/REPO_ROOT/TMP_SEMVER are read
+# by the functions eval'd below, which shellcheck cannot see into.
 run_decision() {
   local fixture="$1" gate_rc="$2"
   (

--- a/scripts/preflight-publish.sh
+++ b/scripts/preflight-publish.sh
@@ -75,10 +75,10 @@
 #     push, but a CI job cannot stop a `cargo publish` a human runs locally —
 #     it reports, this blocks.
 #
-#     No override flag exists, and none is needed: the correct response to a
+#     A BREAK HAS NO OVERRIDE, and none is needed: the correct response to a
 #     firing gate is to bump the breaking position, which the gate then records
-#     as an already-breaking release and skips. A false positive and a real
-#     break have the same safe remedy.
+#     as an already-breaking release and inventories. A false positive and a
+#     real break have the same safe remedy.
 #
 #     A NON-VERDICT IS NOT A VERDICT (#5289). check_semver.sh exits 1 only when
 #     it computed a verdict that says break, and 3 when it could not compute one
@@ -87,6 +87,18 @@
 #     stop the publish; only the first is reported as "your API changed". The
 #     remedy above applies to exit 1 — for exit 3 the remedy is to fix the gate
 #     and re-run, never to bump a version on evidence that does not exist.
+#
+#     NEITHER IS EXIT 0 (#5620). The gate exits 0 on an ADVISORY run it could
+#     not compute — an already-breaking release is permitted by its version
+#     numbers whatever the run did — and CHECK 5 read that status alone, so
+#     `0 crate(s) checked, 0 skipped, 1 inventory NOT computed` printed [PASS]
+#     and trusty-review 0.16.0 shipped with its public-API delta unexamined by
+#     any tool. The decision now reads the gate's counts, not just its status:
+#     `0 compared` and [PASS] are unreachable together. Recorded skips print
+#     [SKIP] and permit; a blind gate prints [FAIL] and stops unless
+#     PREFLIGHT_SEMVER_UNVERIFIED names a reason, which prints [WARN] and
+#     permits. See semver_decide below for why the reason is a string and why a
+#     permanent capability gap belongs in the feature-exclusions TSV instead.
 #
 #     Requires `cargo-semver-checks` (`cargo install cargo-semver-checks@0.50.0
 #     --locked`). Its absence is a FAILURE with that remedy, never a skip.
@@ -162,16 +174,21 @@
 #                     nonzero if any non-overridden check failed.
 #   -h|--help         print this header and exit 0.
 #
-# Exit codes: 0 = all checks passed (or downgraded via PREFLIGHT_ALLOW_DETACHED
-#   for check 1 only) — safe to `cargo publish`. Nonzero = at least one check
-#   failed — DO NOT PUBLISH. 2 = usage error (bad arguments).
+# Exit codes: 0 = all checks passed, or were downgraded by an override that
+#   named itself in the output (PREFLIGHT_ALLOW_DETACHED for check 1,
+#   PREFLIGHT_SEMVER_UNVERIFIED for check 5) — safe to `cargo publish`, with
+#   whatever the WARN lines disclosed. Nonzero = at least one check failed —
+#   DO NOT PUBLISH. 2 = usage error (bad arguments).
 #
 # Test: checks 1-4 are exercised manually — they are bound to the network, the
 #   real crates.io registry, and the logged-in gh account, none of which a
-#   fixture can stand in for. Check 5 has scripts/check_semver_selftest.sh and
-#   check 6 has scripts/check-tag-publish-parity-selftest.sh, and check 7 has
-#   scripts/check-ui-bundle-freshness-selftest.sh — all three drive every
-#   failure branch of the delegated script against fixtures.
+#   fixture can stand in for. Check 5 has TWO: check_semver_selftest.sh drives
+#   the delegated gate, and preflight-check5-selftest.sh drives THIS script's
+#   decision over that gate's output — the half that was wrong in #5620 and the
+#   half a four-minute rustdoc run had kept untested. Check 6 has
+#   scripts/check-tag-publish-parity-selftest.sh and check 7 has
+#   scripts/check-ui-bundle-freshness-selftest.sh; both drive every failure
+#   branch of the delegated script against fixtures.
 #   Verified by construction:
 #     (a) FAIL mode — run from an unmerged feature branch (HEAD != origin/main)
 #         to demonstrate check 1 failing.
@@ -476,34 +493,217 @@ check4_version_not_live() {
 # check_semver.sh never computed one; saying "your API changed" there would be
 # inventing a result, and telling the operator to bump the breaking position
 # would be advising a version change on no evidence. Either way the publish
-# still stops — both branches return 1.
+# still stops.
 check5_semver() {
   local log="${TMP_SEMVER}" rc=0
 
   SKIP_UI_BUILD=1 bash "${REPO_ROOT}/scripts/check_semver.sh" \
     --crate "$PKG_NAME" > "$log" 2>&1 || rc=$?
 
-  if [ "$rc" -eq 0 ]; then
-    echo "[PASS] semver: $(tail -1 "$log")" >&2
-    return 0
-  fi
+  semver_decide "$rc" "$log" "$PKG_NAME" "$VERSION"
+}
 
-  if [ "$rc" -eq 3 ]; then
-    echo "[FAIL] semver: NO VERDICT for ${PKG_NAME} ${VERSION} — the gate could not run:" >&2
+# ---------------------------------------------------------------------------
+# semver_decide <gate-exit> <gate-log> <package> <version> — turn one
+# check_semver.sh run into a publish decision. Returns 0 to permit, 1 to stop.
+#
+# Why this is a separate function from check5_semver: the decision is the part
+# that was wrong, and running the real gate takes four minutes of rustdoc, so
+# the decision had no test. Split out, it is driven against captured gate output
+# by scripts/preflight-check5-selftest.sh — including the verbatim
+# trusty-review 0.16.0 run this function exists because of.
+#
+# THE DEFECT (#5620, measured on the trusty-review 0.16.0 publish). CHECK 5 used
+#   to read check_semver.sh's exit status and nothing else, so exit 0 printed
+#
+#       [PASS] semver: semver gate: scanned (explicit); 0 crate(s) checked,
+#              0 skipped, 1 inventory NOT computed — OK.
+#
+#   and the publish proceeded. Underneath, cargo-semver-checks had exited 101
+#   having compared nothing: trusty-review 0.15.0 cannot be documented, because
+#   pipeline/mapreduce/reduce.rs imports a `profile`-gated item unconditionally,
+#   so rustdoc never built the baseline. The gate reported that honestly on its
+#   own line and in its summary — the loss was here, where "0 examined" and
+#   "0 wrong" were rendered with the same word.
+#
+#   check_semver.sh is right to exit 0 there and that is deliberately unchanged:
+#   whether an already-breaking release is PERMITTED is decided by the version
+#   numbers, not by the advisory run, and a gate that reddened over a permitted
+#   break would teach people to ignore it. What the advisory run carries is the
+#   only coverage a 0.x MINOR bump ever gets — every one of them is major under
+#   Cargo's rules, so the PASS/FAIL arm never fires and the inventory is it.
+#   An inventory that could not be computed is therefore zero coverage, and
+#   whether to publish on zero coverage is THIS script's question to answer.
+#
+# THE INVARIANT: `0 compared` and `[PASS]` are unreachable together. A pass
+#   states how many crates it actually compared and refuses to print PASS when
+#   that number is zero. Four outcomes, four labels, so a reader can always tell
+#   "nothing was wrong" from "nothing was examined":
+#
+#     [PASS] >= 1 crate compared, no unbumped break. The only verified outcome.
+#     [SKIP] 0 compared because no comparison was POSSIBLE — no baseline on
+#            crates.io, no library target, or a row in
+#            semver-checks-crate-exclusions.tsv. A fact about the crate, already
+#            recorded in a reviewable file, so it permits without an override.
+#            It is not a statement that the API is unchanged.
+#     [WARN] 0 compared because the gate was BLIND, and PREFLIGHT_SEMVER_UNVERIFIED
+#            named a reason to accept that. Permits; never prints PASS.
+#     [FAIL] a computed break, a blind gate with no override, or a gate that
+#            malfunctioned.
+#
+# THE OVERRIDE IS FOR SITUATIONAL BLINDNESS ONLY, and it takes a REASON, not a
+#   boolean:
+#
+#       PREFLIGHT_SEMVER_UNVERIFIED="0.15.0 baseline references the profile
+#                                    module removed in #5611"
+#
+#   echoed verbatim into the WARN line. `=1` records that a publish was allowed
+#   but not why, and why is the entire content of the disclosure; a stale reason
+#   string also reads as obviously stale where a stale `1` reads as normal. Set
+#   with no reason, it is refused rather than honoured.
+#
+#   A PERMANENT CAPABILITY GAP IS NOT WHAT THIS IS FOR. When a machine class can
+#   never build a crate's feature set — no CUDA for trusty-search's `cuda`
+#   feature, no libdbus — the lever is a row in
+#   scripts/semver-checks-feature-exclusions.tsv: durable, reviewable in a diff,
+#   and greppable a year later. Route a standing gap through this variable and
+#   within a week it lives in a Makefile target or a shell profile and the WARN
+#   scrolls past every publish. An override that is always set is not an
+#   override.
+#
+# A COMPUTED BREAK IS NEVER OVERRIDE-ABLE. The override answers "the gate could
+#   not run"; exit 1 is the gate running and saying no. Its remedy is unchanged
+#   and is not a variable.
+#
+# Test: scripts/preflight-check5-selftest.sh.
+# ---------------------------------------------------------------------------
+SEMVER_NOT_VERIFIED=""
+
+semver_decide() {
+  local rc="$1" log="$2" pkg="$3" version="$4"
+  local summary checked skipped inventoried blind compared blind_why
+
+  # --- A COMPUTED VERDICT THAT SAYS BREAK. Not override-able.
+  if [ "$rc" -eq 1 ]; then
+    echo "[FAIL] semver: public-API check failed for ${pkg} ${version}:" >&2
     sed 's/^/       /' "$log" >&2
-    echo "       cargo-semver-checks never completed a comparison, so whether this" >&2
-    echo "       release breaks the public API is UNKNOWN. That is not a reason to" >&2
-    echo "       bump the version and not a reason to publish." >&2
-    echo "       Fix the gate (see the NO SEMVER VERDICT block above), then re-run." >&2
+    echo "       Publishing this would ship a breaking change without a breaking" >&2
+    echo "       version bump — the #4088 shape that yanked trusty-analyze 0.7.3." >&2
+    echo "       Bump the breaking position in ${MANIFEST:-the crate manifest}," >&2
+    echo "       or make the change non-breaking (#[non_exhaustive] on public" >&2
+    echo "       structs and enums). PREFLIGHT_SEMVER_UNVERIFIED does not apply to" >&2
+    echo "       a verdict — it covers a gate that could not run, not one that ran." >&2
     return 1
   fi
 
-  echo "[FAIL] semver: public-API check failed for ${PKG_NAME} ${VERSION}:" >&2
+  # --- THE GATE MALFUNCTIONED. 2 is a usage error and anything else is
+  #     undocumented; both mean this script invoked the gate wrongly or the gate
+  #     itself is broken. Those have a direct remedy, so no override applies.
+  if [ "$rc" -ne 0 ] && [ "$rc" -ne 3 ]; then
+    echo "[FAIL] semver: check_semver.sh exited ${rc} for ${pkg} ${version}, which is" >&2
+    echo "       not one of its documented statuses (0 clean, 1 break, 2 usage, 3 no verdict):" >&2
+    sed 's/^/       /' "$log" >&2
+    echo "       Nothing was compared. Fix the invocation or the gate, then re-run." >&2
+    return 1
+  fi
+
+  # --- Read the counts out of the gate's own summary line, e.g.
+  #       semver gate: scanned (explicit); 2 crate(s) checked, 1 skipped,
+  #       1 inventoried (advisory), 1 inventory NOT computed — OK.
+  #     Fails CLOSED: a summary this cannot parse is treated as blindness, so a
+  #     future reword of that line turns CHECK 5 red rather than green.
+  summary=""
+  checked=""
+  skipped=""
+  inventoried=0
+  blind=0
+  if [ "$rc" -eq 0 ]; then
+    summary="$(grep -E '[0-9]+ crate\(s\) checked' "$log" | tail -1 || true)"
+    if [ -n "$summary" ]; then
+      checked="$(printf '%s\n' "$summary" | sed -nE 's/.*[^0-9]([0-9]+) crate\(s\) checked.*/\1/p')"
+      skipped="$(printf '%s\n' "$summary" | sed -nE 's/.*[^0-9]([0-9]+) skipped.*/\1/p')"
+      inventoried="$(printf '%s\n' "$summary" | sed -nE 's/.*[^0-9]([0-9]+) inventoried.*/\1/p')"
+      blind="$(printf '%s\n' "$summary" | sed -nE 's/.*[^0-9]([0-9]+) inventory NOT computed.*/\1/p')"
+      inventoried="${inventoried:-0}"
+      blind="${blind:-0}"
+    fi
+  fi
+
+  if [ "$rc" -eq 3 ]; then
+    blind_why="check_semver.sh reported NO VERDICT (exit 3) — it never completed a comparison"
+  elif [ -z "$checked" ] || [ -z "$skipped" ]; then
+    blind_why="check_semver.sh exited 0 but printed no summary line this script could read, so how much it compared is unknown"
+  elif [ "$blind" -gt 0 ]; then
+    blind_why="the advisory inventory could not be computed for ${blind} crate(s) — cargo-semver-checks completed no check run, which for an already-breaking 0.x release is the ONLY coverage there was"
+  else
+    blind_why=""
+  fi
+
+  # --- VERIFIED. Both arms compare: the PASS/FAIL arm runs the bump-requirement
+  #     lints, the INVENTORY arm runs the full breaking-change lint set as
+  #     advice. Either one examined the API.
+  if [ -z "$blind_why" ]; then
+    compared=$((checked + inventoried))
+    if [ "$compared" -ge 1 ]; then
+      echo "[PASS] semver: ${compared} crate(s) compared against their previous crates.io release — ${summary}" >&2
+      return 0
+    fi
+
+    # --- NOTHING WAS COMPARABLE. Recorded skips only: no baseline exists, no
+    #     library target, or an exclusion row. Permitted, never called a pass.
+    if [ "$skipped" -ge 1 ]; then
+      SEMVER_NOT_VERIFIED="0 crate(s) compared — ${skipped} recorded skip(s)"
+      echo "[SKIP] semver: NOT VERIFIED — 0 crate(s) were compared for ${pkg} ${version}." >&2
+      echo "       ${summary}" >&2
+      grep -E '^SKIP ' "$log" | sed 's/^/       /' >&2 || true
+      echo "       No comparison was POSSIBLE (no baseline on crates.io, no library" >&2
+      echo "       target, or a row in semver-checks-crate-exclusions.tsv), so the" >&2
+      echo "       publish is permitted. This is not a statement that the public API" >&2
+      echo "       is unchanged — nothing looked at it." >&2
+      return 0
+    fi
+
+    # 0 compared, 0 skipped, nothing blind: the gate reported on no crate at
+    # all. Unreachable via --crate, and if it becomes reachable it is blindness.
+    blind_why="check_semver.sh reported on no crate at all — ${summary}"
+  fi
+
+  # --- BLIND. Stop, unless an explicit reason says to accept it.
+  if [ -n "${PREFLIGHT_SEMVER_UNVERIFIED+x}" ]; then
+    if [ -z "$(printf '%s' "${PREFLIGHT_SEMVER_UNVERIFIED}" | tr -d '[:space:]')" ]; then
+      echo "[FAIL] semver: PREFLIGHT_SEMVER_UNVERIFIED is set but empty." >&2
+      echo "       This override records WHY an unverified publish was accepted, so it" >&2
+      echo "       takes a reason, not a flag:" >&2
+      echo "         PREFLIGHT_SEMVER_UNVERIFIED=\"<why the gate cannot compare this release>\"" >&2
+      echo "       Refusing to proceed on an override with nothing in it." >&2
+      return 1
+    fi
+    SEMVER_NOT_VERIFIED="0 crate(s) compared — overridden: ${PREFLIGHT_SEMVER_UNVERIFIED}"
+    echo "[WARN] semver: UNVERIFIED — ${pkg} ${version} is being published without a" >&2
+    echo "       public-API comparison, and PREFLIGHT_SEMVER_UNVERIFIED permits it." >&2
+    echo "       Blind because: ${blind_why}." >&2
+    echo "       Reason given: ${PREFLIGHT_SEMVER_UNVERIFIED}" >&2
+    echo "       Nothing compared this release's API against its predecessor. If it" >&2
+    echo "       breaks something unintentionally, no tool caught it — the reason" >&2
+    echo "       above is the whole record of why that was accepted." >&2
+    echo "       A gap that is a property of the MACHINE, not of this release" >&2
+    echo "       (no CUDA, no libdbus), belongs in" >&2
+    echo "       scripts/semver-checks-feature-exclusions.tsv instead. An override" >&2
+    echo "       that is always set is not an override." >&2
+    return 0
+  fi
+
+  echo "[FAIL] semver: NOT VERIFIED for ${pkg} ${version} — 0 crate(s) were compared:" >&2
   sed 's/^/       /' "$log" >&2
-  echo "       Publishing this would ship a breaking change without a breaking" >&2
-  echo "       version bump — the #4088 shape that yanked trusty-analyze 0.7.3." >&2
-  echo "       Bump the breaking position in ${MANIFEST}, or make the change" >&2
-  echo "       non-breaking (#[non_exhaustive] on public structs and enums)." >&2
+  echo "       Blind because: ${blind_why}." >&2
+  echo "       Whether this release breaks the public API is UNKNOWN. That is not a" >&2
+  echo "       reason to bump the version and not a reason to publish." >&2
+  echo "       Fix the gate and re-run. If it cannot be fixed for THIS release," >&2
+  echo "       publish with the reason recorded:" >&2
+  echo "         PREFLIGHT_SEMVER_UNVERIFIED=\"<why>\" scripts/preflight-publish.sh ${pkg}" >&2
+  echo "       If instead this machine can NEVER check this crate, add a row to" >&2
+  echo "       scripts/semver-checks-feature-exclusions.tsv rather than overriding" >&2
+  echo "       every publish." >&2
   return 1
 }
 
@@ -585,7 +785,15 @@ if [ "$FAILURES" -gt 0 ]; then
   exit 1
 fi
 
-echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 7 checks. Safe to publish." >&2
+if [ -n "${SEMVER_NOT_VERIFIED:-}" ]; then
+  # #5620: "passed all 7 checks" must not absorb a check-5 outcome that verified
+  # nothing. The same distinction the check line draws, drawn again at the line
+  # an operator is most likely to read on its own.
+  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 7 checks, but the" >&2
+  echo "  public API was NOT VERIFIED: ${SEMVER_NOT_VERIFIED}. See the check 5 line above." >&2
+else
+  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 7 checks. Safe to publish." >&2
+fi
 echo "preflight-publish: after 'cargo publish', confirm what cargo actually recorded:" >&2
 echo "  scripts/check-tag-publish-parity.sh --vcs-info auto ${PKG_NAME} ${VERSION}" >&2
 exit 0

--- a/scripts/test-data/preflight-check5/README.md
+++ b/scripts/test-data/preflight-check5/README.md
@@ -1,0 +1,26 @@
+# preflight CHECK 5 decision fixtures (issue #5620)
+
+Captured `scripts/check_semver.sh` output, replayed by
+`scripts/preflight-check5-selftest.sh` through a stub gate. They exist so the
+self-test can prove `preflight-publish.sh`'s CHECK 5 tells a verified pass from
+a blind one without spending four minutes of rustdoc per case — which is why
+that decision had no test until the trusty-review 0.16.0 publish shipped
+unverified.
+
+These are the GATE's output, not `cargo-semver-checks`' — the other direction of
+the same seam. `scripts/test-data/semver-gate/` holds the tool-side fixtures that
+`check_semver_selftest.sh` replays into the gate; these hold the gate-side
+fixtures that this self-test replays into the decision.
+
+The one edit applied to a captured file: absolute paths rewritten to
+`/CARGO_HOME` and `/HOME`, so no author's worktree path is committed.
+
+| File | Stub exit | Captured from |
+|---|---|---|
+| `inventory-blind.out` | 0 | **The defect.** `bash scripts/check_semver.sh --crate trusty-review` on `main` at `293dfa68`, 2026-08-12. `cargo-semver-checks` exits 101 because 0.15.0 cannot be documented — `pipeline/mapreduce/reduce.rs:28` imports a `profile`-gated item unconditionally — so the gate reports `0 crate(s) checked, 0 skipped, 1 inventory NOT computed` and exits 0. This is the run that printed `[PASS]` on the real publish. |
+| `checked-clean.out` | 0 | `--crate tga`, the real 2.18.0 -> 2.19.0 comparison: `196 checks: 196 pass, 58 skip`, `1 crate(s) checked`. The happy path, and what proves the other cases stop on classification rather than because every path now stops. |
+| `recorded-skip.out` | 0 | `--crate trusty-mpm`, excluded by `semver-checks-crate-exclusions.tsv`. `0 crate(s) checked, 1 skipped` — nothing compared, for a reason that is a fact about the crate. |
+| `no-verdict.out` | 3 | `SEMVER_GATE_INDEX_BASE=http://127.0.0.1:1 --crate trusty-common`. A real unreachable-registry run: the gate refuses to grant a skip it cannot justify. |
+| `inventory-clean.out` | 0 | **Composed** from real captures: the gate's own `INVENTORY` lines around a real `196 checks: 196 pass, 58 skip` summary. No crate in this workspace sits at an already-breaking bump with a buildable baseline right now, so the advisory-arm-that-succeeded shape has to be assembled. It pins that an inventory COUNTS as a comparison — the fix must not turn the already-breaking arm into a blanket stop. |
+| `break.out` | 1 | **Synthetic**, carrying the gate's real `VERDICT: BREAK` remediation text. The decision keys on exit 1 alone here, so a captured break would add bytes and no coverage. |
+| `no-summary.out` | 0 | **Synthetic.** A clean-looking run whose final line does not match the summary shape the decision parses. Pins the fail-closed rule: a reworded summary turns CHECK 5 red, never green. |

--- a/scripts/test-data/preflight-check5/break.out
+++ b/scripts/test-data/preflight-check5/break.out
@@ -1,0 +1,20 @@
+toolchain: rustc 1.97.1 (selected over ambient 1.94.1; the scratch resolution ignores Cargo.lock)
+CHECK stub-crate: 1.3.4 -> 1.3.5 (patch release), 11 feature(s)
+     Checked [   1.204s] 223 checks: 214 pass, 9 fail, 0 warn, 31 skip
+     Summary semver requires new major version: 9 major and 0 minor checks failed
+FAIL stub-crate: cargo semver-checks exited 100 against baseline 1.3.4
+
+VERDICT: BREAK. A public API change requires a matching version bump.
+
+  0.x crates: a break needs the MINOR position (0.28.1 -> 0.29.0).
+  1.x+ crates: a break needs the MAJOR position (1.3.4 -> 2.0.0).
+
+Either bump the version in the crate's Cargo.toml, or make the change
+non-breaking. `#[non_exhaustive]` on a struct/enum makes future field and
+variant additions non-breaking by construction — the fix #4088 asked for.
+
+Explain any lint:  cargo semver-checks --explain <lint_name>
+
+This is not advisory. #4088: trusty-common 0.22.5 shipped exactly this class of
+break as a patch bump and bricked `cargo install` for every dependent on a
+^0.22 floor, costing trusty-analyze 0.7.3 a yank.

--- a/scripts/test-data/preflight-check5/checked-clean.out
+++ b/scripts/test-data/preflight-check5/checked-clean.out
@@ -1,0 +1,15 @@
+toolchain: rustc 1.97.1 (selected over ambient 1.94.1; the scratch resolution ignores Cargo.lock)
+CHECK tga: 2.18.0 -> 2.19.0 (minor release), 1 feature(s)
+    Building tga v2.19.0 (current)
+       Built [  30.163s] (current)
+     Parsing tga v2.19.0 (current)
+      Parsed [   0.062s] (current)
+    Building tga v2.18.0 (baseline)
+       Built [  29.192s] (baseline)
+     Parsing tga v2.18.0 (baseline)
+      Parsed [   0.057s] (baseline)
+    Checking tga v2.18.0 -> v2.19.0 (minor change)
+     Checked [   0.058s] 196 checks: 196 pass, 58 skip
+     Summary no semver update required
+    Finished [  61.533s] tga
+semver gate: scanned (explicit); 1 crate(s) checked, 0 skipped — OK.

--- a/scripts/test-data/preflight-check5/inventory-blind.out
+++ b/scripts/test-data/preflight-check5/inventory-blind.out
@@ -1,0 +1,49 @@
+toolchain: rustc 1.97.1 (selected over ambient 1.94.1; the scratch resolution ignores Cargo.lock)
+INVENTORY trusty-review: 0.15.0 -> 0.16.0 is already a breaking release — no bump can be owed, so this run is advisory: what does it break?
+    Building trusty-review v0.16.0 (current)
+       Built [   1.560s] (current)
+     Parsing trusty-review v0.16.0 (current)
+      Parsed [   0.027s] (current)
+    Building trusty-review v0.15.0 (baseline)
+error: running cargo-doc on crate 'trusty-review' failed with output:
+-----
+ Documenting trusty-review v0.15.0
+error[E0433]: cannot find `profile` in `crate`
+  --> /CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-review-0.15.0/src/pipeline/mapreduce/reduce.rs:28:5
+   |
+28 |     profile::synthesizer::jaccard_similarity,
+   |     ^^^^^^^ unresolved import
+   |
+note: found an item that was configured out
+  --> /CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/trusty-review-0.15.0/src/lib.rs:52:9
+   |
+51 | #[cfg(feature = "profile")]
+   |       ------------------- the item is gated behind the `profile` feature
+52 | pub mod profile;
+   |         ^^^^^^^
+help: a similar path exists
+   |
+28 |     aws_config::profile::synthesizer::jaccard_similarity,
+   |     ++++++++++++
+
+For more information about this error, try `rustc --explain E0433`.
+error: could not document `trusty-review`
+
+-----
+
+error: failed to build rustdoc for crate trusty-review v0.15.0
+note: this is usually due to a compilation error in the crate,
+      and is unlikely to be a bug in cargo-semver-checks
+note: the following command can be used to reproduce the error:
+      cargo new --lib example &&
+          cd example &&
+          echo '[workspace]' >> Cargo.toml &&
+          cargo add trusty-review@=0.15.0 --no-default-features --features http-server,mcp,report &&
+          cargo check &&
+          cargo doc
+
+error: aborting due to failure to build rustdoc for crate trusty-review v0.15.0
+NO INVENTORY trusty-review: cargo semver-checks exited 101 and never completed a check run.
+             The release is still permitted (0.15.0 -> 0.16.0 already carries the break),
+             but WHAT it breaks is unknown. Fix the run above to get the list.
+semver gate: scanned (explicit); 0 crate(s) checked, 0 skipped, 1 inventory NOT computed — OK.

--- a/scripts/test-data/preflight-check5/inventory-clean.out
+++ b/scripts/test-data/preflight-check5/inventory-clean.out
@@ -1,0 +1,15 @@
+toolchain: rustc 1.97.1 (selected over ambient 1.94.1; the scratch resolution ignores Cargo.lock)
+INVENTORY stub-crate: 0.2.0 -> 0.3.0 is already a breaking release — no bump can be owed, so this run is advisory: what does it break?
+    Building stub-crate v0.3.0 (current)
+       Built [  23.936s] (current)
+     Parsing stub-crate v0.3.0 (current)
+      Parsed [   0.027s] (current)
+    Building stub-crate v0.2.0 (baseline)
+       Built [  21.402s] (baseline)
+     Parsing stub-crate v0.2.0 (baseline)
+      Parsed [   0.024s] (baseline)
+    Checking stub-crate v0.2.0 -> v0.3.0 (minor change)
+     Checked [   0.871s] 196 checks: 196 pass, 58 skip
+     Summary no semver update required
+INVENTORY stub-crate: no breaking changes found against v0.2.0.
+semver gate: scanned (explicit); 0 crate(s) checked, 0 skipped, 1 inventoried (advisory) — OK.

--- a/scripts/test-data/preflight-check5/no-summary.out
+++ b/scripts/test-data/preflight-check5/no-summary.out
@@ -1,0 +1,5 @@
+toolchain: rustc 1.97.1 (selected over ambient 1.94.1; the scratch resolution ignores Cargo.lock)
+CHECK stub-crate: 0.31.0 -> 0.31.1 (minor release), 4 feature(s)
+     Checked [   0.871s] 196 checks: 196 pass, 58 skip
+     Summary no semver update required
+semver gate: examined 1 package, all clean.

--- a/scripts/test-data/preflight-check5/no-verdict.out
+++ b/scripts/test-data/preflight-check5/no-verdict.out
@@ -1,0 +1,5 @@
+toolchain: rustc 1.97.1 (selected over ambient 1.94.1; the scratch resolution ignores Cargo.lock)
+FAIL: TOOL ERROR — could not reach the crates.io index for 'trusty-common'.
+      http://127.0.0.1:1/tr/us/trusty-common — curl failed.
+      Whether a baseline exists is UNKNOWN, so no skip may be granted.
+      This is NOT a pass (issue #5050).

--- a/scripts/test-data/preflight-check5/recorded-skip.out
+++ b/scripts/test-data/preflight-check5/recorded-skip.out
@@ -1,0 +1,3 @@
+toolchain: rustc 1.97.1 (selected over ambient 1.94.1; the scratch resolution ignores Cargo.lock)
+SKIP trusty-mpm: excluded by scripts/semver-checks-crate-exclusions.tsv — binary-only consumer surface: installed as the `tm` executable via `cargo install trusty-mpm`, and a binary user gets a whole new executable, so library API compatibility is meaningless to them. Zero workspace packages depend on it (re-checked by the gate) and crates.io reported 0 reverse dependencies on 2026-08-12.
+semver gate: scanned (explicit); 0 crate(s) checked, 1 skipped — OK.


### PR DESCRIPTION
`preflight-publish.sh` CHECK 5 read `check_semver.sh`'s exit status and nothing else, so a gate that compared nothing exited 0 and printed `[PASS]`.

Measured on the real trusty-review 0.16.0 publish: `[PASS] semver: … 0 crate(s) checked, 0 skipped, 1 inventory NOT computed — OK.` Underneath, `cargo-semver-checks` had exited 101 — 0.15.0 cannot be documented because `pipeline/mapreduce/reduce.rs` imports a `profile`-gated item unconditionally — so rustdoc never built the baseline and a breaking release shipped with its public-API delta unexamined by any tool.

## Two arms, both closed

- **Arm B (fail-open, what shipped):** baseline unbuildable → inventory not computed → gate exits 0 → `[PASS]` → publish proceeds.
- **Arm A (fail-closed for the wrong reason, #5440):** libdbus absent → `cargo-semver-checks` aborts → gate exits 3 → publish blocked.

Both now route through one rule instead of one status check: **`0 compared` and `[PASS]` are unreachable together.** CHECK 5 reads the gate's counts, and every way it can conclude maps to exactly one of four labels — `[PASS]` (≥1 compared, clean), `[SKIP]` (nothing was comparable, permits), `[WARN]` (blind, overridden, permits), `[FAIL]` (break, or blind with no override). A summary line the decision cannot parse is blindness, so a reword turns CHECK 5 red rather than green.

`check_semver.sh` is unchanged and deliberately so. It reported the blindness honestly on its own line and in its summary, and whether an already-breaking release is *permitted* is settled by its version numbers. What to do about zero coverage is preflight's question.

## The override

`PREFLIGHT_SEMVER_UNVERIFIED="<reason>"` downgrades a blind gate to `[WARN]` and permits. A reason string, not a boolean — `=1` records that a publish was allowed without recording why, and set with no reason it is refused. A computed break is not override-able: the override covers a gate that could not run, not one that ran and said no.

It is not for a standing machine limitation. No CUDA, no libdbus — that belongs in `scripts/semver-checks-feature-exclusions.tsv`, which already exists for it, is reviewable in a diff, and is greppable a year later. An override that is always set is not an override.

## This loosens #5440's arm — deliberately

That path used to block unconditionally: wrong reason, safe outcome, and it refuses good publishes. It is now override-able, so a machine without libdbus can publish with a `[WARN]` and an unverified delta. The trade is judged worth it — a gate that blocks good publishes for reasons the operator cannot fix gets routed around eventually, and a disclosed `[WARN]` beats an undisclosed workaround — but #5440's "correctly refusing for the wrong reason" description no longer matches the code.

## Rung 5 (release tooling, High risk)

New `scripts/preflight-check5-selftest.sh` drives the decision over captured gate output — twelve cases, no cargo, no network. Case 3 is the trusty-review run verbatim (`scripts/test-data/preflight-check5/inventory-blind.out`). `PREFLIGHT_SELFTEST_SCRIPT` points it at another revision, which is the red-then-green:

```
$ PREFLIGHT_SELFTEST_SCRIPT=<origin/main copy> bash scripts/preflight-check5-selftest.sh
SELF-TEST FAIL: inventory blind (the trusty-review 0.16.0 defect): expected the decision to return 1 (0=permit, 1=stop), got 0
       [PASS] semver: semver gate: scanned (explicit); 0 crate(s) checked, 0 skipped, 1 inventory NOT computed — OK.
preflight-check5-selftest: 3 passed, 9 FAILED.

$ bash scripts/preflight-check5-selftest.sh
preflight-check5-selftest: 12 passed, 0 failed.
```

Live, against the real crates:

```
$ bash scripts/preflight-publish.sh --check-only trusty-review
[FAIL] semver: NOT VERIFIED for trusty-review 0.16.0 — 0 crate(s) were compared:
       Blind because: the advisory inventory could not be computed for 1 crate(s) — cargo-semver-checks
       completed no check run, which for an already-breaking 0.x release is the ONLY coverage there was.

$ bash scripts/preflight-publish.sh --check-only tga
[PASS] semver: 1 crate(s) compared against their previous crates.io release — semver gate: scanned (explicit); 1 crate(s) checked, 0 skipped — OK.

$ PREFLIGHT_SEMVER_UNVERIFIED="0.15.0 baseline references the profile module removed in #5611" \
    bash scripts/preflight-publish.sh --check-only trusty-review
[WARN] semver: UNVERIFIED — trusty-review 0.16.0 is being published without a public-API comparison…
       Reason given: 0.15.0 baseline references the profile module removed in #5611
```

Gates run:

| Command | Result |
|---|---|
| `bash scripts/preflight-check5-selftest.sh` | 12 passed, 0 failed |
| `bash scripts/check_semver_selftest.sh` | 25 passed, 0 failed |
| `bash scripts/check_changelog_fragment.sh` | scanned 13 path(s); no crate source changed — OK (fragment exempt) |
| `bash scripts/check_sld.sh` | 59 specs + 3252 files; 0 errors, 0 warnings |
| `bash scripts/check_doc_numbers.sh` | 120 docs / 114 claims; 0 violations |
| `bash scripts/check_line_cap.sh` | 3979 files; 0 violations |
| `bash scripts/check_public_docs.sh` | 27 pages; all inside the boundary |
| `shellcheck -S warning` on both scripts | clean |

No Cargo gate: nothing under `crates/*/src/**` changed.

## Docs

`CLAUDE.md` said CHECK 5's nonzero exit is "the absolute stop", which was true and incomplete — it implied a zero exit is the mirror of it. Corrected there and in `docs/reference/semver-gate.md`, which gains a "Reading the gate's result" section covering the four labels, the override, and the #5440 loosening. The new self-test runs on PRs that touch these files, as a second job in `tag-publish-parity.yml` (same shape, same reason: a preflight check CI cannot run, whose failing branches are the whole product).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
