### PR TITLE
fix: close trusty-embedderd default-features trap and refresh stale version strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,11 +108,20 @@ trusty-code = { path = "crates/trusty-code" }
 # shared by trusty-code's `tcode tui` and trusty-agents' tagent REPL (DOC-50,
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
-trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.5.1" }
+trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.5.2" }
 trusty-common = { path = "crates/trusty-common", version = "0.34" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
-trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.10" }
+# Why: `default-features = false` HERE, not only on the member entry (mirrors
+#      the trusty-review pattern from #5466). trusty-search's own
+#      `default-features = false` (crates/trusty-search/Cargo.toml) works
+#      today only because that edge is a direct `path` + `version` dependency,
+#      not `workspace = true`. If it were ever converted to inherit from here,
+#      Cargo would silently re-enable trusty-embedderd's default features
+#      (`http-server`, `bundled-ort`) unless this entry states the override
+#      too. No workspace member depends on `trusty-embedderd = { workspace =
+#      true }` today, so this has no effect on current feature resolution.
+trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.11", default-features = false }
 # trusty-bm25-daemon: per-palace BM25 lexical-index daemon — referenced by
 # trusty-memory so `cargo install trusty-memory` produces both binaries from
 # one command (mirrors the trusty-embedderd / trusty-search pattern, PR #190).
@@ -122,7 +131,7 @@ trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon", version = "0.2.0" }
 # Cargo edge on it: #5466 removed trusty-review's, and the tga -> trusty-review
 # direction is a PATH lookup, not a manifest edge (#5236, DOC-67 §6). The entry
 # stays so a future in-tree consumer resolves from source rather than crates.io.
-tga = { path = "crates/trusty-git-analytics", version = "2.10" }
+tga = { path = "crates/trusty-git-analytics", version = "2.19.1" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -182,7 +182,7 @@ lru = "0.16"
 #      CTO DB tools became reachable declaratively via the `cto-db` Python
 #      skill. This `install_plugins` mechanism remains available for any
 #      future private launcher.
-trusty-agents-common = { path = "../trusty-agents-common", version = "0.5.0" }
+trusty-agents-common = { path = "../trusty-agents-common", version = "0.5.2" }
 
 # [patch.crates-io] moved to workspace root Cargo.toml (Cargo requires
 # [patch] tables to live in the workspace root; see #460 for context).


### PR DESCRIPTION
## Summary

Two independent manifest-hygiene fixes found during a scoping pass (the pass's other finding, a 1.0.0 version bump, was dropped as out of scope).

- **`default-features = false` on the root `trusty-embedderd` entry** (`Cargo.toml:115`). `trusty-embedderd`'s own defaults are `["http-server", "bundled-ort"]`. `trusty-search`'s dependency on it works today only because it's a direct `path` + `version` edge with its own `default-features = false` — Cargo honors that on a non-`workspace = true` edge. If that edge were ever converted to `workspace = true`, the root entry's silence on `default-features` would silently re-enable both features. Mirrors the `#5466` precedent that added the same guard for `trusty-review`. Verified no workspace member depends on `trusty-embedderd = { workspace = true }` — `trusty-search` is the only Cargo-level consumer, so this has no effect on current feature resolution.
- **Four stale version-requirement strings**, refreshed against each crate's actual `version` field on `origin/main`: `trusty-agents-common` `0.5.1` → `0.5.2` (`Cargo.toml:111`, and its local redeclare in `crates/trusty-agents/Cargo.toml:185` `0.5.0` → `0.5.2`), `trusty-embedderd` `0.3.10` → `0.3.11` (`Cargo.toml:115`), `tga` `2.10` → `2.19.1` (`Cargo.toml:125`). Caret ranges already matched the actual versions, so this is hygiene only — no crate's own `version` field changed.

## Test plan

- [x] `cargo fmt --check` — pass
- [x] `SKIP_UI_BUILD=1 cargo check --workspace` — pass, `Finished` in 2m36s
- [x] `cargo tree -p trusty-search -i trusty-embedderd -e features` before/after — identical (`http-server`, `bundled-ort`), confirming the new `default-features = false` doesn't change today's resolution
- [x] `cargo test -p trusty-embedderd` — 4 passed, 0 failed
- [x] `cargo test -p trusty-search` (TRUSTY_INDEX unset) — 1747 passed, 1 failed under full-suite parallel run (`test_path_prefix_filter_recovers_bm25_match_beyond_want`); re-run in isolation twice, both green — a pre-existing flake, not caused by this change (`git diff --name-only origin/main...HEAD -- crates/trusty-search/` is empty)
- [x] `scripts/check_changelog_fragment.sh` — no crate `src/**` touched, no fragment owed

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools