### PR TITLE
chore(tga): 2.19.1 -> 2.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10262,7 +10262,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.19.1"
+version = "2.20.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon", version = "0.2.0" }
 # Cargo edge on it: #5466 removed trusty-review's, and the tga -> trusty-review
 # direction is a PATH lookup, not a manifest edge (#5236, DOC-67 §6). The entry
 # stays so a future in-tree consumer resolves from source rather than crates.io.
-tga = { path = "crates/trusty-git-analytics", version = "2.19.1" }
+tga = { path = "crates/trusty-git-analytics", version = "2.20.0" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -4,7 +4,7 @@ name = "tga"
 # touches src/**. `persist_work_items` is `pub` but lives in the private
 # `mod linear_pipeline;` (not re-exported), so it is unreachable outside the
 # crate and adds no public API surface.
-version = "2.19.1"
+version = "2.20.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for


### PR DESCRIPTION
Two breaking public-API changes merged into tga today and the crate has not been bumped for either:

- `LinearClient::fetch_referenced_issues` returns `Result<Vec<LinearIssue>>` where it returned `Vec<LinearIssue>` (#5732)
- `CollectionStats::errors` is `Vec<CollectionFault>` where it was `Vec<String>` (#5727)

Under strict SemVer a 2.x crate owes a MAJOR bump for either. This is a deliberate minor bump — the owner's standing decision for this repo. Recorded here so the next release owner sees the reasoning rather than inferring an oversight.

## The gate cannot see either change

`scripts/check_semver.sh --crate tga` reports `196 checks: 196 pass` and `no semver update required`. That is a real run, not a skipped one — and it is structurally blind to both:

- cargo-semver-checks has no lint for `T` -> `Result<T>`; its only return-type lints are the `()`-boundary cases, and an `async fn`'s declared return type is an opaque `impl Future`.
- The type differ that *can* see it (#5738) is wired into `preflight-publish.sh` CHECK 5, not into `check_semver.sh` — so it runs at publish time, not here.

Do not read the clean gate as evidence this bump is unnecessary.

## What was not done

`scripts/bump-version.sh` was not used: it unconditionally runs `assemble-changelog.sh` in its mutating form, which consumes and deletes the `changelog.d/` fragments. Those belong to the release, not to a bump commit. The version fields were edited directly and `cargo check -p tga` regenerated the lockfile.

The root `[workspace.dependencies]` entry was already `2.19.1`, which under caret rules would have kept admitting 2.20.0 untouched. It was updated anyway — every prior tga bump in this repo's history rewrote it in lockstep.

No changelog fragment is owed; `check_changelog_fragment.sh` confirms `no crate source changed`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools