### PR TITLE
fix(trusty-mpm): reap an agent's worktree when its session ends, not only on SubagentStop

### DIFF
--- a/crates/trusty-mpm/changelog.d/4311-session-end-agent-worktree-reap.md
+++ b/crates/trusty-mpm/changelog.d/4311-session-end-agent-worktree-reap.md
@@ -1,10 +1,4 @@
 Fixed
-
-A dispatched agent's worktree is now reclaimed when the session that dispatched
-it ends, not only when its `SubagentStop` arrives. `SubagentStop` was the reap's
-only trigger, so an agent killed by a session exit or restart, an interrupt, or a
-dropped hook POST left its worktree registered and owner-known — and the orphan
-sweep skips agent-owned trees by design, so nothing else ever reclaimed it. A
-refusal is now logged at `warn!` and each session end reports how many trees it
-reclaimed and how many it kept, so a leak the gates decline to clear is visible
-instead of silent.
+- A dispatched agent's worktree is now reclaimed when the session that dispatched it ends, not only when its `SubagentStop` arrives. `SubagentStop` was the reap's only trigger, so an agent killed by a session exit or restart, an interrupt, or a dropped hook POST left its worktree registered and owner-known — and the orphan sweep skips agent-owned trees by design, so nothing else ever reclaimed it.
+- A reap that keeps a worktree is now logged at `warn!` rather than `info!`. The refusal is the only notice anyone gets that a tree needs a human, and nothing retries it.
+- A session-end sweep now reports how many trees it removed, how many were already gone, and how many it kept. It reported two numbers before, counting a tree the harness had already reclaimed as one this sweep removed — which overstated the only number an operator reads to judge whether the reap is doing anything.

--- a/crates/trusty-mpm/changelog.d/4311-session-end-agent-worktree-reap.md
+++ b/crates/trusty-mpm/changelog.d/4311-session-end-agent-worktree-reap.md
@@ -1,0 +1,10 @@
+Fixed
+
+A dispatched agent's worktree is now reclaimed when the session that dispatched
+it ends, not only when its `SubagentStop` arrives. `SubagentStop` was the reap's
+only trigger, so an agent killed by a session exit or restart, an interrupt, or a
+dropped hook POST left its worktree registered and owner-known — and the orphan
+sweep skips agent-owned trees by design, so nothing else ever reclaimed it. A
+refusal is now logged at `warn!` and each session end reports how many trees it
+reclaimed and how many it kept, so a leak the gates decline to clear is visible
+instead of silent.

--- a/crates/trusty-mpm/src/daemon/services/agent_worktree_reap.rs
+++ b/crates/trusty-mpm/src/daemon/services/agent_worktree_reap.rs
@@ -107,6 +107,25 @@ impl ReapOutcome {
     }
 }
 
+/// What one `SessionEnd` sweep did, split by [`ReapOutcome`].
+///
+/// Why `already_gone` is its own counter: the summary used to fold it into
+/// "reclaimed" via a `_ =>` arm, which reported a sweep that removed nothing as
+/// having reclaimed every candidate. `AlreadyGone` means the harness got there
+/// first, so counting it as work this sweep did overstates the only number an
+/// operator reads to judge whether the reap is doing anything.
+/// Test: `session_end_keeps_a_worktree_that_holds_unsaved_work`,
+/// `session_end_spares_another_sessions_agent`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SweepSummary {
+    /// `git worktree remove --force` succeeded.
+    pub removed: usize,
+    /// Nothing was at the path when the sweep reached it.
+    pub already_gone: usize,
+    /// A gate refused, and the directory is still there.
+    pub kept: usize,
+}
+
 /// Is `path` a leaf of a harness agent-worktree store — `…/.claude/worktrees/<name>`?
 ///
 /// Why: this is the only shape this module will delete, and it is deliberately
@@ -330,6 +349,23 @@ async fn paths_in_use(state: &Arc<DaemonState>, self_agent_id: &str) -> Vec<Path
     out
 }
 
+/// The harness agent-worktree store a hook payload's `cwd` names, or `None`.
+///
+/// Why a named function rather than three lines inlined twice: it is the ONLY
+/// thing standing between a payload that carries no `cwd` and a sweep over a
+/// store resolved from somewhere else. Both callers must refuse identically, and
+/// a test can assert the refusal directly instead of inferring it from a
+/// directory that happens to survive.
+/// What: `cwd` → [`harness_root_for`](crate::core::harness_root::harness_root_for)
+/// → `<root>/.claude/worktrees`, the flat store ADR-0036 defines. `None` for a
+/// payload with no `cwd`, a non-string `cwd`, or a `cwd` outside any repository.
+/// Test: `session_end_without_a_cwd_resolves_no_store`.
+fn store_for(payload: &Value) -> Option<PathBuf> {
+    let cwd = payload.get("cwd").and_then(Value::as_str)?;
+    let root = crate::core::harness_root::harness_root_for(Path::new(cwd))?;
+    Some(root.join(".claude").join("worktrees"))
+}
+
 /// Recover an agent's worktree path from on-disk sentinels alone (#4311).
 ///
 /// Why: the delegation map is a `DashMap` built empty at every daemon boot with
@@ -351,9 +387,7 @@ async fn paths_in_use(state: &Arc<DaemonState>, self_agent_id: &str) -> Vec<Path
 /// Test: `stop_reaps_a_worktree_the_registry_lost_to_a_restart`,
 /// `stop_ignores_a_sentinel_naming_a_different_agent`.
 fn rebuild_from_disk(payload: &Value, agent_id: &str) -> Option<PathBuf> {
-    let cwd = payload.get("cwd").and_then(Value::as_str)?;
-    let root = crate::core::harness_root::harness_root_for(Path::new(cwd))?;
-    let found = find_agent_worktree(&root.join(".claude").join("worktrees"), agent_id)?;
+    let found = find_agent_worktree(&store_for(payload)?, agent_id)?;
     tracing::info!(
         agent_id,
         worktree = %found.display(),
@@ -380,6 +414,14 @@ fn rebuild_from_disk(payload: &Value, agent_id: &str) -> Option<PathBuf> {
 /// is the one mistake this module must never make. Such a record keeps its
 /// `worktree_path`, which is what makes the tree visible to `tm doctor` and the
 /// reconcile report instead of invisible as it is today. Stated gap.
+/// # The returned handle
+///
+/// `None` means no reap was even attempted — the event was not a stop, the
+/// payload named no agent, or neither the registry nor the disk knew a worktree
+/// for it. `Some` is the detached task, and awaiting it yields the one
+/// [`ReapOutcome`]. Production callers ignore it; a test awaits it, which is
+/// what lets a negative assertion run AFTER the decision instead of racing a
+/// fixed sleep against it.
 /// Test: `spawn_on_stop_ignores_a_non_stop_event`,
 /// `spawn_on_stop_ignores_a_payload_without_an_agent_id`.
 pub fn spawn_on_stop(
@@ -387,36 +429,30 @@ pub fn spawn_on_stop(
     session: SessionId,
     event: HookEvent,
     payload: &Value,
-) {
+) -> Option<tokio::task::JoinHandle<ReapOutcome>> {
     if !matches!(
         event,
         HookEvent::SubagentStop | HookEvent::SubagentStopFailure
     ) {
-        return;
+        return None;
     }
-    let Some(agent_id) = payload
+    let agent_id = payload
         .get("agent_id")
         .and_then(Value::as_str)
         .filter(|s| !s.is_empty())
-        .map(str::to_string)
-    else {
-        return;
-    };
+        .map(str::to_string)?;
     let registered = state
         .delegations_for(session)
         .into_iter()
         .find(|d| d.agent_id.as_deref() == Some(agent_id.as_str()))
         .and_then(|d| d.worktree_path.clone().map(|p| (Some(d.id), p)));
-    let Some((id, path)) =
-        registered.or_else(|| rebuild_from_disk(payload, &agent_id).map(|p| (None, p)))
-    else {
-        return;
-    };
+    let (id, path) =
+        registered.or_else(|| rebuild_from_disk(payload, &agent_id).map(|p| (None, p)))?;
 
     let state = Arc::clone(state);
-    tokio::spawn(async move {
-        reap_and_record(&state, &agent_id, path, id).await;
-    });
+    Some(tokio::spawn(async move {
+        reap_and_record(&state, &agent_id, path, id).await
+    }))
 }
 
 /// Run the reap for one agent's worktree and record what happened (#4311).
@@ -517,10 +553,10 @@ fn agent_worktrees_of(store: &Path, session: SessionId) -> Vec<(PathBuf, AgentWo
 /// a later agent along with the branch the previous one left checked out, which
 /// is how an unrelated commit reached an open PR's branch on 2026-08-17. That
 /// makes prompt reclamation a correctness property, not housekeeping.
-/// What: on `SessionEnd`, resolves the harness worktree store from the payload's
-/// `cwd` exactly as [`rebuild_from_disk`] does, then runs the UNCHANGED
+/// What: on `SessionEnd`, resolves the harness worktree store with [`store_for`]
+/// — the same resolution [`rebuild_from_disk`] uses — then runs the UNCHANGED
 /// [`reap_worktree`] gate stack against every directory whose sentinel names
-/// this session as its parent, and reports the split.
+/// this session as its parent, and reports the split as a [`SweepSummary`].
 ///
 /// # Why a `SessionEnd` is proof its agents exited
 ///
@@ -531,52 +567,69 @@ fn agent_worktrees_of(store: &Path, session: SessionId) -> Vec<(PathBuf, AgentWo
 /// carries, applied to every child at once, so no gate is weakened to use it: a
 /// candidate still has to pass the sentinel, in-use, git-registry, dirt and
 /// process-liveness gates, and a tree holding unsaved work is still kept.
+///
+/// # The returned handle
+///
+/// `None` means no sweep ran: the event was not a `SessionEnd`, the payload
+/// resolved no store ([`store_for`]), or no directory in that store names this
+/// session. `Some` is the detached task, and awaiting it yields the
+/// [`SweepSummary`] after EVERY candidate has been decided.
+///
+/// That await is the completion signal the tests use. A negative test — "this
+/// tree must survive" — sampled the filesystem after a fixed 750 ms, and one
+/// `lsof` alone costs 0.56-0.67 s on an idle machine before the dirt gate and
+/// the removal even run. So the assertion fired while a real removal was still
+/// in flight and passed against a gate stack that had been deleted. Awaiting the
+/// handle removes the window rather than widening it.
 /// Test: `session_end_reaps_a_worktree_whose_agent_never_stopped`,
 /// `session_end_reaps_every_agent_of_the_ending_session`,
 /// `session_end_keeps_a_worktree_that_holds_unsaved_work`,
 /// `session_end_spares_another_sessions_agent`,
-/// `session_end_without_a_cwd_reaps_nothing`.
+/// `session_end_without_a_cwd_reaps_nothing`,
+/// `session_end_without_a_cwd_resolves_no_store`.
 pub fn spawn_on_session_end(
     state: &Arc<DaemonState>,
     session: SessionId,
     event: HookEvent,
     payload: &Value,
-) {
+) -> Option<tokio::task::JoinHandle<SweepSummary>> {
     if event != HookEvent::SessionEnd {
-        return;
+        return None;
     }
-    let Some(cwd) = payload.get("cwd").and_then(Value::as_str) else {
-        return;
-    };
-    let Some(root) = crate::core::harness_root::harness_root_for(Path::new(cwd)) else {
-        return;
-    };
-    let candidates = agent_worktrees_of(&root.join(".claude").join("worktrees"), session);
+    let candidates = agent_worktrees_of(&store_for(payload)?, session);
     if candidates.is_empty() {
-        return;
+        return None;
     }
 
     let state = Arc::clone(state);
-    tokio::spawn(async move {
-        let (mut reclaimed, mut kept) = (0usize, 0usize);
+    Some(tokio::spawn(async move {
+        let mut summary = SweepSummary::default();
         for (path, owner) in candidates {
             // Each candidate resolves its OWN `in_use` set, which excludes its
             // own delegation. These agents never reported a stop, so their
             // records are still live and a set computed once would name every
             // candidate as in use — the sweep would then reclaim nothing.
             match reap_and_record(&state, &owner.agent_id, path, Some(owner.delegation_id)).await {
-                ReapOutcome::Refused(_) => kept += 1,
-                _ => reclaimed += 1,
+                ReapOutcome::Removed => summary.removed += 1,
+                ReapOutcome::AlreadyGone => summary.already_gone += 1,
+                ReapOutcome::Refused(_) => summary.kept += 1,
             }
         }
+        let SweepSummary {
+            removed,
+            already_gone,
+            kept,
+        } = summary;
         tracing::info!(
             session = %session.0,
-            reclaimed,
+            removed,
+            already_gone,
             kept,
-            "agent-worktree reap: this session ended — reclaimed {reclaimed} of its agents' \
-             worktrees and kept {kept} (#4311)"
+            "agent-worktree reap: this session ended — removed {removed} of its agents' \
+             worktrees, found {already_gone} already gone and kept {kept} (#4311)"
         );
-    });
+        summary
+    }))
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/services/agent_worktree_reap.rs
+++ b/crates/trusty-mpm/src/daemon/services/agent_worktree_reap.rs
@@ -51,6 +51,19 @@
 //! back when the registry has nothing, which is the from-disk reconstruction
 //! ADR-0023 point 4 requires of an ownership record.
 //!
+//! # Two triggers, because one was not enough (#4311 follow-up)
+//!
+//! [`spawn_on_stop`] was the only caller of [`reap_worktree`], so the reap ran
+//! exactly once per agent and only when a `SubagentStop` actually arrived. Every
+//! other exit route — the harness session exiting or restarting under an
+//! in-flight agent, an interrupt, a `tm hook` POST that lost its 2 s budget —
+//! reached it never, and `prune_orphaned_worktrees` skips a `SentinelOwner::Agent`
+//! tree by design, so nothing else could reclaim it either. [`spawn_on_session_end`]
+//! is the second trigger: a session's end is proof its agents exited, and it
+//! runs the same gates against the same store.
+//!
+//! Stated gap: an agent interrupted inside a session that keeps running still
+//! reaches neither trigger, and its tree waits for that session to end.
 //! Test: the `#[cfg(test)]` suite in `agent_worktree_reap_tests.rs`.
 
 use std::path::{Path, PathBuf};
@@ -58,12 +71,13 @@ use std::sync::Arc;
 
 use serde_json::Value;
 
+use crate::core::agent::DelegationId;
 use crate::core::hook::HookEvent;
 use crate::core::session::SessionId;
 use crate::daemon::state::DaemonState;
 use crate::session_manager::worktree_liveness::process_holding;
 use crate::session_manager::worktree_ownership::{
-    SentinelOwner, find_agent_worktree, read_sentinel_owner,
+    AgentWorktreeOwner, SentinelOwner, find_agent_worktree, read_sentinel_owner,
 };
 use crate::session_manager::worktree_safety::{DirtyWorktreePolicy, dirt_blocks_removal};
 
@@ -401,29 +415,167 @@ pub fn spawn_on_stop(
 
     let state = Arc::clone(state);
     tokio::spawn(async move {
-        let in_use = paths_in_use(&state, &agent_id).await;
-        let removal_path = path.clone();
-        let reap_agent_id = agent_id.clone();
-        let outcome = tokio::task::spawn_blocking(move || {
-            reap_worktree(&removal_path, &reap_agent_id, &in_use)
-        })
-        .await
-        .unwrap_or_else(|e| ReapOutcome::Refused(format!("reap task panicked: {e}")));
-        match &outcome {
-            ReapOutcome::Removed | ReapOutcome::AlreadyGone => {
-                // `None` when the path came from disk rather than the registry
-                // — there is no in-memory record left to clear.
-                if let Some(id) = id {
-                    state.mutate_delegation(id, |d| d.worktree_path = None);
-                }
-            }
-            ReapOutcome::Refused(reason) => {
-                tracing::info!(
-                    path = %path.display(),
-                    "agent-worktree reap: keeping this worktree — {reason} (#4311)"
-                );
+        reap_and_record(&state, &agent_id, path, id).await;
+    });
+}
+
+/// Run the reap for one agent's worktree and record what happened (#4311).
+///
+/// Why a shared body: [`spawn_on_stop`] and [`spawn_on_session_end`] are two
+/// TRIGGERS for one decision. Two copies of the gate call, the registry
+/// clear and the refusal log would eventually disagree about what a reap does,
+/// and the trigger is the only thing that legitimately differs between them.
+/// What: resolves this agent's `in_use` set, runs [`reap_worktree`] on a
+/// blocking thread (it shells out to git and `lsof`), clears the delegation's
+/// `worktree_path` on a removal so nothing reads a path that no longer exists,
+/// and reports a refusal.
+///
+/// `id` is `None` when the path came from disk rather than the registry — there
+/// is no in-memory record to clear.
+///
+/// The refusal is `warn!` and not `info!` (#4311 follow-up): a refusal is the
+/// ONLY notice anyone gets that a tree was kept, and nothing retries it. On this
+/// machine 7 worktrees were refused as holding unsaved work, logged once at
+/// `info!`, and left on disk indefinitely with nothing surfacing them. A
+/// refusal is a tree that now needs a human, so it is logged as one.
+/// Test: `session_end_keeps_a_worktree_that_holds_unsaved_work`,
+/// `reap_removes_a_clean_pushed_worktree`.
+async fn reap_and_record(
+    state: &Arc<DaemonState>,
+    agent_id: &str,
+    path: PathBuf,
+    id: Option<DelegationId>,
+) -> ReapOutcome {
+    let in_use = paths_in_use(state, agent_id).await;
+    let removal_path = path.clone();
+    let reap_agent_id = agent_id.to_string();
+    let outcome =
+        tokio::task::spawn_blocking(move || reap_worktree(&removal_path, &reap_agent_id, &in_use))
+            .await
+            .unwrap_or_else(|e| ReapOutcome::Refused(format!("reap task panicked: {e}")));
+    match &outcome {
+        ReapOutcome::Removed | ReapOutcome::AlreadyGone => {
+            if let Some(id) = id {
+                state.mutate_delegation(id, |d| d.worktree_path = None);
             }
         }
+        ReapOutcome::Refused(reason) => {
+            tracing::warn!(
+                agent_id,
+                path = %path.display(),
+                "agent-worktree reap: keeping this worktree — {reason} (#4311)"
+            );
+        }
+    }
+    outcome
+}
+
+/// Every worktree in `store` whose sentinel names `session` as its parent.
+///
+/// Why the sentinel and not the delegation registry: the registry is a `DashMap`
+/// built empty at every boot, so after a restart it knows none of the trees this
+/// sweep exists to reclaim. The sentinel is the durable record ADR-0023 point 4
+/// requires, and `parent_session_id` is the field DOC-66 §5 defines as an agent
+/// worktree's parentage.
+/// What: reads each immediate child of `store` and keeps those whose sentinel is
+/// [`SentinelOwner::Agent`] with a matching `parent_session_id`. An unreadable
+/// store yields nothing, which reclaims nothing.
+/// Test: `session_end_spares_another_sessions_agent`,
+/// `session_end_reaps_every_agent_of_the_ending_session`.
+fn agent_worktrees_of(store: &Path, session: SessionId) -> Vec<(PathBuf, AgentWorktreeOwner)> {
+    let Ok(entries) = std::fs::read_dir(store) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|e| {
+            let path = e.path();
+            match read_sentinel_owner(&path) {
+                SentinelOwner::Agent(owner, _) if owner.parent_session_id == session => {
+                    Some((path, owner))
+                }
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+/// Reap the worktrees of every agent the session that just ended dispatched
+/// (#4311 follow-up).
+///
+/// Why: [`spawn_on_stop`] was the reap's ONLY trigger, and it fires only on a
+/// `SubagentStop` the daemon actually receives. An agent that ends any other way
+/// — the harness session it runs inside exits or restarts under it, a user
+/// interrupt, a `tm hook` POST that loses its 2 s budget — emits no stop, so the
+/// reap never ran and nothing recorded that it had not. `prune_orphaned_worktrees`
+/// skips `SentinelOwner::Agent` by design, so nothing else would ever reclaim
+/// the tree: the leak was permanent and, for this class, entirely silent. In
+/// this machine's daemon log, 54 registered agent worktrees produced 30
+/// removals; 17 of the 24 survivors carry no reap decision of any kind.
+///
+/// A leaked worktree is not only disk. The harness reassigns a stale worktree to
+/// a later agent along with the branch the previous one left checked out, which
+/// is how an unrelated commit reached an open PR's branch on 2026-08-17. That
+/// makes prompt reclamation a correctness property, not housekeeping.
+/// What: on `SessionEnd`, resolves the harness worktree store from the payload's
+/// `cwd` exactly as [`rebuild_from_disk`] does, then runs the UNCHANGED
+/// [`reap_worktree`] gate stack against every directory whose sentinel names
+/// this session as its parent, and reports the split.
+///
+/// # Why a `SessionEnd` is proof its agents exited
+///
+/// A subagent runs inside its parent Claude Code session's process and cannot
+/// outlive it. `SessionEnd` is Claude Code self-reporting that this conversation
+/// ended — the same signal #4337 already treats as unambiguous when it clears a
+/// stale `claude_session_id`. That is the strength of proof `SubagentStop`
+/// carries, applied to every child at once, so no gate is weakened to use it: a
+/// candidate still has to pass the sentinel, in-use, git-registry, dirt and
+/// process-liveness gates, and a tree holding unsaved work is still kept.
+/// Test: `session_end_reaps_a_worktree_whose_agent_never_stopped`,
+/// `session_end_reaps_every_agent_of_the_ending_session`,
+/// `session_end_keeps_a_worktree_that_holds_unsaved_work`,
+/// `session_end_spares_another_sessions_agent`,
+/// `session_end_without_a_cwd_reaps_nothing`.
+pub fn spawn_on_session_end(
+    state: &Arc<DaemonState>,
+    session: SessionId,
+    event: HookEvent,
+    payload: &Value,
+) {
+    if event != HookEvent::SessionEnd {
+        return;
+    }
+    let Some(cwd) = payload.get("cwd").and_then(Value::as_str) else {
+        return;
+    };
+    let Some(root) = crate::core::harness_root::harness_root_for(Path::new(cwd)) else {
+        return;
+    };
+    let candidates = agent_worktrees_of(&root.join(".claude").join("worktrees"), session);
+    if candidates.is_empty() {
+        return;
+    }
+
+    let state = Arc::clone(state);
+    tokio::spawn(async move {
+        let (mut reclaimed, mut kept) = (0usize, 0usize);
+        for (path, owner) in candidates {
+            // Each candidate resolves its OWN `in_use` set, which excludes its
+            // own delegation. These agents never reported a stop, so their
+            // records are still live and a set computed once would name every
+            // candidate as in use — the sweep would then reclaim nothing.
+            match reap_and_record(&state, &owner.agent_id, path, Some(owner.delegation_id)).await {
+                ReapOutcome::Refused(_) => kept += 1,
+                _ => reclaimed += 1,
+            }
+        }
+        tracing::info!(
+            session = %session.0,
+            reclaimed,
+            kept,
+            "agent-worktree reap: this session ended — reclaimed {reclaimed} of its agents' \
+             worktrees and kept {kept} (#4311)"
+        );
     });
 }
 

--- a/crates/trusty-mpm/src/daemon/services/agent_worktree_reap_tests.rs
+++ b/crates/trusty-mpm/src/daemon/services/agent_worktree_reap_tests.rs
@@ -283,12 +283,13 @@ fn hermetic() -> (
 #[tokio::test]
 async fn spawn_on_stop_ignores_a_non_stop_event() {
     let (state, _dir, session) = hermetic();
-    super::spawn_on_stop(
+    let started = super::spawn_on_stop(
         &state,
         session,
         HookEvent::PreToolUse,
         &serde_json::json!({ "agent_id": "a1", "cwd": "/nowhere" }),
     );
+    assert!(started.is_none(), "a non-stop event must start no reap");
     assert!(state.delegations_for(session).is_empty());
 }
 
@@ -301,19 +302,21 @@ async fn spawn_on_stop_ignores_a_non_stop_event() {
 #[tokio::test]
 async fn spawn_on_stop_ignores_a_payload_without_an_agent_id() {
     let (state, _dir, session) = hermetic();
-    super::spawn_on_stop(
+    let missing = super::spawn_on_stop(
         &state,
         session,
         HookEvent::SubagentStop,
         &serde_json::json!({ "cwd": "/nowhere" }),
     );
     // An empty-string id is equally indeterminate, not a match.
-    super::spawn_on_stop(
+    let empty = super::spawn_on_stop(
         &state,
         session,
         HookEvent::SubagentStop,
         &serde_json::json!({ "agent_id": "", "cwd": "/nowhere" }),
     );
+    assert!(missing.is_none(), "no agent_id must start no reap");
+    assert!(empty.is_none(), "an empty agent_id must start no reap");
     assert!(state.delegations_for(session).is_empty());
 }
 
@@ -414,14 +417,17 @@ async fn stop_reaps_a_worktree_the_registry_lost_to_a_restart() {
         "this fixture must hold no registration — that is what a restarted daemon looks like"
     );
 
-    super::spawn_on_stop(
+    let outcome = super::spawn_on_stop(
         &state,
         session,
         HookEvent::SubagentStop,
         &serde_json::json!({ "agent_id": "a601", "cwd": fx.repo.to_string_lossy() }),
-    );
-    await_gone(&wt).await;
+    )
+    .expect("the sentinel names a601, so a reap must start")
+    .await
+    .expect("the reap task must not panic");
 
+    assert_eq!(outcome, ReapOutcome::Removed);
     assert!(
         !wt.exists(),
         "the sentinel is the whole ownership record here; the reap must act on it"
@@ -441,15 +447,20 @@ async fn stop_ignores_a_sentinel_naming_a_different_agent() {
     std::fs::write(wt.join("work.txt"), "done\n").expect("write work");
     GitWorktreeFixture::commit_all_and_push(&wt, "agent work");
 
-    super::spawn_on_stop(
+    let started = super::spawn_on_stop(
         &state,
         session,
         HookEvent::SubagentStop,
         &serde_json::json!({ "agent_id": "a702", "cwd": fx.repo.to_string_lossy() }),
     );
-    // Give a wrong implementation the same window the correct one gets.
-    tokio::time::sleep(std::time::Duration::from_millis(750)).await;
 
+    // The same defect as the sweep's: a fixed sleep here sampled the filesystem
+    // at 750 ms while an `lsof`-gated removal lands at 1-3 s, so a wrong
+    // implementation looked correct. The absence of a task is the exact signal.
+    assert!(
+        started.is_none(),
+        "no sentinel names a702, so no reap task may start"
+    );
     assert!(
         wt.exists(),
         "another agent's worktree must never be reaped by this stop"
@@ -552,6 +563,9 @@ async fn session_end_reaps_every_agent_of_the_ending_session() {
 /// still refuse. A `SessionEnd` proves the agent exited; it proves nothing about
 /// whether its work was saved, and an uncommitted edit is the one thing this
 /// module must never destroy.
+///
+/// Delete gate 5 (`dirt_blocks_removal`) from `reap_worktree` and this goes red:
+/// the summary reports `removed: 1, kept: 0` and the directory is gone.
 #[tokio::test]
 async fn session_end_keeps_a_worktree_that_holds_unsaved_work() {
     let (state, _dir, session) = hermetic();
@@ -559,14 +573,23 @@ async fn session_end_keeps_a_worktree_that_holds_unsaved_work() {
     let wt = harness_worktree_under(&fx, "agent-dirty-at-exit", "a803", session);
     std::fs::write(wt.join("README.md"), "edited, never committed\n").expect("write edit");
 
-    deliver(
+    let swept = settle(super::spawn_on_session_end(
         &state,
         session,
         HookEvent::SessionEnd,
-        serde_json::json!({ "cwd": fx.repo.to_string_lossy() }),
-    );
-    await_settled().await;
+        &serde_json::json!({ "cwd": fx.repo.to_string_lossy() }),
+    ))
+    .await;
 
+    assert_eq!(
+        swept,
+        Some(super::SweepSummary {
+            removed: 0,
+            already_gone: 0,
+            kept: 1,
+        }),
+        "the dirt gate must keep this tree, and the summary must count it as kept"
+    );
     assert!(wt.exists(), "an uncommitted edit must survive its session");
 }
 
@@ -575,27 +598,56 @@ async fn session_end_keeps_a_worktree_that_holds_unsaved_work() {
 /// Why: the sweep's key is the sentinel's `parent_session_id`. Two PMs run
 /// against one project store on this machine, so a sweep keyed on the store
 /// alone would reclaim a live peer's tree the moment either session ended.
+///
+/// The control tree carries its weight: without it the ending session owns no
+/// candidate, the sweep never starts, and "the peer survived" would be true of
+/// an implementation that does nothing at all. With it the sweep provably runs
+/// and provably removes something, so the peer's survival is the filter doing
+/// its job. Delete `owner.parent_session_id == session` from
+/// `agent_worktrees_of` and this goes red: `removed` is 2 and the peer is gone.
 #[tokio::test]
 async fn session_end_spares_another_sessions_agent() {
     let (state, _dir, session) = hermetic();
     let other = crate::core::session::SessionId(uuid::Uuid::new_v4());
     let fx = GitWorktreeFixture::new();
-    let wt = harness_worktree_under(&fx, "agent-peer", "a804", other);
-    std::fs::write(wt.join("work.txt"), "done\n").expect("write work");
-    GitWorktreeFixture::commit_all_and_push(&wt, "agent work");
+    let peer = harness_worktree_under(&fx, "agent-peer", "a804", other);
+    std::fs::write(peer.join("work.txt"), "done\n").expect("write work");
+    GitWorktreeFixture::commit_all_and_push(&peer, "agent work");
+    let control = harness_worktree_under(&fx, "agent-mine", "a808", session);
+    std::fs::write(control.join("work.txt"), "done\n").expect("write work");
+    GitWorktreeFixture::commit_all_and_push(&control, "agent work");
 
-    deliver(
+    let swept = settle(super::spawn_on_session_end(
         &state,
         session,
         HookEvent::SessionEnd,
-        serde_json::json!({ "cwd": fx.repo.to_string_lossy() }),
-    );
-    await_settled().await;
+        &serde_json::json!({ "cwd": fx.repo.to_string_lossy() }),
+    ))
+    .await;
 
-    assert!(wt.exists(), "a peer session's agent worktree must survive");
+    assert_eq!(
+        swept,
+        Some(super::SweepSummary {
+            removed: 1,
+            already_gone: 0,
+            kept: 0,
+        }),
+        "only the ending session's own tree is a candidate"
+    );
+    assert!(
+        !control.exists(),
+        "the control must be gone, or this test proves nothing about the sweep having run"
+    );
+    assert!(
+        peer.exists(),
+        "a peer session's agent worktree must survive"
+    );
 }
 
 /// A `SessionEnd` with no `cwd` resolves no store and reclaims nothing.
+///
+/// Delete the `cwd` guard from `store_for` and this goes red at the `None`:
+/// a store resolves, so the sweep starts.
 #[tokio::test]
 async fn session_end_without_a_cwd_reaps_nothing() {
     let (state, _dir, session) = hermetic();
@@ -604,27 +656,69 @@ async fn session_end_without_a_cwd_reaps_nothing() {
     std::fs::write(wt.join("work.txt"), "done\n").expect("write work");
     GitWorktreeFixture::commit_all_and_push(&wt, "agent work");
 
-    deliver(
+    let swept = settle(super::spawn_on_session_end(
         &state,
         session,
         HookEvent::SessionEnd,
-        serde_json::json!({}),
-    );
-    await_settled().await;
+        &serde_json::json!({}),
+    ))
+    .await;
 
+    assert_eq!(swept, None, "an unresolvable store must start no sweep");
     assert!(wt.exists(), "an unresolvable store must reclaim nothing");
 }
 
-/// Give a detached reap task the same window a correct one gets, so a negative
-/// assertion is not merely racing it.
-async fn await_settled() {
-    tokio::time::sleep(std::time::Duration::from_millis(750)).await;
+/// The `cwd` guard itself, asserted on the resolution rather than on a survivor.
+///
+/// Why both this and the test above: delete the guard and the natural fallback
+/// is the process's own directory, which resolves to the REAL harness store on
+/// this machine. That store holds no sentinel naming a random test session, so
+/// the sweep finds no candidate and the survivor test above still passes — while
+/// the daemon has in fact read the live worktree store off a payload that named
+/// no directory at all. Only the resolution catches that.
+#[test]
+fn session_end_without_a_cwd_resolves_no_store() {
+    assert_eq!(
+        super::store_for(&serde_json::json!({})),
+        None,
+        "a payload with no cwd must resolve no store"
+    );
+    assert_eq!(
+        super::store_for(&serde_json::json!({ "cwd": 7 })),
+        None,
+        "a non-string cwd is not a path"
+    );
+}
+
+/// Await the sweep itself, so a negative assertion runs AFTER the decision.
+///
+/// Why this replaced a fixed 750 ms sleep: that window was unreachable. Gate 6
+/// (`process_holding`) shells out to `lsof`, measured at 0.56-0.67 s on an idle
+/// machine, and it runs after a `git rev-parse` and the dirt gate's several git
+/// subprocesses and before the `git worktree remove` itself. A real removal
+/// lands at roughly 1-3 s idle and later under load, so every "this tree must
+/// survive" assertion sampled the filesystem while the removal was still in
+/// flight — and passed with the gate it existed to protect deleted. Awaiting the
+/// sweep's own handle removes the window instead of widening it.
+///
+/// `None` is not a failure: it is [`super::spawn_on_session_end`] reporting that
+/// no sweep ran at all, which for two of the tests below is the whole point.
+async fn settle(
+    handle: Option<tokio::task::JoinHandle<super::SweepSummary>>,
+) -> Option<super::SweepSummary> {
+    match handle {
+        Some(h) => Some(h.await.expect("the sweep task must not panic")),
+        None => None,
+    }
 }
 
 /// Poll until `path` is gone, or fail with what is still there.
 ///
-/// Why: `spawn_on_stop` detaches the removal onto a task, so the assertion has
-/// to wait on the condition rather than on a fixed sleep.
+/// Why: the two tests that still use this go through `HookService::process`,
+/// which drops the sweep's handle — that is the point, since the defect was that
+/// the pipeline reached no reap at all. With no handle to await, a POSITIVE
+/// assertion has to poll the condition. The negative tests do have a handle and
+/// await it instead; polling cannot prove a removal that must never happen.
 ///
 /// The budget is 60 s and not the 10 s it started at. One reap shells out to
 /// `git status`, `git worktree remove` and a system-wide `lsof` that costs about

--- a/crates/trusty-mpm/src/daemon/services/agent_worktree_reap_tests.rs
+++ b/crates/trusty-mpm/src/daemon/services/agent_worktree_reap_tests.rs
@@ -41,15 +41,37 @@ fn harness_worktree_for(fx: &GitWorktreeFixture, name: &str, agent_id: &str) -> 
 
 /// Stamp `path`'s ownership sentinel as belonging to `agent_id`.
 fn attribute(path: &std::path::Path, agent_id: &str) {
+    attribute_to(path, agent_id, crate::core::session::SessionId::new());
+}
+
+/// [`attribute`], naming `parent` as the dispatching session.
+///
+/// Why a separate helper: the `SessionEnd` sweep resolves candidates by
+/// `parent_session_id`, so a fixture stamped with a random one is invisible to
+/// it and would exercise the "not my agent" arm instead of the gate under test.
+fn attribute_to(path: &std::path::Path, agent_id: &str, parent: crate::core::session::SessionId) {
     write_agent_sentinel(
         path,
         crate::session_manager::worktree_ownership::AgentWorktreeOwner {
             agent_id: agent_id.to_string(),
             delegation_id: crate::core::agent::DelegationId(uuid::Uuid::new_v4()),
-            parent_session_id: crate::core::session::SessionId::new(),
+            parent_session_id: parent,
         },
     )
     .expect("write agent sentinel");
+}
+
+/// [`harness_worktree_for`], attributed to `agent_id` under parent `parent`.
+fn harness_worktree_under(
+    fx: &GitWorktreeFixture,
+    name: &str,
+    agent_id: &str,
+    parent: crate::core::session::SessionId,
+) -> PathBuf {
+    let base = fx.repo.join(".claude").join("worktrees");
+    let wt = fx.add_worktree_at(&base, name);
+    attribute_to(&wt, agent_id, parent);
+    wt
 }
 
 /// #4311 REGRESSION: a finished agent's clean, fully-pushed worktree is removed.
@@ -432,6 +454,171 @@ async fn stop_ignores_a_sentinel_naming_a_different_agent() {
         wt.exists(),
         "another agent's worktree must never be reaped by this stop"
     );
+}
+
+// ── the session-end trigger (#4311 follow-up) ───────────────────────────────
+
+/// Deliver `event` through the real hook pipeline, as the daemon does.
+///
+/// Why the pipeline and not `spawn_on_session_end` directly: the defect was that
+/// no trigger reached the reap at all, so a test calling the reap by hand would
+/// prove the gate stack and skip the wiring that was actually missing.
+fn deliver(
+    state: &std::sync::Arc<crate::daemon::state::DaemonState>,
+    session: crate::core::session::SessionId,
+    event: HookEvent,
+    payload: serde_json::Value,
+) {
+    crate::daemon::services::hook_service::HookService::new(std::sync::Arc::clone(state))
+        .process(session, event, payload);
+}
+
+/// REGRESSION: a `SessionEnd` reaps the worktree of an agent whose
+/// `SubagentStop` never arrived.
+///
+/// Why this test and not a happy-path one: `spawn_on_stop` was the reap's ONLY
+/// trigger, so every exit route that emits no `SubagentStop` — the harness
+/// session exiting or restarting under an in-flight agent, an interrupt, a
+/// `tm hook` POST that lost its 2 s budget — left the tree registered, owned,
+/// and unreclaimable. `prune_orphaned_worktrees` skips `SentinelOwner::Agent`
+/// by design (#4311), so nothing else would ever pick it up: the leak was
+/// permanent and, for this class, entirely unlogged.
+///
+/// The fixture delivers NO stop for `a801`. Against the pre-fix commit the
+/// `SessionEnd` reaches `HookService::process`, which routes it to the overseer,
+/// the idle nudge, the delegation tracker and the ring buffer — none of which
+/// look at worktrees — and `await_gone` panics with the directory still there.
+#[tokio::test]
+async fn session_end_reaps_a_worktree_whose_agent_never_stopped() {
+    let (state, _dir, session) = hermetic();
+    let fx = GitWorktreeFixture::new();
+    let wt = harness_worktree_under(&fx, "agent-abandoned", "a801", session);
+    std::fs::write(wt.join("work.txt"), "done\n").expect("write work");
+    GitWorktreeFixture::commit_all_and_push(&wt, "agent work");
+
+    deliver(
+        &state,
+        session,
+        HookEvent::SessionEnd,
+        serde_json::json!({ "cwd": fx.repo.to_string_lossy() }),
+    );
+
+    await_gone(&wt).await;
+}
+
+/// Every agent of the ending session is reclaimed, not just the first.
+///
+/// Why: the sweep resolves each candidate's own `in_use` set, and each of these
+/// trees is registered to a live-looking delegation of the SAME session. An
+/// implementation that computed `paths_in_use` once, or that failed to exclude
+/// each candidate's own registration, would find every tree "still in use" and
+/// reclaim none.
+#[tokio::test]
+async fn session_end_reaps_every_agent_of_the_ending_session() {
+    let (state, _dir, session) = hermetic();
+    let fx = GitWorktreeFixture::new();
+    let mut trees = Vec::new();
+    for (name, agent) in [("agent-one", "a901"), ("agent-two", "a902")] {
+        let wt = harness_worktree_under(&fx, name, agent, session);
+        std::fs::write(wt.join("work.txt"), "done\n").expect("write work");
+        GitWorktreeFixture::commit_all_and_push(&wt, "agent work");
+        let mut d = crate::core::agent::Delegation::observed(
+            session,
+            "rust-engineer",
+            "work",
+            Some(format!("toolu_{agent}")),
+        );
+        d.agent_id = Some(agent.to_string());
+        d.worktree_path = Some(wt.clone());
+        state.upsert_delegation(d);
+        trees.push(wt);
+    }
+
+    deliver(
+        &state,
+        session,
+        HookEvent::SessionEnd,
+        serde_json::json!({ "cwd": fx.repo.to_string_lossy() }),
+    );
+
+    for wt in &trees {
+        await_gone(wt).await;
+    }
+}
+
+/// A tree holding unsaved work survives the session's end.
+///
+/// Why: the new trigger reuses `reap_worktree` unchanged, so the dirt gate must
+/// still refuse. A `SessionEnd` proves the agent exited; it proves nothing about
+/// whether its work was saved, and an uncommitted edit is the one thing this
+/// module must never destroy.
+#[tokio::test]
+async fn session_end_keeps_a_worktree_that_holds_unsaved_work() {
+    let (state, _dir, session) = hermetic();
+    let fx = GitWorktreeFixture::new();
+    let wt = harness_worktree_under(&fx, "agent-dirty-at-exit", "a803", session);
+    std::fs::write(wt.join("README.md"), "edited, never committed\n").expect("write edit");
+
+    deliver(
+        &state,
+        session,
+        HookEvent::SessionEnd,
+        serde_json::json!({ "cwd": fx.repo.to_string_lossy() }),
+    );
+    await_settled().await;
+
+    assert!(wt.exists(), "an uncommitted edit must survive its session");
+}
+
+/// Another session's agent is untouched by this session's end.
+///
+/// Why: the sweep's key is the sentinel's `parent_session_id`. Two PMs run
+/// against one project store on this machine, so a sweep keyed on the store
+/// alone would reclaim a live peer's tree the moment either session ended.
+#[tokio::test]
+async fn session_end_spares_another_sessions_agent() {
+    let (state, _dir, session) = hermetic();
+    let other = crate::core::session::SessionId(uuid::Uuid::new_v4());
+    let fx = GitWorktreeFixture::new();
+    let wt = harness_worktree_under(&fx, "agent-peer", "a804", other);
+    std::fs::write(wt.join("work.txt"), "done\n").expect("write work");
+    GitWorktreeFixture::commit_all_and_push(&wt, "agent work");
+
+    deliver(
+        &state,
+        session,
+        HookEvent::SessionEnd,
+        serde_json::json!({ "cwd": fx.repo.to_string_lossy() }),
+    );
+    await_settled().await;
+
+    assert!(wt.exists(), "a peer session's agent worktree must survive");
+}
+
+/// A `SessionEnd` with no `cwd` resolves no store and reclaims nothing.
+#[tokio::test]
+async fn session_end_without_a_cwd_reaps_nothing() {
+    let (state, _dir, session) = hermetic();
+    let fx = GitWorktreeFixture::new();
+    let wt = harness_worktree_under(&fx, "agent-no-cwd", "a805", session);
+    std::fs::write(wt.join("work.txt"), "done\n").expect("write work");
+    GitWorktreeFixture::commit_all_and_push(&wt, "agent work");
+
+    deliver(
+        &state,
+        session,
+        HookEvent::SessionEnd,
+        serde_json::json!({}),
+    );
+    await_settled().await;
+
+    assert!(wt.exists(), "an unresolvable store must reclaim nothing");
+}
+
+/// Give a detached reap task the same window a correct one gets, so a negative
+/// assertion is not merely racing it.
+async fn await_settled() {
+    tokio::time::sleep(std::time::Duration::from_millis(750)).await;
 }
 
 /// Poll until `path` is gone, or fail with what is still there.

--- a/crates/trusty-mpm/src/daemon/services/agent_worktree_reap_tests.rs
+++ b/crates/trusty-mpm/src/daemon/services/agent_worktree_reap_tests.rs
@@ -625,8 +625,17 @@ async fn await_settled() {
 ///
 /// Why: `spawn_on_stop` detaches the removal onto a task, so the assertion has
 /// to wait on the condition rather than on a fixed sleep.
+///
+/// The budget is 60 s and not the 10 s it started at. One reap shells out to
+/// `git status`, `git worktree remove` and a system-wide `lsof` that costs about
+/// a second on an idle machine; inside a 5000-test parallel run competing with
+/// other builds it costs far more. At 10 s these tests passed alone and failed
+/// in the full suite — a timing artifact, not a reap that declined. A correct
+/// implementation still finishes in well under a second, so a wider budget
+/// costs a passing run nothing and only changes how long a genuine failure
+/// takes to report.
 async fn await_gone(path: &std::path::Path) {
-    for _ in 0..100 {
+    for _ in 0..600 {
         if !path.exists() {
             return;
         }

--- a/crates/trusty-mpm/src/daemon/services/hook_service.rs
+++ b/crates/trusty-mpm/src/daemon/services/hook_service.rs
@@ -270,6 +270,19 @@ impl HookService {
             &payload,
         );
 
+        // 1e (#4311 follow-up): the SECOND trigger. `SubagentStop` was the only
+        // one, so an agent killed by its session exiting or restarting emitted
+        // no stop and its worktree leaked permanently — the orphan sweep skips
+        // agent-owned trees by design. A `SessionEnd` proves every agent that
+        // session dispatched has exited, so it reclaims them through the same
+        // gate stack. Detached like 1b and 1d, and cannot change the verdict.
+        crate::daemon::services::agent_worktree_reap::spawn_on_session_end(
+            &self.state,
+            session,
+            event,
+            &payload,
+        );
+
         // 2. PostToolUse: compress tool output before it enters the ring buffer.
         if event == HookEvent::PostToolUse {
             let tool_name = payload

--- a/crates/trusty-mpm/src/daemon/services/hook_service.rs
+++ b/crates/trusty-mpm/src/daemon/services/hook_service.rs
@@ -263,12 +263,14 @@ impl HookService {
         // no-ops for every event other than `SubagentStop`. Like 1b it spawns a
         // detached task off this synchronous method — the reap runs git — and
         // like 1b it cannot change the verdict below.
-        crate::daemon::services::agent_worktree_reap::spawn_on_stop(
+        // The returned `JoinHandle` is the tests' completion signal; nothing on
+        // this hot path may await it, so it is dropped and the task detaches.
+        drop(crate::daemon::services::agent_worktree_reap::spawn_on_stop(
             &self.state,
             session,
             event,
             &payload,
-        );
+        ));
 
         // 1e (#4311 follow-up): the SECOND trigger. `SubagentStop` was the only
         // one, so an agent killed by its session exiting or restarting emitted
@@ -276,11 +278,13 @@ impl HookService {
         // agent-owned trees by design. A `SessionEnd` proves every agent that
         // session dispatched has exited, so it reclaims them through the same
         // gate stack. Detached like 1b and 1d, and cannot change the verdict.
-        crate::daemon::services::agent_worktree_reap::spawn_on_session_end(
-            &self.state,
-            session,
-            event,
-            &payload,
+        drop(
+            crate::daemon::services::agent_worktree_reap::spawn_on_session_end(
+                &self.state,
+                session,
+                event,
+                &payload,
+            ),
         );
 
         // 2. PostToolUse: compress tool output before it enters the ring buffer.


### PR DESCRIPTION
## What

`spawn_on_stop` (`agent_worktree_reap.rs:371-382` pre-fix) was the only caller of
`reap_worktree`, so the reap had **one trigger and one attempt per agent**. Every
exit route that delivers no `SubagentStop` reached it never. `prune_orphaned_worktrees`
(`prune.rs:817-839`) skips `SentinelOwner::Agent` by design, so nothing else could
reclaim the tree — the leak was permanent, and for the largest class entirely unlogged.

`spawn_on_session_end` is a second trigger. A subagent runs inside its parent Claude
Code session's process and cannot outlive it, so `SessionEnd` is proof every agent
that session dispatched has exited — the same signal #4337 already treats as
unambiguous. It resolves the store from the payload's `cwd` exactly as
`rebuild_from_disk` does and runs the **unchanged** gate stack against every tree
whose sentinel names that session as parent.

No gate is weakened. A tree holding unsaved work, one a live process stands in, one
git does not claim, and one another session's agent owns are all still kept.

## Evidence

From `~/.trusty-mpm/daemon.log` on the reporting machine: 54 distinct agent worktrees
registered, 30 reaped, **24 never reaped**. 17 of those 24 carry no reap decision line
of any kind; the other 7 were refused once as holding unsaved work and never retried.

A leaked worktree is not only disk. A stale tree gets reassigned to a later agent
carrying the branch the previous one left checked out, which is how an unrelated
commit reached open PR #5831. That makes this correctness, not housekeeping.

## Observability

A refusal moves from `info!` to `warn!`, and each session end reports how many trees
it reclaimed and how many it kept. A tree the gates decline to clear is now visible
rather than silent.

## Regression test, failing pre-fix

Both positive tests go through the real `HookService::process` pipeline, so they
compile against `origin/main` and fail on behaviour rather than on a missing symbol.

```
$ git checkout origin/main -- .../agent_worktree_reap.rs .../hook_service.rs
$ cargo test -p trusty-mpm --lib session_end
test ...::session_end_reaps_a_worktree_whose_agent_never_stopped ... FAILED
test ...::session_end_reaps_every_agent_of_the_ending_session ... FAILED

---- ...::session_end_reaps_a_worktree_whose_agent_never_stopped stdout ----
panicked at crates/trusty-mpm/src/daemon/services/agent_worktree_reap_tests.rs:644:5:
/private/var/folders/.../repos/owner/repo/.claude/worktrees/agent-abandoned was never removed

---- ...::session_end_reaps_every_agent_of_the_ending_session stdout ----
panicked at crates/trusty-mpm/src/daemon/services/agent_worktree_reap_tests.rs:644:5:
/private/var/folders/.../repos/owner/repo/.claude/worktrees/agent-one was never removed

test result: FAILED. 12 passed; 2 failed; 0 ignored; 0 measured; 5046 filtered out; finished in 63.46s
```

The three negative tests (`keeps_a_worktree_that_holds_unsaved_work`,
`spares_another_sessions_agent`, `without_a_cwd_reaps_nothing`) pass both before and
after, which is correct — they guard against over-reaping, so the fix must not move them.

## Test ladder — rung 5 (process lifecycle)

```
$ cargo fmt --all --check
FMT_EXIT=0

$ cargo clippy -p trusty-mpm --all-targets -- -D warnings
CLIPPY_EXIT=0

$ cargo test -p trusty-mpm
test result: ok. 5053 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 212.23s
TEST_EXIT=0

$ bash scripts/check_line_cap.sh
line-cap: measured 4031 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
```

Concurrency and failure-path coverage: `session_end_reaps_every_agent_of_the_ending_session`
(two agents of one session, each resolving its own in-use set),
`session_end_keeps_a_worktree_that_holds_unsaved_work` (dirt gate),
`session_end_spares_another_sessions_agent` (parent-session key),
`session_end_without_a_cwd_reaps_nothing` (unresolvable store).

## Known gaps, stated

- An agent interrupted inside a session that keeps running still reaches neither
  trigger; its tree waits for that session to end.
- Separately observed and **not addressed here**: the reap treats turn-end as
  work-end. Agent `a6e5aeba6b90562a0` registered at 01:22:53 and its tree was removed
  at 01:33:30 by this module while a background build was running in it. That is the
  opposite failure and needs its own fix and its own regression test — conflating the
  two would make both unreviewable. Worth its own issue.

Refs #4311

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
