### PR TITLE
fix: prune two stale rows from the test-pointer allowlist

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -421,7 +421,6 @@ crates/trusty-mpm/src/control/registry.rs	registry_with_classifier_builds_actor_
 crates/trusty-mpm/src/core/auto_resume.rs	effective_from_env_parses_truthy
 crates/trusty-mpm/src/core/compress.rs	caveman_summary_contains_tool_and_size
 crates/trusty-mpm/src/core/compress.rs	strip_ansi_leaves_plain_text
-crates/trusty-mpm/src/core/deploy_validate/mod.rs	repair_reports_error_when_prepare_session_fails
 crates/trusty-mpm/src/core/manifest/schema.rs	instruction_layers_roundtrip
 crates/trusty-mpm/src/core/manifest/schema.rs	mcp_servers_roundtrip
 crates/trusty-mpm/src/core/manifest/schema.rs	model_tiers_roundtrip
@@ -722,7 +721,6 @@ crates/trusty-review/src/pipeline/verify.rs	verify_one_confirmed
 crates/trusty-review/src/pipeline/verify.rs	verify_one_model_unavailable_emits_signal
 crates/trusty-review/src/pipeline/verify.rs	verify_one_refuted
 crates/trusty-review/src/pipeline/voice_config.rs	build_voice_config_principles_on
-crates/trusty-review/src/profile/reporter.rs	reporter_markdown_output
 crates/trusty-review/src/report/analyze_adapter.rs	http_source_maps_from_mock
 crates/trusty-review/src/report/investigate/mod.rs	investigation_survives_one_truncated_batch_of_three
 crates/trusty-review/src/report/investigate/mod.rs	render_tests


### PR DESCRIPTION
Two rows in `.test-pointer-allowlist.tsv` outlived the code they grandfathered, so the ratchet in `scripts/check_test_pointers.sh` has failed the required "Doc-comment pointer lint (Why/What/Test)" check on `origin/main` since 2026-08-12: [#5611](https://github.com/bobmatnyc/trusty-tools/pull/5611) deleted `crates/trusty-review/src/profile/reporter.rs` outright without pruning its `reporter_markdown_output` row, and [#5613](https://github.com/bobmatnyc/trusty-tools/pull/5613) renamed the citation in `deploy_validate/mod.rs` without pruning the old `repair_reports_error_when_prepare_session_fails` row. [#5520](https://github.com/bobmatnyc/trusty-tools/pull/5520) fixed a different stale pointer on this same gate.

Rung 1 (config/ratchet file only, no crate `src/**` touched — confirmed via `scripts/check_changelog_fragment.sh`, which reported no fragment required).

Gates run:
- `bash scripts/check_test_pointers.sh` before: `test-pointers: 0 dangling pointer(s), 2 stale allowlist entries — FAILED.` (exit 1)
- `bash scripts/check_test_pointers.sh --update`: `check_test_pointers --update: pruned 2 stale entries` — diff removes exactly the two expected rows, nothing else
- `bash scripts/check_test_pointers.sh` after: `test-pointers: resolved 24361 Test: citation(s) (floor 5000) — 0 dangling pointers — OK.` (exit 0)
- `bash scripts/check_changelog_fragment.sh`: no crate source changed — OK
- `bash scripts/check_sld.sh`: 0 errors, 0 warnings — OK
- `bash scripts/check_line_cap.sh`: 0 violations — OK

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools