### PR TITLE
fix(trusty-code): an unset RUST_LOG logs at info instead of filtering to silence

### DIFF
--- a/crates/trusty-code/changelog.d/5928-logging-default-level.md
+++ b/crates/trusty-code/changelog.d/5928-logging-default-level.md
@@ -1,0 +1,3 @@
+Fixed
+
+- An unset or malformed `RUST_LOG` now filters at `info` instead of dropping everything below `error`, so the `warn!` decision points the logging convention requires are visible on a default developer machine; `DEFAULT_LOG_LEVEL` is the real fallback rather than advisory documentation ([#5928](https://github.com/bobmatnyc/trusty-tools/pull/5928))

--- a/crates/trusty-code/src/logging/mod.rs
+++ b/crates/trusty-code/src/logging/mod.rs
@@ -36,7 +36,8 @@
 //!   supposed to keep the transcript under budget at all times).
 //!
 //! All logs go to **stderr** via `tracing` (never stdout — see the module
-//! doc above) and are filtered by `RUST_LOG` (`EnvFilter::from_default_env`).
+//! doc above) and are filtered by `RUST_LOG`, falling back to `info` when it
+//! is unset or invalid.
 //!
 //! **Logs vs. events:** structured [`crate::events`] are telemetry for the
 //! UI (a typed, machine-consumed fact stream); `tracing` logs here are for
@@ -46,16 +47,28 @@
 
 use tracing_subscriber::EnvFilter;
 
+/// Build the tracing filter, falling back to [`DEFAULT_LOG_LEVEL`].
+///
+/// Why: `EnvFilter::from_default_env` yields an EMPTY directive set when
+/// `RUST_LOG` is unset or malformed, which filters everything below `error`
+/// and silences the `warn!` decision points this module's convention requires.
+/// What: parses `RUST_LOG`; on any parse failure builds a filter from
+/// [`DEFAULT_LOG_LEVEL`] instead.
+/// Test: `tests/logging_e2e.rs`.
+fn env_filter() -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_LEVEL))
+}
+
 /// Initialise the global tracing subscriber.
 ///
 /// Why: All daemons and CLI entry points call this once at startup to ensure
 /// log output is consistently routed to stderr with the `RUST_LOG` filter.
-/// What: Installs a stderr-bound fmt subscriber with `EnvFilter::from_default_env()`.
+/// What: Installs a stderr-bound fmt subscriber with [`env_filter`].
 /// Panics if called twice (use `init_tracing_for_test` in test binaries).
 /// Test: Called in `main.rs`; correctness is verified by observing log output.
 pub fn init_tracing() {
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(env_filter())
         .with_writer(std::io::stderr)
         .init();
 }
@@ -69,7 +82,7 @@ pub fn init_tracing() {
 /// Test: `init_tracing_for_test_is_idempotent`.
 pub fn init_tracing_for_test() {
     let _ = tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(env_filter())
         .with_writer(std::io::stderr)
         .try_init();
 }
@@ -78,8 +91,8 @@ pub fn init_tracing_for_test() {
 ///
 /// Why: Documents and centralises the default so operators know what to expect
 /// without reading source.
-/// What: A static string literal; the default filter used by `EnvFilter::from_default_env()`.
-/// Test: Not directly tested — the value is advisory documentation.
+/// What: A static string literal used by [`env_filter`] as its real fallback.
+/// Test: `tests/logging_e2e.rs` covers unset and invalid `RUST_LOG` values.
 pub const DEFAULT_LOG_LEVEL: &str = "info";
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/trusty-code/tests/logging_e2e.rs
+++ b/crates/trusty-code/tests/logging_e2e.rs
@@ -1,0 +1,44 @@
+//! Subprocess coverage for the default tracing filter and stdio separation.
+
+use std::process::Command;
+
+const CHILD_ENV: &str = "TCODE_LOGGING_TEST_CHILD";
+const WARNING: &str = "durable-memory-test-warning";
+const PROTOCOL: &str = r#"{"jsonrpc":"2.0","id":1,"result":"ok"}"#;
+
+#[test]
+fn logging_child() {
+    if std::env::var_os(CHILD_ENV).is_none() {
+        return;
+    }
+    trusty_code::logging::init_tracing();
+    tracing::warn!("{WARNING}");
+    println!("{PROTOCOL}");
+}
+
+#[test]
+fn unset_rust_log_keeps_warnings_on_stderr_and_stdout_protocol_clean() {
+    for rust_log in [None, Some("[invalid")] {
+        let mut command = Command::new(std::env::current_exe().expect("current test binary"));
+        command
+            .args(["--exact", "logging_child", "--nocapture"])
+            .env(CHILD_ENV, "1")
+            .env_remove("RUST_LOG");
+        if let Some(value) = rust_log {
+            command.env("RUST_LOG", value);
+        }
+        let output = command.output().expect("run logging child");
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(WARNING),
+            "warning missing from stderr: {stderr}"
+        );
+        assert!(
+            !stdout.contains(WARNING),
+            "warning contaminated stdout: {stdout}"
+        );
+        assert!(stdout.lines().any(|line| line == PROTOCOL));
+    }
+}


### PR DESCRIPTION
## What changed

`crates/trusty-code/src/logging/mod.rs` — `EnvFilter::from_default_env()` becomes
`try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_LEVEL))`,
behind a new private `env_filter()` both `init_tracing` and
`init_tracing_for_test` call.

`from_default_env()` yields an EMPTY directive set when `RUST_LOG` is unset or
malformed. An empty filter passes only `error`, so every `warn!` the module's
own log-level convention (#2857) requires at a decision point was dropped on a
default developer machine. `DEFAULT_LOG_LEVEL = "info"` existed and documented
that default, but no code read it. Now it does.

`crates/trusty-code/tests/logging_e2e.rs` — new. Spawns the test binary as a
child with `RUST_LOG` first removed and then set to `[invalid`, and asserts the
`warn!` reaches stderr, stays off stdout, and leaves the JSON-RPC line on stdout
intact.

No public API change: `env_filter` is private, and the two `pub fn` signatures
and `DEFAULT_LOG_LEVEL` are untouched.

## Provenance

Salvaged from the abandoned branch `codex/tcode-r1-spec-reconcile` (263 commits
behind main). Its three other behaviour changes merged as #5893, #5894, #5895;
this fourth was never assigned. The branch's `docs/trusty-code/r1-blocker-*.md`
specs are deliberately NOT carried over — the owner dropped them as written
against a stale tree.

## Interaction with #5895

#5895 hit this bug's absence: its redaction test assumed an unset `RUST_LOG`
produces `info`, and on main it does not, so the agent set `RUST_LOG=warn`
explicitly. Those two call sites —
`crates/trusty-code/src/session/memory_sink_tests.rs:143` and
`crates/trusty-code/src/session/registry_memory_sink.rs:377` — are left alone.
This change makes the explicit setting redundant, not wrong; removing it here
would quietly change the meaning of a merged test in a PR that is not about it.

## Test ladder — rung 3

Localized behavior inside one crate. `trusty-code` has no `[features]` section,
so `-p trusty-code` compiles the whole crate; nothing here sits behind a
non-default feature.

```
cargo fmt --check                                     EXIT=0
cargo check -p trusty-code                            EXIT=0
cargo clippy -p trusty-code --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-code                             EXIT=0  (1725 passed, 0 failed, 4 ignored across 18 targets)
bash scripts/check_line_cap.sh                        EXIT=0
bash scripts/check_test_pointers.sh                   EXIT=0
```

### Regression test — red before, green after

Test file applied without the `mod.rs` change:

```
running 2 tests
test logging_child ... ok
test unset_rust_log_keeps_warnings_on_stderr_and_stdout_protocol_clean ... FAILED

---- unset_rust_log_keeps_warnings_on_stderr_and_stdout_protocol_clean stdout ----
thread '...' panicked at crates/trusty-code/tests/logging_e2e.rs:34:9:
warning missing from stderr:

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

Same test with the fix:

```
running 2 tests
test logging_child ... ok
test unset_rust_log_keeps_warnings_on_stderr_and_stdout_protocol_clean ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

The empty string after `warning missing from stderr:` is the whole point — the
child's stderr was empty because the `warn!` never passed the filter.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
