### PR TITLE
feat(trusty-common,trusty-review): resolve model tiers instead of pinned ids (#5971)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6519,7 +6519,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11398,7 +11398,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11765,7 +11765,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ trusty-code = { path = "crates/trusty-code", version = "0.3.0" }
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.6.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.36" }
+trusty-common = { path = "crates/trusty-common", version = "0.37" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 # Why: `default-features = false` HERE, not only on the member entry (mirrors
@@ -155,7 +155,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "1.0.0" }
 #      this line existed. Both consumers name what they need: trusty-analyze's
 #      `review` feature pulls `trusty-review/mcp`; trusty-mpm's dev-dependency
 #      only touches `integrations`, which is unconditional.
-trusty-review = { path = "crates/trusty-review", version = "0.18", default-features = false }
+trusty-review = { path = "crates/trusty-review", version = "0.19", default-features = false }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.36.0"
+version = "0.37.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/5971-model-tier-resolution.md
+++ b/crates/trusty-common/changelog.d/5971-model-tier-resolution.md
@@ -1,0 +1,15 @@
+Added
+
+- `inference::ModelTier` maps a capability tier plus a `ProviderId` to a
+  concrete model id, so a consumer asks for the class of model its work needs
+  instead of pinning a version-stamped string that never moves when the model
+  behind a role moves. Three tiers: `Analysis`, `Interaction`, `Haiku`. Analysis
+  and Interaction both resolve to Opus 4.8 today and stay separate variants so
+  they can diverge later.
+- `ModelTier::resolve` returns `Option`, not `Result`. A provider with no
+  verified id for a tier returns `None`, which means "no tier default here" and
+  leaves the caller on whatever default it already had. AWS Bedrock's opus tiers
+  are deliberately unmapped: the inference-profile id could not be verified, and
+  its shape is not derivable from the family name — this table shows both
+  directions, with Sonnet 4.6 working bare while Haiku 4.5 needs a date stamp
+  and a `-v1:0` suffix.

--- a/crates/trusty-common/src/inference/mod.rs
+++ b/crates/trusty-common/src/inference/mod.rs
@@ -15,7 +15,9 @@
 //! capability [`registry`] (context windows incl. the #2330 haiku fix, pricing,
 //! caching, tool dialects), the two-stage [`configurator`] (`provider_for` +
 //! [`Configurator`]), and the [`test_support`] doubles. Concrete provider HTTP
-//! adapters land in #2403/#2407.
+//! adapters land in #2403/#2407. Issue #5971 adds [`tier`] beside the
+//! configurator: the configurator answers "which provider and how do I reach
+//! it", [`ModelTier::resolve`] answers "which model on that provider".
 //!
 //! Test: the `inference-client` surface is covered by each submodule's inline
 //! tests and `crates/trusty-common/tests/inference_foundation.rs`; the
@@ -29,6 +31,8 @@
 //! [`configurator`]: crate::inference::configurator
 //! [`Configurator`]: configurator::Configurator
 //! [`test_support`]: crate::inference::test_support
+//! [`tier`]: crate::inference::tier
+//! [`ModelTier::resolve`]: crate::inference::tier::ModelTier::resolve
 
 /// Deprecated compatibility alias for [`crate::credentials`] (#4564).
 ///
@@ -67,6 +71,8 @@ pub mod streaming;
 #[cfg(feature = "inference-client")]
 pub mod test_support;
 #[cfg(feature = "inference-client")]
+pub mod tier;
+#[cfg(feature = "inference-client")]
 pub mod types;
 
 // Flat re-exports of the most-used surface so consumers write
@@ -94,6 +100,8 @@ pub use streaming::{
     ChatStream, ChatStreamEvent, SseDecoder, StreamAssembly, StreamCompletion, ToolCallDelta,
     buffered_stream, decode_event_stream,
 };
+#[cfg(feature = "inference-client")]
+pub use tier::ModelTier;
 // #4425: `PromptTokensDetails`/`UsageBlock` join the flat re-export because a
 // consumer that owns a `ChatResponse` owns its wire usage block — trusty-code
 // reads it directly for cost accounting and had to reach into `types::usage`.

--- a/crates/trusty-common/src/inference/tier.rs
+++ b/crates/trusty-common/src/inference/tier.rs
@@ -1,0 +1,226 @@
+//! Capability-tier → concrete model id resolution (issue #5971).
+//!
+//! Why: every model default across this workspace is a version-pinned id, so
+//! none of them moves when the model behind a role moves. That has already cost
+//! real behaviour — `trusty-agents-common/src/runner.rs:118-121` records a phase
+//! that silently ran a pinned `claude-sonnet-4-6` while ignoring its configured
+//! override, because the pin was doing the work an alias should have done. A
+//! consumer that asks for a TIER instead of an id moves with the tier.
+//!
+//! What: [`ModelTier`] (three tiers — analysis, interaction, haiku) and
+//! [`ModelTier::resolve`], which maps a tier plus a [`ProviderId`] to a concrete
+//! model id. Resolution is provider-dependent because the same model wears a
+//! different id per provider: Bedrock inference profiles are `us.anthropic.…`,
+//! OpenRouter slugs are `anthropic/claude-…`, and the Anthropic first-party API
+//! uses dashed ids. A provider with no mapping for a tier returns `None` so the
+//! caller keeps whatever default it already had.
+//!
+//! This sits beside the provider/transport resolution epic #2400 put in
+//! [`crate::inference::configurator`] — that layer answers "which provider and
+//! how do I reach it", this one answers "which model on that provider".
+//!
+//! Test: inline `tests` below, plus
+//! `crates/trusty-common/tests/inference_foundation.rs::model_tier_*`.
+
+use super::registry::ProviderId;
+
+// ─── Verified model ids ───────────────────────────────────────────────────────
+//
+// Every id below was verified against its provider before being written here.
+// Do NOT add an id derived from another provider's naming pattern: the shapes do
+// not correspond, and this table proves it in both directions — Bedrock's Sonnet
+// 4.6 profile works bare (`us.anthropic.claude-sonnet-4-6`) while its Haiku 4.5
+// profile needs both a date stamp and a `-v1:0` version suffix. An invented id
+// fails at call time, not compile time.
+
+/// OpenRouter slug for Claude Opus 4.8.
+///
+/// Confirmed present in a live `GET https://openrouter.ai/api/v1/models`
+/// response, 2026-08-18.
+const OPENROUTER_OPUS_4_8: &str = "anthropic/claude-opus-4.8";
+
+/// OpenRouter slug for Claude Haiku 4.5.
+///
+/// Confirmed present in a live `GET https://openrouter.ai/api/v1/models`
+/// response, 2026-08-18.
+const OPENROUTER_HAIKU_4_5: &str = "anthropic/claude-haiku-4.5";
+
+/// Anthropic first-party API id for Claude Opus 4.8.
+///
+/// From the `claude-api` model reference.
+const ANTHROPIC_OPUS_4_8: &str = "claude-opus-4-8";
+
+/// Anthropic first-party API id for Claude Haiku 4.5.
+///
+/// From the `claude-api` model reference.
+const ANTHROPIC_HAIKU_4_5: &str = "claude-haiku-4-5-20251001";
+
+/// Bedrock cross-region inference profile for Claude Haiku 4.5 (US geography).
+///
+/// Verified against a live Bedrock account; the short form
+/// `us.anthropic.claude-haiku-4-5` returns HTTP 400 ValidationException. Same id
+/// as `trusty-review`'s pre-#5971 verifier/summarizer default.
+const BEDROCK_HAIKU_4_5: &str = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+
+// ─── Tiers ────────────────────────────────────────────────────────────────────
+
+/// A capability tier a caller asks for instead of naming a concrete model id.
+///
+/// Why: a role should declare the class of model its work needs, so that moving
+/// the whole workspace to a newer model is one edit to [`ModelTier::resolve`]
+/// rather than a grep for every pinned id.
+/// What: three tiers. [`Self::Analysis`] and [`Self::Interaction`] resolve to
+/// the same model today (owner ruling, 2026-08-18) and are deliberately kept as
+/// two arms so they can diverge without touching a caller. [`Self::Haiku`] is
+/// the cheap high-volume tier for short, low-stakes calls.
+/// Test: `analysis_and_interaction_are_distinct_variants`,
+/// `every_tier_resolves_on_openrouter`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ModelTier {
+    /// Deep reasoning: the model that does the judging (code review, digests,
+    /// deep analysis passes).
+    Analysis,
+    /// Conversational turns with a user.
+    Interaction,
+    /// Short, high-volume, low-stakes calls — per-finding verification,
+    /// classification, summarisation.
+    Haiku,
+}
+
+impl ModelTier {
+    /// Resolve this tier to a concrete model id for `provider`.
+    ///
+    /// Why: the id for one tier differs per provider, so a tier alone cannot
+    /// name a model. The caller already knows its provider (epic #2400's
+    /// `provider_for` resolves it), so it passes both.
+    /// What: returns the provider's id for this tier, or `None` when this
+    /// provider has no verified id for it — including AWS Bedrock's opus tiers,
+    /// deliberately unmapped because the inference-profile id could not be
+    /// verified and its shape is not derivable from the family name. `None` is
+    /// not an error: it means "no tier default here", and the caller keeps
+    /// whatever default it had. Providers that host no Claude model
+    /// (`OpenAI`, `Fireworks`, `Together`, `AtlasCloud`, `Local`) return `None`
+    /// for every tier.
+    /// Test: `bedrock_opus_tiers_are_unmapped`, `bedrock_haiku_resolves`,
+    /// `every_tier_resolves_on_openrouter`, `every_tier_resolves_on_anthropic`,
+    /// `non_claude_providers_resolve_nothing`.
+    pub fn resolve(self, provider: ProviderId) -> Option<&'static str> {
+        match provider {
+            ProviderId::OpenRouter => Some(match self {
+                Self::Analysis | Self::Interaction => OPENROUTER_OPUS_4_8,
+                Self::Haiku => OPENROUTER_HAIKU_4_5,
+            }),
+            ProviderId::Anthropic => Some(match self {
+                Self::Analysis | Self::Interaction => ANTHROPIC_OPUS_4_8,
+                Self::Haiku => ANTHROPIC_HAIKU_4_5,
+            }),
+            // #5971: Bedrock's Opus 4.8 inference-profile id is unmapped by
+            // owner ruling — it could not be verified and must not be guessed.
+            ProviderId::Bedrock => match self {
+                Self::Analysis | Self::Interaction => None,
+                Self::Haiku => Some(BEDROCK_HAIKU_4_5),
+            },
+            ProviderId::OpenAI
+            | ProviderId::Fireworks
+            | ProviderId::Together
+            | ProviderId::AtlasCloud
+            | ProviderId::Local => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_TIERS: &[ModelTier] = &[
+        ModelTier::Analysis,
+        ModelTier::Interaction,
+        ModelTier::Haiku,
+    ];
+
+    #[test]
+    fn every_tier_resolves_on_openrouter() {
+        assert_eq!(
+            ModelTier::Analysis.resolve(ProviderId::OpenRouter),
+            Some("anthropic/claude-opus-4.8")
+        );
+        assert_eq!(
+            ModelTier::Interaction.resolve(ProviderId::OpenRouter),
+            Some("anthropic/claude-opus-4.8")
+        );
+        assert_eq!(
+            ModelTier::Haiku.resolve(ProviderId::OpenRouter),
+            Some("anthropic/claude-haiku-4.5")
+        );
+    }
+
+    #[test]
+    fn every_tier_resolves_on_anthropic() {
+        assert_eq!(
+            ModelTier::Analysis.resolve(ProviderId::Anthropic),
+            Some("claude-opus-4-8")
+        );
+        assert_eq!(
+            ModelTier::Interaction.resolve(ProviderId::Anthropic),
+            Some("claude-opus-4-8")
+        );
+        assert_eq!(
+            ModelTier::Haiku.resolve(ProviderId::Anthropic),
+            Some("claude-haiku-4-5-20251001")
+        );
+    }
+
+    /// Why: guessing an unverified Bedrock inference-profile id fails at call
+    /// time, not compile time, so the absence of a mapping is the intended
+    /// state and must be asserted rather than left to drift (#5971).
+    /// What: both opus-tier arms resolve to `None` on Bedrock.
+    #[test]
+    fn bedrock_opus_tiers_are_unmapped() {
+        assert_eq!(ModelTier::Analysis.resolve(ProviderId::Bedrock), None);
+        assert_eq!(ModelTier::Interaction.resolve(ProviderId::Bedrock), None);
+    }
+
+    #[test]
+    fn bedrock_haiku_resolves() {
+        assert_eq!(
+            ModelTier::Haiku.resolve(ProviderId::Bedrock),
+            Some("us.anthropic.claude-haiku-4-5-20251001-v1:0"),
+            "the date-stamped, version-suffixed profile is the only form Bedrock accepts"
+        );
+    }
+
+    #[test]
+    fn non_claude_providers_resolve_nothing() {
+        for provider in [
+            ProviderId::OpenAI,
+            ProviderId::Fireworks,
+            ProviderId::Together,
+            ProviderId::AtlasCloud,
+            ProviderId::Local,
+        ] {
+            for tier in ALL_TIERS {
+                assert_eq!(
+                    tier.resolve(provider),
+                    None,
+                    "{provider:?} hosts no Claude model, so {tier:?} must not resolve"
+                );
+            }
+        }
+    }
+
+    /// Why: the two tiers name the same model today and the obvious
+    /// simplification is to collapse them into one variant. The split is the
+    /// point — it lets analysis and interaction diverge later without touching
+    /// a caller — so a test pins that they stay separate values (#5971).
+    #[test]
+    fn analysis_and_interaction_are_distinct_variants() {
+        assert_ne!(ModelTier::Analysis, ModelTier::Interaction);
+        assert_eq!(
+            ModelTier::Analysis.resolve(ProviderId::OpenRouter),
+            ModelTier::Interaction.resolve(ProviderId::OpenRouter),
+            "both resolve to Opus 4.8 today (owner ruling 2026-08-18)"
+        );
+    }
+}

--- a/crates/trusty-common/tests/inference_foundation.rs
+++ b/crates/trusty-common/tests/inference_foundation.rs
@@ -266,3 +266,53 @@ async fn mock_http_server_serves_response() {
     let resp: ChatResponse = serde_json::from_str(&raw).expect("parse as ChatResponse");
     assert_eq!(resp.first_text().as_deref(), Some("from mock"));
 }
+
+// ─── Model-tier resolution (#5971) ───────────────────────────────────────────
+
+/// Why: `trusty-review` imports `ModelTier` from the flat `inference::`
+/// re-export, so the surface a consumer actually uses is what needs proving —
+/// the inline unit tests reach the module directly and would still pass if the
+/// re-export were dropped.
+/// What: resolves all three tiers through the public path for the two providers
+/// that have verified ids.
+#[test]
+fn model_tier_resolves_through_the_public_reexport() {
+    use trusty_common::inference::ModelTier;
+
+    assert_eq!(
+        ModelTier::Analysis.resolve(ProviderId::OpenRouter),
+        Some("anthropic/claude-opus-4.8")
+    );
+    assert_eq!(
+        ModelTier::Interaction.resolve(ProviderId::OpenRouter),
+        Some("anthropic/claude-opus-4.8")
+    );
+    assert_eq!(
+        ModelTier::Haiku.resolve(ProviderId::OpenRouter),
+        Some("anthropic/claude-haiku-4.5")
+    );
+    assert_eq!(
+        ModelTier::Analysis.resolve(ProviderId::Anthropic),
+        Some("claude-opus-4-8")
+    );
+    assert_eq!(
+        ModelTier::Haiku.resolve(ProviderId::Anthropic),
+        Some("claude-haiku-4-5-20251001")
+    );
+}
+
+/// Why: a later change that "completes the table" by guessing Bedrock's Opus
+/// 4.8 inference-profile id would ship a string that fails at call time, not
+/// compile time. The gap is the ruled outcome (#5971), so it is asserted.
+/// What: both opus arms are `None` on Bedrock; the haiku arm still resolves.
+#[test]
+fn model_tier_bedrock_opus_stays_unmapped_and_haiku_does_not() {
+    use trusty_common::inference::ModelTier;
+
+    assert_eq!(ModelTier::Analysis.resolve(ProviderId::Bedrock), None);
+    assert_eq!(ModelTier::Interaction.resolve(ProviderId::Bedrock), None);
+    assert_eq!(
+        ModelTier::Haiku.resolve(ProviderId::Bedrock),
+        Some("us.anthropic.claude-haiku-4-5-20251001-v1:0")
+    );
+}

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -15,7 +15,7 @@ name = "trusty-gworkspace-mcp"
 path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.36", features = ["mcp"] }
+trusty-common = { path = "../trusty-common", version = "0.37", features = ["mcp"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -81,7 +81,7 @@ path = "src/bin/mcp_bridge.rs"
 # the index itself rather than a UDS client for a subprocess that holds it.
 # `uds-supervisor` is NOT dropped — trusty-console and trusty-agents still
 # depend on the shared `UdsServiceSupervisor` for trusty-review / trusty-analyze.
-trusty-common = { path = "../trusty-common", version = "0.36", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve"] }
+trusty-common = { path = "../trusty-common", version = "0.37", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console
 # is no longer bundled into trusty-memory (single-owner-per-binary); the
@@ -173,7 +173,7 @@ serial_test = { workspace = true }
 # the production library (mirrors the trusty-mpm and trusty-search pattern).
 # `docgen` (#5205 follow-up): `tests/generated_docs.rs` renders the MCP tool
 # section of README.md from `tool_definitions()`.
-trusty-common = { path = "../trusty-common", version = "0.36", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
+trusty-common = { path = "../trusty-common", version = "0.37", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
 chrono = { workspace = true }
 
 [features]

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -14,7 +14,7 @@ name        = "trusty-review"
 # synthesize_prompt.rs's prompt text (adds a coverage-gaps instruction). No
 # public API changed; the `PR version bump vs crates.io` gate (#4421) still
 # requires the bump since `src/**` changed.
-version     = "0.18.1"
+version     = "0.19.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/5971-roles-resolve-model-tiers.md
+++ b/crates/trusty-review/changelog.d/5971-roles-resolve-model-tiers.md
@@ -1,0 +1,17 @@
+Changed
+
+- The three roles ask for a model tier instead of naming a pinned id: reviewer →
+  analysis tier, verifier and summarizer → haiku tier. On OpenRouter the
+  reviewer now resolves Opus 4.8, so the model that does the judging is an opus
+  model rather than the Bedrock Sonnet 4.6 id it fell back to before.
+- The haiku roles resolve the same model as before —
+  `us.anthropic.claude-haiku-4-5-20251001-v1:0` on Bedrock. What changed is that
+  a date-stamped constant became a tier lookup, so a future haiku move is one
+  edit in `trusty-common` rather than three here.
+- Bedrock's opus tiers are unmapped, so a standalone Bedrock run keeps its
+  Sonnet 4.6 reviewer default. The trusty-audit path configures OpenRouter and
+  gets Opus 4.8.
+- `--reviewer-model`, `TRUSTY_REVIEW_*_MODEL`, and the config file's
+  `[models.*].model` are unaffected. The tier is the built-in layer, below all
+  three, so an explicitly-named id still wins. The provider now resolves before
+  the model so the tier has a provider to key on.

--- a/crates/trusty-review/src/config/config_tests.rs
+++ b/crates/trusty-review/src/config/config_tests.rs
@@ -498,5 +498,137 @@ fn role_models_unparsable_provider_at_every_layer_falls_back_to_default() {
     assert_eq!(roles.reviewer.provider, Provider::Bedrock);
 }
 
+// ─── Model-tier resolution (#5971) ───────────────────────────────────────────
+
+#[test]
+fn provider_maps_to_common_provider_id() {
+    use trusty_common::inference::ProviderId;
+    assert_eq!(Provider::OpenRouter.provider_id(), ProviderId::OpenRouter);
+    assert_eq!(Provider::Bedrock.provider_id(), ProviderId::Bedrock);
+    assert_eq!(Provider::Fireworks.provider_id(), ProviderId::Fireworks);
+}
+
+/// Why: the reviewer is the role that does the judging, and the owner ruled it
+/// runs on the opus tier. On OpenRouter — the provider the trusty-audit path
+/// uses for all inference — that tier has a verified id, so the reviewer must
+/// come out as Opus 4.8 rather than the pinned Bedrock Sonnet default (#5971).
+/// What: selects OpenRouter with no model named at any layer.
+#[test]
+fn role_models_openrouter_reviewer_resolves_opus_tier() {
+    let env = RoleEnv {
+        provider: Some("openrouter".to_string()),
+        ..Default::default()
+    };
+    let roles = RoleModels::from_env(&env);
+    assert_eq!(roles.reviewer.provider, Provider::OpenRouter);
+    assert_eq!(roles.reviewer.model, "anthropic/claude-opus-4.8");
+}
+
+#[test]
+fn role_models_openrouter_haiku_roles_resolve_haiku_tier() {
+    let env = RoleEnv {
+        provider: Some("openrouter".to_string()),
+        ..Default::default()
+    };
+    let roles = RoleModels::from_env(&env);
+    assert_eq!(roles.verifier.model, "anthropic/claude-haiku-4.5");
+    assert_eq!(roles.summarizer.model, "anthropic/claude-haiku-4.5");
+}
+
+/// Why: Bedrock's Opus 4.8 inference-profile id could not be verified and is
+/// deliberately unmapped, so the tier lookup declines and trusty-review must
+/// keep the Sonnet 4.6 profile it defaulted to before #5971. A regression here
+/// would ship an id that fails at call time, not compile time.
+/// What: default provider (Bedrock) with no model named at any layer.
+#[test]
+fn role_models_bedrock_reviewer_keeps_sonnet_default() {
+    let roles = RoleModels::from_env(&RoleEnv::default());
+    assert_eq!(roles.reviewer.provider, Provider::Bedrock);
+    assert_eq!(
+        roles.reviewer.model,
+        crate::llm::models::DEFAULT_REVIEWER_MODEL,
+        "Bedrock's opus tiers are unmapped by ruling — the pinned Sonnet default must survive"
+    );
+    assert_eq!(roles.reviewer.model, "us.anthropic.claude-sonnet-4-6");
+}
+
+/// Why: the haiku roles' resolved value must not change — only the mechanism
+/// producing it (a date-stamped constant became a tier lookup) (#5971).
+#[test]
+fn role_models_bedrock_haiku_roles_resolve_the_same_id_as_before() {
+    let roles = RoleModels::from_env(&RoleEnv::default());
+    for (role, model) in [
+        ("verifier", &roles.verifier.model),
+        ("summarizer", &roles.summarizer.model),
+    ] {
+        assert_eq!(
+            model, "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "{role} must still resolve the date-versioned Bedrock Haiku profile"
+        );
+    }
+}
+
+/// Why: a tier default that outranked an explicitly-named model id would break
+/// `--reviewer-model`, `TRUSTY_REVIEW_REVIEWER_MODEL`, and the config file's
+/// `[models.reviewer].model` — the three layers spec REV-313 puts above the
+/// built-in default. The tier is the built-in layer, nothing more (#5971).
+/// What: on OpenRouter (where the tier DOES resolve, so it could win), each of
+/// the three explicit layers is asserted to beat it.
+#[test]
+fn role_models_explicit_model_beats_tier_default() {
+    let openrouter = || RoleEnv {
+        provider: Some("openrouter".to_string()),
+        ..Default::default()
+    };
+
+    // CLI flag.
+    let cli = RoleCliOverrides {
+        reviewer_model: Some("openai/gpt-5.4-20260305".to_string()),
+        ..Default::default()
+    };
+    let roles = RoleModels::resolve(Some(&cli), &openrouter(), None);
+    assert_eq!(roles.reviewer.model, "openai/gpt-5.4-20260305");
+
+    // Env var.
+    let env = RoleEnv {
+        reviewer_model: Some("openai/gpt-5.4-mini-20260317".to_string()),
+        ..openrouter()
+    };
+    let roles = RoleModels::from_env(&env);
+    assert_eq!(roles.reviewer.model, "openai/gpt-5.4-mini-20260317");
+
+    // Config file.
+    let file = FileModels {
+        reviewer: Some(RoleConfigOverride {
+            model: Some("openai/gpt-5.4-nano-20260317".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let roles = RoleModels::resolve(None, &openrouter(), Some(&file));
+    assert_eq!(roles.reviewer.model, "openai/gpt-5.4-nano-20260317");
+}
+
+/// Why: Fireworks hosts no Claude model, so every tier declines there and the
+/// pinned built-in defaults must still apply — the tier layer must never leave
+/// a role with no model at all (#5971).
+#[test]
+fn role_models_fireworks_falls_back_to_pinned_defaults() {
+    let env = RoleEnv {
+        provider: Some("fireworks".to_string()),
+        ..Default::default()
+    };
+    let roles = RoleModels::from_env(&env);
+    assert_eq!(roles.reviewer.provider, Provider::Fireworks);
+    assert_eq!(
+        roles.reviewer.model,
+        crate::llm::models::DEFAULT_REVIEWER_MODEL
+    );
+    assert_eq!(
+        roles.verifier.model,
+        crate::llm::models::DEFAULT_VERIFIER_MODEL
+    );
+}
+
 // resolve_index and wiring-path tests are in the sibling file to stay under
 // the 500-line cap (#610).  See `config_resolve_index_tests.rs`.

--- a/crates/trusty-review/src/config/mod.rs
+++ b/crates/trusty-review/src/config/mod.rs
@@ -69,6 +69,26 @@ pub enum Provider {
     Fireworks,
 }
 
+impl Provider {
+    /// The `trusty-common` provider identity this backend corresponds to.
+    ///
+    /// Why: `ModelTier::resolve` keys off `trusty_common`'s `ProviderId`, and
+    /// this crate's `Provider` is a narrower enum covering only the three
+    /// backends trusty-review builds clients for. The tier lookup needs the
+    /// shared identity, so the two are bridged in one place rather than at each
+    /// call site (#5971).
+    /// What: a total mapping — every `Provider` variant has a `ProviderId`.
+    /// Test: `provider_maps_to_common_provider_id`.
+    pub fn provider_id(&self) -> trusty_common::inference::ProviderId {
+        use trusty_common::inference::ProviderId;
+        match self {
+            Provider::OpenRouter => ProviderId::OpenRouter,
+            Provider::Bedrock => ProviderId::Bedrock,
+            Provider::Fireworks => ProviderId::Fireworks,
+        }
+    }
+}
+
 impl std::fmt::Display for Provider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/trusty-review/src/config/role_models.rs
+++ b/crates/trusty-review/src/config/role_models.rs
@@ -11,6 +11,7 @@
 
 use serde::{Deserialize, Serialize};
 use tracing::warn;
+use trusty_common::inference::ModelTier;
 
 use super::Provider;
 
@@ -80,8 +81,11 @@ impl RoleModels {
     /// What: each role's fields are resolved independently.  `cli_overrides`
     /// carries any values the caller parsed from `--reviewer-model` etc.
     /// `file_models` carries parsed TOML table values.  Both may be `None` to
-    /// skip that layer.
-    /// Test: unit tests in `config::tests` cover all four precedence levels.
+    /// skip that layer.  The built-in default is a `ModelTier` (#5971): the
+    /// reviewer asks for `Analysis`, the verifier and summarizer for `Haiku`,
+    /// and the tier resolves against whichever provider won its own chain.
+    /// Test: unit tests in `config::tests` cover all four precedence levels;
+    /// the tier layer by `role_models_openrouter_*` / `role_models_bedrock_*`.
     pub fn resolve(
         cli_overrides: Option<&RoleCliOverrides>,
         env: &RoleEnv,
@@ -93,6 +97,7 @@ impl RoleModels {
             env.reviewer_model.as_deref(),
             env.provider.as_deref(),
             file_models.and_then(|f| f.reviewer.as_ref()),
+            ModelTier::Analysis,
             crate::llm::models::DEFAULT_REVIEWER_MODEL,
             Provider::Bedrock,
             0.3,
@@ -104,6 +109,7 @@ impl RoleModels {
             env.verifier_model.as_deref(),
             env.provider.as_deref(),
             file_models.and_then(|f| f.verifier.as_ref()),
+            ModelTier::Haiku,
             crate::llm::models::DEFAULT_VERIFIER_MODEL,
             Provider::Bedrock,
             1.0,
@@ -115,6 +121,7 @@ impl RoleModels {
             env.summarizer_model.as_deref(),
             env.provider.as_deref(),
             file_models.and_then(|f| f.summarizer.as_ref()),
+            ModelTier::Haiku,
             crate::llm::models::DEFAULT_SUMMARIZER_MODEL,
             Provider::Bedrock,
             0.0,
@@ -243,9 +250,14 @@ fn parse_provider_layer(raw: Option<&str>, source: &str) -> Option<Provider> {
 /// What: each parameter is one precedence level; the first `Some` wins.  For
 /// `provider`, a layer that is present but does not parse as a `Provider`
 /// counts as absent and yields to the next layer (#5679) — it never consumes
-/// the chain.
+/// the chain.  The provider is resolved BEFORE the model so the built-in model
+/// default can be a tier lookup against the resolved provider (#5971); the
+/// three explicit layers above it are unaffected, because the tier is only
+/// consulted once CLI, env, and config file have all declined.
 /// Test: covered indirectly by `RoleModels` unit tests; the provider
-/// parse-failure arm is covered by the `role_models_unparsable_*` tests.
+/// parse-failure arm is covered by the `role_models_unparsable_*` tests; the
+/// tier arm by `role_models_openrouter_reviewer_resolves_opus_tier` and
+/// `role_models_bedrock_reviewer_keeps_sonnet_default`.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn resolve_role(
     cli_model: Option<&str>,
@@ -253,18 +265,12 @@ pub(super) fn resolve_role(
     env_model: Option<&str>,
     env_provider: Option<&str>,
     file: Option<&RoleConfigOverride>,
+    default_tier: ModelTier,
     default_model: &str,
     default_provider: Provider,
     default_temp: f32,
     default_max_tokens: u32,
 ) -> RoleConfig {
-    // Model: CLI → env → config file → built-in default.
-    let model = cli_model
-        .or(env_model)
-        .or(file.and_then(|f| f.model.as_deref()))
-        .unwrap_or(default_model)
-        .to_string();
-
     // Provider: CLI → env → config file → built-in default.
     // #5679: each layer parses on its own so a bad value yields the next layer, not the default.
     let provider = parse_provider_layer(cli_provider, "--provider")
@@ -276,6 +282,18 @@ pub(super) fn resolve_role(
             )
         })
         .unwrap_or(default_provider);
+
+    // Model: CLI → env → config file → tier default → pinned built-in default.
+    // #5971: the tier is the built-in layer, so an explicitly-named id at any of
+    // the three layers above still wins. `default_model` remains the fallback
+    // for a (tier, provider) pair with no verified id — notably Bedrock's opus
+    // tiers, which are deliberately unmapped.
+    let model = cli_model
+        .or(env_model)
+        .or(file.and_then(|f| f.model.as_deref()))
+        .or_else(|| default_tier.resolve(provider.provider_id()))
+        .unwrap_or(default_model)
+        .to_string();
 
     // Temperature: config file → built-in default.
     let temperature = file.and_then(|f| f.temperature).unwrap_or(default_temp);

--- a/crates/trusty-review/src/llm/models.rs
+++ b/crates/trusty-review/src/llm/models.rs
@@ -10,6 +10,14 @@
 //! not access-granted in the target account; the three confirmed-available
 //! ids replace it.
 //!
+//! #5971 demoted these constants one rung: the built-in model default is now a
+//! `trusty_common::inference::ModelTier` lookup against the resolved provider,
+//! and a constant here applies only when that (tier, provider) pair has no
+//! verified id. Which is why the reviewer default below still describes
+//! Bedrock: the tier layer resolves Opus 4.8 on OpenRouter and the Anthropic
+//! first-party API, but Bedrock's Opus 4.8 inference-profile id is deliberately
+//! unmapped, so a standalone Bedrock run falls through to Sonnet 4.6 here.
+//!
 //! DEFAULT PROVIDER: Bedrock (effective as of this file's introduction).
 //!   - Reviewer:   `us.anthropic.claude-sonnet-4-6`              (verified)
 //!   - Verifier:   `us.anthropic.claude-haiku-4-5-20251001-v1:0` (verified)
@@ -53,6 +61,9 @@
 /// What: `us.anthropic.claude-sonnet-4-6` is the Claude Sonnet 4.6 cross-region
 /// inference profile for the US geography.  No date stamp or `-v1:0` suffix
 /// (verified against AWS docs as of May 2026).
+/// Since #5971 this is reached only when `ModelTier::Analysis` declines for the
+/// resolved provider — in practice, Bedrock, whose Opus 4.8 profile id is
+/// unmapped by ruling.  On OpenRouter the reviewer resolves Opus 4.8 instead.
 /// Override via `TRUSTY_REVIEW_REVIEWER_MODEL`.
 pub const DEFAULT_REVIEWER_MODEL: &str = "us.anthropic.claude-sonnet-4-6";
 


### PR DESCRIPTION
Closes #5971. Implements the owner rulings in the issue body and the 2026-08-18 rulings comment.

## What changed

`trusty-common` gains `inference::ModelTier` — three tiers (analysis, interaction, haiku) and `ModelTier::resolve(self, provider: ProviderId) -> Option<&'static str>`. It sits beside epic #2400's provider resolution: the configurator answers which provider and how to reach it, this answers which model on that provider.

trusty-review's roles ask for a tier: reviewer → analysis, verifier → haiku, summarizer → haiku. On OpenRouter the reviewer resolves Opus 4.8, so the model that does the judging is an opus model; before, it fell through to the Bedrock Sonnet 4.6 id regardless of provider. The haiku roles resolve the same string as before — a date-stamped constant became a tier lookup.

`resolve_role` resolves the provider before the model, because the tier needs a provider to key on. `Option`, not `Result`: `ReviewConfig::from_env_and_file` returns `Self`, so an error type would ripple through roughly ten call sites in `config_tests.rs`.

Analysis and interaction resolve to the same model today and stay two distinct variants so they can diverge later without touching a caller.

## Bedrock's opus tiers are unmapped, by ruling

`ModelTier::Analysis` and `ModelTier::Interaction` return `None` on Bedrock. The Opus 4.8 inference-profile id could not be verified — `aws bedrock list-inference-profiles` has no credentials in this environment, and AWS moved the per-model ids off their doc pages. The shape is not derivable from the family name, and this table shows it both directions: `us.anthropic.claude-sonnet-4-6` works bare while the Haiku 4.5 profile needs both a date stamp and a `-v1:0` suffix. An invented id fails at call time, not compile time.

So a standalone Bedrock run keeps its Sonnet 4.6 reviewer default. The trusty-audit path configures trusty-review through `engagement.toml`'s `[models]` table and the four `TRUSTY_REVIEW_*` variables against OpenRouter, so it resolves Opus 4.8. `model_tier_bedrock_opus_stays_unmapped_and_haiku_does_not` and `role_models_bedrock_reviewer_keeps_sonnet_default` assert the gap so a later change cannot quietly fill it with a guess.

## Model ids and where each came from

| Provider | analysis / interaction | haiku | Source |
|---|---|---|---|
| OpenRouter | `anthropic/claude-opus-4.8` | `anthropic/claude-haiku-4.5` | live `GET https://openrouter.ai/api/v1/models`, 2026-08-18 |
| Anthropic | `claude-opus-4-8` | `claude-haiku-4-5-20251001` | `claude-api` model reference |
| Bedrock | unmapped → `None` | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | carried from `trusty-review/src/llm/models.rs`, verified against a live account |

Fireworks, OpenAI, Together, AtlasCloud and Local host no Claude model and return `None` for every tier, so their callers keep the pinned defaults.

## Precedence is intact

The tier is the built-in layer, below CLI flag, env var, and config file. `role_models_explicit_model_beats_tier_default` asserts all three beat it on OpenRouter, where the tier does resolve and so could win. Inverting the ordering in `resolve_role` makes it fail:

```
test config::tests::role_models_explicit_model_beats_tier_default ... FAILED
assertion `left == right` failed
  left: "anthropic/claude-opus-4.8"
 right: "openai/gpt-5.4-20260305"
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1608 filtered out
```

## Gates — ladder rung 4 (cross-crate, shared library)

```
cargo fmt --check                                                 EXIT=0
cargo check -p trusty-common --features inference-client          EXIT=0
cargo check -p trusty-review                                      EXIT=0
cargo check --workspace                                           EXIT=0
cargo clippy -p trusty-common --features inference-client --all-targets -- -D warnings   EXIT=0
cargo clippy -p trusty-review --all-targets -- -D warnings        EXIT=0
```

`cargo test -p trusty-common --features inference-client` — `inference-client` is the feature the new module sits behind; the bare form is a `compile_error!`:

```
test inference::tier::tests::analysis_and_interaction_are_distinct_variants ... ok
test inference::tier::tests::bedrock_haiku_resolves ... ok
test inference::tier::tests::bedrock_opus_tiers_are_unmapped ... ok
test inference::tier::tests::every_tier_resolves_on_anthropic ... ok
test inference::tier::tests::every_tier_resolves_on_openrouter ... ok
test inference::tier::tests::non_claude_providers_resolve_nothing ... ok
test result: ok. 579 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out

test model_tier_bedrock_opus_stays_unmapped_and_haiku_does_not ... ok
test model_tier_resolves_through_the_public_reexport ... ok
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo test -p trusty-review`:

```
test config::tests::provider_maps_to_common_provider_id ... ok
test config::tests::role_models_bedrock_haiku_roles_resolve_the_same_id_as_before ... ok
test config::tests::role_models_bedrock_reviewer_keeps_sonnet_default ... ok
test config::tests::role_models_fireworks_falls_back_to_pinned_defaults ... ok
test config::tests::role_models_openrouter_haiku_roles_resolve_haiku_tier ... ok
test config::tests::role_models_explicit_model_beats_tier_default ... ok
test config::tests::role_models_openrouter_reviewer_resolves_opus_tier ... ok
test result: ok. 1604 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out
```

Repo gates:

```
bash scripts/check_line_cap.sh
  line-cap: measured 4074 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
bash scripts/check_sld.sh
  sld-lint: scanned 60 spec doc(s) + 3334 code file(s); resolved 40 frontmatter + 37 inline reference(s); 0 error(s), 0 warning(s)
bash scripts/check_changelog_fragment.sh
  OK   trusty-common: changelog.d fragment present and valid
  OK   trusty-review: changelog.d fragment present and valid
```

## Versions

trusty-common 0.36.0 → 0.37.0, trusty-review 0.18.1 → 0.19.0. Minor in both, for a feature. `Cargo.lock`, the `[workspace.dependencies]` pins, and the three local `version = "0.36"` pins in `trusty-gworkspace` and `trusty-memory` are synced with them.

The workspace `cargo check` above is not evidence the published crates agree — the root path override pairs local source with local dependency (#4088). Nothing here is breaking to a published consumer: `ModelTier` is new, `Provider::provider_id` is additive, and the changed `resolve_role` signature is `pub(super)`. The release-time `cargo-semver-checks` gate is where that gets confirmed.

## Out of scope

trusty-analyze, trusty-mpm, trusty-agents, trusty-code, trusty-git-analytics and trusty-common's legacy `chat::` default keep their current pins, per ruling 1. Neither `crates/trusty-audit` nor `.github/workflows/release.yml` is touched — concurrent work owns both.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
