### PR TITLE
feat(scripts): trusty-audit handoff packaging/verify scaffolding (#5483)

### DIFF
--- a/scripts/package-trusty-audit-handoff.sh
+++ b/scripts/package-trusty-audit-handoff.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# package-trusty-audit-handoff.sh — assemble the trusty-audit handoff zip,
+# shaped for issue #5483's REAL target layout (not the superseded
+# pre-compiled-binaries plan).
+#
+# Why: #5483 supersedes the earlier "includes all necessary pre-compiled
+#   binaries" plan. The auditor client is a standalone Tauri app (#5477) that
+#   downloads `tga`/`trusty-analyze`/`trusty-review`/`gh` itself at pinned
+#   versions at runtime, so the handoff zip carries no tool binaries at all —
+#   only the signed/notarized client `.app` (#5477/#5484), the readable
+#   engagement config (#5478), and a README.
+#
+# 🔴 THIS DOES NOT CLOSE #5483. As of this script's introduction, none of its
+#   three inputs exist as real build outputs in this repo:
+#     #5477 — the Tauri client app itself (no crate, no src-tauri/ anywhere
+#             under crates/trusty-audit/)
+#     #5478 — the engagement config generator / schema
+#     #5484 — Developer-ID signing + notarization of the `.app`
+#   This script only assembles whatever it is handed — it does not build,
+#   sign, or generate any of the three. See
+#   scripts/verify-trusty-audit-handoff-selftest.sh for how it is exercised
+#   today, with synthetic fixtures standing in for all three.
+#
+# What: takes three inputs as PARAMETERS (never hardcoded paths, so this
+#   script works unchanged the day #5477/#5478/#5484 produce real outputs)
+#   and zips them into one canonical top-level layout:
+#
+#     <AppBundleName>.app/...   (recursive copy of --app, basename preserved)
+#     <config-basename>         (--config, basename preserved)
+#     README.md                 (--readme content, normalized to this name)
+#
+#   No tool binaries, no HTML entry point — both are explicitly out of scope
+#   per #5483's current text.
+#
+# Platform: macOS arm64 only (#5483's own scope). The `.app` this script
+#   accepts is expected to be an arm64 bundle; this script does not itself
+#   check architecture — that is verify-trusty-audit-handoff.sh's job, run
+#   separately, since packaging and verifying are different failure surfaces.
+#
+# Usage:
+#   scripts/package-trusty-audit-handoff.sh \
+#     --app <path/to/Name.app> --config <path/to/config.toml> \
+#     --readme <path/to/README.md> --out <path/to/output.zip>
+#
+# Test: scripts/verify-trusty-audit-handoff-selftest.sh builds synthetic
+#   fixtures with this script and asserts the verifier's pass/fail behavior
+#   against what it produces.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/package-trusty-audit-handoff.sh --app <DIR.app> --config <FILE> --readme <FILE> --out <FILE.zip>
+
+  --app     path to the client .app bundle (a directory ending in .app,
+            containing Contents/MacOS/)
+  --config  path to the readable engagement config file
+  --readme  path to the README to include (copied in as README.md)
+  --out     path to write the resulting zip to
+EOF
+}
+
+APP=""
+CONFIG=""
+README=""
+OUT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --app) APP="${2:-}"; shift 2 ;;
+    --config) CONFIG="${2:-}"; shift 2 ;;
+    --readme) README="${2:-}"; shift 2 ;;
+    --out) OUT="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "FAIL: unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [ -z "$APP" ] || [ -z "$CONFIG" ] || [ -z "$README" ] || [ -z "$OUT" ]; then
+  echo "FAIL: --app, --config, --readme, and --out are all required" >&2
+  usage
+  exit 2
+fi
+
+if ! command -v zip >/dev/null 2>&1; then
+  echo "FAIL: 'zip' is not available in this environment" >&2
+  exit 1
+fi
+
+case "$APP" in
+  *.app) ;;
+  *) echo "FAIL: --app must end in .app: $APP" >&2; exit 1 ;;
+esac
+if [ ! -d "$APP" ]; then
+  echo "FAIL: --app is not a directory: $APP" >&2
+  exit 1
+fi
+if [ ! -d "$APP/Contents/MacOS" ]; then
+  echo "FAIL: --app is not a real bundle shape (missing Contents/MacOS/): $APP" >&2
+  exit 1
+fi
+if [ ! -f "$CONFIG" ]; then
+  echo "FAIL: --config does not exist: $CONFIG" >&2
+  exit 1
+fi
+if [ ! -f "$README" ]; then
+  echo "FAIL: --readme does not exist: $README" >&2
+  exit 1
+fi
+
+# Resolve to absolute paths before we `cd` into the staging directory below.
+APP="$(cd "$(dirname "$APP")" && pwd)/$(basename "$APP")"
+CONFIG="$(cd "$(dirname "$CONFIG")" && pwd)/$(basename "$CONFIG")"
+README="$(cd "$(dirname "$README")" && pwd)/$(basename "$README")"
+case "$OUT" in
+  /*) ;;
+  *) OUT="$(pwd)/$OUT" ;;
+esac
+
+APP_BASENAME="$(basename "$APP")"
+CONFIG_BASENAME="$(basename "$CONFIG")"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+STAGE="$WORK/stage"
+mkdir -p "$STAGE"
+cp -R "$APP" "$STAGE/$APP_BASENAME"
+cp "$CONFIG" "$STAGE/$CONFIG_BASENAME"
+cp "$README" "$STAGE/README.md"
+
+mkdir -p "$(dirname "$OUT")"
+rm -f "$OUT"
+( cd "$STAGE" && zip -r -X -q "$OUT" "$APP_BASENAME" "$CONFIG_BASENAME" "README.md" )
+
+if [ ! -s "$OUT" ]; then
+  echo "FAIL: zip was not produced (or is empty): $OUT" >&2
+  exit 1
+fi
+
+echo "PACKAGED: $OUT"
+echo "  app:    $APP_BASENAME"
+echo "  config: $CONFIG_BASENAME"
+echo "  readme: README.md"

--- a/scripts/verify-trusty-audit-handoff-selftest.sh
+++ b/scripts/verify-trusty-audit-handoff-selftest.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+#
+# verify-trusty-audit-handoff-selftest.sh — failing-case fixtures for
+# verify-trusty-audit-handoff.sh (the trusty-audit handoff packaging path,
+# #5483's real target layout — see that script's header for what it checks).
+#
+# Why: a verifier only proves its worth by what it REJECTS — the same
+#   principle behind check_public_docs_selftest.sh and
+#   `check_adr.sh --self-test`. This asserts a clean baseline PASSES first
+#   (mirroring check_adr.sh's "clean corpus passes" assertion, which is what
+#   makes each later mutation meaningful — without it, a mutation "failing"
+#   could just mean the harness itself is broken), then mutates one fixture
+#   at a time and asserts the verifier FAILS with the expected reason on
+#   its output — including the #5620 shape (an absent/empty zip must FAIL,
+#   never read as "nothing found, pass").
+#
+#   Fixtures are built with `cc`, not copied from anywhere real: a trivial C
+#   program compiled for a chosen architecture, wrapped in a hand-built .app
+#   bundle. This is deliberately NOT a real build — unsigned, bundle ID says
+#   "test-fixture-NOT-REAL", --version string says "-selftest". Never mistake
+#   this script's output for a shippable artifact.
+#
+# Requires: macOS with Xcode Command Line Tools (cc, lipo, file, plutil,
+#   zip, unzip) and python3 — the same platform this tooling targets
+#   (#5483 is arm64-only). SKIPs (exit 0) rather than failing if any of
+#   these are missing, since that means the self-test cannot exercise the
+#   verifier at all, not that the verifier is broken.
+#
+# Test: this IS the test. Run directly:
+#   bash scripts/verify-trusty-audit-handoff-selftest.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE="$SCRIPT_DIR/package-trusty-audit-handoff.sh"
+VERIFY="$SCRIPT_DIR/verify-trusty-audit-handoff.sh"
+
+VERSION_STRING="0.0.0-selftest"
+
+for tool in cc lipo file zip unzip python3 plutil; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "SKIP: '$tool' not available — this self-test requires macOS + Xcode Command Line Tools" >&2
+    exit 0
+  fi
+done
+
+passes=0
+failures=0
+
+# --- fixture builders ---------------------------------------------------------
+
+# build_app <dir> <arch> -> prints the path to a synthetic .app bundle whose
+# single executable is compiled for <arch> ("arm64" or "x86_64").
+build_app() {
+  local dir="$1" arch="$2"
+  local app="$dir/TrustyAuditFixture.app"
+  mkdir -p "$app/Contents/MacOS"
+  cat >"$dir/main.c" <<'CSRC'
+#include <stdio.h>
+#include <string.h>
+int main(int argc, char **argv) {
+  if (argc > 1 && strcmp(argv[1], "--version") == 0) {
+    printf("trusty-audit-fixture 0.0.0-selftest\n");
+    return 0;
+  }
+  return 1;
+}
+CSRC
+  cc -arch "$arch" -o "$app/Contents/MacOS/TrustyAuditFixture" "$dir/main.c" 2>&1
+  cat >"$app/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>TrustyAuditFixture</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.trusty-mpm.test-fixture.NOT-REAL</string>
+  <key>CFBundleName</key>
+  <string>TrustyAuditFixture (synthetic self-test fixture, not a real build)</string>
+</dict>
+</plist>
+PLIST
+  printf '%s' "$app"
+}
+
+build_config() {
+  local dir="$1"
+  local cfg="$dir/engagement.toml"
+  cat >"$cfg" <<'TOML'
+# Synthetic self-test fixture — NOT a real engagement config (#5478 does not
+# exist in this repo yet). Shape is illustrative only.
+engagement_name = "selftest-fixture"
+audit_window_weeks = 52
+TOML
+  printf '%s' "$cfg"
+}
+
+build_readme() {
+  local dir="$1"
+  local rd="$dir/SOURCE-README.md"
+  printf '# trusty-audit handoff (self-test fixture)\n\nSynthetic, not a real deliverable.\n' >"$rd"
+  printf '%s' "$rd"
+}
+
+# expect <label> <expected_exit> <expected_substring|-> -- <cmd...>
+expect() {
+  local label="$1" expected_exit="$2" expected_sub="$3"
+  shift 3
+  local out rc
+  out="$("$@" 2>&1)"
+  rc=$?
+  if [ "$rc" -ne "$expected_exit" ]; then
+    echo "FAIL: $label -> exit $rc (expected $expected_exit)" >&2
+    printf '%s\n' "$out" | sed 's/^/       /' >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if [ "$expected_sub" != "-" ] && ! printf '%s\n' "$out" | grep -qF -- "$expected_sub"; then
+    echo "FAIL: $label -> exit $rc as expected, but output never mentions '$expected_sub'" >&2
+    printf '%s\n' "$out" | sed 's/^/       /' >&2
+    failures=$((failures + 1))
+    return
+  fi
+  echo "  ok   $label -> exit $rc"
+  printf '%s\n' "$out" | sed 's/^/       /'
+  passes=$((passes + 1))
+}
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# --- baseline: a clean synthetic artifact must PASS ---------------------------
+# This is the assertion that makes every case below meaningful: if the
+# harness itself were broken (wrong fixture shape, wrong package-script
+# invocation), a mutation "failing" downstream would prove nothing.
+
+clean_dir="$TMP_ROOT/clean"
+mkdir -p "$clean_dir"
+app_path="$(build_app "$clean_dir" arm64)"
+cfg_path="$(build_config "$clean_dir")"
+rd_path="$(build_readme "$clean_dir")"
+good_zip="$TMP_ROOT/good.zip"
+
+if ! pkg_out="$(bash "$PACKAGE" --app "$app_path" --config "$cfg_path" --readme "$rd_path" --out "$good_zip" 2>&1)"; then
+  echo "FAIL: package script could not build the baseline fixture" >&2
+  printf '%s\n' "$pkg_out" | sed 's/^/       /' >&2
+  failures=$((failures + 1))
+else
+  expect "clean synthetic artifact passes" 0 "VERIFY: PASS" \
+    bash "$VERIFY" --zip "$good_zip" --expect-version "$VERSION_STRING"
+fi
+
+# --- case: a member missing --------------------------------------------------
+
+missing_zip="$TMP_ROOT/missing-member.zip"
+cp "$good_zip" "$missing_zip"
+zip -d "$missing_zip" "README.md" >/dev/null
+expect "member missing (README.md)" 1 "missing top-level README.md" \
+  bash "$VERIFY" --zip "$missing_zip" --expect-version "$VERSION_STRING"
+
+# --- case: wrong architecture (x86_64 where arm64 is required) ---------------
+
+wrong_arch_dir="$TMP_ROOT/wrong-arch"
+mkdir -p "$wrong_arch_dir"
+wa_app="$(build_app "$wrong_arch_dir" x86_64)"
+wa_cfg="$(build_config "$wrong_arch_dir")"
+wa_rd="$(build_readme "$wrong_arch_dir")"
+wrong_arch_zip="$TMP_ROOT/wrong-arch.zip"
+bash "$PACKAGE" --app "$wa_app" --config "$wa_cfg" --readme "$wa_rd" --out "$wrong_arch_zip" >/dev/null
+expect "wrong architecture (x86_64)" 1 "NOT arm64" \
+  bash "$VERIFY" --zip "$wrong_arch_zip" --expect-version "$VERSION_STRING"
+
+# --- case: truncated / corrupt .app executable --------------------------------
+# Truncated to 4 bytes: enough for `file` to still see the Mach-O magic, not
+# enough to see the cputype field — so it reports "Mach-O 64-bit" with no
+# architecture, which is what a genuinely truncated download looks like.
+
+corrupt_dir="$TMP_ROOT/corrupt"
+mkdir -p "$corrupt_dir"
+c_app="$(build_app "$corrupt_dir" arm64)"
+dd if="$c_app/Contents/MacOS/TrustyAuditFixture" of="$c_app/Contents/MacOS/TrustyAuditFixture.trunc" bs=1 count=4 2>/dev/null
+mv "$c_app/Contents/MacOS/TrustyAuditFixture.trunc" "$c_app/Contents/MacOS/TrustyAuditFixture"
+c_cfg="$(build_config "$corrupt_dir")"
+c_rd="$(build_readme "$corrupt_dir")"
+corrupt_zip="$TMP_ROOT/corrupt.zip"
+bash "$PACKAGE" --app "$c_app" --config "$c_cfg" --readme "$c_rd" --out "$corrupt_zip" >/dev/null
+expect "truncated/corrupt .app executable" 1 "corrupt or truncated" \
+  bash "$VERIFY" --zip "$corrupt_zip" --expect-version "$VERSION_STRING"
+
+# --- case: unparseable config --------------------------------------------------
+
+badcfg_dir="$TMP_ROOT/badcfg"
+mkdir -p "$badcfg_dir"
+bc_app="$(build_app "$badcfg_dir" arm64)"
+bc_cfg="$badcfg_dir/engagement.toml"
+printf 'this is not [valid toml\n' >"$bc_cfg"
+bc_rd="$(build_readme "$badcfg_dir")"
+badcfg_zip="$TMP_ROOT/badcfg.zip"
+bash "$PACKAGE" --app "$bc_app" --config "$bc_cfg" --readme "$bc_rd" --out "$badcfg_zip" >/dev/null
+expect "unparseable config" 1 "does not parse as TOML" \
+  bash "$VERIFY" --zip "$badcfg_zip" --expect-version "$VERSION_STRING"
+
+# --- case: empty / absent zip (#5620 shape — must FAIL, never read as pass) --
+
+absent_zip="$TMP_ROOT/does-not-exist.zip"
+expect "absent zip (#5620 shape)" 1 "does not exist" \
+  bash "$VERIFY" --zip "$absent_zip" --expect-version "$VERSION_STRING"
+
+empty_zip="$TMP_ROOT/empty.zip"
+: >"$empty_zip"
+expect "empty zip (#5620 shape)" 1 "empty" \
+  bash "$VERIFY" --zip "$empty_zip" --expect-version "$VERSION_STRING"
+
+echo ""
+if [ "$failures" -gt 0 ]; then
+  printf 'verify-trusty-audit-handoff self-test: %d/%d case(s) failed\n' \
+    "$failures" "$((passes + failures))" >&2
+  exit 1
+fi
+printf 'verify-trusty-audit-handoff self-test: all %d cases passed\n' "$passes"

--- a/scripts/verify-trusty-audit-handoff.sh
+++ b/scripts/verify-trusty-audit-handoff.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+#
+# verify-trusty-audit-handoff.sh — open the trusty-audit handoff zip and
+# check its actual contents, shaped for issue #5483's REAL target layout.
+#
+# Why: two failure shapes this repo has been bitten by, both guarded against
+#   here:
+#
+#   #5620 — "found nothing" must never report success. `check_semver.sh`
+#     exited 0 both when it compared a crate and when it compared NOTHING, so
+#     `0 crate(s) checked` printed `[PASS]`. This script distinguishes
+#     "verified and correct" from "nothing found to verify" — an absent,
+#     empty, or unreadable zip is a FAIL, never a pass by default (see
+#     summarize_and_exit below: zero checks run can never exit 0).
+#
+#   #3540 — a false `if:` silently SKIPS a job, and a skipped release is
+#     silent. This script is deliberately NOT wired into any CI workflow: as
+#     of its introduction there is no build job that produces a real `.app`
+#     (#5477/#5478/#5484 are all unimplemented — see
+#     package-trusty-audit-handoff.sh's header), so a CI job calling this
+#     today would always find nothing and either always fail loud (useless
+#     noise on every PR) or be given an `if:` to skip when there's nothing to
+#     check (exactly the #3540 shape, from the other direction). Wire it in
+#     once a real `.app`-producing job exists, as a `needs:` step that fails
+#     BEFORE any upload — not an `if:` on the job (see PR #5767's pattern for
+#     the release-completeness audit).
+#
+# 🔴 THIS DOES NOT CLOSE #5483. Same waits-on list as the packaging script:
+#   #5477 (client app), #5478 (config schema/generator), #5484 (signing /
+#   notarization).
+#
+# What: given a zip built to package-trusty-audit-handoff.sh's canonical
+#   layout, verifies:
+#
+#   1. the zip exists, is non-empty, and is readable as a zip archive.
+#   2. exactly three top-level members: one `*.app` bundle, one literal
+#      `README.md`, and exactly one other regular file (the config) — a
+#      missing OR an extra/unexpected member is a FAIL.
+#   3. the `.app` has a real bundle shape (Contents/Info.plist,
+#      Contents/MacOS/<executable>), and that executable is identified by
+#      `file`(1) as a Mach-O 64-bit **executable**, arm64 — never x86_64-only,
+#      never a truncated/corrupt partial header.
+#   4. if --expect-version is given AND the host CPU itself is arm64, the
+#      executable is actually RUN with `--version` and its output is checked
+#      for the expected substring — never assumed from the static check
+#      alone. On a non-arm64 host this check is explicitly reported as
+#      skipped ("not verified here"), never silently treated as passed.
+#   5. the config member parses as TOML (python3's `tomllib`) — a
+#      byte-present but unparseable file is a FAIL.
+#   6. signing / notarization state is REPORTED via `codesign`/`spctl`,
+#      always printed, separately from checks 2-5. #5484 does not exist yet,
+#      so nothing packaged today will ever pass a signing check — this is
+#      informational by default (pass `--require-signed` to make it a hard
+#      gate once #5484 lands). When codesign/spctl themselves are unavailable
+#      in the running environment, that is reported explicitly as
+#      "not verified here" — it is never allowed to read as "signed".
+#
+# Usage:
+#   scripts/verify-trusty-audit-handoff.sh --zip <FILE.zip> \
+#     [--expect-version <STRING>] [--require-signed]
+#
+# Exit: 0 only when every hard check (2-5) ran AND passed. 1 on any failure,
+#   including an absent/empty/unreadable zip (zero checks run is itself a
+#   FAIL — see summarize_and_exit). 2 on a usage error.
+#
+# Test: scripts/verify-trusty-audit-handoff-selftest.sh
+
+set -uo pipefail  # deliberately not -e: we want to accumulate every failing
+                   # check and report all of them, not stop at the first one
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/verify-trusty-audit-handoff.sh --zip <FILE.zip> [--expect-version <STRING>] [--require-signed]
+EOF
+}
+
+ZIP=""
+EXPECT_VERSION=""
+REQUIRE_SIGNED=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --zip) ZIP="${2:-}"; shift 2 ;;
+    --expect-version) EXPECT_VERSION="${2:-}"; shift 2 ;;
+    --require-signed) REQUIRE_SIGNED=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "FAIL: unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [ -z "$ZIP" ]; then
+  echo "FAIL: --zip is required" >&2
+  usage
+  exit 2
+fi
+
+FAILURES=0
+CHECKS=0
+
+fail() { printf '[FAIL] %s\n' "$1" >&2; FAILURES=$((FAILURES + 1)); }
+ok()   { printf '[ok]   %s\n' "$1"; CHECKS=$((CHECKS + 1)); }
+info() { printf '[INFO] %s\n' "$1"; }
+
+summarize_and_exit() {
+  echo ""
+  # Belt-and-suspenders against the #5620 shape: even if every individual
+  # check above were somehow bypassed, zero checks run is a FAIL, never the
+  # silent PASS that "0 compared" produced there.
+  if [ "$CHECKS" -eq 0 ] && [ "$FAILURES" -eq 0 ]; then
+    fail "no checks were run — nothing was verified"
+  fi
+  if [ "$FAILURES" -gt 0 ]; then
+    printf 'VERIFY: FAIL — %d check(s) passed, %d check(s) failed\n' "$CHECKS" "$FAILURES"
+    exit 1
+  fi
+  printf 'VERIFY: PASS — %d check(s) passed, 0 failed\n' "$CHECKS"
+  exit 0
+}
+
+# --- 1. the zip itself --------------------------------------------------------
+
+if [ ! -e "$ZIP" ]; then
+  fail "zip does not exist: $ZIP"
+  summarize_and_exit
+fi
+if [ ! -s "$ZIP" ]; then
+  fail "zip is empty (0 bytes): $ZIP"
+  summarize_and_exit
+fi
+if ! LISTING="$(unzip -l "$ZIP" 2>&1)"; then
+  fail "zip is not a readable archive: $ZIP"
+  printf '%s\n' "$LISTING" | sed 's/^/       /' >&2
+  summarize_and_exit
+fi
+ok "zip exists, is non-empty, and is a readable archive: $ZIP"
+
+ENTRIES="$(unzip -Z1 "$ZIP" 2>/dev/null || true)"
+if [ -z "$ENTRIES" ]; then
+  fail "zip contains zero entries — nothing to verify"
+  summarize_and_exit
+fi
+if printf '%s\n' "$ENTRIES" | grep -q '\.\./'; then
+  fail "zip contains a path-traversal entry (../) — refusing to extract"
+  summarize_and_exit
+fi
+
+# --- 2. exactly three top-level members --------------------------------------
+
+TOP_NAMES="$(printf '%s\n' "$ENTRIES" | awk -F/ '{print $1}' | sort -u)"
+
+APP_NAMES="$(printf '%s\n' "$TOP_NAMES" | grep '\.app$' || true)"
+N_APP=$(printf '%s\n' "$APP_NAMES" | grep -c . || true)
+if [ "$N_APP" -ne 1 ]; then
+  fail "expected exactly one top-level *.app member, found $N_APP: $(printf '%s' "$APP_NAMES" | tr '\n' ' ')"
+  APP_NAME=""
+else
+  APP_NAME="$(printf '%s\n' "$APP_NAMES" | head -1)"
+  ok "exactly one top-level .app member: $APP_NAME"
+fi
+
+if printf '%s\n' "$TOP_NAMES" | grep -qx "README.md"; then
+  ok "top-level README.md present"
+else
+  fail "missing top-level README.md"
+fi
+
+REMAINING="$(printf '%s\n' "$TOP_NAMES" | grep -vx "README.md" | grep -v '\.app$' || true)"
+N_REMAINING=$(printf '%s\n' "$REMAINING" | grep -c . || true)
+if [ "$N_REMAINING" -ne 1 ]; then
+  fail "expected exactly one top-level config file, found $N_REMAINING: $(printf '%s' "$REMAINING" | tr '\n' ' ')"
+  CONFIG_NAME=""
+else
+  CONFIG_NAME="$(printf '%s\n' "$REMAINING" | head -1)"
+  if printf '%s\n' "$ENTRIES" | grep -q "^${CONFIG_NAME}/"; then
+    fail "$CONFIG_NAME looks like a directory inside the zip, expected a single file"
+    CONFIG_NAME=""
+  else
+    ok "exactly one top-level config member: $CONFIG_NAME"
+  fi
+fi
+
+# Nothing further to inspect without an app to extract.
+if [ -z "$APP_NAME" ]; then
+  summarize_and_exit
+fi
+
+# --- extract for inspection ---------------------------------------------------
+
+TMP_EXTRACT="$(mktemp -d)"
+trap 'rm -rf "$TMP_EXTRACT"' EXIT
+if ! EXTRACT_ERR="$(unzip -q "$ZIP" -d "$TMP_EXTRACT" 2>&1)"; then
+  fail "failed to extract zip for inspection: $ZIP"
+  printf '%s\n' "$EXTRACT_ERR" | sed 's/^/       /' >&2
+  summarize_and_exit
+fi
+
+APP_DIR="$TMP_EXTRACT/$APP_NAME"
+
+# --- 3. app bundle shape + architecture ---------------------------------------
+
+if [ -f "$APP_DIR/Contents/Info.plist" ]; then
+  ok "$APP_NAME: Contents/Info.plist present"
+else
+  fail "$APP_NAME: missing Contents/Info.plist (not a real bundle shape)"
+fi
+
+if [ -d "$APP_DIR/Contents/MacOS" ]; then
+  ok "$APP_NAME: Contents/MacOS/ present"
+else
+  fail "$APP_NAME: missing Contents/MacOS/ (not a real bundle shape)"
+fi
+
+EXEC_NAME=""
+if [ -f "$APP_DIR/Contents/Info.plist" ] && command -v plutil >/dev/null 2>&1; then
+  EXEC_NAME="$(plutil -extract CFBundleExecutable raw -o - "$APP_DIR/Contents/Info.plist" 2>/dev/null || true)"
+fi
+if [ -z "$EXEC_NAME" ] && [ -d "$APP_DIR/Contents/MacOS" ]; then
+  EXEC_NAME="$(ls -1 "$APP_DIR/Contents/MacOS" 2>/dev/null | head -1)"
+fi
+
+EXEC_PATH=""
+FILE_OUT=""
+if [ -z "$EXEC_NAME" ]; then
+  fail "$APP_NAME: no executable found under Contents/MacOS/ (and CFBundleExecutable did not resolve one)"
+else
+  EXEC_PATH="$APP_DIR/Contents/MacOS/$EXEC_NAME"
+  if [ ! -f "$EXEC_PATH" ]; then
+    fail "$APP_NAME: CFBundleExecutable names '$EXEC_NAME' but it does not exist at Contents/MacOS/$EXEC_NAME"
+    EXEC_PATH=""
+  else
+    FILE_OUT="$(file -b "$EXEC_PATH" 2>&1)"
+    case "$FILE_OUT" in
+      *"Mach-O"*"executable"*arm64*)
+        ok "$APP_NAME executable ($EXEC_NAME) is a Mach-O arm64 executable: $FILE_OUT" ;;
+      *"Mach-O"*"executable"*)
+        fail "$APP_NAME executable ($EXEC_NAME) is NOT arm64 (wrong architecture): $FILE_OUT" ;;
+      *"Mach-O"*)
+        fail "$APP_NAME executable ($EXEC_NAME) is corrupt or truncated (Mach-O header present but incomplete): $FILE_OUT" ;;
+      *)
+        fail "$APP_NAME executable ($EXEC_NAME) is not a valid Mach-O executable, possibly corrupt or truncated: $FILE_OUT" ;;
+    esac
+  fi
+fi
+
+# --- 4. --version execution check ---------------------------------------------
+
+if [ -z "$EXPECT_VERSION" ]; then
+  info "--expect-version not given: --version execution check skipped"
+elif [ -z "$EXEC_PATH" ]; then
+  fail "cannot run --version: no valid executable resolved above"
+else
+  HOST_ARCH="$(uname -m)"
+  if [ "$HOST_ARCH" != "arm64" ]; then
+    info "--version execution check: not verified here (host is $HOST_ARCH, not arm64)"
+  elif ! printf '%s' "$FILE_OUT" | grep -q "executable.*arm64\|arm64.*executable"; then
+    info "--version execution check: not verified here (executable did not pass the arm64 check above)"
+  elif [ ! -x "$EXEC_PATH" ]; then
+    fail "$APP_NAME executable ($EXEC_NAME) is not marked executable — cannot run --version"
+  else
+    VERSION_OUT="$("$EXEC_PATH" --version 2>&1)" && VERSION_RC=0 || VERSION_RC=$?
+    if [ "$VERSION_RC" -ne 0 ]; then
+      fail "$APP_NAME executable exited $VERSION_RC on --version: $VERSION_OUT"
+    else
+      case "$VERSION_OUT" in
+        *"$EXPECT_VERSION"*)
+          ok "--version reports the expected string ('$EXPECT_VERSION'): $VERSION_OUT" ;;
+        *)
+          fail "--version did not report the expected string ('$EXPECT_VERSION'), got: $VERSION_OUT" ;;
+      esac
+    fi
+  fi
+fi
+
+# --- 5. config parses as TOML --------------------------------------------------
+
+if [ -z "$CONFIG_NAME" ]; then
+  fail "cannot check config parseability: no single top-level config member resolved above"
+elif [ ! -f "$TMP_EXTRACT/$CONFIG_NAME" ]; then
+  fail "config member not found on disk after extraction: $CONFIG_NAME"
+elif ! command -v python3 >/dev/null 2>&1; then
+  info "config TOML-parse check: not verified here (python3 not available)"
+else
+  TOML_ERR="$(python3 -c "
+import sys, tomllib
+with open(sys.argv[1], 'rb') as f:
+    tomllib.load(f)
+" "$TMP_EXTRACT/$CONFIG_NAME" 2>&1)"
+  if [ $? -eq 0 ]; then
+    ok "$CONFIG_NAME parses as TOML"
+  else
+    fail "$CONFIG_NAME does not parse as TOML: $(printf '%s' "$TOML_ERR" | tail -1)"
+  fi
+fi
+
+# --- 6. signing / notarization state — REPORTED, gated only with --require-signed
+
+report_signing() {
+  local target="$1"
+  if ! command -v codesign >/dev/null 2>&1; then
+    info "SIGNING: codesign not available in this environment — not verified here"
+    [ -n "$REQUIRE_SIGNED" ] && fail "SIGNING required (--require-signed) but codesign is unavailable to check it"
+    return
+  fi
+  local cs_out cs_rc
+  cs_out="$(codesign -dv --verbose=4 "$target" 2>&1)"
+  cs_rc=$?
+  if [ "$cs_rc" -ne 0 ]; then
+    info "SIGNING: $target is NOT signed (codesign exit $cs_rc): $(printf '%s' "$cs_out" | tail -1)"
+    if [ -n "$REQUIRE_SIGNED" ]; then
+      fail "SIGNING required (--require-signed) but $target is not signed"
+    fi
+    return
+  fi
+  if ! command -v spctl >/dev/null 2>&1; then
+    info "SIGNING: $target is signed, but spctl is unavailable — notarization not verified here"
+    [ -n "$REQUIRE_SIGNED" ] && fail "SIGNING required (--require-signed) but spctl is unavailable to check notarization"
+    return
+  fi
+  local sp_out sp_rc
+  sp_out="$(spctl -a -t exec -vv "$target" 2>&1)"
+  sp_rc=$?
+  if [ "$sp_rc" -eq 0 ]; then
+    info "SIGNING: $target is signed and passes Gatekeeper assessment: $sp_out"
+    [ -n "$REQUIRE_SIGNED" ] && ok "SIGNING: $target is signed and Gatekeeper-accepted"
+  else
+    info "SIGNING: $target is signed but FAILS Gatekeeper assessment (not notarized, or notarization not verified here): $sp_out"
+    [ -n "$REQUIRE_SIGNED" ] && fail "SIGNING required (--require-signed) but $target fails Gatekeeper assessment: $sp_out"
+  fi
+}
+
+report_signing "$APP_DIR"
+
+summarize_and_exit


### PR DESCRIPTION
## Summary

Scaffolding for issue #5483's REAL target layout, corrected from a stale
premise mid-session: #5483 supersedes the earlier "includes all necessary
pre-compiled binaries" plan. The auditor client is a standalone Tauri app
(#5477) that downloads `tga`/`trusty-analyze`/`trusty-review`/`gh` itself at
pinned versions at runtime, so the handoff zip carries **no tool binaries at
all** — only the signed/notarized client `.app`, a readable engagement
config, and a README.

🔴 **This does NOT close #5483 and does not claim to.** Confirmed by
inspection: none of #5483's three real inputs exist in this repo yet.

- #5477 — the Tauri client app itself: no crate, no `src-tauri/` anywhere
  under `crates/trusty-audit/`
- #5478 — the engagement config generator / schema: open, unimplemented
- #5484 — Developer-ID signing + notarization of the `.app`: open,
  unimplemented

`trusty-audit`'s own README says the same thing plainly: "Content signing and
the desktop shell do not [exist] — they are later milestones on #5473 /
#5477." Not adding `Closes #5483` to this PR.

## What this adds

- `scripts/package-trusty-audit-handoff.sh` — assembles `--app`, `--config`,
  `--readme` (all parameters, never hardcoded paths) into the canonical zip
  layout `<App>.app/`, `<config-basename>`, `README.md`.
- `scripts/verify-trusty-audit-handoff.sh` — opens the zip and checks: exact
  membership (no missing, no extra), `.app` bundle shape
  (`Contents/Info.plist`, `Contents/MacOS/<exec>`), executable architecture
  via `file`(1) (must be arm64), `--version` output when `--expect-version`
  is given and the host is itself arm64, config TOML parseability
  (`python3`'s `tomllib`), and signing/notarization state via
  `codesign`/`spctl` — reported always, gated only behind `--require-signed`
  (off by default, since nothing will pass it until #5484 exists).
- `scripts/verify-trusty-audit-handoff-selftest.sh` — builds synthetic,
  obviously-fake fixtures (`cc`-compiled trivial binaries, unsigned, bundle
  ID `com.trusty-mpm.test-fixture.NOT-REAL`) and proves the verifier both
  passes a clean artifact and fails 6 broken cases with raw output: a
  missing member, wrong architecture (x86_64), a truncated/corrupt
  executable, an unparseable config, and an absent zip + an empty zip (the
  #5620 shape — "nothing to check" must never print PASS).

**Not wired into CI.** #3540: a false `if:` silently skips a job, and a
skipped release check is silent. There is no build job yet that produces a
real `.app`, so any CI wiring today would either fail loud on every PR for
no reason, or need an `if:` to skip when there's nothing to check — the
#3540 shape from the other direction. Wire this in once a real `.app`-
producing job exists, as a `needs:` step that fails BEFORE any upload (the
pattern PR #5767 used for the release-completeness audit), not an `if:` on
the job.

**Signing conclusion.** `codesign`/`spctl` are available and exercised by
the self-test (see PR description below for raw output). Apple Silicon
auto-applies an ad-hoc signature to any binary at link time, so even the
clean fixture shows `codesign` succeeding but `spctl -a -t exec` failing
Gatekeeper ("code has no resources but signature indicates they must be
present" / not notarized) — which is the honest, correct result for an
unsigned-in-the-Developer-ID-sense fixture. Nothing here fabricates a
signature or a notarization ticket.

## Test plan

- [x] `cargo fmt --check` — clean (no Rust files touched)
- [x] `bash scripts/verify-trusty-audit-handoff-selftest.sh` — 7/7 cases
      pass (baseline clean-artifact pass + 6 failure-mode cases), raw
      output captured in the session report
- [x] `bash scripts/check_changelog_fragment.sh --base origin/main` →
      `scanned 3 changed path(s); no crate source changed (docs-only /
      CI-only / test-only) — OK.` exit 0 — no fragment required, script-only
      change
- [ ] Owner: confirm option-2 scope (scaffolding, not wired to CI) is what
      you want landed now vs. waiting for #5477/#5478/#5484

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools