### PR TITLE
fix(trusty-mpm): a read-only here-document no longer spends the PM file-change budget (#5356)

### DIFF
--- a/crates/trusty-mpm/changelog.d/5356-pm-guard-readonly-turn.md
+++ b/crates/trusty-mpm/changelog.d/5356-pm-guard-readonly-turn.md
@@ -1,0 +1,13 @@
+Fixed
+
+- `tm hook --pm-guard` no longer charges a read-only here-document command
+  against the PM's per-turn file-change budget
+  (closes [#5356](https://github.com/bobmatnyc/trusty-tools/issues/5356)).
+  The redirection check treated any unquoted `>` as a file write, and its quote
+  scan knows only `'` and `"` — so a `>` in here-document body text, such as a
+  `len(k) > 3` comparison in a `python3 <<'PY'` script or an `->` arrow in
+  `cat <<EOF` prose, read as a redirect. Three such reads were allowed silently
+  while consuming the budget, and the fourth was denied as "PM file-change
+  budget 3/3 used this turn" with zero files changed. Only the body is treated
+  as data: `python3 <<'PY' > out.rs` is still a file write, still consumes the
+  budget, and still exhausts it.

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/heredoc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/heredoc.rs
@@ -1,0 +1,261 @@
+//! Here-document body detection for the PM Bash guard (issue #5356).
+//!
+//! Why: [`super::has_file_write_redirection`] treats any unquoted `>` as a
+//! file-write redirection, and [`super::shell_lex::QuoteScan`] only knows `'`
+//! and `"`. A here-document body is quoted data to the shell but plain text to
+//! that scan, so a `>` that is script content — a Python `len(k) > 3`
+//! comparison, an `->` arrow in prose — read as a redirect. The read-only
+//! command was then classified [`super::SHELL_EDIT_REASON`], which is
+//! budget-eligible: three such reads were ALLOWED silently while consuming the
+//! PM's per-turn file-change budget, and the fourth was denied as "PM
+//! file-change budget 3/3 used this turn" with zero files changed.
+//! What: [`HeredocBodies::scan`] returns the byte ranges of a command's
+//! here-document bodies, so a scanner can skip a metacharacter that is body
+//! content. Only the BODY is claimed — the operator line keeps its live
+//! syntax, so `python3 <<'PY' > out.rs` still reads as a redirect. The scan
+//! claims nothing at all (preserving the pre-#5356 over-deny) whenever it
+//! cannot parse with confidence: unbalanced quotes, or a `<<` whose delimiter
+//! never appears on a line of its own, which is also what an arithmetic
+//! `$((1 << 3))` looks like.
+//! Test: `heredoc_bodies_*` in this module's `tests` submodule;
+//! `has_file_write_redirection_ignores_heredoc_body` and
+//! `evaluate_bash_command_allows_readonly_heredoc_script` in the parent's.
+
+use super::shell_lex::QuoteScan;
+
+/// A here-document delimiter word plus its `<<-` tab-stripping mode.
+struct Delimiter {
+    word: String,
+    /// `<<-` lets the terminator line be indented with tabs.
+    strip_tabs: bool,
+}
+
+/// Byte ranges of a command's here-document bodies.
+///
+/// Why: the guard's byte scanners need one shared answer to "is this byte
+/// here-document content rather than shell syntax", computed once per command.
+/// What: half-open `[start, end)` ranges covering the text between a
+/// here-document's operator line and its terminator line, terminator excluded.
+/// Empty whenever [`HeredocBodies::scan`] could not parse the command with
+/// confidence.
+/// Test: `heredoc_bodies_*`.
+pub(super) struct HeredocBodies {
+    spans: Vec<(usize, usize)>,
+}
+
+impl HeredocBodies {
+    /// Locate every here-document body in `command`.
+    ///
+    /// What: walks the command line by line. Each line contributes the
+    /// delimiters of the here-document operators it opens ([`delimiters_on`]),
+    /// and the lines after it are consumed as those bodies in order, each
+    /// running to its own terminator line. A delimiter with no terminator line
+    /// abandons the whole scan and yields no spans, so an unterminated
+    /// here-document and an arithmetic left-shift both leave every byte live.
+    /// Test: `heredoc_bodies_cover_a_quoted_delimiter_body`,
+    /// `heredoc_bodies_claim_nothing_when_unterminated`,
+    /// `heredoc_bodies_span_two_heredocs_on_one_line`.
+    pub(super) fn scan(command: &str) -> Self {
+        let quotes = QuoteScan::new(command);
+        if !quotes.balanced {
+            return Self { spans: Vec::new() };
+        }
+        let lines = line_spans(command);
+        let mut spans = Vec::new();
+        let mut line = 0;
+        while line < lines.len() {
+            let (start, end) = lines[line];
+            let delimiters = delimiters_on(&command[start..end], start, &quotes);
+            line += 1;
+            for delimiter in delimiters {
+                let Some((body, next)) = body_span(command, &lines, line, &delimiter) else {
+                    return Self { spans: Vec::new() };
+                };
+                if body.0 < body.1 {
+                    spans.push(body);
+                }
+                line = next;
+            }
+        }
+        Self { spans }
+    }
+
+    /// Whether byte `idx` is here-document body content.
+    ///
+    /// Test: `heredoc_bodies_exclude_the_operator_line`.
+    pub(super) fn contains(&self, idx: usize) -> bool {
+        self.spans
+            .iter()
+            .any(|(start, end)| idx >= *start && idx < *end)
+    }
+}
+
+/// Half-open `[start, end)` byte ranges of each line, newline excluded.
+fn line_spans(command: &str) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let mut start = 0;
+    for (idx, byte) in command.bytes().enumerate() {
+        if byte == b'\n' {
+            spans.push((start, idx));
+            start = idx + 1;
+        }
+    }
+    spans.push((start, command.len()));
+    spans
+}
+
+/// The here-document delimiters opened by one line, in the order the shell
+/// reads their bodies.
+///
+/// What: scans for an unquoted `<<` that is not the `<<<` here-string
+/// operator, honours the `<<-` tab-stripping form, and reads the delimiter
+/// word with its quoting removed (`<<'PY'`, `<<"PY"`, and `<<PY` name the same
+/// terminator). `offset` maps a line-local index onto `quotes`, which was
+/// built over the whole command.
+/// Test: `heredoc_bodies_ignore_a_here_string`,
+/// `heredoc_bodies_ignore_quoted_operator`,
+/// `heredoc_bodies_handle_tab_stripped_delimiter`.
+fn delimiters_on(line: &str, offset: usize, quotes: &QuoteScan) -> Vec<Delimiter> {
+    let bytes = line.as_bytes();
+    let mut found = Vec::new();
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        if !quotes.is_unquoted(offset + i) || bytes[i] != b'<' || bytes[i + 1] != b'<' {
+            i += 1;
+            continue;
+        }
+        if bytes.get(i + 2) == Some(&b'<') {
+            // `<<<` is a here-string: its word is on this line, no body follows.
+            i += 3;
+            continue;
+        }
+        let mut j = i + 2;
+        let strip_tabs = bytes.get(j) == Some(&b'-');
+        if strip_tabs {
+            j += 1;
+        }
+        while matches!(bytes.get(j), Some(b' ' | b'\t')) {
+            j += 1;
+        }
+        let word_start = j;
+        while j < bytes.len() && !is_word_break(bytes[j]) {
+            j += 1;
+        }
+        let word: String = line[word_start..j]
+            .chars()
+            .filter(|c| !matches!(c, '\'' | '"' | '\\'))
+            .collect();
+        if !word.is_empty() {
+            found.push(Delimiter { word, strip_tabs });
+        }
+        i = j.max(i + 2);
+    }
+    found
+}
+
+/// Whether `byte` ends a here-document delimiter word.
+fn is_word_break(byte: u8) -> bool {
+    matches!(
+        byte,
+        b' ' | b'\t' | b'<' | b'>' | b'|' | b';' | b'&' | b'(' | b')'
+    )
+}
+
+/// The body span for one delimiter, starting at line `from`, plus the line
+/// index the next body starts from.
+///
+/// What: `None` when no later line consists solely of the delimiter word (with
+/// leading tabs allowed under `<<-`) — the caller then claims nothing.
+/// Test: `heredoc_bodies_claim_nothing_when_unterminated`.
+fn body_span(
+    command: &str,
+    lines: &[(usize, usize)],
+    from: usize,
+    delimiter: &Delimiter,
+) -> Option<((usize, usize), usize)> {
+    let body_start = lines.get(from)?.0;
+    for (index, (start, end)) in lines.iter().enumerate().skip(from) {
+        let text = command[*start..*end].trim_end_matches('\r');
+        let candidate = if delimiter.strip_tabs {
+            text.trim_start_matches('\t')
+        } else {
+            text
+        };
+        if candidate == delimiter.word {
+            return Some(((body_start, *start), index + 1));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The body of a `<<'PY'` script — the #5356 reproduction — is claimed.
+    #[test]
+    fn heredoc_bodies_cover_a_quoted_delimiter_body() {
+        let command = "python3 <<'PY'\nprint(len(k) > 3)\nPY";
+        let bodies = HeredocBodies::scan(command);
+        let gt = command.find('>').expect("comparison operator");
+        assert!(bodies.contains(gt), "the script's `>` must be body content");
+    }
+
+    /// A redirect on the operator line stays live syntax.
+    #[test]
+    fn heredoc_bodies_exclude_the_operator_line() {
+        let command = "python3 <<'PY' > out.rs\nprint(1)\nPY";
+        let bodies = HeredocBodies::scan(command);
+        let gt = command.find('>').expect("redirect");
+        assert!(!bodies.contains(gt), "the operator line must stay live");
+    }
+
+    /// `<<<` is a here-string; nothing follows it as a body.
+    #[test]
+    fn heredoc_bodies_ignore_a_here_string() {
+        let command = "grep x <<< 'a > b'\necho done > f.rs";
+        let bodies = HeredocBodies::scan(command);
+        let redirect = command.rfind('>').expect("redirect");
+        assert!(!bodies.contains(redirect));
+    }
+
+    /// An unterminated delimiter — and an arithmetic `<<`, which looks the
+    /// same — claims nothing, so the pre-#5356 over-deny is preserved.
+    #[test]
+    fn heredoc_bodies_claim_nothing_when_unterminated() {
+        let unterminated = "python3 <<'PY'\nprint(1)\n";
+        assert!(!HeredocBodies::scan(unterminated).contains(20));
+        let shift = "echo $((1 << 3))\necho x > f.rs";
+        let redirect = shift.rfind('>').expect("redirect");
+        assert!(!HeredocBodies::scan(shift).contains(redirect));
+    }
+
+    /// `<<-` allows a tab-indented terminator.
+    #[test]
+    fn heredoc_bodies_handle_tab_stripped_delimiter() {
+        let command = "cat <<-EOF\n\ta > b\n\tEOF";
+        let bodies = HeredocBodies::scan(command);
+        let gt = command.find('>').expect("arrow");
+        assert!(bodies.contains(gt));
+    }
+
+    /// A `<<` inside quotes is argument text, not an operator.
+    #[test]
+    fn heredoc_bodies_ignore_quoted_operator() {
+        let command = "grep -n '<<EOF' f\necho x > g.rs";
+        let bodies = HeredocBodies::scan(command);
+        let redirect = command.rfind('>').expect("redirect");
+        assert!(!bodies.contains(redirect));
+    }
+
+    /// Two here-documents opened on one line consume their bodies in order.
+    #[test]
+    fn heredoc_bodies_span_two_heredocs_on_one_line() {
+        let command = "diff <<A <<B\na > b\nA\nc > d\nB";
+        let bodies = HeredocBodies::scan(command);
+        let first = command.find('>').expect("first arrow");
+        let second = command.rfind('>').expect("second arrow");
+        assert!(bodies.contains(first), "first body claimed");
+        assert!(bodies.contains(second), "second body claimed");
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -24,11 +24,15 @@
 //! sibling [`main_checkout`] module carries the rules `pm_guard` calls
 //! directly, ahead of the subagent exemptions: whole-tree-destructive git
 //! verbs aimed at a project's main checkout (ADR-0037), `git commit` there,
-//! and the HEAD-moving `pull`/`merge`/`rebase` (ADR-0048).
+//! and the HEAD-moving `pull`/`merge`/`rebase` (ADR-0048). The sibling
+//! [`heredoc`] module tells the redirection check which bytes are
+//! here-document body content, so a `>` inside a `<<'PY'` script is a
+//! comparison rather than a file write (#5356).
 //! Test: `evaluate_bash_command_*`, `split_shell_segments_*`, and
 //! `has_file_write_redirection_*` in this module's `tests` submodule;
 //! `sed_awk::tests` for the sed/awk-specific safety analysis.
 
+mod heredoc;
 mod main_checkout;
 mod persistence;
 mod sed_awk;
@@ -446,18 +450,32 @@ fn trailing_file_token(command: &str) -> Option<String> {
 /// (`echo x > f`) are unquoted and still caught. NOTE: an in-quote `>` that is
 /// genuinely dangerous — an `awk 'BEGIN{print > "f"}'` in-program file write —
 /// is caught by [`sed_awk::awk_is_readonly`], not here.
+/// Heredoc-aware (#5356): [`QuoteScan`] knows only `'` and `"`, so a `>` in a
+/// here-document body — a `len(k) > 3` comparison in a `python3 <<'PY'`
+/// script, an `->` arrow in `cat <<EOF` prose — read as a redirect and made a
+/// pure read consume the PM's file-change budget. [`heredoc::HeredocBodies`]
+/// marks those bytes as body content; the operator line itself stays live, so
+/// `python3 <<'PY' > out.rs` is still a redirect.
 /// Test: `has_file_write_redirection_detects_write`,
 /// `has_file_write_redirection_detects_append`,
 /// `has_file_write_redirection_ignores_fd_dup`,
 /// `has_file_write_redirection_ignores_dev_null`,
 /// `has_file_write_redirection_ignores_quoted_gt`,
+/// `has_file_write_redirection_ignores_heredoc_body`,
+/// `has_file_write_redirection_detects_redirect_on_a_heredoc_operator_line`,
 /// `has_file_write_redirection_false_for_plain_command`.
 pub(crate) fn has_file_write_redirection(command: &str) -> bool {
     let scan = QuoteScan::new(command);
+    let bodies = heredoc::HeredocBodies::scan(command);
     let bytes = command.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
         if scan.balanced && !scan.is_unquoted(i) {
+            i += 1;
+            continue;
+        }
+        // #5356: a here-document body is data, not shell syntax.
+        if bodies.contains(i) {
             i += 1;
             continue;
         }

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -643,6 +643,50 @@ fn has_file_write_redirection_ignores_quoted_gt() {
 }
 
 #[test]
+fn has_file_write_redirection_ignores_heredoc_body() {
+    // #5356: a `>` in here-document body text is script content, not a
+    // redirect. Both spellings of the issue's reproduction.
+    assert!(!has_file_write_redirection(
+        "python3 <<'PY'\nprint([k for k in d if len(k) > 3])\nPY"
+    ));
+    assert!(!has_file_write_redirection("cat <<EOF\nspec -> code\nEOF"));
+}
+
+#[test]
+fn has_file_write_redirection_detects_redirect_on_a_heredoc_operator_line() {
+    // #5356 must not fail open: only the BODY is data. A redirect on the
+    // operator line, or after the terminator, is still a file write.
+    assert!(has_file_write_redirection(
+        "python3 <<'PY' > out.rs\nprint(1)\nPY"
+    ));
+    assert!(has_file_write_redirection(
+        "python3 <<'PY'\nprint(1)\nPY\necho done > f.rs"
+    ));
+}
+
+#[test]
+fn evaluate_bash_command_allows_readonly_heredoc_script() {
+    // #5356 end-to-end through the classifier: the read-only heredoc that was
+    // classified as a shell file edit (and so consumed the PM's per-turn
+    // file-change budget) now allows.
+    assert_eq!(
+        evaluate_bash_command(
+            "python3 <<'PY'\nimport json\nd = json.load(open('/tmp/x.json'))\nprint([k for k in d if len(k) > 3])\nPY"
+        ),
+        None
+    );
+}
+
+#[test]
+fn evaluate_bash_command_denies_heredoc_with_real_redirect() {
+    // The still-denies arm of #5356.
+    assert_eq!(
+        evaluate_bash_command("python3 <<'PY' > src/lib.rs\nprint(1)\nPY"),
+        Some(SHELL_EDIT_REASON)
+    );
+}
+
+#[test]
 fn evaluate_bash_command_allows_quoted_substitution_prose() {
     // `$(`/backtick inside SINGLE quotes is literal; inside DOUBLE quotes it is
     // still live and a forbidden body still denies.

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -295,6 +295,40 @@ fn pm_guard_denies_forbidden_bash_verb_after_budget_exhausted() {
 }
 
 #[test]
+fn pm_guard_readonly_heredoc_turn_never_touches_the_file_change_budget() {
+    // #5356: a read-only `python3 <<'PY'` script whose body compares with `>`
+    // was classified as a shell file edit, so three such reads were allowed
+    // silently while consuming the budget and the fourth was denied as
+    // "PM file-change budget 3/3 used this turn" with zero files changed.
+    // Pre-fix this test fails twice over: the fourth call denies, and the
+    // counter file exists.
+    let home = isolated_home();
+    let home_s = home.path().to_string_lossy().to_string();
+    let payload = r#"{"hook_event_name":"PreToolUse","session_id":"issue-5356","tool_name":"Bash","tool_input":{"command":"python3 <<'PY'\nimport json\nd = json.load(open('/tmp/x.json'))\nprint([k for k in d if len(k) > 3])\nPY"}}"#;
+    for n in 1..=4 {
+        assert_eq!(
+            run_pm_guard(payload, &[("HOME", &home_s)]).trim(),
+            "",
+            "call {n} reads a file and writes none — it must be allowed"
+        );
+    }
+    let counter = home.path().join(".trusty-mpm/state/pm_guard_turn_budget");
+    assert!(
+        !counter.exists(),
+        "a read-only turn must not record a file change at {}",
+        counter.display()
+    );
+
+    // The still-denies arm: the same heredoc with a real redirect on its
+    // operator line is a file write, and exhausts the budget as before.
+    let writing = r#"{"hook_event_name":"PreToolUse","session_id":"issue-5356","tool_name":"Bash","tool_input":{"command":"python3 <<'PY' > src/lib.rs\nprint(1)\nPY"}}"#;
+    for _ in 1..=3 {
+        assert_eq!(run_pm_guard(writing, &[("HOME", &home_s)]).trim(), "");
+    }
+    assert_denied(&run_pm_guard(writing, &[("HOME", &home_s)]));
+}
+
+#[test]
 fn pm_guard_allows_read_tool() {
     let stdout = run_pm_guard(
         r#"{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"/x/a.rs"}}"#,


### PR DESCRIPTION
Closes #5356.

## Defect

`tm hook --pm-guard` denied a read-only PM Bash call with `PM file-change
budget 3/3 used this turn (prohibitions P1/P5)` after a turn that changed zero
files. Reproduced against `079be7968` (the branch base) with the built binary:
four identical read-only heredoc calls in one session — the first three ALLOW
silently, the fourth prints that exact message, and the counter file holds
`{"count":3,"window_started_at":…}`.

```
python3 <<'PY'
import json
d = json.load(open('/tmp/x.json'))
print([k for k in d if len(k) > 3])
PY
```

## Mechanism

`has_file_write_redirection` treats any unquoted `>` as a file write, and
`shell_lex::QuoteScan` knows only `'` and `"`. A here-document body is quoted
data to the shell but plain text to that scan, so the script's `len(k) > 3`
comparison — or an `->` arrow in `cat <<EOF` prose — read as a redirect. The
command was then classified `SHELL_EDIT_REASON`, which is budget-eligible: a
call within budget is ALLOWED with no output, so each misclassified read spent
a slot the PM never saw it spend, and the next one hit the exhausted-budget
deny. That also explains the reported bypass — rephrasing the same read as
`grep -o` succeeds, because it has no heredoc and no `>`.

`pm_guard_bash::heredoc` now maps here-document body byte ranges and the
redirection scan skips them. Only the body is data — a redirect on the operator
line (`python3 <<'PY' > out.rs`) or after the terminator is still a file write,
still consumes the budget, and still exhausts it. When the scan cannot parse
with confidence it claims nothing, so unbalanced quotes and a `<<` with no
terminator line — which is also what an arithmetic `$((1 << 3))` looks like —
keep the pre-fix over-deny.

Verb classification is deliberately untouched: a heredoc body line is still
split out as a segment and classified, so `bash <<EOF` / `sed -i …` / `EOF`
still denies.

## Test ladder: rung 3

Regression proof — `pm_guard_readonly_heredoc_turn_never_touches_the_file_change_budget`
fails on the pre-fix code with the issue's own message:

```
assertion `left == right` failed: call 4 reads a file and writes none — it must be allowed
  left: "{\"hookSpecificOutput\":{…,\"permissionDecisionReason\":\"PM file-change budget 3/3 used this turn (prohibitions P1/P5). …\"}}"
 right: ""
```

Its second half is the still-denies arm: the same heredoc with `> src/lib.rs`
must exhaust the budget and deny on the fourth call.

| Gate | Result |
| --- | --- |
| `cargo fmt --check` | exit 0 |
| `cargo check -p trusty-mpm --all-targets` | exit 0 |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-mpm` | exit 0 — `5156 passed; 0 failed; 7 ignored` (lib) and `98 passed; 0 failed` (`tm_hook_pm_guard`), across 50 binaries |
| `bash scripts/check_line_cap.sh` | 4090 files, 0 violations |
| `bash scripts/check_test_pointers.sh` | 25964 citations, 0 dangling |
| `bash scripts/check_changelog_fragment.sh` | fragment present and valid |

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
