### PR TITLE
perf(trusty-code): track the working-context floor incrementally instead of rescanning compression.jsonl (#3948)

### DIFF
--- a/crates/trusty-code/changelog.d/3948-incremental-context-floor.md
+++ b/crates/trusty-code/changelog.d/3948-incremental-context-floor.md
@@ -1,0 +1,6 @@
+Performance
+
+- `session.get_context_budget` no longer rescans the multi-session
+  `compression.jsonl` on every call; each session's working-context low-water
+  mark is retained incrementally as measurements arrive. The durable JSONL is
+  unchanged and remains the offline-history source (#3948).

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -959,23 +959,30 @@ pub struct ContextBudgetSnapshot {
     /// for budget state (`session.get_context_budget`) instead of requiring
     /// a second `session.get_transcript` call.
     pub lifetime_compaction_alarm_count: u64,
-    /// (issue #3912) This SESSION's lowest-ever `working_context_pct`,
-    /// derived fresh from `agent_loop::telemetry::session_working_context_floor`
-    /// every time this RPC is queried — `None` when no durable sample for
-    /// this session exists yet. Same "read fresh at query time, `0`/`None`
-    /// placeholder on the write path" pattern as
-    /// `lifetime_compaction_alarm_count` immediately above, and for the same
-    /// reason: the load-realistic compression soak (epic #3866) proved the
-    /// single most-recent snapshot above (`working_context_pct`) can read
-    /// 98-99% while a durable per-turn sample this same session produced
-    /// moments earlier was 48-60% — a coarse once-per-`task.run`-call poll
-    /// reliably misses the turn where the floor was lowest. This field is
-    /// the fix: the real floor, not a snapshot that can miss it.
+    /// (issues #3912, #3948) This SESSION's lowest `working_context_pct`
+    /// across every cadence measurement `SessionRegistry` has recorded for
+    /// it — `None` until the first measurement lands. It exists because the
+    /// load-realistic compression soak (epic #3866) proved the single
+    /// most-recent snapshot above (`working_context_pct`) can read 98-99%
+    /// while the same session dipped to 48-60% moments earlier; a coarse
+    /// poll reliably misses the turn where the floor was lowest.
+    ///
+    /// (#3948) Unlike `lifetime_compaction_alarm_count` above, this is NOT
+    /// read fresh from a durable log at query time. It is folded in
+    /// incrementally by `SessionRegistry::record_context_budget` and lives
+    /// as long as the session does, which means the value is scoped to the
+    /// running daemon: a restart drops the session itself, so the RPC
+    /// answers `session_not_found` rather than a reset floor. Offline
+    /// history stays in `compression.jsonl`, readable via
+    /// `agent_loop::telemetry::session_working_context_floor`; that reader
+    /// aggregates a different sample set (only turns that did compaction
+    /// work, plus threshold fires), so its floor and this one can differ.
     pub working_context_pct_low_water_mark: Option<u8>,
-    /// (issue #3912) How many durable telemetry samples
+    /// (issues #3912, #3948) How many cadence measurements
     /// `working_context_pct_low_water_mark` was computed over for this
     /// session — lets a consumer distinguish "no samples yet" (`None` above)
-    /// from "exactly one, possibly unrepresentative, sample".
+    /// from "exactly one, possibly unrepresentative, sample". Counts live
+    /// measurements, not durable JSONL rows.
     pub working_context_pct_sample_count: usize,
     /// (issue #3911) Lifetime, cross-session count of a cadence-level
     /// 60%-floor breach (`CadenceOutcome::within_budget == false` after

--- a/crates/trusty-code/src/session/mod.rs
+++ b/crates/trusty-code/src/session/mod.rs
@@ -39,6 +39,12 @@ pub mod protocol;
 pub mod registry;
 pub mod transcript;
 
+/// (issue #3948) The per-session working-context floor `registry` folds into
+/// each `SessionEntry` — a private sibling module, not part of the crate's
+/// public surface.
+#[path = "registry_context_floor.rs"]
+mod registry_context_floor;
+
 pub use connector::TcodeConnector;
 pub use memory_sink::{PalaceCreation, TurnMemorySink};
 pub use model::{Session, SessionStatus};

--- a/crates/trusty-code/src/session/protocol_budget.rs
+++ b/crates/trusty-code/src/session/protocol_budget.rs
@@ -227,11 +227,12 @@ mod tests {
 
     // -- issue #3912: working_context_pct_low_water_mark --
 
-    /// The core #3912 acceptance criterion: `session.get_context_budget`
-    /// must surface the REAL floor this session's telemetry recorded, not
-    /// just the most-recent cached snapshot — reproducing the load-soak's
-    /// finding (RPC reads 98-99% while the durable JSONL floor was 48-60%)
-    /// with a small fixture instead of a full daemon soak.
+    /// The core #3912 acceptance criterion, still enforced after #3948 moved
+    /// the computation onto the write path: `session.get_context_budget`
+    /// must surface the REAL floor this session measured, not just the
+    /// most-recent snapshot — the load-soak's finding (RPC reads 98-99%
+    /// while the true floor was 48-60%) with a small fixture instead of a
+    /// full daemon soak.
     #[tokio::test]
     async fn get_context_budget_reflects_working_context_floor() {
         let dir = telemetry_temp_dir("floor-reflects");
@@ -239,37 +240,16 @@ mod tests {
         let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
         let result = crate::agent_loop::telemetry::with_data_dir_env_fut(&dir, async {
-            // Two durable cadence samples for THIS session: one healthy
-            // (90% working), one a real dip (48% working) — simulating the
-            // exact gap the load soak found between a coarse snapshot and
-            // the true per-turn floor.
-            crate::agent_loop::telemetry::record_cadence_event(
-                &dir,
-                Some(session.id.clone()),
-                100_000,
-                20_000,
-                200_000,
-                5,
-                1,
-            ); // working = 90%
-            crate::agent_loop::telemetry::record_cadence_event(
-                &dir,
-                Some(session.id.clone()),
-                100_000,
-                104_000,
-                200_000,
-                5,
-                4,
-            ); // working = 48%
-
-            // The CACHED snapshot itself still only reflects the latest
-            // (healthy-looking) turn, exactly like the real
-            // `record_context_budget` write path.
-            let mut healthy = measurement();
-            healthy.working_context_pct = 90;
-            registry
-                .record_context_budget(&session.id, &healthy)
-                .unwrap();
+            // Three cadence measurements: healthy, a real dip, then a
+            // partial recovery. The cached snapshot alone would report only
+            // the last one.
+            for pct in [90, 48, 75] {
+                let mut sample = measurement();
+                sample.working_context_pct = pct;
+                registry
+                    .record_context_budget(&session.id, &sample)
+                    .unwrap();
+            }
 
             get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
                 .await
@@ -278,23 +258,52 @@ mod tests {
         .await;
 
         assert_eq!(
-            result["working_context_pct"], 90,
-            "the point-in-time snapshot alone still reads the healthy-looking latest turn"
+            result["working_context_pct"], 75,
+            "the point-in-time snapshot still reports the latest turn"
         );
         assert_eq!(
             result["working_context_pct_low_water_mark"], 48,
             "the low-water mark must surface the real floor the snapshot alone hides"
         );
-        assert_eq!(result["working_context_pct_sample_count"], 2);
+        assert_eq!(result["working_context_pct_sample_count"], 3);
 
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    /// A session with no durable telemetry samples yet reports `None`/`0`,
-    /// never a fabricated floor.
+    /// (#3948) Durable history — however large or malformed — cannot move
+    /// the live aggregate, because the query no longer reads it.
     #[tokio::test]
-    async fn get_context_budget_floor_none_without_samples() {
-        let dir = telemetry_temp_dir("floor-none");
+    async fn get_context_budget_floor_ignores_durable_log() {
+        let dir = telemetry_temp_dir("floor-ignores-log");
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let result = crate::agent_loop::telemetry::with_data_dir_env_fut(&dir, async {
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("compression.jsonl"), "{not-json}\n".repeat(10_000)).unwrap();
+            let mut sample = measurement();
+            sample.working_context_pct = 73;
+            registry
+                .record_context_budget(&session.id, &sample)
+                .unwrap();
+            get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
+                .await
+                .unwrap()
+        })
+        .await;
+
+        assert_eq!(result["working_context_pct_low_water_mark"], 73);
+        assert_eq!(result["working_context_pct_sample_count"], 1);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// (#3948) One recorded measurement establishes the floor even when no
+    /// `compression.jsonl` exists at all — the floor is the measurement, not
+    /// a fabricated value and not `None`.
+    #[tokio::test]
+    async fn get_context_budget_floor_without_durable_log() {
+        let dir = telemetry_temp_dir("floor-no-log");
         let registry = SessionRegistry::new();
         let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
@@ -308,8 +317,9 @@ mod tests {
         })
         .await;
 
-        assert!(result["working_context_pct_low_water_mark"].is_null());
-        assert_eq!(result["working_context_pct_sample_count"], 0);
+        assert!(!dir.join("compression.jsonl").exists());
+        assert_eq!(result["working_context_pct_low_water_mark"], 75);
+        assert_eq!(result["working_context_pct_sample_count"], 1);
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -123,6 +123,11 @@ struct SessionEntry {
     /// sub-agent loop never emits one), so `session.get_context_budget` can
     /// distinguish "never recorded" from an all-zero snapshot.
     context_budget: Option<ContextBudgetSnapshot>,
+    /// (issue #3948) This session's retained working-context low-water mark
+    /// and sample count, folded in by every `record_context_budget` call.
+    /// Kept beside `context_budget` rather than inside it so the latest
+    /// point-in-time snapshot stays a pure last-writer-wins value.
+    context_floor: super::registry_context_floor::ContextFloorState,
     /// (DOC-39 §5.4) Live per-agent roster, in first-seen order — the
     /// AUTHORITATIVE state `session.get_agents` reads (see
     /// `session::registry::agents`'s module docs). Updated by [`Self::record`]
@@ -334,6 +339,7 @@ impl SessionRegistry {
                     memory_sink: None,
                     readiness: None,
                     context_budget: None,
+                    context_floor: super::registry_context_floor::ContextFloorState::default(),
                     agents: Vec::new(),
                     search_audit: VecDeque::new(),
                 },

--- a/crates/trusty-code/src/session/registry_context_floor.rs
+++ b/crates/trusty-code/src/session/registry_context_floor.rs
@@ -1,0 +1,32 @@
+//! Incremental per-session working-context floor (issue #3948).
+//!
+//! Why: `session.get_context_budget` is a monitoring path a client polls, and
+//! it used to rebuild this session's floor by scanning the multi-session
+//! `compression.jsonl` on every call — a read whose cost grows with the
+//! machine's whole compression history. Sessions are process-local
+//! (`SessionRegistry` holds them in memory and nothing rehydrates them), so
+//! an aggregate with the same lifetime as the session it describes is enough.
+//! What: every authoritative cadence measurement records one sample; the
+//! minimum percentage is retained and the count saturates rather than wraps.
+//! Test: `registry_tests::context_floor_tracks_every_measurement`,
+//! `registry_tests::context_floor_is_session_scoped`,
+//! `registry_tests::context_floor_saturates_sample_count`,
+//! `registry_tests::context_floor_after_restart_is_absent_not_wrong`.
+
+/// One session's retained working-context floor and how many measurements
+/// produced it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct ContextFloorState {
+    pub(super) low_water_mark: Option<u8>,
+    pub(super) sample_count: usize,
+}
+
+impl ContextFloorState {
+    /// Fold one measurement into the floor.
+    pub(super) fn record(&mut self, working_context_pct: u8) {
+        self.low_water_mark = Some(self.low_water_mark.map_or(working_context_pct, |current| {
+            current.min(working_context_pct)
+        }));
+        self.sample_count = self.sample_count.saturating_add(1);
+    }
+}

--- a/crates/trusty-code/src/session/registry_events.rs
+++ b/crates/trusty-code/src/session/registry_events.rs
@@ -226,15 +226,23 @@ impl SessionRegistry {
     /// (the actual RPC query path — called far less often, once per client
     /// poll) overwrites this field with a fresh read before returning, so no
     /// caller ever observes the placeholder.
+    /// (#3948) The session's working-context floor takes the opposite route:
+    /// it is folded in HERE, under the same lock that stores the snapshot,
+    /// because a `min` over one `u8` costs nothing per turn while the query
+    /// path's alternative — rescanning the multi-session
+    /// `compression.jsonl` — grows with the machine's whole compression
+    /// history.
     /// Test: `registry_tests::record_context_budget_publishes_event`,
-    /// `registry_tests::record_context_budget_caches_snapshot_for_late_query`.
+    /// `registry_tests::record_context_budget_caches_snapshot_for_late_query`,
+    /// `registry_tests::context_floor_tracks_every_measurement`,
+    /// `registry_tests::context_floor_is_session_scoped`.
     pub fn record_context_budget(
         &self,
         id: &str,
         measurement: &crate::agent_loop::ContextBudgetSnapshot,
     ) -> Result<(), RpcError> {
         self.ensure_exists(id)?;
-        let snapshot = ContextBudgetSnapshot {
+        let mut snapshot = ContextBudgetSnapshot {
             context_window_tokens: measurement.context_window,
             overhead_tokens: measurement.overhead_tokens,
             overhead_cap_tokens: measurement.overhead_cap_tokens,
@@ -247,8 +255,8 @@ impl SessionRegistry {
             // `get_context_budget` reads this field back out, and it always
             // overwrites it first.
             lifetime_compaction_alarm_count: 0,
-            // (#3912) Same placeholder contract as the field above —
-            // `get_context_budget` overwrites both before returning.
+            // (#3948) Overwritten from this entry's retained floor under the
+            // registry lock below, before the snapshot is stored.
             working_context_pct_low_water_mark: None,
             working_context_pct_sample_count: 0,
             // (#3911) Same placeholder contract as
@@ -258,6 +266,9 @@ impl SessionRegistry {
         {
             let mut sessions = self.lock();
             if let Some(entry) = sessions.get_mut(id) {
+                entry.context_floor.record(measurement.working_context_pct);
+                snapshot.working_context_pct_low_water_mark = entry.context_floor.low_water_mark;
+                snapshot.working_context_pct_sample_count = entry.context_floor.sample_count;
                 entry.context_budget = Some(snapshot);
             }
         }
@@ -302,31 +313,42 @@ impl SessionRegistry {
     /// once per query, not once per turn per session. This is also why the
     /// count reflects fires from ANY session on this machine, not just this
     /// one: it is derived from a shared log, not a per-session cache.
-    /// (#3912) `working_context_pct_low_water_mark`/
-    /// `working_context_pct_sample_count` are likewise read fresh here, from
-    /// the SAME durable log filtered to THIS session — the fix for the
-    /// load-realistic soak's finding that the cached snapshot above
-    /// (`working_context_pct`) can read 98-99% while this session's real
-    /// floor (durably recorded) was 48-60%.
+    /// (#3948) `working_context_pct_low_water_mark`/
+    /// `working_context_pct_sample_count` are read from the state
+    /// [`Self::record_context_budget`] retains per session, NOT from
+    /// `compression.jsonl`. This query used to call
+    /// `telemetry::session_working_context_floor`, which reopens and reparses
+    /// the machine-wide compression log on every poll; that function is
+    /// unchanged and remains the offline-history reader, but no live query
+    /// path calls it. The two answers are not identical, and the difference
+    /// is deliberate: the live floor samples EVERY cadence tick, while the
+    /// log only carries a percentage for turns where compaction work
+    /// happened (`rounds > 0`) plus threshold-compaction fires, which
+    /// `record_context_budget` never sees. So the live floor is over a
+    /// per-turn superset of this session's cadence measurements, and
+    /// `working_context_pct_sample_count` counts cadence measurements rather
+    /// than durable rows.
     /// Test: `registry_tests::record_context_budget_caches_snapshot_for_late_query`,
     /// `protocol_budget::tests::get_context_budget_never_recorded_session_returns_never_recorded`,
     /// `registry_tests::get_context_budget_unknown_session_errors`,
     /// `protocol_budget::tests::get_context_budget_reflects_lifetime_compaction_alarm_count`,
-    /// `protocol_budget::tests::get_context_budget_reflects_working_context_floor`.
+    /// `protocol_budget::tests::get_context_budget_reflects_working_context_floor`,
+    /// `registry_tests::context_budget_query_does_not_open_compression_log`,
+    /// `registry_tests::context_floor_after_restart_is_absent_not_wrong`.
     pub fn get_context_budget(&self, id: &str) -> Result<ContextBudgetQuery, RpcError> {
         self.ensure_exists(id)?;
-        Ok(self
-            .lock()
-            .get(id)
-            .and_then(|e| e.context_budget)
+        let cached = self.lock().get(id).and_then(|entry| {
+            entry.context_budget.map(|mut snapshot| {
+                snapshot.working_context_pct_low_water_mark = entry.context_floor.low_water_mark;
+                snapshot.working_context_pct_sample_count = entry.context_floor.sample_count;
+                snapshot
+            })
+        });
+        Ok(cached
             .map(|mut snapshot| {
                 let data_dir = crate::agent_loop::telemetry::default_data_dir();
                 snapshot.lifetime_compaction_alarm_count =
                     crate::agent_loop::telemetry::lifetime_compaction_alarm_count(&data_dir);
-                let (low_water_mark, sample_count) =
-                    crate::agent_loop::telemetry::session_working_context_floor(&data_dir, id);
-                snapshot.working_context_pct_low_water_mark = low_water_mark;
-                snapshot.working_context_pct_sample_count = sample_count;
                 snapshot.lifetime_cadence_floor_breach_count =
                     crate::agent_loop::telemetry::lifetime_cadence_floor_breach_count(&data_dir);
                 ContextBudgetQuery::Recorded(snapshot)

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -2090,3 +2090,220 @@ async fn get_context_budget_unknown_session_errors() {
     let err = registry.get_context_budget("nope").unwrap_err();
     assert_eq!(err.code, -32007);
 }
+
+// ── issue #3948: incremental per-session working-context floor ────────────────
+
+/// Build one authoritative cadence measurement at `working_context_pct`.
+fn floor_measurement(working_context_pct: u8) -> crate::agent_loop::ContextBudgetSnapshot {
+    crate::agent_loop::ContextBudgetSnapshot {
+        context_window: 200_000,
+        overhead_tokens: 200_000 * usize::from(100 - working_context_pct) / 100,
+        overhead_cap_tokens: 80_000,
+        working_context_pct,
+        overhead_pct: 100 - working_context_pct,
+        within_budget: working_context_pct >= 60,
+        fired: false,
+        rounds: 0,
+    }
+}
+
+/// Issue #3948: every authoritative cadence measurement contributes exactly
+/// one sample, and the lowest percentage is retained after a later turn
+/// recovers.
+/// Test: this test.
+#[tokio::test]
+async fn context_floor_tracks_every_measurement() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    for pct in [90, 48, 75] {
+        registry
+            .record_context_budget(&session.id, &floor_measurement(pct))
+            .unwrap();
+    }
+
+    let events::ContextBudgetQuery::Recorded(snapshot) =
+        registry.get_context_budget(&session.id).unwrap()
+    else {
+        panic!("expected a recorded context budget");
+    };
+    assert_eq!(snapshot.working_context_pct, 75, "latest turn still wins");
+    assert_eq!(snapshot.working_context_pct_low_water_mark, Some(48));
+    assert_eq!(snapshot.working_context_pct_sample_count, 3);
+}
+
+/// Issue #3948: one session's floor cannot be moved by another session's
+/// measurements in the same registry.
+/// Test: this test.
+#[tokio::test]
+async fn context_floor_is_session_scoped() {
+    let registry = SessionRegistry::new();
+    let first = registry.create(
+        "first".to_string(),
+        None,
+        crate::binding::ProjectBinding::None,
+    );
+    let second = registry.create(
+        "second".to_string(),
+        None,
+        crate::binding::ProjectBinding::None,
+    );
+
+    registry
+        .record_context_budget(&first.id, &floor_measurement(90))
+        .unwrap();
+    registry
+        .record_context_budget(&second.id, &floor_measurement(12))
+        .unwrap();
+
+    let events::ContextBudgetQuery::Recorded(snapshot) =
+        registry.get_context_budget(&first.id).unwrap()
+    else {
+        panic!("expected a recorded context budget");
+    };
+    assert_eq!(snapshot.working_context_pct_low_water_mark, Some(90));
+    assert_eq!(snapshot.working_context_pct_sample_count, 1);
+}
+
+/// Issue #3948: the sample counter is telemetry and must saturate rather
+/// than wrap in a long-lived session.
+/// Test: this test.
+#[test]
+fn context_floor_saturates_sample_count() {
+    let mut floor = super::super::registry_context_floor::ContextFloorState {
+        low_water_mark: Some(60),
+        sample_count: usize::MAX,
+    };
+
+    floor.record(48);
+
+    assert_eq!(floor.low_water_mark, Some(48));
+    assert_eq!(floor.sample_count, usize::MAX);
+}
+
+/// Issue #3948: prove the live query performs no `compression.jsonl` open,
+/// rather than only proving malformed contents do not change its answer.
+///
+/// A FIFO blocks a read-only `File::open` until a writer connects, so the
+/// query must return while this FIFO has no writer. The timeout branch
+/// connects a non-blocking writer to release a blocked reader before
+/// reporting the violation; that timeout is the contract under test, not a
+/// wait for eventual consistency.
+/// Test: this test.
+#[cfg(unix)]
+#[tokio::test]
+async fn context_budget_query_does_not_open_compression_log() {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::sync::mpsc;
+
+    let dir = crate::agent_loop::telemetry::test_temp_dir("context-floor-no-open");
+    let path = CString::new(dir.join("compression.jsonl").as_os_str().as_bytes()).unwrap();
+    // SAFETY: `path` is a valid, NUL-terminated path owned for this call.
+    let created = unsafe { libc::mkfifo(path.as_ptr(), 0o600) };
+    assert_eq!(
+        created,
+        0,
+        "mkfifo failed: {}",
+        std::io::Error::last_os_error()
+    );
+
+    let registry = Arc::new(SessionRegistry::new());
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    registry
+        .record_context_budget(&session.id, &floor_measurement(73))
+        .unwrap();
+
+    let query = crate::agent_loop::telemetry::with_data_dir_env(&dir, || {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let worker_registry = Arc::clone(&registry);
+        let session_id = session.id.clone();
+        let worker = std::thread::spawn(move || {
+            let _ = tx.send(worker_registry.get_context_budget(&session_id));
+        });
+
+        match rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(result) => {
+                worker.join().expect("budget query worker panicked");
+                result
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                // Never let cleanup block on the FIFO itself. If the query
+                // opened a reader this non-blocking writer connects and
+                // releases it; if it did not, `open` returns `ENXIO` and the
+                // detached worker cannot stall the test process.
+                let writer = unsafe {
+                    libc::open(
+                        path.as_ptr(),
+                        libc::O_WRONLY | libc::O_NONBLOCK | libc::O_CLOEXEC,
+                    )
+                };
+                if writer >= 0 {
+                    let payload = b"{not-json}\n";
+                    // SAFETY: `writer` is an open FIFO descriptor and the
+                    // payload pointer is valid for `payload.len()` bytes.
+                    unsafe {
+                        libc::write(writer, payload.as_ptr().cast(), payload.len());
+                        libc::close(writer);
+                    }
+                    worker.join().expect("budget query worker panicked");
+                }
+                panic!("get_context_budget opened compression.jsonl");
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                worker.join().expect("budget query worker panicked");
+                panic!("budget query worker disconnected without a result");
+            }
+        }
+    })
+    .await
+    .unwrap();
+
+    let events::ContextBudgetQuery::Recorded(snapshot) = query else {
+        panic!("expected a recorded context budget");
+    };
+    assert_eq!(snapshot.working_context_pct_low_water_mark, Some(73));
+    assert_eq!(snapshot.working_context_pct_sample_count, 1);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Issue #3948: a daemon restart drops the whole session, so the live floor
+/// cannot silently reset to a wrong value — the RPC reports
+/// `session_not_found`, and the durable JSONL still carries that session's
+/// history for offline analysis.
+/// Test: this test.
+#[tokio::test]
+async fn context_floor_after_restart_is_absent_not_wrong() {
+    let dir = crate::agent_loop::telemetry::test_temp_dir("context-floor-restart");
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    registry
+        .record_context_budget(&session.id, &floor_measurement(48))
+        .unwrap();
+    crate::agent_loop::telemetry::record_cadence_event(
+        &dir,
+        Some(session.id.clone()),
+        100_000,
+        104_000,
+        200_000,
+        5,
+        4,
+    );
+
+    // The restart: nothing in-memory carries over.
+    let restarted = SessionRegistry::new();
+    let err = restarted.get_context_budget(&session.id).unwrap_err();
+    assert_eq!(
+        err.code, -32007,
+        "the session itself is gone, not its floor"
+    );
+
+    assert_eq!(
+        crate::agent_loop::telemetry::session_working_context_floor(&dir, &session.id),
+        (Some(48), 1),
+        "the durable log remains the offline history source across a restart"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
Closes #3948.

`session.get_context_budget` recomputed `working_context_pct_low_water_mark` on every call by reopening and reparsing the multi-session `compression.jsonl`. `SessionRegistry` now folds each measurement into a per-session `ContextFloorState` in `record_context_budget`, under the same lock that stores the snapshot; the query copies that state out and opens no file.

`ContextBudgetSnapshot`'s public fields are unchanged — only the doc comments and where the value is computed.

## What a reader should check

**The live floor and the durable JSONL can differ, on purpose.** The live floor takes a sample on every cadence tick. `compression.jsonl` carries a `working_context_pct_after` only for turns where compaction work happened (`rounds > 0`, `compaction_control.rs:240`) plus threshold-compaction fires, which never reach `record_context_budget` at all. So the live series is a per-turn superset of this session's cadence measurements, and `working_context_pct_sample_count` now counts measurements rather than durable rows. Both field docs say this.

**`telemetry::session_working_context_floor` is untouched** and remains the offline-history reader, with its own tests. Nothing on a live query path calls it any more.

**Restart behaviour is not a fail-open regression.** `SessionRegistry` is in-memory only (`serve/mod.rs:183` constructs a fresh one; nothing rehydrates it) and session ids are UUIDv4, so a restart drops the session rather than resetting its floor: the RPC answers `session_not_found`. Before this change the rescan could not survive a restart either, because `ensure_exists` already errored first. `context_floor_after_restart_is_absent_not_wrong` pins both halves — the RPC errors, and the durable log still reports that session's history.

## Test ladder — rung 3

`trusty-code` has no `[features]` section, so nothing here sits behind a non-default feature.

```
cargo fmt --check                                       # exit 0
cargo check -p trusty-code                              # exit 0
cargo clippy -p trusty-code --all-targets -- -D warnings # exit 0
cargo test -p trusty-code                               # exit 0
```

`cargo test -p trusty-code`: lib `1616 passed; 0 failed; 4 ignored`, plus 14 integration binaries and the bin target, all `0 failed`.

### Red before, green after

`context_budget_query_does_not_open_compression_log` is the behavioural proof that the rescan is gone: it puts a FIFO at `<data_dir>/compression.jsonl`, which blocks a read-only `File::open` until a writer connects, then requires the query to return anyway. On the pre-change code, with only the new module present:

```
test session::registry::registry_tests::context_floor_saturates_sample_count ... ok
test session::registry::registry_tests::context_floor_after_restart_is_absent_not_wrong ... ok
test session::registry::registry_tests::context_floor_is_session_scoped ... FAILED
test session::registry::registry_tests::context_floor_tracks_every_measurement ... FAILED
test session::registry::registry_tests::context_budget_query_does_not_open_compression_log ... FAILED

---- context_floor_tracks_every_measurement stdout ----
assertion `left == right` failed
  left: None
 right: Some(48)

---- context_budget_query_does_not_open_compression_log stdout ----
panicked at crates/trusty-code/src/session/registry_tests.rs:2251:17:
get_context_budget opened compression.jsonl

test result: FAILED. 2 passed; 3 failed; 0 ignored; 0 measured; 1614 filtered out; finished in 5.12s
```

After the change all five pass inside the run above. No timing assertion anywhere — the FIFO timeout is the contract, not a wait for eventual consistency.

### Repo gates

```
line-cap: 4056 tracked .rs file(s); 0 violations — OK
changelog-fragment: all 1 crate(s) with source changes are recorded — OK
sld-lint: 0 error(s), 0 warning(s)
test-pointers: 25473 citation(s), 0 dangling — OK
teardown guard: OK
generation-artifacts: 0 leaked artifacts — OK
```

## Two existing tests changed premise

`protocol_budget::tests::get_context_budget_reflects_working_context_floor` used to seed two durable JSONL rows and assert the query read them. It now records three measurements and asserts the same acceptance criterion (`working_context_pct` 75, floor 48) through the new path. `get_context_budget_floor_none_without_samples` asserted `null`/`0` after a measurement had been recorded — the inverse of the new contract — and is replaced by two tests: `get_context_budget_floor_without_durable_log` (one measurement establishes the floor with no JSONL on disk) and `get_context_budget_floor_ignores_durable_log` (10k malformed lines cannot move it).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
