### PR TITLE
fix(trusty-mpm): repair dead ADR-0043 link breaking website prerender

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -338,7 +338,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - running binary NEWER than cargo's record at the same path is now `Unknown` — the prebuilt installer placed it and keeps no cargo metadata, so provenance is unverifiable rather than broken
   - running binary OLDER than cargo's record stays `Fail`, unchanged: an older binary on top of a newer install is the [#4033](https://github.com/bobmatnyc/trusty-tools/issues/4033) defect
   - versions that cannot be ordered as semver stay `Fail`
-  - `Warn` remains the correct terminal verdict for a `cargo install --path` install per [ADR-0043](docs/adr/0043-cargo-bin-policy.md)
+  - `Warn` remains the correct terminal verdict for a `cargo install --path` install per [ADR-0043](../../docs/adr/0043-cargo-bin-policy.md)
   - the `binary_provenance` description in the bundled `tm-capabilities` skill now states the direction split instead of the retired "any version disagreement fails"
 - `tm-workflow`'s "Worktree Discipline" section now carries the rest of the checkout rules that root `CLAUDE.md` used to state, so every project deploying the skill gets them rather than only this repo
   - the main checkout's forbidden-operation list is now explicit: any edit, any build or test run, any destructive git op (`git reset --hard`, `git checkout .`, `git stash`, `git restore .`), any file-mutating command (`sed`/`awk`/`patch`), and anything else that mutates the working tree, index, or build output


### PR DESCRIPTION
## Summary

The Vercel check is red on every currently open PR ([#5646](https://github.com/bobmatnyc/trusty-tools/pull/5646), [#5645](https://github.com/bobmatnyc/trusty-tools/pull/5645), [#5644](https://github.com/bobmatnyc/trusty-tools/pull/5644), [#5638](https://github.com/bobmatnyc/trusty-tools/pull/5638), [#5637](https://github.com/bobmatnyc/trusty-tools/pull/5637), [#5634](https://github.com/bobmatnyc/trusty-tools/pull/5634)) because `pnpm run build` fails during SSR prerender, not because of anything those PRs touch.

`crates/trusty-mpm/CHANGELOG.md:341` links ADR-0043 as `docs/adr/0043-cargo-bin-policy.md`. Markdown resolves that path relative to the changelog file's own directory, giving `crates/trusty-mpm/docs/adr/0043-cargo-bin-policy.md`, which does not exist. The website's changelog build gate (`website/src/lib/changelog`) treats any unresolved link in any crate's `CHANGELOG.md` as fatal, so `GET /` and `GET /whats-new` both 500 during prerender and `pnpm run build` exits 1 on every deploy — regardless of which crate a given PR actually changed, since the website assembles and renders all crates' changelogs on those two routes.

Fix: point the link at `../../docs/adr/0043-cargo-bin-policy.md`, matching the convention already used elsewhere in the same file (e.g. ADR-0020 at line 2556, `../../docs/adr/0020-session-owned-worktrees.md`). Swept every `crates/*/CHANGELOG.md` for the same unprefixed `](docs/` shape — this was the only instance.

## Root cause (raw build log from the failing deployment)

```
[500] GET /
ChangelogBuildError: changelog build gate: 1 finding(s)
FAIL CHANGELOG-BAD-LINK crates/trusty-mpm/CHANGELOG.md:341: `docs/adr/0043-cargo-bin-policy.md` resolves to `crates/trusty-mpm/docs/adr/0043-cargo-bin-policy.md`, which is not in the repository — point it at the file's current path, write an absolute https:// URL, or drop the link and keep its text
...
Error: Command "pnpm run build" exited with 1
```

## Test plan

Rung 1 (docs-only — `crates/trusty-mpm/CHANGELOG.md` is not `src/**`) plus direct rung-6 UI evidence since this is the website build itself:

- [x] `bash scripts/check_sld.sh` — `0 error(s), 0 warning(s)`
- [x] `bash scripts/check_changelog_fragment.sh` — `no crate source changed (docs-only / CI-only / test-only) — OK`
- [x] `bash scripts/check_public_docs.sh` — `27 page(s) across 5 section(s) — all resolve inside the public boundary` (ruled out as an unrelated suspect)
- [x] `cd website && npx pnpm@9.15.9 install && npx pnpm@9.15.9 run build` — exit 0, zero `ChangelogBuildError`/`[500]` occurrences, `Using @sveltejs/adapter-vercel ✔ done`

## Why this hand-edit to `CHANGELOG.md` is safe

CLAUDE.md bans hand-editing a crate's `CHANGELOG.md` because the fragment
assembler (`scripts/assemble-changelog.sh`) owns that file. Checked whether
this edit fights that ownership:

- `crates/trusty-mpm/changelog.d/` has no fragment containing the bad
  `](docs/adr/...)` shape, so nothing reintroduces the broken link on the next
  release.
- The assembler only ever inserts a new `## [<version>]` section forward of
  existing content — "existing history is never rewritten"
  (`scripts/assemble-changelog.sh`, header comment). Line 341 sits inside the
  already-released `## [1.3.6] — 2026-08-12` section, which the assembler will
  never touch again, so the fix persists through every future release.
- Swept `changelog.d/` across all 21 crates for the same `](docs/` shape —
  zero matches, so this is not a class of bug waiting to reappear from a
  pending fragment elsewhere.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
