### PR TITLE
docs: sync session-placement, write-boundary, and worktree docs with ADR-0044/0048

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,11 +413,12 @@ Publish-time `[patch.crates-io]` semantics are in
 
 ## Parallel Worktree Discipline
 
-Generic worktree discipline — main checkout inspection-only, provisioning off
-`origin/main`, branch-is-the-workstream, one worktree per independently
-reviewable PR outcome, subagent confinement, cleanup — lives in
-`Skill(skill="tm-workflow")`. It applies here in full. What follows is only what
-this repo adds.
+Generic worktree discipline — main checkout read-only for source (mechanically
+enforced; [ADR-0044](docs/adr/0044-main-checkout-write-boundary-and-agent-worktree-ownership.md),
+[ADR-0048](docs/adr/0048-dispatched-writers-get-a-worktree-and-the-write-boundary-is-enforced.md)), provisioning off `origin/main`,
+branch-is-the-workstream, one worktree per independently reviewable PR outcome,
+subagent confinement, cleanup — lives in `Skill(skill="tm-workflow")`. It
+applies here in full. What follows is only what this repo adds.
 
 **End-to-end delivery chain:** accepted outcome → optional issue → worktree
 branch → one cohesive PR → applicable Rust gates → trusty-review gate →

--- a/crates/trusty-mpm/changelog.d/5780-session-placement-docs-sync.md
+++ b/crates/trusty-mpm/changelog.d/5780-session-placement-docs-sync.md
@@ -1,0 +1,3 @@
+Documentation
+
+- `session_new`'s MCP trait doc comment (`mcp/mod.rs`) no longer describes every managed session as an isolated clone; it now names the main-checkout default and the write boundary (ADR-0037, ADR-0044), matching the sibling tool description in `mcp/tools/session.rs`.

--- a/crates/trusty-mpm/docs/ARCHITECTURE-MEMORY-SESSIONS-SEARCH.md
+++ b/crates/trusty-mpm/docs/ARCHITECTURE-MEMORY-SESSIONS-SEARCH.md
@@ -2,9 +2,11 @@
 
 This document describes three foundational design patterns shipped on trusty-mpm's
 `main` branch that govern how the framework manages memory access, session isolation,
-and code search. All three are active in every managed session; understanding their
-trade-offs and failure modes is essential for building reliable tools and debugging
-production behaviour.
+and code search. Memory resolution (§1) and code search indexing (§3) are active in
+every managed session; the worktree model (§2) is active whenever a worktree exists —
+see the note at the top of §2 for when that is. Understanding their trade-offs and
+failure modes is essential for building reliable tools and debugging production
+behaviour.
 
 ## 1. Memory over MCP/JSON-RPC, never a guessed port
 
@@ -47,6 +49,19 @@ shared helper in `trusty-common/src/mcp/memory_rpc.rs` (issue #2030):
 ---
 
 ## 2. Session↔Worktree 1:1 Model + Semantic Naming
+
+> **Superseded default, current scope:** this section predates
+> [ADR-0037](../../../docs/adr/0037-pm-placement-precedence-main-checkout-by-default.md).
+> A managed session no longer gets a worktree by default — it runs on the
+> project's main checkout, which stays writable for documents and
+> configuration only ([ADR-0044](../../../docs/adr/0044-main-checkout-write-boundary-and-agent-worktree-ownership.md),
+> [ADR-0048](../../../docs/adr/0048-dispatched-writers-get-a-worktree-and-the-write-boundary-is-enforced.md)),
+> mechanically enforced, not by convention. What follows still applies whenever
+> a worktree DOES exist: an operator launches with `--worktree`, or a
+> dispatched agent that writes is automatically granted one. A session
+> worktree keeps the `.worktrees/<name>` path this section describes — a
+> different, unaffected family from the harness's own `.claude/worktrees/`
+> agent worktrees ([ADR-0036](../../../docs/adr/0036-all-worktrees-are-siblings-under-claude-worktrees.md)).
 
 **The problem:** Prior to issue #2032, each managed session was backed by a git
 worktree with a UUID-based name (e.g., `.worktrees/fb2c8a12-4e9e-11ec.../`). The

--- a/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
@@ -224,10 +224,18 @@ decides), the PM wanting a second opinion, or confirming green CI.
 
 ## Worktree Isolation on a Dispatch
 
-Pass `isolation: "worktree"` on Agent tool calls when spawning 2+ parallel
-agents that modify files. Not needed for sequential agents, read-only research,
-or separate file trees. Use `run_in_background: true` for fire-and-forget
-parallel work.
+**From a main checkout, this is automatic, not a PM choice (ADR-0048).** `tm
+hook --pm-guard` grants `isolation: "worktree"` to any dispatched agent that
+may write, single or parallel, the moment the session is standing in a main
+checkout — the write boundary above denies that agent a source edit there
+anyway. Nothing needs declaring for this case.
+
+**From inside a worktree, pass it yourself for concurrency.** Pass
+`isolation: "worktree"` on Agent tool calls when spawning 2+ parallel agents
+that modify files on the SAME checkout — the case the guard cannot see,
+because there is no main-checkout grant to fall back on. Not needed for
+sequential agents, read-only research, or separate file trees. Use
+`run_in_background: true` for fire-and-forget parallel work.
 
 🔴 **`isolation: "worktree"` is the only sanctioned mechanism, and the PM never
 authors a `git worktree add` into a dispatch prompt (#5649).**

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -202,16 +202,20 @@ make a red gate green by deleting a test, marking it skipped or ignored, gating
 it out of the build, or excluding it from the run. That hard line ("Sprint, then
 Harden") is unchanged.
 
-## Worktree Discipline (Mandatory Before Any Edit)
+## Worktree Discipline (Mandatory Before Any Source Edit)
 
-The main checkout is **inspection-only** — read-only `git status`/`log`/`diff`/
-`show` and file reads. Forbidden against it: any edit; any build or test run
-(whatever the project's gate is: `cargo build`/`test`, `npm run build`/`test`,
-`pytest`, …); any destructive git operation (`git reset --hard`,
-`git checkout .`, `git stash`, `git restore .`); any file-mutating command
-(`sed`/`awk`/`patch`) — or anything else that mutates the working tree, index,
-or build output. All write-side work happens in a dedicated worktree branched
-off `origin/main`:
+The main checkout's write boundary is mechanically enforced, not a convention
+to remember (`tm hook --pm-guard`; ADR-0044, ADR-0048). Documents and
+configuration stay writable there directly — `.md`, `.toml`, `.json`, `.yaml`,
+extension-less files, `.claude/` framework deployment, and `TASK.md` — for the
+PM and for every agent it dispatches. Forbidden against it: any SOURCE edit;
+`git commit`; any build or test run (whatever the project's gate is: `cargo
+build`/`test`, `npm run build`/`test`, `pytest`, …); any destructive git
+operation (`git reset --hard`, `git checkout .`, `git stash`,
+`git restore .`); any file-mutating command (`sed`/`awk`/`patch`) against a
+source file — or anything else that mutates the working tree, index, or build
+output outside that documents/configuration carve-out. All source write-side
+work happens in a dedicated worktree branched off `origin/main`:
 
 ```bash
 git fetch origin main
@@ -272,9 +276,10 @@ prevent refreshing, so the compliant path and the safe path are the same path.
 If the checkout has genuinely diverged instead, report it and stop.
 
 This is inspection hygiene only, so reads are not answered from stale code. The
-main checkout stays read-only for work; every edit still happens in a worktree.
-`git pull` is already on the PM's allowlist — no new authority, not a budgeted
-direct action.
+main checkout stays read-only for source; every source edit still happens in a
+worktree, and the boundary is enforced mechanically rather than left to
+discipline alone. `git pull` is already on the PM's allowlist — no new
+authority, not a budgeted direct action.
 
 **A worktree is a writer; the branch is the workstream.** The durable unit is
 the branch — one branch per workstream, one session per workstream. A worktree

--- a/crates/trusty-mpm/src/mcp/mod.rs
+++ b/crates/trusty-mpm/src/mcp/mod.rs
@@ -132,14 +132,16 @@ pub trait OrchestratorBackend: Send + Sync {
 
     /// Back `session_new`: spawn a new managed session.
     ///
-    /// Why: the driver skill needs a typed, JSON-native way to create an
-    ///      isolated, provisioned workspace and launch a harness in it — without
-    ///      scraping `tm session new` CLI text (the #842 defect).
-    /// What: provisions a workspace cloned from `repo_url` at `git_ref`, creates
-    ///       the tmux host, launches the selected `runtime` (default claude-code)
-    ///       with `task`, and returns the new session's id / tmux name /
-    ///       workspace path / state / attach command. An unknown `runtime` value
-    ///       is an error string.
+    /// Why: the driver skill needs a typed, JSON-native way to provision a
+    ///      session workspace and launch a harness in it — without scraping
+    ///      `tm session new` CLI text (the #842 defect).
+    /// What: a LOCAL `repo_url` runs the session on that main checkout itself,
+    ///       writing documents and configuration only (ADR-0037, ADR-0044); a
+    ///       remote `repo_url` is cloned into a freshly-provisioned isolated
+    ///       workspace. Either way this creates the tmux host, launches the
+    ///       selected `runtime` (default claude-code) with `task`, and returns
+    ///       the new session's id / tmux name / workspace path / state /
+    ///       attach command. An unknown `runtime` value is an error string.
     /// Test: `dispatch_session_new_tool` (mock) + the daemon-side
     ///       `session_new_spawns_via_manager` integration test.
     async fn session_new(

--- a/docs/getting-started/claude-mpm-vs-trusty-mpm.md
+++ b/docs/getting-started/claude-mpm-vs-trusty-mpm.md
@@ -5,7 +5,7 @@
 **trusty-mpm** (`tm`) is the **Rust** successor to the Python `claude-mpm` project. Both are session orchestrators, but trusty-mpm is a rebuilt, production-grade system with:
 - **Single binary:** `tm` (instead of scattered Python packages)
 - **Managed daemons:** Runs trusty-memory and trusty-search as system services, not ad-hoc
-- **Per-session git worktrees:** Each session gets its own isolated branch, automatically cleaned up on decommission
+- **Main-checkout by default, worktrees on request:** A session runs on the project's main checkout unless launched with `--worktree`; a main-checkout session and every agent it dispatches may write documents and configuration only, and a dispatched agent that writes is automatically granted its own git worktree, cleaned up on decommission
 - **MCP-native storage:** Memory and search are full MCP servers, not REST wrappers
 
 **Install trusty-mpm now:**
@@ -48,8 +48,8 @@ Both systems use the same **agent orchestration framework**:
 | **Primary binary** | `claude-mpm` (Python entry point) | `tm` / `trusty-mpm` (single binary) |
 | **Memory storage** | In-process or external API | Full MCP daemon (`trusty-memory` on port 7070) |
 | **Code search** | External REST API only | Full MCP daemon (`trusty-search` on port 7878) |
-| **Session management** | Ad-hoc tmux windows; manual cleanup | Managed git worktrees; auto-decommission |
-| **Session isolation** | Shared global state | Per-worktree branch + scoped memory palace |
+| **Session management** | Ad-hoc tmux windows; manual cleanup | Main checkout by default, `--worktree` opt-in; auto-decommission |
+| **Session isolation** | Shared global state | Mechanically enforced main-checkout write boundary + scoped memory palace |
 | **MCP servers** | Ad-hoc wrappers | Native MCP stdio + HTTP transports |
 | **Configuration** | Scattered YAML/ENV files | Unified `~/.trusty-tools/config/` + project overrides |
 | **Daemon lifecycle** | Manual start/stop | System services (launchd/systemd) |
@@ -87,12 +87,22 @@ tctl install trusty-mpm
 - All sessions share the main checkout or rely on `[patch.crates-io]` trickery.
 
 **trusty-mpm:**
-- Creates a dedicated **git worktree** per session, branched off `main`.
-- Session name is semantic (e.g., `.worktrees/tm-myproject-01/`) — stable across restarts.
-- Worktree is **automatically decommissioned** when the session ends (branch + directory removed).
-- Each session runs in an isolated branch; changes don't leak to main.
+- A session runs on the project's **main checkout** by default — several sessions
+  sharing one checkout is the normal, intended arrangement, not a hazard.
+  `tm launch --worktree` opts a session into its own dedicated git worktree
+  instead, branched off `main`.
+- A main-checkout session, and every agent it dispatches, may write documents
+  and configuration only; source edits and `git commit` are denied there,
+  mechanically — not left to convention.
+- A dispatched agent that writes is automatically granted its own git worktree
+  the moment its session is standing in a main checkout, so it never collides
+  with another session's uncommitted work.
+- A worktree — session-requested or agent-granted — is **automatically
+  decommissioned** when the work it holds is done (branch + directory
+  removed).
 
-**Impact:** You can safely have 5 parallel sessions, each in a different branch, without branch-collision chaos or manual cleanup.
+**Impact:** You can safely have 5 parallel sessions sharing one checkout, each
+dispatching writers, without branch-collision chaos or manual cleanup.
 
 See [Architecture: Memory, Sessions, Search](../../crates/trusty-mpm/docs/ARCHITECTURE-MEMORY-SESSIONS-SEARCH.md) for the full design.
 
@@ -160,7 +170,7 @@ If you have an existing Claude Code project that was set up with claude-mpm or s
    tm
    ```
 
-Your project is now managed by trusty-mpm. All future sessions will run under the trusty-mpm framework with git worktrees, managed memory, and persistent search indexes.
+Your project is now managed by trusty-mpm. All future sessions will run under the trusty-mpm framework on the main checkout by default (worktrees on request or when an agent it dispatches needs to write), with managed memory and persistent search indexes.
 
 ---
 

--- a/docs/reference/worktree-discipline.md
+++ b/docs/reference/worktree-discipline.md
@@ -1,9 +1,21 @@
 # Parallel Worktree Discipline — Extended Reference
 
-Multiple Claude Code sessions and subagents may share this repo concurrently.
-The main checkout often holds another session's uncommitted work. To prevent
-one session from stomping on another's edits, these rules protect all concurrent
-work.
+Multiple Claude Code sessions and subagents sharing this repo concurrently is
+the normal, intended arrangement, not a hazard to work around. The main
+checkout often holds another session's uncommitted work.
+
+**The write boundary that protects that work is mechanically enforced, not
+left to convention** (`tm hook --pm-guard`; [ADR-0044](../adr/0044-main-checkout-write-boundary-and-agent-worktree-ownership.md),
+[ADR-0048](../adr/0048-dispatched-writers-get-a-worktree-and-the-write-boundary-is-enforced.md)).
+Documents and configuration — `.md`, `.toml`, `.json`, `.yaml`,
+extension-less files, `.claude/` framework deployment, `TASK.md` — stay
+writable directly in the main checkout for the PM and every agent it
+dispatches; source edits and `git commit` there are denied for both. A
+dispatched agent that may write is granted its own worktree under
+`.claude/worktrees/` automatically the moment the session is standing in a
+main checkout — see [ADR-0036](../adr/0036-all-worktrees-are-siblings-under-claude-worktrees.md)
+for where that worktree lives. The rules below are what remains a matter of
+discipline rather than mechanical enforcement.
 
 ## Why Worktree Discipline Matters
 


### PR DESCRIPTION
## Summary

ADR-0044/ADR-0048 (merged in #5769, at `50c40965`) made the main-checkout
write boundary mechanical: documents and configuration stay writable there
for the PM and every dispatched agent, source edits and `git commit` are
denied, and a dispatched writer is auto-granted its own worktree. This PR
syncs the docs that still described the pre-#5769 model.

- `CLAUDE.md` — "Parallel Worktree Discipline" points at the mechanically
  enforced boundary instead of "inspection-only", with links to ADR-0044/0048.
- `crates/trusty-mpm/src/assets/skills/tm-workflow.md` — "Worktree
  Discipline" no longer claims every edit is forbidden in the main checkout;
  documents/configuration are carved out.
- `crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md` —
  "Worktree Isolation on a Dispatch" distinguishes the automatic
  main-checkout grant (ADR-0048) from the PM-declared case inside an
  existing worktree.
- `docs/reference/worktree-discipline.md` — opens by stating concurrent
  sessions are the intended arrangement, names where the boundary is
  enforced.
- `docs/getting-started/claude-mpm-vs-trusty-mpm.md` (public page) —
  replaces "per-session worktree by default" claims with the actual
  main-checkout-by-default behavior.
- `crates/trusty-mpm/docs/ARCHITECTURE-MEMORY-SESSIONS-SEARCH.md` — scopes
  the pre-ADR-0037 "Session↔Worktree 1:1 Model" section to when a worktree
  actually exists.
- `crates/trusty-mpm/src/mcp/mod.rs` — `session_new`'s trait doc comment
  described every session as an isolated clone; corrected to name the
  main-checkout default, mirroring the sibling tool description in
  `mcp/tools/session.rs` (already fixed by an earlier change).
- `crates/trusty-mpm/changelog.d/5780-session-placement-docs-sync.md` — new
  fragment for the `mcp/mod.rs` doc-comment fix.

No ADR Context/Decision/Consequences text was rewritten — all ADR statuses
and INDEX rows were already consistent (0037 Amended by 0044, 0044 Amended
by 0048, 0048 Accepted, 0036 Accepted).

## Test plan

- [x] `bash scripts/check_adr.sh` — 48 workspace ADRs and crate indexes
      consistent
- [x] `bash scripts/check_adr.sh --self-test` — all 6 cases passed
- [x] `bash scripts/check_sld.sh` — 0 errors, 0 warnings
- [x] `bash scripts/check_test_pointers.sh` — 0 dangling pointers
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] `cargo check -p trusty-mpm` — finished clean
- [x] `bash scripts/check_changelog_fragment.sh` — fragment present and valid

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools