### PR TITLE
fix(trusty-review): parse every file of a multi-file diff (#4458)

### DIFF
--- a/crates/trusty-review/changelog.d/4458-parse-diff-files-multifile.md
+++ b/crates/trusty-review/changelog.d/4458-parse-diff-files-multifile.md
@@ -1,0 +1,21 @@
+Fixed
+
+- A multi-file diff no longer collapses into a single file. `parse_diff_files`
+  started a file record only on a `diff --git ` line but bound the path on
+  `+++ b/`, so a diff carrying `---`/`+++` pairs without those markers rebound
+  the open record's path on every file and returned ONE record — named after the
+  last file, holding every file's hunks. Stage A then reported `kept=1` and every
+  map-reduce unit inherited the misattribution (#4458). The parser now also
+  starts a record on a `---`/`+++` pair that arrives after the open record
+  already has a path or hunks, and reads hunk bodies against the line budget
+  their `@@` header declares so a diff-of-a-diff's body lines are not mistaken
+  for file headers.
+- Deleted files, binary files, mode-only changes, and pure renames now reach
+  Stage A. Each of those shapes lacks a `+++ b/` line, so the old parser
+  produced no record for it and the file vanished from the review with no error.
+  A record's path now resolves from the first available of `+++ b/`,
+  `rename to`, `--- a/`, and the `diff --git` header itself.
+- Content the parser cannot attribute to any file is reported instead of
+  dropped. `parse_diff_files_detailed` returns those runs as `UnparsedSection`
+  entries alongside the files, and `DiffAnalyzer::analyze` logs their count at
+  warn level and stamps `parsed` and `unparsed_sections` onto the Stage A line.

--- a/crates/trusty-review/src/pipeline/diff_analyzer/diff_parser.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/diff_parser.rs
@@ -1,0 +1,371 @@
+//! Unified-diff parser feeding Stage A (spec REV-200).
+//!
+//! Why: Stage A classifies files, so it needs one record per file in the diff.
+//! The previous parser opened a record only on `diff --git ` and bound the path
+//! on `+++ b/`, without flushing — so a diff carrying `---`/`+++` pairs but no
+//! `diff --git ` markers rebound the open record's path on every file and
+//! returned ONE record holding every file's hunks, named after the last file
+//! (#4458). It also dropped any file whose record never saw a `+++ b/` line:
+//! deletions, binary files, mode-only changes, and pure renames left no record
+//! at all, and the caller saw a smaller list with no signal that anything was
+//! lost.
+//!
+//! What: a line-oriented state machine over the diff. Records start on
+//! `diff --git ` and on a `---`/`+++` header pair that arrives after the open
+//! record already has a path or hunks. Hunk bodies are consumed against the
+//! line budget declared by their `@@` header, so a diff-of-a-diff's body lines
+//! never read as file headers. Every record resolves a path from the first
+//! available of `+++ b/`, `rename to`, `--- a/`, and the `diff --git` header
+//! itself; a record that resolves none is reported as an `UnparsedSection`
+//! rather than discarded.
+//!
+//! Test: `diff_parser_tests.rs` — see `multi_file_diff_without_git_markers`.
+
+// ─── Public result types ──────────────────────────────────────────────────────
+
+/// A run of diff lines that carried content but no resolvable path.
+///
+/// Why: a parse failure that shrinks the file list silently is how #4458 stayed
+/// invisible in production — callers saw `kept=1` and nothing else. Reporting
+/// the section gives the caller an explicit count to log or reject on.
+/// What: the section's first line (truncated) and how many lines it held.
+/// Test: `headerless_hunks_are_reported_unparsed`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UnparsedSection {
+    /// First line of the section, truncated to `HEADER_SAMPLE_LIMIT` characters.
+    pub header: String,
+    /// Number of lines the section held.
+    pub line_count: usize,
+}
+
+/// Parsed diff: one entry per file, plus anything that resolved to no file.
+///
+/// Why: `parse_diff_files` keeps its `Vec<(path, status, patch)>` shape for
+/// existing callers; this type carries the loss signal alongside it.
+/// What: `files` are `(path, status, patch)` triples in diff order; `unparsed`
+/// holds sections that produced no file.
+/// Test: `diff_parser_tests.rs`.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct ParsedDiff {
+    /// One `(path, status, patch)` triple per file, in diff order.
+    pub files: Vec<(String, String, String)>,
+    /// Sections that carried content but resolved to no path.
+    pub unparsed: Vec<UnparsedSection>,
+}
+
+/// Longest `UnparsedSection::header` sample retained, in characters.
+const HEADER_SAMPLE_LIMIT: usize = 120;
+
+// ─── Entry points ─────────────────────────────────────────────────────────────
+
+/// Parse a unified diff into `(path, status, patch)` triples.
+///
+/// Why: Stage A needs per-file structured data; the raw diff is a flat string.
+/// What: thin wrapper over [`parse_diff_files_detailed`] that discards the
+/// unparsed-section report. Prefer the detailed form where the loss matters.
+/// Test: `parse_diff_files_basic`, `parse_diff_files_new_file`.
+pub fn parse_diff_files(diff: &str) -> Vec<(String, String, String)> {
+    parse_diff_files_detailed(diff).files
+}
+
+/// Parse a unified diff, reporting sections that resolved to no file.
+///
+/// Why: a diff with N files must yield N entries, and any content the parser
+/// cannot attribute must surface as a count rather than shrink the result
+/// (#4458).
+/// What: runs the state machine described in the module doc and returns both
+/// halves of the outcome.
+/// Test: `multi_file_diff_without_git_markers`, `each_file_shape_yields_one_entry`,
+/// `concatenated_diff_yields_one_entry_per_file`, `headerless_hunks_are_reported_unparsed`.
+pub fn parse_diff_files_detailed(diff: &str) -> ParsedDiff {
+    let lines: Vec<&str> = diff.lines().collect();
+    let mut out = ParsedDiff::default();
+    let mut cur: Option<Section> = None;
+    // Remaining old-side / new-side lines declared by the open `@@` header.
+    let mut old_rem = 0usize;
+    let mut new_rem = 0usize;
+    let mut i = 0usize;
+
+    while i < lines.len() {
+        let line = lines[i];
+        let in_hunk_body = old_rem > 0 || new_rem > 0;
+
+        // `diff --git` always starts a file. A well-formed hunk body never
+        // carries one unprefixed, so this stays unconditional.
+        if let Some(rest) = line.strip_prefix("diff --git ") {
+            flush(cur.take(), &mut out);
+            let mut section = Section::new(line);
+            let (old, new) = split_git_header_paths(rest);
+            section.header_old = old;
+            section.header_new = new;
+            cur = Some(section);
+            old_rem = 0;
+            new_rem = 0;
+            i += 1;
+            continue;
+        }
+
+        // A `---`/`+++` pair outside a hunk body is a file header. Requiring
+        // both halves keeps a deleted line spelled `-- x` (rendered `--- x`)
+        // from reading as one.
+        if !in_hunk_body
+            && line.starts_with("--- ")
+            && lines.get(i + 1).is_some_and(|n| n.starts_with("+++ "))
+        {
+            // #4458: the open record already has a path or hunks, so this pair
+            // opens the NEXT file of a diff that carries no `diff --git`
+            // markers. Without this flush every such pair rebound the same
+            // record and the whole diff collapsed into one file.
+            if cur.as_ref().is_some_and(Section::has_content) {
+                flush(cur.take(), &mut out);
+            }
+            let section = cur.get_or_insert_with(|| Section::new(line));
+            section.apply_from_header(line);
+            section.apply_to_header(lines[i + 1]);
+            i += 2;
+            continue;
+        }
+
+        if !in_hunk_body && let Some((old, new)) = parse_hunk_counts(line) {
+            old_rem = old;
+            new_rem = new;
+            let section = cur.get_or_insert_with(|| Section::new(line));
+            section.saw_hunk = true;
+            section.push(line);
+            i += 1;
+            continue;
+        }
+
+        let section = cur.get_or_insert_with(|| Section::new(line));
+        if in_hunk_body {
+            match line.as_bytes().first() {
+                Some(b'-') => old_rem = old_rem.saturating_sub(1),
+                Some(b'+') => new_rem = new_rem.saturating_sub(1),
+                // `\ No newline at end of file` belongs to neither side.
+                Some(b'\\') => {}
+                _ => {
+                    old_rem = old_rem.saturating_sub(1);
+                    new_rem = new_rem.saturating_sub(1);
+                }
+            }
+            section.push(line);
+        } else if !section.apply_extended_header(line) {
+            section.push(line);
+        }
+        i += 1;
+    }
+
+    flush(cur.take(), &mut out);
+    out
+}
+
+// ─── Section state ────────────────────────────────────────────────────────────
+
+/// One file's accumulated state while the parser walks its lines.
+#[derive(Default)]
+struct Section {
+    /// Old path from the `diff --git` header, used when no other path exists.
+    header_old: Option<String>,
+    /// New path from the `diff --git` header, used when no other path exists.
+    header_new: Option<String>,
+    /// Path from `--- a/…`; the only source for a deleted file.
+    from_path: Option<String>,
+    /// Path from `+++ b/…`; the preferred source.
+    to_path: Option<String>,
+    /// Path from `rename to …` / `copy to …`.
+    moved_to: Option<String>,
+    /// Status stated outright by a mode or rename line.
+    explicit_status: Option<&'static str>,
+    /// Status implied by a `/dev/null` side.
+    inferred_status: Option<&'static str>,
+    patch: String,
+    saw_hunk: bool,
+    line_count: usize,
+    has_non_blank: bool,
+    first_line: String,
+}
+
+impl Section {
+    fn new(first_line: &str) -> Self {
+        Self {
+            first_line: first_line.chars().take(HEADER_SAMPLE_LIMIT).collect(),
+            ..Self::default()
+        }
+    }
+
+    fn push(&mut self, line: &str) {
+        self.patch.push_str(line);
+        self.patch.push('\n');
+        self.line_count += 1;
+        if !line.trim().is_empty() {
+            self.has_non_blank = true;
+        }
+    }
+
+    /// Has this section already claimed a file? Used to decide whether an
+    /// incoming `---`/`+++` pair belongs to it or opens the next file.
+    fn has_content(&self) -> bool {
+        self.saw_hunk || self.from_path.is_some() || self.to_path.is_some()
+    }
+
+    fn apply_from_header(&mut self, line: &str) {
+        if line.starts_with("--- /dev/null") {
+            self.inferred_status.get_or_insert("added");
+        } else if let Some(path) = header_path(line) {
+            self.from_path = Some(path);
+        }
+    }
+
+    fn apply_to_header(&mut self, line: &str) {
+        if line.starts_with("+++ /dev/null") {
+            self.inferred_status.get_or_insert("removed");
+        } else if let Some(path) = header_path(line) {
+            self.to_path = Some(path);
+        }
+    }
+
+    /// Consume a git extended-header line. Returns `true` when the line was a
+    /// header (and so must not land in the patch body).
+    fn apply_extended_header(&mut self, line: &str) -> bool {
+        if line.starts_with("new file mode ") {
+            self.explicit_status = Some("added");
+        } else if line.starts_with("deleted file mode ") {
+            self.explicit_status = Some("removed");
+        } else if let Some(rest) = line.strip_prefix("rename to ") {
+            self.explicit_status = Some("renamed");
+            self.moved_to = plain_path(rest);
+        } else if let Some(rest) = line.strip_prefix("copy to ") {
+            self.explicit_status.get_or_insert("added");
+            self.moved_to = plain_path(rest);
+        } else if line.starts_with("rename from ") {
+            self.explicit_status = Some("renamed");
+        } else if !(line.starts_with("index ")
+            || line.starts_with("old mode ")
+            || line.starts_with("new mode ")
+            || line.starts_with("similarity index ")
+            || line.starts_with("dissimilarity index ")
+            || line.starts_with("copy from "))
+        {
+            return false;
+        }
+        self.line_count += 1;
+        true
+    }
+
+    fn resolve_path(&self) -> Option<String> {
+        self.to_path
+            .clone()
+            .or_else(|| self.moved_to.clone())
+            .or_else(|| self.from_path.clone())
+            .or_else(|| self.header_new.clone())
+            .or_else(|| self.header_old.clone())
+    }
+
+    fn status(&self) -> &'static str {
+        self.explicit_status
+            .or(self.inferred_status)
+            .unwrap_or("modified")
+    }
+}
+
+/// Emit a finished section as either a file or an unparsed-section report.
+fn flush(section: Option<Section>, out: &mut ParsedDiff) {
+    let Some(section) = section else { return };
+    if let Some(path) = section.resolve_path() {
+        out.files
+            .push((path, section.status().to_string(), section.patch));
+    } else if section.has_non_blank {
+        // #4458: never shrink the result silently — a section we could not name
+        // is reported so the caller can log or reject on the count.
+        out.unparsed.push(UnparsedSection {
+            header: section.first_line,
+            line_count: section.line_count,
+        });
+    }
+}
+
+// ─── Line helpers ─────────────────────────────────────────────────────────────
+
+/// Read the old/new line budgets out of an `@@ -a,b +c,d @@` hunk header.
+fn parse_hunk_counts(line: &str) -> Option<(usize, usize)> {
+    let rest = line.strip_prefix("@@ ")?;
+    let end = rest.find(" @@")?;
+    let mut parts = rest[..end].split_whitespace();
+    let old = parts.next()?.strip_prefix('-')?;
+    let new = parts.next()?.strip_prefix('+')?;
+    Some((range_len(old), range_len(new)))
+}
+
+/// `start,count` → `count`; a bare `start` means one line.
+fn range_len(spec: &str) -> usize {
+    match spec.split_once(',') {
+        Some((_, count)) => count.parse().unwrap_or(1),
+        None => 1,
+    }
+}
+
+/// Path from a `--- a/path` or `+++ b/path` header, ignoring a trailing
+/// TAB-separated timestamp.
+fn header_path(line: &str) -> Option<String> {
+    let rest = line.get(4..)?;
+    let rest = rest.split('\t').next().unwrap_or(rest);
+    strip_src_prefix(rest)
+}
+
+/// Drop a leading `a/` or `b/` and reject the empty and `/dev/null` cases.
+///
+/// Only for the header forms that carry that prefix — `--- a/x`, `+++ b/x`, and
+/// the `diff --git` header. `rename to` / `copy to` name the path directly, so
+/// they use [`plain_path`]; stripping there would rewrite a real `b/` directory.
+fn strip_src_prefix(path: &str) -> Option<String> {
+    let path = path.trim();
+    let path = path
+        .strip_prefix("a/")
+        .or_else(|| path.strip_prefix("b/"))
+        .unwrap_or(path);
+    plain_path(path)
+}
+
+/// Trim a path and reject the empty and `/dev/null` cases.
+fn plain_path(path: &str) -> Option<String> {
+    let path = path.trim();
+    (!path.is_empty() && path != "/dev/null").then(|| path.to_string())
+}
+
+/// Split `a/<old> b/<new>` out of a `diff --git` header.
+///
+/// Git quotes paths containing spaces or control characters, which makes the
+/// split ambiguous; those headers return `(None, None)` and the record falls
+/// back to its `---`/`+++` pair, which git quotes the same way but which is
+/// only missing for binary and mode-only files.
+fn split_git_header_paths(rest: &str) -> (Option<String>, Option<String>) {
+    let rest = rest.trim();
+    if rest.starts_with('"') || rest.contains(" \"") {
+        return (None, None);
+    }
+    let mut fallback = None;
+    let mut start = 0usize;
+    while let Some(offset) = rest[start..].find(" b/") {
+        let mid = start + offset;
+        let old = strip_src_prefix(&rest[..mid]);
+        let new = strip_src_prefix(&rest[mid + 1..]);
+        // A non-rename header has the same path on both sides; prefer the split
+        // that produces one, so a path containing " b/" does not mis-split.
+        if old.is_some() && old == new {
+            return (old, new);
+        }
+        if fallback.is_none() {
+            fallback = Some((old, new));
+        }
+        start = mid + 3;
+    }
+    fallback.unwrap_or((None, None))
+}
+
+// ─── Unit tests (extracted to keep this file under the 500-SLOC cap) ──────────
+
+#[cfg(test)]
+#[path = "diff_parser_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/pipeline/diff_analyzer/diff_parser_tests.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/diff_parser_tests.rs
@@ -1,0 +1,391 @@
+//! Unit tests for the unified-diff parser (#4458).
+//!
+//! The table `FILE_CASES` holds one fragment per diff shape git can emit. Each
+//! fragment is parsed alone, and then all of them are concatenated into one
+//! diff — that concatenated case is the acceptance criterion: N files in, N
+//! entries out, each with its own path, status, and content.
+
+use super::*;
+
+/// One diff shape, with the single entry it must produce.
+struct FileCase {
+    /// Test-failure label.
+    name: &'static str,
+    /// A complete per-file diff fragment, including its `diff --git` line.
+    fragment: &'static str,
+    /// Path the entry must carry.
+    path: &'static str,
+    /// Status the entry must carry.
+    status: &'static str,
+    /// A substring that must appear in this entry's patch, if it has content.
+    content: Option<&'static str>,
+}
+
+const FILE_CASES: &[FileCase] = &[
+    FileCase {
+        name: "modified",
+        fragment: "diff --git a/src/auth.rs b/src/auth.rs\n\
+                   index 1111111..2222222 100644\n\
+                   --- a/src/auth.rs\n\
+                   +++ b/src/auth.rs\n\
+                   @@ -1,2 +1,2 @@\n\
+                   -fn authenticate() {}\n\
+                   +fn authenticate(cfg: &Config) {}\n\
+                    // trailing context\n",
+        path: "src/auth.rs",
+        status: "modified",
+        content: Some("fn authenticate(cfg: &Config) {}"),
+    },
+    FileCase {
+        name: "added",
+        fragment: "diff --git a/src/new_module.rs b/src/new_module.rs\n\
+                   new file mode 100644\n\
+                   index 0000000..3333333\n\
+                   --- /dev/null\n\
+                   +++ b/src/new_module.rs\n\
+                   @@ -0,0 +1,1 @@\n\
+                   +pub fn fresh() {}\n",
+        path: "src/new_module.rs",
+        status: "added",
+        content: Some("pub fn fresh() {}"),
+    },
+    FileCase {
+        name: "deleted",
+        fragment: "diff --git a/src/gone.rs b/src/gone.rs\n\
+                   deleted file mode 100644\n\
+                   index 4444444..0000000\n\
+                   --- a/src/gone.rs\n\
+                   +++ /dev/null\n\
+                   @@ -1,1 +0,0 @@\n\
+                   -fn gone() {}\n",
+        path: "src/gone.rs",
+        status: "removed",
+        content: Some("fn gone() {}"),
+    },
+    FileCase {
+        name: "renamed with content",
+        fragment: "diff --git a/src/old_edit.rs b/src/new_edit.rs\n\
+                   similarity index 82%\n\
+                   rename from src/old_edit.rs\n\
+                   rename to src/new_edit.rs\n\
+                   index 5555555..6666666 100644\n\
+                   --- a/src/old_edit.rs\n\
+                   +++ b/src/new_edit.rs\n\
+                   @@ -1,1 +1,1 @@\n\
+                   -const N: u8 = 1;\n\
+                   +const N: u8 = 2;\n",
+        path: "src/new_edit.rs",
+        status: "renamed",
+        content: Some("const N: u8 = 2;"),
+    },
+    FileCase {
+        name: "pure rename, no content change",
+        fragment: "diff --git a/src/old_pure.rs b/src/new_pure.rs\n\
+                   similarity index 100%\n\
+                   rename from src/old_pure.rs\n\
+                   rename to src/new_pure.rs\n",
+        path: "src/new_pure.rs",
+        status: "renamed",
+        content: None,
+    },
+    FileCase {
+        name: "mode-only change",
+        fragment: "diff --git a/scripts/run.sh b/scripts/run.sh\n\
+                   old mode 100644\n\
+                   new mode 100755\n",
+        path: "scripts/run.sh",
+        status: "modified",
+        content: None,
+    },
+    FileCase {
+        name: "binary file",
+        fragment: "diff --git a/assets/logo.png b/assets/logo.png\n\
+                   index 7777777..8888888 100644\n\
+                   Binary files a/assets/logo.png and b/assets/logo.png differ\n",
+        path: "assets/logo.png",
+        status: "modified",
+        content: Some("Binary files"),
+    },
+    FileCase {
+        name: "new binary file",
+        fragment: "diff --git a/assets/added.png b/assets/added.png\n\
+                   new file mode 100644\n\
+                   index 0000000..9999999\n\
+                   Binary files /dev/null and b/assets/added.png differ\n",
+        path: "assets/added.png",
+        status: "added",
+        content: Some("Binary files"),
+    },
+    FileCase {
+        // A patch fixture whose own hunk body contains lines beginning `--- `
+        // and `+++ `: `-- a/embedded.rs` removed, `++ b/embedded.rs` added.
+        name: "diff of a diff",
+        fragment: "diff --git a/testdata/sample.patch b/testdata/sample.patch\n\
+                   index aaaaaaa..bbbbbbb 100644\n\
+                   --- a/testdata/sample.patch\n\
+                   +++ b/testdata/sample.patch\n\
+                   @@ -1,1 +1,1 @@\n\
+                   --- a/embedded.rs\n\
+                   +++ b/replacement.rs\n",
+        path: "testdata/sample.patch",
+        status: "modified",
+        content: Some("a/embedded.rs"),
+    },
+];
+
+/// Each shape on its own must produce exactly one entry with the right path,
+/// status, and content.
+#[test]
+fn each_file_shape_yields_one_entry() {
+    for case in FILE_CASES {
+        let parsed = parse_diff_files_detailed(case.fragment);
+        assert_eq!(
+            parsed.files.len(),
+            1,
+            "{}: expected 1 file, got {:?}",
+            case.name,
+            parsed.files.iter().map(|f| &f.0).collect::<Vec<_>>()
+        );
+        assert_eq!(parsed.files[0].0, case.path, "{}: path", case.name);
+        assert_eq!(parsed.files[0].1, case.status, "{}: status", case.name);
+        assert!(
+            parsed.unparsed.is_empty(),
+            "{}: nothing should be unparsed, got {:?}",
+            case.name,
+            parsed.unparsed
+        );
+        if let Some(needle) = case.content {
+            assert!(
+                parsed.files[0].2.contains(needle),
+                "{}: patch missing {needle:?}, got {:?}",
+                case.name,
+                parsed.files[0].2
+            );
+        }
+    }
+}
+
+/// #4458 acceptance criterion: a diff of N files yields N entries, in order,
+/// with each file's content confined to its own entry.
+#[test]
+fn concatenated_diff_yields_one_entry_per_file() {
+    let diff: String = FILE_CASES.iter().map(|c| c.fragment).collect();
+    let parsed = parse_diff_files_detailed(&diff);
+
+    assert_eq!(
+        parsed.files.len(),
+        FILE_CASES.len(),
+        "expected {} files, got {:?}",
+        FILE_CASES.len(),
+        parsed.files.iter().map(|f| &f.0).collect::<Vec<_>>()
+    );
+    assert!(parsed.unparsed.is_empty(), "{:?}", parsed.unparsed);
+
+    for (case, file) in FILE_CASES.iter().zip(parsed.files.iter()) {
+        assert_eq!(file.0, case.path, "{}: path", case.name);
+        assert_eq!(file.1, case.status, "{}: status", case.name);
+    }
+
+    // Content isolation: the modified file's patch must not have absorbed the
+    // added file's line, which is what the pre-fix parser did on a diff whose
+    // per-file markers it failed to honour.
+    assert!(
+        parsed.files[0]
+            .2
+            .contains("fn authenticate(cfg: &Config) {}")
+    );
+    assert!(!parsed.files[0].2.contains("pub fn fresh() {}"));
+}
+
+/// The #4458 collapse itself: a diff carrying `---`/`+++` pairs but no
+/// `diff --git ` markers.
+///
+/// Pre-fix this returned ONE entry named `src/delta.rs` holding all four
+/// files' hunks, because `+++ b/` rebound the open record's path without ever
+/// flushing it.
+#[test]
+fn multi_file_diff_without_git_markers() {
+    const PATHS: &[&str] = &[
+        "src/alpha.rs",
+        "src/beta.rs",
+        "src/gamma.rs",
+        "src/delta.rs",
+    ];
+
+    let mut diff = String::new();
+    for path in PATHS {
+        let stem = path.trim_start_matches("src/").trim_end_matches(".rs");
+        diff.push_str(&format!("--- a/{path}\n+++ b/{path}\n"));
+        diff.push_str("@@ -1,1 +1,1 @@\n");
+        diff.push_str(&format!("-{stem}_old\n+{stem}_new\n"));
+    }
+
+    let parsed = parse_diff_files_detailed(&diff);
+
+    assert_eq!(
+        parsed.files.len(),
+        PATHS.len(),
+        "multi-file diff collapsed: {:?}",
+        parsed.files.iter().map(|f| &f.0).collect::<Vec<_>>()
+    );
+    assert!(parsed.unparsed.is_empty(), "{:?}", parsed.unparsed);
+
+    for (path, file) in PATHS.iter().zip(parsed.files.iter()) {
+        assert_eq!(&file.0, path);
+        assert_eq!(file.1, "modified");
+    }
+    assert!(parsed.files[0].2.contains("alpha_new"));
+    assert!(
+        !parsed.files[0].2.contains("beta_new"),
+        "alpha's patch absorbed beta's content: {:?}",
+        parsed.files[0].2
+    );
+    assert!(parsed.files[3].2.contains("delta_new"));
+    assert!(!parsed.files[3].2.contains("gamma_new"));
+}
+
+/// A hunk body whose lines begin `--- `/`+++ ` must not open a new file. The
+/// `@@` header's line budget is what tells body from header.
+#[test]
+fn hunk_body_lines_do_not_open_a_new_file() {
+    let diff = "--- a/testdata/one.patch\n\
+                +++ b/testdata/one.patch\n\
+                @@ -1,2 +1,2 @@\n\
+                --- a/inner.rs\n\
+                +++ b/inner.rs\n\
+                --- a/other.rs\n\
+                +++ b/other.rs\n";
+    let parsed = parse_diff_files_detailed(diff);
+    assert_eq!(
+        parsed.files.len(),
+        1,
+        "body lines were read as file headers: {:?}",
+        parsed.files.iter().map(|f| &f.0).collect::<Vec<_>>()
+    );
+    assert_eq!(parsed.files[0].0, "testdata/one.patch");
+}
+
+/// Content the parser cannot attribute is reported, never dropped in silence.
+#[test]
+fn headerless_hunks_are_reported_unparsed() {
+    let diff = "@@ -1,1 +1,1 @@\n-old line\n+new line\n";
+    let parsed = parse_diff_files_detailed(diff);
+    assert!(parsed.files.is_empty());
+    assert_eq!(parsed.unparsed.len(), 1);
+    assert_eq!(parsed.unparsed[0].line_count, 3);
+    assert_eq!(parsed.unparsed[0].header, "@@ -1,1 +1,1 @@");
+}
+
+/// A commit-message preamble ahead of the first file is reported too.
+#[test]
+fn preamble_before_the_first_file_is_reported_unparsed() {
+    let diff = "commit deadbeef\nAuthor: Someone\n\n    subject line\n\n\
+                diff --git a/src/a.rs b/src/a.rs\n\
+                --- a/src/a.rs\n\
+                +++ b/src/a.rs\n\
+                @@ -1,1 +1,1 @@\n\
+                -a\n\
+                +b\n";
+    let parsed = parse_diff_files_detailed(diff);
+    assert_eq!(parsed.files.len(), 1);
+    assert_eq!(parsed.files[0].0, "src/a.rs");
+    assert_eq!(parsed.unparsed.len(), 1);
+    assert_eq!(parsed.unparsed[0].header, "commit deadbeef");
+}
+
+/// Blank input produces neither files nor a spurious unparsed section.
+#[test]
+fn empty_diff_reports_nothing() {
+    for diff in ["", "\n", "   \n\n"] {
+        let parsed = parse_diff_files_detailed(diff);
+        assert!(parsed.files.is_empty(), "{diff:?}");
+        assert!(parsed.unparsed.is_empty(), "{diff:?}");
+    }
+}
+
+/// The compatibility wrapper returns exactly the detailed form's file list.
+#[test]
+fn wrapper_matches_detailed_files() {
+    let diff: String = FILE_CASES.iter().map(|c| c.fragment).collect();
+    assert_eq!(
+        parse_diff_files(&diff),
+        parse_diff_files_detailed(&diff).files
+    );
+}
+
+/// `diff --git` header splitting, including a path that itself contains ` b/`.
+#[test]
+fn git_header_paths_split_on_the_matching_boundary() {
+    let cases: &[(&str, Option<&str>, Option<&str>)] = &[
+        ("a/src/x.rs b/src/x.rs", Some("src/x.rs"), Some("src/x.rs")),
+        ("a/old.rs b/new.rs", Some("old.rs"), Some("new.rs")),
+        (
+            "a/pkg b/mod.rs b/pkg b/mod.rs",
+            Some("pkg b/mod.rs"),
+            Some("pkg b/mod.rs"),
+        ),
+        ("\"a/odd path.rs\" \"b/odd path.rs\"", None, None),
+    ];
+    for (input, old, new) in cases {
+        let got = split_git_header_paths(input);
+        assert_eq!(
+            (got.0.as_deref(), got.1.as_deref()),
+            (*old, *new),
+            "input {input:?}"
+        );
+    }
+}
+
+/// Hunk-header line budgets, including the bare `@@ -1 +1 @@` form.
+#[test]
+fn hunk_counts_parse() {
+    let cases: &[(&str, Option<(usize, usize)>)] = &[
+        ("@@ -1,3 +1,5 @@", Some((3, 5))),
+        ("@@ -0,0 +1,2 @@ fn ctx()", Some((0, 2))),
+        ("@@ -1 +1 @@", Some((1, 1))),
+        ("@@@ -1,1 -1,1 +1,1 @@@", None),
+        ("not a hunk header", None),
+    ];
+    for (input, want) in cases {
+        assert_eq!(parse_hunk_counts(input), *want, "input {input:?}");
+    }
+}
+
+// ─── Tests carried over from the pre-#4458 parser ────────────────────────────
+
+const SAMPLE_DIFF: &str = r#"diff --git a/Cargo.lock b/Cargo.lock
+index abc..def 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1,3 +1,3 @@
+-serde = "1.0.100"
++serde = "1.0.200"
+diff --git a/src/auth.rs b/src/auth.rs
+index abc..def 100644
+--- a/src/auth.rs
++++ b/src/auth.rs
+@@ -1,3 +1,5 @@
+-pub fn authenticate(user: &str) -> Result<Token, Error> {
++pub fn authenticate(user: &str, config: &Config) -> Result<Token, Error> {
++    validate(user)?;
+     Ok(Token::new(user))
+ }
+"#;
+
+#[test]
+fn parse_diff_files_basic() {
+    let files = parse_diff_files(SAMPLE_DIFF);
+    assert_eq!(files.len(), 2);
+    let paths: Vec<&str> = files.iter().map(|(p, _, _)| p.as_str()).collect();
+    assert!(paths.contains(&"Cargo.lock"));
+    assert!(paths.contains(&"src/auth.rs"));
+}
+
+#[test]
+fn parse_diff_files_new_file() {
+    let diff = "diff --git a/new.rs b/new.rs\nnew file mode 100644\n--- /dev/null\n+++ b/new.rs\n@@ -0,0 +1 @@\n+fn new() {}\n";
+    let files = parse_diff_files(diff);
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].0, "new.rs");
+    assert_eq!(files[0].1, "added");
+}

--- a/crates/trusty-review/src/pipeline/diff_analyzer/mod.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/mod.rs
@@ -18,11 +18,13 @@
 //!
 //! Test: `diff_analyzer_stages_a_b_integration`, `diff_analyzer_drops_lockfile`.
 
+pub mod diff_parser;
 pub mod file_filter;
 pub mod hunk_classifier;
 pub mod hunk_filter;
 pub mod models;
 
+pub use diff_parser::{ParsedDiff, UnparsedSection, parse_diff_files, parse_diff_files_detailed};
 pub use file_filter::{FileFilter, FilterConfig};
 pub use hunk_classifier::HunkClassifier;
 pub use hunk_filter::HunkFilter;
@@ -30,7 +32,7 @@ pub use models::{DroppedFile, FilteredDiff, FilteredFile, FilteredHunk};
 
 use std::sync::Arc;
 
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::llm::LlmProvider;
 
@@ -85,15 +87,32 @@ impl DiffAnalyzer {
         let original_byte_size = raw_diff.len();
 
         // Parse the raw diff into (path, status, patch) triples.
-        let parsed = parse_diff_files(raw_diff);
+        let ParsedDiff {
+            files: parsed,
+            unparsed,
+        } = parse_diff_files_detailed(raw_diff);
         debug!(file_count = parsed.len(), "parsed diff into files");
+        // #4458: content the parser could not attribute to a file is reported
+        // rather than dropped in silence — a shrinking file list is how the
+        // collapse stayed invisible in production.
+        if !unparsed.is_empty() {
+            let unparsed_lines: usize = unparsed.iter().map(|s| s.line_count).sum();
+            warn!(
+                unparsed_sections = unparsed.len(),
+                unparsed_lines,
+                first = %unparsed[0].header,
+                "diff content could not be attributed to a file"
+            );
+        }
 
         // Stage A: file-level filter.
         let file_filter = FileFilter::new(self.config.clone());
         let (mut kept_files, dropped_files) = file_filter.apply(&parsed);
         info!(
+            parsed = parsed.len(),
             kept = kept_files.len(),
             dropped = dropped_files.len(),
+            unparsed_sections = unparsed.len(),
             "Stage A complete"
         );
 
@@ -161,54 +180,6 @@ impl DiffAnalyzer {
             filtered_byte_size,
         }
     }
-}
-
-// ─── Diff parser ──────────────────────────────────────────────────────────────
-
-/// Parse a unified diff string into `(path, status, patch)` triples.
-///
-/// Why: Stage A needs per-file structured data; the raw diff is a flat string.
-/// What: scans for `diff --git` lines to split files; reads `+++`/`---` headers
-/// for paths; treats the remainder as the patch string.
-/// Test: `parse_diff_files_basic`, `parse_diff_files_new_file`.
-pub fn parse_diff_files(diff: &str) -> Vec<(String, String, String)> {
-    let mut files = Vec::new();
-    let mut current_path: Option<String> = None;
-    let mut current_status = "modified".to_string();
-    let mut current_patch = String::new();
-
-    for line in diff.lines() {
-        if line.starts_with("diff --git ") {
-            // Flush previous file.
-            if let Some(path) = current_path.take() {
-                files.push((path, current_status.clone(), current_patch.clone()));
-                current_patch.clear();
-            }
-            current_status = "modified".to_string();
-        } else if let Some(rest) = line.strip_prefix("+++ b/") {
-            let path = rest.trim().to_string();
-            if path != "/dev/null" && !path.is_empty() {
-                current_path = Some(path);
-            }
-        } else if line.starts_with("+++ /dev/null") {
-            // Deleted file — path already captured from --- line; status = removed.
-            current_status = "removed".to_string();
-        } else if line.starts_with("--- /dev/null") || line.starts_with("new file mode") {
-            current_status = "added".to_string();
-        } else if line.starts_with("deleted file mode") {
-            current_status = "removed".to_string();
-        } else if line.starts_with("rename to ") {
-            current_status = "renamed".to_string();
-        } else if current_path.is_some() {
-            current_patch.push_str(line);
-            current_patch.push('\n');
-        }
-    }
-    // Flush last file.
-    if let Some(path) = current_path {
-        files.push((path, current_status, current_patch));
-    }
-    files
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────
@@ -290,21 +261,43 @@ diff --git a/src/api.rs b/src/api.rs\n\
         );
     }
 
-    #[test]
-    fn parse_diff_files_basic() {
-        let files = parse_diff_files(SAMPLE_DIFF);
-        assert_eq!(files.len(), 2);
-        let paths: Vec<&str> = files.iter().map(|(p, _, _)| p.as_str()).collect();
-        assert!(paths.contains(&"Cargo.lock"));
-        assert!(paths.contains(&"src/auth.rs"));
-    }
+    /// #4458: a diff whose files are separated only by `---`/`+++` pairs must
+    /// reach Stage A as N files, not as one file holding every file's hunks.
+    #[tokio::test]
+    async fn diff_analyzer_keeps_every_file_of_a_marker_less_diff() {
+        let diff = "\
+--- a/package-lock.json\n\
++++ b/package-lock.json\n\
+@@ -1,1 +1,1 @@\n\
+-\"version\": \"1\"\n\
++\"version\": \"2\"\n\
+--- a/src/alpha.rs\n\
++++ b/src/alpha.rs\n\
+@@ -1,1 +1,1 @@\n\
+-fn alpha() {}\n\
++fn alpha(cfg: &Config) {}\n\
+--- a/src/beta.rs\n\
++++ b/src/beta.rs\n\
+@@ -1,1 +1,1 @@\n\
+-fn beta() {}\n\
++fn beta(cfg: &Config) {}\n\
+";
+        let analyzer = DiffAnalyzer::default();
+        let result = analyzer.analyze(diff).await;
 
-    #[test]
-    fn parse_diff_files_new_file() {
-        let diff = "diff --git a/new.rs b/new.rs\nnew file mode 100644\n--- /dev/null\n+++ b/new.rs\n@@ -0,0 +1 @@\n+fn new() {}\n";
-        let files = parse_diff_files(diff);
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].0, "new.rs");
-        assert_eq!(files[0].1, "added");
+        assert_eq!(
+            result.files.len() + result.dropped_files.len(),
+            3,
+            "all three files must reach Stage A; kept={:?} dropped={:?}",
+            result.files.iter().map(|f| &f.filename).collect::<Vec<_>>(),
+            result
+                .dropped_files
+                .iter()
+                .map(|f| &f.path)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(result.dropped_files[0].path, "package-lock.json");
+        let kept: Vec<&str> = result.files.iter().map(|f| f.filename.as_str()).collect();
+        assert_eq!(kept, vec!["src/alpha.rs", "src/beta.rs"]);
     }
 }


### PR DESCRIPTION
Closes #4458.

## Defect

`parse_diff_files` started a file record only on a `diff --git ` line, but bound
the record's path on `+++ b/`. A diff that carries `---`/`+++` pairs without
`diff --git ` markers therefore rebound the SAME record's path on every file and
never flushed it: N files in, one entry out — named after the LAST file, holding
every file's hunks. That is the `kept=1 dropped=0` the issue reports, and every
map-reduce unit downstream inherited the misattribution.

The same gap dropped files outright rather than merging them. A deletion, a
binary file, a mode-only change, and a pure rename all carry no `+++ b/` line, so
each produced no record at all and vanished from the review with no error — the
fail-open shape, a silently smaller result.

Pre-fix behaviour, reproduced by compiling the old function verbatim against the
new fixtures:

```
pre-fix parser returned 1 file(s): ["src/delta.rs"]
pre-fix patch of entry 0:
@@ -1,1 +1,1 @@
-alpha_old
+alpha_new
--- a/src/beta.rs
@@ -1,1 +1,1 @@
-beta_old
+beta_new
--- a/src/gamma.rs
...
assertion `left == right` failed: multi-file diff collapsed: ["src/delta.rs"]
  left: 1
 right: 4

pre-fix parser returned 0 file(s) for a 3-file diff: []
assertion `left == right` failed: files were dropped with no error
  left: 0
 right: 3
```

`multi_file_diff_without_git_markers` is the test that input fails: four files
separated only by `---`/`+++` pairs, which the pre-fix parser returns as one
entry named `src/delta.rs`.

## Mechanism of the fix

The parser moves to `diff_analyzer/diff_parser.rs` as a line-oriented state
machine.

- A `---`/`+++` header pair now STARTS a record when the open record already has
  a path or hunks. That is the flush the collapse was missing.
- Hunk bodies are consumed against the line budget their `@@ -a,b +c,d @@` header
  declares, so a diff-of-a-diff's body lines — a removed `-- a/x` renders as
  `--- a/x` — are not mistaken for a file header.
- A record resolves its path from the first available of `+++ b/`, `rename to`,
  `--- a/`, and the `diff --git a/… b/…` header itself. Deletions, binaries,
  mode-only changes, and pure renames each get an entry.
- Content that still resolves to no path is RETURNED, not discarded. The new
  `parse_diff_files_detailed` reports it as `UnparsedSection` entries;
  `DiffAnalyzer::analyze` logs their count and first line at warn level and adds
  `parsed` / `unparsed_sections` to the Stage A info line. A parse failure is now
  an explicit count, never a smaller result.

`parse_diff_files` keeps its signature and its module path, so no caller changes.

## Test ladder: rung 3

Localized behaviour inside `trusty-review`; `parse_diff_files` has no consumer
outside `diff_analyzer/mod.rs`, so no dependent-crate leg is owed. `cargo check
--workspace` was run anyway and passes, since the crate is a workspace library.

```
cargo fmt --check                                        # exit 0
cargo check -p trusty-review --all-targets               # exit 0
cargo clippy -p trusty-review --all-targets -- -D warnings  # exit 0
cargo test -p trusty-review                              # exit 0
cargo check --workspace                                  # exit 0
bash scripts/check_line_cap.sh                           # 4080 files, 0 violations
bash scripts/check_changelog_fragment.sh                 # OK trusty-review
bash scripts/check_sld.sh                                # 0 errors, 0 warnings
```

`cargo test -p trusty-review` — 1615 passed; 0 failed; 5 ignored (lib), plus
69 + 3 + 3 + 2 + 5 + 2 + 3 + 3 passed across the integration targets, 0 failed
anywhere.

New coverage, all in `diff_parser_tests.rs` unless noted:

- `each_file_shape_yields_one_entry` and
  `concatenated_diff_yields_one_entry_per_file` — table-driven over nine shapes
  (modified, added, deleted, rename with content, pure rename, mode-only, binary,
  new binary, diff-of-a-diff), each alone and all concatenated. The concatenated
  case is the acceptance criterion: nine files in, nine entries out, in order,
  with content confined to its own entry.
- `multi_file_diff_without_git_markers` — the collapse itself.
- `hunk_body_lines_do_not_open_a_new_file` — the hunk-budget guard.
- `headerless_hunks_are_reported_unparsed`,
  `preamble_before_the_first_file_is_reported_unparsed` — the silent-drop half.
- `git_header_paths_split_on_the_matching_boundary`, `hunk_counts_parse`,
  `empty_diff_reports_nothing`, `wrapper_matches_detailed_files`.
- `diff_analyzer_keeps_every_file_of_a_marker_less_diff` (in `mod.rs`) — the same
  input through `DiffAnalyzer::analyze`, asserting all three files reach Stage A.

## Not in scope

#4459 (verifier fails under its own concurrent fan-out) is a separate mechanism —
`buffer_unordered(VERIFY_CONCURRENCY)` in `verify.rs` with no retry or
backpressure. It shares the fail-open family with this bug but no code path.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
