### PR TITLE
fix(trusty-common): unbreak the six doc links that only fail on Linux

### DIFF
--- a/crates/trusty-common/changelog.d/5753-linux-only-broken-doc-links.md
+++ b/crates/trusty-common/changelog.d/5753-linux-only-broken-doc-links.md
@@ -1,0 +1,5 @@
+Fixed
+- Stopped six doc comments in non-gated code from linking to macOS-gated items
+  (`physical_footprint_mb`, `launchd`), which rustdoc could not resolve on
+  Linux. #5744 measured the link count on macOS only, so these never appeared
+  in its baseline and left the pre-publish contract gate red on `main`.

--- a/crates/trusty-common/src/launchd_labels.rs
+++ b/crates/trusty-common/src/launchd_labels.rs
@@ -39,7 +39,7 @@
 //! was never independent evidence of anything. Both are recorded as legacy
 //! aliases below.
 //!
-//! Deliberately NOT `#[cfg(target_os = "macos")]`, unlike [`crate::launchd`]:
+//! Deliberately NOT `#[cfg(target_os = "macos")]`, unlike `crate::launchd`:
 //! the registry is data, and gating it would stop the drift tests from running
 //! on Linux CI, which is where a divergent literal most needs to be caught.
 //!

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -196,8 +196,9 @@ pub mod launchd_activate;
 /// while launchd had `com.trusty.search` loaded, activating nothing.
 /// What: [`launchd_labels::SERVICES`] plus the `com.trusty.<stem>` convention
 /// as executable code, and the legacy aliases an upgrade must evict.
-/// Deliberately NOT macOS-gated, unlike [`launchd`], so the drift tests run on
-/// Linux CI too.
+/// Deliberately NOT macOS-gated, unlike `launchd`, so the drift tests run on
+/// Linux CI too. (`launchd` is named here, not linked: it does not exist on
+/// Linux, so a link to it breaks on the very platform this sentence is about.)
 /// Test: `cargo test -p trusty-common --features unconditional-only launchd_labels`.
 pub mod launchd_labels;
 

--- a/crates/trusty-common/src/sys_metrics.rs
+++ b/crates/trusty-common/src/sys_metrics.rs
@@ -79,10 +79,10 @@ pub fn physical_footprint_mb(pid: u32) -> Option<u64> {
 /// OOM-kill. trusty-search shipped an `rss_limit_mb` it never compared against
 /// anything and grew to 2.2x that limit before the OOM killer intervened; the
 /// missing piece was a way to read another process's RSS at all. This is that
-/// entry point, and it lives here — next to [`physical_footprint_mb`] and
+/// entry point, and it lives here — next to `physical_footprint_mb` and
 /// [`SysMetrics`] — so every trusty-* supervisor reads child memory the same
 /// way instead of each growing its own `/proc` parser.
-/// What: on macOS, delegates to [`physical_footprint_mb`], which counts pages
+/// What: on macOS, delegates to `physical_footprint_mb`, which counts pages
 /// the memory compressor holds (the figure the kernel's Jetsam logic uses). On
 /// Linux, reads `VmRSS` from `/proc/<pid>/status`. Everywhere else, returns
 /// `None`. `None` means "cannot measure", never "measured zero" — callers must
@@ -163,13 +163,13 @@ impl SysMetrics {
     ///      delta window shrinks; `/health` is typically polled every 2 s so
     ///      this is not a concern in practice. On macOS the reported RSS is
     ///      the true physical footprint (issue #2165) — see
-    ///      [`physical_footprint_mb`] — rather than the getrusage-style
+    ///      `physical_footprint_mb` — rather than the getrusage-style
     ///      resident size, which undercounts memory the compressor is
     ///      currently holding for this process.
     /// What: refreshes this process's memory + CPU stats. Returns RSS in
     ///      whole megabytes and CPU as a percentage where `100.0` means one
     ///      fully-saturated core (sysinfo's convention — a process on 4 cores
-    ///      can exceed 100). RSS: macOS uses [`physical_footprint_mb`],
+    ///      can exceed 100). RSS: macOS uses `physical_footprint_mb`,
     ///      falling back to `sysinfo`'s `bytes / 1_048_576` reading if the
     ///      `libproc` call fails; all other platforms use the `sysinfo`
     ///      reading directly (Linux's `/proc/self/status` `VmRSS` — which


### PR DESCRIPTION
Third and last part of unblocking `scripts/check_contracts.sh`, after #5751
(the two macOS-visible links) and #5752 (the gate's own misreport).

Gate 5 stayed red on `main` after both. With #5752's ANSI fix in place the gate
finally named the cause, in run
[31874824768](https://github.com/bobmatnyc/trusty-tools/actions/runs/31874824768):

```
rustdoc reported 7 error(s):
error: unresolved link to `physical_footprint_mb`
  --> crates/trusty-common/src/sys_metrics.rs:82:48
error: unresolved link to `physical_footprint_mb`
  --> crates/trusty-common/src/sys_metrics.rs:85:36
error: unresolved link to `physical_footprint_mb`
  --> crates/trusty-common/src/sys_metrics.rs:166:16
error: unresolved link to `physical_footprint_mb`
  --> crates/trusty-common/src/sys_metrics.rs:172:49
error: unresolved link to `launchd`
error: unresolved link to `crate::launchd`
  = note: no item named `launchd` in module `trusty_common`
```

That naming is itself the payoff from #5752 — the same job printed `rustdoc
emitted no 'error:' diagnostic` one run earlier.

## The cause

All six are doc comments in NON-gated code linking to macOS-gated items.
`physical_footprint_mb` is `#[cfg(target_os = "macos")]` (`sys_metrics.rs:50`);
the whole `launchd` module is `#![cfg(target_os = "macos")]`. On Linux the
targets do not exist, the links break, and
`#![deny(rustdoc::broken_intra_doc_links)]` fails the build the contract
extractor reads.

The two `launchd` sites are the sharpest case: both sit in sentences explaining
that `launchd_labels` is deliberately *not* macOS-gated so its drift tests run
on Linux CI — and the link breaks on exactly the platform the sentence is about.

Each becomes a plain code span. The reference reads the same; it stops claiming
to be a hyperlink that can only resolve on one platform.

## Why nobody saw it

#5744 drove the link baseline to zero against a macOS-only measurement.
`check_rustdoc_links.sh` reports `0 broken link(s)` on macOS and 26 on Linux for
the same tree — the gate is platform-sensitive and the baseline is not.

## Gates

Rung 3 — doc comments in one crate.

| Gate | Result |
|---|---|
| `check_contracts.sh --crate trusty-common` | exit 0 — `15 contract(s) extracted, artifact matches source — OK.` |
| `check_rustdoc_links.sh` (macOS) | exit 0 — `25 crate(s) documented, 0 broken link(s), baseline 0` |
| `cargo fmt --check` | exit 0 |
| `cargo clippy -p trusty-common --features docgen --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-common --features unconditional-only` | `test result: ok. 344 passed; 0 failed; 6 ignored` |
| `check_sld.sh` | exit 0 |
| `check_line_cap.sh` | exit 0 |

macOS cannot measure the Linux result: `cargo doc --target x86_64-unknown-linux-gnu`
fails in `ring`'s build script, so Linux CI is the only oracle. The fix is
correct by construction regardless — a plain code span resolves on every
platform because it resolves nowhere.

## Remaining

The other 20 Linux-only broken links still fail Gate 1: trusty-installer (14),
trusty-mpm (4), trusty-memory (1), trusty-search (1). Out of scope here — this
PR clears trusty-common's 6, which is what Gate 5 builds.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
