### PR TITLE
chore: keep the tm harness scaffolding ignore block after the upstream .gitignore append

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,12 @@ docs/certificates/*.mobileprovision
 # worktree by the daemon, so it appears in that tree as an untracked file and
 # trips the clean-tree guards in scripts/check-publish-ready.sh.
 .trusty-mpm-worktree
+
+# >>> trusty-mpm harness scaffolding (auto-managed by tm, issue #3427) >>>
+.claude/agents/
+.claude/skills/
+.claude/output-styles/
+.trusty-mpm/sessions/
+.trusty-mpm/logs/
+.trusty-mpm/last-instructions.md
+# <<< trusty-mpm harness scaffolding <<<


### PR DESCRIPTION
Commits the tm harness scaffolding ignore block into `.gitignore`, inside the `# >>> trusty-mpm harness scaffolding (auto-managed by tm, issue #3427) >>>` marker fence:

```
.claude/agents/
.claude/skills/
.claude/output-styles/
.trusty-mpm/sessions/
.trusty-mpm/logs/
.trusty-mpm/last-instructions.md
```

`tm` regenerates this block locally when it is absent, so this is not new behavior — it just stops the merge conflict it caused this session: upstream appended `.agents/`, `.codex/`, and `.trusty-mpm-worktree` to the same tail region tm auto-manages, and the two appends collided on pull.

Docs/config only, no crate source touched — no changelog fragment owed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
