### PR TITLE
refactor(trusty-common): one entry point for every gh invocation (#5475)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11782,7 +11782,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -58,7 +58,7 @@ trusty-code = { workspace = true }
 #      stub. Zero added dependency weight: `aws-config`/`aws-sdk-bedrockruntime`/
 #      `aws-types` below are already unconditional direct dependencies of this
 #      crate for the existing `llm::bedrock` (Converse, non-streaming) client.
-trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memory-core", "cli-help", "stdio-mcp-client", "session-naming", "config-cli", "axum-server", "inference-client", "bedrock", "uds"] }
+trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memory-core", "cli-help", "stdio-mcp-client", "session-naming", "config-cli", "axum-server", "inference-client", "bedrock", "uds", "gh-cli"] }
 # Why (issue #226): trusty-agents only links `trusty_memory::MemoryMcpService` for
 #      in-process `rpc.discover` merging; it does not need the axum HTTP/SSE
 #      surface (it owns its own axum stack for the orchestrator's UI). Setting

--- a/crates/trusty-agents/changelog.d/5475-gh-entry-point.md
+++ b/crates/trusty-agents/changelog.d/5475-gh-entry-point.md
@@ -1,0 +1,11 @@
+Changed
+
+- Every `gh` invocation now routes through `trusty_common::gh::GhCommand`
+  ([#5475](https://github.com/bobmatnyc/trusty-tools/issues/5475)) — the
+  `gh_tools` PR/CI tools, the `gh_cli` ticketing backend, the GitHub Actions
+  client, and the workflow ticket manager. No behaviour change: `gh pr checks`
+  still reports a non-zero exit as check STATE rather than a tool failure, and
+  a missing `gh` still surfaces the `gh auth login` hint. The outcome mapping
+  that used to be reachable only by spawning a real subprocess is now a pure
+  function (`map_gh_outcome`), so the tolerance rule is pinned deterministically
+  instead of via POSIX `true`/`false`.

--- a/crates/trusty-agents/src/ticketing/actions.rs
+++ b/crates/trusty-agents/src/ticketing/actions.rs
@@ -17,7 +17,6 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use std::sync::Arc;
-use tokio::process::Command;
 
 use super::gh_cli::gh_available;
 
@@ -248,27 +247,12 @@ impl GhActionsCliClient {
     }
 
     async fn run(&self, args: &[&str]) -> Result<String> {
-        let mut full: Vec<&str> = Vec::with_capacity(args.len() + 2);
-        if let Some(r) = &self.repo {
-            full.push("--repo");
-            full.push(r.as_str());
-        }
-        full.extend_from_slice(args);
-        let output = Command::new("gh")
-            .args(&full)
-            .output()
-            .await
-            .with_context(|| format!("failed to spawn 'gh {}'", full.join(" ")))?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!(
-                "gh {} failed (exit {}): {}",
-                full.join(" "),
-                output.status,
-                stderr.trim()
-            );
-        }
-        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        // #5475: `--repo` prefixing, spawn, and non-zero mapping all come from
+        // trusty-common's single `gh` entry point.
+        Ok(trusty_common::gh::GhCommand::new(args)
+            .repo(self.repo.as_deref())
+            .stdout()
+            .await?)
     }
 }
 

--- a/crates/trusty-agents/src/ticketing/gh_cli/client_impl.rs
+++ b/crates/trusty-agents/src/ticketing/gh_cli/client_impl.rs
@@ -11,7 +11,7 @@
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use serde_json::Value;
-use tokio::process::Command;
+use trusty_common::gh::GhCommand;
 
 use super::{
     GhCliClient, LIST_JSON_FIELDS, TICKET_JSON_FIELDS, gh_issue_to_ticket, plan_gh_issue_edit_calls,
@@ -182,11 +182,12 @@ impl TicketingClient for GhCliClient {
     }
 
     async fn list_available_tags(&self) -> Result<Vec<Tag>> {
-        let stdout = self
-            .run_with_repo(&["label", "list", "--json", "name,color,description"])
+        // #5475: `json` is the entry point's parse combinator — its failure
+        // message names the argv, which the bare `from_str` context did not.
+        let arr: Vec<Value> = GhCommand::new(["label", "list", "--json", "name,color,description"])
+            .repo(self.repo())
+            .json()
             .await?;
-        let arr: Vec<Value> =
-            serde_json::from_str(&stdout).context("failed to parse `gh label list` JSON")?;
         let out = arr
             .iter()
             .filter_map(|l| {
@@ -264,32 +265,34 @@ impl TicketingClient for GhCliClient {
         // Why subprocess-and-tolerant: `gh` may not be authed for `repo` (or
         // installed at all). Failing here would surface a noisy error in
         // every `/projects` render; instead we degrade gracefully to 0.
-        let output = Command::new("gh")
-            .args([
-                "issue", "list", "--repo", repo, "--state", "open", "--json", "number",
-            ])
-            .output()
-            .await?;
-        if !output.status.success() {
+        // #5475: routed through trusty-common's `gh` entry point; the
+        // degrade-to-0 policy stays here, where the UI contract lives.
+        let out = GhCommand::new([
+            "issue", "list", "--repo", repo, "--state", "open", "--json", "number",
+        ])
+        .output()
+        .await?;
+        if !out.success {
             return Ok(0);
         }
-        let json: Value = serde_json::from_slice(&output.stdout)?;
+        let json: Value = serde_json::from_str(&out.stdout)?;
         Ok(json.as_array().map(|a| a.len() as u32).unwrap_or(0))
     }
 
     async fn count_open_prs(&self, repo: &str) -> Result<u32> {
         // #342: companion to `count_open_issues` — same graceful-degrade
         // semantics on auth/install failure.
-        let output = Command::new("gh")
-            .args([
-                "pr", "list", "--repo", repo, "--state", "open", "--json", "number",
-            ])
-            .output()
-            .await?;
-        if !output.status.success() {
+        // #5475: routed through trusty-common's `gh` entry point; the
+        // degrade-to-0 policy stays here, where the UI contract lives.
+        let out = GhCommand::new([
+            "pr", "list", "--repo", repo, "--state", "open", "--json", "number",
+        ])
+        .output()
+        .await?;
+        if !out.success {
             return Ok(0);
         }
-        let json: Value = serde_json::from_slice(&output.stdout)?;
+        let json: Value = serde_json::from_str(&out.stdout)?;
         Ok(json.as_array().map(|a| a.len() as u32).unwrap_or(0))
     }
 

--- a/crates/trusty-agents/src/ticketing/gh_cli/mod.rs
+++ b/crates/trusty-agents/src/ticketing/gh_cli/mod.rs
@@ -21,9 +21,9 @@ mod client_impl;
 #[cfg(test)]
 mod tests;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 use serde_json::Value;
-use tokio::process::Command;
+use trusty_common::gh::GhCommand;
 
 use super::types::{Ticket, TicketStatus, UpdateTicketReq};
 
@@ -37,10 +37,8 @@ use super::types::{Ticket, TicketStatus, UpdateTicketReq};
 /// Test: `gh_available_returns_bool` — only asserts no panic; the actual
 /// boolean depends on the test environment.
 pub async fn gh_available() -> bool {
-    match Command::new("gh").args(["auth", "status"]).output().await {
-        Ok(out) => out.status.success(),
-        Err(_) => false,
-    }
+    // #5475: the probe now lives in trusty-common's `gh` entry point.
+    trusty_common::gh::gh_available().await
 }
 
 /// `gh` CLI-backed `TicketingClient`.
@@ -68,21 +66,13 @@ impl GhCliClient {
     /// What: Spawns `gh <args...>`, returns stdout on success or an error
     /// containing stderr on non-zero exit.
     async fn run(&self, args: &[&str]) -> Result<String> {
-        let output = Command::new("gh")
-            .args(args)
-            .output()
-            .await
-            .with_context(|| format!("failed to spawn 'gh {}'", args.join(" ")))?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!(
-                "gh {} failed (exit {}): {}",
-                args.join(" "),
-                output.status,
-                stderr.trim()
-            );
-        }
-        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        // #5475: spawn + non-zero mapping come from the shared entry point.
+        Ok(GhCommand::new(args).stdout().await?)
+    }
+
+    /// The configured `owner/repo`, if any.
+    pub(super) fn repo(&self) -> Option<&str> {
+        self.repo.as_deref()
     }
 
     /// Run a `gh` command, prepending `--repo <repo>` if configured.

--- a/crates/trusty-agents/src/tools/gh_tools/helpers.rs
+++ b/crates/trusty-agents/src/tools/gh_tools/helpers.rs
@@ -21,7 +21,7 @@
 use std::path::Path;
 
 use serde_json::{Value, json};
-use tokio::process::Command;
+use trusty_common::gh::{GhCommand, GhOutput};
 
 /// Maximum accepted length for any single LLM-supplied operand.
 ///
@@ -142,10 +142,6 @@ pub(super) fn enum_arg(field: &str, raw: &str, accepted: &[&str]) -> Result<Stri
     ))
 }
 
-/// Guidance appended when the `gh` binary cannot be spawned at all.
-const GH_MISSING_HINT: &str =
-    "The GitHub CLI must be installed and authenticated (`gh auth login`) for this tool to work.";
-
 /// Run `gh` with a fully pre-validated argv and return its output verbatim.
 ///
 /// Why: #4170's acceptance criterion is "tool output is legible and unfiltered
@@ -155,83 +151,70 @@ const GH_MISSING_HINT: &str =
 /// pending); treating that as a tool failure would make the single most
 /// useful CI primitive report `is_error` on every red or in-flight PR, which
 /// is precisely the state an orchestrator calls it to observe.
-/// What: Delegates to [`run_program`] with `"gh"` and the missing-binary hint.
-/// Test: `run_gh_surfaces_the_cli_state_legibly`.
+/// What: spawns via trusty-common's single `gh` entry point (#5475) rooted at
+/// `root`, then maps the outcome with [`map_gh_outcome`].
+/// Test: `run_gh_surfaces_the_cli_state_legibly` (environment-tolerant); the
+/// outcome mapping itself is pinned deterministically by `map_gh_outcome_*`.
 pub(super) async fn run_gh(
-    root: &Path,
-    args: &[String],
-    tolerate_nonzero: bool,
-) -> crate::tools::traits::ToolResult {
-    run_program("gh", GH_MISSING_HINT, root, args, tolerate_nonzero).await
-}
-
-/// Spawn `program` with a fixed argv and map its outcome onto a `ToolResult`.
-///
-/// Why: Split out of [`run_gh`] so the two behaviours that actually matter —
-/// non-zero-exit TOLERANCE and the missing-binary message — are testable
-/// deterministically on any POSIX host, without requiring `gh` to be installed
-/// and authenticated in CI. A test that can only ever skip proves nothing, and
-/// the tolerance rule is the one piece of logic here whose regression would be
-/// invisible (every red PR would silently start reading as a tool failure).
-/// What: Runs `program <args>` with `current_dir(root)`, never a shell. On
-/// success returns stdout (or a "no output" note when the program printed
-/// nothing). On non-zero exit returns an error carrying stderr — unless
-/// `tolerate_nonzero`, in which case stdout+stderr and the exit status are
-/// returned as a SUCCESS payload. A spawn failure appends `hint`.
-/// Test: `run_program_tolerates_a_nonzero_exit_when_asked`,
-/// `run_program_reports_a_nonzero_exit_as_an_error_by_default`,
-/// `run_program_reports_a_missing_binary_with_the_hint`,
-/// `run_program_notes_empty_output`.
-pub(super) async fn run_program(
-    program: &str,
-    hint: &str,
     root: &Path,
     args: &[String],
     tolerate_nonzero: bool,
 ) -> crate::tools::traits::ToolResult {
     use crate::tools::traits::ToolResult;
 
-    let rendered = args.join(" ");
-    let output = match Command::new(program)
-        .args(args)
-        .current_dir(root)
-        .output()
-        .await
-    {
-        Ok(o) => o,
-        Err(e) => {
-            return ToolResult::err(format!("failed to run '{program} {rendered}': {e}. {hint}"));
+    match GhCommand::new(args).cwd(root).output().await {
+        Ok(out) => map_gh_outcome(&out, tolerate_nonzero),
+        // #5475: the entry point already classifies a missing binary and its
+        // Display carries the `gh auth login` hint, so no local hint string.
+        Err(e) => ToolResult::err(format!("failed to run 'gh {}': {e}", args.join(" "))),
+    }
+}
+
+/// Map a completed `gh` run onto a `ToolResult` (pure).
+///
+/// Why: split from the spawn so the two behaviours that actually matter —
+/// non-zero-exit TOLERANCE and the empty-output note — are pinned
+/// deterministically, with no `gh` install and no subprocess at all. A test
+/// that can only ever skip proves nothing, and the tolerance rule is the one
+/// piece of logic whose regression would be invisible (every red PR would
+/// silently start reading as a tool failure).
+/// What: zero exit with output -> that stdout; zero exit with no output -> a
+/// "no output" note; non-zero -> an error carrying stderr (or stdout when
+/// stderr is blank), unless `tolerate_nonzero`, in which case the exit status
+/// and both streams are returned as a SUCCESS payload.
+/// Test: `map_gh_outcome_tolerates_a_nonzero_exit_when_asked`,
+/// `map_gh_outcome_reports_a_nonzero_exit_as_an_error_by_default`,
+/// `map_gh_outcome_notes_empty_output`.
+pub(super) fn map_gh_outcome(
+    out: &GhOutput,
+    tolerate_nonzero: bool,
+) -> crate::tools::traits::ToolResult {
+    use crate::tools::traits::ToolResult;
+
+    let exit = out
+        .code
+        .map_or_else(|| "signal".to_string(), |c| c.to_string());
+    if out.success {
+        if out.stdout.trim().is_empty() {
+            return ToolResult::ok(format!("gh {}: no output", out.args));
         }
-    };
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-    if output.status.success() {
-        if stdout.trim().is_empty() {
-            return ToolResult::ok(format!("{program} {rendered}: no output"));
-        }
-        return ToolResult::ok(stdout);
+        return ToolResult::ok(out.stdout.clone());
     }
     if tolerate_nonzero {
         // The exit status IS the answer here; report it alongside the output
         // rather than discarding either.
         return ToolResult::ok(format!(
-            "{program} {rendered} (exit {})\n{stdout}{stderr}",
-            output
-                .status
-                .code()
-                .map_or_else(|| "signal".to_string(), |c| c.to_string())
+            "gh {} (exit {exit})\n{}{}",
+            out.args, out.stdout, out.stderr
         ));
     }
     ToolResult::err(format!(
-        "{program} {rendered} failed (exit {}): {}",
-        output
-            .status
-            .code()
-            .map_or_else(|| "signal".to_string(), |c| c.to_string()),
-        if stderr.trim().is_empty() {
-            stdout.trim()
+        "gh {} failed (exit {exit}): {}",
+        out.args,
+        if out.stderr.trim().is_empty() {
+            out.stdout.trim()
         } else {
-            stderr.trim()
+            out.stderr.trim()
         }
     ))
 }

--- a/crates/trusty-agents/src/tools/gh_tools/tests.rs
+++ b/crates/trusty-agents/src/tools/gh_tools/tests.rs
@@ -10,7 +10,7 @@
 //! subcommand assertions, and validator rejection cases.
 //! Test: this file.
 
-use super::helpers::{enum_arg, limit_arg, plain_arg, repo_arg, run_gh, run_program};
+use super::helpers::{enum_arg, limit_arg, map_gh_outcome, plain_arg, repo_arg, run_gh};
 use super::*;
 use serde_json::json;
 
@@ -355,59 +355,54 @@ async fn gh_run_view_rejects_a_missing_run_id() {
 }
 
 // --------------------------------------------------------------------------
-// Subprocess outcome mapping — exercised via `run_program` against POSIX
-// utilities so the tolerance rule is pinned WITHOUT requiring an installed,
-// authenticated `gh` (a test that can only skip in CI proves nothing).
+// Outcome mapping — pinned deterministically against `GhOutput` values, so
+// the tolerance rule holds without an installed, authenticated `gh` (#5475;
+// a test that can only skip in CI proves nothing).
 // --------------------------------------------------------------------------
 
-#[tokio::test]
-async fn run_program_tolerates_a_nonzero_exit_when_asked() {
+fn gh_out(code: i32, stdout: &str, stderr: &str) -> trusty_common::gh::GhOutput {
+    trusty_common::gh::GhOutput::from_parts("pr checks 1", Some(code), stdout, stderr)
+}
+
+#[test]
+fn map_gh_outcome_tolerates_a_nonzero_exit_when_asked() {
     // THE rule `gh pr checks` depends on: a non-zero exit is check STATE, not
     // a tool failure. If this regresses, every red or pending PR starts
     // reading as `is_error` to the model.
-    let out = run_program("false", "hint", &root(), &[], true).await;
+    let out = map_gh_outcome(&gh_out(1, "pending\n", ""), true);
     assert!(
         !out.is_error(),
         "a tolerated non-zero exit must stay a success: {}",
         out.content()
     );
     assert!(out.content().contains("(exit 1)"), "{}", out.content());
+    assert!(out.content().contains("pending"), "{}", out.content());
 }
 
-#[tokio::test]
-async fn run_program_reports_a_nonzero_exit_as_an_error_by_default() {
-    let out = run_program("false", "hint", &root(), &[], false).await;
+#[test]
+fn map_gh_outcome_reports_a_nonzero_exit_as_an_error_by_default() {
+    let out = map_gh_outcome(&gh_out(1, "", "no such PR"), false);
     assert!(out.is_error());
     assert!(
         out.content().contains("failed (exit 1)"),
         "{}",
         out.content()
     );
+    assert!(out.content().contains("no such PR"), "{}", out.content());
 }
 
-#[tokio::test]
-async fn run_program_reports_a_missing_binary_with_the_hint() {
-    let out = run_program(
-        "trusty-no-such-binary-4170",
-        "install it first",
-        &root(),
-        &[],
-        false,
-    )
-    .await;
-    assert!(out.is_error());
-    assert!(
-        out.content().contains("install it first"),
-        "{}",
-        out.content()
-    );
-}
-
-#[tokio::test]
-async fn run_program_notes_empty_output() {
-    let out = run_program("true", "hint", &root(), &[], false).await;
+#[test]
+fn map_gh_outcome_notes_empty_output() {
+    let out = map_gh_outcome(&gh_out(0, "  \n", ""), false);
     assert!(!out.is_error());
     assert!(out.content().contains("no output"), "{}", out.content());
+}
+
+#[tokio::test]
+async fn run_gh_reports_a_missing_binary_with_the_login_hint() {
+    // The entry point's `NotInstalled` message must survive out to the model.
+    let e = trusty_common::gh::GhError::NotInstalled.to_string();
+    assert!(e.contains("gh auth login"), "{e}");
 }
 
 #[tokio::test]

--- a/crates/trusty-agents/src/workflow/tickets.rs
+++ b/crates/trusty-agents/src/workflow/tickets.rs
@@ -10,7 +10,8 @@
 //! tracks the run from start to completion — phases, costs, and final status —
 //! giving full traceability from git history to GitHub Issues without manual
 //! effort. Opt-in per-workflow via `ticket_management.enabled = true`.
-//! What: Wraps the `gh` CLI via `tokio::process::Command`. A `TicketManager`
+//! What: Wraps the `gh` CLI via trusty-common's `gh::GhCommand` entry point
+//! (#5475). A `TicketManager`
 //! owns a single `issue_number` across the lifecycle; hooks fire at workflow
 //! start, after each phase, and at success/failure. All `gh` failures are
 //! non-fatal — they are logged and the workflow continues.
@@ -18,7 +19,7 @@
 
 use std::path::Path;
 
-use tokio::process::Command;
+use trusty_common::gh::GhCommand;
 
 use crate::workflow::config::TicketManagementConfig;
 
@@ -125,12 +126,13 @@ impl TicketManager {
             args.push(self.config.milestone.clone());
         }
 
-        let output = Command::new("gh").args(&args).output().await?;
+        // #5475: single `gh` entry point.
+        let output = GhCommand::new(&args).output().await?;
 
-        if output.status.success() {
+        if output.success {
             // `gh issue create` prints the issue URL on stdout; the issue
             // number is the last path segment.
-            let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let url = output.stdout_trimmed().to_string();
             if let Some(num_str) = url.rsplit('/').next()
                 && let Ok(num) = num_str.parse::<u64>()
             {
@@ -143,7 +145,7 @@ impl TicketManager {
                 );
             }
         } else {
-            let err = String::from_utf8_lossy(&output.stderr);
+            let err = &output.stderr;
             tracing::warn!("ticket manager: issue create failed: {}", err);
         }
 
@@ -235,19 +237,18 @@ impl TicketManager {
         self.add_comment(issue, &comment).await?;
 
         if self.config.close_on_success {
-            let close_status = Command::new("gh")
-                .args([
-                    "issue",
-                    "close",
-                    &issue.to_string(),
-                    "--repo",
-                    &self.config.repo,
-                    "--comment",
-                    "Closing — workflow run succeeded.",
-                ])
-                .status()
-                .await?;
-            if close_status.success() {
+            let close = GhCommand::new([
+                "issue",
+                "close",
+                &issue.to_string(),
+                "--repo",
+                &self.config.repo,
+                "--comment",
+                "Closing — workflow run succeeded.",
+            ])
+            .output()
+            .await?;
+            if close.success {
                 tracing::info!(issue = issue, "ticket manager: closed issue");
             } else {
                 tracing::warn!(issue = issue, "ticket manager: close failed");
@@ -308,27 +309,26 @@ impl TicketManager {
             return Ok(());
         };
 
-        let output = Command::new("gh")
-            .args([
-                "issue",
-                "list",
-                "--repo",
-                &self.config.repo,
-                "--state",
-                "all",
-                "--search",
-                task_keywords,
-                "--limit",
-                "5",
-                "--json",
-                "number,title",
-                "--jq",
-                ".[] | \"#\\(.number): \\(.title)\"",
-            ])
-            .output()
-            .await?;
+        let output = GhCommand::new([
+            "issue",
+            "list",
+            "--repo",
+            &self.config.repo,
+            "--state",
+            "all",
+            "--search",
+            task_keywords,
+            "--limit",
+            "5",
+            "--json",
+            "number,title",
+            "--jq",
+            ".[] | \"#\\(.number): \\(.title)\"",
+        ])
+        .output()
+        .await?;
 
-        let related = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let related = output.stdout_trimmed().to_string();
         if related.is_empty() {
             return Ok(());
         }
@@ -357,21 +357,20 @@ impl TicketManager {
     /// warning on non-zero exit. Always returns `Ok(())`.
     /// Test: Covered implicitly by the hook-level integration tests.
     async fn add_comment(&self, issue: u64, body: &str) -> anyhow::Result<()> {
-        let output = Command::new("gh")
-            .args([
-                "issue",
-                "comment",
-                &issue.to_string(),
-                "--repo",
-                &self.config.repo,
-                "--body",
-                body,
-            ])
-            .output()
-            .await?;
+        let output = GhCommand::new([
+            "issue",
+            "comment",
+            &issue.to_string(),
+            "--repo",
+            &self.config.repo,
+            "--body",
+            body,
+        ])
+        .output()
+        .await?;
 
-        if !output.status.success() {
-            let err = String::from_utf8_lossy(&output.stderr);
+        if !output.success {
+            let err = &output.stderr;
             tracing::warn!(issue = issue, "ticket manager: comment failed: {}", err);
         }
         Ok(())

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -502,7 +502,11 @@ embedder-client = ["dep:thiserror", "embedder", "uds"]
 # JIRA, and Linear backends (absorbed from the former standalone `trusty-tickets`
 # crate). Pulls in `chrono`, `uuid`, `base64`, `thiserror`, and `toml` as
 # additional optional deps. Requires the `mcp` feature for the stdio loop.
-tickets = ["mcp", "dep:uuid", "dep:base64", "dep:thiserror", "dep:toml"]
+tickets = ["mcp", "dep:uuid", "dep:base64", "dep:thiserror", "dep:toml", "gh-cli"]
+# Enables the `gh` module: the workspace's single entry point for invoking the
+# GitHub CLI (#5475). Pulls in `thiserror` only — `tokio/process`, `serde` and
+# `serde_json` are already unconditional here.
+gh-cli = ["dep:thiserror"]
 # Enables the `intent_source` module: the shared intent-source resolver (ISR)
 # for the intent/method conformance gates (DOC-15, SPEC-CONFORMANCE-03, #1358).
 # Resolves the ticket method + spec method from a PR or ticket-id and applies

--- a/crates/trusty-common/changelog.d/5475-gh-entry-point.md
+++ b/crates/trusty-common/changelog.d/5475-gh-entry-point.md
@@ -13,5 +13,7 @@ Added
   policies on top; a missing binary is classified as `GhError::NotInstalled`
   with the `gh auth login` hint rather than an opaque IO error.
 - `tickets`' GitHub backend resolves its `gh auth token` fallback through that
-  entry point. Behaviour is unchanged, including the rejection of the
-  zero-exit-empty-output response `gh` gives when no account is logged in.
+  entry point. Behaviour is unchanged, including the post-trim blank-output
+  rejection: `gh auth token` exits non-zero when no account is logged in, but
+  with `GH_TOKEN="   "` it exits ZERO printing whitespace, which a status-only
+  check would pass on as a credential.

--- a/crates/trusty-common/changelog.d/5475-gh-entry-point.md
+++ b/crates/trusty-common/changelog.d/5475-gh-entry-point.md
@@ -1,0 +1,17 @@
+Added
+
+- `gh::GhCommand` — the workspace's single entry point for invoking the GitHub
+  CLI ([#5475](https://github.com/bobmatnyc/trusty-tools/issues/5475)), behind
+  the new `gh-cli` feature (implied by `tickets`). It renders `gh <args>` with
+  an optional `--repo`, working directory, and environment overlay/removals,
+  and runs it blocking, on tokio, or hands back the unspawned
+  `std::process::Command` for call sites with their own timeout machinery.
+  Every runner returns the full exit/stdout/stderr triple in `GhOutput` and
+  never decides that a non-zero exit is fatal — `gh pr checks` reports check
+  state through its exit code, so that policy stays at the call site.
+  `GhOutput::ok`, `nonempty_stdout`, `json`, and `gh_available` are the shared
+  policies on top; a missing binary is classified as `GhError::NotInstalled`
+  with the `gh auth login` hint rather than an opaque IO error.
+- `tickets`' GitHub backend resolves its `gh auth token` fallback through that
+  entry point. Behaviour is unchanged, including the rejection of the
+  zero-exit-empty-output response `gh` gives when no account is logged in.

--- a/crates/trusty-common/src/gh.rs
+++ b/crates/trusty-common/src/gh.rs
@@ -1,0 +1,578 @@
+//! The workspace's single entry point for invoking the GitHub CLI (`gh`) — #5475.
+//!
+//! Why: before this module, `gh` was spawned from a dozen independent
+//! `Command::new("gh")` sites across four crates, each re-deriving its own
+//! answer to the same four questions: what to do when the binary is missing,
+//! what to do when the user is not authenticated, whether a non-zero exit is
+//! an error or a signal, and whether stderr reaches the caller. That is the
+//! shape the repo's "common entry point, clean domain demarcation" rule
+//! exists to prevent — a message improvement or an auth fix had to land N
+//! times or silently drift. #5487 (repo discovery) and #5215 (clone) are both
+//! about to route through `gh`, so the entry point lands before them rather
+//! than after two more bespoke copies.
+//! What: [`GhCommand`], a builder that renders `gh <args>` with an optional
+//! `--repo`, working directory, and environment overlay, and runs it either
+//! blocking ([`GhCommand::output_blocking`]) or on tokio
+//! ([`GhCommand::output`]). Every runner returns a [`GhOutput`] carrying the
+//! full triple (exit code, stdout, stderr) and NEVER decides on the caller's
+//! behalf that a non-zero exit is fatal — `gh pr checks` uses its exit code to
+//! report check state, so that policy belongs at the call site. The policies
+//! callers actually share are offered as thin combinators on top:
+//! [`GhCommand::stdout`] (non-zero is an error), [`GhCommand::nonempty_stdout`]
+//! (also rejects empty output), [`GhCommand::json`] (also parses), and
+//! [`gh_available`] (a pure probe). Spawn failure is classified: a missing
+//! binary becomes [`GhError::NotInstalled`] with the `gh auth login` hint,
+//! distinct from any other IO failure.
+//! Test: `tests::*` in this file cover argv rendering, `--repo` placement,
+//! the missing-binary classification, non-zero-exit mapping, empty-output
+//! rejection, and JSON parse failure — all without a real `gh` install, by
+//! pointing `PATH`-independent spawns at a nonexistent binary and by
+//! exercising the pure `GhOutput` policy combinators directly.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+use serde::de::DeserializeOwned;
+
+/// The GitHub CLI binary name. The single place the string `"gh"` is spelled.
+pub const GH_BIN: &str = "gh";
+
+/// Guidance appended whenever the `gh` binary itself cannot be spawned.
+pub const GH_MISSING_HINT: &str =
+    "The GitHub CLI must be installed and authenticated (`gh auth login`) for this to work.";
+
+/// Every way a `gh` invocation can fail, as a structured library error.
+///
+/// Why: the call sites this replaced each hand-rolled a message, so "gh is not
+/// installed" and "gh is installed but you are not logged in" were
+/// indistinguishable to a caller that wanted to degrade differently for each.
+/// What: `NotInstalled` is the missing-binary case specifically;
+/// `Spawn` is any other IO failure starting the process; `NonZero` carries the
+/// exit status and trimmed stderr; `Empty` is a zero exit with no stdout
+/// (which for `gh auth token` means unauthenticated); `Json` is a `--json`
+/// payload that did not parse.
+/// Test: `missing_binary_is_classified_not_installed`,
+/// `nonzero_exit_carries_stderr`, `empty_stdout_is_rejected`,
+/// `malformed_json_is_reported_as_json_error`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum GhError {
+    /// `gh` is not on `PATH`.
+    #[error("`gh` is not installed or not on PATH. {GH_MISSING_HINT}")]
+    NotInstalled,
+    /// `gh` is present but the process could not be started.
+    #[error("failed to spawn `gh {args}`: {source}")]
+    Spawn {
+        /// The rendered argv, for the message.
+        args: String,
+        /// The underlying IO error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// `gh` ran and exited non-zero.
+    #[error("`gh {args}` failed ({status}): {stderr}")]
+    NonZero {
+        /// The rendered argv.
+        args: String,
+        /// The exit status, rendered.
+        status: String,
+        /// Trimmed stderr.
+        stderr: String,
+    },
+    /// `gh` exited zero but printed nothing where output was required.
+    #[error("`gh {args}` returned empty output. {GH_MISSING_HINT}")]
+    Empty {
+        /// The rendered argv.
+        args: String,
+    },
+    /// A `--json` payload did not parse.
+    #[error("failed to parse `gh {args}` JSON output: {source}")]
+    Json {
+        /// The rendered argv.
+        args: String,
+        /// The serde failure.
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+/// The complete result of one `gh` invocation.
+///
+/// Why: a non-zero exit is a FAILURE at some call sites and a SIGNAL at others
+/// (`gh pr checks` exits non-zero while checks are pending), so the runner
+/// must hand back the raw triple and let the caller pick. Every shared policy
+/// is a method here rather than a behaviour baked into the spawn.
+/// What: the rendered argv, the exit code (`None` if signalled), whether the
+/// exit was zero, and lossy-decoded stdout/stderr.
+/// Test: `output_ok_maps_nonzero_to_error`, `combined_joins_streams`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct GhOutput {
+    /// The argv this output came from, rendered space-separated (no `gh`).
+    pub args: String,
+    /// Exit code, or `None` when the process was terminated by a signal.
+    pub code: Option<i32>,
+    /// Whether the process exited zero.
+    pub success: bool,
+    /// Lossy-decoded stdout, verbatim (never trimmed).
+    pub stdout: String,
+    /// Lossy-decoded stderr, verbatim (never trimmed).
+    pub stderr: String,
+}
+
+impl GhOutput {
+    /// Assemble an outcome from a run this module did not spawn.
+    ///
+    /// Why: [`GhCommand::to_std_command`] exists for call sites that own their
+    /// own runner (a kill-on-expiry timeout, a bounded worker thread). Those
+    /// callers still want the shared policy combinators — `ok`, `combined`,
+    /// `stdout_trimmed` — so they need a way to build the triple the runner
+    /// produced. `#[non_exhaustive]` is what makes that a constructor rather
+    /// than a struct literal (#5475).
+    /// What: `code` is the process exit code, `None` when signalled; `success`
+    /// is derived as `code == Some(0)`.
+    /// Test: `from_parts_derives_success_from_the_exit_code`.
+    pub fn from_parts(
+        args: impl Into<String>,
+        code: Option<i32>,
+        stdout: impl Into<String>,
+        stderr: impl Into<String>,
+    ) -> Self {
+        Self {
+            args: args.into(),
+            code,
+            success: code == Some(0),
+            stdout: stdout.into(),
+            stderr: stderr.into(),
+        }
+    }
+
+    fn from_output(args: String, out: Output) -> Self {
+        Self {
+            args,
+            code: out.status.code(),
+            success: out.status.success(),
+            stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        }
+    }
+
+    /// Treat a non-zero exit as an error, returning `self` otherwise.
+    pub fn ok(self) -> Result<Self, GhError> {
+        if self.success {
+            return Ok(self);
+        }
+        Err(GhError::NonZero {
+            args: self.args,
+            status: self
+                .code
+                .map_or_else(|| "signalled".to_string(), |c| format!("exit {c}")),
+            stderr: self.stderr.trim().to_string(),
+        })
+    }
+
+    /// stdout with surrounding whitespace removed.
+    pub fn stdout_trimmed(&self) -> &str {
+        self.stdout.trim()
+    }
+
+    /// stdout followed by stderr, for callers that surface `gh`'s full report.
+    pub fn combined(&self) -> String {
+        format!("{}\n{}", self.stdout, self.stderr)
+    }
+}
+
+/// A `gh` invocation, built then run.
+///
+/// Why: the one place that decides how `gh` is located, how its argv is
+/// rendered for error messages, and how a spawn failure is classified.
+/// What: an argv plus an optional `--repo` selector, working directory, and
+/// environment overlay. Never goes through a shell, so no argument is ever
+/// word-split or glob-expanded.
+/// Test: `argv_renders_without_the_binary_name`, `repo_is_prepended_once`.
+#[derive(Debug, Clone, Default)]
+pub struct GhCommand {
+    args: Vec<OsString>,
+    cwd: Option<PathBuf>,
+    envs: Vec<(OsString, OsString)>,
+    env_removals: Vec<OsString>,
+}
+
+impl GhCommand {
+    /// Build an invocation from a fully-formed argv (without the `gh` itself).
+    pub fn new<I, S>(args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        Self {
+            args: args
+                .into_iter()
+                .map(|a| a.as_ref().to_os_string())
+                .collect(),
+            ..Self::default()
+        }
+    }
+
+    /// Prepend `--repo <owner/repo>`; `None` leaves `gh`'s cwd-remote default.
+    #[must_use]
+    pub fn repo(mut self, repo: Option<&str>) -> Self {
+        if let Some(repo) = repo.filter(|r| !r.trim().is_empty()) {
+            let mut prefixed: Vec<OsString> = vec![OsString::from("--repo"), OsString::from(repo)];
+            prefixed.append(&mut self.args);
+            self.args = prefixed;
+        }
+        self
+    }
+
+    /// Run `gh` with this working directory rather than the caller's.
+    #[must_use]
+    pub fn cwd(mut self, dir: impl AsRef<Path>) -> Self {
+        self.cwd = Some(dir.as_ref().to_path_buf());
+        self
+    }
+
+    /// Overlay one environment variable on the child process.
+    #[must_use]
+    pub fn env(mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) -> Self {
+        self.envs
+            .push((key.as_ref().to_os_string(), value.as_ref().to_os_string()));
+        self
+    }
+
+    /// Remove one environment variable from the child process.
+    ///
+    /// Why: `gh` reads `GH_REPO`, `GH_HOST` and `GH_TOKEN` from the
+    /// environment, so a probe that must answer for a SPECIFIC directory or
+    /// account has to strip the ambient overrides rather than inherit them.
+    #[must_use]
+    pub fn env_remove(mut self, key: impl AsRef<OsStr>) -> Self {
+        self.env_removals.push(key.as_ref().to_os_string());
+        self
+    }
+
+    /// The argv rendered for error messages — lossy, space-separated, no `gh`.
+    pub fn argv_display(&self) -> String {
+        self.args
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn configure<C: CommandLike>(&self, mut cmd: C) -> C {
+        cmd.apply_args(&self.args);
+        if let Some(dir) = &self.cwd {
+            cmd.apply_cwd(dir);
+        }
+        for (k, v) in &self.envs {
+            cmd.apply_env(k, v);
+        }
+        for k in &self.env_removals {
+            cmd.apply_env_remove(k);
+        }
+        cmd
+    }
+
+    fn classify(&self, err: std::io::Error) -> GhError {
+        // #5475: a missing binary is the one spawn failure callers want to
+        // degrade on differently, so it gets its own variant here rather than
+        // a string match at each call site.
+        if err.kind() == std::io::ErrorKind::NotFound {
+            GhError::NotInstalled
+        } else {
+            GhError::Spawn {
+                args: self.argv_display(),
+                source: err,
+            }
+        }
+    }
+
+    /// The configured [`std::process::Command`], not yet spawned.
+    ///
+    /// Why: a call site that owns its own spawn machinery — a wall-clock
+    /// timeout, a kill-on-expiry probe — still has to agree with everyone else
+    /// on WHICH binary, WHICH argv, and WHICH environment scrub. This hands it
+    /// the configured command and lets it keep its own runner, rather than
+    /// forcing every such caller to re-spell `Command::new("gh")` (#5475).
+    /// What: applies argv, working directory, and the environment overlay and
+    /// removals to a fresh `std::process::Command`.
+    /// Test: `to_std_command_carries_argv_and_env`.
+    pub fn to_std_command(&self) -> std::process::Command {
+        self.configure(std::process::Command::new(GH_BIN))
+    }
+
+    /// Run `gh` to completion on the current thread.
+    ///
+    /// A non-zero exit is NOT an error here — see [`GhOutput::ok`].
+    pub fn output_blocking(&self) -> Result<GhOutput, GhError> {
+        let out = self
+            .configure(std::process::Command::new(GH_BIN))
+            .output()
+            .map_err(|e| self.classify(e))?;
+        Ok(GhOutput::from_output(self.argv_display(), out))
+    }
+
+    /// Run `gh` to completion on the tokio runtime.
+    ///
+    /// A non-zero exit is NOT an error here — see [`GhOutput::ok`].
+    pub async fn output(&self) -> Result<GhOutput, GhError> {
+        let out = self
+            .configure(tokio::process::Command::new(GH_BIN))
+            .output()
+            .await
+            .map_err(|e| self.classify(e))?;
+        Ok(GhOutput::from_output(self.argv_display(), out))
+    }
+
+    /// Run `gh`, requiring a zero exit, and return verbatim stdout.
+    pub async fn stdout(&self) -> Result<String, GhError> {
+        Ok(self.output().await?.ok()?.stdout)
+    }
+
+    /// Blocking [`GhCommand::stdout`].
+    pub fn stdout_blocking(&self) -> Result<String, GhError> {
+        Ok(self.output_blocking()?.ok()?.stdout)
+    }
+
+    /// Run `gh`, requiring a zero exit AND non-empty output, trimmed.
+    ///
+    /// Why: `gh auth token` exits zero and prints nothing when no account is
+    /// logged in, so a caller that only checked the exit status would hand an
+    /// empty string onward as if it were a credential.
+    pub async fn nonempty_stdout(&self) -> Result<String, GhError> {
+        require_nonempty(self.output().await?.ok()?)
+    }
+
+    /// Blocking [`GhCommand::nonempty_stdout`].
+    pub fn nonempty_stdout_blocking(&self) -> Result<String, GhError> {
+        require_nonempty(self.output_blocking()?.ok()?)
+    }
+
+    /// Run `gh --json …`, requiring a zero exit, and deserialize stdout.
+    pub async fn json<T: DeserializeOwned>(&self) -> Result<T, GhError> {
+        let out = self.output().await?.ok()?;
+        serde_json::from_str(&out.stdout).map_err(|source| GhError::Json {
+            args: out.args,
+            source,
+        })
+    }
+}
+
+fn require_nonempty(out: GhOutput) -> Result<String, GhError> {
+    let trimmed = out.stdout_trimmed().to_string();
+    if trimmed.is_empty() {
+        return Err(GhError::Empty { args: out.args });
+    }
+    Ok(trimmed)
+}
+
+/// Is `gh` installed AND authenticated?
+///
+/// Why: a fallback chooser needs one boolean, and every failure mode (missing
+/// binary, missing login, IO error) means the same thing to it: do not pick
+/// the `gh` backend. This collapses them deliberately — it is a PROBE, not a
+/// gate, and no state advances on the strength of a `true` it did not earn.
+/// Callers that must distinguish the modes use [`GhCommand`] directly and read
+/// [`GhError`].
+/// What: runs `gh auth status`, returns whether it exited zero.
+/// Test: `gh_available_is_a_pure_probe` (asserts no panic; the boolean is
+/// environment-dependent).
+pub async fn gh_available() -> bool {
+    matches!(GhCommand::new(["auth", "status"]).output().await, Ok(o) if o.success)
+}
+
+/// Blocking [`gh_available`].
+pub fn gh_available_blocking() -> bool {
+    matches!(GhCommand::new(["auth", "status"]).output_blocking(), Ok(o) if o.success)
+}
+
+/// The two `Command` types share no trait, so this is the seam that lets
+/// [`GhCommand::configure`] be written once for both.
+trait CommandLike {
+    fn apply_args(&mut self, args: &[OsString]);
+    fn apply_cwd(&mut self, dir: &Path);
+    fn apply_env(&mut self, k: &OsStr, v: &OsStr);
+    fn apply_env_remove(&mut self, k: &OsStr);
+}
+
+impl CommandLike for std::process::Command {
+    fn apply_args(&mut self, args: &[OsString]) {
+        self.args(args);
+    }
+    fn apply_cwd(&mut self, dir: &Path) {
+        self.current_dir(dir);
+    }
+    fn apply_env(&mut self, k: &OsStr, v: &OsStr) {
+        self.env(k, v);
+    }
+    fn apply_env_remove(&mut self, k: &OsStr) {
+        self.env_remove(k);
+    }
+}
+
+impl CommandLike for tokio::process::Command {
+    fn apply_args(&mut self, args: &[OsString]) {
+        self.args(args);
+    }
+    fn apply_cwd(&mut self, dir: &Path) {
+        self.current_dir(dir);
+    }
+    fn apply_env(&mut self, k: &OsStr, v: &OsStr) {
+        self.env(k, v);
+    }
+    fn apply_env_remove(&mut self, k: &OsStr) {
+        self.env_remove(k);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn out(code: i32, stdout: &str, stderr: &str) -> GhOutput {
+        GhOutput::from_parts("auth token", Some(code), stdout, stderr)
+    }
+
+    #[test]
+    fn from_parts_derives_success_from_the_exit_code() {
+        assert!(GhOutput::from_parts("x", Some(0), "", "").success);
+        assert!(!GhOutput::from_parts("x", Some(1), "", "").success);
+        // A signalled process is never a success.
+        assert!(!GhOutput::from_parts("x", None, "", "").success);
+    }
+
+    #[test]
+    fn argv_renders_without_the_binary_name() {
+        let cmd = GhCommand::new(["issue", "list", "--limit", "5"]);
+        assert_eq!(cmd.argv_display(), "issue list --limit 5");
+    }
+
+    #[test]
+    fn repo_is_prepended_once() {
+        let cmd = GhCommand::new(["issue", "list"]).repo(Some("o/r"));
+        assert_eq!(cmd.argv_display(), "--repo o/r issue list");
+    }
+
+    #[test]
+    fn repo_none_or_blank_leaves_argv_untouched() {
+        assert_eq!(
+            GhCommand::new(["issue", "list"]).repo(None).argv_display(),
+            "issue list"
+        );
+        assert_eq!(
+            GhCommand::new(["issue", "list"])
+                .repo(Some("   "))
+                .argv_display(),
+            "issue list"
+        );
+    }
+
+    #[test]
+    fn output_ok_maps_nonzero_to_error() {
+        let err = out(1, "", "  not logged in  ").ok().unwrap_err();
+        let GhError::NonZero { status, stderr, .. } = &err else {
+            panic!("expected NonZero, got {err:?}");
+        };
+        assert_eq!(status, "exit 1");
+        assert_eq!(stderr, "not logged in");
+    }
+
+    #[test]
+    fn nonzero_exit_carries_stderr() {
+        assert!(
+            out(2, "", "boom")
+                .ok()
+                .unwrap_err()
+                .to_string()
+                .contains("boom")
+        );
+    }
+
+    #[test]
+    fn zero_exit_passes_through_ok() {
+        assert_eq!(out(0, "tok\n", "").ok().unwrap().stdout_trimmed(), "tok");
+    }
+
+    #[test]
+    fn empty_stdout_is_rejected() {
+        // #5475: `gh auth token` exits ZERO with empty stdout when no account
+        // is logged in — the fail-open this combinator exists to close.
+        let err = require_nonempty(out(0, "  \n ", "")).unwrap_err();
+        assert!(matches!(err, GhError::Empty { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn nonempty_stdout_trims_a_real_value() {
+        assert_eq!(require_nonempty(out(0, " a-token \n", "")).unwrap(), "a-token");
+    }
+
+    #[test]
+    fn combined_joins_streams() {
+        assert_eq!(out(0, "a", "b").combined(), "a\nb");
+    }
+
+    #[test]
+    fn malformed_json_is_reported_as_json_error() {
+        let e = serde_json::from_str::<serde_json::Value>("{oops").unwrap_err();
+        let err = GhError::Json {
+            args: "issue list --json number".to_string(),
+            source: e,
+        };
+        assert!(err.to_string().contains("JSON"), "{err}");
+    }
+
+    #[test]
+    fn missing_binary_is_classified_not_installed() {
+        let cmd = GhCommand::new(["auth", "status"]);
+        let err = cmd.classify(std::io::Error::from(std::io::ErrorKind::NotFound));
+        assert!(matches!(err, GhError::NotInstalled), "got {err:?}");
+        assert!(err.to_string().contains("gh auth login"));
+    }
+
+    #[test]
+    fn other_spawn_failures_stay_distinct_from_not_installed() {
+        let cmd = GhCommand::new(["auth", "status"]);
+        let err = cmd.classify(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+        assert!(matches!(err, GhError::Spawn { .. }), "got {err:?}");
+        assert!(err.to_string().contains("auth status"));
+    }
+
+    #[tokio::test]
+    async fn gh_available_is_a_pure_probe() {
+        let _ = gh_available().await;
+    }
+
+    #[test]
+    fn cwd_and_env_survive_onto_the_builder() {
+        let cmd = GhCommand::new(["repo", "view"])
+            .cwd("/tmp")
+            .env("GH_CONFIG_DIR", "/tmp/ghcfg");
+        assert_eq!(cmd.cwd.as_deref(), Some(Path::new("/tmp")));
+        assert_eq!(cmd.envs.len(), 1);
+        assert_eq!(cmd.envs[0].0, OsString::from("GH_CONFIG_DIR"));
+    }
+
+    #[test]
+    fn to_std_command_carries_argv_and_env() {
+        let cmd = GhCommand::new(["pr", "list"])
+            .cwd("/tmp")
+            .env("GH_PAGER", "")
+            .env_remove("GH_REPO")
+            .to_std_command();
+        assert_eq!(cmd.get_program(), OsStr::new("gh"));
+        let args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(args, vec![OsStr::new("pr"), OsStr::new("list")]);
+        assert_eq!(cmd.get_current_dir(), Some(Path::new("/tmp")));
+        let envs: Vec<_> = cmd.get_envs().collect();
+        assert!(envs.contains(&(OsStr::new("GH_PAGER"), Some(OsStr::new("")))));
+        assert!(envs.contains(&(OsStr::new("GH_REPO"), None)));
+    }
+
+    #[test]
+    fn env_removals_are_recorded() {
+        let cmd = GhCommand::new(["pr", "list"]).env_remove("GH_REPO");
+        assert_eq!(cmd.env_removals, vec![OsString::from("GH_REPO")]);
+    }
+}

--- a/crates/trusty-common/src/gh.rs
+++ b/crates/trusty-common/src/gh.rs
@@ -19,7 +19,7 @@
 //! report check state, so that policy belongs at the call site. The policies
 //! callers actually share are offered as thin combinators on top:
 //! [`GhCommand::stdout`] (non-zero is an error), [`GhCommand::nonempty_stdout`]
-//! (also rejects empty output), [`GhCommand::json`] (also parses), and
+//! (also rejects output that is blank after trimming), [`GhCommand::json`] (also parses), and
 //! [`gh_available`] (a pure probe). Spawn failure is classified: a missing
 //! binary becomes [`GhError::NotInstalled`] with the `gh auth login` hint,
 //! distinct from any other IO failure.
@@ -80,7 +80,7 @@ pub enum GhError {
         /// Trimmed stderr.
         stderr: String,
     },
-    /// `gh` exited zero but printed nothing where output was required.
+    /// `gh` exited zero but printed only whitespace where output was required.
     #[error("`gh {args}` returned empty output. {GH_MISSING_HINT}")]
     Empty {
         /// The rendered argv.
@@ -124,12 +124,13 @@ pub struct GhOutput {
 impl GhOutput {
     /// Assemble an outcome from a run this module did not spawn.
     ///
-    /// Why: [`GhCommand::to_std_command`] exists for call sites that own their
-    /// own runner (a kill-on-expiry timeout, a bounded worker thread). Those
-    /// callers still want the shared policy combinators — `ok`, `combined`,
-    /// `stdout_trimmed` — so they need a way to build the triple the runner
-    /// produced. `#[non_exhaustive]` is what makes that a constructor rather
-    /// than a struct literal (#5475).
+    /// Why: `GhOutput` is `#[non_exhaustive]`, so a consumer crate cannot
+    /// build one with a struct literal — and its tests need to, to exercise
+    /// the policy combinators against a known exit/stdout/stderr triple
+    /// without spawning `gh`. That is what `trusty-agents`' `map_gh_outcome`
+    /// tests do. A call site running its own spawner via
+    /// [`GhCommand::to_std_command`] could use it for the same reason; none
+    /// does today (#5475).
     /// What: `code` is the process exit code, `None` when signalled; `success`
     /// is derived as `code == Some(0)`.
     /// Test: `from_parts_derives_success_from_the_exit_code`.
@@ -195,11 +196,27 @@ impl GhOutput {
 pub struct GhCommand {
     args: Vec<OsString>,
     cwd: Option<PathBuf>,
-    envs: Vec<(OsString, OsString)>,
-    env_removals: Vec<OsString>,
+    /// Set/remove operations in CALL ORDER — `Some(v)` sets, `None` removes.
+    /// One list rather than two, so `.env_remove("X").env("X", "v")` leaves X
+    /// SET, which is what the chain reads as (#5475).
+    envs: Vec<(OsString, Option<OsString>)>,
 }
 
 impl GhCommand {
+    /// A binary-and-environment carrier with NO argv.
+    ///
+    /// Why: a caller that owns its own runner builds the environment here and
+    /// then appends the argv to the [`GhCommand::to_std_command`] result —
+    /// `worktree_reclaim` does exactly that. Naming it stops the empty-argv
+    /// case from reading as an oversight, and keeps anyone from running it:
+    /// `output()` on a bare command would invoke `gh` with no subcommand and
+    /// [`GhCommand::argv_display`] would render nothing (#5475).
+    /// What: equivalent to `GhCommand::new(std::iter::empty::<&str>())`.
+    /// Test: `bare_carries_no_argv`.
+    pub fn bare() -> Self {
+        Self::default()
+    }
+
     /// Build an invocation from a fully-formed argv (without the `gh` itself).
     pub fn new<I, S>(args: I) -> Self
     where
@@ -236,8 +253,10 @@ impl GhCommand {
     /// Overlay one environment variable on the child process.
     #[must_use]
     pub fn env(mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) -> Self {
-        self.envs
-            .push((key.as_ref().to_os_string(), value.as_ref().to_os_string()));
+        self.envs.push((
+            key.as_ref().to_os_string(),
+            Some(value.as_ref().to_os_string()),
+        ));
         self
     }
 
@@ -246,9 +265,13 @@ impl GhCommand {
     /// Why: `gh` reads `GH_REPO`, `GH_HOST` and `GH_TOKEN` from the
     /// environment, so a probe that must answer for a SPECIFIC directory or
     /// account has to strip the ambient overrides rather than inherit them.
+    /// What: recorded in the same list as [`GhCommand::env`], so a later call
+    /// on the same key wins whichever it is.
+    /// Test: `later_env_call_wins_over_an_earlier_removal`,
+    /// `later_removal_wins_over_an_earlier_env_call`.
     #[must_use]
     pub fn env_remove(mut self, key: impl AsRef<OsStr>) -> Self {
-        self.env_removals.push(key.as_ref().to_os_string());
+        self.envs.push((key.as_ref().to_os_string(), None));
         self
     }
 
@@ -267,10 +290,10 @@ impl GhCommand {
             cmd.apply_cwd(dir);
         }
         for (k, v) in &self.envs {
-            cmd.apply_env(k, v);
-        }
-        for k in &self.env_removals {
-            cmd.apply_env_remove(k);
+            match v {
+                Some(v) => cmd.apply_env(k, v),
+                None => cmd.apply_env_remove(k),
+            }
         }
         cmd
     }
@@ -331,16 +354,16 @@ impl GhCommand {
         Ok(self.output().await?.ok()?.stdout)
     }
 
-    /// Blocking [`GhCommand::stdout`].
-    pub fn stdout_blocking(&self) -> Result<String, GhError> {
-        Ok(self.output_blocking()?.ok()?.stdout)
-    }
-
-    /// Run `gh`, requiring a zero exit AND non-empty output, trimmed.
+    /// Run `gh`, requiring a zero exit AND non-blank output, trimmed.
     ///
-    /// Why: `gh auth token` exits zero and prints nothing when no account is
-    /// logged in, so a caller that only checked the exit status would hand an
-    /// empty string onward as if it were a credential.
+    /// Why: `gh auth token` exits non-zero when no account is logged in, so
+    /// the exit status does carry that signal. What it does NOT catch is a
+    /// blank credential supplied through the environment: with
+    /// `GH_TOKEN="   "`, gh 2.89.0 exits ZERO and prints `"   \n"`, so a
+    /// caller checking only the status hands whitespace onward as a token.
+    /// The check is post-trim for that reason.
+    /// What: `ok()` first, then rejects stdout that is empty after trimming.
+    /// Test: `empty_stdout_is_rejected`, `nonempty_stdout_trims_a_real_value`.
     pub async fn nonempty_stdout(&self) -> Result<String, GhError> {
         require_nonempty(self.output().await?.ok()?)
     }
@@ -381,11 +404,6 @@ fn require_nonempty(out: GhOutput) -> Result<String, GhError> {
 /// environment-dependent).
 pub async fn gh_available() -> bool {
     matches!(GhCommand::new(["auth", "status"]).output().await, Ok(o) if o.success)
-}
-
-/// Blocking [`gh_available`].
-pub fn gh_available_blocking() -> bool {
-    matches!(GhCommand::new(["auth", "status"]).output_blocking(), Ok(o) if o.success)
 }
 
 /// The two `Command` types share no trait, so this is the seam that lets
@@ -450,6 +468,11 @@ mod tests {
     }
 
     #[test]
+    fn bare_carries_no_argv() {
+        assert_eq!(GhCommand::bare().argv_display(), "");
+    }
+
+    #[test]
     fn repo_is_prepended_once() {
         let cmd = GhCommand::new(["issue", "list"]).repo(Some("o/r"));
         assert_eq!(cmd.argv_display(), "--repo o/r issue list");
@@ -497,15 +520,20 @@ mod tests {
 
     #[test]
     fn empty_stdout_is_rejected() {
-        // #5475: `gh auth token` exits ZERO with empty stdout when no account
-        // is logged in — the fail-open this combinator exists to close.
+        // #5475: `GH_TOKEN="   "` makes `gh auth token` exit ZERO printing
+        // "   \n" (verified against gh 2.89.0). Checking only the exit status
+        // would pass that whitespace on as a credential — this is the
+        // post-trim check that closes it.
         let err = require_nonempty(out(0, "  \n ", "")).unwrap_err();
         assert!(matches!(err, GhError::Empty { .. }), "got {err:?}");
     }
 
     #[test]
     fn nonempty_stdout_trims_a_real_value() {
-        assert_eq!(require_nonempty(out(0, " a-token \n", "")).unwrap(), "a-token");
+        assert_eq!(
+            require_nonempty(out(0, " a-token \n", "")).unwrap(),
+            "a-token"
+        );
     }
 
     #[test]
@@ -552,6 +580,7 @@ mod tests {
         assert_eq!(cmd.cwd.as_deref(), Some(Path::new("/tmp")));
         assert_eq!(cmd.envs.len(), 1);
         assert_eq!(cmd.envs[0].0, OsString::from("GH_CONFIG_DIR"));
+        assert_eq!(cmd.envs[0].1, Some(OsString::from("/tmp/ghcfg")));
     }
 
     #[test]
@@ -573,6 +602,36 @@ mod tests {
     #[test]
     fn env_removals_are_recorded() {
         let cmd = GhCommand::new(["pr", "list"]).env_remove("GH_REPO");
-        assert_eq!(cmd.env_removals, vec![OsString::from("GH_REPO")]);
+        assert_eq!(cmd.envs, vec![(OsString::from("GH_REPO"), None)]);
+    }
+
+    #[test]
+    fn later_env_call_wins_over_an_earlier_removal() {
+        // #5475: the chain must mean what it reads as. Two separate
+        // set-then-remove lists made this leave X REMOVED.
+        let cmd = GhCommand::new(["pr", "list"])
+            .env_remove("X")
+            .env("X", "v")
+            .to_std_command();
+        let envs: Vec<_> = cmd.get_envs().collect();
+        assert_eq!(
+            envs,
+            vec![(OsStr::new("X"), Some(OsStr::new("v")))],
+            "the later .env must win, leaving X set"
+        );
+    }
+
+    #[test]
+    fn later_removal_wins_over_an_earlier_env_call() {
+        let cmd = GhCommand::new(["pr", "list"])
+            .env("X", "v")
+            .env_remove("X")
+            .to_std_command();
+        let envs: Vec<_> = cmd.get_envs().collect();
+        assert_eq!(
+            envs,
+            vec![(OsStr::new("X"), None)],
+            "the later .env_remove must win, leaving X removed"
+        );
     }
 }

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -902,6 +902,21 @@ pub mod catchup;
 /// Test: `cargo test -p trusty-common -- tmux::`.
 pub mod tmux;
 
+/// The workspace's single entry point for invoking the GitHub CLI (#5475).
+///
+/// Why: `gh` was spawned from a dozen independent `Command::new("gh")` sites
+/// across four crates, each re-deriving its own missing-binary,
+/// unauthenticated, non-zero-exit and stderr policy — the exact duplication
+/// the common-entry-point rule forbids, and one more copy was about to land
+/// with #5487 / #5215.
+/// What: gated behind the `gh-cli` feature. Exposes `gh::GhCommand` (builder
+/// + blocking and tokio runners), `gh::GhOutput` (the full exit/stdout/stderr
+/// triple, with the shared policies as combinators), `gh::GhError`, and the
+/// `gh::gh_available` probe.
+/// Test: `cargo test -p trusty-common --features gh-cli -- gh::`.
+#[cfg(feature = "gh-cli")]
+pub mod gh;
+
 // ─── Re-exports preserving the pre-split public API ───────────────────────
 
 pub use chat::{

--- a/crates/trusty-common/src/tickets/api/backends/github/auth.rs
+++ b/crates/trusty-common/src/tickets/api/backends/github/auth.rs
@@ -14,8 +14,9 @@
 //! Test: `tests::*` cover the pure auth-selection + argv logic. The subprocess
 //! shell-out itself is environment-dependent and not exercised in unit tests.
 
-use anyhow::{Context, Result, bail};
-use tokio::process::Command;
+use anyhow::{Context, Result};
+
+use crate::gh::GhCommand;
 
 use crate::tickets::api::config::GithubConfig;
 
@@ -93,25 +94,12 @@ pub(super) async fn resolve_token(cfg: &GithubConfig) -> Result<String> {
 /// an actionable error pointing at `GITHUB_TOKEN` / `gh auth login`.
 /// Test: environment-dependent; not unit-tested.
 async fn gh_auth_token(cfg: &GithubConfig) -> Result<String> {
-    let args = gh_token_args(cfg);
-    let output = Command::new("gh")
-        .args(&args)
-        .output()
+    // #5475: routed through the workspace's single `gh` entry point; the
+    // empty-stdout rejection that used to live here is `nonempty_stdout`.
+    GhCommand::new(gh_token_args(cfg))
+        .nonempty_stdout()
         .await
-        .context("failed to spawn 'gh auth token' — is the gh CLI installed and on PATH?")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!(
-            "gh auth token failed (exit {}): {} — set GITHUB_TOKEN or run 'gh auth login'",
-            output.status,
-            stderr.trim()
-        );
-    }
-    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if token.is_empty() {
-        bail!("gh auth token returned empty output — run 'gh auth login' to authenticate");
-    }
-    Ok(token)
+        .context("set GITHUB_TOKEN or run 'gh auth login'")
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -161,6 +161,10 @@ trusty-agents-common = { workspace = true }
 trusty-common = { workspace = true, features = [
     "mcp",
     "cli-help",
+    # #5475: the workspace's single `gh` entry point (`trusty_common::gh`),
+    # which core::gh_account / gh_account_enforce / workstream_label and
+    # session_manager::worktree_reclaim all route through.
+    "gh-cli",
     "bug-capture",
     "crate-config",
     "console-metrics",

--- a/crates/trusty-mpm/changelog.d/5475-gh-entry-point.md
+++ b/crates/trusty-mpm/changelog.d/5475-gh-entry-point.md
@@ -1,0 +1,11 @@
+Changed
+
+- `core::gh_account`, `core::gh_account_enforce`,
+  `core::session_launch::workstream_label`, and
+  `session_manager::worktree_reclaim` invoke `gh` through
+  `trusty_common::gh::GhCommand`
+  ([#5475](https://github.com/bobmatnyc/trusty-tools/issues/5475)). Timeout
+  bounds, `GH_CONFIG_DIR` scoping, the `GH_TOKEN` env stripping, and the
+  `current_dir`-never-`-C` rule (#2919) are all unchanged — `worktree_reclaim`
+  keeps its own kill-on-expiry runner and takes the unspawned command from the
+  entry point.

--- a/crates/trusty-mpm/src/core/gh_account.rs
+++ b/crates/trusty-mpm/src/core/gh_account.rs
@@ -364,14 +364,11 @@ where
 /// Test: covered via [`probe_gh_auth_with`]'s fake-runner tests.
 pub fn probe_gh_auth(timeout: Duration) -> GhAuthProbe {
     probe_gh_auth_with(timeout, || {
-        let out = std::process::Command::new("gh")
-            .args(["auth", "status"])
-            .output()
+        // #5475: single `gh` entry point.
+        let out = trusty_common::gh::GhCommand::new(["auth", "status"])
+            .output_blocking()
             .ok()?;
-        let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
-        text.push('\n');
-        text.push_str(&String::from_utf8_lossy(&out.stderr));
-        Some(text)
+        Some(out.combined())
     })
 }
 
@@ -429,21 +426,14 @@ pub const GH_USER_ENV_VAR: &str = "GH_USER";
 pub fn gh_token_via_cli(account: &str) -> Result<String, String> {
     let owned = account.to_string();
     run_bounded(GH_ENFORCE_TIMEOUT, move || {
-        let out = std::process::Command::new("gh")
-            .args(["auth", "token", "-u", &owned])
-            .output()
-            .ok()?;
-        if !out.status.success() {
-            let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
-            return Some(Err(format!("`gh auth token -u {owned}` failed: {stderr}")));
-        }
-        let token = String::from_utf8_lossy(&out.stdout).trim().to_string();
-        if token.is_empty() {
-            return Some(Err(format!(
-                "`gh auth token -u {owned}` returned an empty token"
-            )));
-        }
-        Some(Ok(token))
+        // #5475: the non-zero and empty-output arms are the entry point's
+        // `nonempty_stdout_blocking`; the failure message stays local because
+        // it names the pinned account.
+        Some(
+            trusty_common::gh::GhCommand::new(["auth", "token", "-u", &owned])
+                .nonempty_stdout_blocking()
+                .map_err(|e| format!("`gh auth token -u {owned}` failed: {e}")),
+        )
     })
     .unwrap_or_else(|| {
         Err(format!(

--- a/crates/trusty-mpm/src/core/gh_account_enforce.rs
+++ b/crates/trusty-mpm/src/core/gh_account_enforce.rs
@@ -123,22 +123,22 @@ pub fn ensure_gh_account_in_dir(
         return Ok(());
     }
 
-    let switch = std::process::Command::new("gh")
-        .args([
-            "auth",
-            "switch",
-            "--hostname",
-            host,
-            "--user",
-            expected_user,
-        ])
-        .env(GH_CONFIG_DIR_ENV, &dir)
-        .env_remove(GH_TOKEN_ENV_VARS[0])
-        .env_remove(GH_TOKEN_ENV_VARS[1])
-        .output()
-        .with_context(|| format!("failed to spawn `gh auth switch --user {expected_user}`"))?;
-    if !switch.status.success() {
-        let stderr = String::from_utf8_lossy(&switch.stderr);
+    // #5475: single `gh` entry point; the scoping env is unchanged.
+    let switch = trusty_common::gh::GhCommand::new([
+        "auth",
+        "switch",
+        "--hostname",
+        host,
+        "--user",
+        expected_user,
+    ])
+    .env(GH_CONFIG_DIR_ENV, &dir)
+    .env_remove(GH_TOKEN_ENV_VARS[0])
+    .env_remove(GH_TOKEN_ENV_VARS[1])
+    .output_blocking()
+    .with_context(|| format!("failed to spawn `gh auth switch --user {expected_user}`"))?;
+    if !switch.success {
+        let stderr = &switch.stderr;
         anyhow::bail!(
             "`gh auth switch --user {expected_user}` failed inside {dir}: {} \
              (is '{expected_user}' logged in under this GH_CONFIG_DIR? run \
@@ -171,17 +171,14 @@ pub fn ensure_gh_account_in_dir(
 fn run_gh_scoped(config_dir: &str, args: [&'static str; 2]) -> anyhow::Result<String> {
     let config_dir = config_dir.to_string();
     run_bounded(GH_ENFORCE_TIMEOUT, move || {
-        let out = std::process::Command::new("gh")
-            .args(args)
+        // #5475: single `gh` entry point.
+        let out = trusty_common::gh::GhCommand::new(args)
             .env(GH_CONFIG_DIR_ENV, &config_dir)
             .env_remove(GH_TOKEN_ENV_VARS[0])
             .env_remove(GH_TOKEN_ENV_VARS[1])
-            .output()
+            .output_blocking()
             .ok()?;
-        let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
-        text.push('\n');
-        text.push_str(&String::from_utf8_lossy(&out.stderr));
-        Some(text)
+        Some(out.combined())
     })
     .ok_or_else(|| anyhow::anyhow!("`gh` did not respond within {GH_ENFORCE_TIMEOUT:?}"))
 }

--- a/crates/trusty-mpm/src/core/session_launch/workstream_label.rs
+++ b/crates/trusty-mpm/src/core/session_launch/workstream_label.rs
@@ -508,8 +508,8 @@ impl GhLabelRunner for RealGhRunner {
         let color = color.to_string();
         let description = description.to_string();
         run_bounded(GH_LABEL_TIMEOUT, move || {
-            let mut cmd = std::process::Command::new("gh");
-            cmd.args([
+            // #5475: single `gh` entry point.
+            let mut argv: Vec<&str> = vec![
                 "label",
                 "create",
                 &name,
@@ -519,11 +519,14 @@ impl GhLabelRunner for RealGhRunner {
                 &color,
                 "--description",
                 &description,
-            ]);
+            ];
             if force {
-                cmd.arg("--force");
+                argv.push("--force");
             }
-            cmd.output().ok().map(|out| out.status.success())
+            trusty_common::gh::GhCommand::new(argv)
+                .output_blocking()
+                .ok()
+                .map(|out| out.success)
         })
         .unwrap_or(false)
     }

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
@@ -357,17 +357,19 @@ impl PrIndex {
 /// `gh_command_runs_in_the_requested_directory`,
 /// `gh_command_strips_repository_redirecting_env`.
 fn gh_command(dir: &Path) -> Command {
-    let mut cmd = Command::new("gh");
+    // #5475: argv/binary/env come from trusty-common's single `gh` entry
+    // point; this module keeps its own kill-on-timeout runner, which is why it
+    // takes the unspawned `std::process::Command` rather than a runner method.
     // #2919: `current_dir`, NEVER `-C` — `gh` has no such flag.
-    cmd.current_dir(dir);
+    let mut cmd = trusty_common::gh::GhCommand::new(std::iter::empty::<&str>()).cwd(dir);
     for key in GH_STRIPPED_ENV {
-        cmd.env_remove(key);
+        cmd = cmd.env_remove(key);
     }
     cmd.env("GH_PAGER", "")
         .env("GH_PROMPT_DISABLED", "1")
         .env("GH_NO_UPDATE_NOTIFIER", "1")
-        .env("NO_COLOR", "1");
-    cmd
+        .env("NO_COLOR", "1")
+        .to_std_command()
 }
 
 /// The `--json` field set every `gh pr list` call in this module requests.

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
@@ -361,7 +361,7 @@ fn gh_command(dir: &Path) -> Command {
     // point; this module keeps its own kill-on-timeout runner, which is why it
     // takes the unspawned `std::process::Command` rather than a runner method.
     // #2919: `current_dir`, NEVER `-C` — `gh` has no such flag.
-    let mut cmd = trusty_common::gh::GhCommand::new(std::iter::empty::<&str>()).cwd(dir);
+    let mut cmd = trusty_common::gh::GhCommand::bare().cwd(dir);
     for key in GH_STRIPPED_ENV {
         cmd = cmd.env_remove(key);
     }

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name        = "trusty-review"
-version     = "0.16.0"
+# #4421: patch bump — 0.16.0 already published on crates.io and this PR
+# touches src/**. `SystemGhResolver::gh_auth_token` swaps its hand-rolled
+# `gh auth token` spawn for trusty-common's `GhCommand` entry point; the
+# trait method signature and struct are unchanged, so no public API moved.
+version     = "0.16.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -87,7 +87,7 @@ clap         = { workspace = true }
 # `webhook-relay` (#5182): the console->target relay wire contract AND its
 # receive half — the durable inbox, the listener, and the hardened UDS bind
 # this crate mounts in `webhook_listener`. Implies `uds` and `webhook-hmac`.
-trusty-common = { workspace = true, features = ["intent-source", "config-cli", "webhook-relay"] }
+trusty-common = { workspace = true, features = ["intent-source", "config-cli", "webhook-relay", "gh-cli"] }
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console is
 # no longer bundled into trusty-review (single-owner-per-binary); the standalone
 # `trusty-console` crate is its sole producer.

--- a/crates/trusty-review/changelog.d/5475-gh-entry-point.md
+++ b/crates/trusty-review/changelog.d/5475-gh-entry-point.md
@@ -1,0 +1,8 @@
+Changed
+
+- `SystemGhResolver` resolves `gh auth token` through
+  `trusty_common::gh::GhCommand`
+  ([#5475](https://github.com/bobmatnyc/trusty-tools/issues/5475)) instead of
+  its own `Command::new("gh")`. The resolution order (`GITHUB_TOKEN` →
+  `GH_TOKEN` → `gh auth token`) and the debug-log-and-return-`None` degrade are
+  unchanged; the log line now carries the entry point's classified reason.

--- a/crates/trusty-review/src/integrations/github/auth/strategy.rs
+++ b/crates/trusty-review/src/integrations/github/auth/strategy.rs
@@ -171,20 +171,12 @@ pub struct SystemGhResolver;
 
 impl GhTokenResolver for SystemGhResolver {
     fn gh_auth_token(&self) -> Option<String> {
-        let output = std::process::Command::new("gh")
-            .args(["auth", "token"])
-            .output()
-            .map_err(|e| tracing::debug!("`gh auth token` could not be spawned: {e}"))
-            .ok()?;
-        if !output.status.success() {
-            tracing::debug!(
-                status = ?output.status.code(),
-                "`gh auth token` exited non-zero (not logged in?)"
-            );
-            return None;
-        }
-        let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if token.is_empty() { None } else { Some(token) }
+        // #5475: routed through trusty-common's single `gh` entry point; the
+        // spawn/non-zero/empty triad it used to hand-roll are its combinators.
+        trusty_common::gh::GhCommand::new(["auth", "token"])
+            .nonempty_stdout_blocking()
+            .map_err(|e| tracing::debug!("`gh auth token` unusable: {e}"))
+            .ok()
     }
 }
 

--- a/docs/reference/domain-consolidation-audit.md
+++ b/docs/reference/domain-consolidation-audit.md
@@ -13,7 +13,7 @@ as consolidations land. Reference: common-entry-point principle above.
 | HTTP clients (reqwest) | FRAGMENTED | 150+ builder sites incl. 20+ inside trusty-common | backlog |
 | git invocations | FRAGMENTED | ~90 production spawn sites, 7 crates | backlog (after tmux pattern proves) |
 | Shared env-var access | FRAGMENTED | OPENROUTER_API_KEY ×22 files/8 crates; GITHUB_TOKEN ×13/6 | partially covered by epic #2400 (#2401) |
-| gh CLI | FRAGMENTED | 3 wrappers (trusty-agents ticketing/gh_cli most complete) | backlog |
+| gh CLI | CONSOLIDATED | `trusty_common::gh::GhCommand`; 15 production spawn sites across 4 crates migrated 2026-08-13 | done (#5475); the `tm ticket` / `tm watch` CLI keeps its injectable `CommandRunner` seam and passes `"gh"` as data — see below |
 | Config-file loading | FRAGMENTED | 5 implementations (2 pairs within single crates) | backlog |
 | Secret redaction | FRAGMENTED (security) | 4 rule sets (3 inside trusty-mpm) | partially covered by #2401 redact_secret |
 | launchctl | SCATTERED | shared LaunchdConfig exists; 9 bypass sites/4 crates | backlog |
@@ -24,3 +24,22 @@ as consolidations land. Reference: common-entry-point principle above.
 
 First enforcement instances: inference-adapter epic #2400, tmux common entry
 point #2398/PR #2399.
+
+## gh CLI — what "consolidated" covers (#5475, 2026-08-13)
+
+`trusty_common::gh::GhCommand` (feature `gh-cli`) is the only place the string
+`"gh"` is spelled as a program to spawn. It renders the argv, applies an
+optional `--repo`, working directory, and environment overlay/removals, and
+runs blocking, on tokio, or hands back the unspawned `std::process::Command`
+for a caller that owns its own timeout. A non-zero exit is returned, never
+raised — `gh pr checks` reports check state through its exit code — so each
+call site keeps its own failure policy while sharing the spawn.
+
+One family is deliberately NOT routed through it: the `tm ticket` and
+`tm watch` commands in `crates/trusty-mpm/src/bin/tm/`, which call
+`runner.run("gh", &args)` against an injectable `CommandRunner` trait. There
+`"gh"` is DATA passed to a seam that exists so the tests can substitute a fake
+process; replacing the seam with a concrete spawner would delete that test
+coverage to satisfy a rule about spawn-site duplication. If those commands
+ever need the entry point's classification, the right move is a `CommandRunner`
+implementation backed by `GhCommand`, not a rewrite of the call sites.


### PR DESCRIPTION
Closes #5475.

`gh` was spawned from 15 independent `Command::new("gh")` sites across four crates. Each re-derived its own answer to the same four questions: missing binary, unauthenticated, non-zero exit, stderr. #5487 and #5215 are both about to route through `gh`, so the entry point lands before them.

## The entry point

`trusty_common::gh` (new feature `gh-cli`, implied by `tickets`):

- `GhCommand::new(args)` + `.repo(Option<&str>)` / `.cwd()` / `.env()` / `.env_remove()`
- runners: `output()` (tokio), `output_blocking()`, and `to_std_command()` for a caller that owns its own timeout
- combinators: `GhOutput::ok()`, `stdout()`, `nonempty_stdout()`, `json::<T>()`, `combined()`, plus the `gh_available()` probe
- `GhError::{NotInstalled, Spawn, NonZero, Empty, Json}`

A non-zero exit is returned, never raised — `gh pr checks` reports check state through its exit code, so that policy stays at the call site. A missing binary is classified as `NotInstalled` and carries the `gh auth login` hint.

## Call sites migrated (15, all of them)

| Crate | Site |
|---|---|
| trusty-common | `tickets/api/backends/github/auth.rs` — `gh auth token` |
| trusty-review | `integrations/github/auth/strategy.rs` — `SystemGhResolver` |
| trusty-agents | `tools/gh_tools/helpers.rs` — `run_gh` |
| trusty-agents | `ticketing/gh_cli/mod.rs` — `gh_available`, `run` |
| trusty-agents | `ticketing/gh_cli/client_impl.rs` — `count_open_issues`, `count_open_prs`, `list_available_tags` |
| trusty-agents | `ticketing/actions.rs` — `GhActionsCliClient::run` |
| trusty-agents | `workflow/tickets.rs` — issue create / close / list / comment |
| trusty-mpm | `core/gh_account.rs` — `probe_gh_auth`, `gh_token_via_cli` |
| trusty-mpm | `core/gh_account_enforce.rs` — `auth switch`, `run_gh_scoped` |
| trusty-mpm | `core/session_launch/workstream_label.rs` — `label create` |
| trusty-mpm | `session_manager/worktree_reclaim.rs` — `gh_command` |

`git grep 'Command::new("gh")' -- crates/*/src` now returns nothing.

**Deliberately not migrated:** the `tm ticket` / `tm watch` commands in `crates/trusty-mpm/src/bin/tm/`, which call `runner.run("gh", &args)` against an injectable `CommandRunner` trait. There `"gh"` is data passed to a test seam; replacing it with a concrete spawner would delete test coverage to satisfy a rule about spawn-site duplication. Recorded in the audit doc with the follow-up shape (a `CommandRunner` backed by `GhCommand`).

## Behaviour

None intended. The `#2919` argv/env-shape tests on `worktree_reclaim::gh_command` pass unchanged, which is the strongest single check that the migration preserved the `current_dir`-never-`-C` rule and the env scrub. `gh_tools`' non-zero tolerance rule moved into a pure `map_gh_outcome`, so it is now pinned deterministically rather than by spawning POSIX `true`/`false`.

## Test ladder — rung 4

Rung 4: `trusty-common` is a shared library and this adds public API, so rung 3 on the library then `check --workspace` plus each direct dependent's suite. Not rung 5: no persistence, security, or process-lifecycle contract changes, and the one lifecycle-adjacent site (`worktree_reclaim`) keeps its own runner and its existing tests.

\`\`\`
cargo fmt --check
cargo clippy -p trusty-common --features gh-cli,tickets --all-targets -- -D warnings
cargo test  -p trusty-common --features gh-cli,tickets
cargo clippy -p trusty-review --all-targets -- -D warnings
cargo clippy -p trusty-agents --all-targets -- -D warnings
cargo clippy -p trusty-mpm    --all-targets -- -D warnings
SKIP_UI_BUILD=1 cargo check --workspace
SKIP_UI_BUILD=1 cargo test -p trusty-review
SKIP_UI_BUILD=1 cargo test -p trusty-agents
SKIP_UI_BUILD=1 cargo test -p trusty-mpm
bash scripts/check_line_cap.sh
\`\`\`

- `trusty-common` gh module: `test result: ok. 20 passed; 0 failed`
- `trusty-common` full: `test result: ok. 407 passed; 0 failed; 7 ignored`
- `trusty-review`: `test result: ok. 1562 passed; 0 failed; 5 ignored`
- `trusty-agents`: `test result: ok. 3499 passed; 0 failed; 13 ignored` (+ 9 integration binaries green)
- `trusty-mpm`: `test result: ok. 4967 passed; 0 failed; 7 ignored`
- `check_line_cap.sh`: `3980 tracked .rs file(s); 4 allowlisted, 0 violations — OK`
- clippy: zero warnings on all four crates
- `cargo check --workspace`: clean with `SKIP_UI_BUILD=1` (pnpm is absent on this host, so the GUI crates' build scripts panic without it — documented in CLAUDE.md)

### Baseline notes

The post-review re-run is fully green, including `connectors::tm::tests::create_session_full_lifecycle`, which failed once in the first run under full-suite concurrency and did not recur. `git diff --name-only origin/main...HEAD -- crates/trusty-mpm/src/connectors/` is empty either way.

`llm::bedrock::tests::bedrock_region_resolution` fails on any host with `AWS_REGION` set (this one has `us-west-2`) — it reads the ambient var and asserts the default. Every run above uses `env -u AWS_REGION`. Pre-existing and unticketed.

## Failure paths

Covered in `gh::tests`: missing binary (`missing_binary_is_classified_not_installed`, distinguished from other spawn errors), non-zero exit with stderr (`output_ok_maps_nonzero_to_error`, `nonzero_exit_carries_stderr`), malformed JSON (`malformed_json_is_reported_as_json_error`), the blank-credential case (`empty_stdout_is_rejected`), and builder call order (`later_env_call_wins_over_an_earlier_removal`, `later_removal_wins_over_an_earlier_env_call`).

Fail-open check: no path was found or introduced that downgrades a failure while state advances. The three degrading paths are pre-existing, unchanged, and none advances state on an unearned success — `gh_available()` picks a backend, `count_open_issues/prs` render a UI count, and `resolve_gh_account_env` warns and injects nothing.

The blank-credential case is the one that would be a real fail-open, and review corrected my account of it. `gh auth token` exits **1**, not 0, when no account is logged in — verified against gh 2.89.0 under `env -i` with a throwaway `HOME`/`GH_CONFIG_DIR`, in all four unauthenticated variants. The reproducing mechanism is `GH_TOKEN="   "`: exit **0**, stdout `"   \n"`. A caller checking only the exit status hands that whitespace on as a token, which is why `nonempty_stdout` trims before testing for emptiness.

## Review round 1 (`98d14ebc`)

Five findings, all fixed in this PR:

1. **The empty-credential rationale was factually wrong** — corrected in `nonempty_stdout`'s Why, `GhError::Empty`, the test comment, and the trusty-common fragment. Verified mechanism in the Failure paths section above.
2. **`configure` discarded builder call order** — it applied all `env` calls then all `env_remove` calls, so `.env_remove("X").env("X","v")` left X *removed*. Now one ordered `Vec<(OsString, Option<OsString>)>` applied in call order, with a test each way.
3. **Deleted `stdout_blocking` and `gh_available_blocking`** — no consumers, which is the objection `json()` survives only because `list_available_tags` is a genuine fit.
4. **`from_parts`'s Why described a use that does not exist** — restated to the real reason: a downstream crate cannot struct-literal a `#[non_exhaustive]` type in its tests.
5. **The argv-less builder was a trap** — now a named `GhCommand::bare()`, documented as a binary-and-environment carrier whose argv the caller appends after `to_std_command()`.

## Docs / changelog

Fragments in all four crates (`changelog.d/5475-gh-entry-point.md`). `docs/reference/domain-consolidation-audit.md`'s `gh` row moves FRAGMENTED → CONSOLIDATED, with a section recording what that covers and the one family excluded.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
