### PR TITLE
feat(trusty-audit): a launch with no engagement.toml creates one before it asks what to audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11296,7 +11296,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -11581,7 +11581,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-audit"
-version = "0.4.0"
+version = "0.5.0"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/changelog.d/5970-cold-start-launch-added.md
+++ b/crates/trusty-audit/changelog.d/5970-cold-start-launch-added.md
@@ -1,0 +1,13 @@
+Added
+
+- The pins a cold start records come from the latest published stable release of
+  each tool, resolved once and written into `engagement.toml`. Every run after
+  the first reads the file, so `latest` never reaches a second run and the
+  engagement states the exact triple it ran
+  ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))
+- A synthesised `engagement.toml` names its `[models]` table in full, selecting
+  OpenRouter as the provider. Leaving it out fell through to `trusty-review`'s
+  own default, which is Bedrock — an account this engagement never named. All
+  four fields are written because the table is all-or-none, and the values are
+  the crate's own verified slugs rather than new ones
+  ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))

--- a/crates/trusty-audit/changelog.d/5970-cold-start-launch-added.md
+++ b/crates/trusty-audit/changelog.d/5970-cold-start-launch-added.md
@@ -5,9 +5,11 @@ Added
   the first reads the file, so `latest` never reaches a second run and the
   engagement states the exact triple it ran
   ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))
-- A synthesised `engagement.toml` names its `[models]` table in full, selecting
-  OpenRouter as the provider. Leaving it out fell through to `trusty-review`'s
-  own default, which is Bedrock — an account this engagement never named. All
-  four fields are written because the table is all-or-none, and the values are
-  the crate's own verified slugs rather than new ones
-  ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))
+- A synthesised `engagement.toml` names its `[models]` table in full: OpenRouter
+  as the provider, `anthropic/claude-opus-4.8` for the judging call, and
+  `anthropic/claude-haiku-4.5` for the verifier and summarizer. Leaving the table
+  out fell through to `trusty-review`'s own defaults, whose provider is Bedrock —
+  an account this engagement never named. All four fields are written because the
+  table is all-or-none, and because it sits above the built-in constants in
+  `trusty-review`'s precedence chain, these are the models the audit actually runs
+  on ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))

--- a/crates/trusty-audit/changelog.d/5970-cold-start-launch-changed.md
+++ b/crates/trusty-audit/changelog.d/5970-cold-start-launch-changed.md
@@ -1,0 +1,10 @@
+Changed
+
+- The built-in reviewer default is `anthropic/claude-opus-4.8`, was
+  `anthropic/claude-sonnet-4.6`. This changes behavior for EXISTING configs, not
+  only for newly written ones: an auditor-supplied `engagement.toml` with no
+  `[models]` table resolves through this constant, so the judging call on the
+  common handoff path moves to the Opus analysis tier. The verifier and
+  summarizer stay on `anthropic/claude-haiku-4.5`, and a config that names its
+  own `[models]` table is unaffected — it outranks the built-in
+  ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))

--- a/crates/trusty-audit/changelog.d/5970-cold-start-launch.md
+++ b/crates/trusty-audit/changelog.d/5970-cold-start-launch.md
@@ -13,17 +13,3 @@ Fixed
   unreachable: nothing wrote the file, so the three gates that hit its absence
   each degraded quietly and none of them named it
   ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))
-
-Added
-
-- The pins a cold start records come from the latest published stable release of
-  each tool, resolved once and written into `engagement.toml`. Every run after
-  the first reads the file, so `latest` never reaches a second run and the
-  engagement states the exact triple it ran
-  ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))
-- A synthesised `engagement.toml` names its `[models]` table in full, selecting
-  OpenRouter as the provider. Leaving it out fell through to `trusty-review`'s
-  own default, which is Bedrock — an account this engagement never named. All
-  four fields are written because the table is all-or-none, and the values are
-  the crate's own verified slugs rather than new ones
-  ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))

--- a/crates/trusty-audit/changelog.d/5970-cold-start-launch.md
+++ b/crates/trusty-audit/changelog.d/5970-cold-start-launch.md
@@ -1,0 +1,29 @@
+Fixed
+
+- A bare `trusty-audit` in a directory with no `engagement.toml` now sets the
+  engagement up instead of registering targets against one that does not exist.
+  It asks for the OpenRouter key first, writes `engagement.toml` at mode 0600
+  with an exact version pinned per tool, preflights all four pinned tools,
+  installs them, and asks what the audit covers LAST. Registration going first
+  is what produced the reported launch — targets registered, `Tools: 0/4
+  installed`, a command named to run next, and no key prompt at any point
+  ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))
+- A cold start whose `engagement.toml` cannot be written now stops and says so,
+  naming the file and stating that the key was not saved. It used to be
+  unreachable: nothing wrote the file, so the three gates that hit its absence
+  each degraded quietly and none of them named it
+  ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))
+
+Added
+
+- The pins a cold start records come from the latest published stable release of
+  each tool, resolved once and written into `engagement.toml`. Every run after
+  the first reads the file, so `latest` never reaches a second run and the
+  engagement states the exact triple it ran
+  ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))
+- A synthesised `engagement.toml` names its `[models]` table in full, selecting
+  OpenRouter as the provider. Leaving it out fell through to `trusty-review`'s
+  own default, which is Bedrock — an account this engagement never named. All
+  four fields are written because the table is all-or-none, and the values are
+  the crate's own verified slugs rather than new ones
+  ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -313,6 +313,11 @@ pub fn exit_code(outcome: &Outcome) -> i32 {
 // past the 500-SLOC production cap. Re-exported, so `crate::cli::render` stays
 // the name every caller and test already uses.
 pub mod credential;
+// #5970: a launch in a directory with no `engagement.toml` creates one instead
+// of registering targets against an engagement that does not exist. Beside
+// `credential` for the same reason: it prompts, and a prompt is a front-end
+// concern the library must never acquire.
+pub mod bootstrap;
 // #5885: the launch walks the operator into registration rather than naming a
 // command for them to run next. Beside `credential` because both are prompts,
 // and a prompt is a front-end concern the library must never acquire.

--- a/crates/trusty-audit/src/cli/bootstrap.rs
+++ b/crates/trusty-audit/src/cli/bootstrap.rs
@@ -70,7 +70,10 @@ const CHECKING_TOOLS: &str = "\nChecking the pinned tools";
 /// module writes lands at the config-file level, ABOVE them — so binding the two
 /// together would make a config value follow a constant it deliberately
 /// outranks, and #5971 is converting that constant into a tier lookup this path
-/// must not silently inherit.
+/// must not silently inherit. The two carry the SAME id today — #5970 moved the
+/// built-in default to Opus 4.8 as well, so the ruling reaches auditor-supplied
+/// configs too — and that agreement is a coincidence of values, not a reason to
+/// collapse them back into one.
 /// What: an OpenRouter model id, confirmed present in
 /// `GET https://openrouter.ai/api/v1/models` on 2026-08-18. Never derive a
 /// sibling id from this one's shape — OpenRouter's naming is not a pattern to

--- a/crates/trusty-audit/src/cli/bootstrap.rs
+++ b/crates/trusty-audit/src/cli/bootstrap.rs
@@ -60,6 +60,32 @@ const DEFAULT_INSTRUCTIONS: &str = "Assess the last 52 weeks across the register
 /// Shown above the per-tool preflight lines.
 const CHECKING_TOOLS: &str = "\nChecking the pinned tools";
 
+/// The model the audit's judging calls run on.
+///
+/// Why: owner ruling, 2026-08-18 — the analysis tier is Opus 4.8. It is spelled
+/// here as a literal rather than taken from
+/// [`crate::inference::DEFAULT_REVIEWER_MODEL`], and that is deliberate. Those
+/// constants are the BUILT-IN FALLBACK, the bottom of `trusty-review`'s
+/// precedence chain (CLI flag > environment > config file > built-in). What this
+/// module writes lands at the config-file level, ABOVE them — so binding the two
+/// together would make a config value follow a constant it deliberately
+/// outranks, and #5971 is converting that constant into a tier lookup this path
+/// must not silently inherit.
+/// What: an OpenRouter model id, confirmed present in
+/// `GET https://openrouter.ai/api/v1/models` on 2026-08-18. Never derive a
+/// sibling id from this one's shape — OpenRouter's naming is not a pattern to
+/// extrapolate from, and a guessed slug is an HTTP 400 an hour into a sweep.
+/// Test: `super::bootstrap_tests::the_written_config_names_the_ruled_models`.
+const REVIEWER_MODEL: &str = "anthropic/claude-opus-4.8";
+
+/// The model the verifier and summarizer roles run on.
+///
+/// Short, high-volume, low-stakes calls, so the cheapest Haiku tier — the same
+/// role/cost split `trusty-review` uses. Confirmed live on 2026-08-18. See
+/// [`REVIEWER_MODEL`] for why this is a literal.
+/// Test: `super::bootstrap_tests::the_written_config_names_the_ruled_models`.
+const HAIKU_MODEL: &str = "anthropic/claude-haiku-4.5";
+
 /// Everything a cold start needs from outside this process.
 ///
 /// Why: `main.rs` reads the process environment once and hands the result in —
@@ -265,16 +291,17 @@ pub fn create_engagement(
 /// credential, so the crate still has exactly one place that does.
 ///
 /// The `[models]` table is written out in full rather than left to the built-in
-/// fallback. Owner ruling, 2026-08-18: all inference for this crate is
-/// OpenRouter, and an unset `provider` falls through to `trusty-review`'s own
-/// default, which is Bedrock. Naming it in the file is what makes the choice
-/// visible to the recipient reading it, which is the transparency premise of the
-/// whole handoff (#5473). All FOUR fields are named because
-/// [`crate::inference`] treats the table as all-or-none: a config carrying only
-/// `provider` is [`AuditError::SplitInferenceSelection`], not a partial
-/// override. The values are [`crate::inference`]'s own constants, so the written
-/// file states exactly what the crate would otherwise have fallen back to and
-/// no slug is minted here.
+/// fallback. Owner rulings, 2026-08-18: all inference for this crate is
+/// OpenRouter, the analysis tier is Opus 4.8, and the two cheap roles take the
+/// latest Haiku. An unset `provider` falls through to `trusty-review`'s own
+/// default, which is Bedrock, so naming it is what keeps the spend on the
+/// account this engagement was given — and naming it in the file is what makes
+/// that visible to the recipient reading it, the transparency premise of the
+/// whole handoff (#5473).
+///
+/// All FOUR fields are named because [`crate::inference`] treats the table as
+/// all-or-none: a config carrying only `provider` is
+/// [`AuditError::SplitInferenceSelection`], not a partial override.
 fn template(pins: &ToolPins) -> String {
     format!(
         "openrouter_key = \"\"\n\
@@ -286,17 +313,14 @@ fn template(pins: &ToolPins) -> String {
          trusty-review = \"{review}\"\n\
          \n[models]\n\
          provider = \"{provider}\"\n\
-         reviewer = \"{reviewer}\"\n\
-         verifier = \"{verifier}\"\n\
-         summarizer = \"{summarizer}\"\n",
+         reviewer = \"{REVIEWER_MODEL}\"\n\
+         verifier = \"{HAIKU_MODEL}\"\n\
+         summarizer = \"{HAIKU_MODEL}\"\n",
         tga = pins.tga.version(),
         search = pins.trusty_search.version(),
         analyze = pins.trusty_analyze.version(),
         review = pins.trusty_review.version(),
         provider = crate::inference::PROVIDER_OPENROUTER,
-        reviewer = crate::inference::DEFAULT_REVIEWER_MODEL,
-        verifier = crate::inference::DEFAULT_VERIFIER_MODEL,
-        summarizer = crate::inference::DEFAULT_SUMMARIZER_MODEL,
     )
 }
 
@@ -667,59 +691,76 @@ mod bootstrap_tests {
         );
     }
 
-    /// 🔴 Owner ruling, 2026-08-18: all inference for this crate is OpenRouter.
+    /// 🔴 Owner rulings, 2026-08-18: OpenRouter, Opus 4.8 for analysis, latest
+    /// Haiku for the two cheap roles.
     ///
-    /// A config that leaves `[models]` out falls through to `trusty-review`'s
-    /// own default provider, which is Bedrock — a spend on an account this
-    /// engagement never named. So the synthesised file names the provider, and
-    /// therefore all four fields: `crate::inference` treats the table as
-    /// all-or-none, so `provider` alone would be
-    /// `AuditError::SplitInferenceSelection` rather than a partial override.
+    /// Every id is asserted as a LITERAL, not against the constant that produced
+    /// it. A test that compares the file to `crate::inference`'s constants passes
+    /// whatever those happen to say — including a Bedrock `us.anthropic.…`
+    /// profile id named against an OpenRouter endpoint, which fails at call time
+    /// rather than at compile time. The literal is the only spelling that catches
+    /// that.
     ///
-    /// The end-to-end proof is the second half: the child environment this
-    /// config produces selects OpenRouter, which is the thing that actually
-    /// decides where the spend goes.
+    /// The second half is the end-to-end proof: what the `tga audit` child is
+    /// actually handed. `trusty-review`'s precedence is CLI flag > environment >
+    /// config file > built-in constant, and this table sits at the config-file
+    /// level — so these ids are what runs, and the built-in tier defaults are
+    /// never consulted on the audit path.
     #[test]
-    fn the_written_config_selects_openrouter_for_every_role() {
+    fn the_written_config_names_the_ruled_models() {
         let path = Path::new("engagement.toml");
         let text =
             crate::config::generate(&template(&fixed_pins("1.2.3")), &SecretKey::new(KEY), path)
                 .expect("generates");
         let config = EngagementConfig::from_toml(&text, path).expect("loads");
 
-        assert_eq!(
-            config.models.provider.as_deref(),
-            Some(crate::inference::PROVIDER_OPENROUTER)
-        );
+        assert_eq!(config.models.provider.as_deref(), Some("openrouter"));
         assert_eq!(
             config.models.reviewer.as_deref(),
-            Some(crate::inference::DEFAULT_REVIEWER_MODEL)
+            Some("anthropic/claude-opus-4.8")
         );
         assert_eq!(
             config.models.verifier.as_deref(),
-            Some(crate::inference::DEFAULT_VERIFIER_MODEL)
+            Some("anthropic/claude-haiku-4.5")
         );
         assert_eq!(
             config.models.summarizer.as_deref(),
-            Some(crate::inference::DEFAULT_SUMMARIZER_MODEL)
+            Some("anthropic/claude-haiku-4.5")
         );
         assert!(
-            !text.contains("bedrock"),
-            "a synthesised engagement must never name another provider: {text}"
+            !text.contains("bedrock") && !text.contains("us.anthropic."),
+            "a synthesised engagement must never name another provider or its \
+             inference-profile ids: {text}"
         );
 
-        // What the `tga audit` child is actually handed. `|_| None` is an
-        // environment naming none of the four, so the config is what decides.
+        // `|_| None` is an environment naming none of the four, so the config is
+        // what decides — which is the level that outranks the built-in defaults.
         let env =
             crate::inference::inference_env(&config, |_| None).expect("the whole table resolves");
-        let provider = env
-            .iter()
-            .find(|(name, _)| *name == crate::inference::ENV_PROVIDER)
-            .map(|(_, value)| value.as_str());
+        let selected = |name: &str| -> Option<&str> {
+            env.iter()
+                .find(|(var, _)| *var == name)
+                .map(|(_, value)| value.as_str())
+        };
         assert_eq!(
-            provider,
-            Some(crate::inference::PROVIDER_OPENROUTER),
-            "the child must be pointed at OpenRouter: {env:?}"
+            selected(crate::inference::ENV_PROVIDER),
+            Some("openrouter"),
+            "{env:?}"
+        );
+        assert_eq!(
+            selected(crate::inference::ENV_REVIEWER_MODEL),
+            Some("anthropic/claude-opus-4.8"),
+            "the judging call must run on Opus 4.8: {env:?}"
+        );
+        assert_eq!(
+            selected(crate::inference::ENV_VERIFIER_MODEL),
+            Some("anthropic/claude-haiku-4.5"),
+            "{env:?}"
+        );
+        assert_eq!(
+            selected(crate::inference::ENV_SUMMARIZER_MODEL),
+            Some("anthropic/claude-haiku-4.5"),
+            "{env:?}"
         );
     }
 

--- a/crates/trusty-audit/src/cli/bootstrap.rs
+++ b/crates/trusty-audit/src/cli/bootstrap.rs
@@ -1,0 +1,764 @@
+//! Creating the engagement a launch needs, when the recipient has none (#5970).
+//!
+//! Why: the guided launch was built for a recipient who already holds the
+//! `engagement.toml` an auditor hands them. Nothing in the crate synthesised
+//! one, so a bare `trusty-audit` in an empty directory registered targets,
+//! printed `Tools: 0/4 installed`, named a command to run next, and stopped —
+//! never asking for the OpenRouter key, because the key resolves inside a branch
+//! that state could not reach. Three separate gates hit the same missing file
+//! and none of them named it.
+//!
+//! The owner's ruling, 2026-08-18, fixes the ORDER as well as the gap: key,
+//! then the config, then the tools, and registration LAST. Registration going
+//! first is what produced that transcript — an operator naming repositories for
+//! an engagement that did not exist yet.
+//!
+//! What: [`cold_start`] is the whole path. It runs once, when there is no
+//! config; a launch that finds one returns `Ok(None)` and behaves exactly as it
+//! did before. [`key_for_a_cold_start`] is the credential decision on its own,
+//! [`create_engagement`] the write.
+//!
+//! Three properties this module exists to hold:
+//!
+//! - **The key is asked for FIRST and written before anything else runs.** A
+//!   failed write STOPS the launch ([`AuditError::EngagementNotCreated`]) rather
+//!   than carrying the key in memory for one process and leaving nothing behind.
+//! - **The value never reaches the terminal, a log, or an error.** Reading is
+//!   `crate::cli::credential`'s echo-suppressed prompt, the file is written at
+//!   mode 0600 through [`crate::workdir::write_private_atomically`], and every
+//!   line this module shows is a `const` or a path — no entered text is ever
+//!   interpolated into one.
+//! - **Nothing is installed that this machine cannot install.** The preflight
+//!   runs before the download and refuses by name.
+//!
+//! It lives beside [`crate::cli::credential`] and [`crate::cli::registration`]
+//! for the reason both give: [`Session::execute`] is the one door every front
+//! end uses, and none of them has a terminal to prompt on. What crosses that
+//! boundary is a written config, never a way to ask for one.
+//!
+//! Test: `super::bootstrap_tests`.
+
+use std::path::Path;
+
+use crate::cli::credential::{Resolved, Tty, resolve};
+use crate::config::{EngagementConfig, SecretKey, ToolPins};
+use crate::error::AuditError;
+use crate::run::ENV_INFERENCE_CREDENTIAL;
+use crate::session::{Command, Session};
+use crate::tools::{self, ToolAvailability};
+use crate::workdir;
+
+/// Shown once, before anything is asked. Names the state, not a command.
+const OPENING: &str = "\nNo engagement is configured here. Setting one up.";
+
+/// What a new engagement is asked to assess until the operator edits it.
+///
+/// It is a field of the file they now own, and the file says so — this is a
+/// starting point, not a policy.
+const DEFAULT_INSTRUCTIONS: &str = "Assess the last 52 weeks across the registered repositories.";
+
+/// Shown above the per-tool preflight lines.
+const CHECKING_TOOLS: &str = "\nChecking the pinned tools";
+
+/// Everything a cold start needs from outside this process.
+///
+/// Why: `main.rs` reads the process environment once and hands the result in —
+/// that is this crate's standing rule (`crate::workdir::WorkDir::resolve`,
+/// `crate::cli::credential::resolve`), and it is what makes the cold start's
+/// branches provable from a test binary that has whatever the developer happens
+/// to have exported. Bundled rather than passed as two arguments so
+/// `crate::cli::registration::guided_at_the_terminal` forwards one value.
+/// What: where the pins come from, and `OPENROUTER_API_KEY` as `main` read it.
+/// Test: `super::bootstrap_tests` builds one with [`ColdStart::fixed`].
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ColdStart {
+    /// Where the versions written into the new config come from.
+    pub pins: PinResolver,
+    /// `OPENROUTER_API_KEY`, or `None` when it is unset.
+    pub exported_key: Option<String>,
+}
+
+impl ColdStart {
+    /// The production wiring: latest published pins, and this process's
+    /// environment.
+    pub fn from_environment() -> Self {
+        Self {
+            pins: PinResolver::LatestPublished,
+            exported_key: std::env::var(ENV_INFERENCE_CREDENTIAL).ok(),
+        }
+    }
+
+    /// A cold start that reaches no release list and reads no environment.
+    ///
+    /// The seam #5970's tests drive, and the shape a `--pins` flag would take.
+    pub fn fixed(pins: ToolPins) -> Self {
+        Self {
+            pins: PinResolver::Fixed(pins),
+            exported_key: None,
+        }
+    }
+}
+
+/// Where a cold start gets the versions it writes into the new config.
+///
+/// Why: resolving the latest published release reaches GitHub, and every branch
+/// of the cold start above that call has to be provable from a test binary with
+/// no network — the same reason `crate::validate::RepoProbe` is a seam rather
+/// than a direct `gh` call.
+/// What: [`PinResolver::LatestPublished`] is production;
+/// [`PinResolver::Fixed`] answers with what it was given and touches nothing.
+/// Test: `super::bootstrap_tests` drives every case through `Fixed`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum PinResolver {
+    /// Ask the release list for the latest published stable of each tool.
+    LatestPublished,
+    /// Answer with these exact pins, without a network call.
+    Fixed(ToolPins),
+}
+
+impl PinResolver {
+    /// The pins to record in the new engagement config.
+    ///
+    /// # Errors
+    ///
+    /// [`AuditError::PinsUnresolved`] when a release list could not be read.
+    pub async fn resolve(&self) -> Result<ToolPins, AuditError> {
+        match self {
+            PinResolver::LatestPublished => tools::latest_pins().await,
+            PinResolver::Fixed(pins) => Ok(pins.clone()),
+        }
+    }
+}
+
+/// Set this directory up as an engagement, when it is not one yet.
+///
+/// Why: see the module docs — this is #5970's ruling, in the order it states.
+///
+/// # Preconditions
+/// `tty` is a terminal somebody is at. `crate::cli::registration::is_interactive`
+/// and `DevTty::open` are what establish that, in `main`.
+///
+/// # Postconditions
+/// On `Ok(Some(_))`, an `engagement.toml` exists at the session's config path,
+/// owner-readable only, carrying the key and an exact version per tool; and
+/// unless auto-install is off, all four tools are on disk at those versions. On
+/// `Ok(None)` a config was already there and nothing was asked or written. On
+/// `Err`, either nothing was written, or the config was written and the tools
+/// were not — never a key held only in memory.
+///
+/// What: prompt, write, preflight, install. The caller registers targets AFTER
+/// this returns, which is the half of the ruling that cannot be seen from inside
+/// this function — `crate::cli::registration::guided_at_the_terminal` holds it,
+/// and `the_key_is_asked_for_before_the_first_target` is what pins it.
+/// Test: `super::bootstrap_tests::a_cold_start_writes_the_engagement_owner_only`,
+/// `super::bootstrap_tests::a_config_that_cannot_be_written_stops_the_launch`,
+/// `super::bootstrap_tests::an_existing_engagement_is_left_alone`.
+///
+/// # Errors
+///
+/// [`AuditError::NoCredentialSource`] and the prompt's own failures;
+/// [`AuditError::PinsUnresolved`]; [`AuditError::EngagementNotCreated`] when the
+/// file cannot be written; [`AuditError::ToolNotInstallable`] when the preflight
+/// refuses; and whatever [`Command::InstallTools`] fails with.
+pub async fn cold_start(
+    session: &Session,
+    cold: &ColdStart,
+    tty: &mut dyn Tty,
+) -> Result<Option<EngagementConfig>, AuditError> {
+    let config_path = session.config_path().to_path_buf();
+    if EngagementConfig::load_if_present(&config_path)?.is_some() {
+        return Ok(None);
+    }
+    say(tty, OPENING)?;
+
+    // Step 1 — the key, before anything else. A cold start passes `None` for the
+    // configured tier: there is no config to have carried one.
+    let resolved = key_for_a_cold_start(cold.exported_key.clone(), &config_path, Some(tty))?;
+    let source = resolved.source();
+
+    // Step 2 — the pins, then the file. Resolving BEFORE the write is what keeps
+    // the config either complete or absent; there is no half-written engagement.
+    let pins = cold.pins.resolve().await?;
+    let config = create_engagement(&config_path, &resolved.into_key(), &pins)?;
+    say(tty, source.describe())?;
+    say(tty, &format!("  ok: written to {}", config_path.display()))?;
+
+    // Steps 3 and 4 — preflight, then install. `--no-install` skips both, and
+    // the guided card that follows names the install step, exactly as it does
+    // for an auditor-supplied config.
+    if session.auto_install() {
+        say(tty, CHECKING_TOOLS)?;
+        let checked = tools::preflight(session.work_dir(), &config.tools).await?;
+        for entry in &checked {
+            say(tty, &describe(entry))?;
+        }
+        tools::ensure_installable(checked)?;
+        session.execute(Command::InstallTools).await?;
+    }
+    Ok(Some(config))
+}
+
+/// Decide which credential a cold start runs with.
+///
+/// Why: split out so the no-terminal branch is a test rather than a reading of
+/// `main`. That branch matters: without a config there is no `openrouter_key` to
+/// fall back on, so a cold start with no terminal and nothing exported has NO
+/// source, and must refuse rather than proceed with an engagement it cannot
+/// finish.
+/// What: [`crate::cli::credential::resolve`] with the configured tier passed as
+/// `None` — the environment first, then the prompt. One decision function, so a
+/// cold start and an ordinary run cannot disagree about precedence.
+/// Test: `super::bootstrap_tests::without_a_terminal_a_cold_start_refuses`,
+/// `super::bootstrap_tests::an_exported_key_is_used_without_a_prompt`.
+///
+/// # Errors
+///
+/// [`AuditError::NoCredentialSource`] when nothing supplies a key and there is
+/// no terminal; the prompt's own failures otherwise.
+pub fn key_for_a_cold_start(
+    env: Option<String>,
+    config_path: &Path,
+    tty: Option<&mut dyn Tty>,
+) -> Result<Resolved, AuditError> {
+    resolve(env, None, config_path, tty)
+}
+
+/// Write the first `engagement.toml`, owner-readable only, and load it back.
+///
+/// Why: a failed write here is the fail-open shape #5970 exists to close, so it
+/// is its own error variant rather than a bare filesystem failure — the message
+/// has to say that the key was not saved, which no generic write error can.
+/// What: renders a template with a blank key, substitutes the real one through
+/// [`crate::config::generate`] — the crate's ONE writer of a plaintext key into
+/// a config, which also proves the result parses — and publishes it through
+/// [`crate::workdir::write_private_atomically`] at mode 0600. Reloading from the
+/// rendered text rather than from disk keeps the returned value the one that was
+/// just validated.
+/// Test: `super::bootstrap_tests::a_cold_start_writes_the_engagement_owner_only`,
+/// `super::bootstrap_tests::a_config_that_cannot_be_written_stops_the_launch`.
+///
+/// # Errors
+///
+/// [`AuditError::Parse`] or [`AuditError::Render`] when the pins would not
+/// produce a loadable config, and [`AuditError::EngagementNotCreated`] when the
+/// file cannot be written.
+pub fn create_engagement(
+    path: &Path,
+    key: &SecretKey,
+    pins: &ToolPins,
+) -> Result<EngagementConfig, AuditError> {
+    let rendered = crate::config::generate(&template(pins), key, path)?;
+    workdir::write_private_atomically(path, &rendered).map_err(|source| {
+        AuditError::EngagementNotCreated {
+            path: path.to_path_buf(),
+            source: Box::new(source),
+        }
+    })?;
+    EngagementConfig::from_toml(&rendered, path)
+}
+
+/// A new engagement's TOML, with the key left blank for `generate` to fill.
+///
+/// The blank field is deliberate: it keeps this function unable to write a
+/// credential, so the crate still has exactly one place that does.
+///
+/// The `[models]` table is written out in full rather than left to the built-in
+/// fallback. Owner ruling, 2026-08-18: all inference for this crate is
+/// OpenRouter, and an unset `provider` falls through to `trusty-review`'s own
+/// default, which is Bedrock. Naming it in the file is what makes the choice
+/// visible to the recipient reading it, which is the transparency premise of the
+/// whole handoff (#5473). All FOUR fields are named because
+/// [`crate::inference`] treats the table as all-or-none: a config carrying only
+/// `provider` is [`AuditError::SplitInferenceSelection`], not a partial
+/// override. The values are [`crate::inference`]'s own constants, so the written
+/// file states exactly what the crate would otherwise have fallen back to and
+/// no slug is minted here.
+fn template(pins: &ToolPins) -> String {
+    format!(
+        "openrouter_key = \"\"\n\
+         instructions = \"{DEFAULT_INSTRUCTIONS}\"\n\
+         \n[tools]\n\
+         tga = \"{tga}\"\n\
+         trusty-search = \"{search}\"\n\
+         trusty-analyze = \"{analyze}\"\n\
+         trusty-review = \"{review}\"\n\
+         \n[models]\n\
+         provider = \"{provider}\"\n\
+         reviewer = \"{reviewer}\"\n\
+         verifier = \"{verifier}\"\n\
+         summarizer = \"{summarizer}\"\n",
+        tga = pins.tga.version(),
+        search = pins.trusty_search.version(),
+        analyze = pins.trusty_analyze.version(),
+        review = pins.trusty_review.version(),
+        provider = crate::inference::PROVIDER_OPENROUTER,
+        reviewer = crate::inference::DEFAULT_REVIEWER_MODEL,
+        verifier = crate::inference::DEFAULT_VERIFIER_MODEL,
+        summarizer = crate::inference::DEFAULT_SUMMARIZER_MODEL,
+    )
+}
+
+/// One preflight line, in the crate's terminal style.
+fn describe(entry: &ToolAvailability) -> String {
+    let state = match (entry.installed, entry.problem.as_ref()) {
+        (true, _) => "installed".to_owned(),
+        (false, None) => "not installed -> installable".to_owned(),
+        (false, Some(problem)) => format!("not installed -> CANNOT INSTALL: {problem}"),
+    };
+    format!(
+        "  {name:<16}{version:<12}{state}",
+        name = entry.tool.binary_name(),
+        version = entry.version,
+    )
+}
+
+/// Show one line, turning a terminal failure into the credential prompt's error.
+///
+/// The same variant `crate::cli::credential` uses: everything this module shows
+/// belongs to the credential exchange, and an operator whose terminal died has
+/// one problem, not two.
+fn say(tty: &mut dyn Tty, line: &str) -> Result<(), AuditError> {
+    tty.say(line)
+        .map_err(|source| AuditError::CredentialPromptFailed { source })
+}
+
+/// A pin set naming versions this crate's tests never reach a network for.
+///
+/// `pub(crate)` so `crate::cli::registration`'s tests script a cold start
+/// without one, rather than each growing its own copy.
+#[cfg(test)]
+pub(crate) fn fixed_pins(version: &str) -> ToolPins {
+    let pin = || crate::config::ToolPin::Version(version.to_owned());
+    ToolPins {
+        tga: pin(),
+        trusty_search: pin(),
+        trusty_analyze: pin(),
+        trusty_review: pin(),
+    }
+}
+
+#[cfg(test)]
+mod bootstrap_tests {
+    use super::*;
+    use crate::cli::credential::CredentialSource;
+    use crate::config::ToolPin;
+    use crate::tools::RequiredTool;
+    use crate::validate::RepoProbe;
+    use crate::workdir::WorkDir;
+    use std::collections::VecDeque;
+    use std::io;
+
+    const KEY: &str = "sk-or-v1-entered-at-the-cold-start";
+
+    /// A scripted terminal, the shape both sibling modules' fakes have.
+    struct FakeTty {
+        answers: VecDeque<io::Result<String>>,
+        prompts: Vec<String>,
+        shown: Vec<String>,
+    }
+
+    impl FakeTty {
+        fn new<I: IntoIterator<Item = &'static str>>(answers: I) -> Self {
+            Self {
+                answers: answers.into_iter().map(|a| Ok(a.to_owned())).collect(),
+                prompts: Vec::new(),
+                shown: Vec::new(),
+            }
+        }
+
+        fn everything_displayed(&self) -> String {
+            format!("{}\n{}", self.prompts.join("\n"), self.shown.join("\n"))
+        }
+    }
+
+    impl Tty for FakeTty {
+        fn read_hidden(&mut self, prompt: &str) -> io::Result<String> {
+            self.prompts.push(prompt.to_owned());
+            self.answers
+                .pop_front()
+                .unwrap_or_else(|| Err(io::Error::other("the script ran out of answers")))
+        }
+
+        fn read_line(&mut self, prompt: &str) -> io::Result<Option<String>> {
+            self.prompts.push(prompt.to_owned());
+            self.answers.pop_front().transpose()
+        }
+
+        fn say(&mut self, line: &str) -> io::Result<()> {
+            self.shown.push(line.to_owned());
+            Ok(())
+        }
+
+        fn discard_typeahead(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A session rooted in `dir`, with the config beside it and no install.
+    ///
+    /// `with_auto_install(false)` is what keeps every case here offline: it is
+    /// the production `--no-install` path, not a test-only door.
+    fn session_in(dir: &Path) -> Session {
+        Session::new(WorkDir::new(dir.join("work")))
+            .with_config_path(dir.join("engagement.toml"))
+            .with_repo_probe(RepoProbe::accepting())
+            .with_auto_install(false)
+    }
+
+    /// The whole ruling's second and third steps: the key is written into a
+    /// config that carries the resolved pins, and the file is owner-only.
+    ///
+    /// Against `8cfdda3ab` no config is written at all, so this fails on the
+    /// first assertion.
+    #[tokio::test]
+    async fn a_cold_start_writes_the_engagement_owner_only() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = session_in(tmp.path());
+        let mut tty = FakeTty::new([KEY, KEY]);
+
+        let config = cold_start(&session, &ColdStart::fixed(fixed_pins("1.2.3")), &mut tty)
+            .await
+            .expect("the cold start runs")
+            .expect("a directory with no config is a cold start");
+
+        assert_eq!(config.openrouter_key.expose(), KEY);
+        assert_eq!(config.tools.tga.version(), "1.2.3");
+        assert_eq!(config.tools.trusty_review.version(), "1.2.3");
+
+        let path = session.config_path();
+        let reloaded = EngagementConfig::load(path).expect("the written config loads");
+        assert_eq!(reloaded.openrouter_key.expose(), KEY);
+        assert_eq!(reloaded.tools.trusty_search.version(), "1.2.3");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(path).expect("stat").permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "mode was {:o}", mode & 0o777);
+        }
+    }
+
+    /// The hygiene gate, on the strings: nothing typed reaches a prompt, a
+    /// guidance line, or the `Debug` render of what comes back.
+    #[tokio::test]
+    async fn the_entered_key_never_reaches_the_terminal() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = session_in(tmp.path());
+        let mut tty = FakeTty::new([KEY, "sk-or-v1-mistyped", KEY, KEY]);
+
+        let config = cold_start(&session, &ColdStart::fixed(fixed_pins("1.2.3")), &mut tty)
+            .await
+            .expect("a mismatched retype is not a failure")
+            .expect("a cold start");
+
+        let displayed = tty.everything_displayed();
+        assert!(
+            !displayed.contains(KEY),
+            "the terminal showed it: {displayed}"
+        );
+        assert!(
+            !displayed.contains("sk-or-v1-mistyped"),
+            "the terminal showed a rejected entry: {displayed}"
+        );
+        let debug = format!("{config:?}");
+        assert!(!debug.contains(KEY), "Debug leaked the key: {debug}");
+    }
+
+    /// 🔴 The fail-open arm. A write that fails must STOP the launch — carrying
+    /// on would run an hours-long sweep on a key held in memory for one process
+    /// and leave the recipient with nothing set up.
+    ///
+    /// The write is made to fail by putting a regular FILE where the config's
+    /// parent directory belongs, so `create_dir_all` cannot succeed. Against
+    /// `8cfdda3ab` nothing writes the config, so no such error exists.
+    #[tokio::test]
+    async fn a_config_that_cannot_be_written_stops_the_launch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blocker = tmp.path().join("not-a-directory");
+        std::fs::write(&blocker, b"a file, where a directory is needed").expect("write blocker");
+        let path = blocker.join("engagement.toml");
+
+        let err = create_engagement(&path, &SecretKey::new(KEY), &fixed_pins("1.2.3"))
+            .expect_err("an unwritable config must not read as a set-up engagement");
+
+        let AuditError::EngagementNotCreated { path: named, .. } = &err else {
+            panic!("expected EngagementNotCreated, got {err:?}");
+        };
+        assert_eq!(named, &path, "the refusal must name the file");
+        let rendered = err.to_string();
+        assert!(rendered.contains("was NOT saved"), "{rendered}");
+        assert!(
+            !rendered.contains(KEY),
+            "the error quoted the key: {rendered}"
+        );
+        assert!(!path.exists(), "nothing may have been written");
+    }
+
+    /// The same arm through the whole cold start, which is where it matters: the
+    /// key HAS been typed by the time the write fails, and the launch must stop
+    /// rather than carry it forward.
+    ///
+    /// The config lands in a directory that is readable but not writable, so the
+    /// absence probe still answers "no config here" — the state a cold start is
+    /// for — and the write is what fails. Skipped as root, for whom mode bits
+    /// are advisory.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_launch_that_cannot_write_the_engagement_stops_with_the_key_entered() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // SAFETY: `geteuid` reads this process's own effective uid and writes
+        // through no pointer.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let readonly = tmp.path().join("readonly");
+        std::fs::create_dir(&readonly).expect("mkdir");
+        std::fs::set_permissions(&readonly, std::fs::Permissions::from_mode(0o555)).expect("chmod");
+
+        let session = Session::new(WorkDir::new(tmp.path().join("work")))
+            .with_config_path(readonly.join("engagement.toml"))
+            .with_auto_install(false);
+        let mut tty = FakeTty::new([KEY, KEY]);
+
+        let err = cold_start(&session, &ColdStart::fixed(fixed_pins("1.2.3")), &mut tty)
+            .await
+            .expect_err("a launch that cannot write its engagement must stop");
+
+        assert!(
+            matches!(err, AuditError::EngagementNotCreated { .. }),
+            "{err:?}"
+        );
+        assert!(
+            !session.config_path().exists(),
+            "nothing may have been written"
+        );
+        let displayed = tty.everything_displayed();
+        assert!(
+            !displayed.contains(KEY),
+            "the terminal showed it: {displayed}"
+        );
+        assert!(
+            !err.to_string().contains(KEY),
+            "the error quoted the key: {err}"
+        );
+
+        // Let the tempdir clean up after itself.
+        std::fs::set_permissions(&readonly, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod back");
+    }
+
+    /// 🔴 The `curl … | sh` arm, in the state that has no config to fall back
+    /// on. Nothing exported and no terminal must be an actionable refusal — never
+    /// a silent proceed, and never a hang.
+    #[test]
+    fn without_a_terminal_a_cold_start_refuses() {
+        let err = key_for_a_cold_start(None, Path::new("/engagement/engagement.toml"), None)
+            .expect_err("nothing supplies a key and nobody can be asked");
+
+        assert!(
+            matches!(err, AuditError::NoCredentialSource { .. }),
+            "{err:?}"
+        );
+        let text = err.to_string();
+        assert!(text.contains(ENV_INFERENCE_CREDENTIAL), "{text}");
+        assert!(text.contains("engagement.toml"), "{text}");
+    }
+
+    /// A blank export is how a shell says "not for this command", so it must
+    /// fall through rather than winning the tier and writing an empty key.
+    #[test]
+    fn a_blank_export_does_not_count_as_a_source() {
+        let err = key_for_a_cold_start(
+            Some("   ".to_owned()),
+            Path::new("/engagement/engagement.toml"),
+            None,
+        )
+        .expect_err("a blank value is not a credential");
+        assert!(
+            matches!(err, AuditError::NoCredentialSource { .. }),
+            "{err:?}"
+        );
+    }
+
+    /// An auditor who exported the key is not asked for it again.
+    #[test]
+    fn an_exported_key_is_used_without_a_prompt() {
+        let mut tty = FakeTty::new(["sk-or-v1-never-read"]);
+        let resolved = key_for_a_cold_start(
+            Some(KEY.to_owned()),
+            Path::new("/engagement/engagement.toml"),
+            Some(&mut tty),
+        )
+        .expect("the environment supplies it");
+
+        assert_eq!(resolved.source(), CredentialSource::Environment);
+        assert_eq!(resolved.into_key().expose(), KEY);
+        assert!(tty.prompts.is_empty(), "{:?}", tty.prompts);
+    }
+
+    /// A recipient who received a config from their auditor must not be asked
+    /// for anything, and their file must not be touched.
+    #[tokio::test]
+    async fn an_existing_engagement_is_left_alone() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = session_in(tmp.path());
+        let existing = create_engagement(
+            session.config_path(),
+            &SecretKey::new("sk-or-v1-from-the-auditor"),
+            &fixed_pins("9.9.9"),
+        )
+        .expect("seed a config");
+        let before = std::fs::read_to_string(session.config_path()).expect("read");
+
+        let mut tty = FakeTty::new([]);
+        let outcome = cold_start(&session, &ColdStart::fixed(fixed_pins("1.2.3")), &mut tty)
+            .await
+            .expect("an existing engagement is not a failure");
+
+        assert!(
+            outcome.is_none(),
+            "a configured directory is not a cold start"
+        );
+        assert!(tty.prompts.is_empty(), "{:?}", tty.prompts);
+        assert_eq!(
+            std::fs::read_to_string(session.config_path()).expect("read"),
+            before,
+            "the auditor's config must survive verbatim"
+        );
+        assert_eq!(existing.tools.tga.version(), "9.9.9");
+    }
+
+    /// A config that is present and MALFORMED is not an absent one — treating it
+    /// as a cold start would overwrite a file the recipient may have hand-edited.
+    #[tokio::test]
+    async fn a_malformed_engagement_is_not_treated_as_a_cold_start() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = session_in(tmp.path());
+        std::fs::write(session.config_path(), "this is not toml = = =").expect("write");
+
+        let mut tty = FakeTty::new([KEY, KEY]);
+        let err = cold_start(&session, &ColdStart::fixed(fixed_pins("1.2.3")), &mut tty)
+            .await
+            .expect_err("a malformed config must not be overwritten");
+        assert!(matches!(err, AuditError::Parse { .. }), "{err:?}");
+        assert!(tty.prompts.is_empty(), "{:?}", tty.prompts);
+    }
+
+    /// The pins are written verbatim, so what the file says and what the
+    /// resolver returned cannot drift.
+    #[test]
+    fn the_template_records_every_pin() {
+        let mut pins = fixed_pins("1.2.3");
+        pins.trusty_review = ToolPin::Version("4.5.6".to_owned());
+        let text = template(&pins);
+
+        let loaded = crate::config::generate(&text, &SecretKey::new(KEY), Path::new("e.toml"))
+            .and_then(|t| EngagementConfig::from_toml(&t, Path::new("e.toml")))
+            .expect("the template is a loadable engagement config");
+        assert_eq!(loaded.tools.tga.version(), "1.2.3");
+        assert_eq!(loaded.tools.trusty_review.version(), "4.5.6");
+        assert!(
+            !text.contains(KEY),
+            "the template must not be able to carry a key: {text}"
+        );
+    }
+
+    /// 🔴 Owner ruling, 2026-08-18: all inference for this crate is OpenRouter.
+    ///
+    /// A config that leaves `[models]` out falls through to `trusty-review`'s
+    /// own default provider, which is Bedrock — a spend on an account this
+    /// engagement never named. So the synthesised file names the provider, and
+    /// therefore all four fields: `crate::inference` treats the table as
+    /// all-or-none, so `provider` alone would be
+    /// `AuditError::SplitInferenceSelection` rather than a partial override.
+    ///
+    /// The end-to-end proof is the second half: the child environment this
+    /// config produces selects OpenRouter, which is the thing that actually
+    /// decides where the spend goes.
+    #[test]
+    fn the_written_config_selects_openrouter_for_every_role() {
+        let path = Path::new("engagement.toml");
+        let text =
+            crate::config::generate(&template(&fixed_pins("1.2.3")), &SecretKey::new(KEY), path)
+                .expect("generates");
+        let config = EngagementConfig::from_toml(&text, path).expect("loads");
+
+        assert_eq!(
+            config.models.provider.as_deref(),
+            Some(crate::inference::PROVIDER_OPENROUTER)
+        );
+        assert_eq!(
+            config.models.reviewer.as_deref(),
+            Some(crate::inference::DEFAULT_REVIEWER_MODEL)
+        );
+        assert_eq!(
+            config.models.verifier.as_deref(),
+            Some(crate::inference::DEFAULT_VERIFIER_MODEL)
+        );
+        assert_eq!(
+            config.models.summarizer.as_deref(),
+            Some(crate::inference::DEFAULT_SUMMARIZER_MODEL)
+        );
+        assert!(
+            !text.contains("bedrock"),
+            "a synthesised engagement must never name another provider: {text}"
+        );
+
+        // What the `tga audit` child is actually handed. `|_| None` is an
+        // environment naming none of the four, so the config is what decides.
+        let env =
+            crate::inference::inference_env(&config, |_| None).expect("the whole table resolves");
+        let provider = env
+            .iter()
+            .find(|(name, _)| *name == crate::inference::ENV_PROVIDER)
+            .map(|(_, value)| value.as_str());
+        assert_eq!(
+            provider,
+            Some(crate::inference::PROVIDER_OPENROUTER),
+            "the child must be pointed at OpenRouter: {env:?}"
+        );
+    }
+
+    /// The preflight line an operator reads, in all three states.
+    #[test]
+    fn each_preflight_state_reads_differently() {
+        let installed = describe(&ToolAvailability {
+            tool: RequiredTool::Tga,
+            version: "1.2.3".to_owned(),
+            installed: true,
+            problem: None,
+        });
+        assert!(installed.contains("tga") && installed.contains("installed"));
+        assert!(!installed.contains("not installed"), "{installed}");
+
+        let pending = describe(&ToolAvailability {
+            tool: RequiredTool::TrustySearch,
+            version: "0.4.0".to_owned(),
+            installed: false,
+            problem: None,
+        });
+        assert!(
+            pending.contains("not installed -> installable"),
+            "{pending}"
+        );
+
+        let refused = describe(&ToolAvailability {
+            tool: RequiredTool::TrustyReview,
+            version: "0.1.0".to_owned(),
+            installed: false,
+            problem: Some(Box::new(
+                trusty_installer::download::pinned::PinnedError::VersionNotPublished {
+                    crate_name: "trusty-review".to_owned(),
+                    version: "0.1.0".to_owned(),
+                    available: vec!["0.16.0".to_owned()],
+                },
+            )),
+        });
+        assert!(refused.contains("CANNOT INSTALL"), "{refused}");
+        assert!(refused.contains("0.16.0"), "{refused}");
+    }
+}

--- a/crates/trusty-audit/src/cli/registration.rs
+++ b/crates/trusty-audit/src/cli/registration.rs
@@ -34,6 +34,7 @@
 //! Test: `super::registration_tests`.
 
 use crate::chain::ChainOptions;
+use crate::cli::bootstrap::{self, ColdStart};
 use crate::cli::credential::Tty;
 use crate::cli::{Cli, render};
 use crate::error::AuditError;
@@ -133,7 +134,8 @@ pub enum Launch {
 /// a second command. It stops at the DECISION rather than running the sweep
 /// itself so `main` can resolve the inference credential only once the sweep is
 /// actually going to happen (#5896 review) — see [`Launch`].
-/// What: the loop, then [`Command::Guided`] — which is where auto-install
+/// What: the cold start (#5970) when this directory holds no engagement config,
+/// then the loop, then [`Command::Guided`] — which is where auto-install
 /// happens, so the tools land in this same invocation — and then the question,
 /// when the flow reached [`NextStep::ReadyForRun`]. Everything shown before the
 /// answer goes to the terminal; what `main` prints to stdout is whatever it does
@@ -149,8 +151,16 @@ pub enum Launch {
 /// it is reported and the loop asks again.
 pub async fn guided_at_the_terminal(
     session: &Session,
+    cold: &ColdStart,
     tty: &mut dyn Tty,
 ) -> Result<Launch, AuditError> {
+    // #5970: the engagement FIRST — key, config, tools — and registration after
+    // it. The other order is what this issue reported: an operator naming
+    // repositories for an engagement that did not exist, then being told to run
+    // `trusty-audit install`. A directory that already has a config skips this
+    // entirely and the flow is what it always was.
+    bootstrap::cold_start(session, cold, tty).await?;
+
     register_targets(session, tty).await?;
 
     let guided = session.execute(Command::Guided).await?;
@@ -365,11 +375,30 @@ mod registration_tests {
     }
 
     /// A session whose repository registrations succeed without `gh`, rooted in
-    /// a throwaway working directory.
+    /// a throwaway working directory, ALREADY carrying an engagement config.
+    ///
+    /// #5970: the config is seeded so these cases stay about registration. A
+    /// launch that finds one skips the cold start entirely, which is exactly the
+    /// recipient-handed-a-config path every one of them was written for.
+    /// `the_key_is_asked_for_before_the_first_target` is the case that starts
+    /// from nothing.
     fn accepting_session(dir: &Path) -> Session {
-        Session::new(WorkDir::new(dir.join("work")))
+        let session = Session::new(WorkDir::new(dir.join("work")))
+            .with_config_path(dir.join("engagement.toml"))
             .with_repo_probe(RepoProbe::accepting())
-            .with_auto_install(false)
+            .with_auto_install(false);
+        bootstrap::create_engagement(
+            session.config_path(),
+            &crate::config::SecretKey::new("sk-or-v1-from-the-auditor"),
+            &bootstrap::fixed_pins("1.2.3"),
+        )
+        .expect("seed an engagement config");
+        session
+    }
+
+    /// Pins no test here ever downloads.
+    fn pins() -> ColdStart {
+        ColdStart::fixed(bootstrap::fixed_pins("1.2.3"))
     }
 
     /// The outcome a launch that stopped short of the sweep hands back.
@@ -399,7 +428,7 @@ mod registration_tests {
         let mut tty = FakeTty::new(["acme/api", "not a target", "acme/schema", ""]);
 
         let outcome = reported(
-            guided_at_the_terminal(&session, &mut tty)
+            guided_at_the_terminal(&session, &pins(), &mut tty)
                 .await
                 .expect("the loop runs"),
         );
@@ -413,6 +442,83 @@ mod registration_tests {
             status.next,
             NextStep::SelectRepositories,
             "the flow must not still be asking for what was just registered"
+        );
+    }
+
+    /// 🔴 The ordering #5970's ruling fixes, asserted as an order rather than as
+    /// a set of things that happened.
+    ///
+    /// A directory with no `engagement.toml` must be asked for the OpenRouter
+    /// key FIRST, have the config written, and only then be asked what the audit
+    /// covers. Registration going first is what produced the reported transcript:
+    /// the operator named repositories for an engagement that did not exist, was
+    /// told `Tools: 0/4 installed`, and was never asked for a key at all.
+    ///
+    /// Against `8cfdda3ab` this fails on the first assertion — the only prompts
+    /// issued are registration's.
+    #[tokio::test]
+    async fn the_key_is_asked_for_before_the_first_target() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Deliberately NOT `accepting_session`: this case starts from nothing.
+        let session = Session::new(WorkDir::new(tmp.path().join("work")))
+            .with_config_path(tmp.path().join("engagement.toml"))
+            .with_repo_probe(RepoProbe::accepting())
+            .with_auto_install(false);
+        let mut tty = FakeTty::new(["sk-or-v1-cold-start", "sk-or-v1-cold-start", "acme/api", ""]);
+
+        guided_at_the_terminal(&session, &pins(), &mut tty)
+            .await
+            .expect("the cold start runs");
+
+        let first_target = tty
+            .prompts
+            .iter()
+            .position(|p| p == PROMPT)
+            .expect("the registration loop must still run");
+        let last_key = tty
+            .prompts
+            .iter()
+            .rposition(|p| p.contains("key"))
+            .expect("the key must be asked for");
+        assert!(
+            last_key < first_target,
+            "the key must be asked for before the first target: {:?}",
+            tty.prompts
+        );
+
+        let config = crate::config::EngagementConfig::load(session.config_path())
+            .expect("the launch must have written an engagement config");
+        assert_eq!(config.openrouter_key.expose(), "sk-or-v1-cold-start");
+        assert_eq!(config.tools.tga.version(), "1.2.3");
+        assert_eq!(registered_ids(&session), vec!["acme/api"]);
+    }
+
+    /// The other half of the ordering: the config is on disk BEFORE the
+    /// registration loop opens, not written at the end of a successful launch.
+    ///
+    /// A terminal that dies during registration therefore leaves a set-up
+    /// engagement behind, so re-running does not ask for the key again.
+    #[tokio::test]
+    async fn the_engagement_survives_a_terminal_that_dies_during_registration() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = Session::new(WorkDir::new(tmp.path().join("work")))
+            .with_config_path(tmp.path().join("engagement.toml"))
+            .with_repo_probe(RepoProbe::accepting())
+            .with_auto_install(false);
+        let mut tty = FakeTty::new(["sk-or-v1-cold-start", "sk-or-v1-cold-start"]);
+        tty.answers
+            .push_back(Err(io::Error::other("the terminal went away")));
+
+        let err = guided_at_the_terminal(&session, &pins(), &mut tty)
+            .await
+            .expect_err("a terminal that fails is an error");
+        assert!(
+            matches!(err, AuditError::RegistrationPromptFailed { .. }),
+            "{err:?}"
+        );
+        assert!(
+            session.config_path().is_file(),
+            "the engagement must already be on disk when registration opens"
         );
     }
 
@@ -559,7 +665,7 @@ mod registration_tests {
         let mut tty = FakeTty::new(["acme/api", "", "n"]);
 
         let outcome = reported(
-            guided_at_the_terminal(&session, &mut tty)
+            guided_at_the_terminal(&session, &pins(), &mut tty)
                 .await
                 .expect("declining is not a failure"),
         );
@@ -747,7 +853,7 @@ trusty-review = "0.15.1"
     /// wrong `Command` at that seam, so a test that named the command itself
     /// would assert the mistake rather than the behaviour.
     async fn launch(session: &Session, tty: &mut dyn Tty) -> Result<Outcome, AuditError> {
-        match guided_at_the_terminal(session, tty).await? {
+        match guided_at_the_terminal(session, &pins(), tty).await? {
             Launch::Reported(outcome) => Ok(*outcome),
             Launch::SweepConfirmed => session.execute(confirmed_sweep()).await,
         }

--- a/crates/trusty-audit/src/error.rs
+++ b/crates/trusty-audit/src/error.rs
@@ -716,6 +716,73 @@ pub enum AuditError {
         root: PathBuf,
     },
 
+    /// The key was entered, and the engagement config it belongs in could not be
+    /// written.
+    ///
+    /// Why: the fail-open shape this variant exists to rule out (#5970). A cold
+    /// start that carried on here would hold the recipient's key in memory for
+    /// one process, run an hours-long sweep on it, and leave nothing behind — so
+    /// the next launch asks again and no engagement was ever set up. The launch
+    /// stops instead, and says which file it could not write.
+    /// What: names the path and keeps the underlying [`AuditError::WorkDir`]
+    /// failure. Never quotes the key, which is why the message can say what it
+    /// says about it.
+    /// Test: `crate::cli::bootstrap::bootstrap_tests::a_config_that_cannot_be_written_stops_the_launch`.
+    #[error(
+        "the engagement config at {path} could not be written, so nothing was set up and \
+         the key you entered was NOT saved; fix that path and run `trusty-audit` again: {source}"
+    )]
+    EngagementNotCreated {
+        /// The config that could not be written.
+        path: PathBuf,
+        /// What the write failed with. Boxed — `AuditError` inside itself.
+        #[source]
+        source: Box<AuditError>,
+    },
+
+    /// A cold start could not learn which version of a tool to pin.
+    ///
+    /// Why: #5970's cold start records the version of each tool it resolved into
+    /// `engagement.toml`, and that file is the pin from then on. A resolution
+    /// that failed must not be papered over with a guess — a guessed version is
+    /// the #5454 version skew with a config file vouching for it. So the launch
+    /// stops before anything is written.
+    /// What: names the tool whose release list could not be read.
+    /// Test: `crate::tools::tool_tests::an_unresolvable_pin_names_the_tool`.
+    #[error(
+        "cannot determine which version of {tool} to pin — its release list could not be \
+         read; no engagement was created: {source}"
+    )]
+    PinsUnresolved {
+        /// The crate whose latest release could not be resolved.
+        tool: &'static str,
+        /// The underlying lookup failure.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// A pinned tool cannot be installed on this machine.
+    ///
+    /// Why: the preflight #5970 added exists so a recipient learns this before
+    /// committing to a multi-tool download, and learns WHICH tool. Reported as a
+    /// refusal rather than a warning for the same reason every other install-side
+    /// variant is: a set that is missing one tool cannot run a sweep, and a sweep
+    /// over three of four tools is the degraded success #5454 cost us.
+    /// What: names the tool and keeps `trusty-installer`'s structured
+    /// [`trusty_installer::download::pinned::PinnedError`], which already states
+    /// whether the pin is unpublished, the host unsupported, or the release list
+    /// unreachable — three problems with three different remedies. Boxed for the
+    /// `clippy::result_large_err` reason [`AuditError::Install`] documents.
+    /// Test: `crate::tools::tool_tests::a_tool_that_cannot_be_installed_is_refused_by_name`.
+    #[error("{tool} cannot be installed on this machine: {source}")]
+    ToolNotInstallable {
+        /// The crate that cannot be installed.
+        tool: &'static str,
+        /// Why, verbatim from the installer.
+        #[source]
+        source: Box<trusty_installer::download::pinned::PinnedError>,
+    },
+
     /// A capability this scaffold declares but does not yet implement.
     ///
     /// Why: a half-built capability must fail closed rather than silently

--- a/crates/trusty-audit/src/inference.rs
+++ b/crates/trusty-audit/src/inference.rs
@@ -65,18 +65,24 @@ pub const ENV_SUMMARIZER_MODEL: &str = "TRUSTY_REVIEW_SUMMARIZER_MODEL";
 /// The provider name `trusty-review`'s `Provider: FromStr` accepts for OpenRouter.
 pub const PROVIDER_OPENROUTER: &str = "openrouter";
 
-/// Reviewer model — the highest-quality call in the pipeline, so Sonnet-class.
+/// Reviewer model — the audit's judging call, so the Opus analysis tier.
 ///
-/// Why: matches the role/cost split `trusty-review` already uses for Bedrock
-/// (Sonnet reviewer, Haiku verifier and summarizer), so switching provider does
-/// not silently change the quality tier as well.
+/// Why: owner ruling, 2026-08-18 — for `trusty-audit` the analysis tier is Opus
+/// 4.8. It was `anthropic/claude-sonnet-4.6`, which paired this crate's judging
+/// call with the Sonnet-class split `trusty-review` uses for Bedrock. This
+/// constant is the BOTTOM of `trusty-review`'s precedence chain (CLI flag >
+/// environment > config file > built-in), so it decides only for an engagement
+/// config that names no `[models]` table — which is the auditor-supplied
+/// handoff, the common case. Leaving it would have applied the ruling to
+/// configs `crate::cli::bootstrap` writes and to nothing else (#5970).
 /// What: OpenRouter names Anthropic models `anthropic/claude-<tier>-<major>.<minor>`
 /// — a DOT, not a dash. Verified against `GET https://openrouter.ai/api/v1/models`
-/// on 2026-08-13, which lists `anthropic/claude-sonnet-4.6` and no dashed
-/// `-4-6` form. The dashed spelling in `trusty-agents` is that crate's own
+/// on 2026-08-18, which lists `anthropic/claude-opus-4.8` and no dashed
+/// `-4-8` form. The dashed spelling in `trusty-agents` is that crate's own
 /// convention and is not an OpenRouter slug; sending it produces the HTTP 400
 /// `is not a valid model ID` this constant exists to avoid.
-pub const DEFAULT_REVIEWER_MODEL: &str = "anthropic/claude-sonnet-4.6";
+/// Test: `super::inference_tests::a_config_with_no_models_table_judges_on_opus`.
+pub const DEFAULT_REVIEWER_MODEL: &str = "anthropic/claude-opus-4.8";
 
 /// Verifier model — short, high-volume calls, so the cheapest Haiku tier.
 ///
@@ -294,9 +300,62 @@ trusty-review = "0.15.1"
                 "{slug} uses the dashed spelling; OpenRouter names versions with a dot"
             );
         }
-        assert!(DEFAULT_REVIEWER_MODEL.contains("sonnet"));
+        // #5970: the reviewer is the analysis tier, per the owner's ruling of
+        // 2026-08-18. It was `sonnet` until then.
+        assert!(DEFAULT_REVIEWER_MODEL.contains("opus"));
         assert!(DEFAULT_VERIFIER_MODEL.contains("haiku"));
         assert!(DEFAULT_SUMMARIZER_MODEL.contains("haiku"));
+    }
+
+    /// 🔴 The default path, asserted as LITERALS.
+    ///
+    /// Owner ruling, 2026-08-18: for `trusty-audit` the analysis tier is Opus
+    /// 4.8. An engagement config with no `[models]` table — the auditor-supplied
+    /// handoff, and the common case — resolves through the built-in constants,
+    /// so this is the path the ruling reaches only via [`DEFAULT_REVIEWER_MODEL`].
+    ///
+    /// It is distinct from `the_defaults_select_openrouter_and_all_three_roles`
+    /// above, which compares the pairs to those same constants and therefore
+    /// passes whatever they happen to say — including a Bedrock
+    /// `us.anthropic.…` profile id named against an OpenRouter endpoint, which
+    /// fails at call time rather than at compile time. Only a literal catches
+    /// that. Same reason
+    /// `crate::cli::bootstrap::bootstrap_tests::the_written_config_names_the_ruled_models`
+    /// spells its ids out; that test covers the config-file layer, this one the
+    /// built-in layer underneath it.
+    #[test]
+    fn a_config_with_no_models_table_judges_on_opus() {
+        let config = config_from(CONFIG);
+        assert_eq!(
+            config.models,
+            ModelPins::default(),
+            "the fixture must name no models"
+        );
+
+        let env = pairs(&config);
+        assert_eq!(
+            env.get(ENV_PROVIDER).map(String::as_str),
+            Some("openrouter")
+        );
+        assert_eq!(
+            env.get(ENV_REVIEWER_MODEL).map(String::as_str),
+            Some("anthropic/claude-opus-4.8"),
+            "an auditor-supplied config must judge on Opus 4.8: {env:?}"
+        );
+        assert_eq!(
+            env.get(ENV_VERIFIER_MODEL).map(String::as_str),
+            Some("anthropic/claude-haiku-4.5"),
+            "{env:?}"
+        );
+        assert_eq!(
+            env.get(ENV_SUMMARIZER_MODEL).map(String::as_str),
+            Some("anthropic/claude-haiku-4.5"),
+            "{env:?}"
+        );
+        assert!(
+            env.values().all(|v| !v.starts_with("us.anthropic.")),
+            "a Bedrock inference-profile id must never reach an OpenRouter run: {env:?}"
+        );
     }
 
     #[test]

--- a/crates/trusty-audit/src/main.rs
+++ b/crates/trusty-audit/src/main.rs
@@ -95,7 +95,17 @@ async fn main() -> Result<()> {
     // several times — registration, then the guided flow, then the sweep. What
     // it returns is the last outcome, which is what stdout carries.
     let outcome = match &mut terminal {
-        Some(tty) => match cli::registration::guided_at_the_terminal(&session, tty).await? {
+        // #5970: the launch sets the engagement up when there is none — key,
+        // config, tools, and only then targets. `from_environment` is the one
+        // place the cold start's inputs are read; the seam exists so its other
+        // branches are provable without a network and without an exported key.
+        Some(tty) => match cli::registration::guided_at_the_terminal(
+            &session,
+            &cli::bootstrap::ColdStart::from_environment(),
+            tty,
+        )
+        .await?
+        {
             cli::registration::Launch::Reported(outcome) => *outcome,
             cli::registration::Launch::SweepConfirmed => {
                 let sweep = cli::registration::confirmed_sweep();

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -532,6 +532,15 @@ impl Session {
         &self.config_path
     }
 
+    /// Whether this session may download the pinned tools on its own (#5970).
+    ///
+    /// The cold-start launch reads it to decide whether to preflight and install
+    /// after writing the config, so `--no-install` means the same thing there as
+    /// it does in [`Session::guided`] rather than only in one of the two.
+    pub fn auto_install(&self) -> bool {
+        self.auto_install
+    }
+
     /// Run one capability.
     ///
     /// Why: the single entry point. Every front end goes through here, so a

--- a/crates/trusty-audit/src/tools.rs
+++ b/crates/trusty-audit/src/tools.rs
@@ -155,6 +155,29 @@ pub struct ToolStatus {
     pub version: Option<String>,
 }
 
+/// Whether a pinned tool is here, and if not whether it could be (#5970).
+///
+/// Why: [`ToolStatus`] answers "is it on disk", which is the whole question once
+/// an engagement is set up. A cold start has a second one — "and if not, can this
+/// machine get it" — and an operator about to wait several minutes for four
+/// downloads is owed the answer first.
+/// What: the tool, the version pinned for it, whether it is already satisfied,
+/// and the installer's own reason when it cannot be installed. `installed: true`
+/// always carries `problem: None`: nothing asked.
+/// Test: `super::tool_tests::preflight_asks_nothing_about_a_satisfied_set`.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ToolAvailability {
+    /// The tool checked.
+    pub tool: RequiredTool,
+    /// The version this engagement pins for it.
+    pub version: String,
+    /// Whether it is already on disk at that version, verified.
+    pub installed: bool,
+    /// Why it cannot be installed here, or `None` when it can.
+    pub problem: Option<Box<trusty_installer::download::pinned::PinnedError>>,
+}
+
 /// One tool this client installed and verified, at an exact version.
 ///
 /// Why: this is what the deliverable records so a reader knows which triple
@@ -464,6 +487,146 @@ pub async fn ensure(
         return Ok(None);
     }
     install(work, pins, progress).await.map(Some)
+}
+
+/// Resolve the latest published stable release of each required tool (#5970).
+///
+/// Why: a cold start has no `engagement.toml`, so it has no pins — and there is
+/// nowhere else in this crate to get them from. The two candidates were a
+/// compiled-in default set and this. A compiled-in set is a constant nothing in
+/// this workspace bumps: `trusty-audit` releases rarely and the four tools
+/// release often, so a client running a months-old client would pin months-old
+/// tools forever, with a config file that reads as a deliberate choice. Reading
+/// the release list costs nothing this path does not already require — a
+/// recipient who cannot reach the GitHub release host cannot install these tools
+/// at all (see this module's "Known v1 risk").
+///
+/// # Postconditions
+/// On `Ok`, every field of the returned [`ToolPins`] is an EXACT version that
+/// was published as a stable release at the moment this ran. `latest` never
+/// leaves this function: the caller writes these versions into
+/// `engagement.toml`, and every run after the first reads the file. On `Err`,
+/// no version is claimed for any tool and the caller must write nothing.
+///
+/// What: one [`trusty_installer::download::release::resolve_latest_tag`] call
+/// per [`RequiredTool`], through the same HTTP client [`install`] uses. The
+/// fields are named individually rather than mapped over [`RequiredTool::ALL`]
+/// so a fifth tool fails to compile here as well as in [`RequiredTool::pin_in`].
+/// Test: `super::tool_tests::an_unresolvable_pin_names_the_tool`.
+///
+/// # Errors
+///
+/// [`AuditError::PinsUnresolved`] naming the first tool whose release list could
+/// not be read.
+pub async fn latest_pins() -> Result<ToolPins, AuditError> {
+    let client = trusty_installer::download::http_client();
+    Ok(ToolPins {
+        tga: latest_pin(&client, RequiredTool::Tga).await?,
+        trusty_search: latest_pin(&client, RequiredTool::TrustySearch).await?,
+        trusty_analyze: latest_pin(&client, RequiredTool::TrustyAnalyze).await?,
+        trusty_review: latest_pin(&client, RequiredTool::TrustyReview).await?,
+    })
+}
+
+/// One tool's latest published stable version, as a bare version pin.
+///
+/// No digest: nothing here has seen the artifact, and inventing a `sha256` the
+/// caller did not obtain independently would turn the byte pin into decoration.
+async fn latest_pin(client: &reqwest::Client, tool: RequiredTool) -> Result<ToolPin, AuditError> {
+    trusty_installer::download::release::resolve_latest_tag(client, tool.crate_name())
+        .await
+        .map(|resolved| ToolPin::Version(resolved.version))
+        .map_err(|source| AuditError::PinsUnresolved {
+            tool: tool.crate_name(),
+            source: source.into(),
+        })
+}
+
+/// Whether each pinned tool is already here, and if not whether it could be.
+///
+/// Why: the cold-start launch (#5970) tells the recipient what it is about to
+/// do before it spends minutes doing it, and a tool that cannot be installed at
+/// all should surface in that first report rather than half way through a
+/// download. The installability half is
+/// [`trusty_installer::download::pinned::preflight_pinned_set`] — the capability
+/// that issue added INSIDE the installer, so this crate still has exactly one
+/// path that talks to a release list and exactly one that downloads.
+///
+/// # Postconditions
+/// One [`ToolAvailability`] per [`RequiredTool::ALL`] entry, in that order.
+/// Nothing was downloaded and nothing was written.
+///
+/// What: [`unsatisfied`] decides which tools need anything at all; only those
+/// reach the network. A tool already on disk at its pin is reported
+/// `installed: true` with no problem, because asking a release list about a
+/// binary that is already verified answers a question nobody has.
+/// Test: `super::tool_tests::preflight_asks_nothing_about_a_satisfied_set`.
+///
+/// # Errors
+///
+/// Whatever [`unsatisfied`] fails with — an unreadable or malformed version
+/// record. A tool that cannot be installed is DATA here, not an error; turning
+/// it into one is [`ensure_installable`]'s job.
+pub async fn preflight(
+    work: &WorkDir,
+    pins: &ToolPins,
+) -> Result<Vec<ToolAvailability>, AuditError> {
+    let pending = unsatisfied(work, pins)?;
+    let wanted: Vec<PinnedTool> = plan(pins)
+        .into_iter()
+        .zip(RequiredTool::ALL)
+        .filter(|(_, tool)| pending.contains(tool))
+        .map(|(pinned, _)| pinned)
+        .collect();
+    let mut checked = trusty_installer::download::pinned::preflight_pinned_set(
+        &trusty_installer::download::http_client(),
+        &wanted,
+    )
+    .await
+    .into_iter();
+
+    Ok(RequiredTool::ALL
+        .iter()
+        .map(|tool| {
+            let satisfied = !pending.contains(tool);
+            ToolAvailability {
+                tool: *tool,
+                version: tool.pin_in(pins).version().to_owned(),
+                installed: satisfied,
+                problem: if satisfied {
+                    None
+                } else {
+                    checked.next().and_then(|c| c.problem).map(Box::new)
+                },
+            }
+        })
+        .collect())
+}
+
+/// Refuse a set that carries a tool this machine cannot install.
+///
+/// Why: the preflight is only worth running if something acts on it. Pure, so
+/// the verdict is provable without a network.
+/// What: the first problem, as [`AuditError::ToolNotInstallable`]. First rather
+/// than all: the recipient's remedy — reach the release host, or ask for a
+/// package built for their platform — is the same for every entry, and the
+/// rendered report above it already listed them all.
+/// Test: `super::tool_tests::a_tool_that_cannot_be_installed_is_refused_by_name`,
+/// `super::tool_tests::an_installable_set_is_permitted`.
+///
+/// # Errors
+///
+/// [`AuditError::ToolNotInstallable`] naming the first refused tool.
+pub fn ensure_installable(checked: Vec<ToolAvailability>) -> Result<(), AuditError> {
+    for entry in checked {
+        if let Some(problem) = entry.problem {
+            return Err(AuditError::ToolNotInstallable {
+                tool: entry.tool.crate_name(),
+                source: problem,
+            });
+        }
+    }
+    Ok(())
 }
 
 /// Refuse an install target that is not a real directory.
@@ -1021,6 +1184,103 @@ trusty-review = "0.0.0-never-published"
         assert!(
             matches!(err, AuditError::UnsafeToolsDir { .. }),
             "ensure must reach install's guard, got {err:?}"
+        );
+    }
+
+    /// A satisfied set reaches no release list (#5970). The pins name a version
+    /// that was never published, so any lookup would fail — an empty problem
+    /// list is only reachable by not asking.
+    #[tokio::test]
+    async fn preflight_asks_nothing_about_a_satisfied_set() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        place_verified_set(&work, "0.0.0-never-published");
+
+        let checked = preflight(&work, &unpublishable_pins())
+            .await
+            .expect("a satisfied set preflights offline");
+
+        assert_eq!(checked.len(), RequiredTool::ALL.len());
+        assert!(
+            checked.iter().all(|c| c.installed && c.problem.is_none()),
+            "{checked:?}"
+        );
+        let versions: Vec<&str> = checked.iter().map(|c| c.version.as_str()).collect();
+        assert_eq!(versions, vec!["0.0.0-never-published"; 4]);
+    }
+
+    /// The verdict a cold start acts on: one refused tool stops the set, by name.
+    #[test]
+    fn a_tool_that_cannot_be_installed_is_refused_by_name() {
+        let checked = vec![
+            ToolAvailability {
+                tool: RequiredTool::Tga,
+                version: "2.9.4".to_owned(),
+                installed: true,
+                problem: None,
+            },
+            ToolAvailability {
+                tool: RequiredTool::TrustyReview,
+                version: "0.0.1".to_owned(),
+                installed: false,
+                problem: Some(Box::new(
+                    trusty_installer::download::pinned::PinnedError::VersionNotPublished {
+                        crate_name: "trusty-review".to_owned(),
+                        version: "0.0.1".to_owned(),
+                        available: vec!["0.16.0".to_owned()],
+                    },
+                )),
+            },
+        ];
+
+        let err = ensure_installable(checked).expect_err("a refused tool must stop the set");
+        let AuditError::ToolNotInstallable { tool, .. } = &err else {
+            panic!("expected ToolNotInstallable, got {err:?}");
+        };
+        assert_eq!(*tool, "trusty-review");
+        let rendered = err.to_string();
+        assert!(rendered.contains("trusty-review"), "{rendered}");
+        assert!(rendered.contains("0.16.0"), "{rendered}");
+    }
+
+    #[test]
+    fn an_installable_set_is_permitted() {
+        let checked: Vec<ToolAvailability> = RequiredTool::ALL
+            .iter()
+            .map(|tool| ToolAvailability {
+                tool: *tool,
+                version: "1.2.3".to_owned(),
+                installed: false,
+                problem: None,
+            })
+            .collect();
+        ensure_installable(checked).expect("nothing was refused");
+    }
+
+    /// A pin that cannot be resolved names the tool, and no version is invented
+    /// for it — a guessed pin is the #5454 skew with a config file vouching for
+    /// it.
+    #[tokio::test]
+    async fn an_unresolvable_pin_names_the_tool() {
+        // A client with no route to the release host. `latest_pins` resolves in
+        // `RequiredTool::ALL` order, so `tga` is what fails first.
+        let err = latest_pin(
+            &reqwest::Client::builder()
+                .timeout(std::time::Duration::from_millis(1))
+                .build()
+                .expect("client"),
+            RequiredTool::Tga,
+        )
+        .await
+        .expect_err("a one-millisecond timeout cannot reach GitHub");
+
+        let AuditError::PinsUnresolved { tool, .. } = &err else {
+            panic!("expected PinsUnresolved, got {err:?}");
+        };
+        assert_eq!(*tool, "tga");
+        assert!(
+            err.to_string().contains("no engagement was created"),
+            "{err}"
         );
     }
 

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-installer"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"

--- a/crates/trusty-installer/changelog.d/5970-pinned-preflight.md
+++ b/crates/trusty-installer/changelog.d/5970-pinned-preflight.md
@@ -1,0 +1,9 @@
+Added
+
+- `download::pinned::preflight_pinned_set` answers whether a pinned set could be
+  installed on this host without installing it — a Tier-1 target check and a
+  release-list lookup per tool, and no download, hash, or execution. It shares
+  `resolve_pin` with `install_pinned_set`'s staging path, so a preflight cannot
+  come to a different answer than the install it precedes, and a consumer that
+  needed the question answered no longer has to install or grow a second
+  resolver ([#5970](https://github.com/bobmatnyc/trusty-tools/issues/5970))

--- a/crates/trusty-installer/src/download/pinned.rs
+++ b/crates/trusty-installer/src/download/pinned.rs
@@ -40,7 +40,14 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::download::{fetch, glibc, platform, release};
+use crate::download::{fetch, glibc, release};
+
+// #5970: "can this be installed without installing it" — the question a consumer
+// had to either install or grow a second resolver to answer. Its `resolve_pin` is
+// checks 1 and 2 of `stage_one` below, shared rather than copied.
+mod preflight;
+
+pub use preflight::{preflight_pinned_set, PinnedPreflight};
 
 /// A tool to install at an exact pinned version.
 ///
@@ -481,33 +488,10 @@ async fn stage_one(
 ) -> Result<Staged, PinnedError> {
     let (name, version) = (tool.crate_name.as_str(), tool.version.as_str());
 
-    // Check 1 — a prebuilt exists for this host. Unlike the latest path, an
-    // unsupported target is terminal, not a cargo fallback.
-    let target = platform::current_target().ok_or_else(|| PinnedError::UnsupportedTarget {
-        crate_name: name.to_owned(),
-        version: version.to_owned(),
-        os: std::env::consts::OS.to_owned(),
-        arch: std::env::consts::ARCH.to_owned(),
-    })?;
-
-    // Check 2 — the EXACT pinned version is published. #5491: never `latest`.
-    let resolved =
-        release::resolve_pinned_tag_from_url(client, endpoints.releases_url, name, version)
-            .await
-            .map_err(|e| match e {
-                release::ResolveError::NotPublished { available } => {
-                    PinnedError::VersionNotPublished {
-                        crate_name: name.to_owned(),
-                        version: version.to_owned(),
-                        available,
-                    }
-                }
-                release::ResolveError::Fetch(source) => PinnedError::ReleaseLookupFailed {
-                    crate_name: name.to_owned(),
-                    version: version.to_owned(),
-                    source,
-                },
-            })?;
+    // Checks 1 and 2 — a prebuilt exists for this host, and the EXACT pinned
+    // version is published. #5970 moved them into `preflight` so the dry-run
+    // check and this install ask the same two questions of the same code.
+    let (target, resolved) = preflight::resolve_pin(client, endpoints, tool).await?;
 
     let suffix = glibc::select_asset_suffix(name, target, glibc::host_glibc_version()).suffix;
     let archive_name = release::asset_filename(name, &resolved.version, &suffix);

--- a/crates/trusty-installer/src/download/pinned/preflight.rs
+++ b/crates/trusty-installer/src/download/pinned/preflight.rs
@@ -1,0 +1,156 @@
+//! Whether a pinned set COULD be installed here, without installing it (#5970).
+//!
+//! Why: `trusty-audit`'s cold-start launch has to tell a recipient which pinned
+//! tools are installable before it commits them to a multi-tool download that
+//! runs for minutes. Until this module the only way to learn that was to call
+//! [`super::install_pinned_set`], which downloads — so the question could only
+//! be answered by installing, or by a consumer growing a second resolver of its
+//! own. A second resolver is the drift CLAUDE.md's common-entry-point rule
+//! forbids, and it is what this module exists so nobody writes.
+//!
+//! What: [`preflight_pinned_set`] runs the first two of `stage_one`'s five
+//! checks and stops. It downloads nothing, hashes nothing, and executes nothing.
+//! [`resolve_pin`] IS those two checks, and `stage_one` calls the same function,
+//! so a preflight cannot come to a different answer than the install it precedes.
+//!
+//! What a clean preflight does not promise: that the artifact downloads, that it
+//! matches its published checksum, or that the binary reports its pin. Those are
+//! checks 3 to 5, they need the bytes, and they stay in `stage_one`. A preflight
+//! is "this pin resolves for this host", never "this install will succeed".
+//!
+//! Test: `super::tests::preflight_reports_every_tool_as_installable`,
+//! `super::tests::preflight_names_the_tool_whose_version_was_never_published`,
+//! `super::tests::preflight_downloads_nothing`.
+
+use super::{Endpoints, PinnedError, PinnedTool};
+use crate::download::{platform, release};
+
+/// What a preflight found for one pinned tool.
+///
+/// Why: the caller renders a line per tool, so the answer travels per tool
+/// rather than as one verdict for the set — an operator told "the set is not
+/// installable" cannot act, and one told which tool and why can.
+/// What: the pin, and the reason it could not be resolved when there is one.
+/// `problem: None` is the installable case.
+/// Test: `super::tests::preflight_names_the_tool_whose_version_was_never_published`.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct PinnedPreflight {
+    /// The crate that was checked.
+    pub crate_name: String,
+    /// The version that was pinned.
+    pub version: String,
+    /// Why this pin cannot be installed here, or `None` when it can.
+    pub problem: Option<PinnedError>,
+}
+
+impl PinnedPreflight {
+    /// Whether this pin resolved for this host.
+    pub fn installable(&self) -> bool {
+        self.problem.is_none()
+    }
+}
+
+/// Check every pin in the set, without installing any of them.
+///
+/// Why: the set is reported WHOLE — one entry per input tool, even after an
+/// earlier one failed. Stopping at the first problem would make a recipient
+/// behind an egress proxy fix one tool, re-run, and meet the next; the whole
+/// list in one pass is what lets them fix the network once.
+///
+/// # Postconditions
+/// The returned vector has one entry per input tool, in order. Nothing was
+/// downloaded and nothing was written anywhere.
+///
+/// What: [`resolve_pin`] per tool — a Tier-1 target check, then a release-list
+/// lookup for the exact pinned version. Unlike [`super::install_pinned_set`]
+/// this is NOT all-or-none: it makes no change to disk, so there is nothing to
+/// roll back and no reason to hide the rest of the answer.
+///
+/// Test: `super::tests::preflight_reports_every_tool_as_installable`,
+/// `super::tests::preflight_reports_every_tool_even_after_one_fails`.
+pub async fn preflight_pinned_set(
+    client: &reqwest::Client,
+    tools: &[PinnedTool],
+) -> Vec<PinnedPreflight> {
+    preflight_pinned_set_at(client, &Endpoints::default(), tools).await
+}
+
+/// [`preflight_pinned_set`], against caller-supplied endpoints.
+///
+/// The same offline seam [`super::install_pinned_set_at`] uses, so every arm is
+/// provable against the loopback fixture rather than against real GitHub.
+pub(crate) async fn preflight_pinned_set_at(
+    client: &reqwest::Client,
+    endpoints: &Endpoints<'_>,
+    tools: &[PinnedTool],
+) -> Vec<PinnedPreflight> {
+    let mut checked = Vec::with_capacity(tools.len());
+    for tool in tools {
+        checked.push(PinnedPreflight {
+            crate_name: tool.crate_name.clone(),
+            version: tool.version.clone(),
+            problem: resolve_pin(client, endpoints, tool).await.err(),
+        });
+    }
+    checked
+}
+
+/// Checks 1 and 2 of the pinned pipeline: a prebuilt exists for this host, and
+/// the exact pinned version is published.
+///
+/// Why: shared by [`preflight_pinned_set`] and `stage_one` so the preflight and
+/// the install that follows it cannot disagree. Two copies of this pair would
+/// drift the moment either grew a case — and a preflight that says "installable"
+/// over an install that then refuses is worse than no preflight.
+///
+/// # Postconditions
+/// On `Ok`, `tool` names a Tier-1 target and a published stable release; nothing
+/// was downloaded either way.
+///
+/// What: [`platform::current_target`], then
+/// [`release::resolve_pinned_tag_from_url`] — never `latest`, per #5491.
+///
+/// Test: every `super::tests` case reaches it through one of the two callers.
+///
+/// # Errors
+///
+/// [`PinnedError::UnsupportedTarget`] off a Tier-1 host,
+/// [`PinnedError::VersionNotPublished`] when the pin names no release, and
+/// [`PinnedError::ReleaseLookupFailed`] when the list could not be read.
+pub(super) async fn resolve_pin(
+    client: &reqwest::Client,
+    endpoints: &Endpoints<'_>,
+    tool: &PinnedTool,
+) -> Result<(&'static str, release::ResolvedTag), PinnedError> {
+    let (name, version) = (tool.crate_name.as_str(), tool.version.as_str());
+
+    // Check 1 — a prebuilt exists for this host. Unlike the latest path, an
+    // unsupported target is terminal, not a cargo fallback.
+    let target = platform::current_target().ok_or_else(|| PinnedError::UnsupportedTarget {
+        crate_name: name.to_owned(),
+        version: version.to_owned(),
+        os: std::env::consts::OS.to_owned(),
+        arch: std::env::consts::ARCH.to_owned(),
+    })?;
+
+    // Check 2 — the EXACT pinned version is published. #5491: never `latest`.
+    let resolved =
+        release::resolve_pinned_tag_from_url(client, endpoints.releases_url, name, version)
+            .await
+            .map_err(|e| match e {
+                release::ResolveError::NotPublished { available } => {
+                    PinnedError::VersionNotPublished {
+                        crate_name: name.to_owned(),
+                        version: version.to_owned(),
+                        available,
+                    }
+                }
+                release::ResolveError::Fetch(source) => PinnedError::ReleaseLookupFailed {
+                    crate_name: name.to_owned(),
+                    version: version.to_owned(),
+                    source,
+                },
+            })?;
+    Ok((target, resolved))
+}

--- a/crates/trusty-installer/src/download/pinned/tests.rs
+++ b/crates/trusty-installer/src/download/pinned/tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+// #5970: `pinned.rs` reaches the host-target probe through `preflight::resolve_pin`
+// now, so it is no longer in scope via `use super::*`.
+use crate::download::platform;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -796,4 +799,174 @@ async fn fails_closed_when_the_release_list_is_unreachable() {
         "got {err:?}"
     );
     assert_nothing_installed(dir.path());
+}
+
+/// Preflight the set against a fixture, asking only whether each pin resolves.
+async fn preflight(base: &str, tools: &[PinnedTool]) -> Vec<PinnedPreflight> {
+    let releases_url = format!("{base}/releases");
+    let download_base = format!("{base}/dl");
+    let endpoints = Endpoints {
+        releases_url: &releases_url,
+        download_base: &download_base,
+    };
+    preflight::preflight_pinned_set_at(&crate::download::http_client(), &endpoints, tools).await
+}
+
+/// Why: #5970's whole point — a caller can ask "could this be installed" and get
+/// an answer without a download.
+/// What: two published pins over a fixture; both come back installable.
+/// Test: This is the test.
+#[tokio::test]
+async fn preflight_reports_every_tool_as_installable() {
+    let Some(target) = tier1() else {
+        return;
+    };
+    let base = Fixture::new(target)
+        .publish("demo-tool", "1.2.3", Flaw::None)
+        .publish("other-tool", "0.4.0", Flaw::None)
+        .start()
+        .await;
+
+    let checked = preflight(
+        &base,
+        &[
+            PinnedTool::new("demo-tool", "1.2.3"),
+            PinnedTool::new("other-tool", "0.4.0"),
+        ],
+    )
+    .await;
+
+    assert_eq!(checked.len(), 2);
+    assert!(
+        checked.iter().all(PinnedPreflight::installable),
+        "{checked:?}"
+    );
+    let names: Vec<&str> = checked.iter().map(|c| c.crate_name.as_str()).collect();
+    assert_eq!(names, vec!["demo-tool", "other-tool"], "order must survive");
+}
+
+/// Why: the answer has to name the TOOL and the reason, or the operator cannot
+/// act on it.
+/// What: one published pin, one naming a version the fixture never published;
+/// the second carries `VersionNotPublished`.
+/// Test: This is the test.
+#[tokio::test]
+async fn preflight_names_the_tool_whose_version_was_never_published() {
+    let Some(target) = tier1() else {
+        return;
+    };
+    let base = Fixture::new(target)
+        .publish("demo-tool", "1.2.3", Flaw::None)
+        .start()
+        .await;
+
+    let checked = preflight(
+        &base,
+        &[
+            PinnedTool::new("demo-tool", "1.2.3"),
+            PinnedTool::new("demo-tool", "9.9.9"),
+        ],
+    )
+    .await;
+
+    assert!(checked[0].installable(), "{checked:?}");
+    assert!(
+        matches!(
+            checked[1].problem,
+            Some(PinnedError::VersionNotPublished { .. })
+        ),
+        "{checked:?}"
+    );
+    let rendered = checked[1]
+        .problem
+        .as_ref()
+        .expect("a problem was reported")
+        .to_string();
+    assert!(rendered.contains("demo-tool"), "{rendered}");
+    assert!(rendered.contains("9.9.9"), "{rendered}");
+}
+
+/// Why: the set is reported WHOLE. Stopping at the first refusal would make a
+/// recipient fix one tool, re-run, and meet the next.
+/// What: an unpublished pin between two published ones; all three come back.
+/// Test: This is the test.
+#[tokio::test]
+async fn preflight_reports_every_tool_even_after_one_fails() {
+    let Some(target) = tier1() else {
+        return;
+    };
+    let base = Fixture::new(target)
+        .publish("demo-tool", "1.2.3", Flaw::None)
+        .publish("other-tool", "0.4.0", Flaw::None)
+        .start()
+        .await;
+
+    let checked = preflight(
+        &base,
+        &[
+            PinnedTool::new("demo-tool", "1.2.3"),
+            PinnedTool::new("demo-tool", "9.9.9"),
+            PinnedTool::new("other-tool", "0.4.0"),
+        ],
+    )
+    .await;
+
+    let installable: Vec<bool> = checked.iter().map(PinnedPreflight::installable).collect();
+    assert_eq!(installable, vec![true, false, true], "{checked:?}");
+}
+
+/// Why: a preflight that downloaded would be an install under another name, and
+/// `install_pinned_set` must stay the only path that fetches bytes.
+/// What: preflights a pin whose ARTIFACT is missing from the fixture. The pin
+/// still resolves — the tag is published — which is exactly the limit: a clean
+/// preflight promises resolution, never a successful download. The install over
+/// the same set then fails closed, which is what makes that a limit rather than
+/// a hole.
+/// Test: This is the test.
+#[tokio::test]
+async fn preflight_downloads_nothing() {
+    let Some(target) = tier1() else {
+        return;
+    };
+    let base = Fixture::new(target)
+        .publish("demo-tool", "1.2.3", Flaw::AssetMissing)
+        .start()
+        .await;
+
+    let checked = preflight(&base, &[PinnedTool::new("demo-tool", "1.2.3")]).await;
+    assert!(
+        checked[0].installable(),
+        "a published tag resolves even when its asset 404s: {checked:?}"
+    );
+
+    let dir = tempfile::tempdir().unwrap();
+    let err = run(&base, &[PinnedTool::new("demo-tool", "1.2.3")], dir.path())
+        .await
+        .expect_err("a missing artifact must still fail the install");
+    assert!(
+        matches!(err, PinnedError::ArtifactUnavailable { .. }),
+        "got {err:?}"
+    );
+    assert_nothing_installed(dir.path());
+}
+
+/// Why: an unreachable release list is not "not published", and the preflight
+/// owes the same distinction the install does.
+/// What: points the resolver at a port that refuses.
+/// Test: This is the test.
+#[tokio::test]
+async fn preflight_distinguishes_an_unreachable_list_from_an_unpublished_pin() {
+    if tier1().is_none() {
+        return;
+    }
+    let base = format!("http://{}", crate::commands::test_support::dead_addr());
+    let checked = preflight(&base, &[PinnedTool::new("demo-tool", "1.2.3")]).await;
+
+    assert!(
+        matches!(
+            checked[0].problem,
+            Some(PinnedError::ReleaseLookupFailed { .. })
+        ),
+        "{checked:?}"
+    );
 }


### PR DESCRIPTION
Closes #5970.

A bare `trusty-audit` in a directory with no `engagement.toml` registered targets, printed `Tools: 0/4 installed`, named `trusty-audit install`, and stopped — never asking for the OpenRouter key. The launch now creates the engagement first and registers targets last, per the owner's ruling of 2026-08-18.

## What the launch does now

A launch that finds no `engagement.toml`, in this order:

1. Asks for the OpenRouter key (`OPENROUTER_API_KEY` wins if exported).
2. Resolves a pin per tool and writes `engagement.toml` at mode 0600.
3. Preflights all four pinned tools.
4. Installs them.
5. Asks what the audit covers.

A launch that finds a config skips all of it and behaves exactly as before — that is the auditor-handed-a-config path every existing registration test covers.

## Where the pins come from — the one genuine unknown, decided

**Latest published stable per tool, resolved once and recorded in the file.** `trusty-audit` reads `engagement.toml` on every later run, so `latest` never reaches a second run; the engagement states the exact triple it ran.

The alternative was a compiled-in default set. Rejected because nothing in this workspace bumps such a constant: `trusty-audit` releases rarely and the four tools release often, so a client a few months old would pin months-old tools forever behind a config file that reads as a deliberate choice. That is #5454's version skew with a document vouching for it. Resolving from the release list adds no new dependency either — a recipient who cannot reach the GitHub release host cannot install these tools at all (`tools.rs`, "Known v1 risk").

Cost, stated: a cold start needs the release list reachable. If it is not, `AuditError::PinsUnresolved` names the tool and **nothing is written** — the config is complete or absent, never half.

## The preflight is inside `pinned.rs`, not a second copy

`trusty_installer::download::pinned::preflight_pinned_set` runs checks 1 and 2 of the install pipeline — Tier-1 target, exact pinned version published — and stops. It downloads nothing, hashes nothing, executes nothing. `stage_one` now calls the same `resolve_pin`, so a preflight cannot come to a different answer than the install it precedes. `install_pinned_set` remains the only path that fetches bytes; `preflight_downloads_nothing` pins that limit by preflighting a pin whose artifact 404s (it resolves) and then failing the install over the same set.

`0/4` was left alone. `tools.rs:218` reads trusty-audit's own tools area, which is correct.

## Fail-open branches, each with a regression test

| Branch | Error | Test |
|---|---|---|
| Config write fails after the key was typed | `EngagementNotCreated`, naming the file, stating the key was not saved | `a_config_that_cannot_be_written_stops_the_launch`, `a_launch_that_cannot_write_the_engagement_stops_with_the_key_entered` |
| No key available, no terminal | `NoCredentialSource`, unchanged | `without_a_terminal_a_cold_start_refuses`, `a_blank_export_does_not_count_as_a_source` |
| A pinned tool cannot be installed here | `ToolNotInstallable`, naming the tool | `a_tool_that_cannot_be_installed_is_refused_by_name` |
| Release list unreadable | `PinsUnresolved`, naming the tool, nothing written | `an_unresolvable_pin_names_the_tool` |
| Config present but malformed | `Parse` — not treated as a cold start, so a hand-edited file is never overwritten | `a_malformed_engagement_is_not_treated_as_a_cold_start` |

Ordering is asserted as an order, not as a set of events: `the_key_is_asked_for_before_the_first_target` fails if registration moves back ahead of the key. Against `8cfdda3ab` it fails on its first assertion, because the only prompts issued are registration's.

## Credential handling

- Written through `workdir::write_private_atomically` at mode 0600; the mode is asserted (`a_cold_start_writes_the_engagement_owner_only`).
- Read with echo off, through the existing `cli::credential` prompt — no second prompt implementation.
- `the_entered_key_never_reaches_the_terminal` asserts the value, a rejected retype, and the `Debug` render are all clean. This crate's redaction is `SecretKey` (no `Serialize`, redacting `Debug`/`Display`) plus `EngagementConfig::configured_secrets`, which feeds the existing child-output scrubber; the cold start adds no new redaction path.
- The write goes through `config::generate`, which stays the crate's one writer of a plaintext key into a file.

## Owner ruling, 2026-08-18 — inference is OpenRouter

The synthesised config names its `[models]` table in full and selects OpenRouter. Leaving it unset fell through to `trusty-review`'s own default, which is Bedrock. All four fields are written because `crate::inference` treats the table as all-or-none — `provider` alone is `SplitInferenceSelection`, not a partial override. The values are this crate's existing constants (`PROVIDER_OPENROUTER`, `DEFAULT_REVIEWER_MODEL`, `DEFAULT_VERIFIER_MODEL`, `DEFAULT_SUMMARIZER_MODEL`), so no slug is minted here. `the_written_config_selects_openrouter_for_every_role` asserts both the file and the `TRUSTY_REVIEW_*` pairs the `tga audit` child is handed. No edit to `crates/trusty-common` or `crates/trusty-review`.

## Versions

- `trusty-audit` 0.4.0 → **0.5.0**. `guided_at_the_terminal` gained a parameter, which for a 0.x crate puts the bump in the MINOR position.
- `trusty-installer` 0.9.0 → **0.9.1**. Additive only (`preflight_pinned_set`, `PinnedPreflight`); `install_pinned_set`'s signature and semantics are unchanged.

## Test ladder — rung 5

Process lifecycle plus a credential path, and a cross-crate entry point. Commands run, all exit 0:

```
cargo fmt --check
cargo check -p trusty-audit
cargo check -p trusty-installer
cargo clippy -p trusty-audit --all-targets -- -D warnings
cargo clippy -p trusty-installer --all-targets -- -D warnings
cargo test -p trusty-audit
cargo test -p trusty-installer
bash scripts/check_line_cap.sh
bash scripts/check_sld.sh
```

```
=== test trusty-audit
test result: ok. 400 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out; finished in 15.06s   (lib)
test result: ok. 3 passed; 0 failed; 0 ignored   (binary_names)
test result: ok. 5 passed; 0 failed; 0 ignored   (cli_end_to_end)
test result: ok. 4 passed; 0 failed; 0 ignored   (guided_launch)
test result: ok. 4 passed; 0 failed; 2 ignored   (install_fails_closed)
test result: ok. 9 passed; 0 failed; 0 ignored   (run_fails_closed)
=== test trusty-installer
test result: ok. 638 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 4.96s
test result: ok. 3 passed; 0 failed; 0 ignored
test result: ok. 3 passed; 0 failed; 0 ignored
=== check_line_cap
line-cap: measured 4076 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
=== check_sld
sld-lint: scanned 60 spec doc(s) + 3326 code file(s); resolved 40 frontmatter + 37 inline reference(s); 0 error(s), 0 warning(s)
```

## #5889 — not touched

That issue reports a hang during install after credential entry succeeded. This PR does not change how the install runs: the cold start calls `Command::InstallTools`, which is the same `tools::install` → `install_pinned_set` path as before. It does move an install earlier in the launch, so the hang would now be reachable one step sooner. Nothing here diagnoses or absorbs it.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
