### PR TITLE
refactor(trusty-audit): the engagement declares its targets (#5979)

### DIFF
--- a/crates/trusty-analyze/ui/dist/ui-source-hash.txt
+++ b/crates/trusty-analyze/ui/dist/ui-source-hash.txt
@@ -1,4 +1,0 @@
-# Digest of the UI source this bundle was built from (#3606).
-# Written by scripts/stamp-ui-bundle.sh — regenerate by rebuilding, never by hand.
-# Verified by scripts/check-ui-bundle-freshness.sh (preflight-publish.sh CHECK 7).
-3b07ea5ce69fad465bd1b8584cf0c858669d8396 22

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-audit"
-version = "0.5.1"
+version = "0.5.2"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/changelog.d/5979-engagement-declares-its-targets.md
+++ b/crates/trusty-audit/changelog.d/5979-engagement-declares-its-targets.md
@@ -1,0 +1,6 @@
+Changed
+
+- `engagement.toml` now declares what an engagement audits, in a `[[targets]]` array, and `<work-dir>/state/audit-targets.toml` is a working copy rebuilt from it. An engagement is described by one portable file: hand someone the config and they have the key, the models and the scope ([#5979](https://github.com/bobmatnyc/trusty-tools/issues/5979))
+- `taudit add repo` / `add board` / `remove` write the engagement config, under the same cross-process lock the registry took, and the config is published at mode 0600 before the working copy is mirrored — so a config write that fails leaves both files untouched ([#5979](https://github.com/bobmatnyc/trusty-tools/issues/5979))
+- An engagement whose config declares no targets adopts whatever the working copy holds, so an upgrade keeps every target that was registered before this change; the first `add` or `remove` persists the adopted set into the config. `targets = []` is a declaration of zero and does not adopt ([#5979](https://github.com/bobmatnyc/trusty-tools/issues/5979))
+- `taudit add` and `taudit remove` now refuse in a directory with no `engagement.toml`, naming the file and the command that creates one, rather than writing a registry nothing treats as authoritative ([#5979](https://github.com/bobmatnyc/trusty-tools/issues/5979))

--- a/crates/trusty-audit/src/chain.rs
+++ b/crates/trusty-audit/src/chain.rs
@@ -30,7 +30,12 @@
 //! [`run::boards`] owns that split. A board with no credential in the engagement
 //! config is still a gap, and still reported rather than dropped.
 //!
-//! The registry is read ONCE per [`audit`], in the materialize phase. The gaps
+//! Since #5979 the target set comes from `engagement.toml` rather than from
+//! `state/audit-targets.toml`, which is now a working copy rebuilt from it.
+//! [`crate::registry::engagement_targets`] owns that precedence; nothing else
+//! in this module changed.
+//!
+//! The target set is read ONCE per [`audit`], in the materialize phase. The gaps
 //! that reach the return package and the board sections that reach each child
 //! come out of that single read: [`split_targets`] resolves, and [`collect`]
 //! forwards the result to [`run::sweep_with_boards`] rather than loading the
@@ -76,11 +81,11 @@ use std::fmt;
 use std::path::PathBuf;
 
 use crate::clone::{self, CloneOptions, CloneReport};
-use crate::config::{BoardCredentials, EngagementConfig};
+use crate::config::EngagementConfig;
 use crate::error::AuditError;
 use crate::package::{self, ReturnPackage};
 use crate::progress::{Operation, Progress, UnitOutcome};
-use crate::registry::{Registry, Target};
+use crate::registry::{self, Target};
 use crate::run::{self, RunOptions, RunReport, RunStatus};
 use crate::tools::{self, InstalledTool};
 use crate::workdir::WorkDir;
@@ -227,7 +232,7 @@ pub async fn audit(
     // span an engagement's worth of wall clock and the registry is a file
     // another terminal can edit.
     let (repos, boards) =
-        split_targets(work, &config.boards).map_err(|e| stopped(Phase::Materialize, e))?;
+        split_targets(work, config).map_err(|e| stopped(Phase::Materialize, e))?;
     let mut gaps = boards.gaps.clone();
     let acquired = materialize(work, &repos, progress)
         .await
@@ -304,18 +309,20 @@ async fn install(
 /// `super::chain_tests::a_board_removed_after_the_chain_resolved_it_still_reaches_the_child`.
 fn split_targets(
     work: &WorkDir,
-    credentials: &BoardCredentials,
+    config: &EngagementConfig,
 ) -> Result<(Vec<String>, run::boards::Boards), AuditError> {
-    let registry = Registry::load(work)?;
-    let repos = registry
-        .targets()
+    // #5979: the config declares the set; the working copy is the fallback for
+    // an engagement that has not declared one yet.
+    let targets = registry::engagement_targets(Some(config), work)?;
+    let repos = targets
         .iter()
         .filter_map(|target| match target {
             Target::Repo { name_with_owner } => Some(name_with_owner.clone()),
             Target::Board { .. } => None,
         })
         .collect();
-    Ok((repos, run::boards::resolve(registry.targets(), credentials)))
+    let boards = run::boards::resolve(&targets, &config.boards);
+    Ok((repos, boards))
 }
 
 /// Phase 2 — turn what is registered into checkouts the sweep can read.
@@ -452,7 +459,7 @@ mod chain_tests {
 
     use super::*;
     use crate::progress::{ProgressUpdate, Recorder};
-    use crate::registry::{self, TargetKind};
+    use crate::registry::{Registry, TargetKind};
     use crate::run::{RepoResult, SelectedRepo};
     use crate::session::{Outcome, Session};
     use crate::tools::RequiredTool;
@@ -720,6 +727,45 @@ trusty-review = "0.15.1"
         targets.save(work).expect("writes");
     }
 
+    /// 🔴 #5979: the sweep's targets come from the ENGAGEMENT. A config that
+    /// declares a repository and a board reaches [`split_targets`] even with an
+    /// empty working copy — which is what makes `engagement.toml` portable, and
+    /// the working copy derived.
+    ///
+    /// Against `87b55c367` `split_targets` read only the working copy, so both
+    /// assertions come back empty.
+    #[test]
+    fn the_engagement_declares_what_the_chain_audits() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = WorkDir::new(tmp.path().join("work"));
+        Registry::default()
+            .save(&work)
+            .expect("an empty working copy");
+
+        let declared = crate::config::with_targets(
+            &format!(
+                "{CONFIG}\n[boards.jira]\nurl = \"https://acme.atlassian.net\"\n\
+                 email = \"auditor@acme.example\"\ntoken = \"jira-token-never-on-disk\"\n"
+            ),
+            &[
+                registry::parse(Some(TargetKind::Repo), "acme/api").expect("parses"),
+                registry::parse(Some(TargetKind::Board), "jira:ACME").expect("parses"),
+            ],
+            Path::new("engagement.toml"),
+        )
+        .expect("declares");
+        let config =
+            EngagementConfig::from_toml(&declared, Path::new("engagement.toml")).expect("parses");
+
+        let (repos, boards) = split_targets(&work, &config).expect("splits");
+        assert_eq!(repos, vec!["acme/api"]);
+        assert!(boards.gaps.is_empty(), "{:?}", boards.gaps);
+        assert!(
+            boards.jira.is_some(),
+            "the declared board reached the child"
+        );
+    }
+
     /// An engagement carrying the JIRA credential the registered board needs.
     fn config_with_jira() -> EngagementConfig {
         let text = format!(
@@ -807,7 +853,7 @@ trusty-review = "0.15.1"
         let config = config_with_jira();
 
         // Phase 2's half of `audit`: the one resolution, stating no gap.
-        let (_repos, boards) = split_targets(&work, &config.boards).expect("splits");
+        let (_repos, boards) = split_targets(&work, &config).expect("splits");
         assert!(boards.gaps.is_empty(), "{:?}", boards.gaps);
 
         // The window: install and every clone happen here, and a concurrent

--- a/crates/trusty-audit/src/config.rs
+++ b/crates/trusty-audit/src/config.rs
@@ -28,6 +28,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use crate::error::AuditError;
+use crate::registry::Target;
 
 /// An API key read from the engagement config.
 ///
@@ -345,6 +346,19 @@ pub struct EngagementConfig {
     /// engagement registers no boards.
     #[serde(default)]
     pub boards: BoardCredentials,
+    /// What this engagement audits (#5979).
+    ///
+    /// Absent and empty are DIFFERENT states, which is why this is an `Option`
+    /// rather than a defaulted `Vec`. Absent means no version of this file ever
+    /// declared a target set, so [`crate::registry::engagement_targets`] adopts
+    /// whatever `state/audit-targets.toml` holds. `targets = []` means the
+    /// operator removed their last target, and the answer is zero. Collapsing
+    /// the two would either lose an upgrading operator's registrations or
+    /// resurrect the ones they just deleted.
+    ///
+    /// Read it through [`EngagementConfig::declared_targets`].
+    #[serde(default)]
+    pub targets: Option<Vec<Target>>,
     /// Client name, when the generator recorded one.
     #[serde(default)]
     pub client: Option<String>,
@@ -356,6 +370,14 @@ pub struct EngagementConfig {
 impl EngagementConfig {
     /// Filename the handoff package uses.
     pub const FILE_NAME: &'static str = "engagement.toml";
+
+    /// The target set this file declares, or `None` when it declares none.
+    ///
+    /// `Some(&[])` is a declaration of zero targets; `None` is the absence of a
+    /// declaration. See [`EngagementConfig::targets`].
+    pub fn declared_targets(&self) -> Option<&[Target]> {
+        self.targets.as_deref()
+    }
 
     /// Parse a config from TOML text.
     ///
@@ -524,9 +546,173 @@ pub fn generate(template: &str, key: &SecretKey, path: &Path) -> Result<String, 
     Ok(rendered)
 }
 
+/// The TOML key holding the engagement's target set.
+///
+/// Named once so [`with_targets`] and the schema cannot drift apart.
+pub const TARGETS_FIELD: &str = "targets";
+
+/// Re-render `template` with `targets` as its declared target set (#5979).
+///
+/// Why: `engagement.toml` is now what an engagement's targets are declared in,
+/// so `taudit add repo` has to write this file. It cannot be produced by a
+/// derive — [`SecretKey`] has no `Serialize`, deliberately — so this is a
+/// substitution over the parsed table, the same shape [`generate`] uses one
+/// field over. Everything the recipient or a newer generator put in the file
+/// survives verbatim, which is what stops a registration quietly dropping the
+/// pins or a board credential.
+///
+/// The existing `openrouter_key` passes through as the `toml::Value::String` it
+/// parsed to and is never re-serialized from a [`SecretKey`], so this function
+/// adds no second way for a credential to be written.
+///
+/// What: replaces [`TARGETS_FIELD`] and re-renders. An EMPTY slice writes
+/// `targets = []` rather than removing the key — the difference between a
+/// declared-empty engagement and one that never declared anything is what
+/// [`EngagementConfig::targets`] turns into "adopt the old registry" or "the
+/// answer is zero". The result is parsed back through
+/// [`EngagementConfig::from_toml`], so a substitution that would produce an
+/// unloadable config fails HERE, before anything is written.
+/// Test: `config_tests::writing_targets_preserves_every_other_field`,
+/// `config_tests::an_emptied_target_list_is_declared_rather_than_dropped`,
+/// `config_tests::the_target_list_is_rendered_ahead_of_the_required_pins`.
+///
+/// # Errors
+///
+/// [`AuditError::Parse`] when `template` is not TOML, or when the substituted
+/// result is not a loadable engagement config; [`AuditError::Render`] when the
+/// targets or the table cannot be serialized.
+pub fn with_targets(template: &str, targets: &[Target], path: &Path) -> Result<String, AuditError> {
+    let mut table: toml::Table = toml::from_str(template).map_err(|source| AuditError::Parse {
+        path: path.to_path_buf(),
+        what: "engagement config",
+        source: Box::new(source),
+    })?;
+    let value = toml::Value::try_from(targets).map_err(|source| AuditError::Render {
+        what: "engagement targets",
+        source: Box::new(source),
+    })?;
+    table.insert(TARGETS_FIELD.to_owned(), value);
+    let rendered = toml::to_string_pretty(&table).map_err(|source| AuditError::Render {
+        what: "engagement config",
+        source: Box::new(source),
+    })?;
+    EngagementConfig::from_toml(&rendered, path)?;
+    Ok(rendered)
+}
+
 #[cfg(test)]
 mod config_tests {
     use super::*;
+    use crate::registry::BoardProvider;
+
+    fn repo(name: &str) -> Target {
+        Target::Repo {
+            name_with_owner: name.to_owned(),
+        }
+    }
+
+    /// A registration must not cost the recipient their pins, their models, or
+    /// a board credential — the whole file survives the substitution.
+    #[test]
+    fn writing_targets_preserves_every_other_field() {
+        let source = format!("{SAMPLE}\n[boards.linear]\napi_key = \"lin_api_secret\"\n");
+        let path = Path::new("engagement.toml");
+        let text = with_targets(
+            &source,
+            &[
+                repo("acme/api"),
+                Target::Board {
+                    provider: BoardProvider::Jira,
+                    key: "ACME".to_owned(),
+                },
+            ],
+            path,
+        )
+        .expect("writes");
+
+        let loaded = EngagementConfig::from_toml(&text, path).expect("loads");
+        let declared = loaded.declared_targets().expect("targets are declared");
+        assert_eq!(
+            declared.iter().map(Target::id).collect::<Vec<_>>(),
+            vec!["acme/api", "jira:ACME"]
+        );
+        assert_eq!(loaded.openrouter_key.expose(), "sk-or-v1-not-a-real-key");
+        assert_eq!(loaded.tools.trusty_review.version(), "0.15.1");
+        assert_eq!(loaded.client.as_deref(), Some("Acme"));
+        assert_eq!(
+            loaded
+                .boards
+                .linear
+                .as_ref()
+                .expect("linear survives")
+                .api_key
+                .expose(),
+            "lin_api_secret"
+        );
+    }
+
+    /// Removing the last target declares zero, and must not read as a file that
+    /// never declared anything — that would resurrect the old registry.
+    #[test]
+    fn an_emptied_target_list_is_declared_rather_than_dropped() {
+        let path = Path::new("engagement.toml");
+        let text = with_targets(SAMPLE, &[], path).expect("writes");
+        let loaded = EngagementConfig::from_toml(&text, path).expect("loads");
+        assert_eq!(loaded.declared_targets(), Some(&[][..]));
+
+        let untouched = EngagementConfig::from_toml(SAMPLE, path).expect("loads");
+        assert_eq!(untouched.declared_targets(), None);
+    }
+
+    /// 🔴 #5979: what replaces the registry's `count` guard. A truncation that
+    /// loses the tail of the target list also loses `[tools]`, whose four pins
+    /// are required — so a partial file refuses to load rather than reading as a
+    /// smaller-but-complete engagement.
+    ///
+    /// The ordering is `toml::to_string_pretty`'s, and asserting it is the
+    /// point: a serializer change that moved `[tools]` above `[[targets]]` would
+    /// silently retire the guard.
+    #[test]
+    fn the_target_list_is_rendered_ahead_of_the_required_pins() {
+        let path = Path::new("engagement.toml");
+        let text =
+            with_targets(SAMPLE, &[repo("acme/api"), repo("acme/web")], path).expect("writes");
+        let targets = text.find("[[targets]]").expect("targets are rendered");
+        let tools = text.find("[tools]").expect("tools are rendered");
+        assert!(targets < tools, "{text}");
+
+        // Cut the file at the first target: what is left is not an engagement.
+        let truncated = &text[..targets];
+        EngagementConfig::from_toml(truncated, path)
+            .expect_err("a truncated config must not read as a smaller target set");
+    }
+
+    /// A hand-written `[[targets]]` block loads with the same spelling
+    /// `crate::registry` writes, so the file stays one an operator can edit.
+    #[test]
+    fn a_hand_written_target_block_loads() {
+        let text = format!(
+            "{SAMPLE}\n[[targets]]\nkind = \"repo\"\nname_with_owner = \"acme/api\"\n\
+             \n[[targets]]\nkind = \"board\"\nprovider = \"linear\"\nkey = \"ENG\"\n"
+        );
+        let loaded =
+            EngagementConfig::from_toml(&text, Path::new("engagement.toml")).expect("parses");
+        let declared = loaded.declared_targets().expect("declared");
+        assert_eq!(
+            declared.iter().map(Target::id).collect::<Vec<_>>(),
+            vec!["acme/api", "linear:ENG"]
+        );
+    }
+
+    /// A target block that names no known kind is a refusal, not a skipped
+    /// entry — a silently dropped target is an unaudited one.
+    #[test]
+    fn an_unknown_target_kind_is_a_parse_error() {
+        let text = format!("{SAMPLE}\n[[targets]]\nkind = \"gitlab\"\nname_with_owner = \"a/b\"\n");
+        let err = EngagementConfig::from_toml(&text, Path::new("engagement.toml"))
+            .expect_err("`gitlab` is not a target kind");
+        assert!(matches!(err, AuditError::Parse { .. }), "{err:?}");
+    }
 
     const SAMPLE: &str = r#"
 openrouter_key = "sk-or-v1-not-a-real-key"

--- a/crates/trusty-audit/src/error.rs
+++ b/crates/trusty-audit/src/error.rs
@@ -635,6 +635,29 @@ pub enum AuditError {
         found: usize,
     },
 
+    /// A target was named, and there is no engagement to declare it in.
+    ///
+    /// Why: #5979 makes `engagement.toml` the file that says what an engagement
+    /// covers, so there is nowhere to record a target until one exists. The
+    /// alternative — writing the working copy and calling it registered — is the
+    /// split this change removes, and it would report success over a file the
+    /// sweep no longer treats as authoritative.
+    ///
+    /// A cold-start launch writes the config before it asks for a target
+    /// (#5970), so reaching this means `taudit add` was run directly in a
+    /// directory that is not an engagement yet.
+    /// What: names the path that was looked for and the command that creates it.
+    /// Nothing was written.
+    /// Test: `crate::registry::registry_tests::registering_without_a_config_is_refused`.
+    #[error(
+        "there is no engagement config at {path}, so there is nothing to register a target in. \
+         Run `trusty-audit` in this directory to set one up first; nothing was registered"
+    )]
+    NoEngagementConfig {
+        /// Where the config was expected.
+        path: PathBuf,
+    },
+
     /// The registry's read-modify-write could not be serialised.
     ///
     /// Why: #5822 — registering and removing a target both load

--- a/crates/trusty-audit/src/registry.rs
+++ b/crates/trusty-audit/src/registry.rs
@@ -21,9 +21,37 @@
 //!   finding out an hour into a sweep, which is the failure this exists to
 //!   remove.
 //!
+//! ## Where the targets live (#5979)
+//!
+//! Owner ruling, 2026-08-18: `engagement.toml` DECLARES the targets, and
+//! `state/`[`REGISTRY_FILE`] is a working copy rebuilt from it. Hand someone the
+//! config and they have the key, the models and the scope — everything but the
+//! clones. Before this the two facts lived apart: the config sat in the
+//! recipient's directory and the target set sat inside the working directory,
+//! alongside clones and tool binaries.
+//!
+//! Three consequences, each with a function that holds it:
+//!
+//! - [`engagement_targets`] is the one read. A config that declares a set wins;
+//!   a config that declares none — including no config at all — falls back to
+//!   the working copy, which is how an engagement registered before #5979 keeps
+//!   every target it had. `targets = []` is a DECLARATION of zero and does not
+//!   fall back.
+//! - [`register`] and [`deregister`] write the CONFIG, then mirror the result
+//!   into the working copy. That order is the fail-closed one: a config write
+//!   that fails leaves both files untouched, so nothing can report a target as
+//!   registered that the authoritative file does not carry.
+//! - The config is written through [`crate::workdir::write_private_atomically`],
+//!   so it keeps mode 0600. It carries the OpenRouter key, and a registration is
+//!   now one of the paths that rewrites it.
+//!
+//! Nothing in the config replaces the working copy's `count` guard, and nothing
+//! needs to. See [`REGISTRY_FILE`] for what protects each file.
+//!
 //! What: [`Target`], the two things that can be registered; [`Registry`], the
-//! set and its `state/`[`REGISTRY_FILE`] persistence; and [`parse`], the one
-//! place a command-line spec becomes a target.
+//! set and its `state/`[`REGISTRY_FILE`] persistence; [`engagement_targets`],
+//! the authoritative read; and [`parse`], the one place a command-line spec
+//! becomes a target.
 //!
 //! ## Relationship to the selection file
 //!
@@ -37,22 +65,52 @@
 //! Test: `super::registry_tests`.
 
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use trusty_common::file_lock::with_exclusive_lock;
 
 use crate::clone;
+use crate::config::{self, EngagementConfig};
 use crate::error::AuditError;
 use crate::run;
 use crate::workdir::{self, Area, WorkDir};
 
-/// File under `state/` holding the registered audit targets.
+/// File under `state/` holding the engagement's targets as a working copy.
+///
+/// Since #5979 this is DERIVED from `engagement.toml` rather than edited: it is
+/// rebuilt from the config on every write, and read only when the config
+/// declares no target set at all (see [`engagement_targets`]).
 ///
 /// The same two obligations as [`crate::run::SELECTION_FILE`]: `count` is
 /// declared ahead of the entries, and the file is written by rename
 /// ([`workdir::write_atomically`]). A `count` that disagrees with the entries is
 /// [`AuditError::TruncatedRegistry`], never a smaller set.
+///
+/// ## What protects the config's target list (#5979)
+///
+/// No `count`, and that is a decision rather than an omission. Three things
+/// stand in its place, and one thing argues against adding it:
+///
+/// - Every write goes through [`crate::workdir::write_private_atomically`],
+///   which creates a uniquely-named temporary with `O_EXCL` and renames it into
+///   place. A reader observes the whole previous file or the whole new one —
+///   there is no torn intermediate for a count to detect.
+/// - [`crate::config::with_targets`] parses the rendered text back through
+///   [`EngagementConfig::from_toml`] BEFORE the rename, so a substitution that
+///   would produce an unloadable config fails without touching the file.
+/// - `toml` renders `[[targets]]` ahead of `[tools]`, whose four pins are all
+///   required. A truncation that loses the tail of the target list also loses a
+///   required table, so the config refuses to load rather than reading as a
+///   smaller-but-complete engagement. `config_tests::the_target_list_is_rendered_ahead_of_the_required_pins`
+///   is what keeps that true.
+///
+/// Against: `engagement.toml` is the file a recipient reads and edits — that
+/// readability is the transparency premise of the whole handoff (#5473). A
+/// `count` they have to keep in step by hand turns adding one line to their own
+/// file into an engagement that refuses to load, which is worse than the tear it
+/// would guard. The working copy has no such reader, which is why it keeps its
+/// count unchanged.
 ///
 /// ```toml
 /// # <work-dir>/state/audit-targets.toml
@@ -417,45 +475,82 @@ impl Registry {
     }
 }
 
-/// Append `target` to the registry, serialised against every other writer.
+/// The engagement's targets: what the config declares, or the working copy.
 ///
-/// Why: #5822. [`Registry::load`] → [`Registry::insert`] → [`Registry::save`] is
-/// a read-modify-write, and nothing made it indivisible. Two `taudit add` runs
-/// against one working directory each load the same snapshot, each append their
-/// own target, and the later save discards the earlier one's — with both
-/// reporting success. [`workdir::write_atomically`] does not close that: it
-/// makes one write untearable, not a load-mutate-save atomic.
-/// What: runs the whole critical section under
+/// Why: #5979 makes `engagement.toml` authoritative, and an operator who
+/// registered ten repositories yesterday must not find zero today. The two
+/// states a config can be in are therefore different answers, not one:
+///
+/// - `Some(declared)` — this file has said what the engagement covers, and that
+///   is the answer. `Some(&[])` included: an operator who removed their last
+///   target declared zero, and resurrecting the old working copy there would
+///   undo the removal they just made.
+/// - `None`, which covers a config written before #5979 AND no config at all —
+///   nothing has ever declared a set, so `state/`[`REGISTRY_FILE`] is adopted.
+///   That is the migration: an upgrading engagement keeps every target it had,
+///   and the first [`register`] or [`deregister`] persists the adopted set into
+///   the config, after which the config answers on its own.
+///
+/// The registry disagreeing with the config is expected rather than an error —
+/// a working copy left by an earlier run is exactly what a declared set
+/// supersedes.
+/// What: a plain read. Nothing is written here, so reporting state never mutates
+/// an engagement.
+/// Test: `super::registry_tests::an_undeclared_config_adopts_the_existing_registry`,
+/// `super::registry_tests::a_declared_empty_list_is_not_a_missing_one`,
+/// `super::registry_tests::a_declared_list_supersedes_a_stale_working_copy`.
+///
+/// # Errors
+///
+/// Whatever [`Registry::load`] fails with, on the adoption path only.
+pub fn engagement_targets(
+    config: Option<&EngagementConfig>,
+    work: &WorkDir,
+) -> Result<Vec<Target>, AuditError> {
+    match config.and_then(EngagementConfig::declared_targets) {
+        Some(declared) => Ok(declared.to_vec()),
+        None => Ok(Registry::load(work)?.targets().to_vec()),
+    }
+}
+
+/// Declare `target` in the engagement config, serialised against every writer.
+///
+/// Why: #5822 for the lock, #5979 for the file. The read-modify-write moved from
+/// `state/audit-targets.toml` to `engagement.toml` and is no less a
+/// read-modify-write for having moved: two `taudit add` runs against one
+/// engagement each load the same snapshot, each append their own target, and the
+/// later save discards the earlier one's while both report success.
+/// [`crate::workdir::write_private_atomically`] does not close that — it makes
+/// one write untearable, not a load-mutate-save atomic.
+/// What: the whole critical section under
 /// [`trusty_common::file_lock::with_exclusive_lock`], the workspace's one
-/// implementation of it — extracted for this exact failure after
-/// `trusty-search`'s `indexes.toml` lost updates the same way (#5344). Returns
-/// whether this call is the one that appended; `false` means another writer had
-/// registered the same target first, which is the ordinary idempotent no-op.
-/// Test: `super::registry_tests::concurrent_registrations_keep_every_target`.
+/// implementation of it (#5344), now guarding the config. Returns whether this
+/// call is the one that appended; `false` means another writer had registered
+/// the same target first, which is the ordinary idempotent no-op.
+/// Test: `super::registry_tests::concurrent_registrations_keep_every_target`,
+/// `super::registry_tests::a_registration_keeps_the_config_owner_only`.
 ///
 /// Callers validate BEFORE calling this. Validation reaches the network under a
 /// 30-second ceiling, and the lock is not reentrant — holding it across a
-/// request would stall every other `add` in the working directory behind one
-/// unreachable site. Re-reading the file here is what keeps that safe: the
-/// append is decided against the snapshot that is current at write time, not
-/// the one the caller validated against.
+/// request would stall every other `add` for this engagement behind one
+/// unreachable site. Re-reading the config here is what keeps that safe: the
+/// append is decided against the snapshot that is current at write time, not the
+/// one the caller validated against.
 ///
 /// # Errors
 ///
 /// [`AuditError::RegistryLock`] when the lock cannot be taken — never a
-/// bypass — plus whatever [`Registry::load`] and [`Registry::save`] fail with.
-pub fn register(work: &WorkDir, target: &Target) -> Result<bool, AuditError> {
-    locked(work, || {
-        let mut registry = Registry::load(work)?;
-        if !registry.insert(target.clone()) {
-            return Ok(false);
-        }
-        registry.save(work)?;
-        Ok(true)
+/// bypass — [`AuditError::NoEngagementConfig`] when there is no config to
+/// declare anything in, plus whatever [`update`] fails with.
+pub fn register(config_path: &Path, work: &WorkDir, target: &Target) -> Result<bool, AuditError> {
+    locked(config_path, || {
+        update(config_path, work, |registry| {
+            registry.insert(target.clone())
+        })
     })
 }
 
-/// Drop `target` from the registry, under the same lock [`register`] takes.
+/// Drop `target` from the engagement config, under the lock [`register`] takes.
 ///
 /// Why: a removal is the same read-modify-write, so an unserialised one loses a
 /// concurrent add just as readily (#5822).
@@ -466,24 +561,79 @@ pub fn register(work: &WorkDir, target: &Target) -> Result<bool, AuditError> {
 /// # Errors
 ///
 /// The same set as [`register`].
-pub fn deregister(work: &WorkDir, target: &Target) -> Result<bool, AuditError> {
-    locked(work, || {
-        let mut registry = Registry::load(work)?;
-        if !registry.remove(target) {
-            return Ok(false);
-        }
-        registry.save(work)?;
-        Ok(true)
+pub fn deregister(config_path: &Path, work: &WorkDir, target: &Target) -> Result<bool, AuditError> {
+    locked(config_path, || {
+        update(config_path, work, |registry| registry.remove(target))
     })
 }
 
-/// Run `f` holding the registry's exclusive lock.
+/// One read-modify-write over the engagement's target set. Caller holds the lock.
 ///
-/// The lock guards [`Registry::path`] through its `.lock` sidecar, so it
-/// survives the rename [`Registry::save`] publishes with.
-fn locked<T>(work: &WorkDir, f: impl FnOnce() -> Result<T, AuditError>) -> Result<T, AuditError> {
-    let path = Registry::path(work);
-    with_exclusive_lock(&path, f).map_err(|source| AuditError::RegistryLock { path, source })?
+/// Why: the fail-closed order is the whole content of this function, so it is
+/// written once rather than twice (#5979). The config is published FIRST and the
+/// working copy mirrored SECOND, so a config write that fails leaves both files
+/// exactly as they were — "the config write failed but the target looks
+/// registered" is unreachable, in either file. A mirror write that fails is
+/// still an error the caller sees; the config is authoritative by then, and the
+/// next read rebuilds the mirror.
+/// What: reads the config as TEXT as well as parsing it, because
+/// [`crate::config::with_targets`] substitutes over the operator's own file
+/// rather than re-rendering one from the schema — that is what keeps a
+/// registration from dropping a field a newer generator added.
+/// Test: `super::registry_tests::a_config_that_cannot_be_written_registers_nothing`,
+/// `super::registry_tests::registering_without_a_config_is_refused`.
+///
+/// # Errors
+///
+/// [`AuditError::NoEngagementConfig`] when the config is absent,
+/// [`AuditError::Read`] for any other read failure, [`AuditError::Parse`] or
+/// [`AuditError::Render`] from the substitution, and [`AuditError::WorkDir`]
+/// when either file cannot be published.
+fn update(
+    config_path: &Path,
+    work: &WorkDir,
+    mutate: impl FnOnce(&mut Registry) -> bool,
+) -> Result<bool, AuditError> {
+    let text = match std::fs::read_to_string(config_path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(AuditError::NoEngagementConfig {
+                path: config_path.to_path_buf(),
+            });
+        }
+        Err(source) => {
+            return Err(AuditError::Read {
+                path: config_path.to_path_buf(),
+                source,
+            });
+        }
+    };
+    let config = EngagementConfig::from_toml(&text, config_path)?;
+    let mut registry = Registry {
+        targets: engagement_targets(Some(&config), work)?,
+    };
+    if !mutate(&mut registry) {
+        return Ok(false);
+    }
+    let rendered = config::with_targets(&text, registry.targets(), config_path)?;
+    // 0600: the file this now rewrites carries the OpenRouter key (#5868).
+    workdir::write_private_atomically(config_path, &rendered)?;
+    registry.save(work)?;
+    Ok(true)
+}
+
+/// Run `f` holding the engagement config's exclusive lock.
+///
+/// The lock guards `config_path` through its `.lock` sidecar, so it survives the
+/// rename [`crate::workdir::write_private_atomically`] publishes with.
+fn locked<T>(
+    config_path: &Path,
+    f: impl FnOnce() -> Result<T, AuditError>,
+) -> Result<T, AuditError> {
+    with_exclusive_lock(config_path, f).map_err(|source| AuditError::RegistryLock {
+        path: config_path.to_path_buf(),
+        source,
+    })?
 }
 
 /// The repository selection `crate::clone` wrote, when there is one.
@@ -564,6 +714,37 @@ mod registry_tests {
             provider,
             key: key.to_owned(),
         }
+    }
+
+    /// An engagement config that declares no targets — the state every case
+    /// here starts from unless it says otherwise.
+    const ENGAGEMENT: &str = r#"
+openrouter_key = "sk-or-v1-not-a-real-key"
+instructions = "Assess the last 52 weeks."
+
+[tools]
+tga = "2.9.4"
+trusty-search = "0.47.0"
+trusty-analyze = "0.9.2"
+trusty-review = "0.15.1"
+"#;
+
+    /// Write [`ENGAGEMENT`] beside the working directory and hand back its path.
+    fn engagement_in(dir: &std::path::Path) -> PathBuf {
+        let path = dir.join("engagement.toml");
+        std::fs::write(&path, ENGAGEMENT).expect("seed an engagement config");
+        path
+    }
+
+    /// What the engagement config declares, by id, in declaration order.
+    fn declared_ids(config_path: &std::path::Path) -> Vec<String> {
+        EngagementConfig::load(config_path)
+            .expect("the config reads")
+            .declared_targets()
+            .expect("the config declares a set")
+            .iter()
+            .map(Target::id)
+            .collect()
     }
 
     /// The owner named schema repositories specifically, because that is the
@@ -707,20 +888,31 @@ mod registry_tests {
     fn concurrent_registrations_keep_every_target() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let work = work_in(tmp.path());
+        let config = engagement_in(tmp.path());
 
         race(&work, |work, n| {
             assert!(
-                register(work, &repo(&format!("acme/repo-{n:02}"))).expect("a racing add succeeds"),
+                register(&config, work, &repo(&format!("acme/repo-{n:02}")))
+                    .expect("a racing add succeeds"),
                 "acme/repo-{n:02} was reported as already registered"
             );
         });
 
         let mut expected: Vec<String> = (0..WRITERS).map(|n| format!("acme/repo-{n:02}")).collect();
         expected.sort();
+        // #5979: the CONFIG is what must be complete — it is what the sweep
+        // reads. The working copy is asserted alongside it, because a mirror
+        // that fell behind is a mirror nothing rebuilt.
+        let mut declared = declared_ids(&config);
+        declared.sort();
+        assert_eq!(
+            declared, expected,
+            "a concurrently-registered target was discarded from the engagement"
+        );
         assert_eq!(
             registered_ids(&work),
             expected,
-            "a concurrently-registered target was discarded"
+            "the working copy did not track the engagement"
         );
     }
 
@@ -730,24 +922,30 @@ mod registry_tests {
     fn a_removal_holds_the_same_lock_an_add_does() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let work = work_in(tmp.path());
-        let mut seeded = Registry::default();
-        for n in 0..WRITERS {
-            seeded.insert(repo(&format!("acme/repo-{n:02}")));
-        }
-        seeded.save(&work).expect("writes");
+        let config = engagement_in(tmp.path());
+        let seeded: Vec<Target> = (0..WRITERS)
+            .map(|n| repo(&format!("acme/repo-{n:02}")))
+            .collect();
+        std::fs::write(
+            &config,
+            config::with_targets(ENGAGEMENT, &seeded, &config).expect("declares"),
+        )
+        .expect("seed the declared set");
 
         race(&work, |work, n| {
             assert!(
-                deregister(work, &repo(&format!("acme/repo-{n:02}"))).expect("a racing remove"),
+                deregister(&config, work, &repo(&format!("acme/repo-{n:02}")))
+                    .expect("a racing remove"),
                 "acme/repo-{n:02} was reported as not registered"
             );
         });
 
         assert!(
-            registered_ids(&work).is_empty(),
+            declared_ids(&config).is_empty(),
             "a concurrent removal was undone: {:?}",
-            registered_ids(&work)
+            declared_ids(&config)
         );
+        assert!(registered_ids(&work).is_empty());
     }
 
     /// Registering the same target from every writer at once: exactly one call
@@ -756,16 +954,264 @@ mod registry_tests {
     fn only_one_racing_writer_claims_a_duplicate_registration() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let work = work_in(tmp.path());
+        let config = engagement_in(tmp.path());
         let appended = std::sync::atomic::AtomicUsize::new(0);
 
         race(&work, |work, _| {
-            if register(work, &repo("acme/api")).expect("a racing add succeeds") {
+            if register(&config, work, &repo("acme/api")).expect("a racing add succeeds") {
                 appended.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             }
         });
 
         assert_eq!(appended.load(std::sync::atomic::Ordering::Relaxed), 1);
+        assert_eq!(declared_ids(&config), vec!["acme/api"]);
         assert_eq!(registered_ids(&work), vec!["acme/api"]);
+    }
+
+    /// 🔴 #5979's migration, stated as the case that produced it: an operator
+    /// registered ten repositories before this change, so the working copy holds
+    /// them and their config declares nothing. Every read must still answer ten.
+    #[test]
+    fn an_undeclared_config_adopts_the_existing_registry() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let config_path = engagement_in(tmp.path());
+        let mut legacy = Registry::default();
+        for n in 0..10 {
+            legacy.insert(repo(&format!("acme/repo-{n}")));
+        }
+        legacy.save(&work).expect("the pre-#5979 registry");
+
+        let config = EngagementConfig::load(&config_path).expect("loads");
+        assert_eq!(config.declared_targets(), None, "nothing is declared yet");
+        assert_eq!(
+            engagement_targets(Some(&config), &work)
+                .expect("reads")
+                .len(),
+            10,
+            "an upgraded engagement must not read as empty"
+        );
+
+        // The first write persists the adopted set, after which the config
+        // answers on its own.
+        assert!(register(&config_path, &work, &repo("acme/eleventh")).expect("registers"));
+        let declared = declared_ids(&config_path);
+        assert_eq!(declared.len(), 11, "{declared:?}");
+        assert_eq!(declared[10], "acme/eleventh");
+        assert_eq!(declared[0], "acme/repo-0");
+    }
+
+    /// The other half of that decision: an operator who removed their last
+    /// target declared ZERO, and the old working copy must not resurrect it.
+    #[test]
+    fn a_declared_empty_list_is_not_a_missing_one() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let config_path = engagement_in(tmp.path());
+        let mut stale = Registry::default();
+        stale.insert(repo("acme/deleted"));
+        stale.save(&work).expect("a stale working copy");
+
+        std::fs::write(
+            &config_path,
+            config::with_targets(ENGAGEMENT, &[], &config_path).expect("declares zero"),
+        )
+        .expect("write");
+
+        let config = EngagementConfig::load(&config_path).expect("loads");
+        assert_eq!(config.declared_targets(), Some(&[][..]));
+        assert!(
+            engagement_targets(Some(&config), &work)
+                .expect("reads")
+                .is_empty(),
+            "a declared-empty engagement adopted a deleted target"
+        );
+    }
+
+    /// A working copy left by an earlier run is expected, not an error: the
+    /// declared set supersedes it without complaint, and the next write rebuilds
+    /// the mirror.
+    #[test]
+    fn a_declared_list_supersedes_a_stale_working_copy() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let config_path = engagement_in(tmp.path());
+        let mut stale = Registry::default();
+        stale.insert(repo("acme/from-last-week"));
+        stale.save(&work).expect("a stale working copy");
+
+        std::fs::write(
+            &config_path,
+            config::with_targets(ENGAGEMENT, &[repo("acme/api")], &config_path).expect("declares"),
+        )
+        .expect("write");
+
+        let config = EngagementConfig::load(&config_path).expect("loads");
+        assert_eq!(
+            engagement_targets(Some(&config), &work)
+                .expect("reads")
+                .iter()
+                .map(Target::id)
+                .collect::<Vec<_>>(),
+            vec!["acme/api"]
+        );
+
+        assert!(register(&config_path, &work, &repo("acme/web")).expect("registers"));
+        assert_eq!(
+            registered_ids(&work),
+            vec!["acme/api", "acme/web"],
+            "the mirror was not rebuilt from the declared set"
+        );
+    }
+
+    /// 🔴 The file a registration now rewrites carries the OpenRouter key, so it
+    /// must come back at 0600 — not at whatever the process umask allows.
+    ///
+    /// Seeded at 0644 on purpose: the assertion has to prove this write NARROWS
+    /// the file, not that it happened to inherit a mode from somewhere.
+    #[cfg(unix)]
+    #[test]
+    fn a_registration_keeps_the_config_owner_only() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let config = engagement_in(tmp.path());
+        std::fs::set_permissions(&config, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+
+        assert!(register(&config, &work, &repo("acme/api")).expect("registers"));
+        let mode = std::fs::metadata(&config)
+            .expect("stat")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600, "mode was {:o}", mode & 0o777);
+
+        // And the credential survived the substitution — a registration that
+        // dropped the key would leave the engagement unable to run.
+        let text = std::fs::read_to_string(&config).expect("read");
+        assert!(text.contains("sk-or-v1-not-a-real-key"), "{text}");
+
+        assert!(deregister(&config, &work, &repo("acme/api")).expect("removes"));
+        let mode = std::fs::metadata(&config)
+            .expect("stat")
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "a removal widened it: {:o}",
+            mode & 0o777
+        );
+    }
+
+    /// 🔴 The fail-open arm. A config that cannot be published must leave BOTH
+    /// files as they were — "the config write failed but the target looks
+    /// registered" is the shape this ordering exists to rule out.
+    ///
+    /// The write is made to fail by making the config's directory unwritable, so
+    /// the temporary file cannot be created. The `.lock` sidecar is created
+    /// FIRST: without it the lock itself cannot be opened and the refusal
+    /// arrives as [`AuditError::RegistryLock`], which proves a different arm
+    /// than the one under test. Skipped as root, for whom mode bits are
+    /// advisory.
+    #[cfg(unix)]
+    #[test]
+    fn a_config_that_cannot_be_written_registers_nothing() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // SAFETY: `geteuid` reads this process's own effective uid and writes
+        // through no pointer.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let held = tmp.path().join("held");
+        std::fs::create_dir(&held).expect("mkdir");
+        let config = engagement_in(&held);
+        let before = std::fs::read_to_string(&config).expect("read");
+        std::fs::write(trusty_common::file_lock::lock_path(&config), b"").expect("seed the lock");
+        std::fs::set_permissions(&held, std::fs::Permissions::from_mode(0o555)).expect("chmod");
+
+        let err = register(&config, &work, &repo("acme/api"))
+            .expect_err("an unwritable engagement must not read as a registration");
+        assert!(matches!(err, AuditError::WorkDir { .. }), "{err:?}");
+
+        assert_eq!(
+            std::fs::read_to_string(&config).expect("read"),
+            before,
+            "the engagement was modified by a failed write"
+        );
+        assert!(
+            !Registry::path(&work).exists(),
+            "the working copy claims a target the engagement does not declare"
+        );
+
+        // Let the tempdir clean up after itself.
+        std::fs::set_permissions(&held, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod back");
+    }
+
+    /// 🔴 There is nowhere to declare a target without an engagement, so this is
+    /// a refusal rather than a write to the working copy — which nothing now
+    /// treats as authoritative.
+    #[test]
+    fn registering_without_a_config_is_refused() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let missing = tmp.path().join("engagement.toml");
+
+        for outcome in [
+            register(&missing, &work, &repo("acme/api")),
+            deregister(&missing, &work, &repo("acme/api")),
+        ] {
+            let err = outcome.expect_err("no engagement, nothing to declare");
+            let AuditError::NoEngagementConfig { path } = &err else {
+                panic!("expected NoEngagementConfig, got {err:?}");
+            };
+            assert_eq!(path, &missing);
+            assert!(err.to_string().contains("nothing was registered"), "{err}");
+        }
+        assert!(!Registry::path(&work).exists());
+        assert!(!missing.exists(), "a refusal must not create a config");
+    }
+
+    /// A config that is present and malformed is not an absent one: a write
+    /// that would overwrite a hand-edited engagement is refused instead.
+    #[test]
+    fn a_malformed_config_is_not_overwritten_by_a_registration() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let config = tmp.path().join("engagement.toml");
+        std::fs::write(&config, "this is not toml = = =").expect("write");
+
+        let err = register(&config, &work, &repo("acme/api"))
+            .expect_err("a malformed engagement must not be rewritten");
+        assert!(matches!(err, AuditError::Parse { .. }), "{err:?}");
+        assert_eq!(
+            std::fs::read_to_string(&config).expect("read"),
+            "this is not toml = = ="
+        );
+    }
+
+    /// Absence of a config is absence of a declaration, so a directory that is
+    /// not an engagement still reports whatever working copy it has.
+    #[test]
+    fn no_config_at_all_reads_the_working_copy() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let mut legacy = Registry::default();
+        legacy.insert(board(BoardProvider::Linear, "ENG"));
+        legacy.save(&work).expect("writes");
+
+        assert_eq!(
+            engagement_targets(None, &work)
+                .expect("reads")
+                .iter()
+                .map(Target::id)
+                .collect::<Vec<_>>(),
+            vec!["linear:ENG"]
+        );
     }
 
     #[test]

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -472,7 +472,12 @@ where
     let boards = match resolved {
         Some(boards) => boards,
         None => {
-            owned = boards::resolve(registry::Registry::load(work)?.targets(), &config.boards);
+            // #5979: the engagement config declares the targets; the working
+            // copy answers only for an engagement that has declared none.
+            owned = boards::resolve(
+                &registry::engagement_targets(Some(config), work)?,
+                &config.boards,
+            );
             &owned
         }
     };

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -31,7 +31,7 @@ use crate::error::AuditError;
 use crate::manifest::{AuditManifest, RepositoryEntry};
 use crate::package::{self, ReturnPackage};
 use crate::progress::{Progress, ProgressSink};
-use crate::registry::{self, Registration, Registry, Removal, TargetKind, TargetList};
+use crate::registry::{self, Registration, Removal, TargetKind, TargetList};
 use crate::run::{self, RunOptions, RunReport};
 use crate::tools::{self, InstalledTool, RequiredTool, ToolStatus};
 use crate::validate;
@@ -615,31 +615,43 @@ impl Session {
     /// What: [`registry::parse`] owns the spec, [`validate::validate`] owns the
     /// access check, and [`registry::register`] owns the write — including the
     /// lock that stops two concurrent `add` runs discarding each other's target.
+    ///
+    /// #5979: the config is REQUIRED here, where it used to be optional. It is
+    /// the file a target is now declared in, so an absent one is
+    /// [`AuditError::NoEngagementConfig`] rather than a registration that lands
+    /// somewhere no longer authoritative. The check runs before validation, so a
+    /// directory that is not an engagement is told so without a network round
+    /// trip first.
     /// Test: `super::session_tests::a_rejected_target_is_not_persisted`,
     /// `super::session_tests::re_adding_a_registered_target_changes_nothing`,
     /// `crate::registry::registry_tests::concurrent_registrations_keep_every_target`.
     async fn add_target(&self, kind: TargetKind, spec: &str) -> Result<Registration, AuditError> {
         let target = registry::parse(Some(kind), spec)?;
         self.work.create()?;
-        if Registry::load(&self.work)?.contains(&target) {
+        let config = EngagementConfig::load_if_present(&self.config_path)?.ok_or_else(|| {
+            AuditError::NoEngagementConfig {
+                path: self.config_path.clone(),
+            }
+        })?;
+        if registry::engagement_targets(Some(&config), &self.work)?
+            .iter()
+            .any(|t| t.same_as(&target))
+        {
             return Ok(Registration {
                 target,
                 already_registered: true,
             });
         }
-        // Absent rather than required: a repository target needs no config at
-        // all, and a board target's refusal names the field to set (#5822).
-        let config = EngagementConfig::load_if_present(&self.config_path)?;
-        // #5822: validation runs OUTSIDE the registry's lock — it reaches the
-        // network under a 30s ceiling, and holding the lock across that would
-        // stall every other `add` in this working directory behind one
-        // unreachable site. `register` re-reads the file, so the append is
-        // decided against the snapshot current at write time.
-        validate::validate(&target, config.as_ref(), self.repo_probe).await?;
+        // #5822: validation runs OUTSIDE the lock — it reaches the network under
+        // a 30s ceiling, and holding the lock across that would stall every
+        // other `add` for this engagement behind one unreachable site.
+        // `register` re-reads the config, so the append is decided against the
+        // snapshot current at write time.
+        validate::validate(&target, Some(&config), self.repo_probe).await?;
         let inserted = self
             .under_registry_lock({
-                let target = target.clone();
-                move |work| registry::register(work, &target)
+                let (target, config_path) = (target.clone(), self.config_path.clone());
+                move |work| registry::register(&config_path, work, &target)
             })
             .await?;
         Ok(Registration {
@@ -668,17 +680,21 @@ impl Session {
         tokio::task::spawn_blocking(move || f(&work))
             .await
             .map_err(|source| AuditError::RegistryLock {
-                path: Registry::path(&self.work),
+                path: self.config_path.clone(),
                 source: std::io::Error::other(source),
             })?
     }
 
-    /// What is registered, plus the selection file the sweep still reads.
+    /// What the engagement declares, plus the selection file the sweep reads.
     ///
-    /// See [`registry::legacy_selection`] for why both are reported.
+    /// See [`registry::legacy_selection`] for why both are reported, and
+    /// [`registry::engagement_targets`] for what a config that declares nothing
+    /// falls back to. Listing never writes, so a report on an engagement that
+    /// has not been migrated yet leaves it exactly as it was.
     fn list_targets(&self) -> Result<TargetList, AuditError> {
+        let config = EngagementConfig::load_if_present(&self.config_path)?;
         Ok(TargetList {
-            targets: Registry::load(&self.work)?.targets().to_vec(),
+            targets: registry::engagement_targets(config.as_ref(), &self.work)?,
             legacy_selection: registry::legacy_selection(&self.work)?,
         })
     }
@@ -686,13 +702,14 @@ impl Session {
     /// Drop one target. Removing one that is not registered writes nothing.
     ///
     /// Under the same lock `add` takes (#5822): a removal is the same
-    /// load-mutate-save, so an unserialised one discards a concurrent add.
+    /// load-mutate-save, so an unserialised one discards a concurrent add. The
+    /// config is required for the same reason it is in `add` (#5979).
     async fn remove_target(&self, spec: &str) -> Result<Removal, AuditError> {
         let target = registry::parse(None, spec)?;
         let was_registered = self
             .under_registry_lock({
-                let target = target.clone();
-                move |work| registry::deregister(work, &target)
+                let (target, config_path) = (target.clone(), self.config_path.clone());
+                move |work| registry::deregister(&config_path, work, &target)
             })
             .await?;
         Ok(Removal {
@@ -866,6 +883,10 @@ impl Session {
     async fn guided(&self) -> Result<GuidedStatus, AuditError> {
         self.work.create()?;
         let manifest = AuditManifest::load_if_present(&self.manifest_path)?;
+        // #5979: read ONCE here rather than twice below — the flow's repository
+        // check and its auto-install both need it, and reading the file twice
+        // lets the two disagree about an engagement edited in between.
+        let config = EngagementConfig::load_if_present(&self.config_path)?;
 
         // #5502: the epic's pre-sweep order is repo selection, then tooling —
         // so a missing repository set outranks a missing binary.
@@ -885,8 +906,7 @@ impl Session {
         let repos_known = manifest
             .as_ref()
             .is_some_and(|m| !m.repositories.is_empty())
-            || Registry::load(&self.work)?
-                .targets()
+            || registry::engagement_targets(config.as_ref(), &self.work)?
                 .iter()
                 .any(|target| target.kind() == TargetKind::Repo);
 
@@ -896,7 +916,7 @@ impl Session {
         // its state without this process reaching the network — the operator
         // has not committed to an engagement here.
         let installed = if self.auto_install && repos_known {
-            self.auto_install_tools().await?
+            self.auto_install_tools(config.as_ref()).await?
         } else {
             None
         };
@@ -949,13 +969,17 @@ impl Session {
     /// declines to install and the flow names the step, exactly as before.
     ///
     /// A config that is PRESENT and unreadable or malformed is not that case and
-    /// propagates: `load_if_present` tolerates only absence.
-    /// What: `Ok(None)` when there is no config or the set was already
-    /// satisfied; `Ok(Some(installed))` naming what this call placed.
+    /// propagates: the caller's `load_if_present` tolerates only absence.
+    /// What: takes the config [`Session::guided`] already read, so the two
+    /// cannot see different files. `Ok(None)` when there is no config or the set
+    /// was already satisfied; `Ok(Some(installed))` naming what this call placed.
     /// Test: `super::session_tests::guided_without_a_config_still_names_the_step`,
     /// `super::session_tests::guided_propagates_a_malformed_config`.
-    async fn auto_install_tools(&self) -> Result<Option<Vec<InstalledTool>>, AuditError> {
-        let Some(config) = EngagementConfig::load_if_present(&self.config_path)? else {
+    async fn auto_install_tools(
+        &self,
+        config: Option<&EngagementConfig>,
+    ) -> Result<Option<Vec<InstalledTool>>, AuditError> {
+        let Some(config) = config else {
             return Ok(None);
         };
         tools::ensure(&self.work, &config.tools, &self.progress).await
@@ -965,6 +989,7 @@ impl Session {
 #[cfg(test)]
 mod session_tests {
     use super::*;
+    use crate::registry::Registry;
 
     const MANIFEST: &str = r#"
 [report]
@@ -1817,7 +1842,8 @@ trusty-review = "0.15.1"
     #[tokio::test]
     async fn a_refused_repository_registration_writes_nothing() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let session = session_in(tmp.path()).with_repo_probe(validate::RepoProbe::unusable());
+        let session = session_with_config(tmp.path(), CONFIG_WITHOUT_BOARDS)
+            .with_repo_probe(validate::RepoProbe::unusable());
 
         let err = session
             .execute(Command::AddTarget {
@@ -1867,6 +1893,156 @@ trusty-review = "0.15.1"
             .expect_err("a traversing name must not register");
         assert!(matches!(err, AuditError::InvalidRepoName { .. }), "{err:?}");
         assert!(!Registry::path(session.work_dir()).exists());
+    }
+
+    /// 🔴 #5979, through the door a front end actually uses: a target added by
+    /// `Command::AddTarget` is DECLARED in `engagement.toml`, reads back from
+    /// it, and the working copy mirrors it.
+    ///
+    /// Against `87b55c367` the config is never written, so the first assertion
+    /// fails.
+    #[tokio::test]
+    async fn a_target_added_through_the_session_is_declared_in_the_engagement() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = session_with_config(tmp.path(), CONFIG_WITHOUT_BOARDS)
+            .with_repo_probe(validate::RepoProbe::accepting());
+
+        let Outcome::Registered(first) = session
+            .execute(Command::AddTarget {
+                kind: TargetKind::Repo,
+                spec: "acme/api".to_owned(),
+            })
+            .await
+            .expect("registers")
+        else {
+            panic!("AddTarget must yield a Registered outcome");
+        };
+        assert!(!first.already_registered);
+
+        let config = EngagementConfig::load(session.config_path()).expect("the config reloads");
+        assert_eq!(
+            config
+                .declared_targets()
+                .expect("the engagement declares its targets")
+                .iter()
+                .map(crate::registry::Target::id)
+                .collect::<Vec<_>>(),
+            vec!["acme/api"]
+        );
+        assert_eq!(registry_of(&session), vec!["acme/api"]);
+        // The rest of the file is intact — a registration must not cost the
+        // recipient their pins or their key.
+        assert_eq!(config.openrouter_key.expose(), "sk-or-v1-not-a-real-key");
+        assert_eq!(config.tools.trusty_review.version(), "0.15.1");
+
+        // And removing it declares zero rather than reverting to the mirror.
+        session
+            .execute(Command::RemoveTarget {
+                spec: "ACME/API".to_owned(),
+            })
+            .await
+            .expect("removes");
+        let after = EngagementConfig::load(session.config_path()).expect("reloads");
+        assert_eq!(after.declared_targets(), Some(&[][..]));
+        assert!(registry_of(&session).is_empty());
+    }
+
+    /// 🔴 The file `add` now rewrites carries the OpenRouter key, so the whole
+    /// `execute` path has to leave it owner-only. Seeded at 0644 so the
+    /// assertion proves this write NARROWS the mode.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn adding_a_target_leaves_the_engagement_owner_only() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = session_with_config(tmp.path(), CONFIG_WITHOUT_BOARDS)
+            .with_repo_probe(validate::RepoProbe::accepting());
+        std::fs::set_permissions(
+            session.config_path(),
+            std::fs::Permissions::from_mode(0o644),
+        )
+        .expect("chmod");
+
+        session
+            .execute(Command::AddTarget {
+                kind: TargetKind::Repo,
+                spec: "acme/api".to_owned(),
+            })
+            .await
+            .expect("registers");
+
+        let mode = std::fs::metadata(session.config_path())
+            .expect("stat")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600, "mode was {:o}", mode & 0o777);
+    }
+
+    /// 🔴 There is nowhere to declare a target without an engagement. The
+    /// refusal comes BEFORE validation, so a directory that is not an
+    /// engagement is told so without a network round trip first.
+    #[tokio::test]
+    async fn adding_a_target_without_an_engagement_is_refused() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = session_in(tmp.path()).with_repo_probe(validate::RepoProbe::unusable());
+
+        let err = session
+            .execute(Command::AddTarget {
+                kind: TargetKind::Repo,
+                spec: "acme/api".to_owned(),
+            })
+            .await
+            .expect_err("no engagement, nothing to declare");
+        assert!(
+            matches!(err, AuditError::NoEngagementConfig { .. }),
+            "{err:?}"
+        );
+        assert!(!Registry::path(session.work_dir()).exists());
+        assert!(!session.config_path().exists());
+    }
+
+    /// The migration, seen from a front end: an engagement upgraded from before
+    /// #5979 keeps every target its working copy holds, and the first write
+    /// persists them into the config.
+    #[tokio::test]
+    async fn an_upgraded_engagement_keeps_the_targets_it_had() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let session = session_with_config(tmp.path(), CONFIG_WITHOUT_BOARDS)
+            .with_repo_probe(validate::RepoProbe::accepting());
+        session
+            .execute(Command::WorkDir)
+            .await
+            .expect("create tree");
+        let mut legacy = Registry::default();
+        legacy.insert(crate::registry::parse(None, "acme/api").expect("parses"));
+        legacy.insert(crate::registry::parse(None, "acme/web").expect("parses"));
+        legacy
+            .save(session.work_dir())
+            .expect("a pre-#5979 registry");
+
+        let Outcome::Targets(listed) = session.execute(Command::ListTargets).await.expect("lists")
+        else {
+            panic!("ListTargets must yield a Targets outcome");
+        };
+        assert_eq!(listed.targets.len(), 2, "an upgrade must not read as empty");
+
+        session
+            .execute(Command::AddTarget {
+                kind: TargetKind::Repo,
+                spec: "acme/schema".to_owned(),
+            })
+            .await
+            .expect("registers");
+
+        let declared: Vec<String> = EngagementConfig::load(session.config_path())
+            .expect("reloads")
+            .declared_targets()
+            .expect("declared")
+            .iter()
+            .map(crate::registry::Target::id)
+            .collect();
+        assert_eq!(declared, vec!["acme/api", "acme/web", "acme/schema"]);
     }
 
     /// Registration is additive and idempotent, and a repeat does not
@@ -1962,7 +2138,7 @@ trusty-review = "0.15.1"
     #[tokio::test]
     async fn removing_operates_on_the_same_registry() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let session = session_in(tmp.path());
+        let session = session_with_config(tmp.path(), CONFIG_WITHOUT_BOARDS);
         session
             .execute(Command::WorkDir)
             .await

--- a/crates/trusty-console/ui/dist/ui-source-hash.txt
+++ b/crates/trusty-console/ui/dist/ui-source-hash.txt
@@ -1,4 +1,0 @@
-# Digest of the UI source this bundle was built from (#3606).
-# Written by scripts/stamp-ui-bundle.sh — regenerate by rebuilding, never by hand.
-# Verified by scripts/check-ui-bundle-freshness.sh (preflight-publish.sh CHECK 7).
-57cb1a4f3b6c19a25d2f27ce5fb5e2afe14e4d66 21

--- a/crates/trusty-memory/ui/dist/ui-source-hash.txt
+++ b/crates/trusty-memory/ui/dist/ui-source-hash.txt
@@ -1,4 +1,0 @@
-# Digest of the UI source this bundle was built from (#3606).
-# Written by scripts/stamp-ui-bundle.sh — regenerate by rebuilding, never by hand.
-# Verified by scripts/check-ui-bundle-freshness.sh (preflight-publish.sh CHECK 7).
-f3b980827d037dbc674f5fba8fe3b28abf8571ec 26


### PR DESCRIPTION
Closes #5979.

`engagement.toml` gains a `[[targets]]` array and becomes what an engagement's target set IS. `<work-dir>/state/audit-targets.toml` stays as a working copy, rebuilt from the config on every write and read only when the config declares no set at all. Hand someone the config and they have the key, the models and the scope.

Scope is the data model only. No `repos.txt` / `boards.txt` detection, no URL parsing, no menu — that is #5978, which this unblocks.

## What changed

- `EngagementConfig::targets: Option<Vec<Target>>`, read through `declared_targets()`. `config::with_targets` is the one writer, a substitution over the parsed table beside `config::generate` — so the pins, the models table and a board credential survive a registration verbatim, and no `Serialize` impl is added to `SecretKey`.
- `registry::engagement_targets` is the one read and owns the precedence.
- `registry::register` / `deregister` take the config path. They hold `trusty_common::file_lock::with_exclusive_lock` on the config, publish it through `workdir::write_private_atomically` at mode 0600, and mirror the result into the working copy **second**.
- `session::add_target` requires a config and refuses without one. `list_targets`, `guided`, `chain::split_targets` and `run::sweep` all read through `engagement_targets`.

## Point 3 — what protects the target list in the config

No `count`, and that is a decision. Three things stand in its place:

- Every write is `write_private_atomically`: `O_EXCL` temp file, then rename. A reader sees the whole old file or the whole new one — there is no torn intermediate for a count to detect.
- `config::with_targets` re-parses the rendered text through `EngagementConfig::from_toml` **before** the rename, so a substitution that would produce an unloadable config fails without touching the file.
- `toml` renders `[[targets]]` ahead of `[tools]`, whose four pins are all required. A truncation that loses the tail of the target list also loses a required table, so the config refuses to load rather than reading as a smaller-but-complete engagement. `config_tests::the_target_list_is_rendered_ahead_of_the_required_pins` asserts that ordering and asserts the truncated prefix fails to parse.

Against adding one: `engagement.toml` is the file a recipient reads and edits (#5473). A `count` they must keep in step by hand turns adding a line to their own file into an engagement that refuses to load — worse than the tear it guards. The working copy has no such reader and keeps its `count` unchanged.

## Point 4 — the migration

**Adopted on read; persisted on the first write.** `targets` is `Option<Vec<Target>>` rather than a defaulted `Vec`, because absent and empty are different answers:

- Absent (a config written before this change, or no config at all) — nothing has ever declared a set, so the working copy is adopted. An operator who registered ten repos yesterday reads ten today.
- `targets = []` — the operator removed their last target and declared zero. No adoption; resurrecting the deleted set would undo the removal.
- Declared and non-empty — that is the answer, and a stale working copy is superseded without complaint. The next write rebuilds the mirror.

Reading never writes, so reporting state on an unmigrated engagement leaves it exactly as it was. The first `add` or `remove` persists the adopted set into the config, after which the config answers alone.

Tests: `registry_tests::an_undeclared_config_adopts_the_existing_registry`, `a_declared_empty_list_is_not_a_missing_one`, `a_declared_list_supersedes_a_stale_working_copy`, `no_config_at_all_reads_the_working_copy`, `session_tests::an_upgraded_engagement_keeps_the_targets_it_had`.

## Error arms (Fail-Open Check)

- `AuditError::NoEngagementConfig` — `add`/`remove` in a directory with no engagement refuse, naming the file and the command that creates one, rather than writing a working copy nothing treats as authoritative. `registry_tests::registering_without_a_config_is_refused`, `session_tests::adding_a_target_without_an_engagement_is_refused`.
- Config write fails → both files untouched. `registry_tests::a_config_that_cannot_be_written_registers_nothing` makes the config's directory unwritable (seeding the `.lock` sidecar first, so the refusal is the write arm and not `RegistryLock`) and asserts the config is byte-identical and the working copy was never created. This is the "config write failed but the target looks registered" shape.
- A malformed config is not an absent one: `a_malformed_config_is_not_overwritten_by_a_registration`.

Each of these fails against `87b55c367` — the pre-fix `register` wrote only the working copy and would have succeeded.

## Mode 0600

`registry_tests::a_registration_keeps_the_config_owner_only` and `session_tests::adding_a_target_leaves_the_engagement_owner_only` both seed the config at 0644 first, so they prove the write **narrows** the mode rather than inheriting one. The first also asserts the OpenRouter key survived the substitution.

## Concurrency

`concurrent_registrations_keep_every_target` now asserts the **config** holds all 16 racing targets, then that the working copy tracked it. `a_removal_holds_the_same_lock_an_add_does` and `only_one_racing_writer_claims_a_duplicate_registration` likewise.

## Version

PATCH: `trusty-audit` 0.5.1 → 0.5.2, rebased onto the 0.5.1 bump (#5981). The crate is `publish = false`, so `cargo-semver-checks` does not gate it, and nothing here argues for the minor position.

## Test ladder — rung 5

Persisted state plus a credential path.

```
cargo fmt --check                                      EXIT=0
cargo check -p trusty-audit                            EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-audit                             EXIT=0  (419 passed; 0 failed; 5 ignored)
cargo test -p trusty-audit -- --include-ignored        EXIT=0  (424 passed; 0 failed; 0 ignored)
cargo check --workspace                                EXIT=0  (includes trusty-audit-ui)
bash scripts/check_line_cap.sh                         EXIT=0  (4077 files, 0 violations)
bash scripts/check_sld.sh                              EXIT=0  (0 errors, 0 warnings)
bash scripts/check_changelog_fragment.sh               EXIT=0
```

`trusty-audit-ui` is a workspace member and appears in the `cargo check --workspace` output; it compiles unchanged, since it drives `Session::execute` rather than `registry::register`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
