### PR TITLE
fix(trusty-review): synthesis survives provider schema drift — markdown fallback, key normalization, prompt-side contract

### DIFF
--- a/crates/trusty-review/changelog.d/6009-synthesis-markdown-fallback-and-raw-capture.md
+++ b/crates/trusty-review/changelog.d/6009-synthesis-markdown-fallback-and-raw-capture.md
@@ -21,3 +21,20 @@ Fixed
   failing the whole response; the rendered report shows `not stated in
   source data` for a defaulted severity/cost — never a fabricated band or
   figure.
+- Fixed the CLASS of #6009, not just the two prior instances: three
+  consecutive live calls to `anthropic/claude-opus-4.8` via OpenRouter, all
+  with `response_format: json_schema`/`strict: true`, produced three
+  different response shapes (markdown prose, `risk`/`applications`, and
+  `risk`/`cost_effort_framing`/`affected_applications`) — `response_format`
+  is best-effort for Anthropic-family models, since Anthropic's own API has
+  no native strict-JSON mode. The synthesis system prompt now states the
+  exact required JSON field names in the prompt TEXT itself, generated
+  directly from the same schema definition the request forces via
+  `response_format` (so the two can never drift apart), and the per-shape
+  `#[serde(alias)]`s on `RiskRow` are replaced by a whitelist synonym table
+  (`synthesize_normalize`) applied before typed deserialization: a
+  recognised synonym (`risk`, `applications`, `affected_applications`,
+  `cost_effort_framing`) renames onto its canonical field, and any other key
+  is dropped with a recorded `synthesis: dropped unrecognized field` note —
+  never guessed. The numeric guardrail still runs after normalization, so a
+  fabricated figure is rejected exactly as before.

--- a/crates/trusty-review/changelog.d/6009-synthesis-markdown-fallback-and-raw-capture.md
+++ b/crates/trusty-review/changelog.d/6009-synthesis-markdown-fallback-and-raw-capture.md
@@ -13,3 +13,11 @@ Fixed
 - An unparseable synthesis response is now persisted (scrubbed) next to the
   report output as `synthesis-unparseable-response.txt` so a future
   occurrence is diagnosable without spending another live provider call.
+- Report synthesis no longer hard-fails a due-diligence run when a provider
+  returns valid top-level JSON but drifts `top_risks` field names — a live
+  capture used `risk` for `description` and `applications` for `apps`, and
+  omitted `severity`/`cost` entirely. Those field names are now accepted as
+  aliases, and an omitted `severity`/`cost` defaults to unset rather than
+  failing the whole response; the rendered report shows `not stated in
+  source data` for a defaulted severity/cost — never a fabricated band or
+  figure.

--- a/crates/trusty-review/changelog.d/6009-synthesis-markdown-fallback-and-raw-capture.md
+++ b/crates/trusty-review/changelog.d/6009-synthesis-markdown-fallback-and-raw-capture.md
@@ -1,0 +1,15 @@
+Fixed
+
+- Report synthesis no longer hard-fails a due-diligence run when a provider
+  ignores the forced JSON schema and returns markdown-headed free prose
+  instead ([#6009](https://github.com/bobmatnyc/trusty-tools/issues/6009)).
+  Live repro against `anthropic/claude-opus-4.8` via OpenRouter: `200 OK`,
+  `finish_reason: "stop"`, `response_format` silently ignored, response was
+  `## Executive Summary\n\n<prose>\n\n## Top Risks\n\n...`. The parser now
+  recovers `executive_summary` from that shape (never `top_risks`/`findings`
+  — prose is never reconstructed into structured rows); the numeric guardrail
+  still verifies whatever text is recovered, so a fabricated figure is
+  rejected exactly as before.
+- An unparseable synthesis response is now persisted (scrubbed) next to the
+  report output as `synthesis-unparseable-response.txt` so a future
+  occurrence is diagnosable without spending another live provider call.

--- a/crates/trusty-review/src/cli_report.rs
+++ b/crates/trusty-review/src/cli_report.rs
@@ -248,7 +248,7 @@ pub async fn cmd_report(config: ReviewConfig, args: ReportArgs) -> Result<()> {
     // command the recovery path.
     eprintln!("[trusty-review report] Synthesis — calling LLM provider...");
     let budget = resolve_budget(&args, &manifest);
-    let synthesis = run_synthesis(&config, &mut model, budget)
+    let synthesis = run_synthesis(&config, &mut model, budget, &args.out)
         .await
         .with_context(|| {
             format!(
@@ -503,6 +503,7 @@ async fn run_synthesis(
     config: &ReviewConfig,
     model: &mut ReportModel,
     budget: Budget,
+    out_dir: &Path,
 ) -> Result<Synthesis> {
     let role = &config.role_models.reviewer;
     let provider = build_provider(&role.model, &role.provider, config)
@@ -518,13 +519,18 @@ async fn run_synthesis(
             inv.repos.len()
         );
         apply_investigation(model, &inv);
+        // #6009: capture the raw response next to the report output on an
+        // unparseable-response failure, so a future occurrence is diagnosable
+        // without spending another live call to find out what the model sent.
         let mut synthesis = Synthesizer::new(provider, role.model.clone())
+            .with_raw_capture_dir(out_dir)
             .synthesize(model)
             .await?;
         merge_investigation_prose(&mut synthesis, &inv);
         Ok(synthesis)
     } else {
         Ok(Synthesizer::new(provider, role.model.clone())
+            .with_raw_capture_dir(out_dir)
             .synthesize(model)
             .await?)
     }

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -39,6 +39,9 @@ pub mod section_instructions;
 pub mod synthesize;
 pub mod synthesize_digest;
 pub mod synthesize_guard;
+// #6009 shape 3: whitelist-based synonym normalization, used only by
+// `synthesize::parse_raw` — not part of the public report API.
+pub(crate) mod synthesize_normalize;
 pub mod synthesize_prompt;
 pub mod template;
 // #5405: the board-correlation figures tga hands over beside the manifest.

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -366,9 +366,18 @@ fn build_scope(model: &ReportModel) -> Scope {
 /// synthesized rows render (previously the template hard-capped at 3/5 fixed
 /// placeholder rows, silently dropping any beyond the cap — #2373); with zero
 /// top risks no block is pushed and the section collapses via omit-empty.
+/// #6009 shape 2: a live capture omitted `severity`/`cost` entirely, and
+/// [`RiskRow`](super::synthesize::RiskRow) now defaults each to `""` rather
+/// than failing the whole response — `risk_severity`/`risk_cost` are left
+/// UNSET (never set to `""`) when empty, so the fill engine's own honesty
+/// rule renders `not stated in source data` instead of a blank table cell
+/// that could be misread as "no severity/cost", matching the precedent
+/// `reporter_fill.rs::set_executive_summary` already uses for the
+/// deterministic path's `risk_cost`.
 /// Test: `reporter_tests.rs::{reporter_injects_synthesis_prose,
 /// reporter_tags_top_risks_as_inferred, reporter_renders_all_top_risk_rows,
-/// reporter_collapses_empty_top_risks}`.
+/// reporter_collapses_empty_top_risks,
+/// reporter_renders_defaulted_top_risk_severity_honestly}`.
 fn inject_synthesis_summary(root: &mut Scope, syn: &super::synthesize::Synthesis) {
     if let Some(exec) = &syn.executive_summary {
         root.set(
@@ -384,8 +393,12 @@ fn inject_synthesis_summary(root: &mut Scope, syn: &super::synthesize::Synthesis
             "risk_description",
             tag(risk.description.clone(), Provenance::Inferred),
         );
-        row.set("risk_severity", risk.severity.clone());
-        row.set("risk_cost", tag(risk.cost.clone(), Provenance::Inferred));
+        if !risk.severity.is_empty() {
+            row.set("risk_severity", risk.severity.clone());
+        }
+        if !risk.cost.is_empty() {
+            row.set("risk_cost", tag(risk.cost.clone(), Provenance::Inferred));
+        }
         row.set("risk_apps", risk.apps.clone());
         root.push_block("top_risk_row", row);
     }

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -1377,6 +1377,47 @@ fn reporter_collapses_empty_top_risks() {
     assert!(!md.contains("{{risk_rank}}"));
 }
 
+/// Why: #6009 shape 2 — a live capture's `top_risks` rows omitted
+/// `severity`/`cost` entirely, and `RiskRow` now defaults each to `""`
+/// (`synthesize.rs`) rather than failing the whole response. The reporter
+/// must render that honestly — `not stated in source data` — never a blank
+/// cell (which could read as "no severity") and never an invented band or
+/// figure.
+/// What: attaches a `Synthesis` with one top-risk row carrying real
+/// `description`/`apps` but empty `severity`/`cost`, and asserts the rendered
+/// row's severity/cost cells carry [`HONESTY_MARKER`] while the real fields
+/// still render.
+/// Test: this test itself.
+#[test]
+fn reporter_renders_defaulted_top_risk_severity_honestly() {
+    use crate::report::synthesize::{RiskRow, Synthesis};
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut model = fixture_model(tmp.path());
+    model.synthesis = Some(Synthesis {
+        executive_summary: Some("Summary.".to_string()),
+        top_risks: vec![RiskRow {
+            description: "Plaintext secrets at rest".to_string(),
+            severity: String::new(),
+            cost: String::new(),
+            apps: "00-bobmatnyc-trusty-tools".to_string(),
+        }],
+        findings: vec![],
+        notes: vec![],
+    });
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(md.contains("Plaintext secrets at rest"));
+    assert!(md.contains("00-bobmatnyc-trusty-tools"));
+    assert!(
+        md.contains(&format!("| 1 | Plaintext secrets at rest ⁽ⁱ⁾ | {HONESTY_MARKER} | {HONESTY_MARKER} | 00-bobmatnyc-trusty-tools |")),
+        "a defaulted severity/cost must render as the honesty marker, never blank or fabricated: {md}"
+    );
+}
+
 /// Why: live-QA wave-2 defect #5 — the per-language LoC breakdown was computed
 /// (both by the scanner and from an external metrics file) but only language
 /// NAMES reached the rendered Profile table; the actual split (the useful

--- a/crates/trusty-review/src/report/synthesize.rs
+++ b/crates/trusty-review/src/report/synthesize.rs
@@ -127,15 +127,36 @@ pub enum SynthesisError {
 }
 
 /// One synthesized top-risk table row (rationale for the Top Risks table).
+///
+/// Why: #6009 shape 2 — a live capture against `anthropic/claude-opus-4.8`
+/// returned valid top-level JSON, but every `top_risks` item used drifted
+/// field names (`risk` for `description`, `applications` for `apps`) and
+/// omitted `severity`/`cost` entirely, so `serde_json::from_str::<RawSynthesis>`
+/// failed on the whole response and the run was classified `Unparseable` even
+/// though the risk content itself was present and verifiable.
+/// What: `description`/`apps` accept the drifted names via `#[serde(alias)]`
+/// (still SERIALIZED under their canonical names — the JSON twin on
+/// [`ReportModel`] is unaffected). `severity`/`cost` default to `""` when the
+/// provider omits them; the reporter renders an empty value as the honesty
+/// marker (`not stated in source data`), never a fabricated band or figure —
+/// see `reporter.rs::inject_synthesis_summary`.
+/// Test: `synthesize_tests.rs::parse_raw_recovers_shape2_field_name_drift`,
+/// `reporter_tests.rs::reporter_renders_defaulted_top_risk_severity_honestly`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RiskRow {
     /// Risk description.
+    #[serde(alias = "risk")]
     pub description: String,
-    /// Severity band (`RED`/`AMBER`).
+    /// Severity band (`RED`/`AMBER`), or `""` when the provider omitted it
+    /// (#6009 shape 2) — never fabricated.
+    #[serde(default)]
     pub severity: String,
-    /// Qualitative cost/effort framing.
+    /// Qualitative cost/effort framing, or `""` when the provider omitted it
+    /// (#6009 shape 2) — never fabricated.
+    #[serde(default)]
     pub cost: String,
     /// Affected application(s).
+    #[serde(alias = "applications")]
     pub apps: String,
 }
 
@@ -431,11 +452,17 @@ struct RawSynthesis {
 /// mean inventing fields the model never actually populated, which is exactly
 /// what this parser must not do).  `None` when none of the three yields
 /// anything, so a response that is not even this fallback shape is still
-/// rejected as [`SynthesisError::Unparseable`].
+/// rejected as [`SynthesisError::Unparseable`].  A FOURTH shape (#6009 shape
+/// 2) needs no fallback tier of its own: a live capture returned valid
+/// top-level JSON but drifted `top_risks` field names (`risk`/`applications`
+/// for `description`/`apps`, `severity`/`cost` omitted) — [`RiskRow`]'s
+/// `#[serde(alias)]`/`#[serde(default)]` attributes absorb that at the first
+/// (direct-object) tier, so it never falls through to here.
 /// Test: `synthesize_tests.rs::{synthesize_happy_path_injects,
 /// synthesize_malformed_json_fails_closed,
 /// synthesize_recovers_executive_summary_from_markdown_fallback,
-/// synthesize_markdown_fallback_rejects_response_with_no_heading}`.
+/// synthesize_markdown_fallback_rejects_response_with_no_heading,
+/// parse_raw_recovers_shape2_field_name_drift}`.
 fn parse_raw(text: &str) -> Option<RawSynthesis> {
     let body = text.trim();
     if body.starts_with('{')

--- a/crates/trusty-review/src/report/synthesize.rs
+++ b/crates/trusty-review/src/report/synthesize.rs
@@ -18,6 +18,7 @@
 //! Test: `synthesize_tests.rs` — happy-path injection, malformed-JSON and
 //! provider-error hard failure, numeric-guardrail rejection, greens-never-sent.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -31,6 +32,18 @@ use crate::report::synthesize_prompt::build_synthesis_prompt;
 
 /// Default wall-clock ceiling for one synthesis pass before failing closed.
 const DEFAULT_SYNTHESIS_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Filename an unparseable-response capture is written under, inside the
+/// configured [`Synthesizer::with_raw_capture_dir`] directory.
+///
+/// Why: #6009 — a live 4/4 repro against `anthropic/claude-opus-4.8` cost real
+/// OpenRouter spend to diagnose because the only evidence was a WARN log line;
+/// the response itself was gone by the time anyone looked. Persisting it next
+/// to the report output makes every future occurrence diagnosable for free.
+/// What: a fixed name (overwritten on each new failure — this is a diagnostic
+/// aid, not an audit trail) so operators know where to look without parsing a
+/// timestamp out of a WARN line.
+const UNPARSEABLE_CAPTURE_FILENAME: &str = "synthesis-unparseable-response.txt";
 
 /// The literal prefix every guardrail-rejection note carries, so the reporter and
 /// tests can assert on it.
@@ -192,6 +205,7 @@ pub struct Synthesizer {
     llm: Arc<dyn LlmProvider>,
     model: String,
     timeout: Duration,
+    raw_capture_dir: Option<PathBuf>,
 }
 
 impl Synthesizer {
@@ -199,13 +213,15 @@ impl Synthesizer {
     ///
     /// Why: the CLI builds the provider from the reviewer role config; tests
     /// inject stubs.
-    /// What: stores the provider + model with the default timeout.
+    /// What: stores the provider + model with the default timeout and no raw
+    /// capture directory (opt-in via [`with_raw_capture_dir`]).
     /// Test: exercised by every synthesize test.
     pub fn new(llm: Arc<dyn LlmProvider>, model: impl Into<String>) -> Self {
         Self {
             llm,
             model: model.into(),
             timeout: DEFAULT_SYNTHESIS_TIMEOUT,
+            raw_capture_dir: None,
         }
     }
 
@@ -213,6 +229,26 @@ impl Synthesizer {
     #[cfg(test)]
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
+        self
+    }
+
+    /// Opt in to persisting the raw provider response on an unparseable-
+    /// response failure (#6009).
+    ///
+    /// Why: the only prior evidence of an unparseable response was a WARN log
+    /// line with no body — a live 4/4 repro against `anthropic/claude-opus-4.8`
+    /// had to spend a fresh OpenRouter call just to see what the model actually
+    /// sent. The CLI wires this to the report's own output directory so the
+    /// evidence lands next to the report a failed run was trying to produce.
+    /// What: when set, [`Self::synthesize`] writes the scrubbed response text
+    /// to `<dir>/`[`UNPARSEABLE_CAPTURE_FILENAME`] the moment `parse_raw`
+    /// rejects it — before the guardrail or any retry — so the capture reflects
+    /// exactly what the provider sent. The directory is created if missing; a
+    /// write failure is logged and never escalated, since a diagnostic aid must
+    /// not itself turn a reportable error into a different one.
+    /// Test: `capture_dir_persists_raw_response_on_parse_failure`.
+    pub fn with_raw_capture_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.raw_capture_dir = Some(dir.into());
         self
     }
 
@@ -306,6 +342,7 @@ impl Synthesizer {
             Some(r) => r,
             None => {
                 warn!("synthesis: unparseable response");
+                self.capture_unparseable(&resp.text);
                 return Attempt::Failed(SynthesisError::Unparseable);
             }
         };
@@ -316,6 +353,39 @@ impl Synthesizer {
             "synthesis: provider call complete"
         );
         Attempt::Ok(raw)
+    }
+
+    /// Persist a scrubbed copy of an unparseable response, when a capture
+    /// directory was configured (#6009).
+    ///
+    /// Why: see [`Self::with_raw_capture_dir`]. A no-op when unset, which keeps
+    /// every existing test (none of which configure a capture dir) unaffected.
+    /// What: scrubs `text` against [`crate::report::redact::report_secrets`]
+    /// (the same needle set the `Provider` error path already uses) and writes
+    /// it to `<dir>/`[`UNPARSEABLE_CAPTURE_FILENAME`], creating the directory if
+    /// needed. Any I/O failure is logged at `warn` and swallowed — the
+    /// diagnostic write must never mask or replace the real
+    /// [`SynthesisError::Unparseable`] the caller already returns.
+    /// Test: `capture_dir_persists_raw_response_on_parse_failure`.
+    fn capture_unparseable(&self, text: &str) {
+        let Some(dir) = &self.raw_capture_dir else {
+            return;
+        };
+        let secrets = crate::report::redact::report_secrets();
+        let scrubbed = trusty_common::credentials::scrub_secrets(text, &secrets);
+        if let Err(e) = std::fs::create_dir_all(dir) {
+            warn!(error = %e, dir = %dir.display(), "synthesis: could not create raw-capture directory");
+            return;
+        }
+        let path = dir.join(UNPARSEABLE_CAPTURE_FILENAME);
+        match std::fs::write(&path, &scrubbed) {
+            Ok(()) => {
+                warn!(path = %path.display(), "synthesis: unparseable response captured for diagnosis")
+            }
+            Err(e) => {
+                warn!(error = %e, path = %path.display(), "synthesis: could not write raw-capture file")
+            }
+        }
     }
 }
 
@@ -346,11 +416,26 @@ struct RawSynthesis {
 ///
 /// Why: forced structured output returns a bare JSON object, but we still accept
 /// a fenced block (defensive, matching the profile synthesizer) so a provider
-/// that ignores the schema does not silently fail.
-/// What: tries a direct object parse, then a ```json fenced block; `None` when
-/// neither yields a decodable object.
+/// that ignores the schema does not silently fail.  #6009: a live 4/4 repro
+/// against `anthropic/claude-opus-4.8` showed a THIRD shape — `strict:true`
+/// `response_format` silently ignored end to end (200 OK, `finish_reason:
+/// "stop"`), with the model instead writing the system prompt's own `## Output`
+/// section labels back as literal markdown headings ("## Executive Summary",
+/// "## Top Risks", "## Findings") around free prose.  There is no JSON to
+/// recover there, but the executive-summary prose IS recoverable, and it still
+/// passes through the same numeric guardrail as a normal field — so it is
+/// worth recovering rather than discarding a run's only inference output.
+/// What: tries a direct object parse, then a ```json fenced block, then a
+/// markdown-heading fallback that recovers ONLY `executive_summary` (never
+/// `top_risks`/`findings` — reconstructing structured rows out of prose would
+/// mean inventing fields the model never actually populated, which is exactly
+/// what this parser must not do).  `None` when none of the three yields
+/// anything, so a response that is not even this fallback shape is still
+/// rejected as [`SynthesisError::Unparseable`].
 /// Test: `synthesize_tests.rs::{synthesize_happy_path_injects,
-/// synthesize_malformed_json_fails_closed}`.
+/// synthesize_malformed_json_fails_closed,
+/// synthesize_recovers_executive_summary_from_markdown_fallback,
+/// synthesize_markdown_fallback_rejects_response_with_no_heading}`.
 fn parse_raw(text: &str) -> Option<RawSynthesis> {
     let body = text.trim();
     if body.starts_with('{')
@@ -358,10 +443,83 @@ fn parse_raw(text: &str) -> Option<RawSynthesis> {
     {
         return Some(r);
     }
+    if let Some(r) = parse_fenced_json(body) {
+        return Some(r);
+    }
+    parse_markdown_fallback(body)
+}
+
+/// Parse a ```` ```json ````-fenced block, if one is present.
+///
+/// Why: split out of [`parse_raw`] so each fallback tier is independently
+/// readable and testable.
+/// What: finds the LAST `\`\`\`json` marker (defensive against a fence
+/// appearing earlier in reasoning/preamble text), then the next closing fence
+/// after it; `None` when either marker is absent or the enclosed text does not
+/// decode.
+/// Test: covered transitively via `parse_raw`'s own tests.
+fn parse_fenced_json(body: &str) -> Option<RawSynthesis> {
     let fence_start = body.rfind("```json")?;
     let after = &body[fence_start + 7..];
     let fence_end = after.find("```")?;
     serde_json::from_str::<RawSynthesis>(after[..fence_end].trim()).ok()
+}
+
+/// Recover an `executive_summary` from a markdown-headed free-text response
+/// (#6009) when the provider ignored the forced JSON schema entirely.
+///
+/// Why: see [`parse_raw`]'s doc comment. `top_risks` and `findings` are always
+/// left empty here — the deterministic composition (#5374) fills those
+/// placeholders, and the numeric guardrail still verifies whatever text is
+/// recovered before it reaches a reader.
+/// What: locates a line that is ONLY a markdown heading (`#`+ prefix) whose
+/// title matches "executive summary" case-insensitively, and takes every line
+/// up to the next heading (or end of input) as the summary body.  `None` when
+/// no such heading exists or its body is blank, so an unrelated free-text
+/// response (an error message, a refusal, a genuinely different shape) is
+/// still rejected rather than silently accepted.
+/// Test: `synthesize_recovers_executive_summary_from_markdown_fallback`,
+/// `synthesize_markdown_fallback_rejects_response_with_no_heading`.
+fn parse_markdown_fallback(text: &str) -> Option<RawSynthesis> {
+    let exec = heading_section(text, "executive summary")?;
+    if exec.is_empty() {
+        return None;
+    }
+    Some(RawSynthesis {
+        executive_summary: exec,
+        top_risks: Vec::new(),
+        findings: Vec::new(),
+    })
+}
+
+/// Return the trimmed line, minus a leading run of `#`, iff the line is
+/// nothing but a markdown heading marker.
+fn heading_title(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let title = trimmed.trim_start_matches('#');
+    // Require at least one '#' actually present, and a space (or end of
+    // line) after it — "#5454" in prose must never be misread as a heading.
+    if title.len() == trimmed.len() {
+        return None;
+    }
+    let title = title.trim();
+    (!title.is_empty()).then_some(title)
+}
+
+/// Extract the body text between a heading whose title matches `wanted`
+/// (case-insensitively) and the next heading line, or end of input.
+fn heading_section(text: &str, wanted: &str) -> Option<String> {
+    let lines: Vec<&str> = text.lines().collect();
+    let start = lines
+        .iter()
+        .position(|l| heading_title(l).is_some_and(|t| t.eq_ignore_ascii_case(wanted)))?;
+    let body: Vec<&str> = lines[start + 1..]
+        .iter()
+        .take_while(|l| heading_title(l).is_none())
+        .copied()
+        .collect();
+    let joined = body.join("\n").trim().to_string();
+    (!joined.is_empty()).then_some(joined)
 }
 
 /// Apply the numeric guardrail to the raw synthesis, field by field.

--- a/crates/trusty-review/src/report/synthesize.rs
+++ b/crates/trusty-review/src/report/synthesize.rs
@@ -128,35 +128,35 @@ pub enum SynthesisError {
 
 /// One synthesized top-risk table row (rationale for the Top Risks table).
 ///
-/// Why: #6009 shape 2 — a live capture against `anthropic/claude-opus-4.8`
-/// returned valid top-level JSON, but every `top_risks` item used drifted
-/// field names (`risk` for `description`, `applications` for `apps`) and
-/// omitted `severity`/`cost` entirely, so `serde_json::from_str::<RawSynthesis>`
-/// failed on the whole response and the run was classified `Unparseable` even
-/// though the risk content itself was present and verifiable.
-/// What: `description`/`apps` accept the drifted names via `#[serde(alias)]`
-/// (still SERIALIZED under their canonical names — the JSON twin on
-/// [`ReportModel`] is unaffected). `severity`/`cost` default to `""` when the
-/// provider omits them; the reporter renders an empty value as the honesty
-/// marker (`not stated in source data`), never a fabricated band or figure —
-/// see `reporter.rs::inject_synthesis_summary`.
-/// Test: `synthesize_tests.rs::parse_raw_recovers_shape2_field_name_drift`,
+/// Why: three consecutive live calls against `anthropic/claude-opus-4.8`
+/// (#6009) returned three different `top_risks` field-name shapes —
+/// canonical, `risk`/`applications` (shape 2), and
+/// `risk`/`cost_effort_framing`/`affected_applications` (shape 3). Field-name
+/// recovery now happens once, upstream, in
+/// [`crate::report::synthesize_normalize`] — a whitelist synonym table that
+/// runs before `serde_json::from_value` — rather than as a per-shape
+/// `#[serde(alias)]` here, which can never converge on a model that renames
+/// fields differently on every call.
+/// What: `severity`/`cost` still default to `""` when the provider omits them
+/// (observed in shapes 2 and 3); the reporter renders an empty value as the
+/// honesty marker (`not stated in source data`), never a fabricated band or
+/// figure — see `reporter.rs::inject_synthesis_summary`.
+/// Test: `synthesize_tests.rs::{parse_raw_recovers_shape2_field_name_drift,
+/// parse_raw_recovers_shape3_field_name_drift}`,
 /// `reporter_tests.rs::reporter_renders_defaulted_top_risk_severity_honestly`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RiskRow {
     /// Risk description.
-    #[serde(alias = "risk")]
     pub description: String,
     /// Severity band (`RED`/`AMBER`), or `""` when the provider omitted it
-    /// (#6009 shape 2) — never fabricated.
+    /// (#6009 shapes 2/3) — never fabricated.
     #[serde(default)]
     pub severity: String,
     /// Qualitative cost/effort framing, or `""` when the provider omitted it
-    /// (#6009 shape 2) — never fabricated.
+    /// (#6009 shapes 2/3) — never fabricated.
     #[serde(default)]
     pub cost: String,
     /// Affected application(s).
-    #[serde(alias = "applications")]
     pub apps: String,
 }
 
@@ -313,11 +313,11 @@ impl Synthesizer {
         };
 
         match self.try_once(model, false).await {
-            Attempt::Ok(raw) => apply_guardrail(raw, &allowed),
+            Attempt::Ok(raw, norm_notes) => apply_guardrail(raw, &allowed, norm_notes),
             Attempt::Truncated => {
                 warn!("synthesis: response truncated — retrying once, concise");
                 match self.try_once(model, true).await {
-                    Attempt::Ok(raw) => apply_guardrail(raw, &allowed),
+                    Attempt::Ok(raw, norm_notes) => apply_guardrail(raw, &allowed, norm_notes),
                     // #5454: the retry is unchanged; only its exhaustion is now fatal.
                     Attempt::Truncated => {
                         warn!("synthesis: still truncated after retry");
@@ -359,7 +359,7 @@ impl Synthesizer {
             return Attempt::Truncated;
         }
 
-        let raw = match parse_raw(&resp.text) {
+        let (raw, norm_notes) = match parse_raw(&resp.text) {
             Some(r) => r,
             None => {
                 warn!("synthesis: unparseable response");
@@ -373,7 +373,7 @@ impl Synthesizer {
             output_tokens = resp.output_tokens,
             "synthesis: provider call complete"
         );
-        Attempt::Ok(raw)
+        Attempt::Ok(raw, norm_notes)
     }
 
     /// Persist a scrubbed copy of an unparseable response, when a capture
@@ -412,8 +412,10 @@ impl Synthesizer {
 
 /// The outcome of one provider call attempt (pre-guardrail).
 enum Attempt {
-    /// Parsed cleanly; carries the raw (pre-guardrail) synthesis.
-    Ok(RawSynthesis),
+    /// Parsed cleanly; carries the raw (pre-guardrail) synthesis plus any
+    /// normalization notes recorded while resolving field-name drift (#6009
+    /// shape 3 — see [`crate::report::synthesize_normalize`]).
+    Ok(RawSynthesis, Vec<String>),
     /// The response was truncated at the output-token ceiling.
     Truncated,
     /// A provider/timeout/parse error — not a truncation.
@@ -433,47 +435,71 @@ struct RawSynthesis {
     findings: Vec<FindingProse>,
 }
 
-/// Parse the provider response into [`RawSynthesis`].
+/// Parse the provider response into [`RawSynthesis`] plus any normalization
+/// notes recorded while resolving field-name drift.
 ///
 /// Why: forced structured output returns a bare JSON object, but we still accept
 /// a fenced block (defensive, matching the profile synthesizer) so a provider
-/// that ignores the schema does not silently fail.  #6009: a live 4/4 repro
-/// against `anthropic/claude-opus-4.8` showed a THIRD shape — `strict:true`
-/// `response_format` silently ignored end to end (200 OK, `finish_reason:
-/// "stop"`), with the model instead writing the system prompt's own `## Output`
-/// section labels back as literal markdown headings ("## Executive Summary",
-/// "## Top Risks", "## Findings") around free prose.  There is no JSON to
-/// recover there, but the executive-summary prose IS recoverable, and it still
-/// passes through the same numeric guardrail as a normal field — so it is
-/// worth recovering rather than discarding a run's only inference output.
-/// What: tries a direct object parse, then a ```json fenced block, then a
-/// markdown-heading fallback that recovers ONLY `executive_summary` (never
-/// `top_risks`/`findings` — reconstructing structured rows out of prose would
-/// mean inventing fields the model never actually populated, which is exactly
-/// what this parser must not do).  `None` when none of the three yields
-/// anything, so a response that is not even this fallback shape is still
-/// rejected as [`SynthesisError::Unparseable`].  A FOURTH shape (#6009 shape
-/// 2) needs no fallback tier of its own: a live capture returned valid
-/// top-level JSON but drifted `top_risks` field names (`risk`/`applications`
-/// for `description`/`apps`, `severity`/`cost` omitted) — [`RiskRow`]'s
-/// `#[serde(alias)]`/`#[serde(default)]` attributes absorb that at the first
-/// (direct-object) tier, so it never falls through to here.
+/// that ignores the schema does not silently fail.  #6009: three consecutive
+/// live calls against `anthropic/claude-opus-4.8` produced three different
+/// shapes — pure markdown prose (shape 1), valid JSON with `top_risks` fields
+/// renamed to `risk`/`applications` (shape 2), and valid JSON renamed to
+/// `risk`/`cost_effort_framing`/`affected_applications` (shape 3).
+/// `response_format: json_schema` is best-effort for Anthropic-family models —
+/// there is no native strict-JSON mode, so OpenRouter forwards but cannot
+/// enforce the shape — and per-shape `#[serde(alias)]` additions can never
+/// converge on a model that renames fields differently on every call.
+/// What: tries a direct object parse, then a ```json fenced block — both
+/// routed through [`parse_json_object`], which normalizes known field-name
+/// synonyms (shapes 2/3) via [`crate::report::synthesize_normalize`] BEFORE
+/// typed deserialization — then a markdown-heading fallback (shape 1) that
+/// recovers ONLY `executive_summary` (never `top_risks`/`findings` —
+/// reconstructing structured rows out of prose would mean inventing fields
+/// the model never actually populated, which is exactly what this parser
+/// must not do).  `None` when none of the three yields anything, so a
+/// response that is not even this fallback shape is still rejected as
+/// [`SynthesisError::Unparseable`].
 /// Test: `synthesize_tests.rs::{synthesize_happy_path_injects,
 /// synthesize_malformed_json_fails_closed,
 /// synthesize_recovers_executive_summary_from_markdown_fallback,
 /// synthesize_markdown_fallback_rejects_response_with_no_heading,
-/// parse_raw_recovers_shape2_field_name_drift}`.
-fn parse_raw(text: &str) -> Option<RawSynthesis> {
+/// parse_raw_recovers_shape2_field_name_drift,
+/// parse_raw_recovers_shape3_field_name_drift,
+/// parse_raw_rejects_a_wholly_unrecognized_shape}`.
+fn parse_raw(text: &str) -> Option<(RawSynthesis, Vec<String>)> {
     let body = text.trim();
     if body.starts_with('{')
-        && let Ok(r) = serde_json::from_str::<RawSynthesis>(body)
+        && let Some(result) = parse_json_object(body)
     {
-        return Some(r);
+        return Some(result);
     }
-    if let Some(r) = parse_fenced_json(body) {
-        return Some(r);
+    if let Some(result) = parse_fenced_json(body) {
+        return Some(result);
     }
-    parse_markdown_fallback(body)
+    parse_markdown_fallback(body).map(|r| (r, Vec::new()))
+}
+
+/// Parse one JSON object into [`RawSynthesis`], normalizing known field-name
+/// synonyms first.
+///
+/// Why: split out so both the direct-object and fenced-block tiers share the
+/// exact same normalize-then-deserialize path — a synonym recognised at one
+/// tier is recognised at the other.
+/// What: parses `body` as a [`serde_json::Value`], runs
+/// [`crate::report::synthesize_normalize::normalize_raw_synthesis`], then
+/// deserializes the normalized value into [`RawSynthesis`]. `None` when
+/// `body` is not valid JSON or the normalized shape still does not match —
+/// a wholly unrecognised shape (every key dropped by the whitelist) still
+/// deserializes to an empty [`RawSynthesis`], which the numeric guardrail
+/// then rejects as [`SynthesisError::NoVerifiableContent`] rather than this
+/// function silently accepting it as content.
+/// Test: `synthesize_tests.rs::parse_raw_recovers_shape3_field_name_drift`.
+fn parse_json_object(body: &str) -> Option<(RawSynthesis, Vec<String>)> {
+    let mut value: serde_json::Value = serde_json::from_str(body).ok()?;
+    let mut notes = Vec::new();
+    super::synthesize_normalize::normalize_raw_synthesis(&mut value, &mut notes);
+    let raw: RawSynthesis = serde_json::from_value(value).ok()?;
+    Some((raw, notes))
 }
 
 /// Parse a ```` ```json ````-fenced block, if one is present.
@@ -483,13 +509,13 @@ fn parse_raw(text: &str) -> Option<RawSynthesis> {
 /// What: finds the LAST `\`\`\`json` marker (defensive against a fence
 /// appearing earlier in reasoning/preamble text), then the next closing fence
 /// after it; `None` when either marker is absent or the enclosed text does not
-/// decode.
+/// decode via [`parse_json_object`].
 /// Test: covered transitively via `parse_raw`'s own tests.
-fn parse_fenced_json(body: &str) -> Option<RawSynthesis> {
+fn parse_fenced_json(body: &str) -> Option<(RawSynthesis, Vec<String>)> {
     let fence_start = body.rfind("```json")?;
     let after = &body[fence_start + 7..];
     let fence_end = after.find("```")?;
-    serde_json::from_str::<RawSynthesis>(after[..fence_end].trim()).ok()
+    parse_json_object(after[..fence_end].trim())
 }
 
 /// Recover an `executive_summary` from a markdown-headed free-text response
@@ -559,7 +585,11 @@ fn heading_section(text: &str, wanted: &str) -> Option<String> {
 /// deterministic-only report.
 /// What: verifies the executive summary and every risk row / finding against
 /// `allowed`; keeps only clean fields.  Findings must carry a RED/AMBER severity
-/// (defence-in-depth greens exclusion).  `Ok` iff at least one field survived.
+/// (defence-in-depth greens exclusion).  `seed_notes` (the normalization
+/// drop-notes recorded by [`crate::report::synthesize_normalize`], #6009 shape
+/// 3) are recorded first, so an unrecognized-field drop is visible in the
+/// rendered status lines alongside a numeric-guardrail rejection.  `Ok` iff at
+/// least one field survived.
 ///
 /// # Errors
 ///
@@ -570,8 +600,12 @@ fn heading_section(text: &str, wanted: &str) -> Option<String> {
 fn apply_guardrail(
     raw: RawSynthesis,
     allowed: &std::collections::HashSet<String>,
+    seed_notes: Vec<String>,
 ) -> Result<Synthesis, SynthesisError> {
-    let mut out = Synthesis::default();
+    let mut out = Synthesis {
+        notes: seed_notes,
+        ..Synthesis::default()
+    };
 
     // Executive summary.
     let exec = raw.executive_summary.trim();

--- a/crates/trusty-review/src/report/synthesize_normalize.rs
+++ b/crates/trusty-review/src/report/synthesize_normalize.rs
@@ -1,0 +1,218 @@
+//! Whitelist-based synonym normalization for the raw synthesis JSON response
+//! (#6009 shape 3).
+//!
+//! Why: three consecutive live calls to `anthropic/claude-opus-4.8` via
+//! OpenRouter, all with `response_format: json_schema` and `strict: true`,
+//! produced three different shapes for `top_risks`: `description`/`apps`
+//! (canonical), `risk`/`applications` (shape 2), and
+//! `risk`/`cost_effort_framing`/`affected_applications` (shape 3, captured at
+//! `synthesis-unparseable-response.txt`). `response_format` is best-effort for
+//! Anthropic-family models — Anthropic's own API has no native strict-JSON
+//! mode, so OpenRouter forwards the request but cannot enforce the shape, and
+//! per-shape `#[serde(alias)]` additions can never converge on a model that
+//! renames fields differently on every call. Renaming known synonyms onto
+//! their canonical name BEFORE serde ever sees the JSON — one table of
+//! accepted synonyms per field, instead of one alias attribute per drifted
+//! shape — is the class fix. The table is whitelist-based: a key this table
+//! has never seen is DROPPED (never guessed onto the nearest-looking
+//! canonical name), and the drop is recorded so a reader can see exactly what
+//! was lost.
+//! What: [`normalize_raw_synthesis`] walks the top-level object and the
+//! `top_risks`/`findings` arrays, renaming any recognised synonym key onto
+//! its canonical name and removing (with a note) any key that is neither
+//! canonical nor a recognised synonym.
+//! Test: `synthesize_tests.rs::{parse_raw_recovers_shape3_field_name_drift,
+//! parse_raw_recovers_shape2_field_name_drift,
+//! parse_raw_rejects_a_wholly_unrecognized_shape,
+//! normalize_drops_unrecognized_field_with_note,
+//! normalize_prefers_canonical_over_synonym_when_both_present}`.
+
+use std::collections::HashSet;
+
+use serde_json::{Map, Value};
+
+/// One canonical field name plus every accepted synonym for it.
+type FieldTable = &'static [(&'static str, &'static [&'static str])];
+
+/// Top-level `RawSynthesis` fields. No drift has been observed here across
+/// all three #6009 shapes — listed anyway so an unrecognised top-level key is
+/// dropped (and noted) rather than silently retained by serde's default
+/// unknown-field tolerance.
+const TOP_LEVEL_FIELDS: FieldTable = &[
+    ("executive_summary", &[]),
+    ("top_risks", &[]),
+    ("findings", &[]),
+];
+
+/// `top_risks` row fields. Synonyms are the exact drifted names observed in
+/// the three live #6009 captures: shape 2 used `risk`/`applications`; shape 3
+/// used `risk`/`cost_effort_framing`/`affected_applications`.
+const RISK_ROW_FIELDS: FieldTable = &[
+    ("description", &["risk"]),
+    ("severity", &[]),
+    ("cost", &["cost_effort_framing"]),
+    ("apps", &["applications", "affected_applications"]),
+];
+
+/// `findings` row fields. No drift observed yet — listed so the mechanism is
+/// symmetric and ready the moment a shape drifts here too.
+const FINDING_ROW_FIELDS: FieldTable = &[
+    ("app_slug", &[]),
+    ("title", &[]),
+    ("severity", &[]),
+    ("description", &[]),
+    ("evidence", &[]),
+    ("component", &[]),
+    ("business_impact", &[]),
+    ("remediation", &[]),
+    ("cost_effort", &[]),
+];
+
+/// Normalize the raw synthesis JSON value in place: rename synonyms onto
+/// canonical field names, drop anything else, and record every drop.
+///
+/// Why: runs BEFORE `serde_json::from_value` so a drifted-but-recognised
+/// shape parses cleanly through the ordinary typed path, and a wholly
+/// unrecognised shape is left with nothing to deserialize into content —
+/// still rejected downstream by the numeric guardrail's
+/// `NoVerifiableContent`, never silently accepted.
+/// What: normalizes the top-level object against [`TOP_LEVEL_FIELDS`], then
+/// each `top_risks`/`findings` array item against [`RISK_ROW_FIELDS`] /
+/// [`FINDING_ROW_FIELDS`]. A no-op when `value` is not a JSON object.
+/// Test: `synthesize_tests.rs::parse_raw_recovers_shape3_field_name_drift`.
+pub(super) fn normalize_raw_synthesis(value: &mut Value, notes: &mut Vec<String>) {
+    let Some(obj) = value.as_object_mut() else {
+        return;
+    };
+    normalize_object(obj, TOP_LEVEL_FIELDS, "top level", notes);
+    normalize_rows(obj, "top_risks", RISK_ROW_FIELDS, notes);
+    normalize_rows(obj, "findings", FINDING_ROW_FIELDS, notes);
+}
+
+/// Normalize every object item of the array at `key`, if present.
+fn normalize_rows(
+    obj: &mut Map<String, Value>,
+    key: &str,
+    fields: FieldTable,
+    notes: &mut Vec<String>,
+) {
+    let Some(items) = obj.get_mut(key).and_then(Value::as_array_mut) else {
+        return;
+    };
+    for (i, item) in items.iter_mut().enumerate() {
+        if let Some(row) = item.as_object_mut() {
+            normalize_object(row, fields, &format!("{key} row {}", i + 1), notes);
+        }
+    }
+}
+
+/// Rename recognised synonyms onto their canonical key, then drop (with a
+/// note) any key still not in `fields`' canonical set.
+///
+/// Why: whitelist-based — a key survives ONLY as the canonical name or a
+/// synonym this table already lists. This is what keeps normalization from
+/// ever guessing: a field name none of the three live shapes produced is
+/// dropped, not mapped onto the closest-looking canonical field.
+/// What: for each canonical name absent from `obj`, takes the value from the
+/// first present synonym (if any). Afterward, any key not in the canonical
+/// set — including a synonym left over because the canonical name was
+/// ALREADY present — is removed and appended to `notes`.
+fn normalize_object(
+    obj: &mut Map<String, Value>,
+    fields: FieldTable,
+    context: &str,
+    notes: &mut Vec<String>,
+) {
+    for (canonical, synonyms) in fields {
+        if obj.contains_key(*canonical) {
+            continue;
+        }
+        for syn in *synonyms {
+            if let Some(v) = obj.remove(*syn) {
+                obj.insert((*canonical).to_string(), v);
+                break;
+            }
+        }
+    }
+
+    let canonical_names: HashSet<&str> = fields.iter().map(|(c, _)| *c).collect();
+    let unknown: Vec<String> = obj
+        .keys()
+        .filter(|k| !canonical_names.contains(k.as_str()))
+        .cloned()
+        .collect();
+    for k in unknown {
+        obj.remove(&k);
+        notes.push(format!(
+            "synthesis: dropped unrecognized field '{k}' in {context}"
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: a synonym must rename onto the canonical key so the typed parse
+    /// downstream sees the field it expects.
+    /// What: `risk` → `description`, `affected_applications` → `apps`.
+    /// Test: this test itself.
+    #[test]
+    fn normalize_renames_recognised_synonyms() {
+        let mut value = serde_json::json!({
+            "executive_summary": "x",
+            "top_risks": [{"risk": "r1", "affected_applications": "a1"}],
+            "findings": []
+        });
+        let mut notes = Vec::new();
+        normalize_raw_synthesis(&mut value, &mut notes);
+        assert_eq!(value["top_risks"][0]["description"], "r1");
+        assert_eq!(value["top_risks"][0]["apps"], "a1");
+        assert!(value["top_risks"][0].get("risk").is_none());
+        assert!(value["top_risks"][0].get("affected_applications").is_none());
+        assert!(notes.is_empty(), "recognised synonyms record no notes");
+    }
+
+    /// Why: a field name none of the three live shapes ever produced must be
+    /// dropped, never guessed onto a canonical field — the whitelist
+    /// discipline the class fix depends on.
+    /// What: an invented key `confidence_score` is removed and noted.
+    /// Test: this test itself.
+    #[test]
+    fn normalize_drops_unrecognized_field_with_note() {
+        let mut value = serde_json::json!({
+            "executive_summary": "x",
+            "top_risks": [{"description": "r1", "apps": "a1", "confidence_score": 0.9}],
+            "findings": []
+        });
+        let mut notes = Vec::new();
+        normalize_raw_synthesis(&mut value, &mut notes);
+        assert!(value["top_risks"][0].get("confidence_score").is_none());
+        assert!(
+            notes
+                .iter()
+                .any(|n| n.contains("confidence_score") && n.contains("top_risks row 1")),
+            "unrecognized field must be dropped with a note: {notes:?}"
+        );
+    }
+
+    /// Why: when both the canonical name and a synonym are present, the
+    /// canonical value must win and the stray synonym must be dropped rather
+    /// than silently overwriting it.
+    /// What: `description` present alongside `risk`; asserts `description`
+    /// keeps its own value and `risk` is dropped with a note.
+    /// Test: this test itself.
+    #[test]
+    fn normalize_prefers_canonical_over_synonym_when_both_present() {
+        let mut value = serde_json::json!({
+            "executive_summary": "x",
+            "top_risks": [{"description": "canonical", "risk": "synonym", "apps": "a1"}],
+            "findings": []
+        });
+        let mut notes = Vec::new();
+        normalize_raw_synthesis(&mut value, &mut notes);
+        assert_eq!(value["top_risks"][0]["description"], "canonical");
+        assert!(value["top_risks"][0].get("risk").is_none());
+        assert!(notes.iter().any(|n| n.contains("risk")));
+    }
+}

--- a/crates/trusty-review/src/report/synthesize_prompt.rs
+++ b/crates/trusty-review/src/report/synthesize_prompt.rs
@@ -21,10 +21,19 @@
 //! forced [`ResponseSchema`]).  `retry_concise` shrinks the schema's `top_risks`
 //! cap and asks for a shorter paragraph — the same one-shot truncation-retry
 //! shape used by the wave-3 batch investigation.  The `bedrock/`/`openrouter/`
-//! routing prefix is stripped so the bare id reaches the provider API.
+//! routing prefix is stripped so the bare id reaches the provider API.  #6009
+//! shape 3: [`schema_contract_statement`] renders the required field names
+//! and a canonical example object directly from the same [`ResponseSchema`]
+//! value forced via `response_format`, and embeds that text in the system
+//! prompt itself — `response_format` is best-effort for Anthropic-family
+//! models (no native strict-JSON mode; OpenRouter forwards but cannot
+//! enforce), so the field names are also stated where a model that ignores
+//! the schema entirely will still read them.
 //! Test: `synthesize_tests.rs` asserts schema shape, that greens are absent from
 //! the digest, that the prefix is stripped, the compact-digest cap/overflow
-//! behaviour, and the layered-instruction override precedence.
+//! behaviour, the layered-instruction override precedence, and that the
+//! derived contract statement names every field and reaches the system
+//! prompt.
 
 use crate::llm::{ChatMessage, LlmRequest, ResponseSchema, strip_provider_prefix};
 use crate::report::model::ReportModel;
@@ -121,6 +130,72 @@ pub(crate) fn synthesis_schema(top_risks_cap: usize) -> ResponseSchema {
     )
 }
 
+/// Render a deterministic statement of the required JSON shape directly from
+/// the schema's own field names, for embedding in the prompt TEXT itself
+/// (#6009 shape 3).
+///
+/// Why: `response_format: json_schema` (even `strict: true`) is best-effort
+/// for Anthropic-family models routed through OpenRouter — Anthropic's API
+/// has no native strict-JSON mode, so a live 3/3 repro against
+/// `anthropic/claude-opus-4.8` produced three different response shapes on
+/// three consecutive calls with the identical `response_schema` attached: pure
+/// markdown (no JSON at all), then two rounds of `top_risks` field-name
+/// drift. `response_format` alone cannot be trusted to reach a model that
+/// ignores it; stating the exact contract in the prompt's own text is a
+/// second, independent path to the same field names — and generating that
+/// text FROM `schema` (rather than a hand-typed string beside it) is what
+/// keeps the two from silently drifting apart, since [`synthesis_schema`] is
+/// the only place either originates.
+/// What: walks `schema`'s top-level `properties`; for a scalar property
+/// (`executive_summary`) states its name, for an array-of-objects property
+/// (`top_risks`, `findings`) lists its item field names, then appends one
+/// compact canonical-shape example object built the same way. Property
+/// iteration order is [`serde_json::Map`]'s default (`BTreeMap`, this
+/// workspace does not enable `preserve_order`) — alphabetical and stable run
+/// to run.
+/// Test: `synthesize_tests.rs::{schema_contract_statement_lists_every_field_name,
+/// schema_contract_statement_reaches_system_prompt}`.
+pub(crate) fn schema_contract_statement(schema: &serde_json::Value) -> String {
+    let Some(props) = schema["properties"].as_object() else {
+        return String::new();
+    };
+    let mut lines = String::from("Required JSON object shape — use EXACTLY these field names:\n");
+    let mut example = serde_json::Map::new();
+
+    for (name, def) in props {
+        match def["items"]["properties"].as_object() {
+            Some(item_props) => {
+                let field_names: Vec<&str> = item_props.keys().map(String::as_str).collect();
+                lines.push_str(&format!(
+                    "- `{name}`: array of objects, each with fields: {}\n",
+                    field_names.join(", ")
+                ));
+                let mut item_example = serde_json::Map::new();
+                for f in &field_names {
+                    item_example.insert(
+                        (*f).to_string(),
+                        serde_json::Value::String(format!("<{f}>")),
+                    );
+                }
+                example.insert(
+                    name.clone(),
+                    serde_json::Value::Array(vec![serde_json::Value::Object(item_example)]),
+                );
+            }
+            None => {
+                lines.push_str(&format!("- `{name}`: string\n"));
+                example.insert(name.clone(), serde_json::Value::String(format!("<{name}>")));
+            }
+        }
+    }
+
+    lines.push_str(&format!(
+        "\nExample shape (field names only — write your own content, never copy these placeholder values):\n{}\n",
+        serde_json::to_string(&serde_json::Value::Object(example)).unwrap_or_default()
+    ));
+    lines
+}
+
 /// The synthesis system prompt, built from the resolved (layered) section
 /// instructions.
 ///
@@ -130,11 +205,15 @@ pub(crate) fn synthesis_schema(top_risks_cap: usize) -> ResponseSchema {
 /// template or analyst may steer — see [`section_instructions`] for the
 /// generic → template → analyst layering (the same shape as the crate's
 /// existing stock → principles → voice reviewer layering, see `src/voice/`).
-/// What: the "Absolute rules" and "Coverage gaps in the assessed set" blocks
-/// are static invariants; the "Output" section embeds
-/// `resolved[EXECUTIVE_SUMMARY]` / `resolved[TOP_RISKS]` /
-/// `resolved[FINDING_ELABORATION]` verbatim.  `retry_concise` appends a
-/// directive to shorten the response (used on the one truncation retry).
+/// What: the "Absolute rules", "Required JSON object shape", and "Coverage
+/// gaps in the assessed set" blocks are static invariants; the "Required JSON
+/// object shape" block is `contract` — [`schema_contract_statement`] run over
+/// the SAME [`synthesis_schema`] value this request forces via
+/// `response_format`, so the two can never say different things (#6009 shape
+/// 3). The "Output" section embeds `resolved[EXECUTIVE_SUMMARY]` /
+/// `resolved[TOP_RISKS]` / `resolved[FINDING_ELABORATION]` verbatim.
+/// `retry_concise` appends a directive to shorten the response (used on the
+/// one truncation retry).
 ///
 /// The coverage-gaps block is static rather than a fourth section instruction
 /// because a template that overrides `executive_summary` would otherwise drop
@@ -145,10 +224,12 @@ pub(crate) fn synthesis_schema(top_risks_cap: usize) -> ResponseSchema {
 /// [`super::investigate::render::coverage_prompt_summary`] already mandates.
 /// Test: `synthesize_tests.rs::{system_prompt_embeds_resolved_instructions,
 /// system_prompt_concise_retry_directive,
-/// system_prompt_asks_for_unregistered_target_gaps}`.
+/// system_prompt_asks_for_unregistered_target_gaps,
+/// schema_contract_statement_reaches_system_prompt}`.
 fn synthesis_system_prompt(
     resolved: &std::collections::BTreeMap<String, String>,
     retry_concise: bool,
+    contract: &str,
 ) -> String {
     let exec = resolved
         .get(EXECUTIVE_SUMMARY)
@@ -172,6 +253,9 @@ fn synthesis_system_prompt(
 - Write prose for RED and AMBER findings ONLY. Do not mention, elaborate, or infer GREEN/positive findings — none are provided, and none should appear.
 - Be concise, specific, and deal-relevant: what an acquirer must act on.
 - Every finding field is structurally required. Emit an empty string for any you have nothing grounded to say in — never fill one with invented content.
+
+## Required JSON object shape
+Respond with ONLY a single JSON object — no markdown headings, no prose outside it, no fenced code block. {contract}
 
 ## Coverage gaps in the assessed set
 - The applications listed under "Applications assessed" are the ENTIRE assessed set. When the data references a repository, service, database schema, or project board that is not one of them, name it in a short coverage-gaps note closing the executive summary.
@@ -222,16 +306,21 @@ pub(super) fn build_synthesis_prompt(
     } else {
         TOP_RISKS_CAP
     };
+    // #6009 shape 3: built from the SAME schema value forced via
+    // `response_format` below, so the prompt-text contract and the schema can
+    // never say different things — see `schema_contract_statement`.
+    let schema = synthesis_schema(top_risks_cap);
+    let contract = schema_contract_statement(&schema.schema);
     LlmRequest {
         model: strip_provider_prefix(llm_model).to_string(),
-        system: synthesis_system_prompt(&resolved, retry_concise),
+        system: synthesis_system_prompt(&resolved, retry_concise, &contract),
         messages: vec![ChatMessage {
             role: "user".to_string(),
             content: build_digest(model),
         }],
         temperature: SYNTHESIS_TEMPERATURE,
         max_tokens: SYNTHESIS_MAX_TOKENS,
-        response_schema: Some(synthesis_schema(top_risks_cap)),
+        response_schema: Some(schema),
     }
 }
 

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -726,3 +726,143 @@ fn status_lines_render_banners() {
     assert_eq!(lines[0], "synthesis: available");
     assert_eq!(lines[1], syn.notes[0]);
 }
+
+// ── #6009: markdown-heading fallback + raw-capture regression ──────────────
+
+/// A faithful reconstruction of the live 4/4 repro captured against
+/// `anthropic/claude-opus-4.8` (#6009): `strict:true` `response_format` was
+/// silently ignored (200 OK, `finish_reason: "stop"`) and the model wrote the
+/// system prompt's own `## Output` field labels back as markdown headings
+/// around free prose instead of the requested JSON object. The figures here
+/// (8,200 / 120 / 640) are the fixture model's allowed set, so the recovered
+/// text exercises the numeric guardrail rather than bypassing it.
+fn markdown_fallback_response() -> String {
+    "## Executive Summary\n\n\
+     The 8,200 LoC Rust codebase spans 120 files and 640 functions with one \
+     critical security gap that must be remediated before close.\n\n\
+     ## Top Risks\n\n\
+     No RED or AMBER risks were identified in the provided data.\n\n\
+     ## Findings\n\n\
+     No findings require elaboration.\n"
+        .to_string()
+}
+
+/// Why: #6009 — before this fix, `parse_raw` had no fallback for a schema the
+/// provider ignored entirely, so this exact live shape hard-failed the whole
+/// due-diligence run as `Unparseable` with a real finding count sitting
+/// unused behind it. RED against pre-fix `parse_raw` (no markdown fallback),
+/// GREEN after.
+/// What: recovers `executive_summary` from the markdown-headed response;
+/// `top_risks`/`findings` stay empty (never reconstructed from prose).
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_recovers_executive_summary_from_markdown_fallback() {
+    let model = fixture_model(vec![red("x")]);
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body: markdown_fallback_response(),
+        finish_reason: Some("stop".to_string()),
+    });
+    let result = Synthesizer::new(llm, "stub/model")
+        .synthesize(&model)
+        .await
+        .expect("the markdown fallback must recover a usable executive summary");
+
+    assert_eq!(
+        result.executive_summary.as_deref(),
+        Some(
+            "The 8,200 LoC Rust codebase spans 120 files and 640 functions with one \
+             critical security gap that must be remediated before close."
+        )
+    );
+    assert!(
+        result.top_risks.is_empty(),
+        "prose is never reconstructed into risk rows"
+    );
+    assert!(
+        result.findings.is_empty(),
+        "prose is never reconstructed into findings"
+    );
+    assert!(
+        result.notes.is_empty(),
+        "a clean recovered summary records no notes"
+    );
+}
+
+/// Why: the fallback must not turn every unparseable response into a silent
+/// pass — a genuinely different shape (no heading at all, e.g. a refusal or
+/// an error string) must still fail closed exactly like today.
+/// What: a response with no `## Executive Summary` heading; asserts
+/// `Err(SynthesisError::Unparseable)`.
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_markdown_fallback_rejects_response_with_no_heading() {
+    let model = fixture_model(vec![red("x")]);
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body: "I'm unable to provide a structured response for this request.".to_string(),
+        finish_reason: Some("stop".to_string()),
+    });
+    let err = Synthesizer::new(llm, "stub/model")
+        .synthesize(&model)
+        .await
+        .expect_err("a headingless response must not be silently accepted");
+    assert!(
+        matches!(err, SynthesisError::Unparseable),
+        "expected Unparseable, got {err:?}"
+    );
+}
+
+/// Why: recovering the markdown fallback text must not create a second path
+/// around the numeric guardrail — a fabricated figure in the recovered
+/// executive summary must be rejected exactly like a fabricated figure in a
+/// normal JSON response.
+/// What: the heading is present, but the body cites `999` — absent from the
+/// fixture model's allowed set — so nothing survives and the whole pass fails
+/// as `NoVerifiableContent`.
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_markdown_fallback_still_applies_numeric_guardrail() {
+    let model = fixture_model(vec![red("x")]);
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body: "## Executive Summary\n\n999 critical vulnerabilities were found.\n".to_string(),
+        finish_reason: Some("stop".to_string()),
+    });
+    let err = Synthesizer::new(llm, "stub/model")
+        .synthesize(&model)
+        .await
+        .expect_err("a fabricated figure recovered via the fallback must still be rejected");
+    assert!(
+        matches!(err, SynthesisError::NoVerifiableContent),
+        "expected NoVerifiableContent, got {err:?}"
+    );
+}
+
+/// Why: #6009 — the only prior evidence of an unparseable response was a WARN
+/// log line with no body; a live repro had to spend a fresh OpenRouter call to
+/// see what the model actually sent. This proves the capture wiring writes
+/// that evidence to disk instead.
+/// What: configures a capture directory, sends a response with no recoverable
+/// heading, and asserts both the hard failure AND the persisted file.
+/// Test: this test itself.
+#[tokio::test]
+async fn capture_dir_persists_raw_response_on_parse_failure() {
+    let model = fixture_model(vec![red("x")]);
+    let body = "totally free text with no JSON and no recognised heading".to_string();
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body: body.clone(),
+        finish_reason: Some("stop".to_string()),
+    });
+    let dir = tempfile::tempdir().expect("tempdir");
+    let err = Synthesizer::new(llm, "stub/model")
+        .with_raw_capture_dir(dir.path())
+        .synthesize(&model)
+        .await
+        .expect_err("still unparseable — capture must not change the verdict");
+    assert!(matches!(err, SynthesisError::Unparseable));
+
+    let captured = std::fs::read_to_string(dir.path().join(super::UNPARSEABLE_CAPTURE_FILENAME))
+        .expect("the raw response must be persisted next to the report output");
+    assert_eq!(
+        captured, body,
+        "the captured file must hold the verbatim (scrubbed) response"
+    );
+}

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -23,7 +23,9 @@ use crate::report::metrics::{
 };
 use crate::report::model::{ReportModel, RepositoryReport};
 use crate::report::synthesize_guard::{allowed_numbers, numbers_in, verify_prose};
-use crate::report::synthesize_prompt::{build_synthesis_prompt, synthesis_schema};
+use crate::report::synthesize_prompt::{
+    build_synthesis_prompt, schema_contract_statement, synthesis_schema,
+};
 
 use super::{Synthesis, SynthesisError, Synthesizer};
 
@@ -306,6 +308,54 @@ fn synthesis_schema_shape() {
         req.response_schema.is_some(),
         "every synthesis request must force structured output"
     );
+}
+
+/// Why: #6009 shape 3 — the prompt-text contract must be derived FROM the
+/// schema, not hand-typed beside it, or the two can drift exactly the way
+/// the three live shapes drifted from the schema itself.
+/// What: asserts the statement built from `synthesis_schema(5)` names every
+/// canonical top-level field and every `top_risks`/`findings` item field.
+/// Test: this test itself.
+#[test]
+fn schema_contract_statement_lists_every_field_name() {
+    let schema = synthesis_schema(5);
+    let contract = schema_contract_statement(&schema.schema);
+    for needle in [
+        "executive_summary",
+        "top_risks",
+        "findings",
+        "description",
+        "severity",
+        "cost",
+        "apps",
+        "app_slug",
+        "title",
+        "evidence",
+        "component",
+        "business_impact",
+        "remediation",
+        "cost_effort",
+    ] {
+        assert!(
+            contract.contains(needle),
+            "contract statement must name field {needle:?}: {contract}"
+        );
+    }
+}
+
+/// Why: the derived contract text is worthless unless it actually reaches
+/// the system prompt the provider receives.
+/// What: asserts `req.system` contains the "Required JSON object shape"
+/// section and the canonical field names it lists.
+/// Test: this test itself.
+#[test]
+fn schema_contract_statement_reaches_system_prompt() {
+    let model = fixture_model(vec![]);
+    let req = build_synthesis_prompt(&model, "stub/model", false);
+    assert!(req.system.contains("Required JSON object shape"));
+    assert!(req.system.contains("executive_summary"));
+    assert!(req.system.contains("top_risks"));
+    assert!(req.system.contains("findings"));
 }
 
 /// Why: the schema's `top_risks` cap must shrink on the one-shot truncation
@@ -919,8 +969,12 @@ fn shape2_capture_response() -> String {
 /// Test: this test itself.
 #[test]
 fn parse_raw_recovers_shape2_field_name_drift() {
-    let raw =
+    let (raw, notes) =
         super::parse_raw(&shape2_capture_response()).expect("shape-2 field drift must still parse");
+    assert!(
+        notes.is_empty(),
+        "recognised shape-2 synonyms record no drop notes: {notes:?}"
+    );
     assert_eq!(raw.top_risks.len(), 5, "all 5 captured rows must survive");
     assert_eq!(
         raw.top_risks[0].description,
@@ -941,4 +995,171 @@ fn parse_raw_recovers_shape2_field_name_drift() {
             "row {i}: an omitted cost must default to empty, never be fabricated"
         );
     }
+}
+
+// ── #6009 shape 3: a THIRD field-name drift on the same forced schema ──────
+
+/// Verbatim (structure and field names unchanged) reconstruction of the third
+/// consecutive live capture at `synthesis-unparseable-response.txt` (#6009
+/// shape 3): valid top-level JSON, but every `top_risks` item uses `risk`
+/// instead of `description`, `cost_effort_framing` instead of `cost`, and
+/// `affected_applications` instead of `apps` — a THIRD distinct set of
+/// drifted names from the SAME provider/model, proving per-shape
+/// `#[serde(alias)]` additions can never converge and motivating the
+/// whitelist-synonym-table class fix in
+/// `crate::report::synthesize_normalize`.
+fn shape3_capture_response() -> String {
+    r#"{
+  "executive_summary": "This diligence pass on 00-bobmatnyc-trusty-tools surfaced 32 findings, all AMBER, concentrated in authentication & secrets, error handling, state management, and scalability.",
+  "top_risks": [
+    {
+      "risk": "API keys and OAuth client secrets persisted as plaintext files, with hardening that is Unix-only and unverified/absent on Windows.",
+      "cost_effort_framing": "Moderate remediation: introduce OS keyring/secret-manager integration and enforce cross-platform permission or encryption controls before any Windows deployment.",
+      "affected_applications": "00-bobmatnyc-trusty-tools"
+    },
+    {
+      "risk": "Pervasive silent-failure error handling — corrupt or malformed config/credential files degrade to defaults or None, poisoned locks recover silently, and home resolution falls back to CWD.",
+      "cost_effort_framing": "Moderate, dispersed effort: convert silent fallbacks to surfaced errors across multiple modules and add operator-visible diagnostics.",
+      "affected_applications": "00-bobmatnyc-trusty-tools"
+    },
+    {
+      "risk": "Non-atomic persistence in the memory store — cross-segment moves and payload/vector index writes commit in separate steps, risking duplicated or orphaned records on crash.",
+      "cost_effort_framing": "Higher effort: requires transactional or reconciliation design across redb and usearch to guarantee cross-store consistency.",
+      "affected_applications": "00-bobmatnyc-trusty-tools"
+    },
+    {
+      "risk": "Agent tool-capability surface defaults to unrestricted, granting all registered tools including shell-capable ones when a config omits an allowlist; combined with denylist-style traversal checks and an auth-exempt SSE route.",
+      "cost_effort_framing": "Moderate: flip defaults to deny-by-default, adopt allowlist validation, and confirm downstream SSE auth gating.",
+      "affected_applications": "00-bobmatnyc-trusty-tools"
+    },
+    {
+      "risk": "Persistence layer is single-node demo-scale — full-file JSONL re-reads with no fsync/checksum, cross-process locks that cannot serialize the redb writer, blocking flock on the async runtime, and a per-segment write mutex.",
+      "cost_effort_framing": "Higher effort: durability and concurrency rework needed before multi-node or production-scale operation.",
+      "affected_applications": "00-bobmatnyc-trusty-tools"
+    }
+  ],
+  "findings": []
+}"#
+    .to_string()
+}
+
+/// Why: #6009 shape 3 — this is the THIRD distinct field-name shape the same
+/// live model produced across three consecutive calls, and it is neither of
+/// the two `#[serde(alias)]`s the previous round of this fix added. A
+/// per-shape alias can never converge; the whitelist synonym table in
+/// `synthesize_normalize` recognises `cost_effort_framing`/
+/// `affected_applications` alongside the shape-2 `risk`/`applications`
+/// names. RED against `f6102c50a` (pre-fix `RiskRow` has no
+/// `cost_effort_framing`/`affected_applications` alias, so this capture fails
+/// `serde_json::from_str::<RawSynthesis>` and the whole response is
+/// classified `Unparseable`), GREEN after.
+/// What: parses the verbatim shape-3 capture; asserts all 5 rows recover
+/// `description` (from `risk`), `cost` (from `cost_effort_framing`), and
+/// `apps` (from `affected_applications`), with `severity` defaulted to `""`
+/// (omitted in this shape, same as shape 2) — never fabricated.
+/// Test: this test itself.
+#[test]
+fn parse_raw_recovers_shape3_field_name_drift() {
+    let (raw, notes) =
+        super::parse_raw(&shape3_capture_response()).expect("shape-3 field drift must still parse");
+    assert!(
+        notes.is_empty(),
+        "recognised shape-3 synonyms record no drop notes: {notes:?}"
+    );
+    assert_eq!(raw.top_risks.len(), 5, "all 5 captured rows must survive");
+    assert_eq!(
+        raw.top_risks[0].description,
+        "API keys and OAuth client secrets persisted as plaintext files, with hardening that is Unix-only and unverified/absent on Windows.",
+        "`risk` must normalize onto `description`"
+    );
+    assert_eq!(
+        raw.top_risks[0].cost,
+        "Moderate remediation: introduce OS keyring/secret-manager integration and enforce cross-platform permission or encryption controls before any Windows deployment.",
+        "`cost_effort_framing` must normalize onto `cost`"
+    );
+    assert_eq!(
+        raw.top_risks[0].apps, "00-bobmatnyc-trusty-tools",
+        "`affected_applications` must normalize onto `apps`"
+    );
+    for (i, row) in raw.top_risks.iter().enumerate() {
+        assert_eq!(
+            row.severity, "",
+            "row {i}: an omitted severity must default to empty, never be fabricated"
+        );
+    }
+}
+
+/// Why: the shape-3 fixture must also synthesize end to end — not merely
+/// parse — so the numeric guardrail and reporter path are exercised exactly
+/// as they would be against the live response.  The captured executive
+/// summary cites "32 findings", a figure absent from the fixture model's
+/// allowed set (8200/120/640), so the guardrail correctly rejects THAT field
+/// on its own numeric-fabrication grounds — this test is not asserting
+/// normalization bypasses the guardrail, only that the 5 top-risk rows (whose
+/// prose carries no digits, aside from the "00" embedded in the repo name
+/// itself — matched here by naming the fixture repo
+/// "00-bobmatnyc-trusty-tools", exactly as the live capture named it, so that
+/// digit sequence is a legitimately allowed figure) recover and survive
+/// independently.
+/// What: runs the full `Synthesizer::synthesize` against the shape-3
+/// capture; asserts the executive summary is rejected with a note citing
+/// "32", while all 5 top-risk rows survive intact.
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_recovers_shape3_end_to_end() {
+    let mut model = fixture_model(vec![red("x")]);
+    model.repositories[0].name = "00-bobmatnyc-trusty-tools".to_string();
+    model.repositories[0].slug = "00-bobmatnyc-trusty-tools".to_string();
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body: shape3_capture_response(),
+        finish_reason: Some("stop".to_string()),
+    });
+    let result = Synthesizer::new(llm, "stub/model")
+        .synthesize(&model)
+        .await
+        .expect("the shape-3 capture must synthesize end to end (top-risk rows survive)");
+    assert!(
+        result.executive_summary.is_none(),
+        "the captured summary cites an unverifiable figure (32) and must be rejected"
+    );
+    assert!(
+        result
+            .notes
+            .iter()
+            .any(|n| n.contains("rejected (unverified figure)") && n.contains("32")),
+        "the rejection must be recorded: {:?}",
+        result.notes
+    );
+    assert_eq!(result.top_risks.len(), 5, "all 5 rows must survive intact");
+}
+
+/// Why: normalization must never turn a genuinely wrong response shape into
+/// an accepted one — the contract stays strict. A response using entirely
+/// different top-level field names (no `executive_summary` key at all) must
+/// still fail, exactly as it did before this change, just via
+/// `NoVerifiableContent` instead of a parse error (the JSON itself is
+/// syntactically valid; every key is simply unrecognized and dropped).
+/// What: a response with `summary`/`risks` instead of
+/// `executive_summary`/`top_risks`; asserts
+/// `Err(SynthesisError::NoVerifiableContent)`.
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_rejects_a_wholly_unrecognized_shape() {
+    let model = fixture_model(vec![red("x")]);
+    let body = r#"{
+      "summary": "The codebase looks fine overall.",
+      "risks": [{"issue": "something", "severity_band": "RED"}]
+    }"#;
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body: body.to_string(),
+        finish_reason: Some("stop".to_string()),
+    });
+    let err = Synthesizer::new(llm, "stub/model")
+        .synthesize(&model)
+        .await
+        .expect_err("a wholly unrecognized shape must never be accepted");
+    assert!(
+        matches!(err, SynthesisError::NoVerifiableContent),
+        "expected NoVerifiableContent, got {err:?}"
+    );
 }

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -866,3 +866,79 @@ async fn capture_dir_persists_raw_response_on_parse_failure() {
         "the captured file must hold the verbatim (scrubbed) response"
     );
 }
+
+// ── #6009 shape 2: drifted `top_risks` field names ──────────────────────────
+
+/// Verbatim (structure and field names unchanged) reconstruction of the live
+/// capture at `synthesis-unparseable-response.txt` (#6009 shape 2): valid
+/// top-level JSON, but every `top_risks` item uses `risk` instead of
+/// `description` and `applications` instead of `apps`, and omits
+/// `severity`/`cost` entirely.
+fn shape2_capture_response() -> String {
+    r#"{
+  "executive_summary": "Due diligence of 00-bobmatnyc-trusty-tools surfaced 27 AMBER findings and no RED findings.",
+  "top_risks": [
+    {
+      "risk": "Plaintext secrets at rest across credential, OAuth, and MCP config stores, with world-readable fallback on non-unix targets; broad remediation across multiple modules to move to encryption/keyring-backed storage.",
+      "applications": "00-bobmatnyc-trusty-tools"
+    },
+    {
+      "risk": "Unauthenticated API on the default loopback bind reachable by any local process including browser pages hitting 127.0.0.1; moderate effort to enforce auth by default.",
+      "applications": "00-bobmatnyc-trusty-tools"
+    },
+    {
+      "risk": "Non-atomic memory writes — vector mutation and metadata commit as separate transactions with no rollback, and non-atomic move_segment that can duplicate records — risking silent data corruption; significant effort to introduce transactional guarantees.",
+      "applications": "00-bobmatnyc-trusty-tools"
+    },
+    {
+      "risk": "Pervasive silent error suppression in credential reads, config parsing, and memory recall collapsing failures to None/defaults/empty results; moderate effort to surface and log failure paths.",
+      "applications": "00-bobmatnyc-trusty-tools"
+    },
+    {
+      "risk": "Scalability constraints in the memory subsystem — per-session redb+usearch files accumulating unbounded handles, single mutex serializing all segment writes, blocking flock in async context, and uncached config re-reads per prompt; moderate refactoring effort under load.",
+      "applications": "00-bobmatnyc-trusty-tools"
+    }
+  ],
+  "findings": []
+}"#
+    .to_string()
+}
+
+/// Why: #6009 shape 2 — before the `RiskRow` `#[serde(alias)]`/`#[serde(default)]`
+/// fix, this exact live capture failed `serde_json::from_str::<RawSynthesis>`
+/// because every `top_risks` item used `risk`/`applications` instead of
+/// `description`/`apps` and omitted `severity`/`cost` entirely, so the whole
+/// response was classified `Unparseable` even though it was valid top-level
+/// JSON with real, verifiable risk content. RED against pre-fix `RiskRow`
+/// (missing field errors on `description`/`severity`/`cost`/`apps`), GREEN
+/// after.
+/// What: parses the verbatim capture and asserts all 5 rows recover their
+/// drifted-name fields (`description` from `risk`, `apps` from
+/// `applications`) while `severity`/`cost` default to `""` — never a
+/// fabricated band or figure.
+/// Test: this test itself.
+#[test]
+fn parse_raw_recovers_shape2_field_name_drift() {
+    let raw =
+        super::parse_raw(&shape2_capture_response()).expect("shape-2 field drift must still parse");
+    assert_eq!(raw.top_risks.len(), 5, "all 5 captured rows must survive");
+    assert_eq!(
+        raw.top_risks[0].description,
+        "Plaintext secrets at rest across credential, OAuth, and MCP config stores, with world-readable fallback on non-unix targets; broad remediation across multiple modules to move to encryption/keyring-backed storage.",
+        "`risk` must alias onto `description`"
+    );
+    assert_eq!(
+        raw.top_risks[0].apps, "00-bobmatnyc-trusty-tools",
+        "`applications` must alias onto `apps`"
+    );
+    for (i, row) in raw.top_risks.iter().enumerate() {
+        assert_eq!(
+            row.severity, "",
+            "row {i}: an omitted severity must default to empty, never be fabricated"
+        );
+        assert_eq!(
+            row.cost, "",
+            "row {i}: an omitted cost must default to empty, never be fabricated"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #6009

Three live-captured failure shapes from anthropic/claude-opus-4.8 via OpenRouter (markdown-not-JSON; two rounds of field-name drift) showed json_schema response_format is not enforced for Anthropic models. Fixes the class:

1. The required JSON shape is now stated in the prompt itself, generated from the same schema object passed to response_format (single source, cannot drift)
2. Whitelist-based key normalization for observed synonyms — unrecognized keys dropped with a note, never guessed
3. Markdown fallback recovers executive_summary only, guardrail still applied
4. On Unparseable, the raw response is persisted (scrubbed) next to the report for spend-free diagnosis

A genuinely wrong structure is still rejected; the numeric guardrail applies after normalization.

## Verification

Live-verified: two consecutive renders against the real POC manifest produced the full due-diligence report (2026-08-18-technical-due-diligence.md, 25.7KB); rung 3 gates green (1618→ lib tests, clippy -D warnings clean, line-cap/SLD clean, changelog fragment present).

## Follow-up

Follow-up candidate: forced tool-call structured output for Anthropic-family models — larger provider-abstraction change, noted in commit body.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools