### PR TITLE
fix(trusty-mpm): run the health probe's blocking client on its own thread (#5965)

### DIFF
--- a/crates/trusty-mpm/changelog.d/5965-health-probe-blocking-client-thread.md
+++ b/crates/trusty-mpm/changelog.d/5965-health-probe-blocking-client-thread.md
@@ -1,0 +1,15 @@
+Fixed
+
+- `tm services status`, `list`, `port`, `url`, `health`, and `log` no longer
+  panic before printing anything in a debug build
+  (closes [#5965](https://github.com/bobmatnyc/trusty-tools/issues/5965)).
+  `RealHttpProber::get_health` built a `reqwest::blocking` client directly on
+  the caller's thread, and `tm`'s `main` is `#[tokio::main]` — so every health
+  probe constructed reqwest's internal runtime inside the async runtime and
+  aborted with "Cannot drop a runtime in a context where blocking is not
+  allowed". Release builds only appeared healthy because the guard that raises
+  that panic is compiled in under `debug_assertions`; the call still parked the
+  thread it ran on from inside `poll`. The client now runs on a dedicated OS
+  thread that is joined for its result, matching
+  `trusty_common::search_index::best_effort_create_index`. `init` and `restart`
+  were unaffected — they never probe.

--- a/crates/trusty-mpm/src/services/discoverer/mod.rs
+++ b/crates/trusty-mpm/src/services/discoverer/mod.rs
@@ -227,35 +227,51 @@ impl PortProber for RealPortProber {
 
 /// Production HTTP health prober using `reqwest::blocking`.
 ///
-/// Why: reqwest is already a workspace dep; blocking client avoids async
-/// complexity in the prober trait while keeping the caller async-friendly.
-/// What: issues GET to `url` with the given timeout; 2xx → Ok, non-2xx → Fail
-/// with status code, connection error → Fail with error text.
-/// Test: `probe_health_ok_on_2xx`, `probe_health_fail_on_503`.
+/// Why: the prober trait is synchronous, so the client has to be blocking — but
+/// `tm`'s `main` is `#[tokio::main]`, so every caller reaches this from inside a
+/// runtime. Building `reqwest::blocking`'s internal runtime there panics with
+/// "Cannot drop a runtime in a context where blocking is not allowed", and even
+/// in release (where reqwest's tripwire compiles out) it parks the calling
+/// thread from inside `poll`. #5965: run the client on a dedicated OS thread and
+/// join it, so the nested runtime never touches an async worker. Same remedy,
+/// same reason as `trusty_common::search_index::best_effort_create_index`.
+/// What: issues GET to `url` with the given timeout on a spawned thread; 2xx →
+/// Ok, non-2xx → Fail with status code, connection error → Fail with error text,
+/// worker panic → Fail.
+/// Test: `probe_health_ok_on_2xx`, `probe_health_fail_on_503`,
+/// `real_http_prober_survives_being_called_inside_a_tokio_runtime`.
 pub struct RealHttpProber;
 
 impl HttpProber for RealHttpProber {
     fn get_health(&self, url: &str, timeout: Duration) -> HealthState {
-        let client = match reqwest::blocking::Client::builder()
-            .timeout(timeout)
-            .build()
-        {
-            Ok(c) => c,
-            Err(e) => {
-                return HealthState::Fail {
-                    detail: format!("failed to build HTTP client: {e}"),
-                };
+        let url = url.to_string();
+        // #5965: the blocking client builds its own runtime, which cannot be
+        // dropped inside an async context — keep it off the caller's thread.
+        let worker = std::thread::spawn(move || {
+            let client = match reqwest::blocking::Client::builder()
+                .timeout(timeout)
+                .build()
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    return HealthState::Fail {
+                        detail: format!("failed to build HTTP client: {e}"),
+                    };
+                }
+            };
+            match client.get(&url).send() {
+                Ok(resp) if resp.status().is_success() => HealthState::Ok,
+                Ok(resp) => HealthState::Fail {
+                    detail: format!("HTTP {}", resp.status()),
+                },
+                Err(e) => HealthState::Fail {
+                    detail: e.to_string(),
+                },
             }
-        };
-        match client.get(url).send() {
-            Ok(resp) if resp.status().is_success() => HealthState::Ok,
-            Ok(resp) => HealthState::Fail {
-                detail: format!("HTTP {}", resp.status()),
-            },
-            Err(e) => HealthState::Fail {
-                detail: e.to_string(),
-            },
-        }
+        });
+        worker.join().unwrap_or_else(|_| HealthState::Fail {
+            detail: "health probe thread panicked".to_string(),
+        })
     }
 }
 

--- a/crates/trusty-mpm/src/services/discoverer/tests.rs
+++ b/crates/trusty-mpm/src/services/discoverer/tests.rs
@@ -472,3 +472,27 @@ fn pid_falls_back_to_name_match_when_port_unowned() {
     let status = d.status("test-svc").unwrap();
     assert_eq!(status.pid, Some(7009));
 }
+
+/// `RealHttpProber` must not panic when called from inside a tokio runtime (#5965).
+///
+/// Why: `tm`'s `main` is `#[tokio::main]`, so every `tm services` subcommand that
+/// probes health reaches `get_health` from inside the runtime. Building a
+/// `reqwest::blocking` client there panics with "Cannot drop a runtime in a
+/// context where blocking is not allowed", which aborted `tm services status`
+/// and `tm services list` before they printed anything.
+/// What: calls the real prober from an async context against a closed local
+/// port. The assertion is only that it RETURNS — `Fail` is the expected verdict
+/// since nothing is listening; the panic is what this guards against.
+/// Test: this is the test. Note it can only fail while `debug_assertions` is on
+/// — reqwest's nested-runtime tripwire (`blocking/wait.rs`) compiles away in
+/// release, so `cargo test --release` would pass even with the bug present.
+#[tokio::test]
+async fn real_http_prober_survives_being_called_inside_a_tokio_runtime() {
+    // Port 1 on loopback is not routable to any service, so this fails fast
+    // with a transport error instead of waiting out the timeout.
+    let state = RealHttpProber.get_health("http://127.0.0.1:1/health", Duration::from_millis(250));
+    assert!(
+        matches!(state, HealthState::Fail { .. }),
+        "expected a transport failure against a closed port, got {state:?}"
+    );
+}


### PR DESCRIPTION
Fixes #5965 — the issue carries the diagnosis and the debug-vs-release isolation.

`RealHttpProber::get_health` now runs its `reqwest::blocking` client on a spawned
`std::thread` and joins it, so reqwest's internal runtime never lands inside `tm`'s
`#[tokio::main]` runtime. Mirrors `trusty_common::search_index::best_effort_create_index`,
which solved the same problem for the same reason. The `HttpProber` trait stays
synchronous — no call site and no public API changes.

**Test ladder: rung 3** (localized behavior inside one crate), plus the regression
test the rung requires, which provably failed before the change:

```
$ cargo test -p trusty-mpm --lib real_http_prober_survives     # BEFORE
thread '...' panicked at tokio-1.52.3/src/runtime/blocking/shutdown.rs:51:21:
Cannot drop a runtime in a context where blocking is not allowed.
test result: FAILED. 0 passed; 1 failed

$ cargo test -p trusty-mpm --lib real_http_prober_survives     # AFTER
test result: ok. 1 passed; 0 failed; 0 ignored; 5158 filtered out
```

Gates:

```
cargo fmt --check                                     EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-mpm --no-fail-fast               EXIT=0
  test result: ok. 5152 passed; 0 failed; 7 ignored   (lib, + 49 further targets all ok)
bash scripts/check_test_pointers.sh                   EXIT=0  (0 dangling)
bash scripts/check_line_cap.sh                        EXIT=0  (0 violations)
bash scripts/check_changelog_fragment.sh              EXIT=0
```

End-to-end, against live daemons in a debug build — the command that exited 101 before:

```
$ ./target/debug/tm services status trusty-search
  Status:   running    Health:   ok
EXIT=0
```

The regression test only has teeth under `debug_assertions`; reqwest's nested-runtime
tripwire compiles out in release, so `cargo test --release` would pass even with the
bug present. The test's doc comment says so.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
