### PR TITLE
fix(trusty-review): reject a metrics artifact from an unknown schema major

### DIFF
--- a/crates/trusty-review/changelog.d/5747-metrics-schema-version.md
+++ b/crates/trusty-review/changelog.d/5747-metrics-schema-version.md
@@ -1,0 +1,16 @@
+Fixed
+
+- A declared metrics JSON whose `schema_version` names a major this build does
+  not read now fails the run by name instead of loading. Every field of the
+  metrics schema defaults, so a renamed key rendered as a stated zero — a
+  confident wrong LoC total, file count, or complexity distribution in a
+  client-facing due-diligence report — while only syntactically broken JSON
+  errored. A newer minor of a known major still loads, and a tag that resolves
+  to no major at all is refused rather than assumed to be v0.
+- A metrics JSON carrying no `schema_version` still loads, read as v0. Nothing
+  in this workspace writes that artifact — `tga audit` omits the manifest's
+  `metrics` key so the live `--analyze` fetch is not blocked — so the file is
+  hand-authored against a field this crate documented as informational, and v0
+  is the only schema it has ever had. This is where the metrics loader diverges
+  from the ticketing loader, which refuses an untagged artifact because every
+  producer of that one writes the tag.

--- a/crates/trusty-review/src/report/error.rs
+++ b/crates/trusty-review/src/report/error.rs
@@ -125,6 +125,35 @@ pub enum ReportError {
         source: serde_json::Error,
     },
 
+    /// A metrics JSON parsed, but declares a schema major this build does not
+    /// read (#5747).
+    ///
+    /// Why: the producer of the artifact and this reader are separate binaries,
+    /// and every field of [`super::metrics::AnalyzeMetrics`] carries
+    /// `#[serde(default)]`. A renamed key in a later schema therefore parses to
+    /// zero and renders `0 lines of code` or an empty complexity distribution as
+    /// a stated fact in a client-facing due-diligence report. Refusing a major
+    /// this build cannot read routes that the same way an unparseable artifact
+    /// goes: a hard, named failure.
+    /// What: distinct from [`ReportError::Metrics`] because the remedy differs —
+    /// that one is a malformed file, this one is a version mismatch the operator
+    /// resolves by aligning the producer with this build. An artifact carrying
+    /// no `schema_version` at all never reaches this variant; see
+    /// [`super::metrics::load_metrics`] for why absent means v0 here and is a
+    /// refusal for the ticketing artifact.
+    #[error(
+        "metrics artifact at {path} declares schema_version {found:?}, which this build cannot \
+         read; it reads schema major {supported}"
+    )]
+    MetricsSchema {
+        /// The metrics artifact whose schema tag was refused.
+        path: PathBuf,
+        /// The `schema_version` the artifact declared; never empty.
+        found: String,
+        /// The schema major this build reads.
+        supported: u32,
+    },
+
     /// A declared ticketing artifact exists but could not be parsed (#5405).
     ///
     /// Why: the manifest declared the file, so an unreadable one is a producer

--- a/crates/trusty-review/src/report/metrics.rs
+++ b/crates/trusty-review/src/report/metrics.rs
@@ -7,9 +7,11 @@
 //! still parses and unmapped template fields fall through to honesty markers.
 //! What: defines [`AnalyzeMetrics`] (LoC totals + per-language breakdown, file /
 //! function counts, complexity distribution buckets, and a top-findings list
-//! with severity) and [`load_metrics`] which parses the JSON from disk.
-//! Test: `metrics.rs` tests cover a full parse, a minimal `{}` parse, and the
-//! derived helpers (`primary_languages`, `total_loc`).
+//! with severity) and [`load_metrics`] which parses the JSON from disk and
+//! refuses a schema major this build does not read (#5747).
+//! Test: `metrics.rs` tests cover a full parse, a minimal `{}` parse, the
+//! derived helpers (`primary_languages`, `total_loc`), and the schema-major
+//! refusal.
 
 use std::path::Path;
 
@@ -27,7 +29,12 @@ use super::error::ReportError;
 /// Test: `metrics.rs::parse_full_metrics`, `parse_minimal_metrics`.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct AnalyzeMetrics {
-    /// Schema version tag (informational; defaults to empty).
+    /// Schema version tag, e.g. `v0`; empty when the artifact declared none.
+    ///
+    /// #5747: no longer informational — [`load_metrics`] refuses a tag whose
+    /// major it does not read. Empty still loads, because nothing in this
+    /// workspace writes the artifact and the field shipped documented as
+    /// informational.
     #[serde(default)]
     pub schema_version: String,
     /// Repository identifier the metrics describe (informational).
@@ -189,22 +196,68 @@ impl AnalyzeMetrics {
     }
 }
 
+/// The artifact schema major this build reads (#5747).
+///
+/// Why: the file is written by a process this one does not ship with, so the
+/// loader must be able to say "not mine" about a file it can nonetheless
+/// deserialize.
+/// What: `0`, matching the `v0` tag the schema has carried since #2317.
+const SUPPORTED_SCHEMA_MAJOR: u32 = 0;
+
 /// Load and parse a v0 metrics JSON file from disk.
 ///
 /// Why: the report pipeline reads one metrics file per repository when the
 /// manifest declares a `metrics` path; a dedicated loader gives typed errors.
-/// What: reads `path`, parses against [`AnalyzeMetrics`]; I/O and parse errors
-/// map to [`ReportError`].
-/// Test: `metrics.rs::load_roundtrip` writes a temp file and reads it back.
+/// #5747 extends that to a file that reads but is not this schema: every field
+/// defaults, so a renamed key in a later producer's output would otherwise
+/// render as a stated zero in a client-facing due-diligence report.
+/// What: reads `path`, parses against [`AnalyzeMetrics`], then refuses a
+/// declared tag whose [`super::schema::major`] is not
+/// [`SUPPORTED_SCHEMA_MAJOR`]. A newer MINOR of that major loads — the
+/// added-field case `#[serde(default)]` exists for.
+///
+/// An ABSENT tag is read as v0 rather than refused, which is where this
+/// diverges from [`super::ticketing::load_ticketing`]. Nothing in this
+/// workspace writes a metrics artifact — DOC-67 §7 has `tga audit` omit
+/// `RepositoryEntry.metrics` so the live `--analyze` fetch is not blocked — so
+/// the file is hand-authored against a field documented as informational since
+/// #2317. An untagged file is an author who read that documentation, and v0 is
+/// the only schema this artifact has ever had. Refusing one would break working
+/// setups to guard against a rename that cannot have happened yet.
+///
+/// Test: `metrics.rs::{load_roundtrip,
+/// an_artifact_from_an_unknown_schema_major_is_a_named_error,
+/// an_artifact_with_an_uninterpretable_schema_tag_is_a_named_error,
+/// an_artifact_with_a_newer_minor_of_a_known_major_still_parses,
+/// an_untagged_artifact_is_read_as_v0}`.
+///
+/// # Errors
+///
+/// [`ReportError::Io`] when the file cannot be read,
+/// [`ReportError::Metrics`] when it does not parse, and
+/// [`ReportError::MetricsSchema`] when it declares an unreadable major.
 pub fn load_metrics(path: &Path) -> std::result::Result<AnalyzeMetrics, ReportError> {
     let text = std::fs::read_to_string(path).map_err(|source| ReportError::Io {
         path: path.to_path_buf(),
         source,
     })?;
-    serde_json::from_str(&text).map_err(|source| ReportError::Metrics {
-        path: path.to_path_buf(),
-        source,
-    })
+    let metrics: AnalyzeMetrics =
+        serde_json::from_str(&text).map_err(|source| ReportError::Metrics {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    // #5747: a declared tag must name a major this build reads; an absent one
+    // predates the tag and is v0. See the doc comment for why they differ.
+    let declared = metrics.schema_version.trim();
+    if !declared.is_empty() && super::schema::major(declared) != Some(SUPPORTED_SCHEMA_MAJOR) {
+        return Err(ReportError::MetricsSchema {
+            path: path.to_path_buf(),
+            found: metrics.schema_version,
+            supported: SUPPORTED_SCHEMA_MAJOR,
+        });
+    }
+    Ok(metrics)
 }
 
 #[cfg(test)]

--- a/crates/trusty-review/src/report/metrics_tests.rs
+++ b/crates/trusty-review/src/report/metrics_tests.rs
@@ -74,3 +74,81 @@ fn load_roundtrip() {
     let m = load_metrics(&path).expect("load ok");
     assert_eq!(m.repository, "acme-web");
 }
+
+/// Write `body` to a fresh `metrics.json` and hand back the tempdir plus path.
+///
+/// The tempdir is returned because dropping it deletes the file.
+fn artifact(body: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("metrics.json");
+    std::fs::write(&path, body).expect("write");
+    (tmp, path)
+}
+
+/// #5747: the producer of this artifact and its reader are separate binaries, so
+/// a tag naming a major this build cannot read must fail the way an unparseable
+/// file does. Every field carries `#[serde(default)]`, so a renamed key
+/// otherwise parses to zero and renders `0 lines of code` as a stated fact in a
+/// document an acquirer prices a deal from.
+#[test]
+fn an_artifact_from_an_unknown_schema_major_is_a_named_error() {
+    // Well-formed JSON; `total` renamed the way a v9 producer might have.
+    let (_tmp, path) = artifact(
+        r#"{"schema_version": "v9", "repository": "acme-web",
+             "loc": {"total_lines": 1200}}"#,
+    );
+
+    let err = load_metrics(&path).expect_err("must refuse a major this build cannot read");
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("metrics.json") && rendered.contains("schema_version"),
+        "the error must name the artifact and the version mismatch: {rendered}"
+    );
+    assert!(
+        rendered.contains("v9"),
+        "the error must quote the version it refused: {rendered}"
+    );
+}
+
+/// A tag this build cannot resolve to a major at all is refused for the same
+/// reason a wrong major is: the loader cannot claim the file is v0, and
+/// assuming it is renders whatever `#[serde(default)]` produced.
+#[test]
+fn an_artifact_with_an_uninterpretable_schema_tag_is_a_named_error() {
+    let (_tmp, path) = artifact(r#"{"schema_version": "analyze-2027", "counts": {"files": 42}}"#);
+
+    let err = load_metrics(&path).expect_err("must refuse a tag it cannot resolve to a major");
+    assert!(
+        err.to_string().contains("analyze-2027"),
+        "the error must quote the tag it refused: {err}"
+    );
+}
+
+/// A newer MINOR of a known major still loads — that is exactly the added-field
+/// case every field's `#[serde(default)]` exists for. Refusing it would make an
+/// additive producer change require a coordinated release of both binaries.
+#[test]
+fn an_artifact_with_a_newer_minor_of_a_known_major_still_parses() {
+    let (_tmp, path) = artifact(
+        r#"{"schema_version": "v0.3", "repository": "acme-web",
+             "counts": {"files": 42, "functions": 310}, "future_key": true}"#,
+    );
+
+    let m = load_metrics(&path).expect("a newer minor of a known major must load");
+    assert_eq!(m.repository, "acme-web");
+    assert_eq!(m.counts.files, 42);
+}
+
+/// #5747: unlike the ticketing artifact, nothing in this workspace writes a
+/// metrics JSON — DOC-67 §7 has `tga audit` omit `RepositoryEntry.metrics`
+/// outright, and the field has been documented as "informational" since #2317.
+/// An untagged file is therefore an author who followed the documentation, not
+/// a truncated one, and v0 is the only schema this artifact has ever had.
+#[test]
+fn an_untagged_artifact_is_read_as_v0() {
+    let (_tmp, path) = artifact(r#"{"repository": "acme-web", "loc": {"total": 1200}}"#);
+
+    let m = load_metrics(&path).expect("an untagged artifact predates the tag and must still load");
+    assert_eq!(m.repository, "acme-web");
+    assert_eq!(m.loc.total, 1200);
+}

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -33,6 +33,8 @@ pub mod reporter_fill;
 pub mod reporter_findings;
 pub mod reporter_graph_datasets;
 pub mod scan;
+// #5747: the schema-tag parse both artifact loaders decide compatibility from.
+pub(crate) mod schema;
 pub mod section_instructions;
 pub mod synthesize;
 pub mod synthesize_digest;

--- a/crates/trusty-review/src/report/redact_tests.rs
+++ b/crates/trusty-review/src/report/redact_tests.rs
@@ -67,7 +67,12 @@ fn leaky_finding() -> MetricFinding {
 
 fn leaky_metrics() -> AnalyzeMetrics {
     AnalyzeMetrics {
-        schema_version: "analyze-live-v0".to_string(),
+        // #5747: `declared_metrics_file_findings_are_scrubbed` writes this
+        // struct out as a declared metrics FILE, and `load_metrics` now refuses
+        // a tag whose major it cannot read. `analyze-live-v0` is the live HTTP
+        // path's in-memory tag, which never reaches a file; `v0` is what a
+        // declared artifact carries.
+        schema_version: "v0".to_string(),
         repository: format!("repo-{FAKE_TOKEN}"),
         loc: LocMetrics {
             total: 10,

--- a/crates/trusty-review/src/report/schema.rs
+++ b/crates/trusty-review/src/report/schema.rs
@@ -1,0 +1,46 @@
+//! Schema-tag parsing shared by the report's artifact loaders (#5747).
+//!
+//! Why: `report/ticketing.rs` and `report/metrics.rs` both read a JSON artifact
+//! written by a separately versioned, separately installed producer, and both
+//! must decide from a `schema_version` string whether this build can read the
+//! file at all. #5405 added that check to the ticketing loader with a private
+//! `schema_major`; #5747 needs the identical parse for metrics, and a second
+//! independent copy of a rule about cross-process compatibility is exactly the
+//! kind of silent drift the common-entry-point convention exists to prevent.
+//!
+//! What: [`major`], the one parse both loaders call.
+//!
+//! ## What this deliberately does not own
+//!
+//! The POLICY stays with each loader, because the two artifacts differ on it.
+//! Both supply their own supported-major constant, and each decides for itself
+//! what an absent tag means — ticketing refuses one (every producer writes the
+//! tag), metrics accepts one as v0 (no producer in this workspace writes the
+//! artifact at all, and the field shipped documented as informational). Folding
+//! that decision in here would force one artifact's history onto the other.
+//!
+//! Test: `super::schema_tests`.
+
+/// The major component of a schema tag, if it has one.
+///
+/// Why: the tag is a document the producer wrote, not a number, so a loader
+/// reads only what it needs to decide compatibility — a `v0.3` written by a
+/// later producer must resolve to the same major as `v0`, or every additive
+/// change to the artifact would require a coordinated release of both binaries.
+/// What: strips a leading `v`, takes everything up to the first `.`, `-`, or
+/// `+`, and parses it. `None` for an empty, absent, or non-numeric tag — the
+/// caller decides whether that is fatal.
+/// Test: `super::schema_tests::{plain_and_v_prefixed_majors_parse,
+/// a_newer_minor_resolves_to_its_major, an_uninterpretable_tag_has_no_major}`.
+pub(crate) fn major(tag: &str) -> Option<u32> {
+    tag.strip_prefix('v')
+        .unwrap_or(tag)
+        .split(['.', '-', '+'])
+        .next()?
+        .parse()
+        .ok()
+}
+
+#[cfg(test)]
+#[path = "schema_tests.rs"]
+mod schema_tests;

--- a/crates/trusty-review/src/report/schema_tests.rs
+++ b/crates/trusty-review/src/report/schema_tests.rs
@@ -1,0 +1,40 @@
+//! Tests for the shared schema-tag parse (#5747).
+//!
+//! Why: both artifact loaders decide cross-process compatibility from this one
+//! function, so its edge cases are worth pinning in one place rather than
+//! re-deriving them from each loader's behaviour.
+//! What: covers the tag spellings the two producers write and the shapes that
+//! resolve to no major at all.
+//! Test: included as `#[cfg(test)] mod schema_tests` from `schema.rs`.
+
+use super::major;
+
+#[test]
+fn plain_and_v_prefixed_majors_parse() {
+    assert_eq!(major("v0"), Some(0));
+    assert_eq!(major("0"), Some(0));
+    assert_eq!(major("v9"), Some(9));
+    assert_eq!(major("12"), Some(12));
+}
+
+/// A later producer's added field arrives as a bumped MINOR. It must resolve to
+/// the major this build already reads, or `#[serde(default)]` buys nothing.
+#[test]
+fn a_newer_minor_resolves_to_its_major() {
+    assert_eq!(major("v0.3"), Some(0));
+    assert_eq!(major("0.3.1"), Some(0));
+    assert_eq!(major("v0-rc1"), Some(0));
+    assert_eq!(major("v0+build7"), Some(0));
+}
+
+/// `analyze-live-v0` is a real tag this crate writes for the in-memory live
+/// path, and it resolves to no major — which is why a loader that meets it in a
+/// file must refuse rather than assume.
+#[test]
+fn an_uninterpretable_tag_has_no_major() {
+    assert_eq!(major(""), None);
+    assert_eq!(major("v"), None);
+    assert_eq!(major("analyze-live-v0"), None);
+    assert_eq!(major("analyze-2027"), None);
+    assert_eq!(major("corpus-v9"), None);
+}

--- a/crates/trusty-review/src/report/ticketing.rs
+++ b/crates/trusty-review/src/report/ticketing.rs
@@ -106,24 +106,6 @@ impl TicketingSummary {
     }
 }
 
-/// The major component of a schema tag, if it has one.
-///
-/// Why: the tag is a document the producer wrote, not a number, so the loader
-/// reads only what it needs to decide compatibility — a `v0.3` written by a
-/// later tga must resolve to the same major as `v0`.
-/// What: strips a leading `v`, takes everything up to the first separator, and
-/// parses it. `None` for an empty, absent, or non-numeric tag.
-/// Test: `super::ticketing_tests::{an_artifact_with_a_newer_minor_of_a_known_major_still_parses,
-/// an_artifact_with_no_schema_version_is_a_named_error}`.
-fn schema_major(tag: &str) -> Option<u32> {
-    tag.strip_prefix('v')
-        .unwrap_or(tag)
-        .split(['.', '-', '+'])
-        .next()?
-        .parse()
-        .ok()
-}
-
 /// Load and parse a ticketing artifact from disk.
 ///
 /// Why: mirrors [`super::metrics::load_metrics`] — a declared file that cannot
@@ -134,9 +116,10 @@ fn schema_major(tag: &str) -> Option<u32> {
 /// not an edge case, so the check is on the load path rather than left to the
 /// caller.
 /// What: reads `path`, parses it against [`TicketingSummary`], then refuses any
-/// [`schema_major`] other than [`SUPPORTED_SCHEMA_MAJOR`]. A newer MINOR of a
-/// known major loads — that is the added-field case `#[serde(default)]` exists
-/// for.
+/// [`super::schema::major`] other than [`SUPPORTED_SCHEMA_MAJOR`] — including
+/// an absent tag, since every tga that writes this artifact writes one. A newer
+/// MINOR of a known major loads: that is the added-field case
+/// `#[serde(default)]` exists for.
 /// Test: `super::ticketing_tests::{parses_the_artifact_tga_writes,
 /// a_malformed_artifact_is_a_named_error,
 /// an_artifact_from_an_unknown_schema_major_is_a_named_error}`.
@@ -157,7 +140,8 @@ pub fn load_ticketing(path: &Path) -> std::result::Result<TicketingSummary, Repo
             source,
         })?;
 
-    if schema_major(&summary.schema_version) != Some(SUPPORTED_SCHEMA_MAJOR) {
+    // #5747: the parse now lives in `report::schema`, shared with `load_metrics`.
+    if super::schema::major(&summary.schema_version) != Some(SUPPORTED_SCHEMA_MAJOR) {
         return Err(ReportError::TicketingSchema {
             path: path.to_path_buf(),
             found: summary.schema_version,


### PR DESCRIPTION
Closes #5747

`AnalyzeMetrics.schema_version` was written, round-tripped and swept for leaks — but `load_metrics` never compared it against anything. With `#[serde(default)]` on every field, an artifact from a producer this build cannot read parses clean, its fields take their zero defaults, and a wrong number reaches a client-facing report. Only syntactically-broken JSON errored; valid-but-drifted JSON degraded silently.

The test that proves it: an artifact tagged `v9` yielded `loc.total: 0`.

## The absent-tag decision is the opposite of the sibling loader's, deliberately

#5745 fixed the same shape in `report/ticketing.rs` and made a MISSING `schema_version` an error. That was right there — tga writes `ticketing.json`, and every tga that writes it writes the tag, so an untagged file was not written by a recognised producer.

It is wrong here, and the evidence is that **nothing in this workspace writes a metrics artifact at all**. `DdRepositoryEntry` carries `name` and `path` only, DOC-67 §5 states AUDIT relies on live `--analyze` enrichment and "never a hand-authored metrics JSON", and the field shipped in #2317 documented as informational. The producer is a human authoring a manifest, or an external tool. An untagged file is an author who read the docs, and v0 is the only schema this artifact has ever had.

So: **absent reads as v0 and loads. Anything that declares a version and cannot be read errors** — a wrong major (`v9`) and an uninterpretable tag (`analyze-2027`) both fail loudly. No tagged file has a silent-zero path.

## Shared helper, per-loader policy

`report/schema.rs`'s `major()` is now called by both loaders; `ticketing.rs`'s private copy is deleted. The POLICY stayed per-loader, which is what makes the sharing safe — `major("")` returns `None` for both, and each decides what that means. Folding the absent-tag decision into the shared module would have forced ticketing's producer history onto metrics.

## One fixture corrected

`redact_tests.rs::declared_metrics_file_findings_are_scrubbed` tagged its fixture `analyze-live-v0` — `analyze_adapter.rs`'s tag for the live HTTP path, which builds `AnalyzeMetrics` in memory and never writes a file. No declared artifact carries it. Corrected to `v0`. The test's subject is credential scrubbing and that is unchanged: it still loads through `load_metrics`, still sweeps `schema_version`, and the `FAKE_TOKEN`-bearing fields are untouched.

## Test ladder: rung 4 (the extraction touches `ticketing.rs` and the public error enum)

```
cargo fmt --check                                          0
cargo check -p trusty-review                               0
cargo clippy -p trusty-review --all-targets -- -D warnings 0
cargo test -p trusty-review    0   (1591 passed, 0 failed, 5 ignored)
SKIP_UI_BUILD=1 cargo check --workspace                    0
scripts/check_line_cap.sh      0
scripts/check_test_pointers.sh 0   (24791 citations, 0 dangling)
```

`ReportError::MetricsSchema` adds a variant to a public enum that is not `#[non_exhaustive]`. That folds into the MINOR bump trusty-review already owes for `ReportModel`/`ReportSection`/`TicketingSchema` — release-time work, no version touched here.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
