### PR TITLE
fix(trusty-common): repair the two doc links that broke check_contracts.sh on main

### DIFF
--- a/crates/trusty-common/changelog.d/5750-docgen-module-doc-links.md
+++ b/crates/trusty-common/changelog.d/5750-docgen-module-doc-links.md
@@ -1,0 +1,7 @@
+Fixed
+- Qualified the `docgen` module's own doc links to `assert_region` and
+  `sync_region`, which rustdoc could not resolve as bare names. #5744's
+  `#![deny(rustdoc::broken_intra_doc_links)]` turned them into errors, and
+  because the `docgen` feature is enabled only from `[dev-dependencies]` the
+  workspace-wide link gate never documented the module — so the two broke
+  `scripts/check_contracts.sh` on `main` for everyone instead.

--- a/crates/trusty-common/src/docgen.rs
+++ b/crates/trusty-common/src/docgen.rs
@@ -12,8 +12,9 @@
 //!
 //! What: marker parsing (`<!-- BEGIN GENERATED: <id> -->` …
 //! `<!-- END GENERATED: <id> -->`), a deterministic MCP-tool-table renderer,
-//! and [`assert_region`] / [`sync_region`], which check the region or — with
-//! `UPDATE_DOCS=1` in the environment — rewrite it in place.
+//! and [`crate::docgen::assert_region`] / [`crate::docgen::sync_region`], which
+//! check the region or — with `UPDATE_DOCS=1` in the environment — rewrite it
+//! in place.
 //!
 //! Test: `crates/trusty-common/src/docgen/tests.rs`, plus the three consumer
 //! tests `crates/{trusty-search,trusty-memory,trusty-analyze}/tests/generated_docs.rs`.

--- a/scripts/check_contracts.sh
+++ b/scripts/check_contracts.sh
@@ -192,10 +192,54 @@ echo "  building rustdoc JSON (nightly, $(printf '%s' "$FEATURES" | tr ',' '\n' 
 if ! SKIP_UI_BUILD=1 RUSTDOCFLAGS="-Z unstable-options --output-format json" \
   cargo +nightly rustdoc -p "$CRATE" --lib --no-default-features \
   --features "$FEATURES" > "${SCRATCH}/rustdoc.log" 2>&1; then
+  # `tail -20` CANNOT show why this build failed, and reporting it as though it
+  # could is what made this gate unactionable. rustdoc prints diagnostics in
+  # source order and its warnings vastly outnumber its errors: when #5744's
+  # `#![deny(rustdoc::broken_intra_doc_links)]` first failed this build, the two
+  # `error:` blocks sat at lines 391 and 405 of an 1117-line log and the tail
+  # showed twenty lines of unrelated `unclosed HTML tag` warnings. A developer
+  # reading that has no way to reach the cause. Print the error BLOCKS instead,
+  # and when there are none say so, because "no diagnostic" means the failure is
+  # a build script or the toolchain, which is a different thing to go fix.
+  # The block ends at a TRULY empty line, not at `/^[[:space:]]*$/`: rustdoc
+  # renders the offending source line inside its `= note:` block and indents the
+  # blank line above it, so a whitespace-tolerant terminator cuts the block
+  # before `no item named ... in scope` — the one line that says what to fix.
+  ERRORS="${SCRATCH}/rustdoc.errors"
+  awk '/^error/ { blk = 1 } blk { print } /^$/ { blk = 0 }' \
+    "${SCRATCH}/rustdoc.log" > "$ERRORS" || true
+  SAVED_LOG="${REPO_ROOT}/target/contracts-rustdoc-failure.log"
+  mkdir -p "$(dirname "$SAVED_LOG")" 2>/dev/null || true
+  cp "${SCRATCH}/rustdoc.log" "$SAVED_LOG" 2>/dev/null || SAVED_LOG=""
   {
     echo "NO VERDICT: the rustdoc JSON build failed, so no contract was read."
-    echo "            This is NOT a pass. Last 20 lines:"
-    tail -20 "${SCRATCH}/rustdoc.log" | sed 's/^/       /'
+    echo "            This is NOT a pass."
+    echo ""
+    if [ -s "$ERRORS" ]; then
+      echo "            rustdoc reported $(grep -c '^error' "$ERRORS") error(s):"
+      echo ""
+      head -80 "$ERRORS" | sed 's/^/       /'
+    else
+      echo "            rustdoc emitted no 'error:' diagnostic, so this is a BUILD"
+      echo "            failure rather than a documentation failure — a dependency's"
+      echo "            build script or the toolchain itself."
+      if grep -qiE 'dbus|pkg-config|pkg_config' "${SCRATCH}/rustdoc.log"; then
+        echo ""
+        echo "            The log names pkg-config/dbus. This crate's full feature set"
+        echo "            pulls in libdbus-sys, whose build.rs panics when the dbus"
+        echo "            headers are absent — the failure that took down this gate's"
+        echo "            first CI run (31858449749). Install them:"
+        echo "              Debian/Ubuntu:  sudo apt-get install -y libdbus-1-dev"
+        echo "              macOS:          brew install dbus pkg-config"
+      fi
+      echo ""
+      echo "            Last 20 lines:"
+      tail -20 "${SCRATCH}/rustdoc.log" | sed 's/^/       /'
+    fi
+    if [ -n "$SAVED_LOG" ]; then
+      echo ""
+      echo "            Full build log: ${SAVED_LOG}"
+    fi
   } >&2
   exit "$EXIT_NO_VERDICT"
 fi


### PR DESCRIPTION
## The failure

`bash scripts/check_contracts.sh --crate trusty-common` exited 3 (NO VERDICT) on
`main` for everyone. The exit 3 was correct — the gate refused to report a
verdict it could not compute. The build under it was genuinely broken.

Two intra-doc links in the `docgen` module's own `//!` header, written as bare
names, which rustdoc does not resolve there:

```
error: unresolved link to `assert_region`
   = note: no item named `assert_region` in scope
note: the lint level is defined here
  --> crates/trusty-common/src/lib.rs:36:9
36 | #![deny(rustdoc::broken_intra_doc_links)]
```

#5744 added that `deny` to the crate root, so the two stopped being warnings and
failed the rustdoc JSON build the contract extractor reads.

## Why #5744 drove the baseline to zero without seeing them

Its gate, `scripts/check_rustdoc_links.sh`, runs `cargo doc --workspace
--no-deps` under feature unification. `trusty-common`'s `docgen` feature is
enabled only from consumers' `[dev-dependencies]`, which `cargo doc` does not
resolve — so the module is never documented there. Evidence from this branch:

```
SUMMARY  25 crate(s) documented, 0 broken link(s), baseline 0, 0 diagnostic(s) examined
$ ls target/doc/trusty_common/docgen/index.html
No such file or directory
```

`check_contracts.sh` builds `trusty-common` with all 42 non-excluded features,
so it is the only gate that documents `docgen` — and the only one where the two
links surfaced.

## Why CI passed while local failed

They never disagreed. The last green Gates 5-6 ran at `aaf4ca04` (#5743), and
`3e06bee8` (#5744) is not an ancestor of it (`git merge-base --is-ancestor` →
false). CI has not run Gate 5 since the deny lint merged; it would fail
identically.

## Second change: make the gate's own failure readable

`tail -20` cannot show a rustdoc failure's cause. rustdoc prints diagnostics in
source order and warnings vastly outnumber errors, so the two `error:` blocks
sat at lines 391 and 405 of an 1117-line log while the tail printed twenty lines
of unrelated `unclosed HTML tag` warnings. Tracking this down needed a separate
manual reproduction of the build.

The NO VERDICT message now prints the error blocks, states explicitly when there
are none (a build script or the toolchain, not a documentation failure — naming
`libdbus-1-dev` when the log points at it, the failure that took down this
gate's first CI run 31858449749), and keeps the full log at
`target/contracts-rustdoc-failure.log`. Proven by re-breaking the link:

```
NO VERDICT: the rustdoc JSON build failed, so no contract was read.
            This is NOT a pass.

            rustdoc reported 3 error(s):

       error: unresolved link to `assert_region`
          = note: no item named `assert_region` in scope
       note: the lint level is defined here
         --> crates/trusty-common/src/lib.rs:36:9
       36 | #![deny(rustdoc::broken_intra_doc_links)]
```

No gate is weakened: the exit-3 fail-closed contract is untouched, no exclusion
row was added, no version changed.

## Gates

Test ladder rung 3 — a doc comment in one crate plus the gate script that reads
it.

| Gate | Result |
|---|---|
| `check_contracts.sh --crate trusty-common` | exit 0 — `15 contract(s) extracted, artifact matches source — OK.` |
| `check_semver_types.sh --crate trusty-common` | exit 0 — `12672 public item position(s) compared, 0 type change(s) — OK.` |
| `check_rustdoc_links.sh` | exit 0 — `25 crate(s) documented, 0 broken link(s), baseline 0` |
| `check-ci-helpers-selftest.sh` | exit 0 |
| `check_semver_types_selftest.sh` | exit 0 |
| `check_line_cap.sh` | exit 0 |
| `check_sld.sh` | exit 0 |
| `check_changelog_fragment.sh` | exit 0 — `all 1 crate(s) with source changes are recorded` |
| `cargo fmt --check` | exit 0 |
| `cargo clippy -p trusty-common --features docgen --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-common --features docgen` | `test result: ok. 363 passed; 0 failed; 6 ignored` |

`check_semver_types.sh` first reported NO VERDICT for an unrelated reason — an
empty rustdoc cache in a fresh worktree — and its message already named the exact
command to fix it. `bash scripts/check_semver.sh --crate trusty-common` populated
the cache and the verdict above followed. No shared root cause with
`check_contracts.sh`, and `scripts/lib/rustdoc_walk.py` is not implicated in
either: it parses rustdoc JSON, it does not build it.

## Two gaps found, not fixed here

1. `check_rustdoc_links.sh` cannot see any module behind a dev-dependency-only
   feature. Closing it means documenting with those features on, which
   `trusty-common` cannot do via `--all-features` (three mutually exclusive
   `embedder-*` ORT variants).
2. `scripts/check_contracts_selftest.sh` is cited as the `Test:` pointer by
   `diff_contracts.py`, `extract_contracts.py`, and twice by
   `scripts/lib/rustdoc_walk.py`, and does not exist.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
