### PR TITLE
docs: replace the stash-first clean-tree fallback with a throwaway worktree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,7 +471,8 @@ ADR-0049 committable, directly in the main checkout. Check `git status
 --porcelain` before installing from either location; don't assume it.
 
 > **Extended discipline rationale, the install-from-worktree commands, and the
-> stash-first fallback:** see [docs/reference/worktree-discipline.md](docs/reference/worktree-discipline.md).
+> throwaway-worktree fallback for installing from a dirty checkout:** see
+> [docs/reference/worktree-discipline.md](docs/reference/worktree-discipline.md).
 
 ## Abbreviations & Aliases
 

--- a/crates/trusty-code/changelog.d/4730-throwaway-worktree-clean-tree.md
+++ b/crates/trusty-code/changelog.d/4730-throwaway-worktree-clean-tree.md
@@ -1,0 +1,7 @@
+Changed
+
+- The bundled `git-workflow` skill now shows a throwaway worktree
+  (`git worktree add .claude/worktrees/baseline-$$ origin/main`) as the way to
+  get a temporary clean tree, and its "Stashing Work" section saves under a ref
+  and restores by that ref rather than a bare `git stash` followed by a blind
+  `pop`. Kept byte-identical to trusty-mpm's copy of the same skill (#4730).

--- a/crates/trusty-code/src/assets/skills/git-workflow/SKILL.md
+++ b/crates/trusty-code/src/assets/skills/git-workflow/SKILL.md
@@ -138,24 +138,39 @@ git add forgotten_file.py
 git commit --amend --no-edit
 ```
 
-### Stashing Work
+### Getting a Temporary Clean Tree
+
+When you need a clean tree to run one command — a baseline check, a bisect, a
+build against `origin/main` — add a throwaway worktree instead of moving the
+work already in your tree:
 
 ```bash
-# Save current work temporarily
-git stash
+git worktree add .claude/worktrees/baseline-$$ origin/main
+# … run the check there …
+git worktree remove .claude/worktrees/baseline-$$
+```
 
-# List stashes
+Your own tree keeps its changes throughout, so a command that dies partway
+through leaves nothing to restore.
+
+### Stashing Work
+
+The stash stack is repo-global, not per-worktree: every worktree of a repo
+shares one stack. Name each entry and restore it by ref, so you get back the
+one you saved:
+
+```bash
+# Save current work under a name you can recognize
+git stash push -u -m "WIP: authentication feature $(date +%s)"
+
+# List first — confirm which ref is yours
 git stash list
 
-# Apply most recent stash
-git stash pop
-
-# Apply specific stash
-git stash apply stash@{0}
-
-# Create named stash
-git stash save "WIP: authentication feature"
+# Apply the ref you confirmed, not "the most recent"
+git stash apply 'stash@{0}'
 ```
+
+Check that the restored files are the ones you saved before dropping the entry.
 
 ### Cherry-Picking Commits
 

--- a/crates/trusty-mpm/changelog.d/4730-throwaway-worktree-clean-tree.md
+++ b/crates/trusty-mpm/changelog.d/4730-throwaway-worktree-clean-tree.md
@@ -1,0 +1,13 @@
+Changed
+
+- `tm-workflow`'s escape hatch for "I need a clean tree to run one command" is
+  now a throwaway worktree
+  (`git worktree add .claude/worktrees/baseline-$$ origin/main`) rather than
+  stashing the main checkout and restoring it afterwards. The
+  worktree needs no main checkout, and a command that dies partway through
+  leaves every other tree as it was instead of stranding uncommitted work in a
+  stash entry someone has to find (#4730).
+- The bundled `git-workflow` skill gained the same throwaway-worktree recipe for
+  getting a temporary clean tree, and its "Stashing Work" section now saves
+  under a named ref and restores by that ref rather than a bare `git stash`
+  followed by a blind `pop` (#4730).

--- a/crates/trusty-mpm/src/assets/skills/git-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/git-workflow.md
@@ -138,24 +138,39 @@ git add forgotten_file.py
 git commit --amend --no-edit
 ```
 
-### Stashing Work
+### Getting a Temporary Clean Tree
+
+When you need a clean tree to run one command — a baseline check, a bisect, a
+build against `origin/main` — add a throwaway worktree instead of moving the
+work already in your tree:
 
 ```bash
-# Save current work temporarily
-git stash
+git worktree add .claude/worktrees/baseline-$$ origin/main
+# … run the check there …
+git worktree remove .claude/worktrees/baseline-$$
+```
 
-# List stashes
+Your own tree keeps its changes throughout, so a command that dies partway
+through leaves nothing to restore.
+
+### Stashing Work
+
+The stash stack is repo-global, not per-worktree: every worktree of a repo
+shares one stack. Name each entry and restore it by ref, so you get back the
+one you saved:
+
+```bash
+# Save current work under a name you can recognize
+git stash push -u -m "WIP: authentication feature $(date +%s)"
+
+# List first — confirm which ref is yours
 git stash list
 
-# Apply most recent stash
-git stash pop
-
-# Apply specific stash
-git stash apply stash@{0}
-
-# Create named stash
-git stash save "WIP: authentication feature"
+# Apply the ref you confirmed, not "the most recent"
+git stash apply 'stash@{0}'
 ```
+
+Check that the restored files are the ones you saved before dropping the entry.
 
 ### Cherry-Picking Commits
 

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -328,18 +328,21 @@ branch), then the local branch. The remote branch is usually already gone via
 <branch>` goes last, since until the squash-merge lands the branch is the only
 durable copy of the workstream.
 
-**Escape hatch — stash first.** If you genuinely must run one command from the
-main checkout, stash, operate, restore:
+**Escape hatch — a throwaway worktree.** If you genuinely need a clean tree to
+run one command — a baseline check, a bisect, a build against `origin/main` —
+provision a disposable one rather than clearing a checkout another session may
+be writing:
 
 ```bash
-git -C /path/to/main-checkout stash push -u -m "pre-op-safety $(date +%s)"
+git worktree add .claude/worktrees/baseline-$$ origin/main
 # … do the op …
-git -C /path/to/main-checkout stash pop
+git worktree remove .claude/worktrees/baseline-$$
 ```
 
-Surface the stash name in your report if popping fails, so a human can restore
-it manually. This is a narrow exception, not license for routine edits from the
-main checkout.
+This escape hatch used to stash the main checkout, operate, then restore. The
+throwaway worktree needs no main checkout at all, and a run that dies partway
+through leaves every other tree exactly as it was instead of stranding
+uncommitted work in a stash entry a human has to go find (#4730).
 
 Project-specific worktree hazards (binary-install caveats, code-signing caches,
 and the like) belong in the project's own reference docs, not here.

--- a/docs/reference/worktree-discipline.md
+++ b/docs/reference/worktree-discipline.md
@@ -98,15 +98,18 @@ baked into a binary installed from there. The `git status --porcelain` check
 above is what catches that; running it costs one command.
 
 If the checkout you need to install from is not clean and you cannot switch to
-one that is, stash first, operate, then restore:
+one that is, provision a throwaway worktree off `origin/main` and install from
+there:
 
 ```bash
-git -C /path/to/checkout stash push -u \
-    -m "claude: pre-op-safety $(date +%s)"
-# … confirm `git status --porcelain` is now empty, then install …
-git -C /path/to/checkout stash pop
+git worktree add .claude/worktrees/baseline-$$ origin/main
+cargo install --path .claude/worktrees/baseline-$$/crates/<name> --locked
+git worktree remove .claude/worktrees/baseline-$$
 ```
 
-Surface the stash name in the report if popping fails, so the change can be
-restored manually. This is the narrow exception the `tm-workflow` worktree
-rules call out — it does not license routine edits from the main checkout.
+This reaches the clean tree the install needs without disturbing the dirty
+checkout at all: nothing another session can observe changes, and a failure
+partway through leaves that session's uncommitted work exactly where it was.
+The old form of this recipe stashed the dirty checkout instead, which meant an
+interrupted run left the work in a stash entry someone had to find and restore
+by hand (#4730).


### PR DESCRIPTION
## What changed

The fallback for "I need a clean tree to run one command" now provisions a
throwaway worktree instead of stashing an existing checkout and restoring it:

```bash
git worktree add .claude/worktrees/baseline-$$ origin/main
# … run the command there …
git worktree remove .claude/worktrees/baseline-$$
```

## Why the worktree is safer for this procedure

The stash form has two steps that touch a tree someone else may be writing, and
a run that dies between them leaves that work in a stash entry a human has to
find and restore. The worktree form touches no existing checkout at all, so a
half-finished run strands nothing.

The worktree lands under `.claude/worktrees/` rather than `/tmp`: a worktree
provisioned under a temp directory gets reaped mid-task and silently fails
unrelated tests (#3955), and `tm hook` refuses to create one there.

## Files

- `docs/reference/worktree-discipline.md` — re-authored against the current
  ADR-0044/0048/0049 framing, where the trigger is a checkout that is not clean
  and cannot be switched away from.
- `crates/trusty-mpm/src/assets/skills/tm-workflow.md` — the "Escape hatch"
  block. #5650's dispatch sentence scoping `git reset --hard`, `git checkout .`
  and `git stash` to main is untouched.
- `crates/trusty-mpm/src/assets/skills/git-workflow.md` and
  `crates/trusty-code/src/assets/skills/git-workflow/SKILL.md` — new "Getting a
  Temporary Clean Tree" section; "Stashing Work" now saves under a named ref and
  restores by that ref. The two copies stay byte-identical.
- `CLAUDE.md` — pointer text to the reference page.

## Scope

`Refs #4730`, not `Closes` — that issue is closed and stays closed. This is the
fallback-recipe change only; no rule about when `git stash` may be used changes
anywhere.

## Gates

Rung 1 (docs), widened because the skill `.md` files under
`crates/*/src/assets/` are compiled in via `include_str!`.

| Command | Result |
|---|---|
| `cargo fmt --check` | pass |
| `bash scripts/check_line_cap.sh` | 4055 files, 0 violations |
| `bash scripts/check_sld.sh` | 60 specs + 3311 files, 0 errors, 0 warnings |
| `bash scripts/check_changelog_fragment.sh` | trusty-code + trusty-mpm recorded |
| `cargo clippy -p trusty-agents-common -p trusty-code -p trusty-mpm --all-targets -- -D warnings` | pass |
| `cargo test -p trusty-mpm` | 5124 passed; 0 failed; 7 ignored |
| `cargo test -p trusty-code` | 1610 + 21 + integration suites; 0 failed |
| `cargo test -p trusty-agents-common` | 509 passed; 0 failed |

The three `pm_prompt_golden_tests` pass unchanged — the composed PM prompt
embeds neither `tm-workflow.md` nor `git-workflow.md`, confirmed by grepping the
three goldens in `crates/trusty-mpm/src/core/testdata/` for the edited headings
(0 hits).

`cli::daemon_autospawn::daemon_autospawn_tests::spawns_a_daemon_when_none_is_running`
and `spawns_projectless_when_the_tui_is_projectless` failed on one
`cargo test -p trusty-code` run with `stub must have recorded its argv: Os {
code: 2, kind: NotFound }`, then passed on two later full runs and in isolation.
The crate's only change here is an asset `.md` and a changelog fragment, neither
reachable from those tests.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
