### PR TITLE
feat(trusty-audit): audit a repository from a local path, never modifying it (#6001)

### DIFF
--- a/crates/trusty-audit/changelog.d/6001-case-collision.md
+++ b/crates/trusty-audit/changelog.d/6001-case-collision.md
@@ -1,0 +1,15 @@
+Fixed
+
+- Two local checkouts whose basenames differ only by case — `/srv/a/Apex` and
+  `/srv/b/apex` — are now refused as a `CollidingCheckouts` at both
+  registration and `clone_all`, instead of silently landing in one checkout.
+  On a case-insensitive, case-preserving filesystem (APFS's default, and the
+  one this feature runs on) `repos/local/Apex` and `repos/local/apex` are ONE
+  directory, but the derived name kept its case, so the second repository was
+  reported as audited having actually read the first one's history (the
+  #5896 wrong-corpus family). The collision comparison in both gates is now
+  case-folded, unconditionally.
+- `trusty-audit add repo`'s usability check for a local checkout now asks
+  `--is-bare-repository`, `--is-shallow-repository`, and `--show-toplevel` in
+  one `git rev-parse` invocation instead of two, tolerating the toplevel flag
+  failing on its own for a bare repository.

--- a/crates/trusty-audit/changelog.d/6001-ingest-a-local-checkout.md
+++ b/crates/trusty-audit/changelog.d/6001-ingest-a-local-checkout.md
@@ -1,0 +1,21 @@
+Added
+
+- `trusty-audit add repo /path/to/checkout` and a `repos.txt` line naming an
+  absolute path now audit a repository that is already on disk, which is the
+  only way in when the org it came from is no longer reachable from this
+  machine's GitHub credential. An ABSOLUTE path is a checkout and anything else
+  is a GitHub `owner/repo` — a syntactic rule, so the same `repos.txt` means the
+  same thing on every machine. Acquisition is `git clone <path>`, which hardlinks
+  the object store and reads the source only: **the source checkout is never
+  modified** — not a fetch, not a checkout, not a stash (a stash list is shared
+  across every worktree of a repository, so that is real damage, not a
+  theoretical one). The checkout lands under `repos/local/<basename>` and flows
+  through the existing sweep to a report and an `extract/<repo>.db`
+  indistinguishable from a remotely-cloned one, carrying committed history only.
+  A path that does not exist, is not a directory, is not readable, is not a git
+  repository, is a subdirectory of one, is a SHALLOW clone, or has no commits is
+  refused at registration naming which condition failed — a `--depth=1` source
+  would report one commit by one author over a zero-length period (#5916), so it
+  is refused rather than audited thinly. A bare mirror is accepted: it carries
+  the whole history. Two paths whose basenames match would share one checkout
+  directory and are refused at both gates, naming both paths (#6001).

--- a/crates/trusty-audit/src/chain.rs
+++ b/crates/trusty-audit/src/chain.rs
@@ -318,6 +318,9 @@ fn split_targets(
         .iter()
         .filter_map(|target| match target {
             Target::Repo { name_with_owner } => Some(name_with_owner.clone()),
+            // #6001: a local target's id IS its path, which is exactly the spec
+            // `clone_all` resolves — so acquisition takes one list, not two.
+            Target::LocalRepo { .. } => Some(target.id()),
             Target::Board { .. } => None,
         })
         .collect();

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -199,13 +199,17 @@ pub enum Verb {
 /// (#5822).
 #[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
 pub enum AddTarget {
-    /// A GitHub repository, checked with your `gh` credential.
+    /// A repository — on GitHub, or already checked out on this machine.
     ///
     /// Application, database-schema and migration, infrastructure, shared-library
     /// and config repositories all belong here.
+    ///
+    /// #6001: an ABSOLUTE path names a checkout on disk, checked by reading it
+    /// rather than with your `gh` credential; anything else is a GitHub
+    /// owner/name. The audit clones from the path and never modifies it.
     Repo {
-        /// The repository, as owner/name.
-        #[arg(value_name = "OWNER/NAME")]
+        /// The repository, as owner/name or an absolute path to a checkout.
+        #[arg(value_name = "OWNER/NAME|PATH")]
         name: String,
     },
     /// A JIRA project or Linear team, checked with the configured credential.

--- a/crates/trusty-audit/src/cli/targets_file.rs
+++ b/crates/trusty-audit/src/cli/targets_file.rs
@@ -38,7 +38,8 @@ pub const REPOS_FILE: &str = "repos.txt";
 pub const BOARDS_FILE: &str = "boards.txt";
 
 /// The shape a repository line may take, quoted back on a refusal.
-const REPO_SHAPE: &str = "expected owner/repo, or a https://github.com/owner/repo URL";
+const REPO_SHAPE: &str = "expected owner/repo, an absolute path to a checkout on this machine, \
+                          or a https://github.com/owner/repo URL";
 
 /// What a repository URL that is not GitHub's is told.
 const NOT_GITHUB: &str = "only github.com repository URLs are read — expected \
@@ -260,6 +261,15 @@ fn spec_of(kind: TargetKind, entry: &str) -> Result<String, String> {
 /// literal repository name `api.git`, a target that looks valid and clones
 /// nothing.
 fn repo_spec(entry: &str) -> Result<String, &'static str> {
+    // #6001: an absolute path is a checkout on disk and reaches `registry::parse`
+    // verbatim. It must skip every normalization below — `/srv/apex.git` is a
+    // bare mirror whose directory really is named `apex.git`, and the owner/name
+    // split would make `srv` an owner. The parse stays all-or-nothing either
+    // way: a path that is not a repository is refused by `crate::validate` at
+    // registration, naming which condition failed.
+    if crate::local_repo::is_local_spec(entry) {
+        return Ok(entry.to_owned());
+    }
     let (path, from_url) = match scheme_stripped(entry) {
         Some(rest) => (github_path(rest)?, true),
         None => (entry, false),
@@ -475,6 +485,41 @@ mod targets_file_tests {
         );
     }
 
+    /// 🔴 #6001: a `repos.txt` line may be an absolute path, and it must reach
+    /// the registry VERBATIM — no `.git` stripping, no owner/name split.
+    ///
+    /// The parse is all-or-nothing, so against `7eef4bb9b` one path line
+    /// refuses every repository in the file: `/srv/apex` splits to an empty
+    /// owner and `registry::parse` rejects it. `/srv/apex.git` is the sharper
+    /// case — the normalization would rewrite it to a directory that does not
+    /// exist, and the operator would get a refusal naming a path they never
+    /// listed.
+    #[test]
+    fn an_absolute_path_reaches_the_registry_unchanged() {
+        for entry in ["/srv/apex", "/srv/apex.git", "/srv/deep/nested/apex"] {
+            assert_eq!(
+                spec_of(TargetKind::Repo, entry),
+                Ok(entry.to_owned()),
+                "{entry} must reach the registry verbatim"
+            );
+        }
+    }
+
+    /// And a file mixing the two forms parses as one list, because a path line
+    /// halting the read is the same all-or-nothing failure a bad line is.
+    #[test]
+    fn a_path_and_a_remote_are_read_from_one_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            specs(detected(
+                tmp.path(),
+                Some("acme/api\n/srv/apex\nhttps://github.com/acme/web.git\n"),
+                None
+            )),
+            ["acme/api", "/srv/apex", "acme/web"]
+        );
+    }
+
     /// A URL and its short form are the same target, so a file mixing the two
     /// registers one entry per repository rather than two.
     #[test]
@@ -486,6 +531,12 @@ mod targets_file_tests {
     }
 
     /// Every refusal, each naming what it wanted instead.
+    ///
+    /// #6001 moved `/acme/api` out of this list: an absolute path is now a
+    /// checkout on disk, and whether THAT path is a usable repository is
+    /// `crate::validate`'s question — asked at registration, where the refusal
+    /// can name the condition that failed. A relative `acme/../etc` is still a
+    /// malformed `owner/repo` and still refused here.
     #[test]
     fn entries_that_are_not_targets_are_refused() {
         for entry in [
@@ -493,7 +544,6 @@ mod targets_file_tests {
             "acme/api/tree/main",
             "https://gitlab.com/acme/api",
             "https://github.com/acme",
-            "/acme/api",
             "acme/../etc",
         ] {
             assert!(

--- a/crates/trusty-audit/src/clone.rs
+++ b/crates/trusty-audit/src/clone.rs
@@ -246,11 +246,23 @@ fn resolve(spec: &str) -> Result<(String, Source), AuditError> {
 /// audited having read the first one's history. Refusing the whole request is
 /// the same shape as the name check beside it: nothing is acquired when the
 /// request cannot be honoured as asked.
-/// Test: `super::clone_tests::two_paths_with_one_basename_are_refused_together`.
+///
+/// **The comparison is case-folded** ([`local_repo::case_fold`]): on a
+/// case-insensitive, case-preserving filesystem — APFS's default, and the one
+/// this feature runs on — `repos/local/Apex` and `repos/local/apex` are ONE
+/// directory on disk even though [`derive_name`](local_repo::derive_name)
+/// preserves case, so a plain string comparison of `dest` misses exactly the
+/// collision this function exists to catch. Folding is unconditional, not
+/// gated on detecting the filesystem's case sensitivity — a false-positive
+/// refusal of a genuinely distinct pair on a case-sensitive filesystem is far
+/// cheaper than a misattributed audit.
+/// Test: `super::clone_tests::two_paths_with_one_basename_are_refused_together`,
+/// `super::clone_tests::two_paths_that_differ_only_by_case_are_refused_together`.
 fn refuse_collisions(planned: &[(String, Source, PathBuf, PathBuf)]) -> Result<(), AuditError> {
     for (index, (name, source, dest, _)) in planned.iter().enumerate() {
+        let dest_fold = local_repo::case_fold(&dest.to_string_lossy());
         for (other_name, other_source, other_dest, _) in &planned[index + 1..] {
-            if dest != other_dest {
+            if dest_fold != local_repo::case_fold(&other_dest.to_string_lossy()) {
                 continue;
             }
             // The same repository listed twice is the idempotent case, not a
@@ -1342,6 +1354,49 @@ mod clone_tests {
             panic!("expected CollidingCheckouts, got {err:?}");
         };
         assert_eq!(name, "local/apex");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains(&first.display().to_string()),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains(&second.display().to_string()),
+            "{rendered}"
+        );
+        assert!(
+            !work.path(Area::Repos).join("local").exists(),
+            "nothing may be acquired when the request is refused"
+        );
+    }
+
+    /// 🔴 On a case-insensitive, case-preserving filesystem (APFS's default —
+    /// the filesystem this feature runs on) `repos/local/Apex` and
+    /// `repos/local/apex` are ONE directory, but [`local_repo::derive_name`]
+    /// preserves case, so before the collision comparison was case-folded this
+    /// case pair was silently misattributed rather than refused: `clone_all`
+    /// returned `Ok` with the second repository reported as `CloneState::Reused`
+    /// against the first repository's on-disk tree, not `CollidingCheckouts`.
+    #[tokio::test]
+    async fn two_paths_that_differ_only_by_case_are_refused_together() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let first = tmp.path().join("a/Apex");
+        let second = tmp.path().join("b/apex");
+        source_repo(&first);
+        source_repo(&second);
+
+        let err = clone_all(
+            &work,
+            &[first.display().to_string(), second.display().to_string()],
+            &CloneOptions::default(),
+            &Progress::none(),
+        )
+        .await
+        .expect_err("a case-only difference must still be refused as a collision");
+        let AuditError::CollidingCheckouts { name, .. } = &err else {
+            panic!("expected CollidingCheckouts, got {err:?}");
+        };
+        assert_eq!(name.to_ascii_lowercase(), "local/apex");
         let rendered = err.to_string();
         assert!(
             rendered.contains(&first.display().to_string()),

--- a/crates/trusty-audit/src/clone.rs
+++ b/crates/trusty-audit/src/clone.rs
@@ -13,11 +13,15 @@
 //! step. Two further facts settle the mechanism rather than merely permitting
 //! it. `gh repo clone` configures that helper itself, so a private repository
 //! clones with no token ever passing through this crate's hands or its argv.
-//! And this workspace has no common entry point for spawning `git` —
-//! `git grep 'Command::new("git")' -- crates/*/src` returns nothing — so
-//! reaching for `git` directly would mean founding a second process-spawning
-//! domain, which is exactly what CLAUDE.md's common-entry-point rule forbids
-//! doing casually. `gh` already has one: `trusty_common::gh::GhCommand` (#5475).
+//! And `gh` has a common entry point in this workspace —
+//! `trusty_common::gh::GhCommand` (#5475) — while `git` has none, so reaching
+//! for `git` where `gh` answers would be a second implementation of one
+//! capability. That reasoning holds for a REMOTE and stops there: `gh repo
+//! clone` takes an `owner/repo` and cannot address a path, so #6001's local
+//! source spawns `git` in the one function [`crate::local_repo`] keeps it in.
+//! `trusty-audit` is a leaf crate and that spawn is not shared with any other,
+//! so consolidating it is a question for whoever founds a common `git` entry
+//! point, not a reason to leave a 1.4 GB checkout unreadable.
 //!
 //! **What a caller may assume, and may not.** A directory under
 //! [`Area::Repos`] is a COMPLETED, VERIFIED checkout, always. Work happens
@@ -32,6 +36,14 @@
 //! sequence aborts only when EVERY repository failed, which is the one case
 //! where continuing would produce a report about nothing.
 //!
+//! **Two kinds of source, one downstream** (#6001). An entry in the request is
+//! either a GitHub `owner/repo` or an ABSOLUTE path to a checkout already on
+//! disk — [`crate::local_repo::is_local_spec`] owns that decision, and
+//! [`crate::local_repo`] owns the invariant that the operator's checkout is
+//! never modified. The fork lives in [`resolve`] and [`acquire`] and nowhere
+//! else: a local source is acquired into staging, verified and promoted by the
+//! same three steps, so nothing past this module can tell the two apart.
+//!
 //! **Acquiring is selecting** (#5556). What lands here is what the sweep audits:
 //! [`clone_all`] records the usable checkouts in `state/`[`run::SELECTION_FILE`]
 //! so `taudit clone …` and `taudit run` are one chain rather than two stages
@@ -42,9 +54,10 @@
 
 use std::path::{Path, PathBuf};
 
-use trusty_common::gh::{GhCommand, GhError};
+use trusty_common::gh::GhCommand;
 
 use crate::error::AuditError;
+use crate::local_repo;
 use crate::progress::{Operation, Progress, UnitOutcome};
 use crate::run::{self, SelectedRepo};
 use crate::workdir::{Area, WorkDir};
@@ -193,6 +206,74 @@ pub struct CloneReport {
 pub fn destination(work: &WorkDir, name_with_owner: &str) -> Result<PathBuf, AuditError> {
     let (owner, name) = split_name(name_with_owner)?;
     Ok(work.path(Area::Repos).join(owner).join(name))
+}
+
+/// Where one acquisition spec comes from, and what it is audited as.
+///
+/// Why: #6001 — an entry in the request is now either a GitHub `owner/repo` or
+/// an absolute path to a checkout already on disk, and the fork has to be made
+/// exactly once. Resolving it here, ahead of the loop, is what lets every name
+/// be validated and every destination be checked for collisions before ANY
+/// clone runs — the property `a_bad_name_is_refused_before_any_clone_runs`
+/// already held for names.
+/// Test: `super::clone_tests::a_local_path_is_acquired_under_the_local_owner`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Source {
+    /// `gh repo clone <owner/name>`.
+    Remote,
+    /// `git clone <path>`, reading the operator's checkout and never writing it.
+    Local(PathBuf),
+}
+
+/// Split one request entry into what it is audited as and where it comes from.
+///
+/// [`local_repo::is_local_spec`] owns the disambiguation, so `registry::parse`
+/// and this cannot decide differently about the same string.
+fn resolve(spec: &str) -> Result<(String, Source), AuditError> {
+    if !local_repo::is_local_spec(spec) {
+        return Ok((spec.to_owned(), Source::Remote));
+    }
+    let path = local_repo::normalize(spec);
+    let name = local_repo::derive_name(&path)?;
+    Ok((name, Source::Local(path)))
+}
+
+/// Refuse a request in which two entries would occupy one checkout directory.
+///
+/// Why: #6001. `clone_all` REUSES a directory that is already under `repos/`,
+/// which is correct for a re-run and wrong for a collision — `/srv/a/apex` and
+/// `/srv/b/apex` both derive `local/apex`, so the second would be reported as
+/// audited having read the first one's history. Refusing the whole request is
+/// the same shape as the name check beside it: nothing is acquired when the
+/// request cannot be honoured as asked.
+/// Test: `super::clone_tests::two_paths_with_one_basename_are_refused_together`.
+fn refuse_collisions(planned: &[(String, Source, PathBuf, PathBuf)]) -> Result<(), AuditError> {
+    for (index, (name, source, dest, _)) in planned.iter().enumerate() {
+        for (other_name, other_source, other_dest, _) in &planned[index + 1..] {
+            if dest != other_dest {
+                continue;
+            }
+            // The same repository listed twice is the idempotent case, not a
+            // collision: it is one checkout either way.
+            if source == other_source {
+                continue;
+            }
+            return Err(AuditError::CollidingCheckouts {
+                first: spec_of(name, source),
+                second: spec_of(other_name, other_source),
+                name: name.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// What an operator typed for this entry, for a message that points at it.
+fn spec_of(name: &str, source: &Source) -> String {
+    match source {
+        Source::Remote => name.to_owned(),
+        Source::Local(path) => path.display().to_string(),
+    }
 }
 
 /// Where a clone is built before it is renamed into place.
@@ -381,13 +462,15 @@ fn verify_checkout(tree: &Path) -> Result<(), String> {
 /// Test: `super::clone_tests::a_failed_clone_leaves_nothing_behind`,
 /// `super::clone_tests::a_successful_clone_is_renamed_into_place`,
 /// `super::clone_tests::a_commitless_clone_is_not_a_usable_checkout`.
-fn finish_one(dest: &Path, staged: &Path, outcome: Result<(), GhError>) -> (CloneState, u64, bool) {
+fn finish_one(dest: &Path, staged: &Path, outcome: Result<(), String>) -> (CloneState, u64, bool) {
     let discard = |state: CloneState| {
         let _ = std::fs::remove_dir_all(staged);
         (state, 0, true)
     };
-    if let Err(source) = outcome {
-        return discard(CloneState::Failed(source.to_string()));
+    // #6001: the reason arrives as a string rather than a `GhError`, because
+    // acquisition now has two mechanisms and only one of them is `gh`.
+    if let Err(reason) = outcome {
+        return discard(CloneState::Failed(reason));
     }
     // #5215: verify BEFORE the rename, so an unusable tree never occupies the
     // destination even briefly.
@@ -504,9 +587,12 @@ fn record_selection(work: &WorkDir, report: &CloneReport) -> Result<(), AuditErr
 ///
 /// [`AuditError::UnsafeArea`] for a `repos/` area, owner directory, or
 /// destination that is not a real directory, [`AuditError::InvalidRepoName`]
-/// for anything that is not a plain `owner/name`, [`AuditError::WorkDir`] for a
-/// directory that cannot be made or a selection that cannot be recorded, and
-/// [`AuditError::AllClonesFailed`] when nothing at all could be cloned.
+/// for anything that is neither a plain `owner/name` nor an absolute path,
+/// [`AuditError::LocalRepoUnusable`] for a path with no name a checkout can be
+/// made under, [`AuditError::CollidingCheckouts`] when two entries would occupy
+/// one destination, [`AuditError::WorkDir`] for a directory that cannot be made
+/// or a selection that cannot be recorded, and [`AuditError::AllClonesFailed`]
+/// when nothing at all could be cloned.
 pub async fn clone_all(
     work: &WorkDir,
     repos: &[String],
@@ -522,10 +608,23 @@ pub async fn clone_all(
 
     // #5215: every name is validated before ANY clone runs, so a typo in the
     // last entry cannot leave the first ten half-acquired.
-    let planned: Vec<(String, PathBuf, PathBuf)> = repos
+    // #6001: and every spec is resolved to its source in the same pass, so the
+    // two shapes diverge exactly once.
+    let planned: Vec<(String, Source, PathBuf, PathBuf)> = repos
         .iter()
-        .map(|r| Ok((r.clone(), destination(work, r)?, staging(work, r)?)))
+        .map(|spec| {
+            let (name, source) = resolve(spec)?;
+            Ok((
+                name.clone(),
+                source,
+                destination(work, &name)?,
+                staging(work, &name)?,
+            ))
+        })
         .collect::<Result<_, AuditError>>()?;
+    // #6001: two entries sharing a destination is refused here rather than
+    // silently reused as one another's checkout.
+    refuse_collisions(&planned)?;
 
     // #5823: announced only once every name has validated, so a display never
     // opens on an acquisition that a typo is about to refuse.
@@ -533,7 +632,7 @@ pub async fn clone_all(
     progress.operation_started(Operation::CloneRepos, total);
     let mut out = Vec::with_capacity(total);
     let mut spent: u64 = 0;
-    for (index, (name_with_owner, dest, staged)) in planned.into_iter().enumerate() {
+    for (index, (name_with_owner, source, dest, staged)) in planned.into_iter().enumerate() {
         progress.unit_started(
             Operation::CloneRepos,
             name_with_owner.as_str(),
@@ -585,11 +684,7 @@ pub async fn clone_all(
             })?;
         }
 
-        let ran = clone_command(&name_with_owner, &staged)
-            .output()
-            .await
-            .and_then(|o| o.ok())
-            .map(|_| ());
+        let ran = acquire(&name_with_owner, &source, &staged).await;
         let (state, bytes, complete) = finish_one(&dest, &staged, ran);
         spent = spent.saturating_add(bytes);
         announce(progress, &name_with_owner, &state);
@@ -606,6 +701,36 @@ pub async fn clone_all(
     let report = summarize(out)?;
     record_selection(work, &report)?;
     Ok(report)
+}
+
+/// Fetch one repository into `staged`, whichever kind of source it has.
+///
+/// Why: #6001 — the one place the two mechanisms differ. A LOCAL source is
+/// re-inspected here even though registration already proved it: a sweep runs
+/// hours after an `add`, and a source that has since been deleted, replaced
+/// with a shallow clone, or truncated must become a named gap rather than a
+/// thin report. That check is cheap (three `git rev-parse` reads) against a
+/// clone that is not.
+/// What: `gh repo clone` for a remote, `git clone <path>` for a local one.
+/// Either failure comes back as the reason `finish_one` records, so a bad
+/// source is one repository's gap and not the sweep's abort.
+/// Test: `super::clone_tests::a_local_path_is_acquired_under_the_local_owner`,
+/// `super::clone_tests::a_source_that_went_bad_after_registration_is_a_gap`.
+async fn acquire(name_with_owner: &str, source: &Source, staged: &Path) -> Result<(), String> {
+    match source {
+        Source::Remote => clone_command(name_with_owner, staged)
+            .output()
+            .await
+            .and_then(|o| o.ok())
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        Source::Local(path) => {
+            local_repo::inspect(path)
+                .await
+                .map_err(|reason| format!("{} is no longer usable: {reason}", path.display()))?;
+            local_repo::clone_into(path, staged).await
+        }
+    }
 }
 
 /// Tell a watching front end how one repository ended.
@@ -632,6 +757,8 @@ fn announce(progress: &Progress, name_with_owner: &str, state: &CloneState) {
 #[cfg(test)]
 mod clone_tests {
     use super::*;
+    use crate::local_repo::local_repo_tests::{run_git, source_repo};
+    use trusty_common::gh::GhError;
 
     fn work_in(dir: &Path) -> WorkDir {
         let work = WorkDir::new(dir.join("work"));
@@ -965,7 +1092,7 @@ mod clone_tests {
         plant_checkout(&staged);
         std::fs::write(staged.join("README.md"), b"partial").expect("write");
 
-        let (state, bytes, _) = finish_one(&dest, &staged, Err(gh_failure()));
+        let (state, bytes, _) = finish_one(&dest, &staged, Err(gh_failure().to_string()));
         assert!(matches!(state, CloneState::Failed(_)), "{state:?}");
         assert_eq!(bytes, 0);
         assert!(
@@ -1145,6 +1272,150 @@ mod clone_tests {
             report.total_bytes
         );
     }
+    /// 🔴 #6001: the whole local path, end to end. A path registers, clones into
+    /// `repos/local/<basename>`, verifies, and is recorded as the sweep's
+    /// selection — indistinguishable downstream from a remotely-cloned one.
+    ///
+    /// Against `7eef4bb9b` the spec reaches `split_name`, which refuses a
+    /// leading `/`, so `clone_all` returns `InvalidRepoName` and nothing is
+    /// acquired at all.
+    #[tokio::test]
+    async fn a_local_path_is_acquired_under_the_local_owner() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let src = tmp.path().join("apex");
+        source_repo(&src);
+
+        let report = clone_all(
+            &work,
+            &[src.display().to_string()],
+            &CloneOptions::default(),
+            &Progress::none(),
+        )
+        .await
+        .expect("a local checkout is a usable source");
+
+        assert_eq!(report.repos[0].state, CloneState::Cloned);
+        assert_eq!(report.repos[0].name_with_owner, "local/apex");
+        assert_eq!(
+            report.repos[0].path,
+            work.path(Area::Repos).join("local/apex")
+        );
+        assert!(report.gaps.is_empty(), "{:?}", report.gaps);
+        assert!(report.total_bytes > 0, "the report must state disk use");
+
+        // The acquired tree is a whole checkout with the source's history, not
+        // a truncated one — #5916's contract, held for this mechanism too.
+        let acquired = &report.repos[0].path;
+        assert!(!acquired.join(".git/shallow").exists());
+        assert_eq!(run_git(acquired, &["rev-list", "--count", "HEAD"]), "2");
+
+        // #5556: acquiring is selecting, on this path as much as the other.
+        let selected = run::load_selection(&work).expect("the sweep's input is there");
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].name, "local/apex");
+        assert_eq!(selected[0].path, Path::new("repos/local/apex"));
+    }
+
+    /// 🔴 Two local paths with one basename derive one destination, and
+    /// `clone_all` REUSES a directory that is already there — so without this
+    /// guard the second is reported as audited having read the first one's
+    /// history. Refused as a whole request, nothing acquired.
+    #[tokio::test]
+    async fn two_paths_with_one_basename_are_refused_together() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let first = tmp.path().join("a/apex");
+        let second = tmp.path().join("b/apex");
+        source_repo(&first);
+        source_repo(&second);
+
+        let err = clone_all(
+            &work,
+            &[first.display().to_string(), second.display().to_string()],
+            &CloneOptions::default(),
+            &Progress::none(),
+        )
+        .await
+        .expect_err("one destination for two repositories must be refused");
+        let AuditError::CollidingCheckouts { name, .. } = &err else {
+            panic!("expected CollidingCheckouts, got {err:?}");
+        };
+        assert_eq!(name, "local/apex");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains(&first.display().to_string()),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains(&second.display().to_string()),
+            "{rendered}"
+        );
+        assert!(
+            !work.path(Area::Repos).join("local").exists(),
+            "nothing may be acquired when the request is refused"
+        );
+    }
+
+    /// The same path twice is one checkout, not a collision — a `repos.txt` an
+    /// operator listed twice must still run.
+    #[tokio::test]
+    async fn the_same_path_twice_is_not_a_collision() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let src = tmp.path().join("apex");
+        source_repo(&src);
+        let spec = src.display().to_string();
+
+        let report = clone_all(
+            &work,
+            &[spec.clone(), format!("{spec}/")],
+            &CloneOptions::default(),
+            &Progress::none(),
+        )
+        .await
+        .expect("one repository listed twice is one repository");
+        assert_eq!(report.repos[0].state, CloneState::Cloned);
+        assert_eq!(report.repos[1].state, CloneState::Reused);
+    }
+
+    /// 🔴 A source that was fine at registration and is not fine at sweep time
+    /// becomes a NAMED gap. Reporting it as cloned is the fail-open this crate
+    /// has shipped three times.
+    #[tokio::test]
+    async fn a_source_that_went_bad_after_registration_is_a_gap() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let good = tmp.path().join("apex");
+        source_repo(&good);
+        let gone = tmp.path().join("deleted-since");
+
+        let report = clone_all(
+            &work,
+            &[good.display().to_string(), gone.display().to_string()],
+            &CloneOptions::default(),
+            &Progress::none(),
+        )
+        .await
+        .expect("one usable source keeps the sequence going");
+        assert_eq!(report.repos[0].state, CloneState::Cloned);
+        assert!(
+            matches!(report.repos[1].state, CloneState::Failed(_)),
+            "{:?}",
+            report.repos[1].state
+        );
+        assert_eq!(report.gaps.len(), 1);
+        assert!(
+            report.gaps[0].contains("does not exist"),
+            "{:?}",
+            report.gaps
+        );
+        assert!(
+            !work.path(Area::Repos).join("local/deleted-since").exists(),
+            "a failed source must not appear as a checkout"
+        );
+    }
+
     /// Why (#5823): every arm of the acquisition loop ends a unit, and two of
     /// them return early. A missed one leaves a display holding a repository
     /// the loop moved past minutes ago — and reports it as still cloning.

--- a/crates/trusty-audit/src/error.rs
+++ b/crates/trusty-audit/src/error.rs
@@ -689,6 +689,53 @@ pub enum AuditError {
         reason: String,
     },
 
+    /// A local path was registered and it is not a source this audit can read.
+    ///
+    /// Why: #6001. A remote repository is proved by a GitHub probe, and a path
+    /// has no such authority to ask — so the checks are the ones that decide
+    /// whether the sweep would produce a report worth anything, and every one of
+    /// them refuses rather than degrades. "Registered, then silently empty" is
+    /// the fail-open shape this crate has already shipped three times (#5215,
+    /// #5916, #5896).
+    /// What: names the path and the ONE condition that failed, in
+    /// `crate::local_repo::inspect`'s own words — "it has no commits", "it is a
+    /// shallow clone", "it is a subdirectory of the repository at …".
+    /// Test: `crate::local_repo::local_repo_tests::every_unusable_source_is_refused_by_name`,
+    /// `crate::validate::validate_tests::an_unusable_local_source_names_what_failed`.
+    #[error("{path} is not a repository this audit can read: {reason}; nothing was registered")]
+    LocalRepoUnusable {
+        /// The path that was refused.
+        path: PathBuf,
+        /// Which condition failed, as one clause.
+        reason: String,
+    },
+
+    /// Two registered targets would be acquired into one checkout directory.
+    ///
+    /// Why: #6001. A local path is audited under `local/<basename>`, so
+    /// `/srv/a/apex` and `/srv/b/apex` derive one name and one destination —
+    /// and [`crate::clone::clone_all`] reuses a directory that is already
+    /// there, so the second registration would be reported as audited having
+    /// read the first one's history. That is the wrong-corpus failure #5896
+    /// produced, so it is a refusal at both gates rather than a rename.
+    /// What: names both specs and the destination they share. Nothing was
+    /// registered, and nothing was acquired.
+    /// Test: `crate::clone::clone_tests::two_paths_with_one_basename_are_refused_together`,
+    /// `crate::session::session_tests::a_second_local_path_with_the_same_basename_is_refused`.
+    #[error(
+        "{first} and {second} would both be audited as {name}, so one would be reported \
+         having read the other's history — register one of them under a different \
+         directory name; nothing was changed"
+    )]
+    CollidingCheckouts {
+        /// The target that claimed the name first.
+        first: String,
+        /// The target that would have shared it.
+        second: String,
+        /// The `owner/name` both resolve to.
+        name: String,
+    },
+
     /// The target registry carries fewer entries than it declares.
     ///
     /// The registry's half of [`AuditError::TruncatedSelection`], for the same

--- a/crates/trusty-audit/src/lib.rs
+++ b/crates/trusty-audit/src/lib.rs
@@ -29,6 +29,7 @@
 //! | [`registry`] | the repositories and boards this engagement targets (#5822) |
 //! | [`validate`] | proving a target can be read, before it is registered (#5822) |
 //! | [`clone`] | getting the selected repositories onto the recipient's disk (#5215) |
+//! | [`local_repo`] | ingesting a repository that is already on disk, without touching it (#6001) |
 //! | [`run`] | driving the pinned `tga audit` over the selected repositories |
 //! | [`package`] | assembling the unencrypted deliverable that goes back (#5499) |
 //! | [`chain`] | driving all four of those in one call, resumably (#5824) |
@@ -81,6 +82,9 @@ pub mod discover;
 pub mod distribute;
 pub mod error;
 pub mod inference;
+// #6001: ingesting a repository that is already on disk — the disambiguation
+// rule, the read-only validation, and the never-modify-the-source invariant.
+pub mod local_repo;
 pub mod manifest;
 pub mod package;
 // #5823: the seam a front end renders live progress through, and the pump that

--- a/crates/trusty-audit/src/local_repo.rs
+++ b/crates/trusty-audit/src/local_repo.rs
@@ -36,6 +36,20 @@
 //! why the rule is syntactic rather than "an existing directory".
 //!
 //! Test: `super::local_repo_tests`.
+//!
+//! ## Trust boundary
+//!
+//! A local-path line in `engagement.toml` or `repos.txt` is as trusted as a
+//! shell command the operator runs directly: it can name any readable git
+//! repository on the machine, including another engagement's checkout or
+//! anything else the operator's own account can read. There is no sandbox
+//! that confines a local target to "under this engagement's source
+//! directory" — [`is_local_spec`] decides the spec's MEANING syntactically,
+//! and deciding its REACH was a separate question this feature deliberately
+//! left unanswered. The operator who can type a path into `repos.txt` already
+//! had that same filesystem access before this feature existed; this module
+//! adds a way to point the audit at it, not a new privilege. State this
+//! plainly so a future reviewer sees the boundary was considered, not missed.
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -142,6 +156,37 @@ pub fn derive_name(path: &Path) -> Result<String, AuditError> {
     Ok(format!("{LOCAL_OWNER}/{name}"))
 }
 
+/// Case-fold a derived name or destination path for a collision comparison.
+///
+/// Why: on a case-insensitive, case-preserving filesystem — APFS's default
+/// mode, and the filesystem this feature runs on — `repos/local/Apex` and
+/// `repos/local/apex` are ONE directory, but [`derive_name`] preserves case on
+/// purpose (the operator's basename is what an operator recognises). A
+/// collision gate that compares the derived names or destinations as plain
+/// strings sees two different values and misses the collision: the second
+/// registration or clone lands in the first's checkout and is reported as
+/// independently audited, having actually read the first repository's
+/// history. Folding only the *comparison*, not [`derive_name`]'s output,
+/// keeps the on-disk directory name exactly what the operator typed.
+///
+/// **Unconditional and ASCII-only.** Applied to every comparison in both
+/// collision gates — [`crate::clone::refuse_collisions`] and
+/// [`crate::session::Session::refuse_shared_checkout`] — not only when the
+/// two paths are known to share a filesystem: a false-positive refusal of a
+/// genuinely distinct `Apex`/`apex` pair on a case-sensitive filesystem costs
+/// far less than a silently misattributed audit. The fold is
+/// [`str::to_ascii_lowercase`], which folds `A`–`Z` only; a non-ASCII case
+/// pair (Turkish İ/i, German ẞ/ß) is not folded further by this function.
+/// That is a narrower guarantee than a full Unicode case fold, not a
+/// regression — those pairs were compared byte-for-byte before this function
+/// existed, so this can only catch more collisions, never fewer.
+/// Test: `super::local_repo_tests::case_folding_is_ascii_only`,
+/// `crate::clone::clone_tests::two_paths_that_differ_only_by_case_are_refused_together`,
+/// `crate::session::session_tests::a_second_local_path_that_differs_only_by_case_is_refused`.
+pub(crate) fn case_fold(s: &str) -> String {
+    s.to_ascii_lowercase()
+}
+
 /// Prove this path is a repository the audit can read, without changing it.
 ///
 /// Why: a remote target is validated by a GitHub probe; a local one has no such
@@ -183,21 +228,30 @@ pub async fn inspect(path: &Path) -> Result<(), String> {
     }
     std::fs::read_dir(path).map_err(|source| format!("it is not readable: {source}"))?;
 
-    // One invocation answers both, and fails as a unit when the path is not a
-    // repository at all — which is the message that has to come first.
-    let flags = rev_parse(path, &["--is-bare-repository", "--is-shallow-repository"])
-        .await
-        .map_err(|_| "it is not a git repository".to_owned())?;
-    let bare = flags.first().is_some_and(|line| line == "true");
-    let shallow = flags.get(1).is_some_and(|line| line == "true");
+    // Folded into one round trip rather than a bare-only follow-up call for
+    // `--show-toplevel`: a bare repository has no working tree, so that flag
+    // alone fails the whole invocation even though the other two still print —
+    // `rev_parse_lenient` keeps that partial answer instead of discarding it.
+    let lines = rev_parse_lenient(
+        path,
+        &[
+            "--is-bare-repository",
+            "--is-shallow-repository",
+            "--show-toplevel",
+        ],
+    )
+    .await;
+    if lines.len() < 2 {
+        return Err("it is not a git repository".to_owned());
+    }
+    let bare = lines[0] == "true";
+    let shallow = lines[1] == "true";
 
     if !bare {
-        let top = rev_parse(path, &["--show-toplevel"])
-            .await
-            .ok()
-            .and_then(|lines| lines.into_iter().next())
+        let top = lines
+            .get(2)
             .ok_or_else(|| "it is not a git repository".to_owned())?;
-        if !same_directory(path, Path::new(&top)) {
+        if !same_directory(path, Path::new(top)) {
             return Err(format!(
                 "it is a subdirectory of the repository at {top} — register that path instead"
             ));
@@ -268,23 +322,52 @@ pub async fn clone_into(source: &Path, into: &Path) -> Result<(), String> {
     ))
 }
 
+/// `git -C <path> rev-parse <args>`, as an argv.
+fn rev_parse_argv(path: &Path, args: &[&str]) -> Vec<OsString> {
+    let mut argv: Vec<OsString> = vec!["-C".into(), path.as_os_str().to_os_string()];
+    argv.push("rev-parse".into());
+    argv.extend(args.iter().map(OsString::from));
+    argv
+}
+
+/// `stdout` split into trimmed lines.
+fn rev_parse_lines(stdout: &[u8]) -> Vec<String> {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .map(|line| line.trim().to_owned())
+        .collect()
+}
+
 /// `git rev-parse <args>` against `path`, as trimmed stdout lines.
 ///
 /// Read-only in every form used here: `rev-parse` resolves refs and reads
 /// configuration, and writes nothing — which is what keeps the module's
 /// invariant true for the validation half as well as the clone.
 async fn rev_parse(path: &Path, args: &[&str]) -> Result<Vec<String>, ()> {
-    let mut argv: Vec<OsString> = vec!["-C".into(), path.as_os_str().to_os_string()];
-    argv.push("rev-parse".into());
-    argv.extend(args.iter().map(OsString::from));
-    let output = git(argv).output().await.map_err(|_| ())?;
+    let output = git(rev_parse_argv(path, args))
+        .output()
+        .await
+        .map_err(|_| ())?;
     if !output.status.success() {
         return Err(());
     }
-    Ok(String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .map(|line| line.trim().to_owned())
-        .collect())
+    Ok(rev_parse_lines(&output.stdout))
+}
+
+/// `git rev-parse <args>` against `path`, tolerating a non-zero exit.
+///
+/// Why: [`inspect`] folds `--is-bare-repository`, `--is-shallow-repository`
+/// and `--show-toplevel` into one invocation, and `--show-toplevel` fails on
+/// its own for a bare repository (no working tree) even though the two flags
+/// ahead of it already printed. [`rev_parse`]'s success gate would discard
+/// that partial stdout; this variant keeps it.
+/// What: empty only when the process could not be spawned — the same failure
+/// [`rev_parse`] maps to `Err(())`.
+async fn rev_parse_lenient(path: &Path, args: &[&str]) -> Vec<String> {
+    match git(rev_parse_argv(path, args)).output().await {
+        Ok(output) => rev_parse_lines(&output.stdout),
+        Err(_) => Vec::new(),
+    }
 }
 
 /// A `git` child with the ambient repository environment cleared.
@@ -399,6 +482,20 @@ pub(crate) mod local_repo_tests {
         // what stops a derived name reaching a path builder that refuses it.
         let name = derive_name(Path::new("/srv/my repo")).expect("a name");
         crate::clone::split_name(&name).expect("the derived name is a usable owner/name");
+    }
+
+    /// 🔴 The fix for the case-insensitive-filesystem collision (#6001 follow-up):
+    /// `Apex` and `apex` fold to the same string, which is what makes both
+    /// collision gates catch them. Also documents the stated ASCII-only scope —
+    /// a non-ASCII case pair is left exactly as case-sensitive as it was before
+    /// this function existed, never worse.
+    #[test]
+    fn case_folding_is_ascii_only() {
+        assert_eq!(case_fold("Apex"), "apex");
+        assert_eq!(case_fold("local/Apex"), "local/apex");
+        assert_eq!(case_fold("apex"), case_fold("APEX"));
+        // Non-ASCII: no further folding is claimed or attempted.
+        assert_ne!(case_fold("İstanbul"), case_fold("istanbul"));
     }
 
     #[test]

--- a/crates/trusty-audit/src/local_repo.rs
+++ b/crates/trusty-audit/src/local_repo.rs
@@ -1,0 +1,640 @@
+//! Auditing a repository that is already on the operator's disk (#6001).
+//!
+//! Why: [`crate::clone`] only ever ran `gh repo clone` against a remote, so an
+//! engagement whose corpus is a checkout on disk had no way in. That is not a
+//! hypothetical shape: the engagement this landed for has a 1.4 GB checkout with
+//! full history and 109 of its 111 sibling repositories no longer reachable from
+//! the machine's GitHub credential. The data was there and the tool could not
+//! read it.
+//!
+//! **The invariant: the source checkout is never modified.** Not a fetch, not a
+//! checkout, not a stash, not a config write. It matters concretely rather than
+//! theoretically — a git stash list is shared across every worktree of a
+//! repository, so one stash against a client's checkout is real damage to
+//! something someone else is using. Two things hold it:
+//!
+//! - Acquisition is `git clone <source> <staging>`, which reads the source and
+//!   writes only under the working directory. Everything downstream then sees a
+//!   checkout indistinguishable from a remotely-cloned one, so no later stage
+//!   needs to know where it came from.
+//! - The only other command run against the source is `git rev-parse`, which
+//!   reads refs and configuration and writes nothing.
+//!
+//! Test: `super::local_repo_tests::the_source_checkout_is_byte_identical_afterwards`.
+//!
+//! **Clone-from-local rather than operate-in-place.** A local clone hardlinks
+//! the object store, so it costs inodes rather than bytes and finishes in about
+//! the time a directory walk takes. Operating in place would be faster still and
+//! is exactly what the invariant forbids. The cost is that only COMMITTED
+//! history crosses over — uncommitted work in the source is invisible to the
+//! audit, which is what tga consumes anyway.
+//! Test: `super::local_repo_tests::a_local_clone_hardlinks_the_object_store`.
+//!
+//! ## What makes a spec a path rather than an `owner/repo`
+//!
+//! [`is_local_spec`]: the spec is ABSOLUTE. Nothing else — see that function for
+//! why the rule is syntactic rather than "an existing directory".
+//!
+//! Test: `super::local_repo_tests`.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use crate::error::AuditError;
+
+/// The owner segment every locally-sourced checkout is acquired under.
+///
+/// A local path has no owner, and [`crate::clone::destination`] builds
+/// `repos/<owner>/<name>` — so one is supplied. See [`derive_name`].
+pub const LOCAL_OWNER: &str = "local";
+
+/// Is this spec a local path rather than a GitHub `owner/repo`?
+///
+/// Why: `foo/bar` is a valid `owner/repo` AND a valid relative path, and a rule
+/// that guesses wrong audits a different repository than the operator named —
+/// the failure class this crate has already shipped once (#5896, fixed by
+/// #5963). So the rule is one syntactic property with no overlap: an
+/// `owner/repo` can never be absolute, because [`crate::clone::split_name`]
+/// refuses an empty owner and a leading `/` produces one.
+///
+/// It is deliberately NOT `trusty-mpm`'s `is_local_workdir` rule — "an absolute
+/// path that EXISTS as a directory" (`daemon/managed_routes/lifecycle.rs:394`).
+/// That rule asks the filesystem what a spec means, so the same `repos.txt` line
+/// means different things on two machines, and a mistyped absolute path silently
+/// demotes to an `owner/repo` that is then refused for the wrong reason. Making
+/// the meaning syntactic and the USABILITY a separate, loud check ([`inspect`])
+/// is what keeps a refusal pointed at the real problem.
+///
+/// No `file://` or `path:` prefix is accepted either: a second accepted
+/// spelling is a second rule to keep in step, and absoluteness already
+/// disambiguates completely.
+/// Test: `super::local_repo_tests::only_an_absolute_path_reads_as_a_local_repository`.
+pub fn is_local_spec(spec: &str) -> bool {
+    Path::new(spec.trim()).is_absolute()
+}
+
+/// The spec as a path, with trailing separators trimmed.
+///
+/// `/srv/apex/` and `/srv/apex` are one checkout, and leaving them as two
+/// strings would make them two registry entries that then collide on
+/// [`derive_name`]. Pure — nothing here touches the filesystem.
+pub fn normalize(spec: &str) -> PathBuf {
+    let trimmed = spec.trim();
+    let cut = trimmed.trim_end_matches('/');
+    PathBuf::from(if cut.is_empty() { "/" } else { cut })
+}
+
+/// `local/<basename>` — the `owner/name` a local checkout is audited under.
+///
+/// Why: output directories, `extract/<repo>.db` and every report section key on
+/// a repository name, and a path is not one. The basename is what an operator
+/// recognises, and a `.git` suffix comes off because `git clone` itself strips
+/// it — a bare `apex.git` would otherwise be audited under a name its own clone
+/// does not use.
+///
+/// **A git remote is deliberately NOT consulted.** Reading `remote.origin.url`
+/// would name the repository after somewhere it cannot be fetched from, which
+/// is the whole reason this path exists; and for the mirror-of-a-dead-org case
+/// it would resurrect an owner that no longer resolves. The path is the identity
+/// the operator has.
+///
+/// **On collision**, two paths whose basenames match derive one name and would
+/// share `repos/local/<name>` — the second finding the first's checkout and
+/// reporting it as reused, so one repository is audited twice under two
+/// registrations. That is refused rather than disambiguated, at both gates: at
+/// registration by [`crate::session`], and at acquisition by
+/// [`crate::clone::clone_all`], which refuses any request whose entries resolve
+/// to one destination.
+/// Test: `super::local_repo_tests::the_name_is_the_basename_without_a_git_suffix`,
+/// `crate::clone::clone_tests::two_paths_with_one_basename_are_refused_together`.
+///
+/// # Errors
+///
+/// [`AuditError::LocalRepoUnusable`] when the path has no basename, or when its
+/// basename holds no character a directory name may carry.
+pub fn derive_name(path: &Path) -> Result<String, AuditError> {
+    let unusable = |reason: &str| AuditError::LocalRepoUnusable {
+        path: path.to_path_buf(),
+        reason: reason.to_owned(),
+    };
+    let base = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| unusable("it has no directory name to audit it under"))?;
+    let base = base.strip_suffix(".git").unwrap_or(base);
+    // The same charset `clone::split_name` decides, applied by mapping rather
+    // than by refusing: a path is the operator's, not a name they chose for us.
+    let name: String = base
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if name.is_empty() || name == "." || name == ".." {
+        return Err(unusable(
+            "its directory name holds no character a checkout can be named after",
+        ));
+    }
+    Ok(format!("{LOCAL_OWNER}/{name}"))
+}
+
+/// Prove this path is a repository the audit can read, without changing it.
+///
+/// Why: a remote target is validated by a GitHub probe; a local one has no such
+/// authority to ask, so the checks are the ones that decide whether the sweep
+/// would produce a report worth anything. Every one of them is a refusal rather
+/// than a degraded run — this crate's recent history is a run of fail-open
+/// defects (#5215, #5916, #5896), and "accepted, then silently empty" is that
+/// same shape.
+///
+/// What: in order, so the first thing that is wrong is the thing named —
+/// exists, is a directory, is readable, is a git repository, is that
+/// repository's root, is not shallow, has at least one commit.
+///
+/// **Shallow is refused; bare is accepted.** A `--depth=1` source has exactly
+/// one commit, so tga would report one commit by one author over a zero-length
+/// period and every line attributed to whoever last touched it — measured, and
+/// the reason [`crate::clone`] carries no depth knob (#5916). A misleading
+/// report is worse than none, so it is refused loudly. A BARE repository has the
+/// full history and `git clone` turns it into an ordinary checkout, so refusing
+/// it would reject a perfectly good corpus — a mirror of an org that no longer
+/// answers is exactly the shape this feature exists for.
+///
+/// **A subdirectory is refused.** `git rev-parse` inside `/srv/apex/services`
+/// answers about `/srv/apex`, so accepting it would audit a repository the
+/// operator did not name — silently, and with a plausible-looking report.
+///
+/// Returns the bare reason rather than an [`AuditError`] because the two callers
+/// wrap it differently: registration refuses the operator, and the sweep records
+/// a gap.
+/// Test: `super::local_repo_tests::every_unusable_source_is_refused_by_name`,
+/// `super::local_repo_tests::a_bare_repository_is_a_usable_source`.
+pub async fn inspect(path: &Path) -> Result<(), String> {
+    let meta = std::fs::metadata(path).map_err(|source| match source.kind() {
+        std::io::ErrorKind::NotFound => "it does not exist".to_owned(),
+        _ => format!("it could not be read: {source}"),
+    })?;
+    if !meta.is_dir() {
+        return Err("it is not a directory".to_owned());
+    }
+    std::fs::read_dir(path).map_err(|source| format!("it is not readable: {source}"))?;
+
+    // One invocation answers both, and fails as a unit when the path is not a
+    // repository at all — which is the message that has to come first.
+    let flags = rev_parse(path, &["--is-bare-repository", "--is-shallow-repository"])
+        .await
+        .map_err(|_| "it is not a git repository".to_owned())?;
+    let bare = flags.first().is_some_and(|line| line == "true");
+    let shallow = flags.get(1).is_some_and(|line| line == "true");
+
+    if !bare {
+        let top = rev_parse(path, &["--show-toplevel"])
+            .await
+            .ok()
+            .and_then(|lines| lines.into_iter().next())
+            .ok_or_else(|| "it is not a git repository".to_owned())?;
+        if !same_directory(path, Path::new(&top)) {
+            return Err(format!(
+                "it is a subdirectory of the repository at {top} — register that path instead"
+            ));
+        }
+    }
+    if shallow {
+        return Err(
+            "it is a shallow clone, so its history is truncated and the audit would report \
+             one commit by one author — audit a full clone instead"
+                .to_owned(),
+        );
+    }
+    rev_parse(path, &["--verify", "HEAD"])
+        .await
+        .map_err(|_| "it has no commits".to_owned())?;
+    Ok(())
+}
+
+/// Whether two paths name one directory, comparing what the filesystem resolves.
+///
+/// `git rev-parse --show-toplevel` reports the resolved path, so a source
+/// reached through a symlink or a `/var` → `/private/var` alias would otherwise
+/// read as a subdirectory of itself. Falls back to a literal comparison when
+/// either side cannot be canonicalised, which fails CLOSED — an unresolvable
+/// path is refused rather than accepted.
+fn same_directory(left: &Path, right: &Path) -> bool {
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(l), Ok(r)) => l == r,
+        _ => left == right,
+    }
+}
+
+/// The clone invocation, as argv rather than a run.
+///
+/// Why: the argv is where #5916's defect lived — one `--depth=1` emptied the
+/// whole git-analytics leg — so it is asserted rather than trusted. Nothing here
+/// truncates history, and nothing disables the local-clone optimisation that
+/// makes this cheap.
+/// What: `clone <source> <into>`, and no more.
+/// Test: `super::local_repo_tests::a_local_clone_asks_git_for_the_whole_history`.
+pub fn clone_argv(source: &Path, into: &Path) -> Vec<OsString> {
+    vec![
+        "clone".into(),
+        source.as_os_str().to_os_string(),
+        into.as_os_str().to_os_string(),
+    ]
+}
+
+/// Copy the source into `into` with `git clone`, reading the source only.
+///
+/// Returns `git`'s own stderr on failure, so a gap line says what git said.
+///
+/// # Errors
+///
+/// The reason as one line — `git` missing, or a non-zero exit.
+pub async fn clone_into(source: &Path, into: &Path) -> Result<(), String> {
+    let output = git(clone_argv(source, into))
+        .output()
+        .await
+        .map_err(|source| format!("`git clone` could not be run: {source}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(format!(
+        "`git clone` exited {}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr).trim()
+    ))
+}
+
+/// `git rev-parse <args>` against `path`, as trimmed stdout lines.
+///
+/// Read-only in every form used here: `rev-parse` resolves refs and reads
+/// configuration, and writes nothing — which is what keeps the module's
+/// invariant true for the validation half as well as the clone.
+async fn rev_parse(path: &Path, args: &[&str]) -> Result<Vec<String>, ()> {
+    let mut argv: Vec<OsString> = vec!["-C".into(), path.as_os_str().to_os_string()];
+    argv.push("rev-parse".into());
+    argv.extend(args.iter().map(OsString::from));
+    let output = git(argv).output().await.map_err(|_| ())?;
+    if !output.status.success() {
+        return Err(());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|line| line.trim().to_owned())
+        .collect())
+}
+
+/// A `git` child with the ambient repository environment cleared.
+///
+/// An inherited `GIT_DIR` or `GIT_WORK_TREE` redirects a clone at whatever the
+/// parent shell was pointed at, which for an agent-run or hook-run invocation is
+/// somebody else's repository. `GIT_TERMINAL_PROMPT=0` keeps a source that
+/// unexpectedly wants credentials from hanging an unattended sweep.
+fn git(argv: Vec<OsString>) -> tokio::process::Command {
+    let mut command = tokio::process::Command::new("git");
+    command
+        .args(argv)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
+        .env("GIT_TERMINAL_PROMPT", "0");
+    command
+}
+
+#[cfg(test)]
+pub(crate) mod local_repo_tests {
+    use super::*;
+
+    /// Everything a source-checkout fixture needs, built with a real `git`.
+    ///
+    /// Every fixture is created under a `tempfile::tempdir`, so nothing here
+    /// names a path outside the repository and the suite passes on a fresh
+    /// clone on any machine.
+    pub(crate) fn init_repo(path: &Path) {
+        std::fs::create_dir_all(path).expect("the fixture directory");
+        run_git(path, &["init", "-q"]);
+        run_git(path, &["config", "user.email", "fixture@example.invalid"]);
+        run_git(path, &["config", "user.name", "Fixture"]);
+    }
+
+    pub(crate) fn commit(path: &Path, file: &str, body: &str) {
+        std::fs::write(path.join(file), body).expect("write the fixture file");
+        run_git(path, &["add", "-A"]);
+        run_git(path, &["commit", "-q", "-m", "fixture"]);
+    }
+
+    /// A source repository with two commits, ready to clone from.
+    pub(crate) fn source_repo(path: &Path) {
+        init_repo(path);
+        commit(path, "a.txt", "first\n");
+        commit(path, "a.txt", "first\nsecond\n");
+    }
+
+    fn pathstr(path: &Path) -> &str {
+        path.to_str().expect("a UTF-8 fixture path")
+    }
+
+    /// Run `git -C <cwd> <args>`, failing the test with git's own message.
+    pub(crate) fn run_git(cwd: &Path, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(cwd)
+            .args(args)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .output()
+            .expect("git is on PATH for this suite");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_owned()
+    }
+
+    /// 🔴 The disambiguation rule, stated as the pairs it has to keep apart.
+    ///
+    /// `foo/bar` is a valid `owner/repo` AND a valid relative path, so the rule
+    /// has to be one property with no overlap. Against a rule that also accepts
+    /// a relative path, the first two entries register a directory instead of a
+    /// GitHub repository.
+    #[test]
+    fn only_an_absolute_path_reads_as_a_local_repository() {
+        for remote in ["acme/api", "./acme/api", "../api", "acme/api.git", "a/b"] {
+            assert!(!is_local_spec(remote), "{remote} must stay an owner/repo");
+        }
+        for local in ["/srv/apex", "  /srv/apex  ", "/srv/apex/", "/"] {
+            assert!(is_local_spec(local), "{local} must read as a path");
+        }
+    }
+
+    #[test]
+    fn a_trailing_separator_is_not_a_second_repository() {
+        assert_eq!(normalize("/srv/apex/"), normalize("/srv/apex"));
+        assert_eq!(normalize("  /srv/apex  "), PathBuf::from("/srv/apex"));
+        assert_eq!(normalize("/"), PathBuf::from("/"));
+    }
+
+    #[test]
+    fn the_name_is_the_basename_without_a_git_suffix() {
+        for (path, expected) in [
+            ("/srv/apex", "local/apex"),
+            ("/srv/apex.git", "local/apex"),
+            ("/srv/APEX-2", "local/APEX-2"),
+            // Anything outside the charset a checkout directory may carry
+            // becomes `-`, the same substitution `run::sanitize` makes.
+            ("/srv/my repo", "local/my-repo"),
+        ] {
+            assert_eq!(
+                derive_name(Path::new(path)).expect("a name"),
+                expected,
+                "{path}"
+            );
+        }
+        // And what it produces is a name `clone::split_name` accepts, which is
+        // what stops a derived name reaching a path builder that refuses it.
+        let name = derive_name(Path::new("/srv/my repo")).expect("a name");
+        crate::clone::split_name(&name).expect("the derived name is a usable owner/name");
+    }
+
+    #[test]
+    fn a_path_with_no_usable_basename_is_refused() {
+        for path in ["/", "/.."] {
+            let err = derive_name(Path::new(path)).expect_err("{path} must be refused");
+            assert!(
+                matches!(err, AuditError::LocalRepoUnusable { .. }),
+                "{err:?}"
+            );
+        }
+    }
+
+    /// 🔴 Every refusal names the condition that failed, rather than accepting
+    /// the path and producing an empty audit.
+    #[tokio::test]
+    async fn every_unusable_source_is_refused_by_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        let missing = tmp.path().join("nowhere");
+        assert!(
+            inspect(&missing)
+                .await
+                .expect_err("absent")
+                .contains("does not exist"),
+            "an absent path must say so"
+        );
+
+        let file = tmp.path().join("a-file");
+        std::fs::write(&file, b"not a repo").expect("write");
+        assert!(
+            inspect(&file)
+                .await
+                .expect_err("a file")
+                .contains("not a directory"),
+            "a file must say so"
+        );
+
+        let plain = tmp.path().join("plain");
+        std::fs::create_dir(&plain).expect("mkdir");
+        assert!(
+            inspect(&plain)
+                .await
+                .expect_err("not a repo")
+                .contains("not a git repository"),
+            "a plain directory must say so"
+        );
+
+        let empty = tmp.path().join("empty");
+        init_repo(&empty);
+        assert!(
+            inspect(&empty)
+                .await
+                .expect_err("commitless")
+                .contains("no commits"),
+            "a commitless repository must say so"
+        );
+    }
+
+    /// 🔴 A `--depth=1` source produces the exact degenerate database #5916
+    /// measured — one commit, one author, a zero-length period. Refused loudly
+    /// rather than audited thinly.
+    #[tokio::test]
+    async fn a_shallow_source_is_refused_rather_than_audited_thinly() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let full = tmp.path().join("full");
+        source_repo(&full);
+        let shallow = tmp.path().join("shallow");
+        run_git(
+            tmp.path(),
+            &[
+                "clone",
+                "-q",
+                "--depth=1",
+                &format!("file://{}", pathstr(&full)),
+                pathstr(&shallow),
+            ],
+        );
+
+        inspect(&full)
+            .await
+            .expect("a full clone is a usable source");
+        let reason = inspect(&shallow)
+            .await
+            .expect_err("a shallow source must be refused");
+        assert!(reason.contains("shallow"), "{reason}");
+        assert!(
+            reason.contains("full clone"),
+            "the remedy must be named: {reason}"
+        );
+    }
+
+    /// A bare mirror carries the whole history and clones into an ordinary
+    /// checkout, so refusing it would reject the mirror-of-a-dead-org case this
+    /// feature exists for.
+    #[tokio::test]
+    async fn a_bare_repository_is_a_usable_source() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let full = tmp.path().join("full");
+        source_repo(&full);
+        let bare = tmp.path().join("mirror.git");
+        run_git(
+            tmp.path(),
+            &["clone", "-q", "--bare", pathstr(&full), pathstr(&bare)],
+        );
+
+        inspect(&bare)
+            .await
+            .expect("a bare repository is a usable source");
+        assert_eq!(derive_name(&bare).expect("a name"), "local/mirror");
+
+        let into = tmp.path().join("acquired");
+        clone_into(&bare, &into)
+            .await
+            .expect("a bare source clones");
+        assert_eq!(run_git(&into, &["rev-list", "--count", "HEAD"]), "2");
+    }
+
+    /// 🔴 Naming a subdirectory would audit the enclosing repository — a
+    /// different corpus than the operator asked for, reported as though it were
+    /// theirs.
+    #[tokio::test]
+    async fn a_subdirectory_is_refused_rather_than_silently_widened() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("apex");
+        source_repo(&repo);
+        let sub = repo.join("services");
+        std::fs::create_dir(&sub).expect("mkdir");
+
+        let reason = inspect(&sub)
+            .await
+            .expect_err("a subdirectory must be refused");
+        assert!(reason.contains("subdirectory"), "{reason}");
+        assert!(
+            reason.contains(repo.to_str().expect("utf-8")),
+            "the real root must be named: {reason}"
+        );
+    }
+
+    /// #5916's contract for this acquisition path: no depth flag can reach git.
+    #[test]
+    fn a_local_clone_asks_git_for_the_whole_history() {
+        let argv = clone_argv(Path::new("/srv/apex"), Path::new("/w/stage/local/apex"));
+        let rendered: Vec<String> = argv
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(rendered, ["clone", "/srv/apex", "/w/stage/local/apex"]);
+        assert!(
+            !rendered.iter().any(|a| a.contains("--depth")),
+            "{rendered:?}"
+        );
+    }
+
+    /// The "cheap" claim, verified rather than asserted: a local clone hardlinks
+    /// the object store, so the copy costs inodes and not bytes.
+    #[tokio::test]
+    async fn a_local_clone_hardlinks_the_object_store() {
+        use std::os::unix::fs::MetadataExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let src = tmp.path().join("apex");
+        source_repo(&src);
+        let into = tmp.path().join("acquired");
+        clone_into(&src, &into)
+            .await
+            .expect("a local source clones");
+
+        let loose: Vec<PathBuf> = walk(&src.join(".git/objects/")).into_iter().collect();
+        assert!(!loose.is_empty(), "the fixture must have loose objects");
+        for object in &loose {
+            let links = std::fs::metadata(object).expect("stat").nlink();
+            assert!(
+                links >= 2,
+                "{} was copied rather than hardlinked (nlink {links})",
+                object.display()
+            );
+        }
+    }
+
+    /// Every regular file under `dir`, recursively.
+    fn walk(dir: &Path) -> Vec<PathBuf> {
+        let mut out = Vec::new();
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return out;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                out.extend(walk(&path));
+            } else if path.is_file() {
+                out.push(path);
+            }
+        }
+        out
+    }
+
+    /// 🔴 THE invariant. The audit must never modify the source checkout — and a
+    /// git stash list is shared across every worktree of a repository, so this
+    /// is real damage to something someone else is using, not a theoretical one.
+    ///
+    /// Working tree, HEAD and reflog are all recorded before and compared after.
+    /// Against an operate-in-place design — a fetch, a checkout, a stash — every
+    /// one of these three assertions fails.
+    #[tokio::test]
+    async fn the_source_checkout_is_byte_identical_afterwards() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let src = tmp.path().join("apex");
+        source_repo(&src);
+        // Uncommitted work in the tree: the state an in-place fetch or stash
+        // would disturb, and the state this must leave exactly alone.
+        std::fs::write(src.join("dirty.txt"), b"work in progress\n").expect("write");
+
+        let snapshot = |what: &str| -> String {
+            match what {
+                "status" => run_git(&src, &["status", "--porcelain"]),
+                "head" => run_git(&src, &["rev-parse", "HEAD"]),
+                "stash" => run_git(&src, &["stash", "list"]),
+                _ => run_git(&src, &["reflog", "--format=%H %gd %gs"]),
+            }
+        };
+        let before = ["status", "head", "reflog", "stash"].map(snapshot);
+
+        inspect(&src).await.expect("the fixture is a usable source");
+        clone_into(&src, &tmp.path().join("acquired"))
+            .await
+            .expect("the source clones");
+
+        let after = ["status", "head", "reflog", "stash"].map(snapshot);
+        assert_eq!(before[0], after[0], "the working tree changed");
+        assert_eq!(before[1], after[1], "HEAD moved");
+        assert_eq!(before[2], after[2], "the reflog grew");
+        assert_eq!(before[3], after[3], "a stash was pushed onto a shared list");
+        assert!(
+            !src.join(".git/shallow").exists(),
+            "the source was truncated"
+        );
+    }
+}

--- a/crates/trusty-audit/src/registry.rs
+++ b/crates/trusty-audit/src/registry.rs
@@ -73,6 +73,7 @@ use trusty_common::file_lock::with_exclusive_lock;
 use crate::clone;
 use crate::config::{self, EngagementConfig};
 use crate::error::AuditError;
+use crate::local_repo;
 use crate::run;
 use crate::workdir::{self, Area, WorkDir};
 
@@ -241,6 +242,22 @@ pub enum Target {
         /// `owner/name`, the identity `gh` and [`crate::clone`] both take.
         name_with_owner: String,
     },
+    /// A repository already on the operator's disk, validated by reading it
+    /// (#6001).
+    ///
+    /// Why a variant rather than a `Repo` whose name happens to be a path: the
+    /// two are validated differently (a GitHub probe versus
+    /// [`crate::local_repo::inspect`]), acquired differently (`gh repo clone`
+    /// versus `git clone <path>`), and one of them must never have its
+    /// `owner/name` charset applied to it. Making that a field would put the
+    /// same fork inside every reader instead of at the one match arm.
+    LocalRepo {
+        /// The absolute path to the checkout, with trailing separators trimmed.
+        ///
+        /// Read only, ever — see [`crate::local_repo`] for the invariant and the
+        /// test that holds it.
+        path: PathBuf,
+    },
     /// A JIRA project or Linear team, validated with the configured credential.
     Board {
         /// Which provider.
@@ -251,21 +268,30 @@ pub enum Target {
 }
 
 impl Target {
-    /// The canonical spelling: `owner/name`, or `provider:key`.
+    /// The canonical spelling: `owner/name`, an absolute path, or
+    /// `provider:key`.
     ///
     /// This is what an operator types into `taudit remove`, and what the CLI
-    /// prints, so the two are the same string by construction.
+    /// prints, so the two are the same string by construction. It is also what
+    /// [`crate::chain`] hands to [`crate::clone::clone_all`] — a local target's
+    /// id is its path, which is exactly the spec that acquisition takes.
     pub fn id(&self) -> String {
         match self {
             Target::Repo { name_with_owner } => name_with_owner.clone(),
+            Target::LocalRepo { path } => path.display().to_string(),
             Target::Board { provider, key } => format!("{}:{key}", provider.as_str()),
         }
     }
 
     /// Which kind this is.
+    ///
+    /// A local checkout reports [`TargetKind::Repo`]: it is a repository the
+    /// engagement audits, and every count, filter and clone-versus-collect
+    /// decision in this crate wants it on that side of the line. The kind is the
+    /// VERB an operator used, and there is one verb for both — see [`parse`].
     pub fn kind(&self) -> TargetKind {
         match self {
-            Target::Repo { .. } => TargetKind::Repo,
+            Target::Repo { .. } | Target::LocalRepo { .. } => TargetKind::Repo,
             Target::Board { .. } => TargetKind::Board,
         }
     }
@@ -335,8 +361,18 @@ pub fn is_linear_team_key(key: &str) -> bool {
 /// [`clone::split_name`], the one place this crate decides that charset —
 /// registering a name `taudit clone` would later refuse is not a useful state to
 /// be able to reach.
+///
+/// #6001: the `repo` verb takes TWO shapes, and [`local_repo::is_local_spec`]
+/// decides which — an ABSOLUTE path is a checkout on disk, anything else is a
+/// GitHub `owner/repo`. One verb rather than two because the operator's intent
+/// is the same in both cases ("audit this repository"), and because the two
+/// spellings cannot overlap: `clone::split_name` refuses an empty owner, so no
+/// `owner/repo` is ever absolute. Nothing here touches the filesystem — whether
+/// the path is USABLE is [`crate::validate`]'s question, asked where it can be
+/// refused with the condition that failed.
 /// Test: `super::registry_tests::a_spec_that_is_neither_shape_is_refused`,
-/// `super::registry_tests::a_traversing_repo_name_is_never_registered`.
+/// `super::registry_tests::a_traversing_repo_name_is_never_registered`,
+/// `super::registry_tests::an_absolute_path_registers_as_a_local_checkout`.
 ///
 /// # Errors
 ///
@@ -345,12 +381,18 @@ pub fn is_linear_team_key(key: &str) -> bool {
 /// no known provider or carries an unusable key.
 pub fn parse(kind: Option<TargetKind>, spec: &str) -> Result<Target, AuditError> {
     let spec = spec.trim();
-    let wanted = kind.unwrap_or(if spec.contains(':') {
+    // #6001: a path is checked for FIRST, so a path holding a colon is still a
+    // path rather than a board with an unknown provider.
+    let local = local_repo::is_local_spec(spec);
+    let wanted = kind.unwrap_or(if !local && spec.contains(':') {
         TargetKind::Board
     } else {
         TargetKind::Repo
     });
     match wanted {
+        TargetKind::Repo if local => Ok(Target::LocalRepo {
+            path: local_repo::normalize(spec),
+        }),
         TargetKind::Repo => {
             clone::split_name(spec)?;
             Ok(Target::Repo {
@@ -1405,15 +1447,93 @@ trusty-review = "0.15.1"
         assert!(parse(Some(TargetKind::Board), "acme/api").is_err());
     }
 
+    /// 🔴 #6001: an absolute path registers as a checkout on disk rather than
+    /// being run through the `owner/name` charset, which refuses a leading `/`.
+    ///
+    /// Against `7eef4bb9b` every one of these is `InvalidRepoName`, which is the
+    /// whole reason a 1.4 GB checkout with full history could not be audited.
+    #[test]
+    fn an_absolute_path_registers_as_a_local_checkout() {
+        for spec in ["/srv/apex", " /srv/apex ", "/srv/apex/", "/srv/apex.git"] {
+            let target = parse(Some(TargetKind::Repo), spec).expect("{spec} must register");
+            let Target::LocalRepo { path } = &target else {
+                panic!("{spec} registered as {target:?}, not a local checkout");
+            };
+            assert!(path.is_absolute(), "{spec}");
+            // The kind is the verb, and there is one verb for both shapes — so
+            // every count and filter that asks "is this a repository" still
+            // says yes.
+            assert_eq!(target.kind(), TargetKind::Repo);
+            // The id round-trips: `taudit remove <the path you typed>` works.
+            assert_eq!(parse(None, &target.id()).expect("round-trips"), target);
+        }
+    }
+
+    /// The two shapes cannot overlap, so `add repo` needs no second verb: a
+    /// relative `owner/repo` is never read as a path, and a path is never run
+    /// through the GitHub charset.
+    #[test]
+    fn a_relative_spec_is_still_a_github_repository() {
+        assert_eq!(
+            parse(Some(TargetKind::Repo), "acme/api").expect("parses"),
+            repo("acme/api")
+        );
+        // A path holding a colon is still a path, not a board with an unknown
+        // provider — `parse(None, …)` is what `taudit remove` passes.
+        let target = parse(None, "/srv/odd:name").expect("parses");
+        assert_eq!(target.kind(), TargetKind::Repo);
+    }
+
+    /// A local checkout survives the config round trip, so an engagement that
+    /// declares one reads it back as one.
+    #[test]
+    fn a_local_checkout_round_trips_through_the_engagement_config() {
+        let path = PathBuf::from("engagement.toml");
+        let local = parse(Some(TargetKind::Repo), "/srv/apex").expect("parses");
+        let text = config::with_targets(ENGAGEMENT, std::slice::from_ref(&local), &path)
+            .expect("declares");
+        let declared = EngagementConfig::from_toml(&text, &path)
+            .expect("loads")
+            .declared_targets()
+            .expect("declares a set")
+            .to_vec();
+        assert_eq!(declared, vec![local]);
+        assert!(
+            text.contains("local_repo"),
+            "the kind tag must be stable: {text}"
+        );
+    }
+
     /// A registered name becomes a path under the working directory when it is
     /// cloned, so the containment argument in `clone::split_name` applies here.
+    ///
+    /// #6001 moved `/abs/path` out of this list — an absolute path is now a
+    /// LOCAL checkout rather than a malformed `owner/repo`. Containment is not
+    /// weakened by that, and the second half is where it is now proved: a local
+    /// target's DESTINATION is `repos/local/<basename>`, built by
+    /// `local_repo::derive_name`, which maps every character outside the
+    /// checkout charset to `-`. The operator's path is read; it never becomes
+    /// one this crate writes to.
     #[test]
     fn a_traversing_repo_name_is_never_registered() {
-        for spec in ["../etc/passwd", "acme/../../etc", "/abs/path", "acme/a/b"] {
+        for spec in ["../etc/passwd", "acme/../../etc", "acme/a/b"] {
             assert!(
                 parse(Some(TargetKind::Repo), spec).is_err(),
                 "{spec} was accepted"
             );
+        }
+
+        let work = WorkDir::new("/engagement/work");
+        for spec in ["/abs/path", "/../../etc/passwd", "/srv/a/../../../etc"] {
+            let target = parse(Some(TargetKind::Repo), spec).expect("a path registers");
+            let name = local_repo::derive_name(&PathBuf::from(spec)).expect("a checkout name");
+            let dest = clone::destination(&work, &name).expect("a destination");
+            assert!(
+                dest.starts_with(work.path(Area::Repos).join(local_repo::LOCAL_OWNER)),
+                "{spec} escaped to {}",
+                dest.display()
+            );
+            assert_eq!(target.kind(), TargetKind::Repo);
         }
     }
 

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -696,7 +696,16 @@ impl Session {
     /// What: compares derived names, and only among local targets — a remote
     /// `owner/repo` cannot collide with a path, because its owner is GitHub's
     /// and a local one is always `local/`.
-    /// Test: `super::session_tests::a_second_local_path_with_the_same_basename_is_refused`.
+    ///
+    /// **The comparison is case-folded** ([`crate::local_repo::case_fold`]):
+    /// `derive_name` preserves case, so `/a/Apex` and `/b/apex` derive
+    /// `local/Apex` and `local/apex` — two different strings that are the same
+    /// directory on a case-insensitive, case-preserving filesystem (APFS's
+    /// default). An unfolded comparison let that pair through and registered
+    /// both, so the second registration silently pointed at the first's
+    /// checkout the moment `clone_all` ran.
+    /// Test: `super::session_tests::a_second_local_path_with_the_same_basename_is_refused`,
+    /// `super::session_tests::a_second_local_path_that_differs_only_by_case_is_refused`.
     fn refuse_shared_checkout(
         registered: &[registry::Target],
         incoming: &registry::Target,
@@ -705,11 +714,16 @@ impl Session {
             return Ok(());
         };
         let name = crate::local_repo::derive_name(path)?;
+        let name_fold = crate::local_repo::case_fold(&name);
         for existing in registered {
             let registry::Target::LocalRepo { path: other } = existing else {
                 continue;
             };
-            if crate::local_repo::derive_name(other).ok().as_deref() == Some(name.as_str()) {
+            let collides = crate::local_repo::derive_name(other)
+                .ok()
+                .map(|other_name| crate::local_repo::case_fold(&other_name))
+                .is_some_and(|other_fold| other_fold == name_fold);
+            if collides {
                 return Err(AuditError::CollidingCheckouts {
                     first: other.display().to_string(),
                     second: path.display().to_string(),
@@ -1976,6 +1990,57 @@ trusty-review = "0.15.1"
                 "{err}"
             );
         }
+
+        let registered = session
+            .execute(Command::ListTargets)
+            .await
+            .expect("the listing reads");
+        let Outcome::Targets(list) = registered else {
+            panic!("ListTargets must yield a Targets outcome");
+        };
+        assert_eq!(list.targets.len(), 1, "{:?}", list.targets);
+    }
+
+    /// 🔴 On a case-insensitive, case-preserving filesystem (APFS's default —
+    /// the filesystem this feature runs on) `repos/local/Apex` and
+    /// `repos/local/apex` are ONE directory, but `derive_name` preserves case.
+    /// Before the comparison in `refuse_shared_checkout` was case-folded this
+    /// pair registered as two distinct targets, and the second's later
+    /// `clone_all` reused the first's on-disk tree and reported it as
+    /// independently audited — the #5896 wrong-corpus family.
+    #[tokio::test]
+    async fn a_second_local_path_that_differs_only_by_case_is_refused() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let first = tmp.path().join("a/Apex");
+        let second = tmp.path().join("b/apex");
+        crate::local_repo::local_repo_tests::source_repo(&first);
+        crate::local_repo::local_repo_tests::source_repo(&second);
+        let session = session_with_config(tmp.path(), CONFIG_WITHOUT_BOARDS)
+            .with_repo_probe(validate::RepoProbe::unusable());
+
+        session
+            .execute(Command::AddTarget {
+                kind: TargetKind::Repo,
+                spec: first.display().to_string(),
+            })
+            .await
+            .expect("the first registers");
+
+        let err = session
+            .execute(Command::AddTarget {
+                kind: TargetKind::Repo,
+                spec: second.display().to_string(),
+            })
+            .await
+            .expect_err("a case-only difference must still be refused as a collision");
+        let AuditError::CollidingCheckouts { name, .. } = &err else {
+            panic!("expected CollidingCheckouts, got {err:?}");
+        };
+        assert_eq!(name.to_ascii_lowercase(), "local/apex");
+        assert!(
+            err.to_string().contains(&first.display().to_string()),
+            "{err}"
+        );
 
         let registered = session
             .execute(Command::ListTargets)

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -648,15 +648,15 @@ impl Session {
                 path: self.config_path.clone(),
             }
         })?;
-        if registry::engagement_targets(Some(&config), &self.work)?
-            .iter()
-            .any(|t| t.same_as(&target))
-        {
+        let registered = registry::engagement_targets(Some(&config), &self.work)?;
+        if registered.iter().any(|t| t.same_as(&target)) {
             return Ok(Registration {
                 target,
                 already_registered: true,
             });
         }
+        // #6001: two local paths sharing a basename share a checkout directory.
+        Self::refuse_shared_checkout(&registered, &target)?;
         // #5822: validation runs OUTSIDE the lock — it reaches the network under
         // a 30s ceiling, and holding the lock across that would stall every
         // other `add` for this engagement behind one unreachable site.
@@ -677,6 +677,47 @@ impl Session {
             // first; from this call's side that is the idempotent no-op.
             already_registered: !inserted,
         })
+    }
+
+    /// Refuse a registration that would share a checkout directory with an
+    /// existing one.
+    ///
+    /// Why: #6001. A local path is audited under `local/<basename>`, so
+    /// `/srv/a/apex` and `/srv/b/apex` are two distinct targets — different
+    /// ids, so [`Target::same_as`] correctly says they are not the same thing —
+    /// that resolve to ONE destination. `crate::clone::clone_all` then reuses
+    /// whichever landed first and reports the second as audited, having read the
+    /// first one's history. Catching it at registration is what puts the refusal
+    /// in front of the operator who can still choose, rather than in a gap line
+    /// an hour into a sweep.
+    ///
+    /// [`crate::clone::clone_all`] refuses the same shape independently, because
+    /// a hand-edited `engagement.toml` never passes through here.
+    /// What: compares derived names, and only among local targets — a remote
+    /// `owner/repo` cannot collide with a path, because its owner is GitHub's
+    /// and a local one is always `local/`.
+    /// Test: `super::session_tests::a_second_local_path_with_the_same_basename_is_refused`.
+    fn refuse_shared_checkout(
+        registered: &[registry::Target],
+        incoming: &registry::Target,
+    ) -> Result<(), AuditError> {
+        let registry::Target::LocalRepo { path } = incoming else {
+            return Ok(());
+        };
+        let name = crate::local_repo::derive_name(path)?;
+        for existing in registered {
+            let registry::Target::LocalRepo { path: other } = existing else {
+                continue;
+            };
+            if crate::local_repo::derive_name(other).ok().as_deref() == Some(name.as_str()) {
+                return Err(AuditError::CollidingCheckouts {
+                    first: other.display().to_string(),
+                    second: path.display().to_string(),
+                    name,
+                });
+            }
+        }
+        Ok(())
     }
 
     /// Run one registry critical section off the async runtime's thread.
@@ -1874,6 +1915,76 @@ trusty-review = "0.15.1"
             !Registry::path(session.work_dir()).exists(),
             "a refused repository registration wrote a registry file"
         );
+    }
+
+    /// 🔴 #6001: registering a local checkout, end to end through the one door
+    /// every front end gets — with a `gh` that cannot answer, because the
+    /// machine this exists for reaches no GitHub at all.
+    #[tokio::test]
+    async fn a_local_checkout_registers_with_no_github_credential() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let src = tmp.path().join("apex");
+        crate::local_repo::local_repo_tests::source_repo(&src);
+        let session = session_with_config(tmp.path(), CONFIG_WITHOUT_BOARDS)
+            .with_repo_probe(validate::RepoProbe::unusable());
+
+        let outcome = session
+            .execute(Command::AddTarget {
+                kind: TargetKind::Repo,
+                spec: src.display().to_string(),
+            })
+            .await
+            .expect("a real checkout registers without a credential");
+        let Outcome::Registered(registration) = outcome else {
+            panic!("AddTarget must yield a Registered outcome");
+        };
+        assert!(!registration.already_registered);
+        assert_eq!(registration.target.id(), src.display().to_string());
+    }
+
+    /// 🔴 Two checkouts with one basename would share `repos/local/apex`, so the
+    /// second would be reported as audited having read the first's history.
+    /// Refused at registration, naming both paths; nothing is written.
+    #[tokio::test]
+    async fn a_second_local_path_with_the_same_basename_is_refused() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let first = tmp.path().join("a/apex");
+        let second = tmp.path().join("b/apex");
+        crate::local_repo::local_repo_tests::source_repo(&first);
+        crate::local_repo::local_repo_tests::source_repo(&second);
+        let session = session_with_config(tmp.path(), CONFIG_WITHOUT_BOARDS)
+            .with_repo_probe(validate::RepoProbe::unusable());
+
+        for path in [&first, &second] {
+            let outcome = session
+                .execute(Command::AddTarget {
+                    kind: TargetKind::Repo,
+                    spec: path.display().to_string(),
+                })
+                .await;
+            if path == &first {
+                outcome.expect("the first registers");
+                continue;
+            }
+            let err = outcome.expect_err("the second must not share the first's checkout");
+            let AuditError::CollidingCheckouts { name, .. } = &err else {
+                panic!("expected CollidingCheckouts, got {err:?}");
+            };
+            assert_eq!(name, "local/apex");
+            assert!(
+                err.to_string().contains(&first.display().to_string()),
+                "{err}"
+            );
+        }
+
+        let registered = session
+            .execute(Command::ListTargets)
+            .await
+            .expect("the listing reads");
+        let Outcome::Targets(list) = registered else {
+            panic!("ListTargets must yield a Targets outcome");
+        };
+        assert_eq!(list.targets.len(), 1, "{:?}", list.targets);
     }
 
     /// The message names the field to set — the recipient is not the author of

--- a/crates/trusty-audit/src/validate.rs
+++ b/crates/trusty-audit/src/validate.rs
@@ -190,6 +190,16 @@ pub async fn validate(
         Target::Repo { name_with_owner } => validate_repo(name_with_owner, gh)
             .await
             .map(|()| target.clone()),
+        // #6001: a path has no GitHub to probe, so the check is the reading
+        // itself — and it is one `crate::local_repo` owns, so the sweep and the
+        // registration cannot disagree about what a usable source is.
+        Target::LocalRepo { path } => crate::local_repo::inspect(path)
+            .await
+            .map(|()| target.clone())
+            .map_err(|reason| AuditError::LocalRepoUnusable {
+                path: path.clone(),
+                reason,
+            }),
         Target::Board { provider, key } => match provider {
             BoardProvider::Jira => {
                 let creds = config
@@ -738,6 +748,50 @@ trusty-review = "0.15.1"
             .expect_err("a gh that cannot answer must not register a repository");
         assert!(matches!(err, AuditError::RepoUnreachable { .. }), "{err:?}");
         assert!(err.to_string().contains("acme/api"), "{err}");
+    }
+
+    /// 🔴 #6001: a local path is validated by READING it, with no `gh` and no
+    /// network — and a path that is not a usable source is refused at
+    /// registration naming which condition failed, never accepted and then
+    /// silently empty.
+    #[tokio::test]
+    async fn an_unusable_local_source_names_what_failed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let plain = tmp.path().join("not-a-repo");
+        std::fs::create_dir(&plain).expect("mkdir");
+        let target = Target::LocalRepo {
+            path: plain.clone(),
+        };
+
+        // `RepoProbe::unusable` proves no `gh` is consulted: this path must
+        // still refuse for its OWN reason rather than a credential's.
+        let err = validate(&target, None, RepoProbe::unusable())
+            .await
+            .expect_err("a directory that is not a repository must not register");
+        let AuditError::LocalRepoUnusable { path, reason } = &err else {
+            panic!("expected LocalRepoUnusable, got {err:?}");
+        };
+        assert_eq!(path, &plain);
+        assert!(reason.contains("not a git repository"), "{reason}");
+        assert!(err.to_string().contains("nothing was registered"), "{err}");
+    }
+
+    /// The accepted half, with the same probe: a real checkout validates
+    /// offline, so `taudit add repo <path>` works on a machine whose GitHub
+    /// credential reaches nothing.
+    #[tokio::test]
+    async fn a_real_checkout_validates_with_no_credential_at_all() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let src = tmp.path().join("apex");
+        crate::local_repo::local_repo_tests::source_repo(&src);
+        let target = Target::LocalRepo { path: src };
+
+        assert_eq!(
+            validate(&target, None, RepoProbe::unusable())
+                .await
+                .expect("a real checkout needs no credential"),
+            target
+        );
     }
 
     #[test]


### PR DESCRIPTION
`crates/trusty-audit/src/clone.rs` only ran `gh repo clone` against a remote, so an engagement whose corpus is a checkout on disk had no way in. Spec and motivation: #6001.

## The four design decisions

**1. Clone-from-local, not operate-in-place.** `git clone <path>` hardlinks the object store, verified rather than assumed — `local_repo_tests::a_local_clone_hardlinks_the_object_store` asserts `nlink >= 2` on every loose object. It reads the source and writes only under the working directory, so the invariant holds by construction and the whole downstream pipeline is unchanged. The cost is committed history only, which is what tga consumes.

**2. An ABSOLUTE path is local; anything else is `owner/repo`.** Syntactic, decided before touching the filesystem. It cannot overlap — `clone::split_name` rejects an empty owner, so no `owner/repo` is absolute. Deliberately not `trusty-mpm`'s `is_local_workdir` rule ("an absolute path that EXISTS as a directory"): that asks the filesystem what a spec MEANS, so the same `repos.txt` line means different things on two machines and a mistyped path silently demotes to an `owner/repo` refused for the wrong reason. Meaning is syntactic; usability is a separate, loud check. No `file://` or `path:` prefix — a second accepted spelling is a second rule to keep in step.

**3. Both entry points.** `taudit add repo <path>` and a `repos.txt` line. Both route through `registry::parse`, so there is one decision. The targets-file parse is all-or-nothing, so a path line must parse cleanly — it passes through `repo_spec` unnormalized, which matters for a bare `/srv/apex.git` whose directory really is named `apex.git`.

**4. Naming: `local/<basename>`, `.git` stripped; collision REFUSED.** A git remote is deliberately not consulted — naming a repository after somewhere it cannot be fetched from is the whole reason this path exists. Two paths whose basenames match derive one destination, and `clone_all` REUSES a directory already there, so the second would be reported as audited having read the first's history. Refused at both gates — registration (`Session::refuse_shared_checkout`) and acquisition (`clone::refuse_collisions`) — naming both paths, because a hand-edited `engagement.toml` never passes through the first.

## Validation, and what is refused

Does not exist / not a directory / not readable / not a git repository / a subdirectory of one / SHALLOW / no commits — each refused at registration naming which condition failed. A `--depth=1` source would report one commit by one author over a zero-length period (#5916), so it is refused rather than audited thinly. A BARE mirror is accepted: it carries the whole history and clones into an ordinary checkout, which is the mirror-of-a-dead-org case this feature exists for. The source is re-inspected at sweep time too, where a source that went bad after registration becomes a named gap rather than a thin report.

## The invariant

The source checkout is never modified. Acquisition is `git clone`; the only other command run against the source is `git rev-parse`. `local_repo_tests::the_source_checkout_is_byte_identical_afterwards` records `git status --porcelain`, HEAD, the reflog and the stash list before and after, over a source with uncommitted work in it, and asserts all four unchanged. The stash list is in there because it is shared across every worktree of a repository — a stash against a client's checkout is real damage, not a theoretical one.

## Two pre-existing tests changed

`registry_tests::a_traversing_repo_name_is_never_registered` and `targets_file_tests::entries_that_are_not_targets_are_refused` asserted that an absolute path is refused, which is the behaviour this changes. Neither case was dropped: both now state the new containment property instead. A local target's destination is built by `local_repo::derive_name`, which maps every character outside the checkout charset to `-`, so `/../../etc/passwd` resolves to `repos/local/passwd` and the assertion is that it stays under `repos/local/`.

## Red before, green after

The two headline assertions, written against the public API only so one file compiles on both trees, run against `origin/main`'s `crates/trusty-audit/src`:

```
running 2 tests
test an_absolute_path_registers ... FAILED
test an_absolute_path_is_acquired_and_selected ... FAILED

an absolute path must register as a local checkout: InvalidRepoName { name: "/srv/apex" }
a local checkout must be a usable source: InvalidRepoName { name: "/var/folders/.../apex" }

test result: FAILED. 0 passed; 2 failed
```

The same file against this branch:

```
running 2 tests
test an_absolute_path_registers ... ok
test an_absolute_path_is_acquired_and_selected ... ok
test result: ok. 2 passed; 0 failed
```

The probe file is not in the branch. The remaining new assertions (the invariant, shallow/bare/subdirectory refusal, both collision gates, offline validation) exercise code paths that do not exist on `origin/main`, so their red-before is a compile error rather than a failing assertion.

Every fixture is built with real `git init` + commits under a `tempfile::tempdir`. No test names a path outside the repository.

## Gates — ladder rung 3

Localized behavior inside one crate. `validate::validate`'s signature is unchanged.

```
SKIP_UI_BUILD=1 cargo fmt --check -p trusty-audit                          → exit 0
SKIP_UI_BUILD=1 cargo check  --locked -p trusty-audit --all-targets        → exit 0
SKIP_UI_BUILD=1 cargo clippy --locked -p trusty-audit --all-targets -D warnings → exit 0
SKIP_UI_BUILD=1 cargo test   --locked -p trusty-audit                      → exit 0
    lib: 487 passed; 0 failed; 5 ignored
    integration: 3 + 5 + 4 + 4 + 9 passed; 0 failed; 2 ignored
bash scripts/check_line_cap.sh   → 4080 files, 0 violations
bash scripts/check_sld.sh        → 0 errors, 0 warnings
```

`Target` gained a variant, so the one crate depending on `trusty-audit` was checked too — `cargo check --locked -p trusty-audit-ui --all-targets` → exit 0. It does not match on `Target`.

Closes #6001

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
