### PR TITLE
fix: bump Node from 20 to 22 so pnpm and the UI builds work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1764,7 +1764,7 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: pnpm
           cache-dependency-path: ${{ matrix.dir }}/pnpm-lock.yaml
 

--- a/.github/workflows/token-drift.yml
+++ b/.github/workflows/token-drift.yml
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Run check_token_drift.mjs regression tests
         run: node --test scripts/check_token_drift.test.mjs

--- a/.github/workflows/website-tests.yml
+++ b/.github/workflows/website-tests.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: pnpm
           cache-dependency-path: website/pnpm-lock.yaml
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 rust = "1.94"
-node = "20"
+node = "22"


### PR DESCRIPTION
Closes #6016.

The repo pinned `node = "20"`, pnpm requires >= 22.13, and pnpm crashed with `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`. Every Svelte UI build (`trusty-memory`, `trusty-search`, `trusty-agents`) failed under the old pin; workspace builds only succeeded with `SKIP_UI_BUILD=1`.

`mise.toml:3` is the line that fixes the reported symptom. The three workflow bumps (`ci.yml:1767` job `ui-checks`, `token-drift.yml:83`, `website-tests.yml:134`) are consistency, not a repair — a reviewer should not expect a red check to turn green here. `ci.yml`'s `ui-checks` installs pnpm 9 via `pnpm/action-setup@v4` independently of the local toolchain, and pnpm 9 runs on Node 20, so that job was already passing and will keep passing. Same for `website-tests.yml`, which derives pnpm 9 from `website/package.json`'s `packageManager` pin. Bumping them stops the same drift trap firing the next time a pnpm pin moves.

Verification performed: reproduced the bug under the old pin. After the bump, `node -v` reports v22.23.2 and `pnpm -v` reports 11.3.0 clean. `cargo build -p trusty-memory` with no `SKIP_UI_BUILD` succeeded and ran the real vite build (`✓ 137 modules transformed`, `✓ built in 363ms`). `cargo build` exiting 0 is not sufficient proof on its own — `crates/trusty-memory/build.rs` catches a failed UI build, embeds a placeholder page, and still exits 0 — so this was confirmed three ways: no placeholder warning in the log, `dist/index.html` free of the placeholder string, and vite's asset hashes matching what cargo produced.

Gates run: `scripts/check_line_cap.sh` (0 violations), `cargo fmt --check` (exit 0), and — since this PR touches `token-drift.yml` — `node --test scripts/check_token_drift.test.mjs` (13 pass / 0 fail) plus `scripts/check_token_drift.mjs` (exit 0), all under Node 22. Both edited YAML files and the TOML parse clean.

Test ladder: rung 1-2 — config/CI only, no Rust source changes.

No changelog fragment: the PR touches no crate `src/**`, which CLAUDE.md exempts.

Outside this PR's reach: the Vercel dashboard's Node.js Version setting governs the actual cloud deploy, and `@sveltejs/adapter-vercel` derives the function runtime from `process.version` at build time. No repo change can move it — there is no `vercel.json`. Flagging for the owner.

Closed #4770 introduced `node = "20"`; pnpm's floor has risen since. This is a follow-on regression, not a revert of that work.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
