### PR TITLE
feat(trusty-audit): checkpoint the sweep per repository and resume from it (#5494)

### DIFF
--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -36,7 +36,9 @@ trusty-audit repos              # repositories this engagement is configured to 
 trusty-audit tools              # which pinned tools are installed, at which versions
 trusty-audit install            # download and verify the pinned tools
 trusty-audit manifest           # engagement metadata from the companion manifest.toml
-trusty-audit run                # run `tga audit` over the selected repositories
+trusty-audit run                # run `tga audit` over the selected repositories,
+                                #   resuming an interrupted sweep
+trusty-audit run --fresh        # audit every selected repository again
 trusty-audit package            # assemble the deliverable zip to send back
 ```
 
@@ -79,6 +81,35 @@ sanitizing alone is not injective — `acme/api` and `acme-api` would otherwise
 share an output directory and a log file, and the second child would overwrite
 the first's evidence. Each child writes to `out/<stem>/`, `logs/<stem>.log`, and
 `extract/<stem>.db`. The results land in `state/run-progress.toml`.
+
+**An interrupted run is resumed, not repeated.** `state/run-progress.toml` is
+written after every repository — through a temporary file and a rename, so a
+`kill -9` mid-write leaves either the previous whole record or the new one,
+never a prefix. Re-run `trusty-audit run` and it picks up where it stopped: a
+repository the record calls audited is carried over and printed as `resumed`, a
+repository it calls FAILED is retried, and the summary separates the two. A
+failure is usually the transient thing you re-ran to clear, so skipping it would
+make the re-run a no-op reporting the same failure forever.
+
+Being carried over is decided against the disk, not against the record alone.
+The recorded output must still exist and still pass the same verification that
+accepted it the first time, and the current selection must still put that
+repository at the same `out/<stem>/` — reordering the selection changes the stem,
+so a moved repository is audited again rather than credited with a directory this
+run never wrote. Every re-collection states its reason. A record that exists but
+cannot be parsed is a refusal, not an empty slate: starting over silently would
+redo hours you were told were saved.
+
+`trusty-audit run --fresh` ignores the record and audits everything again.
+Reach for it when the recorded outputs are stale rather than missing — you
+re-cloned the repositories, or changed the config in a way that should reach work
+already done. It is the expensive direction, which is why it has to be asked for
+by name.
+
+`trusty-audit package` refuses a sweep that did not finish. The record carries a
+completion flag, so a checkpoint left behind by a run that died is not mistaken
+for a short run that succeeded, and a partial engagement is not sent as a whole
+one. The remedy it names is the resume.
 
 **A zero exit from `tga audit` is not proof anything was assessed.** Its own
 contract is to exit 0 whenever the sweep completed, failed stages included — so
@@ -131,7 +162,7 @@ Everything this client writes lives under one root. The default is
 | `tools/` | pinned `tga` / `trusty-analyze` / `trusty-review` binaries |
 | `repos/` | **clones of your repositories — your source code** |
 | `extract/` | the tga extract database, derived from those clones |
-| `state/` | repository selection and run progress |
+| `state/` | repository selection, tool versions, and the run checkpoint |
 | `out/` | the deliverable to return: report and `manifest.toml` |
 | `logs/` | output from the tools this client runs |
 
@@ -139,6 +170,8 @@ Everything this client writes lives under one root. The default is
 Nothing is written outside the root — that is a tested property
 (`workdir::layout_tests::every_layout_path_is_inside_the_root`), not a claim.
 Deleting mid-run loses the clones and the run progress; nothing else is affected.
+Deleting only `state/run-progress.toml` throws away the resume — the next
+`trusty-audit run` re-collects every selected repository from scratch.
 
 **Open questions, recorded rather than resolved** (#5502): whether the root
 should sit beside the unzipped package (today's default) or under the user's

--- a/crates/trusty-audit/changelog.d/5494-resumable-collection-runs.md
+++ b/crates/trusty-audit/changelog.d/5494-resumable-collection-runs.md
@@ -1,0 +1,25 @@
+Added
+
+- `trusty-audit run` resumes an interrupted sweep instead of repeating it.
+  `state/run-progress.toml` is now written after every repository rather than
+  once at the end, so a crash, a timeout or a Ctrl-C costs the repositories
+  still to come and none of the ones already audited
+  ([#5494](https://github.com/bobmatnyc/trusty-tools/issues/5494))
+- Each carried-over repository is named in the run's output as `resumed`, and
+  the summary separates what an earlier run audited from what ran now. A
+  repository being re-collected states why — its output was deleted, the
+  earlier run recorded it as failed, or `--fresh` was asked for
+  ([#5494](https://github.com/bobmatnyc/trusty-tools/issues/5494))
+- `trusty-audit run --fresh` audits every selected repository again, ignoring
+  the record. Reach for it when the recorded outputs are stale rather than
+  missing — re-cloned repositories, or a config change that should reach work
+  already done ([#5494](https://github.com/bobmatnyc/trusty-tools/issues/5494))
+- A repository the record calls audited is carried over only if its output is
+  still on disk and still passes the same verification that accepted it the
+  first time, and only if the current selection puts it at the same output
+  path. Anything else is audited again
+  ([#5494](https://github.com/bobmatnyc/trusty-tools/issues/5494))
+- `trusty-audit package` refuses a sweep that did not finish, naming the count
+  recorded so far and pointing at the resume. Packaging one would have sent a
+  partial engagement as a whole one
+  ([#5494](https://github.com/bobmatnyc/trusty-tools/issues/5494))

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -20,7 +20,7 @@ use clap::{Parser, Subcommand};
 
 use crate::clone::{CloneOptions, CloneState};
 use crate::registry::TargetKind;
-use crate::run::{RepoResult, RunStatus};
+use crate::run::{RepoResult, RunOptions, RunStatus};
 use crate::session::{Command, NextStep, Outcome};
 
 /// The auditor client's command line.
@@ -113,7 +113,19 @@ pub enum Verb {
         target: String,
     },
     /// Run the audit sweep over the selected repositories.
-    Run,
+    ///
+    /// A repository an earlier run already audited is skipped, so an
+    /// interrupted sweep is resumed rather than repeated. A repository the
+    /// earlier run recorded as FAILED is retried.
+    Run {
+        /// Audit every selected repository again, ignoring recorded progress.
+        ///
+        /// Reach for this when the recorded outputs are stale rather than
+        /// missing — re-cloned repositories, or a config change that should
+        /// reach work already done. Hours-long: it re-collects everything.
+        #[arg(long)]
+        fresh: bool,
+    },
     /// Assemble the unencrypted deliverable zip to send back.
     Package {
         /// Where to write the zip (default: <work-dir>/audit-return-package.zip).
@@ -207,7 +219,9 @@ impl Cli {
             Some(Verb::Remove { target }) => Command::RemoveTarget {
                 spec: target.clone(),
             },
-            Some(Verb::Run) => Command::Run,
+            // #5494: resume is the default and re-collection is the opt-in,
+            // because the expensive direction is the one to ask for by name.
+            Some(Verb::Run { fresh }) => Command::Run(RunOptions { fresh: *fresh }),
             Some(Verb::Package { out }) => Command::Package {
                 destination: out.clone(),
             },
@@ -384,6 +398,14 @@ pub fn render(outcome: &Outcome) -> String {
             let mut out = String::new();
             for run in &report.repos {
                 match &run.result {
+                    // #5494: a repository this run carried over from an earlier
+                    // one reads differently from one it audited. Silent
+                    // skipping is the defect the resume path exists not to be.
+                    RepoResult::Succeeded if run.resumed => out.push_str(&format!(
+                        "resumed {:<24} {}\n",
+                        run.repo.name,
+                        run.output.display()
+                    )),
                     RepoResult::Succeeded => out.push_str(&format!(
                         "ok      {:<24} {}\n",
                         run.repo.name,
@@ -402,6 +424,17 @@ pub fn render(outcome: &Outcome) -> String {
                 }
             }
             let audited = report.repos.len() - report.failures().count();
+            // #5494: a run that audited nothing because everything was already
+            // done is a legitimate outcome, and it has to say so — otherwise
+            // "Audited 6 repositories" over a four-second run reads as a bug.
+            let resumed = report.resumed().count();
+            if resumed > 0 {
+                out.push_str(&format!(
+                    "\nResumed {} from an earlier run; {} audited now.\n",
+                    count_of(resumed, "repository", "repositories"),
+                    audited - resumed
+                ));
+            }
             out.push_str(&match report.status {
                 RunStatus::AllSucceeded => format!(
                     "\nAudited {}.\n",
@@ -622,7 +655,7 @@ mod cli_tests {
             } => vec!["taudit", "add", "board", "jira:ACME"],
             Command::ListTargets => vec!["taudit", "targets"],
             Command::RemoveTarget { .. } => vec!["taudit", "remove", "acme/api"],
-            Command::Run => vec!["taudit", "run"],
+            Command::Run(_) => vec!["taudit", "run"],
             Command::Package { .. } => vec!["taudit", "package"],
         }
     }
@@ -656,7 +689,7 @@ mod cli_tests {
             Command::RemoveTarget {
                 spec: "acme/api".to_owned(),
             },
-            Command::Run,
+            Command::Run(RunOptions::default()),
             Command::Package { destination: None },
         ]
     }
@@ -673,6 +706,23 @@ mod cli_tests {
                 "{argv:?} did not route to {command:?}"
             );
         }
+    }
+
+    /// #5494: resume is what a bare `run` does, and re-collection is the thing
+    /// asked for by name — an operator who types `run` after a crash must get
+    /// the cheap direction, and the expensive one must be impossible to reach
+    /// by accident.
+    #[test]
+    fn run_resumes_by_default_and_re_collects_only_when_asked() {
+        let plain = Cli::try_parse_from(["taudit", "run"]).expect("run parses");
+        assert_eq!(
+            plain.to_command(),
+            Command::Run(RunOptions { fresh: false }),
+            "a bare `run` must resume"
+        );
+
+        let fresh = Cli::try_parse_from(["taudit", "run", "--fresh"]).expect("--fresh parses");
+        assert_eq!(fresh.to_command(), Command::Run(RunOptions { fresh: true }));
     }
 
     #[test]
@@ -966,6 +1016,7 @@ mod cli_tests {
             output: PathBuf::from("/work/out/00-acme-api"),
             log: PathBuf::from("/work/logs/00-acme-api.log"),
             gaps: vec!["Collection stage `jira sync` did not complete.".to_owned()],
+            resumed: false,
             result,
         };
         let ok = run(RepoResult::Succeeded);
@@ -996,6 +1047,44 @@ mod cli_tests {
             "{}",
             render(&total)
         );
+    }
+
+    /// #5494: silent skipping is the defect. A resumed sweep finishes in
+    /// seconds, and without a word about it that reads as a run that did
+    /// nothing — so each carried-over repository is marked in its own line and
+    /// the summary separates what was carried over from what ran now.
+    #[test]
+    fn a_resumed_sweep_says_what_it_carried_over_and_what_it_audited() {
+        use crate::run::{RepoRun, RunReport, SelectedRepo};
+
+        let repo = |name: &str, index: usize, resumed| RepoRun {
+            repo: SelectedRepo {
+                name: name.to_owned(),
+                path: PathBuf::from(format!("repos/{name}")),
+            },
+            output: PathBuf::from(format!("/work/out/0{index}-{name}")),
+            log: PathBuf::from(format!("/work/logs/0{index}-{name}.log")),
+            gaps: Vec::new(),
+            resumed,
+            result: RepoResult::Succeeded,
+        };
+        let outcome = Outcome::Run(RunReport::of(vec![
+            repo("acme-api", 0, true),
+            repo("acme-web", 1, false),
+        ]));
+
+        let text = render(&outcome);
+        assert!(text.contains("resumed acme-api"), "{text}");
+        assert!(text.contains("ok      acme-web"), "{text}");
+        assert!(
+            text.contains("Resumed 1 repository from an earlier run; 1 audited now."),
+            "{text}"
+        );
+        assert_eq!(exit_code(&outcome), 0);
+
+        // A sweep with nothing to carry over says nothing about resuming.
+        let plain = Outcome::Run(RunReport::of(vec![repo("acme-web", 1, false)]));
+        assert!(!render(&plain).contains("Resumed"), "{}", render(&plain));
     }
 
     /// #5499 closure condition 3: the path has to be findable in the output,

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -737,6 +737,7 @@ trusty-review = "0.15.1"
             output,
             log: work.path(Area::Logs).join(format!("{stem}.log")),
             gaps: Vec::new(),
+            resumed: false,
             result: RepoResult::Succeeded,
         }
     }
@@ -754,6 +755,7 @@ trusty-review = "0.15.1"
                 output: work.path(Area::Output).join(stem),
                 log: work.path(Area::Logs).join(format!("{stem}.log")),
                 gaps: Vec::new(),
+                resumed: false,
                 result: RepoResult::Succeeded,
             }
         }

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -34,9 +34,12 @@
 //!   despite a write failure. A caller of this module cannot report success
 //!   without having looked at the status.
 //!
-//! The run-progress record is written LAST, after every child has finished, and
-//! a failure to write it fails the whole call — a record that cannot be written
-//! must not leave the client claiming a run it cannot describe.
+//! The run-progress record is written after EVERY child has finished, not once
+//! at the end (#5494), and a failure to write it fails the whole call — a
+//! record that cannot be written must not leave the client claiming a run it
+//! cannot describe. That checkpoint is also what makes the sweep re-entrant:
+//! see [`checkpoint`] for the resume rules and for why the unit is a repository
+//! rather than a tga stage.
 //!
 //! ## The credential
 //!
@@ -61,8 +64,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::{EngagementConfig, ToolPins};
 use crate::error::AuditError;
 use crate::inference;
-use crate::manifest::AuditManifest;
-use crate::progress::{Operation, Progress, UnitOutcome};
+use crate::progress::{Operation, Progress, StageEvent, StageState, UnitOutcome};
 use crate::relay::tee_and_relay;
 use crate::tools::{self, RequiredTool};
 use crate::workdir::{Area, WorkDir};
@@ -73,10 +75,20 @@ use crate::workdir::{Area, WorkDir};
 // them.
 mod selection;
 
-pub use selection::{SELECTION_FILE, SelectedRepo, load_selection, save_selection, selection_path};
+// #5494: the checkpoint and its resume rules are one subject and they are not
+// this file's — `run.rs` drives children, `checkpoint.rs` decides what a re-run
+// may skip.
+pub mod checkpoint;
 
-/// File under `state/` recording what the last sweep did, per repository.
-pub const PROGRESS_FILE: &str = "run-progress.toml";
+// #5494: "is this output worth believing" gained a second caller — the resume
+// path asks it about a directory no child in this run wrote. Two callers of one
+// judgement is what makes it a module rather than a step inside `run_one`.
+mod verify;
+
+use verify::verify_output;
+
+pub use checkpoint::{PROGRESS_FILE, Recollect, RunProgress, progress_path, read_progress};
+pub use selection::{SELECTION_FILE, SelectedRepo, load_selection, save_selection, selection_path};
 
 /// What happened to one repository.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -116,6 +128,15 @@ pub struct RepoRun {
     /// fail the repository; see [`verify_output`] for which ones do.
     #[serde(default)]
     pub gaps: Vec<String>,
+    /// Whether this entry was carried over from an earlier sweep (#5494).
+    ///
+    /// `true` means no `tga audit` child ran for this repository in the sweep
+    /// that produced this report — an earlier run audited it, and the output it
+    /// left is still on disk and still passes [`verify_output`]. It is recorded
+    /// so a re-run reads as a resume rather than as work that went suspiciously
+    /// fast.
+    #[serde(default)]
+    pub resumed: bool,
     /// How it ended.
     pub result: RepoResult,
 }
@@ -172,11 +193,33 @@ impl RunReport {
     pub fn failures(&self) -> impl Iterator<Item = &RepoRun> {
         self.repos.iter().filter(|r| !r.result.succeeded())
     }
+
+    /// The repositories an earlier sweep audited and this one carried over.
+    pub fn resumed(&self) -> impl Iterator<Item = &RepoRun> {
+        self.repos.iter().filter(|r| r.resumed)
+    }
 }
 
-/// Where the run-progress record is written.
-pub fn progress_path(work: &WorkDir) -> PathBuf {
-    work.path(Area::State).join(PROGRESS_FILE)
+/// How to run the sweep.
+///
+/// Why: a struct rather than a bare `bool` argument, matching
+/// [`crate::clone::CloneOptions`] — the flag is operator-facing and reaches
+/// this crate through [`crate::session::Command::Run`], so it will grow
+/// neighbours (an audit window, a repository subset) and a positional boolean
+/// at every call site is where those go wrong.
+/// What: one field today. [`RunOptions::default`] is the resuming behaviour.
+/// Test: `super::run_tests::a_fresh_run_re_audits_everything`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RunOptions {
+    /// Ignore the recorded progress and audit every selected repository again.
+    ///
+    /// Why: resume is a judgement about what is still valid, and an operator
+    /// who disagrees with that judgement needs a way to overrule it — a
+    /// recipient who has re-cloned their repositories has outputs that verify
+    /// fine and describe source that has moved on. Defaults to `false`, because
+    /// the expensive direction has to be the one asked for by name.
+    pub fresh: bool,
 }
 
 /// The four binaries a run drives, each proven to be at the engagement's pin.
@@ -329,10 +372,13 @@ struct TgaRepository {
 /// # Postconditions
 /// On `Ok`, every selected repository has an entry in [`RunReport::repos`] in
 /// selection order, each child's combined output is at its `log` path, and
-/// `state/`[`PROGRESS_FILE`] records the same results. [`RunReport::status`] is
+/// `state/`[`PROGRESS_FILE`] records the same results with
+/// [`RunProgress::complete`] set. [`RunReport::status`] is
 /// [`RunStatus::AllSucceeded`] only when every child exited 0 AND left the
-/// artifacts [`verify_output`] requires. On `Err`, no claim is made about any
-/// repository.
+/// artifacts [`verify_output`] requires. On `Err`, the checkpoint holds every
+/// repository this call settled before the failure PLUS every one it had
+/// already decided to carry over, and is marked incomplete; no claim is made
+/// about the rest.
 ///
 /// What: checks the tools, reads the selection, then per repository writes a
 /// generated tga config under `state/`, spawns the pinned `tga audit` with the
@@ -355,12 +401,17 @@ struct TgaRepository {
 /// the stages each `tga audit` child reports from inside itself (#5823).
 /// [`Progress::none`] is a complete answer — the sweep behaves identically and
 /// nothing is rendered.
+/// A repository an earlier run already audited is SKIPPED rather than re-run,
+/// unless [`RunOptions::fresh`] says otherwise — `checkpoint::plan` decides,
+/// and every skip is announced through `progress` and marked on the report
+/// (#5494).
 pub async fn sweep(
     work: &WorkDir,
     config: &EngagementConfig,
+    options: &RunOptions,
     progress: &Progress,
 ) -> Result<RunReport, AuditError> {
-    sweep_with_budget(work, config, PER_REPO_TIMEOUT, progress).await
+    sweep_with_budget(work, config, options, PER_REPO_TIMEOUT, progress).await
 }
 
 /// [`sweep`], with the per-repository timeout as an argument.
@@ -374,10 +425,11 @@ pub async fn sweep(
 async fn sweep_with_budget(
     work: &WorkDir,
     config: &EngagementConfig,
+    options: &RunOptions,
     budget: std::time::Duration,
     progress: &Progress,
 ) -> Result<RunReport, AuditError> {
-    sweep_with_env(work, config, budget, progress, |name| {
+    sweep_with_env(work, config, options, budget, progress, |name| {
         std::env::var(name).ok()
     })
     .await
@@ -393,9 +445,11 @@ async fn sweep_with_budget(
 /// races every other thread in a parallel test binary.
 /// Test: `super::run_tests::a_fully_set_operator_environment_is_left_alone`,
 /// `super::run_tests::a_partial_operator_environment_refuses_before_any_child_runs`.
+#[allow(clippy::too_many_arguments)]
 async fn sweep_with_env<F>(
     work: &WorkDir,
     config: &EngagementConfig,
+    options: &RunOptions,
     budget: std::time::Duration,
     progress: &Progress,
     operator: F,
@@ -409,29 +463,91 @@ where
     // every repository, so failing per-repo would just repeat one misconfiguration.
     let inference = inference::inference_env(config, operator)?;
     let selected = load_selection(work)?;
+    // #5494: decided once, against the whole selection, so a repository's fate
+    // does not depend on a record another repository's child rewrote meanwhile.
+    let plan = checkpoint::plan(work, &selected, options.fresh)?;
 
     // #5823: the operation is announced only once the refusals above are past,
     // so a display never opens on a sweep that is not going to run.
     let total = selected.len();
     progress.operation_started(Operation::Sweep, total);
-    let mut runs = Vec::with_capacity(total);
-    for (index, repo) in selected.into_iter().enumerate() {
-        runs.push(
-            run_one(
-                work, config, &binaries, &inference, index, repo, budget, progress, total,
-            )
-            .await?,
-        );
+    // #5494: the record starts as the PLAN, not as an empty list. A repository
+    // this run will carry over is already audited and already on disk, and
+    // rebuilding the record from only what this loop has visited so far would
+    // erase those entries the moment a later repository ends the sweep early —
+    // costing the next run the hours the checkpoint exists to save.
+    let mut runs: Vec<Option<RepoRun>> = plan.iter().map(|c| c.as_ref().ok().cloned()).collect();
+    for ((index, repo), carried) in selected.into_iter().enumerate().zip(plan) {
+        runs[index] = Some(match carried {
+            Ok(done) => skip_one(&done, index, progress, total),
+            Err(why) => {
+                announce_recollection(&repo.name, &why, progress);
+                run_one(
+                    work, config, &binaries, &inference, index, repo, budget, progress, total,
+                )
+                .await?
+            }
+        });
+        // #5494: the record advances with the work, not after it. A crash, a
+        // timeout or a Ctrl-C after this point costs the repositories still to
+        // come and none of the ones already done.
+        checkpoint::write_progress(work, &RunProgress::checkpoint(&decided(&runs)))?;
     }
 
-    let report = RunReport::of(runs);
+    let report = RunReport::of(decided(&runs));
     progress.operation_finished(
         Operation::Sweep,
         report.repos.iter().filter(|r| r.result.succeeded()).count(),
         total,
     );
-    write_progress(work, &report)?;
+    checkpoint::write_progress(work, &RunProgress::finished(&report))?;
     Ok(report)
+}
+
+/// The entries whose fate this run has settled, in selection order.
+///
+/// #5494: a slot is `None` only while its repository is still to be audited, so
+/// dropping those is what turns the plan-seeded vector into a record.
+fn decided(runs: &[Option<RepoRun>]) -> Vec<RepoRun> {
+    runs.iter().flatten().cloned().collect()
+}
+
+/// Carry an earlier sweep's result over, saying so as it happens.
+///
+/// #5494: a resumed repository still opens and closes its unit, because a
+/// display that shows nothing for it is indistinguishable from one that lost
+/// track of it — and the closing verdict carries the reason, so "why was this
+/// not re-collected" is answerable from the run's own output.
+fn skip_one(done: &RepoRun, index: usize, progress: &Progress, total: usize) -> RepoRun {
+    progress.unit_started(Operation::Sweep, done.repo.name.as_str(), index + 1, total);
+    progress.unit_finished(
+        Operation::Sweep,
+        done.repo.name.as_str(),
+        UnitOutcome::Skipped(format!(
+            "already audited by an earlier run — {}",
+            done.output.display()
+        )),
+    );
+    done.clone()
+}
+
+/// State why a repository is being audited again rather than carried over.
+///
+/// Why: #5494 — a resumed sweep that re-collects a repository the operator
+/// believed was saved must say what made the record ineligible, or the only
+/// visible difference is that the run took four hours longer than expected.
+/// What: one stage line inside the unit, through the same relay a `tga audit`
+/// child's own stages use. [`Recollect::NotRecorded`] is suppressed: on a first
+/// run it is true of every repository and carries no information.
+/// Test: `super::run_tests::a_deleted_output_is_re_audited_rather_than_reported_complete`.
+fn announce_recollection(name: &str, why: &Recollect, progress: &Progress) {
+    if matches!(why, Recollect::NotRecorded) {
+        return;
+    }
+    progress.unit_stage(
+        name,
+        StageEvent::new("Sweep", name, StageState::Started).with_detail(why.reason()),
+    );
 }
 
 /// Audit one repository, recording rather than propagating its failure.
@@ -499,86 +615,9 @@ async fn run_one(
         output,
         log,
         gaps,
+        resumed: false,
         result,
     })
-}
-
-/// The gap line `tga` writes when a collection stage failed but the sweep
-/// continued (`tga::audit::gaps::sweep_gap_lines`, DOC-67 §9).
-///
-/// Why: `tga audit` exits 0 whenever the sweep COMPLETED, failed stages
-/// included — its own docs say so. The failure reaches the manifest as prose,
-/// which is the only channel tga offers today, so matching that prose is the
-/// only way this client can tell "assessed" from "assessed nothing".
-const COLLECT_FAILED_MARKER: &str = "stage `collect` did not complete";
-
-/// What a zero exit is allowed to mean.
-///
-/// Why: the finding that made this necessary. `tga audit` returns `Ok` whenever
-/// the sweep completed even with failed stages, so exit 0 alone does not say
-/// anything was assessed — a collect stage that failed on auth, a rate limit or
-/// an empty clone still exits 0. Believing that status is how the recipient gets
-/// a report assessing nothing with every signal green.
-///
-/// # Postconditions
-/// On `Ok`, `<output>/manifest.toml` exists, parses, names at least one
-/// repository, and states no failed COLLECT stage. The returned gap lines are
-/// whatever else the manifest stated. On `Err`, the string is a one-line reason
-/// safe to show the recipient.
-///
-/// What: two checks of different confidence, and the difference is deliberate.
-///
-/// - **Structural**, and reliable: the manifest is there, parses, and names a
-///   repository. A child that wrote nothing cannot pass this whatever tga's
-///   wording does.
-/// - **Textual**, and brittle: a gap line naming a failed `collect` stage. tga
-///   owns that prose and could reword it, at which point this check silently
-///   stops firing. It is a second layer over the structural check, never the
-///   only one — and every other gap is recorded on the [`RepoRun`] and rendered,
-///   so a reworded marker still reaches the operator as a stated gap rather than
-///   disappearing. The durable fix is structured per-stage status in the
-///   manifest, which is tga's to add.
-///
-/// Other failed stages (jira, dora, pr-metrics) are NOT failures here: DOC-67
-/// §9 makes them named gaps on a report that is still worth delivering, and
-/// failing on any gap would fail nearly every real engagement.
-/// Test: `super::run_tests::a_child_that_exits_zero_having_written_nothing_fails`,
-/// `super::run_tests::a_manifest_reporting_a_failed_collect_stage_fails`,
-/// `super::run_tests::ordinary_gaps_do_not_fail_the_repository`.
-fn verify_output(output: &Path) -> Result<Vec<String>, String> {
-    let manifest_path = output.join(AuditManifest::FILE_NAME);
-    let manifest = match AuditManifest::load_if_present(&manifest_path) {
-        Ok(Some(manifest)) => manifest,
-        Ok(None) => {
-            return Err(format!(
-                "`tga audit` exited 0 but wrote no manifest to {} — nothing was assessed",
-                output.display()
-            ));
-        }
-        Err(e) => {
-            return Err(format!(
-                "`tga audit` exited 0 but its manifest at {} cannot be read: {e}",
-                manifest_path.display()
-            ));
-        }
-    };
-    if manifest.repositories.is_empty() {
-        return Err(format!(
-            "`tga audit` exited 0 but its manifest at {} names no repository — nothing was assessed",
-            manifest_path.display()
-        ));
-    }
-    if let Some(gap) = manifest
-        .report
-        .gaps
-        .iter()
-        .find(|g| g.contains(COLLECT_FAILED_MARKER))
-    {
-        return Err(format!(
-            "`tga audit` exited 0 but collection did not complete: {gap}"
-        ));
-    }
-    Ok(manifest.report.gaps)
 }
 
 /// Everything that must be true before a child is worth starting.
@@ -853,50 +892,6 @@ const ENV_ANALYZE_BIN: &str = "TRUSTY_ANALYZE_BIN";
 /// The variable `tga audit` reads its report renderer from.
 const ENV_REVIEW_BIN: &str = "TRUSTY_REVIEW_BIN";
 
-/// Record what the sweep did, per repository.
-///
-/// Why: `workdir` names `state/` as where run progress lives, and #5499
-/// assembles the deliverable from it. Writing it last means a record only ever
-/// describes a sweep that finished.
-/// What: overwrites `state/`[`PROGRESS_FILE`] with the whole report.
-/// Test: `super::run_tests::the_progress_record_survives_a_partial_run`.
-///
-/// # Errors
-///
-/// [`AuditError::WorkDir`] when the record cannot be written. This is NOT
-/// downgraded to a warning: a run whose result cannot be recorded must not
-/// return as a success (#5655).
-fn write_progress(work: &WorkDir, report: &RunReport) -> Result<(), AuditError> {
-    let path = progress_path(work);
-    let text = toml::to_string_pretty(report).map_err(|e| AuditError::WorkDir {
-        path: path.clone(),
-        source: std::io::Error::other(e),
-    })?;
-    std::fs::write(&path, text).map_err(|source| AuditError::WorkDir { path, source })
-}
-
-/// Read the last sweep's record, or nothing when none has run.
-///
-/// # Errors
-///
-/// [`AuditError::Read`] when the record exists but cannot be read, and
-/// [`AuditError::Parse`] when it is malformed.
-pub fn read_progress(work: &WorkDir) -> Result<Option<RunReport>, AuditError> {
-    let path = progress_path(work);
-    let text = match std::fs::read_to_string(&path) {
-        Ok(text) => text,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(source) => return Err(AuditError::Read { path, source }),
-    };
-    toml::from_str(&text)
-        .map(Some)
-        .map_err(|source| AuditError::Parse {
-            path,
-            what: "run progress record",
-            source: Box::new(source),
-        })
-}
-
 #[cfg(test)]
 mod run_tests {
     use super::*;
@@ -1139,7 +1134,7 @@ trusty-review = "0.15.1"
         let work = work_in(tmp.path());
         select(&work, &[("acme-api", "repos/acme-api")]);
 
-        let err = sweep(&work, &config(), &Progress::none())
+        let err = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
             .await
             .expect_err("no pinned tga means no run");
         let AuditError::ToolsNotInstalled { missing } = err else {
@@ -1253,6 +1248,7 @@ trusty-review = "0.15.1"
             output: "/o/a".into(),
             log: "/l/a.log".into(),
             gaps: Vec::new(),
+            resumed: false,
             result: RepoResult::Succeeded,
         };
         let bad = RepoRun {
@@ -1290,7 +1286,7 @@ trusty-review = "0.15.1"
             ],
         );
 
-        let report = sweep(&work, &config(), &Progress::none())
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
             .await
             .expect("the sweep completes");
         assert_eq!(report.status, RunStatus::AllFailed);
@@ -1304,7 +1300,7 @@ trusty-review = "0.15.1"
         let recorded = read_progress(&work)
             .expect("record reads")
             .expect("present");
-        assert_eq!(recorded, report);
+        assert_eq!(recorded.report(), report);
     }
 
     /// A checkout the selection names but that is not there fails that
@@ -1321,7 +1317,7 @@ trusty-review = "0.15.1"
             &[("acme-api", "repos/acme-api"), ("gone", "repos/gone")],
         );
 
-        let report = sweep(&work, &config(), &Progress::none())
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
             .await
             .expect("the sweep completes");
         assert_eq!(report.status, RunStatus::Partial);
@@ -1387,7 +1383,7 @@ trusty-review = "0.15.1"
         make_repo(&work, "acme-api");
         select(&work, &[("acme-api", "repos/acme-api")]);
 
-        let report = sweep(&work, &config(), &Progress::none())
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
             .await
             .expect("the sweep completes");
         assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
@@ -1416,7 +1412,7 @@ trusty-review = "0.15.1"
         make_repo(&work, "acme-api");
         select(&work, &[("acme-api", "repos/acme-api")]);
 
-        let report = sweep(&work, &config(), &Progress::none())
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
             .await
             .expect("the sweep completes");
         assert_eq!(report.status, RunStatus::AllFailed, "{report:?}");
@@ -1444,7 +1440,7 @@ trusty-review = "0.15.1"
         make_repo(&work, "acme-api");
         select(&work, &[("acme-api", "repos/acme-api")]);
 
-        let report = sweep(&work, &config(), &Progress::none())
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
             .await
             .expect("the sweep completes");
         assert_eq!(report.status, RunStatus::AllFailed, "{report:?}");
@@ -1472,7 +1468,7 @@ trusty-review = "0.15.1"
         make_repo(&work, "acme-api");
         select(&work, &[("acme-api", "repos/acme-api")]);
 
-        let report = sweep(&work, &config(), &Progress::none())
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
             .await
             .expect("the sweep completes");
         assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
@@ -1494,6 +1490,7 @@ trusty-review = "0.15.1"
         let report = sweep_with_budget(
             &work,
             &config(),
+            &RunOptions::default(),
             std::time::Duration::from_millis(200),
             &Progress::none(),
         )
@@ -1521,7 +1518,7 @@ trusty-review = "0.15.1"
         make_repo(&work, "acme-api");
         select(&work, &[("../../escape", "repos/acme-api")]);
 
-        let report = sweep(&work, &config(), &Progress::none())
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
             .await
             .expect("the sweep completes");
         for run in &report.repos {
@@ -1574,6 +1571,7 @@ trusty-review = "0.15.1"
         sweep_with_env(
             work,
             &config(),
+            &RunOptions::default(),
             PER_REPO_TIMEOUT,
             &Progress::none(),
             operator,
@@ -1730,7 +1728,7 @@ trusty-review = "0.15.1"
         select(&work, &[("acme-api", "repos/acme-api")]);
 
         let (recorder, progress) = Recorder::new();
-        let report = sweep(&work, &config(), &progress)
+        let report = sweep(&work, &config(), &RunOptions::default(), &progress)
             .await
             .expect("the sweep completes");
         assert_eq!(report.status, RunStatus::AllSucceeded);
@@ -1803,7 +1801,7 @@ trusty-review = "0.15.1"
         select(&work, &[("acme-api", "repos/acme-api")]);
 
         let (recorder, progress) = Recorder::new();
-        let report = sweep(&work, &config(), &progress)
+        let report = sweep(&work, &config(), &RunOptions::default(), &progress)
             .await
             .expect("a failing child is a recorded failure, not an error");
         assert_eq!(report.status, RunStatus::AllFailed);
@@ -1827,6 +1825,381 @@ trusty-review = "0.15.1"
         assert!(log.contains(&started.encode()), "{log}");
     }
 
+    // ── #5494: the incremental checkpoint, and resuming against it ───────────
+
+    /// A stub `tga` that appends its `--output` to `invocations.txt` in the
+    /// work-dir root, then writes the manifest a real one would. It exits 3 for
+    /// any repository whose output path ends with `fails`, so a test can make
+    /// one repository of several fail without a second script.
+    ///
+    /// The invocation log is what "was this repository re-collected" is read
+    /// from: the report says what the sweep CLAIMS, and this says what ran.
+    fn counts_invocations(fails: &str) -> String {
+        format!(
+            "#!/bin/sh\nout=\"\"\nwhile [ $# -gt 0 ]; do\n  \
+             case \"$1\" in --output) out=\"$2\"; shift;; esac\n  shift\ndone\n\
+             echo \"$out\" >> invocations.txt\n\
+             if [ -f state/run-progress.toml ]; then \
+             cp state/run-progress.toml \"$out.seen.toml\"; fi\n\
+             mkdir -p \"$out\"\n\
+             case \"$out\" in *{fails}) exit 3;; esac\n\
+             printf '[report]\\ntitle = \"Acme\"\\n\\n[[repositories]]\\n\
+             name = \"acme\"\\npath = \"/r\"\\n' > \"$out/manifest.toml\"\nexit 0\n"
+        )
+    }
+
+    /// A pattern `counts_invocations` can never match, for a stub that always
+    /// succeeds.
+    const NEVER: &str = "--no-such-repository--";
+
+    /// Every `--output` a stub child was handed, in the order they ran.
+    fn invocations(work: &WorkDir) -> Vec<String> {
+        std::fs::read_to_string(work.root().join("invocations.txt"))
+            .unwrap_or_default()
+            .lines()
+            .map(str::to_owned)
+            .collect()
+    }
+
+    fn two_repos_ready(work: &WorkDir, fails: &str) {
+        install_stubs(work, &counts_invocations(fails));
+        make_repo(work, "acme-api");
+        make_repo(work, "acme-web");
+        select(
+            work,
+            &[
+                ("acme-api", "repos/acme-api"),
+                ("acme-web", "repos/acme-web"),
+            ],
+        );
+    }
+
+    /// Why (#5494): the whole ticket. The record used to be written once, after
+    /// every child had finished, so a crash mid-sweep left nothing at all. This
+    /// proves the record advances WITH the work — the second child reads a
+    /// checkpoint that already names the first — and that it stays marked
+    /// incomplete until the sweep reaches the end of its selection, which is
+    /// what stops a crashed run being packaged as a whole engagement.
+    /// What: two repositories, a stub that copies the record it finds.
+    /// Test: this is the test.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_checkpoint_advances_with_the_sweep_and_completes_only_at_the_end() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        two_repos_ready(&work, NEVER);
+
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("the sweep completes");
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+
+        // What the SECOND child saw when it started.
+        let seen = std::fs::read_to_string(
+            work.path(Area::Output)
+                .join("01-acme-web.seen.toml")
+                .as_path(),
+        )
+        .expect("the second child found a checkpoint the first one's completion wrote");
+        let mid: RunProgress = toml::from_str(&seen).expect("the checkpoint parses");
+        assert_eq!(mid.repos.len(), 1, "{mid:?}");
+        assert_eq!(mid.repos[0].repo.name, "acme-api");
+        assert!(
+            !mid.complete,
+            "a checkpoint written mid-sweep must not claim the sweep finished"
+        );
+
+        // And the first child found nothing, so the checkpoint is this run's.
+        assert!(
+            !work
+                .path(Area::Output)
+                .join("00-acme-api.seen.toml")
+                .exists()
+        );
+
+        let final_record = read_progress(&work).expect("reads").expect("present");
+        assert!(final_record.complete);
+        assert_eq!(final_record.repos.len(), 2);
+    }
+
+    /// Why (#5494, the fail-open check): recording progress is now a branch
+    /// that runs after every repository, and the tempting shape is to warn and
+    /// carry on. That would spend hours auditing repositories nothing on disk
+    /// records, and report them as audited. So the write is a refusal: the
+    /// sweep stops at the first repository whose completion it could not
+    /// record, and never returns a report claiming that repository succeeded.
+    ///
+    /// Downgrade that write to a warning and both children run, the sweep
+    /// returns `Ok(AllSucceeded)`, and two repositories are reported as audited
+    /// by a run nothing on disk describes. The invocation count is what
+    /// separates the two behaviours.
+    /// What: a non-empty directory at the record's path, which no rename can
+    /// replace. The run is `fresh`, so the plan never READS that path — the
+    /// only failure under test is the write.
+    /// Test: this is the test.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_checkpoint_that_cannot_be_written_stops_the_sweep() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        two_repos_ready(&work, NEVER);
+        let blocked = progress_path(&work);
+        std::fs::create_dir_all(&blocked).expect("mkdir");
+        std::fs::write(blocked.join("occupied"), b"x").expect("write");
+
+        let (recorder, progress) = Recorder::new();
+        let err = sweep(&work, &config(), &RunOptions { fresh: true }, &progress)
+            .await
+            .expect_err("a run whose progress cannot be recorded must not report success");
+        assert!(matches!(err, AuditError::WorkDir { .. }), "{err:?}");
+
+        let ran = invocations(&work);
+        assert_eq!(
+            ran.len(),
+            1,
+            "the sweep must stop at the repository whose completion could not be \
+             recorded, not audit the rest against a record it cannot write: {ran:?}"
+        );
+        assert!(
+            !recorder.updates().iter().any(|u| matches!(
+                u,
+                ProgressUpdate::OperationFinished { succeeded, .. } if *succeeded > 0
+            )),
+            "no repository may be reported as audited: {:?}",
+            recorder.updates()
+        );
+    }
+
+    /// Why (#5494): the point of the checkpoint. A re-run must not spend four
+    /// hours re-auditing a repository an earlier run finished — and must retry
+    /// one it recorded as failed, because a failure is usually the transient
+    /// thing the operator re-ran to clear, and skipping it would make the
+    /// re-run a no-op that reports the same failure forever.
+    /// What: two repositories, the second failing; the second sweep runs one
+    /// child. The skip is announced, not silent.
+    /// Test: this is the test.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_re_run_skips_what_succeeded_and_retries_what_failed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        two_repos_ready(&work, "acme-web");
+
+        let first = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("the sweep completes");
+        assert_eq!(first.status, RunStatus::Partial, "{first:?}");
+        assert_eq!(invocations(&work).len(), 2);
+        assert_eq!(first.resumed().count(), 0);
+
+        let (recorder, progress) = Recorder::new();
+        let second = sweep(&work, &config(), &RunOptions::default(), &progress)
+            .await
+            .expect("the sweep completes");
+        assert_eq!(second.status, RunStatus::Partial, "{second:?}");
+
+        let ran = invocations(&work);
+        assert_eq!(
+            ran.len(),
+            3,
+            "only the failed repository may run again: {ran:?}"
+        );
+        assert!(ran[2].ends_with("01-acme-web"), "{ran:?}");
+
+        assert!(second.repos[0].resumed, "{:?}", second.repos[0]);
+        assert!(!second.repos[1].resumed, "{:?}", second.repos[1]);
+        assert_eq!(second.resumed().count(), 1);
+
+        // Silent skipping is the defect: the operator has to be told.
+        let skipped = recorder
+            .updates()
+            .into_iter()
+            .find_map(|u| match u {
+                ProgressUpdate::UnitFinished {
+                    target,
+                    outcome: UnitOutcome::Skipped(why),
+                    ..
+                } if target == "acme-api" => Some(why),
+                _ => None,
+            })
+            .expect("the carried-over repository must be announced");
+        assert!(skipped.contains("already audited"), "{skipped}");
+    }
+
+    /// Why (#5494): a sweep that ends early must not erase what it had already
+    /// decided to carry over. The checkpoint is republished whole after every
+    /// repository, so building it from only the repositories the loop has
+    /// VISITED drops the ones further down the selection — repositories an
+    /// earlier run audited, whose output is on disk and verified, and which the
+    /// next run would then re-collect from scratch. That is the four-hours-lost
+    /// failure this ticket exists to prevent, reappearing one selection later.
+    /// What: four repositories. `a` and `d` are re-collected (their outputs are
+    /// gone), `b` and `c` carry over. `d`'s output path is occupied by a regular
+    /// file, so its `mkdir` fails and the sweep ends after `a` — which is a
+    /// crash's shape: the record on disk is whatever the last checkpoint wrote.
+    /// Test: this is the test.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_sweep_that_ends_early_keeps_the_entries_it_was_carrying_over() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &counts_invocations(NEVER));
+        for name in ["a", "d", "b", "c"] {
+            make_repo(&work, name);
+        }
+        select(
+            &work,
+            &[
+                ("a", "repos/a"),
+                ("d", "repos/d"),
+                ("b", "repos/b"),
+                ("c", "repos/c"),
+            ],
+        );
+
+        let first = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("the sweep completes");
+        assert_eq!(first.status, RunStatus::AllSucceeded, "{first:?}");
+
+        // `a` re-collects because its output is gone. `d` re-collects for the
+        // same reason AND cannot be re-collected: a regular file where its
+        // output directory belongs fails `mkdir`, so the sweep ends there.
+        std::fs::remove_dir_all(work.path(Area::Output).join("00-a")).expect("drop a's output");
+        std::fs::remove_dir_all(work.path(Area::Output).join("01-d")).expect("drop d's output");
+        std::fs::write(work.path(Area::Output).join("01-d"), b"not a directory").expect("occupy");
+
+        let err = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect_err("a repository whose output directory cannot be made ends the sweep");
+        assert!(matches!(err, AuditError::WorkDir { .. }), "{err:?}");
+
+        let record = read_progress(&work).expect("reads").expect("present");
+        assert!(!record.complete, "{record:?}");
+        let names: Vec<&str> = record.repos.iter().map(|r| r.repo.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["a", "b", "c"],
+            "the sweep re-collected `a` and died on `d`; `b` and `c` were already \
+             audited and carried over, and dropping them costs the next run their \
+             collection time all over again"
+        );
+        assert!(
+            record.repos[1].resumed && record.repos[2].resumed,
+            "{record:?}"
+        );
+    }
+
+    /// Why (#5494): resume trusts a record about files it does not re-read, so
+    /// the one thing it must never do is report a repository as complete when
+    /// its data is gone. The record still says `Succeeded`; the disk decides.
+    /// What: a successful sweep, its output deleted, then a re-run — which
+    /// audits it again and says why.
+    /// Test: this is the test.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_deleted_output_is_re_audited_rather_than_reported_complete() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &counts_invocations(NEVER));
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let first = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("the sweep completes");
+        assert_eq!(first.status, RunStatus::AllSucceeded);
+        std::fs::remove_dir_all(&first.repos[0].output).expect("delete the output");
+
+        let (recorder, progress) = Recorder::new();
+        let second = sweep(&work, &config(), &RunOptions::default(), &progress)
+            .await
+            .expect("the sweep completes");
+        assert_eq!(invocations(&work).len(), 2, "the repository must run again");
+        assert!(!second.repos[0].resumed, "{:?}", second.repos[0]);
+        assert!(second.repos[0].output.join("manifest.toml").is_file());
+
+        let stated = recorder
+            .stages()
+            .into_iter()
+            .find_map(|s| s.detail)
+            .expect("the re-collection must state its reason");
+        assert!(stated.contains("no longer usable"), "{stated}");
+    }
+
+    /// Why (#5494): a checkpoint entry is matched to the CURRENT selection, not
+    /// merely to a repository name. `stem` carries the selection index, so a
+    /// reordered selection means a different `out/<stem>/` — and reusing the
+    /// old entry would report a repository as audited into a directory this run
+    /// never wrote.
+    /// What: one repository audited, then a selection with another ahead of it.
+    /// Test: this is the test.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_reordered_selection_does_not_reuse_the_wrong_output() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        two_repos_ready(&work, NEVER);
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("the sweep completes");
+        assert_eq!(invocations(&work).len(), 1);
+
+        select(
+            &work,
+            &[
+                ("acme-web", "repos/acme-web"),
+                ("acme-api", "repos/acme-api"),
+            ],
+        );
+        let second = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("the sweep completes");
+        assert_eq!(
+            invocations(&work).len(),
+            3,
+            "a repository at a new position writes a new output and must be re-audited"
+        );
+        assert_eq!(second.resumed().count(), 0, "{second:?}");
+    }
+
+    /// Why (#5494): the operator's override. A recipient who re-cloned their
+    /// repositories has outputs that verify fine and describe source that has
+    /// moved on, and no automatic check can see that.
+    /// What: `--fresh` re-audits a repository the record says was audited.
+    /// Test: this is the test.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_fresh_run_re_audits_everything() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &counts_invocations(NEVER));
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("the sweep completes");
+        assert_eq!(invocations(&work).len(), 1);
+
+        let report = sweep(
+            &work,
+            &config(),
+            &RunOptions { fresh: true },
+            &Progress::none(),
+        )
+        .await
+        .expect("the sweep completes");
+        assert_eq!(
+            invocations(&work).len(),
+            2,
+            "`--fresh` must run the child again"
+        );
+        assert_eq!(report.resumed().count(), 0);
+    }
+
     /// Why (#5823): piping the child's streams to read them is the change most
     /// able to break something unrelated — a sweep that no longer works is a
     /// worse outcome than one with no display. This is the no-sink path, which
@@ -1842,7 +2215,7 @@ trusty-review = "0.15.1"
         make_repo(&work, "acme-api");
         select(&work, &[("acme-api", "repos/acme-api")]);
 
-        let report = sweep(&work, &config(), &Progress::none())
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
             .await
             .expect("the sweep completes");
         assert_eq!(report.status, RunStatus::AllSucceeded);

--- a/crates/trusty-audit/src/run/checkpoint.rs
+++ b/crates/trusty-audit/src/run/checkpoint.rs
@@ -1,0 +1,265 @@
+//! The run checkpoint: what a sweep has already done, and what a re-run skips.
+//!
+//! Why: #5494. The progress record used to be written ONCE, after every
+//! repository had finished, so a crash, a timeout or a Ctrl-C mid-sweep left no
+//! record of partial progress at all — and a re-run redid every repository,
+//! including ones that had already spent four hours inside `tga audit`. This
+//! module makes the record incremental and makes the sweep re-entrant against
+//! it.
+//!
+//! What: [`RunProgress`], the `state/`[`PROGRESS_FILE`] document, and [`plan`],
+//! which decides per selected repository whether an earlier sweep's result may
+//! be carried over. [`write_progress`] publishes atomically;
+//! [`read_progress`] reads what is there.
+//! Test: `super::run_tests`.
+//!
+//! ## Why the checkpoint is per repository, not per stage
+//!
+//! `tga audit` runs nine stages per repository and, since #5823, relays each
+//! one — so recording stage granularity would be nearly free. It would also be
+//! unusable: `tga audit`'s arguments are `--org --title --analyst --client
+//! --output --weeks` (`tga::commands::audit::AuditArgs`) and there is no way to
+//! ask it to start at stage 5. A checkpoint records a position only so a later
+//! run can re-enter there, and the only re-entry point this crate has is a
+//! fresh `tga audit` child over one repository. Stage events remain what they
+//! are — live display, through [`crate::progress`] — and the checkpoint records
+//! the unit that can actually be resumed.
+//!
+//! ## What is not here: a lock
+//!
+//! `trusty_common::file_lock::with_exclusive_lock` guards load-mutate-save
+//! against a second PROCESS, and this record is not exposed to that race. One
+//! sweep holds its results in memory and republishes the whole document, so
+//! there is no read-modify-write window for another writer to land inside, and
+//! every other reader (`package`, the guided flow) only reads. Two concurrent
+//! `trusty-audit run` invocations against one working directory would collide
+//! long before the checkpoint: they share `out/<stem>/`, `logs/<stem>.log`,
+//! `extract/<stem>.db` and the generated tga config, all of which truncate. A
+//! lock on this file would serialise the one write that is already atomic while
+//! leaving that collision untouched, so the shared working directory stays the
+//! open question `crate::workdir` records rather than something answered here.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::{RepoRun, RunReport, RunStatus, SelectedRepo, stem, verify_output};
+use crate::error::AuditError;
+use crate::workdir::{self, Area, WorkDir};
+
+/// File under `state/` recording what the sweep has done, per repository.
+pub const PROGRESS_FILE: &str = "run-progress.toml";
+
+/// Where the run-progress record is written.
+pub fn progress_path(work: &WorkDir) -> PathBuf {
+    work.path(Area::State).join(PROGRESS_FILE)
+}
+
+/// The `state/run-progress.toml` document.
+///
+/// Why: the file has to answer two different questions, and before #5494 it
+/// answered only one. "What happened to each repository" is [`RunReport`], and
+/// it is what `package` assembles from. "Did the sweep that wrote this actually
+/// finish" is [`RunProgress::complete`], and without it an incremental record
+/// is indistinguishable from a finished short one — which is how a crashed
+/// sweep would otherwise be packaged and sent as a whole engagement.
+///
+/// What: the report's fields plus the completion flag. `complete` defaults to
+/// `false` when absent, so a record written before this field existed reads as
+/// unfinished: the resume path then re-verifies every entry against what is on
+/// disk and re-collects whatever does not hold up, which is the safe direction.
+/// Test: `super::run_tests::the_checkpoint_advances_with_the_sweep_and_completes_only_at_the_end`,
+/// `crate::session::session_tests::packaging_an_unfinished_sweep_is_refused`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RunProgress {
+    /// Whether the sweep that wrote this reached the end of its selection.
+    ///
+    /// `false` means the record is a checkpoint of a sweep still running, or of
+    /// one that died. It is never a reason to discard the entries — they are
+    /// what a re-run resumes from.
+    #[serde(default)]
+    pub complete: bool,
+    /// The verdict over the entries recorded SO FAR.
+    pub status: RunStatus,
+    /// One entry per repository that has finished, in selection order.
+    pub repos: Vec<RepoRun>,
+}
+
+impl RunProgress {
+    /// A checkpoint of a sweep that is still working through its selection.
+    pub(crate) fn checkpoint(repos: &[RepoRun]) -> Self {
+        Self::from_report(RunReport::of(repos.to_vec()), false)
+    }
+
+    /// The record of a sweep that reached the end of its selection.
+    pub(crate) fn finished(report: &RunReport) -> Self {
+        Self::from_report(report.clone(), true)
+    }
+
+    fn from_report(report: RunReport, complete: bool) -> Self {
+        Self {
+            complete,
+            status: report.status,
+            repos: report.repos,
+        }
+    }
+
+    /// The per-repository results, without the completion flag.
+    pub fn report(&self) -> RunReport {
+        RunReport::of(self.repos.clone())
+    }
+}
+
+/// Publish the checkpoint, refusing rather than downgrading a failure.
+///
+/// Why: this runs after EVERY repository now, so it is the branch #5494's
+/// fail-open check names. A write that failed and was warned about would leave
+/// the sweep continuing for hours against a record it cannot update, and the
+/// repositories it finished meanwhile would be reported as audited by a run
+/// nothing on disk describes. So the error propagates and the sweep stops at
+/// the first repository whose completion could not be recorded.
+/// What: renders the document and hands it to
+/// [`workdir::write_atomically`] — a `kill -9` between two repositories finds
+/// either the previous whole checkpoint or the new one, never a prefix.
+/// Test: `super::run_tests::a_checkpoint_that_cannot_be_written_stops_the_sweep`.
+///
+/// # Errors
+///
+/// [`AuditError::WorkDir`] when the record cannot be rendered or published.
+pub(crate) fn write_progress(work: &WorkDir, progress: &RunProgress) -> Result<(), AuditError> {
+    let path = progress_path(work);
+    let text = toml::to_string_pretty(progress).map_err(|e| AuditError::WorkDir {
+        path: path.clone(),
+        source: std::io::Error::other(e),
+    })?;
+    workdir::write_atomically(&path, &text)
+}
+
+/// Read the recorded progress, or nothing when no sweep has run here.
+///
+/// # Errors
+///
+/// [`AuditError::Read`] when the record exists but cannot be read, and
+/// [`AuditError::Parse`] when it is malformed. A record that cannot be parsed
+/// is NOT treated as absent: silently starting over would be defensible, but
+/// silently PACKAGING over it would not, and both callers read through here.
+pub fn read_progress(work: &WorkDir) -> Result<Option<RunProgress>, AuditError> {
+    let path = progress_path(work);
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(AuditError::Read { path, source }),
+    };
+    toml::from_str(&text)
+        .map(Some)
+        .map_err(|source| AuditError::Parse {
+            path,
+            what: "run progress record",
+            source: Box::new(source),
+        })
+}
+
+/// Why one selected repository is being audited again rather than carried over.
+///
+/// Why: silent skipping is the defect #5494 names, and so is a silent re-run —
+/// an operator watching a resumed sweep spend another four hours on a
+/// repository it already audited must be able to see what made it ineligible.
+/// What: the four states [`plan`] distinguishes, each rendered as one line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Recollect {
+    /// No record of this repository, at this position in the selection.
+    NotRecorded,
+    /// It is recorded, and recorded as failed. Re-runs retry failures.
+    Failed,
+    /// It is recorded as audited, but its output no longer holds up.
+    OutputGone(String),
+    /// The operator asked for a full re-collection.
+    Forced,
+}
+
+impl Recollect {
+    /// One line naming why, safe to show the recipient.
+    pub fn reason(&self) -> String {
+        match self {
+            Self::NotRecorded => "not recorded by an earlier run".to_owned(),
+            Self::Failed => "the earlier run recorded it as failed — retrying".to_owned(),
+            Self::OutputGone(why) => format!("its recorded output is no longer usable: {why}"),
+            Self::Forced => "`--fresh` was asked for".to_owned(),
+        }
+    }
+}
+
+/// What a re-run may carry over, decided per selected repository.
+///
+/// Why: the resume decision has to be made against the CURRENT selection, not
+/// against whatever the record happens to hold. Two things go wrong otherwise,
+/// and both end with a repository reported as audited when it was not. A record
+/// naming a repository the operator has since dropped, or moved to a different
+/// position, describes a different `out/<stem>/` than this run will use — so the
+/// entry is matched on the repository AND on the output path this run computes
+/// for it, which the selection index is part of. And a record naming an output
+/// that has since been deleted describes a directory that is not there — so the
+/// output is re-verified through [`verify_output`], the same check that decided
+/// the entry was a success in the first place, rather than trusted because the
+/// file says `Succeeded`.
+///
+/// # Postconditions
+/// The returned vector has one entry per selected repository, in selection
+/// order. `Ok(run)` may be reported without running anything; `Err(reason)`
+/// names why this repository is being audited again.
+///
+/// What: reads the record, then answers per index. `fresh` short-circuits every
+/// entry to [`Recollect::Forced`], which is the operator's way to force a full
+/// re-collection.
+/// Test: `super::run_tests::a_re_run_skips_what_succeeded_and_retries_what_failed`,
+/// `super::run_tests::a_deleted_output_is_re_audited_rather_than_reported_complete`,
+/// `super::run_tests::a_reordered_selection_does_not_reuse_the_wrong_output`,
+/// `super::run_tests::a_fresh_run_re_audits_everything`.
+///
+/// # Errors
+///
+/// [`AuditError::Read`] or [`AuditError::Parse`] when a record exists and is
+/// unusable. A checkpoint that cannot be read is a refusal, not an empty plan:
+/// starting over would redo hours of work the operator was told were saved.
+pub(super) fn plan(
+    work: &WorkDir,
+    selected: &[SelectedRepo],
+    fresh: bool,
+) -> Result<Vec<Result<RepoRun, Recollect>>, AuditError> {
+    let recorded = if fresh {
+        Vec::new()
+    } else {
+        read_progress(work)?.map(|p| p.repos).unwrap_or_default()
+    };
+    Ok(selected
+        .iter()
+        .enumerate()
+        .map(|(index, repo)| {
+            if fresh {
+                return Err(Recollect::Forced);
+            }
+            let output = work.path(Area::Output).join(stem(index, &repo.name));
+            let Some(entry) = recorded
+                .iter()
+                .find(|e| &e.repo == repo && e.output == output)
+            else {
+                return Err(Recollect::NotRecorded);
+            };
+            if !entry.result.succeeded() {
+                return Err(Recollect::Failed);
+            }
+            // #5494: the record says it succeeded; the disk decides whether it
+            // still has. Re-verifying re-reads the gaps too, so a carried-over
+            // entry states what its manifest states today.
+            match verify_output(&entry.output) {
+                Ok(gaps) => Ok(RepoRun {
+                    gaps,
+                    resumed: true,
+                    ..entry.clone()
+                }),
+                Err(why) => Err(Recollect::OutputGone(why)),
+            }
+        })
+        .collect())
+}

--- a/crates/trusty-audit/src/run/selection.rs
+++ b/crates/trusty-audit/src/run/selection.rs
@@ -143,9 +143,9 @@ pub fn load_selection(work: &WorkDir) -> Result<Vec<SelectedRepo>, AuditError> {
 /// atomic-rename and `count`-first obligations are one decision rather than a
 /// note each producer re-reads; #5497's picker writes through here too.
 /// What: renders `count` ahead of the entries (serde field order, and `toml`
-/// emits values before tables), writes to a uniquely-named temporary file in
-/// the same directory, and renames it into place. The unique name is what lets
-/// two writers race without either reading the other's half-written file.
+/// emits values before tables), then publishes through
+/// [`workdir::write_atomically`], which owns the temporary-file-and-rename
+/// obligation for every state document this crate writes (#5494).
 /// Test: `super::run_tests::a_saved_selection_reads_back_whole`,
 /// `super::run_tests::racing_writers_never_leave_a_torn_selection`.
 ///

--- a/crates/trusty-audit/src/run/verify.rs
+++ b/crates/trusty-audit/src/run/verify.rs
@@ -1,0 +1,97 @@
+//! Whether a `tga audit` output directory is worth believing.
+//!
+//! Why: #5494 gave this check a second caller. It used to be a step inside
+//! `run_one`, asked once, immediately after the child that wrote the directory
+//! exited. Resume asks it again, hours or days later, about a directory no
+//! child in this run produced — and the two must ask exactly the same question,
+//! because a resumed repository is carried over on the strength of this answer
+//! alone. One implementation is what keeps "audited" meaning one thing.
+//!
+//! What: [`verify_output`], and the manifest prose it matches on.
+//! Test: `super::run_tests::a_child_that_exits_zero_having_written_nothing_fails`,
+//! `super::run_tests::a_manifest_reporting_a_failed_collect_stage_fails`,
+//! `super::run_tests::ordinary_gaps_do_not_fail_the_repository`,
+//! `super::run_tests::a_deleted_output_is_re_audited_rather_than_reported_complete`.
+
+use std::path::Path;
+
+use crate::manifest::AuditManifest;
+
+/// The gap line `tga` writes when a collection stage failed but the sweep
+/// continued (`tga::audit::gaps::sweep_gap_lines`, DOC-67 §9).
+///
+/// Why: `tga audit` exits 0 whenever the sweep COMPLETED, failed stages
+/// included — its own docs say so. The failure reaches the manifest as prose,
+/// which is the only channel tga offers today, so matching that prose is the
+/// only way this client can tell "assessed" from "assessed nothing".
+const COLLECT_FAILED_MARKER: &str = "stage `collect` did not complete";
+
+/// What a zero exit is allowed to mean.
+///
+/// Why: the finding that made this necessary. `tga audit` returns `Ok` whenever
+/// the sweep completed even with failed stages, so exit 0 alone does not say
+/// anything was assessed — a collect stage that failed on auth, a rate limit or
+/// an empty clone still exits 0. Believing that status is how the recipient gets
+/// a report assessing nothing with every signal green.
+///
+/// # Postconditions
+/// On `Ok`, `<output>/manifest.toml` exists, parses, names at least one
+/// repository, and states no failed COLLECT stage. The returned gap lines are
+/// whatever else the manifest stated. On `Err`, the string is a one-line reason
+/// safe to show the recipient.
+///
+/// What: two checks of different confidence, and the difference is deliberate.
+///
+/// - **Structural**, and reliable: the manifest is there, parses, and names a
+///   repository. A child that wrote nothing cannot pass this whatever tga's
+///   wording does. This is also what makes the check usable on resume, where
+///   the directory may have been deleted, emptied, or partly copied away since.
+/// - **Textual**, and brittle: a gap line naming a failed `collect` stage. tga
+///   owns that prose and could reword it, at which point this check silently
+///   stops firing. It is a second layer over the structural check, never the
+///   only one — and every other gap is recorded on the [`super::RepoRun`] and
+///   rendered, so a reworded marker still reaches the operator as a stated gap
+///   rather than disappearing. The durable fix is structured per-stage status in
+///   the manifest, which is tga's to add.
+///
+/// Other failed stages (jira, dora, pr-metrics) are NOT failures here: DOC-67
+/// §9 makes them named gaps on a report that is still worth delivering, and
+/// failing on any gap would fail nearly every real engagement.
+/// Test: `super::run_tests::a_child_that_exits_zero_having_written_nothing_fails`,
+/// `super::run_tests::a_manifest_reporting_a_failed_collect_stage_fails`,
+/// `super::run_tests::ordinary_gaps_do_not_fail_the_repository`.
+pub(super) fn verify_output(output: &Path) -> Result<Vec<String>, String> {
+    let manifest_path = output.join(AuditManifest::FILE_NAME);
+    let manifest = match AuditManifest::load_if_present(&manifest_path) {
+        Ok(Some(manifest)) => manifest,
+        Ok(None) => {
+            return Err(format!(
+                "`tga audit` exited 0 but wrote no manifest to {} — nothing was assessed",
+                output.display()
+            ));
+        }
+        Err(e) => {
+            return Err(format!(
+                "`tga audit` exited 0 but its manifest at {} cannot be read: {e}",
+                manifest_path.display()
+            ));
+        }
+    };
+    if manifest.repositories.is_empty() {
+        return Err(format!(
+            "`tga audit` exited 0 but its manifest at {} names no repository — nothing was assessed",
+            manifest_path.display()
+        ));
+    }
+    if let Some(gap) = manifest
+        .report
+        .gaps
+        .iter()
+        .find(|g| g.contains(COLLECT_FAILED_MARKER))
+    {
+        return Err(format!(
+            "`tga audit` exited 0 but collection did not complete: {gap}"
+        ));
+    }
+    Ok(manifest.report.gaps)
+}

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -30,7 +30,7 @@ use crate::manifest::{AuditManifest, RepositoryEntry};
 use crate::package::{self, ReturnPackage};
 use crate::progress::{Progress, ProgressSink};
 use crate::registry::{self, Registration, Registry, Removal, TargetKind, TargetList};
-use crate::run::{self, RunReport};
+use crate::run::{self, RunOptions, RunReport};
 use crate::tools::{self, InstalledTool, RequiredTool, ToolStatus};
 use crate::validate;
 use crate::workdir::{Area, WorkDir};
@@ -89,7 +89,11 @@ pub enum Command {
         spec: String,
     },
     /// Run `tga audit` over the selected repositories (#5555).
-    Run,
+    ///
+    /// Carries its options because resume is an operator decision, not a
+    /// property of the session: a re-run skips what an earlier one recorded as
+    /// audited, and [`RunOptions::fresh`] is how that is overruled (#5494).
+    Run(RunOptions),
     /// Assemble the unencrypted deliverable to send back (#5499).
     ///
     /// Carries its argument because the recipient chooses where the file lands —
@@ -427,7 +431,7 @@ impl Session {
             }
             Command::ListTargets => self.list_targets().map(Outcome::Targets),
             Command::RemoveTarget { spec } => self.remove_target(&spec).await.map(Outcome::Removed),
-            Command::Run => self.run().await.map(Outcome::Run),
+            Command::Run(options) => self.run(&options).await.map(Outcome::Run),
             Command::Package { destination } => self.package(destination).map(Outcome::Package),
         }
     }
@@ -536,23 +540,41 @@ impl Session {
     ///
     /// Why: #5499. The config is required for the same reason every other
     /// capability requires it — it carries the engagement metadata the package
-    /// states, and the credential the member scan checks against. The progress
-    /// record is the completion signal: `run::sweep` writes it LAST, after every
-    /// child has finished, so its presence means a sweep finished rather than
-    /// one being under way.
+    /// states, and the credential the member scan checks against.
+    ///
+    /// The completion signal is `RunProgress::complete`, not the record's mere
+    /// presence. Since #5494 the record is written after every repository, so a
+    /// sweep that died three repositories into six leaves one behind — and
+    /// packaging that would send a partial engagement as a whole one. An
+    /// incomplete record is refused with the count it holds, because the
+    /// remedy is to re-run and resume, not to start over.
     /// What: loads both, then hands off to [`package::assemble`].
-    /// Test: `super::session_tests::packaging_before_any_sweep_is_refused`.
+    /// Test: `super::session_tests::packaging_before_any_sweep_is_refused`,
+    /// `super::session_tests::packaging_an_unfinished_sweep_is_refused`.
     fn package(&self, destination: Option<PathBuf>) -> Result<ReturnPackage, AuditError> {
         let config = EngagementConfig::load(&self.config_path)?;
-        let report =
+        let progress =
             run::read_progress(&self.work)?.ok_or_else(|| AuditError::NothingToPackage {
                 reason: format!(
                     "no sweep has finished in {} — run `trusty-audit run` first",
                     self.work.root().display()
                 ),
             })?;
+        if !progress.complete {
+            return Err(AuditError::NothingToPackage {
+                reason: format!(
+                    "the last sweep in {} did not finish — {} recorded so far; \
+                     run `trusty-audit run` to resume it",
+                    self.work.root().display(),
+                    match progress.repos.len() {
+                        1 => "1 repository".to_owned(),
+                        n => format!("{n} repositories"),
+                    }
+                ),
+            });
+        }
         let destination = destination.unwrap_or_else(|| package::default_destination(&self.work));
-        package::assemble(&self.work, &config, &report, &destination)
+        package::assemble(&self.work, &config, &progress.report(), &destination)
     }
 
     /// Read the engagement's key and pins, then sweep the selected repositories.
@@ -561,7 +583,7 @@ impl Session {
     /// it: it carries the OpenRouter key `tga audit`'s report render needs, and
     /// an absent config is a refusal rather than a run that will fail an hour in
     /// (#5555).
-    async fn run(&self) -> Result<RunReport, AuditError> {
+    async fn run(&self, options: &RunOptions) -> Result<RunReport, AuditError> {
         let config = EngagementConfig::load(&self.config_path)?;
         // #5797: the sweep's own preflight refuses over a tool that is missing,
         // unverified, or off the pin. Auto-install closes exactly that set
@@ -572,7 +594,7 @@ impl Session {
         if self.auto_install {
             tools::ensure(&self.work, &config.tools, &self.progress).await?;
         }
-        run::sweep(&self.work, &config, &self.progress).await
+        run::sweep(&self.work, &config, options, &self.progress).await
     }
 
     /// Read the engagement's pins, then install exactly those.
@@ -631,8 +653,13 @@ impl Session {
         // guided flow can advance from — without this the flow's final word is
         // "run the sweep", and the recipient is left holding a working directory
         // with no instruction to send anything back.
-        let audited = run::read_progress(&self.work)?
-            .is_some_and(|report| report.repos.iter().any(|r| r.result.succeeded()));
+        //
+        // #5494: FINISHED, not merely recorded. A checkpoint left by a sweep
+        // that died names audited repositories too, and pointing at the return
+        // package there would send a partial engagement instead of resuming.
+        let audited = run::read_progress(&self.work)?.is_some_and(|progress| {
+            progress.complete && progress.repos.iter().any(|r| r.result.succeeded())
+        });
 
         let next = if audited {
             NextStep::ReturnPackage
@@ -691,6 +718,12 @@ path = "/work/repos/acme-api"
 
     fn session_in(dir: &Path) -> Session {
         Session::new(WorkDir::new(dir.join("work")))
+    }
+
+    /// Record a sweep that reached the end of its selection (#5494).
+    fn write_finished_progress(work: &WorkDir, report: &RunReport) {
+        run::checkpoint::write_progress(work, &run::RunProgress::finished(report))
+            .expect("write progress");
     }
 
     fn write_manifest(session: &Session, text: &str) {
@@ -898,6 +931,91 @@ trusty-review = "0.0.0-never-published"
         );
     }
 
+    /// #5494: the checkpoint is written after every repository now, so a record
+    /// EXISTING no longer means a sweep finished. Packaging one that did not
+    /// would send a partial engagement as a whole one — the same fail-open
+    /// shape as packaging before any sweep, reached by a different route. The
+    /// refusal names the resume, because that is the remedy.
+    #[tokio::test]
+    async fn packaging_an_unfinished_sweep_is_refused() {
+        use crate::run::{RepoResult, RepoRun, SelectedRepo};
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = session_with_config(tmp.path(), UNPUBLISHABLE_CONFIG);
+        session
+            .execute(Command::WorkDir)
+            .await
+            .expect("create tree");
+        let done = vec![RepoRun {
+            repo: SelectedRepo {
+                name: "acme-api".to_owned(),
+                path: PathBuf::from("repos/acme-api"),
+            },
+            output: session.work_dir().path(Area::Output).join("00-acme-api"),
+            log: session.work_dir().path(Area::Logs).join("00-acme-api.log"),
+            gaps: Vec::new(),
+            resumed: false,
+            result: RepoResult::Succeeded,
+        }];
+        run::checkpoint::write_progress(session.work_dir(), &run::RunProgress::checkpoint(&done))
+            .expect("write checkpoint");
+
+        let err = session
+            .execute(Command::Package { destination: None })
+            .await
+            .expect_err("an interrupted sweep is not a deliverable");
+        let AuditError::NothingToPackage { reason } = &err else {
+            panic!("expected NothingToPackage, got {err:?}");
+        };
+        assert!(reason.contains("did not finish"), "{reason}");
+        assert!(reason.contains("1 repository"), "{reason}");
+        assert!(reason.contains("resume"), "{reason}");
+        assert!(
+            !crate::package::default_destination(session.work_dir()).exists(),
+            "a refused package must leave no file"
+        );
+    }
+
+    /// The guided flow reads the same completion signal: a checkpoint from a
+    /// sweep that died must send the operator back to `run` to resume, not on
+    /// to the return package (#5494).
+    #[tokio::test]
+    async fn an_interrupted_sweep_is_not_a_return_package() {
+        use crate::run::{RepoResult, RepoRun, SelectedRepo};
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = session_in(tmp.path());
+        session
+            .execute(Command::WorkDir)
+            .await
+            .expect("create tree");
+        write_manifest(&session, MANIFEST);
+        run::checkpoint::write_progress(
+            session.work_dir(),
+            &run::RunProgress::checkpoint(&[RepoRun {
+                repo: SelectedRepo {
+                    name: "acme-api".to_owned(),
+                    path: PathBuf::from("repos/acme-api"),
+                },
+                output: session.work_dir().path(Area::Output).join("00-acme-api"),
+                log: session.work_dir().path(Area::Logs).join("00-acme-api.log"),
+                gaps: Vec::new(),
+                resumed: false,
+                result: RepoResult::Succeeded,
+            }]),
+        )
+        .expect("write checkpoint");
+
+        let Outcome::Guided(status) = session.execute(Command::Guided).await.expect("runs") else {
+            panic!("Guided command must yield a Guided outcome");
+        };
+        assert_ne!(
+            status.next,
+            NextStep::ReturnPackage,
+            "an interrupted sweep must be resumed, not packaged"
+        );
+    }
+
     /// No engagement config means no metadata and no key to scan against, so
     /// packaging refuses for the same reason installing and running do.
     #[tokio::test]
@@ -933,13 +1051,10 @@ trusty-review = "0.0.0-never-published"
             output: session.work_dir().path(Area::Output).join("00-acme-api"),
             log: session.work_dir().path(Area::Logs).join("00-acme-api.log"),
             gaps: Vec::new(),
+            resumed: false,
             result: RepoResult::Succeeded,
         }]);
-        std::fs::write(
-            run::progress_path(session.work_dir()),
-            toml::to_string_pretty(&report).expect("render"),
-        )
-        .expect("write progress");
+        write_finished_progress(session.work_dir(), &report);
 
         let Outcome::Guided(status) = session.execute(Command::Guided).await.expect("runs") else {
             panic!("Guided command must yield a Guided outcome");
@@ -1073,7 +1188,7 @@ trusty-review = "0.0.0-never-published"
         let session = session_that_cannot_install(tmp.path());
 
         let err = session
-            .execute(Command::Run)
+            .execute(Command::Run(RunOptions::default()))
             .await
             .expect_err("the sweep must have tried to install");
         assert!(
@@ -1091,7 +1206,7 @@ trusty-review = "0.0.0-never-published"
         let session = session_that_cannot_install(tmp.path()).with_auto_install(false);
 
         let err = session
-            .execute(Command::Run)
+            .execute(Command::Run(RunOptions::default()))
             .await
             .expect_err("no tools, no sweep");
         assert!(

--- a/crates/trusty-audit/src/workdir.rs
+++ b/crates/trusty-audit/src/workdir.rs
@@ -221,13 +221,18 @@ impl WorkDir {
 /// it — a producer that crashes mid-write leaves syntactically valid TOML
 /// holding a PREFIX of the entries, which reads as a smaller-but-complete
 /// document. #5822 adds a second such file (`crate::registry`), so the
-/// discipline moved here rather than being restated per producer.
+/// discipline moved here rather than being restated per producer. #5494 adds a
+/// third, and the one that most needs it: the run checkpoint is written after
+/// every repository precisely so it survives the crash it exists for, and a
+/// torn one would tell the next run a four-hour audit had finished.
 /// What: creates the parent directory, writes to a uniquely-named temporary
 /// file beside the target, and renames it into place. The rename is atomic; the
 /// unique suffix is what lets two writers race without either reading the
 /// other's half-written file. A failed rename removes the temporary file.
 /// Test: `crate::run::run_tests::racing_writers_never_leave_a_torn_selection`,
-/// `crate::registry::registry_tests::a_registry_round_trips_both_kinds`.
+/// `crate::registry::registry_tests::a_registry_round_trips_both_kinds`,
+/// `super::layout_tests::an_atomic_write_leaves_no_temporary_behind`,
+/// `super::layout_tests::an_unpublishable_target_is_an_error_and_leaves_no_temporary`.
 ///
 /// This makes ONE write untearable. It does not make a load-mutate-save
 /// indivisible — [`crate::registry::register`] takes a lock for that (#5822).
@@ -324,6 +329,49 @@ mod layout_tests {
         let before = names.len();
         names.dedup();
         assert_eq!(before, names.len(), "two areas share a directory name");
+    }
+
+    /// The temporary the rename publishes from must never outlive the write —
+    /// a `state/` littered with `.tmp` files is how a reader learns to guess.
+    #[test]
+    fn an_atomic_write_leaves_no_temporary_behind() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let target = tmp.path().join("state/run-progress.toml");
+
+        write_atomically(&target, "complete = false\n").expect("first write");
+        write_atomically(&target, "complete = true\n").expect("overwrite");
+
+        assert_eq!(
+            std::fs::read_to_string(&target).expect("reads"),
+            "complete = true\n"
+        );
+        let leftovers: Vec<PathBuf> = std::fs::read_dir(tmp.path().join("state"))
+            .expect("read state")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|e| e == "tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "{leftovers:?}");
+    }
+
+    /// A target that cannot be published is an error, never a silent no-op —
+    /// the caller has to be able to refuse over it.
+    #[test]
+    fn an_unpublishable_target_is_an_error_and_leaves_no_temporary() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let target = tmp.path().join("state/run-progress.toml");
+        // A non-empty directory at the target: the rename cannot replace it.
+        std::fs::create_dir_all(&target).expect("mkdir");
+        std::fs::write(target.join("occupied"), b"x").expect("write");
+
+        let err = write_atomically(&target, "complete = true\n")
+            .expect_err("a directory cannot be replaced by a rename");
+        assert!(matches!(err, AuditError::WorkDir { .. }), "{err:?}");
+        let leftovers: Vec<PathBuf> = std::fs::read_dir(tmp.path().join("state"))
+            .expect("read state")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|e| e == "tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "{leftovers:?}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #5494.

`trusty-audit run` writes `state/run-progress.toml` after every repository
instead of once at the end, and a re-run picks up from it. A crash, a timeout or
a Ctrl-C now costs the repositories still to come and none of the ones already
audited.

Design rationale is in the module docs of `crates/trusty-audit/src/run/checkpoint.rs`
(why the checkpoint is per repository and not per stage, and why it takes no
lock) and in `crates/trusty-audit/README.md`.

## What a reviewer should check

- The checkpoint write is a refusal, not a warning. `run.rs` propagates it with
  `?` after every repository, so a sweep whose progress cannot be recorded stops
  rather than auditing the rest against a record it cannot write.
  `a_checkpoint_that_cannot_be_written_stops_the_sweep` is the proof; removing
  the `?` makes both children run and the assertion fires on the invocation
  count.
- Carrying a repository over is decided against the disk. `checkpoint::plan`
  matches the record on the repository AND on the output path the current
  selection computes for it, then re-runs `verify_output` — the same check that
  accepted the entry originally. A deleted output, a reordered selection, or a
  recorded failure all re-collect.
- `--fresh` is the operator's override, and resume is the default: the expensive
  direction is the one asked for by name.
- `package` and the guided flow read `RunProgress::complete`, not the record's
  presence. A checkpoint left by a sweep that died is refused with the count it
  holds and a pointer at the resume, instead of being sent as a whole engagement.
- `RunOptions` reaches the crate as `Command::Run(RunOptions)` through
  `Session::execute`, which stays terminal-free. `cli.rs`'s exhaustive
  `Command` match is intact.

## Gates — rung 3

The change is localized to `trusty-audit`; no other crate's source is touched.

```
cargo fmt --check                                       EXIT=0
cargo check -p trusty-audit --all-targets               EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-audit                              EXIT=0
  test result: ok. 247 passed; 0 failed; 5 ignored   (lib)
  test result: ok. 3 passed; 0 failed; 0 ignored
  test result: ok. 4 passed; 0 failed; 0 ignored
  test result: ok. 4 passed; 0 failed; 2 ignored
  test result: ok. 9 passed; 0 failed; 0 ignored
  267 passed, 0 failed, 7 ignored
bash scripts/check_line_cap.sh                          EXIT=0
bash scripts/check_sld.sh                               EXIT=0
  sld-lint: scanned 60 spec doc(s) + 3300 code file(s); 0 error(s), 0 warning(s)
bash scripts/check_test_pointers.sh                     EXIT=0
  test-pointers: resolved 25173 Test: citation(s) — 0 dangling pointers — OK.
bash scripts/check_changelog_fragment.sh                EXIT=0
  OK   trusty-audit: changelog.d fragment present and valid
```

The 7 ignored tests are the crate's pre-existing network probes (authenticated
`gh`, the GitHub release API, api.linear.app). This branch adds no `#[ignore]`
and touches no file under `crates/trusty-audit/tests/`.

### The fail-open guard, deliberately broken

`run.rs:494` changed from `write_progress(...)?` to `let _ = write_progress(...)`:

```
running 1 test
test run::run_tests::a_checkpoint_that_cannot_be_written_stops_the_sweep ... FAILED

thread '...' panicked at crates/trusty-audit/src/run.rs:1958:9:
assertion `left == right` failed: the sweep must stop at the repository whose
completion could not be recorded, not audit the rest against a record it cannot
write: [".../work/out/00-acme-api", ".../work/out/01-acme-web"]
  left: 2
 right: 1

test result: FAILED. 0 passed; 1 failed; 0 ignored; 251 filtered out
```

Reverted; the tree at HEAD is the guarded version.

## Note for the next PR that touches `run.rs`

`run.rs` is around 470 production SLOC against the 500 cap. The cap gate passes
here, but the headroom is thin enough that the next addition should expect to
split it.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
