### PR TITLE
fix(trusty-code): retry transient inference failures inside the turn (#2272)

### DIFF
--- a/crates/trusty-code/changelog.d/2272-bounded-inference-retry.md
+++ b/crates/trusty-code/changelog.d/2272-bounded-inference-retry.md
@@ -1,0 +1,5 @@
+Fixed
+
+- Retry transient inference failures inside the current assistant turn with a
+  fixed three-attempt budget, while preventing retries after streamed text is
+  visible and keeping the existing run deadline and re-delegation boundary.

--- a/crates/trusty-code/src/agent_loop/streaming.rs
+++ b/crates/trusty-code/src/agent_loop/streaming.rs
@@ -1,5 +1,5 @@
 //! Token-level streaming for one assistant turn (#4425 — tcode streaming epic
-//! #3696's Gap B).
+//! #3696's Gap B), with #2272's bounded in-turn inference retry.
 //!
 //! Why: Gap A (Slice 1) made an assistant turn OBSERVABLE — `ToolEventSink::agent_message`
 //! published the whole turn once, with `done: true`, after the blocking `chat`
@@ -14,17 +14,49 @@
 //! nothing downstream (transcript, usage accrual, tool dispatch) changes.
 //! What: [`AgentLoop::chat_turn`] — one method with two branches. NO sink
 //! attached (the `run_task` CLI path, every scripted test) takes the blocking
-//! `chat` call, byte-for-byte the pre-#4425 behaviour. A sink attached (the
-//! daemon/TUI path) streams. The turn id is minted by the caller and shared by
-//! every delta of the turn.
+//! `chat` call. A sink attached (the daemon/TUI path) streams. Both branches
+//! run under one three-attempt retry policy for transient provider failures.
+//! The turn id is minted by the caller and shared by every delta of the turn.
 //! Test: `agent_loop::tests::sink_events` — delta sequencing (`done: false` per
 //! chunk, exactly one `done: true`), the tool-only turn emitting nothing, and
 //! equivalence of the assembled response with the blocking path's.
+//! `agent_loop::tests::inference_retry` — the retry budget, backoff, classifier,
+//! exposure boundary, and deadline containment.
+
+use std::time::Duration;
 
 use futures_util::StreamExt;
 
 use super::{AgentLoop, AgentLoopError};
-use crate::llm::{ChatRequest, ChatResponse, ChatStreamEvent, StreamAssembly};
+use crate::llm::{ChatRequest, ChatResponse, ChatStreamEvent, InferenceError, StreamAssembly};
+
+// #2272: three attempts bound transient provider disruption inside one logical
+// turn, so a flaky 503 does not restart a delegated engineer from scratch.
+const INFERENCE_MAX_ATTEMPTS: u8 = 3;
+const INFERENCE_RETRY_DELAYS: [Duration; 2] =
+    [Duration::from_millis(100), Duration::from_millis(200)];
+
+// Every attempt except the last is followed by exactly one delay, so the two
+// constants must stay in step; `wait_before_inference_retry` indexes the delay
+// table directly and this makes an out-of-step edit a compile error rather than
+// a runtime panic.
+const _: () = assert!(INFERENCE_MAX_ATTEMPTS as usize == INFERENCE_RETRY_DELAYS.len() + 1);
+
+/// Whether any text from the current stream attempt has reached the sink.
+///
+/// Why: a retry is only invisible while the user has seen nothing. Once one
+/// non-empty delta is rendered, replaying the turn would duplicate visible text
+/// in the transcript bubble, so a mid-stream failure must propagate instead.
+/// What: `Unexposed` until the first non-empty [`ChatStreamEvent::Delta`] is
+/// forwarded, `Exposed` from then on. Reset per attempt, because a fresh stream
+/// starts from a fresh (still invisible) assembly.
+/// Test: `agent_loop::tests::inference_retry::stream_failure_after_text_delta_is_not_retried`,
+/// `agent_loop::tests::inference_retry::stream_exposed_on_a_later_attempt_is_not_retried_again`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResponseExposure {
+    Unexposed,
+    Exposed,
+}
 
 impl AgentLoop {
     /// Execute one assistant turn, streaming deltas to the sink when there is one.
@@ -40,57 +72,183 @@ impl AgentLoop {
     /// with `done: false` and, once the stream ends, one final call with
     /// `done: true` — but ONLY if the turn produced text at all, so a tool-only
     /// turn stays silent exactly as it did before. `turn_id` correlates every
-    /// delta of this turn and MUST be unique across all agents in the session.
+    /// delta of this turn and MUST be unique across all agents in the session,
+    /// and is shared by every retry attempt: a retry is one logical turn.
     ///
-    /// A `chat_stream` handshake failure is PROPAGATED, never silently retried
-    /// as a blocking call: the shared adapter deliberately declines to degrade
-    /// to buffered on its own, and a silent fallback here would make "is
-    /// streaming working?" unanswerable from the outside — the operator would
-    /// see a working, non-streaming tcode and no signal that anything failed.
-    /// Test: `agent_loop::tests::sink_events::*`.
+    /// (#2272) Both transports run the same three-attempt policy. Only
+    /// [`InferenceError::is_retryable`] failures retry, after 100 ms then
+    /// 200 ms, replaying the identical request. A streaming attempt retries only
+    /// while [`ResponseExposure::Unexposed`]; after that the failure propagates,
+    /// because replaying would duplicate text the user already read. Retries do
+    /// NOT extend the caller's wall-clock deadline — `run_with_transcript`
+    /// wraps this method in `tokio::time::timeout`, which stays the outer bound
+    /// and covers the backoff sleeps.
+    ///
+    /// A `chat_stream` handshake failure is never silently retried as a
+    /// BLOCKING call: the shared adapter deliberately declines to degrade to
+    /// buffered on its own, and a silent fallback here would make "is streaming
+    /// working?" unanswerable from the outside — the operator would see a
+    /// working, non-streaming tcode and no signal that anything failed. A
+    /// retried handshake reopens a STREAM, so that property holds.
+    /// Test: `agent_loop::tests::sink_events::*`,
+    /// `agent_loop::tests::inference_retry::*`.
     pub(super) async fn chat_turn(
         &self,
         request: &ChatRequest,
         turn_id: &str,
     ) -> Result<ChatResponse, AgentLoopError> {
         let Some(sink) = self.sink.clone() else {
-            return Ok(self.llm.chat(request).await?);
+            let mut attempt = 1;
+            loop {
+                match self.llm.chat(request).await {
+                    Ok(response) => return Ok(response),
+                    Err(error) if error.is_retryable() && attempt < INFERENCE_MAX_ATTEMPTS => {
+                        self.wait_before_inference_retry(attempt, &error).await;
+                        attempt += 1;
+                    }
+                    Err(error) => {
+                        if error.is_retryable() {
+                            self.warn_inference_retry_exhausted(attempt, &error);
+                        }
+                        return Err(AgentLoopError::Llm(error));
+                    }
+                }
+            }
         };
 
-        let mut stream = self.llm.chat_stream(request).await?;
-        let mut assembly = StreamAssembly::new();
-        let mut emitted_text = false;
+        let mut attempt = 1;
+        loop {
+            let mut stream = match self.llm.chat_stream(request).await {
+                Ok(stream) => stream,
+                Err(error) if error.is_retryable() && attempt < INFERENCE_MAX_ATTEMPTS => {
+                    self.wait_before_inference_retry(attempt, &error).await;
+                    attempt += 1;
+                    continue;
+                }
+                Err(error) => {
+                    if error.is_retryable() {
+                        self.warn_inference_retry_exhausted(attempt, &error);
+                    }
+                    return Err(AgentLoopError::Llm(error));
+                }
+            };
+            // Both are per-attempt: a retry discards the partial assembly along
+            // with the exposure it never produced, so the next attempt assembles
+            // a whole response rather than splicing two half-streams together.
+            let mut assembly = StreamAssembly::new();
+            let mut exposure = ResponseExposure::Unexposed;
+            let mut retry_error = None;
 
-        while let Some(event) = stream.next().await {
-            let event = event?;
-            if let ChatStreamEvent::Delta(chunk) = &event
-                && !chunk.is_empty()
-            {
-                emitted_text = true;
-                sink.agent_message(
-                    self.agent_name(),
-                    self.agent_id_str(),
-                    turn_id,
-                    chunk,
-                    false,
-                )
-                .await;
+            while let Some(event) = stream.next().await {
+                let event = match event {
+                    Ok(event) => event,
+                    Err(error)
+                        if error.is_retryable()
+                            && exposure == ResponseExposure::Unexposed
+                            && attempt < INFERENCE_MAX_ATTEMPTS =>
+                    {
+                        retry_error = Some(error);
+                        break;
+                    }
+                    Err(error) => {
+                        if error.is_retryable() && exposure == ResponseExposure::Unexposed {
+                            self.warn_inference_retry_exhausted(attempt, &error);
+                        }
+                        return Err(AgentLoopError::Llm(error));
+                    }
+                };
+                if let ChatStreamEvent::Delta(chunk) = &event
+                    && !chunk.is_empty()
+                {
+                    exposure = ResponseExposure::Exposed;
+                    sink.agent_message(
+                        self.agent_name(),
+                        self.agent_id_str(),
+                        turn_id,
+                        chunk,
+                        false,
+                    )
+                    .await;
+                }
+                assembly.push(event);
             }
-            assembly.push(event);
-        }
 
-        // The terminal `done: true` carries no new text — the deltas above
-        // already delivered every character. It exists so a subscriber knows
-        // the bubble is complete and can stop rendering a caret.
-        if emitted_text {
-            sink.agent_message(self.agent_name(), self.agent_id_str(), turn_id, "", true)
-                .await;
-        }
+            if let Some(error) = retry_error {
+                self.wait_before_inference_retry(attempt, &error).await;
+                attempt += 1;
+                continue;
+            }
 
-        // The response id is not reported by the OpenAI-dialect SSE terminal
-        // frame, so it is left empty; `model` echoes the requested slug (see
-        // `crate::llm::resolved_model`, which falls back to exactly this value
-        // whenever a provider omits its own).
-        Ok(assembly.into_response(String::new(), request.model.clone()))
+            // The terminal `done: true` carries no new text — the deltas above
+            // already delivered every character. It exists so a subscriber knows
+            // the bubble is complete and can stop rendering a caret.
+            if exposure == ResponseExposure::Exposed {
+                sink.agent_message(self.agent_name(), self.agent_id_str(), turn_id, "", true)
+                    .await;
+            }
+
+            // The response id is not reported by the OpenAI-dialect SSE terminal
+            // frame, so it is left empty; `model` echoes the requested slug (see
+            // `crate::llm::resolved_model`, which falls back to exactly this value
+            // whenever a provider omits its own).
+            return Ok(assembly.into_response(String::new(), request.model.clone()));
+        }
+    }
+
+    /// Log the failed attempt and sleep its backoff before the next one.
+    ///
+    /// Why: an operator watching a slow turn needs to see that it is retrying
+    /// rather than hung, and which provider is misbehaving.
+    /// What: warns with the attempt number, provider, and error class, then
+    /// sleeps `INFERENCE_RETRY_DELAYS[failed_attempt - 1]` — in range for every
+    /// `failed_attempt < INFERENCE_MAX_ATTEMPTS`, which is the only condition
+    /// under which the callers invoke this.
+    /// Test: `agent_loop::tests::inference_retry::blocking_retry_delays_are_100_then_200_milliseconds`.
+    async fn wait_before_inference_retry(&self, failed_attempt: u8, error: &InferenceError) {
+        let delay = INFERENCE_RETRY_DELAYS[usize::from(failed_attempt - 1)];
+        tracing::warn!(
+            attempt = failed_attempt,
+            max_attempts = INFERENCE_MAX_ATTEMPTS,
+            provider = self.llm.name(),
+            error_class = inference_error_class(error),
+            delay_ms = delay.as_millis(),
+            "retryable inference attempt failed; retrying"
+        );
+        tokio::time::sleep(delay).await;
+    }
+
+    /// Warn that a transient failure escaped because the budget ran out.
+    ///
+    /// Why: a caller sees only the last error, which looks identical to a
+    /// first-attempt failure — this line is what distinguishes "the provider
+    /// blipped once" from "the provider is down".
+    /// Test: covered indirectly by
+    /// `agent_loop::tests::inference_retry::blocking_retry_exhaustion_returns_third_original_error`.
+    fn warn_inference_retry_exhausted(&self, attempt: u8, error: &InferenceError) {
+        tracing::warn!(
+            attempt,
+            max_attempts = INFERENCE_MAX_ATTEMPTS,
+            provider = self.llm.name(),
+            error_class = inference_error_class(error),
+            "retryable inference attempts exhausted"
+        );
+    }
+}
+
+/// A stable, low-cardinality label for an inference failure.
+///
+/// Why: the error's `Display` embeds response bodies and provider ids, which is
+/// wrong for a log field an operator groups by.
+/// Test: exercised by every `agent_loop::tests::inference_retry` case that logs.
+fn inference_error_class(error: &InferenceError) -> &'static str {
+    match error {
+        InferenceError::Transport(_) => "transport",
+        InferenceError::Api { .. } => "api",
+        InferenceError::Deserialise { .. } => "deserialise",
+        InferenceError::MissingCredential { .. } => "missing_credential",
+        InferenceError::NoAdapterRegistered { .. } => "no_adapter_registered",
+        InferenceError::Provider(_) => "provider",
+        InferenceError::Unsupported(_) => "unsupported",
+        InferenceError::MissingConfig(_) => "missing_config",
     }
 }

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -1237,6 +1237,10 @@ mod write_batch;
 // in a focused child module to keep this file under its SLOC cap.
 mod sink_events;
 
+// #2272 bounded inference-retry regression guards live in a focused child
+// module so transient transport policy stays independent of unrelated tests.
+mod inference_retry;
+
 /// Live OpenRouter test: trivial task through the real client + a real tool.
 ///
 /// Why: End-to-end confidence that the loop drives a real model to a final

--- a/crates/trusty-code/src/agent_loop/tests/inference_retry.rs
+++ b/crates/trusty-code/src/agent_loop/tests/inference_retry.rs
@@ -1,0 +1,510 @@
+//! Regression coverage for #2272's bounded, in-turn inference retry policy.
+//!
+//! Why: transient provider failures must not restart a delegated engineer from
+//! scratch, while retrying a stream after visible text would duplicate output.
+//! What: scripted blocking and streaming adapters pin the three-attempt budget,
+//! retry classifier, pre-exposure stream boundary, and enclosing run deadline.
+//! Test: this module is the contract surface.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use futures_util::stream;
+use trusty_common::inference::{
+    ChatStream, ChatStreamEvent, StopReason, StreamCompletion, ToolCallDelta, Usage,
+};
+
+use super::*;
+
+enum BlockingAttempt {
+    Error(InferenceError),
+    Response(ChatResponse),
+}
+
+struct BlockingRetryLlm {
+    attempts: Mutex<VecDeque<BlockingAttempt>>,
+    calls: AtomicUsize,
+    requests: Mutex<Vec<ChatRequest>>,
+    call_times: Mutex<Vec<tokio::time::Instant>>,
+    first_call_delay: Option<Duration>,
+}
+
+impl BlockingRetryLlm {
+    fn new(attempts: Vec<BlockingAttempt>) -> Self {
+        Self {
+            attempts: Mutex::new(attempts.into()),
+            calls: AtomicUsize::new(0),
+            requests: Mutex::new(Vec::new()),
+            call_times: Mutex::new(Vec::new()),
+            first_call_delay: None,
+        }
+    }
+
+    fn with_first_call_delay(mut self, delay: Duration) -> Self {
+        self.first_call_delay = Some(delay);
+        self
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+
+    fn call_times(&self) -> Vec<tokio::time::Instant> {
+        self.call_times.lock().expect("call-time lock").clone()
+    }
+}
+
+#[async_trait]
+impl InferenceAdapter for BlockingRetryLlm {
+    crate::llm::mock_adapter_identity!("mock-blocking-retry");
+
+    async fn chat(&self, request: &ChatRequest) -> Result<ChatResponse, InferenceError> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        self.call_times
+            .lock()
+            .expect("call-time lock")
+            .push(tokio::time::Instant::now());
+        self.requests
+            .lock()
+            .expect("request lock")
+            .push(request.clone());
+        if call == 0
+            && let Some(delay) = self.first_call_delay
+        {
+            tokio::time::sleep(delay).await;
+        }
+        match self
+            .attempts
+            .lock()
+            .expect("attempt lock")
+            .pop_front()
+            .expect("scripted blocking attempt")
+        {
+            BlockingAttempt::Error(error) => Err(error),
+            BlockingAttempt::Response(response) => Ok(response),
+        }
+    }
+}
+
+enum StreamAttempt {
+    HandshakeError(InferenceError),
+    Events(Vec<Result<ChatStreamEvent, InferenceError>>),
+}
+
+struct StreamingRetryLlm {
+    attempts: Mutex<VecDeque<StreamAttempt>>,
+    calls: AtomicUsize,
+}
+
+impl StreamingRetryLlm {
+    fn new(attempts: Vec<StreamAttempt>) -> Self {
+        Self {
+            attempts: Mutex::new(attempts.into()),
+            calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl InferenceAdapter for StreamingRetryLlm {
+    crate::llm::mock_adapter_identity!("mock-streaming-retry");
+
+    async fn chat(&self, _request: &ChatRequest) -> Result<ChatResponse, InferenceError> {
+        panic!("stream retry tests must not use the blocking adapter path")
+    }
+
+    async fn chat_stream(&self, _request: &ChatRequest) -> Result<ChatStream, InferenceError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        match self
+            .attempts
+            .lock()
+            .expect("attempt lock")
+            .pop_front()
+            .expect("scripted streaming attempt")
+        {
+            StreamAttempt::HandshakeError(error) => Err(error),
+            StreamAttempt::Events(events) => Ok(Box::pin(stream::iter(events))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Message {
+    turn_id: String,
+    delta: String,
+    done: bool,
+}
+
+struct RecordingMessageSink {
+    messages: Mutex<Vec<Message>>,
+}
+
+impl RecordingMessageSink {
+    fn new() -> Self {
+        Self {
+            messages: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn messages(&self) -> Vec<Message> {
+        self.messages.lock().expect("message lock").clone()
+    }
+
+    /// Every delta the user could actually have read, in order.
+    fn visible_text(&self) -> Vec<String> {
+        self.messages()
+            .into_iter()
+            .filter(|message| !message.delta.is_empty())
+            .map(|message| message.delta)
+            .collect()
+    }
+}
+
+#[async_trait]
+impl ToolEventSink for RecordingMessageSink {
+    async fn tool_started(&self, _: &str, _: &str, _: &str, _: &str, _: &str) {}
+
+    async fn tool_finished(&self, _: &str, _: &str, _: &str, _: &str, _: bool, _: &str) {}
+
+    async fn tool_error(&self, _: &str, _: &str, _: &str, _: &str, _: &str) {}
+
+    async fn agent_message(&self, _: &str, _: &str, turn_id: &str, delta: &str, done: bool) {
+        self.messages.lock().expect("message lock").push(Message {
+            turn_id: turn_id.to_string(),
+            delta: delta.to_string(),
+            done,
+        });
+    }
+}
+
+fn response(text: &str) -> ChatResponse {
+    serde_json::from_value(stop_response(text)).expect("valid response")
+}
+
+fn done() -> ChatStreamEvent {
+    ChatStreamEvent::Done(StreamCompletion {
+        finish_reason: Some(StopReason::Stop),
+        usage: Usage {
+            prompt_tokens: 7,
+            completion_tokens: 5,
+            ..Usage::default()
+        },
+    })
+}
+
+fn empty_registry() -> Arc<ToolRegistry> {
+    Arc::new(ToolRegistry::new())
+}
+
+#[tokio::test(start_paused = true)]
+async fn blocking_retryable_failure_then_success_is_one_logical_turn() {
+    let llm = Arc::new(BlockingRetryLlm::new(vec![
+        BlockingAttempt::Error(InferenceError::Transport("first".into())),
+        BlockingAttempt::Response(response("done")),
+    ]));
+
+    let output = AgentLoop::new(AgentLoopConfig::default(), llm.clone(), empty_registry())
+        .run("system", "task")
+        .await
+        .expect("retry should recover");
+
+    assert_eq!(llm.calls(), 2);
+    assert_eq!(output.content, "done");
+    assert_eq!(output.usage.prompt_tokens, 7);
+    assert_eq!(output.usage.completion_tokens, 5);
+    let requests = llm.requests.lock().expect("request lock");
+    assert_eq!(requests.len(), 2);
+    assert_eq!(
+        serde_json::to_value(&requests[0]).expect("serialize request"),
+        serde_json::to_value(&requests[1]).expect("serialize request")
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn blocking_retry_exhaustion_returns_third_original_error() {
+    let llm = Arc::new(BlockingRetryLlm::new(vec![
+        BlockingAttempt::Error(InferenceError::Transport("first".into())),
+        BlockingAttempt::Error(InferenceError::Api {
+            status: 429,
+            body: "second".into(),
+        }),
+        BlockingAttempt::Error(InferenceError::Api {
+            status: 503,
+            body: "third-marker".into(),
+        }),
+    ]));
+
+    let error = AgentLoop::new(AgentLoopConfig::default(), llm.clone(), empty_registry())
+        .run("system", "task")
+        .await
+        .expect_err("third retryable failure must escape");
+
+    assert_eq!(llm.calls(), 3);
+    assert!(matches!(
+        error,
+        AgentLoopError::Llm(InferenceError::Api { status: 503, body })
+            if body == "third-marker"
+    ));
+}
+
+#[tokio::test(start_paused = true)]
+async fn blocking_retry_delays_are_100_then_200_milliseconds() {
+    let llm = Arc::new(BlockingRetryLlm::new(vec![
+        BlockingAttempt::Error(InferenceError::Transport("first".into())),
+        BlockingAttempt::Error(InferenceError::Transport("second".into())),
+        BlockingAttempt::Response(response("done")),
+    ]));
+
+    AgentLoop::new(AgentLoopConfig::default(), llm.clone(), empty_registry())
+        .run("system", "task")
+        .await
+        .expect("third attempt should recover");
+
+    let call_times = llm.call_times();
+    assert_eq!(call_times.len(), 3);
+    assert_eq!(call_times[1] - call_times[0], Duration::from_millis(100));
+    assert_eq!(call_times[2] - call_times[1], Duration::from_millis(200));
+}
+
+#[tokio::test(start_paused = true)]
+async fn blocking_non_retryable_error_is_attempted_once() {
+    let failures = vec![
+        InferenceError::Api {
+            status: 400,
+            body: "bad request".into(),
+        },
+        InferenceError::Api {
+            status: 401,
+            body: "unauthorized".into(),
+        },
+        InferenceError::MissingConfig("missing model".into()),
+        InferenceError::Deserialise {
+            message: "bad json".into(),
+            body: "not-json".into(),
+        },
+    ];
+
+    for failure in failures {
+        let llm = Arc::new(BlockingRetryLlm::new(vec![BlockingAttempt::Error(failure)]));
+        let result = AgentLoop::new(AgentLoopConfig::default(), llm.clone(), empty_registry())
+            .run("system", "task")
+            .await;
+        assert!(matches!(result, Err(AgentLoopError::Llm(_))));
+        assert_eq!(llm.calls(), 1);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn stream_handshake_retryable_failure_then_success_recovers() {
+    let llm = Arc::new(StreamingRetryLlm::new(vec![
+        StreamAttempt::HandshakeError(InferenceError::Transport("handshake".into())),
+        StreamAttempt::Events(vec![Ok(ChatStreamEvent::Delta("done".into())), Ok(done())]),
+    ]));
+    let sink = Arc::new(RecordingMessageSink::new());
+
+    let output = AgentLoop::new(AgentLoopConfig::default(), llm.clone(), empty_registry())
+        .with_tool_event_sink(sink.clone())
+        .run("system", "task")
+        .await
+        .expect("handshake retry should recover");
+
+    let messages = sink.messages();
+    assert_eq!(llm.calls(), 2);
+    assert_eq!(output.content, "done");
+    assert_eq!(
+        messages
+            .iter()
+            .map(|message| (message.delta.as_str(), message.done))
+            .collect::<Vec<_>>(),
+        vec![("done", false), ("", true)]
+    );
+    assert_eq!(messages[0].turn_id, messages[1].turn_id);
+}
+
+#[tokio::test(start_paused = true)]
+async fn stream_failure_before_exposure_discards_partial_assembly_before_retry() {
+    let llm = Arc::new(StreamingRetryLlm::new(vec![
+        StreamAttempt::Events(vec![
+            Ok(ChatStreamEvent::Delta(String::new())),
+            Ok(ChatStreamEvent::ToolCall(ToolCallDelta {
+                index: 0,
+                id: Some("discarded".into()),
+                name: Some("discarded_tool".into()),
+                arguments: "{}".into(),
+            })),
+            Err(InferenceError::Transport("stream body".into())),
+        ]),
+        StreamAttempt::Events(vec![Ok(ChatStreamEvent::Delta("clean".into())), Ok(done())]),
+    ]));
+    let sink = Arc::new(RecordingMessageSink::new());
+
+    let output = AgentLoop::new(AgentLoopConfig::default(), llm.clone(), empty_registry())
+        .with_tool_event_sink(sink.clone())
+        .run("system", "task")
+        .await
+        .expect("unexposed body failure should recover");
+
+    assert_eq!(llm.calls(), 2);
+    assert_eq!(output.content, "clean");
+    assert_eq!(sink.visible_text(), vec!["clean".to_string()]);
+    assert_eq!(sink.messages().len(), 2);
+}
+
+#[tokio::test(start_paused = true)]
+async fn stream_failure_after_text_delta_is_not_retried() {
+    let llm = Arc::new(StreamingRetryLlm::new(vec![StreamAttempt::Events(vec![
+        Ok(ChatStreamEvent::Delta("visible".into())),
+        Err(InferenceError::Transport("after exposure".into())),
+    ])]));
+    let sink = Arc::new(RecordingMessageSink::new());
+
+    let error = AgentLoop::new(AgentLoopConfig::default(), llm.clone(), empty_registry())
+        .with_tool_event_sink(sink.clone())
+        .run("system", "task")
+        .await
+        .expect_err("an exposed stream must not retry");
+
+    assert!(matches!(
+        error,
+        AgentLoopError::Llm(InferenceError::Transport(_))
+    ));
+    assert_eq!(llm.calls(), 1);
+    assert_eq!(
+        sink.messages()
+            .iter()
+            .map(|message| (message.delta.as_str(), message.done))
+            .collect::<Vec<_>>(),
+        vec![("visible", false)]
+    );
+}
+
+/// Why (#2272): the exposure flag is reset per attempt, so "already retried
+/// once" and "already showed text" are independent facts. A policy that tracked
+/// only remaining budget — or that hoisted exposure out of the attempt loop —
+/// would still have a retry available here and would replay `visible` a second
+/// time. This is the path the original design note did not cover: exposure
+/// happening on an attempt AFTER the first, with budget left over.
+/// What: attempt 1 fails before showing anything (a legitimate retry), attempt 2
+/// shows text and then fails retryably with one attempt still unspent.
+/// Test: itself.
+#[tokio::test(start_paused = true)]
+async fn stream_exposed_on_a_later_attempt_is_not_retried_again() {
+    let llm = Arc::new(StreamingRetryLlm::new(vec![
+        StreamAttempt::Events(vec![Err(InferenceError::Transport(
+            "before exposure".into(),
+        ))]),
+        StreamAttempt::Events(vec![
+            Ok(ChatStreamEvent::Delta("visible".into())),
+            Err(InferenceError::Transport("after exposure".into())),
+        ]),
+        // A third attempt is inside the budget; reaching it is the bug.
+        StreamAttempt::Events(vec![
+            Ok(ChatStreamEvent::Delta("visible".into())),
+            Ok(done()),
+        ]),
+    ]));
+    let sink = Arc::new(RecordingMessageSink::new());
+
+    let error = AgentLoop::new(AgentLoopConfig::default(), llm.clone(), empty_registry())
+        .with_tool_event_sink(sink.clone())
+        .run("system", "task")
+        .await
+        .expect_err("an exposed stream must not retry even with budget left");
+
+    assert!(matches!(
+        error,
+        AgentLoopError::Llm(InferenceError::Transport(_))
+    ));
+    assert_eq!(llm.calls(), 2);
+    assert_eq!(sink.visible_text(), vec!["visible".to_string()]);
+}
+
+/// Why (#2272): a tool-only turn emits no `agent_message` at all, so "nothing
+/// reached the sink" must not be read as "nothing was assembled". Retrying such
+/// a stream is safe precisely because it was invisible — this pins that the
+/// retry does happen and that the recovered turn still dispatches its tool once.
+/// What: attempt 1 streams a complete tool call and then fails; attempt 2
+/// streams a plain text turn. The user sees only the second attempt's text.
+/// Test: itself.
+#[tokio::test(start_paused = true)]
+async fn tool_only_stream_failure_retries_without_emitting_anything() {
+    let llm = Arc::new(StreamingRetryLlm::new(vec![
+        StreamAttempt::Events(vec![
+            Ok(ChatStreamEvent::ToolCall(ToolCallDelta {
+                index: 0,
+                id: Some("call-1".into()),
+                name: Some("never_dispatched".into()),
+                arguments: "{}".into(),
+            })),
+            Err(InferenceError::Api {
+                status: 503,
+                body: "mid-tool-call".into(),
+            }),
+        ]),
+        StreamAttempt::Events(vec![
+            Ok(ChatStreamEvent::Delta("recovered".into())),
+            Ok(done()),
+        ]),
+    ]));
+    let sink = Arc::new(RecordingMessageSink::new());
+
+    let output = AgentLoop::new(AgentLoopConfig::default(), llm.clone(), empty_registry())
+        .with_tool_event_sink(sink.clone())
+        .run("system", "task")
+        .await
+        .expect("an invisible tool-only stream is safe to retry");
+
+    assert_eq!(llm.calls(), 2);
+    assert_eq!(output.content, "recovered");
+    assert_eq!(sink.visible_text(), vec!["recovered".to_string()]);
+    assert_eq!(
+        sink.messages()
+            .iter()
+            .filter(|message| message.done)
+            .count(),
+        1,
+        "exactly one terminal done: true for the surviving attempt"
+    );
+}
+
+/// Why (#2272): the backoff sleeps are deliberately NOT deducted from a
+/// separate budget — `run_with_transcript` already wraps the whole loop in
+/// `tokio::time::timeout`, and that stays the single outer bound. This pins
+/// that a retry cannot push a run past its configured deadline.
+/// What: the first call burns 950 ms of a 1 s deadline and then fails
+/// retryably; the 100 ms backoff crosses the deadline, so `Timeout` wins and
+/// the second attempt never issues.
+/// Test: itself.
+#[tokio::test(start_paused = true)]
+async fn retry_backoff_is_inside_run_deadline() {
+    let llm = Arc::new(
+        BlockingRetryLlm::new(vec![
+            BlockingAttempt::Error(InferenceError::Transport("late failure".into())),
+            BlockingAttempt::Response(response("must not run")),
+        ])
+        .with_first_call_delay(Duration::from_millis(950)),
+    );
+    let config = AgentLoopConfig {
+        timeout_secs: 1,
+        ..AgentLoopConfig::default()
+    };
+
+    let error = AgentLoop::new(config, llm.clone(), empty_registry())
+        .run("system", "task")
+        .await
+        .expect_err("the outer deadline must expire during retry backoff");
+
+    assert!(matches!(
+        error,
+        AgentLoopError::Timeout {
+            timeout_secs: 1,
+            ..
+        }
+    ));
+    assert_eq!(llm.calls(), 1);
+}


### PR DESCRIPTION
Closes #2272.

`chat_turn` retries a transient inference failure inside the current turn
instead of failing it, on both transports. Three attempts, backing off 100 ms
then 200 ms, replaying the identical request under the same `turn_id`. Only
`InferenceError::is_retryable` failures retry.

A streaming attempt retries only while nothing has reached the sink. Once a
non-empty delta is visible, a mid-stream failure propagates — replaying would
duplicate text the user already read.

## Deadline

The backoff sleeps consume the enclosing run deadline, and that is deliberate:
`run_with_transcript` already wraps the loop in `tokio::time::timeout`, so a
retry cannot push a run past `timeout_secs`. Adding a second budget would give
the retry its own deadline concept for at most 300 ms against a default 120 s
timeout, and the case it would guard against — a backoff sleep crossing the
deadline — is already handled: the timeout fires and returns `Timeout` with the
partial transcript. `retry_backoff_is_inside_run_deadline` pins that.

## Exposure

`ResponseExposure` is per-attempt, so "already retried once" and "already showed
text" stay independent. `stream_exposed_on_a_later_attempt_is_not_retried_again`
covers the case the original design note did not: exposure happening on attempt
2 with a third attempt still inside the budget. A policy keyed on remaining
budget, or one that hoisted the flag out of the attempt loop, replays `visible`
there. `tool_only_stream_failure_retries_without_emitting_anything` pins the
other side — an invisible tool-only stream does retry, and still emits exactly
one terminal `done: true`.

## Gates — rung 3

`agent_loop` is not behind a cargo feature; `trusty-code` declares no
`[features]` section at all, so the crate-scoped run compiles every target here.
`chat_turn` stays `pub(super)` and every new item is private — no public API
change, so rung 4 does not apply.

```
cargo fmt --check                                    # exit 0
cargo check -p trusty-code                           # exit 0
cargo clippy -p trusty-code --all-targets -- -D warnings   # exit 0
cargo test -p trusty-code                            # exit 0
```

`cargo test -p trusty-code`: 1620 passed, 0 failed, 4 ignored (lib) plus every
integration binary green.

### Red without the fix

Reverting only `streaming.rs` to `origin/main` and re-running the new module:

```
test result: FAILED. 2 passed; 8 failed; 0 ignored; 0 measured; 1614 filtered out

blocking_retryable_failure_then_success_is_one_logical_turn
  retry should recover: Llm(Transport("first"))
blocking_retry_exhaustion_returns_third_original_error
  assertion `left == right` failed: left: 1, right: 3
stream_exposed_on_a_later_attempt_is_not_retried_again
  assertion `left == right` failed: left: 1, right: 2
retry_backoff_is_inside_run_deadline
  assertion failed: matches!(error, AgentLoopError::Timeout { timeout_secs: 1, .. })
```

With the fix: `test result: ok. 10 passed; 0 failed`. The two that pass either
way are the negative controls — a non-retryable error is attempted once, and an
exposed stream does not retry — which also hold when nothing retries at all.

Also green: `check_changelog_fragment.sh`, `check_line_cap.sh`,
`check_test_pointers.sh`, `check_teardown_guard.sh`,
`check_generation_artifacts.sh`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
