### PR TITLE
fix(tga): Linear collection writes work_items, not only linear_issues (#5219)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10288,7 +10288,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.19.0"
+version = "2.19.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "tga"
-version = "2.19.0"
+# #4421: patch bump — 2.19.0 already published on crates.io and this PR
+# touches src/**. `persist_work_items` is `pub` but lives in the private
+# `mod linear_pipeline;` (not re-exported), so it is unreachable outside the
+# crate and adds no public API surface.
+version = "2.19.1"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for

--- a/crates/trusty-git-analytics/changelog.d/5219-linear-work-items.md
+++ b/crates/trusty-git-analytics/changelog.d/5219-linear-work-items.md
@@ -1,0 +1,11 @@
+Fixed
+
+- Linear collection now writes the source-agnostic `work_items` corpus, not only its own `linear_issues` table (#5219). Each fetched issue becomes one `work_items` row under `source = 'linear'`, keyed on the Linear identifier — the same string `LinearClient::extract_issue_ids` pulls out of a commit message, so the two sides match — and every commit that mentions a fetched identifier gets a `commit_work_items` link. Before this, only Azure DevOps wrote `work_items` in production, and every `tga.db` on the owner's machine had `work_items = 0`, so commit-to-board correlation had nothing to correlate against for Linear.
+
+  `linear_issues` is unchanged and still written. It carries Linear-specific columns (`team_key`, `priority`, `assignee`) that `work_items` has no place for, and retiring it would drop those with no consumer asking for it; the two are written in the same pass, so they cannot drift.
+
+  The commit query moved from `SELECT message` to `SELECT sha, message`. The SHA is what the join table needs, and reading messages alone made a per-commit link impossible even once the issues were known.
+
+  `work_items.project` is left null. Linear's project lives behind a GraphQL field this crate does not query, and DOC-70 §6 routes project resolution through trusty-common's client instead — writing the team name into that column would fill the field DOC-70 filters on with something that is not a project.
+
+  A failed `work_items` write is recorded in the run's error list and returned as an error from the writer, never downgraded to a zero count. Both tables are written inside one transaction, so a failure leaves neither half-written.

--- a/crates/trusty-git-analytics/src/collect/linear_pipeline.rs
+++ b/crates/trusty-git-analytics/src/collect/linear_pipeline.rs
@@ -4,29 +4,50 @@
 //! which sits over the 500-SLOC production cap on a frozen ratchet budget.
 //! Lifting it out mirrors the existing `github_pipeline` split and keeps
 //! `collector.rs` shrinking rather than growing (#5197).
-//! What: [`fetch_and_store_linear_issues`] — reads every commit message, asks
-//! the Linear client which referenced issues exist, and persists them. Behavior
-//! is unchanged from the inline version: every failure is non-fatal and lands
-//! in `stats.errors`.
-//! Test: covered by `linear`'s own client tests; the orchestration here is
-//! exercised end-to-end by the gated integration tests.
+//! What: [`fetch_and_store_linear_issues`] — reads every commit, asks the
+//! Linear client which referenced issues exist, and persists them into both
+//! `linear_issues` and, since #5219, the source-agnostic `work_items` /
+//! `commit_work_items` pair that correlation and DOC-70's board axis read.
+//! Every failure is non-fatal and lands in `stats.errors`.
+//! Test: this module's own `tests` cover the `work_items` projection; the
+//! client half is unit-tested in `crate::collect::linear`, and the
+//! orchestration is exercised end-to-end by the gated integration tests.
+
+use std::collections::HashMap;
 
 use tracing::info;
 
 use crate::collect::collector::CollectionStats;
-use crate::collect::linear::LinearClient;
+use crate::collect::linear::{LinearClient, LinearIssue};
 use crate::core::config::Config;
-use crate::core::db::Database;
+use crate::core::db::{Database, WorkItemRow};
+
+/// `work_items.source` tag for every row this pipeline writes.
+///
+/// #5219: the source vocabulary is fixed by `sql/0005_work_items.sql:8`
+/// (`'azdo' | 'jira' | 'github' | 'linear'`); DOC-70 §11 reuses it as the
+/// provider tag of its `{provider, id}` board selection.
+const LINEAR_SOURCE: &str = "linear";
+
+/// `work_items.item_type` for a Linear issue.
+///
+/// Linear has no per-issue type field on the GraphQL surface this crate
+/// queries, and the column is `NOT NULL`, so every row carries this constant.
+const LINEAR_ITEM_TYPE: &str = "Issue";
 
 /// Fetch and persist the Linear issues referenced by collected commits.
 ///
 /// Why: Linear identifiers appear in commit messages, and the issue's state and
 /// team are what turn a bare `ENG-123` into something a report can group by.
 /// What: no-ops unless `linear.fetch_on_reference` is set. Otherwise collects
-/// every commit message, calls `fetch_referenced_issues`, and stores the result
-/// into `linear_issues`. Every failure — client init, query, store — is pushed
-/// into `stats.errors` and returns without aborting the surrounding run.
-/// Test: exercised by the gated integration tests; the client half is unit-tested
+/// every `(sha, message)` pair, calls `fetch_referenced_issues`, and stores the
+/// result into BOTH `linear_issues` and the source-agnostic `work_items` /
+/// `commit_work_items` pair. Every failure — client init, query, either store —
+/// is pushed into `stats.errors` and returns without aborting the surrounding
+/// run.
+/// Test: `persist_work_items_writes_linear_rows`,
+/// `persist_work_items_links_commits`, `persist_work_items_is_idempotent`,
+/// `persist_work_items_reports_write_failure`; the client half is unit-tested
 /// in `crate::collect::linear`.
 pub(super) async fn fetch_and_store_linear_issues(
     db: &mut Database,
@@ -38,10 +59,12 @@ pub(super) async fn fetch_and_store_linear_issues(
         if linear_cfg.fetch_on_reference {
             match LinearClient::new(linear_cfg) {
                 Ok(client) => {
-                    // Collect commit messages from DB.
-                    let messages: Vec<String> = {
+                    // #5219: `sha` joins the fetch to `commit_work_items`; the
+                    // pre-fix query read `message` alone, so no commit link
+                    // could be written even once the issues were known.
+                    let commits: Vec<(String, String)> = {
                         let conn = db.connection();
-                        let mut stmt = match conn.prepare("SELECT message FROM commits") {
+                        let mut stmt = match conn.prepare("SELECT sha, message FROM commits") {
                             Ok(s) => s,
                             Err(e) => {
                                 stats
@@ -50,7 +73,9 @@ pub(super) async fn fetch_and_store_linear_issues(
                                 return;
                             }
                         };
-                        let rows = match stmt.query_map([], |row| row.get::<_, String>(0)) {
+                        let rows = match stmt.query_map([], |row| {
+                            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                        }) {
                             Ok(r) => r,
                             Err(e) => {
                                 stats
@@ -66,6 +91,8 @@ pub(super) async fn fetch_and_store_linear_issues(
                         out
                     };
 
+                    let messages: Vec<String> =
+                        commits.iter().map(|(_, msg)| msg.clone()).collect();
                     let msg_refs: Vec<&str> = messages.iter().map(String::as_str).collect();
                     let issues = client
                         .fetch_referenced_issues(&msg_refs, &linear_cfg.team_keys)
@@ -89,11 +116,282 @@ pub(super) async fn fetch_and_store_linear_issues(
                                 .push(format!("Linear: store issues failed: {e}"));
                         }
                     }
+
+                    // #5219: the same issues also land in the source-agnostic
+                    // `work_items` corpus, which is what correlation and
+                    // DOC-70's board axis read.
+                    let commit_refs = build_commit_refs(&commits);
+                    match persist_work_items(db, &issues, &commit_refs) {
+                        Ok(n) => {
+                            info!(
+                                stored = n,
+                                source = LINEAR_SOURCE,
+                                "persisted work_items rows"
+                            );
+                        }
+                        Err(e) => {
+                            stats
+                                .errors
+                                .push(format!("Linear: store work_items failed: {e}"));
+                        }
+                    }
                 }
                 Err(e) => {
                     stats.errors.push(format!("Linear client init failed: {e}"));
                 }
             }
         }
+    }
+}
+
+/// Map each commit SHA to the Linear identifiers its message mentions.
+///
+/// Why: `commit_work_items` is a per-commit join, so the identifiers have to
+/// stay attached to the SHA they came from rather than being flattened into one
+/// global set the way the fetch path does it.
+/// What: runs [`LinearClient::extract_issue_ids`] — the same extractor the
+/// fetch uses, so a commit links to exactly the identifiers that fetch could
+/// have resolved — over each message, dropping commits that mention none.
+/// Test: `persist_work_items_links_commits`.
+fn build_commit_refs(commits: &[(String, String)]) -> HashMap<String, Vec<String>> {
+    let mut out = HashMap::new();
+    for (sha, message) in commits {
+        let ids = LinearClient::extract_issue_ids(message);
+        if !ids.is_empty() {
+            out.insert(sha.clone(), ids);
+        }
+    }
+    out
+}
+
+/// Project fetched Linear issues into `work_items` and link the commits that
+/// reference them.
+///
+/// Why: only Azure DevOps wrote `work_items` in production (#5219), so every
+/// consumer of the source-agnostic corpus — commit correlation, and DOC-70's
+/// board axis, which defines its corpus as the rows with `source = 'linear'` —
+/// saw nothing for Linear no matter how much `linear_issues` held.
+/// What: upserts one `work_items` row per issue under `source = 'linear'`,
+/// keyed on [`LinearIssue::identifier`] so it matches what
+/// [`LinearClient::extract_issue_ids`] yields, then inserts a
+/// `commit_work_items` row for every `(sha, identifier)` pair whose identifier
+/// was actually fetched. Both halves run in one transaction, so a failure
+/// leaves neither table half-written and no dangling join row. An identifier a
+/// commit mentions but Linear did not return is skipped, because the join
+/// table's foreign key would reject it. Returns the number of `work_items`
+/// rows written.
+///
+/// `project` is left `None`: the GraphQL query this crate issues has no project
+/// field, and DOC-70 §6 routes project resolution through trusty-common's
+/// client instead. Writing the team name there would fill the column DOC-70
+/// filters on with a value that is not a project.
+///
+/// # Errors
+///
+/// Returns [`crate::core::TgaError::DbError`] if opening the transaction, any
+/// upsert, any link insert, or the commit fails. The error is returned, never
+/// downgraded to a warning or a zero count — the caller records it in
+/// `stats.errors`.
+///
+/// Test: `persist_work_items_writes_linear_rows`,
+/// `persist_work_items_links_commits`, `persist_work_items_is_idempotent`,
+/// `persist_work_items_skips_unfetched_refs`,
+/// `persist_work_items_reports_write_failure`.
+pub fn persist_work_items(
+    db: &mut Database,
+    issues: &[LinearIssue],
+    commit_refs: &HashMap<String, Vec<String>>,
+) -> crate::core::Result<usize> {
+    use crate::core::db::work_items::{link_commit_work_item, upsert_work_item};
+    use std::collections::HashSet;
+
+    if issues.is_empty() {
+        return Ok(0);
+    }
+
+    let tx = db.connection_mut().transaction()?;
+    let mut written = 0usize;
+    for issue in issues {
+        let row = WorkItemRow {
+            id: issue.identifier.clone(),
+            source: LINEAR_SOURCE.to_string(),
+            title: issue.title.clone(),
+            status: issue.state.clone(),
+            item_type: LINEAR_ITEM_TYPE.to_string(),
+            tags: None,
+            project: None,
+            url: Some(issue.url.clone()),
+            raw_json: serde_json::to_string(issue).ok(),
+        };
+        upsert_work_item(&tx, &row)?;
+        written += 1;
+    }
+
+    let fetched: HashSet<&str> = issues.iter().map(|i| i.identifier.as_str()).collect();
+    for (sha, ids) in commit_refs {
+        for id in ids {
+            if fetched.contains(id.as_str()) {
+                link_commit_work_item(&tx, sha, id, LINEAR_SOURCE)?;
+            }
+        }
+    }
+    tx.commit()?;
+    Ok(written)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn issue(identifier: &str) -> LinearIssue {
+        LinearIssue {
+            identifier: identifier.to_string(),
+            title: format!("Title for {identifier}"),
+            state: "In Progress".to_string(),
+            team: "Engineering".to_string(),
+            assignee: Some("Alice".to_string()),
+            priority: 2,
+            url: format!("https://linear.app/x/issue/{identifier}"),
+        }
+    }
+
+    fn linear_row_count(db: &Database) -> i64 {
+        db.connection()
+            .query_row(
+                "SELECT COUNT(*) FROM work_items WHERE source = 'linear'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("count work_items")
+    }
+
+    /// The #5219 regression: before the fix nothing ever wrote a `work_items`
+    /// row with `source = 'linear'`, so this count stayed at 0 for every run.
+    #[test]
+    fn persist_work_items_writes_linear_rows() {
+        let mut db = Database::open_in_memory().expect("db");
+        let n = persist_work_items(&mut db, &[issue("ENG-1"), issue("FE-42")], &HashMap::new())
+            .expect("persist");
+        assert_eq!(n, 2);
+        assert_eq!(linear_row_count(&db), 2);
+
+        let (title, status, item_type, url): (String, String, String, Option<String>) = db
+            .connection()
+            .query_row(
+                "SELECT title, status, item_type, url FROM work_items \
+                 WHERE id = ?1 AND source = 'linear'",
+                ["ENG-1"],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .expect("query row");
+        assert_eq!(title, "Title for ENG-1");
+        assert_eq!(status, "In Progress");
+        assert_eq!(item_type, "Issue");
+        assert_eq!(url.as_deref(), Some("https://linear.app/x/issue/ENG-1"));
+    }
+
+    #[test]
+    fn persist_work_items_links_commits() {
+        let mut db = Database::open_in_memory().expect("db");
+        let commits = vec![
+            ("sha1".to_string(), "ENG-1: add login".to_string()),
+            ("sha2".to_string(), "chore: no ticket here".to_string()),
+        ];
+        let refs = build_commit_refs(&commits);
+        assert_eq!(refs.len(), 1, "only the ticketed commit contributes a ref");
+
+        persist_work_items(&mut db, &[issue("ENG-1")], &refs).expect("persist");
+
+        let linked: Vec<String> = {
+            let conn = db.connection();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT commit_sha FROM commit_work_items \
+                     WHERE work_item_id = ?1 AND work_item_source = 'linear'",
+                )
+                .expect("prepare");
+            let rows = stmt
+                .query_map(["ENG-1"], |r| r.get::<_, String>(0))
+                .expect("query");
+            rows.flatten().collect()
+        };
+        assert_eq!(linked, vec!["sha1".to_string()]);
+    }
+
+    /// An identifier the extractor found but Linear never returned must not
+    /// reach the join table — its foreign key would reject it and abort the
+    /// whole transaction, losing the rows that were fine.
+    #[test]
+    fn persist_work_items_skips_unfetched_refs() {
+        let mut db = Database::open_in_memory().expect("db");
+        let commits = vec![("sha1".to_string(), "ENG-1 and GONE-9".to_string())];
+        let refs = build_commit_refs(&commits);
+
+        persist_work_items(&mut db, &[issue("ENG-1")], &refs).expect("persist");
+
+        let links: i64 = db
+            .connection()
+            .query_row("SELECT COUNT(*) FROM commit_work_items", [], |r| r.get(0))
+            .expect("count links");
+        assert_eq!(links, 1, "only the fetched identifier is linked");
+    }
+
+    #[test]
+    fn persist_work_items_is_idempotent() {
+        let mut db = Database::open_in_memory().expect("db");
+        let commits = vec![("sha1".to_string(), "ENG-1: work".to_string())];
+        let refs = build_commit_refs(&commits);
+
+        persist_work_items(&mut db, &[issue("ENG-1")], &refs).expect("first");
+        let mut updated = issue("ENG-1");
+        updated.state = "Done".to_string();
+        persist_work_items(&mut db, &[updated], &refs).expect("second");
+
+        assert_eq!(linear_row_count(&db), 1);
+        let status: String = db
+            .connection()
+            .query_row(
+                "SELECT status FROM work_items WHERE id = ?1 AND source = 'linear'",
+                ["ENG-1"],
+                |r| r.get(0),
+            )
+            .expect("query status");
+        assert_eq!(
+            status, "Done",
+            "re-running refreshes rather than duplicates"
+        );
+
+        let links: i64 = db
+            .connection()
+            .query_row("SELECT COUNT(*) FROM commit_work_items", [], |r| r.get(0))
+            .expect("count links");
+        assert_eq!(links, 1);
+    }
+
+    /// The fail-open arm: a write failure must surface as `Err`, never as a
+    /// silent `Ok(0)` that lets the run report success with an empty corpus.
+    #[test]
+    fn persist_work_items_reports_write_failure() {
+        let mut db = Database::open_in_memory().expect("db");
+        db.connection()
+            .execute("DROP TABLE work_items", [])
+            .expect("drop table");
+
+        let err = persist_work_items(&mut db, &[issue("ENG-1")], &HashMap::new())
+            .expect_err("write against a missing table must fail");
+        assert!(
+            err.to_string().contains("work_items"),
+            "error names the failing table: {err}"
+        );
+    }
+
+    #[test]
+    fn persist_work_items_no_issues_is_a_noop() {
+        let mut db = Database::open_in_memory().expect("db");
+        assert_eq!(
+            persist_work_items(&mut db, &[], &HashMap::new()).expect("persist"),
+            0
+        );
+        assert_eq!(linear_row_count(&db), 0);
     }
 }

--- a/crates/trusty-git-analytics/src/collect/linear_pipeline.rs
+++ b/crates/trusty-git-analytics/src/collect/linear_pipeline.rs
@@ -196,7 +196,8 @@ fn build_commit_refs(commits: &[(String, String)]) -> HashMap<String, Vec<String
 /// Test: `persist_work_items_writes_linear_rows`,
 /// `persist_work_items_links_commits`, `persist_work_items_is_idempotent`,
 /// `persist_work_items_skips_unfetched_refs`,
-/// `persist_work_items_reports_write_failure`.
+/// `persist_work_items_reports_write_failure`,
+/// `persist_work_items_rolls_back_a_partial_write`.
 pub fn persist_work_items(
     db: &mut Database,
     issues: &[LinearIssue],
@@ -382,6 +383,34 @@ mod tests {
         assert!(
             err.to_string().contains("work_items"),
             "error names the failing table: {err}"
+        );
+    }
+
+    /// The interleaving the transaction exists for: the issue upsert succeeds,
+    /// then the link insert fails. Dropping only `commit_work_items` reaches
+    /// the link phase with a `work_items` row already written inside the open
+    /// transaction, so the assertion is about rollback rather than about the
+    /// error propagating.
+    #[test]
+    fn persist_work_items_rolls_back_a_partial_write() {
+        let mut db = Database::open_in_memory().expect("db");
+        db.connection()
+            .execute("DROP TABLE commit_work_items", [])
+            .expect("drop join table");
+
+        let commits = vec![("sha1".to_string(), "ENG-1: work".to_string())];
+        let refs = build_commit_refs(&commits);
+
+        let err = persist_work_items(&mut db, &[issue("ENG-1")], &refs)
+            .expect_err("link against a missing table must fail");
+        assert!(
+            err.to_string().contains("commit_work_items"),
+            "error names the failing table: {err}"
+        );
+        assert_eq!(
+            linear_row_count(&db),
+            0,
+            "the issue upsert that already succeeded must roll back with the transaction"
         );
     }
 


### PR DESCRIPTION
Linear collection now writes `work_items` rows under `source = 'linear'`, plus `commit_work_items` links, keyed on the identifier `LinearClient::extract_issue_ids` yields from a commit message. Before this, only Azure DevOps wrote `work_items` in production.

Refs #5219. Unblocks DOC-70 (#5641, PR #5646), whose board corpus is defined as exactly those rows.

**`linear_issues` decision: kept, and written alongside in the same pass.** It carries `team_key`, `priority` and `assignee`, which `work_items` has no column for, and no reader asked for it to go.

**Out of scope:** no migration — `work_items.source` already models `'linear'`. `project` is left null: DOC-70 §6 routes project resolution through trusty-common's client, and writing the team name into the column DOC-70 filters on would fill it with something that is not a project. JIRA and GitHub Issues, the other two trackers in #5219, are untouched.

**Rung 5** (persistence). Commands run:

```
cargo fmt --check                                   # exit 0
cargo check -p tga                                  # exit 0
cargo clippy -p tga --all-targets -- -D warnings    # exit 0
cargo test -p tga                                   # ok. 1199 passed; 0 failed; 1 ignored
cargo test -p tga -- --include-ignored              # exit 101 — see Baseline failures
SKIP_UI_BUILD=1 cargo check --workspace             # exit 0
bash scripts/check_line_cap.sh                      # 0 violations
bash scripts/check_changelog_fragment.sh            # exit 0
bash scripts/check_sld.sh                           # exit 0
```

No crate in the workspace depends on `tga`, so rung 4's per-consumer step is empty.

**Regression proof.** The defect is that no `work_items` row with `source = 'linear'` is ever written. The committed tests are the seven `persist_work_items_*` below; `persist_work_items_writes_linear_rows` is the one that asserts the defect is gone, and `persist_work_items` is called from `fetch_and_store_linear_issues:130`, so it is on the production path.

```
test persist_work_items_writes_linear_rows ... ok
test persist_work_items_links_commits ... ok
test persist_work_items_is_idempotent ... ok
test persist_work_items_skips_unfetched_refs ... ok
test persist_work_items_reports_write_failure ... ok
test persist_work_items_rolls_back_a_partial_write ... ok
test persist_work_items_no_issues_is_a_noop ... ok
test result: ok. 7 passed; 0 failed
```

None of those seven can be run against `origin/main` — `persist_work_items` does not exist there. So the pre-fix side is a **manual probe, written and run by hand in a throwaway worktree checked out at `origin/main` and never committed to this branch**. It called `store_linear_issues`, the only Linear persistence path that existed pre-fix, and asserted a `work_items` row followed:

```
test linear_collection_writes_a_work_items_row ... FAILED
assertion `left == right` failed: Linear collection must populate work_items
  left: 0
 right: 1
test result: FAILED. 0 passed; 1 failed
```

That is real output from a real run, but `grep` will not find the test name on this branch and it is not meant to — the durable coverage is the seven committed tests.

**Fail-open check.** `persist_work_items` returns `Err` on any write failure and never degrades to `Ok(0)`; the caller records it in `stats.errors`. Two tests cover it. `persist_work_items_reports_write_failure` drops `work_items` and fails on the first upsert, proving the error propagates. `persist_work_items_rolls_back_a_partial_write` drops only `commit_work_items`, so the issue upsert succeeds and the *link* fails — the interleaving the transaction exists for — and asserts the already-written row is gone after the `Err`. Rollback holds; no code change was needed for it.

**Baseline failure.** The rung-5 `--include-ignored` gate is red. Run unnarrowed, `cargo test -p tga -- --include-ignored` exits 101:

```
test result: ok. 1201 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.67s
...
test crates/trusty-git-analytics/src/core/config/validator.rs - core::config::validator (line 19) ... FAILED
test crates/trusty-git-analytics/src/core/config/mod.rs - core::config (line 13) ... FAILED

failures:
    crates/trusty-git-analytics/src/core/config/mod.rs - core::config (line 13)
    crates/trusty-git-analytics/src/core/config/validator.rs - core::config::validator (line 19)

test result: FAILED. 6 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.73s
```

Every unit and integration target passes; the two failures are ignored doctests that `--include-ignored` force-runs. `validator.rs:19` uses `?` in a doctest whose `fn main` returns `()`, so it does not compile. `mod.rs:13` calls `Config::load` on a `config.yaml` that is not there and panics with `IoError(NotFound)`.

Both are pre-existing. The failing files are in the crate I changed, so an empty path diff proves nothing (baseline protocol step 4) and I reproduced them on `origin/main` instead — a scratch worktree checked out at `origin/main`, `cargo test -p tga --doc -- --include-ignored`, exit 101, the same two names, `6 passed; 2 failed`. My diff touches only `collect/linear_pipeline.rs` and a changelog fragment; nothing under `src/core/`.

change-specific gates pass; `cargo test -p tga -- --include-ignored` blocked by two pre-existing ignored doctests in `src/core/config/`, reproduced on `origin/main`. No canonical issue is filed for them — they are out of scope for this PR and left untouched.

**Credential scan.** `git diff origin/main...HEAD` scanned for keys, tokens, passwords and private-key blocks — zero hits.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
