### PR TITLE
fix(trusty-audit): the audit collects real history and reads the code it clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11296,7 +11296,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-audit"
-version = "0.1.0"
+version = "0.2.0"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -72,7 +72,9 @@ trusty-installer = { workspace = true }
 # `Command::new("gh")` here a defect — so this crate never spells one.
 # #5822: `credentials` adds `scrub_secrets`, the workspace's one redaction entry
 # point, used where a board provider's own error text reaches an operator.
-trusty-common = { workspace = true, features = ["gh-cli", "credentials"] }
+# #5915: `crate-config` for `crate_config_dir_at` — the workspace's one owner of
+# the `~/.trusty-tools/<crate>` layout, which `workdir.rs` now defaults into.
+trusty-common = { workspace = true, features = ["gh-cli", "credentials", "crate-config"] }
 # #5822: board validation issues HTTP requests, so it needs `reqwest`'s types —
 # the RequestBuilder, and the error it classifies without quoting the URL. The
 # CLIENT still comes from `trusty_installer::download::http_client`, which stays

--- a/crates/trusty-audit/changelog.d/5915-approve-the-clone-for-indexing.md
+++ b/crates/trusty-audit/changelog.d/5915-approve-the-clone-for-indexing.md
@@ -1,0 +1,10 @@
+Fixed
+
+- The code-analysis leg reads the code again. `trusty-search` is default-deny,
+  and nothing in the audit chain ever approved a clone, so `tga audit`'s
+  `trusty-search index <checkout>` was refused on every repository of every
+  run. It was silent: `tga audit` exits 0 whenever its sweep completed, so the
+  run reported success and the report simply had nothing to say about the
+  source. The sweep now runs `trusty-search index add <checkout>` before each
+  child, and a refusal is a named per-repository failure rather than an empty
+  section.

--- a/crates/trusty-audit/changelog.d/5915-work-root-moves-to-the-home-directory.md
+++ b/crates/trusty-audit/changelog.d/5915-work-root-moves-to-the-home-directory.md
@@ -1,0 +1,15 @@
+Changed
+
+- The default working directory is `~/.trusty-tools/trusty-audit/work`, and the
+  packaged launcher no longer pins `--work-dir` beside itself. The tree used to
+  land wherever the recipient unzipped the package, and `trusty-search` refuses
+  to index a checkout under `/tmp`, `/var/folders`, `~/Downloads`, `~/Desktop`
+  or `~/Documents` — which is where an emailed zip gets opened — so the
+  placement cost the code analysis its data on an ordinary machine. `--work-dir`
+  and `TRUSTY_AUDIT_WORKDIR` still override, and the launcher forwards them.
+
+  Two costs, both stated in the package README: approving a clone writes a row
+  to `trusty-search`'s own allowlist, outside the work root, so deleting the
+  root is no longer a complete uninstall (`trusty-search index remove <path>`
+  undoes it); and an existing operator's tree does not move itself — pass
+  `--work-dir` at the old location, or move it.

--- a/crates/trusty-audit/changelog.d/5916-full-clone-removed.md
+++ b/crates/trusty-audit/changelog.d/5916-full-clone-removed.md
@@ -1,0 +1,7 @@
+Removed
+
+- `taudit clone --full` and `CloneOptions::shallow`. A full clone is now the
+  only mode, so the flag had nothing left to select and the field was one
+  assignment away from re-emptying the deliverable. Disk stays bounded by
+  `--budget-gb`, which is unchanged: the same repository is 628 KiB shallow and
+  1.2 MiB full, against a 20 GiB default.

--- a/crates/trusty-audit/changelog.d/5916-full-clone.md
+++ b/crates/trusty-audit/changelog.d/5916-full-clone.md
@@ -1,0 +1,9 @@
+Fixed
+
+- Repositories are cloned with their whole history. `taudit clone` appended
+  `--depth=1`, so tga read exactly one commit per repository and every
+  deliverable said `commits=1`, `authors=1`, a period whose start equalled its
+  end, and one author credited with the entire tree. Measured on
+  `BurntSushi/xsv`: 1 commit by 1 author on 2025-04-24, against a real history
+  of 407 commits by 30 authors from 2014-09-01. Every CSV was a header and one
+  row.

--- a/crates/trusty-audit/src/chain.rs
+++ b/crates/trusty-audit/src/chain.rs
@@ -504,10 +504,21 @@ trusty-review = "0.15.1"
     /// The stub binaries AND the version record, which together are what the
     /// sweep's `pinned_binaries` preflight accepts — so the install phase finds
     /// the pins satisfied and never reaches the network.
+    ///
+    /// #5915: `trusty-search` gets an approving stub rather than `script`. The
+    /// sweep now runs `trusty-search index add <checkout>` before each tga
+    /// child, and `script` describes what TGA does — sharing it would make every
+    /// chain test that expects a failing tga also fail its approval, for a
+    /// reason none of them is about.
     fn install_stubs(work: &WorkDir, script: &str) {
         for tool in RequiredTool::ALL {
             let path = tool.path_in(work);
-            std::fs::write(&path, script).expect("stub binary");
+            let body = if tool == RequiredTool::TrustySearch {
+                "#!/bin/sh\nexit 0\n"
+            } else {
+                script
+            };
+            std::fs::write(&path, body).expect("stub binary");
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt as _;

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -42,7 +42,7 @@ use crate::session::{Command, Outcome};
     long_about = None,
 )]
 pub struct Cli {
-    /// Working-directory root (default: ./trusty-audit-work, or $TRUSTY_AUDIT_WORKDIR).
+    /// Working-directory root (default: ~/.trusty-tools/trusty-audit/work, or $TRUSTY_AUDIT_WORKDIR).
     #[arg(long, global = true, value_name = "DIR")]
     pub work_dir: Option<PathBuf>,
 
@@ -487,6 +487,9 @@ mod cli_tests {
             );
         }
         assert!(text.contains("delete this directory"));
+        // #5915: the approval is recorded outside the root, so the layout must
+        // name what removes it rather than implying deletion covers everything.
+        assert!(text.contains("trusty-search index remove"), "{text}");
     }
 
     #[test]

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -90,9 +90,6 @@ pub enum Verb {
         /// Repositories to clone, as owner/name.
         #[arg(value_name = "OWNER/NAME", required = true)]
         repos: Vec<String>,
-        /// Fetch full history instead of only the tip commit.
-        #[arg(long)]
-        full: bool,
         /// Stop STARTING clones once this many gigabytes are on disk (0: never).
         ///
         /// Not a cap on one repository: a clone already running is never
@@ -242,14 +239,9 @@ impl Cli {
             // omitting the flag keeps `CloneOptions`' bounded default, because
             // the recipient who never thought about disk is the one the budget
             // exists for.
-            Some(Verb::Clone {
-                repos,
-                full,
-                budget_gb,
-            }) => Command::CloneRepos {
+            Some(Verb::Clone { repos, budget_gb }) => Command::CloneRepos {
                 repos: repos.clone(),
                 options: CloneOptions {
-                    shallow: !full,
                     budget_bytes: match budget_gb {
                         Some(0) => None,
                         // #5215 review: `--budget-gb 17179869184` overflowed u64 —
@@ -628,19 +620,26 @@ mod cli_tests {
         assert!(text.contains("archived"), "{text}");
     }
 
+    /// #5916: the verb has no depth knob to get wrong. `--full` used to exist
+    /// and default to off, so the ordinary invocation was the truncating one.
     #[test]
-    fn the_clone_verb_defaults_to_a_shallow_bounded_clone() {
+    fn the_clone_verb_defaults_to_a_bounded_clone_and_takes_no_depth_flag() {
         let cli = Cli::try_parse_from(["taudit", "clone", "acme/api", "acme/web"])
             .expect("the clone verb parses");
         let Command::CloneRepos { repos, options } = cli.to_command() else {
             panic!("clone must route to CloneRepos");
         };
         assert_eq!(repos, vec!["acme/api", "acme/web"]);
-        assert!(options.shallow);
         assert_eq!(
             options.budget_bytes,
             Some(crate::clone::DEFAULT_BUDGET_BYTES)
         );
+        for gone in ["--full", "--depth", "--shallow"] {
+            assert!(
+                Cli::try_parse_from(["taudit", "clone", "acme/api", gone]).is_err(),
+                "{gone} must not be accepted — a truncated clone empties the audit"
+            );
+        }
     }
 
     /// The ceiling comes off only when the recipient asks for it in words.
@@ -654,14 +653,12 @@ mod cli_tests {
         };
         assert_eq!(options.budget_bytes, None);
 
-        let full =
-            Cli::try_parse_from(["taudit", "clone", "acme/api", "--full", "--budget-gb", "2"])
-                .expect("parses")
-                .to_command();
-        let Command::CloneRepos { options, .. } = full else {
+        let bounded = Cli::try_parse_from(["taudit", "clone", "acme/api", "--budget-gb", "2"])
+            .expect("parses")
+            .to_command();
+        let Command::CloneRepos { options, .. } = bounded else {
             panic!("clone must route to CloneRepos");
         };
-        assert!(!options.shallow);
         assert_eq!(options.budget_bytes, Some(2 * 1024 * 1024 * 1024));
     }
 

--- a/crates/trusty-audit/src/cli/render.rs
+++ b/crates/trusty-audit/src/cli/render.rs
@@ -69,8 +69,14 @@ pub fn render(outcome: &Outcome) -> String {
             out
         }
         Outcome::WorkDir(report) => {
+            // #5915: this used to say "everything this client wrote". Approving
+            // a clone for indexing writes a row to `trusty-search`'s own
+            // allowlist, which is outside this root, so deleting the directory
+            // no longer removes everything.
             let mut out = format!(
-                "{}\n  (delete this directory to remove everything this client wrote)\n",
+                "{}\n  (delete this directory to remove what this client wrote here;\n\
+                 \x20  `trusty-search index remove <path>` undoes the indexing approval\n\
+                 \x20  it recorded for each clone, which lives outside this directory)\n",
                 report.root.display()
             );
             for (area, path) in &report.areas {

--- a/crates/trusty-audit/src/clone.rs
+++ b/crates/trusty-audit/src/clone.rs
@@ -68,11 +68,13 @@ pub const STAGING_DIR: &str = "clone-staging";
 pub const DEFAULT_BUDGET_BYTES: u64 = 20 * 1024 * 1024 * 1024;
 
 /// How to clone.
+///
+/// #5916: there is no depth knob. A shallow clone is what made the tga database
+/// degenerate — see [`clone_command`] — and the disk it saves is what
+/// [`CloneOptions::budget_bytes`] is for.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct CloneOptions {
-    /// Fetch only the tip commit. Bounds disk use; loses history.
-    pub shallow: bool,
     /// Stop STARTING new clones once this much is already on disk. `None` never
     /// stops.
     ///
@@ -87,14 +89,9 @@ pub struct CloneOptions {
 }
 
 impl Default for CloneOptions {
-    /// Shallow, and bounded at [`DEFAULT_BUDGET_BYTES`].
-    ///
-    /// Shallow is the default because tga's sweep is configured per repository
-    /// and a hundred full clones is the case that fills a laptop. A caller that
-    /// needs history sets `shallow: false` explicitly.
+    /// Bounded at [`DEFAULT_BUDGET_BYTES`].
     fn default() -> Self {
         Self {
-            shallow: true,
             budget_bytes: Some(DEFAULT_BUDGET_BYTES),
         }
     }
@@ -113,8 +110,8 @@ pub enum CloneState {
     /// `gh` exited zero but produced no checkout worth analyzing.
     ///
     /// Why: its own state rather than a flavour of `Failed`, because the cause
-    /// is different and so is what the recipient should do. `git clone --depth=1`
-    /// of a commitless repository EXITS ZERO and leaves a directory containing
+    /// is different and so is what the recipient should do. Cloning a
+    /// commitless repository EXITS ZERO and leaves a directory containing
     /// only `.git`; `gh repo clone` forwards that status. Reported as `Cloned`,
     /// that is an audit claiming coverage of a repository it never read
     /// (#5215 review).
@@ -270,19 +267,25 @@ fn ensure_real_dir(path: PathBuf) -> Result<(), AuditError> {
 
 /// The clone invocation, as a command rather than a run.
 ///
-/// The `--` separates `gh`'s own flags from the ones it forwards to `git`.
-/// Test: `super::clone_tests::a_shallow_clone_forwards_depth_to_git`.
-fn clone_command(name_with_owner: &str, into: &Path, shallow: bool) -> GhCommand {
-    let mut args: Vec<std::ffi::OsString> = vec![
+/// Why (#5916): this used to append `-- --depth=1`, and that one flag emptied
+/// the whole git-analytics leg. A depth-1 checkout has exactly one commit, so
+/// tga collected `commits=1`, `authors=1`, a period whose start equals its end,
+/// and every line in the tree attributed to whoever last touched it — measured
+/// on `BurntSushi/xsv`, whose real history is 407 commits by 30 authors from
+/// 2014 to 2025. Every CSV in the deliverable was a header and one row. What
+/// bounds the disk that saved is [`CloneOptions::budget_bytes`], which stops
+/// STARTING clones and does not need history thrown away to work: the same
+/// repository is 628 KiB shallow and 1.2 MiB full, against a 20 GiB default.
+/// What: `gh repo clone <owner/name> <dest>`, with no flags forwarded to `git`
+/// at all — so there is no `--` separator either.
+/// Test: `super::clone_tests::a_clone_asks_git_for_the_whole_history`.
+fn clone_command(name_with_owner: &str, into: &Path) -> GhCommand {
+    let args: Vec<std::ffi::OsString> = vec![
         "repo".into(),
         "clone".into(),
         name_with_owner.into(),
         into.as_os_str().to_os_string(),
     ];
-    if shallow {
-        args.push("--".into());
-        args.push("--depth=1".into());
-    }
     // #5215: `GH_REPO` would otherwise override the repository argument.
     GhCommand::new(args).env_remove("GH_REPO")
 }
@@ -327,8 +330,8 @@ fn dir_size(path: &Path) -> (u64, bool) {
 
 /// Is this staged tree a checkout the sweep can actually read?
 ///
-/// Why: `gh` exiting zero is not proof of a usable repository. `git clone
-/// --depth=1` of a COMMITLESS repository exits zero and leaves a directory
+/// Why: `gh` exiting zero is not proof of a usable repository. Cloning a
+/// COMMITLESS repository exits zero and leaves a directory
 /// holding only `.git`, and `gh repo clone` forwards that status — reported as
 /// `Cloned`, the audit claims coverage of a repository nothing ever read
 /// (#5215 review). This is the check the `#[ignore]`d live test was making and
@@ -582,7 +585,7 @@ pub async fn clone_all(
             })?;
         }
 
-        let ran = clone_command(&name_with_owner, &staged, options.shallow)
+        let ran = clone_command(&name_with_owner, &staged)
             .output()
             .await
             .and_then(|o| o.ok())
@@ -937,12 +940,19 @@ mod clone_tests {
         ensure_real_dir(work_in(tmp.path()).path(Area::Repos)).expect("a real directory is fine");
     }
 
+    /// Why (#5916): the argv is where the defect lived. `-- --depth=1` here
+    /// made every tga database report one commit by one author over a
+    /// zero-length period, and nothing downstream could tell that apart from a
+    /// repository that genuinely has one commit.
+    /// What: the invocation carries no depth flag and no `--` separator, so
+    /// `gh` forwards nothing to `git` that could truncate the history.
+    /// Test: this is the test.
     #[test]
-    fn a_shallow_clone_forwards_depth_to_git() {
-        let argv = clone_command("acme/api", Path::new("/w/stage/acme/api"), true).argv_display();
-        assert_eq!(argv, "repo clone acme/api /w/stage/acme/api -- --depth=1");
-        let full = clone_command("acme/api", Path::new("/w/stage/acme/api"), false).argv_display();
-        assert!(!full.contains("--depth"), "{full}");
+    fn a_clone_asks_git_for_the_whole_history() {
+        let argv = clone_command("acme/api", Path::new("/w/stage/acme/api")).argv_display();
+        assert_eq!(argv, "repo clone acme/api /w/stage/acme/api");
+        assert!(!argv.contains("--depth"), "{argv}");
+        assert!(!argv.contains(" -- "), "{argv}");
     }
 
     /// The fail-open regression: a clone that died part-way must not leave a
@@ -1081,7 +1091,6 @@ mod clone_tests {
             &work,
             &["acme/api".to_string(), "acme/web".to_string()],
             &CloneOptions {
-                shallow: true,
                 budget_bytes: Some(4),
             },
             &Progress::none(),
@@ -1099,6 +1108,14 @@ mod clone_tests {
 
     /// The whole path against a real remote.
     ///
+    /// #5916: `.git/shallow` is the filesystem marker `git` writes exactly when
+    /// a clone was truncated, so asserting its ABSENCE is the depth contract
+    /// stated where it can only be true of a real fetch — `clone_command`'s argv
+    /// test proves the flag is gone, and this proves the fetch it produces is
+    /// whole. Its presence is what made every tga database report one commit.
+    /// The measured size is checked against the default budget in the same
+    /// breath, because full clones are the ones that could newly exhaust it.
+    ///
     /// `#[ignore]` because it needs an authenticated `gh` and network —
     /// `cargo test -p trusty-audit -- --include-ignored` runs it.
     #[tokio::test]
@@ -1115,8 +1132,18 @@ mod clone_tests {
         .await
         .expect("a public repository clones");
         assert_eq!(report.repos[0].state, CloneState::Cloned);
-        assert!(report.repos[0].path.join(".git").is_dir());
+        let checkout = &report.repos[0].path;
+        assert!(checkout.join(".git").is_dir());
+        assert!(
+            !checkout.join(".git/shallow").exists(),
+            "the clone was truncated — tga would read one commit by one author"
+        );
         assert!(report.total_bytes > 0, "the report must state disk use");
+        assert!(
+            report.total_bytes < DEFAULT_BUDGET_BYTES,
+            "one ordinary full clone must not exhaust the default budget: {} of {DEFAULT_BUDGET_BYTES}",
+            report.total_bytes
+        );
     }
     /// Why (#5823): every arm of the acquisition loop ends a unit, and two of
     /// them return early. A missed one leaves a display holding a repository

--- a/crates/trusty-audit/src/distribute.rs
+++ b/crates/trusty-audit/src/distribute.rs
@@ -77,9 +77,6 @@ pub const LAUNCHER_NAME: &str = "audit.sh";
 /// The generated README member.
 pub const README_NAME: &str = "README.md";
 
-/// Working directory the launcher pins, relative to the extracted root.
-const WORK_DIR_NAME: &str = "work";
-
 /// How much of the binary is read at a time while copying it.
 const CHUNK_BYTES: usize = 64 * 1024;
 
@@ -559,9 +556,24 @@ fn copy_binary<W: std::io::Write + std::io::Seek>(
 /// one in the package, and a `taudit` already installed on their machine at some
 /// other version must not win.
 /// What: POSIX `sh`, `set -eu`, `exec` so the exit status the client returns is
-/// the one the shell sees. Pins `--work-dir` beside the launcher so the client's
-/// `rm -rf` uninstall promise covers one predictable place.
-/// Test: `super::distribute_tests::the_launcher_resolves_everything_beside_itself`.
+/// the one the shell sees.
+///
+/// #5915: it no longer pins `--work-dir "$here/work"`. That pin put the run's
+/// tree wherever the recipient unzipped the package, and it therefore DECIDED
+/// the placement for every packaged run — the `WorkDir::resolve` default was
+/// unreachable from the only flow that ships. `trusty-search` refuses to index a
+/// checkout under `/tmp`, `/var/folders`, `~/Downloads`, `~/Desktop` or
+/// `~/Documents`, which is where an emailed zip gets opened, so the pin cost the
+/// code-analysis leg its data. Dropping it lets the default
+/// (`~/.trusty-tools/trusty-audit/work`) apply; `--work-dir` and
+/// `TRUSTY_AUDIT_WORKDIR` still override, and the recipient can still pass
+/// `--work-dir` through this launcher because `"$@"` is forwarded.
+///
+/// What this trades: the tree is no longer beside the launcher, so deleting the
+/// extracted folder no longer removes it. [`render_readme`] names the new
+/// location and the command that removes it.
+/// Test: `super::distribute_tests::the_launcher_resolves_everything_beside_itself`,
+/// `super::distribute_tests::the_launcher_leaves_the_work_root_to_the_client`.
 fn render_launcher() -> String {
     format!(
         "#!/bin/sh\n\
@@ -570,7 +582,6 @@ fn render_launcher() -> String {
          here=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\n\
          exec \"$here/{BINARY_NAME}\" \\\n\
          \x20 --config \"$here/{config}\" \\\n\
-         \x20 --work-dir \"$here/{WORK_DIR_NAME}\" \\\n\
          \x20 \"$@\"\n",
         config = EngagementConfig::FILE_NAME,
     )
@@ -600,12 +611,17 @@ fn render_readme(config: &EngagementConfig, platform: &str, explicit_binary: boo
         "# Audit client — {engagement}\n\
          \n\
          Extract this folder anywhere and run the three commands below from inside it.\n\
-         Nothing is installed on your machine outside this folder: deleting the folder\n\
-         removes the client, its tooling, and everything it wrote.\n\
+         Nothing is installed into your system directories.\n\
          \n\
          {platform_line}\n\
          - Configuration: `{config_file}` (readable — open it before you run anything)\n\
-         - Working directory: `{work}/`, created beside this file on first run\n\
+         - Working directory: `{work}`, created on first run\n\
+         \n\
+         The working directory holds the clones, the collected database and the\n\
+         tooling. It is NOT inside this folder — the code analysis cannot read a\n\
+         checkout under `~/Downloads`, `~/Desktop`, `~/Documents` or a temporary\n\
+         directory, which is where this folder usually lands. Override it with\n\
+         `--work-dir <path>` if you want it somewhere else.\n\
          \n\
          ## 1. Register what to audit\n\
          \n\
@@ -639,6 +655,18 @@ fn render_readme(config: &EngagementConfig, platform: &str, explicit_binary: boo
          carries reports and metadata, and it never carries the credential in\n\
          `{config_file}`.\n\
          \n\
+         ## 4. Remove it afterwards\n\
+         \n\
+         ```sh\n\
+         rm -rf {work}\n\
+         trusty-search index remove <each cloned repository path>\n\
+         ```\n\
+         \n\
+         Then delete this folder. The second command matters: to analyse your code the\n\
+         client approves each clone with `trusty-search`, and that approval is recorded\n\
+         in `trusty-search`'s own settings, outside the working directory. `run` prints\n\
+         each path it approves. `trusty-search index list` shows what is approved.\n\
+         \n\
          ## If macOS refuses to run it\n\
          \n\
          A zip that arrived over the network is quarantined, and this build is not yet\n\
@@ -649,7 +677,7 @@ fn render_readme(config: &EngagementConfig, platform: &str, explicit_binary: boo
          ```\n",
         config_file = EngagementConfig::FILE_NAME,
         launcher = LAUNCHER_NAME,
-        work = WORK_DIR_NAME,
+        work = crate::workdir::DEFAULT_ROOT_DISPLAY,
     )
 }
 
@@ -863,7 +891,6 @@ trusty-review = "0.16.0"
             script.contains("--config \"$here/engagement.toml\""),
             "{script}"
         );
-        assert!(script.contains("--work-dir \"$here/work\""), "{script}");
         // The binary is never named bare: every occurrence is `$here/`-prefixed,
         // so a `taudit` already on PATH at some other version cannot win.
         for (index, _) in script.match_indices(BINARY_NAME) {
@@ -872,6 +899,50 @@ trusty-review = "0.16.0"
                 "the launcher must never reach for an installed taudit: {script}"
             );
         }
+    }
+
+    /// #5915: the launcher used to pass `--work-dir "$here/work"`, which decided
+    /// the placement for every packaged run and made `WorkDir::resolve`'s default
+    /// dead code. A checkout under the unzip location is one `trusty-search`
+    /// refuses to index, so the code-analysis leg came back empty on every real
+    /// recipient machine. The launcher must now name no work directory at all
+    /// and forward whatever the recipient passes.
+    #[test]
+    fn the_launcher_leaves_the_work_root_to_the_client() {
+        let fixture = Fixture::new(TEMPLATE);
+        let package = fixture.assemble().expect("assembles");
+
+        let script = member(&package.path, "trusty-audit/audit.sh");
+        assert!(
+            !script.contains("--work-dir"),
+            "the launcher pins the work root again: {script}"
+        );
+        assert!(
+            script.contains("\"$@\""),
+            "the recipient can no longer pass --work-dir through: {script}"
+        );
+    }
+
+    /// The README's uninstall instructions are the only place the recipient
+    /// learns that the tree is not beside the launcher and that approving a
+    /// clone wrote a row outside it (#5915).
+    #[test]
+    fn the_readme_names_where_the_work_root_is_and_how_to_undo_the_approval() {
+        let fixture = Fixture::new(TEMPLATE);
+        let package = fixture.assemble().expect("assembles");
+
+        let readme = member(&package.path, "trusty-audit/README.md");
+        assert!(
+            readme.contains(crate::workdir::DEFAULT_ROOT_DISPLAY),
+            "{readme}"
+        );
+        assert!(readme.contains("trusty-search index remove"), "{readme}");
+        assert!(
+            !readme.contains(
+                "deleting the folder\nremoves the client, its tooling, and everything it wrote"
+            ),
+            "the README still promises a complete uninstall it cannot deliver: {readme}"
+        );
     }
 
     #[test]

--- a/crates/trusty-audit/src/main.rs
+++ b/crates/trusty-audit/src/main.rs
@@ -32,7 +32,15 @@ async fn main() -> Result<()> {
 
     let cwd = std::env::current_dir().context("cannot determine the current directory")?;
     let env_value = std::env::var(WORKDIR_ENV).ok();
-    let work = WorkDir::resolve(cli.work_dir.clone(), env_value.as_deref(), &cwd);
+    // #5915: the home directory is read here, with the rest of the environment,
+    // so `resolve` stays a pure function of what it is handed.
+    let home = dirs::home_dir();
+    let work = WorkDir::resolve(
+        cli.work_dir.clone(),
+        env_value.as_deref(),
+        home.as_deref(),
+        &cwd,
+    );
 
     // #5797: the policy lives on `Session`, so the Tauri shell sets it the same
     // way rather than reimplementing when to install.

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -102,6 +102,13 @@ mod verify;
 // — so it separates cleanly.
 mod pins;
 
+// #5915: approving each clone with `trusty-search` before `tga` tries to index
+// it. Its own module for the same reason `pins` is one — this file is at the
+// 500-SLOC production cap — and because the flag it deliberately does not pass
+// needs somewhere to be explained and asserted.
+mod approve;
+
+use approve::approve_for_indexing;
 use pins::{PinnedBinaries, pinned_binaries};
 use verify::verify_output;
 
@@ -619,7 +626,7 @@ async fn run_one(
     progress.unit_started(Operation::Sweep, repo.name.as_str(), index + 1, total);
 
     let mut gaps = Vec::new();
-    let result = match prepare(work, &output, &stem, &checkout, boards)? {
+    let result = match prepare(work, &output, &stem, &checkout, boards, &binaries.search)? {
         Err(reason) => RepoResult::Failed { reason },
         Ok(config_path) => {
             match spawn_tga(
@@ -672,18 +679,29 @@ async fn run_one(
 /// The inner `Result` is the per-repo verdict: `Err(reason)` is a recorded
 /// failure for this repository, while the outer `Result` is a failure of the
 /// sweep itself (the working directory is not writable).
+///
+/// #5915: approving the checkout with `trusty-search` belongs here rather than
+/// inside the child, for two reasons. It runs before any child spawns, so a
+/// refusal costs nothing; and this function already returns `Err(reason)` as a
+/// per-repo verdict, which is what turns the refusal into a NAMED failure. Left
+/// where it was, a refusal reached nobody — `tga audit` exits 0 whenever the
+/// sweep completed, so the run reported success with an empty code-analysis leg.
 fn prepare(
     work: &WorkDir,
     output: &Path,
     stem: &str,
     checkout: &Path,
     boards: &boards::Boards,
+    search: &Path,
 ) -> Result<Result<PathBuf, String>, AuditError> {
     if !checkout.is_dir() {
         return Ok(Err(format!(
             "no checkout at {} — nothing was audited for this repository",
             checkout.display()
         )));
+    }
+    if let Err(reason) = approve_for_indexing(search, checkout) {
+        return Ok(Err(reason));
     }
     mkdir(output)?;
     let config_path = work.path(Area::State).join(format!("tga-{stem}.yaml"));
@@ -1020,12 +1038,34 @@ trusty-review = "0.15.1"
         )
     }
 
+    /// A stub `trusty-search` that approves whatever it is asked to approve.
+    ///
+    /// #5915: `prepare` now runs `trusty-search index add <checkout>` before any
+    /// tga child, so a stub that refuses fails the repository before the
+    /// behaviour under test is reached. Every test that is about tga gets this
+    /// one; the two that are about the approval install their own.
+    const SEARCH_APPROVES: &str = "#!/bin/sh\nexit 0\n";
+
     /// Place stub binaries AND the version record, which together are what
     /// `pinned_binaries` accepts.
+    ///
+    /// `script` is the TGA-side behaviour under test. `trusty-search` gets
+    /// [`SEARCH_APPROVES`] instead, because it answers a different question and
+    /// a shared script conflates the two (#5915).
     fn install_stubs(work: &WorkDir, script: &str) {
+        install_stubs_with_search(work, script, SEARCH_APPROVES);
+    }
+
+    /// [`install_stubs`], with the `trusty-search` stub named separately.
+    fn install_stubs_with_search(work: &WorkDir, script: &str, search: &str) {
         for tool in RequiredTool::ALL {
             let path = tool.path_in(work);
-            std::fs::write(&path, script).expect("stub binary");
+            let body = if tool == RequiredTool::TrustySearch {
+                search
+            } else {
+                script
+            };
+            std::fs::write(&path, body).expect("stub binary");
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt as _;
@@ -1339,6 +1379,58 @@ trusty-review = "0.15.1"
     /// The error arm this module exists for: a child that exits non-zero must
     /// not read as a success, and the sweep must not stop at it.
     #[cfg(unix)]
+    /// #5915: the refusal that used to reach nobody. `trusty-search` is
+    /// default-deny, tga's index call uses the strict denylist check, and
+    /// `tga audit` exits 0 whenever its sweep completed — so an unapproved
+    /// checkout produced a SUCCESSFUL run whose code-analysis leg had read
+    /// nothing. It must now be a named per-repository failure instead, and the
+    /// tga child must not run at all.
+    #[tokio::test]
+    async fn an_unapprovable_checkout_fails_the_repository_by_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let ran = tmp.path().join("tga-ran");
+        install_stubs_with_search(
+            &work,
+            &format!("#!/bin/sh\ntouch '{}'\nexit 0\n", ran.display()),
+            "#!/bin/sh\necho 'indexing refused: not approved for indexing' >&2\nexit 1\n",
+        );
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("the sweep completes");
+
+        assert_eq!(report.status, RunStatus::AllFailed, "{report:?}");
+        let RepoResult::Failed { reason } = &report.repos[0].result else {
+            panic!("a refused approval must fail the repository: {report:?}");
+        };
+        assert!(reason.contains("trusty-search index add"), "{reason}");
+        assert!(reason.contains("not approved for indexing"), "{reason}");
+        assert!(
+            !ran.exists(),
+            "tga was spawned for a checkout it could never have indexed"
+        );
+    }
+
+    /// The other half: an approval that succeeds leaves the sweep exactly as it
+    /// was, so #5915's fix costs a working run nothing.
+    #[tokio::test]
+    async fn an_approved_checkout_proceeds_to_the_child() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &writes_a_manifest(None));
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("the sweep completes");
+
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+    }
+
     #[tokio::test]
     async fn a_failing_child_is_recorded_and_the_sweep_continues() {
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/trusty-audit/src/run/approve.rs
+++ b/crates/trusty-audit/src/run/approve.rs
@@ -1,0 +1,220 @@
+//! Approving a clone for indexing, so the code-analysis leg has something to read.
+//!
+//! Why: #5915. `trusty-search` is default-deny — a path nobody approved is not
+//! indexed, and `tga audit` runs `trusty-search index <checkout> --name <id>`,
+//! whose handler refuses an unapproved root outright
+//! (`trusty-search/src/commands/index.rs`, the `AllowlistVerdict::NotAllowlisted`
+//! arm). Nothing in the audit chain ever approved anything, so that refusal fired
+//! on every repository of every run. It cost the whole code-analysis leg, and it
+//! cost it SILENTLY: `tga audit` exits 0 when the sweep completed, so the run
+//! reported success and the report simply had nothing to say about the code.
+//!
+//! The approval is a separate verb from the index: `trusty-search index add
+//! <path>` writes a row to `trusty-search`'s allowlist, and only then does
+//! `trusty-search index <path>` proceed.
+//!
+//! What: [`approve_for_indexing`], plus the two pure halves it is made of so
+//! they can be asserted without a live daemon — [`index_add_args`] and
+//! [`refusal`].
+//!
+//! `--allow-sensitive-path` is deliberately NOT passed. It is not reachable from
+//! tga's path anyway — `handle_index` calls the strict `is_denied`, so approving
+//! a denied root would leave the run refused at the next step regardless — and it
+//! does not relax `SENSITIVE_HOME_TOP_DIRS`, which is the rule a recipient
+//! unzipping into `~/Downloads` actually hits. Placement is what fixes those;
+//! see `crate::workdir::WorkDir::resolve`.
+//!
+//! Test: `super::run_tests::an_unapprovable_checkout_fails_the_repository_by_name`,
+//! `super::run_tests::an_approved_checkout_proceeds_to_the_child`, and this
+//! module's own `approve_tests`.
+
+use std::ffi::OsString;
+use std::path::Path;
+use std::process::Output;
+
+/// Approve `checkout` with the pinned `trusty-search`, or say why it refused.
+///
+/// Why: see the module docs — without this the sweep's code-analysis leg reads
+/// nothing, and reports nothing, and exits 0.
+/// What: runs `<search> index add <checkout>` and turns a non-zero exit into a
+/// reason string. `index add` upserts, so re-approving a checkout a previous run
+/// already approved succeeds rather than erroring — which is what makes this
+/// safe to call on every repository of a resumed run.
+///
+/// # Postconditions
+/// On `Ok`, `trusty-search` holds an allowlist row for `checkout` — written
+/// OUTSIDE the work root, which is why `crate::workdir`'s module docs no longer
+/// promise `rm -rf <root>` is a complete uninstall.
+/// On `Err`, the string is one line, safe to show the recipient, and names the
+/// checkout.
+///
+/// This is synchronous inside an async caller on purpose: `index add`
+/// canonicalises a path and rewrites one small TOML file, so it returns in
+/// well under the time the `tga` child it precedes takes to start.
+pub(super) fn approve_for_indexing(search: &Path, checkout: &Path) -> Result<(), String> {
+    let output = std::process::Command::new(search)
+        .args(index_add_args(checkout))
+        .output()
+        .map_err(|e| {
+            format!(
+                "could not run `{} index add {}`: {e} — the code analysis would have had nothing to read",
+                search.display(),
+                checkout.display()
+            )
+        })?;
+    match refusal(checkout, &output) {
+        Some(reason) => Err(reason),
+        None => Ok(()),
+    }
+}
+
+/// The argv `trusty-search` is given, with no opt-in flag.
+///
+/// Kept separate so the absence of `--allow-sensitive-path` is asserted rather
+/// than assumed — the flag is the fix this deliberately did not take (see the
+/// module docs), and a later edit adding it would otherwise pass unnoticed.
+fn index_add_args(checkout: &Path) -> Vec<OsString> {
+    vec![
+        OsString::from("index"),
+        OsString::from("add"),
+        checkout.as_os_str().to_owned(),
+    ]
+}
+
+/// A non-zero exit rendered as one line the recipient can act on.
+///
+/// Why the child's own stderr is quoted rather than replaced: the refusals differ
+/// in what the recipient must do about them — a denylisted path needs a different
+/// working directory, an unreadable allowlist needs a permissions fix — and only
+/// `trusty-search` knows which one fired.
+fn refusal(checkout: &Path, output: &Output) -> Option<String> {
+    if output.status.success() {
+        return None;
+    }
+    let said = String::from_utf8_lossy(&output.stderr);
+    let detail = said
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("no reason given");
+    Some(format!(
+        "`trusty-search index add {}` refused ({}): {detail} — the code analysis \
+         would have read nothing for this repository",
+        checkout.display(),
+        output.status,
+    ))
+}
+
+#[cfg(test)]
+mod approve_tests {
+    use super::*;
+    use std::os::unix::process::ExitStatusExt as _;
+    use std::process::ExitStatus;
+
+    fn output(code: i32, stderr: &str) -> Output {
+        Output {
+            status: ExitStatus::from_raw(code << 8),
+            stdout: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
+    /// The flag the owner ruled out. `--allow-sensitive-path` cannot help here:
+    /// tga's own index call uses the strict check, so a root approved through the
+    /// bypass is refused at the next step anyway.
+    #[test]
+    fn the_approval_never_asks_for_the_sensitive_path_bypass() {
+        let args = index_add_args(Path::new(
+            "/Users/r/.trusty-tools/trusty-audit/work/repos/xsv",
+        ));
+        assert_eq!(
+            args,
+            vec![
+                OsString::from("index"),
+                OsString::from("add"),
+                OsString::from("/Users/r/.trusty-tools/trusty-audit/work/repos/xsv"),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_zero_exit_is_an_approval() {
+        assert_eq!(refusal(Path::new("/w/repos/xsv"), &output(0, "")), None);
+    }
+
+    /// #5915 is entirely about this line existing. The refusal used to reach
+    /// nobody: tga exited 0, so the run reported success with an empty leg.
+    #[test]
+    fn a_refusal_names_the_checkout_and_quotes_what_search_said() {
+        let reason = refusal(
+            Path::new("/var/folders/9x/T/work/repos/xsv"),
+            &output(
+                1,
+                "\n  indexing refused: path is under a temporary directory\n",
+            ),
+        )
+        .expect("a non-zero exit is a refusal");
+
+        assert!(
+            reason.contains("/var/folders/9x/T/work/repos/xsv"),
+            "{reason}"
+        );
+        assert!(
+            reason.contains("indexing refused: path is under a temporary directory"),
+            "{reason}"
+        );
+        assert_eq!(reason.lines().count(), 1, "must stay one line: {reason}");
+    }
+
+    #[test]
+    fn a_silent_refusal_still_produces_a_reason() {
+        let reason = refusal(Path::new("/w/repos/xsv"), &output(2, ""))
+            .expect("a non-zero exit is a refusal");
+        assert!(reason.contains("no reason given"), "{reason}");
+    }
+
+    /// The spawn itself, not just the two pure halves: a stub standing in for
+    /// `trusty-search` proves the argv reaches a child and its exit is read.
+    #[cfg(unix)]
+    #[test]
+    fn a_stub_search_that_refuses_is_reported_rather_than_ignored() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let stub = tmp.path().join("trusty-search");
+        std::fs::write(
+            &stub,
+            "#!/bin/sh\necho \"indexing refused: $3 is not approved\" >&2\nexit 1\n",
+        )
+        .expect("write stub");
+        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        let err = approve_for_indexing(&stub, Path::new("/w/repos/xsv"))
+            .expect_err("a refusing search must fail the repository");
+        assert!(err.contains("/w/repos/xsv"), "{err}");
+        assert!(err.contains("is not approved"), "{err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_stub_search_that_approves_lets_the_repository_proceed() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let stub = tmp.path().join("trusty-search");
+        std::fs::write(&stub, "#!/bin/sh\nexit 0\n").expect("write stub");
+        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        approve_for_indexing(&stub, Path::new("/w/repos/xsv")).expect("a zero exit is an approval");
+    }
+
+    /// A missing binary is a failure of this repository, never a panic and never
+    /// a silent skip — the pinned-tool preflight should have caught it, and if it
+    /// did not, the recipient still gets a named reason.
+    #[test]
+    fn a_search_binary_that_cannot_be_run_is_a_reason_not_a_panic() {
+        let err = approve_for_indexing(Path::new("/nonexistent/trusty-search"), Path::new("/w/x"))
+            .expect_err("an unspawnable binary must fail the repository");
+        assert!(err.contains("could not run"), "{err}");
+    }
+}

--- a/crates/trusty-audit/src/workdir.rs
+++ b/crates/trusty-audit/src/workdir.rs
@@ -6,10 +6,15 @@
 //! now rather than retrofitting one once four features have each picked their
 //! own path. Two properties follow from designing it here:
 //!
-//! - **Everything is under one root.** `rm -rf <root>` is a complete uninstall
-//!   because no path this crate writes escapes the root — that is the property
-//!   `layout_tests::every_layout_path_is_inside_the_root` proves, and it is what
-//!   the README's deletion instructions rest on.
+//! - **Everything this module computes is under one root.** No path in the
+//!   layout escapes it — `layout_tests::every_layout_path_is_inside_the_root`
+//!   proves that, and the README's deletion instructions rest on it.
+//!
+//!   `rm -rf <root>` is no longer a COMPLETE uninstall, and #5915 is where that
+//!   stopped being true: approving a checkout for indexing writes a row to
+//!   `trusty-search`'s own allowlist, outside this root and outside this crate's
+//!   reach. `trusty-search index remove <checkout>` is what undoes it. The
+//!   README says so rather than promising a completeness that is not there.
 //! - **The root holds the recipient's source.** `repos/` is their checkouts and
 //!   `extract/` is derived from them, so this is a data-handling surface. The
 //!   README states what is written where (#5494).
@@ -29,15 +34,13 @@
 //!
 //! ## Open questions, recorded rather than resolved (#5502)
 //!
-//! 1. **Where the root should live.** The scaffold's default is
-//!    `<cwd>/trusty-audit-work`, chosen because the handoff arrives as an
-//!    unzipped directory the recipient already has open (#5473) — so the audit's
-//!    files sit beside the thing they unzipped instead of in a hidden home
-//!    directory they were never told about. The alternative,
-//!    `~/.trusty-tools/trusty-audit/`, matches the rest of this workspace's
-//!    convention and survives the recipient deleting the unzipped folder. Not
-//!    settled; the default here is a placeholder, and `--work-dir` plus
-//!    [`WORKDIR_ENV`] make it overridable meanwhile.
+//! 1. ~~**Where the root should live.**~~ Settled by #5915:
+//!    `~/.trusty-tools/trusty-audit/work`. The scaffold put it beside the
+//!    unzipped folder so the recipient could see it, but `trusty-search` refuses
+//!    to index a checkout under `/tmp`, `/var/folders`, `~/Downloads`,
+//!    `~/Desktop` or `~/Documents` — and those are where an emailed package gets
+//!    unzipped — so the placement silently cost every run its code-analysis leg.
+//!    See [`WorkDir::resolve`]. The property below is what this trades away.
 //! 2. **Whether two runs may share one root.** Nothing here locks, and the
 //!    scaffold does not decide. Sharing is attractive (a second engagement
 //!    reuses the downloaded tools) and dangerous (`state/` and `out/` are
@@ -54,8 +57,18 @@ use crate::error::AuditError;
 /// Environment variable that overrides the default working-directory root.
 pub const WORKDIR_ENV: &str = "TRUSTY_AUDIT_WORKDIR";
 
-/// Directory name appended to the current directory when nothing overrides it.
+/// Directory name appended to the current directory when home cannot be found.
 pub const DEFAULT_WORKDIR_NAME: &str = "trusty-audit-work";
+
+/// This crate's directory under `~/.trusty-tools`, per the workspace convention
+/// `trusty_common::crate_config` owns.
+const CRATE_NAME: &str = "trusty-audit";
+
+/// Subdirectory of `~/.trusty-tools/trusty-audit` the work root occupies.
+///
+/// `config.yaml` is the sibling `crate_config` writes, so the run's own tree is
+/// kept one level down rather than sharing that directory.
+const WORK_SUBDIR: &str = "work";
 
 /// One entry in the working-directory layout.
 ///
@@ -150,10 +163,25 @@ impl WorkDir {
     /// output directory and the extract database together.
     ///
     /// What: `explicit` wins; else `env_value` (the value of [`WORKDIR_ENV`]);
-    /// else [`DEFAULT_WORKDIR_NAME`]; then `cwd.join(...)`, which returns an
-    /// absolute choice unchanged. An empty env value is ignored, since
-    /// `TRUSTY_AUDIT_WORKDIR=` is far more likely to be an unset shell variable
-    /// than a request to use the filesystem root.
+    /// else `~/.trusty-tools/trusty-audit/work`; else — only when `home` is
+    /// `None` — [`DEFAULT_WORKDIR_NAME`] beside the cwd. Then `cwd.join(...)`,
+    /// which returns an absolute choice unchanged. An empty env value is
+    /// ignored, since `TRUSTY_AUDIT_WORKDIR=` is far more likely to be an unset
+    /// shell variable than a request to use the filesystem root.
+    ///
+    /// #5915: the default moved out of the cwd because the cwd is wherever the
+    /// recipient unzipped the package, and `trusty-search` refuses to index a
+    /// checkout under one — `/var/folders` and `/tmp` by
+    /// `SENSITIVE_PATH_PREFIXES`, and `~/Downloads`, `~/Desktop`, `~/Documents`
+    /// by `SENSITIVE_HOME_TOP_DIRS`. `~/Downloads` is where a recipient
+    /// unzipping an emailed package lands by default, so the refusal was the
+    /// ordinary case rather than an edge one, and it cost the whole
+    /// code-analysis leg. `~/.trusty-tools/<crate>` is the one home location the
+    /// denylist permits, and it is already this workspace's convention —
+    /// [`trusty_common::crate_config`] owns the path so this crate does not spell
+    /// a second one.
+    ///
+    /// `home` is passed in rather than read, for the same reason `env_value` is.
     ///
     /// This joins rather than calling `std::fs::canonicalize`, deliberately.
     /// The root normally does not exist yet — [`WorkDir::create`] makes it — and
@@ -162,15 +190,21 @@ impl WorkDir {
     /// print a root the recipient never typed and weaken the README's
     /// `rm -rf <root>` instruction. Joining needs no I/O and cannot fail.
     /// Test: `super::layout_tests::resolution_order_is_flag_then_env_then_default`,
-    /// `super::layout_tests::a_relative_choice_is_anchored_to_the_cwd`.
-    pub fn resolve(explicit: Option<PathBuf>, env_value: Option<&str>, cwd: &Path) -> Self {
+    /// `super::layout_tests::a_relative_choice_is_anchored_to_the_cwd`,
+    /// `super::layout_tests::the_default_root_is_one_trusty_search_will_index`.
+    pub fn resolve(
+        explicit: Option<PathBuf>,
+        env_value: Option<&str>,
+        home: Option<&Path>,
+        cwd: &Path,
+    ) -> Self {
         let chosen = explicit
             .or_else(|| {
                 env_value
                     .filter(|v| !v.trim().is_empty())
                     .map(PathBuf::from)
             })
-            .unwrap_or_else(|| PathBuf::from(DEFAULT_WORKDIR_NAME));
+            .unwrap_or_else(|| default_root(home));
         Self::new(cwd.join(chosen))
     }
 
@@ -216,6 +250,28 @@ impl WorkDir {
         Ok(())
     }
 }
+
+/// Where the run's tree lands when neither the flag nor the environment names a
+/// place (#5915).
+///
+/// Absolute when `home` is known. The relative fallback is the pre-#5915
+/// behaviour, kept only for the case it was never the wrong answer to: a
+/// stripped environment with no home directory, where there is nowhere better
+/// and the cwd is at least writable.
+fn default_root(home: Option<&Path>) -> PathBuf {
+    match home {
+        Some(home) => {
+            trusty_common::crate_config::crate_config_dir_at(home, CRATE_NAME).join(WORK_SUBDIR)
+        }
+        None => PathBuf::from(DEFAULT_WORKDIR_NAME),
+    }
+}
+
+/// The default root as the README and the CLI spell it for a human (#5915).
+///
+/// The tilde is deliberate: it is what the recipient types to reach the
+/// directory, and what a `rm -rf` instruction must name.
+pub const DEFAULT_ROOT_DISPLAY: &str = "~/.trusty-tools/trusty-audit/work";
 
 /// Write a state file so no reader can ever observe a partial one.
 ///
@@ -403,18 +459,65 @@ fn writer_tag() -> String {
 mod layout_tests {
     use super::*;
 
+    const HOME: &str = "/Users/recipient";
+
     #[test]
     fn resolution_order_is_flag_then_env_then_default() {
         let cwd = Path::new("/engagement");
+        let home = Some(Path::new(HOME));
 
-        let flag = WorkDir::resolve(Some(PathBuf::from("/flag")), Some("/env"), cwd);
+        let flag = WorkDir::resolve(Some(PathBuf::from("/flag")), Some("/env"), home, cwd);
         assert_eq!(flag.root(), Path::new("/flag"));
 
-        let env = WorkDir::resolve(None, Some("/env"), cwd);
+        let env = WorkDir::resolve(None, Some("/env"), home, cwd);
         assert_eq!(env.root(), Path::new("/env"));
 
-        let default = WorkDir::resolve(None, None, cwd);
-        assert_eq!(default.root(), Path::new("/engagement/trusty-audit-work"));
+        let default = WorkDir::resolve(None, None, home, cwd);
+        assert_eq!(
+            default.root(),
+            Path::new("/Users/recipient/.trusty-tools/trusty-audit/work")
+        );
+    }
+
+    /// #5915: the default is the one placement `trusty-search` will index. The
+    /// cwd is the recipient's unzip location, and every likely one of those —
+    /// `/tmp`, `/var/folders`, `~/Downloads`, `~/Desktop`, `~/Documents` — is on
+    /// a denylist no flag on tga's path relaxes, so a checkout under the cwd was
+    /// refused and the code-analysis leg came back empty.
+    ///
+    /// The assertion is the placement, not the refusal: the denylist lives in
+    /// `trusty-search` and this crate cannot call it. What this pins is that the
+    /// default no longer descends from the cwd at all.
+    #[test]
+    fn the_default_root_is_one_trusty_search_will_index() {
+        let home = Path::new(HOME);
+        for unzipped_at in [
+            "/var/folders/9x/T/taudit-package",
+            "/tmp/taudit-package",
+            "/Users/recipient/Downloads/trusty-audit",
+            "/Users/recipient/Desktop/trusty-audit",
+            "/Users/recipient/Documents/trusty-audit",
+        ] {
+            let resolved = WorkDir::resolve(None, None, Some(home), Path::new(unzipped_at));
+            assert_eq!(
+                resolved.root(),
+                Path::new("/Users/recipient/.trusty-tools/trusty-audit/work"),
+                "unzipping at {unzipped_at} still decided the root"
+            );
+            assert!(
+                !resolved.root().starts_with(unzipped_at),
+                "the root descends from the unzip location: {}",
+                resolved.root().display()
+            );
+        }
+    }
+
+    /// The one case the pre-#5915 cwd-relative default survives for: no home to
+    /// put anything under. It is not a good root — it is the only one left.
+    #[test]
+    fn without_a_home_directory_the_root_falls_back_beside_the_cwd() {
+        let resolved = WorkDir::resolve(None, None, None, Path::new("/engagement"));
+        assert_eq!(resolved.root(), Path::new("/engagement/trusty-audit-work"));
     }
 
     /// #5672: a relative choice from either source becomes absolute, because
@@ -422,19 +525,32 @@ mod layout_tests {
     #[test]
     fn a_relative_choice_is_anchored_to_the_cwd() {
         let cwd = Path::new("/engagement");
+        let home = Some(Path::new(HOME));
 
-        let flag = WorkDir::resolve(Some(PathBuf::from("w")), None, cwd);
+        let flag = WorkDir::resolve(Some(PathBuf::from("w")), None, home, cwd);
         assert_eq!(flag.root(), Path::new("/engagement/w"));
 
-        let env = WorkDir::resolve(None, Some("w"), cwd);
+        let env = WorkDir::resolve(None, Some("w"), home, cwd);
         assert_eq!(env.root(), Path::new("/engagement/w"));
     }
 
     #[test]
     fn a_blank_env_value_falls_through_to_the_default() {
         let cwd = Path::new("/engagement");
-        let resolved = WorkDir::resolve(None, Some("   "), cwd);
-        assert_eq!(resolved.root(), Path::new("/engagement/trusty-audit-work"));
+        let resolved = WorkDir::resolve(None, Some("   "), Some(Path::new(HOME)), cwd);
+        assert_eq!(
+            resolved.root(),
+            Path::new("/Users/recipient/.trusty-tools/trusty-audit/work")
+        );
+    }
+
+    /// The README and the CLI print this string; the resolver computes a path.
+    /// They must name the same place, and nothing else checks that they do.
+    #[test]
+    fn the_display_string_names_the_path_the_resolver_returns() {
+        let home = Path::new(HOME);
+        let expanded = DEFAULT_ROOT_DISPLAY.replacen('~', &home.display().to_string(), 1);
+        assert_eq!(default_root(Some(home)), PathBuf::from(expanded));
     }
 
     /// The property the README's "delete the directory" instruction rests on.

--- a/scripts/taudit-live-acceptance.sh
+++ b/scripts/taudit-live-acceptance.sh
@@ -17,12 +17,24 @@
 #      validation against a real `gh` credential.
 #   5. Runs the one-shot `audit` chain end to end: install the pinned tools,
 #      clone, analyse via OpenRouter, and assemble the return package.
-#   6. Opens the returned zip and checks its CONTENTS, not just its
-#      existence: the collected SQLite extract database is present and
-#      non-trivial, and the report is present and non-empty.
+#   6. Opens the returned zip and checks its DATA, not just its shape: the
+#      extract database holds ROWS in the tables the audit is made of, more
+#      than one commit, more than one author, and the report names real
+#      files from the audited repository.
 #   7. Greps every extracted member of the returned zip for the OpenRouter
 #      key and fails loudly if it finds it — the one guard whose failure is
 #      invisible by inspection alone.
+#
+# What it deliberately does NOT do any more (#5915, #5916):
+#   - It does not count `sqlite_master` rows. That counts TABLES, which a
+#     migration creates whether or not one byte of data was ever collected,
+#     so it passed against a database holding nothing.
+#   - It does not check the report is merely non-empty. A report assembled
+#     from an empty extract is several KiB of headings.
+#   - It does not put its scratch tree under `mktemp -d`. On macOS that is
+#     `/var/folders/...`, which `trusty-search` refuses to index — so the
+#     script structurally guaranteed the very refusal it should have been
+#     able to catch, and no placement bug could ever make it fail.
 #
 # Requires:
 #   - A real OPENROUTER_API_KEY exported in the environment (never read from
@@ -46,11 +58,23 @@
 #   TAUDIT_E2E_REPO=owner/name OPENROUTER_API_KEY=... scripts/taudit-live-acceptance.sh
 #
 # Idempotent: every artifact this script writes lives under a fresh
-# `mktemp -d` scratch directory, so `taudit distribute`'s refusal to
-# overwrite an existing package never triggers — there is never a package
-# already at the destination. Two consecutive runs are two independent
-# scratch trees. Nothing under ~/duetto/audit, or any other real working
-# directory, is ever touched.
+# per-run directory beneath ~/.taudit-acceptance, so `taudit distribute`'s
+# refusal to overwrite an existing package never triggers — there is never a
+# package already at the destination. Two consecutive runs are two
+# independent scratch trees. Nothing under ~/duetto/audit is ever touched.
+#
+# NOT under `mktemp -d`: see the note above. `~/.taudit-acceptance` is a
+# location `trusty-search` permits, which is the point — the script must be
+# able to observe a placement bug rather than guarantee one.
+#
+# What this script leaves behind on your machine, and how to remove it:
+#   - `~/.trusty-tools/trusty-audit/work` — the run's own tree. `rm -rf` it.
+#   - One `trusty-search` allowlist row per audited clone, in
+#     `~/Library/Application Support/trusty-search/allowlist.toml`. The script
+#     prints them and asserts it destroyed no PRE-EXISTING row, but it does
+#     not remove its own: `trusty-search index remove` ignores its path
+#     argument in 0.45.1 and resolves the index from the CWD instead, so
+#     calling it here would drop an unrelated index. Remove them by hand.
 
 set -euo pipefail
 
@@ -106,17 +130,31 @@ if ! gh auth status >/dev/null 2>&1; then
 fi
 ok "gh auth status: authenticated"
 
-# A small, real, public repository so the sweep finishes in minutes rather
-# than hours: essentially one file and a handful of commits, which still
-# exercises every phase (clone, tga collection, trusty-review inference,
-# packaging) without a large checkout or a long analysis pass. Override with
-# TAUDIT_E2E_REPO=owner/name for a heavier exercise of the pipeline.
-TARGET_REPO="${TAUDIT_E2E_REPO:-octocat/Hello-World}"
+# A small, real, public repository with a REAL history: 1.2 MiB, ~400
+# commits by ~30 authors over a decade, and actual Rust source for the code
+# analysis to have something to name. The previous default,
+# octocat/Hello-World, was too small to test anything — 3 commits means a
+# "more than one commit" assertion barely separates a full clone from a
+# shallow one, and a repository of one README gives the code-analysis leg no
+# file to mention whether it worked or not.
+# Override with TAUDIT_E2E_REPO=owner/name for a heavier exercise.
+TARGET_REPO="${TAUDIT_E2E_REPO:-BurntSushi/xsv}"
 ok "audit target: $TARGET_REPO (override with TAUDIT_E2E_REPO)"
 
 # --- scratch state, cleaned up on success, kept (and named) on failure ---
 
-SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/taudit-live-acceptance.XXXXXX")"
+# Deliberately NOT `mktemp -d`: on macOS that is /var/folders/..., which
+# `trusty-search` refuses to index (SENSITIVE_PATH_PREFIXES). A run whose
+# every path is pre-refused cannot distinguish a working pipeline from a
+# broken one. `~/.taudit-acceptance` is permitted — it is not `~` itself and
+# not one of SENSITIVE_HOME_TOP_DIRS (Desktop, Downloads, Documents,
+# Pictures, Movies, Music, Library).
+SCRATCH="$HOME/.taudit-acceptance/run-$$-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$SCRATCH"
+case "$SCRATCH" in
+  /var/folders/*|/private/var/folders/*|/tmp/*|/private/tmp/*)
+    fail "scratch root landed on a path trusty-search refuses to index: $SCRATCH" ;;
+esac
 cleanup() {
   local exit_code=$?
   if [ "$exit_code" -eq 0 ]; then
@@ -126,6 +164,27 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
+
+# The run's own tree is no longer beside the extracted package (#5915): it is
+# at the client's default, which is the one home location trusty-search will
+# index. A previous run's tree would make "did this run collect anything"
+# unanswerable, so it starts clean.
+WORK_ROOT="$HOME/.trusty-tools/trusty-audit/work"
+rm -rf "$WORK_ROOT"
+ok "work root reset: $WORK_ROOT"
+
+# The allowlist rows this run adds live outside the work root, so `rm -rf` on
+# either does not undo them. Snapshot what was approved BEFORE, so the run
+# can be shown to have destroyed none of it.
+ALLOWLIST="$HOME/Library/Application Support/trusty-search/allowlist.toml"
+ALLOWLIST_BEFORE="$SCRATCH/allowlist-before.toml"
+if [ -f "$ALLOWLIST" ]; then
+  cp "$ALLOWLIST" "$ALLOWLIST_BEFORE"
+  ok "snapshotted the pre-existing trusty-search allowlist ($(grep -c '^\[\[index\]\]' "$ALLOWLIST_BEFORE" || true) entries)"
+else
+  : >"$ALLOWLIST_BEFORE"
+  ok "no pre-existing trusty-search allowlist to preserve"
+fi
 
 AUDITOR_DIR="$SCRATCH/auditor"
 DIST_DIR="$SCRATCH/dist"
@@ -264,23 +323,89 @@ case "$HEADER" in
   "SQLite format 3"*) ok "DB header is a real SQLite file: $DB_FILE" ;;
   *) fail "DB does not have a SQLite header (got: '$HEADER'): $DB_FILE" ;;
 esac
-if [ "$SQLITE3_AVAILABLE" -eq 1 ]; then
-  TABLE_COUNT="$(sqlite3 "$DB_FILE" 'SELECT count(*) FROM sqlite_master;')" \
-    || fail "sqlite3 could not read $DB_FILE"
-  [ "$TABLE_COUNT" -gt 0 ] || fail "collected DB has zero tables — not a real extract: $DB_FILE"
-  ok "DB is non-trivial: $DB_BYTES bytes, $TABLE_COUNT tables"
-else
-  # Belt-and-suspenders floor when sqlite3 is unavailable: still refuse a
-  # DB too small to be a real extract rather than only the header check.
-  [ "$DB_BYTES" -gt 1024 ] || fail "collected DB is suspiciously small ($DB_BYTES bytes) and sqlite3 is unavailable to inspect it: $DB_FILE"
-  ok "DB passes header+size check: $DB_BYTES bytes (sqlite3 unavailable for a table count)"
+# The check this script used to make was `SELECT count(*) FROM sqlite_master`
+# — a count of TABLES. Every migration creates those on an empty database, so
+# it passed against an extract holding no data at all, which is exactly the
+# state #5916 (shallow clone) and #5915 (unapproved index) produced. Count
+# ROWS in the tables the audit is actually made of.
+if [ "$SQLITE3_AVAILABLE" -eq 0 ]; then
+  fail "sqlite3 is not on PATH. This script's central claim is that the collected
+       database holds DATA, and only sqlite3 can check that. A size-and-header
+       fallback passes against an empty extract, which is the defect class this
+       test exists to catch. Install sqlite3 and re-run."
 fi
+
+query() {
+  sqlite3 "$DB_FILE" "$1" 2>/dev/null || printf 'ERR'
+}
+
+COMMIT_ROWS="$(query 'SELECT count(*) FROM commits;')"
+AUTHOR_ROWS="$(query 'SELECT count(*) FROM authors;')"
+FILE_ROWS="$(query 'SELECT count(*) FROM files;')"
+case "$COMMIT_ROWS$AUTHOR_ROWS$FILE_ROWS" in
+  *ERR*) fail "the extract is missing the core audit tables (commits/authors/files): $DB_FILE" ;;
+esac
+
+# #5916: `taudit clone` appended `--depth=1`, so every repository reached tga
+# as ONE synthetic commit by ONE author, with the whole tree credited to
+# whoever last touched each line. A full clone of the default target is ~400
+# commits by ~30 authors. Asserting "more than one" is the weakest statement
+# that a shallow clone cannot satisfy.
+[ "$COMMIT_ROWS" -gt 1 ] || fail "the extract holds $COMMIT_ROWS commit(s).
+       One commit is the signature of a shallow clone (#5916): the whole
+       history collapses to a single synthetic commit and every metric derived
+       from it — authors, tenure, churn over time — is fabricated."
+[ "$AUTHOR_ROWS" -gt 1 ] || fail "the extract holds $AUTHOR_ROWS author(s) across $COMMIT_ROWS commits.
+       A real history of this repository has ~30. One author is what a shallow
+       clone produces (#5916)."
+[ "$FILE_ROWS" -gt 0 ] || fail "the extract holds no file rows — nothing was collected: $DB_FILE"
+
+# A period whose start equals its end is the other shallow-clone signature:
+# one commit means one timestamp, so the "last 52 weeks" window is a point.
+COMMIT_SPAN_DAYS="$(query "SELECT CAST(julianday(max(timestamp)) - julianday(min(timestamp)) AS INTEGER) FROM commits;")"
+case "$COMMIT_SPAN_DAYS" in
+  ERR|'') printf '[INFO] commits.timestamp is absent or unreadable — span check skipped\n' ;;
+  *) [ "$COMMIT_SPAN_DAYS" -gt 0 ] || fail "every commit in the extract shares one date —
+       the history has no span, which is what a depth-1 clone produces (#5916)." ;;
+esac
+
+ok "DB holds real data: $COMMIT_ROWS commits, $AUTHOR_ROWS authors, $FILE_ROWS files, ${COMMIT_SPAN_DAYS:-?} days of history ($DB_BYTES bytes)"
 
 REPORT_FILE="$(find "$RETURN_EXTRACT" -path '*/reports/*/report.md' -type f -print -quit)"
 [ -n "$REPORT_FILE" ] || fail "no reports/*/report.md member found in the return package"
 REPORT_BYTES="$(wc -c <"$REPORT_FILE" | tr -d ' ')"
 [ "$REPORT_BYTES" -gt 0 ] || fail "report is empty: $REPORT_FILE"
-ok "report is present and non-empty: $REPORT_FILE ($REPORT_BYTES bytes)"
+
+# #5915: "non-empty" was never the question. A report assembled from an
+# extract the code analysis never read is several KiB of headings with no
+# finding under them — which is precisely what an unapproved checkout
+# produced, silently, on every run. The report must name files that exist in
+# the repository that was audited.
+step "verify: the report names real files from the audited repository"
+CHECKOUT_DIR="$(find "$WORK_ROOT/repos" -maxdepth 1 -mindepth 1 -type d -print -quit 2>/dev/null || true)"
+[ -n "$CHECKOUT_DIR" ] || fail "no checkout under $WORK_ROOT/repos — the clone phase left nothing behind"
+
+# Real source files from the clone, by basename. A report that read the code
+# names some of them; one assembled from nothing names none.
+NAMED=0
+NAMED_EXAMPLES=""
+while IFS= read -r candidate; do
+  base="$(basename "$candidate")"
+  if grep -q -F -- "$base" "$REPORT_FILE"; then
+    NAMED=$((NAMED + 1))
+    [ -n "$NAMED_EXAMPLES" ] && NAMED_EXAMPLES="$NAMED_EXAMPLES, "
+    NAMED_EXAMPLES="$NAMED_EXAMPLES$base"
+  fi
+done <<EOF
+$(find "$CHECKOUT_DIR" -type f \( -name '*.rs' -o -name '*.py' -o -name '*.go' -o -name '*.ts' -o -name '*.js' -o -name '*.java' \) -not -path '*/.git/*' | head -40)
+EOF
+
+[ "$NAMED" -gt 0 ] || fail "the report ($REPORT_BYTES bytes) names not one source file from
+       $CHECKOUT_DIR. That is what a report looks like when the code-analysis
+       leg read nothing — trusty-search is default-deny, so an unapproved
+       checkout is refused and tga still exits 0 (#5915)."
+ok "report names $NAMED source file(s) from the checkout: $NAMED_EXAMPLES"
+ok "report is present and substantive: $REPORT_FILE ($REPORT_BYTES bytes)"
 
 # --- 8. the guard that matters most: no credential in the return package --
 
@@ -292,16 +417,50 @@ if [ -n "$LEAK_HITS" ]; then
 fi
 ok "grepped every extracted member of the return package — no credential found"
 
+# --- 9. the approvals this run added, and the ones it must not have removed --
+
+step "verify: the run added allowlist rows and destroyed no pre-existing one"
+if [ -s "$ALLOWLIST_BEFORE" ]; then
+  MISSING=""
+  while IFS= read -r prior; do
+    grep -q -F -- "$prior" "$ALLOWLIST" 2>/dev/null || MISSING="$MISSING$prior
+"
+  done <<EOF
+$(grep '^path *=' "$ALLOWLIST_BEFORE" || true)
+EOF
+  if [ -n "$MISSING" ]; then
+    printf '%s\n' "$MISSING" >&2
+    fail "the run removed allowlist entries that existed before it (listed above)"
+  fi
+  ok "every pre-existing allowlist entry survived the run"
+fi
+
+APPROVED="$(grep '^path *=' "$ALLOWLIST" 2>/dev/null | grep -F -- "$WORK_ROOT" || true)"
+if [ -n "$APPROVED" ]; then
+  ok "the run approved these clones for indexing (remove by hand — see the header):"
+  printf '%s\n' "$APPROVED"
+else
+  fail "no allowlist row names a clone under $WORK_ROOT.
+       The audit reported success, but nothing approved a checkout — which
+       means trusty-search refused the index and the code analysis read
+       nothing (#5915). A report can still be produced in that state, which is
+       why this check exists rather than trusting the exit status."
+fi
+
 # --- verdict -----------------------------------------------------------------
 
 REPO_COUNT="$(find "$RETURN_EXTRACT" -path '*/extract/*.db' -type f | wc -l | tr -d ' ')"
 printf '\n================ VERDICT: PASS ================\n'
-printf 'target repository:   %s\n' "$TARGET_REPO"
+printf 'target repository:    %s\n' "$TARGET_REPO"
 printf 'repositories audited: %s (extract DB present)\n' "$REPO_COUNT"
 printf 'install package:      %s\n' "$INSTALL_ZIP"
 printf 'return package:       %s\n' "$RETURN_ZIP"
 printf 'collected DB:         %s (%s bytes)\n' "$DB_FILE" "$DB_BYTES"
-printf 'report:                %s (%s bytes)\n' "$REPORT_FILE" "$REPORT_BYTES"
+printf 'collected data:       %s commits, %s authors, %s files, %s days\n' \
+  "$COMMIT_ROWS" "$AUTHOR_ROWS" "$FILE_ROWS" "${COMMIT_SPAN_DAYS:-?}"
+printf 'report:               %s (%s bytes, names %s checkout file(s))\n' \
+  "$REPORT_FILE" "$REPORT_BYTES" "$NAMED"
 printf 'credential leak check: none found\n'
+printf 'work root (kept):     %s\n' "$WORK_ROOT"
 printf 'scratch (removed on exit): %s\n' "$SCRATCH"
 printf '=================================================\n'

--- a/scripts/taudit-live-acceptance.sh
+++ b/scripts/taudit-live-acceptance.sh
@@ -165,14 +165,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# The run's own tree is no longer beside the extracted package (#5915): it is
-# at the client's default, which is the one home location trusty-search will
-# index. A previous run's tree would make "did this run collect anything"
-# unanswerable, so it starts clean.
-WORK_ROOT="$HOME/.trusty-tools/trusty-audit/work"
-rm -rf "$WORK_ROOT"
-ok "work root reset: $WORK_ROOT"
-
 # The allowlist rows this run adds live outside the work root, so `rm -rf` on
 # either does not undo them. Snapshot what was approved BEFORE, so the run
 # can be shown to have destroyed none of it.
@@ -292,6 +284,25 @@ case "$TARGETS_OUTPUT" in
   *"$TARGET_REPO"*) ok "target list confirms $TARGET_REPO is registered" ;;
   *) fail "'audit.sh targets' did not list $TARGET_REPO" ;;
 esac
+
+# --- 5b. ask the client where its working directory is --------------------
+
+# Asked, never assumed. #5915 MOVED this location, and a hardcoded path would
+# make this script agree with only one revision of the client — which is the
+# opposite of what an acceptance test is for.
+step "workdir: ask the client where it will write"
+WORKDIR_OUTPUT="$("$LAUNCHER" workdir 2>&1)" \
+  || { printf '%s\n' "$WORKDIR_OUTPUT" >&2; fail "'audit.sh workdir' exited non-zero"; }
+printf '%s\n' "$WORKDIR_OUTPUT"
+WORK_ROOT="$(printf '%s\n' "$WORKDIR_OUTPUT" | head -1 | tr -d ' \t')"
+case "$WORK_ROOT" in
+  /*) ok "work root: $WORK_ROOT" ;;
+  *) fail "could not read an absolute work root from 'audit.sh workdir': '$WORK_ROOT'" ;;
+esac
+
+# A previous run's tree would make "did THIS run collect anything" unanswerable.
+rm -rf "$WORK_ROOT"
+ok "work root reset"
 
 # --- 6. run the one-shot audit chain: install, clone, analyse, package ----
 

--- a/scripts/taudit-live-acceptance.sh
+++ b/scripts/taudit-live-acceptance.sh
@@ -266,26 +266,7 @@ else
   fail "extracted engagement.toml does not carry OPENROUTER_API_KEY — 'taudit distribute' did not embed the supplied credential"
 fi
 
-# --- 5. register a real target, from the EXTRACTED copy --------------------
-
-step "add: register $TARGET_REPO from the extracted client"
-ADD_OUTPUT="$("$LAUNCHER" add repo "$TARGET_REPO" 2>&1)" \
-  || { printf '%s\n' "$ADD_OUTPUT" >&2; fail "'audit.sh add repo $TARGET_REPO' exited non-zero"; }
-printf '%s\n' "$ADD_OUTPUT"
-case "$ADD_OUTPUT" in
-  *"registered:"*"$TARGET_REPO"*) ok "registered and validated: $TARGET_REPO" ;;
-  *) fail "add output did not confirm registration of $TARGET_REPO" ;;
-esac
-
-TARGETS_OUTPUT="$("$LAUNCHER" targets 2>&1)" \
-  || { printf '%s\n' "$TARGETS_OUTPUT" >&2; fail "'audit.sh targets' exited non-zero"; }
-printf '%s\n' "$TARGETS_OUTPUT"
-case "$TARGETS_OUTPUT" in
-  *"$TARGET_REPO"*) ok "target list confirms $TARGET_REPO is registered" ;;
-  *) fail "'audit.sh targets' did not list $TARGET_REPO" ;;
-esac
-
-# --- 5b. ask the client where its working directory is --------------------
+# --- 5. ask the client where its working directory is, and reset it -------
 
 # Asked, never assumed. #5915 MOVED this location, and a hardcoded path would
 # make this script agree with only one revision of the client — which is the
@@ -304,7 +285,27 @@ esac
 rm -rf "$WORK_ROOT"
 ok "work root reset"
 
-# --- 6. run the one-shot audit chain: install, clone, analyse, package ----
+# --- 6. register a real target, from the EXTRACTED copy -------------------
+
+step "add: register $TARGET_REPO from the extracted client"
+ADD_OUTPUT="$("$LAUNCHER" add repo "$TARGET_REPO" 2>&1)" \
+  || { printf '%s\n' "$ADD_OUTPUT" >&2; fail "'audit.sh add repo $TARGET_REPO' exited non-zero"; }
+printf '%s\n' "$ADD_OUTPUT"
+case "$ADD_OUTPUT" in
+  *"registered:"*"$TARGET_REPO"*) ok "registered and validated: $TARGET_REPO" ;;
+  *) fail "add output did not confirm registration of $TARGET_REPO" ;;
+esac
+
+TARGETS_OUTPUT="$("$LAUNCHER" targets 2>&1)" \
+  || { printf '%s\n' "$TARGETS_OUTPUT" >&2; fail "'audit.sh targets' exited non-zero"; }
+printf '%s\n' "$TARGETS_OUTPUT"
+case "$TARGETS_OUTPUT" in
+  *"$TARGET_REPO"*) ok "target list confirms $TARGET_REPO is registered" ;;
+  *) fail "'audit.sh targets' did not list $TARGET_REPO" ;;
+esac
+
+
+# --- 7. run the one-shot audit chain: install, clone, analyse, package ----
 
 step "audit: install tools, clone, analyse via OpenRouter, package (this is the slow step)"
 RETURN_ZIP="$RETURN_DIR/audit-return-package.zip"
@@ -318,7 +319,37 @@ esac
 [ -s "$RETURN_ZIP" ] || fail "expected return package not found or empty: $RETURN_ZIP"
 ok "return package: $RETURN_ZIP ($(wc -c <"$RETURN_ZIP" | tr -d ' ') bytes)"
 
-# --- 7. verify the return package BY CONTENT --------------------------------
+# --- 8. the approvals this run added, and the ones it must not have removed --
+
+step "verify: the run added allowlist rows and destroyed no pre-existing one"
+if [ -s "$ALLOWLIST_BEFORE" ]; then
+  MISSING=""
+  while IFS= read -r prior; do
+    grep -q -F -- "$prior" "$ALLOWLIST" 2>/dev/null || MISSING="$MISSING$prior
+"
+  done <<EOF
+$(grep '^path *=' "$ALLOWLIST_BEFORE" || true)
+EOF
+  if [ -n "$MISSING" ]; then
+    printf '%s\n' "$MISSING" >&2
+    fail "the run removed allowlist entries that existed before it (listed above)"
+  fi
+  ok "every pre-existing allowlist entry survived the run"
+fi
+
+APPROVED="$(grep '^path *=' "$ALLOWLIST" 2>/dev/null | grep -F -- "$WORK_ROOT" || true)"
+if [ -n "$APPROVED" ]; then
+  ok "the run approved these clones for indexing (remove by hand — see the header):"
+  printf '%s\n' "$APPROVED"
+else
+  fail "no allowlist row names a clone under $WORK_ROOT.
+       The audit reported success, but nothing approved a checkout — which
+       means trusty-search refused the index and the code analysis read
+       nothing (#5915). A report can still be produced in that state, which is
+       why this check exists rather than trusting the exit status."
+fi
+
+# --- 9. verify the return package BY CONTENT --------------------------------
 
 step "verify: extract and inspect the return package"
 RETURN_EXTRACT="$SCRATCH/return-extracted"
@@ -387,38 +418,54 @@ REPORT_FILE="$(find "$RETURN_EXTRACT" -path '*/reports/*/report.md' -type f -pri
 REPORT_BYTES="$(wc -c <"$REPORT_FILE" | tr -d ' ')"
 [ "$REPORT_BYTES" -gt 0 ] || fail "report is empty: $REPORT_FILE"
 
-# #5915: "non-empty" was never the question. A report assembled from an
-# extract the code analysis never read is several KiB of headings with no
-# finding under them — which is precisely what an unapproved checkout
-# produced, silently, on every run. The report must name files that exist in
-# the repository that was audited.
-step "verify: the report names real files from the audited repository"
-CHECKOUT_DIR="$(find "$WORK_ROOT/repos" -maxdepth 1 -mindepth 1 -type d -print -quit 2>/dev/null || true)"
+ok "git-activity report present: $REPORT_FILE ($REPORT_BYTES bytes)"
+
+# #5915: "non-empty" was never the question, and `report.md` is the wrong file
+# to ask it of — that one is tga's git-activity summary, built from the commit
+# tables alone, so it looks identical whether or not the code was ever read.
+# The CODE analysis lands in `<date>-technical-due-diligence.md`. That is the
+# artifact that must name files from the repository: assembled without an
+# indexed checkout it is prose about commit counts, and it stays several KiB
+# either way, so size cannot tell the two apart.
+step "verify: the code-analysis report names real files from the repository"
+DD_FILE="$(find "$RETURN_EXTRACT" -path '*/reports/*' -name '*technical-due-diligence.md' -type f -print -quit)"
+[ -n "$DD_FILE" ] || fail "no technical-due-diligence report in the return package — the code-analysis leg produced nothing at all"
+DD_BYTES="$(wc -c <"$DD_FILE" | tr -d ' ')"
+
+# The clone lands at repos/<owner>/<name>, so the repository root is the
+# directory holding `.git` — not the first directory under repos/, which is the
+# owner. Getting that wrong points the search at a directory with no source in
+# it and reports a false empty report.
+GIT_DIR="$(find "$WORK_ROOT/repos" -mindepth 1 -maxdepth 3 -type d -name '.git' -print -quit 2>/dev/null || true)"
+CHECKOUT_DIR="$(dirname "$GIT_DIR")"
 [ -n "$CHECKOUT_DIR" ] || fail "no checkout under $WORK_ROOT/repos — the clone phase left nothing behind"
 
-# Real source files from the clone, by basename. A report that read the code
-# names some of them; one assembled from nothing names none.
+# Real source files from the clone, matched as REPOSITORY-RELATIVE paths
+# (`src/main.rs`), not bare basenames: `main.rs` appears in generic prose about
+# any Rust project, while `src/main.rs` is a path the analysis had to have read
+# the tree to write.
 NAMED=0
 NAMED_EXAMPLES=""
 while IFS= read -r candidate; do
-  base="$(basename "$candidate")"
-  if grep -q -F -- "$base" "$REPORT_FILE"; then
+  [ -n "$candidate" ] || continue
+  rel="${candidate#"$CHECKOUT_DIR"/}"
+  if grep -q -F -- "$rel" "$DD_FILE"; then
     NAMED=$((NAMED + 1))
     [ -n "$NAMED_EXAMPLES" ] && NAMED_EXAMPLES="$NAMED_EXAMPLES, "
-    NAMED_EXAMPLES="$NAMED_EXAMPLES$base"
+    NAMED_EXAMPLES="$NAMED_EXAMPLES$rel"
   fi
 done <<EOF
-$(find "$CHECKOUT_DIR" -type f \( -name '*.rs' -o -name '*.py' -o -name '*.go' -o -name '*.ts' -o -name '*.js' -o -name '*.java' \) -not -path '*/.git/*' | head -40)
+$(find "$CHECKOUT_DIR" -type f \( -name '*.rs' -o -name '*.py' -o -name '*.go' -o -name '*.ts' -o -name '*.js' -o -name '*.java' \) -not -path '*/.git/*' | head -60)
 EOF
 
-[ "$NAMED" -gt 0 ] || fail "the report ($REPORT_BYTES bytes) names not one source file from
-       $CHECKOUT_DIR. That is what a report looks like when the code-analysis
-       leg read nothing — trusty-search is default-deny, so an unapproved
-       checkout is refused and tga still exits 0 (#5915)."
-ok "report names $NAMED source file(s) from the checkout: $NAMED_EXAMPLES"
-ok "report is present and substantive: $REPORT_FILE ($REPORT_BYTES bytes)"
+[ "$NAMED" -gt 0 ] || fail "the code-analysis report ($DD_BYTES bytes) names not one source
+       path from $CHECKOUT_DIR. That is what it looks like when the analysis
+       read nothing — trusty-search is default-deny, so an unapproved checkout
+       is refused and tga still exits 0 (#5915)."
+ok "code-analysis report names $NAMED source path(s): $NAMED_EXAMPLES"
+ok "code-analysis report: $DD_FILE ($DD_BYTES bytes)"
 
-# --- 8. the guard that matters most: no credential in the return package --
+# --- 10. the guard that matters most: no credential in the return package --
 
 step "verify: the OpenRouter key never reaches the return package"
 LEAK_HITS="$(grep -a -r -l -F -- "$OPENROUTER_API_KEY" "$RETURN_EXTRACT" 2>/dev/null || true)"
@@ -427,36 +474,6 @@ if [ -n "$LEAK_HITS" ]; then
   fail "OPENROUTER_API_KEY leaked into the return package (see file list above; value withheld from this message)"
 fi
 ok "grepped every extracted member of the return package — no credential found"
-
-# --- 9. the approvals this run added, and the ones it must not have removed --
-
-step "verify: the run added allowlist rows and destroyed no pre-existing one"
-if [ -s "$ALLOWLIST_BEFORE" ]; then
-  MISSING=""
-  while IFS= read -r prior; do
-    grep -q -F -- "$prior" "$ALLOWLIST" 2>/dev/null || MISSING="$MISSING$prior
-"
-  done <<EOF
-$(grep '^path *=' "$ALLOWLIST_BEFORE" || true)
-EOF
-  if [ -n "$MISSING" ]; then
-    printf '%s\n' "$MISSING" >&2
-    fail "the run removed allowlist entries that existed before it (listed above)"
-  fi
-  ok "every pre-existing allowlist entry survived the run"
-fi
-
-APPROVED="$(grep '^path *=' "$ALLOWLIST" 2>/dev/null | grep -F -- "$WORK_ROOT" || true)"
-if [ -n "$APPROVED" ]; then
-  ok "the run approved these clones for indexing (remove by hand — see the header):"
-  printf '%s\n' "$APPROVED"
-else
-  fail "no allowlist row names a clone under $WORK_ROOT.
-       The audit reported success, but nothing approved a checkout — which
-       means trusty-search refused the index and the code analysis read
-       nothing (#5915). A report can still be produced in that state, which is
-       why this check exists rather than trusting the exit status."
-fi
 
 # --- verdict -----------------------------------------------------------------
 


### PR DESCRIPTION
Both data legs of a `taudit` run were empty, and both failed silently — `tga audit` exits 0 whenever its sweep completed, so every run reported success.

- **#5916** — `taudit clone` appended `--depth=1`, so tga read one commit per repository.
- **#5915** — `trusty-search` is default-deny and nothing ever approved a clone, so tga's `trusty-search index <checkout>` was refused and the code analysis read nothing.

## Placement, not the bypass

The documented `is_denied_allowing_sensitive_path` bypass cannot fix #5915. tga runs `trusty-search index <path> --name <id>` (`repo_index.rs`, the `index_args` builder), and that handler calls the STRICT `is_denied` at `trusty-search/src/commands/index.rs:65`. The bypass is reachable only from `index add --allow-sensitive-path` and the daemon's `POST /indexes` — neither is on tga's path — so approving a `/var/folders` root through it leaves the run refused anyway. Installed trusty-search 0.45.1 rejects the flag outright, and the acceptance script pins versions from crates.io, so it is version-fragile even where it is reachable.

**This is a general user bug, not a test artifact.** The bypass never relaxes `SENSITIVE_HOME_TOP_DIRS`, which also refuses `~/Downloads`, `~/Desktop` and `~/Documents`. A recipient who unzips the package into `~/Downloads` — the default for an emailed zip — hits this on an ordinary machine.

So the fix is placement plus approval, and `trusty-search` is untouched:

1. `run::prepare` runs `trusty-search index add <checkout>` before spawning tga. It already returns `Ok(Err(reason))` as a per-repository verdict, so a refusal is now a NAMED failure instead of an empty section. New module `run/approve.rs` — `run.rs` is at the 500-SLOC cap.
2. The default work root moves to `~/.trusty-tools/trusty-audit/work`, routed through `trusty_common::crate_config`.
3. The packaged launcher stops pinning `--work-dir "$here/work"`. That pin put the tree wherever the recipient unzipped, and it made `WorkDir::resolve`'s default unreachable from the only flow that ships. `--work-dir` and `TRUSTY_AUDIT_WORKDIR` still override; the launcher forwards them.

## Two costs, stated rather than discovered

- **`rm -rf <root>` is no longer a complete uninstall.** The approval writes a row to `trusty-search`'s allowlist, outside the work root. `trusty-search index remove <path>` undoes it. The package README, `taudit workdir`, and `workdir.rs`'s module docs all now say so instead of promising completeness.
- **Moving the default relocates existing operators' state.** An existing tree does not move itself; pass `--work-dir` at the old location, or move it.

## 0.2.0

`CloneOptions::shallow` was removed. For a 0.x crate the breaking bump is the minor position. It also sidesteps #5896, still open at 0.1.1.

## Fail-first proof — live, same script, both revisions

The acceptance script could not fail before this PR: it counted `sqlite_master` rows (tables, which a migration creates on an empty database), checked the report was non-empty, and ran under `mktemp -d` — `/var/folders`, which `trusty-search` refuses to index, so it structurally guaranteed the refusal it should have caught.

Hardened, then run against `origin/main`'s client and against this branch. Target `BurntSushi/xsv`.

**`origin/main` — FAIL (exit 1).** The chain printed `Send this file back` and exited 0:

```
[ok] chain reported a finished return package
[ok] return package: .../audit-return-package.zip (40517 bytes)

==> [11] verify: the run added allowlist rows and destroyed no pre-existing one

[FAIL] step 11: no allowlist row names a clone under .../work.
       The audit reported success, but nothing approved a checkout — which
       means trusty-search refused the index and the code analysis read
       nothing (#5915).
```

An earlier run of the same script, with the checks ordered the other way, caught #5916 directly — `commits=1 authors=1 files=66 span_days=0`, first and last commit both `2025-04-24T13:07:36+00:00`.

**This branch — PASS (exit 0):**

```
[ok] DB holds real data: 413 commits, 31 authors, 1465 files, 3887 days of history (1064960 bytes)
[ok] code-analysis report names 14 source path(s): tests/test_join.rs, tests/test_search.rs,
     src/cmd/join.rs, src/cmd/sort.rs, src/cmd/cat.rs, src/cmd/reverse.rs, src/cmd/partition.rs,
     src/cmd/frequency.rs, src/cmd/stats.rs, src/cmd/sample.rs, src/cmd/split.rs,
     src/config.rs, src/select.rs, src/main.rs
[ok] the run approved these clones for indexing
[ok] grepped every extracted member of the return package — no credential found
================ VERDICT: PASS ================
```

Return package 40517 → 277375 bytes. The allowlist row landed at the new placement: `/Users/bob/.trusty-tools/trusty-audit/work/repos/BurntSushi/xsv`.

Machine state restored afterwards: allowlist back to empty as it was, `trusty-tools` daemon registration intact at 1288601448 bytes. The staged credential was purged from every scratch tree and re-verified absent.

## Gates — rung 3 on `trusty-audit`

```
cargo fmt --check                                     EXIT=0
cargo clippy -p trusty-audit --all-targets -D warnings EXIT=0
cargo test -p trusty-audit                            EXIT=0
  test result: ok. 365 passed; 0 failed; 5 ignored
scripts/check_line_cap.sh                             EXIT=0
scripts/check_changelog_fragment.sh                   EXIT=0
scripts/check_sld.sh                                  EXIT=0
```

365 up from 351. New regression tests: `an_unapprovable_checkout_fails_the_repository_by_name` (asserts tga is never spawned), `an_approved_checkout_proceeds_to_the_child`, `the_default_root_is_one_trusty_search_will_index`, `the_launcher_leaves_the_work_root_to_the_client`, plus `run/approve.rs`'s own module tests including one asserting `--allow-sensitive-path` is never passed.

Closes #5915
Closes #5916

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
