### PR TITLE
fix(trusty-audit): select OpenRouter and the three role models for audit inference (#5671)

### DIFF
--- a/crates/trusty-audit/changelog.d/5671-audit-sets-provider.md
+++ b/crates/trusty-audit/changelog.d/5671-audit-sets-provider.md
@@ -7,7 +7,15 @@ Fixed
   last precedence level for all three roles, so the key sat unread while the
   reviewer either failed on missing AWS credentials or silently billed Bedrock
   ([#5671](https://github.com/bobmatnyc/trusty-tools/issues/5671)).
+- The provider and the three model ids are resolved as one selection from a
+  single layer — the operator's environment, else the engagement config, else
+  the built-in slugs. A layer that names some of the four but not all four is
+  refused before any child is spawned, naming what it set and what it left
+  unset. Resolving them independently would pair an operator's
+  `TRUSTY_REVIEW_PROVIDER=bedrock` with this crate's OpenRouter slugs, which is
+  the same HTTP 400 reached from the other direction; nothing downstream catches
+  that pairing ([#5679](https://github.com/bobmatnyc/trusty-tools/issues/5679)).
 - An optional `[models]` table in `engagement.toml` overrides the built-in
-  OpenRouter slugs, so a model rename is a config edit rather than a release.
-  Any of the four variables already set in the operator's environment is
-  inherited rather than clobbered.
+  slugs, so a model rename is a config edit rather than a release. It rejects
+  unknown keys, so `reviewr` is a parse error instead of a silent fallback to
+  the default.

--- a/crates/trusty-audit/changelog.d/5671-audit-sets-provider.md
+++ b/crates/trusty-audit/changelog.d/5671-audit-sets-provider.md
@@ -1,2 +1,13 @@
 Fixed
-The `tga audit` child now carries `TRUSTY_REVIEW_PROVIDER=openrouter` and the reviewer/verifier/summarizer model ids alongside the engagement's `OPENROUTER_API_KEY`, so review inference actually reaches OpenRouter — naming the key was never enough, because `trusty-review` defaults to Bedrock. An `[models]` table in `engagement.toml` overrides the built-in slugs, and any of the four variables already set in the operator's environment is inherited rather than clobbered (#5671).
+
+- The `tga audit` child now carries `TRUSTY_REVIEW_PROVIDER=openrouter` and the
+  reviewer, verifier and summarizer model ids alongside the engagement's
+  `OPENROUTER_API_KEY`, so review inference actually reaches OpenRouter. Naming
+  the key was never enough: `trusty-review` resolves `Provider::Bedrock` as the
+  last precedence level for all three roles, so the key sat unread while the
+  reviewer either failed on missing AWS credentials or silently billed Bedrock
+  ([#5671](https://github.com/bobmatnyc/trusty-tools/issues/5671)).
+- An optional `[models]` table in `engagement.toml` overrides the built-in
+  OpenRouter slugs, so a model rename is a config edit rather than a release.
+  Any of the four variables already set in the operator's environment is
+  inherited rather than clobbered.

--- a/crates/trusty-audit/changelog.d/5671-audit-sets-provider.md
+++ b/crates/trusty-audit/changelog.d/5671-audit-sets-provider.md
@@ -1,0 +1,2 @@
+Fixed
+The `tga audit` child now carries `TRUSTY_REVIEW_PROVIDER=openrouter` and the reviewer/verifier/summarizer model ids alongside the engagement's `OPENROUTER_API_KEY`, so review inference actually reaches OpenRouter — naming the key was never enough, because `trusty-review` defaults to Bedrock. An `[models]` table in `engagement.toml` overrides the built-in slugs, and any of the four variables already set in the operator's environment is inherited rather than clobbered (#5671).

--- a/crates/trusty-audit/src/config.rs
+++ b/crates/trusty-audit/src/config.rs
@@ -164,9 +164,16 @@ pub struct ToolPins {
 /// reviewer = "anthropic/claude-sonnet-4.6"
 /// ```
 ///
-/// Test: `super::config_tests::a_models_table_loads_and_is_optional`, and
-/// `crate::inference::inference_tests::a_models_table_beats_the_built_in_slugs`.
+/// Unknown keys are REJECTED here, unlike the rest of the config. The point of
+/// the table is fixing a slug without a release; `reviewr = "…"` silently
+/// falling back to the built-in default defeats exactly that, and the operator
+/// would only learn of the typo from a surprising bill. The cost is that a
+/// newer generator adding a fifth role fails to load rather than degrading —
+/// the right trade for four keys that are all optional anyway.
+/// Test: `super::config_tests::a_models_table_loads_and_is_optional`,
+/// `super::config_tests::a_typo_in_the_models_table_is_a_parse_error`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct ModelPins {
     /// Overrides the provider `trusty-review` selects (`openrouter` by default).
@@ -307,6 +314,16 @@ trusty-review = "0.15.1"
             Some("anthropic/claude-opus-4.8")
         );
         assert!(pinned.models.verifier.is_none());
+    }
+
+    /// A misspelled role must not fall back to the built-in slug in silence —
+    /// the operator would only find out from the bill.
+    #[test]
+    fn a_typo_in_the_models_table_is_a_parse_error() {
+        let text = format!("{SAMPLE}\n[models]\nreviewr = \"anthropic/claude-opus-4.8\"\n");
+        let err = EngagementConfig::from_toml(&text, Path::new("engagement.toml"))
+            .expect_err("`reviewr` is not a role");
+        assert!(matches!(err, AuditError::Parse { .. }), "{err:?}");
     }
 
     #[test]

--- a/crates/trusty-audit/src/config.rs
+++ b/crates/trusty-audit/src/config.rs
@@ -149,6 +149,36 @@ pub struct ToolPins {
     pub trusty_review: ToolPin,
 }
 
+/// Per-role model selection for the audit's review inference (#5671).
+///
+/// Why: the built-in slugs in [`crate::inference`] are Rust constants, so a
+/// model rename would otherwise need a release before an engagement could run.
+/// Naming them here lets the owner correct a slug in the file the recipient
+/// already has. Every field is optional — a config that says nothing about
+/// models gets the built-in defaults, which is the common case.
+/// What: an all-optional mirror of the four variables `trusty-review` reads.
+/// The TOML shape is a `[models]` table:
+///
+/// ```toml
+/// [models]
+/// reviewer = "anthropic/claude-sonnet-4.6"
+/// ```
+///
+/// Test: `super::config_tests::a_models_table_loads_and_is_optional`, and
+/// `crate::inference::inference_tests::a_models_table_beats_the_built_in_slugs`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[non_exhaustive]
+pub struct ModelPins {
+    /// Overrides the provider `trusty-review` selects (`openrouter` by default).
+    pub provider: Option<String>,
+    /// Overrides the reviewer role's model id.
+    pub reviewer: Option<String>,
+    /// Overrides the verifier role's model id.
+    pub verifier: Option<String>,
+    /// Overrides the summarizer role's model id.
+    pub summarizer: Option<String>,
+}
+
 /// The engagement config that travels inside the handoff package.
 ///
 /// Why: the recipient can read this file before running anything — that
@@ -168,6 +198,10 @@ pub struct EngagementConfig {
     pub instructions: String,
     /// The exact tool versions this engagement runs (#5495).
     pub tools: ToolPins,
+    /// Per-role model selection for review inference (#5671). Absent means the
+    /// built-in slugs in [`crate::inference`].
+    #[serde(default)]
+    pub models: ModelPins,
     /// Client name, when the generator recorded one.
     #[serde(default)]
     pub client: Option<String>,
@@ -255,6 +289,24 @@ trusty-review = "0.15.1"
         assert_eq!(cfg.tools.tga.version(), "2.9.4");
         assert_eq!(cfg.tools.trusty_analyze.version(), "0.9.2");
         assert_eq!(cfg.tools.trusty_review.version(), "0.15.1");
+    }
+
+    /// A model rename must be fixable in the engagement file, and a config that
+    /// says nothing about models must keep loading (#5671).
+    #[test]
+    fn a_models_table_loads_and_is_optional() {
+        let bare =
+            EngagementConfig::from_toml(SAMPLE, Path::new("engagement.toml")).expect("parses");
+        assert_eq!(bare.models, ModelPins::default());
+
+        let text = format!("{SAMPLE}\n[models]\nreviewer = \"anthropic/claude-opus-4.8\"\n");
+        let pinned =
+            EngagementConfig::from_toml(&text, Path::new("engagement.toml")).expect("parses");
+        assert_eq!(
+            pinned.models.reviewer.as_deref(),
+            Some("anthropic/claude-opus-4.8")
+        );
+        assert!(pinned.models.verifier.is_none());
     }
 
     #[test]

--- a/crates/trusty-audit/src/error.rs
+++ b/crates/trusty-audit/src/error.rs
@@ -110,6 +110,33 @@ pub enum AuditError {
         installed: String,
     },
 
+    /// One layer named some of the four inference variables but not all four.
+    ///
+    /// Why: the provider and the three role model ids are ONE selection — a
+    /// model id only means anything in its provider's namespace. Resolving them
+    /// independently pairs, say, an operator's `TRUSTY_REVIEW_PROVIDER=bedrock`
+    /// with this crate's OpenRouter slugs, which is the HTTP 400 #5671 exists to
+    /// remove. Guessing the missing half on someone's behalf is what produces
+    /// that pairing, so a half-named selection refuses instead.
+    /// What: names the layer, what it set, and what it left unset. Raised before
+    /// any child is spawned, because the condition is identical for every
+    /// repository in the sweep.
+    /// Test: `crate::inference::inference_tests::a_partly_set_operator_environment_refuses`,
+    /// `crate::run::run_tests::a_partial_operator_environment_refuses_before_any_child_runs`.
+    #[error(
+        "review inference is half-configured by the {layer}: {set} named, but {missing} left \
+         unset. The provider and all three role models are one selection — name all four or \
+         none, so a provider is never paired with another provider's model ids"
+    )]
+    SplitInferenceSelection {
+        /// Which layer half-named the selection, for the operator to go fix.
+        layer: &'static str,
+        /// The variables (or config keys) that layer did set, comma-separated.
+        set: String,
+        /// The ones it left unset, comma-separated.
+        missing: String,
+    },
+
     /// The working directory's `tools/` area is not a real directory.
     ///
     /// Why: [`crate::workdir`] promises that `rm -rf <root>` removes everything

--- a/crates/trusty-audit/src/inference.rs
+++ b/crates/trusty-audit/src/inference.rs
@@ -16,17 +16,39 @@
 //! one. The scope is deliberately narrow: OpenRouter is selected for THIS child
 //! process only. `trusty-review`'s own default stays Bedrock.
 //!
-//! Precedence, highest first — an operator is never silently overridden:
+//! ## The four variables are ONE selection, not four
 //!
-//! 1. The variable already set in the process environment. The child inherits
-//!    it, so this module emits nothing for that variable at all.
+//! A model id only means anything inside its provider's namespace:
+//! `anthropic/claude-sonnet-4.6` is an OpenRouter slug and
+//! `us.anthropic.claude-sonnet-4-6` is a Bedrock inference profile for the same
+//! model. So provider and models are resolved as a UNIT, from exactly one
+//! layer — highest first:
+//!
+//! 1. The operator's process environment.
 //! 2. The engagement config's `[models]` table ([`ModelPins`]).
 //! 3. The built-in slugs below.
 //!
-//! Test: `super::inference_tests`, and
-//! `crate::run::run_tests::the_child_environment_selects_openrouter_and_all_three_models`.
+//! **The first layer that names any of the four must name all four**, or
+//! [`inference_env`] returns [`AuditError::SplitInferenceSelection`] and the
+//! sweep refuses before spawning anything. Resolving the four independently is
+//! what reproduces #5671: an operator who exports
+//! `TRUSTY_REVIEW_PROVIDER=bedrock` and nothing else would otherwise have
+//! `bedrock` paired with this module's OpenRouter slugs — the same HTTP 400
+//! this module exists to remove, arrived at from the other direction. Nothing
+//! downstream catches that pairing: `resolve_role` resolves provider and model
+//! on independent chains too (#5679).
+//!
+//! Refusing is deliberate. The alternative is guessing which half someone meant,
+//! and a wrong guess here is billed to the operator in a currency they did not
+//! choose.
+//!
+//! Test: `super::inference_tests`, and `crate::run::run_tests`'
+//! `the_child_environment_selects_openrouter_and_all_three_models`,
+//! `a_fully_set_operator_environment_is_left_alone`,
+//! `a_partial_operator_environment_refuses_before_any_child_runs`.
 
 use crate::config::{EngagementConfig, ModelPins};
+use crate::error::AuditError;
 
 /// The variable `trusty-review` reads its provider from.
 pub const ENV_PROVIDER: &str = "TRUSTY_REVIEW_PROVIDER";
@@ -65,53 +87,134 @@ pub const DEFAULT_VERIFIER_MODEL: &str = "anthropic/claude-haiku-4.5";
 /// Summarizer model — deterministic, low-stakes, same tier as the verifier.
 pub const DEFAULT_SUMMARIZER_MODEL: &str = "anthropic/claude-haiku-4.5";
 
+/// The four variables in the order they are reported, so an error message and
+/// the emitted pairs list read the same way.
+const SELECTION: [&str; 4] = [
+    ENV_PROVIDER,
+    ENV_REVIEWER_MODEL,
+    ENV_VERIFIER_MODEL,
+    ENV_SUMMARIZER_MODEL,
+];
+
+/// Split a layer's four values into (named, unnamed), preserving order.
+fn partition(
+    values: [Option<&str>; 4],
+    names: [&'static str; 4],
+) -> (Vec<&'static str>, Vec<&'static str>) {
+    let mut named = Vec::new();
+    let mut unnamed = Vec::new();
+    for (value, name) in values.into_iter().zip(names) {
+        if value.is_some() {
+            named.push(name)
+        } else {
+            unnamed.push(name)
+        }
+    }
+    (named, unnamed)
+}
+
+/// Reject a layer that named some of the four but not all of them.
+fn all_or_none(
+    values: [Option<&str>; 4],
+    names: [&'static str; 4],
+    layer: &'static str,
+) -> Result<bool, AuditError> {
+    let (named, missing) = partition(values, names);
+    match named.len() {
+        0 => Ok(false),
+        4 => Ok(true),
+        _ => Err(AuditError::SplitInferenceSelection {
+            layer,
+            set: named.join(", "),
+            missing: missing.join(", "),
+        }),
+    }
+}
+
 /// Build the `TRUSTY_REVIEW_*` pairs to set on the `tga audit` child.
 ///
 /// # Postconditions
 ///
-/// With a non-blank engagement key and an empty operator environment, the
-/// result names all four variables: [`ENV_PROVIDER`] set to
-/// [`PROVIDER_OPENROUTER`], and one model id per role. Every variable the
-/// `operator` lookup already answers is ABSENT from the result, so the child
-/// inherits the operator's value rather than this crate's. With a blank key the
-/// result is empty — an engagement that configured no credential must not be
-/// pointed at a provider it cannot authenticate against.
+/// On `Ok`, the result is either EMPTY or names all four variables — never a
+/// subset, which is the property that keeps a provider from being paired with
+/// another provider's model ids. Empty means the child's inherited environment
+/// is already self-consistent (the operator named all four) or there is nothing
+/// to authenticate with (a blank engagement key). Otherwise all four come from
+/// the same layer: the engagement `[models]` table if it named them, else the
+/// built-in slugs, with [`ENV_PROVIDER`] set to [`PROVIDER_OPENROUTER`].
+///
+/// # Errors
+///
+/// [`AuditError::SplitInferenceSelection`] when the operator's environment or
+/// the `[models]` table names some of the four but not all four. See the module
+/// docs for why that refuses rather than filling in the rest.
 ///
 /// `operator` is a parameter rather than a direct `std::env::var` call for the
 /// same reason [`crate::workdir::WorkDir::resolve`] takes the environment: the
-/// precedence rule is then provable without mutating the process environment,
-/// which is racy across a parallel test binary.
-/// Test: `super::inference_tests::an_operator_variable_is_never_overridden`.
-pub fn inference_env<F>(config: &EngagementConfig, operator: F) -> Vec<(&'static str, String)>
+/// precedence rule is then provable — through the real spawn path, not just a
+/// unit test — without mutating the process environment, which is racy across a
+/// parallel test binary and `unsafe` in edition 2024.
+/// Test: `super::inference_tests::an_operator_who_named_all_four_is_left_alone`,
+/// `super::inference_tests::a_partly_set_operator_environment_refuses`.
+pub fn inference_env<F>(
+    config: &EngagementConfig,
+    operator: F,
+) -> Result<Vec<(&'static str, String)>, AuditError>
 where
     F: Fn(&str) -> Option<String>,
 {
     if config.openrouter_key.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
+
+    let from_operator = SELECTION.map(&operator);
+    if all_or_none(
+        [
+            from_operator[0].as_deref(),
+            from_operator[1].as_deref(),
+            from_operator[2].as_deref(),
+            from_operator[3].as_deref(),
+        ],
+        SELECTION,
+        "operator environment",
+    )? {
+        // The operator named the whole selection; the child inherits it intact.
+        return Ok(Vec::new());
+    }
+
     let pins: &ModelPins = &config.models;
-    [
-        (ENV_PROVIDER, pins.provider.as_deref(), PROVIDER_OPENROUTER),
-        (
-            ENV_REVIEWER_MODEL,
-            pins.reviewer.as_deref(),
-            DEFAULT_REVIEWER_MODEL,
-        ),
-        (
-            ENV_VERIFIER_MODEL,
-            pins.verifier.as_deref(),
-            DEFAULT_VERIFIER_MODEL,
-        ),
-        (
-            ENV_SUMMARIZER_MODEL,
-            pins.summarizer.as_deref(),
-            DEFAULT_SUMMARIZER_MODEL,
-        ),
-    ]
-    .into_iter()
-    .filter(|(name, _, _)| operator(name).is_none())
-    .map(|(name, pinned, fallback)| (name, pinned.unwrap_or(fallback).to_owned()))
-    .collect()
+    let from_config = [
+        pins.provider.as_deref(),
+        pins.reviewer.as_deref(),
+        pins.verifier.as_deref(),
+        pins.summarizer.as_deref(),
+    ];
+    let config_names = ["provider", "reviewer", "verifier", "summarizer"];
+    let use_config = all_or_none(
+        from_config,
+        config_names,
+        "engagement config `[models]` table",
+    )?;
+
+    let defaults = [
+        PROVIDER_OPENROUTER,
+        DEFAULT_REVIEWER_MODEL,
+        DEFAULT_VERIFIER_MODEL,
+        DEFAULT_SUMMARIZER_MODEL,
+    ];
+    Ok(SELECTION
+        .into_iter()
+        .zip(from_config)
+        .zip(defaults)
+        .map(|((name, pinned), fallback)| {
+            let value = if use_config {
+                pinned.unwrap_or(fallback)
+            } else {
+                fallback
+            };
+            (name, value.to_owned())
+        })
+        .collect())
 }
 
 #[cfg(test)]
@@ -130,6 +233,12 @@ trusty-analyze = "0.9.2"
 trusty-review = "0.15.1"
 "#;
 
+    /// A `[models]` table naming the whole selection, which is the only shape
+    /// the all-or-none rule accepts from the config layer.
+    const WHOLE_TABLE: &str = "\n[models]\nprovider = \"openrouter\"\n\
+         reviewer = \"anthropic/claude-opus-4.8\"\nverifier = \"anthropic/claude-haiku-4.5\"\n\
+         summarizer = \"anthropic/claude-haiku-4.5\"\n";
+
     fn config_from(text: &str) -> EngagementConfig {
         EngagementConfig::from_toml(text, Path::new("engagement.toml")).expect("parses")
     }
@@ -139,7 +248,10 @@ trusty-review = "0.15.1"
     }
 
     fn pairs(config: &EngagementConfig) -> HashMap<&'static str, String> {
-        inference_env(config, nothing_set).into_iter().collect()
+        inference_env(config, nothing_set)
+            .expect("an untouched operator environment resolves")
+            .into_iter()
+            .collect()
     }
 
     #[test]
@@ -147,7 +259,7 @@ trusty-review = "0.15.1"
         let env = pairs(&config_from(CONFIG));
         assert_eq!(
             env.get(ENV_PROVIDER).map(String::as_str),
-            Some("openrouter")
+            Some(PROVIDER_OPENROUTER)
         );
         assert_eq!(
             env.get(ENV_REVIEWER_MODEL).map(String::as_str),
@@ -187,51 +299,91 @@ trusty-review = "0.15.1"
     }
 
     #[test]
-    fn a_models_table_beats_the_built_in_slugs() {
-        let text = format!(
-            "{CONFIG}\n[models]\nreviewer = \"anthropic/claude-opus-4.8\"\nprovider = \"bedrock\"\n"
-        );
-        let env = pairs(&config_from(&text));
+    fn a_whole_models_table_beats_the_built_in_slugs() {
+        let env = pairs(&config_from(&format!("{CONFIG}{WHOLE_TABLE}")));
         assert_eq!(
             env.get(ENV_REVIEWER_MODEL).map(String::as_str),
             Some("anthropic/claude-opus-4.8")
         );
-        assert_eq!(env.get(ENV_PROVIDER).map(String::as_str), Some("bedrock"));
-        // Roles the table did not name still get the defaults.
         assert_eq!(
-            env.get(ENV_VERIFIER_MODEL).map(String::as_str),
-            Some(DEFAULT_VERIFIER_MODEL)
+            env.get(ENV_PROVIDER).map(String::as_str),
+            Some(PROVIDER_OPENROUTER)
         );
     }
 
-    /// The precedence rule that matters most: a value the operator already
-    /// exported is inherited, never replaced.
+    /// The mirror of the operator rule, at the config layer: naming a model
+    /// without its provider (or the reverse) is the same unresolvable half-ask.
     #[test]
-    fn an_operator_variable_is_never_overridden() {
+    fn a_partly_filled_models_table_refuses() {
         let text = format!("{CONFIG}\n[models]\nreviewer = \"anthropic/claude-opus-4.8\"\n");
-        let config = config_from(&text);
-        let env: HashMap<&str, String> = inference_env(&config, |name| {
-            (name == ENV_PROVIDER || name == ENV_REVIEWER_MODEL).then(|| "operator".to_owned())
-        })
-        .into_iter()
-        .collect();
+        let err = inference_env(&config_from(&text), nothing_set)
+            .expect_err("half a selection is not a selection");
+        let AuditError::SplitInferenceSelection {
+            layer,
+            set,
+            missing,
+        } = &err
+        else {
+            panic!("expected SplitInferenceSelection, got {err:?}");
+        };
+        assert!(layer.contains("engagement config"), "{layer}");
+        assert_eq!(set, "reviewer");
+        assert_eq!(missing, "provider, verifier, summarizer");
+    }
 
+    /// An operator who named the whole selection owns it: emit nothing, so the
+    /// child inherits their four values rather than a mix of theirs and ours.
+    #[test]
+    fn an_operator_who_named_all_four_is_left_alone() {
+        let text = format!("{CONFIG}{WHOLE_TABLE}");
+        let emitted = inference_env(&config_from(&text), |_| Some("operator".to_owned()))
+            .expect("a whole operator selection resolves");
         assert!(
-            !env.contains_key(ENV_PROVIDER),
-            "an operator-set provider must be inherited, not clobbered: {env:?}"
+            emitted.is_empty(),
+            "a complete operator selection must be inherited untouched: {emitted:?}"
         );
+    }
+
+    /// The #5671-class regression, arrived at from the other direction: an
+    /// operator on Bedrock who sets only the provider must not be handed
+    /// OpenRouter slugs to pair with it.
+    #[test]
+    fn a_partly_set_operator_environment_refuses() {
+        let err = inference_env(&config_from(CONFIG), |name| {
+            (name == ENV_PROVIDER).then(|| "bedrock".to_owned())
+        })
+        .expect_err("a provider without models is a mismatch waiting to happen");
+        let AuditError::SplitInferenceSelection {
+            layer,
+            set,
+            missing,
+        } = &err
+        else {
+            panic!("expected SplitInferenceSelection, got {err:?}");
+        };
+        assert_eq!(*layer, "operator environment");
+        assert_eq!(set, ENV_PROVIDER);
+        assert_eq!(
+            missing,
+            "TRUSTY_REVIEW_REVIEWER_MODEL, TRUSTY_REVIEW_VERIFIER_MODEL, \
+             TRUSTY_REVIEW_SUMMARIZER_MODEL"
+        );
+        // The message has to be actionable without reading this crate.
+        let rendered = err.to_string();
+        assert!(rendered.contains("all four or none"), "{rendered}");
+    }
+
+    /// The mirror case: a model named without a provider must not have
+    /// `openrouter` forced under it.
+    #[test]
+    fn an_operator_who_set_only_a_model_refuses() {
+        let err = inference_env(&config_from(CONFIG), |name| {
+            (name == ENV_REVIEWER_MODEL).then(|| "us.anthropic.claude-sonnet-4-6".to_owned())
+        })
+        .expect_err("a model without a provider is the same half-ask");
         assert!(
-            !env.contains_key(ENV_REVIEWER_MODEL),
-            "an operator-set model must outrank the engagement config: {env:?}"
-        );
-        // The variables the operator said nothing about are still supplied.
-        assert_eq!(
-            env.get(ENV_VERIFIER_MODEL).map(String::as_str),
-            Some(DEFAULT_VERIFIER_MODEL)
-        );
-        assert_eq!(
-            env.get(ENV_SUMMARIZER_MODEL).map(String::as_str),
-            Some(DEFAULT_SUMMARIZER_MODEL)
+            matches!(err, AuditError::SplitInferenceSelection { .. }),
+            "{err:?}"
         );
     }
 
@@ -240,6 +392,29 @@ trusty-review = "0.15.1"
     #[test]
     fn a_blank_key_selects_nothing() {
         let text = CONFIG.replace("sk-or-v1-not-a-real-key", "   ");
-        assert!(inference_env(&config_from(&text), nothing_set).is_empty());
+        assert!(
+            inference_env(&config_from(&text), nothing_set)
+                .expect("a blank key is not an error")
+                .is_empty()
+        );
+    }
+
+    /// The property the whole module exists for: whatever the inputs, the
+    /// result never names a strict subset of the four.
+    #[test]
+    fn the_result_is_never_a_partial_selection() {
+        let cases = [CONFIG.to_owned(), format!("{CONFIG}{WHOLE_TABLE}")];
+        for text in cases {
+            for operator_set_all in [false, true] {
+                let emitted = inference_env(&config_from(&text), |_| {
+                    operator_set_all.then(|| "operator".to_owned())
+                })
+                .expect("resolves");
+                assert!(
+                    emitted.is_empty() || emitted.len() == SELECTION.len(),
+                    "emitted a partial selection: {emitted:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/trusty-audit/src/inference.rs
+++ b/crates/trusty-audit/src/inference.rs
@@ -1,0 +1,245 @@
+//! Which LLM the audit's review inference actually runs on (#5671).
+//!
+//! Why: the engagement mints a spend-capped OpenRouter key and #5663 puts it in
+//! the `tga audit` child's environment. That was not enough to reach OpenRouter.
+//! `trusty-review` defaults to Bedrock — `RoleModels::resolve` hardcodes
+//! `Provider::Bedrock` as the last precedence level for all three roles — so the
+//! key sat unread while the reviewer either failed on missing AWS credentials or
+//! silently billed Bedrock. Naming the key is not selecting the provider; this
+//! module selects it.
+//!
+//! What: [`inference_env`] returns the `TRUSTY_REVIEW_*` pairs the child needs,
+//! given the engagement config and a lookup into the operator's environment.
+//! The four variables are `trusty-review`'s own second precedence layer
+//! (`crates/trusty-review/src/config/role_models.rs`, `RoleEnv::from_env`), so
+//! this reaches the reviewer through a documented interface rather than a new
+//! one. The scope is deliberately narrow: OpenRouter is selected for THIS child
+//! process only. `trusty-review`'s own default stays Bedrock.
+//!
+//! Precedence, highest first — an operator is never silently overridden:
+//!
+//! 1. The variable already set in the process environment. The child inherits
+//!    it, so this module emits nothing for that variable at all.
+//! 2. The engagement config's `[models]` table ([`ModelPins`]).
+//! 3. The built-in slugs below.
+//!
+//! Test: `super::inference_tests`, and
+//! `crate::run::run_tests::the_child_environment_selects_openrouter_and_all_three_models`.
+
+use crate::config::{EngagementConfig, ModelPins};
+
+/// The variable `trusty-review` reads its provider from.
+pub const ENV_PROVIDER: &str = "TRUSTY_REVIEW_PROVIDER";
+
+/// The variable `trusty-review` reads the reviewer role's model from.
+pub const ENV_REVIEWER_MODEL: &str = "TRUSTY_REVIEW_REVIEWER_MODEL";
+
+/// The variable `trusty-review` reads the verifier role's model from.
+pub const ENV_VERIFIER_MODEL: &str = "TRUSTY_REVIEW_VERIFIER_MODEL";
+
+/// The variable `trusty-review` reads the summarizer role's model from.
+pub const ENV_SUMMARIZER_MODEL: &str = "TRUSTY_REVIEW_SUMMARIZER_MODEL";
+
+/// The provider name `trusty-review`'s `Provider: FromStr` accepts for OpenRouter.
+pub const PROVIDER_OPENROUTER: &str = "openrouter";
+
+/// Reviewer model — the highest-quality call in the pipeline, so Sonnet-class.
+///
+/// Why: matches the role/cost split `trusty-review` already uses for Bedrock
+/// (Sonnet reviewer, Haiku verifier and summarizer), so switching provider does
+/// not silently change the quality tier as well.
+/// What: OpenRouter names Anthropic models `anthropic/claude-<tier>-<major>.<minor>`
+/// — a DOT, not a dash. Verified against `GET https://openrouter.ai/api/v1/models`
+/// on 2026-08-13, which lists `anthropic/claude-sonnet-4.6` and no dashed
+/// `-4-6` form. The dashed spelling in `trusty-agents` is that crate's own
+/// convention and is not an OpenRouter slug; sending it produces the HTTP 400
+/// `is not a valid model ID` this constant exists to avoid.
+pub const DEFAULT_REVIEWER_MODEL: &str = "anthropic/claude-sonnet-4.6";
+
+/// Verifier model — short, high-volume calls, so the cheapest Haiku tier.
+///
+/// A live audit run completed on this exact slug, which is the strongest
+/// evidence available for it; it is also present in OpenRouter's model list.
+pub const DEFAULT_VERIFIER_MODEL: &str = "anthropic/claude-haiku-4.5";
+
+/// Summarizer model — deterministic, low-stakes, same tier as the verifier.
+pub const DEFAULT_SUMMARIZER_MODEL: &str = "anthropic/claude-haiku-4.5";
+
+/// Build the `TRUSTY_REVIEW_*` pairs to set on the `tga audit` child.
+///
+/// # Postconditions
+///
+/// With a non-blank engagement key and an empty operator environment, the
+/// result names all four variables: [`ENV_PROVIDER`] set to
+/// [`PROVIDER_OPENROUTER`], and one model id per role. Every variable the
+/// `operator` lookup already answers is ABSENT from the result, so the child
+/// inherits the operator's value rather than this crate's. With a blank key the
+/// result is empty — an engagement that configured no credential must not be
+/// pointed at a provider it cannot authenticate against.
+///
+/// `operator` is a parameter rather than a direct `std::env::var` call for the
+/// same reason [`crate::workdir::WorkDir::resolve`] takes the environment: the
+/// precedence rule is then provable without mutating the process environment,
+/// which is racy across a parallel test binary.
+/// Test: `super::inference_tests::an_operator_variable_is_never_overridden`.
+pub fn inference_env<F>(config: &EngagementConfig, operator: F) -> Vec<(&'static str, String)>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    if config.openrouter_key.is_empty() {
+        return Vec::new();
+    }
+    let pins: &ModelPins = &config.models;
+    [
+        (ENV_PROVIDER, pins.provider.as_deref(), PROVIDER_OPENROUTER),
+        (
+            ENV_REVIEWER_MODEL,
+            pins.reviewer.as_deref(),
+            DEFAULT_REVIEWER_MODEL,
+        ),
+        (
+            ENV_VERIFIER_MODEL,
+            pins.verifier.as_deref(),
+            DEFAULT_VERIFIER_MODEL,
+        ),
+        (
+            ENV_SUMMARIZER_MODEL,
+            pins.summarizer.as_deref(),
+            DEFAULT_SUMMARIZER_MODEL,
+        ),
+    ]
+    .into_iter()
+    .filter(|(name, _, _)| operator(name).is_none())
+    .map(|(name, pinned, fallback)| (name, pinned.unwrap_or(fallback).to_owned()))
+    .collect()
+}
+
+#[cfg(test)]
+mod inference_tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::path::Path;
+
+    const CONFIG: &str = r#"
+openrouter_key = "sk-or-v1-not-a-real-key"
+instructions = "Assess the last 52 weeks."
+
+[tools]
+tga = "2.9.4"
+trusty-analyze = "0.9.2"
+trusty-review = "0.15.1"
+"#;
+
+    fn config_from(text: &str) -> EngagementConfig {
+        EngagementConfig::from_toml(text, Path::new("engagement.toml")).expect("parses")
+    }
+
+    fn nothing_set(_: &str) -> Option<String> {
+        None
+    }
+
+    fn pairs(config: &EngagementConfig) -> HashMap<&'static str, String> {
+        inference_env(config, nothing_set).into_iter().collect()
+    }
+
+    #[test]
+    fn the_defaults_select_openrouter_and_all_three_roles() {
+        let env = pairs(&config_from(CONFIG));
+        assert_eq!(
+            env.get(ENV_PROVIDER).map(String::as_str),
+            Some("openrouter")
+        );
+        assert_eq!(
+            env.get(ENV_REVIEWER_MODEL).map(String::as_str),
+            Some(DEFAULT_REVIEWER_MODEL)
+        );
+        assert_eq!(
+            env.get(ENV_VERIFIER_MODEL).map(String::as_str),
+            Some(DEFAULT_VERIFIER_MODEL)
+        );
+        assert_eq!(
+            env.get(ENV_SUMMARIZER_MODEL).map(String::as_str),
+            Some(DEFAULT_SUMMARIZER_MODEL)
+        );
+    }
+
+    /// The slugs are OpenRouter's, and OpenRouter spells the version with a dot.
+    /// A dashed slug is the exact input that produced the HTTP 400 in #5671.
+    #[test]
+    fn the_default_slugs_use_openrouters_dotted_spelling() {
+        for slug in [
+            DEFAULT_REVIEWER_MODEL,
+            DEFAULT_VERIFIER_MODEL,
+            DEFAULT_SUMMARIZER_MODEL,
+        ] {
+            assert!(
+                slug.starts_with("anthropic/claude-"),
+                "{slug} is not an OpenRouter anthropic slug"
+            );
+            assert!(
+                slug.contains('.'),
+                "{slug} uses the dashed spelling; OpenRouter names versions with a dot"
+            );
+        }
+        assert!(DEFAULT_REVIEWER_MODEL.contains("sonnet"));
+        assert!(DEFAULT_VERIFIER_MODEL.contains("haiku"));
+        assert!(DEFAULT_SUMMARIZER_MODEL.contains("haiku"));
+    }
+
+    #[test]
+    fn a_models_table_beats_the_built_in_slugs() {
+        let text = format!(
+            "{CONFIG}\n[models]\nreviewer = \"anthropic/claude-opus-4.8\"\nprovider = \"bedrock\"\n"
+        );
+        let env = pairs(&config_from(&text));
+        assert_eq!(
+            env.get(ENV_REVIEWER_MODEL).map(String::as_str),
+            Some("anthropic/claude-opus-4.8")
+        );
+        assert_eq!(env.get(ENV_PROVIDER).map(String::as_str), Some("bedrock"));
+        // Roles the table did not name still get the defaults.
+        assert_eq!(
+            env.get(ENV_VERIFIER_MODEL).map(String::as_str),
+            Some(DEFAULT_VERIFIER_MODEL)
+        );
+    }
+
+    /// The precedence rule that matters most: a value the operator already
+    /// exported is inherited, never replaced.
+    #[test]
+    fn an_operator_variable_is_never_overridden() {
+        let text = format!("{CONFIG}\n[models]\nreviewer = \"anthropic/claude-opus-4.8\"\n");
+        let config = config_from(&text);
+        let env: HashMap<&str, String> = inference_env(&config, |name| {
+            (name == ENV_PROVIDER || name == ENV_REVIEWER_MODEL).then(|| "operator".to_owned())
+        })
+        .into_iter()
+        .collect();
+
+        assert!(
+            !env.contains_key(ENV_PROVIDER),
+            "an operator-set provider must be inherited, not clobbered: {env:?}"
+        );
+        assert!(
+            !env.contains_key(ENV_REVIEWER_MODEL),
+            "an operator-set model must outrank the engagement config: {env:?}"
+        );
+        // The variables the operator said nothing about are still supplied.
+        assert_eq!(
+            env.get(ENV_VERIFIER_MODEL).map(String::as_str),
+            Some(DEFAULT_VERIFIER_MODEL)
+        );
+        assert_eq!(
+            env.get(ENV_SUMMARIZER_MODEL).map(String::as_str),
+            Some(DEFAULT_SUMMARIZER_MODEL)
+        );
+    }
+
+    /// No credential, no provider selection — pointing the reviewer at
+    /// OpenRouter with nothing to authenticate with just moves the failure.
+    #[test]
+    fn a_blank_key_selects_nothing() {
+        let text = CONFIG.replace("sk-or-v1-not-a-real-key", "   ");
+        assert!(inference_env(&config_from(&text), nothing_set).is_empty());
+    }
+}

--- a/crates/trusty-audit/src/lib.rs
+++ b/crates/trusty-audit/src/lib.rs
@@ -60,6 +60,7 @@ pub mod clone;
 pub mod config;
 pub mod discover;
 pub mod error;
+pub mod inference;
 pub mod manifest;
 pub mod run;
 pub mod session;

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -60,6 +60,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::{EngagementConfig, ToolPins};
 use crate::error::AuditError;
+use crate::inference;
 use crate::manifest::AuditManifest;
 use crate::tools::{self, RequiredTool};
 use crate::workdir::{Area, WorkDir};
@@ -688,6 +689,10 @@ pub const PER_REPO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 /// `PATH` can be reached instead. The credential goes in the environment and
 /// only there — see the module docs for what that costs.
 ///
+/// Alongside the credential the child gets the provider and per-role model ids
+/// from [`crate::inference`]: naming the key never routed anything to
+/// OpenRouter on its own, because `trusty-review` defaults to Bedrock (#5671).
+///
 /// A child that outlives `budget` is killed and recorded as a failure, so one
 /// hung repository costs that repository rather than the whole run.
 async fn spawn_tga(
@@ -708,7 +713,8 @@ async fn spawn_tga(
         source,
     })?;
 
-    let spawned = tokio::process::Command::new(&binaries.tga)
+    let mut command = tokio::process::Command::new(&binaries.tga);
+    command
         .arg("--config")
         .arg(config_path)
         .arg("audit")
@@ -721,8 +727,15 @@ async fn spawn_tga(
         .stdin(Stdio::null())
         .stdout(Stdio::from(file))
         .stderr(Stdio::from(errors))
-        .kill_on_drop(true)
-        .spawn();
+        .kill_on_drop(true);
+    // #5671: the credential alone never reached OpenRouter — trusty-review
+    // defaults to Bedrock, so the provider and the three role models must be
+    // named too. Operator-set variables are absent from this list and inherited.
+    for (name, value) in inference::inference_env(config, |name| std::env::var(name).ok()) {
+        command.env(name, value);
+    }
+
+    let spawned = command.spawn();
 
     let mut child = match spawned {
         Ok(child) => child,
@@ -1327,5 +1340,52 @@ trusty-review = "0.15.1"
             assert!(run.log.starts_with(work.root()), "{:?}", run.log);
         }
         assert!(progress_path(&work).starts_with(work.root()));
+    }
+
+    /// #5671: the child must carry the provider AND all three model ids, not
+    /// just the credential. This asserts on the environment the spawned process
+    /// actually received — the stub prints its own `TRUSTY_REVIEW_*` variables —
+    /// rather than on the value this crate computed.
+    ///
+    /// Against `origin/main` the four variables are absent from the child and
+    /// every assertion below fails: `spawn_tga` set only the credential and the
+    /// two binary paths, so `trusty-review` resolved `Provider::Bedrock`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_child_environment_selects_openrouter_and_all_three_models() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        // Dump the inference environment beside the manifest the run verifies.
+        let script = format!(
+            "{}{}",
+            writes_a_manifest(None).trim_end_matches("exit 0\n"),
+            "{\n  echo \"provider=$TRUSTY_REVIEW_PROVIDER\"\n  \
+             echo \"reviewer=$TRUSTY_REVIEW_REVIEWER_MODEL\"\n  \
+             echo \"verifier=$TRUSTY_REVIEW_VERIFIER_MODEL\"\n  \
+             echo \"summarizer=$TRUSTY_REVIEW_SUMMARIZER_MODEL\"\n  \
+             echo \"key=$OPENROUTER_API_KEY\"\n} > \"$out/env.txt\"\nexit 0\n",
+        );
+        install_stubs(&work, &script);
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let report = sweep(&work, &config()).await.expect("the sweep completes");
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+
+        let dumped = std::fs::read_to_string(report.repos[0].output.join("env.txt"))
+            .expect("the stub recorded its environment");
+        for expected in [
+            format!("provider={}", inference::PROVIDER_OPENROUTER),
+            format!("reviewer={}", inference::DEFAULT_REVIEWER_MODEL),
+            format!("verifier={}", inference::DEFAULT_VERIFIER_MODEL),
+            format!("summarizer={}", inference::DEFAULT_SUMMARIZER_MODEL),
+            // #5663's credential must still be there — this widens that, not replaces it.
+            "key=sk-or-v1-not-a-real-key".to_owned(),
+        ] {
+            assert!(
+                dumped.contains(&expected),
+                "the child environment is missing `{expected}`:\n{dumped}"
+            );
+        }
     }
 }

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -469,13 +469,38 @@ async fn sweep_with_budget(
     config: &EngagementConfig,
     budget: std::time::Duration,
 ) -> Result<RunReport, AuditError> {
+    sweep_with_env(work, config, budget, |name| std::env::var(name).ok()).await
+}
+
+/// [`sweep_with_budget`], with the operator's environment as an argument.
+///
+/// Why: the inference selection (#5671) branches on what the operator already
+/// exported, and every branch has to be provable THROUGH the real child spawn —
+/// asserting on [`inference::inference_env`] alone would not catch a wiring
+/// mistake between it and the `Command`. Injecting the lookup makes that
+/// provable without `std::env::set_var`, which is `unsafe` in edition 2024 and
+/// races every other thread in a parallel test binary.
+/// Test: `super::run_tests::a_fully_set_operator_environment_is_left_alone`,
+/// `super::run_tests::a_partial_operator_environment_refuses_before_any_child_runs`.
+async fn sweep_with_env<F>(
+    work: &WorkDir,
+    config: &EngagementConfig,
+    budget: std::time::Duration,
+    operator: F,
+) -> Result<RunReport, AuditError>
+where
+    F: Fn(&str) -> Option<String>,
+{
     work.create()?;
     let binaries = pinned_binaries(work, &config.tools)?;
+    // Resolved once, before any child: a half-named selection is identical for
+    // every repository, so failing per-repo would just repeat one misconfiguration.
+    let inference = inference::inference_env(config, operator)?;
     let selected = load_selection(work)?;
 
     let mut runs = Vec::with_capacity(selected.len());
     for (index, repo) in selected.into_iter().enumerate() {
-        runs.push(run_one(work, config, &binaries, index, repo, budget).await?);
+        runs.push(run_one(work, config, &binaries, &inference, index, repo, budget).await?);
     }
 
     let report = RunReport::of(runs);
@@ -484,10 +509,12 @@ async fn sweep_with_budget(
 }
 
 /// Audit one repository, recording rather than propagating its failure.
+#[allow(clippy::too_many_arguments)]
 async fn run_one(
     work: &WorkDir,
     config: &EngagementConfig,
     binaries: &PinnedBinaries,
+    inference: &[(&'static str, String)],
     index: usize,
     repo: SelectedRepo,
     budget: std::time::Duration,
@@ -504,6 +531,7 @@ async fn run_one(
             match spawn_tga(
                 binaries,
                 config,
+                inference,
                 &config_path,
                 &output,
                 &log,
@@ -695,9 +723,11 @@ pub const PER_REPO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 ///
 /// A child that outlives `budget` is killed and recorded as a failure, so one
 /// hung repository costs that repository rather than the whole run.
+#[allow(clippy::too_many_arguments)]
 async fn spawn_tga(
     binaries: &PinnedBinaries,
     config: &EngagementConfig,
+    inference: &[(&'static str, String)],
     config_path: &Path,
     output: &Path,
     log: &Path,
@@ -730,8 +760,9 @@ async fn spawn_tga(
         .kill_on_drop(true);
     // #5671: the credential alone never reached OpenRouter — trusty-review
     // defaults to Bedrock, so the provider and the three role models must be
-    // named too. Operator-set variables are absent from this list and inherited.
-    for (name, value) in inference::inference_env(config, |name| std::env::var(name).ok()) {
+    // named too. Resolved by `sweep_with_env`: either all four or none, never a
+    // subset that could pair one provider with another's model ids.
+    for (name, value) in inference {
         command.env(name, value);
     }
 
@@ -1342,21 +1373,19 @@ trusty-review = "0.15.1"
         assert!(progress_path(&work).starts_with(work.root()));
     }
 
-    /// #5671: the child must carry the provider AND all three model ids, not
-    /// just the credential. This asserts on the environment the spawned process
-    /// actually received — the stub prints its own `TRUSTY_REVIEW_*` variables —
-    /// rather than on the value this crate computed.
-    ///
-    /// Against `origin/main` the four variables are absent from the child and
-    /// every assertion below fails: `spawn_tga` set only the credential and the
-    /// two binary paths, so `trusty-review` resolved `Provider::Bedrock`.
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn the_child_environment_selects_openrouter_and_all_three_models() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let work = work_in(tmp.path());
-        // Dump the inference environment beside the manifest the run verifies.
-        let script = format!(
+    // ── #5671: what the spawned child's environment actually carries ─────────
+    //
+    // These go through the real `Command`, so they cover the wiring between
+    // `inference_env` and the child, not just the resolution rule. The operator
+    // environment is INJECTED rather than exported: `std::env::set_var` is
+    // `unsafe` in edition 2024 and races every other thread in this test binary,
+    // and `serial_test` is not a dev-dependency of this crate. Injection keeps
+    // the assertions deterministic while still exercising the real spawn.
+
+    /// A stub `tga` that writes the manifest and then records the inference
+    /// variables it was handed, so a test can read back the child's own view.
+    fn records_its_inference_env() -> String {
+        format!(
             "{}{}",
             writes_a_manifest(None).trim_end_matches("exit 0\n"),
             "{\n  echo \"provider=$TRUSTY_REVIEW_PROVIDER\"\n  \
@@ -1364,16 +1393,49 @@ trusty-review = "0.15.1"
              echo \"verifier=$TRUSTY_REVIEW_VERIFIER_MODEL\"\n  \
              echo \"summarizer=$TRUSTY_REVIEW_SUMMARIZER_MODEL\"\n  \
              echo \"key=$OPENROUTER_API_KEY\"\n} > \"$out/env.txt\"\nexit 0\n",
-        );
-        install_stubs(&work, &script);
-        make_repo(&work, "acme-api");
-        select(&work, &[("acme-api", "repos/acme-api")]);
+        )
+    }
 
-        let report = sweep(&work, &config()).await.expect("the sweep completes");
+    /// One repository, stubs installed, ready to sweep.
+    fn one_repo_ready(work: &WorkDir) {
+        install_stubs(work, &records_its_inference_env());
+        make_repo(work, "acme-api");
+        select(work, &[("acme-api", "repos/acme-api")]);
+    }
+
+    /// The `env.txt` the stub wrote, i.e. the child's own environment.
+    fn child_env(report: &RunReport) -> String {
+        std::fs::read_to_string(report.repos[0].output.join("env.txt"))
+            .expect("the stub recorded its environment")
+    }
+
+    async fn sweep_with_operator<F>(work: &WorkDir, operator: F) -> Result<RunReport, AuditError>
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        sweep_with_env(work, &config(), PER_REPO_TIMEOUT, operator).await
+    }
+
+    /// #5671: the child must carry the provider AND all three model ids, not
+    /// just the credential. Asserts on the environment the spawned process
+    /// actually received, not on the value this crate computed.
+    ///
+    /// Against `origin/main` every assertion below fails: `spawn_tga` set only
+    /// the credential and the two binary paths, so `trusty-review` resolved
+    /// `Provider::Bedrock`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_child_environment_selects_openrouter_and_all_three_models() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        one_repo_ready(&work);
+
+        let report = sweep_with_operator(&work, |_| None)
+            .await
+            .expect("the sweep completes");
         assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
 
-        let dumped = std::fs::read_to_string(report.repos[0].output.join("env.txt"))
-            .expect("the stub recorded its environment");
+        let dumped = child_env(&report);
         for expected in [
             format!("provider={}", inference::PROVIDER_OPENROUTER),
             format!("reviewer={}", inference::DEFAULT_REVIEWER_MODEL),
@@ -1387,5 +1449,66 @@ trusty-review = "0.15.1"
                 "the child environment is missing `{expected}`:\n{dumped}"
             );
         }
+    }
+
+    /// An operator who named the whole selection keeps it: this crate writes
+    /// none of the four onto the child, so nothing of ours can contradict
+    /// theirs. The injected lookup reports all four set without exporting them,
+    /// so an emitted default would show up here as a non-empty value.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_fully_set_operator_environment_is_left_alone() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        one_repo_ready(&work);
+
+        let report = sweep_with_operator(&work, |_| Some("operator".to_owned()))
+            .await
+            .expect("a whole operator selection resolves");
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+
+        let dumped = child_env(&report);
+        for role in ["provider", "reviewer", "verifier", "summarizer"] {
+            assert!(
+                dumped.contains(&format!("{role}=\n")),
+                "this crate overrode the operator's `{role}`:\n{dumped}"
+            );
+        }
+        // The credential is not part of the selection and is still delivered.
+        assert!(dumped.contains("key=sk-or-v1-not-a-real-key"), "{dumped}");
+    }
+
+    /// The HIGH finding, end to end: an operator on Bedrock who exports only
+    /// `TRUSTY_REVIEW_PROVIDER` must not have OpenRouter slugs written under it.
+    /// The sweep refuses, and refuses BEFORE spawning — the stub never runs, so
+    /// there is no `env.txt` and no partly-audited repository.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_partial_operator_environment_refuses_before_any_child_runs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        one_repo_ready(&work);
+
+        let err = sweep_with_operator(&work, |name| {
+            (name == inference::ENV_PROVIDER).then(|| "bedrock".to_owned())
+        })
+        .await
+        .expect_err("a provider without models must not be completed by guesswork");
+
+        let AuditError::SplitInferenceSelection { set, missing, .. } = &err else {
+            panic!("expected SplitInferenceSelection, got {err:?}");
+        };
+        assert_eq!(set, inference::ENV_PROVIDER);
+        assert!(
+            missing.contains("TRUSTY_REVIEW_REVIEWER_MODEL"),
+            "{missing}"
+        );
+
+        // Nothing ran: no output directory, so no child was spawned.
+        let outputs = work.path(Area::Output);
+        let spawned = std::fs::read_dir(&outputs)
+            .map(|entries| entries.count())
+            .unwrap_or(0);
+        assert_eq!(spawned, 0, "a refused selection must not spawn any child");
     }
 }


### PR DESCRIPTION
Closes #5671. Replaces #5673, which added credential detection and per-role
provider precedence to `trusty-review` — the wrong mechanism. OpenRouter is
used for audit inference only; `trusty-review`'s own default stays Bedrock and
that crate is untouched.

## The defect

#5663 put `OPENROUTER_API_KEY` into the `tga audit` child's environment.
Naming the key does not select the provider: `RoleModels::resolve` in
`crates/trusty-review/src/config/role_models.rs` passes `Provider::Bedrock` as
the last precedence level for all three roles, so the key sat unread while the
reviewer either failed on missing AWS credentials or silently billed Bedrock.

## The change

`spawn_tga` now sets four more variables on the same child, alongside the
credential it already set: `TRUSTY_REVIEW_PROVIDER`,
`TRUSTY_REVIEW_REVIEWER_MODEL`, `TRUSTY_REVIEW_VERIFIER_MODEL`,
`TRUSTY_REVIEW_SUMMARIZER_MODEL`. Those are `trusty-review`'s own second
precedence layer (`RoleEnv::from_env`), so this reaches the reviewer through a
documented interface rather than a new one.

**Precedence** (highest first): a variable already set in the operator's
process environment — no pair is emitted for it, so the child inherits it —
then the engagement config's optional `[models]` table, then the built-in
slugs. An operator or engagement value is never clobbered.

**Model ids** are overridable from `engagement.toml`, so a model rename does
not need a release:

```toml
[models]
reviewer = "anthropic/claude-opus-4.8"
```

The defaults keep the reviewer at Sonnet-class and verifier/summarizer at
Haiku-class, matching the role/cost split `trusty-review` already uses for
Bedrock. The dotted spelling is OpenRouter's, verified against
`GET https://openrouter.ai/api/v1/models`, which lists
`anthropic/claude-sonnet-4.6` and `anthropic/claude-haiku-4.5` and no dashed
`-4-6` form. The dashed slugs in `crates/trusty-agents/` are that crate's own
convention, not OpenRouter's; sending one produces the HTTP 400
`is not a valid model ID` this fix exists to remove.

Not fixed here: #5672 (relative `--work-dir` against `spawn_tga`'s
`current_dir`) is a separate open bug and was left alone.

## Testing — rung 4

`run::run_tests::the_child_environment_selects_openrouter_and_all_three_models`
asserts on the environment the spawned process actually received: the stub
`tga` prints its own `TRUSTY_REVIEW_*` variables to a file the test reads back.
Verified it fails without the fix by disabling only the `spawn_tga` wiring
(`#[cfg(any())]` on the loop) and re-running — `the child environment is
missing 'provider=openrouter'`, 1 failed — then restoring it.
`inference::inference_tests::an_operator_variable_is_never_overridden` covers
the precedence rule.

Gates, run with `AWS_REGION` / `AWS_DEFAULT_REGION` unset:

```
cargo fmt --check                                     # exit 0
cargo clippy -p trusty-audit --all-targets -- -D warnings   # exit 0
cargo test -p trusty-audit                            # 125 passed; 0 failed; 3 ignored (+3, +4, +6 in the integration binaries)
SKIP_UI_BUILD=1 cargo check --workspace               # exit 0
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
