### PR TITLE
fix(trusty-mpm): pin a working directory for three cwd-sensitive pm-guard tests

### DIFF
--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -46,6 +46,13 @@ fn isolated_home() -> tempfile::TempDir {
 
 /// Spawn `tm hook --pm-guard` with the given stdin JSON and optional extra env,
 /// returning stdout as a string. Asserts a clean `exit 0` (fail-open contract).
+///
+/// It sets NO working directory, so the child inherits the test binary's, and a
+/// payload carrying no `cwd` field lets that decide every rule keyed on
+/// `hook_cwd` (`pm_guard.rs`) — a main checkout in CI, a linked worktree on a
+/// developer machine. Never use this for a dispatch-tool payload or any other
+/// cwd-sensitive rule; reach for [`run_pm_guard_outside_a_checkout`] or
+/// [`run_pm_guard_at`], which pin the directory. See #5708.
 fn run_pm_guard(stdin_json: &str, extra_env: &[(&str, &str)]) -> String {
     let bin = env!("CARGO_BIN_EXE_tm");
     let mut command = Command::new(bin);
@@ -259,15 +266,16 @@ fn pm_guard_allows_read_tool() {
 
 #[test]
 fn pm_guard_allows_git_status_and_task() {
-    let git = run_pm_guard(
+    // #5708: pinned outside any checkout because the `Task` arm is a dispatch —
+    // in a main checkout ADR-0048 denies it for want of an `isolation` field,
+    // which is its own rule's business and asserted separately.
+    let git = run_pm_guard_outside_a_checkout(
         r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git status"}}"#,
-        &[],
     );
     assert_eq!(git.trim(), "", "git status must be allowed");
 
-    let task = run_pm_guard(
+    let task = run_pm_guard_outside_a_checkout(
         r#"{"hook_event_name":"PreToolUse","tool_name":"Task","tool_input":{"subagent_type":"rust-engineer","prompt":"do it"}}"#,
-        &[],
     );
     assert_eq!(task.trim(), "", "Task must be allowed");
 }
@@ -755,15 +763,20 @@ fn pm_guard_denies_task_dispatch_from_mpm_subagent_env() {
 
 #[test]
 fn pm_guard_allows_agent_dispatch_from_pm() {
-    // The load-bearing arm: the PM carries neither marker, so its dispatches
-    // must pass silently. A regression here halts every delegation in the
-    // system, which is strictly worse than the fan-out this guard prevents.
+    // The arm every delegation depends on: the PM carries neither marker, so
+    // its dispatches must pass silently. A regression here halts every
+    // delegation in the system, which is strictly worse than the fan-out this
+    // guard prevents.
+    //
+    // #5708: pinned outside any checkout so this asserts the FAN-OUT rule
+    // alone. In a main checkout ADR-0048 rewrites the same payload to add
+    // `isolation`, which is a different rule with its own tests.
     for tool in ["Agent", "Task"] {
         let payload = format!(
             r#"{{"hook_event_name":"PreToolUse","tool_name":"{tool}","tool_input":{{"subagent_type":"rust-engineer","prompt":"go"}}}}"#
         );
         assert_eq!(
-            run_pm_guard(&payload, &[]).trim(),
+            run_pm_guard_outside_a_checkout(&payload).trim(),
             "",
             "the PM's own {tool} dispatch must be allowed"
         );
@@ -775,12 +788,17 @@ fn pm_guard_fanout_fails_open_on_indeterminate_caller() {
     // An empty-string `agent_id` and a payload with no marker at all are both
     // INDETERMINATE. Indeterminate must ALLOW (#4784): a false deny against
     // the PM halts orchestration; a false allow reproduces prior behaviour.
+    //
+    // #5708: pinned outside any checkout because these payloads carry no
+    // `subagent_type` and are therefore also UNTYPED dispatches, which ADR-0048
+    // deliberately isolates in a main checkout rather than failing open. The two
+    // rules disagree by design; this one is asserted where only it can fire.
     for payload in [
         r#"{"hook_event_name":"PreToolUse","agent_id":"","tool_name":"Agent","tool_input":{"prompt":"go"}}"#,
         r#"{"hook_event_name":"PreToolUse","agent_type":"rust-engineer","tool_name":"Agent","tool_input":{"prompt":"go"}}"#,
     ] {
         assert_eq!(
-            run_pm_guard(payload, &[]).trim(),
+            run_pm_guard_outside_a_checkout(payload).trim(),
             "",
             "an indeterminate caller context must fail OPEN: {payload}"
         );
@@ -844,6 +862,27 @@ fn pm_guard_subagent_keeps_its_working_tool_surface() {
 /// What: as [`run_pm_guard`], plus an explicit `--url` and `current_dir`.
 fn run_pm_guard_at(stdin_json: &str, url: &str, cwd: &std::path::Path) -> String {
     run_pm_guard_at_with_env(stdin_json, url, cwd, &[])
+}
+
+/// Spawn `tm hook --pm-guard` standing in a directory that is no git checkout.
+///
+/// Why (#5708): [`run_pm_guard`] inherits the runner's working directory, and
+/// the ADR-0048 worktree grant fires only in a main checkout. Three tests
+/// asserting a silent allow therefore passed from a worktree and failed from
+/// CI's `actions/checkout` clone — one denied, two got an `updatedInput`
+/// rewrite — off the same binary at the same commit. Pinning a directory that
+/// is no checkout makes the verdict the payload's rather than the runner's.
+/// What: [`run_pm_guard_at`] against the same unreachable daemon URL
+/// [`run_pm_guard`] fixes, in a fresh empty tempdir — no `.git` entry of either
+/// shape, so `is_main_checkout` answers false wherever the suite runs. For
+/// payloads whose rule is cwd-INSENSITIVE by intent only; an assertion ABOUT a
+/// tree belongs in [`run_pm_guard_at`] with a fixture naming the tree it wants.
+/// Test: `pm_guard_allows_git_status_and_task`,
+/// `pm_guard_allows_agent_dispatch_from_pm`,
+/// `pm_guard_fanout_fails_open_on_indeterminate_caller`.
+fn run_pm_guard_outside_a_checkout(stdin_json: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    run_pm_guard_at(stdin_json, "http://127.0.0.1:1", dir.path())
 }
 
 /// [`run_pm_guard_at`] returning STDERR instead of stdout.


### PR DESCRIPTION
`run_pm_guard` (`tests/tm_hook_pm_guard.rs`) sets no working directory, so the guard's `hook_cwd` falls back to `std::env::current_dir()` — the test binary's own (`pm_guard.rs:360-365`). In CI that is the `actions/checkout` clone, a MAIN CHECKOUT; on a developer machine agents run inside `.claude/worktrees/…`, a LINKED WORKTREE. The ADR-0048 worktree grant fires only in a main checkout, so three tests asserting a silent allow got a rewrite or a deny in CI and passed everywhere else — same binary, same commit, verdict decided by where it ran.

Only those three move to a new `run_pm_guard_outside_a_checkout`, which pairs the existing `run_pm_guard_at` with an empty tempdir. `run_pm_guard` itself is unchanged for its other 92 call sites: pinning it globally would break `pm_guard_allows_worktree_add_under_project_dir_via_subagent_payload`, whose relative `.claude/worktrees/wt-x` target trips the #3955 tmp rule once resolved against a tempdir. Confirmed by hand — that payload denies with cwd set to a tempdir and allows without.

No coverage is lost. Every behaviour the three tripped over already has a dedicated cwd-controlled test: `pm_guard_grants_a_worktree_to_a_writer_in_a_main_checkout`, `pm_guard_grants_a_worktree_to_an_unknown_agent_in_a_main_checkout` (untyped dispatch included), `pm_guard_does_not_grant_a_worktree_outside_a_main_checkout`, `pm_guard_denies_a_task_dispatch_it_cannot_isolate`, plus the `tests` module in `src/bin/tm/commands/pm_guard_worktree_grant.rs`. Nothing is ignored, cfg-gated, excluded, or filtered out.

## Before / after, from both checkout types

Same test binary in every run below.

Before, cwd = main checkout:

```
running 3 tests
test pm_guard_fanout_fails_open_on_indeterminate_caller ... FAILED
test pm_guard_allows_agent_dispatch_from_pm ... FAILED
test pm_guard_allows_git_status_and_task ... FAILED

  left: "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"updatedInput\":{\"isolation\":\"worktree\",\"prompt\":\"go\"}}}"
 right: ""

test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 91 filtered out
```

Before, cwd = linked worktree — the same three pass, which is why this stayed invisible locally:

```
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 91 filtered out; finished in 5.78s
```

After, cwd = linked worktree:

```
running 94 tests
test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.67s
```

After, cwd = main checkout:

```
running 94 tests
test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.43s
```

## Gates — rung 3

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | exit 0 |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-mpm` | exit 0 — 5124 + 1736 + 1736 + 94 and the rest, 0 failed, 0 filtered out |
| `bash scripts/check_line_cap.sh` | exit 0 |
| `bash scripts/check_sld.sh` | exit 0 |
| `bash scripts/check_test_pointers.sh` | exit 0 — 25527 citations resolved, 0 dangling |

Test-only change (`tests/` only, no `src/**`), so no changelog fragment.

Closes #5708

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
