### PR TITLE
docs: point five intra-doc links at items that exist (#5973)

### DIFF
--- a/crates/trusty-agents-common/changelog.d/5973-sweep-locked-link.md
+++ b/crates/trusty-agents-common/changelog.d/5973-sweep-locked-link.md
@@ -1,0 +1,5 @@
+Documentation
+- `ManifestLoad` and `AgentManifest::load_checked` referred to
+  `quarantine::sweep_locked` as a rustdoc link. That function is private to its
+  own module, so no path resolves to it from `manifest` and the link rendered as
+  dead text. It is plain code text now (#5973).

--- a/crates/trusty-agents-common/src/agents/manifest.rs
+++ b/crates/trusty-agents-common/src/agents/manifest.rs
@@ -61,10 +61,10 @@ pub const MANIFEST_FILE: &str = ".trusty-mpm-manifest.json";
 /// `Corrupt` covers every non-`NotFound` outcome since #5626, not only a
 /// malformed or truncated document: `EACCES` on an unsearchable parent and a
 /// transient `EIO` leave ownership exactly as undetermined as a torn JSON
-/// document does, and the refusals downstream —
-/// [`crate::agents::quarantine::sweep_locked`]'s `CorruptLedger` above all —
-/// are the correct response to both. The variant's payload names the path and
-/// the underlying failure, so an operator still sees which one it was.
+/// document does, and the refusals downstream — `quarantine::sweep_locked`'s
+/// `CorruptLedger` above all — are the correct response to both. The variant's
+/// payload names the path and the underlying failure, so an operator still sees
+/// which one it was.
 /// Test: `manifest_load_corrupt_returns_corrupt`,
 /// `manifest_load_unreadable_returns_corrupt`.
 #[derive(Debug)]
@@ -355,9 +355,9 @@ impl AgentManifest {
     /// #5626: the `Err(_) => Ok(default)` arm this replaces made that reasoning
     /// hold for a malformed document only. An `EACCES` on the ledger — or a
     /// stale handle, or a transient `EIO` — took the benign arm and defeated
-    /// [`crate::agents::quarantine::sweep_locked`]'s `CorruptLedger` refusal
-    /// without a word, at which point a file the real ledger records as
-    /// user-owned reads as untracked and can be renamed to `.md.disabled`.
+    /// `quarantine::sweep_locked`'s `CorruptLedger` refusal without a word, at
+    /// which point a file the real ledger records as user-owned reads as
+    /// untracked and can be renamed to `.md.disabled`.
     ///
     /// What: reads `<target_dir>/.trusty-mpm-manifest.json`. `ErrorKind::NotFound`
     /// alone returns `ManifestLoad::Ok(default)`; a valid document returns

--- a/crates/trusty-installer/changelog.d/5973-install-report-link.md
+++ b/crates/trusty-installer/changelog.d/5973-install-report-link.md
@@ -1,0 +1,5 @@
+Documentation
+- `stable_set.rs` referred to the report module as `super::install_report`. The
+  module is declared inside `install.rs`, so its real path is
+  `commands::install::install_report` and the link resolved to nothing. Both
+  references are plain code text now (#5973).

--- a/crates/trusty-installer/src/commands/stable_set.rs
+++ b/crates/trusty-installer/src/commands/stable_set.rs
@@ -204,7 +204,7 @@ impl StableMember {
 /// Why (#5806): `filter(|r| required(r)).all(ok)` over zero required rows is
 /// vacuously `true`, so a selection of only OPTIONAL members reported success
 /// no matter what happened. The rule was written twice — once in
-/// [`super::install_report::InstallReport::build`] for `all_ok`, once in
+/// `install::install_report::InstallReport::build` for `all_ok`, once in
 /// [`super::verify_tail::VerifyTailReport::build`] for `verified` — and the
 /// first was fixed while the second kept failing open. It lives here now, so a
 /// third consumer inherits the fix rather than the bug.
@@ -329,7 +329,7 @@ pub fn manage_strategy_for(binary: &str, daemon: bool) -> ManageStrategy {
 /// the run or print a scary FAILED/exit-2 verdict. trusty-installer is
 /// OPTIONAL for a second reason: a bulk `tctl install` runs FROM a working
 /// installer, so failing to refresh that copy leaves the stack usable. Naming
-/// it explicitly is the different case, and [`super::install_report`]'s
+/// it explicitly is the different case, and `install::install_report`'s
 /// `all_ok` derivation handles it — a selection with no REQUIRED member gates
 /// on every member instead of vacuously passing.
 ///

--- a/crates/trusty-mpm/changelog.d/5973-gh-identity-link.md
+++ b/crates/trusty-mpm/changelog.d/5973-gh-identity-link.md
@@ -1,0 +1,9 @@
+Documentation
+- `resolve_gh_account_env_for_registry` still pointed at
+  `find_pinned_gh_account`, which #5864 renamed to `find_pinned_gh_identity`.
+  The doc names the current function now (#5973).
+- `PickerChoice::LaunchNew` linked `LaunchIsolation::OwnWorktree` by bare name,
+  but `session_picker` never imports that type — it re-exports four other items
+  from `picker_launch_new` and not this one. The link carries the full path now.
+  The failing lib doc had been hiding it: rustdoc never reached the `tm` binary
+  while `gh_account.rs` still failed (#5973).

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
@@ -83,7 +83,8 @@ pub(crate) enum PickerDecision {
     /// no-op. Never empty — an unusable name resolves to
     /// [`Self::UnusableName`] instead.
     ///
-    /// `isolation` is [`LaunchIsolation::OwnWorktree`] only when the operator
+    /// `isolation` is [`super::picker_launch_new::LaunchIsolation::OwnWorktree`]
+    /// only when the operator
     /// typed `--worktree`; ADR-0037 decision 1 makes that explicit request the
     /// one input deciding placement.
     LaunchNew(LaunchNewRequest),

--- a/crates/trusty-mpm/src/core/gh_account.rs
+++ b/crates/trusty-mpm/src/core/gh_account.rs
@@ -666,7 +666,7 @@ pub fn resolve_gh_account_env(
 /// here so every call site gets the warning for free.
 /// Test: `resolve_gh_account_env_for_registry_no_origin_is_empty`
 /// (`gh_account_spawn_env_tests.rs`); the registry-matching step is
-/// separately, directly tested via [`find_pinned_gh_account`] below.
+/// separately, directly tested via `find_pinned_gh_identity` below.
 pub async fn resolve_gh_account_env_for_registry(
     registry: &crate::project::ProjectRegistry,
     cwd: &std::path::Path,


### PR DESCRIPTION
Closes #5973.

`Pre-publish gate` run 32115349952 (commit `8cfdda3ab`) reported four broken
intra-doc links across three crates. None of the three has a baseline row, so
any nonzero count fails. **No baseline row was added** — all three stay at zero,
and `scripts/rustdoc-link-baseline.tsv` is untouched. No doc comment was deleted
to make a link disappear; every `.rs` change is a line-for-line rewrite of the
reference.

Fixing the four surfaced a fifth. rustdoc never reached trusty-mpm's `tm` binary
while the crate's lib doc still failed, so `session_picker.rs:86` was masked. It
is fixed here too — the gate is red until it is.

## Per link

**trusty-agents-common `src/agents/manifest.rs:65` and `:358` — exists, but not
public enough to link.** `sweep_locked` sits at exactly the path written, as a
bare `fn` private to `quarantine`. A `pub(crate)` item resolves from another
module and downgrades to a `private_intra_doc_links` warning; a module-private
one does not resolve at all, which is why rustdoc said `no item named
sweep_locked in module quarantine`. Both references are plain code text now,
matching what line 499 of the same file already does.

**trusty-installer `src/commands/stable_set.rs:332` — wrong path.** The module
is declared inside `install.rs` (`#[path = "install_report.rs"] mod
install_report;`), so it lives at `commands::install::install_report`, not
alongside `stable_set`. It is also a private `mod`, so no correct link exists
either; plain text is the fix. Line 207 carries the identical
`super::install_report` mistake and is fixed with it — rustdoc never reported
that one because it sits on a private `fn` rustdoc does not document.

**trusty-mpm `src/core/gh_account.rs:669` — renamed.** #5864 replaced
`find_pinned_gh_account` with `find_pinned_gh_identity`; the doc kept the old
name. The new function is private too, so it is named as plain text.

**trusty-mpm `src/bin/tm/commands/session_picker.rs:86` — not in scope.**
`LaunchIsolation` lives in the sibling `picker_launch_new`, and `session_picker`
re-exports four other items from it but not this one — which is why the
identical bare link in `guided_launch.rs:144`, which does import the type,
resolves fine. This one now carries the full path
`super::picker_launch_new::LaunchIsolation::OwnWorktree` and resolves with no
diagnostic.

## Rung and gates

Rung 1 — doc comments and changelog fragments only; no executable line changed,
so no Cargo test run is owed. `cargo check` is included anyway because three
crates' source files were edited.

```
bash scripts/check_rustdoc_links.sh
SUMMARY	25 crate(s) examined by rustdoc, 0 broken link(s), baseline 0, 0 diagnostic(s) examined
GATE1_EXIT=0

cargo fmt --check                         EXIT=0
cargo check -p trusty-agents-common       EXIT=0
cargo check -p trusty-installer           EXIT=0
cargo check -p trusty-mpm                 EXIT=0

bash scripts/check_line_cap.sh            EXIT=0
line-cap: measured 4074 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.

bash scripts/check_sld.sh                 EXIT=0
sld-lint: scanned 60 spec doc(s) + 3324 code file(s); resolved 40 frontmatter + 37 inline reference(s); 0 error(s), 0 warning(s)

bash scripts/check_changelog_fragment.sh  EXIT=0
OK   trusty-agents-common: changelog.d fragment present and valid
OK   trusty-installer: changelog.d fragment present and valid
OK   trusty-mpm: changelog.d fragment present and valid
changelog-fragment gate: scanned 7 changed path(s); attributed 4 crate-source path(s); all 3 crate(s) with source changes are recorded.
```

`check_rustdoc_links.sh` is Gate 1 of `.github/workflows/pre-publish.yml` run
verbatim, not an approximation. Its `25 crate(s) examined by rustdoc` is the
fail-closed evidence that rustdoc actually executed rather than serving a cached
no-op.

The changelog gate demanded a fragment for all three crates, so all three have
one under `crates/<crate>/changelog.d/5973-*.md`.

## Version bumps

None. Doc comments reach docs.rs with whatever release ships next, and nothing
here changes a public API or runtime behavior. A version exists to name a
release, not to record a comment edit. All three crates stay where they are.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
