### PR TITLE
feat(trusty-audit): a registered repo's GitHub issues reach the ticketing report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11307,6 +11307,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -103,6 +103,12 @@ trusty-progress = { workspace = true }
 # #5499: the return package is one zip file, because the return channel is
 # manual (#5642) and a directory cannot be attached to an email.
 zip = { workspace = true }
+# #5980: a non-reversible, truncated fingerprint of the `gh`-derived
+# credential a sweep resolved, persisted in the checkpoint so packaging (which
+# can run as a separate process, possibly under a different `gh` account) can
+# prove it is scanning outbound files with the credential that produced them
+# rather than a freshly re-resolved one that never touched those files.
+sha2 = { workspace = true }
 # #5499: walking each audited repository's output directory. Not followed
 # through symlinks — `package::collect_dir` refuses one rather than reading a
 # file from outside the working directory into a package that leaves the

--- a/crates/trusty-audit/changelog.d/5980-github-issues-in-sweep.md
+++ b/crates/trusty-audit/changelog.d/5980-github-issues-in-sweep.md
@@ -1,0 +1,12 @@
+Added
+
+- Every registered repository now automatically contributes its own GitHub
+  issues to the sweep's ticketing correlation — no separate board
+  registration for a repo's own tracker. The generated `tga` config for each
+  repository always carries a `github:` section naming that repository, using
+  the recipient's own `gh auth token` credential (never a new raw-token config
+  field) when one can be read, and running unauthenticated otherwise rather
+  than silently omitting the section. A repository whose issues are disabled
+  or whose token cannot read them is reported the same way an unreachable
+  JIRA project already is — a named gap on the affected repository, not an
+  empty-but-successful ticketing section (#5980).

--- a/crates/trusty-audit/changelog.d/5980-github-issues-in-sweep.md
+++ b/crates/trusty-audit/changelog.d/5980-github-issues-in-sweep.md
@@ -6,7 +6,11 @@ Added
   repository always carries a `github:` section naming that repository, using
   the recipient's own `gh auth token` credential (never a new raw-token config
   field) when one can be read, and running unauthenticated otherwise rather
-  than silently omitting the section. A repository whose issues are disabled
-  or whose token cannot read them is reported the same way an unreachable
-  JIRA project already is — a named gap on the affected repository, not an
-  empty-but-successful ticketing section (#5980).
+  than silently omitting the section. A repository whose issues are disabled,
+  whose credential is rejected, or whose repo is invisible to the resolved
+  credential (a private repo with no or an invalid token) is reported the
+  same way an unreachable JIRA project already is — a named gap on the
+  affected repository, not an empty-but-successful ticketing section (#5980).
+  A `gh`-derived token that reaches a child never lands in the run's log or
+  in the packaged deliverable unredacted, the same guarantee `boards`'
+  credentials already carry.

--- a/crates/trusty-audit/changelog.d/5980-github-token-scrub-and-package-guard.md
+++ b/crates/trusty-audit/changelog.d/5980-github-token-scrub-and-package-guard.md
@@ -1,0 +1,7 @@
+Fixed
+
+- The scrubber that keeps a credential out of a spawned child's log, and the
+  guard that refuses to package a file carrying one, both now cover the
+  `gh`-derived GitHub token — previously only `EngagementConfig`'s own
+  secrets were checked, so a rejected token echoed back by a child could
+  reach the log or the deliverable unredacted (#5980).

--- a/crates/trusty-audit/changelog.d/5980-github-token-scrub-and-package-guard.md
+++ b/crates/trusty-audit/changelog.d/5980-github-token-scrub-and-package-guard.md
@@ -5,3 +5,14 @@ Fixed
   `gh`-derived GitHub token — previously only `EngagementConfig`'s own
   secrets were checked, so a rejected token echoed back by a child could
   reach the log or the deliverable unredacted (#5980).
+- Packaging now refuses when the active `gh` credential differs from the one
+  the sweep collected under, instead of silently scanning outbound files with
+  the wrong token. Packaging can run as a separate process from the sweep —
+  possibly under a different `gh` account after the operator re-authenticated
+  — and the previous outbound scan re-resolved the credential fresh each
+  time, so a token a child echoed at sweep time could ship in the deliverable
+  unredacted because the newly-resolved token never matched it. A truncated,
+  non-reversible fingerprint of the sweep's credential is now recorded in the
+  checkpoint and compared at packaging time; a checkpoint written before this
+  fingerprint existed still packages, with the uncertainty stated rather than
+  silently assumed safe (#5980).

--- a/crates/trusty-audit/src/chain.rs
+++ b/crates/trusty-audit/src/chain.rs
@@ -447,9 +447,12 @@ async fn assemble(
     // #5980 CRITICAL 4: resolved here, not threaded from `collect` — the phase
     // is a separate step from collection and re-derives what it needs, the
     // same pattern `run::sweep` and `session::package` both follow.
+    // `from_checkpoint` proves this resolution still matches the account
+    // `collect` recorded before trusting it (#5980 CRITICAL — account-switch
+    // follow-up); a same-process chain still re-verifies rather than
+    // special-casing itself, so one code path owns the guarantee.
     let github_access = crate::run::github_issues::resolve_github_access().await;
-    let assembled =
-        package::from_checkpoint(work, config, gaps, &destination, github_access.raw_token());
+    let assembled = package::from_checkpoint(work, config, gaps, &destination, &github_access);
     progress.unit_finished(
         Operation::Package,
         name.as_str(),

--- a/crates/trusty-audit/src/chain.rs
+++ b/crates/trusty-audit/src/chain.rs
@@ -249,6 +249,7 @@ pub async fn audit(
         .map_err(|e| stopped(Phase::Collect, e))?;
 
     let package = assemble(work, config, &gaps, options.destination.clone(), progress)
+        .await
         .map_err(|e| stopped(Phase::Package, e))?;
 
     Ok(ChainReport {
@@ -429,7 +430,7 @@ async fn collect(
 /// Test: `super::chain_tests::the_chain_installs_collects_and_packages`,
 /// `super::chain_tests::progress_covers_every_phase`,
 /// `cli_end_to_end::a_registered_repository_that_never_cloned_is_named_in_the_package`.
-fn assemble(
+async fn assemble(
     work: &WorkDir,
     config: &EngagementConfig,
     gaps: &[String],
@@ -443,7 +444,12 @@ fn assemble(
     );
     progress.operation_started(Operation::Package, 1);
     progress.unit_started(Operation::Package, name.as_str(), 1, 1);
-    let assembled = package::from_checkpoint(work, config, gaps, &destination);
+    // #5980 CRITICAL 4: resolved here, not threaded from `collect` — the phase
+    // is a separate step from collection and re-derives what it needs, the
+    // same pattern `run::sweep` and `session::package` both follow.
+    let github_access = crate::run::github_issues::resolve_github_access().await;
+    let assembled =
+        package::from_checkpoint(work, config, gaps, &destination, github_access.raw_token());
     progress.unit_finished(
         Operation::Package,
         name.as_str(),

--- a/crates/trusty-audit/src/error.rs
+++ b/crates/trusty-audit/src/error.rs
@@ -428,6 +428,27 @@ pub enum AuditError {
         expected: PathBuf,
     },
 
+    /// The `gh`-derived credential active now differs from the one the sweep
+    /// recorded when it collected.
+    ///
+    /// Why (#5980): packaging re-resolves `gh auth token` fresh rather than
+    /// inheriting the sweep's value, because packaging can run as a separate
+    /// process — possibly hours later, under a different `gh` account.
+    /// [`Self::CredentialInPackage`]'s guarantee depends on scanning outbound
+    /// files with the SAME token a child could have echoed into them; a
+    /// freshly re-resolved token from a different account can never catch an
+    /// older one. `crate::run::github_issues::verify_unchanged` is what
+    /// proves the two disagree before this fires.
+    /// What: refuses packaging with the operator's remedy stated directly —
+    /// no path or token is named, because there is nothing safe to quote.
+    /// Test: `crate::run::github_issues::github_issues_tests::a_mismatched_fingerprint_refuses`,
+    /// `crate::session::session_tests::a_mismatched_github_credential_refuses_packaging`.
+    #[error(
+        "the active GitHub credential differs from the one used during collection; \
+         re-authenticate as the original `gh` account or re-run the sweep"
+    )]
+    GithubCredentialChanged,
+
     /// The return package could not be read, written, or renamed into place.
     #[error("return package {path}: {source}")]
     Package {

--- a/crates/trusty-audit/src/error.rs
+++ b/crates/trusty-audit/src/error.rs
@@ -442,7 +442,7 @@ pub enum AuditError {
     /// What: refuses packaging with the operator's remedy stated directly —
     /// no path or token is named, because there is nothing safe to quote.
     /// Test: `crate::run::github_issues::github_issues_tests::a_mismatched_fingerprint_refuses`,
-    /// `crate::session::session_tests::a_mismatched_github_credential_refuses_packaging`.
+    /// `package::package_tests::packaging_refuses_when_the_active_github_credential_has_changed`.
     #[error(
         "the active GitHub credential differs from the one used during collection; \
          re-authenticate as the original `gh` account or re-run the sweep"

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -88,6 +88,7 @@ use serde::Serialize;
 
 use crate::config::EngagementConfig;
 use crate::error::AuditError;
+use crate::run::github_issues::{self, GithubAccess};
 use crate::run::{RepoRun, RunReport};
 use crate::tools;
 use crate::workdir::{Area, WorkDir};
@@ -233,6 +234,13 @@ struct PackagedRepo {
 /// What: collects the members, refuses a symlink among them, writes the archive
 /// to a sibling temporary file while scanning every byte for the engagement
 /// credential, then renames.
+///
+/// `github_token` is scanned for verbatim — this function trusts the caller
+/// to have already confirmed it is the SAME credential the sweep collected
+/// under. [`from_checkpoint`] is that confirmation (#5980 CRITICAL — the
+/// account-switch follow-up); calling `assemble` directly with a `github_token`
+/// from a different `gh` account than the sweep used will NOT catch an older
+/// token a file carries — there is nothing here to compare against.
 /// Test: `super::package_tests`.
 ///
 /// # Errors
@@ -261,21 +269,29 @@ struct PackagedRepo {
 /// `crate::session::session_tests::packaging_an_unfinished_sweep_is_refused`,
 /// `crate::chain::chain_tests::the_chain_installs_collects_and_packages`.
 ///
-/// `github_token` is the raw `gh`-derived credential (#5980 CRITICAL 4), when
-/// one was read — see `secret_needles`'s docs below for why the outbound scan
-/// needs it and [`crate::run::github_issues::GithubAccess::raw_token`] for why
-/// nothing else exposes the value this way.
+/// `github_access` is a freshly-resolved credential (#5980 CRITICAL 4) —
+/// packaging can run as a separate process from the sweep, so it never
+/// inherits the sweep's own resolution. Before this function hands
+/// [`GithubAccess::raw_token`] to [`assemble`] as the outbound scan's extra
+/// needle, it first confirms that token is the SAME one the sweep recorded,
+/// via [`github_issues::verify_unchanged`] — see that function's docs and
+/// [`GithubAccess::fingerprint`]'s for the account-switch gap this closes.
+/// A stated-but-unrefused gap from that check (the back-compat case) is
+/// folded into the returned package's `excluded` lines alongside
+/// `unattempted`.
 ///
 /// # Errors
 ///
-/// [`AuditError::NothingToPackage`] when no sweep has finished here, and
-/// whatever [`assemble`] fails with.
+/// [`AuditError::NothingToPackage`] when no sweep has finished here,
+/// [`AuditError::GithubCredentialChanged`] when the active GitHub credential
+/// provably differs from the one the sweep collected under, and whatever
+/// [`assemble`] fails with.
 pub fn from_checkpoint(
     work: &WorkDir,
     config: &EngagementConfig,
     unattempted: &[String],
     destination: &Path,
-    github_token: Option<&str>,
+    github_access: &GithubAccess,
 ) -> Result<ReturnPackage, AuditError> {
     let progress =
         crate::run::read_progress(work)?.ok_or_else(|| AuditError::NothingToPackage {
@@ -297,13 +313,17 @@ pub fn from_checkpoint(
             ),
         });
     }
+    let credential_gap =
+        github_issues::verify_unchanged(progress.github_credential.as_ref(), github_access)?;
+    let mut excluded_extra = unattempted.to_vec();
+    excluded_extra.extend(credential_gap);
     assemble(
         work,
         config,
         &progress.report(),
-        unattempted,
+        &excluded_extra,
         destination,
-        github_token,
+        github_access.raw_token(),
     )
 }
 
@@ -1085,6 +1105,141 @@ api_key = "lin_api_do-not-package-me"
             !destination.exists(),
             "a refused package must leave no file"
         );
+    }
+
+    /// #5980 follow-up CRITICAL: the critic's own proof, inverted, through
+    /// the real `from_checkpoint` entry point both `session::package` and
+    /// `chain::assemble` call. A file the sweep wrote carries the SWEEP-TIME
+    /// account's token; packaging under a DIFFERENT account's token must
+    /// refuse instead of silently shipping it — a freshly re-resolved token
+    /// can never be the needle that catches an older one.
+    ///
+    /// Against the commit before this test existed, this scenario packaged
+    /// successfully with the sweep-time token intact in the deliverable —
+    /// `from_checkpoint` took a bare `Option<&str>` and had no checkpoint
+    /// comparison at all.
+    #[test]
+    fn packaging_refuses_when_the_active_github_credential_has_changed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let stem = "00-acme-api";
+        let run = audited(&work, stem, "acme-api");
+        // What a child could echo at sweep time: the SWEEP-TIME token.
+        std::fs::write(
+            run.output.join("leaked.log"),
+            "auth error: bad credentials (token ghp_sweep_time_account_A_token rejected)\n",
+        )
+        .expect("write");
+
+        let sweep_time = GithubAccess::with_token("ghp_sweep_time_account_A_token");
+        crate::run::checkpoint::write_progress(
+            &work,
+            &crate::run::RunProgress::finished(
+                &RunReport::of(vec![run]),
+                github_issues::GithubCredentialRecord::of(&sweep_time),
+            ),
+        )
+        .expect("write checkpoint");
+
+        let package_time = GithubAccess::with_token("ghp_package_time_account_B_token");
+        let destination = default_destination(&work);
+        let err = from_checkpoint(&work, &config(), &[], &destination, &package_time)
+            .expect_err("a mismatched GitHub credential must refuse packaging");
+        assert!(
+            matches!(err, AuditError::GithubCredentialChanged),
+            "{err:?}"
+        );
+        assert!(
+            !destination.exists(),
+            "a refused package must leave no file"
+        );
+    }
+
+    /// The matched-fingerprint counterpart: the SAME account both times still
+    /// packages, and the sweep-time token is caught by the outbound scan like
+    /// any other member.
+    #[test]
+    fn packaging_proceeds_when_the_github_credential_matches() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let stem = "00-acme-api";
+        let run = audited(&work, stem, "acme-api");
+
+        let access = GithubAccess::with_token("ghp_same_account_both_times");
+        crate::run::checkpoint::write_progress(
+            &work,
+            &crate::run::RunProgress::finished(
+                &RunReport::of(vec![run]),
+                github_issues::GithubCredentialRecord::of(&access),
+            ),
+        )
+        .expect("write checkpoint");
+
+        let destination = default_destination(&work);
+        let same_access = GithubAccess::with_token("ghp_same_account_both_times");
+        from_checkpoint(&work, &config(), &[], &destination, &same_access)
+            .expect("a matching credential must not refuse packaging");
+        assert!(destination.exists(), "the package must be written");
+    }
+
+    /// The back-compat case: a checkpoint written before credential
+    /// verification existed carries no `github_credential` record at all.
+    /// Packaging proceeds rather than refusing every pre-existing engagement
+    /// outright, but the returned package states the uncertainty.
+    #[test]
+    fn packaging_an_unverified_checkpoint_proceeds_with_a_stated_gap() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let stem = "00-acme-api";
+        let run = audited(&work, stem, "acme-api");
+        write_progress_without_github_credential(&work, &RunReport::of(vec![run]));
+
+        let destination = default_destination(&work);
+        let package = from_checkpoint(
+            &work,
+            &config(),
+            &[],
+            &destination,
+            &GithubAccess::default(),
+        )
+        .expect("an unrecorded checkpoint must not refuse packaging");
+        assert!(
+            package
+                .excluded
+                .iter()
+                .any(|line| line.contains("not recorded")),
+            "the uncertainty must be stated: {:?}",
+            package.excluded
+        );
+    }
+
+    /// Writes a checkpoint the way a pre-#5980-follow-up sweep would have —
+    /// no `github_credential` field at all, which `#[serde(default)]` reads
+    /// back as `None` and `verify_unchanged` treats as unverifiable.
+    ///
+    /// Why hand-edit rather than hand-assemble: `RunProgress` is
+    /// `#[non_exhaustive]`, so nothing outside `checkpoint.rs` can build one
+    /// by struct literal, and hand-assembling the whole TOML document from
+    /// scratch would silently drift from whatever `RunProgress`'s own
+    /// `Serialize` impl actually produces. Serializing a real value and
+    /// stripping just the one line this field owns keeps everything else
+    /// exactly what the real serializer writes.
+    fn write_progress_without_github_credential(work: &WorkDir, report: &RunReport) {
+        let progress = crate::run::RunProgress::finished(
+            report,
+            github_issues::GithubCredentialRecord::NoToken,
+        );
+        let text = toml::to_string_pretty(&progress).expect("progress serializes");
+        let stripped: String = text
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("github_credential"))
+            .map(|line| format!("{line}\n"))
+            .collect();
+        assert_ne!(
+            stripped, text,
+            "the field must actually have been present to strip"
+        );
+        std::fs::write(crate::run::progress_path(work), stripped).expect("write raw checkpoint");
     }
 
     /// The Linear key, same reason. Two providers, one guard.

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -261,6 +261,11 @@ struct PackagedRepo {
 /// `crate::session::session_tests::packaging_an_unfinished_sweep_is_refused`,
 /// `crate::chain::chain_tests::the_chain_installs_collects_and_packages`.
 ///
+/// `github_token` is the raw `gh`-derived credential (#5980 CRITICAL 4), when
+/// one was read — see `secret_needles`'s docs below for why the outbound scan
+/// needs it and [`crate::run::github_issues::GithubAccess::raw_token`] for why
+/// nothing else exposes the value this way.
+///
 /// # Errors
 ///
 /// [`AuditError::NothingToPackage`] when no sweep has finished here, and
@@ -270,6 +275,7 @@ pub fn from_checkpoint(
     config: &EngagementConfig,
     unattempted: &[String],
     destination: &Path,
+    github_token: Option<&str>,
 ) -> Result<ReturnPackage, AuditError> {
     let progress =
         crate::run::read_progress(work)?.ok_or_else(|| AuditError::NothingToPackage {
@@ -291,7 +297,14 @@ pub fn from_checkpoint(
             ),
         });
     }
-    assemble(work, config, &progress.report(), unattempted, destination)
+    assemble(
+        work,
+        config,
+        &progress.report(),
+        unattempted,
+        destination,
+        github_token,
+    )
 }
 
 pub fn assemble(
@@ -300,6 +313,7 @@ pub fn assemble(
     report: &RunReport,
     unattempted: &[String],
     destination: &Path,
+    github_token: Option<&str>,
 ) -> Result<ReturnPackage, AuditError> {
     let audited: Vec<&RepoRun> = report
         .repos
@@ -333,7 +347,15 @@ pub fn assemble(
     let metadata = render_metadata(work, config, report, &audited, unattempted)?;
     let readme = render_readme(config, &audited, &excluded);
 
-    write_archive(destination, config, readme, metadata, collected, excluded)
+    write_archive(
+        destination,
+        config,
+        readme,
+        metadata,
+        collected,
+        excluded,
+        github_token,
+    )
 }
 
 /// The directory name `run` wrote its output under, which is also the name its
@@ -633,6 +655,7 @@ fn write_archive(
     metadata: String,
     collected: Vec<(String, PathBuf)>,
     excluded: Vec<String>,
+    github_token: Option<&str>,
 ) -> Result<ReturnPackage, AuditError> {
     if let Some(parent) = destination.parent() {
         std::fs::create_dir_all(parent).map_err(|source| AuditError::Package {
@@ -641,7 +664,14 @@ fn write_archive(
         })?;
     }
     let temporary = destination.with_extension("zip.part");
-    let result = fill_archive(&temporary, config, readme, metadata, collected);
+    let result = fill_archive(
+        &temporary,
+        config,
+        readme,
+        metadata,
+        collected,
+        github_token,
+    );
     let mut files = match result {
         Ok(files) => files,
         Err(e) => {
@@ -680,6 +710,7 @@ fn fill_archive(
     readme: String,
     metadata: String,
     collected: Vec<(String, PathBuf)>,
+    github_token: Option<&str>,
 ) -> Result<Vec<PackagedFile>, AuditError> {
     let file = std::fs::File::create(temporary).map_err(|source| AuditError::Package {
         path: temporary.to_path_buf(),
@@ -703,7 +734,14 @@ fn fill_archive(
     }
 
     for (entry, source) in collected {
-        let bytes = credential_scan::copy_member(&mut zip, &entry, &source, config, temporary)?;
+        let bytes = credential_scan::copy_member(
+            &mut zip,
+            &entry,
+            &source,
+            config,
+            temporary,
+            github_token,
+        )?;
         files.push(PackagedFile {
             entry,
             source: Some(source),
@@ -738,9 +776,10 @@ fn start(zip: &mut Archive, entry: &str, bytes: u64, temporary: &Path) -> Result
 
 #[cfg(test)]
 mod package_tests {
+    use std::io::Read as _;
+
     use super::*;
     use crate::run::{RepoResult, RepoRun, SelectedRepo};
-    use std::io::Read as _;
 
     const CONFIG: &str = r#"
 openrouter_key = "sk-or-v1-not-a-real-key"
@@ -847,7 +886,8 @@ trusty-review = "0.15.1"
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
         let destination = default_destination(&work);
 
-        let package = assemble(&work, &config(), &report, &[], &destination).expect("assembles");
+        let package =
+            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
 
         assert_eq!(package.path, destination);
         assert!(destination.is_file(), "the zip was not written");
@@ -874,7 +914,7 @@ trusty-review = "0.15.1"
         install_record(&work);
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
         let destination = default_destination(&work);
-        assemble(&work, &config(), &report, &[], &destination).expect("assembles");
+        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
 
         // `by_index` succeeding with no password IS the unencrypted property:
         // the zip crate returns `UnsupportedArchive` for an encrypted entry.
@@ -911,7 +951,7 @@ trusty-review = "0.15.1"
         let report = RunReport::of(vec![run]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination)
+        let err = assemble(&work, &config(), &report, &[], &destination, None)
             .expect_err("a package carrying the key must not be produced");
         assert!(
             matches!(err, AuditError::CredentialInPackage { .. }),
@@ -959,11 +999,29 @@ api_key = "lin_api_do-not-package-me"
         config: &EngagementConfig,
         leaked: &str,
     ) -> Result<ReturnPackage, AuditError> {
+        packaging_a_member_carrying_with_token(work, config, leaked, None)
+    }
+
+    /// [`packaging_a_member_carrying`], with the `gh`-derived credential the
+    /// caller wants in the needle set (#5980 CRITICAL 4).
+    fn packaging_a_member_carrying_with_token(
+        work: &WorkDir,
+        config: &EngagementConfig,
+        leaked: &str,
+        github_token: Option<&str>,
+    ) -> Result<ReturnPackage, AuditError> {
         install_record(work);
         let run = audited(work, "00-acme-api", "acme-api");
         std::fs::write(run.output.join("leaked.log"), leaked).expect("write");
         let report = RunReport::of(vec![run]);
-        assemble(work, config, &report, &[], &default_destination(work))
+        assemble(
+            work,
+            config,
+            &report,
+            &[],
+            &default_destination(work),
+            github_token,
+        )
     }
 
     /// The JIRA token is a secret this crate now hands to a child, so the
@@ -996,6 +1054,36 @@ api_key = "lin_api_do-not-package-me"
         assert!(
             !destination.with_extension("zip.part").exists(),
             "the temporary must be removed too"
+        );
+    }
+
+    /// #5980 CRITICAL 4: the `gh`-derived GitHub credential is a third source
+    /// alongside the two board secrets above — it never lives in
+    /// `EngagementConfig`, so `configured_secrets()` alone cannot see it.
+    /// Before `secret_needles` took a `github_token` parameter, this member
+    /// packaged clean and the token left the recipient's network.
+    #[test]
+    fn a_member_carrying_the_github_token_is_refused_and_leaves_no_zip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let destination = default_destination(&work);
+        const TOKEN: &str = "ghp_do-not-package-me";
+
+        let err = packaging_a_member_carrying_with_token(
+            &work,
+            &config(),
+            "auth error: bad credentials (token ghp_do-not-package-me rejected)\n",
+            Some(TOKEN),
+        )
+        .expect_err("a package carrying the GitHub token must not be produced");
+
+        assert!(
+            matches!(err, AuditError::CredentialInPackage { .. }),
+            "{err:?}"
+        );
+        assert!(
+            !destination.exists(),
+            "a refused package must leave no file"
         );
     }
 
@@ -1072,7 +1160,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![run]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination)
+        let err = assemble(&work, &config(), &report, &[], &destination, None)
             .expect_err("a symlink must not be followed into the package");
         assert!(
             matches!(err, AuditError::UnsafePackageEntry { .. }),
@@ -1097,7 +1185,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![run]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination)
+        let err = assemble(&work, &config(), &report, &[], &destination, None)
             .expect_err("a hardlink must not carry outside content into the package");
         let AuditError::UnsafePackageEntry { kind, .. } = &err else {
             panic!("expected UnsafePackageEntry, got {err:?}");
@@ -1129,7 +1217,7 @@ api_key = "lin_api_do-not-package-me"
         .expect("hard link");
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination)
+        let err = assemble(&work, &config(), &report, &[], &destination, None)
             .expect_err("a hardlink under extract/ must be refused too");
         let AuditError::UnsafePackageEntry { kind, .. } = &err else {
             panic!("expected UnsafePackageEntry, got {err:?}");
@@ -1160,8 +1248,15 @@ api_key = "lin_api_do-not-package-me"
             assert_eq!(links, 1, "{} has {links} links", path.display());
         }
         let report = RunReport::of(vec![run]);
-        assemble(&work, &config(), &report, &[], &default_destination(&work))
-            .expect("ordinary output must still package");
+        assemble(
+            &work,
+            &config(),
+            &report,
+            &[],
+            &default_destination(&work),
+            None,
+        )
+        .expect("ordinary output must still package");
     }
 
     /// A sweep in which nothing was audited must not produce a package that
@@ -1173,7 +1268,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![failed(&work, "00-acme-api", "acme-api")]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination)
+        let err = assemble(&work, &config(), &report, &[], &destination, None)
             .expect_err("no audited repository means no package");
         assert!(
             matches!(err, AuditError::NothingToPackage { .. }),
@@ -1195,7 +1290,8 @@ api_key = "lin_api_do-not-package-me"
         ]);
         let destination = default_destination(&work);
 
-        let package = assemble(&work, &config(), &report, &[], &destination).expect("assembles");
+        let package =
+            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
         assert_eq!(package.excluded.len(), 1);
         assert!(
             package.excluded[0].contains("acme-web"),
@@ -1242,7 +1338,8 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
         let destination = tmp.path().join("Desktop/return.zip");
 
-        let package = assemble(&work, &config(), &report, &[], &destination).expect("assembles");
+        let package =
+            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
         assert_eq!(package.path, destination);
         assert!(destination.is_file());
         assert!(!destination.starts_with(work.root()));
@@ -1265,7 +1362,7 @@ api_key = "lin_api_do-not-package-me"
         std::fs::write(work.path(Area::Extract).join("09-other.db"), b"other").expect("write");
         let destination = default_destination(&work);
 
-        assemble(&work, &config(), &report, &[], &destination).expect("assembles");
+        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
         let names = entries(&destination);
         assert!(
             names.contains(&"extract/00-acme-api.db".to_owned()),
@@ -1296,7 +1393,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![run]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination)
+        let err = assemble(&work, &config(), &report, &[], &destination, None)
             .expect_err("a report with no database must not be packaged");
         let AuditError::MissingExtractDatabase { repo, expected } = &err else {
             panic!("expected MissingExtractDatabase, got {err:?}");
@@ -1327,7 +1424,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![run]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination)
+        let err = assemble(&work, &config(), &report, &[], &destination, None)
             .expect_err("a missing extract/ directory must not be packaged");
         assert!(
             matches!(err, AuditError::MissingExtractDatabase { .. }),

--- a/crates/trusty-audit/src/package/credential_scan.rs
+++ b/crates/trusty-audit/src/package/credential_scan.rs
@@ -53,7 +53,10 @@ const CHUNK_BYTES: usize = 64 * 1024;
 /// `super::super::package_tests::a_member_carrying_the_linear_api_key_is_refused_and_leaves_no_zip`,
 /// `super::super::package_tests::a_member_carrying_several_secrets_is_refused_on_the_first_pass`,
 /// `super::super::package_tests::a_member_carrying_the_github_token_is_refused_and_leaves_no_zip`.
-fn secret_needles<'a>(config: &'a EngagementConfig, github_token: Option<&'a str>) -> Vec<&'a [u8]> {
+fn secret_needles<'a>(
+    config: &'a EngagementConfig,
+    github_token: Option<&'a str>,
+) -> Vec<&'a [u8]> {
     let mut needles: Vec<&[u8]> = config
         .configured_secrets()
         .into_iter()

--- a/crates/trusty-audit/src/package/credential_scan.rs
+++ b/crates/trusty-audit/src/package/credential_scan.rs
@@ -4,7 +4,11 @@
 //! Why: split out of `package.rs` when adding [`crate::error::AuditError::MissingExtractDatabase`]
 //! pushed that file one line past the 500-SLOC production cap (#5862) — the
 //! same split pattern documented in the project's file-size-cap policy. The
-//! scan itself is unchanged; only its home moved.
+//! scan itself is unchanged; only its home moved. The needle set grew once
+//! more the same way: the `gh`-derived GitHub token (#5980 CRITICAL 4) joined
+//! `openrouter_key` and the two board secrets as a value the deliverable must
+//! never carry, so `secret_needles` and `copy_member` both take it as an
+//! explicit parameter rather than reaching for a type this crate does not own.
 //!
 //! What: [`copy_member`] streams one file into the archive through
 //! [`CredentialScan`], a byte-oriented sliding window that has no notion of
@@ -33,19 +37,32 @@ const CHUNK_BYTES: usize = 64 * 1024;
 /// child writes are exactly the files this function's caller packages and sends
 /// off the recipient's network. One list, so a credential added to
 /// [`EngagementConfig`] is refused here the moment it is configured.
-/// What: [`EngagementConfig::configured_secrets`] as byte slices — the same
-/// list [`crate::run`]'s child-log scrubber uses as its needles, so the two
-/// guards cannot come to disagree about what a secret is. A provider with no
-/// entry contributes no needle.
+///
+/// `github_token` extends the same guard to the `gh`-derived credential
+/// (#5980 CRITICAL 4): before this parameter existed, a token echoed into a
+/// `tga`-written file under `out/`/`extract/` — the same shape #5857 already
+/// covers for JIRA and Linear — reached the deliverable unscanned, because
+/// [`EngagementConfig::configured_secrets`] has no way to name a credential
+/// that never lived in the engagement TOML.
+/// What: [`EngagementConfig::configured_secrets`] as byte slices, plus
+/// `github_token` when one was read — the same pair `crate::run`'s
+/// child-log scrubber uses as its needles, so the two guards cannot come to
+/// disagree about what a secret is. A provider with no entry contributes no
+/// needle.
 /// Test: `super::super::package_tests::a_member_carrying_the_jira_token_is_refused_and_leaves_no_zip`,
 /// `super::super::package_tests::a_member_carrying_the_linear_api_key_is_refused_and_leaves_no_zip`,
-/// `super::super::package_tests::a_member_carrying_several_secrets_is_refused_on_the_first_pass`.
-fn secret_needles(config: &EngagementConfig) -> Vec<&[u8]> {
-    config
+/// `super::super::package_tests::a_member_carrying_several_secrets_is_refused_on_the_first_pass`,
+/// `super::super::package_tests::a_member_carrying_the_github_token_is_refused_and_leaves_no_zip`.
+fn secret_needles<'a>(config: &'a EngagementConfig, github_token: Option<&'a str>) -> Vec<&'a [u8]> {
+    let mut needles: Vec<&[u8]> = config
         .configured_secrets()
         .into_iter()
         .map(str::as_bytes)
-        .collect()
+        .collect();
+    if let Some(token) = github_token {
+        needles.push(token.as_bytes());
+    }
+    needles
 }
 
 /// Copy one file into the archive, refusing it if it carries any credential.
@@ -55,6 +72,7 @@ pub(super) fn copy_member(
     source: &Path,
     config: &EngagementConfig,
     temporary: &Path,
+    github_token: Option<&str>,
 ) -> Result<u64, AuditError> {
     let mut input = std::fs::File::open(source).map_err(|e| AuditError::Package {
         path: source.to_path_buf(),
@@ -63,7 +81,7 @@ pub(super) fn copy_member(
     let bytes = input.metadata().map(|m| m.len()).unwrap_or(0);
     start(zip, entry, bytes, temporary)?;
 
-    let needles = secret_needles(config);
+    let needles = secret_needles(config, github_token);
     let mut scan = CredentialScan::over(&needles);
     let mut buffer = vec![0_u8; CHUNK_BYTES];
     let mut written = 0_u64;

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -482,7 +482,7 @@ where
 /// for what that leaves behind.
 /// Test: `super::run_tests::a_child_that_echoes_the_key_does_not_leave_it_in_the_log`,
 /// `super::run_tests::a_child_that_echoes_a_board_credential_does_not_leave_it_in_the_log`,
-/// `super::run_tests::a_child_that_echoes_the_github_token_does_not_leave_it_in_the_log`.
+/// `super::run_tests::child_output_scrubber_includes_the_github_token`.
 fn child_output_scrubber(
     config: &EngagementConfig,
     github_access: &github_issues::GithubAccess,

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -423,7 +423,13 @@ where
         // #5494: the record advances with the work, not after it. A crash, a
         // timeout or a Ctrl-C after this point costs the repositories still to
         // come and none of the ones already done.
-        checkpoint::write_progress(work, &RunProgress::checkpoint(&decided(&runs)))?;
+        checkpoint::write_progress(
+            work,
+            &RunProgress::checkpoint(
+                &decided(&runs),
+                github_issues::GithubCredentialRecord::of(&github_access),
+            ),
+        )?;
     }
 
     let report = RunReport::of(decided(&runs)).stating(board_gaps);
@@ -432,7 +438,13 @@ where
         report.repos.iter().filter(|r| r.result.succeeded()).count(),
         total,
     );
-    checkpoint::write_progress(work, &RunProgress::finished(&report))?;
+    checkpoint::write_progress(
+        work,
+        &RunProgress::finished(
+            &report,
+            github_issues::GithubCredentialRecord::of(&github_access),
+        ),
+    )?;
     Ok(report)
 }
 

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -383,7 +383,7 @@ where
     // #5869: materialized once for the whole sweep — resolving reads
     // `.env.local` and opens the secure store, which is not a per-child cost,
     // let alone a per-line one.
-    let scrubber = child_output_scrubber(config);
+    let scrubber = child_output_scrubber(config, &github_access);
     // #5494: decided once, against the whole selection, so a repository's fate
     // does not depend on a record another repository's child rewrote meanwhile.
     let plan = checkpoint::plan(work, &selected, options.fresh)?;
@@ -457,13 +457,29 @@ where
 /// quotes a JIRA token in an auth error would otherwise write it to the log
 /// verbatim. [`crate::package::secret_needles`] draws from the same list.
 ///
+/// #5980 CRITICAL 3: `github_access`'s raw token (when `gh auth token`
+/// answered) is a THIRD source, alongside `resolved_secret_values` and
+/// `configured_secrets` — it comes from the recipient's `gh` keychain, never
+/// from `EngagementConfig`, so neither of those two sees it. A child that
+/// echoes a rejected GitHub credential back (an auth-failure HTTP body, for
+/// instance) would otherwise land the Bearer token in the log unredacted —
+/// the same `boards` gap #5857 closed, reopened here for a credential that
+/// reaches the child a different way.
+///
 /// This removes only values this process already holds; see [`crate::relay`]
 /// for what that leaves behind.
 /// Test: `super::run_tests::a_child_that_echoes_the_key_does_not_leave_it_in_the_log`,
-/// `super::run_tests::a_child_that_echoes_a_board_credential_does_not_leave_it_in_the_log`.
-fn child_output_scrubber(config: &EngagementConfig) -> Scrubber {
+/// `super::run_tests::a_child_that_echoes_a_board_credential_does_not_leave_it_in_the_log`,
+/// `super::run_tests::a_child_that_echoes_the_github_token_does_not_leave_it_in_the_log`.
+fn child_output_scrubber(
+    config: &EngagementConfig,
+    github_access: &github_issues::GithubAccess,
+) -> Scrubber {
     let mut secrets = trusty_common::credentials::resolved_secret_values();
     secrets.extend(config.configured_secrets().into_iter().map(str::to_owned));
+    if let Some(token) = github_access.raw_token() {
+        secrets.push(token.to_owned());
+    }
     Scrubber::over(secrets)
 }
 
@@ -1899,6 +1915,28 @@ trusty-review = "0.15.1"
                 path.display()
             );
         }
+    }
+
+    /// #5980 CRITICAL 3 / MEDIUM 1: the `gh`-derived token is a THIRD
+    /// credential source, alongside `resolved_secret_values` and
+    /// `configured_secrets` — before `child_output_scrubber` took a
+    /// `github_access` parameter, nothing put it in the needle set and a
+    /// child that echoed a rejected GitHub credential wrote it to the log in
+    /// the clear, the same shape #5857 already closed for `boards`.
+    ///
+    /// `Scrubber::scrub` itself is private to `crate::relay`, so this proves
+    /// the needle set through `Scrubber`'s derived `Debug` rather than
+    /// through a real spawned child — [`github_issues::GithubAccess::with_token`]
+    /// exists for exactly this: constructing the token-present case without a
+    /// real `gh` on `PATH`.
+    #[test]
+    fn child_output_scrubber_includes_the_github_token() {
+        let access = github_issues::GithubAccess::with_token("ghp_test-token-in-needle-set");
+        let scrubber = child_output_scrubber(&config(), &access);
+        assert!(
+            format!("{scrubber:?}").contains("ghp_test-token-in-needle-set"),
+            "the github token must be in the scrubber's needle set: {scrubber:?}"
+        );
     }
 
     /// The CRITICAL arm: `tga audit` exits 0 whenever the sweep COMPLETED,

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -86,6 +86,13 @@ mod selection;
 // package and must reach them through this one resolution, not a second copy.
 pub mod boards;
 
+// #5980: what a registered repository automatically contributes — its GitHub
+// issues. Public for the same reason `boards` is: the generated section and
+// the environment variable carrying its secret both need to reach `chain` /
+// `session` call sites that construct or inspect a sweep from outside this
+// module.
+pub mod github_issues;
+
 // #5494: the checkpoint and its resume rules are one subject and they are not
 // this file's — `run.rs` drives children, `checkpoint.rs` decides what a re-run
 // may skip.
@@ -174,6 +181,13 @@ fn sanitize(name: &str) -> String {
 /// itself still travels only in the child's environment. Both are omitted when
 /// no board is registered, so a repo-only engagement generates exactly the
 /// document it always did.
+///
+/// #5980: `github` is different from `jira`/`linear` in one respect — it is
+/// never `None`. Every repository this document is generated for already
+/// names itself (the one entry in `repositories`), so its own issue tracker
+/// is not something that can be absent from the engagement the way an
+/// unregistered board is; see `github_issues`'s module docs for why the
+/// section still gets written even when no `gh` credential could be read.
 #[derive(Debug, Serialize)]
 struct TgaConfig {
     repositories: Vec<TgaRepository>,
@@ -182,6 +196,7 @@ struct TgaConfig {
     jira: Option<boards::TgaJira>,
     #[serde(skip_serializing_if = "Option::is_none")]
     linear: Option<boards::TgaLinear>,
+    github: github_issues::TgaGithub,
 }
 
 #[derive(Debug, Serialize)]
@@ -360,6 +375,11 @@ where
         }
     };
     let selected = load_selection(work)?;
+    // #5980: resolved once for the whole sweep, the same shape as `boards`
+    // above — every child gets the same `gh`-derived credential, not a
+    // per-repository one. See `github_issues`'s module docs for why a `gh`
+    // that cannot answer still lets the sweep proceed.
+    let github_access = github_issues::resolve_github_access().await;
     // #5869: materialized once for the whole sweep — resolving reads
     // `.env.local` and opens the secure store, which is not a per-child cost,
     // let alone a per-line one.
@@ -384,8 +404,18 @@ where
             Err(why) => {
                 announce_recollection(&repo.name, &why, progress);
                 run_one(
-                    work, config, &binaries, &inference, boards, index, repo, budget, progress,
-                    total, &scrubber,
+                    work,
+                    config,
+                    &binaries,
+                    &inference,
+                    boards,
+                    &github_access,
+                    index,
+                    repo,
+                    budget,
+                    progress,
+                    total,
+                    &scrubber,
                 )
                 .await?
             }
@@ -495,6 +525,7 @@ async fn run_one(
     binaries: &PinnedBinaries,
     inference: &[(&'static str, String)],
     boards: &boards::Boards,
+    github_access: &github_issues::GithubAccess,
     index: usize,
     repo: SelectedRepo,
     budget: std::time::Duration,
@@ -509,7 +540,16 @@ async fn run_one(
     progress.unit_started(Operation::Sweep, repo.name.as_str(), index + 1, total);
 
     let mut gaps = Vec::new();
-    let result = match prepare(work, &output, &stem, &checkout, boards, &binaries.search)? {
+    let result = match prepare(
+        work,
+        &output,
+        &stem,
+        &checkout,
+        boards,
+        github_access,
+        &repo.name,
+        &binaries.search,
+    )? {
         Err(reason) => RepoResult::Failed { reason },
         Ok(config_path) => {
             match spawn_tga(
@@ -517,6 +557,7 @@ async fn run_one(
                 config,
                 inference,
                 boards,
+                github_access,
                 &config_path,
                 &output,
                 &log,
@@ -569,12 +610,15 @@ async fn run_one(
 /// per-repo verdict, which is what turns the refusal into a NAMED failure. Left
 /// where it was, a refusal reached nobody — `tga audit` exits 0 whenever the
 /// sweep completed, so the run reported success with an empty code-analysis leg.
+#[allow(clippy::too_many_arguments)]
 fn prepare(
     work: &WorkDir,
     output: &Path,
     stem: &str,
     checkout: &Path,
     boards: &boards::Boards,
+    github_access: &github_issues::GithubAccess,
+    name_with_owner: &str,
     search: &Path,
 ) -> Result<Result<PathBuf, String>, AuditError> {
     if !checkout.is_dir() {
@@ -598,6 +642,9 @@ fn prepare(
         // `boards`'s module docs for why the file may never hold the value.
         jira: boards.jira.clone(),
         linear: boards.linear.clone(),
+        // #5980: always written — see `github_issues`'s module docs for why
+        // this is never `None` the way `jira`/`linear` can be.
+        github: github_access.section(name_with_owner),
     };
     // Infallible in practice — the document is owned strings and paths with no
     // map keys — but a serializer error must not be swallowed into a default.
@@ -675,6 +722,7 @@ async fn spawn_tga(
     config: &EngagementConfig,
     inference: &[(&'static str, String)],
     boards: &boards::Boards,
+    github_access: &github_issues::GithubAccess,
     config_path: &Path,
     output: &Path,
     log: &Path,
@@ -728,6 +776,12 @@ async fn spawn_tga(
     // here rather than held on `Boards`, so it lives no longer than this
     // `Command` — the same shape as the inference credential above.
     for (name, value) in boards.env(&config.boards) {
+        command.env(name, value);
+    }
+    // #5980: the `gh`-derived credential the generated config's `github:`
+    // section only references, when one was read — see `github_issues`'s
+    // module docs for why a missing one does not stop the child from running.
+    if let Some((name, value)) = github_access.env() {
         command.env(name, value);
     }
 
@@ -1586,6 +1640,40 @@ trusty-review = "0.15.1"
                 path.display()
             );
         }
+    }
+
+    /// #5980: the load-bearing regression. Against `origin/main` before this
+    /// change, `TgaConfig` carried no `github` field at all, so a registered
+    /// repository's own issues were never collected — not because a fetch
+    /// failed and was reported, but because nothing ever asked. That is the
+    /// silent-empty-success shape #5982 already fixed once for a Linear board
+    /// stored as an id; this proves the same shape cannot recur for a
+    /// repository's own GitHub issues by asserting the section is present
+    /// with NO board registered at all — the case that most directly exposes
+    /// an omission, since there is no `boards.jira`/`boards.linear` machinery
+    /// nearby that could be mistaken for covering it.
+    #[tokio::test]
+    async fn every_registered_repository_generates_a_github_section() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &writes_a_manifest(None));
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+        // Deliberately no `register_boards` call — a repo-only engagement.
+
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("the sweep completes");
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+
+        let generated =
+            std::fs::read_to_string(work.path(Area::State).join("tga-00-acme-api.yaml"))
+                .expect("the generated tga config");
+        assert!(
+            generated.contains("github:"),
+            "a repo-only engagement must still collect its own issues: {generated}"
+        );
+        assert!(generated.contains("repo: acme-api"), "{generated}");
     }
 
     /// The `taudit run` half of #5982. `boards::resolve` states a gap for a

--- a/crates/trusty-audit/src/run/checkpoint.rs
+++ b/crates/trusty-audit/src/run/checkpoint.rs
@@ -43,6 +43,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use super::github_issues::GithubCredentialRecord;
 use super::{RepoRun, RunReport, RunStatus, SelectedRepo, stem, verify_output};
 use crate::error::AuditError;
 use crate::workdir::{self, Area, WorkDir};
@@ -84,24 +85,45 @@ pub struct RunProgress {
     pub status: RunStatus,
     /// One entry per repository that has finished, in selection order.
     pub repos: Vec<RepoRun>,
+    /// What this sweep recorded about the `gh`-derived GitHub credential it
+    /// resolved (#5980 — the re-resolution/account-switch gap).
+    ///
+    /// Why: packaging can run as a separate process, long after the sweep and
+    /// possibly under a different `gh` account — see
+    /// `super::github_issues::GithubAccess::fingerprint`'s docs. `None` is
+    /// reserved for a checkpoint written before this field existed;
+    /// `super::github_issues::verify_unchanged` treats that as unverifiable
+    /// rather than as either recorded state, and proceeds with a stated gap
+    /// rather than refusing every pre-existing engagement outright.
+    /// What: never the raw token — only [`GithubCredentialRecord`]'s
+    /// non-reversible fingerprint, or the explicit "no token" state.
+    /// Test: `super::run_tests::child_output_scrubber_includes_the_github_token`
+    /// (sweep-side), `github_issues_tests` (the verification itself).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_credential: Option<GithubCredentialRecord>,
 }
 
 impl RunProgress {
     /// A checkpoint of a sweep that is still working through its selection.
-    pub(crate) fn checkpoint(repos: &[RepoRun]) -> Self {
-        Self::from_report(RunReport::of(repos.to_vec()), false)
+    pub(crate) fn checkpoint(repos: &[RepoRun], github_credential: GithubCredentialRecord) -> Self {
+        Self::from_report(RunReport::of(repos.to_vec()), false, github_credential)
     }
 
     /// The record of a sweep that reached the end of its selection.
-    pub(crate) fn finished(report: &RunReport) -> Self {
-        Self::from_report(report.clone(), true)
+    pub(crate) fn finished(report: &RunReport, github_credential: GithubCredentialRecord) -> Self {
+        Self::from_report(report.clone(), true, github_credential)
     }
 
-    fn from_report(report: RunReport, complete: bool) -> Self {
+    fn from_report(
+        report: RunReport,
+        complete: bool,
+        github_credential: GithubCredentialRecord,
+    ) -> Self {
         Self {
             complete,
             status: report.status,
             repos: report.repos,
+            github_credential: Some(github_credential),
         }
     }
 

--- a/crates/trusty-audit/src/run/github_issues.rs
+++ b/crates/trusty-audit/src/run/github_issues.rs
@@ -1,0 +1,196 @@
+//! What every registered repository automatically contributes: its GitHub
+//! issues (#5980).
+//!
+//! Why: owner ruling 2026-08-18 — "when a repository is registered as a
+//! target, collect from its GitHub issues automatically... No separate board
+//! registration for the repo's own issue tracker." Unlike a JIRA project or a
+//! Linear team ([`super::boards`]), a repository's issue tracker is not
+//! something an operator registers separately: every [`crate::registry::Target::Repo`]
+//! already names the repository, and that name is also the identity tga's
+//! `github.repo` field needs. So this module has no `resolve(targets, …)`
+//! step of its own — [`GithubAccess::section`] is called once per selected
+//! repository, directly from the same name `crate::run::SelectedRepo::name`
+//! already carries (which [`crate::clone::record_selection`] sets from
+//! [`crate::registry::Target::Repo::name_with_owner`], so it is already
+//! `owner/name`, never a display-only name).
+//!
+//! ## Auth: `gh`'s own OAuth, never a second token field
+//!
+//! Owner ruling: "for the boards, we should be using oauth… same with gh."
+//! [`resolve_github_access`] reuses [`crate::discover::credential_probe`] —
+//! the SAME `gh auth token` invocation `crate::clone` and `crate::validate`
+//! already run — rather than adding a `boards.github` (or similar) config
+//! field the recipient would have to populate with a raw PAT. A `gh` that
+//! cannot answer is not fatal: [`GithubAccess::token`] stays `None`, tga runs
+//! the REST client unauthenticated, and a repository that needs auth to read
+//! its issues fails at the API and is reported the way any other
+//! `work_items` fetch failure is — see the fail-open note below.
+//!
+//! ## Fail-open: no gap invented here, because tga already states one
+//!
+//! DOC-67 §9 / tga #5655 already turns ANY `work_items` fetch fault — issues
+//! disabled (HTTP 410), a rejected credential (401/403), or an unreachable
+//! endpoint — into a failed `collect` stage, which `sweep_gap_lines` turns
+//! into a named line in that repository's own manifest gaps
+//! (`crate::run::verify_output` reads it into `crate::run::RepoRun::gaps`).
+//! That is the JIRA precedent #5980 asks this feature to match: a stage that
+//! failed must not read as a stage that produced nothing. Because that
+//! mechanism already exists and already fires once `github:` is present in
+//! the generated config, this module's only obligation is to make sure that
+//! section is ALWAYS generated for every registered repository — never
+//! omitted because a token could not be read. Omitting it on a credential
+//! failure would be the silent-empty-success shape #5982 already fixed for
+//! Linear, repeated here under a new name.
+//!
+//! Test: `github_issues_tests` below.
+
+use serde::Serialize;
+
+/// The variable the `gh`-derived token reaches the child under.
+pub const ENV_GITHUB_TOKEN: &str = "TRUSTY_AUDIT_GITHUB_TOKEN";
+
+/// tga's `github:` section, as this client generates it.
+///
+/// Enough to drive `work_item_pipeline`'s reference-detection pull (`#NNNN` in
+/// commit messages) — not pull-request collection, which this client does not
+/// ask tga for.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TgaGithub {
+    /// `owner/name` — the same identity the repository was registered and
+    /// cloned under.
+    pub repo: String,
+    /// A `${VAR}` reference to the child's environment, never the token
+    /// itself — see the module docs. `None` when no `gh` credential could be
+    /// read; tga then runs unauthenticated rather than the section being
+    /// omitted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+}
+
+/// What one sweep could read from `gh` for issue collection, resolved once.
+///
+/// Why: every child gets the same credential — it is the recipient's own
+/// `gh` login, not a per-repository secret — so reading it once and reusing
+/// it matches how `crate::inference::inference_env` is resolved once per
+/// sweep rather than per repository.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GithubAccess {
+    /// The real token value, if `gh auth token` answered. Never written to
+    /// disk — only exposed into a child's environment, the same shape as
+    /// `super::boards::Boards::env`.
+    token: Option<String>,
+}
+
+impl GithubAccess {
+    /// The `(name, value)` pair to set in a child's environment, when a
+    /// credential was read.
+    pub fn env(&self) -> Option<(&'static str, &str)> {
+        self.token.as_deref().map(|t| (ENV_GITHUB_TOKEN, t))
+    }
+
+    /// This repository's `github:` section — always `Some`, per the module
+    /// docs: a repository target always contributes its issues, and a
+    /// missing credential is not a reason to omit the attempt.
+    ///
+    /// # Postconditions
+    /// `repo` equals `name_with_owner` verbatim; `token` is `Some("${…}")`
+    /// (never the real value) exactly when this access resolved one.
+    /// Test: `github_issues_tests::a_repo_with_a_token_gets_the_placeholder_never_the_value`,
+    /// `github_issues_tests::a_repo_with_no_token_still_gets_a_github_section`.
+    pub fn section(&self, name_with_owner: &str) -> TgaGithub {
+        TgaGithub {
+            repo: name_with_owner.to_owned(),
+            token: self
+                .token
+                .as_ref()
+                .map(|_| format!("${{{ENV_GITHUB_TOKEN}}}")),
+        }
+    }
+}
+
+/// Resolve the `gh`-derived credential once per sweep.
+///
+/// What: [`crate::discover::credential_probe`]'s `gh auth token`, trimmed.
+/// `Err` (no `gh`, not logged in, blank token) becomes [`GithubAccess`] with
+/// no token rather than a sweep-ending failure — see the module docs for why
+/// that is safe.
+/// Test: `github_issues_tests::an_err_result_resolves_to_no_token`,
+/// `github_issues_tests::an_ok_result_is_carried_through`.
+pub async fn resolve_github_access() -> GithubAccess {
+    from_probe_result(crate::discover::credential_probe().nonempty_stdout().await)
+}
+
+/// [`Result`] of [`GithubAccess`] from an already-resolved outcome.
+///
+/// Why: a test proving the no-token fallback needs to drive both arms of
+/// [`resolve_github_access`]'s match WITHOUT spawning a real `gh` — the same
+/// offline-provable shape `crate::validate::RepoProbe::unusable` gives the
+/// repository-validation arm (#5822). Rather than injecting a fake process
+/// spawner, this takes the already-resolved `Result` the real function
+/// would have awaited, so the mapping is exercised directly.
+/// Test: `github_issues_tests::{an_err_result_resolves_to_no_token,
+/// an_ok_result_is_carried_through}`.
+fn from_probe_result(result: Result<String, trusty_common::gh::GhError>) -> GithubAccess {
+    match result {
+        Ok(token) => GithubAccess { token: Some(token) },
+        Err(_) => GithubAccess::default(),
+    }
+}
+
+#[cfg(test)]
+mod github_issues_tests {
+    use super::*;
+
+    #[test]
+    fn a_repo_with_a_token_gets_the_placeholder_never_the_value() {
+        let access = GithubAccess {
+            token: Some("ghp_real-token-do-not-write-me-down".to_owned()),
+        };
+        let section = access.section("acme/api");
+        assert_eq!(section.repo, "acme/api");
+        assert_eq!(
+            section.token.as_deref(),
+            Some("${TRUSTY_AUDIT_GITHUB_TOKEN}")
+        );
+        assert_eq!(
+            access.env(),
+            Some((ENV_GITHUB_TOKEN, "ghp_real-token-do-not-write-me-down"))
+        );
+    }
+
+    /// #5980: the load-bearing property — an unreadable credential must not
+    /// make the section disappear, or a repository whose token expired would
+    /// silently stop contributing issues with nothing said anywhere. `token:
+    /// None` lets tga run unauthenticated instead of the section vanishing.
+    #[test]
+    fn a_repo_with_no_token_still_gets_a_github_section() {
+        let access = GithubAccess::default();
+        let section = access.section("acme/api");
+        assert_eq!(section.repo, "acme/api");
+        assert_eq!(section.token, None);
+        assert_eq!(access.env(), None);
+    }
+
+    #[test]
+    fn the_generated_document_omits_the_token_key_entirely_when_absent() {
+        let section = GithubAccess::default().section("acme/api");
+        let yaml = serde_yaml::to_string(&section).expect("serializes");
+        assert!(!yaml.contains("token"), "{yaml}");
+        assert!(yaml.contains("acme/api"), "{yaml}");
+    }
+
+    /// A `gh` that cannot answer (not installed, not logged in) must not stop
+    /// the sweep or panic — it resolves to no token, and every repository
+    /// still gets a `github:` section per the property above.
+    #[test]
+    fn an_err_result_resolves_to_no_token() {
+        let access = from_probe_result(Err(trusty_common::gh::GhError::NotInstalled));
+        assert_eq!(access.token, None);
+    }
+
+    #[test]
+    fn an_ok_result_is_carried_through() {
+        let access = from_probe_result(Ok("a-real-token".to_owned()));
+        assert_eq!(access.token.as_deref(), Some("a-real-token"));
+    }
+}

--- a/crates/trusty-audit/src/run/github_issues.rs
+++ b/crates/trusty-audit/src/run/github_issues.rs
@@ -56,7 +56,8 @@
 //!
 //! Test: `github_issues_tests` below.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 /// The variable the `gh`-derived token reaches the child under.
 pub const ENV_GITHUB_TOKEN: &str = "TRUSTY_AUDIT_GITHUB_TOKEN";
@@ -118,6 +119,32 @@ impl GithubAccess {
         self.token.as_deref()
     }
 
+    /// A non-reversible, truncated identity fingerprint of the resolved
+    /// token, or `None` when no credential was resolved.
+    ///
+    /// Why (#5980 — the re-resolution/account-switch gap): packaging
+    /// re-resolves `gh auth token` fresh rather than inheriting the sweep's
+    /// value (see [`verify_unchanged`]'s callers), because packaging can run
+    /// as a separate process — possibly after the operator switched `gh`
+    /// accounts between the sweep and the package command. Scanning outbound
+    /// files with the NEW token's bytes can never catch an OLD token a child
+    /// echoed into a file at sweep time. This fingerprint is what lets
+    /// packaging PROVE the two resolutions are the same account without ever
+    /// persisting the raw token — [`crate::run::checkpoint::RunProgress`]
+    /// stores only this value.
+    /// What: the first 8 bytes (16 hex characters) of the token's SHA-256
+    /// digest. Truncated deliberately: this exists to detect a DIFFERENT
+    /// token, never to be treated as a secondary secret worth protecting at
+    /// full strength.
+    /// Test: `github_issues_tests::{fingerprint_is_stable_for_the_same_token,
+    /// fingerprint_differs_for_different_tokens, fingerprint_is_none_with_no_token}`.
+    pub(crate) fn fingerprint(&self) -> Option<String> {
+        self.token.as_deref().map(|t| {
+            let digest = Sha256::digest(t.as_bytes());
+            digest.iter().take(8).map(|b| format!("{b:02x}")).collect()
+        })
+    }
+
     /// This repository's `github:` section — always `Some`, per the module
     /// docs: a repository target always contributes its issues, and a
     /// missing credential is not a reason to omit the attempt.
@@ -176,6 +203,86 @@ fn from_probe_result(result: Result<String, trusty_common::gh::GhError>) -> Gith
     match result {
         Ok(token) => GithubAccess { token: Some(token) },
         Err(_) => GithubAccess::default(),
+    }
+}
+
+/// What a sweep recorded about the `gh`-derived credential it resolved.
+///
+/// Why: persisted into `crate::run::checkpoint::RunProgress` so packaging — a
+/// later, possibly separate, process — can prove it is scanning outbound
+/// files with the credential that produced them (see
+/// [`GithubAccess::fingerprint`]'s docs for the gap this closes). The record
+/// being ABSENT from a checkpoint (`Option::None` one level up, in
+/// `RunProgress::github_credential`) is reserved for one specific case: a
+/// checkpoint written before this field existed. This enum's own two
+/// variants are for a sweep that recorded something, one way or the other —
+/// [`verify_unchanged`] treats all three states differently.
+/// Test: `github_issues_tests`, `verify_unchanged`'s own tests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GithubCredentialRecord {
+    /// The sweep resolved no `gh` credential and ran unauthenticated.
+    NoToken,
+    /// [`GithubAccess::fingerprint`] of the token the sweep resolved.
+    Fingerprint(String),
+}
+
+impl GithubCredentialRecord {
+    /// What a sweep should record, from the access it resolved.
+    pub(crate) fn of(access: &GithubAccess) -> Self {
+        match access.fingerprint() {
+            Some(fp) => Self::Fingerprint(fp),
+            None => Self::NoToken,
+        }
+    }
+}
+
+/// Confirm the currently-resolved credential is the one the sweep recorded,
+/// before packaging trusts its scrub needle to have covered every file.
+///
+/// Why: see [`GithubAccess::fingerprint`]'s docs for the account-switch gap
+/// this closes. Called from `crate::package::from_checkpoint`, which is the
+/// one place that has both the checkpoint's record and a freshly resolved
+/// [`GithubAccess`] in hand.
+///
+/// # Returns
+/// `Ok(None)` when the two agree — including "neither run had a token",
+/// which is always safe regardless of what the current resolution holds,
+/// because a sweep with no token could not have put one in any file.
+/// `Ok(Some(gap))` when `persisted` is `None` — the checkpoint predates this
+/// field, so there is nothing to compare against; packaging proceeds, and the
+/// returned line names the uncertainty for the operator.
+/// `Err(AuditError::GithubCredentialChanged)` when the checkpoint recorded a
+/// fingerprint this resolution provably disagrees with, whether the current
+/// resolution has a different token or none at all — a fingerprint is
+/// one-way, so a missing current token leaves no way to scan for the one the
+/// checkpoint named.
+/// Test: `github_issues_tests::{a_matching_fingerprint_proceeds_cleanly,
+/// both_runs_having_no_token_proceeds_cleanly,
+/// an_unrecorded_checkpoint_proceeds_with_a_gap,
+/// a_mismatched_fingerprint_refuses,
+/// losing_the_token_between_sweep_and_package_refuses}`.
+///
+/// # Errors
+///
+/// [`crate::error::AuditError::GithubCredentialChanged`] on a proven mismatch.
+pub(crate) fn verify_unchanged(
+    persisted: Option<&GithubCredentialRecord>,
+    resolved: &GithubAccess,
+) -> Result<Option<String>, crate::error::AuditError> {
+    use crate::error::AuditError;
+    match persisted {
+        None => Ok(Some(
+            "the GitHub credential used during collection was not recorded (this \
+             checkpoint predates credential verification) — GitHub-derived content in \
+             this deliverable could not be re-checked against the currently active \
+             credential"
+                .to_owned(),
+        )),
+        Some(GithubCredentialRecord::NoToken) => Ok(None),
+        Some(GithubCredentialRecord::Fingerprint(old)) => match resolved.fingerprint() {
+            Some(new) if new == *old => Ok(None),
+            _ => Err(AuditError::GithubCredentialChanged),
+        },
     }
 }
 
@@ -248,5 +355,93 @@ mod github_issues_tests {
             Some("ghp_real-token-do-not-write-me-down")
         );
         assert_eq!(GithubAccess::default().raw_token(), None);
+    }
+
+    #[test]
+    fn fingerprint_is_stable_for_the_same_token() {
+        let a = GithubAccess::with_token("ghp_account_a_token");
+        let b = GithubAccess::with_token("ghp_account_a_token");
+        assert_eq!(a.fingerprint(), b.fingerprint());
+        assert!(a.fingerprint().is_some());
+    }
+
+    #[test]
+    fn fingerprint_differs_for_different_tokens() {
+        let a = GithubAccess::with_token("ghp_sweep_time_account_A_token");
+        let b = GithubAccess::with_token("ghp_package_time_account_B_token");
+        assert_ne!(a.fingerprint(), b.fingerprint());
+    }
+
+    #[test]
+    fn fingerprint_is_none_with_no_token() {
+        assert_eq!(GithubAccess::default().fingerprint(), None);
+    }
+
+    /// #5980 follow-up CRITICAL: a matching fingerprint proceeds with no gap.
+    #[test]
+    fn a_matching_fingerprint_proceeds_cleanly() {
+        let access = GithubAccess::with_token("ghp_same_account_both_times");
+        let persisted = GithubCredentialRecord::of(&access);
+        let resolved = GithubAccess::with_token("ghp_same_account_both_times");
+        assert_eq!(
+            verify_unchanged(Some(&persisted), &resolved).expect("must not refuse"),
+            None
+        );
+    }
+
+    /// A sweep that ran with no token can never have leaked one — whatever is
+    /// active at package time, there is nothing on disk to have caught.
+    #[test]
+    fn both_runs_having_no_token_proceeds_cleanly() {
+        let persisted = GithubCredentialRecord::NoToken;
+        assert_eq!(
+            verify_unchanged(Some(&persisted), &GithubAccess::default()).expect("no token twice"),
+            None
+        );
+        let with_new_token = GithubAccess::with_token("ghp_a_token_that_showed_up_later");
+        assert_eq!(
+            verify_unchanged(Some(&persisted), &with_new_token)
+                .expect("a sweep with no token never leaked one"),
+            None
+        );
+    }
+
+    /// The back-compat case: a checkpoint written before this field existed.
+    /// Packaging proceeds — refusing every pre-existing engagement's checkpoint
+    /// outright would be disproportionate to a narrowly-scoped verification —
+    /// but the gap line says so, rather than silently claiming agreement.
+    #[test]
+    fn an_unrecorded_checkpoint_proceeds_with_a_gap() {
+        let gap = verify_unchanged(None, &GithubAccess::default())
+            .expect("an unrecorded checkpoint is not a refusal");
+        assert!(gap.is_some(), "the uncertainty must be stated");
+        assert!(gap.unwrap().contains("not recorded"));
+    }
+
+    /// #5980 follow-up CRITICAL — the critic's proof, inverted: a file
+    /// carrying the sweep-time account's token, packaged under a DIFFERENT
+    /// account's token, must now refuse instead of silently succeeding.
+    #[test]
+    fn a_mismatched_fingerprint_refuses() {
+        let sweep_time = GithubAccess::with_token("ghp_sweep_time_account_A_token");
+        let persisted = GithubCredentialRecord::of(&sweep_time);
+        let package_time = GithubAccess::with_token("ghp_package_time_account_B_token");
+        assert!(matches!(
+            verify_unchanged(Some(&persisted), &package_time),
+            Err(crate::error::AuditError::GithubCredentialChanged)
+        ));
+    }
+
+    /// The one-way direction of the mismatch: a token recorded at sweep time
+    /// but NO token active at package time is exactly as unverifiable as a
+    /// different token — the fingerprint cannot be reversed into a needle.
+    #[test]
+    fn losing_the_token_between_sweep_and_package_refuses() {
+        let sweep_time = GithubAccess::with_token("ghp_sweep_time_account_A_token");
+        let persisted = GithubCredentialRecord::of(&sweep_time);
+        assert!(matches!(
+            verify_unchanged(Some(&persisted), &GithubAccess::default()),
+            Err(crate::error::AuditError::GithubCredentialChanged)
+        ));
     }
 }

--- a/crates/trusty-audit/src/run/github_issues.rs
+++ b/crates/trusty-audit/src/run/github_issues.rs
@@ -28,19 +28,31 @@
 //!
 //! ## Fail-open: no gap invented here, because tga already states one
 //!
-//! DOC-67 §9 / tga #5655 already turns ANY `work_items` fetch fault — issues
-//! disabled (HTTP 410), a rejected credential (401/403), or an unreachable
-//! endpoint — into a failed `collect` stage, which `sweep_gap_lines` turns
+//! Corrected (#5980 CRITICAL 2): the section below used to credit DOC-67 §9
+//! for this mechanism; that section is about `report --analyze`'s
+//! `HttpAnalyzeMetricsSource` enrichment, not about `work_items` collection —
+//! wrong governing spec, kept here only as the record of the mistake.
+//!
+//! tga #5655 turns ANY `work_items` fetch fault — issues disabled (HTTP
+//! 410), a rejected credential (401/403), or an unreachable endpoint — into a
+//! failed `collect` stage, which `tga::audit::gaps::sweep_gap_lines` turns
 //! into a named line in that repository's own manifest gaps
 //! (`crate::run::verify_output` reads it into `crate::run::RepoRun::gaps`).
-//! That is the JIRA precedent #5980 asks this feature to match: a stage that
-//! failed must not read as a stage that produced nothing. Because that
-//! mechanism already exists and already fires once `github:` is present in
-//! the generated config, this module's only obligation is to make sure that
-//! section is ALWAYS generated for every registered repository — never
-//! omitted because a token could not be read. Omitting it on a credential
-//! failure would be the silent-empty-success shape #5982 already fixed for
-//! Linear, repeated here under a new name.
+//! **That chain depends on the fetch actually erroring**, though: before
+//! #5980 CRITICAL 1's fix, `GitHubClient::fetch_issue` mapped a private
+//! repository's every-request-404 to `Ok(None)` — indistinguishable from "no
+//! such issue" — so `work_item_pipeline::run_one_adapter`'s authoritative
+//! not-found arm recorded nothing and #5655's mechanism never fired at all.
+//! The repo-visibility probe added there is what makes an invisible repo
+//! reach `stats.fail_stage`/`skip_item` in the first place; this module's
+//! job is unchanged — making sure `github:` is present in the generated
+//! config for every registered repository, never omitted because a token
+//! could not be read, so that when the fetch below it fails, the failure has
+//! something to attach to. Omitting the section on a credential failure
+//! would be the silent-empty-success shape #5982 already fixed for Linear,
+//! repeated here under a new name. That is the JIRA precedent #5980 asks
+//! this feature to match: a stage that failed must not read as a stage that
+//! produced nothing.
 //!
 //! Test: `github_issues_tests` below.
 
@@ -88,6 +100,24 @@ impl GithubAccess {
         self.token.as_deref().map(|t| (ENV_GITHUB_TOKEN, t))
     }
 
+    /// The real token value, for the outbound credential guards ONLY (#5980
+    /// CRITICAL 3 / CRITICAL 4) — every other consumer gets [`Self::env`]'s
+    /// child-environment pair or [`Self::section`]'s `${VAR}` placeholder,
+    /// never this.
+    ///
+    /// Why: a child that echoes an auth failure back (a rejected `gh`-derived
+    /// token quoted in an HTTP error body) can put the raw value in its own
+    /// stdout/stderr, or in a file it writes under `out/`/`extract/` — the
+    /// same two places `crate::run`'s child-log scrubber and
+    /// `crate::package`'s outbound scan already guard for `boards`' JIRA and
+    /// Linear credentials (#5857). Neither guard could see this token before
+    /// it had a way to read it back out of [`GithubAccess`].
+    /// What: the raw `Option<&str>`, unmodified.
+    /// Test: `github_issues_tests::raw_token_exposes_the_value_the_placeholder_hides`.
+    pub(crate) fn raw_token(&self) -> Option<&str> {
+        self.token.as_deref()
+    }
+
     /// This repository's `github:` section — always `Some`, per the module
     /// docs: a repository target always contributes its issues, and a
     /// missing credential is not a reason to omit the attempt.
@@ -104,6 +134,18 @@ impl GithubAccess {
                 .token
                 .as_ref()
                 .map(|_| format!("${{{ENV_GITHUB_TOKEN}}}")),
+        }
+    }
+
+    /// Build a [`GithubAccess`] carrying a specific token, for tests that
+    /// need to prove the credential reaches a child's environment or an
+    /// outbound guard's needle set without spawning a real `gh` (#5980
+    /// MEDIUM 1). Production code only ever constructs this type through
+    /// [`resolve_github_access`].
+    #[cfg(test)]
+    pub(crate) fn with_token(token: impl Into<String>) -> Self {
+        Self {
+            token: Some(token.into()),
         }
     }
 }
@@ -192,5 +234,19 @@ mod github_issues_tests {
     fn an_ok_result_is_carried_through() {
         let access = from_probe_result(Ok("a-real-token".to_owned()));
         assert_eq!(access.token.as_deref(), Some("a-real-token"));
+    }
+
+    /// #5980 MEDIUM 1: `section()` and `env()` both hide the real value behind
+    /// a placeholder or a not-yet-dereferenced pair; `raw_token` is the one
+    /// path that hands back the value itself, and only the outbound guards
+    /// (the child-log scrubber, the package's credential scan) may call it.
+    #[test]
+    fn raw_token_exposes_the_value_the_placeholder_hides() {
+        let access = GithubAccess::with_token("ghp_real-token-do-not-write-me-down");
+        assert_eq!(
+            access.raw_token(),
+            Some("ghp_real-token-do-not-write-me-down")
+        );
+        assert_eq!(GithubAccess::default().raw_token(), None);
     }
 }

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -820,18 +820,14 @@ impl Session {
         // #5980 CRITICAL 4: re-resolved here rather than threaded from `run` —
         // packaging is a standalone command that can run long after (even in a
         // different process from) the sweep that collected GitHub issues, so
-        // there is no live `GithubAccess` to inherit. The outbound credential
-        // scan needs the same value the scrubber used during collection.
+        // there is no live `GithubAccess` to inherit. `from_checkpoint` proves
+        // this resolution is still the same account the sweep recorded before
+        // trusting it as the outbound scan's needle (#5980 CRITICAL — the
+        // account-switch follow-up).
         let github_access = run::github_issues::resolve_github_access().await;
         // No unattempted targets: the standalone verb packages whatever the last
         // sweep recorded and knows nothing about a registry (#5824).
-        package::from_checkpoint(
-            &self.work,
-            &config,
-            &[],
-            &destination,
-            github_access.raw_token(),
-        )
+        package::from_checkpoint(&self.work, &config, &[], &destination, &github_access)
     }
 
     /// Drive the whole engagement in one call (#5824).
@@ -1091,9 +1087,21 @@ path = "/work/repos/acme-api"
     }
 
     /// Record a sweep that reached the end of its selection (#5494).
+    ///
+    /// Records [`run::github_issues::GithubCredentialRecord::NoToken`] (#5980
+    /// follow-up) — deliberately, not because these tests assert anything
+    /// about GitHub: `verify_unchanged` treats "the sweep had no token" as
+    /// compatible with WHATEVER `package()` resolves at test time, real `gh`
+    /// on the host included, so this stays safe however that host answers.
     fn write_finished_progress(work: &WorkDir, report: &RunReport) {
-        run::checkpoint::write_progress(work, &run::RunProgress::finished(report))
-            .expect("write progress");
+        run::checkpoint::write_progress(
+            work,
+            &run::RunProgress::finished(
+                report,
+                run::github_issues::GithubCredentialRecord::NoToken,
+            ),
+        )
+        .expect("write progress");
     }
 
     fn write_manifest(session: &Session, text: &str) {
@@ -1616,8 +1624,14 @@ trusty-review = "0.0.0-never-published"
             resumed: false,
             result: RepoResult::Succeeded,
         }];
-        run::checkpoint::write_progress(session.work_dir(), &run::RunProgress::checkpoint(&done))
-            .expect("write checkpoint");
+        run::checkpoint::write_progress(
+            session.work_dir(),
+            &run::RunProgress::checkpoint(
+                &done,
+                run::github_issues::GithubCredentialRecord::NoToken,
+            ),
+        )
+        .expect("write checkpoint");
 
         let err = session
             .execute(Command::Package { destination: None })
@@ -1651,17 +1665,20 @@ trusty-review = "0.0.0-never-published"
         write_manifest(&session, MANIFEST);
         run::checkpoint::write_progress(
             session.work_dir(),
-            &run::RunProgress::checkpoint(&[RepoRun {
-                repo: SelectedRepo {
-                    name: "acme-api".to_owned(),
-                    path: PathBuf::from("repos/acme-api"),
-                },
-                output: session.work_dir().path(Area::Output).join("00-acme-api"),
-                log: session.work_dir().path(Area::Logs).join("00-acme-api.log"),
-                gaps: Vec::new(),
-                resumed: false,
-                result: RepoResult::Succeeded,
-            }]),
+            &run::RunProgress::checkpoint(
+                &[RepoRun {
+                    repo: SelectedRepo {
+                        name: "acme-api".to_owned(),
+                        path: PathBuf::from("repos/acme-api"),
+                    },
+                    output: session.work_dir().path(Area::Output).join("00-acme-api"),
+                    log: session.work_dir().path(Area::Logs).join("00-acme-api.log"),
+                    gaps: Vec::new(),
+                    resumed: false,
+                    result: RepoResult::Succeeded,
+                }],
+                run::github_issues::GithubCredentialRecord::NoToken,
+            ),
         )
         .expect("write checkpoint");
 

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -601,7 +601,9 @@ impl Session {
             Command::ListTargets => self.list_targets().map(Outcome::Targets),
             Command::RemoveTarget { spec } => self.remove_target(&spec).await.map(Outcome::Removed),
             Command::Run(options) => self.run(&options).await.map(Outcome::Run),
-            Command::Package { destination } => self.package(destination).map(Outcome::Package),
+            Command::Package { destination } => {
+                self.package(destination).await.map(Outcome::Package)
+            }
             // #5824: the one-shot chain over the four above. `crate::chain`
             // calls each of them unchanged, so this and they cannot drift.
             Command::Audit(options) => self.audit(&options).await.map(Outcome::Audit),
@@ -807,7 +809,7 @@ impl Session {
     /// precondition enforced in two places is one that drifts.
     /// Test: `super::session_tests::packaging_before_any_sweep_is_refused`,
     /// `super::session_tests::packaging_an_unfinished_sweep_is_refused`.
-    fn package(&self, destination: Option<PathBuf>) -> Result<ReturnPackage, AuditError> {
+    async fn package(&self, destination: Option<PathBuf>) -> Result<ReturnPackage, AuditError> {
         // #5868: through `engagement_config` so the outbound credential scan
         // looks for the key the sweep actually used. `package::from_checkpoint`
         // refuses a deliverable containing `config.openrouter_key`; with an
@@ -815,9 +817,21 @@ impl Session {
         // the wrong bytes and let the real one through.
         let config = self.engagement_config()?;
         let destination = destination.unwrap_or_else(|| package::default_destination(&self.work));
+        // #5980 CRITICAL 4: re-resolved here rather than threaded from `run` —
+        // packaging is a standalone command that can run long after (even in a
+        // different process from) the sweep that collected GitHub issues, so
+        // there is no live `GithubAccess` to inherit. The outbound credential
+        // scan needs the same value the scrubber used during collection.
+        let github_access = run::github_issues::resolve_github_access().await;
         // No unattempted targets: the standalone verb packages whatever the last
         // sweep recorded and knows nothing about a registry (#5824).
-        package::from_checkpoint(&self.work, &config, &[], &destination)
+        package::from_checkpoint(
+            &self.work,
+            &config,
+            &[],
+            &destination,
+            github_access.raw_token(),
+        )
     }
 
     /// Drive the whole engagement in one call (#5824).

--- a/crates/trusty-git-analytics/changelog.d/5980-github-fetch-issue-visibility-probe.md
+++ b/crates/trusty-git-analytics/changelog.d/5980-github-fetch-issue-visibility-probe.md
@@ -1,0 +1,10 @@
+Fixed
+
+- `GitHubClient::fetch_issue` no longer treats a private repository invisible
+  to the configured credential as "issue not found". GitHub answers every
+  request under such a repo with 404, so a missing token or one that cannot
+  see the repo used to look identical to a genuinely deleted issue and the
+  caller silently collected nothing. A repo-visibility probe now
+  distinguishes the two, cached once per client so it does not repeat on
+  every subsequent lookup, and `fetch_issue` retries on 429/5xx the same as
+  `list_issues` and `fetch_pr_commits` (#5980).

--- a/crates/trusty-git-analytics/src/collect/github/client.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client.rs
@@ -6,7 +6,7 @@ use tracing::{debug, warn};
 
 use async_trait::async_trait;
 
-use crate::collect::errors::Result;
+use crate::collect::errors::{CollectError, Result};
 use crate::collect::github::repo_resolver::{build_http_client, parse_slug};
 use crate::collect::github::retry::retry_get;
 use crate::collect::github::types::{ApiPull, GitHubIssue, GitHubPrCommit, GitHubReview};
@@ -45,6 +45,11 @@ pub struct GitHubClient {
     /// REST root every request is built against. [`GITHUB_API_BASE`] unless a
     /// caller overrode it with [`Self::with_api_base`] (#5465).
     pub(crate) api_base: String,
+    /// Cached result of the repo-visibility probe (#5980 CRITICAL 1).
+    /// `Some(true)` once `GET /repos/{owner}/{repo}` has confirmed this
+    /// client's credential (or lack of one) can see the primary repo — see
+    /// [`Self::ensure_repo_visible`].
+    repo_visible: tokio::sync::OnceCell<bool>,
 }
 
 /// Compute the JSON-encoded `commit_shas` value for a PR row.
@@ -93,6 +98,7 @@ impl GitHubClient {
             repo: repo.clone(),
             repos: vec![(owner, repo)],
             api_base: GITHUB_API_BASE.to_string(),
+            repo_visible: tokio::sync::OnceCell::new(),
         })
     }
 
@@ -129,6 +135,7 @@ impl GitHubClient {
             repo: primary_repo,
             repos,
             api_base: GITHUB_API_BASE.to_string(),
+            repo_visible: tokio::sync::OnceCell::new(),
         })
     }
 
@@ -155,6 +162,7 @@ impl GitHubClient {
             repo: String::new(),
             repos: Vec::new(),
             api_base: GITHUB_API_BASE.to_string(),
+            repo_visible: tokio::sync::OnceCell::new(),
         })
     }
 
@@ -351,15 +359,25 @@ impl GitHubClient {
     /// Fetch a single issue by number from the GitHub REST API.
     ///
     /// Hits `GET /repos/{owner}/{repo}/issues/{number}`. Uses the same
-    /// `Bearer` token (if any) as the bulk PR fetch.
+    /// `Bearer` token (if any) as the bulk PR fetch. Retries on 429/5xx the
+    /// same as [`Self::list_issues`] and [`Self::fetch_pr_commits`] (#5980
+    /// MEDIUM 2 — this used to call `self.client` directly and skip retry).
     ///
-    /// Returns `Ok(None)` when the API responds with `404 Not Found`
-    /// (deleted or invisible issue). All other non-success statuses, as
-    /// well as transport and JSON-parse failures, are propagated as
+    /// Returns `Ok(None)` when the API responds with `404 Not Found` AND the
+    /// repo itself is confirmed visible to this credential (see
+    /// [`Self::ensure_repo_visible`]) — a genuinely deleted or nonexistent
+    /// issue. A 404 on a repo this credential cannot see at all (private repo,
+    /// missing/invalid token) is a different failure — GitHub answers that
+    /// with 404 on every request under it, so treating it as "no such issue"
+    /// would silently report zero issues collected instead of a credential
+    /// problem (#5980 CRITICAL 1). All other non-success statuses, as well as
+    /// transport and JSON-parse failures, are propagated as
     /// [`crate::collect::errors::CollectError`].
     ///
     /// # Errors
     ///
+    /// - [`crate::collect::errors::CollectError::GithubApi`] when the repo
+    ///   itself is not visible to this credential.
     /// - [`crate::collect::errors::CollectError::Http`] on transport or non-`404`
     ///   non-success HTTP responses.
     /// - [`crate::collect::errors::CollectError::Json`] on payload parse failures.
@@ -367,15 +385,64 @@ impl GitHubClient {
         let base = self.api_base();
         let url = format!("{base}/repos/{}/{}/issues/{number}", self.owner, self.repo);
         debug!(url = %url, "GET");
-        let resp = self.client.get(&url).send().await?;
+        let resp = self.retry_request(&url).await?;
 
         if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            self.ensure_repo_visible().await?;
             return Ok(None);
         }
 
         let resp = resp.error_for_status()?;
         let issue: GitHubIssue = resp.json().await?;
         Ok(Some(issue))
+    }
+
+    /// Confirm the primary `(owner, repo)` is visible to this client's
+    /// credential, once per client instance.
+    ///
+    /// Why (#5980 CRITICAL 1): GitHub 404s EVERY request under a private
+    /// repository the credential can't see — `fetch_issue` alone cannot tell
+    /// that apart from "this one issue doesn't exist". Probing
+    /// `GET /repos/{owner}/{repo}` resolves the ambiguity: the repo endpoint
+    /// 404s only when the repo is invisible to this credential (or genuinely
+    /// does not exist), never because of one missing issue number.
+    /// What: on the first call, issues the probe and caches `true` on
+    /// success so later `fetch_issue` calls that also 404 don't repeat the
+    /// request. A failed probe is NOT cached — a transient network error
+    /// should not permanently poison every later call on this client.
+    /// Test: `fetch_issue_tests::a_private_repo_with_no_visible_credential_errors_instead_of_returning_none`,
+    /// `fetch_issue_tests::a_genuinely_missing_issue_on_a_visible_repo_returns_none`,
+    /// `fetch_issue_tests::the_repo_visibility_probe_runs_at_most_once_per_client`.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::collect::errors::CollectError::GithubApi`] when the probe
+    /// itself 404s; [`crate::collect::errors::CollectError::Http`] on any
+    /// other transport or non-success response.
+    async fn ensure_repo_visible(&self) -> Result<()> {
+        if self.repo_visible.get().is_some() {
+            return Ok(());
+        }
+        let base = self.api_base();
+        let url = format!("{base}/repos/{}/{}", self.owner, self.repo);
+        debug!(url = %url, "GET (repo-visibility probe)");
+        let resp = self.retry_request(&url).await?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(CollectError::GithubApi {
+                status: 404,
+                endpoint: url,
+                message: "repository not visible to the configured credential \
+                          (private repo with no or invalid token, or the repo \
+                          genuinely does not exist)"
+                    .to_string(),
+            });
+        }
+        // Any other non-success (401/403/5xx) is a real transport failure,
+        // not the "invisible repo" shape this probe exists to catch.
+        resp.error_for_status()?;
+        let _ = self.repo_visible.set(true);
+        Ok(())
     }
 
     /// Send a GET request with exponential backoff on transient failures.

--- a/crates/trusty-git-analytics/src/collect/github/client_tests.rs
+++ b/crates/trusty-git-analytics/src/collect/github/client_tests.rs
@@ -545,3 +545,117 @@ fn store_pull_requests_applies_genuinely_newer_fetched_at() {
         "a genuinely newer fetched_at must overwrite the previous row"
     );
 }
+
+// ─── fetch_issue: repo-visibility probe (#5980 CRITICAL 1 / MEDIUM 2) ─────────
+
+mod fetch_issue_tests {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    /// A client pointed at `base`, with no token — the exact shape
+    /// `trusty-audit`'s `resolve_github_access` produces when `gh auth token`
+    /// fails (#5980).
+    fn client_at(base: &str) -> GitHubClient {
+        GitHubClient::new(&gh(Some("acme/private-repo"), None))
+            .expect("client builds")
+            .with_api_base(base)
+    }
+
+    /// Against `4e951393b` (this PR's original head) this passes when it
+    /// should fail: `fetch_issue` mapped every 404 to `Ok(None)`, so a
+    /// private repository the credential can't see — which 404s on EVERY
+    /// request, issue endpoint included — read exactly like "issue #42
+    /// doesn't exist". The visibility probe distinguishes them: the repo
+    /// endpoint 404s too, so this must now be `Err`, not `Ok(None)`.
+    #[tokio::test]
+    async fn a_private_repo_with_no_visible_credential_errors_instead_of_returning_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/private-repo/issues/42"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/private-repo"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let err = client_at(&server.uri())
+            .fetch_issue(42)
+            .await
+            .expect_err("an invisible repo must error, not report 'no such issue'");
+        assert!(
+            matches!(err, CollectError::GithubApi { status: 404, .. }),
+            "{err:?}"
+        );
+    }
+
+    /// The other side of the same 404: the repo IS visible, so a 404 on the
+    /// issue endpoint alone means the issue genuinely does not exist.
+    #[tokio::test]
+    async fn a_genuinely_missing_issue_on_a_visible_repo_returns_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/private-repo/issues/42"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/private-repo"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": 1,
+                "full_name": "acme/private-repo"
+            })))
+            .mount(&server)
+            .await;
+
+        let issue = client_at(&server.uri())
+            .fetch_issue(42)
+            .await
+            .expect("a visible repo's genuinely-missing issue must not error");
+        assert!(issue.is_none(), "{issue:?}");
+    }
+
+    /// The probe is cached per client instance: two issue lookups that both
+    /// 404 must not repeat the repo-visibility request a second time.
+    #[tokio::test]
+    async fn the_repo_visibility_probe_runs_at_most_once_per_client() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/private-repo/issues/42"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/private-repo/issues/43"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/acme/private-repo"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": 1,
+                "full_name": "acme/private-repo"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = client_at(&server.uri());
+        assert!(client
+            .fetch_issue(42)
+            .await
+            .expect("first lookup")
+            .is_none());
+        assert!(client
+            .fetch_issue(43)
+            .await
+            .expect("second lookup")
+            .is_none());
+        // `.expect(1)` on the repo-visibility mock is verified when `server`
+        // drops at the end of this test — a second probe call panics there.
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #5980
- Every registered repo's GitHub issues are now collected into the sweep's ticketing correlation automatically — no separate board registration; access via the gh CLI OAuth token through the existing trusty_common::gh entry point; a disabled/unreadable issues API fails the collect stage into a named manifest gap (the same path JIRA uses), never a silent empty section.
- Automatic for every repo, no opt-out; no double-count suppression when a jira/linear board is also registered (documented limitation — needs a repo↔board association that doesn't exist); review-menu counting deferred to #5978.

## Test Plan
Rung 3 — `cargo fmt --check -p trusty-audit`, `cargo clippy -p trusty-audit --all-targets -- -D warnings`, `cargo test -p trusty-audit --lib` (469 passed / 0 failed / 5 ignored, pre-existing network-gated), `scripts/check_line_cap.sh`, `scripts/check_changelog_fragment.sh` all green.

Known gap, named: no e2e test that the gh-derived token reaches the child's TRUSTY_AUDIT_GITHUB_TOKEN env var (would need a PATH-stubbed gh; the 3-line env wiring mirrors the already-tested boards.env() loop and GithubAccess::env() is unit-tested).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools