### PR TITLE
fix(ci): decide the local-main fetch on its condition instead of swallowing every failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,9 +547,12 @@ jobs:
       # local branch list includes "main". GitHub Actions PR checkouts only create
       # a local branch for the PR head; "main" is only a remote ref unless we
       # explicitly create a local tracking branch for it.
+      # #5693: `git fetch origin main:main || true` gave a GitHub 500 and the
+      # expected push-to-main refusal the same exit 128, so a real failure ran on
+      # with no local `main` and surfaced as an unrelated trusty-agents test.
       - name: Create local main branch for git tests
         if: needs.changes.outputs.docs_only != 'true'
-        run: git fetch origin main:main || true
+        run: bash scripts/ci-create-local-main.sh
 
       - name: Install stable toolchain
         if: needs.changes.outputs.docs_only != 'true'

--- a/.github/workflows/pre-publish.yml
+++ b/.github/workflows/pre-publish.yml
@@ -445,8 +445,9 @@ jobs:
       - name: Free disk space
         run: bash scripts/ci-free-disk-space.sh
 
+      # #5693: same swallowed-failure defect as ci.yml's copy of this step.
       - name: Create local main branch for git tests
-        run: git fetch origin main:main || true
+        run: bash scripts/ci-create-local-main.sh
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/scripts/ci-create-local-main.sh
+++ b/scripts/ci-create-local-main.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# ci-create-local-main.sh — create the local `main` branch the trusty-agents git
+# tests need, and let a real failure to create it fail the step (#5693).
+#
+# Why: `git fetch origin main:main || true` ran in ci.yml and pre-publish.yml.
+#   On 2026-08-14 GitHub returned a 500 on that fetch. `|| true` swallowed it,
+#   the step reported success with no local `main`, and eleven minutes later
+#   `trusty-agents git::branch::tests::list_branches_includes_current` failed on
+#   `assertion failed: !branches.is_empty()` — one failure out of 6223, in a
+#   crate the PR did not touch (PR #5692, run 31782111082).
+#
+#   The `|| true` was not gratuitous, and removing it alone would turn every
+#   push-to-main run red. On a `push: main` run actions/checkout checks out
+#   `main` as a local branch, and git then refuses the fetch with
+#   `fatal: refusing to fetch into branch 'refs/heads/main' checked out at …`
+#   and exit 128 — the same exit code and the same `fatal:` prefix an
+#   unreachable remote produces (measured on git 2.50.1). Exit status cannot
+#   separate the expected refusal from a real failure, so this script decides on
+#   the CONDITION instead of on the status.
+#
+# What: three steps.
+#     1. `main` is already the checked-out branch -> skip the fetch. That is the
+#        one case git legitimately refuses, and the branch the tests want
+#        already exists.
+#     2. Otherwise fetch, retrying a failure ATTEMPTS times with linear backoff
+#        so a transient 5xx costs seconds instead of a ~10-minute job. A fetch
+#        still failing after that fails the step.
+#     3. Either way, assert the postcondition the step exists for: a local
+#        `refs/heads/main` resolves afterwards.
+#
+# Test: no automated coverage. Step 1 runs on every `push: main` leg of ci.yml,
+#   step 2 on every `workflow_dispatch` leg and on every pre-publish run.
+set -euo pipefail
+
+ATTEMPTS=3
+
+if [ "$(git symbolic-ref --quiet --short HEAD || true)" = "main" ]; then
+  echo "HEAD is already the local 'main' branch; git would refuse the fetch and nothing needs creating."
+else
+  attempt=1
+  until git fetch origin main:main; do
+    if [ "${attempt}" -ge "${ATTEMPTS}" ]; then
+      echo "::error::git fetch origin main:main failed ${ATTEMPTS} times — see #5693, this used to be swallowed by '|| true'."
+      exit 1
+    fi
+    echo "fetch attempt ${attempt}/${ATTEMPTS} failed; retrying in $((attempt * 5))s"
+    sleep "$((attempt * 5))"
+    attempt=$((attempt + 1))
+  done
+fi
+
+if ! git show-ref --verify --quiet refs/heads/main; then
+  echo "::error::no local 'main' branch after this step — the trusty-agents git tests would fail misleadingly in an unrelated crate. See #5693."
+  exit 1
+fi
+
+echo "local 'main' branch present at $(git rev-parse --short main)."


### PR DESCRIPTION
Closes #5693.

The defect: `git fetch origin main:main || true` at `ci.yml:552` made a network failure, an auth failure, and an expected refusal indistinguishable. A step depending on `main` being fetched then ran against an absent ref.

**What the guard was actually covering, because this is the part that makes the fix non-obvious:** the `test-shard` job runs on `push: main`, where `actions/checkout` leaves `main` as the checked-out branch and git refuses to fetch into it. That is not an edge case — it is every push to main. Removing the `|| true` alone would have turned CI red on every merge.

Exit status cannot separate the two. Both are exit 128 with a `fatal:` prefix — the refusal (`refusing to fetch into branch 'refs/heads/main' checked out at …`) and an unreachable remote (`Could not read from remote repository`). Measured on git 2.50.1.

The fix: new `scripts/ci-create-local-main.sh` decides on the condition — skip the fetch when `main` is already checked out, otherwise fetch unguarded with 3 attempts and linear backoff, then assert `refs/heads/main` resolves. Both workflows call it, replacing two byte-identical copies.

The retry exists because the reported incident was a transient 500; failing a ten-minute job on a blip is the worse trade. A persistent failure still fails, with a `::error::` annotation.

Four local cases verified, raw exit codes: detached HEAD creates the branch (0); `main` checked out skips and succeeds (0); genuine failure retries 3× then fails (1); transient failure recovering on attempt 2 succeeds (0).

**What is only verifiable on a real CI run**, stated plainly rather than claimed: that `actions/checkout@v5` on `push: main` produces a symbolic rather than detached HEAD; the runner's git version behaviour (2.50.1 measured locally, GitHub ships older); `::error::` rendering; and that a GitHub 5xx surfaces as a nonzero fetch exit at all — the issue's logs say it did, the reproduction used an unreachable remote.

A second instance of the identical defect was fixed in the same PR: `pre-publish.yml:449` was byte-identical including the step name. That job checks out by resolved SHA so HEAD is always detached there, meaning the guard was covering nothing and the fix makes a real failure fail.

Other `|| true` uses in the workflows were reviewed and deliberately left alone as a different class — `grep -oP … || true` absorbing grep's no-match exit inside `set -euo pipefail` with an immediate empty-result check, and `du`/`cat`/`kill`/`find`/`ldd`/`strip` diagnostics.

Test ladder rung 1 — CI and scripts only, no Rust touched. `check_changelog_fragment.sh`, `check_line_cap.sh`, `check_sld.sh` all exit 0; `bash -n` clean; both workflows parse as YAML. No actionlint or shellcheck gate exists in this repo, so neither ran.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
