### PR TITLE
fix(trusty-mpm): report the daemon's real workspace verdict on decommission (#5899)

### DIFF
--- a/crates/trusty-mpm/changelog.d/5899-decommission-honest-workspace-verdict.md
+++ b/crates/trusty-mpm/changelog.d/5899-decommission-honest-workspace-verdict.md
@@ -1,0 +1,15 @@
+Fixed
+
+- `tm session decommission <id>` no longer reports "workspace removed" when the
+  workspace is still on disk
+  (closes [#5899](https://github.com/bobmatnyc/trusty-tools/issues/5899)).
+  The daemon's `workspace_removed` verdict was dropped client-side — the response
+  decoded into `ManagedSessionSummary`, which has no field for it, so serde
+  discarded it silently — and the CLI printed a hardcoded success line for every
+  decommission, including adopted and local-path workspaces it never touched. The
+  verdict now rides a purpose-built `ManagedDecommissionOutcome` through the
+  executor to one shared message helper: it reports removal only when the daemon
+  says the removal happened, says the workspace is still on disk when it says
+  otherwise, and says the outcome is unreported when an older daemon sends no
+  verdict. `tm ls` tombstone rows also need
+  [#5897](https://github.com/bobmatnyc/trusty-tools/issues/5897) to clear.

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -31,8 +31,9 @@
 
 use std::io::IsTerminal as _;
 
-use trusty_mpm::client::ManagedSessionSummary;
+use trusty_mpm::client::{ManagedDecommissionOutcome, ManagedSessionSummary};
 
+use super::managed_route::decommission_message;
 use crate::cli::CatalogAction;
 
 /// Build the one-line deprecation message for a renamed CLI verb.
@@ -526,27 +527,27 @@ pub(crate) async fn session_resume(
 
 /// `tm session decommission <id>` — full teardown (may or may not remove workspace).
 ///
-/// Why: adopted/local-path sessions were NEVER owned by tm, so the workspace is
-/// NOT removed on their decommission. Previously the CLI printed an incorrect
-/// "workspace removed" message for every decommission — this fix surfaces the
-/// daemon's actual `workspace_removed` verdict so the operator is never misled.
-/// When the workspace was removed and a pre-decommission path is available, we run
-/// `git worktree prune` on the parent directory so git's worktree bookkeeping is
-/// cleaned up immediately (rather than waiting for the next GC pass).
-/// What: POSTs `/api/v1/sessions/managed/{id}/decommission`, reads the
-/// `workspace_removed` / `workspace_path_was` fields from the JSON response, and
-/// prints a message that accurately reflects what happened. When `workspace_removed`
-/// is `true` and `workspace_path_was` is present, runs `git worktree prune` on
-/// the parent directory (best-effort; errors are silently suppressed).
+/// Why: an adopted or local-path workspace was never tm's to delete, a worktree
+/// holding unsaved work is refused, and a removal can fail — so decommission
+/// often leaves the workspace on disk, and only the daemon knows which happened.
+/// This handler reports that verdict rather than assuming removal. When the
+/// workspace WAS removed and a pre-decommission path came back, it also runs
+/// `git worktree prune` on the parent directory so the base repo's worktree
+/// bookkeeping is cleaned up immediately instead of at the next GC pass.
+/// What: POSTs `/api/v1/sessions/managed/{id}/decommission`, decodes the typed
+/// [`ManagedDecommissionOutcome`], and prints
+/// [`super::managed_route::decommission_message`]'s line for the verdict it
+/// carries. Only `workspace_removed == Some(true)` triggers the
+/// `git worktree prune` (best-effort; errors are suppressed).
 /// A missing id is a genuine failure to decommission the requested session
 /// (#2457) — printing "not found" and returning `Ok(())` let a script/CI
 /// check treat it as success, so this now returns `Err` (non-zero exit)
 /// instead. `prune.rs`'s bulk teardown loop (the only other caller) already
 /// propagates this `Err` with `?`, matching its established fail-closed
 /// convention (#1508).
-/// Test: `decommission_message_reflects_workspace_removed` (unit);
-/// HTTP path covered by the integration test;
-/// `session_decommission_not_found_errors` covers the #2457 exit-code fix.
+/// Test: `session_decommission_prints_daemon_verdict_over_http`;
+/// `session_decommission_not_found_errors` covers the #2457 exit-code fix; the
+/// wording itself is covered by `decommission_message_honours_every_verdict`.
 pub(crate) async fn session_decommission(
     client: &reqwest::Client,
     url: &str,
@@ -559,20 +560,19 @@ pub(crate) async fn session_decommission(
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
         anyhow::bail!("managed session '{id}' not found");
     }
-    let body: serde_json::Value = resp.error_for_status()?.json().await?;
-    let workspace_removed = body
-        .get("workspace_removed")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let id_display = body
-        .get("id")
-        .and_then(|v| v.as_str())
-        .unwrap_or(id.as_str());
-    if workspace_removed {
-        println!("decommissioned {id_display} — workspace removed; tombstone record kept");
-        // Run `git worktree prune` on the parent of the (now-deleted) workspace so
-        // the main repo's worktree bookkeeping is cleaned up immediately.
-        if let Some(ws_was) = body.get("workspace_path_was").and_then(|v| v.as_str()) {
+    // #5899: decode the typed response and render via the ONE message helper the
+    // routed `tm session decommission` verb also uses — key-fishing through a raw
+    // `serde_json::Value` here, and a hardcoded string there, is how the two paths
+    // drifted into disagreeing about what happened.
+    let outcome: ManagedDecommissionOutcome = resp.error_for_status()?.json().await?;
+    println!(
+        "{}",
+        decommission_message(&outcome.summary.id, outcome.workspace_removed)
+    );
+    if outcome.workspace_removed == Some(true) {
+        // Prune the parent of the (now-deleted) workspace so the base repo's
+        // worktree bookkeeping is cleaned up immediately.
+        if let Some(ws_was) = outcome.workspace_path_was.as_deref() {
             let parent = std::path::Path::new(ws_was)
                 .parent()
                 .unwrap_or(std::path::Path::new(ws_was));
@@ -580,11 +580,6 @@ pub(crate) async fn session_decommission(
                 .args(["-C", &parent.to_string_lossy(), "worktree", "prune"])
                 .output();
         }
-    } else {
-        println!(
-            "decommissioned {id_display} — record decommissioned; \
-             workspace left in place (not owned by tm)"
-        );
     }
     Ok(())
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
@@ -109,6 +109,37 @@ pub(crate) fn to_command(action: &SessionAction) -> Option<TrustyCommand> {
     })
 }
 
+/// The one decommission result line the CLI prints, for every verdict (#5899).
+///
+/// Why: two CLI paths report a decommission — the routed chat-core verb
+/// ([`render_cli`]) and the raw-HTTP handler the bulk prune sweep calls
+/// ([`super::managed::session_decommission`]) — and they disagreed. The routed one
+/// hardcoded "workspace removed" for every decommission, so it announced deletion
+/// of worktrees still on disk (#5899, a reintroduction of #1787). One function
+/// both call means the honest wording cannot drift back apart.
+/// What: maps the daemon's verdict to a message. `Some(true)` reports removal,
+/// `Some(false)` says the workspace is still on disk, and `None` — an older daemon
+/// that sends no verdict — reports the tombstone and says the workspace outcome is
+/// unknown. There is no fourth state, and no case claims removal without
+/// `Some(true)`: the CLI never probes the filesystem itself, since the daemon's
+/// verdict is the authority (it is the only party that knows whether
+/// `remove_dir_all` actually ran).
+/// Test: `decommission_message_honours_every_verdict`,
+/// `decommission_cli_message_never_claims_removal_when_workspace_remains`.
+pub(crate) fn decommission_message(id: &str, workspace_removed: Option<bool>) -> String {
+    match workspace_removed {
+        Some(true) => format!("decommissioned {id} — workspace removed; tombstone record kept"),
+        Some(false) => format!(
+            "decommissioned {id} — tombstone record kept; workspace NOT removed \
+             (still on disk)"
+        ),
+        None => format!(
+            "decommissioned {id} — tombstone record kept; workspace outcome not \
+             reported by the daemon"
+        ),
+    }
+}
+
 /// Render a [`CommandResult`] as plain, scriptable terminal text.
 ///
 /// Why: chat-core hands back a structured result; the CLI must render it in its
@@ -154,14 +185,14 @@ pub(crate) fn render_cli(result: &CommandResult) -> String {
             name,
             state,
             action,
+            workspace_removed,
         } => match action.as_str() {
             "stopped" => {
                 format!("runtime stopped {id} (workspace intact; use 'resume' to restart)")
             }
             "resumed" => format!("resumed {name} ({id}) [{state}]"),
-            "decommissioned" => {
-                format!("decommissioned {id} (workspace removed; tombstone record kept)")
-            }
+            // #5899: report the daemon's verdict, never a hardcoded "removed".
+            "decommissioned" => decommission_message(id, *workspace_removed),
             other => format!("{other} {id} ({name}) [{state}]"),
         },
         CommandResult::Error(msg) => msg.clone(),
@@ -530,6 +561,7 @@ mod tests {
             name: "alpha".into(),
             state: "Stopped".into(),
             action: "stopped".into(),
+            workspace_removed: None,
         };
         assert_eq!(
             render_cli(&stop),
@@ -540,17 +572,132 @@ mod tests {
             name: "alpha".into(),
             state: "Running".into(),
             action: "resumed".into(),
+            workspace_removed: None,
         };
         assert_eq!(render_cli(&resume), "resumed alpha (m-1) [Running]");
-        let decom = CommandResult::ManagedLifecycle {
+    }
+
+    /// Build a decommission result carrying `verdict` as the daemon's verdict.
+    fn decommissioned(verdict: Option<bool>) -> CommandResult {
+        CommandResult::ManagedLifecycle {
             id: "m-1".into(),
             name: "alpha".into(),
             state: "Decommissioned".into(),
             action: "decommissioned".into(),
-        };
+            workspace_removed: verdict,
+        }
+    }
+
+    /// #5899: the rendered decommission line must follow the daemon's verdict, and
+    /// only `Some(true)` may claim removal. The `Some(false)` arm is the whole bug
+    /// — the CLI printed "workspace removed" for a worktree still on disk — so it
+    /// gets an explicit assertion, as does the no-verdict arm.
+    #[test]
+    fn decommission_message_honours_every_verdict() {
         assert_eq!(
-            render_cli(&decom),
-            "decommissioned m-1 (workspace removed; tombstone record kept)"
+            render_cli(&decommissioned(Some(true))),
+            "decommissioned m-1 — workspace removed; tombstone record kept"
+        );
+
+        let not_removed = render_cli(&decommissioned(Some(false)));
+        assert_eq!(
+            not_removed,
+            "decommissioned m-1 — tombstone record kept; workspace NOT removed (still on disk)"
+        );
+        assert!(
+            !not_removed.contains("workspace removed"),
+            "a `workspace_removed: false` verdict must never read as removal: {not_removed}"
+        );
+
+        let unknown = render_cli(&decommissioned(None));
+        assert_eq!(
+            unknown,
+            "decommissioned m-1 — tombstone record kept; workspace outcome not reported by the daemon"
+        );
+        assert!(
+            !unknown.contains("workspace removed"),
+            "an absent verdict must not be rendered as removal: {unknown}"
+        );
+    }
+
+    /// #5899 regression: `tm session decommission <id>` must not print the removal
+    /// message while the workspace is still on disk.
+    ///
+    /// This is the reported scenario reproduced whole — a session whose workspace tm
+    /// does not own (the adopt / local-path shape), decommissioned through
+    /// `TrustyCommand::ManagedDecommission` on the real daemon route, rendered by
+    /// [`render_cli`]. The daemon side was already correct and already covered; what
+    /// broke was the client dropping the verdict, so the assertion is on the CLI's
+    /// own output, checked against the filesystem rather than against a fixture.
+    /// Nothing here touches tmux (the isolated test daemon uses a no-op driver) or
+    /// git, so it is deterministic.
+    ///
+    /// Against the pre-fix commit it fails: the workspace survives and the CLI
+    /// announces "workspace removed" anyway. The opposite direction — the removal
+    /// message appearing when the workspace IS gone — is covered end-to-end by
+    /// `executor_decommission_reports_daemon_workspace_verdict`, which asserts the
+    /// verdict against the filesystem in both directions, and exhaustively over the
+    /// three verdicts by `decommission_message_honours_every_verdict`.
+    #[tokio::test]
+    async fn decommission_cli_message_never_claims_removal_when_workspace_remains() {
+        use std::future::IntoFuture as _;
+
+        use trusty_mpm::client::{CommandExecutor, TrustyCommand};
+        use trusty_mpm::daemon::{api, state::DaemonState};
+        use trusty_mpm::runtime::RuntimeKind;
+        use trusty_mpm::session_manager::ManagedSessionId;
+
+        let root = tempfile::tempdir().unwrap().keep();
+        let state =
+            std::sync::Arc::new(DaemonState::with_root_isolated_managed(root.clone()).await);
+        let id = ManagedSessionId::new();
+        let ws = root.join(format!("{id}-unowned-ws"));
+        std::fs::create_dir_all(&ws).expect("create seeded workspace");
+        state
+            .session_manager()
+            .await
+            .create_with_id(
+                id,
+                "regression: #5899 decommission workspace verdict".to_string(),
+                Some(ws.clone()),
+                None,
+                Some(ws.clone()),
+                None,
+                None,
+                RuntimeKind::default(),
+                false,
+                // Unowned: the daemon must refuse to delete this workspace.
+                false,
+            )
+            .await
+            .expect("seed session");
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(axum::serve(listener, api::router(state)).into_future());
+
+        let result = CommandExecutor::new(format!("http://{addr}"))
+            .execute(TrustyCommand::ManagedDecommission {
+                target: id.to_string(),
+            })
+            .await;
+        let rendered = render_cli(&result);
+
+        assert!(
+            ws.exists(),
+            "fixture invariant: decommission must NOT delete an unowned workspace \
+             at {}",
+            ws.display()
+        );
+        assert!(
+            !rendered.contains("workspace removed"),
+            "the CLI claimed removal while the workspace is still on disk at {}: \
+             {rendered}",
+            ws.display()
+        );
+        assert!(
+            rendered.contains("NOT removed"),
+            "the operator must be told the workspace survived: {rendered}"
         );
     }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -22,9 +22,10 @@
 //! doc for why the old `Provisioning`-seed/409 scenario no longer applies
 //! cleanly at this layer) established for the prior direct-POST
 //! implementation.
-//! The pre-existing `truncate_*`/`short_timestamp_*`/
-//! `decommission_message_reflects_workspace_removed` unit tests are carried
-//! over unchanged from the inline module this file replaced.
+//! The pre-existing `truncate_*`/`short_timestamp_*` unit tests are carried over
+//! unchanged from the inline module this file replaced;
+//! `decommission_message_reflects_workspace_removed` was replaced by
+//! `session_decommission_prints_daemon_verdict_over_http` (#5899).
 //! Test: this file IS the test module for `commands::managed`.
 
 use std::future::IntoFuture as _;
@@ -139,39 +140,63 @@ fn short_timestamp_formats_correctly() {
     assert_eq!(short_timestamp("2025-06-27T14:32"), "2025-06-27 14:32");
 }
 
-#[test]
-fn decommission_message_reflects_workspace_removed() {
-    // Guard that the key field names used in session_decommission match the
-    // daemon's DecommissionResponse serde output. If the daemon renames those
-    // keys this test catches the drift before the JSON decodes silently to None.
-    let owned_removed = serde_json::json!({
-        "id": "abc-123",
-        "workspace_removed": true,
-        "workspace_path_was": "/some/workspace/path"
-    });
-    assert_eq!(
-        owned_removed
-            .get("workspace_removed")
-            .and_then(|v| v.as_bool()),
-        Some(true)
+/// #5899: `session_decommission` must decode the real daemon response body and
+/// leave an unowned workspace alone.
+///
+/// Replaces `decommission_message_reflects_workspace_removed`, which asserted only
+/// that `serde_json` can read keys out of a literal it had just built — it never
+/// touched the daemon or the handler, which is why the handler could go on printing
+/// a hardcoded "workspace removed". This drives the handler against the real route:
+/// the typed [`ManagedDecommissionOutcome`] decode is now part of the path, so a
+/// daemon-side key rename surfaces as an `Err` here instead of a silent `None`.
+/// The wording itself is asserted by `decommission_message_honours_every_verdict`.
+#[tokio::test]
+async fn session_decommission_prints_daemon_verdict_over_http() {
+    use std::future::IntoFuture as _;
+    use trusty_mpm::daemon::{api, state::DaemonState};
+    use trusty_mpm::runtime::RuntimeKind;
+    use trusty_mpm::session_manager::ManagedSessionId;
+
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = std::sync::Arc::new(DaemonState::with_root_isolated_managed(root.clone()).await);
+    let id = ManagedSessionId::new();
+    let ws = root.join(format!("{id}-unowned-ws"));
+    std::fs::create_dir_all(&ws).unwrap();
+    state
+        .session_manager()
+        .await
+        .create_with_id(
+            id,
+            "regression: #5899 decommission over HTTP".to_string(),
+            Some(ws.clone()),
+            None,
+            Some(ws.clone()),
+            None,
+            None,
+            RuntimeKind::default(),
+            false,
+            // Unowned: the daemon must report `workspace_removed: false`.
+            false,
+        )
+        .await
+        .expect("seed session");
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, api::router(state)).into_future());
+
+    session_decommission(
+        &reqwest::Client::new(),
+        &format!("http://{addr}"),
+        id.to_string(),
+    )
+    .await
+    .expect("decommissioning a seeded session must succeed");
+    assert!(
+        ws.exists(),
+        "an unowned workspace must survive decommission: {}",
+        ws.display()
     );
-    assert_eq!(
-        owned_removed
-            .get("workspace_path_was")
-            .and_then(|v| v.as_str()),
-        Some("/some/workspace/path")
-    );
-    let adopted_not_removed = serde_json::json!({
-        "id": "xyz-456",
-        "workspace_removed": false
-    });
-    assert_eq!(
-        adopted_not_removed
-            .get("workspace_removed")
-            .and_then(|v| v.as_bool()),
-        Some(false)
-    );
-    assert!(adopted_not_removed.get("workspace_path_was").is_none());
 }
 
 /// Spawn the daemon's real HTTP API on a random loopback port, rooted in a

--- a/crates/trusty-mpm/src/client/executor/managed.rs
+++ b/crates/trusty-mpm/src/client/executor/managed.rs
@@ -280,7 +280,7 @@ impl CommandExecutor {
             Err(err) => return err,
         };
         match self.client().runtime_stop_managed_session(&id).await {
-            Ok(summary) => lifecycle(summary, "stopped"),
+            Ok(summary) => lifecycle(summary, "stopped", None),
             Err(e) => CommandResult::Error(format!("runtime-stop failed: {e}")),
         }
     }
@@ -292,20 +292,40 @@ impl CommandExecutor {
             Err(err) => return err,
         };
         match self.client().resume_managed_session(&id).await {
-            Ok(summary) => lifecycle(summary, "resumed"),
+            Ok(summary) => lifecycle(summary, "resumed", None),
             Err(e) => CommandResult::Error(format!("resume failed: {e}")),
         }
     }
 
     /// `managed-decommission` — decommission a session (terminal; removes the
-    /// workspace).
+    /// workspace only when tm provisioned it).
+    ///
+    /// Why: decommission may leave the workspace on disk — an adopted or
+    /// local-path workspace is never tm's to delete, a worktree holding unsaved
+    /// work is refused, and a removal can fail. The daemon reports which happened;
+    /// this method used to discard that verdict, so every renderer downstream had
+    /// to guess and the CLI guessed "removed" every time (#5899).
+    /// What: forwards the daemon's `workspace_removed` verdict into
+    /// [`CommandResult::ManagedLifecycle`] verbatim, `None` included, and logs the
+    /// key names of any response field this client does not model yet.
+    /// Test: `executor_decommission_reports_daemon_workspace_verdict` and
+    /// `decommission_message_honours_every_verdict`.
     pub(super) async fn managed_decommission(&self, target: &str) -> CommandResult {
         let id = match self.resolve_managed(target).await {
             Ok(s) => s.id,
             Err(err) => return err,
         };
         match self.client().decommission_managed_session(&id).await {
-            Ok(summary) => lifecycle(summary, "decommissioned"),
+            // #5899: carry the daemon's workspace verdict instead of dropping it.
+            Ok(outcome) => {
+                if !outcome.unrecognized.is_empty() {
+                    tracing::debug!(
+                        fields = ?outcome.unrecognized.keys().collect::<Vec<_>>(),
+                        "decommission response carried fields this client does not model"
+                    );
+                }
+                lifecycle(outcome.summary, "decommissioned", outcome.workspace_removed)
+            }
             Err(e) => CommandResult::Error(format!("decommission failed: {e}")),
         }
     }
@@ -315,15 +335,21 @@ impl CommandExecutor {
 ///
 /// Why: the three lifecycle verbs (stop/resume/decommission) all report the same
 /// id/name/state shape; one helper keeps their result construction identical.
-/// What: builds the lifecycle result from the updated summary and the verb that
-/// produced it.
+/// What: builds the lifecycle result from the updated summary, the verb that
+/// produced it, and — for decommission only — the daemon's workspace verdict
+/// (`None` for stop/resume, which never touch the workspace).
 /// Test: covered by the managed lifecycle dispatch tests.
-fn lifecycle(summary: ManagedSessionSummary, action: &str) -> CommandResult {
+fn lifecycle(
+    summary: ManagedSessionSummary,
+    action: &str,
+    workspace_removed: Option<bool>,
+) -> CommandResult {
     CommandResult::ManagedLifecycle {
         id: summary.id,
         name: summary.name,
         state: summary.state,
         action: action.to_string(),
+        workspace_removed,
     }
 }
 

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -524,6 +524,95 @@ async fn execute_managed_adopt_requires_cwd() {
     }
 }
 
+/// #5899: `ManagedDecommission` must carry the daemon's workspace verdict into
+/// [`CommandResult::ManagedLifecycle`] — for a workspace it deleted AND for one it
+/// left alone.
+///
+/// The verdict was computed and sent correctly all along; the executor lost it,
+/// because the response decoded into a summary type with no field for it. This runs
+/// the real daemon route so a key rename daemon-side fails here rather than
+/// deserializing quietly to `None`.
+///
+/// `$HOME` is redirected for the duration: the daemon's removal path applies a
+/// containment guard against the configured workspace root, so a tm-owned workspace
+/// anywhere else would be refused and the removal arm would prove nothing. Serial,
+/// because that redirect is process-wide.
+#[tokio::test]
+#[serial_test::serial]
+async fn executor_decommission_reports_daemon_workspace_verdict() {
+    use crate::runtime::RuntimeKind;
+    use crate::session_manager::ManagedSessionId;
+
+    /// Restores `$HOME` even if an assertion below panics mid-loop.
+    struct HomeGuard(Option<String>);
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            // SAFETY: serialized via `#[serial_test::serial]`.
+            match self.0 {
+                Some(ref p) => unsafe { std::env::set_var("HOME", p) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+        }
+    }
+
+    let home = tempfile::TempDir::new().unwrap();
+    let _home_guard = HomeGuard(std::env::var("HOME").ok());
+    // SAFETY: serialized via `#[serial_test::serial]`; restored by the guard.
+    unsafe { std::env::set_var("HOME", home.path()) };
+    let workspace_root = trusty_common::workspace_layout::resolve_workspace_root(None);
+
+    for owned in [true, false] {
+        let (state, url) = spawn_test_daemon().await;
+        let id = ManagedSessionId::new();
+        let ws = workspace_root.join(format!("tm-5899-{id}"));
+        std::fs::create_dir_all(&ws).expect("create seeded workspace");
+        state
+            .session_manager()
+            .await
+            .create_with_id(
+                id,
+                "regression: #5899 executor verdict".to_string(),
+                Some(ws.clone()),
+                None,
+                Some(ws.clone()),
+                None,
+                None,
+                RuntimeKind::default(),
+                false,
+                owned,
+            )
+            .await
+            .expect("seed session");
+
+        let result = CommandExecutor::new(url)
+            .execute(TrustyCommand::ManagedDecommission {
+                target: id.to_string(),
+            })
+            .await;
+        match result {
+            CommandResult::ManagedLifecycle {
+                action,
+                workspace_removed,
+                ..
+            } => {
+                assert_eq!(action, "decommissioned");
+                assert_eq!(
+                    workspace_removed,
+                    Some(owned),
+                    "owned={owned}: the executor must forward the daemon's verdict"
+                );
+                assert_eq!(
+                    ws.exists(),
+                    !owned,
+                    "owned={owned}: the verdict must match the filesystem"
+                );
+            }
+            other => panic!("expected ManagedLifecycle, got {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+}
+
 #[tokio::test]
 async fn pair_request_returns_code() {
     let (_state, url) = spawn_test_daemon().await;

--- a/crates/trusty-mpm/src/client/http_client/managed.rs
+++ b/crates/trusty-mpm/src/client/http_client/managed.rs
@@ -22,8 +22,9 @@ use super::error::response_or_body_error;
 use super::types::{
     FleetByProjectWireResponse, FleetProjectGroupWire, ManagedActivityResponse,
     ManagedAdoptRequest, ManagedAdoptResponse, ManagedAnswerRequest, ManagedAnswerResponse,
-    ManagedAttachCmdResponse, ManagedListResponse, ManagedSendInputRequest,
-    ManagedSendInputResponse, ManagedSessionSummary, ManagedSpawnRequest, ManagedSpawnResponse,
+    ManagedAttachCmdResponse, ManagedDecommissionOutcome, ManagedListResponse,
+    ManagedSendInputRequest, ManagedSendInputResponse, ManagedSessionSummary, ManagedSpawnRequest,
+    ManagedSpawnResponse,
 };
 
 impl DaemonClient {
@@ -297,13 +298,21 @@ impl DaemonClient {
     /// Decommission a session via `POST .../{id}/decommission`.
     ///
     /// Why: the only operation that permanently removes the workspace directory;
-    /// it is terminal — no resume is possible afterward.
-    /// What: POSTs to the decommission endpoint and returns the tombstone summary.
-    /// Test: live HTTP via `tests/session_manager_mvp.rs`.
+    /// it is terminal — no resume is possible afterward. Decommission does NOT
+    /// always remove the workspace, so the caller needs the daemon's verdict to
+    /// report the outcome honestly — decoding this body into
+    /// [`ManagedSessionSummary`] silently dropped it and made every CLI
+    /// decommission claim removal (#5899).
+    /// What: POSTs to the decommission endpoint and returns the whole response —
+    /// tombstone summary plus `workspace_removed` / `workspace_path_was` — as a
+    /// [`ManagedDecommissionOutcome`].
+    /// Test: `executor_decommission_reports_daemon_workspace_verdict` (real
+    /// daemon round-trip), `decommission_outcome_round_trips_daemon_response`;
+    /// live HTTP via `tests/session_manager_mvp.rs`.
     pub async fn decommission_managed_session(
         &self,
         id: &str,
-    ) -> anyhow::Result<ManagedSessionSummary> {
+    ) -> anyhow::Result<ManagedDecommissionOutcome> {
         let url = format!("{}/api/v1/sessions/managed/{id}/decommission", self.base);
         let resp = self
             .http
@@ -312,7 +321,8 @@ impl DaemonClient {
             .await?
             .error_for_status()?
             .json()
-            .await?;
+            .await
+            .context("decoding decommission response body")?;
         Ok(resp)
     }
 }

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -39,10 +39,10 @@ pub use types::{
     CoordinatorSession, DiscoveredProjectRow, EventRow, FleetByProjectWireResponse,
     FleetProjectGroupWire, HealthSnapshot, LastSeen, LlmChatOutcome, ManagedActivityResponse,
     ManagedAdoptRequest, ManagedAdoptResponse, ManagedAnswerRequest, ManagedAnswerResponse,
-    ManagedAttachCmdResponse, ManagedListResponse, ManagedSendInputRequest,
-    ManagedSendInputResponse, ManagedSessionSummary, ManagedSpawnRequest, ManagedSpawnResponse,
-    ManagedStoreHealth, OverseerSnapshot, PairConfirm, PairRequest, PairStatus, SessionRow,
-    TmuxSessionRow,
+    ManagedAttachCmdResponse, ManagedDecommissionOutcome, ManagedListResponse,
+    ManagedSendInputRequest, ManagedSendInputResponse, ManagedSessionSummary, ManagedSpawnRequest,
+    ManagedSpawnResponse, ManagedStoreHealth, OverseerSnapshot, PairConfirm, PairRequest,
+    PairStatus, SessionRow, TmuxSessionRow,
 };
 
 use serde::Deserialize;

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -464,6 +464,83 @@ fn managed_session_summary_deserializes() {
     assert!(s.source_id.is_none());
 }
 
+/// #5899: the decommission response's workspace verdict must survive the client
+/// round-trip, and an absent verdict must stay distinguishable from `false`.
+///
+/// The keys asserted here are `daemon::managed_routes::DecommissionResponse`'s own
+/// serde output — the flattened summary plus `workspace_removed` /
+/// `workspace_path_was`. Before this type existed the body was decoded into
+/// [`ManagedSessionSummary`], which has nowhere for either field to land, so serde
+/// dropped both and the CLI had nothing left to report.
+#[test]
+fn decommission_outcome_round_trips_daemon_response() {
+    let removed = serde_json::json!({
+        "id": "00000000-0000-0000-0000-000000000001",
+        "name": "tmpm-brave-otter",
+        "state": "decommissioned",
+        "workspace_path": serde_json::Value::Null,
+        "workspace_removed": true,
+        "workspace_path_was": "/tmp/base/.worktrees/abc",
+    });
+    let o: ManagedDecommissionOutcome = serde_json::from_value(removed).unwrap();
+    assert_eq!(o.summary.id, "00000000-0000-0000-0000-000000000001");
+    assert_eq!(o.summary.state, "decommissioned");
+    assert_eq!(o.workspace_removed, Some(true));
+    assert_eq!(
+        o.workspace_path_was.as_deref(),
+        Some("/tmp/base/.worktrees/abc")
+    );
+
+    // The error arm: the daemon says it removed nothing.
+    let kept = serde_json::json!({
+        "id": "x", "name": "n", "state": "decommissioned", "workspace_removed": false
+    });
+    let o: ManagedDecommissionOutcome = serde_json::from_value(kept).unwrap();
+    assert_eq!(o.workspace_removed, Some(false));
+    assert!(o.workspace_path_was.is_none());
+
+    // An older daemon that reports no verdict must NOT read as `false`, which
+    // would assert "still on disk" the client cannot know.
+    let silent = serde_json::json!({"id": "x", "name": "n", "state": "decommissioned"});
+    let o: ManagedDecommissionOutcome = serde_json::from_value(silent).unwrap();
+    assert_eq!(o.workspace_removed, None);
+}
+
+/// #5899: a field the daemon adds later must be retained, not silently dropped.
+///
+/// This is the class of bug, not just the instance: the client discarded
+/// `workspace_removed` because its target type had no field for it, and serde says
+/// nothing when that happens. Unmodelled keys now land in `unrecognized`, where the
+/// executor logs them and this test can see them.
+#[test]
+fn decommission_outcome_keeps_unmodelled_daemon_fields() {
+    let body = serde_json::json!({
+        "id": "x",
+        "name": "n",
+        "state": "decommissioned",
+        "workspace_removed": false,
+        "workspace_removal_error": "worktree holds uncommitted work",
+    });
+    let o: ManagedDecommissionOutcome = serde_json::from_value(body).unwrap();
+    assert_eq!(o.workspace_removed, Some(false));
+    assert_eq!(
+        o.unrecognized
+            .get("workspace_removal_error")
+            .and_then(|v| v.as_str()),
+        Some("worktree holds uncommitted work"),
+        "an unmodelled daemon field must be retained, not dropped: {:?}",
+        o.unrecognized
+    );
+    // Fields the client DOES model are consumed by their own fields, so they must
+    // not also show up as unrecognized.
+    for modelled in ["id", "name", "state", "workspace_removed"] {
+        assert!(
+            !o.unrecognized.contains_key(modelled),
+            "{modelled} is modelled and must not be collected as unrecognized"
+        );
+    }
+}
+
 /// #2595: `unresumable` must round-trip when present, and default `false`
 /// (never spuriously flag a session dead) when an older daemon omits it.
 #[test]

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -629,6 +629,58 @@ pub struct ManagedStoreHealth {
     pub observed_at: String,
 }
 
+/// Response body for `POST /api/v1/sessions/managed/{id}/decommission` (#5899).
+///
+/// Why: the daemon answers a decommission with a session summary PLUS its verdict
+/// on the workspace directory — decommission deletes it only when tm provisioned
+/// it and the deletion actually succeeded. The client used to decode that body
+/// into [`ManagedSessionSummary`], which has no field for the verdict, so serde
+/// dropped `workspace_removed` and `workspace_path_was` without a word and every
+/// `tm session decommission` printed "workspace removed" — including for
+/// worktrees still on disk (#5899, a reintroduction of #1787). A purpose-built
+/// response type is the structural fix: each field the daemon sends has somewhere
+/// to land, and [`Self::unrecognized`] catches the ones this client does not model
+/// yet, so the NEXT field added daemon-side cannot vanish the same way.
+/// What: mirrors `daemon::managed_routes::DecommissionResponse` field-for-field —
+/// the flattened summary, the `workspace_removed` verdict, the pre-tombstone
+/// `workspace_path_was` hint, and a catch-all for unmodelled keys.
+/// Test: `decommission_outcome_round_trips_daemon_response`,
+/// `decommission_outcome_keeps_unmodelled_daemon_fields`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManagedDecommissionOutcome {
+    /// The post-tombstone session summary (`state = decommissioned`,
+    /// `workspace_path = None`).
+    #[serde(flatten)]
+    pub summary: ManagedSessionSummary,
+    /// Whether the daemon actually removed the workspace directory from disk.
+    ///
+    /// `Some(true)` — tm owned the workspace and deleted it.
+    /// `Some(false)` — nothing was deleted: the workspace was not tm's to remove,
+    /// the worktree held unsaved work, the removal failed, or the caller passed
+    /// `?record_only=true`.
+    /// `None` — the daemon reported no verdict (it predates the field). A caller
+    /// must render that as unknown; reading it as either outcome is the #5899 bug
+    /// in a new spelling.
+    #[serde(default)]
+    pub workspace_removed: Option<bool>,
+    /// The workspace path as of just before the tombstone cleared it, for a
+    /// tm-owned workspace. The CLI uses it to locate the base git repo and run
+    /// `git worktree prune`; `None` for adopted/local-path sessions.
+    #[serde(default)]
+    pub workspace_path_was: Option<String>,
+    /// Every response key this client does not model yet.
+    ///
+    /// Why: an unmodelled key is the exact shape of #5899 — the daemon sends
+    /// information and the client discards it silently. Collecting the leftovers
+    /// keeps them observable (the executor logs the key names) and lets a test
+    /// prove nothing is dropped.
+    /// What: the flattened remainder after the named fields and `summary` claim
+    /// theirs; empty against a daemon this client fully models.
+    /// Test: `decommission_outcome_keeps_unmodelled_daemon_fields`.
+    #[serde(flatten)]
+    pub unrecognized: std::collections::BTreeMap<String, serde_json::Value>,
+}
+
 /// Request body for `POST /api/v1/sessions/managed` (spawn).
 ///
 /// Why: spawning a managed session requires the repo, ref, and task; an optional

--- a/crates/trusty-mpm/src/client/mod.rs
+++ b/crates/trusty-mpm/src/client/mod.rs
@@ -36,10 +36,10 @@ pub use http_client::{
     CoordinatorSession, DaemonClient, DiscoveredProjectRow, EventRow, FleetByProjectWireResponse,
     FleetProjectGroupWire, HealthSnapshot, LastSeen, LlmChatOutcome, ManagedActivityResponse,
     ManagedAdoptRequest, ManagedAdoptResponse, ManagedAnswerRequest, ManagedAnswerResponse,
-    ManagedAttachCmdResponse, ManagedListResponse, ManagedSendInputRequest,
-    ManagedSendInputResponse, ManagedSessionSummary, ManagedSpawnRequest, ManagedSpawnResponse,
-    ManagedStoreHealth, OverseerSnapshot, PairConfirm, PairRequest, PairStatus, SessionRow,
-    TmuxSessionRow,
+    ManagedAttachCmdResponse, ManagedDecommissionOutcome, ManagedListResponse,
+    ManagedSendInputRequest, ManagedSendInputResponse, ManagedSessionSummary, ManagedSpawnRequest,
+    ManagedSpawnResponse, ManagedStoreHealth, OverseerSnapshot, PairConfirm, PairRequest,
+    PairStatus, SessionRow, TmuxSessionRow,
 };
 pub use proxy::{
     ActivityDigest, FocusOutcome, FocusTarget, FreeTextRoute, InjectOutcome, ManagedBackend,

--- a/crates/trusty-mpm/src/client/result.rs
+++ b/crates/trusty-mpm/src/client/result.rs
@@ -345,8 +345,9 @@ pub enum CommandResult {
     ///
     /// Why: all three terminal/lifecycle verbs report the same shape — the
     /// session's id, name, and new state — so a UI renders them uniformly.
-    /// What: the resolved id, friendly name, the new lifecycle state, and the
-    /// human-readable verb that produced it (`stopped`/`resumed`/`decommissioned`).
+    /// What: the resolved id, friendly name, the new lifecycle state, the
+    /// human-readable verb that produced it (`stopped`/`resumed`/`decommissioned`),
+    /// and — for `decommissioned` — the daemon's workspace-removal verdict.
     ManagedLifecycle {
         /// The resolved managed session id.
         id: String,
@@ -356,6 +357,20 @@ pub enum CommandResult {
         state: String,
         /// The verb applied (`stopped` | `resumed` | `decommissioned`).
         action: String,
+        /// Whether the daemon removed the workspace directory from disk (#5899).
+        ///
+        /// Why: decommission removes the workspace only when tm provisioned it and
+        /// the removal succeeded, so a renderer that assumes removal lies to the
+        /// operator — which is exactly what `tm session decommission` did while
+        /// this field did not exist. It is the daemon's verdict, never a local
+        /// filesystem guess.
+        /// What: `Some(true)` removed, `Some(false)` still on disk, `None` no
+        /// verdict — either a `stopped`/`resumed` result (no workspace decision
+        /// was made) or a daemon that predates the field. A renderer must keep
+        /// `None` distinct from `Some(false)`.
+        /// Test: `decommission_message_honours_every_verdict`,
+        /// `decommission_cli_message_never_claims_removal_when_workspace_remains`.
+        workspace_removed: Option<bool>,
     },
 
     /// Any failure rendered as a message rather than a panic.

--- a/crates/trusty-mpm/src/slack/formatter/mod.rs
+++ b/crates/trusty-mpm/src/slack/formatter/mod.rs
@@ -217,6 +217,9 @@ impl SlackFormatter {
                 name,
                 state,
                 action,
+                // The workspace verdict is rendered by the CLI only; this line
+                // reports the state transition.
+                ..
             } => format!("✅ {name} ({}) {action} → {state}", short_id(id)),
             CommandResult::Help(text) => text.clone(),
             CommandResult::Health(report) => format_health(report),

--- a/crates/trusty-mpm/src/telegram/formatter/mod.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/mod.rs
@@ -295,6 +295,9 @@ impl TelegramFormatter {
                 name,
                 state,
                 action,
+                // The workspace verdict is rendered by the CLI only; this line
+                // reports the state transition.
+                ..
             } => format!(
                 "✅ {} ({}) {} → {}",
                 html_escape(name),

--- a/crates/trusty-mpm/src/telegram/formatter/tests.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/tests.rs
@@ -245,6 +245,7 @@ fn managed_arms_escape_daemon_sourced_fields() {
         name: raw.into(),
         state: raw.into(),
         action: raw.into(),
+        workspace_removed: None,
     };
     let lifecycle_text = TelegramFormatter::format(&lifecycle);
     assert!(

--- a/crates/trusty-mpm/src/tui/coordinator/render.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/render.rs
@@ -102,6 +102,8 @@ pub fn render_result(result: &CommandResult) -> Vec<Line<'static>> {
             name,
             state,
             action,
+            // The verdict line is CLI-only; this view reports the state change.
+            ..
         } => vec![ok_line(format!(
             "{action} {name} [{state}] ({})",
             short(id)

--- a/crates/trusty-mpm/src/tui/coordinator/tests.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/tests.rs
@@ -1500,6 +1500,7 @@ fn render_result_renders_lifecycle() {
         name: "tmpm-red".to_string(),
         state: "Stopped".to_string(),
         action: "stopped".to_string(),
+        workspace_removed: None,
     });
     let text = line_text(&lines[0]);
     assert!(text.starts_with('✓'), "{text}");

--- a/crates/trusty-mpm/src/tui/project_ctl/actions.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/actions.rs
@@ -71,7 +71,12 @@ pub(crate) async fn dispatch(
             apply_mutation_result(state, result, "resumed");
         }
         PendingAction::Decommission(id) => {
-            let result = client.decommission_managed_session(&id).await;
+            // The notice reports the state change; the workspace verdict rides on
+            // the outcome for the CLI's message (#5899).
+            let result = client
+                .decommission_managed_session(&id)
+                .await
+                .map(|outcome| outcome.summary);
             apply_mutation_result(state, result, "decommissioned");
         }
         PendingAction::Attach(id) => match client.managed_session_attach_cmd(&id).await {


### PR DESCRIPTION
Fixes [#5899](https://github.com/bobmatnyc/trusty-tools/issues/5899).

## What was wrong

`tm session decommission <id>` printed `(workspace removed; tombstone record kept)` and exited 0 even when the worktree was still on disk. The daemon's verdict was correct and was being sent; the client threw it away.

`decommission_managed_session` decoded the response body into `ManagedSessionSummary`, which has no `workspace_removed` / `workspace_path_was` field, so serde dropped both silently. With nothing left to forward, `render_cli` hardcoded the removal message for `action == "decommissioned"`.

## What changed

- New `ManagedDecommissionOutcome` wire type mirroring `DecommissionResponse`: flattened summary, `workspace_removed: Option<bool>`, `workspace_path_was`, plus a flattened catch-all that retains any field the client does not model yet (the executor logs its key names). The silent-drop is now structurally impossible for the next field too.
- `CommandResult::ManagedLifecycle` carries `workspace_removed: Option<bool>`; the executor forwards the daemon's verdict verbatim, `None` included.
- One `decommission_message` helper renders all three states, and both CLI paths call it — the routed verb and `managed::session_decommission` (the bulk-prune path), which also stops fishing keys out of a raw `serde_json::Value`. Removal is claimed only for `Some(true)`; `Some(false)` says the workspace is still on disk; an absent verdict says the outcome was not reported. The CLI never probes the filesystem — the daemon's verdict is the authority.

Out of scope, untouched: `retention.rs` and `prune.rs` (a separate PR for [#5897](https://github.com/bobmatnyc/trusty-tools/issues/5897) owns those). **[#5897](https://github.com/bobmatnyc/trusty-tools/issues/5897) must also land for the user-visible `tm ls` tombstone growth to clear** — this PR stops decommission lying about the removal; that one releases the slot once the workspace guard passes.

No version bump: `trusty-mpm` 1.4.3 is not yet published, so `PR version bump vs crates.io (issue #4421)` passes as-is (`[ OK ] trusty-mpm 1.4.3 — src changed, version not yet published`).

## Tests

- `decommission_cli_message_never_claims_removal_when_workspace_remains` — the reported scenario end-to-end: unowned workspace, real daemon route, `CommandExecutor` → `render_cli`, asserted against the filesystem. **Fails at the pre-fix commit:**

```
test commands::managed_route::tests::decommission_cli_message_never_claims_removal_when_workspace_remains ... FAILED

panicked at crates/trusty-mpm/src/bin/tm/commands/managed_route.rs:626:9:
the CLI claimed removal while the workspace is still on disk at
/var/folders/.../0ae818de-71df-4ec2-9819-c56f8c02a72c-unowned-ws:
decommissioned 0ae818de-71df-4ec2-9819-c56f8c02a72c (workspace removed; tombstone record kept)

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1737 filtered out
```

  and passes after:

```
test commands::managed_route::tests::decommission_cli_message_never_claims_removal_when_workspace_remains ... ok
```

- `decommission_message_honours_every_verdict` — the error arm explicitly, plus the removed and no-verdict arms; exhaustive over the three states.
- `executor_decommission_reports_daemon_workspace_verdict` — real daemon route, owned and unowned, verdict asserted against the filesystem in both directions.
- `decommission_outcome_round_trips_daemon_response` and `decommission_outcome_keeps_unmodelled_daemon_fields` — the wire contract, including that a future daemon field is retained rather than dropped.
- `session_decommission_prints_daemon_verdict_over_http` replaces `decommission_message_reflects_workspace_removed`, which only asserted that `serde_json` could read keys back out of a literal it had just built — it never touched the daemon or the handler.

## Gates — test ladder rung 5

```
cargo fmt --check                                      # EXIT=0
cargo check -p trusty-mpm --all-targets                # EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings # EXIT=0
cargo test -p trusty-mpm                               # 5127 + 1738 + 1738 passed; 0 failed
cargo test -p trusty-mpm --lib -- --include-ignored    # 5134 passed; 0 failed
cargo check --workspace                                # EXIT=0
bash scripts/check_line_cap.sh                         # 0 violations
bash scripts/check_sld.sh                              # 0 errors, 0 warnings
bash scripts/check_test_pointers.sh                    # 25480 citations, 0 dangling
bash scripts/check_teardown_guard.sh                   # OK
bash scripts/check_changelog_fragment.sh               # OK
PR_VERSION_BUMP_BASE=origin/main bash scripts/check-pr-version-bump.sh  # clear
```

The first `--include-ignored` run reported two failures, neither in a file this PR touches: `claude_pid_resolves_through_disclaim_wrapper` (reproduced at the pre-fix commit in a clean worktree — pre-existing, depends on a live disclaim-wrapped claude process) and `bench_stale_assets_for_many` (passes in isolation in both trees; a full re-run was green: `5134 passed; 0 failed`).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
