### PR TITLE
fix(trusty-audit-ui): main does not compile — pass the home directory WorkDir::resolve has required since #5929

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11321,6 +11321,7 @@ dependencies = [
 name = "trusty-audit-ui"
 version = "0.1.0"
 dependencies = [
+ "dirs 5.0.1",
  "serde",
  "serde_json",
  "tauri",

--- a/crates/trusty-audit/changelog.d/5934-desktop-shell-work-root.md
+++ b/crates/trusty-audit/changelog.d/5934-desktop-shell-work-root.md
@@ -1,0 +1,8 @@
+Fixed
+
+- The desktop shell compiles again, and puts its work root where the CLI puts
+  its own. #5915 gave `WorkDir::resolve` a `home` argument and updated the CLI,
+  but not the Tauri shell in `ui/src-tauri`, which no longer built. The shell
+  now reads the home directory the same way `main.rs` does, so with nothing in
+  the environment both front ends open `~/.trusty-tools/trusty-audit/work`
+  rather than the shell landing beside the current directory.

--- a/crates/trusty-audit/ui/src-tauri/Cargo.toml
+++ b/crates/trusty-audit/ui/src-tauri/Cargo.toml
@@ -27,6 +27,11 @@ tokio = { workspace = true }
 # `Session::execute` and calls it IN-PROCESS — no HTTP endpoint, no `taudit`
 # subprocess. Capabilities live in `session::Command`, never here.
 trusty-audit = { workspace = true }
+# #5915 made the work-root default `~/.trusty-tools/trusty-audit/work`, and
+# `WorkDir::resolve` takes the home directory as an argument rather than reading
+# it. This shell reads it the same way `trusty-audit`'s own `main.rs` does, so
+# both front ends land on one root.
+dirs = { workspace = true }
 
 [dev-dependencies]
 # Real directories for the guided-flow mapping tests — the same dependency

--- a/crates/trusty-audit/ui/src-tauri/src/guided.rs
+++ b/crates/trusty-audit/ui/src-tauri/src/guided.rs
@@ -170,7 +170,12 @@ fn session() -> Result<Session, String> {
     let cwd = std::env::current_dir()
         .map_err(|e| format!("cannot determine the current directory: {e}"))?;
     let env_value = std::env::var(WORKDIR_ENV).ok();
-    let work = WorkDir::resolve(None, env_value.as_deref(), &cwd);
+    // #5915: the home directory is read here, with the rest of the environment,
+    // so `resolve` stays a pure function of what it is handed. The CLI's
+    // `main.rs` reads it the same way; omitting it would put this shell's root
+    // beside the cwd, which is the placement #5915 removed.
+    let home = dirs::home_dir();
+    let work = WorkDir::resolve(None, env_value.as_deref(), home.as_deref(), &cwd);
     Ok(Session::new(work).with_config_path(EngagementConfig::resolve_path(None, &cwd)))
 }
 
@@ -337,10 +342,29 @@ mod view_tests {
     #[test]
     fn a_session_resolves_under_the_named_root() {
         let cwd = std::path::Path::new("/engagement");
-        let work = WorkDir::resolve(None, Some("/engagement/work"), cwd);
+        let home = std::path::Path::new("/home/analyst");
+        let work = WorkDir::resolve(None, Some("/engagement/work"), Some(home), cwd);
         assert_eq!(
             Session::new(work).work_dir().root(),
             std::path::Path::new("/engagement/work")
+        );
+    }
+
+    /// With nothing in the environment the shell lands on the home root #5915
+    /// moved the default to — not beside the cwd, which is where an emailed
+    /// package gets unzipped and where `trusty-search` refuses to index.
+    ///
+    /// `session()` reads the process environment, so this asserts the arguments
+    /// it passes rather than calling it. That indirection is exactly what let
+    /// #5929's signature change reach `main.rs` and miss this shell.
+    #[test]
+    fn the_default_root_is_the_home_one_the_cli_uses() {
+        let cwd = std::path::Path::new("/engagement");
+        let home = std::path::Path::new("/home/analyst");
+        let work = WorkDir::resolve(None, None, Some(home), cwd);
+        assert_eq!(
+            Session::new(work).work_dir().root(),
+            std::path::Path::new("/home/analyst/.trusty-tools/trusty-audit/work")
         );
     }
 }


### PR DESCRIPTION
`origin/main` has not compiled for `trusty-audit-ui` since c2d6dde16f (PR #5929,
merged 2026-08-18). #5929 gave `WorkDir::resolve` a fourth parameter,
`home: Option<&Path>`, and updated `crates/trusty-audit/src/main.rs`. The other
caller is in a different crate and still passed three arguments:
`crates/trusty-audit/ui/src-tauri/src/guided.rs:173` and its test at line 340.
Both fail E0061.

Nothing caught it because the required `Clippy` context runs
`--workspace --all-targets --exclude trusty-audit-ui` (plus the three other
Tauri crates), and the leg that does compile this crate, `trusty-audit-ui
clippy`, is not required.

## What I passed, and why

`dirs::home_dir()`, exactly as `main.rs` reads it. `resolve` is deliberately
pure, so the caller supplies the environment.

Passing `None` would have compiled and put the shell's work root beside the
current directory. That is the placement #5915 removed, because `trusty-search`
refuses to index a checkout under `~/Downloads` — where an emailed package gets
unzipped — which costs the run its whole code-analysis leg.

## Does the shell's resolved work root change?

No shipped behaviour changes: the shell has not built since #5929, so there is
no released binary carrying the old root. Against the last version that DID
build, yes — with `TRUSTY_AUDIT_WORKDIR` unset the shell used to resolve
`<cwd>/trusty-audit-work` and now resolves `~/.trusty-tools/trusty-audit/work`.
That is #5915's change reaching the front end it missed, and it is what
`guided.rs`'s own doc comment already claimed ("both front ends open the same
engagement when launched the same way"). With `TRUSTY_AUDIT_WORKDIR` set,
nothing changes — the env value still wins.

## Other consumers of #5929's changed surface

#5929 altered exactly two public items: `WorkDir::resolve`'s signature and the
removal of `CloneOptions::shallow`. `trusty-audit-ui` is the only crate in the
workspace that depends on `trusty-audit`, and it never referenced
`CloneOptions`. Every other `WorkDir::resolve` call site is inside
`crates/trusty-audit/` and was updated by #5929.

The three other Tauri crates the required `Clippy` job also excludes were
checked and are clean:
`cargo check -p trusty-mpm-gui -p trusty-code-gui -p trusty-agents-ui --all-targets` → exit 0.

## Gates — rung 4

Break reproduced first: with `guided.rs` at its `origin/main` content,
`cargo check -p trusty-audit-ui --all-targets` exits 101 with

```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
error: could not compile `trusty-audit-ui` (bin "trusty-audit-ui") due to 1 previous error
error: could not compile `trusty-audit-ui` (bin "trusty-audit-ui" test) due to 2 previous errors
```

With the fix:

| Command | Result |
|---|---|
| `cargo fmt --check` | exit 0 |
| `cargo clippy -p trusty-audit-ui --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-audit-ui` | `ok. 7 passed; 0 failed; 0 ignored` |
| `cargo check -p trusty-audit` | exit 0 |
| `cargo clippy -p trusty-audit --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-audit` | `ok. 365 passed; 0 failed; 5 ignored` plus 7 integration binaries, all ok |
| `bash scripts/check_changelog_fragment.sh` | OK trusty-audit |
| `bash scripts/check_line_cap.sh` | 0 violations |
| `bash scripts/check-pr-version-bump.sh` | OK — no `crates/<crate>/src/**` path, no bump owed |

`trusty-audit-ui` is `publish = false`, and this touches no crate version, so
there is no collision with #5896 (open at trusty-audit 0.1.1).

Refs #5929

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
