### PR TITLE
feat(trusty-audit): coach registration breadth so the audit stops degrading in silence

### DIFF
--- a/crates/trusty-audit/changelog.d/5822-coverage-coaching.md
+++ b/crates/trusty-audit/changelog.d/5822-coverage-coaching.md
@@ -1,0 +1,11 @@
+Added
+
+- The guided flow and the `add` / `targets` help now coach registration breadth
+  rather than waiting to be asked: applications, the repository holding the
+  database schema or migrations, infrastructure and IaC, shared libraries and
+  config repositories, and every ticketing board in use. The wording names what
+  the assessment judges — how mature, how stable and how supportable the
+  technology is — so the ask reads as audit quality rather than an inventory
+  chore, and it claims no detection, because this client cannot see a target
+  that was never registered. One `registry::COVERAGE_COACHING` constant, so the
+  CLI and a later chat wizard present the same substance (#5822).

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -509,7 +509,14 @@ mod cli_tests {
         let session = Session::new(WorkDir::new(tmp.path().join("work")));
         let outcome = session.execute(Command::Guided).await.expect("runs");
         let text = render(&outcome);
-        assert!(text.contains("Next: pick the repositories"), "{text}");
+        // #5884: `repos` LISTS what is already registered; nothing is
+        // registered yet in this state, so the next step names `add`.
+        assert!(
+            text.contains(
+                "Next: register the repositories and boards to audit (`trusty-audit add`)"
+            ),
+            "{text}"
+        );
     }
 
     /// The guided flow coaches breadth at the registration step, naming schema
@@ -523,6 +530,10 @@ mod cli_tests {
         assert!(text.contains("Coverage: "), "{text}");
         assert!(text.contains("database schema or migrations"), "{text}");
         assert!(text.contains("ticketing board"), "{text}");
+        // #5884: the "Next:" line must name the registering path, not the
+        // listing one — `repos` lists what `add` already registered.
+        assert!(text.contains("Next: register"), "{text}");
+        assert!(text.contains("`trusty-audit add`"), "{text}");
     }
 
     /// The `add` help is where an operator reading `--help` decides what counts

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -101,12 +101,23 @@ pub enum Verb {
         budget_gb: Option<u64>,
     },
     /// Register an audit target, after checking it can be read.
+    ///
+    /// Register everything in scope, not only the obvious application
+    /// repositories: the repository holding your database schema or migrations,
+    /// infrastructure and IaC, shared libraries and config repositories, and
+    /// every ticketing board in use. The assessment judges how mature, how
+    /// stable and how supportable the technology is, on what is registered and
+    /// nothing else.
     Add {
         /// What to register.
         #[command(subcommand)]
         target: AddTarget,
     },
     /// List the registered audit targets.
+    ///
+    /// Read it as the audit's coverage: a repository or board absent here —
+    /// a schema repository, an IaC repository, a second ticketing board — is
+    /// absent from the report too.
     Targets,
     /// Remove a registered audit target.
     Remove {
@@ -192,6 +203,9 @@ pub enum Verb {
 #[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
 pub enum AddTarget {
     /// A GitHub repository, checked with your `gh` credential.
+    ///
+    /// Application, database-schema and migration, infrastructure, shared-library
+    /// and config repositories all belong here.
     Repo {
         /// The repository, as owner/name.
         #[arg(value_name = "OWNER/NAME")]
@@ -496,6 +510,33 @@ mod cli_tests {
         let outcome = session.execute(Command::Guided).await.expect("runs");
         let text = render(&outcome);
         assert!(text.contains("Next: pick the repositories"), "{text}");
+    }
+
+    /// The guided flow coaches breadth at the registration step, naming schema
+    /// repositories rather than asking for "relevant" ones.
+    #[tokio::test]
+    async fn the_guided_flow_coaches_registration_breadth() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = Session::new(WorkDir::new(tmp.path().join("work")));
+        let outcome = session.execute(Command::Guided).await.expect("runs");
+        let text = render(&outcome);
+        assert!(text.contains("Coverage: "), "{text}");
+        assert!(text.contains("database schema or migrations"), "{text}");
+        assert!(text.contains("ticketing board"), "{text}");
+    }
+
+    /// The `add` help is where an operator reading `--help` decides what counts
+    /// as a target, so the breadth nudge has to survive there too.
+    #[test]
+    fn the_add_help_names_schema_repositories() {
+        let mut command = <Cli as clap::CommandFactory>::command();
+        let add = command
+            .find_subcommand_mut("add")
+            .expect("`add` is a subcommand")
+            .render_long_help()
+            .to_string();
+        assert!(add.contains("database schema or migrations"), "{add}");
+        assert!(add.contains("ticketing board"), "{add}");
     }
 
     /// A binary this client did not place must never be shown carrying a

--- a/crates/trusty-audit/src/cli/render.rs
+++ b/crates/trusty-audit/src/cli/render.rs
@@ -487,7 +487,9 @@ pub(super) fn count_of(n: usize, singular: &str, plural: &str) -> String {
 fn describe_next(next: &NextStep) -> String {
     match next {
         NextStep::SelectRepositories => {
-            "pick the repositories to audit (`trusty-audit repos`)".to_string()
+            // #5884: `repos` LISTS what is already registered; nothing is
+            // registered yet in this state, so the next step is `add`.
+            "register the repositories and boards to audit (`trusty-audit add`)".to_string()
         }
         NextStep::InstallTools(missing) => {
             let names: Vec<&str> = missing.iter().map(|t| t.binary_name()).collect();

--- a/crates/trusty-audit/src/cli/render.rs
+++ b/crates/trusty-audit/src/cli/render.rs
@@ -14,7 +14,7 @@
 use crate::chain::ChainReport;
 use crate::clone::CloneState;
 use crate::distribute::InstallPackage;
-use crate::registry::TargetKind;
+use crate::registry::{COVERAGE_COACHING, TargetKind};
 use crate::run::{RepoResult, RunStatus};
 use crate::session::{NextStep, Outcome};
 
@@ -57,6 +57,15 @@ pub fn render(outcome: &Outcome) -> String {
                 status.tools.len()
             ));
             out.push_str(&format!("Next: {}\n", describe_next(&status.next)));
+            // The coaching rides every pre-sweep step, not only an empty
+            // registry: an operator who registered one repository has already
+            // left the state where `SelectRepositories` would say it, and that
+            // is exactly when a schema or infrastructure repository goes
+            // missing. Once the sweep has produced a deliverable the advice
+            // changes shape, so `ReturnPackage` is left alone.
+            if !matches!(status.next, NextStep::ReturnPackage) {
+                out.push_str(&format!("Coverage: {COVERAGE_COACHING}\n"));
+            }
             out
         }
         Outcome::WorkDir(report) => {

--- a/crates/trusty-audit/src/registry.rs
+++ b/crates/trusty-audit/src/registry.rs
@@ -73,6 +73,44 @@ use crate::workdir::{self, Area, WorkDir};
 /// validation time only.
 pub const REGISTRY_FILE: &str = "audit-targets.toml";
 
+/// How much to register, in the words every front end uses to ask.
+///
+/// Why: the sweep covers what is registered and nothing else, and it cannot
+/// tell a repository the operator judged irrelevant from one they forgot. So
+/// completeness is the operator's to supply, and a passive `add` verb leaves
+/// the audit to degrade in silence. The wording is deliberately concrete:
+/// an operator who would not describe their migrations repository as a
+/// "relevant repository" still recognises "the repository holding your
+/// database schema", and that is the omission the owner named.
+///
+/// What: one paragraph, wrapped by whoever prints it, naming the kinds that
+/// get left out. It claims no detection — this client cannot see a target that
+/// was never registered, and the text must never imply otherwise. It also
+/// names no command, so the CLI, a chat wizard, or the Tauri shell can each
+/// present it in their own idiom without re-authoring the substance.
+///
+/// The engagement is named neutrally on purpose. The client may be a company or
+/// a single property, and more audit types are expected; today the wording is
+/// pitched at a strategic technology assessment, which is the engagement shape
+/// this client currently serves.
+///
+/// Naming that assessment's lens — how mature, how stable, how supportable and
+/// how staffable the technology is — is what makes the breadth ask land. An
+/// operator who reads only "register everything" hears an inventory chore; one
+/// who reads what the assessment judges can see why a schema or infrastructure
+/// repository changes the answer.
+///
+/// Test: `super::registry_tests::the_coverage_coaching_names_what_operators_leave_out`,
+/// `super::registry_tests::the_coverage_coaching_states_the_assessment_lens`,
+/// `super::registry_tests::the_coverage_coaching_claims_no_detection`.
+pub const COVERAGE_COACHING: &str = "Register every repository and board this \
+     engagement should cover — applications, the repository holding your database \
+     schema or migrations, infrastructure and IaC, shared libraries and config \
+     repositories, and every ticketing board in use. The assessment judges how \
+     mature, how stable and how supportable the technology is, and it judges only \
+     what you register, so anything left unregistered is simply absent from that \
+     picture of the organization's technology estate.";
+
 /// Which kind of target a command asked to register.
 ///
 /// Why: `taudit add repo` and `taudit add board` are separate verbs, so the
@@ -525,6 +563,61 @@ mod registry_tests {
         Target::Board {
             provider,
             key: key.to_owned(),
+        }
+    }
+
+    /// The owner named schema repositories specifically, because that is the
+    /// kind operators forget. Abstract phrasing ("relevant repositories") is
+    /// what the concrete list exists to replace, so the kinds are asserted
+    /// rather than left to whoever next edits the string.
+    #[test]
+    fn the_coverage_coaching_names_what_operators_leave_out() {
+        let text = COVERAGE_COACHING.to_lowercase();
+        for kind in [
+            "schema",
+            "migrations",
+            "infrastructure",
+            "shared librar",
+            "config repositor",
+            "board",
+        ] {
+            assert!(
+                text.contains(kind),
+                "coaching omits {kind}: {COVERAGE_COACHING}"
+            );
+        }
+    }
+
+    /// Breadth without a reason reads as an inventory chore. The coaching says
+    /// what the assessment judges, so an operator can tell why a schema or
+    /// infrastructure repository changes the answer.
+    #[test]
+    fn the_coverage_coaching_states_the_assessment_lens() {
+        let text = COVERAGE_COACHING.to_lowercase();
+        for lens in ["mature", "stable", "supportable"] {
+            assert!(
+                text.contains(lens),
+                "coaching omits the {lens} lens: {COVERAGE_COACHING}"
+            );
+        }
+    }
+
+    /// The coaching must not overstate what this client can see. Nothing here
+    /// can observe an unregistered target, so any claim of detection would be
+    /// false — that claim belongs only to a stage reading collected data.
+    #[test]
+    fn the_coverage_coaching_claims_no_detection() {
+        let text = COVERAGE_COACHING.to_lowercase();
+        for overclaim in [
+            "detect",
+            "finds missing",
+            "will discover",
+            "automatically add",
+        ] {
+            assert!(
+                !text.contains(overclaim),
+                "coaching claims {overclaim}: {COVERAGE_COACHING}"
+            );
         }
     }
 


### PR DESCRIPTION
The sweep covers what is registered and nothing else, and it cannot tell a repository the operator judged irrelevant from one they forgot. Per today's owner ruling, registration completeness is an audit-quality concern the tool coaches, not a passive capability.

Text and help only — registration, validation and the sweep are untouched.

## What changed

- `registry::COVERAGE_COACHING` (`crates/trusty-audit/src/registry.rs:76`) — one constant, so the CLI and a later chat wizard present the same substance. It names the kinds operators leave out (schema/migrations, IaC, shared libraries, config repos, every ticketing board), and it names what the assessment judges: how mature, how stable, how supportable the technology is. The engagement is named neutrally, because the client may be a company or a single property.
- Guided flow (`src/cli/render.rs:59`) prints it at every pre-sweep step, not only on an empty registry — an operator who registered one repository has already left `SelectRepositories`, and that is when a schema repo goes missing. `ReturnPackage` is left alone.
- `add` / `add repo` / `targets` help (`src/cli.rs`) carry the same nudge in the existing style.

## What it deliberately does not claim

The guided text never says this client detects missing repositories — it cannot see a target that was never registered. `the_coverage_coaching_claims_no_detection` holds that line.

## Surface 2 (report prompt) is not in this crate — reported, not edited

`trusty-audit` authors no LLM prompt text. `run::spawn_tga` (`src/run.rs:736-766`) spawns `tga --config <engagement.toml> audit` and passes only environment; `inference.rs` selects the provider and model ids, not prompt wording. The engagement config's `instructions` field is read only into package metadata (`src/package.rs:506`) and no `tga` code reads it.

The report-synthesis prompt that consumes the OpenRouter key lives in the child tool: `crates/trusty-review/src/report/synthesize_prompt.rs`, `build_synthesis_prompt` (system prompt assembled from `section_instructions`). Gap-noting instruction belongs there, in a `trusty-review` PR. Not touched here.

## Gates — rung 3

```
cargo fmt --check                                     EXIT=0
cargo check -p trusty-audit                           EXIT=0
cargo clippy -p trusty-audit --all-targets -D warnings EXIT=0
cargo test -p trusty-audit                            EXIT=0
  test result: ok. 314 passed; 0 failed; 5 ignored
  + 3/5/4/9 passed across the integration binaries
bash scripts/check_line_cap.sh    0 violations
bash scripts/check_sld.sh         0 errors, 0 warnings
```

New tests: `the_coverage_coaching_names_what_operators_leave_out`, `the_coverage_coaching_states_the_assessment_lens`, `the_coverage_coaching_claims_no_detection`, `the_guided_flow_coaches_registration_breadth`, `the_add_help_names_schema_repositories`.

Changelog fragment: `crates/trusty-audit/changelog.d/5822-coverage-coaching.md`.

Refs #5822

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools