### PR TITLE
refactor(uds): migrate the legacy UDS clients onto the shared framing entry point (closes #5180)

### DIFF
--- a/crates/trusty-agents/changelog.d/5180-uds-framing-migration.md
+++ b/crates/trusty-agents/changelog.d/5180-uds-framing-migration.md
@@ -1,0 +1,22 @@
+Changed
+
+- **`MessageBus::send_to` and the ctrl socket's writes now go through
+  `trusty_common::uds`'s shared framing entry point** instead of open-coding
+  `serde_json::to_string` + `push('\n')` + `write_all` + `flush`. ADR-0034 §4
+  put the framing in one module; these two were the `trusty-agents` half of the
+  four sites that never migrated (#5180)
+- The bus is a **notification**, not a request: the receiving bus re-broadcasts
+  the envelope to in-process subscribers and never writes a reply, so it routes
+  through the new `send_framed_notification` rather than `send_framed_request`,
+  which would have blocked on a response that does not exist. `#5180`'s issue
+  text listed it as a `send_framed_request` candidate; it is not one (#5180)
+- `send_to` gained a 10 s bound. A peer whose socket receive buffer was full —
+  an accept loop that stopped draining, a process stopped under a debugger —
+  used to block the sender's `write_all` indefinitely, and `send_to` is called
+  from request-handling paths (#5180)
+- `ctrl/socket_listener` keeps its own **read** loops, and the module header now
+  says why: the connection is multi-message (one command in, N `output`
+  envelopes and a terminal `done`/`error` out) and deliberately lenient about a
+  line that fails to parse. Neither property fits a one-shot request/response
+  helper, and a streaming variant in the shared module would have no second
+  consumer. Its writes still share the framing (#5180)

--- a/crates/trusty-agents/src/bus/mod.rs
+++ b/crates/trusty-agents/src/bus/mod.rs
@@ -8,7 +8,8 @@
 //! and a `broadcast::Sender<BusEnvelope>`. An `accept_loop` task reads
 //! NDJSON lines from each incoming connection and re-broadcasts them to all
 //! subscribers in the same process. `send_to` connects to a peer's socket
-//! and writes one NDJSON line.
+//! and writes one NDJSON line through `trusty_common::uds`'s shared framing
+//! entry point (#5180) — one way, no reply.
 //! Test: Start a bus, connect a raw UnixStream, write a JSON line, subscribe
 //! and assert the envelope is received.
 
@@ -18,7 +19,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::broadcast;
 
@@ -174,23 +175,34 @@ impl MessageBus {
     }
 }
 
+/// Wall-clock ceiling for one bus send.
+///
+/// Why (#5180): before the migration this path had no bound — a peer whose
+/// socket receive buffer was full (an accept loop that stopped draining, a
+/// process stopped under a debugger) blocked the sender's `write_all`
+/// indefinitely, and `send_to` is called from request-handling paths. The
+/// payload is one small envelope to a local socket, so anything that has not
+/// completed in 10 s is not going to.
+/// Test: `send_envelope_to_writes_exactly_one_newline_terminated_frame`.
+const SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Dial `target_path` and write one NDJSON-framed envelope to it.
 ///
 /// Why: split out of [`MessageBus::send_to`] so the dial half is reachable from
 /// a test without writing into the real `~/.trusty-agents/sockets/`, which
 /// `socket_path_for` hardcodes.
-/// What: connects, writes `envelope` plus a newline, flushes.
+/// What: #5180 — routes through
+/// [`trusty_common::uds::send_framed_notification`], the shared framing entry
+/// point, which dials (verifying the socket per #5089), writes one
+/// newline-terminated frame, flushes and half-closes. This is a NOTIFICATION,
+/// not a request: [`accept_loop`] re-broadcasts the envelope to in-process
+/// subscribers and never writes a reply, so `send_framed_request` would block
+/// until its timeout and then report a failure for a delivery that succeeded.
 /// Test: `send_envelope_to_delivers_over_a_hardened_socket`,
+/// `send_envelope_to_writes_exactly_one_newline_terminated_frame`,
 /// `send_envelope_to_refuses_a_world_readable_socket`.
 async fn send_envelope_to(target_path: &Path, envelope: &BusEnvelope) -> Result<()> {
-    // #5089: this writes a payload, so the socket's permissions are the only
-    // thing standing between the envelope and a process that planted a socket
-    // at this path. Verify before writing.
-    let mut stream = trusty_common::uds::connect_hardened(target_path).await?;
-    let mut line = serde_json::to_string(envelope)?;
-    line.push('\n');
-    stream.write_all(line.as_bytes()).await?;
-    stream.flush().await?;
+    trusty_common::uds::send_framed_notification(target_path, envelope, SEND_TIMEOUT).await?;
     Ok(())
 }
 
@@ -370,6 +382,47 @@ mod tests {
         let line = reader.await.expect("join");
         let got: BusEnvelope = serde_json::from_str(&line).expect("parse");
         assert_eq!(got.source_project, "sender");
+    }
+
+    /// #5180 wire-shape guard: the bus is NDJSON, so a peer's `lines()` reader
+    /// desynchronises for the rest of the connection if a send ever emits zero
+    /// or two terminators, or prepends a length prefix. Reading `lines()` (as
+    /// the test above does) cannot see that — it normalises the framing away.
+    /// This one asserts the raw bytes.
+    #[tokio::test]
+    async fn send_envelope_to_writes_exactly_one_newline_terminated_frame() {
+        use tokio::io::AsyncReadExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = tmp.path().join("sockets").join("receiver.sock");
+        let listener = trusty_common::uds::bind_hardened(&sock).expect("bind");
+
+        let reader = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            let mut raw = Vec::new();
+            stream.read_to_end(&mut raw).await.expect("read to eof");
+            raw
+        });
+
+        send_envelope_to(&sock, &envelope()).await.expect("send");
+
+        let raw = reader.await.expect("join");
+        let text = String::from_utf8(raw).expect("utf8");
+        assert!(
+            text.ends_with('\n'),
+            "the frame must be newline-terminated: {text:?}"
+        );
+        assert_eq!(
+            text.matches('\n').count(),
+            1,
+            "exactly one terminator per envelope: {text:?}"
+        );
+        let expected = serde_json::to_string(&envelope()).expect("serialise");
+        assert_eq!(
+            text.trim_end_matches('\n'),
+            expected,
+            "the frame body must be the bare serialised envelope, no prefix"
+        );
     }
 
     /// #5089 step 1a: `send_to` writes a payload, so it must refuse a socket

--- a/crates/trusty-agents/src/ctrl/socket_listener.rs
+++ b/crates/trusty-agents/src/ctrl/socket_listener.rs
@@ -6,12 +6,30 @@
 //! their request through this socket and exit.
 //! What: `spawn_socket_listener`, `handle_socket_connection`, the small
 //! `write_socket_line` helper, and the client-side `forward_to_controller`.
-//! Test: Manual — `trusty-agents` in one terminal, `trusty-agents "task"` in another.
+//! Test: `write_socket_line_emits_one_ndjson_frame_per_value`; end-to-end is
+//! manual — `trusty-agents` in one terminal, `trusty-agents "task"` in another.
+//!
+//! #5180 — framing decision, recorded here because leaving it unstated is what
+//! produced that issue. The WRITE half of this file's NDJSON goes through
+//! `trusty_common::uds::write_frame`, the shared entry point, so "what a frame
+//! is" is stated once for the whole workspace. The READ halves deliberately do
+//! NOT migrate, and this socket does not use `send_framed_request`:
+//!
+//! - It is multi-message. One `task` command goes in; N `output` envelopes and
+//!   a terminal `done`/`error` come back on the same connection. A one-shot
+//!   request/response helper cannot express that, and neither can the one-way
+//!   `send_framed_notification`.
+//! - Its reader is deliberately lenient. `forward_to_controller` logs a line
+//!   that fails to parse and keeps streaming; `send_framed_request` treats a
+//!   malformed frame as terminal, which is right for an RPC and wrong for a
+//!   progress stream.
+//! - Adding a streaming variant to `uds::rpc` to serve this one call site would
+//!   put a second protocol in the shared module with no second consumer.
+//!   Revisit if another multi-message UDS client appears.
 
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use tokio::io::AsyncWriteExt;
 
 use crate::events::{self, Event};
 
@@ -255,16 +273,18 @@ async fn handle_socket_connection(stream: tokio::net::UnixStream) {
 }
 
 /// Write one JSON value as an NDJSON line to a shared writer.
+///
+/// #5180: the framing is `trusty_common::uds::write_frame` now — same bytes,
+/// same `InvalidData` mapping for a serialisation failure, one fewer private
+/// copy of the terminator rule. The mutex stays here because it guards this
+/// connection's writer, not the framing.
+/// Test: `write_socket_line_emits_one_ndjson_frame_per_value`.
 async fn write_socket_line(
     writer: &std::sync::Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>,
     value: &serde_json::Value,
 ) -> std::io::Result<()> {
-    let mut line = serde_json::to_string(value)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-    line.push('\n');
     let mut g = writer.lock().await;
-    g.write_all(line.as_bytes()).await?;
-    g.flush().await
+    trusty_common::uds::write_frame(&mut *g, value).await
 }
 
 /// CLI-side: forward this invocation to a running controller and stream
@@ -312,10 +332,8 @@ pub async fn forward_to_controller(
         "cwd": cwd,
         "history": history_json,
     });
-    let mut line = serde_json::to_string(&cmd)?;
-    line.push('\n');
-    write_half.write_all(line.as_bytes()).await?;
-    write_half.flush().await?;
+    // #5180: same shared framing as the server side above.
+    trusty_common::uds::write_frame(&mut write_half, &cmd).await?;
 
     let mut reader = tokio::io::BufReader::new(read_half);
     let mut buf = String::new();
@@ -372,5 +390,61 @@ pub async fn forward_to_controller(
                 tracing::debug!(kind = %kind, "unknown reply type from controller");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt as _;
+
+    /// Why (#5180): this connection is multi-message, so a send that emitted
+    /// zero or two terminators would desynchronise the client's `read_line`
+    /// loop for every remaining envelope, not just one. The migration onto the
+    /// shared `write_frame` must not have changed those bytes.
+    /// What: writes two envelopes through `write_socket_line` over a real
+    /// socket pair and asserts the peer sees exactly two NDJSON lines.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn write_socket_line_emits_one_ndjson_frame_per_value() {
+        let (client, server) = tokio::net::UnixStream::pair().expect("socketpair");
+        let (_read_half, write_half) = server.into_split();
+        let writer = std::sync::Arc::new(tokio::sync::Mutex::new(write_half));
+
+        write_socket_line(&writer, &serde_json::json!({"type": "output", "text": "a"}))
+            .await
+            .expect("first frame");
+        write_socket_line(&writer, &serde_json::json!({"type": "done"}))
+            .await
+            .expect("second frame");
+        drop(writer);
+
+        let (mut client_read, _client_write) = client.into_split();
+        let mut raw = String::new();
+        client_read
+            .read_to_string(&mut raw)
+            .await
+            .expect("read to eof");
+
+        assert!(
+            raw.ends_with('\n'),
+            "every frame is newline-terminated: {raw:?}"
+        );
+        assert_eq!(
+            raw.matches('\n').count(),
+            2,
+            "exactly one terminator per value: {raw:?}"
+        );
+        let frames: Vec<serde_json::Value> = raw
+            .lines()
+            .map(|l| serde_json::from_str(l).expect("each line is a complete JSON value"))
+            .collect();
+        assert_eq!(
+            frames,
+            vec![
+                serde_json::json!({"type": "output", "text": "a"}),
+                serde_json::json!({"type": "done"}),
+            ]
+        );
     }
 }

--- a/crates/trusty-common/changelog.d/5180-uds-framing-migration.md
+++ b/crates/trusty-common/changelog.d/5180-uds-framing-migration.md
@@ -1,0 +1,27 @@
+Changed
+
+- **`embedder_client::uds` now sends and receives through `uds::rpc`, the
+  shared framing entry point, instead of its own copy.** ADR-0034 §4 decided
+  every UDS client routes through one module. #5169 landed the dial half
+  (`connect_hardened`); the framing half did not, so `send_framed_request` had
+  exactly one consumer while this client kept a private `write_all` +
+  `BufReader::read_line` + `serde_json::from_str` sequence. The wire bytes are
+  unchanged — `embed_batch_sends_one_newline_framed_jsonrpc_frame` asserts the
+  raw request frame against a stub listener and fails if the framing drifts
+  (#5180)
+- **The client gained a wall-clock bound where it had none.** A daemon that
+  accepted the connection and then wedged used to hold the caller open forever.
+  Embed exchanges are now bounded at 600 s — far above anything that completes
+  today. The point is that the wait is finite, not that it is short (#5180)
+- `uds::rpc` grew three additions the migration needed:
+  `send_framed_request_capped` (the response-size budget as a caller argument),
+  `send_framed_notification` (one frame out, no reply — for a peer that never
+  writes back), and `write_frame` / `encode_frame` (the write half alone, for
+  streaming NDJSON senders). `send_framed_request` is unchanged and still
+  defaults to `MAX_FRAME_BYTES` (#5180)
+- The embedder client passes a 256 MiB response budget rather than the shared
+  8 MiB default. An embed reply is bulk data — roughly 12 bytes per
+  JSON-encoded `f32`, so ~9.5 KB per 768-dimension vector — and the dream-dedup
+  pass embeds every drawer in a palace in a single batch, crossing 8 MiB at
+  around 900 drawers. The shared default would have turned a working dream
+  cycle into a hard failure (#5180)

--- a/crates/trusty-common/src/embedder_client/uds.rs
+++ b/crates/trusty-common/src/embedder_client/uds.rs
@@ -12,7 +12,10 @@
 //! `embeddings` array. The wire protocol matches the format used by
 //! `trusty-embed-daemon` (see `crates/trusty-embed-daemon/src/protocol.rs`
 //! for the daemon side's definitions) and by the UDS listener added to
-//! `trusty-embedderd` in issue #164.
+//! `trusty-embedderd` in issue #164. #5180: the framing itself is
+//! [`crate::uds::rpc::send_framed_request_capped`] — this module owns the
+//! JSON-RPC envelope, the dimension check and the error mapping, not the wire
+//! mechanics.
 //!
 //! Test: unit tests below cover empty-batch short-circuit, request
 //! serialisation shape, and error decoding without a live daemon. The
@@ -22,11 +25,38 @@
 //! ONNX model.
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 use super::{EmbedderClient, EmbedderError};
+
+/// Wall-clock ceiling for one embed exchange over the socket.
+///
+/// Why (#5180): the hand-rolled framing this client used before had no bound at
+/// all — a daemon that accepted the connection and then wedged (a stuck ONNX
+/// session, a CoreML cold compile that never finishes) held the caller open
+/// forever. The bound is deliberately loose rather than tight: callers that
+/// want a service-level deadline already impose one
+/// (`memory_core::timeouts::embed_batch_timeout`, 30 s by default), so this
+/// one's only job is to make an infinite hang finite. 10 minutes is longer than
+/// any batch that completes today.
+/// Test: `embed_bounds_are_generous_but_finite`.
+const EMBED_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Response-frame budget for one embed reply, in bytes.
+///
+/// Why (#5180): [`crate::uds::MAX_FRAME_BYTES`] (8 MiB) is sized for
+/// control-plane frames, and an embed reply is bulk data. JSON-encoded `f32`s
+/// run roughly 12 bytes per dimension, so one 768-dimension vector is ~9.5 KB
+/// and the dream-dedup pass — which embeds every drawer in a palace in a SINGLE
+/// batch (`memory_core::dream::cycle::dedup_drawers`) — crosses 8 MiB at around
+/// 900 drawers. Capping at the shared default would have turned a working dream
+/// cycle into a hard failure, so this client states its own budget. 256 MiB
+/// still bounds the read buffer against a peer that never terminates a frame,
+/// which is the only thing the cap is for.
+/// Test: `embed_bounds_are_generous_but_finite`.
+const EMBED_MAX_FRAME_BYTES: u64 = 256 * 1024 * 1024;
 
 // ── Wire types ──────────────────────────────────────────────────────────────
 // These intentionally mirror the private types in `trusty-common::embed_client`
@@ -178,60 +208,25 @@ impl EmbedderClient for UdsEmbedderClient {
             "UdsEmbedderClient: sending batch"
         );
 
-        // Open a fresh connection. UDS connect on a local socket is typically
-        // sub-millisecond, so the simplicity of one-connection-per-call is
-        // justified in Phase 1.
-        // #5099: verify the directory and socket before trusting them.
-        let stream = crate::uds::connect_hardened(&self.socket_path)
-            .await
-            .map_err(|e| {
-                EmbedderError::Uds(format!(
-                    "connect to {} failed: {e}",
-                    self.socket_path.display()
-                ))
-            })?;
-        let (read_half, mut write_half) = stream.into_split();
-
-        // Build and send the request frame.
         let req = RpcRequest {
             jsonrpc: JSONRPC_VERSION,
             method: METHOD_EMBED,
             params: EmbedParams { texts: &texts },
             id: 1,
         };
-        let mut payload = serde_json::to_vec(&req)
-            .map_err(|e| EmbedderError::Uds(format!("serialise JSON-RPC request: {e}")))?;
-        payload.push(b'\n');
 
-        write_half
-            .write_all(&payload)
-            .await
-            .map_err(|e| EmbedderError::Uds(format!("write request frame: {e}")))?;
-
-        // Half-close the write side so the daemon knows the request is complete.
-        write_half
-            .shutdown()
-            .await
-            .map_err(|e| EmbedderError::Uds(format!("half-close write side: {e}")))?;
-
-        // Read exactly one newline-terminated response frame.
-        let mut reader = BufReader::new(read_half);
-        let mut line = String::new();
-        let n = reader
-            .read_line(&mut line)
-            .await
-            .map_err(|e| EmbedderError::Uds(format!("read response frame: {e}")))?;
-
-        if n == 0 {
-            return Err(EmbedderError::Uds(
-                "daemon closed connection before responding".to_owned(),
-            ));
-        }
-
-        // Decode the response.
-        let resp: RpcResponse = serde_json::from_str(line.trim()).map_err(|e| {
-            EmbedderError::Uds(format!("decode response (raw={:?}): {e}", line.trim()))
-        })?;
+        // #5180: dial (with the #5099 permission check), newline framing,
+        // half-close, size cap and timeout all come from the shared entry
+        // point. This used to be a private copy of `write_all` +
+        // `BufReader::read_line` + `serde_json::from_str`.
+        let resp: RpcResponse = crate::uds::rpc::send_framed_request_capped(
+            &self.socket_path,
+            &req,
+            EMBED_TIMEOUT,
+            EMBED_MAX_FRAME_BYTES,
+        )
+        .await
+        .map_err(|e| EmbedderError::Uds(e.to_string()))?;
 
         if let Some(err) = resp.error {
             return Err(EmbedderError::ModelError(format!(
@@ -264,6 +259,83 @@ impl EmbedderClient for UdsEmbedderClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    /// Why (#5180): this client's framing moved into `uds::rpc`, and
+    /// `trusty-embedderd`'s listener — a separate crate — was not changed. A
+    /// drift in the request bytes would only show up against a live daemon,
+    /// which the rest of this module's tests deliberately avoid needing.
+    /// What: runs a real `embed_batch` against a stub listener and asserts the
+    /// wire bytes are exactly one newline-terminated JSON-RPC 2.0 frame, and
+    /// that a newline-terminated reply decodes back into vectors.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn embed_batch_sends_one_newline_framed_jsonrpc_frame() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = tmp.path().join("sockets").join("embedderd-stub.sock");
+        let listener = crate::uds::bind_hardened(&sock).expect("bind stub socket");
+
+        let served = tokio::spawn(async move {
+            let (mut conn, _) = listener.accept().await.expect("accept");
+            // The client half-closes after its request frame.
+            let mut raw = Vec::new();
+            conn.read_to_end(&mut raw).await.expect("drain request");
+            conn.write_all(
+                b"{\"jsonrpc\":\"2.0\",\"result\":{\"embeddings\":[[0.5,0.25]]},\"id\":1}\n",
+            )
+            .await
+            .expect("write reply");
+            conn.flush().await.expect("flush reply");
+            raw
+        });
+
+        let vectors = UdsEmbedderClient::new(sock)
+            .embed_batch(vec!["hello".to_string()])
+            .await
+            .expect("embed round trip");
+        assert_eq!(vectors, vec![vec![0.5_f32, 0.25_f32]]);
+
+        let raw = String::from_utf8(served.await.expect("join")).expect("utf8");
+        assert!(
+            raw.ends_with('\n'),
+            "the request frame must be newline-terminated: {raw:?}"
+        );
+        assert_eq!(
+            raw.matches('\n').count(),
+            1,
+            "exactly one frame, one terminator: {raw:?}"
+        );
+        let sent: serde_json::Value =
+            serde_json::from_str(raw.trim_end_matches('\n')).expect("the frame is one JSON value");
+        assert_eq!(sent["jsonrpc"], "2.0");
+        assert_eq!(sent["method"], "embed");
+        assert_eq!(sent["params"]["texts"][0], "hello");
+        assert_eq!(sent["id"], 1);
+    }
+
+    /// Why (#5180): the migration introduced a timeout and a response-size cap
+    /// where neither existed. The cap in particular is load-bearing — the
+    /// dream-dedup pass embeds a whole palace in one batch, and the shared
+    /// 8 MiB default would refuse the reply at roughly 900 drawers.
+    /// What: pins both bounds against a drift that would start failing real
+    /// batches.
+    /// Test: this test itself.
+    #[test]
+    fn embed_bounds_are_generous_but_finite() {
+        assert!(EMBED_TIMEOUT >= Duration::from_secs(120));
+        assert!(EMBED_TIMEOUT <= Duration::from_secs(3600));
+        // Both operands are consts, so these hold at compile time; a `const`
+        // block is what clippy's `assertions_on_constants` asks for and it
+        // turns a drift into a build failure rather than a test failure.
+        const {
+            assert!(
+                EMBED_MAX_FRAME_BYTES > crate::uds::MAX_FRAME_BYTES,
+                "an embed reply is bulk data; the control-plane default is too small"
+            );
+        }
+        // ~12 bytes per JSON-encoded f32 x 768 dims x 10_000 drawers.
+        const { assert!(EMBED_MAX_FRAME_BYTES >= 92_160_000) };
+    }
 
     #[tokio::test]
     async fn empty_batch_short_circuits() {

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -77,7 +77,10 @@ pub mod supervisor;
 pub use dir::prepare_socket_dir;
 pub use peer::{ensure_peer_is_self, peer_uid, self_uid};
 pub use probe::{SocketVerdict, probe_socket_verdict, socket_is_serving};
-pub use rpc::{MAX_FRAME_BYTES, UdsRpcError, send_framed_request};
+pub use rpc::{
+    MAX_FRAME_BYTES, UdsRpcError, encode_frame, send_framed_notification, send_framed_request,
+    send_framed_request_capped, write_frame,
+};
 pub use singleton::bind_singleton_hardened;
 #[cfg(feature = "uds-supervisor")]
 pub use supervisor::{

--- a/crates/trusty-common/src/uds/rpc.rs
+++ b/crates/trusty-common/src/uds/rpc.rs
@@ -1,44 +1,63 @@
-//! One request, one response, newline-framed JSON over a hardened Unix socket.
+//! Newline-framed JSON over a hardened Unix socket — the workspace's one
+//! framing entry point.
 //!
-//! Why: three call sites already speak this exact protocol by hand
-//! (`embedder_client/uds.rs`, `bm25_client.rs`, `trusty-agents`' `ctrl/socket.rs`)
-//! and #5089 step 3 adds a fourth — console relaying a verified webhook to
-//! `trusty-review` / `trusty-analyze`. Writing a fourth bespoke copy is what the
-//! common-entry-point rule exists to stop, and ADR-0034 §4 names the shared
-//! module explicitly. The three existing clients are migrated in a follow-up;
-//! this lands the entry point they migrate onto.
+//! Why: three call sites spoke this protocol by hand
+//! (`embedder_client/uds.rs`, `trusty-agents`' `MessageBus` and its ctrl
+//! socket) and #5089 step 3 added a fourth — console relaying a verified
+//! webhook to `trusty-review` / `trusty-analyze`. A fourth bespoke copy is what
+//! the common-entry-point rule exists to stop, and ADR-0034 §4 names the shared
+//! module explicitly. #5089 step 3 landed the entry point; #5180 migrated the
+//! legacy clients onto it. A fifth client, `bm25_client.rs`, was on that list
+//! until #5689 deleted the crate it dialled.
 //!
-//! What: [`send_framed_request`] dials through [`super::connect_hardened`] (so
-//! the socket's `0700` directory and `0600` mode are verified before a single
-//! byte of the request is written), writes one newline-terminated JSON frame,
-//! half-closes the write side, and reads one newline-terminated JSON frame back.
-//! The whole exchange is bounded by a caller-supplied timeout and the response
-//! by [`MAX_FRAME_BYTES`].
+//! What: three shapes, one framing contract.
+//! - [`send_framed_request`] — one request, one response. Dials through
+//!   [`super::connect_hardened`] (so the socket's `0700` directory and `0600`
+//!   mode are verified before a single byte is written), writes one
+//!   newline-terminated JSON frame, half-closes the write side, and reads one
+//!   newline-terminated JSON frame back. Bounded by a caller-supplied timeout
+//!   and by [`MAX_FRAME_BYTES`]; [`send_framed_request_capped`] takes the
+//!   budget explicitly for bulk-data callers.
+//! - [`send_framed_notification`] — one frame out, no reply expected. The
+//!   `MessageBus` peer never writes back, so a request helper would block on a
+//!   response that does not exist.
+//! - [`write_frame`] / [`encode_frame`] — the write half alone, for streaming
+//!   NDJSON sites that send many frames over one already-open stream.
 //!
 //! Deliberately not JSON-RPC-aware: `Req` and `Resp` are whatever the caller
 //! names. The framing is the shared part; the envelope is not.
 //!
-//! Test: `tests.rs` — `send_framed_request_*` against a real listener bound
-//! through `bind_hardened`, covering the round trip, a server that closes
-//! without answering, an over-long frame, a malformed frame, an absent socket,
-//! and the timeout; plus `read_failure_*` over [`classify_read_failure`], which
-//! cover the platform split a socket test cannot reproduce on both platforms.
+//! Test: `send_framed_request_round_trips_a_typed_value`,
+//! `send_framed_request_reports_no_response_when_peer_hangs_up`,
+//! `send_framed_request_rejects_an_over_long_frame`,
+//! `send_framed_request_capped_honours_a_caller_supplied_budget`,
+//! `send_framed_notification_delivers_exactly_one_frame`,
+//! `write_frame_terminates_each_value_with_one_newline` — all against a real
+//! listener bound through `bind_hardened`; plus `read_failure_*` over
+//! [`classify_read_failure`], which cover the platform split a socket test
+//! cannot reproduce on both platforms.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
 
 use super::{UdsSecurityError, connect_hardened};
 
-/// Largest response frame [`send_framed_request`] will buffer, in bytes.
+/// Default largest response frame [`send_framed_request`] will buffer, in bytes.
 ///
 /// A peer that never sends a newline would otherwise grow the read buffer
-/// until the process dies. 8 MiB is far above any frame this workspace
-/// exchanges (the largest is an embedding batch) and far below a memory
-/// problem.
+/// until the process dies. 8 MiB is far above any control-plane frame this
+/// workspace exchanges and far below a memory problem.
+///
+/// #5180: bulk-data callers pass their own budget to
+/// [`send_framed_request_capped`] instead — an embed reply carries one
+/// JSON-encoded `f32` array per input text and outgrows this figure on a large
+/// batch, which is a different problem from a peer that never terminates a
+/// frame.
 pub const MAX_FRAME_BYTES: u64 = 8 * 1024 * 1024;
 
 /// Everything that can go wrong on one framed exchange.
@@ -172,7 +191,42 @@ where
     Req: Serialize + ?Sized,
     Resp: DeserializeOwned,
 {
-    match tokio::time::timeout(timeout, exchange::<Req, Resp>(path, request)).await {
+    send_framed_request_capped(path, request, timeout, MAX_FRAME_BYTES).await
+}
+
+/// [`send_framed_request`] with an explicit response-frame budget.
+///
+/// Why: #5180 — [`MAX_FRAME_BYTES`] is sized for control-plane frames, and the
+/// embedder client's reply is bulk data (one JSON-encoded `f32` array per input
+/// text). Forcing it through the shared default would have converted a working
+/// large batch into a hard failure, so the budget becomes the caller's to state
+/// rather than a reason not to share the framing.
+/// What: identical to [`send_framed_request`] except that `max_frame_bytes`
+/// replaces [`MAX_FRAME_BYTES`] as the point at which an unterminated response
+/// is refused.
+///
+/// # Errors
+///
+/// The same [`UdsRpcError`] set as [`send_framed_request`];
+/// [`UdsRpcError::FrameTooLarge`] reports `max_frame_bytes` as its `limit`.
+///
+/// Test: `send_framed_request_capped_honours_a_caller_supplied_budget`.
+pub async fn send_framed_request_capped<Req, Resp>(
+    path: &Path,
+    request: &Req,
+    timeout: Duration,
+    max_frame_bytes: u64,
+) -> Result<Resp, UdsRpcError>
+where
+    Req: Serialize + ?Sized,
+    Resp: DeserializeOwned,
+{
+    match tokio::time::timeout(
+        timeout,
+        exchange::<Req, Resp>(path, request, max_frame_bytes),
+    )
+    .await
+    {
         Ok(result) => result,
         Err(_) => Err(UdsRpcError::Timeout {
             path: path.to_path_buf(),
@@ -181,18 +235,109 @@ where
     }
 }
 
-/// The un-timed body of [`send_framed_request`], split out so the timeout wraps
-/// exactly one future and the error mapping stays readable.
-async fn exchange<Req, Resp>(path: &Path, request: &Req) -> Result<Resp, UdsRpcError>
+/// Send one JSON frame to `path` and return without waiting for a reply.
+///
+/// Why: #5180 — `trusty-agents`' `MessageBus::send_to` is fire-and-forget. The
+/// receiving bus reads NDJSON lines and re-broadcasts them to in-process
+/// subscribers; it never writes anything back. Routing it through
+/// [`send_framed_request`] would block until the caller's timeout expired and
+/// then report a failure for a delivery that succeeded, so the shared module
+/// owes the one-way half of the contract rather than a request the peer cannot
+/// answer.
+///
+/// What: dials via [`super::connect_hardened`], writes one newline-terminated
+/// JSON frame, flushes, and half-closes the write side so the peer sees EOF.
+/// The whole sequence is bounded by `timeout`.
+///
+/// # Errors
+///
+/// [`UdsRpcError::Dial`], [`UdsRpcError::Encode`], [`UdsRpcError::Write`], or
+/// [`UdsRpcError::Timeout`]. `Ok(())` means the bytes reached the kernel, not
+/// that the peer acted on them — that is what one-way means, and a caller that
+/// needs an acknowledgement wants [`send_framed_request`] instead.
+///
+/// Test: `send_framed_notification_delivers_exactly_one_frame`,
+/// `send_framed_notification_reports_dial_failure_for_a_missing_socket`.
+pub async fn send_framed_notification<Req>(
+    path: &Path,
+    request: &Req,
+    timeout: Duration,
+) -> Result<(), UdsRpcError>
 where
     Req: Serialize + ?Sized,
-    Resp: DeserializeOwned,
 {
-    let mut frame = serde_json::to_vec(request).map_err(|source| UdsRpcError::Encode {
+    match tokio::time::timeout(timeout, dial_and_send(path, request)).await {
+        Ok(result) => result.map(|_stream| ()),
+        Err(_) => Err(UdsRpcError::Timeout {
+            path: path.to_path_buf(),
+            timeout,
+        }),
+    }
+}
+
+/// Serialise `value` as one newline-terminated JSON frame.
+///
+/// Why: #5180 — every UDS client in this workspace open-coded the same two
+/// steps (`serde_json::to_vec`, push `b'\n'`), so "what a frame is" was
+/// asserted in five places instead of stated in one.
+/// What: `serde_json::to_vec(value)` with a trailing `\n`. A serialised JSON
+/// value never contains a bare newline outside a string literal, and inside one
+/// it is escaped, so the terminator is unambiguous for any `value`.
+///
+/// # Errors
+///
+/// Whatever `serde_json::to_vec` returns for a value that cannot be serialised.
+///
+/// Test: `encode_frame_appends_exactly_one_newline`.
+pub fn encode_frame<T>(value: &T) -> serde_json::Result<Vec<u8>>
+where
+    T: Serialize + ?Sized,
+{
+    let mut frame = serde_json::to_vec(value)?;
+    frame.push(b'\n');
+    Ok(frame)
+}
+
+/// Write one newline-terminated JSON frame to `writer` and flush it.
+///
+/// Why: #5180 — the streaming NDJSON sites (`trusty-agents`' ctrl socket) push
+/// many frames down one already-connected stream, so they cannot use
+/// [`send_framed_request`], which owns the dial and reads exactly one reply.
+/// Exposing the write half on its own lets them share the framing anyway
+/// instead of keeping a private copy.
+/// What: [`encode_frame`], then `write_all` + `flush`.
+///
+/// # Errors
+///
+/// A serialisation failure surfaces as `io::ErrorKind::InvalidData`, matching
+/// what the call sites this replaced already did; everything else is the
+/// underlying write error.
+///
+/// Test: `write_frame_terminates_each_value_with_one_newline`.
+pub async fn write_frame<W, T>(writer: &mut W, value: &T) -> std::io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+    T: Serialize + ?Sized,
+{
+    let frame =
+        encode_frame(value).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    writer.write_all(&frame).await?;
+    writer.flush().await
+}
+
+/// Dial `path`, write one frame, and half-close the write side.
+///
+/// Split out so [`send_framed_request_capped`] and [`send_framed_notification`]
+/// share one copy of the dial-and-write sequence; the returned stream is the
+/// still-open read half for callers that expect a reply.
+async fn dial_and_send<Req>(path: &Path, request: &Req) -> Result<UnixStream, UdsRpcError>
+where
+    Req: Serialize + ?Sized,
+{
+    let frame = encode_frame(request).map_err(|source| UdsRpcError::Encode {
         path: path.to_path_buf(),
         source,
     })?;
-    frame.push(b'\n');
 
     let mut stream = connect_hardened(path)
         .await
@@ -213,7 +358,35 @@ where
         source,
     })?;
 
-    let mut reader = BufReader::new(stream.take(MAX_FRAME_BYTES));
+    Ok(stream)
+}
+
+/// The un-timed body of [`send_framed_request_capped`], split out so the
+/// timeout wraps exactly one future and the error mapping stays readable.
+async fn exchange<Req, Resp>(
+    path: &Path,
+    request: &Req,
+    max_frame_bytes: u64,
+) -> Result<Resp, UdsRpcError>
+where
+    Req: Serialize + ?Sized,
+    Resp: DeserializeOwned,
+{
+    let stream = dial_and_send(path, request).await?;
+    read_one_frame(stream, path, max_frame_bytes).await
+}
+
+/// Read bytes up to and including the next `\n` and decode them as `Resp`.
+async fn read_one_frame<R, Resp>(
+    source: R,
+    path: &Path,
+    max_frame_bytes: u64,
+) -> Result<Resp, UdsRpcError>
+where
+    R: AsyncRead + Unpin,
+    Resp: DeserializeOwned,
+{
+    let mut reader = BufReader::new(source.take(max_frame_bytes));
     let mut line: Vec<u8> = Vec::new();
     let read = match reader.read_until(b'\n', &mut line).await {
         Ok(read) => read,
@@ -225,10 +398,10 @@ where
             path: path.to_path_buf(),
         });
     }
-    if !line.ends_with(b"\n") && line.len() as u64 >= MAX_FRAME_BYTES {
+    if !line.ends_with(b"\n") && line.len() as u64 >= max_frame_bytes {
         return Err(UdsRpcError::FrameTooLarge {
             path: path.to_path_buf(),
-            limit: MAX_FRAME_BYTES,
+            limit: max_frame_bytes,
         });
     }
 
@@ -482,6 +655,137 @@ mod tests {
         assert!(
             matches!(err, UdsRpcError::Dial { .. }),
             "expected Dial, got {err:?}"
+        );
+    }
+
+    /// Why (#5180): the embedder client raises the budget rather than being
+    /// left out of the shared framing, so the budget must actually be the
+    /// caller's — a `capped` call that silently used [`MAX_FRAME_BYTES`] would
+    /// look identical on the happy path and fail only on a big batch in
+    /// production.
+    /// What: feeds an unterminated 4 KiB flood under a 1 KiB budget and asserts
+    /// the reported limit is the caller's figure, not the module default.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn send_framed_request_capped_honours_a_caller_supplied_budget() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let flood = vec![b'x'; 4096];
+        let sock = spawn_stub(tmp.path(), vec![StubReply::Bytes(flood)]);
+
+        let err = send_framed_request_capped::<_, Pong>(
+            &sock,
+            &Ping {
+                method: "ping",
+                n: 1,
+            },
+            Duration::from_secs(5),
+            1024,
+        )
+        .await
+        .expect_err("an unterminated flood past the caller's budget must be refused");
+
+        assert!(
+            matches!(err, UdsRpcError::FrameTooLarge { limit, .. } if limit == 1024),
+            "expected FrameTooLarge at the caller's 1024-byte budget, got {err:?}"
+        );
+    }
+
+    /// Why (#5180): `MessageBus`'s peer never replies. This is the test that
+    /// fails if `send_to` is ever re-pointed at a request helper — the stub
+    /// here writes nothing back, exactly like a real bus.
+    /// What: sends a notification to a stub that only reads, and asserts both
+    /// that the call succeeds and that the bytes on the wire are one
+    /// newline-terminated JSON frame with no second newline.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn send_framed_notification_delivers_exactly_one_frame() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = tmp.path().join("sockets").join("notify.sock");
+        let listener: UnixListener = bind_hardened(&sock).expect("bind");
+
+        let served = tokio::spawn(async move {
+            let (mut conn, _) = listener.accept().await.expect("accept");
+            let mut got = Vec::new();
+            conn.read_to_end(&mut got).await.expect("drain");
+            got
+        });
+
+        send_framed_notification(
+            &sock,
+            &Ping {
+                method: "ping",
+                n: 9,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("a peer that never replies is still a successful delivery");
+
+        let bytes = served.await.expect("join");
+        let text = String::from_utf8(bytes).expect("utf8");
+        assert_eq!(
+            text, "{\"method\":\"ping\",\"n\":9}\n",
+            "one frame, one trailing newline, nothing else"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_framed_notification_reports_dial_failure_for_a_missing_socket() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sock = tmp.path().join("sockets").join("absent.sock");
+
+        let err = send_framed_notification(
+            &sock,
+            &Ping {
+                method: "ping",
+                n: 1,
+            },
+            Duration::from_secs(5),
+        )
+        .await
+        .expect_err("no listener means no delivery");
+
+        assert!(
+            matches!(err, UdsRpcError::Dial { .. }),
+            "expected Dial, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn encode_frame_appends_exactly_one_newline() {
+        let frame = encode_frame(&Ping {
+            method: "ping",
+            n: 3,
+        })
+        .expect("encode");
+        assert_eq!(frame, b"{\"method\":\"ping\",\"n\":3}\n");
+        assert_eq!(
+            frame.iter().filter(|b| **b == b'\n').count(),
+            1,
+            "a frame carries exactly one newline, and it is the terminator"
+        );
+    }
+
+    /// Why (#5180): this is the primitive the streaming ctrl socket writes
+    /// through, where N frames share one stream. A missing or doubled
+    /// terminator there desynchronises the reader for the rest of the
+    /// connection, not just one message.
+    /// What: writes two values into one buffer and asserts the result is two
+    /// NDJSON lines.
+    /// Test: this test itself.
+    #[tokio::test]
+    async fn write_frame_terminates_each_value_with_one_newline() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_frame(&mut buf, &Ping { method: "a", n: 1 })
+            .await
+            .expect("first frame");
+        write_frame(&mut buf, &Ping { method: "b", n: 2 })
+            .await
+            .expect("second frame");
+
+        assert_eq!(
+            String::from_utf8(buf).expect("utf8"),
+            "{\"method\":\"a\",\"n\":1}\n{\"method\":\"b\",\"n\":2}\n"
         );
     }
 


### PR DESCRIPTION
Salvages the UDS framing migration from the abandoned `fix/5180-uds-framing-migration` branch. ADR-0034 §4 and #5180 have the rationale; the commit message has the design decisions.

## What changed from the abandoned branch

- **Dropped the `bm25_client.rs` hunk.** #5689 deleted that crate, so its migration is moot. The `uds/rpc.rs` module header records why the client count went from five to four.
- **Reconciled `uds/rpc.rs` with #5182.** That PR added `classify_read_failure` inside the read loop this change splits into `dial_and_send` / `read_one_frame`. The classifier is now called from `read_one_frame`, so an abortive close with nothing buffered still reports `NoResponse` rather than `Read`. #5182's three `read_failure_*` tests pass unchanged against the split — no divergence from either design.
- **Two lint fixes the branch predates.** `assertions_on_constants` on the embed-budget asserts (now `const` blocks, so drift is a build failure) and `items_after_test_module` in `socket_listener.rs` (test module moved to end of file).
- The second commit on that branch (`ac822ea4`, an automated session sweep) is discarded.

## Migration completeness

Every call site listed in #5180 now routes through the shared entry point:

| Site | Now uses |
|---|---|
| `embedder_client/uds.rs` `embed_batch` | `send_framed_request_capped` |
| `bus/mod.rs` `send_envelope_to` | `send_framed_notification` |
| `ctrl/socket_listener.rs` `write_socket_line`, `forward_to_controller` | `write_frame` |

Reads in `socket_listener` stay bespoke by design — the connection is multi-message and deliberately lenient about an unparseable line. The module header states this.

Swept the workspace for other UDS clients: `ctrl/socket.rs` and `debugger/socket_monitor.rs` dial but never frame JSON, so nothing there to migrate. No new unmigrated site appeared.

## Gates — rung 4

`trusty-common` is a shared library and this touches its public surface.

```
cargo fmt --check                                                          EXIT=0
cargo clippy --workspace --all-targets -- -D warnings                      EXIT=0
SKIP_UI_BUILD=1 cargo check --workspace --all-targets                      EXIT=0
cargo test -p trusty-common \
  --features memory-core,embedder-test-support,embedder-client,uds,uds-supervisor,webhook-relay
  test result: ok. 1284 passed; 0 failed; 13 ignored
cargo test -p trusty-search    ok. 1748 passed; 0 failed (+ 432, 3, 3, 5, …)
```

**The prescribed feature set was a false green.** `--features memory-core,embedder-test-support` compiles neither file this PR changes — `uds` and `embedder_client` sit behind the `uds` / `embedder-client` features, which that set does not pull in. It ran 1039 tests and exited 0 with zero coverage of the change; the correct set runs 1284 and is what the numbers above report. Same trap as #4901, one feature layer deeper.

Script gates: `check_line_cap.sh` 0, `check_sld.sh` 0, `check_test_pointers.sh` 0, `check_changelog_fragment.sh` 0 (7 paths scanned, both crates recorded), `check_contracts.sh --crate trusty-common` 0 (15 contracts, artifact matches source), `check_rustdoc_links.sh` 0 broken / baseline 0.

**SemVer:** `check_semver_types.sh --crate trusty-common` — 12672 public items compared, **0 changed, 0 removed, 48 added**. Purely additive; no bump needed beyond the 0.34.0 → 0.35.0 already on main. `check_semver.sh` reports one breaking finding, `feature_missing: bm25-client`, which is #5329/#5689's removal already covered by that bump — not from this PR.

## Pre-existing reds, not caused here

- `trusty-agents` `credential_status_never_leaks_a_value` — #5678. Reads a real `.env.local`; no path from `uds`/`embedder_client` to credential tier resolution. Remaining 3504 pass.
- `trusty-memory` — the six known `prompt_context` / `inbox_check` failures. 765 pass.
- `trusty-search` failed two different env-dependent tests across runs, both traced to `TRUSTY_INDEX=trusty-tools` being set in the shell. With it unset the suite is fully green (output above), and `git diff origin/main...HEAD -- crates/trusty-search/` is empty.

Closes #5180

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
