### PR TITLE
feat(trusty-mpm): surface build-performance setup at Rust project init

### DIFF
--- a/crates/trusty-mpm/changelog.d/5820-tm-init-build-performance-pointer.md
+++ b/crates/trusty-mpm/changelog.d/5820-tm-init-build-performance-pointer.md
@@ -1,0 +1,19 @@
+Added
+
+- `/tm-init` now adds a **Build Performance** pointer to a Rust project's
+  scaffolded or refreshed `CLAUDE.md` (keyed off the same `Cargo.toml` marker
+  `rust-engineer` deploys on), so build-performance discipline is part of
+  standard project setup instead of something reached only after a build
+  already feels slow. The pointer references the bundled
+  `rust-build-performance` skill and directs a new contributor to
+  `cargo build --timings` for a measured baseline. It deliberately does not
+  assert that `sccache` (or any shared compilation cache) makes builds
+  faster: for a workspace's own path/member crates — the common
+  multi-worktree cold-build scenario — sccache under its default config gets
+  zero benefit, since cargo's dev profile builds those crates incrementally
+  and sccache cannot cache incremental output. `CARGO_INCREMENTAL=0` is
+  named as the only lever for a cross-worktree hit on path crates, without
+  recommending it — that tradeoff is unmeasured. Whether sccache pays off on
+  a workspace's external, non-path dependencies stays a separate, unanswered
+  question the pointer directs the operator to measure (`sccache
+  --show-stats`) rather than assume.

--- a/crates/trusty-mpm/src/assets/skills/tm-init.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-init.md
@@ -40,7 +40,12 @@ managed session) — not `/tm-init`.
 2. **Scaffold or update `CLAUDE.md`** — the project-instructions file that
    tells any future session how to build, test, and navigate this repo. New
    projects get a fresh priority-ranked (🔴🟡🟢⚪) file; existing projects get a
-   smart, non-destructive refresh that preserves custom sections.
+   smart, non-destructive refresh that preserves custom sections. For a Rust
+   project (`Cargo.toml` present — the same marker `rust-engineer` deploys
+   on), this step also adds the **Build Performance** pointer described under
+   "What Gets Written" below, so build-performance discipline is part of
+   project setup rather than something reached only after a build already
+   feels slow.
 3. **Register the project** with the trusty-mpm daemon (`tm project init`) so it
    is tracked, listable, and resumable.
 4. Optionally surface recent work context (`update` / `context` / `catchup`
@@ -120,6 +125,39 @@ project — instant, no LLM analysis. After running it, reconcile against
   (point the link at the project's own repo when known), and that this overrides
   any harness default — never `🤖 Generated with Claude Code` or a
   `Co-Authored-By: Claude …` trailer. Preserve the section on smart-merge.
+- ✅ **Build Performance pointer (Rust projects only)** — when `Cargo.toml`
+  exists at the project root, a scaffolded or refreshed `CLAUDE.md` MUST
+  include a short **Build Performance** section, added at setup time instead
+  of waiting for a build to feel slow first:
+  - Point at the bundled `rust-build-performance` skill
+    (`Skill(skill="rust-build-performance")`) for the day-to-day discipline —
+    `cargo check` first, trim the dependency/feature graph, and protect
+    incremental compilation.
+  - Name `cargo build --timings` as the first concrete action for a new
+    contributor: establish a measured baseline before assuming anything is
+    slow or reaching for a shared-cache/compiler-flag fix.
+  - **Never assert that `sccache` (or any other shared compilation cache)
+    makes builds faster.** The skill's own §6 is explicit that for a
+    workspace's own path/member crates — the common multi-worktree
+    cold-build scenario — sccache under its default config gets **zero
+    benefit**: cargo's dev profile builds those crates incrementally, and
+    sccache cannot cache incremental compiler output. That is not a
+    theoretical caveat; a forced path-crate recompile under an active
+    sccache wrapper reproduces it directly (`Non-cacheable reasons:
+    incremental`, 0 hits). The only lever for a cross-worktree hit on path
+    crates is `CARGO_INCREMENTAL=0`, which trades away single-tree
+    incremental speed to get it — name that tradeoff, but do not recommend
+    making it; it is unmeasured and stays an explicit operator decision.
+    Whether sccache's cache pays off on a workspace's EXTERNAL, non-path
+    dependencies (the one case its mechanism is expected to help, since
+    those build non-incrementally and identically across worktrees) is a
+    separate, still-unquantified question — point at `sccache --show-stats`
+    to measure a real hit rate on the target machine before treating that
+    case as settled either. State any adoption as a measured, opt-in
+    team/operator decision, never as a default every Rust project should
+    turn on.
+  Preserve this section on smart-merge, same as the attribution section
+  above.
 - ✅ project registration under `.trusty-mpm/` (via `tm project init`)
 - ❌ never `.claude/agents/`, `.claude/skills/`, `.claude/settings.json`,
   `INSTRUCTIONS.md`, output styles, or `.mcp.json` (those are `tm install`'s job)
@@ -141,6 +179,11 @@ version-controllable and is never clobbered on re-`init`.
 
 - `tm install` — (re)deploy the trusty **config** (agents/skills/settings/mcp);
   this is the config path `/tm-init` deliberately does not cover.
+- `rust-build-performance` — the skill the Build Performance pointer (above)
+  points to for a detected Rust project; also carried resident in
+  `rust-engineer` and `tauri-engineer`'s own `skills:` frontmatter, so this
+  pointer is a project-setup complement to that per-agent coverage, not a
+  duplicate of it.
 - `/tm-session-management` — session pause/resume policy, the auto-pause
   threshold, project-local `.trusty-mpm/sessions/` format, and worktree pruning.
 - `/tm-session-pause` and `/tm-session-resume` — the focused pause/resume actions.

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -1229,6 +1229,46 @@ fn rust_build_performance_declared_by_rust_family_agents() {
 }
 
 #[test]
+fn tm_init_surfaces_build_performance_pointer_for_rust_projects() {
+    // The `rust-build-performance` skill (per-agent, resident in
+    // `rust-engineer`/`tauri-engineer` — see
+    // `rust_build_performance_declared_by_rust_family_agents` above) only
+    // reaches a session that dispatches one of those agents. Nothing at
+    // PROJECT-SETUP time surfaced it before a build already felt slow — this
+    // test pins the `/tm-init` fix: a Rust project's scaffolded/refreshed
+    // `CLAUDE.md` MUST get a durable Build Performance pointer, and that
+    // pointer must not assert a benefit the in-flight sccache measurement
+    // has not established.
+    assert!(
+        TM_INIT.contains("Cargo.toml"),
+        "tm-init must key the Build Performance pointer off the same \
+         Cargo.toml marker rust-engineer deploys on"
+    );
+    assert!(
+        TM_INIT.contains("Build Performance"),
+        "tm-init is missing the Build Performance section instruction for \
+         Rust projects"
+    );
+    assert!(
+        TM_INIT.contains("rust-build-performance"),
+        "tm-init's Build Performance pointer must reference the bundled \
+         rust-build-performance skill"
+    );
+    assert!(
+        TM_INIT.contains("cargo build --timings"),
+        "tm-init must direct a new Rust project toward measuring a baseline \
+         with --timings, not toward a compiler-flag or cache guess"
+    );
+    assert!(
+        TM_INIT.contains("Never assert that `sccache`"),
+        "tm-init must not let a scaffolded CLAUDE.md assert an unmeasured \
+         sccache speedup — the skill's own §6 caveats (no default hit on \
+         incremental path-crate builds) must be preserved, not silently \
+         dropped, by the pointer this test guards"
+    );
+}
+
+#[test]
 fn output_styles_keep_claude_code_coding_instructions() {
     // Claude Code strips its built-in software-engineering instructions (how to
     // scope changes, write comments, verify work) from any custom output style


### PR DESCRIPTION
## Summary

- `rust-build-performance` (bundled at `crates/trusty-mpm/src/assets/skills/rust-build-performance.md`) only reached a session via its own reactive description ("when a build feels slow") or as a resident skill on `rust-engineer`/`tauri-engineer` dispatch (2026-07-17 directive) — nothing reached it at **project setup**, before any pain was paid.
- `/tm-init` (`crates/trusty-mpm/src/assets/skills/tm-init.md`) is the deterministically-invoked project-init/refresh skill that already does stack detection to scaffold/refresh `CLAUDE.md`. It now adds a **Build Performance** section instruction there, keyed off the same `Cargo.toml` marker `rust-engineer` deploys on (`framework-manifest.toml`).
- The pointer: names `cargo build --timings` as the first concrete baseline action, references the bundled skill, and is explicit that it must **never assert sccache makes builds faster** — a live in-flight measurement in this repo confirmed a workspace's path/member crates get **zero** sccache benefit under default config (cargo's incremental dev profile isn't cacheable by sccache), names `CARGO_INCREMENTAL=0` as the only lever for a cross-worktree hit on path crates **without recommending it** (unmeasured tradeoff), and leaves whether sccache helps external non-path dependencies as an open, unquantified question the pointer tells the operator to measure (`sccache --show-stats`), not assume.

## Why this location, not the alternatives

- **`framework-manifest.toml` skill_categories gating** — rejected. Skills currently have one `universal` deploy rule (deployed to every project already); gating `rust-build-performance` to Rust-only projects would change *distribution scope*, not *when in the workflow* it's consulted — orthogonal to the actual gap.
- **`rust-engineer`'s resident `skills:` frontmatter** — already exists (2026-07-17 directive, proven by `rust_build_performance_declared_by_rust_family_agents`) and is unchanged here. It only reaches a session that dispatches that specific agent, mid-task — not the PM/operator at project setup, and not durable in the project's own docs.
- **The skill's own description field** — broadening it to also match "project setup" relies on semantic skill-trigger luck, the exact mechanism that already wasn't firing at the right time.
- **`tm-workflow`** — governs the general ticket→worktree→PR delivery lifecycle, not stack-specific setup; would need to duplicate `tm-init`'s own Rust detection.

`/tm-init` wins: it's the standing, deterministically-invoked project-setup skill, already keys off language/framework detection, and writes durable project documentation (`CLAUDE.md`) every future session — not just `rust-engineer` — sees.

## Test plan

Rung 3 (localized behavior inside `trusty-mpm`, markdown asset + a compiled-in Rust test — no detection/deployment logic touched):

- `cargo fmt --check -p trusty-mpm` — clean
- `cargo check -p trusty-mpm --all-targets` — clean (pre-existing unrelated multi-bin-target warnings only)
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo test -p trusty-mpm` — 5018 passed, 1 pre-existing unrelated flake (`daemon::api::tests::tmux_snapshot_unknown_session_is_404`), 7 ignored. That test's code path (tmux/daemon) is untouched by this diff; it passes in isolation on both the unmodified main checkout and this branch, and fails only inside the full parallel suite on this heavily loaded machine — reproduced as pre-existing, not caused by this change.
- New regression test `tm_init_surfaces_build_performance_pointer_for_rust_projects` (`bundle_tests.rs`) — verified it **fails** against the pre-fix `tm-init.md` content and **passes** against the fix.
- `bash scripts/check_changelog_fragment.sh --base origin/main` — OK
- `bash scripts/check_line_cap.sh` — exit 0

No issue was filed for this. Two things worth the user routing to an issue if desired: (1) the pre-existing `tmux_snapshot_unknown_session_is_404` full-suite-only flake, unrelated to this change; (2) applying this same Build Performance section to trusty-tools' own root `CLAUDE.md` via a live `/tm-init update` run, once the in-flight sccache measurement fully lands.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools