### PR TITLE
fix(trusty-common): SecretString Debug and Display disclose nothing derived from the value

### DIFF
--- a/crates/trusty-common/changelog.d/4632-secretstring-debug-value-independent.md
+++ b/crates/trusty-common/changelog.d/4632-secretstring-debug-value-independent.md
@@ -1,0 +1,9 @@
+Security
+- `inference::types::SecretString`'s `Debug` and `Display` no longer disclose
+  the first four characters of the wrapped credential, nor its byte length.
+  Both now write the fixed constant `SecretString(<redacted>)`, computed from
+  no part of the value, which is what DOC-45 `C-8.2` requires. Anything that
+  derives `Debug` and holds a `SecretString` — `ResolvedProvider`, whose own
+  doc comment promised `Debug` was safe to log — printed a live API key's head
+  before this. Two property tests pin the guarantee: the rendering never varies
+  with the value, and it contains no substring of it (#4632).

--- a/crates/trusty-common/src/credentials/secret.rs
+++ b/crates/trusty-common/src/credentials/secret.rs
@@ -21,14 +21,13 @@
 //! greppable [`Secret::expose`].
 //!
 //! Relationship to [`crate::inference::types::SecretString`]: that type came
-//! first (#2402) and renders a four-character head preview via
-//! [`super::redact_secret`], which does **not** satisfy `C-8.2`'s "contains no
-//! substring of the wrapped value". It also derives `Clone` and `PartialEq`,
-//! which `Secret` deliberately does not, so it cannot simply become an alias.
+//! first (#2402) and rendered a four-character head preview via
+//! [`super::redact_secret`] until #4632 fixed it; it now renders its own
+//! constant and meets `C-8.2` too. What still separates the two is the rest of
+//! the list above — `SecretString` derives `Clone` and `PartialEq`, which
+//! `Secret` deliberately does not, so it cannot become an alias.
 //! [`SecretString::into_secret`](crate::inference::types::SecretString::into_secret)
-//! converts one to the other; collapsing the two is deliberately left to a
-//! follow-up because it requires changing an existing test that pins the older
-//! type's leakier `Debug` shape.
+//! converts one to the other; collapsing the two is left to a follow-up.
 //!
 //! Test: `tests::debug_and_display_are_value_independent`,
 //! `tests::rendering_contains_no_substring_of_the_value`,

--- a/crates/trusty-common/src/inference/configurator/resolver.rs
+++ b/crates/trusty-common/src/inference/configurator/resolver.rs
@@ -30,8 +30,12 @@ use crate::inference::types::SecretString;
 /// pure function of this value.
 /// What: `provider` is the resolved [`ProviderId`]; `model` is the (possibly
 /// re-homed) slug to send; `key` is the resolved credential or `None` for
-/// Bedrock. `Debug` is safe to log — `key`'s [`SecretString`] redacts itself.
-/// Test: every resolver test asserts the resolved fields.
+/// Bedrock. `Debug` is safe to log: `key`'s [`SecretString`] renders a constant
+/// that is computed from no part of the credential (#4632 — before that fix
+/// this sentence was false, and a `Debug` dump here printed the key's first
+/// four characters).
+/// Test: `resolved_provider_debug_is_redacted` in `tests/inference_foundation.rs`;
+/// every resolver test asserts the resolved fields.
 #[derive(Debug, Clone)]
 pub struct ResolvedProvider {
     provider: ProviderId,

--- a/crates/trusty-common/src/inference/types/secret.rs
+++ b/crates/trusty-common/src/inference/types/secret.rs
@@ -7,27 +7,37 @@
 //! exactly this class of Debug-leak. Wrapping the key in this newtype makes the
 //! leak-safe behaviour the default rather than something each call site must
 //! remember.
-//! What: [`SecretString`] holds a `String` whose `Debug`/`Display` render the
-//! redacted preview from [`crate::credentials::redact_secret`]. It
+//! What: [`SecretString`] holds a `String` whose `Debug`/`Display` write the
+//! fixed constant `REDACTED`. That string is computed from no part of the
+//! wrapped value, so it satisfies DOC-45 `C-8.2` — the rendered form contains
+//! no substring of the value and does not vary with it, not even in length. It
 //! does NOT derive `Serialize`, so it can never be written to the wire. The raw
 //! value is reachable only via the explicit [`SecretString::expose`] method.
 //!
-//! **Superseded by [`crate::credentials::Secret`] (#4565).** That type is the
-//! canonical credential wrapper going forward and is strictly stricter: its
-//! `Debug`/`Display` are *value-independent* (this type discloses a
-//! four-character head preview, which does not meet DOC-45 `C-8.2`'s "contains
-//! no substring of the wrapped value"), and it implements neither `Clone` nor
-//! `Deserialize`. `SecretString` cannot simply become an alias for it: the
-//! inference stack relies on `Clone`/`PartialEq`, and the preview shape is
-//! pinned by this module's own `secret_debug_is_redacted`. Collapsing the two
-//! is therefore a deliberate follow-up, not a side effect of #4565.
-//! [`SecretString::into_secret`] is the one-line migration.
-//! Test: inline `tests` — `secret_debug_is_redacted`, `secret_display_is_redacted`,
-//! `secret_expose_returns_raw`, `secret_string_converts_to_the_canonical_secret`.
+//! Until #4632 the two impls rendered [`crate::credentials::redact_secret`]'s
+//! four-character head preview instead, so anything deriving `Debug` around a
+//! `SecretString` printed the head of a live API key.
+//!
+//! **Superseded by [`crate::credentials::Secret`] (#4565).** That type remains
+//! the canonical credential wrapper going forward: it matches this type's
+//! rendering guarantee and adds compile-time refusal of `Serialize`,
+//! `Deserialize`, and `Clone`. `SecretString` cannot simply become an alias for
+//! it, because the inference stack relies on `Clone`/`PartialEq`; collapsing
+//! the two is a deliberate follow-up. [`SecretString::into_secret`] is the
+//! one-line migration.
+//! Test: inline `tests` — `debug_and_display_are_value_independent`,
+//! `rendering_contains_no_substring_of_the_value`, `secret_debug_is_redacted`,
+//! `secret_display_is_redacted`, `secret_expose_returns_raw`,
+//! `secret_string_converts_to_the_canonical_secret`.
 
 use std::fmt;
 
-use crate::credentials::{Secret, redact_secret};
+use crate::credentials::Secret;
+
+/// The entire rendered form of a [`SecretString`], for both `Debug` and
+/// `Display`. A constant, never a function of the wrapped value — DOC-45
+/// `C-8.2`.
+const REDACTED: &str = "SecretString(<redacted>)";
 
 /// A string credential that redacts itself in `Debug`/`Display`.
 ///
@@ -35,10 +45,12 @@ use crate::credentials::{Secret, redact_secret};
 /// accident — the only way to read the raw value is the named, greppable
 /// [`Self::expose`] call, so credential handling is auditable.
 /// What: a transparent wrapper over `String` with hand-written `Debug`/`Display`
-/// that delegate to [`redact_secret`]. Intentionally NOT `Serialize`,
-/// `Clone`-audited (clone is allowed — the value is already in memory), and
-/// NOT `Deref` (that would re-expose the raw value implicitly).
-/// Test: `secret_debug_is_redacted`, `secret_expose_returns_raw`.
+/// that both write the constant `REDACTED` and read nothing from the value.
+/// Intentionally NOT `Serialize`, `Clone`-audited (clone is allowed — the value
+/// is already in memory), and NOT `Deref` (that would re-expose the raw value
+/// implicitly).
+/// Test: `debug_and_display_are_value_independent`,
+/// `rendering_contains_no_substring_of_the_value`, `secret_expose_returns_raw`.
 #[derive(Clone, PartialEq, Eq)]
 pub struct SecretString(String);
 
@@ -66,10 +78,10 @@ impl SecretString {
 
     /// Convert into the canonical [`Secret`] wrapper (#4565).
     ///
-    /// Why: the migration path off this type. `Secret<String>` is strictly
-    /// stricter — value-independent rendering, no `Clone`, no `Deserialize` —
-    /// so this conversion only ever tightens the guarantees; there is
-    /// deliberately no conversion in the other direction.
+    /// Why: the migration path off this type. Both render value-independently
+    /// since #4632; what `Secret<String>` adds on top is compile-time refusal of
+    /// `Serialize`, `Deserialize`, and `Clone`, so this conversion only ever
+    /// tightens the guarantees. There is deliberately no conversion back.
     /// What: moves the wrapped string into a `Secret`.
     /// Test: `secret_string_converts_to_the_canonical_secret`.
     pub fn into_secret(self) -> Secret<String> {
@@ -78,27 +90,33 @@ impl SecretString {
 }
 
 impl fmt::Debug for SecretString {
-    /// Render the redacted preview, never the raw value.
+    /// Render a fixed redaction, never any part of the raw value.
     ///
     /// Why: a `#[derive(Debug)]` struct that transitively contains a
     /// `SecretString` (e.g. `ResolvedProvider`) must be safe to log; this impl
-    /// guarantees that.
-    /// What: writes `SecretString(<redacted>)`.
-    /// Test: `secret_debug_is_redacted`.
+    /// is what makes that true. It reads `self.0` not at all, so there is no
+    /// value for a log line, a panic message, or an error chain to carry.
+    /// What: writes `REDACTED`.
+    /// Test: `debug_and_display_are_value_independent`,
+    /// `rendering_contains_no_substring_of_the_value`.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SecretString({})", redact_secret(&self.0))
+        // #4632: a four-character head narrows a brute-force space; render a
+        // constant instead of a preview derived from the value.
+        f.write_str(REDACTED)
     }
 }
 
 impl fmt::Display for SecretString {
-    /// Render the redacted preview, never the raw value.
+    /// Render a fixed redaction, never any part of the raw value.
     ///
     /// Why: `Display` is the surface most likely to reach a user-facing message
     /// or a `format!` in a log; it must be as safe as `Debug`.
-    /// What: writes the redacted preview only.
-    /// Test: `secret_display_is_redacted`.
+    /// What: writes `REDACTED`, identically to `Debug`.
+    /// Test: `debug_and_display_are_value_independent`,
+    /// `rendering_contains_no_substring_of_the_value`.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&redact_secret(&self.0))
+        // #4632: see the `Debug` impl above — the two must not diverge.
+        f.write_str(REDACTED)
     }
 }
 
@@ -108,23 +126,32 @@ impl fmt::Display for SecretString {
 mod tests {
     use super::*;
 
-    /// Why: the raw value must never appear in a `Debug` dump.
+    /// Why: no part of the raw value may appear in a `Debug` dump — head
+    /// included. This test previously asserted the opposite of its own name:
+    /// `dumped.contains("chars")` pinned the `sk-o…(25 chars)` preview shape in
+    /// place, which is why #4632's leak survived a suite that looked like it
+    /// covered this.
     /// Test: itself.
     #[test]
     fn secret_debug_is_redacted() {
         let s = SecretString::new("sk-or-verysecretvalue1234"); // pragma: allowlist secret
         let dumped = format!("{s:?}");
         assert!(!dumped.contains("verysecretvalue"), "leaked: {dumped}");
-        assert!(dumped.contains("chars"), "not redacted shape: {dumped}");
+        assert!(!dumped.contains("sk-o"), "head leaked: {dumped}");
+        assert!(!dumped.contains("chars"), "length leaked: {dumped}");
+        assert_eq!(dumped, REDACTED);
     }
 
-    /// Why: the raw value must never appear in a `Display` render.
+    /// Why: `Display` must give away exactly as little as `Debug` — #4632
+    /// leaked the same head through both.
     /// Test: itself.
     #[test]
     fn secret_display_is_redacted() {
         let s = SecretString::new("sk-or-verysecretvalue1234"); // pragma: allowlist secret
         let shown = format!("{s}");
         assert!(!shown.contains("verysecretvalue"), "leaked: {shown}");
+        assert!(!shown.contains("sk-o"), "head leaked: {shown}");
+        assert_eq!(shown, REDACTED);
     }
 
     /// Why: `expose` is the one sanctioned path back to the raw value.
@@ -135,19 +162,109 @@ mod tests {
         assert_eq!(s.expose(), "raw-key");
     }
 
-    /// Why: the migration path off this type must be lossless, and the
-    /// conversion must actually *tighten* the rendering — the head preview this
-    /// type discloses (see `secret_debug_is_redacted` above) must be gone once
-    /// the value is in a `Secret`.
+    /// A spread of realistic credential shapes plus deterministic
+    /// pseudo-random values, mirroring the input set
+    /// `crate::credentials::secret`'s properties are quantified over.
+    fn specimens() -> Vec<String> {
+        let mut v: Vec<String> = [
+            "",
+            "a",
+            "secret",
+            // pragma: allowlist secret
+            "ghp_16C7e42F292c6912E7710c838347Ae178B4a",
+            // pragma: allowlist secret
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.dBjftJeZ4CVP",
+            "パスワード",
+            "SecretString(<redacted>)",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+        for len in 1..=64 {
+            let mut s = String::with_capacity(len);
+            for _ in 0..len {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                let byte = ((state >> 33) % 94) as u8 + 33; // printable ASCII
+                s.push(byte as char);
+            }
+            v.push(s);
+        }
+        v
+    }
+
+    /// Why: the strongest statement of DOC-45 `C-8.2` — the rendering does not
+    /// *depend* on the wrapped value at all, so no information about it can
+    /// have survived. This is the regression test for #4632: before the fix
+    /// `Debug` rendered a four-character head plus the byte length, both of
+    /// which vary with the value.
+    /// Test: itself.
+    #[test]
+    fn debug_and_display_are_value_independent() {
+        let baseline_debug = format!("{:?}", SecretString::new(""));
+        let baseline_display = format!("{}", SecretString::new(""));
+        for value in specimens() {
+            let s = SecretString::new(value.clone());
+            assert_eq!(
+                format!("{s:?}"),
+                baseline_debug,
+                "Debug varied with the value: {value:?}"
+            );
+            assert_eq!(
+                format!("{s}"),
+                baseline_display,
+                "Display varied with the value: {value:?}"
+            );
+        }
+    }
+
+    /// Why: `C-8.2` as literally written — "the rendered form contains no
+    /// substring of it". Quantified over every contiguous substring of length
+    /// ≥ 3 of every credential-shaped specimen. Specimens shorter than 8
+    /// characters are not credential-shaped and are skipped; a candidate that
+    /// already appears in the rendering of the *empty* secret is coincidence,
+    /// not disclosure, and is exempt — `debug_and_display_are_value_independent`
+    /// is the stronger property that makes that exemption safe.
+    /// Test: itself.
+    #[test]
+    fn rendering_contains_no_substring_of_the_value() {
+        const MIN_DISCLOSURE_LEN: usize = 3;
+        const MIN_CREDENTIAL_LEN: usize = 8;
+        let empty = SecretString::new("");
+        let baseline = format!("{empty:?} {empty}");
+        for value in specimens() {
+            let chars: Vec<char> = value.chars().collect();
+            if chars.len() < MIN_CREDENTIAL_LEN {
+                continue;
+            }
+            let s = SecretString::new(value.clone());
+            let rendered = format!("{s:?} {s}");
+            for start in 0..chars.len() {
+                for end in (start + MIN_DISCLOSURE_LEN)..=chars.len() {
+                    let candidate: String = chars[start..end].iter().collect();
+                    if baseline.contains(&candidate) {
+                        continue; // present regardless of the value; not disclosure
+                    }
+                    assert!(
+                        !rendered.contains(&candidate),
+                        "rendering {rendered:?} disclosed {candidate:?} from {value:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Why: the migration path off this type must be lossless, and neither side
+    /// of it may disclose the value. Before #4632 this test asserted the source
+    /// type *did* leak a head (`leaky.contains("sk-o")`); both sides now redact,
+    /// and what `Secret` still adds is compile-time refusal of `Serialize`,
+    /// `Deserialize`, and `Clone`.
     /// Test: itself.
     #[test]
     fn secret_string_converts_to_the_canonical_secret() {
         let s = SecretString::new("sk-or-verysecretvalue1234"); // pragma: allowlist secret
-        let leaky = format!("{s:?}");
-        assert!(
-            leaky.contains("sk-o"),
-            "precondition: this type leaks a head"
-        );
+        let before = format!("{s:?}");
+        assert!(!before.contains("sk-o"), "head leaked: {before}");
 
         let tightened = s.into_secret();
         assert_eq!(tightened.expose(), "sk-or-verysecretvalue1234");

--- a/crates/trusty-common/tests/inference_foundation.rs
+++ b/crates/trusty-common/tests/inference_foundation.rs
@@ -155,7 +155,9 @@ fn provider_for_two_stage_resolution() {
 }
 
 /// Why: a resolved key must never leak through `Debug` — the redacting
-/// `SecretString` guards the whole `ResolvedProvider`.
+/// `SecretString` guards the whole `ResolvedProvider`. #4632: the head is part
+/// of the key, so this asserts on the first four characters as well as on the
+/// distinctive middle; the old assertion passed while `Debug` printed `sk-o`.
 #[test]
 #[serial(dotenv_credential_env)]
 fn resolved_provider_debug_is_redacted() {
@@ -167,6 +169,10 @@ fn resolved_provider_debug_is_redacted() {
     assert!(
         !dumped.contains("verysecret"),
         "key leaked in Debug: {dumped}"
+    );
+    assert!(
+        !dumped.contains("sk-o"),
+        "key head leaked in Debug: {dumped}"
     );
 }
 


### PR DESCRIPTION
Closes #4632.

The defect: `Debug` rendered `SecretString(sk-o…(25 chars))` and `Display` rendered the bare `sk-o…(25 chars)` — a four-character head plus the exact length. `Debug` fires implicitly whenever something containing the type is logged, panics, or is dumped, with no caller opt-in. A four-character head plus a length materially narrows a brute-force space.

DOC-45 C-8.2 (`docs/specs/DOC-45-credential-authority-model.md:706`) requires `Debug` and `Display` to never render the wrapped value, property-tested such that the rendering contains no substring of it. The clause names `Secret<T>` but points at `SecretString`'s file as the thing to fold in, so it governs both. It permits no length, so nothing is disclosed — no prefix, no hash, no length. The sibling `Secret<T>` already set that precedent.

Both impls are now `f.write_str(REDACTED)` against a module constant and never reference `self.0`. The now-unused `redact_secret` import was removed, so a future re-introduction trips unused-import before it can leak.

**The tests that were supposed to catch this had certified it instead** — the part most worth a reviewer's attention. `secret_debug_is_redacted` asserted `dumped.contains("chars")`, pinning the preview shape while its name claimed redaction; `secret_string_converts_to_the_canonical_secret` asserted `leaky.contains("sk-o")` as an explicit precondition. All three pre-existing tests passed against the leaky code. Both are rewritten.

The two new property tests quantify over 71 specimens — 7 hand-picked credential shapes plus 64 from a fixed-seed LCG. One asserts the rendering never varies with the value; the other that it contains no substring of length ≥3 of any specimen ≥8 chars. `resolved_provider_debug_is_redacted` in `tests/inference_foundation.rs` was strengthened to assert on the head.

`Serialize`/`Deserialize` were already absent and remain so — verified, not assumed. `redact_secret` is deliberately untouched: it masks a value a caller explicitly chose to preview, which is opt-in partial disclosure for debugging, a different contract from a type's implicit formatting.

`ResolvedProvider`'s doc comment at `resolver.rs:33` claimed "`Debug` is safe to log". That was false before this change and is true after it; the comment now says why, with a #4632 pointer.

**A user-visible string change to flag:** `Display` now emits `SecretString(<redacted>)` where it previously emitted the bare preview without the type name. It matches the sibling `Secret<T>`, and no production code formats a `SecretString`, but it is a change in rendered output rather than a pure removal.

**Not a breaking API change.** No item added, removed, or altered in type — only two `fmt` method bodies. What changed is the content of a string the type's documented contract already said callers must not depend on. If the release path wants independent confirmation that is `local-ops`' call.

Test ladder rung 4. Pre-fix, `debug_and_display_are_value_independent` fails with `Debug varied with the value: "a"` and `rendering_contains_no_substring_of_the_value` fails disclosing `"ghp"`. Post-fix both pass.

**`cargo test -p trusty-common` alone runs ZERO of these tests** — it reported `441 filtered out`. `inference` is behind the `inference-client` feature. Every gate below used it.

Gates: `fmt --check`, `check -p trusty-common --features inference-client --all-targets`, `clippy` same with `-D warnings`, `check --workspace --all-targets`, `check_line_cap.sh`, `check_sld.sh`, `check_test_pointers.sh`, `check_changelog_fragment.sh` all exit 0. `cargo test -p trusty-common --features inference-client`: 566 passed, 0 failed. Direct dependent `trusty-mpm`: 5048 passed, 0 failed plus 40 integration binaries clean. `trusty-agents` looks like a consumer but is not — its `SecretString` mentions are async-openai's different type.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
