### PR TITLE
fix(trusty-mpm): regenerate tm-capabilities cli.md and mcp-tools.md

### DIFF
--- a/crates/trusty-mpm/changelog.d/5783-capabilities-drift-regen.md
+++ b/crates/trusty-mpm/changelog.d/5783-capabilities-drift-regen.md
@@ -1,0 +1,3 @@
+Fixed
+
+- Regenerated `tm-capabilities/references/cli.md` and `mcp-tools.md`, which had drifted from `main` since v1.5.0 (#5769) added a daemon route and changed the guard surface. `mcp-tools.md`'s `session_new` entry now reflects the ADR-0037 reversal: a local `repo_url` runs the session on that main checkout itself, only a remote URL is cloned into a freshly-provisioned workspace.

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
@@ -40,7 +40,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
 - `hooks` — Project-settings hook hygiene: detect and remove tm hook contamination (issue #2940)
   - `clean` — Remove tm-owned hook entries from project-level `.claude/settings.json` / `settings.local.json` files
 - `install` — Install the bundled framework artifacts to `~/.trusty-mpm/framework/`
-- `internal-spawn-disclaimed` — [INTERNAL] Spawn a program with macOS TCC responsibility disclaimed (issue #2997) — not for direct use
+- `internal-spawn-disclaimed` — \[INTERNAL\] Spawn a program with macOS TCC responsibility disclaimed (issue #2997) — not for direct use
 - `issue` — YAML-configurable issue state-management (labels/transitions/assignee)
   - `current` — Report an issue's current state, derived from its labels
   - `repair` — Resolve a mid-transition issue carrying multiple state labels
@@ -121,7 +121,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `list` — List all SESSCTL sessions
   - `run` — Spawn a SESSCTL session for a project via the daemon HTTP API
   - `stop` — Stop a session (graceful by default, --force for immediate)
-- `session` — [DEPRECATED] Alias of `sessions` (#2116) — use `tm sessions <verb>`
+- `session` — \[DEPRECATED\] Alias of `sessions` (#2116) — use `tm sessions <verb>`
   - `activity` — Show recent activity for a managed session
   - `answer` — Answer a managed session's pending decision
   - `attach` — Print the tmux attach command for a managed session
@@ -136,8 +136,8 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `instructions` — Print the composed launch instructions a session would receive
   - `list` — List sessions for the current project
   - `ls` — List managed sessions (session-manager MVP)
-  - `managed-resume` — [DEPRECATED] Resume a stopped managed session — use `resume` instead
-  - `managed-stop` — [DEPRECATED] Stop a managed session's runtime — use `stop` instead
+  - `managed-resume` — \[DEPRECATED\] Resume a stopped managed session — use `resume` instead
+  - `managed-stop` — \[DEPRECATED\] Stop a managed session's runtime — use `stop` instead
   - `new` — Spawn a new managed session from a repo + ref (session-manager MVP)
   - `output` — Capture the current output of a session's tmux pane
   - `pause` — Pause a running session, saving state for later resume
@@ -148,7 +148,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `rename` — Rename a managed session — from the list OR from within a session
   - `resume` — Resume a stopped/paused session (managed or project session)
   - `run` — Send a command to a session's tmux pane
-  - `runtime-stop` — [DEPRECATED] Stop a managed session's runtime — use `stop` instead
+  - `runtime-stop` — \[DEPRECATED\] Stop a managed session's runtime — use `stop` instead
   - `send` — Inject text into a managed session's pane
   - `start` — Start a new Claude Code session in the current/specified project
   - `stop` — Stop a session by id or friendly name (managed or project session)
@@ -169,8 +169,8 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `instructions` — Print the composed launch instructions a session would receive
   - `list` — List sessions for the current project
   - `ls` — List managed sessions (session-manager MVP)
-  - `managed-resume` — [DEPRECATED] Resume a stopped managed session — use `resume` instead
-  - `managed-stop` — [DEPRECATED] Stop a managed session's runtime — use `stop` instead
+  - `managed-resume` — \[DEPRECATED\] Resume a stopped managed session — use `resume` instead
+  - `managed-stop` — \[DEPRECATED\] Stop a managed session's runtime — use `stop` instead
   - `new` — Spawn a new managed session from a repo + ref (session-manager MVP)
   - `output` — Capture the current output of a session's tmux pane
   - `pause` — Pause a running session, saving state for later resume
@@ -181,7 +181,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `rename` — Rename a managed session — from the list OR from within a session
   - `resume` — Resume a stopped/paused session (managed or project session)
   - `run` — Send a command to a session's tmux pane
-  - `runtime-stop` — [DEPRECATED] Stop a managed session's runtime — use `stop` instead
+  - `runtime-stop` — \[DEPRECATED\] Stop a managed session's runtime — use `stop` instead
   - `send` — Inject text into a managed session's pane
   - `start` — Start a new Claude Code session in the current/specified project
   - `stop` — Stop a session by id or friendly name (managed or project session)

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/mcp-tools.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/mcp-tools.md
@@ -84,7 +84,7 @@ File a GitHub issue in bobmatnyc/trusty-tools for the error identified by `finge
 
 ## `session_new`
 
-Spawn a new managed Claude Code (or trusty-code) session in an isolated, freshly-provisioned workspace cloned from `repo_url` at `ref`. The daemon creates the tmux host, deploys agents/skills, and launches the harness with the given `task`. Returns the new managed session id, tmux name, workspace path, lifecycle state, and the `tmux attach-session` command.
+Spawn a new managed Claude Code (or trusty-code) session for `repo_url` at `ref`. A LOCAL `repo_url` — an absolute path to an existing directory — runs the session on that main checkout itself (ADR-0037); only a remote URL is cloned into a freshly-provisioned workspace. A main-checkout session may write documents and configuration only, and the writers it dispatches are given their own worktrees (ADR-0044, ADR-0048). The daemon creates the tmux host, deploys agents/skills, and launches the harness with the given `task`. Returns the new managed session id, tmux name, workspace path, lifecycle state, and the `tmux attach-session` command.
 
 | Parameter | Type | Required |
 |---|---|---|


### PR DESCRIPTION
## Summary
- `Capabilities drift` has been red on `main` since #5769 (v1.5.0) changed the CLI/guard surface without a regeneration. Confirmed red at `3ad1b8ca`, `ae896053`, and `eafe45fd`; pre-existing, not caused by any PR since.
- Regenerated with THIS branch's own freshly-built binary (`trusty-mpm 1.5.0`, built via `cargo build -p trusty-mpm --bins` from this worktree off `origin/main` at `f32dc1e1`) — not the operator's stale 1.4.1 on PATH, which would have reproduced drift in the wrong direction.
- `mcp-tools.md`'s `session_new` entry now reflects the ADR-0037 reversal: a local `repo_url` runs the session on that main checkout itself; only a remote URL is cloned into a freshly-provisioned workspace. Matches the already-corrected docstring in `crates/trusty-mpm/src/mcp/tools/session.rs`.
- No overlap with #5780 (`docs/session-placement-survey`) — it touches hand-written docs and an internal trait doc comment in `mcp/mod.rs`, not the generated files or the `session.rs` tool description this regeneration sources from.

Closes #5783.

## Test plan
- [x] `./target/debug/tm generate capabilities --check` — reproduced the drift before the fix
- [x] `./target/debug/tm generate capabilities` — regenerated; only `cli.md` and `mcp-tools.md` changed, matching the CI failure's file list exactly
- [x] `./target/debug/tm generate capabilities --check` — now reports "up to date (7 generated files)"
- [x] `bash scripts/check_line_cap.sh` — pass
- [x] `bash scripts/check_sld.sh` — pass
- [x] `bash scripts/check_changelog_fragment.sh` — pass ("scanned 3 changed path(s); all 1 crate(s) with source changes are recorded")

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools