### PR TITLE
fix(trusty-audit): a Linear board registered by id collects the issues it was registered for (#5982)

### DIFF
--- a/crates/trusty-audit/changelog.d/5982-linear-team-id-resolves-to-its-team-key.md
+++ b/crates/trusty-audit/changelog.d/5982-linear-team-id-resolves-to-its-team-key.md
@@ -7,6 +7,23 @@ Fixed
   validated green and contributed nothing on every subsequent run. The same
   round trip also stores Linear's own casing, which that exact-match filter is
   equally sensitive to.
-- A Linear board already stored as something no issue can carry is now stated as
-  a gap in the return package, naming the re-registration to make. It used to
-  reach the collector and report as a covered board that happened to be quiet.
+- Registration now refuses a team whose key the sweep could never match, rather
+  than persisting it. `validate` documented that a registered Linear key is one
+  `is_linear_team_key` accepts and nothing enforced it: the reply's `key` field
+  is optional, so a reply that omitted it registered an empty key — an entry that
+  validated green, could never collect, and could not be removed either, because
+  `taudit remove linear:` is not a spelling the parser accepts.
+- A Linear team key already on disk is uppercased on its way to the sweep rather
+  than skipped. tga reads a stored key twice and disagreed with itself: its
+  collector compares team keys ignoring case, so `linear:eng` did collect
+  `ENG-1234`, while its classifier compares exactly, so the same issue classified
+  as nothing. Uppercasing keeps the collection and adds the classification.
+- A Linear board that no normalisation can save is now stated as a gap on
+  `taudit run` as well as `taudit audit`, and the run exits 2 rather than 0. The
+  sweep resolved the boards, discarded the gaps, and returned "every repository
+  audited" with no `linear:` section and nothing said — the silent skip the gap
+  line exists to replace.
+- That gap line now describes the key shape it needs instead of asserting the
+  stored key is a team id, and names both halves of the remedy: registering the
+  team key leaves the old entry behind, and a registry still holding it keeps
+  reporting the board as not audited.

--- a/crates/trusty-audit/changelog.d/5982-linear-team-id-resolves-to-its-team-key.md
+++ b/crates/trusty-audit/changelog.d/5982-linear-team-id-resolves-to-its-team-key.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `taudit add board linear:<team-id>` now registers the team's short key, so the
+  board collects the issues it was registered for. Validation accepted a team id
+  and stored it verbatim; collection matches `linear.team_keys` against the text
+  before the hyphen in `ENG-1234`, which a team id never occupies, so the board
+  validated green and contributed nothing on every subsequent run. The same
+  round trip also stores Linear's own casing, which that exact-match filter is
+  equally sensitive to.
+- A Linear board already stored as something no issue can carry is now stated as
+  a gap in the return package, naming the re-registration to make. It used to
+  reach the collector and report as a covered board that happened to be quiet.

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -843,6 +843,38 @@ mod cli_tests {
         );
     }
 
+    /// #5982: every repository succeeded and a registered board was skipped, so
+    /// this is `AllSucceeded` and still not a whole engagement. Before the
+    /// `board_gaps` wiring, `taudit run` over a legacy `linear:<team-id>` exited
+    /// 0 and rendered nothing at all about the board — the silent-empty shape
+    /// `boards::resolve`'s gap lines exist to replace.
+    ///
+    /// Against `9ee9cc386` the `RunReport::stating` constructor does not exist.
+    #[test]
+    fn a_sweep_that_skipped_a_board_does_not_exit_zero() {
+        use crate::run::{RepoRun, RunReport, SelectedRepo};
+
+        let audited = RepoRun {
+            repo: SelectedRepo {
+                name: "acme-api".to_owned(),
+                path: PathBuf::from("repos/acme-api"),
+            },
+            output: PathBuf::from("/work/out/00-acme-api"),
+            log: PathBuf::from("/work/logs/00-acme-api.log"),
+            gaps: Vec::new(),
+            resumed: false,
+            result: RepoResult::Succeeded,
+        };
+        let gap = "linear:a1b2c3d4 was not audited — re-register it (#5982)";
+        let outcome = Outcome::Run(RunReport::of(vec![audited]).stating(vec![gap.to_owned()]));
+
+        let text = render(&outcome);
+        assert!(text.contains(&format!("Not audited: {gap}")), "{text}");
+        // The board is not a repository that failed: the verdict is unchanged.
+        assert!(text.contains("Audited 1 repository"), "{text}");
+        assert_eq!(exit_code(&outcome), EXIT_INCOMPLETE);
+    }
+
     /// #5494: silent skipping is the defect. A resumed sweep finishes in
     /// seconds, and without a word about it that reads as a run that did
     /// nothing — so each carried-over repository is marked in its own line and

--- a/crates/trusty-audit/src/cli/render.rs
+++ b/crates/trusty-audit/src/cli/render.rs
@@ -372,6 +372,13 @@ fn render_package(package: &crate::package::ReturnPackage) -> String {
 /// `super::cli_tests::a_resumed_sweep_says_what_it_carried_over_and_what_it_audited`.
 fn render_run(report: &crate::run::RunReport) -> String {
     let mut out = String::new();
+    // #5982: a registered board this sweep will not collect, stated before the
+    // per-repository lines because it is a dimension of the whole sweep rather
+    // than of any one repository. Empty on the chain path, which states the same
+    // gaps in its own roll-up below — see `crate::run::RunReport::board_gaps`.
+    for gap in &report.board_gaps {
+        out.push_str(&format!("Not audited: {gap}\n"));
+    }
     for run in &report.repos {
         match &run.result {
             // #5494: a repository this run carried over from an earlier

--- a/crates/trusty-audit/src/registry.rs
+++ b/crates/trusty-audit/src/registry.rs
@@ -294,6 +294,35 @@ impl fmt::Display for Target {
 /// The shape a board spec must have, quoted back on a refusal.
 const BOARD_SHAPE: &str = "expected jira:<PROJECT-KEY> or linear:<TEAM-KEY-or-ID>";
 
+/// The longest team key tga's own extractor can produce. See
+/// [`is_linear_team_key`].
+const LINEAR_TEAM_KEY_MAX: usize = 10;
+
+/// Whether a Linear board key is one the sweep can actually collect against.
+///
+/// Why: #5982. `crate::validate` accepts a team's short key or its internal id,
+/// and only the short key ever reaches a collected issue — tga matches
+/// `linear.team_keys` against the text before the hyphen in an identifier like
+/// `ENG-1234`. A registered id validated green and collected nothing, and
+/// nothing said so, because from the collector's side a team with no matching
+/// issues looks exactly like a team with no issues. This is the one place that
+/// question is answered, so `crate::validate` (which resolves an id to the key
+/// before it is persisted) and `crate::run::boards` (which states the gap when a
+/// key stored earlier cannot collect) cannot drift apart.
+///
+/// What: `[A-Z][A-Z0-9]{0,9}`, the prefix shape
+/// `tga::classify::sources::linear::linear_key_regex` can capture. A team id
+/// fails it on all three counts — 36 characters, lowercase hex, and hyphens.
+///
+/// Test: `super::registry_tests::a_team_id_is_not_a_key_the_sweep_can_collect`.
+pub fn is_linear_team_key(key: &str) -> bool {
+    (1..=LINEAR_TEAM_KEY_MAX).contains(&key.len())
+        && key.starts_with(|c: char| c.is_ascii_uppercase())
+        && key
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
+}
+
 /// Turn a command-line spec into a target.
 ///
 /// Why: the one place argv becomes a [`Target`], so the CLI and the Tauri shell
@@ -713,6 +742,27 @@ mod registry_tests {
         Target::Board {
             provider,
             key: key.to_owned(),
+        }
+    }
+
+    /// The line between the two things `linear:<key>` has always accepted
+    /// (#5982). A team id is a legal spec and a readable team; it is simply not
+    /// a key any collected issue can carry.
+    #[test]
+    fn a_team_id_is_not_a_key_the_sweep_can_collect() {
+        for collectable in ["ENG", "FE", "A", "X9", "ABCDEFGHIJ"] {
+            assert!(is_linear_team_key(collectable), "{collectable}");
+        }
+        for not in [
+            "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "eng",
+            "ENG-1",
+            "ENG_X",
+            "9ENG",
+            "ABCDEFGHIJK",
+            "",
+        ] {
+            assert!(!is_linear_team_key(not), "{not}");
         }
     }
 

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -64,7 +64,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::config::EngagementConfig;
 use crate::error::AuditError;
@@ -108,144 +108,18 @@ mod pins;
 // needs somewhere to be explained and asserted.
 mod approve;
 
+// #5982: the values a sweep produces, split out when `RunReport::board_gaps`
+// crossed the 500-SLOC production cap. Re-exported, so `crate::run::RunReport`
+// and friends stay where every caller already names them.
+mod report;
+
 use approve::approve_for_indexing;
 use pins::{PinnedBinaries, pinned_binaries};
 use verify::verify_output;
 
 pub use checkpoint::{PROGRESS_FILE, Recollect, RunProgress, progress_path, read_progress};
+pub use report::{RepoResult, RepoRun, RunOptions, RunReport, RunStatus};
 pub use selection::{SELECTION_FILE, SelectedRepo, load_selection, save_selection, selection_path};
-
-/// What happened to one repository.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
-pub enum RepoResult {
-    /// `tga audit` exited 0 for this repository.
-    Succeeded,
-    /// It did not. The reason is the child's status, or why it never started.
-    Failed {
-        /// One line naming what went wrong, safe to show the recipient.
-        reason: String,
-    },
-}
-
-impl RepoResult {
-    /// Whether this repository was audited successfully.
-    pub fn succeeded(&self) -> bool {
-        matches!(self, RepoResult::Succeeded)
-    }
-}
-
-/// One repository's run: where its output and log landed, and how it ended.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
-pub struct RepoRun {
-    /// The repository, as selected.
-    pub repo: SelectedRepo,
-    /// Directory under `out/` holding this repository's audit output.
-    pub output: PathBuf,
-    /// File under `logs/` holding the child's combined stdout and stderr.
-    pub log: PathBuf,
-    /// Gaps `tga audit` stated in this repository's manifest (DOC-67 §9).
-    ///
-    /// A gap is a dimension the sweep could not assess — an unconfigured JIRA
-    /// project, a repository that could not be fetched from its remote. It is
-    /// ordinary for a successful run to state some, so a gap does not by itself
-    /// fail the repository; see [`verify_output`] for which ones do.
-    #[serde(default)]
-    pub gaps: Vec<String>,
-    /// Whether this entry was carried over from an earlier sweep (#5494).
-    ///
-    /// `true` means no `tga audit` child ran for this repository in the sweep
-    /// that produced this report — an earlier run audited it, and the output it
-    /// left is still on disk and still passes [`verify_output`]. It is recorded
-    /// so a re-run reads as a resume rather than as work that went suspiciously
-    /// fast.
-    #[serde(default)]
-    pub resumed: bool,
-    /// How it ended.
-    pub result: RepoResult,
-}
-
-/// Whether the sweep succeeded, partly succeeded, or failed outright.
-///
-/// Why: closure condition 3 of #5555, and DOC-67 §9's failed-but-continuing
-/// model. "One repository of six failed" and "every repository failed" call for
-/// different actions from the recipient, and collapsing them into a boolean is
-/// how a partial run gets delivered as a whole one.
-/// What: three states over the per-repo results. An empty sweep never reaches
-/// here — no selection is an error, not an [`AllSucceeded`](Self::AllSucceeded).
-/// Test: `super::run_tests::status_distinguishes_partial_from_total_failure`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
-pub enum RunStatus {
-    /// Every selected repository was audited.
-    AllSucceeded,
-    /// Some repositories were audited and some were not.
-    Partial,
-    /// No repository was audited.
-    AllFailed,
-}
-
-/// The result of one sweep.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
-pub struct RunReport {
-    /// One entry per selected repository, in selection order.
-    pub repos: Vec<RepoRun>,
-    /// The sweep's overall verdict.
-    pub status: RunStatus,
-}
-
-impl RunReport {
-    /// Build a report and derive its status from the per-repo results.
-    ///
-    /// Why: the status is DERIVED, never passed in, so no caller can construct
-    /// a report claiming a status its per-repo results do not support.
-    /// Test: `super::run_tests::status_distinguishes_partial_from_total_failure`.
-    pub fn of(repos: Vec<RepoRun>) -> Self {
-        let succeeded = repos.iter().filter(|r| r.result.succeeded()).count();
-        let status = if succeeded == repos.len() {
-            RunStatus::AllSucceeded
-        } else if succeeded == 0 {
-            RunStatus::AllFailed
-        } else {
-            RunStatus::Partial
-        };
-        Self { repos, status }
-    }
-
-    /// The repositories that failed.
-    pub fn failures(&self) -> impl Iterator<Item = &RepoRun> {
-        self.repos.iter().filter(|r| !r.result.succeeded())
-    }
-
-    /// The repositories an earlier sweep audited and this one carried over.
-    pub fn resumed(&self) -> impl Iterator<Item = &RepoRun> {
-        self.repos.iter().filter(|r| r.resumed)
-    }
-}
-
-/// How to run the sweep.
-///
-/// Why: a struct rather than a bare `bool` argument, matching
-/// [`crate::clone::CloneOptions`] — the flag is operator-facing and reaches
-/// this crate through [`crate::session::Command::Run`], so it will grow
-/// neighbours (an audit window, a repository subset) and a positional boolean
-/// at every call site is where those go wrong.
-/// What: one field today. [`RunOptions::default`] is the resuming behaviour.
-/// Test: `super::run_tests::a_fresh_run_re_audits_everything`.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct RunOptions {
-    /// Ignore the recorded progress and audit every selected repository again.
-    ///
-    /// Why: resume is a judgement about what is still valid, and an operator
-    /// who disagrees with that judgement needs a way to overrule it — a
-    /// recipient who has re-cloned their repositories has outputs that verify
-    /// fine and describe source that has moved on. Defaults to `false`, because
-    /// the expensive direction has to be the one asked for by name.
-    pub fresh: bool,
-}
 
 /// A filename-safe, collision-free stem for one repository's files.
 ///
@@ -468,6 +342,9 @@ where
     // is not reported ahead of a missing tool. Every child gets the same
     // sections: a board is a dimension of the engagement, not a unit of the
     // sweep, and tga correlates it against whichever repository it is auditing.
+    // #5982: only the arm that resolves states the gaps — see
+    // `RunReport::board_gaps`.
+    let mut board_gaps = Vec::new();
     let owned;
     let boards = match resolved {
         Some(boards) => boards,
@@ -478,6 +355,7 @@ where
                 &registry::engagement_targets(Some(config), work)?,
                 &config.boards,
             );
+            board_gaps.clone_from(&owned.gaps);
             &owned
         }
     };
@@ -518,7 +396,7 @@ where
         checkpoint::write_progress(work, &RunProgress::checkpoint(&decided(&runs)))?;
     }
 
-    let report = RunReport::of(decided(&runs));
+    let report = RunReport::of(decided(&runs)).stating(board_gaps);
     progress.operation_finished(
         Operation::Sweep,
         report.repos.iter().filter(|r| r.result.succeeded()).count(),
@@ -1708,6 +1586,93 @@ trusty-review = "0.15.1"
                 path.display()
             );
         }
+    }
+
+    /// The `taudit run` half of #5982. `boards::resolve` states a gap for a
+    /// board it will not collect, and until now only `crate::chain` read it —
+    /// this path resolved the boards, dropped `Boards::gaps` on the floor, and
+    /// returned `AllSucceeded` with no `linear:` section and nothing said. The
+    /// gap is a dimension of the sweep, not a repository that failed, so the
+    /// status stays `AllSucceeded` and `Outcome::exit_code` is what stops it
+    /// reading as a whole engagement.
+    ///
+    /// Against `9ee9cc386` the `board_gaps` field does not exist.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_board_the_sweep_cannot_collect_is_stated_on_the_run_path() {
+        /// A Linear team id, the shape a registry written before #5982 holds.
+        const TEAM_ID: &str = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &writes_a_manifest(None));
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+        register_boards(&work, &["linear:ENG", &format!("linear:{TEAM_ID}")]);
+
+        let report = sweep(
+            &work,
+            &board_config(),
+            &RunOptions::default(),
+            &Progress::none(),
+        )
+        .await
+        .expect("the sweep completes");
+
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+        assert_eq!(report.board_gaps.len(), 1, "{:?}", report.board_gaps);
+        assert!(
+            report.board_gaps[0].contains(TEAM_ID),
+            "{:?}",
+            report.board_gaps
+        );
+        assert_eq!(
+            crate::session::Outcome::Run(report).exit_code(),
+            crate::session::EXIT_INCOMPLETE,
+            "a sweep that skipped a registered board must not chain onward"
+        );
+
+        // The team that CAN collect is untouched by the one that cannot.
+        let generated =
+            std::fs::read_to_string(work.path(Area::State).join("tga-00-acme-api.yaml"))
+                .expect("the generated tga config");
+        assert!(generated.contains("- ENG"), "{generated}");
+        assert!(!generated.contains(TEAM_ID), "{generated}");
+    }
+
+    /// The chain states its own board gaps, so a sweep handed a resolution says
+    /// nothing about it — otherwise `taudit audit` prints each gap twice.
+    ///
+    /// Against `9ee9cc386` the `board_gaps` field does not exist.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_sweep_handed_its_boards_leaves_the_gaps_to_the_caller() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &writes_a_manifest(None));
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let config = board_config();
+        let resolved = boards::resolve(
+            &[
+                registry::parse(None, "linear:a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+                    .expect("parses"),
+            ],
+            &config.boards,
+        );
+        assert_eq!(resolved.gaps.len(), 1, "{resolved:?}");
+
+        let report = sweep_with_boards(
+            &work,
+            &config,
+            &RunOptions::default(),
+            &resolved,
+            &Progress::none(),
+        )
+        .await
+        .expect("the sweep completes");
+        assert!(report.board_gaps.is_empty(), "{:?}", report.board_gaps);
     }
 
     /// A stub that records the board variables it was handed.

--- a/crates/trusty-audit/src/run/boards.rs
+++ b/crates/trusty-audit/src/run/boards.rs
@@ -42,7 +42,7 @@
 use serde::Serialize;
 
 use crate::config::BoardCredentials;
-use crate::registry::{BoardProvider, Target};
+use crate::registry::{self, BoardProvider, Target};
 
 /// The variable the JIRA API token reaches the child under.
 pub const ENV_JIRA_TOKEN: &str = "TRUSTY_AUDIT_JIRA_TOKEN";
@@ -150,7 +150,10 @@ impl Boards {
 /// registered. Linear teams accumulate into one section, because tga's
 /// `linear.team_keys` is a list. A SECOND JIRA project is a gap: tga's
 /// `jira.project_key` is a single value, so the extra board would otherwise be
-/// silently dropped.
+/// silently dropped. A Linear team the sweep cannot match — the key is not a
+/// team key [`registry::is_linear_team_key`] recognises — is a gap for the same
+/// reason: it would otherwise reach `team_keys`, match no issue, and be reported
+/// as a covered board that happened to be quiet (#5982).
 /// Test: `super::boards_tests`.
 pub fn resolve(targets: &[Target], credentials: &BoardCredentials) -> Boards {
     let mut resolved = Boards::default();
@@ -174,6 +177,11 @@ pub fn resolve(targets: &[Target], credentials: &BoardCredentials) -> Boards {
             },
             BoardProvider::Linear => match credentials.linear.as_ref() {
                 None => resolved.gaps.push(unconfigured(target, *provider)),
+                // #5982: a key tga's matcher can never match collects nothing,
+                // and a silent nothing reads as a team with no issues.
+                Some(_) if !registry::is_linear_team_key(key) => {
+                    resolved.gaps.push(uncollectable_linear(target));
+                }
                 Some(_) => linear_teams.push(key.clone()),
             },
         }
@@ -194,6 +202,19 @@ fn unconfigured(target: &Target, provider: BoardProvider) -> String {
     )
 }
 
+/// The gap for a Linear board stored as something no issue can carry.
+///
+/// #5982 reached this state through registration, which accepted a team id and
+/// wrote it down; that half is fixed at the source now. This stays because the
+/// file outlives the fix — a target registered by id before it is still on disk,
+/// and a run that skipped it silently is the failure this line replaces.
+fn uncollectable_linear(target: &Target) -> String {
+    format!(
+        "{target} was not audited — `tga audit` matches Linear issues by team key (the `ENG` in \
+         `ENG-1234`), and that is a team id; re-register it as `linear:<TEAM-KEY>` (#5982)"
+    )
+}
+
 fn second_jira(target: &Target) -> String {
     format!(
         "{target} was not audited — `tga audit` takes one JIRA project per run, and another was \
@@ -209,6 +230,9 @@ mod boards_tests {
 
     const JIRA_TOKEN: &str = "jira-token-do-not-write-me-down";
     const LINEAR_KEY: &str = "lin_api_do-not-write-me-down";
+
+    /// A Linear team id, in the shape the API returns one. See #5982.
+    const TEAM_ID: &str = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
 
     fn board(spec: &str) -> Target {
         registry::parse(Some(TargetKind::Board), spec).expect("parses")
@@ -267,6 +291,33 @@ mod boards_tests {
         let linear = resolved.linear.expect("a configured Linear board");
         assert_eq!(linear.team_keys, vec!["ENG".to_owned(), "FE".to_owned()]);
         assert!(resolved.gaps.is_empty(), "{:?}", resolved.gaps);
+    }
+
+    /// A team id is what #5982 names: `crate::validate` accepted one, and tga
+    /// compares `team_keys` against the text before the hyphen in `ENG-1234`,
+    /// where a UUID never appears. The id used to reach `team_keys` and the run
+    /// reported a covered board that contributed nothing — indistinguishable
+    /// from a team with no issues.
+    #[test]
+    fn a_registered_team_id_is_a_gap_rather_than_a_team_that_collects_nothing() {
+        let resolved = resolve(&[board(&format!("linear:{TEAM_ID}"))], &both());
+        assert!(resolved.linear.is_none(), "{:?}", resolved.linear);
+        assert_eq!(resolved.gaps.len(), 1, "{:?}", resolved.gaps);
+        assert!(resolved.gaps[0].contains(TEAM_ID), "{:?}", resolved.gaps);
+        assert!(resolved.gaps[0].contains("#5982"), "{:?}", resolved.gaps);
+    }
+
+    /// The gap costs the teams around it nothing: a stale id alongside a real
+    /// team key leaves that team collecting exactly as it did.
+    #[test]
+    fn a_team_id_does_not_displace_the_team_keys_that_do_collect() {
+        let resolved = resolve(
+            &[board("linear:ENG"), board(&format!("linear:{TEAM_ID}"))],
+            &both(),
+        );
+        let linear = resolved.linear.clone().expect("ENG still collects");
+        assert_eq!(linear.team_keys, vec!["ENG".to_owned()]);
+        assert_eq!(resolved.gaps.len(), 1, "{:?}", resolved.gaps);
     }
 
     /// `jira.project_key` is one value, so the second project has nowhere to go.

--- a/crates/trusty-audit/src/run/boards.rs
+++ b/crates/trusty-audit/src/run/boards.rs
@@ -150,10 +150,14 @@ impl Boards {
 /// registered. Linear teams accumulate into one section, because tga's
 /// `linear.team_keys` is a list. A SECOND JIRA project is a gap: tga's
 /// `jira.project_key` is a single value, so the extra board would otherwise be
-/// silently dropped. A Linear team the sweep cannot match — the key is not a
-/// team key [`registry::is_linear_team_key`] recognises — is a gap for the same
-/// reason: it would otherwise reach `team_keys`, match no issue, and be reported
-/// as a covered board that happened to be quiet (#5982).
+/// silently dropped. A Linear team key is UPPERCASED on the way into
+/// `team_keys`, because tga's collector matches it case-insensitively and its
+/// classifier matches it exactly — so a lowercase key collected issues and
+/// classified none, and uppercasing is what makes one stored key mean one thing
+/// to both. A key that is not a team key [`registry::is_linear_team_key`]
+/// recognises even uppercased is a gap: it would otherwise reach `team_keys`,
+/// match no issue, and be reported as a covered board that happened to be quiet
+/// (#5982).
 /// Test: `super::boards_tests`.
 pub fn resolve(targets: &[Target], credentials: &BoardCredentials) -> Boards {
     let mut resolved = Boards::default();
@@ -177,12 +181,22 @@ pub fn resolve(targets: &[Target], credentials: &BoardCredentials) -> Boards {
             },
             BoardProvider::Linear => match credentials.linear.as_ref() {
                 None => resolved.gaps.push(unconfigured(target, *provider)),
-                // #5982: a key tga's matcher can never match collects nothing,
-                // and a silent nothing reads as a team with no issues.
-                Some(_) if !registry::is_linear_team_key(key) => {
-                    resolved.gaps.push(uncollectable_linear(target));
+                // #5982: uppercase first, gap only on what uppercasing cannot
+                // save. tga reads a stored key twice and disagrees with itself:
+                // `collect::linear::client::fetch_referenced_issues` compares
+                // `team_keys` with `eq_ignore_ascii_case`, so `eng` collected
+                // `ENG-1234`, while `classify::sources::linear::matches_team_key`
+                // compares exactly, so the same issue classified as nothing.
+                // Uppercasing keeps the collection and adds the classification;
+                // gapping a lowercase key would have taken the collection away.
+                Some(_) => {
+                    let key = key.to_ascii_uppercase();
+                    if registry::is_linear_team_key(&key) {
+                        linear_teams.push(key);
+                    } else {
+                        resolved.gaps.push(uncollectable_linear(target));
+                    }
                 }
-                Some(_) => linear_teams.push(key.clone()),
             },
         }
     }
@@ -207,11 +221,23 @@ fn unconfigured(target: &Target, provider: BoardProvider) -> String {
 /// #5982 reached this state through registration, which accepted a team id and
 /// wrote it down; that half is fixed at the source now. This stays because the
 /// file outlives the fix — a target registered by id before it is still on disk,
-/// and a run that skipped it silently is the failure this line replaces.
+/// and a run that skipped it silently is the failure this line replaces on the
+/// paths that state gaps: `taudit audit`, and `taudit run` via
+/// [`crate::run::RunReport::board_gaps`].
+///
+/// The line names the SHAPE rather than guessing what the stored key is. It is
+/// reached by a team id, by an over-long key, and by anything carrying a
+/// character a Linear identifier cannot — calling every one of them a team id
+/// was wrong. It also names BOTH halves of the remedy: registering the team key
+/// leaves the old entry in place, and a registry still holding it keeps
+/// answering [`crate::session::EXIT_INCOMPLETE`] for a board that is now
+/// audited.
 fn uncollectable_linear(target: &Target) -> String {
     format!(
         "{target} was not audited — `tga audit` matches Linear issues by team key (the `ENG` in \
-         `ENG-1234`), and that is a team id; re-register it as `linear:<TEAM-KEY>` (#5982)"
+         `ENG-1234`), which is one to ten characters of A-Z and 0-9 starting with a letter, and \
+         that key is not; re-register it as `linear:<TEAM-KEY>` AND drop this entry with `taudit \
+         remove {target}`, or every later run keeps reporting it (#5982)"
     )
 }
 
@@ -305,6 +331,40 @@ mod boards_tests {
         assert_eq!(resolved.gaps.len(), 1, "{:?}", resolved.gaps);
         assert!(resolved.gaps[0].contains(TEAM_ID), "{:?}", resolved.gaps);
         assert!(resolved.gaps[0].contains("#5982"), "{:?}", resolved.gaps);
+    }
+
+    /// The lowercase key #5982's fix must not cost anything. tga's collector
+    /// (`fetch_referenced_issues`) compares `team_keys` with
+    /// `eq_ignore_ascii_case`, so `linear:eng` already collected `ENG-1234`;
+    /// only its classifier (`matches_team_key`) compared exactly and matched
+    /// nothing. Gapping the key would have turned partial collection into none.
+    /// Uppercasing keeps the collection and adds the classification.
+    #[test]
+    fn a_lowercase_legacy_key_collects_uppercased_rather_than_gapping() {
+        let resolved = resolve(&[board("linear:eng")], &both());
+        let linear = resolved
+            .linear
+            .expect("a lowercase key still reaches the child");
+        assert_eq!(linear.team_keys, vec!["ENG".to_owned()]);
+        assert!(resolved.gaps.is_empty(), "{:?}", resolved.gaps);
+    }
+
+    /// The remedy the gap line states has two halves, and stating only the
+    /// first leaves the registry answering `EXIT_INCOMPLETE` forever for a board
+    /// the operator has since re-registered correctly. The line also describes
+    /// the key SHAPE rather than asserting the stored key is a team id — it is
+    /// reached by an over-long key too.
+    #[test]
+    fn the_gap_line_states_the_shape_and_both_halves_of_the_remedy() {
+        let resolved = resolve(&[board("linear:ABCDEFGHIJK")], &both());
+        assert!(resolved.linear.is_none(), "{:?}", resolved.linear);
+        let gap = &resolved.gaps[0];
+        assert!(!gap.contains("that is a team id"), "{gap}");
+        assert!(
+            gap.contains("re-register it as `linear:<TEAM-KEY>`"),
+            "{gap}"
+        );
+        assert!(gap.contains("`taudit remove linear:ABCDEFGHIJK`"), "{gap}");
     }
 
     /// The gap costs the teams around it nothing: a stale id alongside a real

--- a/crates/trusty-audit/src/run/report.rs
+++ b/crates/trusty-audit/src/run/report.rs
@@ -1,0 +1,189 @@
+//! What a sweep produced, and how it was asked to run.
+//!
+//! Why: #5982 added [`RunReport::board_gaps`] and pushed `run.rs` past the
+//! 500-SLOC production cap — the fourth split for that reason, after
+//! `selection`, `pins` and `approve`. It separates on the same line those did:
+//! `run.rs` drives `tga audit` children, and these types are the values that
+//! cross the boundary out of it. Nothing here spawns, reads or writes anything.
+//!
+//! What: [`RepoResult`] and [`RepoRun`] per repository, [`RunStatus`] and
+//! [`RunReport`] over the sweep, and [`RunOptions`] going the other way.
+//!
+//! Test: `super::run_tests`.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::SelectedRepo;
+
+/// What happened to one repository.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum RepoResult {
+    /// `tga audit` exited 0 for this repository.
+    Succeeded,
+    /// It did not. The reason is the child's status, or why it never started.
+    Failed {
+        /// One line naming what went wrong, safe to show the recipient.
+        reason: String,
+    },
+}
+
+impl RepoResult {
+    /// Whether this repository was audited successfully.
+    pub fn succeeded(&self) -> bool {
+        matches!(self, RepoResult::Succeeded)
+    }
+}
+
+/// One repository's run: where its output and log landed, and how it ended.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RepoRun {
+    /// The repository, as selected.
+    pub repo: SelectedRepo,
+    /// Directory under `out/` holding this repository's audit output.
+    pub output: PathBuf,
+    /// File under `logs/` holding the child's combined stdout and stderr.
+    pub log: PathBuf,
+    /// Gaps `tga audit` stated in this repository's manifest (DOC-67 §9).
+    ///
+    /// A gap is a dimension the sweep could not assess — an unconfigured JIRA
+    /// project, a repository that could not be fetched from its remote. It is
+    /// ordinary for a successful run to state some, so a gap does not by itself
+    /// fail the repository; see `super::verify_output` for which ones do.
+    #[serde(default)]
+    pub gaps: Vec<String>,
+    /// Whether this entry was carried over from an earlier sweep (#5494).
+    ///
+    /// `true` means no `tga audit` child ran for this repository in the sweep
+    /// that produced this report — an earlier run audited it, and the output it
+    /// left is still on disk and still passes `super::verify_output`. It is
+    /// recorded so a re-run reads as a resume rather than as work that went
+    /// suspiciously fast.
+    #[serde(default)]
+    pub resumed: bool,
+    /// How it ended.
+    pub result: RepoResult,
+}
+
+/// Whether the sweep succeeded, partly succeeded, or failed outright.
+///
+/// Why: closure condition 3 of #5555, and DOC-67 §9's failed-but-continuing
+/// model. "One repository of six failed" and "every repository failed" call for
+/// different actions from the recipient, and collapsing them into a boolean is
+/// how a partial run gets delivered as a whole one.
+/// What: three states over the per-repo results. An empty sweep never reaches
+/// here — no selection is an error, not an [`AllSucceeded`](Self::AllSucceeded).
+/// Test: `super::run_tests::status_distinguishes_partial_from_total_failure`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum RunStatus {
+    /// Every selected repository was audited.
+    AllSucceeded,
+    /// Some repositories were audited and some were not.
+    Partial,
+    /// No repository was audited.
+    AllFailed,
+}
+
+/// The result of one sweep.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RunReport {
+    /// One entry per selected repository, in selection order.
+    pub repos: Vec<RepoRun>,
+    /// The sweep's overall verdict.
+    pub status: RunStatus,
+    /// One line per registered board this sweep resolved and will not collect.
+    ///
+    /// Why: #5982. `super::boards::Boards::gaps` had exactly one reader,
+    /// `crate::chain`, so a board gap stated on `taudit audit` was discarded on
+    /// `taudit run` — a legacy `linear:<team-id>` produced exit 0,
+    /// [`RunStatus::AllSucceeded`], no `linear:` section, and no message. That
+    /// is the silent-empty shape `super::boards::resolve`'s gap lines exist to
+    /// replace, and replacing it on one of the two commands that run a sweep is
+    /// not replacing it.
+    ///
+    /// What: empty unless the sweep resolved the boards itself, which is the
+    /// `taudit run` path. `super::sweep_with_boards` takes a resolution its
+    /// caller already stated, and repeating it here would print each gap twice
+    /// on one screen — the same duplication `crate::cli::render::render_chain`
+    /// filters for the acquisition phase.
+    ///
+    /// Test: `super::run_tests::a_board_the_sweep_cannot_collect_is_stated_on_the_run_path`,
+    /// `super::run_tests::a_sweep_handed_its_boards_leaves_the_gaps_to_the_caller`,
+    /// `crate::cli::cli_tests::a_sweep_that_skipped_a_board_does_not_exit_zero`.
+    #[serde(default)]
+    pub board_gaps: Vec<String>,
+}
+
+impl RunReport {
+    /// Build a report and derive its status from the per-repo results.
+    ///
+    /// Why: the status is DERIVED, never passed in, so no caller can construct
+    /// a report claiming a status its per-repo results do not support.
+    /// Test: `super::run_tests::status_distinguishes_partial_from_total_failure`.
+    pub fn of(repos: Vec<RepoRun>) -> Self {
+        let succeeded = repos.iter().filter(|r| r.result.succeeded()).count();
+        let status = if succeeded == repos.len() {
+            RunStatus::AllSucceeded
+        } else if succeeded == 0 {
+            RunStatus::AllFailed
+        } else {
+            RunStatus::Partial
+        };
+        Self {
+            repos,
+            status,
+            board_gaps: Vec::new(),
+        }
+    }
+
+    /// The same report, also stating the boards the sweep will not collect.
+    ///
+    /// Separate from [`Self::of`] because the status stays derived from the
+    /// per-repo results alone: a board the sweep never attempted is not a
+    /// repository that failed, and folding it into [`RunStatus`] would report a
+    /// clean sweep as [`RunStatus::Partial`]. `crate::session::Outcome` is where
+    /// the two meet, and it answers `EXIT_INCOMPLETE` rather than
+    /// `EXIT_PARTIAL`. See [`Self::board_gaps`] (#5982).
+    #[must_use]
+    pub fn stating(mut self, board_gaps: Vec<String>) -> Self {
+        self.board_gaps = board_gaps;
+        self
+    }
+
+    /// The repositories that failed.
+    pub fn failures(&self) -> impl Iterator<Item = &RepoRun> {
+        self.repos.iter().filter(|r| !r.result.succeeded())
+    }
+
+    /// The repositories an earlier sweep audited and this one carried over.
+    pub fn resumed(&self) -> impl Iterator<Item = &RepoRun> {
+        self.repos.iter().filter(|r| r.resumed)
+    }
+}
+
+/// How to run the sweep.
+///
+/// Why: a struct rather than a bare `bool` argument, matching
+/// [`crate::clone::CloneOptions`] — the flag is operator-facing and reaches
+/// this crate through [`crate::session::Command::Run`], so it will grow
+/// neighbours (an audit window, a repository subset) and a positional boolean
+/// at every call site is where those go wrong.
+/// What: one field today. [`RunOptions::default`] is the resuming behaviour.
+/// Test: `super::run_tests::a_fresh_run_re_audits_everything`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RunOptions {
+    /// Ignore the recorded progress and audit every selected repository again.
+    ///
+    /// Why: resume is a judgement about what is still valid, and an operator
+    /// who disagrees with that judgement needs a way to overrule it — a
+    /// recipient who has re-cloned their repositories has outputs that verify
+    /// fine and describe source that has moved on. Defaults to `false`, because
+    /// the expensive direction has to be the one asked for by name.
+    pub fresh: bool,
+}

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -616,6 +616,13 @@ impl Session {
     /// access check, and [`registry::register`] owns the write — including the
     /// lock that stops two concurrent `add` runs discarding each other's target.
     ///
+    /// #5982: what is written is the target validation ANSWERED with, not the
+    /// one parsed from argv. `linear:<team-id>` names a readable team and is not
+    /// a key the sweep can collect against, so validation resolves it to the
+    /// team key while it already has Linear's team list in hand. The
+    /// [`Registration`] reports that same resolved target, so an operator who
+    /// typed an id is shown what was actually registered.
+    ///
     /// #5979: the config is REQUIRED here, where it used to be optional. It is
     /// the file a target is now declared in, so an absent one is
     /// [`AuditError::NoEngagementConfig`] rather than a registration that lands
@@ -647,7 +654,9 @@ impl Session {
         // other `add` for this engagement behind one unreachable site.
         // `register` re-reads the config, so the append is decided against the
         // snapshot current at write time.
-        validate::validate(&target, Some(&config), self.repo_probe).await?;
+        // #5982: what gets persisted is what validation resolved, not what was
+        // typed — a Linear team id would otherwise be stored and never collect.
+        let target = validate::validate(&target, Some(&config), self.repo_probe).await?;
         let inserted = self
             .under_registry_lock({
                 let (target, config_path) = (target.clone(), self.config_path.clone());

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -320,19 +320,27 @@ impl Outcome {
     /// next stage over a set the operator never actually got (#5215 review,
     /// #5555).
     /// What: [`EXIT_PARTIAL`] for a [`RunReport`] that did not fully succeed;
-    /// [`EXIT_INCOMPLETE`] for a [`CloneReport`] that carries gaps, and for a
-    /// [`ReturnPackage`] that does not cover every repository the sweep
-    /// attempted (#5499 — the package is still worth sending, and it is still
-    /// not the whole engagement); 0 otherwise. The policy lives here rather than
-    /// in `main.rs` so the Tauri shell reads the same judgement rather than
-    /// re-deriving it.
+    /// [`EXIT_INCOMPLETE`] for a [`CloneReport`] that carries gaps, for a
+    /// [`RunReport`] whose repositories all succeeded and which skipped a
+    /// registered board (#5982), and for a [`ReturnPackage`] that does not cover
+    /// every repository the sweep attempted (#5499 — the package is still worth
+    /// sending, and it is still not the whole engagement); 0 otherwise. The
+    /// policy lives here rather than in `main.rs` so the Tauri shell reads the
+    /// same judgement rather than re-deriving it.
     /// Test: `crate::cli::cli_tests::a_partial_sweep_does_not_exit_zero`,
     /// `crate::cli::cli_tests::a_run_with_gaps_exits_non_zero`,
+    /// `crate::cli::cli_tests::a_sweep_that_skipped_a_board_does_not_exit_zero`,
     /// `crate::cli::cli_tests::a_package_that_omits_a_repository_does_not_exit_zero`,
     /// `crate::chain::chain_tests::a_partly_failed_chain_packages_and_still_does_not_exit_zero`.
     pub fn exit_code(&self) -> i32 {
         match self {
             Outcome::Run(report) if report.status != run::RunStatus::AllSucceeded => EXIT_PARTIAL,
+            // #5982: a registered board the sweep could not collect is the same
+            // shape as a `Cloned` gap — every repository was audited and the
+            // engagement still did not cover what was registered. Without this,
+            // `taudit run` over a legacy `linear:<team-id>` exits 0 and chains
+            // onward over a board nobody read.
+            Outcome::Run(report) if !report.board_gaps.is_empty() => EXIT_INCOMPLETE,
             Outcome::Cloned(report) if !report.gaps.is_empty() => EXIT_INCOMPLETE,
             Outcome::Package(package) if !package.excluded.is_empty() => EXIT_INCOMPLETE,
             // #5824: the chain reports the sweep's verdict for the same reason

--- a/crates/trusty-audit/src/validate.rs
+++ b/crates/trusty-audit/src/validate.rs
@@ -43,7 +43,7 @@ use trusty_common::gh::GhCommand;
 use crate::config::{EngagementConfig, JiraCredentials, LinearCredentials};
 use crate::discover;
 use crate::error::AuditError;
-use crate::registry::{BoardProvider, Target};
+use crate::registry::{BoardProvider, Target, is_linear_team_key};
 
 /// Ceiling on one validation request.
 ///
@@ -165,12 +165,14 @@ const NO_SUCH_SUBCOMMAND: &str = "no-such-subcommand-5822";
 ///
 /// # Postconditions
 /// The returned target has the same [`Target::kind`] as `target`, and for a
-/// Linear board its key satisfies [`crate::registry::is_linear_team_key`] —
-/// which is the property `crate::run::boards::resolve` requires before a board
-/// reaches `linear.team_keys`.
+/// Linear board its key satisfies [`is_linear_team_key`] — which is the property
+/// `crate::run::boards::resolve` requires before a board reaches
+/// `linear.team_keys`. [`resolve_team_key`] is what enforces it; before #5982 it
+/// was a claim about a string this function echoed from the reply unchecked.
 ///
 /// Test: `super::validate_tests::a_board_with_no_credential_names_the_field`,
 /// `super::validate_tests::a_team_id_registers_as_the_team_key_that_collects`,
+/// `super::validate_tests::a_team_whose_key_the_sweep_cannot_match_is_refused`,
 /// and the `#[ignore]`d live probes.
 ///
 /// # Errors
@@ -335,14 +337,42 @@ struct Team {
 /// the id and the lowercase spelling Linear accepts here are both dead on
 /// arrival at collection. This is the only place that knows both what was typed
 /// and what Linear calls the team, so it is where the two are reconciled.
+///
 /// What: the first team whose `key` or `id` equals `typed` ignoring ASCII case,
-/// answered with that team's OWN `key` — never the caller's string.
-/// Test: `super::validate_tests::a_team_id_registers_as_the_team_key_that_collects`.
-fn resolve_team_key(teams: &[Team], typed: &str) -> Option<String> {
-    teams
+/// answered with that team's OWN `key` — never the caller's string, and only
+/// once uppercased — the same normalisation [`crate::run::boards::resolve`]
+/// applies to a key already on disk — and only when the result satisfies
+/// [`is_linear_team_key`]. Answering with the reply's
+/// key unchecked is what made [`validate`]'s postcondition a claim nothing
+/// enforced: [`Team::key`] is `#[serde(default)]`, so a reply that omits the
+/// field yields `""`, and an empty key registers green, can never collect, and
+/// cannot be removed either — `registry::parse(None, "linear:")` is an error, so
+/// the operator has no spelling that names the entry to drop. The `Err` is the
+/// reason [`board_refusal`] states, so the two failures read differently: the
+/// credential sees no such team, or it sees the team and Linear calls it
+/// something the sweep cannot match.
+///
+/// Test: `super::validate_tests::a_team_id_registers_as_the_team_key_that_collects`,
+/// `super::validate_tests::a_team_whose_key_the_sweep_cannot_match_is_refused`.
+fn resolve_team_key(teams: &[Team], typed: &str) -> Result<String, String> {
+    let Some(team) = teams
         .iter()
         .find(|t| t.key.eq_ignore_ascii_case(typed) || t.id.eq_ignore_ascii_case(typed))
-        .map(|t| t.key.clone())
+    else {
+        return Err(format!(
+            "the credential reaches {} team(s), and none of them is that one",
+            teams.len()
+        ));
+    };
+    let key = team.key.to_ascii_uppercase();
+    if is_linear_team_key(&key) {
+        return Ok(key);
+    }
+    Err(format!(
+        "Linear reports that team's key as `{}`, and `tga audit` matches issues by a key like the \
+         `ENG` in `ENG-1234` — one to ten characters of A-Z and 0-9 starting with a letter (#5982)",
+        team.key
+    ))
 }
 
 /// Prove the configured Linear credential can read this team, and name it.
@@ -396,17 +426,10 @@ async fn validate_linear(
         ));
     }
     let teams = reply.data.map(|d| d.teams.nodes).unwrap_or_default();
-    if let Some(team_key) = resolve_team_key(&teams, key) {
-        return Ok(team_key);
-    }
-    Err(board_refusal(
-        BoardProvider::Linear,
-        key,
-        format!(
-            "the credential reaches {} team(s), and none of them is that one",
-            teams.len()
-        ),
-    ))
+    // #5982: the resolver owns both outcomes, so a team the sweep could never
+    // match is refused here rather than persisted as a green registration.
+    resolve_team_key(&teams, key)
+        .map_err(|reason| board_refusal(BoardProvider::Linear, key, reason))
 }
 
 fn board_refusal(provider: BoardProvider, key: &str, reason: String) -> AuditError {
@@ -599,8 +622,35 @@ trusty-review = "0.15.1"
                 "the sweep cannot collect against {resolved}"
             );
         }
-        assert_eq!(resolve_team_key(&teams, "OPS"), None);
-        assert_eq!(resolve_team_key(&[], TEAM_ID), None);
+        for (teams, typed) in [(teams.as_slice(), "OPS"), (&[], TEAM_ID)] {
+            let reason = resolve_team_key(teams, typed).expect_err("no such team");
+            assert!(reason.contains("none of them is that one"), "{reason}");
+        }
+    }
+
+    /// The postcondition `validate` states, which nothing enforced: the reply's
+    /// `key` was echoed verbatim, and `Team::key` is `#[serde(default)]`, so a
+    /// reply that omits the field registered an empty key. That entry validated
+    /// green, could never collect, and could not be removed either —
+    /// `registry::parse(None, "linear:")` is an error, so no spelling names it.
+    /// Refusing at registration is the only point where the operator can still
+    /// act on it. See #5982.
+    #[test]
+    fn a_team_whose_key_the_sweep_cannot_match_is_refused() {
+        const TEAM_ID: &str = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+        for key in ["", "eng-team", "ABCDEFGHIJK", "1ENG"] {
+            let teams = vec![Team {
+                id: TEAM_ID.to_owned(),
+                key: key.to_owned(),
+            }];
+            let reason = resolve_team_key(&teams, TEAM_ID)
+                .expect_err("a key the sweep cannot match is not a registration");
+            assert!(reason.contains("#5982"), "key {key:?}: {reason}");
+            assert!(
+                reason.contains("matches issues by a key"),
+                "key {key:?}: {reason}"
+            );
+        }
     }
 
     /// The credential must not reach an error string, asserted directly rather

--- a/crates/trusty-audit/src/validate.rs
+++ b/crates/trusty-audit/src/validate.rs
@@ -145,17 +145,32 @@ impl RepoProbe {
 #[cfg(test)]
 const NO_SUCH_SUBCOMMAND: &str = "no-such-subcommand-5822";
 
-/// Prove `target` can be read with the credential the sweep will use.
+/// Prove `target` can be read, and answer with the spelling to persist.
 ///
-/// Why: the gate `crate::registry` runs before it persists anything. Returning
-/// `Ok(())` rather than data is deliberate — this answers one question, and a
-/// caller that also wanted the project's name would be tempted to make this a
-/// second collector.
-/// What: dispatches on the target. A board whose provider has no credential in
-/// the engagement config is refused HERE rather than at the request, so the
-/// message names the config field instead of an HTTP 401. `gh` carries the
-/// repository arm's invocations — see [`RepoProbe`].
+/// Why: the gate `crate::registry` runs before it persists anything. It returns
+/// the target rather than `()` because for Linear the two are not the same
+/// string: `taudit add board linear:<team-id>` names a team the credential can
+/// read, and the id is not what the sweep can collect against. Resolving it
+/// HERE — against the team list this check already fetches — is what keeps
+/// validation and collection agreeing on what identifies a board (#5982). The
+/// same round trip also canonicalises case, which `tga`'s exact-match filter
+/// is equally sensitive to.
+///
+/// What: dispatches on the target. A repository and a JIRA project are returned
+/// unchanged; a Linear board comes back carrying the team key Linear itself
+/// reports. A board whose provider has no credential in the engagement config is
+/// refused HERE rather than at the request, so the message names the config
+/// field instead of an HTTP 401. `gh` carries the repository arm's invocations —
+/// see [`RepoProbe`].
+///
+/// # Postconditions
+/// The returned target has the same [`Target::kind`] as `target`, and for a
+/// Linear board its key satisfies [`crate::registry::is_linear_team_key`] —
+/// which is the property `crate::run::boards::resolve` requires before a board
+/// reaches `linear.team_keys`.
+///
 /// Test: `super::validate_tests::a_board_with_no_credential_names_the_field`,
+/// `super::validate_tests::a_team_id_registers_as_the_team_key_that_collects`,
 /// and the `#[ignore]`d live probes.
 ///
 /// # Errors
@@ -168,23 +183,31 @@ pub async fn validate(
     target: &Target,
     config: Option<&EngagementConfig>,
     gh: RepoProbe,
-) -> Result<(), AuditError> {
+) -> Result<Target, AuditError> {
     match target {
-        Target::Repo { name_with_owner } => validate_repo(name_with_owner, gh).await,
+        Target::Repo { name_with_owner } => validate_repo(name_with_owner, gh)
+            .await
+            .map(|()| target.clone()),
         Target::Board { provider, key } => match provider {
             BoardProvider::Jira => {
                 let creds = config
                     .and_then(|c| c.boards.jira.as_ref())
                     .filter(|c| !c.token.is_empty() && !c.url.trim().is_empty())
                     .ok_or_else(|| missing(*provider, key))?;
-                validate_jira(creds, key).await
+                validate_jira(creds, key).await.map(|()| target.clone())
             }
             BoardProvider::Linear => {
                 let creds = config
                     .and_then(|c| c.boards.linear.as_ref())
                     .filter(|c| !c.api_key.is_empty())
                     .ok_or_else(|| missing(*provider, key))?;
-                validate_linear(creds, key, LINEAR_GRAPHQL_URL).await
+                // #5982: what gets stored is the team key Linear reports, not
+                // the id or the casing the operator happened to type.
+                let resolved = validate_linear(creds, key, LINEAR_GRAPHQL_URL).await?;
+                Ok(Target::Board {
+                    provider: *provider,
+                    key: resolved,
+                })
             }
         },
     }
@@ -306,18 +329,36 @@ struct Team {
     key: String,
 }
 
-/// Prove the configured Linear credential can read this team.
+/// The team key to register, given what the operator typed.
+///
+/// Why: #5982. A registered board is matched downstream by team key alone, so
+/// the id and the lowercase spelling Linear accepts here are both dead on
+/// arrival at collection. This is the only place that knows both what was typed
+/// and what Linear calls the team, so it is where the two are reconciled.
+/// What: the first team whose `key` or `id` equals `typed` ignoring ASCII case,
+/// answered with that team's OWN `key` — never the caller's string.
+/// Test: `super::validate_tests::a_team_id_registers_as_the_team_key_that_collects`.
+fn resolve_team_key(teams: &[Team], typed: &str) -> Option<String> {
+    teams
+        .iter()
+        .find(|t| t.key.eq_ignore_ascii_case(typed) || t.id.eq_ignore_ascii_case(typed))
+        .map(|t| t.key.clone())
+}
+
+/// Prove the configured Linear credential can read this team, and name it.
 ///
 /// One query lists the teams the key can see, and the match is made here rather
 /// than by a server-side filter: that answers "is the credential usable" and "is
 /// this team visible to it" in a single round trip, and a workspace whose team
 /// list is empty is then distinguishable from one where the key simply does not
-/// match. `endpoint` is a parameter so the live probe below can point elsewhere.
+/// match. Having the whole list is also what lets [`resolve_team_key`] answer
+/// with the team key rather than echoing what was typed. `endpoint` is a
+/// parameter so the live probe below can point elsewhere.
 async fn validate_linear(
     creds: &LinearCredentials,
     key: &str,
     endpoint: &str,
-) -> Result<(), AuditError> {
+) -> Result<String, AuditError> {
     let query = format!("query {{ teams(first: {LINEAR_TEAM_PAGE}) {{ nodes {{ id key }} }} }}");
     let response = trusty_installer::download::http_client()
         .post(endpoint)
@@ -355,11 +396,8 @@ async fn validate_linear(
         ));
     }
     let teams = reply.data.map(|d| d.teams.nodes).unwrap_or_default();
-    if teams
-        .iter()
-        .any(|t| t.key.eq_ignore_ascii_case(key) || t.id.eq_ignore_ascii_case(key))
-    {
-        return Ok(());
+    if let Some(team_key) = resolve_team_key(&teams, key) {
+        return Ok(team_key);
     }
     Err(board_refusal(
         BoardProvider::Linear,
@@ -533,6 +571,36 @@ trusty-review = "0.15.1"
             matches!(err, AuditError::BoardCredentialMissing { .. }),
             "{err:?}"
         );
+    }
+
+    /// #5982: registration used to store whatever the operator typed, so
+    /// `linear:<team-id>` validated green and then matched no issue. Resolution
+    /// happens against the team list the check already has, and the property the
+    /// collector needs is asserted on the answer rather than assumed.
+    #[test]
+    fn a_team_id_registers_as_the_team_key_that_collects() {
+        const TEAM_ID: &str = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+        let teams = vec![
+            Team {
+                id: TEAM_ID.to_owned(),
+                key: "ENG".to_owned(),
+            },
+            Team {
+                id: "99999999-0000-0000-0000-000000000000".to_owned(),
+                key: "FE".to_owned(),
+            },
+        ];
+
+        for typed in [TEAM_ID, "ENG", "eng"] {
+            let resolved = resolve_team_key(&teams, typed).expect("the team is visible");
+            assert_eq!(resolved, "ENG", "typed {typed}");
+            assert!(
+                crate::registry::is_linear_team_key(&resolved),
+                "the sweep cannot collect against {resolved}"
+            );
+        }
+        assert_eq!(resolve_team_key(&teams, "OPS"), None);
+        assert_eq!(resolve_team_key(&[], TEAM_ID), None);
     }
 
     /// The credential must not reach an error string, asserted directly rather


### PR DESCRIPTION
Closes #5982.

## What changed

Registration stores what validation resolved. `validate::validate` answers with
the target to persist rather than `()`, and the Linear arm reads the team key
out of the team list it already fetches — so `linear:<team-id>` is registered as
`linear:ENG`. The same round trip stores Linear's own casing, which tga's
exact-match filter is equally sensitive to; `linear:eng` had the identical
failure and is fixed by the same line.

`registry::is_linear_team_key` is the one place "is this a key the sweep can
collect against" is answered — it is the prefix shape tga's own extractor can
capture. Validation resolves against it and `run::boards::resolve` requires it,
so the two cannot drift.

A board already stored as something no issue can carry is now a gap line in the
return package naming the re-registration to make, rather than a `team_keys`
entry that matches nothing. The engagement config outlives this fix: a target
registered by id before it is still on disk, and reporting it as covered-and-quiet
is the failure mode being removed, not one to leave behind for the old rows.

Rejecting an id at registration was the other option. It would resolve the
asymmetry by removing an input `registry.rs` documents (`Project key, team key,
or team id`) and that Linear itself accepts, and it would leave already-registered
boards silently empty.

## Test ladder

Rung 3 — localized behavior inside `trusty-audit`, with `cargo check --workspace`
and the one dependent added because `validate::validate`'s signature changed.

```
cargo fmt --check                                       # exit 0
cargo check -p trusty-audit --all-targets               # exit 0
cargo clippy -p trusty-audit --all-targets -- -D warnings  # exit 0
cargo test -p trusty-audit                              # 423 + 25 passed; 0 failed; 7 ignored
cargo check --workspace                                 # exit 0
cargo check -p trusty-audit-ui --all-targets            # exit 0
```

The regression test, red on the pre-fix tree:

```
test run::boards::boards_tests::a_registered_team_id_is_a_gap_rather_than_a_team_that_collects_nothing ... FAILED
test run::boards::boards_tests::a_team_id_does_not_displace_the_team_keys_that_do_collect ... FAILED

assertion `left == right` failed
  left: ["ENG", "a1b2c3d4-e5f6-7890-abcd-ef1234567890"]
 right: ["ENG"]
test result: FAILED. 8 passed; 2 failed
```

Green after:

```
test registry::registry_tests::a_team_id_is_not_a_key_the_sweep_can_collect ... ok
test validate::validate_tests::a_team_id_registers_as_the_team_key_that_collects ... ok
test run::boards::boards_tests::a_registered_team_id_is_a_gap_rather_than_a_team_that_collects_nothing ... ok
test run::boards::boards_tests::a_team_id_does_not_displace_the_team_keys_that_do_collect ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 424 filtered out
```

Every test constructs the registered state directly — none needs a Linear
credential or the network.

Repo gates: `check_line_cap.sh`, `check_sld.sh`, `check_doc_numbers.sh`,
`check_teardown_guard.sh`, `check_changelog_fragment.sh` all exit 0.

## Also: `taudit run` now reports what it skips

`board_gaps` grew during review beyond the Linear id/key fix above.

- `taudit run` now reports registered boards it cannot collect from, and
  exits `EXIT_INCOMPLETE` when it skipped one. Previously the gap was
  resolved and discarded, so the command exited 0 over a board it never
  audited.
- The same channel now also surfaces the pre-existing `unconfigured` and
  `second_jira` gaps on `taudit run`, which were equally silent there before.
- A clean sweep with a skipped board is `AllSucceeded` + `EXIT_INCOMPLETE`,
  not `Partial` — status stays derived from per-repo results, because a board
  nobody attempted is not a repository that failed.
- `crates/trusty-audit/src/run.rs` hit the 500 SLOC cap when `board_gaps` was
  added. The value types moved to `run/report.rs` and are re-exported; no
  caller changed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

