### PR TITLE
fix(scripts): stop check_contracts.sh misreporting a colored rustdoc failure

### DIFF
--- a/scripts/check_contracts.sh
+++ b/scripts/check_contracts.sh
@@ -205,9 +205,18 @@ if ! SKIP_UI_BUILD=1 RUSTDOCFLAGS="-Z unstable-options --output-format json" \
   # renders the offending source line inside its `= note:` block and indents the
   # blank line above it, so a whitespace-tolerant terminator cuts the block
   # before `no item named ... in scope` — the one line that says what to fix.
+  #
+  # STRIP ANSI FIRST. CI sets `CARGO_TERM_COLOR: always`, so on a GitHub runner
+  # every diagnostic arrives as `\033[1m\033[91merror\033[0m: ...` and an anchored
+  # `/^error/` matches NONE of them. The first version of this block shipped
+  # without the strip and run 31873627099 reported `rustdoc emitted no 'error:'
+  # diagnostic` for a build that failed on exactly such errors — the same class
+  # of misreport it was written to end, just one layer further in.
+  PLAIN="${SCRATCH}/rustdoc.plain"
+  sed $'s/\033\\[[0-9;]*[A-Za-z]//g' "${SCRATCH}/rustdoc.log" > "$PLAIN" || cp "${SCRATCH}/rustdoc.log" "$PLAIN"
   ERRORS="${SCRATCH}/rustdoc.errors"
   awk '/^error/ { blk = 1 } blk { print } /^$/ { blk = 0 }' \
-    "${SCRATCH}/rustdoc.log" > "$ERRORS" || true
+    "$PLAIN" > "$ERRORS" || true
   SAVED_LOG="${REPO_ROOT}/target/contracts-rustdoc-failure.log"
   mkdir -p "$(dirname "$SAVED_LOG")" 2>/dev/null || true
   cp "${SCRATCH}/rustdoc.log" "$SAVED_LOG" 2>/dev/null || SAVED_LOG=""
@@ -223,18 +232,26 @@ if ! SKIP_UI_BUILD=1 RUSTDOCFLAGS="-Z unstable-options --output-format json" \
       echo "            rustdoc emitted no 'error:' diagnostic, so this is a BUILD"
       echo "            failure rather than a documentation failure — a dependency's"
       echo "            build script or the toolchain itself."
-      if grep -qiE 'dbus|pkg-config|pkg_config' "${SCRATCH}/rustdoc.log"; then
+      # Name the missing library only on a REAL build-script failure. Matching
+      # `dbus` anywhere in the log fires on the ordinary `Compiling libdbus-sys`
+      # progress line, which is present on every successful run — run
+      # 31873627099 printed the whole install-libdbus remedy for a build that
+      # had libdbus installed and was failing on doc links. A remedy for a
+      # problem the developer does not have is worse than no remedy.
+      if grep -q 'failed to run custom build command' "$PLAIN" &&
+        grep -qiE 'libdbus|pkg-config|pkg_config' "$PLAIN"; then
         echo ""
-        echo "            The log names pkg-config/dbus. This crate's full feature set"
-        echo "            pulls in libdbus-sys, whose build.rs panics when the dbus"
-        echo "            headers are absent — the failure that took down this gate's"
-        echo "            first CI run (31858449749). Install them:"
+        echo "            A build script failed and the log names libdbus/pkg-config."
+        echo "            This crate's full feature set pulls in libdbus-sys, whose"
+        echo "            build.rs panics when the dbus headers are absent — the"
+        echo "            failure that took down this gate's first CI run"
+        echo "            (31858449749). Install them:"
         echo "              Debian/Ubuntu:  sudo apt-get install -y libdbus-1-dev"
         echo "              macOS:          brew install dbus pkg-config"
       fi
       echo ""
       echo "            Last 20 lines:"
-      tail -20 "${SCRATCH}/rustdoc.log" | sed 's/^/       /'
+      tail -20 "$PLAIN" | sed 's/^/       /'
     fi
     if [ -n "$SAVED_LOG" ]; then
       echo ""


### PR DESCRIPTION
Follow-up to #5751, which fixed the two doc links blocking
`scripts/check_contracts.sh` locally and added a diagnostic block to its NO
VERDICT path. Dispatched run
[31873627099](https://github.com/bobmatnyc/trusty-tools/actions/runs/31873627099)
showed that block getting the answer wrong on a runner.

It printed:

```
rustdoc emitted no 'error:' diagnostic, so this is a BUILD
failure rather than a documentation failure — a dependency's
build script or the toolchain itself.

The log names pkg-config/dbus. ... sudo apt-get install -y libdbus-1-dev
```

Both statements were false. The build failed on unresolved intra-doc links, and
libdbus was installed by the job's own step.

## Two defects

**ANSI.** CI sets `CARGO_TERM_COLOR: always`, so every diagnostic on a runner
arrives as `\033[1m\033[91merror\033[0m: ...`. The anchored `/^error/` matched
none of them, so a build failing on errors took the no-diagnostic branch. That
is the same class of misreport the block was written to end, one layer further
in. The log is now stripped of ANSI before anything matches it.

**Over-loose remedy.** The libdbus hint keyed on `dbus` appearing anywhere in
the log, which the ordinary `Compiling libdbus-sys` progress line satisfies on
every run, successful or not. It now requires an actual `failed to run custom
build command` alongside the libdbus/pkg-config mention.

## Verification

Reproduced the runner's condition on macOS — `CARGO_TERM_COLOR=always` with a
deliberately broken link:

```
NO VERDICT: the rustdoc JSON build failed, so no contract was read.
            This is NOT a pass.

            rustdoc reported 2 error(s):

       error: unresolved link to `assert_region`
          = note: no item named `assert_region` in scope
       note: the lint level is defined here
         --> crates/trusty-common/src/lib.rs:36:9
       36 | #![deny(rustdoc::broken_intra_doc_links)]
```

No dbus hint, correct branch, clean text.

| Gate | Result |
|---|---|
| `check_contracts.sh --crate trusty-common` | exit 0 — `15 contract(s) extracted, artifact matches source — OK.` |
| `check_contracts.sh` under `CARGO_TERM_COLOR=always`, link broken | exit 3, error blocks printed (above) |
| `check-ci-helpers-selftest.sh` | exit 0 |
| `check_line_cap.sh` | exit 0 |
| `check_sld.sh` | exit 0 |
| `check_changelog_fragment.sh` | exit 0 — `no crate source changed` |

Scripts-only change, so no changelog fragment is owed.

## What this does NOT fix

Gate 5 stays red on `main`, and Gate 1 with it, for a reason unrelated to this
diagnostic. Run 31873627099's Gate 1 reports:

```
SUMMARY  25 crate(s) documented, 26 broken link(s), baseline 0, 26 diagnostic(s) examined
FAIL  UNBASELINED  trusty-common has 6 broken link(s) and no baseline row
FAIL  UNBASELINED  trusty-installer has 14 broken link(s) and no baseline row
FAIL  UNBASELINED  trusty-memory has 1 broken link(s) and no baseline row
FAIL  UNBASELINED  trusty-mpm has 4 broken link(s) and no baseline row
FAIL  UNBASELINED  trusty-search has 1 broken link(s) and no baseline row
```

The same gate reports `0 broken link(s)` on macOS. #5744 drove the baseline to
zero against a macOS-only measurement, so 26 links that only break under Linux
`cfg` were never counted. The mechanism is direct: `crates/trusty-common/src/launchd.rs`
is `#![cfg(target_os = "macos")]`, and `launchd_labels.rs:42` — a module that is
deliberately not gated — links to `[`crate::launchd`]`, which does not exist on
Linux.

That is a separate piece of work across five crates, and it cannot be measured
on this machine: `cargo doc --target x86_64-unknown-linux-gnu` fails in `ring`'s
build script, so Linux CI is the only oracle for it.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
