### PR TITLE
test(trusty-code): read the M1 log assertions from the envelope's nested event payload (#5911)

### DIFF
--- a/crates/trusty-code/tests/m1_cutline_e2e.rs
+++ b/crates/trusty-code/tests/m1_cutline_e2e.rs
@@ -48,11 +48,13 @@ mod support;
 use std::collections::HashSet;
 use std::time::Duration;
 
+use chrono::Utc;
 use serde_json::{Value, json};
 use support::{
     StdioSession, assert_envelopes_contiguous, find_session_event, open_sse, parse_sse_frames,
     project_with_agents, read_sse_until,
 };
+use trusty_code::events::{Event, SessionEventEnvelope};
 
 /// The exact, deterministic ordered event-kind sequence a standard
 /// `TCODE_MOCK_LLM=echo` `task.run` produces, from `session.create` through
@@ -165,7 +167,7 @@ fn filter_async_kinds<'a>(kinds: impl IntoIterator<Item = &'a str>) -> Vec<&'a s
         .collect()
 }
 
-/// Assert every `log` envelope in `events` is a well-formed durable-memory
+/// Assert every `log` envelope in `envelopes` is a well-formed durable-memory
 /// degradation warning — unordered, and tolerant of any count including zero.
 ///
 /// Why: [`filter_async_kinds`] drops `log` from the ordered baseline, which on
@@ -181,21 +183,30 @@ fn filter_async_kinds<'a>(kinds: impl IntoIterator<Item = &'a str>) -> Vec<&'a s
 /// `MemoryFailureCategory::PalaceEnsure` vocabulary, the only category a
 /// tempdir-rooted run can produce (`session::registry_memory_sink`). A
 /// regression that changed the level, the category, or the message shape fails
-/// here.
+/// here. Both fields are read from the envelope's nested `event` payload, which
+/// is where `Event::Log` puts them; `kind` is the only field
+/// `SessionEventEnvelope` lifts to the top level (#5911).
 /// Test: called by `m1_cutline_full_scenario_over_stdio` and
-/// `m1_cutline_full_scenario_over_http`.
-fn assert_memory_degradation_logs_well_formed(events: &[Value]) {
-    for event in events.iter().filter(|e| e["kind"] == "log") {
+/// `m1_cutline_full_scenario_over_http`, and pinned without a daemon by
+/// `degradation_log_events_never_move_the_ordered_baseline`.
+fn assert_memory_degradation_logs_well_formed(envelopes: &[Value]) {
+    for envelope in envelopes.iter().filter(|e| e["kind"] == "log") {
+        // #5911: `level`/`message` are `Event::Log`'s own fields, so they live
+        // under the envelope's nested `event` payload. `kind` is the only one
+        // duplicated to the top level (`SessionEventEnvelope`).
+        let payload = &envelope["event"];
         assert_eq!(
-            event["level"], "warn",
+            payload["level"], "warn",
             "the only log event this run can emit is the #2425 degradation \
-             warning, which is warn-level: {event}"
+             warning, which is warn-level: {envelope}"
         );
-        let message = event["message"].as_str().unwrap_or_default();
+        let message = payload["message"]
+            .as_str()
+            .unwrap_or_else(|| panic!("a log event always carries a string message: {envelope}"));
         assert!(
             message.starts_with("durable memory degraded: category=PalaceEnsure "),
             "a tempdir-rooted run's only log event is the PalaceEnsure \
-             degradation warning (#4638): {event}"
+             degradation warning (#4638): {envelope}"
         );
     }
 }
@@ -215,7 +226,12 @@ fn assert_memory_degradation_logs_well_formed(events: &[Value]) {
 /// can deliver them at — and asserts the filtered spine is the baseline every
 /// time. The `PalaceEnsure` token comes from the production enum, so a rename
 /// there fails here rather than silently weakening
-/// [`assert_memory_degradation_logs_well_formed`].
+/// [`assert_memory_degradation_logs_well_formed`]. The warning envelopes are
+/// SERIALISED from `SessionEventEnvelope`/`Event::Log` for the same reason
+/// (#5911): the first version of this test hand-wrote them as flat `json!`
+/// objects with `level`/`message` at the top level, which is not the wire shape,
+/// so it agreed with a helper that read the wrong path and CI stayed red. A
+/// production-derived fixture cannot drift from the envelope it stands in for.
 /// Test: this test.
 #[test]
 fn degradation_log_events_never_move_the_ordered_baseline() {
@@ -223,16 +239,25 @@ fn degradation_log_events_never_move_the_ordered_baseline() {
         "{:?}",
         trusty_code::session::MemoryFailureCategory::PalaceEnsure
     );
+    // #5911: built by SERIALISING the production envelope, never hand-written as
+    // a flat `json!`. A hand-written fixture states the test author's belief about
+    // the wire shape; this one states the shape itself, so a helper that reads the
+    // wrong path fails here instead of only in CI.
     let warning = |consecutive: u32| {
-        json!({
-            "kind": "log",
-            "session_id": "s1",
-            "level": "warn",
-            "message": format!(
-                "durable memory degraded: category={category} total_failed_turns=2 \
-                 consecutive_failed_turns={consecutive}"
-            ),
-        })
+        serde_json::to_value(SessionEventEnvelope::new(
+            "s1".to_string(),
+            0,
+            Utc::now(),
+            Event::Log {
+                session_id: "s1".to_string(),
+                level: "warn".to_string(),
+                message: format!(
+                    "durable memory degraded: category={category} total_failed_turns=2 \
+                     consecutive_failed_turns={consecutive}"
+                ),
+            },
+        ))
+        .expect("a SessionEventEnvelope always serialises")
     };
     let spine: Vec<Value> = BASELINE_EVENT_KINDS
         .iter()


### PR DESCRIPTION
Closes the `m1_cutline_full_scenario_over_stdio` failure that has kept shard 2 of `Rust tests (pre-publish gate)` red on `main`. Tracked in #5911.

## Which cause

Both, in sequence — the investigation found the red had already changed shape once.

**The original failure (baseline sequence mismatch, cause B).** #5895 (`b713b5bc5`, merged 22:16:38Z) deliberately added a per-session durable-memory degradation `log` event and did not update the pinned `BASELINE_EVENT_KINDS`. #5921 (`46812ab2a`) established that and fixed it correctly: the drain is a detached `tokio::spawn`ed task with no ordering against the session lifecycle, and `memory_outcome_reconciler` warns at streak thresholds `[1, 3]`, so `log` belongs in `filter_async_kinds` beside `index_readiness`, not in the ordered baseline. That reasoning stands and this PR does not touch it.

**The failure actually on `main` now (a defect in that fix).** `46812ab2a`'s own run was still red, and the panic had moved from line 249 to line 189:

```
assertion `left == right` failed: the only log event this run can emit is the
#2425 degradation warning, which is warn-level:
{"at":"...","event":{"level":"warn","message":"durable memory degraded: category=PalaceEnsure
total_failed_turns=1 consecutive_failed_turns=1","session_id":"...","type":"log"},
"kind":"log","seq":16,"session_id":"..."}
  left: Null
 right: "warn"
```

The envelope in the failure message is the evidence. `SessionEventEnvelope` (`crates/trusty-code/src/events.rs:1175`) lifts only `kind` to the top level; `Event::Log`'s `level` and `message` (`events.rs:384-389`) stay under the nested `event` payload. `assert_memory_degradation_logs_well_formed` read them off the envelope root, so `level` was `Null`.

Production is correct. `record_log` at `crates/trusty-code/src/session/registry_memory_sink.rs:225` emits exactly what the envelope shows. This is a test-harness defect only.

**Why review did not catch it.** The synthetic guard added in the same commit, `degradation_log_events_never_move_the_ordered_baseline`, hand-wrote its warning envelopes as flat `json!` objects with `level`/`message` at the top level. That is not the wire shape, so the fixture agreed with the helper's wrong path and passed. A fixture that states the author's belief about a shape cannot catch a reader that shares the belief.

## What changed

`crates/trusty-code/tests/m1_cutline_e2e.rs` only — no `src/**`, so no changelog fragment.

- `assert_memory_degradation_logs_well_formed` reads `envelope["event"]["level"]` and `envelope["event"]["message"]`.
- Its fixture is now SERIALISED from `SessionEventEnvelope::new` with a real `Event::Log`, so it cannot drift from the production shape again.
- `message` no longer falls back to `unwrap_or_default()`. An absent field used to yield `""`, which fails the `starts_with` check for the wrong reason and would have hidden this same error had the `level` assertion not fired first.
- Comments record why the trailing `log` event is expected and why the fixture is production-derived.

## Test that catches a recurrence

Two layers, because neither alone is sufficient:

- `degradation_log_events_never_move_the_ordered_baseline` — deterministic, no daemon, no timing. Now built from the production envelope type, so it fails on a wrong path.
- The live scenarios — verified to genuinely cover this, not assumed. With `TRUSTY_MEMORY_URL` pointed at an unreachable port to force CI's condition, reinstating the old path turns `m1_cutline_full_scenario_over_stdio` red.

The control run, old path restored:

```
test m1_cutline_full_scenario_over_stdio ... FAILED
panicked at crates/trusty-code/tests/m1_cutline_e2e.rs:198:9:
  left: Null
 right: "warn"
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 3 filtered out
```

Note `m1_cutline_full_scenario_over_http` passed in that same control run — no `log` landed in its read window. That is exactly the position/count nondeterminism #5921 documented, and it is why the synthetic guard has to exist.

## Gates — rung 2 (test-only)

```
cargo fmt --check                                     EXIT=0
cargo check -p trusty-code --all-targets              EXIT=0
cargo clippy -p trusty-code --all-targets -D warnings EXIT=0
cargo test -p trusty-code --no-fail-fast              EXIT=0
```

`cargo test -p trusty-code --no-fail-fast` — 1642 passed, 0 failed, 4 ignored across 18 targets.

Flake re-run, 10 consecutive runs of the file under the forced CI condition (`TRUSTY_MEMORY_URL=http://127.0.0.1:1`), all `5 passed; 0 failed`.

Repo gates: `check_line_cap.sh` 0 violations, `check_test_pointers.sh` 0 dangling pointers, `check_generation_artifacts.sh` 0 leaked artifacts.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
