### PR TITLE
test(tga): replace timing assumptions in the concurrent-guard test

### DIFF
--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -1002,6 +1002,55 @@ async fn serve_healthy() -> u16 {
     serve_health(0).await
 }
 
+/// A listener whose `/health` answers `503 Service Unavailable` until
+/// `spawn_log` holds `required` lines, and `200 OK` from then on. Returns the
+/// port it bound.
+///
+/// Why a spawn log rather than [`serve_health`]'s reply counter (#5713): the
+/// counter flips on the Nth REQUEST, which is a different event from the spawns
+/// the concurrency test asserts on. Both guards could therefore reach `Ok` off
+/// the counter alone, before either detached stub had been scheduled to append
+/// its line — and on a loaded host they did, leaving the test reading an empty
+/// log and reporting `got []`.
+///
+/// Gating on the log inverts that: the daemon becomes ready BECAUSE the spawns
+/// happened, so a guard that returns `Ok` proves both lines are already on disk.
+/// It also fixes the opening-probe ordering for free. A guard's own spawn cannot
+/// precede its own opening probe, so the second guard's probe sees at most one
+/// line, misses, and spawns — by construction rather than by winning a race
+/// against the first guard's readiness polls.
+///
+/// A file rather than an in-process counter, because the thing that writes it is
+/// a detached child process — the same reason [`serve_health_gated_on`] uses one.
+async fn serve_health_after_spawns(spawn_log: std::path::PathBuf, required: usize) -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind an ephemeral port");
+    let port = listener
+        .local_addr()
+        .expect("read the bound address")
+        .port();
+    tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let spawn_log = spawn_log.clone();
+            tokio::spawn(async move {
+                use tokio::io::AsyncWriteExt as _;
+                let spawned = std::fs::read_to_string(&spawn_log)
+                    .unwrap_or_default()
+                    .lines()
+                    .count();
+                let reply: &[u8] = if spawned >= required {
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+                } else {
+                    b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n"
+                };
+                let _ = stream.write_all(reply).await;
+            });
+        }
+    });
+    port
+}
+
 /// An executable stub at `dir/name` running `script`, standing in for a
 /// `trusty-analyze` binary without needing one on the machine.
 #[cfg(unix)]
@@ -1217,11 +1266,16 @@ async fn two_concurrent_guards_both_resolve_against_one_slow_daemon() {
         ),
     );
 
-    // Degraded for exactly the two opening probes — one per guard — then ready.
-    // Both calls therefore miss, spawn, and find the daemon on a later poll.
-    let port = serve_health(2).await;
+    // #5713: the daemon goes ready only once BOTH spawns have appended, so
+    // readiness is caused by the spawns instead of racing them. Each guard's own
+    // spawn follows its own opening probe, so the second probe sees at most one
+    // line and misses — both calls spawn by construction, not by timing luck.
+    let port = serve_health_after_spawns(spawn_log.clone(), 2).await;
     let mut guard = guard_on(port, &stub);
-    guard.startup_timeout = std::time::Duration::from_secs(5);
+    // A ceiling, not a schedule. The happy path ends when the second stub
+    // appends, however many seconds a loaded host takes to schedule it; this
+    // only bounds a genuinely stuck run.
+    guard.startup_timeout = std::time::Duration::from_secs(60);
 
     let (first, second) = tokio::join!(
         crate::audit::ensure_analyze_daemon_with(&guard),
@@ -1235,28 +1289,13 @@ async fn two_concurrent_guards_both_resolve_against_one_slow_daemon() {
     assert_eq!(guard.url, format!("http://127.0.0.1:{port}"));
     assert_eq!(guard.binary, stub);
 
-    // The stubs are detached, so their writes land after the guards return.
-    // Poll for the expected count rather than sleeping a guessed interval —
-    // and keep polling past it, so a THIRD spawn would be seen rather than
-    // raced past.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
-    while std::time::Instant::now() < deadline {
-        if std::fs::read_to_string(&spawn_log)
-            .unwrap_or_default()
-            .lines()
-            .count()
-            >= 2
-        {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-    }
-    // Then keep waiting past the expected count, so a THIRD spawn is seen
-    // rather than raced past.
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    let spawns = std::fs::read_to_string(&spawn_log).unwrap_or_default();
-
-    let spawned: Vec<&str> = spawns.lines().collect();
+    // Both calls returned, and neither could have without the daemon going
+    // ready, which needs both lines on disk — so the expected two are already
+    // there and there is nothing left to wait FOR. What remains is the opposite
+    // question, the absence of a third spawn, and absence is not a condition to
+    // poll on. So wait for the count to stop changing instead of for a guessed
+    // interval: a loaded host simply takes more rounds to settle.
+    let spawned = settled_spawn_log(&spawn_log).await;
     assert_eq!(
         spawned.len(),
         2,
@@ -1269,6 +1308,39 @@ async fn two_concurrent_guards_both_resolve_against_one_slow_daemon() {
             "every spawn carries the configured port"
         );
     }
+}
+
+/// The spawn log's lines, read once its length has stopped changing.
+///
+/// #5713: a third spawn would be issued before its call returned, but the write
+/// itself is a detached child that can still be in flight — so the count is read
+/// only after it holds steady across several consecutive rounds.
+async fn settled_spawn_log(spawn_log: &std::path::Path) -> Vec<String> {
+    const STABLE_ROUNDS: usize = 4;
+    let round = std::time::Duration::from_millis(25);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+
+    let read = || -> Vec<String> {
+        std::fs::read_to_string(spawn_log)
+            .unwrap_or_default()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    };
+
+    let mut lines = read();
+    let mut stable = 0usize;
+    while stable < STABLE_ROUNDS && std::time::Instant::now() < deadline {
+        tokio::time::sleep(round).await;
+        let next = read();
+        stable = if next.len() == lines.len() {
+            stable + 1
+        } else {
+            0
+        };
+        lines = next;
+    }
+    lines
 }
 
 // ─── #5670: indexing every audited repository before the render ──────────────

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -963,9 +963,12 @@ pub(super) fn free_port() -> u16 {
 /// `SERVICE_UNAVAILABLE` + `status: "degraded"`). `probe_once` counts only a
 /// 2xx, so a 503 daemon reads to the guard exactly like no daemon.
 ///
-/// Counting replies rather than sleeping is what makes the slow-start tests
-/// deterministic — the guard's first probe is guaranteed to miss on a loaded
-/// machine, where a wall-clock delay could be overtaken.
+/// The counter advances on REPLIES, so this is deterministic only for
+/// assertions about replies — which probes missed, and what the guard concluded
+/// from them. An assertion about a side effect the stub performs, such as a
+/// spawn or a file write, is a different event: it can still be pending when
+/// the counter has already flipped the daemon to ready. Gate that on the effect
+/// itself — see `serve_health_after_spawns` (#5713).
 async fn serve_health(degraded_replies: usize) -> u16 {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;


### PR DESCRIPTION
Closes #5713

The stated cause was wrong, and the captured failure shows why:

```
assertion `left == right` failed: each call spawns for its own missed probe; got []
```

`got []` — the spawn log was empty, not off by one. `serve_health(2)` flips to 200 on the second HTTP **reply**, which is a different event from the spawn-log writes the test asserts on. Both guards satisfied their readiness polls off that counter alone, so neither stub ever had to run. The test then waited a fixed 3s hoping two detached `sh` processes would be scheduled and append; under saturation they were not. The 400ms startup budget named in the issue was never the binding constraint.

Readiness is now caused by the spawns: `serve_health_after_spawns` answers 503 until the spawn log holds two lines. A guard cannot return `Ok` below two lines, so when the join returns both are provably on disk — the 3s wait is deleted rather than lengthened. The 60s ceiling is a pure failure bound, never touched on the happy path.

The one part not expressible as a condition is the ABSENCE of a third spawn — there is no event to wait on for something that should never happen. `settled_spawn_log` polls until the line count is unchanged across four rounds, anchored after a state where two lines are guaranteed. It is a convergence check, not a condition poll, and the comment says so.

## Reproduction — the protocol matters

Isolated repeats do NOT reproduce this, even at load average ~60: 30/30 passed before the fix. Only the full suite under saturation does, because in-process contention from the other ~1200 tests is what starves the detached stubs.

| Protocol | Before | After |
|---|---|---|
| Isolated, quiet, 30 runs | 30/30 | 30/30 |
| Isolated, load ~60, 15 runs | 15/15 | 12/12 |
| **Full `cargo test -p tga --lib`, load ~60** | **9/10** | **10/10** |

## Rung 2 (test-only stabilization)

```
cargo fmt --check                     0
cargo test -p tga                     0   (1225 passed, 0 failed, 7 ignored)
scripts/check_test_pointers.sh        0   (24653 citations, 0 dangling)
scripts/check_line_cap.sh             0
scripts/check_changelog_fragment.sh   0   (classified test-only, no fragment owed)
```

The spawn-count assertion is still exactly 2. No production code changed, no `#[ignore]`, no `#[serial]`, no cfg-gating.

A second commit corrects `serve_health`'s doc comment, which claimed counting replies is what makes slow-start tests deterministic. That holds only for assertions about replies — the claim is what invites this bug, so it now states the contract and points at `serve_health_after_spawns`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
