### PR TITLE
feat(trusty-audit): one command chains install, materialize, collect and package (#5824)

### DIFF
--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -88,3 +88,8 @@ walkdir = { workspace = true }
 [dev-dependencies]
 # Real directories for the working-directory creation tests.
 tempfile = { workspace = true }
+# #5824: `tests/cli_end_to_end.rs` opens the return package the chain wrote and
+# reads its generated members, because what the recipient receives is the zip
+# rather than the console output that produced it. Already a dependency above,
+# so this costs no extra compilation.
+zip = { workspace = true }

--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -40,7 +40,34 @@ trusty-audit run                # run `tga audit` over the selected repositories
                                 #   resuming an interrupted sweep
 trusty-audit run --fresh        # audit every selected repository again
 trusty-audit package            # assemble the deliverable zip to send back
+trusty-audit audit              # all four of the above, in one invocation
 ```
+
+## The one-shot run
+
+`trusty-audit audit` drives the whole engagement: it installs the pinned tools,
+clones the repositories `trusty-audit add repo` registered, sweeps them, and
+assembles the return package. It is the command an operator who has already
+registered their targets runs; the four separate verbs stay for debugging one
+phase at a time.
+
+Interrupt it and run it again. Installed tools, complete checkouts and audited
+repositories are all carried over — the same per-phase re-entrancy the separate
+verbs have, chained.
+
+It continues past a repository that fails, because one failure in six should not
+discard five audits. What it will not do is let that read as a whole engagement:
+the package names every repository it does not cover, the process exits non-zero
+whenever anything registered was not audited, and a sweep in which NOTHING was
+audited stops before the package phase rather than producing a zip of two
+generated files. A failure names the phase it came from — install, materialize,
+collect or package — so a stopped run says which step to look at.
+
+A registered board (`jira:ACME`, `linear:ENG`) is reported as a stated gap
+rather than collected. `tga audit` does take a JIRA project, but it reads that
+credential as a literal string in its config file, and this client passes
+secrets to a child through its environment and never through a file. Wiring
+boards through needs env-var expansion on tga's JIRA credential first.
 
 The same program is also installed as `taudit`, a shorter name for repeat use —
 `taudit workdir` and `trusty-audit workdir` are one binary built from one

--- a/crates/trusty-audit/changelog.d/5824-clone-gaps-reach-the-package.md
+++ b/crates/trusty-audit/changelog.d/5824-clone-gaps-reach-the-package.md
@@ -1,0 +1,9 @@
+Fixed
+
+- A registered repository that failed to clone no longer vanishes from a
+  one-shot `trusty-audit audit` run. Its failure was recorded only on the clone
+  report, and because an unusable checkout is never selected, the sweep could
+  not see it either — so the command exited 0 and handed back a package whose
+  README said every repository was covered. The chain now folds the clone
+  report's gaps into its own, which makes the exit status non-zero and puts the
+  repository's name in the package's own `README.md` and `package.toml`.

--- a/crates/trusty-audit/changelog.d/5824-one-shot-audit.md
+++ b/crates/trusty-audit/changelog.d/5824-one-shot-audit.md
@@ -1,0 +1,13 @@
+Added
+
+- `trusty-audit audit` runs a whole engagement in one invocation — install the
+  pinned tools, clone the registered repository targets, sweep them with `tga
+  audit`, and assemble the return package — instead of `install`, `clone`, `run`
+  and `package` in order. The four separate verbs are unchanged.
+- The chained run is resumable: interrupting it and running it again carries
+  over installed tools, complete checkouts and audited repositories.
+- A phase that fails names the phase it failed in — install, materialize,
+  collect or package — rather than reporting "the audit failed".
+- A sweep that audited nothing stops before packaging, so a failed collection
+  cannot produce a zip that looks like a finished engagement. A sweep that
+  partly failed still packages, names what it omits, and exits non-zero.

--- a/crates/trusty-audit/changelog.d/5824-registry-reaches-the-sweep.md
+++ b/crates/trusty-audit/changelog.d/5824-registry-reaches-the-sweep.md
@@ -1,0 +1,10 @@
+Changed
+
+- A registered repository target now reaches the sweep. `state/audit-targets.toml`
+  had no reader until now — `run` took its input from the selection file only
+  `clone` wrote — so registering a repository did nothing until someone cloned it
+  by hand under the same name. The one-shot `audit` command clones what is
+  registered.
+- A registered board is reported as a stated gap rather than silently skipped.
+  Passing one to `tga audit` would mean writing the board credential into the
+  generated tga config on disk, which this client will not do.

--- a/crates/trusty-audit/src/chain.rs
+++ b/crates/trusty-audit/src/chain.rs
@@ -40,7 +40,10 @@
 //!   deliverable.
 //! - A sweep in which SOME repository failed still packages, and
 //!   [`crate::package::assemble`] names every repository it does not cover in
-//!   the package's own README and metadata.
+//!   the package's own README and metadata. So does every target the chain
+//!   never attempted: a repository that failed to CLONE reaches the same two
+//!   generated members, because the recipient opening the zip has those and not
+//!   this process's console output (#5824 review).
 //! - Either way [`crate::session::Outcome::exit_code`] is non-zero, so
 //!   `taudit audit && send-it` cannot chain onward over an incomplete
 //!   engagement.
@@ -152,13 +155,17 @@ pub struct ChainReport {
     pub run: RunReport,
     /// The deliverable, and what it does not cover.
     pub package: ReturnPackage,
-    /// What this engagement targets and the chain could not audit.
+    /// What this engagement targets and the chain never attempted.
     ///
-    /// Distinct from [`ReturnPackage::excluded`], which names repositories the
-    /// sweep ATTEMPTED and failed. A gap here is something never attempted at
-    /// all — a registered board today. Non-empty makes the run's exit status
-    /// non-zero, so a silently unaudited target cannot read as a whole
-    /// engagement.
+    /// Two sources: a registered board, which [`board_gap`] explains, and a
+    /// registered repository that failed to clone. Neither reaches the sweep, so
+    /// neither can appear among [`RunReport::failures`] — which is why the chain
+    /// carries them itself rather than deriving everything from the sweep.
+    ///
+    /// [`ReturnPackage::excluded`] is the superset: these lines PLUS the
+    /// repositories the sweep attempted and failed. Non-empty here makes the
+    /// run's exit status non-zero, so a silently unaudited target cannot read as
+    /// a whole engagement.
     pub gaps: Vec<String>,
 }
 
@@ -201,16 +208,22 @@ pub async fn audit(
         .await
         .map_err(|e| stopped(Phase::InstallTools, e))?;
 
-    let (repos, gaps) = split_targets(work).map_err(|e| stopped(Phase::Materialize, e))?;
+    let (repos, mut gaps) = split_targets(work).map_err(|e| stopped(Phase::Materialize, e))?;
     let acquired = materialize(work, &repos, progress)
         .await
         .map_err(|e| stopped(Phase::Materialize, e))?;
+    // #5824: a repository that failed to clone is named ONLY on the clone
+    // report. It is never selected, so the sweep cannot report it and nothing
+    // downstream would otherwise learn it was registered.
+    if let Some(acquired) = &acquired {
+        gaps.extend(acquired.gaps.iter().cloned());
+    }
 
     let run = collect(work, config, options, progress)
         .await
         .map_err(|e| stopped(Phase::Collect, e))?;
 
-    let package = assemble(work, config, options.destination.clone(), progress)
+    let package = assemble(work, config, &gaps, options.destination.clone(), progress)
         .map_err(|e| stopped(Phase::Package, e))?;
 
     Ok(ChainReport {
@@ -374,12 +387,21 @@ async fn collect(
 /// proves — that the record on disk describes a sweep which FINISHED. Passing
 /// the in-memory report would skip that check and leave two packaging paths with
 /// different preconditions.
+///
+/// `gaps` is threaded through rather than merged into
+/// [`ReturnPackage::excluded`] afterwards, because the zip is already written by
+/// the time this returns: a gap appended to the returned value would correct
+/// what this process prints and leave the README and metadata INSIDE the
+/// deliverable still claiming full coverage — and the zip is what the third
+/// party opens (#5824 review).
 /// What: announces the phase through `progress`, then assembles.
 /// Test: `super::chain_tests::the_chain_installs_collects_and_packages`,
-/// `super::chain_tests::progress_covers_every_phase`.
+/// `super::chain_tests::progress_covers_every_phase`,
+/// `cli_end_to_end::a_registered_repository_that_never_cloned_is_named_in_the_package`.
 fn assemble(
     work: &WorkDir,
     config: &EngagementConfig,
+    gaps: &[String],
     destination: Option<PathBuf>,
     progress: &Progress,
 ) -> Result<ReturnPackage, AuditError> {
@@ -390,7 +412,7 @@ fn assemble(
     );
     progress.operation_started(Operation::Package, 1);
     progress.unit_started(Operation::Package, name.as_str(), 1, 1);
-    let assembled = package::from_checkpoint(work, config, &destination);
+    let assembled = package::from_checkpoint(work, config, gaps, &destination);
     progress.unit_finished(
         Operation::Package,
         name.as_str(),

--- a/crates/trusty-audit/src/chain.rs
+++ b/crates/trusty-audit/src/chain.rs
@@ -1,0 +1,404 @@
+//! The one-shot audit: register, then run one command instead of four.
+//!
+//! Why: #5824. An operator who receives a handoff package and registers what to
+//! audit still had to type `install`, `clone`, `run` and `package` in the right
+//! order, and to know what each one had left behind before the next would work.
+//! `Command::Guided` walked the same steps but only REPORTED the next one; it
+//! never drove past it. This module drives them.
+//!
+//! What: [`audit`], which chains four phases over one working directory —
+//! install the pinned tools, materialize the registered targets, collect and
+//! analyze each one, assemble the return package — and [`ChainReport`], what
+//! each phase produced. Every phase is an existing capability called unchanged:
+//! nothing here re-implements installing, cloning, sweeping or packaging, so the
+//! four verbs and this one cannot drift apart.
+//!
+//! ## Where the registry finally reaches the sweep
+//!
+//! #5822 added `state/audit-targets.toml` and nothing read it. The sweep reads
+//! `state/selected-repos.toml`, which only `crate::clone` writes. So a
+//! registered repository was invisible to `run` until someone cloned it by hand
+//! with the same name. The materialize phase closes that: it reads the registry
+//! and hands the repository targets to [`crate::clone::clone_all`], which
+//! records the usable checkouts as the selection. A registered repository now
+//! reaches the sweep because it was registered.
+//!
+//! A registered BOARD does not, and is reported as a gap rather than dropped —
+//! see [`board_gap`] for what passing one through would cost today.
+//!
+//! ## Partial success is the normal case, and it is not success
+//!
+//! With six repositories, one failing is ordinary. The chain CONTINUES past it,
+//! because stopping would discard five audits over one failure and because that
+//! is already what `clone` and `run` do on their own (DOC-68 §14 Q2, DOC-67 §9).
+//! What it must never do is let a partial run read as a whole one, so three
+//! things hold at once:
+//!
+//! - A sweep in which NOTHING was audited stops the chain in
+//!   [`Phase::Collect`]. There is no package, because a package over zero
+//!   audited repositories is a zip of two generated files that looks like a
+//!   deliverable.
+//! - A sweep in which SOME repository failed still packages, and
+//!   [`crate::package::assemble`] names every repository it does not cover in
+//!   the package's own README and metadata.
+//! - Either way [`crate::session::Outcome::exit_code`] is non-zero, so
+//!   `taudit audit && send-it` cannot chain onward over an incomplete
+//!   engagement.
+//!
+//! ## Attribution, and resume
+//!
+//! Every phase failure arrives as [`AuditError::ChainStopped`], naming the
+//! phase; the wrapped error names the target and the reason. And because each
+//! phase is individually re-entrant — `tools::ensure` is a no-op when the pins
+//! are satisfied, `clone_all` reuses a complete checkout, and the sweep resumes
+//! from `crate::run`'s per-repository checkpoint (#5494) — re-running the chain
+//! after an interruption continues rather than restarts.
+//!
+//! Test: `super::chain_tests`.
+
+use std::fmt;
+use std::path::PathBuf;
+
+use crate::clone::{self, CloneOptions, CloneReport};
+use crate::config::EngagementConfig;
+use crate::error::AuditError;
+use crate::package::{self, ReturnPackage};
+use crate::progress::{Operation, Progress, UnitOutcome};
+use crate::registry::{Registry, Target};
+use crate::run::{self, RunOptions, RunReport, RunStatus};
+use crate::tools::{self, InstalledTool};
+use crate::workdir::WorkDir;
+
+/// Which link of the chain a failure came from.
+///
+/// Why: #5824's second requirement. Four fallible phases collapsed into one
+/// error is a message an operator cannot act on — "cannot read
+/// /w/state/audit-targets.toml" and "`tga audit` exited with code 2" call for
+/// completely different next steps, and a chain that reports both as "the audit
+/// failed" makes the operator re-derive which stage they are in.
+/// What: one variant per phase, carried on [`AuditError::ChainStopped`]. The
+/// wrapped error names the target and the reason; this names the stage.
+/// Test: `super::chain_tests::a_sweep_that_audited_nothing_stops_before_packaging`,
+/// `super::chain_tests::an_engagement_with_nothing_to_audit_stops_in_materialize`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Phase {
+    /// Downloading and verifying the engagement's pinned tool set (#5495).
+    InstallTools,
+    /// Turning registered targets into checkouts the sweep can read (#5215).
+    Materialize,
+    /// Running `tga audit` over each of them (#5555).
+    Collect,
+    /// Assembling the deliverable to send back (#5499).
+    Package,
+}
+
+impl Phase {
+    /// The name this phase is reported under, e.g. `"collect"`.
+    pub fn label(self) -> &'static str {
+        match self {
+            Phase::InstallTools => "install",
+            Phase::Materialize => "materialize",
+            Phase::Collect => "collect",
+            Phase::Package => "package",
+        }
+    }
+}
+
+impl fmt::Display for Phase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// How to run the chain.
+///
+/// Why: a struct for the same reason [`RunOptions`] is one — these are
+/// operator-facing knobs reaching the crate through
+/// [`crate::session::Command::Audit`], and they will grow neighbours.
+/// What: the sweep's `--fresh`, forwarded unchanged, and the package
+/// destination, which is the one path this client writes outside the working
+/// directory. [`ChainOptions::default`] resumes and writes the default
+/// destination.
+/// Test: `crate::cli::cli_tests::the_one_shot_audit_resumes_by_default`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ChainOptions {
+    /// Audit every selected repository again, ignoring recorded progress.
+    pub fresh: bool,
+    /// Where the return package lands, or `None` for the default.
+    pub destination: Option<PathBuf>,
+}
+
+/// What one chained run did, phase by phase.
+///
+/// Why: structured rather than text, like every other
+/// [`crate::session::Outcome`] — the CLI renders it and the Tauri shell will
+/// render the same values as a window. Keeping each phase's own report intact
+/// rather than flattening them to a verdict is what lets the front end show
+/// which repository failed at which stage.
+/// What: one field per phase, plus the gaps the chain itself states.
+/// Test: `super::chain_tests::the_chain_installs_collects_and_packages`.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ChainReport {
+    /// What the install phase placed, or `None` when the pins were satisfied
+    /// already or `--no-install` declined to reach the network.
+    pub installed: Option<Vec<InstalledTool>>,
+    /// What the materialize phase acquired, or `None` when the registry named
+    /// no repository and an earlier `clone` had already left a selection.
+    pub acquired: Option<CloneReport>,
+    /// Per-repository results from the sweep.
+    pub run: RunReport,
+    /// The deliverable, and what it does not cover.
+    pub package: ReturnPackage,
+    /// What this engagement targets and the chain could not audit.
+    ///
+    /// Distinct from [`ReturnPackage::excluded`], which names repositories the
+    /// sweep ATTEMPTED and failed. A gap here is something never attempted at
+    /// all — a registered board today. Non-empty makes the run's exit status
+    /// non-zero, so a silently unaudited target cannot read as a whole
+    /// engagement.
+    pub gaps: Vec<String>,
+}
+
+/// Run the whole engagement: install, materialize, collect, package.
+///
+/// Why: #5824 — the operator registers what to audit and then runs one command.
+/// See the module docs for the partial-success policy and what each phase is.
+///
+/// # Preconditions
+/// The engagement config is loaded (the caller owns that, as every other
+/// capability's caller does). Either the registry names at least one repository
+/// or an earlier `clone` left a selection; both absent is a refusal, not an
+/// empty run.
+///
+/// # Postconditions
+/// On `Ok`, every phase completed, at least one repository was audited, and
+/// [`ChainReport::package`] is a written file. On `Err`, the error is
+/// [`AuditError::ChainStopped`] naming the phase, and nothing claims a
+/// repository was audited that was not — in particular no package exists over a
+/// sweep that audited nothing.
+///
+/// What: four phases, each an existing capability called unchanged, each
+/// failure wrapped with its phase.
+/// Test: `super::chain_tests`.
+///
+/// # Errors
+///
+/// [`AuditError::ChainStopped`] wrapping whichever phase refused — see
+/// [`Phase`]. The credential reaches `tga audit` exactly as
+/// [`crate::run::sweep`] already sends it, through the child's environment;
+/// nothing here opens a second path to it.
+pub async fn audit(
+    work: &WorkDir,
+    config: &EngagementConfig,
+    options: &ChainOptions,
+    auto_install: bool,
+    progress: &Progress,
+) -> Result<ChainReport, AuditError> {
+    let installed = install(work, config, auto_install, progress)
+        .await
+        .map_err(|e| stopped(Phase::InstallTools, e))?;
+
+    let (repos, gaps) = split_targets(work).map_err(|e| stopped(Phase::Materialize, e))?;
+    let acquired = materialize(work, &repos, progress)
+        .await
+        .map_err(|e| stopped(Phase::Materialize, e))?;
+
+    let run = collect(work, config, options, progress)
+        .await
+        .map_err(|e| stopped(Phase::Collect, e))?;
+
+    let package = assemble(work, config, options.destination.clone(), progress)
+        .map_err(|e| stopped(Phase::Package, e))?;
+
+    Ok(ChainReport {
+        installed,
+        acquired,
+        run,
+        package,
+        gaps,
+    })
+}
+
+/// Attribute a phase's failure to that phase.
+///
+/// Boxed because [`AuditError`] is already large enough for
+/// `clippy::result_large_err` to care, and nesting one inside another without a
+/// box would grow every `Result` in the crate.
+fn stopped(phase: Phase, source: AuditError) -> AuditError {
+    AuditError::ChainStopped {
+        phase,
+        source: Box::new(source),
+    }
+}
+
+/// Phase 1 — the pinned tool set, installed only if it is not already right.
+///
+/// The same call `run` makes (#5797), so the chain cannot install a different
+/// set from the one the standalone verb installs. `--no-install` declines,
+/// leaving the sweep's own fail-closed preflight to refuse in [`Phase::Collect`]
+/// — which is the correct attribution: with the opt-out the operator asked for
+/// the tools not to be fetched, and the phase that then cannot proceed is the
+/// sweep.
+async fn install(
+    work: &WorkDir,
+    config: &EngagementConfig,
+    auto_install: bool,
+    progress: &Progress,
+) -> Result<Option<Vec<InstalledTool>>, AuditError> {
+    if !auto_install {
+        return Ok(None);
+    }
+    tools::ensure(work, &config.tools, progress).await
+}
+
+/// The registered repositories, and one gap line per target the chain cannot
+/// audit.
+fn split_targets(work: &WorkDir) -> Result<(Vec<String>, Vec<String>), AuditError> {
+    let registry = Registry::load(work)?;
+    let mut repos = Vec::new();
+    let mut gaps = Vec::new();
+    for target in registry.targets() {
+        match target {
+            Target::Repo { name_with_owner } => repos.push(name_with_owner.clone()),
+            Target::Board { .. } => gaps.push(board_gap(target)),
+        }
+    }
+    Ok((repos, gaps))
+}
+
+/// Why a registered board is a gap rather than a collected dimension.
+///
+/// Why: `tga audit` does take a board — its config has a `jira:` section and it
+/// runs a `JiraSync` stage — but tga reads that section's `token` as a literal
+/// string, with none of the `${VAR}` expansion its Linear and Azure DevOps
+/// clients apply (`tga::collect::env_expand::expand_env_var`). Passing a JIRA
+/// board through today therefore means writing the board credential into the
+/// generated `state/tga-<stem>.yaml`, and this crate's whole credential posture
+/// is that a secret reaches a child through its environment and never through a
+/// file (DOC-68 §13, `crate::run`'s module docs). The chain states the gap
+/// instead, and the durable fix is env-var expansion on tga's JIRA credential.
+/// What: one line naming the board, safe to show the recipient.
+/// Test: `super::chain_tests::a_registered_board_is_stated_as_a_gap`.
+fn board_gap(target: &Target) -> String {
+    format!(
+        "{target} was not audited — this client cannot pass a board to `tga audit` without \
+         writing its credential to a file, which it will not do (#5824)"
+    )
+}
+
+/// Phase 2 — turn what is registered into checkouts the sweep can read.
+///
+/// Why: the registry-to-sweep gap, see the module docs.
+///
+/// An EMPTY repository set is not automatically a refusal: an operator who
+/// cloned by hand before the registry existed has a selection on disk, and the
+/// chain must keep working for them (#5824 requirement 4). So an empty registry
+/// falls through to whatever `clone` last selected, and only the case where
+/// there is no selection either is refused — with the remedy named, because
+/// `NoRepositoriesSelected`'s "nothing in this file" does not tell an operator
+/// to go and register something.
+/// What: [`clone::clone_all`], which reuses complete checkouts and records the
+/// usable ones as the selection. A repository that fails to clone is a gap on
+/// its report and is NOT selected, so the sweep never records it as audited.
+/// Test: `super::chain_tests::an_engagement_with_nothing_to_audit_stops_in_materialize`,
+/// `super::chain_tests::an_empty_registry_falls_back_to_an_existing_selection`.
+async fn materialize(
+    work: &WorkDir,
+    repos: &[String],
+    progress: &Progress,
+) -> Result<Option<CloneReport>, AuditError> {
+    if repos.is_empty() {
+        return match run::load_selection(work) {
+            Ok(_) => Ok(None),
+            Err(AuditError::NoRepositoriesSelected { .. }) => Err(AuditError::NothingRegistered {
+                root: work.root().to_path_buf(),
+            }),
+            // A truncated or unreadable selection is a different fact, and
+            // reporting it as "nothing is registered" would send the operator
+            // to fix the wrong file.
+            Err(other) => Err(other),
+        };
+    }
+    clone::clone_all(work, repos, &CloneOptions::default(), progress)
+        .await
+        .map(Some)
+}
+
+/// Phase 3 — collect and analyze, refusing to advance over a sweep that
+/// audited nothing.
+///
+/// Why: this is the fail-open branch #5824 names. The chain deliberately
+/// continues past a repository that failed, so the guard has to be at the point
+/// where continuing would produce a deliverable describing nothing:
+/// [`RunStatus::AllFailed`] means every child failed, and packaging that would
+/// hand the recipient a zip that looks like a completed engagement. It stops
+/// here, attributed to the phase that actually failed rather than to the
+/// package assembly it would otherwise trip a stage later.
+///
+/// A repository that FAILED among others that succeeded is not this case — that
+/// package is worth sending and names what it omits.
+/// What: [`run::sweep`] unchanged, then the status check.
+/// Test: `super::chain_tests::a_sweep_that_audited_nothing_stops_before_packaging`,
+/// `super::chain_tests::a_partly_failed_chain_packages_and_still_does_not_exit_zero`.
+async fn collect(
+    work: &WorkDir,
+    config: &EngagementConfig,
+    options: &ChainOptions,
+    progress: &Progress,
+) -> Result<RunReport, AuditError> {
+    let report = run::sweep(
+        work,
+        config,
+        &RunOptions {
+            fresh: options.fresh,
+        },
+        progress,
+    )
+    .await?;
+    if report.status == RunStatus::AllFailed {
+        return Err(AuditError::NothingAudited {
+            attempted: report.repos.len(),
+        });
+    }
+    Ok(report)
+}
+
+/// Phase 4 — assemble the deliverable, through the same completion check the
+/// standalone verb uses.
+///
+/// Why: [`package::from_checkpoint`] rather than [`package::assemble`] over the
+/// report already in hand, so the chain proves the same thing `taudit package`
+/// proves — that the record on disk describes a sweep which FINISHED. Passing
+/// the in-memory report would skip that check and leave two packaging paths with
+/// different preconditions.
+/// What: announces the phase through `progress`, then assembles.
+/// Test: `super::chain_tests::the_chain_installs_collects_and_packages`,
+/// `super::chain_tests::progress_covers_every_phase`.
+fn assemble(
+    work: &WorkDir,
+    config: &EngagementConfig,
+    destination: Option<PathBuf>,
+    progress: &Progress,
+) -> Result<ReturnPackage, AuditError> {
+    let destination = destination.unwrap_or_else(|| package::default_destination(work));
+    let name = destination.file_name().map_or_else(
+        || destination.display().to_string(),
+        |n| n.to_string_lossy().into_owned(),
+    );
+    progress.operation_started(Operation::Package, 1);
+    progress.unit_started(Operation::Package, name.as_str(), 1, 1);
+    let assembled = package::from_checkpoint(work, config, &destination);
+    progress.unit_finished(
+        Operation::Package,
+        name.as_str(),
+        match &assembled {
+            Ok(_) => UnitOutcome::Succeeded,
+            Err(e) => UnitOutcome::Failed(e.to_string()),
+        },
+    );
+    progress.operation_finished(Operation::Package, usize::from(assembled.is_ok()), 1);
+    assembled
+}

--- a/crates/trusty-audit/src/chain.rs
+++ b/crates/trusty-audit/src/chain.rs
@@ -402,3 +402,374 @@ fn assemble(
     progress.operation_finished(Operation::Package, usize::from(assembled.is_ok()), 1);
     assembled
 }
+
+#[cfg(test)]
+mod chain_tests {
+    use std::path::Path;
+
+    use super::*;
+    use crate::progress::{ProgressUpdate, Recorder};
+    use crate::registry::{self, TargetKind};
+    use crate::run::{RepoResult, SelectedRepo};
+    use crate::session::{Outcome, Session};
+    use crate::tools::RequiredTool;
+    use crate::workdir::Area;
+
+    const CONFIG: &str = r#"
+openrouter_key = "sk-or-v1-not-a-real-key"
+instructions = "Assess the last 52 weeks."
+
+[tools]
+tga = "2.9.4"
+trusty-search = "0.47.0"
+trusty-analyze = "0.9.2"
+trusty-review = "0.15.1"
+"#;
+
+    fn config() -> EngagementConfig {
+        EngagementConfig::from_toml(CONFIG, Path::new("engagement.toml")).expect("parses")
+    }
+
+    fn work_in(dir: &Path) -> WorkDir {
+        let work = WorkDir::new(dir.join("work"));
+        work.create().expect("create");
+        work
+    }
+
+    /// A stub `tga` that writes the manifest a real one would for every
+    /// repository whose output stem is in `succeed`, and exits 1 for the rest.
+    ///
+    /// Matching on the stem is what lets one script produce a MIXED sweep, which
+    /// is the case the fail-open test needs — a partial run, not a clean one and
+    /// not a total failure.
+    fn tga_stub(succeed: &[&str]) -> String {
+        let cases: String = succeed
+            .iter()
+            .map(|stem| format!("  *{stem}*) ok=1 ;;\n"))
+            .collect();
+        format!(
+            "#!/bin/sh\nout=\"\"\nwhile [ $# -gt 0 ]; do\n  \
+             case \"$1\" in --output) out=\"$2\"; shift;; esac\n  shift\ndone\n\
+             ok=0\ncase \"$out\" in\n{cases}esac\n\
+             [ \"$ok\" = 1 ] || exit 1\n\
+             mkdir -p \"$out\"\n\
+             printf '[report]\\ntitle = \"Acme\"\\n\\n[[repositories]]\\n\
+             name = \"acme\"\\npath = \"/r\"\\n' > \"$out/manifest.toml\"\nexit 0\n"
+        )
+    }
+
+    /// The stub binaries AND the version record, which together are what the
+    /// sweep's `pinned_binaries` preflight accepts — so the install phase finds
+    /// the pins satisfied and never reaches the network.
+    fn install_stubs(work: &WorkDir, script: &str) {
+        for tool in RequiredTool::ALL {
+            let path = tool.path_in(work);
+            std::fs::write(&path, script).expect("stub binary");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt as _;
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+                    .expect("chmod");
+            }
+        }
+        let record = format!(
+            "[[tools]]\ncrate_name = \"tga\"\nversion = \"2.9.4\"\nbinary = \"{tga}\"\n\
+             [[tools]]\ncrate_name = \"trusty-search\"\nversion = \"0.47.0\"\nbinary = \"{s}\"\n\
+             [[tools]]\ncrate_name = \"trusty-analyze\"\nversion = \"0.9.2\"\nbinary = \"{a}\"\n\
+             [[tools]]\ncrate_name = \"trusty-review\"\nversion = \"0.15.1\"\nbinary = \"{r}\"\n",
+            tga = RequiredTool::Tga.path_in(work).display(),
+            s = RequiredTool::TrustySearch.path_in(work).display(),
+            a = RequiredTool::TrustyAnalyze.path_in(work).display(),
+            r = RequiredTool::TrustyReview.path_in(work).display(),
+        );
+        std::fs::write(crate::tools::record_path(work), record).expect("write record");
+    }
+
+    /// A checkout on disk and a selection naming it.
+    ///
+    /// The chain's materialize phase falls back to the selection when the
+    /// registry names no repository, which is what makes an offline test of the
+    /// whole chain possible — cloning would reach GitHub.
+    fn select(work: &WorkDir, names: &[&str]) {
+        let repos: Vec<SelectedRepo> = names
+            .iter()
+            .map(|name| {
+                std::fs::create_dir_all(work.path(Area::Repos).join(name)).expect("mkdir repo");
+                SelectedRepo {
+                    name: (*name).to_owned(),
+                    path: PathBuf::from(format!("repos/{name}")),
+                }
+            })
+            .collect();
+        run::save_selection(work, &repos).expect("write selection");
+    }
+
+    /// One prepared working directory: stubs installed, checkouts on disk.
+    fn prepared(dir: &Path, repos: &[&str], succeed: &[&str]) -> WorkDir {
+        let work = work_in(dir);
+        install_stubs(&work, &tga_stub(succeed));
+        select(&work, repos);
+        work
+    }
+
+    async fn run_chain(work: &WorkDir, progress: &Progress) -> Result<ChainReport, AuditError> {
+        audit(work, &config(), &ChainOptions::default(), true, progress).await
+    }
+
+    /// The whole point of #5824: four verbs' worth of work from one call, ending
+    /// in a file the recipient can send.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_chain_installs_collects_and_packages() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = prepared(tmp.path(), &["acme-api"], &["acme-api"]);
+
+        let report = run_chain(&work, &Progress::none())
+            .await
+            .expect("the chain runs");
+
+        assert_eq!(
+            report.run.status,
+            RunStatus::AllSucceeded,
+            "{:?}",
+            report.run
+        );
+        assert!(report.package.path.is_file(), "the package must be a file");
+        assert!(report.package.excluded.is_empty(), "{:?}", report.package);
+        assert!(report.gaps.is_empty(), "{:?}", report.gaps);
+        // The pins were already satisfied, so nothing was downloaded.
+        assert!(report.installed.is_none());
+        // Nothing registered, so the materialize phase cloned nothing and used
+        // the selection already on disk.
+        assert!(report.acquired.is_none());
+        assert_eq!(Outcome::Audit(report).exit_code(), 0);
+    }
+
+    /// The fail-open guard, and the reason this PR needed one (#5824).
+    ///
+    /// The chain CONTINUES past a repository that failed — that is deliberate,
+    /// and it is what makes a partial run reach the package phase at all. What
+    /// must not happen is that partial run reading as a whole engagement: the
+    /// package has to name the repository it does not cover, and the process
+    /// exit status has to be non-zero so `taudit audit && send-it` stops.
+    ///
+    /// Without the `Outcome::Audit` arm of `Outcome::exit_code`, this fails on
+    /// the last assertion with a zero status over a package covering one
+    /// repository of two.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_partly_failed_chain_packages_and_still_does_not_exit_zero() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Only the first repository's output stem is accepted by the stub.
+        let work = prepared(tmp.path(), &["acme-api", "acme-web"], &["00-acme-api"]);
+
+        let report = run_chain(&work, &Progress::none())
+            .await
+            .expect("one repository failing is not a failure of the chain");
+
+        assert_eq!(report.run.status, RunStatus::Partial, "{:?}", report.run);
+        assert!(report.package.path.is_file());
+        assert_eq!(report.package.excluded.len(), 1, "{:?}", report.package);
+        assert!(
+            report.package.excluded[0].contains("acme-web"),
+            "the package must name what it does not cover: {:?}",
+            report.package.excluded
+        );
+        assert_ne!(
+            Outcome::Audit(report).exit_code(),
+            0,
+            "a partial engagement must not exit zero"
+        );
+    }
+
+    /// The second half of the same guard: when NOTHING was audited there is no
+    /// package at all, and the refusal names the phase that failed rather than
+    /// the packaging it would otherwise trip one stage later.
+    ///
+    /// Without the `RunStatus::AllFailed` check in `collect`, the chain reaches
+    /// `package::from_checkpoint`, which refuses too — so this fails on the
+    /// phase assertion, reporting a collection failure as a packaging one.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_sweep_that_audited_nothing_stops_before_packaging() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // No stem is accepted, so every child exits 1.
+        let work = prepared(tmp.path(), &["acme-api", "acme-web"], &[]);
+
+        let err = run_chain(&work, &Progress::none())
+            .await
+            .expect_err("a sweep that audited nothing must not produce a package");
+
+        let AuditError::ChainStopped { phase, source } = &err else {
+            panic!("expected a phase-attributed refusal, got {err:?}");
+        };
+        assert_eq!(*phase, Phase::Collect, "{err}");
+        assert!(
+            matches!(**source, AuditError::NothingAudited { attempted: 2 }),
+            "{source:?}"
+        );
+        assert!(
+            !package::default_destination(&work).exists(),
+            "a chain that audited nothing left a package behind"
+        );
+    }
+
+    /// An engagement that targets nothing is a refusal naming the remedy, not an
+    /// empty run — and it is attributed to the phase that could not proceed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_engagement_with_nothing_to_audit_stops_in_materialize() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &tga_stub(&["acme-api"]));
+
+        let err = run_chain(&work, &Progress::none())
+            .await
+            .expect_err("nothing is registered and nothing was cloned");
+
+        let AuditError::ChainStopped { phase, source } = &err else {
+            panic!("expected a phase-attributed refusal, got {err:?}");
+        };
+        assert_eq!(*phase, Phase::Materialize, "{err}");
+        assert!(
+            matches!(**source, AuditError::NothingRegistered { .. }),
+            "{source:?}"
+        );
+        assert!(
+            err.to_string().contains("trusty-audit add repo"),
+            "the refusal must name the remedy: {err}"
+        );
+    }
+
+    /// #5824 requirement 4: the operator who cloned by hand before the registry
+    /// existed keeps working. An empty registry is not a refusal while a
+    /// selection is on disk.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_empty_registry_falls_back_to_an_existing_selection() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = prepared(tmp.path(), &["acme-api"], &["acme-api"]);
+
+        let report = run_chain(&work, &Progress::none())
+            .await
+            .expect("the chain runs");
+        assert!(report.acquired.is_none(), "nothing needed cloning");
+        assert_eq!(report.run.repos.len(), 1);
+    }
+
+    /// A registered board is something this engagement targets and this chain
+    /// cannot audit. Dropping it silently would leave the recipient sending a
+    /// package that claims to cover an engagement it does not.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_registered_board_is_stated_as_a_gap() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = prepared(tmp.path(), &["acme-api"], &["acme-api"]);
+        let mut registry = Registry::default();
+        registry.insert(registry::parse(Some(TargetKind::Board), "jira:ACME").expect("parses"));
+        registry.save(&work).expect("writes");
+
+        let report = run_chain(&work, &Progress::none())
+            .await
+            .expect("the chain runs");
+
+        assert_eq!(report.gaps.len(), 1, "{:?}", report.gaps);
+        assert!(report.gaps[0].contains("jira:ACME"), "{:?}", report.gaps);
+        assert_ne!(
+            Outcome::Audit(report).exit_code(),
+            0,
+            "an unaudited target must not exit zero even when the sweep was clean"
+        );
+    }
+
+    /// Resumable by construction: every phase is re-entrant, so a second run
+    /// carries the first one's work over rather than repeating it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn re_running_the_chain_resumes_rather_than_re_collecting() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = prepared(tmp.path(), &["acme-api"], &["acme-api"]);
+
+        let first = run_chain(&work, &Progress::none())
+            .await
+            .expect("the first run");
+        assert_eq!(first.run.resumed().count(), 0);
+
+        let second = run_chain(&work, &Progress::none())
+            .await
+            .expect("the second run");
+        assert_eq!(second.run.resumed().count(), 1, "{:?}", second.run);
+        assert!(second.run.repos[0].result.succeeded());
+        assert!(second.package.path.is_file());
+    }
+
+    /// Closure condition 3 of #5824: the display does not fall silent partway
+    /// through. Every phase that runs announces itself, including the packaging
+    /// that used to happen with no output at all.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn progress_covers_every_phase() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = prepared(tmp.path(), &["acme-api"], &["acme-api"]);
+        let (recorder, progress) = Recorder::new();
+
+        run_chain(&work, &progress).await.expect("the chain runs");
+
+        let operations: Vec<Operation> = recorder
+            .updates()
+            .into_iter()
+            .filter_map(|u| match u {
+                ProgressUpdate::OperationStarted { operation, .. } => Some(operation),
+                _ => None,
+            })
+            .collect();
+        assert!(operations.contains(&Operation::Sweep), "{operations:?}");
+        assert!(operations.contains(&Operation::Package), "{operations:?}");
+    }
+
+    /// The chain is reachable the way every other capability is — through
+    /// `Session::execute`, with no private path of its own (#5502).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_chain_runs_through_the_one_dispatch_every_front_end_uses() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = prepared(tmp.path(), &["acme-api"], &["acme-api"]);
+        let config_path = tmp.path().join("engagement.toml");
+        std::fs::write(&config_path, CONFIG).expect("write config");
+        let session = Session::new(work.clone()).with_config_path(&config_path);
+
+        let outcome = session
+            .execute(crate::session::Command::Audit(ChainOptions::default()))
+            .await
+            .expect("the chain runs through execute");
+        let Outcome::Audit(report) = &outcome else {
+            panic!("Audit must yield an Audit outcome: {outcome:?}");
+        };
+        assert!(report.package.path.is_file());
+        assert_eq!(outcome.exit_code(), 0);
+    }
+
+    /// The failure a chained repository produces still reads as that
+    /// repository's, not as "the audit failed" — requirement 2 of #5824 is about
+    /// the target as much as the phase.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_failed_repository_is_named_in_the_report_that_comes_back() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = prepared(tmp.path(), &["acme-api", "acme-web"], &["00-acme-api"]);
+
+        let report = run_chain(&work, &Progress::none())
+            .await
+            .expect("the chain runs");
+
+        let failed = report.run.failures().next().expect("one repository failed");
+        assert_eq!(failed.repo.name, "acme-web");
+        let RepoResult::Failed { reason } = &failed.result else {
+            panic!("a failure must carry a reason");
+        };
+        assert!(
+            reason.contains(&failed.log.display().to_string()),
+            "the reason must point at this repository's own log: {reason}"
+        );
+    }
+}

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -829,6 +829,65 @@ mod cli_tests {
         );
     }
 
+    /// #5824: a chained run that printed only its last phase would hide the two
+    /// places an engagement most often comes up short — a repository that could
+    /// not be cloned, and a registered target the chain cannot audit at all.
+    /// Both must survive into the text even when the package assembled fine.
+    #[test]
+    fn a_chained_run_names_every_phase() {
+        use crate::chain::ChainReport;
+        use crate::run::{RepoRun, RunReport, SelectedRepo};
+
+        let report = ChainReport {
+            installed: Some(vec![InstalledTool {
+                crate_name: "tga".to_owned(),
+                version: "2.9.4".to_owned(),
+                binary: PathBuf::from("/work/tools/tga"),
+            }]),
+            acquired: Some(CloneReport {
+                repos: vec![ClonedRepo {
+                    name_with_owner: "acme/web".to_owned(),
+                    path: PathBuf::from("/work/repos/acme/web"),
+                    state: CloneState::Failed("no such repository".to_owned()),
+                    bytes: 0,
+                    bytes_complete: true,
+                }],
+                total_bytes: 0,
+                total_bytes_complete: true,
+                gaps: vec!["acme/web was not audited — the clone failed".to_owned()],
+            }),
+            run: RunReport::of(vec![RepoRun {
+                repo: SelectedRepo {
+                    name: "acme-api".to_owned(),
+                    path: PathBuf::from("repos/acme-api"),
+                },
+                output: PathBuf::from("/work/out/00-acme-api"),
+                log: PathBuf::from("/work/logs/00-acme-api.log"),
+                gaps: Vec::new(),
+                resumed: false,
+                result: RepoResult::Succeeded,
+            }]),
+            package: ReturnPackage {
+                path: PathBuf::from("/work/audit-return-package.zip"),
+                files: Vec::new(),
+                total_bytes: 0,
+                packaged_bytes: 0,
+                excluded: Vec::new(),
+            },
+            gaps: vec!["jira:ACME was not audited".to_owned()],
+        };
+
+        let text = render(&Outcome::Audit(report));
+        assert!(text.contains("Installed 1 tool: tga 2.9.4"), "{text}");
+        assert!(
+            text.contains("acme/web"),
+            "the clone phase is missing: {text}"
+        );
+        assert!(text.contains("ok      acme-api"), "{text}");
+        assert!(text.contains("Not audited: jira:ACME"), "{text}");
+        assert!(text.contains("Send this file back"), "{text}");
+    }
+
     /// The save-dialog equivalent: the recipient names where the file lands.
     #[test]
     fn the_package_destination_is_choosable_from_the_command_line() {

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -18,10 +18,11 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
-use crate::clone::{CloneOptions, CloneState};
+use crate::chain::ChainOptions;
+use crate::clone::CloneOptions;
 use crate::registry::TargetKind;
-use crate::run::{RepoResult, RunOptions, RunStatus};
-use crate::session::{Command, NextStep, Outcome};
+use crate::run::RunOptions;
+use crate::session::{Command, Outcome};
 
 /// The auditor client's command line.
 ///
@@ -126,6 +127,27 @@ pub enum Verb {
         #[arg(long)]
         fresh: bool,
     },
+    /// Run the whole engagement: install, clone, audit, package.
+    ///
+    /// One invocation over what `trusty-audit add` registered, instead of
+    /// `install`, `clone`, `run` and `package` in order. Interrupt it and run it
+    /// again: installed tools, complete checkouts and audited repositories are
+    /// all carried over rather than redone.
+    ///
+    /// It continues past a repository that fails and names it in the package it
+    /// assembles. It exits non-zero whenever anything registered was not
+    /// audited, and it assembles nothing at all when no repository was.
+    Audit {
+        /// Audit every selected repository again, ignoring recorded progress.
+        ///
+        /// Hours-long: it re-collects everything. Same flag, same meaning, as
+        /// `trusty-audit run --fresh`.
+        #[arg(long)]
+        fresh: bool,
+        /// Where to write the return package (default: <work-dir>/audit-return-package.zip).
+        #[arg(long, value_name = "FILE")]
+        out: Option<PathBuf>,
+    },
     /// Assemble the unencrypted deliverable zip to send back.
     Package {
         /// Where to write the zip (default: <work-dir>/audit-return-package.zip).
@@ -225,6 +247,13 @@ impl Cli {
             Some(Verb::Package { out }) => Command::Package {
                 destination: out.clone(),
             },
+            // #5824: the same two knobs the phases it chains already take, and
+            // no third one — anything else the chain needs it reads from the
+            // registry, which is where the operator put it.
+            Some(Verb::Audit { fresh, out }) => Command::Audit(ChainOptions {
+                fresh: *fresh,
+                destination: out.clone(),
+            }),
         }
     }
 }
@@ -245,386 +274,23 @@ pub fn exit_code(outcome: &Outcome) -> i32 {
     outcome.exit_code()
 }
 
-/// Render an outcome as the text the CLI prints.
-///
-/// Why: rendering is the front end's job, so it lives here rather than on
-/// [`Outcome`] — the Tauri shell will render the same values as a window. It
-/// returns a `String` instead of printing so it is assertable in a test.
-/// What: one arm per [`Outcome`] variant.
-/// Test: `super::cli_tests::rendering_names_the_root_and_every_area`.
-pub fn render(outcome: &Outcome) -> String {
-    match outcome {
-        Outcome::Guided(status) => {
-            let mut out = format!("Working directory: {}\n", status.root.display());
-            match &status.manifest {
-                Some(m) => out.push_str(&format!(
-                    "Engagement: {} ({} configured)\n",
-                    m.report.title,
-                    count_of(m.repositories.len(), "repository", "repositories")
-                )),
-                None => out.push_str("Engagement: no manifest yet — nothing has run here\n"),
-            }
-            // #5797: a download the operator did not ask for is otherwise just
-            // a pause. Naming the versions is also what makes the auto-install
-            // auditable after the fact.
-            if let Some(placed) = &status.installed {
-                out.push_str(&format!(
-                    "Installed {}: {}\n",
-                    count_of(placed.len(), "tool", "tools"),
-                    placed
-                        .iter()
-                        .map(|t| format!("{} {}", t.crate_name, t.version))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ));
-            }
-            let installed = status.tools.iter().filter(|s| s.installed).count();
-            out.push_str(&format!(
-                "Tools: {installed}/{} installed\n",
-                status.tools.len()
-            ));
-            out.push_str(&format!("Next: {}\n", describe_next(&status.next)));
-            out
-        }
-        Outcome::WorkDir(report) => {
-            let mut out = format!(
-                "{}\n  (delete this directory to remove everything this client wrote)\n",
-                report.root.display()
-            );
-            for (area, path) in &report.areas {
-                out.push_str(&format!(
-                    "  {:<8} {}\n           {}\n",
-                    area.dir_name(),
-                    path.display(),
-                    area.description()
-                ));
-            }
-            out
-        }
-        Outcome::Manifest(manifest) => {
-            let mut out = format!("Title:  {}\n", manifest.report.title);
-            if let Some(client) = &manifest.report.client {
-                out.push_str(&format!("Client: {client}\n"));
-            }
-            if let Some(analyst) = &manifest.report.analyst {
-                out.push_str(&format!("Analyst: {analyst}\n"));
-            }
-            out.push_str(&format!(
-                "Repositories: {}\n",
-                count_of(manifest.repositories.len(), "repository", "repositories")
-            ));
-            for gap in &manifest.report.gaps {
-                out.push_str(&format!("Gap: {gap}\n"));
-            }
-            out
-        }
-        Outcome::Tools(statuses) => {
-            let mut out = String::new();
-            for status in statuses {
-                // #5495: "installed" and "installed at a known version" are
-                // different states, and the recipient has to be able to tell
-                // them apart — a binary this client did not place is one it
-                // cannot vouch for, so it is never shown carrying a version.
-                let mark = match (status.installed, status.version.is_some()) {
-                    (false, _) => "MISSING",
-                    (true, true) => "ok",
-                    (true, false) => "UNVERIFIED",
-                };
-                let version = status.version.as_deref().unwrap_or("-");
-                out.push_str(&format!(
-                    "{mark:<11} {:<16} {version:<12} {}\n",
-                    status.tool.binary_name(),
-                    status.path.display()
-                ));
-            }
-            out
-        }
-        Outcome::Installed(installed) => {
-            let mut out = format!(
-                "Installed and verified {}:\n",
-                count_of(installed.len(), "tool", "tools")
-            );
-            for tool in installed {
-                out.push_str(&format!(
-                    "  {:<16} {:<12} {}\n",
-                    tool.crate_name,
-                    tool.version,
-                    tool.binary.display()
-                ));
-            }
-            out
-        }
-        Outcome::Repos(repos) => {
-            if repos.is_empty() {
-                return "No repositories configured yet — run the guided flow to pick them.\n"
-                    .to_string();
-            }
-            repos
-                .iter()
-                .map(|r| format!("{:<24} {}\n", r.name, r.path.display()))
-                .collect()
-        }
-        Outcome::Discovered(repos) => {
-            // #5487: an empty result here means the credential really can see
-            // nothing — every failure is an error, never a short list — so the
-            // wording says so rather than hedging.
-            if repos.is_empty() {
-                return "Your GitHub credential can reach no repositories.\n".to_string();
-            }
-            let mut out = format!(
-                "{} your credential can reach:\n",
-                count_of(repos.len(), "repository", "repositories")
-            );
-            for repo in repos {
-                let mut marks = Vec::new();
-                if repo.is_private {
-                    marks.push("private");
-                }
-                if repo.is_archived {
-                    marks.push("archived");
-                }
-                out.push_str(&format!(
-                    "  {:<40} {}\n",
-                    repo.name_with_owner,
-                    marks.join(", ")
-                ));
-            }
-            out
-        }
-        // #5555: a partial sweep must not read like a clean one. Each failure
-        // is printed with its reason and its log path, and the verdict line
-        // says which of the three states this run ended in.
-        Outcome::Run(report) => {
-            let mut out = String::new();
-            for run in &report.repos {
-                match &run.result {
-                    // #5494: a repository this run carried over from an earlier
-                    // one reads differently from one it audited. Silent
-                    // skipping is the defect the resume path exists not to be.
-                    RepoResult::Succeeded if run.resumed => out.push_str(&format!(
-                        "resumed {:<24} {}\n",
-                        run.repo.name,
-                        run.output.display()
-                    )),
-                    RepoResult::Succeeded => out.push_str(&format!(
-                        "ok      {:<24} {}\n",
-                        run.repo.name,
-                        run.output.display()
-                    )),
-                    RepoResult::Failed { reason } => {
-                        out.push_str(&format!("FAILED  {:<24} {reason}\n", run.repo.name))
-                    }
-                }
-                // #5555: a stated gap is a dimension the sweep could not assess
-                // (DOC-67 §9). It does not fail the repository, and it must not
-                // be invisible either — an audited repo with four gaps is not
-                // the same result as one with none.
-                for gap in &run.gaps {
-                    out.push_str(&format!("  gap   {gap}\n"));
-                }
-            }
-            let audited = report.repos.len() - report.failures().count();
-            // #5494: a run that audited nothing because everything was already
-            // done is a legitimate outcome, and it has to say so — otherwise
-            // "Audited 6 repositories" over a four-second run reads as a bug.
-            let resumed = report.resumed().count();
-            if resumed > 0 {
-                out.push_str(&format!(
-                    "\nResumed {} from an earlier run; {} audited now.\n",
-                    count_of(resumed, "repository", "repositories"),
-                    audited - resumed
-                ));
-            }
-            out.push_str(&match report.status {
-                RunStatus::AllSucceeded => format!(
-                    "\nAudited {}.\n",
-                    count_of(audited, "repository", "repositories")
-                ),
-                RunStatus::Partial => format!(
-                    "\nPARTIAL: {} audited, {} failed. The report covers only what succeeded.\n",
-                    audited,
-                    report.failures().count()
-                ),
-                RunStatus::AllFailed => format!(
-                    "\nFAILED: no repository was audited ({} attempted).\n",
-                    report.repos.len()
-                ),
-            });
-            out
-        }
-        Outcome::Cloned(report) => {
-            let mut out = String::new();
-            for repo in &report.repos {
-                // #5215: a repository that is NOT in the audit has to read as
-                // excluded, never as a blank line the recipient scrolls past.
-                let state = match &repo.state {
-                    CloneState::Cloned => "cloned".to_string(),
-                    CloneState::Reused => "already present".to_string(),
-                    CloneState::Failed(why) => format!("FAILED — {why}"),
-                    CloneState::Empty(why) => format!("NOTHING CLONED — {why}"),
-                    CloneState::Skipped(why) => format!("SKIPPED — {why}"),
-                };
-                out.push_str(&format!("  {:<40} {state}\n", repo.name_with_owner));
-            }
-            out.push_str(&format!(
-                "{} on disk, using {}{}.\n",
-                count_of(
-                    report.repos.iter().filter(|r| r.state.is_usable()).count(),
-                    "repository",
-                    "repositories"
-                ),
-                // #5215 review: a walk that hit something unreadable produces a
-                // floor, and saying "using X" of a floor is a confident number
-                // nothing measured.
-                if report.total_bytes_complete {
-                    ""
-                } else {
-                    "at least "
-                },
-                human_bytes(report.total_bytes)
-            ));
-            for gap in &report.gaps {
-                out.push_str(&format!("Gap: {gap}\n"));
-            }
-            out
-        }
-        // #5822: an idempotent re-add and a fresh registration are different
-        // facts, and an operator re-running `add` over a list needs to see
-        // which one happened rather than the same line twice.
-        Outcome::Registered(registration) => {
-            let verb = if registration.already_registered {
-                "already registered"
-            } else {
-                "registered"
-            };
-            format!(
-                "{verb}: {:<8} {}\n",
-                describe_kind(registration.target.kind()),
-                registration.target
-            )
-        }
-        Outcome::Targets(list) => {
-            let mut out = if list.targets.is_empty() {
-                "No targets registered yet — `trusty-audit add repo <owner>/<name>`.\n".to_string()
-            } else {
-                let mut out = format!(
-                    "{} registered:\n",
-                    count_of(list.targets.len(), "target", "targets")
-                );
-                for target in &list.targets {
-                    out.push_str(&format!(
-                        "  {:<8} {}\n",
-                        describe_kind(target.kind()),
-                        target
-                    ));
-                }
-                out
-            };
-            // The registry supersedes the selection file as the record of what
-            // this engagement targets, and the sweep still reads that file as
-            // the record of what is on disk. Printing only one of the two would
-            // read as though the other had been lost.
-            if let Some((path, count)) = &list.legacy_selection {
-                out.push_str(&format!(
-                    "\n{} on disk from a previous `clone`, which the sweep reads from {}.\n",
-                    count_of(*count, "repository", "repositories"),
-                    path.display()
-                ));
-            }
-            out
-        }
-        Outcome::Removed(removal) => {
-            if removal.was_registered {
-                format!("removed: {}\n", removal.target)
-            } else {
-                format!("{} was not registered — nothing changed.\n", removal.target)
-            }
-        }
-        // #5499 closure condition 3: the recipient has to be able to find the
-        // file. The path is the first and last line, and everything between is
-        // what they can check before sending it.
-        Outcome::Package(package) => {
-            let mut out = format!("Return package: {}\n", package.path.display());
-            out.push_str(&format!(
-                "  {} in {}, unencrypted — open it and read what you are sending\n",
-                count_of(package.files.len(), "file", "files"),
-                human_bytes(package.packaged_bytes)
-            ));
-            for file in &package.files {
-                out.push_str(&format!(
-                    "  {:>10}  {}\n",
-                    human_bytes(file.bytes),
-                    file.entry
-                ));
-            }
-            for line in &package.excluded {
-                out.push_str(&format!("Not included: {line}\n"));
-            }
-            out.push_str(&format!(
-                "\nSend this file back: {}\n",
-                package.path.display()
-            ));
-            out
-        }
-    }
-}
+// #5824: rendering moved out when the one-shot chain's own arm pushed this file
+// past the 500-SLOC production cap. Re-exported, so `crate::cli::render` stays
+// the name every caller and test already uses.
+mod render;
 
-/// Bytes as something a recipient reads, not a raw count.
-fn human_bytes(bytes: u64) -> String {
-    const UNITS: [&str; 4] = ["B", "KiB", "MiB", "GiB"];
-    let mut value = bytes as f64;
-    let mut unit = 0;
-    while value >= 1024.0 && unit + 1 < UNITS.len() {
-        value /= 1024.0;
-        unit += 1;
-    }
-    if unit == 0 {
-        format!("{bytes} B")
-    } else {
-        format!("{value:.1} {}", UNITS[unit])
-    }
-}
-
-/// The column label for one target kind.
-fn describe_kind(kind: TargetKind) -> &'static str {
-    match kind {
-        TargetKind::Repo => "repo",
-        TargetKind::Board => "board",
-    }
-}
-
-/// `"1 repository"` / `"3 repositories"` — this text goes to the recipient.
-fn count_of(n: usize, singular: &str, plural: &str) -> String {
-    format!("{n} {}", if n == 1 { singular } else { plural })
-}
-
-fn describe_next(next: &NextStep) -> String {
-    match next {
-        NextStep::SelectRepositories => {
-            "pick the repositories to audit (`trusty-audit repos`)".to_string()
-        }
-        NextStep::InstallTools(missing) => {
-            let names: Vec<&str> = missing.iter().map(|t| t.binary_name()).collect();
-            format!(
-                "install the pinned tools (`trusty-audit install`): {}",
-                names.join(", ")
-            )
-        }
-        NextStep::ReadyForRun => "run the audit sweep (`trusty-audit run`)".to_string(),
-        NextStep::ReturnPackage => {
-            "assemble the deliverable and send it back (`trusty-audit package`)".to_string()
-        }
-    }
-}
+pub use render::render;
 
 #[cfg(test)]
 mod cli_tests {
+    use super::render::count_of;
     use super::*;
-    use crate::clone::{CloneReport, ClonedRepo};
+    use crate::clone::{CloneReport, CloneState, ClonedRepo};
     use crate::discover::DiscoveredRepo;
     use crate::manifest::AuditManifest;
     use crate::package::{PackagedFile, ReturnPackage};
     use crate::registry::Target;
+    use crate::run::RepoResult;
     use crate::session::EXIT_INCOMPLETE;
     use crate::session::{Session, WorkDirReport};
     use crate::tools::{InstalledTool, RequiredTool, ToolStatus};
@@ -657,6 +323,7 @@ mod cli_tests {
             Command::RemoveTarget { .. } => vec!["taudit", "remove", "acme/api"],
             Command::Run(_) => vec!["taudit", "run"],
             Command::Package { .. } => vec!["taudit", "package"],
+            Command::Audit(_) => vec!["taudit", "audit"],
         }
     }
 
@@ -691,7 +358,27 @@ mod cli_tests {
             },
             Command::Run(RunOptions::default()),
             Command::Package { destination: None },
+            Command::Audit(ChainOptions::default()),
         ]
+    }
+
+    /// #5824: the chain must not be a way to reach the expensive direction by
+    /// accident, and its two knobs must mean what the same flags mean on the
+    /// verbs it chains.
+    #[test]
+    fn the_one_shot_audit_resumes_by_default() {
+        let plain = Cli::try_parse_from(["taudit", "audit"]).expect("audit parses");
+        assert_eq!(plain.to_command(), Command::Audit(ChainOptions::default()));
+
+        let asked = Cli::try_parse_from(["taudit", "audit", "--fresh", "--out", "/tmp/p.zip"])
+            .expect("both flags parse");
+        assert_eq!(
+            asked.to_command(),
+            Command::Audit(ChainOptions {
+                fresh: true,
+                destination: Some(PathBuf::from("/tmp/p.zip")),
+            })
+        );
     }
 
     #[test]

--- a/crates/trusty-audit/src/cli/render.rs
+++ b/crates/trusty-audit/src/cli/render.rs
@@ -1,0 +1,450 @@
+//! Turning an [`Outcome`] into the text the CLI prints.
+//!
+//! Why: split out of `super` when #5824's one-shot chain pushed it past the
+//! 500-SLOC production cap. It earns its own file rather than an arbitrary cut:
+//! `super` maps argv onto a capability, this maps a capability's result onto
+//! text, and the two directions share nothing but the enums they name.
+//!
+//! What: [`render`], an exhaustive match over [`Outcome`] — so a capability that
+//! arrives without a way to display its result is a compile error, the same
+//! enforcement `super::Cli::to_command` provides on the input side — plus the
+//! small formatters it needs.
+//! Test: `super::cli_tests`.
+
+use crate::chain::ChainReport;
+use crate::clone::CloneState;
+use crate::registry::TargetKind;
+use crate::run::{RepoResult, RunStatus};
+use crate::session::{NextStep, Outcome};
+
+/// Render an outcome as the text the CLI prints.
+///
+/// Why: rendering is the front end's job, so it lives here rather than on
+/// [`Outcome`] — the Tauri shell will render the same values as a window. It
+/// returns a `String` instead of printing so it is assertable in a test.
+/// What: one arm per [`Outcome`] variant.
+/// Test: `super::cli_tests::rendering_names_the_root_and_every_area`.
+pub fn render(outcome: &Outcome) -> String {
+    match outcome {
+        Outcome::Guided(status) => {
+            let mut out = format!("Working directory: {}\n", status.root.display());
+            match &status.manifest {
+                Some(m) => out.push_str(&format!(
+                    "Engagement: {} ({} configured)\n",
+                    m.report.title,
+                    count_of(m.repositories.len(), "repository", "repositories")
+                )),
+                None => out.push_str("Engagement: no manifest yet — nothing has run here\n"),
+            }
+            // #5797: a download the operator did not ask for is otherwise just
+            // a pause. Naming the versions is also what makes the auto-install
+            // auditable after the fact.
+            if let Some(placed) = &status.installed {
+                out.push_str(&format!(
+                    "Installed {}: {}\n",
+                    count_of(placed.len(), "tool", "tools"),
+                    placed
+                        .iter()
+                        .map(|t| format!("{} {}", t.crate_name, t.version))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            let installed = status.tools.iter().filter(|s| s.installed).count();
+            out.push_str(&format!(
+                "Tools: {installed}/{} installed\n",
+                status.tools.len()
+            ));
+            out.push_str(&format!("Next: {}\n", describe_next(&status.next)));
+            out
+        }
+        Outcome::WorkDir(report) => {
+            let mut out = format!(
+                "{}\n  (delete this directory to remove everything this client wrote)\n",
+                report.root.display()
+            );
+            for (area, path) in &report.areas {
+                out.push_str(&format!(
+                    "  {:<8} {}\n           {}\n",
+                    area.dir_name(),
+                    path.display(),
+                    area.description()
+                ));
+            }
+            out
+        }
+        Outcome::Manifest(manifest) => {
+            let mut out = format!("Title:  {}\n", manifest.report.title);
+            if let Some(client) = &manifest.report.client {
+                out.push_str(&format!("Client: {client}\n"));
+            }
+            if let Some(analyst) = &manifest.report.analyst {
+                out.push_str(&format!("Analyst: {analyst}\n"));
+            }
+            out.push_str(&format!(
+                "Repositories: {}\n",
+                count_of(manifest.repositories.len(), "repository", "repositories")
+            ));
+            for gap in &manifest.report.gaps {
+                out.push_str(&format!("Gap: {gap}\n"));
+            }
+            out
+        }
+        Outcome::Tools(statuses) => {
+            let mut out = String::new();
+            for status in statuses {
+                // #5495: "installed" and "installed at a known version" are
+                // different states, and the recipient has to be able to tell
+                // them apart — a binary this client did not place is one it
+                // cannot vouch for, so it is never shown carrying a version.
+                let mark = match (status.installed, status.version.is_some()) {
+                    (false, _) => "MISSING",
+                    (true, true) => "ok",
+                    (true, false) => "UNVERIFIED",
+                };
+                let version = status.version.as_deref().unwrap_or("-");
+                out.push_str(&format!(
+                    "{mark:<11} {:<16} {version:<12} {}\n",
+                    status.tool.binary_name(),
+                    status.path.display()
+                ));
+            }
+            out
+        }
+        Outcome::Installed(installed) => {
+            let mut out = format!(
+                "Installed and verified {}:\n",
+                count_of(installed.len(), "tool", "tools")
+            );
+            for tool in installed {
+                out.push_str(&format!(
+                    "  {:<16} {:<12} {}\n",
+                    tool.crate_name,
+                    tool.version,
+                    tool.binary.display()
+                ));
+            }
+            out
+        }
+        Outcome::Repos(repos) => {
+            if repos.is_empty() {
+                return "No repositories configured yet — run the guided flow to pick them.\n"
+                    .to_string();
+            }
+            repos
+                .iter()
+                .map(|r| format!("{:<24} {}\n", r.name, r.path.display()))
+                .collect()
+        }
+        Outcome::Discovered(repos) => {
+            // #5487: an empty result here means the credential really can see
+            // nothing — every failure is an error, never a short list — so the
+            // wording says so rather than hedging.
+            if repos.is_empty() {
+                return "Your GitHub credential can reach no repositories.\n".to_string();
+            }
+            let mut out = format!(
+                "{} your credential can reach:\n",
+                count_of(repos.len(), "repository", "repositories")
+            );
+            for repo in repos {
+                let mut marks = Vec::new();
+                if repo.is_private {
+                    marks.push("private");
+                }
+                if repo.is_archived {
+                    marks.push("archived");
+                }
+                out.push_str(&format!(
+                    "  {:<40} {}\n",
+                    repo.name_with_owner,
+                    marks.join(", ")
+                ));
+            }
+            out
+        }
+        Outcome::Run(report) => render_run(report),
+        Outcome::Cloned(report) => render_cloned(report),
+        // #5822: an idempotent re-add and a fresh registration are different
+        // facts, and an operator re-running `add` over a list needs to see
+        // which one happened rather than the same line twice.
+        Outcome::Registered(registration) => {
+            let verb = if registration.already_registered {
+                "already registered"
+            } else {
+                "registered"
+            };
+            format!(
+                "{verb}: {:<8} {}\n",
+                describe_kind(registration.target.kind()),
+                registration.target
+            )
+        }
+        Outcome::Targets(list) => {
+            let mut out = if list.targets.is_empty() {
+                "No targets registered yet — `trusty-audit add repo <owner>/<name>`.\n".to_string()
+            } else {
+                let mut out = format!(
+                    "{} registered:\n",
+                    count_of(list.targets.len(), "target", "targets")
+                );
+                for target in &list.targets {
+                    out.push_str(&format!(
+                        "  {:<8} {}\n",
+                        describe_kind(target.kind()),
+                        target
+                    ));
+                }
+                out
+            };
+            // The registry supersedes the selection file as the record of what
+            // this engagement targets, and the sweep still reads that file as
+            // the record of what is on disk. Printing only one of the two would
+            // read as though the other had been lost.
+            if let Some((path, count)) = &list.legacy_selection {
+                out.push_str(&format!(
+                    "\n{} on disk from a previous `clone`, which the sweep reads from {}.\n",
+                    count_of(*count, "repository", "repositories"),
+                    path.display()
+                ));
+            }
+            out
+        }
+        Outcome::Removed(removal) => {
+            if removal.was_registered {
+                format!("removed: {}\n", removal.target)
+            } else {
+                format!("{} was not registered — nothing changed.\n", removal.target)
+            }
+        }
+        Outcome::Package(package) => render_package(package),
+        // #5824: one section per phase, in the order they ran, so the operator
+        // reads the chain the way they watched it. Each phase reuses the arm
+        // that renders it on its own, because a chained clone must not read
+        // differently from a `taudit clone`.
+        Outcome::Audit(report) => render_chain(report),
+    }
+}
+
+/// The one-shot chain, phase by phase.
+///
+/// Why: a chained run that printed only its last phase would hide the two
+/// places an engagement most often comes up short — a repository that failed to
+/// clone, and a registered target the chain cannot audit at all. Both are
+/// reported here even though the package assembled fine.
+/// What: the install line, the clone report, the sweep report, this chain's own
+/// gaps, and the package — the same text each phase prints alone.
+/// Test: `super::cli_tests::a_chained_run_names_every_phase`.
+fn render_chain(report: &ChainReport) -> String {
+    let mut out = String::new();
+    if let Some(placed) = &report.installed {
+        out.push_str(&format!(
+            "Installed {}: {}\n\n",
+            count_of(placed.len(), "tool", "tools"),
+            placed
+                .iter()
+                .map(|t| format!("{} {}", t.crate_name, t.version))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if let Some(acquired) = &report.acquired {
+        out.push_str(&render_cloned(acquired));
+        out.push('\n');
+    }
+    out.push_str(&render_run(&report.run));
+    // A gap here is a registered target the chain never attempted, which the
+    // sweep's own report has no way to mention — it only knows what it swept.
+    for gap in &report.gaps {
+        out.push_str(&format!("Not audited: {gap}\n"));
+    }
+    out.push('\n');
+    out.push_str(&render_package(&report.package));
+    out
+}
+
+/// The deliverable, and what it does not cover.
+///
+/// Why: #5499 closure condition 3 — the recipient has to be able to find the
+/// file. The path is the first and last line, and everything between is what
+/// they can check before sending it.
+/// Test: `super::cli_tests::a_package_that_omits_a_repository_does_not_exit_zero`.
+fn render_package(package: &crate::package::ReturnPackage) -> String {
+    let mut out = format!("Return package: {}\n", package.path.display());
+    out.push_str(&format!(
+        "  {} in {}, unencrypted — open it and read what you are sending\n",
+        count_of(package.files.len(), "file", "files"),
+        human_bytes(package.packaged_bytes)
+    ));
+    for file in &package.files {
+        out.push_str(&format!(
+            "  {:>10}  {}\n",
+            human_bytes(file.bytes),
+            file.entry
+        ));
+    }
+    for line in &package.excluded {
+        out.push_str(&format!("Not included: {line}\n"));
+    }
+    out.push_str(&format!(
+        "\nSend this file back: {}\n",
+        package.path.display()
+    ));
+    out
+}
+
+/// The sweep's per-repository results and its verdict.
+///
+/// Why: #5555 — a partial sweep must not read like a clean one. Each failure is
+/// printed with its reason and its log path, and the verdict line says which of
+/// the three states this run ended in. A named function rather than an inline
+/// arm since #5824, so the chain renders the sweep identically to `taudit run`
+/// rather than growing a second wording.
+/// What: one line per repository, then the resumed count and the verdict.
+/// Test: `super::cli_tests::a_partial_sweep_is_never_rendered_as_a_clean_one`.
+fn render_run(report: &crate::run::RunReport) -> String {
+    let mut out = String::new();
+    for run in &report.repos {
+        match &run.result {
+            // #5494: a repository this run carried over from an earlier
+            // one reads differently from one it audited. Silent
+            // skipping is the defect the resume path exists not to be.
+            RepoResult::Succeeded if run.resumed => out.push_str(&format!(
+                "resumed {:<24} {}\n",
+                run.repo.name,
+                run.output.display()
+            )),
+            RepoResult::Succeeded => out.push_str(&format!(
+                "ok      {:<24} {}\n",
+                run.repo.name,
+                run.output.display()
+            )),
+            RepoResult::Failed { reason } => {
+                out.push_str(&format!("FAILED  {:<24} {reason}\n", run.repo.name))
+            }
+        }
+        // #5555: a stated gap is a dimension the sweep could not assess
+        // (DOC-67 §9). It does not fail the repository, and it must not
+        // be invisible either — an audited repo with four gaps is not
+        // the same result as one with none.
+        for gap in &run.gaps {
+            out.push_str(&format!("  gap   {gap}\n"));
+        }
+    }
+    let audited = report.repos.len() - report.failures().count();
+    // #5494: a run that audited nothing because everything was already
+    // done is a legitimate outcome, and it has to say so — otherwise
+    // "Audited 6 repositories" over a four-second run reads as a bug.
+    let resumed = report.resumed().count();
+    if resumed > 0 {
+        out.push_str(&format!(
+            "\nResumed {} from an earlier run; {} audited now.\n",
+            count_of(resumed, "repository", "repositories"),
+            audited - resumed
+        ));
+    }
+    out.push_str(&match report.status {
+        RunStatus::AllSucceeded => format!(
+            "\nAudited {}.\n",
+            count_of(audited, "repository", "repositories")
+        ),
+        RunStatus::Partial => format!(
+            "\nPARTIAL: {} audited, {} failed. The report covers only what succeeded.\n",
+            audited,
+            report.failures().count()
+        ),
+        RunStatus::AllFailed => format!(
+            "\nFAILED: no repository was audited ({} attempted).\n",
+            report.repos.len()
+        ),
+    });
+    out
+}
+
+/// What acquisition put on disk, and what it could not.
+///
+/// Test: `super::cli_tests::a_failed_clone_is_rendered_as_an_exclusion`.
+fn render_cloned(report: &crate::clone::CloneReport) -> String {
+    let mut out = String::new();
+    for repo in &report.repos {
+        // #5215: a repository that is NOT in the audit has to read as
+        // excluded, never as a blank line the recipient scrolls past.
+        let state = match &repo.state {
+            CloneState::Cloned => "cloned".to_string(),
+            CloneState::Reused => "already present".to_string(),
+            CloneState::Failed(why) => format!("FAILED — {why}"),
+            CloneState::Empty(why) => format!("NOTHING CLONED — {why}"),
+            CloneState::Skipped(why) => format!("SKIPPED — {why}"),
+        };
+        out.push_str(&format!("  {:<40} {state}\n", repo.name_with_owner));
+    }
+    out.push_str(&format!(
+        "{} on disk, using {}{}.\n",
+        count_of(
+            report.repos.iter().filter(|r| r.state.is_usable()).count(),
+            "repository",
+            "repositories"
+        ),
+        // #5215 review: a walk that hit something unreadable produces a
+        // floor, and saying "using X" of a floor is a confident number
+        // nothing measured.
+        if report.total_bytes_complete {
+            ""
+        } else {
+            "at least "
+        },
+        human_bytes(report.total_bytes)
+    ));
+    for gap in &report.gaps {
+        out.push_str(&format!("Gap: {gap}\n"));
+    }
+    out
+}
+
+/// Bytes as something a recipient reads, not a raw count.
+pub(super) fn human_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 4] = ["B", "KiB", "MiB", "GiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+/// The column label for one target kind.
+fn describe_kind(kind: TargetKind) -> &'static str {
+    match kind {
+        TargetKind::Repo => "repo",
+        TargetKind::Board => "board",
+    }
+}
+
+/// `"1 repository"` / `"3 repositories"` — this text goes to the recipient.
+pub(super) fn count_of(n: usize, singular: &str, plural: &str) -> String {
+    format!("{n} {}", if n == 1 { singular } else { plural })
+}
+
+fn describe_next(next: &NextStep) -> String {
+    match next {
+        NextStep::SelectRepositories => {
+            "pick the repositories to audit (`trusty-audit repos`)".to_string()
+        }
+        NextStep::InstallTools(missing) => {
+            let names: Vec<&str> = missing.iter().map(|t| t.binary_name()).collect();
+            format!(
+                "install the pinned tools (`trusty-audit install`): {}",
+                names.join(", ")
+            )
+        }
+        NextStep::ReadyForRun => "run the audit sweep (`trusty-audit run`)".to_string(),
+        NextStep::ReturnPackage => {
+            "assemble the deliverable and send it back (`trusty-audit package`)".to_string()
+        }
+    }
+}

--- a/crates/trusty-audit/src/cli/render.rs
+++ b/crates/trusty-audit/src/cli/render.rs
@@ -268,7 +268,7 @@ fn render_chain(report: &ChainReport) -> String {
 /// Why: #5499 closure condition 3 — the recipient has to be able to find the
 /// file. The path is the first and last line, and everything between is what
 /// they can check before sending it.
-/// Test: `super::cli_tests::a_package_that_omits_a_repository_does_not_exit_zero`.
+/// Test: `super::cli_tests::rendering_a_package_names_the_file_to_send_and_its_members`.
 fn render_package(package: &crate::package::ReturnPackage) -> String {
     let mut out = format!("Return package: {}\n", package.path.display());
     out.push_str(&format!(
@@ -301,7 +301,8 @@ fn render_package(package: &crate::package::ReturnPackage) -> String {
 /// arm since #5824, so the chain renders the sweep identically to `taudit run`
 /// rather than growing a second wording.
 /// What: one line per repository, then the resumed count and the verdict.
-/// Test: `super::cli_tests::a_partial_sweep_is_never_rendered_as_a_clean_one`.
+/// Test: `super::cli_tests::a_partial_sweep_does_not_exit_zero`,
+/// `super::cli_tests::a_resumed_sweep_says_what_it_carried_over_and_what_it_audited`.
 fn render_run(report: &crate::run::RunReport) -> String {
     let mut out = String::new();
     for run in &report.repos {
@@ -363,7 +364,7 @@ fn render_run(report: &crate::run::RunReport) -> String {
 
 /// What acquisition put on disk, and what it could not.
 ///
-/// Test: `super::cli_tests::a_failed_clone_is_rendered_as_an_exclusion`.
+/// Test: `super::cli_tests::rendering_a_clone_report_names_every_exclusion`.
 fn render_cloned(report: &crate::clone::CloneReport) -> String {
     let mut out = String::new();
     for repo in &report.repos {

--- a/crates/trusty-audit/src/cli/render.rs
+++ b/crates/trusty-audit/src/cli/render.rs
@@ -255,7 +255,13 @@ fn render_chain(report: &ChainReport) -> String {
     out.push_str(&render_run(&report.run));
     // A gap here is a registered target the chain never attempted, which the
     // sweep's own report has no way to mention — it only knows what it swept.
-    for gap in &report.gaps {
+    //
+    // #5824: since the chain folds the clone report's gaps into its own, a
+    // failed clone would otherwise print the identical sentence twice on one
+    // screen — once as the acquisition section's `Gap:` above, once here. The
+    // roll-up states only what no earlier section did.
+    let acquired: &[String] = report.acquired.as_ref().map_or(&[], |a| a.gaps.as_slice());
+    for gap in report.gaps.iter().filter(|g| !acquired.contains(g)) {
         out.push_str(&format!("Not audited: {gap}\n"));
     }
     out.push('\n');

--- a/crates/trusty-audit/src/error.rs
+++ b/crates/trusty-audit/src/error.rs
@@ -475,6 +475,66 @@ pub enum AuditError {
         source: std::io::Error,
     },
 
+    /// The one-shot audit stopped, and this is the phase it stopped in.
+    ///
+    /// Why: #5824 chains four fallible phases, and an operator who sees it stop
+    /// must know which one. Reporting every phase's failure as "the audit
+    /// failed" makes them re-derive the stage before they can act — "cannot read
+    /// the registry" and "`tga audit` exited with code 2" have nothing in common
+    /// as next steps.
+    /// What: the phase, plus the underlying refusal, which names the target and
+    /// the reason. `source` is boxed because nesting one `AuditError` inside
+    /// another unboxed would grow every `Result` in the crate past
+    /// `clippy::result_large_err`.
+    /// Test: `crate::chain::chain_tests::a_sweep_that_audited_nothing_stops_before_packaging`.
+    #[error("the audit stopped in the {phase} phase — {source}")]
+    ChainStopped {
+        /// Which link of the chain refused.
+        phase: crate::chain::Phase,
+        /// What it refused with.
+        #[source]
+        source: Box<AuditError>,
+    },
+
+    /// The sweep ran and audited no repository at all.
+    ///
+    /// Why: #5824's fail-open guard. The chain continues past a repository that
+    /// failed, because five audits are worth having when the sixth did not work.
+    /// A sweep in which EVERY repository failed is not that case: packaging it
+    /// would hand the recipient a zip of two generated files that looks like a
+    /// finished engagement. [`AuditError::NothingToPackage`] is the same refusal
+    /// one stage later, from `crate::package`; this one exists so the chain
+    /// attributes it to the phase that actually failed.
+    /// What: how many repositories were attempted. The per-repository reasons
+    /// are in `state/run-progress.toml` and in each repository's log.
+    /// Test: `crate::chain::chain_tests::a_sweep_that_audited_nothing_stops_before_packaging`.
+    #[error(
+        "no repository was audited ({attempted} attempted) — nothing was packaged; see the \
+         per-repository failures above, and `trusty-audit package` if you want the partial \
+         output anyway"
+    )]
+    NothingAudited {
+        /// How many repositories the sweep attempted.
+        attempted: usize,
+    },
+
+    /// The chain was asked to audit an engagement that targets nothing.
+    ///
+    /// Why: #5824. `NoRepositoriesSelected` names a file the operator has never
+    /// heard of and does not write, so on the one-shot path it is the wrong
+    /// message — the remedy is to register a target, not to go and edit
+    /// `state/selected-repos.toml`.
+    /// What: names the working directory and the command that fixes it.
+    /// Test: `crate::chain::chain_tests::an_engagement_with_nothing_to_audit_stops_in_materialize`.
+    #[error(
+        "nothing to audit in {root} — no repository is registered and no earlier clone left a \
+         selection; register one with `trusty-audit add repo <owner>/<name>`"
+    )]
+    NothingRegistered {
+        /// The working directory that targets nothing.
+        root: PathBuf,
+    },
+
     /// A capability this scaffold declares but does not yet implement.
     ///
     /// Why: a half-built capability must fail closed rather than silently

--- a/crates/trusty-audit/src/lib.rs
+++ b/crates/trusty-audit/src/lib.rs
@@ -31,6 +31,7 @@
 //! | [`clone`] | getting the selected repositories onto the recipient's disk (#5215) |
 //! | [`run`] | driving the pinned `tga audit` over the selected repositories |
 //! | [`package`] | assembling the unencrypted deliverable that goes back (#5499) |
+//! | [`chain`] | driving all four of those in one call, resumably (#5824) |
 //!
 //! ## What this milestone is not
 //!
@@ -67,6 +68,8 @@
 // ratchet in `scripts/check_rustdoc_links.sh` absorb a new one.
 #![deny(rustdoc::broken_intra_doc_links)]
 
+// #5824: the one-shot chain over install, materialize, collect and package.
+pub mod chain;
 pub mod cli;
 pub mod clone;
 pub mod config;

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -194,6 +194,55 @@ struct PackagedRepo {
 /// `extract/`,
 /// [`AuditError::CredentialInPackage`] when a member carries the engagement key,
 /// and [`AuditError::Package`] for any read, write, or rename failure.
+/// Assemble from the sweep's own record, refusing one that did not finish.
+///
+/// Why: #5824 gave packaging a second caller. The completion check used to live
+/// in `Session::package`, so the chain would either have had to duplicate it or
+/// to skip it by passing the report it already held in memory — and skipping it
+/// is how a sweep that died three repositories into six gets sent as a whole
+/// engagement. One function, both callers, one precondition.
+///
+/// The completion signal is [`crate::run::RunProgress::complete`], not the
+/// record's mere presence: since #5494 the record is written after every
+/// repository, so an unfinished sweep leaves one behind.
+/// What: reads `state/run-progress.toml`, requires it to be complete, and hands
+/// its report to [`assemble`].
+/// Test: `crate::session::session_tests::packaging_before_any_sweep_is_refused`,
+/// `crate::session::session_tests::packaging_an_unfinished_sweep_is_refused`,
+/// `crate::chain::chain_tests::the_chain_installs_collects_and_packages`.
+///
+/// # Errors
+///
+/// [`AuditError::NothingToPackage`] when no sweep has finished here, and
+/// whatever [`assemble`] fails with.
+pub fn from_checkpoint(
+    work: &WorkDir,
+    config: &EngagementConfig,
+    destination: &Path,
+) -> Result<ReturnPackage, AuditError> {
+    let progress =
+        crate::run::read_progress(work)?.ok_or_else(|| AuditError::NothingToPackage {
+            reason: format!(
+                "no sweep has finished in {} — run `trusty-audit run` first",
+                work.root().display()
+            ),
+        })?;
+    if !progress.complete {
+        return Err(AuditError::NothingToPackage {
+            reason: format!(
+                "the last sweep in {} did not finish — {} recorded so far; \
+                 run `trusty-audit run` to resume it",
+                work.root().display(),
+                match progress.repos.len() {
+                    1 => "1 repository".to_owned(),
+                    n => format!("{n} repositories"),
+                }
+            ),
+        });
+    }
+    assemble(work, config, &progress.report(), destination)
+}
+
 pub fn assemble(
     work: &WorkDir,
     config: &EngagementConfig,

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -123,7 +123,11 @@ pub struct ReturnPackage {
     pub total_bytes: u64,
     /// Size of the zip on disk.
     pub packaged_bytes: u64,
-    /// One line per repository the package does not cover, and why.
+    /// One line per target the package does not cover, and why.
+    ///
+    /// The sweep's own failures, plus whatever the caller passed as
+    /// `unattempted` — a repository that never cloned reaches the sweep's
+    /// records nowhere, so it can only arrive that way (#5824).
     pub excluded: Vec<String>,
 }
 
@@ -134,6 +138,7 @@ pub struct ReturnPackage {
 /// redacted copy, so there is no field for the credential to be carried in and
 /// no `skip_serializing` a later edit could remove.
 /// What: scalars first, then the two table arrays — TOML requires that order.
+/// `not_attempted` is a plain string array, so it sits with the scalars.
 #[derive(Debug, Serialize)]
 struct PackageMetadata {
     generated_by: String,
@@ -142,6 +147,16 @@ struct PackageMetadata {
     instructions: String,
     repositories_audited: usize,
     repositories_excluded: usize,
+    /// Targets that never reached the sweep, so `repositories` cannot list them
+    /// and `repositories_excluded` cannot count them (#5824).
+    ///
+    /// A repository that failed to clone and a registered board are both here.
+    /// Kept separate from `repositories_excluded` rather than folded into it,
+    /// because a board is not a repository and counting one as an excluded
+    /// repository would overstate what the sweep was asked to do. Always
+    /// emitted, so an empty array is a positive claim of full coverage rather
+    /// than an absent key a reader has to interpret.
+    not_attempted: Vec<String>,
     tools: Vec<ToolVersion>,
     repositories: Vec<PackagedRepo>,
 }
@@ -218,6 +233,7 @@ struct PackagedRepo {
 pub fn from_checkpoint(
     work: &WorkDir,
     config: &EngagementConfig,
+    unattempted: &[String],
     destination: &Path,
 ) -> Result<ReturnPackage, AuditError> {
     let progress =
@@ -240,13 +256,14 @@ pub fn from_checkpoint(
             ),
         });
     }
-    assemble(work, config, &progress.report(), destination)
+    assemble(work, config, &progress.report(), unattempted, destination)
 }
 
 pub fn assemble(
     work: &WorkDir,
     config: &EngagementConfig,
     report: &RunReport,
+    unattempted: &[String],
     destination: &Path,
 ) -> Result<ReturnPackage, AuditError> {
     let audited: Vec<&RepoRun> = report
@@ -275,8 +292,10 @@ pub fn assemble(
     }
     collected.sort_by(|a, b| a.0.cmp(&b.0));
 
-    let excluded = exclusions(report);
-    let metadata = render_metadata(work, config, report, &audited)?;
+    // #5824: the sweep's own failures, then the targets that never reached it.
+    let mut excluded = exclusions(report);
+    excluded.extend(unattempted.iter().cloned());
+    let metadata = render_metadata(work, config, report, &audited, unattempted)?;
     let readme = render_readme(config, &audited, &excluded);
 
     write_archive(destination, config, readme, metadata, collected, excluded)
@@ -458,6 +477,7 @@ fn render_metadata(
     config: &EngagementConfig,
     report: &RunReport,
     audited: &[&RepoRun],
+    unattempted: &[String],
 ) -> Result<String, AuditError> {
     let tools = tools::read_record(work)?
         .into_iter()
@@ -486,6 +506,7 @@ fn render_metadata(
         instructions: config.instructions.clone(),
         repositories_audited: audited.len(),
         repositories_excluded: report.repos.len() - audited.len(),
+        not_attempted: unattempted.to_vec(),
         tools,
         repositories,
     };
@@ -846,7 +867,7 @@ trusty-review = "0.15.1"
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
         let destination = default_destination(&work);
 
-        let package = assemble(&work, &config(), &report, &destination).expect("assembles");
+        let package = assemble(&work, &config(), &report, &[], &destination).expect("assembles");
 
         assert_eq!(package.path, destination);
         assert!(destination.is_file(), "the zip was not written");
@@ -873,7 +894,7 @@ trusty-review = "0.15.1"
         install_record(&work);
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
         let destination = default_destination(&work);
-        assemble(&work, &config(), &report, &destination).expect("assembles");
+        assemble(&work, &config(), &report, &[], &destination).expect("assembles");
 
         // `by_index` succeeding with no password IS the unencrypted property:
         // the zip crate returns `UnsupportedArchive` for an encrypted entry.
@@ -910,7 +931,7 @@ trusty-review = "0.15.1"
         let report = RunReport::of(vec![run]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &destination)
+        let err = assemble(&work, &config(), &report, &[], &destination)
             .expect_err("a package carrying the key must not be produced");
         assert!(
             matches!(err, AuditError::CredentialInPackage { .. }),
@@ -954,7 +975,7 @@ trusty-review = "0.15.1"
         let report = RunReport::of(vec![run]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &destination)
+        let err = assemble(&work, &config(), &report, &[], &destination)
             .expect_err("a symlink must not be followed into the package");
         assert!(
             matches!(err, AuditError::UnsafePackageEntry { .. }),
@@ -979,7 +1000,7 @@ trusty-review = "0.15.1"
         let report = RunReport::of(vec![run]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &destination)
+        let err = assemble(&work, &config(), &report, &[], &destination)
             .expect_err("a hardlink must not carry outside content into the package");
         let AuditError::UnsafePackageEntry { kind, .. } = &err else {
             panic!("expected UnsafePackageEntry, got {err:?}");
@@ -1011,7 +1032,7 @@ trusty-review = "0.15.1"
         .expect("hard link");
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &destination)
+        let err = assemble(&work, &config(), &report, &[], &destination)
             .expect_err("a hardlink under extract/ must be refused too");
         let AuditError::UnsafePackageEntry { kind, .. } = &err else {
             panic!("expected UnsafePackageEntry, got {err:?}");
@@ -1042,7 +1063,7 @@ trusty-review = "0.15.1"
             assert_eq!(links, 1, "{} has {links} links", path.display());
         }
         let report = RunReport::of(vec![run]);
-        assemble(&work, &config(), &report, &default_destination(&work))
+        assemble(&work, &config(), &report, &[], &default_destination(&work))
             .expect("ordinary output must still package");
     }
 
@@ -1055,7 +1076,7 @@ trusty-review = "0.15.1"
         let report = RunReport::of(vec![failed(&work, "00-acme-api", "acme-api")]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &destination)
+        let err = assemble(&work, &config(), &report, &[], &destination)
             .expect_err("no audited repository means no package");
         assert!(
             matches!(err, AuditError::NothingToPackage { .. }),
@@ -1077,7 +1098,7 @@ trusty-review = "0.15.1"
         ]);
         let destination = default_destination(&work);
 
-        let package = assemble(&work, &config(), &report, &destination).expect("assembles");
+        let package = assemble(&work, &config(), &report, &[], &destination).expect("assembles");
         assert_eq!(package.excluded.len(), 1);
         assert!(
             package.excluded[0].contains("acme-web"),
@@ -1124,7 +1145,7 @@ trusty-review = "0.15.1"
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
         let destination = tmp.path().join("Desktop/return.zip");
 
-        let package = assemble(&work, &config(), &report, &destination).expect("assembles");
+        let package = assemble(&work, &config(), &report, &[], &destination).expect("assembles");
         assert_eq!(package.path, destination);
         assert!(destination.is_file());
         assert!(!destination.starts_with(work.root()));
@@ -1147,7 +1168,7 @@ trusty-review = "0.15.1"
         std::fs::write(work.path(Area::Extract).join("09-other.db"), b"other").expect("write");
         let destination = default_destination(&work);
 
-        assemble(&work, &config(), &report, &destination).expect("assembles");
+        assemble(&work, &config(), &report, &[], &destination).expect("assembles");
         let names = entries(&destination);
         assert!(
             names.contains(&"extract/00-acme-api.db".to_owned()),

--- a/crates/trusty-audit/src/progress.rs
+++ b/crates/trusty-audit/src/progress.rs
@@ -47,6 +47,12 @@ pub enum Operation {
     CloneRepos,
     /// Running `tga audit` over the selected repositories (#5555).
     Sweep,
+    /// Assembling the deliverable to send back (#5499).
+    ///
+    /// One unit — the archive. It earns an operation anyway because #5824's
+    /// chain would otherwise fall silent for its last phase, and a display that
+    /// stops before the run does reads as a hang.
+    Package,
 }
 
 impl Operation {
@@ -56,6 +62,7 @@ impl Operation {
             Self::InstallTools => "installing pinned tools",
             Self::CloneRepos => "cloning repositories",
             Self::Sweep => "auditing repositories",
+            Self::Package => "assembling the return package",
         }
     }
 
@@ -64,6 +71,7 @@ impl Operation {
         match self {
             Self::InstallTools => "tool",
             Self::CloneRepos | Self::Sweep => "repository",
+            Self::Package => "archive",
         }
     }
 
@@ -75,6 +83,7 @@ impl Operation {
         match self {
             Self::InstallTools => "tools",
             Self::CloneRepos | Self::Sweep => "repositories",
+            Self::Package => "archives",
         }
     }
 }

--- a/crates/trusty-audit/src/progress/terminal.rs
+++ b/crates/trusty-audit/src/progress/terminal.rs
@@ -196,6 +196,7 @@ fn verb(operation: Operation) -> &'static str {
         Operation::InstallTools => "installing",
         Operation::CloneRepos => "cloning",
         Operation::Sweep => "auditing",
+        Operation::Package => "packaging",
     }
 }
 
@@ -205,6 +206,7 @@ fn done(operation: Operation) -> &'static str {
         Operation::InstallTools => "installed",
         Operation::CloneRepos => "cloned",
         Operation::Sweep => "audited",
+        Operation::Package => "packaged",
     }
 }
 

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -589,7 +589,9 @@ impl Session {
     fn package(&self, destination: Option<PathBuf>) -> Result<ReturnPackage, AuditError> {
         let config = EngagementConfig::load(&self.config_path)?;
         let destination = destination.unwrap_or_else(|| package::default_destination(&self.work));
-        package::from_checkpoint(&self.work, &config, &destination)
+        // No unattempted targets: the standalone verb packages whatever the last
+        // sweep recorded and knows nothing about a registry (#5824).
+        package::from_checkpoint(&self.work, &config, &[], &destination)
     }
 
     /// Drive the whole engagement in one call (#5824).

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -22,6 +22,7 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::chain::{self, ChainOptions, ChainReport};
 use crate::clone::{self, CloneOptions, CloneReport};
 use crate::config::EngagementConfig;
 use crate::discover::{self, DiscoveredRepo};
@@ -103,6 +104,14 @@ pub enum Command {
         /// Where to write the zip, or `None` for the default inside the work dir.
         destination: Option<PathBuf>,
     },
+    /// Drive the whole engagement in one call: install, materialize the
+    /// registered targets, collect and analyze each one, package (#5824).
+    ///
+    /// This is an ADDITION, not a replacement — the four capabilities it chains
+    /// stay individually invocable, because an operator debugging one phase
+    /// needs to run just that phase. See [`crate::chain`] for the partial-success
+    /// policy and what each phase is.
+    Audit(ChainOptions),
 }
 
 /// The working directory's layout, as reported to a front end.
@@ -208,6 +217,13 @@ pub enum Outcome {
     Run(RunReport),
     /// From [`Command::Package`] — the file to send back, and what it omits.
     Package(ReturnPackage),
+    /// From [`Command::Audit`] — what every phase of the chain produced.
+    ///
+    /// Like [`Outcome::Run`], a report carrying failures is an ORDINARY `Ok`:
+    /// the chain finished and some of it did not, and those failures are data
+    /// the front end must show. [`Outcome::exit_code`] is what stops that
+    /// reading as success.
+    Audit(ChainReport),
 }
 
 /// Exit status for a run that succeeded but did not cover everything asked for.
@@ -236,12 +252,26 @@ impl Outcome {
     /// re-deriving it.
     /// Test: `crate::cli::cli_tests::a_partial_sweep_does_not_exit_zero`,
     /// `crate::cli::cli_tests::a_run_with_gaps_exits_non_zero`,
-    /// `crate::cli::cli_tests::a_package_that_omits_a_repository_does_not_exit_zero`.
+    /// `crate::cli::cli_tests::a_package_that_omits_a_repository_does_not_exit_zero`,
+    /// `crate::chain::chain_tests::a_partly_failed_chain_packages_and_still_does_not_exit_zero`.
     pub fn exit_code(&self) -> i32 {
         match self {
             Outcome::Run(report) if report.status != run::RunStatus::AllSucceeded => EXIT_PARTIAL,
             Outcome::Cloned(report) if !report.gaps.is_empty() => EXIT_INCOMPLETE,
             Outcome::Package(package) if !package.excluded.is_empty() => EXIT_INCOMPLETE,
+            // #5824: the chain reports the sweep's verdict for the same reason
+            // `run` does — a repository that failed makes this an incomplete
+            // engagement, and `taudit audit && send-it` must not chain onward.
+            Outcome::Audit(report) if report.run.status != run::RunStatus::AllSucceeded => {
+                EXIT_PARTIAL
+            }
+            // A target the chain never attempted (a registered board today) is
+            // not a sweep failure and would otherwise be invisible to `$?`.
+            Outcome::Audit(report)
+                if !report.gaps.is_empty() || !report.package.excluded.is_empty() =>
+            {
+                EXIT_INCOMPLETE
+            }
             _ => 0,
         }
     }
@@ -433,6 +463,9 @@ impl Session {
             Command::RemoveTarget { spec } => self.remove_target(&spec).await.map(Outcome::Removed),
             Command::Run(options) => self.run(&options).await.map(Outcome::Run),
             Command::Package { destination } => self.package(destination).map(Outcome::Package),
+            // #5824: the one-shot chain over the four above. `crate::chain`
+            // calls each of them unchanged, so this and they cannot drift.
+            Command::Audit(options) => self.audit(&options).await.map(Outcome::Audit),
         }
     }
 
@@ -548,33 +581,32 @@ impl Session {
     /// packaging that would send a partial engagement as a whole one. An
     /// incomplete record is refused with the count it holds, because the
     /// remedy is to re-run and resume, not to start over.
-    /// What: loads both, then hands off to [`package::assemble`].
+    /// What: loads the config, then hands off to [`package::from_checkpoint`],
+    /// which owns the completion check — #5824 gave it a second caller, and a
+    /// precondition enforced in two places is one that drifts.
     /// Test: `super::session_tests::packaging_before_any_sweep_is_refused`,
     /// `super::session_tests::packaging_an_unfinished_sweep_is_refused`.
     fn package(&self, destination: Option<PathBuf>) -> Result<ReturnPackage, AuditError> {
         let config = EngagementConfig::load(&self.config_path)?;
-        let progress =
-            run::read_progress(&self.work)?.ok_or_else(|| AuditError::NothingToPackage {
-                reason: format!(
-                    "no sweep has finished in {} — run `trusty-audit run` first",
-                    self.work.root().display()
-                ),
-            })?;
-        if !progress.complete {
-            return Err(AuditError::NothingToPackage {
-                reason: format!(
-                    "the last sweep in {} did not finish — {} recorded so far; \
-                     run `trusty-audit run` to resume it",
-                    self.work.root().display(),
-                    match progress.repos.len() {
-                        1 => "1 repository".to_owned(),
-                        n => format!("{n} repositories"),
-                    }
-                ),
-            });
-        }
         let destination = destination.unwrap_or_else(|| package::default_destination(&self.work));
-        package::assemble(&self.work, &config, &progress.report(), &destination)
+        package::from_checkpoint(&self.work, &config, &destination)
+    }
+
+    /// Drive the whole engagement in one call (#5824).
+    ///
+    /// The config is loaded here for the same reason [`Session::run`] loads it,
+    /// and `auto_install` is forwarded so `--no-install` means the same thing on
+    /// the chained path as on the four separate ones.
+    async fn audit(&self, options: &ChainOptions) -> Result<ChainReport, AuditError> {
+        let config = EngagementConfig::load(&self.config_path)?;
+        chain::audit(
+            &self.work,
+            &config,
+            options,
+            self.auto_install,
+            &self.progress,
+        )
+        .await
     }
 
     /// Read the engagement's key and pins, then sweep the selected repositories.

--- a/crates/trusty-audit/tests/cli_end_to_end.rs
+++ b/crates/trusty-audit/tests/cli_end_to_end.rs
@@ -164,9 +164,99 @@ impl Engagement {
         self.taudit(&["run"])
     }
 
+    /// The one-shot chain: install, materialize, collect, package (#5824).
+    fn audit(&self) -> (String, String, Option<i32>) {
+        self.taudit(&["audit"])
+    }
+
     fn selection(&self) -> String {
         std::fs::read_to_string(self.work.join("state/selected-repos.toml")).unwrap_or_default()
     }
+
+    /// Register repository targets the way `taudit add repo` would.
+    ///
+    /// Written directly rather than driven through `add`, because `add`
+    /// validates each target with `gh repo view` and the stub `gh` answers only
+    /// `repo clone`. What this test needs from the registry is that the
+    /// materialize phase READS it, which is the same whichever writer filled it.
+    fn register_repos(&self, repos: &[&str]) {
+        let mut document = format!("count = {}\n", repos.len());
+        for name_with_owner in repos {
+            document.push_str(&format!(
+                "\n[[targets]]\nkind = \"repo\"\nname_with_owner = \"{name_with_owner}\"\n"
+            ));
+        }
+        std::fs::write(self.work.join("state/audit-targets.toml"), document).expect("registry");
+    }
+
+    /// One generated member of the return package, as the recipient reads it.
+    fn package_entry(&self, entry: &str) -> String {
+        let path = self.work.join("audit-return-package.zip");
+        let file =
+            std::fs::File::open(&path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
+        let mut archive = zip::ZipArchive::new(file).expect("a readable zip");
+        let mut member = archive.by_name(entry).expect("entry present");
+        let mut text = String::new();
+        std::io::Read::read_to_string(&mut member, &mut text).expect("read entry");
+        text
+    }
+}
+
+/// The defect #5852's review found: a registered repository that never cloned
+/// vanished from the engagement and the command reported success.
+///
+/// The clone failure is recorded only on `CloneReport::gaps`. `record_selection`
+/// keeps unusable checkouts out of the selection, so the sweep never sees the
+/// repository, `RunStatus` is `AllSucceeded`, and `package::exclusions` — which
+/// derives entirely from the sweep's failures — never learns it existed. Before
+/// the fix this exits 0 with a package whose README reads "Every repository the
+/// sweep was asked to audit is in this package."
+///
+/// Both halves matter and neither substitutes for the other: the exit status is
+/// what stops `taudit audit && send-it`, and the package's own README and
+/// metadata are what a third party opening the zip has instead of this console.
+#[test]
+fn a_registered_repository_that_never_cloned_is_named_in_the_package() {
+    let e = Engagement::new();
+    e.stub_gh(Some("gone"));
+    e.install_stubs(&Engagement::manifest_writer(None));
+    e.register_repos(&["acme/api", "acme/gone"]);
+
+    let (stdout, stderr, code) = e.audit();
+
+    // 2 is EXIT_INCOMPLETE, and pinning it proves WHICH arm of
+    // `Outcome::exit_code` fired. The sweep audited every repository it was
+    // given, so the partial-sweep arm (1) cannot have run: the only thing left
+    // to make this non-zero is the materialize-phase gap.
+    assert_eq!(
+        code,
+        Some(2),
+        "a registered repository that never cloned must not exit zero\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(stdout.contains("Audited 1 repository"), "{stdout}");
+
+    // Each section states the fact it owns, and no section repeats another's
+    // sentence: the acquisition failed it, and the package does not include it.
+    assert!(stdout.contains("Gap: acme/gone"), "{stdout}");
+    assert!(stdout.contains("Not included: acme/gone"), "{stdout}");
+    assert!(
+        !stdout.contains("Not audited: acme/gone"),
+        "the chain roll-up repeated the acquisition section verbatim:\n{stdout}"
+    );
+
+    let readme = e.package_entry("README.md");
+    assert!(
+        readme.contains("acme/gone"),
+        "the package README must name the repository it does not cover:\n{readme}"
+    );
+    assert!(readme.contains("Not in this package"), "{readme}");
+
+    let metadata = e.package_entry("package.toml");
+    assert!(
+        metadata.contains("acme/gone"),
+        "package.toml must name the repository it does not cover:\n{metadata}"
+    );
 }
 
 /// #5556 closure conditions 1 and 2: one CLI-driven sequence selects SEVERAL


### PR DESCRIPTION
Closes #5824.

`taudit audit` runs the whole engagement in one invocation. Each phase calls the
existing capability unchanged — `tools::ensure`, `clone::clone_all`,
`run::sweep`, `package::from_checkpoint` — so the chain and the four separate
verbs cannot drift apart. Those four verbs are untouched.

New module `crates/trusty-audit/src/chain.rs`; new `Command::Audit(ChainOptions)`
dispatched through `Session::execute` like every other capability.

## The registry reaches the sweep

`state/audit-targets.toml` (#5822) had no reader. `run` takes its input from
`state/selected-repos.toml`, which only `clone` writes, so registering a
repository did nothing until someone cloned it by hand under the same name. The
materialize phase reads the registry and hands the repository targets to
`clone_all`, which records the usable checkouts as the selection.

An empty registry falls back to whatever an earlier `clone` selected, so an
operator who cloned by hand before the registry existed keeps working. Both
absent is a refusal naming the remedy, not an empty run.

## Boards are a stated gap, and wiring them is bigger than this PR

`tga audit` does take a JIRA project — its config has a `jira:` section and it
runs a `JiraSync` stage — but tga reads that section's `token` as a literal
string. The `${VAR}` expansion its Linear and Azure DevOps clients apply
(`tga::collect::env_expand::expand_env_var`) is not applied to the JIRA
credential. Passing a board through today therefore means writing the board
credential into the generated `state/tga-<stem>.yaml`, and this crate's posture
is that a secret reaches a child through its environment and never through a
file (DOC-68 §13).

Two other things would be needed even after that: `RunReport` is per-repository
(`RepoRun`, `SelectedRepo`) with no shape for a board's result, and nothing
verifies what a board collection produced the way `verify_output` does for a
repository. So a registered board becomes one stated gap line, which makes the
run's exit status non-zero — it is reported, never dropped. The durable fix
starts with env-var expansion on tga's JIRA credential.

## Partial success: continue and report

With six repositories, one failing is ordinary. The chain continues past it,
which is already what `clone` and `run` do alone (DOC-68 §14 Q2, DOC-67 §9).
Stopping would discard five audits over one failure.

Three things keep that from reading as a whole engagement:

- A sweep in which nothing was audited stops in the collect phase. There is no
  package, because a package over zero audited repositories is a zip of two
  generated files that looks like a deliverable.
- A sweep in which some repository failed still packages, and `package::assemble`
  names every repository it does not cover in the README and metadata.
- Either way `Outcome::exit_code` is non-zero, so `taudit audit && send-it`
  stops.

## Attribution

Every phase failure arrives as `AuditError::ChainStopped { phase, source }`. The
phase says which of install / materialize / collect / package stopped; the
wrapped error names the target and the reason. Per-target results stay in each
phase's own report — `CloneReport.repos`, `RunReport.repos` — so a failed
repository still points at its own log.

## Resume

Every phase is re-entrant already: `tools::ensure` is a no-op when the pins are
satisfied, `clone_all` reuses a complete checkout, and the sweep resumes from
#5494's per-repository checkpoint. `--fresh` forwards to the sweep unchanged.

## Fail-open check

Two error-arm tests, each shown failing with its guard removed.

`a_partly_failed_chain_packages_and_still_does_not_exit_zero` — two repositories,
one fails. Without the `Outcome::Audit` arm of `Outcome::exit_code`:

```
thread 'chain::chain_tests::a_partly_failed_chain_packages_and_still_does_not_exit_zero'
panicked at crates/trusty-audit/src/chain.rs:571:9:
assertion `left != right` failed: a partial engagement must not exit zero
  left: 0
 right: 0

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 262 filtered out
```

`a_sweep_that_audited_nothing_stops_before_packaging` — every child exits 1.
Without the `RunStatus::AllFailed` check in the collect phase:

```
thread 'chain::chain_tests::a_sweep_that_audited_nothing_stops_before_packaging'
panicked at crates/trusty-audit/src/chain.rs:594:9:
assertion `left == right` failed: the audit stopped in the package phase — no repository was audited (2 attempted), so there is no report to return
  left: Package
 right: Collect

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 262 filtered out
```

The second case would refuse either way — `package::assemble` already rejects a
report in which nothing was audited — but it would refuse as a packaging failure
over what is a collection failure.

## SLOC split

`cli.rs` was at 441 SLOC and the new outcome arm took it over 500. Rendering
moved to `crates/trusty-audit/src/cli/render.rs` (353 SLOC), leaving `cli.rs` at
135: argv-to-capability in one file, capability-to-text in the other. `render` is
re-exported, so no caller or test moved. `run.rs` is untouched and stays at 472.

The completion check that used to live in `Session::package` moved to
`package::from_checkpoint`, because the chain became its second caller and a
precondition enforced in two places is one that drifts.

## Gates — rung 3 (localized behavior inside `trusty-audit`)

```
cargo fmt --check                                        EXIT=0
cargo check -p trusty-audit --all-targets                EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings EXIT=0
cargo test -p trusty-audit                               EXIT=0
  test result: ok. 259 passed; 0 failed; 5 ignored  (lib)
  test result: ok. 3 passed  (binary_names)
  test result: ok. 4 passed  (cli_end_to_end)
  test result: ok. 4 passed; 2 ignored  (install_fails_closed)
  test result: ok. 9 passed  (run_fails_closed)
bash scripts/check_line_cap.sh          4043 files, 0 violations — OK
bash scripts/check_sld.sh               0 errors, 0 warnings
bash scripts/check_test_pointers.sh     25199 citations, 0 dangling
bash scripts/check_changelog_fragment.sh OK trusty-audit
```

Rung 3 rather than 4: every changed file is in `crates/trusty-audit`, and no
other crate depends on it (`grep trusty-audit crates/*/Cargo.toml` finds only its
own manifest).

Branched off #5847's branch while that was in flight, then rebased onto `main`
after it merged.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
