### PR TITLE
fix(ci): run the SemVer gate's self-tests when the gate machinery itself changed

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -172,6 +172,31 @@ jobs:
             echo "No crate declares a new version in this diff."
           fi
 
+      # #5501: the SECOND trigger, and the self-tests below run on either one.
+      # `have_work` is computed only from detect-version-bumps.sh, so a PR that
+      # repairs this gate and bumps nothing took the no-op path and the
+      # self-tests stood down on exactly the PR that changed the thing they
+      # test. Observed on PR #5496 (see #5500): it fixed this workflow, `Public
+      # API / SemVer` passed in ~15s through the no-op path, and its regression
+      # proof was local only.
+      #
+      # The `else` arm is the tag push and the manual dispatch, neither of which
+      # has a diff to classify. `have_work` is true by construction there, so
+      # this output changes nothing — it says true rather than false because a
+      # classifier that could not look must never be the reason a self-test is
+      # skipped.
+      - name: Classify SemVer gate machinery from the diff
+        id: machinery
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SEMVER_GATE_BASE="origin/${BASE_REF}" \
+              bash scripts/detect-semver-gate-inputs.sh > /dev/null
+          else
+            echo "semver_gate_inputs_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # STABLE, DELIBERATELY NOT THE MSRV 1.94 THIS REPO PINS (#5289).
       # cargo-semver-checks builds rustdoc in a scratch project that ignores this
       # workspace's Cargo.lock, so the graph it resolves can demand a higher
@@ -186,8 +211,14 @@ jobs:
       # to pay on every PR, so they are gated on there being a release under
       # test. STEP-level, never job-level: a skipped JOB does not satisfy a
       # required context.
+      #
+      # #5501: this one step also runs on the machinery path, because both
+      # self-tests need a `cargo` on PATH — check_semver_selftest.sh's stub
+      # forwards `cargo metadata` to the real one, and the type differ resolves
+      # `--crate` the same way. It costs seconds; the three below stay on
+      # `have_work` alone, which is what keeps #5149's decision intact.
       - name: Install stable toolchain
-        if: steps.crate.outputs.have_work == 'true'
+        if: steps.crate.outputs.have_work == 'true' || steps.machinery.outputs.semver_gate_inputs_changed == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       # #5440: trusty-common's `keyring-store` feature pulls in libdbus-sys,
@@ -234,8 +265,12 @@ jobs:
 
       # Runs BEFORE the real gate, matching line-cap.yml's selftest-then-gate
       # ordering: a gate that cannot fail makes the real run's green meaningless.
+      #
+      # #5501: OR the machinery trigger — a gate-fix PR bumps no version, and
+      # gating this on the bump alone skipped the proof on every PR that changed
+      # the gate.
       - name: SemVer gate selftest (must refuse a blind run)
-        if: steps.crate.outputs.have_work == 'true'
+        if: steps.crate.outputs.have_work == 'true' || steps.machinery.outputs.semver_gate_inputs_changed == 'true'
         run: bash scripts/check_semver_selftest.sh
 
       # cargo-semver-checks 0.50.0 compares NO TYPES: substitute any type and
@@ -249,9 +284,9 @@ jobs:
       # Gated the same way as the selftest above, not because it is expensive —
       # it reads two committed rustdoc JSON documents and builds nothing — but
       # because its --crate cases need `cargo metadata`, and the toolchain step
-      # is itself gated on there being a release under test.
+      # is itself gated. #5501 widened both to the machinery trigger together.
       - name: Type-differ selftest (must catch what the lints miss)
-        if: steps.crate.outputs.have_work == 'true'
+        if: steps.crate.outputs.have_work == 'true' || steps.machinery.outputs.semver_gate_inputs_changed == 'true'
         run: bash scripts/check_semver_types_selftest.sh
 
       # The two nonzero statuses are annotated differently ON PURPOSE (#5289).

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -476,6 +476,43 @@ assert_eq "this classifier does not"                   "true" \
   "$(pointer_inputs_of '.test-pointer-allowlist.tsv')"
 
 # ---------------------------------------------------------------------------
+# detect-semver-gate-inputs.sh (#5501)
+#
+# The second trigger for the SemVer gate's self-tests. The first one —
+# detect-version-bumps.sh, whose "source changed, no version bump" case below
+# says "" — is the reason it exists: a gate-fix PR changes the gate and bumps
+# nothing, so keying the self-tests on the bump stood them down on exactly the
+# diff they were needed for.
+# ---------------------------------------------------------------------------
+gate_inputs_of() {
+  printf '%s' "$1" | bash scripts/detect-semver-gate-inputs.sh 2>/dev/null |
+    sed -n 's/^semver_gate_inputs_changed=//p'
+}
+
+echo
+echo "detect-semver-gate-inputs:"
+assert_eq "the workflow wiring"       "true"  "$(gate_inputs_of '.github/workflows/semver-checks.yml')"
+assert_eq "the gate itself"           "true"  "$(gate_inputs_of 'scripts/check_semver.sh')"
+assert_eq "the gate's self-test"      "true"  "$(gate_inputs_of 'scripts/check_semver_selftest.sh')"
+assert_eq "the type differ"           "true"  "$(gate_inputs_of 'scripts/check_semver_types.sh')"
+assert_eq "the type differ's tests"   "true"  "$(gate_inputs_of 'scripts/check_semver_types_selftest.sh')"
+assert_eq "the rustdoc walk it imports" "true" "$(gate_inputs_of 'scripts/lib/rustdoc_walk.py')"
+assert_eq "crate selection"           "true"  "$(gate_inputs_of 'scripts/detect-version-bumps.sh')"
+assert_eq "this classifier"           "true"  "$(gate_inputs_of 'scripts/detect-semver-gate-inputs.sh')"
+assert_eq "the crate exclusions"      "true"  "$(gate_inputs_of 'scripts/semver-checks-crate-exclusions.tsv')"
+assert_eq "the feature exclusions"    "true"  "$(gate_inputs_of 'scripts/semver-checks-feature-exclusions.tsv')"
+assert_eq "a replayed tool capture"   "true"  "$(gate_inputs_of 'scripts/test-data/semver-gate/clean.out')"
+assert_eq "a rustdoc JSON fixture"    "true"  "$(gate_inputs_of 'scripts/test-data/semver-types/baseline.json')"
+assert_eq "crate source"              "false" "$(gate_inputs_of 'crates/trusty-common/src/lib.rs')"
+assert_eq "a manifest"                "false" "$(gate_inputs_of 'crates/trusty-common/Cargo.toml')"
+assert_eq "documentation"             "false" "$(gate_inputs_of 'docs/reference/semver-gate.md')"
+assert_eq "an unrelated workflow"     "false" "$(gate_inputs_of '.github/workflows/ci.yml')"
+assert_eq "an unrelated gate script"  "false" "$(gate_inputs_of 'scripts/check_line_cap.sh')"
+assert_eq "mixed source + machinery"  "true"  "$(gate_inputs_of 'crates/trusty-common/src/lib.rs
+scripts/check_semver.sh')"
+assert_eq "empty diff (fail closed)"  "true"  "$(gate_inputs_of '')"
+
+# ---------------------------------------------------------------------------
 # detect-version-bumps.sh (#5311)
 # ---------------------------------------------------------------------------
 # Under STUB_DIR so the EXIT trap set above still cleans it up — a second
@@ -630,16 +667,26 @@ assert_eq "no gate in semver-checks branches on the activity type" "0" \
   "$(grep -c 'github\.event\.action' <<<"$(sed -n '/^jobs:/,$p' .github/workflows/semver-checks.yml)" || true)"
 # The expensive half of the SemVer gate stays behind the diff verdict — this is
 # what keeps #5149's "not 20 minutes on every PR" true while the context reports.
-# #5440 added a sixth guarded step (libdbus install, needed for trusty-common's
-# keyring-store feature): Install stable toolchain, Install system dependencies
-# (libdbus for keyring-store), Install cargo-semver-checks (pinned prebuilt),
-# Cache cargo artifacts, SemVer gate selftest, Enforce public-API SemVer against
-# crates.io. The seventh is the type-differ selftest, which is cheap — it reads
-# two committed rustdoc JSON documents — but its --crate cases need
-# `cargo metadata`, and the toolchain step above is itself gated. All seven
-# belong behind have_work: none has a reason to run when nothing is released.
-assert_eq "semver-checks gates its costly steps on there being work" "7" \
-  "$(grep -c "if: steps.crate.outputs.have_work == 'true'" .github/workflows/semver-checks.yml || true)"
+# Four steps have no reason to run when nothing is released: Install system
+# dependencies (libdbus for keyring-store, #5440), Install cargo-semver-checks
+# (pinned prebuilt), Cache cargo artifacts, Enforce public-API SemVer against
+# crates.io.
+#
+# ANCHORED ON `$` (#5501). Unanchored, this assertion is a substring match that
+# the widened `have_work == 'true' || …` condition below also satisfies, so it
+# would have kept counting 7 and reported green over the exact regression it is
+# here to catch.
+assert_eq "semver-checks gates its costly steps on there being work" "4" \
+  "$(grep -cE "if: steps\.crate\.outputs\.have_work == 'true'$" .github/workflows/semver-checks.yml || true)"
+# #5501: the three CHEAP steps run on either trigger — a declared bump, or a
+# change to the gate's own machinery. Gating them on the bump alone skipped the
+# self-tests on every PR that changed the gate, which is every gate-fix PR (PR
+# #5496 is the observed case). The three: Install stable toolchain (both
+# self-tests need a `cargo` on PATH), SemVer gate selftest, Type-differ selftest.
+assert_eq "semver-checks runs its self-tests when the gate itself changed" "3" \
+  "$(grep -c "have_work == 'true' || steps.machinery.outputs.semver_gate_inputs_changed == 'true'" .github/workflows/semver-checks.yml || true)"
+assert_eq "semver-checks classifies its own machinery from the diff" "1" \
+  "$(grep -c 'bash scripts/detect-semver-gate-inputs.sh' .github/workflows/semver-checks.yml || true)"
 
 echo
 if [ "${FAILURES}" -gt 0 ]; then

--- a/scripts/detect-semver-gate-inputs.sh
+++ b/scripts/detect-semver-gate-inputs.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# detect-semver-gate-inputs.sh — does a change set touch the SemVer gate's own
+# machinery? (issue #5501)
+#
+# Why: `.github/workflows/semver-checks.yml` ran its two self-tests only when
+#   `scripts/detect-version-bumps.sh` found a declared version bump. A PR that
+#   repairs the gate and bumps nothing — which is what every gate-fix PR looks
+#   like — therefore took the no-op path, and the self-tests that exist to catch
+#   a broken gate were SKIPPED on exactly the PRs that change it. Observed on
+#   PR #5496: it fixed this gate, `Public API / SemVer` passed in ~15s through
+#   the no-op path, and the repair's own regression tests never ran in CI.
+#
+#   Keying the self-tests on the bump was never the right predicate for them.
+#   The bump predicate belongs to the EXPENSIVE half of the gate — installing
+#   the pinned `cargo-semver-checks` and warming a cold `target/semver-checks`
+#   cache is the 20+ minutes #5149 refused to pay on every PR, and this script
+#   must not restore that. The self-tests cost seconds: they replay committed
+#   fixtures and stub the tool. So they get their own, second trigger, ORed with
+#   the bump — "did this branch change the gate?" — and the expensive steps keep
+#   the bump predicate untouched.
+#
+# What: reads a newline-separated list of changed paths on stdin (or resolves
+#   one itself from git when given a base ref) and answers ONE question: could
+#   any changed path change what the SemVer gate's self-tests report? Emits
+#   `semver_gate_inputs_changed=true|false` on stdout, and appends the same line
+#   to $GITHUB_OUTPUT when that is set.
+#
+#   The rules below are the gate's machinery as the workflow actually wires it,
+#   read out of the file rather than guessed:
+#     .github/workflows/semver-checks.yml       the wiring that runs all of it
+#     scripts/detect-version-bumps.sh           crate selection (workflow L145)
+#     scripts/check_semver_selftest.sh          run at workflow L239
+#     scripts/check_semver_types_selftest.sh    run at workflow L255
+#     scripts/check_semver.sh                   run at workflow L277, and the
+#                                               subject of check_semver_selftest
+#     scripts/check_semver_types.sh             the subject of the type-differ
+#                                               self-test
+#     scripts/lib/rustdoc_walk.py               the walk check_semver_types.sh
+#                                               imports (ADR-0047)
+#     scripts/semver-checks-*-exclusions.tsv    the crate and feature exclusion
+#                                               tables check_semver.sh reads
+#     scripts/test-data/semver-gate/**          the captured cargo-semver-checks
+#     scripts/test-data/semver-types/**         output and rustdoc JSON the two
+#                                               self-tests replay — a changed
+#                                               fixture changes what they prove
+#     scripts/detect-semver-gate-inputs.sh      this classifier — a change to
+#                                               the decision must be checked by
+#                                               the gate it decides for
+#
+#   `scripts/preflight-publish.sh` is deliberately NOT here. It runs the same
+#   check_semver.sh at publish time and has its own self-test
+#   (scripts/preflight-check5-selftest.sh); nothing this workflow runs reads it.
+#
+#   An EMPTY change set is relevant, not irrelevant: it means the diff could not
+#   be resolved, and a self-test must never stand down as the consequence of a
+#   lookup failure. Same fail-closed direction as
+#   scripts/detect-pointer-lint-inputs.sh, whose shape this follows.
+#
+# Usage:
+#   git diff --name-only --no-renames "$MERGE_BASE" HEAD | scripts/detect-semver-gate-inputs.sh
+#   SEMVER_GATE_BASE=origin/main scripts/detect-semver-gate-inputs.sh
+#
+# Exit: 0 on a successful classification; 2 when a requested base ref cannot be
+#   resolved (fail closed — the caller must not guess).
+#
+# Test: scripts/check-ci-helpers-selftest.sh (`detect-semver-gate-inputs:`
+#   cases) runs this against each machinery path, unrelated paths, mixed and
+#   empty change sets and asserts the emitted verdict for each.
+
+set -euo pipefail
+
+# is_gate_input <path> — true when the path can change what the SemVer gate's
+# self-tests report.
+is_gate_input() {
+  case "$1" in
+    .github/workflows/semver-checks.yml) return 0 ;;
+    scripts/check_semver.sh) return 0 ;;
+    scripts/check_semver_selftest.sh) return 0 ;;
+    scripts/check_semver_types.sh) return 0 ;;
+    scripts/check_semver_types_selftest.sh) return 0 ;;
+    scripts/detect-version-bumps.sh) return 0 ;;
+    scripts/detect-semver-gate-inputs.sh) return 0 ;;
+    scripts/lib/rustdoc_walk.py) return 0 ;;
+    scripts/semver-checks-crate-exclusions.tsv) return 0 ;;
+    scripts/semver-checks-feature-exclusions.tsv) return 0 ;;
+    scripts/test-data/semver-gate/*) return 0 ;;
+    scripts/test-data/semver-types/*) return 0 ;;
+  esac
+  return 1
+}
+
+main() {
+  local input
+  if [ -n "${SEMVER_GATE_BASE:-}" ]; then
+    local merge_base
+    if ! merge_base="$(git merge-base "${SEMVER_GATE_BASE}" HEAD 2>/dev/null)"; then
+      echo "detect-semver-gate-inputs: cannot resolve merge-base against '${SEMVER_GATE_BASE}'" >&2
+      return 2
+    fi
+    input="$(git diff --name-only --no-renames "${merge_base}" HEAD)"
+  else
+    input="$(cat)"
+  fi
+
+  local changed=false
+  local count=0
+  local path
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    count=$((count + 1))
+    if is_gate_input "$path"; then
+      echo "  gate machinery: ${path}" >&2
+      changed=true
+    fi
+  done <<<"$input"
+
+  if [ "$count" -eq 0 ]; then
+    echo "detect-semver-gate-inputs: empty change set — treating as relevant (fail closed)" >&2
+    changed=true
+  fi
+
+  echo "detect-semver-gate-inputs: ${count} changed path(s) -> semver_gate_inputs_changed=${changed}" >&2
+  echo "semver_gate_inputs_changed=${changed}"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "semver_gate_inputs_changed=${changed}" >>"${GITHUB_OUTPUT}"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Closes #5501.

The defect: both self-test steps in `.github/workflows/semver-checks.yml` (lines 238 and 254) were gated on `have_work == 'true'`, computed only from `scripts/detect-version-bumps.sh`, which reads declared `[package] version` changes. A PR that changes the gate machinery but bumps no version produced `have_work == false`, so the self-tests stood down on exactly the PRs modifying the gate they exist to protect.

The fix: a new `scripts/detect-semver-gate-inputs.sh` classifier emits `semver_gate_inputs_changed`. Three steps now run on `have_work || semver_gate_inputs_changed` — both self-tests plus `Install stable toolchain`. Four stay on `have_work` alone: the libdbus install, the pinned `cargo-semver-checks` install, the rustdoc cache, and `Enforce public-API SemVer against crates.io`. That split keeps #5149's cost decision intact — nothing that reaches crates.io runs more often than before.

The classifier mirrors `scripts/detect-pointer-lint-inputs.sh`, which solved the same problem for `test-pointers.yml` in #5311 — same shape, same self-inclusion rule, same fail-closed empty set. An empty change set is treated as relevant, so a failed lookup can never be the reason a self-test is skipped.

**The machinery path set was derived from what the workflow actually invokes**, not from a hand-written list: four invoked scripts, then each one's runtime reads — the feature and crate exclusion TSVs, `check_semver_types.sh`, `scripts/lib/rustdoc_walk.py`, and both `scripts/test-data/` fixture directories. Twelve rules. `scripts/preflight-publish.sh` is deliberately excluded: nothing this workflow runs reads it, and it has its own self-test.

**This PR is its own verification.** Its diff bumps no version, so `have_work` is false — before this change both self-tests would have skipped on it. They must show as run, not skipped.

One fix beyond the issue's ask, worth a reviewer's eye: `check-ci-helpers-selftest.sh`'s `have_work`-only count assertion was an unanchored substring match, so the widened `have_work == 'true' || …` line satisfied it too. It would have kept reporting `7` and passing over the exact regression it exists to catch. Now anchored on `$`, reading `4`.

Verified locally that the cheap path is self-sufficient: both self-tests pass with `cargo-semver-checks` absent from PATH and only `cargo` present — the runner's state when the pinned install step does not run.

**What is only verifiable on a real CI run**, stated rather than claimed: that GitHub evaluates the widened `if:` to true and executes the two steps. The YAML was verified to parse with the condition on the right steps and the referenced step id existing and writing that output name; `steps.machinery.outputs.*` resolution and the tag-push `else` arm are unobserved.

Test ladder rung 1 — CI and shell only, no Rust. `check-ci-helpers-selftest.sh` (156 cases, +19 new plus two workflow-shape assertions), `check_changelog_fragment.sh`, `check_line_cap.sh`, `check_sld.sh` all exit 0. No actionlint or yamllint exists in this repo; YAML validated by parsing.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
