### PR TITLE
refactor(trusty-common): consolidate EnvVarGuard copies; add check_contracts selftest; wire trusty-audit into vmtest table

### DIFF
--- a/crates/trusty-common/changelog.d/3451-consolidate-env-var-guard.md
+++ b/crates/trusty-common/changelog.d/3451-consolidate-env-var-guard.md
@@ -1,0 +1,9 @@
+Changed
+- Consolidated the three independent `EnvVarGuard` test helpers
+  (`credentials::resolver`, `memory_core::dream`, `memory_core::semantic_consolidation`)
+  into one shared `credentials::env_guard::EnvVarGuard`. All three restored a
+  variable's prior value (or absence) identically on drop and relied on the
+  same external `#[serial(dotenv_credential_env)]` group; the only difference
+  was `semantic_consolidation`'s method being named `clear` instead of
+  `remove`, now unified. One implementation around the process-env mutation
+  race tracked in #3451, instead of three that could drift apart.

--- a/crates/trusty-common/src/credentials/env_guard.rs
+++ b/crates/trusty-common/src/credentials/env_guard.rs
@@ -1,0 +1,161 @@
+//! The ONE test-only RAII guard for mutating a process environment variable
+//! and restoring it on drop.
+//!
+//! Why (#3451): three independent copies of this exact guard accumulated —
+//! one in `credentials::resolver::tests`, one in
+//! `memory_core::dream::tests`, one in `memory_core::semantic_consolidation`'s
+//! test module — each protecting the same process-wide hazard (env vars are
+//! global state; the test harness runs tests in parallel threads within one
+//! binary, and `OPENROUTER_API_KEY` / the credential-provider vars are each
+//! read and written by tests in more than one of those three files). Three
+//! subtly different guards around one hazard is how the mutation race the
+//! guard exists to prevent stayed alive: a fourth copy, or a fix applied to
+//! only one of the three, was one accidental omission away. This module is
+//! the merge of all three call sites onto a single implementation.
+//!
+//! What: [`EnvVarGuard`] captures the variable's prior value on construction,
+//! applies the new value (or removes the variable) for the guard's lifetime,
+//! and reinstates the prior value — or removes the variable again if there
+//! was none — on [`Drop`]. It carries no lock of its own: every caller across
+//! all three call sites already joins the shared `#[serial(dotenv_credential_env)]`
+//! group (see `credentials::resolver::tests`, `memory_core::dream::tests`,
+//! and `memory_core::semantic_consolidation::tests`), which is what
+//! serialises access to the real process environment across test threads
+//! and across files. That external-lock contract is identical in all three
+//! prior copies, so merging them changes no caller's behavior.
+//!
+//! Test: exercised transitively by every test in the three modules listed
+//! above; `env_var_guard_restores_absent_as_absent` and
+//! `env_var_guard_restores_prior_value` pin the restore contract directly.
+
+/// RAII guard over one process-wide environment variable, for tests only.
+///
+/// Why/What: see the module docs.
+pub(crate) struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    /// Set `key` to `value` for the guard's lifetime, restoring the prior
+    /// value (or absence) on drop.
+    ///
+    /// The caller MUST already hold the `dotenv_credential_env` serial group
+    /// — see the module docs — for the whole window the guard is live.
+    pub(crate) fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        // SAFETY: every caller is `#[serial(dotenv_credential_env)]`, so no
+        // other thread reads or writes the environment concurrently.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+
+    /// Remove `key` for the guard's lifetime, restoring the prior value (or
+    /// absence) on drop.
+    ///
+    /// Why a test reaches for this instead of just assuming the variable is
+    /// unset: the ambient shell environment is not a fixture the test
+    /// controls (#4407) — a test asserting "behavior X holds when this var is
+    /// absent" must make it absent itself, not assume the machine happens to
+    /// agree.
+    pub(crate) fn remove(key: &'static str) -> Self {
+        let previous = std::env::var(key).ok();
+        // SAFETY: see `EnvVarGuard::set`.
+        unsafe { std::env::remove_var(key) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: see `EnvVarGuard::set`.
+        unsafe {
+            match self.previous.take() {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EnvVarGuard;
+    use serial_test::serial;
+
+    /// Why: the restore-on-drop contract must put back exactly what was
+    /// there before, not a default or an empty string.
+    /// What: sets a var with a known prior value, drops the guard, asserts
+    /// the prior value came back.
+    /// Test: this test.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn env_var_guard_restores_prior_value() {
+        const KEY: &str = "TRUSTY_COMMON_ENV_GUARD_TEST_PRIOR";
+        // SAFETY: `#[serial(dotenv_credential_env)]` above.
+        unsafe { std::env::set_var(KEY, "original") };
+
+        {
+            let _guard = EnvVarGuard::set(KEY, "overwritten");
+            assert_eq!(std::env::var(KEY).as_deref(), Ok("overwritten"));
+        }
+
+        assert_eq!(
+            std::env::var(KEY).as_deref(),
+            Ok("original"),
+            "drop must restore the exact prior value"
+        );
+        // SAFETY: `#[serial(dotenv_credential_env)]` above.
+        unsafe { std::env::remove_var(KEY) };
+    }
+
+    /// Why: a variable that was ABSENT before the guard must come back
+    /// absent, not present-with-some-value — the distinction the task
+    /// description calls out as potentially load-bearing.
+    /// What: ensures the var starts absent, applies a value through the
+    /// guard, drops it, asserts the var is absent again.
+    /// Test: this test.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn env_var_guard_restores_absent_as_absent() {
+        const KEY: &str = "TRUSTY_COMMON_ENV_GUARD_TEST_ABSENT";
+        // SAFETY: `#[serial(dotenv_credential_env)]` above.
+        unsafe { std::env::remove_var(KEY) };
+        assert!(std::env::var(KEY).is_err(), "precondition: var is absent");
+
+        {
+            let _guard = EnvVarGuard::set(KEY, "temporary");
+            assert_eq!(std::env::var(KEY).as_deref(), Ok("temporary"));
+        }
+
+        assert!(
+            std::env::var(KEY).is_err(),
+            "drop must restore absence, not leave an empty or stale value"
+        );
+    }
+
+    /// Why: `remove` is the other half of the contract — used when a test
+    /// needs the var unset for its body regardless of ambient state.
+    /// What: sets a prior value, uses `remove` to clear it for the guard's
+    /// lifetime, asserts it is absent while the guard lives and restored on
+    /// drop.
+    /// Test: this test.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn env_var_guard_remove_then_restores() {
+        const KEY: &str = "TRUSTY_COMMON_ENV_GUARD_TEST_REMOVE";
+        // SAFETY: `#[serial(dotenv_credential_env)]` above.
+        unsafe { std::env::set_var(KEY, "was-here") };
+
+        {
+            let _guard = EnvVarGuard::remove(KEY);
+            assert!(std::env::var(KEY).is_err(), "guard must clear the var");
+        }
+
+        assert_eq!(
+            std::env::var(KEY).as_deref(),
+            Ok("was-here"),
+            "drop must restore the value `remove` displaced"
+        );
+    }
+}

--- a/crates/trusty-common/src/credentials/mod.rs
+++ b/crates/trusty-common/src/credentials/mod.rs
@@ -63,6 +63,11 @@
 
 pub mod authority;
 mod dotenv;
+// #3451: the single shared test-only `EnvVarGuard`, consolidated from three
+// prior copies (this module's `resolver::tests`, `memory_core::dream::tests`,
+// and `memory_core::semantic_consolidation::tests`).
+#[cfg(test)]
+pub(crate) mod env_guard;
 mod error;
 mod file_store;
 mod handle;

--- a/crates/trusty-common/src/credentials/resolver.rs
+++ b/crates/trusty-common/src/credentials/resolver.rs
@@ -105,58 +105,8 @@ pub fn default_store() -> Box<dyn KeyStore> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::credentials::env_guard::EnvVarGuard;
     use serial_test::serial;
-
-    /// RAII guard over one process-wide credential environment variable.
-    ///
-    /// Why: these tests must drive `std::env` to exercise the env tier, but
-    /// the same process environment is where [`dotenv::load_env_local_once`]
-    /// deposits the developer's REAL credentials. A test that ended with a
-    /// bare `remove_var` therefore destroyed a real value for every test that
-    /// ran after it in the same binary, and a test that assumed a variable was
-    /// absent was reading machine state rather than a fixture it built. This
-    /// guard makes each test set what it needs and put back exactly what it
-    /// found, so no test depends on — or damages — ambient state (#3451).
-    /// What: captures the prior value on construction and restores it on drop,
-    /// removing the variable again when there was no prior value.
-    /// Test: used by every test in this module.
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        /// Set `key` to `value` for the guard's lifetime.
-        fn set(key: &'static str, value: &str) -> Self {
-            let previous = std::env::var(key).ok();
-            // SAFETY: every caller is `#[serial(dotenv_credential_env)]` — the
-            // group every test in this crate that reads or writes a credential
-            // env var joins — so no other test thread mutates the environment
-            // concurrently with this call.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, previous }
-        }
-
-        /// Remove `key` for the guard's lifetime.
-        fn remove(key: &'static str) -> Self {
-            let previous = std::env::var(key).ok();
-            // SAFETY: see `EnvVarGuard::set`.
-            unsafe { std::env::remove_var(key) };
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            // SAFETY: see `EnvVarGuard::set`.
-            unsafe {
-                match self.previous.take() {
-                    Some(v) => std::env::set_var(self.key, v),
-                    None => std::env::remove_var(self.key),
-                }
-            }
-        }
-    }
 
     /// Render a resolved credential for a failure message without disclosing it.
     ///

--- a/crates/trusty-common/src/memory_core/dream/tests.rs
+++ b/crates/trusty-common/src/memory_core/dream/tests.rs
@@ -1,6 +1,7 @@
 use super::guard::CompactionGuard;
 use super::helpers::{MERGED_CONTENT_CAP, char_safe_prefix, merge_into, now_secs};
 use super::*;
+use crate::credentials::env_guard::EnvVarGuard;
 use crate::memory_core::palace::{Palace, PalaceId, RoomType};
 use crate::memory_core::retrieval::{PalaceHandle, seed_shared_embedder_with_mock};
 use chrono::{Duration as ChronoDuration, Utc};
@@ -798,9 +799,10 @@ async fn dream_cycle_semantic_consolidation_skips_task_drawers() {
 #[tokio::test]
 // Audit finding (same class as #3607/#3608): `OPENROUTER_API_KEY` is also
 // mutated by `credentials::{resolver,dotenv}::tests` under
-// `#[serial(dotenv_credential_env)]`. This file's `EnvVarGuard` has no lock
-// of its own, so join that same serial group rather than relying on the
-// (false) assumption that this is the only mutator of the var.
+// `#[serial(dotenv_credential_env)]`. The shared `EnvVarGuard` (#3451,
+// `credentials::env_guard`) has no lock of its own, so join that same serial
+// group rather than relying on the (false) assumption that this is the only
+// mutator of the var.
 #[serial(dotenv_credential_env)]
 async fn dream_cycle_semantic_consolidation_no_inference() {
     // Ensure no env key is set for this test.
@@ -1779,43 +1781,6 @@ async fn apply_consolidation_result_keeps_original_when_kg_write_fails() {
         superseded_ids.is_empty(),
         "original must NOT be marked evictable when the superseded_by KG write failed"
     );
-}
-
-// ─── RAII env-var guard for tests ────────────────────────────────────────
-//
-// Safety: test-only; the tokio::test macro with default settings uses the
-// current-thread runtime so env-var mutation is single-threaded.
-
-struct EnvVarGuard {
-    key: &'static str,
-    previous: Option<String>,
-}
-
-impl EnvVarGuard {
-    fn remove(key: &'static str) -> Self {
-        let previous = std::env::var(key).ok();
-        // Safety: test-only; every caller is `#[serial(dotenv_credential_env)]`.
-        unsafe { std::env::remove_var(key) };
-        Self { key, previous }
-    }
-
-    /// Set `key` to `value` for the guard's lifetime.
-    fn set(key: &'static str, value: &str) -> Self {
-        let previous = std::env::var(key).ok();
-        // Safety: test-only; every caller is `#[serial(dotenv_credential_env)]`.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        // Safety: test-only; every caller is `#[serial(dotenv_credential_env)]`.
-        match &self.previous {
-            Some(v) => unsafe { std::env::set_var(self.key, v) },
-            None => unsafe { std::env::remove_var(self.key) },
-        }
-    }
 }
 
 /// Why: pins both halves of the reason [`dedup_only_config`] exists.

--- a/crates/trusty-common/src/memory_core/semantic_consolidation/mod.rs
+++ b/crates/trusty-common/src/memory_core/semantic_consolidation/mod.rs
@@ -28,6 +28,7 @@ pub use types::{
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::credentials::env_guard::EnvVarGuard;
     use crate::memory_core::palace::Drawer;
     use std::sync::Arc;
     use uuid::Uuid;
@@ -131,7 +132,7 @@ mod tests {
         // the very var this test just cleared, mid-assertion (the #3464
         // mechanism). Forcing it now makes the clear below the last word.
         crate::credentials::load_env_local_once();
-        let _guard = EnvVarGuard::clear("OPENROUTER_API_KEY");
+        let _guard = EnvVarGuard::remove("OPENROUTER_API_KEY");
         assert!(!inference_available("", false));
         assert!(!inference_available("   ", false));
     }
@@ -161,9 +162,10 @@ mod tests {
     /// process environment before picking a backend; `resolve_openrouter_api_key`
     /// must do the same so every caller (including
     /// `trusty-memory::dream_config_from_user_config`) agrees on the
-    /// resolved key. `#[serial(dotenv_credential_env)]` + a local
-    /// `EnvVarGuard` avoid racing other tests that read/write the same real
-    /// env var — the named group joins the SAME lock used by
+    /// resolved key. `#[serial(dotenv_credential_env)]` + the shared
+    /// `credentials::env_guard::EnvVarGuard` (#3451) avoid racing other tests
+    /// that read/write the same real env var — the named group joins the
+    /// SAME lock used by
     /// `credentials::{resolver,dotenv}::tests` and
     /// `memory_core::dream::tests` (audit finding, same class as
     /// #3607/#3608: a bare unnamed `#[serial]` here does NOT coordinate with
@@ -174,50 +176,6 @@ mod tests {
     fn resolve_openrouter_api_key_falls_back_to_env() {
         let _guard = EnvVarGuard::set("OPENROUTER_API_KEY", "sk-from-env");
         assert_eq!(resolve_openrouter_api_key(""), "sk-from-env");
-    }
-
-    // ─── RAII env-var guard for tests (mirrors
-    // trusty_common::memory_core::dream::tests::EnvVarGuard) ───────────────
-    //
-    // Safety: test-only; `#[serial_test::serial(dotenv_credential_env)]` on
-    // every caller serialises access to the real process environment across
-    // test threads (and across the other files sharing this named group).
-
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let previous = std::env::var(key).ok();
-            // Safety: test-only; caller is `#[serial]`.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, previous }
-        }
-
-        /// Remove `key` for the guard's lifetime, restoring it on drop (#4407).
-        ///
-        /// Why: a test asserting "behaviour X holds when this var is UNSET" must
-        /// make it unset, not assume the ambient shell left it that way — see
-        /// `inference_available_false_without_key`, which failed on any machine
-        /// with a real `OPENROUTER_API_KEY` exported.
-        fn clear(key: &'static str) -> Self {
-            let previous = std::env::var(key).ok();
-            // Safety: test-only; caller is `#[serial]`.
-            unsafe { std::env::remove_var(key) };
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            // Safety: test-only; caller is `#[serial]`.
-            match &self.previous {
-                Some(v) => unsafe { std::env::set_var(self.key, v) },
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
     }
 
     /// Why: `parse_consolidation_actions` must extract actions from raw JSON.

--- a/scripts/check_contracts_selftest.sh
+++ b/scripts/check_contracts_selftest.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+#
+# check_contracts_selftest.sh — mutation self-test for the behavioural gate
+# (scripts/check_contracts.sh, scripts/extract_contracts.py,
+# scripts/diff_contracts.py).
+#
+# Why: this gate exists because #5620 and #5723 each shipped a checker that
+#   reported success while it had verified nothing — a diff it never scanned,
+#   a comparison that ran zero checks. `check_contracts.sh` and its two Python
+#   helpers are written to fail closed instead: an unparseable contract, a
+#   walk that found nothing, an unrecognised rustdoc/artifact schema, or a
+#   comparison with no overlap all report NO VERDICT (exit 3), never a pass.
+#   That posture is only real if something re-proves it on every change — a
+#   later refactor that turns a `raise Unrecognised(...)` into `return None`
+#   would make the gate green again while checking nothing, exactly the shape
+#   of the two bugs above. This file is that proof, mirroring
+#   `check_semver_selftest.sh` and `check_semver_types_selftest.sh`.
+#
+# What: two groups of cases.
+#
+#   EXTRACTION (scripts/extract_contracts.py, driven directly — it is the
+#   piece `check_contracts.sh --crate` calls after building rustdoc JSON, and
+#   driving it directly means this file needs no nightly toolchain and no
+#   cargo build; see "Fixtures" below):
+#     1. a clean extraction — one valid `# Code Contract` block, exit 0.
+#     2. an unparseable contract block — free prose inside the block where
+#        only a section header, a claim, or a continuation is legal. Exit 3.
+#     3. zero contracts extracted — a valid document with no `# Code Contract`
+#        block anywhere. Exit 3 (an extractor that found nothing has not
+#        verified anything — #5620).
+#     4. an unknown rustdoc schema — `format_version` outside
+#        `extract_contracts.py`'s `SUPPORTED_FORMAT_VERSIONS`. Exit 3.
+#
+#   COMPARISON (`scripts/check_contracts.sh --diff`, the shell entry point —
+#   driven through the gate itself rather than calling diff_contracts.py
+#   directly, so this file also proves the shell wrapper's exit-code mapping,
+#   0/1/3, and not only the Python helper underneath it):
+#     5. a clean comparison — two artifacts with identical claims on the one
+#        item they share. Exit 0.
+#     6. drift detection — the same item, one claim reworded. Must be
+#        reported as one REMOVED claim and one ADDED claim. Exit 1.
+#     7. an unknown artifact version — `artifact_version` outside
+#        `diff_contracts.py`'s `SUPPORTED_ARTIFACT_VERSIONS`. Exit 3.
+#     8. zero common items — both artifacts are individually valid but name no
+#        item in common, so nothing was actually compared. Exit 3.
+#
+#   Every fail-closed case (2, 3, 4, 7, 8) asserts exit 3 SPECIFICALLY, not
+#   merely "nonzero" — case 6 (drift) is also nonzero (exit 1), and confusing
+#   "no verdict was computed" with "a verdict found a problem" is exactly the
+#   distinction this gate exists to keep visible to a caller (preflight-publish.sh
+#   CHECK-style scripts branch on the difference).
+#
+# Fixtures: scripts/test-data/contracts/, all hand-written and synthetic (see
+#   the README there). None is captured from a real `cargo +nightly rustdoc`
+#   build — deliberately, so this file stays independent of whether a live
+#   rustdoc build currently succeeds on this machine. That independence is not
+#   theoretical: as of this writing `check_contracts.sh --crate` returns NO
+#   VERDICT on `main` because the rustdoc JSON build itself fails for an
+#   unrelated reason (build-environment, not this gate's logic) — a live-build
+#   selftest would inherit that failure and prove nothing about the logic
+#   under test. `extract_contracts.py` and `diff_contracts.py`'s own
+#   fail-closed branches are pure Python over a JSON document, so fixtures
+#   exercise them completely without a build.
+#
+# Usage:  bash scripts/check_contracts_selftest.sh
+# Exit:   0 when every case behaves; 1 (naming the case) when one does not.
+#
+# Portability: bash 3.2 (macOS) and bash 5 (Linux CI). Needs python3, which
+# both helpers need anyway.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+GATE="${REPO_ROOT}/scripts/check_contracts.sh"
+EXTRACTOR="${REPO_ROOT}/scripts/extract_contracts.py"
+FIXTURES="${REPO_ROOT}/scripts/test-data/contracts"
+
+PASSED=0
+FAILED=0
+
+fail_case() {
+  echo "SELF-TEST FAIL: $1" >&2
+  shift
+  printf '%s\n' "$@" | sed 's/^/       /' >&2
+  FAILED=$((FAILED + 1))
+}
+
+pass_case() {
+  echo "  ok  $1"
+  PASSED=$((PASSED + 1))
+}
+
+for f in \
+  "${FIXTURES}/rustdoc-good.json" \
+  "${FIXTURES}/rustdoc-bad-contract.json" \
+  "${FIXTURES}/rustdoc-no-contracts.json" \
+  "${FIXTURES}/rustdoc-bad-schema.json" \
+  "${FIXTURES}/artifact-clean-a.json" \
+  "${FIXTURES}/artifact-clean-b.json" \
+  "${FIXTURES}/artifact-drift-a.json" \
+  "${FIXTURES}/artifact-drift-b.json" \
+  "${FIXTURES}/artifact-bad-version.json" \
+  "${FIXTURES}/artifact-empty-common-a.json" \
+  "${FIXTURES}/artifact-empty-common-b.json"; do
+  if [[ ! -f "$f" ]]; then
+    echo "SELF-TEST FAIL: fixture ${f} is missing; see ${FIXTURES}/README.md." >&2
+    exit 1
+  fi
+done
+
+# run_extractor <rustdoc.json> — capture combined output into $OUT, status
+# into $RC.
+OUT=""
+RC=0
+run_extractor() {
+  RC=0
+  OUT="$(python3 "$EXTRACTOR" "$1" demo 2>&1 1>/dev/null)" || RC=$?
+}
+
+# run_gate_diff <baseline.json> <current.json> — same, through the shell gate.
+run_gate_diff() {
+  RC=0
+  OUT="$(cd "$REPO_ROOT" && bash "$GATE" --diff "$1" "$2" 2>&1)" || RC=$?
+}
+
+# ===========================================================================
+# 1. A clean extraction: one valid `# Code Contract` block.
+# ===========================================================================
+run_extractor "${FIXTURES}/rustdoc-good.json"
+if [[ "$RC" -ne 0 ]]; then
+  fail_case "extraction/clean: expected exit 0, got ${RC}" "$OUT"
+elif [[ "$OUT" != *"extracted: 1 contract(s)"* ]]; then
+  fail_case "extraction/clean: exit 0 but did not report extracting 1 contract" "$OUT"
+else
+  pass_case "a valid Code Contract block is extracted (exit 0)"
+fi
+
+# ===========================================================================
+# 2. Unparseable contract block: free prose where only a header, a claim, or
+#    a continuation is legal.
+# ===========================================================================
+run_extractor "${FIXTURES}/rustdoc-bad-contract.json"
+if [[ "$RC" -eq 0 ]]; then
+  fail_case "extraction/unparseable: a malformed Code Contract block exited 0" "$OUT"
+elif [[ "$RC" -ne 3 ]]; then
+  fail_case "extraction/unparseable: expected exit 3 (NO VERDICT), got ${RC}" "$OUT"
+elif [[ "$OUT" != *"NO VERDICT"* ]]; then
+  fail_case "extraction/unparseable: exit 3 without saying NO VERDICT" "$OUT"
+elif [[ "$OUT" != *"neither a section header"* ]]; then
+  fail_case "extraction/unparseable: refused without naming the free-prose line, so it may be failing for an unrelated reason" "$OUT"
+else
+  pass_case "an unparseable Code Contract block is refused (exit 3)"
+fi
+
+# ===========================================================================
+# 3. Zero contracts extracted: a valid document, no # Code Contract block
+#    anywhere. "It found nothing" must not read as "nothing changed."
+# ===========================================================================
+run_extractor "${FIXTURES}/rustdoc-no-contracts.json"
+if [[ "$RC" -eq 0 ]]; then
+  fail_case "extraction/zero: a crate with no Code Contract blocks exited 0" "$OUT"
+elif [[ "$RC" -ne 3 ]]; then
+  fail_case "extraction/zero: expected exit 3 (NO VERDICT), got ${RC}" "$OUT"
+elif [[ "$OUT" != *"0 contracts were extracted"* ]]; then
+  fail_case "extraction/zero: exit 3 without saying 0 contracts were extracted" "$OUT"
+else
+  pass_case "zero contracts extracted is refused, not reported as clean (exit 3)"
+fi
+
+# ===========================================================================
+# 4. Unknown rustdoc schema: format_version outside SUPPORTED_FORMAT_VERSIONS.
+# ===========================================================================
+run_extractor "${FIXTURES}/rustdoc-bad-schema.json"
+if [[ "$RC" -eq 0 ]]; then
+  fail_case "extraction/bad-schema: an unrecognised format_version exited 0" "$OUT"
+elif [[ "$RC" -ne 3 ]]; then
+  fail_case "extraction/bad-schema: expected exit 3 (NO VERDICT), got ${RC}" "$OUT"
+elif [[ "$OUT" != *"format_version"* ]]; then
+  fail_case "extraction/bad-schema: refused without naming format_version, so it may be failing for an unrelated reason" "$OUT"
+else
+  pass_case "an unrecognised rustdoc format_version is refused (exit 3)"
+fi
+
+# ===========================================================================
+# 5. A clean comparison: identical claims on the one shared item.
+# ===========================================================================
+run_gate_diff "${FIXTURES}/artifact-clean-a.json" "${FIXTURES}/artifact-clean-b.json"
+if [[ "$RC" -ne 0 ]]; then
+  fail_case "comparison/clean: expected exit 0, got ${RC}" "$OUT"
+elif [[ "$OUT" != *"1 contracted item(s) in both; 0 claim change(s)"* ]]; then
+  fail_case "comparison/clean: exit 0 but did not report 1 item / 0 claim changes" "$OUT"
+else
+  pass_case "identical contracts on a shared item compare clean (exit 0)"
+fi
+
+# ===========================================================================
+# 6. Drift detection: the same item, one postcondition claim reworded.
+# ===========================================================================
+run_gate_diff "${FIXTURES}/artifact-drift-a.json" "${FIXTURES}/artifact-drift-b.json"
+if [[ "$RC" -eq 0 ]]; then
+  fail_case "comparison/drift: a reworded claim exited 0 — the change was not seen" "$OUT"
+elif [[ "$RC" -ne 1 ]]; then
+  fail_case "comparison/drift: expected exit 1 (DRIFT), got ${RC}" "$OUT"
+elif [[ "$OUT" != *"REMOVED function demo::f [postconditions]: returns x doubled"* ]]; then
+  fail_case "comparison/drift: the removed claim was not reported" "$OUT"
+elif [[ "$OUT" != *"ADDED   function demo::f [postconditions]: returns x squared"* ]]; then
+  fail_case "comparison/drift: the added claim was not reported" "$OUT"
+else
+  pass_case "a reworded claim is reported as REMOVED + ADDED (exit 1)"
+fi
+
+# ===========================================================================
+# 7. Unknown artifact version: artifact_version outside
+#    SUPPORTED_ARTIFACT_VERSIONS. Must be exit 3, distinct from drift's exit 1.
+# ===========================================================================
+run_gate_diff "${FIXTURES}/artifact-clean-a.json" "${FIXTURES}/artifact-bad-version.json"
+if [[ "$RC" -eq 0 ]]; then
+  fail_case "comparison/bad-version: an unrecognised artifact_version exited 0" "$OUT"
+elif [[ "$RC" -eq 1 ]]; then
+  fail_case "comparison/bad-version: exited 1 (DRIFT) — an unreadable artifact is NO VERDICT, not a computed drift" "$OUT"
+elif [[ "$RC" -ne 3 ]]; then
+  fail_case "comparison/bad-version: expected exit 3 (NO VERDICT), got ${RC}" "$OUT"
+elif [[ "$OUT" != *"artifact_version"* ]]; then
+  fail_case "comparison/bad-version: refused without naming artifact_version, so it may be failing for an unrelated reason" "$OUT"
+else
+  pass_case "an unrecognised artifact_version is refused (exit 3)"
+fi
+
+# ===========================================================================
+# 8. Zero common items: both artifacts individually valid, no item shared.
+#    "0 compared" must never print as a pass (#5620).
+# ===========================================================================
+run_gate_diff "${FIXTURES}/artifact-empty-common-a.json" "${FIXTURES}/artifact-empty-common-b.json"
+if [[ "$RC" -eq 0 ]]; then
+  fail_case "comparison/empty-common: 0 shared items exited 0 — nothing was compared and it reported clean" "$OUT"
+elif [[ "$RC" -eq 1 ]]; then
+  fail_case "comparison/empty-common: exited 1 (DRIFT) — there was nothing to compute a drift over" "$OUT"
+elif [[ "$RC" -ne 3 ]]; then
+  fail_case "comparison/empty-common: expected exit 3 (NO VERDICT), got ${RC}" "$OUT"
+elif [[ "$OUT" != *"0 contracted items are present in both artifacts"* ]]; then
+  fail_case "comparison/empty-common: refused without saying nothing was shared, so it may be failing for an unrelated reason" "$OUT"
+else
+  pass_case "two artifacts with no item in common are refused, not compared (exit 3)"
+fi
+
+echo
+if [[ "$FAILED" -ne 0 ]]; then
+  echo "check_contracts_selftest: ${PASSED} passed, ${FAILED} FAILED." >&2
+  exit 1
+fi
+echo "check_contracts_selftest: ${PASSED} passed, 0 failed."

--- a/scripts/test-data/contracts/README.md
+++ b/scripts/test-data/contracts/README.md
@@ -1,0 +1,51 @@
+# contracts fixtures
+
+Inputs for `scripts/check_contracts_selftest.sh`, which tests
+`scripts/extract_contracts.py`, `scripts/diff_contracts.py`, and the
+`--diff` mode of `scripts/check_contracts.sh` that wraps the latter.
+
+All fixtures here are **hand-written and synthetic** — none is captured from a
+real `cargo +nightly rustdoc` build. That is deliberate: `check_contracts.sh
+--crate` needs the nightly toolchain and currently fails to build rustdoc JSON
+on `main` for an unrelated reason (being fixed separately), and the
+extractor's and differ's own fail-closed logic is pure Python that does not
+need a real build to exercise. Driving the selftest off fixtures rather than a
+live build is what keeps it independent of that build's health.
+
+## rustdoc-JSON fixtures (`extract_contracts.py`)
+
+Each is a minimal document shaped like real rustdoc JSON — just enough for
+`scripts/lib/rustdoc_walk.py`'s loader and `SurfaceWalker` to accept it: a
+crate-root module (id `0`) containing one public function (id `1`).
+
+- `rustdoc-good.json` — the function's doc comment carries a valid
+  `# Code Contract` block (one precondition, one postcondition). Extracting it
+  must succeed with exactly 1 contract.
+- `rustdoc-bad-contract.json` — same shape, but the block contains a line that
+  is neither a section header, a `- ` claim, nor a continuation of one (free
+  prose). Must be a parse error — NO VERDICT, exit 3.
+- `rustdoc-no-contracts.json` — same shape, but the function's doc comment has
+  no `# Code Contract` heading at all. The walk succeeds and finds nothing to
+  extract — NO VERDICT, exit 3 (zero contracts is never a silent pass).
+- `rustdoc-bad-schema.json` — identical to `rustdoc-good.json` except
+  `format_version` is `999`, a value `extract_contracts.py`'s
+  `SUPPORTED_FORMAT_VERSIONS = (57, 61)` does not list. NO VERDICT, exit 3.
+
+## Contract-artifact fixtures (`diff_contracts.py`, `check_contracts.sh --diff`)
+
+Each is a minimal artifact in the shape `extract_contracts.py` writes:
+`{"artifact_version": 1, "crate": ..., "items": [...]}`.
+
+- `artifact-clean-a.json` / `artifact-clean-b.json` — byte-identical items.
+  Comparing them must find one item in common and zero claim changes — exit 0.
+- `artifact-drift-a.json` / `artifact-drift-b.json` — same item, one
+  postcondition claim reworded (`"returns x doubled"` ->
+  `"returns x squared"`). Must be reported as one REMOVED + one ADDED claim —
+  exit 1.
+- `artifact-bad-version.json` — `artifact_version: 2`, which
+  `diff_contracts.py`'s `SUPPORTED_ARTIFACT_VERSIONS = (1,)` does not list.
+  Paired against `artifact-clean-a.json`, must be NO VERDICT, exit 3.
+- `artifact-empty-common-a.json` / `artifact-empty-common-b.json` — valid,
+  `artifact_version: 1`, but name different items (`demo::f` vs `demo::g`), so
+  the two artifacts share no item. NO VERDICT, exit 3 — "0 compared" must
+  never print as a pass (#5620).

--- a/scripts/test-data/contracts/artifact-bad-version.json
+++ b/scripts/test-data/contracts/artifact-bad-version.json
@@ -1,0 +1,13 @@
+{
+  "artifact_version": 2,
+  "crate": "demo",
+  "items": [
+    {
+      "kind": "function",
+      "path": "demo::f",
+      "preconditions": ["x is positive"],
+      "postconditions": ["returns x doubled"],
+      "invariants": []
+    }
+  ]
+}

--- a/scripts/test-data/contracts/artifact-clean-a.json
+++ b/scripts/test-data/contracts/artifact-clean-a.json
@@ -1,0 +1,13 @@
+{
+  "artifact_version": 1,
+  "crate": "demo",
+  "items": [
+    {
+      "kind": "function",
+      "path": "demo::f",
+      "preconditions": ["x is positive"],
+      "postconditions": ["returns x doubled"],
+      "invariants": []
+    }
+  ]
+}

--- a/scripts/test-data/contracts/artifact-clean-b.json
+++ b/scripts/test-data/contracts/artifact-clean-b.json
@@ -1,0 +1,13 @@
+{
+  "artifact_version": 1,
+  "crate": "demo",
+  "items": [
+    {
+      "kind": "function",
+      "path": "demo::f",
+      "preconditions": ["x is positive"],
+      "postconditions": ["returns x doubled"],
+      "invariants": []
+    }
+  ]
+}

--- a/scripts/test-data/contracts/artifact-drift-a.json
+++ b/scripts/test-data/contracts/artifact-drift-a.json
@@ -1,0 +1,13 @@
+{
+  "artifact_version": 1,
+  "crate": "demo",
+  "items": [
+    {
+      "kind": "function",
+      "path": "demo::f",
+      "preconditions": ["x is positive"],
+      "postconditions": ["returns x doubled"],
+      "invariants": []
+    }
+  ]
+}

--- a/scripts/test-data/contracts/artifact-drift-b.json
+++ b/scripts/test-data/contracts/artifact-drift-b.json
@@ -1,0 +1,13 @@
+{
+  "artifact_version": 1,
+  "crate": "demo",
+  "items": [
+    {
+      "kind": "function",
+      "path": "demo::f",
+      "preconditions": ["x is positive"],
+      "postconditions": ["returns x squared"],
+      "invariants": []
+    }
+  ]
+}

--- a/scripts/test-data/contracts/artifact-empty-common-a.json
+++ b/scripts/test-data/contracts/artifact-empty-common-a.json
@@ -1,0 +1,13 @@
+{
+  "artifact_version": 1,
+  "crate": "demo",
+  "items": [
+    {
+      "kind": "function",
+      "path": "demo::f",
+      "preconditions": ["x is positive"],
+      "postconditions": [],
+      "invariants": []
+    }
+  ]
+}

--- a/scripts/test-data/contracts/artifact-empty-common-b.json
+++ b/scripts/test-data/contracts/artifact-empty-common-b.json
@@ -1,0 +1,13 @@
+{
+  "artifact_version": 1,
+  "crate": "demo",
+  "items": [
+    {
+      "kind": "function",
+      "path": "demo::g",
+      "preconditions": ["y is positive"],
+      "postconditions": [],
+      "invariants": []
+    }
+  ]
+}

--- a/scripts/test-data/contracts/rustdoc-bad-contract.json
+++ b/scripts/test-data/contracts/rustdoc-bad-contract.json
@@ -1,0 +1,29 @@
+{
+  "format_version": 57,
+  "root": 0,
+  "index": {
+    "0": {
+      "id": 0,
+      "crate_id": 0,
+      "name": "demo",
+      "visibility": "public",
+      "docs": null,
+      "inner": { "module": { "is_crate": true, "is_stripped": false, "items": [1] } }
+    },
+    "1": {
+      "id": 1,
+      "crate_id": 0,
+      "name": "f",
+      "visibility": "public",
+      "docs": "Why: fixture for check_contracts_selftest.sh.\nWhat: no-op.\nTest: none.\n\n# Code Contract\nPreconditions:\n- x is positive\nThis line breaks the grammar: it is neither a section header, a claim, nor a continuation.\n",
+      "inner": {
+        "function": {
+          "generics": { "params": [], "where_predicates": [] },
+          "has_body": true,
+          "header": { "abi": "Rust", "is_async": false, "is_const": false, "is_unsafe": false },
+          "sig": { "inputs": [], "is_c_variadic": false, "output": { "primitive": "u64" } }
+        }
+      }
+    }
+  }
+}

--- a/scripts/test-data/contracts/rustdoc-bad-schema.json
+++ b/scripts/test-data/contracts/rustdoc-bad-schema.json
@@ -1,0 +1,29 @@
+{
+  "format_version": 999,
+  "root": 0,
+  "index": {
+    "0": {
+      "id": 0,
+      "crate_id": 0,
+      "name": "demo",
+      "visibility": "public",
+      "docs": null,
+      "inner": { "module": { "is_crate": true, "is_stripped": false, "items": [1] } }
+    },
+    "1": {
+      "id": 1,
+      "crate_id": 0,
+      "name": "f",
+      "visibility": "public",
+      "docs": "Why: fixture for check_contracts_selftest.sh.\nWhat: no-op.\nTest: none.\n\n# Code Contract\nPreconditions:\n- x is positive\nPostconditions:\n- returns x doubled\n",
+      "inner": {
+        "function": {
+          "generics": { "params": [], "where_predicates": [] },
+          "has_body": true,
+          "header": { "abi": "Rust", "is_async": false, "is_const": false, "is_unsafe": false },
+          "sig": { "inputs": [], "is_c_variadic": false, "output": { "primitive": "u64" } }
+        }
+      }
+    }
+  }
+}

--- a/scripts/test-data/contracts/rustdoc-good.json
+++ b/scripts/test-data/contracts/rustdoc-good.json
@@ -1,0 +1,29 @@
+{
+  "format_version": 57,
+  "root": 0,
+  "index": {
+    "0": {
+      "id": 0,
+      "crate_id": 0,
+      "name": "demo",
+      "visibility": "public",
+      "docs": null,
+      "inner": { "module": { "is_crate": true, "is_stripped": false, "items": [1] } }
+    },
+    "1": {
+      "id": 1,
+      "crate_id": 0,
+      "name": "f",
+      "visibility": "public",
+      "docs": "Why: fixture for check_contracts_selftest.sh.\nWhat: no-op.\nTest: none.\n\n# Code Contract\nPreconditions:\n- x is positive\nPostconditions:\n- returns x doubled\n",
+      "inner": {
+        "function": {
+          "generics": { "params": [], "where_predicates": [] },
+          "has_body": true,
+          "header": { "abi": "Rust", "is_async": false, "is_const": false, "is_unsafe": false },
+          "sig": { "inputs": [], "is_c_variadic": false, "output": { "primitive": "u64" } }
+        }
+      }
+    }
+  }
+}

--- a/scripts/test-data/contracts/rustdoc-no-contracts.json
+++ b/scripts/test-data/contracts/rustdoc-no-contracts.json
@@ -1,0 +1,29 @@
+{
+  "format_version": 57,
+  "root": 0,
+  "index": {
+    "0": {
+      "id": 0,
+      "crate_id": 0,
+      "name": "demo",
+      "visibility": "public",
+      "docs": null,
+      "inner": { "module": { "is_crate": true, "is_stripped": false, "items": [1] } }
+    },
+    "1": {
+      "id": 1,
+      "crate_id": 0,
+      "name": "f",
+      "visibility": "public",
+      "docs": "Why: fixture for check_contracts_selftest.sh.\nWhat: no-op.\nTest: none.\n",
+      "inner": {
+        "function": {
+          "generics": { "params": [], "where_predicates": [] },
+          "has_body": true,
+          "header": { "abi": "Rust", "is_async": false, "is_const": false, "is_unsafe": false },
+          "sig": { "inputs": [], "is_c_variadic": false, "output": { "primitive": "u64" } }
+        }
+      }
+    }
+  }
+}

--- a/vmtest-harness/expected-binaries.tsv
+++ b/vmtest-harness/expected-binaries.tsv
@@ -16,6 +16,8 @@ trusty-console	trusty-console	trusty-console	src/main.rs	-	yes	present	present	p
 trusty-agents	trusty-agents	tagent	src/main.rs	-	no	-	-	-
 trusty-agents-ui	trusty-agents/ui/src-tauri	trusty-agents-ui	src/main.rs	-	no	-	-	-
 trusty-agents-local	trusty-agents-local	trusty-agents-local	src/main.rs	-	no	-	-	-
+trusty-audit	trusty-audit	trusty-audit	src/main.rs	-	no	-	-	-
+trusty-audit	trusty-audit	taudit	src/main.rs	-	no	-	-	-
 trusty-channels	trusty-channels	slack-mcp	src/bin/slack-mcp.rs	-	no	-	-	-
 trusty-channels	trusty-channels	telegram-mcp	src/bin/telegram-mcp.rs	-	no	-	-	-
 trusty-code-gui	trusty-code-gui	trusty-code-gui	src/main.rs	-	no	-	-	-


### PR DESCRIPTION
## Summary
- Consolidated three independent `EnvVarGuard` test helpers (`credentials::resolver`, `memory_core::dream`, `memory_core::semantic_consolidation`) into one `credentials::env_guard::EnvVarGuard`. All three restored a variable's prior value (or absence) identically on drop and shared the same external `#[serial(dotenv_credential_env)]` synchronization; the only difference was a method name (`clear` vs `remove`), now unified as `remove`. Addresses the drift risk around the process-env race tracked in #3451.
- Added `scripts/check_contracts_selftest.sh` (rung: new test-only script, mirrors `check_semver_selftest.sh` / `check_semver_types_selftest.sh`): a clean comparison, a drift detection, and every fail-closed branch (unparseable contract block, zero contracts extracted, unknown rustdoc schema, unknown artifact version, zero common items) — each fail-closed case asserts exit 3 specifically. Driven entirely by hand-written fixtures under `scripts/test-data/contracts/`, so it does not depend on the (separately being fixed) rustdoc-JSON build failure on `main`.
- `vmtest --check-table` reported `trusty-audit`'s `taudit` and `trusty-audit` binaries absent from `vmtest-harness/expected-binaries.tsv`. Per DOC-1 D3 (the harness's nine in-scope crates), and `trusty-audit` declaring `publish = false`, both binaries are added as `in_scope=no` rows in the existing out-of-scope section — not a D3 widening.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p trusty-common --all-targets --features memory-core,embedder-test-support -- -D warnings`
- [x] `cargo test -p trusty-common --features memory-core,embedder-test-support` — 1066 passed, 0 failed
- [x] The consolidated guard's tests (`credentials::`, `memory_core::dream::`, `memory_core::semantic_consolidation::`) re-run 10x to check for intermittency — all 10 runs green
- [x] `SKIP_UI_BUILD=1 cargo check --workspace`
- [x] `bash scripts/check_contracts_selftest.sh` (new) — 8/8 cases pass
- [x] `bash scripts/check_semver_selftest.sh`, `check_semver_types_selftest.sh`, `check-ci-helpers-selftest.sh` (135 cases)
- [x] `bash scripts/check_line_cap.sh`, `check_sld.sh`, `check_rustdoc_links.sh` (0 broken, baseline 0), `check_changelog_fragment.sh`
- [x] `bash vmtest-harness/vmtest --check-table` — clean, no ADDED/REMOVED/CHANGED findings

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools