### PR TITLE
fix(trusty-review): retry the verifier's own fan-out and report what it could not verify (#4459)

### DIFF
--- a/crates/trusty-review/changelog.d/4459-verifier-concurrency.md
+++ b/crates/trusty-review/changelog.d/4459-verifier-concurrency.md
@@ -1,0 +1,18 @@
+Fixed
+
+- The per-finding verifier retries a transient failure instead of writing the
+  finding off on the first error. The transport errors that made this pass fail
+  on nearly every finding came from the round's own fan-out — 27 of 29 findings
+  in one measured review returned `Transport` while a single call to the same
+  model succeeded in ~845 ms — so fabrication detection was effectively off.
+  Each finding now gets up to `[verification] max_attempts` calls (default 3)
+  with exponential backoff and jitter, and the fan-out width is
+  `[verification] concurrency` (default 4, unchanged) instead of a hardcoded
+  constant. Both read `TRUSTY_REVIEW_VERIFY_MAX_ATTEMPTS` /
+  `TRUSTY_REVIEW_VERIFY_CONCURRENCY` over the config file. See #4459.
+- A finding the verifier still cannot reach after its last attempt is recorded
+  `unverifiable` — never confirmed, never refuted — rather than `error_refuted`,
+  which read as a judgment nothing made and clamped the finding's confidence to
+  0.10. `ReviewResult` carries a new `unverified_count` so a consumer can see how
+  much of a review went unchecked. A round that rendered no judgment on anything
+  can no longer relax the verdict the model itself reported. See #4459.

--- a/crates/trusty-review/src/config/verification.rs
+++ b/crates/trusty-review/src/config/verification.rs
@@ -7,13 +7,20 @@
 //! Centralising these two knobs here keeps `config/mod.rs` under the 500-line
 //! cap and gives the `[verification]` TOML table a single typed home.
 //!
-//! What: exposes `VerificationConfig` (`enabled`, `liveness_check`) and its
-//! TOML-deserialisable mirror `VerificationFileConfig`.  `from_env_and_file`
-//! resolves the two-layer precedence (env var over config file over default),
-//! matching the rest of the config module.
+//! What: exposes `VerificationConfig` (`enabled`, `liveness_check`,
+//! `concurrency`, `max_attempts`) and its TOML-deserialisable mirror
+//! `VerificationFileConfig`.  `from_env_and_file` resolves the two-layer
+//! precedence (env var over config file over default), matching the rest of the
+//! config module.
+//!
+//! `concurrency` and `max_attempts` arrived with #4459: the verifier fan-out
+//! ceiling used to be a module-private constant in `pipeline::verify`, so an
+//! operator whose provider was throttling the round had no lever short of a
+//! release.  `pipeline::verify::VerifyPolicy` reads both.
 //!
 //! Test: `verification_defaults_enabled`, `verification_env_disables`,
-//! `verification_file_disables`, `verification_env_beats_file` in this module.
+//! `verification_file_disables`, `verification_env_beats_file`,
+//! `verify_fan_out_knobs_resolve_and_clamp` in this module.
 
 use serde::Deserialize;
 use tracing::warn;
@@ -34,6 +41,41 @@ const ENV_VERIFICATION_ENABLED: &str = "TRUSTY_REVIEW_VERIFICATION_ENABLED";
 /// What: same truthiness parsing as `ENV_VERIFICATION_ENABLED`.
 const ENV_LIVENESS_CHECK: &str = "TRUSTY_REVIEW_VERIFIER_LIVENESS_CHECK";
 
+/// Environment variable that sets how many verifier calls run at once (#4459).
+///
+/// Why: the fan-out ceiling was a module-private constant in `pipeline::verify`,
+/// so the only way to relieve a transport-error storm was a code change and a
+/// release. An operator hitting provider throttling needs to turn it down now.
+/// What: a positive integer; `0` and unparseable values are ignored with a
+/// warning, keeping the file/default value.
+const ENV_VERIFY_CONCURRENCY: &str = "TRUSTY_REVIEW_VERIFY_CONCURRENCY";
+
+/// Environment variable that sets the per-finding verifier attempt budget (#4459).
+///
+/// Why: the retry budget trades wall-clock latency against how many findings
+/// come back UNVERIFIED under provider pressure, and the right trade differs
+/// per deployment.
+/// What: a positive integer counting TOTAL attempts (1 = no retry); `0` and
+/// unparseable values are ignored with a warning.
+const ENV_VERIFY_MAX_ATTEMPTS: &str = "TRUSTY_REVIEW_VERIFY_MAX_ATTEMPTS";
+
+/// Verifier calls in flight per verification round when nothing overrides it.
+///
+/// Why: unchanged from the pre-#4459 hardcoded value, so an operator who sets
+/// nothing sees the same fan-out width as before; what changed is that the
+/// retry ladder now absorbs the transport errors that width produces.
+/// What: the default for [`VerificationConfig::concurrency`].
+pub const DEFAULT_VERIFY_CONCURRENCY: usize = 4;
+
+/// Total verifier attempts per finding when nothing overrides it (#4459).
+///
+/// Why: three attempts across the default backoff ladder covers the transport
+/// blips and 429s a concurrent fan-out produces without stalling a review when
+/// the provider is genuinely down.
+/// What: the default for [`VerificationConfig::max_attempts`]; counts the first
+/// call, so `1` disables retry.
+pub const DEFAULT_VERIFY_MAX_ATTEMPTS: u32 = 3;
+
 /// Resolved configuration for the verification round.
 ///
 /// Why: the runner and the `serve` startup path both read these flags; a single
@@ -52,18 +94,26 @@ pub struct VerificationConfig {
     /// When `true` (default), live mode refuses to start if the startup
     /// verifier-model liveness probe fails with a config/lifecycle error.
     pub liveness_check: bool,
+    /// Verifier calls in flight per round (#4459). Always ≥ 1.
+    pub concurrency: usize,
+    /// Total verifier attempts per finding, first call included (#4459).
+    /// Always ≥ 1; `1` disables retry.
+    pub max_attempts: u32,
 }
 
 impl Default for VerificationConfig {
     /// Why: the safe default is "verification on, liveness gate on" so a
     /// mis-deployed verifier model fails loudly instead of silently
     /// auto-refuting every finding (the code-intelligence incident).
-    /// What: both flags `true`.
+    /// What: both flags `true`; the fan-out knobs take
+    /// [`DEFAULT_VERIFY_CONCURRENCY`] / [`DEFAULT_VERIFY_MAX_ATTEMPTS`].
     /// Test: `verification_defaults_enabled`.
     fn default() -> Self {
         Self {
             enabled: true,
             liveness_check: true,
+            concurrency: DEFAULT_VERIFY_CONCURRENCY,
+            max_attempts: DEFAULT_VERIFY_MAX_ATTEMPTS,
         }
     }
 }
@@ -77,17 +127,31 @@ impl VerificationConfig {
     /// Unrecognised env values are ignored with a warning (fail-open: keep the
     /// stricter file/default value rather than silently flipping a safety gate).
     /// Test: `verification_env_disables`, `verification_file_disables`,
-    /// `verification_env_beats_file`.
+    /// `verification_env_beats_file`, `verify_fan_out_knobs_resolve_and_clamp`.
     pub fn from_env_and_file(file: Option<&VerificationFileConfig>) -> Self {
         let mut cfg = VerificationConfig {
             enabled: file.and_then(|f| f.enabled).unwrap_or(true),
             liveness_check: file.and_then(|f| f.liveness_check).unwrap_or(true),
+            concurrency: file
+                .and_then(|f| f.concurrency)
+                .filter(|n| *n > 0)
+                .unwrap_or(DEFAULT_VERIFY_CONCURRENCY),
+            max_attempts: file
+                .and_then(|f| f.max_attempts)
+                .filter(|n| *n > 0)
+                .unwrap_or(DEFAULT_VERIFY_MAX_ATTEMPTS),
         };
         if let Some(v) = parse_bool_env(ENV_VERIFICATION_ENABLED) {
             cfg.enabled = v;
         }
         if let Some(v) = parse_bool_env(ENV_LIVENESS_CHECK) {
             cfg.liveness_check = v;
+        }
+        if let Some(v) = parse_positive_env(ENV_VERIFY_CONCURRENCY) {
+            cfg.concurrency = v as usize;
+        }
+        if let Some(v) = parse_positive_env(ENV_VERIFY_MAX_ATTEMPTS) {
+            cfg.max_attempts = v;
         }
         cfg
     }
@@ -106,6 +170,10 @@ pub struct VerificationFileConfig {
     pub enabled: Option<bool>,
     /// `[verification] liveness_check = false` disables only the startup gate.
     pub liveness_check: Option<bool>,
+    /// `[verification] concurrency = 2` narrows the verifier fan-out (#4459).
+    pub concurrency: Option<usize>,
+    /// `[verification] max_attempts = 5` widens the per-finding retry budget (#4459).
+    pub max_attempts: Option<u32>,
 }
 
 /// Parse a boolean env var with lenient truthiness, or `None` if unset/empty.
@@ -133,6 +201,29 @@ fn parse_bool_env(var: &str) -> Option<bool> {
     }
 }
 
+/// Parse a strictly positive integer env var, or `None` if unset/invalid.
+///
+/// Why: both fan-out knobs are counts where `0` means "verify nothing" — a
+/// typo that would silently disable the anti-fabrication net is the exact
+/// failure #4459 is about, so `0` is rejected rather than honoured.
+/// What: returns `Some(n)` for `n >= 1`; `None` (with a warning) for `0`,
+/// negatives, non-numbers, and unset/empty.
+/// Test: `verify_fan_out_knobs_resolve_and_clamp`.
+fn parse_positive_env(var: &str) -> Option<u32> {
+    let raw = std::env::var(var).ok()?;
+    let v = raw.trim();
+    if v.is_empty() {
+        return None;
+    }
+    match v.parse::<u32>() {
+        Ok(n) if n >= 1 => Some(n),
+        _ => {
+            warn!("{var} must be a positive integer, got {v:?} — ignoring");
+            None
+        }
+    }
+}
+
 // ─── Unit tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -144,6 +235,8 @@ mod tests {
         unsafe {
             std::env::remove_var(ENV_VERIFICATION_ENABLED);
             std::env::remove_var(ENV_LIVENESS_CHECK);
+            std::env::remove_var(ENV_VERIFY_CONCURRENCY);
+            std::env::remove_var(ENV_VERIFY_MAX_ATTEMPTS);
         }
     }
 
@@ -152,6 +245,42 @@ mod tests {
         let cfg = VerificationConfig::default();
         assert!(cfg.enabled, "verification must default ON");
         assert!(cfg.liveness_check, "liveness gate must default ON");
+        assert_eq!(cfg.concurrency, DEFAULT_VERIFY_CONCURRENCY);
+        assert_eq!(cfg.max_attempts, DEFAULT_VERIFY_MAX_ATTEMPTS);
+    }
+
+    /// #4459: the fan-out ceiling and the retry budget are operator knobs, and a
+    /// `0` on either must not disable verification by the back door.
+    #[test]
+    #[serial]
+    fn verify_fan_out_knobs_resolve_and_clamp() {
+        clear_env();
+        let file = VerificationFileConfig {
+            concurrency: Some(0),
+            max_attempts: Some(7),
+            ..Default::default()
+        };
+        let cfg = VerificationConfig::from_env_and_file(Some(&file));
+        assert_eq!(
+            cfg.concurrency, DEFAULT_VERIFY_CONCURRENCY,
+            "a 0 in the file must fall through to the default, never to no verification"
+        );
+        assert_eq!(
+            cfg.max_attempts, 7,
+            "a positive file value must be honoured"
+        );
+
+        unsafe {
+            std::env::set_var(ENV_VERIFY_CONCURRENCY, "2");
+            std::env::set_var(ENV_VERIFY_MAX_ATTEMPTS, "0");
+        }
+        let cfg = VerificationConfig::from_env_and_file(Some(&file));
+        assert_eq!(cfg.concurrency, 2, "env must override the file value");
+        assert_eq!(
+            cfg.max_attempts, 7,
+            "a 0 in the env must be ignored, leaving the file value in force"
+        );
+        clear_env();
     }
 
     #[test]
@@ -174,6 +303,7 @@ mod tests {
         let file = VerificationFileConfig {
             enabled: Some(false),
             liveness_check: Some(false),
+            ..Default::default()
         };
         let cfg = VerificationConfig::from_env_and_file(Some(&file));
         assert!(!cfg.enabled, "file false must disable verification");
@@ -192,6 +322,7 @@ mod tests {
         let file = VerificationFileConfig {
             enabled: Some(false),
             liveness_check: None,
+            ..Default::default()
         };
         let cfg = VerificationConfig::from_env_and_file(Some(&file));
         assert!(cfg.enabled, "env true must override file false");
@@ -208,6 +339,7 @@ mod tests {
         let file = VerificationFileConfig {
             enabled: Some(false),
             liveness_check: None,
+            ..Default::default()
         };
         let cfg = VerificationConfig::from_env_and_file(Some(&file));
         assert!(

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -252,6 +252,26 @@ impl VerifyOutcome {
             }
         }
     }
+
+    /// Does this outcome mean nothing ever rendered a judgment on the finding?
+    ///
+    /// Why (#4459): a consumer deciding whether to trust a review needs one
+    /// number for "how much of this went unchecked", and every surface that
+    /// answered it locally answered it differently. Counting is what makes the
+    /// unable-to-verify case visible instead of silent — a review where the
+    /// verifier was unreachable for most findings must not read the same as one
+    /// where it examined them all.
+    /// What: exhaustive match, no `_` arm, so a new variant forces the decision
+    /// here. True for the three unreachable/unchecked outcomes; false for
+    /// `Confirmed`, `Refuted` (the verifier DID judge), and `Skipped` (below the
+    /// candidate floor — never a question that was asked).
+    /// Test: `is_unverified_covers_every_unable_to_verify_outcome`.
+    pub fn is_unverified(&self) -> bool {
+        match self {
+            Self::Confirmed | Self::Refuted | Self::Skipped => false,
+            Self::ErrorRefuted { .. } | Self::TruncationRefuted | Self::Unverifiable { .. } => true,
+        }
+    }
 }
 
 // ─── Finding category ──────────────────────────────────────────────────────────
@@ -524,6 +544,23 @@ pub struct ReviewResult {
     /// `findings_count_matches_len_on_completed_review` (runner_tests.rs).
     #[serde(default)]
     pub findings_count: usize,
+    /// How many findings nothing ever rendered a judgment on (#4459).
+    ///
+    /// Why: the verifier can fail on most of a review's findings while the
+    /// review still reads clean — that is exactly what #4459 reports, and a
+    /// consumer had no way to see it short of walking `findings` and matching on
+    /// `verified` variants. One integer says how much of this review went
+    /// unchecked, so a consumer can hold a review whose safety net was down
+    /// instead of trusting or discarding it blindly.
+    /// What: the count of findings whose `verified` outcome answers true to
+    /// `VerifyOutcome::is_unverified` — unreachable verifier, truncated
+    /// response, or a claim the pipeline declined to check. Synced at the same
+    /// two canonical exit points as `findings_count`. `#[serde(default)]` keeps
+    /// pre-#4459 serialised results deserialising with `0`.
+    /// Test: `unverified_count_matches_the_unverified_findings` (post_tests),
+    /// `verify_permanent_transport_failure_lands_in_unverified`.
+    #[serde(default)]
+    pub unverified_count: usize,
     /// Per-line inline review comments that were (or, in dry-run, would be)
     /// posted to the PR diff (#1414).
     ///
@@ -666,6 +703,7 @@ impl ReviewResult {
             grade: None,
             findings: Vec::new(),
             findings_count: 0,
+            unverified_count: 0,
             inline_comments: Vec::new(),
             inline_finding_indices: Vec::new(),
             suppressed_nits: 0,

--- a/crates/trusty-review/src/models/tests.rs
+++ b/crates/trusty-review/src/models/tests.rs
@@ -458,3 +458,27 @@ fn caveat_confirmed_and_skipped_are_unqualified() {
         "must carry the recorded reason: {unverifiable}"
     );
 }
+
+/// #4459: `is_unverified` is what `unverified_count` counts, so it must answer
+/// for every variant — a verifier that judged the finding (`Confirmed` /
+/// `Refuted`) and one that was never asked (`Skipped`) are not unverified;
+/// everything else is.
+#[test]
+fn is_unverified_covers_every_unable_to_verify_outcome() {
+    assert!(!VerifyOutcome::Confirmed.is_unverified());
+    assert!(!VerifyOutcome::Refuted.is_unverified());
+    assert!(!VerifyOutcome::Skipped.is_unverified());
+    assert!(
+        VerifyOutcome::ErrorRefuted {
+            error_class: "Transport".to_string()
+        }
+        .is_unverified()
+    );
+    assert!(VerifyOutcome::TruncationRefuted.is_unverified());
+    assert!(
+        VerifyOutcome::Unverifiable {
+            reason: "unreachable".to_string()
+        }
+        .is_unverified()
+    );
+}

--- a/crates/trusty-review/src/pipeline/post.rs
+++ b/crates/trusty-review/src/pipeline/post.rs
@@ -30,7 +30,7 @@ use tracing::{error, info, warn};
 use crate::{
     config::ReviewConfig,
     integrations::github::{AuthStrategy, GithubClient, RunMode, post_pr_review},
-    models::ReviewResult,
+    models::{Finding, ReviewResult},
     pipeline::{
         output::{print_review_result, write_review_log},
         trigger::{TriggerDecision, effective_dry_run},
@@ -168,6 +168,23 @@ pub fn decide_action(
     }
 }
 
+/// Count the findings nothing rendered a judgment on (#4459).
+///
+/// Why: both canonical exits — `finalize_review` here and `abort_dry` in
+/// `runner_helpers` — owe the caller the same number, and two copies of the
+/// predicate would drift the moment a `VerifyOutcome` variant is added.
+/// What: counts findings whose recorded outcome answers true to
+/// `VerifyOutcome::is_unverified`. A finding with no outcome at all is NOT
+/// counted — it was never a verification candidate, the same state as
+/// `Skipped`.
+/// Test: `unverified_count_matches_the_unverified_findings`.
+pub(crate) fn count_unverified(findings: &[Finding]) -> usize {
+    findings
+        .iter()
+        .filter(|f| f.verified.as_ref().is_some_and(|v| v.is_unverified()))
+        .count()
+}
+
 /// Context the runner passes to `finalize_review` for the post path.
 ///
 /// Why: posting needs the PR coordinates, the run mode (to select the auth
@@ -217,6 +234,9 @@ pub async fn finalize_review(
     // completed-review exit point (covers both the unified and map-reduce
     // paths, which both funnel through `finalize_run` → here).
     result.findings_count = result.findings.len();
+    // #4459: same rationale one field over — report how many findings nothing
+    // verified, so a review whose verifier was unreachable does not read clean.
+    result.unverified_count = count_unverified(&result.findings);
 
     // #4044: the narrative summary was written BEFORE the verification round on
     // both paths, so it can still cite a finding the verifier refuted as a merge
@@ -336,6 +356,34 @@ async fn post_live(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::{Effort, VerifyOutcome};
+
+    /// #4459: the count reports every finding nothing rendered a judgment on,
+    /// and nothing else — a judged finding and one that was never a candidate
+    /// both stay out of it.
+    #[test]
+    fn unverified_count_matches_the_unverified_findings() {
+        let mk = |outcome: Option<VerifyOutcome>| {
+            let mut f = Finding::new("src/a.rs", "logic", "a bug", "fix it", 0.9, Effort::Medium);
+            f.verified = outcome;
+            f
+        };
+        let findings = vec![
+            mk(Some(VerifyOutcome::Confirmed)),
+            mk(Some(VerifyOutcome::Refuted)),
+            mk(Some(VerifyOutcome::Skipped)),
+            mk(None),
+            mk(Some(VerifyOutcome::ErrorRefuted {
+                error_class: "AccessDenied".to_string(),
+            })),
+            mk(Some(VerifyOutcome::TruncationRefuted)),
+            mk(Some(VerifyOutcome::Unverifiable {
+                reason: "unreachable after 3 attempt(s)".to_string(),
+            })),
+        ];
+        assert_eq!(count_unverified(&findings), 3);
+        assert_eq!(count_unverified(&[]), 0);
+    }
 
     // ── Footer rendering ──────────────────────────────────────────────────────
 

--- a/crates/trusty-review/src/pipeline/runner_helpers.rs
+++ b/crates/trusty-review/src/pipeline/runner_helpers.rs
@@ -255,6 +255,9 @@ pub(super) async fn abort_dry(
     // #1877: keep the authoritative findings_count in sync at this canonical
     // early-abort exit point, regardless of which guard triggered the abort.
     result.findings_count = result.findings.len();
+    // #4459: the same sync for the unverified count, so an aborted run reports
+    // it too rather than leaving a stale zero.
+    result.unverified_count = crate::pipeline::post::count_unverified(&result.findings);
     // Release the in-progress claim so a retry can re-run this head SHA.
     // #5064: only when this review actually acquired it — see `DedupClaim`.
     if claim == DedupClaim::Held

--- a/crates/trusty-review/src/pipeline/verify.rs
+++ b/crates/trusty-review/src/pipeline/verify.rs
@@ -43,9 +43,22 @@
 //! truncated responses), so `rederive_verdict` preserves `primary_verdict`
 //! instead of discarding it.  See `verify_one` for the full rationale.
 //!
+//! ## Fan-out retry and honest UNVERIFIED (#4459)
+//! The round used to fan out at a hardcoded width of 4 with no retry, and in
+//! production that fan-out was the thing breaking it: 27 of 29 findings in one
+//! measured review came back `Transport` while a single call to the same model
+//! in isolation succeeded in ~845 ms, so fabrication detection was effectively
+//! off. `VerifyPolicy` now carries the width and a per-finding attempt budget
+//! from `[verification] concurrency` / `max_attempts`, `verify_one` retries a
+//! transient failure with exponential backoff and jitter, and a finding still
+//! unreachable after the last attempt is recorded `Unverifiable` — counted by
+//! `ReviewResult::unverified_count` — rather than `ErrorRefuted`, which reads as
+//! a judgment nothing made.
+//!
 //! Test: `verify_tests.rs` — candidate selection, CONFIRMED/REFUTED outcomes,
 //! verdict re-derivation, truncation regression (#726), transient-error
-//! fail-open regression (#1876), and liveness-gate logic.
+//! fail-open regression (#1876), fan-out retry / UNVERIFIED accounting (#4459),
+//! and liveness-gate logic.
 
 use std::sync::Arc;
 
@@ -58,6 +71,7 @@ use crate::{
     config::constants::{
         BLOCK_VERDICT_MIN_CONFIDENCE, VERIFY_CANDIDATE_MIN_CONFIDENCE, VERIFY_REFUTED_CONFIDENCE,
     },
+    config::verification::{DEFAULT_VERIFY_CONCURRENCY, DEFAULT_VERIFY_MAX_ATTEMPTS},
     llm::{LlmError, LlmProvider},
     models::{Finding, Verdict, VerifyOutcome},
     pipeline::{
@@ -66,13 +80,91 @@ use crate::{
     },
 };
 
-/// Maximum number of verifier calls to run concurrently.
+/// Base backoff before the second attempt at one finding (#4459).
 ///
-/// Why: verifications are independent per finding, so running them concurrently
-/// cuts wall-clock latency; the bound caps provider concurrency so a PR with
-/// many findings does not burst the verifier model's rate limit.
-/// What: `buffer_unordered(VERIFY_CONCURRENCY)` over the candidate stream.
-const VERIFY_CONCURRENCY: usize = 4;
+/// Why: the ladder has to outlast a provider's throttling window without
+/// stalling a review — 250 / 500 / 1000 ms plus jitter spans the range a
+/// transport blip or a 429 under fan-out clears in, and a default round of 3
+/// attempts adds at most ~750 ms of sleep to a finding that eventually succeeds.
+/// What: attempt *n* (1-based) sleeps `VERIFY_BACKOFF_BASE_MS << (n - 1)` plus
+/// jitter; `VerifyPolicy::backoff_base_ms` overrides it, and `0` disables the
+/// sleep entirely so tests exercise the ladder without waiting.
+const VERIFY_BACKOFF_BASE_MS: u64 = 250;
+
+/// How the round fans out and how hard it retries (#4459).
+///
+/// Why: the fan-out ceiling was a private constant and there was no retry at
+/// all, so a review whose verifier calls hit transport errors had no way to
+/// recover and an operator had no way to relieve the pressure. Both are now
+/// resolved config (`[verification] concurrency` / `max_attempts`), and this
+/// struct is the shape the round reads them through.
+/// What: `concurrency` is the `buffer_unordered` width; `max_attempts` counts
+/// TOTAL attempts per finding, so `1` means no retry; `backoff_base_ms` is the
+/// first sleep in the exponential ladder. Both counts are clamped to ≥ 1 on
+/// construction — a `0` would silently verify nothing.
+/// Test: `verify_transient_failure_is_retried_until_it_succeeds`,
+/// `verify_round_never_exceeds_the_configured_concurrency`,
+/// `policy_from_config_clamps_zero_counts`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VerifyPolicy {
+    /// Verifier calls in flight at once.
+    pub concurrency: usize,
+    /// Total attempts per finding, first call included.
+    pub max_attempts: u32,
+    /// Sleep before the second attempt; doubles each further attempt.
+    pub backoff_base_ms: u64,
+}
+
+impl Default for VerifyPolicy {
+    /// The pre-#4459 fan-out width, plus the retry ladder that width needs.
+    fn default() -> Self {
+        Self {
+            concurrency: DEFAULT_VERIFY_CONCURRENCY,
+            max_attempts: DEFAULT_VERIFY_MAX_ATTEMPTS,
+            backoff_base_ms: VERIFY_BACKOFF_BASE_MS,
+        }
+    }
+}
+
+impl VerifyPolicy {
+    /// Read the policy out of resolved verification config.
+    ///
+    /// Why: `VerificationConfig` owns the env/file precedence; this is the only
+    /// place the pipeline turns it into a fan-out decision.
+    /// What: clamps both counts to ≥ 1 and keeps the default backoff base.
+    /// Test: `policy_from_config_clamps_zero_counts`.
+    pub fn from_config(config: &crate::config::VerificationConfig) -> Self {
+        Self {
+            concurrency: config.concurrency.max(1),
+            max_attempts: config.max_attempts.max(1),
+            backoff_base_ms: VERIFY_BACKOFF_BASE_MS,
+        }
+    }
+
+    /// Sleep before attempt `attempt` (1-based; attempt 1 never sleeps).
+    ///
+    /// Why: a fixed ladder makes every concurrent call retry in lockstep, which
+    /// re-creates the burst that failed in the first place. Jitter spreads the
+    /// retries of a fan-out across the window instead of stacking them.
+    /// What: `backoff_base_ms << (attempt - 2)` plus up to 25% jitter drawn from
+    /// the wall clock. Returns zero when `backoff_base_ms` is zero.
+    /// Test: `backoff_grows_and_stays_within_its_jitter_band`.
+    fn backoff(&self, attempt: u32) -> std::time::Duration {
+        if self.backoff_base_ms == 0 || attempt < 2 {
+            return std::time::Duration::ZERO;
+        }
+        let base = self.backoff_base_ms << (attempt - 2).min(6);
+        // #4459: no `rand` in this crate's graph, and the jitter only has to
+        // decorrelate concurrent retries — nanosecond clock skew between the
+        // in-flight calls is enough for that.
+        let jitter_span = (base / 4).max(1);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos() as u64)
+            .unwrap_or(0);
+        std::time::Duration::from_millis(base + nanos % jitter_span)
+    }
+}
 
 // ─── Runner seam ──────────────────────────────────────────────────────────────
 
@@ -106,7 +198,7 @@ pub async fn maybe_verify(
         return verdict;
     };
     let role = &config.role_models.verifier;
-    run_verification_round(
+    run_verification_round_with_policy(
         verifier,
         &role.model,
         diff,
@@ -115,6 +207,7 @@ pub async fn maybe_verify(
         Some(role.temperature),
         Some(role.max_tokens),
         author_rationale,
+        VerifyPolicy::from_config(&config.verification),
     )
     .await
 }
@@ -150,6 +243,43 @@ pub async fn run_verification_round(
     max_tokens: Option<u32>,
     author_rationale: Option<&str>,
 ) -> Verdict {
+    run_verification_round_with_policy(
+        verifier,
+        verifier_model,
+        diff,
+        primary_verdict,
+        findings,
+        temperature,
+        max_tokens,
+        author_rationale,
+        VerifyPolicy::default(),
+    )
+    .await
+}
+
+/// Run the verification round under an explicit fan-out policy (#4459).
+///
+/// Why: [`run_verification_round`] is the stable seam its existing callers use;
+/// this is the same round with the concurrency ceiling and retry budget passed
+/// in, so `maybe_verify` can honour operator config and a test can run the
+/// ladder with the sleep set to zero.
+/// What: identical to [`run_verification_round`] except that `policy` replaces
+/// the defaults.
+/// Test: `verify_transient_failure_is_retried_until_it_succeeds`,
+/// `verify_permanent_transport_failure_lands_in_unverified`,
+/// `verify_round_never_exceeds_the_configured_concurrency`.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_verification_round_with_policy(
+    verifier: &Arc<dyn LlmProvider>,
+    verifier_model: &str,
+    diff: &str,
+    primary_verdict: Verdict,
+    findings: &mut [Finding],
+    temperature: Option<f32>,
+    max_tokens: Option<u32>,
+    author_rationale: Option<&str>,
+    policy: VerifyPolicy,
+) -> Verdict {
     // UNKNOWN is terminal — the diff was unassessable, so there is nothing to
     // verify and no verdict to re-derive.
     if primary_verdict == Verdict::Unknown {
@@ -167,6 +297,8 @@ pub async fn run_verification_round(
         candidates = candidate_idxs.len(),
         total = findings.len(),
         primary = %primary_verdict,
+        concurrency = policy.concurrency,
+        max_attempts = policy.max_attempts,
         "verification round: verifying candidate findings"
     );
 
@@ -184,22 +316,26 @@ pub async fn run_verification_round(
                 author_rationale,
             );
             async move {
-                let outcome = verify_one(verifier, req).await;
+                let outcome = verify_one(verifier, req, policy).await;
                 (idx, outcome)
             }
         })
-        .buffer_unordered(VERIFY_CONCURRENCY)
+        .buffer_unordered(policy.concurrency.max(1))
         .collect()
         .await;
 
     // Apply outcomes: record on the finding and demote refuted ones.
     let mut any_confirmed = false;
     let mut any_clean_refuted = false;
+    let mut unverified = 0usize;
     for (idx, outcome) in outcomes {
         match &outcome {
             VerifyOutcome::Confirmed => any_confirmed = true,
             VerifyOutcome::Refuted => any_clean_refuted = true,
             _ => {}
+        }
+        if outcome.is_unverified() {
+            unverified += 1;
         }
         apply_outcome(&mut findings[idx], outcome);
     }
@@ -216,6 +352,7 @@ pub async fn run_verification_round(
         final = %final_verdict,
         any_confirmed,
         any_clean_refuted,
+        unverified,
         "verification round complete — verdict re-derived"
     );
     final_verdict
@@ -246,10 +383,16 @@ pub async fn run_verification_round(
 ///         NOT individually clear the severity-floor confidence gate.
 ///   b)  clean model REFUTED, nothing confirmed
 ///       → drop to APPROVE baseline (escalation rested on refuted evidence)
-///   c)  all demotions are infra / unable-to-verify failures (TruncationRefuted /
-///       ErrorRefuted — the latter now also covers transient errors, #1876), no
-///       confirmed → preserve `primary_verdict` (do not fail-open to APPROVE on
-///       verifier infra failure, #726 + #1876)
+///   c)  nothing was confirmed and nothing was cleanly refuted — every outcome
+///       was an infra / unable-to-verify failure (TruncationRefuted,
+///       ErrorRefuted, or, since #4459, `Unverifiable` after an exhausted retry
+///       budget) → preserve `primary_verdict` (do not fail-open to APPROVE on
+///       verifier infra failure, #726 + #1876). Since #4459 that preservation is
+///       enforced on the RESULT (`verdict_max` against `primary_verdict`), not
+///       just handed to `derive_verdict` as a baseline: an `Unverifiable`
+///       finding SURVIVES into the survivor set, and an all-advisory survivor
+///       set trips `grade`'s low-confidence collapse, which dissolved the
+///       model's own BLOCK. Surviving findings may still escalate.
 ///
 /// `UNKNOWN` is handled by the caller and never reaches here.
 /// What: filters survivors (non-refuted), selects baseline (path a2 takes the
@@ -312,9 +455,20 @@ fn rederive_verdict(
     //      → drop to APPROVE; let survivors alone decide
     //  c)  infra-only fail (TruncationRefuted / ErrorRefuted), nothing confirmed
     //      → preserve primary_verdict (don't discard on infra failure #726)
+    // #4459: path (c) below says "preserve primary_verdict", and until now it
+    // said so by passing `primary_verdict` as the baseline and trusting
+    // `derive_verdict` to treat it as a lower bound. That holds only while the
+    // survivor set is empty. Once an unable-to-verify finding SURVIVES — which
+    // is what `Unverifiable` does, unlike the refutation variants — an
+    // all-advisory survivor set trips `grade`'s low-confidence collapse and
+    // dissolves the model's own BLOCK, which is the fail-open this issue is
+    // about, arriving by a new route. Remember whether this round rendered any
+    // judgment at all; nothing may relax the verdict when nothing did.
+    let no_judgment_rendered = !any_confirmed && !any_clean_refuted;
+
     let baseline = if any_confirmed && any_confirmed_high {
         // Path (a): confirmed High-effort evidence supports the escalation fully.
-        primary_verdict
+        primary_verdict.clone()
     } else if any_confirmed {
         // Path (a2): confirmed evidence, but only Medium/Low tier.  Take the
         // severity-MIN of the model's own verdict and APPROVE* (the advisory tier)
@@ -329,7 +483,7 @@ fn rederive_verdict(
         // `derive_verdict(baseline, survivors)` will still escalate further if the
         // surviving findings warrant it (e.g. a surviving High → BLOCK, or as of
         // #1876 a surviving confident Medium → REQUEST_CHANGES).
-        verdict_min(primary_verdict, Verdict::ApproveWithReservations)
+        verdict_min(primary_verdict.clone(), Verdict::ApproveWithReservations)
     } else if any_clean_refuted {
         // Path (b): at least one clean REFUTED from the model — escalation rested
         // on refuted evidence; let survivors alone decide.
@@ -338,10 +492,30 @@ fn rederive_verdict(
         // Path (c): all demotions were infrastructure failures (TruncationRefuted /
         // ErrorRefuted) — preserve the model's escalation rather than silently
         // collapsing to APPROVE due to verifier infra failure.
-        primary_verdict
+        primary_verdict.clone()
     };
 
-    derive_verdict(baseline, &survivors)
+    let rederived = derive_verdict(baseline, &survivors);
+    if no_judgment_rendered {
+        // Path (c): the round reached no judgment on anything. Surviving
+        // findings may still ESCALATE the verdict, but none of them may lower
+        // what the model itself said.
+        return verdict_max(rederived, primary_verdict);
+    }
+    rederived
+}
+
+/// Return the *more severe* (severity-max) of two verdicts.
+///
+/// Why (#4459): the mirror of [`verdict_min`], used by path (c) so an
+/// infra-only round can escalate on surviving evidence but can never relax the
+/// model's own verdict — nothing in that round examined anything.
+/// What: compares via `Verdict::ordinal`, the single source of truth shared with
+/// `grade.rs`.
+/// Test: `verify_permanent_transport_failure_lands_in_unverified`,
+/// `rederive_error_refuted_preserves_primary_verdict`.
+fn verdict_max(a: Verdict, b: Verdict) -> Verdict {
+    if a.ordinal() >= b.ordinal() { a } else { b }
 }
 
 /// Return the *less severe* (severity-min) of two verdicts.
@@ -455,14 +629,95 @@ struct VerifyJudgment {
 /// itself is still excluded from the severity floor either way (an unverified
 /// finding must not drive escalation on its own); only the *fail-open-to-APPROVE*
 /// side effect on the surrounding review is fixed.
+/// #4459 retry + honest UNVERIFIED: a transient error is now retried up to
+/// `policy.max_attempts` times with exponential backoff and jitter before any
+/// outcome is recorded, because the transport errors that disabled this pass in
+/// production came from the round's OWN fan-out — a single call to the same
+/// model in isolation succeeded in ~845 ms while 27 of 29 findings in a
+/// concurrent round came back `Transport`. When the budget is exhausted the
+/// finding is recorded as `Unverifiable`, NOT `ErrorRefuted`: nothing examined
+/// it, so calling the result a refutation (and clamping its confidence to 0.10
+/// as `apply_outcome` does for every refutation variant) states a judgment the
+/// pipeline never made. `Unverifiable` keeps the finding visible as an advisory
+/// that cannot escalate, and `ReviewResult::unverified_count` reports how many
+/// there were. Alarm-class errors keep the `ErrorRefuted` + alarm treatment from
+/// #726 — a broken deployment is a different fact from an unreachable call, and
+/// retrying a deterministic ModelNotFound only delays the alarm.
 /// Test: `verify_one_confirmed`, `verify_one_refuted`,
 /// `verify_one_model_unavailable_emits_signal`,
 /// `verify_truncated_response_is_truncation_refuted`,
-/// `verify_transient_error_marks_error_refuted_not_plain_refuted` (#1876).
-async fn verify_one(verifier: &Arc<dyn LlmProvider>, req: crate::llm::LlmRequest) -> VerifyOutcome {
+/// `verify_transient_error_is_not_plain_refuted` (#1876),
+/// `verify_transient_failure_is_retried_until_it_succeeds` (#4459),
+/// `verify_permanent_transport_failure_lands_in_unverified` (#4459).
+async fn verify_one(
+    verifier: &Arc<dyn LlmProvider>,
+    req: crate::llm::LlmRequest,
+    policy: VerifyPolicy,
+) -> VerifyOutcome {
     let model = req.model.clone();
+    let attempts = policy.max_attempts.max(1);
+    let mut last_class = String::new();
+    for attempt in 1..=attempts {
+        match attempt_verify(verifier, req.clone(), &model).await {
+            Ok(outcome) => return outcome,
+            Err(AttemptError::Alarm(outcome)) => return outcome,
+            Err(AttemptError::Transient(class)) => {
+                last_class = class;
+                if attempt < attempts {
+                    let backoff = policy.backoff(attempt + 1);
+                    warn!(
+                        attempt,
+                        max_attempts = attempts,
+                        backoff_ms = backoff.as_millis(),
+                        error_class = %last_class,
+                        "verifier transient error — retrying (#4459)"
+                    );
+                    if !backoff.is_zero() {
+                        tokio::time::sleep(backoff).await;
+                    }
+                }
+            }
+        }
+    }
+    warn!(
+        attempts,
+        error_class = %last_class,
+        "verifier unreachable after every attempt — recording the finding as UNVERIFIED (#4459)"
+    );
+    VerifyOutcome::Unverifiable {
+        reason: format!(
+            "the verifier could not be reached after {attempts} attempt(s) ({last_class}); \
+             the finding was neither confirmed nor refuted"
+        ),
+    }
+}
+
+/// Why one attempt failed, when it did (#4459).
+///
+/// Why: the retry loop must tell "retry this" from "stop now, the deployment is
+/// broken" without re-deriving the classification the alarm branch already made.
+/// What: `Alarm` carries the terminal outcome to return as-is; `Transient`
+/// carries the error class for the log line and the eventual reason string.
+enum AttemptError {
+    Alarm(VerifyOutcome),
+    Transient(String),
+}
+
+/// One verifier call, classified.
+///
+/// Why: keeps `verify_one`'s loop readable — the response-parsing arms are the
+/// same on every attempt and only the error arms decide whether to loop.
+/// What: `Ok` on any response the pipeline can act on (including a truncated
+/// one, which is a provider fault the same request will reproduce); `Err` on a
+/// call that failed.
+/// Test: covered through `verify_one` by the tests it lists.
+async fn attempt_verify(
+    verifier: &Arc<dyn LlmProvider>,
+    req: crate::llm::LlmRequest,
+    model: &str,
+) -> Result<VerifyOutcome, AttemptError> {
     match verifier.complete(req).await {
-        Ok(resp) => match parse_judgment(&resp.text) {
+        Ok(resp) => Ok(match parse_judgment(&resp.text) {
             Some(Judgment::Confirmed) => VerifyOutcome::Confirmed,
             Some(Judgment::Refuted) => VerifyOutcome::Refuted,
             // #5309: the verifier declined to confirm a claim the diff cannot
@@ -480,31 +735,30 @@ async fn verify_one(verifier: &Arc<dyn LlmProvider>, req: crate::llm::LlmRequest
                 // distinguish "model said REFUTED" from "provider returned garbage".
                 VerifyOutcome::TruncationRefuted
             }
-        },
+        }),
         Err(e) if e.is_alarm() => {
             // Config/lifecycle failure: the verifier model is broken.  This is
             // the incident path — make it loud, do not pretend the finding was
-            // refuted on its merits.
+            // refuted on its merits.  Deterministic, so it is never retried.
             let error_class = error_class(&e);
-            emit_verification_model_error(&model, &error_class, &e);
-            VerifyOutcome::ErrorRefuted { error_class }
+            emit_verification_model_error(model, &error_class, &e);
+            Err(AttemptError::Alarm(VerifyOutcome::ErrorRefuted {
+                error_class,
+            }))
         }
         Err(e) => {
-            // Transient failure (#1876): we could not verify this finding, but
-            // the deployment is not broken and the model never rendered a
-            // judgment.  Fail toward CAUTION, not toward "this finding is
-            // wrong" — map to ErrorRefuted (not plain Refuted) so
-            // rederive_verdict preserves primary_verdict (path c) instead of
-            // fail-opening the whole review to APPROVE (path b).  This is not
-            // an alarm-worthy incident (no emit_verification_model_error call):
-            // rate limits and transport blips are expected operational noise,
-            // not a broken deployment.
+            // Transient failure (#1876, #4459): we could not verify this
+            // finding, but the deployment is not broken and the model never
+            // rendered a judgment.  Hand it back to the retry ladder; only an
+            // exhausted budget decides an outcome.  This is not an alarm-worthy
+            // incident (no emit_verification_model_error call): rate limits and
+            // transport blips are expected operational noise.
             let error_class = error_class(&e);
-            warn!(
+            debug!(
                 error_class = %error_class,
-                "verifier transient error (treating as unable-to-verify, not refuted): {e}"
+                "verifier call failed (retryable): {e}"
             );
-            VerifyOutcome::ErrorRefuted { error_class }
+            Err(AttemptError::Transient(error_class))
         }
     }
 }

--- a/crates/trusty-review/src/pipeline/verify_tests.rs
+++ b/crates/trusty-review/src/pipeline/verify_tests.rs
@@ -572,12 +572,18 @@ async fn verify_model_unavailable_marks_error_refuted_and_preserves_verdict() {
 /// all (it just could not be reached). This is the textbook fail-open bug: an
 /// infrastructure hiccup silently downgraded a real BLOCK to APPROVE.
 /// What: a `LlmError::RateLimited` (a non-alarm, transient error per
-/// `LlmError::is_alarm`) on the ONLY candidate finding must record
-/// `ErrorRefuted` and take path (c) — preserve `primary_verdict` — instead of
-/// path (b) — collapse to APPROVE.
+/// `LlmError::is_alarm`) on the ONLY candidate finding must NOT record plain
+/// `Refuted`, and the round must take a path that preserves `primary_verdict`
+/// instead of path (b) — collapse to APPROVE.
+///
+/// #4459 moved where that lands: an exhausted retry budget now records
+/// `Unverifiable` rather than `ErrorRefuted`, because nothing examined the
+/// finding. The invariant this test was written for is unchanged and still
+/// asserted here — a transient error is never a refutation, and never
+/// fail-opens the review.
 /// Test: this test itself.
 #[tokio::test]
-async fn verify_transient_error_marks_error_refuted_not_plain_refuted() {
+async fn verify_transient_error_is_not_plain_refuted() {
     let verifier: Arc<dyn LlmProvider> = Arc::new(FailingVerifier {
         make_err: || LlmError::RateLimited,
     });
@@ -594,16 +600,22 @@ async fn verify_transient_error_marks_error_refuted_not_plain_refuted() {
     )
     .await;
     assert!(
-        matches!(
-            findings[0].verified,
-            Some(VerifyOutcome::ErrorRefuted { .. })
-        ),
-        "a transient verifier error must map to ErrorRefuted, not plain Refuted (#1876)"
+        !matches!(findings[0].verified, Some(VerifyOutcome::Refuted)),
+        "a transient verifier error must never read as a refutation (#1876)"
+    );
+    assert!(
+        findings[0]
+            .verified
+            .as_ref()
+            .is_some_and(|v| v.is_unverified()),
+        "a transient verifier error must record an unable-to-verify outcome (#1876, #4459), \
+         got {:?}",
+        findings[0].verified
     );
     assert_eq!(
         verdict,
         Verdict::Block,
-        "a transient-error-only round must preserve primary_verdict (path c), \
+        "a transient-error-only round must preserve primary_verdict, \
          not fail-open to APPROVE (path b) (#1876)"
     );
 }
@@ -866,5 +878,316 @@ fn apply_outcome_unverifiable_strips_block_floor_signals() {
         f.confidence <= 0.65,
         "confidence capped, got {}",
         f.confidence
+    );
+}
+
+// ── Fan-out retry and UNVERIFIED accounting (#4459) ───────────────────────────
+
+/// A verifier that fails the first `fail_first` attempts at each distinct
+/// request, then answers CONFIRMED — the shape of a transport blip under
+/// fan-out, where the same call succeeds on a second try.
+struct FlakyVerifier {
+    fail_first: usize,
+    attempts: std::sync::Mutex<std::collections::HashMap<String, usize>>,
+    in_flight: Arc<std::sync::atomic::AtomicUsize>,
+    peak_in_flight: Arc<std::sync::atomic::AtomicUsize>,
+    /// Hold each call until this many are in flight at once, so the test
+    /// observes the real ceiling instead of whatever the scheduler happened to
+    /// interleave. `0` disables the rendezvous.
+    rendezvous_at: usize,
+}
+
+impl FlakyVerifier {
+    fn new(fail_first: usize) -> Self {
+        Self {
+            fail_first,
+            attempts: std::sync::Mutex::new(std::collections::HashMap::new()),
+            in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            peak_in_flight: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            rendezvous_at: 0,
+        }
+    }
+
+    fn rendezvous_at(mut self, n: usize) -> Self {
+        self.rendezvous_at = n;
+        self
+    }
+}
+
+#[async_trait]
+impl LlmProvider for FlakyVerifier {
+    fn name(&self) -> &str {
+        "flaky-verifier"
+    }
+    async fn complete(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        use std::sync::atomic::Ordering;
+        let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.peak_in_flight.fetch_max(now, Ordering::SeqCst);
+
+        // Condition polling, never a sleep: yield until the round has as many
+        // calls in flight as the rendezvous asks for, bounded so a wrong
+        // expectation fails the test instead of hanging it.
+        if self.rendezvous_at > 0 {
+            let mut spins = 0;
+            while self.in_flight.load(Ordering::SeqCst) < self.rendezvous_at && spins < 10_000 {
+                spins += 1;
+                tokio::task::yield_now().await;
+            }
+        }
+
+        let key = format!("{:?}", req.messages);
+        let seen = {
+            let mut map = self.attempts.lock().expect("attempt map poisoned");
+            let e = map.entry(key).or_insert(0);
+            *e += 1;
+            *e
+        };
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+
+        if seen <= self.fail_first {
+            return Err(LlmError::Transport("connection reset by peer".into()));
+        }
+        Ok(LlmResponse {
+            text: r#"{"judgment":"CONFIRMED","reason":"present in diff"}"#.to_string(),
+            model: req.model.clone(),
+            input_tokens: 10,
+            output_tokens: 5,
+            latency_ms: 1,
+            cost_usd: 0.0,
+            finish_reason: None,
+        })
+    }
+}
+
+/// Distinct findings, so each one produces a distinct verifier request.
+fn findings_for_fan_out(n: usize) -> Vec<Finding> {
+    (0..n)
+        .map(|i| {
+            let mut f = Finding::new(
+                format!("src/f{i}.rs"),
+                "logic",
+                format!("bug number {i}"),
+                "fix it",
+                0.95,
+                Effort::High,
+            );
+            f.line = Some(10 + i as u32);
+            f.code_provable = true;
+            f
+        })
+        .collect()
+}
+
+/// Zero-sleep policy: the ladder still runs, the test just does not wait on it.
+fn test_policy(concurrency: usize, max_attempts: u32) -> VerifyPolicy {
+    VerifyPolicy {
+        concurrency,
+        max_attempts,
+        backoff_base_ms: 0,
+    }
+}
+
+/// #4459 (a): a transient transport failure must be RETRIED, and a finding that
+/// succeeds on a later attempt must come back CONFIRMED.
+///
+/// Why: this is the whole bug. Before this fix `verify_one` recorded an outcome
+/// on the FIRST error, so every finding whose call lost the race with the
+/// round's own fan-out was written off unverified — 27 of 29 in the measured
+/// incident — while the same call in isolation succeeded.
+/// What: a verifier that fails each request twice and then answers CONFIRMED,
+/// under a 3-attempt budget. On the pre-fix code this test fails: the outcome is
+/// recorded from attempt 1, so the finding lands on `ErrorRefuted` and the
+/// verifier is never called a second time.
+/// Test: this test itself.
+#[tokio::test]
+async fn verify_transient_failure_is_retried_until_it_succeeds() {
+    let verifier: Arc<dyn LlmProvider> = Arc::new(FlakyVerifier::new(2));
+    let mut findings = vec![finding(Effort::High, 0.95)];
+    let verdict = run_verification_round_with_policy(
+        &verifier,
+        "m",
+        "+ diff",
+        Verdict::Block,
+        &mut findings,
+        None,
+        None,
+        None,
+        test_policy(4, 3),
+    )
+    .await;
+    assert!(
+        matches!(findings[0].verified, Some(VerifyOutcome::Confirmed)),
+        "a transient failure inside the attempt budget must be retried to a real \
+         judgment, got {:?}",
+        findings[0].verified
+    );
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "the confirmed High finding still holds BLOCK"
+    );
+}
+
+/// #4459 (b): a finding the verifier never reaches, on any attempt, is
+/// UNVERIFIED — not refuted, not confirmed — and the run counts it.
+///
+/// Why: recording `ErrorRefuted` states a judgment nothing made, and
+/// `apply_outcome` clamps every refutation variant to 0.10, so the finding
+/// disappeared from the review while the review itself still read clean. The
+/// count is what makes the failure visible to a consumer.
+/// What: a verifier that always returns `Transport`, under a 2-attempt budget.
+/// On the pre-fix code this test fails on the `Unverifiable` assertion — the
+/// outcome was `ErrorRefuted`.
+/// Test: this test itself.
+#[tokio::test]
+async fn verify_permanent_transport_failure_lands_in_unverified() {
+    let verifier: Arc<dyn LlmProvider> = Arc::new(FailingVerifier {
+        make_err: || LlmError::Transport("connection refused".into()),
+    });
+    let mut findings = vec![finding(Effort::High, 0.95)];
+    let verdict = run_verification_round_with_policy(
+        &verifier,
+        "m",
+        "+ diff",
+        Verdict::Block,
+        &mut findings,
+        None,
+        None,
+        None,
+        test_policy(4, 2),
+    )
+    .await;
+
+    let Some(VerifyOutcome::Unverifiable { reason }) = &findings[0].verified else {
+        panic!(
+            "an unreachable verifier must record UNVERIFIED, got {:?}",
+            findings[0].verified
+        );
+    };
+    assert!(
+        reason.contains("2 attempt(s)") && reason.contains("Transport"),
+        "the reason must say what was tried and why it failed, got {reason:?}"
+    );
+    assert_eq!(
+        crate::pipeline::post::count_unverified(&findings),
+        1,
+        "the run must report the finding it could not check"
+    );
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "an unverifiable-only round must preserve primary_verdict, never fail-open \
+         to APPROVE"
+    );
+    assert!(
+        !findings[0].code_provable && findings[0].confidence <= 0.65,
+        "an unverified finding must be demoted so it cannot drive escalation"
+    );
+}
+
+/// #4459 (c): the round honours the configured fan-out ceiling, and every
+/// finding in a wide fan-out still reaches a real judgment.
+///
+/// Why: the ceiling was a hardcoded `4` with no way for an operator to relieve a
+/// provider that was throttling the round. It is now config, and a round that
+/// ignored it would recreate the burst this issue is about.
+/// What: eight findings under a ceiling of 2, against a verifier that fails each
+/// request once before answering. The provider rendezvouses at 2 concurrent
+/// calls (condition polling, no sleep) so the peak is actually observed. On the
+/// pre-fix code this test fails twice over: the width is fixed at 4, and the
+/// single injected failure per finding is never retried.
+/// Test: this test itself.
+#[tokio::test]
+async fn verify_round_never_exceeds_the_configured_concurrency() {
+    use std::sync::atomic::Ordering;
+    let flaky = FlakyVerifier::new(1).rendezvous_at(2);
+    let peak = flaky.peak_in_flight.clone();
+    let verifier: Arc<dyn LlmProvider> = Arc::new(flaky);
+
+    let mut findings = findings_for_fan_out(8);
+    let verdict = run_verification_round_with_policy(
+        &verifier,
+        "m",
+        "+ diff",
+        Verdict::Block,
+        &mut findings,
+        None,
+        None,
+        None,
+        test_policy(2, 3),
+    )
+    .await;
+
+    assert_eq!(
+        peak.load(Ordering::SeqCst),
+        2,
+        "the round must fan out to exactly the configured width — no wider, and \
+         wide enough that the ceiling is the thing being measured"
+    );
+    for (i, f) in findings.iter().enumerate() {
+        assert!(
+            matches!(f.verified, Some(VerifyOutcome::Confirmed)),
+            "finding {i} must survive its transient failure and be judged, got {:?}",
+            f.verified
+        );
+    }
+    assert_eq!(
+        crate::pipeline::post::count_unverified(&findings),
+        0,
+        "nothing is unverified once every retry succeeded"
+    );
+    assert_eq!(verdict, Verdict::Block);
+}
+
+/// The policy reads operator config and refuses a zero on either count.
+#[test]
+fn policy_from_config_clamps_zero_counts() {
+    let cfg = crate::config::VerificationConfig {
+        enabled: true,
+        liveness_check: true,
+        concurrency: 0,
+        max_attempts: 0,
+    };
+    let policy = VerifyPolicy::from_config(&cfg);
+    assert_eq!(policy.concurrency, 1, "a 0 width must never verify nothing");
+    assert_eq!(
+        policy.max_attempts, 1,
+        "a 0 budget must still make one call"
+    );
+
+    let cfg = crate::config::VerificationConfig {
+        concurrency: 6,
+        max_attempts: 5,
+        ..Default::default()
+    };
+    let policy = VerifyPolicy::from_config(&cfg);
+    assert_eq!(policy.concurrency, 6);
+    assert_eq!(policy.max_attempts, 5);
+}
+
+/// The backoff doubles per attempt and stays inside its jitter band.
+#[test]
+fn backoff_grows_and_stays_within_its_jitter_band() {
+    let policy = VerifyPolicy {
+        concurrency: 4,
+        max_attempts: 4,
+        backoff_base_ms: 200,
+    };
+    assert!(policy.backoff(1).is_zero(), "the first attempt never waits");
+    for (attempt, base) in [(2u32, 200u64), (3, 400), (4, 800)] {
+        let ms = policy.backoff(attempt).as_millis() as u64;
+        assert!(
+            (base..base + base / 4).contains(&ms),
+            "attempt {attempt} must wait {base}ms plus up to 25% jitter, got {ms}ms"
+        );
+    }
+    assert!(
+        VerifyPolicy {
+            backoff_base_ms: 0,
+            ..policy
+        }
+        .backoff(3)
+        .is_zero(),
+        "a zero base disables the wait so tests do not sleep"
     );
 }


### PR DESCRIPTION
Closes #4459.

## Failure signature

27 of 29 findings in one measured review carried
`verified={"error_refuted":{"error_class":"Transport"}}`; the other 2 were
`null`. A single `converse` call to the same model, region and box succeeded in
~845 ms. Fabrication detection was therefore off in production while the review
still read as if every finding had been checked.

## Mechanism

`pipeline/verify.rs` fanned out at a hardcoded `VERIFY_CONCURRENCY = 4` with no
retry, and `verify_one` recorded an outcome on the FIRST error. Every call that
lost the race with the round's own fan-out was written off — the errors came
from the verifier's own concurrency, not from a provider outage. Two of the
three providers (`openrouter.rs`, `fireworks.rs`) have no retry of their own, so
for them the first transport blip was final.

The outcome it recorded compounded that. `ErrorRefuted` is a refutation variant:
`apply_outcome` clamps the finding's confidence to 0.10 and `rederive_verdict`
drops it from the survivor set, so the pipeline stated a judgment nothing had
made, and the review reported nothing about how much of it went unchecked.

## What changed

**Retry.** `verify_one` now retries a transient (`LlmError::is_retryable`)
failure up to `[verification] max_attempts` times (default 3) with exponential
backoff and jitter — 250/500/1000 ms plus up to 25%, drawn from the wall clock
so concurrent retries decorrelate instead of re-bursting. Alarm-class errors
(`ModelNotFound`, `AccessDenied`, …) are deterministic and still fail
immediately with the `verification_model_error` signal from #726.

**UNVERIFIED.** A finding still unreachable after the last attempt records
`VerifyOutcome::Unverifiable { reason }`, naming the attempt count and error
class — never confirmed, never refuted. It keeps the advisory demotion
(`code_provable` cleared, High→Medium, confidence capped at 0.65) so it cannot
escalate, and `ReviewResult::unverified_count` reports how many findings nothing
judged. Alarm-class failures keep their `ErrorRefuted` treatment: a broken
deployment is a different fact from an unreachable call.

That surfaced a second fail-open, fixed here. Path (c) of `rederive_verdict`
("nothing was verified — preserve the model's verdict") relied on passing
`primary_verdict` as a baseline, which only holds while the survivor set is
empty. `Unverifiable` findings SURVIVE, and an all-advisory survivor set trips
`grade`'s low-confidence collapse, which dissolved the model's own BLOCK. Path
(c) now enforces the preservation on the result (`verdict_max` against
`primary_verdict`); surviving findings may still escalate, none may relax.
`verify_permanent_transport_failure_lands_in_unverified` failed on exactly this
before the fix went in.

**Config.** The fan-out width and the attempt budget are `[verification]
concurrency` / `max_attempts`, overridable by `TRUSTY_REVIEW_VERIFY_CONCURRENCY`
/ `TRUSTY_REVIEW_VERIFY_MAX_ATTEMPTS`. Defaults keep today's width of 4. A `0`
on either is rejected with a warning rather than honoured — silently verifying
nothing is the failure this issue is about.

## Common-entry-point check

trusty-common has no generic retry-a-fallible-call entry point to extend:
`spawn_retry` is ETXTBSY-specific, and the rest (`memory_core::store`,
`embedder_client::supervisor`, `search_index`) are domain-local ladders with
their own retryability predicates. This retry keys on
`crate::llm::LlmError::is_retryable`, a type private to trusty-review, and lives
inside one crate — so the rule's cross-crate scope does not reach it, and adding
a shared abstraction with one consumer would be speculative. Nothing in
trusty-common changed; this stays rung 3.

One interaction worth knowing: `BedrockProvider::complete` already retries
transient errors 3× internally, so on Bedrock a verifier call can now be
attempted up to 9 times before landing UNVERIFIED. That is deliberate — the
seam-level ladder is the only retry the OpenRouter and Fireworks paths get.

## Test ladder — rung 3

Localized behavior inside one crate, plus regression tests that provably failed
before.

```
cargo fmt --check                                        # clean
cargo check -p trusty-review --all-targets               # clean
cargo clippy -p trusty-review --all-targets -- -D warnings  # clean
cargo test -p trusty-review                              # 1612 passed; 0 failed; 5 ignored (lib)
                                                         # + 10 target suites, 91 passed; 0 failed
bash scripts/check_line_cap.sh                           # 0 violations
bash scripts/check_changelog_fragment.sh                 # 1 crate recorded
bash scripts/check_sld.sh                                # 0 errors, 0 warnings
```

Three arms, all in `pipeline/verify_tests.rs`, all against a mock provider:

- `verify_transient_failure_is_retried_until_it_succeeds` — a verifier that
  fails each request twice then confirms. Pre-fix the outcome was recorded from
  attempt 1 and there was no second call. Demonstrated by running the same test
  with a 1-attempt budget:
  `panicked ... a transient failure inside the attempt budget must be retried to a real judgment, got Some(Unverifiable { reason: "the verifier could not be reached after 1 attempt(s) (Transport); ..." })`
- `verify_permanent_transport_failure_lands_in_unverified` — always fails.
  Asserts `Unverifiable` (pre-fix: `ErrorRefuted`), the reason string, a
  `count_unverified` of 1, that the verdict is not relaxed, and that the finding
  is demoted.
- `verify_round_never_exceeds_the_configured_concurrency` — 8 findings, ceiling
  of 2, one injected failure each. The mock rendezvouses at 2 in-flight by
  condition polling (`yield_now`, bounded spin — no sleeps anywhere in these
  tests) so the peak is actually observed. Pre-fix the width was fixed at 4 and
  the failures were never retried.

Plus `policy_from_config_clamps_zero_counts`,
`backoff_grows_and_stays_within_its_jitter_band`,
`verify_fan_out_knobs_resolve_and_clamp`,
`is_unverified_covers_every_unable_to_verify_outcome`, and
`unverified_count_matches_the_unverified_findings`.

`verify_transient_error_marks_error_refuted_not_plain_refuted` is renamed
`verify_transient_error_is_not_plain_refuted` and keeps both #1876 assertions —
a transient error is never a refutation, and never fail-opens the review — now
stated against `is_unverified()` rather than the `ErrorRefuted` variant. No
coverage was removed.

Kept clear of `pipeline/diff_analyzer/` (PR #6007).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
