### PR TITLE
fix(trusty-mpm): identify the daemon by its port and its own lock record (#1731, #5951)

### DIFF
--- a/crates/trusty-mpm/changelog.d/1731-daemon-lock-ownership.md
+++ b/crates/trusty-mpm/changelog.d/1731-daemon-lock-ownership.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `~/.trusty-mpm/daemon.lock` is no longer deleted by a process that does not
+  own it (closes [#1731](https://github.com/bobmatnyc/trusty-tools/issues/1731)).
+  The daemon has written the file at startup since #1731 first closed, but the
+  `daemon::lock` unit test called `write_lock` then `remove_lock` against the
+  real path to prove they do not panic — so every `cargo test -p trusty-mpm` run
+  overwrote a live daemon's record with the test process's PID and then removed
+  it, leaving a running daemon with no lock file. Removal is now
+  ownership-checked in both the daemon's shutdown handler and `tm stop`, so an
+  outgoing daemon cannot delete a successor's record either, and that test is
+  hermetic.

--- a/crates/trusty-mpm/changelog.d/1731-daemon-lock-product-magic.md
+++ b/crates/trusty-mpm/changelog.d/1731-daemon-lock-product-magic.md
@@ -1,0 +1,12 @@
+Changed
+
+- The daemon lock file carries a `product = "trusty-mpm"` field and readers
+  reject any record without it
+  (see [#1731](https://github.com/bobmatnyc/trusty-tools/issues/1731)).
+  `daemon.lock` is not a unique filename — Claude Code writes one too, at a path
+  containing "trusty-mpm" — and a reader that trusts the path alone can hand an
+  operator an unrelated PID. A daemon started by an older binary writes no such
+  field, so its record is ignored until that daemon restarts; discovery falls
+  back to the console gateway probe and the default URL meanwhile, and
+  `tm daemon` now also probes the address it is about to bind so it cannot spawn
+  a duplicate during that window.

--- a/crates/trusty-mpm/changelog.d/5951-services-reports-port-owner.md
+++ b/crates/trusty-mpm/changelog.d/5951-services-reports-port-owner.md
@@ -1,0 +1,13 @@
+Fixed
+
+- `tm services` reports the PID of the process bound to a service's port, not
+  the first `pgrep -f` name match
+  (closes [#5951](https://github.com/bobmatnyc/trusty-tools/issues/5951)).
+  The manifest's `process_match: "trusty-mpm"` is a substring every sibling
+  process shares, so `trusty-mpm-daemon` was reported with a
+  `trusty-mpm serve --stdio` bridge's PID while `launchctl list`, `ps`, the
+  daemon's own `/health` and the console gateway all named the daemon. Since
+  this repo's guidance sends operators to `tm services` instead of raw
+  `ps`/`lsof`, that PID is one somebody signals. Name matching remains the
+  fallback for portless services such as `trusty-embedderd`, for a port nothing
+  is listening on, and for a host without `lsof`.

--- a/crates/trusty-mpm/src/bin/tm/commands/daemon.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/daemon.rs
@@ -388,7 +388,7 @@ pub(crate) async fn stop_daemon() -> anyhow::Result<()> {
         let any_alive = targets.iter().any(|p| pid_alive(*p));
         if !any_alive {
             println!("Daemon stopped");
-            cleanup_lock_file();
+            cleanup_lock_file(&targets);
             return Ok(());
         }
         if Instant::now() >= deadline {
@@ -414,21 +414,26 @@ pub(crate) async fn stop_daemon() -> anyhow::Result<()> {
         println!("Daemon may still be shutting down");
     } else {
         println!("Daemon stopped");
-        cleanup_lock_file();
+        cleanup_lock_file(&targets);
     }
     Ok(())
 }
 
-/// Remove the stale `~/.trusty-mpm/daemon.lock` after a successful stop.
+/// Remove the `~/.trusty-mpm/daemon.lock` left by the daemons we just stopped.
 ///
 /// Why: the daemon writes its lock file on bind and removes it on graceful
 /// shutdown, but SIGKILL leaves it behind; the next `tm status` call would
 /// then chase a dead address through the discovery timeout.
-/// What: best-effort `fs::remove_file` of `lock_file_path()`.
-/// Test: covered indirectly by the stop integration path.
-pub(crate) fn cleanup_lock_file() {
-    let path = trusty_mpm::core::lock_file_path();
-    let _ = std::fs::remove_file(&path);
+/// Why `stopped` (#1731): this used to delete whatever file sat at the path.
+/// A daemon that started between the SIGTERM and this call owns a valid record,
+/// and deleting it strands a live daemon with no lock file.
+/// What: removes the record only when it names one of `stopped`, then drops the
+/// guided-autostart pidfile.
+/// Test: `remove_lock_owned_by_keeps_newer_daemons_record` in
+/// `trusty_mpm::core::daemon_identity`; the stop path is covered by the stop
+/// integration path.
+pub(crate) fn cleanup_lock_file(stopped: &[u32]) {
+    trusty_mpm::core::daemon_identity::remove_lock_owned_by(stopped);
     // Also drop the guided-autostart pidfile so a stale PID from a prior raw
     // fallback spawn does not mislead `tm`'s tooling after the daemon stops (#1900).
     let root = trusty_mpm::core::paths::FrameworkPaths::default().root;
@@ -503,25 +508,15 @@ pub(crate) fn send_signal(_pid: u32, _sig: &str) -> std::io::Result<()> {
     ))
 }
 
-/// Check whether a PID is still alive (Unix only).
+/// Check whether a PID is still alive.
 ///
-/// Why: the SIGTERM-then-SIGKILL poll loop needs a portable "is this PID
-/// alive?" probe. `kill -0` returns success when the process exists.
-/// What: invokes `kill -0 <pid>` via `Command` so no extra dep is needed.
-/// Test: covered indirectly by the stop integration path.
-#[cfg(unix)]
+/// Why: the SIGTERM-then-SIGKILL poll loop needs a "is this PID alive?" probe.
+/// #1731: this spawned a `kill -0` subprocess per PID per poll iteration and
+/// was the crate's second answer to the question; both now route through the
+/// `kill(pid, 0)` syscall in `core::daemon_identity`.
+/// Test: `pid_alive_true_for_self` in `trusty_mpm::core::daemon_identity`.
 pub(crate) fn pid_alive(pid: u32) -> bool {
-    std::process::Command::new("kill")
-        .arg("-0")
-        .arg(pid.to_string())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-}
-
-#[cfg(not(unix))]
-pub(crate) fn pid_alive(_pid: u32) -> bool {
-    true
+    trusty_mpm::core::daemon_identity::pid_alive(pid)
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
@@ -115,6 +115,18 @@ pub(crate) async fn run_daemon(
         return Ok(());
     }
 
+    // #1731: the lock file now has to carry the trusty-mpm product magic to be
+    // trusted, so a daemon started by a pre-#1731 binary is invisible to the
+    // check above and the `AddrInUse` fallback below would quietly spawn a
+    // duplicate on an ephemeral port. Ask the address this invocation intends
+    // to bind whether a daemon already answers there. Scoped to `addr`, not the
+    // default, so `--addr` still starts a second daemon on a free port.
+    let intended_url = format!("http://{addr}");
+    if trusty_common::probe_health(&intended_url, "/health").await {
+        eprintln!("trusty-mpm daemon is already running at {intended_url}");
+        return Ok(());
+    }
+
     // Auto port selection: try configured address; fall back to ephemeral.
     let listener = match tokio::net::TcpListener::bind(addr).await {
         Ok(l) => l,

--- a/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/info_box/mod.rs
@@ -347,30 +347,14 @@ pub(crate) fn abbreviate_home(path: &str) -> String {
 ///
 /// Why: the lock file is cheaper than an HTTP probe and tells us the daemon
 /// address before we decide whether to fire the probe.
-/// What: parses `addr = "..."` and `pid = N`; on Unix validates the PID with
-/// `kill(pid, 0)`; returns `None` when the lock file is absent or PID is stale.
-/// Test: covered indirectly by the welcome-panel render tests.
+/// What: delegates to `core::daemon_identity::read_lock`, which rejects a
+/// record that does not carry the trusty-mpm product magic and one whose PID is
+/// no longer alive. #1731: this was the crate's third hand-rolled lock parser,
+/// and the panel would show an address taken from any TOML file at that path.
+/// Test: covered indirectly by the welcome-panel render tests; the record rules
+/// are covered in `trusty_mpm::core::daemon_identity`.
 fn read_lock_addr() -> Option<String> {
-    let path = trusty_mpm::core::lock_file_path();
-    let content = std::fs::read_to_string(&path).ok()?;
-    let mut addr: Option<String> = None;
-    let mut pid: Option<u32> = None;
-    for line in content.lines() {
-        if let Some(v) = line.strip_prefix("addr = ") {
-            addr = Some(v.trim_matches('"').to_string());
-        }
-        if let Some(v) = line.strip_prefix("pid = ") {
-            pid = v.trim().parse().ok();
-        }
-    }
-    #[cfg(unix)]
-    if let Some(p) = pid
-        && unsafe { libc::kill(p as libc::pid_t, 0) } != 0
-    {
-        return None;
-    }
-    let _ = pid;
-    addr
+    trusty_mpm::core::daemon_identity::read_lock().map(|lock| lock.addr)
 }
 
 // ── Two-panel compositor bridge ───────────────────────────────────────────────

--- a/crates/trusty-mpm/src/core/daemon_identity.rs
+++ b/crates/trusty-mpm/src/core/daemon_identity.rs
@@ -1,0 +1,374 @@
+//! Which process is the trusty-mpm daemon — the single entry point.
+//!
+//! Why: two defects had the same cause, that nothing in the codebase could
+//! authoritatively answer "which process is the daemon". #1731: the lock file
+//! at `~/.trusty-mpm/daemon.lock` carried no identity, so any process could
+//! delete it and any same-named file from another product could be read as
+//! ours. #5951: `tm services list` picked the daemon's PID with
+//! `pgrep -f trusty-mpm`, whose first hit on this machine is a
+//! `trusty-mpm serve --stdio` MCP bridge, not the daemon.
+//!
+//! What: owns the lock-file record (write, parse, ownership-checked removal)
+//! and the port-owner lookup. Every reader and writer of the lock file routes
+//! through here — before this module there were three independent hand-rolled
+//! parsers in this crate alone (`core::discovery`, `daemon::lock`, the `tm`
+//! welcome panel), each with its own idea of what a valid lock file is.
+//!
+//! Test: `parse_lock_*`, `read_lock_*`, `remove_lock_owned_by_*`,
+//! `parse_lsof_pid_*` below.
+
+use serde::{Deserialize, Serialize};
+
+use super::discovery::lock_file_path;
+
+/// Value of the lock file's `product` field written by this daemon.
+///
+/// Why (#1731): the filename `daemon.lock` is not unique to trusty-mpm.
+/// Claude Code writes `daemon.lock` too — one lives at
+/// `~/.trusty-tools/trusty-mpm/claude-config/daemon.lock` naming an unrelated
+/// PID, inside a path that contains "trusty-mpm". A reader that trusts the
+/// path alone can hand an operator someone else's PID to inspect or signal.
+/// What: [`parse_lock`] rejects any file whose `product` is absent or
+/// different, so trusting the contents requires the file to say it is ours.
+/// Test: `parse_lock_rejects_foreign_product`, `parse_lock_rejects_missing_product`.
+pub const LOCK_PRODUCT: &str = "trusty-mpm";
+
+/// The daemon's on-disk identity record.
+///
+/// Why: clients discover the daemon's actual bound address from this file —
+/// the daemon falls back to an ephemeral port when 7880 is busy, so the
+/// compiled-in default is not always right.
+/// What: serialised as TOML at [`lock_file_path`]. `product` is the
+/// [`LOCK_PRODUCT`] magic; `pid` identifies the writing process so removal can
+/// be ownership-checked; `addr` is the base URL clients connect to.
+/// Test: `parse_lock_round_trips`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonLock {
+    /// Product magic — must equal [`LOCK_PRODUCT`] for the record to be trusted.
+    pub product: String,
+    /// PID of the daemon process that wrote this file.
+    pub pid: u32,
+    /// Base URL the daemon bound, e.g. `http://127.0.0.1:7880`.
+    pub addr: String,
+    /// RFC-3339 timestamp of the write, for operator diagnostics only.
+    #[serde(default)]
+    pub started_at: String,
+}
+
+/// Parse a lock-file body, rejecting anything that does not claim to be ours.
+///
+/// Why (#1731): this is the check that makes the lock file safe to act on.
+/// Without it the reader's only evidence is the path, and a same-named file
+/// from another product parses far enough to yield a PID.
+/// What: TOML-decodes into [`DaemonLock`] and returns `None` unless `product`
+/// equals [`LOCK_PRODUCT`]. Malformed TOML, a missing `product`, and a foreign
+/// `product` are all the same answer: not ours, do not act on it.
+/// Test: `parse_lock_round_trips`, `parse_lock_rejects_foreign_product`,
+/// `parse_lock_rejects_missing_product`, `parse_lock_rejects_claude_code_lock`.
+pub fn parse_lock(text: &str) -> Option<DaemonLock> {
+    let lock: DaemonLock = toml::from_str(text).ok()?;
+    (lock.product == LOCK_PRODUCT).then_some(lock)
+}
+
+/// Serialise a lock record to the TOML body written to disk.
+///
+/// Test: `parse_lock_round_trips`.
+pub fn render_lock(lock: &DaemonLock) -> String {
+    toml::to_string(lock).unwrap_or_else(|e| {
+        // A fixed four-string struct cannot fail TOML encoding; if it somehow
+        // does, an empty body is rejected by `parse_lock` rather than written
+        // as a half-record that a reader might trust.
+        tracing::warn!("failed to encode daemon lock: {e}");
+        String::new()
+    })
+}
+
+/// Is `pid` a live process?
+///
+/// What: `kill(pid, 0)` on Unix; assumes alive on other platforms, where the
+/// lock file's PID cannot be checked.
+/// Test: `pid_alive_true_for_self`, `read_lock_rejects_dead_pid`.
+pub fn pid_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        // SAFETY: `kill` with signal 0 performs the permission/existence check
+        // only; it delivers no signal and cannot affect the target process.
+        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        true
+    }
+}
+
+/// Read the daemon's lock record, if one belongs to us and its PID is alive.
+///
+/// Why: the single read path for every consumer — URL resolution, the `tm`
+/// welcome panel, and the daemon's own duplicate-instance guard.
+/// What: reads [`lock_file_path`], rejects a foreign record via [`parse_lock`],
+/// then verifies the PID. A stale record (ours, dead PID) is deleted; a
+/// foreign file is left untouched, because deleting another product's file is
+/// the same mistake as reading it.
+/// Test: `read_lock_returns_written_record`, `read_lock_rejects_dead_pid`,
+/// `read_lock_leaves_foreign_file_in_place`.
+pub fn read_lock_at(path: &std::path::Path) -> Option<DaemonLock> {
+    let lock = parse_lock(&std::fs::read_to_string(path).ok()?)?;
+    if pid_alive(lock.pid) {
+        return Some(lock);
+    }
+    let _ = std::fs::remove_file(path);
+    None
+}
+
+/// [`read_lock_at`] against the real `~/.trusty-mpm/daemon.lock`.
+pub fn read_lock() -> Option<DaemonLock> {
+    read_lock_at(&lock_file_path())
+}
+
+/// Write the lock file naming `addr` and the current process.
+///
+/// What: creates parent directories, then writes the TOML record. Best-effort:
+/// a failure is logged, never fatal — the daemon still serves.
+/// Test: `read_lock_returns_written_record`.
+pub fn write_lock_at(path: &std::path::Path, addr: &str) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let lock = DaemonLock {
+        product: LOCK_PRODUCT.to_string(),
+        pid: std::process::id(),
+        addr: addr.to_string(),
+        started_at: chrono::Utc::now().to_rfc3339(),
+    };
+    match std::fs::write(path, render_lock(&lock)) {
+        Ok(()) => tracing::debug!("lock file written: {}", path.display()),
+        Err(e) => tracing::warn!("failed to write daemon lock file {}: {e}", path.display()),
+    }
+}
+
+/// [`write_lock_at`] against the real `~/.trusty-mpm/daemon.lock`.
+pub fn write_lock(addr: &str) {
+    write_lock_at(&lock_file_path(), addr);
+}
+
+/// Remove the lock file only when it names one of `owners`.
+///
+/// Why (#1731): unconditional removal is how the write was lost. A daemon
+/// going down removed whatever lock file was present, so a restart in which
+/// the incoming daemon bound and wrote its record before the outgoing daemon
+/// finished its shutdown handler left a running daemon with no lock file —
+/// exactly the state the reopened issue reports. The same applies to `tm stop`,
+/// which cleans up after the PIDs it signalled, not after a daemon that
+/// started since.
+/// What: reads the record, and deletes the file only if its `pid` is in
+/// `owners`. A foreign or newer record is left alone.
+/// Test: `remove_lock_owned_by_removes_own_record`,
+/// `remove_lock_owned_by_keeps_newer_daemons_record`,
+/// `remove_lock_owned_by_keeps_foreign_file`.
+pub fn remove_lock_owned_by_at(path: &std::path::Path, owners: &[u32]) {
+    let Some(lock) = std::fs::read_to_string(path)
+        .ok()
+        .as_deref()
+        .and_then(parse_lock)
+    else {
+        // Absent, unreadable, or not ours — nothing this process may delete.
+        return;
+    };
+    if !owners.contains(&lock.pid) {
+        tracing::debug!(
+            "leaving daemon lock in place: it names pid {}, not {owners:?}",
+            lock.pid
+        );
+        return;
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => tracing::debug!("lock file removed"),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => tracing::warn!("failed to remove lock file: {e}"),
+    }
+}
+
+/// [`remove_lock_owned_by_at`] against the real `~/.trusty-mpm/daemon.lock`.
+pub fn remove_lock_owned_by(owners: &[u32]) {
+    remove_lock_owned_by_at(&lock_file_path(), owners);
+}
+
+/// Extract the first PID from `lsof -t` output.
+///
+/// What: `-t` prints one bare PID per line; several appear when a process has
+/// forked while holding the listening descriptor. The first is the listener.
+/// Test: `parse_lsof_pid_reads_first`, `parse_lsof_pid_empty`,
+/// `parse_lsof_pid_ignores_garbage`.
+pub fn parse_lsof_pid(stdout: &str) -> Option<u32> {
+    stdout.split_whitespace().next()?.parse().ok()
+}
+
+/// PID of the process listening on `port`, if any.
+///
+/// Why (#5951): the process bound to the port IS the service. Matching a
+/// process name instead reports whichever same-named sibling the process table
+/// happens to yield first — on this machine `pgrep -f trusty-mpm` returns a
+/// `trusty-mpm serve --stdio` MCP bridge ahead of the daemon.
+/// What: `lsof -t -nP -iTCP:<port> -sTCP:LISTEN`, first PID. Returns `None`
+/// when nothing listens, when `lsof` is absent, or when the port is held by a
+/// process this user cannot see — callers fall back to name matching.
+/// Test: `parse_lsof_pid_reads_first` covers the parse; the spawn is exercised
+/// live by `tests/services_integration.rs`.
+pub fn pid_listening_on(port: u16) -> Option<u32> {
+    let out = std::process::Command::new("lsof")
+        .args(["-t", "-nP", &format!("-iTCP:{port}"), "-sTCP:LISTEN"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_lsof_pid(&String::from_utf8_lossy(&out.stdout))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> DaemonLock {
+        DaemonLock {
+            product: LOCK_PRODUCT.to_string(),
+            pid: std::process::id(),
+            addr: "http://127.0.0.1:7880".to_string(),
+            started_at: "2026-08-18T03:45:07.813744+00:00".to_string(),
+        }
+    }
+
+    #[test]
+    fn parse_lock_round_trips() {
+        let lock = sample();
+        assert_eq!(parse_lock(&render_lock(&lock)), Some(lock));
+    }
+
+    #[test]
+    fn parse_lock_rejects_foreign_product() {
+        let body =
+            "product = \"some-other-daemon\"\npid = 84890\naddr = \"http://127.0.0.1:7880\"\n";
+        assert_eq!(parse_lock(body), None);
+    }
+
+    #[test]
+    fn parse_lock_rejects_missing_product() {
+        // The pre-#1731 format. It is indistinguishable from any other
+        // product's TOML lock, so it is no longer trusted.
+        let body = "pid = 84890\naddr = \"http://127.0.0.1:7880\"\n";
+        assert_eq!(parse_lock(body), None);
+    }
+
+    /// #1731: the only `daemon.lock` on the reporting machine belongs to
+    /// Claude Code, not trusty-mpm, and sits inside a path containing
+    /// "trusty-mpm". Reading it and reporting its `pid` would send an operator
+    /// to an unrelated process.
+    #[test]
+    fn parse_lock_rejects_claude_code_lock() {
+        let body = r#"{
+  "pid": 84890,
+  "version": "2.1.225",
+  "launchTarget": "/Users/masa/.local/share/claude/versions/2.1.225"
+}"#;
+        assert_eq!(parse_lock(body), None);
+    }
+
+    #[test]
+    fn pid_alive_true_for_self() {
+        assert!(pid_alive(std::process::id()));
+    }
+
+    #[test]
+    fn read_lock_returns_written_record() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("daemon.lock");
+        write_lock_at(&path, "http://127.0.0.1:7880");
+        let lock = read_lock_at(&path).expect("own lock file must be readable");
+        assert_eq!(lock.product, LOCK_PRODUCT);
+        assert_eq!(lock.pid, std::process::id());
+        assert_eq!(lock.addr, "http://127.0.0.1:7880");
+        assert!(!lock.started_at.is_empty());
+    }
+
+    #[test]
+    fn read_lock_rejects_dead_pid() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("daemon.lock");
+        // PID 0 is never a live user process; `kill(0, 0)` addresses the
+        // caller's process group, so use a high PID that cannot be running.
+        std::fs::write(
+            &path,
+            "product = \"trusty-mpm\"\npid = 4194303\naddr = \"http://127.0.0.1:7880\"\nstarted_at = \"\"\n",
+        )
+        .expect("write");
+        assert_eq!(read_lock_at(&path), None);
+        assert!(!path.exists(), "a stale record of ours is cleaned up");
+    }
+
+    #[test]
+    fn read_lock_leaves_foreign_file_in_place() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("daemon.lock");
+        let body = "product = \"claude-code\"\npid = 4194303\naddr = \"http://127.0.0.1:7880\"\n";
+        std::fs::write(&path, body).expect("write");
+        assert_eq!(read_lock_at(&path), None);
+        assert!(path.exists(), "another product's file must not be deleted");
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), body);
+    }
+
+    #[test]
+    fn remove_lock_owned_by_removes_own_record() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("daemon.lock");
+        write_lock_at(&path, "http://127.0.0.1:7880");
+        remove_lock_owned_by_at(&path, &[std::process::id()]);
+        assert!(!path.exists());
+    }
+
+    /// #1731: the regression mechanism. An outgoing daemon must not delete the
+    /// record an incoming daemon has already written, or a restart leaves a
+    /// live daemon with no lock file.
+    #[test]
+    fn remove_lock_owned_by_keeps_newer_daemons_record() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("daemon.lock");
+        write_lock_at(&path, "http://127.0.0.1:7880");
+        let outgoing = std::process::id() + 1;
+        remove_lock_owned_by_at(&path, &[outgoing]);
+        assert!(path.exists(), "the incoming daemon's record must survive");
+        assert_eq!(
+            read_lock_at(&path).expect("still ours").pid,
+            std::process::id()
+        );
+    }
+
+    #[test]
+    fn remove_lock_owned_by_keeps_foreign_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("daemon.lock");
+        let body = "product = \"claude-code\"\npid = 4194303\n";
+        std::fs::write(&path, body).expect("write");
+        remove_lock_owned_by_at(&path, &[4194303]);
+        assert!(
+            path.exists(),
+            "a PID match is not ownership without the magic"
+        );
+    }
+
+    #[test]
+    fn parse_lsof_pid_reads_first() {
+        assert_eq!(parse_lsof_pid("48689\n48690\n"), Some(48689));
+    }
+
+    #[test]
+    fn parse_lsof_pid_empty() {
+        assert_eq!(parse_lsof_pid(""), None);
+        assert_eq!(parse_lsof_pid("\n  \n"), None);
+    }
+
+    #[test]
+    fn parse_lsof_pid_ignores_garbage() {
+        assert_eq!(parse_lsof_pid("lsof: not found"), None);
+    }
+}

--- a/crates/trusty-mpm/src/core/discovery.rs
+++ b/crates/trusty-mpm/src/core/discovery.rs
@@ -462,34 +462,12 @@ async fn probe_url(client: &reqwest::Client, url: &str) -> bool {
 }
 
 /// Read the daemon URL from the lock file if present and the PID is alive.
+///
+/// #1731: the parse, the product-magic check, and the stale-record cleanup all
+/// live in [`crate::core::daemon_identity`] — this hand-rolled a second copy of
+/// them, and trusted any TOML at the path with an `addr` line.
 fn read_lock_file_url() -> Option<String> {
-    let path = lock_file_path();
-    let content = std::fs::read_to_string(&path).ok()?;
-
-    let mut addr: Option<String> = None;
-    let mut pid: Option<u32> = None;
-
-    for line in content.lines() {
-        if let Some(v) = line.strip_prefix("addr = ") {
-            addr = Some(v.trim_matches('"').to_string());
-        }
-        if let Some(v) = line.strip_prefix("pid = ") {
-            pid = v.trim().parse::<u32>().ok();
-        }
-    }
-
-    // Validate PID is still alive (Unix only; on non-Unix skip check).
-    #[cfg(unix)]
-    if let Some(p) = pid {
-        // kill(pid, 0) returns Ok if process exists, Err otherwise.
-        if unsafe { libc::kill(p as libc::pid_t, 0) } != 0 {
-            // Stale lock — remove it silently.
-            let _ = std::fs::remove_file(&path);
-            return None;
-        }
-    }
-
-    addr
+    super::daemon_identity::read_lock().map(|lock| lock.addr)
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -65,6 +65,7 @@ pub mod config;
 /// Unrecognised-key reporting for the host-level config files (#5207).
 pub mod config_keys;
 pub mod connect;
+pub mod daemon_identity;
 pub mod delegation_authority;
 pub mod deploy_validate;
 pub mod deterministic_overseer;

--- a/crates/trusty-mpm/src/daemon/lock.rs
+++ b/crates/trusty-mpm/src/daemon/lock.rs
@@ -1,60 +1,46 @@
-//! Daemon lock file: written on bind, deleted on shutdown.
+//! Daemon lock file: written on bind, removed on shutdown by its owner.
 //!
-//! Why: Clients use the lock file to discover the daemon's actual address
-//! (which may differ from the configured port if auto-selection kicked in).
-//! The file lives at `~/.trusty-mpm/daemon.lock` — the same framework root
-//! every other artifact uses — so the daemon and its clients always agree on
-//! its location.
-//! What: `write_lock` creates the TOML file; `remove_lock` deletes it.
-//! Both are best-effort — errors are logged but not fatal.
-//! Test: `write_lock` / `remove_lock` round-trip covered below.
+//! Why: clients discover the daemon's actual bound address here, which differs
+//! from the compiled-in default whenever port auto-selection kicked in.
+//! What: a thin daemon-side facade over [`crate::core::daemon_identity`], which
+//! owns the record format, the product-magic check, and the ownership rule for
+//! removal. This module exists so the daemon's call sites read as
+//! `lock::write_lock(&url)` rather than reaching across into `core`.
+//! Test: the record's behaviour is covered in `core::daemon_identity`;
+//! `write_and_remove_round_trip` covers this facade.
 
-use crate::core::lock_file_path;
+use crate::core::daemon_identity;
 
-/// Write the daemon lock file with the actual bound address and current PID.
+/// Write the lock file with the actual bound address and this process's PID.
 ///
-/// Why: Must be called after `TcpListener::local_addr()` is known. As of
+/// Why: must be called after `TcpListener::local_addr()` is known. As of
 /// ADR-0011's loopback-only doctrine (issue #3330) the daemon never binds a
-/// second (Tailscale) listener, so the lock file no longer carries an
-/// optional `tailscale_addr` field.
-/// What: Creates parent dirs if needed, writes TOML, logs on error.
+/// second (Tailscale) listener, so the record carries no `tailscale_addr`.
+/// What: delegates to [`daemon_identity::write_lock`]; best-effort.
+/// Test: `write_and_remove_round_trip`.
 pub fn write_lock(addr: &str) {
-    let path = lock_file_path();
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    let pid = std::process::id();
-    let started_at = chrono::Utc::now().to_rfc3339();
-    let content = format!("pid = {pid}\naddr = \"{addr}\"\nstarted_at = \"{started_at}\"\n");
-    if let Err(e) = std::fs::write(&path, content) {
-        tracing::warn!("failed to write daemon lock file {}: {e}", path.display());
-    } else {
-        tracing::debug!("lock file written: {}", path.display());
-    }
+    daemon_identity::write_lock(addr);
 }
 
-/// Remove the daemon lock file on clean shutdown.
+/// Remove the lock file on clean shutdown — but only if it still names us.
 ///
-/// Why: A deleted lock file signals that no daemon is running, avoiding stale
-/// reads by clients that check the file before falling back to the default URL.
-/// What: Best-effort `fs::remove_file`; silently ignores "not found".
+/// Why (#1731): this used to delete whatever file sat at the path. During a
+/// restart the incoming daemon binds and writes its own record while the
+/// outgoing daemon is still running its shutdown handler, so an unconditional
+/// delete left a live daemon with no lock file — the state the reopened issue
+/// reports.
+/// What: delegates to [`daemon_identity::remove_lock_owned_by`] naming this
+/// process, so a successor's record survives.
+/// Test: `remove_lock_owned_by_keeps_newer_daemons_record` in
+/// `core::daemon_identity`.
 pub fn remove_lock() {
-    let path = lock_file_path();
-    match std::fs::remove_file(&path) {
-        Ok(()) => tracing::debug!("lock file removed"),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => tracing::warn!("failed to remove lock file: {e}"),
-    }
+    daemon_identity::remove_lock_owned_by(&[std::process::id()]);
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn write_and_remove_round_trip() {
-        // Just verify the functions don't panic on a writable path.
-        write_lock("http://127.0.0.1:7880");
-        remove_lock();
-    }
-}
+// #1731: there is deliberately no test here. The test this file used to carry
+// called `write_lock` / `remove_lock` against the REAL `~/.trusty-mpm/daemon.lock`
+// to prove they "don't panic" — so every `cargo test -p trusty-mpm` run
+// overwrote a live daemon's record with the test process's PID and then deleted
+// it, leaving a running daemon with no lock file. That is the reported state.
+// The behaviour these two functions delegate to is covered hermetically, against
+// a tempdir path, in `core::daemon_identity`.

--- a/crates/trusty-mpm/src/daemon/lock.rs
+++ b/crates/trusty-mpm/src/daemon/lock.rs
@@ -6,8 +6,9 @@
 //! owns the record format, the product-magic check, and the ownership rule for
 //! removal. This module exists so the daemon's call sites read as
 //! `lock::write_lock(&url)` rather than reaching across into `core`.
-//! Test: the record's behaviour is covered in `core::daemon_identity`;
-//! `write_and_remove_round_trip` covers this facade.
+//! Test: the record's behaviour is covered hermetically in
+//! `core::daemon_identity`. This facade carries no test of its own — the note
+//! at the foot of this file says why (#1731).
 
 use crate::core::daemon_identity;
 
@@ -17,7 +18,7 @@ use crate::core::daemon_identity;
 /// ADR-0011's loopback-only doctrine (issue #3330) the daemon never binds a
 /// second (Tailscale) listener, so the record carries no `tailscale_addr`.
 /// What: delegates to [`daemon_identity::write_lock`]; best-effort.
-/// Test: `write_and_remove_round_trip`.
+/// Test: `read_lock_returns_written_record` in `core::daemon_identity`.
 pub fn write_lock(addr: &str) {
     daemon_identity::write_lock(addr);
 }

--- a/crates/trusty-mpm/src/services/discoverer/mod.rs
+++ b/crates/trusty-mpm/src/services/discoverer/mod.rs
@@ -125,6 +125,17 @@ pub struct HealthResult {
 pub trait ProcessProber: Send + Sync {
     /// Run `pgrep -f <pattern>` and return the first matched PID.
     fn pgrep(&self, pattern: &str) -> Option<u32>;
+
+    /// PID of the process listening on `port`, if any.
+    ///
+    /// Why (#5951): name matching cannot tell a daemon from a same-named
+    /// sibling; the process holding the listening socket can. Defaults to
+    /// `None` so a prober that cannot answer falls back to `pgrep`.
+    /// Test: `pid_prefers_port_owner_over_name_match`.
+    fn pid_listening_on(&self, port: u16) -> Option<u32> {
+        let _ = port;
+        None
+    }
 }
 
 /// Trait for port file reading.
@@ -189,6 +200,10 @@ impl ProcessProber for RealProcessProber {
             .split_whitespace()
             .next()
             .and_then(|s| s.parse::<u32>().ok())
+    }
+
+    fn pid_listening_on(&self, port: u16) -> Option<u32> {
+        crate::core::daemon_identity::pid_listening_on(port)
     }
 }
 
@@ -440,8 +455,8 @@ impl Discoverer {
     /// What: runs process, port, health, version, and uptime probes in sequence.
     /// Test: covered by the mock-based discoverer unit tests.
     fn probe(&mut self, name: &str, decl: &ServiceDecl) -> ServiceStatus {
-        let pid = self.probe_process(decl);
         let port = self.probe_port(decl);
+        let pid = self.probe_pid(decl, port);
         let url = port.map(|p| format!("http://localhost:{p}"));
 
         let health = if let Some(u) = &url {
@@ -493,6 +508,28 @@ impl Discoverer {
             log_path,
             uptime_secs,
         }
+    }
+
+    /// PID of the service: the port's owner when there is one, else a name match.
+    ///
+    /// Why (#5951): `tm services list` reported `trusty-mpm-daemon` as PID 7009,
+    /// a `trusty-mpm serve --stdio` MCP bridge, because the manifest's
+    /// `process_match: "trusty-mpm"` is a substring every sibling shares and
+    /// `pgrep` returns the lowest PID first. Four independent sources —
+    /// `launchctl list`, `ps`, the daemon's `/health`, and the console
+    /// gateway — named the daemon, and `tm` named something else. Operators are
+    /// told to use `tm services` instead of raw `ps`/`lsof`, so the wrong PID
+    /// here is a PID somebody signals.
+    /// What: when the service has a resolved port, the process holding its
+    /// listening socket is the service, definitionally. Name matching stays the
+    /// fallback for portless services (`trusty-embedderd`), for a port nothing
+    /// is listening on, and for a host without `lsof`.
+    /// Test: `pid_prefers_port_owner_over_name_match`,
+    /// `pid_falls_back_to_name_match_without_port`,
+    /// `pid_falls_back_to_name_match_when_port_unowned`.
+    fn probe_pid(&self, decl: &ServiceDecl, port: Option<u16>) -> Option<u32> {
+        port.and_then(|p| self.process_prober.pid_listening_on(p))
+            .or_else(|| self.probe_process(decl))
     }
 
     /// Run pgrep for the service's `process_match` pattern.

--- a/crates/trusty-mpm/src/services/discoverer/tests.rs
+++ b/crates/trusty-mpm/src/services/discoverer/tests.rs
@@ -394,3 +394,81 @@ fn sidecar_shows_unknown_health_when_running() {
     assert_eq!(status.health, HealthState::Unknown);
     assert!(status.port.is_none());
 }
+
+// ── #5951: the PID reported must be the port's owner, not a same-named sibling ──
+
+/// A prober that answers both questions differently, the way the reporting
+/// machine did: `pgrep -f trusty-mpm` returned the stdio bridge (7009) while
+/// port 7880 was held by the daemon (48689).
+struct MockPortOwnerProber {
+    name_pid: Option<u32>,
+    port_owner: Option<u32>,
+}
+
+impl ProcessProber for MockPortOwnerProber {
+    fn pgrep(&self, _pattern: &str) -> Option<u32> {
+        self.name_pid
+    }
+    fn pid_listening_on(&self, _port: u16) -> Option<u32> {
+        self.port_owner
+    }
+}
+
+/// #5951: `tm services list` printed 7009, a `trusty-mpm serve --stdio` MCP
+/// bridge, for a daemon whose real PID was 48689.
+#[test]
+fn pid_prefers_port_owner_over_name_match() {
+    let m = static_manifest_with_port(7880);
+    let mut d = Discoverer::with_probers(
+        m,
+        Box::new(MockPortOwnerProber {
+            name_pid: Some(7009),
+            port_owner: Some(48689),
+        }),
+        Box::new(MockPortProber { port: Some(7880) }),
+        Box::new(MockHttpProber::new(HealthState::Ok)),
+        Box::new(MockVersionRunner { version: None }),
+    );
+    let status = d.status("test-svc").unwrap();
+    assert_eq!(
+        status.pid,
+        Some(48689),
+        "the process bound to the port is the service; 7009 is a sibling"
+    );
+    assert!(status.running);
+}
+
+/// A portless sidecar has no socket to attribute, so name matching stands.
+#[test]
+fn pid_falls_back_to_name_match_without_port() {
+    let mut d = Discoverer::with_probers(
+        sidecar_manifest(),
+        Box::new(MockPortOwnerProber {
+            name_pid: Some(7009),
+            port_owner: Some(48689),
+        }),
+        Box::new(MockPortProber { port: None }),
+        Box::new(MockHttpProber::new(HealthState::Ok)),
+        Box::new(MockVersionRunner { version: None }),
+    );
+    let status = d.status("sidecar").unwrap();
+    assert_eq!(status.pid, Some(7009));
+}
+
+/// No `lsof`, or nothing listening: report the name match rather than nothing.
+#[test]
+fn pid_falls_back_to_name_match_when_port_unowned() {
+    let m = static_manifest_with_port(7880);
+    let mut d = Discoverer::with_probers(
+        m,
+        Box::new(MockPortOwnerProber {
+            name_pid: Some(7009),
+            port_owner: None,
+        }),
+        Box::new(MockPortProber { port: Some(7880) }),
+        Box::new(MockHttpProber::new(HealthState::Ok)),
+        Box::new(MockVersionRunner { version: None }),
+    );
+    let status = d.status("test-svc").unwrap();
+    assert_eq!(status.pid, Some(7009));
+}

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -1329,8 +1329,10 @@ fn cli_prune_idle_unreachable_exit_code() {
     let fake_home = tempfile::tempdir().expect("create temp home");
     let lock_dir = fake_home.path().join(".trusty-mpm");
     std::fs::create_dir_all(&lock_dir).expect("create .trusty-mpm under fake HOME");
+    // #1731: the record must carry the trusty-mpm product magic, or the reader
+    // rejects it as another product's same-named file.
     let lock_content = format!(
-        "addr = \"http://127.0.0.1:1\"\npid = {}\n",
+        "product = \"trusty-mpm\"\naddr = \"http://127.0.0.1:1\"\npid = {}\n",
         std::process::id()
     );
     std::fs::write(lock_dir.join("daemon.lock"), &lock_content).expect("write fake daemon.lock");


### PR DESCRIPTION
Both issues are the same failure: nothing in the crate could authoritatively say which process is the daemon. Three hand-rolled lock-file parsers and a first-match `pgrep` each answered differently. `core::daemon_identity` is now the one place that answers it; `core::discovery`, `daemon::lock`, the `tm` welcome panel, `tm stop` and the service discoverer all route through it. They converged rather than splitting.

## #1731 — what the history actually shows

The daemon has written `~/.trusty-mpm/daemon.lock` since [#1731](https://github.com/bobmatnyc/trusty-tools/issues/1731) first closed. `daemon_run.rs:133` calls `trusty_mpm::daemon::lock::write_lock(&base_url)` right after `local_addr()`, and the closing commit `2f1eef59b` said so. The writer was never removed, never gated, and never wrote elsewhere.

The deleter is what lost it. `daemon/lock.rs` carried a unit test that called `write_lock` then `remove_lock` against the **real** path to prove they do not panic, so every `cargo test -p trusty-mpm` run overwrote a live daemon's record with the test process's PID and then deleted it. Observed live while writing this PR: the file held `pid = 48689` at 03:51, a sibling worktree ran the suite, and by 03:58 it was gone with daemon 48689 still answering `/health`. That is why the file "does not exist on this machine" on a host that runs this suite constantly, and why a fix that only re-checked the writer would close the issue again without changing anything.

Removal is now ownership-checked in the daemon's shutdown handler and in `tm stop`, so neither an unrelated process nor an outgoing daemon can delete a successor's record. The test is hermetic.

The record also carries `product = "trusty-mpm"`, and readers reject anything without it. `daemon.lock` is not a unique filename — Claude Code writes one at `~/.trusty-tools/trusty-mpm/claude-config/daemon.lock` naming an unrelated PID, inside a path containing "trusty-mpm". A foreign file is now neither read nor deleted.

## #5951 — the reported PID

`process_match: "trusty-mpm"` is a substring every sibling process shares and `pgrep -f` returns the lowest match, so the answer was whichever process the table yielded first. The PID is now the process holding the port's listening socket. Name matching stays the fallback for portless services (`trusty-embedderd`), for a port nothing is listening on, and for hosts without `lsof`.

## Verification against the live daemon

Ground truth, four ways — `lsof -nP -iTCP:7880 -sTCP:LISTEN -t` and `GET /health` both say **48689**; `launchctl list` shows `com.trusty.mpm.supervisor`.

```
=== BEFORE: installed tm 1.4.3 (main, release) ===
  "running": true,  "pid": 407,    "port": 7880, "health": "ok", "uptime_secs": 9

=== AFTER: this branch (release) ===
  "running": true,  "pid": 48689,  "port": 7880, "health": "ok", "uptime_secs": 1817
```

Main's answer is not merely wrong but unstable — three consecutive runs gave 7009 (the PID in the issue), 206, and 407. 407 had a 9-second uptime; 48689's 1817s matches the daemon's actual start. `ps -p 206` returned nothing at all: main reported a PID for a process that had already exited, alongside `running: true` and `health: ok`.

## Tests

New, all failing against `main` (the first two describe behaviour `main` does not have — its writer emits no identity and its readers apply no product check):

| Test | Pins |
|---|---|
| `read_lock_returns_written_record` | the record a daemon writes is one the reader accepts |
| `parse_lock_rejects_missing_product`, `parse_lock_rejects_foreign_product`, `parse_lock_rejects_claude_code_lock` | a `daemon.lock` written by another product is rejected |
| `read_lock_leaves_foreign_file_in_place`, `remove_lock_owned_by_keeps_foreign_file` | and is not deleted either |
| `remove_lock_owned_by_keeps_newer_daemons_record` | the regression mechanism: an outgoing owner cannot delete a successor's record |
| `read_lock_rejects_dead_pid` | a stale record of ours is still cleaned up |
| `pid_prefers_port_owner_over_name_match` | #5951, with the reported PIDs (7009 vs 48689) as the fixture |
| `pid_falls_back_to_name_match_without_port`, `pid_falls_back_to_name_match_when_port_unowned` | the fallback still works |

## Gates — rung 5

```
cargo fmt --check                                       EXIT=0
cargo check --workspace                                 EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings EXIT=0
cargo test -p trusty-mpm --no-fail-fast                 EXIT=0
  → 7356 passed; 0 failed; 27 ignored (55 test binaries)
bash scripts/check_line_cap.sh                          0 violations
bash scripts/check_sld.sh                               0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh                OK
```

No crate depends on `trusty-mpm` as a library, so rung 4's per-dependent runs are vacuous; `check --workspace` covers it. The 27 ignored tests are network, live-tmux and live-provider only — none touches the lock file or service discovery, and running them would create real tmux sessions on a host carrying live sessions. The live before/after above is the integration evidence in their place. Rung 5 also asks for a `code-critic` round; that has not been run.

## Upgrade window

A daemon started by an older binary writes no `product` field, so its record is ignored until that daemon restarts. Discovery falls back to the console gateway probe and the default URL meanwhile — both correct here. To keep that window from producing a duplicate daemon, `tm daemon` now also probes the address it is about to bind, scoped to `--addr` so starting a second daemon on a free port still works.

## Found while working, not fixed here

- `tm services status` panics in any **debug** build: `RealHttpProber` builds a `reqwest::blocking` client inside `tm::main`'s async runtime, and dropping it panics with "Cannot drop a runtime in a context where blocking is not allowed". Reproduced on unmodified `main` at `1e96b074d`, so it is pre-existing. Release builds are unaffected, which is why nobody has hit it.
- `trusty-console`'s `detect/mpm.rs` reads the same lock file with its own line scan and applies no product check. It keeps working (it only reads `addr`), but it is the remaining instance of the hazard, in a crate outside this PR's scope. Related: [#4925](https://github.com/bobmatnyc/trusty-tools/issues/4925).
- `daemon_identity::pid_listening_on` spawns `lsof`, and `trusty-installer`'s `port_guard` does too for a different question (free-vs-held adjudication with a bind probe). Consolidating them is a cross-crate refactor this PR does not attempt.

Closes #1731
Closes #5951

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
