### PR TITLE
fix(trusty-audit): the confirmed launch audits what was registered, not a stale selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11296,7 +11296,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-audit"
-version = "0.3.0"
+version = "0.4.0"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"
@@ -44,6 +44,15 @@ dirs = { workspace = true }
 # Argument parsing. The parser lives in the LIBRARY (`cli.rs`) so every CLI
 # invocation is unit-testable without spawning the binary.
 clap = { workspace = true }
+# POSIX job control and terminal-queue calls the prompt path needs, none of
+# which `std` exposes. `tcgetpgrp`/`getpgrp` refuse a terminal this process is
+# in a BACKGROUND group of — reading one raises SIGTTIN and stops the job with
+# no diagnostic — and `tcflush(TCIFLUSH)` discards typeahead before the question
+# that commits to an hours-long sweep (both #5896 review). `rpassword` still
+# owns every echo-suppression call, so this crate spells no `termios` of its
+# own. Also `setsid(2)` in `tests/guided_launch.rs`, which needs a child with no
+# controlling terminal at all.
+libc = { workspace = true }
 # Reading the companion engagement config and tga's `manifest.toml`.
 serde = { workspace = true }
 toml = { workspace = true }
@@ -103,12 +112,6 @@ walkdir = { workspace = true }
 [dev-dependencies]
 # Real directories for the working-directory creation tests.
 tempfile = { workspace = true }
-# #5885: `tests/guided_launch.rs` proves the launch is non-interactive when
-# there is no controlling terminal, which means launching a child that HAS none
-# — `setsid(2)` in a `pre_exec` hook. Without it the test inherits the
-# developer's terminal, the interactive path opens `/dev/tty`, and the test
-# blocks on a read nobody is there to answer.
-libc = { workspace = true }
 # #5824: `tests/cli_end_to_end.rs` opens the return package the chain wrote and
 # reads its generated members, because what the recipient receives is the zip
 # rather than the console output that produced it. Already a dependency above,

--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -27,9 +27,14 @@ Two constraints are permanent, not phases:
 
 A bare invocation is the entry point, and on a terminal it is the whole
 engagement: it asks for the audit targets one at a time, registers each as you
-enter it, installs the pinned tools, and then asks before starting the sweep. Run
-it with no controlling terminal — a script, a CI job, `TRUSTY_AUDIT_NO_LAUNCH=1`
-— and it prints the status card instead, prompting for nothing.
+enter it, installs the pinned tools, and then asks before starting the sweep.
+
+Two ways to get the status card instead, prompting for nothing: run
+`trusty-audit guided`, which is the named verb for exactly that, or run the bare
+invocation with no controlling terminal — a script, a cron entry, a CI job.
+`TRUSTY_AUDIT_NO_LAUNCH=1` is not one of them: it is read by `install.sh`, where
+it decides whether the installer starts the binary at all, and the binary itself
+never reads it.
 
 ```
 trusty-audit                    # guided flow: register targets, install, sweep

--- a/crates/trusty-audit/changelog.d/5896-post-merge-critic-fixes-api.md
+++ b/crates/trusty-audit/changelog.d/5896-post-merge-critic-fixes-api.md
@@ -1,0 +1,8 @@
+Changed
+
+- `cli::registration::is_interactive` takes `&Cli` rather than `&Command`, and
+  `guided_at_the_terminal` returns `Launch` rather than an `Outcome` so the
+  front end owns when the credential is resolved.
+- `README.md` no longer offers `TRUSTY_AUDIT_NO_LAUNCH=1` as a way to make the
+  binary non-interactive. It is an `install.sh` variable deciding whether the
+  installer starts the binary; the binary never reads it.

--- a/crates/trusty-audit/changelog.d/5896-post-merge-critic-fixes.md
+++ b/crates/trusty-audit/changelog.d/5896-post-merge-critic-fixes.md
@@ -1,0 +1,26 @@
+Fixed
+
+- The confirmed launch now runs the one-shot chain instead of the bare sweep. The
+  sweep reads `state/selected-repos.toml`, which only `clone` writes and nothing
+  in the guided launch wrote — so a fresh recipient died at
+  `NoRepositoriesSelected` right after being told "Everything is in place", and a
+  recipient carrying a selection from an earlier `taudit clone` had those OLD
+  repositories audited, reported as audited, and exited 0.
+- `trusty-audit guided` prints the status card and exits again. The interactive
+  decision now reads the parsed CLI rather than the `Command` it maps to, which
+  cannot tell the named verb from a bare launch — under a pty that turned the
+  documented spelling into an unbounded hang.
+- The sweep question discards terminal typeahead before it is asked, so an
+  operator double-tapping Enter to finish adding targets no longer starts hours
+  of unattended work with the second newline. Enter still starts the sweep.
+- A board-only registry reports `SelectRepositories` again. Any registered target
+  counted as a repository, so `taudit add board jira:ACME` skipped repository
+  selection, triggered a real multi-tool download, and reported `ReadyForRun`.
+- A bare launch prints its status card without asking for an inference
+  credential. The key is resolved once the operator confirms the sweep, not
+  before the card — a config with a blank key made the read-only launch exit
+  non-zero after three mismatched retypes, never printing anything.
+- A launch backgrounded with `&` prints the card instead of stopping silently.
+  Opening `/dev/tty` for write succeeds from a background process group, so the
+  first read raised SIGTTIN; the terminal probe now also checks the foreground
+  group.

--- a/crates/trusty-audit/src/cli/credential.rs
+++ b/crates/trusty-audit/src/cli/credential.rs
@@ -174,6 +174,24 @@ pub trait Tty {
     ///
     /// Whatever writing to the terminal failed with.
     fn say(&mut self, line: &str) -> io::Result<()>;
+
+    /// Discard anything typed ahead that no read has consumed yet.
+    ///
+    /// Why: a terminal in canonical mode queues typing that arrives before the
+    /// program asks for it. The registration loop (#5885) ends when the
+    /// operator presses Enter on an empty line, and the very next prompt gates
+    /// an hours-long unattended sweep that spends the client's inference
+    /// credential — so an operator who double-taps Enter to finish adding
+    /// targets has the second newline answer a question they never read.
+    /// What: implementations drop the pending input queue. Called immediately
+    /// before a prompt whose default answer commits to something expensive; a
+    /// prompt that only costs a retry does not need it.
+    /// Test: `super::super::registration::registration_tests::the_sweep_prompt_discards_typeahead_first`.
+    ///
+    /// # Errors
+    ///
+    /// Whatever discarding the terminal's input queue failed with.
+    fn discard_typeahead(&mut self) -> io::Result<()>;
 }
 
 /// The process's controlling terminal, reached through `/dev/tty`.
@@ -209,10 +227,56 @@ impl DevTty {
     /// # Errors
     ///
     /// Whatever opening `/dev/tty` failed with — `ENXIO` or `ENOENT` when the
-    /// process has no controlling terminal.
+    /// process has no controlling terminal — and `ENOTTY` when this process is
+    /// not in the terminal's foreground group. See [`DevTty::in_foreground`].
     pub fn open() -> io::Result<Self> {
         let out = std::fs::OpenOptions::new().write(true).open(Self::PATH)?;
+        Self::refuse_a_background_terminal(&out)?;
         Ok(Self { out })
+    }
+
+    /// Whether a terminal whose foreground group is `terminal` may be read by a
+    /// process in group `ours`.
+    ///
+    /// Why: opening `/dev/tty` for WRITE succeeds from a background job, so the
+    /// probe above is not on its own evidence that anyone can be asked. A
+    /// background process that READS the controlling terminal raises SIGTTIN,
+    /// whose default action STOPS the process — `trusty-audit &` from an
+    /// interactive shell went silent with nothing printed and no diagnostic.
+    /// What: the two groups agree. Split out as a pure function so the
+    /// comparison's direction is a test rather than a reading of the `unsafe`
+    /// block that supplies its arguments.
+    /// Test: `super::credential_tests::a_background_process_group_is_not_promptable`.
+    fn in_foreground(terminal: i32, ours: i32) -> bool {
+        terminal == ours
+    }
+
+    /// Refuse `out` when this process is in a background group of it.
+    ///
+    /// `ENOTTY` rather than a new error variant: `main` already treats a failed
+    /// [`DevTty::open`] as "there is nobody to ask" and prints the status card,
+    /// which is exactly the behaviour a backgrounded launch should get.
+    #[cfg(unix)]
+    fn refuse_a_background_terminal(out: &std::fs::File) -> io::Result<()> {
+        use std::os::fd::AsRawFd as _;
+        // SAFETY: `tcgetpgrp` reads the foreground group of a terminal through
+        // a live descriptor this call borrows, and `getpgrp` reads this
+        // process's own group. Neither writes through a pointer, and neither
+        // can fail in a way that leaves state to unwind.
+        let (terminal, ours) = unsafe { (libc::tcgetpgrp(out.as_raw_fd()), libc::getpgrp()) };
+        if terminal == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        if Self::in_foreground(terminal, ours) {
+            return Ok(());
+        }
+        Err(io::Error::from_raw_os_error(libc::ENOTTY))
+    }
+
+    /// No controlling-terminal job control to consult off unix.
+    #[cfg(not(unix))]
+    fn refuse_a_background_terminal(_out: &std::fs::File) -> io::Result<()> {
+        Ok(())
     }
 }
 
@@ -242,6 +306,30 @@ impl Tty for DevTty {
         use std::io::Write as _;
         writeln!(self.out, "{line}")?;
         self.out.flush()
+    }
+
+    /// `tcflush(TCIFLUSH)` on the controlling terminal.
+    ///
+    /// A READ handle is opened for it, for the same reason [`Tty::read_line`]
+    /// opens one: the handle this struct holds is write-only, and the input
+    /// queue being discarded belongs to the terminal rather than to any one
+    /// descriptor, so a fresh `/dev/tty` reaches the same queue.
+    #[cfg(unix)]
+    fn discard_typeahead(&mut self) -> io::Result<()> {
+        use std::os::fd::AsRawFd as _;
+        let tty = std::fs::File::open(Self::PATH)?;
+        // SAFETY: `tcflush` acts on a live descriptor owned by `tty` for the
+        // duration of the call and writes through no pointer.
+        if unsafe { libc::tcflush(tty.as_raw_fd(), libc::TCIFLUSH) } == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    /// No POSIX terminal input queue to discard off unix.
+    #[cfg(not(unix))]
+    fn discard_typeahead(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }
 
@@ -523,6 +611,25 @@ trusty-review = "0.15.1"
             self.shown.push(line.to_owned());
             Ok(())
         }
+
+        /// Nothing in this module discards typeahead — the credential prompt's
+        /// default answer is another prompt, not an hours-long sweep. The
+        /// registration loop's fake is what records the call (#5885).
+        fn discard_typeahead(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A launch backgrounded with `&` still opens `/dev/tty` for write, so the
+    /// open on its own is not evidence anyone can be asked. Reading it from a
+    /// background group raises SIGTTIN and stops the job silently.
+    #[test]
+    fn a_background_process_group_is_not_promptable() {
+        assert!(DevTty::in_foreground(4242, 4242));
+        assert!(
+            !DevTty::in_foreground(4242, 4243),
+            "a process outside the terminal's foreground group must not be asked"
+        );
     }
 
     fn config_path() -> &'static Path {

--- a/crates/trusty-audit/src/cli/registration.rs
+++ b/crates/trusty-audit/src/cli/registration.rs
@@ -33,11 +33,11 @@
 //!
 //! Test: `super::registration_tests`.
 
+use crate::chain::ChainOptions;
 use crate::cli::credential::Tty;
-use crate::cli::render;
+use crate::cli::{Cli, render};
 use crate::error::AuditError;
 use crate::registry::{self, COVERAGE_COACHING, Target};
-use crate::run::RunOptions;
 use crate::session::{Command, NextStep, Outcome, Session};
 
 /// The one prompt, naming both shapes it takes and how to stop.
@@ -69,45 +69,93 @@ const SWEEP_DECLINED: &str = "Not started. Run `trusty-audit run` when you are r
 /// Whether this invocation is eligible for the interactive launch.
 ///
 /// Why: a named subcommand is what a script, a CI job or the E2E harness runs,
-/// and none of them may be stopped for a prompt. Stating the rule as a function
-/// makes "no subcommand ever prompts" a test rather than a reading of the
-/// twenty-line binary shim.
-/// What: only a bare launch — [`Command::Guided`]. Having a terminal is the
-/// second and independent condition, which `main` checks with
-/// [`DevTty::open`](crate::cli::credential::DevTty::open); both must hold.
+/// and none of them may be stopped for a prompt. It takes the PARSED CLI rather
+/// than the [`Command`] it maps to because that mapping is not injective:
+/// `Cli::to_command` collapses `None | Some(Verb::Guided)` onto
+/// [`Command::Guided`], so by the time a `Command` exists, `trusty-audit` and
+/// `trusty-audit guided` are the same value. Asking the `Command` therefore made
+/// the named verb — a documented spelling, and the one #5502's reachability
+/// table mandates — block on a prompt where it used to print the card and exit.
+/// Under any pty (expect, `ssh -t`, tmux, a tty-allocating CI runner) that is an
+/// unbounded hang.
+/// What: no subcommand at all, and a command that may prompt. Having a terminal
+/// is the third and independent condition, which `main` checks with
+/// [`DevTty::open`](crate::cli::credential::DevTty::open); all must hold.
+/// Test: `super::registration_tests::the_named_guided_verb_is_not_interactive`,
+/// `super::registration_tests::only_a_bare_launch_is_interactive`.
+pub fn is_interactive(cli: &Cli) -> bool {
+    cli.verb.is_none() && may_prompt(&cli.to_command())
+}
+
+/// Which capability may ever be reached interactively.
+///
+/// The secondary guard: [`is_interactive`]'s first condition already excludes
+/// every named verb, and this keeps the answer assertable over the CAPABILITY
+/// set too — so a future `Command` that a bare launch could route to has to be
+/// named here before it can prompt.
 /// Test: `super::registration_tests::only_a_bare_launch_is_interactive`.
-pub fn is_interactive(command: &Command) -> bool {
+fn may_prompt(command: &Command) -> bool {
     matches!(command, Command::Guided)
 }
 
-/// Drive the whole launch: register, advance the guided flow, then sweep.
+/// What the launch decided at the terminal.
 ///
-/// Why: "one step" means one invocation. The operator supplies their key (which
-/// `main` has already resolved by the time this is called), names what the audit
-/// covers, and the flow carries on into tool installation and the sweep without
-/// a second command.
+/// Why: the sweep needs an inference credential and the status card does not,
+/// so `main` cannot resolve one before knowing which of the two happened. This
+/// type is that answer, which is what lets a launch that only wants to see its
+/// own state never be stopped for a key (#5896 review).
+/// What: either the outcome to print, or the operator's agreement to the sweep —
+/// which `main` answers by resolving a credential and running
+/// [`Command::Audit`].
+/// Test: `super::registration_tests::a_declined_sweep_returns_the_guided_card`,
+/// `super::registration_tests::a_confirmed_sweep_audits_the_registered_target`.
+///
+/// Deliberately NOT `#[non_exhaustive]`, unlike [`Command`] and [`Outcome`]: it
+/// crosses only into `main.rs`, and #5502's enforcement is exactly that a new
+/// variant fails the shim's match to compile until someone decides what the
+/// launch does with it.
+#[derive(Debug)]
+pub enum Launch {
+    /// The flow stopped short of the sweep. This is what to print.
+    ///
+    /// Boxed because [`Outcome`] is large enough for
+    /// `clippy::large_enum_variant` to care, and this enum is returned from
+    /// every launch — including the one that carries nothing.
+    Reported(Box<Outcome>),
+    /// The operator saw the card and agreed to the sweep.
+    SweepConfirmed,
+}
+
+/// Drive the launch up to the operator's decision: register, advance, ask.
+///
+/// Why: "one step" means one invocation. The operator names what the audit
+/// covers and the flow carries on into tool installation and the sweep without
+/// a second command. It stops at the DECISION rather than running the sweep
+/// itself so `main` can resolve the inference credential only once the sweep is
+/// actually going to happen (#5896 review) — see [`Launch`].
 /// What: the loop, then [`Command::Guided`] — which is where auto-install
-/// happens, so the tools land in this same invocation — and then
-/// [`Command::Run`] when the flow reached [`NextStep::ReadyForRun`] and the
-/// operator agreed. The returned [`Outcome`] is whichever of the two ran last,
-/// and `main` prints it to stdout; everything before it is shown on the terminal.
+/// happens, so the tools land in this same invocation — and then the question,
+/// when the flow reached [`NextStep::ReadyForRun`]. Everything shown before the
+/// answer goes to the terminal; what `main` prints to stdout is whatever it does
+/// with the returned [`Launch`].
 /// Test: `super::registration_tests::a_scripted_session_registers_and_advances_the_flow`,
-/// `super::registration_tests::a_declined_sweep_returns_the_guided_card`.
+/// `super::registration_tests::a_declined_sweep_returns_the_guided_card`,
+/// `super::registration_tests::a_confirmed_sweep_audits_the_registered_target`.
 ///
 /// # Errors
 ///
 /// [`AuditError::RegistrationPromptFailed`] when the terminal fails, plus
-/// whatever the guided flow or the sweep fail with. A refused TARGET is not an
-/// error here — it is reported and the loop asks again.
+/// whatever the guided flow fails with. A refused TARGET is not an error here —
+/// it is reported and the loop asks again.
 pub async fn guided_at_the_terminal(
     session: &Session,
     tty: &mut dyn Tty,
-) -> Result<Outcome, AuditError> {
+) -> Result<Launch, AuditError> {
     register_targets(session, tty).await?;
 
     let guided = session.execute(Command::Guided).await?;
     if !ready_for_run(&guided) {
-        return Ok(guided);
+        return Ok(Launch::Reported(Box::new(guided)));
     }
 
     // The card first: the operator decides whether to commit hours from what is
@@ -115,9 +163,28 @@ pub async fn guided_at_the_terminal(
     say(tty, render(&guided).trim_end())?;
     if !confirmed(tty)? {
         say(tty, SWEEP_DECLINED)?;
-        return Ok(guided);
+        return Ok(Launch::Reported(Box::new(guided)));
     }
-    session.execute(Command::Run(RunOptions::default())).await
+    Ok(Launch::SweepConfirmed)
+}
+
+/// The capability a confirmed launch runs.
+///
+/// Why: #5896 shipped [`Command::Run`] here. `Run` reads
+/// `state/selected-repos.toml`, which only [`crate::clone`] writes, and nothing
+/// in the guided launch clones — [`register_targets`] writes the registry and
+/// [`Command::Guided`] installs tools. So on a fresh recipient the one-step
+/// launch died at `NoRepositoriesSelected` immediately after saying "Everything
+/// is in place", and on a recipient carrying a selection from an earlier
+/// `taudit clone` it AUDITED THOSE OLD REPOSITORIES, reported them as audited,
+/// and exited 0.
+/// What: [`Command::Audit`], whose materialize phase reads the registry and
+/// clones the registered targets before the sweep — the only path that bridges
+/// registry to selection (`crate::chain`, "Where the registry finally reaches
+/// the sweep").
+/// Test: `super::registration_tests::a_confirmed_sweep_audits_the_registered_target`.
+pub fn confirmed_sweep() -> Command {
+    Command::Audit(ChainOptions::default())
 }
 
 /// Ask for targets until the operator presses Enter on an empty line.
@@ -201,7 +268,17 @@ fn ready_for_run(outcome: &Outcome) -> bool {
 /// needs is already in place by the time this is asked. Anything starting with
 /// `n` declines; end of input declines too, because a terminal that closed
 /// cannot have agreed to anything.
+///
+/// The input queue is discarded FIRST (#5896 review). The registration loop
+/// ends when the operator presses Enter on an empty line, and a terminal in
+/// canonical mode holds whatever arrived after that — so an operator
+/// double-tapping Enter to finish adding targets had the second newline
+/// answered this question, starting hours of unattended work that spends the
+/// client's inference credential. The prompt itself is unchanged: Enter still
+/// starts the sweep, it just has to be an Enter pressed after reading the
+/// question.
 fn confirmed(tty: &mut dyn Tty) -> Result<bool, AuditError> {
+    tty.discard_typeahead().map_err(prompt_failed)?;
     let answer = tty.read_line(RUN_PROMPT).map_err(prompt_failed)?;
     Ok(answer.is_some_and(|line| !line.trim().to_ascii_lowercase().starts_with('n')))
 }
@@ -224,7 +301,7 @@ mod registration_tests {
     use crate::workdir::WorkDir;
     use std::collections::VecDeque;
     use std::io;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     /// A scripted terminal: answers come from a queue, and everything shown is
     /// recorded so a test can assert on it.
@@ -237,6 +314,11 @@ mod registration_tests {
         answers: VecDeque<io::Result<String>>,
         prompts: Vec<String>,
         shown: Vec<String>,
+        /// How many prompts had been issued when typeahead was last discarded.
+        ///
+        /// The ORDER is what matters: discarding after the question has been
+        /// asked closes nothing, so a count alone would not prove the fix.
+        discarded_after: Vec<usize>,
     }
 
     impl FakeTty {
@@ -245,6 +327,7 @@ mod registration_tests {
                 answers: answers.into_iter().map(|a| Ok(a.to_owned())).collect(),
                 prompts: Vec::new(),
                 shown: Vec::new(),
+                discarded_after: Vec::new(),
             }
         }
 
@@ -274,6 +357,11 @@ mod registration_tests {
             self.shown.push(line.to_owned());
             Ok(())
         }
+
+        fn discard_typeahead(&mut self) -> io::Result<()> {
+            self.discarded_after.push(self.prompts.len());
+            Ok(())
+        }
     }
 
     /// A session whose repository registrations succeed without `gh`, rooted in
@@ -282,6 +370,14 @@ mod registration_tests {
         Session::new(WorkDir::new(dir.join("work")))
             .with_repo_probe(RepoProbe::accepting())
             .with_auto_install(false)
+    }
+
+    /// The outcome a launch that stopped short of the sweep hands back.
+    fn reported(launch: Launch) -> Outcome {
+        match launch {
+            Launch::Reported(outcome) => *outcome,
+            Launch::SweepConfirmed => panic!("this launch must not have started a sweep"),
+        }
     }
 
     fn registered_ids(session: &Session) -> Vec<String> {
@@ -302,9 +398,11 @@ mod registration_tests {
         let session = accepting_session(tmp.path());
         let mut tty = FakeTty::new(["acme/api", "not a target", "acme/schema", ""]);
 
-        let outcome = guided_at_the_terminal(&session, &mut tty)
-            .await
-            .expect("the loop runs");
+        let outcome = reported(
+            guided_at_the_terminal(&session, &mut tty)
+                .await
+                .expect("the loop runs"),
+        );
 
         assert_eq!(registered_ids(&session), vec!["acme/api", "acme/schema"]);
 
@@ -460,9 +558,11 @@ mod registration_tests {
         }
         let mut tty = FakeTty::new(["acme/api", "", "n"]);
 
-        let outcome = guided_at_the_terminal(&session, &mut tty)
-            .await
-            .expect("declining is not a failure");
+        let outcome = reported(
+            guided_at_the_terminal(&session, &mut tty)
+                .await
+                .expect("declining is not a failure"),
+        );
 
         let Outcome::Guided(status) = outcome else {
             panic!("a declined sweep must hand back the guided card");
@@ -483,16 +583,46 @@ mod registration_tests {
         assert!(!confirmed(&mut tty).expect("end of input is not an error"));
     }
 
+    /// The verb #5896 broke. `Cli::to_command` maps `taudit guided` and a bare
+    /// `taudit` onto the same `Command::Guided`, so a rule stated over `Command`
+    /// cannot tell them apart — and #5502's own reachability table mandates the
+    /// named spelling, which under any pty then blocked on a prompt forever.
+    ///
+    /// Against `501b6dae5` this fails on the second assertion.
+    #[test]
+    fn the_named_guided_verb_is_not_interactive() {
+        use clap::Parser as _;
+
+        assert!(
+            is_interactive(&Cli::parse_from(["taudit"])),
+            "a bare launch is the one invocation that may prompt"
+        );
+        assert!(
+            !is_interactive(&Cli::parse_from(["taudit", "guided"])),
+            "`taudit guided` is what a script and the E2E harness run — it must \
+             print the card and exit, never block on a prompt"
+        );
+        // The same holds however the global options are spelled around it.
+        assert!(
+            !is_interactive(&Cli::parse_from(["taudit", "guided", "--no-install"])),
+            "the verb decides, not the flags beside it"
+        );
+        assert!(is_interactive(&Cli::parse_from(["taudit", "--no-install"])));
+    }
+
     /// Every named subcommand is something a script or the E2E harness runs, so
     /// none of them may be stopped for a prompt however the terminal looks.
+    ///
+    /// Stated over the CAPABILITY set, which is the secondary guard — the
+    /// argv-level rule is `the_named_guided_verb_is_not_interactive`.
     #[test]
     fn only_a_bare_launch_is_interactive() {
-        use crate::chain::ChainOptions;
         use crate::clone::CloneOptions;
         use crate::distribute::DistributeOptions;
         use crate::registry::TargetKind;
+        use crate::run::RunOptions;
 
-        assert!(is_interactive(&Command::Guided));
+        assert!(may_prompt(&Command::Guided));
         for command in [
             Command::WorkDir,
             Command::Manifest,
@@ -518,10 +648,31 @@ mod registration_tests {
             Command::Distribute(DistributeOptions::default()),
         ] {
             assert!(
-                !is_interactive(&command),
+                !may_prompt(&command),
                 "{command:?} must never prompt — a script runs it"
             );
         }
+    }
+
+    /// The typeahead hazard (#5896 review). The registration loop ENDS on an
+    /// empty line, and the very next question commits to hours of unattended
+    /// work that spends the client's inference credential — so an operator
+    /// double-tapping Enter had the second newline answer a question they never
+    /// read. The queue is discarded BEFORE the question is asked; discarding it
+    /// afterwards would close nothing.
+    ///
+    /// The prompt semantics are unchanged and deliberately so: Enter still
+    /// starts the sweep.
+    #[test]
+    fn the_sweep_prompt_discards_typeahead_first() {
+        let mut tty = FakeTty::new([""]);
+        assert!(confirmed(&mut tty).expect("Enter still starts the sweep"));
+        assert_eq!(
+            tty.discarded_after,
+            vec![0],
+            "typeahead must be discarded before the prompt is issued, not after"
+        );
+        assert_eq!(tty.prompts, vec![RUN_PROMPT.to_owned()]);
     }
 
     /// Enter means yes — the sweep is what the launch exists to reach, and by
@@ -536,5 +687,171 @@ mod registration_tests {
             let mut tty = FakeTty::new([answer]);
             assert!(!confirmed(&mut tty).expect("answers"), "{answer:?} agreed");
         }
+    }
+
+    /// An engagement pinning the versions `install_stubs` records.
+    const CONFIG: &str = r#"
+openrouter_key = "sk-or-v1-not-a-real-key"
+instructions = "Assess the last 52 weeks."
+
+[tools]
+tga = "2.9.4"
+trusty-search = "0.47.0"
+trusty-analyze = "0.9.2"
+trusty-review = "0.15.1"
+"#;
+
+    /// Stub binaries plus the version record, which together are what the
+    /// sweep's `pinned_binaries` preflight accepts — so nothing reaches the
+    /// network. `tga` writes the manifest a real one would for whatever
+    /// `--output` it is handed, so the sweep succeeds over ANY repository and
+    /// the only thing a test can be reading is WHICH one ran.
+    #[cfg(unix)]
+    fn install_stubs(work: &crate::workdir::WorkDir) {
+        use crate::tools::RequiredTool;
+        use std::os::unix::fs::PermissionsExt as _;
+
+        const TGA: &str = "#!/bin/sh\nout=\"\"\nwhile [ $# -gt 0 ]; do\n  \
+             case \"$1\" in --output) out=\"$2\"; shift;; esac\n  shift\ndone\n\
+             mkdir -p \"$out\"\n\
+             printf '[report]\\ntitle = \"Acme\"\\n\\n[[repositories]]\\n\
+             name = \"acme\"\\npath = \"/r\"\\n' > \"$out/manifest.toml\"\nexit 0\n";
+
+        for tool in RequiredTool::ALL {
+            let path = tool.path_in(work);
+            let body = if tool == RequiredTool::Tga {
+                TGA
+            } else {
+                "#!/bin/sh\nexit 0\n"
+            };
+            std::fs::write(&path, body).expect("stub binary");
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        }
+        let record = format!(
+            "[[tools]]\ncrate_name = \"tga\"\nversion = \"2.9.4\"\nbinary = \"{tga}\"\n\
+             [[tools]]\ncrate_name = \"trusty-search\"\nversion = \"0.47.0\"\nbinary = \"{s}\"\n\
+             [[tools]]\ncrate_name = \"trusty-analyze\"\nversion = \"0.9.2\"\nbinary = \"{a}\"\n\
+             [[tools]]\ncrate_name = \"trusty-review\"\nversion = \"0.15.1\"\nbinary = \"{r}\"\n",
+            tga = RequiredTool::Tga.path_in(work).display(),
+            s = RequiredTool::TrustySearch.path_in(work).display(),
+            a = RequiredTool::TrustyAnalyze.path_in(work).display(),
+            r = RequiredTool::TrustyReview.path_in(work).display(),
+        );
+        std::fs::write(crate::tools::record_path(work), record).expect("write record");
+    }
+
+    /// The launch as `main` drives it: the terminal decides, and a confirmed
+    /// sweep runs [`confirmed_sweep`] through the one dispatch door.
+    ///
+    /// It mirrors `main.rs` deliberately — the defect this covers was a single
+    /// wrong `Command` at that seam, so a test that named the command itself
+    /// would assert the mistake rather than the behaviour.
+    async fn launch(session: &Session, tty: &mut dyn Tty) -> Result<Outcome, AuditError> {
+        match guided_at_the_terminal(session, tty).await? {
+            Launch::Reported(outcome) => Ok(*outcome),
+            Launch::SweepConfirmed => session.execute(confirmed_sweep()).await,
+        }
+    }
+
+    /// Whichever repositories the confirmed sweep actually audited, whichever
+    /// capability it reached them through.
+    fn audited(outcome: &Outcome) -> Vec<String> {
+        let repos = match outcome {
+            Outcome::Audit(report) => &report.run.repos,
+            Outcome::Run(report) => &report.repos,
+            other => panic!("a confirmed sweep produced no sweep at all: {other:?}"),
+        };
+        repos.iter().map(|r| r.repo.name.clone()).collect()
+    }
+
+    /// 🔴 The defect #5896 shipped, and the reason it is dangerous rather than
+    /// merely broken.
+    ///
+    /// The confirmed launch ran `Command::Run`, which audits
+    /// `state/selected-repos.toml` — a file only `crate::clone` writes, and
+    /// nothing in the guided launch clones. A recipient carrying a selection
+    /// from an earlier `taudit clone` therefore registered `acme/newrepo`, was
+    /// told "Everything is in place", and received an audit of `acme-oldrepo`
+    /// reported as success. A wrong answer that exits 0, at a client site.
+    ///
+    /// The fix is `Command::Audit`, whose materialize phase reads the REGISTRY
+    /// and clones what is registered — the only path bridging the two records.
+    /// Against `501b6dae5` this fails on the audited-set assertion with
+    /// `["acme-oldrepo"]`.
+    ///
+    /// Offline by construction: the registered target already has a checkout on
+    /// disk, so `clone_all` reuses it (`CloneState::Reused`) and never reaches
+    /// GitHub.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_confirmed_sweep_audits_the_registered_target() {
+        use crate::clone::destination;
+        use crate::registry::{Registry, TargetKind};
+        use crate::run::{SelectedRepo, save_selection};
+        use crate::workdir::{Area, WorkDir};
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = WorkDir::new(tmp.path().join("work"));
+        work.create().expect("create the tree");
+        install_stubs(&work);
+
+        // The stale selection an earlier `taudit clone` left behind.
+        std::fs::create_dir_all(work.path(Area::Repos).join("acme-oldrepo")).expect("old checkout");
+        save_selection(
+            &work,
+            &[SelectedRepo {
+                name: "acme-oldrepo".to_owned(),
+                path: PathBuf::from("repos/acme-oldrepo"),
+            }],
+        )
+        .expect("write the stale selection");
+
+        // What this engagement is actually registered to audit. Its checkout
+        // exists, so materialize reuses it rather than cloning.
+        let mut registry = Registry::default();
+        registry.insert(registry::parse(Some(TargetKind::Repo), "acme/newrepo").expect("parses"));
+        registry.save(&work).expect("write the registry");
+        std::fs::create_dir_all(destination(&work, "acme/newrepo").expect("a plain name"))
+            .expect("registered checkout");
+
+        let config_path = tmp.path().join("engagement.toml");
+        std::fs::write(&config_path, CONFIG).expect("write the engagement config");
+        let session = Session::new(work)
+            .with_config_path(&config_path)
+            .with_auto_install(false);
+
+        // Enter to finish adding targets, then Enter to start the sweep.
+        let mut tty = FakeTty::new(["", ""]);
+        let outcome = launch(&session, &mut tty)
+            .await
+            .expect("the confirmed launch runs");
+
+        assert_eq!(
+            audited(&outcome),
+            vec!["acme/newrepo".to_owned()],
+            "the confirmed sweep must audit what this engagement REGISTERED, \
+             never whatever an earlier clone left selected"
+        );
+        assert_eq!(
+            outcome.exit_code(),
+            0,
+            "a clean sweep over the registered target must exit zero: {outcome:?}"
+        );
+    }
+
+    /// The fresh-recipient half of the same defect: nothing was ever cloned, so
+    /// `Command::Run` died at `NoRepositoriesSelected` one line after saying
+    /// "Everything is in place". `Command::Audit` clones what is registered.
+    ///
+    /// Asserted through the capability rather than by running it, because
+    /// reaching the sweep for a target with no checkout means reaching GitHub.
+    #[test]
+    fn the_confirmed_sweep_is_the_capability_that_reads_the_registry() {
+        assert_eq!(
+            confirmed_sweep(),
+            Command::Audit(ChainOptions::default()),
+            "only the chain's materialize phase turns a registered target into \
+             something the sweep can read"
+        );
     }
 }

--- a/crates/trusty-audit/src/main.rs
+++ b/crates/trusty-audit/src/main.rs
@@ -21,8 +21,7 @@ use clap::Parser;
 use trusty_audit::cli::{self, Cli};
 use trusty_audit::config::EngagementConfig;
 use trusty_audit::progress::terminal::TerminalProgress;
-use trusty_audit::run::RunOptions;
-use trusty_audit::session::{Command, Session};
+use trusty_audit::session::Session;
 use trusty_audit::workdir::{WORKDIR_ENV, WorkDir};
 
 // #5495: installing the pinned tools downloads, so `execute` is async and this
@@ -58,7 +57,11 @@ async fn main() -> Result<()> {
     // prompt uses it (#5868) — under `curl … | sh` stdin is the pipe carrying
     // the script, so it is never the thing to ask on. No terminal means no
     // interactive path and the launch prints the card it always did.
-    let mut terminal = cli::registration::is_interactive(&command)
+    //
+    // #5896 review: the PARSED CLI decides, not the `Command`. `to_command`
+    // maps both a bare launch and `trusty-audit guided` onto `Command::Guided`,
+    // so asking the command made the named verb block on a prompt.
+    let mut terminal = cli::registration::is_interactive(&cli)
         .then(cli::credential::DevTty::open)
         .and_then(Result::ok);
 
@@ -67,20 +70,20 @@ async fn main() -> Result<()> {
     // Tauri shell calls, and it has no terminal to ask on. The source is
     // reported on stderr because stdout carries the report.
     //
-    // #5885: the interactive launch resolves the key the SWEEP needs, before
-    // registration, so the operator answers key → targets → run in that order
-    // rather than being stopped for a credential after naming their targets.
-    let resolving_for = match terminal {
-        Some(_) => Command::Run(RunOptions::default()),
-        None => command.clone(),
+    // #5896 review: an interactive launch resolves NOTHING here. Resolving for
+    // the sweep up front gave the read-only launch `CredentialNeed::Required`,
+    // so a bare `trusty-audit` against a config with a blank key exited non-zero
+    // at `CredentialNotEntered` after three mismatched retypes without ever
+    // printing the status card. The key is resolved below, once the operator has
+    // agreed to the sweep that needs it.
+    let credential = match terminal {
+        Some(_) => None,
+        None => cli::credential::resolve_for(&command, &config_path)?,
     };
-    let credential = cli::credential::resolve_for(&resolving_for, &config_path)?;
-    if let Some(resolved) = &credential {
-        eprintln!("{}", resolved.source().describe());
-    }
+    report_source(credential.as_ref());
 
     let mut session = Session::new(work)
-        .with_config_path(config_path)
+        .with_config_path(config_path.clone())
         .with_credential(credential.map(cli::credential::Resolved::into_key))
         .with_auto_install(!cli.no_install)
         .with_progress(std::sync::Arc::new(TerminalProgress::to_stderr()));
@@ -92,7 +95,19 @@ async fn main() -> Result<()> {
     // several times — registration, then the guided flow, then the sweep. What
     // it returns is the last outcome, which is what stdout carries.
     let outcome = match &mut terminal {
-        Some(tty) => cli::registration::guided_at_the_terminal(&session, tty).await?,
+        Some(tty) => match cli::registration::guided_at_the_terminal(&session, tty).await? {
+            cli::registration::Launch::Reported(outcome) => *outcome,
+            cli::registration::Launch::SweepConfirmed => {
+                let sweep = cli::registration::confirmed_sweep();
+                let credential = cli::credential::resolve_for(&sweep, &config_path)?;
+                report_source(credential.as_ref());
+                session
+                    .clone()
+                    .with_credential(credential.map(cli::credential::Resolved::into_key))
+                    .execute(sweep)
+                    .await?
+            }
+        },
         None => session.execute(command).await?,
     };
     print!("{}", cli::render(&outcome));
@@ -110,4 +125,15 @@ async fn main() -> Result<()> {
     // `process::exit` does not flush Rust's stdout buffer.
     std::io::Write::flush(&mut std::io::stdout()).context("cannot write the report")?;
     std::process::exit(code);
+}
+
+/// Name which source supplied the credential, on stderr. Never the value.
+///
+/// Called at both resolution points since #5896's review split them — the
+/// non-interactive one before the session is built, and the interactive one
+/// after the operator agrees to the sweep.
+fn report_source(credential: Option<&cli::credential::Resolved>) {
+    if let Some(resolved) = credential {
+        eprintln!("{}", resolved.source().describe());
+    }
 }

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -866,10 +866,20 @@ impl Session {
         // reading only the manifest left the flow repeating that instruction
         // after they had done it, with the manifest not written until a sweep
         // finishes. Either record means the operator has named an engagement.
+        //
+        // #5896 review: REPOSITORIES, not any target. `Registry::targets` mixes
+        // repositories and boards, so `taudit add board jira:ACME` against an
+        // otherwise empty registry skipped `SelectRepositories`, triggered a
+        // real multi-tool download through `auto_install_tools`, and reported
+        // `ReadyForRun` over an engagement with nothing to sweep. A board is not
+        // a unit of the sweep — `crate::chain::split_targets` says the same.
         let repos_known = manifest
             .as_ref()
             .is_some_and(|m| !m.repositories.is_empty())
-            || !Registry::load(&self.work)?.targets().is_empty();
+            || Registry::load(&self.work)?
+                .targets()
+                .iter()
+                .any(|target| target.kind() == TargetKind::Repo);
 
         // #5797: install at the point the flow would otherwise have printed
         // "now go run `install`", and not one step earlier. Repository selection
@@ -1018,6 +1028,49 @@ trusty-review = "0.0.0-never-published"
         assert_eq!(status.next, NextStep::SelectRepositories);
         assert!(status.manifest.is_none());
         assert!(status.tools.iter().all(|s| !s.installed));
+    }
+
+    /// #5896 review: a BOARD is not a repository. `Registry::targets` mixes the
+    /// two, so a board-only registry looked like a named engagement — the flow
+    /// skipped `SelectRepositories`, `auto_install_tools` started a real
+    /// multi-tool download, and it reported `ReadyForRun` over a sweep with
+    /// nothing to run on.
+    ///
+    /// `with_auto_install(false)` here so the assertion is about the STEP: with
+    /// the defect present and auto-install on, this test would reach the network
+    /// rather than fail.
+    ///
+    /// Against `501b6dae5` this fails with `NextStep::InstallTools(…)`.
+    #[tokio::test]
+    async fn a_board_only_registry_still_asks_for_repositories() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = session_in(tmp.path()).with_auto_install(false);
+        session
+            .execute(Command::WorkDir)
+            .await
+            .expect("create tree");
+
+        let mut registry = Registry::default();
+        registry.insert(registry::parse(Some(TargetKind::Board), "jira:ACME").expect("parses"));
+        registry.save(session.work_dir()).expect("write registry");
+
+        let Outcome::Guided(status) = session.execute(Command::Guided).await.expect("runs") else {
+            panic!("Guided command must yield a Guided outcome");
+        };
+        assert_eq!(
+            status.next,
+            NextStep::SelectRepositories,
+            "a board is not a unit of the sweep — there is still nothing to audit"
+        );
+
+        // And one repository beside it is: the guard must not have gone the
+        // other way and started ignoring the registry.
+        registry.insert(registry::parse(Some(TargetKind::Repo), "acme/api").expect("parses"));
+        registry.save(session.work_dir()).expect("write registry");
+        let Outcome::Guided(status) = session.execute(Command::Guided).await.expect("runs") else {
+            panic!("Guided command must yield a Guided outcome");
+        };
+        assert_ne!(status.next, NextStep::SelectRepositories);
     }
 
     #[tokio::test]

--- a/crates/trusty-audit/tests/guided_launch.rs
+++ b/crates/trusty-audit/tests/guided_launch.rs
@@ -167,3 +167,125 @@ fn the_card_ends_a_sentence_rather_than_trailing_a_colon() {
     );
     assert!(last.ends_with('.'), "the card ends mid-sentence: {last:?}");
 }
+
+/// The named verb is what a script, a CI job and the E2E harness run, and
+/// #5502's own reachability table mandates that spelling — so it must print the
+/// card and exit even with a terminal attached (#5896 review).
+///
+/// It is checked here rather than only as a unit test because the unit-level
+/// mistake was precisely a rule stated one layer too late: `Cli::to_command`
+/// collapses `taudit` and `taudit guided` onto the same value, so an assertion
+/// over `Command` could not have caught this.
+#[test]
+fn the_named_guided_verb_prints_the_card_and_exits() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let work = tmp.path().join("trusty-audit-work");
+
+    // No `setsid`: this child KEEPS whatever terminal the test runner has, so
+    // the verb is the only thing that can be deciding.
+    let out = Command::new(TAUDIT)
+        .args(["guided", "--work-dir"])
+        .arg(&work)
+        .arg("--config")
+        .arg(tmp.path().join("engagement.toml"))
+        .current_dir(tmp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("`taudit guided` exits");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout: {stdout}\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(stdout.contains("Working directory:"), "{stdout}");
+    assert!(
+        !stdout.contains("press Enter when done"),
+        "`taudit guided` reached the registration prompt:\n{stdout}"
+    );
+}
+
+/// A launch backgrounded with `&` must print the card, not stop silently
+/// (#5896 review).
+///
+/// `trusty-audit &` still opens `/dev/tty` for WRITE, so the terminal probe
+/// succeeded and the first READ raised SIGTTIN — whose default action stops the
+/// job, with nothing printed and no diagnostic to say why. `DevTty::open` now
+/// refuses a terminal this process is in a background group of.
+///
+/// The child is put in its own process group with `setpgid(0, 0)` while keeping
+/// the runner's controlling terminal, which is exactly the shape `&` produces.
+/// It SKIPS when the runner has no controlling terminal — in CI there is
+/// nothing to be in the background of, and both the defect and the fix behave
+/// identically. The wait is bounded rather than blocking, because the failure
+/// mode under test is a process that stops rather than one that exits.
+#[test]
+fn a_backgrounded_launch_prints_the_card_rather_than_stopping() {
+    if std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/tty")
+        .is_err()
+    {
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let work = tmp.path().join("trusty-audit-work");
+
+    let mut command = Command::new(TAUDIT);
+    command
+        .arg("--work-dir")
+        .arg(&work)
+        .arg("--config")
+        .arg(tmp.path().join("engagement.toml"))
+        .current_dir(tmp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    // SAFETY: `setpgid` is async-signal-safe and this hook runs in the forked
+    // child before `exec`, moving only the child into its own process group.
+    unsafe {
+        command.pre_exec(|| match libc::setpgid(0, 0) {
+            -1 => Err(std::io::Error::last_os_error()),
+            _ => Ok(()),
+        });
+    }
+
+    let mut child = command.spawn().expect("taudit spawns");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let exited = loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => break Some(status),
+            None if std::time::Instant::now() >= deadline => break None,
+            None => std::thread::sleep(std::time::Duration::from_millis(50)),
+        }
+    };
+
+    let Some(status) = exited else {
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!(
+            "a backgrounded launch never exited — it was stopped by SIGTTIN on a \
+             read it should never have attempted"
+        );
+    };
+
+    let out = child.wait_with_output().expect("output");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "stdout: {stdout}\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(stdout.contains("Working directory:"), "{stdout}");
+    assert!(
+        !stdout.contains("press Enter when done"),
+        "a backgrounded launch reached the registration prompt:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Post-merge fixes for code-critic findings that landed unaddressed in #5896 (squash `501b6dae5`). The critic's verdict was BLOCK; a batch-merge agent merged the PR before it could be acted on. All six were re-confirmed by reading `main` directly. Every CI gate was green on #5896 — none of these is gate-detectable.

## The one that matters

The confirmed launch ran `Command::Run`, which audits `state/selected-repos.toml`. Only `crate::clone` writes that file and nothing in the guided launch clones — `register_targets` writes the registry, `Command::Guided` installs tools. Two failure modes:

- Fresh recipient: `NoRepositoriesSelected`, one line after "Everything is in place".
- Recipient with a selection from an earlier `taudit clone`: **the sweep audits those old repositories, reports them as audited, and exits 0.** The operator registers `acme/new` and receives an audit of `acme/old`.

`Command::Audit` is the only capability whose materialize phase reads the registry and clones what is registered — see `chain.rs`, "Where the registry finally reaches the sweep".

## The rest

| Finding | Fix |
|---|---|
| `trusty-audit guided` blocked on a prompt — an unbounded hang under any pty | `is_interactive` keys off the parsed `Cli`, not the `Command` (`to_command` maps both spellings onto `Command::Guided`). The `Command`-level table stays as a secondary guard. |
| The `[Y/n]` sweep prompt consumed typeahead from the Enter that ended the registration loop | `tcflush(TCIFLUSH)` before the prompt is issued. Prompt semantics unchanged — Enter still starts the sweep, per the owner's ruling. |
| A board-only registry reached `ReadyForRun` and triggered a real multi-tool download | `repos_known` filters on `TargetKind::Repo`. Confirmed line-by-line before fixing. |
| The read-only launch became a hard credential gate | The key is resolved after the operator confirms the sweep, not before the card. `guided_at_the_terminal` returns `Launch` so the front end owns that ordering. |
| `trusty-audit &` stopped silently on SIGTTIN | `DevTty::open` also checks `tcgetpgrp(fd) == getpgrp()`; a background group is `ENOTTY`, which `main` already handles as "print the card". Confirmed before fixing. |
| README offered `TRUSTY_AUDIT_NO_LAUNCH=1` as a non-interactive switch | Deleted rather than implemented. It is an `install.sh` variable (`install.sh:519`) deciding whether the installer execs the binary; a second meaning under the same name in the binary would be worse than the gap. `trusty-audit guided` is the non-interactive spelling, and HIGH-2 makes that true again. |

Not fixed, filed separately by the reporter: `rpassword` clears `ISIG` and leaves the terminal unusable after Ctrl-C. Pre-existing upstream; #5896 only moved it onto the most-run invocation.

## Version

`0.3.0` → `0.4.0`. `is_interactive` changes signature and `guided_at_the_terminal` changes return type, which is a break; for a `0.y.z` crate the breaking position is MINOR. The crate is `publish = false` and no workspace crate depends on it, so nothing else moves.

## Gates — rung 3 on `trusty-audit`, plus the excluded UI crate

```
cargo fmt --check                                        EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings EXIT=0
cargo clippy -p trusty-audit-ui --all-targets -- -D warnings EXIT=0
cargo test -p trusty-audit
  lib:               test result: ok. 382 passed; 0 failed; 5 ignored
  binary_names:      test result: ok. 3 passed; 0 failed
  cli_end_to_end:    test result: ok. 5 passed; 0 failed
  guided_launch:     test result: ok. 4 passed; 0 failed
  install_fails_closed: test result: ok. 4 passed; 0 failed; 2 ignored
  run_fails_closed:  test result: ok. 9 passed; 0 failed
scripts/check_line_cap.sh                EXIT=0  (0 violations)
scripts/check_changelog_fragment.sh      EXIT=0
scripts/check_sld.sh                     EXIT=0
scripts/check_teardown_guard.sh          EXIT=0
```

`trusty-audit-ui` is excluded from the required workspace Clippy context (`ci.yml:381`) and is the only job that compiles the Tauri shell, so it is run here by hand.

## The CRITICAL-1 test, failing against `501b6dae5`

`a_confirmed_sweep_audits_the_registered_target` registers `acme/newrepo`, leaves a stale selection naming `acme-oldrepo`, and drives the confirmed launch. Offline by construction: the registered target already has a checkout, so `clone_all` reuses it.

With `confirmed_sweep()` reverted to the `Command::Run` this PR replaces:

```
thread '...a_confirmed_sweep_audits_the_registered_target' panicked at
crates/trusty-audit/src/cli/registration.rs:829:9:
assertion `left == right` failed: the confirmed sweep must audit what this
engagement REGISTERED, never whatever an earlier clone left selected
  left: ["acme-oldrepo"]
 right: ["acme/newrepo"]

test result: FAILED. 0 passed; 1 failed; 0 ignored; 386 filtered out
```

On this branch it passes, inside the 382 above. That branch had zero coverage before — `a_scripted_session_registers_and_advances_the_flow` never reaches `ReadyForRun` and `a_declined_sweep_returns_the_guided_card` declines.

Two more reproduce the same way, with only their own fix reverted:

```
the_named_guided_verb_is_not_interactive ... FAILED
  `taudit guided` is what a script and the E2E harness run — it must print
  the card and exit, never block on a prompt

a_board_only_registry_still_asks_for_repositories ... FAILED
  assertion `left == right` failed: a board is not a unit of the sweep
    left: InstallTools([Tga, TrustySearch, TrustyAnalyze, TrustyReview])
   right: SelectRepositories
```

Refs #5896

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
