### PR TITLE
the interaction tier resolves Sonnet 4.6, and the third tier is named for its purpose (#5987)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11398,7 +11398,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11765,7 +11765,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ trusty-code = { path = "crates/trusty-code", version = "0.3.0" }
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.6.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.37" }
+trusty-common = { path = "crates/trusty-common", version = "0.38" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 # Why: `default-features = false` HERE, not only on the member entry (mirrors

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.37.0"
+version = "0.38.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/5987-interaction-tier-sonnet-and-classification-rename.md
+++ b/crates/trusty-common/changelog.d/5987-interaction-tier-sonnet-and-classification-rename.md
@@ -1,0 +1,4 @@
+Changed
+
+- `ModelTier::Interaction` resolves Claude Sonnet 4.6 instead of Opus 4.8, on both OpenRouter (`anthropic/claude-sonnet-4.6`) and the Anthropic first-party API (`claude-sonnet-4-6`). Bedrock's opus arms stay deliberately unmapped. See #5987.
+- **Breaking:** `ModelTier::Haiku` is renamed to `ModelTier::Classification`, so the tier names its purpose rather than the model it currently resolves to. The mapped value is unchanged at Haiku 4.5 on every provider. See #5987.

--- a/crates/trusty-common/src/inference/tier.rs
+++ b/crates/trusty-common/src/inference/tier.rs
@@ -7,7 +7,7 @@
 //! override, because the pin was doing the work an alias should have done. A
 //! consumer that asks for a TIER instead of an id moves with the tier.
 //!
-//! What: [`ModelTier`] (three tiers — analysis, interaction, haiku) and
+//! What: [`ModelTier`] (three tiers — analysis, interaction, classification) and
 //! [`ModelTier::resolve`], which maps a tier plus a [`ProviderId`] to a concrete
 //! model id. Resolution is provider-dependent because the same model wears a
 //! different id per provider: Bedrock inference profiles are `us.anthropic.…`,
@@ -39,6 +39,13 @@ use super::registry::ProviderId;
 /// response, 2026-08-18.
 const OPENROUTER_OPUS_4_8: &str = "anthropic/claude-opus-4.8";
 
+/// OpenRouter slug for Claude Sonnet 4.6.
+///
+/// Confirmed present in a live `GET https://openrouter.ai/api/v1/models`
+/// response, 2026-08-18. Same id `trusty-audit` verified on 2026-08-13 and used
+/// as its `DEFAULT_REVIEWER_MODEL` until earlier that day (#5987).
+const OPENROUTER_SONNET_4_6: &str = "anthropic/claude-sonnet-4.6";
+
 /// OpenRouter slug for Claude Haiku 4.5.
 ///
 /// Confirmed present in a live `GET https://openrouter.ai/api/v1/models`
@@ -49,6 +56,14 @@ const OPENROUTER_HAIKU_4_5: &str = "anthropic/claude-haiku-4.5";
 ///
 /// From the `claude-api` model reference.
 const ANTHROPIC_OPUS_4_8: &str = "claude-opus-4-8";
+
+/// Anthropic first-party API id for Claude Sonnet 4.6.
+///
+/// From the `claude-api` model reference, which states the first-party ids are
+/// complete as written and must never carry a date suffix — so this is
+/// `claude-sonnet-4-6`, not a dated variant, and it is NOT derived from the
+/// OpenRouter spelling above (#5987).
+const ANTHROPIC_SONNET_4_6: &str = "claude-sonnet-4-6";
 
 /// Anthropic first-party API id for Claude Haiku 4.5.
 ///
@@ -68,11 +83,13 @@ const BEDROCK_HAIKU_4_5: &str = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 ///
 /// Why: a role should declare the class of model its work needs, so that moving
 /// the whole workspace to a newer model is one edit to [`ModelTier::resolve`]
-/// rather than a grep for every pinned id.
-/// What: three tiers. [`Self::Analysis`] and [`Self::Interaction`] resolve to
-/// the same model today (owner ruling, 2026-08-18) and are deliberately kept as
-/// two arms so they can diverge without touching a caller. [`Self::Haiku`] is
-/// the cheap high-volume tier for short, low-stakes calls.
+/// rather than a grep for every pinned id. Every variant therefore names a
+/// PURPOSE, never a model — a variant named for the model it currently resolves
+/// to goes stale the moment that workload moves, which is the pin-shaped mistake
+/// this layer exists to remove (#5987).
+/// What: three tiers, resolving to three different models under the owner ruling
+/// of 2026-08-18 — [`Self::Analysis`] to Opus 4.8, [`Self::Interaction`] to
+/// Sonnet 4.6, [`Self::Classification`] to Haiku 4.5.
 /// Test: `analysis_and_interaction_are_distinct_variants`,
 /// `every_tier_resolves_on_openrouter`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -83,9 +100,10 @@ pub enum ModelTier {
     Analysis,
     /// Conversational turns with a user.
     Interaction,
-    /// Short, high-volume, low-stakes calls — per-finding verification,
-    /// classification, summarisation.
-    Haiku,
+    /// Sorting inputs into categories — labelling, routing, triage. Also the
+    /// cheapest tier, which is why cost-driven callers select it; see
+    /// `trusty-review`'s `RoleModels::resolve` for that distinction.
+    Classification,
 }
 
 impl ModelTier {
@@ -102,24 +120,29 @@ impl ModelTier {
     /// whatever default it had. Providers that host no Claude model
     /// (`OpenAI`, `Fireworks`, `Together`, `AtlasCloud`, `Local`) return `None`
     /// for every tier.
-    /// Test: `bedrock_opus_tiers_are_unmapped`, `bedrock_haiku_resolves`,
+    /// Test: `bedrock_opus_tiers_are_unmapped`, `bedrock_classification_resolves`,
     /// `every_tier_resolves_on_openrouter`, `every_tier_resolves_on_anthropic`,
     /// `non_claude_providers_resolve_nothing`.
     pub fn resolve(self, provider: ProviderId) -> Option<&'static str> {
         match provider {
             ProviderId::OpenRouter => Some(match self {
-                Self::Analysis | Self::Interaction => OPENROUTER_OPUS_4_8,
-                Self::Haiku => OPENROUTER_HAIKU_4_5,
+                Self::Analysis => OPENROUTER_OPUS_4_8,
+                Self::Interaction => OPENROUTER_SONNET_4_6,
+                Self::Classification => OPENROUTER_HAIKU_4_5,
             }),
             ProviderId::Anthropic => Some(match self {
-                Self::Analysis | Self::Interaction => ANTHROPIC_OPUS_4_8,
-                Self::Haiku => ANTHROPIC_HAIKU_4_5,
+                Self::Analysis => ANTHROPIC_OPUS_4_8,
+                Self::Interaction => ANTHROPIC_SONNET_4_6,
+                Self::Classification => ANTHROPIC_HAIKU_4_5,
             }),
             // #5971: Bedrock's Opus 4.8 inference-profile id is unmapped by
             // owner ruling — it could not be verified and must not be guessed.
+            // #5987 moved interaction to Sonnet 4.6 but left this arm alone:
+            // the ruling covers the OpenRouter and Anthropic providers only, so
+            // adding a Bedrock sonnet mapping here needs its own decision.
             ProviderId::Bedrock => match self {
                 Self::Analysis | Self::Interaction => None,
-                Self::Haiku => Some(BEDROCK_HAIKU_4_5),
+                Self::Classification => Some(BEDROCK_HAIKU_4_5),
             },
             ProviderId::OpenAI
             | ProviderId::Fireworks
@@ -137,7 +160,7 @@ mod tests {
     const ALL_TIERS: &[ModelTier] = &[
         ModelTier::Analysis,
         ModelTier::Interaction,
-        ModelTier::Haiku,
+        ModelTier::Classification,
     ];
 
     #[test]
@@ -148,10 +171,10 @@ mod tests {
         );
         assert_eq!(
             ModelTier::Interaction.resolve(ProviderId::OpenRouter),
-            Some("anthropic/claude-opus-4.8")
+            Some("anthropic/claude-sonnet-4.6")
         );
         assert_eq!(
-            ModelTier::Haiku.resolve(ProviderId::OpenRouter),
+            ModelTier::Classification.resolve(ProviderId::OpenRouter),
             Some("anthropic/claude-haiku-4.5")
         );
     }
@@ -164,12 +187,31 @@ mod tests {
         );
         assert_eq!(
             ModelTier::Interaction.resolve(ProviderId::Anthropic),
-            Some("claude-opus-4-8")
+            Some("claude-sonnet-4-6"),
+            "the first-party id carries no date suffix, and is not derived from \
+             the OpenRouter spelling"
         );
         assert_eq!(
-            ModelTier::Haiku.resolve(ProviderId::Anthropic),
+            ModelTier::Classification.resolve(ProviderId::Anthropic),
             Some("claude-haiku-4-5-20251001")
         );
+    }
+
+    /// Why: the three tiers resolved to two distinct models before #5987 and
+    /// three after, so a refactor that re-groups the match arms could silently
+    /// collapse interaction back onto analysis. Asserting the values differ
+    /// pins the ruling rather than the arm layout.
+    /// What: on both mapped providers, no two tiers resolve to the same id.
+    #[test]
+    fn the_three_tiers_resolve_three_distinct_models() {
+        for provider in [ProviderId::OpenRouter, ProviderId::Anthropic] {
+            let analysis = ModelTier::Analysis.resolve(provider);
+            let interaction = ModelTier::Interaction.resolve(provider);
+            let classification = ModelTier::Classification.resolve(provider);
+            assert_ne!(analysis, interaction, "{provider:?}");
+            assert_ne!(interaction, classification, "{provider:?}");
+            assert_ne!(analysis, classification, "{provider:?}");
+        }
     }
 
     /// Why: guessing an unverified Bedrock inference-profile id fails at call
@@ -183,9 +225,9 @@ mod tests {
     }
 
     #[test]
-    fn bedrock_haiku_resolves() {
+    fn bedrock_classification_resolves() {
         assert_eq!(
-            ModelTier::Haiku.resolve(ProviderId::Bedrock),
+            ModelTier::Classification.resolve(ProviderId::Bedrock),
             Some("us.anthropic.claude-haiku-4-5-20251001-v1:0"),
             "the date-stamped, version-suffixed profile is the only form Bedrock accepts"
         );
@@ -210,17 +252,17 @@ mod tests {
         }
     }
 
-    /// Why: the two tiers name the same model today and the obvious
-    /// simplification is to collapse them into one variant. The split is the
-    /// point — it lets analysis and interaction diverge later without touching
-    /// a caller — so a test pins that they stay separate values (#5971).
+    /// Why: the two tiers resolved to the same model when the split was
+    /// introduced, so #5971 pinned that they stayed separate variants against a
+    /// collapse. #5987 gave them different models, which is the divergence the
+    /// split existed to allow — the assertion now checks that it happened.
     #[test]
     fn analysis_and_interaction_are_distinct_variants() {
         assert_ne!(ModelTier::Analysis, ModelTier::Interaction);
-        assert_eq!(
+        assert_ne!(
             ModelTier::Analysis.resolve(ProviderId::OpenRouter),
             ModelTier::Interaction.resolve(ProviderId::OpenRouter),
-            "both resolve to Opus 4.8 today (owner ruling 2026-08-18)"
+            "analysis is Opus 4.8 and interaction is Sonnet 4.6 (owner ruling 2026-08-18)"
         );
     }
 }

--- a/crates/trusty-common/tests/inference_foundation.rs
+++ b/crates/trusty-common/tests/inference_foundation.rs
@@ -285,10 +285,10 @@ fn model_tier_resolves_through_the_public_reexport() {
     );
     assert_eq!(
         ModelTier::Interaction.resolve(ProviderId::OpenRouter),
-        Some("anthropic/claude-opus-4.8")
+        Some("anthropic/claude-sonnet-4.6")
     );
     assert_eq!(
-        ModelTier::Haiku.resolve(ProviderId::OpenRouter),
+        ModelTier::Classification.resolve(ProviderId::OpenRouter),
         Some("anthropic/claude-haiku-4.5")
     );
     assert_eq!(
@@ -296,7 +296,11 @@ fn model_tier_resolves_through_the_public_reexport() {
         Some("claude-opus-4-8")
     );
     assert_eq!(
-        ModelTier::Haiku.resolve(ProviderId::Anthropic),
+        ModelTier::Interaction.resolve(ProviderId::Anthropic),
+        Some("claude-sonnet-4-6")
+    );
+    assert_eq!(
+        ModelTier::Classification.resolve(ProviderId::Anthropic),
         Some("claude-haiku-4-5-20251001")
     );
 }
@@ -312,7 +316,7 @@ fn model_tier_bedrock_opus_stays_unmapped_and_haiku_does_not() {
     assert_eq!(ModelTier::Analysis.resolve(ProviderId::Bedrock), None);
     assert_eq!(ModelTier::Interaction.resolve(ProviderId::Bedrock), None);
     assert_eq!(
-        ModelTier::Haiku.resolve(ProviderId::Bedrock),
+        ModelTier::Classification.resolve(ProviderId::Bedrock),
         Some("us.anthropic.claude-haiku-4-5-20251001-v1:0")
     );
 }

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -15,7 +15,7 @@ name = "trusty-gworkspace-mcp"
 path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.37", features = ["mcp"] }
+trusty-common = { path = "../trusty-common", version = "0.38", features = ["mcp"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -81,7 +81,7 @@ path = "src/bin/mcp_bridge.rs"
 # the index itself rather than a UDS client for a subprocess that holds it.
 # `uds-supervisor` is NOT dropped — trusty-console and trusty-agents still
 # depend on the shared `UdsServiceSupervisor` for trusty-review / trusty-analyze.
-trusty-common = { path = "../trusty-common", version = "0.37", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve"] }
+trusty-common = { path = "../trusty-common", version = "0.38", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console
 # is no longer bundled into trusty-memory (single-owner-per-binary); the
@@ -173,7 +173,7 @@ serial_test = { workspace = true }
 # the production library (mirrors the trusty-mpm and trusty-search pattern).
 # `docgen` (#5205 follow-up): `tests/generated_docs.rs` renders the MCP tool
 # section of README.md from `tool_definitions()`.
-trusty-common = { path = "../trusty-common", version = "0.37", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
+trusty-common = { path = "../trusty-common", version = "0.38", default-features = false, features = ["memory-core", "embedder-test-support", "docgen"] }
 chrono = { workspace = true }
 
 [features]

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -14,7 +14,7 @@ name        = "trusty-review"
 # synthesize_prompt.rs's prompt text (adds a coverage-gaps instruction). No
 # public API changed; the `PR version bump vs crates.io` gate (#4421) still
 # requires the bump since `src/**` changed.
-version     = "0.19.0"
+version     = "0.19.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/5987-classification-tier-rename.md
+++ b/crates/trusty-review/changelog.d/5987-classification-tier-rename.md
@@ -1,0 +1,3 @@
+Changed
+
+- The verifier and summarizer roles request `ModelTier::Classification`, renamed from `ModelTier::Haiku` in trusty-common. Both roles resolve the same model as before; a doc comment at the role mapping records that they select that tier for cost, not because verifying or summarising is classification. See #5987.

--- a/crates/trusty-review/src/config/config_tests.rs
+++ b/crates/trusty-review/src/config/config_tests.rs
@@ -525,7 +525,7 @@ fn role_models_openrouter_reviewer_resolves_opus_tier() {
 }
 
 #[test]
-fn role_models_openrouter_haiku_roles_resolve_haiku_tier() {
+fn role_models_openrouter_cost_roles_resolve_classification_tier() {
     let env = RoleEnv {
         provider: Some("openrouter".to_string()),
         ..Default::default()
@@ -552,10 +552,11 @@ fn role_models_bedrock_reviewer_keeps_sonnet_default() {
     assert_eq!(roles.reviewer.model, "us.anthropic.claude-sonnet-4-6");
 }
 
-/// Why: the haiku roles' resolved value must not change — only the mechanism
-/// producing it (a date-stamped constant became a tier lookup) (#5971).
+/// Why: the two cost-driven roles must keep the value they had — only the
+/// mechanism producing it changed (a date-stamped constant became a tier
+/// lookup in #5971, and that tier was renamed in #5987).
 #[test]
-fn role_models_bedrock_haiku_roles_resolve_the_same_id_as_before() {
+fn role_models_bedrock_cost_roles_resolve_the_same_id_as_before() {
     let roles = RoleModels::from_env(&RoleEnv::default());
     for (role, model) in [
         ("verifier", &roles.verifier.model),

--- a/crates/trusty-review/src/config/role_models.rs
+++ b/crates/trusty-review/src/config/role_models.rs
@@ -82,8 +82,18 @@ impl RoleModels {
     /// carries any values the caller parsed from `--reviewer-model` etc.
     /// `file_models` carries parsed TOML table values.  Both may be `None` to
     /// skip that layer.  The built-in default is a `ModelTier` (#5971): the
-    /// reviewer asks for `Analysis`, the verifier and summarizer for `Haiku`,
-    /// and the tier resolves against whichever provider won its own chain.
+    /// reviewer asks for `Analysis`, the verifier and summarizer for
+    /// `Classification`, and the tier resolves against whichever provider won
+    /// its own chain.
+    ///
+    /// The verifier and summarizer take `Classification` for its COST, not
+    /// because verifying or summarising IS classification (#5987).  The owner
+    /// ruling is that the model doing the judging is opus while not every
+    /// inference in the chain needs to be, and `Classification` is the cheapest
+    /// tier — the two roles land there for that reason alone.  Classification
+    /// as a workload is a separate concern that happens to resolve the same
+    /// model today; if the tiers diverge, revisit which one these roles want
+    /// rather than assuming this mapping still follows.
     /// Test: unit tests in `config::tests` cover all four precedence levels;
     /// the tier layer by `role_models_openrouter_*` / `role_models_bedrock_*`.
     pub fn resolve(
@@ -109,7 +119,7 @@ impl RoleModels {
             env.verifier_model.as_deref(),
             env.provider.as_deref(),
             file_models.and_then(|f| f.verifier.as_ref()),
-            ModelTier::Haiku,
+            ModelTier::Classification,
             crate::llm::models::DEFAULT_VERIFIER_MODEL,
             Provider::Bedrock,
             1.0,
@@ -121,7 +131,7 @@ impl RoleModels {
             env.summarizer_model.as_deref(),
             env.provider.as_deref(),
             file_models.and_then(|f| f.summarizer.as_ref()),
-            ModelTier::Haiku,
+            ModelTier::Classification,
             crate::llm::models::DEFAULT_SUMMARIZER_MODEL,
             Provider::Bedrock,
             0.0,


### PR DESCRIPTION
Closes #5987. Builds on the tier layer from #5976.

## Two changes

**The interaction tier resolves Sonnet 4.6.** Owner ruling of 2026-08-18 supersedes the earlier "both tiers resolve to Opus 4.8": classification → Haiku 4.5, user interaction → Sonnet 4.6, analysis → Opus 4.8. `ModelTier::Interaction` now resolves `anthropic/claude-sonnet-4.6` on OpenRouter and `claude-sonnet-4-6` on the Anthropic first-party API.

**The third variant is renamed `Haiku` → `Classification`.** The mapped value stays `anthropic/claude-haiku-4.5`. A tier names its purpose, not its current model.

## Model ids — how each was obtained

| Provider | Id | Source |
|---|---|---|
| OpenRouter | `anthropic/claude-sonnet-4.6` | Confirmed present in a live `GET https://openrouter.ai/api/v1/models` this session |
| Anthropic | `claude-sonnet-4-6` | `Skill(skill="claude-api")` model table, which states first-party ids are complete as written and must never carry a date suffix |

The two were obtained independently — the first-party id is not derived from the OpenRouter spelling.

## What the rename must not collapse

trusty-review's verifier and summarizer resolve that tier for **cost**, per the earlier ruling that the model doing the judging is opus while not every inference in the chain needs to be. Classification as a workload is a different concern. Both land on Haiku 4.5 today and are not the same thing. A doc comment at `RoleModels::resolve` records this so `verifier → Classification` does not read as a claim that verifying is classification. No fourth variant.

## Bedrock

Bedrock's opus arms stay unmapped, unchanged. Interaction is no longer an opus tier, so a Bedrock sonnet mapping is now conceivable — I did **not** add one. The ruling names OpenRouter and Anthropic only, and `crates/trusty-common/src/inference/tier.rs` separately documents a bare `us.anthropic.claude-sonnet-4-6` profile, so that arm is a decision for the owner rather than something to infer here. The code comment says so at the change site.

## Versions

`trusty-common` 0.37.0 → **0.38.0** — the minor position, because renaming a public enum variant is breaking and the crate is 0.x, so `preflight-publish.sh` CHECK 5 would stop a patch bump at release time. Three `version = "0.37"` requirement pins (root `[workspace.dependencies]`, trusty-gworkspace, trusty-memory) move to `"0.38"`. `trusty-review` 0.19.0 → 0.19.1 (patch — its own public API is unchanged; only a private built-in default moved).

`Cargo.lock` is regenerated in the same commit; `git diff Cargo.lock` is exactly the two version lines, and `cargo metadata --locked` exits 0.

## Test ladder — rung 4 (cross-crate: shared library plus its consumer)

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo check -p trusty-common -p trusty-review` | EXIT=0 |
| `cargo check --workspace` | EXIT=0, finished in 18m 39s |
| `cargo clippy -p trusty-common -p trusty-review --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-common --features inference-client` | `ok. 580 passed; 0 failed; 12 ignored` + `ok. 10 passed` (integration) |
| `cargo test -p trusty-review` | `ok. 1604 passed; 0 failed; 5 ignored`, plus 7 further green targets |
| `check_line_cap.sh` / `check_sld.sh` / `check-ui-bundle-freshness.sh` / `check_changelog_fragment.sh` | EXIT=0 each |

Every cargo invocation ran under `SKIP_UI_BUILD=1`; `git status --porcelain` confirms no `ui/dist` file changed.

The eight tier tests that actually ran:

```
test inference::tier::tests::analysis_and_interaction_are_distinct_variants ... ok
test inference::tier::tests::bedrock_classification_resolves ... ok
test inference::tier::tests::bedrock_opus_tiers_are_unmapped ... ok
test inference::tier::tests::every_tier_resolves_on_anthropic ... ok
test inference::tier::tests::every_tier_resolves_on_openrouter ... ok
test inference::tier::tests::non_claude_providers_resolve_nothing ... ok
test inference::tier::tests::the_three_tiers_resolve_three_distinct_models ... ok
test model_tier_resolves_through_the_public_reexport ... ok
```

### The precedence test is non-vacuous

#5976 proved `role_models_explicit_model_beats_tier_default` by inverting the precedence and watching it fail. Same check here — the tier moved ahead of the three explicit layers in `resolve_role`:

```
test config::tests::role_models_explicit_model_beats_tier_default ... FAILED
assertion `left == right` failed
  left: "anthropic/claude-opus-4.8"
 right: "openai/gpt-5.4-20260305"
test result: FAILED. 0 passed; 1 failed
```

The tier default beat the explicitly-named model, which is the regression the test exists to catch. Reverted, and the 16 `role_models_*` tests pass again.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
