### PR TITLE
fix(trusty-review): 0.17.0 for the report-module API break, and #[non_exhaustive] so the next one is not

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11744,7 +11744,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "1.0.0" }
 #      this line existed. Both consumers name what they need: trusty-analyze's
 #      `review` feature pulls `trusty-review/mcp`; trusty-mpm's dev-dependency
 #      only touches `integrations`, which is unconditional.
-trusty-review = { path = "crates/trusty-review", version = "0.16", default-features = false }
+trusty-review = { path = "crates/trusty-review", version = "0.17", default-features = false }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name        = "trusty-review"
-# #4421: patch bump — 0.16.0 already published on crates.io and this PR
-# touches src/**. `SystemGhResolver::gh_auth_token` swaps its hand-rolled
-# `gh auth token` spawn for trusty-common's `GhCommand` entry point; the
-# trait method signature and struct are unchanged, so no public API moved.
-version     = "0.16.1"
+# #5762: MINOR bump — for a 0.y.z crate the breaking position is MINOR, and the
+# public API of the `report` module broke since 0.16.0: `ReportSection` and
+# `ReportModel` each gained a required field (`ticketing`), and `ReportError`
+# gained three variants (`MetricsSchema`, `Ticketing`, `TicketingSchema`).
+# 0.16.1 was tagged for that delta and is wrong; the three types now carry
+# `#[non_exhaustive]` so the same additions are non-breaking from here on.
+version     = "0.17.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/5762-non-exhaustive-report-types.md
+++ b/crates/trusty-review/changelog.d/5762-non-exhaustive-report-types.md
@@ -1,0 +1,4 @@
+Changed
+
+- **0.17.0, not 0.16.1 — the public API of the `report` module broke and the patch bump did not say so.** `ReportSection` and `ReportModel` each gained a required `ticketing` field, and `ReportError` gained `MetricsSchema`, `Ticketing` and `TicketingSchema`. Cargo's 0.x rule puts the breaking position at MINOR for a `0.y.z` crate, so this ships as 0.17.0. The `trusty-review-v0.16.1` tag was cut for that delta and is abandoned.
+- `ReportError`, `ReportSection` and `ReportModel` now carry `#[non_exhaustive]`. A downstream `match` on `ReportError` needs a `_` arm and the two structs are built through `ReportModel::build` or manifest deserialization rather than a struct literal, so the next variant or field is a minor bump instead of a major one. No in-workspace caller was affected — neither trusty-analyze nor trusty-mpm reaches the `report` module.

--- a/crates/trusty-review/src/report/error.rs
+++ b/crates/trusty-review/src/report/error.rs
@@ -76,7 +76,13 @@ pub enum ManifestError {
 /// and generic I/O; the CLI maps these to `anyhow` at the boundary.
 /// Test: `reporter_tests.rs` (I/O), `template.rs` tests (`TemplateNotFound`),
 /// `metrics.rs` tests (`Metrics`).
+///
+/// `#[non_exhaustive]` (#5762): every new failure mode this pipeline learns to
+/// name adds a variant, and three arrived between 0.16.0 and 0.17.0 alone. A
+/// downstream `match` must carry a `_` arm, which makes those additions a minor
+/// bump instead of a major one.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ReportError {
     /// A manifest-level failure (parse or validation).
     #[error(transparent)]

--- a/crates/trusty-review/src/report/manifest.rs
+++ b/crates/trusty-review/src/report/manifest.rs
@@ -42,7 +42,13 @@ pub struct Manifest {
 /// What: `title` is required; `template` and `analyst` are optional.  When
 /// `template` is absent the CLI falls back to the default template name.
 /// Test: `manifest_tests.rs::parse_local_path_entry`.
+///
+/// `#[non_exhaustive]` (#5762): the section grows a field whenever the manifest
+/// learns a new key — `ticketing` arrived in 0.17.0 — and a struct literal
+/// outside this crate would break on each one. Construct it by deserializing a
+/// manifest, which is the only supported source.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct ReportSection {
     /// Human-readable report title (used as the target codename and slug seed).
     pub title: String,

--- a/crates/trusty-review/src/report/model.rs
+++ b/crates/trusty-review/src/report/model.rs
@@ -43,7 +43,13 @@ pub fn vendor_methodology() -> String {
 /// What: report-level fields (title, chosen template, analyst, dates, manifest
 /// provenance) plus one [`RepositoryReport`] per repository.
 /// Test: `reporter_tests.rs::build_model_from_manifest`.
+///
+/// `#[non_exhaustive]` (#5762): each new report section adds a field here —
+/// `ticketing` arrived in 0.17.0 — so a struct literal outside this crate would
+/// break on every section the report gains. Build it with
+/// [`ReportModel::build`].
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct ReportModel {
     /// Report title (used as the target codename and output slug seed).
     pub title: String,


### PR DESCRIPTION
`trusty-review` 0.16.1 is a PATCH bump carrying a real public-API break, which is why the publish chain stopped there.

## The break

Since 0.16.0, `cargo-semver-checks` reports:

```
constructible_struct_adds_field  ReportSection.ticketing   src/report/manifest.rs
constructible_struct_adds_field  ReportModel.ticketing     src/report/model.rs
enum_variant_added               ReportError:MetricsSchema
enum_variant_added               ReportError:Ticketing
enum_variant_added               ReportError:TicketingSchema
```

Cargo's 0.x rule puts the breaking position at MINOR for a `0.y.z` crate, so this ships as **0.17.0**. The `trusty-review-v0.16.1` tag was cut for that delta and is abandoned — `trusty-review-v0.17.0` will be tagged at the commit that actually publishes.

## `#[non_exhaustive]`

`ReportError`, `ReportSection` and `ReportModel` now carry it. That is itself a one-time break, taken here where the version already accounts for it. From 0.17.0 on, a new `ReportError` variant or a new report section field is a minor bump instead of a major one.

## Pin sites and construction sites

One pin site: the root `[workspace.dependencies]` entry, moved to `version = "0.17"` with its `default-features = false` from #5466 preserved. Both consumers reference the crate as `workspace = true`, so nothing else states a version.

No construction site broke. `git grep` finds no use of `ReportSection`, `ReportModel` or `ReportError` outside `trusty-review` — trusty-analyze reaches only `trusty_review::mcp`, trusty-mpm only `trusty_review::integrations::context`. `#[non_exhaustive]` restricts other crates only, so the in-crate literals and matches are unaffected.

## Gates — test ladder rung 4 (public API of a shared library)

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo clippy -p trusty-review --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-review` | `1591 passed; 0 failed; 5 ignored` plus 10 integration binaries, 0 failed |
| `SKIP_UI_BUILD=1 cargo check --workspace --all-targets` | EXIT=0 — this is the check that proves no consumer broke |
| `bash scripts/check_line_cap.sh` | EXIT=0 |
| `bash scripts/check_sld.sh` | EXIT=0 |
| `bash scripts/check_semver.sh --crate trusty-review` | EXIT=0 — see below |

The semver gate runs advisory here, because 0.16.0 → 0.17.0 is already a breaking release and no bump can be owed:

```
INVENTORY trusty-review: 0.16.0 -> 0.17.0 is already a breaking release — no bump
can be owed, so this run is advisory: what does it break?
     Checked 196 checks: 194 pass, 2 fail, 0 warn, 58 skip
--- failure enum_marked_non_exhaustive   → ReportError
--- failure struct_marked_non_exhaustive → ReportSection, ReportModel
     Summary semver requires new major version: 2 major and 0 minor checks failed
INVENTORY trusty-review: breaking change(s) listed above — permitted by the major
bump. Confirm every one was intended (#5297).
semver gate: scanned (explicit); 0 crate(s) checked, 0 skipped, 1 inventoried (advisory) — OK.
```

The two reported breaks are the `#[non_exhaustive]` markings, which subsume the five original findings — once a type is non-exhaustive, adding a field or variant to it is no longer reported. Both were intended.

Blocks the publish chain: trusty-review 0.17.0 → trusty-analyze 0.9.1 → trusty-mpm 1.4.2 → trusty-search 0.47.0.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools