### PR TITLE
test(trusty-mpm): take process startup out of the pm-guard race window (#5914)

### DIFF
--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -54,10 +54,42 @@ fn isolated_home() -> tempfile::TempDir {
 /// cwd-sensitive rule; reach for [`run_pm_guard_outside_a_checkout`] or
 /// [`run_pm_guard_at`], which pin the directory. See #5708.
 fn run_pm_guard(stdin_json: &str, extra_env: &[(&str, &str)]) -> String {
+    finish_pm_guard(spawn_pm_guard(
+        stdin_json,
+        UNREACHABLE_DAEMON,
+        None,
+        extra_env,
+    ))
+}
+
+/// The daemon URL the URL-insensitive helpers pin: nothing listens on port 1,
+/// so a daemon call fails open on a refused connection, never on a timeout.
+const UNREACHABLE_DAEMON: &str = "http://127.0.0.1:1";
+
+/// Spawn `tm hook --pm-guard` and hand back the running child (#5914).
+///
+/// Why: the concurrency test needs both children STARTED before either is
+/// collected, so it cannot use a helper that waits. Splitting spawn from
+/// collect also gives this file one place that scrubs the environment — five
+/// `env_remove` calls had been copied into three spawn sites, which is how one
+/// of them drifts into inheriting an operator escape hatch from the runner and
+/// quietly asserting nothing.
+/// What: builds the child, writes `stdin_json`, closes stdin, and returns
+/// without waiting. `cwd` of `None` inherits the runner's directory, which is
+/// [`run_pm_guard`]'s documented behaviour.
+/// Test: every helper below routes through it, and
+/// `pm_guard_denies_the_second_of_two_simultaneous_dispatches` is the one
+/// caller that needs the un-waited child.
+fn spawn_pm_guard(
+    stdin_json: &str,
+    url: &str,
+    cwd: Option<&std::path::Path>,
+    extra_env: &[(&str, &str)],
+) -> std::process::Child {
     let bin = env!("CARGO_BIN_EXE_tm");
     let mut command = Command::new(bin);
     command
-        .args(["--url", "http://127.0.0.1:1", "hook", "--pm-guard"])
+        .args(["--url", url, "hook", "--pm-guard"])
         .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
         .env_remove("CLAUDE_MPM_SUB_AGENT")
         .env_remove("TRUSTY_MPM_PM_UNRESTRICTED")
@@ -66,20 +98,27 @@ fn run_pm_guard(stdin_json: &str, extra_env: &[(&str, &str)]) -> String {
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
     for (k, v) in extra_env {
         command.env(k, v);
     }
     let mut child = command
         .spawn()
         .expect("failed to spawn `tm hook --pm-guard`");
-
     child
         .stdin
         .take()
         .expect("child stdin")
         .write_all(stdin_json.as_bytes())
         .expect("write stdin");
+    child
+}
 
+/// Collect a child started by [`spawn_pm_guard`], asserting the fail-open
+/// contract (`exit 0`, always) and returning its stdout.
+fn finish_pm_guard(child: std::process::Child) -> String {
     let output = child
         .wait_with_output()
         .expect("wait for tm hook --pm-guard");
@@ -518,6 +557,38 @@ fn pm_guard_denies_composition_hidden_verb() {
     assert_denied(&run_pm_guard(redirect, &[("HOME", &home2_s)]));
 }
 
+/// A working directory outside every root in `WORKTREE_TMP_DENYLIST_ROOTS`
+/// (`pm_guard_bash/mod.rs`), used to pin the two ALLOW cases below (#5914).
+///
+/// Why: `resolves_under_denylisted_tmp` is purely lexical and never touches the
+/// filesystem, so this path does not have to exist — and must not, since a
+/// directory that existed as a git checkout would drag the ADR-0048 rules into
+/// a test about the worktree-tmp rule.
+const NON_DENYLISTED_CWD: &str = "/projects/example-repo";
+
+/// A `git worktree add` payload whose target is the in-project convention and
+/// whose working directory is stated rather than inherited (#5914).
+///
+/// Why: the guard resolves a RELATIVE worktree target against `hook_cwd` —
+/// the payload's own `cwd` field, falling back to the guard process's
+/// directory. With no `cwd` in the payload the verdict became the RUNNER's:
+/// run from a scratch worktree under `/private/tmp`, the two ALLOW assertions
+/// below both saw a DENY, because the resolved target landed under a
+/// denylisted root. That is the test's location deciding the test's outcome.
+/// What: emits the payload with `cwd` set to [`NON_DENYLISTED_CWD`], and
+/// `agent_id` present only when the caller is exercising the native-subagent
+/// shape.
+/// Test: `pm_guard_allows_worktree_add_under_project_dir_via_subagent_payload`,
+/// `pm_guard_claude_mpm_sub_agent_env_still_allows_everything_else`.
+fn in_project_worktree_add_payload(agent_id: Option<&str>) -> String {
+    let agent = agent_id
+        .map(|id| format!(r#""agent_id":"{id}","#))
+        .unwrap_or_default();
+    format!(
+        r#"{{"hook_event_name":"PreToolUse",{agent}"cwd":"{NON_DENYLISTED_CWD}","tool_name":"Bash","tool_input":{{"command":"git worktree add .claude/worktrees/wt-x"}}}}"#
+    )
+}
+
 #[test]
 fn pm_guard_blocks_worktree_add_under_tmp_for_pm_own_call() {
     // The PM's own (non-subagent) `git worktree add /tmp/...` must be denied
@@ -597,7 +668,9 @@ fn pm_guard_claude_mpm_sub_agent_env_still_allows_everything_else() {
     // Edit, which `pm_guard_sub_agent_env_allows_all` already covers, and a
     // worktree add targeting an in-project path.
     let ok_worktree = run_pm_guard(
-        r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git worktree add .claude/worktrees/wt-x"}}"#,
+        // #5914: the payload names its own working directory, so the relative
+        // target resolves the same wherever the suite runs.
+        &in_project_worktree_add_payload(None),
         &[("CLAUDE_MPM_SUB_AGENT", "1")],
     );
     assert_eq!(
@@ -647,9 +720,11 @@ fn pm_guard_unrestricted_env_still_allows_worktree_add_under_tmp() {
 fn pm_guard_allows_worktree_add_under_project_dir_via_subagent_payload() {
     // The companion positive case: the SAME subagent payload shape, but
     // targeting the documented in-project convention, must be allowed.
-    let payload = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-xyz789","tool_name":"Bash","tool_input":{"command":"git worktree add .claude/worktrees/wt-x"}}"#;
+    // #5914: the payload names its own working directory, so the relative
+    // target resolves the same wherever the suite runs.
+    let payload = in_project_worktree_add_payload(Some("agent-xyz789"));
     assert_eq!(
-        run_pm_guard(payload, &[]).trim(),
+        run_pm_guard(&payload, &[]).trim(),
         "",
         "an in-project worktree target must be allowed even unbudgeted \
          (worktree add is not a budget-eligible file-change deny)"
@@ -882,7 +957,7 @@ fn run_pm_guard_at(stdin_json: &str, url: &str, cwd: &std::path::Path) -> String
 /// `pm_guard_fanout_fails_open_on_indeterminate_caller`.
 fn run_pm_guard_outside_a_checkout(stdin_json: &str) -> String {
     let dir = tempfile::tempdir().expect("tempdir");
-    run_pm_guard_at(stdin_json, "http://127.0.0.1:1", dir.path())
+    run_pm_guard_at(stdin_json, UNREACHABLE_DAEMON, dir.path())
 }
 
 /// [`run_pm_guard_at`] returning STDERR instead of stdout.
@@ -895,25 +970,7 @@ fn run_pm_guard_outside_a_checkout(stdin_json: &str) -> String {
 /// silent regression there would leave every test green.
 /// What: as [`run_pm_guard_at`], but hands back the child's stderr.
 fn run_pm_guard_at_stderr(stdin_json: &str, url: &str, cwd: &std::path::Path) -> String {
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let mut child = Command::new(bin)
-        .args(["--url", url, "hook", "--pm-guard"])
-        .current_dir(cwd)
-        .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
-        .env_remove("CLAUDE_MPM_SUB_AGENT")
-        .env_remove("TRUSTY_MPM_PM_UNRESTRICTED")
-        .env_remove("TM_MANAGED_SESSION_ID")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("failed to spawn `tm hook --pm-guard`");
-    child
-        .stdin
-        .take()
-        .expect("child stdin")
-        .write_all(stdin_json.as_bytes())
-        .expect("write stdin");
+    let child = spawn_pm_guard(stdin_json, url, Some(cwd), &[]);
     let output = child.wait_with_output().expect("wait");
     assert!(output.status.success(), "the guard must always exit 0");
     String::from_utf8(output.stderr).expect("stderr is utf8")
@@ -929,38 +986,7 @@ fn run_pm_guard_at_with_env(
     cwd: &std::path::Path,
     extra_env: &[(&str, &str)],
 ) -> String {
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let mut command = Command::new(bin);
-    command
-        .args(["--url", url, "hook", "--pm-guard"])
-        .current_dir(cwd)
-        .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
-        .env_remove("CLAUDE_MPM_SUB_AGENT")
-        .env_remove("TRUSTY_MPM_PM_UNRESTRICTED")
-        .env_remove("TRUSTY_MPM_PM_DENY_BY_DEFAULT")
-        .env_remove("TM_MANAGED_SESSION_ID")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    for (k, v) in extra_env {
-        command.env(k, v);
-    }
-    let mut child = command
-        .spawn()
-        .expect("failed to spawn `tm hook --pm-guard`");
-    child
-        .stdin
-        .take()
-        .expect("child stdin")
-        .write_all(stdin_json.as_bytes())
-        .expect("write stdin");
-    let output = child.wait_with_output().expect("wait");
-    assert!(
-        output.status.success(),
-        "tm hook --pm-guard must always exit 0 (fail-open): stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    String::from_utf8(output.stdout).expect("stdout is utf8")
+    finish_pm_guard(spawn_pm_guard(stdin_json, url, Some(cwd), extra_env))
 }
 
 /// A one-shot HTTP stand-in for the daemon's shared-tree-dispatch route.
@@ -1038,6 +1064,12 @@ struct CapturedRequest(std::sync::mpsc::Receiver<String>);
 
 impl CapturedRequest {
     /// The forwarded hook payload the guard sent, or `None` if nothing arrived.
+    ///
+    /// The five seconds are a deadlock backstop, not a wait, so they carry no
+    /// load sensitivity (#5914). Every caller collects the guard child first,
+    /// and the mock sends on this channel BEFORE it writes the response the
+    /// child is waiting for — so the value is already queued by the time any
+    /// caller asks, and the receive returns without blocking.
     fn posted(&self) -> Option<serde_json::Value> {
         let raw = self
             .0
@@ -1215,6 +1247,29 @@ fn serve_delegation_router_behind_a_barrier(expected: usize) -> (String, tempfil
     (format!("http://{addr}"), dir)
 }
 
+/// Run one throwaway `tm hook --pm-guard` so the next exec is not the cold one
+/// (#5914).
+///
+/// Why: the concurrency test below is the only test whose correctness depends
+/// on how long a child takes to START, because the barrier holds one child's
+/// request open across the other's startup and the guard's HTTP client gives up
+/// after 2 s. Paging a ~100 MB debug binary in is the whole of that cost, and it
+/// is paid once per machine, not once per exec — so moving it ahead of the
+/// barrier removes it from the window entirely rather than budgeting for it.
+/// What: the cheapest complete path through the same binary — a `Read` payload,
+/// which no rule gates and which never dials the daemon. The verdict is
+/// discarded; only the page cache it leaves behind is wanted.
+fn prewarm_pm_guard_binary() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"/x/a.rs"}}"#;
+    let verdict = run_pm_guard_at(payload, UNREACHABLE_DAEMON, dir.path());
+    assert_eq!(
+        verdict.trim(),
+        "",
+        "the warm-up payload must be one no rule gates"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn pm_guard_denies_the_second_of_two_simultaneous_dispatches() {
     // #5324, the window #4480 left open. Two `Agent` dispatches issued in one PM
@@ -1242,31 +1297,47 @@ async fn pm_guard_denies_the_second_of_two_simultaneous_dispatches() {
     // through `claim_shared_tree_dispatch` directly with no scheduler in the
     // way. Treat the two as a pair: this one proves the wiring, that one proves
     // the mutual exclusion.
+    // #5914: the barrier holds the FIRST child's HTTP request open until the
+    // SECOND child's arrives, and `post_shared_tree` gives up after 2 s and
+    // fails OPEN. So the whole of the second child's process startup sits
+    // inside a 2 s budget. A COLD first exec of `tm` measured 1.5 s on this
+    // machine against 40 ms warm, and under a parallel `cargo build` it crossed
+    // the budget: the held request timed out, its guard read the timeout as
+    // "nobody else is here", and BOTH dispatches were admitted — the reported
+    // `got: ["", ""]`. Two changes take startup out of the window, neither of
+    // them a tuned delay: `prewarm_pm_guard_binary` pays the cold-exec cost
+    // before the barrier is armed, and both children are forked back to back
+    // from this one thread, so what remains between their arrivals is two warm
+    // execs, not a thread hand-off plus a page-in.
     let (url, _dir) = serve_delegation_router_behind_a_barrier(2);
     let cwd = tempfile::tempdir().expect("tempdir");
+    prewarm_pm_guard_binary();
 
-    let mut children = Vec::new();
-    for tool_use_id in ["toolu_race_a", "toolu_race_b"] {
-        let payload = format!(
-            r#"{{"hook_event_name":"PreToolUse","session_id":"11111111-1111-1111-1111-111111111111","tool_use_id":"{tool_use_id}","tool_name":"Agent","tool_input":{{"subagent_type":"rust-engineer","prompt":"go"}}}}"#
-        );
-        let url = url.clone();
-        let dir = cwd.path().to_path_buf();
-        children.push(std::thread::spawn(move || {
-            run_pm_guard_at(&payload, &url, &dir)
-        }));
-    }
+    let started = std::time::Instant::now();
+    let children: Vec<std::process::Child> = ["toolu_race_a", "toolu_race_b"]
+        .iter()
+        .map(|tool_use_id| {
+            let payload = format!(
+                r#"{{"hook_event_name":"PreToolUse","session_id":"11111111-1111-1111-1111-111111111111","tool_use_id":"{tool_use_id}","tool_name":"Agent","tool_input":{{"subagent_type":"rust-engineer","prompt":"go"}}}}"#
+            );
+            spawn_pm_guard(&payload, &url, Some(cwd.path()), &[])
+        })
+        .collect();
 
     let verdicts: Vec<String> = children
         .into_iter()
-        .map(|h| h.join().expect("guard thread").trim().to_string())
+        .map(|child| finish_pm_guard(child).trim().to_string())
         .collect();
+    let elapsed = started.elapsed();
 
     let allowed = verdicts.iter().filter(|v| v.is_empty()).count();
     let denied: Vec<&String> = verdicts.iter().filter(|v| !v.is_empty()).collect();
     assert_eq!(
         allowed, 1,
-        "exactly one of two simultaneous dispatches may be admitted, got: {verdicts:?}"
+        "exactly one of two simultaneous dispatches may be admitted, got: {verdicts:?} \
+         (both children ran in {elapsed:?}; at or past the guard's 2 s client budget in \
+         `post_shared_tree` the held request timed out and failed open — that is the \
+         machine, not this rule regressing, see #5914)"
     );
     assert_eq!(denied.len(), 1, "and exactly one must be denied");
     assert_denied(denied[0]);


### PR DESCRIPTION
Closes #5914. Test-only; no production source changed.

## What was wrong

**Timing.** `pm_guard_denies_the_second_of_two_simultaneous_dispatches` holds
the first child's HTTP request at a barrier until the second child's request
arrives. `post_shared_tree` (`pm_guard_dispatch.rs:548`) gives up after 2 s and
fails OPEN, so the second child's entire process startup sat inside a 2 s
budget. Reproduced by forcing the skew:

```
skew 2.5 s -> allowed=1 shapes=["DENY(2.650354541s)", "ALLOW(13.426166ms)"]
skew 6.0 s -> allowed=2 shapes=["ALLOW(3.590520708s)", "ALLOW(42.619916ms)"]
```

The 6 s row is the reported failure exactly — both admitted, both verdicts
empty. The held guard waited 3.59 s: startup plus the 2 s timeout, then read
the timeout as "nobody else is here".

The first `tm` exec in a run measured **1.84 s idle and 2.03–2.07 s under a
parallel cold `cargo build`** — past the budget on its own.

**Working directory.** `pm_guard_allows_worktree_add_under_project_dir_via_subagent_payload`
and `pm_guard_claude_mpm_sub_agent_env_still_allows_everything_else` assert an
ALLOW for the relative target `.claude/worktrees/wt-x`. The guard resolves a
relative target against `hook_cwd` — the payload's `cwd` field, falling back to
the process directory — so with no `cwd` in the payload the runner's location
decided the verdict. Run from `/private/tmp`, both DENIED:

```
test result: FAILED. 92 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
```

## What changed

- `prewarm_pm_guard_binary` runs one throwaway guard before the barrier is
  armed, so the cold-exec cost is paid outside the window.
- Both children are forked back to back from one thread via `spawn_pm_guard`,
  instead of from two spawned threads, so a thread hand-off is not part of the
  skew either.
- The two ALLOW payloads state their own working directory
  (`in_project_worktree_add_payload`). Resolution is lexical and never touches
  the filesystem, so the path need not exist.
- Three copies of the child-process setup fold into `spawn_pm_guard` /
  `finish_pm_guard` — that split is what makes an un-waited child available.
- `CapturedRequest::posted`'s five seconds are documented as a deadlock
  backstop, not a wait: the mock sends before writing the response the child
  waits for, so the value is queued before any caller asks.

No sleep, no timing constant, no widened tolerance, no `#[ignore]`, no deleted
assertion. The race test still requires exactly one admit and exactly one deny.

After the fix the race resolves in **14 ms idle, 24–45 ms under load-33**,
against the same 2 s budget.

## What would still make the timing test fail

The window is now the gap between two WARM `tm` execs. A warm exec measured
50–92 ms under load-33; the race as a whole ran in 24–45 ms. For a failure the
gap between the two arrivals would have to reach 2 s — roughly 50x the observed
total. It is not zero: this is a smaller real-time window, not the absence of
one.

Making it provably zero needs a production seam, which a test-only PR should
not open. Either would do it:

- expose the dispatch decision as a library entry point (it lives under
  `src/bin/tm/`), so two in-process tasks can race it with no process boundary
  and no HTTP client at all; or
- make `post_shared_tree`'s 2 s timeout injectable, so the harness can remove
  the budget rather than fit inside it.

## Adjacent finding, not fixed here

`WORKTREE_TMP_DENYLIST_ROOTS` lists `/tmp`, `/private/tmp` and `/var/folders`,
but not `/private/var/folders`. On macOS `/var` is a symlink to `/private/var`,
so `std::env::current_dir()` inside `$TMPDIR` returns the `/private/var/...`
spelling and a RELATIVE worktree target resolved from there misses the
denylist. An explicit `/var/folders/...` argument is still caught. Production
behaviour, out of scope for this PR.

## Gates — ladder rung 2 (test-only stabilization)

```
cargo fmt --check                                 EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-mpm                          EXIT=0
  test result: ok. 5124 passed; 0 failed; 7 ignored
  test result: ok. 1736 passed; 0 failed; 1 ignored
  test result: ok. 1736 passed; 0 failed; 1 ignored
  test result: ok. 94 passed; 0 failed; 0 ignored   <- tm_hook_pm_guard
  (46 further targets, all ok)
bash scripts/check_line_cap.sh                    EXIT=0
bash scripts/check_changelog_fragment.sh          EXIT=0
  "no crate source changed (docs-only / CI-only / test-only) — OK"
```

No changelog fragment: the repo's own gate reports none is owed for a test-only
change.

### Ten idle runs, `cargo test -p trusty-mpm --test tm_hook_pm_guard`

```
load averages: 12.40 15.68 11.84
run  1: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.85s
run  2: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.94s
run  3: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.92s
run  4: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.91s
run  5: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.90s
run  6: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.01s
run  7: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.91s
run  8: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.85s
run  9: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.97s
run 10: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.97s
```

### Eight runs under a parallel cold `cargo build --workspace --all-targets -j 16`

```
load averages: 36.14 24.45 16.02
run  1: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.45s
run  2: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.99s
run  3: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.53s
run  4: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.41s
run  5: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.20s
run  6: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.51s
run  7: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.69s
run  8: test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.53s
load averages: 36.51 25.75 16.83
```

Run 5 at 6.20 s is 3x the idle baseline — the contention shape that produced
the original failure — and still green.

### Twenty isolated runs of the three named tests, under load, from `/private/tmp`

Same directory that reproduced the cwd failure, same parallel build running.

```
load averages: 37.17 26.23 17.10
race  1: test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 93 filtered out; finished in 0.05s
race  2: test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 93 filtered out; finished in 0.04s
race  3: test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 93 filtered out; finished in 0.04s
race  4: test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 93 filtered out; finished in 0.04s
race  5: test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 93 filtered out; finished in 0.04s
race  6: test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 93 filtered out; finished in 0.05s
race  7: test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 93 filtered out; finished in 0.07s
race  8: test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 93 filtered out; finished in 0.05s
race  9: test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 93 filtered out; finished in 0.05s
race 10: test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 93 filtered out; finished in 0.05s
cwd   1: test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 92 filtered out; finished in 0.02s
cwd   2: test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 92 filtered out; finished in 0.04s
cwd   3: test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 92 filtered out; finished in 0.02s
cwd   4: test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 92 filtered out; finished in 0.02s
cwd   5: test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 92 filtered out; finished in 0.02s
cwd   6: test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 92 filtered out; finished in 0.02s
cwd   7: test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 92 filtered out; finished in 0.02s
cwd   8: test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 92 filtered out; finished in 0.02s
cwd   9: test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 92 filtered out; finished in 0.02s
cwd  10: test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 92 filtered out; finished in 0.02s
```

Full suite from `/private/tmp` after the fix: `94 passed; 0 failed`. Before the
fix from the same directory: `92 passed; 2 failed`.

Also re-run post-rebase onto `origin/main`: `94 passed; 0 failed`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
