### PR TITLE
fix(trusty-mpm): an out-of-order SubagentStop resolves once its agent_id lands (#4142)

### DIFF
--- a/crates/trusty-mpm/changelog.d/4142-out-of-order-subagent-stop.md
+++ b/crates/trusty-mpm/changelog.d/4142-out-of-order-subagent-stop.md
@@ -1,0 +1,9 @@
+Fixed
+
+- A `SubagentStop` that reached the daemon before the `PostToolUse` teaching its
+  `agent_id` no longer strands its delegation `Running` for six hours. The stop
+  is held in a bounded, TTL'd ledger and applied the moment the id is taught, so
+  the two arrival orders converge on one record. Resolution still matches only
+  the exact `agent_id` the stop quoted — nothing guesses at a "most recent"
+  delegation, and an entry the ledger drops leaves the delegation to the
+  staleness sweep exactly as before (#4142).

--- a/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
+++ b/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
@@ -52,6 +52,23 @@
 //! manufacture a false idle, which is the specific failure this design exists to
 //! prevent.
 //!
+//! # Arrival order is a race, not a contract (#4142)
+//!
+//! `PostToolUse` is installed `async: true` and `SubagentStop` synchronously
+//! (`core::standalone::hooks`), so each is its own `tm hook` process posting
+//! independently. The async one can be descheduled while the synchronous stop
+//! for the same subagent completes and posts first — at which point the stop
+//! quotes an `agent_id` no record has learned yet, and the only reason it
+//! resolves nothing is that it is early.
+//!
+//! [`on_subagent_stop`] therefore *holds* an unresolvable stop in
+//! [`crate::daemon::state::pending_stops`] rather than discarding it, and
+//! [`on_launched`] applies it the instant the `agent_id` is taught. The key is
+//! the exact id the stop quoted, so the deferred path terminalizes precisely the
+//! record the in-order path would have — the two orders converge instead of one
+//! of them winning. This buffers evidence; it never invents any, and the "most
+//! recent" guess stays forbidden in both directions.
+//!
 //! # Fail direction
 //!
 //! Every branch here fails **closed**: uncertainty leaves a delegation `Running`
@@ -65,7 +82,8 @@
 //! The cost of failing closed is that a delegation can enter `Running` with no
 //! route out: `SubagentStop` is not guaranteed to arrive (`tm hook` POSTs fail
 //! open on a 2 s budget, an interrupted subagent emits no stop, a dispatch that
-//! never learned an `agent_id` can never be resolved by one). That is bounded
+//! never learned an `agent_id` can never be resolved by one — a stop that merely
+//! arrived early is the one case now recovered, see #4142 above). That is bounded
 //! outside the hot path by
 //! [`DaemonState::sweep_delegations`](crate::daemon::state::DaemonState::sweep_delegations),
 //! which the 60 s reap loop drives: a long-overdue live delegation becomes
@@ -684,7 +702,15 @@ fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: 
             .unwrap_or(false);
     let outcome = classify_dispatch(response);
 
-    state.mutate_delegation(id, |d| {
+    // #4142: the stop for this agent may already have arrived and found nothing
+    // to resolve. `peek` rather than take — the entry is cleared below only once
+    // the terminalization it authorises has actually landed, so a mutate that
+    // finds no record leaves the stop recoverable instead of discarding it.
+    let pending = agent_id
+        .as_deref()
+        .and_then(|a| state.pending_stops().peek(session, a));
+
+    let mutated = state.mutate_delegation(id, |d| {
         if agent_id.is_some() {
             d.agent_id = agent_id.clone();
         }
@@ -696,7 +722,12 @@ fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: 
         // `SubagentStop` will close it. `Unknown` terminalizes only on an
         // explicit dispatch failure, which is itself positive evidence that
         // nothing was left running.
-        let terminal = match outcome {
+        //
+        // #4142: a stop already observed for this exact `agent_id` outranks all
+        // three. It is the authoritative terminal signal, and applying the
+        // status it determined is what makes the two arrival orders converge on
+        // one record rather than one of them deciding.
+        let terminal = pending.or(match outcome {
             DispatchOutcome::Launched => None,
             DispatchOutcome::Returned => Some(if errored {
                 DelegationStatus::Failed
@@ -705,12 +736,22 @@ fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: 
             }),
             DispatchOutcome::Unknown if errored => Some(DelegationStatus::Failed),
             DispatchOutcome::Unknown => None,
-        };
+        });
         if let Some(status) = terminal {
             d.status = status;
             d.ended_at = Some(Utc::now());
         }
     });
+
+    // Only now is the deferred stop spent. A `false` here means the record
+    // vanished between the lookup and the write, so the stop stays pending for
+    // whatever record carries this id next.
+    if mutated
+        && pending.is_some()
+        && let Some(a) = agent_id.as_deref()
+    {
+        state.pending_stops().clear(session, a);
+    }
 }
 
 /// What a dispatch `PostToolUse` response says about whether a subagent is
@@ -773,21 +814,21 @@ enum DispatchOutcome {
 ///
 /// [`on_subagent_stop`] resolves a delegation *only* by `agent_id`, and
 /// `agent_id` is taught *only* by this function. A response with no *usable*
-/// `agentId` — absent, `null`, `""`, or any non-string ([`usable_agent_id`])
-/// therefore has **no** route to termination other than this branch — nothing
-/// can ever quote it back to us. Compounding that, `PostToolUse` is installed
-/// `async: true` while `SubagentStop` is synchronous
-/// (`core::standalone::hooks`), so the two are independent `tm hook` processes
-/// whose arrival order at the daemon is not guaranteed; an out-of-order stop
-/// matches nothing and nothing re-checks. Making this branch affirmative without
-/// first giving `on_subagent_stop` a recovery path would convert a rare
-/// fail-open into a guaranteed six-hour phantom "agent in flight" for every such
-/// dispatch.
+/// `agentId` — absent, `null`, `""`, or any non-string ([`usable_agent_id`]) —
+/// therefore has **no** route to termination other than this branch, because
+/// nothing can ever quote it back to us. Making this branch affirmative would
+/// convert a rare fail-open into a guaranteed six-hour phantom "agent in flight"
+/// for every such dispatch.
+///
+/// The #4142 deferred-stop ledger does NOT close this. That ledger recovers a
+/// stop that merely arrived *early*, by holding it until the `agent_id` is
+/// taught. When no usable `agentId` is ever taught, there is no key for it to be
+/// held against and the delegation is unreachable by any stop, in any order.
 ///
 /// The band is unobserved: Claude Code 2.1.220 returns
 /// `{isAsync, status, agentId, resolvedModel}` for a dispatch, which takes the
-/// `Launched` branch. Tightening is blocked on the stop-side recovery work and
-/// is tracked with it, not attempted here.
+/// `Launched` branch. Tightening it needs a correlation key this response does
+/// not carry, so it is not attempted here.
 /// Test: `post_tool_use_without_tool_response_stays_running`,
 /// `post_tool_use_with_unrecognized_response_stays_running`,
 /// `post_tool_use_with_only_an_agent_id_stays_running`,
@@ -829,18 +870,38 @@ fn recognized_response(response: &Value) -> bool {
         .is_some_and(|o| TOOL_RESPONSE_KEYS.iter().any(|k| o.contains_key(*k)))
 }
 
-/// `SubagentStop`: terminalize exactly the delegation that ended.
+/// `SubagentStop`: terminalize exactly the delegation that ended, or remember
+/// the stop until the delegation can be found (#4142).
 ///
 /// Why: this is the authoritative completion signal, and the only one that
-/// arrives when the subagent actually finishes.
-/// What: resolves `payload.agent_id` against the stored `agent_id` and
-/// terminalizes that record alone (`Failed` for `SubagentStopFailure`, else
-/// `Completed`). When `agent_id` is absent, or matches nothing, **nothing is
-/// terminalized** — see the module note on why a "most recent" fallback is
-/// forbidden.
+/// arrives when the subagent actually finishes. It resolves only by `agent_id`,
+/// which only [`on_launched`] teaches — and `PostToolUse` is installed
+/// `async: true` while this event is synchronous, so a stop can reach the daemon
+/// before the id it quotes has been recorded. Discarding it there left the
+/// delegation `Running` for the full six-hour staleness window as a phantom
+/// in-flight agent.
+/// What: `Failed` for `SubagentStopFailure`, else `Completed`. Three
+/// dispositions, and the third is the #4142 fix:
+///
+/// 1. A **live** delegation carries this `agent_id` — terminalize it. `Stale` is
+///    deliberately not terminal, so a stop arriving after the staleness sweep
+///    gave up still replaces "we lost track" with the truth.
+/// 2. A **terminal** delegation carries it — this stop was redelivered and its
+///    fact is already recorded. Nothing to do, and nothing to remember.
+/// 3. **No delegation carries it at all** — either the id is not ours, or its
+///    `PostToolUse` has not landed yet, and the two are indistinguishable here.
+///    So the stop goes to [`crate::daemon::state::pending_stops`] and
+///    [`on_launched`] applies it the moment the id becomes known. A stop that
+///    was never ours simply expires there.
+///
+/// A missing `agent_id` still terminalizes nothing and records nothing — with no
+/// correlation key there is nothing to defer, and the module note explains why a
+/// "most recent" guess is forbidden.
 /// Test: `subagent_stop_completes_matching_delegation`,
 /// `subagent_stop_without_agent_id_terminalizes_nothing`,
-/// `concurrent_delegations_terminalize_independently`.
+/// `concurrent_delegations_terminalize_independently`,
+/// `out_of_order_subagent_stop_resolves_when_its_post_tool_use_lands`,
+/// `a_redelivered_stop_for_a_finished_delegation_records_no_pending_stop`.
 fn on_subagent_stop(state: &DaemonState, session: SessionId, payload: &Value, event: HookEvent) {
     let Some(agent_id) = field(payload, "agent_id") else {
         tracing::trace!(
@@ -849,19 +910,27 @@ fn on_subagent_stop(state: &DaemonState, session: SessionId, payload: &Value, ev
         );
         return;
     };
-    // `Stale` is deliberately not terminal, so a stop that arrives after the
-    // staleness sweep gave up still replaces "we lost track" with the truth.
-    let Some(id) = state.find_delegation(session, |d| {
-        d.agent_id.as_deref() == Some(agent_id) && !d.status.is_terminal()
-    }) else {
-        return;
-    };
     let status = if event == HookEvent::SubagentStopFailure {
         DelegationStatus::Failed
     } else {
         DelegationStatus::Completed
     };
-    state.terminate_delegation(id, status);
+    if let Some(id) = state.find_delegation(session, |d| {
+        d.agent_id.as_deref() == Some(agent_id) && !d.status.is_terminal()
+    }) {
+        state.terminate_delegation(id, status);
+        return;
+    }
+    if state
+        .find_delegation(session, |d| d.agent_id.as_deref() == Some(agent_id))
+        .is_some()
+    {
+        return;
+    }
+    // #4142: the id is unknown to this session — hold the stop rather than drop it.
+    state
+        .pending_stops()
+        .record(session, agent_id, status, Utc::now());
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/services/delegation_tracker_tests.rs
+++ b/crates/trusty-mpm/src/daemon/services/delegation_tracker_tests.rs
@@ -14,6 +14,7 @@
 use super::*;
 use crate::core::session::{ControlModel, Session, SessionStatus};
 use crate::daemon::idle_nudge::has_live_children;
+use crate::daemon::state::pending_stops::PENDING_STOP_TTL_SECS;
 use crate::daemon::state::sessions::{
     DECLARED_STALE_AFTER_SECS, DELEGATION_RETENTION_SECS, RUNNING_STALE_AFTER_SECS,
     STALE_RETENTION_SECS,
@@ -1533,4 +1534,264 @@ fn an_unknown_agent_id_registers_nothing() {
         &subagent_call("ghost", "/tmp/p/.claude/worktrees/ghost"),
     );
     assert!(state.delegations_for(sid).is_empty());
+}
+
+// ---- #4142: out-of-order `SubagentStop` recovery -------------------------
+
+/// Find one session's delegation by its `tool_use_id`.
+fn by_tool_use(state: &DaemonState, session: SessionId, tool_use_id: &str) -> Delegation {
+    state
+        .delegations_for(session)
+        .into_iter()
+        .find(|d| d.tool_use_id.as_deref() == Some(tool_use_id))
+        .unwrap_or_else(|| panic!("no delegation carries tool_use_id {tool_use_id}"))
+}
+
+/// THE acceptance criterion for #4142.
+///
+/// A stop that lands before the `PostToolUse` teaching its `agent_id` must
+/// resolve the delegation it names once that id arrives — and must leave every
+/// other live delegation alone. The second, unrelated `Running` delegation is
+/// the control: a "most recent Running" guess at stop time would have closed
+/// THAT one, which is the false all-clear #4142 forbids.
+#[test]
+fn out_of_order_subagent_stop_resolves_when_its_post_tool_use_lands() {
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "first", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "qa", "second", "toolu_2"),
+    );
+    // The control's own PostToolUse lands normally.
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_2", "aid2"),
+    );
+
+    // The race: toolu_1's stop overtakes its async PostToolUse.
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid1"));
+    assert_eq!(
+        by_tool_use(&state, sid, "toolu_1").status,
+        DelegationStatus::Running,
+        "nothing may be terminalized before the id is known"
+    );
+    assert_eq!(
+        by_tool_use(&state, sid, "toolu_2").status,
+        DelegationStatus::Running,
+        "an unmatched stop must never close another delegation"
+    );
+
+    // The late PostToolUse finally teaches `aid1`.
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+
+    let resolved = by_tool_use(&state, sid, "toolu_1");
+    assert_eq!(
+        resolved.status,
+        DelegationStatus::Completed,
+        "the out-of-order stop must resolve without waiting on the staleness sweep"
+    );
+    assert!(resolved.ended_at.is_some(), "ended_at must be stamped");
+    assert_eq!(
+        by_tool_use(&state, sid, "toolu_2").status,
+        DelegationStatus::Running,
+        "the control delegation must still be live"
+    );
+    assert!(has_live_children(&state.delegations_for(sid)));
+}
+
+/// A `SubagentStopFailure` that overtakes its `PostToolUse` still lands as
+/// `Failed` — the deferred path applies the status the stop determined, not a
+/// re-derivation from the launch response.
+#[test]
+fn an_out_of_order_stop_failure_lands_as_failed() {
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    observe(&state, sid, HookEvent::SubagentStopFailure, &stop("aid1"));
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+    assert_eq!(only(&state, sid).status, DelegationStatus::Failed);
+}
+
+/// A deferred stop resolves the delegation naming it and no other, even when a
+/// later dispatch's `PostToolUse` lands first.
+#[test]
+fn a_pending_stop_never_terminalizes_a_delegation_it_does_not_name() {
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "one", "toolu_1"),
+    );
+    // A stop for an agent this session never dispatched.
+    observe(&state, sid, HookEvent::SubagentStop, &stop("stranger"));
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+    assert_eq!(
+        only(&state, sid).status,
+        DelegationStatus::Running,
+        "a stop naming another agent must never close this one"
+    );
+}
+
+/// A stop redelivered after its delegation is already terminal must not enter
+/// the ledger — that is a repeat, not an ordering failure, and an entry there
+/// would outlive the record it refers to.
+#[test]
+fn a_redelivered_stop_for_a_finished_delegation_records_no_pending_stop() {
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "e", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid1"));
+    assert_eq!(state.pending_stops().len(), 0);
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid1"));
+    assert_eq!(
+        state.pending_stops().len(),
+        0,
+        "a redelivered stop for a terminal delegation must record nothing"
+    );
+}
+
+/// The ledger entry is spent only by a terminalization that actually landed. A
+/// `PostToolUse` naming a `tool_use_id` no delegation carries resolves nothing,
+/// so the stop must survive for the record that does carry it.
+#[test]
+fn an_unmatched_post_tool_use_does_not_consume_the_pending_stop() {
+    let (state, sid) = state_with_session();
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid1"));
+    assert_eq!(state.pending_stops().len(), 1);
+
+    // Same agentId, but a tool_use_id nothing tracks: `on_launched` returns early.
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_ghost", "aid1"),
+    );
+    assert_eq!(
+        state.pending_stops().len(),
+        1,
+        "an unresolved launch must not spend the deferred stop"
+    );
+
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "e", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+    assert_eq!(only(&state, sid).status, DelegationStatus::Completed);
+    assert_eq!(state.pending_stops().len(), 0, "and is spent exactly once");
+}
+
+/// A stop is scoped to its own session, exactly as in-order resolution is.
+#[test]
+fn a_pending_stop_does_not_cross_sessions() {
+    let (state, sid) = state_with_session();
+    let other = SessionId::new();
+    let mut s = Session::new(other, "/tmp/q", ControlModel::Tmux, None);
+    s.status = SessionStatus::Active;
+    state.register_session(s);
+
+    observe(&state, other, HookEvent::SubagentStop, &stop("aid1"));
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "e", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+    assert_eq!(
+        only(&state, sid).status,
+        DelegationStatus::Running,
+        "another session's stop must not resolve this one"
+    );
+}
+
+/// An expired deferred stop degrades to the pre-#4142 behavior — the delegation
+/// stays live for the staleness sweep — and never to a wrong terminalization.
+#[test]
+fn an_expired_pending_stop_never_resolves_a_later_launch() {
+    let (state, sid) = state_with_session();
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid1"));
+
+    let past_ttl = chrono::Utc::now() + chrono::Duration::seconds(PENDING_STOP_TTL_SECS + 1);
+    state.sweep_delegations_at(past_ttl);
+    assert_eq!(state.pending_stops().len(), 0, "the sweep ages the ledger");
+
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "e", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+    assert_eq!(only(&state, sid).status, DelegationStatus::Running);
+}
+
+/// The 60 s sweep is what bounds the ledger's age; this pins the wiring.
+#[test]
+fn the_delegation_sweep_ages_the_deferred_stop_ledger() {
+    let (state, sid) = state_with_session();
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid1"));
+    assert_eq!(state.pending_stops().len(), 1);
+    state.sweep_delegations_at(chrono::Utc::now());
+    assert_eq!(state.pending_stops().len(), 1, "a fresh entry survives");
+    state.sweep_delegations_at(
+        chrono::Utc::now() + chrono::Duration::seconds(PENDING_STOP_TTL_SECS + 1),
+    );
+    assert_eq!(state.pending_stops().len(), 0);
 }

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -412,6 +412,13 @@ pub struct DaemonState {
     /// so the two can never deadlock. In-memory work only: no I/O, no await.
     /// Test: `a_grant_and_the_tracker_converge_in_either_order`.
     pub(super) dispatch_record: parking_lot::Mutex<()>,
+    /// `SubagentStop`s that arrived before the `agent_id` naming them (#4142).
+    ///
+    /// Why: `PostToolUse` is async and `SubagentStop` synchronous, so the stop
+    /// can win the race and match nothing. See
+    /// [`crate::daemon::state::pending_stops`] for the whole rationale.
+    /// Test: `out_of_order_subagent_stop_resolves_when_its_post_tool_use_lands`.
+    pub(super) pending_stops: super::pending_stops::PendingStops,
 }
 
 impl Default for DaemonState {
@@ -510,6 +517,7 @@ impl DaemonState {
             nudge_ledger: parking_lot::Mutex::new(crate::core::idle_nudge::NudgeLedger::new()),
             shared_tree_claim: parking_lot::Mutex::new(()),
             dispatch_record: parking_lot::Mutex::new(()),
+            pending_stops: super::pending_stops::PendingStops::default(),
         }
     }
 
@@ -585,6 +593,7 @@ impl DaemonState {
             nudge_ledger: parking_lot::Mutex::new(crate::core::idle_nudge::NudgeLedger::new()),
             shared_tree_claim: parking_lot::Mutex::new(()),
             dispatch_record: parking_lot::Mutex::new(()),
+            pending_stops: super::pending_stops::PendingStops::default(),
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/state/mod.rs
+++ b/crates/trusty-mpm/src/daemon/state/mod.rs
@@ -14,6 +14,7 @@
 
 mod core;
 mod overseer;
+pub(crate) mod pending_stops;
 mod resources;
 pub(crate) mod sessions;
 mod sm;

--- a/crates/trusty-mpm/src/daemon/state/pending_stops.rs
+++ b/crates/trusty-mpm/src/daemon/state/pending_stops.rs
@@ -1,0 +1,261 @@
+//! Stops that arrived before the event naming their agent (#4142).
+//!
+//! Why: `PostToolUse` is installed `async: true` and `SubagentStop`
+//! synchronously (`core::standalone::hooks`), so each runs as its own `tm hook`
+//! process and their arrival order at the daemon is a race. `on_subagent_stop`
+//! resolves a delegation only by `agent_id`, and only `on_launched` teaches one,
+//! so a stop that wins that race matched nothing, terminalized nothing, and was
+//! discarded — leaving the delegation `Running` until the 6 h staleness sweep
+//! reaped it as a phantom in-flight agent.
+//!
+//! What: a bounded, TTL'd ledger of `(session, agent_id) -> terminal status`.
+//! `on_subagent_stop` records here instead of discarding; `on_launched` consults
+//! it the moment it learns an `agent_id` and applies the status the stop already
+//! determined. Both arrival orders therefore converge on the same record.
+//!
+//! # This buffers evidence — it never manufactures any
+//!
+//! The key stored is the exact `agent_id` the stop quoted, so a later lookup
+//! either finds the same delegation the in-order path would have found or finds
+//! nothing. There is no "most recent Running" guess anywhere in this file, and
+//! adding one would reintroduce the false all-clear the whole delegation tracker
+//! exists to prevent.
+//!
+//! # Every loss path degrades to the pre-#4142 behavior
+//!
+//! Both bounds drop entries: [`PENDING_STOP_CAP`] on pressure, and
+//! [`PENDING_STOP_TTL_SECS`] on age. A dropped entry costs the recovery, so the
+//! delegation stays `Running` and the staleness sweep reaps it exactly as it did
+//! before this module existed. Nothing here can terminalize a delegation no stop
+//! named, which is why bounding the buffer is safe to do bluntly.
+//! Test: the `#[cfg(test)]` suite below, plus the `#4142` arms of
+//! `delegation_tracker_tests`.
+
+use std::collections::VecDeque;
+
+use chrono::{DateTime, Utc};
+
+use crate::core::agent::DelegationStatus;
+use crate::core::session::SessionId;
+
+/// Most unresolved stops held at once.
+///
+/// Why: the buffer must not become the leak it exists to close. An entry is
+/// ~60 bytes and only a stop whose `PostToolUse` has not yet landed occupies
+/// one, so the steady-state population is the number of subagents mid-race —
+/// single digits. 256 is far above any real concurrency while still capping the
+/// worst case (a daemon that never sees another `PostToolUse`) at a few tens of
+/// kilobytes.
+/// Test: `the_ledger_evicts_its_oldest_entry_at_capacity`.
+pub(crate) const PENDING_STOP_CAP: usize = 256;
+
+/// How long an unresolved stop stays useful.
+///
+/// Why: the window this bridges is one async hook's scheduling delay, which is
+/// milliseconds — `PostToolUse` fires ~1 ms after launch and is merely
+/// descheduled, never deferred by design. Fifteen minutes is orders of magnitude
+/// beyond that, so it cannot expire a stop that was going to be matched, while
+/// still evicting one whose `PostToolUse` was dropped outright (a failed hook
+/// POST) rather than holding it forever.
+/// Test: `an_expired_entry_is_pruned`.
+pub(crate) const PENDING_STOP_TTL_SECS: i64 = 15 * 60;
+
+/// One `SubagentStop` still waiting for its `agent_id` to be taught.
+#[derive(Debug, Clone)]
+struct PendingStop {
+    session: SessionId,
+    agent_id: String,
+    /// The status the stop determined — `Failed` for `SubagentStopFailure`,
+    /// else `Completed`. Stored rather than recomputed so the deferred path
+    /// applies exactly what the in-order path would have.
+    status: DelegationStatus,
+    seen_at: DateTime<Utc>,
+}
+
+/// The bounded ledger itself.
+///
+/// Why: held by [`crate::daemon::state::DaemonState`] because it is daemon-wide
+/// correlation state, and behind a `Mutex<VecDeque>` rather than a `DashMap`
+/// because capacity eviction needs insertion order and the population is small
+/// enough that a linear scan is cheaper than hashing. Neither of its two callers
+/// is on the `PreToolUse` hot path.
+/// What: insertion-ordered, oldest at the front, keyed by `(session, agent_id)`.
+/// Test: the suite below.
+#[derive(Debug, Default)]
+pub struct PendingStops {
+    entries: parking_lot::Mutex<VecDeque<PendingStop>>,
+}
+
+impl PendingStops {
+    /// Remember a stop nothing could resolve yet.
+    ///
+    /// What: replaces any entry already holding this key — a redelivered stop
+    /// restates the same fact and must not consume a second slot — otherwise
+    /// appends, then evicts from the front until the ledger is within
+    /// [`PENDING_STOP_CAP`].
+    /// Test: `a_recorded_stop_is_visible`, `re_recording_a_key_replaces_it`,
+    /// `the_ledger_evicts_its_oldest_entry_at_capacity`.
+    pub(crate) fn record(
+        &self,
+        session: SessionId,
+        agent_id: &str,
+        status: DelegationStatus,
+        now: DateTime<Utc>,
+    ) {
+        let mut entries = self.entries.lock();
+        entries.retain(|e| !(e.session == session && e.agent_id == agent_id));
+        entries.push_back(PendingStop {
+            session,
+            agent_id: agent_id.to_string(),
+            status,
+            seen_at: now,
+        });
+        while entries.len() > PENDING_STOP_CAP {
+            if let Some(dropped) = entries.pop_front() {
+                tracing::warn!(
+                    agent_id = dropped.agent_id,
+                    cap = PENDING_STOP_CAP,
+                    "delegation: dropped the oldest unresolved SubagentStop to keep the \
+                     ledger bounded (#4142); its delegation now relies on the staleness \
+                     sweep, exactly as it did before recovery existed"
+                );
+            }
+        }
+    }
+
+    /// The status a stop already determined for this agent, if one is waiting.
+    ///
+    /// Why this reads rather than takes: the caller clears the entry only once
+    /// the terminalization it authorises has actually landed. Taking here would
+    /// discard the stop on any path that then failed to write — the silent-loss
+    /// shape this module exists to remove.
+    /// Test: `a_recorded_stop_is_visible`,
+    /// `an_unmatched_post_tool_use_does_not_consume_the_pending_stop`.
+    pub(crate) fn peek(&self, session: SessionId, agent_id: &str) -> Option<DelegationStatus> {
+        self.entries
+            .lock()
+            .iter()
+            .find(|e| e.session == session && e.agent_id == agent_id)
+            .map(|e| e.status)
+    }
+
+    /// Forget a stop whose delegation is now terminal.
+    /// Test: `clearing_removes_only_the_named_key`.
+    pub(crate) fn clear(&self, session: SessionId, agent_id: &str) {
+        self.entries
+            .lock()
+            .retain(|e| !(e.session == session && e.agent_id == agent_id));
+    }
+
+    /// Drop every entry older than [`PENDING_STOP_TTL_SECS`], returning how many.
+    ///
+    /// Why: driven by the 60 s reap loop through
+    /// [`DaemonState::sweep_delegations`](crate::daemon::state::DaemonState::sweep_delegations),
+    /// never by a hook — the same placement, and for the same reason, as the
+    /// delegation staleness sweep it rides along with.
+    /// Test: `an_expired_entry_is_pruned`.
+    pub(crate) fn prune_at(&self, now: DateTime<Utc>) -> usize {
+        let ttl = chrono::Duration::seconds(PENDING_STOP_TTL_SECS);
+        let mut entries = self.entries.lock();
+        let before = entries.len();
+        entries.retain(|e| now - e.seen_at <= ttl);
+        before - entries.len()
+    }
+
+    /// How many stops are waiting.
+    ///
+    /// Why `cfg(test)`: production reads the ledger only through [`Self::peek`],
+    /// which asks about one key. Depth is what the bound and the TTL assert, and
+    /// nothing but a test needs it — exposing it unconditionally would be dead
+    /// code claiming to be an API.
+    /// Test: `the_ledger_evicts_its_oldest_entry_at_capacity`,
+    /// `the_delegation_sweep_ages_the_deferred_stop_ledger`.
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.lock().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sid() -> SessionId {
+        SessionId::new()
+    }
+
+    #[test]
+    fn a_recorded_stop_is_visible() {
+        let led = PendingStops::default();
+        let s = sid();
+        led.record(s, "aid1", DelegationStatus::Completed, Utc::now());
+        assert_eq!(led.peek(s, "aid1"), Some(DelegationStatus::Completed));
+        assert_eq!(led.peek(s, "aid2"), None, "another agent must not match");
+        assert_eq!(
+            led.peek(sid(), "aid1"),
+            None,
+            "another session must not match"
+        );
+    }
+
+    #[test]
+    fn a_failure_stop_keeps_its_status() {
+        let led = PendingStops::default();
+        let s = sid();
+        led.record(s, "aid1", DelegationStatus::Failed, Utc::now());
+        assert_eq!(led.peek(s, "aid1"), Some(DelegationStatus::Failed));
+    }
+
+    #[test]
+    fn re_recording_a_key_replaces_it() {
+        let led = PendingStops::default();
+        let s = sid();
+        led.record(s, "aid1", DelegationStatus::Completed, Utc::now());
+        led.record(s, "aid1", DelegationStatus::Failed, Utc::now());
+        assert_eq!(led.len(), 1, "a redelivered stop must not consume a slot");
+        assert_eq!(led.peek(s, "aid1"), Some(DelegationStatus::Failed));
+    }
+
+    #[test]
+    fn clearing_removes_only_the_named_key() {
+        let led = PendingStops::default();
+        let s = sid();
+        led.record(s, "aid1", DelegationStatus::Completed, Utc::now());
+        led.record(s, "aid2", DelegationStatus::Completed, Utc::now());
+        led.clear(s, "aid1");
+        assert_eq!(led.peek(s, "aid1"), None);
+        assert_eq!(led.peek(s, "aid2"), Some(DelegationStatus::Completed));
+    }
+
+    #[test]
+    fn the_ledger_evicts_its_oldest_entry_at_capacity() {
+        let led = PendingStops::default();
+        let s = sid();
+        let now = Utc::now();
+        for i in 0..PENDING_STOP_CAP + 10 {
+            led.record(s, &format!("aid{i}"), DelegationStatus::Completed, now);
+        }
+        assert_eq!(led.len(), PENDING_STOP_CAP, "the buffer must stay bounded");
+        assert_eq!(led.peek(s, "aid0"), None, "the oldest goes first");
+        let newest = format!("aid{}", PENDING_STOP_CAP + 9);
+        assert_eq!(led.peek(s, &newest), Some(DelegationStatus::Completed));
+    }
+
+    #[test]
+    fn an_expired_entry_is_pruned() {
+        let led = PendingStops::default();
+        let s = sid();
+        let now = Utc::now();
+        led.record(s, "old", DelegationStatus::Completed, now);
+        led.record(
+            s,
+            "fresh",
+            DelegationStatus::Completed,
+            now + chrono::Duration::seconds(PENDING_STOP_TTL_SECS),
+        );
+        let dropped = led.prune_at(now + chrono::Duration::seconds(PENDING_STOP_TTL_SECS + 1));
+        assert_eq!(dropped, 1);
+        assert_eq!(led.peek(s, "old"), None);
+        assert_eq!(led.peek(s, "fresh"), Some(DelegationStatus::Completed));
+    }
+}

--- a/crates/trusty-mpm/src/daemon/state/sessions.rs
+++ b/crates/trusty-mpm/src/daemon/state/sessions.rs
@@ -523,6 +523,19 @@ impl DaemonState {
         self.dispatch_record.lock()
     }
 
+    /// Stops still waiting for the `agent_id` that names them (#4142).
+    ///
+    /// Why: `crate::daemon::services::delegation_tracker` is the ledger's only
+    /// caller — it records on an unresolvable `SubagentStop` and consults it on
+    /// the `PostToolUse` that finally teaches the id. Exposed as a borrow rather
+    /// than wrapped in per-operation methods so the ledger's own invariants
+    /// (bound, TTL, peek-before-clear) stay in one file.
+    /// What: `pub(crate)` — internal correlation state, never a consumer API.
+    /// Test: `out_of_order_subagent_stop_resolves_when_its_post_tool_use_lands`.
+    pub(crate) fn pending_stops(&self) -> &super::pending_stops::PendingStops {
+        &self.pending_stops
+    }
+
     /// All delegations belonging to one session.
     pub fn delegations_for(&self, session: SessionId) -> Vec<Delegation> {
         self.delegations
@@ -746,12 +759,15 @@ impl DaemonState {
     /// nothing. Past 24 h a `Stale` record IS dropped and a later stop finds
     /// nothing: the recovery window is long, not infinite, because the map must
     /// stay bounded. That bound is asserted, not incidental.
+    /// It also ages the #4142 deferred-stop ledger on the same pass, for the
+    /// same reason: both are bounded off the hook path, never on it.
     /// Test: `stale_running_delegation_stops_suppressing_the_nudge`,
     /// `declared_but_never_dispatched_goes_stale_quickly`,
     /// `terminal_delegations_are_evicted_after_retention`,
     /// `live_delegations_are_never_evicted`,
     /// `stale_delegation_stays_resolvable_far_past_the_terminal_window`,
-    /// `a_stale_delegation_is_eventually_evicted`.
+    /// `a_stale_delegation_is_eventually_evicted`,
+    /// `the_delegation_sweep_ages_the_deferred_stop_ledger`.
     pub fn sweep_delegations(&self) -> DelegationSweep {
         self.sweep_delegations_at(chrono::Utc::now())
     }
@@ -766,6 +782,13 @@ impl DaemonState {
         now: chrono::DateTime<chrono::Utc>,
     ) -> DelegationSweep {
         let mut sweep = DelegationSweep::default();
+        // #4142: the deferred-stop ledger ages on the same loop, and off the
+        // hook path for the same reason. An expired entry costs only the
+        // recovery — the delegation it would have closed is staled below.
+        let expired = self.pending_stops.prune_at(now);
+        if expired > 0 {
+            tracing::debug!(expired, "delegation: pruned expired deferred stops (#4142)");
+        }
         self.delegations.retain(|_, d| {
             let age_from = d.started_at.unwrap_or(d.created_at);
             if d.status.is_live() {


### PR DESCRIPTION
Closes #4142.

## Staleness check first

PR #6012 (squash `6d3ce17d`) removed the `SubagentStop` trigger from the
**agent-worktree reap** — a different consumer of the same event. It touched
`agent_worktree_reap.rs` and one call site in `hook_service.rs`, and did not
touch `delegation_tracker.rs`. Every claim in #4142 still holds on HEAD:

| #4142 claim | Verified on `079be7968` |
|---|---|
| `PostToolUse` is `async: true` | `core/standalone/hooks/mod.rs:155-162` |
| `SubagentStop` is synchronous | `core/standalone/hooks/mod.rs:172-178` |
| The tracker still receives both | `hook_service.rs:259` calls `delegation_tracker::observe` for every event |
| `on_subagent_stop` resolves only by `agent_id` | `delegation_tracker.rs:854` |
| An unmatched stop is discarded, nothing re-checks | `delegation_tracker.rs:857`, a bare `return` |

Outcome (a) — still fully valid. #4163 and #4164, flagged on the issue as
possible fold-ins, are both already CLOSED; nothing to fold.

## The defect

`agent_id` is the only key `on_subagent_stop` resolves by, and only
`on_launched` teaches one. The two hooks are independent `tm hook` processes, so
a synchronous stop can post before the async `PostToolUse` naming its agent. The
stop then matched nothing, was discarded, and nothing re-checked — the
delegation stayed `Running` for the full six-hour staleness window as a phantom
in-flight agent.

## Mechanism

A stop that resolves nothing is now held in a bounded ledger
(`daemon/state/pending_stops.rs`) keyed by the exact `(session, agent_id)` it
quoted. `on_launched` consults it the moment that id is taught and applies the
status the stop already determined, so both arrival orders converge on one
record.

The key is the same one in-order resolution uses. The deferred path therefore
closes precisely the record the in-order path would have, or nothing — there is
no "most recent Running" fallback in either direction.

### Fail-closed on every error arm

- A stop whose `agent_id` names an **already-terminal** delegation is a
  redelivery, not an ordering failure, and records nothing. Without that arm the
  ledger would accumulate entries for records that can never be resolved again.
- `on_launched` **peeks rather than takes**. The entry is spent only after the
  terminalization it authorises has landed (`mutate_delegation` returned true),
  so a record that vanished mid-flight leaves the stop recoverable instead of
  silently discarded.
- Both bounds — 256 entries, a 15-minute TTL aged by the existing 60 s sweep —
  drop an entry by leaving its delegation live for the staleness sweep, exactly
  as before this existed. Nothing here can close a delegation no stop named, so
  bounding the buffer is safe to do bluntly.

### What this does NOT close

`classify_dispatch`'s KNOWN LIMITATION stands, and its note is corrected to say
why. That band is a response that never teaches a usable `agentId` at all — with
no key, there is nothing for the ledger to hold the stop against, in any order.
The old note cited the arrival-order race as a reason; that half is now fixed
and the note no longer claims it.

## Tests

Fourteen arms. The three behavioral ones were proven against pre-fix source
(`delegation_tracker.rs` reverted to `origin/main`, tests and the additive state
layer retained):

| Test | Pre-fix result |
|---|---|
| `out_of_order_subagent_stop_resolves_when_its_post_tool_use_lands` | FAILED — `left: Running, right: Completed`, "the out-of-order stop must resolve without waiting on the staleness sweep" |
| `an_out_of_order_stop_failure_lands_as_failed` | FAILED — `left: Running, right: Failed` |
| `a_pending_stop_never_terminalizes_a_delegation_it_does_not_name` | **passes both** — the must-not-regress control |

The acceptance test carries a second, unrelated `Running` delegation as its
control. A fix that guessed "most recent Running" at stop time would have closed
*that* one — the false all-clear #4142 forbids — so the test fails a wrong fix,
not only a missing one.

## Rung 3 — localized behavior inside one crate

```
cargo fmt --check                                     EXIT=0
cargo check -p trusty-mpm --all-targets               EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-mpm                              EXIT=0
  test result: ok. 5170 passed; 0 failed; 7 ignored (lib)
  test result: ok. 1755 passed; 0 failed; 1 ignored (bin tm)
  test result: ok. 1755 passed; 0 failed; 1 ignored (bin trusty-mpm)
bash scripts/check_line_cap.sh                        EXIT=0  (4090 files, 0 violations)
bash scripts/check_test_pointers.sh                   EXIT=0  (25968 citations, 0 dangling)
bash scripts/check_changelog_fragment.sh              EXIT=0
```

Rung 3 and not 4: nothing crosses a crate boundary. The two `DaemonState`
additions are `pub(crate)`, and `delegation_tracker` is their only caller.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
