### PR TITLE
fix(trusty-audit): guided.rs call sites for WorkDir::resolve's new home param [unblocks red main]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11321,6 +11321,7 @@ dependencies = [
 name = "trusty-audit-ui"
 version = "0.1.0"
 dependencies = [
+ "dirs 5.0.1",
  "serde",
  "serde_json",
  "tauri",

--- a/crates/trusty-audit/changelog.d/5935-guided-workdir-resolve-home-param.md
+++ b/crates/trusty-audit/changelog.d/5935-guided-workdir-resolve-home-param.md
@@ -1,0 +1,2 @@
+Fixed
+- `trusty-audit-ui`'s guided-flow session builder (`guided.rs`) failed to compile against `WorkDir::resolve`'s new `home: Option<&Path>` parameter (#5929), which broke `origin/main` as a workspace. Both call sites — the production `session()` builder and its own test — now pass `dirs::home_dir()`, the same source `trusty-audit`'s CLI entry point uses, so the shell and the CLI keep resolving the same default work-dir root (#5935).

--- a/crates/trusty-audit/ui/src-tauri/Cargo.toml
+++ b/crates/trusty-audit/ui/src-tauri/Cargo.toml
@@ -23,6 +23,11 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 serde = { workspace = true }
 tokio = { workspace = true }
+# #5935: `WorkDir::resolve` takes a `home: Option<&Path>` (#5929) so its
+# default can land under `~/.trusty-tools/trusty-audit/work` rather than
+# beside the cwd. Same dependency `trusty-audit`'s own `main.rs` uses to
+# supply it, for the same reason.
+dirs = { workspace = true }
 # The auditor client itself. DOC-68 §11: this shell is a view over
 # `Session::execute` and calls it IN-PROCESS — no HTTP endpoint, no `taudit`
 # subprocess. Capabilities live in `session::Command`, never here.

--- a/crates/trusty-audit/ui/src-tauri/src/guided.rs
+++ b/crates/trusty-audit/ui/src-tauri/src/guided.rs
@@ -162,7 +162,11 @@ fn next_view(next: &NextStep) -> Result<NextStepView, String> {
 /// from the process environment instead — `TRUSTY_AUDIT_WORKDIR` and the
 /// current directory. Resolution goes through the same `WorkDir::resolve` and
 /// `EngagementConfig::resolve_path` the CLI uses, so both front ends open the
-/// same engagement when launched the same way.
+/// same engagement when launched the same way. #5935: that parity was broken
+/// by #5929's new `home` parameter on `WorkDir::resolve` — this call site went
+/// uncompiled, not just unupdated, and `main.rs` is the pattern it follows:
+/// `dirs::home_dir()`, read here alongside the rest of the environment so
+/// `resolve` stays a pure function of what it is handed.
 /// What: resolves the work-dir root and the engagement config, then builds a
 /// `Session` over them.
 /// Test: `super::view_tests::a_session_resolves_under_the_named_root`.
@@ -170,7 +174,8 @@ fn session() -> Result<Session, String> {
     let cwd = std::env::current_dir()
         .map_err(|e| format!("cannot determine the current directory: {e}"))?;
     let env_value = std::env::var(WORKDIR_ENV).ok();
-    let work = WorkDir::resolve(None, env_value.as_deref(), &cwd);
+    let home = dirs::home_dir();
+    let work = WorkDir::resolve(None, env_value.as_deref(), home.as_deref(), &cwd);
     Ok(Session::new(work).with_config_path(EngagementConfig::resolve_path(None, &cwd)))
 }
 
@@ -337,7 +342,9 @@ mod view_tests {
     #[test]
     fn a_session_resolves_under_the_named_root() {
         let cwd = std::path::Path::new("/engagement");
-        let work = WorkDir::resolve(None, Some("/engagement/work"), cwd);
+        // `home` is irrelevant here: an explicit env value always wins over
+        // the home-derived default (see `WorkDir::resolve`'s precedence).
+        let work = WorkDir::resolve(None, Some("/engagement/work"), None, cwd);
         assert_eq!(
             Session::new(work).work_dir().root(),
             std::path::Path::new("/engagement/work")


### PR DESCRIPTION
🔴 **Unblocks a red `main`.** `origin/main` does not compile as a workspace right now — this is time-sensitive.

## The break

PR #5929 (`c2d6dde16`) added a third parameter, `home: Option<&Path>`, to `WorkDir::resolve` (`crates/trusty-audit/src/workdir.rs:195`). Two call sites in `crates/trusty-audit/ui/src-tauri/src/guided.rs` (the Tauri UI crate `trusty-audit-ui`) were never updated:

```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
  --> crates/trusty-audit/ui/src-tauri/src/guided.rs:173:16
```

## What `home` is for, and what I passed

`WorkDir::resolve`'s `home` parameter drives its default work-dir root (#5915): when neither `--work-dir` nor `TRUSTY_AUDIT_WORKDIR` names a place, `home` decides between `~/.trusty-tools/trusty-audit/work` (when known) and the pre-#5915 `<cwd>/trusty-audit-work` fallback (when not). `crates/trusty-audit/src/main.rs` — the CLI entry point — reads `dirs::home_dir()` for it.

`guided.rs`'s own `session()` doc comment already states the intent: "the shell resolves its working directory the way the CLI does, so both front ends open the same engagement when launched the same way." Passing `None` would compile, but would silently break that stated parity — the shell would fall back to the pre-#5915 cwd-relative default in exactly the case (no explicit override) where the CLI now resolves under home. So `session()` now calls `dirs::home_dir()` itself, the same source and the same place in the call chain as `main.rs`. Added `dirs = { workspace = true }` to `trusty-audit-ui/Cargo.toml` (already a workspace dependency, unconditionally used by `trusty-audit`'s own `main.rs`).

The test call site (`a_session_resolves_under_the_named_root`, `guided.rs:345`) exercises the env-value branch, which always wins over the home-derived default in `resolve`'s precedence — so `home` is inert there. It passes `None` with a one-line comment saying why.

## Regression test

None added. The break was a call site not updated after a signature change; the compiler already catches that class of error on any invocation that runs it. The actual gap was that no CI job ran the compiler over the whole workspace before merge — that's #5934 (a CI-config change needing admin), not something a test in this crate can close.

## Gates — rung 3/4 on `trusty-audit-ui` and `trusty-audit`

Ran with `SKIP_UI_BUILD=1` (no pnpm needed) from a fresh worktree branched off `origin/main`:

```
cargo fmt --check                                        EXIT=0
cargo check -p trusty-audit-ui --all-targets              EXIT=0
cargo clippy -p trusty-audit-ui --all-targets -D warnings EXIT=0
cargo test -p trusty-audit-ui                              EXIT=0
  test result: ok. 6 passed; 0 failed; 0 ignored
cargo check --workspace                                    EXIT=0
cargo test -p trusty-audit                                  EXIT=0
  test result: ok. 365 passed; 0 failed; 5 ignored
```

`neither_source_leaves_the_project_fallback_intact` (#5709, known-red) does not appear in `trusty-audit`'s output — not applicable to this crate.

Closes #5935

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools