### PR TITLE
chore: ignore claude-mpm leftover directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,7 @@ docs/certificates/*.cert
 docs/certificates/*.pem
 docs/certificates/*.key
 docs/certificates/*.mobileprovision
+
+# claude-mpm (unrelated Python project) leftovers — synced skills/agents, never a deliverable here
+.agents/
+.codex/


### PR DESCRIPTION
Ignores `.agents/` and `.codex/` — claude-mpm (the unrelated Python project) leftovers, currently untracked. The owner has stopped using claude-mpm and wants them ignored rather than deleted, so a stray `git add -A` doesn't sweep 81 synced skill directories and 21 Codex agent definitions into this repo.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools