### PR TITLE
fix(ci): repair the three pre-publish gate defects its first real run exposed

### DIFF
--- a/.github/workflows/pre-publish.yml
+++ b/.github/workflows/pre-publish.yml
@@ -515,6 +515,19 @@ jobs:
           bash scripts/check_contracts.sh --crate trusty-common
         id: contract-drift
 
+      # NEXT AUTHOR, READ THIS BEFORE WIRING THE REAL COMPARISON. When a
+      # published trusty-common finally carries contracts.json, the entry point
+      # to use is NOT `python3 scripts/diff_contracts.py` — it is
+      #
+      #     bash scripts/check_contracts.sh --diff <baseline> <current>
+      #
+      # which #5729 built for exactly this, and which owns the exit-code
+      # contract (0 clean / 1 drift / 2 usage / 3 no verdict) that this job
+      # should be reading. Calling the Python differ directly would re-implement
+      # that mapping here and let the two drift apart. This step still shells out
+      # to diff_contracts.py only as a RUNNABILITY PROBE; both arms end in the
+      # no-baseline SKIP today, so the choice has no effect yet and was left
+      # alone rather than changed speculatively.
       - name: "Gate 6 — cross-version contract diff"
         run: |
           set -euo pipefail

--- a/.github/workflows/pre-publish.yml
+++ b/.github/workflows/pre-publish.yml
@@ -135,7 +135,18 @@ jobs:
           # is a legitimate green.
           green="$(printf '%s' "${runs}" | jq '[.[] | select(.status == "completed" and .conclusion == "success")] | length')"
           if [ "${green}" -eq 0 ]; then
-            echo "::error::CI has run for ${SHA} but no run concluded 'success'. A release gate cannot pass over a red or still-running CI. Conclusions above."
+            # STILL RUNNING and CONCLUDED RED are different facts and get
+            # different messages. On the gate's first real run the only CI run
+            # for the SHA was `queued` — the gate was dispatched ~20 s after the
+            # merge landed — and a message about a "red CI" would have sent
+            # someone hunting a failure that did not exist. Both still FAIL:
+            # an unfinished CI has not proved anything yet.
+            pending="$(printf '%s' "${runs}" | jq '[.[] | select(.status != "completed")] | length')"
+            if [ "${pending}" -gt 0 ]; then
+              echo "::error::CI for ${SHA} has not finished — ${pending} run(s) still queued or in progress. This gate is dispatched too early; wait for CI to settle, then re-run. Nothing here is red, but nothing has been proved either."
+            else
+              echo "::error::CI has run to completion for ${SHA} and no run concluded 'success'. A release gate cannot pass over a red CI. Conclusions above."
+            fi
             exit 1
           fi
           echo "OK — ${green} green CI run(s) for ${SHA}"
@@ -471,6 +482,16 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
             build-essential pkg-config libssl-dev
+
+      # libdbus-1-dev is REQUIRED here and nowhere else in this workflow. The
+      # contract extractor builds rustdoc JSON for trusty-common with its full
+      # feature set, which pulls in libdbus-sys; its build.rs calls pkg-config
+      # and `explicit panic`s when the headers are absent. On the gate's first
+      # real run (31858449749) that failed Gate 5 with exit 3 — a build failure,
+      # correctly NOT reported as a contract verdict. The other jobs build
+      # narrower graphs and do not need it.
+      - name: Install libdbus (contract extraction only)
+        run: sudo apt-get install -y --no-install-recommends libdbus-1-dev
 
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2

--- a/scripts/check_deny_duplicates.sh
+++ b/scripts/check_deny_duplicates.sh
@@ -89,7 +89,25 @@ else
   # the default set, the extra 34 being candle/gemm/pulp copies from backends
   # that are never on at the same time. Counting those would make the ratchet
   # track an artifact nobody builds.
-  cargo deny check bans > "$TMP_OUT" 2>&1 || DENY_RC=$?
+  # `--color never` because this output is PARSED, not read. The pre-publish
+  # workflow sets CARGO_TERM_COLOR=always (inherited from ci.yml's env block),
+  # and cargo-deny honours it: its verdict line arrives as
+  # `bans \e[32mok\e[0m`, so an anchored `^bans ok` match fails and the
+  # vacuous-scan refusal below fires on a run that actually succeeded. That is
+  # what happened on the gate's first real execution (run 31858449749, Gate 3).
+  # The refusal behaved correctly — it declined to report a count it could not
+  # trust — but the gate was unusable until the colour was turned off.
+  cargo deny --color never check bans > "$TMP_OUT" 2>&1 || DENY_RC=$?
+fi
+
+# Strip any ANSI escape sequences that survived, so every match below reads
+# plain text. Belt and braces alongside `--color never`: a future cargo-deny
+# that colours on a different switch, or a caller passing captured colourised
+# output to --from-output, must not silently turn a real verdict into a refusal.
+if command -v perl >/dev/null 2>&1; then
+  perl -pe 's/\e\[[0-9;]*[A-Za-z]//g' "$TMP_OUT" > "${TMP_OUT}.plain" && mv "${TMP_OUT}.plain" "$TMP_OUT"
+else
+  sed -E $'s/\033\\[[0-9;]*[A-Za-z]//g' "$TMP_OUT" > "${TMP_OUT}.plain" && mv "${TMP_OUT}.plain" "$TMP_OUT"
 fi
 
 # A hard violation (a banned crate, a wildcard requirement) is cargo-deny's own

--- a/scripts/prepublish-ignored-tests.tsv
+++ b/scripts/prepublish-ignored-tests.tsv
@@ -33,8 +33,8 @@ trusty-memory	web::tests::health_tests::health_endpoint_includes_resource_fields
 trusty-memory	web::tests::health_tests::health_endpoint_round_trip_on_fresh_install_is_ok	loads the default ONNX embedder; fresh-install path a published daemon runs at first start
 trusty-memory	web::tests::health_tests::health_endpoint_round_trip_with_palace_is_ok	loads the default ONNX embedder; palace-backed round trip
 
-# THE UNSELECTED REMAINDER. 160 ignored tests are enumerable in this workspace;
-# the 11 rows above run, and 149 do not. The gate prints that number on every
+# THE UNSELECTED REMAINDER. 159 ignored tests are enumerable in this workspace;
+# the 11 rows above run, and 148 do not. The gate prints that number on every
 # run, grouped by crate, and FAILS if it grows — so a new ignored test either
 # joins the list above or forces this number up in a reviewed diff.
 #
@@ -52,4 +52,4 @@ trusty-memory	web::tests::health_tests::health_endpoint_round_trip_with_palace_i
 # builds the gate.
 #
 # LOWERING THIS NUMBER IS ALWAYS WELCOME. Raising it is a review decision.
-# UNSELECTED-BASELINE: 149
+# UNSELECTED-BASELINE: 148

--- a/scripts/rustdoc-link-baseline.tsv
+++ b/scripts/rustdoc-link-baseline.tsv
@@ -13,6 +13,18 @@
 # broken link on docs.rs cannot be fixed without publishing a new version, so
 # the cost of letting one through is a wasted version number.
 #
+# RAISED ONCE, ON 2026-08-15, FROM 852 TO 873. The original numbers were
+# measured at e39183c3. #5729 (Code Contracts) and #5730 (CI speed) merged
+# between that measurement and this gate's first real run, and the gate caught
+# the delta on that run (31858449749): trusty-installer +14, trusty-mpm +4,
+# trusty-common +2, trusty-memory +1. Those 21 links are not this gate's work to
+# fix and predate its enforcement, so the rows were rebased onto main rather
+# than reverted — which is the raise this file calls a review decision, recorded
+# here because that is what the rule asks for.
+#
+# This is the only rebase of its kind that should ever be needed. From here the
+# gate runs on every release, so a regression is caught by the PR that causes it.
+#
 # Regenerate with: bash scripts/check_rustdoc_links.sh --update-baseline
 # Format (tab-separated):  <crate-directory>	<broken-link-count>
 trusty-agents	11
@@ -21,12 +33,12 @@ trusty-analyze	1
 trusty-audit	2
 trusty-channels	2
 trusty-code	125
-trusty-common	200
+trusty-common	202
 trusty-git-analytics	43
 trusty-gworkspace	1
-trusty-installer	4
-trusty-memory	17
-trusty-mpm	256
+trusty-installer	18
+trusty-memory	18
+trusty-mpm	260
 trusty-review	7
 trusty-search	29
 trusty-sld-lint	2


### PR DESCRIPTION
## What

Repairs the three defects the pre-publish gate's **first real execution**
([run 31858449749](https://github.com/bobmatnyc/trusty-tools/actions/runs/31858449749))
exposed, and rebases two baselines onto main.

| Job | First run | Cause |
|---|---|---|
| Gate 2 — cargo audit | **pass** 11s | — |
| Gate 4 — ignored ONNX tests | **pass** 15m31s | 11/11 passed |
| Gate 1 — cargo doc | fail 4m43s | ratchet caught a real +21 regression |
| Gate 3 — cargo deny | fail 32s | **gate defect** — ANSI codes |
| Gates 5-6 — contracts | fail 2m33s | **gate defect** — missing libdbus |
| ci-parity | fail 6s | dispatched ~20s after merge; CI still `queued` |

## The three defects

**cargo deny duplicate ratchet.** The workflow sets `CARGO_TERM_COLOR=always`,
cargo-deny honours it, and the verdict arrived as `bans \e[32mok\e[0m` — so the
anchored `^bans ok` match failed and the vacuous-scan refusal fired on a run
that had succeeded. The refusal was *correct behaviour* (it declined to report a
count it could not trust) but the gate was unusable. Now `--color never` plus
defensive escape-stripping. Reproduced locally under `CARGO_TERM_COLOR=always`:
FAIL before, `[PASS] 83 at baseline` after.

**contracts job.** `libdbus-sys`' `build.rs` panics without `libdbus-1-dev`,
failing the trusty-common rustdoc JSON build with exit 3 — correctly *not*
reported as a contract verdict. Added to that job only.

**ci-parity.** Behaved correctly but said "red or still-running CI" for a run
that was merely `queued`, which would send someone hunting a failure that does
not exist. Both states still fail closed; they now get distinct messages.

## Baselines rebased

`rustdoc-link-baseline.tsv` **852 → 873, once.** #5729 and #5730 merged between
the `e39183c3` measurement and the first run, adding 21 broken links
(trusty-installer +14, trusty-mpm +4, trusty-common +2, trusty-memory +1). **The
gate caught them — that is the ratchet working.** They predate its enforcement
and are not this gate's work to fix, so the rows are rebased with the reason
recorded in the file. This should be the only rebase of its kind: from here the
gate runs on every release, so a regression is caught by the PR that causes it.

`prepublish-ignored-tests.tsv` **149 → 148**, per the gate's own `IMPROVED` note.

## Verification

```
CARGO_TERM_COLOR=always bash scripts/check_deny_duplicates.sh   EXIT=0
  [PASS] deny-duplicates: 83 duplicated crate(s), at the baseline.

bash scripts/check_line_cap.sh            EXIT=0  4008 files, 0 violations
bash scripts/check-ci-helpers-selftest.sh EXIT=0  all 135 cases passed
bash scripts/check_sld.sh                 EXIT=0  0 errors, 0 warnings
```

Gate 4's raw output from the first run — the tests that had never executed
anywhere:

```
Summary [4.978s] 11 tests run: 11 passed, 6713 skipped
[PASS] ignored-tests: every selected ignored test passed.
```

The libdbus and ci-parity fixes are verified by reasoning from the run logs, not
by a second execution. Dispatch the gate again after this merges — once CI for
the merge commit has settled, which is the ci-parity lesson.

Rung 1 (CI config + baselines). No crate source changed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
