### PR TITLE
fix: distinguish absent from undeterminable on destructive agent/skill/bm25 paths (#5626, #5627)

### DIFF
--- a/crates/trusty-agents-common/src/agents/deployer.rs
+++ b/crates/trusty-agents-common/src/agents/deployer.rs
@@ -232,10 +232,12 @@ fn deploy_agents_locked(
     // managed files as user-owned and silently skip the entire deploy.
     let mut manifest = match AgentManifest::load_checked(target_dir) {
         ManifestLoad::Ok(m) => m,
-        ManifestLoad::Corrupt(detail) => {
+        // #5626: same refusal for a read that failed — resetting to empty
+        // reclassifies every managed file as user-owned either way.
+        ManifestLoad::Corrupt(detail) | ManifestLoad::Unreadable(detail) => {
             return Err(AgentBuildError::FrontmatterParse(format!(
-                "agent manifest is corrupt and cannot be safely loaded; \
-                 run `tm repair deploy` to recover. Detail: {detail}"
+                "agent ownership ledger could not be established and the deploy cannot \
+                 safely proceed; run `tm repair deploy` to recover. Detail: {detail}"
             )));
         }
     };
@@ -535,9 +537,13 @@ fn retract_locked(
 
     let mut manifest = match AgentManifest::load_checked(target_dir) {
         ManifestLoad::Ok(m) => m,
-        ManifestLoad::Corrupt(detail) => {
+        // #5626: an unreadable ledger refuses like a corrupt one — retraction
+        // DELETES files, and the ownership record that says which ones is
+        // exactly what this run failed to obtain.
+        ManifestLoad::Corrupt(detail) | ManifestLoad::Unreadable(detail) => {
             return Err(AgentBuildError::FrontmatterParse(format!(
-                "agent manifest is corrupt; refusing to retract any file on the strength \
+                "agent ownership ledger could not be established; refusing to retract any \
+                 file on the strength \
                  of an unreadable ownership ledger. `tm repair deploy` cannot fix this — \
                  it only repairs the user-tier deploy, not this workspace's ledger. \
                  Delete `.claude/agents/.trusty-mpm-manifest.json` in this workspace by \

--- a/crates/trusty-agents-common/src/agents/manifest.rs
+++ b/crates/trusty-agents-common/src/agents/manifest.rs
@@ -54,15 +54,29 @@ pub const MANIFEST_FILE: &str = ".trusty-mpm-manifest.json";
 /// Why: callers need to distinguish "no manifest yet" (first deploy, expect
 /// empty) from "manifest is corrupt" (dangerous — silently resetting to empty
 /// would reclassify managed files as user-owned and skip re-deploying them).
+/// [`Unreadable`](Self::Unreadable) is the third state (#5626, [ADR-0045]): a
+/// read that FAILED establishes nothing at all, and folding it into
+/// [`Ok`](Self::Ok) was the same reclassification arriving through EACCES
+/// instead of through a truncated write.
 /// What: `Ok(manifest)` when the file is absent or parses cleanly; `Corrupt`
-/// when the file exists but is malformed or truncated.
-/// Test: `manifest_load_corrupt_returns_corrupt`.
+/// when the file exists but is malformed or truncated; `Unreadable` when the
+/// read itself failed for any reason other than `NotFound`. Both non-`Ok`
+/// variants carry a caller-renderable detail string and mean the ledger has not
+/// been established — every consumer must treat them alike.
+/// `#[non_exhaustive]` so a future state is added without breaking consumers.
+/// Test: `manifest_load_corrupt_returns_corrupt`,
+/// `manifest_load_unreadable_is_not_ok`.
+///
+/// [ADR-0045]: ../../../../docs/adr/0045-distinguish-absent-from-undeterminable-on-destructive-paths.md
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ManifestLoad {
     /// File was absent (first deploy) or parsed cleanly.
     Ok(AgentManifest),
     /// File exists but is malformed / truncated.
     Corrupt(String),
+    /// The file could not be read, so nothing is known about what it holds.
+    Unreadable(String),
 }
 
 /// Scratch path for one [`atomic_write`] attempt — unique per writer, per
@@ -342,10 +356,12 @@ impl AgentManifest {
     /// deploy, producing a silent no-op rather than a re-deploy.
     /// What: reads `<target_dir>/.trusty-mpm-manifest.json`; if absent returns
     /// `ManifestLoad::Ok(default)`; if present but malformed returns
-    /// `ManifestLoad::Corrupt` with the parse error; if valid returns
-    /// `ManifestLoad::Ok(parsed)`.
+    /// `ManifestLoad::Corrupt` with the parse error; if the read itself fails
+    /// for any other reason returns `ManifestLoad::Unreadable` with the I/O
+    /// error; if valid returns `ManifestLoad::Ok(parsed)`.
     /// Test: `manifest_load_missing_returns_empty`,
     ///       `manifest_load_corrupt_returns_corrupt`,
+    ///       `manifest_load_unreadable_is_not_ok`,
     ///       `manifest_round_trip`.
     pub fn load_checked(target_dir: &Path) -> ManifestLoad {
         let path = target_dir.join(MANIFEST_FILE);
@@ -355,7 +371,10 @@ impl AgentManifest {
                 Err(e) => ManifestLoad::Corrupt(format!("{path}: {e}", path = path.display())),
             },
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => ManifestLoad::Ok(Self::default()),
-            Err(_) => ManifestLoad::Ok(Self::default()),
+            // #5626: an EACCES/ESTALE/EIO read establishes nothing, and the
+            // empty default it used to return reclassified every managed file
+            // as user-owned — the exact outcome `ManifestLoad` exists to stop.
+            Err(e) => ManifestLoad::Unreadable(format!("{path}: {e}", path = path.display())),
         }
     }
 
@@ -363,15 +382,28 @@ impl AgentManifest {
     ///
     /// Why: preserves the pre-existing call sites that can tolerate a silent
     /// empty-on-corruption fallback (e.g. the deployer, which calls
-    /// `load_checked` itself when it cares about the distinction).
+    /// `load_checked` itself when it cares about the distinction). Every caller
+    /// whose decision MOVES, DELETES, or OVERWRITES a file calls `load_checked`
+    /// instead — an empty ledger reclassifies managed files as user-owned, and
+    /// #5626 is the record of what that costs on such a path.
     /// What: delegates to `load_checked`; returns the manifest on `Ok`, an
-    /// empty default on `Corrupt` (with no side-effects — callers that need
-    /// to react to corruption should use `load_checked`).
+    /// empty default when the ledger was not established, logging why.
     /// Test: `manifest_load_missing_returns_empty`, `manifest_round_trip`.
     pub fn load(target_dir: &Path) -> Self {
         match Self::load_checked(target_dir) {
             ManifestLoad::Ok(m) => m,
-            ManifestLoad::Corrupt(_) => Self::default(),
+            // intentional fail-open: the staleness and scaffold reporters that
+            // still call this have no error channel, and over-reporting a
+            // refresh as needed is their safe direction. #5626 left the shim
+            // unchanged and moved the destructive callers off it instead.
+            ManifestLoad::Corrupt(detail) | ManifestLoad::Unreadable(detail) => {
+                tracing::error!(
+                    detail,
+                    "agent ownership ledger could not be established; treating this \
+                     directory as unmanaged for a read-only report"
+                );
+                Self::default()
+            }
         }
     }
 

--- a/crates/trusty-agents-common/src/agents/quarantine.rs
+++ b/crates/trusty-agents-common/src/agents/quarantine.rs
@@ -93,19 +93,23 @@ const RECEIPT_FILE: &str = "RECEIPT.md";
 /// Why: these are the conditions under which acting at all would be reckless,
 /// as distinct from a per-file refusal (which is a [`SkipReason`], not an
 /// error). Every variant means NOTHING was touched.
-/// What: [`CorruptLedger`](Self::CorruptLedger) — the ownership ledger is
-/// unreadable, so the operator-owned exemption cannot be honoured;
+/// What: [`CorruptLedger`](Self::CorruptLedger) — the ownership ledger did not
+/// parse, or could not be read at all (#5626), so the operator-owned exemption
+/// cannot be honoured;
 /// [`EmptyRoster`](Self::EmptyRoster) — the bundled roster resolved empty, which
 /// would make every file classify as custom (a silent no-op that hides a broken
 /// install); [`Manifest`](Self::Manifest) — the ledger lock could not be taken.
 /// Test: `quarantine_refuses_on_a_corrupt_ledger`,
+/// `quarantine_refuses_when_the_ledger_cannot_be_read`,
 /// `quarantine_refuses_an_empty_roster`.
 #[derive(Debug, thiserror::Error)]
 pub enum QuarantineError {
-    /// The ownership ledger could not be read. Nothing was moved.
+    /// The ownership ledger was not established — corrupt, or unreadable.
+    /// Nothing was moved.
     #[error(
-        "agent ownership ledger is corrupt; refusing to move any file on the strength of an \
-         unreadable ledger, because the operator-owned exemption lives in it. Detail: {0}"
+        "agent ownership ledger could not be established; refusing to move any file on the \
+         strength of a ledger this run never read, because the operator-owned exemption lives \
+         in it. Detail: {0}"
     )]
     CorruptLedger(String),
     /// The bundled roster is empty. Nothing was moved.
@@ -193,7 +197,13 @@ fn sweep_locked(
 ) -> Result<QuarantineReport, QuarantineError> {
     let manifest = match AgentManifest::load_checked(tier_dir) {
         ManifestLoad::Ok(m) => m,
-        ManifestLoad::Corrupt(detail) => return Err(QuarantineError::CorruptLedger(detail)),
+        // #5626: an unreadable ledger refuses exactly like a corrupt one — the
+        // user-owned exemption it holds is the reason nothing may move, and a
+        // read that failed is no more evidence of a file's owner than a parse
+        // that failed.
+        ManifestLoad::Corrupt(detail) | ManifestLoad::Unreadable(detail) => {
+            return Err(QuarantineError::CorruptLedger(detail));
+        }
     };
     let vcs = VcsIndex::probe(tier_dir);
     let backup_dir = backup_root.join(run_id);

--- a/crates/trusty-agents-common/src/agents/quarantine_tests.rs
+++ b/crates/trusty-agents-common/src/agents/quarantine_tests.rs
@@ -840,6 +840,53 @@ fn a_sweep_destroys_no_content() {
     }
 }
 
+/// #5626 (ADR-0045). A ledger the sweep could not READ must reach the same
+/// refusal a corrupt one does.
+///
+/// `CorruptLedger` exists so nothing moves "on the strength of an unreadable
+/// ledger, because the operator-owned exemption lives in it". Before the fix
+/// only a parse failure reached it: an EACCES took `load_checked`'s catch-all
+/// `Err(_)` arm to `Ok(default)`, the operator's user-owned entry read as
+/// untracked, and this sweep renamed their file to `qa.md.disabled`.
+#[test]
+#[cfg(unix)]
+fn quarantine_refuses_when_the_ledger_cannot_be_read() {
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Restore the mode on drop so a panic cannot leave `TempDir` unable to
+    /// clean up.
+    struct ModeGuard(PathBuf);
+    impl Drop for ModeGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o644));
+        }
+    }
+
+    let f = Fixture::new();
+    let content = tm_agent("qa");
+    let original = f.write("qa.md", &content);
+    // The operator owns this file, and only the ledger says so.
+    f.ledger("qa.md", &content, Origin::User);
+
+    // A readable ledger already preserves it — establishes the fixture is real.
+    let healthy = f.sweep(&roster(&["qa"])).expect("sweep");
+    assert!(healthy.moved.is_empty(), "report: {healthy:?}");
+
+    let ledger = f.tier.join(MANIFEST_FILE);
+    let _guard = ModeGuard(ledger.clone());
+    std::fs::set_permissions(&ledger, std::fs::Permissions::from_mode(0o000)).expect("chmod ledger");
+
+    let err = f
+        .sweep(&roster(&["qa"]))
+        .expect_err("an unreadable ledger must refuse the whole sweep");
+    assert!(
+        matches!(err, QuarantineError::CorruptLedger(_)),
+        "expected CorruptLedger, got {err:?}"
+    );
+    assert!(original.exists(), "the operator's file must still be there");
+    assert!(!f.tier.join("qa.md.disabled").exists());
+}
+
 /// Every regular file under `root`, recursively. Test-only.
 fn walk(root: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();

--- a/crates/trusty-agents-common/src/agents/tier_audit.rs
+++ b/crates/trusty-agents-common/src/agents/tier_audit.rs
@@ -276,6 +276,49 @@ pub fn classify_tier_resident(
     TierResidentClass::Custom
 }
 
+/// The result of scanning one non-canonical agent tier.
+///
+/// Why (#5626, [ADR-0045]): [`audit_agent_tier`] used to answer with a bare
+/// `Vec`, so "scanned it, found nothing" and "could not scan it" were the same
+/// empty value. `tm doctor`'s `asset_tier` probe turned that into
+/// `CheckStatus::Ok` reading `no tm-owned agent files … (scanned: <dir>)` — a
+/// clean bill of health naming a directory it never opened, over the one defect
+/// (#4408) whose defining property was that no check could fail.
+/// What: [`Scanned`](Self::Scanned) carries the findings, possibly empty;
+/// [`Unscannable`](Self::Unscannable) carries the reason the directory could
+/// not be listed. A directory that does not exist is `Scanned(vec![])` —
+/// [ADR-0045] keeps `NotFound` benign, and an unprovisioned tier is not a
+/// finding.
+/// Test: `audit_missing_dir_is_empty`, `audit_unreadable_dir_is_unscannable`.
+///
+/// [ADR-0045]: ../../../../docs/adr/0045-distinguish-absent-from-undeterminable-on-destructive-paths.md
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TierScanResult {
+    /// The directory was listed. The vec holds every tm-owned file in it.
+    Scanned(Vec<MisplacedAgent>),
+    /// The directory could not be listed; the string says why. Nothing is
+    /// known about what it holds.
+    Unscannable(String),
+}
+
+impl TierScanResult {
+    /// The tm-owned files found, or none when the tier could not be scanned.
+    ///
+    /// Why: consumers that only render the file list should not re-match the
+    /// enum; the scan FAILURE is a separate question they answer separately.
+    /// What: the slice for [`Scanned`](Self::Scanned), empty for
+    /// [`Unscannable`](Self::Unscannable) — never read an empty return here as
+    /// "the tier is clean".
+    /// Test: `audit_unreadable_dir_is_unscannable`.
+    pub fn found(&self) -> &[MisplacedAgent] {
+        match self {
+            Self::Scanned(found) => found,
+            Self::Unscannable(_) => &[],
+        }
+    }
+}
+
 /// Scan one non-canonical agent tier and return the tm-owned files in it.
 ///
 /// Why: the shared scan both consumers run, so "what doctor flags" and "what
@@ -285,8 +328,11 @@ pub fn classify_tier_resident(
 /// this directory's ownership manifest for [`ownership_of`], classifies with
 /// [`classify_tier_resident`], and returns the
 /// non-[`TierResidentClass::Custom`] results sorted by name for stable output.
-/// A missing/unreadable `dir` returns an empty vec. A CORRUPT manifest degrades
-/// to [`TierOwnership::Untracked`] for every file rather than failing: shadowing
+/// A missing `dir` is [`TierScanResult::Scanned`] with nothing in it; a `dir`
+/// that exists but cannot be listed is [`TierScanResult::Unscannable`] (#5626)
+/// — the two were one value until then, and the difference is the whole
+/// verdict. A CORRUPT OR UNREADABLE manifest degrades to
+/// [`TierOwnership::Untracked`] for every file rather than failing: shadowing
 /// is established by the roster alone, so the load-bearing signal survives.
 /// Note the asymmetry that makes that safe — an unreadable ledger can only
 /// LOSE the user-owned exemption, so #4448 must re-read the ledger under its
@@ -297,17 +343,27 @@ pub fn classify_tier_resident(
 /// `audit_ignores_a_user_owned_entry_on_a_bundled_name`,
 /// `audit_reports_a_stranded_framework_entry`, `audit_missing_dir_is_empty`,
 /// `audit_tolerates_a_corrupt_manifest`,
+/// `audit_unreadable_dir_is_unscannable`,
 /// `audit_flags_a_renamed_file_that_declares_a_bundled_name`,
 /// `audit_ignores_a_bundled_filename_that_declares_a_custom_name`.
-pub fn audit_agent_tier(dir: &Path, bundled: &BTreeSet<String>) -> Vec<MisplacedAgent> {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return Vec::new();
+pub fn audit_agent_tier(dir: &Path, bundled: &BTreeSet<String>) -> TierScanResult {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        // #5626: absent is a clean tier; unlistable is not a tier we can speak
+        // for, and reporting it as clean is what asserted a scan that failed.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return TierScanResult::Scanned(Vec::new());
+        }
+        Err(e) => {
+            return TierScanResult::Unscannable(format!("{dir}: {e}", dir = dir.display()));
+        }
     };
     let manifest = match AgentManifest::load_checked(dir) {
         ManifestLoad::Ok(m) => m,
-        // Corrupt ledger: keep the roster-based half of the verdict rather than
-        // reporting nothing. See the doc comment.
-        ManifestLoad::Corrupt(_) => AgentManifest::default(),
+        // Ledger not established: keep the roster-based half of the verdict
+        // rather than reporting nothing. See the doc comment — the directory
+        // listing above is what makes that half trustworthy.
+        _ => AgentManifest::default(),
     };
 
     let mut found: Vec<MisplacedAgent> = entries
@@ -328,7 +384,7 @@ pub fn audit_agent_tier(dir: &Path, bundled: &BTreeSet<String>) -> Vec<Misplaced
         })
         .collect();
     found.sort_by(|a, b| a.name.cmp(&b.name));
-    found
+    TierScanResult::Scanned(found)
 }
 
 #[cfg(test)]

--- a/crates/trusty-agents-common/src/agents/tier_audit_tests.rs
+++ b/crates/trusty-agents-common/src/agents/tier_audit_tests.rs
@@ -16,6 +16,18 @@ use std::collections::BTreeSet;
 use super::*;
 use crate::agents::manifest::{AgentManifest, ManifestEntry, Origin, checksum};
 
+/// The findings of a scan that must have SUCCEEDED.
+///
+/// #5626: every case below asserts about what a real scan saw, so an
+/// `Unscannable` here is a broken fixture, never an empty result — which is
+/// exactly the conflation `TierScanResult` exists to end.
+fn audit_scanned(dir: &std::path::Path, bundled: &BTreeSet<String>) -> Vec<MisplacedAgent> {
+    match audit_agent_tier(dir, bundled) {
+        TierScanResult::Scanned(found) => found,
+        TierScanResult::Unscannable(why) => panic!("fixture is not scannable: {why}"),
+    }
+}
+
 /// Build a name set from string literals.
 fn roster(names: &[&str]) -> BTreeSet<String> {
     names.iter().map(|s| (*s).to_owned()).collect()
@@ -214,7 +226,7 @@ fn audit_reports_a_shadowing_stub() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("rust-engineer.md"), doc("rust-engineer")).unwrap();
 
-    let found = audit_agent_tier(tmp.path(), &roster(&["rust-engineer"]));
+    let found = audit_scanned(tmp.path(), &roster(&["rust-engineer"]));
     assert_eq!(found.len(), 1, "found: {found:?}");
     assert_eq!(found[0].name, "rust-engineer");
     assert_eq!(found[0].class, TierResidentClass::ShadowsBundled);
@@ -228,7 +240,7 @@ fn audit_flags_a_renamed_file_that_declares_a_bundled_name() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("helper.md"), doc("rust-engineer")).unwrap();
 
-    let found = audit_agent_tier(tmp.path(), &roster(&["rust-engineer"]));
+    let found = audit_scanned(tmp.path(), &roster(&["rust-engineer"]));
     assert_eq!(found.len(), 1, "found: {found:?}");
     assert_eq!(found[0].name, "rust-engineer");
     assert_eq!(found[0].path, tmp.path().join("helper.md"));
@@ -241,7 +253,7 @@ fn audit_ignores_a_bundled_filename_that_declares_a_custom_name() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("rust-engineer.md"), doc("acme-custom")).unwrap();
 
-    assert!(audit_agent_tier(tmp.path(), &roster(&["rust-engineer"])).is_empty());
+    assert!(audit_scanned(tmp.path(), &roster(&["rust-engineer"])).is_empty());
 }
 
 #[test]
@@ -252,7 +264,7 @@ fn audit_ignores_a_custom_agent() {
     std::fs::write(tmp.path().join("acme-internal.md"), doc("acme-internal")).unwrap();
     std::fs::write(tmp.path().join("qa.md"), doc("qa")).unwrap();
 
-    let found = audit_agent_tier(tmp.path(), &roster(&["qa"]));
+    let found = audit_scanned(tmp.path(), &roster(&["qa"]));
     assert_eq!(found.len(), 1, "found: {found:?}");
     assert_eq!(found[0].name, "qa");
 }
@@ -266,7 +278,7 @@ fn audit_ignores_a_user_owned_entry_on_a_bundled_name() {
     std::fs::write(tmp.path().join("qa.md"), doc("qa")).unwrap();
     track(tmp.path(), "qa.md", Origin::User);
 
-    assert!(audit_agent_tier(tmp.path(), &roster(&["qa"])).is_empty());
+    assert!(audit_scanned(tmp.path(), &roster(&["qa"])).is_empty());
 }
 
 #[test]
@@ -277,7 +289,7 @@ fn audit_reports_a_stranded_framework_entry() {
     std::fs::write(tmp.path().join("legacy-agent.md"), doc("legacy-agent")).unwrap();
     track(tmp.path(), "legacy-agent.md", Origin::Bundled);
 
-    let found = audit_agent_tier(tmp.path(), &roster(&["qa"]));
+    let found = audit_scanned(tmp.path(), &roster(&["qa"]));
     assert_eq!(found.len(), 1, "found: {found:?}");
     assert_eq!(found[0].class, TierResidentClass::StrandedFrameworkOwned);
 }
@@ -289,13 +301,57 @@ fn audit_ignores_a_user_owned_manifest_entry() {
     std::fs::write(tmp.path().join("mine.md"), doc("mine")).unwrap();
     track(tmp.path(), "mine.md", Origin::User);
 
-    assert!(audit_agent_tier(tmp.path(), &roster(&["qa"])).is_empty());
+    assert!(audit_scanned(tmp.path(), &roster(&["qa"])).is_empty());
 }
 
 #[test]
 fn audit_missing_dir_is_empty() {
+    // ADR-0045 §3: NotFound stays benign. An unprovisioned tier is genuinely
+    // empty, and making that an error would fail every project without one.
     let tmp = tempfile::tempdir().unwrap();
-    assert!(audit_agent_tier(&tmp.path().join("nope"), &roster(&["qa"])).is_empty());
+    assert!(audit_scanned(&tmp.path().join("nope"), &roster(&["qa"])).is_empty());
+}
+
+/// #5626 (ADR-0045). A directory that exists but cannot be LISTED is not an
+/// empty directory.
+///
+/// Before the fix `read_dir`'s error took the same `return Vec::new()` as a
+/// clean scan, and `tm doctor`'s `asset_tier` probe printed
+/// `no tm-owned agent files … (scanned: <dir>)` over a shadowing stub it never
+/// saw.
+#[test]
+#[cfg(unix)]
+fn audit_unreadable_dir_is_unscannable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Restore the mode on drop so `TempDir` can still clean up after a panic.
+    struct ModeGuard(std::path::PathBuf);
+    impl Drop for ModeGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o755));
+        }
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let tier = tmp.path().join("agents");
+    std::fs::create_dir(&tier).unwrap();
+    std::fs::write(tier.join("qa.md"), doc("qa")).unwrap();
+
+    // Readable, the shadowing file is found — establishes the fixture is real.
+    assert_eq!(audit_scanned(&tier, &roster(&["qa"])).len(), 1);
+
+    let _guard = ModeGuard(tier.clone());
+    std::fs::set_permissions(&tier, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let scan = audit_agent_tier(&tier, &roster(&["qa"]));
+    assert!(
+        matches!(scan, TierScanResult::Unscannable(_)),
+        "expected Unscannable, got {scan:?}"
+    );
+    assert!(
+        scan.found().is_empty(),
+        "an unscannable tier yields no findings — and no clean bill either"
+    );
 }
 
 #[test]
@@ -310,7 +366,7 @@ fn audit_tolerates_a_corrupt_manifest() {
     )
     .unwrap();
 
-    let found = audit_agent_tier(tmp.path(), &roster(&["qa"]));
+    let found = audit_scanned(tmp.path(), &roster(&["qa"]));
     assert_eq!(found.len(), 1, "found: {found:?}");
     assert_eq!(found[0].class, TierResidentClass::ShadowsBundled);
 }
@@ -323,7 +379,7 @@ fn audit_is_sorted_by_name() {
         std::fs::write(tmp.path().join(format!("{name}.md")), doc(name)).unwrap();
     }
 
-    let found = audit_agent_tier(tmp.path(), &roster(&["qa", "engineer", "rust-engineer"]));
+    let found = audit_scanned(tmp.path(), &roster(&["qa", "engineer", "rust-engineer"]));
     let names: Vec<&str> = found.iter().map(|f| f.name.as_str()).collect();
     assert_eq!(names, vec!["engineer", "qa", "rust-engineer"]);
 }

--- a/crates/trusty-agents-common/src/skills/deployer.rs
+++ b/crates/trusty-agents-common/src/skills/deployer.rs
@@ -177,7 +177,10 @@ fn deploy_skills_locked(
 ) -> Result<DeployStats> {
     let mut stats = DeployStats::default();
 
-    let mut manifest = SkillManifest::load(dest);
+    // #5626: a ledger that could not be READ must stop the deploy — the empty
+    // default reclassifies every managed skill as user-owned, and the files this
+    // run writes then carry no ledger entry, which is the #4881 freeze.
+    let mut manifest = SkillManifest::load_checked(dest)?;
     // #4881: the snapshot the compare-and-swap save is checked against.
     let base = manifest.clone();
     let now = chrono::Utc::now().to_rfc3339();

--- a/crates/trusty-agents-common/src/skills/deployer_tests.rs
+++ b/crates/trusty-agents-common/src/skills/deployer_tests.rs
@@ -49,7 +49,7 @@ fn deploy_new_skill() {
     let doctor = fs::read_to_string(tgt.path().join("tm-doctor").join("SKILL.md")).unwrap();
     assert!(doctor.contains("Diagnostic skill."));
 
-    let manifest = SkillManifest::load(tgt.path());
+    let manifest = SkillManifest::load_checked(tgt.path()).unwrap();
     assert!(manifest.is_managed("tm-doctor"));
 }
 
@@ -421,7 +421,7 @@ fn deploy_blocks_while_the_skill_ledger_lock_is_held() {
         .expect("deploy must complete once the lock is released");
     assert_eq!(stats.deployed.len(), 2);
     assert!(
-        SkillManifest::load(tgt.path()).is_managed("tm-doctor"),
+        SkillManifest::load_checked(tgt.path()).unwrap().is_managed("tm-doctor"),
         "the released deploy must have recorded its entries"
     );
 }
@@ -445,7 +445,7 @@ fn a_racing_writer_freezes_nothing_on_either_side() {
 
     // A first, uncontended deploy. This is the `base` an in-flight deploy loads.
     deploy_skills(src.path(), tgt.path()).unwrap();
-    let base = SkillManifest::load(tgt.path());
+    let base = SkillManifest::load_checked(tgt.path()).unwrap();
 
     // A writer that does NOT take the ledger lock — an older installed `tm`
     // during a rollout — publishes its own entry after our base was loaded.
@@ -496,7 +496,7 @@ fn a_racing_writer_freezes_nothing_on_either_side() {
 
     // Nothing is frozen on the RACER's side either: a blind save would have
     // dropped its entry, leaving its file untracked and skipped from then on.
-    let final_manifest = SkillManifest::load(tgt.path());
+    let final_manifest = SkillManifest::load_checked(tgt.path()).unwrap();
     assert!(
         final_manifest.is_managed("racing-writer-skill"),
         "the racing writer's entry must survive, or ITS file freezes instead"
@@ -532,7 +532,7 @@ fn deploy_records_files_written_before_a_mid_loop_failure() {
     let written = tgt.path().join("aaa-skill").join("SKILL.md");
     assert!(written.exists(), "aaa-skill was written before the failure");
     // ...and the ledger records it, so it is not orphaned.
-    let manifest = SkillManifest::load(tgt.path());
+    let manifest = SkillManifest::load_checked(tgt.path()).unwrap();
     assert!(
         manifest.is_managed("aaa-skill"),
         "a file written before the failure must still be recorded"
@@ -611,7 +611,7 @@ fn deploy_directory_skill_records_every_file_in_the_manifest() {
 
     deploy_skills(src.path(), tgt.path()).unwrap();
 
-    let manifest = SkillManifest::load(tgt.path());
+    let manifest = SkillManifest::load_checked(tgt.path()).unwrap();
     for key in [
         "duetto-design-system",
         "duetto-design-system/metadata.json",
@@ -663,7 +663,7 @@ fn deploy_flat_skill_still_works_alongside_a_directory_skill() {
             .join("cli.md")
             .is_file()
     );
-    let manifest = SkillManifest::load(tgt.path());
+    let manifest = SkillManifest::load_checked(tgt.path()).unwrap();
     assert!(manifest.is_managed("tm-doctor/references/cli.md"));
 }
 
@@ -748,5 +748,57 @@ fn deploy_directory_skill_preserves_a_user_edited_reference() {
             .deployed
             .contains(&"duetto-design-system/references/index.md".to_string()),
         "{stats:?}"
+    );
+}
+
+/// #5626 (ADR-0045). A ledger the deploy could not READ must stop the deploy,
+/// not read as "this tier manages nothing".
+///
+/// The empty default reclassifies every managed skill as user-owned, and the
+/// files this run writes land with no ledger entry behind them — bytes newer
+/// than any recorded checksum, which `deploy_one_file` reads as a hand-edit and
+/// skips from then on. Before the fix the last assertion below found `SKILL.md`
+/// on disk: the deploy wrote it on the strength of a ledger it never read.
+#[test]
+#[cfg(unix)]
+fn deploy_refuses_when_the_skill_ledger_cannot_be_read() {
+    use crate::skills::manifest::{SKILL_MANIFEST_FILE, SkillManifestEntry};
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Restore the mode on drop so a panic cannot leave `TempDir` unable to
+    /// clean up.
+    struct ModeGuard(std::path::PathBuf);
+    impl Drop for ModeGuard {
+        fn drop(&mut self) {
+            let _ = fs::set_permissions(&self.0, fs::Permissions::from_mode(0o644));
+        }
+    }
+
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    write_sources(src.path());
+
+    // A tier that HAS a ledger: tm-doctor was deployed here once and its file
+    // has since been removed, so this deploy is about to write it again.
+    let mut seeded = SkillManifest::default();
+    seeded.managed.insert(
+        "tm-doctor".to_string(),
+        SkillManifestEntry {
+            checksum: checksum("whatever"),
+            deployed_at: "2026-08-12T00:00:00Z".to_string(),
+        },
+    );
+    seeded.save(tgt.path()).unwrap();
+
+    let ledger = tgt.path().join(SKILL_MANIFEST_FILE);
+    let _guard = ModeGuard(ledger.clone());
+    fs::set_permissions(&ledger, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let err = deploy_skills(src.path(), tgt.path())
+        .expect_err("an unreadable ledger must fail the deploy, not empty it");
+    assert!(matches!(err, ManifestError::Io(_)), "{err:?}");
+    assert!(
+        !tgt.path().join("tm-doctor").join("SKILL.md").exists(),
+        "nothing may be written on the strength of a ledger that could not be read"
     );
 }

--- a/crates/trusty-agents-common/src/skills/manifest.rs
+++ b/crates/trusty-agents-common/src/skills/manifest.rs
@@ -138,19 +138,41 @@ impl Default for SkillManifest {
 }
 
 impl SkillManifest {
-    /// Load the manifest from `target_dir`, defaulting to empty when absent.
+    /// Load the manifest from `target_dir`, defaulting to empty only when it is
+    /// genuinely ABSENT.
     ///
-    /// Why: a first-ever deploy has no manifest; treating a missing file as an
-    /// empty manifest keeps the deployer's logic uniform.
-    /// What: reads `<target_dir>/.trusty-mpm-skills-manifest.json`; a missing or
-    /// unparseable file yields a fresh empty manifest.
-    /// Test: `skill_manifest_load_missing_returns_empty`, `skill_manifest_round_trip`.
-    pub fn load(target_dir: &Path) -> Self {
-        let path = target_dir.join(SKILL_MANIFEST_FILE);
-        match std::fs::read_to_string(&path) {
-            Ok(raw) => serde_json::from_str(&raw).unwrap_or_default(),
-            Err(_) => Self::default(),
-        }
+    /// Why (#5626, [ADR-0045]): the previous `load` answered a missing file, an
+    /// unparseable one, and an EACCES/ESTALE/EIO read failure with the same
+    /// empty manifest. Every consumer reads empty as "this tier manages
+    /// nothing", so one unreadable ledger reclassifies every managed skill as
+    /// user-owned: `deployer::deploy_one_file` then skips those files and
+    /// records nothing for them, which is the #4881 freeze reached through a
+    /// read failure instead of a lost update. The distinction already existed
+    /// one method away in [`Self::read_parsed`], added for
+    /// [`Self::save_merging`]; this routes `load` through the same helper rather
+    /// than keeping a third reading of the same file.
+    /// What: `Ok(default)` when the file does not exist (a first-ever deploy —
+    /// [ADR-0045] keeps `NotFound` benign); `Ok(parsed)` when it reads;
+    /// `Err(Io)` when it exists but does not parse, naming `tm repair deploy`,
+    /// which is the rule `agents::deployer` already applies to a corrupt agent
+    /// ledger; `Err` for any other I/O failure.
+    /// Test: `skill_manifest_load_missing_returns_empty`,
+    /// `skill_manifest_load_propagates_an_unreadable_ledger`,
+    /// `skill_manifest_load_rejects_a_corrupt_ledger`, `skill_manifest_round_trip`.
+    ///
+    /// [ADR-0045]: ../../../../docs/adr/0045-distinguish-absent-from-undeterminable-on-destructive-paths.md
+    pub fn load_checked(target_dir: &Path) -> Result<Self> {
+        // #5626: `read_parsed` already separates absent from unparseable and
+        // propagates every other I/O error; only the None arm is decided here.
+        Self::read_parsed(target_dir)?.ok_or_else(|| {
+            ManifestError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "{} is not valid JSON; run `tm repair deploy` to recover",
+                    target_dir.join(SKILL_MANIFEST_FILE).display()
+                ),
+            ))
+        })
     }
 
     /// Persist the manifest to `<target_dir>/.trusty-mpm-skills-manifest.json`
@@ -242,12 +264,12 @@ impl SkillManifest {
 
     /// Read the on-disk manifest, distinguishing "absent" from "unparseable".
     ///
-    /// Why (#4881 review): [`SkillManifest::load`] collapses both into the empty
-    /// default, which is right for a first-ever deploy and wrong for corruption
-    /// — a merge that starts from "empty" because it could not read the file
-    /// publishes a ledger missing everything the file held. Only
-    /// [`SkillManifest::save_merging`] needs the distinction, so this stays
-    /// private rather than adding a second public load API.
+    /// Why (#4881 review): a merge that starts from "empty" because it could
+    /// not read the file publishes a ledger missing everything the file held.
+    /// [`SkillManifest::load_checked`] reads through this same helper since
+    /// #5626, so the three states are separated once for both callers; it stays
+    /// private because the `Ok(None)` shape is the merge's vocabulary, not a
+    /// load API's.
     /// What: `Ok(Some(default))` when the file is absent (nothing was ever
     /// deployed here), `Ok(Some(parsed))` when it reads, `Ok(None)` when it
     /// exists but does not parse. A non-`NotFound` I/O error propagates.

--- a/crates/trusty-agents-common/src/skills/manifest_tests.rs
+++ b/crates/trusty-agents-common/src/skills/manifest_tests.rs
@@ -27,7 +27,7 @@ fn skill_manifest_load_missing_returns_empty() {
     // A directory with no manifest file must yield an empty, valid
     // manifest rather than an error.
     let tmp = TempDir::new().unwrap();
-    let manifest = SkillManifest::load(tmp.path());
+    let manifest = SkillManifest::load_checked(tmp.path()).unwrap();
     assert_eq!(manifest.version, SKILL_MANIFEST_VERSION);
     assert!(manifest.managed.is_empty());
 }
@@ -42,7 +42,7 @@ fn skill_manifest_round_trip() {
         .insert("tm-doctor.md".into(), sample_entry());
     manifest.save(tmp.path()).unwrap();
 
-    let loaded = SkillManifest::load(tmp.path());
+    let loaded = SkillManifest::load_checked(tmp.path()).unwrap();
     assert_eq!(loaded, manifest);
     assert!(tmp.path().join(SKILL_MANIFEST_FILE).exists());
 }
@@ -113,7 +113,7 @@ fn skill_manifest_lock_serialises_concurrent_writers() {
             let dir = dir.clone();
             std::thread::spawn(move || {
                 with_skill_manifest_lock::<(), ManifestError, _>(&dir, || {
-                    let mut m = SkillManifest::load(&dir);
+                    let mut m = SkillManifest::load_checked(&dir).unwrap();
                     m.managed.insert(format!("skill-{i}"), sample_entry());
                     std::thread::sleep(std::time::Duration::from_millis(5));
                     m.save(&dir)
@@ -126,7 +126,7 @@ fn skill_manifest_lock_serialises_concurrent_writers() {
         h.join().unwrap();
     }
 
-    let final_manifest = SkillManifest::load(&dir);
+    let final_manifest = SkillManifest::load_checked(&dir).unwrap();
     assert_eq!(
         final_manifest.managed.len(),
         8,
@@ -175,7 +175,7 @@ fn skill_manifest_save_merging_folds_in_a_concurrent_writer() {
         SkillManifestSave::Merged
     );
 
-    let on_disk = SkillManifest::load(dir);
+    let on_disk = SkillManifest::load_checked(dir).unwrap();
     assert!(on_disk.is_managed("ours"), "our own entry must be recorded");
     assert!(
         on_disk.is_managed("from-the-other-writer"),
@@ -210,7 +210,7 @@ fn skill_manifest_save_merging_applies_this_runs_removals() {
         SkillManifestSave::Merged
     );
 
-    let on_disk = SkillManifest::load(dir);
+    let on_disk = SkillManifest::load_checked(dir).unwrap();
     assert!(!on_disk.is_managed("prune-me"), "our removal must apply");
     assert!(on_disk.is_managed("keep"));
     assert!(
@@ -233,16 +233,16 @@ fn skill_manifest_save_merging_writes_when_unchanged() {
         first.save_merging(dir, &base).unwrap(),
         SkillManifestSave::Written
     );
-    assert!(SkillManifest::load(dir).is_managed("tm-doctor"));
+    assert!(SkillManifest::load_checked(dir).unwrap().is_managed("tm-doctor"));
 
-    let base = SkillManifest::load(dir);
+    let base = SkillManifest::load_checked(dir).unwrap();
     let mut second = base.clone();
     second.managed.insert("tm-workflow".into(), sample_entry());
     assert_eq!(
         second.save_merging(dir, &base).unwrap(),
         SkillManifestSave::Written
     );
-    let on_disk = SkillManifest::load(dir);
+    let on_disk = SkillManifest::load_checked(dir).unwrap();
     assert!(on_disk.is_managed("tm-doctor"));
     assert!(on_disk.is_managed("tm-workflow"));
 }
@@ -273,7 +273,7 @@ fn skill_manifest_save_merging_over_a_corrupt_ledger_keeps_the_base() {
         SkillManifestSave::OverwroteUnreadable
     );
 
-    let on_disk = SkillManifest::load(dir);
+    let on_disk = SkillManifest::load_checked(dir).unwrap();
     assert_eq!(
         on_disk.managed.len(),
         10,

--- a/crates/trusty-agents-common/src/skills/reconcile.rs
+++ b/crates/trusty-agents-common/src/skills/reconcile.rs
@@ -100,7 +100,7 @@ pub fn adopt_unmanaged_bundled_skills(
     // neither blocks on a concurrent writer nor leaves a lock sidecar in a
     // directory it will not touch — `adopt_no_findings_writes_nothing` holds
     // the target byte-identical. The authoritative scan happens again inside.
-    if unmanaged_bundled_skills(dest, bundled).is_empty() {
+    if unmanaged_bundled_skills(dest, bundled)?.is_empty() {
         return Ok(Vec::new());
     }
     with_skill_manifest_lock(dest, || adopt_locked(dest, bundled, backup_root))
@@ -120,12 +120,13 @@ fn adopt_locked(
     bundled: &BTreeSet<String>,
     backup_root: &Path,
 ) -> Result<Vec<AdoptedSkill>> {
-    let found = unmanaged_bundled_skills(dest, bundled);
+    let found = unmanaged_bundled_skills(dest, bundled)?;
     if found.is_empty() {
         return Ok(Vec::new());
     }
 
-    let mut manifest = SkillManifest::load(dest);
+    // #5626: adoption re-stamps the ledger, so an unreadable one must stop it.
+    let mut manifest = SkillManifest::load_checked(dest)?;
     // #4881: the snapshot the merging save replays this run's delta against.
     let base = manifest.clone();
     let now = chrono::Utc::now().to_rfc3339();
@@ -178,7 +179,7 @@ fn adopt_locked(
 pub fn preview_unmanaged_bundled_skills(
     dest: &Path,
     bundled: &BTreeSet<String>,
-) -> Vec<UnmanagedBundledSkill> {
+) -> Result<Vec<UnmanagedBundledSkill>> {
     unmanaged_bundled_skills(dest, bundled)
 }
 
@@ -241,7 +242,9 @@ fn force_adopt_locked(
     bundled: &BTreeSet<String>,
     backup_root: &Path,
 ) -> Result<Vec<AdoptedSkill>> {
-    let mut manifest = SkillManifest::load(dest);
+    // #5626: same rule as `adopt_locked` — never re-stamp against a ledger the
+    // run could not read.
+    let mut manifest = SkillManifest::load_checked(dest)?;
     let base = manifest.clone();
     let now = chrono::Utc::now().to_rfc3339();
     let mut adopted = Vec::new();

--- a/crates/trusty-agents-common/src/skills/reconcile_tests.rs
+++ b/crates/trusty-agents-common/src/skills/reconcile_tests.rs
@@ -51,7 +51,7 @@ fn adopt_registers_the_skill_and_its_references() {
             "tm-workflow/references/a.md".to_string()
         ]
     );
-    let manifest = SkillManifest::load(dest.path());
+    let manifest = SkillManifest::load_checked(dest.path()).unwrap();
     assert!(manifest.is_managed("tm-workflow"));
     assert!(manifest.is_managed("tm-workflow/references/a.md"));
     // The recorded checksum is of the content ON DISK, so the deployer sees
@@ -102,7 +102,7 @@ fn adopt_leaves_an_operator_skill_alone() {
             .unwrap();
 
     assert!(adopted.is_empty());
-    assert!(!SkillManifest::load(dest.path()).is_managed("my-own-skill"));
+    assert!(!SkillManifest::load_checked(dest.path()).unwrap().is_managed("my-own-skill"));
     assert_eq!(
         fs::read_to_string(dest.path().join("my-own-skill").join("SKILL.md")).unwrap(),
         "mine"
@@ -176,7 +176,8 @@ fn preview_matches_what_adoption_touches() {
     let backups = TempDir::new().unwrap();
     stage_untracked(dest.path(), "tm-workflow", "stale");
 
-    let preview = preview_unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]));
+    let preview =
+        preview_unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).unwrap();
     let adopted =
         adopt_unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]), backups.path())
             .unwrap();
@@ -271,7 +272,7 @@ fn force_adopt_leaves_an_operator_skill_alone() {
 
     assert!(adopted.is_empty(), "{adopted:?}");
     assert_eq!(fs::read_to_string(&path).unwrap(), "OPERATOR CONTENT");
-    assert!(!SkillManifest::load(dest.path()).is_managed("my-own-skill"));
+    assert!(!SkillManifest::load_checked(dest.path()).unwrap().is_managed("my-own-skill"));
 }
 
 #[test]
@@ -303,7 +304,7 @@ fn force_adopt_leaves_an_operator_reference_stray_untracked() {
         vec!["tm-workflow".to_string()],
         "only the tracked entry point may be re-stamped: {adopted:?}"
     );
-    let manifest = SkillManifest::load(dest.path());
+    let manifest = SkillManifest::load_checked(dest.path()).unwrap();
     assert!(
         !manifest.is_managed("tm-workflow/references/my-notes.md"),
         "the operator's stray must stay untracked"

--- a/crates/trusty-agents-common/src/skills/tiers.rs
+++ b/crates/trusty-agents-common/src/skills/tiers.rs
@@ -245,7 +245,10 @@ pub fn list_project_custom_stems(dest: &Path) -> Result<BTreeSet<String>> {
     if !dest.is_dir() {
         return Ok(stems);
     }
-    let manifest = SkillManifest::load(dest);
+    // #5626: an unreadable ledger would classify every managed skill as
+    // project-custom, and the planner drops project-custom stems from the
+    // bundled deploy — the #4605 permanent stall, tier-wide.
+    let manifest = SkillManifest::load_checked(dest)?;
     for entry in std::fs::read_dir(dest)? {
         let entry = entry?;
         if !entry.file_type()?.is_dir() {

--- a/crates/trusty-agents-common/src/skills/unmanaged.rs
+++ b/crates/trusty-agents-common/src/skills/unmanaged.rs
@@ -36,6 +36,7 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
+use crate::agents::manifest::Result;
 use crate::skills::manifest::SkillManifest;
 
 /// The entry-point filename Claude Code discovers a skill directory by.
@@ -110,19 +111,23 @@ impl UnmanagedBundledSkill {
 /// A missing or unreadable `dest` yields an empty vec — an unprovisioned tier
 /// is not a finding. An EMPTY `bundled` set likewise yields nothing: callers
 /// must treat that as "cannot classify by name", never as "nothing is
-/// bundled", since the latter reading would condemn every skill at once.
+/// bundled", since the latter reading would condemn every skill at once. A
+/// LEDGER that cannot be read is an `Err` (#5626): "untracked" is a claim about
+/// what the ledger says, and an unreadable ledger says nothing — reporting
+/// every bundled skill in the tier as unmanaged is the same false positive at
+/// the scale of the whole tier.
 /// Test: `unmanaged_finds_a_bundled_named_untracked_skill`,
 /// `unmanaged_ignores_a_managed_skill`, `unmanaged_ignores_an_operator_skill`,
 /// `unmanaged_missing_dest_is_empty`, `unmanaged_lists_reference_files`.
 pub fn unmanaged_bundled_skills(
     dest: &Path,
     bundled: &BTreeSet<String>,
-) -> Vec<UnmanagedBundledSkill> {
-    let manifest = SkillManifest::load(dest);
-    bundled_skill_dirs(dest, bundled)
+) -> Result<Vec<UnmanagedBundledSkill>> {
+    let manifest = SkillManifest::load_checked(dest)?;
+    Ok(bundled_skill_dirs(dest, bundled)
         .into_iter()
         .filter(|skill| !manifest.is_managed(&skill.stem))
-        .collect()
+        .collect())
 }
 
 /// Every bundled-named skill directory at `dest`, managed or not.

--- a/crates/trusty-agents-common/src/skills/unmanaged_tests.rs
+++ b/crates/trusty-agents-common/src/skills/unmanaged_tests.rs
@@ -33,7 +33,7 @@ fn unmanaged_finds_a_bundled_named_untracked_skill() {
     let dest = TempDir::new().unwrap();
     stage_untracked(dest.path(), "tm-workflow", "stale body");
 
-    let found = unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]));
+    let found = unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]).unwrap();
     assert_eq!(found.len(), 1, "expected one finding, got {found:?}");
     assert_eq!(found[0].stem, "tm-workflow");
     assert_eq!(found[0].dir, dest.path().join("tm-workflow"));
@@ -51,7 +51,7 @@ fn unmanaged_ignores_a_managed_skill() {
     fs::write(source.path().join("tm-workflow.md"), "v1").unwrap();
     deploy_skills(source.path(), dest.path()).unwrap();
 
-    assert!(unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).is_empty());
+    assert!(unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).unwrap().is_empty());
 }
 
 #[test]
@@ -62,7 +62,7 @@ fn unmanaged_ignores_an_operator_skill() {
     let dest = TempDir::new().unwrap();
     stage_untracked(dest.path(), "my-own-skill", "mine");
 
-    assert!(unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).is_empty());
+    assert!(unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).unwrap().is_empty());
 }
 
 #[test]
@@ -72,14 +72,14 @@ fn unmanaged_empty_roster_reports_nothing() {
     let dest = TempDir::new().unwrap();
     stage_untracked(dest.path(), "tm-workflow", "stale body");
 
-    assert!(unmanaged_bundled_skills(dest.path(), &BTreeSet::new()).is_empty());
+    assert!(unmanaged_bundled_skills(dest.path(), &BTreeSet::new()).unwrap().is_empty());
 }
 
 #[test]
 fn unmanaged_missing_dest_is_empty() {
     // An unprovisioned tier is not a finding, and never an error.
     assert!(
-        unmanaged_bundled_skills(Path::new("/nonexistent/skills"), &roster(&["tm"])).is_empty()
+        unmanaged_bundled_skills(Path::new("/nonexistent/skills"), &roster(&["tm"])).unwrap().is_empty()
     );
 }
 
@@ -89,7 +89,7 @@ fn unmanaged_ignores_a_directory_without_an_entry_point() {
     let dest = TempDir::new().unwrap();
     fs::create_dir_all(dest.path().join("tm-workflow").join("references")).unwrap();
 
-    assert!(unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).is_empty());
+    assert!(unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"])).unwrap().is_empty());
 }
 
 #[test]
@@ -104,7 +104,7 @@ fn unmanaged_lists_reference_files() {
     fs::write(refs.join("a.md"), "a").unwrap();
     fs::write(refs.join("notes.txt"), "ignored").unwrap();
 
-    let found = unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]));
+    let found = unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]).unwrap();
     assert_eq!(
         found[0].files,
         vec![
@@ -125,7 +125,7 @@ fn manifest_keys_match_the_deployer_key_shape() {
     fs::create_dir_all(&refs).unwrap();
     fs::write(refs.join("a.md"), "a").unwrap();
 
-    let found = unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]));
+    let found = unmanaged_bundled_skills(dest.path(), &roster(&["tm-workflow"]).unwrap();
     assert_eq!(
         found[0].manifest_keys(),
         vec![
@@ -157,7 +157,7 @@ fn bundled_skill_dirs_includes_a_managed_skill() {
     let roster: BTreeSet<String> = ["tm-workflow".to_string()].into_iter().collect();
 
     assert!(
-        unmanaged_bundled_skills(dest.path(), &roster).is_empty(),
+        unmanaged_bundled_skills(dest.path(), &roster).unwrap().is_empty(),
         "a managed skill is not an unmanaged finding"
     );
     let all = bundled_skill_dirs(dest.path(), &roster);

--- a/crates/trusty-bm25-daemon/src/batch_queue.rs
+++ b/crates/trusty-bm25-daemon/src/batch_queue.rs
@@ -15,8 +15,14 @@
 //! channel round-trip (~microseconds) plus the score computation; that is
 //! invisible at typical palace sizes (hundreds to low thousands of drawers).
 //!
+//! A write's ack is the daemon's statement that the write is ON DISK, so the
+//! worker holds each per-op reply until the flush that covers it succeeds
+//! (#5627). That costs a write up to one coalescing window of latency and buys
+//! the guarantee an acked write is not lost by a crash or a supervisor reap.
+//!
 //! Test: `batch_queue_persists_indexed_doc`, `batch_queue_search_finds_match`,
-//! `batch_queue_delete_removes_doc`, `batch_queue_rebuild_clears_index`.
+//! `batch_queue_delete_removes_doc`, `batch_queue_rebuild_clears_index`,
+//! `batch_queue_index_ack_fails_when_the_flush_fails`.
 
 use std::time::Duration;
 
@@ -142,8 +148,14 @@ impl BatchQueue {
     /// Why: callers (the JSON-RPC dispatch) need a per-request future so
     /// they can return a typed response when the write lands.
     /// What: sends a `Op::Index` on the channel, awaits the worker's
-    /// oneshot reply. Returns `true` when the doc was inserted/updated.
-    /// Test: `batch_queue_persists_indexed_doc`.
+    /// oneshot reply. Returns `true` when the doc was inserted/updated AND the
+    /// snapshot covering it reached disk — the reply is released by that flush,
+    /// so it lands at the end of the write window rather than on the in-memory
+    /// mutation (#5627). An `Err` means the write may not have survived; the
+    /// document is in the live index either way, so a search sees it and a
+    /// restart may not.
+    /// Test: `batch_queue_persists_indexed_doc`,
+    /// `batch_queue_index_ack_fails_when_the_flush_fails`.
     pub async fn index_doc(&self, doc_id: String, text: String) -> Result<bool> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.tx
@@ -164,7 +176,9 @@ impl BatchQueue {
     /// Why: same motivation as [`Self::index_doc`] — reserved for the dream
     /// subprocess, but exposed on the queue so the dispatch code is uniform.
     /// What: sends a `Op::Delete` on the channel. Returns `true` iff the id
-    /// was present beforehand.
+    /// was present beforehand. Carries the same durability contract as
+    /// [`Self::index_doc`] (#5627): the reply waits for the flush that covers
+    /// the batch.
     /// Test: `batch_queue_delete_removes_doc`.
     pub async fn delete(&self, doc_id: String) -> Result<bool> {
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -343,7 +357,8 @@ async fn batch_worker(mut rx: mpsc::Receiver<Op>, mut index: PalaceBm25Index, co
                 continue;
             }
             Op::Flush { reply } => {
-                let _ = reply.send(flush_now(&mut index));
+                // Cold path: no batch is open, so there are no held acks.
+                let _ = reply.send(flush_now(&mut index, Vec::new()));
                 continue;
             }
             Op::MissingDocs { doc_ids, reply } => {
@@ -364,7 +379,9 @@ async fn batch_worker(mut rx: mpsc::Receiver<Op>, mut index: PalaceBm25Index, co
 
         // We have a write op — enter batching mode.
         let mut write_count: usize = 0;
-        apply_write_op(&mut index, writes_started_with);
+        // #5627: every write's ack rides here until the flush that covers it.
+        let mut pending: Vec<PendingAck> = Vec::new();
+        pending.extend(apply_write_op(&mut index, writes_started_with));
         write_count += 1;
 
         let deadline = sleep(config.write_window);
@@ -404,14 +421,20 @@ async fn batch_worker(mut rx: mpsc::Receiver<Op>, mut index: PalaceBm25Index, co
                         // the caller is usually a shutdown or reap path that
                         // must not lose the window's writes. The outer loop
                         // still flushes at the window's end; `flush` is a
-                        // no-op once the dirty bit is clear.
-                        let _ = reply.send(flush_now(&mut index));
+                        // no-op once the dirty bit is clear. #5627: this flush
+                        // covers the batch so far, so it releases those acks.
+                        let held = std::mem::take(&mut pending);
+                        let _ = reply.send(flush_now(&mut index, held));
                     }
                     Some(Op::Rebuild { reply }) => {
                         // Honour the rebuild atomically. Flush the pending
                         // write batch first so the new empty state is the
                         // last thing on disk.
                         let flush_pre = index.flush();
+                        // #5627: the rebuild is about to drop this batch from
+                        // memory, so its acks are decided by THIS flush and
+                        // nothing later can rescue them.
+                        release_acks(std::mem::take(&mut pending), &flush_pre);
                         if let Err(e) = flush_pre {
                             // Surface the flush error to whoever issued the
                             // rebuild — they care about durability.
@@ -432,14 +455,18 @@ async fn batch_worker(mut rx: mpsc::Receiver<Op>, mut index: PalaceBm25Index, co
                         break;
                     }
                     Some(write_op @ (Op::Index { .. } | Op::Delete { .. })) => {
-                        apply_write_op(&mut index, write_op);
+                        pending.extend(apply_write_op(&mut index, write_op));
                         write_count += 1;
                     }
                     None => {
                         // Channel closed mid-batch — flush below and exit.
-                        if let Err(e) = index.flush() {
+                        let flushed = index.flush();
+                        if let Err(e) = &flushed {
                             tracing::warn!("BM25 snapshot flush at shutdown failed: {e:#}");
                         }
+                        // #5627: a caller still awaiting its ack when the queue
+                        // shuts down hears the truth, not a dropped channel.
+                        release_acks(std::mem::take(&mut pending), &flushed);
                         return;
                     }
                 }
@@ -452,9 +479,13 @@ async fn batch_worker(mut rx: mpsc::Receiver<Op>, mut index: PalaceBm25Index, co
                 doc_count = index.doc_count(),
                 "bm25 write batch flushing snapshot"
             );
-            if let Err(e) = index.flush() {
+            let flushed = index.flush();
+            if let Err(e) = &flushed {
                 tracing::error!("BM25 snapshot flush failed: {e:#}");
             }
+            // #5627: the acks this batch held are true only now, and only if
+            // the flush above succeeded.
+            release_acks(std::mem::take(&mut pending), &flushed);
         }
     }
 }
@@ -473,28 +504,76 @@ fn stats_of(index: &PalaceBm25Index) -> StatsResult {
     }
 }
 
-/// Flush the snapshot and report the resulting document count.
+/// Flush the snapshot, release the acks it covers, and report the count.
 ///
 /// Why: the worker answers `Op::Flush` from two places and both must report
 /// the same thing — the count that is now ON DISK, so a caller can treat a
-/// successful flush as durability and not merely as "the call returned".
-/// What: `index.flush()` then `doc_count()`. A clean index flushes nothing and
-/// still reports its count.
-/// Test: `batch_queue_flush_persists_within_the_write_window`.
-fn flush_now(index: &mut PalaceBm25Index) -> Result<usize> {
-    index.flush()?;
+/// successful flush as durability and not merely as "the call returned". Since
+/// #5627 the same flush also decides the fate of every write ack held behind
+/// it, and that pairing lives here so a second call site cannot flush without
+/// answering the writers it just made durable.
+/// What: `index.flush()`, then [`release_acks`] over `pending` (empty on the
+/// cold path, where no batch is open), then `doc_count()`. A clean index
+/// flushes nothing and still reports its count.
+/// Test: `batch_queue_flush_persists_within_the_write_window`,
+/// `batch_queue_index_ack_fails_when_the_flush_fails`.
+fn flush_now(index: &mut PalaceBm25Index, pending: Vec<PendingAck>) -> Result<usize> {
+    let flushed = index.flush();
+    release_acks(pending, &flushed);
+    flushed?;
     Ok(index.doc_count())
 }
 
-/// Apply one write op to the index, forwarding the typed reply.
+/// One applied write's ack, held until the flush that makes it durable.
 ///
-/// Why: factored out so the worker loop reads top-to-bottom and the per-op
-/// reply shape stays in one place.
-/// What: handles `Index` (returns `true` on success) and `Delete` (returns
-/// the prior-presence bool). The receiver awaiting the oneshot may have been
-/// cancelled (client disconnect); ignore that case so the worker keeps
-/// draining the rest of the batch.
-fn apply_write_op(index: &mut PalaceBm25Index, op: Op) {
+/// Why (#5627): the value a write op reports is known the moment the in-memory
+/// index is mutated, but it is not TRUE until the snapshot is on disk. Holding
+/// the sender rather than the answer is what lets the flush decide which of the
+/// two the caller hears.
+/// What: the caller's oneshot and the answer to send if the flush succeeds.
+/// Test: `batch_queue_index_ack_fails_when_the_flush_fails`.
+struct PendingAck {
+    reply: oneshot::Sender<Result<bool>>,
+    value: bool,
+}
+
+/// Release a batch's held acks once its durability is known.
+///
+/// Why (#5627): the acks and the flush are one statement — "these writes are on
+/// disk" — so both outcomes are delivered from the same place rather than each
+/// call site re-deriving what a failed flush means. `anyhow::Error` is not
+/// `Clone`, so the failure is rendered once and every caller in the batch is
+/// told the same thing.
+/// What: sends each held value on success, or an error naming the flush failure
+/// on `Err`. A receiver that hung up (client disconnect) is ignored, as before.
+/// Test: `batch_queue_index_ack_fails_when_the_flush_fails`.
+fn release_acks(pending: Vec<PendingAck>, flushed: &Result<()>) {
+    let failure = flushed
+        .as_ref()
+        .err()
+        .map(|e| format!("BM25 snapshot flush failed, so this write is not durable: {e:#}"));
+    for ack in pending {
+        let _ = match &failure {
+            None => ack.reply.send(Ok(ack.value)),
+            Some(msg) => ack.reply.send(Err(anyhow!("{msg}"))),
+        };
+    }
+}
+
+/// Apply one write op to the index, returning the ack the flush will release.
+///
+/// Why (#5627): sending the ack here — on the in-memory mutation — told every
+/// caller in the batch that its write had landed before the snapshot flush that
+/// would persist it had run, and a failed flush was `tracing::error!` and
+/// nothing else. A crash or ungraceful restart then lost writes the daemon had
+/// definitively acked. The reply now travels back to the worker, which releases
+/// it through [`release_acks`] once the covering flush has succeeded.
+/// What: handles `Index` (reports `true`) and `Delete` (reports the
+/// prior-presence bool), and returns the held ack. `None` for a non-write op,
+/// which the caller guarantees never reaches here.
+/// Test: `batch_queue_index_ack_fails_when_the_flush_fails`,
+/// `batch_queue_persists_indexed_doc`, `batch_queue_delete_removes_doc`.
+fn apply_write_op(index: &mut PalaceBm25Index, op: Op) -> Option<PendingAck> {
     match op {
         Op::Index {
             doc_id,
@@ -502,11 +581,14 @@ fn apply_write_op(index: &mut PalaceBm25Index, op: Op) {
             reply,
         } => {
             index.index_doc(&doc_id, &text);
-            let _ = reply.send(Ok(true));
+            Some(PendingAck { reply, value: true })
         }
         Op::Delete { doc_id, reply } => {
             let was_present = index.delete_doc(&doc_id);
-            let _ = reply.send(Ok(was_present));
+            Some(PendingAck {
+                reply,
+                value: was_present,
+            })
         }
         // Caller guarantees only write ops reach here; treat anything else
         // as a programmer error in this module.
@@ -516,6 +598,7 @@ fn apply_write_op(index: &mut PalaceBm25Index, op: Op) {
         | Op::Flush { .. }
         | Op::MissingDocs { .. } => {
             tracing::error!("apply_write_op called with non-write op — this is a bug");
+            None
         }
     }
 }
@@ -688,6 +771,49 @@ mod tests {
 
         let raw = std::fs::read_to_string(&snapshot).expect("snapshot must exist after flush");
         assert!(raw.contains("phoenix rising"), "got: {raw}");
+    }
+
+    /// Why (#5627, ADR-0045 framing): the ack is the daemon's only statement
+    /// that a write landed. Before the fix `apply_write_op` sent it on the
+    /// in-memory mutation, so a failing end-of-batch flush was `tracing::error!`
+    /// and nothing else — every caller in that batch had already been told
+    /// `Ok(true)` about bytes that never reached disk.
+    /// What: makes the palace directory read-only so `flush` fails at its tmp
+    /// write, then asserts the write op reports that failure. Pre-fix this
+    /// returned `Ok(true)`.
+    /// Test: this test itself.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn batch_queue_index_ack_fails_when_the_flush_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        /// Restore the mode on drop so `TempDir` can still clean up.
+        struct ModeGuard(std::path::PathBuf);
+        impl Drop for ModeGuard {
+            fn drop(&mut self) {
+                let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o755));
+            }
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let index = PalaceBm25Index::load_or_create(dir.path()).expect("load palace index");
+        let snapshot = index.snapshot_path().to_path_buf();
+        let q = BatchQueue::new(index, BatchConfig::default());
+
+        let _guard = ModeGuard(dir.path().to_path_buf());
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555))
+            .expect("chmod palace dir");
+
+        let acked = q.index_doc("d1".into(), "phoenix rising".into()).await;
+
+        assert!(
+            acked.is_err(),
+            "a write may not be acked when the flush that would persist it failed"
+        );
+        assert!(
+            !snapshot.exists(),
+            "precondition: the failed flush left nothing on disk"
+        );
     }
 
     #[tokio::test]

--- a/crates/trusty-mpm/src/core/skill_repair_tests.rs
+++ b/crates/trusty-mpm/src/core/skill_repair_tests.rs
@@ -85,7 +85,7 @@ fn repair_rewrites_drifted_and_verifies() {
 
     // And the manifest was updated, so the file is tm-owned again rather than
     // reading as frozen on the next audit.
-    assert!(SkillManifest::load(&dest).checksum_matches("tm-workflow", "v2"));
+    assert!(SkillManifest::load_checked(&dest).unwrap().checksum_matches("tm-workflow", "v2"));
 }
 
 /// #4622 review HIGH-1: a drifted REFERENCE FILE must be repaired at its own

--- a/crates/trusty-mpm/src/core/skill_retire_tests.rs
+++ b/crates/trusty-mpm/src/core/skill_retire_tests.rs
@@ -80,7 +80,7 @@ fn retire_removes_a_pristine_orphan() {
     assert_eq!(retired[0].stem, "tm-pr-workflow");
     assert!(retired[0].removed, "{retired:?}");
     assert!(!dest.join("tm-pr-workflow").exists());
-    let manifest = SkillManifest::load(&dest);
+    let manifest = SkillManifest::load_checked(&dest).unwrap();
     assert!(
         manifest
             .managed
@@ -116,7 +116,7 @@ fn retire_spares_a_user_tier_skill() {
         dest.join("my-own-skill").join("SKILL.md").is_file(),
         "a user-tier skill was removed"
     );
-    assert!(SkillManifest::load(&dest).is_managed("my-own-skill"));
+    assert!(SkillManifest::load_checked(&dest).unwrap().is_managed("my-own-skill"));
 }
 
 #[test]
@@ -171,7 +171,7 @@ fn retire_keeps_a_hand_edited_orphan_but_releases_the_ledger() {
         "an operator edit was destroyed"
     );
     assert!(
-        !SkillManifest::load(&dest).is_managed("tm-pr-workflow"),
+        !SkillManifest::load_checked(&dest).unwrap().is_managed("tm-pr-workflow"),
         "the ledger still claims a skill nothing ships"
     );
 }
@@ -320,7 +320,7 @@ fn verdict_allows_a_pristine_skill() {
     let tmp = TempDir::new().unwrap();
     let dest = tmp.path().join("skills");
     let _src = deploy_real(&dest, "tm-doctor", "v1", Some(("extra.md", "reference")));
-    let manifest = SkillManifest::load(&dest);
+    let manifest = SkillManifest::load_checked(&dest).unwrap();
     assert_eq!(
         skill_removal_verdict(&manifest, &dest, "tm-doctor"),
         SkillRemoval::Removable
@@ -333,7 +333,7 @@ fn verdict_keeps_a_hand_edited_skill() {
     let dest = tmp.path().join("skills");
     let _src = deploy_real(&dest, "tm-doctor", "v1", None);
     fs::write(dest.join("tm-doctor").join("SKILL.md"), "edited").unwrap();
-    let manifest = SkillManifest::load(&dest);
+    let manifest = SkillManifest::load_checked(&dest).unwrap();
     assert!(matches!(
         skill_removal_verdict(&manifest, &dest, "tm-doctor"),
         SkillRemoval::Kept(_)
@@ -346,7 +346,7 @@ fn verdict_keeps_an_untracked_file() {
     let dest = tmp.path().join("skills");
     let _src = deploy_real(&dest, "tm-doctor", "v1", None);
     fs::write(dest.join("tm-doctor").join("stray.md"), "mine").unwrap();
-    let manifest = SkillManifest::load(&dest);
+    let manifest = SkillManifest::load_checked(&dest).unwrap();
     assert!(matches!(
         skill_removal_verdict(&manifest, &dest, "tm-doctor"),
         SkillRemoval::Kept(_)

--- a/crates/trusty-mpm/src/core/update_check/apply/tests.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply/tests.rs
@@ -382,7 +382,7 @@ fn apply_prune_removes_deselected_skill() {
         fw.claude_skills_dir().join("keep-me/SKILL.md").is_file(),
         "selected skill retained"
     );
-    let manifest = SkillManifest::load(&fw.claude_skills_dir());
+    let manifest = SkillManifest::load_checked(&fw.claude_skills_dir()).unwrap();
     assert!(!manifest.is_managed("drop-me"));
     assert!(manifest.is_managed("keep-me"));
 }
@@ -422,7 +422,7 @@ fn apply_prune_skips_hand_edited_skill() {
     // The ledger entry stays too — dropping it would reclassify the file as
     // user-owned and freeze it against every future deploy (#4881's shape).
     assert!(
-        SkillManifest::load(&fw.claude_skills_dir()).is_managed("edited"),
+        SkillManifest::load_checked(&fw.claude_skills_dir()).unwrap().is_managed("edited"),
         "the kept skill stays managed"
     );
 }
@@ -460,7 +460,7 @@ fn apply_prune_spares_user_tier_skill() {
         "the user tier deploys regardless of the bundled selection"
     );
     assert!(
-        SkillManifest::load(&fw.claude_skills_dir()).is_managed("mine"),
+        SkillManifest::load_checked(&fw.claude_skills_dir()).unwrap().is_managed("mine"),
         "and it lands in the ledger looking exactly like a bundled skill"
     );
 
@@ -571,7 +571,7 @@ fn apply_prune_keeps_the_ledger_entry_for_a_selected_skills_carried_file() {
     apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, false).unwrap();
 
     let key = "carrier/references/notes.md";
-    assert!(SkillManifest::load(&fw.claude_skills_dir()).is_managed(key));
+    assert!(SkillManifest::load_checked(&fw.claude_skills_dir()).unwrap().is_managed(key));
 
     let report = apply_catalog(FakeGitBackend::new(), &fw, project.path(), true, true).unwrap();
 
@@ -585,7 +585,7 @@ fn apply_prune_keeps_the_ledger_entry_for_a_selected_skills_carried_file() {
             .is_file()
     );
     assert!(
-        SkillManifest::load(&fw.claude_skills_dir()).is_managed(key),
+        SkillManifest::load_checked(&fw.claude_skills_dir()).unwrap().is_managed(key),
         "a selected skill's carried file keeps its ledger entry"
     );
 }

--- a/crates/trusty-mpm/src/daemon/doctor_asset_tier_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_asset_tier_tests.rs
@@ -313,6 +313,62 @@ fn verdict_names_the_files_and_both_tiers() {
     }
 }
 
+/// #5626 (ADR-0045). A tier the probe could not read must not be reported as
+/// scanned and clean.
+///
+/// `audit_agent_tier` returned the same empty vec for "scanned, found nothing"
+/// and "could not scan", so before the fix this asserted `CheckStatus::Ok` with
+/// the message `no tm-owned agent files outside the canonical tier … (scanned:
+/// <dir>)` — over a directory holding a shadowing stub the probe never opened.
+#[test]
+#[cfg(unix)]
+fn unreadable_project_tier_is_not_reported_clean() {
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Restore the mode on drop so `TempDir` can still clean up after a panic.
+    struct ModeGuard(PathBuf);
+    impl Drop for ModeGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(0o755));
+        }
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&project).unwrap();
+    place_agent(
+        &project,
+        "rust-engineer.md",
+        "---\nname: rust-engineer\n---\n",
+    );
+
+    let tier = project.join(".claude").join("agents");
+    let _guard = ModeGuard(tier.clone());
+    std::fs::set_permissions(&tier, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let paths = hermetic_paths(&home);
+    let check = check_asset_tier(&paths, Some(&project), &home);
+
+    assert_ne!(
+        check.status,
+        CheckStatus::Ok,
+        "a tier that could not be scanned is not a clean tier: {}",
+        check.message
+    );
+    assert!(
+        !check.message.contains("(scanned:"),
+        "the verdict must not claim a scan that failed: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains(&tier.display().to_string()),
+        "the operator needs the path: {}",
+        check.message
+    );
+}
+
 #[test]
 fn verdict_summarises_a_long_list() {
     // Six offenders must not produce a six-name wall; the count survives.


### PR DESCRIPTION
**Provenance:** rescued 2026-08-17 during a worktree/branch cleanup sweep. This work existed only as uncommitted files in a worktree that was about to be deleted; it has now been committed and pushed to preserve it.

**Not gate-verified.** No test run, no clippy, no changelog-fragment check, no `code-critic` review has happened against this diff. `git merge-tree` against current `origin/main` shows real conflicts (`crates/trusty-agents-common/src/agents/manifest.rs` and others) — this branch predates recent main history and will need conflict resolution before it can even build.

Adds a third `ManifestLoad::Unreadable` variant so an EACCES/ESTALE/EIO read of the agent-ownership ledger no longer collapses into the same empty-default as "file absent" — that collapse was reclassifying every managed file as user-owned on the deploy, quarantine, and tier-audit paths. Carries the same fix through the skills manifest/deployer/reconcile/unmanaged modules. Separately touches `crates/trusty-bm25-daemon/src/batch_queue.rs`, changing write acks so `index_doc`/`delete` don't resolve until the flush covering them lands on disk, with `release_acks` handling rebuild and shutdown. Tests updated alongside.

Refs #5626, Refs #5627

**Reviewer decision:** is this worth rebasing onto current `main` and running the ladder against, or should it be closed and the branch dropped? Note `trusty-bm25-daemon` has since been deleted from `main` (#5689, in-process BM25 refactor) — the batch_queue portion of this diff may already be moot.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
