### PR TITLE
fix(trusty-review): render ticketing coverage in the CAST template too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11744,7 +11744,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "1.0.0" }
 #      this line existed. Both consumers name what they need: trusty-analyze's
 #      `review` feature pulls `trusty-review/mcp`; trusty-mpm's dev-dependency
 #      only touches `integrations`, which is unconditional.
-trusty-review = { path = "crates/trusty-review", version = "0.17", default-features = false }
+trusty-review = { path = "crates/trusty-review", version = "0.18", default-features = false }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name        = "trusty-review"
-# #5762: MINOR bump — for a 0.y.z crate the breaking position is MINOR, and the
-# public API of the `report` module broke since 0.16.0: `ReportSection` and
-# `ReportModel` each gained a required field (`ticketing`), and `ReportError`
-# gained three variants (`MetricsSchema`, `Ticketing`, `TicketingSchema`).
-# 0.16.1 was tagged for that delta and is wrong; the three types now carry
-# `#[non_exhaustive]` so the same additions are non-breaking from here on.
-version     = "0.17.0"
+# MINOR bump — 0.17.0 is already published, and this change edits `src/**`, so
+# the `PR version bump vs crates.io` gate (#4421) requires the bump here. MINOR
+# by the owner's standing decision; nothing in the public API changed, and the
+# three `report` types that broke at 0.17.0 now carry `#[non_exhaustive]`
+# (#5762), so field and variant additions stay non-breaking from here on.
+version     = "0.18.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/cast-template-ticketing-section.md
+++ b/crates/trusty-review/changelog.d/cast-template-ticketing-section.md
@@ -1,0 +1,9 @@
+Fixed
+
+- The CAST template (`report-technical-dd-cast`) renders the ticketing-coverage
+  section the generic template gained at 0.17.0. A CAST engagement whose
+  manifest declared a valid `[report].ticketing` artifact showed no coverage
+  figures and no gap line either: with no section in the template there was no
+  placeholder to collapse, so the omission escaped the polish pass that exists
+  to name absences. The section is now section 8 in both templates and Gaps &
+  Caveats is section 9 in both.

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -1894,7 +1894,10 @@ fn reporter_captions_a_truncated_top_risks_table() {
 }
 
 /// Build a model whose manifest declares a ticketing artifact (#5405).
-fn fixture_model_with_ticketing(dir: &Path, artifact: &str) -> ReportModel {
+///
+/// `template` is the name recorded on the model; the caller loads the same
+/// template's text separately, so both bundled templates run this fixture.
+fn fixture_model_with_ticketing(dir: &Path, template: &str, artifact: &str) -> ReportModel {
     std::fs::write(dir.join("ticketing.json"), artifact).expect("write ticketing");
 
     let toml = r#"
@@ -1909,43 +1912,44 @@ fn fixture_model_with_ticketing(dir: &Path, artifact: &str) -> ReportModel {
     "#;
     let manifest_path = dir.join("manifest.toml");
     let manifest = parse_manifest(toml, &manifest_path).expect("manifest parse");
-    ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None).expect("build model")
+    ReportModel::build(&manifest, &manifest_path, template, None).expect("build model")
 }
 
-/// #5405's first closure condition, asserted on the RENDERED artifact rather
-/// than on the model: the report reads `work_items` (by way of the correlation
-/// figures tga wrote) and states them on the page.
+/// The figures-present case, asserted on the RENDERED artifact rather than on
+/// the model: the report reads `work_items` (by way of the correlation figures
+/// tga wrote) and states them on the page.
 ///
 /// The end-to-end shape matters here. Every intermediate layer could hold the
 /// figures correctly and the section could still never reach the page — the
 /// polish pass drops marker rows and collapses emptied sections, so a scalar
-/// this test only checked on the model would prove nothing about the document
-/// an acquirer reads.
-#[test]
-fn reporter_states_ticketing_coverage() {
+/// checked only on the model would prove nothing about the document an acquirer
+/// reads. Both bundled templates place the section at §8, so one body serves
+/// both.
+fn assert_template_states_ticketing_coverage(template_name: &str) {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let model = fixture_model_with_ticketing(
         tmp.path(),
+        template_name,
         r#"{"schema_version":"v0","commits":412,"commits_linked":260,
             "work_items":180,"work_items_linked":155,"sources":["jira","linear"]}"#,
     );
     let template = TemplateLoader::bundled_only()
-        .load("report-technical-dd")
+        .load(template_name)
         .expect("bundled template");
     let md = Reporter::new(tmp.path()).render(&model, &template);
 
     assert!(
         md.contains("## 8. Ticketing & Delivery Traceability"),
-        "the section must render:\n{md}"
+        "{template_name}: the section must render:\n{md}"
     );
     assert!(
         md.contains("260 of 412 commit(s)") && md.contains("jira, linear"),
-        "the counts and the boards they came from must reach the page:\n{md}"
+        "{template_name}: the counts and the boards they came from must reach the page:\n{md}"
     );
     // Not collapsed, and not swept into the gaps list.
     assert!(
         !md.contains("## 8. Ticketing & Delivery Traceability\n\n_No data available"),
-        "a populated section must not collapse:\n{md}"
+        "{template_name}: a populated section must not collapse:\n{md}"
     );
     assert!(!md.contains("{{ticketing_coverage}}"));
 }
@@ -1954,35 +1958,41 @@ fn reporter_states_ticketing_coverage() {
 /// correlated nothing STATES that. A zero is a finding about the codebase —
 /// commits do not cite tracked work — and must never render as the same blank
 /// a missing artifact produces.
-#[test]
-fn reporter_states_a_zero_coverage_run_rather_than_omitting_it() {
+fn assert_template_states_a_zero_coverage_run(template_name: &str) {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let model = fixture_model_with_ticketing(
         tmp.path(),
+        template_name,
         r#"{"schema_version":"v0","commits":300,"commits_linked":0,
             "work_items":12,"work_items_linked":0,"sources":[]}"#,
     );
     let template = TemplateLoader::bundled_only()
-        .load("report-technical-dd")
+        .load(template_name)
         .expect("bundled template");
     let md = Reporter::new(tmp.path()).render(&model, &template);
 
     assert!(
         md.contains("No commit referenced a tracked board item"),
-        "a zero run must state itself, not collapse:\n{md}"
+        "{template_name}: a zero run must state itself, not collapse:\n{md}"
     );
-    assert!(md.contains("300 commit(s)"), "{md}");
+    assert!(md.contains("300 commit(s)"), "{template_name}:\n{md}");
 }
 
 /// The other side of that contract: when the producing run supplied NO
 /// artifact, the section must be named as unassessed rather than silently
 /// absent — DOC-67 §9's rule, and the defect #5405 is one level up from.
-#[test]
-fn a_missing_ticketing_artifact_is_named_not_silently_dropped() {
+///
+/// This is the case a template can fail invisibly. A template with no section
+/// at all renders no placeholder, so the polish pass has nothing to collapse
+/// and nothing to name: the omission escapes the very mechanism built to
+/// surface it. Assert the heading, the collapse line, and the gap entry
+/// together — any one of the three alone passes on a template that dropped the
+/// dimension entirely.
+fn assert_template_names_a_missing_ticketing_artifact(template_name: &str) {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let model = fixture_model(tmp.path());
     let template = TemplateLoader::bundled_only()
-        .load("report-technical-dd")
+        .load(template_name)
         .expect("bundled template");
     let md = Reporter::new(tmp.path()).render(&model, &template);
 
@@ -1990,7 +2000,7 @@ fn a_missing_ticketing_artifact_is_named_not_silently_dropped() {
     // the dimension exists and was not assessed.
     assert!(
         md.contains("## 8. Ticketing & Delivery Traceability"),
-        "the heading must survive so the omission is visible:\n{md}"
+        "{template_name}: the heading must survive so the omission is visible:\n{md}"
     );
     let section = md
         .split("## 8. Ticketing & Delivery Traceability")
@@ -1998,7 +2008,7 @@ fn a_missing_ticketing_artifact_is_named_not_silently_dropped() {
         .expect("section body");
     assert!(
         section.contains("_No data available — see Gaps & Caveats._"),
-        "an unpopulated section must say so:\n{section}"
+        "{template_name}: an unpopulated section must say so:\n{section}"
     );
     // And it is listed among the gaps, not merely blank on the page.
     let gaps = md
@@ -2007,6 +2017,45 @@ fn a_missing_ticketing_artifact_is_named_not_silently_dropped() {
         .expect("gaps section");
     assert!(
         gaps.contains("Ticketing & Delivery Traceability"),
-        "the unassessed dimension must be named in Gaps & Caveats:\n{gaps}"
+        "{template_name}: the unassessed dimension must be named in Gaps & Caveats:\n{gaps}"
     );
+}
+
+#[test]
+fn reporter_states_ticketing_coverage() {
+    assert_template_states_ticketing_coverage("report-technical-dd");
+}
+
+#[test]
+fn reporter_states_a_zero_coverage_run_rather_than_omitting_it() {
+    assert_template_states_a_zero_coverage_run("report-technical-dd");
+}
+
+#[test]
+fn a_missing_ticketing_artifact_is_named_not_silently_dropped() {
+    assert_template_names_a_missing_ticketing_artifact("report-technical-dd");
+}
+
+/// The CAST template's copy of the figures-present case.
+///
+/// A CAST engagement resolves the same manifest and the same model: nothing on
+/// the load path is template-aware, so the figures reach `build_scope`
+/// identically. Only the template decides whether they reach the page.
+#[test]
+fn cast_reporter_states_ticketing_coverage() {
+    assert_template_states_ticketing_coverage("report-technical-dd-cast");
+}
+
+/// The CAST template's copy of the correlated-nothing case.
+#[test]
+fn cast_reporter_states_a_zero_coverage_run_rather_than_omitting_it() {
+    assert_template_states_a_zero_coverage_run("report-technical-dd-cast");
+}
+
+/// The CAST template's copy of the missing-artifact case — the one that was
+/// failing invisibly. The template had no §8 at all, so a CAST report showed
+/// neither the coverage figures nor a gap line explaining their absence.
+#[test]
+fn a_missing_ticketing_artifact_is_named_in_the_cast_template_too() {
+    assert_template_names_a_missing_ticketing_artifact("report-technical-dd-cast");
 }

--- a/crates/trusty-review/templates/report-technical-dd-cast.md
+++ b/crates/trusty-review/templates/report-technical-dd-cast.md
@@ -308,7 +308,21 @@ Summary: {{total_components}} components detected; {{critical_cve_components}} w
 |---|---|---|---|---|
 | {{app_name}} | {{deficiency_name}} | {{tech_name}} | {{deficiency_count}} | {{deficiency_effort}} |
 
-## 8. Gaps & Caveats
+## 8. Ticketing & Delivery Traceability
+
+<!-- Engagement-wide commit ↔ board-item correlation, measured by the
+     collection sweep that produced this report's data. Counts and the boards
+     they came from — deliberately no linkage-quality score, grade, or band:
+     nothing here is calibrated against a peer population, and an uncalibrated
+     ratio in this document would be read as one. Deliberately NOT expressed on
+     the CAST 1.00–4.00 scale for the same reason — a health-factor-shaped
+     number here would read as a CAST measurement, and CAST measures no such
+     thing. When the producing run supplied no correlation data this section
+     collapses and is named under Gaps & Caveats, never silently omitted. -->
+
+{{ticketing_coverage}}
+
+## 9. Gaps & Caveats
 
 - {{gap_1}}
 - {{gap_2}}


### PR DESCRIPTION
#5405 added a ticketing-coverage section to `report-technical-dd.md`. `report-technical-dd-cast.md` never got one, so a CAST-methodology engagement rendered no coverage — and no gap line explaining why.

The second half is what made it worth fixing. `polish.rs`'s `omit_empty` collapses an empty section and names it as a gap, keyed on the section heading it sits inside. No section means no heading, so there is nothing to collapse and nothing to name: the omission escapes the exact mechanism built to surface omissions. A reader could not tell an engagement with no board data from one whose template simply dropped the dimension.

The data was always reaching a CAST run. Nothing on the load path is template-aware — `ReportModel::build` records `model.template` and nothing reads it during rendering. A CAST engagement with a valid declared artifact built a populated `TicketingSummary` and discarded it at the template.

## Verified before it was written

The three CAST tests were written first and run against the unmodified template:

```
test cast_reporter_states_ticketing_coverage ... FAILED
test cast_reporter_states_a_zero_coverage_run_rather_than_omitting_it ... FAILED
test a_missing_ticketing_artifact_is_named_in_the_cast_template_too ... FAILED
test result: FAILED. 1 passed; 2 failed
```

with the three generic-template equivalents passing in the same runs.

## Three cases, same as the generic template

| Case | Rendered |
|---|---|
| Figures present | `260 of 412 commit(s) reference 155 of 180 synced board item(s) across jira, linear.` |
| Correlated nothing | `No commit referenced a tracked board item. 300 commit(s)…` |
| No artifact | heading survives, `_No data available — see Gaps & Caveats._`, and the gap is named under §9 |

The missing-artifact test asserts heading, collapse line and gap entry together — any one alone would pass against a template that dropped the dimension entirely.

One CAST-specific choice: the figures are deliberately not placed on the CAST 1.00–4.00 scale. A health-factor-shaped number there would read as a CAST measurement, and CAST measures no such thing.

## Renumbering

Gaps & Caveats moves from §8 to §9, matching the generic template. Checked for references before renumbering — the only tests asserting on those numbers target the generic template and were already updated by #5745; `mermaid_tests.rs` uses a hand-written string, not a loaded template; no doc enumerates either template's sections.

Rather than duplicate ~60 lines, the three existing assertion bodies are now template-parameterized helpers with a named test per template. The three original test names are unchanged — `model.rs:138` and `ticketing.rs` cite them in `Test:` pointers.

## Version bump

`trusty-review` 0.17.0 → 0.18.0. 0.17.0 is published, and `check-pr-version-bump.sh` matches `^crates/[^/]+/src/` with no test-file exemption, so editing `reporter_tests.rs` trips the gate. Minor, per the standing decision.

Worth noting for the tooling owner: `check_changelog_fragment.sh` classified this same diff as test-only and would not have required a fragment, while the version gate treated it as source. The two gates disagree about whether a test file under `crates/*/src/` counts. A fragment was written regardless.

## Test ladder: rung 3

```
cargo fmt --check                                            0
cargo check -p trusty-review                                 0
cargo clippy -p trusty-review --all-targets -- -D warnings   0
cargo test -p trusty-review   0   (1594 passed, 0 failed, 5 ignored)
SKIP_UI_BUILD=1 cargo check --workspace                      0
scripts/check_test_pointers.sh  0   (24840 citations, 0 dangling)
scripts/check_line_cap.sh       0
scripts/check_sld.sh            0
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools