### PR TITLE
fix(trusty-agents-common): stop the ticketing agent's trusty-mpm label reflex

### DIFF
--- a/crates/trusty-agents-common/changelog.d/5679-ticketing-crate-label-reflex.md
+++ b/crates/trusty-agents-common/changelog.d/5679-ticketing-crate-label-reflex.md
@@ -9,3 +9,10 @@ Fixed
   path the finding cites; when no crate label fits, apply none. `trusty-mpm`
   is now a crate label like any other, applied only when the finding's own
   file path is under `crates/trusty-mpm/` (#5679).
+- Closed a follow-on loophole in that same rule: a live run correctly found
+  no crate applied to a `.github/workflows/ci.yml` defect, then attached
+  `trusty-mpm` anyway as a self-invented "provenance" label recording which
+  session found it. The rule now states directly that no such second label
+  axis exists — the origin of a finding is never a labeling input under any
+  name, and "no crate label fits" is final, not a fallback trigger for
+  `trusty-mpm` (#5679).

--- a/crates/trusty-agents-common/changelog.d/5679-ticketing-crate-label-reflex.md
+++ b/crates/trusty-agents-common/changelog.d/5679-ticketing-crate-label-reflex.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `ticketing` agent no longer applies `trusty-mpm` as an "umbrella" crate
+  label on every issue it files. The instruction that caused it — apply
+  `trusty-mpm` to "anything surfaced through tm-orchestrated dogfooding" —
+  fired on every ticket the agent created, since the agent always runs
+  inside a tm-orchestrated session. Replaced with a positive rule: a crate
+  label names the crate whose code the defect lives in, read from the file
+  path the finding cites; when no crate label fits, apply none. `trusty-mpm`
+  is now a crate label like any other, applied only when the finding's own
+  file path is under `crates/trusty-mpm/` (#5679).

--- a/crates/trusty-agents-common/src/assets/agents/ticketing.md
+++ b/crates/trusty-agents-common/src/assets/agents/ticketing.md
@@ -95,26 +95,39 @@ incomplete filing, not something to tidy up afterwards.
 **1. Type — exactly one** of `bug`, `enhancement`, `refactor`, `chore`,
 `documentation`, `epic`.
 
-**2. Component/crate — one or more**, naming the crate the defect actually
-lives in: `trusty-memory`, `trusty-search`, `trusty-mpm`, `trusty-installer`,
-`trusty-embedderd`, `daemon`, and so on. Resolve an abbreviation against the
-project's own table rather than guessing — in trusty-tools that is the root
-`CLAUDE.md` section "Abbreviations & Aliases". `trusty-mpm` doubles as the
-umbrella label for anything surfaced through tm-orchestrated dogfooding, so a
-trusty-memory bug found during a tm session carries **both**. The umbrella
-never substitutes for the specific crate label.
+**2. Component/crate — determined from the file path in the finding, not
+from the harness you happen to be running under.** A crate label names the
+crate whose code the defect actually lives in — read the file path(s) the
+finding cites (`crates/trusty-review/src/report/...` → `trusty-review`;
+`scripts/bump-version.sh` → release tooling, not a crate label at all) and
+label the crate that path belongs to: `trusty-memory`, `trusty-search`,
+`trusty-mpm`, `trusty-installer`, `trusty-embedderd`, `daemon`, and so on.
+Resolve an abbreviation against the project's own table rather than
+guessing — in trusty-tools that is the root `CLAUDE.md` section
+"Abbreviations & Aliases". **When no crate label fits the file path, apply
+none** — an unlabeled component field is correct more often than a guessed
+one.
+
+🔴 **`trusty-mpm` is a crate label like every other one — it applies ONLY
+when the finding's own file path is under `crates/trusty-mpm/` (or the tm
+CLI's own release/orchestration tooling).** Filing the ticket from inside a
+tm-orchestrated session is not evidence the defect lives in `trusty-mpm` —
+the harness that surfaced the finding and the crate the finding is *about*
+are two different questions, and only the second one picks the label. A
+defect in `crates/trusty-review/...` gets `trusty-review`, never
+`trusty-mpm`, regardless of which session found it.
 
 **3. Priority — `P0`–`P3`, only when the issue text itself asserts severity**:
 an explicit "P1" in the title, or language like "data loss", "unrecoverable",
 "silent corruption". Otherwise omit it. A guessed priority is noise someone
 else has to re-triage.
 
-These stack on the trusty-mpm defaults, which already work — `--assignee @me`,
-`--label trusty-mpm`, `--label ws/<session-name>`:
+These stack on the non-crate defaults, which already work — `--assignee @me`,
+`--label ws/<session-name>`:
 
 ```bash
 gh issue create --title "…" --body "…" \
-  --assignee @me --label trusty-mpm --label "ws/$WS_NAME" \
+  --assignee @me --label "ws/$WS_NAME" \
   --label bug --label trusty-memory --label P1
 ```
 
@@ -153,7 +166,7 @@ a `gh`-authenticated repo — this is the common case), use `gh` directly:
 ```bash
 # full label set per "Label at Creation" above — type + component + optional priority
 gh issue create --title "Title" --body "Details" \
-  --assignee @me --label trusty-mpm --label "ws/$WS_NAME" --label bug --label trusty-search
+  --assignee @me --label "ws/$WS_NAME" --label bug --label trusty-search
 gh issue edit 4069 --add-label refactor --add-label trusty-common
 gh issue list --search "search terms" --state all   # search open AND closed FIRST
 gh issue reopen 4069 --comment "Recurred 2026-08-06: …"   # prefer this over a new issue
@@ -277,7 +290,7 @@ Searched: "reconcile" / "WatcherManager" / -p trusty-search — open + closed
 REOPEN #3712 (same root cause recurred; commented)
 COMMENT on open #4409
 NEW REGRESSION #5002 — different failure mode after #3990's verified fix
-CREATED #5001 — bug, trusty-search, trusty-mpm, P1; milestone unset
+CREATED #5001 — bug, trusty-search, P1; milestone unset
 NO TICKET (1 item — fixed in the current PR)
 
 IN-SCOPE (2 items — created as subtasks)

--- a/crates/trusty-agents-common/src/assets/agents/ticketing.md
+++ b/crates/trusty-agents-common/src/assets/agents/ticketing.md
@@ -108,14 +108,19 @@ guessing — in trusty-tools that is the root `CLAUDE.md` section
 none** — an unlabeled component field is correct more often than a guessed
 one.
 
-🔴 **`trusty-mpm` is a crate label like every other one — it applies ONLY
-when the finding's own file path is under `crates/trusty-mpm/` (or the tm
-CLI's own release/orchestration tooling).** Filing the ticket from inside a
-tm-orchestrated session is not evidence the defect lives in `trusty-mpm` —
-the harness that surfaced the finding and the crate the finding is *about*
-are two different questions, and only the second one picks the label. A
-defect in `crates/trusty-review/...` gets `trusty-review`, never
-`trusty-mpm`, regardless of which session found it.
+🔴 **There is no second, unnamed label axis for "which session found this."
+`trusty-mpm` never fills one, because none exists.** `trusty-mpm` is a crate
+label and nothing else — it applies ONLY when the finding's own file path is
+under `crates/trusty-mpm/` (or the tm CLI's own release/orchestration
+tooling). The origin of a finding — which session, harness, or agent
+surfaced it — is not a labeling input, under any name, ever. Running inside
+a tm-orchestrated session is not evidence the defect lives in `trusty-mpm`,
+and it is not license to attach `trusty-mpm` as a "provenance" or
+"surfaced-by" marker once you have already decided no crate label fits — that
+decision is final, not a fallback trigger. A defect in
+`crates/trusty-review/...`, or in `.github/workflows/ci.yml`, gets
+`trusty-review` or no crate label at all — never `trusty-mpm` — regardless of
+which session found it or why no crate label applies.
 
 **3. Priority — `P0`–`P3`, only when the issue text itself asserts severity**:
 an explicit "P1" in the title, or language like "data loss", "unrecoverable",


### PR DESCRIPTION
## The reflex

Observed three times in one session — the `ticketing` agent applied the
`trusty-mpm` label to issues that have nothing to do with the `trusty-mpm`
crate:

- #5674 — a defect in `scripts/bump-version.sh` (release tooling). Corrected
  to `bug`, `ci`, `release-cleanup`.
- #5675 — a defect in `crates/trusty-review/src/report/synthesize_prompt.rs`.
  Corrected to `bug`, `P1`, `trusty-review`.
- #5679 — a defect in `crates/trusty-review/src/config/role_models.rs`.
  Corrected directly via `gh issue edit` (now `bug`, `trusty-review`) — not
  part of this diff.

Three in a row is a reflex, not three misreadings.

## Root cause

`crates/trusty-agents-common/src/assets/agents/ticketing.md:98-105` (before this
change) told the agent:

> `trusty-mpm` doubles as the umbrella label for anything surfaced through
> tm-orchestrated dogfooding, so a trusty-memory bug found during a tm session
> carries **both**. The umbrella never substitutes for the specific crate
> label.

The ticketing agent runs inside a tm-orchestrated session by construction —
every ticket it ever files satisfies that clause. So the "umbrella" fires
unconditionally, on every issue, regardless of which crate the defect
actually lives in. Two `gh issue create` templates
(`ticketing.md:112-118`, `:154-157` before the change) and one worked
example (`:280`) also baked `--label trusty-mpm` in as a hardcoded default,
reinforcing the same reflex outside the prose. This is the third diagnosis
in the brief: the agent conflates its own harness (`trusty-mpm`/`tm`) with
the crate the defect is actually in.

## The fix

`crates/trusty-agents-common/src/assets/agents/ticketing.md` — this is the
*source* of the official agent catalog under `assets/agents/` (confirmed via
`Skill(skill="tm-agent-architecture")`), not a deployed copy under
`.claude/agents/` or `~/.trusty-mpm/`, so it survives the next `tm install`.

1. Replaced the umbrella-label instruction with a positive rule: **a crate
   label names the crate whose code the defect lives in, determined from
   the file path the finding cites; when no crate label fits, apply none.**
2. Added an explicit clause: `trusty-mpm` is a crate label like any other —
   it applies only when the finding's own file path is under
   `crates/trusty-mpm/` (or the tm CLI's own release/orchestration
   tooling), never because the session that surfaced the finding happens to
   run under tm.
3. Dropped the hardcoded `--label trusty-mpm` from both `gh issue create`
   templates and the one worked example — a default that fires
   unconditionally is the same mechanism that produced the reflex, banning
   the label by name would only relocate it to the next plausible default.

`BASE-AGENT.md` (the shared base every agent inherits) was checked and
carries no label defaults — the reflex was isolated to `ticketing.md`.

## Verification

```
$ cargo build -p trusty-mpm
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 25s

$ cargo test -p trusty-agents-common --lib
test result: ok. 502 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.80s

$ cargo fmt --check -p trusty-agents-common
(clean, exit 0)

$ bash scripts/check_sld.sh
sld-lint: scanned 60 spec doc(s) + 3257 code file(s); resolved 40 frontmatter + 37 inline reference(s); 0 error(s), 0 warning(s)

$ bash scripts/check_line_cap.sh
line-cap: measured 3987 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.

$ bash scripts/check_changelog_fragment.sh
OK   trusty-agents-common: changelog.d fragment present and valid
changelog-fragment gate: scanned 2 changed path(s); all 1 crate(s) with source changes are recorded.
```

No `cargo clippy` run — this PR touches only `crates/trusty-agents-common/src/assets/agents/ticketing.md`
(a Markdown asset embedded at build time) and a changelog fragment; no Rust
logic changed.

## Test plan

- [x] `crates/trusty-agents-common/src/assets/agents/ticketing.md` compiles
      into the `trusty-mpm` binary (`cargo build -p trusty-mpm`)
- [x] `cargo test -p trusty-agents-common --lib` — 502 passed, 0 failed
- [x] `bash scripts/check_sld.sh`, `check_line_cap.sh`,
      `check_changelog_fragment.sh` — all pass
- [x] Manual review: the base `BASE-AGENT.md` template carries no
      conflicting label guidance
- [ ] Maintainer confirms `#5679` stays correctly labeled after this PR
      lands (labels were already corrected out-of-band via `gh issue edit`)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools