### PR TITLE
feat(trusty-audit): collect a registered board instead of reporting it as a gap (#5857)

### DIFF
--- a/crates/trusty-audit/changelog.d/5857-board-credentials-changed.md
+++ b/crates/trusty-audit/changelog.d/5857-board-credentials-changed.md
@@ -12,6 +12,11 @@ Changed
   key, as it already did for the OpenRouter key. Those two secrets now travel to
   a `tga audit` child, and the files that child writes are the files the package
   sends off the recipient's network.
+- The child-log scrubber strips the board credentials too. It built its needles
+  from the registered providers plus the OpenRouter key, and no provider there
+  is a board, so a `tga` child quoting a JIRA token in an auth error wrote it to
+  `work/logs/<repo>.log` in the clear. The packaging guard and the scrubber now
+  draw their secrets from one list on `EngagementConfig`.
 - `taudit audit` reads the target registry once. It used to read it again when
   the sweep started, hours later on a real engagement, so a board removed
   between the two reads left the report claiming coverage while nothing

--- a/crates/trusty-audit/changelog.d/5857-board-credentials-changed.md
+++ b/crates/trusty-audit/changelog.d/5857-board-credentials-changed.md
@@ -8,3 +8,11 @@ Changed
 - A board is still stated as a gap when the engagement config carries no
   credential for its provider, and when a second JIRA project is registered —
   `tga`'s `jira.project_key` holds one.
+- The return package refuses a file carrying the JIRA token or the Linear API
+  key, as it already did for the OpenRouter key. Those two secrets now travel to
+  a `tga audit` child, and the files that child writes are the files the package
+  sends off the recipient's network.
+- `taudit audit` reads the target registry once. It used to read it again when
+  the sweep started, hours later on a real engagement, so a board removed
+  between the two reads left the report claiming coverage while nothing
+  collected it — a zero exit over an engagement that skipped a registered board.

--- a/crates/trusty-audit/changelog.d/5857-board-credentials-changed.md
+++ b/crates/trusty-audit/changelog.d/5857-board-credentials-changed.md
@@ -1,0 +1,10 @@
+Changed
+
+- The board credential reaches `tga` the way the OpenRouter key already does:
+  the generated `state/tga-<stem>.yaml` carries `${TRUSTY_AUDIT_JIRA_TOKEN}` /
+  `${TRUSTY_AUDIT_LINEAR_API_KEY}`, and the sweep puts the real value in the
+  child's environment. No secret is written to a file. An unset variable is a
+  `tga` config error naming the field, not a silent unauthenticated read.
+- A board is still stated as a gap when the engagement config carries no
+  credential for its provider, and when a second JIRA project is registered —
+  `tga`'s `jira.project_key` holds one.

--- a/crates/trusty-audit/changelog.d/5857-boards-reach-the-sweep.md
+++ b/crates/trusty-audit/changelog.d/5857-boards-reach-the-sweep.md
@@ -1,0 +1,7 @@
+Added
+
+- A registered board is now collected instead of reported as a gap. `jira:ACME`
+  or `linear:ENG` becomes a `jira:` / `linear:` section on each generated tga
+  config, so `tga audit` syncs the board alongside the repositories. Registering
+  a board previously stated it as a gap and held the whole engagement at a
+  non-zero exit.

--- a/crates/trusty-audit/src/chain.rs
+++ b/crates/trusty-audit/src/chain.rs
@@ -30,6 +30,15 @@
 //! [`run::boards`] owns that split. A board with no credential in the engagement
 //! config is still a gap, and still reported rather than dropped.
 //!
+//! The registry is read ONCE per [`audit`], in the materialize phase. The gaps
+//! that reach the return package and the board sections that reach each child
+//! come out of that single read: [`split_targets`] resolves, and [`collect`]
+//! forwards the result to [`run::sweep_with_boards`] rather than loading the
+//! registry again. Reading it twice is what the phases below make dangerous —
+//! tool install and every clone sit between them, so the two reads are an
+//! engagement's wall clock apart and a `taudit remove board` in another terminal
+//! lands cleanly inside the window (#5857).
+//!
 //! ## Partial success is the normal case, and it is not success
 //!
 //! With six repositories, one failing is ordinary. The chain CONTINUES past it,
@@ -213,8 +222,13 @@ pub async fn audit(
         .await
         .map_err(|e| stopped(Phase::InstallTools, e))?;
 
-    let (repos, mut gaps) =
+    // #5857: the registry is read ONCE for this whole invocation. `collect` is
+    // handed the resolution rather than repeating it, because the phases below
+    // span an engagement's worth of wall clock and the registry is a file
+    // another terminal can edit.
+    let (repos, boards) =
         split_targets(work, &config.boards).map_err(|e| stopped(Phase::Materialize, e))?;
+    let mut gaps = boards.gaps.clone();
     let acquired = materialize(work, &repos, progress)
         .await
         .map_err(|e| stopped(Phase::Materialize, e))?;
@@ -225,7 +239,7 @@ pub async fn audit(
         gaps.extend(acquired.gaps.iter().cloned());
     }
 
-    let run = collect(work, config, options, progress)
+    let run = collect(work, config, options, &boards, progress)
         .await
         .map_err(|e| stopped(Phase::Collect, e))?;
 
@@ -278,20 +292,20 @@ async fn install(
 ///
 /// Why: a registered BOARD used to land here as an unconditional gap — the
 /// wiring simply stopped at the repository arm (#5857). It now goes to
-/// [`run::boards::resolve`], the same call [`run::sweep`] makes when it
-/// generates each child's config, so the gap this states and the coverage that
-/// child gets are one decision rather than two that can disagree. What is left
-/// as a gap is narrow: a board whose provider has no credential in the
-/// engagement config, and a second JIRA project (tga's `jira.project_key` holds
-/// one).
-/// What: repositories by name for [`materialize`], and the resolver's gap lines
-/// verbatim.
+/// [`run::boards::resolve`], and the WHOLE resolution is returned rather than
+/// only its gap lines, because [`audit`] hands it to [`collect`]: the gaps this
+/// states and the sections that child gets are then one decision made once, not
+/// two reads of a mutable file hours apart. What is left as a gap is narrow: a
+/// board whose provider has no credential in the engagement config, and a second
+/// JIRA project (tga's `jira.project_key` holds one).
+/// What: repositories by name for [`materialize`], and the resolution itself.
 /// Test: `super::chain_tests::a_registered_board_with_a_credential_is_collected`,
-/// `super::chain_tests::a_board_with_no_configured_credential_is_still_a_gap`.
+/// `super::chain_tests::a_board_with_no_configured_credential_is_still_a_gap`,
+/// `super::chain_tests::a_board_removed_after_the_chain_resolved_it_still_reaches_the_child`.
 fn split_targets(
     work: &WorkDir,
     credentials: &BoardCredentials,
-) -> Result<(Vec<String>, Vec<String>), AuditError> {
+) -> Result<(Vec<String>, run::boards::Boards), AuditError> {
     let registry = Registry::load(work)?;
     let repos = registry
         .targets()
@@ -301,10 +315,7 @@ fn split_targets(
             Target::Board { .. } => None,
         })
         .collect();
-    Ok((
-        repos,
-        run::boards::resolve(registry.targets(), credentials).gaps,
-    ))
+    Ok((repos, run::boards::resolve(registry.targets(), credentials)))
 }
 
 /// Phase 2 — turn what is registered into checkouts the sweep can read.
@@ -358,21 +369,26 @@ async fn materialize(
 ///
 /// A repository that FAILED among others that succeeded is not this case — that
 /// package is worth sending and names what it omits.
-/// What: [`run::sweep`] unchanged, then the status check.
+/// What: [`run::sweep_with_boards`], then the status check. `boards` is
+/// [`split_targets`]'s resolution, forwarded so the sweep does not read the
+/// registry a second time — see that function and [`audit`].
 /// Test: `super::chain_tests::a_sweep_that_audited_nothing_stops_before_packaging`,
-/// `super::chain_tests::a_partly_failed_chain_packages_and_still_does_not_exit_zero`.
+/// `super::chain_tests::a_partly_failed_chain_packages_and_still_does_not_exit_zero`,
+/// `super::chain_tests::a_board_removed_after_the_chain_resolved_it_still_reaches_the_child`.
 async fn collect(
     work: &WorkDir,
     config: &EngagementConfig,
     options: &ChainOptions,
+    boards: &run::boards::Boards,
     progress: &Progress,
 ) -> Result<RunReport, AuditError> {
-    let report = run::sweep(
+    let report = run::sweep_with_boards(
         work,
         config,
         &RunOptions {
             fresh: options.fresh,
         },
+        boards,
         progress,
     )
     .await?;
@@ -757,6 +773,55 @@ trusty-review = "0.15.1"
             Outcome::Audit(report).exit_code(),
             0,
             "an unaudited target must not exit zero even when the sweep was clean"
+        );
+    }
+
+    /// The registry is read ONCE per `audit`, so nothing that happens to it
+    /// afterwards can move the coverage away from what the report states.
+    ///
+    /// Why this is worth a test: `audit` states its board gaps in the Materialize
+    /// phase and the sweep runs after tool install and every clone — an
+    /// hour-scale window. A `taudit remove board jira:ACME` inside it used to
+    /// leave the report claiming coverage (no gap) while the child got no `jira:`
+    /// section at all, and the engagement exited 0 having never read the board.
+    ///
+    /// Against `5a615fe0e` this fails on the `project_key: ACME` assertion:
+    /// `run::sweep` called `Registry::load` a second time and found nothing.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_board_removed_after_the_chain_resolved_it_still_reaches_the_child() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = prepared(tmp.path(), &["acme-api"], &["acme-api"]);
+        register_boards(&work, &["jira:ACME"]);
+        let config = config_with_jira();
+
+        // Phase 2's half of `audit`: the one resolution, stating no gap.
+        let (_repos, boards) = split_targets(&work, &config.boards).expect("splits");
+        assert!(boards.gaps.is_empty(), "{:?}", boards.gaps);
+
+        // The window: install and every clone happen here, and a concurrent
+        // `taudit remove board` lands inside it.
+        Registry::default().save(&work).expect("writes");
+
+        // Phase 3, driven exactly as `audit` drives it.
+        let report = collect(
+            &work,
+            &config,
+            &ChainOptions::default(),
+            &boards,
+            &Progress::none(),
+        )
+        .await
+        .expect("the sweep runs");
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+
+        let generated =
+            std::fs::read_to_string(work.path(Area::State).join("tga-00-acme-api.yaml"))
+                .expect("the generated tga config");
+        assert!(
+            generated.contains("project_key: ACME"),
+            "the report stated no gap for jira:ACME, so the child must have \
+             collected it: {generated}"
         );
     }
 

--- a/crates/trusty-audit/src/chain.rs
+++ b/crates/trusty-audit/src/chain.rs
@@ -23,8 +23,12 @@
 //! records the usable checkouts as the selection. A registered repository now
 //! reaches the sweep because it was registered.
 //!
-//! A registered BOARD does not, and is reported as a gap rather than dropped —
-//! see [`board_gap`] for what passing one through would cost today.
+//! A registered BOARD reaches it too, since #5857. It is not a unit of the
+//! sweep — there is nothing to clone — so it becomes a `jira:` or `linear:`
+//! section on every child's generated config, with its credential referenced as
+//! `${TRUSTY_AUDIT_JIRA_TOKEN}` and delivered through the child's environment.
+//! [`run::boards`] owns that split. A board with no credential in the engagement
+//! config is still a gap, and still reported rather than dropped.
 //!
 //! ## Partial success is the normal case, and it is not success
 //!
@@ -63,7 +67,7 @@ use std::fmt;
 use std::path::PathBuf;
 
 use crate::clone::{self, CloneOptions, CloneReport};
-use crate::config::EngagementConfig;
+use crate::config::{BoardCredentials, EngagementConfig};
 use crate::error::AuditError;
 use crate::package::{self, ReturnPackage};
 use crate::progress::{Operation, Progress, UnitOutcome};
@@ -157,10 +161,11 @@ pub struct ChainReport {
     pub package: ReturnPackage,
     /// What this engagement targets and the chain never attempted.
     ///
-    /// Two sources: a registered board, which [`board_gap`] explains, and a
-    /// registered repository that failed to clone. Neither reaches the sweep, so
-    /// neither can appear among [`RunReport::failures`] — which is why the chain
-    /// carries them itself rather than deriving everything from the sweep.
+    /// Two sources: a registered board [`run::boards::resolve`] could not turn
+    /// into a config section, and a registered repository that failed to clone.
+    /// Neither reaches the sweep, so neither can appear among
+    /// [`RunReport::failures`] — which is why the chain carries them itself
+    /// rather than deriving everything from the sweep.
     ///
     /// [`ReturnPackage::excluded`] is the superset: these lines PLUS the
     /// repositories the sweep attempted and failed. Non-empty here makes the
@@ -208,7 +213,8 @@ pub async fn audit(
         .await
         .map_err(|e| stopped(Phase::InstallTools, e))?;
 
-    let (repos, mut gaps) = split_targets(work).map_err(|e| stopped(Phase::Materialize, e))?;
+    let (repos, mut gaps) =
+        split_targets(work, &config.boards).map_err(|e| stopped(Phase::Materialize, e))?;
     let acquired = materialize(work, &repos, progress)
         .await
         .map_err(|e| stopped(Phase::Materialize, e))?;
@@ -269,37 +275,36 @@ async fn install(
 
 /// The registered repositories, and one gap line per target the chain cannot
 /// audit.
-fn split_targets(work: &WorkDir) -> Result<(Vec<String>, Vec<String>), AuditError> {
-    let registry = Registry::load(work)?;
-    let mut repos = Vec::new();
-    let mut gaps = Vec::new();
-    for target in registry.targets() {
-        match target {
-            Target::Repo { name_with_owner } => repos.push(name_with_owner.clone()),
-            Target::Board { .. } => gaps.push(board_gap(target)),
-        }
-    }
-    Ok((repos, gaps))
-}
-
-/// Why a registered board is a gap rather than a collected dimension.
 ///
-/// Why: `tga audit` does take a board — its config has a `jira:` section and it
-/// runs a `JiraSync` stage — but tga reads that section's `token` as a literal
-/// string, with none of the `${VAR}` expansion its Linear and Azure DevOps
-/// clients apply (`tga::collect::env_expand::expand_env_var`). Passing a JIRA
-/// board through today therefore means writing the board credential into the
-/// generated `state/tga-<stem>.yaml`, and this crate's whole credential posture
-/// is that a secret reaches a child through its environment and never through a
-/// file (DOC-68 §13, `crate::run`'s module docs). The chain states the gap
-/// instead, and the durable fix is env-var expansion on tga's JIRA credential.
-/// What: one line naming the board, safe to show the recipient.
-/// Test: `super::chain_tests::a_registered_board_is_stated_as_a_gap`.
-fn board_gap(target: &Target) -> String {
-    format!(
-        "{target} was not audited — this client cannot pass a board to `tga audit` without \
-         writing its credential to a file, which it will not do (#5824)"
-    )
+/// Why: a registered BOARD used to land here as an unconditional gap — the
+/// wiring simply stopped at the repository arm (#5857). It now goes to
+/// [`run::boards::resolve`], the same call [`run::sweep`] makes when it
+/// generates each child's config, so the gap this states and the coverage that
+/// child gets are one decision rather than two that can disagree. What is left
+/// as a gap is narrow: a board whose provider has no credential in the
+/// engagement config, and a second JIRA project (tga's `jira.project_key` holds
+/// one).
+/// What: repositories by name for [`materialize`], and the resolver's gap lines
+/// verbatim.
+/// Test: `super::chain_tests::a_registered_board_with_a_credential_is_collected`,
+/// `super::chain_tests::a_board_with_no_configured_credential_is_still_a_gap`.
+fn split_targets(
+    work: &WorkDir,
+    credentials: &BoardCredentials,
+) -> Result<(Vec<String>, Vec<String>), AuditError> {
+    let registry = Registry::load(work)?;
+    let repos = registry
+        .targets()
+        .iter()
+        .filter_map(|target| match target {
+            Target::Repo { name_with_owner } => Some(name_with_owner.clone()),
+            Target::Board { .. } => None,
+        })
+        .collect();
+    Ok((
+        repos,
+        run::boards::resolve(registry.targets(), credentials).gaps,
+    ))
 }
 
 /// Phase 2 — turn what is registered into checkouts the sweep can read.
@@ -679,24 +684,75 @@ trusty-review = "0.15.1"
         assert_eq!(report.run.repos.len(), 1);
     }
 
-    /// A registered board is something this engagement targets and this chain
-    /// cannot audit. Dropping it silently would leave the recipient sending a
-    /// package that claims to cover an engagement it does not.
+    /// Register boards the way `taudit add board` does.
+    fn register_boards(work: &WorkDir, specs: &[&str]) {
+        let mut targets = Registry::default();
+        for spec in specs {
+            targets.insert(registry::parse(Some(TargetKind::Board), spec).expect("parses"));
+        }
+        targets.save(work).expect("writes");
+    }
+
+    /// An engagement carrying the JIRA credential the registered board needs.
+    fn config_with_jira() -> EngagementConfig {
+        let text = format!(
+            "{CONFIG}\n[boards.jira]\nurl = \"https://acme.atlassian.net\"\n\
+             email = \"auditor@acme.example\"\ntoken = \"jira-token-never-on-disk\"\n"
+        );
+        EngagementConfig::from_toml(&text, Path::new("engagement.toml")).expect("parses")
+    }
+
+    /// #5857's whole point: a registered board with a credential is COLLECTED.
+    /// It contributes no gap, so a clean sweep over it exits zero.
+    ///
+    /// Against `origin/main` this fails on the gap assertion: `split_targets`
+    /// turned every board into a gap line unconditionally, and the non-zero exit
+    /// that followed made `taudit audit && send-it` refuse a whole engagement.
     #[cfg(unix)]
     #[tokio::test]
-    async fn a_registered_board_is_stated_as_a_gap() {
+    async fn a_registered_board_with_a_credential_is_collected() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let work = prepared(tmp.path(), &["acme-api"], &["acme-api"]);
-        let mut registry = Registry::default();
-        registry.insert(registry::parse(Some(TargetKind::Board), "jira:ACME").expect("parses"));
-        registry.save(&work).expect("writes");
+        register_boards(&work, &["jira:ACME"]);
 
+        let report = audit(
+            &work,
+            &config_with_jira(),
+            &ChainOptions::default(),
+            true,
+            &Progress::none(),
+        )
+        .await
+        .expect("the chain runs");
+
+        assert!(report.gaps.is_empty(), "{:?}", report.gaps);
+        assert!(report.package.excluded.is_empty(), "{:?}", report.package);
+        assert_eq!(
+            Outcome::Audit(report).exit_code(),
+            0,
+            "a collected board must not hold the engagement at a non-zero exit"
+        );
+    }
+
+    /// The one board case still stated as a gap: registered, but the engagement
+    /// config carries no credential for its provider. Dropping it silently would
+    /// leave the recipient sending a package that claims to cover an engagement
+    /// it does not.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_board_with_no_configured_credential_is_still_a_gap() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = prepared(tmp.path(), &["acme-api"], &["acme-api"]);
+        register_boards(&work, &["jira:ACME"]);
+
+        // `config()` names no `[boards]` table at all.
         let report = run_chain(&work, &Progress::none())
             .await
             .expect("the chain runs");
 
         assert_eq!(report.gaps.len(), 1, "{:?}", report.gaps);
         assert!(report.gaps[0].contains("jira:ACME"), "{:?}", report.gaps);
+        assert!(report.gaps[0].contains("boards.jira"), "{:?}", report.gaps);
         assert_ne!(
             Outcome::Audit(report).exit_code(),
             0,

--- a/crates/trusty-audit/src/config.rs
+++ b/crates/trusty-audit/src/config.rs
@@ -434,6 +434,33 @@ impl EngagementConfig {
     pub fn resolve_path(explicit: Option<PathBuf>, package_dir: &Path) -> PathBuf {
         explicit.unwrap_or_else(|| Self::default_path(package_dir))
     }
+
+    /// Every secret value this config carries, in one list.
+    ///
+    /// Why: two guards need exactly this set and had derived it separately —
+    /// [`crate::package`] refuses an archive member containing any of them, and
+    /// [`crate::run`] strips them out of a child's log. The board credentials
+    /// are what makes a shared list worth having: they arrive here from the
+    /// TOML rather than from the environment, so
+    /// `trusty_common::credentials::resolved_secret_values` — which enumerates
+    /// the registered providers — does not know them, and each guard has to add
+    /// them by hand. A guard that added one and forgot the other is the #5869
+    /// leak class, one credential over.
+    /// What: the OpenRouter key, plus each board credential the engagement was
+    /// given. Raw values: the only correct uses are as scrub needles and as
+    /// scan needles.
+    /// Test: `super::config_tests::configured_secrets_covers_every_credential`,
+    /// `crate::run::run_tests::a_child_that_echoes_a_board_credential_does_not_leave_it_in_the_log`.
+    pub fn configured_secrets(&self) -> Vec<&str> {
+        let mut secrets = vec![self.openrouter_key.expose()];
+        if let Some(jira) = self.boards.jira.as_ref() {
+            secrets.push(jira.token.expose());
+        }
+        if let Some(linear) = self.boards.linear.as_ref() {
+            secrets.push(linear.api_key.expose());
+        }
+        secrets
+    }
 }
 
 /// The TOML key holding the OpenRouter credential.
@@ -694,6 +721,38 @@ trusty-review = "0.15.1"
             "Debug leaked: {debug}"
         );
         assert!(!debug.contains("lin_api_secret"), "Debug leaked: {debug}");
+    }
+
+    /// The list both credential guards draw from holds every secret the config
+    /// carries, and shrinks to just the OpenRouter key when no board is given.
+    ///
+    /// The count assertions are the point: a new secret field added to the
+    /// schema and not to `configured_secrets` fails here, rather than reaching
+    /// a child's log or a handoff archive unnoticed.
+    #[test]
+    fn configured_secrets_covers_every_credential() {
+        let text = format!(
+            "{SAMPLE}\n[boards.jira]\nurl = \"https://acme.atlassian.net\"\n\
+             email = \"auditor@acme.example\"\ntoken = \"jira-token-secret\"\n\
+             \n[boards.linear]\napi_key = \"lin_api_secret\"\n"
+        );
+        let cfg = EngagementConfig::from_toml(&text, Path::new("engagement.toml")).expect("parses");
+
+        let secrets = cfg.configured_secrets();
+        assert!(
+            secrets.contains(&cfg.openrouter_key.expose()),
+            "{secrets:?}"
+        );
+        assert!(secrets.contains(&"jira-token-secret"), "{secrets:?}");
+        assert!(secrets.contains(&"lin_api_secret"), "{secrets:?}");
+        assert_eq!(secrets.len(), 3, "{secrets:?}");
+
+        let bare = EngagementConfig::from_toml(SAMPLE, Path::new("engagement.toml"))
+            .expect("parses without boards");
+        assert_eq!(
+            bare.configured_secrets(),
+            vec![bare.openrouter_key.expose()]
+        );
     }
 
     /// `boards.jira.url` is a plain `String` an operator may have pasted

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -687,20 +687,19 @@ fn start(zip: &mut Archive, entry: &str, bytes: u64, temporary: &Path) -> Result
 /// child writes are exactly the files this function's caller packages and sends
 /// off the recipient's network. One list, so a credential added to
 /// [`EngagementConfig`] is refused here the moment it is configured.
-/// What: the OpenRouter key, then whichever board credentials the config names.
-/// A provider with no entry contributes no needle.
+/// What: [`EngagementConfig::configured_secrets`] as byte slices — the same
+/// list [`crate::run`]'s child-log scrubber uses as its needles, so the two
+/// guards cannot come to disagree about what a secret is. A provider with no
+/// entry contributes no needle.
 /// Test: `super::package_tests::a_member_carrying_the_jira_token_is_refused_and_leaves_no_zip`,
 /// `super::package_tests::a_member_carrying_the_linear_api_key_is_refused_and_leaves_no_zip`,
 /// `super::package_tests::a_member_carrying_several_secrets_is_refused_on_the_first_pass`.
 fn secret_needles(config: &EngagementConfig) -> Vec<&[u8]> {
-    let mut needles = vec![config.openrouter_key.expose().as_bytes()];
-    if let Some(jira) = config.boards.jira.as_ref() {
-        needles.push(jira.token.expose().as_bytes());
-    }
-    if let Some(linear) = config.boards.linear.as_ref() {
-        needles.push(linear.api_key.expose().as_bytes());
-    }
-    needles
+    config
+        .configured_secrets()
+        .into_iter()
+        .map(str::as_bytes)
+        .collect()
 }
 
 /// Copy one file into the archive, refusing it if it carries any credential.

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -679,7 +679,31 @@ fn start(zip: &mut Archive, entry: &str, bytes: u64, temporary: &Path) -> Result
         })
 }
 
-/// Copy one file into the archive, refusing it if it carries the credential.
+/// Every secret this engagement holds, as the bytes a member may not carry.
+///
+/// Why: the guard used to scan for `openrouter_key` alone, and #5857 put two
+/// more secrets on the same trust boundary — the JIRA token and the Linear API
+/// key reach a `tga audit` child through its environment, and the files that
+/// child writes are exactly the files this function's caller packages and sends
+/// off the recipient's network. One list, so a credential added to
+/// [`EngagementConfig`] is refused here the moment it is configured.
+/// What: the OpenRouter key, then whichever board credentials the config names.
+/// A provider with no entry contributes no needle.
+/// Test: `super::package_tests::a_member_carrying_the_jira_token_is_refused_and_leaves_no_zip`,
+/// `super::package_tests::a_member_carrying_the_linear_api_key_is_refused_and_leaves_no_zip`,
+/// `super::package_tests::a_member_carrying_several_secrets_is_refused_on_the_first_pass`.
+fn secret_needles(config: &EngagementConfig) -> Vec<&[u8]> {
+    let mut needles = vec![config.openrouter_key.expose().as_bytes()];
+    if let Some(jira) = config.boards.jira.as_ref() {
+        needles.push(jira.token.expose().as_bytes());
+    }
+    if let Some(linear) = config.boards.linear.as_ref() {
+        needles.push(linear.api_key.expose().as_bytes());
+    }
+    needles
+}
+
+/// Copy one file into the archive, refusing it if it carries any credential.
 fn copy_member(
     zip: &mut Archive,
     entry: &str,
@@ -694,8 +718,8 @@ fn copy_member(
     let bytes = input.metadata().map(|m| m.len()).unwrap_or(0);
     start(zip, entry, bytes, temporary)?;
 
-    let needle = config.openrouter_key.expose().as_bytes().to_vec();
-    let mut scan = CredentialScan::over(&needle);
+    let needles = secret_needles(config);
+    let mut scan = CredentialScan::over(&needles);
     let mut buffer = vec![0_u8; CHUNK_BYTES];
     let mut written = 0_u64;
     loop {
@@ -721,37 +745,54 @@ fn copy_member(
     Ok(written)
 }
 
-/// A substring search across a stream, without holding the stream in memory.
+/// A multi-needle substring search across a stream, without holding the stream
+/// in memory.
 ///
 /// Why: the credential check has to cover an extract database that can run to
 /// hundreds of megabytes, and a match that straddles two reads is exactly the
-/// case a naive per-chunk search misses. Keeping the last `needle.len() - 1`
-/// bytes as the next window's prefix is what closes that gap.
+/// case a naive per-chunk search misses. Keeping the last `len - 1` bytes as the
+/// next window's prefix is what closes that gap.
+///
+/// The carried tail is sized to the LONGEST needle (#5857): one buffer serves
+/// every needle, and a tail cut to the shortest would let a longer secret
+/// straddle two reads undetected — the precise failure a per-needle tail exists
+/// to prevent. One shared window also means one copy per chunk rather than one
+/// per needle per chunk, which matters at extract-database size.
 /// Test: `super::package_tests::a_credential_split_across_two_reads_is_caught`.
 struct CredentialScan<'a> {
-    needle: &'a [u8],
+    /// Every secret to refuse. Empty needles are dropped at construction — an
+    /// unset credential must not match every file.
+    needles: Vec<&'a [u8]>,
+    /// Bytes to carry into the next window: `longest needle - 1`.
+    keep: usize,
     tail: Vec<u8>,
 }
 
 impl<'a> CredentialScan<'a> {
-    fn over(needle: &'a [u8]) -> Self {
+    fn over(needles: &[&'a [u8]]) -> Self {
+        let needles: Vec<&'a [u8]> = needles.iter().copied().filter(|n| !n.is_empty()).collect();
+        let keep = needles.iter().map(|n| n.len()).max().unwrap_or(1) - 1;
         Self {
-            needle,
+            needles,
+            keep,
             tail: Vec::new(),
         }
     }
 
-    /// Whether the needle appears in the stream up to and including `chunk`.
+    /// Whether any needle appears in the stream up to and including `chunk`.
     fn feed(&mut self, chunk: &[u8]) -> bool {
-        if self.needle.is_empty() {
+        if self.needles.is_empty() {
             return false;
         }
         let mut window = std::mem::take(&mut self.tail);
         window.extend_from_slice(chunk);
-        let found = window
-            .windows(self.needle.len())
-            .any(|candidate| candidate == self.needle);
-        let keep = (self.needle.len() - 1).min(window.len());
+        let found = self.needles.iter().any(|needle| {
+            window.len() >= needle.len()
+                && window
+                    .windows(needle.len())
+                    .any(|candidate| candidate == *needle)
+        });
+        let keep = self.keep.min(window.len());
         self.tail = window[window.len() - keep..].to_vec();
         found
     }
@@ -947,17 +988,157 @@ trusty-review = "0.15.1"
         );
     }
 
-    /// A needle straddling two reads is the case the chunked scan exists for.
+    /// The board credentials #5857 routes through this crate, on the same
+    /// engagement that already carries the OpenRouter key.
+    const BOARD_CONFIG: &str = r#"
+openrouter_key = "sk-or-v1-not-a-real-key"
+instructions = "Assess the last 52 weeks."
+client = "Acme"
+
+[tools]
+tga = "2.9.4"
+trusty-search = "0.47.0"
+trusty-analyze = "0.9.2"
+trusty-review = "0.15.1"
+
+[boards.jira]
+url = "https://acme.atlassian.net"
+email = "auditor@acme.example"
+token = "jira-token-do-not-package-me"
+
+[boards.linear]
+api_key = "lin_api_do-not-package-me"
+"#;
+
+    fn config_with_boards() -> EngagementConfig {
+        EngagementConfig::from_toml(BOARD_CONFIG, Path::new("engagement.toml")).expect("parses")
+    }
+
+    /// Package one member carrying `leaked`, and return what `assemble` did.
+    fn packaging_a_member_carrying(
+        work: &WorkDir,
+        config: &EngagementConfig,
+        leaked: &str,
+    ) -> Result<ReturnPackage, AuditError> {
+        install_record(work);
+        let run = audited(work, "00-acme-api", "acme-api");
+        std::fs::write(run.output.join("leaked.log"), leaked).expect("write");
+        let report = RunReport::of(vec![run]);
+        assemble(work, config, &report, &[], &default_destination(work))
+    }
+
+    /// The JIRA token is a secret this crate now hands to a child, so the
+    /// package guard owes it the refusal the OpenRouter key already gets.
+    ///
+    /// Against `5a615fe0e` this fails on the first assertion: `copy_member`
+    /// scanned for `openrouter_key` alone, so the token was packaged and the
+    /// engagement's own board credential left the recipient's network.
+    #[test]
+    fn a_member_carrying_the_jira_token_is_refused_and_leaves_no_zip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let destination = default_destination(&work);
+
+        let err = packaging_a_member_carrying(
+            &work,
+            &config_with_boards(),
+            "authorization: Basic jira-token-do-not-package-me\n",
+        )
+        .expect_err("a package carrying the JIRA token must not be produced");
+
+        assert!(
+            matches!(err, AuditError::CredentialInPackage { .. }),
+            "{err:?}"
+        );
+        assert!(
+            !destination.exists(),
+            "a refused package must leave no file"
+        );
+        assert!(
+            !destination.with_extension("zip.part").exists(),
+            "the temporary must be removed too"
+        );
+    }
+
+    /// The Linear key, same reason. Two providers, one guard.
+    #[test]
+    fn a_member_carrying_the_linear_api_key_is_refused_and_leaves_no_zip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let destination = default_destination(&work);
+
+        let err = packaging_a_member_carrying(
+            &work,
+            &config_with_boards(),
+            "LINEAR_API_KEY=lin_api_do-not-package-me\n",
+        )
+        .expect_err("a package carrying the Linear key must not be produced");
+
+        assert!(
+            matches!(err, AuditError::CredentialInPackage { .. }),
+            "{err:?}"
+        );
+        assert!(!destination.exists());
+        assert!(!destination.with_extension("zip.part").exists());
+    }
+
+    /// Several needles in one member: neither board secret hides behind the
+    /// other, and neither depends on the OpenRouter key being present to trip
+    /// the guard.
+    #[test]
+    fn a_member_carrying_several_secrets_is_refused_on_the_first_pass() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+
+        let err = packaging_a_member_carrying(
+            &work,
+            &config_with_boards(),
+            "jira=jira-token-do-not-package-me\nlinear=lin_api_do-not-package-me\n",
+        )
+        .expect_err("a package carrying two board secrets must not be produced");
+
+        assert!(
+            matches!(err, AuditError::CredentialInPackage { .. }),
+            "{err:?}"
+        );
+        assert!(!default_destination(&work).exists());
+    }
+
+    /// A member carrying none of them still packages — the widened scan must not
+    /// refuse ordinary output.
+    #[test]
+    fn an_ordinary_member_still_packages_under_the_widened_scan() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+
+        let package =
+            packaging_a_member_carrying(&work, &config_with_boards(), "commits: 412\nauthors: 9\n")
+                .expect("output carrying no secret packages");
+
+        assert!(package.path.is_file(), "{package:?}");
+    }
+
+    /// A needle straddling two reads is the case the chunked scan exists for,
+    /// and with several needles the tail has to be sized to the LONGEST — a tail
+    /// cut to the shortest would let the longest one straddle undetected.
     #[test]
     fn a_credential_split_across_two_reads_is_caught() {
-        let needle = b"sk-or-v1-secret";
-        let mut scan = CredentialScan::over(needle);
+        let mut scan = CredentialScan::over(&[b"sk-or-v1-secret".as_slice()]);
         assert!(!scan.feed(b"noise sk-or-v1-"));
         assert!(scan.feed(b"secret more noise"));
 
+        // The LONGEST needle straddles while a shorter one is also registered —
+        // a tail sized to the shortest would miss this.
+        let mut several =
+            CredentialScan::over(&[b"lin_api".as_slice(), b"jira-token-that-is-long".as_slice()]);
+        assert!(!several.feed(b"noise jira-token-"));
+        assert!(several.feed(b"that-is-long more noise"));
+
         // And an empty key never matches everything.
-        let mut blank = CredentialScan::over(b"");
+        let mut blank = CredentialScan::over(&[b"".as_slice()]);
         assert!(!blank.feed(b"anything at all"));
+        let mut nothing = CredentialScan::over(&[]);
+        assert!(!nothing.feed(b"anything at all"));
     }
 
     /// Following a symlink would read a file outside the working directory into

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -66,13 +66,12 @@ use std::process::Stdio;
 
 use serde::{Deserialize, Serialize};
 
-use crate::config::{EngagementConfig, ToolPins};
+use crate::config::EngagementConfig;
 use crate::error::AuditError;
 use crate::inference;
 use crate::progress::{Operation, Progress, StageEvent, StageState, UnitOutcome};
 use crate::registry;
 use crate::relay::{Scrubber, tee_and_relay};
-use crate::tools::{self, RequiredTool};
 use crate::workdir::{Area, WorkDir};
 
 // #5823: the selection file crossed run.rs past the 500-SLOC production cap, and
@@ -97,6 +96,13 @@ pub mod checkpoint;
 // judgement is what makes it a module rather than a step inside `run_one`.
 mod verify;
 
+// #5857: the pinned-tool preflight, split out when this file crossed the
+// 500-SLOC production cap. It runs to completion before any child starts and
+// answers one question — are the installed tools the ones this engagement pins
+// — so it separates cleanly.
+mod pins;
+
+use pins::{PinnedBinaries, pinned_binaries};
 use verify::verify_output;
 
 pub use checkpoint::{PROGRESS_FILE, Recollect, RunProgress, progress_path, read_progress};
@@ -234,85 +240,6 @@ pub struct RunOptions {
     pub fresh: bool,
 }
 
-/// The four binaries a run drives, each proven to be at the engagement's pin.
-///
-/// Why: named fields rather than a lookup table, so the "tool not found" branch
-/// does not exist. The obvious table version needs a fallback arm at every use
-/// site, and the natural fallback — the bare binary name — is a `PATH` lookup,
-/// which is the one thing this module must never do.
-#[derive(Debug, Clone)]
-struct PinnedBinaries {
-    tga: PathBuf,
-    search: PathBuf,
-    analyze: PathBuf,
-    review: PathBuf,
-}
-
-/// The pinned binaries this run drives, or a refusal naming what is wrong.
-///
-/// Why: the run must use the binaries THIS client installed and verified at the
-/// version THIS engagement pins — never whatever `tga` happens to be on the
-/// operator's `PATH`, and never a copy installed before the config was bumped.
-/// Both are the #5454 version-skew class, and there is no fallback for either.
-///
-/// Three conditions, each a refusal: the file is present, the version record
-/// this client wrote names it, and that recorded version equals the engagement's
-/// pin. The second matters because a binary someone dropped into `tools/` by
-/// hand reads as `installed` with no version — unverified is not a weaker kind
-/// of installed. The third matters because install and run are separate steps,
-/// so the config can change between them.
-/// What: reads [`tools::status`], checks all three conditions, and returns the
-/// paths by name.
-/// Test: `super::run_tests::a_run_without_the_pinned_tools_is_refused`,
-/// `super::run_tests::an_unverified_binary_does_not_count_as_installed`,
-/// `super::run_tests::a_binary_installed_at_a_different_pin_is_refused`.
-///
-/// # Errors
-///
-/// [`AuditError::ToolsNotInstalled`] naming every tool that is missing or
-/// unverified, [`AuditError::VersionMismatch`] for the first tool whose recorded
-/// version is not the engagement's pin, and whatever [`tools::status`] fails
-/// with.
-fn pinned_binaries(work: &WorkDir, pins: &ToolPins) -> Result<PinnedBinaries, AuditError> {
-    let statuses = tools::status(work)?;
-    let missing: Vec<&'static str> = statuses
-        .iter()
-        .filter(|s| !s.installed || s.version.is_none())
-        .map(|s| s.tool.binary_name())
-        .collect();
-    if !missing.is_empty() {
-        return Err(AuditError::ToolsNotInstalled { missing });
-    }
-
-    let path_of = |tool: RequiredTool| -> Result<PathBuf, AuditError> {
-        let pinned = tool.pin_in(pins).version();
-        let status = statuses.iter().find(|s| s.tool == tool).ok_or_else(|| {
-            AuditError::ToolsNotInstalled {
-                missing: vec![tool.binary_name()],
-            }
-        })?;
-        // `version` is Some: the missing check above rejected every None.
-        match status.version.as_deref() {
-            Some(v) if v == pinned => Ok(status.path.clone()),
-            Some(v) => Err(AuditError::VersionMismatch {
-                tool: tool.crate_name(),
-                pinned: pinned.to_owned(),
-                installed: v.to_owned(),
-            }),
-            None => Err(AuditError::ToolsNotInstalled {
-                missing: vec![tool.binary_name()],
-            }),
-        }
-    };
-
-    Ok(PinnedBinaries {
-        tga: path_of(RequiredTool::Tga)?,
-        search: path_of(RequiredTool::TrustySearch)?,
-        analyze: path_of(RequiredTool::TrustyAnalyze)?,
-        review: path_of(RequiredTool::TrustyReview)?,
-    })
-}
-
 /// A filename-safe, collision-free stem for one repository's files.
 ///
 /// Why: two things at once. The name comes from a selection file this client did
@@ -433,7 +360,47 @@ pub async fn sweep(
     options: &RunOptions,
     progress: &Progress,
 ) -> Result<RunReport, AuditError> {
-    sweep_with_budget(work, config, options, PER_REPO_TIMEOUT, progress).await
+    sweep_with_budget(work, config, options, None, PER_REPO_TIMEOUT, progress).await
+}
+
+/// [`sweep`], over boards the caller has already resolved.
+///
+/// Why: #5857 left `crate::chain` and this module each calling
+/// [`boards::resolve`] against their own [`registry::Registry::load`], hours
+/// apart — the chain states its board gaps in the Materialize phase and the
+/// sweep runs after tool install and every clone. A `taudit remove board`
+/// inside that window made the two reads disagree: the report claimed coverage
+/// while the child got no board section, and the engagement exited 0 having
+/// never read the board. The chain now resolves once and hands the result here,
+/// so there is one resolution per invocation rather than two reads that can
+/// diverge.
+///
+/// # Preconditions
+/// `boards` was resolved from the same [`EngagementConfig::boards`] passed as
+/// `config` — [`boards::Boards::env`] reads the secrets out of `config`, and a
+/// section resolved against different credentials would reference a variable
+/// this call does not set.
+/// Test: `crate::chain::chain_tests::a_board_removed_after_the_chain_resolved_it_still_reaches_the_child`.
+///
+/// # Errors
+///
+/// Exactly [`sweep`]'s, minus the registry read this call does not perform.
+pub async fn sweep_with_boards(
+    work: &WorkDir,
+    config: &EngagementConfig,
+    options: &RunOptions,
+    boards: &boards::Boards,
+    progress: &Progress,
+) -> Result<RunReport, AuditError> {
+    sweep_with_budget(
+        work,
+        config,
+        options,
+        Some(boards),
+        PER_REPO_TIMEOUT,
+        progress,
+    )
+    .await
 }
 
 /// [`sweep`], with the per-repository timeout as an argument.
@@ -448,10 +415,11 @@ async fn sweep_with_budget(
     work: &WorkDir,
     config: &EngagementConfig,
     options: &RunOptions,
+    boards: Option<&boards::Boards>,
     budget: std::time::Duration,
     progress: &Progress,
 ) -> Result<RunReport, AuditError> {
-    sweep_with_env(work, config, options, budget, progress, |name| {
+    sweep_with_env(work, config, options, boards, budget, progress, |name| {
         std::env::var(name).ok()
     })
     .await
@@ -472,6 +440,7 @@ async fn sweep_with_env<F>(
     work: &WorkDir,
     config: &EngagementConfig,
     options: &RunOptions,
+    resolved: Option<&boards::Boards>,
     budget: std::time::Duration,
     progress: &Progress,
     operator: F,
@@ -484,12 +453,22 @@ where
     // Resolved once, before any child: a half-named selection is identical for
     // every repository, so failing per-repo would just repeat one misconfiguration.
     let inference = inference::inference_env(config, operator)?;
-    // #5857: resolved once, from the same registry `crate::chain` reads, so
-    // `taudit run` and `taudit audit` collect the same boards. Every child gets
-    // the same sections — a board is a dimension of the engagement, not a unit
-    // of the sweep, and tga correlates it against whichever repository it is
-    // auditing.
-    let boards = boards::resolve(registry::Registry::load(work)?.targets(), &config.boards);
+    // #5857: ONE resolution per invocation. `crate::chain` resolved the boards
+    // an hour ago to state its gaps and hands that result down, so the coverage
+    // the report claims and the sections the child gets cannot diverge over a
+    // registry edited meanwhile. `taudit run` supplies nothing and resolves here
+    // — still once, and still after the refusals above, so a truncated registry
+    // is not reported ahead of a missing tool. Every child gets the same
+    // sections: a board is a dimension of the engagement, not a unit of the
+    // sweep, and tga correlates it against whichever repository it is auditing.
+    let owned;
+    let boards = match resolved {
+        Some(boards) => boards,
+        None => {
+            owned = boards::resolve(registry::Registry::load(work)?.targets(), &config.boards);
+            &owned
+        }
+    };
     let selected = load_selection(work)?;
     // #5869: materialized once for the whole sweep — resolving reads
     // `.env.local` and opens the secure store, which is not a per-child cost,
@@ -515,7 +494,7 @@ where
             Err(why) => {
                 announce_recollection(&repo.name, &why, progress);
                 run_one(
-                    work, config, &binaries, &inference, &boards, index, repo, budget, progress,
+                    work, config, &binaries, &inference, boards, index, repo, budget, progress,
                     total, &scrubber,
                 )
                 .await?
@@ -977,6 +956,7 @@ const ENV_REVIEW_BIN: &str = "TRUSTY_REVIEW_BIN";
 mod run_tests {
     use super::*;
     use crate::progress::{ProgressUpdate, Recorder, StageEvent, StageState};
+    use crate::tools::{self, RequiredTool};
     // The selection document itself, so a test can write a torn one by hand.
     use crate::run::selection::Selection;
 
@@ -1788,6 +1768,7 @@ trusty-review = "0.15.1"
             &work,
             &config(),
             &RunOptions::default(),
+            None,
             std::time::Duration::from_millis(200),
             &Progress::none(),
         )
@@ -1869,6 +1850,7 @@ trusty-review = "0.15.1"
             work,
             &config(),
             &RunOptions::default(),
+            None,
             PER_REPO_TIMEOUT,
             &Progress::none(),
             operator,

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -54,6 +54,11 @@
 //! file persists on disk, and a command-line argument is world-readable in
 //! `ps`).
 //!
+//! A registered board's credential travels the same way (#5857). The generated
+//! config gets a `${TRUSTY_AUDIT_JIRA_TOKEN}`-style reference and the value goes
+//! in the environment beside it; [`boards`] owns that split and the reasons for
+//! it.
+//!
 //! Test: `super::run_tests`.
 
 use std::path::{Path, PathBuf};
@@ -65,6 +70,7 @@ use crate::config::{EngagementConfig, ToolPins};
 use crate::error::AuditError;
 use crate::inference;
 use crate::progress::{Operation, Progress, StageEvent, StageState, UnitOutcome};
+use crate::registry;
 use crate::relay::{Scrubber, tee_and_relay};
 use crate::tools::{self, RequiredTool};
 use crate::workdir::{Area, WorkDir};
@@ -74,6 +80,12 @@ use crate::workdir::{Area, WorkDir};
 // `crate::run::SelectedRepo` and friends stay where every caller already names
 // them.
 mod selection;
+
+// #5857: what a registered board contributes to a child — the generated config
+// section, the variable carrying its secret, and the gap when it cannot be
+// collected. Public because `crate::chain` states the same gaps in the return
+// package and must reach them through this one resolution, not a second copy.
+pub mod boards;
 
 // #5494: the checkpoint and its resume rules are one subject and they are not
 // this file's — `run.rs` drives children, `checkpoint.rs` decides what a re-run
@@ -348,10 +360,20 @@ fn sanitize(name: &str) -> String {
 /// The database is placed under `extract/`, which is the area `workdir` names
 /// for exactly that, so it is inside the root that `rm -rf` cleans.
 /// The engagement credential is deliberately NOT here; see the module docs.
+///
+/// #5857: a registered board adds a `jira:` or `linear:` section, and those
+/// carry a `${VAR}` reference rather than the board's secret — the secret
+/// itself still travels only in the child's environment. Both are omitted when
+/// no board is registered, so a repo-only engagement generates exactly the
+/// document it always did.
 #[derive(Debug, Serialize)]
 struct TgaConfig {
     repositories: Vec<TgaRepository>,
     database: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    jira: Option<boards::TgaJira>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    linear: Option<boards::TgaLinear>,
 }
 
 #[derive(Debug, Serialize)]
@@ -462,6 +484,12 @@ where
     // Resolved once, before any child: a half-named selection is identical for
     // every repository, so failing per-repo would just repeat one misconfiguration.
     let inference = inference::inference_env(config, operator)?;
+    // #5857: resolved once, from the same registry `crate::chain` reads, so
+    // `taudit run` and `taudit audit` collect the same boards. Every child gets
+    // the same sections — a board is a dimension of the engagement, not a unit
+    // of the sweep, and tga correlates it against whichever repository it is
+    // auditing.
+    let boards = boards::resolve(registry::Registry::load(work)?.targets(), &config.boards);
     let selected = load_selection(work)?;
     // #5869: materialized once for the whole sweep — resolving reads
     // `.env.local` and opens the secure store, which is not a per-child cost,
@@ -487,8 +515,8 @@ where
             Err(why) => {
                 announce_recollection(&repo.name, &why, progress);
                 run_one(
-                    work, config, &binaries, &inference, index, repo, budget, progress, total,
-                    &scrubber,
+                    work, config, &binaries, &inference, &boards, index, repo, budget, progress,
+                    total, &scrubber,
                 )
                 .await?
             }
@@ -590,6 +618,7 @@ async fn run_one(
     config: &EngagementConfig,
     binaries: &PinnedBinaries,
     inference: &[(&'static str, String)],
+    boards: &boards::Boards,
     index: usize,
     repo: SelectedRepo,
     budget: std::time::Duration,
@@ -604,13 +633,14 @@ async fn run_one(
     progress.unit_started(Operation::Sweep, repo.name.as_str(), index + 1, total);
 
     let mut gaps = Vec::new();
-    let result = match prepare(work, &output, &stem, &checkout)? {
+    let result = match prepare(work, &output, &stem, &checkout, boards)? {
         Err(reason) => RepoResult::Failed { reason },
         Ok(config_path) => {
             match spawn_tga(
                 binaries,
                 config,
                 inference,
+                boards,
                 &config_path,
                 &output,
                 &log,
@@ -661,6 +691,7 @@ fn prepare(
     output: &Path,
     stem: &str,
     checkout: &Path,
+    boards: &boards::Boards,
 ) -> Result<Result<PathBuf, String>, AuditError> {
     if !checkout.is_dir() {
         return Ok(Err(format!(
@@ -676,6 +707,10 @@ fn prepare(
             name: stem.to_string(),
         }],
         database: work.path(Area::Extract).join(format!("{stem}.db")),
+        // #5857: `${TRUSTY_AUDIT_JIRA_TOKEN}`, not the token — see
+        // `boards`'s module docs for why the file may never hold the value.
+        jira: boards.jira.clone(),
+        linear: boards.linear.clone(),
     };
     // Infallible in practice — the document is owned strings and paths with no
     // map keys — but a serializer error must not be swallowed into a default.
@@ -752,6 +787,7 @@ async fn spawn_tga(
     binaries: &PinnedBinaries,
     config: &EngagementConfig,
     inference: &[(&'static str, String)],
+    boards: &boards::Boards,
     config_path: &Path,
     output: &Path,
     log: &Path,
@@ -799,6 +835,12 @@ async fn spawn_tga(
     // named too. Resolved by `sweep_with_env`: either all four or none, never a
     // subset that could pair one provider with another's model ids.
     for (name, value) in inference {
+        command.env(name, value);
+    }
+    // #5857: the board credential the generated config only references. Exposed
+    // here rather than held on `Boards`, so it lives no longer than this
+    // `Command` — the same shape as the inference credential above.
+    for (name, value) in boards.env(&config.boards) {
         command.env(name, value);
     }
 
@@ -1493,6 +1535,166 @@ trusty-review = "0.15.1"
                 path.display()
             );
         }
+    }
+
+    // ── #5857: a registered board reaches the child ──────────────────────────
+
+    /// The JIRA API token this engagement is given. Never expected on disk.
+    const JIRA_TOKEN: &str = "jira-token-never-on-disk";
+
+    /// The Linear personal API key. Never expected on disk.
+    const LINEAR_KEY: &str = "lin_api_never-on-disk";
+
+    /// An engagement carrying both board credentials.
+    fn board_config() -> EngagementConfig {
+        let text = format!(
+            "{CONFIG}\n[boards.jira]\nurl = \"https://acme.atlassian.net\"\n\
+             email = \"auditor@acme.example\"\ntoken = \"{JIRA_TOKEN}\"\n\
+             \n[boards.linear]\napi_key = \"{LINEAR_KEY}\"\n"
+        );
+        EngagementConfig::from_toml(&text, Path::new("engagement.toml")).expect("parses")
+    }
+
+    /// Register boards the way `taudit add board` does, so the sweep reads them
+    /// from the file it actually reads rather than from an injected value.
+    fn register_boards(work: &WorkDir, specs: &[&str]) {
+        let mut targets = registry::Registry::default();
+        for spec in specs {
+            targets
+                .insert(registry::parse(Some(registry::TargetKind::Board), spec).expect("parses"));
+        }
+        targets.save(work).expect("write registry");
+    }
+
+    /// The generated config carries a REFERENCE to each board credential and
+    /// never the credential, and the JIRA section carries both halves of the
+    /// Basic-auth pair.
+    ///
+    /// The `username` assertion is the one that catches the silent failure:
+    /// `JiraClient::new` builds its credential from `(&username, &token)` and
+    /// takes the `(Some, Some)` arm only, so a section with the token alone
+    /// runs UNAUTHENTICATED and reports no error at all.
+    ///
+    /// Against `origin/main` this fails at the first assertion — `TgaConfig` had
+    /// no `jira` field, so the board never reached the document.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_generated_config_references_the_board_secret_and_never_holds_it() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &writes_a_manifest(None));
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+        register_boards(&work, &["jira:ACME", "linear:ENG"]);
+
+        let report = sweep(
+            &work,
+            &board_config(),
+            &RunOptions::default(),
+            &Progress::none(),
+        )
+        .await
+        .expect("the sweep completes");
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+
+        let generated =
+            std::fs::read_to_string(work.path(Area::State).join("tga-00-acme-api.yaml"))
+                .expect("the generated tga config");
+        assert!(
+            generated.contains("${TRUSTY_AUDIT_JIRA_TOKEN}"),
+            "{generated}"
+        );
+        assert!(
+            generated.contains("${TRUSTY_AUDIT_LINEAR_API_KEY}"),
+            "{generated}"
+        );
+        assert!(
+            generated.contains("username: auditor@acme.example"),
+            "a token without a username is an unauthenticated client: {generated}"
+        );
+        assert!(generated.contains("project_key: ACME"), "{generated}");
+        assert!(generated.contains("- ENG"), "{generated}");
+
+        // Not just this file: every file the run left anywhere under the root.
+        for path in files_under(work.root()) {
+            let text = std::fs::read_to_string(&path).unwrap_or_default();
+            assert!(
+                !text.contains(JIRA_TOKEN) && !text.contains(LINEAR_KEY),
+                "{} carries a board credential",
+                path.display()
+            );
+        }
+    }
+
+    /// A stub that records the board variables it was handed.
+    fn records_its_board_env() -> String {
+        format!(
+            "{}{}",
+            writes_a_manifest(None).trim_end_matches("exit 0\n"),
+            "{\n  echo \"jira=$TRUSTY_AUDIT_JIRA_TOKEN\"\n  \
+             echo \"linear=$TRUSTY_AUDIT_LINEAR_API_KEY\"\n} > \"$out/board-env.txt\"\nexit 0\n",
+        )
+    }
+
+    /// The `${…}` reference is worth nothing unless the variable is set, so this
+    /// asserts on what the SPAWNED PROCESS received — not on what this crate
+    /// computed. tga expands the reference on the far side.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_child_environment_carries_the_real_board_credentials() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &records_its_board_env());
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+        register_boards(&work, &["jira:ACME", "linear:ENG"]);
+
+        let report = sweep(
+            &work,
+            &board_config(),
+            &RunOptions::default(),
+            &Progress::none(),
+        )
+        .await
+        .expect("the sweep completes");
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+
+        let seen = std::fs::read_to_string(report.repos[0].output.join("board-env.txt"))
+            .expect("the stub recorded its environment");
+        assert!(seen.contains(&format!("jira={JIRA_TOKEN}")), "{seen}");
+        assert!(seen.contains(&format!("linear={LINEAR_KEY}")), "{seen}");
+    }
+
+    /// An engagement that registers no board generates the document it always
+    /// did, and exports no board variable — so the sections and the variables
+    /// appear together or not at all.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_repo_only_engagement_gets_no_board_section_and_no_board_variable() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &records_its_board_env());
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let report = sweep(
+            &work,
+            &board_config(),
+            &RunOptions::default(),
+            &Progress::none(),
+        )
+        .await
+        .expect("the sweep completes");
+
+        let generated =
+            std::fs::read_to_string(work.path(Area::State).join("tga-00-acme-api.yaml"))
+                .expect("the generated tga config");
+        assert!(!generated.contains("jira"), "{generated}");
+        assert!(!generated.contains("linear"), "{generated}");
+        let seen = std::fs::read_to_string(report.repos[0].output.join("board-env.txt"))
+            .expect("the stub recorded its environment");
+        assert!(seen.contains("jira=\n"), "{seen}");
+        assert!(seen.contains("linear=\n"), "{seen}");
     }
 
     /// The CRITICAL arm: `tga audit` exits 0 whenever the sweep COMPLETED,

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -528,15 +528,22 @@ where
 /// What: the registry-wide resolved set from
 /// [`trusty_common::credentials::resolved_secret_values`] — the shared entry
 /// point, so a credential added there is scrubbed without this changing — plus
-/// the engagement key, which comes from the config file rather than the
-/// environment and so is not in that set.
+/// [`EngagementConfig::configured_secrets`], which is every credential this
+/// engagement's TOML carries and so reaches none of that registry.
+///
+/// #5857: the board credentials are in that second half for the same reason the
+/// OpenRouter key always was. `resolved_secret_values` walks
+/// `registered_providers`, and no provider there is a board, so a child that
+/// quotes a JIRA token in an auth error would otherwise write it to the log
+/// verbatim. [`crate::package::secret_needles`] draws from the same list.
 ///
 /// This removes only values this process already holds; see [`crate::relay`]
 /// for what that leaves behind.
-/// Test: `super::run_tests::a_child_that_echoes_the_key_does_not_leave_it_in_the_log`.
+/// Test: `super::run_tests::a_child_that_echoes_the_key_does_not_leave_it_in_the_log`,
+/// `super::run_tests::a_child_that_echoes_a_board_credential_does_not_leave_it_in_the_log`.
 fn child_output_scrubber(config: &EngagementConfig) -> Scrubber {
     let mut secrets = trusty_common::credentials::resolved_secret_values();
-    secrets.push(config.openrouter_key.expose().to_owned());
+    secrets.extend(config.configured_secrets().into_iter().map(str::to_owned));
     Scrubber::over(secrets)
 }
 
@@ -1675,6 +1682,73 @@ trusty-review = "0.15.1"
             .expect("the stub recorded its environment");
         assert!(seen.contains("jira=\n"), "{seen}");
         assert!(seen.contains("linear=\n"), "{seen}");
+    }
+
+    /// Why: #5869's filter is the OpenRouter test above, one credential over.
+    /// [`child_output_scrubber`] builds its needles from
+    /// `resolved_secret_values`, which enumerates the registered providers —
+    /// openrouter, anthropic, github, slack, and no board. A board credential
+    /// arrives from the engagement TOML rather than the environment, so before
+    /// #5857 appended it nothing put it in the needle set and a child that
+    /// quoted it wrote it to `work/logs/<repo>.log` in the clear.
+    /// What: a child that echoes both board credentials back, on both streams,
+    /// in the shapes a real one would — a provider rejection body quoting the
+    /// token, and an auth failure quoting the key — leaves neither in the log
+    /// nor in any other file the run wrote.
+    /// Test: this is the test.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_child_that_echoes_a_board_credential_does_not_leave_it_in_the_log() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let mut script = String::from(
+            "#!/bin/sh\n\
+             echo \"jira 401: {\\\"message\\\":\\\"token \
+             $TRUSTY_AUDIT_JIRA_TOKEN is not valid\\\"}\"\n\
+             echo \"linear auth failed: key $TRUSTY_AUDIT_LINEAR_API_KEY rejected\" >&2\n",
+        );
+        script.push_str(writes_a_manifest(None).trim_start_matches("#!/bin/sh\n"));
+        install_stubs(&work, &script);
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+        register_boards(&work, &["jira:ACME", "linear:ENG"]);
+
+        let report = sweep(
+            &work,
+            &board_config(),
+            &RunOptions::default(),
+            &Progress::none(),
+        )
+        .await
+        .expect("the sweep completes");
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+
+        let log = std::fs::read_to_string(&report.repos[0].log).expect("read the child log");
+        assert!(
+            !log.contains(JIRA_TOKEN),
+            "the log carries the token:\n{log}"
+        );
+        assert!(!log.contains(LINEAR_KEY), "the log carries the key:\n{log}");
+        // The child really did echo both — otherwise the assertions above prove
+        // nothing about the filter.
+        assert_eq!(
+            log.matches("[REDACTED]").count(),
+            2,
+            "both echoes must be masked, one per stream:\n{log}"
+        );
+        // The log is still a log: masking replaced the credentials, not the
+        // diagnosis.
+        assert!(log.contains("jira 401"), "{log}");
+        assert!(log.contains("linear auth failed"), "{log}");
+
+        for path in files_under(work.root()) {
+            let text = std::fs::read_to_string(&path).unwrap_or_default();
+            assert!(
+                !text.contains(JIRA_TOKEN) && !text.contains(LINEAR_KEY),
+                "{} carries a board credential",
+                path.display()
+            );
+        }
     }
 
     /// The CRITICAL arm: `tga audit` exits 0 whenever the sweep COMPLETED,

--- a/crates/trusty-audit/src/run/boards.rs
+++ b/crates/trusty-audit/src/run/boards.rs
@@ -125,9 +125,17 @@ impl Boards {
 
 /// Turn the registered boards into config sections, or into stated gaps.
 ///
-/// Why: one function, called by both `crate::run::sweep` (which needs the
-/// sections) and `crate::chain::split_targets` (which needs the gaps), so the
-/// two cannot disagree about which boards a run covers.
+/// Why: one function, called by `crate::chain::split_targets` (which needs the
+/// gaps) and by `crate::run::sweep` (which needs the sections), so both read the
+/// registry through the same rules.
+///
+/// That alone does NOT make the two agree, and claiming it did was wrong: the
+/// same resolver over the same mutable file at two different times can return
+/// two different answers, and the chain's two calls were an engagement apart.
+/// The guarantee is one resolution per invocation. `crate::chain::audit`
+/// resolves here once and hands the result to `crate::run::sweep_with_boards`;
+/// `taudit run` resolves here once inside `crate::run::sweep`. Nothing calls it
+/// twice for one run.
 ///
 /// # Postconditions
 /// Every element of `targets` that is a [`Target::Board`] either contributes to

--- a/crates/trusty-audit/src/run/boards.rs
+++ b/crates/trusty-audit/src/run/boards.rs
@@ -1,0 +1,338 @@
+//! What a registered board contributes to one `tga audit` child.
+//!
+//! Why: #5857. `crate::registry` could hold a JIRA project or a Linear team
+//! since #5822, and nothing downstream read it — `crate::chain::split_targets`
+//! forwarded repositories and turned every board into a gap line. So an
+//! engagement that registered a board got a non-zero exit and a package saying
+//! the board was not covered, for a board tga can collect.
+//!
+//! What: [`resolve`], which turns the registered boards plus the engagement's
+//! [`BoardCredentials`] into the `jira:` / `linear:` sections of the generated
+//! tga config, the variables the child needs in its environment, and one gap
+//! line per board that still cannot be collected.
+//!
+//! ## The generated config carries a placeholder, never the secret
+//!
+//! `crate::run`'s posture is that a secret reaches a child through its
+//! environment and never through a file. A board credential does not change
+//! that: the generated `state/tga-<stem>.yaml` gets `${TRUSTY_AUDIT_JIRA_TOKEN}`
+//! and `crate::run::spawn_tga` puts the real value in the child's environment
+//! under that name. tga expands it on the far side —
+//! `tga::collect::jira::client::JiraClient::new` expands BOTH `username` and
+//! `token` through `expand_credential`, and `tga::collect::linear::client`
+//! expands `api_key`. Neither accepts an empty expansion: an unset variable is a
+//! `CollectError::Config` naming the field, so this crate adds no second guard
+//! of its own.
+//!
+//! `email` is written literally. It is the Basic-auth username, and
+//! `crate::config::JiraCredentials`'s own `Debug` already treats it as
+//! non-secret for the same reason — with the password held back it is not on its
+//! own a credential.
+//!
+//! ## Why JIRA writes BOTH fields
+//!
+//! `JiraClient::new` builds its credential from `(&config.username,
+//! &config.token)` and takes the `(Some, Some)` arm only. A config carrying the
+//! token alone falls through to `None` and the client runs UNAUTHENTICATED —
+//! no error, just an audit that reads nothing. Linear is a different shape: a
+//! bare `api_key` with no username, and an absent one is refused outright.
+//!
+//! Test: `super::boards::boards_tests`.
+
+use serde::Serialize;
+
+use crate::config::BoardCredentials;
+use crate::registry::{BoardProvider, Target};
+
+/// The variable the JIRA API token reaches the child under.
+pub const ENV_JIRA_TOKEN: &str = "TRUSTY_AUDIT_JIRA_TOKEN";
+
+/// The variable the Linear personal API key reaches the child under.
+pub const ENV_LINEAR_API_KEY: &str = "TRUSTY_AUDIT_LINEAR_API_KEY";
+
+/// The `${VAR}` reference tga expands, for a variable this crate will set.
+fn placeholder(variable: &str) -> String {
+    format!("${{{variable}}}")
+}
+
+/// tga's `jira:` section, as this client generates it.
+///
+/// Field names match `tga::core::config::JiraConfig` — `url`, `username`,
+/// `token`, `project_key` — because that struct is what parses this document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TgaJira {
+    /// Site base URL, from `boards.jira.url`.
+    pub url: String,
+    /// Basic-auth username: the account email, written literally.
+    pub username: String,
+    /// Basic-auth password, as a `${…}` reference — never the token itself.
+    pub token: String,
+    /// The registered project key.
+    pub project_key: String,
+}
+
+/// tga's `linear:` section, as this client generates it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TgaLinear {
+    /// Personal API key, as a `${…}` reference — never the key itself.
+    pub api_key: String,
+    /// Every registered Linear team key, in registration order.
+    pub team_keys: Vec<String>,
+}
+
+/// What the registered boards add to one child, and what they cannot.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Boards {
+    /// The `jira:` section to generate, when a JIRA board is collectable.
+    pub jira: Option<TgaJira>,
+    /// The `linear:` section to generate, when a Linear board is collectable.
+    pub linear: Option<TgaLinear>,
+    /// One line per registered board this sweep will not collect, safe to show
+    /// the recipient. `crate::chain` carries these into the return package.
+    pub gaps: Vec<String>,
+}
+
+impl Boards {
+    /// Whether any board reaches the child at all.
+    pub fn is_empty(&self) -> bool {
+        self.jira.is_none() && self.linear.is_none()
+    }
+
+    /// The variables the child needs, paired with the real secret values.
+    ///
+    /// Why: the exposed secret is produced HERE rather than stored on
+    /// [`Boards`], so it lives only as long as the `Command` being built —
+    /// the same shape as `crate::run::spawn_tga` calling
+    /// `SecretKey::expose` inline for the inference credential.
+    /// What: one pair per section that [`resolve`] produced, so a variable is
+    /// never set for a provider whose section was not written.
+    /// Test: `super::boards_tests::the_environment_covers_exactly_the_sections_written`.
+    pub fn env<'a>(&self, credentials: &'a BoardCredentials) -> Vec<(&'static str, &'a str)> {
+        let mut pairs = Vec::new();
+        if self.jira.is_some()
+            && let Some(jira) = credentials.jira.as_ref()
+        {
+            pairs.push((ENV_JIRA_TOKEN, jira.token.expose()));
+        }
+        if self.linear.is_some()
+            && let Some(linear) = credentials.linear.as_ref()
+        {
+            pairs.push((ENV_LINEAR_API_KEY, linear.api_key.expose()));
+        }
+        pairs
+    }
+}
+
+/// Turn the registered boards into config sections, or into stated gaps.
+///
+/// Why: one function, called by both `crate::run::sweep` (which needs the
+/// sections) and `crate::chain::split_targets` (which needs the gaps), so the
+/// two cannot disagree about which boards a run covers.
+///
+/// # Postconditions
+/// Every element of `targets` that is a [`Target::Board`] either contributes to
+/// [`Boards::jira`] / [`Boards::linear`] or appears in [`Boards::gaps`], never
+/// both and never neither. No returned value contains a secret: the credential
+/// fields are `${VAR}` references.
+///
+/// What: a board whose provider has no entry in the engagement config is a gap
+/// naming the field to set — that is the same fact
+/// [`crate::error::AuditError::BoardCredentialMissing`] states at registration
+/// time, reached here because a config can lose a section after a board was
+/// registered. Linear teams accumulate into one section, because tga's
+/// `linear.team_keys` is a list. A SECOND JIRA project is a gap: tga's
+/// `jira.project_key` is a single value, so the extra board would otherwise be
+/// silently dropped.
+/// Test: `super::boards_tests`.
+pub fn resolve(targets: &[Target], credentials: &BoardCredentials) -> Boards {
+    let mut resolved = Boards::default();
+    let mut linear_teams = Vec::new();
+    for target in targets {
+        let Target::Board { provider, key } = target else {
+            continue;
+        };
+        match provider {
+            BoardProvider::Jira => match credentials.jira.as_ref() {
+                None => resolved.gaps.push(unconfigured(target, *provider)),
+                Some(_) if resolved.jira.is_some() => resolved.gaps.push(second_jira(target)),
+                Some(creds) => {
+                    resolved.jira = Some(TgaJira {
+                        url: creds.url.clone(),
+                        username: creds.email.clone(),
+                        token: placeholder(ENV_JIRA_TOKEN),
+                        project_key: key.clone(),
+                    });
+                }
+            },
+            BoardProvider::Linear => match credentials.linear.as_ref() {
+                None => resolved.gaps.push(unconfigured(target, *provider)),
+                Some(_) => linear_teams.push(key.clone()),
+            },
+        }
+    }
+    if !linear_teams.is_empty() {
+        resolved.linear = Some(TgaLinear {
+            api_key: placeholder(ENV_LINEAR_API_KEY),
+            team_keys: linear_teams,
+        });
+    }
+    resolved
+}
+
+fn unconfigured(target: &Target, provider: BoardProvider) -> String {
+    format!(
+        "{target} was not audited — this engagement's config carries no `{}` credential (#5857)",
+        provider.config_field()
+    )
+}
+
+fn second_jira(target: &Target) -> String {
+    format!(
+        "{target} was not audited — `tga audit` takes one JIRA project per run, and another was \
+         registered first (#5857)"
+    )
+}
+
+#[cfg(test)]
+mod boards_tests {
+    use super::*;
+    use crate::config::{JiraCredentials, LinearCredentials, SecretKey};
+    use crate::registry::{self, TargetKind};
+
+    const JIRA_TOKEN: &str = "jira-token-do-not-write-me-down";
+    const LINEAR_KEY: &str = "lin_api_do-not-write-me-down";
+
+    fn board(spec: &str) -> Target {
+        registry::parse(Some(TargetKind::Board), spec).expect("parses")
+    }
+
+    fn jira_creds() -> JiraCredentials {
+        JiraCredentials {
+            url: "https://acme.atlassian.net".to_owned(),
+            email: "auditor@acme.example".to_owned(),
+            token: SecretKey::new(JIRA_TOKEN),
+        }
+    }
+
+    fn both() -> BoardCredentials {
+        BoardCredentials {
+            jira: Some(jira_creds()),
+            linear: Some(LinearCredentials {
+                api_key: SecretKey::new(LINEAR_KEY),
+            }),
+        }
+    }
+
+    /// The trap #5857 names: `JiraClient::new` takes its `(Some, Some)` arm
+    /// only, so a section carrying the token alone yields an UNAUTHENTICATED
+    /// client and an audit that silently reads nothing. Both fields, or the
+    /// wiring is worse than the gap it replaced.
+    #[test]
+    fn a_jira_board_writes_both_the_username_and_the_token() {
+        let resolved = resolve(&[board("jira:ACME")], &both());
+        let jira = resolved
+            .jira
+            .expect("a configured JIRA board is collectable");
+        assert_eq!(jira.username, "auditor@acme.example");
+        assert_eq!(jira.token, "${TRUSTY_AUDIT_JIRA_TOKEN}");
+        assert_eq!(jira.project_key, "ACME");
+        assert_eq!(jira.url, "https://acme.atlassian.net");
+        assert!(resolved.gaps.is_empty(), "{:?}", resolved.gaps);
+    }
+
+    /// Linear is a bare key with no username, so modelling it on JIRA's pair
+    /// would invent a field tga's `LinearConfig` does not have.
+    #[test]
+    fn a_linear_board_is_a_bare_key_and_a_team_list() {
+        let resolved = resolve(&[board("linear:ENG")], &both());
+        let linear = resolved.linear.expect("a configured Linear board");
+        assert_eq!(linear.api_key, "${TRUSTY_AUDIT_LINEAR_API_KEY}");
+        assert_eq!(linear.team_keys, vec!["ENG".to_owned()]);
+        assert!(resolved.jira.is_none(), "{:?}", resolved.jira);
+    }
+
+    /// `linear.team_keys` is a list at tga, so a second team is coverage rather
+    /// than a gap.
+    #[test]
+    fn every_registered_linear_team_reaches_the_one_section() {
+        let resolved = resolve(&[board("linear:ENG"), board("linear:FE")], &both());
+        let linear = resolved.linear.expect("a configured Linear board");
+        assert_eq!(linear.team_keys, vec!["ENG".to_owned(), "FE".to_owned()]);
+        assert!(resolved.gaps.is_empty(), "{:?}", resolved.gaps);
+    }
+
+    /// `jira.project_key` is one value, so the second project has nowhere to go.
+    /// Stating it beats dropping it.
+    #[test]
+    fn a_second_jira_project_is_a_gap_rather_than_a_silent_drop() {
+        let resolved = resolve(&[board("jira:ACME"), board("jira:OPS")], &both());
+        assert_eq!(
+            resolved.jira.expect("the first project").project_key,
+            "ACME"
+        );
+        assert_eq!(resolved.gaps.len(), 1, "{:?}", resolved.gaps);
+        assert!(resolved.gaps[0].contains("jira:OPS"), "{:?}", resolved.gaps);
+    }
+
+    /// A board registered against a config that says nothing about its provider
+    /// is the one board case that is still a gap — and the line names the field
+    /// to set, as `BoardCredentialMissing` does at registration time.
+    #[test]
+    fn a_board_with_no_configured_credential_is_a_gap_naming_the_field() {
+        let none = BoardCredentials::default();
+        let resolved = resolve(&[board("jira:ACME"), board("linear:ENG")], &none);
+        assert!(resolved.is_empty(), "{resolved:?}");
+        assert_eq!(resolved.gaps.len(), 2, "{:?}", resolved.gaps);
+        assert!(
+            resolved.gaps[0].contains("boards.jira"),
+            "{:?}",
+            resolved.gaps
+        );
+        assert!(
+            resolved.gaps[1].contains("boards.linear"),
+            "{:?}",
+            resolved.gaps
+        );
+    }
+
+    /// Nothing this function returns may carry a secret — the config document
+    /// it feeds is written to disk.
+    #[test]
+    fn no_resolved_section_carries_the_secret_itself() {
+        let resolved = resolve(&[board("jira:ACME"), board("linear:ENG")], &both());
+        let rendered = format!("{resolved:?}");
+        assert!(!rendered.contains(JIRA_TOKEN), "{rendered}");
+        assert!(!rendered.contains(LINEAR_KEY), "{rendered}");
+    }
+
+    /// A variable is set only for a section that was written, so a provider
+    /// that gapped never exports a credential the child has no config to use.
+    #[test]
+    fn the_environment_covers_exactly_the_sections_written() {
+        let credentials = both();
+        let jira_only = resolve(&[board("jira:ACME")], &credentials);
+        assert_eq!(
+            jira_only.env(&credentials),
+            vec![(ENV_JIRA_TOKEN, JIRA_TOKEN)]
+        );
+
+        let neither = resolve(&[], &credentials);
+        assert!(neither.env(&credentials).is_empty());
+
+        let both_boards = resolve(&[board("jira:ACME"), board("linear:ENG")], &credentials);
+        assert_eq!(
+            both_boards.env(&credentials),
+            vec![
+                (ENV_JIRA_TOKEN, JIRA_TOKEN),
+                (ENV_LINEAR_API_KEY, LINEAR_KEY)
+            ]
+        );
+    }
+
+    /// A repository in the same registry is not this module's business.
+    #[test]
+    fn a_repository_target_contributes_nothing() {
+        let repo = registry::parse(Some(TargetKind::Repo), "acme/api").expect("parses");
+        assert_eq!(resolve(&[repo], &both()), Boards::default());
+    }
+}

--- a/crates/trusty-audit/src/run/pins.rs
+++ b/crates/trusty-audit/src/run/pins.rs
@@ -1,0 +1,102 @@
+//! The preflight that decides which four binaries a sweep may drive.
+//!
+//! Why: split out of `crate::run` when that file crossed the 500-SLOC
+//! production cap (#5857). It is the one concern in the sweep that runs to
+//! completion before any child starts and answers a single question — are the
+//! installed tools the ones this engagement pins — so it separates cleanly.
+//!
+//! What: [`PinnedBinaries`], the four paths by name, and [`pinned_binaries`],
+//! the three-condition check that produces them or refuses.
+//!
+//! Test: `crate::run::run_tests::a_run_without_the_pinned_tools_is_refused`,
+//! `crate::run::run_tests::an_unverified_binary_does_not_count_as_installed`,
+//! `crate::run::run_tests::a_binary_installed_at_a_different_pin_is_refused`.
+
+use std::path::PathBuf;
+
+use crate::config::ToolPins;
+use crate::error::AuditError;
+use crate::tools::{self, RequiredTool};
+use crate::workdir::WorkDir;
+
+/// The four binaries a run drives, each proven to be at the engagement's pin.
+///
+/// Why: named fields rather than a lookup table, so the "tool not found" branch
+/// does not exist. The obvious table version needs a fallback arm at every use
+/// site, and the natural fallback — the bare binary name — is a `PATH` lookup,
+/// which is the one thing the sweep must never do.
+#[derive(Debug, Clone)]
+pub(super) struct PinnedBinaries {
+    pub(super) tga: PathBuf,
+    pub(super) search: PathBuf,
+    pub(super) analyze: PathBuf,
+    pub(super) review: PathBuf,
+}
+
+/// The pinned binaries this run drives, or a refusal naming what is wrong.
+///
+/// Why: the run must use the binaries THIS client installed and verified at the
+/// version THIS engagement pins — never whatever `tga` happens to be on the
+/// operator's `PATH`, and never a copy installed before the config was bumped.
+/// Both are the #5454 version-skew class, and there is no fallback for either.
+///
+/// Three conditions, each a refusal: the file is present, the version record
+/// this client wrote names it, and that recorded version equals the engagement's
+/// pin. The second matters because a binary someone dropped into `tools/` by
+/// hand reads as `installed` with no version — unverified is not a weaker kind
+/// of installed. The third matters because install and run are separate steps,
+/// so the config can change between them.
+/// What: reads [`tools::status`], checks all three conditions, and returns the
+/// paths by name.
+/// Test: `crate::run::run_tests::a_run_without_the_pinned_tools_is_refused`,
+/// `crate::run::run_tests::an_unverified_binary_does_not_count_as_installed`,
+/// `crate::run::run_tests::a_binary_installed_at_a_different_pin_is_refused`.
+///
+/// # Errors
+///
+/// [`AuditError::ToolsNotInstalled`] naming every tool that is missing or
+/// unverified, [`AuditError::VersionMismatch`] for the first tool whose recorded
+/// version is not the engagement's pin, and whatever [`tools::status`] fails
+/// with.
+pub(super) fn pinned_binaries(
+    work: &WorkDir,
+    pins: &ToolPins,
+) -> Result<PinnedBinaries, AuditError> {
+    let statuses = tools::status(work)?;
+    let missing: Vec<&'static str> = statuses
+        .iter()
+        .filter(|s| !s.installed || s.version.is_none())
+        .map(|s| s.tool.binary_name())
+        .collect();
+    if !missing.is_empty() {
+        return Err(AuditError::ToolsNotInstalled { missing });
+    }
+
+    let path_of = |tool: RequiredTool| -> Result<PathBuf, AuditError> {
+        let pinned = tool.pin_in(pins).version();
+        let status = statuses.iter().find(|s| s.tool == tool).ok_or_else(|| {
+            AuditError::ToolsNotInstalled {
+                missing: vec![tool.binary_name()],
+            }
+        })?;
+        // `version` is Some: the missing check above rejected every None.
+        match status.version.as_deref() {
+            Some(v) if v == pinned => Ok(status.path.clone()),
+            Some(v) => Err(AuditError::VersionMismatch {
+                tool: tool.crate_name(),
+                pinned: pinned.to_owned(),
+                installed: v.to_owned(),
+            }),
+            None => Err(AuditError::ToolsNotInstalled {
+                missing: vec![tool.binary_name()],
+            }),
+        }
+    };
+
+    Ok(PinnedBinaries {
+        tga: path_of(RequiredTool::Tga)?,
+        search: path_of(RequiredTool::TrustySearch)?,
+        analyze: path_of(RequiredTool::TrustyAnalyze)?,
+        review: path_of(RequiredTool::TrustyReview)?,
+    })
+}


### PR DESCRIPTION
The trusty-audit half of #5857. A registered board is now collected instead of
routed into `gaps`.

## What was actually broken

`chain::split_targets` forwarded repository targets and turned every
`Target::Board` into a gap line. Nothing downstream had ever read a board, so an
engagement that registered `jira:ACME` got a non-zero exit and a package stating
the board was not covered.

A board is not a unit of the sweep — there is nothing to clone. It becomes a
`jira:` or `linear:` section on each generated `state/tga-<stem>.yaml`, and
`tga audit` syncs it against the repository that child is auditing.

## The credential never lands in a file

The generated config carries `${TRUSTY_AUDIT_JIRA_TOKEN}` /
`${TRUSTY_AUDIT_LINEAR_API_KEY}`; `run::spawn_tga` puts the real value in the
child's environment, beside the OpenRouter key that already travels that way.
tga expands the reference on the far side and rejects an empty expansion, so an
unset variable is a `CollectError::Config` naming the field. No audit-side guard
duplicates that check.

The JIRA section writes **both** `username` and `token`. `JiraClient::new` builds
its credential from `(&username, &token)` and takes the `(Some, Some)` arm only —
a token alone yields an unauthenticated client with no error. Linear is a bare
`api_key` plus a team list, modelled on its own shape rather than JIRA's.

Two board cases stay gaps: a provider with no credential in the engagement
config, and a second JIRA project (tga's `jira.project_key` holds one).

## The blocker in the old comment does not exist

`chain.rs`'s `board_gap` claimed tga read the JIRA `token` as a literal string
with no `${VAR}` expansion. That has been false since #4067 / `fb1cd9bff`:
`collect/jira/client.rs:167-173` expands both fields through `expand_credential`,
and `collect/linear/client.rs:106` expands `api_key`. The comment is removed with
the function. **#5857's blocker-1 text is stale the same way** — flagged here,
not edited on the issue.

No tga change was needed and none is in this diff.

## Scope

`RunReport` is untouched. It remains #5857's second open closure condition, so
this does not close the issue.

## Gates — ladder rung 3, crate-scoped, treated as high risk (credential path)

```
cargo fmt --check                                     clean
cargo check -p trusty-audit --all-targets             clean
cargo clippy -p trusty-audit --all-targets -D warnings clean
cargo test -p trusty-audit                            299 passed; 0 failed; 5 ignored
                                                      + 21 integration passed; 0 failed
bash scripts/check_line_cap.sh                        4052 files, 0 violations
bash scripts/check_sld.sh                             0 errors, 0 warnings
bash scripts/check_teardown_guard.sh                  OK
bash scripts/check_changelog_fragment.sh              OK
```

`run.rs` was at 472/500 SLOC, which is why the resolution lives in a new
`run/boards.rs` rather than inline.

### Regression proof

Two of the new tests were run against a deliberate mutation dropping the JIRA
`username`, and both failed:

```
run::boards::boards_tests::a_jira_board_writes_both_the_username_and_the_token ... FAILED
run::run_tests::the_generated_config_references_the_board_secret_and_never_holds_it ... FAILED
test result: FAILED. 10 passed; 2 failed; 292 filtered out
```

`a_registered_board_with_a_credential_is_collected` and
`the_generated_config_references_the_board_secret_and_never_holds_it` cannot pass
on `origin/main` at all — `TgaConfig` had no `jira` field there, and
`split_targets` gapped every board unconditionally.

## New tests

| Test | Asserts |
|---|---|
| `run_tests::the_generated_config_references_the_board_secret_and_never_holds_it` | the file on disk contains both placeholders and `username`, and no file under the root contains either secret |
| `run_tests::the_child_environment_carries_the_real_board_credentials` | the spawned process received the real values under the expected names |
| `run_tests::a_repo_only_engagement_gets_no_board_section_and_no_board_variable` | sections and variables appear together or not at all |
| `chain_tests::a_registered_board_with_a_credential_is_collected` | no gap, no exclusion, exit 0 |
| `chain_tests::a_board_with_no_configured_credential_is_still_a_gap` | the gap names the board and the config field |
| `boards_tests::a_jira_board_writes_both_the_username_and_the_token` | the trap: token-only must fail |
| `boards_tests::a_linear_board_is_a_bare_key_and_a_team_list` | Linear on its own shape |
| `boards_tests` (5 more) | second JIRA project gaps, Linear teams accumulate, no secret in `Debug`, env covers exactly the sections written |

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
