### PR TITLE
feat(website): add a copy button to the trusty-audit install command

### DIFF
--- a/website/src/lib/components/CopyButton.svelte
+++ b/website/src/lib/components/CopyButton.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	/**
+	 * Why: the install step's command is meant to land in a terminal exactly as
+	 * shown. Selecting it by hand risks catching a stray character or missing
+	 * the trailing `sh`, and a mouse-only "select the `<pre>`" affordance
+	 * leaves keyboard and screen-reader users with no equivalent shortcut.
+	 *
+	 * What: copies `text` verbatim via `navigator.clipboard.writeText`, swaps
+	 * the icon to a checkmark and announces the result through an `aria-live`
+	 * region, then reverts after two seconds. `navigator.clipboard` is
+	 * undefined on insecure origins and in some browsers, and a write can be
+	 * rejected (permission denial); both land in `error`, never a false
+	 * `copied` — the source `<pre>` is never touched, so its text stays
+	 * selectable either way.
+	 *
+	 * Test: manually verified against the production build with Chromium
+	 * (button renders, is keyboard-focusable, exposes the passed `label` as
+	 * its accessible name, and a click populates the clipboard with `text`
+	 * unchanged) — see the trusty-audit copy-button PR description. No
+	 * component-test harness (`@testing-library/svelte` or similar) is
+	 * installed in this package, and adding one is out of scope for this
+	 * change.
+	 */
+	interface Props {
+		/** Exact text to copy — no leading prompt, no trailing newline. */
+		text: string;
+		/** Accessible name for the button, e.g. "Copy install command". */
+		label: string;
+	}
+
+	let { text, label }: Props = $props();
+
+	type Status = 'idle' | 'copied' | 'error';
+	let status = $state<Status>('idle');
+	let resetTimer: ReturnType<typeof setTimeout> | undefined;
+
+	function scheduleReset() {
+		clearTimeout(resetTimer);
+		resetTimer = setTimeout(() => {
+			status = 'idle';
+		}, 2000);
+	}
+
+	async function copy() {
+		if (!navigator.clipboard) {
+			status = 'error';
+			scheduleReset();
+			return;
+		}
+		try {
+			await navigator.clipboard.writeText(text);
+			status = 'copied';
+		} catch {
+			status = 'error';
+		}
+		scheduleReset();
+	}
+</script>
+
+<button
+	type="button"
+	class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-sm border border-foundry-border bg-foundry-card text-foundry-secondary transition-colors hover:border-foundry-border-strong hover:text-foundry-text"
+	aria-label={label}
+	onclick={copy}
+>
+	{#if status === 'copied'}
+		<svg
+			viewBox="0 0 20 20"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			class="h-4 w-4 text-foundry-success"
+			aria-hidden="true"
+		>
+			<path d="M4 10.5l3.5 3.5L16 6" stroke-linecap="round" stroke-linejoin="round" />
+		</svg>
+	{:else}
+		<svg
+			viewBox="0 0 20 20"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			class="h-4 w-4"
+			aria-hidden="true"
+		>
+			<rect x="6.5" y="6.5" width="9" height="9" rx="1.5" />
+			<path d="M4.5 12V5A1.5 1.5 0 0 1 6 3.5h7" stroke-linecap="round" />
+		</svg>
+	{/if}
+</button>
+<span class="sr-only" role="status" aria-live="polite">
+	{#if status === 'copied'}
+		Copied to clipboard
+	{:else if status === 'error'}
+		Could not copy automatically — select the text and copy it manually
+	{/if}
+</span>

--- a/website/src/routes/tools/trusty-audit/+page.svelte
+++ b/website/src/routes/tools/trusty-audit/+page.svelte
@@ -34,6 +34,7 @@
 	 * `TRUSTY_AUDIT_NO_LAUNCH=1`, which resolved latest as 0.1.0, verified its
 	 * sha256, and installed both `trusty-audit` and `taudit`.
 	 */
+	import CopyButton from '$lib/components/CopyButton.svelte';
 	import ToolPage from '$lib/components/ToolPage.svelte';
 	import { installCommand, TOOLS } from '$lib/tools';
 
@@ -130,12 +131,17 @@
 			actually runs, installs it with an atomic rename, and then launches it.
 		</p>
 		<!-- `min-w-0`: a `<pre>` never wraps, so without it the flex child widens
-		     to the longest command and the page scrolls sideways at 375px. -->
-		<div class="mt-6 max-w-3xl min-w-0">
+		     to the longest command and the page scrolls sideways at 375px.
+		     `pr-14` on the `<pre>` keeps the copy button clear of the text; the
+		     button sits in the wrapper's own padding, not over the command. -->
+		<div class="relative mt-6 max-w-3xl min-w-0">
 			<pre
-				class="overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-4 text-xs leading-relaxed text-foundry-text">{installCommand(
+				class="overflow-x-auto rounded-sm border border-foundry-border bg-foundry-card p-4 pr-14 text-xs leading-relaxed text-foundry-text">{installCommand(
 					tool
 				)}</pre>
+			<div class="absolute right-2 top-2">
+				<CopyButton text={installCommand(tool)} label="Copy install command" />
+			</div>
 		</div>
 		<p class="mt-4 max-w-3xl text-foundry-secondary">
 			It installs into <code class="text-sm">$&#123;CARGO_HOME:-$HOME/.cargo&#125;/bin</code> and


### PR DESCRIPTION
## Summary

Attached to the "1 · Install" step's `<pre>` block in `website/src/routes/tools/trusty-audit/+page.svelte` — the box carrying `curl -fsSL … install.sh | sh`. That page also embeds `ToolPage.svelte`'s own shared install box near the footer; left that one alone since the task named the `+page.svelte` install step specifically.

No existing copy/clipboard pattern was found anywhere under `website/src/lib/` or `src/routes/tools/`, so added one: `website/src/lib/components/CopyButton.svelte`, a real `<button>` with an `aria-label`, inline-SVG copy/check icons, an `aria-live="polite"` status region, and a two-second revert. `navigator.clipboard` missing or a rejected write both land on the same error path — never a false "Copied" — and the source `<pre>` is untouched so its text stays selectable either way.

No new dependency; `package.json`/`pnpm-lock.yaml` untouched.

## Verified

- `pnpm test` (from inside `website/`): 242/252 pass. The 10 failures are all in `theme.test.ts` (`localStorage.clear()` on undefined) — a known local-only artifact of running Node 26 against a suite CI runs on Node 20, unrelated to this change.
- `pnpm build`: clean.
- `bash scripts/check_changelog_fragment.sh`: `no crate source changed … OK` — a website-only PR owes no fragment.
- `pnpm exec eslint` + `pnpm exec prettier --check` scoped to the two changed files: clean. (The rest of the touched page has pre-existing prettier drift under the installed plugin version, unrelated to this change — left untouched to keep the diff minimal.)
- Drove a real Chromium (via the `playwright` devDependency already in this package, no new install) against the production `.vercel/output/static` build: the button renders, is keyboard-focusable, its accessible name reads "Copy install command", and a click populates the clipboard with the install command byte-for-byte. Separately verified the failure path with `navigator.clipboard` stubbed to `undefined`: the live region announces the error (not "Copied"), and it reverts to idle after ~2s.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools