### PR TITLE
fix(trusty-review): make bedrock_region_resolution independent of ambient AWS_REGION

### DIFF
--- a/crates/trusty-review/changelog.d/5706-bedrock-region-env-isolation.md
+++ b/crates/trusty-review/changelog.d/5706-bedrock-region-env-isolation.md
@@ -1,0 +1,10 @@
+Fixed
+
+- `bedrock_region_resolution` no longer fails on a machine with `AWS_REGION`
+  exported ([#5706](https://github.com/bobmatnyc/trusty-tools/issues/5706)). The
+  test asserted that an empty explicit region reaches `us-east-1`, which skips
+  the `TRUSTY_AWS_REGION` and `AWS_REGION` tiers that `resolve_bedrock_region`
+  is documented to consult first. The precedence walk moved into a pure
+  `resolve_region_from(explicit, trusty_env, aws_env)` helper the test drives
+  directly, so every tier is covered without reading or mutating process-wide
+  env vars. `resolve_bedrock_region`'s behaviour is unchanged.

--- a/crates/trusty-review/src/llm/bedrock/mod.rs
+++ b/crates/trusty-review/src/llm/bedrock/mod.rs
@@ -81,18 +81,38 @@ const MAX_RETRIES: u32 = 3;
 ///       > `AWS_REGION` > `"us-east-1"`.
 /// Test: `bedrock_region_resolution`.
 pub fn resolve_bedrock_region(explicit: Option<&str>) -> String {
+    // #5706: read the env here so the precedence walk itself stays pure and
+    // testable without inheriting or mutating the ambient environment.
+    let trusty_env = std::env::var(ENV_REGION_TRUSTY).ok();
+    let aws_env = std::env::var(ENV_REGION_AWS).ok();
+    resolve_region_from(explicit, trusty_env.as_deref(), aws_env.as_deref())
+}
+
+/// Pick the first non-empty region among the four precedence tiers.
+///
+/// Why (#5706): [`resolve_bedrock_region`] reads process-wide env vars, so a
+/// test of its precedence either inherits the developer's `AWS_REGION` or has
+/// to mutate global state and race every other test in the binary. Taking the
+/// two env tiers as arguments makes the ordering provable with neither hazard.
+/// What: returns `explicit` > `trusty_env` > `aws_env` > [`DEFAULT_REGION`].
+/// An empty `explicit` counts as unset; an env tier is trimmed first, so a
+/// whitespace-only value counts as unset too.
+/// Test: `bedrock_region_resolution`.
+fn resolve_region_from(
+    explicit: Option<&str>,
+    trusty_env: Option<&str>,
+    aws_env: Option<&str>,
+) -> String {
     if let Some(r) = explicit.filter(|s| !s.is_empty()) {
         return r.to_string();
     }
-    for var in [ENV_REGION_TRUSTY, ENV_REGION_AWS] {
-        if let Ok(val) = std::env::var(var) {
-            let val = val.trim().to_string();
-            if !val.is_empty() {
-                return val;
-            }
-        }
-    }
-    DEFAULT_REGION.to_string()
+    [trusty_env, aws_env]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|s| !s.is_empty())
+        .unwrap_or(DEFAULT_REGION)
+        .to_string()
 }
 
 // ─── Model id validation ──────────────────────────────────────────────────────

--- a/crates/trusty-review/src/llm/bedrock/tests.rs
+++ b/crates/trusty-review/src/llm/bedrock/tests.rs
@@ -12,32 +12,66 @@ use aws_sdk_bedrockruntime::Client as BedrockClient;
 
 use super::{
     BedrockProvider, DEFAULT_REGION, LlmRequest, estimate_bedrock_cost_usd, normalize_model_family,
-    resolve_bedrock_region, validate_model_id,
+    resolve_bedrock_region, resolve_region_from, validate_model_id,
 };
 use crate::llm::bedrock::tool_use::build_tool_config;
 use crate::llm::{ChatMessage, LlmError, LlmProvider, ResponseSchema};
 
 // ── Region resolution ─────────────────────────────────────────────────────
 
+/// Pin the precedence order explicit > `TRUSTY_AWS_REGION` > `AWS_REGION` >
+/// default.
+///
+/// Why: operators set the region through different env vars in different
+/// deployment contexts, so the ordering must stay stable. #5706: this test used
+/// to call `resolve_bedrock_region` and assert that an empty explicit region
+/// reaches the default, which skips the two env tiers and fails outright on any
+/// machine with `AWS_REGION` exported.
+/// What: drives the pure `resolve_region_from` walk with both env tiers passed
+/// as arguments, so every case is deterministic. The one `resolve_bedrock_region`
+/// assertion left exercises the tier that is env-independent by construction.
+/// Test: this test.
 #[test]
 fn bedrock_region_resolution() {
-    // Explicit wins.
+    assert_eq!(
+        resolve_region_from(Some("eu-west-1"), Some("ap-south-1"), Some("us-west-2")),
+        "eu-west-1",
+        "explicit should win over both env tiers"
+    );
+    assert_eq!(
+        resolve_region_from(Some(""), Some("ap-south-1"), Some("us-west-2")),
+        "ap-south-1",
+        "empty explicit should fall through to TRUSTY_AWS_REGION"
+    );
+    assert_eq!(
+        resolve_region_from(None, None, Some("us-west-2")),
+        "us-west-2",
+        "AWS_REGION should be used when TRUSTY_AWS_REGION is unset"
+    );
+    assert_eq!(
+        resolve_region_from(Some(""), None, None),
+        DEFAULT_REGION,
+        "empty explicit with no env should reach the default"
+    );
+    assert_eq!(
+        resolve_region_from(None, None, None),
+        DEFAULT_REGION,
+        "None with no env should reach the default"
+    );
+    assert_eq!(
+        resolve_region_from(Some(""), Some("  "), Some("\t")),
+        DEFAULT_REGION,
+        "a whitespace-only env var counts as unset"
+    );
+    assert_eq!(
+        resolve_region_from(None, Some(" eu-central-1 "), None),
+        "eu-central-1",
+        "an env tier is trimmed before use"
+    );
     assert_eq!(
         resolve_bedrock_region(Some("eu-west-1")),
         "eu-west-1",
-        "explicit should win"
-    );
-    // Empty explicit falls through.
-    assert_eq!(
-        resolve_bedrock_region(Some("")),
-        DEFAULT_REGION,
-        "empty explicit should fall through to default"
-    );
-    // None falls through.
-    assert_eq!(
-        resolve_bedrock_region(None),
-        DEFAULT_REGION,
-        "None should return default"
+        "the public wrapper's explicit tier ignores the environment"
     );
 }
 


### PR DESCRIPTION
Closes #5706

`bedrock_region_resolution` read the ambient process environment, so the "empty explicit falls through to `DEFAULT_REGION`" assertion failed for any developer with `AWS_REGION` exported. `resolve_bedrock_region` now delegates its precedence walk to a pure `resolve_region_from(explicit, trusty_env, aws_env)`, and the test drives that helper directly.

Mirrors #5707, which fixed the same defect in `trusty-common` (cb2cd057), with one deliberate difference: this crate trims each env value before the emptiness check and `trusty-common` does not. #5707's uniform `find(|s| !s.is_empty())` would have silently dropped that trim, turning a refactor into an unannounced behaviour change. The asymmetry is preserved and two assertions now pin it.

## Test ladder: rung 3 (touches production source, not only tests)

```
cargo fmt --check                                           0
cargo check -p trusty-review                                0
cargo clippy -p trusty-review --all-targets -- -D warnings  0
AWS_REGION=us-west-2 cargo test -p trusty-review            0   (1572 passed, 0 failed, 5 ignored)
```

The suite was run deliberately WITH `AWS_REGION` set — that is the condition the bug needs.

## Proof

Before, with `AWS_REGION=us-west-2`:

```
assertion `left == right` failed: empty explicit should fall through to default
  left: "us-west-2"
 right: "us-east-1"
```

After, green in three environments: `AWS_REGION` set, both region vars unset, and both set with `TRUSTY_AWS_REGION` winning.

## Note

Three copies of this helper now exist across the workspace, identical except for the trim. Consolidation is #5469's work and is not attempted here.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools