### PR TITLE
feat(trusty-memory): bare `serve` speaks MCP stdio; start daemon single-flight (closes #5267)

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -285,7 +285,6 @@ crates/trusty-memory/src/commands/doctor/mod.rs	doctor_fix_palaces_lists_orphane
 crates/trusty-memory/src/commands/kuzu_migrate.rs	read_entities_returns_expected_count
 crates/trusty-memory/src/commands/kuzu_migrate.rs	read_relations_returns_expected_count
 crates/trusty-memory/src/commands/kuzu_migrate.rs	schema_table_names_are_defined
-crates/trusty-memory/src/commands/serve_stdio_bridge.rs	ensure_daemon_up
 crates/trusty-memory/src/commands/serve_stdio_bridge.rs	value_to_mcp_response_err
 crates/trusty-memory/src/commands/serve_stdio_bridge.rs	value_to_mcp_response_malformed
 crates/trusty-memory/src/commands/serve_stdio_bridge.rs	value_to_mcp_response_ok

--- a/crates/trusty-agents/assets/config/default-config.toml
+++ b/crates/trusty-agents/assets/config/default-config.toml
@@ -148,7 +148,7 @@ description = "List recent Granola meetings"
 name = "trusty-memory"
 description = "Trusty memory service — recall/remember/forget over a native MCP-stdio server"
 command = "trusty-memory"
-args = ["serve", "--stdio"]
+args = ["serve"]
 transport = "stdio"
 enabled = true
 discover = true
@@ -237,7 +237,8 @@ scope_enforcement = "deny"
 # `driver = "direct"` (OpenRPC-over-stdio via a `--rpc` flag) but neither
 # binary has ever implemented that mode — genuinely dead config, not merely
 # disabled-by-default. Both binaries DO already implement the generic
-# MCP-stdio protocol (`trusty-memory serve --stdio`, `trusty-search serve`),
+# MCP-stdio protocol (`trusty-memory serve`, `trusty-search serve` — both bare
+# `serve` since #5267 aligned trusty-memory to trusty-search),
 # so they now live as live `[[mcp.services]]` entries above instead of
 # waiting on a driver that will never ship. Do not re-add them here; extend
 # their `[[mcp.services]]` entries instead.

--- a/crates/trusty-agents/changelog.d/5267-memory-serve-args.md
+++ b/crates/trusty-agents/changelog.d/5267-memory-serve-args.md
@@ -1,0 +1,5 @@
+Changed
+
+- The bundled `trusty-memory` MCP service entry now uses `args = ["serve"]`; the
+  `--stdio` flag became redundant when bare `serve` started meaning MCP stdio
+  (#5267). The `trusty-mpm` entry keeps `--stdio`, whose semantics are unchanged.

--- a/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
@@ -259,7 +259,8 @@ fn default_config_is_valid_toml() {
         .expect("trusty-memory present");
     assert!(mem.enabled, "trusty-memory must ship enabled, not DISABLED");
     assert_eq!(mem.command, "trusty-memory");
-    assert_eq!(mem.args, vec!["serve".to_string(), "--stdio".to_string()]);
+    // #5267: bare `serve` IS MCP stdio for trusty-memory, matching trusty-search.
+    assert_eq!(mem.args, vec!["serve".to_string()]);
     assert!(mem.discover, "trusty-memory should live-discover its tools");
     let search = cfg
         .mcp

--- a/crates/trusty-common/changelog.d/5267-single-flight-start.md
+++ b/crates/trusty-common/changelog.d/5267-single-flight-start.md
@@ -1,0 +1,6 @@
+Added
+
+- `mcp::ensure_daemon_up_single_flight` and `mcp::StartLock`: start a daemon at
+  most once across concurrent processes, using an exclusive `flock(2)` that the
+  kernel releases if the starter dies. Additive — `DaemonBridgeConfig` and
+  `ensure_daemon_up` are unchanged.

--- a/crates/trusty-common/src/mcp/daemon_bridge.rs
+++ b/crates/trusty-common/src/mcp/daemon_bridge.rs
@@ -203,7 +203,25 @@ pub async fn ensure_daemon_up(config: &DaemonBridgeConfig) -> Result<String> {
         ));
     }
 
-    // Slow path: spawn the daemon detached.
+    // Slow path: spawn the daemon detached, then wait for it to bind.
+    spawn_daemon_detached(config)?;
+    poll_until_ready(config, startup_timeout, poll_interval).await
+}
+
+/// Spawn `current_exe() + config.spawn_args` as a detached background daemon.
+///
+/// Why: extracted from [`ensure_daemon_up`] so the single-flight start path
+/// ([`super::single_flight::ensure_daemon_up_single_flight`]) launches the
+/// daemon through the SAME code rather than a parallel lifecycle — this repo's
+/// common-entry-point rule. A second spawn implementation is how the two paths
+/// would drift on stdio hygiene or cwd handling.
+/// What: resolves `current_exe()`, sets a stable cwd so the daemon never
+/// inherits a deleted worktree directory, nulls all three stdio fds so the
+/// child outlives the bridge process, and spawns. Does NOT wait for readiness —
+/// that is [`poll_until_ready`]'s job.
+/// Test: the spawn path is exercised end-to-end by
+/// `crates/trusty-common/tests/single_flight_exclusion.rs`.
+pub(crate) fn spawn_daemon_detached(config: &DaemonBridgeConfig) -> Result<()> {
     eprintln!("\u{25cf} Starting {} daemon\u{2026}", config.service_name);
 
     let exe = std::env::current_exe().map_err(|e| anyhow!("could not resolve current_exe: {e}"))?;
@@ -223,9 +241,27 @@ pub async fn ensure_daemon_up(config: &DaemonBridgeConfig) -> Result<String> {
                 config.spawn_args.join(" "),
             )
         })?;
+    Ok(())
+}
 
-    // Poll until ready, re-reading the base URL each iteration so dynamic ports
-    // are discovered as soon as the daemon writes its address file.
+/// Poll the daemon's health endpoint until it responds or the budget expires.
+///
+/// Why: shared by [`ensure_daemon_up`] and the single-flight start path so both
+/// enforce the same bounded wait and the same fail-closed timeout. Returning
+/// `Ok` on a daemon that never bound is the defect this function exists to make
+/// impossible — a caller that proceeded anyway would surface the failure
+/// downstream as an empty result instead of an error.
+/// What: sleeps `poll_interval`, re-evaluates `base_url_fn` each iteration so a
+/// dynamic-port daemon is discovered as soon as it writes its address file, and
+/// probes `/health`. Hard-errors once `startup_timeout` is exceeded. There is no
+/// success path that does not include a live 2xx health response.
+/// Test: `daemon_that_never_becomes_ready_is_a_hard_error` in
+/// `crates/trusty-common/tests/single_flight_exclusion.rs`.
+pub(crate) async fn poll_until_ready(
+    config: &DaemonBridgeConfig,
+    startup_timeout: Duration,
+    poll_interval: Duration,
+) -> Result<String> {
     let deadline = Instant::now() + startup_timeout;
     loop {
         tokio::time::sleep(poll_interval).await;

--- a/crates/trusty-common/src/mcp/mod.rs
+++ b/crates/trusty-common/src/mcp/mod.rs
@@ -27,9 +27,11 @@ pub mod daemon_bridge;
 pub mod memory_rpc;
 pub mod openrpc;
 pub mod service;
+pub mod single_flight;
 
 pub use daemon_bridge::{DaemonBridgeConfig, ensure_daemon_up};
 pub use service::ServiceDescriptor;
+pub use single_flight::{StartLock, ensure_daemon_up_single_flight};
 
 /// JSON-RPC 2.0 error codes.
 ///

--- a/crates/trusty-common/src/mcp/single_flight.rs
+++ b/crates/trusty-common/src/mcp/single_flight.rs
@@ -1,0 +1,293 @@
+//! Single-flight daemon start: N concurrent bridges produce exactly ONE daemon.
+//!
+//! Why (#5267, and the #1152 outage it must not reproduce): the trusty-* stdio
+//! bridges each need the HTTP daemon to exist before they can proxy to it. The
+//! obvious implementation — probe, and spawn if the probe misses — is what
+//! caused #1152. A health probe is a *window*, not a lock: under load (dozens of
+//! concurrent agent worktrees) N bridges each miss inside the same window and
+//! each spawn a daemon. Every one of them opens the production palace redb and
+//! contends for its exclusive single-writer lock. Observed 2026-06-12: ~36
+//! orphan daemons, one squatting the write lock on every palace, all writes
+//! failing `DatabaseAlreadyOpen` while reads served stale snapshots.
+//!
+//! #1152 fixed that by refusing to spawn at all (`no_spawn`). That trades an
+//! outage for a papercut: a bridge whose daemon is merely not running hard-errors
+//! instead of starting it. This module implements the branch #1152's own approved
+//! text sanctioned — "auto-start the CANONICAL daemon via the single-instance-
+//! guarded start … so duplicates are structurally impossible" — by supplying the
+//! mutual exclusion that a probe alone cannot provide.
+//!
+//! What: [`ensure_daemon_up_single_flight`] probes without a lock (the common
+//! case costs nothing), and on a miss takes an exclusive `flock(2)` covering the
+//! whole start — re-probe, spawn, readiness wait — so a bridge that loses the
+//! race blocks and then finds a *ready* daemon instead of starting a second one.
+//!
+//! STDOUT hygiene: never writes to stdout — stdout is the JSON-RPC channel in
+//! every caller. All diagnostics go to stderr.
+//!
+//! Test: `crates/trusty-common/tests/single_flight_exclusion.rs` drives N
+//! concurrent real processes and asserts exactly one daemon starts; unit tests
+//! below cover lock acquisition, release, and crash safety.
+
+use std::fs::OpenOptions;
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow};
+
+use super::daemon_bridge::{
+    DAEMON_POLL_INTERVAL, DAEMON_START_TIMEOUT, DaemonBridgeConfig, poll_until_ready,
+    probe_health_once, spawn_daemon_detached,
+};
+
+/// An exclusive advisory lock on the daemon-start critical section.
+///
+/// Why `flock(2)` and not an `O_EXCL` lockfile: the lock must survive a starter
+/// that crashes mid-start. An `O_EXCL` lockfile is a *file that exists*, so a
+/// killed starter leaves it behind and every later bridge deadlocks on a stale
+/// lock until a human deletes it — trading #1152's duplicate-daemon failure for a
+/// total-wedge failure. `flock` is held by the open file description, so the
+/// kernel drops it when the process dies for ANY reason, including `SIGKILL`.
+/// There is no stale state to clean up and no reaper to write.
+///
+/// What: owns the lock file handle. The lock is released by [`Drop`] — which
+/// runs on the success path, on `?` early-return, on panic unwind, and on future
+/// cancellation — and by the kernel if the process dies before `Drop` can. The
+/// lock FILE is never deleted: unlinking it would let a later process open a
+/// different inode and lock nothing, silently defeating the exclusion.
+/// Test: `lock_is_exclusive_across_handles`, `lock_released_on_error_path`,
+/// `lock_file_survives_release`.
+#[derive(Debug)]
+pub struct StartLock {
+    file: std::fs::File,
+}
+
+impl StartLock {
+    /// Acquire the exclusive start lock, blocking until it is available.
+    ///
+    /// Why: blocking is the point — a bridge that loses the race must WAIT for
+    /// the winner to finish starting the daemon, then observe it running. A
+    /// `try_lock` that gave up would put the loser back into the racing path
+    /// this module exists to close.
+    /// What: creates the lock file's parent directory and the file itself if
+    /// absent (never truncating — the file's CONTENT is irrelevant, only its
+    /// inode identity matters), then `flock(LOCK_EX)`, retrying on `EINTR`.
+    /// Blocks the calling thread; async callers must run it on a blocking-safe
+    /// thread.
+    /// Test: `lock_is_exclusive_across_handles`.
+    pub fn acquire_blocking(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("could not create start-lock directory {}", parent.display())
+            })?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .truncate(false)
+            .write(true)
+            .open(path)
+            .with_context(|| format!("could not open start-lock file {}", path.display()))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::io::AsRawFd;
+            let fd = file.as_raw_fd();
+            loop {
+                // Safety: `fd` is owned by `file` and stays open for the whole
+                // call; `flock` only affects the referenced open file description.
+                let rc = unsafe { libc::flock(fd, libc::LOCK_EX) };
+                if rc == 0 {
+                    break;
+                }
+                let err = std::io::Error::last_os_error();
+                if err.kind() == std::io::ErrorKind::Interrupted {
+                    continue; // EINTR: a signal arrived while blocked; retry.
+                }
+                return Err(anyhow!(
+                    "could not acquire start lock {}: {err}",
+                    path.display()
+                ));
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            // Fail closed rather than silently running without exclusion, which
+            // would reintroduce #1152's duplicate-daemon race.
+            return Err(anyhow!(
+                "single-flight daemon start requires flock(2) and is not supported on this platform"
+            ));
+        }
+
+        Ok(Self { file })
+    }
+}
+
+impl Drop for StartLock {
+    /// Release the lock explicitly, then close the file.
+    ///
+    /// Why: closing the descriptor alone would release the `flock`, but an
+    /// explicit `LOCK_UN` documents the release at the point it happens and keeps
+    /// the critical section greppable. Errors are ignored — the fd close that
+    /// follows releases the lock unconditionally, so there is no failure mode
+    /// left to report.
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::io::AsRawFd;
+            // Safety: `self.file` is still open; `LOCK_UN` on an owned fd is
+            // infallible in practice and harmless if the lock was already lost.
+            unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+        }
+    }
+}
+
+/// Ensure the daemon is running, starting it at most once across all processes.
+///
+/// Why: this is the "start if it's not running" contract — distinct from
+/// auto-spawn, which is what #1152 removed. Auto-spawn means every bridge
+/// independently starts a daemon; this means the daemon's existence is *ensured*,
+/// once, under coordination. Seven bridges converge on one daemon.
+///
+/// What: (1) probes health with no lock held, so the overwhelmingly common
+/// "daemon already up" case pays nothing and touches no filesystem. (2) On a
+/// miss, blocks on [`StartLock`] at `lock_path`. (3) **Re-probes under the
+/// lock** — the process that just released it usually started the daemon, so the
+/// loser must re-check before concluding anything. (4) Only if the re-probe also
+/// misses does it spawn, via the shared [`spawn_daemon_detached`]. (5) Waits for
+/// readiness via the shared [`poll_until_ready`], still holding the lock, so a
+/// concurrent bridge cannot spawn a second daemon during the boot window. Fails
+/// closed: an unreachable daemon is an `Err`, never an `Ok` the caller would
+/// discover downstream as an empty result.
+///
+/// The lock is held across the readiness wait deliberately. Releasing it at spawn
+/// time would reopen the race — a second bridge would acquire, re-probe a daemon
+/// that has not bound yet, and start another.
+///
+/// Test: `crates/trusty-common/tests/single_flight_exclusion.rs` —
+/// `n_concurrent_bridges_start_exactly_one_daemon`,
+/// `already_running_daemon_is_not_restarted`,
+/// `daemon_that_never_becomes_ready_is_a_hard_error`,
+/// `crashed_starter_does_not_deadlock_the_next_bridge`.
+pub async fn ensure_daemon_up_single_flight(
+    config: &DaemonBridgeConfig,
+    lock_path: &Path,
+) -> Result<String> {
+    let startup_timeout = config.startup_timeout.unwrap_or(DAEMON_START_TIMEOUT);
+    let poll_interval = config.poll_interval.unwrap_or(DAEMON_POLL_INTERVAL);
+
+    // (1) Fast path: no lock, no filesystem access.
+    if probe_health_once(&config.health_url()).await {
+        return Ok((config.base_url_fn)());
+    }
+
+    // (2) Serialise the start. Blocking `flock` goes on a blocking-safe thread;
+    // the guard is `Send` and is held across the awaits below on purpose.
+    let lock_path_owned = lock_path.to_path_buf();
+    let _lock = tokio::task::spawn_blocking(move || StartLock::acquire_blocking(&lock_path_owned))
+        .await
+        .context("start-lock acquisition task panicked")??;
+
+    // (3) Re-probe under the lock: whoever held it before us most likely just
+    // started the daemon, in which case we must NOT start another.
+    if probe_health_once(&config.health_url()).await {
+        return Ok((config.base_url_fn)());
+    }
+
+    // (4) We are the single starter.
+    spawn_daemon_detached(config)?;
+
+    // (5) Bounded readiness wait, lock still held. `_lock` drops here on every
+    // path — Ok, Err, panic, or cancellation.
+    poll_until_ready(config, startup_timeout, poll_interval).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    /// Why: the whole design rests on the lock actually excluding a second
+    /// holder. If it does not, #1152's race is back with extra ceremony.
+    /// What: takes the lock, then from a separate thread (separate fd, as a
+    /// separate process would have) asserts the second acquisition BLOCKS until
+    /// the first is dropped.
+    /// Test: itself.
+    #[test]
+    fn lock_is_exclusive_across_handles() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("start.lock");
+
+        let first = StartLock::acquire_blocking(&path).expect("first acquire");
+        let p2 = path.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let _second = StartLock::acquire_blocking(&p2).expect("second acquire");
+            tx.send(Instant::now()).expect("send");
+        });
+
+        // The contender must still be blocked after a real delay.
+        std::thread::sleep(Duration::from_millis(300));
+        assert!(
+            rx.try_recv().is_err(),
+            "second acquisition must block while the first lock is held"
+        );
+
+        drop(first);
+        let acquired_at = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("second acquisition must succeed once the first is released");
+        handle.join().expect("thread join");
+        // Sanity: it acquired after we released, not before.
+        let _ = acquired_at;
+    }
+
+    /// Why: a starter that fails must not leave the lock held — the next bridge
+    /// has to be able to try. Covers the `?` early-return path.
+    /// What: acquires inside a closure that returns `Err`, then asserts a fresh
+    /// acquisition succeeds immediately.
+    /// Test: itself.
+    #[test]
+    fn lock_released_on_error_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("start.lock");
+
+        let failed: Result<()> = (|| {
+            let _lock = StartLock::acquire_blocking(&path)?;
+            Err(anyhow!("simulated start failure"))
+        })();
+        assert!(failed.is_err());
+
+        // Must not block: the guard dropped when the closure unwound.
+        let start = Instant::now();
+        let _again = StartLock::acquire_blocking(&path).expect("reacquire after error");
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "lock must be free after the error path"
+        );
+    }
+
+    /// Why: the lock file must persist across acquisitions. Deleting it would let
+    /// a later process lock a different inode and exclude nobody.
+    /// What: acquires, drops, and asserts the file still exists.
+    /// Test: itself.
+    #[test]
+    fn lock_file_survives_release() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("start.lock");
+        drop(StartLock::acquire_blocking(&path).expect("acquire"));
+        assert!(path.exists(), "lock file must not be unlinked on release");
+    }
+
+    /// Why: the lock lives under the data dir, which may not exist on a first
+    /// run. Failing there would make a cold start impossible.
+    /// What: points at a nested path with no parent and asserts acquisition
+    /// creates it.
+    /// Test: itself.
+    #[test]
+    fn lock_creates_missing_parent_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested/deeper/start.lock");
+        let _lock = StartLock::acquire_blocking(&path).expect("acquire with missing parent");
+        assert!(path.exists());
+    }
+}

--- a/crates/trusty-common/tests/single_flight_exclusion.rs
+++ b/crates/trusty-common/tests/single_flight_exclusion.rs
@@ -1,0 +1,390 @@
+//! #1152 regression test: N concurrent bridge PROCESSES start exactly ONE daemon.
+//!
+//! Why: this is the failure #1152 actually was. Under load — dozens of agent
+//! worktrees each launching an MCP stdio bridge — every bridge's health probe
+//! missed inside the same window and every bridge spawned a daemon. ~36 orphan
+//! daemons resulted, one squatting redb's exclusive write lock, and all writes
+//! failed machine-wide. A probe is a window; only a lock is an exclusion. This
+//! test is what keeps that distinction enforced.
+//!
+//! What: spawns N real child processes, each calling the production
+//! [`trusty_common::mcp::ensure_daemon_up_single_flight`] against one shared
+//! lock file and one shared (initially absent) daemon. The "daemon" is this test
+//! binary re-executed in a daemon role — a real process binding a real TCP port
+//! and serving `/health` — so the spawn, probe, and readiness paths under test
+//! are the production ones, not stubs. Each daemon instance records its start by
+//! creating a uniquely-named file, so the assertion is a simple count with no
+//! timing assumptions: exactly one start, no matter how the children interleave.
+//!
+//! Determinism: the children are released simultaneously and the assertion is on
+//! a count of on-disk artifacts after every child has exited. Nothing depends on
+//! a sleep, a scheduling order, or a race being "won" by anyone in particular.
+//!
+//! Test: `cargo test -p trusty-common --features mcp --test single_flight_exclusion`.
+
+#![cfg(feature = "mcp")]
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use trusty_common::mcp::{DaemonBridgeConfig, ensure_daemon_up_single_flight};
+
+/// Env var naming which role a re-executed copy of this binary should play.
+const ROLE_VAR: &str = "TRUSTY_SF_TEST_ROLE";
+/// Env var carrying the shared scratch directory every role coordinates through.
+const DIR_VAR: &str = "TRUSTY_SF_TEST_DIR";
+
+/// Number of concurrent bridges. Chosen above the ~7 bridges seen live so the
+/// test exercises real contention rather than the happy path.
+const BRIDGES: usize = 12;
+
+/// Resolve the shared scratch directory from the environment.
+fn scratch_dir() -> PathBuf {
+    PathBuf::from(std::env::var(DIR_VAR).expect("scratch dir env var must be set"))
+}
+
+/// Where the daemon publishes the address it actually bound.
+fn addr_file(dir: &Path) -> PathBuf {
+    dir.join("http_addr")
+}
+
+/// Directory in which each started daemon drops one uniquely-named marker.
+///
+/// Why: counting files is order-independent and needs no synchronisation, so the
+/// assertion cannot itself become a race.
+fn starts_dir(dir: &Path) -> PathBuf {
+    dir.join("starts")
+}
+
+/// Build the bridge config used by every child, pointed at the scratch dir.
+///
+/// Why: all children must resolve the SAME base URL and spawn the SAME daemon
+/// command, exactly as the real bridges share one `daemon_start_config`.
+/// What: `base_url_fn` reads the daemon's published address file each call (as
+/// the production dynamic-port resolver does); `spawn_args` re-executes this
+/// test binary in the daemon role.
+fn bridge_config(dir: &Path) -> DaemonBridgeConfig {
+    let dir_owned = dir.to_path_buf();
+    DaemonBridgeConfig {
+        service_name: "sf-test".to_string(),
+        spawn_args: vec![
+            "daemon_role_entrypoint".to_string(),
+            "--exact".to_string(),
+            "--nocapture".to_string(),
+        ],
+        health_path: "/health".to_string(),
+        base_url_fn: Box::new(move || {
+            std::fs::read_to_string(addr_file(&dir_owned))
+                .map(|s| format!("http://{}", s.trim()))
+                // Before the daemon publishes an address there is nothing to
+                // probe; a port that refuses instantly keeps the probe honest.
+                .unwrap_or_else(|_| "http://127.0.0.1:1".to_string())
+        }),
+        startup_timeout: Some(Duration::from_secs(20)),
+        poll_interval: Some(Duration::from_millis(100)),
+        no_spawn: false,
+        no_spawn_hint: None,
+    }
+}
+
+/// The daemon role: bind a port, record the start, serve `/health` forever.
+///
+/// Why: a real listening process is what makes the probe/readiness path under
+/// test the production one. Recording the start BEFORE binding means a daemon
+/// that starts is always counted, so the test can never under-report a
+/// duplicate — it fails closed.
+/// What: creates a unique marker in `starts/`, binds an ephemeral port, writes
+/// the address atomically, then answers every connection with a 200. Exits when
+/// the parent test removes the scratch directory.
+#[test]
+fn daemon_role_entrypoint() {
+    if std::env::var(ROLE_VAR).as_deref() != Ok("daemon") {
+        return; // Not the re-executed daemon: no-op during a normal test run.
+    }
+    let dir = scratch_dir();
+
+    // Record this start first — an uncounted daemon would hide the very
+    // duplicate this test exists to catch.
+    std::fs::create_dir_all(starts_dir(&dir)).expect("create starts dir");
+    let marker = starts_dir(&dir).join(format!("{}", std::process::id()));
+    std::fs::write(&marker, b"started").expect("write start marker");
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local addr");
+
+    // Publish atomically: a reader must never observe a half-written address.
+    let tmp = dir.join("http_addr.tmp");
+    std::fs::write(&tmp, addr.to_string()).expect("write tmp addr");
+    std::fs::rename(&tmp, addr_file(&dir)).expect("publish addr");
+
+    for stream in listener.incoming() {
+        let Ok(stream) = stream else { continue };
+        serve_health(stream);
+        if !dir.exists() {
+            break; // Parent cleaned up; nothing left to serve.
+        }
+    }
+}
+
+/// Answer one HTTP request with a 200, whatever was asked for.
+fn serve_health(mut stream: TcpStream) {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let mut line = String::new();
+    let _ = reader.read_line(&mut line);
+    // Drain headers so the client sees a well-formed exchange.
+    loop {
+        let mut h = String::new();
+        match reader.read_line(&mut h) {
+            Ok(0) => break,
+            Ok(_) if h.trim().is_empty() => break,
+            Ok(_) => continue,
+            Err(_) => break,
+        }
+    }
+    let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok");
+    let _ = stream.flush();
+}
+
+/// The bridge role: run the production ensure-daemon-up path exactly once.
+///
+/// Why: each child must exercise the real function, not a reimplementation, or
+/// the test proves nothing about production behavior.
+#[test]
+fn bridge_role_entrypoint() {
+    if std::env::var(ROLE_VAR).as_deref() != Ok("bridge") {
+        return; // Not the re-executed bridge: no-op during a normal test run.
+    }
+    let dir = scratch_dir();
+
+    // The daemon this bridge may spawn inherits our environment, so hand it the
+    // daemon role. Without this it would inherit "bridge" and no-op, and the
+    // readiness wait would time out instead of testing anything.
+    // Safety: single-threaded at this point; no other thread reads the env.
+    unsafe { std::env::set_var(ROLE_VAR, "daemon") };
+
+    let config = bridge_config(&dir);
+    let lock = dir.join("start.lock");
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let result = rt.block_on(ensure_daemon_up_single_flight(&config, &lock));
+    // A bridge that could not reach a daemon must fail loudly — never proceed.
+    result.expect("bridge must end with a reachable daemon");
+}
+
+/// Spawn one child of this test binary in the given role.
+fn spawn_role(role: &str, dir: &Path, test_name: &str) -> std::process::Child {
+    Command::new(std::env::current_exe().expect("current exe"))
+        .arg(test_name)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env(ROLE_VAR, role)
+        .env(DIR_VAR, dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn role child")
+}
+
+/// Count the daemons that recorded a start.
+fn started_count(dir: &Path) -> usize {
+    std::fs::read_dir(starts_dir(dir))
+        .map(|rd| rd.filter_map(|e| e.ok()).count())
+        .unwrap_or(0)
+}
+
+/// Kill every daemon this test started, so none outlives the run.
+fn reap_daemons(dir: &Path) {
+    if let Ok(rd) = std::fs::read_dir(starts_dir(dir)) {
+        for entry in rd.filter_map(|e| e.ok()) {
+            if let Some(pid) = entry
+                .file_name()
+                .to_str()
+                .and_then(|s| s.parse::<i32>().ok())
+            {
+                #[cfg(unix)]
+                // Safety: `pid` names a process this test spawned.
+                unsafe {
+                    libc::kill(pid, libc::SIGKILL);
+                }
+            }
+        }
+    }
+}
+
+/// Why: THE #1152 regression test. Without the exclusion, N bridges each probe a
+/// missing daemon, each miss, and each spawn — the exact shape that produced ~36
+/// orphan daemons and a machine-wide write-lock outage.
+/// What: releases 12 real bridge processes against one shared lock and one
+/// absent daemon, waits for all of them to exit successfully, and asserts
+/// exactly ONE daemon recorded a start.
+/// Test: itself.
+#[test]
+fn n_concurrent_bridges_start_exactly_one_daemon() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().to_path_buf();
+    std::fs::create_dir_all(starts_dir(&dir)).expect("create starts dir");
+
+    let children: Vec<_> = (0..BRIDGES)
+        .map(|_| spawn_role("bridge", &dir, "bridge_role_entrypoint"))
+        .collect();
+
+    let mut failures = Vec::new();
+    for (i, mut child) in children.into_iter().enumerate() {
+        let status = child.wait().expect("wait for bridge child");
+        if !status.success() {
+            failures.push(i);
+        }
+    }
+
+    let started = started_count(&dir);
+    reap_daemons(&dir);
+
+    assert!(
+        failures.is_empty(),
+        "every bridge must succeed; these failed: {failures:?}"
+    );
+    assert_eq!(
+        started, 1,
+        "{BRIDGES} concurrent bridges must start exactly ONE daemon (#1152); \
+         {started} daemons started"
+    );
+}
+
+/// Why: the fast path must cost nothing and start nothing. A bridge that
+/// restarted a healthy daemon would be its own outage.
+/// What: starts one daemon, waits for it to be healthy, then runs a bridge and
+/// asserts the start count is still 1.
+/// Test: itself.
+#[test]
+fn already_running_daemon_is_not_restarted() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().to_path_buf();
+    std::fs::create_dir_all(starts_dir(&dir)).expect("create starts dir");
+
+    let mut daemon = spawn_role("daemon", &dir, "daemon_role_entrypoint");
+
+    // Wait for it to publish an address and answer a probe.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < deadline && started_count(&dir) == 0 {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert_eq!(started_count(&dir), 1, "fixture daemon must start");
+    while Instant::now() < deadline && !addr_file(&dir).exists() {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    let mut bridge = spawn_role("bridge", &dir, "bridge_role_entrypoint");
+    let status = bridge.wait().expect("wait for bridge");
+
+    let started = started_count(&dir);
+    let _ = daemon.kill();
+    // Reap it so the fixture daemon leaves no zombie behind.
+    let _ = daemon.wait();
+    reap_daemons(&dir);
+
+    assert!(
+        status.success(),
+        "bridge must succeed against a live daemon"
+    );
+    assert_eq!(
+        started, 1,
+        "a healthy daemon must not be restarted; {started} daemons exist"
+    );
+}
+
+/// Why: the fail-closed rule. A bridge whose daemon never becomes ready must
+/// return an error, never an `Ok` that surfaces downstream as an empty recall.
+/// That silent-degradation shape is this repo's recurring defect.
+/// What: configures a spawn command that exits immediately without ever binding,
+/// and asserts `ensure_daemon_up_single_flight` returns `Err` within the budget.
+/// Test: itself.
+#[test]
+fn daemon_that_never_becomes_ready_is_a_hard_error() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().to_path_buf();
+
+    let mut config = bridge_config(&dir);
+    // A role no entrypoint answers: the child exits without binding anything.
+    config.spawn_args = vec![
+        "daemon_role_entrypoint".to_string(),
+        "--exact".to_string(),
+        "--nocapture".to_string(),
+    ];
+    config.startup_timeout = Some(Duration::from_secs(2));
+    config.poll_interval = Some(Duration::from_millis(100));
+
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let result = rt.block_on(ensure_daemon_up_single_flight(
+        &config,
+        &dir.join("start.lock"),
+    ));
+
+    assert!(
+        result.is_err(),
+        "an unready daemon must be a hard error, never a silent Ok"
+    );
+}
+
+/// Why: a starter killed mid-start must not wedge every later bridge. `flock` is
+/// released by the kernel on process death, which is precisely why this design
+/// uses it instead of an `O_EXCL` lockfile that would survive the crash.
+/// What: spawns a child that takes the lock and is then SIGKILLed, and asserts a
+/// subsequent acquisition succeeds promptly rather than blocking forever.
+/// Test: itself.
+#[test]
+fn crashed_starter_does_not_deadlock_the_next_bridge() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().to_path_buf();
+    let lock = dir.join("start.lock");
+
+    // Hold the lock in a child, then kill it without letting it release.
+    let holder = spawn_role("lock_holder", &dir, "lock_holder_entrypoint");
+    let pid = holder.id();
+
+    // Wait until the child signals it holds the lock.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline && !dir.join("held").exists() {
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    assert!(dir.join("held").exists(), "holder must acquire the lock");
+
+    #[cfg(unix)]
+    // Safety: `pid` names the child we just spawned.
+    unsafe {
+        libc::kill(pid as i32, libc::SIGKILL);
+    }
+    let mut holder = holder;
+    let _ = holder.wait();
+
+    // The kernel released the flock when the process died: this must not block.
+    let start = Instant::now();
+    let acquired =
+        trusty_common::mcp::StartLock::acquire_blocking(&lock).expect("acquire after crash");
+    let elapsed = start.elapsed();
+    drop(acquired);
+
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "a crashed starter must not deadlock the next bridge; waited {elapsed:?}"
+    );
+}
+
+/// Helper role: take the lock, announce it, then block until killed.
+#[test]
+fn lock_holder_entrypoint() {
+    if std::env::var(ROLE_VAR).as_deref() != Ok("lock_holder") {
+        return;
+    }
+    let dir = scratch_dir();
+    let _lock = trusty_common::mcp::StartLock::acquire_blocking(&dir.join("start.lock"))
+        .expect("holder acquires lock");
+    std::fs::write(dir.join("held"), b"1").expect("signal held");
+    // Block forever; the parent SIGKILLs us while the lock is still held.
+    loop {
+        std::thread::sleep(Duration::from_secs(3600));
+    }
+}

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -155,6 +155,10 @@ open = "5"
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# libc: the #5267 TTY-gated notice can only be exercised by giving the child a
+# REAL terminal on stdin, which needs openpty(3). A pipe proves the silent half
+# of the contract; only a pty proves the human-facing half.
+libc = { workspace = true }
 # #5005: encode a real 384-dim vector when seeding a synthetic id collision
 # into a palace's index redb, so HnswStore's dimension check accepts the file.
 postcard = { workspace = true }

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -127,12 +127,13 @@ Expected output: the semantic version of the installed binary (e.g., `trusty-mem
 ### Start the daemon
 
 ```bash
-trusty-memory serve
+trusty-memory start
 ```
 
-By default, `serve` self-spawns a detached background daemon (alias for
-`trusty-memory start`) and returns control to the shell so you keep your
-prompt. The daemon binds HTTP/SSE on a dynamic port in the `7070..=7079`
+`start` is the daemon verb: it spawns a detached background daemon and returns
+once the daemon answers `/health`. Bare `trusty-memory serve` speaks MCP over
+stdio (matching `trusty-search serve`), so use `start` — not `serve` — when you
+want a background daemon. The daemon binds HTTP/SSE on a dynamic port in the `7070..=7079`
 range (with OS fallback) and writes the resolved address to its
 discovery file. Pass `--foreground` to keep the daemon inline (used by
 launchd / systemd / Docker), or `--http <ADDR>` to pin a specific address.
@@ -153,7 +154,7 @@ substitution fails cleanly.
 
 ### Browser dashboard + REST API
 
-The same `trusty-memory serve` daemon serves the embedded Svelte admin UI
+The same `trusty-memory start` daemon serves the embedded Svelte admin UI
 at the bound address (printed by `trusty-memory monitor web` once the
 daemon is running) and a REST API under `/api/v1/`.
 
@@ -168,7 +169,8 @@ Key REST API field names (verified against `src/web.rs` and `src/service.rs`):
 When all tool calls should default to one palace namespace, use `--palace`:
 
 ```bash
-trusty-memory serve --palace my-project
+trusty-memory start          # daemon
+trusty-memory serve --palace my-project   # MCP stdio bound to one palace
 ```
 
 With a default set, the `palace` argument becomes optional in every MCP tool
@@ -232,7 +234,7 @@ minor version.
 
 Claude Code auto-discovers `.mcp.json` on project open. The daemon must be
 running (started either by `trusty-memory setup`'s LaunchAgent or by
-`trusty-memory start` / `trusty-memory serve`).
+`trusty-memory start`).
 
 ## Available MCP Tools
 

--- a/crates/trusty-memory/changelog.d/5267-serve-starts-daemon.md
+++ b/crates/trusty-memory/changelog.d/5267-serve-starts-daemon.md
@@ -1,0 +1,8 @@
+Changed
+
+- The `serve --stdio` bridge now starts the HTTP daemon when it is not running
+  instead of hard-erroring with "run `trusty-memory start`". The start is
+  single-flight: it takes an exclusive `flock` covering probe, spawn, and
+  readiness wait, so N concurrent bridges produce exactly one daemon (#1152).
+  `trusty-memory start` now waits for the daemon to answer `/health` before
+  returning, which is what keeps that exclusion honest.

--- a/crates/trusty-memory/changelog.d/5267-serve-stdio-default.md
+++ b/crates/trusty-memory/changelog.d/5267-serve-stdio-default.md
@@ -1,0 +1,8 @@
+Breaking
+
+- Bare `trusty-memory serve` now speaks MCP over stdio instead of detaching an
+  HTTP daemon, matching `trusty-search serve`. Use `trusty-memory start` for the
+  background daemon. Every flagged form is unchanged: `serve --stdio`,
+  `serve --http <ADDR>`, `serve --foreground`, and `start`. A human running bare
+  `serve` at a terminal gets a one-line stderr notice explaining the move; MCP
+  clients (piped stdin) see nothing.

--- a/crates/trusty-memory/help.yaml
+++ b/crates/trusty-memory/help.yaml
@@ -27,6 +27,9 @@ commands:
         description: Default palace for MCP tool calls when caller omits palace
     examples:
       - cmd: trusty-memory serve
+        note: MCP stdio (starts the daemon if it is not already running)
+      - cmd: trusty-memory start
+        note: the background HTTP daemon
       - cmd: trusty-memory serve --foreground --http 127.0.0.1:7070
   migrate:
     description: Migrate from another memory MCP server to trusty-memory

--- a/crates/trusty-memory/src/cli_tests.rs
+++ b/crates/trusty-memory/src/cli_tests.rs
@@ -1,8 +1,12 @@
-//! Unit tests for `serve` subcommand argument parsing (#914 PR4).
+//! Unit tests for `serve` argument parsing and transport selection
+//! (#914 PR4; transport matrix rewritten by #5267).
 //!
-//! Why: the `--http` flag was changed from `Option<SocketAddr>` to
-//! `Option<Option<SocketAddr>>` so bare `--http` (explicit HTTP mode, dynamic
-//! port) is valid in addition to `--http 127.0.0.1:7070` (specific address).
+//! Why: two separate contracts live here. Parsing — the `--http` flag is
+//! `Option<Option<SocketAddr>>` so bare `--http` and `--http ADDR` are both
+//! valid, and `--stdio` conflicts with both HTTP flags. Selection (#5267) —
+//! which server bare `serve` actually runs, asserted via [`super::serve_mode`]
+//! rather than by parsing alone, because a parse-only test passes identically
+//! before and after the behavior change.
 //! These tests guard against clap-level regressions in:
 //!
 //!   - bare `serve` (no flags)
@@ -19,11 +23,13 @@
 use super::{Cli, Command};
 use clap::Parser;
 
-/// Why: bare `serve` must keep HTTP as default (no flags set).
-/// What: parses `["trusty-memory", "serve"]` and asserts http=None, stdio=false.
+/// Why: bare `serve` sets no transport flag — that is what #5267 reinterprets.
+/// What: parses `["trusty-memory", "serve"]` and asserts all three transport
+/// flags are unset. This is the PARSING contract only; which server that
+/// selects is `serve_mode_bare_is_stdio`'s job.
 /// Test: this function.
 #[test]
-fn serve_bare_is_http_default() {
+fn serve_bare_sets_no_transport_flag() {
     let cli = Cli::try_parse_from(["trusty-memory", "serve"]).expect("parse ok");
     let Command::Serve {
         http,
@@ -93,5 +99,122 @@ fn serve_http_and_stdio_together_is_error() {
     assert!(
         result.is_err(),
         "--http and --stdio together must be rejected by clap"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Transport selection (#5267) — the behavior change, not just the parse.
+// ---------------------------------------------------------------------------
+
+use super::{serve_mode, ServeMode};
+
+/// Parse an argv and return the transport it selects.
+///
+/// Why: every selection test below needs the same parse-then-decide pipeline;
+/// routing them through one helper keeps each test one assertion long.
+fn mode_of(args: &[&str]) -> ServeMode {
+    let cli = Cli::try_parse_from(args).expect("parse ok");
+    let Command::Serve {
+        http,
+        stdio,
+        foreground,
+        ..
+    } = cli.command
+    else {
+        panic!("expected Serve");
+    };
+    serve_mode(&http, foreground, stdio)
+}
+
+/// Why: THE #5267 regression test. Before the change bare `serve` selected the
+/// HTTP daemon; it now speaks MCP stdio, matching `trusty-search serve`. This
+/// assertion fails against the pre-fix binary — a parse-only test would not.
+/// What: asserts bare `serve` selects stdio AND requests the human notice.
+/// Test: itself.
+#[test]
+fn serve_mode_bare_is_stdio() {
+    assert_eq!(
+        mode_of(&["trusty-memory", "serve"]),
+        ServeMode::Stdio { notify: true },
+        "bare `serve` must speak MCP stdio (#5267)"
+    );
+}
+
+/// Why: `serve --stdio` was already stdio and must be byte-identical in
+/// behavior — but it must NOT emit the notice, because its meaning did not
+/// change and its caller is an MCP client.
+/// Test: itself.
+#[test]
+fn serve_mode_explicit_stdio() {
+    assert_eq!(
+        mode_of(&["trusty-memory", "serve", "--stdio"]),
+        ServeMode::Stdio { notify: false },
+        "`serve --stdio` must stay stdio and stay silent"
+    );
+}
+
+/// Why: `serve --http` (bare) selected HTTP before and must still.
+/// Test: itself.
+#[test]
+fn serve_mode_http_bare() {
+    assert_eq!(
+        mode_of(&["trusty-memory", "serve", "--http"]),
+        ServeMode::Http
+    );
+}
+
+/// Why: `serve --http ADDR` is how callers bind a specific port; unchanged.
+/// Test: itself.
+#[test]
+fn serve_mode_http_addr() {
+    assert_eq!(
+        mode_of(&["trusty-memory", "serve", "--http", "127.0.0.1:7070"]),
+        ServeMode::Http
+    );
+}
+
+/// Why: the launchd plist and `handle_start` both spawn `serve --foreground`.
+/// If this regressed, the daemon on every installed machine would come up as a
+/// stdio process blocking on a null stdin instead of an HTTP server.
+/// Test: itself.
+#[test]
+fn serve_mode_foreground_is_http() {
+    assert_eq!(
+        mode_of(&["trusty-memory", "serve", "--foreground"]),
+        ServeMode::Http,
+        "`serve --foreground` is the launchd/`start` daemon path"
+    );
+}
+
+/// Why: `--palace` is a scoping flag, not a transport flag, so it must not
+/// change the selection — `serve --palace X` is still the bare form.
+/// Test: itself.
+#[test]
+fn serve_mode_palace_only_is_stdio() {
+    assert_eq!(
+        mode_of(&["trusty-memory", "serve", "--palace", "demo"]),
+        ServeMode::Stdio { notify: true }
+    );
+}
+
+/// Why: the parser must stay strict. Making bare `serve` permissive must not
+/// have loosened anything else — an unknown flag is still an error.
+/// Test: itself.
+#[test]
+fn serve_rejects_unknown_flag() {
+    assert!(
+        Cli::try_parse_from(["trusty-memory", "serve", "--not-a-real-flag"]).is_err(),
+        "unknown flags must still be rejected"
+    );
+}
+
+/// Why: `--foreground` and `--stdio` are mutually exclusive (`conflicts_with`),
+/// and that relationship must survive the #5267 dispatch rewrite.
+/// Test: itself.
+#[test]
+fn serve_foreground_conflicts_with_stdio() {
+    assert!(
+        Cli::try_parse_from(["trusty-memory", "serve", "--foreground", "--stdio"]).is_err(),
+        "--foreground and --stdio must remain mutually exclusive"
     );
 }

--- a/crates/trusty-memory/src/commands/serve_stdio_bridge.rs
+++ b/crates/trusty-memory/src/commands/serve_stdio_bridge.rs
@@ -8,10 +8,11 @@
 //! the stdio process never opens redb.
 //!
 //! What: `run_stdio_bridge` (1) ensures the daemon is running via the shared
-//! `trusty_common::mcp::ensure_daemon_up` helper (auto-starting it detached
-//! if absent, polling the `http_addr` file for the real dynamic port);
-//! (2) forwards each non-notification request to `POST /rpc` on the daemon
-//! and returns the daemon response verbatim to the MCP client.
+//! `trusty_common::mcp::ensure_daemon_up_single_flight` helper — starting it
+//! under an exclusive lock if absent (#5267), polling the `http_addr` file for
+//! the real dynamic port; (2) forwards each non-notification request to
+//! `POST /rpc` on the daemon and returns the daemon response verbatim to the
+//! MCP client.
 //!
 //! Caller-identity injection (DOC-53 §4.3, critical fix): the daemon this
 //! bridge proxies to is ONE shared process serving every concurrently-
@@ -35,9 +36,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use std::time::Duration;
-use trusty_common::mcp::{self, DaemonBridgeConfig};
-
-use crate::commands::daemon_guard::daemon_base_url;
+use trusty_common::mcp;
 
 /// Per-request forwarding timeout (60 s -- headroom for cold-start embedding).
 ///
@@ -91,54 +90,30 @@ pub(crate) async fn forward_rpc(
         .context("deserialise JSON-RPC response from daemon")
 }
 
-/// Build the `DaemonBridgeConfig` for the trusty-memory stdio bridge.
-///
-/// Why (issue #1152): the stdio bridge is a pure proxy — it must NEVER spawn
-/// an unmanaged daemon.  The previous config used `spawn_args = ["serve",
-/// "--foreground", "--http", "127.0.0.1:0"]`, which auto-started a background
-/// process on a random OS-assigned port whenever the health probe to the
-/// launchd daemon at :7070 failed transiently.  That spawned daemon opened the
-/// production palace redb files and squatted the exclusive write lock, starving
-/// the real daemon and causing all writes to fail with "DatabaseAlreadyOpen".
-/// Setting `no_spawn: true` converts the spawn-on-miss path into a clear `Err`
-/// so the user is told to run `trusty-memory start` rather than silently
-/// spawning a write-lock squatter.
-/// What: returns a `DaemonBridgeConfig` with `no_spawn: true` and empty
-/// `spawn_args` (unused when `no_spawn` is set) that is ready for
-/// `ensure_daemon_up`.
-/// Test: `ensure_daemon_up` unit tests in `trusty_common::mcp::daemon_bridge`;
-/// `no_spawn_returns_err_without_spawning` specifically covers this path.
-fn build_bridge_config() -> DaemonBridgeConfig {
-    DaemonBridgeConfig {
-        service_name: "trusty-memory".to_string(),
-        // spawn_args is unused because no_spawn = true: the bridge never
-        // spawns a daemon.  Left empty rather than deleted so DaemonBridgeConfig
-        // consumers that iterate spawn_args don't need a None-check.
-        spawn_args: vec![],
-        health_path: "/health".to_string(),
-        base_url_fn: Box::new(daemon_base_url),
-        startup_timeout: None, // use the shared 30s default
-        poll_interval: None,   // use the shared 500ms default
-        // Issue #1152: NEVER spawn an unmanaged daemon from the stdio bridge.
-        // If the launchd daemon at :7070 is not reachable, fail loudly.
-        no_spawn: true,
-        // trusty-memory's real operator guidance matches the shared helper's
-        // generic `{service} setup` / `io.trusty.{service}.plist` wording, so
-        // no override is needed here (issue #2491).
-        no_spawn_hint: None,
-    }
-}
-
 /// Ensure the trusty-memory daemon is running and return its live base URL.
 ///
-/// Why: thin wrapper around the shared `ensure_daemon_up` helper that supplies
-/// the trusty-memory-specific `DaemonBridgeConfig`. Kept as a named function so
-/// `run_stdio_bridge` reads cleanly and the config details are isolated.
-/// What: delegates entirely to `trusty_common::mcp::ensure_daemon_up`.
-/// Test: e2e coverage in `tests/serve_stdio_e2e.rs`.
+/// Why (#5267, superseding the `no_spawn: true` posture of #1152): a bridge whose
+/// daemon is merely not running should start it, not hard-error. #1152 was an
+/// *auto-spawn* outage — every bridge independently spawning `serve --foreground
+/// --http 127.0.0.1:0`, N bridges producing N daemons racing for redb's write
+/// lock. What this does instead is start-if-not-running: the daemon's existence
+/// is ensured ONCE, under an exclusive lock, so seven bridges converge on one
+/// daemon. #1152's own approved text sanctioned this branch ("auto-start the
+/// CANONICAL daemon via the single-instance-guarded start … so duplicates are
+/// structurally impossible"); the lock is the exclusion it assumed.
+/// What: delegates to the shared
+/// [`trusty_common::mcp::ensure_daemon_up_single_flight`] with the one
+/// [`crate::commands::start::daemon_start_config`] that `trusty-memory start`
+/// also uses — same spawn args, same lock file, so the two paths cannot race
+/// each other. Fails closed if the daemon does not become ready.
+/// Test: `crates/trusty-common/tests/single_flight_exclusion.rs`
+/// (`n_concurrent_bridges_start_exactly_one_daemon`); e2e in
+/// `tests/serve_stdio_e2e.rs`.
 pub(crate) async fn ensure_daemon_up_for_stdio() -> Result<String> {
-    let config = build_bridge_config();
-    trusty_common::mcp::ensure_daemon_up(&config).await
+    let lock_path = crate::commands::start::start_lock_path()
+        .ok_or_else(|| anyhow!("could not resolve the trusty-memory data directory"))?;
+    let config = crate::commands::start::daemon_start_config();
+    trusty_common::mcp::ensure_daemon_up_single_flight(&config, &lock_path).await
 }
 
 /// Returns true if the request is a JSON-RPC notification.
@@ -163,8 +138,9 @@ fn is_notification(req: &mcp::Request) -> bool {
 /// under the daemon-bridge architecture (issue #1078). The prior direct-store
 /// path opened redb in the stdio process and hit the write-lock exclusion
 /// problem; this path never touches the store at all.
-/// What: (1) ensures the daemon is running via the shared `ensure_daemon_up`
-/// helper (auto-start with 30 s budget); (2) builds a shared reqwest client;
+/// What: (1) ensures the daemon is running via the shared single-flight helper
+/// (start-if-absent under an exclusive lock, 30 s readiness budget, #5267);
+/// (2) builds a shared reqwest client;
 /// (3) enters `run_stdio_loop` -- for each JSON-RPC request, detects and
 /// suppresses notifications (per MCP spec section 4.1), then forwards
 /// non-notification requests to `POST /rpc` on the daemon and returns the

--- a/crates/trusty-memory/src/commands/start.rs
+++ b/crates/trusty-memory/src/commands/start.rs
@@ -1,17 +1,17 @@
 //! Handler for `trusty-memory start` — boots the HTTP daemon in the background.
 //!
 //! Why: the three trusty-* daemons (search, memory, mpm) historically had
-//! diverging `start` / `serve` / `stop` semantics. As of this change,
-//! `trusty-memory start` mirrors `trusty-search start`: it self-spawns a
-//! detached copy of the binary with `serve --foreground` so the parent shell
-//! gets its prompt back immediately. A second `start` invocation while the
-//! daemon is already healthy is a no-op (prints the live address and exits 0)
-//! rather than racing a second instance against the dynamic port walker.
-//! What: a thin async handler that probes `read_daemon_addr("trusty-memory")`
-//! plus an HTTP `/health` check, and on cold start spawns `<this exe> serve
-//! --foreground` with stdio piped to `/dev/null`.
-//! Test: `cargo run -p trusty-memory -- start` returns immediately; running
-//! it twice in a row reports "already running" on the second invocation.
+//! diverging `start` / `serve` / `stop` semantics. `trusty-memory start`
+//! mirrors `trusty-search start`: it spawns a detached `serve --foreground`.
+//! A second `start` while the daemon is already healthy is a no-op (prints the
+//! live address and exits 0) rather than racing a second instance against the
+//! dynamic port walker.
+//! What: probes `read_daemon_addr("trusty-memory")` plus an HTTP `/health`
+//! check, and on cold start goes through the shared single-flight start
+//! (#5267) so a concurrent `serve --stdio` bridge cannot start a second daemon.
+//! Test: `spawn_args_never_bind_port_zero`,
+//! `start_lock_lives_beside_the_addr_file`; cross-process exclusion in
+//! `crates/trusty-common/tests/single_flight_exclusion.rs`.
 
 use anyhow::Result;
 use colored::Colorize;
@@ -31,24 +31,67 @@ pub(crate) fn addr_file_path() -> Option<std::path::PathBuf> {
         .map(|d| d.join("http_addr"))
 }
 
+/// Path to the exclusive lock that serialises daemon starts (#5267).
+///
+/// Why: `handle_start` and the `serve --stdio` bridge both start the daemon.
+/// They must contend for the SAME lock file or the exclusion is only within each
+/// path and a `start` racing a bridge still yields two daemons — #1152's failure
+/// mode. One derivation, used by both, is what makes that impossible.
+/// What: returns `{resolve_data_dir("trusty-memory")}/start.lock`, alongside the
+/// `http_addr` file so both live under the same (test-overridable) data dir.
+/// Returns `None` when the data dir cannot be resolved.
+/// Test: `start_lock_lives_beside_the_addr_file`. The exclusion this path
+/// depends on is proven cross-crate in
+/// crates/trusty-common/tests/single_flight_exclusion.rs.
+pub(crate) fn start_lock_path() -> Option<std::path::PathBuf> {
+    trusty_common::resolve_data_dir("trusty-memory")
+        .ok()
+        .map(|d| d.join("start.lock"))
+}
+
+/// Build the `DaemonBridgeConfig` describing how to start the canonical daemon.
+///
+/// Why (#1152, #5267): the daemon must be started ONE way, from one place. The
+/// spawn args are `serve --foreground` with **no `--http`** — that is
+/// load-bearing. #1152's outage came from `--http 127.0.0.1:0`, whose
+/// OS-assigned random port always differed from the canonical one and always
+/// overwrote `http_addr`, so each spawned daemon stole address ownership from
+/// the launchd daemon and squatted redb's write lock. Bare `serve --foreground`
+/// takes the dynamic walker starting at the canonical 7070 instead.
+/// What: returns the config shared by `handle_start` and the stdio bridge.
+/// Test: `spawn_args_never_bind_port_zero`.
+pub(crate) fn daemon_start_config() -> trusty_common::mcp::DaemonBridgeConfig {
+    trusty_common::mcp::DaemonBridgeConfig {
+        service_name: "trusty-memory".to_string(),
+        // NEVER `--http 127.0.0.1:0` — see the doc comment above (#1152).
+        spawn_args: vec!["serve".to_string(), "--foreground".to_string()],
+        health_path: "/health".to_string(),
+        base_url_fn: Box::new(crate::commands::daemon_guard::daemon_base_url),
+        startup_timeout: None,
+        poll_interval: None,
+        // #5267: the single-flight path supplies the exclusion `no_spawn` was
+        // standing in for, so starting is safe again.
+        no_spawn: false,
+        no_spawn_hint: None,
+    }
+}
+
 /// Boot the trusty-memory HTTP daemon in the background.
 ///
-/// Why: a CLI invocation must return control to the shell as soon as the
-/// daemon is healthy. Blocking on `run_http_dynamic` (as `serve` historically
-/// did) tied the daemon's lifetime to the controlling terminal, which broke
-/// shell profiles, tmux panes, and any `make`-driven dev loop. Detaching via
-/// self-spawn fixes the lifetime AND keeps the surface identical to
-/// `trusty-search start`. The duplicate-instance guard
-/// (`check_already_running`) is the load-bearing piece: without it a second
-/// invocation would silently spawn a second daemon on the next free port.
+/// Why: the daemon must outlive the invoking shell, so it runs detached rather
+/// than tied to the controlling terminal (which broke shell profiles, tmux
+/// panes, and `make`-driven dev loops). Since #5267 this also waits for the
+/// daemon to answer `/health` before returning: the previous fire-and-forget
+/// return released the start lock before the port was bound, which let the next
+/// contender re-probe a dead address and start a second daemon (#1152).
 /// What: if `trusty_common::check_already_running` reports a healthy daemon,
-/// prints its URL and returns. Otherwise spawns `<this exe> serve
-/// --foreground` with stdio redirected to `/dev/null` so the child inherits no
-/// terminal, and prints the spawned PID. Does NOT wait for the child to finish
-/// binding — callers that need health confirmation should run `trusty-memory
-/// doctor` next.
-/// Test: `cargo run -p trusty-memory -- start` returns within a second; running
-/// it twice in a row reports "already running" on the second invocation.
+/// prints its URL and returns without taking the lock. Otherwise delegates to
+/// [`trusty_common::mcp::ensure_daemon_up_single_flight`], which starts
+/// `serve --foreground` at most once across all processes and waits for it to
+/// become ready. Fails closed if it never does.
+/// Test: `spawn_args_never_bind_port_zero`,
+/// `start_config_relies_on_the_single_flight_lock`; end-to-end exclusion in
+/// `crates/trusty-common/tests/single_flight_exclusion.rs`.
 pub async fn handle_start() -> Result<()> {
     if let Some(path) = addr_file_path() {
         if let Some(url) = trusty_common::check_already_running(&path, "/health").await {
@@ -57,20 +100,84 @@ pub async fn handle_start() -> Result<()> {
         }
     }
 
-    let exe = std::env::current_exe()
-        .map_err(|e| anyhow::anyhow!("could not resolve current_exe: {e}"))?;
-    let child = std::process::Command::new(&exe)
-        .arg("serve")
-        .arg("--foreground")
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .map_err(|e| anyhow::anyhow!("could not spawn detached daemon: {e}"))?;
-    let pid = child.id();
-    eprintln!(
-        "{} Daemon starting in background (pid {pid}). Run `trusty-memory doctor` to verify readiness.",
-        "✓".green()
-    );
+    // #5267: start under the shared single-flight lock so a concurrent `serve
+    // --stdio` bridge cannot start a second daemon. Waiting for readiness here
+    // (rather than returning at spawn time, as this used to) is what keeps the
+    // exclusion honest — releasing the lock before the daemon binds would let
+    // the next contender re-probe a not-yet-listening port and start another.
+    let lock_path = start_lock_path()
+        .ok_or_else(|| anyhow::anyhow!("could not resolve the trusty-memory data directory"))?;
+    let config = daemon_start_config();
+    let url = trusty_common::mcp::ensure_daemon_up_single_flight(&config, &lock_path).await?;
+    eprintln!("{} trusty-memory daemon ready at {url}", "✓".green());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: `--http 127.0.0.1:0` is the exact spawn shape that caused #1152. An
+    /// OS-assigned random port always differs from the canonical one and always
+    /// overwrites `http_addr`, so each spawned daemon stole address ownership
+    /// from the launchd daemon and squatted redb's write lock. This asserts the
+    /// shape can never come back by accident.
+    /// What: inspects the shared start config's spawn args.
+    /// Test: itself.
+    #[test]
+    fn spawn_args_never_bind_port_zero() {
+        let config = daemon_start_config();
+        let joined = config.spawn_args.join(" ");
+        assert!(
+            !joined.contains(":0"),
+            "spawn args must never bind port 0 (#1152); got: {joined}"
+        );
+        assert!(
+            !config.spawn_args.iter().any(|a| a == "--http"),
+            "the canonical daemon takes the dynamic walker from 7070, not an \
+             explicit --http (#1152); got: {joined}"
+        );
+        assert_eq!(
+            config.spawn_args,
+            vec!["serve".to_string(), "--foreground".to_string()],
+            "the canonical daemon command must stay `serve --foreground`"
+        );
+    }
+
+    /// Why: `handle_start` and the stdio bridge must contend for the SAME lock
+    /// file. If they derived different paths the exclusion would hold only
+    /// within each path, and a `start` racing a bridge would still yield two
+    /// daemons — #1152's failure mode through a side door.
+    /// What: asserts the lock path is derived from the data dir and sits beside
+    /// `http_addr`, so both callers resolve it identically.
+    /// Test: itself.
+    #[test]
+    fn start_lock_lives_beside_the_addr_file() {
+        let (Some(lock), Some(addr)) = (start_lock_path(), addr_file_path()) else {
+            return; // No resolvable data dir in this environment.
+        };
+        assert_eq!(
+            lock.parent(),
+            addr.parent(),
+            "the start lock must live in the same data dir as http_addr"
+        );
+        assert_eq!(lock.file_name().unwrap(), "start.lock");
+    }
+
+    /// Why: the bridge must never be able to spawn without exclusion. `no_spawn`
+    /// is off now, so the lock is the ONLY thing preventing #1152 — this pins
+    /// the pairing so a future edit cannot turn spawning back on without it.
+    /// Test: itself.
+    #[test]
+    fn start_config_relies_on_the_single_flight_lock() {
+        let config = daemon_start_config();
+        assert!(
+            !config.no_spawn,
+            "start-if-not-running requires spawning to be permitted (#5267)"
+        );
+        assert!(
+            start_lock_path().is_some(),
+            "a spawning config must have a lock path to serialise on"
+        );
+    }
 }

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -1,9 +1,9 @@
 //! CLI entry point for the `trusty-memory` binary.
 //!
 //! Why: ship a thin clap-to-handler shim so users can `cargo install
-//! trusty-memory` and invoke `trusty-memory serve --stdio` (the direct
-//! MCP stdio server, PR1 #919 of the #914 stdio-cutover epic), `trusty-memory
-//! serve` (the HTTP/SSE daemon), or `trusty-memory migrate kuzu-memory`
+//! trusty-memory` and invoke `trusty-memory serve` (MCP stdio — bare `serve`
+//! and `serve --stdio` are the same thing since #5267), `trusty-memory start`
+//! (the HTTP/SSE daemon), or `trusty-memory migrate kuzu-memory`
 //! (which rewrites Claude settings files that still reference the legacy
 //! kuzu-memory MCP server). All real logic lives in the library and the
 //! `commands::` modules — this file does CLI parsing and dispatch only.
@@ -11,8 +11,9 @@
 //! removed in PR3 of the #914 epic; `serve --stdio` is the canonical
 //! stdio integration.
 //! What: defines a `clap::Parser` with `serve`, `migrate`, and other
-//! subcommands. `serve --stdio` defers to `commands::serve_stdio_bridge`;
-//! `serve` (HTTP) defers to `trusty_memory::run_http` / `run_http_dynamic`.
+//! subcommands. `serve` and `serve --stdio` defer to
+//! `commands::serve_stdio_bridge`; `serve --http` / `--foreground` defer to
+//! `trusty_memory::run_http` / `run_http_dynamic`.
 //! Test: `cargo run -p trusty-memory -- --help` lists all subcommands.
 //! `cargo run -p trusty-memory -- migrate kuzu-memory --dry-run` exercises
 //! the migrate path end-to-end without modifying any files.
@@ -80,32 +81,31 @@ enum Command {
     /// way to take it down that does not depend on launchd / systemd.
     Stop,
 
-    /// Run the daemon.  Mode matrix (#914 PR4):
-    ///   serve                  → HTTP daemon (default, dynamic port, background)
-    ///   serve --http[=ADDR]    → explicit HTTP; optional bind address
+    /// Run the server.  Mode matrix (#5267; supersedes #914 PR4):
+    ///   serve                  → MCP stdio (same as `--stdio`)
+    ///   serve --stdio          → MCP stdio JSON-RPC server (Claude Code)
+    ///   serve --http[=ADDR]    → HTTP daemon; optional bind address
     ///   serve --foreground     → HTTP in foreground (launchd / systemd)
-    ///   serve --stdio          → direct stdio JSON-RPC MCP server (Claude Code)
     ///
-    /// Default mode is HTTP/SSE with dynamic port selection (7070..=7079, OS
-    /// fallback). Without `--foreground`, `serve` self-spawns a detached
-    /// background daemon (alias for `start`) and returns immediately so the
-    /// parent shell gets its prompt back. Pass `--foreground` to keep the
-    /// daemon in the foreground (used internally by `start` to host the
-    /// actual HTTP server, and by launchd / systemd). Pass `--http <ADDR>`
-    /// to bind a specific address.
+    /// Bare `serve` speaks MCP over stdio, matching `trusty-search serve`. Use
+    /// `trusty-memory start` for the background HTTP daemon — that is the
+    /// daemon-launching verb. Before #5267 bare `serve` detached an HTTP daemon,
+    /// which made the same word mean opposite things in two sibling crates.
     ///
-    /// Claude Code integration (recommended): use `serve --stdio` for a
-    /// direct stdio JSON-RPC MCP server (PR1 #919, #914).  This mode binds
-    /// no HTTP port; stdout is the JSON-RPC channel.  Palaces are opened
-    /// read-only via the snapshot fallback when a write lock is held by
-    /// another process.  Every request resolves within a deadline — success
-    /// or an explicit JSON-RPC error — so the MCP client never hangs.
+    /// The stdio path is a pure proxy to the HTTP daemon and will START that
+    /// daemon if it is not already running, under an exclusive lock so N
+    /// concurrent bridges produce exactly one daemon (#5267, #1152).
+    ///
+    /// `--http` selects the HTTP/SSE daemon with dynamic port selection
+    /// (7070..=7079, OS fallback); without `--foreground` it self-spawns a
+    /// detached background daemon and returns immediately. Pass `--foreground`
+    /// to keep it in the foreground (used by `start`, launchd, and systemd).
     Serve {
         /// Select HTTP mode explicitly with an optional bind address.
         ///
-        /// `--http` (bare): dynamic port (same as bare `serve`).
+        /// `--http` (bare): dynamic port, self-spawning detached daemon.
         /// `--http 127.0.0.1:7070`: bind that exact address.
-        /// Absent: default HTTP mode — bare `serve` behaviour unchanged.
+        /// Absent: MCP stdio mode (#5267) — this flag is what selects HTTP.
         #[arg(
             long,
             value_name = "ADDR",
@@ -688,17 +688,20 @@ async fn main() -> Result<()> {
             foreground,
             stdio,
             palace,
-        } => {
-            if stdio {
+        } => match serve_mode(&http, foreground, stdio) {
+            ServeMode::Stdio { notify } => {
+                if notify {
+                    warn_bare_serve_is_stdio();
+                }
                 run_serve_stdio(palace).await
-            } else {
-                // Flatten Option<Option<SocketAddr>> → Option<SocketAddr>.
-                // --http (bare) → Some(None) → flatten → None → dynamic port.
-                // --http ADDR   → Some(Some(addr)) → flatten → Some(addr).
-                // absent        → None → flatten → None → dynamic port.
+            }
+            // Flatten Option<Option<SocketAddr>> → Option<SocketAddr>.
+            // --http (bare) → Some(None) → flatten → None → dynamic port.
+            // --http ADDR   → Some(Some(addr)) → flatten → Some(addr).
+            ServeMode::Http => {
                 run_serve(http.flatten(), foreground, palace, log_buffer, error_store).await
             }
-        }
+        },
         Command::Migrate {
             target,
             dry_run,
@@ -830,6 +833,69 @@ async fn run_monitor(target: MonitorTarget) -> Result<()> {
 /// `commands/serve_stdio_bridge.rs`.
 async fn run_serve_stdio(palace: Option<String>) -> Result<()> {
     trusty_memory::commands::serve_stdio_bridge::run_stdio_bridge(palace).await
+}
+
+/// Which server `serve` runs, decided from its transport flags.
+///
+/// Why: the bare-vs-flagged decision is the whole of #5267's behavior change, so
+/// it is a value a test can assert on rather than a branch buried in `main`'s
+/// dispatch. A test that only proved `serve` PARSES would have passed just as
+/// well before the change.
+/// Test: `serve_mode_*` in `cli_tests.rs`.
+#[derive(Debug, PartialEq, Eq)]
+enum ServeMode {
+    /// MCP stdio JSON-RPC. `notify` is set only for the bare form, whose
+    /// meaning changed and whose user may therefore be surprised.
+    Stdio { notify: bool },
+    /// The axum HTTP/SSE daemon.
+    Http,
+}
+
+/// Decide the `serve` transport from its flags (#5267).
+///
+/// Why: bare `serve` used to mean "detach an HTTP daemon" and now means "speak
+/// MCP stdio", aligning with `trusty-search serve`. Only the no-flag case moved;
+/// every flagged form resolves exactly as it did before, which is what keeps the
+/// launchd plist, `handle_start`, and the existing integration tests working
+/// untouched.
+/// What: `--stdio` → stdio. `--http` (with or without an address) or
+/// `--foreground` → HTTP. Nothing → stdio, with the notice flag set. `--palace`
+/// is not a transport flag and does not affect the choice.
+/// Test: `serve_mode_bare_is_stdio` (fails before #5267),
+/// `serve_mode_explicit_stdio`, `serve_mode_http_bare`, `serve_mode_http_addr`,
+/// `serve_mode_foreground_is_http`, `serve_mode_palace_only_is_stdio`.
+fn serve_mode(http: &Option<Option<SocketAddr>>, foreground: bool, stdio: bool) -> ServeMode {
+    if stdio {
+        return ServeMode::Stdio { notify: false };
+    }
+    if http.is_some() || foreground {
+        return ServeMode::Http;
+    }
+    ServeMode::Stdio { notify: true }
+}
+
+/// Tell an interactive human that bare `serve` now speaks MCP stdio (#5267).
+///
+/// Why: bare `serve` used to detach an HTTP daemon and return the prompt. It now
+/// blocks reading JSON-RPC from stdin, which to someone who typed it at a shell
+/// looks exactly like a hang. The notice names the new verb so they are not left
+/// guessing.
+///
+/// What: writes one line to **stderr** — never stdout, which is the JSON-RPC
+/// channel — and only when stdin is a TTY, so an MCP client (whose stdin is a
+/// pipe) sees nothing. The TTY check gates ONLY the notice: bare `serve` speaks
+/// stdio identically either way. Behavior that varied by TTY would make the
+/// tests lie about what a real client gets.
+/// Test: `bare_serve_notice_absent_when_stdin_is_piped`,
+/// `bare_serve_notice_present_when_stdin_is_a_tty`.
+fn warn_bare_serve_is_stdio() {
+    use std::io::IsTerminal;
+    if std::io::stdin().is_terminal() {
+        eprintln!(
+            "trusty-memory: `serve` speaks MCP over stdio and is waiting on stdin. \
+             To run the HTTP daemon, use `trusty-memory start`."
+        );
+    }
 }
 
 /// Dispatch `serve` (HTTP path) to the HTTP server.

--- a/crates/trusty-memory/tests/serve_cli_surface.rs
+++ b/crates/trusty-memory/tests/serve_cli_surface.rs
@@ -1,0 +1,262 @@
+//! Binary-level surface tests for `trusty-memory serve` (#5267).
+//!
+//! Why: the transport-selection unit tests in `cli_tests.rs` prove which branch
+//! the dispatch takes; these prove what the real binary does when you run it —
+//! that bare `serve` actually reaches the stdio server, that the explanatory
+//! notice goes to stderr and only for a human, and that stdout stays clean
+//! enough to carry JSON-RPC. A notice on stdout would corrupt MCP framing, which
+//! no parse-level test can catch.
+//!
+//! These tests never touch the machine's real daemon or palace: every child runs
+//! under `TRUSTY_DATA_DIR_OVERRIDE` pointing at a fresh temp dir, and none of
+//! them is allowed to reach a readiness state that would start anything.
+//!
+//! Test: `cargo test -p trusty-memory --test serve_cli_surface`.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+/// Path to the binary under test, as cargo builds it for this integration test.
+fn bin() -> std::path::PathBuf {
+    let mut p = std::env::current_exe().expect("current exe");
+    p.pop(); // .../deps
+    p.pop(); // .../debug
+    p.push("trusty-memory");
+    p
+}
+
+/// Run `trusty-memory <args>` with a piped stdin that is closed immediately.
+///
+/// Why: closing stdin gives the MCP stdio loop a clean EOF, so a bare `serve`
+/// exits promptly instead of blocking the test. Piped (not TTY) stdin is also
+/// exactly the shape an MCP client presents, which is what the notice tests
+/// assert against.
+/// What: returns `(stdout, stderr)` after a bounded wait.
+fn run_piped(args: &[&str], data_dir: &std::path::Path) -> (String, String) {
+    let mut child = Command::new(bin())
+        .args(args)
+        .env("TRUSTY_DATA_DIR_OVERRIDE", data_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn trusty-memory");
+
+    // Close stdin so the stdio loop sees EOF.
+    drop(child.stdin.take());
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        if let Some(_status) = child.try_wait().expect("try_wait") {
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            let _ = child.kill();
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let out = child.wait_with_output().expect("wait_with_output");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+/// Why: an MCP client's stdin is a pipe, and it must see NO notice — the notice
+/// is for a human who typed the command. It must also never appear on stdout,
+/// which carries JSON-RPC framing.
+/// What: runs bare `serve` with piped stdin and asserts the notice text is
+/// absent from both streams.
+/// Test: itself.
+#[test]
+fn bare_serve_notice_absent_when_stdin_is_piped() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (stdout, stderr) = run_piped(&["serve"], tmp.path());
+
+    assert!(
+        !stderr.contains("waiting on stdin"),
+        "no notice for a piped (MCP client) stdin; stderr was: {stderr}"
+    );
+    assert!(
+        !stdout.contains("waiting on stdin"),
+        "the notice must NEVER reach stdout — it is the JSON-RPC channel"
+    );
+}
+
+/// Why: stdout is the JSON-RPC channel. Anything the bare `serve` path prints
+/// there corrupts MCP framing for every client. This is the hygiene invariant
+/// the whole stdio design rests on.
+/// What: runs bare `serve` with immediate EOF and asserts stdout carries no
+/// non-JSON chatter (it is either empty or valid JSON-RPC lines).
+/// Test: itself.
+#[test]
+fn bare_serve_keeps_stdout_clean() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (stdout, _stderr) = run_piped(&["serve"], tmp.path());
+
+    for line in stdout.lines().filter(|l| !l.trim().is_empty()) {
+        assert!(
+            serde_json::from_str::<serde_json::Value>(line).is_ok(),
+            "stdout must carry only JSON-RPC; found non-JSON line: {line}"
+        );
+    }
+}
+
+/// Why: bare `serve` and `serve --stdio` must be the same server. If they
+/// diverged, the alignment #5267 delivers would be cosmetic.
+/// What: runs both with an identical closed stdin and asserts their stdout
+/// behavior matches (both clean, both terminating on EOF).
+/// Test: itself.
+#[test]
+fn bare_serve_and_explicit_stdio_behave_alike() {
+    let tmp_a = tempfile::tempdir().expect("tempdir");
+    let tmp_b = tempfile::tempdir().expect("tempdir");
+    let (out_bare, _) = run_piped(&["serve"], tmp_a.path());
+    let (out_flag, _) = run_piped(&["serve", "--stdio"], tmp_b.path());
+
+    let json_lines = |s: &str| {
+        s.lines()
+            .filter(|l| !l.trim().is_empty())
+            .filter(|l| serde_json::from_str::<serde_json::Value>(l).is_ok())
+            .count()
+    };
+    assert_eq!(
+        json_lines(&out_bare),
+        json_lines(&out_flag),
+        "bare `serve` and `serve --stdio` must produce the same stdout shape"
+    );
+}
+
+/// Why: an unknown flag must still be an error. Making bare `serve` meaningful
+/// must not have made the parser permissive.
+/// What: asserts a nonzero exit and a clap usage error on stderr.
+/// Test: itself.
+#[test]
+fn unknown_flag_is_still_rejected() {
+    let out = Command::new(bin())
+        .args(["serve", "--definitely-not-a-flag"])
+        .output()
+        .expect("run");
+    assert!(!out.status.success(), "unknown flag must exit nonzero");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("unexpected argument") || stderr.contains("error"),
+        "expected a usage error, got: {stderr}"
+    );
+}
+
+/// Why: `--stdio` conflicts with both HTTP flags, and #5267 must not have
+/// relaxed either relationship.
+/// What: asserts both conflicting combinations exit nonzero.
+/// Test: itself.
+#[test]
+fn conflicting_transport_flags_still_rejected() {
+    for args in [
+        ["serve", "--http", "--stdio"],
+        ["serve", "--foreground", "--stdio"],
+    ] {
+        let out = Command::new(bin()).args(args).output().expect("run");
+        assert!(
+            !out.status.success(),
+            "{args:?} must be rejected as conflicting"
+        );
+    }
+}
+
+/// Why: `--help` is how a user discovers that the verb moved. If it still
+/// described `serve` as the daemon, the change would be undiscoverable.
+/// What: asserts the help text names `start` as the daemon verb and `serve` as
+/// MCP stdio.
+/// Test: itself.
+#[test]
+fn help_documents_the_new_serve_semantics() {
+    let out = Command::new(bin())
+        .args(["serve", "--help"])
+        .output()
+        .expect("run --help");
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        help.contains("stdio"),
+        "serve --help must describe the stdio default; got: {help}"
+    );
+    assert!(
+        help.contains("start"),
+        "serve --help must point at `start` for the daemon; got: {help}"
+    );
+}
+
+/// Why: the other half of the notice contract. A human at a terminal MUST be
+/// told that `serve` now waits on stdin and that `start` is the daemon verb —
+/// without it, bare `serve` looks exactly like a hang. Only a real pty
+/// exercises this branch; a pipe takes the silent path.
+/// What: allocates a pty with `openpty(3)`, hands the slave to the child as
+/// stdin, sends Ctrl-D so the stdio loop sees EOF, and asserts the notice
+/// appears on stderr and never on stdout.
+/// Test: itself.
+#[cfg(unix)]
+#[test]
+fn bare_serve_notice_present_when_stdin_is_a_tty() {
+    use std::os::unix::io::FromRawFd;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let mut master: libc::c_int = 0;
+    let mut slave: libc::c_int = 0;
+    // Safety: both out-params are valid ints; the remaining three are optional
+    // and null means "use defaults".
+    let rc = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, 0, "openpty must succeed");
+
+    // Safety: `slave` is a fresh fd from openpty and is not used elsewhere.
+    let child_stdin = unsafe { Stdio::from_raw_fd(slave) };
+    let mut child = Command::new(bin())
+        .arg("serve")
+        .env("TRUSTY_DATA_DIR_OVERRIDE", tmp.path())
+        .stdin(child_stdin)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn trusty-memory on a pty");
+
+    // Ctrl-D: canonical-mode EOF, so the stdio loop terminates.
+    // Safety: `master` is a valid open fd owned by this test.
+    let mut master_file = unsafe { std::fs::File::from_raw_fd(master) };
+    std::thread::sleep(Duration::from_millis(300));
+    let _ = master_file.write_all(&[0x04]);
+    let _ = master_file.flush();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        if child.try_wait().expect("try_wait").is_some() {
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            let _ = child.kill();
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let out = child.wait_with_output().expect("output");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stderr.contains("waiting on stdin") && stderr.contains("start"),
+        "a human at a terminal must be told serve is stdio and start is the \
+         daemon verb; stderr was: {stderr}"
+    );
+    assert!(
+        !stdout.contains("waiting on stdin"),
+        "the notice must never reach stdout; stdout was: {stdout}"
+    );
+}


### PR DESCRIPTION
Closes #5267.

Two changes that only make sense together.

**Bare `serve` speaks MCP stdio.** `trusty-memory serve` used to detach an HTTP daemon; `trusty-search serve` speaks MCP stdio. The same word meant opposite things in sibling crates. Bare `serve` now means stdio in both, and `trusty-memory start` is the daemon-launching verb. Every flagged form resolves exactly as before — `serve --stdio`, `serve --http <ADDR>`, `serve --foreground`, `start` — which is what leaves the launchd plist, `handle_start`, and the existing integration tests untouched. A human running bare `serve` at a terminal gets a one-line **stderr** notice naming the new verb, because a command that used to return the prompt and now blocks on stdin otherwise looks like a hang. The TTY check gates only the notice, never the behavior, so a piped MCP client sees nothing and the tests do not lie about what a real client gets.

**`start` is single-flight instead of hard-erroring.** The stdio bridge needs the daemon to exist. #1152 removed auto-spawn because a health probe is a window, not a lock: N bridges each missed inside the same window and each spawned a daemon — ~36 orphans, one squatting redb's write lock, all writes failing. Refusing to spawn traded an outage for a papercut. `trusty_common::mcp::ensure_daemon_up_single_flight` supplies the exclusion the probe never could: probe unlocked (the common case costs nothing), then on a miss take an exclusive `flock(2)` covering re-probe, spawn, and readiness wait. A bridge that loses the race blocks and then finds a *ready* daemon.

`flock` rather than an `O_EXCL` lockfile because the lock must survive a starter that is killed — the kernel drops it on process death, so there is no stale state and no reaper. The lock is held across the readiness wait deliberately; releasing at spawn time would let a second bridge re-probe a not-yet-bound port and start another. `handle_start` and the bridge derive the lock path from one function so they contend for the same file.

`trusty-memory start` now waits for `/health` before returning, which is what keeps that exclusion honest.

## Test ladder — rung 4 (cross-crate: trusty-common + trusty-memory + trusty-agents)

```
cargo fmt --check                                             EXIT=0
cargo check -p trusty-common -p trusty-memory -p trusty-agents EXIT=0
cargo clippy -p trusty-common --features mcp --all-targets -D warnings   EXIT=0
cargo clippy -p trusty-memory -p trusty-agents --all-targets -D warnings EXIT=0
cargo test -p trusty-common --features mcp
    lib                       → 378 passed; 0 failed; 7 ignored
    single_flight_exclusion   → 7 passed; 0 failed
cargo test -p trusty-memory --test serve_cli_surface → 7 passed; 0 failed
cargo test -p trusty-memory --bins                   → 13 passed; 0 failed
SKIP_UI_BUILD=1 cargo check --workspace              EXIT=0

bash scripts/check_line_cap.sh           EXIT=0
bash scripts/check_sld.sh                EXIT=0
bash scripts/check_changelog_fragment.sh EXIT=0
bash scripts/check_rustdoc_links.sh      → 25 crate(s) documented, 0 broken link(s), baseline 0
```

`tests/single_flight_exclusion.rs` is the #1152 regression: 12 concurrent child processes call the production `ensure_daemon_up_single_flight` against one shared lock and one absent daemon, where the "daemon" is the test binary re-executed in a daemon role binding a real port. Each start drops a uniquely-named file, so the assertion is a count with no timing assumption.

### Pre-existing failures, reproduced on `origin/main`

`cargo test -p trusty-memory` → 765 passed; 6 failed. The six are `commands::inbox_check::tests::palace_slug_from_stdin_cwd_uses_stdin_path` and five `commands::prompt_context::tests::*`. This PR touches neither module. Reproduced at `origin/main` detached:

```
cargo test -p trusty-memory --lib commands::prompt_context
  test result: FAILED. 44 passed; 5 failed; 0 ignored; 723 filtered out
cargo test -p trusty-memory --lib commands::inbox_check
  test result: FAILED. 3 passed; 1 failed; 0 ignored; 768 filtered out
```

`cargo test -p trusty-agents` → 3502 passed; 1 failed: `system_status::credentials::tests::credential_status_never_leaks_a_value`, tracked in #5678.

`bash scripts/check_contracts.sh --crate trusty-common` returns NO VERDICT because the nightly rustdoc JSON build fails on unresolved intra-doc links. It fails identically at `origin/main` (same error, 130 warnings there vs 132 here), so it is pre-existing and not addressed here. The two added warnings are `private_intra_doc_links` on `ensure_daemon_up_single_flight`'s references to the `pub(crate)` helpers it shares with `ensure_daemon_up`; they are warnings, not the error that stops the build, and `check_rustdoc_links.sh` reports 0 broken.

## Rebase

Rebased onto `origin/main` with no conflicts. Two corrections on top of the original branch: the four changelog fragments were missing their `- ` bullet and failed `check_changelog_fragment.sh`, and a `Test:` pointer on `StartLock` named `lock_released_on_drop`, which does not exist — it now names the tests that do. An unrelated `crates/trusty-memory/ui/package-lock.json` reformat was dropped.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
