### PR TITLE
fix: add missing version to trusty-code dependency, tighten wildcards to deny

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 # ── Internal crates (path deps so the monorepo builds without publish cycles) ──
 # trusty-code: per-project Claude-Code-compatible MPM orchestration harness (#587).
 # First published to crates.io at version 0.1.0.
-trusty-code = { path = "crates/trusty-code" }
+trusty-code = { path = "crates/trusty-code", version = "0.3.0" }
 # trusty-tui: engine-agnostic terminal-UI seam (`TuiEngine` trait + `ReplEvent`)
 # shared by trusty-code's `tcode tui` and trusty-agents' tagent REPL (DOC-50,
 # epic #3411). Not yet published (Slice 1, #3425).

--- a/deny.toml
+++ b/deny.toml
@@ -150,26 +150,15 @@ confidence-threshold = 0.8
 # never required.
 [bans]
 multiple-versions = "warn"
-# WILDCARDS ARE "warn" AND THAT IS A COMPROMISE, NOT A JUDGEMENT.
-#
-# Set to "deny" — which is what a publish gate wants, since crates.io rejects a
-# path dependency carrying no version — this check FAILS TODAY on a real defect:
-#
-#   error[wildcard]: found 1 wildcard dependency for crate 'trusty-agents'.
-#     crates/trusty-agents/Cargo.toml:34  trusty-code = { workspace = true }
-#
-# The root `[workspace.dependencies]` entry is `trusty-code = { path =
-# "crates/trusty-code" }` with NO `version` key, unlike every other internal
-# dependency trusty-agents declares (trusty-memory "0.23", trusty-search "0.47",
-# trusty-gworkspace "0.2.2", …). `cargo publish -p trusty-agents` would be
-# rejected outright: crates.io requires a version on every dependency. trusty-code
-# IS published, so the fix is one field on that root entry.
-#
-# It is left at "warn" here for one reason only: the root Cargo.toml is being
-# rewritten by a concurrent workstream, and a one-line edit landing in two PRs at
-# once is a conflict nobody needs. RAISE THIS TO "deny" once that lands and the
-# version field is added. The finding is recorded in this PR's body.
-wildcards = "warn"
+# WILDCARDS IS "deny": crates.io rejects a publish whose dependency carries no
+# version, so a path dependency missing `version` is a real publish-breaking
+# defect, not a style nit. This caught exactly that case once — the root
+# `[workspace.dependencies]` entry `trusty-code = { path = "crates/trusty-code" }`
+# had no `version` key, unlike every other internal dependency trusty-agents
+# declares (trusty-memory "0.23", trusty-search "0.47", trusty-gworkspace
+# "0.2.2", …), and `cargo publish -p trusty-agents` failed outright. Fixed by
+# adding `version = "0.3.0"` to that entry.
+wildcards = "deny"
 # Dev-dependency wildcards are exempt because they never reach a published
 # artifact and crates.io does not reject them.
 allow-wildcard-paths = true


### PR DESCRIPTION
## Summary

- Root `Cargo.toml:106` `trusty-code = { path = "crates/trusty-code" }` had no `version` key, unlike every other internal dependency in `[workspace.dependencies]`. crates.io rejects a publish whose dependency carries no version, so `cargo publish -p trusty-agents` failed at dependency resolution. Added `version = "0.3.0"`, read from `crates/trusty-code/Cargo.toml`'s own `version` field.
- Audited every other internal `path` dependency declaration in the workspace (`git grep -n 'path = "crates/' -- Cargo.toml 'crates/*/Cargo.toml'` plus a scan of every `crates/*/Cargo.toml` for `path = "../..."` internal deps) — all already carry a `version`. No other instance found.
- `deny.toml`'s `wildcards` moved from `"warn"` to `"deny"` now that the underlying defect is fixed, so a future versionless/wildcard path dependency fails CI instead of merging silently. Stale comment explaining the temporary `"warn"` compromise removed.

## Test plan — rung 1 (manifest/config-only, no crate `src/**` touched)

- `cargo fmt --check` — exit 0
- `SKIP_UI_BUILD=1 cargo check --workspace` — exit 0
- `cargo deny check bans` — exit 0, "bans ok", 0 wildcard warnings
- `cargo deny check licenses` — exit 0
- `cargo publish -p trusty-agents --dry-run` — now clears dependency resolution (no more `trusty-code` version error). Fails on an unrelated, pre-existing gap: `trusty-agents-common = "^0.5.2"` is not yet published to crates.io (latest published is 0.5.1). Not chased per scope.
- `bash scripts/check_line_cap.sh` — exit 0
- `bash scripts/check_sld.sh` — exit 0
- `scripts/check_changelog_fragment.sh` — confirms no fragment owed: "scanned 2 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK."

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools