### PR TITLE
fix(trusty-agents): content-address stale backups so a second local edit survives reprovision

### DIFF
--- a/crates/trusty-agents/changelog.d/4461-content-addressed-stale-backups.md
+++ b/crates/trusty-agents/changelog.d/4461-content-addressed-stale-backups.md
@@ -1,0 +1,8 @@
+Fixed
+
+- Bundled-agent reprovision no longer destroys a locally-edited file after the first time ([#4461](https://github.com/bobmatnyc/trusty-tools/issues/4461))
+  - The backup was written only when `<file>.stale.bak` did not already exist. So the first reprovision archived a hand-edit, and every reprovision after that overwrote the file and skipped the backup because one was already sitting there. A second edit-then-reprovision cycle lost the work with no error, no warning, and no recoverable copy — which is how a `cto-assistant` tool grant was destroyed on 2026-07-31.
+  - The backup path now carries the SHA-256 digest of the bytes being archived: `<file>.stale.<digest>.bak`. Two different contents can never target the same path, so no pass can clobber another's backup — the property the fixed name was protecting — and every divergence stays recoverable.
+  - What bounds the set: one file per distinct content ever overwritten at that path. An untouched file is never overwritten and never archived, and re-archiving identical bytes resolves to the path already there, so repeated `tagent agents repair` runs add nothing. The set grows only with real divergences, never with the number of reprovisions. Nothing prunes it — every entry is content a human may still need.
+  - Each archive now logs a `WARN` naming the file and its backup, so a refresh that discarded local content is distinguishable from one that refreshed a pristine file.
+  - Existing `<file>.stale.bak` files from earlier versions are left alone. Both agent listers already skip `*.bak`, so the new names never surface as bogus agents.

--- a/crates/trusty-agents/src/agents/bundled/lock.rs
+++ b/crates/trusty-agents/src/agents/bundled/lock.rs
@@ -5,11 +5,14 @@
 //! sequence unguarded, and `delegate_to_agent` routinely spawns a fresh
 //! `tagent` subprocess per delegation — so multiple processes can enter the
 //! stale-stamp refresh path concurrently right after a binary upgrade.
-//! Without mutual exclusion across the ENTIRE pass (not just per file), one
-//! process's crash mid-write (or a genuinely torn on-disk file left by an
-//! earlier interrupted pass) can be picked up by a second pass and archived
-//! OVER a prior process's still-good `.stale.bak`, destroying the one
-//! recovery copy a hand-edit depended on. `crates/trusty-agents/src/
+//! Without mutual exclusion across the ENTIRE pass (not just per file), a
+//! second pass can observe a half-finished one — a torn on-disk file left by
+//! an earlier interrupted pass, or a stamp that does not yet match what is
+//! actually on disk — and act on it. Since #4461 a backup path is derived
+//! from the bytes it holds, so that torn content lands in its own file
+//! rather than over a prior pass's still-good backup; the lock is what keeps
+//! the stamp read-decide-write in one critical section with the refresh
+//! loop. `crates/trusty-agents/src/
 //! state_writer.rs` already solves the identical class of problem (fs4
 //! advisory lock + tmp-file + rename) for state files at PER-FILE
 //! granularity; this reuses the same `fs4` primitive but at PASS granularity

--- a/crates/trusty-agents/src/agents/bundled/mod.rs
+++ b/crates/trusty-agents/src/agents/bundled/mod.rs
@@ -26,8 +26,10 @@
 //! ([`stamp`]) and, on a hash mismatch, refreshes exactly the bundled files
 //! whose content actually changed — never a user's own non-bundled agent,
 //! and never silently: a bundled file whose ON-DISK content differs from
-//! what is about to be written is archived to a sibling `<file>.stale.bak`
-//! first, so a user who hand-edited a bundled file can recover it.
+//! what is about to be written is archived to a sibling
+//! `<file>.stale.<digest>.bak` first, so a user who hand-edited a bundled
+//! file can recover it — see [`stale_backup_path`] for why the name carries
+//! the content digest and what bounds the resulting set (#4461).
 //!
 //! trusty-mpm solves the identical problem for ITS bundled agents/skills via
 //! `include_str!` + an explicit `install` deploy step
@@ -66,10 +68,10 @@
 //! loop, leaving the stamp read/decide/write outside it — two concurrent
 //! passes could both observe the same stale stamp, both refresh, then race
 //! writing the stamp). Two concurrent passes over the same `target_dir` are
-//! now fully serialized end to end, not just per-file. A `<file>.stale.bak`
-//! is only ever created when one doesn't already exist, so a later pass —
-//! even one recovering from a prior crash — can never clobber a genuine
-//! backup with torn or already-refreshed content.
+//! now fully serialized end to end, not just per-file. A backup path is
+//! derived from the bytes it holds, so a later pass — even one recovering
+//! from a prior crash — writes torn or already-refreshed content to its own
+//! path and can never clobber a genuine backup (#4461).
 //!
 //! Test: see `tests.rs` in this module, plus `stamp`'s and `lock`'s own
 //! tests.
@@ -77,6 +79,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
 
 mod lock;
 mod stamp;
@@ -114,7 +117,7 @@ struct BundledWorkflows;
 /// What: `written` counts brand-new files, `refreshed` counts existing
 /// bundled files whose content was updated to match the current embedded
 /// template, `backed_up` counts how many of those refreshes archived a
-/// differing prior copy to `<file>.stale.bak` first.
+/// differing prior copy to `<file>.stale.<digest>.bak` first.
 /// Test: `deploy_writes_missing_files_only`, `stale_stamp_triggers_refresh`,
 /// `refresh_backs_up_differing_content` (tests.rs).
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -199,17 +202,19 @@ fn reprovision_bundled_agents(target_dir: &Path, refresh_stale: bool) -> Result<
 /// present and `refresh_stale` is `false`, skips it untouched; when present
 /// and `refresh_stale` is `true`, compares on-disk bytes to the embedded
 /// bytes — identical content is skipped, differing content is archived to
-/// `<dest>.stale.bak` (`backed_up`) ONLY WHEN that backup doesn't already
-/// exist (so a later pass recovering from an earlier crash can never
-/// clobber a genuine prior backup with torn or already-refreshed content),
-/// THEN overwritten (`refreshed`) via `crate::state_writer::atomic_write`
+/// the content-addressed [`stale_backup_path`] (`backed_up`) and then
+/// overwritten (`refreshed`) via `crate::state_writer::atomic_write`
 /// (tmp-file + rename, so a crash mid-write leaves the original file/backup
-/// intact rather than torn). Only ever touches paths that are part of the
-/// embedded bundle — a user's own non-bundled file at `target_dir` is never
-/// read, backed up, or written.
+/// intact rather than torn). The backup write is skipped only when that
+/// exact path already exists, which — because the path is derived from the
+/// bytes — means those bytes are already archived. Only ever touches paths
+/// that are part of the embedded bundle — a user's own non-bundled file at
+/// `target_dir` is never read, backed up, or written.
 /// Test: `stale_stamp_triggers_refresh`, `refresh_backs_up_differing_content`,
 /// `non_bundled_user_file_untouched_by_refresh`,
-/// `existing_stale_backup_is_never_clobbered` (tests.rs);
+/// `existing_stale_backup_is_never_clobbered`,
+/// `repeated_divergence_is_recoverable_across_reprovisions`,
+/// `pristine_files_are_reprovisioned_without_littering_backups` (tests.rs);
 /// `pass_lock_serializes_concurrent_reprovision_calls` (`lock`'s own tests)
 /// pins the underlying mutual-exclusion primitive.
 fn reprovision_embedded_locked<E: rust_embed::RustEmbed>(
@@ -232,7 +237,10 @@ fn reprovision_embedded_locked<E: rust_embed::RustEmbed>(
             if current == file.data.as_ref() {
                 continue;
             }
-            let backup = stale_backup_path(&dest);
+            // #4461: the backup name carries the digest of the bytes being
+            // archived, so a second divergence lands beside the first rather
+            // than being skipped as "already backed up".
+            let backup = stale_backup_path(&dest, &current);
             if !backup.exists() {
                 crate::state_writer::atomic_write(&backup, &current).with_context(|| {
                     format!(
@@ -240,6 +248,12 @@ fn reprovision_embedded_locked<E: rust_embed::RustEmbed>(
                         backup.display()
                     )
                 })?;
+                tracing::warn!(
+                    file = %dest.display(),
+                    backup = %backup.display(),
+                    "on-disk bundled file differs from the shipped template; \
+                     archived its content before overwriting"
+                );
                 report.backed_up += 1;
             }
             crate::state_writer::atomic_write(&dest, file.data.as_ref())
@@ -255,20 +269,45 @@ fn reprovision_embedded_locked<E: rust_embed::RustEmbed>(
     Ok(report)
 }
 
-/// Sibling backup path for a bundled file about to be overwritten (#3556).
+/// Sibling backup path for a bundled file about to be overwritten, named
+/// after the CONTENT being archived (#3556, #4461).
 ///
-/// Why: constraints call for a fixed, non-wall-clock suffix (the environment
-/// this ships in forbids `Date::now()`-style timestamps in library code, and
-/// a fixed name is also simpler to document/find than a rotating one) — a
-/// single generation of backup is enough to recover from an unintentional
-/// refresh; it intentionally overwrites any PRIOR `.stale.bak` rather than
-/// accumulating an unbounded history.
-/// What: appends the literal `.stale.bak` suffix to the full file name
-/// (e.g. `assistant/agent.toml` -> `assistant/agent.toml.stale.bak`).
-/// Test: `refresh_backs_up_differing_content` (tests.rs).
-fn stale_backup_path(dest: &Path) -> PathBuf {
+/// Why: the original fixed `.stale.bak` name gave each file exactly one
+/// backup slot, and the caller wrote it only when that slot was empty — so
+/// the first reprovision preserved a hand-edit and every later one discarded
+/// the user's work silently, because a backup was already sitting there
+/// (#4461). Deriving the name from the archived bytes makes the write both
+/// safe and complete: two different contents can never target the same path,
+/// so no pass can clobber another's backup (the property the fixed name was
+/// protecting), and the same content re-archived resolves to the same path,
+/// so nothing accumulates from repeated no-change passes. A wall-clock
+/// suffix would give the same safety but a new file on every pass; the
+/// digest is what bounds the set.
+///
+/// What bounds the set: one file per DISTINCT content ever overwritten at
+/// this path. Reprovisioning N times over an unchanged file adds nothing —
+/// an unchanged file is never overwritten at all, and re-archiving identical
+/// bytes hits the existing path. The set grows only when the file genuinely
+/// diverges again with content not already archived, so its size is the
+/// number of real divergences, never the number of reprovisions. Nothing
+/// prunes it: every entry is content a human may still need, and an
+/// automatic sweep would be free to delete the exact hand-edit this exists
+/// to preserve.
+///
+/// What: appends `.stale.<digest>.bak` to the full file name, where
+/// `<digest>` is the first 16 hex characters of the SHA-256 of `content`
+/// (e.g. `assistant/agent.toml` -> `assistant/agent.toml.stale.9f2c….bak`).
+/// The `.bak` tail is kept because the agent listers filter on it —
+/// `repl::agent_commands::list_assistant_agents_into` and
+/// `api::server::projects`'s catalog scan both skip `*.bak`, so a backup
+/// never surfaces as a bogus agent.
+/// Test: `refresh_backs_up_differing_content`,
+/// `repeated_divergence_is_recoverable_across_reprovisions`,
+/// `identical_content_reuses_one_backup_path` (tests.rs).
+fn stale_backup_path(dest: &Path, content: &[u8]) -> PathBuf {
+    let digest = format!("{:x}", Sha256::digest(content));
     let mut name = dest.as_os_str().to_os_string();
-    name.push(".stale.bak");
+    name.push(format!(".stale.{}.bak", &digest[..16]));
     PathBuf::from(name)
 }
 
@@ -326,8 +365,9 @@ pub fn ensure_bundled_agents_deployed_in(target_dir: &Path) -> Result<Reprovisio
 /// (#5227 generalisation of `ensure_bundled_agents_deployed_in`).
 ///
 /// Why: agents and workflows need byte-identical deploy semantics — the
-/// pass-level lock, the content-hash staleness check, the `.stale.bak` archive
-/// of a differing on-disk copy. Duplicating that for a second config kind
+/// pass-level lock, the content-hash staleness check, the
+/// `.stale.<digest>.bak` archive of a differing on-disk copy. Duplicating
+/// that for a second config kind
 /// would guarantee the two drift; parameterising over the embed keeps one
 /// implementation. `stamp` and `lock` are already per-`target_dir`, so the two
 /// trees never share a stamp file.

--- a/crates/trusty-agents/src/agents/bundled/tests.rs
+++ b/crates/trusty-agents/src/agents/bundled/tests.rs
@@ -15,6 +15,83 @@
 
 use super::*;
 
+/// Every archived backup of `dest`, found by NAME rather than by calling the
+/// implementation's own path builder (#4461).
+///
+/// Why: a test that asks `stale_backup_path` where to look would agree with
+/// the implementation by construction, including when the implementation is
+/// wrong — the whole defect was a backup that silently never got written.
+/// Scanning the directory for `<name>.stale.*.bak` also matches the legacy
+/// fixed `<name>.stale.bak`, so these tests measure how many distinct
+/// contents are recoverable, not what the files happen to be called.
+/// What: reads `dest`'s parent directory and returns every sibling whose name
+/// starts with `<dest file name>.stale.` and ends with `.bak`, sorted.
+/// Test: used by `refresh_backs_up_differing_content`,
+/// `existing_stale_backup_is_never_clobbered`,
+/// `repeated_divergence_is_recoverable_across_reprovisions`,
+/// `identical_content_reuses_one_backup_path`.
+fn stale_backups_of(dest: &Path) -> Vec<PathBuf> {
+    let dir = dest.parent().expect("dest sits inside the target dir");
+    let name = dest
+        .file_name()
+        .and_then(|s| s.to_str())
+        .expect("bundled paths are UTF-8");
+    let prefix = format!("{name}.stale.");
+    let mut found: Vec<PathBuf> = std::fs::read_dir(dir)
+        .expect("the package directory exists after a deploy")
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|s| s.to_str())
+                .is_some_and(|n| n.starts_with(&prefix) && n.ends_with(".bak"))
+        })
+        .collect();
+    found.sort();
+    found
+}
+
+/// The archived content of every backup of `dest`, in path order.
+fn stale_backup_contents(dest: &Path) -> Vec<String> {
+    stale_backups_of(dest)
+        .iter()
+        .map(|path| std::fs::read_to_string(path).expect("a backup must be readable"))
+        .collect()
+}
+
+/// Every `*.bak` file anywhere under `root` (#4461).
+///
+/// Why: "an untouched file must not litter backups" is a claim about the
+/// WHOLE deploy tree, not one package — a per-file check would miss a backup
+/// written beside some other bundled agent.
+/// What: walks `root` depth-first and collects every file whose name ends
+/// with `.bak`.
+/// Test: used by `first_run_writes_no_backups`,
+/// `pristine_files_are_reprovisioned_without_littering_backups`.
+fn all_backup_files(root: &Path) -> Vec<PathBuf> {
+    let mut pending = vec![root.to_path_buf()];
+    let mut found = Vec::new();
+    while let Some(dir) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .is_some_and(|n| n.ends_with(".bak"))
+            {
+                found.push(path);
+            }
+        }
+    }
+    found.sort();
+    found
+}
+
 /// Why: the core contract — a fresh empty target directory gets every
 /// embedded file, and the count matches what was actually written.
 /// Test: itself.
@@ -157,20 +234,137 @@ fn refresh_backs_up_differing_content() {
     assert_eq!(report.backed_up, 1);
     assert_eq!(report.refreshed, 1);
 
-    let backup_path = tmp.path().join("assistant").join("agent.toml.stale.bak");
-    let backup_content = std::fs::read_to_string(&backup_path).unwrap();
+    let backups = stale_backups_of(&assistant_toml);
+    assert_eq!(backups.len(), 1, "exactly one archived copy: {backups:?}");
+    let backup_content = std::fs::read_to_string(&backups[0]).unwrap();
     assert_eq!(
         backup_content, hand_edited,
         "backup must preserve the pre-refresh content verbatim"
     );
 }
 
-/// Why (#3556 code-critic follow-up, HIGH): a `.stale.bak` is a one-shot
-/// recovery copy — if a SECOND refresh pass (e.g. a later process recovering
-/// from an earlier pass's crash, or simply another edit) finds a backup
-/// already there, it must NOT overwrite it with whatever is on disk NOW.
-/// Without this, a genuine hand-edit backed up by pass 1 could be silently
-/// destroyed by pass 2 backing up torn or already-refreshed content over it.
+/// Why (#4461 — the defect this test would have caught): the backup used to
+/// be written only when NO backup existed yet, so the first reprovision
+/// preserved a hand-edit and every later one overwrote the file while
+/// skipping the backup. Two edit-then-reprovision cycles lost the second
+/// edit with no error, no warning, and no recoverable copy — which is how a
+/// `cto-assistant` tool grant was destroyed on 2026-07-31.
+/// What: edits a bundled file, reprovisions, edits it differently,
+/// reprovisions again, then asserts BOTH edits are still readable from
+/// archived backups. Against the pre-fix code the second pass reports
+/// `backed_up == 0` and the second edit is unrecoverable.
+/// Test: itself.
+#[test]
+fn repeated_divergence_is_recoverable_across_reprovisions() {
+    let tmp = tempfile::tempdir().unwrap();
+    deploy_bundled_agents(tmp.path()).unwrap();
+    let assistant_toml = tmp.path().join("assistant").join("agent.toml");
+
+    let first_edit = "# edit one — an owner-requested tool grant\n[agent]\nname = \"assistant\"\n";
+    std::fs::write(&assistant_toml, first_edit).unwrap();
+    let first_pass = force_reprovision_bundled_agents(tmp.path()).unwrap();
+    assert_eq!(first_pass.backed_up, 1, "the first edit must be archived");
+
+    let second_edit =
+        "# edit two — made after the first reprovision\n[agent]\nname = \"assistant\"\n";
+    std::fs::write(&assistant_toml, second_edit).unwrap();
+    let second_pass = force_reprovision_bundled_agents(tmp.path()).unwrap();
+    assert_eq!(
+        second_pass.backed_up, 1,
+        "the second edit is new content and must be archived too"
+    );
+    assert_eq!(second_pass.refreshed, 1);
+
+    let archived = stale_backup_contents(&assistant_toml);
+    assert!(
+        archived.iter().any(|c| c == first_edit),
+        "the first edit must still be recoverable: {archived:?}"
+    );
+    assert!(
+        archived.iter().any(|c| c == second_edit),
+        "the second edit must still be recoverable — this is the data loss \
+         #4461 reported: {archived:?}"
+    );
+}
+
+/// Why (#4461): naming a backup after its content is what bounds the set —
+/// re-archiving bytes that are already archived must reuse the same path
+/// rather than adding a generation. Without this, the fix would trade silent
+/// data loss for an unbounded pile of files.
+/// What: applies the SAME edit twice, with a reprovision after each, and
+/// asserts exactly one backup exists holding that content.
+/// Test: itself.
+#[test]
+fn identical_content_reuses_one_backup_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    deploy_bundled_agents(tmp.path()).unwrap();
+    let assistant_toml = tmp.path().join("assistant").join("agent.toml");
+
+    let edit =
+        "# the same hand edit, re-applied after each repair\n[agent]\nname = \"assistant\"\n";
+    for _ in 0..2 {
+        std::fs::write(&assistant_toml, edit).unwrap();
+        force_reprovision_bundled_agents(tmp.path()).unwrap();
+    }
+
+    let backups = stale_backups_of(&assistant_toml);
+    assert_eq!(
+        backups.len(),
+        1,
+        "identical content must archive to one path, not one per pass: {backups:?}"
+    );
+    assert_eq!(std::fs::read_to_string(&backups[0]).unwrap(), edit);
+}
+
+/// Why (#4461): a reprovision over files the user never touched must leave no
+/// backups at all — an operator who runs `tagent agents repair` routinely
+/// should never accumulate `.bak` files for it.
+/// What: deploys, then force-reprovisions twice with no edit in between, and
+/// asserts no `*.bak` file exists anywhere under the target directory.
+/// Test: itself.
+#[test]
+fn pristine_files_are_reprovisioned_without_littering_backups() {
+    let tmp = tempfile::tempdir().unwrap();
+    deploy_bundled_agents(tmp.path()).unwrap();
+
+    for _ in 0..2 {
+        let report = force_reprovision_bundled_agents(tmp.path()).unwrap();
+        assert_eq!(report.backed_up, 0);
+        assert_eq!(report.refreshed, 0, "on-disk content already matches");
+    }
+
+    let backups = all_backup_files(tmp.path());
+    assert!(
+        backups.is_empty(),
+        "an untouched deploy must produce no backups: {backups:?}"
+    );
+}
+
+/// Why (#4461): on a machine with no deployed roster yet there is nothing to
+/// overwrite, so the backup path must not run at all.
+/// What: points a stamp-aware deploy at an empty directory and asserts files
+/// were written, none were backed up, and no `*.bak` exists.
+/// Test: itself.
+#[test]
+fn first_run_writes_no_backups() {
+    let tmp = tempfile::tempdir().unwrap();
+    let report = ensure_bundled_agents_deployed_in(tmp.path()).unwrap();
+
+    assert!(report.written > 0, "a first run establishes the roster");
+    assert_eq!(report.backed_up, 0, "nothing existed to back up");
+    let backups = all_backup_files(tmp.path());
+    assert!(backups.is_empty(), "no backups on a first run: {backups:?}");
+}
+
+/// Why (#3556 code-critic follow-up, HIGH; naming reworked by #4461): a
+/// second refresh pass — a later process recovering from an earlier pass's
+/// crash, or simply another edit — must never overwrite an existing backup
+/// with whatever is on disk NOW. #3556 bought that by refusing to write a
+/// second backup at all, which is exactly what destroyed the second edit
+/// (#4461); the digest-named path buys the same protection without the loss,
+/// because torn or already-refreshed content resolves to its own path.
+/// What: backs up one hand edit, then reprovisions again over DIFFERENT
+/// content and asserts the first backup is still byte-identical.
 /// Test: itself.
 #[test]
 fn existing_stale_backup_is_never_clobbered() {
@@ -186,8 +380,10 @@ fn existing_stale_backup_is_never_clobbered() {
     assert_eq!(first_pass.backed_up, 1);
     assert_eq!(first_pass.refreshed, 1);
 
-    let backup_path = tmp.path().join("assistant").join("agent.toml.stale.bak");
-    assert_eq!(std::fs::read_to_string(&backup_path).unwrap(), first_edit);
+    let first_backup = stale_backups_of(&assistant_toml)
+        .pop()
+        .expect("the first edit must be archived");
+    assert_eq!(std::fs::read_to_string(&first_backup).unwrap(), first_edit);
 
     // A second stale pass — standing in for a crash-recovering later process
     // or another hand edit — must not clobber the FIRST backup.
@@ -195,13 +391,9 @@ fn existing_stale_backup_is_never_clobbered() {
     std::fs::write(&assistant_toml, second_edit).unwrap();
 
     let second_pass = force_reprovision_bundled_agents(tmp.path()).unwrap();
-    assert_eq!(
-        second_pass.backed_up, 0,
-        "a backup already exists — a second pass must not overwrite it"
-    );
     assert_eq!(second_pass.refreshed, 1, "dest itself is still refreshed");
     assert_eq!(
-        std::fs::read_to_string(&backup_path).unwrap(),
+        std::fs::read_to_string(&first_backup).unwrap(),
         first_edit,
         "the ORIGINAL backup must survive untouched"
     );
@@ -229,9 +421,10 @@ fn non_bundled_user_file_untouched_by_refresh() {
         after, user_content,
         "a non-bundled user file must never be touched by a refresh pass"
     );
+    let backups = stale_backups_of(&user_file);
     assert!(
-        !tmp.path().join("my-custom-agent.toml.stale.bak").exists(),
-        "no backup should be created for a file the bundle doesn't own"
+        backups.is_empty(),
+        "no backup should be created for a file the bundle doesn't own: {backups:?}"
     );
 }
 

--- a/crates/trusty-agents/src/runtime/registry_cmds/mod.rs
+++ b/crates/trusty-agents/src/runtime/registry_cmds/mod.rs
@@ -135,7 +135,7 @@ use workflow::WorkflowEngine;
 /// bundle content has changed since the last deploy (detected via a
 /// persisted content-hash stamp), refreshes exactly the bundled files whose
 /// content actually differs — archiving any differing on-disk copy to
-/// `<file>.stale.bak` first. A non-bundled file (a user's own agent) is
+/// `<file>.stale.<digest>.bak` first. A non-bundled file (a user's own agent) is
 /// never touched either way. `repair` bypasses the stamp check entirely,
 /// force-refreshing every bundled file unconditionally.
 /// Test: Covered manually; unit-tested via `AgentRegistry::list` and
@@ -230,7 +230,7 @@ fn print_reprovision_report(verb: &str, report: &agents::bundled::ReprovisionRep
     }
     let backup_note = if report.backed_up > 0 {
         format!(
-            ", {} pre-refresh backup(s) saved as *.stale.bak",
+            ", {} pre-refresh backup(s) saved as *.stale.<digest>.bak",
             report.backed_up
         )
     } else {


### PR DESCRIPTION
Closes #4461.

The defect: `stale_backup_path` wrote to a single fixed `<file>.stale.bak`, and the caller wrote only when that path was absent. The first reprovision archived a hand-edit; every one after overwrote the local file and **skipped the backup because one already existed**. The second edit-then-reprovision cycle lost work silently. The changelog fragment names the 2026-07-31 incident where `cto-assistant.toml` was destroyed this way.

**The `!backup.exists()` guard was deliberate, not an oversight** — this is the part a reviewer needs. The module doc, `lock.rs`, and `existing_stale_backup_is_never_clobbered` all state its purpose: stop a later pass writing torn or already-refreshed content over a genuine hand-edit backup. So overwriting the slot when content differs would reintroduce that clobber, and two upgrades in a row would archive the pristine old template over the user's edit. Refusing to overwrite a diverged file would block the security-fix propagation #3556 exists to deliver.

The fix: backups are content-addressed as `<file>.stale.<16-hex-of-sha256>.bak`. The path derives from the bytes being archived, so absence means "these bytes are not archived yet" rather than "this file has never been backed up". Keeps the anti-clobber property — different bytes cannot collide on a path — and adds the missing one.

**What bounds the set:** one file per distinct content ever overwritten at that path, not one per reprovision. An unchanged file is never overwritten so never archived; re-archiving identical bytes resolves to the path already there. Nothing prunes it, deliberately — every entry is content a human may still need, and a retention sweep would be free to delete the exact hand-edit this exists to preserve.

Also added: a `tracing::warn!` naming the file and its backup, so a `5 refreshed` report stops being indistinguishable between a pristine refresh and a discarded local edit.

Existing `.stale.bak` files are untouched, and both listers (`repl/agent_commands.rs:206`, `api/server/projects.rs:623`) filter on `ends_with(".bak")`, so the new names still never surface as bogus agents.

The new tests locate backups by scanning for `<name>.stale.*.bak` rather than calling `stale_backup_path`, so they measure how many distinct contents are recoverable and cannot agree with a wrong implementation by construction. That is also why the pre-fix run compiles and fails on behaviour rather than on a signature: `repeated_divergence_is_recoverable_across_reprovisions` fails with `left: 0, right: 1`.

Test ladder rung 3. `fmt --check`, `check -p trusty-agents --all-targets`, `clippy -p trusty-agents --all-targets -- -D warnings`, `check --workspace`, `check_line_cap.sh`, `check_sld.sh`, `check_test_pointers.sh`, `check_changelog_fragment.sh` all exit 0. `cargo test -p trusty-agents`: 3508 passed, 1 failed — `credential_status_never_leaks_a_value`, the known environmental failure #5678, caused by an ancestor `.env.local` reachable from any worktree. `git diff --name-only -- crates/trusty-agents/src/system_status/` is empty.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
