### PR TITLE
fix(scripts): CHECK 8's run table loses an empty field to tab collapsing

### DIFF
--- a/scripts/preflight-check8-selftest.sh
+++ b/scripts/preflight-check8-selftest.sh
@@ -175,7 +175,12 @@ text_of() { printf '%s' "$1" | cut -d'|' -f2-; }
 # tbl <target> <status> <conclusion> <url> [<target> <status> ...] — one row per
 # group of four. printf reuses its format for leftover arguments, which is what
 # lets a multi-run fixture stay one readable call.
-tbl() { printf '%s\t%s\t%s\t%s\n' "$@"; }
+#
+# PIPE-separated, matching the shipped table. Tab would be wrong here for the
+# same reason it was wrong there: it is IFS whitespace, so `read` would collapse
+# the empty <conclusion> of case 5's in-progress row and shift the url into it —
+# the exact defect measured on run 31878535281.
+tbl() { printf '%s|%s|%s|%s\n' "$@"; }
 
 echo "gate_decide — attribution:"
 
@@ -208,6 +213,12 @@ assert_absent "4 red attributed: not 'never ran'" "NO 'Pre-publish gate' run gat
 raw="$(run_decide "$(tbl "$HEAD_SHA" in_progress "" https://gh/run/5)")"
 assert_eq "5 in-progress: stops" "1" "$(status_of "$raw")"
 assert_contains "5 in-progress: says wait" "still-running gate is not a" "$(text_of "$raw")"
+# An in-progress run is the ONLY row with an empty <conclusion>, which makes it
+# the row that catches a delimiter regression: under a tab delimiter `read`
+# collapses the empty field and the url shifts into $concl, printing
+# "in_progress/https://…" with no url of its own (run 31878535281).
+# (run_decide collapses runs of spaces, so this is the single-space form.)
+assert_contains "5 in-progress: empty conclusion not collapsed" "in_progress/<none> https://gh/run/5" "$(text_of "$raw")"
 
 # --- 6. runs exist, none attributed to HEAD ----------------------------------
 raw="$(run_decide "$(tbl "$OTHER_SHA" completed success https://gh/a "$LATER_SHA" completed failure https://gh/b)")"

--- a/scripts/preflight-publish.sh
+++ b/scripts/preflight-publish.sh
@@ -1066,9 +1066,18 @@ gate_run_target() {
 # including the verbatim run-31874835425 attribution this function exists
 # because of.
 #
-# Input is one tab-separated line per candidate run:
-#     <target>\t<status>\t<conclusion>\t<html_url>
+# Input is one PIPE-separated line per candidate run:
+#     <target>|<status>|<conclusion>|<html_url>
 # where <target> is gate_run_target's output for that run.
+#
+# PIPE, NOT TAB, and this is load-free but not arbitrary: tab is IFS whitespace,
+# so `read` collapses a RUN of tabs into one delimiter and an empty field
+# silently vanishes. A queued or in-progress run has an empty `conclusion`, so
+# with a tab delimiter its html_url shifted left into $concl and $url came back
+# empty — measured on run 31878535281, which printed `in_progress/<the url>`.
+# A non-whitespace delimiter preserves empty fields. No field can contain `|`:
+# targets are hex or a keyword, statuses and conclusions are a fixed vocabulary,
+# and a GitHub run URL has no pipe in it.
 #
 # THE INVARIANT: a [PASS] means a run said, in its own output, that it gated
 # THIS commit — and no count of runs that merely mention it can substitute.
@@ -1082,7 +1091,7 @@ gate_decide() {
   # processed: read returns nonzero at EOF even when it filled the variables,
   # and silently dropping the last run would drop the newest one — the run the
   # operator just dispatched.
-  while IFS=$'\t' read -r target status concl url || [ -n "$target" ]; do
+  while IFS='|' read -r target status concl url || [ -n "$target" ]; do
     [ -n "$target" ] || continue
     case "$target" in
       NOGATE) continue ;;
@@ -1157,7 +1166,7 @@ check8_prepublish_gate() {
   # `|| rc=$?` rather than a bare call: a network failure must reach the
   # unverified path below, not abort the script under `set -e`.
   runs="$(gh api "repos/${GATE_REPO}/actions/workflows/pre-publish.yml/runs?per_page=100" \
-    --jq '.workflow_runs[] | [(.id|tostring), .created_at, .status, (.conclusion // ""), .html_url] | @tsv' 2>/dev/null)" || rc=$?
+    --jq '.workflow_runs[] | [(.id|tostring), .created_at, .status, (.conclusion // ""), .html_url] | join("|")' 2>/dev/null)" || rc=$?
 
   if [ "$rc" -ne 0 ]; then
     gate_unverified "the GitHub Actions API could not be reached (gh exited ${rc})"
@@ -1174,13 +1183,13 @@ d = datetime.datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
 print((d - datetime.timedelta(days=int(sys.argv[2]))).strftime("%Y-%m-%dT%H:%M:%SZ"))
 ' "$head_date" "$GATE_SCAN_DAYS" 2>/dev/null || echo "")"
 
-  while IFS=$'\t' read -r run_id created status concl url; do
+  while IFS='|' read -r run_id created status concl url; do
     [ -n "$run_id" ] || continue
     if [ -n "$cutoff" ] && [[ "$created" < "$cutoff" ]]; then continue; fi
     if [ "$examined" -ge "$GATE_SCAN_CAP" ]; then capped=1; break; fi
     examined=$((examined + 1))
     target="$(gate_run_target "$run_id")"
-    table="${table}${target}"$'\t'"${status}"$'\t'"${concl}"$'\t'"${url}"$'\n'
+    table="${table}${target}|${status}|${concl}|${url}"$'\n'
     # Newest-first from the API, so the run just dispatched is normally the
     # first one opened. Stop there rather than paying two API calls per run for
     # a verdict that cannot change.


### PR DESCRIPTION
Follow-up to #5758, found by running the check against the run that PR dispatched.

CHECK 8's internal run table was tab-separated. Tab is IFS whitespace, so `read`
collapses a run of tabs into a single delimiter and an empty field disappears. A
queued or in-progress run is the only row with an empty `conclusion`, so its
html_url shifted left into `$concl` and `$url` came back empty.

Measured on run 31878535281:

```
before:  in_progress/https://github.com/bobmatnyc/trusty-tools/actions/runs/31878535281
after:   in_progress/<none>  https://github.com/bobmatnyc/trusty-tools/actions/runs/31878535281
```

**The verdict was already correct** — a shifted url never equals `success`, so an
in-progress run still failed the green test and still landed on the red-gate arm.
What was wrong is the diagnostic an operator reads to decide what to do next, plus
a latent hazard: any future field whose emptiness is meaningful would take a
neighbouring value silently.

Delimiter switched to `|`, which is not IFS whitespace and preserves empty fields:

```
$ printf "a\tb\t\tc\n" | { IFS=$'\t' read -r w x y z; echo "y=[$y] z=[$z]"; }
y=[c] z=[]
$ printf "a|b||c\n"    | { IFS='|'  read -r w x y z; echo "y=[$y] z=[$z]"; }
y=[] z=[c]
```

No field can contain a pipe — targets are hex or a keyword, statuses and
conclusions are a fixed vocabulary, and a GitHub run URL has none.

### Verification

The in-progress fixture is the only case with an empty conclusion, so it is the one
that catches a delimiter regression; it now asserts the url lands in its own field.

```
scripts/preflight-check8-selftest.sh   EXIT=0   39 assertion(s) passed
cargo fmt --check                      EXIT=0
scripts/check_changelog_fragment.sh    EXIT=0   no crate source changed
```

Both live directions re-confirmed against the real API with the fix in place, same
green run 31864924233 in both, only HEAD differing:

```
=== CHECK 8 at HEAD=0c44ff94… (the commit that run gated) ===
[PASS] prepublish-gate: 1 green 'Pre-publish gate' run(s) gated 0c44ff94…
EXIT=0

=== CHECK 8 at HEAD=eb40680a… (that run's head_sha) ===
[FAIL] prepublish-gate: could not determine whether the release gate passed…
EXIT=1
```

Refs #5755

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
