### PR TITLE
feat(trusty-mpm): the PM prompt states who owns a repository's merge queue

### DIFF
--- a/crates/trusty-mpm/changelog.d/5964-merge-queue-ownership.md
+++ b/crates/trusty-mpm/changelog.d/5964-merge-queue-ownership.md
@@ -1,0 +1,9 @@
+Added
+
+- The PM instruction package's workflow section now states merge-queue ownership: one
+  session owns a repository's merge queue at a time, a merge authorization is scoped to
+  the PRs presented when it was given, an outstanding review verdict (a `code-critic`
+  BLOCK, a requested-changes review, a hold label) blocks a merge that green required
+  contexts would otherwise permit, and a hold is marked in GitHub state rather than
+  announced by message. Procedure in the `tm-workflow` skill; pointer from
+  `tm-delegation-patterns`' Cross-Workstream Coordination.

--- a/crates/trusty-mpm/src/assets/instructions/sections/workflow.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/workflow.md
@@ -72,3 +72,21 @@ from the merge base — two-dot reports files DELETED from `main` since your bra
 point as your own additions, burying a real secret in another PR's noise. The
 branch protection it sits inside, and the review and changelog gates:
 `Skill(skill="tm-workflow")`.
+
+## Merge-Queue Ownership
+
+Exactly one session owns a repository's merge queue at a time. A session that
+does not own it never merges — it routes the merge to the owner and reports that
+it did. An owner's merge authorization is scoped to the PRs presented when it was
+given: "merge them as they clear" is not a standing licence over PRs another
+session opens afterward.
+
+🔴 **Green required contexts are not sufficient to merge.** Check each PR for an
+outstanding review verdict first — a `code-critic` BLOCK, a requested-changes
+review, a hold label. A BLOCK is not a CI context, so no status check can see it,
+and a batch merge gated on "all contexts green" walks straight past one.
+
+Hold a PR by marking it in GitHub state — draft, assignee, or a `do-not-merge`
+label — never by message; messages are advisory and lose races
+(`tm-delegation-patterns`, "Cross-Workstream Coordination"). Claiming the queue
+and handing it off: `Skill(skill="tm-workflow")`.

--- a/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
@@ -314,6 +314,10 @@ the real-time channel. Before dispatching multi-agent work on an area:
    refs, expected-land condition.
 3. Supersede (or `memory_forget`) the claim once the work lands or is abandoned.
 
+A claim drawer covers the work area, never the merge queue. Who may merge on a
+shared repository is its own claim: `Skill(skill="tm-workflow")`,
+"Merge-Queue Ownership".
+
 ## Long-Wait Delegation (issues #2833, #4792)
 
 A delegated agent's own gate (`cargo test -p <crate>`, a release build) blocks in

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -505,6 +505,43 @@ gh pr merge <PR> --squash --delete-branch
 After a squash-merge the local feature branch shows as "unmerged" to git (the
 squashed commit has a different hash). That is expected, not a failed merge.
 
+## Merge-Queue Ownership — the Procedure
+
+The rule is in the instruction package's workflow section: one session owns a
+repository's merge queue, an owner's authorization is scoped to the PRs it named,
+and green required contexts alone never license a merge. This is how to run it.
+
+**Establish who owns the queue before merging anything.** Ownership is a claim in
+git/GitHub state, not an understanding between sessions. Read it from the open
+PRs: `gh pr list --json number,author,assignees,isDraft,labels,headRefName`. If
+another session's PRs are open on the same base branch and you were not told you
+own the queue, you do not — hand your merge-ready PR to that session and report
+that you routed it rather than merging.
+
+**Per-PR pre-merge check, in this order.** Required contexts are the last gate,
+not the first:
+
+```bash
+gh pr view <PR> --json isDraft,labels,assignees,reviewDecision,statusCheckRollup
+gh pr view <PR> --json reviews --jq '.reviews[-3:][] | {author:.author.login,state}'
+```
+
+Stop on any of: `isDraft: true`; a hold label (`do-not-merge`, or whatever the
+project uses); `reviewDecision: CHANGES_REQUESTED`; an unresolved `code-critic`
+BLOCK in the PR comments. A critic verdict is a PR comment, so
+`statusCheckRollup` cannot see it — read the comments
+(`gh pr view <PR> --comments`) before a batch merge, once per PR, not once per
+batch.
+
+**Holding someone else's PR.** Convert it to draft (`gh pr ready --undo <PR>`) or
+apply the hold label. Send the message too, for awareness — but the message is
+never the hold. It loses the race; tonight's incident had a block arrive four
+minutes after the merge.
+
+**Handing the queue off.** Say which repository, which base branch, and which PRs
+are in flight. The receiving session re-reads state rather than trusting the
+list — the handoff is a notification, and the PRs are the record.
+
 ## Shipped Defaults on the PR
 
 These trusty-mpm framework defaults override any harness default and belong in

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -357,6 +357,24 @@ point as your own additions, burying a real secret in another PR's noise. The
 branch protection it sits inside, and the review and changelog gates:
 `Skill(skill="tm-workflow")`.
 
+## Merge-Queue Ownership
+
+Exactly one session owns a repository's merge queue at a time. A session that
+does not own it never merges — it routes the merge to the owner and reports that
+it did. An owner's merge authorization is scoped to the PRs presented when it was
+given: "merge them as they clear" is not a standing licence over PRs another
+session opens afterward.
+
+🔴 **Green required contexts are not sufficient to merge.** Check each PR for an
+outstanding review verdict first — a `code-critic` BLOCK, a requested-changes
+review, a hold label. A BLOCK is not a CI context, so no status check can see it,
+and a batch merge gated on "all contexts green" walks straight past one.
+
+Hold a PR by marking it in GitHub state — draft, assignee, or a `do-not-merge`
+label — never by message; messages are advisory and lose races
+(`tm-delegation-patterns`, "Cross-Workstream Coordination"). Claiming the queue
+and handing it off: `Skill(skill="tm-workflow")`.
+
 ## Opportunistic Fixes
 
 An easy fix discovered while working on a file is noted on the CURRENT issue and made in the same work. Never file a new issue for it.

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -357,6 +357,24 @@ point as your own additions, burying a real secret in another PR's noise. The
 branch protection it sits inside, and the review and changelog gates:
 `Skill(skill="tm-workflow")`.
 
+## Merge-Queue Ownership
+
+Exactly one session owns a repository's merge queue at a time. A session that
+does not own it never merges — it routes the merge to the owner and reports that
+it did. An owner's merge authorization is scoped to the PRs presented when it was
+given: "merge them as they clear" is not a standing licence over PRs another
+session opens afterward.
+
+🔴 **Green required contexts are not sufficient to merge.** Check each PR for an
+outstanding review verdict first — a `code-critic` BLOCK, a requested-changes
+review, a hold label. A BLOCK is not a CI context, so no status check can see it,
+and a batch merge gated on "all contexts green" walks straight past one.
+
+Hold a PR by marking it in GitHub state — draft, assignee, or a `do-not-merge`
+label — never by message; messages are advisory and lose races
+(`tm-delegation-patterns`, "Cross-Workstream Coordination"). Claiming the queue
+and handing it off: `Skill(skill="tm-workflow")`.
+
 ## Opportunistic Fixes
 
 An easy fix discovered while working on a file is noted on the CURRENT issue and made in the same work. Never file a new issue for it.


### PR DESCRIPTION
## What

Adds a `## Merge-Queue Ownership` section to the framework PM instruction package —
`crates/trusty-mpm/src/assets/instructions/sections/workflow.md`, the section every PM
prompt in every project already carries merge/PR delivery doctrine in. 13 resident lines.
The procedure lives in the `tm-workflow` skill behind a pointer, so it costs nothing
per turn.

Four rules, in order of what went wrong:

1. One session owns a repository's merge queue. A session that does not own it routes
   the merge to the owner and reports that it did.
2. An owner's merge authorization is scoped to the PRs presented when it was given.
   "Merge them as they clear" is not a standing licence over PRs another session opens
   afterward.
3. Green required contexts are not sufficient to merge. Check each PR for an outstanding
   review verdict first — a `code-critic` BLOCK is a PR comment, so `statusCheckRollup`
   cannot see it, and a batch merge gated on "all contexts green" walks past one.
4. A hold is marked in GitHub state — draft, assignee, `do-not-merge` label — never
   announced by message. Cites `tm-delegation-patterns`' Cross-Workstream Coordination
   rather than restating its "git/GitHub state is the authoritative claim" line.

## Why

2026-08-18, this repository. Two sessions worked one PR queue under separate owner
authorizations. Cost: two independent fixes for the same `m1_cutline` bug (one PR closed,
one engineer agent and CI round wasted); a second duplicate where one session fixed a
break another was already fixing; three PRs merging out from under a peer's merge agent
mid-run; and [#5896](https://github.com/bobmatnyc/trusty-tools/issues/5896) merged as
[`501b6dae5`](https://github.com/bobmatnyc/trusty-tools/commit/501b6dae5) past an
outstanding `code-critic` BLOCK carrying a CRITICAL — a guided sweep that audits the
wrong repositories and reports success at exit 0.

The merging session's own account: "I authorized the batch on 'nine required contexts
green' and never asked whether any PR in it had an open review verdict. A critic BLOCK is
not one of the nine contexts, so nothing in my gate could see it."

Nothing in the framework prompt contradicted either session's reading of its own
authorization, because the prompt said nothing about merge-queue ownership at all.

## Also changed

- `assets/skills/tm-workflow.md` — new "Merge-Queue Ownership — the Procedure" section
  under Squash-Merge. The skill had no multi-session merge coordination content before
  this, so there is nothing to contradict: the framework carries the rule, the skill
  carries the procedure.
- `assets/skills/tm-delegation-patterns.md` — three lines at the end of Cross-Workstream
  Coordination saying a claim drawer covers the work area, never the merge queue, and
  pointing at the new procedure.
- `src/core/testdata/pm-prompt-{bundled-fallback,roster-absent}.md` — regenerated with
  `UPDATE_GOLDEN=1 cargo test -p trusty-mpm golden`. `pm-prompt-claude-md-override.md` is
  unchanged, because that fixture replaces the whole `WORKFLOW` section — which is the
  confirmation that this doctrine is project-overridable today.

## Overridability

`workflow` is `customization_tier: "project"`, so a `<!-- TRUSTY-MPM: WORKFLOW START v=1 -->`
block in a project's `CLAUDE.md` deletes this text along with the rest of the section.
`core` is the only tier-`fixed` section. Making the doctrine non-overridable would mean
moving it into `sections/core.md`. Flagging the option; not taking it here.

## Gates — rung 3

```
cargo fmt --check                                        FMT_EXIT=0
cargo check -p trusty-mpm --all-targets                  CHECK_EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings  CLIPPY_EXIT=0
bash scripts/check_changelog_fragment.sh                 OK trusty-mpm: fragment present and valid
PR_VERSION_BUMP_BASE=origin/main scripts/check-pr-version-bump.sh
                                                         [ OK ] trusty-mpm 1.4.3 — src changed, version not yet published
```

Change-specific coverage, the golden-prompt snapshots and the package/override suites:

```
cargo test -p trusty-mpm golden
  test core::pm_prompt_golden_tests::golden_bundled_fallback_prompt ... ok
  test core::pm_prompt_golden_tests::golden_roster_absent_assembly_prompt ... ok
  test core::pm_prompt_golden_tests::golden_claude_md_override_prompt ... ok
  test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 5138 filtered out
  GOLDEN2_EXIT=0

cargo test -p trusty-mpm --lib -- instruction_package bundled_pm_package instruction_overrides
  test result: ok. 98 passed; 0 failed; 0 ignored; 0 measured; 5044 filtered out
  PKG_EXIT=0
```

### `cargo test -p trusty-mpm` could not complete on this machine

Not a failure — a hang, and it is not this branch's. `claude --version` never
returns on this host right now. A bare `claude --version` run outside cargo was
still alive after 3 minutes; six of them orphaned to PPID 1 survived the run that
spawned them, one set for 31 minutes.

`core::output_style::claude_supports_native_output_style` (`output_style.rs:204`)
spawns `claude --version` through `spawn_disclaim::disclaimed_output` and waits
with no timeout. Every test that reaches it blocks forever, and because those
tests are `serial_test`-serialized, the first one to block stalls the rest of the
lib binary behind the lock. `sample(1)` on the stuck binary put the lock holder in
`spawn_disclaim::macos::capture::spawn_capture_disclaimed`, three `claude
--version` children live beneath it.

Two runs stalled identically. Skipping the first blocker
(`connectors::tm::tests::create_session_full_lifecycle`) just moved the stall to
`core::instruction_pipeline::tests::pipeline_creates_claude_md`
(`instruction_pipeline.rs:410`, same probe), so this is not one bad test.

This branch changes six files, all markdown — `git diff --name-only
origin/main...HEAD` lists no `.rs` at all, and nothing in it is reachable from
`spawn_disclaim`.

Filed as a finding, not fixed here: that probe has no timeout, so a wedged
`claude` binary hangs a real session launch, not just the test suite.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
