### PR TITLE
feat(trusty-mpm): add an ASD-STE-100 sentence-construction layer to the PM voice rules

### DIFF
--- a/crates/trusty-agents-common/changelog.d/4574-asd-ste-100-sentence-layer.md
+++ b/crates/trusty-agents-common/changelog.d/4574-asd-ste-100-sentence-layer.md
@@ -1,0 +1,7 @@
+Added
+
+- `BASE-AGENT.md` carries the same ASD-STE-100 sentence-construction layer the
+  PM output styles now state, keeping the two prose channels in step: one idea
+  per sentence, ~20/25-word targets, active voice, one meaning per word, the
+  same term for the same thing, no noun cluster over three words, present
+  tense. The approved word list is explicitly not adopted (#4574).

--- a/crates/trusty-agents-common/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-agents-common/src/assets/agents/BASE-AGENT.md
@@ -386,6 +386,30 @@ nor its output style.
   "…, not the other way around" or "…, never X" appended to a sentence that
   already said it.
 
+**Sentence construction — ASD-STE-100, applied in spirit.** ASD-STE-100
+(Simplified Technical English, ASD/AIA) is the controlled-language standard for
+aerospace maintenance writing. Its construction rules transfer to this voice.
+Its ~900-word approved vocabulary does NOT — that list forbids common verbs and
+would make analysis and trade-off discussion stilted. This is a spirit
+adoption. Never tighten it into literal conformance with the word list.
+
+- One idea per sentence; one instruction per sentence. Split anything carrying
+  three commas and a dash.
+- Short sentences: about 20 words for an instruction, 25 for a description. A
+  target, not a cap — a longer sentence is a signal to split, not an error.
+- Active voice, with the actor named: "the gate blocked the merge", not "the
+  merge was blocked".
+- One meaning per word. Do not use a word two ways in the same report.
+- The same term for the same thing, every time. No synonym variation for
+  variety: "the worktree" never becomes "the tree" or "the checkout" midway.
+- No noun cluster longer than three words. "session context catchup pipeline
+  failure" becomes "the catchup pipeline failed to load session context".
+- Present tense where it works: "the check reads the counts", not "the check
+  will read the counts".
+
+These seven govern how a sentence is built. The rules around them govern
+stance — what you may claim, praise, hedge, or announce. Both apply at once.
+
 **No praise for the user.** When the user makes a point, corrects you, or offers
 a framing: acknowledge with "OK", or disagree and say why. Never praise the
 contribution.

--- a/crates/trusty-mpm/changelog.d/4574-asd-ste-100-sentence-layer.md
+++ b/crates/trusty-mpm/changelog.d/4574-asd-ste-100-sentence-layer.md
@@ -1,0 +1,11 @@
+Added
+
+- All three bundled output styles gain an ASD-STE-100 (Simplified Technical
+  English) sentence-construction layer in `Communication — Write Plainly`: one
+  idea per sentence, ~20/25-word sentence targets, active voice, one meaning
+  per word, the same term for the same thing, no noun cluster over three
+  words, present tense. The ~900-word approved vocabulary is named as NOT
+  adopted so a future reader cannot tighten it into literal conformance. The
+  stance rules it sits on top of are unchanged; the superseded "Short
+  sentences, one idea each" bullet is folded into the layer rather than left
+  beside it (#4574).

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
@@ -149,8 +149,6 @@ Lead with the point: what happened, then why it matters.
   "The critic is checking now." State what is true, not what you asked an agent
   to do.
 - End options as a bare enumeration: "Two options: A, or B."
-- Short sentences, one idea each. Split anything carrying three commas and a
-  dash.
 - No closing aphorisms. Never end a point or a message with a punchy line that
   restates what was just said. Stop at the last useful sentence.
 - Don't justify the restraint. "I don't know yet" is the whole answer — the
@@ -181,6 +179,30 @@ BEFORE (wrong):
 AFTER (right):
 
 > Summarize model in README.md, OK.
+
+**Sentence construction — ASD-STE-100, applied in spirit.** ASD-STE-100
+(Simplified Technical English, ASD/AIA) is the controlled-language standard for
+aerospace maintenance writing. Its construction rules transfer to this voice.
+Its ~900-word approved vocabulary does NOT — that list forbids common verbs and
+would make analysis and trade-off discussion stilted. This is a spirit
+adoption. Never tighten it into literal conformance with the word list.
+
+- One idea per sentence; one instruction per sentence. Split anything carrying
+  three commas and a dash.
+- Short sentences: about 20 words for an instruction, 25 for a description. A
+  target, not a cap — a longer sentence is a signal to split, not an error.
+- Active voice, with the actor named: "the gate blocked the merge", not "the
+  merge was blocked".
+- One meaning per word. Do not use a word two ways in the same reply.
+- The same term for the same thing, every time. No synonym variation for
+  variety: "the worktree" never becomes "the tree" or "the checkout" midway.
+- No noun cluster longer than three words. "session context catchup pipeline
+  failure" becomes "the catchup pipeline failed to load session context".
+- Present tense where it works: "the check reads the counts", not "the check
+  will read the counts".
+
+These seven govern how a sentence is built. The rules around them govern
+stance — what you may claim, praise, hedge, or announce. Both apply at once.
 
 **No praise for the user.** When the user makes a point, corrects you, or offers
 a framing: acknowledge with "OK", or disagree and say why. Never praise the

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
@@ -144,8 +144,6 @@ Lead with the point: what happened, then why it matters.
   "The critic is checking now." State what is true, not what you asked an agent
   to do.
 - End options as a bare enumeration: "Two options: A, or B."
-- Short sentences, one idea each. Split anything carrying three commas and a
-  dash.
 - No closing aphorisms. Never end a point or a message with a punchy line that
   restates what was just said. Stop at the last useful sentence.
 - Don't justify the restraint. "I don't know yet" is the whole answer — the
@@ -176,6 +174,30 @@ BEFORE (wrong):
 AFTER (right):
 
 > Summarize model in README.md, OK.
+
+**Sentence construction — ASD-STE-100, applied in spirit.** ASD-STE-100
+(Simplified Technical English, ASD/AIA) is the controlled-language standard for
+aerospace maintenance writing. Its construction rules transfer to this voice.
+Its ~900-word approved vocabulary does NOT — that list forbids common verbs and
+would make analysis and trade-off discussion stilted. This is a spirit
+adoption. Never tighten it into literal conformance with the word list.
+
+- One idea per sentence; one instruction per sentence. Split anything carrying
+  three commas and a dash.
+- Short sentences: about 20 words for an instruction, 25 for a description. A
+  target, not a cap — a longer sentence is a signal to split, not an error.
+- Active voice, with the actor named: "the gate blocked the merge", not "the
+  merge was blocked".
+- One meaning per word. Do not use a word two ways in the same reply.
+- The same term for the same thing, every time. No synonym variation for
+  variety: "the worktree" never becomes "the tree" or "the checkout" midway.
+- No noun cluster longer than three words. "session context catchup pipeline
+  failure" becomes "the catchup pipeline failed to load session context".
+- Present tense where it works: "the check reads the counts", not "the check
+  will read the counts".
+
+These seven govern how a sentence is built. The rules around them govern
+stance — what you may claim, praise, hedge, or announce. Both apply at once.
 
 **No praise for the user.** When the user makes a point, corrects you, or offers
 a framing: acknowledge with "OK", or disagree and say why. Never praise the

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
@@ -126,8 +126,6 @@ Lead with the point: what happened, then why it matters.
   "The critic is checking now." State what is true, not what you asked an agent
   to do.
 - End options as a bare enumeration: "Two options: A, or B."
-- Short sentences, one idea each. Split anything carrying three commas and a
-  dash.
 - No closing aphorisms. Never end a point or a message with a punchy line that
   restates what was just said. Stop at the last useful sentence.
 - Don't justify the restraint. "I don't know yet" is the whole answer — the
@@ -158,6 +156,30 @@ BEFORE (wrong):
 AFTER (right):
 
 > Summarize model in README.md, OK.
+
+**Sentence construction — ASD-STE-100, applied in spirit.** ASD-STE-100
+(Simplified Technical English, ASD/AIA) is the controlled-language standard for
+aerospace maintenance writing. Its construction rules transfer to this voice.
+Its ~900-word approved vocabulary does NOT — that list forbids common verbs and
+would make analysis and trade-off discussion stilted. This is a spirit
+adoption. Never tighten it into literal conformance with the word list.
+
+- One idea per sentence; one instruction per sentence. Split anything carrying
+  three commas and a dash.
+- Short sentences: about 20 words for an instruction, 25 for a description. A
+  target, not a cap — a longer sentence is a signal to split, not an error.
+- Active voice, with the actor named: "the gate blocked the merge", not "the
+  merge was blocked".
+- One meaning per word. Do not use a word two ways in the same reply.
+- The same term for the same thing, every time. No synonym variation for
+  variety: "the worktree" never becomes "the tree" or "the checkout" midway.
+- No noun cluster longer than three words. "session context catchup pipeline
+  failure" becomes "the catchup pipeline failed to load session context".
+- Present tense where it works: "the check reads the counts", not "the check
+  will read the counts".
+
+These seven govern how a sentence is built. The rules around them govern
+stance — what you may claim, praise, hedge, or announce. Both apply at once.
 
 **No praise for the user.** When the user makes a point, corrects you, or offers
 a framing: acknowledge with "OK", or disagree and say why. Never praise the

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -1361,6 +1361,58 @@ fn the_honest_ban_reaches_both_prose_channels() {
 }
 
 #[test]
+fn the_asd_ste_100_layer_reaches_both_prose_channels() {
+    // The owner added ASD-STE-100 as a sentence-CONSTRUCTION layer on top of
+    // the existing stance rules, in spirit only: the ~900-word approved
+    // vocabulary is deliberately NOT adopted, because it forbids common verbs
+    // and would make trade-off discussion stilted. Both halves are asserted —
+    // the layer's presence, and the refusal that keeps a future reader from
+    // "fixing" it into literal conformance. Reaches PM prose (output styles,
+    // #2647) and agent prose (BASE-AGENT.md composition) alike, per the
+    // keep-the-two-in-step rule the section states.
+    use crate::core::agent_builder::compose_agent;
+    use std::path::Path;
+
+    const REQUIRED: &[&str] = &[
+        "**Sentence construction — ASD-STE-100, applied in spirit.**",
+        "approved vocabulary does NOT",
+        "Never tighten it into literal conformance with the word list.",
+        "One idea per sentence; one instruction per sentence.",
+        "No noun cluster longer than three words.",
+        // ADD, not replace: the stance rules the layer sits on top of.
+        "**No praise for the user.**",
+    ];
+
+    for style in OUTPUT_STYLES {
+        for needle in REQUIRED {
+            assert!(
+                style.content.contains(needle),
+                "{} is missing the ASD-STE-100 construction layer {needle:?}",
+                style.id
+            );
+        }
+        // The superseded bullet was FOLDED IN, not left beside the layer as a
+        // second statement of "one idea per sentence" in different words.
+        assert!(
+            !style.content.contains("Short sentences, one idea each"),
+            "{}: the old short-sentence bullet must be folded into the \
+             ASD-STE-100 layer, not duplicated beside it",
+            style.id
+        );
+    }
+
+    let assets_dir = Path::new(trusty_agents_common::agent_assets::AGENT_ASSETS_DIR);
+    let composed =
+        compose_agent("version-control", assets_dir).expect("compose_agent must succeed");
+    for needle in REQUIRED {
+        assert!(
+            composed.contains(needle),
+            "composed agent is missing the ASD-STE-100 construction layer {needle:?}"
+        );
+    }
+}
+
+#[test]
 fn base_agent_graduated_verbosity_survives_composition() {
     // Output styles do NOT apply to subagents (they run their own system
     // prompt), so the sparse-on-success rule has to reach agents through


### PR DESCRIPTION
## What changed

`Communication — Write Plainly` governed stance — what the PM may claim,
praise, hedge, or announce. One bullet ("Short sentences, one idea each")
carried the entire sentence-construction axis. All three bundled output styles
now state a construction layer taken from ASD-STE-100 (Simplified Technical
English, ASD/AIA): one idea per sentence, ~20/25-word sentence targets, active
voice, one meaning per word, the same term for the same thing, no noun cluster
over three words, present tense.

The spec is named so a reader can look it up, and the ~900-word approved
vocabulary is named as NOT adopted, with the reason: it forbids common verbs
and would make analysis and trade-off discussion stilted. The block ends with
"Never tighten it into literal conformance with the word list", so a future
reader cannot mistake this for strict conformance.

## ADD, not replace

Every stance rule stands unchanged: no praise for the operator, no openers
announcing a fact's significance, the "honest"/"candidly"/"plainly" ban, no
borrowed-metaphor jargon, no closing aphorisms, no process narration, no
trailing emphatic negation. The two layers govern different things — stance
versus sentence construction — and the new block says so in one line.

The one deletion is a redundancy the layer created: `- Short sentences, one
idea each. Split anything carrying three commas and a dash.` is folded into
the layer's first two bullets, which keep the three-commas-and-a-dash
heuristic. Two statements of one rule in different words break the layer's own
one-meaning-per-word principle. `the_asd_ste_100_layer_reaches_both_prose_channels`
asserts the old bullet does not reappear beside the layer.

Two nearby rules were left alone because they say something else: "State
mechanism as cause then effect, in plain verbs" is about the shape of an
explanation, not voice; "Plain words over inflated ones" bans inflated diction,
which is the closest the existing rules come to a vocabulary rule and the
reason the layer adds no simple-words bullet.

## BASE-AGENT.md — added, same text

The section states that `assets/agents/BASE-AGENT.md` carries the agent-facing
variant and that the two stay in step when a rule changes. This change belongs
there: agents author reports, review verdicts, and PR/ticket body text, so
sentence construction binds them as much as it binds the PM. Output styles do
not apply to subagents — an agent runs its own system prompt — so composition
through BASE-AGENT.md is the only channel that reaches it. Leaving it out would
have made the layer PM-only while the surrounding stance rules stayed in both,
which is the drift the keep-in-step rule exists to prevent.

The agent copy is the same seven rules with one word changed ("in the same
report" rather than "in the same reply"), matching how the existing agent
variant is worded.

## Gates — rung 3 (localized behavior in one crate), run per crate

Bundled assets compiled into the binary, so this is not docs-only.

```
cargo fmt --check                                            EXIT=0
cargo clippy -p trusty-agents-common --all-targets -D warn   EXIT=0
cargo clippy -p trusty-mpm --all-targets -D warnings         EXIT=0
cargo test -p trusty-agents-common   502 passed; 0 failed; 0 ignored
cargo test -p trusty-mpm            4977 passed; 0 failed; 7 ignored (lib)
                                    1657 passed; 0 failed; 1 ignored (tm bin, ×2)
bash scripts/check_line_cap.sh                               EXIT=0
bash scripts/check_sld.sh                                    EXIT=0
bash scripts/check_changelog_fragment.sh                     EXIT=0
```

`clippy --all-targets` subsumes `cargo check` for both crates.

Regression test: `core::bundle::tests::the_asd_ste_100_layer_reaches_both_prose_channels`
pins the layer in all three output styles and in a composed agent, pins the
word-list refusal, pins `**No praise for the user.**` beside it to prove the
change adds rather than replaces, and pins the absence of the folded-in bullet.
It fails on `origin/main` by construction — `git grep ASD-STE-100 origin/main --
crates/` returns no matches.

The two content-pinning tests named as at-risk both pass unchanged:
`pm_authority_doctrine_survives_composition` (trusty-mpm) and
`credential_switching_is_forbidden_in_the_shipped_assets`
(trusty-agents-common). Neither pins text this edit touches.

Changelog fragments: `crates/trusty-mpm/changelog.d/4574-asd-ste-100-sentence-layer.md`,
`crates/trusty-agents-common/changelog.d/4574-asd-ste-100-sentence-layer.md`.

Context: #4574. No issue exists for this change and nothing is closed by it.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
