### PR TITLE
fix(trusty-common): stop tests reading — and printing — the machine's real credentials

### DIFF
--- a/crates/trusty-common/changelog.d/3451-credential-resolver-test-leak.md
+++ b/crates/trusty-common/changelog.d/3451-credential-resolver-test-leak.md
@@ -1,0 +1,7 @@
+Security
+- `credentials::resolver`'s precedence tests no longer print a resolved
+  credential when they fail. The env tier reads real credential variables, so
+  a bare `assert_eq!` on the result echoed whatever the process held — which
+  is how a live OpenRouter key reached test output. Actual values now render
+  through `redact_secret`, and a test provokes the failure path to prove it
+  (#3451).

--- a/crates/trusty-common/changelog.d/3451-tests-stop-reading-ambient-credentials.md
+++ b/crates/trusty-common/changelog.d/3451-tests-stop-reading-ambient-credentials.md
@@ -1,0 +1,14 @@
+Fixed
+- Tests no longer inherit the machine's real `.env.local` credentials.
+  `credentials::redact`'s `resolved_secret_values` test fired the process-wide
+  `.env.local` loader while holding no lock, republishing a real
+  `OPENROUTER_API_KEY` mid-assertion in `credentials::resolver`'s tests; it now
+  joins the `dotenv_credential_env` serial group. The `memory_core::dream`
+  dedup, prune, stats and recall tests built on `DreamConfig::default()`, whose
+  empty key resolves against that same environment — with one present they
+  built a live OpenRouter backend and issued billed LLM calls whose merge
+  actions moved the drawer counts they assert on, which is why
+  `dream_cycle_merges_duplicates` and
+  `dream_cycle_compression_ratio_nonzero_after_dedup` failed intermittently.
+  Those tests now disable the semantic phase explicitly and read no credential
+  environment variable (#3451).

--- a/crates/trusty-common/src/credentials/redact.rs
+++ b/crates/trusty-common/src/credentials/redact.rs
@@ -427,7 +427,17 @@ mod tests {
     /// usable as a needle set — never that a particular provider is
     /// configured, which depends on the machine running the test.
     /// Test: itself.
+    ///
+    /// [`resolved_secret_values`] calls `load_env_local_once`, which folds the
+    /// machine's real `.env.local` into the PROCESS environment. Held no lock
+    /// until now, so it raced `credentials::resolver::tests`: firing the loader
+    /// between that test's `remove_var` and its `load_env_from_path` republished
+    /// the real `OPENROUTER_API_KEY`, `dotenvy` then declined to override it,
+    /// and the assertion printed a live key into test output. Join the same
+    /// `dotenv_credential_env` group as every other test that reads or writes a
+    /// credential env var — this test is a WRITER of them, via the loader.
     #[test]
+    #[serial_test::serial(dotenv_credential_env)]
     fn resolved_secret_values_are_scrubbable_by_scrub_secrets() {
         let values = resolved_secret_values();
         assert!(

--- a/crates/trusty-common/src/credentials/resolver.rs
+++ b/crates/trusty-common/src/credentials/resolver.rs
@@ -107,26 +107,128 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
+    /// RAII guard over one process-wide credential environment variable.
+    ///
+    /// Why: these tests must drive `std::env` to exercise the env tier, but
+    /// the same process environment is where [`dotenv::load_env_local_once`]
+    /// deposits the developer's REAL credentials. A test that ended with a
+    /// bare `remove_var` therefore destroyed a real value for every test that
+    /// ran after it in the same binary, and a test that assumed a variable was
+    /// absent was reading machine state rather than a fixture it built. This
+    /// guard makes each test set what it needs and put back exactly what it
+    /// found, so no test depends on — or damages — ambient state (#3451).
+    /// What: captures the prior value on construction and restores it on drop,
+    /// removing the variable again when there was no prior value.
+    /// Test: used by every test in this module.
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        /// Set `key` to `value` for the guard's lifetime.
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            // SAFETY: every caller is `#[serial(dotenv_credential_env)]` — the
+            // group every test in this crate that reads or writes a credential
+            // env var joins — so no other test thread mutates the environment
+            // concurrently with this call.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+
+        /// Remove `key` for the guard's lifetime.
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            // SAFETY: see `EnvVarGuard::set`.
+            unsafe { std::env::remove_var(key) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: see `EnvVarGuard::set`.
+            unsafe {
+                match self.previous.take() {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    /// Render a resolved credential for a failure message without disclosing it.
+    ///
+    /// Why: the env tier reads REAL credential variables, so a failing
+    /// `assert_eq!` on the raw `Option<String>` prints whatever the process
+    /// actually holds. That is how this module printed a live OpenRouter key
+    /// into test output. Every ACTUAL value goes through
+    /// [`crate::credentials::redact_secret`], which is non-reversible by
+    /// contract; only the EXPECTED side is a test literal and safe verbatim.
+    fn describe(value: Option<&str>) -> String {
+        match value {
+            None => "None".to_string(),
+            Some(v) => format!("Some({})", crate::credentials::redact_secret(v)),
+        }
+    }
+
+    /// Assert a resolution result, redacting the actual value on failure.
+    ///
+    /// Why: no assertion in this module may print a credential, pass or fail —
+    /// see [`describe`].
+    fn assert_resolved(actual: Option<String>, expected: Option<&str>) {
+        assert!(
+            actual.as_deref() == expected,
+            "expected {expected:?}, got {} (actual value redacted: this \
+             assertion can observe a real credential from the process \
+             environment)",
+            describe(actual.as_deref())
+        );
+    }
+
+    /// Why: the leak this module shipped lived in the FAILURE path — a passing
+    /// run printed nothing, so no happy-path test could catch its return. The
+    /// env tier reads real credential variables, so a mismatch here can hold a
+    /// live key; assert directly that the panic message does not carry it.
+    /// What: provokes a failed [`assert_resolved`] with a secret-shaped actual
+    /// value and checks the message keeps only the non-reversible preview.
+    /// Test: itself.
+    #[test]
+    fn a_failed_resolution_assert_never_prints_the_secret() {
+        let secret = "sk-or-v1-0123456789abcdef0123456789abcdef";
+        let panic = std::panic::catch_unwind(|| {
+            assert_resolved(Some(secret.to_string()), Some("from-dotenv"));
+        })
+        .expect_err("a mismatched resolution must panic");
+        let msg = panic
+            .downcast_ref::<String>()
+            .expect("assert! panics with a String payload");
+
+        assert!(
+            !msg.contains(secret),
+            "the failure message echoed the secret verbatim"
+        );
+        assert!(
+            !msg.contains("0123456789"),
+            "the failure message echoed secret material past the redaction head"
+        );
+        assert!(
+            msg.contains(&crate::credentials::redact_secret(secret)),
+            "the failure message must still identify WHICH credential it saw"
+        );
+    }
+
     /// Why: tier 1 (process env) must win over tier 3 (store) — the core
     /// precedence contract.
     /// Test: itself.
     #[test]
     #[serial(dotenv_credential_env)]
     fn env_beats_store() {
-        // SAFETY: `#[serial(dotenv_credential_env)]` guarantees no other
-        // test in this crate mutates process env concurrently with this one.
-        unsafe {
-            std::env::set_var("FIREWORKS_API_KEY", "from-env");
-        }
+        let _guard = EnvVarGuard::set("FIREWORKS_API_KEY", "from-env");
         let store = MemoryKeyStore::new();
         store.set("fireworks", "from-store").unwrap();
-        assert_eq!(
-            resolve_key_with("fireworks", &store),
-            Some("from-env".to_string())
-        );
-        unsafe {
-            std::env::remove_var("FIREWORKS_API_KEY");
-        }
+        assert_resolved(resolve_key_with("fireworks", &store), Some("from-env"));
     }
 
     /// Why: tier 2 (`.env.local`, once loaded into the process env) must
@@ -138,10 +240,13 @@ mod tests {
     #[test]
     #[serial(dotenv_credential_env)]
     fn dotenv_loaded_value_beats_store() {
-        // SAFETY: see `env_beats_store`.
-        unsafe {
-            std::env::remove_var("OPENROUTER_API_KEY");
-        }
+        // The guard clears the variable so `load_env_from_path` below is what
+        // populates it (`dotenvy` never overrides an already-set var), and
+        // restores whatever the machine had on drop. Nothing here reads an
+        // ambient value: the fixture is a `.env.local` this test writes into a
+        // temp dir, so the outcome is identical on a machine with no such file
+        // and on one whose file says something else.
+        let _guard = EnvVarGuard::remove("OPENROUTER_API_KEY");
         let tmp = tempfile::TempDir::new().unwrap();
         let env_path = tmp.path().join(".env.local");
         std::fs::write(&env_path, "OPENROUTER_API_KEY=from-dotenv\n").unwrap();
@@ -149,13 +254,7 @@ mod tests {
 
         let store = MemoryKeyStore::new();
         store.set("openrouter", "from-store").unwrap();
-        assert_eq!(
-            resolve_key_with("openrouter", &store),
-            Some("from-dotenv".to_string())
-        );
-        unsafe {
-            std::env::remove_var("OPENROUTER_API_KEY");
-        }
+        assert_resolved(resolve_key_with("openrouter", &store), Some("from-dotenv"));
     }
 
     /// Why: with no env var and no `.env.local` value, the store tier must
@@ -164,16 +263,10 @@ mod tests {
     #[test]
     #[serial(dotenv_credential_env)]
     fn falls_through_to_store() {
-        // SAFETY: see `env_beats_store`.
-        unsafe {
-            std::env::remove_var("ANTHROPIC_API_KEY");
-        }
+        let _guard = EnvVarGuard::remove("ANTHROPIC_API_KEY");
         let store = MemoryKeyStore::new();
         store.set("anthropic", "from-store").unwrap();
-        assert_eq!(
-            resolve_key_with("anthropic", &store),
-            Some("from-store".to_string())
-        );
+        assert_resolved(resolve_key_with("anthropic", &store), Some("from-store"));
     }
 
     /// Why: when every tier is absent, resolution must return `None`, not
@@ -182,12 +275,9 @@ mod tests {
     #[test]
     #[serial(dotenv_credential_env)]
     fn absent_everywhere_is_none() {
-        // SAFETY: see `env_beats_store`.
-        unsafe {
-            std::env::remove_var("OPENAI_API_KEY");
-        }
+        let _guard = EnvVarGuard::remove("OPENAI_API_KEY");
         let store = MemoryKeyStore::new();
-        assert_eq!(resolve_key_with("openai", &store), None);
+        assert_resolved(resolve_key_with("openai", &store), None);
     }
 
     /// Why: an env var explicitly set to the empty string must not shadow
@@ -196,18 +286,9 @@ mod tests {
     #[test]
     #[serial(dotenv_credential_env)]
     fn empty_env_var_falls_through_to_store() {
-        // SAFETY: see `env_beats_store`.
-        unsafe {
-            std::env::set_var("FIREWORKS_API_KEY", "");
-        }
+        let _guard = EnvVarGuard::set("FIREWORKS_API_KEY", "");
         let store = MemoryKeyStore::new();
         store.set("fireworks", "from-store").unwrap();
-        assert_eq!(
-            resolve_key_with("fireworks", &store),
-            Some("from-store".to_string())
-        );
-        unsafe {
-            std::env::remove_var("FIREWORKS_API_KEY");
-        }
+        assert_resolved(resolve_key_with("fireworks", &store), Some("from-store"));
     }
 }

--- a/crates/trusty-common/src/memory_core/dream/cycle.rs
+++ b/crates/trusty-common/src/memory_core/dream/cycle.rs
@@ -344,8 +344,14 @@ pub struct RoomConsolidationStats {
 /// `SemanticConsolidator`.
 /// Test: exercised via `dream_cycle_semantic_consolidation_no_inference`
 /// (`Ok(None)` path), `dream_cycle_semantic_consolidation_invalid_model_disables_once`
-/// (`Err` path), and the production daemon.
-fn build_consolidator_from_config(
+/// (`Err` path), and the production daemon; the env-tier read itself is pinned
+/// by `dream::tests::dedup_only_config_ignores_an_ambient_openrouter_key`.
+///
+/// `pub(super)` only so that last test can call it directly — reaching it
+/// through `dream_cycle` cannot distinguish "no backend was built" from "a
+/// backend was built and its network call failed", which is the whole
+/// distinction that test exists to pin. Still private to `dream`.
+pub(super) fn build_consolidator_from_config(
     config: &DreamConfig,
 ) -> Result<Option<Arc<SemanticConsolidator>>> {
     if !config.semantic.enabled {

--- a/crates/trusty-common/src/memory_core/dream/tests.rs
+++ b/crates/trusty-common/src/memory_core/dream/tests.rs
@@ -74,6 +74,35 @@ async fn open_test_handle(name: &str) -> Arc<PalaceHandle> {
     handle
 }
 
+/// A [`DreamConfig`] whose semantic phase is switched off.
+///
+/// Why: `DreamConfig::default()` leaves `semantic.enabled = true` with an empty
+/// `openrouter_api_key`, and `build_consolidator_from_config` resolves that
+/// empty key against the PROCESS environment. On a machine with no
+/// `OPENROUTER_API_KEY` the Ollama branch rejects the default cloud model id,
+/// the phase disables itself, and these tests look deterministic. Let any test
+/// in this binary call `load_env_local_once` first — it folds the developer's
+/// real `.env.local` into the process environment — and the identical config
+/// instead builds an `OpenRouterInference` and issues live, billed LLM calls
+/// whose merge actions add and supersede drawers, changing the very counts
+/// these tests assert on. Every test below that exercises dedup, prune,
+/// compaction, stats or the recall benchmark reads no credential and wants no
+/// network, so it says so rather than inheriting whichever answer the machine
+/// happens to give.
+/// What: `DreamConfig::default()` with `semantic.enabled = false`, which makes
+/// `build_consolidator_from_config` return `Ok(None)` before it reads any
+/// environment variable.
+/// Test: `dedup_only_config_ignores_an_ambient_openrouter_key`.
+fn dedup_only_config() -> DreamConfig {
+    DreamConfig {
+        semantic: crate::memory_core::semantic_consolidation::SemanticConsolidationConfig {
+            enabled: false,
+            ..Default::default()
+        },
+        ..DreamConfig::default()
+    }
+}
+
 /// Why: Two near-identical drawers should collapse to one after a dream
 /// cycle so the L1 cache isn't filled with duplicates.
 /// What: Insert two drawers with the same content (verbatim — embeddings
@@ -103,7 +132,7 @@ async fn dream_cycle_merges_duplicates() {
         .unwrap();
     assert_eq!(handle.drawers.read().len(), 2);
 
-    let dreamer = Dreamer::new(DreamConfig::default());
+    let dreamer = Dreamer::new(dedup_only_config());
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
 
     assert_eq!(stats.merged, 1, "expected exactly one merge");
@@ -137,7 +166,7 @@ async fn dream_cycle_prunes_low_importance() {
     }
     assert_eq!(handle.drawers.read().len(), 1);
 
-    let dreamer = Dreamer::new(DreamConfig::default());
+    let dreamer = Dreamer::new(dedup_only_config());
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
 
     assert_eq!(stats.pruned, 1, "expected exactly one prune");
@@ -180,7 +209,7 @@ async fn dream_cycle_prunes_at_floor_importance() {
     }
     assert_eq!(handle.drawers.read().len(), 1);
 
-    let dreamer = Dreamer::new(DreamConfig::default());
+    let dreamer = Dreamer::new(dedup_only_config());
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
 
     assert_eq!(
@@ -206,7 +235,7 @@ async fn dreamer_shutdown_terminates_loop() {
     registry.register_arc(handle);
     let dreamer = Arc::new(Dreamer::new(DreamConfig {
         idle_secs: 10,
-        ..DreamConfig::default()
+        ..dedup_only_config()
     }));
     let (tx, rx) = tokio::sync::watch::channel(false);
     let join = dreamer.clone().start_with_shutdown(registry, id, rx);
@@ -250,7 +279,7 @@ async fn dream_loop_does_not_pin_palace_handle() {
     // never peeks the registry during this test and holds no handle Arc.
     let dreamer = Arc::new(Dreamer::new(DreamConfig {
         idle_secs: 3600,
-        ..DreamConfig::default()
+        ..dedup_only_config()
     }));
     let (_tx, rx) = tokio::sync::watch::channel(false);
     let _join = dreamer.start_with_shutdown(registry.clone(), id.clone(), rx);
@@ -326,7 +355,7 @@ async fn dream_cycle_compacts_orphaned_vectors() {
     // don't trigger an accidental merge against the orphan vectors.
     let dreamer = Dreamer::new(DreamConfig {
         dedup_threshold: 0.999,
-        ..DreamConfig::default()
+        ..dedup_only_config()
     });
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
 
@@ -366,7 +395,7 @@ async fn dream_stats_persisted_after_cycle() {
         .await
         .unwrap();
 
-    let dreamer = Dreamer::new(DreamConfig::default());
+    let dreamer = Dreamer::new(dedup_only_config());
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
 
     let data_dir = handle.data_dir.clone().expect("data_dir set");
@@ -404,7 +433,7 @@ async fn closet_refresh_builds_index() {
         .await
         .unwrap();
 
-    let dreamer = Dreamer::new(DreamConfig::default());
+    let dreamer = Dreamer::new(dedup_only_config());
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
     assert!(
         stats.closets_updated > 0,
@@ -441,7 +470,7 @@ async fn dream_cycle_toggles_is_compacting() {
     assert!(!handle.is_compacting(), "guard must clear on drop");
 
     // Full cycle still clears the flag on exit.
-    let dreamer = Dreamer::new(DreamConfig::default());
+    let dreamer = Dreamer::new(dedup_only_config());
     let _stats = dreamer.dream_cycle(&handle).await.unwrap();
     assert!(
         !handle.is_compacting(),
@@ -483,7 +512,7 @@ async fn dream_content_prune_drops_blocklist_drawer() {
         .unwrap();
     assert_eq!(handle.drawers.read().len(), 2);
 
-    let dreamer = Dreamer::new(DreamConfig::default());
+    let dreamer = Dreamer::new(dedup_only_config());
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
 
     assert_eq!(
@@ -526,7 +555,7 @@ async fn dream_content_prune_drops_short_drawer() {
         .unwrap();
     assert_eq!(handle.drawers.read().len(), 2);
 
-    let dreamer = Dreamer::new(DreamConfig::default());
+    let dreamer = Dreamer::new(dedup_only_config());
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
 
     assert_eq!(
@@ -560,7 +589,7 @@ async fn dream_content_prune_keeps_good_drawer() {
         .unwrap();
     assert_eq!(handle.drawers.read().len(), 1);
 
-    let dreamer = Dreamer::new(DreamConfig::default());
+    let dreamer = Dreamer::new(dedup_only_config());
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
 
     assert_eq!(
@@ -842,6 +871,9 @@ async fn dream_cycle_semantic_consolidation_invalid_model_disables_once() {
         .await
         .unwrap();
 
+    // Deliberately the real default: this test is ABOUT the semantic phase's
+    // validation path, so it must keep `semantic.enabled = true` and rely on
+    // `EnvVarGuard::remove` above for its hermeticity.
     let dreamer = Dreamer::new(DreamConfig::default());
     assert!(!dreamer.is_semantic_consolidation_disabled());
 
@@ -1120,7 +1152,7 @@ async fn dream_cycle_records_drawer_counts() {
 
     let dreamer = Dreamer::new(DreamConfig {
         dedup_threshold: 0.999, // nothing deduped
-        ..DreamConfig::default()
+        ..dedup_only_config()
     });
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
 
@@ -1163,7 +1195,7 @@ async fn dream_cycle_compression_ratio_nonzero_after_dedup() {
         .unwrap();
     assert_eq!(handle.drawers.read().len(), 2);
 
-    let dreamer = Dreamer::new(DreamConfig::default());
+    let dreamer = Dreamer::new(dedup_only_config());
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
 
     assert_eq!(stats.drawers_before, 2, "two drawers before cycle");
@@ -1245,7 +1277,7 @@ async fn dream_cycle_records_recall_scores() {
 
     let dreamer = Dreamer::new(DreamConfig {
         dedup_threshold: 0.999, // nothing removed
-        ..DreamConfig::default()
+        ..dedup_only_config()
     });
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
 
@@ -1289,7 +1321,7 @@ async fn dream_stats_effectiveness_fields_persisted() {
 
     let dreamer = Dreamer::new(DreamConfig {
         dedup_threshold: 0.999,
-        ..DreamConfig::default()
+        ..dedup_only_config()
     });
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
 
@@ -1342,7 +1374,7 @@ async fn dream_cycle_recall_benchmark_disabled() {
     let dreamer = Dreamer::new(DreamConfig {
         recall_benchmark_enabled: false,
         dedup_threshold: 0.999, // nothing removed
-        ..DreamConfig::default()
+        ..dedup_only_config()
     });
     let stats = dreamer.dream_cycle(&handle).await.unwrap();
 
@@ -1762,20 +1794,64 @@ struct EnvVarGuard {
 impl EnvVarGuard {
     fn remove(key: &'static str) -> Self {
         let previous = std::env::var(key).ok();
-        // Safety: test-only; single-threaded test execution.
+        // Safety: test-only; every caller is `#[serial(dotenv_credential_env)]`.
         unsafe { std::env::remove_var(key) };
+        Self { key, previous }
+    }
+
+    /// Set `key` to `value` for the guard's lifetime.
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        // Safety: test-only; every caller is `#[serial(dotenv_credential_env)]`.
+        unsafe { std::env::set_var(key, value) };
         Self { key, previous }
     }
 }
 
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
-        // Safety: test-only; single-threaded test execution.
+        // Safety: test-only; every caller is `#[serial(dotenv_credential_env)]`.
         match &self.previous {
             Some(v) => unsafe { std::env::set_var(self.key, v) },
             None => unsafe { std::env::remove_var(self.key) },
         }
     }
+}
+
+/// Why: pins both halves of the reason [`dedup_only_config`] exists.
+/// `DreamConfig::default()` resolves its empty `openrouter_api_key` against the
+/// PROCESS environment, so once anything in this binary calls
+/// `load_env_local_once` — which folds the developer's real `.env.local` into
+/// that environment — every dedup/prune/stats test built on the default config
+/// silently acquired a live OpenRouter backend and issued billed LLM calls
+/// whose merge actions moved the drawer counts those tests assert on. That is
+/// the intermittency behind `dream_cycle_merges_duplicates` and
+/// `dream_cycle_compression_ratio_nonzero_after_dedup`.
+/// What: with a fixture key in the environment, asserts the dedup-only config
+/// builds NO backend while the default config builds one. Constructing a
+/// backend issues no request, so this reaches no network and needs no real
+/// credential.
+/// Test: itself.
+#[test]
+#[serial(dotenv_credential_env)]
+fn dedup_only_config_ignores_an_ambient_openrouter_key() {
+    let _guard = EnvVarGuard::set("OPENROUTER_API_KEY", "sk-or-v1-fixture-not-a-real-key");
+
+    assert!(
+        super::cycle::build_consolidator_from_config(&dedup_only_config())
+            .expect("a disabled semantic phase is not an error")
+            .is_none(),
+        "dedup-only config must build no inference backend, so the ambient \
+         key is never read and no LLM call can be issued"
+    );
+
+    assert!(
+        super::cycle::build_consolidator_from_config(&DreamConfig::default())
+            .expect("a resolvable cloud key passes model validation")
+            .is_some(),
+        "default config turns an ambient OPENROUTER_API_KEY into a live \
+         backend — the behaviour the dedup tests used to inherit by accident"
+    );
 }
 
 /// Why (#5187): `merge_into` capped the merged drawer with a raw


### PR DESCRIPTION
Three tests red on `main`, reachable since #5743 replaced the vacuous
feature-less `cargo test -p trusty-common` with a `compile_error!`. They share
one root cause: `load_env_local_once` folds the developer's real `.env.local`
into the shared test process environment, and tests read `OPENROUTER_API_KEY`
back out of it.

Refs #3451 (hermetic test isolation epic).

## The credential leak — `credentials::resolver::tests::dotenv_loaded_value_beats_store`

`credentials::redact`'s `resolved_secret_values_are_scrubbable_by_scrub_secrets`
is the writer. It calls `resolved_secret_values()` → `load_env_local_once()`
while holding no lock, so it raced the resolver test between that test's
`remove_var` and its `load_env_from_path`. The real key was republished,
`dotenvy` declined to override it, and `assert_eq!` printed a live OpenRouter
key into test output. Reproduced at iteration 3 of 30 running just those two
under 4 threads; the same loop is now 60/60 clean.

Two fixes, because there are two defects:

- The redact test joins the `dotenv_credential_env` serial group — it is a
  WRITER of credential env vars, via the loader.
- No resolver assertion can print a credential any more, pass or fail. Actual
  values render through `redact_secret`; only the expected side is a test
  literal. All five tests in the module had the same shape, so all five
  changed. They also borrow-and-restore via an RAII guard instead of ending in
  a bare `remove_var` that clobbered a real value for every later test.

`a_failed_resolution_assert_never_prints_the_secret` provokes the failure path
and asserts the message keeps no secret material. What it produces now:

```
expected Some("from-dotenv"), got Some(sk-o…(41 chars)) (actual value
redacted: this assertion can observe a real credential from the process
environment)
```

The test also builds its own `.env.local` fixture in a temp dir and reads no
ambient value, so it passes on a machine with no such file and on one whose
file says something else.

## The dream tests — `dream_cycle_merges_duplicates`, `dream_cycle_compression_ratio_nonzero_after_dedup`

Not flakes, and not order-dependence between themselves. `DreamConfig::default()`
leaves `semantic.enabled = true` with an empty `openrouter_api_key`, and
`build_consolidator_from_config` resolves that empty key against the process
environment. With no key the Ollama branch rejects the default cloud model id
and the phase disables itself, which is why these looked deterministic. With a
key present the same config builds an `OpenRouterInference` and issues live,
billed LLM calls whose merge actions add and supersede drawers — moving the
very counts these tests assert on.

Measured, same test, same binary: 0.23-0.26s per run with no key, 0.36-0.45s
with one. The difference is the HTTPS round trip.

Every dedup, prune, stats and recall test now uses `dedup_only_config()`, which
disables the semantic phase so no credential is read and no backend is built.
The semantic tests keep `DreamConfig::default()` and their existing env guards
— they are about that phase.

## Production change

One, and it is visibility only: `build_consolidator_from_config` becomes
`pub(super)`, still private to `dream`. Reaching it through `dream_cycle`
cannot distinguish "no backend was built" from "a backend was built and its
network call failed", which is the distinction the new regression test exists
to pin. No public API changes, so no consumer can observe it.

## Gates — rung 4

```
cargo fmt --check                                                  clean
cargo clippy -p trusty-common --all-targets --features memory-core,embedder-test-support -- -D warnings
                                                                   exit 0
cargo test -p trusty-common --features memory-core,embedder-test-support
                                                                   1039 passed; 0 failed; 13 ignored (was 1037; +2 new tests)
SKIP_UI_BUILD=1 cargo check --workspace                            exit 0
bash scripts/check_rustdoc_links.sh   25 crate(s), 0 broken link(s), baseline 0
bash scripts/check_line_cap.sh                                     exit 0
bash scripts/check_sld.sh                                          exit 0
bash scripts/check_changelog_fragment.sh   all 1 crate(s) with source changes recorded
```

Repeated runs, after the fix:

```
three named tests, 15 runs         FAILURES=0 of 15
dream+credentials, 15 runs, 8 threads   FAILURES=0 of 15  (139 passed each)
whole lib suite, 3 runs            1039 passed / 1039 passed / 1039 passed
resolver+redact contention, 60 runs     FAILURES=0 of 60
```

The new `dedup_only_config_ignores_an_ambient_openrouter_key` was verified to
FAIL when the fix is reverted (flip `enabled: false` back to `true`):

```
panicked at crates/trusty-common/src/memory_core/dream/tests.rs:1840:5:
dedup-only config must build no inference backend, so the ambient key is
never read and no LLM call can be issued
```

## Pre-existing, not touched

`bash scripts/check_contracts.sh --crate trusty-common` exits 3 with
`NO VERDICT: the rustdoc JSON build failed`. Verified identical on a clean
`origin/main` at `3e06bee8` with these changes stashed — pre-existing, unrelated
to this PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
