### PR TITLE
feat(trusty-review): ask synthesis to name targets the data references but the audit never analysed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11762,7 +11762,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -9,7 +9,12 @@ name        = "trusty-review"
 # #4421: this PR (#5754) additionally converts config/mod.rs's module doc to
 # the inner `//!`-only standard — a doc-comment-only change, so it lands under
 # the 0.18.0 above with no further bump needed.
-version     = "0.18.0"
+#
+# #5886: PATCH bump — 0.18.0 is already published, and this PR edits
+# synthesize_prompt.rs's prompt text (adds a coverage-gaps instruction). No
+# public API changed; the `PR version bump vs crates.io` gate (#4421) still
+# requires the bump since `src/**` changed.
+version     = "0.18.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/5870-synthesis-coverage-gaps.md
+++ b/crates/trusty-review/changelog.d/5870-synthesis-coverage-gaps.md
@@ -1,0 +1,11 @@
+Added
+
+- The report-synthesis system prompt now asks for a coverage-gaps note. When the
+  analysed data references a repository, service, database schema, or project
+  board that is not one of the assessed applications, the executive summary names
+  it and recommends the operator register it and re-run. Schema and migration
+  repositories are called out specifically — a finding citing a table or a
+  migration with no schema repository in the assessed set is the common tell. The
+  instruction is static, so a template overriding `executive_summary` cannot drop
+  it, and it permits naming only what the data actually references — never a
+  target the model infers probably exists.

--- a/crates/trusty-review/src/report/synthesize_prompt.rs
+++ b/crates/trusty-review/src/report/synthesize_prompt.rs
@@ -130,12 +130,22 @@ pub(crate) fn synthesis_schema(top_risks_cap: usize) -> ResponseSchema {
 /// template or analyst may steer — see [`section_instructions`] for the
 /// generic → template → analyst layering (the same shape as the crate's
 /// existing stock → principles → voice reviewer layering, see `src/voice/`).
-/// What: the "Absolute rules" block is a static invariant; the "Output"
-/// section embeds `resolved[EXECUTIVE_SUMMARY]` / `resolved[TOP_RISKS]` /
+/// What: the "Absolute rules" and "Coverage gaps in the assessed set" blocks
+/// are static invariants; the "Output" section embeds
+/// `resolved[EXECUTIVE_SUMMARY]` / `resolved[TOP_RISKS]` /
 /// `resolved[FINDING_ELABORATION]` verbatim.  `retry_concise` appends a
 /// directive to shorten the response (used on the one truncation retry).
+///
+/// The coverage-gaps block is static rather than a fourth section instruction
+/// because a template that overrides `executive_summary` would otherwise drop
+/// it, and because the response schema is fixed — the executive summary is the
+/// only narrative field the model controls, so the note has nowhere else to
+/// go.  It is scoped to targets ABSENT from the assessed set, which is a
+/// different question from the per-repo dimension coverage that
+/// [`super::investigate::render::coverage_prompt_summary`] already mandates.
 /// Test: `synthesize_tests.rs::{system_prompt_embeds_resolved_instructions,
-/// system_prompt_concise_retry_directive}`.
+/// system_prompt_concise_retry_directive,
+/// system_prompt_asks_for_unregistered_target_gaps}`.
 fn synthesis_system_prompt(
     resolved: &std::collections::BTreeMap<String, String>,
     retry_concise: bool,
@@ -162,6 +172,12 @@ fn synthesis_system_prompt(
 - Write prose for RED and AMBER findings ONLY. Do not mention, elaborate, or infer GREEN/positive findings — none are provided, and none should appear.
 - Be concise, specific, and deal-relevant: what an acquirer must act on.
 - Every finding field is structurally required. Emit an empty string for any you have nothing grounded to say in — never fill one with invented content.
+
+## Coverage gaps in the assessed set
+- The applications listed under "Applications assessed" are the ENTIRE assessed set. When the data references a repository, service, database schema, or project board that is not one of them, name it in a short coverage-gaps note closing the executive summary.
+- In that note, recommend the operator register the named targets and re-run, so the report reflects the full technology estate under assessment.
+- Check specifically for schema and migration repositories: a finding citing a table, a migration, or a stored procedure with no corresponding schema repository in the assessed set is exactly this case, and it is the omission operators make most often.
+- Name ONLY targets the data above actually references. Never list one you infer probably exists, and write no note at all when the data references nothing outside the assessed set.
 
 ## Output
 Populate the structured response:

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -382,6 +382,45 @@ fn partial_template_override_leaves_other_sections_generic() {
     assert!(req.system.contains("deal-analytic paragraph"));
 }
 
+/// Why: an audit is only as complete as the set of targets the operator
+/// registered, and the report is the only place that gap becomes visible.  The
+/// instruction must be static — a template that overrides `executive_summary`
+/// must not be able to drop it — and it must name schema/migration
+/// repositories, the kind operators forget most often.
+/// What: asserts the coverage-gaps block reaches `req.system` with the
+/// register-and-re-run recommendation, the schema-repository call-out, and the
+/// no-speculation constraint; asserts it survives an `executive_summary`
+/// override; and asserts the digest emits the "Applications assessed" heading
+/// the instruction tells the model to compare references against.
+/// Test: this test itself.
+#[test]
+fn system_prompt_asks_for_unregistered_target_gaps() {
+    let mut model = fixture_model(vec![]);
+    model.section_instructions.insert(
+        "executive_summary".to_string(),
+        "OVERRIDE: lead with the TQI posture.".to_string(),
+    );
+    let req = build_synthesis_prompt(&model, "stub/model", false);
+    for needle in [
+        "Coverage gaps in the assessed set",
+        "coverage-gaps note",
+        "register the named targets and re-run",
+        "schema and migration repositories",
+        "Never list one you infer probably exists",
+    ] {
+        assert!(
+            req.system.contains(needle),
+            "coverage-gaps instruction must survive a template override and contain {needle:?}: {}",
+            req.system
+        );
+    }
+    assert!(
+        req.messages[0].content.contains("Applications assessed"),
+        "the digest must name the assessed set the instruction compares against: {}",
+        req.messages[0].content
+    );
+}
+
 // ── Synthesize: happy path + fail-closed paths ──────────────────────────────
 
 fn good_response() -> String {


### PR DESCRIPTION
Surface 2 of the owner ruling on the trusty-audit workstream: the audit report should encourage complete target registration.

trusty-audit authors no LLM prompt text. The synthesis prompt that consumes the OpenRouter key is `crates/trusty-review/src/report/synthesize_prompt.rs`, so the instruction lands there. No trusty-audit or tga changes.

## What changed

`synthesis_system_prompt` gains a static "Coverage gaps in the assessed set" block. When the data references a repository, service, database schema, or project board that is not one of the assessed applications, the executive summary names it and recommends the operator register it and re-run. Schema and migration repositories are named as a specifically-checked-for kind.

Static, not a fourth section instruction, for two reasons. A template overriding `executive_summary` would drop it. And the response schema is fixed, so the executive summary is the only narrative field the model controls — the note has nowhere else to go.

## The prompt does know the analysed set

`build_digest` writes `Applications assessed: <names>` into the user message (`crates/trusty-review/src/report/synthesize_prompt.rs:246-254`, post-change line numbers). The instruction can therefore say "compare references against that list" rather than relying on the model's impression of what it was handed. The test asserts the digest still emits that heading, so the two halves cannot drift apart.

Honesty constraint: the instruction permits naming only what the data actually references, forbids listing a target the model infers probably exists, and asks for no note when nothing outside the assessed set is referenced. That keeps it distinct from the per-repo dimension coverage `coverage_prompt_summary` already mandates.

No change to the response schema, the section-instruction tiers, or output parsing.

## Gates — test ladder rung 3, `-p trusty-review`

```
cargo fmt --check                                        # clean
cargo clippy -p trusty-review --all-targets -- -D warnings  # clean
cargo test -p trusty-review                              # 1595 passed, 0 failed, 5 ignored (lib);
                                                         # all integration targets green
bash scripts/check_line_cap.sh                           # 0 violations
bash scripts/check_sld.sh                                # 0 errors, 0 warnings
```

Regression proof — `system_prompt_asks_for_unregistered_target_gaps` against the unmodified prompt:

```
test report::synthesize::tests::system_prompt_asks_for_unregistered_target_gaps ... FAILED
coverage-gaps instruction must survive a template override and contain "Coverage gaps in the assessed set"
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1599 filtered out
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
