### PR TITLE
fix(trusty-audit): scrub credentials out of the tga audit child's log (#5869)

### DIFF
--- a/crates/trusty-audit/changelog.d/5869-scrub-the-child-log.md
+++ b/crates/trusty-audit/changelog.d/5869-scrub-the-child-log.md
@@ -26,3 +26,12 @@ Fixed
   clear. What the pump still holds back at a flush is only a credential that has
   not finished arriving, counted in text bytes so injected garbage rides along
   with it ([#5869](https://github.com/bobmatnyc/trusty-tools/issues/5869))
+- The size cap on that hold-back no longer writes out the credential it exists
+  to keep. The hold-back is measured in text bytes and was capped in raw bytes,
+  so around 4KB of non-UTF-8 output near a flush boundary — a binary diff or a
+  corrupted pack object from a `git` child — pushed the cap past the text it was
+  holding and wrote a partly-arrived key to the log in the clear; the rest of the
+  key then arrived without its start and matched nothing, so both halves landed.
+  The cap is now honoured by writing the invalid padding out of the hold instead,
+  which leaks nothing, and the pump's buffer bound is unchanged at one segment
+  plus the hold-back ([#5869](https://github.com/bobmatnyc/trusty-tools/issues/5869))

--- a/crates/trusty-audit/changelog.d/5869-scrub-the-child-log.md
+++ b/crates/trusty-audit/changelog.d/5869-scrub-the-child-log.md
@@ -13,6 +13,16 @@ Fixed
   already holds, so the log is lower-risk rather than proven clean
   ([#5869](https://github.com/bobmatnyc/trusty-tools/issues/5869))
 - The output pump no longer buffers a line without bound. A child printing one
-  endless line with no newline is flushed in bounded pieces, holding back a tail
-  as long as the longest credential so one straddling a flush is still caught
+  endless line with no newline is flushed in bounded pieces
   ([#5869](https://github.com/bobmatnyc/trusty-tools/issues/5869))
+- The filter sees a credential in one contiguous search space, so neither of the
+  two boundaries the pump used to invent can split one into unmatched halves. It
+  scrubs its whole buffer before cutting a piece off to write, rather than
+  scrubbing only the piece — a key lying across that cut used to reach the log in
+  two verbatim halves. It also searches a mixed-encoding segment over its
+  valid-UTF-8 runs concatenated, rather than one run at a time — a key is valid
+  UTF-8 and so cannot contain an invalid byte, but a child can inject one into
+  the middle of it, and the two flanking fragments used to reach the log in the
+  clear. What the pump still holds back at a flush is only a credential that has
+  not finished arriving, counted in text bytes so injected garbage rides along
+  with it ([#5869](https://github.com/bobmatnyc/trusty-tools/issues/5869))

--- a/crates/trusty-audit/changelog.d/5869-scrub-the-child-log.md
+++ b/crates/trusty-audit/changelog.d/5869-scrub-the-child-log.md
@@ -1,0 +1,18 @@
+Fixed
+
+- A credential echoed by the `tga audit` child — or by the `trusty-review` it
+  spawns — no longer reaches the per-repository log file. Both piped streams are
+  filtered on the way to disk through `trusty_common::credentials::scrub_secrets`,
+  the workspace's one redactor, and the relay path decodes the scrubbed bytes so
+  a key quoted inside a stage detail never reaches the operator's terminal either
+  ([#5869](https://github.com/bobmatnyc/trusty-tools/issues/5869))
+- The needle set is every credential the process can resolve
+  (`resolved_secret_values`), not only the engagement's OpenRouter key: a `gh`
+  token embedded in a git remote URL is a different credential from a different
+  source, and the narrow set would miss it. It removes only values this process
+  already holds, so the log is lower-risk rather than proven clean
+  ([#5869](https://github.com/bobmatnyc/trusty-tools/issues/5869))
+- The output pump no longer buffers a line without bound. A child printing one
+  endless line with no newline is flushed in bounded pieces, holding back a tail
+  as long as the longest credential so one straddling a flush is still caught
+  ([#5869](https://github.com/bobmatnyc/trusty-tools/issues/5869))

--- a/crates/trusty-audit/src/relay.rs
+++ b/crates/trusty-audit/src/relay.rs
@@ -42,7 +42,9 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use tokio::io::{AsyncBufReadExt as _, AsyncRead, AsyncReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::io::{
+    AsyncBufReadExt as _, AsyncRead, AsyncReadExt as _, AsyncWriteExt as _, BufReader,
+};
 use trusty_common::credentials::scrub_secrets;
 use trusty_progress::relay::StageEvent;
 
@@ -309,10 +311,7 @@ mod relay_tests {
             .await
             .expect("the pump completes");
 
-        (
-            std::fs::read(&path).expect("read log"),
-            recorder.stages(),
-        )
+        (std::fs::read(&path).expect("read log"), recorder.stages())
     }
 
     /// Why: the two obligations at once, and they pull in opposite directions —
@@ -398,7 +397,10 @@ mod relay_tests {
         let log = String::from_utf8(log).expect("text");
 
         assert!(!log.contains(KEY), "{log}");
-        assert_eq!(log, "ERROR 401: the key [REDACTED] is not valid\nnext line\n");
+        assert_eq!(
+            log,
+            "ERROR 401: the key [REDACTED] is not valid\nnext line\n"
+        );
     }
 
     /// Why: #5869 — a credential quoted in a stage detail would otherwise reach
@@ -409,7 +411,7 @@ mod relay_tests {
     #[tokio::test]
     async fn a_credential_inside_a_relay_line_is_masked_before_the_sink() {
         let leaky = StageEvent::new("Audit", "review", StageState::Failed)
-            .with_detail(&format!("provider rejected {KEY}"));
+            .with_detail(format!("provider rejected {KEY}"));
         let input = format!("{}\n", leaky.encode());
 
         let (log, stages) = run_bytes(input.as_bytes(), Scrubber::over(vec![KEY.to_owned()])).await;
@@ -440,7 +442,11 @@ mod relay_tests {
         let log = String::from_utf8(log).expect("text");
 
         assert!(!log.contains(KEY), "the key survived the flush boundary");
-        assert!(log.contains("[REDACTED] trailing"), "tail: {:?}", &log[log.len() - 40..]);
+        assert!(
+            log.contains("[REDACTED] trailing"),
+            "tail: {:?}",
+            &log[log.len() - 40..]
+        );
     }
 
     /// Why: a needle is valid UTF-8, so it cannot span an invalid byte — but a
@@ -463,18 +469,59 @@ mod relay_tests {
     /// Why: `read_until` grows its buffer until a newline arrives, so a child
     /// printing one endless line is an unbounded allocation in a process that
     /// runs for hours.
-    /// What: a stream several times [`SEGMENT_LIMIT`] with no newline at all
-    /// still reaches the log whole, which is only possible because the pump
-    /// flushed it in pieces rather than holding it.
+    /// What: the assertion is that bytes reach the log while the stream is
+    /// STILL OPEN and has carried no newline. A pump that buffered the line
+    /// would have written nothing yet, so an empty log here is the unbounded
+    /// behaviour and a non-empty one is the bound. The log then still holds the
+    /// whole stream once it closes — flushing early costs no bytes.
     /// Test: this is the test.
     #[tokio::test]
     async fn a_line_that_never_ends_does_not_grow_without_bound() {
-        let input = vec![b'z'; SEGMENT_LIMIT * 3 + 17];
-        let (log, stages) = run_bytes(&input, Scrubber::over(vec![KEY.to_owned()])).await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("child.log");
+        let file = tokio::fs::File::create(&path).await.expect("create log");
+        let (_recorder, progress) = Recorder::new();
+        let (mut writer, reader) = tokio::io::duplex(64 * 1024);
 
-        assert_eq!(log.len(), input.len(), "the log must hold the whole stream");
-        assert_eq!(log, input);
-        assert!(stages.is_empty(), "{stages:?}");
+        let pump = tokio::spawn(tee_and_relay(
+            reader,
+            file,
+            progress,
+            "acme/api".into(),
+            Scrubber::over(vec![KEY.to_owned()]),
+        ));
+
+        let burst = vec![b'z'; SEGMENT_LIMIT * 3 + 17];
+        let feeder = tokio::spawn(async move {
+            writer.write_all(&burst).await.expect("feed the pump");
+            // Hold the stream open: the point is what the log holds BEFORE EOF.
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            writer
+        });
+
+        // Poll rather than sleep-and-hope: the condition is "the pump wrote
+        // something", and it is either reached or the test fails on the bound.
+        let mut on_disk = 0;
+        for _ in 0..100 {
+            on_disk = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+            if on_disk > 0 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            on_disk > 0,
+            "nothing reached the log while the endless line was still open — \
+             the pump is buffering it whole"
+        );
+
+        drop(feeder.await.expect("the feeder finishes"));
+        pump.await.expect("join").expect("the pump completes");
+        assert_eq!(
+            std::fs::read(&path).expect("read log"),
+            vec![b'z'; SEGMENT_LIMIT * 3 + 17],
+            "flushing early must not cost a byte"
+        );
     }
 
     /// Why: the hold-back is derived from the needles, and a set with none must

--- a/crates/trusty-audit/src/relay.rs
+++ b/crates/trusty-audit/src/relay.rs
@@ -39,8 +39,8 @@
 //! ## One search space, no invented boundaries
 //!
 //! A needle is removed only if the scrubber sees it whole, so every boundary
-//! this module invents is somewhere a credential can hide in two halves. Two
-//! such boundaries existed and both leaked (#5869 review round):
+//! this module invents is somewhere a credential can hide in two halves. Three
+//! such boundaries existed and all three leaked (#5869 review rounds):
 //!
 //! - The pump used to scrub only the part of its buffer it was about to write,
 //!   so a needle straddling that cut was split, matched neither half, and both
@@ -52,11 +52,19 @@
 //!   being injected INTO it. [`Scrubber::scrub`] now searches the runs
 //!   concatenated — invalid bytes elided — and maps each match back to the
 //!   segment's own byte offsets.
+//! - The fix for the second one invented the third. The hold-back is counted in
+//!   TEXT bytes and was then clamped in RAW bytes, and the two units disagree
+//!   exactly when invalid padding sits inside an arrived prefix: the raw clamp
+//!   moved the cut PAST the text walk's boundary and wrote the prefix out. Any
+//!   bound stated in one unit and applied in the other is this defect again.
 //!
 //! What survives is a hold-back: bytes at the tail of the buffer that the pump
 //! keeps rather than writes, because a needle that has only PARTLY ARRIVED
 //! cannot be matched yet. That is a bound on the stream, not a boundary in the
-//! search space.
+//! search space — and the bound is now enforced without moving the cut. The
+//! hold-back's raw size is capped by dropping invalid padding OUT of it, which
+//! the pump then writes; the text the walk kept is never given up
+//! ([`Scrubber::cut_for`]).
 //!
 //! Test: `super::relay_tests`.
 
@@ -90,12 +98,21 @@ const SEGMENT_LIMIT: usize = 256 * 1024;
 /// longer than this is bounded here and loses only the partly-arrived case,
 /// never the ordinary one.
 ///
-/// It caps the hold-back twice, because the hold-back is counted in two units.
-/// [`Scrubber::held_back`] is a count of TEXT bytes, so that invalid bytes
-/// injected between a needle's characters are retained along with them; this
-/// same value then caps the RAW byte count the tail may reach, so a segment
-/// padded with injected garbage cannot make the pump hold its whole buffer.
-/// Test: `super::relay_tests::an_absurd_needle_cannot_stall_the_pump`.
+/// It bounds the hold-back twice, in the two units the hold-back is counted in.
+/// [`Scrubber::held_back`] is a count of TEXT bytes and is capped here at
+/// construction; the RAW span those text bytes occupy is capped here again,
+/// because invalid bytes injected among them make the span arbitrarily longer.
+///
+/// **The raw cap must never be applied by moving the cut.** It was, until the
+/// #5869 re-verify round: the cut was computed by walking text bytes and then
+/// clamped in raw bytes, so ~4KB of invalid padding inside an arrived prefix
+/// pushed the cut PAST the walk's boundary and wrote that prefix to the log in
+/// the clear — the remainder then arrived without it and matched nothing. The
+/// cap is now honoured by dropping invalid padding out of the hold
+/// ([`Scrubber::cut_for`]), which is bytes the pump writes rather than bytes it
+/// evicts.
+/// Test: `super::relay_tests::an_absurd_needle_cannot_stall_the_pump`,
+/// `super::relay_tests::a_padded_partial_credential_survives_a_four_kilobyte_pad`.
 const MAX_HELD_BACK: usize = 4096;
 
 /// The token [`scrub_secrets`] leaves in a needle's place.
@@ -261,45 +278,120 @@ impl Scrubber {
         out
     }
 
-    /// Where to cut `bytes` so the tail keeps every byte of a needle that has
+    /// How to divide `bytes` so the tail keeps every byte of a needle that has
     /// only partly arrived.
+    ///
+    /// # Postconditions
+    /// Every TEXT byte the walk chose to keep is in [`Cut::carry`], in order.
+    /// No raw-byte bound moves the division past that boundary — a bound that
+    /// binds takes it out of [`Cut::padding`], which the pump WRITES, never out
+    /// of the text the walk kept. `carry` is at most [`MAX_HELD_BACK`] bytes in
+    /// every case, and `head`, `padding` and `carry` together are `bytes`.
     ///
     /// Why: the pump writes what it cuts off, so anything it cuts through is
     /// written in the clear. A partly-arrived needle occupies at most
     /// [`Self::held_back`] bytes of TEXT at the very end of the buffer — but
-    /// invalid bytes injected between its characters make its RAW length longer
+    /// invalid bytes injected between its characters make its RAW span longer
     /// than that, and a raw-byte hold-back would slice its head off. So the walk
     /// counts text bytes and lets the invalid bytes among them ride along.
     /// What: walks the valid-UTF-8 runs backwards until the tail holds
-    /// [`Self::held_back`] bytes of text, then clamps the tail to
-    /// [`MAX_HELD_BACK`] raw bytes and to half the buffer, so garbage padding
-    /// can neither unbound the buffer nor stall the pump.
+    /// [`Self::held_back`] bytes of text. If the raw span of that tail is within
+    /// [`MAX_HELD_BACK`] the tail is carried whole, invalid bytes and all —
+    /// which is what keeps [`Self::redact_spans`] able to remove the ones INSIDE
+    /// the eventual match. Past that span the padding is lifted out and written
+    /// instead: the pump's memory bound is honoured by writing meaningless
+    /// bytes early rather than by evicting credential bytes, and the only cost
+    /// is that in that case those invalid bytes reach the log ahead of the text
+    /// they interrupted rather than being removed with it.
     /// Test: `super::relay_tests::a_credential_straddling_the_flush_cut_is_still_caught`,
     /// `super::relay_tests::an_interrupted_credential_straddling_a_cut_is_removed`,
+    /// `super::relay_tests::a_padded_partial_credential_survives_a_four_kilobyte_pad`,
+    /// `super::relay_tests::the_half_buffer_clamp_cannot_evict_a_partly_arrived_credential`,
+    /// `super::relay_tests::a_credential_at_the_head_of_an_almost_wholly_invalid_segment_is_held`,
     /// `super::relay_tests::a_line_that_never_ends_does_not_grow_without_bound`.
-    fn cut_for(&self, bytes: &[u8]) -> usize {
+    fn cut_for<'a>(&self, bytes: &'a [u8]) -> Cut<'a> {
         if self.held_back == 0 {
-            return bytes.len();
+            return Cut::written_whole(bytes);
         }
         let (_, runs) = utf8_runs(bytes);
-        let mut want = self.held_back;
-        let mut cut = 0usize;
+        let cut = Self::text_cut(&runs, self.held_back);
+        if bytes.len() - cut <= MAX_HELD_BACK {
+            return Cut {
+                head: &bytes[..cut],
+                padding: Vec::new(),
+                carry: Cow::Borrowed(&bytes[cut..]),
+            };
+        }
+        let (padding, carry) = lift_padding(bytes, &runs, cut);
+        Cut {
+            head: &bytes[..cut],
+            padding,
+            carry: Cow::Owned(carry),
+        }
+    }
+
+    /// The offset the last `want` TEXT bytes of a segment start at.
+    ///
+    /// Zero when the segment holds fewer than `want` of them: the whole segment
+    /// is then a candidate arrived prefix, so none of it may be written.
+    fn text_cut(runs: &[Run], want: usize) -> usize {
+        let mut want = want;
         for run in runs.iter().rev() {
             if run.len >= want {
-                cut = run.orig + run.len - want;
-                want = 0;
-                break;
+                return run.orig + run.len - want;
             }
             want -= run.len;
-            cut = run.orig;
         }
-        if want > 0 {
-            // Fewer text bytes in the whole buffer than the hold-back wants.
-            cut = 0;
-        }
-        let hold = (bytes.len() - cut).min(MAX_HELD_BACK).min(bytes.len() / 2);
-        bytes.len() - hold
+        0
     }
+}
+
+/// How one flush divides a scrubbed buffer.
+///
+/// `head`, then `padding`, then `carry` is `bytes` reordered only to the extent
+/// [`Scrubber::cut_for`] documents. The pump writes `head` and `padding` and
+/// keeps `carry` for the next segment.
+struct Cut<'a> {
+    /// Written first, unchanged: the buffer up to the hold-back's start.
+    head: &'a [u8],
+    /// Written after `head`: invalid bytes lifted out of an over-long hold.
+    /// Empty on the ordinary path, where the hold is carried whole.
+    padding: Vec<u8>,
+    /// Kept for the next segment.
+    carry: Cow<'a, [u8]>,
+}
+
+impl<'a> Cut<'a> {
+    /// The whole buffer written, nothing held — a scrubber with no needles.
+    fn written_whole(bytes: &'a [u8]) -> Self {
+        Self {
+            head: bytes,
+            padding: Vec::new(),
+            carry: Cow::Borrowed(&[]),
+        }
+    }
+}
+
+/// Split `bytes[from..]` into its invalid bytes and its text bytes, each in
+/// stream order.
+///
+/// Why: a hold whose raw span outgrew [`MAX_HELD_BACK`] must shrink, and the
+/// invalid bytes in it are the part that can be given up — they are not
+/// credential characters, so writing them leaks nothing, whereas writing the
+/// text among them is exactly the #5869 re-verify CRITICAL.
+/// Test: `super::relay_tests::a_padded_partial_credential_survives_a_four_kilobyte_pad`.
+fn lift_padding(bytes: &[u8], runs: &[Run], from: usize) -> (Vec<u8>, Vec<u8>) {
+    let mut padding = Vec::new();
+    let mut text = Vec::new();
+    let mut at = from;
+    for run in runs.iter().filter(|r| r.orig + r.len > from) {
+        let start = run.orig.max(from);
+        padding.extend_from_slice(&bytes[at..start]);
+        text.extend_from_slice(&bytes[start..run.orig + run.len]);
+        at = run.orig + run.len;
+    }
+    padding.extend_from_slice(&bytes[at..]);
+    (padding, text)
 }
 
 /// One maximal run of valid UTF-8 inside a segment.
@@ -397,9 +489,10 @@ fn utf8_runs(bytes: &[u8]) -> (String, Vec<Run>) {
 /// finished arriving ([`Scrubber::cut_for`]). Scrubbing the emitted part alone,
 /// as this did before the #5869 review, wrote both halves of a straddling
 /// credential verbatim. Early writing is also what keeps a child printing one
-/// endless line from growing this buffer without bound: it peaks at
-/// [`SEGMENT_LIMIT`] plus [`MAX_HELD_BACK`], with one scrubbed copy of that
-/// alive at a time.
+/// endless line from growing this buffer without bound: [`Scrubber::cut_for`]
+/// carries at most [`MAX_HELD_BACK`] bytes forward whatever the encoding, so
+/// the buffer peaks at [`SEGMENT_LIMIT`] plus [`MAX_HELD_BACK`], with one
+/// scrubbed copy of that alive at a time.
 /// Test: `super::relay_tests::every_non_secret_byte_reaches_the_log_and_events_reach_the_sink`,
 /// `super::relay_tests::a_credential_straddling_the_flush_cut_is_still_caught`,
 /// `super::relay_tests::an_interrupted_credential_straddling_a_cut_is_removed`,
@@ -445,9 +538,12 @@ where
             // straddling credential into two unmatched halves.
             let clean = scrubber.scrub(&pending).into_owned();
             let cut = scrubber.cut_for(&clean);
-            emit(&mut log, &progress, &target, &clean[..cut]).await?;
+            emit(&mut log, &progress, &target, cut.head).await?;
+            if !cut.padding.is_empty() {
+                emit(&mut log, &progress, &target, &cut.padding).await?;
+            }
             pending.clear();
-            pending.extend_from_slice(&clean[cut..]);
+            pending.extend_from_slice(&cut.carry);
         }
     }
     log.flush().await
@@ -681,7 +777,7 @@ mod relay_tests {
         let (log, _) = run_bytes(input.as_bytes(), scrubber).await;
         let log = String::from_utf8(log).expect("text");
 
-        assert_no_fragment_of_the_key(&log);
+        assert_no_fragment_of_the_key(log.as_bytes());
         assert!(
             log.contains("[REDACTED] trailing"),
             "the key was not replaced"
@@ -707,7 +803,7 @@ mod relay_tests {
 
         let (log, _) = run_bytes(&input, Scrubber::over(vec![KEY.to_owned()])).await;
 
-        assert_no_fragment_of_the_key(&String::from_utf8_lossy(&log));
+        assert_no_fragment_of_the_key(&log);
         assert_eq!(log, b"before [REDACTED] after\n".to_vec());
     }
 
@@ -747,20 +843,134 @@ mod relay_tests {
         let (log, _) = run_bytes(&input, scrubber).await;
         let log = String::from_utf8(log).expect("only the garbage was invalid, and it went");
 
-        assert_no_fragment_of_the_key(&log);
+        assert_no_fragment_of_the_key(log.as_bytes());
         assert_eq!(log, format!("{filler}[REDACTED] trailing\n"));
     }
 
     /// No run of the key's characters, at any length worth recovering, is in
     /// `log`. A whole-key check alone passes on a leak of all but one character.
-    fn assert_no_fragment_of_the_key(log: &str) {
+    ///
+    /// Searches RAW bytes: a log that carries invalid UTF-8 has no `str` form to
+    /// search, and converting it lossily first is a second unit system in a file
+    /// whose every leak so far came from exactly that.
+    fn assert_no_fragment_of_the_key(log: &[u8]) {
         for len in [8, 16, 24, 32, KEY.len()] {
-            let fragment = &KEY[..len];
+            let fragment = &KEY.as_bytes()[..len];
             assert!(
-                !log.contains(fragment),
-                "a {len}-character fragment of the key reached the log: {fragment}"
+                !log.windows(len).any(|w| w == fragment),
+                "a {len}-character fragment of the key reached the log: {}",
+                &KEY[..len]
             );
         }
+    }
+
+    /// Whether `needle` occurs anywhere in `log`, byte for byte.
+    fn contains_bytes(log: &[u8], needle: &[u8]) -> bool {
+        log.windows(needle.len()).any(|w| w == needle)
+    }
+
+    /// The reproduction behind the third #5869 CRITICAL, parameterised by how
+    /// much invalid padding sits inside the arrived prefix.
+    ///
+    /// The key straddles the flush cut with `garbage` invalid bytes injected
+    /// into its arrived prefix, so the prefix's RAW span is
+    /// `garbage + 40` while its TEXT span is 40. Any clamp counted in raw bytes
+    /// moves the cut past the prefix's first text byte and writes it out.
+    async fn assert_a_padded_prefix_survives_the_cut(garbage: usize) {
+        let scrubber = Scrubber::over(vec![KEY.to_owned()]);
+        let (head, rest) = KEY.split_at(20);
+        let (middle, last) = rest.split_at(10);
+        let filler = "x".repeat(SEGMENT_LIMIT - head.len() - garbage - middle.len());
+
+        let mut input: Vec<u8> = format!("{filler}{head}").into_bytes();
+        input.extend(std::iter::repeat_n(0xff_u8, garbage));
+        input.extend_from_slice(format!("{middle}{last} trailing\n").as_bytes());
+        assert!(
+            input.len() > SEGMENT_LIMIT,
+            "the flush path must be reached"
+        );
+        assert!(
+            garbage + head.len() + middle.len() > MAX_HELD_BACK,
+            "the padding must outrun the raw clamp, or this proves nothing"
+        );
+
+        let (log, _) = run_bytes(&input, scrubber).await;
+
+        assert_no_fragment_of_the_key(&log);
+        assert!(
+            contains_bytes(&log, b"[REDACTED] trailing"),
+            "the key was not replaced"
+        );
+    }
+
+    /// Why: #5869 re-verify round, CRITICAL 3. [`Scrubber::cut_for`] walked TEXT
+    /// bytes to find the cut and then clamped the result in RAW bytes. When
+    /// invalid padding inside the arrived prefix pushed its raw span past
+    /// [`MAX_HELD_BACK`], the clamp moved the cut PAST the walk's own boundary
+    /// and wrote the prefix out in the clear; the remainder arrived in a later
+    /// segment without it and matched nothing, so both halves reached the log.
+    /// The trigger is ~4KB of non-UTF-8 near a flush boundary — a binary diff or
+    /// a corrupted pack object from a `git` child, no alignment needed.
+    /// What: 4200 bytes of padding inside the prefix, and nothing of the key
+    /// reaches the log.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn a_padded_partial_credential_survives_a_four_kilobyte_pad() {
+        assert_a_padded_prefix_survives_the_cut(4200).await;
+    }
+
+    /// Why: the same defect at a different split point — the re-verifier's two
+    /// reproductions cut the key in different places, so one size is one data
+    /// point rather than the class.
+    /// What: 10000 bytes of padding inside the prefix, same outcome.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn a_padded_partial_credential_survives_a_ten_kilobyte_pad() {
+        assert_a_padded_prefix_survives_the_cut(10_000).await;
+    }
+
+    /// Why: [`MAX_HELD_BACK`] was not the only raw-byte clamp over a text-byte
+    /// walk — `.min(bytes.len() / 2)` was the second, and it evicts the same
+    /// bytes once the padding is large enough to reach it. A fix aimed only at
+    /// the constant named in the finding leaves this one live.
+    /// What: 200000 bytes of padding, over half a full segment, and the key is
+    /// still removed whole.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn the_half_buffer_clamp_cannot_evict_a_partly_arrived_credential() {
+        assert_a_padded_prefix_survives_the_cut(200_000).await;
+    }
+
+    /// Why: the third place the two units disagreed. When a segment holds FEWER
+    /// text bytes than the hold-back wants, the walk gives up and cuts at zero —
+    /// meaning "keep all of it" — and the raw clamp then turned that into "keep
+    /// the last 4096 bytes", writing a key sitting at the head of a segment that
+    /// is otherwise invalid bytes.
+    /// What: 20 characters of the key, then a segment's worth of invalid bytes,
+    /// then the rest. The head is held across every flush and the key is removed
+    /// whole when its remainder arrives.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn a_credential_at_the_head_of_an_almost_wholly_invalid_segment_is_held() {
+        let scrubber = Scrubber::over(vec![KEY.to_owned()]);
+        let (head, rest) = KEY.split_at(20);
+        let garbage = SEGMENT_LIMIT + MAX_HELD_BACK;
+        assert!(
+            head.len() < scrubber.held_back,
+            "the walk must run out of text before it is satisfied"
+        );
+
+        let mut input: Vec<u8> = head.as_bytes().to_vec();
+        input.extend(std::iter::repeat_n(0xff_u8, garbage));
+        input.extend_from_slice(format!("{rest} trailing\n").as_bytes());
+
+        let (log, _) = run_bytes(&input, scrubber).await;
+
+        assert_no_fragment_of_the_key(&log);
+        assert!(
+            contains_bytes(&log, b"[REDACTED] trailing"),
+            "the key was not replaced"
+        );
     }
 
     /// Why: [`Scrubber::redact_spans`] writes [`REDACTED`] itself, because
@@ -884,7 +1094,16 @@ mod relay_tests {
     }
 
     /// Why: the hold-back must stay far below [`SEGMENT_LIMIT`] or the pump
-    /// re-holds everything it read and stops making progress.
+    /// re-holds everything it read and stops making progress. Two things can
+    /// inflate it, and the #5869 re-verify round closed the second one without
+    /// reopening the first: an absurdly long NEEDLE, capped here at
+    /// construction; and invalid PADDING among a needle's characters, which no
+    /// cap on the needle bounds because it is not part of the needle.
+    /// [`Scrubber::cut_for`] now bounds the padding by writing it out rather
+    /// than by moving the cut, so both vectors stay closed and the carried tail
+    /// is at most [`MAX_HELD_BACK`] bytes however the segment is encoded — the
+    /// claim `the_hold_back_stays_within_its_cap_whatever_the_padding` checks
+    /// directly.
     /// What: an absurdly long needle is capped at [`MAX_HELD_BACK`].
     /// Test: this is the test.
     #[test]
@@ -892,5 +1111,53 @@ mod relay_tests {
         let huge = Scrubber::over(vec!["q".repeat(SEGMENT_LIMIT * 2)]);
         assert_eq!(huge.held_back, MAX_HELD_BACK);
         assert!(huge.held_back < SEGMENT_LIMIT / 2);
+    }
+
+    /// Why: the pump's memory bound is `SEGMENT_LIMIT + MAX_HELD_BACK`, and it
+    /// rests entirely on what [`Scrubber::cut_for`] carries. The tests above
+    /// reach that through the pump; this asserts the bound itself, over the
+    /// segment shapes that inflate a raw hold — padding inside the tail,
+    /// padding at the very end, and a segment with almost no text in it at all.
+    /// What: whatever the encoding, the carry is within the cap, its text is
+    /// within the needle-derived hold-back, and the three pieces reassemble the
+    /// segment's bytes.
+    /// Test: this is the test.
+    #[test]
+    fn the_hold_back_stays_within_its_cap_whatever_the_padding() {
+        let scrubber = Scrubber::over(vec![KEY.to_owned()]);
+        let text = "t".repeat(64);
+        let shapes: Vec<Vec<u8>> = vec![
+            // Padding inside the held tail: the walk keeps text either side.
+            [text.as_bytes(), &vec![0xff; 9000], &text.as_bytes()[..20]].concat(),
+            // Padding after the last text byte.
+            [text.as_bytes(), &vec![0xff; 9000]].concat(),
+            // Almost no text at all: the walk runs out and cuts at zero.
+            [&b"ab"[..], &vec![0xff; 9000]].concat(),
+            // No text at all.
+            vec![0xff; 9000],
+        ];
+
+        for bytes in shapes {
+            let cut = scrubber.cut_for(&bytes);
+            assert!(
+                !cut.padding.is_empty(),
+                "every shape here outruns the cap, so every one must lift padding"
+            );
+            assert!(
+                cut.carry.len() <= MAX_HELD_BACK,
+                "carried {} bytes, cap is {MAX_HELD_BACK}",
+                cut.carry.len()
+            );
+            let carried_text: usize = utf8_runs(&cut.carry).1.iter().map(|r| r.len).sum();
+            assert!(
+                carried_text <= scrubber.held_back,
+                "carried {carried_text} text bytes against a hold-back of {}",
+                scrubber.held_back
+            );
+            let mut whole = cut.head.to_vec();
+            whole.extend_from_slice(&cut.padding);
+            whole.extend_from_slice(&cut.carry);
+            assert_eq!(whole.len(), bytes.len(), "no byte was dropped");
+        }
     }
 }

--- a/crates/trusty-audit/src/relay.rs
+++ b/crates/trusty-audit/src/relay.rs
@@ -1,4 +1,5 @@
-//! Reading a child's output: everything to the log, the progress lines onward.
+//! Reading a child's output: credentials removed, everything else to the log,
+//! the progress lines onward.
 //!
 //! Why: #5823. `crate::run` gave each `tga audit` child a log file as its
 //! stdout and stderr and then awaited it, so the four-hour budget could elapse
@@ -10,37 +11,206 @@
 //! byte still lands in the log, and the lines that are progress events are
 //! additionally decoded and forwarded to the display.
 //!
-//! What: [`tee_and_relay`], one call per stream.
+//! What: [`tee_and_relay`], one call per stream, filtered by a [`Scrubber`].
+//!
+//! ## Why the tee scrubs (#5869)
+//!
+//! The child is handed the OpenRouter credential in its environment, and it
+//! spawns `trusty-review` with the same. Any process in that chain can echo a
+//! credential — a provider's non-2xx body quoted verbatim, a debug line, a
+//! `git` remote URL carrying a token in a clone failure — and until #5869 those
+//! bytes went straight to disk. A human opening the log to diagnose a failure
+//! read the key in plaintext, and the planned guided-help path would send
+//! bounded excerpts of that same log to OpenRouter inside a prompt body.
+//!
+//! **What this cannot do.** [`scrub_secrets`] removes only values this process
+//! already holds. A secret the child derived, fetched over the network, or read
+//! from its own config under a name no registry entry knows passes through
+//! untouched. The log is therefore LOWER-RISK, NOT PROVEN CLEAN — treat it as
+//! sensitive still.
 //!
 //! ## Why bytes rather than lines of text
 //!
 //! A child's output is not guaranteed to be UTF-8 — one `git` message in an
 //! unexpected encoding is enough. Reading `String` lines would end the pump at
 //! the first such byte and truncate the log from there, turning a cosmetic
-//! feature into evidence loss. So the log write is bytes, verbatim, and only a
-//! line that already carries the relay marker is decoded at all.
+//! feature into evidence loss. So the pump is byte-oriented throughout, and a
+//! segment that is not valid UTF-8 is scrubbed run-by-run rather than lost.
 //!
 //! Test: `super::relay_tests`.
 
-use tokio::io::{AsyncBufReadExt as _, AsyncRead, AsyncWriteExt as _, BufReader};
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use tokio::io::{AsyncBufReadExt as _, AsyncRead, AsyncReadExt as _, AsyncWriteExt as _, BufReader};
+use trusty_common::credentials::scrub_secrets;
 use trusty_progress::relay::StageEvent;
 
 use crate::progress::Progress;
 
-/// Copy `reader` into `log`, forwarding progress lines to `progress`.
+/// Most bytes the pump will accumulate from one read before forcing them out.
+///
+/// Why: the child's output is a stream and a line is only a line once a newline
+/// arrives. `read_until` alone will grow its buffer until one does, so a child
+/// that prints a megabyte-per-second single line with no newline — a stuck
+/// progress spinner, a base64 blob — is an unbounded allocation in a process
+/// that must survive four hours. Bounding the read turns that into a flush.
+/// Test: `super::relay_tests::a_line_that_never_ends_does_not_grow_without_bound`.
+const SEGMENT_LIMIT: usize = 256 * 1024;
+
+/// Most bytes held back across a mid-line flush, whatever the needles say.
+///
+/// Why: the hold-back exists so a credential straddling a flush is still
+/// matched next round, so it wants to be the longest needle. It must also stay
+/// far below [`SEGMENT_LIMIT`] or the pump stops making progress — it would
+/// re-hold everything it just read. A pathological "secret" longer than this is
+/// bounded here and loses only the straddling case, never the ordinary one.
+const MAX_HELD_BACK: usize = 4096;
+
+/// The credential values to strip from a child's output.
+///
+/// Why: #5869. The needles must be materialized once per sweep, not once per
+/// line — [`trusty_common::credentials::resolved_secret_values`] reads
+/// `.env.local` and opens the secure store, which is not a per-line cost. The
+/// two pumps of one child share this by `Arc`, and every child of one sweep
+/// shares the same set.
+/// What: an immutable needle set plus the hold-back it implies. Cloning is an
+/// `Arc` bump. An empty set makes [`Scrubber::scrub`] a borrow and the pump's
+/// hold-back zero, so a build with no resolvable credential pays nothing.
+/// Test: `super::relay_tests::a_credential_never_reaches_the_log`,
+/// `super::relay_tests::a_credential_split_across_a_flush_is_still_caught`.
+#[derive(Clone, Debug)]
+pub(crate) struct Scrubber {
+    secrets: Arc<[String]>,
+    held_back: usize,
+}
+
+impl Scrubber {
+    /// Build a scrubber over `secrets`, deriving the hold-back from them.
+    ///
+    /// What: the hold-back is one byte short of the longest needle — enough
+    /// that any needle straddling a mid-line flush still lies whole inside the
+    /// next segment — capped at [`MAX_HELD_BACK`].
+    pub(crate) fn over(secrets: Vec<String>) -> Self {
+        let held_back = secrets
+            .iter()
+            .map(String::len)
+            .max()
+            .unwrap_or(0)
+            .saturating_sub(1)
+            .min(MAX_HELD_BACK);
+        Self {
+            secrets: secrets.into(),
+            held_back,
+        }
+    }
+
+    /// A scrubber that removes nothing, for a caller with no credential to hide.
+    #[cfg(test)]
+    pub(crate) fn none() -> Self {
+        Self::over(Vec::new())
+    }
+
+    /// `bytes` with every known credential replaced by `[REDACTED]`.
+    ///
+    /// Why: the hot path is a log line with no credential in it, run once per
+    /// line for hours. It must not allocate, so a segment that is whole UTF-8
+    /// and matches nothing is returned borrowed.
+    /// What: validates once, then asks each needle whether it occurs; only a hit
+    /// reaches [`scrub_secrets`], the workspace's one redactor. A segment that
+    /// is not valid UTF-8 falls to [`Self::scrub_mixed`] rather than being
+    /// lossily converted, because the log is a verbatim record.
+    /// Test: `super::relay_tests::a_credential_never_reaches_the_log`,
+    /// `super::relay_tests::a_credential_beside_non_utf8_bytes_is_still_removed`.
+    fn scrub<'a>(&self, bytes: &'a [u8]) -> Cow<'a, [u8]> {
+        if self.secrets.is_empty() {
+            return Cow::Borrowed(bytes);
+        }
+        match std::str::from_utf8(bytes) {
+            Ok(text) => {
+                if !self.occurs_in(text) {
+                    return Cow::Borrowed(bytes);
+                }
+                Cow::Owned(scrub_secrets(text, &self.secrets).into_bytes())
+            }
+            Err(_) => Cow::Owned(self.scrub_mixed(bytes)),
+        }
+    }
+
+    /// Whether any needle occurs in `text`.
+    ///
+    /// `str::contains` is a two-way search rather than the naive scan a
+    /// `windows()` comparison over raw bytes would be, which is why this asks
+    /// the question in `str` rather than in `[u8]`.
+    fn occurs_in(&self, text: &str) -> bool {
+        self.secrets.iter().any(|s| text.contains(s.as_str()))
+    }
+
+    /// Scrub the valid-UTF-8 runs of `bytes`, passing the invalid bytes through.
+    ///
+    /// Why: a credential is by construction valid UTF-8, so it can never span an
+    /// invalid byte — scrubbing each valid run and copying the invalid bytes
+    /// verbatim removes exactly as much as scrubbing the whole would, while
+    /// keeping the log byte-faithful where the child was not text. Converting
+    /// lossily instead would substitute replacement characters into the one
+    /// artifact a failure is diagnosed from.
+    /// What: walks the segment, splitting at each [`std::str::Utf8Error`], and
+    /// scrubs only the runs on the valid side of the split. An `error_len` of
+    /// `None` is an incomplete trailing sequence, which is copied whole.
+    /// Test: `super::relay_tests::a_credential_beside_non_utf8_bytes_is_still_removed`.
+    fn scrub_mixed(&self, bytes: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(bytes.len());
+        let mut rest = bytes;
+        loop {
+            let (valid, tail, skip) = match std::str::from_utf8(rest) {
+                Ok(_) => (rest, &[][..], 0),
+                Err(e) => {
+                    let (valid, tail) = rest.split_at(e.valid_up_to());
+                    (valid, tail, e.error_len().unwrap_or(tail.len()).max(1))
+                }
+            };
+            // `valid` is UTF-8 by `valid_up_to`, so this conversion never
+            // substitutes anything; it is the no-unwrap spelling of the cast.
+            let text = String::from_utf8_lossy(valid);
+            if self.occurs_in(&text) {
+                out.extend_from_slice(scrub_secrets(&text, &self.secrets).as_bytes());
+            } else {
+                out.extend_from_slice(valid);
+            }
+            let skip = skip.min(tail.len());
+            out.extend_from_slice(&tail[..skip]);
+            rest = &tail[skip..];
+            if rest.is_empty() {
+                return out;
+            }
+        }
+    }
+}
+
+/// Copy `reader` into `log` with credentials removed, forwarding progress lines.
 ///
 /// # Postconditions
-/// On `Ok`, every byte read was written to `log` and `log` was flushed, and
-/// every well-formed relay line was delivered as a
+/// On `Ok`, every byte read reached `log` except the bytes of a needle in
+/// `scrubber`, each of which was replaced by `[REDACTED]`, and `log` was
+/// flushed; every well-formed relay line was delivered as a
 /// [`crate::progress::ProgressUpdate::UnitStage`] for `target`. On `Err`, the
 /// log is incomplete — the caller must treat that as a failure of the unit
 /// rather than a cosmetic one, because the log is the evidence.
 ///
-/// What: reads up to each `\n`, writes the bytes through unchanged, and decodes
-/// the line only when it starts with the relay marker. A relay line is kept in
-/// the log too: the log is a record of what the child said, not a filtered view
-/// of it.
-/// Test: `super::relay_tests::every_byte_reaches_the_log_and_events_reach_the_sink`.
+/// What: accumulates up to each `\n`, bounded by [`SEGMENT_LIMIT`], scrubs the
+/// segment, writes it, and decodes it only when it starts with the relay marker.
+/// A relay line is kept in the log too: the log is a record of what the child
+/// said, not a filtered view of it. The relay side reads the SCRUBBED bytes, so
+/// a credential quoted inside a stage detail never reaches the display either;
+/// `[REDACTED]` carries no tab, so the wire format's field count survives.
+///
+/// A segment that reaches [`SEGMENT_LIMIT`] with no newline is written out
+/// early, minus a hold-back tail long enough that a credential straddling the
+/// cut is matched on the next segment instead. That is what keeps a child
+/// printing one endless line from growing this buffer without bound.
+/// Test: `super::relay_tests::every_non_secret_byte_reaches_the_log_and_events_reach_the_sink`,
+/// `super::relay_tests::a_credential_split_across_a_flush_is_still_caught`,
+/// `super::relay_tests::a_line_that_never_ends_does_not_grow_without_bound`.
 ///
 /// # Errors
 ///
@@ -50,27 +220,56 @@ pub(crate) async fn tee_and_relay<R>(
     mut log: tokio::fs::File,
     progress: Progress,
     target: String,
+    scrubber: Scrubber,
 ) -> std::io::Result<()>
 where
     R: AsyncRead + Unpin,
 {
     let mut reader = BufReader::new(reader);
-    let mut line = Vec::new();
+    let mut pending: Vec<u8> = Vec::new();
     loop {
-        line.clear();
-        if reader.read_until(b'\n', &mut line).await? == 0 {
+        let read = (&mut reader)
+            .take(SEGMENT_LIMIT as u64)
+            .read_until(b'\n', &mut pending)
+            .await?;
+        if read == 0 {
+            // EOF. The child was killed mid-line, or simply ended without one;
+            // either way what is held is the last thing it managed to say.
+            if !pending.is_empty() {
+                emit(&scrubber, &mut log, &progress, &target, &pending).await?;
+            }
             break;
         }
-        log.write_all(&line).await?;
-        // `is_active` first: the common line is ordinary logging, and with no
-        // sink attached there is nothing to decode it for.
-        if progress.is_active()
-            && let Some(event) = decode(&line)
-        {
-            progress.unit_stage(target.as_str(), event);
+        if pending.ends_with(b"\n") {
+            emit(&scrubber, &mut log, &progress, &target, &pending).await?;
+            pending.clear();
+        } else if pending.len() >= SEGMENT_LIMIT {
+            let cut = pending.len() - scrubber.held_back.min(pending.len());
+            emit(&scrubber, &mut log, &progress, &target, &pending[..cut]).await?;
+            pending.drain(..cut);
         }
     }
     log.flush().await
+}
+
+/// Scrub one segment, write it, and relay it if it is an event.
+async fn emit(
+    scrubber: &Scrubber,
+    log: &mut tokio::fs::File,
+    progress: &Progress,
+    target: &str,
+    segment: &[u8],
+) -> std::io::Result<()> {
+    let clean = scrubber.scrub(segment);
+    log.write_all(&clean).await?;
+    // `is_active` first: the common segment is ordinary logging, and with no
+    // sink attached there is nothing to decode it for.
+    if progress.is_active()
+        && let Some(event) = decode(&clean)
+    {
+        progress.unit_stage(target, event);
+    }
+    Ok(())
 }
 
 /// The event a line carries, or `None` for ordinary output.
@@ -92,18 +291,26 @@ mod relay_tests {
     use crate::progress::{Recorder, StageState};
     use trusty_progress::relay::StageEvent;
 
+    /// A needle long enough for `scrub_secrets` to apply (its floor is 8 chars).
+    const KEY: &str = "sk-or-v1-0123456789abcdef0123456789abcdef";
+
     async fn run(input: &str) -> (String, Vec<StageEvent>) {
+        let (log, stages) = run_bytes(input.as_bytes(), Scrubber::none()).await;
+        (String::from_utf8(log).expect("text"), stages)
+    }
+
+    async fn run_bytes(input: &[u8], scrubber: Scrubber) -> (Vec<u8>, Vec<StageEvent>) {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("child.log");
         let file = tokio::fs::File::create(&path).await.expect("create log");
         let (recorder, progress) = Recorder::new();
 
-        tee_and_relay(input.as_bytes(), file, progress, "acme/api".into())
+        tee_and_relay(input, file, progress, "acme/api".into(), scrubber)
             .await
             .expect("the pump completes");
 
         (
-            std::fs::read_to_string(&path).expect("read log"),
+            std::fs::read(&path).expect("read log"),
             recorder.stages(),
         )
     }
@@ -112,10 +319,13 @@ mod relay_tests {
     /// a filter that forwarded events would be simpler and would silently drop
     /// them from the log a failure is diagnosed from.
     /// What: a child stream mixing ordinary logging with relay lines leaves the
-    /// log byte-identical to the input AND delivers every event.
+    /// log byte-identical to the input AND delivers every event. #5869 renamed
+    /// this from `every_byte_reaches_the_log_…`: with scrubbing in the path the
+    /// unqualified claim is no longer true, and the assertion it makes — over a
+    /// stream holding no credential — is the qualified one.
     /// Test: this is the test.
     #[tokio::test]
-    async fn every_byte_reaches_the_log_and_events_reach_the_sink() {
+    async fn every_non_secret_byte_reaches_the_log_and_events_reach_the_sink() {
         let started = StageEvent::new("Audit", "collect", StageState::Started)
             .with_counts(0, Some(9))
             .with_detail("stage 1 of 9");
@@ -166,21 +376,130 @@ mod relay_tests {
     /// Test: this is the test.
     #[tokio::test]
     async fn invalid_utf8_does_not_truncate_the_log() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("child.log");
-        let file = tokio::fs::File::create(&path).await.expect("create log");
-        let (recorder, progress) = Recorder::new();
         let event = StageEvent::new("Audit", "report", StageState::Completed);
-
         let mut input: Vec<u8> = b"before\n\xff\xfe not text\n".to_vec();
         input.extend_from_slice(event.encode().as_bytes());
         input.push(b'\n');
 
-        tee_and_relay(input.as_slice(), file, progress, "acme/api".into())
-            .await
-            .expect("the pump survives non-text output");
+        let (log, stages) = run_bytes(&input, Scrubber::none()).await;
+        assert_eq!(log, input);
+        assert_eq!(stages, vec![event]);
+    }
 
-        assert_eq!(std::fs::read(&path).expect("read log"), input);
-        assert_eq!(recorder.stages(), vec![event]);
+    /// Why: #5869 — the whole point. A child handed the credential can echo it,
+    /// and until this the bytes went to disk verbatim.
+    /// What: a key on the child's stream is replaced in the log, and the
+    /// surrounding text is untouched.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn a_credential_never_reaches_the_log() {
+        let input = format!("ERROR 401: the key {KEY} is not valid\nnext line\n");
+        let (log, _) = run_bytes(input.as_bytes(), Scrubber::over(vec![KEY.to_owned()])).await;
+        let log = String::from_utf8(log).expect("text");
+
+        assert!(!log.contains(KEY), "{log}");
+        assert_eq!(log, "ERROR 401: the key [REDACTED] is not valid\nnext line\n");
+    }
+
+    /// Why: #5869 — a credential quoted in a stage detail would otherwise reach
+    /// the operator's terminal, a second sink with the same exposure.
+    /// What: the relay path decodes the SCRUBBED bytes, so the event's detail
+    /// arrives masked and the wire format still parses.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn a_credential_inside_a_relay_line_is_masked_before_the_sink() {
+        let leaky = StageEvent::new("Audit", "review", StageState::Failed)
+            .with_detail(&format!("provider rejected {KEY}"));
+        let input = format!("{}\n", leaky.encode());
+
+        let (log, stages) = run_bytes(input.as_bytes(), Scrubber::over(vec![KEY.to_owned()])).await;
+
+        assert!(!String::from_utf8_lossy(&log).contains(KEY));
+        assert_eq!(stages.len(), 1, "the event must still decode: {stages:?}");
+        assert_eq!(
+            stages[0].detail.as_deref(),
+            Some("provider rejected [REDACTED]")
+        );
+    }
+
+    /// Why: the child's output is a stream, so a credential can land either side
+    /// of the point where the pump gives up waiting for a newline. Naive
+    /// per-segment scrubbing misses exactly that case.
+    /// What: a key placed deliberately across the mid-line flush boundary is
+    /// still removed, because the pump holds back a tail as long as the longest
+    /// needle before writing.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn a_credential_split_across_a_flush_is_still_caught() {
+        // One line with no newline until well past the limit, with the key
+        // straddling the first flush point.
+        let head = "x".repeat(SEGMENT_LIMIT - KEY.len() / 2);
+        let input = format!("{head}{KEY} trailing\n");
+
+        let (log, _) = run_bytes(input.as_bytes(), Scrubber::over(vec![KEY.to_owned()])).await;
+        let log = String::from_utf8(log).expect("text");
+
+        assert!(!log.contains(KEY), "the key survived the flush boundary");
+        assert!(log.contains("[REDACTED] trailing"), "tail: {:?}", &log[log.len() - 40..]);
+    }
+
+    /// Why: a needle is valid UTF-8, so it cannot span an invalid byte — but a
+    /// pump that gave up on a non-text segment would leave the key beside it in
+    /// the clear.
+    /// What: a key in the same segment as invalid bytes is removed, and the
+    /// invalid bytes still reach the log unchanged.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn a_credential_beside_non_utf8_bytes_is_still_removed() {
+        let mut input: Vec<u8> = format!("before {KEY} ").into_bytes();
+        input.extend_from_slice(b"\xff\xfe after\n");
+
+        let (log, _) = run_bytes(&input, Scrubber::over(vec![KEY.to_owned()])).await;
+
+        assert!(!log.windows(KEY.len()).any(|w| w == KEY.as_bytes()));
+        assert_eq!(log, b"before [REDACTED] \xff\xfe after\n".to_vec());
+    }
+
+    /// Why: `read_until` grows its buffer until a newline arrives, so a child
+    /// printing one endless line is an unbounded allocation in a process that
+    /// runs for hours.
+    /// What: a stream several times [`SEGMENT_LIMIT`] with no newline at all
+    /// still reaches the log whole, which is only possible because the pump
+    /// flushed it in pieces rather than holding it.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn a_line_that_never_ends_does_not_grow_without_bound() {
+        let input = vec![b'z'; SEGMENT_LIMIT * 3 + 17];
+        let (log, stages) = run_bytes(&input, Scrubber::over(vec![KEY.to_owned()])).await;
+
+        assert_eq!(log.len(), input.len(), "the log must hold the whole stream");
+        assert_eq!(log, input);
+        assert!(stages.is_empty(), "{stages:?}");
+    }
+
+    /// Why: the hold-back is derived from the needles, and a set with none must
+    /// not make the pump hold bytes it will never need.
+    /// What: an empty scrubber holds back nothing and returns its input borrowed.
+    /// Test: this is the test.
+    #[test]
+    fn an_empty_scrubber_holds_nothing_back_and_never_allocates() {
+        let empty = Scrubber::none();
+        assert_eq!(empty.held_back, 0);
+        assert!(matches!(empty.scrub(b"anything at all"), Cow::Borrowed(_)));
+
+        let one = Scrubber::over(vec![KEY.to_owned()]);
+        assert_eq!(one.held_back, KEY.len() - 1);
+        assert!(matches!(one.scrub(b"nothing to remove"), Cow::Borrowed(_)));
+    }
+
+    /// Why: the hold-back must stay far below [`SEGMENT_LIMIT`] or the pump
+    /// re-holds everything it read and stops making progress.
+    /// What: an absurdly long needle is capped at [`MAX_HELD_BACK`].
+    /// Test: this is the test.
+    #[test]
+    fn an_absurd_needle_cannot_stall_the_pump() {
+        let huge = Scrubber::over(vec!["q".repeat(SEGMENT_LIMIT * 2)]);
+        assert_eq!(huge.held_back, MAX_HELD_BACK);
+        assert!(huge.held_back < SEGMENT_LIMIT / 2);
     }
 }

--- a/crates/trusty-audit/src/relay.rs
+++ b/crates/trusty-audit/src/relay.rs
@@ -34,8 +34,29 @@
 //! A child's output is not guaranteed to be UTF-8 — one `git` message in an
 //! unexpected encoding is enough. Reading `String` lines would end the pump at
 //! the first such byte and truncate the log from there, turning a cosmetic
-//! feature into evidence loss. So the pump is byte-oriented throughout, and a
-//! segment that is not valid UTF-8 is scrubbed run-by-run rather than lost.
+//! feature into evidence loss. So the pump is byte-oriented throughout.
+//!
+//! ## One search space, no invented boundaries
+//!
+//! A needle is removed only if the scrubber sees it whole, so every boundary
+//! this module invents is somewhere a credential can hide in two halves. Two
+//! such boundaries existed and both leaked (#5869 review round):
+//!
+//! - The pump used to scrub only the part of its buffer it was about to write,
+//!   so a needle straddling that cut was split, matched neither half, and both
+//!   halves reached the log verbatim. The pump now scrubs the WHOLE buffer and
+//!   cuts the result.
+//! - The mixed-encoding path used to scrub each valid-UTF-8 run separately, so
+//!   one invalid byte injected between a credential's characters split it the
+//!   same way. A needle cannot CONTAIN an invalid byte, but nothing stops one
+//!   being injected INTO it. [`Scrubber::scrub`] now searches the runs
+//!   concatenated — invalid bytes elided — and maps each match back to the
+//!   segment's own byte offsets.
+//!
+//! What survives is a hold-back: bytes at the tail of the buffer that the pump
+//! keeps rather than writes, because a needle that has only PARTLY ARRIVED
+//! cannot be matched yet. That is a bound on the stream, not a boundary in the
+//! search space.
 //!
 //! Test: `super::relay_tests`.
 
@@ -62,12 +83,30 @@ const SEGMENT_LIMIT: usize = 256 * 1024;
 
 /// Most bytes held back across a mid-line flush, whatever the needles say.
 ///
-/// Why: the hold-back exists so a credential straddling a flush is still
-/// matched next round, so it wants to be the longest needle. It must also stay
-/// far below [`SEGMENT_LIMIT`] or the pump stops making progress — it would
-/// re-hold everything it just read. A pathological "secret" longer than this is
-/// bounded here and loses only the straddling case, never the ordinary one.
+/// Why: the hold-back exists so a credential that has only PARTLY ARRIVED is
+/// still matched next round, so it wants to be as long as the longest needle.
+/// It must also stay far below [`SEGMENT_LIMIT`] or the pump stops making
+/// progress — it would re-hold everything it just read. A pathological "secret"
+/// longer than this is bounded here and loses only the partly-arrived case,
+/// never the ordinary one.
+///
+/// It caps the hold-back twice, because the hold-back is counted in two units.
+/// [`Scrubber::held_back`] is a count of TEXT bytes, so that invalid bytes
+/// injected between a needle's characters are retained along with them; this
+/// same value then caps the RAW byte count the tail may reach, so a segment
+/// padded with injected garbage cannot make the pump hold its whole buffer.
+/// Test: `super::relay_tests::an_absurd_needle_cannot_stall_the_pump`.
 const MAX_HELD_BACK: usize = 4096;
+
+/// The token [`scrub_secrets`] leaves in a needle's place.
+///
+/// Why: [`Scrubber::redact_spans`] splices the replacement into a byte buffer
+/// rather than a `str`, which is a thing `scrub_secrets` — `&str` in, `String`
+/// out — cannot express, so this module writes the token itself.
+/// `trusty_common` does not export it, so this restates it.
+/// Test: `super::relay_tests::the_replacement_token_matches_the_redactor`,
+/// which fails the moment the two drift.
+const REDACTED: &[u8] = b"[REDACTED]";
 
 /// The credential values to strip from a child's output.
 ///
@@ -80,7 +119,8 @@ const MAX_HELD_BACK: usize = 4096;
 /// `Arc` bump. An empty set makes [`Scrubber::scrub`] a borrow and the pump's
 /// hold-back zero, so a build with no resolvable credential pays nothing.
 /// Test: `super::relay_tests::a_credential_never_reaches_the_log`,
-/// `super::relay_tests::a_credential_split_across_a_flush_is_still_caught`.
+/// `super::relay_tests::a_credential_straddling_the_flush_cut_is_still_caught`,
+/// `super::relay_tests::a_credential_interrupted_by_an_invalid_byte_is_removed`.
 #[derive(Clone, Debug)]
 pub(crate) struct Scrubber {
     secrets: Arc<[String]>,
@@ -90,10 +130,14 @@ pub(crate) struct Scrubber {
 impl Scrubber {
     /// Build a scrubber over `secrets`, deriving the hold-back from them.
     ///
-    /// What: the hold-back is one byte short of the longest needle — enough
-    /// that any needle straddling a mid-line flush still lies whole inside the
-    /// next segment — capped at [`MAX_HELD_BACK`].
+    /// What: drops the values [`scrub_secrets`] would decline (it applies a
+    /// minimum length, which it does not export — [`Self::qualifies`] asks it
+    /// rather than restating the rule), then takes the hold-back one byte short
+    /// of the longest survivor, capped at [`MAX_HELD_BACK`]. Filtering here is
+    /// what keeps [`Self::redact_spans`], which locates needles itself, from
+    /// removing a value the redactor would have left alone.
     pub(crate) fn over(secrets: Vec<String>) -> Self {
+        let secrets: Vec<String> = secrets.into_iter().filter(|s| Self::qualifies(s)).collect();
         let held_back = secrets
             .iter()
             .map(String::len)
@@ -107,6 +151,18 @@ impl Scrubber {
         }
     }
 
+    /// Whether [`scrub_secrets`] would actually remove `needle`.
+    ///
+    /// Why: `trusty_common` owns the rule for which values are worth redacting
+    /// — too short a needle turns prose into `[REDACTED]` confetti — and keeps
+    /// the threshold private. Asking the redactor what it does to a needle in
+    /// isolation reads the rule without copying it: a value it declines comes
+    /// back unchanged.
+    /// Test: `super::relay_tests::a_needle_the_redactor_declines_is_dropped`.
+    fn qualifies(needle: &str) -> bool {
+        scrub_secrets(needle, std::slice::from_ref(&needle)) != needle
+    }
+
     /// A scrubber that removes nothing, for a caller with no credential to hide.
     #[cfg(test)]
     pub(crate) fn none() -> Self {
@@ -115,28 +171,43 @@ impl Scrubber {
 
     /// `bytes` with every known credential replaced by `[REDACTED]`.
     ///
+    /// # Postconditions
+    /// On return, no needle of `self` occurs in the result — neither
+    /// contiguously nor with invalid bytes injected between its characters.
+    /// Every byte of `bytes` that no needle covers is present unchanged and in
+    /// order; a needle's own bytes, and any invalid bytes injected among them,
+    /// are gone. This holds for the WHOLE of `bytes`: the caller owes it a
+    /// contiguous buffer, because a needle split across two calls is a needle
+    /// neither call can see.
+    ///
     /// Why: the hot path is a log line with no credential in it, run once per
-    /// line for hours. It must not allocate, so a segment that is whole UTF-8
-    /// and matches nothing is returned borrowed.
-    /// What: validates once, then asks each needle whether it occurs; only a hit
-    /// reaches [`scrub_secrets`], the workspace's one redactor. A segment that
-    /// is not valid UTF-8 falls to [`Self::scrub_mixed`] rather than being
-    /// lossily converted, because the log is a verbatim record.
+    /// line for hours. It must not allocate, so a segment that matches nothing
+    /// is returned borrowed — including one holding invalid bytes, which the
+    /// pre-review code always copied.
+    /// What: whole-UTF-8 segments — nearly all of them — take one validation,
+    /// one search, and [`scrub_secrets`], the workspace's one redactor. A
+    /// segment carrying invalid bytes is searched over its valid runs
+    /// CONCATENATED, so a needle those bytes interrupt is still found, and a
+    /// match is spliced back by byte offset rather than lossily converted,
+    /// because the log is a verbatim record where nothing was removed.
     /// Test: `super::relay_tests::a_credential_never_reaches_the_log`,
-    /// `super::relay_tests::a_credential_beside_non_utf8_bytes_is_still_removed`.
+    /// `super::relay_tests::a_credential_beside_non_utf8_bytes_is_still_removed`,
+    /// `super::relay_tests::a_credential_interrupted_by_an_invalid_byte_is_removed`.
     fn scrub<'a>(&self, bytes: &'a [u8]) -> Cow<'a, [u8]> {
         if self.secrets.is_empty() {
             return Cow::Borrowed(bytes);
         }
-        match std::str::from_utf8(bytes) {
-            Ok(text) => {
-                if !self.occurs_in(text) {
-                    return Cow::Borrowed(bytes);
-                }
-                Cow::Owned(scrub_secrets(text, &self.secrets).into_bytes())
+        if let Ok(text) = std::str::from_utf8(bytes) {
+            if !self.occurs_in(text) {
+                return Cow::Borrowed(bytes);
             }
-            Err(_) => Cow::Owned(self.scrub_mixed(bytes)),
+            return Cow::Owned(scrub_secrets(text, &self.secrets).into_bytes());
         }
+        let (text, runs) = utf8_runs(bytes);
+        if !self.occurs_in(&text) {
+            return Cow::Borrowed(bytes);
+        }
+        Cow::Owned(self.redact_spans(bytes, &text, &runs))
     }
 
     /// Whether any needle occurs in `text`.
@@ -148,45 +219,158 @@ impl Scrubber {
         self.secrets.iter().any(|s| text.contains(s.as_str()))
     }
 
-    /// Scrub the valid-UTF-8 runs of `bytes`, passing the invalid bytes through.
+    /// `bytes` with every needle found in `text` cut out by byte offset.
     ///
-    /// Why: a credential is by construction valid UTF-8, so it can never span an
-    /// invalid byte — scrubbing each valid run and copying the invalid bytes
-    /// verbatim removes exactly as much as scrubbing the whole would, while
-    /// keeping the log byte-faithful where the child was not text. Converting
-    /// lossily instead would substitute replacement characters into the one
-    /// artifact a failure is diagnosed from.
-    /// What: walks the segment, splitting at each [`std::str::Utf8Error`], and
-    /// scrubs only the runs on the valid side of the split. An `error_len` of
-    /// `None` is an incomplete trailing sequence, which is copied whole.
-    /// Test: `super::relay_tests::a_credential_beside_non_utf8_bytes_is_still_removed`.
-    fn scrub_mixed(&self, bytes: &[u8]) -> Vec<u8> {
-        let mut out = Vec::with_capacity(bytes.len());
-        let mut rest = bytes;
-        loop {
-            let (valid, tail, skip) = match std::str::from_utf8(rest) {
-                Ok(_) => (rest, &[][..], 0),
-                Err(e) => {
-                    let (valid, tail) = rest.split_at(e.valid_up_to());
-                    (valid, tail, e.error_len().unwrap_or(tail.len()).max(1))
+    /// Why: `text` is the segment's valid-UTF-8 runs concatenated, so a match in
+    /// it can span a gap of invalid bytes — the case that reached the log in the
+    /// clear before the #5869 review. Splicing by offset is what keeps the
+    /// invalid bytes OUTSIDE a match, which are ordinary evidence, while
+    /// dropping the ones INSIDE one, which are part of the credential's span.
+    /// What: matches longest needle first and drops any overlap, mirroring
+    /// [`scrub_secrets`]' own longest-first ordering so a secret that is a
+    /// prefix of another cannot leave the longer one's tail behind. Each match
+    /// is mapped from `text` offsets back to `bytes` offsets through `runs`, and
+    /// the surviving stretches are copied unchanged.
+    /// Test: `super::relay_tests::a_credential_interrupted_by_an_invalid_byte_is_removed`,
+    /// `super::relay_tests::a_credential_beside_non_utf8_bytes_is_still_removed`.
+    fn redact_spans(&self, bytes: &[u8], text: &str, runs: &[Run]) -> Vec<u8> {
+        let mut needles: Vec<&str> = self.secrets.iter().map(String::as_str).collect();
+        needles.sort_unstable_by_key(|s| std::cmp::Reverse(s.len()));
+
+        let mut spans: Vec<(usize, usize)> = Vec::new();
+        for needle in needles {
+            for (at, _) in text.match_indices(needle) {
+                let (start, end) = (at, at + needle.len());
+                if !spans.iter().any(|&(a, b)| a < end && start < b) {
+                    spans.push((start, end));
                 }
-            };
-            // `valid` is UTF-8 by `valid_up_to`, so this conversion never
-            // substitutes anything; it is the no-unwrap spelling of the cast.
-            let text = String::from_utf8_lossy(valid);
-            if self.occurs_in(&text) {
-                out.extend_from_slice(scrub_secrets(&text, &self.secrets).as_bytes());
-            } else {
-                out.extend_from_slice(valid);
-            }
-            let skip = skip.min(tail.len());
-            out.extend_from_slice(&tail[..skip]);
-            rest = &tail[skip..];
-            if rest.is_empty() {
-                return out;
             }
         }
+        spans.sort_unstable();
+
+        let mut out = Vec::with_capacity(bytes.len());
+        let mut cursor = 0usize;
+        for (start, end) in spans {
+            let from = Run::origin_at(runs, start);
+            let to = Run::origin_after(runs, end);
+            out.extend_from_slice(&bytes[cursor..from]);
+            out.extend_from_slice(REDACTED);
+            cursor = to;
+        }
+        out.extend_from_slice(&bytes[cursor..]);
+        out
     }
+
+    /// Where to cut `bytes` so the tail keeps every byte of a needle that has
+    /// only partly arrived.
+    ///
+    /// Why: the pump writes what it cuts off, so anything it cuts through is
+    /// written in the clear. A partly-arrived needle occupies at most
+    /// [`Self::held_back`] bytes of TEXT at the very end of the buffer — but
+    /// invalid bytes injected between its characters make its RAW length longer
+    /// than that, and a raw-byte hold-back would slice its head off. So the walk
+    /// counts text bytes and lets the invalid bytes among them ride along.
+    /// What: walks the valid-UTF-8 runs backwards until the tail holds
+    /// [`Self::held_back`] bytes of text, then clamps the tail to
+    /// [`MAX_HELD_BACK`] raw bytes and to half the buffer, so garbage padding
+    /// can neither unbound the buffer nor stall the pump.
+    /// Test: `super::relay_tests::a_credential_straddling_the_flush_cut_is_still_caught`,
+    /// `super::relay_tests::an_interrupted_credential_straddling_a_cut_is_removed`,
+    /// `super::relay_tests::a_line_that_never_ends_does_not_grow_without_bound`.
+    fn cut_for(&self, bytes: &[u8]) -> usize {
+        if self.held_back == 0 {
+            return bytes.len();
+        }
+        let (_, runs) = utf8_runs(bytes);
+        let mut want = self.held_back;
+        let mut cut = 0usize;
+        for run in runs.iter().rev() {
+            if run.len >= want {
+                cut = run.orig + run.len - want;
+                want = 0;
+                break;
+            }
+            want -= run.len;
+            cut = run.orig;
+        }
+        if want > 0 {
+            // Fewer text bytes in the whole buffer than the hold-back wants.
+            cut = 0;
+        }
+        let hold = (bytes.len() - cut).min(MAX_HELD_BACK).min(bytes.len() / 2);
+        bytes.len() - hold
+    }
+}
+
+/// One maximal run of valid UTF-8 inside a segment.
+///
+/// `text` is the run's offset in the segment's runs CONCATENATED — the space a
+/// needle is searched in; `orig` is its offset in the segment itself.
+#[derive(Clone, Copy, Debug)]
+struct Run {
+    text: usize,
+    orig: usize,
+    len: usize,
+}
+
+impl Run {
+    /// The segment offset of the text byte at `text` offset `at`.
+    fn origin_at(runs: &[Run], at: usize) -> usize {
+        let i = runs.partition_point(|r| r.text <= at).saturating_sub(1);
+        runs[i].orig + (at - runs[i].text)
+    }
+
+    /// The segment offset one past the text byte ending at `text` offset `end`.
+    ///
+    /// Distinct from [`Run::origin_at`] because a match ending exactly at a
+    /// run's end must resolve to that run, not to the next one across the gap —
+    /// resolving forwards would swallow invalid bytes that are not part of it.
+    fn origin_after(runs: &[Run], end: usize) -> usize {
+        let i = runs.partition_point(|r| r.text + r.len < end);
+        runs[i].orig + (end - runs[i].text)
+    }
+}
+
+/// Split `bytes` into its valid-UTF-8 runs, and those runs concatenated.
+///
+/// Why: a needle is valid UTF-8, so it can never CONTAIN an invalid byte — but
+/// nothing stops one being INJECTED INTO it, and the pre-review code split at
+/// every such byte and searched each side alone. The concatenation is the one
+/// contiguous search space a needle is guaranteed to lie inside; the runs are
+/// how a match in it maps back to the segment's own offsets.
+/// What: walks the segment, splitting at each [`std::str::Utf8Error`]. An
+/// `error_len` of `None` is an incomplete trailing sequence, skipped whole.
+/// Runs are non-empty and in stream order, so their `text` offsets increase.
+/// Test: `super::relay_tests::a_credential_interrupted_by_an_invalid_byte_is_removed`.
+fn utf8_runs(bytes: &[u8]) -> (String, Vec<Run>) {
+    let mut text = String::with_capacity(bytes.len());
+    let mut runs: Vec<Run> = Vec::new();
+    let mut at = 0usize;
+    while at < bytes.len() {
+        let rest = &bytes[at..];
+        let (valid_len, skip) = match std::str::from_utf8(rest) {
+            Ok(_) => (rest.len(), 0),
+            Err(e) => (
+                e.valid_up_to(),
+                e.error_len().unwrap_or(rest.len() - e.valid_up_to()).max(1),
+            ),
+        };
+        if valid_len > 0 {
+            runs.push(Run {
+                text: text.len(),
+                orig: at,
+                len: valid_len,
+            });
+            // `valid_up_to` guarantees this borrows rather than substituting;
+            // it is the no-unwrap spelling of the cast.
+            text.push_str(&String::from_utf8_lossy(&rest[..valid_len]));
+        }
+        at += valid_len + skip;
+        if skip == 0 {
+            break;
+        }
+    }
+    (text, runs)
 }
 
 /// Copy `reader` into `log` with credentials removed, forwarding progress lines.
@@ -207,11 +391,18 @@ impl Scrubber {
 /// `[REDACTED]` carries no tab, so the wire format's field count survives.
 ///
 /// A segment that reaches [`SEGMENT_LIMIT`] with no newline is written out
-/// early, minus a hold-back tail long enough that a credential straddling the
-/// cut is matched on the next segment instead. That is what keeps a child
-/// printing one endless line from growing this buffer without bound.
+/// early. The buffer is scrubbed WHOLE and the CUT IS TAKEN FROM THE SCRUBBED
+/// RESULT, so a credential lying across the cut is already gone before there is
+/// a cut to lie across; what the tail holds back is only a needle that has not
+/// finished arriving ([`Scrubber::cut_for`]). Scrubbing the emitted part alone,
+/// as this did before the #5869 review, wrote both halves of a straddling
+/// credential verbatim. Early writing is also what keeps a child printing one
+/// endless line from growing this buffer without bound: it peaks at
+/// [`SEGMENT_LIMIT`] plus [`MAX_HELD_BACK`], with one scrubbed copy of that
+/// alive at a time.
 /// Test: `super::relay_tests::every_non_secret_byte_reaches_the_log_and_events_reach_the_sink`,
-/// `super::relay_tests::a_credential_split_across_a_flush_is_still_caught`,
+/// `super::relay_tests::a_credential_straddling_the_flush_cut_is_still_caught`,
+/// `super::relay_tests::an_interrupted_credential_straddling_a_cut_is_removed`,
 /// `super::relay_tests::a_line_that_never_ends_does_not_grow_without_bound`.
 ///
 /// # Errors
@@ -238,36 +429,47 @@ where
             // EOF. The child was killed mid-line, or simply ended without one;
             // either way what is held is the last thing it managed to say.
             if !pending.is_empty() {
-                emit(&scrubber, &mut log, &progress, &target, &pending).await?;
+                let clean = scrubber.scrub(&pending);
+                emit(&mut log, &progress, &target, &clean).await?;
             }
             break;
         }
         if pending.ends_with(b"\n") {
-            emit(&scrubber, &mut log, &progress, &target, &pending).await?;
+            {
+                let clean = scrubber.scrub(&pending);
+                emit(&mut log, &progress, &target, &clean).await?;
+            }
             pending.clear();
         } else if pending.len() >= SEGMENT_LIMIT {
-            let cut = pending.len() - scrubber.held_back.min(pending.len());
-            emit(&scrubber, &mut log, &progress, &target, &pending[..cut]).await?;
-            pending.drain(..cut);
+            // #5869: scrub the WHOLE buffer, THEN cut it. Cutting first split a
+            // straddling credential into two unmatched halves.
+            let clean = scrubber.scrub(&pending).into_owned();
+            let cut = scrubber.cut_for(&clean);
+            emit(&mut log, &progress, &target, &clean[..cut]).await?;
+            pending.clear();
+            pending.extend_from_slice(&clean[cut..]);
         }
     }
     log.flush().await
 }
 
-/// Scrub one segment, write it, and relay it if it is an event.
+/// Write one ALREADY-SCRUBBED segment, and relay it if it is an event.
+///
+/// Why: every caller scrubs a whole buffer before cutting anything out of it,
+/// so this cannot scrub for them without re-introducing the boundary the
+/// #5869 review found. The contract is therefore on the caller: `clean` is
+/// what [`Scrubber::scrub`] returned, or a prefix of it.
 async fn emit(
-    scrubber: &Scrubber,
     log: &mut tokio::fs::File,
     progress: &Progress,
     target: &str,
-    segment: &[u8],
+    clean: &[u8],
 ) -> std::io::Result<()> {
-    let clean = scrubber.scrub(segment);
-    log.write_all(&clean).await?;
+    log.write_all(clean).await?;
     // `is_active` first: the common segment is ordinary logging, and with no
     // sink attached there is nothing to decode it for.
     if progress.is_active()
-        && let Some(event) = decode(&clean)
+        && let Some(event) = decode(clean)
     {
         progress.unit_stage(target, event);
     }
@@ -447,6 +649,148 @@ mod relay_tests {
             "tail: {:?}",
             &log[log.len() - 40..]
         );
+    }
+
+    /// Why: #5869 review round, CRITICAL 1. The pump used to scrub only the
+    /// part of its buffer it was about to write, so a needle whose start lay in
+    /// `[cut - len + 1, cut - 1]` was split by the cut, matched neither half,
+    /// and BOTH HALVES reached the log verbatim. The reproduction measured a log
+    /// byte-identical in length to its input — not one byte redacted anywhere.
+    /// `a_credential_split_across_a_flush_is_still_caught` passed throughout
+    /// because it starts its key AFTER the cut rather than across it.
+    /// What: the key starts exactly `held_back` bytes before the first cut — the
+    /// adversarial position — and is still removed, because the buffer is
+    /// scrubbed whole before there is a cut to straddle.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn a_credential_straddling_the_flush_cut_is_still_caught() {
+        let scrubber = Scrubber::over(vec![KEY.to_owned()]);
+        // The first cut lands `held_back` from the end of a full segment, so a
+        // key starting `held_back` before that cut lies across it.
+        let cut = SEGMENT_LIMIT - scrubber.held_back;
+        let head = "x".repeat(cut - scrubber.held_back);
+        // Long enough that the newline arrives well after SEGMENT_LIMIT, so the
+        // pump reaches the mid-line flush at all.
+        let tail = format!(" trailing{}\n", "y".repeat(200));
+        let input = format!("{head}{KEY}{tail}");
+        assert!(
+            input.len() > SEGMENT_LIMIT,
+            "the flush path must be reached"
+        );
+
+        let (log, _) = run_bytes(input.as_bytes(), scrubber).await;
+        let log = String::from_utf8(log).expect("text");
+
+        assert_no_fragment_of_the_key(&log);
+        assert!(
+            log.contains("[REDACTED] trailing"),
+            "the key was not replaced"
+        );
+        assert_eq!(log.len(), input.len() - KEY.len() + REDACTED.len());
+    }
+
+    /// Why: #5869 review round, CRITICAL 2. The mixed-encoding path used to
+    /// scrub each valid-UTF-8 run alone. A needle cannot CONTAIN an invalid
+    /// byte, which is what the old reasoning said — but nothing stops one being
+    /// INJECTED INTO it, and after the split neither run held the whole key. The
+    /// reproduction recovered the entire key from two fragments flanking one
+    /// meaningless byte. It needs no long line and no cut alignment.
+    /// What: a key cut in two by a single stray non-UTF-8 byte is removed whole,
+    /// the injected byte goes with it, and the text either side survives.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn a_credential_interrupted_by_an_invalid_byte_is_removed() {
+        let (head, rest) = KEY.split_at(20);
+        let mut input: Vec<u8> = format!("before {head}").into_bytes();
+        input.push(0xff);
+        input.extend_from_slice(format!("{rest} after\n").as_bytes());
+
+        let (log, _) = run_bytes(&input, Scrubber::over(vec![KEY.to_owned()])).await;
+
+        assert_no_fragment_of_the_key(&String::from_utf8_lossy(&log));
+        assert_eq!(log, b"before [REDACTED] after\n".to_vec());
+    }
+
+    /// Why: #5869 review round — the case that catches a partial fix. Removing
+    /// one of the two boundaries leaves the other: a needle both interrupted by
+    /// an invalid byte AND cut in half by the flush is missed by a fix to either
+    /// alone. It is also why the hold-back counts TEXT bytes, not raw ones — the
+    /// arrived prefix here is 50 raw bytes against a 40-byte hold-back, so a
+    /// raw-byte hold-back would slice nine characters of the key off and write
+    /// them.
+    /// What: the segment ends mid-key with garbage injected into the arrived
+    /// prefix; nothing of the key reaches the log, and it is removed whole once
+    /// the rest arrives.
+    /// Test: this is the test.
+    #[tokio::test]
+    async fn an_interrupted_credential_straddling_a_cut_is_removed() {
+        let scrubber = Scrubber::over(vec![KEY.to_owned()]);
+        const GARBAGE: usize = 20;
+        let (head, rest) = KEY.split_at(20);
+        let (middle, last) = rest.split_at(10);
+        // Land the segment boundary exactly at the end of `middle`, so the key
+        // is half-arrived when the pump flushes.
+        let filler = "x".repeat(SEGMENT_LIMIT - head.len() - GARBAGE - middle.len());
+
+        let mut input: Vec<u8> = format!("{filler}{head}").into_bytes();
+        input.extend(std::iter::repeat_n(0xff_u8, GARBAGE));
+        input.extend_from_slice(format!("{middle}{last} trailing\n").as_bytes());
+        assert!(
+            input.len() > SEGMENT_LIMIT,
+            "the flush path must be reached"
+        );
+        assert!(
+            head.len() + GARBAGE + middle.len() > scrubber.held_back,
+            "the arrived prefix must outrun a raw-byte hold-back"
+        );
+
+        let (log, _) = run_bytes(&input, scrubber).await;
+        let log = String::from_utf8(log).expect("only the garbage was invalid, and it went");
+
+        assert_no_fragment_of_the_key(&log);
+        assert_eq!(log, format!("{filler}[REDACTED] trailing\n"));
+    }
+
+    /// No run of the key's characters, at any length worth recovering, is in
+    /// `log`. A whole-key check alone passes on a leak of all but one character.
+    fn assert_no_fragment_of_the_key(log: &str) {
+        for len in [8, 16, 24, 32, KEY.len()] {
+            let fragment = &KEY[..len];
+            assert!(
+                !log.contains(fragment),
+                "a {len}-character fragment of the key reached the log: {fragment}"
+            );
+        }
+    }
+
+    /// Why: [`Scrubber::redact_spans`] writes [`REDACTED`] itself, because
+    /// splicing into bytes is a thing `scrub_secrets` cannot express. The two
+    /// tokens must not drift.
+    /// What: the redactor's own replacement for a qualifying needle is byte-for
+    /// byte what this module writes.
+    /// Test: this is the test.
+    #[test]
+    fn the_replacement_token_matches_the_redactor() {
+        let probe = "0123456789abcdef";
+        assert_eq!(scrub_secrets(probe, &[probe]).as_bytes(), REDACTED);
+    }
+
+    /// Why: this module locates needles itself, so a value it would remove but
+    /// `scrub_secrets` would decline is a value redacted on one path and not the
+    /// other — divergence in a credential filter.
+    /// What: a needle under the redactor's minimum is dropped at construction,
+    /// so it can never reach either path, and the hold-back follows the
+    /// survivors.
+    /// Test: this is the test.
+    #[test]
+    fn a_needle_the_redactor_declines_is_dropped() {
+        assert!(!Scrubber::qualifies(""));
+        assert!(!Scrubber::qualifies("abc"));
+        assert!(Scrubber::qualifies(KEY));
+
+        let mixed = Scrubber::over(vec!["abc".to_owned(), KEY.to_owned()]);
+        assert_eq!(&*mixed.secrets, &[KEY.to_owned()]);
+        assert_eq!(mixed.held_back, KEY.len() - 1);
     }
 
     /// Why: a needle is valid UTF-8, so it cannot span an invalid byte — but a

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -1439,6 +1439,62 @@ trusty-review = "0.15.1"
         }
     }
 
+    /// Why: #5869 — the test above walks the whole root but its stub never
+    /// ECHOES the key, so it passed against a log written verbatim. This is the
+    /// arm that did not hold: a child that prints the credential back, on both
+    /// streams, in the two shapes a real one would — a provider's rejection body
+    /// and a `git` remote URL in a clone failure.
+    /// What: the key reaches neither the log nor any other file the run wrote,
+    /// and the surrounding diagnostic text survives so the log is still useful.
+    /// Test: this is the test.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_child_that_echoes_the_key_does_not_leave_it_in_the_log() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let mut script = String::from(
+            "#!/bin/sh\n\
+             echo \"ERROR 401 from provider: {\\\"message\\\":\\\"key $OPENROUTER_API_KEY \
+             is not valid\\\"}\"\n\
+             echo \"fatal: could not read from \
+             https://x-access-token:$OPENROUTER_API_KEY@github.com/acme/api\" >&2\n",
+        );
+        script.push_str(writes_a_manifest(None).trim_start_matches("#!/bin/sh\n"));
+        install_stubs(&work, &script);
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("the sweep completes");
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+
+        let log = std::fs::read_to_string(&report.repos[0].log).expect("read the child log");
+        assert!(
+            !log.contains("sk-or-v1-not-a-real-key"),
+            "the log carries the key:\n{log}"
+        );
+        // The child really did echo it — otherwise the assertion above proves
+        // nothing about the filter.
+        assert_eq!(
+            log.matches("[REDACTED]").count(),
+            2,
+            "both echoes must be masked, one per stream:\n{log}"
+        );
+        // The log is still a log: masking replaced the key, not the diagnosis.
+        assert!(log.contains("ERROR 401 from provider"), "{log}");
+        assert!(log.contains("github.com/acme/api"), "{log}");
+
+        for path in files_under(work.root()) {
+            let text = std::fs::read_to_string(&path).unwrap_or_default();
+            assert!(
+                !text.contains("sk-or-v1-not-a-real-key"),
+                "{} carries the key",
+                path.display()
+            );
+        }
+    }
+
     /// The CRITICAL arm: `tga audit` exits 0 whenever the sweep COMPLETED,
     /// failed stages included, so a zero exit alone is not evidence anything was
     /// assessed. A child that wrote no manifest audited nothing.

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -65,7 +65,7 @@ use crate::config::{EngagementConfig, ToolPins};
 use crate::error::AuditError;
 use crate::inference;
 use crate::progress::{Operation, Progress, StageEvent, StageState, UnitOutcome};
-use crate::relay::tee_and_relay;
+use crate::relay::{Scrubber, tee_and_relay};
 use crate::tools::{self, RequiredTool};
 use crate::workdir::{Area, WorkDir};
 
@@ -463,6 +463,10 @@ where
     // every repository, so failing per-repo would just repeat one misconfiguration.
     let inference = inference::inference_env(config, operator)?;
     let selected = load_selection(work)?;
+    // #5869: materialized once for the whole sweep — resolving reads
+    // `.env.local` and opens the secure store, which is not a per-child cost,
+    // let alone a per-line one.
+    let scrubber = child_output_scrubber(config);
     // #5494: decided once, against the whole selection, so a repository's fate
     // does not depend on a record another repository's child rewrote meanwhile.
     let plan = checkpoint::plan(work, &selected, options.fresh)?;
@@ -484,6 +488,7 @@ where
                 announce_recollection(&repo.name, &why, progress);
                 run_one(
                     work, config, &binaries, &inference, index, repo, budget, progress, total,
+                    &scrubber,
                 )
                 .await?
             }
@@ -502,6 +507,30 @@ where
     );
     checkpoint::write_progress(work, &RunProgress::finished(&report))?;
     Ok(report)
+}
+
+/// Every credential this process can name, for stripping out of a child's log.
+///
+/// Why: #5869. The `tga audit` child is handed the engagement's OpenRouter key
+/// and spawns `trusty-review` with it, so any of them can echo it into the log —
+/// and the log is both what a human opens to diagnose a failure and what the
+/// planned guided-help path would excerpt into a prompt body sent to OpenRouter.
+/// The needle set is deliberately WIDER than the one key this crate hands over:
+/// a `gh` token embedded in a git remote URL is a different credential from a
+/// different source, and scrubbing only what we passed would miss it.
+/// What: the registry-wide resolved set from
+/// [`trusty_common::credentials::resolved_secret_values`] — the shared entry
+/// point, so a credential added there is scrubbed without this changing — plus
+/// the engagement key, which comes from the config file rather than the
+/// environment and so is not in that set.
+///
+/// This removes only values this process already holds; see [`crate::relay`]
+/// for what that leaves behind.
+/// Test: `super::run_tests::a_child_that_echoes_the_key_does_not_leave_it_in_the_log`.
+fn child_output_scrubber(config: &EngagementConfig) -> Scrubber {
+    let mut secrets = trusty_common::credentials::resolved_secret_values();
+    secrets.push(config.openrouter_key.expose().to_owned());
+    Scrubber::over(secrets)
 }
 
 /// The entries whose fate this run has settled, in selection order.
@@ -566,6 +595,7 @@ async fn run_one(
     budget: std::time::Duration,
     progress: &Progress,
     total: usize,
+    scrubber: &Scrubber,
 ) -> Result<RepoRun, AuditError> {
     let stem = stem(index, &repo.name);
     let output = work.path(Area::Output).join(&stem);
@@ -588,6 +618,7 @@ async fn run_one(
                 budget,
                 progress,
                 &repo.name,
+                scrubber,
             )
             .await?
             {
@@ -711,6 +742,11 @@ pub const PER_REPO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 /// progress lines the child writes on stderr additionally reach `progress`. The
 /// log is unchanged as a record; what changed is that it is no longer the only
 /// place the output goes.
+///
+/// #5869: `scrubber` filters both streams on the way to the log, because the
+/// credential this function puts in the child's environment can come back out
+/// of it — a provider's 401 body, a `git` remote URL in a clone failure. See
+/// [`crate::relay`] for what that filtering can and cannot promise.
 #[allow(clippy::too_many_arguments)]
 async fn spawn_tga(
     binaries: &PinnedBinaries,
@@ -723,6 +759,7 @@ async fn spawn_tga(
     budget: std::time::Duration,
     progress: &Progress,
     target: &str,
+    scrubber: &Scrubber,
 ) -> Result<RepoResult, AuditError> {
     let file = std::fs::File::create(log).map_err(|source| AuditError::WorkDir {
         path: log.to_path_buf(),
@@ -787,6 +824,7 @@ async fn spawn_tga(
             tokio::fs::File::from_std(file),
             progress.clone(),
             target.to_owned(),
+            scrubber.clone(),
         )));
     }
     if let Some(stream) = child.stderr.take() {
@@ -795,6 +833,7 @@ async fn spawn_tga(
             tokio::fs::File::from_std(errors),
             progress.clone(),
             target.to_owned(),
+            scrubber.clone(),
         )));
     }
 


### PR DESCRIPTION
Closes #5869

## The gap was real on today's `main`

`crate::relay::tee_and_relay` wrote every byte it read straight to the log:
`log.write_all(&line).await?`, no filter. The `tga audit` child gets the
OpenRouter credential in its environment (`run.rs`, `ENV_INFERENCE_CREDENTIAL`)
and spawns `trusty-review` with the same, so a 401 body quoted verbatim, a debug
line, or a `git` remote URL in a clone failure put the key in
`work/logs/<repo>.log` in plaintext.

Proved by mutation rather than by reading: reverting `emit` to the verbatim
write makes the new end-to-end test fail with `the log carries the key`.

The existing `the_key_reaches_the_child_by_environment_and_is_never_written_down`
walks every file under the root, but its stub never *echoes* the key — so it
passed against an unfiltered log and says nothing about this.

## What this does

Both piped streams route through `trusty_common::credentials::scrub_secrets`,
the workspace's one redactor. No second redactor is written here; this module
owns only the streaming and segmentation.

The needle set is `resolved_secret_values()` — every credential the registry can
currently resolve — plus the engagement key, which comes from the config file
rather than the environment and so is not in that set. Deliberately wider than
the one key this crate hands over: a `gh` token embedded in a git remote URL is
a different credential from a different source. Resolved once per sweep, shared
by `Arc` across every child and both its pumps.

**The limit, stated rather than implied.** `scrub_secrets` removes only values
this process already holds. A secret the child derived, fetched over the
network, or read from its own config under a name no registry entry knows passes
through untouched. The log is lower-risk, not proven clean. That is in the module
docs and the changelog, not just here.

### Chunk boundaries

The pump already read to each `\n`, so a needle inside one line was never split
by a chunk boundary — an API key contains no newline. The real split is the one
the pump itself creates: bounding the read (below) introduces a flush point
mid-line. Before writing early, the pump holds back a tail one byte shorter than
the longest needle, so a credential straddling the cut lies whole inside the
next segment. `a_credential_split_across_a_flush_is_still_caught` constructs
that boundary deliberately and fails when the hold-back is removed.

### Long lines

`read_until` grows its buffer until a newline arrives, so a child printing one
endless line was an unbounded allocation in a process that runs four hours —
that was already true before this PR. Each read is now bounded by
`SEGMENT_LIMIT` (256 KiB); a segment that reaches it with no newline is written
out early minus the hold-back tail. Peak buffer is `SEGMENT_LIMIT + 4096`,
regardless of what the child prints.

`a_line_that_never_ends_does_not_grow_without_bound` asserts this where it is
observable: bytes reach the log **while the newline-free stream is still open**,
which a buffering pump cannot do. It fails when the flush is removed.

### Non-UTF-8

Not lossily converted — that would substitute replacement characters into the
one artifact a failure is diagnosed from. A needle is by construction valid
UTF-8, so it cannot span an invalid byte: `scrub_mixed` scrubs each valid run
and copies the invalid bytes verbatim. `invalid_utf8_does_not_truncate_the_log`
still asserts byte equality.

### The relay side

Covered by construction rather than separately: the scrub happens before the tee
splits, so the relay decodes the *scrubbed* bytes and a credential quoted inside
a stage detail never reaches the operator's terminal either. `[REDACTED]` carries
no tab, so the wire format's field count survives — asserted by
`a_credential_inside_a_relay_line_is_masked_before_the_sink`.

## Performance

Measured over 16 MB of realistic log text (200k lines), release build:

```
no needles :  5423.3 ms => 3 MB/s
1 needle   :  5573.8 ms => 3 MB/s
4 needles  :  5307.4 ms => 3 MB/s
```

Scrubbing is free at this scale — the differences are noise. The 3 MB/s ceiling
is the per-line `write_all` on the log file, which #5823 introduced and this PR
does not change. A `BufWriter` would lift it but is deliberately not done here:
stdout and stderr are two handles on the same file, and buffering them
separately would scramble their interleaving.

The hot path (a line with no credential) does one UTF-8 validation plus one
`str::contains` per needle, and returns `Cow::Borrowed` — no allocation. An
empty needle set short-circuits before either.

## One test renamed

`every_byte_reaches_the_log_and_events_reach_the_sink` →
`every_non_secret_byte_reaches_the_log_and_events_reach_the_sink`. Its assertion
is unchanged and still byte-equality; the stream it runs holds no credential.
The rename is because the unqualified claim is no longer true with a filter in
the path, and leaving the old name would have it assert one thing and promise
another. `a_childs_stage_events_reach_the_progress_sink` is untouched and passes.

## Gates — rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                     EXIT=0
cargo clippy -p trusty-audit --all-targets -D warnings EXIT=0
cargo test -p trusty-audit                            EXIT=0
  lib:              295 passed; 0 failed; 5 ignored
  binary_names:       3 passed; 0 failed
  cli_end_to_end:     5 passed; 0 failed
  install_fails_closed: 4 passed; 0 failed; 2 ignored
  run_fails_closed:   9 passed; 0 failed
bash scripts/check_line_cap.sh            EXIT=0  (4052 files, 0 violations)
bash scripts/check_sld.sh                 EXIT=0  (0 errors, 0 warnings)
bash scripts/check_test_pointers.sh       EXIT=0  (25365 citations, 0 dangling)
bash scripts/check_changelog_fragment.sh  EXIT=0
```

Rung 3 rather than 4: nothing outside `crates/trusty-audit/src/` changed —
`git diff --name-only origin/main...HEAD` is `relay.rs`, `run.rs`, and the
changelog fragment. `trusty-common` is consumed, not modified.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
