### PR TITLE
fix(trusty-mpm): the agent-worktree reap keeps a tree the harness can still resume into (#5800)

### DIFF
--- a/crates/trusty-mpm/changelog.d/5800-reap-fail-closed.md
+++ b/crates/trusty-mpm/changelog.d/5800-reap-fail-closed.md
@@ -1,0 +1,5 @@
+Fixed
+
+- The agent-worktree reap no longer removes a worktree the harness can still resume an agent into (#5800). A `SubagentStop` reports a turn boundary rather than an agent's exit, so it no longer triggers a reap; a session's end, which does prove its agents are gone, is now the sole trigger.
+- A finished delegation's registered worktree is protected from another agent's reap — a terminal status records that trusty-mpm watched the delegation end, not that the harness released the directory.
+- A worktree whose agent is stamped on two directories is kept rather than guessed at, so an ambiguous ownership claim reclaims neither tree.

--- a/crates/trusty-mpm/src/daemon/services/agent_worktree_reap.rs
+++ b/crates/trusty-mpm/src/daemon/services/agent_worktree_reap.rs
@@ -42,28 +42,43 @@
 //! fallback — a `git worktree remove` this module cannot complete leaves the
 //! tree alone.
 //!
-//! # The record survives a restart (#4311)
+//! # One trigger, because the other one had no proof (#5800)
 //!
-//! `DaemonState::delegations` is a `DashMap` built empty at every boot with no
-//! load path, so a restart used to end the reap permanently for any agent alive
-//! across it — a `SubagentStop` arrives once. Registration now writes an
-//! ownership sentinel into the worktree, and [`rebuild_from_disk`] reads it
-//! back when the registry has nothing, which is the from-disk reconstruction
-//! ADR-0023 point 4 requires of an ownership record.
+//! [`spawn_on_session_end`] is now the only trigger. A `SubagentStop` one was
+//! removed: that event is a TURN boundary, not the agent's exit, and the agent
+//! stays resumable after it. Four reaps on 2026-08-18 removed trees whose agents
+//! the harness still considered resumable — one had finished and pushed its work
+//! to an open PR — and the next `SendMessage` to each failed with "This agent
+//! cannot be resumed: its worktree no longer exists". Two properties made that
+//! reachable, and both were reachable ONLY from the stop trigger:
 //!
-//! # Two triggers, because one was not enough (#4311 follow-up)
+//! - **A terminal delegation status was read as a release.** It is not. It says
+//!   trusty-mpm watched the delegation finish, and says nothing about whether the
+//!   harness still needs the directory to resume the agent.
+//! - **An agent the registry had never heard of was reaped anyway.** The removed
+//!   `rebuild_from_disk` reconstructed ownership from the on-disk sentinel when
+//!   `DaemonState::delegations` — a `DashMap` rebuilt empty at every boot — held
+//!   no record, and proceeded on that reconstruction. That is fail-OPEN on the
+//!   `Unknown` state [ADR-0045](../../../../../docs/adr/0045-distinguish-absent-from-undeterminable-on-destructive-paths.md)
+//!   requires be treated as undeterminable, and it is the inverse of what
+//!   `worktree_reclaim::agent_ownership_blocks` does on the sibling reclaim path.
 //!
-//! [`spawn_on_stop`] was the only caller of [`reap_worktree`], so the reap ran
-//! exactly once per agent and only when a `SubagentStop` actually arrived. Every
-//! other exit route — the harness session exiting or restarting under an
-//! in-flight agent, an interrupt, a `tm hook` POST that lost its 2 s budget —
-//! reached it never, and `prune_orphaned_worktrees` skips a `SentinelOwner::Agent`
-//! tree by design, so nothing else could reclaim it either. [`spawn_on_session_end`]
-//! is the second trigger: a session's end is proof its agents exited, and it
-//! runs the same gates against the same store.
+//! A `SessionEnd` carries the proof a stop does not. A subagent runs inside its
+//! parent Claude Code session's process and cannot outlive it, so the session's
+//! end is Claude Code self-reporting that every agent it dispatched is gone and
+//! unresumable. That is the positive release signal this module now requires, and
+//! it is the one signal available today: the `.trusty-mpm-worktree` sentinel is
+//! not yet authoritative over the harness store (ADR-0055 decision C, unimplemented
+//! — #5997), so nothing on disk can answer "is this tree still resumable" instead.
 //!
-//! Stated gap: an agent interrupted inside a session that keeps running still
-//! reaches neither trigger, and its tree waits for that session to end.
+//! # What that costs, and why it is the right direction
+//!
+//! An agent whose session keeps running holds its tree until that session ends,
+//! and a session killed hard enough to emit no `SessionEnd` holds it until
+//! `tm session prune-worktrees --merged-prs` reclaims it behind
+//! `worktree_reclaim`'s own fail-closed gates. Both are leaks, and a leak is
+//! recoverable. The deletion this replaced was not: it destroyed ~11 minutes of
+//! in-flight build once and broke agent resumption four times in one day.
 //! Test: the `#[cfg(test)]` suite in `agent_worktree_reap_tests.rs`.
 
 use std::path::{Path, PathBuf};
@@ -174,9 +189,11 @@ pub(crate) fn delegation_state_for_agent(
 /// 2. Not a `…/.claude/worktrees/<name>` leaf → refuse
 ///    ([`is_harness_agent_worktree`]).
 /// 3. `in_use` names the path → refuse. The caller supplies every live managed
-///    session's `workspace_path` and every other non-terminal delegation's
-///    registered worktree, so a tree whose owning session is still live, or
-///    that a sibling agent is still writing in, survives.
+///    session's `workspace_path` and every other delegation's registered
+///    worktree — terminal ones included since #5800, because a finished
+///    delegation's tree can still be one the harness needs to resume its agent.
+///    So a tree whose owning session is still live, that a sibling agent is
+///    still writing in, or that another agent may yet be resumed into, survives.
 /// 4. No git registry claims the path → refuse. There is deliberately no
 ///    `remove_dir_all` fallback here: `decommission::remove_session_worktree`
 ///    has one because it is removing a tree trusty-mpm created and can
@@ -329,15 +346,29 @@ fn ownership_unconfirmed(path: &Path, agent_id: &str) -> Option<String> {
 /// What: every managed session's `workspace_path` — deliberately UNFILTERED by
 /// record state, for the reason `prune.rs` gives (a record's state is
 /// bookkeeping, not a liveness signal) — plus the registered worktree of every
-/// non-terminal delegation in EVERY session, excluding `self_agent_id`'s own.
+/// delegation in EVERY session, excluding `self_agent_id`'s own.
 ///
 /// The delegation half was scoped to the stopping agent's own session until
 /// #4311's review. That scoping was wrong for the same reason the record-state
 /// filter above is: a sibling agent dispatched from a different session is
 /// exactly as live, and its worktree is exactly as un-deletable. Sessions are
 /// not an isolation boundary for "is something running in this directory".
+///
+/// # A terminal delegation is not a released tree (#5800)
+///
+/// This dropped every terminal delegation from the set until #5800, which made
+/// `is_terminal()` decide a question it cannot answer. Terminal means trusty-mpm
+/// watched THIS delegation finish. The harness can still hold the same agent's
+/// worktree open for a resume, and on 2026-08-18 it did: an agent that had
+/// finished and pushed to an open PR had its tree removed and became permanently
+/// unreachable. The record-state filter is dropped here for the same reason
+/// `prune.rs` never had one — bookkeeping is not a liveness signal, in either
+/// direction. Excluding `self_agent_id` is what still lets a candidate be
+/// reclaimed; without that exclusion the sweep would find every tree in use and
+/// reclaim none.
 /// Test: `reap_refuses_a_path_a_live_session_holds`,
-/// `reap_spares_a_worktree_another_sessions_agent_still_holds`.
+/// `reap_spares_a_worktree_another_sessions_agent_still_holds`,
+/// `paths_in_use_protects_a_terminal_delegations_worktree`.
 async fn paths_in_use(state: &Arc<DaemonState>, self_agent_id: &str) -> Vec<PathBuf> {
     let mut out: Vec<PathBuf> = state
         .session_manager()
@@ -348,7 +379,7 @@ async fn paths_in_use(state: &Arc<DaemonState>, self_agent_id: &str) -> Vec<Path
         .filter_map(|r| r.workspace_path)
         .collect();
     for d in state.all_delegations() {
-        if d.status.is_terminal() || d.agent_id.as_deref() == Some(self_agent_id) {
+        if d.agent_id.as_deref() == Some(self_agent_id) {
             continue;
         }
         if let Some(p) = d.worktree_path {
@@ -375,108 +406,21 @@ fn store_for(payload: &Value) -> Option<PathBuf> {
     Some(root.join(".claude").join("worktrees"))
 }
 
-/// Recover an agent's worktree path from on-disk sentinels alone (#4311).
-///
-/// Why: the delegation map is a `DashMap` built empty at every daemon boot with
-/// no load path, so a restart drops every registration and, before this, ended
-/// the reap for every agent alive across it — permanently, since a `SubagentStop`
-/// arrives once. ADR-0023 point 4 requires the ownership record to be
-/// rebuildable from on-disk sentinels plus git and nothing else; this is that
-/// rebuild, applied to the one record the stop needs.
-/// What: resolves the harness worktree store from the stopping payload's `cwd`
-/// — [`harness_root_for`](crate::core::harness_root::harness_root_for) maps any
-/// checkout back to the one that owns the project's state, and ADR-0036 puts
-/// every worktree flat under `<that>/.claude/worktrees/` — then asks
-/// [`find_agent_worktree`] for the directory whose sentinel names this exact
-/// `agent_id`.
-///
-/// Returns `None` for a payload with no `cwd`, a `cwd` outside any repository,
-/// or a store holding no sentinel for this agent. Every one of those ends the
-/// reap, which is the pre-#4311 behaviour and keeps the directory.
-/// Test: `stop_reaps_a_worktree_the_registry_lost_to_a_restart`,
-/// `stop_ignores_a_sentinel_naming_a_different_agent`.
-fn rebuild_from_disk(payload: &Value, agent_id: &str) -> Option<PathBuf> {
-    let found = find_agent_worktree(&store_for(payload)?, agent_id)?;
-    tracing::info!(
-        agent_id,
-        worktree = %found.display(),
-        "agent-worktree reap: the delegation registry did not know this agent — its \
-         ownership sentinel did, so the reap proceeds against the rebuilt record (#4311)"
-    );
-    Some(found)
-}
-
-/// Reap the worktree of the agent a `SubagentStop` just ended (#4311).
-///
-/// Why: `SubagentStop` is the authoritative exit signal — it carries an exact
-/// `agent_id`, so closing one of two concurrent agents cannot close the other
-/// (see [`super::delegation_tracker`]'s correlation note). DOC-66 §5 makes the
-/// agent's exit the reap trigger, and this is the only event that reports one.
-/// What: no-ops for every event other than `SubagentStop`/`SubagentStopFailure`,
-/// for a payload with no `agent_id`, and for a delegation carrying no registered
-/// worktree. Otherwise spawns a detached task — the git calls are blocking and
-/// this runs inside the hook's synchronous budget — which clears the record's
-/// `worktree_path` on a removal so nothing reads a path that no longer exists.
-///
-/// A stale delegation is NOT reaped. `Stale` means tracking lost the agent, not
-/// that it exited, and removing the tree of an agent that may still be running
-/// is the one mistake this module must never make. Such a record keeps its
-/// `worktree_path`, which is what makes the tree visible to `tm doctor` and the
-/// reconcile report instead of invisible as it is today. Stated gap.
-/// # The returned handle
-///
-/// `None` means no reap was even attempted — the event was not a stop, the
-/// payload named no agent, or neither the registry nor the disk knew a worktree
-/// for it. `Some` is the detached task, and awaiting it yields the one
-/// [`ReapOutcome`]. Production callers ignore it; a test awaits it, which is
-/// what lets a negative assertion run AFTER the decision instead of racing a
-/// fixed sleep against it.
-/// Test: `spawn_on_stop_ignores_a_non_stop_event`,
-/// `spawn_on_stop_ignores_a_payload_without_an_agent_id`.
-pub fn spawn_on_stop(
-    state: &Arc<DaemonState>,
-    session: SessionId,
-    event: HookEvent,
-    payload: &Value,
-) -> Option<tokio::task::JoinHandle<ReapOutcome>> {
-    if !matches!(
-        event,
-        HookEvent::SubagentStop | HookEvent::SubagentStopFailure
-    ) {
-        return None;
-    }
-    let agent_id = payload
-        .get("agent_id")
-        .and_then(Value::as_str)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)?;
-    let registered = state
-        .delegations_for(session)
-        .into_iter()
-        .find(|d| d.agent_id.as_deref() == Some(agent_id.as_str()))
-        .and_then(|d| d.worktree_path.clone().map(|p| (Some(d.id), p)));
-    let (id, path) =
-        registered.or_else(|| rebuild_from_disk(payload, &agent_id).map(|p| (None, p)))?;
-
-    let state = Arc::clone(state);
-    Some(tokio::spawn(async move {
-        reap_and_record(&state, &agent_id, path, id).await
-    }))
-}
-
 /// Run the reap for one agent's worktree and record what happened (#4311).
 ///
-/// Why a shared body: [`spawn_on_stop`] and [`spawn_on_session_end`] are two
-/// TRIGGERS for one decision. Two copies of the gate call, the registry
-/// clear and the refusal log would eventually disagree about what a reap does,
-/// and the trigger is the only thing that legitimately differs between them.
+/// Why still its own function with one caller: it is the whole decision minus
+/// the trigger, and #5800 removed a second trigger rather than a second copy of
+/// this body. Keeping the split is what made that removal a deletion of
+/// `spawn_on_stop` alone, with no gate, log line or registry write to
+/// re-derive.
 /// What: resolves this agent's `in_use` set, runs [`reap_worktree`] on a
 /// blocking thread (it shells out to git and `lsof`), clears the delegation's
 /// `worktree_path` on a removal so nothing reads a path that no longer exists,
 /// and reports a refusal.
 ///
-/// `id` is `None` when the path came from disk rather than the registry — there
-/// is no in-memory record to clear.
+/// `id` comes from the candidate's own sentinel, so it names a delegation the
+/// registry may no longer hold; [`DaemonState::mutate_delegation`] no-ops on an
+/// id it does not know.
 ///
 /// The refusal is `warn!` and not `info!` (#4311 follow-up): a refusal is the
 /// ONLY notice anyone gets that a tree was kept, and nothing retries it. On this
@@ -489,7 +433,7 @@ async fn reap_and_record(
     state: &Arc<DaemonState>,
     agent_id: &str,
     path: PathBuf,
-    id: Option<DelegationId>,
+    id: DelegationId,
 ) -> ReapOutcome {
     let in_use = paths_in_use(state, agent_id).await;
     let removal_path = path.clone();
@@ -500,9 +444,7 @@ async fn reap_and_record(
             .unwrap_or_else(|e| ReapOutcome::Refused(format!("reap task panicked: {e}")));
     match &outcome {
         ReapOutcome::Removed | ReapOutcome::AlreadyGone => {
-            if let Some(id) = id {
-                state.mutate_delegation(id, |d| d.worktree_path = None);
-            }
+            state.mutate_delegation(id, |d| d.worktree_path = None);
         }
         ReapOutcome::Refused(reason) => {
             tracing::warn!(
@@ -525,8 +467,21 @@ async fn reap_and_record(
 /// What: reads each immediate child of `store` and keeps those whose sentinel is
 /// [`SentinelOwner::Agent`] with a matching `parent_session_id`. An unreadable
 /// store yields nothing, which reclaims nothing.
+///
+/// # One agent must name one directory (#5800, ADR-0045)
+///
+/// A candidate is also dropped unless [`find_agent_worktree`] resolves its
+/// agent back to this exact directory. That lookup returns `None` when two
+/// directories carry a sentinel naming one agent, which is a state this store is
+/// measurably in: on 2026-08-18, `agent-a23097670a51a0450`'s sentinel recorded
+/// `agent_id: a5ed76bc80fd52e41`, cause undetermined. Nothing deletes a stale
+/// sentinel and registration re-fires on every `PreToolUse`, so an agent that
+/// moved between trees leaves the first one stamped. Which directory such an
+/// agent owns is undeterminable, and an undeterminable owner on a destructive
+/// path keeps every candidate rather than picking one.
 /// Test: `session_end_spares_another_sessions_agent`,
-/// `session_end_reaps_every_agent_of_the_ending_session`.
+/// `session_end_reaps_every_agent_of_the_ending_session`,
+/// `session_end_keeps_a_worktree_whose_agent_names_two_directories`.
 fn agent_worktrees_of(store: &Path, session: SessionId) -> Vec<(PathBuf, AgentWorktreeOwner)> {
     let Ok(entries) = std::fs::read_dir(store) else {
         return Vec::new();
@@ -542,30 +497,44 @@ fn agent_worktrees_of(store: &Path, session: SessionId) -> Vec<(PathBuf, AgentWo
                 _ => None,
             }
         })
+        .filter(|(path, owner)| {
+            if find_agent_worktree(store, &owner.agent_id).as_deref() == Some(path.as_path()) {
+                return true;
+            }
+            tracing::warn!(
+                agent_id = %owner.agent_id,
+                path = %path.display(),
+                "agent-worktree reap: keeping this worktree — its agent's sentinel does not \
+                 resolve to this directory alone, so which tree it owns is undeterminable \
+                 (#5800, ADR-0045)"
+            );
+            false
+        })
         .collect()
 }
 
 /// Reap the worktrees of every agent the session that just ended dispatched
 /// (#4311 follow-up).
 ///
-/// Why: [`spawn_on_stop`] was the reap's ONLY trigger, and it fires only on a
-/// `SubagentStop` the daemon actually receives. An agent that ends any other way
+/// Why: a `SubagentStop` trigger was the reap's only other one, and it fired on
+/// an event that reports a turn boundary rather than an exit — #5800 removed it
+/// for reaping trees the harness still needed. An agent that ends any way at all
 /// — the harness session it runs inside exits or restarts under it, a user
-/// interrupt, a `tm hook` POST that loses its 2 s budget — emits no stop, so the
-/// reap never ran and nothing recorded that it had not. `prune_orphaned_worktrees`
-/// skips `SentinelOwner::Agent` by design, so nothing else would ever reclaim
-/// the tree: the leak was permanent and, for this class, entirely silent. In
-/// this machine's daemon log, 54 registered agent worktrees produced 30
-/// removals; 17 of the 24 survivors carry no reap decision of any kind.
+/// interrupt, a `tm hook` POST that loses its 2 s budget — reaches this trigger
+/// and no other. `prune_orphaned_worktrees` skips `SentinelOwner::Agent` by
+/// design, so without it nothing else would ever reclaim the tree: the leak was
+/// permanent and, for this class, entirely silent. In this machine's daemon log,
+/// 54 registered agent worktrees produced 30 removals; 17 of the 24 survivors
+/// carry no reap decision of any kind.
 ///
 /// A leaked worktree is not only disk. The harness reassigns a stale worktree to
 /// a later agent along with the branch the previous one left checked out, which
 /// is how an unrelated commit reached an open PR's branch on 2026-08-17. That
 /// makes prompt reclamation a correctness property, not housekeeping.
-/// What: on `SessionEnd`, resolves the harness worktree store with [`store_for`]
-/// — the same resolution [`rebuild_from_disk`] uses — then runs the UNCHANGED
-/// [`reap_worktree`] gate stack against every directory whose sentinel names
-/// this session as its parent, and reports the split as a [`SweepSummary`].
+/// What: on `SessionEnd`, resolves the harness worktree store with [`store_for`],
+/// then runs the [`reap_worktree`] gate stack against every directory whose
+/// sentinel names this session as its parent, and reports the split as a
+/// [`SweepSummary`].
 ///
 /// # Why a `SessionEnd` is proof its agents exited
 ///
@@ -618,7 +587,7 @@ pub fn spawn_on_session_end(
             // own delegation. These agents never reported a stop, so their
             // records are still live and a set computed once would name every
             // candidate as in use — the sweep would then reclaim nothing.
-            match reap_and_record(&state, &owner.agent_id, path, Some(owner.delegation_id)).await {
+            match reap_and_record(&state, &owner.agent_id, path, owner.delegation_id).await {
                 ReapOutcome::Removed => summary.removed += 1,
                 ReapOutcome::AlreadyGone => summary.already_gone += 1,
                 ReapOutcome::Refused(_) => summary.kept += 1,

--- a/crates/trusty-mpm/src/daemon/services/agent_worktree_reap.rs
+++ b/crates/trusty-mpm/src/daemon/services/agent_worktree_reap.rs
@@ -478,7 +478,10 @@ async fn reap_and_record(
 /// sentinel and registration re-fires on every `PreToolUse`, so an agent that
 /// moved between trees leaves the first one stamped. Which directory such an
 /// agent owns is undeterminable, and an undeterminable owner on a destructive
-/// path keeps every candidate rather than picking one.
+/// path keeps every candidate rather than picking one. This is not a
+/// permanent leak: an ambiguous pair stays reclaimable via `tm session
+/// prune-worktrees --merged-prs`, whose sweep (`worktree_reclaim`) does not
+/// consult this guard.
 /// Test: `session_end_spares_another_sessions_agent`,
 /// `session_end_reaps_every_agent_of_the_ending_session`,
 /// `session_end_keeps_a_worktree_whose_agent_names_two_directories`.

--- a/crates/trusty-mpm/src/daemon/services/agent_worktree_reap_tests.rs
+++ b/crates/trusty-mpm/src/daemon/services/agent_worktree_reap_tests.rs
@@ -325,49 +325,86 @@ async fn delegation_state_reports_live_ended_and_unknown() {
     );
 }
 
-/// `spawn_on_stop` is a no-op for anything that is not an agent exit.
+/// #5800 REGRESSION: a `SubagentStop` reaps nothing, because a turn boundary is
+/// not an exit.
 ///
-/// Why: it runs on the hook pipeline's hot path, in front of every event in
-/// every managed session, so an event that is not a stop must return before it
-/// reaches the delegation lookup at all.
+/// Why: this is the defect verbatim. On 2026-08-18 an agent that had finished
+/// and pushed its work to open PR #5990 had its worktree removed on its stop,
+/// and the next `SendMessage` to it failed with "This agent cannot be resumed:
+/// its worktree no longer exists". A `SubagentStop` reports that the agent's
+/// TURN ended; the harness can still resume it afterwards, so nothing in that
+/// event releases the tree.
+///
+/// The control is what gives this test its teeth. The fixture is a clean,
+/// fully-pushed, correctly-attributed tree — it passes every surviving gate —
+/// so its survival could otherwise be an artifact of some unrelated refusal.
+/// Delivering the `SessionEnd` afterwards proves the same tree IS reapable
+/// through the trigger that carries release evidence; only the stop declined.
+/// Against the pre-fix commit the first `await_gone`-shaped wait is unnecessary:
+/// `spawn_on_stop` removes the directory and the `wt.exists()` assertion below
+/// fails.
 #[tokio::test]
-async fn spawn_on_stop_ignores_a_non_stop_event() {
+async fn subagent_stop_does_not_reap_a_resumable_worktree() {
     let (state, _dir, session) = hermetic();
-    let started = super::spawn_on_stop(
+    let fx = GitWorktreeFixture::new();
+    let wt = harness_worktree_under(&fx, "agent-resumable", "a5800", session);
+    std::fs::write(wt.join("work.txt"), "finished and pushed\n").expect("write work");
+    GitWorktreeFixture::commit_all_and_push(&wt, "agent work");
+
+    for event in [HookEvent::SubagentStop, HookEvent::SubagentStopFailure] {
+        deliver(
+            &state,
+            session,
+            event,
+            serde_json::json!({ "agent_id": "a5800", "cwd": fx.repo.to_string_lossy() }),
+        );
+    }
+    // A removal takes 1-3 s (git subprocesses plus a system-wide `lsof`), so a
+    // same-instant assertion would pass against an implementation that reaps.
+    // Give a reap every chance to land before asserting it did not happen.
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    assert!(
+        wt.exists(),
+        "a stop is a turn boundary — the agent stays resumable and its tree must survive"
+    );
+
+    // The control: the same tree, through the trigger that does carry proof.
+    deliver(
         &state,
         session,
-        HookEvent::PreToolUse,
-        &serde_json::json!({ "agent_id": "a1", "cwd": "/nowhere" }),
+        HookEvent::SessionEnd,
+        serde_json::json!({ "cwd": fx.repo.to_string_lossy() }),
     );
-    assert!(started.is_none(), "a non-stop event must start no reap");
-    assert!(state.delegations_for(session).is_empty());
+    await_gone(&wt).await;
 }
 
-/// A stop with no `agent_id` reaps nothing.
+/// #5800 REGRESSION: a terminal delegation's worktree is still protected.
 ///
-/// Why: `agent_id` is the only exact correlation key a stop carries, and
-/// `delegation_tracker`'s own note forbids a "most recent" guess — under
-/// concurrency it closes the wrong agent. Reaping on such a guess would delete
-/// the wrong directory, so the absence of the key must end the path.
+/// Why: `paths_in_use` dropped every terminal delegation from the protection set
+/// until #5800, letting `is_terminal()` decide a question it cannot answer.
+/// Terminal means trusty-mpm watched THAT delegation finish; the harness can
+/// still hold the same tree open to resume the agent. Against the pre-fix body
+/// this path is absent from the set and the assertion fails.
 #[tokio::test]
-async fn spawn_on_stop_ignores_a_payload_without_an_agent_id() {
+async fn paths_in_use_protects_a_terminal_delegations_worktree() {
+    use crate::core::agent::{Delegation, DelegationStatus, ModelTier};
+
     let (state, _dir, session) = hermetic();
-    let missing = super::spawn_on_stop(
-        &state,
-        session,
-        HookEvent::SubagentStop,
-        &serde_json::json!({ "cwd": "/nowhere" }),
+    let finished = PathBuf::from("/r/.claude/worktrees/agent-finished");
+
+    let mut done = Delegation::new(session, None, "rust-engineer", ModelTier::Sonnet, "work");
+    done.agent_id = Some("a-finished".into());
+    done.status = DelegationStatus::Completed;
+    done.worktree_path = Some(finished.clone());
+    state.upsert_delegation(done);
+
+    let in_use = super::paths_in_use(&state, "a-stopping-agent").await;
+
+    assert!(
+        in_use.contains(&finished),
+        "a finished delegation's tree can still be one the harness resumes into; got {in_use:?}"
     );
-    // An empty-string id is equally indeterminate, not a match.
-    let empty = super::spawn_on_stop(
-        &state,
-        session,
-        HookEvent::SubagentStop,
-        &serde_json::json!({ "agent_id": "", "cwd": "/nowhere" }),
-    );
-    assert!(missing.is_none(), "no agent_id must start no reap");
-    assert!(empty.is_none(), "an empty agent_id must start no reap");
-    assert!(state.delegations_for(session).is_empty());
 }
 
 // ── the liveness gate (#4311) ───────────────────────────────────────────────
@@ -444,80 +481,7 @@ async fn reap_spares_a_worktree_another_sessions_agent_still_holds() {
     );
 }
 
-// ── ownership rebuilt from disk (#4311, ADR-0023 point 4) ───────────────────
-
-/// #4311 REGRESSION: a stop reaps a tree the in-memory registry never knew.
-///
-/// Why: `DaemonState::delegations` is a `DashMap` built empty at every boot
-/// with no load path, so a daemon restart drops every registration — and a
-/// `SubagentStop` arrives once, so the reap was lost permanently for any agent
-/// alive across the restart. This test registers NOTHING in the daemon state
-/// (which is exactly what a post-restart daemon holds) and asserts the reap
-/// still fires from the on-disk sentinel alone. It fails against the pre-#4311
-/// body, whose only lookup was the DashMap.
-#[tokio::test]
-async fn stop_reaps_a_worktree_the_registry_lost_to_a_restart() {
-    let (state, _dir, session) = hermetic();
-    let fx = GitWorktreeFixture::new();
-    let wt = harness_worktree_for(&fx, "agent-restarted", "a601");
-    std::fs::write(wt.join("work.txt"), "done\n").expect("write work");
-    GitWorktreeFixture::commit_all_and_push(&wt, "agent work");
-    assert!(
-        state.delegations_for(session).is_empty(),
-        "this fixture must hold no registration — that is what a restarted daemon looks like"
-    );
-
-    let outcome = super::spawn_on_stop(
-        &state,
-        session,
-        HookEvent::SubagentStop,
-        &serde_json::json!({ "agent_id": "a601", "cwd": fx.repo.to_string_lossy() }),
-    )
-    .expect("the sentinel names a601, so a reap must start")
-    .await
-    .expect("the reap task must not panic");
-
-    assert_eq!(outcome, ReapOutcome::Removed);
-    assert!(
-        !wt.exists(),
-        "the sentinel is the whole ownership record here; the reap must act on it"
-    );
-}
-
-/// A sentinel naming a DIFFERENT agent is not this agent's tree.
-///
-/// Why: the disk lookup is the one place a "close enough" match would delete
-/// a directory belonging to an agent that is still running. It must be as
-/// exact as `on_subagent_stop`'s own `agent_id` resolution.
-#[tokio::test]
-async fn stop_ignores_a_sentinel_naming_a_different_agent() {
-    let (state, _dir, session) = hermetic();
-    let fx = GitWorktreeFixture::new();
-    let wt = harness_worktree_for(&fx, "agent-other", "a701");
-    std::fs::write(wt.join("work.txt"), "done\n").expect("write work");
-    GitWorktreeFixture::commit_all_and_push(&wt, "agent work");
-
-    let started = super::spawn_on_stop(
-        &state,
-        session,
-        HookEvent::SubagentStop,
-        &serde_json::json!({ "agent_id": "a702", "cwd": fx.repo.to_string_lossy() }),
-    );
-
-    // The same defect as the sweep's: a fixed sleep here sampled the filesystem
-    // at 750 ms while an `lsof`-gated removal lands at 1-3 s, so a wrong
-    // implementation looked correct. The absence of a task is the exact signal.
-    assert!(
-        started.is_none(),
-        "no sentinel names a702, so no reap task may start"
-    );
-    assert!(
-        wt.exists(),
-        "another agent's worktree must never be reaped by this stop"
-    );
-}
-
-// ── the session-end trigger (#4311 follow-up) ───────────────────────────────
+// ── the session-end trigger (#4311 follow-up, sole trigger since #5800) ─────
 
 /// Deliver `event` through the real hook pipeline, as the daemon does.
 ///
@@ -692,6 +656,113 @@ async fn session_end_spares_another_sessions_agent() {
         peer.exists(),
         "a peer session's agent worktree must survive"
     );
+}
+
+/// #5800: the legitimate reap still runs — known agent, terminal, released.
+///
+/// Why: #5800 tightened two gates and removed a trigger, and the failure mode of
+/// such a change is a reap that now never fires. This is the arm that must
+/// survive it: the registry KNOWS this agent (a delegation names it), that
+/// delegation is TERMINAL, and the parent session ending is the release
+/// evidence. All three hold, so the tree is removed.
+///
+/// It also pins the boundary the other two #5800 tests draw. The same terminal
+/// delegation that `paths_in_use` now protects from a stop must NOT protect this
+/// tree from its own session's end — `paths_in_use` excludes the candidate's own
+/// agent, and if that exclusion were lost this test reports `kept: 1`.
+#[tokio::test]
+async fn session_end_reaps_a_finished_agents_released_worktree() {
+    use crate::core::agent::{Delegation, DelegationStatus, ModelTier};
+
+    let (state, _dir, session) = hermetic();
+    let fx = GitWorktreeFixture::new();
+    let wt = harness_worktree_under(&fx, "agent-released", "a5801", session);
+    std::fs::write(wt.join("work.txt"), "done\n").expect("write work");
+    GitWorktreeFixture::commit_all_and_push(&wt, "agent work");
+
+    let mut done = Delegation::new(session, None, "rust-engineer", ModelTier::Sonnet, "work");
+    done.agent_id = Some("a5801".into());
+    done.status = DelegationStatus::Completed;
+    done.worktree_path = Some(wt.clone());
+    state.upsert_delegation(done);
+
+    let swept = settle(super::spawn_on_session_end(
+        &state,
+        session,
+        HookEvent::SessionEnd,
+        &serde_json::json!({ "cwd": fx.repo.to_string_lossy() }),
+    ))
+    .await;
+
+    assert_eq!(
+        swept,
+        Some(super::SweepSummary {
+            removed: 1,
+            already_gone: 0,
+            kept: 0,
+        }),
+        "known + terminal + released is the population this reap exists for"
+    );
+    assert!(!wt.exists(), "the directory must be gone: {}", wt.display());
+}
+
+/// #5800: an agent stamped on TWO directories owns neither, so both survive.
+///
+/// Why: nothing deletes a stale sentinel and registration re-fires on every
+/// `PreToolUse`, so an agent that moved between trees leaves the first one
+/// stamped — and this store is measurably in that state
+/// (`agent-a23097670a51a0450`'s sentinel recorded `agent_id: a5ed76bc80fd52e41`
+/// on 2026-08-18). Which tree such an agent owns is undeterminable, and ADR-0045
+/// forbids resolving an undeterminable owner by picking one.
+///
+/// The control tree carries the same weight it does in
+/// `session_end_spares_another_sessions_agent`: without it the sweep could
+/// reclaim nothing for an unrelated reason and this test would still pass.
+/// Remove the `find_agent_worktree` filter from `agent_worktrees_of` and this
+/// goes red — `removed` is 3 and both ambiguous directories are gone.
+#[tokio::test]
+async fn session_end_keeps_a_worktree_whose_agent_names_two_directories() {
+    let (state, _dir, session) = hermetic();
+    let fx = GitWorktreeFixture::new();
+    let mut ambiguous = Vec::new();
+    for name in ["agent-moved-from", "agent-moved-to"] {
+        let wt = harness_worktree_under(&fx, name, "a5802", session);
+        std::fs::write(wt.join("work.txt"), "done\n").expect("write work");
+        GitWorktreeFixture::commit_all_and_push(&wt, "agent work");
+        ambiguous.push(wt);
+    }
+    let control = harness_worktree_under(&fx, "agent-unambiguous", "a5803", session);
+    std::fs::write(control.join("work.txt"), "done\n").expect("write work");
+    GitWorktreeFixture::commit_all_and_push(&control, "agent work");
+
+    let swept = settle(super::spawn_on_session_end(
+        &state,
+        session,
+        HookEvent::SessionEnd,
+        &serde_json::json!({ "cwd": fx.repo.to_string_lossy() }),
+    ))
+    .await;
+
+    assert_eq!(
+        swept,
+        Some(super::SweepSummary {
+            removed: 1,
+            already_gone: 0,
+            kept: 0,
+        }),
+        "only the unambiguous tree is a candidate; the ambiguous pair is not swept at all"
+    );
+    assert!(
+        !control.exists(),
+        "the control must be gone, or this test proves nothing about the sweep having run"
+    );
+    for wt in &ambiguous {
+        assert!(
+            wt.exists(),
+            "an undeterminable owner keeps every candidate: {}",
+            wt.display()
+        );
+    }
 }
 
 /// A `SessionEnd` with no `cwd` resolves no store and reclaims nothing.

--- a/crates/trusty-mpm/src/daemon/services/hook_service.rs
+++ b/crates/trusty-mpm/src/daemon/services/hook_service.rs
@@ -258,26 +258,16 @@ impl HookService {
         // the verdict below.
         crate::daemon::services::delegation_tracker::observe(&self.state, session, event, &payload);
 
-        // 1d (#4311): reap the worktree of an agent that just exited. Runs
-        // AFTER `observe`, which is what terminalizes the record this reads, and
-        // no-ops for every event other than `SubagentStop`. Like 1b it spawns a
-        // detached task off this synchronous method — the reap runs git — and
-        // like 1b it cannot change the verdict below.
+        // 1d (#4311, sole trigger since #5800): reap the worktrees of every
+        // agent a session dispatched, when that session ends. A `SubagentStop`
+        // trigger stood here until #5800 — that event reports a turn boundary,
+        // not an exit, so it reaped trees the harness still needed to resume
+        // their agents. A `SessionEnd` proves every agent that session
+        // dispatched has exited, which is the release evidence a stop lacks.
+        // Like 1b it spawns a detached task off this synchronous method — the
+        // reap runs git — and like 1b it cannot change the verdict below.
         // The returned `JoinHandle` is the tests' completion signal; nothing on
         // this hot path may await it, so it is dropped and the task detaches.
-        drop(crate::daemon::services::agent_worktree_reap::spawn_on_stop(
-            &self.state,
-            session,
-            event,
-            &payload,
-        ));
-
-        // 1e (#4311 follow-up): the SECOND trigger. `SubagentStop` was the only
-        // one, so an agent killed by its session exiting or restarting emitted
-        // no stop and its worktree leaked permanently — the orphan sweep skips
-        // agent-owned trees by design. A `SessionEnd` proves every agent that
-        // session dispatched has exited, so it reclaims them through the same
-        // gate stack. Detached like 1b and 1d, and cannot change the verdict.
         drop(
             crate::daemon::services::agent_worktree_reap::spawn_on_session_end(
                 &self.state,


### PR DESCRIPTION
Closes #5800.

## The two defects

**Defect 1 — a terminal delegation status was read as a release**
(`agent_worktree_reap.rs:351`, `paths_in_use`). The set dropped every
delegation in a terminal status, so a finished agent's tree was never
protected. Terminal says trusty-mpm watched *that delegation* finish. It says
nothing about whether the harness still needs the directory to resume the
agent, and the harness routinely does.

**Defect 2 — an agent unknown to the registry was reaped anyway**
(`agent_worktree_reap.rs:398`, `rebuild_from_disk`). When `DaemonState::delegations`
— a `DashMap` rebuilt empty at every boot — held no record, ownership was
reconstructed from the on-disk sentinel and the reap *proceeded* on that
reconstruction. That is fail-OPEN on the `Unknown` state ADR-0045 requires be
treated as undeterminable, and the exact inverse of what
`worktree_reclaim::agent_ownership_blocks` (#5853) does on the sibling reclaim
path.

## Mechanism

Both were reachable only from `spawn_on_stop`, whose trigger is
`SubagentStop`/`SubagentStopFailure`. That event reports that an agent's TURN
ended, not that the agent exited — the module's own doc claimed it was "the
authoritative exit signal", and the evidence in #5800 refutes it. The agent
stays resumable after a stop, so nothing in that event releases the tree.

`SessionEnd` is different, and the module already argued why: a subagent runs
inside its parent Claude Code session's process and cannot outlive it, so the
session's end is Claude Code self-reporting that every agent it dispatched is
gone and unresumable.

So the fix is not a new gate on the stop path — it is that the stop path never
had release evidence to gate on. `spawn_on_stop` and `rebuild_from_disk` are
removed; `spawn_on_session_end` becomes the sole trigger, running the same
gate stack it already ran.

### Why not a positive on-disk signal instead

ADR-0055 decision C makes the `.trusty-mpm-worktree` sentinel authoritative
over the harness store, which would let the reap ask disk whether a tree is
still resumable. That decision is **unimplemented** — it is #5997, no PR open,
and ADR-0055 states plainly that it "does not resolve #5800". On this machine 6
of 57 harness worktrees carry a sentinel at all. So the signal does not exist
today, and per the conservative direction this PR keeps the tree.

**What that costs.** An agent whose session keeps running holds its tree until
that session ends; a session killed hard enough to emit no `SessionEnd` holds
it until `tm session prune-worktrees --merged-prs` reclaims it behind
`worktree_reclaim`'s own fail-closed gates. Both are leaks. A leak is
recoverable — that is why #5846 added the session-end trigger. The deletion
this replaces was not: it destroyed ~11 minutes of in-flight build once and
broke agent resumption four times in one day.

## Log evidence

`~/.trusty-mpm/daemon.log`, 2026-08-18. The `rebuild_from_disk` line fired 4
times, each followed within seconds by removal of that same agent's worktree,
one correlating with "auto-resume failed: workspace directory ... no longer
exists":

```
14:02:11 delegation: registered the agent worktree its dispatch was granted (#4311) agent_id="a69ca7ef80a3e6744"
14:27:49 agent-worktree reap: the delegation registry did not know this agent — its ownership sentinel did, so the reap proceeds against the rebuilt record
14:27:55 agent-worktree reap: removed the worktree its agent has finished with (#4311)
```

That agent had finished and pushed to open PR #5990. No work was lost, but it
became permanently unreachable: every follow-up cost a fresh dispatch and a
hand-rebuilt brief.

## Also fixed

`agent_worktrees_of` now drops a candidate unless `find_agent_worktree`
resolves its agent back to that exact directory. #5800 recorded a store in
exactly the state that guards against — `agent-a23097670a51a0450`'s sentinel
recording `agent_id: a5ed76bc80fd52e41`. Nothing deletes a stale sentinel and
registration re-fires on every `PreToolUse`, so an agent that moved between
trees leaves the first one stamped, and which tree it owns is undeterminable.

## Scope check

`gh pr list --search 5997` returns nothing and no branch implements ADR-0055
decision C, so this does not collide with in-flight sentinel-authority work.
This fix stands alone and does not satisfy decision C.
`worktree_reclaim.rs` behavior is unchanged.

## Tests

Three regression arms, each proven failing on the pre-fix source (source files
reverted to `origin/main`, new tests retained):

| Test | Pre-fix result |
|---|---|
| `subagent_stop_does_not_reap_a_resumable_worktree` | FAILED — "a stop is a turn boundary — the agent stays resumable and its tree must survive"; the stop removed the directory |
| `paths_in_use_protects_a_terminal_delegations_worktree` | FAILED — the terminal delegation's path is absent from the returned set |
| `session_end_keeps_a_worktree_whose_agent_names_two_directories` | FAILED — `left: SweepSummary { removed: 3, .. }` vs `right: SweepSummary { removed: 1, .. }`; both ambiguous trees deleted |

The still-reaps arm, `session_end_reaps_a_finished_agents_released_worktree`
(known agent + terminal + released), **passes both before and after** — it is
the arm that must not regress, and it pins the boundary: the same terminal
delegation `paths_in_use` now protects from a stop must not protect that tree
from its own session's end.

The stop test carries a control. Its fixture is clean, pushed and correctly
attributed, so it passes every surviving gate; delivering the `SessionEnd`
afterwards proves the same tree IS reapable through the trigger that carries
release evidence, and only the stop declined.

Four tests of the removed `spawn_on_stop` go with it. One of them,
`stop_reaps_a_worktree_the_registry_lost_to_a_restart`, asserted defect 2 as
correct behavior — the assertion, not the coverage, was the thing that was
wrong. ADR-0023 point 4's from-disk rebuild requirement is still met by
`agent_worktrees_of`, which reconstructs ownership from sentinels alone.

## Gates — test ladder rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                     EXIT=0
cargo check -p trusty-mpm --all-targets               EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-mpm                              EXIT=0
bash scripts/check_line_cap.sh                        EXIT=0
bash scripts/check_changelog_fragment.sh              EXIT=0
bash scripts/check_sld.sh                             EXIT=0
```

- `cargo test -p trusty-mpm`: `5152 passed; 0 failed; 7 ignored` (lib),
  `1752 passed; 0 failed; 1 ignored` (bin, ×2), plus 47 integration suites all
  green. The reap module itself: 23 passed, 0 failed.
- `check_line_cap.sh`: `measured 4080 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations`.
  `agent_worktree_reap.rs` is a net 243-line reduction and stays well under cap.
- `check_sld.sh`: `0 error(s), 0 warning(s)`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
