### PR TITLE
fix(trusty-memory): print the palace that resolves, not the slug before the redirect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11620,7 +11620,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/changelog.d/5816-alias-target-if-absent.md
+++ b/crates/trusty-common/changelog.d/5816-alias-target-if-absent.md
@@ -1,0 +1,2 @@
+Added
+- `palace_alias::alias_target_if_absent` names the palace an alias redirects to, and only when the redirect actually fires. `memory_core::registry` now reads this rule from there instead of implementing it privately.

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -715,7 +715,9 @@ pub use palace_id::{
 /// palace does not exist and memory splits in two. A persisted alias map lets the
 /// non-existent `owner-repo` name resolve to the existing bare palace. This is a
 /// PALACE-level redirect, distinct from the in-palace term/KG entity aliases.
-/// What: exposes [`palace_alias::PalaceAliasStore`] (load/register/resolve) plus
+/// What: exposes [`palace_alias::PalaceAliasStore`] (load/register/resolve),
+/// [`palace_alias::alias_target_if_absent`] (the one rule for whether a redirect
+/// fires, shared with the registry), plus
 /// [`palace_alias::default_palace_registry_dir`] and
 /// [`palace_alias::palace_registry_dir_from`] for locating the registry dir. This
 /// module is always compiled (no `memory-core` gate) so trusty-mpm's always-on

--- a/crates/trusty-common/src/memory_core/registry.rs
+++ b/crates/trusty-common/src/memory_core/registry.rs
@@ -17,7 +17,6 @@ use crate::memory_core::palace::{Palace, PalaceId};
 use crate::memory_core::retrieval::PalaceHandle;
 use crate::memory_core::store::concurrent_open::OpenIntent;
 use crate::memory_core::store::palace_store::{PalaceStore, PalaceStoreError};
-use crate::palace_alias::PalaceAliasStore;
 use anyhow::{Context, Result};
 use dashmap::DashMap;
 use lru::LruCache;
@@ -580,44 +579,28 @@ impl PalaceRegistry {
     /// the target to also exist on disk stops a stale alias from redirecting to a
     /// deleted palace (which would just fail load anyway, but this keeps the
     /// error message about the ORIGINAL id).
-    /// What: returns `palace_id` unchanged when `<data_root>/<palace_id>/palace.json`
-    /// is present. Otherwise consults [`PalaceAliasStore::resolve_alias`]; if it maps
-    /// to a `target` whose `<data_root>/<target>/palace.json` is present, returns that
-    /// target id. In every other case returns `palace_id` unchanged so the caller
-    /// surfaces the normal "metadata missing" error. Alias-map read errors are
-    /// swallowed (best-effort redirect) — a broken alias file must not break
-    /// resolution of palaces that DO exist.
+    /// What: delegates the whole rule to
+    /// [`crate::palace_alias::alias_target_if_absent`] (#5810) and adopts its
+    /// answer: the target id when it names a redirect, `palace_id` unchanged
+    /// otherwise, so the caller surfaces the normal "metadata missing" error.
+    /// That function owns the presence probe, the alias-map read, and the
+    /// swallow-on-error contract — read it there rather than restating it here.
     ///
-    /// Presence is `try_exists`, and only `Ok(false)` counts as absent (#5592,
-    /// ADR-0045). `exists()` reported a path we are denied to stat as one that is
-    /// not there, which broke both guards in the direction that lies: an alias
-    /// whose target could not be verified lost its redirect, and `load_palace`
-    /// then answered truthfully about the alias id's own empty directory — a
-    /// `NotFound` for the wrong palace, which [`Self::open_error_is_absent`]
-    /// cannot tell from the real thing. Returning `PalaceId` rather than a
-    /// `Result` is why an undeterminable probe presumes PRESENT instead of
-    /// propagating: this cannot fail, and every path it feeds ends at
+    /// One consequence belongs at this call site. Presence is `try_exists` and an
+    /// undeterminable probe presumes PRESENT (#5592, ADR-0045), which is only safe
+    /// because this returns `PalaceId` and cannot fail: every path it feeds ends at
     /// `load_palace`, which classifies the same denial correctly one call later.
-    /// That also stops a stale alias from shadowing a real palace that merely
-    /// could not be stat'd.
+    /// [`Self::open_error_is_absent`] cannot tell a `NotFound` for the alias id's
+    /// own empty directory from a real one, so the presumption has to sit here.
     /// Test: `open_palace_follows_alias`, `open_palace_ignores_alias_when_target_missing`,
     /// `open_palace_prefers_real_palace_over_alias`,
     /// `open_error_is_not_absent_for_an_unstattable_alias_target`.
     fn resolve_palace_alias(data_root: &Path, palace_id: &PalaceId) -> PalaceId {
-        // #5592: `exists()` read a palace we are DENIED to stat as one that is
-        // not there. Only `Ok(false)` is a genuine absence.
-        let exists = |id: &str| {
-            !matches!(
-                data_root.join(id).join("palace.json").try_exists(),
-                Ok(false)
-            )
-        };
-        if exists(palace_id.as_str()) {
-            return palace_id.clone();
-        }
-        match PalaceAliasStore::resolve_alias(data_root, palace_id.as_str()) {
-            Ok(Some(target)) if exists(&target) => PalaceId::new(target),
-            _ => palace_id.clone(),
+        // #5810: the rule above now lives in `palace_alias` so callers that only
+        // want to NAME the palace they will reach read the same one.
+        match crate::palace_alias::alias_target_if_absent(data_root, palace_id.as_str()) {
+            Some(target) => PalaceId::new(target),
+            None => palace_id.clone(),
         }
     }
 

--- a/crates/trusty-common/src/palace_alias.rs
+++ b/crates/trusty-common/src/palace_alias.rs
@@ -171,6 +171,44 @@ impl PalaceAliasStore {
     }
 }
 
+/// Name the palace an alias redirects to, but only when the redirect actually fires.
+///
+/// Why (#5810): the registry applied this rule privately, so every caller that
+/// wanted to *name* the palace it was about to reach had no way to ask. The
+/// `UserPromptSubmit` hook printed the derived slug — `bobmatnyc-trusty-tools` —
+/// while the drawers under it came from `trusty-tools`, and `palace_list` returns
+/// only the latter. A second copy of the rule in trusty-memory would be the drift
+/// this workspace's common-entry-point rule forbids, so the rule lives here and
+/// [`crate::memory_core::registry`] now reads it from the same place.
+/// What: returns `Some(target)` only when `<registry_dir>/<palace_id>/palace.json`
+/// is absent AND an alias maps `palace_id` to a `target` whose own `palace.json`
+/// is present. Returns `None` in every other case — the palace exists, no alias is
+/// registered, the target is missing, or the alias file cannot be read — so a
+/// caller's `unwrap_or(derived)` keeps today's behaviour on every degraded path.
+///
+/// Presence is `try_exists`, and only `Ok(false)` counts as absent (#5592,
+/// ADR-0045): a path we are denied to stat presumes PRESENT, so an unverifiable
+/// alias target never wins a redirect and an unstattable palace is never shadowed.
+/// Test: `alias_target_is_none_when_the_palace_exists`,
+/// `alias_target_names_the_redirect`,
+/// `alias_target_is_none_when_the_target_is_missing`,
+/// `alias_target_is_none_without_an_alias`.
+pub fn alias_target_if_absent(registry_dir: &Path, palace_id: &str) -> Option<String> {
+    let exists = |id: &str| {
+        !matches!(
+            registry_dir.join(id).join("palace.json").try_exists(),
+            Ok(false)
+        )
+    };
+    if exists(palace_id) {
+        return None;
+    }
+    match PalaceAliasStore::resolve_alias(registry_dir, palace_id) {
+        Ok(Some(target)) if exists(&target) => Some(target),
+        _ => None,
+    }
+}
+
 /// Resolve the directory that holds the per-palace subdirectories for a data dir.
 ///
 /// Why: two on-disk layouts exist in the wild. The current code treats the data
@@ -323,6 +361,58 @@ mod tests {
         let nested = tmp.path().join("palaces");
         std::fs::create_dir_all(&nested).unwrap();
         assert_eq!(palace_registry_dir_from(tmp.path().to_path_buf()), nested);
+    }
+
+    /// Write a minimal `palace.json` so the presence probe sees a real palace.
+    fn seed_palace(registry_dir: &Path, id: &str) {
+        let dir = registry_dir.join(id);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("palace.json"), b"{}").unwrap();
+    }
+
+    /// Why: an alias must never shadow a real palace, so a palace that exists on
+    /// disk reports no redirect even when an alias names it.
+    /// Test: itself.
+    #[test]
+    fn alias_target_is_none_when_the_palace_exists() {
+        let tmp = tempdir().unwrap();
+        seed_palace(tmp.path(), "owner-repo");
+        seed_palace(tmp.path(), "repo");
+        PalaceAliasStore::register_alias(tmp.path(), "owner-repo", "repo").unwrap();
+        assert_eq!(alias_target_if_absent(tmp.path(), "owner-repo"), None);
+    }
+
+    /// Why: the split-brain case this exists for — the derived name owns no
+    /// directory, the alias target does, so the target is the usable name.
+    /// Test: itself.
+    #[test]
+    fn alias_target_names_the_redirect() {
+        let tmp = tempdir().unwrap();
+        seed_palace(tmp.path(), "trusty-tools");
+        PalaceAliasStore::register_alias(tmp.path(), "bobmatnyc-trusty-tools", "trusty-tools")
+            .unwrap();
+        assert_eq!(
+            alias_target_if_absent(tmp.path(), "bobmatnyc-trusty-tools").as_deref(),
+            Some("trusty-tools")
+        );
+    }
+
+    /// Why: a stale alias pointing at a deleted palace must not rename anything —
+    /// the caller keeps the original id so its error names the palace asked for.
+    /// Test: itself.
+    #[test]
+    fn alias_target_is_none_when_the_target_is_missing() {
+        let tmp = tempdir().unwrap();
+        PalaceAliasStore::register_alias(tmp.path(), "ghost", "also-gone").unwrap();
+        assert_eq!(alias_target_if_absent(tmp.path(), "ghost"), None);
+    }
+
+    /// Why: the common case — no alias file at all — must be a cheap `None`.
+    /// Test: itself.
+    #[test]
+    fn alias_target_is_none_without_an_alias() {
+        let tmp = tempdir().unwrap();
+        assert_eq!(alias_target_if_absent(tmp.path(), "anything"), None);
     }
 
     /// Why: absent a `palaces/` subdir the data dir itself is the registry root

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -3,7 +3,7 @@ name = "trusty-memory"
 # #4421: patch bump — 0.23.0 already published on crates.io and this PR
 # touches src/**. Every hunk is a doc-comment edit (module docs moved to the
 # inner `//!` standard, #5754) — no item signature or behavior changed.
-version = "0.23.1"
+version = "0.23.2"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license.workspace = true

--- a/crates/trusty-memory/changelog.d/5816-prompt-context-header-names-resolved-palace.md
+++ b/crates/trusty-memory/changelog.d/5816-prompt-context-header-names-resolved-palace.md
@@ -1,0 +1,2 @@
+Fixed
+- The `UserPromptSubmit` injection header and the `SessionStart` inbox header now name the palace that resolves, not the derived slug an alias redirects away from. The printed name can be pasted into `memory_recall`, `palace_info`, and `memory_remember`.

--- a/crates/trusty-memory/src/commands/inbox_check.rs
+++ b/crates/trusty-memory/src/commands/inbox_check.rs
@@ -78,7 +78,9 @@ struct ServerMessage {
 /// failure path exits 0 silently with no stdout so the user's session
 /// start is never blocked.
 /// What:
-///   1. Resolves the recipient palace slug from cwd (or explicit `--palace`).
+///   1. Resolves the recipient palace slug from cwd (or explicit `--palace`),
+///      then follows any palace-level alias so the name it prints is one the
+///      memory tools accept as input (#5810).
 ///   2. Fetches unread messages via the daemon's HTTP API.
 ///   3. Prints the formatted Markdown blocks to stdout.
 ///   4. POSTs back to mark each delivered message read.
@@ -98,10 +100,13 @@ pub async fn handle_inbox_check(palace: Option<String>) -> Result<()> {
     // into the SessionStart hook reflects the user's actual cwd, which
     // differs from the hook process cwd when the hook was registered from a
     // different directory); then the process cwd; finally `"<unknown>"`.
+    // #5810: the inbox header printed this name, so it must be one `palace_list`
+    // returns — the redirect is a no-op unless the derived palace is absent.
     let recipient = palace
         .clone()
         .or_else(|| palace_slug_from_stdin_cwd(&trigger_prompt))
         .or_else(|| crate::messaging::cwd_palace_slug().ok())
+        .map(crate::palace_id_derive::follow_palace_alias)
         .unwrap_or_else(|| "<unknown>".to_string());
 
     let injection = run_inbox_fetch(&trigger_prompt, &recipient, start).await;
@@ -343,9 +348,18 @@ mod tests {
     /// What: build a JSON payload with a tempdir `cwd`; assert the derived
     /// slug matches `cwd_palace_slug_at(tempdir)` and reflects the tempdir
     /// basename rather than the process cwd basename.
+    ///
+    /// #5810: `TRUSTY_MEMORY_PALACE` is precedence level 1 and outranks the
+    /// tempdir path this asserts on, so an ambient value — every trusty-mpm
+    /// managed session exports one — made this fail with the developer's own
+    /// palace name. Scrubbed under `env_test_lock`, which is what serialises
+    /// every env mutation in this crate's test binary.
     /// Test: itself.
-    #[test]
-    fn palace_slug_from_stdin_cwd_uses_stdin_path() {
+    #[tokio::test]
+    async fn palace_slug_from_stdin_cwd_uses_stdin_path() {
+        let _guard = crate::commands::env_test_lock().lock().await;
+        // SAFETY: `env_test_lock` is held for the whole test.
+        unsafe { std::env::remove_var(trusty_common::PALACE_OVERRIDE_ENV) };
         let tmp = tempfile::tempdir().expect("tempdir");
         let project = tmp.path().join("inbox-stdin-project");
         std::fs::create_dir_all(&project).expect("create project dir");

--- a/crates/trusty-memory/src/commands/prompt_context/mod.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/mod.rs
@@ -722,14 +722,19 @@ fn configured_deny_tags() -> Vec<String> {
 /// hook process was launched with. The stdin `cwd` is the source of truth.
 /// What: parse stdin as JSON, take `cwd`, derive slug via
 /// [`crate::messaging::cwd_palace_slug_at`]. Falls back to the process
-/// cwd's slug. Returns `None` only when neither resolves cleanly.
+/// cwd's slug. Returns `None` only when neither resolves cleanly. The derived
+/// slug then goes through [`crate::palace_id_derive::follow_palace_alias`], so
+/// every consumer of this value — the injection header, the recall and KG
+/// requests, the prompt log, the activity event — names the palace the daemon
+/// will actually open rather than the pre-redirect slug.
 /// Test: `resolve_palace_for_log_prefers_stdin_cwd` (the log helper uses
-/// the same chain).
+/// the same chain), `prompt_context_header_names_the_alias_target`.
 fn resolve_palace_slug(stdin_payload: &str) -> Option<String> {
-    if let Some(slug) = palace_slug_from_stdin_cwd(stdin_payload) {
-        return Some(slug);
-    }
-    crate::messaging::cwd_palace_slug().ok()
+    let derived = palace_slug_from_stdin_cwd(stdin_payload)
+        .or_else(|| crate::messaging::cwd_palace_slug().ok())?;
+    // #5810: the header printed the derived slug while the drawers under it came
+    // from the alias target, naming a palace `palace_list` never returns.
+    Some(crate::palace_id_derive::follow_palace_alias(derived))
 }
 
 /// Resolve the palace identifier for the log entry.

--- a/crates/trusty-memory/src/commands/prompt_context/tests.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/tests.rs
@@ -562,6 +562,92 @@ async fn prompt_context_recalls_palace_drawers() {
     addr_handle.shutdown().await;
 }
 
+/// Why (#5810): the header named the DERIVED slug while the drawers under it were
+/// recalled through a palace-level alias, so it printed a name `palace_list` does
+/// not return and `memory_recall` / `palace_info` / `memory_remember` cannot take
+/// as input. This is the split-brain shape from the field: an `owner-repo` slug
+/// with no directory of its own, aliased to the bare-repo palace that holds the
+/// drawers.
+/// What: creates the canonical palace with one drawer, then a second project dir
+/// pinned to a slug that owns no palace, and registers the alias between them.
+/// Drives `build_injection_body` from the aliased cwd and asserts the header names
+/// the canonical palace — and that the unusable derived slug appears nowhere in the
+/// injection. Pre-#5810 this fails on the first assertion: the drawer arrives
+/// (the daemon redirects) under a header reading the derived slug.
+/// Test: itself.
+/// Note (issue #226): gated on `axum-server`; spins up the HTTP daemon.
+#[cfg(feature = "axum-server")]
+#[tokio::test]
+async fn prompt_context_header_names_the_alias_target() {
+    let _guard = crate::commands::env_test_lock().lock().await;
+    unsafe {
+        std::env::remove_var(ENV_MIN_SCORE);
+        std::env::remove_var(ENV_RECALL_DENY_TAGS);
+    }
+    let (state, _data_dir_tmp, project_dir_tmp, _project_dir, canonical, addr_handle) =
+        spin_up_test_daemon_with_palace("ptx-alias-canonical").await;
+
+    let _ = crate::tools::dispatch_tool(
+        &state,
+        "memory_remember",
+        json!({
+            "palace": canonical,
+            "text": "Rust integration uses tokio for async tasks and serde for JSON",
+            "room": "General",
+            "tags": ["rust", "tokio"],
+        }),
+    )
+    .await
+    .expect("memory_remember");
+
+    // The derived slug: a project dir pinned to a palace that was never created.
+    let derived = "ptx-alias-derived";
+    let aliased_project = project_dir_tmp.path().join(derived);
+    std::fs::create_dir_all(&aliased_project).expect("aliased project dir");
+    crate::project_root::write_project_pin(
+        &aliased_project,
+        &crate::project_root::ProjectPin {
+            schema_version: crate::project_root::PIN_SCHEMA_VERSION,
+            palace: derived.to_string(),
+            note: None,
+        },
+    )
+    .expect("write pin for the aliased project");
+
+    let registry_dir =
+        trusty_common::palace_alias::default_palace_registry_dir().expect("registry dir");
+    assert!(
+        !registry_dir.join(derived).join("palace.json").exists(),
+        "the derived slug must own no palace, or this test proves nothing"
+    );
+    trusty_common::palace_alias::PalaceAliasStore::register_alias(
+        &registry_dir,
+        derived,
+        &canonical,
+    )
+    .expect("register palace alias");
+
+    let payload = json!({
+        "hook_event_name": "UserPromptSubmit",
+        "cwd": aliased_project.to_string_lossy(),
+        "prompt": "how does rust integration work?"
+    })
+    .to_string();
+    let body = build_injection_body(&payload).await;
+
+    assert!(
+        body.contains(&format!("## Relevant memories from palace `{canonical}`")),
+        "the header must name the palace the drawers came from; got:\n{body}"
+    );
+    assert!(
+        !body.contains(derived),
+        "the pre-redirect slug is not a usable memory-tool input and must not \
+         appear in the injection; got:\n{body}"
+    );
+
+    addr_handle.shutdown().await;
+}
+
 /// Why (issue #5037, end to end): the unit tests above pin the floor over
 /// synthetic scores. This one proves the whole chain — real embedder, real HTTP
 /// recall, real `score` on the wire, real filter — turns an off-topic prompt
@@ -717,6 +803,13 @@ async fn spin_up_test_daemon_with_palace(
         std::env::remove_var(crate::prompt_log::ENV_ENABLED);
         std::env::remove_var(crate::prompt_log::ENV_DIR);
         std::env::remove_var(crate::prompt_log::ENV_HASH_PROMPTS);
+        // #5810: `TRUSTY_MEMORY_PALACE` is precedence level 1 and outranks the
+        // pin file written below, so an ambient value — every trusty-mpm managed
+        // session exports one — made these tests resolve the developer's own
+        // palace instead of the fixture's. Every one of them then recalled
+        // nothing and asserted against `EMPTY_PLACEHOLDER`. Scrub it here so the
+        // pin is authoritative, matching what the comment below already claims.
+        std::env::remove_var(trusty_common::PALACE_OVERRIDE_ENV);
         // Issue #88: bypass palace-slug enforcement so test palaces with
         // arbitrary names can be created without a matching project root.
         std::env::set_var("TRUSTY_SKIP_PALACE_ENFORCEMENT", "1");
@@ -748,9 +841,9 @@ async fn spin_up_test_daemon_with_palace(
     state.set_ready();
 
     // Create the palace via MCP dispatch so the on-disk metadata
-    // matches what a real client would have produced. The `TRUSTY_MEMORY_PALACE`
-    // override pinned above makes `cwd_palace_slug_at` (and thus the hook)
-    // resolve to exactly this slug (issue #1217).
+    // matches what a real client would have produced. The pin file written
+    // above makes `cwd_palace_slug_at` (and thus the hook) resolve to exactly
+    // this slug (issue #1217).
     let _ = crate::tools::dispatch_tool(&state, "palace_create", json!({"name": palace_slug}))
         .await
         .expect("palace_create");

--- a/crates/trusty-memory/src/palace_id_derive.rs
+++ b/crates/trusty-memory/src/palace_id_derive.rs
@@ -10,11 +10,14 @@
 //! variant — lives in [`trusty_common::palace_id`].
 //!
 //! What: re-exports [`derive_palace_id`], [`owner_repo_from_git_remote`],
-//! [`parent_dir_slug`], [`PALACE_OVERRIDE_ENV`], and [`palace_override_from_env`].
+//! [`parent_dir_slug`], [`PALACE_OVERRIDE_ENV`], and [`palace_override_from_env`],
+//! and adds [`follow_palace_alias`] (#5810) — the step after derivation that turns
+//! a derived slug into a name the memory tools accept as input.
 //!
-//! Test: behaviour is pinned by `cargo test -p trusty-common -- palace_id::tests`;
+//! Test: derivation is pinned by `cargo test -p trusty-common -- palace_id::tests`;
 //! trusty-memory inherits it transitively (its `messaging` tests exercise the
-//! env-override read path that wraps these shims).
+//! env-override read path that wraps these shims). The alias step has its own
+//! tests in this module.
 //!
 //! [`derive_palace_id`]: trusty_common::palace_id::derive_palace_id
 //! [`owner_repo_from_git_remote`]: trusty_common::palace_id::owner_repo_from_git_remote
@@ -26,3 +29,97 @@ pub use trusty_common::palace_id::{
     derive_palace_id, owner_repo_from_git_remote, palace_override_from_env, parent_dir_slug,
     PALACE_OVERRIDE_ENV,
 };
+
+/// Follow a palace-level alias so a derived slug becomes a name that resolves.
+///
+/// Why (#5810): derivation stops at the `owner-repo` slug, and the daemon
+/// redirects that to the aliased palace only once a request arrives. Anything
+/// that printed the derived name — the `UserPromptSubmit` injection header, the
+/// `SessionStart` inbox header — therefore named a palace `palace_list` does not
+/// return and `memory_recall` callers cannot copy. Applying the redirect here,
+/// once, gives the hooks a name the memory tools accept as input, and makes the
+/// name they print the same palace they queried.
+/// What: resolves the daemon's registry directory via
+/// [`trusty_common::palace_alias::default_palace_registry_dir`] — the same
+/// derivation `main.rs` uses for `AppState::data_root`, so the two cannot point
+/// at different files — and returns
+/// [`trusty_common::palace_alias::alias_target_if_absent`]'s target when a
+/// redirect fires. Returns `slug` untouched on every other path, including an
+/// unreadable data dir, so a degraded filesystem keeps today's behaviour instead
+/// of losing the name entirely. The redirect is a no-op unless the derived
+/// palace is absent AND its alias target exists, so a real palace is never
+/// renamed.
+/// Test: `follow_palace_alias_names_the_target`,
+/// `follow_palace_alias_leaves_a_real_palace_alone`,
+/// `prompt_context_header_names_the_alias_target`.
+pub fn follow_palace_alias(slug: String) -> String {
+    let Ok(registry_dir) = trusty_common::palace_alias::default_palace_registry_dir() else {
+        return slug;
+    };
+    trusty_common::palace_alias::alias_target_if_absent(&registry_dir, &slug).unwrap_or(slug)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trusty_common::palace_alias::PalaceAliasStore;
+
+    /// Point the data-dir override at `dir` for the duration of the closure.
+    ///
+    /// SAFETY: callers hold `crate::commands::env_test_lock`, which serialises
+    /// every `TRUSTY_DATA_DIR_OVERRIDE` mutation in this crate's test binary.
+    fn with_data_dir<T>(dir: &std::path::Path, f: impl FnOnce() -> T) -> T {
+        unsafe { std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, dir) };
+        let out = f();
+        unsafe { std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV) };
+        out
+    }
+
+    fn seed_palace(registry_dir: &std::path::Path, id: &str) {
+        let dir = registry_dir.join(id);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("palace.json"), b"{}").unwrap();
+    }
+
+    /// Why (#5810): the whole point — a derived slug with no palace of its own
+    /// must come back as the palace the memory tools actually accept.
+    /// Test: itself.
+    #[tokio::test]
+    async fn follow_palace_alias_names_the_target() {
+        let _guard = crate::commands::env_test_lock().lock().await;
+        let tmp = tempfile::tempdir().unwrap();
+        with_data_dir(tmp.path(), || {
+            let registry = trusty_common::palace_alias::default_palace_registry_dir().unwrap();
+            seed_palace(&registry, "trusty-tools");
+            PalaceAliasStore::register_alias(&registry, "bobmatnyc-trusty-tools", "trusty-tools")
+                .unwrap();
+            assert_eq!(
+                follow_palace_alias("bobmatnyc-trusty-tools".to_string()),
+                "trusty-tools"
+            );
+        });
+    }
+
+    /// Why: an alias must never rename a palace that exists, and a slug with no
+    /// alias at all must survive the round trip unchanged.
+    /// Test: itself.
+    #[tokio::test]
+    async fn follow_palace_alias_leaves_a_real_palace_alone() {
+        let _guard = crate::commands::env_test_lock().lock().await;
+        let tmp = tempfile::tempdir().unwrap();
+        with_data_dir(tmp.path(), || {
+            let registry = trusty_common::palace_alias::default_palace_registry_dir().unwrap();
+            seed_palace(&registry, "real-palace");
+            seed_palace(&registry, "other-palace");
+            PalaceAliasStore::register_alias(&registry, "real-palace", "other-palace").unwrap();
+            assert_eq!(
+                follow_palace_alias("real-palace".to_string()),
+                "real-palace"
+            );
+            assert_eq!(
+                follow_palace_alias("never-aliased".to_string()),
+                "never-aliased"
+            );
+        });
+    }
+}


### PR DESCRIPTION
## What

The `UserPromptSubmit` injection header named the palace slug the hook *asked
with*, not the one the daemon *opened*. With
`{"bobmatnyc-trusty-tools": "trusty-tools"}` in `palace_aliases.json`, the header
read:

```
## Relevant memories from palace `bobmatnyc-trusty-tools`
```

while every drawer under it came from `trusty-tools` — the only name
`palace_list` returns. Copying the printed name into `memory_recall`,
`palace_info`, or `memory_remember` named something that does not appear in the
palace list. After this change the header names `trusty-tools`.

The rule for whether an alias redirect fires was private to
`memory_core::registry`. It moves to
`trusty_common::palace_alias::alias_target_if_absent`; the registry now reads it
from there rather than keeping a second copy. trusty-memory applies it once, in
`palace_id_derive::follow_palace_alias`.

## Sibling emitters

Fixed here, same defect and same crate:

- `commands/inbox_check.rs` — the `SessionStart` header
  `# Inter-project inbox (trusty-memory, palace `{recipient}`)` came off the same
  derived-slug chain.
- The enriched-prompt log's `palace` field and the `HookFired` activity event's
  `palace_id`/`palace_name` share the corrected value.

Left alone deliberately: `commands/send_message.rs` and `tools/memory_ops.rs`
derive a `from_palace` that is stored as message provenance, not displayed.
Resolving those would rewrite sender identity, which is a separate decision.
`trusty-agents`' `persona_memory.rs` prints a palace name from agent config, not
from derivation.

## Relationship to #5811

`878dbb863` (branch `worktree-agent-ac95537dbaa58eaa4`, unpushed at time of
writing) consolidates palace *derivation* into `trusty_common::palace_resolve`.
It rewrites `cwd_palace_slug_at`, which produces the slug this PR then resolves,
and it stops trusty-mpm minting new aliases for pinned projects — so it removes
the current trigger for this repo's symptom. It does not touch the display path,
`palace_alias.rs`, `registry.rs`, or either hook header, and the alias mechanism
survives it. The two compose; the only shared file is
`crates/trusty-common/src/lib.rs`, where both edit adjacent module-doc blocks.
Sequence this after #5811 if you prefer.

## Test ladder

Rung 4 — the change adds a public function to `trusty-common`.

```
cargo fmt --check                                                          # EXIT=0
cargo clippy -p trusty-memory --all-targets -- -D warnings                 # EXIT=0
cargo clippy -p trusty-common --all-targets \
    --features memory-core,embedder-test-support -- -D warnings            # EXIT=0
cargo test -p trusty-common --features memory-core,embedder-test-support   # 1048 passed; 0 failed; 13 ignored (+8 further targets, all ok)
cargo test -p trusty-memory                                                # 774 passed; 0 failed; 4 ignored (+27 further targets, all ok)
cargo check --workspace                                                    # EXIT=0
bash scripts/check_line_cap.sh                                             # EXIT=0
bash scripts/check_sld.sh                                                  # EXIT=0
```

`trusty-common`'s only new symbol is `alias_target_if_absent`, and no existing
signature changed, so `trusty-memory` is its one new consumer; `check --workspace`
covers the rest.

## Regression test

`prompt_context_header_names_the_alias_target` builds the field shape — a slug
with no palace directory, aliased to one that has the drawers — and drives
`build_injection_body` from that cwd.

Against the parent behaviour (production call site reverted, test unchanged):

```
thread '...prompt_context_header_names_the_alias_target' panicked at
crates/trusty-memory/src/commands/prompt_context/tests.rs:638:5:
the header must name the palace the drawers came from; got:
## Relevant memories from palace `ptx-alias-derived`
- Rust integration uses tokio for async tasks and serde for JSON  _(tags: `rust`, `tokio`)_
test result: FAILED. 16 passed; 1 failed; 0 ignored; 0 measured; 761 filtered out
```

With the fix:

```
test commands::prompt_context::tests::prompt_context_header_names_the_alias_target ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 777 filtered out
```

## Test hygiene fixed on the way

`TRUSTY_MEMORY_PALACE` is precedence level 1 and every trusty-mpm managed session
exports one, so an ambient value outranked the pin file and the tempdir path
these tests assert on. Reproduced pre-existing at `origin/main` 819f55cc9 with a
clean tree:

```
thread '...palace_slug_from_stdin_cwd_uses_stdin_path' panicked at
crates/trusty-memory/src/commands/inbox_check.rs:362:9:
expected slug derived from stdin path, got "bobmatnyc-trusty-tools"
test result: FAILED. 0 passed; 1 failed
```

Five prompt-context daemon tests failed the same way. Both sites now scrub the
variable under `env_test_lock`. CI is green on this because no managed session
exports the variable there.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
