### PR TITLE
fix: unbreak Gate 1 — the link gate that examined nothing, and the 20 links it missed

### DIFF
--- a/crates/trusty-installer/changelog.d/5759-linux-only-broken-doc-links.md
+++ b/crates/trusty-installer/changelog.d/5759-linux-only-broken-doc-links.md
@@ -1,0 +1,7 @@
+Fixed
+- Stopped 14 doc comments in non-gated code from linking to macOS-gated items
+  (`has_developer_id_cert`, `sign_binary`, `verify_signature`, `sign_set_strict`,
+  `current_identifier`, `post_install_signed_set`, `apply_not_loaded_fallback`,
+  `attempt_verify_fallback`), which rustdoc cannot resolve on Linux. docs.rs
+  builds on Linux once per release and never rebuilds, so these would have been
+  baked into the published documentation permanently.

--- a/crates/trusty-installer/src/commands/macos_signing/mod.rs
+++ b/crates/trusty-installer/src/commands/macos_signing/mod.rs
@@ -21,7 +21,7 @@
 //! - The canonicalization above is a SILENT IDENTIFIER MIGRATION for any host
 //!   previously signed by the pre-PR Rust hook's `com.trusty.search` — changing
 //!   the designated requirement invalidates that host's existing FDA grant with
-//!   no warning (reproducing #873's `indexes:2` symptom). [`current_identifier`]
+//!   no warning (reproducing #873's `indexes:2` symptom). `current_identifier`
 //!   reads the binary's on-disk identifier before signing and
 //!   [`identifier_migration_notice`] prints a loud, distinct callout when it is
 //!   about to change.
@@ -101,12 +101,12 @@
 //! What: [`binaries_for_set`] and [`codesign_identifier`] are both derived from
 //! the single [`SIGNABLE_BINARIES`] table (binary, set, identifier) so set
 //! membership and identifier mapping can never drift apart again.
-//! [`has_developer_id_cert`] probes for a cert (env var `TRUSTY_SIGN_IDENTITY` >
-//! `security find-identity`). [`sign_binary`] signs with `--options runtime
+//! `has_developer_id_cert` probes for a cert (env var `TRUSTY_SIGN_IDENTITY` >
+//! `security find-identity`). `sign_binary` signs with `--options runtime
 //! --timestamp` only when `hardened` is `true` (see [`use_hardened_runtime`]),
-//! and [`verify_signature`] checks with `codesign --verify --deep --strict`.
+//! and `verify_signature` checks with `codesign --verify --deep --strict`.
 //! [`post_install_search`] / [`post_install_mpm`] are the fail-soft hooks
-//! `commands::install` calls after each member lands; [`sign_set_strict`] is the
+//! `commands::install` calls after each member lands; `sign_set_strict` is the
 //! hard-failing primitive the standalone `tctl sign <target>` command
 //! (`commands::sign`) uses, which `scripts/install-trusty-search-signed.sh` now
 //! shells out to instead of duplicating codesign flags in bash.
@@ -614,7 +614,7 @@ pub fn verify_signature(path: &std::path::Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Typed error for [`sign_set_strict`].
+/// Typed error for `sign_set_strict`.
 ///
 /// Why: PR #2657 review (MEDIUM) — `commands::sign::run_macos` previously
 /// distinguished "no cert" from "signing failed" by substring-matching the
@@ -957,11 +957,11 @@ fn post_install_signed_set(
 /// should immediately sign them (if a cert is available) or report the FDA
 /// re-grant guidance so the operator knows what to do next.
 ///
-/// What: On macOS delegates to [`post_install_signed_set`] for [`SEARCH_SET`],
+/// What: On macOS delegates to `post_install_signed_set` for [`SEARCH_SET`],
 /// returning its note/guidance text instead of printing directly (see that
 /// function's doc), plus a `bool` telling the caller whether
 /// [`signing_persistence_tip`] should be printed. On non-macOS: `None`.
-/// `existed_before` / `primary_path` — see [`post_install_signed_set`]; both
+/// `existed_before` / `primary_path` — see `post_install_signed_set`; both
 /// MUST come from the caller's `InstalledBinary` result for the CONCRETE
 /// outcome branch taken, never re-derived from `install_dir` alone.
 ///
@@ -992,11 +992,11 @@ pub fn post_install_search(
 /// same stable-identity signing as trusty-search so the App Data TCC prompt
 /// does not re-fire on every `cargo install` rebuild.
 ///
-/// What: On macOS delegates to [`post_install_signed_set`] for [`MPM_SET`],
+/// What: On macOS delegates to `post_install_signed_set` for [`MPM_SET`],
 /// returning its note/guidance text instead of printing directly (see that
 /// function's doc), plus a `bool` telling the caller whether
 /// [`signing_persistence_tip`] should be printed. On non-macOS: `None`.
-/// `existed_before` / `primary_path` — see [`post_install_signed_set`]; both
+/// `existed_before` / `primary_path` — see `post_install_signed_set`; both
 /// MUST come from the caller's `InstalledBinary` result for the CONCRETE
 /// outcome branch taken, never re-derived from `install_dir` alone.
 ///

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -39,10 +39,10 @@
 //!    defensive-fallback check).
 //! 5. (#3841 belt-and-braces, second layer) A member classified
 //!    [`DownState::NotLoaded`] whose plist is present on disk gets ONE more
-//!    repair attempt here — [`apply_not_loaded_fallback`] calls the exact same
+//!    repair attempt here — `apply_not_loaded_fallback` calls the exact same
 //!    `ServiceEnv::bootstrap_fallback` primitive
 //!    `service_bootstrap::bootstrap_one`'s install-time postcondition uses
-//!    (via [`attempt_verify_fallback`]), and on success re-probes through the
+//!    (via `attempt_verify_fallback`), and on success re-probes through the
 //!    SAME [`poll_until_not_down`]/[`bounded_attempts`] machinery the #2498
 //!    kickstart retry uses (#3849 code-critic MEDIUM 1 fix — a single instant
 //!    re-probe here would race a just-repaired but slow-starting daemon
@@ -152,7 +152,7 @@ pub struct VerifyRow {
     /// `None` for a healthy/stale/unknown/not_installed member, or a
     /// non-LAUNCHD member.
     pub down_state: Option<DownState>,
-    /// Whether [`attempt_verify_fallback`] was invoked for this member
+    /// Whether `attempt_verify_fallback` was invoked for this member
     /// (#3841 — the verify tail's own second-layer repair for a `NotLoaded`
     /// diagnosis, independent of `service_bootstrap`'s install-time
     /// postcondition).
@@ -268,7 +268,7 @@ pub fn needs_kickstart(outcome: &ProbeOutcome, manage: ManageStrategy) -> bool {
 /// `tests::verify_one_does_not_kickstart_a_healthy_launchd_daemon` run the REAL
 /// probe against a stubbed healthy daemon and then assert ZERO restarts — the
 /// only shape of test that closes the loop. Mirrors the `ServiceEnv` seam already
-/// in this file (see [`apply_not_loaded_fallback`], tested against
+/// in this file (see `apply_not_loaded_fallback`, tested against
 /// `tests::FakeServiceEnv`).
 /// What: one operation — force-start a member's launchd job — returning whether
 /// it succeeded.

--- a/crates/trusty-memory/changelog.d/5759-linux-only-broken-doc-links.md
+++ b/crates/trusty-memory/changelog.d/5759-linux-only-broken-doc-links.md
@@ -1,0 +1,4 @@
+Fixed
+- Stopped the doctor `checks` module doc from linking to the macOS-gated
+  `check_launchd_plist`, which rustdoc cannot resolve on Linux. docs.rs builds
+  on Linux once per release and never rebuilds.

--- a/crates/trusty-memory/src/commands/doctor/checks.rs
+++ b/crates/trusty-memory/src/commands/doctor/checks.rs
@@ -4,7 +4,7 @@
 //! implementations live in their own focused file, separate from the
 //! audit data types and the command entry-points.
 //! What: exports check functions called by [`super::handle_doctor`]:
-//! [`check_fastembed_cache`], [`check_launchd_plist`] (macOS),
+//! [`check_fastembed_cache`], `check_launchd_plist` (macOS),
 //! [`check_daemon_health`], and [`check_stale_palace_locks`]. Also exports
 //! private helpers used by the tests in `mod.rs`.
 //! Test: individual check helpers are exercised by unit tests in `mod.rs`;

--- a/crates/trusty-memory/src/commands/service.rs
+++ b/crates/trusty-memory/src/commands/service.rs
@@ -5,7 +5,7 @@
 //! `launchctl` for diagnostics. Wrapping the plist mechanics in `service`
 //! subcommands keeps users from having to hand-edit XML. This mirrors the
 //! pattern used by `trusty-search service`, sharing the
-//! [`trusty_common::launchd`] implementation so the two tools cannot drift.
+//! `trusty_common::launchd` implementation so the two tools cannot drift.
 //! What: macOS routes to `service_install` / `service_start` / `service_stop`
 //! / `service_logs`. Non-macOS prints a "not supported" error and exits 1.
 //!

--- a/crates/trusty-mpm/changelog.d/5759-linux-only-broken-doc-links.md
+++ b/crates/trusty-mpm/changelog.d/5759-linux-only-broken-doc-links.md
@@ -1,0 +1,5 @@
+Fixed
+- Stopped four `spawn_disclaim` doc comments from linking into the macOS-gated
+  `macos` submodule (`resolve_disclaim_fn`, `spawn_stderr_piped_disclaimed`,
+  `spawn_stdout_piped_disclaimed`, `wait_for`), which rustdoc cannot resolve on
+  Linux. docs.rs builds on Linux once per release and never rebuilds.

--- a/crates/trusty-mpm/src/core/spawn_disclaim/mod.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/mod.rs
@@ -418,7 +418,7 @@ pub use pane::{PANE_DISCLAIM_SUBCOMMAND, disclaim_pane_command};
 /// whether managed panes can actually disclaim — a future macOS that dropped
 /// the SPI would silently degrade the whole fix to a no-op, and that should be
 /// surfaced, not invisible.
-/// What: `true` on macOS when [`macos::resolve_disclaim_fn`] finds the symbol;
+/// What: `true` on macOS when `macos::resolve_disclaim_fn` finds the symbol;
 /// `false` on every non-macOS build (there is no TCC there).
 /// Test: `daemon::doctor`'s `tcc_taint_*` checks fold this into the verdict;
 /// direct coverage lives in the capture/status/piped spawn tests that only

--- a/crates/trusty-mpm/src/core/spawn_disclaim/stderr_piped.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/stderr_piped.rs
@@ -1,7 +1,7 @@
 //! Synchronous piped-stderr disclaimed spawn — the public, platform-agnostic
 //! half of `macos::spawn_stderr_piped_disclaimed` (the macOS
 //! `posix_spawn`-based implementation lives in `macos::stderr_piped`; this
-//! file holds the public API, the non-macOS/[`DISABLE_ENV`] fallback, and the
+//! file holds the public API, the non-macOS/[`super::DISABLE_ENV`] fallback, and the
 //! shared [`StderrPipedSpawn`] return type both paths produce).
 //!
 //! Why: `provisioner::clone_progress::clone_with_progress` reads `git clone
@@ -16,7 +16,7 @@
 //! lifecycle handle; [`disclaimed_stderr_piped_spawn`] spawns `cmd` with
 //! stdout discarded to `/dev/null`, stderr piped, and stdin inherited,
 //! disclaiming TCC responsibility on macOS exactly like
-//! [`super::disclaimed_output`]. On non-macOS (or with [`DISABLE_ENV`] set)
+//! [`super::disclaimed_output`]. On non-macOS (or with [`super::DISABLE_ENV`] set)
 //! it sets the same stdio shape on `cmd` and delegates to `cmd.spawn()`,
 //! taking the child's stderr pipe exactly as the pre-fix code did.
 //! Test: `tests::disclaimed_stderr_piped_spawn_streams_and_waits`,
@@ -101,7 +101,7 @@ impl StderrPipedSpawn {
 /// spawns via `posix_spawnp` with a `/dev/null` stdout file action, a piped
 /// stderr, no stdin file action (inherited — matches the pre-existing
 /// `Command`'s implicit default), and the disclaim attribute when the
-/// private SPI resolves. On non-macOS (or with [`DISABLE_ENV`] set) sets
+/// private SPI resolves. On non-macOS (or with [`super::DISABLE_ENV`] set) sets
 /// `cmd.stdout(Stdio::null()).stderr(Stdio::piped())` and delegates to
 /// `cmd.spawn()`, taking the child's stderr pipe exactly as the pre-fix code
 /// did.

--- a/crates/trusty-mpm/src/core/spawn_disclaim/stderr_piped.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/stderr_piped.rs
@@ -1,5 +1,5 @@
 //! Synchronous piped-stderr disclaimed spawn — the public, platform-agnostic
-//! half of [`macos::spawn_stderr_piped_disclaimed`] (the macOS
+//! half of `macos::spawn_stderr_piped_disclaimed` (the macOS
 //! `posix_spawn`-based implementation lives in `macos::stderr_piped`; this
 //! file holds the public API, the non-macOS/[`DISABLE_ENV`] fallback, and the
 //! shared [`StderrPipedSpawn`] return type both paths produce).
@@ -68,7 +68,7 @@ impl StderrPipedSpawn {
     /// the child exits or closes fd 2 itself, so waiting before draining a
     /// large-output child can deadlock on a full pipe buffer.
     /// What: reaps the native `Child` or, on the macOS-disclaimed path, the
-    /// raw pid via [`macos::wait_for`].
+    /// raw pid via `macos::wait_for`.
     /// Test: see [`disclaimed_stderr_piped_spawn`].
     pub fn wait(&mut self) -> std::io::Result<ExitStatus> {
         match &mut self.handle {

--- a/crates/trusty-mpm/src/core/spawn_disclaim/stdout_piped.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/stdout_piped.rs
@@ -1,7 +1,7 @@
 //! Synchronous piped-stdout disclaimed spawn — the public, platform-agnostic
 //! half of `macos::spawn_stdout_piped_disclaimed` (the macOS
 //! `posix_spawn`-based implementation lives in `macos::stdout_piped`; this
-//! file holds the public API, the non-macOS/[`DISABLE_ENV`] fallback, and the
+//! file holds the public API, the non-macOS/[`super::DISABLE_ENV`] fallback, and the
 //! shared [`StdoutPipedSpawn`] return type both paths produce).
 //!
 //! Why: `formatters::info_box::probes::run_git_log` (in the `tm` binary)
@@ -16,7 +16,7 @@
 //! [`disclaimed_stdout_piped_spawn`] spawns `cmd` with stdout piped, stderr
 //! discarded to `/dev/null`, and stdin inherited, disclaiming TCC
 //! responsibility on macOS exactly like [`super::disclaimed_output`]. On
-//! non-macOS (or with [`DISABLE_ENV`] set) it sets the same stdio shape on
+//! non-macOS (or with [`super::DISABLE_ENV`] set) it sets the same stdio shape on
 //! `cmd` and delegates to `cmd.spawn()`, exposing `Child::id()` exactly as
 //! the pre-fix code did.
 //! Test: `tests::disclaimed_stdout_piped_spawn_captures_and_waits`,
@@ -106,7 +106,7 @@ impl StdoutPipedSpawn {
 /// `posix_spawnp` with a piped stdout, a `/dev/null` stderr file action, no
 /// stdin file action (inherited), and the disclaim attribute when the
 /// private SPI resolves — returning the pid immediately, unwaited. On
-/// non-macOS (or with [`DISABLE_ENV`] set) sets
+/// non-macOS (or with [`super::DISABLE_ENV`] set) sets
 /// `cmd.stdout(Stdio::piped()).stderr(Stdio::null())` and delegates to
 /// `cmd.spawn()`, exposing `Child::id()` exactly as the pre-fix code did.
 /// Test: `tests::disclaimed_stdout_piped_spawn_captures_and_waits`,

--- a/crates/trusty-mpm/src/core/spawn_disclaim/stdout_piped.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/stdout_piped.rs
@@ -1,5 +1,5 @@
 //! Synchronous piped-stdout disclaimed spawn — the public, platform-agnostic
-//! half of [`macos::spawn_stdout_piped_disclaimed`] (the macOS
+//! half of `macos::spawn_stdout_piped_disclaimed` (the macOS
 //! `posix_spawn`-based implementation lives in `macos::stdout_piped`; this
 //! file holds the public API, the non-macOS/[`DISABLE_ENV`] fallback, and the
 //! shared [`StdoutPipedSpawn`] return type both paths produce).

--- a/crates/trusty-search/changelog.d/5759-linux-only-broken-doc-links.md
+++ b/crates/trusty-search/changelog.d/5759-linux-only-broken-doc-links.md
@@ -1,0 +1,5 @@
+Fixed
+- Stopped `memguard`'s doc comment from linking to
+  `trusty_common::sys_metrics::physical_footprint_mb`, which is macOS-gated and
+  so unresolvable on Linux. The link is cross-crate, which is why repairing
+  trusty-common's own six links did not fix it.

--- a/crates/trusty-search/src/core/memguard.rs
+++ b/crates/trusty-search/src/core/memguard.rs
@@ -290,7 +290,7 @@ pub fn current_rss_mb() -> Option<u64> {
 /// figure that excludes pages the memory compressor currently holds. A daemon
 /// with several GB compressed can read as tens of MB, so `TRUSTY_MEMORY_LIMIT_MB`
 /// never trips. On macOS this now tries
-/// [`trusty_common::sys_metrics::physical_footprint_mb`] (the `ri_phys_footprint`
+/// `trusty_common::sys_metrics::physical_footprint_mb` (the `ri_phys_footprint`
 /// counter `vmmap`/`footprint`/Activity Monitor report) first, falling back to
 /// the `sysinfo` reading if the `libproc` call fails (e.g. cross-user
 /// permission denial sampling a foreign pid).

--- a/scripts/check_rustdoc_links.sh
+++ b/scripts/check_rustdoc_links.sh
@@ -38,19 +38,54 @@
 #   every diagnostic to a span with no heuristics; the checker below asserts
 #   that it accounted for every one it saw.
 #
-# FAIL-CLOSED BEHAVIOUR. Five distinct ways this refuses to report success:
+# FAIL-CLOSED BEHAVIOUR. Six distinct ways this refuses to report success:
 #   1. A non-lint compile error (the crate does not build) FAILS, and says so
 #      separately from a link count — "your docs are fine" is not a thing to say
 #      about a crate that did not compile.
-#   2. A run that parsed ZERO compiler messages while cargo exited nonzero FAILS
-#      as a vacuous scan. Zero findings and zero examined are different facts.
-#   3. A crate that cargo never documented FAILS, even though its count is 0.
+#   2. A run where rustdoc executed for ZERO crates FAILS as a vacuous scan,
+#      whatever cargo's exit status was. See "WHAT COUNTS AS EXAMINED" below.
+#   3. A crate whose doc unit was served from cache FAILS by name: rustdoc was
+#      never invoked for it, so it could not have produced a diagnostic.
+#   4. A crate that cargo never documented FAILS, even though its count is 0.
 #      An absent crate's zero is not evidence about its links; this is the
 #      "0 compared must never print PASS" invariant CHECK 5 of
 #      preflight-publish.sh learned the hard way.
-#   4. A diagnostic whose span this script cannot attribute to a crate FAILS
+#   5. A diagnostic whose span this script cannot attribute to a crate FAILS
 #      rather than being dropped.
-#   5. A crate with findings but no baseline row FAILS.
+#   6. A crate with findings but no baseline row FAILS.
+#
+# WHAT COUNTS AS EXAMINED — the #5620 shape, third instance.
+#   Two things had to be true for a broken link to be counted, and the gate
+#   checked neither. First, the old vacuous-scan guard fired only on
+#   `parsed_messages == 0 AND cargo_rc != 0`: it asked whether cargo had
+#   COMPLAINED, not whether rustdoc had RUN. Second, a warm target dir makes
+#   `cargo doc` a no-op — cargo re-emits every `compiler-artifact` with
+#   `"fresh": true` and invokes rustdoc for none of them. A cached run therefore
+#   exits 0 with an empty diagnostic stream, satisfies neither half of the
+#   guard, and prints a pass over nothing examined.
+#
+#   The diagnostic count cannot carry this check, because a genuinely clean tree
+#   also has zero diagnostics. The evidence is the ARTIFACT: a `compiler-artifact`
+#   whose filenames point into `target/doc/**/index.html` and whose `fresh` is
+#   false means rustdoc actually executed for that crate. Zero of those is a
+#   vacuous scan; the run also deletes the `doc-*` fingerprints up front so a
+#   warm tree produces real evidence rather than a refusal.
+#
+#   Counting the wrong artifact was the other half of the illusion: every
+#   workspace member is COMPILED as well as documented, and the rlib artifacts
+#   outnumber the rustdoc ones. Scoring those is how a run in which rustdoc
+#   executed for 3 crates reported "25 crate(s) documented".
+#
+# KNOWN LIMIT — features this gate cannot see.
+#   `cargo doc` resolves DEFAULT features only, so a module behind a non-default
+#   feature is never documented and its links are never checked. trusty-common's
+#   `docgen` is the worked example: it is enabled only from `[dev-dependencies]`,
+#   which `cargo doc` does not resolve, so `target/doc/trusty_common/docgen/`
+#   is never created and two bare links lived there until `check_contracts.sh`
+#   (which builds all 42 features) surfaced them. `--all-features` is not
+#   available workspace-wide — trusty-common's three `embedder-*` ORT variants
+#   are mutually exclusive. So this gate is sound for what it examines and
+#   SILENT about the rest; it is not a whole-crate clean-tree assertion.
 #
 # Exit codes: 0 = at or below baseline for every crate. 1 = a crate regressed,
 #   or an unbaselined crate has findings. 3 = the gate could not compute a
@@ -59,22 +94,22 @@
 #   "nothing was checked", the distinction #5289 added to the semver gate.
 #   2 = usage error.
 #
-# Test: verified by construction against the real workspace at e39183c3 —
-#   `--json` accepts a captured cargo stream, which is how the parser was
-#   cross-checked (852 diagnostics attributed, 0 unattributable) and how the
-#   NOT-DOCUMENTED branch was caught firing wrongly on crates whose doc build
-#   FAILED and therefore emit no `compiler-artifact`. A fixture-driven self-test
-#   covering the remaining fail-closed branches is NOT yet written; the `--json`
-#   entry point exists so one can be added without a doc build.
+# Test: `scripts/check_rustdoc_links_selftest.sh` drives every fail-closed
+#   branch through the `--json` entry point with synthetic cargo streams, so it
+#   needs no doc build. Its load-bearing case is `cached_no_op_is_not_a_pass`:
+#   a stream of exclusively `fresh: true` doc artifacts with zero diagnostics
+#   and cargo exit 0 — the exact shape that printed a pass — must exit 3.
 
 set -euo pipefail
 
 usage() {
-  echo "usage: scripts/check_rustdoc_links.sh [--update-baseline] [--json <file>]" >&2
+  echo "usage: scripts/check_rustdoc_links.sh [--update-baseline] [--json <file>] [--cargo-rc <n>]" >&2
   echo "       --update-baseline   rewrite the baseline from this run's counts" >&2
   echo "       --json <file>       score a previously captured JSON stream" >&2
   echo "                           instead of running cargo doc (used by the" >&2
   echo "                           self-test)" >&2
+  echo "       --cargo-rc <n>      with --json, the cargo exit status to score" >&2
+  echo "                           the stream against (default 0)" >&2
   exit 2
 }
 
@@ -82,14 +117,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
-BASELINE="${REPO_ROOT}/scripts/rustdoc-link-baseline.tsv"
+# BASELINE_OVERRIDE lets the self-test score fixtures against a baseline it
+# controls rather than whatever the real one says this week.
+BASELINE="${BASELINE_OVERRIDE:-${REPO_ROOT}/scripts/rustdoc-link-baseline.tsv}"
 UPDATE=0
 JSON_IN=""
+FAKE_RC=0
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --update-baseline) UPDATE=1; shift ;;
     --json) JSON_IN="${2:-}"; [ -n "$JSON_IN" ] || usage; shift 2 ;;
+    --cargo-rc) FAKE_RC="${2:-}"; [ -n "$FAKE_RC" ] || usage; shift 2 ;;
     -h|--help) usage ;;
     *) echo "check_rustdoc_links: unknown argument: $1" >&2; usage ;;
   esac
@@ -109,8 +148,21 @@ if [ -n "$JSON_IN" ]; then
   [ -f "$JSON_IN" ] || { echo "check_rustdoc_links: no such file: $JSON_IN" >&2; exit 2; }
   cp "$JSON_IN" "$TMP_JSON"
   : > "$TMP_ERR"
-  CARGO_RC=0
+  CARGO_RC="$FAKE_RC"
 else
+  # Force rustdoc to actually RUN. cargo's freshness cache makes `cargo doc` a
+  # no-op against a warm target dir: it re-emits every `compiler-artifact` with
+  # `"fresh": true` and invokes rustdoc for none of them, so the run emits ZERO
+  # diagnostics and the gate scored an empty stream as "0 broken links". That is
+  # the #5620 shape — a PASS printed over nothing examined — and it is how 26
+  # real Linux-only broken links read as green locally for a week.
+  #
+  # Deleting only the `doc-*` fingerprints invalidates the rustdoc units and
+  # NOTHING else: dependency compilation stays cached, so this costs a rustdoc
+  # pass (~40 s warm) rather than a full rebuild. CI needs it too — `rust-cache`
+  # restores a warm target dir there, so a cached no-op is not a local-only risk.
+  find "${CARGO_TARGET_DIR:-target}" -path '*/.fingerprint/*' -name 'doc-*' -delete 2>/dev/null || true
+
   # --keep-going is what makes the inventory complete. Without it cargo stops at
   # the first crate whose docs fail, and the run reports only the crates it
   # happened to reach: the same command without it documented 4 of 24 crates and
@@ -150,7 +202,9 @@ HEADER = """# Per-crate broken intra-doc link baseline (scripts/check_rustdoc_li
 """
 
 counts = collections.Counter()
-documented = set()
+documented = set()     # rustdoc RAN for these crates (fresh=false doc artifact)
+cached = set()         # rustdoc was SKIPPED for these (fresh=true doc artifact)
+findings = []          # (crate, file:line, message) for every broken link
 hard_errors = []       # non-lint errors: the crate did not build
 unattributable = []    # a diagnostic this script could not place
 parsed_messages = 0
@@ -163,6 +217,16 @@ def crate_of(path):
         return parts[1]
     return None
 
+def is_doc_artifact(filenames):
+    """A rustdoc output, as opposed to a compiled rlib for a dependency.
+
+    `cargo doc` emits `compiler-artifact` for BOTH: every workspace member is
+    also COMPILED (members depend on each other), and those rlib artifacts
+    outnumber the rustdoc ones. Counting them is what let a fully cached run
+    report "25 crate(s) documented" while rustdoc ran for three.
+    """
+    return any("/doc/" in f and f.endswith("index.html") for f in filenames)
+
 with open(json_path) as fh:
     for line in fh:
         line = line.strip()
@@ -174,15 +238,17 @@ with open(json_path) as fh:
             continue
         reason = m.get("reason")
 
-        # Which crates cargo actually documented. Used for the fail-closed
-        # "a crate we never built cannot be reported as clean" check.
+        # Which crates rustdoc actually RAN for. `fresh` is the whole point:
+        # a cached unit re-emits this message without invoking rustdoc, so it
+        # cannot have produced a diagnostic and its zero is not evidence.
         if reason == "compiler-artifact":
+            if not is_doc_artifact(m.get("filenames") or []):
+                continue
             tgt = (m.get("target") or {})
-            name = tgt.get("name")
             src = tgt.get("src_path") or ""
             c = crate_of(os.path.relpath(src, os.getcwd())) if src.startswith("/") else crate_of(src)
             if c:
-                documented.add(c)
+                (cached if m.get("fresh") else documented).add(c)
             continue
 
         if reason != "compiler-message":
@@ -220,6 +286,11 @@ with open(json_path) as fh:
         )
         if is_link_lint:
             counts[crate] += 1
+            # Name every broken link. Reporting only a per-crate count leaves an
+            # engineer with a number and no way to act on it — the Linux-only
+            # links of #5753 had to be recovered by reading raw CI logs.
+            loc = f'{primary[0]["file_name"]}:{primary[0].get("line_start", "?")}'
+            findings.append((crate, loc, text))
         else:
             hard_errors.append(f"{crate}: {text}")
 
@@ -249,11 +320,21 @@ if os.path.exists(baseline_path):
                 continue
 
 if update:
+    # Refuse to record a baseline from a run that examined nothing. #5744 drove
+    # this baseline to zero from a macOS measurement that had already gone
+    # vacuous, which is what made 26 broken links invisible: a bad baseline
+    # outlives the run that wrote it.
+    if not documented:
+        print("FAIL\tVACUOUS-SCAN\trustdoc ran for ZERO crates — refusing to "
+              f"write a baseline from a run that examined nothing ({len(cached)} "
+              "crate(s) served from cache)")
+        sys.exit(3)
     with open(baseline_path, "w") as fh:
         fh.write(HEADER)
         for crate in sorted(counts):
             fh.write(f"{crate}\t{counts[crate]}\n")
-    print(f"BASELINE-UPDATED\t{len(counts)}")
+    print(f"BASELINE-UPDATED\t{len(counts)} crate(s) with findings, "
+          f"{len(documented)} examined")
     sys.exit(0)
 
 failures, notes = [], []
@@ -264,10 +345,30 @@ if hard_errors:
         failures.append(f"BUILD-ERROR\t{e}")
 
 # ---- FAIL CLOSED 2: vacuous scan ---------------------------------------
-if parsed_messages == 0 and cargo_rc != 0:
+# POSITIVE EVIDENCE, not an exit code. The old test was
+# `parsed_messages == 0 and cargo_rc != 0`, which asked whether cargo COMPLAINED
+# rather than whether rustdoc RAN. A fully cached `cargo doc` exits 0 and emits
+# no diagnostics, so it satisfied neither half and scored as a clean pass over
+# an empty stream — 26 real broken links read as "0 broken" for a week.
+#
+# The evidence that a scan happened is a crate rustdoc actually re-documented.
+# Zero of those is a vacuous scan whatever cargo's status was, and a clean tree
+# legitimately has zero DIAGNOSTICS, so the diagnostic count can never carry
+# this check.
+if not documented:
     failures.append(
-        "VACUOUS-SCAN\tcargo doc exited "
-        f"{cargo_rc} but this gate parsed ZERO diagnostics — it examined nothing"
+        "VACUOUS-SCAN\trustdoc ran for ZERO crates "
+        f"({len(cached)} served from cache, cargo exited {cargo_rc}) — this gate "
+        "examined nothing and cannot report a verdict"
+    )
+
+# ---- FAIL CLOSED 2b: a partially cached run ----------------------------
+# A crate whose doc unit was cached emitted no diagnostics because rustdoc was
+# never invoked for it, not because its links are sound.
+for crate in sorted(cached - documented):
+    failures.append(
+        f"NOT-EXAMINED\t{crate}: rustdoc was served from cache, so its zero "
+        "findings are not evidence — delete target/**/.fingerprint/**/doc-* and rerun"
     )
 
 # ---- FAIL CLOSED 4: unattributable diagnostics -------------------------
@@ -317,14 +418,18 @@ for crate in sorted(baseline):
 
 total = sum(counts.values())
 base_total = sum(baseline.values())
-print(f"SUMMARY\t{len(documented)} crate(s) documented, {total} broken link(s), "
-      f"baseline {base_total}, {parsed_messages} diagnostic(s) examined")
+print(f"SUMMARY\t{len(documented)} crate(s) examined by rustdoc, {total} broken "
+      f"link(s), baseline {base_total}, {parsed_messages} diagnostic(s) examined"
+      + (f", {len(cached)} crate(s) SERVED FROM CACHE" if cached else ""))
+for crate, loc, text in findings:
+    print(f"LINK\t{crate}\t{loc}\t{text}")
 for n in notes:
     print(f"NOTE\t{n}")
 for f in failures:
     print(f"FAIL\t{f}")
 
-if any(f.startswith(("BUILD-ERROR", "VACUOUS-SCAN", "UNATTRIBUTABLE", "NOT-DOCUMENTED")) for f in failures):
+if any(f.startswith(("BUILD-ERROR", "VACUOUS-SCAN", "NOT-EXAMINED", "UNATTRIBUTABLE", "NOT-DOCUMENTED"))
+       for f in failures):
     sys.exit(3)
 sys.exit(1 if failures else 0)
 PY

--- a/scripts/check_rustdoc_links_selftest.sh
+++ b/scripts/check_rustdoc_links_selftest.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# check_rustdoc_links_selftest.sh — fail-closed fixtures for the broken
+# intra-doc link gate, scripts/check_rustdoc_links.sh.
+#
+# Why: the gate printed
+#     SUMMARY  25 crate(s) documented, 0 broken link(s), baseline 0, 0 examined
+#   and exited 0 on a tree carrying 26 broken links. Nothing in the gate was
+#   observed rejecting a vacuous run, and a scan that has only ever been seen
+#   passing is indistinguishable from one that returns 0 unconditionally. That
+#   is the #5620 shape for the third time in this repo, so the case that pins
+#   it — `cached-no-op` — is the reason this file exists.
+#
+#   The three vacuous fixtures differ only in what the old guard would have
+#   made of them, which is the point:
+#     - cached-no-op       cargo exit 0, zero diagnostics, every doc artifact
+#                          `fresh: true`. The old guard needed cargo_rc != 0,
+#                          so it passed this. THE REGRESSION CASE.
+#     - partial-cache      one crate re-documented, one served from cache. The
+#                          cached crate's zero is not evidence and must be named.
+#     - rlib-only          artifacts exist for workspace crates but none is a
+#                          rustdoc output. Counting these is what produced
+#                          "25 crate(s) documented" from 3 real rustdoc runs.
+#
+#   `clean-fresh` is the necessary counterweight: a genuinely clean tree has
+#   ZERO diagnostics too, so a gate that demanded diagnostics as proof-of-life
+#   could never go green. Positive evidence has to come from the artifact, and
+#   this case proves the distinction is actually drawn.
+#
+# What: feeds synthetic cargo JSON streams to the gate's `--json` entry point
+#   (with `--cargo-rc` to set the exit status being scored) against an empty
+#   baseline, asserting both the exit status and the finding code on stdout.
+#   Asserting the CODE stops a fixture from passing for the wrong reason — a
+#   vacuous fixture that fails as UNBASELINED rather than VACUOUS-SCAN is not
+#   testing what it claims to.
+#
+#   No cargo doc build is involved, so this runs in well under a second.
+#
+# Test: this IS the test. Run directly:
+#   bash scripts/check_rustdoc_links_selftest.sh
+#
+# Portability: POSIX tools only; bash 3.2 (macOS) and bash 5 (Linux CI).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$SCRIPT_DIR/check_rustdoc_links.sh"
+FIXTURE_DIR="$SCRIPT_DIR/test-data/rustdoc-links"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/rustdoc-links-selftest.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# An empty baseline: every crate must have zero findings.
+EMPTY_BASELINE="$WORK/empty-baseline.tsv"
+printf '# empty baseline for the self-test\n' > "$EMPTY_BASELINE"
+
+TAB="$(printf '\t')"
+
+# fixture<TAB>cargo_rc<TAB>expected_exit<TAB>expected_code ("-" when exit 0)
+CASES="cached-no-op.json${TAB}0${TAB}3${TAB}VACUOUS-SCAN
+cached-no-op.json${TAB}101${TAB}3${TAB}VACUOUS-SCAN
+rlib-only.json${TAB}0${TAB}3${TAB}VACUOUS-SCAN
+partial-cache.json${TAB}0${TAB}3${TAB}NOT-EXAMINED
+clean-fresh.json${TAB}0${TAB}0${TAB}-
+broken-link.json${TAB}101${TAB}1${TAB}UNBASELINED
+build-error.json${TAB}101${TAB}3${TAB}BUILD-ERROR
+unattributable.json${TAB}101${TAB}3${TAB}UNATTRIBUTABLE"
+
+fail=0
+run=0
+
+while IFS="$TAB" read -r fixture cargo_rc expected_exit expected_code; do
+  [ -n "$fixture" ] || continue
+  run=$((run + 1))
+  fixture_path="$FIXTURE_DIR/$fixture"
+  if [ ! -f "$fixture_path" ]; then
+    echo "FAIL  $fixture (rc=$cargo_rc): fixture not found at $fixture_path"
+    fail=1
+    continue
+  fi
+
+  out="$WORK/out.txt"
+  actual_exit=0
+  BASELINE_OVERRIDE="$EMPTY_BASELINE" \
+    bash "$GATE" --json "$fixture_path" --cargo-rc "$cargo_rc" \
+    > "$out" 2>&1 || actual_exit=$?
+
+  if [ "$actual_exit" != "$expected_exit" ]; then
+    echo "FAIL  $fixture (cargo_rc=$cargo_rc): expected exit $expected_exit, got $actual_exit"
+    sed 's/^/        /' "$out"
+    fail=1
+    continue
+  fi
+
+  if [ "$expected_code" != "-" ]; then
+    if ! grep -q "$expected_code" "$out"; then
+      echo "FAIL  $fixture (cargo_rc=$cargo_rc): exit $actual_exit correct, but '$expected_code' not reported"
+      sed 's/^/        /' "$out"
+      fail=1
+      continue
+    fi
+  fi
+
+  echo "ok    $fixture (cargo_rc=$cargo_rc) -> exit $actual_exit ${expected_code}"
+done <<EOF
+$CASES
+EOF
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "check_rustdoc_links_selftest: FAILED ($run case(s) run)"
+  exit 1
+fi
+echo "check_rustdoc_links_selftest: all $run case(s) passed"

--- a/scripts/test-data/rustdoc-links/broken-link.json
+++ b/scripts/test-data/rustdoc-links/broken-link.json
@@ -1,0 +1,5 @@
+{"reason":"compiler-artifact","fresh":false,"target":{"name":"trusty_common","kind":["lib"],"src_path":"crates/trusty-common/src/lib.rs"},"filenames":["target/doc/trusty_common/index.html"]}
+{"reason":"compiler-message","message":{"level":"error","message":"unresolved link to `physical_footprint_mb`","code":{"code":"rustdoc::broken_intra_doc_links"},"spans":[{"is_primary":true,"file_name":"crates/trusty-common/src/sys_metrics.rs","line_start":82}]}}
+{"reason":"compiler-message","message":{"level":"error","message":"unresolved link to `launchd`","code":{"code":"rustdoc::broken_intra_doc_links"},"spans":[{"is_primary":true,"file_name":"crates/trusty-common/src/lib.rs","line_start":180}]}}
+{"reason":"compiler-message","message":{"level":"error","message":"could not document `trusty-common`","code":null,"spans":[]}}
+{"reason":"build-finished","success":false}

--- a/scripts/test-data/rustdoc-links/build-error.json
+++ b/scripts/test-data/rustdoc-links/build-error.json
@@ -1,0 +1,3 @@
+{"reason":"compiler-artifact","fresh":false,"target":{"name":"trusty_common","kind":["lib"],"src_path":"crates/trusty-common/src/lib.rs"},"filenames":["target/doc/trusty_common/index.html"]}
+{"reason":"compiler-message","message":{"level":"error","message":"cannot find function `resolve_binary` in this scope","code":{"code":"E0425"},"spans":[{"is_primary":true,"file_name":"crates/trusty-common/src/bin_resolve.rs","line_start":118}]}}
+{"reason":"build-finished","success":false}

--- a/scripts/test-data/rustdoc-links/cached-no-op.json
+++ b/scripts/test-data/rustdoc-links/cached-no-op.json
@@ -1,0 +1,5 @@
+{"reason":"compiler-artifact","fresh":true,"target":{"name":"trusty_common","kind":["lib"],"src_path":"crates/trusty-common/src/lib.rs"},"filenames":["target/doc/trusty_common/index.html"]}
+{"reason":"compiler-artifact","fresh":true,"target":{"name":"trusty_search","kind":["lib"],"src_path":"crates/trusty-search/src/lib.rs"},"filenames":["target/doc/trusty_search/index.html"]}
+{"reason":"compiler-artifact","fresh":true,"target":{"name":"trusty-installer","kind":["bin"],"src_path":"crates/trusty-installer/src/main.rs"},"filenames":["target/doc/trusty_installer/index.html"]}
+{"reason":"compiler-artifact","fresh":true,"target":{"name":"serde","kind":["lib"],"src_path":"/home/runner/.cargo/registry/src/serde-1.0.0/src/lib.rs"},"filenames":["target/debug/deps/libserde-1111.rmeta"]}
+{"reason":"build-finished","success":true}

--- a/scripts/test-data/rustdoc-links/clean-fresh.json
+++ b/scripts/test-data/rustdoc-links/clean-fresh.json
@@ -1,0 +1,5 @@
+{"reason":"compiler-artifact","fresh":false,"target":{"name":"trusty_common","kind":["lib"],"src_path":"crates/trusty-common/src/lib.rs"},"filenames":["target/doc/trusty_common/index.html"]}
+{"reason":"compiler-artifact","fresh":false,"target":{"name":"trusty_search","kind":["lib"],"src_path":"crates/trusty-search/src/lib.rs"},"filenames":["target/doc/trusty_search/index.html"]}
+{"reason":"compiler-artifact","fresh":true,"target":{"name":"serde","kind":["lib"],"src_path":"/home/runner/.cargo/registry/src/serde-1.0.0/src/lib.rs"},"filenames":["target/debug/deps/libserde-1111.rmeta"]}
+{"reason":"compiler-message","message":{"level":"warning","message":"unused import: `std::fmt`","code":{"code":"unused_imports"},"spans":[{"is_primary":true,"file_name":"crates/trusty-common/src/lib.rs","line_start":9}]}}
+{"reason":"build-finished","success":true}

--- a/scripts/test-data/rustdoc-links/partial-cache.json
+++ b/scripts/test-data/rustdoc-links/partial-cache.json
@@ -1,0 +1,3 @@
+{"reason":"compiler-artifact","fresh":false,"target":{"name":"trusty_common","kind":["lib"],"src_path":"crates/trusty-common/src/lib.rs"},"filenames":["target/doc/trusty_common/index.html"]}
+{"reason":"compiler-artifact","fresh":true,"target":{"name":"trusty_search","kind":["lib"],"src_path":"crates/trusty-search/src/lib.rs"},"filenames":["target/doc/trusty_search/index.html"]}
+{"reason":"build-finished","success":true}

--- a/scripts/test-data/rustdoc-links/rlib-only.json
+++ b/scripts/test-data/rustdoc-links/rlib-only.json
@@ -1,0 +1,4 @@
+{"reason":"compiler-artifact","fresh":false,"target":{"name":"trusty_common","kind":["lib"],"src_path":"crates/trusty-common/src/lib.rs"},"filenames":["target/debug/deps/libtrusty_common-aaaa.rmeta"]}
+{"reason":"compiler-artifact","fresh":false,"target":{"name":"trusty_search","kind":["lib"],"src_path":"crates/trusty-search/src/lib.rs"},"filenames":["target/debug/deps/libtrusty_search-bbbb.rmeta"]}
+{"reason":"compiler-artifact","fresh":false,"target":{"name":"build-script-build","kind":["custom-build"],"src_path":"crates/trusty-search/build.rs"},"filenames":["target/debug/build/trusty-search-cccc/build-script-build"]}
+{"reason":"build-finished","success":true}

--- a/scripts/test-data/rustdoc-links/unattributable.json
+++ b/scripts/test-data/rustdoc-links/unattributable.json
@@ -1,0 +1,3 @@
+{"reason":"compiler-artifact","fresh":false,"target":{"name":"trusty_common","kind":["lib"],"src_path":"crates/trusty-common/src/lib.rs"},"filenames":["target/doc/trusty_common/index.html"]}
+{"reason":"compiler-message","message":{"level":"error","message":"unresolved link to `SomeItem`","code":{"code":"rustdoc::broken_intra_doc_links"},"spans":[{"is_primary":true,"file_name":"website/src/lib/generated.rs","line_start":4}]}}
+{"reason":"build-finished","success":false}


### PR DESCRIPTION
Gate 1 has been red on `main` since #5744. Two linked defects; the gate is fixed
first, because until it is you cannot verify the link fixes.

## 1. The gate passed over a scan that examined nothing

Locally it reported `25 crate(s) documented, 0 broken link(s), 0 examined` and
exited 0, on the commit where CI counted 20 broken links.

Two defects stacked. The vacuous-scan guard fired only on
`parsed_messages == 0 AND cargo_rc != 0` — it asked whether cargo had
COMPLAINED, not whether rustdoc had RUN. And a warm target dir makes `cargo doc`
a no-op: cargo re-emits every `compiler-artifact` with `"fresh": true` and
invokes rustdoc for none. A cached run exits 0 with an empty stream, satisfies
neither half of the guard, and prints a pass over nothing. The #5620 shape, third
instance.

The crate count measured the wrong artifact: workspace members are compiled as
well as documented, and rlib artifacts outnumber rustdoc ones. Measured here —
38 doc units, 35 served from cache, so "25 documented" came from a run where
rustdoc executed for three.

A diagnostic count cannot carry this check, because a clean tree has zero
diagnostics too. Positive evidence is now the artifact: `fresh: false` on a
`target/doc/**/index.html` artifact means rustdoc actually ran. Zero of those
fails whatever cargo's status was; a cached crate fails by name. The run deletes
`doc-*` fingerprints up front — invalidating rustdoc units and nothing else, so
dependency compilation stays cached. CI needs this too: `rust-cache` restores a
warm target dir there.

Also: `--update-baseline` refuses to write from a vacuous run (#5744 drove the
baseline to zero from an already-vacuous macOS measurement), and the gate now
NAMES each broken link — #5753's had to be recovered from raw CI logs.

## 2. The 20 links, all macOS-gated targets referenced from ungated docs

trusty-installer 14, trusty-mpm 4, trusty-memory 1, trusty-search 1.
trusty-common's 6 landed in #5753.

Each becomes a plain code span, the treatment #5753 established: the reference
reads identically, it just stops claiming to be a hyperlink that resolves on one
platform only. No prose removed, and every link whose target exists on both
platforms is left live — only the macOS-gated names in a given sentence change.

`trusty-search`'s single link is cross-crate
(`trusty_common::sys_metrics::physical_footprint_mb`), which is why fixing
trusty-common did not fix it.

## Verification

`cargo doc --target x86_64-unknown-linux-gnu` cannot run on the dev machine —
`ring`'s build script needs `x86_64-linux-gnu-gcc`, which is not installed. So
the macOS run proves nothing about this class of link and Linux CI is the oracle;
Gate 1 on this branch is the verification of record.

Selftest: `scripts/check_rustdoc_links_selftest.sh`, 8 cases over synthetic cargo
streams, no doc build. The load-bearing case is `cached-no-op` at cargo exit 0 —
the pre-change script exits 0 on that fixture, the new one exits 3.

Test ladder: rung 1 for the crates (doc comments only, no behavior change) plus
rung 3 for `scripts/`, whose regression proof is the selftest.

## Version bumps

Not made here, per instruction — a release is being staged and version edits
route to `local-ops`. Four crates take doc-comment changes under `src/**` and
need patch bumps: **trusty-installer, trusty-mpm, trusty-memory, trusty-search**.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools