### PR TITLE
feat(website): add the trusty-audit flagship page

### DIFF
--- a/website/src/lib/changelog/README.md
+++ b/website/src/lib/changelog/README.md
@@ -1,7 +1,7 @@
 # The changelog reader
 
 Generates the "What's new" strip on the landing page and the whole `/whats-new`
-page from the six flagship crates' own `CHANGELOG.md` files. Everything here
+page from the released flagship crates' own `CHANGELOG.md` files. Everything here
 runs in Node **at build time**; the published pages are static HTML that reads
 no file and opens no connection.
 
@@ -13,9 +13,12 @@ and organised.** Nothing here writes to, generates, or edits a
 
 ## Scope
 
-Exactly the six crates in `FLAGSHIPS` (`../site.ts`, re-exported from
-`../tools.ts`): `trusty-search`, `trusty-memory`, `trusty-mpm`,
-`trusty-analyze`, `trusty-review`, `trusty-git-analytics`. The other crates'
+Exactly the crates in `RELEASED_FLAGSHIPS` (`../site.ts`, the `FLAGSHIPS`
+entries whose `Tool.released` is true): `trusty-search`, `trusty-memory`,
+`trusty-mpm`, `trusty-analyze`, `trusty-review`, `trusty-git-analytics`.
+`trusty-audit` is a flagship with a page and a card and is deliberately absent:
+it has no release yet, and a section for it would render empty — which is the
+exact state the `CHANGELOG-NO-RELEASES` gate exists to stop. The other crates'
 changelogs are read in the repository by the people who need them; `/whats-new`
 links to `crates/` and stops there.
 
@@ -24,7 +27,7 @@ links to `crates/` and stops there.
 | File        | Responsibility                                                                           |
 | ----------- | ---------------------------------------------------------------------------------------- |
 | `parse.ts`  | One file's markdown → releases. Pure; no I/O, so every failure path is fixturable.       |
-| `site.ts`   | Reads the six files, applies the gates, memoises. The only entry point routes call.      |
+| `site.ts`   | Reads those files, applies the gates, memoises. The only entry point routes call.        |
 | `errors.ts` | The failure vocabulary. Record shape and formatting are shared with `../docs/errors.ts`. |
 
 The remark/rehype pipeline is `../docs/render.ts`. There is deliberately no

--- a/website/src/lib/changelog/site.test.ts
+++ b/website/src/lib/changelog/site.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 
-import { FLAGSHIPS } from '../site';
+import { RELEASED_FLAGSHIPS } from '../site';
 import { findRepoRoot } from '../docs/repo';
 import { ChangelogBuildError } from './errors';
 import {
@@ -20,8 +20,8 @@ import {
  * each gate is provoked here rather than assumed. The real corpus is exercised
  * too, because the grammar deviations that would break it are in the files and
  * not in any fixture.
- * What: one pass over the six real changelogs, then a temp-repo fixture per
- * gate. Each fixture starts from a WORKING repo and breaks exactly one thing,
+ * What: one pass over the released crates' real changelogs, then a temp-repo
+ * fixture per gate. Each fixture starts from a WORKING repo and breaks exactly one thing,
  * so a green assertion means that one change caused the failure.
  * Test: this file.
  */
@@ -47,7 +47,7 @@ function fixture(overrides: Record<string, string | null> = {}): string {
 		path.join(root, 'docs/public-manifest.tsv')
 	);
 
-	for (const flagship of FLAGSHIPS) {
+	for (const flagship of RELEASED_FLAGSHIPS) {
 		if (overrides[flagship.name] === null) continue;
 		const file = path.join(root, 'crates', flagship.name, 'CHANGELOG.md');
 		mkdirSync(path.dirname(file), { recursive: true });
@@ -76,8 +76,8 @@ describe('the real six-crate corpus', () => {
 		site = buildChangelogSite(REPO_ROOT);
 	});
 
-	it('covers exactly the six flagships, in FLAGSHIPS order', () => {
-		expect(site.crates.map((crate) => crate.name)).toEqual(FLAGSHIPS.map((f) => f.name));
+	it('covers exactly the released flagships, in RELEASED_FLAGSHIPS order', () => {
+		expect(site.crates.map((crate) => crate.name)).toEqual(RELEASED_FLAGSHIPS.map((f) => f.name));
 	});
 
 	it('gives every flagship at least one release with at least one item', () => {
@@ -132,15 +132,22 @@ describe('the real six-crate corpus', () => {
 		expect(hrefs.some((href) => href.includes('/blob/main/docs/specs/'))).toBe(true);
 	});
 
-	it('keeps the other 21 crates out of both surfaces', () => {
+	/**
+	 * trusty-audit is a FLAGSHIP with a page and a card, and still absent here:
+	 * it has no release, so `released` is false and the release-driven surfaces
+	 * skip it. Asserting that explicitly is what keeps a future `released: true`
+	 * from silently landing an empty section.
+	 */
+	it('keeps the unreleased flagship and the other crates out of both surfaces', () => {
 		expect(site.crates.map((c) => c.name)).not.toContain('trusty-common');
+		expect(site.crates.map((c) => c.name)).not.toContain('trusty-audit');
 		expect(site.crates).toHaveLength(6);
 	});
 });
 
 describe('the build gates', () => {
 	it('passes on a repository where every flagship is populated', () => {
-		expect(buildChangelogSite(fixture()).crates).toHaveLength(FLAGSHIPS.length);
+		expect(buildChangelogSite(fixture()).crates).toHaveLength(RELEASED_FLAGSHIPS.length);
 	});
 
 	it('fails when a flagship CHANGELOG.md is missing', () => {

--- a/website/src/lib/changelog/site.ts
+++ b/website/src/lib/changelog/site.ts
@@ -5,10 +5,12 @@
  * `/whats-new` would otherwise each re-read and re-parse 8 400 lines of
  * markdown to reach the same answer.
  *
- * Scope is the SIX FLAGSHIPS and only them (`$lib/site`'s `FLAGSHIPS`). The
- * other crates' changelogs are read in the repository by the people who need
- * them; putting 21 more sections on a marketing page would bury the six that
- * a visitor came for.
+ * Scope is the RELEASED FLAGSHIPS and only them (`$lib/site`'s
+ * `RELEASED_FLAGSHIPS`). The other crates' changelogs are read in the
+ * repository by the people who need them; putting 21 more sections on a
+ * marketing page would bury the six that a visitor came for. A flagship that
+ * has never shipped is excluded by the same rule the NO_RELEASES gate below
+ * enforces — it would have nothing to render.
  *
  * THE GATES. Each of these fails the build rather than rendering an empty
  * section, because an empty "What's New" is indistinguishable from "nothing
@@ -26,14 +28,14 @@
  * This runs in Node at BUILD time only. Its output is prerendered into static
  * HTML, so the published page reads no file and opens no connection.
  *
- * Test: `site.test.ts` — the real six-crate corpus builds clean, and each gate
+ * Test: `site.test.ts` — the real released corpus builds clean, and each gate
  * is provoked from a temp-repo fixture.
  */
 
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { FLAGSHIPS } from '../site';
+import { RELEASED_FLAGSHIPS } from '../site';
 import { GITHUB_REPO, findRepoRoot } from '../docs/repo';
 import { CHANGELOG_CODES, throwIfFailed, type ChangelogFailure } from './errors';
 import { parseChangelog, type ChangelogRelease } from './parse';
@@ -93,7 +95,7 @@ export function buildChangelogSite(repoRootOverride?: string): ChangelogSite {
 	const failures: ChangelogFailure[] = [];
 	const crates: CrateChangelog[] = [];
 
-	for (const flagship of FLAGSHIPS) {
+	for (const flagship of RELEASED_FLAGSHIPS) {
 		const source = `crates/${flagship.name}/CHANGELOG.md`;
 		const markdown = readChangelog(repoRoot, source, failures);
 		if (markdown === undefined) continue;
@@ -110,7 +112,7 @@ export function buildChangelogSite(repoRootOverride?: string): ChangelogSite {
 				file: source,
 				problem: 'parsed to zero release sections, so this crate would render an empty section',
 				remedy:
-					'give the file at least one `## [<version>] — <YYYY-MM-DD>` heading, or take the crate out of `FLAGSHIPS` in website/src/lib/site.ts'
+					'give the file at least one `## [<version>] — <YYYY-MM-DD>` heading, or set `released: false` on the crate in website/src/lib/tools.ts'
 			});
 			continue;
 		}
@@ -158,7 +160,7 @@ function readChangelog(
 			file: source,
 			problem: 'a flagship crate has no readable CHANGELOG.md',
 			remedy:
-				'restore the file, or take the crate out of `FLAGSHIPS` in website/src/lib/site.ts — the What’s New page renders no placeholder for a crate it cannot read'
+				'restore the file, or set `released: false` on the crate in website/src/lib/tools.ts — the What’s New page renders no placeholder for a crate it cannot read'
 		});
 		return undefined;
 	}

--- a/website/src/lib/components/ToolPage.svelte
+++ b/website/src/lib/components/ToolPage.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	/**
-	 * Why: the six flagship pages share a hero, an install block, and a
-	 * footer of outbound links. Writing that markup six times would let the
-	 * pages drift apart visually and would repeat the `<svelte:head>` wiring
-	 * six ways. The BODY is not shared — each page writes its own sections
-	 * through the `children` snippet, because the copy is the point.
+	 * Why: the flagship pages share a hero, an install block, and a footer of
+	 * outbound links. Writing that markup once per page would let the pages
+	 * drift apart visually and would repeat the `<svelte:head>` wiring as many
+	 * ways. The BODY is not shared — each page writes its own sections through
+	 * the `children` snippet, because the copy is the point.
 	 *
 	 * What: chrome only. Takes the tool's record from `$lib/tools`, plus the
 	 * facts strip that page wants above the fold.
@@ -13,7 +13,7 @@
 	 * and asserts it loads no third-party subresource.
 	 */
 	import { GITHUB_URL } from '$lib/site';
-	import type { Tool } from '$lib/tools';
+	import { installCommand, type Tool } from '$lib/tools';
 
 	interface Props {
 		tool: Tool;
@@ -73,20 +73,25 @@
 <section class="border-y border-foundry-border bg-foundry-raised">
 	<div class="mx-auto max-w-content px-4 py-16 sm:px-6">
 		<h2 id="install" class="scroll-mt-24 font-display text-2xl font-bold sm:text-3xl">Install</h2>
-		<p class="mt-3 max-w-2xl text-foundry-secondary">
-			<code class="text-sm">tctl</code> resolves whatever else this crate needs at runtime and keeps
-			macOS signing grants stable across upgrades. The
-			<a href="/#install" class="text-foundry-primary underline underline-offset-2"
-				>other install paths</a
-			>
-			— Homebrew, or <code class="text-sm">cargo install</code> from source — are on the home page.
-		</p>
+		{#if tool.install.via === 'tctl'}
+			<p class="mt-3 max-w-2xl text-foundry-secondary">
+				<code class="text-sm">tctl</code> resolves whatever else this crate needs at runtime and
+				keeps macOS signing grants stable across upgrades. The
+				<a href="/#install" class="text-foundry-primary underline underline-offset-2"
+					>other install paths</a
+				>
+				— Homebrew, or <code class="text-sm">cargo install</code> from source — are on the home page.
+			</p>
+		{:else}
+			<p class="mt-3 max-w-2xl text-foundry-secondary">{tool.install.note}</p>
+		{/if}
 		<!-- `min-w-0`: a `<pre>` never wraps, so without it the flex child
 		     widens to the longest command and the page scrolls sideways. -->
 		<div class="mt-6 max-w-xl min-w-0">
 			<pre
-				class="overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-3 text-xs leading-relaxed text-foundry-text">curl -sSf https://raw.githubusercontent.com/bobmatnyc/trusty-tools/main/install.sh | sh
-{tool.install}</pre>
+				class="overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-3 text-xs leading-relaxed text-foundry-text">{installCommand(
+					tool
+				)}</pre>
 		</div>
 		<p class="mt-6 max-w-2xl text-sm text-foundry-secondary">
 			Build and test this crate from a checkout with

--- a/website/src/lib/site.ts
+++ b/website/src/lib/site.ts
@@ -34,12 +34,25 @@ export const NAV_LINKS: { href: string; label: string }[] = [
 ];
 
 /**
- * The six flagship crates, each with a hand-authored page under `/tools/`.
- * The records live in `./tools` because those pages need more per-crate detail
- * than a landing-page card does, and a second copy here would drift.
+ * The flagship crates, each with a hand-authored page under `/tools/` and a
+ * card on the landing page. The records live in `./tools` because those pages
+ * need more per-crate detail than a landing-page card does, and a second copy
+ * here would drift.
  */
 export type Flagship = Tool;
 export const FLAGSHIPS: Flagship[] = TOOLS;
+
+/**
+ * The flagships whose release history drives the "What's new" surfaces — the
+ * strip on each landing-page card, and `/whats-new`.
+ *
+ * Why a subset rather than `FLAGSHIPS`: `$lib/changelog/site` fails the build
+ * for a crate whose `CHANGELOG.md` parses to zero release sections, because an
+ * empty section is indistinguishable from "nothing shipped". trusty-audit is
+ * `publish = false` and has no release tag, so it is carded and paged like the
+ * rest and carries no strip until its first release (`Tool.released`).
+ */
+export const RELEASED_FLAGSHIPS: Flagship[] = FLAGSHIPS.filter((f) => f.released);
 
 export interface CrateGroup {
 	group: string;

--- a/website/src/lib/tools.test.ts
+++ b/website/src/lib/tools.test.ts
@@ -2,15 +2,15 @@ import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { TOOLS } from './tools';
+import { installCommand, TOOLS } from './tools';
 import { STABLE_SET } from './site';
 
 /**
  * Why: the flagship pages assert things about crates. The two claims most
  * likely to rot silently are the ones the reader will act on — the `-p` flag
- * they paste into `cargo test`, and the `tctl install` target — because both
- * look plausible while being wrong. `crates/trusty-git-analytics` is package
- * `tga`, so the directory name is NOT the package name and cannot be assumed.
+ * they paste into `cargo test`, and the install command — because both look
+ * plausible while being wrong. `crates/trusty-git-analytics` is package `tga`,
+ * so the directory name is NOT the package name and cannot be assumed.
  *
  * What: re-derives each record's crate directory, package name, install
  * target, and docs route from the repository rather than from prose.
@@ -27,7 +27,7 @@ const REPO_ROOT = path.resolve(HERE, '../../..');
 
 describe('flagship tool records are grounded in the repository', () => {
 	it('names a crate directory that exists', () => {
-		expect(TOOLS.length).toBe(6);
+		expect(TOOLS.length).toBe(7);
 		for (const tool of TOOLS) {
 			expect(existsSync(path.join(REPO_ROOT, 'crates', tool.name, 'Cargo.toml')), tool.name).toBe(
 				true
@@ -47,10 +47,47 @@ describe('flagship tool records are grounded in the repository', () => {
 		}
 	});
 
-	it('every install command targets a stable-set member', () => {
-		for (const tool of TOOLS) {
-			const target = tool.install.replace('tctl install', '').trim();
+	it('every tctl install command targets a stable-set member', () => {
+		const tctl = TOOLS.filter((tool) => tool.install.via === 'tctl');
+		expect(tctl.length).toBe(TOOLS.length - 1);
+		for (const tool of tctl) {
+			const target = tool.install.via === 'tctl' ? tool.install.target : '';
 			expect(STABLE_SET, `${tool.name} installs ${target}`).toContain(target);
+			// The rendered block is the bootstrap line, then the tctl line.
+			expect(installCommand(tool)).toContain(`\ntctl install ${target}`);
+		}
+	});
+
+	/**
+	 * The one tool tctl does not manage. `trusty-audit` is `publish = false` and
+	 * absent from `stable_set.rs`, so a `tctl install` line on its page would be
+	 * a command that cannot work. Its own bootstrap script is shipped by #5873;
+	 * this asserts the URL SHAPE rather than the file's presence, because the
+	 * script lands in a different PR from this page.
+	 */
+	it('installs trusty-audit from its own bootstrap script, not tctl', () => {
+		const audit = TOOLS.find((tool) => tool.name === 'trusty-audit')!;
+		expect(audit.install.via).toBe('script');
+		expect(installCommand(audit)).toBe(
+			'curl -fsSL https://raw.githubusercontent.com/bobmatnyc/trusty-tools/main/crates/trusty-audit/install.sh | sh'
+		);
+		expect(STABLE_SET).not.toContain('trusty-audit');
+	});
+
+	/**
+	 * `$lib/changelog/site` fails the build for a crate whose CHANGELOG.md
+	 * parses to zero releases, so `released` and the file have to agree: a
+	 * record claiming a release the changelog does not carry breaks the build
+	 * on `/whats-new`, and the reverse silently hides a shipped crate.
+	 */
+	it('marks a tool released only when its CHANGELOG.md carries a release', () => {
+		for (const tool of TOOLS) {
+			const changelog = readFileSync(
+				path.join(REPO_ROOT, 'crates', tool.name, 'CHANGELOG.md'),
+				'utf8'
+			);
+			const hasRelease = /^## \[(?!Unreleased\])/m.test(changelog);
+			expect(tool.released, `${tool.name} CHANGELOG.md`).toBe(hasRelease);
 		}
 	});
 
@@ -84,7 +121,10 @@ describe('flagship tool records are grounded in the repository', () => {
 			'trusty-mpm-telegram',
 			'trusty-memory-core',
 			'TRUSTY_ALLOW_UNLISTED',
-			'search_code'
+			'search_code',
+			// The `taudit` alias still exists in the binary and is being dropped.
+			// No user-facing string may name it: `trusty-audit` everywhere.
+			'taudit'
 		]) {
 			expect(prose, banned).not.toContain(banned);
 		}

--- a/website/src/lib/tools.ts
+++ b/website/src/lib/tools.ts
@@ -1,5 +1,5 @@
 /**
- * Why: the six flagship crates each get a hand-authored page under
+ * Why: the flagship crates each get a hand-authored page under
  * `src/routes/tools/`, and the landing page cards link into them. Keeping the
  * shared per-tool facts here means the card and the page can never disagree
  * about a crate's name, package flag, install command, or docs link.
@@ -18,6 +18,37 @@
  * name, the docs route, and the install target from the repository.
  */
 
+/**
+ * The workspace bootstrap, printed above every `tctl install` line.
+ *
+ * `$lib/site`'s `INSTALL_OPTIONS` carries the same URL for the landing page and
+ * is the copy `site.test.ts` resolves against a tracked file.
+ */
+const TCTL_BOOTSTRAP =
+	'curl -sSf https://raw.githubusercontent.com/bobmatnyc/trusty-tools/main/install.sh | sh';
+
+/**
+ * How a crate is installed, and therefore what its Install section prints.
+ *
+ * Why a union rather than one string: `tctl` manages the crates in
+ * `STABLE_SET`, and trusty-audit is not one of them — it is `publish = false`
+ * and ships its own bootstrap script. Flattening both into a single command
+ * string would leave the tctl prose on a page whose crate tctl cannot install.
+ */
+export type ToolInstall =
+	| {
+			via: 'tctl';
+			/** `tctl install <target>`. Must be a `STABLE_SET` member. */
+			target: string;
+	  }
+	| {
+			via: 'script';
+			/** The crate's own bootstrap one-liner, printed verbatim. */
+			command: string;
+			/** One sentence under the Install heading, in place of the tctl prose. */
+			note: string;
+	  };
+
 export interface Tool {
 	/** Route segment: the page lives at `/tools/<slug>`. */
 	slug: string;
@@ -32,14 +63,38 @@ export interface Tool {
 	points: string[];
 	/** One-line summary for the page hero and its `<meta name="description">`. */
 	lede: string;
-	/** `tctl install` target. Every entry must be a `STABLE_SET` member. */
-	install: string;
+	/** How the page's Install section reads. */
+	install: ToolInstall;
+	/**
+	 * Whether this crate has a published release, and so appears on the
+	 * release-driven surfaces — the card's "What's new" strip and `/whats-new`.
+	 *
+	 * `$lib/changelog/site` fails the build for a crate whose `CHANGELOG.md`
+	 * parses to zero release sections, so a crate that has never shipped cannot
+	 * be in them. trusty-audit is `publish = false` and carries no release tag
+	 * yet; flip this to `true` in the same change that cuts its first release,
+	 * and both surfaces pick it up.
+	 */
+	released: boolean;
 	/**
 	 * The doc reader's page for this crate, at `/docs/tools/<crate>` — a
 	 * different URL from this page by one path segment. `null` for
-	 * trusty-review, which publishes no doc page.
+	 * trusty-review and trusty-audit, which publish no doc page.
 	 */
 	docsPath: string | null;
+}
+
+/**
+ * The command block a tool's Install section prints.
+ *
+ * Why here and not in the component: `tests/build-smoke.test.ts` asserts the
+ * built page contains it, and re-deriving the two-line tctl form there would be
+ * a second implementation of this concatenation.
+ */
+export function installCommand(tool: Tool): string {
+	return tool.install.via === 'tctl'
+		? `${TCTL_BOOTSTRAP}\ntctl install ${tool.install.target}`
+		: tool.install.command;
 }
 
 export const TOOLS: Tool[] = [
@@ -56,7 +111,8 @@ export const TOOLS: Tool[] = [
 			'Branch-aware ranking and caller/callee chain expansion'
 		],
 		lede: 'Three retrieval lanes over one corpus, fused into a single ranking, served by one daemon for every project on the machine.',
-		install: 'tctl install trusty-search',
+		install: { via: 'tctl', target: 'trusty-search' },
+		released: true,
 		docsPath: '/docs/tools/trusty-search'
 	},
 	{
@@ -72,7 +128,8 @@ export const TOOLS: Tool[] = [
 			'A dream cycle that consolidates near-duplicates instead of hoarding them'
 		],
 		lede: 'Long-term memory an assistant can write to and recall from across sessions, organised per project rather than per conversation.',
-		install: 'tctl install trusty-memory',
+		install: { via: 'tctl', target: 'trusty-memory' },
+		released: true,
 		docsPath: '/docs/tools/trusty-memory'
 	},
 	{
@@ -88,7 +145,8 @@ export const TOOLS: Tool[] = [
 			'Remote control from Telegram or Slack when you are away from the terminal'
 		],
 		lede: 'A project manager for coding sessions: it provisions them, watches them, and keeps the roster straight while you work in several at once.',
-		install: 'tctl install trusty-mpm',
+		install: { via: 'tctl', target: 'trusty-mpm' },
+		released: true,
 		docsPath: '/docs/tools/trusty-mpm'
 	},
 	{
@@ -104,7 +162,8 @@ export const TOOLS: Tool[] = [
 			'Tree-sitter adapters for 14 languages, behind one HTTP API and one MCP server'
 		],
 		lede: 'A second daemon that reads trusty-search’s corpus and answers the question search cannot: not where the code is, but how bad it is.',
-		install: 'tctl install trusty-analyze',
+		install: { via: 'tctl', target: 'trusty-analyze' },
+		released: true,
 		docsPath: '/docs/tools/trusty-analyze'
 	},
 	{
@@ -120,7 +179,8 @@ export const TOOLS: Tool[] = [
 			'Skips a review it cannot ground rather than issue a confident guess'
 		],
 		lede: 'A reviewer that reads the rest of the repository before it reads your diff, and says so plainly when it cannot.',
-		install: 'tctl install trusty-review',
+		install: { via: 'tctl', target: 'trusty-review' },
+		released: true,
 		docsPath: null
 	},
 	{
@@ -136,7 +196,32 @@ export const TOOLS: Tool[] = [
 			'CSV, JSON, and Markdown output from one `tga analyze` run'
 		],
 		lede: 'Turns git history into per-author and per-week reporting, with a classification cascade that names the work each commit did.',
-		install: 'tctl install tga',
+		install: { via: 'tctl', target: 'tga' },
+		released: true,
 		docsPath: '/docs/tools/trusty-git-analytics'
+	},
+	{
+		slug: 'trusty-audit',
+		name: 'trusty-audit',
+		cargoPackage: 'trusty-audit',
+		unit: 'UNIT 07',
+		tagline: 'Audit engagements at a client site',
+		points: [
+			'One command downloads the macOS binary, verifies its checksum, and launches it',
+			'Installs and version-pins the tga, trusty-search, trusty-analyze and trusty-review it runs',
+			'Registers GitHub repositories and JIRA or Linear boards, checking each can be read first',
+			'One resumable run — install, clone, audit, package — ending in a zip to send back'
+		],
+		lede: 'The client-side half of an audit engagement: it installs the tooling it pins, collects from the repositories you register, and writes one zip to return to your auditor.',
+		install: {
+			via: 'script',
+			// #5873 adds `crates/trusty-audit/install.sh`; this is the Usage line
+			// the script's own header documents.
+			command:
+				'curl -fsSL https://raw.githubusercontent.com/bobmatnyc/trusty-tools/main/crates/trusty-audit/install.sh | sh',
+			note: 'One command, macOS on Apple Silicon only. It verifies the release tarball against its published SHA-256 before anything reaches your PATH, installs into ${CARGO_HOME:-$HOME/.cargo}/bin with an atomic rename, and then launches the binary.'
+		},
+		released: false,
+		docsPath: null
 	}
 ];

--- a/website/src/routes/+page.server.ts
+++ b/website/src/routes/+page.server.ts
@@ -4,10 +4,11 @@
  * time. Reading it here rather than in the component keeps the page a pure
  * render, and keeps the only filesystem access on the prerender path.
  *
- * What: the newest release of each flagship, flattened to at most three lines.
- * A crate whose changelog is missing, unparseable, or empty stops the build in
- * `$lib/changelog/site` — nothing here substitutes a placeholder, so a page
- * that renders at all has six populated strips.
+ * What: the newest release of each RELEASED flagship, flattened to at most
+ * three lines. A crate whose changelog is missing, unparseable, or empty stops
+ * the build in `$lib/changelog/site` — nothing here substitutes a placeholder,
+ * so every strip a page renders is populated. A flagship with no release yet
+ * (`Tool.released`) produces no strip at all, and its card omits the block.
  *
  * Test: `src/lib/changelog/site.test.ts` (`the landing-page strip`).
  */

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -13,8 +13,9 @@
 	/**
 	 * The strip is keyed by crate name rather than zipped by index so the card
 	 * loop cannot silently pair a crate with another crate's release. Every
-	 * flagship always has one: `$lib/changelog/site` fails the build otherwise,
-	 * so the `{#if}` below satisfies the type, it is not a fallback.
+	 * RELEASED flagship always has one: `$lib/changelog/site` fails the build
+	 * otherwise. The `{#if}` below is for the other kind — a flagship with no
+	 * release yet (`Tool.released`), whose card carries no strip.
 	 */
 	const strips = $derived(new Map(data.strips.map((strip) => [strip.name, strip])));
 
@@ -69,9 +70,9 @@
 		</p>
 		<p class="text-foundry-secondary">
 			Each crate versions, tags, and publishes independently, and everything is MIT licensed. Five
-			of the six flagship tools below speak the Model Context Protocol, so they plug into Claude
-			Code and any other MCP client without a bespoke integration; the sixth is a command-line
-			analytics tool.
+			of the seven flagship tools below speak the Model Context Protocol, so they plug into Claude
+			Code and any other MCP client without a bespoke integration; the other two are command-line
+			tools.
 		</p>
 	</div>
 </section>
@@ -79,7 +80,7 @@
 <!-- FLAGSHIP TOOLS -->
 <section class="mx-auto max-w-content px-4 pb-16 sm:px-6">
 	<h2 id="flagships" class="scroll-mt-24 font-display text-2xl font-bold sm:text-3xl">
-		Six flagship tools
+		Seven flagship tools
 	</h2>
 	<p class="mt-3 max-w-2xl text-foundry-secondary">
 		Each one has its own page — what it does, how it works, and how to install it.
@@ -203,8 +204,12 @@
 <section class="mx-auto max-w-content px-4 py-16 sm:px-6">
 	<h2 id="install" class="scroll-mt-24 font-display text-2xl font-bold sm:text-3xl">Install</h2>
 	<p class="mt-3 max-w-2xl text-foundry-secondary">
-		A bare <code class="text-sm">tctl install</code> brings up the seven managed crates in dependency
-		order. Name one to install just that crate and whatever it needs at runtime.
+		A bare <code class="text-sm">tctl install</code> brings up the eight managed crates in
+		dependency order. Name one to install just that crate and whatever it needs at runtime.
+		trusty-audit is not one of them — it
+		<a href="/tools/trusty-audit" class="text-foundry-primary underline underline-offset-2"
+			>installs itself</a
+		>.
 	</p>
 	<div class="mt-8 grid gap-6 lg:grid-cols-3">
 		{#each INSTALL_OPTIONS as option (option.id)}

--- a/website/src/routes/tools/trusty-audit/+page.svelte
+++ b/website/src/routes/tools/trusty-audit/+page.svelte
@@ -1,0 +1,316 @@
+<script lang="ts">
+	/**
+	 * Why: the reader of this page is an operator at a client company who was
+	 * sent the URL and has to run the engagement today. Every other flagship
+	 * page pitches a tool to someone choosing one; this one is instructions.
+	 * Hence the numbered flow, the prerequisites stated before step 1, and the
+	 * troubleshooting section carrying the installer's real refusals.
+	 *
+	 * What: the four steps `crates/trusty-audit` actually implements — install,
+	 * first run, register targets, audit — then what comes back, then the
+	 * failure modes.
+	 *
+	 * Sourcing: verbs and flags from `src/cli.rs`; the pinned four-tool set from
+	 * `src/tools.rs` (`RequiredTool::ALL`) and `src/config.rs` (`ToolPins`); the
+	 * credential precedence and prompt from `src/cli/credential.rs` (#5872); the
+	 * working-directory layout and defaults from `src/workdir.rs`; the return
+	 * package from `src/package.rs`; the refusals below from `install.sh`
+	 * (#5873). The crate README is a draft here, not a source — it still names
+	 * three pinned tools where the code pins four.
+	 */
+	import ToolPage from '$lib/components/ToolPage.svelte';
+	import { installCommand, TOOLS } from '$lib/tools';
+
+	const tool = TOOLS.find((t) => t.slug === 'trusty-audit')!;
+
+	const facts = [
+		{ label: 'Package', value: 'trusty-audit' },
+		{ label: 'Runs on', value: 'macOS, Apple Silicon' },
+		{ label: 'Needs', value: 'gh, authenticated' },
+		{ label: 'Returns', value: 'audit-return-package.zip' }
+	];
+</script>
+
+<ToolPage {tool} {facts}>
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">What it is</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			An auditor has been engaged to assess your codebase and how your team works in it. Rather than
+			ship your source to them, they send you this: a client-side collector that runs on your
+			machine, inside your network, against repositories you name. It installs the exact audit
+			tooling the engagement pins, runs it, and writes one zip file. You look inside that file, then
+			send it back.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Nothing here is a background service. It runs when you run it, writes everything under a
+			single working directory, and stops. <code class="text-sm">rm -rf</code> on that directory removes
+			everything it wrote.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">Before you start</h2>
+		<ul class="mt-6 max-w-3xl space-y-3 text-foundry-secondary">
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">A Mac with Apple Silicon.</span> The installer
+					refuses an Intel Mac and refuses a non-macOS host, rather than downloading a binary that cannot
+					execute. There is no Windows or Linux build.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text"
+						>The <code class="text-sm">engagement.toml</code> your auditor sent you.</span
+					>
+					It pins the tool versions this engagement runs and carries its instructions. Put it in the directory
+					you will run from, or point at it with
+					<code class="text-sm">--config &lt;FILE&gt;</code>. Without it there is nothing to install
+					and the run refuses.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text"
+						>GitHub, through <code class="text-sm">gh</code>.</span
+					>
+					Repository access uses your own GitHub login: run
+					<code class="text-sm">gh auth login</code> first. Every repository read goes through
+					<code class="text-sm">gh</code>, so whatever your credential can see is what the audit can
+					see, and nothing more.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Board tokens, if boards are in scope.</span
+					>
+					JIRA needs a site URL, an account email, and an API token; Linear needs a personal API key.
+					Both live in <code class="text-sm">engagement.toml</code> under
+					<code class="text-sm">[boards.jira]</code>
+					and <code class="text-sm">[boards.linear]</code>. Skip this if the engagement covers code
+					only.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Outbound access to github.com.</span> Both the
+					installer and the pinned tools download release assets from there. A proxy that blocks binary
+					downloads fails in the first thirty seconds, naming the URL it could not reach.</span
+				>
+			</li>
+		</ul>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">1 · Install</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			One command. It detects your platform, resolves the latest release, downloads the tarball and
+			its published SHA-256 sidecar, refuses to continue if the two disagree, checks the binary
+			actually runs, installs it with an atomic rename, and then launches it.
+		</p>
+		<!-- `min-w-0`: a `<pre>` never wraps, so without it the flex child widens
+		     to the longest command and the page scrolls sideways at 375px. -->
+		<div class="mt-6 max-w-3xl min-w-0">
+			<pre
+				class="overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-4 text-xs leading-relaxed text-foundry-text">{installCommand(
+					tool
+				)}</pre>
+		</div>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			It installs into <code class="text-sm">$&#123;CARGO_HOME:-$HOME/.cargo&#125;/bin</code> and
+			never uses <code class="text-sm">sudo</code>. If that directory is not on your
+			<code class="text-sm">PATH</code>, the installer says so and prints the line to add.
+			Re-running the command upgrades in place.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Three environment variables change what it does:
+			<code class="text-sm">TRUSTY_AUDIT_VERSION</code> pins an exact version instead of taking the
+			latest, <code class="text-sm">TRUSTY_AUDIT_INSTALL_DIR</code> chooses a different destination,
+			and <code class="text-sm">TRUSTY_AUDIT_NO_LAUNCH=1</code> installs without starting the binary.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">2 · First run</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			The audit renders its report through a language model, so it needs an OpenRouter key. Your
+			auditor conveys theirs out of band — it is not in anything you downloaded — or you supply your
+			own OpenRouter account. On the first run that needs it, trusty-audit asks at the terminal,
+			with the typing hidden, and asks twice so a mistyped key is caught immediately.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			What you type is written into <code class="text-sm">engagement.toml</code>, readable only by
+			your account, and it is not asked for again. An
+			<code class="text-sm">OPENROUTER_API_KEY</code> already exported in your shell wins over the file,
+			and the run prints which of the two it used. The key never reaches a log line, an error message,
+			or the package you send back.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			If there is no terminal to ask on — a script, a CI job — it refuses and names both ways to
+			supply a key, rather than hanging or reading whatever happened to be on standard input.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">3 · Register what to audit</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Name each target once. Registration is additive, so you build the set up over several
+			commands, and registering the same thing twice changes nothing.
+		</p>
+		<div class="mt-6 max-w-3xl min-w-0">
+			<pre
+				class="overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-4 text-xs leading-relaxed text-foundry-text">trusty-audit add repo acme/api
+trusty-audit add board jira:ACME
+trusty-audit add board linear:ENG
+trusty-audit targets</pre>
+		</div>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Each <code class="text-sm">add</code> reaches the target with the same credential the audit
+			will use — your
+			<code class="text-sm">gh</code> login for a repository, the configured board token for a board —
+			and refuses one it cannot read. That is deliberate: a target recorded without ever being reached
+			becomes a gap discovered an hour into an unattended run.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			<code class="text-sm">trusty-audit discover</code> lists every repository your GitHub
+			credential can see, marking private and archived ones, if you would rather look before you
+			choose. <code class="text-sm">trusty-audit remove &lt;target&gt;</code> takes one back out.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">4 · Run the audit</h2>
+		<div class="mt-6 max-w-3xl min-w-0">
+			<pre
+				class="overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-4 text-xs leading-relaxed text-foundry-text">trusty-audit audit</pre>
+		</div>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			One command chains four phases. It downloads and version-checks the four tools the engagement
+			pins — tga, trusty-search, trusty-analyze and trusty-review — clones the repositories you
+			registered, sweeps each one, and assembles the return package. Progress prints as it goes,
+			phase by phase and repository by repository.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Expect it to take hours on a large set. You can interrupt it and run the same command again:
+			installed tools, completed clones, and audited repositories are all carried over rather than
+			redone, and each carried-over repository is printed as resumed so a fast re-run does not read
+			as a run that did nothing. <code class="text-sm">--fresh</code> discards that record and audits
+			everything again, which is the expensive direction and has to be asked for by name.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			One repository failing does not stop the rest. The run continues, names every repository it
+			did not cover, and exits non-zero — so a partial engagement can never be mistaken for a whole
+			one, by you or by a shell command chained after it. A repository that produces nothing for
+			four hours is stopped and recorded as a timeout, so a hang costs one repository instead of the
+			whole run.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Everything lands under one directory — <code class="text-sm">./trusty-audit-work</code> by
+			default, or wherever <code class="text-sm">--work-dir</code> points. Clones go in
+			<code class="text-sm">repos/</code>, the pinned binaries in
+			<code class="text-sm">tools/</code>, tool output in <code class="text-sm">logs/</code>, and
+			the deliverable in
+			<code class="text-sm">out/</code>. Clones are shallow and stop starting new ones past 20 GB on
+			disk, so an org-wide audit does not fill the machine.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">What you send back</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			The last line of a finished run is the path to one file:
+			<code class="text-sm">audit-return-package.zip</code>, inside the working directory unless
+			<code class="text-sm">--out</code> named somewhere else. Send that file to your auditor by whatever
+			channel you agreed. Nothing is uploaded for you.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			It is unencrypted and has no password, on purpose: open it and read exactly what you are about
+			to send. Inside are the report directory for each audited repository, the analysis database
+			those reports were computed from, a README describing the contents, and a metadata file naming
+			which repositories were covered and at which tool versions.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Two guarantees hold while the zip is written. The OpenRouter key is scanned for across every
+			member, and a match refuses the whole package rather than quietly dropping one file. A symlink
+			or a hardlink under the collected directories is refused for the same reason — either could
+			pull a file from outside the working directory into an archive that leaves your network.
+		</p>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			The analysis database holds no file contents, no diffs and no patches. It does hold free text
+			— commit messages, pull-request and work-item titles, classification notes — so a snippet
+			someone pasted into one of those is in the file.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="font-display text-2xl font-bold sm:text-3xl">When something refuses</h2>
+		<p class="mt-4 max-w-3xl text-foundry-secondary">
+			Every refusal below leaves nothing installed and nothing half-written. The installer's
+			messages name what failed, why, and what to do; these are the ones you are most likely to see.
+		</p>
+		<ul class="mt-6 max-w-3xl space-y-3 text-foundry-secondary">
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Unsupported operating system.</span> You are
+					not on macOS. There is no asset to download; run it on a Mac.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Unsupported macOS architecture.</span> An Intel
+					Mac. No x86_64 macOS asset is published for any crate in this workspace, and handing you the
+					arm64 one would give you a file that cannot execute.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Checksum mismatch.</span> The download does not
+					match its published digest. Retry once; if it mismatches again, do not use the file — report
+					it against the repository.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Could not reach the releases API.</span>
+					Network or proxy. If you are rate limited, set <code class="text-sm">GITHUB_TOKEN</code>
+					and re-run, or pin a version with <code class="text-sm">TRUSTY_AUDIT_VERSION</code> to skip
+					the lookup.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Install directory is not writable.</span>
+					The installer never uses <code class="text-sm">sudo</code>. Point
+					<code class="text-sm">TRUSTY_AUDIT_INSTALL_DIR</code> at a directory you own.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">Installed, but not launched.</span> There was
+					no terminal to attach, so it printed the command to run yourself rather than starting something
+					that could not prompt you for the key.</span
+				>
+			</li>
+			<li class="flex gap-3">
+				<span aria-hidden="true" class="mt-[0.55em] h-1 w-1 shrink-0 bg-foundry-primary"></span>
+				<span
+					><span class="font-semibold text-foundry-text">A pinned tool will not install.</span> Usually
+					an egress proxy blocking binary downloads. The error names the URL. Allow the GitHub release-asset
+					host, or ask your auditor for a package built for your network — all four tools install or none
+					do, so there is never a half-pinned set.</span
+				>
+			</li>
+		</ul>
+	</div>
+</ToolPage>

--- a/website/src/routes/whats-new/+page.svelte
+++ b/website/src/routes/whats-new/+page.svelte
@@ -6,7 +6,7 @@
 	 * `$lib/changelog` — so `{@html}` is placing markup this build produced from
 	 * six files in this repository, not rendering anything from a request.
 	 *
-	 * What: one section per flagship in `FLAGSHIPS` order, each with
+	 * What: one section per flagship in `RELEASED_FLAGSHIPS` order, each with
 	 * `id="<crate-name>"` so the landing page's "All changes →" lands on it.
 	 * Recent releases carry their items; every older one is listed by version
 	 * and date inside a native `<details>`, which keeps 118 trusty-search

--- a/website/tests/build-smoke.test.ts
+++ b/website/tests/build-smoke.test.ts
@@ -3,7 +3,8 @@ import { existsSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
-import { TOOLS } from '../src/lib/tools';
+import { installCommand, TOOLS } from '../src/lib/tools';
+import { RELEASED_FLAGSHIPS } from '../src/lib/site';
 
 /**
  * Why: every other test here reads source files. None of them prove the site
@@ -179,7 +180,7 @@ describe('production build', () => {
 	it('renders real changelog content on /whats-new, not an empty frame', () => {
 		const html = readFileSync(path.join(STATIC, 'whats-new.html'), 'utf8');
 		const text = visibleText(html);
-		for (const tool of TOOLS) {
+		for (const tool of RELEASED_FLAGSHIPS) {
 			const { version, phrase } = newestRelease(tool.name);
 			expect(html, `${tool.name} has no section anchor`).toContain(`id="${tool.name}"`);
 			expect(text, `${tool.name} is missing version ${version}`).toContain(version);
@@ -190,9 +191,9 @@ describe('production build', () => {
 		}
 	});
 
-	it('renders the What’s new strip on every landing-page card, with real items', () => {
+	it('renders the What’s new strip on every RELEASED landing-page card, with real items', () => {
 		const text = visibleText(landingPage);
-		for (const tool of TOOLS) {
+		for (const tool of RELEASED_FLAGSHIPS) {
 			const { version, phrase } = newestRelease(tool.name);
 			expect(landingPage, `${tool.name} card has no All-changes link`).toContain(
 				`href="/whats-new#${tool.name}"`
@@ -249,10 +250,10 @@ describe('production build', () => {
 
 	// Why: the assertion above proves only that a FILE exists. A page whose
 	// component threw during prerender, or one wired to the wrong `Tool` record,
-	// still writes an HTML shell and still passes it — and with six hand-authored
-	// pages, a copy/paste that leaves two routes rendering the same crate is the
-	// realistic failure, not a missing file. Nothing else in this suite reads a
-	// tool page's body.
+	// still writes an HTML shell and still passes it — and across the
+	// hand-authored pages, a copy/paste that leaves two routes rendering the same
+	// crate is the realistic failure, not a missing file. Nothing else in this
+	// suite reads a tool page's body.
 	// What: for each `TOOLS` entry, re-derives what that page must contain from
 	// the same record the page renders from, and pins it to the route's own
 	// artifact — the `<h1>` must name THAT crate, and the unit stamp, tagline,
@@ -266,7 +267,7 @@ describe('production build', () => {
 			expect(heading, `${file} has no <h1>`).not.toBeNull();
 			expect(heading?.[1], `${file} <h1>`).toContain(tool.name);
 
-			for (const copy of [tool.unit, tool.tagline, tool.lede, tool.install]) {
+			for (const copy of [tool.unit, tool.tagline, tool.lede, installCommand(tool)]) {
 				expect(html, `${file} is missing ${JSON.stringify(copy)}`).toContain(copy);
 			}
 			if (tool.docsPath) {
@@ -301,6 +302,19 @@ describe('production build', () => {
 
 		const toolPage = readFileSync(path.join(STATIC, 'tools/trusty-git-analytics.html'), 'utf8');
 		expect(toolPage, 'tool page does not link the audit page').toContain(`href="${AUDIT_ROUTE}"`);
+	});
+
+	/**
+	 * Why: the binary still ships under both `trusty-audit` and `taudit`, and the
+	 * alias is being dropped. `src/lib/tools.test.ts` guards the RECORDS; this
+	 * guards the rendered PAGES, which is where the prose actually lives.
+	 * What: every built tool page's visible text, checked for the alias.
+	 */
+	it('names no retired binary alias in any tool page', () => {
+		for (const name of [...toolPages(), AUDIT_PAGE]) {
+			const text = visibleText(readFileSync(path.join(STATIC, name), 'utf8'));
+			expect(text, `${name} names the taudit alias`).not.toContain('taudit');
+		}
 	});
 
 	it('loads no subresource from a third-party origin', () => {
@@ -355,7 +369,7 @@ describe('production build', () => {
 
 	it('renders real landing-page content, not a shell', () => {
 		expect(landingPage).toContain('trusty-search');
-		expect(landingPage).toContain('Six flagship tools');
+		expect(landingPage).toContain('Seven flagship tools');
 		expect(landingPage).toContain('brew tap bobmatnyc/trusty');
 		for (const tool of TOOLS) {
 			expect(landingPage, tool.slug).toContain(`/tools/${tool.slug}`);


### PR DESCRIPTION
Adds `/tools/trusty-audit`, the seventh flagship page. It is written for the operator at a client company who was sent the URL and has to run the engagement: prerequisites first, then install, first run, register targets, run, what comes back, and the installer's real refusals.

## Two dependencies a reviewer needs to know

- **The install command comes from #5873**, which adds `crates/trusty-audit/install.sh`. That PR is open and not on main. The command block matches the Usage line in the script's own header; `tools.test.ts` asserts the URL *shape*, deliberately not the file's presence, because the script lands in a different PR.
- **The first-run credential prompt comes from #5872**, also open. The "2 · First run" section describes `src/cli/credential.rs` on that branch: `/dev/tty` not stdin, typed twice, `OPENROUTER_API_KEY` beats the config, persisted at 0600, no terminal is a refusal rather than a hang.
- **No trusty-audit release exists yet, so the download is dead until the first `trusty-audit-v*` tag.** The page is written for the steady state; merge sequencing is the PM's call, not the page's.

## What had to change beyond the page

trusty-audit is `publish = false`, absent from `stable_set.rs`, and has no release. Two assumptions baked into the shared model had to become explicit:

- `Tool.install` is now a union — `{ via: 'tctl', target }` or `{ via: 'script', command, note }`. A `tctl install trusty-audit` line would be a command that cannot work, and `ToolPage.svelte` was printing the tctl prose unconditionally.
- `Tool.released` says whether the release-driven surfaces cover a crate. `$lib/changelog/site` fails the build for a crate whose CHANGELOG.md parses to zero releases, so trusty-audit cannot be in them today. `RELEASED_FLAGSHIPS` (`$lib/site`) is the subset `/whats-new` and the card strip read; the landing page cards all seven. Flip `released` to `true` in the change that cuts the first release and both surfaces pick it up — `tools.test.ts` now asserts the flag agrees with the crate's CHANGELOG.md, so the two cannot drift.

Landing-page copy follows: "Seven flagship tools", five of seven speak MCP, and the install section's "seven managed crates" corrected to eight (`STABLE_SET` has had eight members since #5805).

## Naming

`trusty-audit` everywhere. The `taudit` alias exists in the binary and is being dropped by owner ruling, so `tools.test.ts` bans the string in the records and `build-smoke.test.ts` bans it in every built tool page.

## Accuracy

Every command, flag, path and refusal was checked against crate source, not the README — `README.md` still names three pinned tools where `RequiredTool::ALL` and `ToolPins` pin four (tga, trusty-search, trusty-analyze, trusty-review). The page states the `engagement.toml` prerequisite the brief did not: `install` and `audit` refuse without it, because the tool pins are required and have no default.

## Gates

Test ladder **rung 6** by surface (UI), website-only — no Rust gate applies, and no changelog fragment (`crates/*/src` untouched).

```
pnpm test        (from inside website/)
  Test Files  1 failed | 13 passed (14)
       Tests  10 failed | 242 passed (252)

pnpm build
  ✓ built in 7.05s        BUILD_EXIT=0

pnpm run check   (svelte-check)
  COMPLETED 491 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
```

The 10 failures are all `src/lib/theme/theme.test.ts`, every one of them:

```
TypeError: Cannot read properties of undefined (reading 'clear')
 ❯ src/lib/theme/theme.test.ts:40:16
     40|   localStorage.clear();
```

Pre-existing and environmental — the exact case CLAUDE.md records ("The workflow runs Node 20; a newer local Node can report spurious `localStorage` failures in `theme.test.ts`"); this machine is on Node v26. `git diff --name-only origin/main...HEAD -- website/src/lib/theme/` is empty.

`tests/build-smoke.test.ts` runs two real production builds and passes, which is what proves the seven pages prerender, each renders from its own record, `/whats-new` still carries real changelog content for the six released crates, and no page loads a third-party subresource.

Not fixed here: `pnpm run lint` reports a pre-existing prettier drift in `src/routes/tools/trusty-git-analytics/audit/+page.svelte`. Reverted rather than folded in — CI runs `pnpm run test` only, and it is unrelated to this page.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
