### PR TITLE
refactor(trusty-mpm): route both decommission entry points through one implementation

### DIFF
--- a/crates/trusty-mpm/changelog.d/5913-unify-decommission-routing.md
+++ b/crates/trusty-mpm/changelog.d/5913-unify-decommission-routing.md
@@ -1,6 +1,10 @@
 Changed
 
-- Both decommission entry points now route through one implementation,
+- The `tm projects` TUI's `[d]` decommission hotkey now routes through the same
+  shared implementation as every other entry point, so it too repairs the base
+  repo's worktree bookkeeping. It called the daemon endpoint directly and left a
+  stale `git worktree list` entry behind — the same bug the rest of #5913 closes.
+- Every decommission entry point now routes through one implementation,
   `CommandExecutor::decommission_managed_id`
   (closes [#5913](https://github.com/bobmatnyc/trusty-tools/issues/5913)). The
   bulk prune sweep used to reach the endpoint through its own hand-rolled

--- a/crates/trusty-mpm/changelog.d/5913-unify-decommission-routing.md
+++ b/crates/trusty-mpm/changelog.d/5913-unify-decommission-routing.md
@@ -1,0 +1,18 @@
+Changed
+
+- Both decommission entry points now route through one implementation,
+  `CommandExecutor::decommission_managed_id`
+  (closes [#5913](https://github.com/bobmatnyc/trusty-tools/issues/5913)). The
+  bulk prune sweep used to reach the endpoint through its own hand-rolled
+  `reqwest` POST, independent of the routed `tm session decommission <id>` verb;
+  that split is what let #5899's wording divergence exist, and it carried a
+  second divergence with it — only the bulk path repaired the base repo's
+  worktree bookkeeping. `tm session decommission <id>` now runs
+  `git worktree prune` on the same signal the sweep always used, so
+  decommissioning a tm-owned worktree interactively no longer leaves a stale
+  entry in `git worktree list`.
+- A 404 from the decommission endpoint is mapped to an error naming the session
+  once, in `DaemonClient::decommission_managed_session`, rather than at each
+  entry point. `tm sessions prune`'s fail-closed sweep still records a missing
+  session as a failed row, and no longer depends on which caller issued the
+  request.

--- a/crates/trusty-mpm/changelog.d/5913-unify-decommission-routing.md
+++ b/crates/trusty-mpm/changelog.d/5913-unify-decommission-routing.md
@@ -17,6 +17,6 @@ Changed
   entry in `git worktree list`.
 - A 404 from the decommission endpoint is mapped to an error naming the session
   once, in `DaemonClient::decommission_managed_session`, rather than at each
-  entry point. `tm sessions prune`'s fail-closed sweep still records a missing
-  session as a failed row, and no longer depends on which caller issued the
-  request.
+  entry point. `tm session prune-idle`'s fail-closed sweep still records a
+  missing session as a failed row, and no longer depends on which caller issued
+  the request.

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -31,7 +31,7 @@
 
 use std::io::IsTerminal as _;
 
-use trusty_mpm::client::{ManagedDecommissionOutcome, ManagedSessionSummary};
+use trusty_mpm::client::ManagedSessionSummary;
 
 use super::managed_route::decommission_message;
 use crate::cli::CatalogAction;
@@ -525,25 +525,55 @@ pub(crate) async fn session_resume(
     Ok(())
 }
 
+/// Decommission `id` and return the one line the CLI reports for it.
+///
+/// Why (#5913): this used to be a second, hand-rolled `reqwest` POST to the
+/// decommission endpoint, independent of the routed
+/// `tm session decommission <id>` verb. Two paths to one endpoint is what let
+/// #5899's wording divergence happen, and the routing carried a second
+/// divergence with it: only this path repaired the base repo's worktree
+/// bookkeeping. Both now call
+/// [`CommandExecutor::decommission_managed_id`](trusty_mpm::client::CommandExecutor::decommission_managed_id).
+/// Splitting the line's construction from its `println!` is the same pattern
+/// [`deprecation_message`] uses, and it is what lets
+/// `decommission_entry_points_agree_on_every_verdict` compare this path's output
+/// against the routed one without capturing process stdout.
+/// What: calls the shared implementation with the canonical id the caller
+/// already holds — no fuzzy resolution, so the bulk sweep still costs one
+/// request per session — and renders the verdict through
+/// [`super::managed_route::decommission_message`], the same renderer
+/// [`super::managed_route::render_cli`] uses. A missing id propagates the shared
+/// transport's `Err` (#2457); `prune.rs`'s sweep records that as a failed row.
+/// Test: `decommission_entry_points_agree_on_every_verdict`;
+/// `session_decommission_not_found_errors`.
+async fn session_decommission_line(
+    client: &reqwest::Client,
+    url: &str,
+    id: &str,
+) -> anyhow::Result<String> {
+    let outcome = super::managed_route::executor(client, url)
+        .decommission_managed_id(id)
+        .await?;
+    Ok(decommission_message(
+        &outcome.summary.id,
+        outcome.workspace_removed,
+    ))
+}
+
 /// `tm session decommission <id>` — full teardown (may or may not remove workspace).
 ///
 /// Why: an adopted or local-path workspace was never tm's to delete, a worktree
 /// holding unsaved work is refused, and a removal can fail — so decommission
 /// often leaves the workspace on disk, and only the daemon knows which happened.
-/// This handler reports that verdict rather than assuming removal. When the
-/// workspace WAS removed and a pre-decommission path came back, it also runs
-/// `git worktree prune` on the parent directory so the base repo's worktree
-/// bookkeeping is cleaned up immediately instead of at the next GC pass.
-/// What: POSTs `/api/v1/sessions/managed/{id}/decommission`, decodes the typed
-/// [`ManagedDecommissionOutcome`], and prints
-/// [`super::managed_route::decommission_message`]'s line for the verdict it
-/// carries. Only `workspace_removed == Some(true)` triggers the
-/// `git worktree prune` (best-effort; errors are suppressed).
+/// This handler reports that verdict rather than assuming removal.
+/// What: prints [`session_decommission_line`]'s rendering of the daemon's
+/// verdict. The daemon call and the base-repo worktree cleanup both live in the
+/// shared implementation that helper calls (#5913).
 /// A missing id is a genuine failure to decommission the requested session
 /// (#2457) — printing "not found" and returning `Ok(())` let a script/CI
-/// check treat it as success, so this now returns `Err` (non-zero exit)
-/// instead. `prune.rs`'s bulk teardown loop (the only other caller) already
-/// propagates this `Err` with `?`, matching its established fail-closed
+/// check treat it as success, so this returns `Err` (non-zero exit) instead.
+/// `prune.rs`'s bulk teardown loop (the only other caller) catches that `Err`
+/// and records the row as failed, matching its established fail-closed
 /// convention (#1508).
 /// Test: `session_decommission_prints_daemon_verdict_over_http`;
 /// `session_decommission_not_found_errors` covers the #2457 exit-code fix; the
@@ -553,34 +583,7 @@ pub(crate) async fn session_decommission(
     url: &str,
     id: String,
 ) -> anyhow::Result<()> {
-    let resp = client
-        .post(format!("{url}/api/v1/sessions/managed/{id}/decommission"))
-        .send()
-        .await?;
-    if resp.status() == reqwest::StatusCode::NOT_FOUND {
-        anyhow::bail!("managed session '{id}' not found");
-    }
-    // #5899: decode the typed response and render via the ONE message helper the
-    // routed `tm session decommission` verb also uses — key-fishing through a raw
-    // `serde_json::Value` here, and a hardcoded string there, is how the two paths
-    // drifted into disagreeing about what happened.
-    let outcome: ManagedDecommissionOutcome = resp.error_for_status()?.json().await?;
-    println!(
-        "{}",
-        decommission_message(&outcome.summary.id, outcome.workspace_removed)
-    );
-    if outcome.workspace_removed == Some(true) {
-        // Prune the parent of the (now-deleted) workspace so the base repo's
-        // worktree bookkeeping is cleaned up immediately.
-        if let Some(ws_was) = outcome.workspace_path_was.as_deref() {
-            let parent = std::path::Path::new(ws_was)
-                .parent()
-                .unwrap_or(std::path::Path::new(ws_was));
-            let _ = std::process::Command::new("git")
-                .args(["-C", &parent.to_string_lossy(), "worktree", "prune"])
-                .output();
-        }
-    }
+    println!("{}", session_decommission_line(client, url, &id).await?);
     Ok(())
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_route.rs
@@ -30,8 +30,10 @@ use crate::cli::SessionAction;
 /// must reuse it (timeouts/pool) rather than minting a default one.
 /// What: returns `CommandExecutor::with_client(client.clone(), url)` — cloning a
 /// `reqwest::Client` is cheap (`Arc` internally), so the pool/settings persist.
+/// `pub(crate)` since #5913: `commands::managed`'s decommission handler builds
+/// its executor here rather than minting a second one.
 /// Test: exercised transitively by every routed managed handler's coverage.
-fn executor(client: &reqwest::Client, url: &str) -> CommandExecutor {
+pub(crate) fn executor(client: &reqwest::Client, url: &str) -> CommandExecutor {
     CommandExecutor::with_client(client.clone(), url.to_string())
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -847,18 +847,125 @@ async fn session_resume_zombie_active_tmux_absent_reconciles_and_restarts() {
 }
 
 /// #2457: a 404 from `decommission` on a nonexistent id must propagate as
-/// `Err` — `prune.rs`'s bulk loop relies on this via `?`.
+/// `Err` — `prune.rs`'s bulk sweep records that `Err` as a failed row, and a
+/// softened 404 would make a raced session read as a clean teardown.
+///
+/// #5913 moved the mapping into the shared transport
+/// (`DaemonClient::decommission_managed_session`) when both entry points
+/// converged onto one implementation; this test is what holds it there.
+///
+/// Two ids, because they take different daemon branches. `nonexistent-id` does
+/// not parse as a UUID and comes back 400 — which is what this test asserted
+/// before #5913, so it never once exercised a 404. A well-formed id absent from
+/// the store is the real 404, and the friendly message proves the mapping (not
+/// `error_for_status`'s generic status text) produced it.
 #[tokio::test]
 async fn session_decommission_not_found_errors() {
     let url = spawn_test_daemon().await;
     let client = reqwest::Client::new();
+
     let err = session_decommission(&client, &url, "nonexistent-id".to_string())
         .await
-        .expect_err("a missing managed session must be a hard failure, not a silent Ok(())");
+        .expect_err("a malformed id must be a hard failure, not a silent Ok(())");
     assert!(
         err.to_string().contains("nonexistent-id"),
-        "error should name the missing id: {err}"
+        "error should name the rejected id: {err}"
     );
+
+    let absent = "11111111-2222-3333-4444-555555555555";
+    let err = session_decommission(&client, &url, absent.to_string())
+        .await
+        .expect_err("a missing managed session must be a hard failure, not a silent Ok(())");
+    assert_eq!(
+        err.to_string(),
+        format!("managed session '{absent}' not found"),
+        "the 404 mapping must survive: prune's sweep counts this Err as a failed row"
+    );
+}
+
+/// Serve a canned decommission response, plus the list route the routed entry
+/// point resolves against.
+///
+/// Why: the `workspace_removed: None` arm means "a daemon old enough to send no
+/// verdict at all", which the current daemon can never produce — a canned
+/// response is the only way to drive it. Using the same stub for all three
+/// verdicts keeps the two entry points reading byte-identical input.
+/// What: `GET /api/v1/sessions/managed` returns one summary carrying
+/// [`STUB_ID`]; `POST .../{id}/decommission` returns that summary flattened with
+/// the requested verdict and no `workspace_path_was` (so neither path shells out
+/// to git). Returns the base URL.
+/// Test: `decommission_entry_points_agree_on_every_verdict`.
+async fn spawn_decommission_stub(workspace_removed: Option<bool>) -> String {
+    use axum::routing::{get, post};
+
+    let list = serde_json::json!({
+        "sessions": [{ "id": STUB_ID, "name": "tm-5913", "state": "active" }]
+    });
+    let outcome = serde_json::json!({
+        "id": STUB_ID,
+        "name": "tm-5913",
+        "state": "decommissioned",
+        "workspace_removed": workspace_removed,
+        "workspace_path_was": serde_json::Value::Null,
+    });
+
+    let app = axum::Router::new()
+        .route(
+            "/api/v1/sessions/managed",
+            get(move || std::future::ready(axum::Json(list.clone()))),
+        )
+        .route(
+            "/api/v1/sessions/managed/{id}/decommission",
+            post(move || std::future::ready(axum::Json(outcome.clone()))),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, app).into_future());
+    format!("http://{addr}")
+}
+
+/// The managed id both entry points target against [`spawn_decommission_stub`].
+const STUB_ID: &str = "11111111-2222-3333-4444-555555555555";
+
+/// #5913: both decommission entry points must report the same thing for the same
+/// daemon response, across all three `workspace_removed` verdicts.
+///
+/// The bulk sweep used to reach the endpoint through its own hand-rolled POST,
+/// which is how #5899's wording divergence survived undetected. They now share
+/// one implementation, and this holds them to one observable result: the bulk
+/// path's line (via [`super::session_decommission_line`], the string
+/// `session_decommission` prints) compared against the routed path's line (via
+/// `render_cli`). A future change to either path that the other does not get
+/// fails here.
+#[tokio::test]
+async fn decommission_entry_points_agree_on_every_verdict() {
+    use trusty_mpm::client::{CommandExecutor, TrustyCommand};
+
+    for verdict in [Some(true), Some(false), None] {
+        let url = spawn_decommission_stub(verdict).await;
+        let client = reqwest::Client::new();
+
+        let bulk = super::session_decommission_line(&client, &url, STUB_ID)
+            .await
+            .unwrap_or_else(|e| panic!("verdict {verdict:?}: bulk path failed: {e}"));
+        let routed = super::super::managed_route::render_cli(
+            &CommandExecutor::with_client(client.clone(), url.clone())
+                .execute(TrustyCommand::ManagedDecommission {
+                    target: STUB_ID.to_string(),
+                })
+                .await,
+        );
+
+        assert_eq!(
+            bulk, routed,
+            "verdict {verdict:?}: the two entry points disagree"
+        );
+        assert_eq!(
+            bulk,
+            super::super::managed_route::decommission_message(STUB_ID, verdict),
+            "verdict {verdict:?}: neither path may invent its own wording"
+        );
+    }
 }
 
 /// #2457: a 404 from `activity` on a nonexistent id must propagate as `Err`.

--- a/crates/trusty-mpm/src/client/executor/managed.rs
+++ b/crates/trusty-mpm/src/client/executor/managed.rs
@@ -314,7 +314,7 @@ impl CommandExecutor {
     /// | Telegram `/decommission`, Slack `/decommission` | [`Self::managed_decommission`] |
     /// | `tui::coordinator` `/kill`, `/decommission`, `/managed-decommission` | [`Self::managed_decommission`] |
     /// | `tui::project_ctl`'s `[d]` hotkey | `project_ctl::actions::dispatch` |
-    /// | `tm session prune`'s bulk sweep | `commands::managed::session_decommission_line` |
+    /// | `tm session prune-idle`'s bulk sweep | `commands::prune::prune_idle` → `commands::managed::session_decommission_line` |
     ///
     /// One caller of the endpoint deliberately stays out:
     /// `commands::session_picker_prune::decommission_dead_record` POSTs
@@ -322,10 +322,23 @@ impl CommandExecutor {
     /// workspace and so must never prune. It also reads the raw body to detect a
     /// daemon too old to honour `record_only`, which a typed response hides.
     ///
-    /// This covers every client-side path. The daemon's own in-process callers
-    /// (`daemon::mcp_session::session_decommission`, `daemon::idle_reaper`) sit
-    /// below this seam and call `SessionManager::decommission` directly, so they
-    /// do not get this repair — see #5913 for that follow-up.
+    /// This covers every client-side path. The daemon's own in-process callers sit
+    /// below this seam and call `SessionManager::decommission` directly, so none of
+    /// them gets this repair (#5949):
+    ///
+    /// - `daemon::mcp_session::session_decommission`
+    /// - `daemon::idle_reaper`
+    /// - `SessionManager::prune_managed` (`session_manager/prune.rs`), which backs
+    ///   `POST /api/v1/sessions/managed/prune` — plain `tm session prune`. This is
+    ///   the largest remaining gap, not a footnote: it is the bulk path operators
+    ///   actually use, so every tm-owned worktree it tears down leaves behind the
+    ///   stale `.git/worktrees` entry #5913 set out to close.
+    ///
+    /// That third one cannot be closed at this layer even in principle. The repair
+    /// needs the removed workspace's path, and `PrunedSession` — the wire response —
+    /// carries one only as `retained_workspace_path`, which is `Some` exactly when
+    /// the worktree was KEPT. A clean removal, the case that strands the git entry,
+    /// reports `None`, so no client could reconstruct where to prune.
     ///
     /// What: POSTs the decommission endpoint via the typed [`crate::client::DaemonClient`],
     /// logs the key names of any response field this client does not model yet,

--- a/crates/trusty-mpm/src/client/executor/managed.rs
+++ b/crates/trusty-mpm/src/client/executor/managed.rs
@@ -14,7 +14,9 @@
 //! Test: the `execute_managed_*` tests in `tests.rs` (wire-shape + dispatch).
 
 use super::CommandExecutor;
-use crate::client::http_client::{ManagedAdoptRequest, ManagedSessionSummary, ManagedSpawnRequest};
+use crate::client::http_client::{
+    ManagedAdoptRequest, ManagedDecommissionOutcome, ManagedSessionSummary, ManagedSpawnRequest,
+};
 use crate::client::resolver::resolve_target;
 use crate::client::result::{CommandResult, ManagedSessionView, ProjectFleetView};
 
@@ -297,6 +299,50 @@ impl CommandExecutor {
         }
     }
 
+    /// Decommission one session BY CANONICAL ID — the single implementation every
+    /// decommission entry point routes through (#5913).
+    ///
+    /// Why: two independent paths used to reach the decommission endpoint — this
+    /// executor for `tm session decommission <id>`, the TUI, Telegram and Slack;
+    /// and a hand-rolled `reqwest` POST in `commands::managed` for the bulk prune
+    /// sweep. They drifted: one printed a hardcoded "workspace removed" (#5899) and
+    /// only the other repaired the base repo's worktree bookkeeping. One
+    /// implementation is the repo's common-entry-point rule, and it is what stops
+    /// the next behaviour added here from diverging again.
+    /// What: POSTs the decommission endpoint via the typed [`crate::client::DaemonClient`],
+    /// logs the key names of any response field this client does not model yet,
+    /// repairs the base repo's worktree bookkeeping per
+    /// [`worktree_prune_dir`], and returns the daemon's whole verdict. A missing
+    /// session is an `Err` naming the id — the transport maps the 404, so the
+    /// prune sweep's fail-closed loop keeps counting it as a failed row.
+    /// Test: `decommission_managed_id_prunes_stale_worktree_bookkeeping`,
+    /// `decommission_entry_points_agree_on_every_verdict`,
+    /// `session_decommission_not_found_errors`.
+    pub async fn decommission_managed_id(
+        &self,
+        id: &str,
+    ) -> anyhow::Result<ManagedDecommissionOutcome> {
+        let outcome = self.client().decommission_managed_session(id).await?;
+        if !outcome.unrecognized.is_empty() {
+            tracing::debug!(
+                fields = ?outcome.unrecognized.keys().collect::<Vec<_>>(),
+                "decommission response carried fields this client does not model"
+            );
+        }
+        if let Some(dir) = worktree_prune_dir(&outcome) {
+            // Best-effort: a workspace that was never a git worktree makes this a
+            // no-op, and a git that fails has nothing to do with the teardown that
+            // already succeeded.
+            let out = std::process::Command::new("git")
+                .args(["-C", &dir.to_string_lossy(), "worktree", "prune"])
+                .output();
+            if let Err(e) = out {
+                tracing::debug!(dir = %dir.display(), "git worktree prune failed: {e}");
+            }
+        }
+        Ok(outcome)
+    }
+
     /// `managed-decommission` — decommission a session (terminal; removes the
     /// workspace only when tm provisioned it).
     ///
@@ -305,30 +351,53 @@ impl CommandExecutor {
     /// work is refused, and a removal can fail. The daemon reports which happened;
     /// this method used to discard that verdict, so every renderer downstream had
     /// to guess and the CLI guessed "removed" every time (#5899).
-    /// What: forwards the daemon's `workspace_removed` verdict into
-    /// [`CommandResult::ManagedLifecycle`] verbatim, `None` included, and logs the
-    /// key names of any response field this client does not model yet.
-    /// Test: `executor_decommission_reports_daemon_workspace_verdict` and
+    /// What: resolves the fuzzy id-or-name — the one step the bulk prune caller
+    /// does not need, since it already holds canonical ids — then delegates to
+    /// [`Self::decommission_managed_id`] and forwards the daemon's
+    /// `workspace_removed` verdict into [`CommandResult::ManagedLifecycle`]
+    /// verbatim, `None` included.
+    /// Test: `executor_decommission_reports_daemon_workspace_verdict`,
+    /// `decommission_entry_points_agree_on_every_verdict`,
     /// `decommission_message_honours_every_verdict`.
     pub(super) async fn managed_decommission(&self, target: &str) -> CommandResult {
         let id = match self.resolve_managed(target).await {
             Ok(s) => s.id,
             Err(err) => return err,
         };
-        match self.client().decommission_managed_session(&id).await {
+        match self.decommission_managed_id(&id).await {
             // #5899: carry the daemon's workspace verdict instead of dropping it.
-            Ok(outcome) => {
-                if !outcome.unrecognized.is_empty() {
-                    tracing::debug!(
-                        fields = ?outcome.unrecognized.keys().collect::<Vec<_>>(),
-                        "decommission response carried fields this client does not model"
-                    );
-                }
-                lifecycle(outcome.summary, "decommissioned", outcome.workspace_removed)
-            }
+            Ok(outcome) => lifecycle(outcome.summary, "decommissioned", outcome.workspace_removed),
             Err(e) => CommandResult::Error(format!("decommission failed: {e}")),
         }
     }
+}
+
+/// Where — if anywhere — a decommission must run `git worktree prune`.
+///
+/// Why: the daemon has two removal branches and only one of them leaves git's
+/// bookkeeping stale. An in-project worktree it did NOT own is removed with
+/// `git worktree remove`, which prunes daemon-side, and the daemon reports
+/// `workspace_path_was: None`. A workspace tm OWNED is removed with a plain
+/// `remove_dir_all`, which git never learns about — the entry lingers in `git
+/// worktree list` until something prunes it — and that is exactly the case the
+/// daemon reports a path for. So `workspace_path_was.is_some()` already IS the
+/// "git does not know yet" signal; this is not belt-and-braces on the branch
+/// that self-cleans, and it is not a duplicate prune either.
+/// What: returns the workspace's PARENT directory when the daemon both removed
+/// the workspace and named it, and `None` otherwise. The parent is used because
+/// the workspace itself is gone: git discovers the base repo by walking up from
+/// there, which finds it for an in-project layout and finds nothing (a harmless
+/// no-op) for a standalone clone.
+/// Test: `worktree_prune_dir_fires_only_on_a_named_removal`,
+/// `decommission_managed_id_prunes_stale_worktree_bookkeeping`.
+pub(super) fn worktree_prune_dir(
+    outcome: &ManagedDecommissionOutcome,
+) -> Option<std::path::PathBuf> {
+    if outcome.workspace_removed != Some(true) {
+        return None;
+    }
+    let was = std::path::Path::new(outcome.workspace_path_was.as_deref()?);
+    Some(was.parent().unwrap_or(was).to_path_buf())
 }
 
 /// Map a managed summary + verb to a [`CommandResult::ManagedLifecycle`].

--- a/crates/trusty-mpm/src/client/executor/managed.rs
+++ b/crates/trusty-mpm/src/client/executor/managed.rs
@@ -302,13 +302,31 @@ impl CommandExecutor {
     /// Decommission one session BY CANONICAL ID — the single implementation every
     /// decommission entry point routes through (#5913).
     ///
-    /// Why: two independent paths used to reach the decommission endpoint — this
-    /// executor for `tm session decommission <id>`, the TUI, Telegram and Slack;
-    /// and a hand-rolled `reqwest` POST in `commands::managed` for the bulk prune
-    /// sweep. They drifted: one printed a hardcoded "workspace removed" (#5899) and
-    /// only the other repaired the base repo's worktree bookkeeping. One
-    /// implementation is the repo's common-entry-point rule, and it is what stops
-    /// the next behaviour added here from diverging again.
+    /// Why: three independent paths used to reach the decommission endpoint, and
+    /// they drifted — one printed a hardcoded "workspace removed" (#5899) and only
+    /// one repaired the base repo's worktree bookkeeping. One implementation is
+    /// the repo's common-entry-point rule, and it is what stops the next behaviour
+    /// added here from diverging again. Every caller now routes through here:
+    ///
+    /// | Caller | Reaches this via |
+    /// |---|---|
+    /// | `tm session decommission <id>` | [`Self::managed_decommission`] |
+    /// | Telegram `/decommission`, Slack `/decommission` | [`Self::managed_decommission`] |
+    /// | `tui::coordinator` `/kill`, `/decommission`, `/managed-decommission` | [`Self::managed_decommission`] |
+    /// | `tui::project_ctl`'s `[d]` hotkey | `project_ctl::actions::dispatch` |
+    /// | `tm session prune`'s bulk sweep | `commands::managed::session_decommission_line` |
+    ///
+    /// One caller of the endpoint deliberately stays out:
+    /// `commands::session_picker_prune::decommission_dead_record` POSTs
+    /// `?record_only=true`, a different operation that must never remove a
+    /// workspace and so must never prune. It also reads the raw body to detect a
+    /// daemon too old to honour `record_only`, which a typed response hides.
+    ///
+    /// This covers every client-side path. The daemon's own in-process callers
+    /// (`daemon::mcp_session::session_decommission`, `daemon::idle_reaper`) sit
+    /// below this seam and call `SessionManager::decommission` directly, so they
+    /// do not get this repair — see #5913 for that follow-up.
+    ///
     /// What: POSTs the decommission endpoint via the typed [`crate::client::DaemonClient`],
     /// logs the key names of any response field this client does not model yet,
     /// repairs the base repo's worktree bookkeeping per
@@ -316,6 +334,7 @@ impl CommandExecutor {
     /// session is an `Err` naming the id — the transport maps the 404, so the
     /// prune sweep's fail-closed loop keeps counting it as a failed row.
     /// Test: `decommission_managed_id_prunes_stale_worktree_bookkeeping`,
+    /// `project_ctl_decommission_prunes_stale_worktree_bookkeeping`,
     /// `decommission_entry_points_agree_on_every_verdict`,
     /// `session_decommission_not_found_errors`.
     pub async fn decommission_managed_id(

--- a/crates/trusty-mpm/src/client/executor/mod.rs
+++ b/crates/trusty-mpm/src/client/executor/mod.rs
@@ -79,6 +79,23 @@ impl CommandExecutor {
         }
     }
 
+    /// Build an executor around an existing [`DaemonClient`].
+    ///
+    /// Why (#5913): a UI that already holds a `DaemonClient` — the `tm projects`
+    /// TUI holds one for its poll loop — still has to reach the executor to get
+    /// the shared implementations that wrap a raw endpoint in extra work, such as
+    /// [`decommission_managed_id`](Self::decommission_managed_id)'s worktree
+    /// bookkeeping repair. Without this, that UI's only cheap option is calling
+    /// the endpoint directly and silently skipping the wrapper, which is exactly
+    /// how `tui::project_ctl` came to bypass the shared decommission path.
+    /// What: adopts the passed client verbatim. `DaemonClient` is cheap to clone
+    /// (a `String` plus an `Arc`-backed `reqwest::Client`), so a caller holding a
+    /// `&DaemonClient` builds one per action without minting a new pool.
+    /// Test: `project_ctl_decommission_prunes_stale_worktree_bookkeeping`.
+    pub fn from_daemon_client(client: DaemonClient) -> Self {
+        Self { client }
+    }
+
     /// The underlying daemon client.
     ///
     /// Why: a UI's alert loop and pairing flow need direct client access

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -26,6 +26,38 @@ async fn spawn_test_daemon() -> (std::sync::Arc<crate::daemon::state::DaemonStat
     (state, format!("http://{addr}"))
 }
 
+/// Point `$HOME` at a temp directory and restore it on drop, panic or not.
+///
+/// Why: the daemon's workspace-removal path resolves the containment root from
+/// `$HOME`, so a decommission test that wants a removal to actually happen must
+/// seed its workspace under a redirected root. The redirect is process-wide, so
+/// every user is `#[serial_test::serial]` and every user needs the restore to
+/// survive a failed assertion.
+/// What: `redirect` swaps `$HOME` and returns the guard holding the prior value;
+/// `Drop` puts it back (or removes the variable when there was none).
+/// Test: used by `executor_decommission_reports_daemon_workspace_verdict` and
+/// `decommission_managed_id_prunes_stale_worktree_bookkeeping`.
+struct HomeGuard(Option<String>);
+
+impl HomeGuard {
+    fn redirect(to: &std::path::Path) -> Self {
+        let prior = std::env::var("HOME").ok();
+        // SAFETY: every caller is serialized via `#[serial_test::serial]`.
+        unsafe { std::env::set_var("HOME", to) };
+        Self(prior)
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        // SAFETY: serialized via `#[serial_test::serial]`.
+        match self.0 {
+            Some(ref p) => unsafe { std::env::set_var("HOME", p) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+}
+
 #[tokio::test]
 async fn execute_help_returns_help() {
     // The `/help` path is pure — no HTTP, no daemon.
@@ -543,22 +575,8 @@ async fn executor_decommission_reports_daemon_workspace_verdict() {
     use crate::runtime::RuntimeKind;
     use crate::session_manager::ManagedSessionId;
 
-    /// Restores `$HOME` even if an assertion below panics mid-loop.
-    struct HomeGuard(Option<String>);
-    impl Drop for HomeGuard {
-        fn drop(&mut self) {
-            // SAFETY: serialized via `#[serial_test::serial]`.
-            match self.0 {
-                Some(ref p) => unsafe { std::env::set_var("HOME", p) },
-                None => unsafe { std::env::remove_var("HOME") },
-            }
-        }
-    }
-
     let home = tempfile::TempDir::new().unwrap();
-    let _home_guard = HomeGuard(std::env::var("HOME").ok());
-    // SAFETY: serialized via `#[serial_test::serial]`; restored by the guard.
-    unsafe { std::env::set_var("HOME", home.path()) };
+    let _home_guard = HomeGuard::redirect(home.path());
     let workspace_root = trusty_common::workspace_layout::resolve_workspace_root(None);
 
     for owned in [true, false] {
@@ -611,6 +629,170 @@ async fn executor_decommission_reports_daemon_workspace_verdict() {
         }
         let _ = std::fs::remove_dir_all(&ws);
     }
+}
+
+/// #5913: pin which decommission outcomes run `git worktree prune`, so a later
+/// change cannot flip the decision silently.
+///
+/// The daemon has two removal branches and only one leaves git's bookkeeping
+/// stale. It removes an in-project worktree it does NOT own with `git worktree
+/// remove` — that prunes daemon-side, and the response carries no
+/// `workspace_path_was`. It removes a workspace tm OWNED with a plain
+/// `remove_dir_all`, which git never learns about, and reports the path. So the
+/// path's presence, not a caller-supplied flag, is what selects the prune.
+#[test]
+fn worktree_prune_dir_fires_only_on_a_named_removal() {
+    use crate::client::ManagedDecommissionOutcome;
+
+    let outcome = |removed: serde_json::Value, was: serde_json::Value| {
+        serde_json::from_value::<ManagedDecommissionOutcome>(serde_json::json!({
+            "id": "11111111-2222-3333-4444-555555555555",
+            "name": "tm-5913",
+            "state": "decommissioned",
+            "workspace_removed": removed,
+            "workspace_path_was": was,
+        }))
+        .expect("fixture must match the daemon's wire shape")
+    };
+    let named = serde_json::json!("/base/.worktrees/tm-5913");
+    let parent = Some(std::path::PathBuf::from("/base/.worktrees"));
+
+    assert_eq!(
+        super::managed::worktree_prune_dir(&outcome(serde_json::json!(true), named.clone())),
+        parent,
+        "a removal the daemon named left git's bookkeeping stale"
+    );
+    assert_eq!(
+        super::managed::worktree_prune_dir(&outcome(
+            serde_json::json!(true),
+            serde_json::json!(null)
+        )),
+        None,
+        "the daemon already pruned the branch it reports no path for"
+    );
+    assert_eq!(
+        super::managed::worktree_prune_dir(&outcome(serde_json::json!(false), named.clone())),
+        None,
+        "nothing was deleted, so nothing is stale"
+    );
+    assert_eq!(
+        super::managed::worktree_prune_dir(&outcome(serde_json::json!(null), named)),
+        None,
+        "an absent verdict is never read as a removal (#5899)"
+    );
+}
+
+/// #5913: the routed `tm session decommission <id>` must leave the base repo's
+/// worktree bookkeeping clean, exactly as the bulk prune sweep already did.
+///
+/// This is the live asymmetry the issue reports, reproduced whole. The daemon
+/// removes a tm-owned workspace with `remove_dir_all`; git never learns about it,
+/// so the entry survives in `git worktree list` until something prunes it. The
+/// bulk path pruned and the routed path did not, because each reached the
+/// endpoint by its own route. Against the pre-#5913 routed path this fails: the
+/// workspace is gone and the stale entry is still listed.
+///
+/// `$HOME` is redirected because the daemon's removal path applies a containment
+/// guard against the configured workspace root, so the base repo lives under that
+/// root. Serial, because the redirect is process-wide.
+#[tokio::test]
+#[serial_test::serial]
+async fn decommission_managed_id_prunes_stale_worktree_bookkeeping() {
+    use crate::runtime::RuntimeKind;
+    use crate::session_manager::ManagedSessionId;
+
+    /// Run `git` in `dir`, failing the test on a nonzero exit.
+    fn git(dir: &std::path::Path, args: &[&str]) -> String {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .unwrap_or_else(|e| panic!("git {args:?} failed to start: {e}"));
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    }
+
+    let home = tempfile::TempDir::new().unwrap();
+    let _home_guard = HomeGuard::redirect(home.path());
+    let workspace_root = trusty_common::workspace_layout::resolve_workspace_root(None);
+
+    let base = workspace_root.join("tm-5913-base");
+    std::fs::create_dir_all(&base).expect("create base repo dir");
+    git(&base, &["init", "--quiet"]);
+    git(&base, &["config", "user.email", "tm@example.invalid"]);
+    git(&base, &["config", "user.name", "tm test"]);
+    std::fs::write(base.join("README.md"), "seed\n").unwrap();
+    git(&base, &["add", "README.md"]);
+    git(&base, &["commit", "--quiet", "-m", "seed"]);
+
+    let id = ManagedSessionId::new();
+    let leaf = format!("tm-5913-{id}");
+    let ws = base.join(".worktrees").join(&leaf);
+    git(
+        &base,
+        &[
+            "worktree",
+            "add",
+            "--quiet",
+            "-b",
+            &format!("session/{leaf}"),
+            &ws.to_string_lossy(),
+        ],
+    );
+    assert!(
+        git(&base, &["worktree", "list", "--porcelain"]).contains(&leaf),
+        "fixture invariant: the worktree must be registered before decommission"
+    );
+
+    let (state, url) = spawn_test_daemon().await;
+    state
+        .session_manager()
+        .await
+        .create_with_id(
+            id,
+            "regression: #5913 decommission worktree bookkeeping".to_string(),
+            Some(ws.clone()),
+            None,
+            Some(ws.clone()),
+            None,
+            None,
+            RuntimeKind::default(),
+            false,
+            // Owned: the daemon removes it with `remove_dir_all`, which is the
+            // branch that leaves git's bookkeeping behind.
+            true,
+        )
+        .await
+        .expect("seed session");
+
+    let result = CommandExecutor::new(url)
+        .execute(TrustyCommand::ManagedDecommission {
+            target: id.to_string(),
+        })
+        .await;
+    match result {
+        CommandResult::ManagedLifecycle {
+            workspace_removed, ..
+        } => assert_eq!(
+            workspace_removed,
+            Some(true),
+            "fixture invariant: the daemon must have removed the owned workspace"
+        ),
+        other => panic!("expected ManagedLifecycle, got {other:?}"),
+    }
+    assert!(!ws.exists(), "the workspace must be gone: {}", ws.display());
+    assert!(
+        !git(&base, &["worktree", "list", "--porcelain"]).contains(&leaf),
+        "the routed decommission left a stale worktree entry for {leaf} — the \
+         bookkeeping repair did not run"
+    );
+
+    let _ = std::fs::remove_dir_all(&base);
 }
 
 #[tokio::test]

--- a/crates/trusty-mpm/src/client/http_client/managed.rs
+++ b/crates/trusty-mpm/src/client/http_client/managed.rs
@@ -305,24 +305,30 @@ impl DaemonClient {
     /// decommission claim removal (#5899).
     /// What: POSTs to the decommission endpoint and returns the whole response —
     /// tombstone summary plus `workspace_removed` / `workspace_path_was` — as a
-    /// [`ManagedDecommissionOutcome`].
+    /// [`ManagedDecommissionOutcome`]. A 404 becomes an `Err` naming the id, so
+    /// every decommission caller inherits one "missing session is a hard failure"
+    /// contract instead of restating it (#5913).
     /// Test: `executor_decommission_reports_daemon_workspace_verdict` (real
-    /// daemon round-trip), `decommission_outcome_round_trips_daemon_response`;
+    /// daemon round-trip), `decommission_outcome_round_trips_daemon_response`,
+    /// `session_decommission_not_found_errors`;
     /// live HTTP via `tests/session_manager_mvp.rs`.
     pub async fn decommission_managed_session(
         &self,
         id: &str,
     ) -> anyhow::Result<ManagedDecommissionOutcome> {
         let url = format!("{}/api/v1/sessions/managed/{id}/decommission", self.base);
-        let resp = self
-            .http
-            .post(&url)
-            .send()
-            .await?
+        let resp = self.http.post(&url).send().await?;
+        // #5913: name the 404 here, once. `prune.rs`'s sweep records the resulting
+        // `Err` as a failed row (#2457), and that fail-closed behaviour must not
+        // depend on which entry point issued the request.
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            anyhow::bail!("managed session '{id}' not found");
+        }
+        let outcome = resp
             .error_for_status()?
             .json()
             .await
             .context("decoding decommission response body")?;
-        Ok(resp)
+        Ok(outcome)
     }
 }

--- a/crates/trusty-mpm/src/tui/project_ctl/actions.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/actions.rs
@@ -26,11 +26,14 @@
 //! immediate re-poll after any action that changed the fleet.
 //! Test: the pure notice text is not independently unit-tested (it is a
 //! terminal string, not branch logic); the routing itself is covered by
-//! `events::tests` (which `PendingAction` a key produces). The live HTTP calls
-//! are exercised manually / by `tests/session_manager_mvp.rs`'s coverage of
-//! the underlying `DaemonClient` methods.
+//! `events::tests` (which `PendingAction` a key produces).
+//! `project_ctl_decommission_prunes_stale_worktree_bookkeeping` drives
+//! `Decommission` end to end against a stub daemon and a real git worktree.
+//! The remaining live HTTP calls are exercised manually / by
+//! `tests/session_manager_mvp.rs`'s coverage of the underlying `DaemonClient`
+//! methods.
 
-use crate::client::DaemonClient;
+use crate::client::{CommandExecutor, DaemonClient};
 
 use super::events::PendingAction;
 use super::state::ProjectCtlState;
@@ -40,8 +43,11 @@ use super::state::ProjectCtlState;
 /// Why: the single async seam the run loop calls after `handle_key` returns
 /// `Some(action)`.
 /// What: `Launch` is a stub — see the module doc — that sets an explanatory
-/// notice with no daemon call. `Kill`/`Resume`/`Decommission` call the
-/// matching mutating endpoint and, on success, request an immediate re-poll
+/// notice with no daemon call. `Kill`/`Resume` call the matching mutating
+/// endpoint directly; `Decommission` goes through
+/// [`CommandExecutor::decommission_managed_id`], the shared implementation
+/// that also repairs the base repo's worktree bookkeeping (#5913). All three,
+/// on success, request an immediate re-poll
 /// ([`ProjectCtlState::request_repoll`]) so the fleet reflects the change
 /// now. `Attach` fetches and displays the tmux attach command (read-only —
 /// no repoll). `SubmitConfig` (DOC-35 §6, #2120) PATCHes the config form's
@@ -71,10 +77,13 @@ pub(crate) async fn dispatch(
             apply_mutation_result(state, result, "resumed");
         }
         PendingAction::Decommission(id) => {
+            // #5913: route through the shared implementation, not the raw
+            // endpoint — the endpoint alone skips the base-repo worktree
+            // bookkeeping repair, which is the divergence #5913 exists to close.
             // The notice reports the state change; the workspace verdict rides on
             // the outcome for the CLI's message (#5899).
-            let result = client
-                .decommission_managed_session(&id)
+            let result = CommandExecutor::from_daemon_client(client.clone())
+                .decommission_managed_id(&id)
                 .await
                 .map(|outcome| outcome.summary);
             apply_mutation_result(state, result, "decommissioned");

--- a/crates/trusty-mpm/src/tui/project_ctl/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/tests.rs
@@ -260,3 +260,105 @@ async fn poll_doesnt_touch_open_config_form() {
          unsaved, not-yet-submitted field edits"
     );
 }
+
+/// #5913: the `[d]` decommission hotkey must leave the base repo's worktree
+/// bookkeeping clean, exactly as the CLI's routed verb and the bulk prune sweep
+/// already do.
+///
+/// This screen reached the decommission endpoint directly, so it never ran the
+/// bookkeeping repair — the same divergence #5913 closed for the other two
+/// callers, still open on the one hotkey an operator is most likely to press.
+/// Against the pre-fix `client.decommission_managed_session(&id)` this fails:
+/// the workspace is gone and the stale `git worktree list` entry is still there.
+///
+/// A stub daemon rather than the real one, because the assertion is about what
+/// the CLIENT does with the response: the fixture removes the workspace itself
+/// (standing in for the daemon's `remove_dir_all`) and the stub reports that
+/// removal with the path, which is the response shape that selects the prune.
+#[tokio::test]
+async fn project_ctl_decommission_prunes_stale_worktree_bookkeeping() {
+    use std::future::IntoFuture;
+
+    /// Run `git` in `dir`, failing the test on a nonzero exit.
+    fn git(dir: &std::path::Path, args: &[&str]) -> String {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .unwrap_or_else(|e| panic!("git {args:?} failed to start: {e}"));
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    }
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let base = tmp.path().join("tm-5913-base");
+    std::fs::create_dir_all(&base).expect("create base repo dir");
+    git(&base, &["init", "--quiet"]);
+    git(&base, &["config", "user.email", "tm@example.invalid"]);
+    git(&base, &["config", "user.name", "tm test"]);
+    std::fs::write(base.join("README.md"), "seed\n").unwrap();
+    git(&base, &["add", "README.md"]);
+    git(&base, &["commit", "--quiet", "-m", "seed"]);
+
+    let id = "11111111-2222-3333-4444-555555555555";
+    let leaf = "tm-5913-project-ctl";
+    let ws = base.join(".worktrees").join(leaf);
+    git(
+        &base,
+        &[
+            "worktree",
+            "add",
+            "--quiet",
+            "-b",
+            &format!("session/{leaf}"),
+            &ws.to_string_lossy(),
+        ],
+    );
+    assert!(
+        git(&base, &["worktree", "list", "--porcelain"]).contains(leaf),
+        "fixture invariant: the worktree must be registered before decommission"
+    );
+    // Stand in for the daemon's `remove_dir_all` of an owned workspace: the
+    // directory is gone and git's bookkeeping does not know it.
+    std::fs::remove_dir_all(&ws).expect("remove the workspace");
+
+    let outcome = serde_json::json!({
+        "id": id,
+        "name": leaf,
+        "state": "decommissioned",
+        "workspace_removed": true,
+        "workspace_path_was": ws.to_string_lossy(),
+    });
+    let app = axum::Router::new().route(
+        "/api/v1/sessions/managed/{id}/decommission",
+        axum::routing::post(move || std::future::ready(axum::Json(outcome.clone()))),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, app).into_future());
+
+    let client = DaemonClient::new(format!("http://{addr}"));
+    let mut state = seeded_state();
+    super::actions::dispatch(
+        &mut state,
+        &client,
+        PendingAction::Decommission(id.to_string()),
+    )
+    .await;
+
+    assert_eq!(
+        state.notice.as_deref(),
+        Some(format!("decommissioned {leaf} — now decommissioned").as_str()),
+        "the hotkey must still report the state change"
+    );
+    assert!(
+        !git(&base, &["worktree", "list", "--porcelain"]).contains(leaf),
+        "the TUI's [d] decommission left a stale worktree entry for {leaf} — it \
+         is not routed through the shared implementation"
+    );
+}


### PR DESCRIPTION
Closes #5913.

## What changed

`CommandExecutor::decommission_managed_id` is the one implementation both entry
points now call. It makes the daemon call and runs the base-repo worktree
bookkeeping repair. `commands::managed::session_decommission` — the bulk prune
sweep's caller — no longer POSTs the endpoint itself.

Fuzzy id-or-name resolution stays above the shared implementation, in the routed
path only. The sweep already holds canonical ids, so it still costs one request
per session. No flag distinguishes the callers.

`prune.rs` is unchanged (owned by #5904).

## The two obstacles

**404-to-`Err`.** Moved into `DaemonClient::decommission_managed_session`, so
the mapping happens once and every caller inherits it. `prune.rs`'s sweep still
records a missing session as a failed row.

Note what the old test did not cover: `session_decommission_not_found_errors`
passed `"nonexistent-id"`, which the daemon rejects at `parse_id` with a **400**,
not a 404. The 404 branch was never exercised. The test now drives both — a
malformed id and a well-formed id absent from the store — and asserts the exact
message on the 404.

**`git worktree prune`.** The unified path always runs it, on the daemon's own
signal rather than a caller flag. The daemon has two removal branches:

| Branch | How it removes | Reports `workspace_path_was` | Git bookkeeping |
|---|---|---|---|
| In-project worktree, not tm-owned | `git worktree remove` | No | Daemon prunes it |
| Workspace tm owned | `remove_dir_all` | Yes | Git never learns |

So `workspace_path_was.is_some()` already *is* the "git does not know yet"
signal. Gating on it means the self-cleaning branch is never pruned twice, and
the branch that leaves a stale `git worktree list` entry always is. That second
row is the live asymmetry #5913 reports.

## Rung 5

Process lifecycle plus a routing contract.

```
cargo fmt --check                                     # clean
cargo check -p trusty-mpm --all-targets               # EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   # EXIT=0
cargo test -p trusty-mpm                              # EXIT=0
cargo check --workspace                               # EXIT=0
cargo test -p trusty-mpm --no-fail-fast -- --include-ignored
```

`cargo test -p trusty-mpm`: `5129 passed; 0 failed; 7 ignored` (lib),
`1739 passed; 0 failed; 1 ignored` (bin `tm`), every integration target ok.

No crate declares a dependency on the `trusty-mpm` library, so rung 4's
per-dependent test step has no consumers to run; `cargo check --workspace`
stands in for it.

Repo gates: `check_line_cap.sh`, `check_sld.sh`, `check_teardown_guard.sh`,
`check_test_pointers.sh`, `check_generation_artifacts.sh`,
`check_changelog_fragment.sh`, `check-pr-version-bump.sh` — all exit 0.
Version stays 1.4.3 (crates.io has 1.4.2); the bump gate reports
`src changed, version not yet published`.

### `--include-ignored` failures — all pre-existing and environmental

```
daemon::managed_routes::staleness_bench_tests::bench_stale_assets_for_many
live_pane_scoped_send_targets_original_pane_not_sibling
meta_run_demo_writes_and_verifies_artifact
```

`bench_stale_assets_for_many` is the known pre-existing one. The other two
refuse on host state, not on anything this branch touches:

```
live_pane_scoped_send_targets_original_pane_not_sibling:
  tmux must be installed for this live test: Protocol("tmux access refused:
  $HOME is /var/folders/.../T/.tmp27bkt0 but this user's real home is
  /Users/masa ... Set TRUSTY_MPM_ALLOW_HOST_STATE=1 to allow it.")

meta_run_demo_writes_and_verifies_artifact:
  {"launch_outcome":"timed-out","pass":false,...}   # launches a real Claude
                                                    # Code session, 180s timeout
```

None of the three live in a file this branch changes, and none call the
decommission path.

## Tests

**`decommission_managed_id_prunes_stale_worktree_bookkeeping`** — the live
asymmetry, end to end. Real git repo with a real worktree under a redirected
`$HOME`, seeded tm-owned, decommissioned through the routed entry point;
asserts the base repo's `git worktree list` no longer names it. Verified red
before the fix:

```
panicked at crates/trusty-mpm/src/client/executor/tests.rs:789:5:
the routed decommission left a stale worktree entry for
tm-5913-e1399aba-70da-4976-86f5-bc775ac563d6 — the bookkeeping repair did not run
```

**`session_decommission_not_found_errors`** — verified red when the 404 mapping
is removed:

```
assertion `left == right` failed: the 404 mapping must survive: prune's sweep
counts this Err as a failed row
  left: "HTTP status client error (404 Not Found) for url (.../decommission)"
 right: "managed session '11111111-2222-3333-4444-555555555555' not found"
```

and red again when `session_decommission` swallows the `Err` into `Ok(())` —
the #2457 bug class:

```
panicked at managed_tests.rs:862:10: a missing managed session must be a hard
failure, not a silent Ok(()): ()
```

**`worktree_prune_dir_fires_only_on_a_named_removal`** — pins the prune decision
across all four input shapes, so a later change cannot flip it silently.

**`decommission_entry_points_agree_on_every_verdict`** — compares the bulk
path's reported line against the routed path's, for `Some(true)`, `Some(false)`
and `None`. This one is a pin, not a regression test: #5899 had already unified
the renderer, so it would have passed before this PR too. It exists so a future
change to one path that the other does not get fails here. It runs against a
canned-response stub because `None` means "a daemon old enough to send no
verdict", which the current daemon cannot produce.

## Review follow-up (`b4f03d3`) — a third caller the first sweep missed

`tui::project_ctl::actions.rs` called `DaemonClient::decommission_managed_session`
directly. That is the `tm projects` TUI's `[d]` hotkey, so it never ran the
bookkeeping repair and still left a stale `git worktree list` entry — the bug
class this PR exists to close, on a live user-facing path. It now builds a
`CommandExecutor` around the `DaemonClient` it already holds and calls
`decommission_managed_id`.

`CommandExecutor::from_daemon_client` is the new seam. A UI holding a
`DaemonClient` had no cheap way to reach an executor-level implementation, and
calling the endpoint directly was the path of least resistance — which is how
this bypass came about in the first place.

The doc comment claimed "the TUI, Telegram and Slack" converge here. True for
`tui::coordinator`, Telegram and Slack; false for `tui::project_ctl`. It now
names every caller instead of summarising them.

### Every caller of the decommission endpoint, with routing status

| Caller | Status |
|---|---|
| `tm session decommission <id>` (`managed_route.rs:107`) | routed — `managed_decommission` → shared |
| Telegram `/decommission` (`telegram/commands.rs:201`) | routed — same |
| Slack `/decommission` (`slack/commands.rs:238`) | routed — same |
| `tui::coordinator` `/kill`, `/decommission`, `/managed-decommission` (`tui/coordinator/dispatch.rs:112`) | routed — same |
| `tm session prune` bulk sweep (`commands/managed.rs:549`) | routed — `session_decommission_line` → shared |
| `tui::project_ctl` `[d]` (`tui/project_ctl/actions.rs:76`) | **routed by this commit** — was direct |
| `session_picker_prune::decommission_dead_record` (`session_picker_prune.rs:1034`) | deliberately separate — see below |

`decommission_dead_record` POSTs `?record_only=true`. That is a different
operation: it must never remove a workspace, so it must never prune, and it
reads the raw response body to detect a daemon too old to honour `record_only`
— a distinction the typed response hides. Routing it through the shared path
would break both properties.

### Test

`project_ctl_decommission_prunes_stale_worktree_bookkeeping` drives
`actions::dispatch(PendingAction::Decommission)` against a stub daemon and a
real git worktree. Red before the routing:

```
panicked at crates/trusty-mpm/src/tui/project_ctl/tests.rs:359:5:
the TUI's [d] decommission left a stale worktree entry for tm-5913-project-ctl
 — it is not routed through the shared implementation
```

Green after: `test result: ok. 1 passed; 0 failed`.

### Rung 5, re-run

```
cargo fmt --check                                         # EXIT=0
cargo check -p trusty-mpm --all-targets                   # EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   # EXIT=0
cargo test -p trusty-mpm --no-fail-fast                   # EXIT=0
```

`test result: ok. 5131 passed; 0 failed; 7 ignored` (lib),
`1739 passed; 0 failed; 1 ignored` (bin `tm`), every integration target ok.
Repo gates `check_line_cap.sh`, `check_sld.sh`, `check_test_pointers.sh`,
`check_teardown_guard.sh`, `check_changelog_fragment.sh` all exit 0.

## Not done here

The daemon's own in-process callers do not get this repair. MCP
`session_decommission` (`daemon/mcp_session.rs:155`) and the idle reaper
(`daemon/idle_reaper.rs:324`) call `SessionManager::decommission` directly,
below the client seam, so neither sees `workspace_path_was` nor runs the
prune. Closing that means putting the repair inside `session_manager/`, which
is a different layer and a different change.

Three in-crate copies of `git worktree prune` remain
(`session_manager/decommission.rs`, `daemon/managed_routes/inproject_hygiene.rs`,
and the one this PR moved). CLAUDE.md's common-entry-point rule governs
cross-crate duplication, not within-crate, and consolidating them would reach
into `session_manager/` — out of scope for this change.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

