### PR TITLE
fix(tga): start the trusty-search daemon before the audit sweep

### DIFF
--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -169,6 +169,7 @@ The versions come from the engagement config, which is required — there is no
 ```toml
 [tools]
 tga = "2.9.4"
+trusty-search = "0.47.0"
 trusty-analyze = "0.9.2"
 # Pin the artifact's bytes as well as its version, when the handoff was built
 # with a recorded digest.

--- a/crates/trusty-audit/changelog.d/5670-pin-trusty-search-changed.md
+++ b/crates/trusty-audit/changelog.d/5670-pin-trusty-search-changed.md
@@ -1,0 +1,4 @@
+Changed
+
+- An engagement config that omits the `trusty-search` pin no longer loads. Add the
+  key to any existing config before the next run.

--- a/crates/trusty-audit/changelog.d/5670-pin-trusty-search.md
+++ b/crates/trusty-audit/changelog.d/5670-pin-trusty-search.md
@@ -1,0 +1,9 @@
+Added
+
+- `trusty-search` is now a pinned tool alongside `tga`, `trusty-analyze` and
+  `trusty-review`. `[tools]` in the engagement config gains a required
+  `trusty-search` key, and `trusty-audit install` fetches the binary into
+  `work/tools/`.
+- `trusty-audit run` sets `TRUSTY_SEARCH_BIN` on every `tga audit` child, so the
+  audit's search preflight starts the engagement's pinned copy instead of falling
+  through to a PATH lookup on a clean machine.

--- a/crates/trusty-audit/src/config.rs
+++ b/crates/trusty-audit/src/config.rs
@@ -132,7 +132,7 @@ impl ToolPin {
 /// "latest" reintroduces that from the install side, so the versions are
 /// engagement data rather than a build-time constant, and the report package
 /// records which triple produced it.
-/// What: three REQUIRED fields. Serde rejects a config that omits one, which is
+/// What: four REQUIRED fields. Serde rejects a config that omits one, which is
 /// the fail-closed behaviour — there is no default to silently fall back to.
 /// The TOML keys are the crate names, hyphenated.
 /// Test: `super::config_tests::a_config_missing_one_pin_does_not_load`.
@@ -141,6 +141,10 @@ impl ToolPin {
 pub struct ToolPins {
     /// The audit sweep itself.
     pub tga: ToolPin,
+    /// The search daemon `trusty-analyze` and the indexing pass both need
+    /// (#5670). `tga audit` starts it, so an engagement pins it like the rest.
+    #[serde(rename = "trusty-search")]
+    pub trusty_search: ToolPin,
     /// Static analysis feeding the scorecard.
     #[serde(rename = "trusty-analyze")]
     pub trusty_analyze: ToolPin,
@@ -282,6 +286,7 @@ client = "Acme"
 
 [tools]
 tga = "2.9.4"
+trusty-search = "0.47.0"
 trusty-analyze = "0.9.2"
 trusty-review = "0.15.1"
 "#;

--- a/crates/trusty-audit/src/inference.rs
+++ b/crates/trusty-audit/src/inference.rs
@@ -229,6 +229,7 @@ instructions = "Assess the last 52 weeks."
 
 [tools]
 tga = "2.9.4"
+trusty-search = "0.47.0"
 trusty-analyze = "0.9.2"
 trusty-review = "0.15.1"
 "#;

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -699,6 +699,7 @@ client = "Acme"
 
 [tools]
 tga = "2.9.4"
+trusty-search = "0.47.0"
 trusty-analyze = "0.9.2"
 trusty-review = "0.15.1"
 "#;

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -334,15 +334,16 @@ fn writer_tag() -> String {
     format!("{}-{}", std::process::id(), hasher.finish())
 }
 
-/// The three binaries a run drives, each proven to be at the engagement's pin.
+/// The four binaries a run drives, each proven to be at the engagement's pin.
 ///
-/// Why: three named fields rather than a lookup table, so the "tool not found"
-/// branch does not exist. The obvious table version needs a fallback arm at
-/// every use site, and the natural fallback — the bare binary name — is a `PATH`
-/// lookup, which is the one thing this module must never do.
+/// Why: named fields rather than a lookup table, so the "tool not found" branch
+/// does not exist. The obvious table version needs a fallback arm at every use
+/// site, and the natural fallback — the bare binary name — is a `PATH` lookup,
+/// which is the one thing this module must never do.
 #[derive(Debug, Clone)]
 struct PinnedBinaries {
     tga: PathBuf,
+    search: PathBuf,
     analyze: PathBuf,
     review: PathBuf,
 }
@@ -406,6 +407,7 @@ fn pinned_binaries(work: &WorkDir, pins: &ToolPins) -> Result<PinnedBinaries, Au
 
     Ok(PinnedBinaries {
         tga: path_of(RequiredTool::Tga)?,
+        search: path_of(RequiredTool::TrustySearch)?,
         analyze: path_of(RequiredTool::TrustyAnalyze)?,
         review: path_of(RequiredTool::TrustyReview)?,
     })
@@ -763,11 +765,11 @@ pub const PER_REPO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 
 /// Spawn the pinned `tga audit` and turn its exit into a per-repo verdict.
 ///
-/// The child inherits nothing it does not need: the three binaries are named by
+/// The child inherits nothing it does not need: the four binaries are named by
 /// absolute path or by the variables tga and trusty-review read
-/// (`TRUSTY_ANALYZE_BIN`, `TRUSTY_REVIEW_BIN`), so nothing on the operator's
-/// `PATH` can be reached instead. The credential goes in the environment and
-/// only there — see the module docs for what that costs.
+/// (`TRUSTY_SEARCH_BIN`, `TRUSTY_ANALYZE_BIN`, `TRUSTY_REVIEW_BIN`), so nothing
+/// on the operator's `PATH` can be reached instead. The credential goes in the
+/// environment and only there — see the module docs for what that costs.
 ///
 /// Alongside the credential the child gets the provider and per-role model ids
 /// from [`crate::inference`]: naming the key never routed anything to
@@ -804,6 +806,11 @@ async fn spawn_tga(
         .arg(output)
         .current_dir(cwd)
         .env(ENV_INFERENCE_CREDENTIAL, config.openrouter_key.expose())
+        // #5670: `tga audit` starts trusty-search and indexes each repository
+        // through it. On a recipient's clean machine the pinned copy in
+        // `work/tools/` is the only one there is, so without this the guard falls
+        // through to a PATH lookup and refuses the run.
+        .env(ENV_SEARCH_BIN, &binaries.search)
         .env(ENV_ANALYZE_BIN, &binaries.analyze)
         .env(ENV_REVIEW_BIN, &binaries.review)
         .stdin(Stdio::null())
@@ -865,6 +872,9 @@ async fn spawn_tga(
 /// The variable `tga audit` reads the inference credential from.
 pub const ENV_INFERENCE_CREDENTIAL: &str = "OPENROUTER_API_KEY";
 
+/// The variable `tga audit` reads its trusty-search binary from (#5670).
+const ENV_SEARCH_BIN: &str = "TRUSTY_SEARCH_BIN";
+
 /// The variable `trusty-review` reads its analyze binary from.
 const ENV_ANALYZE_BIN: &str = "TRUSTY_ANALYZE_BIN";
 
@@ -925,6 +935,7 @@ instructions = "Assess the last 52 weeks."
 
 [tools]
 tga = "2.9.4"
+trusty-search = "0.47.0"
 trusty-analyze = "0.9.2"
 trusty-review = "0.15.1"
 "#;
@@ -986,9 +997,11 @@ trusty-review = "0.15.1"
         }
         let record = format!(
             "[[tools]]\ncrate_name = \"tga\"\nversion = \"2.9.4\"\nbinary = \"{tga}\"\n\
+             [[tools]]\ncrate_name = \"trusty-search\"\nversion = \"0.47.0\"\nbinary = \"{s}\"\n\
              [[tools]]\ncrate_name = \"trusty-analyze\"\nversion = \"0.9.2\"\nbinary = \"{a}\"\n\
              [[tools]]\ncrate_name = \"trusty-review\"\nversion = \"0.15.1\"\nbinary = \"{r}\"\n",
             tga = RequiredTool::Tga.path_in(work).display(),
+            s = RequiredTool::TrustySearch.path_in(work).display(),
             a = RequiredTool::TrustyAnalyze.path_in(work).display(),
             r = RequiredTool::TrustyReview.path_in(work).display(),
         );
@@ -1361,9 +1374,14 @@ trusty-review = "0.15.1"
         let tmp = tempfile::tempdir().expect("tempdir");
         let work = work_in(tmp.path());
         let mut script = String::from(
+            // #5670: the search binary is checked alongside the other two — on a
+            // recipient's clean machine the pinned copy is the only one there is,
+            // and without it named here `tga audit`'s search preflight falls
+            // through to a PATH lookup and refuses the run.
             "#!/bin/sh\ntest -n \"$OPENROUTER_API_KEY\" || exit 9\n\
              test -n \"$TRUSTY_REVIEW_BIN\" || exit 8\n\
-             test -n \"$TRUSTY_ANALYZE_BIN\" || exit 7\n",
+             test -n \"$TRUSTY_ANALYZE_BIN\" || exit 7\n\
+             test -n \"$TRUSTY_SEARCH_BIN\" || exit 6\n",
         );
         script.push_str(writes_a_manifest(None).trim_start_matches("#!/bin/sh\n"));
         install_stubs(&work, &script);

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -446,6 +446,7 @@ instructions = "Assess the last 52 weeks."
 
 [tools]
 tga = "0.0.0-never-published"
+trusty-search = "0.0.0-never-published"
 trusty-analyze = "0.0.0-never-published"
 trusty-review = "0.0.0-never-published"
 "#;

--- a/crates/trusty-audit/src/tools.rs
+++ b/crates/trusty-audit/src/tools.rs
@@ -62,6 +62,14 @@ pub const VERSION_RECORD_FILE: &str = "tool-versions.toml";
 pub enum RequiredTool {
     /// The audit sweep itself.
     Tga,
+    /// The search daemon the rest of the stack stands on (#5670).
+    ///
+    /// Why it is a pinned tool rather than a machine prerequisite: `tga audit`
+    /// starts this daemon itself, and on a recipient's clean machine the only
+    /// copy it can start is the one this client installed. Without it here,
+    /// `TRUSTY_SEARCH_BIN` would have nothing to name and the guard would fall
+    /// through to a `PATH` lookup — the one thing an isolated run must not do.
+    TrustySearch,
     /// Static analysis feeding the scorecard.
     TrustyAnalyze,
     /// Report rendering.
@@ -69,9 +77,13 @@ pub enum RequiredTool {
 }
 
 impl RequiredTool {
-    /// Every tool the run needs (#5495).
-    pub const ALL: [RequiredTool; 3] = [
+    /// Every tool the run needs (#5495, #5670).
+    ///
+    /// The order is the prerequisite chain: trusty-search must exist before
+    /// `trusty-analyze` can boot against it, and both before `tga` sweeps.
+    pub const ALL: [RequiredTool; 4] = [
         RequiredTool::Tga,
+        RequiredTool::TrustySearch,
         RequiredTool::TrustyAnalyze,
         RequiredTool::TrustyReview,
     ];
@@ -80,6 +92,7 @@ impl RequiredTool {
     pub fn binary_name(self) -> &'static str {
         match self {
             RequiredTool::Tga => "tga",
+            RequiredTool::TrustySearch => "trusty-search",
             RequiredTool::TrustyAnalyze => "trusty-analyze",
             RequiredTool::TrustyReview => "trusty-review",
         }
@@ -89,6 +102,7 @@ impl RequiredTool {
     pub fn crate_name(self) -> &'static str {
         match self {
             RequiredTool::Tga => "tga",
+            RequiredTool::TrustySearch => "trusty-search",
             RequiredTool::TrustyAnalyze => "trusty-analyze",
             RequiredTool::TrustyReview => "trusty-review",
         }
@@ -101,7 +115,7 @@ impl RequiredTool {
 
     /// This tool's pin, from the engagement config.
     ///
-    /// Why: an exhaustive match, so adding a fourth tool to [`RequiredTool`]
+    /// Why: an exhaustive match, so adding a fifth tool to [`RequiredTool`]
     /// fails to compile until [`ToolPins`] gains a field for it. A lookup by
     /// string key would instead resolve to "absent" at runtime, and absent is
     /// how an unpinned tool gets fetched at whatever version is current.
@@ -110,6 +124,7 @@ impl RequiredTool {
     pub fn pin_in(self, pins: &ToolPins) -> &ToolPin {
         match self {
             RequiredTool::Tga => &pins.tga,
+            RequiredTool::TrustySearch => &pins.trusty_search,
             RequiredTool::TrustyAnalyze => &pins.trusty_analyze,
             RequiredTool::TrustyReview => &pins.trusty_review,
         }
@@ -444,6 +459,7 @@ instructions = "Assess the last 52 weeks."
 
 [tools]
 tga = "2.9.4"
+trusty-search = "0.47.0"
 trusty-analyze = "0.9.2"
 trusty-review = "0.15.1"
 "#,
@@ -464,6 +480,7 @@ trusty-review = "0.15.1"
     fn a_matching_set() -> Vec<InstalledTool> {
         vec![
             install_of("tga", "2.9.4"),
+            install_of("trusty-search", "0.47.0"),
             install_of("trusty-analyze", "0.9.2"),
             install_of("trusty-review", "0.15.1"),
         ]
@@ -511,7 +528,7 @@ trusty-review = "0.15.1"
             assert_eq!(pinned.binary, tool.binary_name());
         }
         let versions: Vec<&str> = plan.iter().map(|p| p.version.as_str()).collect();
-        assert_eq!(versions, vec!["2.9.4", "0.9.2", "0.15.1"]);
+        assert_eq!(versions, vec!["2.9.4", "0.47.0", "0.9.2", "0.15.1"]);
         // No digest was pinned, so none is invented.
         assert!(plan.iter().all(|p| p.sha256.is_none()));
     }
@@ -535,7 +552,7 @@ trusty-review = "0.15.1"
                 .iter()
                 .map(|i| i.version.as_str())
                 .collect::<Vec<_>>(),
-            vec!["2.9.4", "0.9.2", "0.15.1"]
+            vec!["2.9.4", "0.47.0", "0.9.2", "0.15.1"]
         );
     }
 
@@ -543,7 +560,7 @@ trusty-review = "0.15.1"
     #[test]
     fn a_version_that_drifts_from_the_pin_is_refused() {
         let mut installs = a_matching_set();
-        installs[2] = install_of("trusty-review", "0.14.0");
+        installs[3] = install_of("trusty-review", "0.14.0");
         let err = verify(&pins(), &installs).expect_err("a drifted version must not verify");
         let AuditError::VersionMismatch {
             tool,
@@ -565,7 +582,7 @@ trusty-review = "0.15.1"
         assert!(matches!(
             err,
             AuditError::VersionMismatch {
-                tool: "trusty-analyze",
+                tool: "trusty-search",
                 ..
             }
         ));

--- a/crates/trusty-audit/tests/cli_end_to_end.rs
+++ b/crates/trusty-audit/tests/cli_end_to_end.rs
@@ -32,6 +32,7 @@ instructions = "Assess the last 52 weeks."
 
 [tools]
 tga = "2.9.4"
+trusty-search = "0.47.0"
 trusty-analyze = "0.9.2"
 trusty-review = "0.15.1"
 "#;
@@ -114,14 +115,15 @@ impl Engagement {
         )
     }
 
-    /// Stand in for a verified install: three executables plus the record that
+    /// Stand in for a verified install: four executables plus the record that
     /// says this client placed them.
     fn install_stubs(&self, script: &str) {
-        for name in ["tga", "trusty-analyze", "trusty-review"] {
+        for name in ["tga", "trusty-search", "trusty-analyze", "trusty-review"] {
             Self::write_script(&self.work.join("tools").join(name), script);
         }
         let record = format!(
             "[[tools]]\ncrate_name = \"tga\"\nversion = \"2.9.4\"\nbinary = \"{d}/tga\"\n\
+             [[tools]]\ncrate_name = \"trusty-search\"\nversion = \"0.47.0\"\nbinary = \"{d}/s\"\n\
              [[tools]]\ncrate_name = \"trusty-analyze\"\nversion = \"0.9.2\"\nbinary = \"{d}/a\"\n\
              [[tools]]\ncrate_name = \"trusty-review\"\nversion = \"0.15.1\"\nbinary = \"{d}/r\"\n",
             d = self.work.join("tools").display()

--- a/crates/trusty-audit/tests/install_fails_closed.rs
+++ b/crates/trusty-audit/tests/install_fails_closed.rs
@@ -30,6 +30,7 @@ instructions = "Assess the last 52 weeks."
 
 [tools]
 tga = "0.0.0-never-published"
+trusty-search = "0.0.0-never-published"
 trusty-analyze = "0.0.0-never-published"
 trusty-review = "0.0.0-never-published"
 "#;

--- a/crates/trusty-audit/tests/run_fails_closed.rs
+++ b/crates/trusty-audit/tests/run_fails_closed.rs
@@ -26,6 +26,7 @@ instructions = "Assess the last 52 weeks."
 
 [tools]
 tga = "2.9.4"
+trusty-search = "0.47.0"
 trusty-analyze = "0.9.2"
 trusty-review = "0.15.1"
 "#;
@@ -67,16 +68,17 @@ impl Engagement {
         )
     }
 
-    /// Stand in for a verified install: three executables plus the record that
+    /// Stand in for a verified install: four executables plus the record that
     /// says this client placed them.
     fn install_stubs(&self, script: &str) {
-        for name in ["tga", "trusty-analyze", "trusty-review"] {
+        for name in ["tga", "trusty-search", "trusty-analyze", "trusty-review"] {
             let path = self.work.join("tools").join(name);
             std::fs::write(&path, script).expect("stub");
             std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
         }
         let record = format!(
             "[[tools]]\ncrate_name = \"tga\"\nversion = \"2.9.4\"\nbinary = \"{d}/tga\"\n\
+             [[tools]]\ncrate_name = \"trusty-search\"\nversion = \"0.47.0\"\nbinary = \"{d}/s\"\n\
              [[tools]]\ncrate_name = \"trusty-analyze\"\nversion = \"0.9.2\"\nbinary = \"{d}/a\"\n\
              [[tools]]\ncrate_name = \"trusty-review\"\nversion = \"0.15.1\"\nbinary = \"{d}/r\"\n",
             d = self.work.join("tools").display()

--- a/crates/trusty-git-analytics/changelog.d/5670-audit-starts-trusty-search.md
+++ b/crates/trusty-git-analytics/changelog.d/5670-audit-starts-trusty-search.md
@@ -1,0 +1,14 @@
+Fixed
+
+- `tga audit` now starts the `trusty-search` daemon before its sweep, ahead of the
+  `trusty-analyze` preflight. `trusty-analyze serve` exits at its own trusty-search
+  check, so on a machine with no search daemon the audit refused outright and the
+  operator had to run `trusty-search start` by hand.
+- A stale `trusty-analyze` that had been up for days on top of a dead
+  trusty-search also refused every run: it answers `503 degraded` while the search
+  daemon is unreachable, which the readiness probe reads as no daemon at all. The
+  search guard running first recovers it.
+- The daemon address comes from `trusty_common`'s shared `DaemonAddrLayout`
+  resolver rather than a hard-coded `127.0.0.1:7878`, so an auto-ported or
+  `TRUSTY_DATA_DIR`-isolated instance is found. The binary honours
+  `TRUSTY_SEARCH_BIN`, else PATH.

--- a/crates/trusty-git-analytics/src/audit/mod.rs
+++ b/crates/trusty-git-analytics/src/audit/mod.rs
@@ -25,6 +25,7 @@ mod analyze;
 mod gaps;
 mod repo_index;
 mod review;
+mod search_daemon;
 mod stage;
 mod sweep;
 
@@ -57,6 +58,12 @@ pub use review::{
     require_review_supports_required_inference, resolve_review_binary, run_review_report,
     MissingInferenceCredential, ReviewBinaryTooOld, ReviewRun, ReviewRunError, UnverifiedReport,
     DEFAULT_REVIEW_BIN, ENV_INFERENCE_CREDENTIAL, ENV_REVIEW_BIN, MIN_REVIEW_VERSION,
+};
+/// #5670: link 1 of the prerequisite chain — the daemon `trusty-analyze` itself
+/// refuses to boot without, and reports `503 degraded` for as long as it is gone.
+pub use search_daemon::{
+    ensure_search_daemon, ensure_search_daemon_with, SearchDaemonUnavailable, SearchGuard,
+    SEARCH_STARTUP_TIMEOUT,
 };
 pub use stage::{AuditSweepStats, StageOutcome, StageStatus, StaleFetch, SweepStage};
 pub use sweep::{run_full_sweep, SweepOptions};

--- a/crates/trusty-git-analytics/src/audit/real_binary_tests.rs
+++ b/crates/trusty-git-analytics/src/audit/real_binary_tests.rs
@@ -11,7 +11,9 @@
 //!
 //! What: two runs of the guard against `target/<profile>/trusty-analyze` — the
 //! refusal arm (trusty-search unreachable) and the success arm (trusty-search
-//! reachable).
+//! reachable) — plus the same treatment for the two other contracts that live in
+//! `trusty-search`'s binary: the indexing CLI the repository pass builds, and the
+//! `start --foreground` / `/health` pair [`super::search_daemon`] rests on.
 //!
 //! Both are `#[ignore]`d because they need that binary built, which
 //! `cargo test -p tga` does not do, and the success arm additionally needs a
@@ -331,4 +333,68 @@ async fn the_real_search_binary_exits_non_zero_for_an_unknown_index() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
+}
+
+/// `start --foreground` is still the CLI the search guard spawns.
+///
+/// Why this cannot be checked in-crate: `super::search_daemon::start_args` is a
+/// vector a stub accepts whatever it contains, so every stub test would still
+/// pass if trusty-search renamed or dropped the flag. Without `--foreground` the
+/// child re-spawns itself and the process the guard detached exits at once, which
+/// reads to the readiness poll exactly like a daemon that will not start.
+///
+/// `--help` mutates nothing and needs no daemon, so this arm costs one process
+/// spawn.
+#[ignore = "needs `cargo build -p trusty-search`; run with --include-ignored"]
+#[test]
+fn the_real_search_binary_still_takes_start_foreground() {
+    let binary = real_search_binary();
+    let output = std::process::Command::new(&binary)
+        .args(["start", "--help"])
+        .output()
+        .expect("run `trusty-search start --help`");
+    assert!(output.status.success(), "`start --help` exited non-zero");
+
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        help.contains("--foreground"),
+        "`--foreground` is what stops the child re-spawning itself:\n{help}"
+    );
+}
+
+/// The fast path, end to end: a running trusty-search satisfies the preflight at
+/// the address the shared layout resolves, without anything being spawned.
+///
+/// This is the half no stub can stand in for. It checks three facts the guard
+/// assumes separately — that `DaemonAddrLayout::TRUSTY_SEARCH.resolve_base_url()`
+/// finds the daemon an operator actually started, that its `/health` answers 2xx
+/// rather than the `degraded` 503 the analyze daemon reports, and that
+/// [`super::SearchGuard::from_env`] therefore returns a guard that passes. The
+/// binary is a path that cannot exist, so any spawn attempt would fail the test.
+///
+/// The spawn arm is deliberately NOT exercised against the real binary: starting
+/// a second `trusty-search` would contend with the operator's daemon for its data
+/// directory and spend ONNX model-load time in a unit-test suite. The argument
+/// vector it would use is checked above instead.
+#[ignore = "needs a running trusty-search; run with --include-ignored"]
+#[tokio::test]
+async fn the_real_search_daemon_satisfies_the_preflight_without_a_spawn() {
+    let _ = reachable_trusty_search().await;
+
+    let resolved = crate::audit::SearchGuard::from_env();
+    let guard = crate::audit::SearchGuard {
+        binary: "/nonexistent/trusty-search".to_string(),
+        startup_timeout: Duration::from_secs(2),
+        poll_interval: Duration::from_millis(200),
+        ..resolved
+    };
+    crate::audit::ensure_search_daemon_with(&guard)
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "a running trusty-search must satisfy the preflight at the resolved address \
+                 `{}`: {e}",
+                guard.url
+            )
+        });
 }

--- a/crates/trusty-git-analytics/src/audit/search_daemon.rs
+++ b/crates/trusty-git-analytics/src/audit/search_daemon.rs
@@ -1,0 +1,234 @@
+//! Starting the `trusty-search` daemon the whole audit stack stands on (#5670).
+//!
+//! Why: the audit's prerequisite chain is trusty-search → per-repository index →
+//! trusty-analyze, and [`super::analyze`] closed only the last link. Starting
+//! `trusty-analyze` is not enough on its own, in two different ways.
+//!
+//! On a cold machine `trusty-analyze serve` exits at its own trusty-search check
+//! before it ever binds a port, so the analyze preflight spawns a process that is
+//! already gone by the first poll and refuses the run. The operator's remedy was
+//! to run `trusty-search start` by hand, which DOC-67 §2 does not allow: the
+//! sweep gets one non-interactive shot and owes no manual prerequisite.
+//!
+//! The second case is the one a fresh-spawn fix misses. `trusty-analyze` answers
+//! its own `/health` with `503 degraded` whenever trusty-search is unreachable,
+//! and `probe_once` counts only a 2xx — so the analyze preflight re-reads
+//! trusty-search's LIVE status on every run. An analyze daemon that has been up
+//! for days on top of a trusty-search that died an hour ago fails the probe, the
+//! spawned replacement exits at its own search check, the original keeps
+//! answering 503, and the readiness poll refuses. Nothing about that run is a
+//! cold start.
+//!
+//! What: [`ensure_search_daemon`], the address and binary rules it applies, and
+//! [`SearchDaemonUnavailable`]. It runs BEFORE the analyze preflight in
+//! `crate::commands::audit::run`, which is the whole point — analyze cannot boot
+//! without it. The probe/spawn/poll loop is `trusty_common::daemon_guard`, the
+//! workspace's one daemon-lifecycle entry point, and the address comes from
+//! [`DaemonAddrLayout::TRUSTY_SEARCH`] rather than a second copy of
+//! trusty-search's discovery rules.
+//!
+//! Nothing here is fail-open. Both failure arms — the binary would not spawn, and
+//! the daemon never answered — return `Err`, for the same reason the analyze
+//! preflight refuses: a report with its findings, complexity and health sections
+//! empty reads as a clean bill of health rather than as an outage.
+//! Test: `super::tests` against stubs; `super::real_binary_tests` (`#[ignore]`d)
+//! against the real `trusty-search` binary.
+//!
+//! # Spec References
+//! - [`SPEC-TGAUDIT-06~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-06~draft)
+//! - [`SPEC-TGAUDIT-09~draft`](../../../../docs/specs/DOC-67-tga-audit-mode.md#SPEC-TGAUDIT-09~draft)
+
+use std::time::Duration;
+
+use trusty_common::daemon_guard::{
+    probe_once, spawn_detached, spin_until_ready, DaemonAddrLayout, DaemonGuardConfig,
+    DEFAULT_POLL_INTERVAL,
+};
+
+use super::repo_index::{resolve_search_binary, ENV_SEARCH_BIN};
+
+/// Wall-clock budget for a freshly-spawned `trusty-search` to answer `/health`.
+///
+/// Why: 60s, matching `trusty-search`'s own guard
+/// (`crates/trusty-search/src/commands/daemon_guard.rs`'s `READY_TIMEOUT`) rather
+/// than `daemon_guard::DEFAULT_STARTUP_TIMEOUT`'s 30s. The HTTP port binds in
+/// about a second, but a first run on a machine with no model cache spends 15–30s
+/// in ONNX load before it answers, and refusing an audit at 30s would turn a slow
+/// cold start into a failed engagement.
+pub const SEARCH_STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The audit cannot proceed without the trusty-search daemon.
+///
+/// Why: this is refused before the sweep rather than reported after it, so the
+/// message is the operator's whole remedy. It names trusty-search as the FIRST
+/// link rather than describing the analyze symptom, because an operator reading
+/// "trusty-analyze is degraded" reaches for the wrong daemon.
+/// What: the address probed, the binary tried, and the underlying cause.
+/// Test: `super::tests::an_unspawnable_search_binary_refuses_the_audit`.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "trusty-search is not reachable at {url} and could not be started ({cause}). Every \
+     analyze-derived section of the audit report stands on it: `trusty-analyze serve` exits \
+     immediately when trusty-search is unreachable, and an analyze daemon that is already \
+     running answers `503 degraded` for as long as it stays unreachable — so the findings table, \
+     the complexity distribution and the health factors would all render empty, which reads as a \
+     clean bill of health rather than as an outage. Start it first:\n\n    trusty-search start\n\n\
+     Override the binary with {ENV_SEARCH_BIN}, and the address by pointing TRUSTY_DATA_DIR at \
+     the instance's data directory."
+)]
+#[non_exhaustive]
+pub struct SearchDaemonUnavailable {
+    /// The address that was probed.
+    pub url: String,
+    /// The binary name or path that was tried.
+    pub binary: String,
+    /// What stopped it — a spawn failure, or the readiness timeout.
+    pub cause: String,
+}
+
+/// Where and how [`ensure_search_daemon`] looks for the daemon.
+///
+/// Why: the address and binary come from the environment and the two budgets are
+/// fixed, which makes the whole guard untestable if it reads them itself. Taking
+/// them as a value is what lets a test drive the spawn-and-poll path against a
+/// stub executable on an ephemeral port — the same split [`super::AnalyzeGuard`]
+/// uses.
+/// What: the daemon address, the binary to spawn, and the readiness budget.
+/// Test: `super::tests::a_reachable_search_daemon_is_not_restarted`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SearchGuard {
+    /// Base address of the daemon, e.g. `http://127.0.0.1:7878`.
+    pub url: String,
+    /// Binary name or path to spawn when the daemon is absent.
+    pub binary: String,
+    /// Wall-clock budget for a freshly-spawned daemon to answer `/health`.
+    pub startup_timeout: Duration,
+    /// Interval between readiness probes.
+    pub poll_interval: Duration,
+}
+
+impl SearchGuard {
+    /// The guard this process runs with, resolved from the environment.
+    ///
+    /// Why: the address is NOT a `tga` setting and there is no tga-side variable
+    /// for it. `trusty-search` binds an OS-assigned port and records it in its own
+    /// discovery files, so the only correct answer comes from reading those files
+    /// the way every other client of that daemon reads them — which is
+    /// [`DaemonAddrLayout::TRUSTY_SEARCH`], promoted into `trusty-common` for
+    /// exactly this caller (#5670). Hard-coding `127.0.0.1:7878` here would miss
+    /// an auto-ported daemon and every `TRUSTY_DATA_DIR`-isolated one.
+    /// What: resolves the address from the discovery files and the binary from
+    /// [`ENV_SEARCH_BIN`] via [`resolve_search_binary`] — the same resolver
+    /// [`super::ensure_repositories_indexed`] uses, so the daemon this starts and
+    /// the binary that indexes into it are never two different installs.
+    /// Test: `super::tests::the_search_guard_resolves_its_address_from_the_shared_layout`.
+    pub fn from_env() -> Self {
+        Self {
+            url: DaemonAddrLayout::TRUSTY_SEARCH.resolve_base_url(),
+            binary: resolve_search_binary(),
+            startup_timeout: SEARCH_STARTUP_TIMEOUT,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+        }
+    }
+}
+
+impl Default for SearchGuard {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}
+
+/// The health endpoint for a base address, tolerating a trailing slash.
+fn health_url(base: &str) -> String {
+    format!("{}/health", base.trim_end_matches('/'))
+}
+
+/// The exact argument vector the guard hands `trusty-search`.
+///
+/// Why: this list IS the tga→trusty-search contract, and `--foreground` is
+/// load-bearing rather than decorative — a bare `trusty-search start` re-spawns
+/// itself as a background daemon and the parent exits, which is why
+/// trusty-search's own guard passes the flag
+/// (`crates/trusty-search/src/commands/daemon_guard.rs`'s
+/// `spawn_daemon_with_device`). We already detach the child ourselves, so the
+/// second fork would only cost the guard its view of the process it started.
+/// Building the vector in a pure function is what lets a test assert its contents
+/// without spawning anything.
+/// What: `start --foreground`.
+/// Test: `super::tests::the_search_spawn_arguments_are_start_in_the_foreground`.
+pub(super) fn start_args() -> Vec<String> {
+    vec!["start".to_string(), "--foreground".to_string()]
+}
+
+/// Ensure the trusty-search daemon is up before anything else in the audit.
+///
+/// Why/What: see the module docs. Resolves the guard from the environment and
+/// delegates to [`ensure_search_daemon_with`], so the environment and the
+/// discovery files are read exactly once, at the public entry point.
+///
+/// # Errors
+///
+/// [`SearchDaemonUnavailable`] when the daemon is absent and cannot be started.
+///
+/// Test: `super::tests::a_reachable_search_daemon_is_not_restarted`.
+pub async fn ensure_search_daemon() -> Result<(), SearchDaemonUnavailable> {
+    ensure_search_daemon_with(&SearchGuard::from_env()).await
+}
+
+/// [`ensure_search_daemon`] with the address, binary and budgets already fixed.
+///
+/// Why: taking them as a value is what lets a test drive the whole spawn-and-poll
+/// path against a stub executable on an ephemeral port, without touching the
+/// process environment or leaving a daemon behind.
+/// What: probes `<url>/health`; on a hit, returns without spawning anything. On a
+/// miss, spawns `<binary> start --foreground` detached and polls until it answers.
+/// Neither failure is downgraded — a spawn that fails and a daemon that never
+/// answers both return `Err`.
+///
+/// The address is resolved once, before the spawn, and the poll reuses it. That
+/// is what `trusty-search`'s own CLI does at every call site
+/// (`commands::add`'s `ensure_daemon_running_or_exit(&daemon_base_url())`), so a
+/// daemon this guard starts is found the same way the daemon's own client would
+/// find it.
+///
+/// # Errors
+///
+/// [`SearchDaemonUnavailable`] carrying the spawn error, or the readiness timeout.
+///
+/// Test: `super::tests::{a_reachable_search_daemon_is_not_restarted,
+/// an_unspawnable_search_binary_refuses_the_audit,
+/// a_search_daemon_that_never_comes_up_refuses_the_audit,
+/// the_search_guard_starts_the_daemon_the_analyze_preflight_then_needs}`.
+pub async fn ensure_search_daemon_with(guard: &SearchGuard) -> Result<(), SearchDaemonUnavailable> {
+    let health = health_url(&guard.url);
+    if probe_once(&health).await {
+        return Ok(());
+    }
+
+    let refuse = |cause: String| SearchDaemonUnavailable {
+        url: guard.url.clone(),
+        binary: guard.binary.clone(),
+        cause,
+    };
+
+    eprintln!(
+        "[tga audit] trusty-search is not answering at {}; starting `{} start --foreground`…",
+        guard.url, guard.binary
+    );
+    let args = start_args();
+    let args: Vec<&str> = args.iter().map(String::as_str).collect();
+    spawn_detached(&guard.binary, &args).map_err(|e| refuse(e.to_string()))?;
+
+    let config = DaemonGuardConfig {
+        health_url: health,
+        service_name: "trusty-search".to_string(),
+        startup_timeout: guard.startup_timeout,
+        poll_interval: guard.poll_interval,
+        timeout_hint: "run `trusty-search start` by hand to see why it will not stay up"
+            .to_string(),
+    };
+    spin_until_ready(&config)
+        .await
+        .map_err(|e| refuse(e.to_string()))
+}

--- a/crates/trusty-git-analytics/src/audit/search_daemon.rs
+++ b/crates/trusty-git-analytics/src/audit/search_daemon.rs
@@ -199,7 +199,7 @@ pub async fn ensure_search_daemon() -> Result<(), SearchDaemonUnavailable> {
 /// Test: `super::tests::{a_reachable_search_daemon_is_not_restarted,
 /// an_unspawnable_search_binary_refuses_the_audit,
 /// a_search_daemon_that_never_comes_up_refuses_the_audit,
-/// the_search_guard_starts_the_daemon_the_analyze_preflight_then_needs}`.
+/// the_search_guard_recovers_a_stale_degraded_analyze_daemon}`.
 pub async fn ensure_search_daemon_with(guard: &SearchGuard) -> Result<(), SearchDaemonUnavailable> {
     let health = health_url(&guard.url);
     if probe_once(&health).await {

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -1643,3 +1643,282 @@ fn a_credential_in_an_index_failure_never_reaches_the_gap_line() {
         gaps[0]
     );
 }
+
+// ─── #5670: starting trusty-search, link 1 of the prerequisite chain ──────────
+
+use crate::audit::search_daemon::start_args;
+use crate::audit::{ensure_search_daemon_with, SearchGuard};
+
+/// A listener whose `/health` answers `503 Service Unavailable` while `flag` is
+/// absent and `200 OK` once it exists. Returns the port it bound.
+///
+/// The flag file stands in for "trusty-search is up". Both daemons in the
+/// ordering fixture below read the same flag, because that is the real coupling:
+/// `trusty-analyze`'s health is a function of trusty-search's live status
+/// (`crates/trusty-analyze/src/service/routes.rs`'s `health`), not of its own
+/// uptime. A file rather than an in-process flag, because the thing that flips it
+/// is a detached child process.
+async fn serve_health_gated_on(flag: std::path::PathBuf) -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind an ephemeral port");
+    let port = listener
+        .local_addr()
+        .expect("read the bound address")
+        .port();
+    tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let flag = flag.clone();
+            tokio::spawn(async move {
+                use tokio::io::AsyncWriteExt as _;
+                let reply: &[u8] = if flag.exists() {
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+                } else {
+                    b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n"
+                };
+                let _ = stream.write_all(reply).await;
+            });
+        }
+    });
+    port
+}
+
+/// A search guard pointed at `port`, with budgets short enough for a unit test.
+fn search_guard_on(port: u16, binary: &str) -> SearchGuard {
+    SearchGuard {
+        url: format!("http://127.0.0.1:{port}"),
+        binary: binary.to_string(),
+        startup_timeout: std::time::Duration::from_millis(400),
+        poll_interval: std::time::Duration::from_millis(50),
+    }
+}
+
+/// The address is trusty-search's to publish, not tga's to guess.
+///
+/// `trusty-search` binds an OS-assigned port and records it in its own discovery
+/// files, so a hard-coded `127.0.0.1:7878` here would miss every auto-ported and
+/// every `TRUSTY_DATA_DIR`-isolated daemon. This asserts the guard asks
+/// `DaemonAddrLayout::TRUSTY_SEARCH` — the resolver promoted into `trusty-common`
+/// for exactly this caller (#5670) — rather than carrying a second copy of those
+/// rules, and that the binary comes from the one resolver `repo_index` already
+/// owns, so the daemon this starts and the binary that indexes into it are the
+/// same install.
+#[test]
+fn the_search_guard_resolves_its_address_from_the_shared_layout() {
+    use trusty_common::daemon_guard::DaemonAddrLayout;
+
+    let guard = SearchGuard::from_env();
+    assert_eq!(
+        guard.url,
+        DaemonAddrLayout::TRUSTY_SEARCH.resolve_base_url()
+    );
+    assert_eq!(guard.binary, crate::audit::resolve_search_binary());
+    assert_eq!(guard.startup_timeout, crate::audit::SEARCH_STARTUP_TIMEOUT);
+}
+
+/// The argument vector is the tga→trusty-search contract, asserted without
+/// spawning anything.
+///
+/// `--foreground` is the load-bearing half: it is what trusty-search's own guard
+/// passes (`crates/trusty-search/src/commands/daemon_guard.rs`'s
+/// `spawn_daemon_with_device`), and without it `start` re-spawns itself as a
+/// background daemon and the child we detached exits immediately.
+#[test]
+fn the_search_spawn_arguments_are_start_in_the_foreground() {
+    assert_eq!(start_args(), vec!["start", "--foreground"]);
+}
+
+/// A daemon that is already up is left alone.
+///
+/// The binary is a path that cannot exist, so any spawn attempt would fail the
+/// run — passing is therefore proof the fast path returned without spawning
+/// anything, which is what keeps `tga audit` from starting a second daemon beside
+/// the operator's own.
+#[tokio::test]
+async fn a_reachable_search_daemon_is_not_restarted() {
+    let port = serve_healthy().await;
+    let guard = search_guard_on(port, "/nonexistent/trusty-search");
+    ensure_search_daemon_with(&guard)
+        .await
+        .expect("a healthy daemon must satisfy the preflight without a spawn");
+}
+
+/// #5670, the spawn-failure arm: a machine with no trusty-search installed is a
+/// refusal, not a warning the sweep proceeds past.
+///
+/// The message has to name trusty-search and the path that was tried, because on
+/// a recipient's machine the whole remedy is either installing it or pointing
+/// `TRUSTY_SEARCH_BIN` at the engagement's pinned copy.
+#[tokio::test]
+async fn an_unspawnable_search_binary_refuses_the_audit() {
+    let guard = search_guard_on(free_port(), "/nonexistent/trusty-search");
+    let err = ensure_search_daemon_with(&guard)
+        .await
+        .expect_err("a binary that cannot be spawned must stop the audit");
+
+    let msg = err.to_string();
+    for needle in [
+        "trusty-search",
+        "/nonexistent/trusty-search",
+        "TRUSTY_SEARCH_BIN",
+    ] {
+        assert!(msg.contains(needle), "missing {needle:?}: {msg}");
+    }
+}
+
+/// #5670, the readiness arm: a spawn that succeeds is not a daemon, and the
+/// refusal must arrive at the timeout rather than hanging the one-shot sweep.
+///
+/// The stub execs and exits at once, which is what `trusty-search start` does on
+/// a host it refuses to run on — under-spec RAM, or a data directory it cannot
+/// lock. The `cause` is what separates this arm from the spawn-failure one:
+/// reaching the readiness timeout is only possible after `spawn_detached`
+/// returned a live PID.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_search_daemon_that_never_comes_up_refuses_the_audit() {
+    let dir = tempfile::tempdir().expect("create a temp dir");
+    let stub = stub_binary(dir.path(), "trusty-search-stub", "#!/bin/sh\nexit 1\n");
+
+    let started = std::time::Instant::now();
+    let guard = search_guard_on(free_port(), &stub);
+    let err = ensure_search_daemon_with(&guard)
+        .await
+        .expect_err("a daemon that exits at once must stop the audit");
+
+    assert!(
+        err.cause.contains("did not become ready"),
+        "expected the readiness arm, got: {}",
+        err.cause
+    );
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(10),
+        "the refusal must be bounded by the budget, not hang: {:?}",
+        started.elapsed()
+    );
+}
+
+/// The two-daemon fixture the ordering test below drives in both directions.
+///
+/// Returns a search guard and an analyze guard sharing one "trusty-search is up"
+/// flag file. The search stub creates the flag — starting trusty-search. The
+/// analyze stub exits 1, as the real `trusty-analyze serve` does at its own
+/// trusty-search check. Both `/health` listeners answer 503 until the flag
+/// exists, which is what an analyze daemon that has been up for days does while
+/// its trusty-search is dead.
+///
+/// `budget` is the readiness budget both guards get. The caller sets it per
+/// direction: a direction that waits on a real forked process needs a real one,
+/// and a direction whose flag is never created is decided by the fixture rather
+/// than by the clock.
+#[cfg(unix)]
+async fn degraded_stack(
+    dir: &std::path::Path,
+    budget: std::time::Duration,
+) -> (SearchGuard, crate::audit::AnalyzeGuard, std::path::PathBuf) {
+    let flag = dir.join("trusty-search-is-up");
+    let search_stub = stub_binary(
+        dir,
+        "trusty-search-stub",
+        &format!(
+            "#!/bin/sh\ntouch {}\nsleep 30\n",
+            flag.to_str().expect("a UTF-8 temp path")
+        ),
+    );
+    let analyze_stub = stub_binary(dir, "trusty-analyze-stub", "#!/bin/sh\nexit 1\n");
+
+    let mut search = search_guard_on(serve_health_gated_on(flag.clone()).await, &search_stub);
+    search.startup_timeout = budget;
+    let mut analyze = guard_on(serve_health_gated_on(flag.clone()).await, &analyze_stub);
+    analyze.startup_timeout = budget;
+
+    (search, analyze, flag)
+}
+
+/// #5670, THE regression: trusty-search is down while a stale `trusty-analyze`
+/// keeps answering `503 degraded`, and only the search guard running FIRST
+/// recovers it.
+///
+/// This is the case a fresh-spawn fix misses. `trusty-analyze`'s `/health` is a
+/// function of trusty-search's LIVE status, and `probe_once` counts only a 2xx,
+/// so an analyze daemon that has been up for days on top of a trusty-search that
+/// died an hour ago fails the analyze probe every run. Its spawned replacement
+/// exits at its own search check, the original keeps answering 503, and the
+/// readiness poll refuses an audit that has nothing wrong with its analyze daemon
+/// at all.
+///
+/// The test drives BOTH orders against the same fixture. Search-then-analyze
+/// leaves both preflights satisfied without the analyze daemon being touched;
+/// analyze-then-search refuses at the analyze poll, exactly as the defect did. So
+/// the assertion is not that two guards pass — it is that the ORDER is what makes
+/// them pass. `the_audit_command_runs_the_search_guard_before_the_analyze_guard`
+/// pins that order at the call site.
+///
+/// The two directions get different readiness budgets, and the short one is not
+/// what decides the failure: the reversed direction's flag file is never created
+/// by anything, which the assertion below states outright, so waiting longer
+/// changes nothing. The forward direction waits on a real forked process, which
+/// needs a budget wide enough to survive a loaded machine.
+#[cfg(unix)]
+#[tokio::test]
+async fn the_search_guard_recovers_a_stale_degraded_analyze_daemon() {
+    // The fixed order, as `crate::commands::audit::run` runs it.
+    let ok_dir = tempfile::tempdir().expect("create a temp dir");
+    let (search, analyze, flag) =
+        degraded_stack(ok_dir.path(), std::time::Duration::from_secs(20)).await;
+    assert!(!flag.exists(), "trusty-search starts this run down");
+
+    ensure_search_daemon_with(&search)
+        .await
+        .expect("the search guard must start trusty-search");
+    assert!(
+        flag.exists(),
+        "the search guard must have started the daemon"
+    );
+    crate::audit::ensure_analyze_daemon_with(&analyze)
+        .await
+        .expect("a stale 503 analyze daemon recovers once trusty-search is back");
+
+    // The reverse order, against an identical fixture.
+    let bad_dir = tempfile::tempdir().expect("create a temp dir");
+    let (search, analyze, flag) =
+        degraded_stack(bad_dir.path(), std::time::Duration::from_secs(2)).await;
+    let err = crate::audit::ensure_analyze_daemon_with(&analyze)
+        .await
+        .expect_err("running the analyze guard first must refuse the audit");
+    assert!(
+        err.cause.contains("did not become ready"),
+        "the analyze preflight must fail at its readiness poll against the live 503, got: {}",
+        err.cause
+    );
+    assert!(
+        !flag.exists(),
+        "nothing in the analyze preflight starts trusty-search — that is the defect"
+    );
+    ensure_search_daemon_with(&search)
+        .await
+        .expect("the search guard still works; it was simply run too late");
+}
+
+/// #5670: the call site keeps the two preflights in the order the test above
+/// proves is load-bearing.
+///
+/// The behavioural test can only show that search-then-analyze passes where
+/// analyze-then-search refuses; it cannot see which order `run` uses. This reads
+/// the source of that function and asserts the search guard is called first, so a
+/// later edit that reorders them — or drops the search guard entirely — fails
+/// here rather than on a recipient's machine.
+#[test]
+fn the_audit_command_runs_the_search_guard_before_the_analyze_guard() {
+    let source = include_str!("../commands/audit.rs");
+    let search = source
+        .find("ensure_search_daemon().await?")
+        .expect("`tga audit` must ensure trusty-search before its sweep");
+    let analyze = source
+        .find("ensure_analyze_daemon().await?")
+        .expect("`tga audit` must still ensure trusty-analyze");
+    assert!(
+        search < analyze,
+        "trusty-analyze cannot boot without trusty-search, so its guard must run second"
+    );
+}

--- a/crates/trusty-git-analytics/src/commands/audit.rs
+++ b/crates/trusty-git-analytics/src/commands/audit.rs
@@ -18,7 +18,7 @@ use clap::Args;
 
 use anyhow::Context as _;
 use tga::audit::{
-    ensure_analyze_daemon, ensure_repositories_indexed, index_gap_lines,
+    ensure_analyze_daemon, ensure_repositories_indexed, ensure_search_daemon, index_gap_lines,
     require_inference_credential, require_rendered_report_carries_synthesis,
     require_review_supports_required_inference, resolve_review_binary, run_full_sweep,
     run_review_report, sweep_gap_lines, AuditSweepStats, SweepOptions, SweepStage,
@@ -133,9 +133,9 @@ const DEFAULT_OUTPUT_DIR: &str = "audit-output";
 ///
 /// # Errors
 ///
-/// Propagates a missing inference credential, an unstartable `trusty-analyze`
-/// daemon (#5670), and a failure to create the output directory — all whole-run
-/// preconditions. A stage failure is reported, not propagated.
+/// Propagates a missing inference credential, an unstartable `trusty-search` or
+/// `trusty-analyze` daemon (#5670), and a failure to create the output directory
+/// — all whole-run preconditions. A stage failure is reported, not propagated.
 pub async fn run(config: Config, db: &mut Database, args: AuditArgs) -> anyhow::Result<()> {
     // #5454: the report's narrative now requires inference, so a missing
     // credential is checked before ANY work — ahead of the output directory and
@@ -148,6 +148,14 @@ pub async fn run(config: Config, db: &mut Database, args: AuditArgs) -> anyhow::
     // renderer is ordinary — and that renderer produces exactly the report this
     // ticket abolished, while exiting 0.
     require_review_supports_required_inference()?;
+
+    // #5670: link 1 of the prerequisite chain, and it must precede the analyze
+    // preflight below — `trusty-analyze serve` exits at its own trusty-search
+    // check, and an analyze daemon that is already up answers `503 degraded` for
+    // as long as trusty-search is unreachable, which the analyze probe reads as
+    // no daemon at all. Reordering these two makes the analyze preflight refuse
+    // every run on a machine whose trusty-search is down.
+    ensure_search_daemon().await?;
 
     // #5670: the third whole-run precondition. Nothing started `trusty-analyze`,
     // and DOC-67 §8 sources the findings table, the complexity distribution and

--- a/crates/trusty-git-analytics/src/commands/audit.rs
+++ b/crates/trusty-git-analytics/src/commands/audit.rs
@@ -157,7 +157,7 @@ pub async fn run(config: Config, db: &mut Database, args: AuditArgs) -> anyhow::
     // every run on a machine whose trusty-search is down.
     ensure_search_daemon().await?;
 
-    // #5670: the third whole-run precondition. Nothing started `trusty-analyze`,
+    // #5670: the fourth whole-run precondition. Nothing started `trusty-analyze`,
     // and DOC-67 §8 sources the findings table, the complexity distribution and
     // the health factors from it alone — so a machine without the daemon
     // produced a report with those three sections empty, and exited 0. This

--- a/docs/specs/DOC-67-tga-audit-mode.md
+++ b/docs/specs/DOC-67-tga-audit-mode.md
@@ -386,14 +386,29 @@ The full prerequisite chain is trusty-search → per-repository index →
 trusty-analyze, and #5670 reaches each link differently:
 
 - **trusty-analyze (link 3) — closed.** The preflight starts it or refuses.
-- **trusty-search (link 1) — hard-refused on every run.** Not only on a fresh
-  spawn. `trusty-analyze`'s own `/health` answers `503 degraded` whenever
-  trusty-search is unreachable (`crates/trusty-analyze/src/service/routes.rs`'s
-  `health`), and `probe_once` counts only a 2xx — so the preflight's opening
-  probe re-reads trusty-search's LIVE status each run. An analyze daemon that has
-  been up for days on top of a trusty-search that died an hour ago fails the
-  probe, its spawned replacement exits at its own search check, the original
-  keeps answering 503, and the readiness poll refuses the audit.
+- **trusty-search (link 1) — started by the audit, ahead of link 3.** It had to
+  be, and not only for a cold machine. `trusty-analyze`'s own `/health` answers
+  `503 degraded` whenever trusty-search is unreachable
+  (`crates/trusty-analyze/src/service/routes.rs`'s `health`), and `probe_once`
+  counts only a 2xx — so the analyze preflight re-reads trusty-search's LIVE
+  status each run. An analyze daemon up for days on top of a trusty-search that
+  died an hour ago failed that probe, its spawned replacement exited at its own
+  search check, the original kept answering 503, and the readiness poll refused
+  an audit with nothing wrong with its analyze daemon at all.
+
+  `crate::audit::search_daemon::ensure_search_daemon` now runs FIRST, before the
+  analyze preflight: it probes `/health`, spawns `<binary> start --foreground`
+  detached when there is no answer, and polls for up to 60s — trusty-search's own
+  `READY_TIMEOUT`, which covers a first-run ONNX model load. The binary is
+  `TRUSTY_SEARCH_BIN` else PATH, resolved through the one rule
+  `audit::repo_index` already owns so the daemon that gets started and the binary
+  that indexes into it are the same install. The ADDRESS is not a tga setting:
+  trusty-search binds an OS-assigned port and records it, so the guard reads
+  `trusty_common::daemon_guard::DaemonAddrLayout::TRUSTY_SEARCH`, the resolver
+  promoted into `trusty-common` for this caller. Both failure arms refuse the run,
+  as link 3's do. `trusty-audit` pins `trusty-search` as a fourth
+  `RequiredTool` and exports `TRUSTY_SEARCH_BIN` onto every `tga audit` child, so
+  an isolated run reaches the engagement's copy rather than a PATH lookup.
 - **The per-repository index (link 2) — built by the audit, and still fail-open
   per repository.** `crate::audit::repo_index::ensure_repositories_indexed` runs
   between the sweep and the manifest: it probes each repository with


### PR DESCRIPTION
Closes #5670

`tga audit`'s preflight started trusty-analyze but not trusty-search. trusty-analyze hard-refuses at boot when trusty-search is unreachable, and once running its `/health` answers `503 degraded` whenever trusty-search drops — which `probe_once` counts as a failure. So the audit refused on a cold machine until the operator ran `trusty-search start` by hand, violating DOC-67 §2's no-manual-prerequisite principle.

The subtler case, and the one a fresh-spawn-only fix misses: an analyze daemon up for days on top of a trusty-search that died an hour ago also fails. The probe re-reads trusty-search's live status every run, the spawned replacement exits at its own search check, and the original keeps answering 503.

`ensure_search_daemon()` now runs ahead of `ensure_analyze_daemon()`, resolving the address through `DaemonAddrLayout::TRUSTY_SEARCH` and reusing `repo_index`'s binary resolver — no second implementation of either.

This is the last of three PRs for #5670, after #5712 (per-repository indexing) and #5714 (shared address resolution).

## Breaking change for existing configs

`trusty-audit`'s engagement config gains a REQUIRED `trusty-search` pin. Any existing `engagement.toml` fails to load until the key is added; the error names the missing field and its line. Kept required rather than defaulting to PATH deliberately — a silent PATH fallback for the daemon whose absence is the subject of this issue would reopen the hole it closes. `trusty-audit` is `publish = false`, so this is a deployed-config break, not a crates.io API break.

## Test ladder: rung 5 (process lifecycle), two crates

```
cargo fmt --check                                          0
cargo check -p tga && cargo check -p trusty-audit          0
cargo clippy -p tga --all-targets -- -D warnings           0
cargo clippy -p trusty-audit --all-targets -- -D warnings  0
cargo test -p tga            0   (1225 passed, 0 failed, 7 ignored)
cargo test -p trusty-audit   0   (156 passed, 0 failed, 3 ignored)
scripts/check_line_cap.sh    0 violations
scripts/check_sld.sh         0 errors, 0 warnings
```

`check_semver.sh --crate tga` reports no update required; both new public types are `#[non_exhaustive]`.

## The regression that matters

`the_search_guard_recovers_a_stale_degraded_analyze_daemon` runs a two-daemon fixture in both directions. Search-then-analyze: both pass, analyze is never respawned. Analyze-then-search: the analyze guard refuses at its readiness poll — the defect, reproduced.

`the_audit_command_runs_the_search_guard_before_the_analyze_guard` pins the call-site order. Proven to bite: swapping the two calls fails it, then the order was restored. It is a source-text assertion and cannot see through indirection — a known limitation, recorded rather than papered over.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
