### PR TITLE
fix(trusty-audit, docs): document TRUSTY_AUDIT_WORKDIR and update publish comment

### DIFF
--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -11,9 +11,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-# #5502: not published to crates.io. The delivery path for this crate is the
-# handoff zip of pre-compiled macOS arm64 binaries (#5483), not `cargo install`
-# by the recipient. Flip this to a real publish only if that changes.
+# #5483: not published to crates.io. The delivery path is the signed/notarized client .app plus config and README, not `cargo install` by the recipient.
 publish = false
 
 [lib]

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -39,6 +39,12 @@
 | `TRUSTY_SHUTDOWN_FLUSH_TIMEOUT_SECS` | `trusty-search` daemon (issues #874, #2922) | Explicit override for the graceful-shutdown per-index HNSW/corpus flush deadline, in seconds. When unset (the default), each index's deadline is instead scaled from its own on-disk HNSW snapshot size (`30s` floor + `1s` per 20 MB, capped at 20 minutes) so a multi-hundred-MB index gets a workable budget instead of the old flat `10s` — which was short enough to time out mid-write on large indexes before atomic tmp+rename hardening landed. Set this only to force an exact value (e.g. a constrained CI/test environment); any positive integer wins outright over size-based scaling for every index. `0` or unset falls back to size scaling. |
 | `TRUSTY_SHUTDOWN_FLUSH_CONCURRENCY` | `trusty-search` daemon (issue #2922) | Max number of indexes flushed concurrently during graceful shutdown. Default `4`. Previously all indexes flushed strictly sequentially, so total shutdown time was `N × per-index timeout`; running a bounded number in parallel keeps a fleet of small/fast indexes from queuing behind one large one while still bounding peak concurrent disk I/O. Must be a positive integer; `0` or unparseable falls back to the default. |
 
+## trusty-audit
+
+| Variable | Required by | Purpose |
+|---|---|---|
+| `TRUSTY_AUDIT_WORKDIR` | `trusty-audit` CLI | Root directory for the auditor's working tree. Resolution precedence: `--work-dir` flag, then this env var, then `<cwd>/trusty-audit-work`. |
+
 ## trusty-git-analytics (tga)
 
 | Variable | Required by | Purpose |


### PR DESCRIPTION
## Summary

- Add `TRUSTY_AUDIT_WORKDIR` environment variable to docs/reference/environment-variables.md with resolution precedence
- Update stale Cargo.toml comment to reflect current delivery plan per #5483 (signed/notarized client app, not pre-compiled binaries)

Fixes #5502 characterization.

## Test plan

- ✓ check_sld.sh
- ✓ cargo check -p trusty-audit
- ✓ changelog_fragment gate (docs-only, no fragment needed)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools