### PR TITLE
docs(specs): lift the tm-1.3.5 implementation hold on DOC-67

### DIFF
--- a/docs/specs/DOC-67-tga-audit-mode.md
+++ b/docs/specs/DOC-67-tga-audit-mode.md
@@ -5,17 +5,18 @@ spec_refs: []
 # DOC-67 — tga AUDIT Mode: Remote Codebase Analysis for Acquisition Due Diligence
 
 **Status:** APPROVED 2026-08-08. The owner signed off §3's dimension-scope
-assumption and every open question (Q1–Q6) is resolved. **Implementation is
-HELD until tm 1.3.5 ships** — owner directive, 2026-08-08: *"yes, hold off on
-building until we release 1.3.5."* Issues may be filed against §13; no code
-may be written until that release lands.
+assumption and every open question (Q1–Q6) is resolved. Implementation was
+HELD until tm 1.3.5 shipped — owner directive, 2026-08-08: *"yes, hold off on
+building until we release 1.3.5."* **The owner lifted that hold on
+2026-08-13 ([#5643](https://github.com/bobmatnyc/trusty-tools/issues/5643));
+the §13 issues may be filed and implementation may begin.**
 **Spec ID:** `SPEC-TGAUDIT-01~draft` … `SPEC-TGAUDIT-13~draft`
 **Subsystem:** `trusty-git-analytics` (tga) — orchestration, new `audit`
 subcommand, DD-manifest adapter; `trusty-review` — existing DD report
 pipeline, consumed unmodified; `trusty-analyze` — existing HTTP analysis
 surface, consumed unmodified by trusty-review, not touched by tga
 **Owner:** Bob Matsuoka
-**Last-updated:** 2026-08-08
+**Last-updated:** 2026-08-13 (implementation hold lifted, #5643)
 **DOC-N claim:** `DOC-67`, scan-before-claim per DOC-38 §4.1. Verified against
 this worktree (branched from `origin/main`): no `DOC-67` filename or
 header self-label anywhere under `docs/specs/**`; `scripts/check_doc_numbers.sh`
@@ -596,12 +597,14 @@ surface AUDIT needs exists, silently reintroducing the Q1 gap.
 surface, performance and cost declared explicit gaps in the report. Nothing
 in this spec is awaiting a decision.
 
-**One scheduling constraint replaces it.** Implementation is held until tm
-1.3.5 ships (owner, 2026-08-08). The §13 issues may be filed now; no code is
-written against them until that release lands. Milestone
+**The scheduling constraint that replaced it has since been lifted.**
+Implementation was held until tm 1.3.5 shipped (owner, 2026-08-08); the
+owner lifted that hold on 2026-08-13
+([#5643](https://github.com/bobmatnyc/trusty-tools/issues/5643)), so the
+§13 issues may now be filed and implemented. Milestone
 [#43](https://github.com/bobmatnyc/trusty-tools/milestone/43)'s 2026-08-09
-due date covers this specification, which is delivered — not the
-implementation, which is gated on a release with open readiness criteria.
+due date covered this specification's delivery, which is unaffected by
+either the hold or its lifting.
 
 ## {#SPEC-TGAUDIT-13~draft} 13. Proposed Issue Breakdown for Milestone #43
 

--- a/docs/specs/DOC-67-tga-audit-mode.md
+++ b/docs/specs/DOC-67-tga-audit-mode.md
@@ -609,12 +609,12 @@ either the hold or its lifting.
 ## {#SPEC-TGAUDIT-13~draft} 13. Proposed Issue Breakdown for Milestone #43
 
 Proposed only. Nothing below has been filed. Titles, scope, and
-dependencies are this spec's recommendation for how to slice the work once
-the owner approves §3.
+dependencies are this spec's recommendation for how to slice the work,
+following the owner's 2026-08-08 approval of §3.
 
 | Proposed title | One-line scope | Depends on |
 |---|---|---|
-| `feat(tga): audit orchestrator command scaffold` | New `tga audit` subcommand parsing CLI flags (org/workspace, title, `--analyst`, `--client`, output dir), dispatch wiring in `main.rs`, no report generation yet, no interactivity anywhere in the path (§2) | none (can start once §3 is approved) |
+| `feat(tga): audit orchestrator command scaffold` | New `tga audit` subcommand parsing CLI flags (org/workspace, title, `--analyst`, `--client`, output dir), dispatch wiring in `main.rs`, no report generation yet, no interactivity anywhere in the path (§2) | none |
 | `feat(tga): #5217 library entry point` | **Amend #5217 in place** (owner, Q6) — not a separate issue: expose `run_full_sweep` per §7's proposed signature — no TTY, no confirmation, returns a stats struct, optionally emits to the existing progress bus. The TUI's "Run Audit" button becomes a caller of this function. | #5217 |
 | `feat(tga): DD-manifest adapter` | `report/dd_manifest.rs` — `build_dd_manifest` + TOML serialization per §6's field mapping, unit-tested against fixture `Config` values | audit orchestrator scaffold |
 | `feat(tga): audit sweep sequencing` | Wire the orchestrator to call the #5217 library entry point | #5217 library entry point |
@@ -631,4 +631,4 @@ the owner approves §3.
 *This document is the deliverable requested for milestone
 [#43](https://github.com/bobmatnyc/trusty-tools/milestone/43). No code was
 written, no `Cargo.toml` was changed, and no issue listed in §13 has been
-filed — all pending owner approval of §3.*
+filed — the owner approved §3 on 2026-08-08.*


### PR DESCRIPTION
Closes #5643.

The owner lifted DOC-67's "no code until tm 1.3.5 ships" hold on 2026-08-13. `docs/specs/DOC-67-tga-audit-mode.md` carried that gate in two places: the Status line (header) and §12 ("Open Questions for the Owner"). Both now record that the gate existed, was lifted on 2026-08-13, and point at #5643 — not a bare deletion, so a later reader can still see the spec had a hold. `Last-updated` bumped to match.

**What changed:** Status line and §12 rewritten past-tense with the lift date and issue link; no other section touched.

**Deliberately left alone (out of scope for this PR — pre-existing, unrelated to the 1.3.5 hold):**
- §13's intro ("...once the owner approves §3") and the proposed-issue table's "can start once §3 is approved" note are stale against the Status line's existing "APPROVED 2026-08-08" — that inconsistency predates this PR and is about §3 sign-off, not the tm-1.3.5 code hold.
- The closing footer ("...all pending owner approval of §3") has the same pre-existing staleness.
- DOC-68 (`docs/specs/DOC-68-audit-handoff-package.md`) and `crates/trusty-audit/README.md` reference DOC-67 but never restate the hold text itself — nothing to change there.
- `docs/specs/README.md`'s catalog entries for DOC-67 are claim-registration notes, not hold restatements — nothing to change there.

**Update:** the three §3-staleness lines listed above as "deliberately left alone" were folded into this PR under CLAUDE.md's opportunistic-fixes rule — all three rewritten past-tense to agree with the Status line's existing "APPROVED 2026-08-08"; the one dependency cell that named the stale condition as a gate now reads "none".

**Public website:** DOC-67 is not in `docs/public-manifest.tsv`, so this change does not go live on the public site.

**Rung:** 1 (docs only). Gates run:
```
bash scripts/check_sld.sh          → sld-lint: 0 error(s), 0 warning(s)
bash scripts/check_doc_numbers.sh  → 120 doc(s) / 114 claim(s), 3 grandfathered, 0 violations
bash scripts/check_line_cap.sh     → 3979 tracked .rs file(s), 4 allowlisted, 0 violations
bash scripts/check_changelog_fragment.sh → docs-only, no crate source changed — OK
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
