### PR TITLE
fix(trusty-search): wait for the file watcher to terminate before a delete releases its teardown guard

### DIFF
--- a/crates/trusty-search/changelog.d/5910-watcher-stop-awaits-termination.md
+++ b/crates/trusty-search/changelog.d/5910-watcher-stop-awaits-termination.md
@@ -1,0 +1,9 @@
+Fixed
+
+- `DELETE /indexes/{id}` no longer releases its teardown guard while the index's
+  file watcher still holds the indexer. `WatcherTask::stop` only called
+  `JoinHandle::abort()`, which reaps an idle task inline but not a running one,
+  so the watcher's `Arc<RwLock<CodeIndexer>>` — and the open redb corpus it owns
+  — could outlive the delete. Recreating the same id then hit
+  `DatabaseAlreadyOpen`, set `corpus_open_failed`, and answered `500`. `stop`
+  now awaits the consumer task's termination (issue #3049).

--- a/crates/trusty-search/src/service/server/tests_3049.rs
+++ b/crates/trusty-search/src/service/server/tests_3049.rs
@@ -479,8 +479,11 @@ async fn create_index_cannot_register_while_a_delete_is_tearing_the_id_down() {
     assert_eq!(created.status(), axum::http::StatusCode::OK, "gen-1 create");
 
     // An in-flight writer keeps the delete parked long enough for the create to
-    // be issued squarely inside the teardown window.
-    let writer_guard = index_teardown_lock(&IndexId::new(ID)).read_owned().await;
+    // be issued squarely inside the teardown window. Both arrivals are WAITED
+    // FOR rather than slept through — see `await_condition` for why.
+    let lock = crate::service::reindex::index_teardown_lock(&IndexId::new(ID));
+    let baseline = teardown_lock_waiters(&lock);
+    let writer_guard = Arc::clone(&lock).read_owned().await;
     let order = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
 
     let delete_state = Arc::clone(&state);
@@ -490,7 +493,12 @@ async fn create_index_cannot_register_while_a_delete_is_tearing_the_id_down() {
         delete_order.lock().expect("order lock").push("delete");
         outcome
     });
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // The delete has reached its exclusive acquire and parked: it now holds an
+    // `Arc` clone of the lock, on top of the guard this test holds.
+    await_condition("the delete to park on the teardown lock", || async {
+        teardown_lock_waiters(&lock) >= baseline + 2
+    })
+    .await;
 
     let create_state = Arc::clone(&state);
     let create_order = Arc::clone(&order);
@@ -505,7 +513,15 @@ async fn create_index_cannot_register_while_a_delete_is_tearing_the_id_down() {
         resp
     });
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    // The create has reached `acquire_index_teardown_read` and parked BEHIND the
+    // delete's pending write — which is what puts it squarely inside the
+    // teardown window this test exists to cover. Without this wait the create
+    // could still be in `validate_root_path` when the guard drops, and the test
+    // would assert an ordering it never actually raced for.
+    await_condition("the create to park behind the delete", || async {
+        teardown_lock_waiters(&lock) >= baseline + 3
+    })
+    .await;
     drop(writer_guard);
 
     let deleted = delete.await.expect("delete task");
@@ -582,6 +598,52 @@ async fn patch_index_config_waits_for_an_in_flight_teardown() {
         axum::http::StatusCode::OK,
         "once teardown releases, the PATCH proceeds normally"
     );
+}
+
+/// Poll `cond` until it holds, or panic with `what` once the budget expires.
+///
+/// Why: the tests below have to stage a precise interleaving — a delete parked
+/// on the teardown lock, then a create parked behind it. Staging that with
+/// `sleep(100ms)` encodes a GUESS about scheduling, which is why
+/// `create_index_cannot_register_while_a_delete_is_tearing_the_id_down` failed
+/// intermittently on a loaded CI runner and never on an idle one. Polling an
+/// observable makes the wait end when the state is actually reached.
+/// What: 5 ms poll, 10 s budget. The budget only ever costs time on a host where
+/// the alternative was a false failure; expiry is a hard panic naming `what`, so
+/// a genuine hang reports what never happened rather than failing an unrelated
+/// assertion further down.
+/// Test: every caller in this module.
+async fn await_condition<C, Fut>(what: &str, mut cond: C)
+where
+    C: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    const BUDGET: Duration = Duration::from_secs(10);
+    const POLL: Duration = Duration::from_millis(5);
+    let deadline = tokio::time::Instant::now() + BUDGET;
+    while !cond().await {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out after {BUDGET:?} waiting for {what}"
+        );
+        tokio::time::sleep(POLL).await;
+    }
+}
+
+/// Number of live `Arc` clones of `id`'s teardown lock.
+///
+/// Why: this is the observable that says "another task is parked on this lock".
+/// Both `acquire_index_teardown_read` and `acquire_index_teardown_write` clone
+/// the `Arc` before awaiting, so a task waiting to acquire is holding one; the
+/// count therefore rises as each participant arrives and is what the tests below
+/// wait on instead of guessing at a duration. Counting through a caller-held
+/// `Arc` rather than a fresh `index_teardown_lock` call keeps the reading free
+/// of the temporary that call would itself create.
+/// What: `Arc::strong_count`, relative to a baseline the caller samples first —
+/// the absolute value also counts the map entry and any guard the test holds,
+/// so only the DELTA is meaningful.
+fn teardown_lock_waiters(lock: &Arc<tokio::sync::RwLock<()>>) -> usize {
+    Arc::strong_count(lock)
 }
 
 /// Build a `CreateIndexRequest` with every optional field defaulted — the same

--- a/crates/trusty-search/src/service/watch_loop.rs
+++ b/crates/trusty-search/src/service/watch_loop.rs
@@ -46,17 +46,34 @@ pub struct WatcherTask {
 }
 
 impl WatcherTask {
-    /// Stop watching: abort the consumer task and drop the OS watcher.
+    /// Stop watching and WAIT for the consumer task to terminate.
     ///
-    /// Why: lets the [`crate::service::watcher_manager::WatcherManager`] tear a
-    /// single watcher down deterministically (e.g. on `DELETE /indexes/:id` or
-    /// graceful shutdown) without waiting for the value to be dropped at an
-    /// `await` boundary.
-    /// What: aborts the consumer `JoinHandle`; the `FileWatcher` is dropped when
-    /// `self` is consumed, releasing the kqueue/inotify/fsevent handle.
-    /// Test: `watcher_task_stop_aborts_consumer`.
-    pub fn stop(self) {
+    /// Why: the consumer task owns a clone of the index's
+    /// `Arc<RwLock<CodeIndexer>>`, and that indexer owns the index's open redb
+    /// corpus. redb is single-open, so until the task is gone the corpus file
+    /// cannot be reopened. `abort()` alone does not give that: it drops the
+    /// future inline only when the task is idle, and a task that is actively
+    /// running keeps its captured `Arc` until it reaches its next await point on
+    /// some other worker thread. `DELETE /indexes/:id` then released its
+    /// teardown guard while the previous generation's corpus was still open, so
+    /// a recreate under the same id hit `DatabaseAlreadyOpen`, set
+    /// `corpus_open_failed`, and answered `500` — see #3049 and
+    /// `unregister_index`. Measured: the watcher held the indexer at the end of
+    /// every one of 60 delete runs; the test only passed because the drop
+    /// usually landed inside `open_corpus_with_retry`'s single 50 ms retry.
+    /// What: aborts the consumer `JoinHandle` and awaits it. A cancelled task
+    /// resolves to `Err(JoinError::Cancelled)`, which is the expected outcome
+    /// and is discarded. The `FileWatcher` is dropped when `self` is dropped at
+    /// the end of the call, releasing the kqueue/inotify/fsevent handle. The
+    /// wait is bounded by construction: an idle or lock-parked task is dropped
+    /// by `abort()` itself, and a running one cancels at its next await.
+    /// Test: `watcher_task_stop_aborts_consumer`,
+    /// `stop_for_index_releases_the_indexer_before_it_returns`.
+    pub async fn stop(mut self) {
         self.join.abort();
+        // `JoinHandle` is `Unpin` and cannot be moved out of `self` (this type
+        // has a `Drop` impl), so await it through a `&mut` borrow.
+        let _ = (&mut self.join).await;
         // `_watcher` drops here, terminating the OS watch.
     }
 }
@@ -744,11 +761,12 @@ mod tests {
         )
         .expect("watch loop starts");
 
-        // Stop immediately — the OS watch is dropped and the consumer aborted.
-        task.stop();
+        // Stop immediately. #3049: `stop` now AWAITS the consumer's termination,
+        // so there is no in-flight teardown left to sleep for — the settle sleep
+        // this replaces was the only thing standing between the abort and the
+        // write below.
+        task.stop().await;
 
-        // Allow any in-flight teardown to settle, then write a file.
-        tokio::time::sleep(Duration::from_millis(150)).await;
         tokio::fs::write(dir.path().join("after_stop.rs"), "fn z() {}\n")
             .await
             .expect("write file");

--- a/crates/trusty-search/src/service/watcher_manager.rs
+++ b/crates/trusty-search/src/service/watcher_manager.rs
@@ -244,7 +244,7 @@ impl WatcherManager {
         let mut guard = self.inner.lock().await;
         if guard.contains_key(&handle.id) {
             drop(guard);
-            task.stop();
+            task.stop().await;
             return;
         }
         guard.insert(handle.id.clone(), task);
@@ -260,10 +260,15 @@ impl WatcherManager {
     /// the OS watch. No-op when the index is not being watched.
     ///
     /// Why: `DELETE /indexes/:id` must not leave a watcher firing into a
-    /// dropped indexer.
-    /// What: removes the entry and calls `WatcherTask::stop`. Returns `true`
-    /// when a watcher was actually stopped.
-    /// Test: `stop_for_index_removes_entry`.
+    /// dropped indexer — and, since #3049, must not return while the watcher
+    /// still HOLDS that indexer. The watcher's `Arc<RwLock<CodeIndexer>>` keeps
+    /// the index's redb corpus open, and redb is single-open, so a recreate
+    /// under the same id fails to open the corpus until this returns.
+    /// What: removes the entry and awaits `WatcherTask::stop`, which aborts the
+    /// consumer task and waits for it to terminate. Returns `true` when a
+    /// watcher was actually stopped.
+    /// Test: `stop_for_index_removes_entry`,
+    /// `stop_for_index_releases_the_indexer_before_it_returns`.
     pub async fn stop_for_index(&self, id: &IndexId) -> bool {
         let task = self.inner.lock().await.remove(id);
         // Issue #3408: `DELETE /indexes/:id` should not leave a stale
@@ -271,7 +276,7 @@ impl WatcherManager {
         self.network_degraded.lock().await.remove(id);
         match task {
             Some(task) => {
-                task.stop();
+                task.stop().await;
                 tracing::debug!(index_id = %id, "file watcher stopped");
                 true
             }
@@ -284,13 +289,19 @@ impl WatcherManager {
     /// Why: the daemon's graceful-shutdown path (`run_daemon`, after the axum
     /// server drains) calls this so the OS watches and consumer tasks are gone
     /// before the process exits — honouring SIGTERM cleanly (issue #534/#1621).
-    /// What: drains the map and calls `stop` on each `WatcherTask`.
+    /// What: drains the map and awaits `stop` on each `WatcherTask`, so every
+    /// consumer task has terminated — and released its indexer `Arc` — before
+    /// the process exits. Drained OUT of the map first so the lock is not held
+    /// across the waits.
     /// Test: `stop_all_clears_all`.
     pub async fn stop_all(&self) -> usize {
-        let mut guard = self.inner.lock().await;
-        let count = guard.len();
-        for (_id, task) in guard.drain() {
-            task.stop();
+        let tasks: Vec<WatcherTask> = {
+            let mut guard = self.inner.lock().await;
+            guard.drain().map(|(_id, task)| task).collect()
+        };
+        let count = tasks.len();
+        for task in tasks {
+            task.stop().await;
         }
         if count > 0 {
             tracing::info!("stopped {count} file watcher(s) on shutdown");
@@ -440,6 +451,91 @@ mod tests {
 
         // Stopping again is a no-op.
         assert!(!mgr.stop_for_index(&handle.id).await);
+    }
+
+    /// #3049: `stop_for_index` must not return while the watcher still holds the
+    /// index's indexer.
+    ///
+    /// Why: the watcher's `Arc<RwLock<CodeIndexer>>` owns the index's open redb
+    /// corpus, and redb is single-open. `DELETE /indexes/:id` calls this while
+    /// holding the teardown write guard and then releases it; if the watcher
+    /// task is still alive at that moment, the recreate that follows cannot open
+    /// the corpus, sets `corpus_open_failed`, and answers `500` —
+    /// `create_index_cannot_register_while_a_delete_is_tearing_the_id_down`'s
+    /// intermittent CI failure. `WatcherTask::stop` used to call only `abort()`,
+    /// which drops the task's future inline when the task is IDLE but not when
+    /// it is running, so a watcher with events to process outlived the call.
+    /// What: drives real file events through the loop first, then asserts that
+    /// nothing owns `indexer` once `stop_for_index` returns — the watcher is the
+    /// only other owner by then, so `Weak::strong_count` reads exactly "does the
+    /// watcher still hold it".
+    ///
+    /// HONEST LIMIT: this is an invariant guard, NOT a proof. It does not fail
+    /// against the pre-fix code, because `abort()` DOES reap an idle task inline
+    /// and this test cannot pin the watcher mid-poll without a hook into the
+    /// loop. What the fix rests on is a direct measurement instead: instrumented
+    /// `unregister_index` reported the watcher still holding the indexer at the
+    /// end of all 60 of 60 runs of
+    /// `create_index_cannot_register_while_a_delete_is_tearing_the_id_down`, and
+    /// 0 of 1 with `TRUSTY_DISABLE_WATCHER=1`. See the PR for the raw counts.
+    /// Test: this test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn stop_for_index_releases_the_indexer_before_it_returns() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let id = IndexId::new("release-idx");
+        let indexer = Arc::new(RwLock::new(CodeIndexer::new("release-idx", dir.path())));
+        let weak = Arc::downgrade(&indexer);
+        let handle = Arc::new(IndexHandle::bare(
+            id.clone(),
+            Arc::clone(&indexer),
+            dir.path().to_path_buf(),
+        ));
+        drop(indexer);
+
+        let mgr = WatcherManager::new();
+        mgr.spawn_for_index(&handle).await;
+        assert!(mgr.is_watching(&id).await, "watcher must be running");
+
+        // Drive the loop until it has provably picked work up, so the abort
+        // below lands on a task that is doing something rather than one parked
+        // on an empty channel.
+        let file = dir.path().join("busy.rs");
+        {
+            let probe = Arc::clone(&handle);
+            let reacted = crate::service::watch_test_support::await_watch_condition(
+                |generation| {
+                    for n in 0..16 {
+                        std::fs::write(
+                            dir.path().join(format!("busy{n}.rs")),
+                            format!("fn f{generation}_{n}() {{}}\n"),
+                        )
+                        .expect("write file");
+                    }
+                    std::fs::write(&file, format!("fn busy{generation}() {{}}\n"))
+                        .expect("write file");
+                },
+                move || {
+                    let probe = Arc::clone(&probe);
+                    async move { probe.indexer.read().await.chunk_count() > 0 }
+                },
+            )
+            .await;
+            assert!(reacted, "watcher never indexed the stimulus");
+        }
+
+        // The watcher's clone is now the only other owner; drop ours so the
+        // count below is unambiguous.
+        drop(handle);
+
+        assert!(mgr.stop_for_index(&id).await, "a watcher was stopped");
+
+        assert_eq!(
+            weak.strong_count(),
+            0,
+            "stop_for_index returned while the watcher task still held the \
+             indexer — its redb corpus is still open, so a recreate under this \
+             id would fail to open it and answer 500 (issue #3049)"
+        );
     }
 
     /// Why: graceful shutdown must clear every watcher and report the count.


### PR DESCRIPTION
Fixes the second of the two tests keeping `main` red:
`tests_3049::create_index_cannot_register_while_a_delete_is_tearing_the_id_down`
(run `32079086875`, shard 2).

## Cause

`WatcherTask::stop` called `JoinHandle::abort()` and returned. `abort()` drops an
idle task's future inline but cannot touch one that is actively running, so the
watcher's `Arc<RwLock<CodeIndexer>>` — and the open redb corpus that indexer owns
— outlived `stop_for_index`; `unregister_index` then released its exclusive
teardown guard with generation 1's corpus still open, and the recreate hit redb's
single-open rule, set `corpus_open_failed`, and answered 500. `stop` now awaits
the consumer task's termination.

## Correction to the diagnosis this was dispatched with

The prescribed fix — moving `stop_for_index` above `registry.remove_and_get` —
would not have worked, and the instrumentation says why. At the moment the delete
releases its guard the removed handle's strong count is already **0**: the
registry had released its `Arc`, so reordering those two lines changes nothing.
The surviving reference is the watcher's separate clone of `handle.indexer`
(`spawn_for_index` clones the indexer, not the handle), and it survives because
`abort()` is asynchronous — not because of where the drop sits relative to an
await.

## Evidence

Instrumented `unregister_index` to report, at the point it releases the teardown
guard, the strong counts of the removed generation's `Arc`s:

```
60 PROBE-UNREG[recreate-window-3049]: indexer_strong=1 handle_strong=0   (60 of 60 runs)
   PROBE-UNREG[recreate-window-3049]: indexer_strong=0 handle_strong=0   (TRUSTY_DISABLE_WATCHER=1)
```

Generation 1's corpus was still open on **every** run; the test passed only when
the watcher's drop landed inside `open_corpus_with_retry`'s single 50 ms retry.
Disabling the watcher takes it to 0, which identifies the holder.

**What I could not do:** produce a test that fails deterministically against the
pre-fix code. `abort()` reaps an idle task inline, so a test can only catch the
leak while the watcher is mid-poll, and I found no way to pin it there without a
hook into the loop. Two attempts (a single-worker runtime; a file-event stimulus)
both passed pre-fix, 30/30. The added
`stop_for_index_releases_the_indexer_before_it_returns` is therefore an invariant
guard, and its doc comment says so rather than claiming to be a regression test.
The 60/60 measurement above is the real evidence. Straight reproduction of the
CI failure also did not hold locally: 40 runs under 10 CPU burners, 0 failures.

## The two decisions left to me

**1. Should a `!quiesced` deregistration hold the teardown write lock?** No — and
it is not a policy choice. `!quiesced` *means* the exclusive guard could not be
acquired within the timeout; there is no guard available to hold, and blocking
for one is what the timeout exists to avoid. The exposure it describes is real
but is closed from the other side: `stop_for_index` now drains the watcher on
both paths.

**2. Should `corpus_open_failed` on a fresh create be retryable rather than
terminal?** No. The transience is now handled at its source, `open_corpus_with_retry`
already retries once on `DatabaseAlreadyOpen`, and reclassifying a documented 500
on `POST /indexes` is an API-surface change (rung 6) that should not ride along
with a lifecycle fix.

## Also

The two wall-clock sleeps that staged the failing test (100 ms / 200 ms before
`drop(writer_guard)`) are replaced with polling on the teardown lock's waiter
count — the delete's arrival and the create's arrival behind it are both waited
for rather than guessed at.

## Rung

Rung 3 — localized behavior inside one crate, plus `cargo check --workspace`
because `stop`'s signature changed.

```
cargo fmt --all --check                                  EXIT=0
cargo clippy -p trusty-search --all-targets -- -D warnings  EXIT=0
cargo test -p trusty-search --lib      1753 passed; 0 failed; 1 ignored
bash scripts/check_line_cap.sh          4059 files, 0 violations — OK
bash scripts/check_sld.sh               0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh  OK
bash scripts/check_test_pointers.sh     EXIT=0
```

## Pre-existing failures, not from this change

Neither touches a file in this diff (`watch_loop.rs`, `watcher_manager.rs`,
`tests_3049.rs`).

- `commands::serve::index_env_tests::neither_source_leaves_the_project_fallback_intact`
  — fails in isolation in 0.03 s, `left: Some("trusty-tools") right: None`; it
  resolves a project name from the working directory, so it is cwd-dependent.
- `cargo test -p trusty-search --features ner,clustering,test-support` does not
  compile: `E0063: missing fields archive_reason and on_branch` at
  `core/concept_cluster.rs:259`, behind the `clustering` feature.

Refs #3049

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
