### PR TITLE
fix(trusty-mpm): classify documentation/version-control/qa as file-mutating (#5650)

### DIFF
--- a/crates/trusty-mpm/changelog.d/5650-widen-dispatch-isolation-classifier.md
+++ b/crates/trusty-mpm/changelog.d/5650-widen-dispatch-isolation-classifier.md
@@ -1,0 +1,15 @@
+Fixed
+
+- `tm hook --pm-guard` now denies an unisolated `documentation`,
+  `version-control`, `qa`, `web-qa`, or `api-qa` dispatch that would share a
+  running file-mutating agent's working tree. The classifier recognised only
+  engineer-tier agents, so those five wrote into an engineer's tree on one git
+  HEAD with no deny at any step (#5650).
+- `code-critic` still classifies as non-mutating. It declares the same
+  `role: qa` and `extends: base-qa` as the three QA writers but only reviews, so
+  the QA agents are matched by name rather than by role — a role-based widen
+  would have denied a review dispatched alongside the engineer it reviews
+  (#5650).
+- `tm-workflow` now lists which agents count as file-mutating, replacing wording
+  that said QA agents get their own worktree while the guard classified `qa` as
+  non-mutating (#5650).

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -303,9 +303,16 @@ available and always correct. Hand-rolling a worktree in order to parallelize
 anyway is what this rule forbids.
 
 The dispatch still forbids leaving the assigned tree into the main checkout, and
-forbids `git reset --hard`, `git checkout .`, and `git stash` against main. QA
-agents get their own worktree (e.g. `.claude/worktrees/qa-<ticket-or-pass>`),
-same as engineering agents.
+forbids `git reset --hard`, `git checkout .`, and `git stash` against main.
+
+**Who counts as file-mutating** (#5650): every engineer-tier agent, plus
+`documentation`, `version-control`, and the three QA agents that author tests —
+`qa`, `web-qa`, `api-qa`. Each gets its own worktree, same as an engineer. A
+dispatch that only reads does not: `research`, `code-analyzer`, `ticketing`, and
+`code-critic`, which shares `role: qa` with the QA writers but recommends rather
+than edits. The guard reads this from the bundled agent's own frontmatter
+(`dispatch_isolation.rs`), so a custom or project-local agent it does not ship is
+never denied — declare `isolation: "worktree"` for one that writes.
 
 Clean up after merge with `git worktree remove --force <path>` (which deletes the
 worktree directory and never the main checkout), then `git branch -D <branch>`

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_dispatch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_dispatch.rs
@@ -515,8 +515,9 @@ mod tests {
     #[test]
     fn allows_a_read_only_agent() {
         // Research/review dispatches share a cwd harmlessly and the PM fans
-        // them out constantly.
-        for agent in ["research", "code-critic", "qa"] {
+        // them out constantly. #5650 moved `qa` out of this list — it writes
+        // test files — while `code-critic` stays, because it only reads.
+        for agent in ["research", "code-critic", "code-analyzer"] {
             assert_eq!(
                 evaluate_shared_tree_dispatch(
                     "Agent",
@@ -527,6 +528,21 @@ mod tests {
                 None,
                 "{agent} must be allowed alongside a running engineer"
             );
+        }
+    }
+
+    #[test]
+    fn denies_a_file_writing_non_engineer_alongside_an_engineer() {
+        // #5650: these wrote into the engineer's tree with no deny at all.
+        for agent in ["documentation", "version-control", "qa", "web-qa", "api-qa"] {
+            let reason = evaluate_shared_tree_dispatch(
+                "Agent",
+                Some(&input(agent, None)),
+                Path::new("/repo"),
+                &["rust-engineer".to_string()],
+            )
+            .unwrap_or_else(|| panic!("{agent} writes files and must be denied"));
+            assert!(reason.contains("rust-engineer"), "{reason}");
         }
     }
 

--- a/crates/trusty-mpm/src/core/dispatch_isolation.rs
+++ b/crates/trusty-mpm/src/core/dispatch_isolation.rs
@@ -26,18 +26,24 @@
 //! A false DENY lands on the PM and halts every dispatch in the system; a false
 //! ALLOW merely reproduces the behaviour that shipped before this module. So
 //! [`agent_mutates_files`] answers `true` only for an agent this binary ships
-//! and can positively identify as engineer-tier — an unknown name, a custom
+//! and can positively identify as file-mutating — an unknown name, a custom
 //! project agent, a renamed agent, or an unparseable frontmatter all answer
 //! `false` and the dispatch proceeds.
 //!
-//! Why engineer-tier and not "every agent that could conceivably write": the
-//! narrower set is what keeps the guard from false-denying the ordinary
-//! workflow. A `version-control` agent opening a PR, a `documentation` agent
-//! editing a doc, or an `ops` agent running a build all touch files, but they
-//! routinely need to see the engineer's work in the shared tree — denying them
-//! for lack of an isolated worktree would block the normal delivery chain to
-//! prevent a race they are not the documented trigger for. The documented
-//! incident is two concurrent engineers, and that is what this classifies.
+//! What the classifier covers, and why not more: an agent counts when its own
+//! bundled definition tells it to write to the tree it is dispatched into.
+//! #4480 shipped engineer-tier alone on the theory that the adjacent tiers need
+//! to see the engineer's work in the shared tree; #5650 found that reasoning
+//! backwards for three of them. `documentation` creates and reorganises files,
+//! `git mv`s them, and commits; `version-control` branches, commits, and pushes;
+//! `qa` writes test files. Wanting to read the engineer's work does not make
+//! writing alongside it safe — a `documentation` agent dispatched next to a
+//! `rust-engineer`, both unisolated, is the same single-HEAD collision the module
+//! exists to stop, and it passed with no deny at all until #5650.
+//!
+//! A dispatch that only reads — research, code analysis, adversarial review,
+//! ticketing — still answers `false` and still parallelises freely. That is where
+//! the line sits now: writes, not proximity to writes.
 //!
 //! Test: the `#[cfg(test)]` suite below.
 
@@ -63,14 +69,40 @@ pub const ISOLATING_DISPATCH_MODES: &[&str] = &["worktree", "remote"];
 ///
 /// Why: `role:` is the declared domain every bundled agent carries, so this is a
 /// property of the agent definition rather than a name-shaped guess that a
-/// rename would silently invalidate. The set is deliberately the engineer tier
-/// alone — see the module doc for why widening it trades a rare race for a
-/// common false deny.
+/// rename would silently invalidate. A role belongs here only when EVERY bundled
+/// agent declaring it writes files; a role with a read-only member is keyed by
+/// name in [`FILE_MUTATING_NAMES`] instead.
 /// What: matched case-sensitively against [`crate::core::agent_metadata::AgentMetadata::role`].
 /// `data-engineer` is listed explicitly because it declares that role rather
-/// than plain `engineer` while still extending `base-engineer`.
-/// Test: `engineer_tier_agents_mutate_files`, `non_engineer_agents_do_not`.
-const FILE_MUTATING_ROLES: &[&str] = &["engineer", "data-engineer"];
+/// than plain `engineer` while still extending `base-engineer`. `documentation`
+/// and `version-control` each have exactly one bundled agent, and both write —
+/// docs and `git mv`s for one, branches and commits for the other.
+/// Test: `engineer_tier_agents_mutate_files`, `file_writing_non_engineer_agents_mutate_files`,
+/// `non_engineer_agents_do_not`.
+// #5650: documentation and version-control demonstrably write files; omitting
+// them let two unisolated writers share one HEAD with no deny.
+const FILE_MUTATING_ROLES: &[&str] = &[
+    "engineer",
+    "data-engineer",
+    "documentation",
+    "version-control",
+];
+
+/// Bundled agent `name:`s that mutate files but whose `role:` cannot say so.
+///
+/// Why: this list is keyed on NAME rather than role, and that is deliberate —
+/// do not fold it back into [`FILE_MUTATING_ROLES`]. All four bundled agents
+/// declaring `role: qa` also declare `extends: base-qa`, but they do not agree
+/// about writing: `qa`, `web-qa`, and `api-qa` author test files, while
+/// `code-critic` is a pure reviewer that reads code and returns a verdict
+/// (`code-critic.md` — "You did not write this code"). Adding `qa` to the role
+/// list would classify `code-critic` as mutating and deny a review dispatched
+/// alongside an engineer, which is the ordinary workflow.
+/// What: matched case-sensitively against the agent's declared `name:`.
+/// Test: `file_writing_non_engineer_agents_mutate_files`,
+/// `code_critic_is_not_file_mutating`.
+// #5650: role: qa is not homogeneous — code-critic shares it and only reviews.
+const FILE_MUTATING_NAMES: &[&str] = &["qa", "web-qa", "api-qa"];
 
 /// The `extends:` base whose descendants are engineer-tier regardless of role.
 ///
@@ -104,14 +136,16 @@ pub fn isolation_separates_working_tree(isolation: Option<&str>) -> bool {
 /// added.
 /// What: scans the compiled-in bundle for the agent whose declared `name:`
 /// equals `agent`, and reports whether its `role:` is in
-/// [`FILE_MUTATING_ROLES`] or its `extends:` is [`FILE_MUTATING_BASE`]. A name
-/// this binary does not ship — a project-local or custom agent — answers
-/// `false`, the fail-open direction this module's doc commits to.
+/// [`FILE_MUTATING_ROLES`], its `extends:` is [`FILE_MUTATING_BASE`], or its
+/// name is in [`FILE_MUTATING_NAMES`]. A name this binary does not ship — a
+/// project-local or custom agent — answers `false`, the fail-open direction
+/// this module's doc commits to.
 ///
 /// No caching and no I/O: the bundle is a compile-time table of ~40 entries and
 /// this runs once per `Agent` dispatch, which is rare compared to ordinary tool
 /// calls. A process-lifetime cache would be global state for no measurable win.
-/// Test: `engineer_tier_agents_mutate_files`, `non_engineer_agents_do_not`,
+/// Test: `engineer_tier_agents_mutate_files`,
+/// `file_writing_non_engineer_agents_mutate_files`, `non_engineer_agents_do_not`,
 /// `unknown_agent_fails_open`.
 pub fn agent_mutates_files(agent: &str) -> bool {
     if agent.is_empty() {
@@ -132,6 +166,9 @@ pub fn agent_mutates_files(agent: &str) -> bool {
                 .as_deref()
                 .is_some_and(|r| FILE_MUTATING_ROLES.contains(&r))
                 || meta.extends.as_deref() == Some(FILE_MUTATING_BASE)
+                // #5650: name-keyed because `role: qa` mixes writers with the
+                // read-only `code-critic`; see FILE_MUTATING_NAMES.
+                || FILE_MUTATING_NAMES.contains(&agent)
         })
 }
 
@@ -228,18 +265,40 @@ mod tests {
     }
 
     #[test]
+    fn file_writing_non_engineer_agents_mutate_files() {
+        // #5650: these five write files and got no isolation at all before it.
+        // `documentation` and `version-control` arrive by role; the three QA
+        // agents by name, because `role: qa` also covers `code-critic`.
+        for agent in ["documentation", "version-control", "qa", "web-qa", "api-qa"] {
+            assert!(
+                agent_mutates_files(agent),
+                "{agent} writes files and must classify as file-mutating"
+            );
+        }
+    }
+
+    #[test]
+    fn code_critic_is_not_file_mutating() {
+        // The trap FILE_MUTATING_NAMES exists to avoid. `code-critic` declares
+        // the same `role: qa` and `extends: base-qa` as the three QA writers,
+        // but it only reads code and returns a verdict. Widening by role would
+        // deny a review dispatched alongside the engineer it reviews.
+        assert!(
+            !agent_mutates_files("code-critic"),
+            "code-critic reviews and never writes; a role-based widen would misclassify it"
+        );
+    }
+
+    #[test]
     fn non_engineer_agents_do_not() {
-        // The read-only and adjacent tiers the PM dispatches in parallel
-        // routinely. Denying these would halt the ordinary workflow to prevent
-        // a race they are not the trigger for — see the module doc.
+        // The read-only tiers the PM dispatches in parallel routinely. Denying
+        // these would halt the ordinary workflow to prevent a race they are not
+        // the trigger for — see the module doc.
         for agent in [
             "research",
             "code-critic",
             "code-analyzer",
-            "qa",
             "security",
-            "documentation",
-            "version-control",
             "ticketing",
         ] {
             assert!(


### PR DESCRIPTION
Closes #5650

`agent_mutates_files` recognised only `role: engineer` / `data-engineer` and
`extends: base-engineer`. `documentation`, `version-control`, `qa`, `web-qa`, and
`api-qa` all answered `false`, so any of them dispatched unisolated alongside a
running engineer wrote into that engineer's tree on one git HEAD and `tm hook
--pm-guard` allowed it.

## What changed

- `documentation` and `version-control` join `FILE_MUTATING_ROLES`. Each role has
  exactly one bundled agent (`crates/trusty-agents-common/src/assets/agents/`),
  and both write: `documentation` creates/reorganises files, `git mv`s them, and
  commits; `version-control` branches, commits, and pushes.
- `qa`, `web-qa`, and `api-qa` are matched by a new **name**-keyed
  `FILE_MUTATING_NAMES` instead. `role: qa` is not homogeneous — `code-critic`
  declares the identical `role: qa` and `extends: base-qa` but is a pure reviewer
  ("You did not write this code… you recommend, the PM decides",
  `code-critic.md:16,111`). A role-based widen would deny a review dispatched
  alongside the engineer it reviews. The const carries a comment saying not to
  fold it back into the role list.
- Fail-open is unchanged. The name check sits inside the bundle lookup, so an
  unbundled, custom, or renamed agent still answers `false`;
  `unknown_agent_fails_open` passes unmodified.
- Module doc rationale rewritten: the old paragraph argued the adjacent tiers
  need to see the engineer's work in the shared tree, which is an argument for
  reading it, not for writing into it.
- `tm-workflow.md` said "QA agents get their own worktree… same as engineering
  agents" while the guard classified `qa` as non-mutating. It now lists exactly
  which agents count, including the `code-critic` exception.

## Changed test expectations — flagging explicitly

`dispatch_isolation.rs::non_engineer_agents_do_not` pinned the old behaviour: it
asserted `documentation`, `version-control`, and `qa` were **not** file-mutating.
Those three names are removed from it and now assert the opposite in
`file_writing_non_engineer_agents_mutate_files`. `code-critic`, `research`,
`code-analyzer`, `security`, and `ticketing` stay in the original test unchanged.

Same edit in `pm_guard_dispatch.rs::allows_a_read_only_agent`: `qa` moved out
(replaced by `code-analyzer`), and the new
`denies_a_file_writing_non_engineer_alongside_an_engineer` asserts the deny.

That the old assertions passed on `main` is the proof the new ones failed before
this change.

New tests:

- `file_writing_non_engineer_agents_mutate_files` — all five names classify as
  mutating.
- `code_critic_is_not_file_mutating` — the trap this design avoids.
- `denies_a_file_writing_non_engineer_alongside_an_engineer` — the guard-level
  deny, not just the classifier.

## Gates — rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                      EXIT=0
cargo check -p trusty-mpm                              EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings EXIT=0
cargo test -p trusty-mpm                               EXIT=0
```

`cargo test -p trusty-mpm`: 4969 passed / 0 failed / 7 ignored in the lib target,
1657 + 1657 across the two binary targets, all remaining targets green.

Also run: `bash scripts/check_line_cap.sh` (EXIT=0 — `dispatch_isolation.rs` is
well under the 500-SLOC production cap), `bash scripts/check_sld.sh` (EXIT=0),
`bash scripts/check_changelog_fragment.sh` (EXIT=0).

## Not addressed here

Issue #5650 lists three other fail-open paths as evidence — untyped dispatch with
no `subagent_type`, `cwd` exact-equality in `sessions.rs:557`, and the daemon-down
warning in `pm_guard_dispatch.rs`. Each is a separate change with its own blast
radius; this PR is the classifier only.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
