### PR TITLE
docs: stop citing a drift-history count in CLAUDE.md's CI-gates section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,13 +119,14 @@ claims, and disputed results. Full rule in
 ### What CI actually gates
 
 🔴 **A bounded list of required checks gates every merge — read it live, never
-hand-copy the count.** This section has re-copied that count repeatedly: six,
-then nine, then eleven, with a rise to thirteen already staged (`ci.yml`
-gained `trusty-mpm-gui clippy` and `trusty-code-gui clippy` in
-[#5958](https://github.com/bobmatnyc/trusty-tools/pull/5958); only the
-branch-protection update to make them required is still pending). A stale copy
-has already cost a real merge (next paragraph). The list is never worth
-copying here — read it directly:
+hand-copy the list.** This section has repeated the same mistake every time a
+required job was added — most recently when `ci.yml` gained `trusty-mpm-gui
+clippy` and `trusty-code-gui clippy`
+([#5958](https://github.com/bobmatnyc/trusty-tools/pull/5958)) and branch
+protection picked both up as required. Copying the list here only gives the
+next such change one more place to go stale, and a stale copy has already cost
+a real merge (next paragraph). The list is never worth copying here — read it
+directly:
 
 ```bash
 gh api repos/bobmatnyc/trusty-tools/branches/main/protection \


### PR DESCRIPTION
## Summary

`CLAUDE.md`'s "What CI actually gates" section already reads the required-checks list live via `gh api ... --jq '.required_status_checks.contexts'` instead of hand-copying it (landed in #5967). What remained was a numeric drift-history sentence — "six, then nine, then eleven, with a rise to thirteen already staged ... only the branch-protection update ... still pending" — and that sentence had itself gone stale: the branch-protection update it called pending has landed, `gh api` now returns thirteen contexts, and the file still framed thirteen as not-yet-real.

This replaces that sentence with the same "why re-copying drifts" rationale, stated without any number: it names #5958 as a concrete example of how a required job gets added, instead of a count destined to drift again.

## What changed

Before:
> 🔴 **A bounded list of required checks gates every merge — read it live, never hand-copy the count.** This section has re-copied that count repeatedly: six, then nine, then eleven, with a rise to thirteen already staged (`ci.yml` gained `trusty-mpm-gui clippy` and `trusty-code-gui clippy` in [#5958](https://github.com/bobmatnyc/trusty-tools/pull/5958); only the branch-protection update to make them required is still pending). A stale copy has already cost a real merge (next paragraph). The list is never worth copying here — read it directly:

After:
> 🔴 **A bounded list of required checks gates every merge — read it live, never hand-copy the list.** This section has repeated the same mistake every time a required job was added — most recently when `ci.yml` gained `trusty-mpm-gui clippy` and `trusty-code-gui clippy` ([#5958](https://github.com/bobmatnyc/trusty-tools/pull/5958)) and branch protection picked both up as required. Copying the list here only gives the next such change one more place to go stale, and a stale copy has already cost a real merge (next paragraph). The list is never worth copying here — read it directly:

Everything else in the section is unchanged: the `gh api` command, the docs_only/`paths:`-filter/`strict:false` facts, the #5836 anecdote, the Tauri-UI-clippy paragraph, the eight-shard note, the BEHIND-branch note, and the `--admin` note.

## Test plan

- [x] `bash scripts/check_sld.sh` — exit 0
- [x] `bash scripts/check_line_cap.sh` — 0 violations (scopes `.rs` files only; doesn't apply to `CLAUDE.md`, run anyway per instructions)
- Docs-only change: no Cargo gates, no changelog fragment required

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools