### PR TITLE
feat(trusty-review): acquisition report templates — Code, Security, Performance sections, Key Facts block, linked executive summary

### DIFF
--- a/crates/trusty-review/changelog.d/6004-code-security-performance-sections.md
+++ b/crates/trusty-review/changelog.d/6004-code-security-performance-sections.md
@@ -1,0 +1,26 @@
+Added
+
+- The technical due-diligence report gains three new sections: "Code Quality &
+  Architecture" and "Security Posture" re-project complexity, LoC/tech-stack,
+  and RED/AMBER lint-tool findings already loaded for other sections —
+  Security Posture is the promoted, now actually-filled, successor to the old
+  §6.1 Security Violations table (previously unfilled template scaffolding).
+  "Performance & Scalability" states, in fixed text never touched by
+  synthesis, that no performance data source exists and what an assessment
+  would require.
+- A "Key Facts" block ahead of the executive summary frontloads codebase
+  density (LoC, file count, languages) and a merged complexity profile —
+  deterministic, never LLM-touched. Author count, work-volume estimate, and
+  monthly trajectory rows render as named gaps until the authorship artifact
+  lands.
+- The executive summary carries a deterministic jump-list linking to every
+  section actually present in the rendered document — never a link to a
+  section a custom template omitted.
+- Two new LLM narrative slots, `code_quality_summary` and `security_summary`,
+  join the existing synthesis call and inherit its numeric guardrail. A
+  template may override either section's voice via
+  `<!-- instruct:code_quality_summary ... -->` /
+  `<!-- instruct:security_summary ... -->`, same as the existing three.
+- The default narrative voice (executive summary, top risks, and the two new
+  slots) is now explicitly balanced/adversarial: acquirer-side, skeptical of
+  risk, evenhanded about genuine strengths, never promotional.

--- a/crates/trusty-review/changelog.d/6004-code-security-performance-sections.md
+++ b/crates/trusty-review/changelog.d/6004-code-security-performance-sections.md
@@ -24,3 +24,8 @@ Added
 - The default narrative voice (executive summary, top risks, and the two new
   slots) is now explicitly balanced/adversarial: acquirer-side, skeptical of
   risk, evenhanded about genuine strengths, never promotional.
+- The `report-technical-dd-cast.md` template variant intentionally does not
+  get the new Code Quality & Architecture / Security Posture / Performance &
+  Scalability sections, the Key Facts block, or the Contents jump-list yet —
+  porting them to CAST's own methodology and health-factor voice is deferred
+  to follow-up work tracked on #6004.

--- a/crates/trusty-review/src/report/contents_links.rs
+++ b/crates/trusty-review/src/report/contents_links.rs
@@ -1,0 +1,107 @@
+//! Executive-summary jump-list: deterministic intra-document anchor links
+//! (#6004).
+//!
+//! Why: owner ruling 2026-08-18 — the executive summary becomes a navigable
+//! entry point, carrying links to every section, and "no link to a section
+//! that was omitted." The anchor set can only be known AFTER the full
+//! document is rendered and polished (a section's heading can survive while
+//! its body collapses to the omit-empty gap line, and a custom/vendor
+//! template — e.g. `report-technical-dd-cast.md` — may not carry every
+//! section this template does at all). So the link scaffold is built by a
+//! deterministic POST-render scan of the actual `##` headings present,
+//! never authored by the LLM: the guardrailed narrative text never has to
+//! emit a URL.
+//! What: [`set_contents_placeholder`] fills a stable sentinel scalar at
+//! fill-time (so it survives `polish`'s comment-stripping and honesty-marker
+//! rules exactly like any other real content); [`inject`] runs LAST in
+//! `Reporter::render`, scans the finished markdown for every level-2 (`## `)
+//! heading, and replaces the sentinel with a bullet list of markdown links
+//! to each one it actually found — skipping the Executive Summary heading
+//! itself, since the list lives inside that section.
+//! Test: `contents_links_tests.rs`.
+
+use super::fill::Scope;
+use super::manifest::slugify;
+
+/// The scalar name the template carries the jump-list placeholder under.
+pub const PLACEHOLDER_FIELD: &str = "report_contents_block";
+
+/// A sentinel unlikely to collide with any real content, filled at fill-time
+/// and replaced post-polish once the final heading set is known.
+///
+/// Why: NUL is not valid inside any markdown a template author or the LLM
+/// could produce (the numeric guardrail and JSON transport both exclude it),
+/// so a literal-text collision is not a real risk.
+const SENTINEL: &str = "\u{0}REPORT_CONTENTS_LINKS\u{0}";
+
+/// The heading text this module never links to (it lives inside that
+/// section, so a self-link is redundant).
+const SELF_HEADING_NEEDLE: &str = "Executive Summary";
+
+/// Set the jump-list placeholder scalar.
+///
+/// Why: called unconditionally from `reporter::build_scope` — the block is
+/// tool structure, not data, so it is never honesty-marked or omitted.
+/// What: sets [`PLACEHOLDER_FIELD`] to [`SENTINEL`].
+pub fn set_contents_placeholder(root: &mut Scope) {
+    root.set(PLACEHOLDER_FIELD, SENTINEL);
+}
+
+/// Replace the sentinel with the real jump-list, built from the headings
+/// actually present in `rendered`.
+///
+/// Why: must run AFTER `polish` (so a collapsed-but-still-headed section is
+/// linkable) and after every section-appending pass in `Reporter::render`
+/// (mermaid, synthesis/benchmark status notes, investigation sections) so
+/// every heading that ends up in the document is a candidate.
+/// What: scans line-by-line for `## ` (level-2 only — deeper headings are
+/// per-application/per-finding detail, not top-level sections) in document
+/// order, skips [`SELF_HEADING_NEEDLE`], slugs each via [`slugify`] (the same
+/// algorithm GitHub's own renderer produces for a heading of this shape:
+/// lowercase, punctuation collapsed to `-`), de-duplicates a slug collision
+/// with a numeric suffix, and replaces [`SENTINEL`] with one bullet per
+/// heading found. No sentinel in `rendered` (a custom template that never
+/// included the placeholder) leaves the text unchanged. Zero other headings
+/// found removes the sentinel with no list.
+/// Test: `contents_links_tests::{links_every_top_level_heading,
+/// never_links_a_heading_absent_from_the_document, noop_without_sentinel}`.
+pub fn inject(rendered: &str) -> String {
+    if !rendered.contains(SENTINEL) {
+        return rendered.to_string();
+    }
+
+    let mut seen_slugs: Vec<String> = Vec::new();
+    let mut links: Vec<String> = Vec::new();
+    for line in rendered.lines() {
+        let trimmed = line.trim_end();
+        let Some(text) = trimmed.strip_prefix("## ") else {
+            continue;
+        };
+        // Exclude a nested `### ` etc. that also starts with "## " by chance —
+        // cannot happen (`### ` does not start with `## ` followed by a space
+        // at the same position), but guard against a stray "##" with no space.
+        if text.trim().is_empty() || text.contains(SELF_HEADING_NEEDLE) {
+            continue;
+        }
+        let heading = text.trim();
+        let mut slug = slugify(heading);
+        let mut n = 2;
+        while seen_slugs.contains(&slug) {
+            slug = format!("{}-{n}", slugify(heading));
+            n += 1;
+        }
+        seen_slugs.push(slug.clone());
+        links.push(format!("- [{heading}](#{slug})"));
+    }
+
+    let block = if links.is_empty() {
+        String::new()
+    } else {
+        format!("**Contents**\n\n{}", links.join("\n"))
+    };
+    rendered.replace(SENTINEL, &block)
+}
+
+#[cfg(test)]
+#[path = "contents_links_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/contents_links.rs
+++ b/crates/trusty-review/src/report/contents_links.rs
@@ -62,9 +62,14 @@ pub fn set_contents_placeholder(root: &mut Scope) {
 /// with a numeric suffix, and replaces [`SENTINEL`] with one bullet per
 /// heading found. No sentinel in `rendered` (a custom template that never
 /// included the placeholder) leaves the text unchanged. Zero other headings
-/// found removes the sentinel with no list.
+/// found removes the sentinel with no list. A fenced code block (``` … ```)
+/// is tracked with the same `in_fence` toggle guard as
+/// [`super::polish::collapse_recursive`] — every fenced line is skipped, so a
+/// `## `-prefixed line inside a `raw_evidence` quote of source bytes is never
+/// misread as a heading and never linked as a dangling anchor.
 /// Test: `contents_links_tests::{links_every_top_level_heading,
-/// never_links_a_heading_absent_from_the_document, noop_without_sentinel}`.
+/// never_links_a_heading_absent_from_the_document, noop_without_sentinel,
+/// fenced_evidence_hash_line_is_not_mistaken_for_a_heading}`.
 pub fn inject(rendered: &str) -> String {
     if !rendered.contains(SENTINEL) {
         return rendered.to_string();
@@ -72,8 +77,16 @@ pub fn inject(rendered: &str) -> String {
 
     let mut seen_slugs: Vec<String> = Vec::new();
     let mut links: Vec<String> = Vec::new();
+    let mut in_fence = false;
     for line in rendered.lines() {
         let trimmed = line.trim_end();
+        if trimmed.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
         let Some(text) = trimmed.strip_prefix("## ") else {
             continue;
         };

--- a/crates/trusty-review/src/report/contents_links_tests.rs
+++ b/crates/trusty-review/src/report/contents_links_tests.rs
@@ -53,3 +53,22 @@ fn slug_collision_gets_a_distinct_anchor() {
     assert!(out.contains("(#notes)"));
     assert!(out.contains("(#notes-2)"));
 }
+
+/// A `## `-prefixed line inside a fenced evidence quote (raw_evidence embeds
+/// source bytes verbatim) must never be mistaken for a document heading — it
+/// is quoted source text, not a section boundary, so it must produce no
+/// Contents link and no dangling anchor.
+#[test]
+fn fenced_evidence_hash_line_is_not_mistaken_for_a_heading() {
+    let doc = format!(
+        "## 2. Executive Summary\n\n{SENTINEL}\n\n## 3. Code Quality & Architecture\n\n```\n## Not A Real Section\n```\n\n## 9. Gaps & Caveats\n\nx\n"
+    );
+    let out = inject(&doc);
+    assert!(!out.contains(SENTINEL));
+    assert!(out.contains("[3. Code Quality & Architecture](#3-code-quality-architecture)"));
+    assert!(out.contains("[9. Gaps & Caveats](#9-gaps-caveats)"));
+    // The fenced quote's own text survives untouched, but it must never be
+    // linked as a heading (no bullet, no anchor).
+    assert!(!out.contains("[Not A Real Section]"));
+    assert!(!out.contains("(#not-a-real-section)"));
+}

--- a/crates/trusty-review/src/report/contents_links_tests.rs
+++ b/crates/trusty-review/src/report/contents_links_tests.rs
@@ -1,0 +1,55 @@
+use super::*;
+
+/// Links every top-level (`## `) heading present, except Executive Summary.
+#[test]
+fn links_every_top_level_heading() {
+    let doc = format!(
+        "## 1. Report Metadata\n\n## 2. Executive Summary\n\n{SENTINEL}\n\n### Top Risks\n\n## 3. Code Quality & Architecture\n\ncontent\n\n## 9. Gaps & Caveats\n\nx\n"
+    );
+    let out = inject(&doc);
+    assert!(!out.contains(SENTINEL));
+    assert!(out.contains("[1. Report Metadata](#1-report-metadata)"));
+    assert!(out.contains("[3. Code Quality & Architecture](#3-code-quality-architecture)"));
+    assert!(out.contains("[9. Gaps & Caveats](#9-gaps-caveats)"));
+    // Never a self-link to the section the list lives inside.
+    assert!(!out.contains("[2. Executive Summary]"));
+}
+
+/// A heading absent from the document never gets a link — the anchor set is
+/// derived from the ACTUAL rendered headings, not a fixed candidate list.
+#[test]
+fn never_links_a_heading_absent_from_the_document() {
+    let doc = format!("## 2. Executive Summary\n\n{SENTINEL}\n\n## 9. Gaps & Caveats\n\nx\n");
+    let out = inject(&doc);
+    assert!(out.contains("[9. Gaps & Caveats]"));
+    assert!(!out.contains("Security Posture"));
+    assert!(!out.contains("Performance"));
+}
+
+/// A document with no sentinel (a custom template without the placeholder)
+/// is returned unchanged.
+#[test]
+fn noop_without_sentinel() {
+    let doc = "## 1. Report Metadata\n\ncontent\n";
+    assert_eq!(inject(doc), doc);
+}
+
+/// A document whose only heading is Executive Summary itself produces an
+/// empty jump-list block rather than a lone "**Contents**" with nothing
+/// under it.
+#[test]
+fn no_other_headings_yields_empty_block() {
+    let doc = format!("## 2. Executive Summary\n\n{SENTINEL}\n\ntext\n");
+    let out = inject(&doc);
+    assert!(!out.contains(SENTINEL));
+    assert!(!out.contains("**Contents**"));
+}
+
+/// Two headings that would slug identically get distinct anchors.
+#[test]
+fn slug_collision_gets_a_distinct_anchor() {
+    let doc = format!("## 2. Executive Summary\n\n{SENTINEL}\n\n## Notes\n\na\n\n## Notes!\n\nb\n");
+    let out = inject(&doc);
+    assert!(out.contains("(#notes)"));
+    assert!(out.contains("(#notes-2)"));
+}

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -15,6 +15,8 @@
 
 pub mod analyze_adapter;
 pub mod benchmark;
+// #6004: exec-summary jump-list — post-render anchor-link injection.
+pub mod contents_links;
 pub mod error;
 pub mod exec_summary;
 pub mod fill;
@@ -29,9 +31,15 @@ pub mod polish;
 pub mod provenance;
 pub mod redact;
 pub mod reporter;
+// #6004: Code Quality & Architecture / Security Posture deterministic fill.
+pub mod reporter_codesec;
+// #6004: engagement-wide Key Facts block.
+pub mod reporter_facts;
 pub mod reporter_fill;
 pub mod reporter_findings;
 pub mod reporter_graph_datasets;
+// #6004: fixed Performance & Scalability gap text.
+pub mod reporter_performance;
 pub mod scan;
 // #5747: the schema-tag parse both artifact loaders decide compatibility from.
 pub(crate) mod schema;

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 
 use tracing::info;
 
+use super::contents_links;
 use super::error::{ReportError, Result};
 use super::fill::{Scope, render, strip_leading_comment};
 use super::manifest::slugify;
@@ -22,6 +23,8 @@ use super::metrics::Severity;
 use super::model::{ReportModel, RepositoryReport};
 use super::polish::polish_with_gaps;
 use super::provenance::{self, Provenance, tag};
+use super::reporter_codesec::{push_code_quality_rows, push_security_violation_rows};
+use super::reporter_facts::fill_key_facts;
 use super::reporter_fill::{
     crate_version, fill_profile, instructions_block, set_executive_summary, set_scoring_model,
 };
@@ -29,6 +32,7 @@ use super::reporter_findings::push_finding_band;
 use super::reporter_graph_datasets::{
     inject_complexity_distribution_dataset, inject_loc_by_technology_dataset,
 };
+use super::reporter_performance::fill_performance_note;
 
 /// Renders a [`ReportModel`] to markdown + JSON and writes them atomically.
 ///
@@ -110,7 +114,11 @@ impl Reporter {
         // sections, plus the rejected-evidence note, are appended after polish so
         // their measured/inferred rows are never subject to omit-empty.
         out.push_str(&super::investigate::report_sections(model));
-        out
+        // #6004: LAST — every section this render pass can produce has now been
+        // appended, so this is the one point where the final `##` heading set is
+        // known. Replaces the exec-summary jump-list sentinel with real links to
+        // whichever of those headings actually survived.
+        contents_links::inject(&out)
     }
 
     /// Render and write `{slug}.md` + `{slug}.json` atomically to `output_dir`.
@@ -222,6 +230,11 @@ fn build_scope(model: &ReportModel) -> Scope {
     root.set("report_version", tag(crate_version(), Provenance::Measured));
     root.set("provenance_legend", provenance::LEGEND);
     root.set("analyst_instructions_block", instructions_block(model));
+    // #6004: the Key Facts block frontloads density/complexity/(author/
+    // trajectory once PR B lands) facts ahead of the executive summary.
+    fill_key_facts(&mut root, model);
+    // #6004: deterministic structure, never data — always set.
+    contents_links::set_contents_placeholder(&mut root);
     // Declared deal-side fields: filled + tagged when the manifest supplies them,
     // otherwise omitted (→ Gaps) rather than rendered as a "not stated" row.
     if let Some(analyst) = &model.analyst {
@@ -330,6 +343,14 @@ fn build_scope(model: &ReportModel) -> Scope {
     // never synthesized — filled independent of synthesis availability.
     push_green_topics(&mut root, model);
 
+    // #6004: Code Quality & Architecture and Security Posture re-project data
+    // already loaded above (complexity/findings/LoC) — no new data source, no
+    // LLM involvement in the rows themselves. Performance & Scalability is
+    // FIXED text (DOC-67 §3: no performance data source exists at all).
+    push_code_quality_rows(&mut root, model);
+    push_security_violation_rows(&mut root, model);
+    fill_performance_note(&mut root);
+
     // #5318: §2 has a deterministic source.  It used to be filled ONLY from
     // verified synthesis, so a run without `--synthesize` — which was every
     // `tga audit` run before #5454 — collapsed the first section a diligence
@@ -383,6 +404,22 @@ fn inject_synthesis_summary(root: &mut Scope, syn: &super::synthesize::Synthesis
         root.set(
             "executive_summary_paragraph",
             tag(exec.clone(), Provenance::Inferred),
+        );
+    }
+    // #6004: same injection shape as the executive summary — verified prose
+    // only, tagged inferred; the deterministic rows built by
+    // `push_code_quality_rows`/`push_security_violation_rows` fill the section
+    // regardless of whether either narrative slot survived the guardrail.
+    if let Some(cq) = &syn.code_quality_summary {
+        root.set(
+            "code_quality_summary_paragraph",
+            tag(cq.clone(), Provenance::Inferred),
+        );
+    }
+    if let Some(sec) = &syn.security_summary {
+        root.set(
+            "security_summary_paragraph",
+            tag(sec.clone(), Provenance::Inferred),
         );
     }
 

--- a/crates/trusty-review/src/report/reporter_codesec.rs
+++ b/crates/trusty-review/src/report/reporter_codesec.rs
@@ -1,0 +1,126 @@
+//! Code Quality & Architecture and Security Posture: deterministic
+//! re-projections of already-loaded `AnalyzeMetrics` data (#6004).
+//!
+//! Why: both new sections restate data the model already carries — nothing
+//! here is a new data source. Code Quality re-projects the complexity
+//! distribution, LoC/tech-stack, and maintainability (refactor/code-smell)
+//! findings already used by §3/§4/§5; Security Posture re-projects the SAME
+//! RED/AMBER findings §5 lists, grouped by tool/domain — the promoted, now
+//! actually-filled, successor to the old §6.1 `security_violations_table`
+//! block (previously template scaffolding with no reporter fill code at
+//! all). Splitting this out of `reporter.rs` keeps that file under the
+//! 500-SLOC production cap.
+//! What: [`push_code_quality_rows`] and [`push_security_violation_rows`],
+//! both called from `reporter::build_scope`.
+//! Test: `reporter_codesec_tests.rs`.
+
+use super::fill::Scope;
+use super::metrics::{AnalyzeMetrics, Severity};
+use super::model::ReportModel;
+use super::provenance::{Provenance, tag};
+
+/// `MetricFinding.category` value `analyze_adapter::refactor_finding` always
+/// writes — refactor/code-smell findings are maintainability by construction,
+/// so this is the seam between "code quality" and "security posture" below.
+const MAINTAINABILITY_CATEGORY: &str = "maintainability";
+
+/// Push one `code_quality_row` per repository carrying metrics.
+///
+/// Why: re-projects complexity distribution, tech-stack/LoC, and the
+/// maintainability-finding count into a dedicated section (#6004) rather than
+/// requiring a reader to cross-reference §3/§4/§5.
+/// What: `cq_loc`/`cq_tech`/`cq_complexity` restate per-app profile data;
+/// `cq_maintainability_count` counts non-GREEN `maintainability`-category
+/// findings — a real zero is a stated fact (tagged, not omitted), never a gap.
+/// A repository with no metrics at all is skipped (its row would be 100%
+/// honesty markers, which the omit-empty pass would drop anyway).
+/// Test: `reporter_codesec_tests::code_quality_rows_reproject_metrics`.
+pub fn push_code_quality_rows(root: &mut Scope, model: &ReportModel) {
+    for repo in &model.repositories {
+        let Some(m) = &repo.metrics else { continue };
+        let mut row = Scope::new();
+        row.set("cq_app_name", repo.name.clone());
+        if m.loc.total > 0 {
+            row.set("cq_loc", tag(m.loc.total.to_string(), Provenance::Measured));
+        }
+        let langs = m.primary_languages(3);
+        if !langs.is_empty() {
+            row.set("cq_tech", tag(langs.join(", "), Provenance::Measured));
+        }
+        if let Some(summary) = bucket_summary(m) {
+            row.set("cq_complexity", tag(summary, Provenance::Measured));
+        }
+        let maint = m
+            .findings
+            .iter()
+            .filter(|f| f.severity != Severity::Green && f.category == MAINTAINABILITY_CATEGORY)
+            .count();
+        row.set(
+            "cq_maintainability_count",
+            tag(maint.to_string(), Provenance::Measured),
+        );
+        root.push_block("code_quality_row", row);
+    }
+}
+
+/// Push one `security_violations_table` row per (application, tool/domain)
+/// with at least one RED/AMBER finding whose category is NOT maintainability.
+///
+/// Why (#6004): promotes §6.1 out of Risk Registers into its own top-level
+/// Security Posture section — the block name and column shape are unchanged
+/// (`app_name`/`violation_domain`/`violation_count`) so this is a straight
+/// re-projection of the RED/AMBER findings §5 already lists, grouped by the
+/// producing tool. This is the first reporter code that actually fills that
+/// block; before #6004 it was unfilled template scaffolding.
+/// What: excludes GREEN (no-green-analysis rule) and `maintainability`
+/// (Code Quality's finding class, not a lint/security domain).
+/// Test: `reporter_codesec_tests::security_rows_group_by_domain_excluding_maintainability`.
+pub fn push_security_violation_rows(root: &mut Scope, model: &ReportModel) {
+    for repo in &model.repositories {
+        let Some(m) = &repo.metrics else { continue };
+        let mut counts: Vec<(String, u64)> = Vec::new();
+        for f in &m.findings {
+            if f.severity == Severity::Green || f.category == MAINTAINABILITY_CATEGORY {
+                continue;
+            }
+            match counts.iter_mut().find(|(c, _)| *c == f.category) {
+                Some(entry) => entry.1 += 1,
+                None => counts.push((f.category.clone(), 1)),
+            }
+        }
+        for (domain, count) in counts {
+            let mut row = Scope::new();
+            row.set("app_name", repo.name.clone());
+            row.set("violation_domain", tag(domain, Provenance::Measured));
+            row.set(
+                "violation_count",
+                tag(count.to_string(), Provenance::Measured),
+            );
+            root.push_block("security_violations_table", row);
+        }
+    }
+}
+
+/// A compact "label: count (pct%)" complexity summary for one repository's
+/// `AnalyzeMetrics.complexity` — the per-app counterpart of
+/// `reporter_facts::complexity_profile`'s engagement-wide merge.
+fn bucket_summary(m: &AnalyzeMetrics) -> Option<String> {
+    let total: u64 = m.complexity.buckets.iter().map(|b| b.count).sum();
+    if total == 0 {
+        return None;
+    }
+    let parts: Vec<String> = m
+        .complexity
+        .buckets
+        .iter()
+        .map(|b| {
+            let pct = (b.count as f64 / total as f64) * 100.0;
+            format!("{}: {} ({pct:.0}%)", b.label, b.count)
+        })
+        .collect();
+    Some(parts.join("; "))
+}
+
+#[cfg(test)]
+#[path = "reporter_codesec_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/reporter_codesec_tests.rs
+++ b/crates/trusty-review/src/report/reporter_codesec_tests.rs
@@ -1,0 +1,126 @@
+use super::*;
+use crate::report::metrics::{
+    ComplexityBucket, ComplexityDistribution, CountMetrics, LanguageLoc, LocMetrics, MetricFinding,
+    Severity,
+};
+use crate::report::model::RepositoryReport;
+
+fn repo(metrics: Option<AnalyzeMetrics>) -> RepositoryReport {
+    RepositoryReport {
+        name: "app".to_string(),
+        slug: "app".to_string(),
+        source: "/tmp/app".to_string(),
+        source_kind: "local_path".to_string(),
+        username: None,
+        git_ref: None,
+        git_info: None,
+        local_path: None,
+        scan: None,
+        metrics,
+    }
+}
+
+fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
+    ReportModel {
+        title: "Test".to_string(),
+        template: "report-technical-dd".to_string(),
+        analyst: None,
+        client: None,
+        vendor_methodology: crate::report::model::vendor_methodology(),
+        instructions: None,
+        instructions_source: None,
+        report_date: "2026-08-18".to_string(),
+        generated_date: "2026-08-18".to_string(),
+        manifest_path: "manifest.toml".to_string(),
+        repositories: repos,
+        gaps: vec![],
+        synthesis: None,
+        benchmark: None,
+        investigation: None,
+        section_instructions: Default::default(),
+        ticketing: None,
+    }
+}
+
+fn finding(category: &str, severity: Severity) -> MetricFinding {
+    MetricFinding {
+        title: format!("{category} finding"),
+        severity,
+        category: category.to_string(),
+        component: "src/lib.rs".to_string(),
+        description: "desc".to_string(),
+        remediation: "fix it".to_string(),
+    }
+}
+
+/// (a): a model with metrics data yields a populated code-quality row.
+#[test]
+fn code_quality_rows_reproject_metrics() {
+    let metrics = AnalyzeMetrics {
+        loc: LocMetrics {
+            total: 500,
+            by_language: vec![LanguageLoc {
+                language: "Rust".to_string(),
+                loc: 500,
+            }],
+        },
+        counts: CountMetrics {
+            files: 10,
+            functions: 30,
+        },
+        complexity: ComplexityDistribution {
+            buckets: vec![ComplexityBucket {
+                label: "low (1-5)".to_string(),
+                count: 30,
+            }],
+        },
+        findings: vec![finding(MAINTAINABILITY_CATEGORY, Severity::Amber)],
+        ..Default::default()
+    };
+    let model = model_with(vec![repo(Some(metrics))]);
+    let mut root = Scope::new();
+    push_code_quality_rows(&mut root, &model);
+
+    let template = "<!-- BEGIN code_quality_row -->{{cq_app_name}}|{{cq_loc}}|{{cq_tech}}|{{cq_complexity}}|{{cq_maintainability_count}}<!-- END code_quality_row -->";
+    let rendered = crate::report::fill::render(template, &root);
+    assert!(rendered.contains("app|500"));
+    assert!(rendered.contains("Rust"));
+    assert!(rendered.contains("low (1-5): 30 (100%)"));
+    assert!(rendered.contains("|1"));
+}
+
+/// (b): a model with no metrics produces no code-quality rows (honesty, never
+/// fabricated) — the block collapses via omit-empty at the reporter layer.
+#[test]
+fn no_metrics_yields_no_code_quality_rows() {
+    let model = model_with(vec![repo(None)]);
+    let mut root = Scope::new();
+    push_code_quality_rows(&mut root, &model);
+    let template = "<!-- BEGIN code_quality_row -->{{cq_app_name}}<!-- END code_quality_row -->";
+    let rendered = crate::report::fill::render(template, &root);
+    assert_eq!(rendered, "");
+}
+
+/// Security rows group by domain and exclude maintainability + GREEN.
+#[test]
+fn security_rows_group_by_domain_excluding_maintainability() {
+    let metrics = AnalyzeMetrics {
+        findings: vec![
+            finding("clippy", Severity::Red),
+            finding("clippy", Severity::Amber),
+            finding(MAINTAINABILITY_CATEGORY, Severity::Amber),
+            finding("ruff", Severity::Green),
+        ],
+        ..Default::default()
+    };
+    let model = model_with(vec![repo(Some(metrics))]);
+    let mut root = Scope::new();
+    push_security_violation_rows(&mut root, &model);
+
+    let template = "<!-- BEGIN security_violations_table -->{{app_name}}|{{violation_domain}}|{{violation_count}}\n<!-- END security_violations_table -->";
+    let rendered = crate::report::fill::render(template, &root);
+    assert!(rendered.contains("app|clippy"));
+    assert!(rendered.contains("|2 "), "rendered: {rendered}");
+    assert!(!rendered.contains("maintainability"));
+    assert!(!rendered.contains("ruff"));
+}

--- a/crates/trusty-review/src/report/reporter_facts.rs
+++ b/crates/trusty-review/src/report/reporter_facts.rs
@@ -1,0 +1,133 @@
+//! Key Facts block: deterministic frontloaded codebase facts (#6004).
+//!
+//! Why: owner ruling 2026-08-18 — "We should frontload facts: density,
+//! complexity, number of authors, how much work we estimate and its
+//! trajectory by month." The block sits ahead of the executive summary so a
+//! reader gets the numbers before the narrative. Every row here is
+//! deterministic and never LLM-touched — it is exactly the anchor set the
+//! numeric guardrail (`synthesize_guard::allowed_numbers`) already validates
+//! narrative prose against, so this block strengthens that design rather
+//! than duplicating it.
+//! What: [`fill_key_facts`] sets the `facts_*` scalars on the root [`Scope`]
+//! from data already loaded onto the model (LoC, file counts, languages,
+//! complexity distribution — all from `AnalyzeMetrics`, re-aggregated across
+//! every repository). Author count, work-volume estimate, and monthly
+//! trajectory are PR B's authorship-artifact fields (#5453) — left unset here
+//! so each renders as the honesty marker and surfaces its own line under
+//! Gaps & Caveats until that data exists, per the omit-empty row rule
+//! (`polish.rs::process_table`). tga has no effort-estimation metric today
+//! (verified: `story_points` fields are documented placeholders, always
+//! zero) — `facts_work_estimate` stays unset rather than inventing one.
+//! Test: `reporter_facts_tests.rs`.
+
+use super::fill::Scope;
+use super::model::ReportModel;
+use super::provenance::{Provenance, tag};
+
+/// Fill the Key Facts scalars from data already on `model`.
+///
+/// Why: single entry point `reporter::build_scope` calls; keeps the
+/// aggregation logic out of `reporter.rs` (SLOC pressure — see its module
+/// doc) and testable in isolation.
+/// What: sums LoC/file counts across every repository with metrics, ranks
+/// languages by aggregate LoC, and re-projects the merged complexity
+/// distribution as a compact percentage summary. Each scalar is set only
+/// when the underlying data is non-empty, so an all-remote or metrics-free
+/// manifest leaves every row as a named gap rather than a stated zero.
+/// Test: `reporter_facts_tests::{fills_aggregate_facts, empty_model_is_all_gaps}`.
+pub fn fill_key_facts(root: &mut Scope, model: &ReportModel) {
+    let total_loc: u64 = model
+        .repositories
+        .iter()
+        .filter_map(|r| r.metrics.as_ref())
+        .map(|m| m.loc.total)
+        .sum();
+    if total_loc > 0 {
+        root.set(
+            "facts_total_loc",
+            tag(total_loc.to_string(), Provenance::Measured),
+        );
+    }
+
+    let total_files: u64 = model
+        .repositories
+        .iter()
+        .filter_map(|r| r.metrics.as_ref())
+        .map(|m| m.counts.files)
+        .sum();
+    if total_files > 0 {
+        root.set(
+            "facts_total_files",
+            tag(total_files.to_string(), Provenance::Measured),
+        );
+    }
+
+    let langs = aggregate_languages(model);
+    if !langs.is_empty() {
+        root.set(
+            "facts_languages",
+            tag(langs.join(", "), Provenance::Measured),
+        );
+    }
+
+    if let Some(summary) = complexity_profile(model) {
+        root.set(
+            "facts_complexity_summary",
+            tag(summary, Provenance::Measured),
+        );
+    }
+
+    // #5453: facts_author_count / facts_work_estimate / facts_trajectory are
+    // intentionally left unset in PR A — see module doc. PR B's authorship
+    // artifact completes them.
+}
+
+/// The top 5 languages by aggregate LoC across every repository with metrics.
+fn aggregate_languages(model: &ReportModel) -> Vec<String> {
+    let mut totals: Vec<(String, u64)> = Vec::new();
+    for m in model.repositories.iter().filter_map(|r| r.metrics.as_ref()) {
+        for lang in &m.loc.by_language {
+            match totals.iter_mut().find(|(name, _)| *name == lang.language) {
+                Some(entry) => entry.1 += lang.loc,
+                None => totals.push((lang.language.clone(), lang.loc)),
+            }
+        }
+    }
+    totals.sort_by_key(|(_, loc)| std::cmp::Reverse(*loc));
+    totals.into_iter().take(5).map(|(name, _)| name).collect()
+}
+
+/// A compact "label: count (pct%)" complexity summary, merged across every
+/// repository's `AnalyzeMetrics.complexity` buckets by matching label.
+///
+/// Why: a single engagement-wide profile is what "frontload facts" asks for;
+/// per-application detail already lives in §4's Health-Factor Scores and the
+/// Graph Appendix's `complexity_distribution` dataset.
+/// What: `None` when no repository contributed any bucket (nothing to show).
+fn complexity_profile(model: &ReportModel) -> Option<String> {
+    let mut buckets: Vec<(String, u64)> = Vec::new();
+    for m in model.repositories.iter().filter_map(|r| r.metrics.as_ref()) {
+        for b in &m.complexity.buckets {
+            match buckets.iter_mut().find(|(label, _)| *label == b.label) {
+                Some(entry) => entry.1 += b.count,
+                None => buckets.push((b.label.clone(), b.count)),
+            }
+        }
+    }
+    let total: u64 = buckets.iter().map(|(_, c)| c).sum();
+    if total == 0 {
+        return None;
+    }
+    let parts: Vec<String> = buckets
+        .iter()
+        .map(|(label, count)| {
+            let pct = (*count as f64 / total as f64) * 100.0;
+            format!("{label}: {count} ({pct:.0}%)")
+        })
+        .collect();
+    Some(parts.join("; "))
+}
+
+#[cfg(test)]
+#[path = "reporter_facts_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/reporter_facts_tests.rs
+++ b/crates/trusty-review/src/report/reporter_facts_tests.rs
@@ -1,0 +1,141 @@
+use super::*;
+use crate::report::metrics::{
+    AnalyzeMetrics, ComplexityBucket, ComplexityDistribution, CountMetrics, LanguageLoc, LocMetrics,
+};
+use crate::report::model::RepositoryReport;
+
+fn repo(metrics: Option<AnalyzeMetrics>) -> RepositoryReport {
+    RepositoryReport {
+        name: "app".to_string(),
+        slug: "app".to_string(),
+        source: "/tmp/app".to_string(),
+        source_kind: "local_path".to_string(),
+        username: None,
+        git_ref: None,
+        git_info: None,
+        local_path: None,
+        scan: None,
+        metrics,
+    }
+}
+
+fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
+    ReportModel {
+        title: "Test".to_string(),
+        template: "report-technical-dd".to_string(),
+        analyst: None,
+        client: None,
+        vendor_methodology: crate::report::model::vendor_methodology(),
+        instructions: None,
+        instructions_source: None,
+        report_date: "2026-08-18".to_string(),
+        generated_date: "2026-08-18".to_string(),
+        manifest_path: "manifest.toml".to_string(),
+        repositories: repos,
+        gaps: vec![],
+        synthesis: None,
+        benchmark: None,
+        investigation: None,
+        section_instructions: Default::default(),
+        ticketing: None,
+    }
+}
+
+/// (a)-style: facts fill from data already present on the model.
+#[test]
+fn fills_aggregate_facts() {
+    let metrics = AnalyzeMetrics {
+        loc: LocMetrics {
+            total: 1000,
+            by_language: vec![
+                LanguageLoc {
+                    language: "Rust".to_string(),
+                    loc: 800,
+                },
+                LanguageLoc {
+                    language: "Shell".to_string(),
+                    loc: 200,
+                },
+            ],
+        },
+        counts: CountMetrics {
+            files: 42,
+            functions: 100,
+        },
+        complexity: ComplexityDistribution {
+            buckets: vec![
+                ComplexityBucket {
+                    label: "low (1-5)".to_string(),
+                    count: 80,
+                },
+                ComplexityBucket {
+                    label: "high (>20)".to_string(),
+                    count: 20,
+                },
+            ],
+        },
+        ..Default::default()
+    };
+    let model = model_with(vec![repo(Some(metrics))]);
+
+    let mut scope = Scope::new();
+    fill_key_facts(&mut scope, &model);
+    let rendered = crate::report::fill::render(
+        "{{facts_total_loc}}|{{facts_total_files}}|{{facts_languages}}|{{facts_complexity_summary}}",
+        &scope,
+    );
+
+    assert!(rendered.contains("1000"));
+    assert!(rendered.contains("42"));
+    assert!(rendered.contains("Rust"));
+    assert!(rendered.contains("low (1-5): 80 (80%)"));
+    assert!(rendered.contains("high (>20): 20 (20%)"));
+    // Author/work/trajectory rows are PR B's — never fabricated here.
+    assert!(!rendered.contains("facts_author_count"));
+}
+
+/// (b)-style: a model with no metrics produces honesty markers, never
+/// fabricated values — every `facts_*` scalar stays unset.
+#[test]
+fn empty_model_is_all_gaps() {
+    let model = model_with(vec![repo(None)]);
+    let mut scope = Scope::new();
+    fill_key_facts(&mut scope, &model);
+    let rendered = crate::report::fill::render(
+        "{{facts_total_loc}}|{{facts_total_files}}|{{facts_languages}}|{{facts_complexity_summary}}",
+        &scope,
+    );
+    assert_eq!(
+        rendered,
+        format!("{h}|{h}|{h}|{h}", h = crate::report::fill::HONESTY_MARKER)
+    );
+}
+
+/// Complexity buckets with the same label across repositories merge counts
+/// rather than producing duplicate rows.
+#[test]
+fn complexity_buckets_merge_across_repositories() {
+    let m1 = AnalyzeMetrics {
+        complexity: ComplexityDistribution {
+            buckets: vec![ComplexityBucket {
+                label: "low (1-5)".to_string(),
+                count: 10,
+            }],
+        },
+        ..Default::default()
+    };
+    let m2 = AnalyzeMetrics {
+        complexity: ComplexityDistribution {
+            buckets: vec![ComplexityBucket {
+                label: "low (1-5)".to_string(),
+                count: 10,
+            }],
+        },
+        ..Default::default()
+    };
+    let model = model_with(vec![repo(Some(m1)), repo(Some(m2))]);
+    let mut scope = Scope::new();
+    fill_key_facts(&mut scope, &model);
+    let rendered = crate::report::fill::render("{{facts_complexity_summary}}", &scope);
+    assert_eq!(rendered, "low (1-5): 20 (100%) ⁽ᵐ⁾");
+}

--- a/crates/trusty-review/src/report/reporter_performance.rs
+++ b/crates/trusty-review/src/report/reporter_performance.rs
@@ -1,0 +1,46 @@
+//! Performance & Scalability: a deliberately-empty, honestly-captioned gap
+//! section (#6004).
+//!
+//! Why: DOC-67 §3 declares a performance dimension unavailable — this
+//! pipeline collects no load-test results, latency/throughput measurements,
+//! or capacity data from any source. Rather than leave the section as bare
+//! template scaffolding (which the omit-empty pass would silently collapse
+//! to a generic "No data available" line indistinguishable from any other
+//! empty section), it states explicitly what a performance assessment WOULD
+//! need and that none was made — the same "named gap, not a silent one"
+//! principle #5239 established for Gaps & Caveats.
+//! What: [`PERFORMANCE_NOTE`] is FIXED text — never LLM-touched, never
+//! computed from the model — so [`fill_performance_note`] renders
+//! byte-identical output regardless of whether synthesis ran or what it
+//! produced.
+//! Test: `reporter_performance_tests.rs`.
+
+use super::fill::Scope;
+
+/// The fixed Performance & Scalability section text.
+///
+/// Why: naming this a constant (rather than building the string inline) is
+/// what makes the byte-identical-regardless-of-synthesis property mechanical
+/// rather than a convention someone can drift from.
+pub const PERFORMANCE_NOTE: &str = "No performance or scalability assessment was made for this \
+    report. This pipeline has no performance data source: it collects no load-test results, \
+    latency/throughput measurements, or capacity/scaling headroom data (DOC-67 §3). A \
+    performance assessment would require load tests run under representative traffic, \
+    latency and throughput percentiles, and capacity data showing how the system behaves \
+    as load and data volume grow — none of which was collected or assessed here.";
+
+/// Set the Performance & Scalability section's fixed text.
+///
+/// Why: single call site `reporter::build_scope` uses; kept out of
+/// `reporter.rs` for the same SLOC reason as its `reporter_*` siblings.
+/// What: unconditionally sets `performance_assessment_note` to
+/// [`PERFORMANCE_NOTE`] — never gated on model data, never touched by
+/// synthesis.
+/// Test: `reporter_performance_tests::note_is_fixed_regardless_of_synthesis`.
+pub fn fill_performance_note(root: &mut Scope) {
+    root.set("performance_assessment_note", PERFORMANCE_NOTE);
+}
+
+#[cfg(test)]
+#[path = "reporter_performance_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/reporter_performance_tests.rs
+++ b/crates/trusty-review/src/report/reporter_performance_tests.rs
@@ -1,0 +1,17 @@
+use super::*;
+
+/// (d): the Performance section text is byte-identical regardless of the
+/// model or whether synthesis ran — it never reads from the model at all.
+#[test]
+fn note_is_fixed_regardless_of_synthesis() {
+    let mut a = Scope::new();
+    fill_performance_note(&mut a);
+    let mut b = Scope::new();
+    fill_performance_note(&mut b);
+
+    let rendered_a = crate::report::fill::render("{{performance_assessment_note}}", &a);
+    let rendered_b = crate::report::fill::render("{{performance_assessment_note}}", &b);
+    assert_eq!(rendered_a, rendered_b);
+    assert_eq!(rendered_a, PERFORMANCE_NOTE);
+    assert!(rendered_a.contains("No performance or scalability assessment was made"));
+}

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -20,11 +20,16 @@ use crate::report::template::TemplateLoader;
 /// Build a model from an in-memory manifest whose single repo has metrics.
 fn fixture_model(dir: &Path) -> ReportModel {
     // Write a metrics file the manifest will reference by relative path.
+    // #6004: `complexity` populates Key Facts + Code Quality — every field the
+    // bundled template asks for must be present so the full-purity assertions
+    // in `render_contains_expected`/`reporter_omits_empty_findings_sections_
+    // without_metrics` (zero honesty markers anywhere) still hold.
     let metrics = r#"{
       "loc": { "total": 5000, "by_language": [
         { "language": "Rust", "loc": 5000 }
       ]},
-      "counts": { "files": 20, "functions": 150 }
+      "counts": { "files": 20, "functions": 150 },
+      "complexity": { "buckets": [ { "label": "low (1-5)", "count": 150 } ] }
     }"#;
     std::fs::write(dir.join("acme.json"), metrics).expect("write metrics");
 
@@ -140,6 +145,75 @@ fn render_contains_expected() {
     assert!(!md.contains("{{"));
 }
 
+/// (a) #6004: a model WITH analyze data yields both the Code Quality &
+/// Architecture and Security Posture sections populated — never blank
+/// scaffolding.
+/// Test: this test itself.
+#[test]
+fn code_quality_and_security_sections_populate_from_analyze_data() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = fixture_model_with_findings(tmp.path());
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(md.contains("## Code Quality & Architecture"));
+    assert!(md.contains("## Security Posture"));
+    assert!(md.contains("## Performance & Scalability"));
+    // Code Quality: the fixture's LoC/language/maintainability-finding data.
+    assert!(md.contains("Acme Web"));
+    assert!(md.contains("5000"));
+    // Security Posture: the fixture's RED "security"-category finding,
+    // re-projected as a violation-domain row — not the maintainability one.
+    assert!(md.contains("security"));
+    let security_section = md
+        .split("## Security Posture")
+        .nth(1)
+        .and_then(|s| s.split("## Performance").next())
+        .expect("Security Posture section present");
+    assert!(!security_section.contains("_No data available"));
+    // Performance stays the fixed gap text regardless of the data present.
+    assert!(md.contains(crate::report::reporter_performance::PERFORMANCE_NOTE));
+}
+
+/// (b) #6004: a model WITHOUT analyze data leaves both sections as honesty
+/// markers folded into Gaps & Caveats, never blank or fabricated — Code
+/// Quality's table collapses (no metrics anywhere) and Performance still
+/// states its fixed gap text (never a silent absence).
+/// Test: this test itself.
+#[test]
+fn code_quality_and_security_sections_gap_without_analyze_data() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let toml = r#"
+        [report]
+        title = "No Metrics DD"
+
+        [[repositories]]
+        name = "Acme Web"
+        remote = "acme/web"
+    "#;
+    let manifest_path = tmp.path().join("manifest.toml");
+    let manifest = parse_manifest(toml, &manifest_path).expect("manifest parse");
+    let model = ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None)
+        .expect("build model");
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(md.contains("## Code Quality & Architecture"));
+    assert!(md.contains("## Security Posture"));
+    assert!(
+        !md.contains(HONESTY_MARKER),
+        "omit-empty must fold every unmapped field into Gaps, never leave a marker: {md}"
+    );
+    assert!(md.contains("Data gaps:"));
+    // Performance & Scalability is FIXED — present and identical even with
+    // zero analyze data (never a silent gap, never LLM-touched).
+    assert!(md.contains(crate::report::reporter_performance::PERFORMANCE_NOTE));
+}
+
 /// Why: the CAST template's demonstration `<!-- instruct:executive_summary
 /// ... -->` override (#2357 layered instructions) must NEVER leak into a real
 /// rendered report — a comment-stripping regression here would be a live
@@ -229,6 +303,8 @@ fn reporter_injects_synthesis_prose() {
     let mut model = fixture_model(tmp.path());
     let slug = model.repositories[0].slug.clone();
     model.synthesis = Some(Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
         executive_summary: Some("A grounded acquirer-relevant summary.".to_string()),
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -287,6 +363,8 @@ fn reporter_appends_guardrail_rejection_note() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let mut model = fixture_model(tmp.path());
     model.synthesis = Some(Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
         notes: vec![
             "synthesis: rejected (unverified figure) in executive summary: 9999".to_string(),
         ],
@@ -433,6 +511,8 @@ fn evidence_renders_as_fenced_block() {
     let mut model = fixture_model(tmp.path());
     let slug = model.repositories[0].slug.clone();
     model.synthesis = Some(Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
         executive_summary: None,
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -485,6 +565,8 @@ fn evidence_with_blank_line_fences_cleanly() {
     let quote =
         "function serializeSession(user) {\n\n  return Buffer.from(JSON.stringify(user));\n}";
     model.synthesis = Some(Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
         executive_summary: None,
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -540,6 +622,8 @@ fn evidence_containing_triple_backticks_uses_longer_fence() {
     let slug = model.repositories[0].slug.clone();
     let quote = "const doc = \"```js\\nconsole.log(1)\\n```\";";
     model.synthesis = Some(Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
         executive_summary: None,
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -614,6 +698,8 @@ fn evidence_with_adjacent_hash_comment_lines_renders_byte_identical() {
     let slug = model.repositories[0].slug.clone();
     let quote = "# ALLOWED_OAUTH_DOMAINS: comma-separated Google Workspace hosted-domains (`hd`\n# claim) allowed to enter the visualization area. The gate FAILS CLOSED if this\n# is empty.";
     model.synthesis = Some(Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
         executive_summary: None,
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -677,6 +763,8 @@ fn evidence_with_blank_line_full_render_has_no_fenced_splice() {
     let slug = model.repositories[0].slug.clone();
     let quote = "AI_GATEWAY_API_KEY=\n\n# Optional overrides for the gateway model IDs (format: \"provider/model\").\n# Defaults: AI_GATEWAY_MODEL=anthropic/claude-sonnet-4-5-20250929,";
     model.synthesis = Some(Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
         executive_summary: None,
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -851,6 +939,8 @@ fn reporter_merges_synthesis_prose_onto_deterministic_finding() {
     let mut model = fixture_model_with_findings(tmp.path());
     let slug = model.repositories[0].slug.clone();
     model.synthesis = Some(Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
         executive_summary: None,
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -1262,6 +1352,8 @@ fn reporter_tags_top_risks_as_inferred() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let mut model = fixture_model(tmp.path());
     model.synthesis = Some(Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
         executive_summary: Some("Summary.".to_string()),
         top_risks: vec![RiskRow {
             description: "Unpatched dependency chain".to_string(),
@@ -1307,6 +1399,8 @@ fn reporter_renders_all_top_risk_rows() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let mut model = fixture_model(tmp.path());
     model.synthesis = Some(Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
         executive_summary: Some("Summary.".to_string()),
         top_risks: (1..=5).map(risk).collect(),
         findings: vec![],
@@ -1357,6 +1451,8 @@ fn reporter_collapses_empty_top_risks() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let mut model = fixture_model(tmp.path());
     model.synthesis = Some(Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
         executive_summary: Some("Summary.".to_string()),
         top_risks: vec![],
         findings: vec![],
@@ -1396,6 +1492,8 @@ fn reporter_renders_defaulted_top_risk_severity_honestly() {
     let mut model = fixture_model(tmp.path());
     model.synthesis = Some(Synthesis {
         executive_summary: Some("Summary.".to_string()),
+        code_quality_summary: None,
+        security_summary: None,
         top_risks: vec![RiskRow {
             description: "Plaintext secrets at rest".to_string(),
             severity: String::new(),
@@ -1840,6 +1938,8 @@ fn reporter_prefers_synthesis_over_deterministic_summary() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let mut model = fixture_model_with_findings(tmp.path());
     model.synthesis = Some(Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
         executive_summary: Some("An acquirer-relevant judgement.".to_string()),
         top_risks: vec![RiskRow {
             description: "Credential exposure".to_string(),

--- a/crates/trusty-review/src/report/section_instructions.rs
+++ b/crates/trusty-review/src/report/section_instructions.rs
@@ -27,9 +27,19 @@ pub const EXECUTIVE_SUMMARY: &str = "executive_summary";
 pub const TOP_RISKS: &str = "top_risks";
 /// Section id: per-finding elaboration prose.
 pub const FINDING_ELABORATION: &str = "finding_elaboration";
+/// Section id: the Code Quality & Architecture narrative paragraph (#6004).
+pub const CODE_QUALITY_SUMMARY: &str = "code_quality_summary";
+/// Section id: the Security Posture narrative paragraph (#6004).
+pub const SECURITY_SUMMARY: &str = "security_summary";
 
 /// Every recognised section id, in the order they appear in the synthesis output.
-pub const ALL_SECTION_IDS: &[&str] = &[EXECUTIVE_SUMMARY, TOP_RISKS, FINDING_ELABORATION];
+pub const ALL_SECTION_IDS: &[&str] = &[
+    EXECUTIVE_SUMMARY,
+    TOP_RISKS,
+    FINDING_ELABORATION,
+    CODE_QUALITY_SUMMARY,
+    SECURITY_SUMMARY,
+];
 
 /// True when `id` names a recognised synthesized section.
 ///
@@ -50,17 +60,26 @@ pub fn is_valid_section_id(id: &str) -> bool {
 /// Test: `section_instructions_tests::defaults_cover_all_sections`.
 pub fn default_instruction(id: &str) -> Option<&'static str> {
     match id {
+        // #6004: balanced/adversarial voice — the owner's characterization is
+        // "acquirer-side, skeptical, strengths and risks presented evenhandedly
+        // but risk hunted adversarially, never promotional." Applied to every
+        // default below; a template's `instruct:` override may still replace it.
         EXECUTIVE_SUMMARY => Some(
             "Write ONE deal-analytic paragraph synthesising the verified findings, \
              severity-weighted (RED findings first), tied to what an acquirer must act \
-             on. Reference a coverage gap ONLY if one is genuinely named in the coverage \
-             data above (a listed not-investigated dimension or a named failed batch) — \
-             and name it specifically; never imply a gap that isn't documented there.",
+             on. Write from the acquirer's side: skeptical and adversarial about risk — \
+             hunt for what should worry a buyer — while still naming genuine strengths \
+             the data supports, evenhandedly, never as promotional filler. Reference a \
+             coverage gap ONLY if one is genuinely named in the coverage data above (a \
+             listed not-investigated dimension or a named failed batch) — and name it \
+             specifically; never imply a gap that isn't documented there.",
         ),
         TOP_RISKS => Some(
             "List the most material RED/AMBER risks, most material first (at most 5 \
              rows), each with a qualitative cost/effort framing and the affected \
-             application(s). Draw ONLY from the findings provided.",
+             application(s). Draw ONLY from the findings provided. Hunt for risk \
+             adversarially, from the acquirer's side — do not soften a finding to read \
+             as minor when the underlying data does not support that.",
         ),
         FINDING_ELABORATION => Some(
             "For each finding listed as requiring elaboration, write one concise \
@@ -69,6 +88,21 @@ pub fn default_instruction(id: &str) -> Option<&'static str> {
              already verified elsewhere in the provided data — leave it out of this \
              list entirely; re-elaborating it wastes output budget and cannot improve \
              on already-verified prose.",
+        ),
+        CODE_QUALITY_SUMMARY => Some(
+            "Write ONE paragraph on code quality and architecture, grounded strictly in \
+             the complexity distribution, code-smell/refactor findings, and LoC/tech-stack \
+             data provided. Take the acquirer's skeptical side on maintainability risk \
+             while naming genuine strengths the data supports, evenhandedly. Never invent \
+             an architectural pattern or a metric not present in the data.",
+        ),
+        SECURITY_SUMMARY => Some(
+            "Write ONE paragraph characterising the security posture strictly from the \
+             lint-graded RED/AMBER findings provided. This is code-hygiene signal, NOT a \
+             SAST/CVE/secrets/pen-test result — never write as though it were; state that \
+             limitation if it changes how a risk should be read. Take the acquirer's \
+             skeptical side while still crediting a genuinely clean signal where the data \
+             supports it.",
         ),
         _ => None,
     }

--- a/crates/trusty-review/src/report/synthesize.rs
+++ b/crates/trusty-review/src/report/synthesize.rs
@@ -69,6 +69,14 @@ pub struct Synthesis {
     /// Verified executive-summary prose, or `None` when the guardrail rejected it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub executive_summary: Option<String>,
+    /// Verified Code Quality & Architecture narrative, or `None` when rejected or
+    /// never emitted (#6004). Same guardrail path as `executive_summary`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code_quality_summary: Option<String>,
+    /// Verified Security Posture narrative, or `None` when rejected or never
+    /// emitted (#6004). Same guardrail path as `executive_summary`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub security_summary: Option<String>,
     /// Verified top-risk rows (rejected rows are dropped).
     #[serde(default)]
     pub top_risks: Vec<RiskRow>,
@@ -429,6 +437,12 @@ enum Attempt {
 struct RawSynthesis {
     #[serde(default)]
     executive_summary: String,
+    /// #6004: same schema/call/guardrail as `executive_summary`.
+    #[serde(default)]
+    code_quality_summary: String,
+    /// #6004: same schema/call/guardrail as `executive_summary`.
+    #[serde(default)]
+    security_summary: String,
     #[serde(default)]
     top_risks: Vec<RiskRow>,
     #[serde(default)]
@@ -540,6 +554,13 @@ fn parse_markdown_fallback(text: &str) -> Option<RawSynthesis> {
     }
     Some(RawSynthesis {
         executive_summary: exec,
+        // #6004 fields are never recoverable from this free-text fallback —
+        // reconstructing them from prose would mean inventing content the
+        // model never structured; they stay empty and the guardrail leaves
+        // them absent from `Synthesis`, same honesty-marker path as an
+        // outright-rejected field.
+        code_quality_summary: String::new(),
+        security_summary: String::new(),
         top_risks: Vec::new(),
         findings: Vec::new(),
     })
@@ -618,6 +639,27 @@ fn apply_guardrail(
         }
     }
 
+    // #6004: Code Quality & Architecture and Security Posture narratives — same
+    // per-field guardrail path as the executive summary.
+    let code_quality = raw.code_quality_summary.trim();
+    if !code_quality.is_empty() {
+        match verify_prose(code_quality, allowed) {
+            Ok(()) => out.code_quality_summary = Some(code_quality.to_string()),
+            Err(tok) => out
+                .notes
+                .push(format!("{REJECTED_NOTE} in code quality summary: {tok}")),
+        }
+    }
+    let security = raw.security_summary.trim();
+    if !security.is_empty() {
+        match verify_prose(security, allowed) {
+            Ok(()) => out.security_summary = Some(security.to_string()),
+            Err(tok) => out
+                .notes
+                .push(format!("{REJECTED_NOTE} in security summary: {tok}")),
+        }
+    }
+
     // Top-risk rows.
     for (i, r) in raw.top_risks.into_iter().enumerate() {
         match verify_all(&[&r.description, &r.severity, &r.cost, &r.apps], allowed) {
@@ -656,7 +698,12 @@ fn apply_guardrail(
         }
     }
 
-    if out.executive_summary.is_none() && out.top_risks.is_empty() && out.findings.is_empty() {
+    if out.executive_summary.is_none()
+        && out.code_quality_summary.is_none()
+        && out.security_summary.is_none()
+        && out.top_risks.is_empty()
+        && out.findings.is_empty()
+    {
         return Err(SynthesisError::NoVerifiableContent);
     }
     Ok(out)

--- a/crates/trusty-review/src/report/synthesize_normalize.rs
+++ b/crates/trusty-review/src/report/synthesize_normalize.rs
@@ -38,8 +38,16 @@ type FieldTable = &'static [(&'static str, &'static [&'static str])];
 /// all three #6009 shapes — listed anyway so an unrecognised top-level key is
 /// dropped (and noted) rather than silently retained by serde's default
 /// unknown-field tolerance.
+///
+/// #6004: `code_quality_summary` and `security_summary` are listed here too —
+/// this whitelist is the single gate every top-level key passes through
+/// before `serde_json::from_value`, so a narrative slot absent from this
+/// table is silently dropped as "unrecognized" even though `RawSynthesis`
+/// and [`super::synthesize_prompt::synthesis_schema`] both declare it.
 const TOP_LEVEL_FIELDS: FieldTable = &[
     ("executive_summary", &[]),
+    ("code_quality_summary", &[]),
+    ("security_summary", &[]),
     ("top_risks", &[]),
     ("findings", &[]),
 ];

--- a/crates/trusty-review/src/report/synthesize_prompt.rs
+++ b/crates/trusty-review/src/report/synthesize_prompt.rs
@@ -38,7 +38,7 @@
 use crate::llm::{ChatMessage, LlmRequest, ResponseSchema, strip_provider_prefix};
 use crate::report::model::ReportModel;
 use crate::report::section_instructions::{
-    self, EXECUTIVE_SUMMARY, FINDING_ELABORATION, TOP_RISKS,
+    self, CODE_QUALITY_SUMMARY, EXECUTIVE_SUMMARY, FINDING_ELABORATION, SECURITY_SUMMARY, TOP_RISKS,
 };
 use crate::report::synthesize_digest::{
     build_split, gather_compact_findings, render_context_section, render_elaboration_section,
@@ -87,6 +87,16 @@ pub(crate) fn synthesis_schema(top_risks_cap: usize) -> ResponseSchema {
                 "executive_summary": {
                     "type": "string",
                     "description": "ONE deal-relevant paragraph synthesised across all applications. Use ONLY figures present in the provided data; never invent numbers; preserve any \"(approx)\" marker verbatim."
+                },
+                // #6004: two additional narrative slots, same schema/call/guardrail as
+                // executive_summary — see synthesize.rs::apply_guardrail.
+                "code_quality_summary": {
+                    "type": "string",
+                    "description": "ONE paragraph on code quality and architecture, grounded ONLY in the complexity/findings/LoC data provided. Empty string if the data supports nothing."
+                },
+                "security_summary": {
+                    "type": "string",
+                    "description": "ONE paragraph characterising security posture from the lint-graded RED/AMBER findings ONLY — this is code-hygiene signal, not a SAST/CVE/secrets scan. Empty string if the data supports nothing."
                 },
                 "top_risks": {
                     "type": "array",
@@ -243,9 +253,21 @@ fn synthesis_system_prompt(
         .get(FINDING_ELABORATION)
         .map(String::as_str)
         .unwrap_or_default();
+    // #6004: two additional resolved narrative slots.
+    let code_quality = resolved
+        .get(CODE_QUALITY_SUMMARY)
+        .map(String::as_str)
+        .unwrap_or_default();
+    let security = resolved
+        .get(SECURITY_SUMMARY)
+        .map(String::as_str)
+        .unwrap_or_default();
 
     let mut prompt = format!(
         r#"You are a senior technical due-diligence analyst writing the narrative sections of an acquisition-grade report from pre-computed repository analysis data.
+
+## Voice
+Write from the acquirer's side: balanced but adversarial. Hunt for risk skeptically — never read a finding as more benign than the data supports — while still naming genuine strengths the data actually shows, evenhandedly. Never write promotional or vendor-style prose.
 
 ## Absolute rules
 - Use ONLY values present in the provided data. NEVER invent, estimate, or extrapolate a number that is not given.
@@ -267,7 +289,9 @@ Respond with ONLY a single JSON object — no markdown headings, no prose outsid
 Populate the structured response:
 - `executive_summary`: {exec}
 - `top_risks`: {risks}
-- `findings`: {elaboration}"#
+- `findings`: {elaboration}
+- `code_quality_summary`: {code_quality}
+- `security_summary`: {security}"#
     );
 
     if retry_concise {

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -794,6 +794,50 @@ fn code_quality_summary_guardrail_rejects_unverified_figure() {
     );
 }
 
+/// (c) #6004: `security_summary` is rejected exactly like
+/// `code_quality_summary` when it cites a figure absent from the model — same
+/// construction as `code_quality_summary_guardrail_rejects_unverified_figure`,
+/// mirrored onto the sibling field.
+/// What: one clean top-risk row (so the overall pass still succeeds) plus a
+/// `security_summary` citing 9999; asserts the field is dropped, a rejection
+/// note names it, and the clean row survives untouched.
+/// Test: this test itself.
+#[test]
+fn security_summary_guardrail_rejects_unverified_figure() {
+    let allowed: std::collections::HashSet<String> = ["moderate".to_string(), "Acme".to_string()]
+        .into_iter()
+        .collect();
+    let raw = super::RawSynthesis {
+        executive_summary: String::new(),
+        code_quality_summary: String::new(),
+        security_summary: "9999 vulnerable dependencies were flagged.".to_string(),
+        top_risks: vec![super::RiskRow {
+            description: "moderate".to_string(),
+            severity: "AMBER".to_string(),
+            cost: "moderate".to_string(),
+            apps: "Acme".to_string(),
+        }],
+        findings: vec![],
+    };
+
+    let result = super::apply_guardrail(raw, &allowed, Vec::new())
+        .expect("the clean top-risk row keeps this Ok");
+
+    assert!(
+        result.security_summary.is_none(),
+        "a security_summary citing 9999 must be rejected"
+    );
+    assert_eq!(result.top_risks.len(), 1, "the clean row must survive");
+    assert!(
+        result
+            .notes
+            .iter()
+            .any(|n| n.contains("rejected (unverified figure)") && n.contains("security")),
+        "a guardrail rejection note must name the security summary: {:?}",
+        result.notes
+    );
+}
+
 /// Why: when nothing survives verification there is no narrative, which #5454
 /// makes a failed report rather than a deterministic-only one.
 /// What: every field cites 9999; asserts

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -299,6 +299,10 @@ fn synthesis_schema_shape() {
     assert_eq!(schema.name, "report_synthesis");
     let props = &schema.schema["properties"];
     assert!(props["executive_summary"].is_object());
+    // #6004: the two additional narrative slots must be forced via the same
+    // schema value as executive_summary.
+    assert!(props["code_quality_summary"].is_object());
+    assert!(props["security_summary"].is_object());
     assert!(props["top_risks"].is_object());
     assert!(props["findings"].is_object());
     assert_eq!(props["top_risks"]["maxItems"], 5);
@@ -322,6 +326,10 @@ fn schema_contract_statement_lists_every_field_name() {
     let contract = schema_contract_statement(&schema.schema);
     for needle in [
         "executive_summary",
+        // #6004: the contract statement is derived from the same schema
+        // value, so these must be named alongside executive_summary.
+        "code_quality_summary",
+        "security_summary",
         "top_risks",
         "findings",
         "description",
@@ -354,6 +362,10 @@ fn schema_contract_statement_reaches_system_prompt() {
     let req = build_synthesis_prompt(&model, "stub/model", false);
     assert!(req.system.contains("Required JSON object shape"));
     assert!(req.system.contains("executive_summary"));
+    // #6004: the same derivation must carry the new narrative slots into the
+    // system prompt text, not just `response_format`.
+    assert!(req.system.contains("code_quality_summary"));
+    assert!(req.system.contains("security_summary"));
     assert!(req.system.contains("top_risks"));
     assert!(req.system.contains("findings"));
 }
@@ -511,6 +523,50 @@ async fn synthesize_happy_path_injects() {
     assert_eq!(result.findings.len(), 1);
     assert_eq!(result.findings[0].app_slug, "acme-core");
     assert!(result.notes.is_empty(), "clean response records no notes");
+}
+
+/// Why: regression for the rebase seam between #6009/#6014's whitelist
+/// normalizer and #6004's two new narrative slots — a normalizer whitelist
+/// keyed only off the pre-#6004 field set silently drops
+/// `code_quality_summary`/`security_summary` as "unrecognized" even though
+/// both the schema and `RawSynthesis` declare them.
+/// What: a full-shape response carrying both new fields, grounded in figures
+/// present in the fixture model; asserts both survive parse → normalize →
+/// guardrail into `Synthesis`, and that no drop note was recorded for either.
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_happy_path_injects_new_narrative_fields() {
+    let model = fixture_model(vec![red("SQL injection risk")]);
+    let body = r#"{
+      "executive_summary": "The 8,200 LoC Rust codebase spans 120 files and 640 functions with one critical security gap.",
+      "code_quality_summary": "The 8,200 LoC codebase spans 120 files, a moderate footprint.",
+      "security_summary": "640 functions were assessed; one RED finding stands out.",
+      "top_risks": [],
+      "findings": []
+    }"#
+    .to_string();
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body,
+        finish_reason: Some("stop".to_string()),
+    });
+    let result = Synthesizer::new(llm, "stub/model")
+        .synthesize(&model)
+        .await
+        .expect("a clean response synthesizes");
+
+    assert_eq!(
+        result.code_quality_summary.as_deref(),
+        Some("The 8,200 LoC codebase spans 120 files, a moderate footprint.")
+    );
+    assert_eq!(
+        result.security_summary.as_deref(),
+        Some("640 functions were assessed; one RED finding stands out.")
+    );
+    assert!(
+        result.notes.is_empty(),
+        "neither new field is unrecognized or unverified: {:?}",
+        result.notes
+    );
 }
 
 /// Why: a malformed response must never be partial-trusted. #5454 regression —
@@ -693,6 +749,51 @@ async fn synthesize_rejects_unverified_figure() {
     );
 }
 
+/// (c) #6004: `code_quality_summary` is rejected exactly like
+/// `executive_summary` when it cites a figure absent from the model —
+/// constructed by calling the guardrail directly (`apply_guardrail`), not by
+/// routing a fabricated figure through a stub LLM whose trigger condition is
+/// the same as `synthesize_rejects_unverified_figure` already covers.
+/// What: one clean top-risk row (so the overall pass still succeeds) plus a
+/// `code_quality_summary` citing 9999; asserts the field is dropped, a
+/// rejection note names it, and the clean row survives untouched.
+/// Test: this test itself.
+#[test]
+fn code_quality_summary_guardrail_rejects_unverified_figure() {
+    let allowed: std::collections::HashSet<String> = ["moderate".to_string(), "Acme".to_string()]
+        .into_iter()
+        .collect();
+    let raw = super::RawSynthesis {
+        executive_summary: String::new(),
+        code_quality_summary: "Complexity sits at 9999 on average.".to_string(),
+        security_summary: String::new(),
+        top_risks: vec![super::RiskRow {
+            description: "moderate".to_string(),
+            severity: "AMBER".to_string(),
+            cost: "moderate".to_string(),
+            apps: "Acme".to_string(),
+        }],
+        findings: vec![],
+    };
+
+    let result = super::apply_guardrail(raw, &allowed, Vec::new())
+        .expect("the clean top-risk row keeps this Ok");
+
+    assert!(
+        result.code_quality_summary.is_none(),
+        "a code_quality_summary citing 9999 must be rejected"
+    );
+    assert_eq!(result.top_risks.len(), 1, "the clean row must survive");
+    assert!(
+        result
+            .notes
+            .iter()
+            .any(|n| n.contains("rejected (unverified figure)") && n.contains("code quality")),
+        "a guardrail rejection note must name the code quality summary: {:?}",
+        result.notes
+    );
+}
+
 /// Why: when nothing survives verification there is no narrative, which #5454
 /// makes a failed report rather than a deterministic-only one.
 /// What: every field cites 9999; asserts
@@ -769,6 +870,8 @@ async fn synthesize_with_many_findings_produces_exec_summary() {
 #[test]
 fn status_lines_render_banners() {
     let syn = Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
         notes: vec!["synthesis: rejected (unverified figure) in top-risk row 1: 42".to_string()],
         ..Default::default()
     };
@@ -831,6 +934,18 @@ async fn synthesize_recovers_executive_summary_from_markdown_fallback() {
     assert!(
         result.findings.is_empty(),
         "prose is never reconstructed into findings"
+    );
+    // #6004: the markdown fallback recovers executive_summary ONLY — the two
+    // new narrative slots are absent from this response shape entirely, so
+    // they stay `None` (the reporter's honesty-marker path), same as
+    // top_risks/findings above.
+    assert!(
+        result.code_quality_summary.is_none(),
+        "the markdown fallback never recovers code_quality_summary"
+    );
+    assert!(
+        result.security_summary.is_none(),
+        "the markdown fallback never recovers security_summary"
     );
     assert!(
         result.notes.is_empty(),

--- a/crates/trusty-review/templates/report-technical-dd-cast.md
+++ b/crates/trusty-review/templates/report-technical-dd-cast.md
@@ -50,6 +50,12 @@
   rendered output — they never appear in a generated report. This template
   demonstrates one override below (`executive_summary`, CAST health-factor
   voice).
+
+  DEFERRED (#6004): this CAST variant intentionally does not carry the
+  generic template's Code Quality & Architecture / Security Posture /
+  Performance & Scalability sections, Key Facts block, or Contents
+  jump-list — porting them to CAST's own health-factor voice and scales is
+  follow-up work tracked on #6004, not an oversight in this revision.
 -->
 
 <!-- instruct:executive_summary

--- a/crates/trusty-review/templates/report-technical-dd.md
+++ b/crates/trusty-review/templates/report-technical-dd.md
@@ -37,20 +37,30 @@
   analysis focused on what the acquirer/reader actually needs to act on.
 
   SECTION-INSTRUCTION OVERRIDES (#2357 layered instructions)
-  Under `--synthesize`, three narrative sections are LLM-written: the executive
-  summary, the top-risks rows, and per-finding elaboration prose. Each has a
-  generic built-in instruction (see `src/report/section_instructions.rs`) that
-  a template may override for its own methodology's voice by embedding a
+  Under `--synthesize`, five narrative sections are LLM-written: the executive
+  summary, the top-risks rows, per-finding elaboration prose, the Code Quality
+  & Architecture summary, and the Security Posture summary. Each has a generic
+  built-in instruction (see `src/report/section_instructions.rs`) that a
+  template may override for its own methodology's voice by embedding a
   `<!-- instruct:<section_id> ... -->` comment anywhere in the file, where
   `<section_id>` is one of `executive_summary`, `top_risks`,
-  `finding_elaboration`. The override REPLACES the generic default for that
-  section only. This generic template ships no override (it uses the crate's
-  defaults for all three sections) — see `report-technical-dd-cast.md` for a
-  worked example overriding `executive_summary` with CAST health-factor
+  `finding_elaboration`, `code_quality_summary`, `security_summary`. The
+  override REPLACES the generic default for that section only. This generic
+  template ships no override (it uses the crate's defaults, which are
+  balanced/adversarial — acquirer-side, skeptical of risk, evenhanded about
+  genuine strengths, never promotional) — see `report-technical-dd-cast.md`
+  for a worked example overriding `executive_summary` with CAST health-factor
   language. An analyst's `--instructions` brief still applies ADDITIVELY on top
   of whichever instruction is active — it steers emphasis, never replaces it.
   `instruct:` comments are parsed at template-load time and, like every other
   comment here, are stripped from rendered output.
+
+  JUMP-LIST PLACEHOLDER (#6004)
+  `{{report_contents_block}}` is deterministic post-render structure, not a
+  data field — never remove it and never expect it to honesty-mark. It is
+  replaced, after every other section has rendered, with links to whichever
+  `##`-level headings actually survived in THIS document (see
+  `src/report/contents_links.rs`).
 -->
 
 # Technical Due-Diligence Analysis: {{target_codename}}
@@ -72,12 +82,39 @@
 | Analyst (this instance) | {{analyst_name}} |
 | Analysis generated | {{analysis_generated_date}} |
 
+## Key Facts
+
+<!-- Owner ruling 2026-08-18: frontload facts — density, complexity, author
+     count, estimated work volume, and its trajectory by month — ahead of the
+     narrative below. Every row is deterministic, never LLM-touched (it is
+     the same anchor set the numeric guardrail validates narrative against).
+     Author count and monthly trajectory are the tga-side authorship artifact
+     (#5453); a manifest without one renders those two rows as named gaps,
+     never a silent zero. "Estimated work volume" is a named gap in every run
+     today — tga has no effort-estimation metric (its `story_points` fields
+     are documented placeholders, always zero) — rather than an invented
+     figure. -->
+
+| Metric | Value |
+|---|---|
+| Codebase size (total LoC) | {{facts_total_loc}} |
+| File count | {{facts_total_files}} |
+| Primary languages | {{facts_languages}} |
+| Complexity profile | {{facts_complexity_summary}} |
+| Number of authors | {{facts_author_count}} |
+| Estimated work volume | {{facts_work_estimate}} |
+| 12-month trajectory | {{facts_trajectory}} |
+
 ## 2. Executive Summary
 
 {{executive_summary_paragraph}}
 
 <!-- One paragraph, deal-relevant: what matters to an acquirer, synthesized
-     across all applications — not a restatement of section headers. -->
+     across all applications — not a restatement of section headers. Voice is
+     balanced/adversarial: acquirer-side, skeptical of risk, evenhanded about
+     genuine strengths, never promotional. -->
+
+{{report_contents_block}}
 
 ### Top Risks
 
@@ -171,9 +208,21 @@ report against others normalized through this same template.
 - {{green_topic_3}}
 <!-- one bullet per positive topic -->
 
-## 6. Risk Registers
+## Code Quality & Architecture
 
-### 6.1 Security Violations
+<!-- #6004: re-projects data already loaded for §3/§4/§5 — complexity
+     distribution, LoC/tech-stack, and maintainability (refactor/code-smell)
+     findings — into its own section. No new data source. -->
+
+{{code_quality_summary_paragraph}}
+
+<!-- BEGIN code_quality_row -->
+| Application | LoC | Primary tech | Complexity profile | Maintainability findings |
+|---|---|---|---|---|
+| {{cq_app_name}} | {{cq_loc}} | {{cq_tech}} | {{cq_complexity}} | {{cq_maintainability_count}} |
+<!-- END code_quality_row -->
+
+## Security Posture
 
 *This table counts findings from general-purpose lint tools (clippy, ruff,
 biome, rubocop, PMD, and similar per language) that happened to be graded
@@ -181,13 +230,25 @@ biome, rubocop, PMD, and similar per language) that happened to be graded
 not a secrets scan. Treat it as a proxy for code-hygiene risk, not as
 evidence the codebase has been screened for exploitable vulnerabilities.*
 
+{{security_summary_paragraph}}
+
 <!-- BEGIN security_violations_table -->
 | Application | Domain | Total violations |
 |---|---|---|
 | {{app_name}} | {{violation_domain}} | {{violation_count}} |
 <!-- END security_violations_table -->
 
-### 6.2 Open-Source / CVE Exposure
+## Performance & Scalability
+
+<!-- #6004: fixed text, never LLM-generated — DOC-67 §3 declares this
+     dimension unavailable; no performance data source exists in this
+     pipeline. -->
+
+{{performance_assessment_note}}
+
+## 6. Risk Registers
+
+### 6.1 Open-Source / CVE Exposure
 
 <!-- BEGIN cve_table -->
 | Application | Component | Critical | High | Medium |
@@ -195,7 +256,7 @@ evidence the codebase has been screened for exploitable vulnerabilities.*
 | {{app_name}} | {{component_name}} | {{cve_critical}} | {{cve_high}} | {{cve_medium}} |
 <!-- END cve_table -->
 
-### 6.3 License / IP Risk
+### 6.2 License / IP Risk
 
 <!-- BEGIN license_risk_table -->
 | Application | License | Risk factor | Component count | Top component |
@@ -203,7 +264,7 @@ evidence the codebase has been screened for exploitable vulnerabilities.*
 | {{app_name}} | {{license_name}} | {{license_risk_factor}} | {{license_component_count}} | {{license_top_component}} |
 <!-- END license_risk_table -->
 
-### 6.4 Obsolescence
+### 6.3 Obsolescence
 
 <!-- BEGIN obsolescence_table -->
 | Application | Total components | % ≥5yr gap | % ≥5yr old | % no release 5yr |
@@ -211,7 +272,7 @@ evidence the codebase has been screened for exploitable vulnerabilities.*
 | {{app_name}} | {{obs_total}} | {{obs_gap_pct}} | {{obs_age_pct}} | {{obs_stale_pct}} |
 <!-- END obsolescence_table -->
 
-### 6.5 Cloud Readiness Blockers
+### 6.4 Cloud Readiness Blockers
 
 <!-- BEGIN cloud_readiness_table -->
 | Application | Cloud maturity % | Blockers % | Roadblock count | Top blocking technology |
@@ -219,7 +280,7 @@ evidence the codebase has been screened for exploitable vulnerabilities.*
 | {{app_name}} | {{cloud_maturity_pct}} | {{cloud_blockers_pct}} | {{cloud_roadblock_count}} | {{cloud_top_tech}} |
 <!-- END cloud_readiness_table -->
 
-### 6.6 Technical-Debt / Remediation Economics
+### 6.5 Technical-Debt / Remediation Economics
 
 <!-- BEGIN remediation_economics_table -->
 | Application | Tier | Violations addressed | Effort (person-days) | Cost |

--- a/crates/trusty-review/tests/report_e2e.rs
+++ b/crates/trusty-review/tests/report_e2e.rs
@@ -31,7 +31,8 @@ fn end_to_end_two_repo_report() {
             { "language": "TypeScript", "loc": 6000 },
             { "language": "CSS", "loc": 2200 }
           ]},
-          "counts": { "files": 120, "functions": 640 }
+          "counts": { "files": 120, "functions": 640 },
+          "complexity": { "buckets": [ { "label": "low (1-5)", "count": 640 } ] }
         }"#,
     )
     .expect("write web metrics");


### PR DESCRIPTION
Refs #6004

## Summary

Implements the owner's codebase-acquisition template rulings of 2026-08-18:
- Three new top-level report sections:
  - Code Quality & Architecture
  - Security Posture (keeping the lint-grade-not-SAST caption)
  - Performance & Scalability (deliberately-empty, honestly-captioned gap section with fixed never-LLM text)
- Deterministic Key Facts block opening the report (density, complexity, authors, work estimate rows degrade to named gaps until the authorship artifact lands in the follow-up PR)
- Deterministic post-render section links on the executive summary
- Balanced/adversarial default voice in section instructions
- Two new guardrailed narrative slots (code_quality_summary, security_summary) on the existing single synthesis schema — flowing through #6014's prompt-side contract and normalizer whitelist automatically (regression-tested)

## Test Ladder

Rung 3 — fmt --check / check --locked / clippy --locked -D warnings / test --lib (1653 passed, 0 failed) on trusty-review; line-cap 0 violations; SLD clean; changelog fragment present.

## Note

Follow-up PR (Authorship & Key-Person Risk, #5453) is stacked on this branch.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools