### PR TITLE
fix(trusty-installer): probe trusty-mpm /health over HTTP instead of reporting unknown (closes #4925)

### DIFF
--- a/crates/trusty-installer/changelog.d/4925-probe-mpm-over-http.md
+++ b/crates/trusty-installer/changelog.d/4925-probe-mpm-over-http.md
@@ -1,0 +1,22 @@
+Fixed
+
+- `probe_member_health` now probes trusty-mpm's `/health` over HTTP instead of
+  reporting it `unknown`. Probeability is a property of the daemon's HTTP
+  transport, not of its lifecycle-management strategy; the two axes diverged when
+  #4246 moved the probe from `<binary> health --json` to HTTP, and the
+  `ManageStrategy::OwnVerb` arm was still keyed off the lifecycle enum. mpm now
+  reports `healthy` when serving and `down` when not, in `tctl status`,
+  `tctl stack health`, `tctl stack doctor` and the `tctl install` verify tail —
+  and `tctl up` no longer issues a redundant `start` against a daemon already
+  known to be answering.
+  - **Behaviour change.** trusty-mpm is `required: true`, so a stopped mpm now
+    yields `tctl status` / `tctl stack health` / `tctl stack doctor` →
+    `degraded`, exit 2, and `tctl install` → NOT VERIFIED. This is intended: mpm
+    becomes consistent with its declared `required` flag rather than exempt from
+    it, exactly as a stopped trusty-search already behaves. CI that gates on
+    `tctl status` exit codes may start failing where it previously passed; start
+    mpm (`tctl start trusty-mpm`) or drop it from the gated set.
+  - `ManageStrategy` is unchanged and still governs `tctl start|stop|restart`
+    dispatch and `needs_kickstart`, so a confirmed-down mpm still cannot be
+    handed to `launchctl kickstart -k` against the nonexistent `com.trusty.mpm`
+    label.

--- a/crates/trusty-installer/src/commands/probe.rs
+++ b/crates/trusty-installer/src/commands/probe.rs
@@ -16,17 +16,24 @@
 //! `output_with_timeout` subprocess wrapper it needed were deleted with the
 //! transport they served.
 //!
+//! #4925: probeability is a property of the daemon's HTTP transport, not of its
+//! lifecycle-management strategy, so [`probe_member_health`] no longer keys the
+//! probe off [`ManageStrategy`]. Both axes coincided while the probe was a
+//! `<binary> health --json` subprocess; #4246 moved it to HTTP `/health` and they
+//! diverged. `OwnVerb` (trusty-mpm) now takes the same transport as `Launchd`.
+//!
 //! What:
-//! - [`probe_member_health`] / [`health_string`]: the strategy-aware daemon
-//!   health probe. Process-managed members (trusty-mpm) are reported
-//!   `Unprobeable` rather than falsely `down`.
+//! - [`probe_member_health`] / [`health_string`]: the daemon health probe. EVERY
+//!   daemon member is probed over HTTP, launchd-supervised or process-managed;
+//!   only a non-daemon ([`ManageStrategy::None`]) is `Unprobeable`.
 //! - [`spawn_member_json`]: spawn `<binary> <verb> --json` and return parsed JSON.
 //! - [`validate_version_envelope`]: the DOC-1 conformance check used by
 //!   `doctor --self-check` (asserts `contract_version` + `verbs[]`).
 //!
 //! Test: `tests` covers `health_string`, `validate_version_envelope`, the
-//! strategy gating in `probe_member_health`, and (against a stub server) the
-//! launchd arm end-to-end — a path no test executed before #4246.
+//! non-daemon gating in `probe_member_health`, and (against a stub server) BOTH
+//! probed arms end-to-end — `Launchd` (a path no test executed before #4246) and
+//! `OwnVerb` (#4925).
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -78,9 +85,9 @@ fn resolve_binary_path(binary: &str) -> Option<PathBuf> {
 /// Why: `status` and `stack` render a one-word health per member; a flat set of
 /// constants keeps the vocabulary consistent and greppable instead of scattering
 /// string literals.
-/// What: the canonical health strings. `UNKNOWN` is the verdict for a
-/// process-managed member whose health cannot be probed via the standard
-/// `health --json` contract verb.
+/// What: the canonical health strings. `UNKNOWN` is the verdict for a member
+/// with no HTTP transport to probe — post-#4925 that is a NON-DAEMON only, so no
+/// member of the shipped stable set produces it (callers filter on `m.daemon`).
 /// Test: used by `health_string`; asserted in `tests::health_string_mapping`.
 pub mod health_str {
     /// Running and at an acceptable version.
@@ -111,7 +118,7 @@ pub fn health_string(h: MemberHealth) -> &'static str {
     }
 }
 
-/// Probe a member's health, honouring its lifecycle [`ManageStrategy`].
+/// Probe a member's health over HTTP, iff it has an HTTP transport to probe.
 ///
 /// Why (#4246): this is THE health probe every `tctl` rollup and the install
 /// verify tail agree on. It used to spawn `<binary> health --json`, a contract no
@@ -122,20 +129,53 @@ pub fn health_string(h: MemberHealth) -> &'static str {
 /// only safe basis for a destructive repair is a transport-level observation
 /// ([`ProbeOutcome::is_confirmed_down`]) — a distinction a `String` cannot carry.
 ///
+/// Why (#4925): PROBEABILITY IS A PROPERTY OF THE TRANSPORT, NOT OF THE
+/// LIFECYCLE. [`ManageStrategy`] answers "how do I start and stop this member?"
+/// — `launchctl bootstrap` versus `trusty-mpm start`. While the probe was a
+/// `<binary> health --json` subprocess the two axes plausibly coincided, so this
+/// dispatch keyed one off the other; #4246 moved the probe to HTTP `/health` and
+/// they separated. Keying off `manage` after that split reported `unknown` for
+/// trusty-mpm — a daemon with an `http_addr`, a fixed-port fallback
+/// (`probe_http::fixed_port_for`) and a 200 on the first try. The host already
+/// demonstrates the separation from the other side: launchd members with NO plist
+/// probe `healthy` every day, so launchd supervision was never a precondition
+/// either. So the dispatch now asks the transport question — does this member
+/// serve HTTP at all? — and only a non-daemon answers no.
+///
+/// `ManageStrategy` is untouched and still governs everything it was for:
+/// `lifecycle::apply_to_member`'s start/stop/restart dispatch and
+/// [`super::verify_tail::needs_kickstart`], which independently requires
+/// `manage == Launchd`. That second one is why this is a one-arm change rather
+/// than a cross-cutting one — a confirmed-down mpm reaches `Refused` here yet
+/// still cannot be handed to `launchctl kickstart -k` against the nonexistent
+/// `com.trusty.mpm` label, which is also why mpm stays `OwnVerb` in
+/// `stable_set::manage_strategy_for` rather than being reclassified.
+///
+/// ACCEPTED CONSEQUENCE (#4925): mpm is `required: true` (`stable_set`), and
+/// `down` — unlike `unknown` — fails `VerifyTailReport::build` and `status`'s
+/// exit code. A user who has simply not started mpm therefore gets `tctl status`
+/// → `degraded`/exit 2 and `tctl install` → NOT VERIFIED. That is intended: it
+/// makes mpm consistent with its declared `required` flag instead of exempt from
+/// it, exactly as a stopped trusty-search already behaves. Do NOT re-add a
+/// tolerance here; demoting `required` would be a separate, argued decision.
+///
 /// # Postconditions
 /// - A binary resolvable on neither `PATH` nor the default install directory is
 ///   [`ProbeOutcome::NotInstalled`] (#3876) — the probe never runs.
-/// - A `Launchd` member is probed over HTTP via [`super::probe_http`].
-/// - An `OwnVerb`/`None` member is [`ProbeOutcome::Unprobeable`], rendering
-///   `unknown`, and can therefore never be kickstarted.
+/// - A DAEMON member — `Launchd` or `OwnVerb` — is probed over HTTP via
+///   [`super::probe_http`].
+/// - A `None` (non-daemon) member is [`ProbeOutcome::Unprobeable`], rendering
+///   `unknown`. It never reaches here in production (callers filter on
+///   `m.daemon`) but keeps the safe default.
 ///
-/// What: resolves the binary, then dispatches on `manage`. The `app` name handed
-/// to the transport is the BINARY name — the `http_addr` discovery file is keyed
-/// by app name, and `crate_name == binary == app name` holds for every stable-set
-/// daemon (see `stable_set`; the one member where it does not, trusty-mpm which
-/// ships both `tm` and `trusty-mpm`, takes the `OwnVerb` arm and is never
-/// probed).
-/// Test: `tests::own_verb_member_is_unknown`,
+/// What: resolves the binary, then dispatches on whether `manage` describes a
+/// daemon. The `app` name handed to the transport is the BINARY name — the
+/// `http_addr` discovery file is keyed by app name, and
+/// `crate_name == binary == app name` holds for every stable-set daemon INCLUDING
+/// trusty-mpm, whose entry is `("trusty-mpm", "trusty-mpm", …)`; the second binary
+/// it ships (`tm`) is not a stable-set member and is never the lookup key.
+/// Test: `tests::own_verb_member_is_probed_over_http`,
+/// `tests::own_verb_member_refused_when_nothing_listens`,
 /// `tests::probe_member_health_serves_from_http_addr`,
 /// `tests::probe_member_health_refused_when_nothing_listens`.
 pub fn probe_member_health(binary: &str, manage: ManageStrategy) -> ProbeOutcome {
@@ -143,17 +183,18 @@ pub fn probe_member_health(binary: &str, manage: ManageStrategy) -> ProbeOutcome
         return ProbeOutcome::NotInstalled;
     }
     match manage {
-        ManageStrategy::Launchd => probe_member_http_blocking(binary, binary),
-        // #4246: trusty-mpm (`OwnVerb`) is DELIBERATELY left unprobed and
-        // reported `unknown`, even though it does answer `/health` on 7880.
-        // It is `required: true` (`stable_set`), and `unknown` is the only
-        // verdict `VerifyTailReport::build` and `status`'s exit code tolerate —
-        // so probing it would flip `tctl status` to exit 2 and `tctl install` to
-        // NOT VERIFIED for every user who simply has not started mpm. Enabling
-        // it is a separate, user-visible policy change, tracked separately.
-        // `None` (non-daemon) never reaches here in production (callers filter on
-        // `m.daemon`) but shares the safe default.
-        ManageStrategy::OwnVerb | ManageStrategy::None => ProbeOutcome::Unprobeable,
+        // #4925: BOTH daemon strategies take the HTTP transport. `OwnVerb` is
+        // process-managed, not transport-less — trusty-mpm answers `/health` on
+        // 7880 — and the `unknown` this arm used to return was a carve-out from
+        // #4246, not a fact about the daemon. `needs_kickstart` still gates the
+        // destructive repair on `Launchd` alone, so widening this arm cannot arm
+        // `kickstart -k` against mpm's nonexistent launchd label.
+        ManageStrategy::Launchd | ManageStrategy::OwnVerb => {
+            probe_member_http_blocking(binary, binary)
+        }
+        // A non-daemon has no `/health` to ask. `Unprobeable` is the honest
+        // answer, not a policy choice.
+        ManageStrategy::None => ProbeOutcome::Unprobeable,
     }
 }
 
@@ -271,20 +312,80 @@ mod tests {
         }
     }
 
-    /// Why (#4246): trusty-mpm is `required: true`, and `unknown` is the only
-    /// verdict `VerifyTailReport::build` and `status`'s exit code tolerate — so
-    /// the `OwnVerb` arm staying `Unprobeable` is what keeps `tctl status` from
-    /// exiting 2, and `tctl install` from printing NOT VERIFIED, for every user
-    /// who has simply not started mpm. Deliberately unchanged by this fix; pin
-    /// it so a well-meaning follow-up cannot flip it silently.
-    /// What: an INSTALLED binary probed with `OwnVerb` is `Unprobeable` and
-    /// renders `unknown`, never a launchd verdict.
+    /// Why (#4925): THE reversal. This test used to be
+    /// `own_verb_member_is_unknown`, pinning `OwnVerb` → `Unprobeable` →
+    /// `unknown` so "a well-meaning follow-up cannot flip it silently". That pin
+    /// was the #4246 carve-out, and #4925 is the argued decision that removes it:
+    /// probeability tracks the HTTP transport, not the lifecycle strategy, and
+    /// trusty-mpm serves `/health`. The assertion is inverted rather than deleted
+    /// so the reversal is recorded in the same place the carve-out was.
+    /// What: plants an `http_addr` for a stub answering `{"status":"ok"}` and
+    /// asserts an `OwnVerb` member probes it — `Serving`/`healthy`, NOT
+    /// `Unprobeable`/`unknown`.
     /// Test: This is the test.
     #[test]
-    fn own_verb_member_is_unknown() {
+    fn own_verb_member_is_probed_over_http() {
+        use crate::commands::test_support as ts;
+        let _guard = ts::ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let addr = ts::stub_seq_blocking(vec![("HTTP/1.1 200 OK", r#"{"status":"ok"}"#)]);
+        let dir = ts::stub_data_dir(ts::PROBEABLE_BINARY, &addr);
+        let outcome = probe_member_health(ts::PROBEABLE_BINARY, ManageStrategy::OwnVerb);
+        ts::clear_data_dir_override(&dir);
+
+        assert_eq!(
+            outcome,
+            ProbeOutcome::Serving {
+                status: "ok".to_owned(),
+                version: None,
+            },
+            "an OwnVerb daemon must take the HTTP transport, not the unknown carve-out"
+        );
+        assert_eq!(outcome.health_string(), health_str::HEALTHY);
+    }
+
+    /// Why (#4925): the mirror of `own_verb_member_is_probed_over_http`, and the
+    /// half that carries the accepted user-visible consequence — a stopped mpm
+    /// now reads `down`, which (unlike `unknown`) fails
+    /// `VerifyTailReport::build`'s required-member gate and degrades `status`'s
+    /// exit code. Asserting it here is what makes that consequence deliberate
+    /// rather than emergent.
+    /// What: plants an `http_addr` at an address guaranteed to refuse and asserts
+    /// an `OwnVerb` member reaches `Refused` → `is_confirmed_down` → `down`.
+    /// Test: This is the test.
+    #[test]
+    fn own_verb_member_refused_when_nothing_listens() {
+        use crate::commands::test_support as ts;
+        let _guard = ts::ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = ts::stub_data_dir(ts::PROBEABLE_BINARY, &ts::dead_addr());
+        let outcome = probe_member_health(ts::PROBEABLE_BINARY, ManageStrategy::OwnVerb);
+        ts::clear_data_dir_override(&dir);
+
+        assert_eq!(outcome, ProbeOutcome::Refused);
+        assert!(outcome.is_confirmed_down());
+        assert_eq!(outcome.health_string(), health_str::DOWN);
+        // The kickstart gate is a SEPARATE axis and must not have moved with the
+        // probe: a confirmed-down `OwnVerb` member is still ineligible for
+        // `launchctl kickstart -k` (there is no `com.trusty.mpm` label to
+        // kickstart). Asserted end-to-end from a REAL probe outcome here;
+        // `verify_tail_tests::needs_kickstart_only_for_confirmed_down_launchd`
+        // covers the predicate's full truth table.
+        assert!(!crate::commands::verify_tail::needs_kickstart(
+            &outcome,
+            ManageStrategy::OwnVerb
+        ));
+    }
+
+    /// Why (#4925): a NON-daemon has no `/health` to ask, so `Unprobeable` must
+    /// survive the reversal for `ManageStrategy::None`. Without this the widened
+    /// arm could quietly grow to cover every strategy and start probing `tga`.
+    /// What: an INSTALLED binary probed with `None` is `Unprobeable`, renders
+    /// `unknown`, and is not confirmed-down.
+    /// Test: This is the test.
+    #[test]
+    fn non_daemon_member_is_unprobeable() {
         let outcome = probe_member_health(
             crate::commands::test_support::PROBEABLE_BINARY,
-            ManageStrategy::OwnVerb,
+            ManageStrategy::None,
         );
         assert_eq!(outcome, ProbeOutcome::Unprobeable);
         assert_eq!(outcome.health_string(), health_str::UNKNOWN);

--- a/crates/trusty-installer/src/commands/probe_http.rs
+++ b/crates/trusty-installer/src/commands/probe_http.rs
@@ -223,11 +223,13 @@ impl ProbeOutcome {
     /// Map to the `tctl up` orchestration vocabulary.
     ///
     /// Why: `ensure_member` (DOC-12 §3.4) branches on `MemberHealth`, not on a
-    /// string. `Unprobeable` maps to `Down` here — NOT to a health verdict —
-    /// deliberately preserving today's `tctl up` behaviour for trusty-mpm (it
-    /// falls through to `start`, which is idempotent). `ensure_member` treats
-    /// `Down` and `HealthyStale` identically, so nothing in `up`'s action set
-    /// turns on that choice.
+    /// string. `Unprobeable` maps to `Down` here — NOT to a health verdict — so a
+    /// member whose health could not be established falls through to `start`,
+    /// which is idempotent. `ensure_member` treats `Down` and `HealthyStale`
+    /// identically, so nothing in `up`'s action set turns on that choice.
+    /// (#4925: trusty-mpm is no longer the example. It is probed over HTTP now,
+    /// so it reaches a real `Serving`/`Refused` verdict and only a NON-daemon
+    /// still arrives here as `Unprobeable`.)
     /// What: `Serving` via [`classify_status`]; `NotInstalled` preserved; every
     /// other variant `Down`.
     /// Test: `tests::member_health_maps_every_variant`.

--- a/crates/trusty-installer/src/commands/probe_http_tests.rs
+++ b/crates/trusty-installer/src/commands/probe_http_tests.rs
@@ -656,8 +656,10 @@ fn health_string_maps_every_variant() {
 }
 
 /// Why: `tctl up`'s `ensure_member` branches on `MemberHealth`, not on a string.
-/// `Unprobeable` must map to `Down` (not to a health verdict) so trusty-mpm keeps
-/// falling through to its idempotent `start`, exactly as before #4246.
+/// `Unprobeable` must map to `Down` (not to a health verdict) so a member whose
+/// health could not be established falls through to its idempotent `start`.
+/// (#4925: trusty-mpm is no longer that member — it is probed over HTTP and
+/// reaches a real verdict; only a non-daemon is `Unprobeable` now.)
 /// What: asserts the `MemberHealth` for each variant.
 /// Test: This is the test.
 #[test]
@@ -669,7 +671,7 @@ fn member_health_maps_every_variant() {
     assert_eq!(
         ProbeOutcome::Unprobeable.member_health(),
         MemberHealth::Down,
-        "mpm must keep falling through to `start`, as it did pre-#4246"
+        "an unestablished health must fall through to the idempotent `start`"
     );
     for down in [
         ProbeOutcome::NoAddress,

--- a/crates/trusty-installer/src/commands/stack/health.rs
+++ b/crates/trusty-installer/src/commands/stack/health.rs
@@ -54,9 +54,12 @@ impl HealthReport {
     /// to `degraded`. A `down` daemon is the running-but-broken failure signal; a
     /// `not_installed` member is a real gap in the resolved stable set (an
     /// operator after a failed install must NOT see green). Only a genuinely
-    /// `unknown` member (e.g. trusty-mpm, deliberately left unprobed — #4246) does
-    /// NOT degrade — its health is unprobeable, not absent. `stale` also stays
-    /// non-degrading (running, just below the version floor).
+    /// `unknown` member does NOT degrade — its health is undetermined, not
+    /// absent. `stale` also stays non-degrading (running, just below the version
+    /// floor). (#4925: trusty-mpm used to be this policy's one live example; it is
+    /// probed over HTTP now, so a stopped mpm degrades the verdict like any other
+    /// daemon. Whether an undetermined health should advance a green verdict at
+    /// all is #4847's open question and is untouched here.)
     /// Test: `tests::verdict_down_is_degraded`,
     /// `tests::verdict_not_installed_is_degraded`,
     /// `tests::verdict_unknown_is_ready`.
@@ -165,8 +168,10 @@ mod tests {
         assert_eq!(r.exit_code(), 2);
     }
 
-    /// Why: an `unknown` member (mpm) must NOT degrade the verdict — its health
-    /// is merely unprobeable via the standard contract, not absent.
+    /// Why: an `unknown` member must NOT degrade the verdict — its health is
+    /// merely undetermined, not absent. (#4925: the `trusty-mpm` name is now just
+    /// a label on a hand-written row; mpm itself is probed and no longer reports
+    /// `unknown`. The POLICY under test is unchanged and still live.)
     /// What: one unknown member → `ready`, exit 0. A mix of unknown + healthy
     /// also stays ready, proving unknown never falsely degrades.
     /// Test: This is the test.

--- a/crates/trusty-installer/src/commands/status.rs
+++ b/crates/trusty-installer/src/commands/status.rs
@@ -217,8 +217,10 @@ mod tests {
         assert_eq!(incomplete.exit_code(), 0);
     }
 
-    /// Why: A process-managed member (mpm) reports `unknown` health, which must
-    /// NOT degrade the verdict (it is not a `down` daemon).
+    /// Why: an `unknown` health must NOT degrade the verdict (it is not a `down`
+    /// daemon). A generic policy pin, not an assertion about any one member —
+    /// #4925 made mpm probeable, so the `trusty-mpm` name below is only a label on
+    /// a hand-written row; the policy it pins is unchanged.
     /// What: Builds a report with an `unknown` daemon; asserts `ready`.
     /// Test: This is the test.
     #[test]

--- a/crates/trusty-installer/src/commands/up/system_runner.rs
+++ b/crates/trusty-installer/src/commands/up/system_runner.rs
@@ -97,9 +97,14 @@ impl Runner for SystemRunner {
     /// `start`). What DOES change, and is the point, is that a genuinely healthy
     /// daemon now reads `HealthyVersionOk` and is reported a no-op instead of
     /// being handed a redundant `start` — the same false-`down` class as the
-    /// verify tail's spurious kickstart, one layer up. trusty-mpm keeps its
-    /// pre-#4246 behaviour exactly: `OwnVerb` → `Unprobeable` → `Down` → `start`,
-    /// which is idempotent.
+    /// verify tail's spurious kickstart, one layer up.
+    ///
+    /// #4925 extended that saving to trusty-mpm. It used to keep its pre-#4246
+    /// behaviour exactly — `OwnVerb` → `Unprobeable` → `Down` → a redundant (but
+    /// idempotent) `start` on every `tctl up`, indistinguishable in the logs from
+    /// a real recovery. It is now probed over HTTP like every other daemon, so a
+    /// serving mpm reads `HealthyVersionOk` and `up` reports a no-op instead of
+    /// spawning a process against a daemon already known to be answering.
     fn probe(&self, member: &BootMember) -> MemberHealth {
         let manage = crate::commands::stable_set::manage_strategy_for(&member.binary, true);
         crate::commands::probe::probe_member_health(&member.binary, manage).member_health()

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -190,11 +190,18 @@ impl VerifyTailReport {
     /// `down`/`not_installed`` (an OPTIONAL member's health never fails this
     /// — demo-critical fix). A `stale` or `unknown` member does NOT fail
     /// verification — mirrors `stack::health::HealthReport`'s degrade policy
-    /// exactly (an under-the-version-floor daemon is still up; an
-    /// unprobeable process-managed member is not a verified gap).
+    /// exactly (an under-the-version-floor daemon is still up; a member with no
+    /// probeable transport is not a verified gap).
+    ///
+    /// #4925: trusty-mpm is no longer an example of the `unknown` tolerance. It
+    /// is probed over HTTP now, so a stopped mpm arrives here as `down` and — it
+    /// being `required: true` — FAILS verification. That is the accepted policy
+    /// consequence, not an oversight: the tolerance is for members whose health
+    /// genuinely cannot be determined, and mpm's can.
     /// Test: `tests::verified_requires_ensure_and_health`,
     /// `tests::verified_tolerates_stale_and_unknown`,
-    /// `tests::verified_ignores_optional_down_member`.
+    /// `tests::verified_ignores_optional_down_member`,
+    /// `tests::required_mpm_reporting_down_fails_verification`.
     fn build(ensure_ok: bool, members: Vec<VerifyRow>) -> Self {
         let health_ok = members
             .iter()
@@ -213,8 +220,17 @@ impl VerifyTailReport {
 ///
 /// Why: only a `down` LAUNCHD daemon is the #2498 failure signature
 /// (`launchctl bootstrap` succeeded, `RunAtLoad` never fired); a `not_installed`
-/// member, an `unknown` process-managed member (trusty-mpm), or a non-launchd
-/// member must never trigger a kickstart attempt.
+/// member, or any non-launchd member, must never trigger a kickstart attempt.
+///
+/// #4925: the `manage == Launchd` half of this predicate is now LOAD-BEARING FOR
+/// A LIVE CODE PATH rather than a hypothetical. `probe_member_health` used to
+/// return `Unprobeable` for trusty-mpm, so no `OwnVerb` member could ever reach
+/// `is_confirmed_down()` and the strategy check was belt-and-braces. mpm is now
+/// probed over HTTP, so a genuinely-stopped mpm DOES produce `Refused`, and this
+/// check is the only thing standing between that and
+/// `launchctl kickstart -k gui/<uid>/com.trusty.mpm` — a label that does not
+/// exist (mpm is process-managed via its own `start`/`stop` verbs; the
+/// `com.trusty.mpm.supervisor` job is a different job). Do not relax it.
 ///
 /// #4246: this predicate was never wrong — `probe_member_health` MANUFACTURED
 /// the `down` it fired on, by shelling out to a `health --json` verb no daemon

--- a/crates/trusty-installer/src/commands/verify_tail_tests.rs
+++ b/crates/trusty-installer/src/commands/verify_tail_tests.rs
@@ -68,6 +68,15 @@ impl Kickstarter for FakeKickstarter {
 /// Why: only a CONFIRMED-down LAUNCHD daemon is the #2498 failure signature.
 /// #4246 changed the input from a hand-typed string to a typed `ProbeOutcome`
 /// and the condition to `is_confirmed_down` — a transport-level observation.
+///
+/// #4925 MADE THE `OwnVerb` ROW LOAD-BEARING FOR A LIVE CODE PATH. It used to be
+/// hypothetical: `probe_member_health` returned `Unprobeable` for trusty-mpm, so
+/// no `OwnVerb` member could reach `is_confirmed_down()` and this row asserted
+/// about a state production never produced. mpm is now probed over HTTP, so a
+/// genuinely-stopped mpm DOES arrive here as `Refused` — and this row is the
+/// assertion that it is still refused a `launchctl kickstart -k` against
+/// `com.trusty.mpm`, a label that does not exist on any host. Flipping it green
+/// would mean firing a destructive repair at a nonexistent launchd job.
 /// What: asserts the truth table across outcome x manage-strategy, including the
 /// mirror property that a genuinely-refusing daemon IS still repaired.
 /// Test: This is the test.
@@ -78,7 +87,12 @@ fn needs_kickstart_only_for_confirmed_down_launchd() {
             needs_kickstart(&confirmed, ManageStrategy::Launchd),
             "{confirmed:?} on a launchd member must still be repaired"
         );
-        assert!(!needs_kickstart(&confirmed, ManageStrategy::OwnVerb));
+        assert!(
+            !needs_kickstart(&confirmed, ManageStrategy::OwnVerb),
+            "#4925: a confirmed-down mpm is now REACHABLE and must never be \
+             eligible for `launchctl kickstart -k com.trusty.mpm` — no such label \
+             exists ({confirmed:?})"
+        );
         assert!(!needs_kickstart(&confirmed, ManageStrategy::None));
     }
 
@@ -254,9 +268,18 @@ fn verified_requires_ensure_and_health() {
     assert!(both_ok.verified);
 }
 
-/// Why: `stale` (running, below version floor) and `unknown`
-/// (process-managed, unprobeable — trusty-mpm) must NOT fail verification
-/// — mirrors `stack::health::HealthReport`'s degrade policy exactly.
+/// Why: `stale` (running, below version floor) and `unknown` (no probeable
+/// transport) must NOT fail verification — mirrors
+/// `stack::health::HealthReport`'s degrade policy exactly.
+///
+/// #4925: the POLICY under test is unchanged and still live, but its trusty-mpm
+/// EXEMPLAR is now hypothetical. mpm is probed over HTTP, so production no longer
+/// hands this function an `unknown` mpm row — a stopped mpm arrives as `down` and
+/// correctly fails (see `required_mpm_reporting_down_fails_verification`). The row
+/// is kept rather than swapped for a `None`-strategy member because this is a pure
+/// test of `build`'s string policy over hand-written rows: it asserts that
+/// `unknown` is tolerated whoever reports it, which is exactly the property #4847
+/// is still arguing about and which must not be lost by accident here.
 /// What: a report with only stale/unknown members still verifies.
 /// Test: This is the test.
 #[test]
@@ -269,6 +292,42 @@ fn verified_tolerates_stale_and_unknown() {
         ],
     );
     assert!(report.verified);
+}
+
+/// Why (#4925): THE gate that was unreachable before this change. `verify_tail`
+/// filters on `m.daemon` and trusty-mpm is `daemon: true`, so mpm was always
+/// probed and always landed a row here — but the row read `unknown`, and
+/// `build`'s required-member gate rejects only `down`/`not_installed`. mpm being
+/// `required: true` was therefore inert: an install that left mpm dead printed
+/// VERIFIED and exited 0. Now that the probe yields `down`, mpm's `required` flag
+/// finally has effect, and this test is what pins the accepted consequence.
+/// What: a REQUIRED trusty-mpm row reporting `down` flips `verified` to `false`;
+/// the same row `healthy` verifies, so it is the health and not the member name
+/// doing the work.
+/// Test: This is the test.
+#[test]
+fn required_mpm_reporting_down_fails_verification() {
+    let dead_mpm = VerifyTailReport::build(
+        true,
+        vec![
+            row("trusty-search", health_str::HEALTHY),
+            row("trusty-mpm", health_str::DOWN),
+        ],
+    );
+    assert!(
+        !dead_mpm.verified,
+        "a required member reporting `down` must fail verification — mpm is \
+         `required: true` and is no longer exempt via `unknown` (#4925)"
+    );
+
+    let live_mpm = VerifyTailReport::build(
+        true,
+        vec![
+            row("trusty-search", health_str::HEALTHY),
+            row("trusty-mpm", health_str::HEALTHY),
+        ],
+    );
+    assert!(live_mpm.verified);
 }
 
 /// Why: THE demo-critical fix — an OPTIONAL daemon member (e.g.

--- a/docs/research/tart-vm-testing-harness/02-design/02-harness-contracts.md
+++ b/docs/research/tart-vm-testing-harness/02-design/02-harness-contracts.md
@@ -102,7 +102,8 @@ PASS  iff  for every in-scope package p:
            and H_P(p), the accepted health set for p under pattern P, is
 
              H_P(p) := {healthy, stale}
-                     ∪ {unknown}  if member(p).plist_installed == null
+                     ∪ {unknown, down}
+                                  if member(p).plist_installed == null
                      ∪ {down}     if P ∈ {b, c} and member(p).plist_installed == false
 
            and, since 2026-08-04, PASS additionally requires
@@ -197,23 +198,51 @@ the *opposite* direction — a doctor member the TSV does not carry is logged, n
 asserted, which is why `trusty-console` correctly does not fail a run. This is
 that rule's missing counterpart.
 
-**(b) `unknown` is accepted for members the product deliberately declines to
-probe.** `probe_member_health` (`commands/probe.rs:141-158`) returns
-`ProbeOutcome::Unprobeable` for `ManageStrategy::OwnVerb`, and
-`probe_http.rs:211` maps `Unprobeable` to `unknown`. The source comment is
-explicit that this is a decision, not a gap:
+**(b) A non-launchd member (`plist_installed == null`) is accepted `unknown` or
+`down`.**
 
-> `#4246`: trusty-mpm (`OwnVerb`) is DELIBERATELY left unprobed and reported
-> `unknown`, even though it does answer `/health` on 7880. […] probing it would
-> flip `tctl status` to exit 2 and `tctl install` to NOT VERIFIED for every user
-> who simply has not started mpm. Enabling it is a separate, user-visible policy
-> change, tracked separately.
+> **PREMISE REVERSED BY THE PRODUCT 2026-08-05 (`#4925`).** This bullet
+> previously read *"`unknown` is accepted for members the product deliberately
+> declines to probe"*, and cited `probe_member_health`
+> (`commands/probe.rs:141-158`) returning `ProbeOutcome::Unprobeable` for
+> `ManageStrategy::OwnVerb`, quoting that function's own comment as the warrant:
+>
+> > `#4246`: trusty-mpm (`OwnVerb`) is DELIBERATELY left unprobed and reported
+> > `unknown`, even though it does answer `/health` on 7880. […] probing it would
+> > flip `tctl status` to exit 2 and `tctl install` to NOT VERIFIED for every user
+> > who simply has not started mpm. Enabling it is a separate, user-visible policy
+> > change, tracked separately.
+>
+> **`#4925` is that separate, user-visible policy change, and it was accepted.**
+> The carve-out is gone: `probe_member_health` now routes `ManageStrategy::OwnVerb`
+> through the same HTTP `/health` transport as `Launchd`, because **probeability is
+> a property of the daemon's HTTP transport, not of its lifecycle-management
+> strategy** — the two axes diverged when `#4246` moved the probe from
+> `<binary> health --json` to HTTP. `ManageStrategy` is unchanged and still governs
+> start/stop dispatch and `needs_kickstart`, which is why mpm remains `OwnVerb` in
+> `stable_set`. Corrected here rather than deleted, per this doc set's
+> record-reversals convention.
 
-Rejecting `unknown` therefore asserts against a documented product decision.
-**The condition is written as `plist_installed == null`, not as a member name.**
-`null` means "not a launchd member" (§1.1's own field table) which is exactly the
-`OwnVerb`/`None` set that `probe_member_health` returns `Unprobeable` for, so the
-acceptance is **derived from the JSON** and follows the product automatically if
+**What that leaves.** trusty-mpm — the only member this clause has ever fired for
+— now reports a real verdict: `healthy` when serving on 7880, `down` when not.
+
+- **`unknown` is retained but vestigial.** No member of the shipped stable set
+  produces it any more (only `ManageStrategy::None`, a non-daemon, is still
+  `Unprobeable`, and `stack doctor` does not report non-daemons). It is kept so a
+  member that genuinely cannot be probed does not turn into a red run before
+  anyone has decided that it should — that is **#4847**'s open policy question,
+  which this oracle does not pre-empt.
+- **`down` is now accepted for `plist_installed == null` too**, for exactly the
+  reason (c) accepts it for `plist_installed == false`: nothing in this harness's
+  install path starts a daemon before the oracle reads `doctor`. A process-managed
+  member has no plist and no `service install` step for the `false` branch to key
+  off, so its pre-start `down` is the same artefact of the ordering, not a
+  packaging defect. **A genuinely dead mpm still fails the run** — at
+  `verify_daemon_liveness`, which probes it directly *after* `tctl start --json`.
+
+**The condition is still written as `plist_installed == null`, not as a member
+name.** `null` means "not a launchd member" (§1.1's own field table), so the
+acceptance stays **derived from the JSON** and follows the product automatically if
 another member ever changes strategy. Naming `trusty-mpm` in the predicate would
 hardcode today's `stable_set` into the oracle.
 
@@ -229,9 +258,10 @@ it correctly. **The cause previously recorded for it was not.**
 > modified by this correction** — only the reasoning a future reader would act on.
 
 **Mechanism — `health` is a pure HTTP fact, and `plist_installed` is not an input
-to it.** For a `Launchd` member, `probe_member_health` delegates to
-`probe_member_http_blocking` (`commands/probe.rs:146`), a blocking `GET /health`
-against the member's recorded address. `probe_http.rs:213-218` maps
+to it.** For a DAEMON member — `Launchd` or, since `#4925`, `OwnVerb` —
+`probe_member_health` delegates to `probe_member_http_blocking`
+(`commands/probe.rs`), a blocking `GET /health` against the member's recorded
+address. `probe_http.rs:213-218` maps
 `NoAddress | Refused | Timeout | HttpError | BadEnvelope | ProbeFailed` to
 `down` — **every one of those is a transport fact about the request**.
 `plist_installed` is computed **only** at `doctor.rs:117-124`, solely to populate
@@ -659,13 +689,18 @@ INTERIM (as amended 2026-08-04 — see below; the status CODE is not the signal)
 > (`stack/health.rs:96`), classified on the body through the same
 > `probe_member_health` this amendment is modelled on — so it is genuinely
 > product-maintained, body-based, 503-tolerant, and sweeps the whole stable set.
-> **It would nonetheless LOSE an assertion this oracle already makes.**
-> `trusty-mpm` is *deliberately* left unprobed by `probe_member_health`
+> **The primary reason for declining it was withdrawn 2026-08-05 (#4925).** It
+> used to be that delegating **would LOSE an assertion this oracle already makes**:
+> `trusty-mpm` was *deliberately* left unprobed by `probe_member_health`
 > (`ManageStrategy::OwnVerb` → `Unprobeable` → `unknown`, #4246) **even though it
 > does answer `/health` on 7880** — which the oracle's own probe reaches and
-> proves. Delegating would downgrade a daemon this harness demonstrates is serving
-> into a verdict nothing can assert on. It also drops `version`, drops each
-> daemon's raw body, and carries no `service` discriminator.
+> proves, so delegating would have downgraded a daemon this harness demonstrates is
+> serving into a verdict nothing can assert on. #4925 removed that carve-out;
+> `stack health` now covers mpm and no assertion is lost on that account.
+>
+> **The decision stands on the reasons that were always independent of mpm:** it
+> drops `version`, drops each daemon's raw body, and carries no `service`
+> discriminator.
 >
 > **So the product's CLASSIFICATION RULE is adopted; the product's COMMAND is not
 > substituted for the probe.** `stack health --json` is recorded verbatim in the
@@ -677,7 +712,8 @@ INTERIM (as amended 2026-08-04 — see below; the status CODE is not the signal)
 > per-member predicate, whose verdict vocabularies differ (`ready|degraded` vs
 > `ok|degraded`). `verify_stack_doctor` still uses `stack doctor`. This section
 > considered `stack health` as an *additional* surface for the liveness probe
-> specifically, and **declined it** for the `trusty-mpm` reason above.
+> specifically, and **declined it** — originally for the `trusty-mpm` reason above,
+> now for the envelope reasons that outlived it.
 
 > **`trusty-review` is now one of the daemons this covers.** *(Amended 2026-07-31,
 > D3 widened to eight crates.)* It was previously in this section's four-shape table
@@ -3154,10 +3190,12 @@ Recorded in the same register as DOC-1 §14, so they are not lost.
   > whole stable set, so the harness need not invent a health rule. **It recovers
   > none of the envelope itself** — no `version`, no per-daemon body, and **no
   > `service` discriminator**, so the **#3364** squatter-collision class stays
-  > open; that class is closable only by a product change RC-1 would carry. It
-  > also reports `trusty-mpm` as `unknown` (`OwnVerb` → `Unprobeable`, #4246),
+  > open; that class is closable only by a product change RC-1 would carry.
+  > ~~It also reports `trusty-mpm` as `unknown` (`OwnVerb` → `Unprobeable`, #4246),
   > which is why substituting it for the probe would **lose** an assertion the
-  > oracle already makes. The harness therefore adopted the product's
+  > oracle already makes.~~ **Withdrawn 2026-08-05 (#4925)** — mpm is probed over
+  > HTTP now, so `stack health` covers it; the envelope reasons above are what the
+  > decision rests on. The harness therefore adopted the product's
   > **classification rule** and declined its **command**. **RC-1's status is
   > unchanged by this evaluation** — it neither becomes more urgent nor less.
 - ~~**RC-2 — `tctl install` cargo-absent exit code and message** (§6.2). Not pinned

--- a/vmtest-harness/lib/verify.sh
+++ b/vmtest-harness/lib/verify.sh
@@ -572,22 +572,47 @@ _verify_package_expectation() {
 #       §F-10(e) resolved the OPPOSITE direction (a doctor member the TSV does
 #       not carry -> logged, not asserted); this is its missing counterpart.
 #
-#   (b) `unknown` IS ACCEPTED FOR A MEMBER THE PRODUCT DECLINES TO PROBE.
-#       `probe_member_health` (commands/probe.rs:141-158) returns
-#       `ProbeOutcome::Unprobeable` for `ManageStrategy::OwnVerb`, which
-#       `probe_http.rs:211` maps to `unknown`. The source comment is explicit
-#       that this is a DECISION, not a gap — #4246: "trusty-mpm (`OwnVerb`) is
-#       DELIBERATELY left unprobed and reported `unknown`, even though it does
-#       answer /health on 7880 […] Enabling it is a separate, user-visible
-#       policy change, tracked separately." Rejecting `unknown` asserts against
-#       a documented product decision.
+#   (b) A NON-LAUNCHD MEMBER (`plist_installed == null`) IS ACCEPTED
+#       `unknown` OR `down`.
 #
-#       THE CONDITION IS `plist_installed == null`, NOT A MEMBER NAME. `null`
-#       means "not a launchd member" (§1.1's field table) — exactly the
-#       `OwnVerb`/`None` set `probe_member_health` returns `Unprobeable` for. So
-#       the acceptance is DERIVED FROM THE JSON and follows the product by
-#       itself if another member ever changes strategy. Hardcoding `trusty-mpm`
-#       here would freeze today's `stable_set` into the oracle.
+#       PREMISE REVERSED BY THE PRODUCT, 2026-08-05 (#4925). This bullet used to
+#       read "`unknown` IS ACCEPTED FOR A MEMBER THE PRODUCT DECLINES TO PROBE",
+#       and quoted `probe.rs`'s own comment as the warrant: "#4246: trusty-mpm
+#       (`OwnVerb`) is DELIBERATELY left unprobed and reported `unknown`, even
+#       though it does answer /health on 7880 […] Enabling it is a separate,
+#       user-visible policy change, tracked separately." THAT CARVE-OUT IS GONE.
+#       #4925 is the separate, argued policy change it referred to:
+#       `probe_member_health` now routes `ManageStrategy::OwnVerb` through the
+#       SAME HTTP transport as `Launchd`, because probeability is a property of
+#       the daemon's HTTP transport and not of its lifecycle-management strategy
+#       — the two axes diverged when #4246 moved the probe from
+#       `<binary> health --json` to HTTP `/health`. Only `ManageStrategy::None`
+#       (a non-daemon, which `stack doctor` does not report on) is still
+#       `Unprobeable`.
+#
+#       WHAT THAT MEANS FOR THE ORACLE. trusty-mpm — the only member this
+#       clause has ever fired for — now reports a REAL verdict: `healthy` when
+#       serving on 7880, `down` when not. So:
+#         - `unknown` is retained in the accepted set but is now VESTIGIAL: no
+#           member of the shipped stable set produces it. It is kept rather than
+#           deleted so a member that genuinely cannot be probed does not turn
+#           into a red run before anyone has decided that it should (that is
+#           #4847's open policy question, and this oracle does not pre-empt it).
+#         - `down` IS NOW ACCEPTED FOR `plist_installed == null` TOO, for
+#           EXACTLY the reason (c) accepts it for `plist_installed == false`:
+#           nothing in this harness's install path starts a daemon before the
+#           oracle reads `doctor`. mpm is process-managed (`OwnVerb`), so no
+#           plist and no `service install` step is even applicable to it — its
+#           pre-start `down` is the same structural artefact of the ordering,
+#           not a packaging defect. `verify_daemon_liveness` runs
+#           `tctl start --json` and asserts mpm SERVING afterwards; that is
+#           where a genuinely dead mpm fails, and it still does.
+#
+#       THE CONDITION IS STILL `plist_installed == null`, NOT A MEMBER NAME.
+#       `null` means "not a launchd member" (§1.1's field table). Hardcoding
+#       `trusty-mpm` here would freeze today's `stable_set` into the oracle; the
+#       acceptance stays DERIVED FROM THE JSON and follows the product by itself
+#       if another member ever changes strategy.
 #
 #   (c) `down` IS ACCEPTED WHEN `plist_installed == false`, UNDER ALL THREE
 #       PATTERNS — WIDENED FROM {b,c} ON 2026-08-04, BY OBSERVATION, AND ONLY
@@ -762,14 +787,26 @@ verify_stack_doctor() {
             present)
                 # H_P(p) — the accepted health set, DERIVED FROM THE JSON, never
                 # from a member name (§1.1a). Base {healthy, stale}; plus
-                # `unknown` when `plist_installed == null` (a non-launchd member,
-                # which is exactly the OwnVerb/None set `probe_member_health`
-                # returns `Unprobeable` for, #4246); plus `down` when
-                # `plist_installed == false` under the source-install patterns,
-                # where DOC-1 §6.5 bans the only step that writes a plist.
+                # {unknown, down} when `plist_installed == null` (a non-launchd
+                # member); plus `down` when `plist_installed == false`, where
+                # DOC-1 §6.5 bans the only step that writes a plist.
+                #
+                # #4925 CHANGED WHAT THE `null` BRANCH IS FOR — see §1.1a(b).
+                # `unknown` used to be the point of it: `probe_member_health`
+                # returned `Unprobeable` for `ManageStrategy::OwnVerb`, so
+                # trusty-mpm reported `unknown` by product decision. That
+                # carve-out is gone — `OwnVerb` now takes the same HTTP `/health`
+                # transport as `Launchd`, so mpm reports `healthy` or `down` like
+                # any other daemon. `unknown` is kept but is VESTIGIAL (no
+                # shipped member produces it); `down` is added because nothing in
+                # this harness's install path starts a daemon before doctor is
+                # read, and a process-managed member has no plist for the `false`
+                # branch to key off. A genuinely dead mpm still fails the run —
+                # at `verify_daemon_liveness`, which probes it directly AFTER
+                # `tctl start --json`.
                 accepted='healthy stale'
                 if [ "$plist" = 'null' ]; then
-                    accepted="${accepted} unknown"
+                    accepted="${accepted} unknown down"
                 fi
                 # An explicit `if`, NOT `[ … ] && accepted=…`: a bare AND-list
                 # whose left side fails is the `set -e` gotcha the driver warns
@@ -1027,16 +1064,24 @@ verify_versions() {
 # `{"command","members":[{"member","health"}],"verdict":"ready"|"degraded"}`,
 # exit 0/2, over `stable_set()` filtered to `m.daemon` (stack/health.rs:96),
 # body-classified and 503-tolerant through the same `probe_member_health` this
-# correction is modelled on. It is tempting AND IT WOULD LOSE AN ASSERTION THIS
-# ORACLE ALREADY MAKES: `trusty-mpm` is DELIBERATELY LEFT UNPROBED by
-# `probe_member_health` (`ManageStrategy::OwnVerb` -> `Unprobeable` ->
-# `unknown`, #4246), so delegating would downgrade a daemon this loop PROVES is
-# serving on 7880 into a verdict nothing can assert on. It also drops `version`
-# and carries no `service` discriminator, so it closes nothing RC-1 opens. The
-# product's CLASSIFICATION RULE is adopted here; the product's COMMAND is not
-# substituted for the probe. (§1.1's warning against swapping `stack health` in
-# for `stack doctor` is a different question and is untouched — `verify_stack_doctor`
-# still uses `stack doctor`.)
+# correction is modelled on.
+#
+# THE PRIMARY REASON FOR DECLINING IT WAS WITHDRAWN 2026-08-05 (#4925). It used
+# to be that delegating WOULD LOSE AN ASSERTION THIS ORACLE ALREADY MAKES:
+# `trusty-mpm` was DELIBERATELY LEFT UNPROBED by `probe_member_health`
+# (`ManageStrategy::OwnVerb` -> `Unprobeable` -> `unknown`, #4246), so `stack
+# health` could not speak to a daemon this loop PROVES is serving on 7880. #4925
+# removed that carve-out — `OwnVerb` takes the same HTTP `/health` transport as
+# `Launchd` now, so `stack health` DOES cover mpm and no assertion would be lost
+# on that account.
+#
+# THE DECISION STANDS ANYWAY, on the reasons that were always independent of mpm:
+# `stack health --json` drops `version`, drops each daemon's raw body, and carries
+# no `service` discriminator, so it closes nothing RC-1 opens and leaves the #3364
+# squatter-collision class open. The product's CLASSIFICATION RULE is adopted
+# here; the product's COMMAND is not substituted for the probe. (§1.1's warning
+# against swapping `stack health` in for `stack doctor` is a different question and
+# is untouched — `verify_stack_doctor` still uses `stack doctor`.)
 # ===========================================================================
 #
 # §F-7 — DAEMON START AND PORT DISCOVERY, RESOLVED BY OBSERVATION (step 2, not
@@ -1314,9 +1359,10 @@ verify_snapshot_inputs() {
     done
 
     # `tctl stack health --json` — RECORDED, NEVER ASSERTED ON, and deliberately
-    # not the liveness probe (see `verify_daemon_liveness`'s header for why:
-    # `trusty-mpm` is `Unprobeable` -> `unknown` there, which would LOSE an
-    # assertion this harness already makes). It is logged because it is the
+    # not the liveness probe (see `verify_daemon_liveness`'s header for why: it
+    # drops `version`, the raw body, and any `service` discriminator. The mpm
+    # `Unprobeable` -> `unknown` reason that used to head that list was withdrawn
+    # by #4925 — mpm is probed over HTTP now.) It is logged because it is the
     # product's own body-based rollup over the same member set, so a divergence
     # between it and the oracle's own probe is the single most informative thing
     # a reader of a failed run could have. Read at snapshot time, i.e. BEFORE


### PR DESCRIPTION
Closes #4925.

`probe_member_health` keyed its dispatch off `ManageStrategy`, which answers "how do I start and stop this member?" — not "does this member serve HTTP?". While the probe was a `<binary> health --json` subprocess the two coincided. #4246 moved the probe to HTTP `/health` and they separated, leaving trusty-mpm reported `unknown` despite answering `/health` on 7880 with an `http_addr` file and a fixed-port fallback. Both daemon strategies now take the HTTP transport; only `ManageStrategy::None` (non-daemon) stays `Unprobeable`.

## The policy change this carries

Main pinned the old behaviour in `own_verb_member_is_unknown` — "pin it so a well-meaning follow-up cannot flip it silently". This PR is that follow-up, arriving deliberately with the owner's approval. The pin is replaced, not worked around: the same test is inverted in place to `own_verb_member_is_probed_over_http`, so the reversal is recorded where the carve-out was.

**Accepted consequence.** trusty-mpm is `required: true`, and `down` — unlike `unknown` — fails `VerifyTailReport::build` and `status`'s exit code. A user who has not started mpm now gets `tctl status` → `degraded`/exit 2 and `tctl install` → NOT VERIFIED. That is the point: mpm becomes consistent with its declared `required` flag instead of exempt from it, exactly as a stopped trusty-search already behaves. `required_mpm_reporting_down_fails_verification` pins it.

## What did not move

`needs_kickstart` is unchanged — `outcome.is_confirmed_down() && manage == ManageStrategy::Launchd`. That `manage == Launchd` check is the only thing preventing `launchctl kickstart -k` against the nonexistent `com.trusty.mpm` label, and it becomes load-bearing here because a confirmed-down mpm now reaches `Refused`. `own_verb_member_refused_when_nothing_listens` asserts it end-to-end from a real probe outcome; `needs_kickstart_only_for_confirmed_down_launchd` covers the predicate's truth table.

mpm also stays `OwnVerb` in `stable_set::manage_strategy_for` — reclassifying it would move the kickstart axis too.

## Test ladder — rung 4

`trusty-audit` depends on `trusty-installer`, so the dependent leg is included.

```
cargo fmt --check                                          EXIT=0
cargo check -p trusty-installer                            EXIT=0
cargo clippy -p trusty-installer --all-targets -D warnings EXIT=0
cargo test -p trusty-installer   → 595 passed; 0 failed; 4 ignored (+ 6 in integration targets)
SKIP_UI_BUILD=1 cargo check --workspace                    EXIT=0
cargo test -p trusty-audit       → 156 passed; 0 failed; 3 ignored (+ 18 in integration targets)

bash scripts/check_line_cap.sh           EXIT=0
bash scripts/check_sld.sh                EXIT=0
bash scripts/check_changelog_fragment.sh EXIT=0
bash scripts/check_rustdoc_links.sh      → 25 crate(s) documented, 0 broken link(s), baseline 0
```

New tests that fail on `main`: `own_verb_member_is_probed_over_http` and `own_verb_member_refused_when_nothing_listens` both assert an `OwnVerb` member takes the HTTP transport, where `main` returns `Unprobeable`.

Rebased onto `origin/main` at 3e06bee8 with no conflicts — the branch already carried a merge of #4246, and #4388's probe work did not touch the dispatch arm.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
