### PR TITLE
fix(trusty-mpm): revert declared version 1.5.0 back to 1.4.x line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11649,7 +11649,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.0"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "1.5.0"
+version = "1.4.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- PR #5769 read the owner's "minor bump" instruction as the semver MINOR position (1.4.2 -> 1.5.0). The owner meant staying in the 1.4.x line.
- `crates/trusty-mpm/Cargo.toml` version moves from `1.5.0` to `1.4.3`.

## Why 1.4.3, not 1.4.2

1.4.2 is unavailable for reuse — evidence:

1. **crates.io**: `trusty-mpm` 1.4.2 is published (`max_version: 1.4.2`, created 2026-08-15T15:57:05Z).
2. **Remote tag**: `trusty-mpm-v1.4.2` exists on `origin` at `667a089f42b00ca60f047306600e7230b92f8d04`.
3. **Ancestry**: that commit is an ancestor of `origin/main`.
4. **GitHub release**: exists and is `immutable: true` (published 2026-08-15T16:09:18Z, with built binary assets for all three platforms).

Reusing 1.4.2 would repeat the `tga-v2.17.0` / `trusty-review-v0.16.1` dead-tag collision this repo has already hit twice. 1.4.3 is unclaimed on all three fronts (no remote tag, no GitHub release, not on crates.io).

## Scope

Single-site change. No other `1.5.0` reference exists in the crate, and no crate consumes `trusty-mpm = { workspace = true }` — the root `[workspace.dependencies]` entry pinned at `1.0.0` has zero consumers. `Cargo.lock` updated to match.

## Note for the next release

#5769 removed parameters from two public methods, which for a 1.x crate is a MAJOR change. A 1.4.x number will trip `preflight-publish.sh` CHECK 5 (`cargo-semver-checks`) at the next release. That is the owner's explicit choice and is not addressed by this PR.

## Test plan

- [x] `SKIP_UI_BUILD=1 cargo check --workspace` — exit 0
- [ ] Reviewer: confirm milestone `1.4.2` is the intended tracking milestone despite the crate version landing on 1.4.3

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools