### PR TITLE
fix(ci): resync Cargo.lock and restore three deleted UI bundle stamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11296,7 +11296,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/trusty-analyze/ui/dist/ui-source-hash.txt
+++ b/crates/trusty-analyze/ui/dist/ui-source-hash.txt
@@ -1,0 +1,4 @@
+# Digest of the UI source this bundle was built from (#3606).
+# Written by scripts/stamp-ui-bundle.sh — regenerate by rebuilding, never by hand.
+# Verified by scripts/check-ui-bundle-freshness.sh (preflight-publish.sh CHECK 7).
+3b07ea5ce69fad465bd1b8584cf0c858669d8396 22

--- a/crates/trusty-console/ui/dist/ui-source-hash.txt
+++ b/crates/trusty-console/ui/dist/ui-source-hash.txt
@@ -1,0 +1,4 @@
+# Digest of the UI source this bundle was built from (#3606).
+# Written by scripts/stamp-ui-bundle.sh — regenerate by rebuilding, never by hand.
+# Verified by scripts/check-ui-bundle-freshness.sh (preflight-publish.sh CHECK 7).
+57cb1a4f3b6c19a25d2f27ce5fb5e2afe14e4d66 21

--- a/crates/trusty-memory/ui/dist/ui-source-hash.txt
+++ b/crates/trusty-memory/ui/dist/ui-source-hash.txt
@@ -1,0 +1,4 @@
+# Digest of the UI source this bundle was built from (#3606).
+# Written by scripts/stamp-ui-bundle.sh — regenerate by rebuilding, never by hand.
+# Verified by scripts/check-ui-bundle-freshness.sh (preflight-publish.sh CHECK 7).
+f3b980827d037dbc674f5fba8fe3b28abf8571ec 26


### PR DESCRIPTION
Repairs the collateral damage from #5985 (merge `24afd0c7d`). Two independent breaks on `main`, one PR.

## Break 1 — `Cargo.lock` out of sync

#5985 bumped `crates/trusty-audit/Cargo.toml` 0.5.1 → 0.5.2 and left `Cargo.lock` pinning 0.5.1. Every `cargo` invocation carrying `--locked` then died during resolve, before doing any work.

That is what failed `SLD (DOC-38) reference + spec-doc lint`. `scripts/check_sld.sh:35` runs `cargo run --quiet --locked -p trusty-sld-lint`, so the resolve failed and the linter never started. The check name points at SLD references; no SLD reference was wrong.

Fix: `cargo update --workspace --offline`. The diff is one line.

```
 Cargo.lock | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

 [[package]]
 name = "trusty-audit"
-version = "0.5.1"
+version = "0.5.2"
```

No dependency churn.

## Break 2 — three UI bundle stamps deleted

#5985's diff also removed, four deletions each:

```
crates/trusty-analyze/ui/dist/ui-source-hash.txt
crates/trusty-console/ui/dist/ui-source-hash.txt
crates/trusty-memory/ui/dist/ui-source-hash.txt
```

`scripts/check-ui-bundle-freshness.sh` reported `STAMP-MISSING` for all three, blocking `preflight-publish.sh` CHECK 7 for those crates.

**Decision: restored verbatim from `a4a10e8f3`, not rebuilt.**

The stamp records a digest of the UI *source*, so restoring one is only honest if the source has not moved since. Two independent checks say it has not:

1. Between `a4a10e8f3` and `HEAD`, the only change anywhere under `crates/*/ui/` and `crates/*/ui-dist/` is the three deletions themselves — `git diff --name-status` lists three `D` rows and nothing else. No bundle byte moved.
2. Each crate's source digest, recomputed with `scripts/lib/ui_source_digest.sh`, is identical at `a4a10e8f3`, at `HEAD`, and in the working tree — and matches what the deleted file recorded:

| crate | recorded in deleted stamp | source@a4a10e8f3 | source@HEAD | source@worktree |
|---|---|---|---|---|
| trusty-analyze | `3b07ea5ce69f` / 22 | same | same | same |
| trusty-console | `57cb1a4f3b6c` / 21 | same | same | same |
| trusty-memory | `f3b980827d03` / 26 | same | same | same |

A rebuild would have churned Vite's content-hashed filenames without changing what the stamp asserts. Restoring a stamp that no longer described its bundle would be worse than the current failure — the gate would go green while lying — which is why the digests were checked before choosing.

## Verification

`scripts/check_sld.sh` — the actual failing command. Before the lock fix:

```
error: cannot update the lock file /Users/bob/.../Cargo.lock because --locked was passed to prevent this
help: to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
EXIT=101
```

After:

```
sld-lint: scanned 60 spec doc(s) + 3327 code file(s); resolved 40 frontmatter + 37 inline reference(s); 0 error(s), 0 warning(s)
EXIT=0
```

`scripts/check-ui-bundle-freshness.sh`, run on the commit:

```
PASS: trusty-search — 28 source file(s) vs 4 bundle file(s), 4 blob hash(es) bundle=bdae22a4d050, 2 asset ref(s) resolved; recorded source digest 3beeffe6b3d5 matches
PASS: trusty-memory — 26 source file(s) vs 4 bundle file(s), 4 blob hash(es) bundle=9a6753e36a63, 2 asset ref(s) resolved; recorded source digest f3b980827d03 matches
PASS: trusty-analyze — 22 source file(s) vs 4 bundle file(s), 4 blob hash(es) bundle=e6f48ebc66ec, 2 asset ref(s) resolved; recorded source digest 3b07ea5ce69f matches
PASS: trusty-console — 21 source file(s) vs 4 bundle file(s), 4 blob hash(es) bundle=d0fad1f2dd86, 2 asset ref(s) resolved; recorded source digest 57cb1a4f3b6c matches
check-ui-bundle-freshness: OK at HEAD — 4 crate(s), 97 source file(s), 16 bundle file(s), 16 blob hash(es), 8 asset ref(s).
EXIT=0
```

Other gates:

```
scripts/check_line_cap.sh              EXIT=0
scripts/check_generation_artifacts.sh  EXIT=0
scripts/check_teardown_guard.sh        EXIT=0
cargo fmt --check                      EXIT=0
```

## Changelog fragment

`scripts/check_changelog_fragment.sh` exits 0 and demands none:

```
changelog-fragment gate: scanned 4 changed path(s); attributed 0 crate-source path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
```

Four paths scanned, so this is a real pass rather than the scan-floor refusal. No crate `src/**` changed.

## Version bump

None. No gate asked for one, and no crate source changed. `crates/trusty-audit/Cargo.toml` keeps the 0.5.2 that #5985 set — this PR only makes the lock agree with it.

## Footgun note

`pnpm` is on PATH on this host (`/opt/homebrew/bin/pnpm`), so a `cargo` command without `SKIP_UI_BUILD=1` rebuilds those `ui/dist` trees, and the rebuild does not recreate `ui-source-hash.txt` — only `scripts/stamp-ui-bundle.sh` writes it. That is the shape that produced Break 2. Every `cargo` command here ran with `SKIP_UI_BUILD=1`, and `git status --porcelain` was checked before committing: the commit is exactly `Cargo.lock` plus the three restored stamps, with no other `ui/dist` file touched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
