### PR TITLE
feat(tga): harvest ticket references from branch names and PR bodies

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/5734-harvest-branch-and-pr-refs.md
+++ b/crates/trusty-git-analytics/changelog.d/5734-harvest-branch-and-pr-refs.md
@@ -1,0 +1,7 @@
+Added
+
+- Pull requests now carry their source branch (`head_ref`) and the issue their body declares (`body_ticket_id`), and both feed the same ticket extraction as commit subjects. Schema migration v24 adds the two columns; existing databases keep their rows and read the new columns as "no claim made".
+- `correlate_commits` resolves a commit's ticket key through a stated precedence — the commit's own text, then the branch name of the pull request that carried it, then that pull request's body. A key the commit declares is never displaced by either new source.
+- `CorrelationOutcome` reports `from_branch` and `from_pr_body`, and the summary line prints both even when they are zero, so a source that harvests nothing is distinguishable from one that was never consulted.
+- `branch_ticket_key` and `pr_body_ticket_key` apply the #5199 rejection rules unchanged: a branch such as `fix/ADR-0029-followup` yields nothing, and no JIRA-shaped token is ever read from a pull-request body. Measured over this repository's 2376 merged pull requests, that keeps out 2501 false keys across 423 distinct prefixes and recovers a genuine issue reference for 51 commits whose subject declared none.
+- Azure DevOps pull requests now persist the `sourceRefName` they already parsed, so the branch harvest works there too.

--- a/crates/trusty-git-analytics/src/collect/azdo/pr_fetcher/db.rs
+++ b/crates/trusty-git-analytics/src/collect/azdo/pr_fetcher/db.rs
@@ -117,9 +117,12 @@ pub fn upsert_pr(conn: &Connection, pr: &AdoPullRequest, repository: &str) -> Co
     };
 
     conn.execute(
+        // #5734: `source_branch` was parsed from `sourceRefName` but never
+        // persisted. It is the same `refs/heads/...` value `branch_ticket_key`
+        // normalizes, so storing it makes the branch harvest work on ADO.
         "INSERT OR REPLACE INTO pull_requests \
-         (provider, repository, pr_number, title, author, state, created_at, merged_at, commit_shas) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+         (provider, repository, pr_number, title, author, state, created_at, merged_at, commit_shas, head_ref) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
         params![
             "azdo",
             repository,
@@ -130,6 +133,7 @@ pub fn upsert_pr(conn: &Connection, pr: &AdoPullRequest, repository: &str) -> Co
             pr.created_at.to_rfc3339(),
             pr.closed_at.map(|t| t.to_rfc3339()),
             commit_shas,
+            pr.source_branch,
         ],
     )?;
 

--- a/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/client.rs
@@ -465,6 +465,11 @@ fn map_pr(pr: BbPullRequest, repository: &str) -> PullRequest {
         merged_at,
         commit_shas,
         fetched_at: Utc::now().to_rfc3339(),
+        // #5734: Bitbucket's list payload does carry `source.branch.name` and
+        // `description`, but neither is deserialized yet. `None` states that
+        // this provider makes no claim, rather than asserting an empty branch.
+        head_ref: None,
+        body_ticket_id: None,
     }
 }
 

--- a/crates/trusty-git-analytics/src/collect/bitbucket/tests.rs
+++ b/crates/trusty-git-analytics/src/collect/bitbucket/tests.rs
@@ -552,6 +552,8 @@ fn sample_pr(repository: &str, pr_number: u64, state: PrState, fetched_at: &str)
         merged_at: None,
         commit_shas: "[]".to_string(),
         fetched_at: fetched_at.to_string(),
+        head_ref: None,
+        body_ticket_id: None,
     }
 }
 

--- a/crates/trusty-git-analytics/src/collect/collector.rs
+++ b/crates/trusty-git-analytics/src/collect/collector.rs
@@ -704,41 +704,9 @@ impl CollectionPipeline {
 
         // Drain results as they complete. Persistence runs on the main task
         // (where `&mut Database` is safe to use) and uses the matching
-        // provider's `store_pull_requests`.
-        while let Some(joined) = set.join_next().await {
-            let (provider_name, fetch_result) = match joined {
-                Ok(t) => t,
-                Err(e) => {
-                    stats.fail_stage(format!("PR fetch task panicked: {e}"));
-                    continue;
-                }
-            };
-            match fetch_result {
-                Ok(prs) => {
-                    // Find the matching provider for storage.
-                    let Some(provider) = providers.iter().find(|p| p.name() == provider_name)
-                    else {
-                        stats.fail_stage(format!(
-                            "internal: no provider registered for '{provider_name}' \
-                             when storing PRs"
-                        ));
-                        continue;
-                    };
-                    match provider.store_pull_requests(db, &prs) {
-                        Ok(n) => {
-                            info!(provider = %provider_name, prs = n, "stored pull requests");
-                            stats.prs_fetched += n;
-                        }
-                        Err(e) => {
-                            stats.fail_stage(format!("{provider_name} PR store failed: {e}"));
-                        }
-                    }
-                }
-                Err(e) => {
-                    stats.fail_stage(format!("{provider_name} PR fetch failed: {e}"));
-                }
-            }
-        }
+        // provider's `store_pull_requests`. The drain lives in
+        // `pr_pipeline` so every fault-severity decision sits in one place.
+        super::pr_pipeline::drain_and_store_pull_requests(set, &providers, db, stats).await;
 
         // Phase 3 (issue #742): GitHub reviewer ingestion pass (serial, after
         // PRs are stored so FK lookups succeed).

--- a/crates/trusty-git-analytics/src/collect/correlate.rs
+++ b/crates/trusty-git-analytics/src/collect/correlate.rs
@@ -17,9 +17,11 @@
 //!
 //! Test: `tests` at the bottom of this file.
 
+use std::collections::HashMap;
+
 use rusqlite::{params, Connection};
 
-use crate::collect::ticket::extract_ticket_id;
+use crate::collect::ticket::{branch_ticket_key, extract_ticket_id};
 use crate::core::db::work_items::link_commit_work_item;
 use crate::core::errors::{Result, TgaError};
 use crate::core::progress::{ProgressBus, ProgressEvent, Stage};
@@ -62,18 +64,38 @@ pub struct CorrelationOutcome {
     /// Commits whose ticket key has no matching `work_items` row — the gap a
     /// board pull would close.
     pub no_work_item: u64,
+    /// Commits whose key came from their pull request's branch name (#5734).
+    ///
+    /// Why: harvesting a source that yields nothing must be visible as a zero,
+    /// not as silence. On this repository this reads 0 — branch names here are
+    /// lowercase (`fix/5734-slug`), so there is no key to find. An operator who
+    /// expected otherwise can see that from the summary line rather than
+    /// inferring it from an unchanged link count.
+    pub from_branch: u64,
+    /// Commits whose key came from their pull request's body (#5734).
+    pub from_pr_body: u64,
 }
 
 impl CorrelationOutcome {
     /// One-line summary for the activity log and the CLI.
     ///
-    /// Why: the four dispositions only mean something together.
-    /// What: `"N linked, N already linked, N ticket without board item, N without ticket"`.
-    /// Test: `tests::summary_names_every_disposition`.
+    /// Why: the dispositions only mean something together. #5734 appends the
+    /// two harvest counts unconditionally — printing them only when non-zero
+    /// would make "this source found nothing" and "this source was never
+    /// consulted" the same output.
+    /// What: the four dispositions, then `"N via branch, N via PR body"`.
+    /// Test: `tests::summary_names_every_disposition`,
+    /// `tests::summary_reports_a_zero_harvest_rather_than_omitting_it`.
     pub fn summary(&self) -> String {
         format!(
-            "{} linked, {} already linked, {} ticket without board item, {} without ticket",
-            self.linked, self.already_linked, self.no_work_item, self.no_ticket
+            "{} linked, {} already linked, {} ticket without board item, \
+             {} without ticket ({} via branch, {} via PR body)",
+            self.linked,
+            self.already_linked,
+            self.no_work_item,
+            self.no_ticket,
+            self.from_branch,
+            self.from_pr_body
         )
     }
 }
@@ -113,21 +135,159 @@ fn load_candidates(conn: &Connection) -> Result<Vec<Candidate>> {
     Ok(out)
 }
 
-/// The ticket key for a commit: the stored column, else the message.
+/// Where a commit's ticket key came from.
+///
+/// Why: #5734 added two more places a key can come from, and they disagree —
+/// 323 of this repository's merged commits have a subject key and a PR-body key
+/// that differ. Which one wins must be a stated rule, not a side effect of the
+/// order someone happened to write the `or_else` chain in.
+///
+/// What: the variants are declared in precedence order and [`SOURCE_ORDER`]
+/// iterates them; `derive(PartialOrd)` follows declaration order, so the type
+/// and the constant cannot drift apart. The ordering rests on how specifically
+/// the author was naming THIS commit's work:
+///
+/// 1. [`Self::CommitText`] — the commit's own subject, written about this one
+///    commit. #5199 established subject position as authoritative and nothing
+///    here weakens it: a new source never displaces a key the commit declares.
+/// 2. [`Self::BranchName`] — authored once as a work identifier and shared by
+///    every commit on the branch. Coarser than a subject, but it is a
+///    deliberate identifier rather than prose.
+/// 3. [`Self::PrBody`] — prose written last, routinely citing several issues.
+///    Weakest, and the only source measured to need an action keyword before
+///    it can be believed at all.
+///
+/// Test: `tests::precedence_prefers_commit_text_then_branch_then_body`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TicketSource {
+    /// The commit's own `ticket_id` column or subject line.
+    CommitText,
+    /// The head-ref of the pull request that carried the commit.
+    BranchName,
+    /// The `Closes #N` reference in that pull request's body.
+    PrBody,
+}
+
+/// The sources a commit's ticket key is resolved from, most trusted first.
+///
+/// Why: see [`TicketSource`] — the precedence is data, so it can be read in one
+/// place and asserted directly by a test.
+/// What: the three variants in declaration order.
+/// Test: `tests::precedence_order_matches_the_declared_variant_order`.
+const SOURCE_ORDER: [TicketSource; 3] = [
+    TicketSource::CommitText,
+    TicketSource::BranchName,
+    TicketSource::PrBody,
+];
+
+/// What one pull request contributes to the commits it produced.
+///
+/// Why: #5734 — a commit carries no branch, so the branch and body keys arrive
+/// through `pull_requests.commit_shas`. Both are `Option` because a provider
+/// that supplies neither must be distinguishable from one that supplied an
+/// empty value.
+/// What: the harvested key from each source, already extracted.
+/// Test: `tests::branch_name_supplies_a_key_the_subject_lacks`.
+#[derive(Debug, Clone, Default)]
+struct PrKeys {
+    /// Key read from the PR's head ref by [`branch_ticket_key`].
+    branch: Option<String>,
+    /// Key extracted from the PR body at fetch time.
+    body: Option<String>,
+}
+
+/// Map every commit SHA a pull request produced to that PR's harvested keys.
+///
+/// Why: #5734's join. `pull_requests.commit_shas` is a JSON array of SHAs, so
+/// the mapping is built in Rust rather than leaning on SQLite's JSON1
+/// extension, matching how [`load_candidates`] already reads everything up
+/// front.
+///
+/// What: reads every PR row carrying a head ref or a body key, runs
+/// [`branch_ticket_key`] over the head ref, and indexes both by SHA. A PR whose
+/// `commit_shas` will not parse is skipped rather than failing the pass — the
+/// column is provider-written and one malformed row must not cost the whole
+/// correlation. A later PR wins a SHA collision, which cannot occur in practice
+/// because a squash merge SHA belongs to exactly one PR.
+///
+/// # Errors
+///
+/// Returns [`TgaError::DbError`] when the query itself fails — that is a whole
+/// -source failure, not one skippable row, so it is NOT swallowed.
+fn load_pr_keys(conn: &Connection) -> Result<HashMap<String, PrKeys>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT commit_shas, head_ref, body_ticket_id FROM pull_requests \
+             WHERE (head_ref IS NOT NULL AND head_ref != '') OR body_ticket_id IS NOT NULL",
+        )
+        .map_err(TgaError::from)?;
+    let mapped = stmt
+        .query_map([], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, Option<String>>(1)?,
+                r.get::<_, Option<String>>(2)?,
+            ))
+        })
+        .map_err(TgaError::from)?;
+
+    let mut out: HashMap<String, PrKeys> = HashMap::new();
+    for row in mapped {
+        let (shas_json, head_ref, body_key) = row.map_err(TgaError::from)?;
+        let branch = head_ref.as_deref().and_then(branch_ticket_key);
+        if branch.is_none() && body_key.is_none() {
+            continue;
+        }
+        // #5734: a provider-written JSON column; a malformed one skips this PR.
+        let Ok(shas) = serde_json::from_str::<Vec<String>>(&shas_json) else {
+            continue;
+        };
+        for sha in shas {
+            out.insert(
+                sha,
+                PrKeys {
+                    branch: branch.clone(),
+                    body: body_key.clone(),
+                },
+            );
+        }
+    }
+    Ok(out)
+}
+
+/// The ticket key for a commit, and which source produced it.
 ///
 /// Why: `commits.ticket_id` is populated at collection time, but rows written
 /// before that column existed (or by a collector run that predates the
 /// extractor) still carry the key in the message. Falling back keeps the pass
-/// useful on an old database without a re-collect.
-/// What: the trimmed non-empty `ticket_id`, else
-/// [`extract_ticket_id`] over `message`, else `None`.
-/// Test: `tests::links_matching_ticket_keys` (the `ddd` case).
-fn ticket_key(ticket_id: Option<&str>, message: &str) -> Option<String> {
-    ticket_id
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
-        .or_else(|| extract_ticket_id(message))
+/// useful on an old database without a re-collect. #5734 adds the two
+/// pull-request sources behind it.
+///
+/// What: walks [`SOURCE_ORDER`] and returns the first source that yields a key,
+/// so the precedence is the constant's, not this function's control flow.
+/// [`TicketSource::CommitText`] is the trimmed non-empty `ticket_id` else
+/// [`extract_ticket_id`] over the message — unchanged from before #5734, which
+/// is what keeps #5199's subject-position rule authoritative.
+///
+/// Test: `tests::ticket_key_prefers_column_then_message`,
+/// `tests::precedence_prefers_commit_text_then_branch_then_body`.
+fn ticket_key(
+    ticket_id: Option<&str>,
+    message: &str,
+    pr: Option<&PrKeys>,
+) -> Option<(String, TicketSource)> {
+    SOURCE_ORDER.iter().find_map(|&source| {
+        let key = match source {
+            TicketSource::CommitText => ticket_id
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .or_else(|| extract_ticket_id(message)),
+            TicketSource::BranchName => pr.and_then(|p| p.branch.clone()),
+            TicketSource::PrBody => pr.and_then(|p| p.body.clone()),
+        };
+        key.map(|k| (k, source))
+    })
 }
 
 /// Link commits to board items already present in `work_items`.
@@ -149,6 +309,8 @@ fn ticket_key(ticket_id: Option<&str>, message: &str) -> Option<String> {
 /// Returns [`TgaError::DbError`] when a query, insert, or the commit fails.
 pub fn correlate_commits(conn: &mut Connection, bus: &ProgressBus) -> Result<CorrelationOutcome> {
     let candidates = load_candidates(conn)?;
+    // #5734: branch and PR-body keys reach a commit through `commit_shas`.
+    let pr_keys = load_pr_keys(conn)?;
     let total = candidates.len() as u64;
     bus.emit(ProgressEvent::started(
         Stage::Correlate,
@@ -168,9 +330,16 @@ pub fn correlate_commits(conn: &mut Connection, bus: &ProgressBus) -> Result<Cor
             if *already {
                 outcome.already_linked += 1;
             } else {
-                match ticket_key(ticket_id.as_deref(), message) {
+                match ticket_key(ticket_id.as_deref(), message, pr_keys.get(sha)) {
                     None => outcome.no_ticket += 1,
-                    Some(key) => {
+                    Some((key, from)) => {
+                        // #5734: count the harvest per source so a source that
+                        // finds nothing reports a zero instead of staying silent.
+                        match from {
+                            TicketSource::CommitText => {}
+                            TicketSource::BranchName => outcome.from_branch += 1,
+                            TicketSource::PrBody => outcome.from_pr_body += 1,
+                        }
                         let sources: Vec<String> = lookup
                             .query_map(params![key], |r| r.get::<_, String>(0))
                             .map_err(TgaError::from)?
@@ -225,6 +394,27 @@ mod tests {
             url: None,
             raw_json: None,
         }
+    }
+
+    /// Seed a pull request that claims `sha`, with a head ref and/or a
+    /// body-extracted key (#5734).
+    fn insert_pr(
+        conn: &Connection,
+        pr_number: i64,
+        sha: &str,
+        head_ref: Option<&str>,
+        body_key: Option<&str>,
+    ) {
+        let shas = serde_json::to_string(&vec![sha]).expect("encode shas");
+        conn.execute(
+            "INSERT INTO pull_requests \
+             (provider, repository, pr_number, title, author, state, created_at, \
+              commit_shas, head_ref, body_ticket_id) \
+             VALUES ('github', 'acme/widgets', ?1, 'T', 'ada', 'merged', \
+                     '2026-01-01T00:00:00Z', ?2, ?3, ?4)",
+            params![pr_number, shas, head_ref.unwrap_or(""), body_key],
+        )
+        .expect("insert pr");
     }
 
     fn insert_commit(conn: &Connection, sha: &str, message: &str, ticket: Option<&str>) {
@@ -384,26 +574,36 @@ mod tests {
             already_linked: 1,
             no_ticket: 1,
             no_work_item: 1,
+            from_branch: 2,
+            from_pr_body: 3,
         };
         let s = out.summary();
         assert!(s.contains("1 linked"));
         assert!(s.contains("1 already linked"));
         assert!(s.contains("1 ticket without board item"));
         assert!(s.contains("1 without ticket"));
+        assert!(s.contains("2 via branch"));
+        assert!(s.contains("3 via PR body"));
     }
 
     #[test]
     fn ticket_key_prefers_column_then_message() {
         assert_eq!(
-            ticket_key(Some("PROJ-1"), "PROJ-2 unrelated"),
-            Some("PROJ-1".into())
+            ticket_key(Some("PROJ-1"), "PROJ-2 unrelated", None),
+            Some(("PROJ-1".into(), TicketSource::CommitText))
         );
         // #5199: the message fallback reads a subject-leading key. The
         // fixtures say `PROJ-2 seen` rather than `sees PROJ-2` for that
         // reason; which of the two sources wins is what this test covers.
-        assert_eq!(ticket_key(Some("  "), "PROJ-2 seen"), Some("PROJ-2".into()));
-        assert_eq!(ticket_key(None, "PROJ-2 seen"), Some("PROJ-2".into()));
-        assert_eq!(ticket_key(None, "chore: nothing"), None);
+        assert_eq!(
+            ticket_key(Some("  "), "PROJ-2 seen", None),
+            Some(("PROJ-2".into(), TicketSource::CommitText))
+        );
+        assert_eq!(
+            ticket_key(None, "PROJ-2 seen", None),
+            Some(("PROJ-2".into(), TicketSource::CommitText))
+        );
+        assert_eq!(ticket_key(None, "chore: nothing", None), None);
     }
 
     /// Why: #5199 — this pass is where the corrupted key became an operator-
@@ -431,5 +631,168 @@ mod tests {
         );
         assert_eq!(out.no_work_item, 0, "ADR-0034 is not a phantom gap");
         assert_eq!(out.no_ticket, 0);
+    }
+
+    // ── #5734: branch names and PR bodies as correlation inputs ───────────
+
+    /// Why: #5734's first closure condition — a branch name must reach
+    /// `commit_work_items` for a commit whose own text declares nothing.
+    /// What: a commit with no key, carried by a PR whose head ref names one,
+    /// links; the harvest is counted under `from_branch`.
+    /// Test: this test itself.
+    #[test]
+    fn branch_name_supplies_a_key_the_subject_lacks() {
+        let mut db = Database::open_in_memory().expect("open");
+        insert_commit(db.connection(), "aaa", "chore: tidy up", None);
+        insert_pr(db.connection(), 1, "aaa", Some("feature/PROJ-1-tidy"), None);
+        upsert_work_item(db.connection(), &work_item("PROJ-1", "jira")).expect("upsert");
+
+        let out = correlate_commits(db.connection_mut(), &ProgressBus::disabled()).expect("run");
+        assert_eq!(out.linked, 1, "the branch name carried the key");
+        assert_eq!(out.from_branch, 1);
+        assert_eq!(out.from_pr_body, 0);
+        assert_eq!(out.no_ticket, 0);
+    }
+
+    /// Why: #5734 — measured on this repository, a PR body's `Closes #N`
+    /// recovers a key for 51 merged commits whose subject declares none. This
+    /// is the source that actually earns its keep here.
+    /// What: a commit with no key, carried by a PR whose body named an issue,
+    /// links; the harvest is counted under `from_pr_body`.
+    /// Test: this test itself.
+    #[test]
+    fn pr_body_supplies_a_key_the_subject_lacks() {
+        let mut db = Database::open_in_memory().expect("open");
+        insert_commit(db.connection(), "aaa", "chore: tidy up", None);
+        insert_pr(db.connection(), 1, "aaa", None, Some("#5089"));
+        upsert_work_item(db.connection(), &work_item("#5089", "github")).expect("upsert");
+
+        let out = correlate_commits(db.connection_mut(), &ProgressBus::disabled()).expect("run");
+        assert_eq!(out.linked, 1);
+        assert_eq!(out.from_pr_body, 1);
+        assert_eq!(out.from_branch, 0);
+    }
+
+    /// Why: #5734 — 323 of this repository's merged commits have a subject key
+    /// and a PR-body key that DIFFER, so which source wins is not academic.
+    /// #5199 made subject position authoritative and a new source must not
+    /// displace it.
+    /// What: with all three sources disagreeing, the commit's own text wins;
+    /// remove it and the branch wins; remove that and the body wins.
+    /// Test: this test itself.
+    #[test]
+    fn precedence_prefers_commit_text_then_branch_then_body() {
+        let pr = PrKeys {
+            branch: Some("BRANCH-2".into()),
+            body: Some("#3".into()),
+        };
+        assert_eq!(
+            ticket_key(Some("SUBJ-1"), "SUBJ-1 x", Some(&pr)),
+            Some(("SUBJ-1".into(), TicketSource::CommitText)),
+            "the commit's own text outranks both pull-request sources"
+        );
+        assert_eq!(
+            ticket_key(None, "chore: nothing", Some(&pr)),
+            Some(("BRANCH-2".into(), TicketSource::BranchName)),
+            "a deliberate branch identifier outranks PR prose"
+        );
+        let body_only = PrKeys {
+            branch: None,
+            body: Some("#3".into()),
+        };
+        assert_eq!(
+            ticket_key(None, "chore: nothing", Some(&body_only)),
+            Some(("#3".into(), TicketSource::PrBody))
+        );
+        assert_eq!(ticket_key(None, "chore: nothing", None), None);
+    }
+
+    /// Why: the precedence must be readable in one place; a constant that
+    /// drifted from the enum's declaration order would silently reorder it.
+    /// What: `SOURCE_ORDER` is sorted, so it agrees with `derive(Ord)`.
+    /// Test: this test itself.
+    #[test]
+    fn precedence_order_matches_the_declared_variant_order() {
+        let mut sorted = SOURCE_ORDER;
+        sorted.sort();
+        assert_eq!(SOURCE_ORDER, sorted);
+        assert!(TicketSource::CommitText < TicketSource::BranchName);
+        assert!(TicketSource::BranchName < TicketSource::PrBody);
+    }
+
+    /// Why: #5734's central risk — a branch named `fix/ADR-0029-followup` is
+    /// exactly what #5199 spent its effort excluding, and harvesting it here
+    /// would undo that work through a side door. `correlate_commits` is where
+    /// a bad key becomes an operator-facing `no_work_item` number.
+    /// What: neither an ADR-citing branch nor a body full of `DOC-`/`ADR-`
+    /// prose produces a key, so neither becomes a phantom coverage gap.
+    /// Test: this test itself.
+    #[test]
+    fn branch_and_body_noise_never_becomes_a_phantom_coverage_gap() {
+        let mut db = Database::open_in_memory().expect("open");
+        insert_commit(db.connection(), "aaa", "chore: tidy up", None);
+        insert_pr(
+            db.connection(),
+            1,
+            "aaa",
+            Some("fix/ADR-0029-followup"),
+            None,
+        );
+        insert_commit(db.connection(), "bbb", "chore: tidy more", None);
+        // A body whose only JIRA-shaped tokens are documentation citations
+        // extracts no key at fetch time, so `body_ticket_id` is NULL.
+        insert_pr(db.connection(), 2, "bbb", Some("fix/5734-slug"), None);
+
+        let out = correlate_commits(db.connection_mut(), &ProgressBus::disabled()).expect("run");
+        assert_eq!(out.no_ticket, 2, "neither commit gains a key");
+        assert_eq!(out.from_branch, 0);
+        assert_eq!(out.no_work_item, 0, "no phantom gap is reported");
+    }
+
+    /// Why: #5734 — a source that harvests nothing must say so. Silence is
+    /// indistinguishable from a source that was never consulted, which is the
+    /// fail-open this pass has to avoid.
+    /// What: with no PR rows at all, the summary still names both counts as 0.
+    /// Test: this test itself.
+    #[test]
+    fn summary_reports_a_zero_harvest_rather_than_omitting_it() {
+        let mut db = Database::open_in_memory().expect("open");
+        insert_commit(db.connection(), "aaa", "chore: nothing", None);
+        let out = correlate_commits(db.connection_mut(), &ProgressBus::disabled()).expect("run");
+        assert_eq!(out.from_branch, 0);
+        assert_eq!(out.from_pr_body, 0);
+        let s = out.summary();
+        assert!(s.contains("0 via branch"), "summary was: {s}");
+        assert!(s.contains("0 via PR body"), "summary was: {s}");
+    }
+
+    /// Why: `pull_requests.commit_shas` is provider-written, and #5734 now
+    /// parses it during correlation. One malformed row must not cost the whole
+    /// pass — but it must not fail the query silently either.
+    /// What: a PR with unparseable `commit_shas` is skipped and the other
+    /// commit still correlates.
+    /// Test: this test itself.
+    #[test]
+    fn a_malformed_commit_shas_column_skips_one_pr_not_the_pass() {
+        let mut db = Database::open_in_memory().expect("open");
+        insert_commit(db.connection(), "aaa", "chore: tidy", None);
+        insert_commit(db.connection(), "bbb", "chore: tidy", None);
+        db.connection()
+            .execute(
+                "INSERT INTO pull_requests \
+                 (provider, repository, pr_number, title, author, state, created_at, \
+                  commit_shas, head_ref) \
+                 VALUES ('github','acme/w',1,'T','ada','merged','2026-01-01T00:00:00Z', \
+                         'not json', 'feature/PROJ-1-x')",
+                [],
+            )
+            .expect("insert malformed pr");
+        insert_pr(db.connection(), 2, "bbb", Some("feature/PROJ-1-y"), None);
+        upsert_work_item(db.connection(), &work_item("PROJ-1", "jira")).expect("upsert");
+
+        let out = correlate_commits(db.connection_mut(), &ProgressBus::disabled()).expect("run");
+        assert_eq!(out.linked, 1, "the well-formed PR still correlates");
+        assert_eq!(out.from_branch, 1);
+        assert_eq!(out.no_ticket, 1, "the malformed PR's commit gains nothing");
     }
 }

--- a/crates/trusty-git-analytics/src/collect/github/client.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client.rs
@@ -11,6 +11,8 @@ use crate::collect::github::repo_resolver::{build_http_client, parse_slug};
 use crate::collect::github::retry::retry_get;
 use crate::collect::github::types::{ApiPull, GitHubIssue, GitHubPrCommit, GitHubReview};
 use crate::collect::pr_provider::PrProvider;
+// #5734: the PR body is scanned once here and discarded; only the key is kept.
+use crate::collect::ticket::pr_body_ticket_key;
 use crate::core::config::GithubConfig;
 use crate::core::db::Database;
 use crate::core::models::{PrState, PullRequest};
@@ -249,6 +251,12 @@ impl GitHubClient {
                     PrState::Open
                 };
                 let commit_shas = commit_shas_for_pull(&p)?;
+                // #5734: GitHub always sends `head.ref`, so `Some("")` here is
+                // an anomaly the collector reports rather than harvests as
+                // nothing. `None` means the payload carried no head block at
+                // all — the same "no claim made" value other providers use.
+                let head_ref = p.head.map(|h| h.ref_name);
+                let body_ticket_id = p.body.as_deref().and_then(pr_body_ticket_key);
                 out.push(PullRequest {
                     id: 0,
                     pr_number: p.number,
@@ -260,6 +268,8 @@ impl GitHubClient {
                     merged_at: p.merged_at,
                     commit_shas,
                     fetched_at: Utc::now().to_rfc3339(),
+                    head_ref,
+                    body_ticket_id,
                 });
             }
             if (n as u32) < PAGE_SIZE {
@@ -301,13 +311,17 @@ impl GitHubClient {
         let mut count = 0usize;
         for pr in prs {
             conn.execute(
+                // #5734: head_ref / body_ticket_id ride the same stale-write
+                // guard as every other mutable column, so an older snapshot
+                // cannot overwrite a newer branch or issue reference.
                 "INSERT INTO pull_requests \
-                 (provider,repository,pr_number,title,author,state,created_at,merged_at,commit_shas,fetched_at) \
-                 VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10) \
+                 (provider,repository,pr_number,title,author,state,created_at,merged_at,commit_shas,fetched_at,head_ref,body_ticket_id) \
+                 VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12) \
                  ON CONFLICT(provider,repository,pr_number) DO UPDATE SET \
                    title=excluded.title,author=excluded.author,state=excluded.state,\
                    merged_at=excluded.merged_at,commit_shas=excluded.commit_shas,\
-                   fetched_at=excluded.fetched_at \
+                   fetched_at=excluded.fetched_at,head_ref=excluded.head_ref,\
+                   body_ticket_id=excluded.body_ticket_id \
                  WHERE excluded.fetched_at > pull_requests.fetched_at",
                 params![
                     "github",
@@ -320,6 +334,8 @@ impl GitHubClient {
                     pr.merged_at.map(|t| t.to_rfc3339()),
                     pr.commit_shas,
                     pr.fetched_at,
+                    pr.head_ref.as_deref().unwrap_or(""),
+                    pr.body_ticket_id,
                 ],
             )?;
             count += 1;

--- a/crates/trusty-git-analytics/src/collect/github/client_tests.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client_tests.rs
@@ -31,6 +31,8 @@ fn sample_pr(repository: &str, pr_number: u64, state: PrState, fetched_at: &str)
         merged_at: None,
         commit_shas: "[]".to_string(),
         fetched_at: fetched_at.to_string(),
+        head_ref: Some("feature/PROJ-1-thing".to_string()),
+        body_ticket_id: Some("#42".to_string()),
     }
 }
 

--- a/crates/trusty-git-analytics/src/collect/github/types.rs
+++ b/crates/trusty-git-analytics/src/collect/github/types.rs
@@ -26,6 +26,24 @@ pub(crate) struct ApiPull {
     pub(crate) merged_at: Option<DateTime<Utc>>,
     #[serde(default)]
     pub(crate) merge_commit_sha: Option<String>,
+    /// #5734: source-branch block. Already present in this same list response —
+    /// harvesting it costs no extra request and no extra rate-limit budget.
+    #[serde(default)]
+    pub(crate) head: Option<ApiPullRef>,
+    /// #5734: PR description. Scanned once at fetch time for an action-keyword
+    /// issue reference; the prose itself is never persisted.
+    #[serde(default)]
+    pub(crate) body: Option<String>,
+}
+
+/// Internal wire type for the `head` block of a pull request (#5734).
+///
+/// Only `ref` is deserialized: `head.repo` is null for a PR from a deleted
+/// fork, but `head.ref` survives that, so the branch name stays readable.
+#[derive(Debug, Deserialize)]
+pub(crate) struct ApiPullRef {
+    #[serde(rename = "ref")]
+    pub(crate) ref_name: String,
 }
 
 /// Internal wire type for an author / actor embedded in PR payloads.

--- a/crates/trusty-git-analytics/src/collect/mod.rs
+++ b/crates/trusty-git-analytics/src/collect/mod.rs
@@ -41,6 +41,8 @@ pub mod linear;
 mod linear_pipeline;
 mod notify;
 pub mod pm_adapter;
+// #5734: the concurrent PR fetch drain, split out of `collector` (frozen SLOC).
+mod pr_pipeline;
 pub mod pr_provider;
 pub mod ticket;
 pub mod weeks;

--- a/crates/trusty-git-analytics/src/collect/pr_pipeline.rs
+++ b/crates/trusty-git-analytics/src/collect/pr_pipeline.rs
@@ -1,0 +1,180 @@
+//! Draining and persisting the concurrent pull-request fetch.
+//!
+//! Why: the fetch fans out across providers on a `JoinSet` and every result has
+//! four possible dispositions — the task panicked, no provider matched the
+//! returned name, the fetch failed, or the store failed. Each maps to a
+//! different [`crate::collect::CollectionFault`] severity, and keeping that
+//! mapping in one place is what stops a half-persisted run from reporting
+//! success. Extracted from [`crate::collect::collector`] for the same reason
+//! [`crate::collect::github_pipeline`] was: that module is on a frozen SLOC
+//! budget.
+//!
+//! What: [`drain_and_store_pull_requests`] awaits every spawned fetch, matches
+//! each result back to the provider that produced it, and persists the batch.
+//!
+//! Test: `crate::collect::correlate::tests` covers what the persisted rows then
+//! feed; the fault severities are covered by
+//! `crate::commands::collect::tests::a_failed_stage_makes_collect_exit_non_zero`.
+
+use std::sync::Arc;
+
+use tokio::task::JoinSet;
+use tracing::info;
+
+use crate::collect::collector::CollectionStats;
+use crate::collect::errors::Result;
+use crate::collect::pr_provider::PrProvider;
+use crate::core::db::Database;
+use crate::core::models::PullRequest;
+
+/// Await every spawned pull-request fetch and persist what came back.
+///
+/// Why: see the module header — one place decides which failures reach the
+/// process exit code. A fetch or store that failed wholesale is
+/// [`CollectionStats::fail_stage`], because that provider's data is absent from
+/// the database; a payload anomaly that cost only some harvested detail is
+/// [`CollectionStats::skip_item`].
+///
+/// What: drains `set`, matches each `(provider_name, result)` pair back to its
+/// entry in `providers`, records an empty-source-branch anomaly (#5734), then
+/// calls that provider's `store_pull_requests`. Every disposition is recorded;
+/// none aborts the drain, so one bad provider cannot cost the others.
+///
+/// #5734: a provider that answers with `Some("")` for a head ref made a claim
+/// and the claim was empty, which is an anomaly worth reporting. `None` means
+/// the provider never claimed to supply one — Bitbucket today — and is silent
+/// by design. Collapsing the two would make a broken payload indistinguishable
+/// from a branch harvest that legitimately found nothing.
+///
+/// Test: `tests::blank_head_ref_is_recorded_as_a_skipped_item`.
+pub(super) async fn drain_and_store_pull_requests(
+    mut set: JoinSet<(String, Result<Vec<PullRequest>>)>,
+    providers: &[Arc<dyn PrProvider + Send + Sync>],
+    db: &mut Database,
+    stats: &mut CollectionStats,
+) {
+    while let Some(joined) = set.join_next().await {
+        let (provider_name, fetch_result) = match joined {
+            Ok(t) => t,
+            Err(e) => {
+                stats.fail_stage(format!("PR fetch task panicked: {e}"));
+                continue;
+            }
+        };
+        let prs = match fetch_result {
+            Ok(prs) => prs,
+            Err(e) => {
+                stats.fail_stage(format!("{provider_name} PR fetch failed: {e}"));
+                continue;
+            }
+        };
+        let Some(provider) = providers.iter().find(|p| p.name() == provider_name) else {
+            stats.fail_stage(format!(
+                "internal: no provider registered for '{provider_name}' when storing PRs"
+            ));
+            continue;
+        };
+        record_blank_head_refs(stats, &provider_name, &prs);
+        match provider.store_pull_requests(db, &prs) {
+            Ok(n) => {
+                info!(provider = %provider_name, prs = n, "stored pull requests");
+                stats.prs_fetched += n;
+            }
+            Err(e) => {
+                stats.fail_stage(format!("{provider_name} PR store failed: {e}"));
+            }
+        }
+    }
+}
+
+/// Record pull requests whose provider claimed a source branch and gave an
+/// empty one (#5734).
+///
+/// Why: without this the branch harvest fails open — a provider returning blank
+/// refs yields zero keys, which looks exactly like a repository whose branches
+/// carry no ticket keys.
+/// What: counts `Some("")` head refs and records ONE `skip_item` naming the
+/// count. `None` is skipped: that is "no claim made", not a fault.
+/// Test: `tests::blank_head_ref_is_recorded_as_a_skipped_item`,
+/// `tests::absent_head_ref_is_not_a_fault`.
+fn record_blank_head_refs(stats: &mut CollectionStats, provider: &str, prs: &[PullRequest]) {
+    let blank = prs
+        .iter()
+        .filter(|p| p.head_ref.as_deref() == Some(""))
+        .count();
+    if blank > 0 {
+        stats.skip_item(format!(
+            "{provider}: {blank} pull request(s) reported an empty source branch; \
+             no branch ticket key harvested for them"
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::models::PrState;
+    use chrono::Utc;
+
+    fn pr(head_ref: Option<&str>) -> PullRequest {
+        PullRequest {
+            id: 0,
+            pr_number: 1,
+            repository: "acme/widgets".into(),
+            title: "T".into(),
+            author: "ada".into(),
+            state: PrState::Merged,
+            created_at: Utc::now(),
+            merged_at: None,
+            commit_shas: "[]".into(),
+            fetched_at: "2026-01-01T00:00:00Z".into(),
+            head_ref: head_ref.map(str::to_string),
+            body_ticket_id: None,
+        }
+    }
+
+    /// Why: #5734 — an empty source branch harvests nothing, and without a
+    /// recorded fault that is indistinguishable from a repository whose
+    /// branches simply carry no keys. This is the fail-open the check exists
+    /// to close.
+    /// What: two blank refs produce one `ItemSkipped` fault naming the count,
+    /// and no stage failure — the rest of the batch still persisted.
+    /// Test: this test itself.
+    #[test]
+    fn blank_head_ref_is_recorded_as_a_skipped_item() {
+        let mut stats = CollectionStats::default();
+        record_blank_head_refs(
+            &mut stats,
+            "github",
+            &[pr(Some("")), pr(Some("feature/PROJ-1")), pr(Some(""))],
+        );
+        assert_eq!(
+            stats.errors.len(),
+            1,
+            "one aggregated fault, not one per PR"
+        );
+        assert!(
+            stats.stage_failures().is_empty(),
+            "a payload anomaly must not reach the exit code"
+        );
+        let msg = stats.errors[0].message.clone();
+        assert!(msg.contains("github"), "{msg}");
+        assert!(msg.contains('2'), "the count must be named: {msg}");
+    }
+
+    /// Why: `None` means the provider never claimed to supply a source branch —
+    /// Bitbucket today. Reporting that as a fault would make every Bitbucket
+    /// collection noisy about a feature it does not implement.
+    /// What: absent and non-empty head refs record nothing.
+    /// Test: this test itself.
+    #[test]
+    fn absent_head_ref_is_not_a_fault() {
+        let mut stats = CollectionStats::default();
+        record_blank_head_refs(
+            &mut stats,
+            "bitbucket",
+            &[pr(None), pr(None), pr(Some("feature/PROJ-1"))],
+        );
+        assert!(stats.errors.is_empty());
+    }
+}

--- a/crates/trusty-git-analytics/src/collect/ticket.rs
+++ b/crates/trusty-git-analytics/src/collect/ticket.rs
@@ -90,6 +90,16 @@ struct ExtractPatterns {
     jira_anchored: Regex,
     /// GitHub bare issue reference: `#123`.
     gh_bare: Regex,
+    /// #5734: JIRA/Linear key anchored to the start of one `/`-separated
+    /// branch-name segment. Distinct from [`Self::jira_anchored`] only in its
+    /// right boundary, which must also accept `-` and `_` because a branch
+    /// slug runs the key straight into its description
+    /// (`feature/PROJ-123-add-thing`).
+    jira_branch_segment: Regex,
+    /// #5734: GitHub action-keyword reference with the issue number captured
+    /// (`Closes #5734`). [`TicketPatterns::gh_action`] only answers whether one
+    /// is present; this one yields the `#N` to store.
+    gh_action_ref: Regex,
 }
 
 /// Global, lazily-initialized extraction pattern set.
@@ -110,6 +120,14 @@ fn extract_patterns() -> &'static ExtractPatterns {
             jira_anchored: Regex::new(r"^([A-Z][A-Z0-9]*-\d+)(?:$|[\s:,.;)\]])")
                 .expect("jira_anchored pattern compiles"),
             gh_bare: Regex::new(r"(?:^|\s)(#\d+)\b").expect("gh_bare extract pattern compiles"),
+            // #5734: same `^`-anchoring as `jira_anchored`, so a tail segment of
+            // a longer identifier stays unreachable here too.
+            jira_branch_segment: Regex::new(r"^([A-Z][A-Z0-9]*-\d+)(?:$|[-_./\s])")
+                .expect("jira_branch_segment pattern compiles"),
+            gh_action_ref: Regex::new(
+                r"(?i)\b(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+(#\d+)\b",
+            )
+            .expect("gh_action_ref pattern compiles"),
         }
     })
 }
@@ -261,6 +279,114 @@ pub fn extract_ticket_id(message: &str) -> Option<String> {
     }
 
     None
+}
+
+/// The ticket key a branch NAME declares, if any.
+///
+/// Why: #5734 — `feature/PROJ-123-thing` names its work item as deliberately as
+/// a commit subject does, and nothing harvested it. The rule has to be as tight
+/// as #5199's, because a branch called `fix/ADR-0029-followup` is the same
+/// shape as a real key: #5199 measured 466 false keys across 178 prefixes on
+/// this repository's commit bodies, and re-admitting them through a branch name
+/// would undo that work through a side door.
+///
+/// What: strips a leading `refs/heads/` (Azure DevOps reports full refs), then
+/// tries each `/`-separated segment in order and returns the first key anchored
+/// at that segment's START. The right boundary accepts `-` and `_` as well as
+/// end-of-segment, because a branch slug runs the key into its description with
+/// no space. [`DOC_REF_PREFIXES`] is applied unchanged, so `ADR`, `DOC`, `RFC`
+/// and `SPEC` are rejected here exactly as they are in a commit subject.
+/// Anchoring at `^` also keeps `SPEC-INSTALLER-01` from yielding
+/// `INSTALLER-01`, the tail-segment case #5199 closed.
+///
+/// A wrong key here is contained the same way #5199's are:
+/// [`crate::collect::correlate_commits`] only links a key that matches a row
+/// already in `work_items`, so a bad key becomes a reported gap, never an
+/// invented link.
+///
+/// Measured over this repository's 2376 merged pull requests, this yields
+/// ZERO keys — branch names here are lowercase (`fix/5734-slug`). That is a
+/// property of this repository's conventions, not of the extractor.
+///
+/// Test: `tests::branch_ticket_key_reads_the_key_a_branch_declares`,
+/// `tests::branch_ticket_key_rejects_documentation_prefixes`.
+///
+/// # Examples
+///
+/// ```
+/// use tga::collect::ticket::branch_ticket_key;
+///
+/// assert_eq!(branch_ticket_key("feature/PROJ-123-thing"), Some("PROJ-123".to_string()));
+/// assert_eq!(branch_ticket_key("refs/heads/ENG-7"), Some("ENG-7".to_string()));
+/// // #5199's rejection rules apply here unchanged.
+/// assert_eq!(branch_ticket_key("fix/ADR-0029-followup"), None);
+/// assert_eq!(branch_ticket_key("fix/5734-harvest-refs"), None);
+/// ```
+pub fn branch_ticket_key(branch: &str) -> Option<String> {
+    let p = extract_patterns();
+    let trimmed = branch
+        .trim()
+        .strip_prefix("refs/heads/")
+        .unwrap_or(branch.trim());
+    for segment in trimmed.split('/') {
+        let Some(key) = p
+            .jira_branch_segment
+            .captures(segment)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str().to_string())
+        else {
+            continue;
+        };
+        // #5734: the same deny-list #5199 applied to a commit subject.
+        if !is_doc_reference(&key) {
+            return Some(key);
+        }
+    }
+    None
+}
+
+/// The issue reference a pull-request BODY declares, if any.
+///
+/// Why: #5734 — a PR body routinely carries `Closes #N` for work the commit
+/// subject never names, and none of it was harvested. What it must NOT do is
+/// re-admit the noise #5199 removed: an unrestricted JIRA-shaped scan over this
+/// repository's 2433 PR bodies returns 2501 matches across 423 distinct keys,
+/// led by `DOC-39` (88), `DOC-48` (63) and `ADR-0024` (46) — five times the
+/// false-key volume #5199 deleted from commit bodies. Gating that scan on an
+/// action keyword does not rescue it either: `Closes <JIRA-key>` appears 8
+/// times and 6 are `ADR-0038`, `ADR-0032`, `DOC-56`, `DOC-29`,
+/// `RUSTSEC-2026` and a `HIGH-1` severity label.
+///
+/// What: reads ONLY an action-keyword GitHub reference — `closes #N`,
+/// `fixes #N`, `resolves #N` and their tense variants — and returns the `#N`.
+/// No JIRA/Linear pattern runs against a PR body at all, and a BARE `#N` is
+/// rejected as well: bare refs fire on 147 further bodies here, which is the
+/// #445 over-counting the bare pattern was excluded from [`is_ticketed`] for.
+/// A body must name its issue with an action keyword to be believed.
+///
+/// Measured over this repository, this recovers a genuine issue reference for
+/// 51 merged commits whose subject declares no key.
+///
+/// Test: `tests::pr_body_ticket_key_needs_an_action_keyword`,
+/// `tests::pr_body_ticket_key_never_reads_a_jira_shaped_token`.
+///
+/// # Examples
+///
+/// ```
+/// use tga::collect::ticket::pr_body_ticket_key;
+///
+/// assert_eq!(pr_body_ticket_key("Rework the guard.\n\nCloses #5734"), Some("#5734".to_string()));
+/// // A bare mention is not a declaration.
+/// assert_eq!(pr_body_ticket_key("Supersedes #123, see #456"), None);
+/// // The #5199 noise class never reaches a key.
+/// assert_eq!(pr_body_ticket_key("Per DOC-39 and ADR-0024, fixes UTF-8 handling"), None);
+/// ```
+pub fn pr_body_ticket_key(body: &str) -> Option<String> {
+    extract_patterns()
+        .gh_action_ref
+        .captures(body)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string())
 }
 
 #[cfg(test)]
@@ -551,5 +677,119 @@ mod tests {
     fn empty_message_is_not_ticketed() {
         assert!(!is_ticketed(""));
         assert!(!is_ticketed("\n\n"));
+    }
+
+    // ── #5734: branch names ───────────────────────────────────────────────
+
+    /// Why: #5734 — the branch shapes a real workflow produces must all
+    /// resolve, whichever `/`-separated segment carries the key.
+    /// What: bare, prefixed, nested and full-ref forms yield the key.
+    /// Test: this test itself.
+    #[test]
+    fn branch_ticket_key_reads_the_key_a_branch_declares() {
+        for (branch, want) in [
+            ("PROJ-123", "PROJ-123"),
+            ("PROJ-123-add-thing", "PROJ-123"),
+            ("feature/PROJ-123-thing", "PROJ-123"),
+            ("feature/ENG-7_login", "ENG-7"),
+            ("bobmatnyc/feature/API-9", "API-9"),
+            ("refs/heads/feature/BB-2746-auth", "BB-2746"),
+            ("refs/heads/SRE-3104", "SRE-3104"),
+        ] {
+            assert_eq!(
+                branch_ticket_key(branch),
+                Some(want.to_string()),
+                "branch: {branch:?}"
+            );
+        }
+    }
+
+    /// Why: #5734's central risk — a branch named `fix/ADR-0029-followup` is
+    /// exactly the shape #5199 spent its effort excluding, and harvesting one
+    /// would reintroduce that noise through a side door.
+    /// What: every [`DOC_REF_PREFIXES`] entry is rejected in a branch name, the
+    /// hyphenated-tail case stays unreachable, and a lowercase or
+    /// numeric-leading branch yields nothing.
+    /// Test: this test itself.
+    #[test]
+    fn branch_ticket_key_rejects_documentation_prefixes() {
+        for branch in [
+            "fix/ADR-0029-followup",
+            "docs/DOC-67-rewrite",
+            "chore/RFC-2119-sweep",
+            "feat/SPEC-14-tightened",
+            "refs/heads/ADR-0034",
+            // The tail of a longer identifier is unreachable, as in a subject.
+            "feat/SPEC-INSTALLER-01-detect",
+            // This repository's own convention: lowercase type, numeric slug.
+            "fix/5734-harvest-branch-and-pr-refs",
+            "feat/pre-publish-sha-targeting-5740",
+            "main",
+            "",
+        ] {
+            assert_eq!(branch_ticket_key(branch), None, "branch: {branch:?}");
+        }
+    }
+
+    // ── #5734: pull-request bodies ────────────────────────────────────────
+
+    /// Why: #5734 — a PR body's `Closes #N` is the reference worth harvesting;
+    /// a bare mention is the #445 over-counting that fires on 147 further
+    /// bodies in this repository alone.
+    /// What: action-keyword forms and their tense variants yield the `#N`;
+    /// bare mentions yield nothing.
+    /// Test: this test itself.
+    #[test]
+    fn pr_body_ticket_key_needs_an_action_keyword() {
+        for (body, want) in [
+            ("Closes #5734", "#5734"),
+            ("Rework the guard.\n\nCloses #5734\n", "#5734"),
+            ("fixes #99 and tidies up", "#99"),
+            ("RESOLVED #7", "#7"),
+            ("This closed #42 at last", "#42"),
+        ] {
+            assert_eq!(
+                pr_body_ticket_key(body),
+                Some(want.to_string()),
+                "body: {body:?}"
+            );
+        }
+        for body in [
+            "Supersedes #123, see #456",
+            "Follow-up to #5199.",
+            "#5734 is the tracking issue",
+            "no reference at all",
+            "",
+        ] {
+            assert_eq!(pr_body_ticket_key(body), None, "body: {body:?}");
+        }
+    }
+
+    /// Why: #5734 — the measured reason no JIRA/Linear pattern runs over a PR
+    /// body. An unrestricted scan of this repository's 2433 bodies returns
+    /// 2501 matches across 423 keys led by `DOC-39`, `DOC-48` and `ADR-0024`;
+    /// gating on an action keyword still leaves `RUSTSEC-2026` and a `HIGH-1`
+    /// severity label. Both routes are closed, not filtered.
+    /// What: none of these bodies yields a JIRA-shaped key, including the ones
+    /// where an action keyword sits directly in front of it.
+    /// Test: this test itself.
+    #[test]
+    fn pr_body_ticket_key_never_reads_a_jira_shaped_token() {
+        for body in [
+            "Per DOC-39 the manifest is an allowlist.",
+            "Implements ADR-0024 and DOC-48.",
+            "fixes UTF-8 filename handling",
+            "closes RUSTSEC-2026-0187",
+            "resolves HIGH-1 from the audit",
+            "Fixes PROJ-123 in the tracker",
+            "SHA-256 digest pinned; ISO-8601 offsets kept",
+        ] {
+            assert_eq!(pr_body_ticket_key(body), None, "body: {body:?}");
+        }
+        // A body that names BOTH still yields only the GitHub reference.
+        assert_eq!(
+            pr_body_ticket_key("Per ADR-0034 the relay spools durably.\n\nCloses #5089\n"),
+            Some("#5089".to_string())
+        );
     }
 }

--- a/crates/trusty-git-analytics/src/core/db/migrations/mod.rs
+++ b/crates/trusty-git-analytics/src/core/db/migrations/mod.rs
@@ -149,6 +149,13 @@ pub const MIGRATIONS: &[Migration] = &[
         name: "jira_ingestion",
         sql: include_str!("../sql/0023_jira_ingestion.sql"),
     },
+    // #5734: a PR's source branch and its body-declared issue ref, so branch
+    // names and PR bodies feed the same ticket extraction as commit subjects.
+    Migration {
+        version: 24,
+        name: "pull_requests_head_ref_and_body_ticket",
+        sql: include_str!("../sql/0024_pull_requests_head_ref_and_body_ticket.sql"),
+    },
 ];
 
 /// Ensure the `schema_migrations` bookkeeping table exists.
@@ -201,12 +208,29 @@ pub(super) fn column_names(conn: &Connection, table: &str) -> Result<Vec<String>
 /// Returns [`TgaError::MigrationError`] if a migration's SQL fails. The
 /// transaction guarantees partial application cannot occur.
 pub fn run(conn: &mut Connection) -> Result<()> {
+    run_through(conn, i64::MAX)
+}
+
+/// Apply migrations up to and including `max_version`.
+///
+/// Why: `run` always migrates to the newest version, so nothing could build a
+/// database at an OLDER schema — and without that, no test can prove an
+/// existing database survives a new migration. #5734 adds a column to
+/// `pull_requests`, which every deployed database already has rows in.
+/// What: the body `run` used to have, with a ceiling. `run` passes
+/// [`i64::MAX`], so its behaviour is unchanged.
+/// Test: `tests::migration_v24_preserves_an_existing_v23_database`.
+///
+/// # Errors
+///
+/// Returns [`TgaError::MigrationError`] if a migration's SQL fails.
+fn run_through(conn: &mut Connection, max_version: i64) -> Result<()> {
     ensure_migrations_table(conn)?;
     let current = current_version(conn)?;
     debug!(current_version = current, "running migrations");
 
     for m in MIGRATIONS {
-        if m.version <= current {
+        if m.version <= current || m.version > max_version {
             continue;
         }
         info!(version = m.version, name = m.name, "applying migration");
@@ -466,6 +490,92 @@ mod tests {
             updated_state, "merged",
             "REPLACE must update fields in place"
         );
+    }
+
+    /// Why: #5734 adds two columns to `pull_requests`, a table every deployed
+    /// database already has rows in. A migration that dropped or invalidated
+    /// those rows would be silent — the collector would simply re-fetch and
+    /// nobody would see the loss.
+    /// What: builds a genuine v23 database (the schema shipped before #5734),
+    /// writes a PR row through the OLD column set, then migrates to the head
+    /// and asserts the row survives byte-for-byte, its new columns read as the
+    /// documented "no claim" defaults, and the new columns are writable.
+    /// Test: this test itself.
+    #[test]
+    fn migration_v24_preserves_an_existing_v23_database() {
+        let mut conn = rusqlite::Connection::open_in_memory().expect("open");
+        super::run_through(&mut conn, 23).expect("migrate to v23");
+
+        let version: i64 = conn
+            .query_row("SELECT MAX(version) FROM schema_migrations", [], |r| {
+                r.get(0)
+            })
+            .expect("read version");
+        assert_eq!(version, 23, "the fixture must be a real pre-#5734 database");
+
+        // A row written the way the v23 collector wrote it — no head_ref, no
+        // body_ticket_id, because neither column existed.
+        conn.execute(
+            "INSERT INTO pull_requests \
+             (provider, repository, pr_number, title, author, state, created_at, \
+              merged_at, commit_shas, fetched_at) \
+             VALUES ('github','acme/widgets',7,'Old PR','ada','merged', \
+                     '2026-01-01T00:00:00Z','2026-01-02T00:00:00Z','[\"deadbeef\"]', \
+                     '2026-01-02T00:00:01Z')",
+            [],
+        )
+        .expect("insert v23-era pr");
+
+        // The upgrade every existing database performs on next open.
+        super::run(&mut conn).expect("migrate to head");
+
+        let (title, shas, fetched, head_ref, body_key): (
+            String,
+            String,
+            String,
+            String,
+            Option<String>,
+        ) = conn
+            .query_row(
+                "SELECT title, commit_shas, fetched_at, head_ref, body_ticket_id \
+                 FROM pull_requests WHERE pr_number = 7",
+                [],
+                |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get::<_, Option<String>>(4)?,
+                    ))
+                },
+            )
+            .expect("the pre-migration row must still be readable");
+
+        assert_eq!(title, "Old PR", "existing data must survive untouched");
+        assert_eq!(shas, "[\"deadbeef\"]");
+        assert_eq!(fetched, "2026-01-02T00:00:01Z");
+        assert_eq!(head_ref, "", "the documented default for an existing row");
+        assert_eq!(body_key, None);
+
+        // #5734: and the new columns are writable on the upgraded database.
+        conn.execute(
+            "UPDATE pull_requests SET head_ref = 'feature/PROJ-1-x', \
+             body_ticket_id = '#42' WHERE pr_number = 7",
+            [],
+        )
+        .expect("write the new columns");
+        let round_trip: String = conn
+            .query_row(
+                "SELECT head_ref FROM pull_requests WHERE pr_number = 7",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read back");
+        assert_eq!(round_trip, "feature/PROJ-1-x");
+
+        // Re-running is a no-op, per the runner's idempotence contract.
+        super::run(&mut conn).expect("re-run is idempotent");
     }
 
     // Migration v20 tests live in `v20.rs`.

--- a/crates/trusty-git-analytics/src/core/db/sql/0024_pull_requests_head_ref_and_body_ticket.sql
+++ b/crates/trusty-git-analytics/src/core/db/sql/0024_pull_requests_head_ref_and_body_ticket.sql
@@ -1,0 +1,34 @@
+-- Migration v24: carry a PR's source branch and its body-declared issue ref.
+--
+-- Issue #5734 (split from #5199). `collect/ticket.rs` reads a ticket key from
+-- the commit subject only. Branch names and PR bodies carry keys constantly and
+-- none of it reached `work_items` / `commit_work_items`.
+--
+-- Why these columns live on `pull_requests` and not on `commits`:
+-- a commit object carries no branch. `git branch --contains` answers "which
+-- refs reach this commit", which under a squash-merge workflow is `main` for
+-- every merged commit and the authoring branch for none — this repository has
+-- 2633 commits against 13 live remote branches. The branch a commit was
+-- authored on survives in exactly one place, the pull request's head ref, and
+-- `pull_requests.commit_shas` already joins a PR to the commits it produced.
+-- So the per-commit branch reference is reachable, and it is stored where it is
+-- actually a fact rather than as a mostly-NULL column on `commits`.
+--
+-- `head_ref` is the raw source-branch name (`feature/PROJ-123-thing`, or an
+-- ADO-style `refs/heads/...`). Empty string means the provider supplied none;
+-- see `PullRequest::head_ref` for the not-claimed vs. claimed-and-empty split.
+--
+-- `body_ticket_id` stores the key EXTRACTED from the PR body, not the body
+-- itself. The body is not persisted: this repository's 2433 PR bodies total
+-- 9.4 MB, and an unrestricted JIRA-shaped scan over them yields 2501 matches
+-- across 423 distinct keys dominated by `DOC-39`, `DOC-48` and `ADR-0024` —
+-- five times the false-key volume #5199 removed from commit bodies, against 51
+-- genuine `Closes #N` references. Storing 9.4 MB of prose to recover 51 keys is
+-- the wrong trade, so the high-precision extraction runs at fetch time and only
+-- its result is kept. See `collect::ticket::pr_body_ticket_key`.
+--
+-- Additive only — no existing column is modified and no data is removed.
+-- Existing rows default to '' / NULL, which both read as "this provider made no
+-- claim", so an old database keeps working untouched until its next collect.
+ALTER TABLE pull_requests ADD COLUMN head_ref TEXT NOT NULL DEFAULT '';
+ALTER TABLE pull_requests ADD COLUMN body_ticket_id TEXT;

--- a/crates/trusty-git-analytics/src/core/models/mod.rs
+++ b/crates/trusty-git-analytics/src/core/models/mod.rs
@@ -219,6 +219,51 @@ pub struct PullRequest {
     /// Test: `store_pull_requests_stale_write_guard_*` in
     /// `collect::github::client_tests` and `collect::bitbucket::tests`.
     pub fetched_at: String,
+
+    /// Raw source-branch name this PR was opened from, when the provider
+    /// supplies one.
+    ///
+    /// Why: #5734 — this is the ONLY place a commit's authoring branch
+    /// survives. A commit object carries no branch, and `git branch --contains`
+    /// answers a different question: under a squash-merge workflow it returns
+    /// `main` for every merged commit and the authoring branch for none. Joined
+    /// through [`Self::commit_shas`], this field is the per-commit branch
+    /// reference that #5734 asks for.
+    ///
+    /// What: `None` and `Some("")` mean different things, and the distinction
+    /// is what keeps a missing branch from being silently harvested as nothing.
+    /// `None` is "this provider makes no claim" — Bitbucket and Azure DevOps
+    /// PRs fetched before #5734 wired their source branch through. `Some("")`
+    /// is "the provider answered and the ref was empty", an anomaly the
+    /// collector records as a [`crate::collect::CollectionFault`] with
+    /// `skip_item` severity rather than passing over.
+    ///
+    /// GitHub reports a bare name (`feature/PROJ-123-thing`); Azure DevOps
+    /// reports a full ref (`refs/heads/...`).
+    /// [`crate::collect::ticket::branch_ticket_key`] normalizes both.
+    ///
+    /// Test: `collect::correlate::tests::branch_name_supplies_a_key_the_subject_lacks`.
+    #[serde(default)]
+    pub head_ref: Option<String>,
+
+    /// Issue reference extracted from this PR's body at fetch time.
+    ///
+    /// Why: #5734 — a PR body routinely declares `Closes #N` for work the
+    /// commit subject never names; this recovers a key for 51 merged commits in
+    /// this repository. The EXTRACTED key is stored rather than the body
+    /// because the body is 9.4 MB across 2433 PRs here and an unrestricted scan
+    /// of it yields 2501 false JIRA-shaped keys — see
+    /// [`crate::collect::ticket::pr_body_ticket_key`] for the measurement and
+    /// `0024_pull_requests_head_ref_and_body_ticket.sql` for the trade.
+    ///
+    /// What: `Some("#N")` when the body declared an issue with an action
+    /// keyword, `None` otherwise. Because the key is derived at fetch time,
+    /// sharpening the extraction rule needs a re-collect to take effect on
+    /// existing rows — that is the cost of not keeping the prose.
+    ///
+    /// Test: `collect::correlate::tests::pr_body_supplies_a_key_the_subject_lacks`.
+    #[serde(default)]
+    pub body_ticket_id: Option<String>,
 }
 
 /// Cascade tier that produced a classification.


### PR DESCRIPTION
Closes #5734

## A `commits.branch` column would have been the wrong shape

The issue assumed one. A commit object carries no branch; `git branch --contains` answers a different question — here it returns `main` plus every unmerged branch fast-forwarded past the commit — and under squash-merge the authoring branch is deleted for essentially every historical commit. The branch survives in exactly one place: the PR's `head.ref`, and `pull_requests.commit_shas` already joins a PR to the commits it produced. So `head_ref` and `body_ticket_id` went on `pull_requests` (migration v24), which the issue permits. A `commits.branch` column would have been NULL for every commit not produced by a merged PR.

## PR bodies: the extracted key is stored, never the prose

2433 PR bodies here are 9.4 MB. An unrestricted JIRA-shaped scan of them returns **2501 matches across 423 distinct keys** — `DOC-39` (88), `DOC-48` (63), `ADR-0024` (46) — against 51 genuine references. Five times the false-key volume #5199 removed.

So **no JIRA/Linear pattern runs against a PR body at all.** Only a bare `#N` with an action keyword. Gating on the keyword alone would not have saved it: `closes <JIRA-key>` appears 8 times and 6 are `ADR-0038`, `ADR-0032`, `DOC-56`, `DOC-29`, `RUSTSEC-2026`, and a `HIGH-1` severity label. A further 819 bodies with a bare `#N` and no keyword are rejected too.

Branch names DO run the full path — `branch_ticket_key` anchors at a segment start and applies #5199's `DOC_REF_PREFIXES` rejection, so `fix/ADR-0029-followup` yields nothing.

## Precedence is declared, not emergent

`TicketSource` with a `SOURCE_ORDER` constant, and a test asserting the constant is sorted so it cannot drift from the enum. CommitText (#5199's subject rule, never displaced) → BranchName → PrBody. Not academic: **323** merged commits here have a subject key and a body key that disagree.

## What it actually harvests on this repo

```
CorrelationOutcome { scanned: 2376, linked: 2064, no_ticket: 312,
                     no_work_item: 0, from_branch: 0, from_pr_body: 51 }
```

51 commits gain a key they did not have (`no_ticket` 363 → 312). **`from_branch` is 0** — this repo's branches are lowercase (`fix/5734-slug`), so there is no key to find. That is a property of the conventions here, not the extractor; the branch path is built, tested and wired for ADO, and will earn its keep on a JIRA-convention repo.

`summary()` prints both source counts **even at zero**, so a source that found nothing stays distinguishable from one never consulted.

## Test ladder: rung 5 (new column, migration, persisted output)

```
cargo fmt --check                                  0
cargo clippy -p tga --all-targets -- -D warnings   0
cargo test -p tga        0   (1283 passed, 0 failed, 7 ignored)
SKIP_UI_BUILD=1 cargo check --workspace            0
scripts/check_line_cap.sh       0
scripts/check_test_pointers.sh  0   (24804 citations, 0 dangling)
```

`migration_v24_preserves_an_existing_v23_database` builds a genuine v23 database, writes a PR row through the OLD column set, migrates to head, and asserts the old fields survive byte-for-byte while the new ones are writable and re-running is a no-op.

`collector.rs` hit 770 against its frozen 766 SLOC ratchet; the concurrent PR-fetch drain moved to `collect/pr_pipeline.rs` rather than moving the budget.

## Note for release

`PullRequest` is not `#[non_exhaustive]`, so the two new fields are a breaking change the release-time SemVer gate will see.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
