### PR TITLE
fix(scripts): build the SemVer selftest's breaking baseline from the major, not the minor (closes #5690)

### DIFF
--- a/scripts/check_semver_selftest.sh
+++ b/scripts/check_semver_selftest.sh
@@ -341,8 +341,21 @@ chmod +x "${STUB_DIR}/cargo"
 
 # The stub crate must be publishable, have a lib target, and — since #5296 — sit
 # at a version that admits BOTH a same-minor predecessor (so cases 5-8 land in
-# the normal PASS/FAIL arm) and a lower-minor one (so case 11 lands in the
-# already-breaking INVENTORY arm). That means patch > 0 and minor > 0.
+# the normal PASS/FAIL arm) and a predecessor whose bump to it is already
+# BREAKING (so cases 11, 12, 18 and 21 land in the INVENTORY arm). That means
+# patch > 0 and minor > 0.
+#
+# WHICH PREDECESSOR IS BREAKING DEPENDS ON THE MAJOR (#5690). Under Cargo's 0.x
+# rule a lower MINOR is breaking, but only while the major is 0; for a 1.x+ crate
+# a lower minor is an ordinary `minor` release and the inventory arm is never
+# reached. This picker hardcoded the 0.x form, which was invisible while
+# trusty-common (0.33.1) won the preference below. #5717 moved it to 0.34.0,
+# patch == 0 dropped it from the candidate list, and the fallback picked tga
+# 2.19.1 — a 2.x crate, whose 2.18.0 baseline classifies `minor`. All four
+# inventory cases then failed, blaming the gate for a harness assumption.
+# Build the breaking predecessor from the same rule release_type applies:
+# drop the major when there is one, otherwise drop the minor.
+#
 # trusty-common is preferred for continuity with the captured fixtures; any
 # qualifying crate works, and none qualifying is a loud failure rather than a
 # quietly degraded run.
@@ -363,7 +376,10 @@ for p in json.load(sys.stdin)["packages"]:
         continue
     if y == 0 or z == 0:
         continue
-    cands.append((p["name"], p["version"], "%d.%d.%d" % (x, y, z - 1), "%d.%d.0" % (x, y - 1)))
+    # #5690: a lower minor is breaking only under the 0.x rule. For a 1.x+ crate
+    # the breaking position is the major, so drop that instead.
+    breaking = "%d.0.0" % (x - 1) if x > 0 else "0.%d.0" % (y - 1)
+    cands.append((p["name"], p["version"], "%d.%d.%d" % (x, y, z - 1), breaking))
 cands.sort()
 preferred = [c for c in cands if c[0] == "trusty-common"] or cands
 if preferred:
@@ -373,14 +389,31 @@ if preferred:
 set -- $PICK
 STUB_CRATE="${1:-}"
 STUB_VERSION="${2:-}"
-STUB_PREV="${3:-}"      # same minor, patch below  -> a PATCH release
-STUB_OLD_MINOR="${4:-}" # lower minor             -> a MAJOR release under 0.x
+STUB_PREV="${3:-}"     # same minor, patch below -> a PATCH release
+STUB_BREAKING="${4:-}" # major dropped (0.x: minor) -> already a MAJOR release
 if [[ -z "$STUB_CRATE" || -z "$STUB_VERSION" || -z "$STUB_PREV" ]]; then
   echo "SELF-TEST FAIL: no publishable lib crate with minor>0 and patch>0 in this workspace;" >&2
   echo "                cases 5-11 cannot construct a baseline. Pick a crate by hand." >&2
   exit 1
 fi
-echo "stub crate: ${STUB_CRATE} v${STUB_VERSION} (prev ${STUB_PREV}, older minor ${STUB_OLD_MINOR})"
+echo "stub crate: ${STUB_CRATE} v${STUB_VERSION} (prev ${STUB_PREV}, breaking base ${STUB_BREAKING})"
+
+# The inventory cases below are only reached when the gate classifies
+# STUB_BREAKING -> STUB_VERSION as `major`, so check it against the gate's own
+# rule rather than assuming the construction above still matches it. #5690: when
+# it silently stopped matching, four cases failed with messages naming the GATE
+# ("the gate skipped instead of listing what the release breaks"), which is the
+# wrong file to go looking in. release_type is lifted out of the gate BY PATTERN
+# so this reads the shipped definition; case 22 exercises it directly.
+eval "$(awk '/^release_type\(\) \{/,/^\}/' "$GATE")"
+STUB_BREAKING_RTYPE="$(release_type "$STUB_BREAKING" "$STUB_VERSION")"
+if [[ "$STUB_BREAKING_RTYPE" != "major" ]]; then
+  echo "SELF-TEST FAIL: harness setup, not the gate — ${STUB_CRATE} ${STUB_BREAKING} -> ${STUB_VERSION}" >&2
+  echo "                classifies '${STUB_BREAKING_RTYPE}', so cases 11, 12, 18 and 21 would exercise the" >&2
+  echo "                PASS/FAIL arm instead of the INVENTORY arm they assert on. Fix the breaking-baseline" >&2
+  echo "                construction in the stub-crate picker above (#5690)." >&2
+  exit 1
+fi
 
 # name  fixture  stub-rc  expected-exit  must-contain  must-NOT-contain ("-" = none)
 TAB="$(printf '\t')"
@@ -497,8 +530,8 @@ fi
 # --- 11. Already-breaking bump: an INVENTORY, not a skip, and advisory — the
 #         listed breaks are permitted by the bump, so the gate stays green.
 rc=0
-out="$(gate_with_index "${STUB_OLD_MINOR}" "${STUB_OLD_MINOR}=break.out:100")" || rc=$?
-if [[ "$out" != *"INVENTORY ${STUB_CRATE}: ${STUB_OLD_MINOR} -> ${STUB_VERSION}"* ]]; then
+out="$(gate_with_index "${STUB_BREAKING}" "${STUB_BREAKING}=break.out:100")" || rc=$?
+if [[ "$out" != *"INVENTORY ${STUB_CRATE}: ${STUB_BREAKING} -> ${STUB_VERSION}"* ]]; then
   fail_case "inventory/already-breaking: the gate skipped instead of listing what the release breaks (#5297)" "$out"
 elif [[ "$rc" -ne 0 ]]; then
   fail_case "inventory/already-breaking: the inventory is advisory and must not fail the gate (exit ${rc})" "$out"
@@ -513,7 +546,7 @@ fi
 # --- 12. The inventory itself could not run. Still advisory — but it must say
 #         so, or "no inventory" would read as "inventory clean".
 rc=0
-out="$(gate_with_index "${STUB_OLD_MINOR}" "${STUB_OLD_MINOR}=build-error.out:101")" || rc=$?
+out="$(gate_with_index "${STUB_BREAKING}" "${STUB_BREAKING}=build-error.out:101")" || rc=$?
 if [[ "$rc" -ne 0 ]]; then
   fail_case "inventory/blind: a failed advisory run must not block an already-permitted release (exit ${rc})" "$out"
 elif [[ "$out" != *"NO INVENTORY ${STUB_CRATE}"* ]]; then
@@ -531,7 +564,7 @@ fi
 #         against vX" from a run that examined nothing — the advisory half of the
 #         same false pass. It must land in the blind arm instead.
 rc=0
-out="$(gate_with_index "${STUB_OLD_MINOR}" "${STUB_OLD_MINOR}=all-skipped.out:0")" || rc=$?
+out="$(gate_with_index "${STUB_BREAKING}" "${STUB_BREAKING}=all-skipped.out:0")" || rc=$?
 if [[ "$rc" -ne 0 ]]; then
   fail_case "inventory/zero-checks: an advisory run must not block an already-permitted release (exit ${rc})" "$out"
 elif [[ "$out" == *"no breaking changes found"* ]]; then
@@ -548,7 +581,7 @@ fi
 #         half of PR #5458 verbatim: a completed run with 4 real failures that
 #         the gate announced as "exited 100 without completing a run".
 rc=0
-out="$(gate_with_index "${STUB_OLD_MINOR}" "${STUB_OLD_MINOR}=break-colored.out:100")" || rc=$?
+out="$(gate_with_index "${STUB_BREAKING}" "${STUB_BREAKING}=break-colored.out:100")" || rc=$?
 if [[ "$rc" -ne 0 ]]; then
   fail_case "inventory/coloured: an advisory run over coloured output must stay green (exit ${rc})" "$out"
 elif [[ "$out" == *"NO INVENTORY ${STUB_CRATE}"* ]]; then
@@ -631,8 +664,9 @@ fi
 # No crate in this workspace declares 0.0.z, so the end-to-end arms cannot reach
 # it. The function is lifted out of the gate BY PATTERN rather than copied here,
 # so this case exercises the shipped definition and not a stale duplicate of it.
+# That lift now happens at the stub-crate pick above, which needs the same
+# function to check its own breaking baseline (#5690).
 # ===========================================================================
-eval "$(awk '/^release_type\(\) \{/,/^\}/' "$GATE")"
 
 # baseline  current  expected
 RELEASE_TYPE_CASES="0.0.5 0.0.6 major


### PR DESCRIPTION
Closes #5690.

## What was actually red

`Public API / SemVer` fails in its **selftest** step, which runs before the crate
comparison — so the gate exits having compared nothing. Reproduced on `ff785521`
(clean `main`) and in CI run
[31837577538](https://github.com/bobmatnyc/trusty-tools/actions/runs/31837577538):

```
SELF-TEST FAIL: inventory/already-breaking: the gate skipped instead of listing what the release breaks (#5297)
SELF-TEST FAIL: inventory/blind: a failed advisory run must not block an already-permitted release (exit 3)
SELF-TEST FAIL: inventory/zero-checks: an advisory run must not block an already-permitted release (exit 3)
SELF-TEST FAIL: inventory/coloured: an advisory run over coloured output must stay green (exit 1)
check_semver_selftest: 21 passed, 4 FAILED.
```

## Cause

All four cases assert on `check_semver.sh`'s INVENTORY arm, which the gate enters
only when `release_type` classifies `baseline -> current` as `major`. The
stub-crate picker built that baseline as `x.(y-1).0` — breaking under Cargo's 0.x
rule, an ordinary `minor` release for any 1.x+ crate.

It stayed invisible while `trusty-common` won the picker's preference. #5689
declares `trusty-common 0.34.0` and #5717 landed the same bump on `main`; the
picker's `patch > 0` filter drops it, the fallback picks `tga 2.19.1`, and
`release_type 2.18.0 -> 2.19.1` is `minor`. The four cases then ran against the
PASS/FAIL arm, where the same fixtures mean the opposite thing.

Two things this corrects in #5690's writeup:

- The `rustc 1.94.1 is not supported ... takecell@0.1.2` text in the log is
  **fixture content**, not a live error — case 12 replays `build-error.out`,
  which was captured with that message in it. No rustdoc is built on that path.
- The `Synthesis` field removal against `trusty-review 0.14.1` is likewise
  fixture text (`break.out`, captured from PR #5458). The gate's real baselines
  today are two releases newer, so no live run could have produced that line:

  ```
  $ bash scripts/check_semver.sh --probe trusty-review
  probe trusty-review: baseline=0.16.0 (declared=0.16.1, latest on crates.io=0.16.0, pre-release below=NONE)
  $ bash scripts/check_semver.sh --probe tga
  probe tga: baseline=2.19.0 (declared=2.19.1, latest on crates.io=2.19.0, pre-release below=NONE)
  ```

  The `FAIL tga: ... against baseline 2.18.0` line in the same log is the stub
  crate's label wrapped around that fixture, not a comparison of tga either.

## Fix

Build the baseline from the position that is actually breaking — drop the major
when there is one, otherwise drop the minor — and check the construction against
the gate's own `release_type` at setup. The four failures named the *gate* ("the
gate skipped instead of listing what the release breaks"), which is the wrong
file to go looking in; the new check names the harness instead. `STUB_OLD_MINOR`
becomes `STUB_BREAKING`, since the value is `1.0.0` for tga and the stale name is
what hid the assumption.

No exclusions file was touched and no crate version was changed.

## Gates

Rung 2 (test-harness only; no crate `src/**` changed, so no changelog fragment —
`check_changelog_fragment.sh` agrees: `no crate source changed ... OK`).

```
$ bash scripts/check_semver_selftest.sh
stub crate: tga v2.19.1 (prev 2.19.0, breaking base 1.0.0)
check_semver_selftest: 25 passed, 0 failed.      # EXIT=0   (was 21 passed, 4 FAILED)
```

Mutation check — the old formula restored in a scratch copy, to prove the new
setup check catches this class rather than the four cases failing again:

```
stub crate: tga v2.19.1 (prev 2.19.0, breaking base 2.18.0)
SELF-TEST FAIL: harness setup, not the gate — tga 2.18.0 -> 2.19.1
                classifies 'minor', so cases 11, 12, 18 and 21 would exercise the
                PASS/FAIL arm instead of the INVENTORY arm they assert on. Fix the breaking-baseline
                construction in the stub-crate picker above (#5690).
```

## CI evidence — read this before trusting the green check on this PR

`Public API / SemVer` passes here in 16s via the no-op path: this PR declares no
version bump, `have_work` is false, and the selftest step never runs. The green
check on this PR is **not** evidence the fix works.

Real evidence comes from a `workflow_dispatch` of the same workflow on this
branch, which forces `have_work=true` and runs the selftest on the same runner
image that was red —
[run 31841998542](https://github.com/bobmatnyc/trusty-tools/actions/runs/31841998542),
conclusion `success`:

```
stub crate: tga v2.19.1 (prev 2.19.0, breaking base 1.0.0)
check_semver_selftest: 25 passed, 0 failed.
CHECK trusty-review: 0.16.0 -> 0.16.1 (minor release), 3 feature(s)
semver gate: scanned (explicit); 1 crate(s) checked, 0 skipped — OK.
```

The gate reaches the real comparison for the first time since #5690 opened, and
`trusty-review 0.16.0 -> 0.16.1` is clean.

Other local gates, both unaffected by a scripts-only change and both run anyway:

```
line-cap: measured 4005 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
sld-lint: scanned 60 spec doc(s) + 3269 code file(s); resolved 40 frontmatter + 37 inline reference(s); 0 error(s), 0 warning(s)
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
