### PR TITLE
feat(trusty-mpm): per-project flag to decline the dispatched-agent worktree grant

### DIFF
--- a/crates/trusty-mpm/changelog.d/5814-agent-worktree-opt-out.md
+++ b/crates/trusty-mpm/changelog.d/5814-agent-worktree-opt-out.md
@@ -1,0 +1,4 @@
+Added
+
+- A project can now decline the dispatched-agent worktree grant. Set `agent_worktree = false` in the project's committed `.trusty-mpm.toml` and every agent dispatched there stays in the main checkout: no worktree is created, and none needs reclaiming (#5814). The dispatch's prompt is annotated with the workflow that replaces isolation — edit in place, commit on the branch the checkout already has, push. Isolation stays the default everywhere else; an absent, malformed, or unreadable config keeps ADR-0048's grant exactly as it was.
+- `agent_worktree` is a separate key from `worktree`, which decides where a managed SESSION runs. Setting one does not move the other. The opt-out exempts the dispatch from the worktree grant only: the ADR-0044 main-checkout write boundary is unchanged, and a second concurrent writer in the same checkout is still refused.

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
@@ -140,7 +140,11 @@
 //! the daemon who holds this checkout, which both keeps the concurrency verdict
 //! alive if the harness ignores `updatedInput` and records the granted isolation
 //! so the tracker's original-payload record stops naming an isolated writer as a
-//! shared-checkout one.
+//! shared-checkout one. **A project may decline the grant (#5814):** with
+//! `agent_worktree = false` in its committed `.trusty-mpm.toml` the dispatch
+//! keeps the checkout and its prompt is annotated with the in-place workflow
+//! instead. That arm reports no granted worktree to the daemon — there is none —
+//! but still runs the #4480 concurrency check before printing.
 //! **Subagent fan-out denial (issue #4784):** [`pm_guard`] calls
 //! [`crate::commands::pm_guard_fanout::evaluate_subagent_fanout`] DIRECTLY,
 //! before Guards 1 and 4, denying `Task`/`Agent` when the calling session is
@@ -532,6 +536,28 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
             pm_guard_worktree_grant::WorktreeGrant::Deny(reason) => {
                 audit_denied_tool(url, session_id, tool_name, reason).await;
                 println!("{}", build_pretooluse_deny_response(reason));
+            }
+            // #5814: this project declared `agent_worktree = false`, so the
+            // dispatch keeps the checkout and is told the workflow that replaces
+            // isolation. It must NOT go through `evaluate_granted_worktree` —
+            // that records a granted worktree, and there is none to record. The
+            // #4480 concurrency question is still asked here rather than skipped:
+            // opting out of isolation does not make two writers on one git HEAD
+            // safe, and a printed rewrite ends this call, so the check below
+            // would never run.
+            pm_guard_worktree_grant::WorktreeGrant::InPlace(updated_input) => {
+                match pm_guard_dispatch::evaluate(url, &payload, tool_name, tool_input, session_id)
+                    .await
+                {
+                    Some(reason) => {
+                        audit_denied_tool(url, session_id, tool_name, &reason).await;
+                        println!("{}", build_pretooluse_deny_response(&reason));
+                    }
+                    None => println!(
+                        "{}",
+                        pm_guard_worktree_grant::build_worktree_grant_response(&updated_input)
+                    ),
+                }
             }
         }
         return Ok(());

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_worktree_grant.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_worktree_grant.rs
@@ -46,7 +46,19 @@
 //! unnecessary worktree to a read-only custom agent is the whole cost of that
 //! choice.
 //!
-//! Test: `grants_*`, `does_not_grant_*`, `task_dispatch_*` below;
+//! **A project may decline the grant entirely (#5814).** Isolation buys
+//! separation between concurrent writers and between build states. A writing or
+//! documentation repo has neither, so the grant costs it agent edits stranded in
+//! `.claude/worktrees/agent-<id>/` and trees left to reclaim. Such a project sets
+//! `agent_worktree = false` in its committed `.trusty-mpm.toml`, which
+//! [`trusty_mpm::project::dispatched_agent_worktree_enabled`] reads: the dispatch
+//! then gets [`WorktreeGrant::InPlace`] — its prompt annotated with
+//! `IN_PLACE_WORKFLOW_NOTE` and no `isolation` added — instead of a worktree.
+//! The check runs AFTER `is_main_checkout` so only a dispatch that would
+//! otherwise be granted pays for the file read, and an absent, malformed, or
+//! unreadable config leaves the grant exactly as it was.
+//!
+//! Test: `grants_*`, `does_not_grant_*`, `task_dispatch_*`, `in_place_*` below;
 //! `pm_guard_grants_a_worktree_to_a_writer_in_a_main_checkout` and siblings in
 //! `tests/tm_hook_pm_guard.rs` run it through the real binary.
 
@@ -58,6 +70,7 @@ use trusty_mpm::core::dispatch_isolation::{
     dispatch_agent, dispatch_isolation, requires_own_worktree_in_main_checkout,
 };
 use trusty_mpm::core::project_aliases::is_main_checkout;
+use trusty_mpm::project::dispatched_agent_worktree_enabled;
 
 /// The `isolation` value granted to a dispatch that needs its own tree.
 ///
@@ -95,6 +108,26 @@ pub(crate) const TASK_DENY_REASON: &str = "Unisolated dispatch denied in a main 
      own; `Task` carries no isolation parameter, so it cannot be given one here. A read-only \
      agent (research, review, analysis) is never blocked by this rule.";
 
+/// What an opted-out project's dispatch is told instead of being isolated.
+///
+/// Why (#5814): suppressing the grant is only half the fix. The agent still
+/// arrives carrying the framework's own worktree discipline and, finding itself
+/// in a main checkout with no tree of its own, stops rather than proceeds — the
+/// reported failure is a `version-control` agent that refused to commit for
+/// exactly that reason. The note states the workflow the project chose when it
+/// set the flag, and it reaches the agent as data: it is appended to the
+/// dispatch's own prompt through `hookSpecificOutput.updatedInput`, the same
+/// mechanism the grant uses, so it applies whether or not the PM read anything.
+/// What: appended verbatim, once, to a string `prompt`.
+/// Test: `in_place_notice_is_appended_to_the_prompt`,
+/// `in_place_notice_is_not_appended_twice`.
+const IN_PLACE_WORKFLOW_NOTE: &str = "\n\n---\nWorktree isolation is OFF for this project: it sets `agent_worktree = false` in \
+     `.trusty-mpm.toml` (trusty-tools#5814). No worktree has been created for you and none will \
+     be reclaimed, so work IN PLACE in the current working directory — edit the files where they \
+     are, commit on the branch the checkout already has, and push. Do not create a worktree, a \
+     branch, or a pull request unless this project's own instructions ask for one. The \
+     main-checkout write boundary is unchanged: a source-file edit here is still denied.";
+
 /// Decide what to do with one dispatch made from a main checkout.
 ///
 /// Why: the single entry point `pm_guard` calls, kept as one function so the
@@ -104,13 +137,15 @@ pub(crate) const TASK_DENY_REASON: &str = "Unisolated dispatch denied in a main 
 /// that already declares isolation, for a positively-identified read-only
 /// agent, and for any cwd that is not a main checkout. Otherwise
 /// [`WorktreeGrant::Rewrite`] carrying the dispatch's own input with
-/// `isolation` added, or [`WorktreeGrant::Deny`] when the tool cannot accept
-/// one.
+/// `isolation` added, [`WorktreeGrant::Deny`] when the tool cannot accept one,
+/// or [`WorktreeGrant::InPlace`] when the project declined isolation (#5814).
 ///
 /// `is_main_checkout` is tested LAST because it is the only branch that touches
-/// the filesystem, and every ordinary tool call must not pay for it.
+/// the filesystem, and every ordinary tool call must not pay for it. The #5814
+/// project opt-out reads a second file and therefore sits behind it.
 /// Test: `grants_a_worktree_to_an_unisolated_writer`,
-/// `does_not_grant_outside_a_main_checkout`, `does_not_grant_a_read_only_agent`.
+/// `does_not_grant_outside_a_main_checkout`, `does_not_grant_a_read_only_agent`,
+/// `grants_nothing_when_the_project_opts_out`.
 pub(crate) fn evaluate_worktree_grant(
     tool_name: &str,
     tool_input: Option<&Value>,
@@ -126,6 +161,11 @@ pub(crate) fn evaluate_worktree_grant(
     if !is_main_checkout(cwd) {
         return None;
     }
+    // #5814: a project with no concurrent writers and no build state declares
+    // `agent_worktree = false`, and its agents work in the checkout instead.
+    if !dispatched_agent_worktree_enabled(cwd) {
+        return with_in_place_notice(tool_input).map(WorktreeGrant::InPlace);
+    }
     if tool_name != ISOLATION_AWARE_DISPATCH_TOOL {
         return Some(WorktreeGrant::Deny(TASK_DENY_REASON));
     }
@@ -134,17 +174,26 @@ pub(crate) fn evaluate_worktree_grant(
 
 /// What [`evaluate_worktree_grant`] decided.
 ///
-/// Why: the two outcomes are different JSON objects on the hook's stdout — one
-/// replaces the tool's arguments, the other blocks the call — and a `PreToolUse`
-/// hook may print exactly one of them, so the choice has to be explicit rather
-/// than inferred from an `Option` at the call site.
-/// Test: `task_dispatch_is_denied_rather_than_rewritten`.
+/// Why: the outcomes are different JSON objects on the hook's stdout — two
+/// replace the tool's arguments, one blocks the call — and a `PreToolUse` hook
+/// may print exactly one of them, so the choice has to be explicit rather than
+/// inferred from an `Option` at the call site.
+/// Test: `task_dispatch_is_denied_rather_than_rewritten`,
+/// `grants_nothing_when_the_project_opts_out`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum WorktreeGrant {
     /// Replace the dispatch's arguments with these, isolation included.
     Rewrite(Value),
     /// Block the dispatch; the tool cannot be given isolation.
     Deny(&'static str),
+    /// The project declined isolation (#5814): these arguments carry the
+    /// original input plus the in-place workflow note, and NO `isolation`.
+    ///
+    /// It is a separate variant from [`Self::Rewrite`] because the call site
+    /// must not report a granted worktree to the daemon for a dispatch that was
+    /// given none — the delegation record would then name a tree that does not
+    /// exist. The concurrency question is still asked; see the call site.
+    InPlace(Value),
 }
 
 /// The dispatch's own input with `isolation` set to [`GRANTED_ISOLATION`].
@@ -165,6 +214,33 @@ fn with_granted_isolation(tool_input: Option<&Value>) -> Value {
     input
 }
 
+/// The dispatch's own input with [`IN_PLACE_WORKFLOW_NOTE`] appended to its prompt.
+///
+/// Why (#5814): `updatedInput` REPLACES a tool's arguments, so the whole input
+/// is carried and only the prompt changes — above all, `isolation` is NOT added,
+/// which is the entire point of the opt-out.
+/// What: `Some(input)` when the dispatch carries a string `prompt` that does not
+/// already end with the note; `None` otherwise, which leaves the dispatch
+/// untouched and unisolated. `None` covers both a dispatch with no prompt to
+/// annotate — there is nothing to say it to, and inventing a field the caller
+/// did not send is how a malformed rewrite gets built — and a re-evaluated
+/// dispatch, which must not accumulate a second copy of the note.
+/// Test: `in_place_notice_is_appended_to_the_prompt`,
+/// `in_place_notice_is_not_appended_twice`,
+/// `in_place_leaves_a_promptless_dispatch_alone`.
+fn with_in_place_notice(tool_input: Option<&Value>) -> Option<Value> {
+    let Some(Value::Object(map)) = tool_input else {
+        return None;
+    };
+    let prompt = map.get("prompt").and_then(Value::as_str)?;
+    if prompt.contains(IN_PLACE_WORKFLOW_NOTE) {
+        return None;
+    }
+    let mut input = Value::Object(map.clone());
+    input["prompt"] = Value::String(format!("{prompt}{IN_PLACE_WORKFLOW_NOTE}"));
+    Some(input)
+}
+
 /// Build the `hookSpecificOutput.updatedInput` body for a granted dispatch.
 ///
 /// Why: mirrors [`crate::commands::hook_rewrite::build_pretooluse_rewrite_response`]
@@ -172,7 +248,8 @@ fn with_granted_isolation(tool_input: Option<&Value>) -> Value {
 /// rather than reusing it, because that one is shaped for a Bash command string
 /// and this one carries a whole tool input.
 /// What: `{"hookSpecificOutput": {"hookEventName": "PreToolUse",
-/// "updatedInput": <input>}}`.
+/// "updatedInput": <input>}}`. The #5814 in-place rewrite prints through here
+/// too — the envelope is the same, only the input differs.
 /// Test: `grant_response_has_the_documented_shape`.
 pub(crate) fn build_worktree_grant_response(updated_input: &Value) -> String {
     serde_json::json!({
@@ -352,6 +429,114 @@ mod tests {
         assert_eq!(updated["model"], "sonnet");
         assert_eq!(updated["subagent_type"], "rust-engineer");
         assert_eq!(updated["isolation"], "worktree");
+    }
+
+    /// A project directory that is a main checkout AND carries a project config.
+    ///
+    /// Why: the opt-out is only reachable past `is_main_checkout`, so every
+    /// #5814 case needs both the `.git` directory and the config file.
+    fn main_checkout_with_config(body: &str) -> TempDir {
+        let dir = main_checkout();
+        std::fs::write(
+            dir.path()
+                .join(trusty_mpm::core::project_config::PROJECT_CONFIG_FILE),
+            body,
+        )
+        .expect("write project config");
+        dir
+    }
+
+    #[test]
+    fn grants_nothing_when_the_project_opts_out() {
+        // #5814: `agent_worktree = false` — the writer stays in the checkout,
+        // and the rewrite carries no `isolation` at all.
+        let dir = main_checkout_with_config("agent_worktree = false\n");
+        let sent = serde_json::json!({"subagent_type": "rust-engineer", "prompt": "do the thing"});
+        let grant = evaluate_worktree_grant("Agent", Some(&sent), dir.path())
+            .expect("an opted-out project must still annotate the dispatch");
+        let WorktreeGrant::InPlace(updated) = grant else {
+            panic!("an opted-out project must not be granted a worktree");
+        };
+        assert!(
+            updated.get("isolation").is_none(),
+            "the opt-out must not add isolation: {updated}"
+        );
+        assert_eq!(updated["subagent_type"], "rust-engineer");
+    }
+
+    #[test]
+    fn opt_out_covers_task_which_would_otherwise_be_denied() {
+        // A `Task` writer is denied today only because it needs a worktree it
+        // cannot be given. A project that needs no worktree has no such dispatch
+        // to refuse.
+        let dir = main_checkout_with_config("agent_worktree = false\n");
+        let sent = serde_json::json!({"subagent_type": "rust-engineer", "prompt": "go"});
+        assert!(
+            matches!(
+                evaluate_worktree_grant("Task", Some(&sent), dir.path()),
+                Some(WorktreeGrant::InPlace(_))
+            ),
+            "the opt-out must reach Task before the deny"
+        );
+    }
+
+    #[test]
+    fn grants_a_worktree_when_the_project_says_nothing_or_says_yes() {
+        // The default branch, which is every project that predates #5814: an
+        // absent key, an absent file, an unrelated key, and a config that cannot
+        // be parsed at all must ALL leave ADR-0048's grant exactly as it was.
+        for body in [
+            "default_model = \"opus\"\n",
+            "agent_worktree = true\n",
+            "worktree = false\n",
+            "agent_worktre = false\n",
+            "agent_worktree = \"false\"\n",
+            "agent_worktree = false\nnot toml at all(",
+        ] {
+            let dir = main_checkout_with_config(body);
+            let sent = serde_json::json!({"subagent_type": "rust-engineer", "prompt": "go"});
+            let grant = evaluate_worktree_grant("Agent", Some(&sent), dir.path())
+                .expect("a writer in a main checkout is still granted a worktree");
+            let WorktreeGrant::Rewrite(updated) = grant else {
+                panic!("expected the ordinary grant for config: {body}");
+            };
+            assert_eq!(updated["isolation"], "worktree", "config was: {body}");
+        }
+    }
+
+    #[test]
+    fn in_place_notice_is_appended_to_the_prompt() {
+        // The note is how the agent learns the workflow that replaces isolation;
+        // the original brief must survive in front of it.
+        let sent =
+            serde_json::json!({"subagent_type": "documentation", "prompt": "write the memo"});
+        let updated = with_in_place_notice(Some(&sent)).expect("a prompted dispatch is annotated");
+        let prompt = updated["prompt"].as_str().expect("prompt stays a string");
+        assert!(prompt.starts_with("write the memo"));
+        assert!(prompt.ends_with(IN_PLACE_WORKFLOW_NOTE));
+        assert!(prompt.contains("agent_worktree = false"));
+        assert_eq!(updated["subagent_type"], "documentation");
+    }
+
+    #[test]
+    fn in_place_notice_is_not_appended_twice() {
+        let sent = serde_json::json!({"prompt": format!("brief{IN_PLACE_WORKFLOW_NOTE}")});
+        assert_eq!(with_in_place_notice(Some(&sent)), None);
+    }
+
+    #[test]
+    fn in_place_leaves_a_promptless_dispatch_alone() {
+        // Nothing to annotate, and inventing a `prompt` the caller never sent
+        // would rewrite the dispatch into one it did not make.
+        assert_eq!(with_in_place_notice(None), None);
+        assert_eq!(
+            with_in_place_notice(Some(&serde_json::json!({"subagent_type": "documentation"}))),
+            None
+        );
+        assert_eq!(
+            with_in_place_notice(Some(&serde_json::json!({"prompt": 7}))),
+            None
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/project_config.rs
+++ b/crates/trusty-mpm/src/core/project_config.rs
@@ -26,7 +26,8 @@
 //! stays host-level — it is a property of the operator's supervisor, not of the
 //! repository.
 //!
-//! Test: `project_config_parses_worktree`, `project_config_rejects_unknown_key`,
+//! Test: `project_config_parses_worktree`, `project_config_parses_agent_worktree`,
+//! `project_config_rejects_unknown_key`,
 //! `project_config_absent_is_none`, `project_config_rejects_wrong_type`,
 //! `project_config_empty_file_is_all_none` in `project_config_tests.rs`.
 //!
@@ -129,6 +130,37 @@ pub struct ProjectLevelConfig {
     /// `worktree_project_config_overrides_registry`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree: Option<bool>,
+
+    /// Whether a dispatched agent in this project gets a worktree of its own.
+    ///
+    /// Why (#5814): ADR-0048 decision 1 grants every dispatched writer its own
+    /// worktree when the session stands in a main checkout, and that grant is
+    /// mechanical — it never reads the dispatch prompt, so no instruction can
+    /// wave it off. Worktree isolation pays for concurrent writers and separate
+    /// build state; a writing or documentation repo has neither, and pays only
+    /// the costs: agent edits land in `.claude/worktrees/agent-<id>/` and never
+    /// reach the checkout, a second agent has to copy them across, and the trees
+    /// and branches pile up needing reclamation. This field is that project
+    /// class's opt-out.
+    ///
+    /// What: `None` (the default) → the grant behaves exactly as it did before
+    /// this key existed. `Some(false)` → dispatched agents stay in the main
+    /// checkout: nothing is created and nothing needs reclaiming. `Some(true)`
+    /// → the default, stated explicitly.
+    ///
+    /// This is a SEPARATE key from [`Self::worktree`], not a widening of it.
+    /// `worktree` decides where a managed SESSION is placed and ADR-0044
+    /// decision 6 narrowed its live effect to the daemon-unreachable
+    /// provisioning fallback; reusing it here would give one key two unrelated
+    /// meanings again — the double duty ADR-0037 called out. Setting this key
+    /// exempts the dispatch from the worktree GRANT only: the ADR-0044
+    /// main-checkout write boundary is untouched, so a source-file edit there is
+    /// still denied.
+    /// Test: `project_config_parses_agent_worktree`,
+    /// `agent_worktree_opt_out_is_honoured`,
+    /// `grants_nothing_when_the_project_opts_out`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_worktree: Option<bool>,
 
     /// Default model id (or tier alias) for sessions launched in this project.
     ///

--- a/crates/trusty-mpm/src/core/project_config_tests.rs
+++ b/crates/trusty-mpm/src/core/project_config_tests.rs
@@ -43,6 +43,28 @@ fn project_config_parses_worktree() {
     assert_eq!(cfg.default_model, None);
 }
 
+/// Why (#5814): `agent_worktree` is a SEPARATE key from `worktree` — a file
+/// that sets one must leave the other undecided, or the dispatched-agent opt-out
+/// would silently relocate the project's sessions as well.
+#[test]
+fn project_config_parses_agent_worktree() {
+    let cfg = ProjectLevelConfig::from_toml("agent_worktree = false\n", Path::new("t.toml"))
+        .expect("valid config");
+    assert_eq!(cfg.agent_worktree, Some(false));
+    assert_eq!(
+        cfg.worktree, None,
+        "the session-placement key must stay undecided"
+    );
+
+    let both = ProjectLevelConfig::from_toml(
+        "worktree = true\nagent_worktree = false\n",
+        Path::new("t.toml"),
+    )
+    .expect("valid config");
+    assert_eq!(both.worktree, Some(true));
+    assert_eq!(both.agent_worktree, Some(false));
+}
+
 /// Why: an empty (or comment-only) file is a legitimate state — it overrides
 /// nothing and must not be an error.
 #[test]

--- a/crates/trusty-mpm/src/project/mod.rs
+++ b/crates/trusty-mpm/src/project/mod.rs
@@ -15,7 +15,9 @@
 //! - `worktree_policy` — the `worktree` opt-out decision, shared by the daemon
 //!   and the out-of-process `tm` CLI (#3455, #4300). Since #5207 a project's
 //!   own committed `.trusty-mpm.toml` outranks the machine-global registry;
-//!   see [`worktree_enabled_for_project`].
+//!   see [`worktree_enabled_for_project`]. The separate `agent_worktree` key
+//!   (#5814) answers a different question — whether a DISPATCHED AGENT gets a
+//!   worktree — through [`dispatched_agent_worktree_enabled`].
 //! Test: each submodule carries inline unit tests; run with
 //! `cargo test -p trusty-mpm`.
 //!
@@ -24,6 +26,7 @@
 //! [`derive_name_from_url`]: crate::project::derive_name_from_url
 //! [`ProjectStore`]: crate::project::store::ProjectStore
 //! [`worktree_enabled_for_project`]: crate::project::worktree_enabled_for_project
+//! [`dispatched_agent_worktree_enabled`]: crate::project::dispatched_agent_worktree_enabled
 
 pub mod record;
 pub mod registry;
@@ -39,7 +42,7 @@ pub use resolver::{
 };
 pub use store::ProjectStoreError;
 pub use worktree_policy::{
-    registry_data_dir, registry_data_dir_under, worktree_enabled_for_origin,
-    worktree_enabled_for_origin_at, worktree_enabled_for_project, worktree_enabled_in,
-    worktree_override_in_project,
+    dispatched_agent_worktree_enabled, registry_data_dir, registry_data_dir_under,
+    worktree_enabled_for_origin, worktree_enabled_for_origin_at, worktree_enabled_for_project,
+    worktree_enabled_in, worktree_override_in_project,
 };

--- a/crates/trusty-mpm/src/project/worktree_policy.rs
+++ b/crates/trusty-mpm/src/project/worktree_policy.rs
@@ -189,6 +189,35 @@ pub async fn worktree_enabled_for_project(
     worktree_enabled_for_origin(registry, origin).await
 }
 
+/// Does a dispatched agent in this project get a worktree of its own (#5814)?
+///
+/// Why: ADR-0048 decision 1 grants one to every dispatched writer standing in a
+/// main checkout, and the decision is mechanical — `tm hook --pm-guard` never
+/// reads the dispatch prompt, so a project whose workflow wants no isolation had
+/// no way to say so. Isolation buys separation between concurrent writers and
+/// between build states; a writing or documentation repo has neither pressure,
+/// and pays instead in edits stranded in a tree the operator never looks at.
+///
+/// What: reads the project's committed `.trusty-mpm.toml` and answers its
+/// `agent_worktree` key; `true` when the key, the file, or a readable file is
+/// absent. It deliberately consults NO registry layer — `projects.json` carries
+/// #3455's `worktree` flag, which ADR-0044 decision 6 narrowed to the
+/// daemon-unreachable provisioning fallback, and letting that machine-global
+/// record reach this decision would resurrect the double duty ADR-0037 removed.
+/// A malformed or unreadable file resolves to `true` through
+/// [`load_or_report`], so no failure can strip a project of isolation it had
+/// before this key existed.
+/// Test: `agent_worktree_defaults_true_without_a_config`,
+/// `agent_worktree_opt_out_is_honoured`,
+/// `agent_worktree_malformed_config_keeps_isolation`,
+/// `agent_worktree_is_independent_of_the_session_worktree_key`.
+pub fn dispatched_agent_worktree_enabled(project_dir: &Path) -> bool {
+    // #5814: absent, undecided, or unreadable all mean "keep ADR-0048's grant".
+    load_or_report(project_dir)
+        .and_then(|cfg| cfg.agent_worktree)
+        .unwrap_or(true)
+}
+
 #[cfg(test)]
 #[path = "worktree_policy_tests.rs"]
 mod tests;

--- a/crates/trusty-mpm/src/project/worktree_policy_tests.rs
+++ b/crates/trusty-mpm/src/project/worktree_policy_tests.rs
@@ -13,9 +13,9 @@
 use std::path::Path;
 
 use super::{
-    REGISTRY_DIR_NAME, registry_data_dir_under, worktree_enabled_for_origin,
-    worktree_enabled_for_origin_at, worktree_enabled_for_project, worktree_enabled_in,
-    worktree_override_in_project,
+    REGISTRY_DIR_NAME, dispatched_agent_worktree_enabled, registry_data_dir_under,
+    worktree_enabled_for_origin, worktree_enabled_for_origin_at, worktree_enabled_for_project,
+    worktree_enabled_in, worktree_override_in_project,
 };
 use crate::project::{Project, ProjectRegistry};
 
@@ -528,5 +528,89 @@ async fn agent_isolation_stays_enabled_for_a_worktree_true_project() {
             .await,
         "`worktree: false` must still reach the main-checkout answer, or the two \
          assertions above would pass for a resolver hard-wired to `true`"
+    );
+}
+
+// ── Dispatched-agent worktree opt-out (#5814) ────────────────────────────────
+//
+// Why these four: the flag has exactly two branches that matter (a project that
+// opts out, and every project that does not), one failure mode that must not
+// change behaviour (a file that does not parse), and one collision to rule out
+// (the pre-existing `worktree` key must not reach this decision).
+
+/// Why: a project that predates this key must behave exactly as it does today.
+/// Both routes to "undecided" — no config file, and a config that sets other
+/// keys — keep the ADR-0048 grant.
+/// Test: itself.
+#[test]
+fn agent_worktree_defaults_true_without_a_config() {
+    let empty = tempfile::TempDir::new().expect("tempdir");
+    assert!(
+        dispatched_agent_worktree_enabled(empty.path()),
+        "a project with no .trusty-mpm.toml keeps ADR-0048's grant"
+    );
+
+    let other_keys = project_dir_with_config("default_model = \"opus\"\n");
+    assert!(
+        dispatched_agent_worktree_enabled(other_keys.path()),
+        "a config that declines to decide keeps ADR-0048's grant"
+    );
+
+    let missing = empty.path().join("never-created");
+    assert!(
+        dispatched_agent_worktree_enabled(&missing),
+        "a directory that does not exist keeps ADR-0048's grant"
+    );
+}
+
+/// Why: the feature itself — a writing repo declares it wants its agents in the
+/// checkout, and the resolver says so. `agent_worktree = true` is also asserted,
+/// so a resolver hard-wired to `false` fails here rather than passing.
+/// Test: itself.
+#[test]
+fn agent_worktree_opt_out_is_honoured() {
+    let opted_out = project_dir_with_config("agent_worktree = false\n");
+    assert!(!dispatched_agent_worktree_enabled(opted_out.path()));
+
+    let explicit_on = project_dir_with_config("agent_worktree = true\n");
+    assert!(dispatched_agent_worktree_enabled(explicit_on.path()));
+}
+
+/// Why: the config is COMMITTED, so a bad edit reaches everyone at once. A file
+/// that cannot be understood must leave isolation ON — the state the project had
+/// before the key existed — never strip it.
+/// Test: itself.
+#[test]
+fn agent_worktree_malformed_config_keeps_isolation() {
+    for body in [
+        "agent_worktre = false\n",       // misspelled key
+        "agent_worktree = \"false\"\n",  // wrong type
+        "agent_worktree = false\nthis(", // not TOML at all
+    ] {
+        let dir = project_dir_with_config(body);
+        assert!(
+            dispatched_agent_worktree_enabled(dir.path()),
+            "an unusable config must keep isolation ON, got OFF for: {body}"
+        );
+    }
+}
+
+/// Why: #3455's `worktree` key decides SESSION placement and ADR-0044 decision 6
+/// narrowed it further. If it reached this decision, every project that already
+/// launches on main would silently lose agent isolation too — the collision this
+/// key exists to avoid.
+/// Test: itself.
+#[test]
+fn agent_worktree_is_independent_of_the_session_worktree_key() {
+    let session_opt_out = project_dir_with_config("worktree = false\n");
+    assert!(
+        dispatched_agent_worktree_enabled(session_opt_out.path()),
+        "`worktree = false` must not reach the dispatched-agent decision"
+    );
+
+    let opposed = project_dir_with_config("worktree = true\nagent_worktree = false\n");
+    assert!(
+        !dispatched_agent_worktree_enabled(opposed.path()),
+        "the two keys are answered independently, in both directions"
     );
 }

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -2004,6 +2004,51 @@ fn pm_guard_grants_a_worktree_to_a_writer_in_a_main_checkout() {
 }
 
 #[test]
+fn pm_guard_keeps_an_opted_out_project_in_the_checkout() {
+    // #5814: the project declares `agent_worktree = false`, so the same dispatch
+    // that is granted a worktree above is left in the checkout and told the
+    // workflow that replaces isolation. Read through the real binary because the
+    // config read is a filesystem step the unit tests fake.
+    let (_dir, repo) = main_checkout_fixture();
+    std::fs::write(repo.join(".trusty-mpm.toml"), "agent_worktree = false\n")
+        .expect("write project config");
+    let input = r#"{"subagent_type":"documentation","prompt":"write the memo"}"#;
+    let stdout = run_pm_guard(&tool_payload_at("Agent", input, &repo, ""), &[]);
+
+    let value: serde_json::Value =
+        serde_json::from_str(stdout.trim()).unwrap_or_else(|e| panic!("{e}: {stdout}"));
+    let updated = &value["hookSpecificOutput"]["updatedInput"];
+    assert!(
+        updated.get("isolation").is_none(),
+        "an opted-out project must not be granted a worktree: {stdout}"
+    );
+    let prompt = updated["prompt"].as_str().expect("prompt survives");
+    assert!(prompt.starts_with("write the memo"), "{stdout}");
+    assert!(prompt.contains("agent_worktree = false"), "{stdout}");
+    assert!(prompt.contains("work IN PLACE"), "{stdout}");
+}
+
+#[test]
+fn pm_guard_still_grants_when_the_project_config_is_unreadable() {
+    // #5814's default branch: a config that does not parse leaves ADR-0048's
+    // grant exactly as it was. A project that predates the key behaves today
+    // as it did before it existed — covered by the sibling above, which uses
+    // the same fixture with no config file at all.
+    let (_dir, repo) = main_checkout_fixture();
+    std::fs::write(repo.join(".trusty-mpm.toml"), "agent_worktre = false\n")
+        .expect("write project config");
+    let input = r#"{"subagent_type":"rust-engineer","prompt":"do the thing"}"#;
+    let stdout = run_pm_guard(&tool_payload_at("Agent", input, &repo, ""), &[]);
+
+    let value: serde_json::Value =
+        serde_json::from_str(stdout.trim()).unwrap_or_else(|e| panic!("{e}: {stdout}"));
+    assert_eq!(
+        value["hookSpecificOutput"]["updatedInput"]["isolation"], "worktree",
+        "a config that cannot be parsed must never strip isolation: {stdout}"
+    );
+}
+
+#[test]
 fn pm_guard_denies_a_granted_dispatch_beside_a_live_writer() {
     // #5769 finding 2: the grant used to return BEFORE the #4480 concurrency
     // check, so that verdict stopped being computed for every dispatch made from

--- a/docs/adr/0048-dispatched-writers-get-a-worktree-and-the-write-boundary-is-enforced.md
+++ b/docs/adr/0048-dispatched-writers-get-a-worktree-and-the-write-boundary-is-enforced.md
@@ -61,7 +61,12 @@ leave the boundary unenforced. The owner's ruling is that both close together.
    the dispatch after reading a denial. The grant is reported to the daemon so
    the dispatch's delegation record carries the isolation it was given, and it is
    emitted only after that same call reports the checkout free — see
-   Consequences for why neither is optional.
+   Consequences for why neither is optional. Since #5814 a project may decline
+   this grant by setting `agent_worktree = false` in its committed
+   `.trusty-mpm.toml`; its dispatches then stay in the checkout with the in-place
+   workflow appended to the prompt. That key is separate from decision 6's
+   `worktree` flag, and exempts the grant only — the write boundary below is
+   unchanged.
 2. **Trusty-mpm still creates no worktrees.** ADR-0044 decision 4 is unchanged
    and this decision depends on it: the harness provisions the worktree under
    `.claude/worktrees/` per [ADR-0036](0036-all-worktrees-are-siblings-under-claude-worktrees.md)

--- a/docs/reference/config-convention.md
+++ b/docs/reference/config-convention.md
@@ -70,6 +70,8 @@ trusty-mpm also reads one file **from the project itself**:
 ```toml
 # Do this repo's managed sessions get a per-session git worktree?
 worktree = false
+# Does an agent DISPATCHED in this repo get a worktree of its own? (#5814)
+agent_worktree = false
 # Default model id or tier alias for sessions launched in this project.
 default_model = opus
 ```
@@ -87,7 +89,19 @@ Where a setting appears here, this file is the **top** of its precedence chain:
 | Setting | Precedence, highest first |
 |---|---|
 | `worktree` | `.trusty-mpm.toml` → the `projects.json` registry → built-in `true` |
+| `agent_worktree` | `.trusty-mpm.toml` → built-in `true` |
 | `default_model` | `.trusty-mpm.toml` → `config.yaml`'s `default_model` → `config.toml`'s `[models] default` → built-in `sonnet` |
+
+`worktree` and `agent_worktree` answer different questions and neither implies
+the other. `worktree` decides where a managed SESSION is placed; `agent_worktree`
+decides whether an agent DISPATCHED from a main checkout is given a worktree of
+its own under ADR-0048 decision 1. `agent_worktree` reads no registry layer at
+all — a machine-global record must not decide a project's dispatch workflow.
+Setting `agent_worktree = false` suits a repo with no concurrent writers and no
+build state (a writing or documentation repo): its agents edit in place, commit
+on the checked-out branch, and push. It exempts the worktree grant only. The
+ADR-0044 main-checkout write boundary still denies a source-file edit there, and
+a second concurrent writer in the same checkout is still refused.
 
 `default_model` is a *default*: an explicit `--model`, a per-agent
 `[models.agents]` entry, and an agent's own frontmatter are all more specific and


### PR DESCRIPTION
Closes #5814

## What

Adds an `agent_worktree` key to a project's committed `.trusty-mpm.toml`. When set `false`, dispatched agents in that project stay in the main checkout — no worktree is created and none needs reclaiming. Default is unchanged.

## Why

Worktree isolation earns its cost where there are concurrent writers or build state. A writing or documentation repo has neither and pays real costs: agent edits land in `.claude/worktrees/agent-<id>/` and never reach the checkout, and worktrees pile up. #5814 documents this from a real session in a markdown-only repo.

## Where it branches

`crates/trusty-mpm/src/bin/tm/commands/pm_guard_worktree_grant.rs:164-168`, after the main-checkout test and before the `Task` deny.

## Relationship to the existing `worktree` key

This is a NEW key, deliberately independent of #3455's `worktree` (narrowed by ADR-0044 decision 6 to the daemon-unreachable fallback). `agent_worktree_is_independent_of_the_session_worktree_key` asserts both directions.

Unreadable or malformed config keeps isolation on, so a project predating this change behaves exactly as today.

## Limitation

The opt-out covers the worktree grant only. On a code repo an opted-out agent is still denied source-file edits by the ADR-0044 write boundary, so the flag is fully useful for the markdown/docs class #5814 names and only partly useful elsewhere. Widening the write boundary was not requested and was not done.

## Testing

Rung 3: `cargo fmt --all --check`, `cargo check -p trusty-mpm --all-targets`, `cargo clippy -p trusty-mpm --all-targets -- -D warnings`, `cargo test -p trusty-mpm`, `cargo check --workspace`, plus `check_line_cap.sh`, `check_sld.sh`, `check_test_pointers.sh`, `check_changelog_fragment.sh`, `check_public_docs.sh`. All exit 0. `8866 passed, 0 failed, 18 ignored` across 49 binaries. 14 new tests, covering both the opt-out branch and six default-branch configs.

## Docs

One sentence added to ADR-0048 decision 1 recording that the grant can be declined, keeping that ADR's prose accurate. No new ADR — this is an ordinary config feature, not a decision reversal.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
