### PR TITLE
feat(trusty-common): the interaction tier resolves Sonnet 4.6 on Bedrock

### DIFF
--- a/crates/trusty-common/changelog.d/5987-bedrock-interaction-sonnet-4-6.md
+++ b/crates/trusty-common/changelog.d/5987-bedrock-interaction-sonnet-4-6.md
@@ -1,0 +1,6 @@
+Changed
+
+- `ModelTier::Interaction` resolves `us.anthropic.claude-sonnet-4-6` on AWS
+  Bedrock instead of returning `None`. The analysis tier stays unmapped there:
+  its Opus 4.8 inference-profile id could not be verified, and the Sonnet
+  profile's shape does not predict it.

--- a/crates/trusty-common/src/inference/tier.rs
+++ b/crates/trusty-common/src/inference/tier.rs
@@ -70,6 +70,14 @@ const ANTHROPIC_SONNET_4_6: &str = "claude-sonnet-4-6";
 /// From the `claude-api` model reference.
 const ANTHROPIC_HAIKU_4_5: &str = "claude-haiku-4-5-20251001";
 
+/// Bedrock cross-region inference profile for Claude Sonnet 4.6 (US geography).
+///
+/// The bare form is the one Bedrock accepts — no date stamp and no `-v1:0`
+/// suffix, unlike the Haiku profile below. #5987: the owner ruled this arm maps
+/// because this id is verified, which is the whole difference from the analysis
+/// tier's unverifiable Opus profile.
+const BEDROCK_SONNET_4_6: &str = "us.anthropic.claude-sonnet-4-6";
+
 /// Bedrock cross-region inference profile for Claude Haiku 4.5 (US geography).
 ///
 /// Verified against a live Bedrock account; the short form
@@ -113,14 +121,15 @@ impl ModelTier {
     /// name a model. The caller already knows its provider (epic #2400's
     /// `provider_for` resolves it), so it passes both.
     /// What: returns the provider's id for this tier, or `None` when this
-    /// provider has no verified id for it — including AWS Bedrock's opus tiers,
-    /// deliberately unmapped because the inference-profile id could not be
-    /// verified and its shape is not derivable from the family name. `None` is
-    /// not an error: it means "no tier default here", and the caller keeps
-    /// whatever default it had. Providers that host no Claude model
+    /// provider has no verified id for it — including AWS Bedrock's analysis
+    /// tier, deliberately unmapped because the Opus 4.8 inference-profile id
+    /// could not be verified and its shape is not derivable from the family
+    /// name. `None` is not an error: it means "no tier default here", and the
+    /// caller keeps whatever default it had. Providers that host no Claude model
     /// (`OpenAI`, `Fireworks`, `Together`, `AtlasCloud`, `Local`) return `None`
     /// for every tier.
-    /// Test: `bedrock_opus_tiers_are_unmapped`, `bedrock_classification_resolves`,
+    /// Test: `bedrock_analysis_tier_is_unmapped`,
+    /// `bedrock_interaction_resolves_sonnet_4_6`, `bedrock_classification_resolves`,
     /// `every_tier_resolves_on_openrouter`, `every_tier_resolves_on_anthropic`,
     /// `non_claude_providers_resolve_nothing`.
     pub fn resolve(self, provider: ProviderId) -> Option<&'static str> {
@@ -135,13 +144,16 @@ impl ModelTier {
                 Self::Interaction => ANTHROPIC_SONNET_4_6,
                 Self::Classification => ANTHROPIC_HAIKU_4_5,
             }),
-            // #5971: Bedrock's Opus 4.8 inference-profile id is unmapped by
-            // owner ruling — it could not be verified and must not be guessed.
-            // #5987 moved interaction to Sonnet 4.6 but left this arm alone:
-            // the ruling covers the OpenRouter and Anthropic providers only, so
-            // adding a Bedrock sonnet mapping here needs its own decision.
             ProviderId::Bedrock => match self {
-                Self::Analysis | Self::Interaction => None,
+                // #5971: Bedrock's Opus 4.8 inference-profile id is unmapped by
+                // owner ruling — it could not be verified and must not be
+                // guessed. Do not map this arm from the Sonnet arm below: the
+                // profile shapes do not correspond, and an invented id fails at
+                // call time, not compile time.
+                Self::Analysis => None,
+                // #5987: the owner ruled this arm maps, because unlike Opus the
+                // Sonnet 4.6 profile id is verified.
+                Self::Interaction => Some(BEDROCK_SONNET_4_6),
                 Self::Classification => Some(BEDROCK_HAIKU_4_5),
             },
             ProviderId::OpenAI
@@ -216,12 +228,26 @@ mod tests {
 
     /// Why: guessing an unverified Bedrock inference-profile id fails at call
     /// time, not compile time, so the absence of a mapping is the intended
-    /// state and must be asserted rather than left to drift (#5971).
-    /// What: both opus-tier arms resolve to `None` on Bedrock.
+    /// state and must be asserted rather than left to drift (#5971). Its
+    /// neighbours now resolve, so a later change that "completes the table" from
+    /// their shape has to delete this assertion to do it.
+    /// What: the analysis tier resolves to `None` on Bedrock.
     #[test]
-    fn bedrock_opus_tiers_are_unmapped() {
+    fn bedrock_analysis_tier_is_unmapped() {
         assert_eq!(ModelTier::Analysis.resolve(ProviderId::Bedrock), None);
-        assert_eq!(ModelTier::Interaction.resolve(ProviderId::Bedrock), None);
+    }
+
+    /// Why: Bedrock's Sonnet 4.6 profile id is verified, so the interaction tier
+    /// resolves there while analysis stays unmapped (owner ruling, #5987).
+    /// What: the interaction arm returns the bare profile — no date stamp and no
+    /// `-v1:0` suffix, unlike the Haiku profile beside it.
+    #[test]
+    fn bedrock_interaction_resolves_sonnet_4_6() {
+        assert_eq!(
+            ModelTier::Interaction.resolve(ProviderId::Bedrock),
+            Some("us.anthropic.claude-sonnet-4-6"),
+            "the bare profile is the form Bedrock accepts for Sonnet 4.6"
+        );
     }
 
     #[test]

--- a/crates/trusty-common/tests/inference_foundation.rs
+++ b/crates/trusty-common/tests/inference_foundation.rs
@@ -308,13 +308,27 @@ fn model_tier_resolves_through_the_public_reexport() {
 /// Why: a later change that "completes the table" by guessing Bedrock's Opus
 /// 4.8 inference-profile id would ship a string that fails at call time, not
 /// compile time. The gap is the ruled outcome (#5971), so it is asserted.
-/// What: both opus arms are `None` on Bedrock; the haiku arm still resolves.
+/// What: the analysis arm is `None` on Bedrock through the public re-export.
 #[test]
-fn model_tier_bedrock_opus_stays_unmapped_and_haiku_does_not() {
+fn model_tier_bedrock_analysis_stays_unmapped() {
     use trusty_common::inference::ModelTier;
 
     assert_eq!(ModelTier::Analysis.resolve(ProviderId::Bedrock), None);
-    assert_eq!(ModelTier::Interaction.resolve(ProviderId::Bedrock), None);
+}
+
+/// Why: the two mapped Bedrock arms spell their profiles differently — Sonnet
+/// bare, Haiku date-stamped and version-suffixed — so pinning both together
+/// catches a change that normalises one onto the other's shape (#5987).
+/// What: the interaction and classification arms resolve through the public
+/// re-export, each to its own verified profile form.
+#[test]
+fn model_tier_bedrock_sonnet_and_haiku_resolve() {
+    use trusty_common::inference::ModelTier;
+
+    assert_eq!(
+        ModelTier::Interaction.resolve(ProviderId::Bedrock),
+        Some("us.anthropic.claude-sonnet-4-6")
+    );
     assert_eq!(
         ModelTier::Classification.resolve(ProviderId::Bedrock),
         Some("us.anthropic.claude-haiku-4-5-20251001-v1:0")


### PR DESCRIPTION
Closes the Bedrock half of the tier ruling recorded in #5987.

## What changed

`ModelTier::Interaction` returned `None` for `ProviderId::Bedrock`. It now
resolves the `us.anthropic.claude-sonnet-4-6` inference profile, per the owner's
ruling.

**The analysis arm still returns `None`, and that is deliberate.** The earlier
ruling to leave it unmapped covered Opus specifically, and rested on the Opus 4.8
profile id being unverifiable. Sonnet's is verified — that is the whole
difference. The two arms previously shared one comment; the comment is now split
so the Opus reason stands on its own, and the two-arm match became three arms.

## Tests

Two separate tests, so neither can be quietly widened into the other:

- `bedrock_interaction_resolves_sonnet_4_6` — asserts the exact profile id.
- `bedrock_analysis_tier_is_unmapped` — asserts the analysis arm is still `None`.
  This is what a later change has to delete before it can complete the table by
  guessing.

The integration suite gains the same split through the public re-export.

The new test was run red first against the pre-fix source at `33dca36c`:

```
test inference::tier::tests::bedrock_interaction_resolves_sonnet_4_6 ... FAILED
assertion `left == right` failed: the bare profile is the form Bedrock accepts for Sonnet 4.6
  left: None
 right: Some("us.anthropic.claude-sonnet-4-6")
test result: FAILED. 7 passed; 1 failed; 0 ignored; 0 measured; 585 filtered out
```

## Gates — rung 3, plus the rung-4 cross-crate additions (trusty-common is a shared library)

```
cargo fmt --check                                                        -> exit 0
cargo clippy -p trusty-common --features inference-client --all-targets -- -D warnings
                                                                         -> exit 0
cargo test -p trusty-common --features inference-client                  -> 581 passed; 0 failed; 12 ignored (lib)
                                                                            11 passed; 0 failed (inference_foundation)
SKIP_UI_BUILD=1 cargo check --workspace                                  -> exit 0 (Finished `dev` profile in 25m 53s)
cargo test -p trusty-review                                              -> 1604 passed; 0 failed; 5 ignored (lib), plus 10 test binaries all ok
```

`--features inference-client` is required: `inference::tier` is gated behind it,
so a bare `cargo test -p trusty-common` compiles none of this and is rejected by
the crate's zero-feature guard.

`trusty-review` is the only consumer of `trusty_common::inference::ModelTier`
(`trusty-mpm`'s same-named enum is unrelated).

## Non-Bedrock providers — no inconsistency found

Both other mapped providers already resolve the interaction tier to Sonnet 4.6:
OpenRouter to `anthropic/claude-sonnet-4.6`, the Anthropic first-party API to
`claude-sonnet-4-6`. Nothing to reconcile.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
