### PR TITLE
chore(trusty-agents-common): bump 0.5.3 -> 0.6.0 for #5626's breaking API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11189,7 +11189,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-agents-common"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ trusty-code = { path = "crates/trusty-code", version = "0.3.0" }
 # shared by trusty-code's `tcode tui` and trusty-agents' tagent REPL (DOC-50,
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
-trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.5.3" }
+trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.6.0" }
 trusty-common = { path = "crates/trusty-common", version = "0.35" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.

--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "trusty-agents-common"
-# #4421: patch bump — 0.5.2 already published on crates.io and this PR
-# touches src/**. Every hunk in this bump is a doc-comment edit (module docs
-# moved to the inner `//!` standard, #5754) — no item signature or behavior
-# changed, so a patch asserts no breaking change.
-version = "0.5.3"
+# #5626: minor bump — 0.5.2 is the latest published version on crates.io.
+# The 0.5.3 that was on main was an unpublished doc-only patch bump (no item
+# signature changed). This bump covers #5626's four breaking API changes
+# (SkillManifest::load, unmanaged_bundled_skills,
+# preview_unmanaged_bundled_skills, audit_agent_tier all gained a fallible
+# Result-wrapped return; TierAuditError is a new public type) — for a 0.y.z
+# crate, Cargo's rule makes the MINOR position the breaking position.
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-agents-common/changelog.d/5626-minor-bump-breaking-api.md
+++ b/crates/trusty-agents-common/changelog.d/5626-minor-bump-breaking-api.md
@@ -1,0 +1,11 @@
+Changed
+
+- Version bumped 0.5.3 → 0.6.0. The crate's four #5626 breaking changes
+  (`SkillManifest::load`, `skills::unmanaged::unmanaged_bundled_skills`,
+  `skills::reconcile::preview_unmanaged_bundled_skills`, and
+  `agents::tier_audit::audit_agent_tier` all became fallible; `TierAuditError`
+  is new and public) shipped in an unpublished 0.5.3 patch bump. For a
+  `0.y.z` crate the MINOR position is the breaking position, so this bump
+  moves the crate to the version its own API change requires.
+  crates.io's latest published version is still 0.5.2 — nothing is yanked
+  or republished by this change.

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -182,7 +182,7 @@ lru = "0.16"
 #      CTO DB tools became reachable declaratively via the `cto-db` Python
 #      skill. This `install_plugins` mechanism remains available for any
 #      future private launcher.
-trusty-agents-common = { path = "../trusty-agents-common", version = "0.5.3" }
+trusty-agents-common = { path = "../trusty-agents-common", version = "0.6.0" }
 
 # [patch.crates-io] moved to workspace root Cargo.toml (Cargo requires
 # [patch] tables to live in the workspace root; see #460 for context).


### PR DESCRIPTION
## What
Bumps `trusty-agents-common` 0.5.3 → 0.6.0. Closes nothing; references #5626.

## Why 0.6.0
MINOR is the breaking position for a `0.y.z` crate under Cargo's rules, and #5626 introduced four breaking public-API changes (verified in source against commit `c64a0c614`):

- `SkillManifest::load` — constructor, `Self` → `Result<Self>`
- `skills::unmanaged::unmanaged_bundled_skills` — free function, `Vec<T>` → `Result<Vec<T>>`
- `skills::reconcile::preview_unmanaged_bundled_skills` — free function, `Vec<T>` → `Result<Vec<T>>`
- `agents::tier_audit::audit_agent_tier` — free function, `Vec<T>` → `Result<Vec<T>>`, also newly exports `TierAuditError`

## Why three manifests
The other two pin `version = "0.5.3"`, which Cargo reads as `^0.5.3` and does not admit 0.6.0, so bumping only the crate manifest breaks workspace resolution.

## Gates (rung 4 — cross-crate manifest change)

- `cargo metadata --locked --format-version 1` — EXIT=0, the resolution proof. Verified to have teeth: reverting the root pin to `0.5.3` produces `failed to select a version for the requirement 'trusty-agents-common = "^0.5.3"' ... candidate versions found which didn't match: 0.6.0`.
- `cargo fmt --check` — EXIT=0
- `cargo test -p trusty-agents-common` — 509 passed, 0 failed
- `bash scripts/check_semver.sh --crate trusty-agents-common` — EXIT=0, advisory path, `0 checked, 0 skipped, 1 inventoried`, since 0.6.0 is already breaking-position over crates.io's 0.5.2.

## One known failure, not caused by this branch
`cargo test -p trusty-agents` fails `system_status::credentials::tests::credential_status_never_leaks_a_value` (3509 passed, 1 failed) on a machine that has a repo-root `.env.local`. The test reads `trusty_common::credentials::env_local_value` and expects the secure-store tier. `git diff --name-only origin/main...HEAD -- crates/trusty-agents/` returns only `Cargo.toml`, which proves the branch touches no source in that crate.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
