### PR TITLE
chore(trusty-audit): bump version to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11296,7 +11296,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-audit"
-version = "0.5.0"
+version = "0.5.1"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"


### PR DESCRIPTION
## Summary
- Bumps `trusty-audit` from 0.5.0 to 0.5.1 (patch release, owner-authorized).
- Version field and `Cargo.lock` only — no source changes.
- `trusty-audit` is `publish = false`; this is a binary-release tag, not a crates.io publish.

## Test plan
- [x] `cargo check -p trusty-audit` — passes, regenerated `Cargo.lock` entry to 0.5.1.
- [x] `bash scripts/check_changelog_fragment.sh` — reports no crate source changed (Cargo.toml/Cargo.lock aren't under `src/**`), gate passes without a fragment.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools