### PR TITLE
fix(scripts): resolve the publish order from the complete dependency graph

### DIFF
--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -164,6 +164,23 @@ jobs:
         if: steps.gate.outputs.run_check == 'true'
         run: bash scripts/check_scan_floor_selftest.sh pr_version_bump
 
+      # Publish-ORDER selftest (issue #5358). Different question from this
+      # job's own gate — not "is this version already live" but "would we
+      # upload a crate before a sibling it needs" — and it lives here because
+      # this is the only PR-triggered, unconditionally-run job on the
+      # publish-safety side. Its own workflow cannot host it:
+      # release.yml's `publish-dry-run` job fires on `*-v*` tags only, and
+      # pre-publish.yml states in its header that it deliberately does not run
+      # on pull_request. A selftest nothing invokes on a PR is #5501's defect,
+      # so it goes where PRs actually reach it.
+      #
+      # Cheap enough to sit in a required job: pure shell plus python3 against
+      # a checked-in cargo-metadata fixture, no cargo, no network, well under
+      # a second. It never runs `cargo publish` — every case is --list-only.
+      - name: Publish-order selftest (optional + dev dep edges must order first)
+        if: steps.gate.outputs.run_check == 'true'
+        run: bash scripts/publish-dry-run-order_selftest.sh
+
       # #4688: diff against the base branch AS IT IS NOW, not the frozen
       # `base.sha` snapshot. checkout leaves refs/remotes/origin/<base> at
       # whatever it fetched; re-fetching pins it to the live tip so the merge

--- a/scripts/publish-dry-run-order.sh
+++ b/scripts/publish-dry-run-order.sh
@@ -17,14 +17,36 @@
 #   mechanical so a release doesn't depend on someone re-deriving the
 #   dependency graph by hand under time pressure.
 #
-# What: runs `cargo metadata` once, computes a topological order over every
-#   PUBLISHABLE workspace crate (i.e. not `publish = false`) using internal
-#   (workspace-to-workspace) dependency edges only, then runs
+# What: runs `cargo metadata --all-features` once, computes a topological
+#   order over every PUBLISHABLE workspace crate (i.e. not `publish = false`)
+#   using internal (workspace-to-workspace) dependency edges only, then runs
 #   `cargo publish --dry-run -p <crate>` for each crate in that order —
 #   dependencies always before dependents. Any single dry-run failure stops
 #   the run immediately (fail fast: a downstream crate's dry-run failing
 #   because an upstream sibling isn't live yet is exactly the class of bug
 #   this script exists to catch before a real publish).
+#
+# Graph completeness (#5358) — the order is only as safe as the graph it is
+#   computed from, and `cargo publish` resolves MORE than a default build does:
+#
+#   * FEATURES: `--all-features` is required. Plain `cargo metadata` resolves
+#     default features only, so an optional/feature-gated sibling edge is
+#     absent from `resolve` entirely. `trusty-analyze` reaches `trusty-review`
+#     only through its optional, `review`-gated dependency
+#     (crates/trusty-analyze/Cargo.toml), so that edge was invisible and the
+#     printed order put `trusty-analyze` BEFORE `trusty-review` — the 2026-08-10
+#     release failure this issue records.
+#   * KINDS: dependency kind is deliberately NOT filtered. `resolve`'s flat
+#     per-node `dependencies` list is the union of normal, build, and dev
+#     edges, and all three must already be live on crates.io — `cargo publish`
+#     resolves a full lockfile for the packaged crate, dev-dependencies
+#     included (`trusty-mpm` depends on `trusty-review` as a dev-dependency
+#     ONLY, and still cannot be published before it). Narrowing to normal
+#     edges via `deps[].dep_kinds` would reintroduce this same defect.
+#
+#   There is deliberately no fallback to a feature-less resolve if
+#   `--all-features` fails: `set -e` stopping loudly beats silently ordering a
+#   release off an incomplete graph, which is what this guard exists to prevent.
 #
 # Usage:
 #   scripts/publish-dry-run-order.sh              # every publishable crate, in order
@@ -86,7 +108,9 @@ done
 TMP_METADATA="$(mktemp "${TMPDIR:-/tmp}/publish-dry-run-order.metadata.XXXXXX.json")"
 trap 'rm -f "${TMP_METADATA}"' EXIT
 
-cargo metadata --format-version=1 --locked >"${TMP_METADATA}"
+# #5358: --all-features, or optional/feature-gated sibling edges are missing
+# from `resolve` and a crate gets ordered before a sibling it really needs.
+cargo metadata --format-version=1 --locked --all-features >"${TMP_METADATA}"
 
 ORDER="$(python3 - "${TMP_METADATA}" "${FILTER[@]}" <<'PYEOF'
 import json
@@ -104,6 +128,12 @@ packages = {p["id"]: p for p in data["packages"] if p["id"] in members}
 publishable = {pid for pid, p in packages.items() if p.get("publish") is None}
 
 # Internal (workspace-to-workspace) dependency edges, keyed by package id.
+#
+# #5358: read the flat `dependencies` list, NOT `deps[].dep_kinds` — it is the
+# union of normal, build and dev edges, and `cargo publish` needs all three
+# resolvable against the live registry. Combined with the `--all-features`
+# metadata invocation above, this is the complete set of internal edges
+# `cargo publish` will resolve.
 resolve_nodes = {n["id"]: n for n in data["resolve"]["nodes"]}
 edges = {pid: set() for pid in publishable}
 for pid in publishable:
@@ -117,7 +147,16 @@ for pid in publishable:
 # Kahn's algorithm: repeatedly emit any publishable crate whose remaining
 # unemitted dependencies are all already emitted, breaking ties by name for
 # deterministic output.
-remaining = dict(edges)
+#
+# #5358: copy each edge SET, not just the outer dict. `dict(edges)` is shallow,
+# so the loop's `deps.difference_update(ready)` below emptied the very sets
+# `edges` holds — leaving every `edges[pid]` empty once the sort finished. The
+# `--list-only <crate>` closure walk further down reads `edges`, so it found no
+# transitive dependencies and emitted the requested crates alone. That is the
+# form release.yml's `publish-dry-run` job runs (one crate name, release.yml),
+# so the job dry-ran the tagged crate against whatever was already live and
+# checked none of its siblings.
+remaining = {pid: set(deps) for pid, deps in edges.items()}
 emitted = []
 name_of = {pid: packages[pid]["name"] for pid in publishable}
 while remaining:

--- a/scripts/publish-dry-run-order_selftest.sh
+++ b/scripts/publish-dry-run-order_selftest.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+#
+# publish-dry-run-order_selftest.sh — the graph half of the publish-order
+# preflight (issue #5358).
+#
+# Why: scripts/publish-dry-run-order.sh decides what order crates are published
+#   in, and `cargo publish` cannot be undone — a crate uploaded before a sibling
+#   it needs is fixed by a yank. The order is only as good as the graph it is
+#   computed from, and the graph was wrong twice, in two independent ways that
+#   each produced a confident, exit-0, plausible-looking order:
+#
+#     1. `cargo metadata` ran without --all-features, so optional and
+#        feature-gated sibling edges were absent from `resolve` entirely.
+#        trusty-analyze reaches trusty-review only through its optional
+#        `review`-gated dependency, so the printed order put trusty-analyze
+#        FIRST. Caught on 2026-08-10 by a dry-run that failed, not by the order.
+#     2. `remaining = dict(edges)` was a shallow copy, so Kahn's
+#        `difference_update` emptied the very sets `edges` holds. The
+#        single-crate filter walks `edges` afterwards to build the publishable
+#        closure, so it found nothing and emitted the requested crate ALONE.
+#        That is the form release.yml's `publish-dry-run` job runs, so the job
+#        dry-ran one crate against whatever happened to be live already and
+#        checked none of its siblings.
+#
+#   Neither failure is visible in an exit status: the pre-fix script exits 0 on
+#   every case below. Only the ORDER shows it, which is why this file asserts on
+#   the order rather than on the status.
+#
+# What: runs the real script against a checked-in cargo-metadata fixture
+#   (scripts/test-data/publish-dry-run-order/metadata.json) with a `cargo` shim
+#   earlier on PATH, and asserts the emitted order. The shim models the one
+#   behaviour that matters here — WITHOUT --all-features it strips the optional
+#   edge from the graph, exactly as real cargo does — so case 1 tests the flag
+#   itself rather than trusting that it was passed.
+#
+#   Always --list-only: no `cargo publish` ever runs, nothing touches crates.io,
+#   and the whole file finishes in well under a second.
+#
+#   A fixture rather than a live `cargo metadata` run, deliberately: today
+#   trusty-analyze -> trusty-review is the only optional internal edge in the
+#   real workspace, and a test resting on that would go vacuous the moment
+#   someone made that dependency unconditional. See the fixture's own _comment
+#   for the crate-by-crate mapping back to the real graph.
+#
+# Usage:
+#   bash scripts/publish-dry-run-order_selftest.sh                 # every case
+#   bash scripts/publish-dry-run-order_selftest.sh optional_dep_order
+#   bash scripts/publish-dry-run-order_selftest.sh --script /tmp/old.sh
+#                                                  # drive a DIFFERENT copy of
+#                                                  # the script, e.g. the
+#                                                  # pre-fix one out of git, to
+#                                                  # confirm these cases still
+#                                                  # reproduce the defect
+#   (names: optional_dep_order filter_closure dev_dep_edge)
+#
+# Exit: 0 when every case holds; 1 (naming the case, with the order it got)
+#   when one does not.
+#
+# Portability: bash 3.2 (macOS) and bash 5 (Linux CI). python3, which the script
+#   under test already requires.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+FIXTURE="$REPO_ROOT/scripts/test-data/publish-dry-run-order/metadata.json"
+UNDER_TEST="$REPO_ROOT/scripts/publish-dry-run-order.sh"
+
+KNOWN="optional_dep_order filter_closure dev_dep_edge"
+
+ONLY=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --script)
+      [ "$#" -ge 2 ] || { echo "publish-dry-run-order_selftest: --script needs a path." >&2; exit 2; }
+      UNDER_TEST="$2"
+      shift 2
+      ;;
+    -h|--help)
+      grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      case " $KNOWN " in
+        *" $1 "*) ONLY="$ONLY $1" ;;
+        *)
+          echo "publish-dry-run-order_selftest: unknown case '$1'." >&2
+          echo "  known: $KNOWN" >&2
+          exit 2
+          ;;
+      esac
+      shift
+      ;;
+  esac
+done
+
+[ -r "$FIXTURE" ] || {
+  echo "publish-dry-run-order_selftest: fixture missing: $FIXTURE" >&2
+  exit 2
+}
+[ -r "$UNDER_TEST" ] || {
+  echo "publish-dry-run-order_selftest: script under test missing: $UNDER_TEST" >&2
+  exit 2
+}
+
+PASSED=0
+FAILED=0
+
+# ---------------------------------------------------------------------------
+# new_fixture_dir: a throwaway dir holding a copy of the script under test and
+# a `cargo` shim. The script derives its repo root from its own BASH_SOURCE, so
+# copying it in keeps the run hermetic. No `git init` needed — unlike the gates
+# in check_scan_floor_selftest.sh, this script enumerates nothing from git.
+# ---------------------------------------------------------------------------
+new_fixture_dir() {
+  local tmp
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/publishorder.XXXXXX")"
+  mkdir -p "$tmp/scripts" "$tmp/bin"
+  cp "$UNDER_TEST" "$tmp/scripts/publish-dry-run-order.sh"
+
+  # The cargo shim. `cargo metadata` prints the fixture; WITHOUT --all-features
+  # it first strips the optional demo-analyze -> demo-review edge, which is what
+  # real cargo does when the gating feature is not activated. Any other cargo
+  # subcommand is a bug in the test — the cases are --list-only, so the script
+  # must never reach `cargo publish`.
+  cat > "$tmp/bin/cargo" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" != "metadata" ]; then
+  echo "cargo shim: refusing unexpected subcommand '\${1:-}' (selftest is --list-only)" >&2
+  exit 97
+fi
+all_features=0
+for a in "\$@"; do
+  [ "\$a" = "--all-features" ] && all_features=1
+done
+exec python3 - "$FIXTURE" "\$all_features" <<'PYSHIM'
+import json, sys
+data = json.load(open(sys.argv[1]))
+if sys.argv[2] != "1":
+    # Model default-feature resolution: the optional, 'review'-gated edge is
+    # simply not in the resolve graph.
+    gated_from = "path+file:///w/crates/demo-analyze#demo-analyze@0.1.0"
+    gated_to = "path+file:///w/crates/demo-review#demo-review@0.1.0"
+    for node in data["resolve"]["nodes"]:
+        if node["id"] == gated_from:
+            node["dependencies"] = [d for d in node["dependencies"] if d != gated_to]
+            node["deps"] = [d for d in node["deps"] if d["pkg"] != gated_to]
+json.dump(data, sys.stdout)
+PYSHIM
+EOF
+  chmod +x "$tmp/bin/cargo"
+  echo "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# order_of <fixture-dir> [crate ...] — run the script and print the computed
+# order, one crate per line. The script writes the order to STDERR (stdout is
+# left clean), indented two spaces under a header line.
+# ---------------------------------------------------------------------------
+order_of() {
+  local dir="$1"
+  shift
+  ( cd "$dir" && PATH="$dir/bin:$PATH" \
+      bash scripts/publish-dry-run-order.sh --list-only "$@" 2>&1 ) \
+    | sed -n 's/^  \([a-z0-9-]*\)$/\1/p'
+}
+
+# ---------------------------------------------------------------------------
+# expect_before <label> <order> <first> <second> — assert both crates are in
+# the order and <first> precedes <second>.
+# ---------------------------------------------------------------------------
+expect_before() {
+  local label="$1" order="$2" first="$3" second="$4"
+  local i_first i_second
+  # `|| true` on both: a MISSING crate is the single most informative failure
+  # this file can report, and under `set -o pipefail` grep's exit 1 would
+  # otherwise kill the run before the diagnostic below ever prints — losing
+  # cases 2 and 3 behind case 1.
+  i_first="$(printf '%s\n' "$order" | grep -n "^${first}\$" | head -1 | cut -d: -f1 || true)"
+  i_second="$(printf '%s\n' "$order" | grep -n "^${second}\$" | head -1 | cut -d: -f1 || true)"
+
+  if [ -z "$i_first" ]; then
+    fail "$label" "'${first}' is missing from the order entirely" "$order"
+    return
+  fi
+  if [ -z "$i_second" ]; then
+    fail "$label" "'${second}' is missing from the order entirely" "$order"
+    return
+  fi
+  if [ "$i_first" -ge "$i_second" ]; then
+    fail "$label" "'${first}' must be published before '${second}', but came after" "$order"
+    return
+  fi
+
+  echo "  ok  ${label} (${first} before ${second})"
+  PASSED=$((PASSED + 1))
+}
+
+# ---------------------------------------------------------------------------
+# expect_absent <label> <order> <crate> — assert a crate is NOT in the order.
+# ---------------------------------------------------------------------------
+expect_absent() {
+  local label="$1" order="$2" crate="$3"
+  if printf '%s\n' "$order" | grep -q "^${crate}\$"; then
+    fail "$label" "'${crate}' must never appear in a publish order" "$order"
+    return
+  fi
+  echo "  ok  ${label} (${crate} absent)"
+  PASSED=$((PASSED + 1))
+}
+
+fail() {
+  local label="$1" why="$2" order="$3"
+  echo "SELF-TEST FAIL: ${label}" >&2
+  echo "       ${why}" >&2
+  echo "       computed order was:" >&2
+  printf '%s\n' "$order" | sed 's/^/         /' >&2
+  FAILED=$((FAILED + 1))
+}
+
+want() {
+  [ -z "$ONLY" ] && return 0
+  case " $ONLY " in
+    *" $1 "*) return 0 ;;
+  esac
+  return 1
+}
+
+# ===========================================================================
+# 1. The OPTIONAL, feature-gated edge (demo-analyze -> demo-review).
+#    Without --all-features the shim withholds that edge, both crates come back
+#    ready in the same Kahn round, and the alphabetical tie-break emits
+#    demo-analyze first — a confident order that publishes a crate before the
+#    sibling it needs. This is trusty-analyze vs trusty-review on 2026-08-10.
+#
+#    demo-private is asserted absent in the same run: it is `publish = false`
+#    and depends on demo-analyze, so a regression that stopped honouring the
+#    publishable filter would show up here rather than at a real publish.
+# ===========================================================================
+if want optional_dep_order; then
+  d="$(new_fixture_dir)"
+  o="$(order_of "$d")"
+  expect_before "full order: optional edge is respected" "$o" demo-review demo-analyze
+  expect_absent "full order: publish=false crate excluded" "$o" demo-private
+  expect_absent "full order: external crate excluded" "$o" serde
+  rm -rf "$d"
+fi
+
+# ===========================================================================
+# 2. The SINGLE-CRATE FILTER — the form release.yml:1661 actually invokes
+#    (`bash scripts/publish-dry-run-order.sh "<pkg_name>"`). The closure must
+#    come back with the requested crate's publishable dependencies, in order.
+#    Pre-fix this returned `demo-analyze` alone, because Kahn had emptied the
+#    edge sets the closure walk reads — so the release job dry-ran one crate
+#    and proved nothing about the siblings it needs.
+# ===========================================================================
+if want filter_closure; then
+  d="$(new_fixture_dir)"
+  o="$(order_of "$d" demo-analyze)"
+  expect_before "scoped closure: sibling pulled in" "$o" demo-review demo-analyze
+  expect_before "scoped closure: transitive dep pulled in" "$o" demo-common demo-review
+  rm -rf "$d"
+fi
+
+# ===========================================================================
+# 3. The DEV-ONLY edge (demo-mpm -> demo-review). `cargo publish` resolves a
+#    full lockfile for the packaged crate, dev-dependencies included, so a
+#    dev-only sibling must still be live first. The script gets this right by
+#    reading resolve's flat `dependencies` list, which unions normal, build and
+#    dev edges; this case exists so a later "tidy-up" that narrows to
+#    `deps[].dep_kinds` normal edges fails here instead of at a publish.
+#    trusty-mpm depends on trusty-review exactly this way.
+# ===========================================================================
+if want dev_dep_edge; then
+  d="$(new_fixture_dir)"
+  o="$(order_of "$d" demo-mpm)"
+  expect_before "dev-only edge counts" "$o" demo-review demo-mpm
+  rm -rf "$d"
+fi
+
+# ===========================================================================
+# Verdict
+# ===========================================================================
+if [ "$FAILED" -ne 0 ]; then
+  echo "publish-order self-test: ${PASSED} passed, ${FAILED} FAILED — see above (issue #5358)." >&2
+  exit 1
+fi
+
+if [ "$PASSED" -eq 0 ]; then
+  echo "publish-order self-test: 0 assertions ran — this self-test just proved nothing." >&2
+  echo "  (check the case-name argument; a test that examines nothing is not a passing test.)" >&2
+  exit 1
+fi
+
+echo "publish-order self-test: ${PASSED} assertion(s) hold over the fixture graph — OK."
+exit 0

--- a/scripts/test-data/publish-dry-run-order/metadata.json
+++ b/scripts/test-data/publish-dry-run-order/metadata.json
@@ -1,0 +1,173 @@
+{
+  "_comment": [
+    "Fixture for scripts/publish-dry-run-order_selftest.sh (#5358).",
+    "",
+    "A cargo-metadata --format-version=1 --all-features document for a synthetic",
+    "five-crate workspace, shaped to carry the three edges the publish-order",
+    "computation has to get right. Checked in rather than produced by a live",
+    "`cargo metadata` run so the cases stay deterministic as the real workspace",
+    "changes: today trusty-analyze->trusty-review is the only optional internal",
+    "edge in the tree, and a test that depended on that staying true would go",
+    "vacuous the moment someone made the dependency unconditional.",
+    "",
+    "The mapping to the real defect:",
+    "  demo-analyze -> demo-review   OPTIONAL, feature-gated ('review'). Invisible",
+    "                                to a metadata run without --all-features.",
+    "                                This is trusty-analyze -> trusty-review.",
+    "  demo-mpm     -> demo-review   DEV-dependency only. Must still be counted:",
+    "                                cargo publish resolves a full lockfile.",
+    "                                This is trusty-mpm -> trusty-review.",
+    "  demo-private                  publish = false. Must never appear in the",
+    "                                order even though it depends on demo-analyze.",
+    "  serde                         external. Must never appear in the order.",
+    "",
+    "Only the keys publish-dry-run-order.sh reads are populated faithfully;",
+    "`deps` carries dep_kinds so the dev-edge case has real data to assert on.",
+    "That key is ignored by the script (it reads workspace_members, packages and",
+    "resolve.nodes) and exists to keep the fixture self-describing."
+  ],
+
+  "workspace_members": [
+    "path+file:///w/crates/demo-analyze#demo-analyze@0.1.0",
+    "path+file:///w/crates/demo-common#demo-common@0.1.0",
+    "path+file:///w/crates/demo-mpm#demo-mpm@0.1.0",
+    "path+file:///w/crates/demo-private#demo-private@0.1.0",
+    "path+file:///w/crates/demo-review#demo-review@0.1.0"
+  ],
+
+  "packages": [
+    {
+      "id": "path+file:///w/crates/demo-analyze#demo-analyze@0.1.0",
+      "name": "demo-analyze",
+      "version": "0.1.0",
+      "publish": null,
+      "features": {
+        "default": [],
+        "review": ["dep:demo-review"]
+      }
+    },
+    {
+      "id": "path+file:///w/crates/demo-common#demo-common@0.1.0",
+      "name": "demo-common",
+      "version": "0.1.0",
+      "publish": null,
+      "features": {}
+    },
+    {
+      "id": "path+file:///w/crates/demo-mpm#demo-mpm@0.1.0",
+      "name": "demo-mpm",
+      "version": "0.1.0",
+      "publish": null,
+      "features": {}
+    },
+    {
+      "id": "path+file:///w/crates/demo-private#demo-private@0.1.0",
+      "name": "demo-private",
+      "version": "0.1.0",
+      "publish": [],
+      "features": {}
+    },
+    {
+      "id": "path+file:///w/crates/demo-review#demo-review@0.1.0",
+      "name": "demo-review",
+      "version": "0.1.0",
+      "publish": null,
+      "features": {}
+    },
+    {
+      "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0",
+      "name": "serde",
+      "version": "1.0.0",
+      "publish": null,
+      "features": {}
+    }
+  ],
+
+  "resolve": {
+    "root": null,
+    "nodes": [
+      {
+        "id": "path+file:///w/crates/demo-analyze#demo-analyze@0.1.0",
+        "dependencies": [
+          "path+file:///w/crates/demo-common#demo-common@0.1.0",
+          "path+file:///w/crates/demo-review#demo-review@0.1.0"
+        ],
+        "deps": [
+          {
+            "name": "demo_common",
+            "pkg": "path+file:///w/crates/demo-common#demo-common@0.1.0",
+            "dep_kinds": [{ "kind": null, "target": null }]
+          },
+          {
+            "name": "demo_review",
+            "pkg": "path+file:///w/crates/demo-review#demo-review@0.1.0",
+            "dep_kinds": [{ "kind": null, "target": null }]
+          }
+        ]
+      },
+      {
+        "id": "path+file:///w/crates/demo-common#demo-common@0.1.0",
+        "dependencies": [
+          "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0"
+        ],
+        "deps": [
+          {
+            "name": "serde",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0",
+            "dep_kinds": [{ "kind": null, "target": null }]
+          }
+        ]
+      },
+      {
+        "id": "path+file:///w/crates/demo-mpm#demo-mpm@0.1.0",
+        "dependencies": [
+          "path+file:///w/crates/demo-common#demo-common@0.1.0",
+          "path+file:///w/crates/demo-review#demo-review@0.1.0"
+        ],
+        "deps": [
+          {
+            "name": "demo_common",
+            "pkg": "path+file:///w/crates/demo-common#demo-common@0.1.0",
+            "dep_kinds": [{ "kind": null, "target": null }]
+          },
+          {
+            "name": "demo_review",
+            "pkg": "path+file:///w/crates/demo-review#demo-review@0.1.0",
+            "dep_kinds": [{ "kind": "dev", "target": null }]
+          }
+        ]
+      },
+      {
+        "id": "path+file:///w/crates/demo-private#demo-private@0.1.0",
+        "dependencies": [
+          "path+file:///w/crates/demo-analyze#demo-analyze@0.1.0"
+        ],
+        "deps": [
+          {
+            "name": "demo_analyze",
+            "pkg": "path+file:///w/crates/demo-analyze#demo-analyze@0.1.0",
+            "dep_kinds": [{ "kind": null, "target": null }]
+          }
+        ]
+      },
+      {
+        "id": "path+file:///w/crates/demo-review#demo-review@0.1.0",
+        "dependencies": [
+          "path+file:///w/crates/demo-common#demo-common@0.1.0"
+        ],
+        "deps": [
+          {
+            "name": "demo_common",
+            "pkg": "path+file:///w/crates/demo-common#demo-common@0.1.0",
+            "dep_kinds": [{ "kind": null, "target": null }]
+          }
+        ]
+      },
+      {
+        "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0",
+        "dependencies": [],
+        "deps": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #5358.

Defect 1: `cargo metadata` ran without `--all-features`, so optional and feature-gated dependencies were absent from the resolved graph and a crate could be ordered ahead of one it depends on. `cargo publish` uploads are irreversible; the wrong order means publishing against a dependency not yet on crates.io, and the fix is a yank.

Defect 2, found while fixing the first and worse: `remaining = dict(edges)` was a shallow copy, and Kahn's `deps.difference_update(ready)` mutates the shared sets in place, so every `edges[pid]` was empty by the time the single-crate filter's transitive walk read it. `release.yml:1661` calls exactly that path. The `publish-dry-run` job dry-ran the tagged crate against whatever was already live and checked none of its siblings — for every crate, not just feature-gated ones. It existed but proved nothing about ordering.

Both fixes are independently necessary; the 2x2 is in the selftest, and against a half-fixed script (`--all-features` added, shallow copy retained) case 1 passes while the three closure assertions still fail.

Order change: `trusty-analyze` moves from position 5 to 15, crossing `trusty-review` at 13 — the exact pair the issue named. Scoped run went from `trusty-analyze` alone to `trusty-common, trusty-review, trusty-analyze`.

The script deliberately does NOT filter by dependency kind, and that is documented in it now so nobody tidies it away: `cargo publish` resolves a full lockfile including dev-dependencies, and `trusty-mpm -> trusty-review` is a dev-only edge that must stay live.

New `scripts/publish-dry-run-order_selftest.sh` with six assertions over a checked-in fixture at `scripts/test-data/publish-dry-run-order/metadata.json`. Fixture rather than live `cargo metadata` for determinism, and because `trusty-analyze -> trusty-review` is currently the only optional internal edge in the workspace — a test resting on the real graph would go vacuous the moment that dependency became unconditional. The selftest shims `cargo` on PATH inside a subshell scoped to a temp dir, the same technique `check_scan_floor_selftest.sh` uses for `git`, so no production test seam was added.

Flag for the reviewer, do not bury: the selftest is wired into `.github/workflows/version-parity.yml`, which is a REQUIRED branch-protection context, so it blocks merges. It is hermetic and sub-second — no cargo, no network, all cases `--list-only`. It went there because it is the only PR-triggered, unconditionally-run job on the publish-safety side: `release.yml`'s `publish-dry-run` fires on `*-v*` tags only, and `pre-publish.yml` deliberately skips `pull_request`. If a non-blocking home is preferred, `ci.yml`'s `changes` job is the alternative.

Test ladder rung 1 — scripts and CI only, no Rust. `bash -n` on both scripts, `check_changelog_fragment.sh`, `check_line_cap.sh`, `check_sld.sh` all exit 0. No shellcheck gate exists in this repo.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
