### PR TITLE
fix(trusty-agents-common): the ownership ledger must not report an absence it never established

### DIFF
--- a/crates/trusty-agents-common/changelog.d/5626-ledger-absence-vs-unreadable-changed.md
+++ b/crates/trusty-agents-common/changelog.d/5626-ledger-absence-vs-unreadable-changed.md
@@ -1,0 +1,10 @@
+Changed
+
+- **Breaking (#5626):** `SkillManifest::load` returns `Result<SkillManifest>`,
+  `skills::unmanaged::unmanaged_bundled_skills` and
+  `skills::reconcile::preview_unmanaged_bundled_skills` return
+  `Result<Vec<UnmanagedBundledSkill>>`, and
+  `agents::tier_audit::audit_agent_tier` returns
+  `Result<Vec<MisplacedAgent>, TierAuditError>`. `TierAuditError` is new and
+  public. Callers must decide what an unreadable ledger means for them; an
+  `unwrap_or_default()` reinstates the defect this release removes.

--- a/crates/trusty-agents-common/changelog.d/5626-ledger-absence-vs-unreadable-fixed.md
+++ b/crates/trusty-agents-common/changelog.d/5626-ledger-absence-vs-unreadable-fixed.md
@@ -1,0 +1,15 @@
+Fixed
+
+- The agent and skill ownership ledgers no longer report an absence they never
+  established (#5626, ADR-0045). `SkillManifest::load` returned the empty
+  manifest for a missing file, a malformed document, `EACCES`, and any other
+  I/O error alike, and every consumer reads the empty manifest as "trusty-mpm
+  owns nothing here" — which let a deploy write over managed skills and record
+  none of them. It now returns `Result<SkillManifest>`: only
+  `ErrorKind::NotFound` yields the empty default, and every other failure is a
+  `ManifestError` naming the ledger. `AgentManifest::load_checked` routes
+  non-`NotFound` I/O errors to `ManifestLoad::Corrupt`, so
+  `quarantine::sweep_locked`'s `CorruptLedger` refusal now covers an unreadable
+  ledger as well as a torn one. `audit_agent_tier` returns
+  `Result<Vec<MisplacedAgent>, TierAuditError>` so a tier directory it could not
+  enumerate is no longer reported to `tm doctor` as scanned-and-clean.

--- a/crates/trusty-agents-common/src/agents/manifest.rs
+++ b/crates/trusty-agents-common/src/agents/manifest.rs
@@ -52,16 +52,27 @@ pub const MANIFEST_FILE: &str = ".trusty-mpm-manifest.json";
 /// The outcome of loading the agent manifest.
 ///
 /// Why: callers need to distinguish "no manifest yet" (first deploy, expect
-/// empty) from "manifest is corrupt" (dangerous — silently resetting to empty
-/// would reclassify managed files as user-owned and skip re-deploying them).
+/// empty) from "the ledger's contents could not be established" (dangerous —
+/// silently resetting to empty would reclassify managed files as user-owned and
+/// skip re-deploying them).
 /// What: `Ok(manifest)` when the file is absent or parses cleanly; `Corrupt`
-/// when the file exists but is malformed or truncated.
-/// Test: `manifest_load_corrupt_returns_corrupt`.
+/// when the ledger exists but could not be read as one.
+///
+/// `Corrupt` covers every non-`NotFound` outcome since #5626, not only a
+/// malformed or truncated document: `EACCES` on an unsearchable parent and a
+/// transient `EIO` leave ownership exactly as undetermined as a torn JSON
+/// document does, and the refusals downstream —
+/// [`crate::agents::quarantine::sweep_locked`]'s `CorruptLedger` above all —
+/// are the correct response to both. The variant's payload names the path and
+/// the underlying failure, so an operator still sees which one it was.
+/// Test: `manifest_load_corrupt_returns_corrupt`,
+/// `manifest_load_unreadable_returns_corrupt`.
 #[derive(Debug)]
 pub enum ManifestLoad {
     /// File was absent (first deploy) or parsed cleanly.
     Ok(AgentManifest),
-    /// File exists but is malformed / truncated.
+    /// The ledger exists but could not be read as one — malformed, truncated,
+    /// or unreadable.
     Corrupt(String),
 }
 
@@ -336,16 +347,25 @@ impl AgentManifest {
     /// Load the manifest from `target_dir`, defaulting to empty when absent.
     ///
     /// Why: a first-ever deploy has no manifest; treating a missing file as an
-    /// empty manifest keeps the deployer's logic uniform. A corrupt (malformed /
-    /// truncated) manifest must NOT silently reset to empty — that would cause
+    /// empty manifest keeps the deployer's logic uniform. A ledger that exists
+    /// but cannot be read must NOT silently reset to empty — that would cause
     /// managed files to be reclassified as user-owned and skipped on the next
     /// deploy, producing a silent no-op rather than a re-deploy.
-    /// What: reads `<target_dir>/.trusty-mpm-manifest.json`; if absent returns
-    /// `ManifestLoad::Ok(default)`; if present but malformed returns
-    /// `ManifestLoad::Corrupt` with the parse error; if valid returns
-    /// `ManifestLoad::Ok(parsed)`.
+    ///
+    /// #5626: the `Err(_) => Ok(default)` arm this replaces made that reasoning
+    /// hold for a malformed document only. An `EACCES` on the ledger — or a
+    /// stale handle, or a transient `EIO` — took the benign arm and defeated
+    /// [`crate::agents::quarantine::sweep_locked`]'s `CorruptLedger` refusal
+    /// without a word, at which point a file the real ledger records as
+    /// user-owned reads as untracked and can be renamed to `.md.disabled`.
+    ///
+    /// What: reads `<target_dir>/.trusty-mpm-manifest.json`. `ErrorKind::NotFound`
+    /// alone returns `ManifestLoad::Ok(default)`; a valid document returns
+    /// `ManifestLoad::Ok(parsed)`; a parse failure or any other I/O failure
+    /// returns [`ManifestLoad::Corrupt`] naming the path and the cause.
     /// Test: `manifest_load_missing_returns_empty`,
     ///       `manifest_load_corrupt_returns_corrupt`,
+    ///       `manifest_load_unreadable_returns_corrupt`,
     ///       `manifest_round_trip`.
     pub fn load_checked(target_dir: &Path) -> ManifestLoad {
         let path = target_dir.join(MANIFEST_FILE);
@@ -355,7 +375,9 @@ impl AgentManifest {
                 Err(e) => ManifestLoad::Corrupt(format!("{path}: {e}", path = path.display())),
             },
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => ManifestLoad::Ok(Self::default()),
-            Err(_) => ManifestLoad::Ok(Self::default()),
+            // #5626: an unreadable ledger determines nothing, so it takes the
+            // same refusal a torn one does.
+            Err(e) => ManifestLoad::Corrupt(format!("{path}: {e}", path = path.display())),
         }
     }
 
@@ -466,6 +488,37 @@ mod tests {
         assert!(
             matches!(result, ManifestLoad::Corrupt(_)),
             "expected Corrupt for malformed manifest"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn manifest_load_unreadable_returns_corrupt() {
+        // #5626, ADR-0045: the `Err(_) => Ok(default)` arm this replaces gave
+        // EACCES the same benign answer as a missing file, which defeated
+        // `quarantine::sweep_locked`'s CorruptLedger refusal without a word —
+        // a file the real ledger records as UserOwned then reads as Untracked
+        // and can be renamed to `.md.disabled`.
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let mut manifest = AgentManifest::default();
+        manifest
+            .managed
+            .insert("engineer.md".into(), sample_entry());
+        manifest.save(tmp.path()).unwrap();
+
+        let path = tmp.path().join(MANIFEST_FILE);
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+        let result = AgentManifest::load_checked(tmp.path());
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let ManifestLoad::Corrupt(detail) = result else {
+            panic!("expected Corrupt for an unreadable ledger, got {result:?}");
+        };
+        assert!(
+            detail.contains(MANIFEST_FILE),
+            "the detail must name the ledger: {detail}"
         );
     }
 

--- a/crates/trusty-agents-common/src/agents/tier_audit.rs
+++ b/crates/trusty-agents-common/src/agents/tier_audit.rs
@@ -79,9 +79,39 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
+use thiserror::Error;
+
 use crate::agents::deployer::is_agent_file;
 use crate::agents::manifest::{AgentManifest, ManifestLoad};
 use crate::agents::metadata::agent_metadata_from_str;
+
+/// Why [`audit_agent_tier`] could not answer for a directory.
+///
+/// Why (#5626, [ADR-0045]): the scan's empty vec is what `tm doctor` renders as
+/// `no tm-owned agent files outside the canonical tier … (scanned: <dir>)` — a
+/// positive claim about a directory. `let Ok(entries) = read_dir(dir) else {
+/// return Vec::new() }` produced that same claim for a directory the process
+/// could not enumerate, so the probe asserted a scan it never performed. A
+/// separate value is what lets the consumer say "undetermined" instead.
+/// What: one variant. The directory being ABSENT is not an error — an
+/// unprovisioned tier holds nothing, which is a real answer — so only a
+/// non-`NotFound` `read_dir` failure lands here.
+/// Test: `audit_unscannable_dir_is_an_error`, `audit_missing_dir_is_empty`.
+///
+/// [ADR-0045]: https://github.com/bobmatnyc/trusty-tools/blob/main/docs/adr/0045-distinguish-absent-from-undeterminable-on-destructive-paths.md
+#[derive(Debug, Error)]
+pub enum TierAuditError {
+    /// The tier directory exists (or its state is unknown) but could not be
+    /// enumerated.
+    #[error("cannot scan agent tier {path}: {source}")]
+    Unscannable {
+        /// The directory the scan was asked for.
+        path: PathBuf,
+        /// The underlying `read_dir` failure.
+        #[source]
+        source: std::io::Error,
+    },
+}
 
 /// What this directory's ownership ledger says about one file.
 ///
@@ -285,28 +315,48 @@ pub fn classify_tier_resident(
 /// this directory's ownership manifest for [`ownership_of`], classifies with
 /// [`classify_tier_resident`], and returns the
 /// non-[`TierResidentClass::Custom`] results sorted by name for stable output.
-/// A missing/unreadable `dir` returns an empty vec. A CORRUPT manifest degrades
-/// to [`TierOwnership::Untracked`] for every file rather than failing: shadowing
-/// is established by the roster alone, so the load-bearing signal survives.
-/// Note the asymmetry that makes that safe — an unreadable ledger can only
-/// LOSE the user-owned exemption, so #4448 must re-read the ledger under its
-/// own write lock before moving anything; this read-only probe does not hold
-/// one. Never call this on the canonical deploy directory — every file there
-/// would classify as tm-owned, correctly and uselessly.
+/// An ABSENT `dir` returns an empty vec — an unprovisioned tier holds nothing.
+/// A `dir` that exists but cannot be enumerated returns
+/// [`TierAuditError::Unscannable`] (#5626): the empty vec is what the consumer
+/// renders as "scanned, found nothing", and a scan that failed has established
+/// no such thing.
+///
+/// A CORRUPT or unreadable manifest degrades to [`TierOwnership::Untracked`] for
+/// every file rather than failing: shadowing is established by the roster alone,
+/// so the load-bearing signal survives. Note the asymmetry that makes that safe
+/// — an unreadable ledger can only LOSE the user-owned exemption, so the result
+/// can only over-report, never under-report; #4448 must re-read the ledger under
+/// its own write lock before moving anything, and this read-only probe does not
+/// hold one. Never call this on the canonical deploy directory — every file
+/// there would classify as tm-owned, correctly and uselessly.
 /// Test: `audit_reports_a_shadowing_stub`, `audit_ignores_a_custom_agent`,
 /// `audit_ignores_a_user_owned_entry_on_a_bundled_name`,
 /// `audit_reports_a_stranded_framework_entry`, `audit_missing_dir_is_empty`,
-/// `audit_tolerates_a_corrupt_manifest`,
+/// `audit_unscannable_dir_is_an_error`, `audit_tolerates_a_corrupt_manifest`,
 /// `audit_flags_a_renamed_file_that_declares_a_bundled_name`,
 /// `audit_ignores_a_bundled_filename_that_declares_a_custom_name`.
-pub fn audit_agent_tier(dir: &Path, bundled: &BTreeSet<String>) -> Vec<MisplacedAgent> {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return Vec::new();
+pub fn audit_agent_tier(
+    dir: &Path,
+    bundled: &BTreeSet<String>,
+) -> Result<Vec<MisplacedAgent>, TierAuditError> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        // #5626: an absent tier is a real answer; anything else is not.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(TierAuditError::Unscannable {
+                path: dir.to_path_buf(),
+                source,
+            });
+        }
     };
     let manifest = match AgentManifest::load_checked(dir) {
         ManifestLoad::Ok(m) => m,
-        // Corrupt ledger: keep the roster-based half of the verdict rather than
-        // reporting nothing. See the doc comment.
+        // intentional fail-open (ADR-0045 §4): an undetermined ledger can only
+        // widen this read-only report, never narrow it — it loses the user-owned
+        // exemption and nothing else. Refusing instead would drop the
+        // roster-based shadowing verdict, which needs no ledger at all. The
+        // mover (#4448) re-reads under its own lock and refuses there.
         ManifestLoad::Corrupt(_) => AgentManifest::default(),
     };
 
@@ -328,7 +378,7 @@ pub fn audit_agent_tier(dir: &Path, bundled: &BTreeSet<String>) -> Vec<Misplaced
         })
         .collect();
     found.sort_by(|a, b| a.name.cmp(&b.name));
-    found
+    Ok(found)
 }
 
 #[cfg(test)]

--- a/crates/trusty-agents-common/src/agents/tier_audit_tests.rs
+++ b/crates/trusty-agents-common/src/agents/tier_audit_tests.rs
@@ -214,7 +214,7 @@ fn audit_reports_a_shadowing_stub() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("rust-engineer.md"), doc("rust-engineer")).unwrap();
 
-    let found = audit_agent_tier(tmp.path(), &roster(&["rust-engineer"]));
+    let found = audit_agent_tier(tmp.path(), &roster(&["rust-engineer"])).unwrap();
     assert_eq!(found.len(), 1, "found: {found:?}");
     assert_eq!(found[0].name, "rust-engineer");
     assert_eq!(found[0].class, TierResidentClass::ShadowsBundled);
@@ -228,7 +228,7 @@ fn audit_flags_a_renamed_file_that_declares_a_bundled_name() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("helper.md"), doc("rust-engineer")).unwrap();
 
-    let found = audit_agent_tier(tmp.path(), &roster(&["rust-engineer"]));
+    let found = audit_agent_tier(tmp.path(), &roster(&["rust-engineer"])).unwrap();
     assert_eq!(found.len(), 1, "found: {found:?}");
     assert_eq!(found[0].name, "rust-engineer");
     assert_eq!(found[0].path, tmp.path().join("helper.md"));
@@ -241,7 +241,11 @@ fn audit_ignores_a_bundled_filename_that_declares_a_custom_name() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("rust-engineer.md"), doc("acme-custom")).unwrap();
 
-    assert!(audit_agent_tier(tmp.path(), &roster(&["rust-engineer"])).is_empty());
+    assert!(
+        audit_agent_tier(tmp.path(), &roster(&["rust-engineer"]))
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]
@@ -252,7 +256,7 @@ fn audit_ignores_a_custom_agent() {
     std::fs::write(tmp.path().join("acme-internal.md"), doc("acme-internal")).unwrap();
     std::fs::write(tmp.path().join("qa.md"), doc("qa")).unwrap();
 
-    let found = audit_agent_tier(tmp.path(), &roster(&["qa"]));
+    let found = audit_agent_tier(tmp.path(), &roster(&["qa"])).unwrap();
     assert_eq!(found.len(), 1, "found: {found:?}");
     assert_eq!(found[0].name, "qa");
 }
@@ -266,7 +270,11 @@ fn audit_ignores_a_user_owned_entry_on_a_bundled_name() {
     std::fs::write(tmp.path().join("qa.md"), doc("qa")).unwrap();
     track(tmp.path(), "qa.md", Origin::User);
 
-    assert!(audit_agent_tier(tmp.path(), &roster(&["qa"])).is_empty());
+    assert!(
+        audit_agent_tier(tmp.path(), &roster(&["qa"]))
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]
@@ -277,7 +285,7 @@ fn audit_reports_a_stranded_framework_entry() {
     std::fs::write(tmp.path().join("legacy-agent.md"), doc("legacy-agent")).unwrap();
     track(tmp.path(), "legacy-agent.md", Origin::Bundled);
 
-    let found = audit_agent_tier(tmp.path(), &roster(&["qa"]));
+    let found = audit_agent_tier(tmp.path(), &roster(&["qa"])).unwrap();
     assert_eq!(found.len(), 1, "found: {found:?}");
     assert_eq!(found[0].class, TierResidentClass::StrandedFrameworkOwned);
 }
@@ -289,13 +297,49 @@ fn audit_ignores_a_user_owned_manifest_entry() {
     std::fs::write(tmp.path().join("mine.md"), doc("mine")).unwrap();
     track(tmp.path(), "mine.md", Origin::User);
 
-    assert!(audit_agent_tier(tmp.path(), &roster(&["qa"])).is_empty());
+    assert!(
+        audit_agent_tier(tmp.path(), &roster(&["qa"]))
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]
 fn audit_missing_dir_is_empty() {
+    // #5626 kept this benign: a tier directory that does not exist holds
+    // nothing, and "nothing" is a real answer. Only a scan that FAILED is an
+    // error.
     let tmp = tempfile::tempdir().unwrap();
-    assert!(audit_agent_tier(&tmp.path().join("nope"), &roster(&["qa"])).is_empty());
+    assert!(
+        audit_agent_tier(&tmp.path().join("nope"), &roster(&["qa"]))
+            .expect("an absent tier is not an error")
+            .is_empty()
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn audit_unscannable_dir_is_an_error() {
+    // #5626, ADR-0045: `let Ok(entries) = read_dir(dir) else { Vec::new() }`
+    // returned the same empty vec for "scanned, found nothing" and "could not
+    // scan", and `doctor_asset_tier` rendered that as
+    // `no tm-owned agent files … (scanned: <dir>)` — asserting a scan that
+    // never ran. The directory here holds a real shadowing stub.
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let tier = tmp.path().join("agents");
+    std::fs::create_dir(&tier).unwrap();
+    std::fs::write(tier.join("qa.md"), doc("qa")).unwrap();
+
+    std::fs::set_permissions(&tier, std::fs::Permissions::from_mode(0o000)).unwrap();
+    let result = audit_agent_tier(&tier, &roster(&["qa"]));
+    std::fs::set_permissions(&tier, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let err = result.expect_err("an unscannable tier must not report an empty scan");
+    let TierAuditError::Unscannable { path, source } = &err;
+    assert_eq!(path, &tier);
+    assert_eq!(source.kind(), std::io::ErrorKind::PermissionDenied);
 }
 
 #[test]
@@ -310,7 +354,7 @@ fn audit_tolerates_a_corrupt_manifest() {
     )
     .unwrap();
 
-    let found = audit_agent_tier(tmp.path(), &roster(&["qa"]));
+    let found = audit_agent_tier(tmp.path(), &roster(&["qa"])).unwrap();
     assert_eq!(found.len(), 1, "found: {found:?}");
     assert_eq!(found[0].class, TierResidentClass::ShadowsBundled);
 }
@@ -323,7 +367,8 @@ fn audit_is_sorted_by_name() {
         std::fs::write(tmp.path().join(format!("{name}.md")), doc(name)).unwrap();
     }
 
-    let found = audit_agent_tier(tmp.path(), &roster(&["qa", "engineer", "rust-engineer"]));
+    let found =
+        audit_agent_tier(tmp.path(), &roster(&["qa", "engineer", "rust-engineer"])).unwrap();
     let names: Vec<&str> = found.iter().map(|f| f.name.as_str()).collect();
     assert_eq!(names, vec!["engineer", "qa", "rust-engineer"]);
 }

--- a/crates/trusty-agents-common/src/skills/deployer.rs
+++ b/crates/trusty-agents-common/src/skills/deployer.rs
@@ -177,7 +177,11 @@ fn deploy_skills_locked(
 ) -> Result<DeployStats> {
     let mut stats = DeployStats::default();
 
-    let mut manifest = SkillManifest::load(dest);
+    // #5626: an unreadable ledger stops the deploy before a single file is
+    // written. Proceeding on the empty default would classify every managed
+    // skill as user-owned, skip it, and record nothing — the #4881 freeze
+    // reached through a transient read failure instead of a lost update.
+    let mut manifest = SkillManifest::load(dest)?;
     // #4881: the snapshot the compare-and-swap save is checked against.
     let base = manifest.clone();
     let now = chrono::Utc::now().to_rfc3339();

--- a/crates/trusty-agents-common/src/skills/deployer_tests.rs
+++ b/crates/trusty-agents-common/src/skills/deployer_tests.rs
@@ -49,7 +49,7 @@ fn deploy_new_skill() {
     let doctor = fs::read_to_string(tgt.path().join("tm-doctor").join("SKILL.md")).unwrap();
     assert!(doctor.contains("Diagnostic skill."));
 
-    let manifest = SkillManifest::load(tgt.path());
+    let manifest = SkillManifest::load(tgt.path()).unwrap();
     assert!(manifest.is_managed("tm-doctor"));
 }
 
@@ -421,7 +421,9 @@ fn deploy_blocks_while_the_skill_ledger_lock_is_held() {
         .expect("deploy must complete once the lock is released");
     assert_eq!(stats.deployed.len(), 2);
     assert!(
-        SkillManifest::load(tgt.path()).is_managed("tm-doctor"),
+        SkillManifest::load(tgt.path())
+            .unwrap()
+            .is_managed("tm-doctor"),
         "the released deploy must have recorded its entries"
     );
 }
@@ -445,7 +447,7 @@ fn a_racing_writer_freezes_nothing_on_either_side() {
 
     // A first, uncontended deploy. This is the `base` an in-flight deploy loads.
     deploy_skills(src.path(), tgt.path()).unwrap();
-    let base = SkillManifest::load(tgt.path());
+    let base = SkillManifest::load(tgt.path()).unwrap();
 
     // A writer that does NOT take the ledger lock — an older installed `tm`
     // during a rollout — publishes its own entry after our base was loaded.
@@ -496,7 +498,7 @@ fn a_racing_writer_freezes_nothing_on_either_side() {
 
     // Nothing is frozen on the RACER's side either: a blind save would have
     // dropped its entry, leaving its file untracked and skipped from then on.
-    let final_manifest = SkillManifest::load(tgt.path());
+    let final_manifest = SkillManifest::load(tgt.path()).unwrap();
     assert!(
         final_manifest.is_managed("racing-writer-skill"),
         "the racing writer's entry must survive, or ITS file freezes instead"
@@ -532,7 +534,7 @@ fn deploy_records_files_written_before_a_mid_loop_failure() {
     let written = tgt.path().join("aaa-skill").join("SKILL.md");
     assert!(written.exists(), "aaa-skill was written before the failure");
     // ...and the ledger records it, so it is not orphaned.
-    let manifest = SkillManifest::load(tgt.path());
+    let manifest = SkillManifest::load(tgt.path()).unwrap();
     assert!(
         manifest.is_managed("aaa-skill"),
         "a file written before the failure must still be recorded"
@@ -611,7 +613,7 @@ fn deploy_directory_skill_records_every_file_in_the_manifest() {
 
     deploy_skills(src.path(), tgt.path()).unwrap();
 
-    let manifest = SkillManifest::load(tgt.path());
+    let manifest = SkillManifest::load(tgt.path()).unwrap();
     for key in [
         "duetto-design-system",
         "duetto-design-system/metadata.json",
@@ -663,7 +665,7 @@ fn deploy_flat_skill_still_works_alongside_a_directory_skill() {
             .join("cli.md")
             .is_file()
     );
-    let manifest = SkillManifest::load(tgt.path());
+    let manifest = SkillManifest::load(tgt.path()).unwrap();
     assert!(manifest.is_managed("tm-doctor/references/cli.md"));
 }
 

--- a/crates/trusty-agents-common/src/skills/manifest.rs
+++ b/crates/trusty-agents-common/src/skills/manifest.rs
@@ -138,18 +138,43 @@ impl Default for SkillManifest {
 }
 
 impl SkillManifest {
-    /// Load the manifest from `target_dir`, defaulting to empty when absent.
+    /// Load the manifest from `target_dir`. Absent means empty; unreadable is an
+    /// error.
     ///
-    /// Why: a first-ever deploy has no manifest; treating a missing file as an
-    /// empty manifest keeps the deployer's logic uniform.
-    /// What: reads `<target_dir>/.trusty-mpm-skills-manifest.json`; a missing or
-    /// unparseable file yields a fresh empty manifest.
-    /// Test: `skill_manifest_load_missing_returns_empty`, `skill_manifest_round_trip`.
-    pub fn load(target_dir: &Path) -> Self {
+    /// Why (#5626, [ADR-0045]): the empty manifest is a positive claim — every
+    /// consumer reads it as "trusty-mpm owns nothing here", which licenses a
+    /// deploy to write over files the ledger existed to protect and licenses a
+    /// retirement to unrecord them. Only a genuinely ABSENT file establishes
+    /// that claim. The previous `Err(_) => Self::default()` also returned it for
+    /// `EACCES` on an unsearchable parent, a stale NFS handle, and a transient
+    /// `EIO` — and `serde_json::from_str(..).unwrap_or_default()` returned it for
+    /// a torn document, which is the very corruption
+    /// [`SkillManifest::save_merging`] refuses to merge from. The sibling
+    /// [`SkillManifest::read_parsed`] already drew this line for `save_merging`
+    /// and its comment named the collapse wrong; this applies the same rule to
+    /// the load every consumer actually calls.
+    ///
+    /// What: reads `<target_dir>/.trusty-mpm-skills-manifest.json`.
+    /// `ErrorKind::NotFound` — a first-ever deploy — yields the empty default and
+    /// no error. Every other I/O failure yields [`ManifestError::Io`] naming the
+    /// path, and a document that does not parse yields [`ManifestError::Json`].
+    /// The caller decides; no caller may substitute an empty ledger for the
+    /// error, since that reinstates this defect one level up.
+    /// Test: `skill_manifest_load_missing_returns_empty`,
+    /// `skill_manifest_load_malformed_is_an_error`,
+    /// `skill_manifest_load_unreadable_is_an_error`, `skill_manifest_round_trip`.
+    ///
+    /// [ADR-0045]: https://github.com/bobmatnyc/trusty-tools/blob/main/docs/adr/0045-distinguish-absent-from-undeterminable-on-destructive-paths.md
+    pub fn load(target_dir: &Path) -> Result<Self> {
         let path = target_dir.join(SKILL_MANIFEST_FILE);
         match std::fs::read_to_string(&path) {
-            Ok(raw) => serde_json::from_str(&raw).unwrap_or_default(),
-            Err(_) => Self::default(),
+            Ok(raw) => Ok(serde_json::from_str(&raw)?),
+            // #5626: NotFound is the ONLY failure that proves nothing is owned.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(ManifestError::Io(std::io::Error::new(
+                e.kind(),
+                format!("{path}: {e}", path = path.display()),
+            ))),
         }
     }
 

--- a/crates/trusty-agents-common/src/skills/manifest_tests.rs
+++ b/crates/trusty-agents-common/src/skills/manifest_tests.rs
@@ -25,11 +25,121 @@ fn sample_entry() -> SkillManifestEntry {
 #[test]
 fn skill_manifest_load_missing_returns_empty() {
     // A directory with no manifest file must yield an empty, valid
-    // manifest rather than an error.
+    // manifest rather than an error. #5626 tightened the error arms around
+    // this case; the first-ever deploy must stay a silent success.
     let tmp = TempDir::new().unwrap();
-    let manifest = SkillManifest::load(tmp.path());
+    let manifest = SkillManifest::load(tmp.path()).expect("an absent ledger is not an error");
     assert_eq!(manifest.version, SKILL_MANIFEST_VERSION);
     assert!(manifest.managed.is_empty());
+}
+
+#[test]
+fn skill_manifest_load_malformed_is_an_error() {
+    // #5626: a torn or hand-mangled ledger must NOT read as "nothing is
+    // owned here" — that licenses the deployer to write over every managed
+    // skill and record none of it.
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join(SKILL_MANIFEST_FILE), b"not valid json{{{").unwrap();
+    let err = SkillManifest::load(tmp.path()).expect_err("a malformed ledger must be an error");
+    assert!(
+        matches!(err, ManifestError::Json(_)),
+        "expected a Json error, got {err:?}"
+    );
+}
+
+#[test]
+fn skill_manifest_load_truncated_is_an_error() {
+    // A crash mid-write leaves valid JSON prefix and nothing else. It is the
+    // shape `save_merging` already refuses to merge from (#4881); `load` now
+    // refuses it too (#5626).
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join(SKILL_MANIFEST_FILE),
+        b"{\"version\":1,\"managed\":{",
+    )
+    .unwrap();
+    assert!(
+        SkillManifest::load(tmp.path()).is_err(),
+        "a truncated ledger must be an error"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn skill_manifest_load_unreadable_is_an_error() {
+    // #5626, ADR-0045: EACCES is the arm the old `Err(_) => Self::default()`
+    // swallowed. The ledger is present and holds an entry; the process simply
+    // cannot read it. Reporting an empty ledger here asserts an absence the
+    // read never established.
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    let mut manifest = SkillManifest::default();
+    manifest.managed.insert("tm-doctor".into(), sample_entry());
+    manifest.save(tmp.path()).unwrap();
+
+    let path = tmp.path().join(SKILL_MANIFEST_FILE);
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+    let loaded = SkillManifest::load(tmp.path());
+    // Restore before asserting so a failure still leaves a removable TempDir.
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    let err = loaded.expect_err("an unreadable ledger must be an error, not an empty one");
+    assert!(
+        matches!(&err, ManifestError::Io(e) if e.kind() == std::io::ErrorKind::PermissionDenied),
+        "expected a PermissionDenied Io error, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains(SKILL_MANIFEST_FILE),
+        "the error must name the ledger it could not read: {err}"
+    );
+}
+
+#[test]
+fn skill_manifest_deploy_refuses_a_ledger_it_could_not_read() {
+    // #5626: the consumer half, and the sharper of the two outcomes. On the
+    // empty default the deploy did not merely mis-classify — it RAN, skipped
+    // every managed skill as untracked, and then `save_merging` took its
+    // `OverwroteUnreadable` arm and published this run's near-empty ledger over
+    // the unreadable one. The entries it held are then gone for good, and the
+    // files they described are frozen against every future update (#4881's
+    // shape). Post-fix the deploy stops at the load, so the bytes on disk are
+    // untouched and an operator can still repair them.
+    let src = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    std::fs::write(src.path().join("tm-doctor.md"), "v1").unwrap();
+
+    crate::skills::deployer::deploy_skills(src.path(), dest.path()).unwrap();
+    let ledger = dest.path().join(SKILL_MANIFEST_FILE);
+    assert!(
+        SkillManifest::load(dest.path())
+            .unwrap()
+            .is_managed("tm-doctor"),
+        "the first deploy must record the skill"
+    );
+
+    // Corrupt the ledger the way a crash mid-write does, keeping enough of the
+    // document that its loss is visible.
+    let corrupt = "{\"version\":1,\"managed\":{\"tm-doctor\":";
+    std::fs::write(&ledger, corrupt).unwrap();
+    std::fs::write(src.path().join("tm-doctor.md"), "v2").unwrap();
+
+    let result = crate::skills::deployer::deploy_skills(src.path(), dest.path());
+
+    assert!(
+        result.is_err(),
+        "the deploy must refuse rather than act as if nothing is owned"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&ledger).unwrap(),
+        corrupt,
+        "a refused deploy must leave the ledger exactly as it found it"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dest.path().join("tm-doctor").join("SKILL.md")).unwrap(),
+        "v1",
+        "a refused deploy writes no skill content either"
+    );
 }
 
 #[test]
@@ -42,7 +152,7 @@ fn skill_manifest_round_trip() {
         .insert("tm-doctor.md".into(), sample_entry());
     manifest.save(tmp.path()).unwrap();
 
-    let loaded = SkillManifest::load(tmp.path());
+    let loaded = SkillManifest::load(tmp.path()).unwrap();
     assert_eq!(loaded, manifest);
     assert!(tmp.path().join(SKILL_MANIFEST_FILE).exists());
 }
@@ -113,7 +223,7 @@ fn skill_manifest_lock_serialises_concurrent_writers() {
             let dir = dir.clone();
             std::thread::spawn(move || {
                 with_skill_manifest_lock::<(), ManifestError, _>(&dir, || {
-                    let mut m = SkillManifest::load(&dir);
+                    let mut m = SkillManifest::load(&dir).unwrap();
                     m.managed.insert(format!("skill-{i}"), sample_entry());
                     std::thread::sleep(std::time::Duration::from_millis(5));
                     m.save(&dir)
@@ -126,7 +236,7 @@ fn skill_manifest_lock_serialises_concurrent_writers() {
         h.join().unwrap();
     }
 
-    let final_manifest = SkillManifest::load(&dir);
+    let final_manifest = SkillManifest::load(&dir).unwrap();
     assert_eq!(
         final_manifest.managed.len(),
         8,
@@ -175,7 +285,7 @@ fn skill_manifest_save_merging_folds_in_a_concurrent_writer() {
         SkillManifestSave::Merged
     );
 
-    let on_disk = SkillManifest::load(dir);
+    let on_disk = SkillManifest::load(dir).unwrap();
     assert!(on_disk.is_managed("ours"), "our own entry must be recorded");
     assert!(
         on_disk.is_managed("from-the-other-writer"),
@@ -210,7 +320,7 @@ fn skill_manifest_save_merging_applies_this_runs_removals() {
         SkillManifestSave::Merged
     );
 
-    let on_disk = SkillManifest::load(dir);
+    let on_disk = SkillManifest::load(dir).unwrap();
     assert!(!on_disk.is_managed("prune-me"), "our removal must apply");
     assert!(on_disk.is_managed("keep"));
     assert!(
@@ -233,16 +343,16 @@ fn skill_manifest_save_merging_writes_when_unchanged() {
         first.save_merging(dir, &base).unwrap(),
         SkillManifestSave::Written
     );
-    assert!(SkillManifest::load(dir).is_managed("tm-doctor"));
+    assert!(SkillManifest::load(dir).unwrap().is_managed("tm-doctor"));
 
-    let base = SkillManifest::load(dir);
+    let base = SkillManifest::load(dir).unwrap();
     let mut second = base.clone();
     second.managed.insert("tm-workflow".into(), sample_entry());
     assert_eq!(
         second.save_merging(dir, &base).unwrap(),
         SkillManifestSave::Written
     );
-    let on_disk = SkillManifest::load(dir);
+    let on_disk = SkillManifest::load(dir).unwrap();
     assert!(on_disk.is_managed("tm-doctor"));
     assert!(on_disk.is_managed("tm-workflow"));
 }
@@ -273,7 +383,7 @@ fn skill_manifest_save_merging_over_a_corrupt_ledger_keeps_the_base() {
         SkillManifestSave::OverwroteUnreadable
     );
 
-    let on_disk = SkillManifest::load(dir);
+    let on_disk = SkillManifest::load(dir).unwrap();
     assert_eq!(
         on_disk.managed.len(),
         10,

--- a/crates/trusty-agents-common/src/skills/reconcile.rs
+++ b/crates/trusty-agents-common/src/skills/reconcile.rs
@@ -100,7 +100,7 @@ pub fn adopt_unmanaged_bundled_skills(
     // neither blocks on a concurrent writer nor leaves a lock sidecar in a
     // directory it will not touch — `adopt_no_findings_writes_nothing` holds
     // the target byte-identical. The authoritative scan happens again inside.
-    if unmanaged_bundled_skills(dest, bundled).is_empty() {
+    if unmanaged_bundled_skills(dest, bundled)?.is_empty() {
         return Ok(Vec::new());
     }
     with_skill_manifest_lock(dest, || adopt_locked(dest, bundled, backup_root))
@@ -120,12 +120,16 @@ fn adopt_locked(
     bundled: &BTreeSet<String>,
     backup_root: &Path,
 ) -> Result<Vec<AdoptedSkill>> {
-    let found = unmanaged_bundled_skills(dest, bundled);
+    let found = unmanaged_bundled_skills(dest, bundled)?;
     if found.is_empty() {
         return Ok(Vec::new());
     }
 
-    let mut manifest = SkillManifest::load(dest);
+    // #5626: adoption writes ownership records over files the ledger may
+    // already track. An unreadable ledger read as empty makes every managed
+    // skill look unmanaged, and adoption then re-stamps each one against its
+    // CURRENT bytes — erasing the hand-edit evidence the checksum carried.
+    let mut manifest = SkillManifest::load(dest)?;
     // #4881: the snapshot the merging save replays this run's delta against.
     let base = manifest.clone();
     let now = chrono::Utc::now().to_rfc3339();
@@ -178,7 +182,7 @@ fn adopt_locked(
 pub fn preview_unmanaged_bundled_skills(
     dest: &Path,
     bundled: &BTreeSet<String>,
-) -> Vec<UnmanagedBundledSkill> {
+) -> Result<Vec<UnmanagedBundledSkill>> {
     unmanaged_bundled_skills(dest, bundled)
 }
 
@@ -241,7 +245,11 @@ fn force_adopt_locked(
     bundled: &BTreeSet<String>,
     backup_root: &Path,
 ) -> Result<Vec<AdoptedSkill>> {
-    let mut manifest = SkillManifest::load(dest);
+    // #5626: re-stamping decides ownership from this ledger. On the empty
+    // default an unreadable ledger reads as "tm owns nothing", so every
+    // bundled-named skill in the target — the operator's edits included —
+    // becomes tm's on the strength of a read that failed.
+    let mut manifest = SkillManifest::load(dest)?;
     let base = manifest.clone();
     let now = chrono::Utc::now().to_rfc3339();
     let mut adopted = Vec::new();

--- a/crates/trusty-agents-common/src/skills/reconcile_tests.rs
+++ b/crates/trusty-agents-common/src/skills/reconcile_tests.rs
@@ -51,7 +51,7 @@ fn adopt_registers_the_skill_and_its_references() {
             "tm-workflow/references/a.md".to_string()
         ]
     );
-    let manifest = SkillManifest::load(dest.path());
+    let manifest = SkillManifest::load(dest.path()).unwrap();
     assert!(manifest.is_managed("tm-workflow"));
     assert!(manifest.is_managed("tm-workflow/references/a.md"));
     // The recorded checksum is of the content ON DISK, so the deployer sees
@@ -102,7 +102,11 @@ fn adopt_leaves_an_operator_skill_alone() {
             .unwrap();
 
     assert!(adopted.is_empty());
-    assert!(!SkillManifest::load(dest.path()).is_managed("my-own-skill"));
+    assert!(
+        !SkillManifest::load(dest.path())
+            .unwrap()
+            .is_managed("my-own-skill")
+    );
     assert_eq!(
         fs::read_to_string(dest.path().join("my-own-skill").join("SKILL.md")).unwrap(),
         "mine"
@@ -176,7 +180,7 @@ fn preview_matches_what_adoption_touches() {
     let backups = TempDir::new().unwrap();
     stage_untracked(dest.path(), "tm-workflow", "stale");
 
-    let preview = preview_unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]));
+    let preview = preview_unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).unwrap();
     let adopted =
         adopt_unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]), backups.path())
             .unwrap();
@@ -271,7 +275,11 @@ fn force_adopt_leaves_an_operator_skill_alone() {
 
     assert!(adopted.is_empty(), "{adopted:?}");
     assert_eq!(fs::read_to_string(&path).unwrap(), "OPERATOR CONTENT");
-    assert!(!SkillManifest::load(dest.path()).is_managed("my-own-skill"));
+    assert!(
+        !SkillManifest::load(dest.path())
+            .unwrap()
+            .is_managed("my-own-skill")
+    );
 }
 
 #[test]
@@ -303,7 +311,7 @@ fn force_adopt_leaves_an_operator_reference_stray_untracked() {
         vec!["tm-workflow".to_string()],
         "only the tracked entry point may be re-stamped: {adopted:?}"
     );
-    let manifest = SkillManifest::load(dest.path());
+    let manifest = SkillManifest::load(dest.path()).unwrap();
     assert!(
         !manifest.is_managed("tm-workflow/references/my-notes.md"),
         "the operator's stray must stay untracked"

--- a/crates/trusty-agents-common/src/skills/tiers.rs
+++ b/crates/trusty-agents-common/src/skills/tiers.rs
@@ -245,7 +245,11 @@ pub fn list_project_custom_stems(dest: &Path) -> Result<BTreeSet<String>> {
     if !dest.is_dir() {
         return Ok(stems);
     }
-    let manifest = SkillManifest::load(dest);
+    // #5626: an unreadable ledger cannot answer "which of these did tm deploy?",
+    // and the empty default answers "none of them" — which would hand the
+    // planner every bundled skill in the target as project-custom and let each
+    // one shadow its own source.
+    let manifest = SkillManifest::load(dest)?;
     for entry in std::fs::read_dir(dest)? {
         let entry = entry?;
         if !entry.file_type()?.is_dir() {

--- a/crates/trusty-agents-common/src/skills/unmanaged.rs
+++ b/crates/trusty-agents-common/src/skills/unmanaged.rs
@@ -36,6 +36,7 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
+use crate::agents::manifest::Result;
 use crate::skills::manifest::SkillManifest;
 
 /// The entry-point filename Claude Code discovers a skill directory by.
@@ -107,22 +108,30 @@ impl UnmanagedBundledSkill {
 /// past a skill's own `references/`), keeps those that (1) contain a
 /// [`SKILL_ENTRY_POINT`], (2) have a stem `bundled` contains, and (3) are NOT
 /// managed by `dest`'s [`SkillManifest`], and returns them sorted by stem.
-/// A missing or unreadable `dest` yields an empty vec — an unprovisioned tier
-/// is not a finding. An EMPTY `bundled` set likewise yields nothing: callers
+/// A missing `dest` yields an empty vec — an unprovisioned tier is not a
+/// finding. An EMPTY `bundled` set likewise yields nothing: callers
 /// must treat that as "cannot classify by name", never as "nothing is
 /// bundled", since the latter reading would condemn every skill at once.
+///
+/// Fallible since #5626: the ownership filter is the whole predicate, so a
+/// ledger that could not be read has no answer to give. On the empty default
+/// every managed skill reported as unmanaged, and
+/// [`crate::skills::reconcile::adopt_unmanaged_bundled_skills`] — this
+/// function's other consumer — then re-stamps each one against its current
+/// bytes, discarding the checksum that recorded the operator's edit.
 /// Test: `unmanaged_finds_a_bundled_named_untracked_skill`,
 /// `unmanaged_ignores_a_managed_skill`, `unmanaged_ignores_an_operator_skill`,
-/// `unmanaged_missing_dest_is_empty`, `unmanaged_lists_reference_files`.
+/// `unmanaged_missing_dest_is_empty`, `unmanaged_lists_reference_files`,
+/// `unmanaged_unreadable_ledger_is_an_error`.
 pub fn unmanaged_bundled_skills(
     dest: &Path,
     bundled: &BTreeSet<String>,
-) -> Vec<UnmanagedBundledSkill> {
-    let manifest = SkillManifest::load(dest);
-    bundled_skill_dirs(dest, bundled)
+) -> Result<Vec<UnmanagedBundledSkill>> {
+    let manifest = SkillManifest::load(dest)?;
+    Ok(bundled_skill_dirs(dest, bundled)
         .into_iter()
         .filter(|skill| !manifest.is_managed(&skill.stem))
-        .collect()
+        .collect())
 }
 
 /// Every bundled-named skill directory at `dest`, managed or not.

--- a/crates/trusty-agents-common/src/skills/unmanaged_tests.rs
+++ b/crates/trusty-agents-common/src/skills/unmanaged_tests.rs
@@ -33,7 +33,7 @@ fn unmanaged_finds_a_bundled_named_untracked_skill() {
     let dest = TempDir::new().unwrap();
     stage_untracked(dest.path(), "tm-workflow", "stale body");
 
-    let found = unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]));
+    let found = unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).unwrap();
     assert_eq!(found.len(), 1, "expected one finding, got {found:?}");
     assert_eq!(found[0].stem, "tm-workflow");
     assert_eq!(found[0].dir, dest.path().join("tm-workflow"));
@@ -51,7 +51,11 @@ fn unmanaged_ignores_a_managed_skill() {
     fs::write(source.path().join("tm-workflow.md"), "v1").unwrap();
     deploy_skills(source.path(), dest.path()).unwrap();
 
-    assert!(unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).is_empty());
+    assert!(
+        unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]))
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]
@@ -62,7 +66,11 @@ fn unmanaged_ignores_an_operator_skill() {
     let dest = TempDir::new().unwrap();
     stage_untracked(dest.path(), "my-own-skill", "mine");
 
-    assert!(unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).is_empty());
+    assert!(
+        unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]))
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]
@@ -72,14 +80,47 @@ fn unmanaged_empty_roster_reports_nothing() {
     let dest = TempDir::new().unwrap();
     stage_untracked(dest.path(), "tm-workflow", "stale body");
 
-    assert!(unmanaged_bundled_skills(dest.path(), &BTreeSet::new()).is_empty());
+    assert!(
+        unmanaged_bundled_skills(dest.path(), &BTreeSet::new())
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]
 fn unmanaged_missing_dest_is_empty() {
     // An unprovisioned tier is not a finding, and never an error.
     assert!(
-        unmanaged_bundled_skills(Path::new("/nonexistent/skills"), &roster(&["tm"])).is_empty()
+        unmanaged_bundled_skills(Path::new("/nonexistent/skills"), &roster(&["tm"]))
+            .expect("an absent tier is not an error")
+            .is_empty()
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn unmanaged_unreadable_ledger_is_an_error() {
+    // #5626: the ownership filter IS this function's predicate, so a ledger it
+    // could not read has no answer. The empty default reported every MANAGED
+    // skill as unmanaged, and `reconcile::adopt_unmanaged_bundled_skills` then
+    // re-stamped each one against its current bytes.
+    use std::os::unix::fs::PermissionsExt;
+
+    let source = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    fs::write(source.path().join("tm-workflow.md"), "v1").unwrap();
+    deploy_skills(source.path(), dest.path()).unwrap();
+
+    let ledger = dest
+        .path()
+        .join(crate::skills::manifest::SKILL_MANIFEST_FILE);
+    fs::set_permissions(&ledger, fs::Permissions::from_mode(0o000)).unwrap();
+    let result = unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]));
+    fs::set_permissions(&ledger, fs::Permissions::from_mode(0o644)).unwrap();
+
+    assert!(
+        result.is_err(),
+        "an unreadable ledger must not report a managed skill as unmanaged: {result:?}"
     );
 }
 
@@ -89,7 +130,11 @@ fn unmanaged_ignores_a_directory_without_an_entry_point() {
     let dest = TempDir::new().unwrap();
     fs::create_dir_all(dest.path().join("tm-workflow").join("references")).unwrap();
 
-    assert!(unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).is_empty());
+    assert!(
+        unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]))
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]
@@ -104,7 +149,7 @@ fn unmanaged_lists_reference_files() {
     fs::write(refs.join("a.md"), "a").unwrap();
     fs::write(refs.join("notes.txt"), "ignored").unwrap();
 
-    let found = unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]));
+    let found = unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).unwrap();
     assert_eq!(
         found[0].files,
         vec![
@@ -125,7 +170,7 @@ fn manifest_keys_match_the_deployer_key_shape() {
     fs::create_dir_all(&refs).unwrap();
     fs::write(refs.join("a.md"), "a").unwrap();
 
-    let found = unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]));
+    let found = unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).unwrap();
     assert_eq!(
         found[0].manifest_keys(),
         vec![
@@ -157,7 +202,9 @@ fn bundled_skill_dirs_includes_a_managed_skill() {
     let roster: BTreeSet<String> = ["tm-workflow".to_string()].into_iter().collect();
 
     assert!(
-        unmanaged_bundled_skills(dest.path(), &roster).is_empty(),
+        unmanaged_bundled_skills(dest.path(), &roster)
+            .unwrap()
+            .is_empty(),
         "a managed skill is not an unmanaged finding"
     );
     let all = bundled_skill_dirs(dest.path(), &roster);

--- a/crates/trusty-mpm/changelog.d/5626-ledger-absence-vs-unreadable.md
+++ b/crates/trusty-mpm/changelog.d/5626-ledger-absence-vs-unreadable.md
@@ -1,0 +1,14 @@
+Fixed
+
+- `tm doctor`'s `asset_tier` check no longer prints
+  `no tm-owned agent files outside the canonical tier … (scanned: <dir>)` for a
+  directory whose scan failed (#5626, ADR-0045). A tier it cannot enumerate is
+  reported as UNDETERMINED and downgrades an otherwise-clean run to `Warn`; the
+  `scanned:` list now names only directories that were actually read. A
+  confirmed shadowing still outranks it and keeps its `Fail`.
+- Every `SkillManifest::load` call site now handles an unreadable ledger
+  explicitly instead of proceeding on the empty default: the skill deploy, prune,
+  retire, repair and adopt paths refuse to act, and the read-only probes
+  (`skill_drift`, `skill_staleness`, `stale_skills`, `deploy_validate`,
+  `doctor_scaffold_tracking`, `session_assets`, `update_check`) report the
+  failure rather than "nothing is owned here".

--- a/crates/trusty-mpm/src/bin/tm/commands/install_skills.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/install_skills.rs
@@ -93,7 +93,21 @@ pub(crate) fn unmanaged_report_lines(
     }
     let mut lines = Vec::new();
     for tier in tiers {
-        for skill in unmanaged_bundled_skills(&tier.dir, &bundled) {
+        // #5626: a tier whose ledger could not be read gets a line saying so.
+        // On the empty default it produced a line per MANAGED skill instead,
+        // telling the operator to reconcile files that were already tracked.
+        let found = match unmanaged_bundled_skills(&tier.dir, &bundled) {
+            Ok(found) => found,
+            Err(e) => {
+                lines.push(format!(
+                    "? {} \u{2014} ownership ledger unreadable, so nothing here can be \
+                     classified: {e}",
+                    tier.dir.display()
+                ));
+                continue;
+            }
+        };
+        for skill in found {
             lines.push(format!(
                 "! {} (untracked at {} \u{2014} not managed, not refreshed; \
                  see `tm install --reconcile-skills`)",
@@ -141,7 +155,9 @@ pub(crate) fn reconcile_skills(
         backups.display()
     );
     for tier in &tiers {
-        let found = unmanaged_bundled_skills(&tier.dir, &bundled);
+        // #5626: reconcile WRITES ownership records, so an unreadable ledger
+        // aborts the run rather than adopting every managed skill afresh.
+        let found = unmanaged_bundled_skills(&tier.dir, &bundled)?;
         if found.is_empty() {
             println!(
                 "  {} ({}): nothing unmanaged",

--- a/crates/trusty-mpm/src/core/deploy_validate/mod.rs
+++ b/crates/trusty-mpm/src/core/deploy_validate/mod.rs
@@ -88,6 +88,10 @@ pub enum DeploymentGap {
     AgentFrontmatterInvalid(String, String),
     /// `.claude/skills/.trusty-mpm-skills-manifest.json` does not exist.
     SkillManifestMissing,
+    /// The skill manifest exists but could not be read — malformed, or an I/O
+    /// failure (#5626). Distinct from missing: the ledger is there and its
+    /// contents are undetermined, so nothing in the tier is attributable.
+    SkillManifestCorrupt(String),
     /// A canonical bundled skill (`<name>/SKILL.md`) is not deployed on disk.
     SkillMissing(String),
     /// `.claude/settings.json` itself does not exist.
@@ -128,6 +132,7 @@ impl DeploymentGap {
                 "skill ownership manifest ({}) is missing",
                 skill_manifest::SKILL_MANIFEST_FILE
             ),
+            Self::SkillManifestCorrupt(detail) => format!("skill manifest is corrupt: {detail}"),
             Self::SkillMissing(name) => format!("skill `{name}` is not deployed"),
             Self::SettingsMissing => ".claude/settings.json is missing".to_string(),
             Self::SettingsMalformed(detail) => {
@@ -235,7 +240,20 @@ fn validate_skills(fw: &FrameworkPaths, gaps: &mut Vec<DeploymentGap>) {
     if !manifest_present {
         gaps.push(DeploymentGap::SkillManifestMissing);
     }
-    let manifest = manifest_present.then(|| skill_manifest::SkillManifest::load(&target));
+    // #5626: a ledger that is present but unreadable is its own gap. Folding it
+    // into `None` made `expected_skill_stems` fall back to the bundled roster
+    // and report every skill as deployed-or-missing against a ledger nobody read.
+    let manifest = match manifest_present.then(|| skill_manifest::SkillManifest::load(&target)) {
+        None => None,
+        Some(Ok(m)) => Some(m),
+        Some(Err(e)) => {
+            gaps.push(DeploymentGap::SkillManifestCorrupt(format!(
+                "{}: {e}",
+                target.join(skill_manifest::SKILL_MANIFEST_FILE).display()
+            )));
+            None
+        }
+    };
     for name in expected_skill_stems(fw, manifest.as_ref()) {
         if !target.join(&name).join("SKILL.md").is_file() {
             gaps.push(DeploymentGap::SkillMissing(name));

--- a/crates/trusty-mpm/src/core/session_assets.rs
+++ b/crates/trusty-mpm/src/core/session_assets.rs
@@ -169,7 +169,25 @@ pub fn session_asset_staleness_with_shared(
     deployed_agents: &DeployedAgentHashes,
 ) -> StalenessReport {
     let skills_dir = fw.claude_skills_dir();
-    let deployed_skills = crate::core::skill_manifest::SkillManifest::load(&skills_dir);
+    // #5626: an unreadable ledger is `unknown`, not fresh. The empty default
+    // made every deployed skill look absent, so `detect` reported the whole
+    // catalog as `new` — or, once the plan selected nothing, reported currency
+    // this read never established. `unknown` is the report's own documented
+    // "nothing authoritative to compare against" state.
+    let deployed_skills = match crate::core::skill_manifest::SkillManifest::load(&skills_dir) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(
+                dir = %skills_dir.display(),
+                error = %e,
+                "skill ownership ledger unreadable — staleness is undetermined"
+            );
+            return StalenessReport {
+                unknown: true,
+                ..StalenessReport::default()
+            };
+        }
+    };
     catalog.detect(
         deployed_agents,
         &deployed_skills,

--- a/crates/trusty-mpm/src/core/session_launch/skills.rs
+++ b/crates/trusty-mpm/src/core/session_launch/skills.rs
@@ -51,15 +51,21 @@ pub(super) fn deploy_session_skills(
     // #4583/#4604: a long-lived worktree that never re-provisioned keeps the old
     // skill text (e.g. an outdated attribution footer) until this very deploy
     // self-heals it. The warn makes that drift auditable. Non-fatal, read-only.
-    let stale =
-        crate::core::skill_staleness::stale_skills(&plan.skill_source, &fw.claude_skills_dir());
-    if !stale.is_empty() {
-        tracing::warn!(
+    match crate::core::skill_staleness::stale_skills(&plan.skill_source, &fw.claude_skills_dir()) {
+        Ok(stale) if !stale.is_empty() => tracing::warn!(
             project_dir = %project_dir.display(),
             stale_skills = %stale.join(", "),
             "deployed skills were stale relative to bundled assets — refreshing now \
              (run `tm doctor` to audit; long-lived worktrees drift until re-provisioned)"
-        );
+        ),
+        Ok(_) => {}
+        // #5626: the probe could not run. It is advisory, so the launch
+        // continues — but the deploy below reads the same ledger and will
+        // refuse there, so this must not read as "nothing was stale".
+        Err(e) => roster_errors.push(format!(
+            "skill staleness undetermined — the ownership ledger at {} could not be read: {e}",
+            fw.claude_skills_dir().display()
+        )),
     }
 
     // DOC-42 (issue #2889): fold every deployed agent's declared `skills:` into

--- a/crates/trusty-mpm/src/core/skill_drift.rs
+++ b/crates/trusty-mpm/src/core/skill_drift.rs
@@ -321,9 +321,17 @@ pub fn key_stem(manifest_key: &str) -> &str {
 /// Test: `skill_drift_tests.rs`.
 pub fn audit_deployed_skills(reference: &SkillReference, dest_dir: &Path) -> TierAudit {
     let manifest_path = dest_dir.join(SKILL_MANIFEST_FILE);
+    // #5626: the parsed document is CARRIED to the findings loop rather than
+    // re-read there. The old second read went through `SkillManifest::load`,
+    // whose empty-on-any-error default would have reported "no managed skills"
+    // for a ledger this probe had just classified `Present`.
+    let mut parsed: Option<SkillManifest> = None;
     let state = match std::fs::read_to_string(&manifest_path) {
         Ok(raw) => match serde_json::from_str::<SkillManifest>(&raw) {
-            Ok(_) => ManifestState::Present,
+            Ok(m) => {
+                parsed = Some(m);
+                ManifestState::Present
+            }
             Err(e) => ManifestState::Unreadable(format!(
                 "{} is not valid JSON: {e}",
                 manifest_path.display()
@@ -358,14 +366,13 @@ pub fn audit_deployed_skills(reference: &SkillReference, dest_dir: &Path) -> Tie
         )),
     };
 
-    if state != ManifestState::Present {
+    let Some(manifest) = parsed.filter(|_| state == ManifestState::Present) else {
         return TierAudit {
             manifest: state,
             findings: Vec::new(),
         };
-    }
+    };
 
-    let manifest = SkillManifest::load(dest_dir);
     let mut findings: Vec<SkillDriftFinding> = manifest
         .managed
         .keys()

--- a/crates/trusty-mpm/src/core/skill_drift_tests.rs
+++ b/crates/trusty-mpm/src/core/skill_drift_tests.rs
@@ -265,7 +265,7 @@ fn the_old_cache_comparison_reports_clean_on_the_same_inputs() {
     )
     .unwrap();
 
-    let old = crate::core::skill_staleness::stale_skills(cache.path(), dest.path());
+    let old = crate::core::skill_staleness::stale_skills(cache.path(), dest.path()).unwrap();
     println!("OLD (cache vs manifest)       -> {old:?}");
 
     let reference = reference_of(&[("tm-workflow", "v2 describes the JSON manifest")]);

--- a/crates/trusty-mpm/src/core/skill_repair.rs
+++ b/crates/trusty-mpm/src/core/skill_repair.rs
@@ -244,7 +244,26 @@ fn repair_tier_locked(
         return outcomes;
     }
 
-    let mut manifest = SkillManifest::load(&tier.dir);
+    // #5626: `audit_deployed_skills` above already refuses an unreadable
+    // ledger, so reaching this arm means the file changed under us between the
+    // two reads. Report it as the same unverifiable skip rather than repairing
+    // against an empty ledger — that would stamp every file in the tier as
+    // tm-owned.
+    let mut manifest = match SkillManifest::load(&tier.dir) {
+        Ok(m) => m,
+        Err(e) => {
+            outcomes.push(RepairOutcome {
+                tier: tier.label,
+                stem: "<manifest>".to_string(),
+                path: tier.dir.clone(),
+                action: RepairAction::SkippedUnverifiable(format!(
+                    "{e} — refusing to touch this tier; repairing it would rewrite an \
+                     ownership ledger that cannot be read"
+                )),
+            });
+            return outcomes;
+        }
+    };
     // #4881: the snapshot the merging save replays this run's delta against.
     let base = manifest.clone();
     let mut manifest_dirty = false;

--- a/crates/trusty-mpm/src/core/skill_repair_tests.rs
+++ b/crates/trusty-mpm/src/core/skill_repair_tests.rs
@@ -85,7 +85,11 @@ fn repair_rewrites_drifted_and_verifies() {
 
     // And the manifest was updated, so the file is tm-owned again rather than
     // reading as frozen on the next audit.
-    assert!(SkillManifest::load(&dest).checksum_matches("tm-workflow", "v2"));
+    assert!(
+        SkillManifest::load(&dest)
+            .unwrap()
+            .checksum_matches("tm-workflow", "v2")
+    );
 }
 
 /// #4622 review HIGH-1: a drifted REFERENCE FILE must be repaired at its own

--- a/crates/trusty-mpm/src/core/skill_retire.rs
+++ b/crates/trusty-mpm/src/core/skill_retire.rs
@@ -312,7 +312,11 @@ fn retire_orphans_locked(
     dest: &Path,
     live: &BTreeSet<String>,
 ) -> ManifestResult<Vec<RetiredSkill>> {
-    let mut manifest = SkillManifest::load(dest);
+    // #5626: retirement deletes files and drops ledger entries. On the empty
+    // default an unreadable ledger yields no candidates, which is harmless —
+    // but it also publishes a merged ledger built from that default, so the
+    // refusal is the correct answer rather than a lucky one.
+    let mut manifest = SkillManifest::load(dest)?;
     let base = manifest.clone();
 
     // #5224: candidates are STEMS, never raw ledger keys. A key like

--- a/crates/trusty-mpm/src/core/skill_retire_tests.rs
+++ b/crates/trusty-mpm/src/core/skill_retire_tests.rs
@@ -80,7 +80,7 @@ fn retire_removes_a_pristine_orphan() {
     assert_eq!(retired[0].stem, "tm-pr-workflow");
     assert!(retired[0].removed, "{retired:?}");
     assert!(!dest.join("tm-pr-workflow").exists());
-    let manifest = SkillManifest::load(&dest);
+    let manifest = SkillManifest::load(&dest).unwrap();
     assert!(
         manifest
             .managed
@@ -116,7 +116,11 @@ fn retire_spares_a_user_tier_skill() {
         dest.join("my-own-skill").join("SKILL.md").is_file(),
         "a user-tier skill was removed"
     );
-    assert!(SkillManifest::load(&dest).is_managed("my-own-skill"));
+    assert!(
+        SkillManifest::load(&dest)
+            .unwrap()
+            .is_managed("my-own-skill")
+    );
 }
 
 #[test]
@@ -171,7 +175,9 @@ fn retire_keeps_a_hand_edited_orphan_but_releases_the_ledger() {
         "an operator edit was destroyed"
     );
     assert!(
-        !SkillManifest::load(&dest).is_managed("tm-pr-workflow"),
+        !SkillManifest::load(&dest)
+            .unwrap()
+            .is_managed("tm-pr-workflow"),
         "the ledger still claims a skill nothing ships"
     );
 }
@@ -320,7 +326,7 @@ fn verdict_allows_a_pristine_skill() {
     let tmp = TempDir::new().unwrap();
     let dest = tmp.path().join("skills");
     let _src = deploy_real(&dest, "tm-doctor", "v1", Some(("extra.md", "reference")));
-    let manifest = SkillManifest::load(&dest);
+    let manifest = SkillManifest::load(&dest).unwrap();
     assert_eq!(
         skill_removal_verdict(&manifest, &dest, "tm-doctor"),
         SkillRemoval::Removable
@@ -333,7 +339,7 @@ fn verdict_keeps_a_hand_edited_skill() {
     let dest = tmp.path().join("skills");
     let _src = deploy_real(&dest, "tm-doctor", "v1", None);
     fs::write(dest.join("tm-doctor").join("SKILL.md"), "edited").unwrap();
-    let manifest = SkillManifest::load(&dest);
+    let manifest = SkillManifest::load(&dest).unwrap();
     assert!(matches!(
         skill_removal_verdict(&manifest, &dest, "tm-doctor"),
         SkillRemoval::Kept(_)
@@ -346,7 +352,7 @@ fn verdict_keeps_an_untracked_file() {
     let dest = tmp.path().join("skills");
     let _src = deploy_real(&dest, "tm-doctor", "v1", None);
     fs::write(dest.join("tm-doctor").join("stray.md"), "mine").unwrap();
-    let manifest = SkillManifest::load(&dest);
+    let manifest = SkillManifest::load(&dest).unwrap();
     assert!(matches!(
         skill_removal_verdict(&manifest, &dest, "tm-doctor"),
         SkillRemoval::Kept(_)

--- a/crates/trusty-mpm/src/core/skill_staleness.rs
+++ b/crates/trusty-mpm/src/core/skill_staleness.rs
@@ -22,6 +22,7 @@
 
 use std::path::Path;
 
+use crate::core::agent_manifest::Result as ManifestResult;
 use crate::core::skill_deployer::{is_skill_file, skill_stem};
 use crate::core::skill_manifest::SkillManifest;
 
@@ -42,18 +43,22 @@ use crate::core::skill_manifest::SkillManifest;
 /// from the manifest (never deployed, or user-owned) are ignored — those are a
 /// different probe's concern. Read failures on an individual source file skip
 /// that file rather than aborting.
+///
+/// Fallible since #5626: an empty ledger short-circuits to "nothing is stale",
+/// which is right for a tier never deployed to and wrong for one whose ledger
+/// could not be read — the caller then warns about no drift it never looked for.
 /// Test: `stale_skills_flags_changed_source`, `stale_skills_empty_when_fresh`,
 /// `stale_skills_ignores_unmanaged`, `stale_skills_missing_source_is_empty`.
-pub fn stale_skills(source_dir: &Path, dest_dir: &Path) -> Vec<String> {
-    let manifest = SkillManifest::load(dest_dir);
+pub fn stale_skills(source_dir: &Path, dest_dir: &Path) -> ManifestResult<Vec<String>> {
+    let manifest = SkillManifest::load(dest_dir)?;
     if manifest.managed.is_empty() {
         // Nothing has been deployed here yet — there is no prior deploy to be
         // stale relative to. Skip the directory read entirely.
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     let Ok(entries) = std::fs::read_dir(source_dir) else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
 
     let mut stale: Vec<String> = Vec::new();
@@ -82,7 +87,7 @@ pub fn stale_skills(source_dir: &Path, dest_dir: &Path) -> Vec<String> {
         }
     }
     stale.sort_unstable();
-    stale
+    Ok(stale)
 }
 
 #[cfg(test)]
@@ -105,7 +110,7 @@ mod tests {
     fn stale_skills_empty_when_fresh() {
         // A skill just deployed from an unchanged source is not stale.
         let (src, dest) = deploy_one("---\nname: tm-doctor\n---\n\nv1\n");
-        assert!(stale_skills(src.path(), dest.path()).is_empty());
+        assert!(stale_skills(src.path(), dest.path()).unwrap().is_empty());
     }
 
     #[test]
@@ -119,7 +124,7 @@ mod tests {
             "---\nname: tm-doctor\n---\n\nv2 with new attribution footer\n",
         )
         .unwrap();
-        let stale = stale_skills(src.path(), dest.path());
+        let stale = stale_skills(src.path(), dest.path()).unwrap();
         assert_eq!(stale, vec!["tm-doctor".to_string()]);
     }
 
@@ -135,7 +140,7 @@ mod tests {
             "---\nname: brand-new\n---\n\nnever deployed\n",
         )
         .unwrap();
-        let stale = stale_skills(src.path(), dest.path());
+        let stale = stale_skills(src.path(), dest.path()).unwrap();
         assert!(!stale.contains(&"brand-new".to_string()));
         assert!(stale.is_empty());
     }
@@ -145,7 +150,7 @@ mod tests {
         // A missing source directory yields no staleness (nothing to compare),
         // never an error.
         let dest = TempDir::new().unwrap();
-        let stale = stale_skills(Path::new("/nonexistent/skill/source"), dest.path());
+        let stale = stale_skills(Path::new("/nonexistent/skill/source"), dest.path()).unwrap();
         assert!(stale.is_empty());
     }
 
@@ -156,6 +161,6 @@ mod tests {
         let src = TempDir::new().unwrap();
         let dest = TempDir::new().unwrap();
         fs::write(src.path().join("tm-doctor.md"), "body").unwrap();
-        assert!(stale_skills(src.path(), dest.path()).is_empty());
+        assert!(stale_skills(src.path(), dest.path()).unwrap().is_empty());
     }
 }

--- a/crates/trusty-mpm/src/core/stale_skills.rs
+++ b/crates/trusty-mpm/src/core/stale_skills.rs
@@ -250,7 +250,23 @@ pub fn find_stale_mpm_skills(claude_skills_dir: &Path) -> Vec<StaleSkill> {
         return Vec::new();
     }
 
-    let manifest = SkillManifest::load(claude_skills_dir);
+    // #5626: this list is a DELETE list, and the ledger is the primary origin
+    // proof. On the empty default an unreadable ledger sent every candidate to
+    // `frozen_content_checksum`, which can confirm on its own — so a permission
+    // error could authorise removing a directory. Refusing to nominate anything
+    // is the safe direction here; there is nothing to lose by scanning again
+    // later.
+    let manifest = match SkillManifest::load(claude_skills_dir) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::error!(
+                dir = %claude_skills_dir.display(),
+                error = %e,
+                "skill ownership ledger unreadable — nominating no stale skills for removal"
+            );
+            return Vec::new();
+        }
+    };
 
     FORMER_TRUSTY_MPM_SKILLS
         .iter()
@@ -422,7 +438,7 @@ mod tests {
     /// [`is_confirmed_trusty_mpm_origin`] since #1905's fork-model fix.
     fn write_confirmed_trusty_mpm_skill(claude_skills_dir: &Path, name: &str, content: &str) {
         write_skill_with_content(claude_skills_dir, name, content);
-        let mut manifest = SkillManifest::load(claude_skills_dir);
+        let mut manifest = SkillManifest::load(claude_skills_dir).unwrap();
         manifest.managed.insert(
             name.to_string(),
             SkillManifestEntry {

--- a/crates/trusty-mpm/src/core/update_check/apply.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply.rs
@@ -415,7 +415,10 @@ fn prune_skills_locked(
     user_stems: &BTreeSet<String>,
     backup_root: &Path,
 ) -> Result<PruneOutcome, ApplyError> {
-    let mut manifest = SkillManifest::load(target);
+    // #5626: the prune deletes files and rewrites the ledger. On the empty
+    // default it also republished that default over the real ledger through
+    // `save_merging`, unrecording every skill in the tier.
+    let mut manifest = SkillManifest::load(target)?;
     // #4881: the snapshot the merging save replays this run's delta against —
     // here the delta is REMOVALS, which `save_merging` applies to the current
     // on-disk document rather than reverting a concurrent writer's inserts.

--- a/crates/trusty-mpm/src/core/update_check/apply/tests.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply/tests.rs
@@ -382,7 +382,7 @@ fn apply_prune_removes_deselected_skill() {
         fw.claude_skills_dir().join("keep-me/SKILL.md").is_file(),
         "selected skill retained"
     );
-    let manifest = SkillManifest::load(&fw.claude_skills_dir());
+    let manifest = SkillManifest::load(&fw.claude_skills_dir()).unwrap();
     assert!(!manifest.is_managed("drop-me"));
     assert!(manifest.is_managed("keep-me"));
 }
@@ -422,7 +422,9 @@ fn apply_prune_skips_hand_edited_skill() {
     // The ledger entry stays too — dropping it would reclassify the file as
     // user-owned and freeze it against every future deploy (#4881's shape).
     assert!(
-        SkillManifest::load(&fw.claude_skills_dir()).is_managed("edited"),
+        SkillManifest::load(&fw.claude_skills_dir())
+            .unwrap()
+            .is_managed("edited"),
         "the kept skill stays managed"
     );
 }
@@ -460,7 +462,9 @@ fn apply_prune_spares_user_tier_skill() {
         "the user tier deploys regardless of the bundled selection"
     );
     assert!(
-        SkillManifest::load(&fw.claude_skills_dir()).is_managed("mine"),
+        SkillManifest::load(&fw.claude_skills_dir())
+            .unwrap()
+            .is_managed("mine"),
         "and it lands in the ledger looking exactly like a bundled skill"
     );
 
@@ -571,7 +575,11 @@ fn apply_prune_keeps_the_ledger_entry_for_a_selected_skills_carried_file() {
     apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
 
     let key = "carrier/references/notes.md";
-    assert!(SkillManifest::load(&fw.claude_skills_dir()).is_managed(key));
+    assert!(
+        SkillManifest::load(&fw.claude_skills_dir())
+            .unwrap()
+            .is_managed(key)
+    );
 
     let report = apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, true).unwrap();
 
@@ -585,7 +593,9 @@ fn apply_prune_keeps_the_ledger_entry_for_a_selected_skills_carried_file() {
             .is_file()
     );
     assert!(
-        SkillManifest::load(&fw.claude_skills_dir()).is_managed(key),
+        SkillManifest::load(&fw.claude_skills_dir())
+            .unwrap()
+            .is_managed(key),
         "a selected skill's carried file keeps its ledger entry"
     );
 }

--- a/crates/trusty-mpm/src/core/update_check/mod.rs
+++ b/crates/trusty-mpm/src/core/update_check/mod.rs
@@ -823,7 +823,22 @@ pub fn detect_for_framework(
     let agents_dir = fw.agent_deploy_dir();
     let skills_dir = fw.claude_skills_dir();
     let deployed_agents = AgentManifest::load(&agents_dir);
-    let deployed_skills = SkillManifest::load(&skills_dir);
+    // #5626: same rule as `session_assets` — a ledger this read could not
+    // establish leaves staleness `unknown`, never fresh.
+    let deployed_skills = match SkillManifest::load(&skills_dir) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(
+                dir = %skills_dir.display(),
+                error = %e,
+                "skill ownership ledger unreadable — catalog staleness is undetermined"
+            );
+            return StalenessReport {
+                unknown: true,
+                ..StalenessReport::default()
+            };
+        }
+    };
 
     detect_staleness(
         &plan.agent_source,

--- a/crates/trusty-mpm/src/daemon/doctor_asset_tier.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_asset_tier.rs
@@ -24,6 +24,7 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
+use trusty_agents_common::agents::tier_audit::TierAuditError;
 use trusty_agents_common::agents::tier_audit::{MisplacedAgent, audit_agent_tier};
 
 // #4448: the roster moved to `core::bundled_roster` so the quarantine in
@@ -38,14 +39,42 @@ const CHECK_NAME: &str = "asset_tier";
 /// How many offending agent names the message lists before summarising.
 const MAX_NAMED: usize = 5;
 
-/// One scanned non-canonical tier and what was found in it.
+/// One non-canonical tier and what the scan established about it.
 struct TierScan {
     /// Human label for the message (`project`, `operator home`).
     label: &'static str,
-    /// The scanned directory.
+    /// The directory the scan was asked for.
     dir: PathBuf,
-    /// tm-owned files found there, sorted by resolved agent name.
-    found: Vec<MisplacedAgent>,
+    /// What the scan found, or why it could not look.
+    outcome: TierOutcome,
+}
+
+/// What one tier scan established.
+///
+/// Why (#5626): the probe's message asserts `(scanned: <dir>)`, so "found
+/// nothing" and "could not look" must not arrive as the same empty vec — that
+/// is #4408's defining property, a check no failure can reach, reinstated by a
+/// permission error.
+/// What: [`Scanned`](Self::Scanned) carries the tm-owned files, possibly none;
+/// [`Unscannable`](Self::Unscannable) carries the rendered
+/// [`TierAuditError`].
+/// Test: `verdict_unscannable_tier_is_warn`,
+/// `verdict_unscannable_tier_is_not_reported_as_scanned`.
+enum TierOutcome {
+    /// The directory was enumerated; these are the tm-owned files in it.
+    Scanned(Vec<MisplacedAgent>),
+    /// The directory could not be enumerated; nothing is known about it.
+    Unscannable(String),
+}
+
+impl TierScan {
+    /// The tm-owned files found here, or none when the scan never ran.
+    fn found(&self) -> &[MisplacedAgent] {
+        match &self.outcome {
+            TierOutcome::Scanned(found) => found,
+            TierOutcome::Unscannable(_) => &[],
+        }
+    }
 }
 
 /// Probe for tm-owned agent files living outside the canonical deploy tier.
@@ -84,8 +113,17 @@ pub(super) fn check_asset_tier(
         if !seen.insert(dir.clone()) {
             continue;
         }
-        let found = audit_agent_tier(&dir, &roster);
-        scans.push(TierScan { label, dir, found });
+        // #5626: a tier that could not be enumerated is recorded as such, not
+        // folded into "scanned, found nothing".
+        let outcome = match audit_agent_tier(&dir, &roster) {
+            Ok(found) => TierOutcome::Scanned(found),
+            Err(e @ TierAuditError::Unscannable { .. }) => TierOutcome::Unscannable(e.to_string()),
+        };
+        scans.push(TierScan {
+            label,
+            dir,
+            outcome,
+        });
     }
 
     verdict(&scans, &canonical)
@@ -115,12 +153,49 @@ fn agent_tier_of(base: &Path) -> PathBuf {
 /// but do not resolve. And the empirical half: the deployer's skip-and-warn log
 /// covering this same directory fired on eight separate days through
 /// 2026-07-30 with no operator follow-up — a `Warn` here would join it.
+///
+/// #5626: a tier that could not be enumerated never appears in the `scanned:`
+/// list, and an otherwise-clean run holding one is `Warn`, not `Ok` — the
+/// question is open, not answered. A real hit still outranks it, since a
+/// confirmed shadowing is the more actionable finding.
 /// Test: `verdict_project_hit_is_fail`, `verdict_home_only_is_warn`,
-/// `verdict_clean_is_ok`, `verdict_names_the_files_and_both_tiers`.
+/// `verdict_clean_is_ok`, `verdict_names_the_files_and_both_tiers`,
+/// `verdict_unscannable_tier_is_warn`,
+/// `verdict_unscannable_tier_is_not_reported_as_scanned`.
 fn verdict(scans: &[TierScan], canonical: &Path) -> DoctorCheck {
-    let hits: Vec<&TierScan> = scans.iter().filter(|s| !s.found.is_empty()).collect();
+    let unscannable: Vec<String> = scans
+        .iter()
+        .filter_map(|s| match &s.outcome {
+            TierOutcome::Unscannable(why) => Some(format!("{} tier — {why}", s.label)),
+            TierOutcome::Scanned(_) => None,
+        })
+        .collect();
+
+    let hits: Vec<&TierScan> = scans.iter().filter(|s| !s.found().is_empty()).collect();
     if hits.is_empty() {
-        let scanned: Vec<String> = scans.iter().map(|s| s.dir.display().to_string()).collect();
+        let scanned: Vec<String> = scans
+            .iter()
+            .filter(|s| matches!(s.outcome, TierOutcome::Scanned(_)))
+            .map(|s| s.dir.display().to_string())
+            .collect();
+        if !unscannable.is_empty() {
+            return DoctorCheck::new(
+                CHECK_NAME,
+                CheckStatus::Warn,
+                format!(
+                    "a non-canonical agent tier could not be scanned, so whether tm-owned agent \
+                     files shadow the canonical tier {} is UNDETERMINED here: {}. Scanned: {}. \
+                     Make the directory readable and re-run, or delete it.",
+                    canonical.display(),
+                    unscannable.join("; "),
+                    if scanned.is_empty() {
+                        "none".to_owned()
+                    } else {
+                        scanned.join(", ")
+                    }
+                ),
+            );
+        }
         return DoctorCheck::new(
             CHECK_NAME,
             CheckStatus::Ok,
@@ -137,17 +212,18 @@ fn verdict(scans: &[TierScan], canonical: &Path) -> DoctorCheck {
     }
 
     let shadowing = hits.iter().any(|s| s.label == "project");
-    let detail: Vec<String> = hits
+    let mut detail: Vec<String> = hits
         .iter()
         .map(|s| {
             format!(
                 "{} tier {} — {}",
                 s.label,
                 s.dir.display(),
-                name_list(&s.found)
+                name_list(s.found())
             )
         })
         .collect();
+    detail.extend(unscannable.iter().map(|u| format!("{u} (UNDETERMINED)")));
 
     if shadowing {
         return DoctorCheck::new(

--- a/crates/trusty-mpm/src/daemon/doctor_asset_tier_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_asset_tier_tests.rs
@@ -58,14 +58,28 @@ fn scan(label: &'static str, dir: &Path, names: &[&str]) -> TierScan {
     TierScan {
         label,
         dir: dir.to_path_buf(),
-        found: names
-            .iter()
-            .map(|s| MisplacedAgent {
-                path: dir.join(format!("{s}.md")),
-                name: (*s).to_owned(),
-                class: TierResidentClass::ShadowsBundled,
-            })
-            .collect(),
+        outcome: TierOutcome::Scanned(
+            names
+                .iter()
+                .map(|s| MisplacedAgent {
+                    path: dir.join(format!("{s}.md")),
+                    name: (*s).to_owned(),
+                    class: TierResidentClass::ShadowsBundled,
+                })
+                .collect(),
+        ),
+    }
+}
+
+/// Build a scan that could not run, for the #5626 undetermined-tier tests.
+fn unscannable(label: &'static str, dir: &Path) -> TierScan {
+    TierScan {
+        label,
+        dir: dir.to_path_buf(),
+        outcome: TierOutcome::Unscannable(format!(
+            "cannot scan agent tier {}: Permission denied (os error 13)",
+            dir.display()
+        )),
     }
 }
 
@@ -280,6 +294,48 @@ fn verdict_clean_is_ok() {
     let check = verdict(&[scan("project", &dir, &[])], &canonical);
     assert_eq!(check.status, CheckStatus::Ok);
     assert!(check.message.contains("/c/agents"), "{}", check.message);
+}
+
+#[test]
+fn verdict_unscannable_tier_is_warn() {
+    // #5626: the probe could not look, so it must not say it looked and found
+    // nothing. Pre-fix the same input produced `Ok` with "(scanned: <dir>)".
+    let dir = PathBuf::from("/w/.claude/agents");
+    let canonical = PathBuf::from("/c/agents");
+    let check = verdict(&[unscannable("project", &dir)], &canonical);
+    assert_eq!(check.status, CheckStatus::Warn, "{}", check.message);
+    assert!(check.message.contains("UNDETERMINED"), "{}", check.message);
+}
+
+#[test]
+fn verdict_unscannable_tier_is_not_reported_as_scanned() {
+    // The `scanned:` list is a factual claim about which directories were read.
+    // A tier that failed belongs in the failure detail, never in that list.
+    let scanned_dir = PathBuf::from("/h/.claude/agents");
+    let failed_dir = PathBuf::from("/w/.claude/agents");
+    let canonical = PathBuf::from("/c/agents");
+    let check = verdict(
+        &[
+            scan("operator home", &scanned_dir, &[]),
+            unscannable("project", &failed_dir),
+        ],
+        &canonical,
+    );
+    let scanned_clause = check
+        .message
+        .split("Scanned: ")
+        .nth(1)
+        .unwrap_or_else(|| panic!("no Scanned: clause in {}", check.message));
+    assert!(
+        scanned_clause.contains("/h/.claude/agents"),
+        "the tier that WAS read must be listed: {}",
+        check.message
+    );
+    assert!(
+        !scanned_clause.contains("/w/.claude/agents"),
+        "the tier that failed must not be claimed as scanned: {}",
+        check.message
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/daemon/doctor_scaffold_tracking.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_scaffold_tracking.rs
@@ -69,7 +69,9 @@ use crate::core::skill_manifest::SkillManifest;
 /// Test: `regenerated_paths_includes_managed_agent`,
 /// `regenerated_paths_includes_skill_entry_and_references`,
 /// `regenerated_paths_includes_all_output_styles`.
-fn regenerated_scaffold_paths(project_dir: &Path) -> BTreeSet<String> {
+fn regenerated_scaffold_paths(
+    project_dir: &Path,
+) -> crate::core::agent_manifest::Result<BTreeSet<String>> {
     let mut paths = BTreeSet::new();
 
     let agent_manifest = AgentManifest::load(&project_dir.join(".claude").join("agents"));
@@ -77,7 +79,11 @@ fn regenerated_scaffold_paths(project_dir: &Path) -> BTreeSet<String> {
         paths.insert(format!(".claude/agents/{filename}"));
     }
 
-    let skill_manifest = SkillManifest::load(&project_dir.join(".claude").join("skills"));
+    // #5626: an unreadable ledger contributes no paths and says so. The empty
+    // default silently shrank "what tm regenerates", and the intersection this
+    // feeds then reported a tracked scaffold file as tm-untouched.
+    let skills_dir = project_dir.join(".claude").join("skills");
+    let skill_manifest = SkillManifest::load(&skills_dir)?;
     for key in skill_manifest.managed.keys() {
         if key.contains('/') {
             paths.insert(format!(".claude/skills/{key}"));
@@ -90,7 +96,7 @@ fn regenerated_scaffold_paths(project_dir: &Path) -> BTreeSet<String> {
         paths.insert(format!(".claude/output-styles/{}", style.file_name));
     }
 
-    paths
+    Ok(paths)
 }
 
 /// Paths under the three harness subtrees that `git` tracks in `project_dir`.
@@ -184,7 +190,23 @@ pub(super) fn check_scaffold_tracking(project_dir: Option<&Path>) -> DoctorCheck
         );
     };
 
-    let regenerated = regenerated_scaffold_paths(project);
+    // #5626: an unreadable ledger shrinks the regenerated set, and a smaller
+    // set means a smaller intersection — the check would report no collision it
+    // never looked for. Say so instead.
+    let regenerated = match regenerated_scaffold_paths(project) {
+        Ok(paths) => paths,
+        Err(e) => {
+            return DoctorCheck::new(
+                "scaffold_tracking",
+                CheckStatus::Warn,
+                format!(
+                    "an ownership ledger under {}/.claude could not be read, so which paths tm \
+                     regenerates is UNDETERMINED and this check could not run: {e}",
+                    project.display()
+                ),
+            );
+        }
+    };
     let collisions: BTreeSet<String> = tracked.intersection(&regenerated).cloned().collect();
 
     if collisions.is_empty() {

--- a/crates/trusty-mpm/src/daemon/doctor_scaffold_tracking_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_scaffold_tracking_tests.rs
@@ -211,7 +211,7 @@ fn regenerated_paths_includes_managed_agent() {
     let tmp = crate::test_support::hermetic_temp_dir();
     write_agent_manifest(tmp.path(), &["engineer.md"]);
 
-    let paths = regenerated_scaffold_paths(tmp.path());
+    let paths = regenerated_scaffold_paths(tmp.path()).unwrap();
     assert!(paths.contains(".claude/agents/engineer.md"));
 }
 
@@ -223,7 +223,7 @@ fn regenerated_paths_includes_skill_entry_and_references() {
         &["tm-doctor", "tm-doctor/references/checklist.md"],
     );
 
-    let paths = regenerated_scaffold_paths(tmp.path());
+    let paths = regenerated_scaffold_paths(tmp.path()).unwrap();
     assert!(paths.contains(".claude/skills/tm-doctor/SKILL.md"));
     assert!(paths.contains(".claude/skills/tm-doctor/references/checklist.md"));
 }
@@ -232,7 +232,7 @@ fn regenerated_paths_includes_skill_entry_and_references() {
 fn regenerated_paths_includes_all_output_styles() {
     let tmp = crate::test_support::hermetic_temp_dir();
 
-    let paths = regenerated_scaffold_paths(tmp.path());
+    let paths = regenerated_scaffold_paths(tmp.path()).unwrap();
     for style in crate::core::bundle::OUTPUT_STYLES {
         assert!(
             paths.contains(&format!(".claude/output-styles/{}", style.file_name)),

--- a/crates/trusty-mpm/src/daemon/doctor_skill_unmanaged.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_skill_unmanaged.rs
@@ -75,7 +75,24 @@ pub(super) fn check_skill_unmanaged(
 
     let mut findings: Vec<String> = Vec::new();
     for tier in skill_deploy_tiers(paths, project_dir) {
-        for skill in unmanaged_bundled_skills(&tier.dir, &bundled) {
+        // #5626: an unreadable ledger classifies nothing, and reporting `Ok`
+        // for such a tier is the same unverifiable-rendered-as-healthy shape
+        // the empty-roster guard above already refuses.
+        let found = match unmanaged_bundled_skills(&tier.dir, &bundled) {
+            Ok(found) => found,
+            Err(e) => {
+                return DoctorCheck::new(
+                    CHECK_NAME,
+                    CheckStatus::Unknown,
+                    format!(
+                        "the ownership ledger at {} could not be read, so which deployed \
+                         skills are tm's is undetermined: {e}",
+                        tier.dir.display()
+                    ),
+                );
+            }
+        };
+        for skill in found {
             findings.push(format!("{}/{}", tier.label, skill.stem));
         }
     }


### PR DESCRIPTION
Closes #5626.

The defect: `Err(_) => Self::default()` turned every read failure — missing, malformed, permission denied, I/O error — into an empty ledger, which downstream reads as "nothing is owned". Same fail-open class as #5620, #4576 and #5851.

**The highest-consequence instance, worth leading with:** at `core/stale_skills.rs`, the empty default sent every candidate to the frozen-checksum fallback, which can confirm on its own — so a permission error could authorise **removing a directory**. `find_stale_mpm_skills` returns the delete list itself, so the new error arm yields an empty delete list directly and returns before any path is read out of the manifest.

Three load sites fixed, not one — the issue's closure conditions name all three: `SkillManifest::load` (`skills/manifest.rs:170-180`), `AgentManifest::load_checked` (`agents/manifest.rs:377-380`), and `audit_agent_tier` (`agents/tier_audit.rs:333-345`).

Genuinely-absent still yields an empty ledger with no error — the first-run boundary is preserved and tested. Only present-but-unreadable propagates.

`AgentManifest::load_checked` needed no new type: its final arm now routes to the existing `ManifestLoad::Corrupt`, the refusal every consumer already handles — including `quarantine::sweep_locked`'s `CorruptLedger`, which an EACCES previously walked straight past. Widening a variant's documented meaning rather than adding one meant no consumer needed a new match arm.

**All 16 production call sites are enumerated with a decided behaviour**, because a caller doing `unwrap_or_default()` reintroduces the bug one level up. Six refuse and propagate; six report undetermined rather than empty (`StalenessReport { unknown: true }`, a new `DeploymentGap::SkillManifestCorrupt`, `CheckStatus::Unknown`); two fail closed deliberately. `core/skill_drift.rs` was restructured — it already had a correct four-state probe and then re-read through `load`, which would have re-defaulted.

One `unwrap_or_default()` was written at `doctor_scaffold_tracking.rs` and removed: a shrunken regenerated set means a smaller intersection, so the check would have reported no collision it never looked for.

**A test that passed pre-fix was rewritten rather than kept.** The first `deploy_refuses_an_unreadable_ledger` did error — but at save time, after already skipping the managed skill, so it proved nothing. The replacement uses a torn ledger, where pre-fix the deploy *succeeds* and `save_merging` publishes a near-empty ledger over it; it now asserts the ledger bytes are unchanged.

Pre-fix, seven of nine tests fail; post-fix all nine pass. The two passing in both states are the NotFound boundary — proof the fix did not over-correct into breaking first run.

🔴 **This breaks `trusty-agents-common`'s public API.** Four signature changes plus one new public type (`TierAuditError`). The crate is at `0.5.3`, so under Cargo's 0.x rule the breaking bump is the MINOR position: **0.6.0**. `trusty-mpm` re-exports `SkillManifest`, so its surface moves with it, and `DeploymentGap` gained a variant. No version file was edited — that routes to `local-ops`. A workspace `cargo check` cannot catch this class, since the root path override pairs local source with local dependency; `preflight-publish.sh` CHECK 5 is the real gate.

Test ladder rung 4. Gates: `fmt --check`, `check`/`clippy -p trusty-agents-common --all-targets -D warnings`, `check --workspace`, `check`/`clippy -p trusty-mpm`, `check_line_cap.sh`, `check_sld.sh`, `check_test_pointers.sh`, `check_changelog_fragment.sh` all exit 0. `cargo test -p trusty-agents-common`: 509 passed, 0 failed. All four direct dependents tested: `trusty-code` 1608 passed, `trusty-kb` 21 passed, `trusty-mpm` 5049 passed / 1 failed, `trusty-agents` 3504 passed / 1 failed.

Both reds are unrelated. `trusty-agents` is the known environmental #5678. `trusty-mpm`'s `spawn_session_without_tmux_returns_422_on_no_tmux_host` is a **newly observed flake** — the test branches on `TmuxDriver::is_available()`, took the no-tmux branch, then the spawn found tmux anyway because a concurrent agent's tmux server came up between the guard and the spawn. Same class as #3886. It passes in isolation, and nothing in this change touches tmux, session spawn, or the daemon API.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
