### PR TITLE
docs: separate the cargo-install cdhash fix from the worktree-provenance claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,18 +426,32 @@ squash-merge → worktree cleanup. `tm-workflow` owns the full sequence and
 `tm-ticketing` owns whether the optional issue exists; this file adds only the
 Rust-specific gates (see the Rust Test Ladder above).
 
-🟡 **`cargo install` from a worktree, not the main checkout.** The preferred
-pattern for installing a freshly-built binary onto your PATH is:
+🟡 **`cargo install` a clean checkout, never `cp`.** The preferred pattern for
+installing a freshly-built binary onto your PATH is:
 
 ```bash
 cargo install --path .claude/worktrees/<dirname>/crates/<name> --locked
 ```
 
-Cargo writes atomically to a temp file and renames into `~/.cargo/bin/`,
-which keeps the macOS kernel's cdhash cache consistent (see the
-release-workflow note above). A plain `cp` over an on-PATH binary leaves a stale
-cdhash cache and the next exec is SIGKILL'd. The main checkout never needs to be
-involved.
+Cargo writes atomically to a temp file and renames into `~/.cargo/bin/`, which
+keeps the macOS kernel's cdhash cache consistent (see the release-workflow
+note above). A plain `cp` over an on-PATH binary leaves a stale cdhash cache
+and the next exec is SIGKILL'd — that hazard is about `cargo install` versus
+`cp`, and holds identically no matter which checkout you run it from.
+
+What the checkout DOES decide is provenance: `cargo install --path` bakes in
+whatever is on disk, including uncommitted edits. Install from a checkout with
+an empty `git status --porcelain` at a known commit. A freshly-provisioned
+worktree off `origin/main` satisfies that by construction, which is why it
+stays the default. The main checkout is not automatically disqualified, but
+the write boundary
+([ADR-0044](docs/adr/0044-main-checkout-write-boundary-and-agent-worktree-ownership.md),
+[ADR-0048](docs/adr/0048-dispatched-writers-get-a-worktree-and-the-write-boundary-is-enforced.md),
+[ADR-0049](docs/adr/0049-docs-commits-are-permitted-in-a-main-checkout.md))
+only restricts SOURCE writes there — it classifies by file extension, and
+documents and configuration (`.md` included) stay writable, and since
+ADR-0049 committable, directly in the main checkout. Check `git status
+--porcelain` before installing from either location; don't assume it.
 
 > **Extended discipline rationale, the install-from-worktree commands, and the
 > stash-first fallback:** see [docs/reference/worktree-discipline.md](docs/reference/worktree-discipline.md).

--- a/docs/reference/worktree-discipline.md
+++ b/docs/reference/worktree-discipline.md
@@ -6,12 +6,15 @@ checkout often holds another session's uncommitted work.
 
 **The write boundary that protects that work is mechanically enforced, not
 left to convention** (`tm hook --pm-guard`; [ADR-0044](../adr/0044-main-checkout-write-boundary-and-agent-worktree-ownership.md),
-[ADR-0048](../adr/0048-dispatched-writers-get-a-worktree-and-the-write-boundary-is-enforced.md)).
+[ADR-0048](../adr/0048-dispatched-writers-get-a-worktree-and-the-write-boundary-is-enforced.md),
+[ADR-0049](../adr/0049-docs-commits-are-permitted-in-a-main-checkout.md)).
 Documents and configuration — `.md`, `.toml`, `.json`, `.yaml`,
 extension-less files, `.claude/` framework deployment, `TASK.md` — stay
 writable directly in the main checkout for the PM and every agent it
-dispatches; source edits and `git commit` there are denied for both. A
-dispatched agent that may write is granted its own worktree under
+dispatches; source edits there are denied for both. `git commit` there is
+denied too, except for a staged set that is entirely documents and
+configuration (ADR-0049) and only when no other session is writing the same
+checkout. A dispatched agent that may write is granted its own worktree under
 `.claude/worktrees/` automatically the moment the session is standing in a
 main checkout — see [ADR-0036](../adr/0036-all-worktrees-are-siblings-under-claude-worktrees.md)
 for where that worktree lives. The rules below are what remains a matter of
@@ -55,27 +58,53 @@ section, cross-referenced from the "Worktree Discipline" section of the
 
 ## Installing a Freshly Built Binary
 
-Prefer installing from the worktree, never the main checkout:
+Install from a checkout with an empty `git status --porcelain`, at a known
+commit — `cargo install --path` bakes in whatever is actually on disk, so a
+dirty or unverified checkout ships whatever it happens to be holding:
 
 ```bash
-cargo install --path .claude/worktrees/<dirname>/crates/<name> --locked
+git -C <checkout> status --porcelain   # must print nothing
+git -C <checkout> log -1 --oneline     # is this the commit you meant to ship?
+cargo install --path <checkout>/crates/<name> --locked
 ```
 
 Cargo writes atomically to a temp file and renames into `~/.cargo/bin/`,
 which keeps the macOS kernel's cdhash cache consistent — see
 [release-workflow.md](release-workflow.md) for the full cdhash hazard (why a
 bare `cp` over an on-PATH binary SIGKILLs the next exec, and the TCC-grant
-consequences). The main checkout never needs to be involved.
+consequences). That property holds for `cargo install --path` from any clean
+checkout; it says nothing about which checkout to pick.
 
-If a command genuinely must run from the main checkout — for example
-`cargo install --path crates/<name> --locked` right after a merge lands —
-stash first, operate, then restore:
+A freshly-provisioned worktree off `origin/main` satisfies the clean-tree
+requirement by construction, which is why it stays the default:
 
 ```bash
-git -C /path/to/main-checkout stash push -u \
+cargo install --path .claude/worktrees/<dirname>/crates/<name> --locked
+```
+
+The main checkout is not automatically disqualified, but it is not
+automatically clean either. The write boundary
+([ADR-0044](../adr/0044-main-checkout-write-boundary-and-agent-worktree-ownership.md),
+[ADR-0048](../adr/0048-dispatched-writers-get-a-worktree-and-the-write-boundary-is-enforced.md),
+[ADR-0049](../adr/0049-docs-commits-are-permitted-in-a-main-checkout.md)) denies
+source edits and source commits there, which rules out the worst case, but it
+classifies by file EXTENSION, not by directory: documents and configuration
+stay writable, and since ADR-0049 committable, directly in the main checkout.
+`crates/trusty-mpm/src/assets/skills/*.md` falls on the writable side of that
+line even though it lives under `src/` and is compiled into the `trusty-mpm`
+binary at build time via `include_str!` — so a locally-edited, uncommitted (or
+locally-committed-but-unpushed) skill file in the main checkout can still be
+baked into a binary installed from there. The `git status --porcelain` check
+above is what catches that; running it costs one command.
+
+If the checkout you need to install from is not clean and you cannot switch to
+one that is, stash first, operate, then restore:
+
+```bash
+git -C /path/to/checkout stash push -u \
     -m "claude: pre-op-safety $(date +%s)"
-# … do the op …
-git -C /path/to/main-checkout stash pop
+# … confirm `git status --porcelain` is now empty, then install …
+git -C /path/to/checkout stash pop
 ```
 
 Surface the stash name in the report if popping fails, so the change can be


### PR DESCRIPTION
## Summary
- The worktree-discipline rule ("`cargo install` from a worktree, not the main checkout") justified two separate claims with one argument: never `cp` a binary onto PATH (true — the cdhash/SIGKILL reasoning fully supports it) and install from a worktree rather than the main checkout (a different claim the cdhash argument never supported, since `cargo install --path` is equally atomic from either location).
- Restates the rule around what actually matters: install from a checkout with an empty `git status --porcelain` at a known commit. A freshly-provisioned worktree satisfies that by construction, which is why it stays the default.
- Keeps the never-`cp`/`cargo install` instruction exactly as forceful as before — only the provenance justification changes.
- Notes the one place the main checkout's write boundary (ADR-0044/0048/0049) does not guarantee a clean tree: it classifies by file extension, not directory, so `crates/trusty-mpm/src/assets/skills/*.md` — under `src/`, baked into the `trusty-mpm` binary via `include_str!` — stays writable, and since ADR-0049 committable, directly in the main checkout.

Root `CLAUDE.md` and `docs/reference/worktree-discipline.md` both carried the conflation and are both fixed here. `docs/reference/release-workflow.md` discusses the same cdhash mechanism but only for TCC/code-signing purposes — never for worktree-vs-main provenance — so it was left untouched.

## Test plan
- [x] `bash scripts/check_sld.sh` — exit 0
- [x] `bash scripts/check_line_cap.sh` — exit 0
- [x] `bash scripts/check_changelog_fragment.sh` — exit 0 (docs-only PR, no `src/` touched, fragment correctly not required)
- [x] `docs/reference/worktree-discipline.md` is absent from `docs/public-manifest.tsv`, so `check_public_docs.sh` does not apply

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools