### PR TITLE
feat(trusty-code): report per-session durable-memory degradation (#2425)

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -176,7 +176,7 @@ crates/trusty-code/src/runner/in_process.rs	with_timeout_secs_overrides_only_tim
 crates/trusty-code/src/serve/http.rs	http_session_events_sse_streams_replay_then_live_event
 crates/trusty-code/src/session/registry.rs	cancel_is_idempotent_on_terminal_session
 crates/trusty-code/src/session/registry.rs	detach_stops_the_forwarder
-crates/trusty-code/src/session/registry.rs	get_transcript_returns_stored_record
+crates/trusty-code/src/session/registry_transcript.rs	get_transcript_returns_stored_record
 crates/trusty-code/src/session/transcript.rs	get_transcript_returns_stored_record
 crates/trusty-code/src/skills/mod.rs	load_skill_body_io_error
 crates/trusty-code/src/tools/registry.rs	register_panics_on_duplicate_in_debug

--- a/crates/trusty-code/changelog.d/2425-memory-durability-observability.md
+++ b/crates/trusty-code/changelog.d/2425-memory-durability-observability.md
@@ -1,0 +1,5 @@
+Fixed
+
+- `session.get_transcript` reports a per-session `memory_durability` status — lifetime failed turns, the current streak, and the latest failure's category and time — and the registry logs a warning at the first and third consecutive failed turn, so a session whose durable history is thinning no longer looks identical to a healthy one ([#2425](https://github.com/bobmatnyc/trusty-tools/issues/2425))
+- Turn-recorder warnings name a closed failure category instead of quoting the memory daemon's error text and `memory_remember` `reason` back, either of which can carry a preview of the very credential the #2520 secret gate refused to store ([#2425](https://github.com/bobmatnyc/trusty-tools/issues/2425))
+- An outcome the reorder reconciler refuses is counted in `memory_durability.unrecorded_outcomes` and reported by the observer instead of being discarded, so exceeding the bound no longer erases the degradation signal it was meant to surface ([#2425](https://github.com/bobmatnyc/trusty-tools/issues/2425))

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -443,6 +443,7 @@ mod tests {
             mode: Some(crate::mode::HarnessMode::DailyDriver),
             compaction_events: 0,
             goals: vec![],
+            memory_durability: crate::session::MemoryDurabilityStatus::default(),
         };
         let out = render_transcript_human(&record);
         assert!(out.contains("pm"));
@@ -461,6 +462,7 @@ mod tests {
             mode: None,
             compaction_events: 0,
             goals: vec![],
+            memory_durability: crate::session::MemoryDurabilityStatus::default(),
         };
         let out = render_transcript_human(&record);
         assert!(out.contains("s-1"));

--- a/crates/trusty-code/src/session/memory_outcome_reconciler.rs
+++ b/crates/trusty-code/src/session/memory_outcome_reconciler.rs
@@ -1,0 +1,282 @@
+//! Bounded logical-order reconciliation for durable-memory turn outcomes
+//! (#2425).
+//!
+//! Why: queue-full outcomes are reported synchronously by
+//! `TurnMemorySink::enqueue`, while accepted turns finish later in the detached
+//! FIFO drain. Arrival order can therefore be `D2, D3, D1` even though
+//! durability status is defined over QUEUED-TURN order — and folding outcomes
+//! in arrival order lets an older durable completion erase a newer dropped
+//! turn's streak, or skip a warning threshold entirely. Keeping every early
+//! outcome in a map instead would make a stuck drain plus sustained queue-full
+//! load an unbounded in-process memory leak.
+//! What: adjacent equal outcomes are stored as compact sequence RUNS and folded
+//! only when the next logical sequence is available. The default sink has at
+//! most `QUEUE_CAPACITY` queued turns plus one in the drain, and each pair of
+//! pending synchronous-failure runs must be separated by one such accepted
+//! turn, so at most `QUEUE_CAPACITY + 2` runs are reachable. That bound is
+//! enforced structurally even if a caller violates those sink-ordering
+//! invariants: the excess outcome is REFUSED, and the refusal is reported to
+//! the caller rather than silently dropped — see
+//! `SessionRegistry::record_memory_durability`.
+//! Test: `registry_tests::two_out_of_order_degradations_fold_in_logical_sequence`,
+//! `registry_tests::three_out_of_order_degradations_emit_every_crossed_warning_threshold`,
+//! `registry_tests::outcome_beyond_the_reorder_bound_is_counted_as_unrecorded`.
+
+use chrono::{DateTime, Utc};
+
+use super::memory_sink::{MemoryFailureCategory, MemoryTurnOutcome, QUEUE_CAPACITY};
+use super::transcript::MemoryDurabilityStatus;
+
+/// The most pending runs reachable under the sink's own ordering invariants.
+const MAX_PENDING_RUNS: usize = QUEUE_CAPACITY + 2;
+
+/// One streak threshold this fold crossed, for the caller to report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct MemoryDurabilityWarning {
+    pub category: MemoryFailureCategory,
+    pub consecutive: u32,
+}
+
+/// A maximal run of adjacent sequences sharing one verdict.
+#[derive(Debug)]
+enum PendingRun {
+    Durable {
+        start: u64,
+        end: u64,
+    },
+    Degraded {
+        start: u64,
+        end: u64,
+        category: MemoryFailureCategory,
+        latest_at: DateTime<Utc>,
+    },
+}
+
+impl PendingRun {
+    fn start(&self) -> u64 {
+        match self {
+            Self::Durable { start, .. } | Self::Degraded { start, .. } => *start,
+        }
+    }
+
+    fn end(&self) -> u64 {
+        match self {
+            Self::Durable { end, .. } | Self::Degraded { end, .. } => *end,
+        }
+    }
+
+    fn contains(&self, sequence: u64) -> bool {
+        self.start() <= sequence && sequence <= self.end()
+    }
+
+    /// Fuse `self` with the run that immediately follows it, or hand both back.
+    ///
+    /// Why: compaction is what makes the bound hold — without it, sustained
+    /// queue-full load under a stuck drain would add one entry per turn.
+    /// What: only adjacent runs of the SAME verdict (and, when degraded, the
+    /// same category) merge; the merged run keeps the later `latest_at`, which
+    /// is the one the status reports.
+    fn merge(self, right: Self) -> Result<Self, (Self, Self)> {
+        if self.end().checked_add(1) != Some(right.start()) {
+            return Err((self, right));
+        }
+        match (self, right) {
+            (Self::Durable { start, .. }, Self::Durable { end, .. }) => {
+                Ok(Self::Durable { start, end })
+            }
+            (
+                Self::Degraded {
+                    start, category, ..
+                },
+                Self::Degraded {
+                    end,
+                    category: right_category,
+                    latest_at,
+                    ..
+                },
+            ) if category == right_category => Ok(Self::Degraded {
+                start,
+                end,
+                category,
+                latest_at,
+            }),
+            (left, right) => Err((left, right)),
+        }
+    }
+}
+
+/// Folds out-of-order turn outcomes back into queued-turn order (#2425).
+#[derive(Debug)]
+pub(super) struct MemoryOutcomeReconciler {
+    next_sequence: u64,
+    pending: Vec<PendingRun>,
+}
+
+impl Default for MemoryOutcomeReconciler {
+    fn default() -> Self {
+        Self {
+            // `TurnMemorySink::enqueue` numbers its first turn 1.
+            next_sequence: 1,
+            pending: Vec::new(),
+        }
+    }
+}
+
+impl MemoryOutcomeReconciler {
+    /// Fold one outcome into `status`, returning the streak thresholds it
+    /// crossed.
+    ///
+    /// Why: the status must reflect LOGICAL turn order, so an outcome that
+    /// arrives before its predecessor is parked rather than applied.
+    /// `total_failed_turns` is the exception — it is order-free, so a degraded
+    /// outcome counts the moment it arrives, whether or not it can fold yet.
+    /// What: `Ok(warnings)` on success, possibly empty. `Err(())` when the
+    /// pending-run bound would be exceeded; the outcome is then NOT applied and
+    /// NOT counted, which is why the caller must record the refusal rather than
+    /// discard it. A sequence already folded or already pending is idempotently
+    /// ignored.
+    /// Test: `registry_tests::mixed_out_of_order_memory_outcomes_preserve_the_newest_logical_state`,
+    /// `registry_tests::outcome_beyond_the_reorder_bound_is_counted_as_unrecorded`.
+    pub(super) fn observe(
+        &mut self,
+        status: &mut MemoryDurabilityStatus,
+        outcome: MemoryTurnOutcome,
+    ) -> Result<Vec<MemoryDurabilityWarning>, ()> {
+        let sequence = outcome_sequence(&outcome);
+        if sequence < self.next_sequence || self.pending.iter().any(|run| run.contains(sequence)) {
+            return Ok(Vec::new());
+        }
+
+        if sequence == self.next_sequence {
+            if matches!(outcome, MemoryTurnOutcome::Degraded { .. }) {
+                status.total_failed_turns = status.total_failed_turns.saturating_add(1);
+            }
+            let mut warnings = Vec::new();
+            self.fold(status, outcome.into(), &mut warnings);
+            self.fold_ready(status, &mut warnings);
+            return Ok(warnings);
+        }
+
+        let degraded = matches!(outcome, MemoryTurnOutcome::Degraded { .. });
+        self.insert(outcome.into())?;
+        if degraded {
+            status.total_failed_turns = status.total_failed_turns.saturating_add(1);
+        }
+        Ok(Vec::new())
+    }
+
+    /// Park a run that cannot fold yet, refusing it if the bound is reached.
+    fn insert(&mut self, run: PendingRun) -> Result<(), ()> {
+        let position = self
+            .pending
+            .partition_point(|existing| existing.start() < run.start());
+        self.pending.insert(position, run);
+        self.compact();
+        if self.pending.len() > MAX_PENDING_RUNS {
+            self.pending.remove(position.min(self.pending.len() - 1));
+            return Err(());
+        }
+        Ok(())
+    }
+
+    fn compact(&mut self) {
+        let mut index = 0;
+        while index + 1 < self.pending.len() {
+            let left = self.pending.remove(index);
+            let right = self.pending.remove(index);
+            match left.merge(right) {
+                Ok(merged) => self.pending.insert(index, merged),
+                Err((left, right)) => {
+                    self.pending.insert(index, right);
+                    self.pending.insert(index, left);
+                    index += 1;
+                }
+            }
+        }
+    }
+
+    fn fold_ready(
+        &mut self,
+        status: &mut MemoryDurabilityStatus,
+        warnings: &mut Vec<MemoryDurabilityWarning>,
+    ) {
+        while self
+            .pending
+            .first()
+            .is_some_and(|run| run.start() == self.next_sequence)
+        {
+            let run = self.pending.remove(0);
+            self.fold(status, run, warnings);
+        }
+    }
+
+    /// Apply one run at the head of logical order.
+    ///
+    /// Why: a run of N degraded turns can cross BOTH warning thresholds at
+    /// once, so the thresholds are tested against the streak's before/after
+    /// span rather than incremented one turn at a time.
+    fn fold(
+        &mut self,
+        status: &mut MemoryDurabilityStatus,
+        run: PendingRun,
+        warnings: &mut Vec<MemoryDurabilityWarning>,
+    ) {
+        debug_assert_eq!(run.start(), self.next_sequence);
+        let end = run.end();
+        match run {
+            PendingRun::Durable { .. } => status.consecutive_failed_turns = 0,
+            PendingRun::Degraded {
+                start,
+                end,
+                category,
+                latest_at,
+            } => {
+                let previous = status.consecutive_failed_turns;
+                let run_len =
+                    u32::try_from(end.saturating_sub(start).saturating_add(1)).unwrap_or(u32::MAX);
+                let next = previous.saturating_add(run_len);
+                for threshold in [1, 3] {
+                    if previous < threshold && threshold <= next {
+                        warnings.push(MemoryDurabilityWarning {
+                            category,
+                            consecutive: threshold,
+                        });
+                    }
+                }
+                status.consecutive_failed_turns = next;
+                status.latest_failure_category = Some(category);
+                status.latest_failure_at = Some(latest_at);
+            }
+        }
+        self.next_sequence = end.saturating_add(1);
+    }
+}
+
+fn outcome_sequence(outcome: &MemoryTurnOutcome) -> u64 {
+    match outcome {
+        MemoryTurnOutcome::Durable { sequence } | MemoryTurnOutcome::Degraded { sequence, .. } => {
+            *sequence
+        }
+    }
+}
+
+impl From<MemoryTurnOutcome> for PendingRun {
+    fn from(outcome: MemoryTurnOutcome) -> Self {
+        match outcome {
+            MemoryTurnOutcome::Durable { sequence } => Self::Durable {
+                start: sequence,
+                end: sequence,
+            },
+            MemoryTurnOutcome::Degraded {
+                sequence,
+                category,
+                at,
+            } => Self::Degraded {
+                start: sequence,
+                end: sequence,
+                category,
+                latest_at: at,
+            },
+        }
+    }
+}

--- a/crates/trusty-code/src/session/memory_sink.rs
+++ b/crates/trusty-code/src/session/memory_sink.rs
@@ -61,7 +61,11 @@
 //! Test: `memory_sink::tests::*`.
 
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -76,6 +80,81 @@ use crate::memory_envelope::call_tool_wrapped;
 /// policy below kicks in.
 /// Test: `memory_sink::tests::enqueue_drops_newest_when_queue_full`.
 pub const QUEUE_CAPACITY: usize = 50;
+
+/// Which half of the dual-write degraded, as the retained per-session status
+/// reports it (#2425).
+///
+/// Why: "the durable history is thinning" is not actionable on its own — an
+/// operator needs to know whether the daemon is unreachable, the palace is
+/// missing, a content gate rejected the write, or the local queue overflowed,
+/// because those have different remedies. This is a CLOSED vocabulary rather
+/// than the underlying error string precisely so it can be retained and
+/// reported without carrying daemon-controlled text into the operator surface.
+/// What: one variant per failure site in [`drain`]/[`write_turn`]/
+/// [`TurnMemorySink::enqueue`]. Serialises `snake_case`.
+/// Test: `memory_sink::tests::queue_full_and_closed_drain_are_immediate_failures`,
+/// `registry_tests::memory_degradation_event_is_redacted`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryFailureCategory {
+    /// The target palace could not be probed or created (#2424).
+    PalaceEnsure,
+    /// `chat_turn_append` returned an RPC error.
+    ChatTurnAppend,
+    /// `memory_remember` returned an RPC error.
+    MemoryRemember,
+    /// `memory_remember` returned `status=skipped` despite `force: true` (#2363).
+    MemoryRememberSkipped,
+    /// The bounded queue was full, so the newest turn was dropped.
+    QueueFull,
+    /// The drain task was gone, so the turn was dropped.
+    DrainClosed,
+}
+
+/// The durability verdict for exactly one queued turn (#2425).
+///
+/// Why: durability is defined over QUEUED-TURN order, but outcomes do not
+/// arrive in that order — a queue-full failure is reported synchronously by
+/// [`TurnMemorySink::enqueue`] while accepted turns finish later in the
+/// detached drain. `sequence` is what lets the consumer put them back in
+/// logical order (see `memory_outcome_reconciler`).
+/// What: `sequence` is assigned by `enqueue` from a monotonic per-sink
+/// counter, so it is dense and gap-free across both reporting paths.
+/// Test: `memory_sink::tests::queue_full_and_closed_drain_are_immediate_failures`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MemoryTurnOutcome {
+    Durable {
+        sequence: u64,
+    },
+    Degraded {
+        sequence: u64,
+        category: MemoryFailureCategory,
+        at: DateTime<Utc>,
+    },
+}
+
+/// Sink-side hook that reports each turn's durability verdict (#2425).
+///
+/// Why: the sink must stay a leaf — it knows nothing about sessions or the
+/// registry — but the retained status has to live on the session. An observer
+/// inverts that dependency so `registry_memory_sink` installs the coupling and
+/// the sink keeps its existing shape.
+/// What: called once per queued turn, on whichever thread produced the verdict
+/// (the caller's for a synchronous `enqueue` failure, the drain task's
+/// otherwise). Implementations MUST NOT block or panic — see
+/// `RegistryMemoryDurabilityObserver` for the fail-open contract.
+/// Test: `memory_sink::tests::queue_full_and_closed_drain_are_immediate_failures`,
+/// `memory_sink::tests::dropping_sink_releases_detached_drain_observer`.
+pub(crate) trait MemoryDurabilityObserver: Send + Sync {
+    fn observe(&self, outcome: MemoryTurnOutcome);
+}
+
+/// The observer a sink built without one gets — the pre-#2425 behaviour.
+struct NoopMemoryDurabilityObserver;
+
+impl MemoryDurabilityObserver for NoopMemoryDurabilityObserver {
+    fn observe(&self, _outcome: MemoryTurnOutcome) {}
+}
 
 /// Whether a sink is entitled to bring its target palace into EXISTENCE
 /// (#4638).
@@ -108,6 +187,8 @@ pub enum PalaceCreation {
 /// One user-prompt/assistant-response turn queued for durable dual-write.
 #[derive(Debug, Clone)]
 struct QueuedTurn {
+    /// (#2425) Dense, monotonic position in this sink's queued-turn order.
+    sequence: u64,
     session_id: String,
     prompt: String,
     response: String,
@@ -132,6 +213,10 @@ pub struct TurnMemorySink {
     palace: String,
     /// Whether this sink may bring `palace` into existence (#4638).
     creation: PalaceCreation,
+    /// (#2425) Where each turn's durability verdict is reported.
+    observer: Arc<dyn MemoryDurabilityObserver>,
+    /// (#2425) Assigns each enqueued turn its `QueuedTurn::sequence`.
+    next_sequence: AtomicU64,
 }
 
 impl TurnMemorySink {
@@ -141,6 +226,18 @@ impl TurnMemorySink {
     /// Test: `memory_sink::tests::enqueue_drain_happy_path`.
     pub fn new(base_url: String, palace: String, creation: PalaceCreation) -> Self {
         Self::with_capacity(base_url, palace, QUEUE_CAPACITY, creation)
+    }
+
+    /// Same as [`Self::new`], reporting each turn's durability verdict to
+    /// `observer` (#2425).
+    /// Test: `registry_tests::memory_durability_retains_counts_resets_streak_and_warns_at_one_and_three`.
+    pub(crate) fn new_observed(
+        base_url: String,
+        palace: String,
+        creation: PalaceCreation,
+        observer: Arc<dyn MemoryDurabilityObserver>,
+    ) -> Self {
+        Self::with_capacity_observed(base_url, palace, QUEUE_CAPACITY, creation, observer)
     }
 
     /// Same as [`Self::new`] with an explicit queue capacity — tests use a
@@ -165,13 +262,46 @@ impl TurnMemorySink {
         capacity: usize,
         creation: PalaceCreation,
     ) -> Self {
+        Self::with_capacity_observed(
+            base_url,
+            palace,
+            capacity,
+            creation,
+            Arc::new(NoopMemoryDurabilityObserver),
+        )
+    }
+
+    /// Same as [`Self::with_capacity`], reporting each turn's durability
+    /// verdict to `observer` (#2425).
+    ///
+    /// Why: the drain task needs its own handle on the observer because it
+    /// outlives no-one but the sink — the sink holds the sender half, so the
+    /// task ends (and releases its `Arc`) when the sink drops.
+    /// What: clones the `Arc` into the spawned [`drain`] and keeps one on the
+    /// sink for [`Self::enqueue`]'s synchronous failure paths.
+    /// Test: `memory_sink::tests::dropping_sink_releases_detached_drain_observer`.
+    pub(crate) fn with_capacity_observed(
+        base_url: String,
+        palace: String,
+        capacity: usize,
+        creation: PalaceCreation,
+        observer: Arc<dyn MemoryDurabilityObserver>,
+    ) -> Self {
         let (tx, rx) = mpsc::channel(capacity);
-        tokio::spawn(drain(base_url.clone(), palace.clone(), creation, rx));
+        tokio::spawn(drain(
+            base_url.clone(),
+            palace.clone(),
+            creation,
+            rx,
+            Arc::clone(&observer),
+        ));
         Self {
             tx,
             base_url,
             palace,
             creation,
+            observer,
+            next_sequence: AtomicU64::new(1),
         }
     }
 
@@ -230,7 +360,11 @@ impl TurnMemorySink {
         prompt: impl Into<String>,
         response: impl Into<String>,
     ) {
+        // #2425: the sequence is assigned here, on the ONE path every turn
+        // takes, so the two reporting paths below share one dense ordering.
+        let sequence = self.next_sequence.fetch_add(1, Ordering::Relaxed);
         let turn = QueuedTurn {
+            sequence,
             session_id: session_id.into(),
             prompt: prompt.into(),
             response: response.into(),
@@ -238,10 +372,30 @@ impl TurnMemorySink {
         match self.tx.try_send(turn) {
             Ok(()) => {}
             Err(mpsc::error::TrySendError::Full(_)) => {
-                warn!("turn_recorder: queue full (capacity reached) — dropping newest turn");
+                warn!(
+                    failure_category = "queue_full",
+                    tool = "turn_recorder",
+                    status = "dropped",
+                    "turn_recorder: queue full (capacity reached) — dropping newest turn"
+                );
+                self.observer.observe(MemoryTurnOutcome::Degraded {
+                    sequence,
+                    category: MemoryFailureCategory::QueueFull,
+                    at: Utc::now(),
+                });
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
-                warn!("turn_recorder: drain task gone — dropping turn");
+                warn!(
+                    failure_category = "drain_closed",
+                    tool = "turn_recorder",
+                    status = "dropped",
+                    "turn_recorder: drain task gone — dropping turn"
+                );
+                self.observer.observe(MemoryTurnOutcome::Degraded {
+                    sequence,
+                    category: MemoryFailureCategory::DrainClosed,
+                    at: Utc::now(),
+                });
             }
         }
     }
@@ -280,6 +434,7 @@ async fn drain(
     palace: String,
     creation: PalaceCreation,
     mut rx: mpsc::Receiver<QueuedTurn>,
+    observer: Arc<dyn MemoryDurabilityObserver>,
 ) {
     let mut palace_ensured = false;
     while let Some(turn) = rx.recv().await {
@@ -295,9 +450,14 @@ async fn drain(
                 "turn_recorder: dropping turn — palace absent and auto-create \
                  withheld for an ephemeral project root (#4638)"
             );
+            observer.observe(MemoryTurnOutcome::Degraded {
+                sequence: turn.sequence,
+                category: MemoryFailureCategory::PalaceEnsure,
+                at: Utc::now(),
+            });
             continue;
         }
-        write_turn(&base_url, &palace, &turn).await;
+        observer.observe(write_turn(&base_url, &palace, &turn).await);
     }
 }
 
@@ -349,10 +509,15 @@ async fn ensure_palace(base_url: &str, palace: &str, creation: PalaceCreation) -
             info!(palace = %palace, "turn_recorder: created missing palace (#2424)");
             true
         }
-        Err(e) => {
+        // #2425: the daemon's error text is server-controlled and can be
+        // arbitrarily long or carry a credential-shaped preview of the
+        // rejected content, so the default warning names the failure
+        // CATEGORY instead. See `write_turn` for the same treatment.
+        Err(_error) => {
             warn!(
-                palace = %palace,
-                error = %e,
+                failure_category = "palace_ensure",
+                tool = "palace_create",
+                status = "rpc_error",
                 "turn_recorder: palace ensure failed (fail-open, will retry next turn)"
             );
             false
@@ -391,21 +556,34 @@ async fn ensure_palace(base_url: &str, palace: &str, creation: PalaceCreation) -
 /// `tracing::warn!` and swallowed, matching
 /// `resolve_memory_base_url_or_unreachable`'s fail-open contract (mirrored
 /// here, not reused directly, since `base_url` is already resolved by the
-/// caller of [`TurnMemorySink::new`]).
+/// caller of [`TurnMemorySink::new`]). (#2425) It RETURNS the turn's verdict
+/// rather than propagating anything: `Degraded` with the first failed half's
+/// category if either call failed, `Durable` otherwise. The default warnings
+/// name that category and DELIBERATELY omit the daemon's own error text and
+/// `reason` string, both of which are server-controlled and can quote rejected
+/// content back — including the credential preview #2520's secret gate refused
+/// to store. The daemon's own logs keep that text; this warning does not.
 /// Test: `memory_sink::tests::enqueue_drain_happy_path`,
 /// `memory_sink::tests::write_turn_is_fail_open_on_unreachable_daemon`,
-/// `memory_sink::tests::write_turn_warns_on_skipped_status`.
-async fn write_turn(base_url: &str, palace: &str, turn: &QueuedTurn) {
+/// `memory_sink::tests::write_turn_warns_on_skipped_status`,
+/// `memory_sink::tests::partial_dual_write_counts_once_as_failed_turn`,
+/// `memory_sink::tests::default_memory_warnings_redact_server_payloads_in_subprocess`.
+async fn write_turn(base_url: &str, palace: &str, turn: &QueuedTurn) -> MemoryTurnOutcome {
+    // #2425: the FIRST failure wins the reported category — a turn that lost
+    // both halves is still exactly one degraded turn, not two.
+    let mut failure = None;
     let append_params = json!({
         "palace": palace,
         "session_id": turn.session_id,
         "prompt": turn.prompt,
         "response": turn.response,
     });
-    if let Err(e) = call_tool_wrapped(base_url, "chat_turn_append", append_params).await {
+    if let Err(_error) = call_tool_wrapped(base_url, "chat_turn_append", append_params).await {
+        failure = Some(MemoryFailureCategory::ChatTurnAppend);
         warn!(
-            session_id = %turn.session_id,
-            error = %e,
+            failure_category = "chat_turn_append",
+            tool = "chat_turn_append",
+            status = "rpc_error",
             "turn_recorder: chat_turn_append failed (fail-open)"
         );
     }
@@ -419,25 +597,39 @@ async fn write_turn(base_url: &str, palace: &str, turn: &QueuedTurn) {
     match call_tool_wrapped(base_url, "memory_remember", remember_params).await {
         Ok(result) => {
             if result.get("status").and_then(|v| v.as_str()) == Some("skipped") {
-                let reason = result
-                    .get("reason")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown");
+                // #2425: `reason` is server-controlled and quotes the rejected
+                // content back — for the secret-detection gate (#2520) that is
+                // a preview of the very credential the gate refused to store.
+                failure.get_or_insert(MemoryFailureCategory::MemoryRememberSkipped);
                 warn!(
-                    session_id = %turn.session_id,
-                    reason = %reason,
+                    failure_category = "memory_remember_skipped",
+                    tool = "memory_remember",
+                    status = "skipped",
                     "turn_recorder: memory_remember returned status=skipped despite force=true \
                      (#2363) — session recall surface may be thinning"
                 );
             }
         }
-        Err(e) => {
+        Err(_error) => {
+            failure.get_or_insert(MemoryFailureCategory::MemoryRemember);
             warn!(
-                session_id = %turn.session_id,
-                error = %e,
+                failure_category = "memory_remember",
+                tool = "memory_remember",
+                status = "rpc_error",
                 "turn_recorder: memory_remember failed (fail-open)"
             );
         }
+    }
+
+    match failure {
+        Some(category) => MemoryTurnOutcome::Degraded {
+            sequence: turn.sequence,
+            category,
+            at: Utc::now(),
+        },
+        None => MemoryTurnOutcome::Durable {
+            sequence: turn.sequence,
+        },
     }
 }
 

--- a/crates/trusty-code/src/session/memory_sink_tests.rs
+++ b/crates/trusty-code/src/session/memory_sink_tests.rs
@@ -23,6 +23,7 @@
 //! chain.
 //! Test: this file.
 
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -38,6 +39,122 @@ use super::*;
 
 /// One captured `/rpc` call: the JSON-RPC `method` and its `params`.
 type Captured = Arc<Mutex<Vec<(String, Value)>>>;
+
+/// An observer that keeps every outcome it is handed, in arrival order.
+#[derive(Default)]
+struct RecordingObserver(Mutex<Vec<MemoryTurnOutcome>>);
+
+impl MemoryDurabilityObserver for RecordingObserver {
+    fn observe(&self, outcome: MemoryTurnOutcome) {
+        self.0
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(outcome);
+    }
+}
+
+const REDACTION_CHILD_ENV: &str = "TCODE_MEMORY_WARNING_REDACTION_CHILD";
+const REDACTION_CHILD_TEST_PATH: &str =
+    "session::memory_sink::tests::memory_warning_redaction_child";
+/// Server-controlled markers the daemon mock plants in its error and `reason`
+/// text. A default warning must carry none of them.
+const CREDENTIAL_SENTINEL: &str = "sk-live-memory-credential-do-not-leak";
+const REASON_SENTINEL: &str = "Bearer credential-preview-do-not-leak";
+const OVERSIZED_SENTINEL: &str = "OVERSIZED_MEMORY_ERROR_DO_NOT_LEAK";
+
+/// Drive one dual-write against a daemon that plants credential-shaped text in
+/// both its error message and its `reason` field.
+///
+/// Runs only under the parent below — a bare `cargo test` sees it return
+/// immediately.
+#[tokio::test]
+async fn memory_warning_redaction_child() {
+    if std::env::var_os(REDACTION_CHILD_ENV).is_none() {
+        return;
+    }
+
+    async fn handle(Json(body): Json<Value>) -> Json<Value> {
+        let tool = body["params"]["name"].as_str().unwrap_or_default();
+        let response = match tool {
+            "chat_turn_append" => json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {
+                    "code": -32603,
+                    "message": format!(
+                        "{CREDENTIAL_SENTINEL} {}",
+                        OVERSIZED_SENTINEL.repeat(512)
+                    )
+                }
+            }),
+            "memory_remember" => json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": wrapped_result(&json!({
+                    "status": "skipped",
+                    "reason": REASON_SENTINEL
+                }))
+            }),
+            _ => json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": wrapped_result(&json!({"ok": true}))
+            }),
+        };
+        Json(response)
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
+    let addr = listener.local_addr().expect("mock address");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, Router::new().route("/rpc", post(handle))).await;
+    });
+
+    crate::logging::init_tracing_for_test();
+    let outcome = write_turn(
+        &format!("http://{addr}"),
+        "test-palace",
+        &QueuedTurn {
+            sequence: 1,
+            session_id: "session-redaction".into(),
+            prompt: "prompt".into(),
+            response: "response".into(),
+        },
+    )
+    .await;
+    assert!(matches!(outcome, MemoryTurnOutcome::Degraded { .. }));
+}
+
+/// #2425: the default turn-recorder warnings must name the failure category and
+/// carry NO daemon-controlled payload.
+///
+/// A subprocess because the assertion is about what reaches stderr, and this
+/// binary's tracing subscriber is process-global.
+#[test]
+fn default_memory_warnings_redact_server_payloads_in_subprocess() {
+    let output = Command::new(std::env::current_exe().expect("current test binary"))
+        .args([
+            "--exact",
+            REDACTION_CHILD_TEST_PATH,
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env(REDACTION_CHILD_ENV, "1")
+        .env("RUST_LOG", "warn")
+        .output()
+        .expect("run memory warning redaction child");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "child failed: {stderr}");
+    for secret in [CREDENTIAL_SENTINEL, REASON_SENTINEL, OVERSIZED_SENTINEL] {
+        assert!(
+            !stderr.contains(secret),
+            "default warning leaked server-controlled payload marker {secret}: {stderr}"
+        );
+    }
+    assert!(stderr.contains("failure_category"), "{stderr}");
+    assert!(stderr.contains("chat_turn_append"), "{stderr}");
+    assert!(stderr.contains("memory_remember_skipped"), "{stderr}");
+}
 
 /// Wrap `inner` as the real daemon's `tools/call` response envelope: the
 /// tool result STRINGIFIED inside `content[0].text` (mirrors the
@@ -353,6 +470,8 @@ async fn forbidden_creation_still_writes_to_an_existing_palace() {
 /// subscriber in a real deployment, not asserted on here (no test-local
 /// tracing capture exists in this crate yet), so this test's assertion is:
 /// the drain task tolerates a skipped envelope exactly like a stored one.
+/// (#2425) It also pins that a skipped envelope reports `Degraded`, not
+/// `Durable` — a thinned recall surface is a degraded turn.
 #[tokio::test]
 async fn write_turn_warns_on_skipped_status() {
     async fn handle_skipped(Json(body): Json<Value>) -> Json<Value> {
@@ -371,15 +490,71 @@ async fn write_turn_warns_on_skipped_status() {
         let _ = axum::serve(listener, app).await;
     });
 
-    let sink = TurnMemorySink::new(
+    let observer = Arc::new(RecordingObserver::default());
+    let sink = TurnMemorySink::new_observed(
         format!("http://{addr}"),
         "test-palace".to_string(),
         PalaceCreation::Allowed,
+        observer.clone(),
     );
     sink.enqueue("sess-skip", "prompt", "response");
     // The assertion is simply that this never panics/hangs; give the drain
     // task a moment to run.
     tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(matches!(
+        observer
+            .0
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_slice(),
+        [MemoryTurnOutcome::Degraded {
+            category: MemoryFailureCategory::MemoryRememberSkipped,
+            ..
+        }]
+    ));
+}
+
+/// (#2425) A turn that lost ONE half of the dual-write is exactly one degraded
+/// turn, reported under the half that failed first — not two, and not durable.
+#[tokio::test]
+async fn partial_dual_write_counts_once_as_failed_turn() {
+    async fn handle_partial(Json(body): Json<Value>) -> Json<Value> {
+        if body["params"]["name"].as_str() == Some("chat_turn_append") {
+            return Json(json!({
+                "jsonrpc": "2.0", "id": 1,
+                "error": {"code": -32603, "message": "sensitive raw response"}
+            }));
+        }
+        Json(json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": wrapped_result(&json!({"ok": true}))
+        }))
+    }
+    let app = Router::new().route("/rpc", post(handle_partial));
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let outcome = write_turn(
+        &format!("http://{addr}"),
+        "test-palace",
+        &QueuedTurn {
+            sequence: 1,
+            session_id: "s".into(),
+            prompt: "credential-shaped prompt".into(),
+            response: "secret response".into(),
+        },
+    )
+    .await;
+    assert!(matches!(
+        outcome,
+        MemoryTurnOutcome::Degraded {
+            category: MemoryFailureCategory::ChatTurnAppend,
+            ..
+        }
+    ));
 }
 
 /// [`TurnMemorySink::base_url`]/[`TurnMemorySink::palace`] must expose
@@ -393,6 +568,8 @@ fn base_url_and_palace_expose_construction_args() {
         base_url: "http://example.test:1234".to_string(),
         palace: "a-palace".to_string(),
         creation: PalaceCreation::Allowed,
+        observer: Arc::new(NoopMemoryDurabilityObserver),
+        next_sequence: AtomicU64::new(1),
     };
     assert_eq!(sink.base_url(), "http://example.test:1234");
     assert_eq!(sink.palace(), "a-palace");
@@ -429,6 +606,8 @@ fn enqueue_drops_newest_when_queue_full() {
         base_url: String::new(),
         palace: String::new(),
         creation: PalaceCreation::Allowed,
+        observer: Arc::new(NoopMemoryDurabilityObserver),
+        next_sequence: AtomicU64::new(1),
     };
 
     sink.enqueue("s1", "p1", "r1");
@@ -440,6 +619,74 @@ fn enqueue_drops_newest_when_queue_full() {
         rx.try_recv().is_err(),
         "second turn must have been dropped, not queued"
     );
+}
+
+/// (#2425) Both of `enqueue`'s synchronous drop paths report a degraded turn,
+/// so a turn the drain never sees still reaches the session's status.
+#[test]
+fn queue_full_and_closed_drain_are_immediate_failures() {
+    let observer = Arc::new(RecordingObserver::default());
+    let (tx, mut rx) = mpsc::channel(1);
+    let sink = TurnMemorySink {
+        tx,
+        base_url: String::new(),
+        palace: String::new(),
+        creation: PalaceCreation::Allowed,
+        observer: observer.clone(),
+        next_sequence: AtomicU64::new(1),
+    };
+    sink.enqueue("s", "p1", "r1");
+    sink.enqueue("s", "p2", "r2"); // queue full
+    let _ = rx.try_recv();
+    drop(rx); // drain gone
+    sink.enqueue("s", "p3", "r3");
+
+    let outcomes = observer.0.lock().unwrap_or_else(|e| e.into_inner());
+    assert!(matches!(
+        outcomes.as_slice(),
+        [
+            MemoryTurnOutcome::Degraded {
+                sequence: 2,
+                category: MemoryFailureCategory::QueueFull,
+                ..
+            },
+            MemoryTurnOutcome::Degraded {
+                sequence: 3,
+                category: MemoryFailureCategory::DrainClosed,
+                ..
+            }
+        ]
+    ));
+}
+
+/// (#2425) The detached drain must release its observer when the sink drops —
+/// otherwise a registry-backed observer would outlive every session.
+#[tokio::test]
+async fn dropping_sink_releases_detached_drain_observer() {
+    let observer: Arc<dyn MemoryDurabilityObserver> = Arc::new(RecordingObserver::default());
+    let observer_weak = Arc::downgrade(&observer);
+    let sink = TurnMemorySink::with_capacity_observed(
+        "http://127.0.0.1:1".into(),
+        "p".into(),
+        1,
+        PalaceCreation::Allowed,
+        Arc::clone(&observer),
+    );
+    drop(observer);
+    assert!(
+        observer_weak.upgrade().is_some(),
+        "sink/drain must own the observer while the sink is live"
+    );
+
+    drop(sink);
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while observer_weak.upgrade().is_some() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("detached drain did not release its observer after sender closure");
+    assert!(observer_weak.upgrade().is_none());
 }
 
 /// No git remote, no override -> falls back to a non-empty, stable slug

--- a/crates/trusty-code/src/session/mod.rs
+++ b/crates/trusty-code/src/session/mod.rs
@@ -33,6 +33,10 @@
 //! [`protocol::register`]: crate::session::protocol::register
 
 pub mod connector;
+/// (#2425) Bounded logical-order fold for durable-memory turn outcomes.
+/// Private: `registry::SessionEntry` owns one per session and is the only
+/// thing that drives it.
+mod memory_outcome_reconciler;
 pub mod memory_sink;
 pub mod model;
 pub mod protocol;
@@ -40,7 +44,7 @@ pub mod registry;
 pub mod transcript;
 
 pub use connector::TcodeConnector;
-pub use memory_sink::{PalaceCreation, TurnMemorySink};
+pub use memory_sink::{MemoryFailureCategory, PalaceCreation, TurnMemorySink};
 pub use model::{Session, SessionStatus};
 pub use registry::SessionRegistry;
-pub use transcript::{GoalSlotRecord, TranscriptRecord};
+pub use transcript::{GoalSlotRecord, MemoryDurabilityStatus, TranscriptRecord};

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -49,7 +49,7 @@ use crate::perf::TokenUsage;
 use crate::run_task::TurnRecord;
 
 use super::model::{Session, SessionStatus};
-use super::transcript::TranscriptRecord;
+use super::transcript::MemoryDurabilityStatus;
 
 /// Default ring-buffer capacity per session (vision spec §12, 11.5).
 ///
@@ -108,6 +108,12 @@ struct SessionEntry {
     /// reused for the life of the session (see `memory_sink` module docs for
     /// why its background drain task must outlive any single run).
     memory_sink: Option<Arc<super::memory_sink::TurnMemorySink>>,
+    /// (#2425) Retained durable-memory degradation status, as
+    /// `session.get_transcript` reports it.
+    memory_durability: MemoryDurabilityStatus,
+    /// (#2425) Bounded logical-order projection folding the sink's detached and
+    /// synchronous outcomes into `memory_durability`.
+    memory_outcomes: super::memory_outcome_reconciler::MemoryOutcomeReconciler,
     /// (DOC-39 §5.6 Slice D) The most recently recorded `IndexReadiness`
     /// probe for this session — last-writer-wins, overwritten by every new
     /// `record_index_readiness` call. `None` until the session's first probe
@@ -332,6 +338,8 @@ impl SessionRegistry {
                     cost_usd: None,
                     pm_transcript: None,
                     memory_sink: None,
+                    memory_durability: MemoryDurabilityStatus::default(),
+                    memory_outcomes: Default::default(),
                     readiness: None,
                     context_budget: None,
                     agents: Vec::new(),
@@ -855,47 +863,6 @@ impl SessionRegistry {
         }
     }
 
-    /// `session.get_transcript`: fetch the stored run record for a session
-    /// (#2058).
-    ///
-    /// Why: [`Self::set_run_outcome`] populates the storage; this is its read
-    /// counterpart — the M1 cut-line's "inspect transcript" verb. A never-run
-    /// session is a valid, empty transcript, not an error: `SessionEntry`'s
-    /// `transcript`/`usage`/`cost_usd` fields already default to
-    /// empty/zero/`None` at `create` time, so returning them unconditionally
-    /// (once the session itself is confirmed to exist) is correct with no
-    /// extra branching.
-    /// What: `Err(session_not_found)` if `id` is unknown; otherwise a clone of
-    /// whatever is currently stored, wrapped in a self-describing
-    /// [`TranscriptRecord`]. Never recomputes cost or usage — exposes exactly
-    /// what [`Self::set_run_outcome`] last stored. `compaction_events` (#2349)
-    /// reads `entry.pm_transcript`'s own cumulative counter — `0` when the
-    /// session has never run (`pm_transcript` still `None`).
-    /// Test: `registry_tests::get_transcript_returns_stored_record`,
-    /// `registry_tests::get_transcript_on_never_run_session_is_empty`,
-    /// `registry_tests::get_transcript_unknown_session_errors`,
-    /// `registry_tests::get_transcript_reports_compaction_events`,
-    /// `registry_tests::get_transcript_round_trips_goal_state`.
-    pub fn get_transcript(&self, id: &str) -> Result<TranscriptRecord, RpcError> {
-        let sessions = self.lock();
-        let entry = sessions
-            .get(id)
-            .ok_or_else(|| RpcError::session_not_found(id))?;
-        Ok(TranscriptRecord {
-            session_id: id.to_string(),
-            turns: entry.transcript.clone(),
-            usage: entry.usage,
-            cost_usd: entry.cost_usd,
-            mode: entry.session.mode,
-            compaction_events: entry
-                .pm_transcript
-                .as_ref()
-                .map(Transcript::compaction_events)
-                .unwrap_or(0),
-            goals: goal_ops::goal_records(entry),
-        })
-    }
-
     /// `task.run`: persist the resolved `HarnessMode` onto the session
     /// (#2059).
     ///
@@ -1083,6 +1050,11 @@ mod events;
 /// the same 500-SLOC-cap reason as `events` above.
 #[path = "registry_memory_sink.rs"]
 mod memory_sink_ext;
+
+/// #2058's `session.get_transcript` projection, split out into its own file
+/// for the same 500-SLOC-cap reason as `events` above.
+#[path = "registry_transcript.rs"]
+mod transcript_ops;
 
 /// #2350 operator-facing goal-slot plumbing (`session.set_goal`/
 /// `clear_goal`/`get_goals`), split out into its own file for the same

--- a/crates/trusty-code/src/session/registry_memory_sink.rs
+++ b/crates/trusty-code/src/session/registry_memory_sink.rs
@@ -20,10 +20,14 @@
 //! `registry_tests::memory_sink_for_many_sessions_mint_at_most_one_palace`.
 
 use std::path::Path;
+use std::sync::Weak;
 
 use tracing::{debug, warn};
 
-use crate::session::memory_sink::{PalaceCreation, TurnMemorySink, derive_palace_id_for_project};
+use crate::session::memory_sink::{
+    MemoryDurabilityObserver, MemoryTurnOutcome, PalaceCreation, TurnMemorySink,
+    derive_palace_id_for_project,
+};
 
 use super::*;
 
@@ -112,8 +116,16 @@ impl SessionRegistry {
     /// `registry_tests::memory_sink_for_projectless_session_returns_none`,
     /// `registry_tests::memory_sink_for_temp_rooted_session_forbids_palace_create`,
     /// `registry_tests::memory_sink_for_many_sessions_mint_at_most_one_palace`.
+    ///
+    /// (#2425) The receiver is `&Arc<Self>` rather than `&self` because the
+    /// sink is handed a durability observer holding a `Weak<SessionRegistry>`,
+    /// and a weak reference can only be minted from an `Arc`. `Weak` and not
+    /// `Arc`: the registry owns the sink, which owns the observer, so a strong
+    /// back-reference would be a cycle that never drops. This is a BREAKING
+    /// change to `trusty-code`'s public API — every in-workspace caller already
+    /// holds an `Arc<SessionRegistry>`, so no call site changed.
     pub fn memory_sink_for(
-        &self,
+        self: &Arc<Self>,
         id: &str,
         project_dir: Option<&Path>,
     ) -> Option<Arc<TurnMemorySink>> {
@@ -149,8 +161,239 @@ impl SessionRegistry {
             } else {
                 PalaceCreation::Allowed
             };
-            entry.memory_sink = Some(Arc::new(TurnMemorySink::new(base_url, palace, creation)));
+            // #2425: the sink reports every turn's durability verdict back to
+            // this session's retained status.
+            let observer = Arc::new(RegistryMemoryDurabilityObserver {
+                registry: Arc::downgrade(self),
+                session_id: id.to_string(),
+            });
+            entry.memory_sink = Some(Arc::new(TurnMemorySink::new_observed(
+                base_url, palace, creation, observer,
+            )));
         }
         entry.memory_sink.clone()
+    }
+
+    /// Fold one turn's durability verdict into the session's retained status,
+    /// emitting a session log event at each streak threshold it crosses
+    /// (#2425).
+    ///
+    /// Why: a fail-open sink makes a session whose durable history is thinning
+    /// look identical to a healthy one. Warning at the FIRST and THIRD
+    /// consecutive failure — rather than every failure — is what keeps a
+    /// multi-hour outage from burying the event log while still surfacing the
+    /// problem on the turn it starts.
+    /// What: `Err(session_not_found)` if the session is gone. `Err(internal)`
+    /// when the reconciler refuses the outcome because its pending-run bound is
+    /// exhausted; before returning that, `unrecorded_outcomes` is incremented,
+    /// so `session.get_transcript` still SAYS its counters under-report rather
+    /// than reading as if nothing was lost. Warning messages carry only the
+    /// closed [`crate::session::MemoryFailureCategory`] vocabulary and the two
+    /// counters — never a prompt, response, or daemon error string.
+    /// Test: `registry_tests::memory_durability_retains_counts_resets_streak_and_warns_at_one_and_three`,
+    /// `registry_tests::outcome_beyond_the_reorder_bound_is_counted_as_unrecorded`,
+    /// `registry_tests::memory_degradation_event_is_redacted`.
+    pub(crate) fn record_memory_durability(
+        &self,
+        id: &str,
+        outcome: MemoryTurnOutcome,
+    ) -> Result<(), RpcError> {
+        let warnings = {
+            let mut sessions = self.lock();
+            let entry = sessions
+                .get_mut(id)
+                .ok_or_else(|| RpcError::session_not_found(id))?;
+            match entry
+                .memory_outcomes
+                .observe(&mut entry.memory_durability, outcome)
+            {
+                Ok(warnings) => warnings,
+                Err(()) => {
+                    entry.memory_durability.unrecorded_outcomes = entry
+                        .memory_durability
+                        .unrecorded_outcomes
+                        .saturating_add(1);
+                    return Err(RpcError::internal("memory outcome reorder bound exceeded"));
+                }
+            }
+        };
+        for warning in warnings {
+            let total = self
+                .get_transcript(id)?
+                .memory_durability
+                .total_failed_turns;
+            self.record_log(
+                id,
+                "warn",
+                &format!(
+                    "durable memory degraded: category={:?} total_failed_turns={total} \
+                     consecutive_failed_turns={}",
+                    warning.category, warning.consecutive
+                ),
+            )?;
+        }
+        Ok(())
+    }
+}
+
+/// The [`MemoryDurabilityObserver`] a registry-owned sink is built with.
+///
+/// Why: `Weak` breaks the registry -> sink -> observer -> registry cycle, so a
+/// dropped registry stays dropped.
+/// What: forwards each outcome to [`SessionRegistry::record_memory_durability`]
+/// on the thread that produced it.
+/// Test: `observer_tests::weak_observer_does_not_keep_registry_alive`,
+/// `observer_tests::unrecordable_outcomes_are_reported_in_subprocess`.
+struct RegistryMemoryDurabilityObserver {
+    registry: Weak<SessionRegistry>,
+    session_id: String,
+}
+
+impl MemoryDurabilityObserver for RegistryMemoryDurabilityObserver {
+    /// Report one outcome, failing OPEN on the turn and never SILENT on the
+    /// signal (#2425).
+    ///
+    /// Why: this runs on the turn path (a synchronous queue-full report from
+    /// `enqueue`) as well as in the detached drain, so it must not propagate,
+    /// block, or panic — a failed memory write must not kill the turn. That is
+    /// the execution contract, and it is unchanged. What it does NOT license is
+    /// discarding the error: `record_memory_durability` fails exactly when the
+    /// degradation signal could not be retained, so swallowing it made the
+    /// signal loss itself unobservable — which is the failure #2425 exists to
+    /// prevent. The registry-side counter this pairs with (`unrecorded_outcomes`)
+    /// survives only while the session does; the `warn!` here survives the
+    /// session's removal, which is the `session_not_found` case.
+    /// What: a dead registry means the session and its status died with it, so
+    /// there is nothing left to degrade and nothing to report. Any other error
+    /// is warned about with the RPC code and no session content.
+    /// Test: `observer_tests::weak_observer_does_not_keep_registry_alive`,
+    /// `observer_tests::unrecordable_outcomes_are_reported_in_subprocess`.
+    fn observe(&self, outcome: MemoryTurnOutcome) {
+        let Some(registry) = self.registry.upgrade() else {
+            return;
+        };
+        if let Err(error) = registry.record_memory_durability(&self.session_id, outcome) {
+            warn!(
+                failure_category = "memory_durability_unrecorded",
+                rpc_code = error.code,
+                "turn_recorder: a durable-memory outcome could not be recorded on its \
+                 session — retained degradation counters under-report (#2425)"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod observer_tests {
+    use super::*;
+    use crate::session::memory_sink::MemoryFailureCategory;
+    use chrono::Utc;
+    use std::process::Command;
+
+    const UNRECORDABLE_CHILD_ENV: &str = "TCODE_MEMORY_UNRECORDABLE_OUTCOME_CHILD";
+    const CHILD_TEST_PATH: &str =
+        "session::registry::memory_sink_ext::observer_tests::unrecordable_outcome_child";
+    /// A prompt the child must never leak into a warning on stderr.
+    const PROMPT_SENTINEL: &str = "sk-live-session-prompt-do-not-leak";
+
+    /// The observer must not keep the registry it reports to alive — a strong
+    /// back-reference would be a cycle (registry -> sink -> observer).
+    #[test]
+    fn weak_observer_does_not_keep_registry_alive() {
+        let registry = Arc::new(SessionRegistry::new());
+        let weak = Arc::downgrade(&registry);
+        let observer = RegistryMemoryDurabilityObserver {
+            registry: weak.clone(),
+            session_id: "gone".into(),
+        };
+        drop(registry);
+        assert!(weak.upgrade().is_none());
+        observer.observe(MemoryTurnOutcome::Degraded {
+            sequence: 1,
+            category: MemoryFailureCategory::DrainClosed,
+            at: Utc::now(),
+        });
+    }
+
+    /// Drive both of `record_memory_durability`'s error arms through the
+    /// observer, with the warnings this test's parent reads off stderr.
+    ///
+    /// Runs only under the parent below — a bare `cargo test` sees it return
+    /// immediately.
+    #[test]
+    fn unrecordable_outcome_child() {
+        if std::env::var_os(UNRECORDABLE_CHILD_ENV).is_none() {
+            return;
+        }
+        crate::logging::init_tracing_for_test();
+
+        let registry = Arc::new(SessionRegistry::new());
+        let session = registry.create(
+            PROMPT_SENTINEL.to_string(),
+            None,
+            crate::binding::ProjectBinding::None,
+        );
+
+        // Arm 1: the session is gone. Nothing can retain the signal, so the
+        // warning on stderr is the only surviving record of it.
+        let orphaned = RegistryMemoryDurabilityObserver {
+            registry: Arc::downgrade(&registry),
+            session_id: "no-such-session".into(),
+        };
+        orphaned.observe(MemoryTurnOutcome::Degraded {
+            sequence: 1,
+            category: MemoryFailureCategory::QueueFull,
+            at: Utc::now(),
+        });
+
+        // Arm 2: sequence 1 never arrives, so every later outcome parks as its
+        // own non-adjacent pending run until the bound refuses one.
+        let observer = RegistryMemoryDurabilityObserver {
+            registry: Arc::downgrade(&registry),
+            session_id: session.id.clone(),
+        };
+        for sequence in (2..).step_by(2).take(reorder_bound() + 1) {
+            observer.observe(MemoryTurnOutcome::Degraded {
+                sequence,
+                category: MemoryFailureCategory::QueueFull,
+                at: Utc::now(),
+            });
+        }
+    }
+
+    /// #2425 regression: neither error arm of `record_memory_durability` may be
+    /// swallowed. `observe` cannot propagate (it runs on the turn path), so the
+    /// proof has to be read off the child's stderr.
+    #[test]
+    fn unrecordable_outcomes_are_reported_in_subprocess() {
+        let output = Command::new(std::env::current_exe().expect("current test binary"))
+            .args([
+                "--exact",
+                CHILD_TEST_PATH,
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env(UNRECORDABLE_CHILD_ENV, "1")
+            .env("RUST_LOG", "warn")
+            .output()
+            .expect("run unrecordable outcome child");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "child failed: {stderr}");
+        assert_eq!(
+            stderr.matches("memory_durability_unrecorded").count(),
+            2,
+            "both a session_not_found and a bound-exceeded refusal must be \
+             reported, not swallowed: {stderr}"
+        );
+        assert!(
+            !stderr.contains(PROMPT_SENTINEL),
+            "the warning leaked session content: {stderr}"
+        );
+    }
+
+    /// How many non-adjacent pending runs the reconciler accepts before it
+    /// refuses one — mirrors its own `QUEUE_CAPACITY + 2`.
+    fn reorder_bound() -> usize {
+        crate::session::memory_sink::QUEUE_CAPACITY + 2
     }
 }

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -4,6 +4,7 @@
 //! under the 500-SLOC cap.
 
 use super::*;
+use crate::session::TranscriptRecord;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio::time::{Duration, timeout};
@@ -1060,7 +1061,7 @@ fn durable_project_root() -> &'static std::path::Path {
 /// `task.run`s on one session rather than being rebuilt per run.
 #[tokio::test]
 async fn memory_sink_for_reuses_the_same_sink_across_calls() {
-    let registry = SessionRegistry::new();
+    let registry = Arc::new(SessionRegistry::new());
     let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let first = registry
@@ -1105,7 +1106,7 @@ async fn memory_sink_for_unresolvable_palace_returns_no_sink() {
     )
     .unwrap();
 
-    let registry = SessionRegistry::new();
+    let registry = Arc::new(SessionRegistry::new());
     let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     assert!(
@@ -1121,7 +1122,7 @@ async fn memory_sink_for_unresolvable_palace_returns_no_sink() {
 /// (best-effort, mirrors `set_run_outcome`'s framing).
 #[tokio::test]
 async fn memory_sink_for_unknown_session_returns_none() {
-    let registry = SessionRegistry::new();
+    let registry = Arc::new(SessionRegistry::new());
     assert!(
         registry
             .memory_sink_for("nope", Some(durable_project_root()))
@@ -1146,7 +1147,7 @@ async fn memory_sink_for_unknown_session_returns_none() {
 /// `/private/var/folders/…`, so the guard must recognise both spellings).
 #[tokio::test]
 async fn memory_sink_for_temp_rooted_session_forbids_palace_create() {
-    let registry = SessionRegistry::new();
+    let registry = Arc::new(SessionRegistry::new());
     let project_dir = tempfile::TempDir::new().unwrap();
 
     let raw = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
@@ -1189,7 +1190,7 @@ async fn memory_sink_for_temp_rooted_session_forbids_palace_create() {
 /// palaces-that-could-be-minted, which is the quantity that leaked.
 #[tokio::test]
 async fn memory_sink_for_many_sessions_mint_at_most_one_palace() {
-    let registry = SessionRegistry::new();
+    let registry = Arc::new(SessionRegistry::new());
     let mut creatable: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     let mut temp_rooted = 0usize;
 
@@ -1772,13 +1773,361 @@ async fn create_derives_project_label_from_binding() {
 /// be a clean `None`, not a panic and not a palace derived from a scratch path.
 #[tokio::test]
 async fn memory_sink_for_projectless_session_returns_none() {
-    let registry = SessionRegistry::new();
+    let registry = Arc::new(SessionRegistry::new());
     let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     assert!(
         registry.memory_sink_for(&session.id, None).is_none(),
         "a projectless session must have no project-scoped memory palace"
     );
+}
+
+// ── #2425: durable-memory degradation status ──────────────────────────────────
+
+/// Every warning `record_memory_durability` emitted for `id`, in order.
+fn durability_warnings(registry: &SessionRegistry, id: &str) -> Vec<String> {
+    registry
+        .replay(id)
+        .unwrap()
+        .into_iter()
+        .filter_map(|envelope| match envelope.event {
+            Event::Log { level, message, .. } if level == "warn" => Some(message),
+            _ => None,
+        })
+        .collect()
+}
+
+/// #2425: the lifetime total never resets, the streak does, and only the first
+/// and third consecutive failure warn.
+#[test]
+fn memory_durability_retains_counts_resets_streak_and_warns_at_one_and_three() {
+    use crate::session::memory_sink::{MemoryFailureCategory, MemoryTurnOutcome};
+
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".into(), None, crate::binding::ProjectBinding::None);
+    let mut next_sequence = 1;
+    let mut degraded = |category| {
+        let sequence = next_sequence;
+        next_sequence += 1;
+        MemoryTurnOutcome::Degraded {
+            sequence,
+            category,
+            at: Utc::now(),
+        }
+    };
+
+    for category in [
+        MemoryFailureCategory::ChatTurnAppend,
+        MemoryFailureCategory::MemoryRemember,
+        MemoryFailureCategory::MemoryRememberSkipped,
+        MemoryFailureCategory::QueueFull,
+    ] {
+        registry
+            .record_memory_durability(&session.id, degraded(category))
+            .unwrap();
+    }
+
+    assert_eq!(
+        durability_warnings(&registry, &session.id).len(),
+        2,
+        "warn only at streaks one and three"
+    );
+
+    let status = registry
+        .get_transcript(&session.id)
+        .unwrap()
+        .memory_durability;
+    assert_eq!(status.total_failed_turns, 4);
+    assert_eq!(status.consecutive_failed_turns, 4);
+    assert_eq!(status.unrecorded_outcomes, 0);
+    assert_eq!(
+        status.latest_failure_category,
+        Some(MemoryFailureCategory::QueueFull)
+    );
+    assert!(status.latest_failure_at.is_some());
+
+    registry
+        .record_memory_durability(&session.id, MemoryTurnOutcome::Durable { sequence: 5 })
+        .unwrap();
+    let reset = registry
+        .get_transcript(&session.id)
+        .unwrap()
+        .memory_durability;
+    assert_eq!(reset.total_failed_turns, 4);
+    assert_eq!(reset.consecutive_failed_turns, 0);
+}
+
+/// #2425: a newer enqueue can fail synchronously while the detached drain is
+/// still completing an older accepted turn, so arrival order is the reverse of
+/// logical turn order. The older completion must not clear the newer failure.
+#[test]
+fn older_durable_completion_does_not_clear_newer_queue_failure() {
+    use crate::session::memory_sink::{MemoryFailureCategory, MemoryTurnOutcome};
+
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".into(), None, crate::binding::ProjectBinding::None);
+
+    registry
+        .record_memory_durability(
+            &session.id,
+            MemoryTurnOutcome::Degraded {
+                sequence: 2,
+                category: MemoryFailureCategory::QueueFull,
+                at: Utc::now(),
+            },
+        )
+        .unwrap();
+    registry
+        .record_memory_durability(&session.id, MemoryTurnOutcome::Durable { sequence: 1 })
+        .unwrap();
+
+    let status = registry
+        .get_transcript(&session.id)
+        .unwrap()
+        .memory_durability;
+    assert_eq!(status.total_failed_turns, 1);
+    assert_eq!(
+        status.consecutive_failed_turns, 1,
+        "an older durable completion must not erase a newer dropped turn"
+    );
+    assert_eq!(
+        status.latest_failure_category,
+        Some(MemoryFailureCategory::QueueFull)
+    );
+}
+
+/// #2425: two degradations arriving reversed still fold in logical order, so
+/// `latest_failure_*` describe turn 2, not the one that arrived last.
+#[test]
+fn two_out_of_order_degradations_fold_in_logical_sequence() {
+    use crate::session::memory_sink::{MemoryFailureCategory, MemoryTurnOutcome};
+
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".into(), None, crate::binding::ProjectBinding::None);
+    let first_at = Utc::now();
+    let second_at = first_at + chrono::Duration::seconds(1);
+
+    for outcome in [
+        MemoryTurnOutcome::Degraded {
+            sequence: 2,
+            category: MemoryFailureCategory::QueueFull,
+            at: second_at,
+        },
+        MemoryTurnOutcome::Degraded {
+            sequence: 1,
+            category: MemoryFailureCategory::ChatTurnAppend,
+            at: first_at,
+        },
+    ] {
+        registry
+            .record_memory_durability(&session.id, outcome)
+            .unwrap();
+    }
+
+    let status = registry
+        .get_transcript(&session.id)
+        .unwrap()
+        .memory_durability;
+    assert_eq!(status.total_failed_turns, 2);
+    assert_eq!(status.consecutive_failed_turns, 2);
+    assert_eq!(
+        status.latest_failure_category,
+        Some(MemoryFailureCategory::QueueFull)
+    );
+    assert_eq!(status.latest_failure_at, Some(second_at));
+}
+
+/// #2425: a run that jumps the streak from 0 to 3 in one fold must emit BOTH
+/// thresholds — a warning cannot be skipped just because it was crossed by a
+/// backlog rather than one turn at a time.
+#[test]
+fn three_out_of_order_degradations_emit_every_crossed_warning_threshold() {
+    use crate::session::memory_sink::{MemoryFailureCategory, MemoryTurnOutcome};
+
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".into(), None, crate::binding::ProjectBinding::None);
+    let now = Utc::now();
+
+    for (sequence, category) in [
+        (2, MemoryFailureCategory::QueueFull),
+        (3, MemoryFailureCategory::QueueFull),
+        (1, MemoryFailureCategory::ChatTurnAppend),
+    ] {
+        registry
+            .record_memory_durability(
+                &session.id,
+                MemoryTurnOutcome::Degraded {
+                    sequence,
+                    category,
+                    at: now + chrono::Duration::seconds(sequence as i64),
+                },
+            )
+            .unwrap();
+    }
+
+    let status = registry
+        .get_transcript(&session.id)
+        .unwrap()
+        .memory_durability;
+    assert_eq!(status.total_failed_turns, 3);
+    assert_eq!(status.consecutive_failed_turns, 3);
+    assert_eq!(
+        status.latest_failure_category,
+        Some(MemoryFailureCategory::QueueFull)
+    );
+
+    let warnings = durability_warnings(&registry, &session.id);
+    assert_eq!(
+        warnings.len(),
+        2,
+        "streak thresholds one and three both warn"
+    );
+    assert!(warnings[0].contains("category=ChatTurnAppend"));
+    assert!(warnings[0].contains("consecutive_failed_turns=1"));
+    assert!(warnings[1].contains("category=QueueFull"));
+    assert!(warnings[1].contains("consecutive_failed_turns=3"));
+}
+
+/// #2425: logical order is degraded(1), durable(2), degraded(3), but the
+/// synchronous queue failure for turn 3 overtakes both older drain completions.
+/// Older outcomes still count toward the lifetime total and must not rewrite
+/// turn 3's streak.
+#[test]
+fn mixed_out_of_order_memory_outcomes_preserve_the_newest_logical_state() {
+    use crate::session::memory_sink::{MemoryFailureCategory, MemoryTurnOutcome};
+
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".into(), None, crate::binding::ProjectBinding::None);
+    let now = Utc::now();
+
+    for outcome in [
+        MemoryTurnOutcome::Degraded {
+            sequence: 3,
+            category: MemoryFailureCategory::QueueFull,
+            at: now,
+        },
+        MemoryTurnOutcome::Degraded {
+            sequence: 1,
+            category: MemoryFailureCategory::DrainClosed,
+            at: now,
+        },
+        MemoryTurnOutcome::Durable { sequence: 2 },
+    ] {
+        registry
+            .record_memory_durability(&session.id, outcome)
+            .unwrap();
+    }
+
+    let status = registry
+        .get_transcript(&session.id)
+        .unwrap()
+        .memory_durability;
+    assert_eq!(status.total_failed_turns, 2);
+    assert_eq!(
+        status.consecutive_failed_turns, 1,
+        "late outcomes must not move the logical streak behind turn 3"
+    );
+    assert_eq!(
+        status.latest_failure_category,
+        Some(MemoryFailureCategory::QueueFull)
+    );
+    assert_eq!(status.latest_failure_at, Some(now));
+
+    // Turn 2 is durable, so turns 1 and 3 are two SEPARATE streaks and each
+    // reaches its own first consecutive failure. The warnings are named in
+    // logical order, not the order the outcomes arrived in.
+    let warnings = durability_warnings(&registry, &session.id);
+    assert_eq!(
+        warnings.len(),
+        2,
+        "each streak warns at its own first failure"
+    );
+    assert!(warnings[0].contains("category=DrainClosed"));
+    assert!(warnings[0].contains("consecutive_failed_turns=1"));
+    assert!(warnings[1].contains("category=QueueFull"));
+    assert!(warnings[1].contains("consecutive_failed_turns=1"));
+}
+
+/// #2425: an outcome the reconciler refuses must be COUNTED, not discarded —
+/// otherwise the three counters beside it silently under-report and the
+/// operator has no way to know the status is incomplete.
+///
+/// Regression for the fail-silent arm: `RegistryMemoryDurabilityObserver`
+/// discarded this `Err` and nothing else recorded it, so exceeding the reorder
+/// bound left no trace anywhere.
+#[test]
+fn outcome_beyond_the_reorder_bound_is_counted_as_unrecorded() {
+    use crate::session::memory_sink::{MemoryFailureCategory, MemoryTurnOutcome, QUEUE_CAPACITY};
+
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".into(), None, crate::binding::ProjectBinding::None);
+
+    // Sequence 1 never arrives, so nothing folds; the even sequences are
+    // non-adjacent, so no two of them compact into one run.
+    let bound = QUEUE_CAPACITY + 2;
+    let mut refusals = 0;
+    for sequence in (2..).step_by(2).take(bound + 1) {
+        let result = registry.record_memory_durability(
+            &session.id,
+            MemoryTurnOutcome::Degraded {
+                sequence,
+                category: MemoryFailureCategory::QueueFull,
+                at: Utc::now(),
+            },
+        );
+        if let Err(error) = result {
+            refusals += 1;
+            assert!(
+                error.message.contains("reorder bound exceeded"),
+                "unexpected error: {}",
+                error.message
+            );
+        }
+    }
+    assert_eq!(refusals, 1, "exactly the outcome past the bound is refused");
+
+    let status = registry
+        .get_transcript(&session.id)
+        .unwrap()
+        .memory_durability;
+    assert_eq!(
+        status.unrecorded_outcomes, 1,
+        "a refused outcome must leave a trace on the session's status"
+    );
+    assert_eq!(
+        status.total_failed_turns, bound as u64,
+        "the refused outcome is not counted as a failed turn — it was never applied"
+    );
+}
+
+/// #2425: a degradation warning must name the failure category and carry no
+/// session content.
+#[test]
+fn memory_degradation_event_is_redacted() {
+    use crate::session::memory_sink::{MemoryFailureCategory, MemoryTurnOutcome};
+
+    let registry = SessionRegistry::new();
+    let session = registry.create(
+        "secret prompt".into(),
+        None,
+        crate::binding::ProjectBinding::None,
+    );
+    registry
+        .record_memory_durability(
+            &session.id,
+            MemoryTurnOutcome::Degraded {
+                sequence: 1,
+                category: MemoryFailureCategory::MemoryRemember,
+                at: Utc::now(),
+            },
+        )
+        .unwrap();
+
+    let warnings = durability_warnings(&registry, &session.id);
+    let message = warnings.first().expect("warning event");
+    assert!(!message.contains("secret prompt"));
+    assert!(message.contains("MemoryRemember"));
+    assert!(message.contains("total_failed_turns=1"));
 }
 
 // ── #2784 / epic #2343: index readiness + working-context budget ───────────────

--- a/crates/trusty-code/src/session/registry_transcript.rs
+++ b/crates/trusty-code/src/session/registry_transcript.rs
@@ -1,0 +1,61 @@
+//! `SessionRegistry::get_transcript` (#2058), split out of `registry.rs` for
+//! the 500-SLOC cap — a child module of `registry` (declared via
+//! `#[path = ...] mod transcript_ops;`), so it keeps full access to
+//! `SessionRegistry`'s private `lock` helper and `SessionEntry`'s private
+//! fields exactly as if the method were still defined there.
+//!
+//! Why: #2425 added `SessionEntry::memory_durability`/`memory_outcomes` and the
+//! reconciler module declaration, which pushed `registry.rs` over its cap. This
+//! projection is the natural thing to move: it reads `SessionEntry` and builds
+//! a DTO, touching none of the registry's own state machine.
+//! What: [`SessionRegistry::get_transcript`].
+//! Test: `registry_tests::get_transcript_*`.
+
+use super::*;
+use crate::session::transcript::TranscriptRecord;
+
+impl SessionRegistry {
+    /// `session.get_transcript`: fetch the stored run record for a session
+    /// (#2058).
+    ///
+    /// Why: [`Self::set_run_outcome`] populates the storage; this is its read
+    /// counterpart — the M1 cut-line's "inspect transcript" verb. A never-run
+    /// session is a valid, empty transcript, not an error: `SessionEntry`'s
+    /// `transcript`/`usage`/`cost_usd` fields already default to
+    /// empty/zero/`None` at `create` time, so returning them unconditionally
+    /// (once the session itself is confirmed to exist) is correct with no
+    /// extra branching.
+    /// What: `Err(session_not_found)` if `id` is unknown; otherwise a clone of
+    /// whatever is currently stored, wrapped in a self-describing
+    /// [`TranscriptRecord`]. Never recomputes cost, usage, or durability —
+    /// exposes exactly what [`Self::set_run_outcome`] and (#2425)
+    /// [`Self::record_memory_durability`] last stored. `compaction_events`
+    /// (#2349) reads `entry.pm_transcript`'s own cumulative counter — `0` when
+    /// the session has never run (`pm_transcript` still `None`).
+    /// Test: `registry_tests::get_transcript_returns_stored_record`,
+    /// `registry_tests::get_transcript_on_never_run_session_is_empty`,
+    /// `registry_tests::get_transcript_unknown_session_errors`,
+    /// `registry_tests::get_transcript_reports_compaction_events`,
+    /// `registry_tests::get_transcript_round_trips_goal_state`,
+    /// `registry_tests::memory_durability_retains_counts_resets_streak_and_warns_at_one_and_three`.
+    pub fn get_transcript(&self, id: &str) -> Result<TranscriptRecord, RpcError> {
+        let sessions = self.lock();
+        let entry = sessions
+            .get(id)
+            .ok_or_else(|| RpcError::session_not_found(id))?;
+        Ok(TranscriptRecord {
+            session_id: id.to_string(),
+            turns: entry.transcript.clone(),
+            usage: entry.usage,
+            cost_usd: entry.cost_usd,
+            mode: entry.session.mode,
+            compaction_events: entry
+                .pm_transcript
+                .as_ref()
+                .map(Transcript::compaction_events)
+                .unwrap_or(0),
+            goals: goal_ops::goal_records(entry),
+            memory_durability: entry.memory_durability.clone(),
+        })
+    }
+}

--- a/crates/trusty-code/src/session/transcript.rs
+++ b/crates/trusty-code/src/session/transcript.rs
@@ -39,6 +39,42 @@ use crate::agent_loop::{GoalSlot, GoalSource};
 use crate::mode::HarnessMode;
 use crate::perf::TokenUsage;
 use crate::run_task::TurnRecord;
+use crate::session::memory_sink::MemoryFailureCategory;
+
+/// Per-session durable-memory degradation status (#2425).
+///
+/// Why: the turn recorder is fail-open by design — a failed `chat_turn_append`
+/// or `memory_remember` is logged and dropped so the turn still completes. That
+/// makes a session whose durable history is silently thinning indistinguishable
+/// from a healthy one at the operator surface. This is the retained counterpart
+/// to those per-turn warnings: `session.get_transcript` reports how much of the
+/// session's history failed to land.
+/// What: `total_failed_turns` counts every degraded turn for the session's
+/// lifetime; `consecutive_failed_turns` is the current streak and resets to `0`
+/// on the next durable turn; `latest_failure_category`/`latest_failure_at`
+/// describe the most recent degradation in LOGICAL turn order, not arrival
+/// order. `unrecorded_outcomes` counts outcomes that could not be folded in at
+/// all (see [`super::registry`]'s `record_memory_durability`) — a non-zero
+/// value means the three counters above UNDER-report.
+/// Every field is `#[serde(default)]`, so a transcript serialised before #2425
+/// still deserialises.
+/// Test: `registry_tests::memory_durability_retains_counts_resets_streak_and_warns_at_one_and_three`,
+/// `registry_tests::outcome_beyond_the_reorder_bound_is_counted_as_unrecorded`,
+/// `transcript::tests::old_transcript_json_defaults_memory_durability_status`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryDurabilityStatus {
+    #[serde(default)]
+    pub total_failed_turns: u64,
+    #[serde(default)]
+    pub consecutive_failed_turns: u32,
+    #[serde(default)]
+    pub latest_failure_category: Option<MemoryFailureCategory>,
+    #[serde(default)]
+    pub latest_failure_at: Option<DateTime<Utc>>,
+    /// Outcomes discarded before they reached the counters above (#2425).
+    #[serde(default)]
+    pub unrecorded_outcomes: u64,
+}
 
 /// A serialisable snapshot of one occupied goal slot, as
 /// `TranscriptRecord.goals` and `session.get_goals` (#2350) expose it.
@@ -109,6 +145,9 @@ pub struct TranscriptRecord {
     pub compaction_events: u32,
     #[serde(default)]
     pub goals: Vec<GoalSlotRecord>,
+    /// (#2425) Durable-memory degradation status for this session.
+    #[serde(default)]
+    pub memory_durability: MemoryDurabilityStatus,
 }
 
 #[cfg(test)]
@@ -129,6 +168,7 @@ mod tests {
             mode: None,
             compaction_events: 7,
             goals: vec![],
+            memory_durability: MemoryDurabilityStatus::default(),
         };
 
         let json = serde_json::to_value(&record).expect("serialize");
@@ -136,5 +176,24 @@ mod tests {
 
         let round_tripped: TranscriptRecord = serde_json::from_value(json).expect("deserialize");
         assert_eq!(round_tripped.compaction_events, 7);
+    }
+
+    /// (#2425) A transcript serialised before `memory_durability` existed must
+    /// still deserialise — the field is additive, so every `#[serde(default)]`
+    /// on it has to hold for the nested struct as well as the outer one.
+    #[test]
+    fn old_transcript_json_defaults_memory_durability_status() {
+        let old = serde_json::json!({
+            "session_id": "s-1",
+            "turns": [],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0,
+                      "cache_read_tokens": 0, "cache_creation_tokens": 0},
+            "cost_usd": null,
+            "mode": null,
+            "compaction_events": 0,
+            "goals": []
+        });
+        let record: TranscriptRecord = serde_json::from_value(old).expect("old transcript");
+        assert_eq!(record.memory_durability, MemoryDurabilityStatus::default());
     }
 }


### PR DESCRIPTION
Closes #2425.

## 🔴 BREAKING change to `trusty-code`'s public API

`SessionRegistry::memory_sink_for` takes `self: &Arc<Self>` rather than `&self`, so it can hand the sink a `Weak` self-reference without creating a registry → sink → observer → registry cycle. Every in-workspace caller already holds an `Arc<SessionRegistry>`, so no call site changed — but the published signature did. `TranscriptRecord` also gains a `memory_durability` field (`#[serde(default)]`, so old JSON still deserialises).

`cargo-semver-checks` does not run per-PR, so this surfaces at whichever release ships it. For a `0.y.z` crate that is a MINOR bump.

## The fail-silent defect this fixes

`record_memory_durability` returns `Err` on two paths: `session_not_found`, and `internal("memory outcome reorder bound exceeded")`. The observer discarded both with `let _ =`. So the reorder bound could be exceeded, the degradation signal lost, and nothing observed it — which defeats the point of #2425.

Two channels now, because neither alone covers both arms:

- The bound-exceeded arm increments `memory_durability.unrecorded_outcomes` before returning `Err`, so `session.get_transcript` SAYS its counters under-report rather than reading as if nothing was lost. This channel dies with the session, which is exactly the `session_not_found` case.
- The observer warns instead of swallowing, with the RPC code and no session content. This channel survives the session's removal.

Task execution stays fail-open: `observe` runs on the turn path (a synchronous queue-full report from `enqueue`), so it still cannot propagate, block, or panic. Fail-open on the EXECUTION path is correct; fail-silent on the SIGNAL path was the bug.

### Red-then-green proof

Both regression tests were run against the pre-fix behaviour first.

Red 1 — `unrecorded_outcomes` increment reverted:

```
test session::registry::registry_tests::outcome_beyond_the_reorder_bound_is_counted_as_unrecorded ... FAILED
test session::registry::memory_sink_ext::observer_tests::unrecordable_outcomes_are_reported_in_subprocess ... FAILED

assertion `left == right` failed: a refused outcome must leave a trace on the session's status
  left: 0
 right: 1
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 1628 filtered out
```

Red 2 — increment restored, only the `let _ =` swallow reverted, isolating the observer arm:

```
test session::registry::memory_sink_ext::observer_tests::unrecordable_outcomes_are_reported_in_subprocess ... FAILED

assertion `left == right` failed: both a session_not_found and a bound-exceeded refusal must be reported, not swallowed:
  left: 0
 right: 2
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1629 filtered out
```

Green, with the fix:

```
test session::registry::registry_tests::outcome_beyond_the_reorder_bound_is_counted_as_unrecorded ... ok
test session::registry::memory_sink_ext::observer_tests::unrecordable_outcomes_are_reported_in_subprocess ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1628 filtered out
```

`observe` cannot propagate, so the second test reads its proof off a child process's stderr — the same subprocess technique the redaction test uses, and for the same reason: the tracing subscriber is process-global.

## Redaction — verified, not assumed

`default_memory_warnings_redact_server_payloads_in_subprocess` runs a child against a mock daemon that plants three credential-shaped sentinels in its error `message` and its `memory_remember` `reason`, then asserts none reach stderr while `failure_category` does. `reason` matters specifically: for #2520's secret gate it quotes back a preview of the very credential the gate refused to store.

`memory_degradation_event_is_redacted` covers the registry-side warning: category and counters, no prompt text.

## Gate — rung 4

`memory_sink_for` is `pub` on a `pub` type and its published signature changed. Direct dependents: `trusty-agents`, `trusty-code-gui`. No module touched here sits behind a non-default cargo feature.

```
cargo fmt --check                                     EXIT=0
cargo check -p trusty-code --all-targets              EXIT=0
cargo clippy -p trusty-code --all-targets -D warnings EXIT=0
cargo test -p trusty-code        1626 passed; 0 failed; 4 ignored (+ 17 integration targets, all ok)
cargo check --workspace --all-targets                 EXIT=0
cargo test -p trusty-agents --lib --bins   3510 passed; 0 failed; 13 ignored
cargo test -p trusty-code-gui                4 passed; 0 failed
```

Repo gates: `check_line_cap.sh` (4057 files, 0 violations), `check_changelog_fragment.sh`, `check_sld.sh`, `check_test_pointers.sh` (25491 citations, 0 dangling), `check_teardown_guard.sh`, `check_generation_artifacts.sh` — all exit 0.

### Pre-existing failure, not caused by this branch

`cargo test -p trusty-agents` (full) fails 7 tests in `tests/plain_cli_repl.rs`, all "tagent did not exit within 120s". Reproduced identically on clean `origin/main` with the branch stashed:

```
    no_tui_env_forces_plain_mode_without_the_flag
    plain_cli_defaults_active_agent_to_assistant_not_ctrl
    plain_cli_resolves_assistant_via_bundled_deploy_when_no_project_tier
    plain_flag_stays_resident_and_exits_cleanly_on_quit
    profile_resolves_from_env_without_interactive_prompt
    quit_command_stops_the_loop_immediately
    switch_ctrl_still_reaches_the_ctrl_coordinator
test result: FAILED. 0 passed; 7 failed; 0 ignored; 0 measured; finished in 120.18s
```

Same seven, same timeout, at base. The `--lib --bins` counts above are this branch's coverage of that crate.

## One ported assertion was wrong

This work came off an abandoned branch that was never run green. `mixed_out_of_order_memory_outcomes_preserve_the_newest_logical_state` asserted one warning for the sequence degraded(1), durable(2), degraded(3). Turn 2 is durable, so turns 1 and 3 are two separate streaks and each reaches its own first consecutive failure — two warnings, per the documented "warn at the first and third consecutive failed turn" contract. The assertion is corrected; the implementation is not.

## SLOC-cap split

`get_transcript` moves to `registry_transcript.rs`. `registry.rs` was at 498 of its 500-SLOC cap, and the two new `SessionEntry` fields pushed it over; it is now 485. Same-PR split per the no-standalone-cap-fix rule.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
