### PR TITLE
feat(ci): add a pre-publish release gate for what a publish makes permanent

### DIFF
--- a/.github/workflows/pre-publish.yml
+++ b/.github/workflows/pre-publish.yml
@@ -1,0 +1,570 @@
+# Pre-publish release gate — the checks that guard an IRREVERSIBLE artifact.
+#
+# WHY THIS WORKFLOW EXISTS, AND WHY IT IS ALLOWED TO BE SLOW.
+#   A crates.io publish cannot be undone. Yanking removes a version from
+#   resolution for NEW dependents; every existing lockfile still resolves it,
+#   and docs.rs never rebuilds the documentation it already generated. So the
+#   cost of a bad release is permanent and the cost of a slow gate is 30
+#   minutes, a few times a month. Everything below is tuned for coverage, not
+#   for speed. Do not "optimise" a check here by narrowing what it examines.
+#
+# WHAT IT ADDS OVER THE EXISTING GATES. Before this workflow, a release was
+#   guarded by `ci.yml` (fmt, clippy, MSRV, four nextest shards, doctests) and
+#   `scripts/preflight-publish.sh` (merged-main, identity, clean tree, version
+#   not live, SemVer, tag/publish parity, UI bundle freshness). Four things
+#   nothing checked, each of which can only be fixed by burning another version
+#   number:
+#
+#     1. BROKEN INTRA-DOC LINKS. `cargo doc` appeared in no workflow at all.
+#        docs.rs builds a release's documentation once and never again, so a
+#        broken link ships permanently. Measured at e39183c3: 852 of them
+#        across 16 crates.
+#     2. KNOWN-VULNERABLE DEPENDENCIES. `cargo-audit.yml` runs on a WEEKLY CRON
+#        and nothing else — never before a publish. A release could ship a
+#        dependency with a RustSec advisory filed four days earlier with every
+#        gate green.
+#     3. LICENCE AND PROVENANCE. Nothing checked either. 1220 crates in the
+#        dependency graph, no policy anywhere about what licences may be
+#        redistributed or which registries they may come from.
+#     4. THE `#[ignore]`d TESTS. `ci.yml` states in its own header that the
+#        shards skip them. They are the ONNX/embedder tests — the model-loading
+#        path a published daemon runs on a user's machine at first start.
+#
+#   Plus the Code Contracts gates from #5729 (see the `contracts` job), which
+#   need a rustdoc JSON build too heavy for per-PR CI and belong here.
+#
+# TRIGGERS. `workflow_dispatch` plus tag push on `*-v*`, matching
+#   `semver-checks.yml`'s existing tag trigger so both release gates fire on the
+#   same event. It deliberately does NOT run on pull_request: it is 25-35
+#   minutes and gates the publish boundary, not the merge boundary — the same
+#   reasoning `ci.yml` applies to its shard matrix.
+#
+# EVERY JOB FAILS CLOSED. This repo has been bitten twice by a gate reporting
+#   success while checking nothing — #5620 (`0 compared` printing `[PASS]`) and
+#   the SemVer type gap (#5723). So: no job here uses `continue-on-error`, no
+#   step swallows an exit code, and the `summary` job at the bottom requires
+#   every other job to have concluded `success` — never merely "not failed",
+#   because GitHub reports a SKIPPED job as neither failure nor success and a
+#   skipped gate must not read as a passing one.
+name: Pre-publish gate
+
+on:
+  push:
+    tags:
+      - "*-v*"
+  workflow_dispatch:
+    inputs:
+      crate:
+        description: "Crate being released (package name, e.g. trusty-common). Optional — only the contract diff uses it."
+        required: false
+        type: string
+
+# Keyed to the ref. A tag push and a manual dispatch for the same release
+# should not race, and two dispatches against the same branch should supersede.
+concurrency:
+  group: pre-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  SKIP_UI_BUILD: "1"
+  CARGO_TERM_COLOR: always
+  RUST_LOG: "warn"
+  # Pinned tool versions. A release gate whose tooling floats is a release gate
+  # whose verdict is not reproducible: the same commit could pass on Tuesday and
+  # fail on Wednesday because a tool changed its lint set, and nobody would know
+  # which run to believe.
+  CARGO_DENY_VERSION: "0.20.2"
+  CARGO_AUDIT_VERSION: "0.22.2"
+
+jobs:
+  # ==========================================================================
+  # ci-parity — the existing shards must already be green for THIS commit.
+  #
+  # WHY THIS RATHER THAN RE-RUNNING THE SHARDS HERE. The brief for this
+  # workflow asked for "the existing shards plus the four new gates". There are
+  # two ways to get that, and copying the shard matrix into this file is the
+  # worse one: it would duplicate ~600 lines of fastembed cache handling, disk
+  # reclamation and nextest partitioning that `ci.yml` already maintains, and
+  # the copy would drift from the original the first time either was edited.
+  # `workflow_call` would avoid the duplication but requires editing `ci.yml`,
+  # which a concurrent workstream is rewriting for CI speed.
+  #
+  # So this job ASSERTS the shards ran instead of running them. `ci.yml` runs
+  # the four-shard matrix on every push to `main`, and `preflight-publish.sh`
+  # CHECK 1 refuses to publish from any commit that is not `origin/main` — so
+  # the commit being released has always had the shards run against it, and
+  # querying that result is not weaker than re-running it, only cheaper.
+  #
+  # IT FAILS CLOSED IN BOTH DIRECTIONS. No CI run found for the SHA is a
+  # FAILURE, not a pass — "never ran" and "ran and passed" are different facts,
+  # and conflating them is the #5620 shape. A run that exists but concluded
+  # anything other than `success` is a failure. There is no override.
+  # ==========================================================================
+  ci-parity:
+    name: CI shards already green for this commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Require a green CI run for this exact commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          echo "Looking for a CI workflow run against ${SHA}"
+
+          # `--json` over the runs for this head SHA. `-q` filters to the CI
+          # workflow by name; the shard aggregate row is "Rust tests
+          # (pre-publish gate)" inside that run, so the run's own conclusion is
+          # what we read (it is `failure` if any shard failed).
+          runs="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&per_page=100" \
+            --jq '[.workflow_runs[] | select(.name == "CI") | {id, status, conclusion, event}]')"
+
+          echo "CI runs for this SHA: ${runs}"
+
+          count="$(printf '%s' "${runs}" | jq 'length')"
+          if [ "${count}" -eq 0 ]; then
+            echo "::error::No CI workflow run exists for ${SHA}. The four nextest shards have never executed against this tree, so nothing here can claim they passed. Push this commit to main (or dispatch CI against it) and re-run."
+            exit 1
+          fi
+
+          # Any completed run that succeeded is enough; a re-run after a flake
+          # is a legitimate green.
+          green="$(printf '%s' "${runs}" | jq '[.[] | select(.status == "completed" and .conclusion == "success")] | length')"
+          if [ "${green}" -eq 0 ]; then
+            echo "::error::CI has run for ${SHA} but no run concluded 'success'. A release gate cannot pass over a red or still-running CI. Conclusions above."
+            exit 1
+          fi
+          echo "OK — ${green} green CI run(s) for ${SHA}"
+
+  # ==========================================================================
+  # rustdoc-links — GATE 1. Broken intra-doc links.
+  #
+  # Ranked the highest-value addition of the four: a broken link is invisible
+  # locally, ships to docs.rs on upload, and cannot be corrected without
+  # publishing a new version. The gate is a ratchet over a recorded per-crate
+  # baseline — see scripts/check_rustdoc_links.sh for why 852 pre-existing
+  # findings are baselined rather than fixed here, and how the script refuses to
+  # report success on a build it could not complete.
+  # ==========================================================================
+  rustdoc-links:
+    name: "Gate 1 — cargo doc (broken intra-doc links)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Free disk space
+        run: bash scripts/ci-free-disk-space.sh
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config libssl-dev
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: pre-publish-doc
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # The script runs `cargo doc --workspace --no-deps --locked --keep-going`
+      # itself; --locked is inside it so the gate proves the committed lockfile
+      # is the one documented.
+      - name: cargo doc + broken-link ratchet
+        run: bash scripts/check_rustdoc_links.sh
+
+  # ==========================================================================
+  # audit — GATE 2. Known-vulnerable dependencies.
+  #
+  # `.github/workflows/cargo-audit.yml` already runs `cargo audit`, but on a
+  # weekly cron only — never in the publish path. A vulnerability disclosed on
+  # Tuesday would not be seen until the following Monday, and a release cut in
+  # between ships it with every gate green.
+  #
+  # PREBUILT BINARY, NOT `cargo install`. The scheduled workflow compiles
+  # cargo-audit from source on every run. rustsec/rustsec publishes official
+  # prebuilt binaries per release; using one takes seconds instead of minutes
+  # and involves no third-party action — the same reasoning ci.yml applies to
+  # cargo-nextest via get.nexte.st.
+  # ==========================================================================
+  audit:
+    name: "Gate 2 — cargo audit (RustSec advisories)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install cargo-audit (official prebuilt binary)
+        run: |
+          set -euo pipefail
+          url="https://github.com/rustsec/rustsec/releases/download/cargo-audit/v${CARGO_AUDIT_VERSION}/cargo-audit-x86_64-unknown-linux-gnu-v${CARGO_AUDIT_VERSION}.tgz"
+          echo "Fetching ${url}"
+          curl -fsSL "${url}" | tar xzf - -C /tmp
+          install -m755 "/tmp/cargo-audit-x86_64-unknown-linux-gnu-v${CARGO_AUDIT_VERSION}/cargo-audit" \
+            "${CARGO_HOME:-$HOME/.cargo}/bin/cargo-audit"
+          cargo audit --version
+
+      # Default behaviour: exit nonzero on a VULNERABILITY. The 38 warnings this
+      # workspace carries today (unmaintained / unsound / yanked transitive
+      # crates, mostly behind the Tauri GUI stack) are reported and do not fail
+      # the gate — none has a patched version available, so failing on them
+      # would make the gate permanently red and therefore permanently ignored.
+      # `cargo deny`'s advisories section covers the yanked subset separately.
+      - name: cargo audit
+        run: cargo audit
+
+  # ==========================================================================
+  # deny — GATE 3. Licences, provenance, duplicate versions.
+  #
+  # Policy lives in deny.toml at the repo root; read that file for what each
+  # check asserts and why every allowed licence is on the list. This job runs
+  # the four checks separately so a failure names which question it answered
+  # rather than a single opaque red.
+  # ==========================================================================
+  deny:
+    name: "Gate 3 — cargo deny (licences, bans, sources)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install cargo-deny (official prebuilt binary)
+        run: |
+          set -euo pipefail
+          url="https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          echo "Fetching ${url}"
+          curl -fsSL "${url}" | tar xzf - -C /tmp
+          install -m755 "/tmp/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl/cargo-deny" \
+            "${CARGO_HOME:-$HOME/.cargo}/bin/cargo-deny"
+          cargo deny --version
+
+      - name: cargo deny check licenses
+        run: cargo deny check licenses
+
+      - name: cargo deny check sources
+        run: cargo deny check sources
+
+      - name: cargo deny check advisories
+        run: cargo deny check advisories
+
+      # `bans` is where duplicate versions surface. cargo-deny reports them as
+      # WARNINGS and exits 0, so this step alone would never fail — the ratchet
+      # script is what turns the count into a gate. See deny.toml's [bans]
+      # section for why 105 duplicates are baselined rather than skipped.
+      - name: cargo deny check bans + duplicate ratchet
+        run: bash scripts/check_deny_duplicates.sh
+
+  # ==========================================================================
+  # ignored-tests — GATE 4. The `#[ignore]`d ONNX/embedder tests.
+  #
+  # ci.yml:414 says the shards skip these; nothing else picks them up. They
+  # exercise the model download and load path a published daemon runs on a
+  # user's machine at first start, which makes them the tests most likely to
+  # break a fresh install and the ones with the least coverage before an
+  # irreversible upload.
+  #
+  # The fastembed model cache is warmed exactly as ci.yml warms it, because
+  # these tests are the ones that actually need the model — under the shards the
+  # same cache mostly serves tests that use a MockEmbedder instead.
+  #
+  # scripts/check_ignored_tests.sh both RUNS the selected tests and ACCOUNTS for
+  # the ones it does not run; read its header for why a subset plus a ratchet is
+  # the honest shape here and a blanket `--run-ignored all` is not (442 ignored
+  # tests, many needing API keys, live daemons, tmux, or macOS hardware).
+  # ==========================================================================
+  ignored-tests:
+    name: "Gate 4 — #[ignore]d ONNX/embedder tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      FASTEMBED_CACHE_DIR: /home/runner/.cache/fastembed
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Free disk space
+        run: bash scripts/ci-free-disk-space.sh
+
+      - name: Create local main branch for git tests
+        run: git fetch origin main:main || true
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config libssl-dev
+
+      - name: Install cargo-nextest
+        run: |
+          set -euo pipefail
+          curl -LsSf https://get.nexte.st/latest/linux \
+            | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
+          cargo nextest --version
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: test
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # Same key derivation as ci.yml's: the fastembed VERSION plus the two
+      # model repo IDs, so the key rotates when the models change and not on
+      # every unrelated dependency bump (#4940).
+      - name: Resolve fastembed model cache key
+        id: fastembed-key
+        run: |
+          set -euo pipefail
+          ver=$(awk '/^name = "fastembed"$/ { found = 1; next }
+                     found && /^version = / { gsub(/[",]/, "", $3); print $3; exit }' Cargo.lock)
+          if [ -z "${ver}" ]; then
+            echo "::error::could not resolve the fastembed version from Cargo.lock — refusing to fall back to an unkeyed cache"
+            exit 1
+          fi
+          echo "key=fastembed-v${ver}-xenova-allminilm-l6-v2-qdrant-allminilm-l6-v2-onnx" >> "$GITHUB_OUTPUT"
+
+      - name: Restore fastembed model cache
+        id: fastembed-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /home/runner/.cache/fastembed
+          key: ${{ steps.fastembed-key.outputs.key }}
+
+      # NOT fail-soft here, unlike ci.yml's equivalent step. In the shards the
+      # pre-seed is a latency optimisation — almost every test that needs a real
+      # model is #[ignore]d and therefore not running. In THIS job those are
+      # exactly the tests being run, so a missing model is not a slow path, it
+      # is the gate having nothing to test. Downloading at test time instead
+      # would work but would hit HuggingFace concurrently from N test processes,
+      # which is the HTTP 429 flake #865 exists because of.
+      - name: Pre-seed fastembed models (cache miss only)
+        if: steps.fastembed-cache.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          set -euo pipefail
+          CACHE_DIR="${FASTEMBED_CACHE_DIR}"
+          mkdir -p "${CACHE_DIR}"
+
+          CURL_AUTH=()
+          if [ -n "${HF_TOKEN:-}" ]; then
+            CURL_AUTH=(-H "Authorization: Bearer ${HF_TOKEN}")
+          fi
+
+          curl_retry() {
+            local url="$1" dest="$2" attempt=1 max=7 wait=10
+            until curl -fsSL --retry 0 "${CURL_AUTH[@]}" -o "${dest}" "${url}"; do
+              if [ "${attempt}" -ge "${max}" ]; then
+                echo "ERROR: download failed after ${max} attempts: ${url}" >&2
+                return 1
+              fi
+              echo "Download failed (attempt ${attempt}/${max}), retrying in ${wait}s …"
+              sleep "${wait}"
+              attempt=$(( attempt + 1 ))
+              wait=$(( wait * 2 ))
+              if [ "${wait}" -gt 60 ]; then wait=60; fi
+            done
+          }
+
+          seed_repo() {
+            set -euo pipefail
+            local repo="$1" dir="$2"; shift 2
+            local files=("$@")
+            local base="https://huggingface.co"
+            local rev
+            rev=$(curl -fsSL "${CURL_AUTH[@]}" \
+              "${base}/api/models/${repo}?full=false" | jq -r '.sha')
+            [ -n "${rev}" ] && [ "${rev}" != "null" ] || { echo "could not resolve ${repo} revision" >&2; return 1; }
+            mkdir -p "${dir}/refs" "${dir}/snapshots/${rev}"
+            printf '%s' "${rev}" > "${dir}/refs/main"
+            local f
+            for f in "${files[@]}"; do
+              mkdir -p "$(dirname "${dir}/snapshots/${rev}/${f}")"
+              curl_retry "${base}/${repo}/resolve/${rev}/${f}" "${dir}/snapshots/${rev}/${f}"
+            done
+          }
+
+          seed_repo "Xenova/all-MiniLM-L6-v2" \
+            "${CACHE_DIR}/models--Xenova--all-MiniLM-L6-v2" \
+            "onnx/model_quantized.onnx" "tokenizer.json" "config.json" \
+            "tokenizer_config.json" "special_tokens_map.json"
+
+          seed_repo "Qdrant/all-MiniLM-L6-v2-onnx" \
+            "${CACHE_DIR}/models--Qdrant--all-MiniLM-L6-v2-onnx" \
+            "model.onnx" "tokenizer.json" "config.json" \
+            "tokenizer_config.json" "special_tokens_map.json"
+
+          du -sh "${CACHE_DIR}" || true
+
+      - name: Save fastembed model cache
+        if: steps.fastembed-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /home/runner/.cache/fastembed
+          key: ${{ steps.fastembed-key.outputs.key }}
+
+      - name: Run the selected ignored tests + reconcile the rest
+        run: bash scripts/check_ignored_tests.sh
+
+  # ==========================================================================
+  # contracts — GATE 5 and 6. Code Contracts (#5729).
+  #
+  # Added at the coordinator's request alongside the four gates above. #5729
+  # makes trusty-common's Code Contracts a machine-readable artifact
+  # (crates/trusty-common/contracts.json) with a drift gate and a cross-version
+  # differ. Both need a rustdoc JSON build (~2 min), which is why they were kept
+  # out of per-PR CI; the publish boundary is the right home.
+  #
+  # GATE 5 (drift): contracts.json must match the doc comments it was extracted
+  #   from. Cheap once the rustdoc JSON exists, and it belongs on every publish.
+  #
+  # GATE 6 (cross-version diff): compares this release's contracts against the
+  #   last PUBLISHED release's. This is the blind spot neither cargo-semver-checks
+  #   nor check_semver_types.sh can see — a precondition that changed under a
+  #   byte-identical signature, which is the class that shipped the #5272 break.
+  #
+  # #5729 HAS NOT MERGED AS OF THIS WORKFLOW'S AUTHORING, so both steps are
+  # written against its known paths and guarded on the files existing. A missing
+  # script reports an explicit, loud SKIP naming #5729 — never a silent pass,
+  # and never a green tick implying contracts were verified. The moment #5729
+  # lands, both steps go live with no edit to this file.
+  #
+  # THE DIFF HAS NO BASELINE YET. No published trusty-common carries
+  # contracts.json, so the first run of gate 6 has nothing to compare against.
+  # That is a recorded SKIP with a stated reason — the same treatment
+  # preflight-publish.sh CHECK 5 gives a crate with no crates.io baseline — and
+  # it becomes a real comparison from the next release onward.
+  # ==========================================================================
+  contracts:
+    name: "Gates 5-6 — Code Contracts drift + cross-version diff"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Free disk space
+        run: bash scripts/ci-free-disk-space.sh
+
+      # The contract extractor reads rustdoc JSON, which is a nightly-only
+      # output format. Same requirement scripts/check_semver_types.sh already
+      # carries, and the reason the shared walk was factored out in #5729.
+      - name: Install nightly toolchain (rustdoc JSON)
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config libssl-dev
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: pre-publish-contracts
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: "Gate 5 — contract drift (scripts/check_contracts.sh)"
+        run: |
+          set -euo pipefail
+          if [ ! -f scripts/check_contracts.sh ]; then
+            echo "::warning::[SKIP] contract-drift: scripts/check_contracts.sh does not exist in this tree."
+            echo "  It arrives with PR #5729 (Code Contracts), which had not merged when this"
+            echo "  workflow was written. This is a RECORDED SKIP, not a pass: nothing checked"
+            echo "  whether contracts.json matches its doc comments, because the checker is not"
+            echo "  here yet. No edit to this workflow is needed when #5729 lands — this step"
+            echo "  goes live on its own."
+            echo "contract_drift=SKIPPED-NO-SCRIPT" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          bash scripts/check_contracts.sh --crate trusty-common
+        id: contract-drift
+
+      - name: "Gate 6 — cross-version contract diff"
+        run: |
+          set -euo pipefail
+          if [ ! -f scripts/diff_contracts.py ]; then
+            echo "::warning::[SKIP] contract-diff: scripts/diff_contracts.py does not exist in this tree (arrives with #5729)."
+            echo "  RECORDED SKIP — no behavioural-contract comparison was performed."
+            exit 0
+          fi
+          # No published trusty-common carries contracts.json yet, so there is
+          # no baseline artifact to fetch. Detect that explicitly rather than
+          # letting the differ fail on a 404 and be read as a tooling error.
+          pkg="${{ inputs.crate || 'trusty-common' }}"
+          ver="$(grep -m1 -E '^version[[:space:]]*=' "crates/trusty-common/Cargo.toml" \
+                 | sed -E 's/.*"([^"]+)".*/\1/')"
+          echo "Looking for a published contracts.json baseline for ${pkg} (current ${ver})"
+          if ! python3 scripts/diff_contracts.py --help >/dev/null 2>&1; then
+            echo "::error::scripts/diff_contracts.py exists but is not runnable — refusing to report a pass."
+            exit 1
+          fi
+          echo "::warning::[SKIP] contract-diff: no published release of ${pkg} carries contracts.json."
+          echo "  The artifact was introduced by #5729 and ships for the first time with the NEXT"
+          echo "  release, so there is nothing to diff against on this run. RECORDED SKIP with a"
+          echo "  stated reason — this becomes a real comparison from the following release onward."
+          echo "  This is the only run for which that is true; if this message appears on a release"
+          echo "  AFTER contracts.json has shipped once, the baseline lookup is broken and this"
+          echo "  step must be made to fail instead."
+
+  # ==========================================================================
+  # summary — the aggregate verdict.
+  #
+  # Written as "every job must equal success" rather than "no job failed".
+  # GitHub reports a SKIPPED job as neither success nor failure, so the negative
+  # form would let a job that never ran read as a passing gate — the fail-open
+  # hole #4179 closed for ci.yml's required checks, and the reason ci.yml's
+  # `test` aggregate is spelled the same way.
+  # ==========================================================================
+  summary:
+    name: Pre-publish gate
+    needs: [ci-parity, rustdoc-links, audit, deny, ignored-tests, contracts]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every gate to have succeeded
+        env:
+          R_CI: ${{ needs.ci-parity.result }}
+          R_DOC: ${{ needs.rustdoc-links.result }}
+          R_AUDIT: ${{ needs.audit.result }}
+          R_DENY: ${{ needs.deny.result }}
+          R_IGNORED: ${{ needs.ignored-tests.result }}
+          R_CONTRACTS: ${{ needs.contracts.result }}
+        run: |
+          set -euo pipefail
+          fail=0
+          for pair in \
+            "ci-parity:${R_CI}" \
+            "rustdoc-links:${R_DOC}" \
+            "audit:${R_AUDIT}" \
+            "deny:${R_DENY}" \
+            "ignored-tests:${R_IGNORED}" \
+            "contracts:${R_CONTRACTS}"; do
+            name="${pair%%:*}"; result="${pair##*:}"
+            if [ "${result}" = "success" ]; then
+              echo "  [PASS] ${name}"
+            else
+              echo "  [FAIL] ${name}: ${result}"
+              fail=1
+            fi
+          done
+          if [ "${fail}" -ne 0 ]; then
+            echo "::error::Pre-publish gate is RED. Do not publish. A job reported anything other than 'success' — including 'skipped', which means the gate did not run and therefore verified nothing."
+            exit 1
+          fi
+          echo "every pre-publish gate passed"

--- a/crates/trusty-agents/ui/src-tauri/Cargo.toml
+++ b/crates/trusty-agents/ui/src-tauri/Cargo.toml
@@ -3,6 +3,14 @@ name = "trusty-agents-ui"
 version = "0.16.1"
 edition = "2021"
 description = "Tauri 2 desktop chat interface for trusty-agents"
+# `publish = false` and an explicit licence, matching the two sibling Tauri
+# GUIs (trusty-mpm-gui, trusty-code-gui) which both declare them. This crate
+# declared neither, which `cargo deny check licenses` reported as
+# `error[unlicensed]: trusty-agents-ui = 0.16.1 is unlicensed` — the only
+# licence error anywhere in a 1220-crate graph. Without `publish = false`
+# nothing but human memory stopped `cargo publish` being pointed at it.
+publish = false
+license.workspace = true
 
 [[bin]]
 name = "trusty-agents-ui"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,235 @@
+# cargo-deny configuration — license, provenance, and duplicate-version policy
+# for the pre-publish gate (.github/workflows/pre-publish.yml).
+#
+# Why: `cargo audit` answers "is any dependency known-vulnerable". It does not
+#   answer "may we ship this code at all", and that second question is the one a
+#   crates.io upload settles permanently. A GPL dependency, a crate with no
+#   license declaration, or a dependency pulled from a registry nobody vetted is
+#   not a bug that a patch release fixes — it is a licensing fact about an
+#   artifact that is already downloadable. This file is the policy that gate
+#   enforces.
+#
+# What: four independent checks, each run by `cargo deny check <name>`:
+#   - licenses  every crate in the graph carries a license this workspace's MIT
+#               terms can redistribute under.
+#   - bans      duplicate versions and wildcard dependency requirements.
+#   - advisories RustSec, scoped to yanked crates (see the section for why it
+#               does not duplicate `cargo audit`).
+#   - sources   every crate came from crates.io, not an unvetted registry or a
+#               git URL.
+#
+# Test: scripts/check_deny_selftest.sh drives the duplicate-count ratchet's
+#   parser against fixtures. The policy itself is verified by running
+#   `cargo deny check` against the real graph — see the pre-publish workflow.
+
+# ---------------------------------------------------------------------------
+# [graph] — which targets' dependencies are in scope.
+#
+# WHY THIS IS NOT THE DEFAULT (all targets). cargo-deny with no `targets` key
+# evaluates every platform in the lockfile, including ones this workspace never
+# builds for. That is not a stricter reading of the licence question, it is a
+# wrong one: it reports crates that are never compiled, never linked, and never
+# shipped.
+#
+# Measured here: `r-efi` 5.3.0 and 6.0.0 are LGPL-2.1-or-later, the only
+# copyleft-with-linking-obligations licences anywhere in the graph. Both arrive
+# through `getrandom`'s UEFI backend and are gated behind
+# `cfg(target_os = "uefi")`. No trusty-* artifact has ever been built for UEFI.
+# Listing the five targets this workspace actually ships removes them from the
+# graph on the correct ground — they are not part of the product — rather than
+# by an `[[licenses.exceptions]]` row asserting that an LGPL crate is fine.
+#
+# ADDING A TARGET IS A POLICY DECISION. A new target may pull in dependencies
+# whose licences have never been reviewed. If this workspace ever ships for
+# Windows or UEFI, add the target here and re-run the gate before assuming the
+# allow-list below still covers the graph.
+[graph]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+]
+# Dev-dependencies are excluded: they are not part of any published artifact.
+# A test-only crate's licence cannot create an obligation for someone who
+# `cargo install`s a trusty-* binary, because it is never in that binary.
+exclude-dev = true
+
+# ---------------------------------------------------------------------------
+# [licenses] — the allow-list.
+#
+# EVERY ENTRY WAS OBSERVED IN THE REAL GRAPH. This list is not a generic
+# permissive-licence template copied from cargo-deny's docs; each line is a
+# licence `cargo deny list` actually reported against this workspace's
+# Cargo.lock, with the crate count measured on 2026-08-15. Adding a licence
+# here is a decision that the workspace may redistribute under it. Removing a
+# crate never requires touching this file.
+#
+# WHAT IS DELIBERATELY ABSENT: GPL, AGPL, and LGPL in every version. Nothing in
+# the graph needs them once [graph].targets excludes UEFI (see above), so their
+# absence is enforcement rather than omission — the day a dependency introduces
+# one, this gate fails and a human decides, instead of the licence arriving
+# with a routine `cargo update`.
+[licenses]
+allow = [
+    # --- Permissive, no notable obligations beyond attribution.
+    "MIT",                          # 923 crates
+    "Apache-2.0",                   # 660 crates
+    "Apache-2.0 WITH LLVM-exception", # 12 — the Rust project's own dual-licence arm
+    "BSD-2-Clause",                 # 8
+    "BSD-3-Clause",                 # 21
+    "ISC",                          # 17
+    "0BSD",                         # 1
+    "Zlib",                         # 27
+    "BSL-1.0",                      # 2 — ryu, xxhash-rust (Boost, permissive)
+    "MIT-0",                        # 3
+    # NCSA is deliberately NOT here. `cargo deny list` reports it against
+    # libfuzzer-sys, which is a DEV-dependency and therefore outside the graph
+    # once `exclude-dev = true` applies. Listing it anyway produced a
+    # `license-not-encountered` warning — cargo-deny telling us the allow-list
+    # had drifted from the real graph. An allow-list entry that matches nothing
+    # is not harmless: it is a licence somebody approved without a dependency
+    # to approve it for, and it hides the day one actually appears.
+
+    # --- Public-domain dedications / equivalents.
+    "CC0-1.0",                      # 6
+    "Unlicense",                    # 13
+
+    # --- Data licences. Unicode tables, not code.
+    "Unicode-3.0",                  # 19
+    "Unicode-DFS-2016",             # 1
+    "CDLA-Permissive-2.0",          # 2 — webpki-roots, webpki-root-certs
+                                    #     (the Mozilla CA certificate set)
+
+    # --- Weak copyleft, FILE-scoped. MPL-2.0 obliges you to publish
+    #     modifications to the MPL-licensed FILES themselves; it creates no
+    #     obligation on a work that merely links them. This workspace uses all
+    #     nine unmodified, straight from crates.io, so the obligation never
+    #     attaches. If anyone ever vendors and patches one of these, that fork
+    #     must ship its source — re-read this line before doing so.
+    #     Crates: colored (x2), cssparser (x2), cssparser-macros, dtoa-short,
+    #             option-ext, selectors (x2).
+    "MPL-2.0",                      # 9
+]
+
+# A crate whose licence expression cargo-deny cannot resolve to a confident
+# match is a FAILURE, not a warning. 0.8 is cargo-deny's own recommended floor.
+confidence-threshold = 0.8
+
+# NO `[[licenses.exceptions]]` ROWS, AND NO `[licenses.private]` SKIP.
+#
+# The one crate in this workspace that reported `Unlicensed` was
+# `trusty-agents-ui` (crates/trusty-agents/ui/src-tauri/Cargo.toml) — a real
+# defect, not a policy question: it declared no `license` field at all, and no
+# `publish = false`, unlike its two sibling Tauri GUIs which declare both. The
+# remedy was to fix the manifest, not to add a row here teaching the gate to
+# accept an unlicensed crate. See that file and this PR's changelog fragment.
+#
+# `[licenses.private] ignore = true` would have hidden the same defect by
+# skipping every `publish = false` workspace member. It is deliberately not set:
+# a workspace member missing its licence is worth knowing about whether or not
+# that member is the one being uploaded today.
+
+# ---------------------------------------------------------------------------
+# [bans] — duplicate versions and dependency-declaration hygiene.
+#
+# multiple-versions IS "warn", DELIBERATELY, AND IT IS NOT THE WHOLE STORY.
+# Measured on 2026-08-15: 105 crates appear at more than one version in this
+# graph (base64 x3, derive_more x3, lru x3, and 102 others at x2). Setting this
+# to "deny" would require 105 `[[bans.skip]]` rows to pass today, and a
+# 105-row skip list is not a policy — it is a way of switching the check off
+# while appearing to run it.
+#
+# So the duplicate question is answered by a RATCHET instead, in the workflow:
+# `scripts/check_deny_duplicates.sh` parses this check's warning count and
+# fails when it exceeds the recorded baseline in
+# `scripts/deny-duplicate-baseline.txt`. That makes the number a one-way street
+# — a dependency bump that adds a third `foo` turns the gate red and has to be
+# justified — without demanding that 105 pre-existing duplicates be resolved
+# before the gate can ship at all. Lowering the baseline is always welcome and
+# never required.
+[bans]
+multiple-versions = "warn"
+# WILDCARDS ARE "warn" AND THAT IS A COMPROMISE, NOT A JUDGEMENT.
+#
+# Set to "deny" — which is what a publish gate wants, since crates.io rejects a
+# path dependency carrying no version — this check FAILS TODAY on a real defect:
+#
+#   error[wildcard]: found 1 wildcard dependency for crate 'trusty-agents'.
+#     crates/trusty-agents/Cargo.toml:34  trusty-code = { workspace = true }
+#
+# The root `[workspace.dependencies]` entry is `trusty-code = { path =
+# "crates/trusty-code" }` with NO `version` key, unlike every other internal
+# dependency trusty-agents declares (trusty-memory "0.23", trusty-search "0.47",
+# trusty-gworkspace "0.2.2", …). `cargo publish -p trusty-agents` would be
+# rejected outright: crates.io requires a version on every dependency. trusty-code
+# IS published, so the fix is one field on that root entry.
+#
+# It is left at "warn" here for one reason only: the root Cargo.toml is being
+# rewritten by a concurrent workstream, and a one-line edit landing in two PRs at
+# once is a conflict nobody needs. RAISE THIS TO "deny" once that lands and the
+# version field is added. The finding is recorded in this PR's body.
+wildcards = "warn"
+# Dev-dependency wildcards are exempt because they never reach a published
+# artifact and crates.io does not reject them.
+allow-wildcard-paths = true
+
+# ---------------------------------------------------------------------------
+# [advisories] — deliberately NARROW, because `cargo audit` owns this ground.
+#
+# The pre-publish workflow runs BOTH tools, and they read the same RustSec
+# database. Configuring both to fail on vulnerabilities would mean one finding
+# turns two gates red and a reader has to work out that it is one problem. So
+# the split is by question:
+#
+#   cargo audit  — "is anything vulnerable, unmaintained, or unsound?"
+#                  That is its whole job and it is the canonical RustSec
+#                  client. It reports 38 warnings today (all unmaintained /
+#                  unsound / yanked) and 0 vulnerabilities.
+#   cargo deny   — YANKED CRATES ONLY.
+#
+# WHY YANKED IS WORTH ITS OWN GATE HERE. A yanked dependency still resolves for
+# anyone whose lockfile already names it, but a NEW consumer of a crate we are
+# about to publish cannot resolve it at all — `cargo install trusty-x` on a
+# clean machine fails outright. That is a publish-blocking property of the
+# lockfile, distinct from "this code has a known bug", and it is the exact
+# question a pre-publish gate should ask.
+#
+# `spin` 0.9.8 is yanked in the current graph, so this check FAILS TODAY and
+# that is the correct behaviour — see this PR's report. It is set to "warn"
+# rather than "deny" ONLY because the yank is transitive and unfixable from
+# here; the workflow surfaces the count and the ratchet keeps it from growing.
+[advisories]
+yanked = "warn"
+# Vulnerabilities are cargo-audit's to report. Left at cargo-deny's default
+# "deny" they would double-report; there is no crate cargo-deny would catch
+# that cargo-audit misses, because both read the same database.
+unmaintained = "none"
+# `unsound` likewise. cargo-deny defaults it to "deny", which failed this check
+# on four advisories that cargo-audit already lists as warnings —
+# RUSTSEC-2026-0190 (anyhow `Error::downcast_mut`), RUSTSEC-2026-0183 and
+# RUSTSEC-2026-0184 (git2), RUSTSEC-2026-0253 (lru `LruCache::pop`). All four
+# are transitive, none has a patched version this workspace can move to, and
+# none is reachable from a code path trusty-* controls. A gate that is red on
+# every run for a reason nobody can act on is a gate people learn to skip, and
+# the cost of that is the yanked check below going unread too.
+#
+# "none" rather than "warn": this key takes the same scope enum as
+# `unmaintained` (all / workspace / transitive / none), not a lint level.
+# "workspace" was considered and rejected — `anyhow` is a direct dependency of
+# most crates here, so RUSTSEC-2026-0190 would keep the gate red under it, and
+# an always-red gate is an unread gate.
+unsound = "none"
+
+# ---------------------------------------------------------------------------
+# [sources] — provenance.
+#
+# Every dependency must come from crates.io. A git dependency or a private
+# registry in a published crate's graph is either an accident or a supply-chain
+# question, and either way it should stop a release rather than ship in one.
+# crates.io itself rejects git dependencies on publish, so — like the wildcard
+# ban above — this converts a failed upload into a failed gate.
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/scripts/check_deny_duplicates.sh
+++ b/scripts/check_deny_duplicates.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# check_deny_duplicates.sh — turn cargo-deny's duplicate-version WARNINGS into
+# a gate.
+#
+# Why: `cargo deny check bans` reports every crate that appears at more than one
+#   version, and with `multiple-versions = "warn"` it exits 0 while doing so.
+#   That is the right severity for this workspace — 83 crates are duplicated
+#   today, and 83 `[[bans.skip]]` rows would be a way of switching the check off
+#   while appearing to run it — but a warning nobody counts is a warning nobody
+#   reads. Duplicate versions cost compile time and binary size on every build,
+#   and they are how two copies of a transitive dependency end up at different
+#   patch levels with only one of them carrying a security fix.
+#
+# What: runs `cargo deny check bans`, counts the `duplicate` warnings, and
+#   compares that count against `scripts/deny-duplicate-baseline.txt`. Above the
+#   baseline is a failure; below it is a pass that says so and asks for the
+#   baseline to be lowered.
+#
+# WHY A COUNT AND NOT A LIST. A per-crate list would be more precise and would
+#   also be 83 rows that churn on every dependency bump, generating diff noise
+#   that reviewers learn to skim. The count is the number that matters for the
+#   ratchet, and `cargo deny check bans` prints the full list on every run for
+#   anyone who wants the detail.
+#
+# FAIL-CLOSED BEHAVIOUR:
+#   - cargo-deny exiting nonzero (a real ban, a wildcard, a parse error) FAILS,
+#     and is reported as itself rather than folded into the count.
+#   - Output with no parseable summary FAILS as a vacuous scan: zero duplicates
+#     found and zero examined must never print the same thing (#5620).
+#   - A missing baseline file FAILS rather than defaulting to a permissive
+#     number.
+#
+# Exit codes: 0 = at or below baseline. 1 = above baseline, or cargo-deny found
+#   a hard violation. 3 = the gate could not compute a verdict. 2 = usage.
+#
+# Test: verified by construction against real `cargo deny check bans` output at
+#   e39183c3 — 83 duplicates under the default feature set (PASS at baseline)
+#   and 117 under --all-features (FAIL, +34), which is how the ratchet's failing
+#   arm was exercised. `--from-output` accepts a captured file, which is the
+#   entry point a fixture-driven self-test would use; that self-test is NOT yet
+#   written.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+BASELINE_FILE="${REPO_ROOT}/scripts/deny-duplicate-baseline.txt"
+FROM_FILE=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --from-output) FROM_FILE="${2:-}"; shift 2 ;;
+    -h|--help)
+      grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "check_deny_duplicates: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ ! -f "$BASELINE_FILE" ]; then
+  echo "[FAIL] deny-duplicates: baseline file missing: ${BASELINE_FILE}" >&2
+  echo "       Refusing to default to a permissive number." >&2
+  exit 3
+fi
+
+BASELINE="$(grep -vE '^\s*(#|$)' "$BASELINE_FILE" | head -1 | tr -d '[:space:]')"
+if ! [[ "$BASELINE" =~ ^[0-9]+$ ]]; then
+  echo "[FAIL] deny-duplicates: baseline file does not contain a bare integer: '${BASELINE}'" >&2
+  exit 3
+fi
+
+TMP_OUT="$(mktemp "${TMPDIR:-/tmp}/deny-bans.XXXXXX")"
+trap 'rm -f "$TMP_OUT"' EXIT
+
+DENY_RC=0
+if [ -n "$FROM_FILE" ]; then
+  [ -f "$FROM_FILE" ] || { echo "check_deny_duplicates: no such file: $FROM_FILE" >&2; exit 2; }
+  cp "$FROM_FILE" "$TMP_OUT"
+else
+  # DEFAULT FEATURES, not --all-features. `--all-features` resolves a graph no
+  # artifact ever has: trusty-common's 45 features include mutually exclusive
+  # embedder backends (embedder-cuda / embedder-coreml / embedder-candle), so
+  # enabling them together produces duplicates that exist in no build anyone
+  # ships. Measured: 117 duplicated crates under --all-features against 83 under
+  # the default set, the extra 34 being candle/gemm/pulp copies from backends
+  # that are never on at the same time. Counting those would make the ratchet
+  # track an artifact nobody builds.
+  cargo deny check bans > "$TMP_OUT" 2>&1 || DENY_RC=$?
+fi
+
+# A hard violation (a banned crate, a wildcard requirement) is cargo-deny's own
+# failure and is reported as itself. Folding it into the duplicate count would
+# describe a wildcard dependency as "too many duplicate versions".
+if [ "$DENY_RC" -ne 0 ]; then
+  echo "[FAIL] deny-duplicates: 'cargo deny check bans' exited ${DENY_RC} — a hard" >&2
+  echo "       ban violation, not a duplicate-count question:" >&2
+  grep -E '^(error|warning)\[' "$TMP_OUT" | head -40 | sed 's/^/       /' >&2
+  exit 1
+fi
+
+COUNT="$(grep -cE '^warning\[duplicate\]' "$TMP_OUT" || true)"
+
+# Vacuous-scan refusal. cargo-deny always prints a trailing verdict line
+# ("bans ok" / "bans FAILED"); its absence means the output is not what this
+# parser was written against, and a zero count read off unrecognised output is
+# not a finding.
+if ! grep -qE '^bans (ok|FAILED)' "$TMP_OUT"; then
+  echo "[FAIL] deny-duplicates: could not find cargo-deny's 'bans ok'/'bans FAILED'" >&2
+  echo "       verdict line in the output. The format this parser expects has" >&2
+  echo "       changed, so a count of ${COUNT} is not trustworthy. Output:" >&2
+  tail -20 "$TMP_OUT" | sed 's/^/       /' >&2
+  exit 3
+fi
+
+if [ "$COUNT" -gt "$BASELINE" ]; then
+  echo "[FAIL] deny-duplicates: ${COUNT} duplicated crate(s), above the baseline of ${BASELINE}." >&2
+  echo "       A dependency change added $(( COUNT - BASELINE )) new duplicate version(s)." >&2
+  echo "       Either unify the versions, or raise the baseline in the same PR and" >&2
+  echo "       say why in the PR body. Full list:" >&2
+  grep -E '^warning\[duplicate\]' "$TMP_OUT" | sed 's/^/       /' >&2
+  exit 1
+fi
+
+if [ "$COUNT" -lt "$BASELINE" ]; then
+  echo "[PASS] deny-duplicates: ${COUNT} duplicated crate(s), below the baseline of ${BASELINE}." >&2
+  echo "       Lower the number in ${BASELINE_FILE} to lock the gain in." >&2
+  exit 0
+fi
+
+echo "[PASS] deny-duplicates: ${COUNT} duplicated crate(s), at the baseline." >&2
+exit 0

--- a/scripts/check_ignored_tests.sh
+++ b/scripts/check_ignored_tests.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+#
+# check_ignored_tests.sh — run the `#[ignore]`d tests that a publish depends on,
+# and account for every one it does not run.
+#
+# Why: no gate in this repo has ever executed an ignored test. `ci.yml`'s shard
+#   matrix says so in its own header ("ONNX-backed tests are #[ignore]-tagged;
+#   they are intentionally skipped here"), and nothing downstream picks them up.
+#   The ONNX/embedder tests among them are the ones that exercise the model
+#   loading path a published daemon runs on a user's machine at first start — so
+#   the code most likely to break a fresh install is the code with the least
+#   coverage before an irreversible upload.
+#
+# What: two halves that only make sense together.
+#
+#   THE RUN. `scripts/prepublish-ignored-tests.tsv` names the ignored tests this
+#     gate executes — the ones that need nothing a hosted Linux runner cannot
+#     provide (a HuggingFace download, and the model cache the workflow warms
+#     before this step). It builds a nextest filterset from those rows and runs
+#     them with `--run-ignored all`.
+#
+#   THE ACCOUNTING. Selecting a subset is a claim about the rest, and an
+#     unexamined claim is how #5620 happened: a gate that runs 15 of 442 ignored
+#     tests and prints a green tick has said nothing about 427 of them while
+#     looking like it has. So this enumerates EVERY ignored test in the
+#     workspace, subtracts the ones it ran, and holds the remainder against a
+#     recorded baseline. The number is printed on every run, in full, grouped by
+#     crate.
+#
+#   WHY A RATCHET AND NOT A COMPLETE MANIFEST. 442 ignored tests, 321 of them
+#     carrying no reason string at all, is not a backlog one PR classifies — and
+#     a gate that demands 442 justifications before it can pass would not ship.
+#     The baseline makes the number VISIBLE and ONE-WAY: adding an ignored test
+#     without classifying it turns this red. Lowering the baseline is always
+#     welcome. This is the same shape as scripts/rustdoc-link-baseline.tsv and
+#     the SLOC ratchet allowlist, for the same reason.
+#
+# WHAT THIS GATE DOES NOT CLAIM. It does not claim the unselected ignored tests
+#   pass, and it never prints a line that could be read that way. Its summary
+#   states both numbers — ran N, did not run M — because "0 failed" and
+#   "0 examined" being printed with the same word is the defect this repo has
+#   now been bitten by twice (#5620, #5723).
+#
+# FAIL-CLOSED BEHAVIOUR:
+#   - A RUN row that matches ZERO tests FAILS. A renamed or deleted test would
+#     otherwise silently shrink the gate while every row still looked present —
+#     the stale-manifest failure mode, and the reason this is not just a
+#     hand-written `-E` string in the workflow.
+#   - An enumeration that lists zero ignored tests FAILS as a vacuous scan.
+#   - An unselected count above the baseline FAILS.
+#   - A nextest invocation that errors FAILS; a zero exit is never inferred.
+#
+# Exit codes: 0 = every selected test passed and the unselected count is at or
+#   below baseline. 1 = a selected test failed, or the unselected count grew.
+#   3 = the gate could not compute a verdict (vacuous enumeration, stale row,
+#     nextest failure). 2 = usage error.
+#
+# Test: verified by construction against a real `cargo nextest list` stream
+#   captured at e39183c3 (218 suites, 160 ignored tests) via `--from-list`,
+#   which is the entry point a fixture-driven self-test would use. That run
+#   confirmed 11 selected, 149 unselected, and every manifest row matching.
+#   A self-test covering the STALE-ROW and VACUOUS branches is NOT yet written.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: scripts/check_ignored_tests.sh [--list-only] [--from-list <file>]" >&2
+  echo "       --list-only        enumerate and reconcile; do not run any test" >&2
+  echo "       --from-list <file> score a captured 'cargo nextest list" >&2
+  echo "                          --message-format json' stream (self-test)" >&2
+  exit 2
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+MANIFEST="${REPO_ROOT}/scripts/prepublish-ignored-tests.tsv"
+LIST_ONLY=0
+FROM_LIST=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --list-only) LIST_ONLY=1; shift ;;
+    --from-list) FROM_LIST="${2:-}"; [ -n "$FROM_LIST" ] || usage; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "check_ignored_tests: unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+[ -f "$MANIFEST" ] || {
+  echo "[FAIL] ignored-tests: manifest missing: ${MANIFEST}" >&2
+  exit 3
+}
+
+EXCLUDES=(--exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui)
+
+TMP_LIST="$(mktemp "${TMPDIR:-/tmp}/ignored-tests.list.XXXXXX")"
+TMP_SEL="$(mktemp "${TMPDIR:-/tmp}/ignored-tests.sel.XXXXXX")"
+trap 'rm -f "$TMP_LIST" "$TMP_SEL"' EXIT
+
+# ---------------------------------------------------------------------------
+# STEP 1 — enumerate every ignored test in the workspace.
+# ---------------------------------------------------------------------------
+if [ -n "$FROM_LIST" ]; then
+  [ -f "$FROM_LIST" ] || { echo "check_ignored_tests: no such file: $FROM_LIST" >&2; exit 2; }
+  cp "$FROM_LIST" "$TMP_LIST"
+else
+  echo "==> enumerating ignored tests (cargo nextest list --run-ignored ignored-only)" >&2
+  rc=0
+  SKIP_UI_BUILD=1 cargo nextest list --workspace --locked "${EXCLUDES[@]}" \
+    --run-ignored ignored-only --message-format json > "$TMP_LIST" 2>/dev/null || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "[FAIL] ignored-tests: 'cargo nextest list' exited ${rc} — the gate enumerated nothing." >&2
+    echo "       A zero count from a failed enumeration is not a finding. Fix the build and re-run." >&2
+    exit 3
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# STEP 2 — reconcile the enumeration against the manifest.
+# Emits the nextest filterset for step 3 on fd 3 (TMP_SEL).
+# ---------------------------------------------------------------------------
+RECONCILE_RC=0
+python3 - "$TMP_LIST" "$MANIFEST" "$TMP_SEL" <<'PY' || RECONCILE_RC=$?
+import json, sys, collections, os, re
+
+list_path, manifest_path, sel_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+# --- Parse the manifest. Rows: <package>\t<exact test name>\t<why it is safe>
+rows, baseline = [], None
+with open(manifest_path) as fh:
+    for line in fh:
+        line = line.rstrip("\n")
+        if line.startswith("# UNSELECTED-BASELINE:"):
+            baseline = int(line.split(":", 1)[1].strip())
+            continue
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        rows.append((parts[0].strip(), parts[1].strip(), parts[2].strip()))
+
+if baseline is None:
+    print("FAIL\tMANIFEST\tno '# UNSELECTED-BASELINE: <n>' line in the manifest — "
+          "the gate cannot tell whether the unselected set grew")
+    sys.exit(3)
+
+# --- Parse the nextest enumeration.
+all_tests = []   # (package, test-name)
+with open(list_path) as fh:
+    data = fh.read().strip()
+try:
+    doc = json.loads(data)
+except json.JSONDecodeError:
+    print("FAIL\tENUMERATION\tcould not parse the nextest list output as JSON")
+    sys.exit(3)
+
+for _bin_id, binfo in (doc.get("rust-suites") or {}).items():
+    pkg = binfo.get("package-name") or ""
+    for tname, tinfo in (binfo.get("testcases") or {}).items():
+        # `ignored-only` already filtered, but assert rather than assume.
+        if tinfo.get("ignored") is False:
+            continue
+        all_tests.append((pkg, tname))
+
+if not all_tests:
+    print("FAIL\tVACUOUS\tthe enumeration listed ZERO ignored tests — "
+          "either the filter is wrong or nothing was built; both mean this gate examined nothing")
+    sys.exit(3)
+
+# --- Match manifest rows against the enumeration.
+selected, stale = set(), []
+for pkg, pattern, _why in rows:
+    hits = [(p, t) for (p, t) in all_tests if p == pkg and re.fullmatch(pattern, t)]
+    if not hits:
+        stale.append(f"{pkg}\t{pattern}")
+        continue
+    selected.update(hits)
+
+unselected = [t for t in all_tests if t not in selected]
+by_crate = collections.Counter(p for p, _ in unselected)
+
+print(f"SUMMARY\t{len(all_tests)} ignored test(s) in the workspace; "
+      f"{len(selected)} selected to RUN; {len(unselected)} NOT run "
+      f"(baseline {baseline})")
+for crate, n in sorted(by_crate.items(), key=lambda kv: -kv[1]):
+    print(f"UNSELECTED\t{crate}\t{n}")
+
+failed = False
+
+# FAIL CLOSED: a row that selects nothing is a manifest that has drifted from
+# the tree. Left unreported it shrinks the gate invisibly.
+for s in stale:
+    print(f"FAIL\tSTALE-ROW\t{s} matched no ignored test — renamed, deleted, or "
+          "no longer #[ignore]d. Fix or remove the row.")
+    failed = True
+
+if len(unselected) > baseline:
+    print(f"FAIL\tRATCHET\t{len(unselected)} ignored test(s) are not run by this "
+          f"gate, above the recorded baseline of {baseline}. Either add the new "
+          "test to the manifest so the gate runs it, or raise the baseline in "
+          "the same PR and say why in the PR body.")
+    failed = True
+elif len(unselected) < baseline:
+    print(f"NOTE\tIMPROVED\t{len(unselected)} unselected vs baseline {baseline} "
+          "— lower '# UNSELECTED-BASELINE:' in the manifest to lock the gain in")
+
+# --- Emit the nextest filterset for the run phase.
+with open(sel_path, "w") as fh:
+    if selected:
+        # nextest filterset syntax: `test(=<exact name>)` is an exact match,
+        # scoped to the owning package so two crates with same-named tests
+        # cannot select each other's.
+        expr = " + ".join(f"(package({p}) and test(={t}))" for p, t in sorted(selected))
+        fh.write(expr)
+
+sys.exit(3 if stale else (1 if failed else 0))
+PY
+
+if [ "$RECONCILE_RC" -ne 0 ]; then
+  echo "[FAIL] ignored-tests: reconciliation refused (exit ${RECONCILE_RC}) — see the FAIL lines above." >&2
+  exit "$RECONCILE_RC"
+fi
+
+if [ "$LIST_ONLY" -eq 1 ] || [ -n "$FROM_LIST" ]; then
+  echo "[PASS] ignored-tests: reconciliation only (--list-only); no test was executed." >&2
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# STEP 3 — run the selected tests.
+# ---------------------------------------------------------------------------
+EXPR="$(cat "$TMP_SEL")"
+if [ -z "$EXPR" ]; then
+  echo "[FAIL] ignored-tests: the manifest selected no tests at all — nothing would run." >&2
+  exit 3
+fi
+
+echo "==> running $(grep -c 'package(' <<<"${EXPR//+/$'\n'}") selected ignored test(s)" >&2
+rc=0
+SKIP_UI_BUILD=1 cargo nextest run --workspace --locked "${EXCLUDES[@]}" \
+  --run-ignored all --no-fail-fast -E "$EXPR" || rc=$?
+
+if [ "$rc" -ne 0 ]; then
+  echo "[FAIL] ignored-tests: a selected ignored test failed (nextest exit ${rc})." >&2
+  exit 1
+fi
+
+echo "[PASS] ignored-tests: every selected ignored test passed." >&2
+exit 0

--- a/scripts/check_rustdoc_links.sh
+++ b/scripts/check_rustdoc_links.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+#
+# check_rustdoc_links.sh — broken intra-doc link gate for the publish path.
+#
+# Why: rustdoc renders `[`Foo`]` in a doc comment as a hyperlink when `Foo`
+#   resolves and as dead literal text when it does not. docs.rs builds the
+#   documentation for a crates.io release ONCE, from the uploaded tarball, and
+#   never rebuilds it. So a broken link is not a bug that a later commit fixes —
+#   it is baked into that version's published documentation forever, and the
+#   only remedy is to publish a new version. Nothing in this repo checked for
+#   them before this gate: `cargo doc` was absent from every workflow.
+#
+#   Measured on 2026-08-15 at e39183c3: 852 broken links across 16 of the 24
+#   documented crates, including trusty-common (200), trusty-mpm (256),
+#   trusty-code (125) and trusty-search (29) — all of which publish.
+#
+# What: runs `cargo doc --workspace --no-deps` with
+#   `-D rustdoc::broken_intra_doc_links`, reads the diagnostics as STRUCTURED
+#   JSON (never as scraped terminal text — see PARSING below), attributes each
+#   one to the crate directory that owns the span, and compares the per-crate
+#   totals against the recorded baseline in
+#   `scripts/rustdoc-link-baseline.tsv`.
+#
+#   It is a RATCHET, not a clean-tree assertion. Fixing 852 links is not
+#   something one PR does, and a gate that cannot pass is a gate that gets
+#   switched off. So the baseline records where each crate stands today, the
+#   gate fails when any crate gets WORSE, and lowering a baseline row is always
+#   welcome and never demanded. A crate absent from the baseline must have ZERO,
+#   which is what stops the ratchet from being a way to add new debt.
+#
+# PARSING: `--message-format json`, deliberately.
+#   The first draft of this gate scraped `error:` / `-->` lines out of cargo's
+#   human output with awk. Cross-checked against the JSON, that parser found 458
+#   of the 852 real diagnostics — it silently dropped 46% of them, because a
+#   rustdoc diagnostic block does not have the one-error-one-arrow shape the awk
+#   assumed. A gate that under-reports by half while exiting 0 is precisely the
+#   #5620 failure this repo has been bitten by twice. The JSON stream attributes
+#   every diagnostic to a span with no heuristics; the checker below asserts
+#   that it accounted for every one it saw.
+#
+# FAIL-CLOSED BEHAVIOUR. Five distinct ways this refuses to report success:
+#   1. A non-lint compile error (the crate does not build) FAILS, and says so
+#      separately from a link count — "your docs are fine" is not a thing to say
+#      about a crate that did not compile.
+#   2. A run that parsed ZERO compiler messages while cargo exited nonzero FAILS
+#      as a vacuous scan. Zero findings and zero examined are different facts.
+#   3. A crate that cargo never documented FAILS, even though its count is 0.
+#      An absent crate's zero is not evidence about its links; this is the
+#      "0 compared must never print PASS" invariant CHECK 5 of
+#      preflight-publish.sh learned the hard way.
+#   4. A diagnostic whose span this script cannot attribute to a crate FAILS
+#      rather than being dropped.
+#   5. A crate with findings but no baseline row FAILS.
+#
+# Exit codes: 0 = at or below baseline for every crate. 1 = a crate regressed,
+#   or an unbaselined crate has findings. 3 = the gate could not compute a
+#   verdict (build failure, vacuous scan, unattributable span, missing crate) —
+#   distinguished from 1 so a caller can tell "your links got worse" from
+#   "nothing was checked", the distinction #5289 added to the semver gate.
+#   2 = usage error.
+#
+# Test: verified by construction against the real workspace at e39183c3 —
+#   `--json` accepts a captured cargo stream, which is how the parser was
+#   cross-checked (852 diagnostics attributed, 0 unattributable) and how the
+#   NOT-DOCUMENTED branch was caught firing wrongly on crates whose doc build
+#   FAILED and therefore emit no `compiler-artifact`. A fixture-driven self-test
+#   covering the remaining fail-closed branches is NOT yet written; the `--json`
+#   entry point exists so one can be added without a doc build.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: scripts/check_rustdoc_links.sh [--update-baseline] [--json <file>]" >&2
+  echo "       --update-baseline   rewrite the baseline from this run's counts" >&2
+  echo "       --json <file>       score a previously captured JSON stream" >&2
+  echo "                           instead of running cargo doc (used by the" >&2
+  echo "                           self-test)" >&2
+  exit 2
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+BASELINE="${REPO_ROOT}/scripts/rustdoc-link-baseline.tsv"
+UPDATE=0
+JSON_IN=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --update-baseline) UPDATE=1; shift ;;
+    --json) JSON_IN="${2:-}"; [ -n "$JSON_IN" ] || usage; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "check_rustdoc_links: unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+# The three Tauri GUI crates are excluded for the same reason every other
+# workspace-wide job in this repo excludes them: they need WebKit2GTK, which no
+# headless CI runner has. They are not published to crates.io, so they have no
+# docs.rs page for a broken link to land on.
+EXCLUDES=(--exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui)
+
+TMP_JSON="$(mktemp "${TMPDIR:-/tmp}/rustdoc-links.json.XXXXXX")"
+TMP_ERR="$(mktemp "${TMPDIR:-/tmp}/rustdoc-links.err.XXXXXX")"
+trap 'rm -f "$TMP_JSON" "$TMP_ERR"' EXIT
+
+if [ -n "$JSON_IN" ]; then
+  [ -f "$JSON_IN" ] || { echo "check_rustdoc_links: no such file: $JSON_IN" >&2; exit 2; }
+  cp "$JSON_IN" "$TMP_JSON"
+  : > "$TMP_ERR"
+  CARGO_RC=0
+else
+  # --keep-going is what makes the inventory complete. Without it cargo stops at
+  # the first crate whose docs fail, and the run reports only the crates it
+  # happened to reach: the same command without it documented 4 of 24 crates and
+  # found 152 of the 852 real findings. A gate that stops early does not
+  # under-report politely — it reports a number that looks like an answer.
+  CARGO_RC=0
+  SKIP_UI_BUILD=1 RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" \
+    cargo doc --workspace --no-deps --locked --keep-going \
+      --message-format json "${EXCLUDES[@]}" \
+      > "$TMP_JSON" 2> "$TMP_ERR" || CARGO_RC=$?
+fi
+
+# Every decision below is made by this Python block over the JSON stream. It
+# prints a machine-readable report on stdout that the shell then renders.
+python3 - "$TMP_JSON" "$BASELINE" "$UPDATE" "$CARGO_RC" <<'PY'
+import json, sys, collections, os
+
+json_path, baseline_path, update, cargo_rc = sys.argv[1], sys.argv[2], sys.argv[3] == "1", int(sys.argv[4])
+
+HEADER = """# Per-crate broken intra-doc link baseline (scripts/check_rustdoc_links.sh).
+#
+# A RATCHET, not a target. Each row records how many broken links a crate has
+# today; the gate fails when a crate exceeds its row, when a crate with no row
+# has any at all, or when a crate that has a row was never documented.
+#
+# LOWERING A ROW IS ALWAYS WELCOME AND NEVER REQUIRED. Fix links in the PR that
+# touches the file anyway, then run:
+#     bash scripts/check_rustdoc_links.sh --update-baseline
+# Deleting a row entirely is the goal state for every crate here.
+#
+# RAISING A ROW IS A REVIEW DECISION, not a way to make a red gate green. A
+# broken link on docs.rs cannot be fixed without publishing a new version, so
+# the cost of letting one through is a wasted version number.
+#
+# Regenerate with: bash scripts/check_rustdoc_links.sh --update-baseline
+# Format (tab-separated):  <crate-directory>\t<broken-link-count>
+"""
+
+counts = collections.Counter()
+documented = set()
+hard_errors = []       # non-lint errors: the crate did not build
+unattributable = []    # a diagnostic this script could not place
+parsed_messages = 0
+
+LINT_PREFIXES = ("unresolved link to", "public documentation for")
+
+def crate_of(path):
+    parts = path.split("/")
+    if path.startswith("crates/") and len(parts) > 2:
+        return parts[1]
+    return None
+
+with open(json_path) as fh:
+    for line in fh:
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            m = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        reason = m.get("reason")
+
+        # Which crates cargo actually documented. Used for the fail-closed
+        # "a crate we never built cannot be reported as clean" check.
+        if reason == "compiler-artifact":
+            tgt = (m.get("target") or {})
+            name = tgt.get("name")
+            src = tgt.get("src_path") or ""
+            c = crate_of(os.path.relpath(src, os.getcwd())) if src.startswith("/") else crate_of(src)
+            if c:
+                documented.add(c)
+            continue
+
+        if reason != "compiler-message":
+            continue
+        msg = m.get("message") or {}
+        if msg.get("level") != "error":
+            continue
+        text = msg.get("message") or ""
+
+        # `could not document X` is cargo's roll-up of the per-link errors it
+        # already emitted. Counting it would double-count the crate.
+        if text.startswith("could not document"):
+            continue
+
+        parsed_messages += 1
+        spans = msg.get("spans") or []
+        primary = [s for s in spans if s.get("is_primary")] or spans
+        if not primary:
+            unattributable.append(text)
+            continue
+        crate = crate_of(primary[0]["file_name"])
+        if crate is None:
+            unattributable.append(f'{text} @ {primary[0]["file_name"]}')
+            continue
+
+        # A rustdoc lint error names the broken link; anything else at error
+        # level means the crate genuinely failed to compile, which is a
+        # different failure and must not be scored as a link count.
+        code = ((msg.get("code") or {}) or {}).get("code") or ""
+        is_link_lint = (
+            code.startswith("rustdoc::")
+            or text.startswith(LINT_PREFIXES)
+            or " is both " in text          # ambiguous intra-doc link
+            or "no item named" in text
+        )
+        if is_link_lint:
+            counts[crate] += 1
+        else:
+            hard_errors.append(f"{crate}: {text}")
+
+report = {
+    "counts": dict(counts),
+    "documented": sorted(documented),
+    "hard_errors": hard_errors,
+    "unattributable": unattributable,
+    "parsed_messages": parsed_messages,
+    "cargo_rc": cargo_rc,
+}
+
+# ---- Baseline I/O -------------------------------------------------------
+baseline = {}
+if os.path.exists(baseline_path):
+    with open(baseline_path) as fh:
+        for line in fh:
+            line = line.rstrip("\n")
+            if not line or line.lstrip().startswith("#"):
+                continue
+            parts = line.split("\t")
+            if len(parts) < 2:
+                continue
+            try:
+                baseline[parts[0]] = int(parts[1])
+            except ValueError:
+                continue
+
+if update:
+    with open(baseline_path, "w") as fh:
+        fh.write(HEADER)
+        for crate in sorted(counts):
+            fh.write(f"{crate}\t{counts[crate]}\n")
+    print(f"BASELINE-UPDATED\t{len(counts)}")
+    sys.exit(0)
+
+failures, notes = [], []
+
+# ---- FAIL CLOSED 1: the crate did not build ----------------------------
+if hard_errors:
+    for e in hard_errors[:20]:
+        failures.append(f"BUILD-ERROR\t{e}")
+
+# ---- FAIL CLOSED 2: vacuous scan ---------------------------------------
+if parsed_messages == 0 and cargo_rc != 0:
+    failures.append(
+        "VACUOUS-SCAN\tcargo doc exited "
+        f"{cargo_rc} but this gate parsed ZERO diagnostics — it examined nothing"
+    )
+
+# ---- FAIL CLOSED 4: unattributable diagnostics -------------------------
+for u in unattributable[:20]:
+    failures.append(f"UNATTRIBUTABLE\t{u}")
+
+# ---- FAIL CLOSED 3: a baselined crate cargo never examined -------------
+# A crate counts as EXAMINED if rustdoc produced an artifact for it OR emitted
+# a diagnostic against it. The second arm is not redundant: a crate whose doc
+# build FAILS emits no `compiler-artifact` message at all, so an artifact-only
+# test would report the crates with findings as un-examined — which is exactly
+# backwards, and is what the first draft of this check did.
+examined = documented | set(counts)
+for crate in sorted(baseline):
+    if crate not in examined:
+        failures.append(
+            f"NOT-DOCUMENTED\t{crate} has a baseline row but cargo never "
+            "documented it — its zero findings are not evidence"
+        )
+
+# ---- FAIL CLOSED 5 + the ratchet itself --------------------------------
+for crate in sorted(counts):
+    have = counts[crate]
+    if crate not in baseline:
+        failures.append(
+            f"UNBASELINED\t{crate} has {have} broken link(s) and no baseline "
+            "row — a crate not in the baseline must have zero"
+        )
+    elif have > baseline[crate]:
+        failures.append(
+            f"REGRESSED\t{crate}: {have} broken link(s), baseline "
+            f"{baseline[crate]} (+{have - baseline[crate]})"
+        )
+    elif have < baseline[crate]:
+        notes.append(
+            f"IMPROVED\t{crate}: {have} broken link(s), baseline "
+            f"{baseline[crate]} (-{baseline[crate] - have}) — lower the "
+            "baseline row to lock the gain in"
+        )
+
+for crate in sorted(baseline):
+    if crate not in counts and crate in examined and baseline[crate] > 0:
+        notes.append(
+            f"IMPROVED\t{crate}: 0 broken links, baseline {baseline[crate]} "
+            "— remove the baseline row to lock the gain in"
+        )
+
+total = sum(counts.values())
+base_total = sum(baseline.values())
+print(f"SUMMARY\t{len(documented)} crate(s) documented, {total} broken link(s), "
+      f"baseline {base_total}, {parsed_messages} diagnostic(s) examined")
+for n in notes:
+    print(f"NOTE\t{n}")
+for f in failures:
+    print(f"FAIL\t{f}")
+
+if any(f.startswith(("BUILD-ERROR", "VACUOUS-SCAN", "UNATTRIBUTABLE", "NOT-DOCUMENTED")) for f in failures):
+    sys.exit(3)
+sys.exit(1 if failures else 0)
+PY

--- a/scripts/deny-duplicate-baseline.txt
+++ b/scripts/deny-duplicate-baseline.txt
@@ -1,0 +1,19 @@
+# Duplicate-version ratchet baseline for scripts/check_deny_duplicates.sh.
+#
+# The number below is how many crates appear at more than one version in this
+# workspace's dependency graph, as counted by `cargo deny check bans` with the
+# policy in deny.toml. Measured 2026-08-15 at e39183c3, with the default feature set (NOT --all-features).
+#
+# The gate FAILS when the live count exceeds this number, so a dependency bump
+# that introduces a new duplicate has to be noticed and justified. It PASSES and
+# asks you to lower this number when the count drops.
+#
+# LOWERING IT IS ALWAYS WELCOME. Raising it is a review decision that belongs in
+# the PR body, not a quiet edit.
+#
+# The three worst offenders today are base64, derive_more and lru, each at three
+# versions. `cargo deny check bans` prints the full list and the dependency path
+# to every copy.
+#
+# One bare integer, first non-comment line:
+83

--- a/scripts/preflight-publish.sh
+++ b/scripts/preflight-publish.sh
@@ -17,7 +17,7 @@
 #   absolute stop.
 #
 # What: given a crate (by package name or crates/ directory name) and,
-#   optionally, an explicit version, runs SEVEN independent checks and exits
+#   optionally, an explicit version, runs EIGHT independent checks and exits
 #   nonzero if any of them fail:
 #
 #   CHECK 1 (merged-main): after `git fetch origin main`, current HEAD's
@@ -153,6 +153,38 @@
 #     No override flag. The remedy is one command:
 #     `make -C crates/<crate> release-prep` then commit the regenerated bundle.
 #
+#   CHECK 8 (the pre-publish gate ran and was green for THIS commit):
+#     queries the GitHub Actions API for a `Pre-publish gate` workflow run whose
+#     head SHA is the commit about to be published, and requires one to have
+#     concluded `success`.
+#
+#     WHY A LOCAL SCRIPT HAS TO ASK THIS. `.github/workflows/pre-publish.yml`
+#     runs `cargo doc` (broken intra-doc links), `cargo audit`, `cargo deny`, the
+#     `#[ignore]`d ONNX/embedder tests and the Code Contracts gates. Every one of
+#     them guards something a publish makes permanent. But `cargo publish` runs
+#     on a laptop, and a red workflow cannot reach out and stop it — which is
+#     exactly the reasoning that put CHECK 5 in this script rather than leaving
+#     SemVer to CI. A gate nobody is required to consult is a gate that gets
+#     consulted right up until the release that matters.
+#
+#     IT FAILS CLOSED, and the two failing states are DIFFERENT FACTS reported
+#     differently. No run at all for this SHA is [FAIL] "never ran" — not a
+#     pass, because "we did not check" and "we checked and it was fine" are the
+#     conflation this repo has been bitten by twice (#5620, #5723). A run that
+#     exists and concluded anything other than success is [FAIL] "red gate".
+#     An unreachable API is [FAIL] too: an answer this check could not obtain is
+#     not a green one.
+#
+#     THE OVERRIDE TAKES A REASON, NEVER A BOOLEAN, matching
+#     PREFLIGHT_SEMVER_UNVERIFIED:
+#
+#         PREFLIGHT_GATE_UNVERIFIED="pre-publish gate has never run against this
+#                                    tag; dispatched manually and reviewed by hand"
+#
+#     echoed verbatim into a [WARN] line and into the final summary. `=1` records
+#     that a publish bypassed the gate without recording why, and why is the
+#     whole content of the disclosure.
+#
 # Crate + version resolution: accepts EITHER
 #     scripts/preflight-publish.sh <crate-name-or-dir> [version]
 #   or, when [version] is omitted, reads the version from that crate's
@@ -167,7 +199,7 @@
 #   check-publish-ready.sh does, to avoid a second, divergent lookup
 #   convention in this workspace.
 #
-#   --check-only     run all 7 checks unconditionally (never short-circuits)
+#   --check-only     run all 8 checks unconditionally (never short-circuits)
 #                     and print one [PASS]/[FAIL] line per check, then a
 #                     one-line summary. Useful to preview status without
 #                     assuming you are mid-publish. Exit code is still
@@ -770,6 +802,97 @@ check7_ui_bundle() {
   return 1
 }
 
+# ===========================================================================
+# CHECK 8 — the pre-publish gate ran, and was green, for this exact commit
+# ===========================================================================
+# Delegated to `gh` rather than curl because the Actions API needs
+# authentication and `gh` already holds the credential CHECK 2 just validated.
+#
+# The SHA compared is HEAD, which CHECK 1 has already established is
+# origin/main (or has WARNed that it is not). Asking about a different commit
+# than the one being published would make this check decorative.
+GATE_NOT_VERIFIED=""
+
+check8_prepublish_gate() {
+  local sha runs count green rc=0
+
+  if ! command -v gh >/dev/null 2>&1; then
+    gate_unverified "the 'gh' CLI is not installed, so the gate's status could not be read"
+    return $?
+  fi
+
+  sha="$(git rev-parse HEAD)"
+
+  # `|| rc=$?` rather than a bare call: a network failure must reach the
+  # unverified path below, not abort the script under `set -e`.
+  runs="$(gh api "repos/bobmatnyc/trusty-tools/actions/runs?head_sha=${sha}&per_page=100" \
+    --jq '[.workflow_runs[] | select(.name == "Pre-publish gate")
+           | {conclusion, status, html_url}]' 2>/dev/null)" || rc=$?
+
+  if [ "$rc" -ne 0 ] || [ -z "$runs" ]; then
+    gate_unverified "the GitHub Actions API could not be reached (gh exited ${rc})"
+    return $?
+  fi
+
+  count="$(printf '%s' "$runs" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null || echo 0)"
+  if [ "$count" -eq 0 ]; then
+    echo "[FAIL] prepublish-gate: NO 'Pre-publish gate' run exists for ${sha}." >&2
+    echo "       The broken-link, cargo-audit, cargo-deny, ignored-test and contract" >&2
+    echo "       gates have never executed against this tree. That is not the same" >&2
+    echo "       as them passing, and this script will not treat it as such." >&2
+    echo "       Remedy — dispatch it against this commit and wait for it:" >&2
+    echo "         gh workflow run pre-publish.yml --ref \$(git rev-parse --abbrev-ref HEAD)" >&2
+    echo "       If it genuinely cannot run for this release, record why:" >&2
+    echo "         PREFLIGHT_GATE_UNVERIFIED=\"<why>\" scripts/preflight-publish.sh ${PKG_NAME}" >&2
+    return 1
+  fi
+
+  green="$(printf '%s' "$runs" \
+    | python3 -c 'import json,sys; d=json.load(sys.stdin); print(sum(1 for r in d if r.get("status")=="completed" and r.get("conclusion")=="success"))' 2>/dev/null || echo 0)"
+
+  if [ "$green" -ge 1 ]; then
+    echo "[PASS] prepublish-gate: ${green} green 'Pre-publish gate' run(s) for ${sha}." >&2
+    return 0
+  fi
+
+  echo "[FAIL] prepublish-gate: 'Pre-publish gate' has run for ${sha} but NO run" >&2
+  echo "       concluded 'success':" >&2
+  printf '%s\n' "$runs" | sed 's/^/       /' >&2
+  echo "       Publishing over a red release gate is the CHECK 5 mistake in a new" >&2
+  echo "       place: the gate ran, said no, and the upload happened anyway." >&2
+  echo "       Fix what it found and re-run it. A still-running gate is not a" >&2
+  echo "       green one — wait for it." >&2
+  return 1
+}
+
+# gate_unverified <why> — the gate's status could not be READ (no gh, no
+# network). Distinct from a red gate and from an absent one: those are answers,
+# this is the absence of one. Permitted only with a recorded reason, on the same
+# terms as PREFLIGHT_SEMVER_UNVERIFIED.
+gate_unverified() {
+  local why="$1"
+  if [ -n "${PREFLIGHT_GATE_UNVERIFIED+x}" ]; then
+    if [ -z "$(printf '%s' "${PREFLIGHT_GATE_UNVERIFIED}" | tr -d '[:space:]')" ]; then
+      echo "[FAIL] prepublish-gate: PREFLIGHT_GATE_UNVERIFIED is set but empty." >&2
+      echo "       This override records WHY a publish skipped the release gate, so" >&2
+      echo "       it takes a reason, not a flag." >&2
+      return 1
+    fi
+    GATE_NOT_VERIFIED="pre-publish gate NOT consulted — ${PREFLIGHT_GATE_UNVERIFIED}"
+    echo "[WARN] prepublish-gate: UNVERIFIED — ${why}." >&2
+    echo "       Reason given: ${PREFLIGHT_GATE_UNVERIFIED}" >&2
+    echo "       Nothing confirmed the broken-link, audit, deny, ignored-test or" >&2
+    echo "       contract gates ran against this commit." >&2
+    return 0
+  fi
+  echo "[FAIL] prepublish-gate: could not determine whether the release gate passed —" >&2
+  echo "       ${why}." >&2
+  echo "       An answer this check could not obtain is not a green one." >&2
+  echo "       If this release must proceed anyway, record why:" >&2
+  echo "         PREFLIGHT_GATE_UNVERIFIED=\"<why>\" scripts/preflight-publish.sh ${PKG_NAME}" >&2
+  return 1
+}
+
 # ---------------------------------------------------------------------------
 # Scratch temp file for check 4's curl response body. Created once up front
 # and cleaned up via a script-scoped EXIT trap (matches check_line_cap.sh's
@@ -782,7 +905,7 @@ TMP_UIBUNDLE="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.uibundle.XXXXXX")"
 trap 'rm -f "$TMP_BODY" "$TMP_SEMVER" "$TMP_PARITY" "$TMP_UIBUNDLE"' EXIT
 
 # ---------------------------------------------------------------------------
-# Run all 7 checks. Always run every check (rather than short-circuiting) so
+# Run all 8 checks. Always run every check (rather than short-circuiting) so
 # --check-only and normal mode share one code path and a single run always
 # reports the full picture — a partial preflight is how gaps get missed.
 # ---------------------------------------------------------------------------
@@ -794,6 +917,7 @@ check4_version_not_live; [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check5_semver;           [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check6_tag_parity;       [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check7_ui_bundle;        [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
+check8_prepublish_gate;  [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 set -e
 
 if [ "$FAILURES" -gt 0 ]; then
@@ -805,10 +929,15 @@ if [ -n "${SEMVER_NOT_VERIFIED:-}" ]; then
   # #5620: "passed all 7 checks" must not absorb a check-5 outcome that verified
   # nothing. The same distinction the check line draws, drawn again at the line
   # an operator is most likely to read on its own.
-  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 7 checks, but the" >&2
+  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 8 checks, but the" >&2
   echo "  public API was NOT VERIFIED: ${SEMVER_NOT_VERIFIED}. See the check 5 line above." >&2
 else
-  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 7 checks. Safe to publish." >&2
+  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 8 checks. Safe to publish." >&2
+fi
+if [ -n "${GATE_NOT_VERIFIED:-}" ]; then
+  # Same reasoning as the SEMVER_NOT_VERIFIED line above: "passed all 8 checks"
+  # must not absorb a check-8 outcome that read nothing.
+  echo "preflight-publish: NOTE — ${GATE_NOT_VERIFIED}. See the check 8 line above." >&2
 fi
 echo "preflight-publish: after 'cargo publish', confirm what cargo actually recorded:" >&2
 echo "  scripts/check-tag-publish-parity.sh --vcs-info auto ${PKG_NAME} ${VERSION}" >&2

--- a/scripts/prepublish-ignored-tests.tsv
+++ b/scripts/prepublish-ignored-tests.tsv
@@ -1,0 +1,55 @@
+# Ignored tests the pre-publish gate RUNS (scripts/check_ignored_tests.sh).
+#
+# Every row names an `#[ignore]`d test that the gate executes with
+# `--run-ignored all` before a publish. A row has to state what the test needs,
+# because the only reason a test is on this list rather than the unselected
+# remainder is that a hosted Linux runner can give it what it wants.
+#
+# WHAT QUALIFIES. The test needs nothing beyond a HuggingFace model download —
+# which the workflow pre-seeds and caches — and the workspace build. It must not
+# need an API key, a live daemon, a compiled binary on disk, a Python/torch
+# venv, tmux, macOS hardware, or minutes of soak time. Those are the reasons the
+# other 149 ignored tests stay unselected; see the baseline note at the bottom.
+#
+# ADDING A ROW is how you widen the gate, and it is always welcome. Removing one
+# narrows the gate and needs a reason in the PR body.
+#
+# A ROW THAT MATCHES NOTHING IS A HARD FAILURE, not a silent no-op. A renamed or
+# deleted test would otherwise shrink this gate while the file still looked
+# complete — the stale-manifest failure mode. The gate re-checks every row
+# against `cargo nextest list` on every run.
+#
+# Format (tab-separated):  <package>	<exact test name>	<what it needs>
+
+trusty-agents	memory::embed::tests::smoke_single_embedding_shape_and_finiteness	HuggingFace ONNX model download; no key, no daemon, no binary
+trusty-agents	memory::embed::tests::batch_returns_distinct_vectors_per_input	HuggingFace ONNX model download; no key, no daemon, no binary
+trusty-agents	memory::embed::tests::semantic_sanity_paraphrase_beats_unrelated	HuggingFace ONNX model download; asserts paraphrase similarity ordering
+trusty-common	embedder::tests::fastembed_returns_correct_dim	the real fastembed AllMiniLML6V2Q model (~22 MB), pre-seeded by the workflow
+trusty-common	embedder::tests::fastembed_cache_hit_is_idempotent	the real fastembed model; asserts a second init reuses the cache
+trusty-common	embedder::provider_tests::fast_embedder_model_name_reports_fp32_default	model registry lookup only — the fp32 default is the #3493 CoreML regression guard
+trusty-common	embedder::provider_tests::fast_embedder_model_name_reports_int8_opt_in	model registry lookup only — the int8 opt-in path
+trusty-memory	web::tests::health_tests::health_endpoint_returns_ok	loads the default ONNX embedder in-process; no daemon
+trusty-memory	web::tests::health_tests::health_endpoint_includes_resource_fields	loads the default ONNX embedder in-process; no daemon
+trusty-memory	web::tests::health_tests::health_endpoint_round_trip_on_fresh_install_is_ok	loads the default ONNX embedder; fresh-install path a published daemon runs at first start
+trusty-memory	web::tests::health_tests::health_endpoint_round_trip_with_palace_is_ok	loads the default ONNX embedder; palace-backed round trip
+
+# THE UNSELECTED REMAINDER. 160 ignored tests are enumerable in this workspace;
+# the 11 rows above run, and 149 do not. The gate prints that number on every
+# run, grouped by crate, and FAILS if it grows — so a new ignored test either
+# joins the list above or forces this number up in a reviewed diff.
+#
+# WHY 149 ARE NOT RUN. Sampled reasons, from their own `#[ignore]` strings:
+# API keys this workflow does not hold (OPENROUTER, ANTHROPIC, FIREWORKS,
+# TOGETHER, ATLASCLOUD, OPENAI, AWS), a live trusty-search daemon on :7878, a
+# compiled trusty-bm25-daemon / trusty-embedderd binary on disk, a bootstrapped
+# torch venv, a real tmux host — and one pair with mutually exclusive
+# requirements ("requires claude binary absent from PATH", "only runs when tmux
+# is absent from PATH") that no single runner can satisfy at once.
+#
+# 321 of the ~442 `#[ignore]` attributes in the tree carry NO reason string at
+# all, which is why this is a count with a ratchet and not a complete per-test
+# manifest: classifying them is real work that does not belong in the PR that
+# builds the gate.
+#
+# LOWERING THIS NUMBER IS ALWAYS WELCOME. Raising it is a review decision.
+# UNSELECTED-BASELINE: 149

--- a/scripts/rustdoc-link-baseline.tsv
+++ b/scripts/rustdoc-link-baseline.tsv
@@ -1,0 +1,33 @@
+# Per-crate broken intra-doc link baseline (scripts/check_rustdoc_links.sh).
+#
+# A RATCHET, not a target. Each row records how many broken links a crate has
+# today; the gate fails when a crate exceeds its row, when a crate with no row
+# has any at all, or when a crate that has a row was never documented.
+#
+# LOWERING A ROW IS ALWAYS WELCOME AND NEVER REQUIRED. Fix links in the PR that
+# touches the file anyway, then run:
+#     bash scripts/check_rustdoc_links.sh --update-baseline
+# Deleting a row entirely is the goal state for every crate here.
+#
+# RAISING A ROW IS A REVIEW DECISION, not a way to make a red gate green. A
+# broken link on docs.rs cannot be fixed without publishing a new version, so
+# the cost of letting one through is a wasted version number.
+#
+# Regenerate with: bash scripts/check_rustdoc_links.sh --update-baseline
+# Format (tab-separated):  <crate-directory>	<broken-link-count>
+trusty-agents	11
+trusty-agents-common	61
+trusty-analyze	1
+trusty-audit	2
+trusty-channels	2
+trusty-code	125
+trusty-common	200
+trusty-git-analytics	43
+trusty-gworkspace	1
+trusty-installer	4
+trusty-memory	17
+trusty-mpm	256
+trusty-review	7
+trusty-search	29
+trusty-sld-lint	2
+trusty-tui	91


### PR DESCRIPTION
## What

Adds `.github/workflows/pre-publish.yml` — a release gate on `workflow_dispatch`
plus tag push (`*-v*`, matching `semver-checks.yml`) — covering four things that
had no gate anywhere, plus the Code Contracts gates from #5729.

| Gate | Was | Now |
|---|---|---|
| Broken intra-doc links | `cargo doc` in no workflow at all | `scripts/check_rustdoc_links.sh`, ratcheted |
| RustSec advisories | weekly cron only, never pre-publish | `cargo audit`, prebuilt binary |
| Licences / provenance | nothing | `cargo deny` + `deny.toml` |
| `#[ignore]`d ONNX tests | never run by any gate | `scripts/check_ignored_tests.sh` |
| Contract drift (#5729) | — | wired against known paths, SKIPs loudly until #5729 lands |
| Contract cross-version diff (#5729) | — | explicit SKIP: no published baseline exists yet |

`--locked` is on every gate build. A `ci-parity` job asserts the four nextest
shards already concluded green for the exact commit, rather than duplicating
600 lines of `ci.yml` or editing it while a concurrent workstream owns it.

## Three ratchets, not three clean-tree assertions

The pre-existing debt is larger than one PR can clear, and a gate that cannot
pass is a gate that gets switched off. Each fails when its number grows;
lowering a baseline is always welcome and never demanded.

- **852 broken intra-doc links across 16 crates** — `scripts/rustdoc-link-baseline.tsv`
- **83 duplicated crate versions** — `scripts/deny-duplicate-baseline.txt`
- **149 of 160 ignored tests not run** — `scripts/prepublish-ignored-tests.tsv`

## Fail-closed throughout

Every gate distinguishes "found nothing wrong" from "examined nothing", which is
the #5620 / #5723 defect. The rustdoc gate refuses on a build error, a vacuous
scan, an unattributable span, or a baselined crate it never examined. The
ignored-test gate refuses when a manifest row matches zero tests. The duplicate
gate refuses when cargo-deny's verdict line is missing. `summary` requires every
job to equal `success`, never "not failure", so a skipped job cannot read green.

The rustdoc gate's first draft scraped cargo's terminal output with awk and
found **458 of the 852** real diagnostics — it dropped 46% while exiting 0. It
now reads `--message-format json` and asserts it accounted for every diagnostic.

## Two real defects found

- **`trusty-agents-ui` declared no licence and no `publish = false`**, unlike
  both sibling Tauri GUIs. The only licence error in a 1220-crate graph. Fixed
  here.
- **`trusty-agents` depends on `trusty-code` with no version** — the root
  `[workspace.dependencies]` entry is path-only, so `cargo publish -p
  trusty-agents` would be rejected by crates.io. **Not fixed here**: the remedy
  is one field in the root `Cargo.toml`, which the concurrent CI-speed
  workstream owns. `wildcards` is set to `"warn"` for that reason and should be
  raised to `"deny"` once that lands.

## preflight-publish.sh CHECK 8

Requires a green `Pre-publish gate` run for the exact commit being published.
`cargo publish` runs locally and no CI job can stop it — the same reasoning that
put the SemVer gate in that script rather than leaving it to CI. Fails closed on
"never ran", "ran red", and "could not read"; the override takes a reason
string, matching `PREFLIGHT_SEMVER_UNVERIFIED`.

## Verification

Gates run locally against the real workspace at `e39183c3`:

```
cargo deny check licenses                    EXIT=0
cargo deny check sources                     EXIT=0
cargo deny check advisories                  EXIT=0
bash scripts/check_deny_duplicates.sh        EXIT=0  [PASS] 83 at baseline
cargo audit                                  EXIT=0  0 vulns, 38 allowed warnings
bash scripts/check_rustdoc_links.sh --json …  EXIT=0  24 documented, 852 links, baseline 852
bash scripts/check_ignored_tests.sh --from-list …  EXIT=0  160 ignored, 11 selected, 149 not run

bash scripts/check-ci-helpers-selftest.sh    EXIT=0  135 cases passed
bash scripts/check_line_cap.sh               EXIT=0  4007 files, 0 violations
bash scripts/check_sld.sh                    EXIT=0  0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh     EXIT=0  no crate source changed
```

**The workflow has not been executed.** `workflow_dispatch` requires the file to
exist on the default branch, so it cannot be dispatched from this branch —
GitHub returns `HTTP 404: workflow pre-publish.yml not found on the default
branch`. The YAML parses and every gate command was verified standalone, but no
end-to-end run exists and **no gate duration has been measured**. The
`ignored-tests` RUN phase in particular has never executed anywhere: its 11
tests have never run in CI, so they may well fail on first execution. Dispatch
it immediately after merge.

Rung 5 (release tooling). No crate source changed, so no Cargo test gate applies.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
