### PR TITLE
fix(ci): run the website test suite in CI, and fix the four defects keeping it red

### DIFF
--- a/.github/workflows/website-tests.yml
+++ b/.github/workflows/website-tests.yml
@@ -1,0 +1,159 @@
+# #5200: nothing in CI ran `website/`'s Vitest suite — this workflow does.
+#
+# The gap this closes: `scripts/detect-docs-only.sh` buckets `website/**` as
+# inert (same as `docs/**`) on the strength of a comment claiming the site
+# "builds and lints under its own workflow". That workflow did not exist, so a
+# website-only PR set `docs_only=true`, `ci.yml`'s `Test` job skipped, and the
+# `ui-checks` matrix — the only pnpm surface in `ci.yml` — never listed
+# `website/`. Every website PR merged on a green that tested nothing.
+#
+# WHY A SEPARATE WORKFLOW, not a ninth leg on `ci.yml`'s `ui-checks` matrix:
+# every step in that matrix is gated on `needs.changes.outputs.docs_only !=
+# 'true'`, and `website/**` IS `docs_only` by that classifier's own rule. A
+# website leg bolted onto that matrix would skip on exactly the PRs it exists
+# to check. Its own workflow with its own `paths:` filter inverts that — it
+# runs when `website/` changes and stays quiet otherwise.
+#
+# TRIGGER PATHS — derived from what the suite READS, not from Vercel's
+# rebuild set. The two overlap but are not the same list:
+#   website/**                        the suite and its sources
+#   docs/**                           `docs/public-manifest.tsv` drives the
+#                                     `/docs/**` routes `build-smoke.test.ts`
+#                                     asserts exist; a PAGE row naming a
+#                                     missing file fails the build
+#   Cargo.toml                        `site.test.ts` pins the advertised MSRV
+#                                     to `rust-version`
+#   crates/*/Cargo.toml               `site.test.ts` / `tools.test.ts` assert
+#                                     every advertised crate exists and its
+#                                     version matches
+#   crates/*/CHANGELOG.md             `changelog/parse.test.ts` and
+#                                     `changelog/site.test.ts` parse the real
+#                                     six-crate corpus
+#   .../commands/stable_set.rs        `site.test.ts` pins `STABLE_SET` to the
+#                                     Rust declaration
+#   .../download/platform.rs          `site.test.ts` pins the platform list to
+#                                     the Tier-1 triples
+#
+# `Cargo.lock` is in Vercel's rebuild set and deliberately NOT here: nothing
+# in the build or the suite reads it. The two `trusty-installer` source files
+# are here and NOT in Vercel's set — they are test inputs, not build inputs,
+# and a change to either is exactly what broke this suite on 2026-08-16
+# (commit 819f55cc9 took `StableMember::new(` from 7 occurrences to 9).
+#
+# PNPM — the version is READ from `website/package.json`'s `packageManager`
+# field rather than hardcoded, then asserted after install. `ui-checks` pins
+# `version: 9`, which floats across the 9.x line; `website/` pins the exact
+# `pnpm@9.15.9`, and a shell at the repo root has no pin at all. Parsing the
+# field keeps one source of truth, and the assertion makes a mis-resolution
+# fail loudly instead of running the suite under some other pnpm.
+#
+# NODE 20 — `website/` declares no `engines` field and has no `.nvmrc`. 20 is
+# the version every sibling workflow uses AND the lowest one all three
+# floors accept: vitest 4 wants `^20 || ^22 || >=24`, vite 6 wants
+# `^18 || ^20 || >=22`, SvelteKit 2 wants `>=18.13`.
+#
+# CHROMIUM — `tests/mobile-overflow.test.ts` launches a real browser to
+# measure `scrollWidth`; jsdom has no layout engine and cannot. That file's
+# header assumes a browser already cached by `crates/trusty-agents/ui`'s
+# Playwright install, which is a developer-machine assumption — an ephemeral
+# runner has nothing cached, so this installs it explicitly.
+name: Website tests
+
+on:
+  push:
+    branches: [main]
+    # Duplicated verbatim under `pull_request` below: GitHub Actions does not
+    # expand YAML anchors in workflow files, so the two lists are kept in sync
+    # by hand — same as token-drift.yml.
+    paths:
+      - "website/**"
+      - "docs/**"
+      - "Cargo.toml"
+      - "crates/*/Cargo.toml"
+      - "crates/*/CHANGELOG.md"
+      - "crates/trusty-installer/src/commands/stable_set.rs"
+      - "crates/trusty-installer/src/download/platform.rs"
+      - ".github/workflows/website-tests.yml"
+  pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+    branches: [main]
+    paths:
+      - "website/**"
+      - "docs/**"
+      - "Cargo.toml"
+      - "crates/*/Cargo.toml"
+      - "crates/*/CHANGELOG.md"
+      - "crates/trusty-installer/src/commands/stable_set.rs"
+      - "crates/trusty-installer/src/download/platform.rs"
+      - ".github/workflows/website-tests.yml"
+
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml / token-drift.yml.
+concurrency:
+  group: website-tests-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
+
+jobs:
+  website-tests:
+    name: Vitest (unit + smoke)
+    if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
+    runs-on: ubuntu-latest
+    # The `smoke` project shells out to a real `vite build` twice (once per
+    # `tests/**` file, `fileParallelism: false`) and then drives Chromium over
+    # the output. ~4 min on an M-series laptop; 20 leaves headroom on a
+    # slower hosted runner without letting a hang burn a full hour.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Read the pinned pnpm version from website/package.json
+        id: pin
+        run: |
+          set -euo pipefail
+          version="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"pnpm@\([0-9][0-9.]*\).*/\1/p' website/package.json)"
+          if [ -z "$version" ]; then
+            echo "::error::no pnpm@<version> found in website/package.json packageManager" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ steps.pin.outputs.version }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: website/pnpm-lock.yaml
+
+      - name: Verify the resolved pnpm is the pinned one
+        run: |
+          set -euo pipefail
+          resolved="$(pnpm --version)"
+          expected="${{ steps.pin.outputs.version }}"
+          if [ "$resolved" != "$expected" ]; then
+            echo "::error::pnpm $resolved resolved, but website/package.json pins $expected" >&2
+            exit 1
+          fi
+          echo "pnpm $resolved matches the pin"
+
+      - name: Install dependencies
+        working-directory: website
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Chromium for the mobile-overflow smoke test
+        working-directory: website
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run the website test suite
+        working-directory: website
+        run: pnpm run test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,10 +534,16 @@ the Root Directory", and the Ignored Build Step are configured in the Vercel
 dashboard only — dashboard drift leaves no trace in git. Setup and the full
 path table: [website/README.md](website/README.md).
 
-🔴 Website tests do not run in CI (#5200). Run them by hand: `pnpm test` from
-INSIDE `website/` — pnpm is pinned there (`packageManager` field); a shell at
-the repo root has no such pin and its resolved pnpm can require a Node version
-newer than what's installed.
+🟡 Website tests run in CI under `.github/workflows/website-tests.yml` (#5200) —
+its own workflow, not a leg on `ci.yml`'s `ui-checks` matrix, because
+`scripts/detect-docs-only.sh` buckets `website/**` as docs-only and every
+`ui-checks` step is gated on `docs_only != 'true'`; a leg there would skip on
+exactly the PRs it exists to check. Still run them by hand before pushing:
+`pnpm test` from INSIDE `website/` — pnpm is pinned there (`packageManager`
+field); a shell at the repo root has no such pin and its resolved pnpm can
+require a Node version newer than what's installed. The workflow runs Node 20;
+a newer local Node can report spurious `localStorage` failures in
+`theme.test.ts`.
 
 ## Common Pitfalls — Quick Checklist
 

--- a/website/README.md
+++ b/website/README.md
@@ -28,6 +28,13 @@ pnpm dev        # http://localhost:5173
 pnpm `9.15.9`, pinned in `packageManager` to match the seven UI packages under
 `crates/*/ui/`.
 
+`pnpm test` runs in CI as `.github/workflows/website-tests.yml` (#5200), on
+Node 20 with Chromium installed for the mobile-overflow smoke test. It is a
+separate workflow rather than a leg on `ci.yml`'s `ui-checks` matrix because
+`scripts/detect-docs-only.sh` buckets `website/**` as docs-only, and every
+`ui-checks` step is gated on `docs_only != 'true'` — a leg there would skip on
+exactly the PRs it exists to check.
+
 ## Vercel project settings
 
 Three settings must be configured on the Vercel project. Only the first is

--- a/website/src/lib/site.test.ts
+++ b/website/src/lib/site.test.ts
@@ -66,8 +66,13 @@ describe('install commands are grounded in the repository', () => {
 
 	it('STABLE_SET matches stable_set.rs', () => {
 		const source = read('crates/trusty-installer/src/commands/stable_set.rs');
-		const declared = [...source.matchAll(/StableMember::new\("([^"]+)"/g)].map((m) => m[1]);
-		expect(declared.length).toBe(7);
+		// #5200: scope the match to the `stable_set()` body. Sweeping the whole
+		// file also counts the `StableMember::new` in the test module — a
+		// fixture, not a shipped member — so the count drifted with test edits.
+		const body = source.match(/pub fn stable_set\(\) -> Vec<StableMember> \{([\s\S]*?)\n\}/);
+		expect(body, 'stable_set() not found in stable_set.rs').not.toBeNull();
+		const declared = [...body![1].matchAll(/StableMember::new\("([^"]+)"/g)].map((m) => m[1]);
+		expect(declared.length).toBe(8);
 		expect(STABLE_SET).toEqual(declared);
 	});
 

--- a/website/src/lib/site.ts
+++ b/website/src/lib/site.ts
@@ -141,7 +141,7 @@ export const INSTALL_OPTIONS: InstallOption[] = [
 	}
 ];
 
-/** The seven crates `tctl install` manages, from `stable_set.rs`. */
+/** The eight crates `tctl install` manages, in `stable_set.rs` order. */
 export const STABLE_SET = [
 	'trusty-search',
 	'trusty-memory',
@@ -149,7 +149,9 @@ export const STABLE_SET = [
 	'trusty-review',
 	'tga',
 	'trusty-console',
-	'trusty-mpm'
+	'trusty-mpm',
+	// #5805: the control plane installs itself, and is last in the Rust order.
+	'trusty-installer'
 ];
 
 /**

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -86,7 +86,13 @@
 	</p>
 	<div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
 		{#each FLAGSHIPS as flagship (flagship.name)}
-			<article class="card flex flex-col">
+			<!-- `min-w-0`: same grid-item rule as the install cards below — a grid
+			     item's automatic minimum size is its content's min-content width.
+			     The what's-new strip carries changelog prose whose min-content ran
+			     to 367px, widening the card to 417px inside a 343px column and
+			     scrolling the page sideways at 375px. #5200 surfaced this once the
+			     suite actually ran; related to #5255, which named the 320px case. -->
+			<article class="card flex min-w-0 flex-col">
 				<p class="eyebrow">{flagship.unit}</p>
 				<h3 class="mt-2 break-words font-display text-xl font-semibold">
 					<a

--- a/website/tests/mobile-overflow.test.ts
+++ b/website/tests/mobile-overflow.test.ts
@@ -71,13 +71,17 @@ import { whatsNewSections } from '../src/lib/changelog/site';
  * overflow. 1px is kept as an explicit, narrow allowance for exactly that —
  * not "a wider hidden" — and stays two orders of magnitude below anything a
  * real clipped-content regression produces (the injection proof below reads
- * main.scrollWidth 1697 against a 375 clientWidth). The homepage's OWN
- * 320px reading is different in kind, not degree — its `/` card grid
- * overflows main by 37px, a real layout defect with a real card clipped,
- * pre-existing and unrelated to this fix (present on `origin/main` before
- * it, confirmed by re-running this measurement against the unmodified
- * `app.css`). Silently tolerating that would be the masking this file
- * exists to prevent, so `/` is asserted at 375px only here — see #5255.
+ * main.scrollWidth 1697 against a 375 clientWidth).
+ *
+ * The homepage's own card-grid overflow (#5255) is fixed rather than tolerated,
+ * so `/` is now asserted at both widths. Its cards carried no `min-w-0`, and a
+ * grid item's automatic minimum size is its content's min-content width — the
+ * what's-new strip's changelog prose measured 367px, widening the card to 417px
+ * inside a 343px column. That read main.scrollWidth 433 against a 375
+ * clientWidth; with `min-w-0` on the card both widths land exactly on their
+ * clientWidth. Nothing about it was specific to 320px, and the earlier reading
+ * of "37px at 320px only" was taken while this file's `beforeAll` was timing
+ * out at 60s and skipping every measurement in it (#5200).
  * Test: this file.
  */
 
@@ -118,10 +122,10 @@ const SAFE_UNESCAPED_IDENTIFIER = /^[\w./:-]+$/;
 /**
  * Why: pinning one specific identifier (`pipeline::citation_check::…`) broke
  * the moment its release aged out of `/whats-new`'s `DETAILED_RELEASES`
- * window (#5461) — trusty-review shipped past 0.11.0, and CI never runs this
- * suite (#5200), so the drift was silent. `whatsNewSections()` is the exact
- * data `/whats-new` renders from, so picking a probe out of it can never
- * target content the page has stopped showing.
+ * window (#5461) — trusty-review shipped past 0.11.0, and at the time CI ran
+ * this suite nowhere (#5200), so the drift was silent. `whatsNewSections()` is
+ * the exact data `/whats-new` renders from, so picking a probe out of it can
+ * never target content the page has stopped showing.
  * What: the longest whitespace-free `<code>` run across every flagship
  * crate's currently-detailed releases — standing in for "a long inline
  * identifier", whichever one happens to be current.
@@ -145,16 +149,6 @@ function longestInlineCodeIdentifier(): string {
 		}
 	}
 	return longest;
-}
-
-/**
- * `/` at 320px has its own pre-existing, unrelated overflow (#5255 — a card
- * grid, not changelog prose) that this PR does not fix. Skipping it here is
- * not masking: it is asserted at 375px like every other route, and the gap
- * is named, not silently widened away.
- */
-function isKnownPreexistingGap(route: string, width: number): boolean {
-	return route === '/' && width === 320;
 }
 
 /** `/whats-new` -> `whats-new.html`; `/` -> `index.html`; `/a/b` -> `a/b.html`. */
@@ -231,7 +225,9 @@ beforeAll(async () => {
 	const { port } = server.address() as AddressInfo;
 	baseUrl = `http://127.0.0.1:${port}`;
 	browser = await chromium.launch();
-}, 60_000);
+	// #5200: no per-hook override — this hook runs a real `vite build` (1m21s
+	// measured), so the project's own `hookTimeout: 300_000` governs.
+});
 
 afterAll(async () => {
 	await browser?.close();
@@ -241,8 +237,7 @@ afterAll(async () => {
 describe('no page scrolls horizontally on mobile', () => {
 	for (const width of WIDTHS) {
 		for (const route of ROUTES) {
-			const testFn = isKnownPreexistingGap(route, width) ? it.skip : it;
-			testFn(`${route} at ${width}px`, async () => {
+			it(`${route} at ${width}px`, async () => {
 				const page = await browser.newPage({ viewport: { width, height: 800 } });
 				try {
 					await page.goto(baseUrl + route, { waitUntil: 'networkidle' });

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -23,7 +23,12 @@ export default defineConfig({
 				test: {
 					name: 'unit',
 					environment: 'jsdom',
-					include: ['src/**/*.test.ts']
+					include: ['src/**/*.test.ts'],
+					// #5200: the changelog tests parse the real six-crate corpus
+					// (11k lines and growing every release) under vitest's 5s
+					// default. Worst case measured 21.1s locally; a hosted runner
+					// is materially slower on CPU-bound parsing.
+					testTimeout: 120_000
 				}
 			},
 			{


### PR DESCRIPTION
Closes #5200.

Adds `.github/workflows/website-tests.yml`, running the `website/` suite under Node 20 with pnpm 9.15.9 (from `website/package.json`'s `packageManager`), with an explicit `playwright install chromium`.

**Why a separate workflow rather than a ninth `ui-checks` leg** — the non-obvious part: `scripts/detect-docs-only.sh:112-116` buckets `website/**` as docs-only, and every step in `ci.yml`'s `ui-checks` matrix is gated on `docs_only != 'true'`. A website leg there would skip on exactly the PRs it exists to check. That also corroborates the false comment #5200 already noted in that script.

The suite was red on `main`, so the workflow could not land green as scoped. Four defects, all fixed here:

1. **A one-day-old regression.** `819f55cc9` ("make trusty-installer a member of its own stable set") added a `StableMember::new(...)` entry, taking the count `site.test.ts` asserts from 7 to 9. Fixed both halves: the regex now scopes to the `stable_set()` body so a test fixture at `stable_set.rs:575` can never count as a shipped member, and `trusty-installer` is appended to the website's `STABLE_SET` because it genuinely is the 8th member. **A Rust-only PR broke the website suite and merged green because no workflow ran it — #5200 demonstrating itself, one day old.**
2. Six changelog-corpus tests inherited Vitest's default 5s `testTimeout` while parsing 11,038 lines across six crates, taking up to 21.1s locally. `unit` project now sets `testTimeout: 120_000`.
3. `mobile-overflow.test.ts:234` closed its `beforeAll` with `}, 60_000)`, overriding the project's `hookTimeout: 300_000` for a hook that runs a `vite build` measured at 1m21s. Argument dropped so the project value governs.
4. Found only because fixing 3 made the 16 measurements run for the first time: `/` at 375px reported `main.scrollWidth 433` against a `375` clientWidth. Isolated as pre-existing by stashing the unrelated change and getting the identical 433. The flagship `<article class="card">` had no `min-w-0`, so the grid item's automatic minimum size was its content's min-content width — the what's-new strip's prose measures 367px, widening the card to 417px inside a 343px column. Adding `min-w-0` lands both widths exactly on clientWidth.

Neither timeout fix weakens an assertion. Coverage went **up**: 248 passed | 1 skipped → 249 passed | 0 skipped, because the `min-w-0` fix also resolved the 320px case the file recorded as a known gap, so a stale skip was removed.

Green under Node 20: `14 passed (14)`, `249 passed (249)`, 39.75s. Deliberate-failure check done — setting `FACTS` MSRV to `Rust 9.99` produced a failing run at exit 1, then reverted.

Docs: `CLAUDE.md:537` now points at the workflow, downgraded 🔴→🟡, keeping the run-by-hand instruction and adding the Node 20 / `localStorage` note. `website/README.md` gains a paragraph on why the workflow is separate. Two stale claims in `mobile-overflow.test.ts` corrected.

Test ladder rung 6 — UI/API surface, with direct UI evidence rather than crate tests.

**Two decisions for the reviewer, stated plainly, not buried:** whether the `min-w-0` card fix should split into its own PR, and whether it closes #5255 — that issue is referenced deliberately without a closing keyword.

Known unrelated: `pnpm lint` fails on `src/routes/tools/trusty-git-analytics/audit/+page.svelte`, a prettier complaint present on `origin/main` and untouched here. The workflow runs `pnpm run test` only.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
