### PR TITLE
fix(scripts): attribute crate source by manifest, not path depth, and fail closed on unattributable paths

### DIFF
--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -73,6 +73,17 @@ jobs:
       - name: Stale-base selftest (must refuse a pinned base.sha)
         run: bash scripts/check_changelog_base_selftest.sh
 
+      # Crate-attribution selftest (#4576): the gate selected nested crate
+      # source with a `case` glob whose `*` spans `/`, then extracted the crate
+      # with a sed that spans exactly one directory level — so a nested path was
+      # selected and silently DROPPED, and the gate printed "no crate source
+      # changed … — OK" over a whole shipped source tree (PR #5796). This
+      # re-proves that nested source is attributed, that an unattributable path
+      # fails rather than vanishing, and that build.rs / tests/ / benches/ /
+      # testdata/ / dist bundles / Cargo.toml still need no fragment.
+      - name: Crate-attribution selftest (must not drop nested crate source)
+        run: bash scripts/check_changelog_attribution_selftest.sh
+
       # #4688: diff against the base branch AS IT IS NOW, not the frozen
       # `base.sha` snapshot. checkout leaves refs/remotes/origin/<base> at
       # whatever it fetched; re-fetching pins it to the live tip so the merge

--- a/scripts/check_changelog_attribution_selftest.sh
+++ b/scripts/check_changelog_attribution_selftest.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+#
+# check_changelog_attribution_selftest.sh — crate-attribution regressions for
+# scripts/check_changelog_fragment.sh (issue #4576).
+#
+# Why: the gate selected source paths with the bash `case` glob
+#   `crates/*/src/*`, whose `*` spans `/`, then extracted the crate with
+#   `sed -E 's#^crates/([^/]+)/src/.*#\1#'`, which spans exactly ONE directory
+#   level. A nested crate source path — `crates/trusty-audit/ui/src-tauri/src/`
+#   is the live instance, `crates/trusty-agents/ui/src/` the original one — was
+#   therefore selected and then discarded by the `[[ "$crate" == */* ]]` guard
+#   that followed. Nothing was raised: the path never entered the changed set,
+#   the gate concluded "no crate source changed" and reported SUCCESS. PR #5796
+#   added a whole nested source tree and the gate said exactly that while
+#   passing. That is the #5620 shape — a green that means "examined nothing" is
+#   indistinguishable from one that means "checked and clean".
+#
+#   The attribution had no test, so nothing stopped the drop from being
+#   reintroduced by the next edit. This is that test.
+#
+# What: builds a throwaway git repo carrying every path shape the gate has to
+#   classify, runs the gate over one branch per shape, and asserts the verdict.
+#
+#   Cases:
+#     nested-tauri-src-fails      crates/demo/ui/src-tauri/src/** changed with
+#                                 no fragment FAILS naming crate `demo`. This is
+#                                 the case that reports SUCCESS against the
+#                                 pre-#4576 script.
+#     nested-ui-src-fails         crates/demo/ui/src/** (Svelte/TS) likewise —
+#                                 the shape #4576 was originally filed for.
+#     nested-source-recorded      the same nested change WITH a valid fragment
+#                                 in the shipping crate's changelog.d/ passes.
+#                                 Attribution rolls the nested member up to
+#                                 crates/demo/, the only directory that owns a
+#                                 changelog.d/ the assembler can read.
+#     depth-1-src-unchanged       the ordinary crates/demo/src/** case still
+#                                 fails without a fragment. The fix must not
+#                                 weaken the gate it is widening.
+#     unattributed-source-fails   a source-shaped path under crates/ with no
+#                                 Cargo.toml in any ancestor at either rev FAILS
+#                                 naming UNATTRIBUTED SOURCE. Pre-fix it was
+#                                 dropped and the gate printed OK.
+#     non-source-shapes-exempt    build.rs, tests/, benches/, testdata/, a
+#                                 generated ui/dist bundle, Cargo.toml and a
+#                                 README all change at once and the gate still
+#                                 passes with no fragment. This is the SCOPE
+#                                 guard: the fix must not start demanding
+#                                 fragments for path classes that never needed
+#                                 one.
+#     dissolved-crate-exempt      deleting a crate outright stays exempt (#3732)
+#                                 and must NOT be reported as unattributable —
+#                                 its manifest is gone at HEAD, so attribution
+#                                 falls back to the merge base to find it.
+#
+# Usage:
+#   bash scripts/check_changelog_attribution_selftest.sh
+#   bash scripts/check_changelog_attribution_selftest.sh --gate /path/to/gate.sh
+#
+#   `--gate` runs the cases against an ALTERNATE copy of the gate. Pointing it
+#   at the pre-#4576 script is how the mutation is demonstrated: that run must
+#   FAIL here, proving these cases are not merely passing by construction.
+#
+# Exit: 0 when every case holds; 1 (naming the case) when one does not.
+#
+# Test: this IS the test. It is wired into .github/workflows/changelog-fragment.yml
+#   ahead of the real gate run.
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
+#   only. Same constraints as the script under test.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+GATE_SOURCE="$SCRIPT_DIR/check_changelog_fragment.sh"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --gate)
+      [[ $# -lt 2 ]] && {
+        echo "ERROR: --gate needs a path" >&2
+        exit 2
+      }
+      GATE_SOURCE="$2"
+      shift 2
+      ;;
+    *)
+      echo "ERROR: unknown argument '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -f "$GATE_SOURCE" ]] || {
+  echo "ERROR: no gate script at '$GATE_SOURCE'" >&2
+  exit 2
+}
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/changelog-attribution-selftest.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+REPO="$TMP_ROOT/repo"
+GATE="scripts/check_changelog_fragment.sh"
+fail=0
+
+g() { git -C "$REPO" "$@"; }
+
+# ---------------------------------------------------------------------------
+# Fixture. One shipping crate (`demo`) with:
+#   - ordinary depth-1 source            crates/demo/src/lib.rs
+#   - a NESTED workspace member          crates/demo/ui/src-tauri/{Cargo.toml,src/main.rs}
+#   - nested non-Rust UI source          crates/demo/ui/src/App.svelte
+#   - every non-source shape the gate must keep ignoring
+# plus a second crate (`doomed`) that a later case dissolves.
+# ---------------------------------------------------------------------------
+mkdir -p "$REPO/scripts"
+cp "$GATE_SOURCE" "$REPO/scripts/check_changelog_fragment.sh"
+cp "$SCRIPT_DIR/assemble-changelog.sh" "$REPO/scripts/"
+
+new_crate() {
+  local name="$1" dir="$REPO/crates/$1"
+  mkdir -p "$dir/src" "$dir/changelog.d"
+  printf 'pub fn v() -> u32 { 1 }\n' >"$dir/src/lib.rs"
+  printf '[package]\nname = "%s"\nversion = "0.1.0"\n' "$name" >"$dir/Cargo.toml"
+  printf '# Changelog\n\n---\n' >"$dir/CHANGELOG.md"
+  printf 'Placeholder keeping changelog.d/ tracked between releases.\n' \
+    >"$dir/changelog.d/README.md"
+}
+
+fragment() {
+  # crate, filename, category
+  printf '%s\n\n- a user-visible change in %s\n' "$3" "$1" \
+    >"$REPO/crates/$1/changelog.d/$2"
+}
+
+g init -q -b main
+g config user.email selftest@example.invalid
+g config user.name "changelog attribution self-test"
+
+new_crate demo
+new_crate doomed
+
+# The nested workspace member, modelled on crates/trusty-audit/ui/src-tauri:
+# its own Cargo.toml, its own src/, and NO changelog.d/ of its own.
+mkdir -p "$REPO/crates/demo/ui/src-tauri/src" "$REPO/crates/demo/ui/src/lib"
+printf '[package]\nname = "demo-ui"\nversion = "0.1.0"\n' \
+  >"$REPO/crates/demo/ui/src-tauri/Cargo.toml"
+printf 'fn main() {}\n' >"$REPO/crates/demo/ui/src-tauri/src/main.rs"
+printf 'fn build() {}\n' >"$REPO/crates/demo/ui/src-tauri/build.rs"
+printf '<script lang="ts">let n = 1;</script>\n' \
+  >"$REPO/crates/demo/ui/src/App.svelte"
+
+# Non-source shapes that have never required a fragment.
+mkdir -p "$REPO/crates/demo/tests" "$REPO/crates/demo/benches" \
+  "$REPO/crates/demo/src/testdata" "$REPO/crates/demo/ui/dist/assets" "$REPO/docs"
+printf 'fn main() {}\n' >"$REPO/crates/demo/build.rs"
+printf '#[test]\nfn t() {}\n' >"$REPO/crates/demo/tests/it.rs"
+printf 'fn bench() {}\n' >"$REPO/crates/demo/benches/b.rs"
+printf 'golden\n' >"$REPO/crates/demo/src/testdata/golden.txt"
+printf 'console.log(1)\n' >"$REPO/crates/demo/ui/dist/assets/index-aaaa.js"
+printf '# Docs\n' >"$REPO/docs/notes.md"
+
+g add -A
+g commit -qm "M0: demo (with a nested member) and doomed"
+BASE="$(g rev-parse HEAD)"
+
+# ---------------------------------------------------------------------------
+# assert_case: name, expected exit status, ERE the output must match, ERE the
+# output must NOT match ("" to skip either match).
+# ---------------------------------------------------------------------------
+assert_case() {
+  local name="$1" want_rc="$2" want_re="$3" deny_re="$4" out rc=0
+  # Capture, then match. NOT `... | grep -q`: under `set -o pipefail` the gate's
+  # own (expected) non-zero exit becomes the pipeline's status even when grep
+  # matched, so every rejection assertion would read as a miss.
+  out="$(cd "$REPO" && CHANGELOG_GATE_BASE=main bash "$GATE" 2>&1)" || rc=$?
+  if [ "$rc" -ne "$want_rc" ]; then
+    echo "FAIL: $name -> exit $rc (expected $want_rc)" >&2
+    printf '%s\n' "$out" | sed 's/^/       /' >&2
+    fail=1
+    return
+  fi
+  if [ -n "$want_re" ] && ! grep -qE "$want_re" <<<"$out"; then
+    echo "FAIL: $name -> exit $rc as expected, but output does not match /$want_re/" >&2
+    printf '%s\n' "$out" | sed 's/^/       /' >&2
+    fail=1
+    return
+  fi
+  if [ -n "$deny_re" ] && grep -qE "$deny_re" <<<"$out"; then
+    echo "FAIL: $name -> exit $rc as expected, but output MATCHES forbidden /$deny_re/" >&2
+    printf '%s\n' "$out" | sed 's/^/       /' >&2
+    fail=1
+    return
+  fi
+  echo "PASS: $name -> exit $rc${want_re:+, matched /$want_re/}"
+}
+
+# start_case: a fresh branch off the fixture base, so each case is independent.
+start_case() { g checkout -q -B "$1" "$BASE"; }
+
+# ---------------------------------------------------------------------------
+# 1. THE #4576 DEFECT — the live instance. Only the nested member's Rust source
+#    changes. Pre-fix the path is selected, then dropped, and the gate prints
+#    "no crate source changed (docs-only / CI-only / test-only) — OK."
+# ---------------------------------------------------------------------------
+start_case nested-tauri
+printf 'fn main() { println!("changed"); }\n' \
+  >"$REPO/crates/demo/ui/src-tauri/src/main.rs"
+g add -A
+g commit -qm "change nested src-tauri source, no fragment"
+assert_case nested-tauri-src-fails 1 \
+  'FAIL demo: crates/demo/src/\*\* changed with no changelog record' \
+  'no crate source changed'
+
+# ---------------------------------------------------------------------------
+# 2. THE #4576 DEFECT — the original instance. Nested Svelte/TS UI source, which
+#    ships to users exactly as the Rust does.
+# ---------------------------------------------------------------------------
+start_case nested-ui
+printf '<script lang="ts">let n = 2;</script>\n' \
+  >"$REPO/crates/demo/ui/src/App.svelte"
+g add -A
+g commit -qm "change nested ui source, no fragment"
+assert_case nested-ui-src-fails 1 \
+  'FAIL demo: crates/demo/src/\*\* changed with no changelog record' \
+  'no crate source changed'
+
+# ---------------------------------------------------------------------------
+# 3. THE FIX IS SATISFIABLE. The nested member owns no changelog.d/, so the
+#    fragment belongs to the crate that SHIPS it — which is where attribution
+#    rolls the path up to, and what `assemble-changelog.sh <crate-dir>` accepts.
+# ---------------------------------------------------------------------------
+start_case nested-recorded
+printf 'fn main() { println!("changed"); }\n' \
+  >"$REPO/crates/demo/ui/src-tauri/src/main.rs"
+printf '<script lang="ts">let n = 3;</script>\n' \
+  >"$REPO/crates/demo/ui/src/App.svelte"
+fragment demo 4576-nested-change.md Fixed
+g add -A
+g commit -qm "change nested source and record it"
+assert_case nested-source-recorded 0 \
+  'OK   demo: changelog.d fragment present and valid' \
+  'FAIL'
+
+# ---------------------------------------------------------------------------
+# 4. STILL A GATE. The ordinary depth-1 path the gate always handled.
+# ---------------------------------------------------------------------------
+start_case depth-1
+printf 'pub fn v() -> u32 { 2 }\n' >"$REPO/crates/demo/src/lib.rs"
+g add -A
+g commit -qm "change depth-1 source, no fragment"
+assert_case depth-1-src-unchanged 1 \
+  'FAIL demo: crates/demo/src/\*\* changed with no changelog record' \
+  ''
+
+# ---------------------------------------------------------------------------
+# 5. FAIL CLOSED. A source-shaped path under crates/ that belongs to no crate at
+#    HEAD or at the merge base must be REPORTED. Pre-fix it was dropped in
+#    silence and the gate printed OK — the fail-open this issue is about.
+# ---------------------------------------------------------------------------
+start_case orphan
+mkdir -p "$REPO/crates/orphan/ui/src"
+printf 'export const x = 1;\n' >"$REPO/crates/orphan/ui/src/x.ts"
+g add -A
+g commit -qm "add source under crates/ with no Cargo.toml anywhere"
+assert_case unattributed-source-fails 1 \
+  'UNATTRIBUTED SOURCE' \
+  'no crate source changed'
+
+# ---------------------------------------------------------------------------
+# 6. SCOPE GUARD. Every path class that has never required a fragment changes at
+#    once. If the attribution fix widened what counts as crate source, this goes
+#    red — which is the point of asserting it.
+# ---------------------------------------------------------------------------
+start_case non-source
+printf 'fn main() { /* changed */ }\n' >"$REPO/crates/demo/build.rs"
+printf 'fn build() { /* changed */ }\n' >"$REPO/crates/demo/ui/src-tauri/build.rs"
+printf '#[test]\nfn t() { assert!(true); }\n' >"$REPO/crates/demo/tests/it.rs"
+printf 'fn bench() { /* changed */ }\n' >"$REPO/crates/demo/benches/b.rs"
+printf 'golden v2\n' >"$REPO/crates/demo/src/testdata/golden.txt"
+printf 'console.log(2)\n' >"$REPO/crates/demo/ui/dist/assets/index-aaaa.js"
+printf '[package]\nname = "demo"\nversion = "0.1.1"\n' >"$REPO/crates/demo/Cargo.toml"
+printf '# Docs\n\nchanged\n' >"$REPO/docs/notes.md"
+g add -A
+g commit -qm "change every non-source shape, no fragment"
+assert_case non-source-shapes-exempt 0 \
+  'no crate source changed \(docs-only / CI-only / test-only\) — OK' \
+  'FAIL'
+
+# ---------------------------------------------------------------------------
+# 7. #3732 EXEMPTION INTACT. Dissolving a crate deletes every source file under
+#    it AND its Cargo.toml, so attribution finds no manifest at HEAD. It must
+#    fall back to the merge base and grant the exemption, not report the crate
+#    as unattributable.
+# ---------------------------------------------------------------------------
+start_case dissolve
+g rm -rq crates/doomed
+g commit -qm "dissolve the doomed crate"
+assert_case dissolved-crate-exempt 0 \
+  'no crate source changed \(docs-only / CI-only / test-only\) — OK' \
+  'UNATTRIBUTED SOURCE|FAIL'
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "check_changelog_attribution_selftest: FAILED — the gate mis-attributes" >&2
+  echo "  crate source paths (issue #4576). Gate under test: ${GATE_SOURCE}" >&2
+  exit 1
+fi
+echo "check_changelog_attribution_selftest: all crate-attribution cases passed."

--- a/scripts/check_changelog_fragment.sh
+++ b/scripts/check_changelog_fragment.sh
@@ -12,8 +12,13 @@
 #   fragment is a NEW file, and its presence or absence is unambiguous.
 #
 # What: diffs the working branch against a base ref and, for every crate whose
-#   `crates/<crate>/src/**` changed, requires evidence that the change was
-#   recorded. Accepted evidence, per crate:
+#   source changed, requires evidence that the change was recorded. A path is
+#   crate source when it lies under `crates/` and carries a `/src/` directory
+#   segment — the selector is unchanged since #4476; what changed in #4576 is
+#   only that a NESTED one (`crates/trusty-audit/ui/src-tauri/src/main.rs`,
+#   `crates/trusty-agents/ui/src/App.svelte`) is now attributed to the crate that
+#   ships it instead of being silently dropped. See ATTRIBUTION BY STRUCTURE.
+#   Accepted evidence, per crate:
 #     1. an ADDED-or-MODIFIED `crates/<crate>/changelog.d/<name>.md` fragment
 #        that the release assembler ACCEPTS                        (the rule)
 #     2. a `crates/<crate>/CHANGELOG.md` edit that adds a bullet   (TRANSITIONAL)
@@ -49,9 +54,17 @@
 #   maintain and no cleanup PR to remember. It also requires the diff to add a
 #   real bullet line, so a whitespace-only CHANGELOG.md touch is not evidence.
 #
+# ATTRIBUTION BY STRUCTURE (#4576). The crate that owns a changed path is found
+#   by walking UP to the nearest ancestor directory holding a Cargo.toml, then
+#   rolling that owner up to the `crates/<crate>/` directory that owns
+#   changelog.d/. No path depth is hardcoded, so a crate nested three levels
+#   deep needs no second fix. A path this gate SELECTS as source but cannot
+#   attribute is a hard failure naming the path (UNATTRIBUTED SOURCE), never a
+#   silent drop — see the fail-open it replaces in `resolve_source_crate`.
+#
 # Exemptions (a crate is NOT required to have evidence when):
-#   - no `crates/<crate>/src/**` path changed at all — this is what makes
-#     docs-only and CI-only PRs pass, per the documented rule;
+#   - no crate source path changed at all — this is what makes docs-only and
+#     CI-only PRs pass, per the documented rule;
 #   - the only changed paths under that crate's src/** are test files, using
 #     check_line_cap.sh's own classification (basename `tests.rs`, or ending
 #     `_test.rs`/`_tests.rs`, or a `/tests/` or `/benches/` path segment). A
@@ -123,9 +136,12 @@
 #   synthetic repo — a branch touching crate A only, with crate B's src/**
 #   changed and B's fragments consumed by a release on main since the fork
 #   point — and asserts the stale base is refused, the live branch base passes
-#   naming only A, and a genuinely missing fragment still fails. Fragment
-#   validation is covered by scripts/assemble_changelog_selftest.sh and the
-#   scan floor by scripts/check_scan_floor_selftest.sh.
+#   naming only A, and a genuinely missing fragment still fails.
+#   scripts/check_changelog_attribution_selftest.sh replays the #4576 shape:
+#   a nested crate source path must be attributed, not dropped, and an
+#   unattributable one must fail the gate. Fragment validation is covered by
+#   scripts/assemble_changelog_selftest.sh and the scan floor by
+#   scripts/check_scan_floor_selftest.sh.
 #
 # Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
 #   only — `git`, `grep`, `sed`, `sort`.
@@ -147,7 +163,8 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     -h | --help)
-      sed -n '2,80p' "$0" >&2
+      # Through the exemption list — keep this range in step with the header.
+      sed -n '2,92p' "$0" >&2
       exit 0
       ;;
     *)
@@ -286,6 +303,75 @@ is_test_path() {
   return 1
 }
 
+# #4576: attribute a source path to its crate by STRUCTURE, not by path depth.
+#
+# Why: the source arm used to extract the crate with
+# `sed -E 's#^crates/([^/]+)/src/.*#\1#'`, which spans exactly one directory
+# level. The `case` glob that selects the path does NOT — bash `case` lets `*`
+# span `/` — so every NESTED crate source path was selected and then silently
+# discarded by the `[[ "$crate" == */* ]] && continue` guard that followed. It
+# raised nothing: the gate concluded "no crate source changed" and reported
+# success. PR #5796 added crates/trusty-audit/ui/src-tauri/src/** and the gate
+# said exactly that while passing. A green meaning "examined nothing" is
+# indistinguishable from one meaning "checked and clean" — the #5620 shape.
+# Widening the sed by one more hardcoded level would only move the wrong depth.
+#
+# What: `nearest_manifest_dir` walks UP from a path's directory to the nearest
+# ancestor holding a Cargo.toml at <rev>, bounded to directories under crates/.
+# `resolve_source_crate` then rolls that owner up to the top-level `crates/<name>`
+# directory, which is the unit changelog.d/ and `assemble-changelog.sh <crate-dir>`
+# are keyed to — a nested member such as crates/trusty-audit/ui/src-tauri owns no
+# changelog.d/ of its own, so its changes are recorded by the crate that ships it.
+# HEAD is tried first, then the merge base, so a path whose crate this PR DELETED
+# still attributes and reaches the #3732 dissolution exemption below.
+#
+# Neither uses command substitution: `path_exists_at_rev` hard-exits the gate on
+# a genuine git failure, and a `$(...)` would trap that exit in a subshell and
+# hand back a garbage crate name — reintroducing a fail-open inside the fix for
+# one.
+#
+# Test: scripts/check_changelog_attribution_selftest.sh.
+OWNER_DIR=""
+nearest_manifest_dir() {
+  local rev="$1" dir="$2"
+  OWNER_DIR=""
+  while [[ "$dir" == crates/?* ]]; do
+    if path_exists_at_rev "$rev" "${dir}/Cargo.toml"; then
+      OWNER_DIR="$dir"
+      return 0
+    fi
+    dir="${dir%/*}"
+  done
+  return 1
+}
+
+# `git diff --name-only` emits sorted paths, so files in one directory arrive
+# adjacent; caching the last directory's answer collapses the repeated walk on a
+# large diff without a bash-3.2-hostile associative array.
+ATTRIB_DIR=""
+ATTRIB_CRATE=""
+
+# Sets SOURCE_CRATE to the owning top-level crate name; returns 1 when the path
+# is under crates/ and looks like source but belongs to no crate at either rev.
+SOURCE_CRATE=""
+resolve_source_crate() {
+  local path="$1" dir
+  dir="${path%/*}"
+  if [[ "$dir" == "$ATTRIB_DIR" ]]; then
+    SOURCE_CRATE="$ATTRIB_CRATE"
+    [[ -n "$SOURCE_CRATE" ]]
+    return
+  fi
+  SOURCE_CRATE=""
+  if nearest_manifest_dir HEAD "$dir" || nearest_manifest_dir "$MERGE_BASE" "$dir"; then
+    SOURCE_CRATE="${OWNER_DIR#crates/}"
+    SOURCE_CRATE="${SOURCE_CRATE%%/*}"
+  fi
+  ATTRIB_DIR="$dir"
+  ATTRIB_CRATE="$SOURCE_CRATE"
+  [[ -n "$SOURCE_CRATE" ]]
+}
+
 # Why: `case` globs let `*` span `/`, so the pattern `crates/*/changelog.d/*.md`
 # also matches `crates/a/b/changelog.d/x.md` and a naive sed extraction then
 # emits a whole path where a crate name belongs. Extract first, then verify the
@@ -306,24 +392,67 @@ needs=""
 has_fragment=""
 # Crates with transitional CHANGELOG.md evidence.
 has_changelog=""
+# #4576: source paths this gate could not attribute to any crate. An
+# unattributable path is a gap in the gate's own knowledge, never an exemption.
+unattributed=""
+# Source paths actually attributed, reported so a future silent drop is visible
+# in the log the way the scan floor's path count already is (#4618).
+attributed_count=0
+# "<crate>\t<path>" for paths attributed from OUTSIDE crates/<crate>/src/. The
+# failure line names `crates/<crate>/src/**`, which is where a reader would look
+# and not find a nested change; one sample path saves that trip.
+nested_samples=""
 
 # Source changes come from the deletion-inclusive view.
 while IFS= read -r path; do
   [[ -z "$path" ]] && continue
   case "$path" in
     crates/*/src/*)
-      crate="$(printf '%s' "$path" | sed -E 's#^crates/([^/]+)/src/.*#\1#')"
-      [[ "$crate" == */* ]] && continue
       is_test_path "$path" && continue
+      # #4576: attribute by structure. A path this arm SELECTED but cannot
+      # attribute is reported, never dropped — the silent drop is what made the
+      # gate report success over a whole nested source tree.
+      if ! resolve_source_crate "$path"; then
+        unattributed="${unattributed}${path}"$'\n'
+        continue
+      fi
+      crate="$SOURCE_CRATE"
+      attributed_count=$((attributed_count + 1))
+      case "$path" in
+        "crates/${crate}/src/"*) ;;
+        *) nested_samples="${nested_samples}${crate}"$'\t'"${path}"$'\n' ;;
+      esac
       # The crate was dissolved by this PR — there is no changelog.d/ left to
       # put a fragment in, and the assembler cannot run for it. See the
       # "crate no longer EXISTS at HEAD" exemption above. A git FAILURE here is
       # not the exemption; path_exists_at_rev hard-fails on one (#4618).
-      path_exists_at_rev HEAD "crates/${crate}/Cargo.toml" || continue
-      needs="${needs}${crate}"$'\n'
+      if path_exists_at_rev HEAD "crates/${crate}/Cargo.toml"; then
+        needs="${needs}${crate}"$'\n'
+      elif ! path_exists_at_rev "$MERGE_BASE" "crates/${crate}/Cargo.toml"; then
+        # #4576: not a dissolution — the top-level crate directory holds no
+        # manifest at EITHER rev, so there is no changelog.d/ this path could
+        # ever be recorded in and nothing said so. Report it.
+        unattributed="${unattributed}${path}"$'\n'
+      fi
       ;;
   esac
 done <<<"$CHANGED"
+
+# #4576: fail CLOSED. Pre-fix these paths vanished from the changed set with no
+# message, so the gate printed "no crate source changed … — OK" over them.
+if [[ -n "$unattributed" ]]; then
+  echo "FAIL: UNATTRIBUTED SOURCE — path(s) under crates/ that look like crate" >&2
+  echo "      source belong to no crate this gate can name, at HEAD or at the" >&2
+  echo "      merge base ${MERGE_BASE:0:10}:" >&2
+  printf '%s' "$unattributed" | grep -v '^$' | sed 's/^/         /' >&2
+  echo "      Attribution walks up from each path to the nearest ancestor" >&2
+  echo "      directory holding a Cargo.toml, then to the crates/<crate>/ that" >&2
+  echo "      owns changelog.d/. None was found, so the gate cannot say which" >&2
+  echo "      crate must record the change — and will not call that an" >&2
+  echo "      exemption. Add the crate's Cargo.toml, or move the file out of" >&2
+  echo "      crates/ if it is not crate source (issue #4576)." >&2
+  exit 1
+fi
 
 # Evidence comes from the view that excludes deletions.
 while IFS= read -r path; do
@@ -353,7 +482,7 @@ done <<<"$PRESENT"
 needs="$(printf '%s' "$needs" | grep -v '^$' | LC_ALL=C sort -u || true)"
 
 if [[ -z "$needs" ]]; then
-  echo "changelog-fragment gate: scanned ${CHANGED_COUNT} changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK."
+  echo "changelog-fragment gate: scanned ${CHANGED_COUNT} changed path(s); attributed ${attributed_count} crate-source path(s); no crate source changed (docs-only / CI-only / test-only) — OK."
   exit 0
 fi
 
@@ -375,6 +504,12 @@ while IFS= read -r crate; do
     echo "OK   ${crate}: CHANGELOG.md entry (TRANSITIONAL — branch predates #4476)"
   else
     echo "FAIL ${crate}: crates/${crate}/src/** changed with no changelog record" >&2
+    # #4576: name a nested path when that is what changed, so the reader is not
+    # sent to crates/<crate>/src/ to find nothing there.
+    sample="$(printf '%s' "$nested_samples" | grep -m1 "^${crate}	" || true)"
+    if [[ -n "$sample" ]]; then
+      echo "       nested source, e.g. ${sample#*	}" >&2
+    fi
     fail=1
   fi
 done <<<"$needs"
@@ -408,4 +543,4 @@ EOF
 fi
 
 crate_count="$(printf '%s\n' "$needs" | grep -c '[^[:space:]]' || true)"
-echo "changelog-fragment gate: scanned ${CHANGED_COUNT} changed path(s); all ${crate_count} crate(s) with source changes are recorded."
+echo "changelog-fragment gate: scanned ${CHANGED_COUNT} changed path(s); attributed ${attributed_count} crate-source path(s); all ${crate_count} crate(s) with source changes are recorded."


### PR DESCRIPTION
Closes #4576.

The defect: the gate mapped a changed path to its crate with `sed -E 's#^crates/([^/]+)/src/.*#\1#'`, matching exactly one directory level. A nested path was selected as crate source, then silently dropped — and the gate reported PASS having examined nothing. Same class as #5620.

The fix: attribution now walks up to the nearest ancestor `Cargo.toml`, bounded to `crates/`, then rolls up to the top-level crate that owns the `changelog.d/` directory. A selected path that cannot be attributed at either rev now fails the gate with `FAIL: UNATTRIBUTED SOURCE` naming each path.

**Proof it was live**, replayed from #5796's squash-merge against its parent: pre-fix `scanned 27 changed path(s); no crate source changed — OK` exit 0; post-fix `attributed 7 crate-source path(s); all 1 crate(s) with source changes are recorded` exit 0. Both green, for opposite reasons.

**No-change control** on #5809's 117-path set: both gates named the same 12 crates and produced byte-identical output.

**What now requires a fragment and did not before:**

| Path shape | Count | Before | After |
|---|---|---|---|
| `crates/<name>/src/**` | 4103 | fragment required | unchanged |
| `crates/<name>/ui/src/**` | 264 | silently dropped | fragment required |
| `crates/<name>/ui/src-tauri/src/**` | 7 | silently dropped | fragment required |
| `crates/trusty-agents/.trusty-agents/skills/cto-db/python/src/**` | 4 | silently dropped | fragment required |

Practical effect: a UI-only PR now owes a changelog fragment. `build.rs`, `tests/`, `benches/`, `testdata/`, and generated `ui/dist` bundles are unchanged and still exempt.

New self-test `scripts/check_changelog_attribution_selftest.sh`, wired into `.github/workflows/changelog-fragment.yml` ahead of the real gate. It takes `--gate <path>` so the pre-fix failure stays reproducible. Seven cases; five fail against the pre-fix gate.

A fail-open inside the fix itself was avoided deliberately: `path_exists_at_rev` hard-exits on a git failure, and wrapping it in `$(...)` would trap that exit in a subshell and hand back a garbage crate name. The scan-floor self-test confirms the exit still propagates.

Test ladder rung 1 — scripts and CI only, no Rust source touched. Gates run: `check_changelog_fragment.sh`, `check_line_cap.sh`, `check_sld.sh`, `check_test_pointers.sh`, `check_scan_floor_selftest.sh`, `check_changelog_base_selftest.sh`, `assemble_changelog_selftest.sh` — all exit 0. No shellcheck or actionlint gate exists in this repo, so neither ran.

Runtime on the 117-path set: 1m9.6s before, 1m8.9s after.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
