### PR TITLE
perf(ci): cut cache-quota eviction and shorten the push-to-main critical path

### DIFF
--- a/.github/workflows/al2023-build.yml
+++ b/.github/workflows/al2023-build.yml
@@ -181,8 +181,20 @@ jobs:
       # 4. Cache cargo registry + build artefacts, under a key prefix scoped
       #    to this job's dependency graph (tree-sitter grammars, usearch, …).
       # ------------------------------------------------------------------
-      - name: Cache cargo registry and build artefacts
-        uses: actions/cache@v4
+      # Split into restore/save because `actions/cache@v4` has no `save-if`
+      # input — the guard `Swatinem/rust-cache` offers natively has to be
+      # spelled as an `if:` on a separate save step here.
+      #
+      # Save only from main: a cache saved on a PR ref is readable by that PR
+      # alone but still counts against the repo-wide 10 GB quota, and this repo
+      # was over it — see the note on the test-shard cache in ci.yml. This
+      # entry is the single largest in the repo at 2.32 GB (22% of quota), and
+      # this workflow DOES trigger on pull_request (path-filtered to
+      # trusty-search / trusty-embedderd / trusty-common), so every PR touching
+      # those crates could mint another 2.32 GB copy that no other PR can read.
+      - name: Restore cargo registry and build artefacts
+        id: al2023-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/registry/index/
@@ -260,3 +272,18 @@ jobs:
           cargo build -p trusty-search \
             --no-default-features \
             --features load-dynamic
+
+      # The `save-if` half of the split above. `cache-hit` is true only on an
+      # exact key match, so a run that restored via `restore-keys` (a stale
+      # lockfile prefix) still saves under the current key and the entry keeps
+      # up with Cargo.lock.
+      - name: Save cargo registry and build artefacts
+        if: github.ref == 'refs/heads/main' && steps.al2023-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: al2023-1.94-search-${{ hashFiles('Cargo.lock') }}

--- a/.github/workflows/capabilities-drift.yml
+++ b/.github/workflows/capabilities-drift.yml
@@ -62,6 +62,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: capabilities-drift
+          # Save only from main: a cache saved on a PR ref is readable by that
+          # PR alone but still counts against the repo-wide 10 GB quota, and this
+          # repo was over it — see the note on the test-shard cache in ci.yml.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check tm-capabilities generated skill for drift
         run: bash scripts/check_capabilities.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,15 @@
 #              or to the job, so required checks always report.
 #   fmt      – cargo fmt --all --check (stable)
 #   clippy   – cargo clippy --workspace --all-targets -D warnings (stable, SKIP_UI_BUILD=1)
-#   test-shard – cargo nextest run --workspace, split 4 ways (stable,
+#   test-shard – cargo nextest run --workspace, split 8 ways (stable,
 #              SKIP_UI_BUILD=1, full clone for git tests). PUSH TO MAIN AND
 #              workflow_dispatch ONLY — it does not run on pull requests; see
 #              that job's `if:` for why and for how to run it on a branch.
-#   test     – roll-up over the four shards; inherits the same trigger scope
+#   test-doc – cargo test --doc, on its own runner (nextest has no doctest
+#              harness, so the shards cannot run them). Same trigger scope as
+#              test-shard.
+#   test     – roll-up over the shards AND test-doc; inherits the same trigger
+#              scope
 #   msrv     – cargo check --workspace (toolchain 1.94, SKIP_UI_BUILD=1)
 #   agents-ui – cargo clippy -p trusty-agents-ui (stable, WebKit2GTK-enabled runner)
 #   embedder-cuda-check – cargo check -p trusty-common --features embedder-cuda
@@ -443,7 +447,7 @@ jobs:
   # config files pulled by fastembed are also captured.
   # --------------------------------------------------------------------------
   test-shard:
-    name: Rust tests (pre-publish gate) — shard ${{ matrix.shard }} of 4
+    name: Rust tests (pre-publish gate) — shard ${{ matrix.shard }} of 8
     needs: [changes]
     # #4179: `needs:` alone would make this job SKIP when `changes` fails, and
     # GitHub reports a skipped required check as PASSING — reintroducing the
@@ -452,7 +456,7 @@ jobs:
     # '' and every gated step runs, i.e. a broken classifier costs a FULL
     # build, never a silent skip.
     #
-    # NOT ON PULL REQUESTS. This matrix runs 11–13.5 minutes per leg — roughly
+    # NOT ON PULL REQUESTS. This matrix runs ~9.6 minutes per leg — roughly
     # 3x the entire required-check set, which settles in ~4 minutes — while
     # gating nothing: it is not a required context and `docs/reference/
     # test-ladder-baseline.md` already places `cargo test --workspace` at the
@@ -488,7 +492,13 @@ jobs:
       # other three shards stay green is what localises it.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        # 4 -> 8 (see the `--partition` comment on the nextest step). The
+        # per-shard build is ~496s and is NOT shardable — only the ~653s of
+        # test execution splits — so the leg time is build + total/N: at N=4
+        # that is ~496+163=~11-13.5m, at N=8 ~496+82=~9.6m. Runner minutes are
+        # unlimited on a public repo and no queueing was observed, so the extra
+        # four legs are paid in a resource this repo does not ration.
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       # Point fastembed (and hf-hub) at a stable, writable path so the
       # actions/cache key can target it precisely. This env var is honoured
@@ -521,10 +531,12 @@ jobs:
       # #3668 was a real disk-exhaustion incident in this job, on a target/
       # tree fed by onnxruntime/ort, ~a dozen tree-sitter grammars,
       # aws-sdk-bedrock and usearch. The script fires the reclamation on
-      # measured headroom instead of unconditionally; the .rcgu.o sweep below,
-      # not this step, is what actually remedied #3668. Every shard still does
-      # the full workspace build, so the disk pressure this guards against is
-      # unchanged by sharding.
+      # measured headroom instead of unconditionally. #3668 is now held off by
+      # CARGO_PROFILE_TEST_DEBUG=line-tables-only (see this job's `env:`) plus
+      # this step; the `.rcgu.o` sweep that used to follow the build phase was
+      # deleted once its own logging showed it reclaimed nothing. Every shard
+      # still does the full workspace build, so the disk pressure this guards
+      # against is unchanged by sharding.
       - name: Free disk space
         if: needs.changes.outputs.docs_only != 'true'
         run: bash scripts/ci-free-disk-space.sh
@@ -561,10 +573,11 @@ jobs:
             | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
           cargo nextest --version
 
-      # ONE cache shared by all four shards. Every shard runs the same
+      # ONE cache shared by every shard. Every shard runs the same
       # `--workspace` build and differs only in which tests it executes, so the
-      # target/ trees are identical and four separate caches would be four
-      # copies of the same bytes against a quota that is already blown.
+      # target/ trees are identical and a cache per shard would be N copies of
+      # the same bytes against a quota that is already blown. This is also why
+      # widening the matrix costs no additional cache storage.
       #
       # `save-if` restricted to main is deliberate and is a FIX, not a
       # restriction (see the PR that introduced sharding). GitHub scopes a
@@ -930,18 +943,15 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         run: cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui --no-run
 
-      # Sweep intermediate per-codegen-unit object files (#3668): once a
-      # test binary is linked, its .rcgu.o inputs are dead weight — cargo
-      # never reclaims them itself, and they made up ~18 GB of the runner's
-      # disk exhaustion. Verified locally that deleting them does not cause
-      # a subsequent `cargo test` invocation to relink (cargo's fingerprint
-      # tracking does not depend on these surviving).
-      - name: Sweep intermediate .rcgu.o codegen objects
-        if: needs.changes.outputs.docs_only != 'true'
-        run: |
-          echo "Before sweep:"; du -sh target/debug 2>/dev/null || true
-          find target/debug/deps -name '*.rcgu.o' -delete
-          echo "After sweep:"; du -sh target/debug 2>/dev/null || true
+      # The `.rcgu.o` sweep that used to sit here (#3668) was deleted as dead
+      # code. It found nothing left to delete: `CARGO_PROFILE_TEST_DEBUG=
+      # line-tables-only` (set in this job's `env:` above) plus
+      # CARGO_INCREMENTAL=0 already leave no intermediate codegen objects
+      # behind. Its own logging proved it on every run — run 31852921362,
+      # shard 1 printed `Before sweep: 45G` and `After sweep: 45G`, byte-for-
+      # byte identical, in 0.16s. The disk headroom #3668 needed now comes
+      # from that debug-level setting and `scripts/ci-free-disk-space.sh`,
+      # neither of which this step contributed to.
 
       # cargo-nextest instead of `cargo test`, for two reasons measured on this
       # repo:
@@ -970,12 +980,12 @@ jobs:
       # stopped at the first failing BINARY, so a PR breaking two crates needed
       # two CI rounds to discover that.
       #
-      # The divisor is `strategy.job-total`, not a literal 4. nextest only
-      # rejects a partition whose numerator exceeds its denominator, so a
+      # The divisor is `strategy.job-total`, not a literal shard count. nextest
+      # only rejects a partition whose numerator exceeds its denominator, so a
       # hand-written divisor left stale after the matrix changed would silently
-      # stop running a quarter of the suite with every shard green. Deriving it
-      # from the matrix makes `shard: [1, 2, 3, 4]` the only place the count
-      # exists.
+      # stop running part of the suite with every shard green. Deriving it from
+      # the matrix makes the `shard:` list the only place the count exists —
+      # which is what let the 4 -> 8 widening be a one-line change.
       #
       # `hash:N/M` rather than `count:N/M`: hash assigns a test to a partition
       # from its name, so a given test lands in the same shard on every run and
@@ -991,17 +1001,11 @@ jobs:
             --partition hash:${{ matrix.shard }}/${{ strategy.job-total }} \
             -E 'not test(=update::tests::cache_fresh_returns_some_when_newer)'
 
-      # nextest cannot run doctests — it has no doctest harness at all (see
-      # nextest issue #16). Skipping this step would silently drop every
-      # doctest from CI, so `cargo test --doc` runs them separately.
-      #
-      # Shard 1 only: `--partition` splits the tests nextest owns, and doctests
-      # are not among them, so running this in all four shards would run the
-      # same doctests four times rather than a quarter of them each. There are
-      # ~7 across the workspace; this is here for coverage, not for speed.
-      - name: cargo test --doc
-        if: needs.changes.outputs.docs_only != 'true' && matrix.shard == 1
-        run: cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui --doc
+      # The `cargo test --doc` step that used to run here (shard 1 only) is now
+      # the `test-doc` job below. It cost shard 1 ~68s that no other leg paid,
+      # and the matrix finishes when its SLOWEST leg finishes — so a serial 68s
+      # on one leg was 68s on the whole matrix. Same doctests, own runner, in
+      # parallel. `test` still gates on it, so nothing is verified less.
 
       # trusty-common's cache_fresh_returns_some_when_newer needs CI unset
       # (see check_throttled in crates/trusty-common/src/update/mod.rs: it
@@ -1034,6 +1038,79 @@ jobs:
         run: cargo test -p trusty-common --lib --features codex-config codex_config
 
   # --------------------------------------------------------------------------
+  # test-doc: the workspace doctests, on their own runner.
+  #
+  # nextest cannot run doctests — it has no doctest harness at all (see nextest
+  # issue #16) — so `cargo test --doc` has to run them separately. It used to
+  # be a `matrix.shard == 1` step inside `test-shard`, where it cost that one
+  # leg ~68s serially. A matrix finishes when its slowest leg finishes, so a
+  # cost carried by a single leg is a cost carried by the whole matrix: shard 1
+  # ran 13.31m against shard 3's 11.74m. Here it runs concurrently instead.
+  #
+  # It is NOT shardable and must not be: `--partition` splits the tests nextest
+  # owns and doctests are not among them, so every leg would run all ~7
+  # doctests rather than a share each. One job is the correct shape.
+  #
+  # `test` gates on this job as well as on the matrix, so a failing doctest
+  # still turns "Rust tests (pre-publish gate)" red exactly as before.
+  # --------------------------------------------------------------------------
+  test-doc:
+    name: Rust doctests (pre-publish gate)
+    needs: [changes]
+    # Identical to `test-shard`'s condition — see the reasoning there. The two
+    # must stay in lockstep: `test` requires BOTH, so a divergence would make
+    # the roll-up unsatisfiable on whichever trigger they disagree about.
+    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Must match `test-shard`'s value exactly, for two reasons. rust-cache
+      # hashes every env var whose name starts with CARGO into its cache key,
+      # so a different value here would miss the `test` cache entirely and
+      # rebuild the 864-crate graph from scratch. Cargo's own fingerprint would
+      # then disagree with the restored tree as well. See #3668 for why the
+      # shard job sets it.
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Free disk space
+        if: needs.changes.outputs.docs_only != 'true'
+        run: bash scripts/ci-free-disk-space.sh
+
+      - name: Install stable toolchain
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system dependencies
+        if: needs.changes.outputs.docs_only != 'true'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            pkg-config \
+            libssl-dev
+
+      # Shares `test-shard`'s cache rather than minting its own: the doctest
+      # build resolves the same fingerprint as that job's `cargo test --no-run`
+      # build phase, so the restored target/ tree is directly reusable.
+      #
+      # `save-if: false` — restore only. `test-shard` is the sole writer of
+      # this key. Two jobs racing to save one key leaves the loser logging a
+      # 409, and a second copy of a 1.28 GB entry is exactly the quota waste
+      # the `save-if` guards elsewhere in this file exist to prevent.
+      - name: Cache cargo artifacts
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: test
+          save-if: false
+
+      - name: cargo test --doc
+        if: needs.changes.outputs.docs_only != 'true'
+        run: cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui --doc
+
+  # --------------------------------------------------------------------------
   # test: the aggregate gate over the sharded suite above.
   #
   # This job exists to give the shard matrix ONE roll-up row instead of N,
@@ -1063,7 +1140,7 @@ jobs:
   # --------------------------------------------------------------------------
   test:
     name: Rust tests (pre-publish gate)
-    needs: [changes, test-shard]
+    needs: [changes, test-shard, test-doc]
     if: ${{ !cancelled() && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1071,14 +1148,26 @@ jobs:
       - name: Require every test shard to have succeeded
         env:
           SHARDS_RESULT: ${{ needs.test-shard.result }}
+          DOC_RESULT: ${{ needs.test-doc.result }}
         run: |
           set -euo pipefail
           echo "test-shard matrix aggregate result: ${SHARDS_RESULT}"
+          echo "test-doc result: ${DOC_RESULT}"
+          failed=0
           if [ "${SHARDS_RESULT}" != "success" ]; then
-            echo "::error::Rust tests (pre-publish gate) is red: the test-shard matrix reported '${SHARDS_RESULT}'. Open the individual 'Rust tests (pre-publish gate) — shard N of 4' jobs — nextest names the owning crate for every failing test."
+            echo "::error::Rust tests (pre-publish gate) is red: the test-shard matrix reported '${SHARDS_RESULT}'. Open the individual 'Rust tests (pre-publish gate) — shard N of 8' jobs — nextest names the owning crate for every failing test."
+            failed=1
+          fi
+          # Checked with the same "must equal success" polarity as the matrix,
+          # and for the same reason: a skipped job must fail closed here.
+          if [ "${DOC_RESULT}" != "success" ]; then
+            echo "::error::Rust tests (pre-publish gate) is red: 'Rust doctests (pre-publish gate)' reported '${DOC_RESULT}'."
+            failed=1
+          fi
+          if [ "${failed}" -ne 0 ]; then
             exit 1
           fi
-          echo "every test shard succeeded"
+          echo "every test shard and the doctest job succeeded"
 
   # --------------------------------------------------------------------------
   # msrv: verify the workspace compiles on the effective MSRV.
@@ -1435,8 +1524,9 @@ jobs:
         run: ${{ matrix.command }}
 
   # --------------------------------------------------------------------------
-  # search-daemon-smoke: build the trusty-search release binary and verify
-  # that the HTTP daemon starts and answers /health with status=ok.
+  # search-daemon-smoke: build the trusty-search binary under the `ci-smoke`
+  # profile and verify that the HTTP daemon starts and answers /health with
+  # status=ok.
   #
   # Design notes (issue #952):
   #
@@ -1525,9 +1615,23 @@ jobs:
 
       # SKIP_UI_BUILD=1 is already set globally via env: at the workflow level.
       # The committed ui-dist/ bundle is used as-is; pnpm is not required.
-      - name: Build trusty-search release binary
+      #
+      # `--profile ci-smoke`, not `--release`: this job builds trusty-search
+      # only to start it and assert `/health` returns `status=ok`. The
+      # ci-smoke profile drops thin LTO and opt-level 3 (see the profile's
+      # comment in the root Cargo.toml, which records the coverage trade this
+      # makes). Named profiles are stable since Cargo 1.57; this job pins
+      # `dtolnay/rust-toolchain@stable`.
+      #
+      # Artefacts land in `target/ci-smoke/`, which rust-cache handles without
+      # extra configuration: its cleanup identifies a profile directory by the
+      # presence of `deps`/`.fingerprint`/`build` rather than by a hardcoded
+      # debug/release list, and it caches the whole `target/` tree. No
+      # `cache-directories` entry is needed (contrast semver-checks.yml, where
+      # `target/semver-checks/` is not a cargo profile directory at all).
+      - name: Build trusty-search ci-smoke binary
         if: needs.changes.outputs.docs_only != 'true'
-        run: cargo build --release -p trusty-search
+        run: cargo build --profile ci-smoke -p trusty-search
 
       - name: Start trusty-search daemon (background)
         if: needs.changes.outputs.docs_only != 'true'
@@ -1543,7 +1647,7 @@ jobs:
           TRUSTY_SKIP_RAM_CHECK: "1"
         run: |
           mkdir -p /tmp/ts-smoke
-          ./target/release/trusty-search start \
+          ./target/ci-smoke/trusty-search start \
             --foreground \
             --port 7999 \
             --data-dir /tmp/ts-smoke \

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -226,6 +226,11 @@ jobs:
           # cargo-semver-checks builds into target/semver-checks/, which
           # rust-cache prunes as "unrecognised" by default.
           cache-directories: target/semver-checks
+          # Save only from main: a cache saved on a PR ref is readable by that
+          # PR alone but still counts against the repo-wide 10 GB quota, and this
+          # repo was over it — see the note on the test-shard cache in ci.yml.
+          # This one also saved from worktree branches pushed for release tags.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Runs BEFORE the real gate, matching line-cap.yml's selftest-then-gate
       # ordering: a gate that cannot fail makes the real run's green meaningless.

--- a/.github/workflows/sld-lint.yml
+++ b/.github/workflows/sld-lint.yml
@@ -86,6 +86,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: sld-lint
+          # Save only from main: a cache saved on a PR ref is readable by that
+          # PR alone but still counts against the repo-wide 10 GB quota, and this
+          # repo was over it — see the note on the test-shard cache in ci.yml.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run SLD linter (default / grandfathering mode)
         run: bash scripts/check_sld.sh

--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -204,6 +204,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: version-parity
+          # Save only from main: a cache saved on a PR ref is readable by that
+          # PR alone but still counts against the repo-wide 10 GB quota, and this
+          # repo was over it — see the note on the test-shard cache in ci.yml.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run version-parity guard
         run: bash scripts/check-version-parity.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -442,3 +442,29 @@ opt-level = 0
 [profile.release]
 opt-level = 3
 lto = "thin"
+
+# Build profile for CI's trusty-search daemon smoke test ONLY. Never used for
+# anything that ships.
+#
+# That job builds `-p trusty-search` at full `release` — opt-level 3 plus thin
+# LTO, ~210s median — to start the daemon and assert `/health` returns
+# `status=ok`. The assertion itself takes 0s, and it exercises process startup
+# and HTTP wiring, neither of which is sensitive to optimisation level. Thin
+# LTO across trusty-search's dependency graph (ort/onnxruntime, tree-sitter,
+# usearch, tantivy) is the bulk of that time and buys the check nothing.
+#
+# This IS a deliberate coverage trade, made knowingly by the repo owner: the
+# smoke binary is still optimised, but it is no longer byte-identical to what
+# ships. A release-only regression — one that needs opt-level 3 or cross-crate
+# LTO inlining to appear — would no longer be caught by the smoke test. It was
+# not catching that class of bug reliably at `release` either; it asserts one
+# HTTP field.
+#
+# `inherits = "release"` rather than "dev": `debug_assertions` stays off, so
+# the daemon runs the same code paths as a release build. Only the codegen
+# effort changes.
+[profile.ci-smoke]
+inherits = "release"
+lto = false
+codegen-units = 16
+opt-level = 1

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -429,10 +429,15 @@ assert_eq "df prints nothing at all"    "purge"    "$(disk_decision_real_df '')"
 assert_eq "df prints only a header"     "purge"    "$(disk_decision_real_df 'Avail')"
 
 # Wiring: the script being correct proves nothing if a job still inlines the
-# ungated `rm -rf`. All four jobs that reclaim disk must route through it.
+# ungated `rm -rf`. Every job that reclaims disk must route through it.
+#
+# 4 -> 5: the `test-doc` job was split out of `test-shard` (the doctests used
+# to be a `matrix.shard == 1` step). It does its own full workspace build and
+# so carries the same disk pressure the other four do, which is why it calls
+# the helper rather than being exempted from this count.
 assert_eq "ci.yml has no inlined SDK purge left" "0" \
   "$(grep -c 'sudo rm -rf /usr/share/dotnet' "${ci_wf}" || true)"
-assert_eq "all four disk-reclaim jobs call the helper" "4" \
+assert_eq "all five disk-reclaim jobs call the helper" "5" \
   "$(grep -c 'bash scripts/ci-free-disk-space.sh' "${ci_wf}" || true)"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Six measured CI optimizations plus a seventh added mid-flight by the owner. None changes what CI verifies — the claim is checked per item below.

The driver: `active_caches_size_in_bytes` is 10,449,432,235 against a 10 GB limit, so the cache evicts continuously. 3 of 24 runs missed and paid +250s on the critical-path job, which is the entire p90 tail (4.02m → 7.88m).

## 1. `save-if` on four unguarded caches

`.github/workflows/{sld-lint,version-parity,capabilities-drift,semver-checks}.yml` — added the main-only guard `ci.yml` already applies to every cache it owns.

Measured on the live cache list, PR and worktree refs held **1.43 GB** across exactly these four:

| ref | key | bytes |
|---|---|---|
| `refs/pull/5722/merge` | `v0-rust-capabilities-drift-…` | 636,452,853 |
| `refs/pull/5721/merge` | `v0-rust-sld-lint-…` | 407,925,476 |
| `refs/heads/worktree-agent-ac2dc3ddd…` | `v0-rust-semver-checks-…` | 390,215,936 |

Each is byte-identical to a `refs/heads/main` copy that already exists, and none is readable by any other PR. Saves ~1.4 GB of standing quota pressure, which is what stops the main-ref caches being evicted.

**Verifies the same:** `save-if` gates *writing* the cache only. Restore is untouched, and no job's commands change.

## 2. AL2023 cache — 22% of quota

`.github/workflows/al2023-build.yml` — 2,320,411,761 bytes, the single largest entry.

`actions/cache@v4` has **no `save-if` input**, so this is a restore/save split with an `if:` on the save half. The save is additionally gated on `cache-hit != 'true'` so a run that restored via `restore-keys` still refreshes the entry under the current lockfile key.

This workflow triggers on `pull_request` (path-filtered to trusty-search / trusty-embedderd / trusty-common), so without the guard every PR touching those crates mints another 2.3 GB copy nothing else can read.

**Narrowing `path:` off the whole `target/` — declined, reported as follow-up.** It needs a judgment call about which subdirectories the load-dynamic link step actually requires, which is exactly the case the brief said to defer.

## 3. `lld` via RUSTFLAGS — NOT APPLIED

The brief said to check whether `RUSTFLAGS` invalidates the rust-cache key and report rather than proceed if it does. It does.

`Swatinem/rust-cache/src/config.ts`:

```ts
// these prefixes should cover most of the compiler / rust / cargo keys
const envPrefixes = ["CARGO", "CC", "CFLAGS", "CXX", "CMAKE", "RUST"];
envPrefixes.push(...core.getInput("env-vars").split(/\s+/).filter(Boolean));
…
if (envPrefixes.some((prefix) => key.startsWith(prefix)) && value) {
  hasher.update(`${key}=${value}`);
```

`"RUSTFLAGS".startsWith("RUST")` is true, so RUSTFLAGS is hashed in. Two details make it worse than a one-time cost:

- The hash lands in `self.restoreKey`, which is the **fallback prefix**, not just the primary key. There is no partial restore across a RUSTFLAGS change.
- Combined with `save-if: main`, a PR adding RUSTFLAGS never saves under the new key, so every PR run is fully cold until it merges.

Setting RUSTFLAGS also changes cargo's own fingerprint, so the restored tree would rebuild regardless. Rotating the largest keys while already over quota works directly against items 1 and 2. Not applied.

Setting the linker in `.cargo/config.toml` would dodge the *key* rotation but imposes an `lld` dependency on every contributor's local build — a much larger change than the brief scoped.

## 4. Doctests moved to their own job

`ci.yml` — `cargo test --doc` ran on shard 1 only, +68s. Shard 1 was the slowest leg (13.31m vs shard 3's 11.74m), and a matrix finishes when its slowest leg does, so 68s on one leg was 68s on the matrix.

New `test-doc` job, `if:` identical to `test-shard`'s. It sets `CARGO_PROFILE_TEST_DEBUG: line-tables-only` to match the shard job — that variable starts with `CARGO`, so it is in the rust-cache key, and a mismatch would miss the shared `test` cache and rebuild the 864-crate graph. It uses `shared-key: test` with `save-if: false` (restore-only), leaving `test-shard` the sole writer, so no new cache entry and no save race.

**Verifies the same:** the `test` roll-up now `needs: [changes, test-shard, test-doc]` and checks the doctest result with the same "must equal success" polarity as the matrix, so a skipped or failing doctest job still fails closed. Without that wiring this item *would* have weakened the gate.

## 5. Shard matrix 4 → 8

`ci.yml:502`. Confirmed the divisor is genuinely derived — `--partition hash:${{ matrix.shard }}/${{ strategy.job-total }}` — and the only other hardcoded `4` was the job's display name, now `of 8`. Also checked branch protection: the required contexts are `Format check`, `Clippy`, `MSRV check`, `500-line file-size cap`, `trusty-search daemon smoke test`, `PR version bump vs crates.io` — the shards are not among them, so the rename breaks no required check.

Build is ~496s and not shardable; execution is ~653s total. Leg time ~496+163 → ~496+82.

## 6. Deleted the `.rcgu.o` sweep

`ci.yml:950–955`. Verified against a real run rather than trusting the timing: run `31852921362`, shard 1 —

```
Before sweep:
45G	target/debug
After sweep:
45G	target/debug
```

Identical, 00:22:40.109 → 00:22:40.272 = 0.16s. `find -delete` matched nothing; `CARGO_PROFILE_TEST_DEBUG=line-tables-only` plus `CARGO_INCREMENTAL=0` leave nothing behind.

Two comments credited this step with remedying #3668 — including the free-disk-space step's comment, which said "the .rcgu.o sweep below, not this step, is what actually remedied #3668". Both are corrected to name the debug-level setting and `ci-free-disk-space.sh`, which are what actually hold the disk. Deleting a step whose comment claims it prevents disk exhaustion is worth the paragraph.

## 7. `[profile.ci-smoke]` for the smoke test

Root `Cargo.toml` plus the smoke job. `--release` (opt-level 3, thin LTO, 210s median) to start a daemon and assert one HTTP field.

```toml
[profile.ci-smoke]
inherits = "release"
lto = false
codegen-units = 16
opt-level = 1
```

**This IS a coverage trade, made knowingly by the owner, not an oversight.** The smoke binary is still optimized but is no longer byte-identical to what ships. A regression that needs opt-level 3 or cross-crate LTO inlining to appear would no longer be caught here. `inherits = "release"` keeps `debug_assertions` off, so the daemon runs release code paths; only codegen effort changes.

Verified rather than assumed, per the instruction:

- **Profile syntax.** Named profiles are stable since Cargo 1.57; CI pins `dtolnay/rust-toolchain@stable`. Ran `cargo check --profile ci-smoke -p trusty-common` → `EXIT=0`, and confirmed the output directory is literally `target/ci-smoke/` (the daemon start step's path is updated to match).
- **Cache key — does not rotate.** rust-cache hashes workspace *member* manifests, resolved through `cargo metadata`. The root `Cargo.toml` is a virtual manifest (`[workspace]`, no `[package]`), so it is not a member and the added profile is not hashed.
- **The new target dir is cached, no `cache-directories` needed.** `cleanup.ts` identifies a profile directory by the presence of `build` / `.fingerprint` / `deps` rather than a hardcoded debug/release list, and `cachePaths` includes the whole `target/`. Confirmed the built `target/ci-smoke/` contains `build` and `deps`. This is why it differs from `target/semver-checks/`, which needs an explicit entry — that one is not a cargo profile directory at all.

One-time cost: the first main run after merge builds into a fresh profile dir. Steady state is cheaper.

## Gates

```
check-ci-helpers-selftest: all 135 cases passed
line-cap: measured 4007 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
sld-lint: scanned 60 spec doc(s) + 3269 code file(s); resolved 40 frontmatter + 37 inline reference(s); 0 error(s), 0 warning(s)
changelog-fragment gate: scanned 8 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
cargo check --profile ci-smoke -p trusty-common   EXIT=0
```

No changelog fragment is owed — confirmed by running the gate, which scanned 8 paths rather than no-opping on an empty diff.

The repo has no `actionlint`, so all six edited workflows were parsed and asserted structurally: matrix is `[1..8]`, `test-doc` exists with an `if:` identical to `test-shard`'s, `test` needs all three, the doctest step and the rcgu sweep are gone from the shard job, and the smoke build is `cargo build --profile ci-smoke -p trusty-search`.

`scripts/check-ci-helpers-selftest.sh` needed one assertion updated with a reason, as #5723 did: the disk-reclaim caller count moves 4 → 5 because `test-doc` does its own full workspace build and so carries the same disk pressure. The `have_work` count in semver-checks stayed at 7 — `save-if` is a `with:` input, not an `if:`.

## What this PR cannot show

Items 4, 5 and 6 touch `test-shard`, which **does not run on pull requests** (`ci.yml` `if: github.event_name != 'pull_request'`). Their effect is only observable on push-to-main or via `workflow_dispatch`. Item 7 is on the required `trusty-search daemon smoke test`, so this PR's own CI does exercise it end-to-end — though on a cold `ci-smoke` cache, since `save-if` is main-only, so its *timing* here is not the steady-state number.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
