### PR TITLE
feat(tga): AgenticMode gains an 'unknown' state distinct from 'none' (closes #5250)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10262,7 +10262,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.20.0"
+version = "3.0.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon", version = "0.2.0" }
 # Cargo edge on it: #5466 removed trusty-review's, and the tga -> trusty-review
 # direction is a PATH lookup, not a manifest edge (#5236, DOC-67 §6). The entry
 # stays so a future in-tree consumer resolves from source rather than crates.io.
-tga = { path = "crates/trusty-git-analytics", version = "2.20.0" }
+tga = { path = "crates/trusty-git-analytics", version = "3.0.0" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "tga"
-# #4421: patch bump — 2.19.0 already published on crates.io and this PR
-# touches src/**. `persist_work_items` is `pub` but lives in the private
-# `mod linear_pipeline;` (not re-exported), so it is unreachable outside the
-# crate and adds no public API surface.
-version = "2.20.0"
+# #5250: MAJOR bump from the published 2.20.0. `AgenticMode` gains an `Unknown`
+# variant AND `#[non_exhaustive]`; both break an exhaustive downstream `match`,
+# and tga is past 1.0 so the breaking position is MAJOR. Supersedes the #4421
+# patch bump that carried 2.19.0 → 2.20.0.
+version = "3.0.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for

--- a/crates/trusty-git-analytics/changelog.d/5250-agentic-mode-non-exhaustive.md
+++ b/crates/trusty-git-analytics/changelog.d/5250-agentic-mode-non-exhaustive.md
@@ -1,0 +1,5 @@
+Breaking
+- `AgenticMode` is now `#[non_exhaustive]` and gained a variant, so external
+  `match` sites need a `_ =>` arm. tga goes to 3.0.0: adding a variant to an
+  exhaustive public enum is a major break under `cargo-semver-checks`, and the
+  attribute keeps the next addition (#5251) a minor bump.

--- a/crates/trusty-git-analytics/changelog.d/5250-agentic-unknown.md
+++ b/crates/trusty-git-analytics/changelog.d/5250-agentic-unknown.md
@@ -1,0 +1,20 @@
+Added
+- `AgenticMode::Unknown` — a fourth agentic mode for commits whose message git
+  or a forge composed, so a marker the author emitted was discarded before the
+  commit object existed. It separates "we read the author's message and found
+  no AI marker" from "the message we hold was never the author's".
+  - Detection reaches it only when no marker matched and the message shows a
+    rewrite fingerprint: a git/GitHub merge summary (`Merge branch 'x'`,
+    `Merge pull request #N from …`), or a `(#N)` squash subject whose body was
+    replaced by synthesized trailers. A marker always wins.
+  - "No marker matched" means BOTH the builtin and the operator sets (#5414)
+    came up empty. An operator marker still classifies a merge-summary-shaped
+    commit; the `Unknown` verdict is decided once, after both scans, so it
+    never pre-empts the operator set.
+  - No migration: `commits.agentic_mode` is `TEXT NOT NULL DEFAULT 'none'` with
+    no CHECK constraint, so `'unknown'` was already schema-legal.
+  - `agentic_pct` in `fact_weekly_engineer` keeps `unknown` in the
+    `net_commits` denominator and out of both numerators, which makes it an
+    explicit lower bound. `persist_weekly_engineer`'s doc states this.
+  - Reading an unrecognised `agentic_mode` string back from SQLite now yields
+    `Unknown` rather than `None`.

--- a/crates/trusty-git-analytics/src/collect/ai_attribution.rs
+++ b/crates/trusty-git-analytics/src/collect/ai_attribution.rs
@@ -11,6 +11,10 @@
 //! - [`detect_ai_tool`] — the stable tool identifier for the `ai_tool` column.
 //! - [`detect_agentic_mode`] — the canonical [`AgenticMode`] (issue #1113).
 //!
+//! Also [`provenance_possibly_stripped`], the predicate behind
+//! [`AgenticMode::Unknown`] (#5250): it decides whether a message with no
+//! marker is one the author wrote or one git/a forge composed.
+//!
 //! Since #5249 the patterns themselves live in
 //! [`crate::collect::ai_markers`], which is configurable per run and also
 //! matches author/committer emails. Callers that have a commit's identities —
@@ -22,6 +26,10 @@
 //! Test: unit tests in [`tests`] at the bottom of this file, and
 //! `collect::ai_markers::tests` for the marker engine itself.
 
+use std::sync::OnceLock;
+
+use regex::Regex;
+
 use crate::collect::ai_markers::{detect, CommitSignals};
 
 /// Canonical agentic-mode classification for a commit (issue #1113).
@@ -31,10 +39,21 @@ use crate::collect::ai_markers::{detect, CommitSignals};
 /// (autonomous CLI agent) is qualitatively different from a Cursor
 /// inline-completion commit. Downstream analytics (DAAU, agentic %)
 /// need to distinguish these modes without losing the existing columns.
-/// What: three-valued enum, persisted as the TEXT column `agentic_mode`.
+/// What: four-valued enum, persisted as the TEXT column `agentic_mode`. The
+/// column is `TEXT NOT NULL DEFAULT 'none'` with no CHECK constraint, so
+/// `'unknown'` (#5250) needed no migration — the three-value restriction only
+/// ever lived in `as_str`/`FromStr` here.
 /// Test: `tests::detect_agentic_mode_*` below; see also
 /// `core::db::migrations::v21` which adds the column.
+///
+/// `#[non_exhaustive]` because #5250's variant addition cost tga a major bump
+/// (`cargo-semver-checks` `enum_variant_added`, and the crate is 2.x). The
+/// attribute makes the next one — per-tool attribution in
+/// [#5251](https://github.com/bobmatnyc/trusty-tools/issues/5251) — a minor
+/// bump instead. It costs external `match` sites a `_ =>` arm; matches inside
+/// this crate are unaffected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum AgenticMode {
     /// Full-agentic: autonomous CLI agent (Claude Code, Devin, OpenHands,
     /// Aider, or a house wrapper such as trusty-mpm). Which markers imply it
@@ -43,13 +62,27 @@ pub enum AgenticMode {
     /// IDE-assisted: inline AI completions from an IDE plugin
     /// (Cursor, GitHub Copilot).
     IdeAssisted,
-    /// No AI marker was found.
+    /// No AI marker was found in a message the author actually wrote.
     ///
-    /// This is NOT the same claim as "a human wrote it": a commit whose
-    /// trailers were stripped, squashed, or rewritten is indistinguishable
-    /// from one that never had them. #5250 proposes a distinct `unknown`
-    /// state for that case.
+    /// This is still not the same claim as "a human wrote it" — a commit can
+    /// be rewritten in ways this detector cannot see. It is the narrower
+    /// claim that the message carries no rewrite fingerprint either, so the
+    /// absence of a marker is the best evidence available.
     None,
+    /// No AI marker was found, but the message shows a rewrite fingerprint,
+    /// so a marker the author emitted would have been discarded (#5250).
+    ///
+    /// Why: `agentic_pct` is an acquirer-facing figure (DOC-67 §8). A
+    /// git-generated merge summary and a genuinely human commit both used to
+    /// persist as `'none'`, which reports "we checked, there was no AI" for a
+    /// message that never had room to say so.
+    /// What: reached only when no marker matched AND
+    /// [`provenance_possibly_stripped`] holds for the message. It is a
+    /// refinement of [`AgenticMode::None`], never of a positive
+    /// classification: a marker always wins.
+    /// Test: `tests::detect_agentic_mode_merge_summary_is_unknown`,
+    /// `tests::unknown_is_distinct_from_none`.
+    Unknown,
 }
 
 impl AgenticMode {
@@ -64,6 +97,7 @@ impl AgenticMode {
             AgenticMode::FullAgentic => "full_agentic",
             AgenticMode::IdeAssisted => "ide_assisted",
             AgenticMode::None => "none",
+            AgenticMode::Unknown => "unknown",
         }
     }
 }
@@ -80,9 +114,93 @@ impl std::str::FromStr for AgenticMode {
             "full_agentic" => Ok(AgenticMode::FullAgentic),
             "ide_assisted" => Ok(AgenticMode::IdeAssisted),
             "none" => Ok(AgenticMode::None),
+            "unknown" => Ok(AgenticMode::Unknown),
             _ => Err(()),
         }
     }
+}
+
+/// Does this message carry a fingerprint of having been synthesized by git or
+/// a forge, rather than written by the commit's author (#5250)?
+///
+/// Why: [`AgenticMode::None`] is a finding — "we read the author's message and
+/// there was no AI marker in it". That finding is only sound when the message
+/// we hold IS the author's. When git or GitHub composed it, any footer or
+/// trailer the author emitted was discarded before the commit object existed,
+/// and "no marker" says nothing about how the work was done.
+/// What: two fingerprints, both message-only. **(a) a machine merge summary** —
+/// `Merge branch 'x'`, `Merge remote-tracking branch 'x'`, `Merge tag 'x'`,
+/// `Merge commit 'x'`, or `Merge pull request #N from owner/branch`. git and
+/// GitHub compose these in full; none of them can contain an authored footer.
+/// **(b) a forge squash-merge that replaced the body** — a subject ending in
+/// `(#N)` whose every remaining non-blank line is a `Key: value` trailer. This
+/// is what GitHub's "default to PR title" squash setting emits: the branch's
+/// commit bodies, where footers live, are dropped and only synthesized
+/// `Co-authored-by:` trailers remain.
+///
+/// Message-only is a deliberate constraint, not an oversight: `commits` has no
+/// `committer_email` column, so `tga backfill ai-detection-commits` sees only
+/// the message. A predicate reading identities would classify a freshly walked
+/// row differently from a repaired one, breaking the equivalence
+/// [`detect`] promises.
+///
+/// # What this deliberately does NOT catch
+///
+/// A `(#N)` squash whose body is the PR description. On this repo's HEAD
+/// history the predicate claims 16 commits and leaves 128 of these unclaimed —
+/// and at least some of the 128 were agentic: `a92bb941` (#5379) carries no
+/// marker, while the branch commits GitHub squashed into it do.
+///
+/// Separating those needs a signal this function does not have (the pre-squash
+/// commits, or the PR body). The subject shape alone cannot tell a squash from
+/// a hand-written `fix: thing (#12)`, and on a repo that references issues in
+/// subjects by convention it would claim nearly everything — trading a false
+/// `none` for an `unknown` no measurement could refute.
+///
+/// Test: `tests::provenance_possibly_stripped_*`.
+pub fn provenance_possibly_stripped(message: &str) -> bool {
+    let mut lines = message.lines().map(str::trim);
+    let Some(subject) = lines.next() else {
+        return false;
+    };
+    if machine_merge_subject().is_match(subject) {
+        return true;
+    }
+    if !squash_pr_subject().is_match(subject) {
+        return false;
+    }
+    // An empty remainder satisfies this: a `(#N)` subject with no body at all
+    // is the "PR title only" squash in its purest form.
+    lines
+        .filter(|l| !l.is_empty())
+        .all(|l| trailer_shaped().is_match(l))
+}
+
+/// Subjects git and GitHub compose for merge commits. The quoted ref is the
+/// guard: it rejects prose such as `Merge branch handling into the parser`.
+fn machine_merge_subject() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"(?i)^Merge (?:(?:remote-tracking )?branch|tag|commit) '|^Merge pull request #\d+ from \S",
+        )
+        .expect("machine_merge_subject pattern compiles")
+    })
+}
+
+/// The `(#N)` suffix GitHub appends to a squash-merge subject.
+fn squash_pr_subject() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\(#\d+\)$").expect("squash_pr_subject pattern compiles"))
+}
+
+/// A git trailer line — `Key: value`, the only body content GitHub synthesizes
+/// for a title-only squash.
+fn trailer_shaped() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^[A-Za-z][A-Za-z0-9_-]*:\s*\S").expect("trailer_shaped pattern compiles")
+    })
 }
 
 /// Detect the AI tool that produced a commit, from its message alone.
@@ -118,7 +236,7 @@ pub fn detect_ai_tool(message: &str) -> Option<&'static str> {
     detect(&CommitSignals::from_message(message)).tool
 }
 
-/// Classify a commit into one of the three canonical agentic modes.
+/// Classify a commit into one of the four canonical agentic modes.
 ///
 /// Why: distinguishes autonomous CLI-agent commits (Claude Code) from IDE
 /// inline-completion commits (Cursor/Copilot) from plain human commits
@@ -127,9 +245,11 @@ pub fn detect_ai_tool(message: &str) -> Option<&'static str> {
 /// What: runs the shipped marker set (the marker set) over `message`
 /// with no author or committer email. A full-agentic marker (Claude Code, the
 /// trusty-mpm footer, Devin, OpenHands, Aider, the `X-AI-*` trailers) outranks
-/// an IDE marker (Copilot, Cursor); no match is `None`. Callers holding a
-/// commit's identities should call [`detect`] instead so the email
-/// family is not skipped.
+/// an IDE marker (Copilot, Cursor). With no match the result is `None` for a
+/// message the author wrote and `Unknown` when the message carries a rewrite
+/// fingerprint (#5250 — see [`provenance_possibly_stripped`]). Callers holding
+/// a commit's identities should call [`detect`] instead so the email family is
+/// not skipped.
 /// Test: `tests::detect_agentic_mode_*` below.
 ///
 /// # Examples
@@ -254,6 +374,7 @@ mod tests {
         assert_eq!(AgenticMode::FullAgentic.as_str(), "full_agentic");
         assert_eq!(AgenticMode::IdeAssisted.as_str(), "ide_assisted");
         assert_eq!(AgenticMode::None.as_str(), "none");
+        assert_eq!(AgenticMode::Unknown.as_str(), "unknown");
     }
 
     /// Why: `FromStr` must invert `as_str` for lossless DB round-trips.
@@ -270,6 +391,7 @@ mod tests {
             Ok(AgenticMode::IdeAssisted)
         );
         assert_eq!(AgenticMode::from_str("none"), Ok(AgenticMode::None));
+        assert_eq!(AgenticMode::from_str("unknown"), Ok(AgenticMode::Unknown));
         assert!(AgenticMode::from_str("unknown_value").is_err());
         assert!(AgenticMode::from_str("").is_err());
     }
@@ -375,6 +497,97 @@ mod tests {
         let msg = "fix: npe\n\nCo-Authored-By: AI Bot <ai@cursor.sh>";
         assert_eq!(detect_agentic_mode(msg), AgenticMode::IdeAssisted);
         assert_eq!(detect_ai_tool(msg), Some("cursor"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #5250 — the Unknown state
+    // -------------------------------------------------------------------------
+
+    /// Why: git composes these subjects in full, so an author's footer cannot
+    /// survive into them. 117 of this repo's 453 marker-less commits are of
+    /// this shape.
+    /// What: each git/GitHub merge summary form is a rewrite fingerprint.
+    #[test]
+    fn provenance_possibly_stripped_matches_machine_merge_summaries() {
+        for msg in [
+            "Merge branch 'feat/x' into main",
+            "Merge remote-tracking branch 'origin/main'",
+            "Merge tag 'v2.15.0' into develop",
+            "Merge commit 'deadbeef'",
+            "Merge pull request #42 from bobmatnyc/feat-x\n\nfeat: add the thing",
+        ] {
+            assert!(provenance_possibly_stripped(msg), "{msg}");
+        }
+    }
+
+    /// Why: GitHub's "default to PR title" squash discards the branch's commit
+    /// bodies, which is where footers live, and leaves only the trailers it
+    /// synthesizes.
+    /// What: a `(#N)` subject whose remaining lines are all trailers — or which
+    /// has no body at all — is a rewrite fingerprint.
+    #[test]
+    fn provenance_possibly_stripped_matches_body_replacing_squash() {
+        assert!(provenance_possibly_stripped(
+            "docs: align the corpus (#5397)"
+        ));
+        assert!(provenance_possibly_stripped(
+            "ci: scope the check (#5400)\n\n\
+             Co-authored-by: bobmatnyc <bobmatnyc@users.noreply.github.com>"
+        ));
+    }
+
+    /// Why: the predicate is only worth having if it stays narrow. Each of
+    /// these is a message the author actually wrote, so "no marker" there is a
+    /// finding and must stay `None`.
+    /// What: prose that merely starts with "Merge", a squash whose body is the
+    /// PR description, a plain commit, and an empty message.
+    #[test]
+    fn provenance_possibly_stripped_rejects_authored_messages() {
+        for msg in [
+            "Merge branch handling into the parser",
+            "refactor: merge pull request handling into one module",
+            "docs: record a rejected proposal (#5379)\n\n\
+             Docs-only. The linker switch measured slower on this runner.",
+            "feat: add button",
+            "",
+        ] {
+            assert!(!provenance_possibly_stripped(msg), "{msg}");
+        }
+    }
+
+    /// Why: this is the #5250 acceptance — a stripped-provenance commit must
+    /// stop sharing a bucket with a genuinely human one.
+    /// What: a git merge summary is `Unknown`; the same author's hand-written
+    /// commit is `None`; the two are not equal.
+    #[test]
+    fn detect_agentic_mode_merge_summary_is_unknown() {
+        assert_eq!(
+            detect_agentic_mode("Merge branch 'feat/x' into main"),
+            AgenticMode::Unknown
+        );
+    }
+
+    /// Why: `Unknown` is a refinement of `None`, and a report that treated
+    /// them as one value would erase the whole point of the variant.
+    #[test]
+    fn unknown_is_distinct_from_none() {
+        assert_ne!(AgenticMode::Unknown, AgenticMode::None);
+        assert_ne!(AgenticMode::Unknown.as_str(), AgenticMode::None.as_str());
+        assert_ne!(
+            detect_agentic_mode("Merge branch 'feat/x' into main"),
+            detect_agentic_mode("feat: add button")
+        );
+    }
+
+    /// Why: `Unknown` must never displace a positive classification — a merge
+    /// commit an agent authored still carries its footer.
+    /// What: a merge summary plus the house footer stays `FullAgentic`.
+    #[test]
+    fn marker_wins_over_rewrite_fingerprint() {
+        let msg = "Merge branch 'feat/x' into main\n\n\
+                   🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools";
+        assert_eq!(detect_agentic_mode(msg), AgenticMode::FullAgentic);
+        assert_eq!(detect_ai_tool(msg), Some("trusty-mpm"));
     }
 
     /// Why: Claude must win over Cursor when both trailers present.

--- a/crates/trusty-git-analytics/src/collect/ai_markers.rs
+++ b/crates/trusty-git-analytics/src/collect/ai_markers.rs
@@ -23,7 +23,7 @@ use std::sync::OnceLock;
 
 use regex::Regex;
 
-use crate::collect::ai_attribution::AgenticMode;
+use crate::collect::ai_attribution::{provenance_possibly_stripped, AgenticMode};
 use crate::collect::ai_marker_config::{
     marker_file_path, MarkerConfig, MarkerConfigError, MarkerScope,
 };
@@ -61,8 +61,9 @@ impl<'a> CommitSignals<'a> {
 ///
 /// Why: `ai_tool`, `is_ai_assisted` and `agentic_mode` are written from the
 /// same scan so they cannot disagree about whether a commit was AI-assisted.
-/// What: `tool` is the winning marker's label; `mode` is
-/// [`AgenticMode::None`] when nothing matched.
+/// What: `tool` is the winning marker's label; when nothing matched, `mode` is
+/// [`AgenticMode::None`], or [`AgenticMode::Unknown`] if the message shows a
+/// rewrite fingerprint (#5250).
 /// Test: `tests::detects_trusty_mpm_footer`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Detection {
@@ -83,10 +84,13 @@ pub struct Detection {
 /// verdict of [`AgenticMode::None`] falls through to them. Within one scan the
 /// first `FullAgentic` match returns immediately, so it outranks an
 /// `IdeAssisted` match found earlier in that slice; among `IdeAssisted` matches
-/// the earliest supplies the label.
+/// the earliest supplies the label. When neither scan matches, the verdict
+/// splits on [`provenance_possibly_stripped`] (#5250) — that predicate reads the
+/// message only, never the identities the backfill lacks.
 /// Test: `tests::detects_trusty_mpm_footer`,
 /// `tests::full_agentic_wins_over_ide_assisted`,
-/// `tests::operator_full_agentic_cannot_upgrade_a_builtin_ide_match`.
+/// `tests::operator_full_agentic_cannot_upgrade_a_builtin_ide_match`,
+/// `tests::merge_summary_is_unknown_not_none`.
 pub fn detect(signals: &CommitSignals<'_>) -> Detection {
     detect_in(marker_set(), signals)
 }
@@ -101,8 +105,12 @@ pub fn detect(signals: &CommitSignals<'_>) -> Detection {
 /// single flat scan could not deliver it: `scan` returns early on `FullAgentic`
 /// but merely records `IdeAssisted` and keeps going, so an operator
 /// `FullAgentic` entry appended after the two builtin `IdeAssisted` markers
-/// overwrote a copilot verdict with its own.
-/// Test: `tests::operator_full_agentic_cannot_upgrade_a_builtin_ide_match`.
+/// overwrote a copilot verdict with its own. The #5250 `Unknown` split lands
+/// here rather than in `scan` for the same structural reason — see the two
+/// `provenance_stripped` tests below.
+/// Test: `tests::operator_full_agentic_cannot_upgrade_a_builtin_ide_match`,
+/// `tests::operator_marker_still_applies_to_a_provenance_stripped_subject`,
+/// `tests::provenance_stripped_subject_is_unknown_when_no_marker_matches`.
 fn detect_in(set: &MarkerSet, signals: &CommitSignals<'_>) -> Detection {
     let trailers: Vec<&str> = trailer_line()
         .captures_iter(signals.message)
@@ -113,7 +121,26 @@ fn detect_in(set: &MarkerSet, signals: &CommitSignals<'_>) -> Detection {
     if builtin.mode != AgenticMode::None {
         return builtin;
     }
-    scan(&set.markers[set.builtin_len..], signals, &trailers)
+    let operator = scan(&set.markers[set.builtin_len..], signals, &trailers);
+    if operator.mode != AgenticMode::None {
+        return operator;
+    }
+
+    // #5250: neither scan matched a marker. A message git or the forge composed
+    // never had room for the author's marker, so "no marker" is not a
+    // human-work finding there. This split runs once, AFTER both scans — a
+    // `scan` that returned `Unknown` itself would satisfy the `!= None` test
+    // above and skip the operator markers #5414 added.
+    if provenance_possibly_stripped(signals.message) {
+        return Detection {
+            tool: None,
+            mode: AgenticMode::Unknown,
+        };
+    }
+    Detection {
+        tool: None,
+        mode: AgenticMode::None,
+    }
 }
 
 /// One ordered pass over a marker slice.
@@ -135,7 +162,7 @@ fn scan(markers: &[AiMarker], signals: &CommitSignals<'_>, trailers: &[&str]) ->
                     ide = Some(marker.tool);
                 }
             }
-            AgenticMode::None => {}
+            AgenticMode::None | AgenticMode::Unknown => {}
         }
     }
 
@@ -144,6 +171,8 @@ fn scan(markers: &[AiMarker], signals: &CommitSignals<'_>, trailers: &[&str]) ->
             tool: Some(tool),
             mode: AgenticMode::IdeAssisted,
         },
+        // "No marker in this slice" only. The #5250 Unknown split belongs to
+        // `detect_in`, which alone knows both slices came up empty.
         None => Detection {
             tool: None,
             mode: AgenticMode::None,
@@ -621,6 +650,28 @@ mod tests {
         );
     }
 
+    /// Why: #5250 — the fingerprint split happens inside `detect`, not only in
+    /// the predicate, and the email family must not change the verdict. The
+    /// backfill path sees empty emails, so a merge summary has to classify
+    /// identically with and without them or a repaired row stops matching a
+    /// freshly walked one.
+    #[test]
+    fn merge_summary_is_unknown_not_none() {
+        let msg = "Merge branch 'feat/x' into main";
+        let by_message = detect(&CommitSignals::from_message(msg));
+        assert_eq!(by_message.mode, AgenticMode::Unknown);
+        assert_eq!(by_message.tool, None);
+
+        let with_identities = detect(&CommitSignals {
+            message: msg,
+            author_email: "engineer@example.com",
+            committer_email: "noreply@github.com",
+        });
+        assert_eq!(with_identities, by_message);
+
+        assert_eq!(mode_of("feat: add button"), AgenticMode::None);
+    }
+
     /// Why: the disclosure is the answer to "does a low share mean no AI?".
     #[test]
     fn disclosure_names_active_tools() {
@@ -722,6 +773,54 @@ mod tests {
         let d = detect_in(&set, &CommitSignals::from_message(msg));
         assert_eq!(d.mode, AgenticMode::FullAgentic);
         assert_eq!(d.tool, Some("claude"));
+    }
+
+    /// Why: the seam where #5414 and #5250 meet. `provenance_possibly_stripped`
+    /// is true for this subject, so deciding `Unknown` inside `scan` would let
+    /// the builtin pass return a non-`None` verdict and skip the operator
+    /// markers entirely — a merge-summary-shaped commit would become
+    /// unclassifiable by any house marker. The split therefore runs once, after
+    /// both passes.
+    /// What: an operator marker matching a machine merge subject still wins.
+    #[test]
+    fn operator_marker_still_applies_to_a_provenance_stripped_subject() {
+        let msg = "Merge branch 'feat/x' into main";
+        assert!(
+            provenance_possibly_stripped(msg),
+            "precondition: the subject must look stripped, else this proves nothing"
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_marker_file(
+            &dir,
+            "markers:\n  - { tool: house-bot, mode: full_agentic, scope: message, pattern: \"Merge branch\" }\n",
+        );
+        let set = build_marker_set(&path);
+        let d = detect_in(&set, &CommitSignals::from_message(msg));
+        assert_eq!(
+            d.mode,
+            AgenticMode::FullAgentic,
+            "the operator marker must be consulted, not pre-empted by Unknown"
+        );
+        assert_eq!(d.tool, Some("house-bot"));
+    }
+
+    /// Why: the other half of the pair above — with no operator marker to match,
+    /// the same subject must still reach the #5250 `Unknown` verdict.
+    #[test]
+    fn provenance_stripped_subject_is_unknown_when_no_marker_matches() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_marker_file(
+            &dir,
+            "markers:\n  - { tool: house-bot, mode: full_agentic, scope: message, pattern: 'nothing-matches-this' }\n",
+        );
+        let set = build_marker_set(&path);
+        let d = detect_in(
+            &set,
+            &CommitSignals::from_message("Merge branch 'feat/x' into main"),
+        );
+        assert_eq!(d.mode, AgenticMode::Unknown);
+        assert_eq!(d.tool, None);
     }
 
     /// Why: THE error arm. A marker file with a pattern the regex crate

--- a/crates/trusty-git-analytics/src/report/aggregator/accumulate.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/accumulate.rs
@@ -268,7 +268,10 @@ pub(super) fn accumulate_rows(rows: &[CommitRow], flags: &RowFlags) -> Accumulat
         match row.agentic_mode {
             AgenticMode::FullAgentic => w.agentic_count += 1,
             AgenticMode::IdeAssisted => w.ide_assisted_count += 1,
-            AgenticMode::None => {}
+            // #5250: `Unknown` is not a positive classification, so it counts
+            // toward neither numerator — it stays in the `net_commits`
+            // denominator exactly as `None` does. See `persist_weekly_engineer`.
+            AgenticMode::None | AgenticMode::Unknown => {}
         }
         // Issue #445 batch B (request #6): accumulate complexity sum so
         // materialize_weekly_activity can compute avg_complexity without a

--- a/crates/trusty-git-analytics/src/report/aggregator/mod.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/mod.rs
@@ -412,9 +412,13 @@ impl Aggregator {
             let complexity: Option<i64> = row.get(12).unwrap_or(None);
             // Issue #1113: agentic_mode TEXT; defaults to 'none' for pre-v21 rows.
             let agentic_mode_str: String = row.get(13).unwrap_or_else(|_| "none".to_string());
+            // #5250: an unparseable stored value means a newer tga wrote a mode
+            // this build has no name for — that is the "we cannot tell" case,
+            // not a human-work finding. Pre-v21 rows keep reading as 'none'
+            // above, so this fallback only fires on a genuinely foreign value.
             let agentic_mode = agentic_mode_str
                 .parse::<AgenticMode>()
-                .unwrap_or(AgenticMode::None);
+                .unwrap_or(AgenticMode::Unknown);
             Ok(CommitRow {
                 sha: row.get(0)?,
                 author_name: row.get(1)?,

--- a/crates/trusty-git-analytics/src/report/persist.rs
+++ b/crates/trusty-git-analytics/src/report/persist.rs
@@ -190,7 +190,24 @@ pub fn persist_weekly_quality(db: &Database, data: &ReportData) -> Result<usize>
 /// 100` (full-agentic only — excludes `ide_assisted_count`). Rows with
 /// unresolvable author emails are skipped with a `warn!` to preserve
 /// grain-key integrity.
-/// Test: `report::tests::persist_weekly_engineer_upserts_rows`.
+/// Test: `report::tests::persist_weekly_engineer_upserts_rows`,
+/// `report::tests::agentic_pct_keeps_unknown_in_the_denominator`.
+///
+/// # How `agentic_pct` treats `AgenticMode::Unknown` (#5250)
+///
+/// `unknown` commits stay in the `net_commits` DENOMINATOR and contribute to
+/// neither numerator, exactly as `none` does. `agentic_pct` is therefore a
+/// LOWER BOUND on agentic share: a repository whose merge and squash commits
+/// were composed by the forge reports a smaller percentage than the work
+/// warrants, and the size of that deficit is bounded by the unknown count.
+///
+/// Excluding them from the denominator was the alternative, and was rejected:
+/// `fact_weekly_engineer` has no `unknown_count` column, so a reader of the
+/// table could no longer reproduce `agentic_pct` from the columns beside it —
+/// `net_commits` would stop being the denominator it is named for. Reporting
+/// the unknown share needs that column, which is a migration and belongs with
+/// the per-tool attribution work in
+/// [#5251](https://github.com/bobmatnyc/trusty-tools/issues/5251).
 ///
 /// # Errors
 ///
@@ -218,6 +235,8 @@ pub fn persist_weekly_engineer(db: &Database, data: &ReportData) -> Result<usize
             // agentic_pct = agentic_count / net * 100 — intentionally
             // EXCLUDES ide_assisted_count (full-agentic only, per #1113 spec).
             // ide_assisted is tracked separately and must NOT inflate the numerator.
+            // #5250: `unknown` commits are in `net` and in neither numerator, so
+            // this is a lower bound — see the fn doc for why they stay there.
             let agentic_pct = if net > 0 {
                 (wa.agentic_count as f64) / (net as f64) * 100.0
             } else {

--- a/crates/trusty-git-analytics/src/report/tests.rs
+++ b/crates/trusty-git-analytics/src/report/tests.rs
@@ -924,3 +924,65 @@ fn pipeline_author_filter_single_author() {
 
     std::fs::remove_dir_all(&dir).ok();
 }
+
+// =========================================================================
+// agentic_pct treatment of AgenticMode::Unknown (issue #5250)
+// =========================================================================
+
+/// Why: `unknown` and `none` are different findings but must land in the same
+/// place in the `agentic_pct` arithmetic, and nothing in `persist.rs` says so
+/// mechanically. This pins the denominator: `unknown` commits are counted in
+/// `net_commits` and in neither numerator, which is what makes `agentic_pct` a
+/// lower bound rather than a claim.
+/// What: one author-week with one commit of each mode, no reverts, so
+/// `net_commits` is 4. Only `agentic_pct == 25.0` satisfies that — 50.0 would
+/// mean `unknown` was bucketed with `full_agentic`, and 33.3 would mean it was
+/// dropped from the denominator.
+/// Test: this test itself.
+#[test]
+fn agentic_pct_keeps_unknown_in_the_denominator() {
+    let db = Database::open_in_memory().expect("open db");
+    let conn = db.connection();
+    let rows = [
+        ("a1", "feat: agentic work", "full_agentic"),
+        ("a2", "feat: ide completion", "ide_assisted"),
+        ("a3", "Merge branch 'topic' into main", "unknown"),
+        ("a4", "feat: hand written", "none"),
+    ];
+    for (sha, msg, mode) in rows {
+        conn.execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                 repository, files_changed, insertions, deletions, is_merge, ticketed, \
+                 agentic_mode) \
+             VALUES (?1, 'Dana', 'dana@example.com', '2024-01-15T10:00:00+00:00', ?2, \
+                 'repo-a', 1, 5, 1, 0, 0, ?3)",
+            rusqlite::params![sha, msg, mode],
+        )
+        .expect("insert agentic commit");
+    }
+
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+    assert_eq!(data.weekly_activity.len(), 1);
+    let wa = &data.weekly_activity[0];
+    assert_eq!(wa.commit_count_net, 4, "no reverts, so net is all four");
+    assert_eq!(wa.agentic_count, 1, "only full_agentic counts as agentic");
+    assert_eq!(wa.ide_assisted_count, 1, "unknown must not inflate this");
+
+    let (net, agentic, ide, pct): (i64, i64, i64, f64) = db
+        .connection()
+        .query_row(
+            "SELECT net_commits, agentic_count, ide_assisted_count, agentic_pct \
+             FROM fact_weekly_engineer WHERE author_email = 'dana@example.com'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .expect("read persisted engineer row");
+    assert_eq!(net, 4);
+    assert_eq!(agentic, 1);
+    assert_eq!(ide, 1);
+    assert!(
+        (pct - 25.0).abs() < 1e-9,
+        "agentic_pct must be 1/4; 50.0 would bucket unknown as agentic and \
+         33.3 would drop it from the denominator. got {pct}"
+    );
+}

--- a/crates/trusty-git-analytics/tests/agentic_detection_corpus.rs
+++ b/crates/trusty-git-analytics/tests/agentic_detection_corpus.rs
@@ -22,6 +22,7 @@ use std::collections::BTreeMap;
 
 use git2::Repository;
 use regex::Regex;
+use tga::collect::ai_attribution::AgenticMode;
 use tga::collect::ai_markers::{detect, detection_disclosure, CommitSignals};
 
 struct Commit {
@@ -120,6 +121,9 @@ fn catch_rate_on_trusty_tools_history() {
     let mut before = 0usize;
     let mut after = 0usize;
     let mut beyond_baseline = 0usize;
+    // #5250: how much of the marker-less remainder is a message git or the
+    // forge composed, rather than one an author wrote.
+    let mut unknown = 0usize;
     let mut by_tool: BTreeMap<&str, usize> = BTreeMap::new();
 
     for c in &commits {
@@ -143,6 +147,9 @@ fn catch_rate_on_trusty_tools_history() {
                 beyond_baseline += 1;
             }
         }
+        if d.mode == AgenticMode::Unknown {
+            unknown += 1;
+        }
     }
 
     let total = commits.len();
@@ -162,6 +169,28 @@ fn catch_rate_on_trusty_tools_history() {
     );
     let observed: Vec<String> = by_tool.iter().map(|(t, n)| format!("{t}={n}")).collect();
     println!("detections by tool: {}", observed.join(" "));
+    println!(
+        "#5250 unknown (rewrite fingerprint, no marker) = {unknown} ({:.2}% of all commits, \
+         {:.2}% of the {} with no marker)",
+        pct(unknown),
+        unknown as f64 * 100.0 / (total - after) as f64,
+        total - after
+    );
+
+    // #5250: `unknown` is a refinement of the marker-less remainder, so it can
+    // never exceed it. A predicate that started claiming a large share of the
+    // whole corpus would have stopped being the narrow, mechanism-backed rule
+    // this issue asked for.
+    assert!(
+        unknown <= total - after,
+        "unknown must be a subset of the marker-less commits: {unknown} of {}",
+        total - after
+    );
+    assert!(
+        pct(unknown) < 15.0,
+        "the rewrite-fingerprint predicate must stay narrow; got {:.2}% of all commits",
+        pct(unknown)
+    );
 
     assert!(
         pct(after) >= 85.0,

--- a/docs/specs/DOC-67-tga-audit-mode.md
+++ b/docs/specs/DOC-67-tga-audit-mode.md
@@ -513,8 +513,13 @@ indistinguishable from human work — so a low share means "no markers
 emitted", not "no AI assistance". `collect::ai_markers::detection_disclosure()`
 returns the active tool list plus that caveat, and `tga collect` logs it once
 per run; the section renders it verbatim rather than presenting a bare
-percentage. #5250 proposes a distinct `unknown` state so a stripped-marker
-commit stops sharing a bucket with a genuinely human one.
+percentage. #5250 ships a distinct `unknown` state for the part of that
+population detection can prove: a commit whose message git or the forge
+composed, so the author's marker was discarded before the commit object
+existed. `agentic_pct` keeps those commits in its denominator and out of its
+numerator, which makes the figure an explicit lower bound. It does not reach
+a squash whose body is the PR description — that needs the pre-squash commits
+or the PR body, neither of which the commit carries.
 
 The marker set is `collect::ai_markers::BUILTIN` plus whatever operator markers
 `collect::ai_marker_config` loads from disk (#5414). A target org's own house


### PR DESCRIPTION
Rebased onto `aaf4ca04`. Original branch `feat/5250-agentic-unknown` (2 commits, one a `main` merge; the rebase flattened it to one).

## What changes

`AgenticMode` gains `Unknown`, distinct from `None`: a commit whose message git or a forge composed never had room for the author's marker, so "no marker" there is not a human-work finding. Detection reaches it only when no marker matched AND the subject shows a rewrite fingerprint (machine merge summary, or a `(#N)` squash whose body is only synthesized trailers). The enum also becomes `#[non_exhaustive]`.

## Rebase: four conflicts, one of them behavioral

`Cargo.lock`, root `Cargo.toml`, and `crates/trusty-git-analytics/Cargo.toml` were version-only. `ai_markers.rs` was not.

Main gained the #5414 operator-marker file after this branch was written — a two-scan design where builtins decide first and operator markers are consulted only for a commit the builtins left unmarked. The textual auto-merge combined the two features into a real regression:

```rust
// what the auto-merge produced
let builtin = scan(&set.markers[..set.builtin_len], signals, &trailers);
if builtin.mode != AgenticMode::None {
    return builtin;                 // Unknown satisfies this
}
scan(&set.markers[set.builtin_len..], signals, &trailers)
```

with `scan` now returning `Unknown` for "no marker matched, subject looks stripped". For a merge-summary commit the builtin scan returns `Unknown`, the `!= None` test passes, and **the operator markers are never consulted** — a house marker could no longer classify a merge-summary-shaped commit at all.

Resolved by deciding the split once, in `detect_in`, after both scans. `scan` goes back to reporting only "no marker in this slice". Both features then hold simultaneously, which is the only composition where they do.

## Two regression tests, proven to bite

`operator_marker_still_applies_to_a_provenance_stripped_subject` and `provenance_stripped_subject_is_unknown_when_no_marker_matches`. Temporarily reinstating the buggy composition:

```
test collect::ai_markers::tests::operator_marker_still_applies_to_a_provenance_stripped_subject ... FAILED
thread '...' panicked at crates/trusty-git-analytics/src/collect/ai_markers.rs:803:9:
assertion `left == right` failed: the operator marker must be consulted, not pre-empted by Unknown
test result: FAILED. 20 passed; 1 failed
```

Restored, both pass.

## Version: 3.0.0, and the gate agrees

Main had bumped tga to 2.20.0 (#4421 patch, unpublished). A breaking change past 1.0 takes the major position, so 3.0.0 supersedes it. `scripts/check_semver.sh --crate tga` against the published 2.19.0 baseline:

```
Checking tga v2.19.0 -> v3.0.0 (assume minor change)
 Checked [0.310s] 196 checks: 195 pass, 1 fail, 0 warn, 58 skip
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---
Failed in:
  enum AgenticMode in crates/trusty-git-analytics/src/collect/ai_attribution.rs:57
 Summary semver requires new major version: 1 major and 0 minor checks failed
INVENTORY tga: breaking change(s) listed above — permitted by the major bump.
```

Exactly one breaking change, and it is the intended one.

## Rung 3 (localized to tga; no workspace member takes a Cargo edge on it)

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo check -p tga` | EXIT=0 |
| `cargo clippy -p tga --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p tga` | `ok. 1260 passed; 0 failed; 7 ignored` (1258 before the two new tests) |
| `SKIP_UI_BUILD=1 cargo check --workspace` | EXIT=0 (manifest + lockfile changed) |
| `check_line_cap.sh` | `4011 tracked .rs file(s); 4 allowlisted, 0 violations — OK` |
| `check_sld.sh` / `check_changelog_fragment.sh` | EXIT=0 |

## Flake observed, not caused by this branch

The first `cargo test -p tga` failed `audit::tests::the_search_guard_recovers_a_stale_degraded_analyze_daemon`. It is in the same daemon-timing family as the known-flaky `two_concurrent_guards_both_resolve_against_one_slow_daemon`. This branch changes nothing under `src/audit/` (empty `git diff origin/main...HEAD -- crates/trusty-git-analytics/src/audit/`); `origin/main` ran the same filter green 3/3 and the branch 2/2 on re-run. Not chased.

Closes #5250

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
