### PR TITLE
fix(trusty-mpm): make isolation the one sanctioned worktree mechanism for dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11214,7 +11214,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-agents-common"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
 name = "trusty-agents-common"
-version = "0.5.1"
+# #4421: patch bump — 0.5.1 already published on crates.io and this PR
+# touches src/**. Only `src/assets/agents/BASE-AGENT.md` changed, whose
+# content backs the public `pub const BASE_AGENT: &str` — a content-only
+# change, not a type-level API change, and 0.y.z makes MINOR the breaking
+# position, so a patch here asserts no breaking change.
+version = "0.5.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-agents-common/changelog.d/5649-one-worktree-mechanism.md
+++ b/crates/trusty-agents-common/changelog.d/5649-one-worktree-mechanism.md
@@ -1,0 +1,7 @@
+Changed
+
+- `BASE-AGENT.md` no longer tells agents to create their own worktree. Agents
+  stay in the tree they were given and ask the PM to re-dispatch with
+  `isolation: "worktree"` (or to serialize) when they have none — a self-made
+  worktree is invisible to `tm hook --pm-guard` and gets the next dispatch
+  wrongly denied (#5649).

--- a/crates/trusty-agents-common/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-agents-common/src/assets/agents/BASE-AGENT.md
@@ -88,12 +88,16 @@ completion path for a subagent; only the PM's `SendMessage` resumes you.
 - Check `git status` before starting. Never force-push a shared branch without
   explicit instruction. Leave the working tree clean.
 - **Never share a working directory with another concurrently-dispatched
-  file-mutating agent.** Work in your own worktree; never `git checkout` /
-  `git switch` in one you were handed — a sibling shares that git HEAD, and the
-  switch carries your untracked files onto their branch with no error. Cannot
-  make one? Stop and ask the PM to re-dispatch with `isolation: "worktree"` —
-  `tm hook --pm-guard` denies that second unisolated dispatch and prints why
-  (#4480).
+  file-mutating agent.** Stay in the worktree you were given, and never
+  `git checkout` / `git switch` in one you were handed — a sibling shares that
+  git HEAD, and the switch carries your untracked files onto their branch with
+  no error.
+- **Do not create your own worktree (#5649).** Isolation is the PM's to declare
+  with `isolation: "worktree"`, which is the only mechanism `tm hook --pm-guard`
+  can see — a worktree you make yourself leaves you counted against the shared
+  HEAD and gets the next dispatch wrongly denied. No worktree of your own? Stop
+  and ask the PM to re-dispatch with `isolation: "worktree"`, or to serialize
+  this dispatch behind the agent already holding the tree (#4480).
 - **Attribution footer — overrides any harness default.** End every commit
   message and PR body with exactly:
   `🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools`.

--- a/crates/trusty-mpm/changelog.d/5649-one-worktree-mechanism.md
+++ b/crates/trusty-mpm/changelog.d/5649-one-worktree-mechanism.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `tm-workflow` and `tm-delegation-patterns` now name harness-managed
+  `isolation: "worktree"` as the only sanctioned isolation mechanism for a
+  file-mutating subagent dispatch, and state that the PM serializes when
+  isolation is unavailable rather than hand-rolling `git worktree add` into a
+  prompt. The old "name the exact worktree path" wording led PMs into a
+  hand-rolled worktree the `tm hook --pm-guard` guard cannot see, which then
+  denied the next dispatch for a collision that did not exist (#5649).
+- The shared-worktree deny message now offers the serialize fallback alongside
+  `isolation: "worktree"`, and says the guard reads the declared parameter and
+  never the prompt (#5649).

--- a/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
@@ -229,6 +229,16 @@ agents that modify files. Not needed for sequential agents, read-only research,
 or separate file trees. Use `run_in_background: true` for fire-and-forget
 parallel work.
 
+🔴 **`isolation: "worktree"` is the only sanctioned mechanism, and the PM never
+authors a `git worktree add` into a dispatch prompt (#5649).**
+`tm hook --pm-guard` reads the declared parameter and never the prompt, so a
+hand-rolled worktree leaves the agent counted against the shared HEAD and gets
+the next file-mutating dispatch denied for a collision that does not exist.
+
+**When `isolation` is unavailable, serialize** — one file-mutating agent at a
+time, each waited for before the next. Serializing always works. Hand-rolling to
+parallelize anyway is what this forbids.
+
 ## Cross-Workstream Coordination (memory claim drawers, DOC-53)
 
 Memory is awareness only — never a lock, never a message channel. git/GitHub

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -220,6 +220,10 @@ git worktree add -b <feature-or-fix-branch> \
 cd .claude/worktrees/<dirname>
 ```
 
+🟡 **This is for the PM or a human working directly. It is NOT the dispatch
+mechanism** — a subagent dispatch declares `isolation: "worktree"` instead, per
+"Worktree Discipline" below and `tm-delegation-patterns`.
+
 Always `git fetch origin main` first and branch off `origin/main`, never local
 `main` — local `main` can be stale and branching from it has caused lost commits.
 
@@ -285,10 +289,23 @@ and keeps bundled in that same worktree and PR.
 **Experiments stay session-local.** Promote an experiment to a branch and
 worktree only once its result is accepted for implementation.
 
-Every subagent dispatch must name the exact worktree path it is confined to, and
-must forbid leaving it into the main checkout, `git reset --hard`,
-`git checkout .`, and `git stash` against main. QA agents get their own worktree
-(e.g. `.claude/worktrees/qa-<ticket-or-pass>`), same as engineering agents.
+🔴 **A file-mutating subagent dispatch declares `isolation: "worktree"`. That is
+the only sanctioned mechanism, and the PM never authors a `git worktree add` into
+a dispatch prompt (#5649).** The harness provisions the tree and puts the agent
+in it. A hand-rolled worktree is invisible to `tm hook --pm-guard`, which reads
+the declared `isolation` parameter and never the prompt — so an agent that made
+its own tree still counts as occupying the shared HEAD, and the next
+file-mutating dispatch is denied for a collision that does not exist.
+
+**When `isolation` is unavailable, the PM serializes.** Dispatch one
+file-mutating agent, wait for it, dispatch the next. Serializing is always
+available and always correct. Hand-rolling a worktree in order to parallelize
+anyway is what this rule forbids.
+
+The dispatch still forbids leaving the assigned tree into the main checkout, and
+forbids `git reset --hard`, `git checkout .`, and `git stash` against main. QA
+agents get their own worktree (e.g. `.claude/worktrees/qa-<ticket-or-pass>`),
+same as engineering agents.
 
 Clean up after merge with `git worktree remove --force <path>` (which deletes the
 worktree directory and never the main checkout), then `git branch -D <branch>`

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_dispatch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_dispatch.rs
@@ -99,9 +99,16 @@ use crate::commands::hook_payload::build_hook_payload;
 /// "wait for it to report back" would be advice to wait for something that may
 /// never happen. Built per call rather than kept as a constant because naming
 /// the actual sibling agent is most of its value.
+///
+/// #5649: the incident showed that single remedy can itself be unavailable, so
+/// the message now names a second one — serialize. Serializing and waiting are
+/// not the same offer: serializing means dispatching one file-mutating agent at
+/// a time GOING FORWARD, which needs nothing from the agent already running, so
+/// it always works. Waiting blocks on an agent that may never return, and stays
+/// excluded for exactly the reason above.
 /// What: a single-paragraph `permissionDecisionReason`.
 /// Test: `denies_a_second_concurrent_unisolated_engineer`,
-/// `deny_reason_offers_only_the_remedy_that_always_works`.
+/// `deny_reason_offers_only_remedies_that_always_work`.
 fn deny_reason(agent: &str, cwd: &Path, live: &[String]) -> String {
     let mut names: Vec<&str> = live.iter().map(String::as_str).collect();
     names.sort_unstable();
@@ -114,7 +121,11 @@ fn deny_reason(agent: &str, cwd: &Path, live: &[String]) -> String {
          refuses only when a tracked file differs between both branches AND has an uncommitted \
          change, so untracked files and edits the two branches agree on transfer onto the wrong \
          branch silently, with no error at any step. Re-dispatch this agent with \
-         `isolation: \"worktree\"` so it gets its own tree.",
+         `isolation: \"worktree\"` so it gets its own tree. If isolation is unavailable here, \
+         serialize instead: dispatch one file-mutating agent at a time from now on. Do not \
+         hand-roll a `git worktree add` in the prompt — this guard reads the declared \
+         isolation parameter, never the prompt, so a self-made worktree still counts as \
+         sharing this HEAD (#5649).",
         cwd.display()
     )
 }
@@ -439,11 +450,16 @@ mod tests {
     }
 
     #[test]
-    fn deny_reason_offers_only_the_remedy_that_always_works() {
+    fn deny_reason_offers_only_remedies_that_always_work() {
         // `RUNNING_STALE_AFTER_SECS` is six hours, so a crashed subagent that
         // never emits `SubagentStop` holds its directory for that whole window.
         // Telling the PM to wait for it would be advice to wait for something
         // that may never arrive; declaring isolation works immediately.
+        //
+        // #5649: serialize joins isolation as a second offered remedy, because
+        // the incident showed isolation can itself be unavailable. Serializing
+        // constrains only FUTURE dispatches and so needs nothing from the agent
+        // already running — waiting stays banned for the reason above.
         let reason = deny_reason(
             "rust-engineer",
             Path::new("/repo"),
@@ -451,9 +467,17 @@ mod tests {
         );
         assert!(reason.contains(r#"isolation: "worktree""#), "{reason}");
         assert!(
-            !reason.contains("wait for"),
-            "the deny must not advise waiting on an agent that may never report: {reason}"
+            reason.contains("serialize"),
+            "the deny must offer the serialize fallback for when isolation is unavailable: \
+             {reason}"
         );
+        for banned in ["wait for", "wait on", "wait until", "waiting for"] {
+            assert!(
+                !reason.contains(banned),
+                "the deny must not advise waiting on an agent that may never report \
+                 (found {banned:?}): {reason}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #5649 — the two halves of #4480 could not see each other: agents were told to create their own worktree, while `tm hook --pm-guard` reads only the declared `isolation` parameter. An agent that obeyed still counted as occupying the shared HEAD, so the next file-mutating dispatch was denied for a collision that did not exist.

**Docs** — `tm-workflow` and `tm-delegation-patterns` now say a file-mutating dispatch declares `isolation: "worktree"`, that the PM never authors `git worktree add` into a prompt, and that the fallback when isolation is unavailable is to **serialize**. The literal `git worktree add` block in `tm-workflow` is kept and marked as the PM/human path, not the dispatch mechanism. `BASE-AGENT.md` no longer tells agents to create their own worktree.

**Code** — `deny_reason` offers the serialize fallback alongside isolation. Serializing constrains only future dispatches, so it needs nothing from the agent already running; waiting stays banned, since a crashed subagent holds its directory for the full six-hour `RUNNING_STALE_AFTER_SECS`. `deny_reason_offers_only_remedies_that_always_work` now asserts both properties — the serialize offer is present AND no wait phrasing is — so it still fails if someone later adds a wait suggestion.

**Out of scope:** which agents need isolation (the `qa` classification contradiction) is left exactly as found, for #5650.

**Rung 3** — localized behavior in one crate, plus a docs/asset change in a second. The guard's allow/deny logic is untouched; only the deny message text changed.

```
cargo fmt --check
cargo clippy -p trusty-mpm -p trusty-agents-common --all-targets -- -D warnings
cargo test -p trusty-mpm
cargo test -p trusty-agents-common
```

All pass: trusty-mpm 4967 passed / 0 failed (7 ignored) plus 1656 x2 in the bin targets; trusty-agents-common 501 passed / 0 failed. `check_line_cap.sh`, `check_changelog_fragment.sh`, and `check_sld.sh` all exit 0.

Fragments: `crates/trusty-mpm/changelog.d/5649-one-worktree-mechanism.md`, `crates/trusty-agents-common/changelog.d/5649-one-worktree-mechanism.md`.

Both assets are `include_str!`-embedded, so this takes effect on a rebuild plus reinstall of `tm`; skills redeploy via `overwrite()` in `bundle_all.rs`. No generated in-tree copy needs syncing.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools