### PR TITLE
fix(ci): let the ignored-test gate's build output reach the log

### DIFF
--- a/scripts/check_ignored_tests.sh
+++ b/scripts/check_ignored_tests.sh
@@ -107,12 +107,26 @@ if [ -n "$FROM_LIST" ]; then
   cp "$FROM_LIST" "$TMP_LIST"
 else
   echo "==> enumerating ignored tests (cargo nextest list --run-ignored ignored-only)" >&2
+  # #5890: stderr used to go to /dev/null here, with no comment recorded
+  # anywhere justifying the discard (checked git blame on this line — it has
+  # had exactly one author, in the commit that introduced this file, #5731).
+  # `--message-format json` on STDOUT is what the STEP 2 parser reads, so that
+  # redirect stays; STDERR is left to inherit the script's own stderr instead.
+  # Cargo's non-tty build output is one "Compiling <crate>" line per crate as
+  # each finishes — exactly the periodic progress signal that tells a slow
+  # build apart from a hang — and on a failure those lines are the compiler
+  # diagnostics that used to be thrown away, already sitting in the job log
+  # above the [FAIL] line below rather than needing to be captured and
+  # replayed. Letting it inherit is not noise: it is the same build log any
+  # plain `cargo build` in CI would print, and there is no cap to size because
+  # nothing here re-buffers or truncates it.
   rc=0
   SKIP_UI_BUILD=1 cargo nextest list --workspace --locked "${EXCLUDES[@]}" \
-    --run-ignored ignored-only --message-format json > "$TMP_LIST" 2>/dev/null || rc=$?
+    --run-ignored ignored-only --message-format json > "$TMP_LIST" || rc=$?
   if [ "$rc" -ne 0 ]; then
     echo "[FAIL] ignored-tests: 'cargo nextest list' exited ${rc} — the gate enumerated nothing." >&2
-    echo "       A zero count from a failed enumeration is not a finding. Fix the build and re-run." >&2
+    echo "       A zero count from a failed enumeration is not a finding. See the compiler output" >&2
+    echo "       above for why the build failed, fix it, and re-run." >&2
     exit 3
   fi
 fi


### PR DESCRIPTION
## What

`scripts/check_ignored_tests.sh` STEP 1 ran `cargo nextest list --message-format json` with `2>/dev/null` on the enumeration build. That redirect had two costs: a slow build looked identical to a hang (nothing printed between "enumerating" and completion), and a failed build reported only `'cargo nextest list' exited 101 — the gate enumerated nothing`, with every compiler diagnostic thrown away. Both symptoms trace to the same line.

`git blame` on that line shows exactly one author, from the commit that introduced the file (#5731) — no comment anywhere records a reason for silencing stderr.

## Fix

Drop the `2>/dev/null` entirely; STDERR now inherits the script's own stderr instead of being captured or buffered. `--message-format json` on STDOUT is what the STEP 2 python parser reads, so that redirect is untouched — only STDERR changes. Cargo's non-tty build output prints one `Compiling <crate>` line per crate as it finishes, which is the periodic progress signal that tells a slow build apart from a hang, and doubles as the failure diagnostic on a red run — it's already in the job log, above the `[FAIL]` line, with nothing to capture, cap, or replay. The `[FAIL]` message now points at "the compiler output above" instead of just naming the exit code.

No cap on the output — there's nothing left to overflow, since it streams straight through rather than being buffered by the script.

The gate's existing diagnostic line, "A zero count from a failed enumeration is not a finding," is unchanged.

## Verification

**Healthy run** — `bash scripts/check_ignored_tests.sh --list-only` on a clean tree (full cold build, no `target/` present at start; `Finished` in 18m08s):

```
==> enumerating ignored tests (cargo nextest list --run-ignored ignored-only)
warning: .../trusty-audit/Cargo.toml: file .../trusty-audit/src/main.rs found to be present in multiple build targets:
  * `bin` target `taudit`
  * `bin` target `trusty-audit`
   Compiling openssl-sys v0.9.116
   Compiling trusty-code v0.3.0 (.../crates/trusty-code)
   ... (25 "Compiling <crate>" lines total, one per crate as it finishes)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 18m 08s
SUMMARY	155 ignored test(s) in the workspace; 11 selected to RUN; 144 NOT run (baseline 148)
UNSELECTED	trusty-search	41
UNSELECTED	trusty-common	26
... (12 more UNSELECTED rows, one per crate)
NOTE	IMPROVED	144 unselected vs baseline 148 — lower '# UNSELECTED-BASELINE:' in the manifest to lock the gain in
[PASS] ignored-tests: reconciliation only (--list-only); no test was executed.
EXIT=0
```

This confirms two things at once: build progress streams live during STEP 1 (the "Compiling" lines, previously silent), and the STEP 2 JSON parser still works — STDOUT stayed clean, so the redirect split is correct.

**Induced-failure run** — a temporary syntax error was appended to `crates/trusty-common/src/lib.rs` (`fn __induced_syntax_error_issue_5890( {`) and the script re-run. This is partial evidence, stated plainly: the run confirmed live streaming — 846 lines of real-time `Compiling <crate>` progress reached the terminal during the build, where the old code produced nothing — but the run was still in progress (past 12 minutes, well beyond the failing crate's own compile) when it was interrupted and had to be killed before the compiler's actual error diagnostic surfaced in the captured output. The induced break was reverted (`git checkout -- crates/trusty-common/src/lib.rs`; confirmed via `git status --porcelain`) rather than re-run, per direction to prefer the healthy-run evidence over a second long induced-failure attempt for what is a one-line redirect removal. The mechanism — STDERR inheriting the script's own stderr instead of `/dev/null` — is not conditional on the failure mode, so the healthy run's proof that stderr now reaches the terminal live covers the failure path by construction: whatever cargo would have printed on error, it prints the same way it printed the "Compiling" lines, live and in full.

## Note on CI

`Pre-publish gate` is expected to be RED on `main` right now for the underlying build failure this issue is about (runs 32115349952 and 32048129537, exit 101 at ~5m20s, not yet diagnosed). This PR doesn't fix that failure — it fixes the gate's blindness to it. After this merges, the next occurrence will show the compiler's own diagnostic instead of just an exit code.

Closes #5890

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
