### PR TITLE
fix(trusty-common): a closed unhealthy_signal disables its select branch instead of spinning (#3026)

### DIFF
--- a/crates/trusty-common/changelog.d/3026-unhealthy-signal-drop.md
+++ b/crates/trusty-common/changelog.d/3026-unhealthy-signal-drop.md
@@ -1,0 +1,12 @@
+Fixed
+- The embedder supervision loop no longer busy-spins when the sidecar
+  client's `unhealthy_signal` sender drops without ever firing. A closed
+  `watch` channel makes `changed()` resolve `Ready(Err(_))` on every poll,
+  and the old `Err` arm logged and looped back around — re-arming the same
+  immediately-ready future and monopolising a tokio worker for the rest of
+  the child's life (88,897 loop passes in 300ms, measured). The branch is
+  now excluded from the `select!` while the channel is closed, so the loop
+  keeps supervising through `child.wait()` and `shutdown_rx` alone. Unlike
+  the sibling `shutdown_rx` fix (#3023), the disabled state is recomputed
+  per iteration rather than latched, because a successful respawn replaces
+  the receiver and the new sidecar's health must be watched again (#3026).

--- a/crates/trusty-common/src/embedder_client/supervisor.rs
+++ b/crates/trusty-common/src/embedder_client/supervisor.rs
@@ -563,8 +563,18 @@ fn should_give_up(
 /// counters feed `should_give_up` and both drive the exponential back-off, so
 /// a workload-deterministic wedge that recurs after every respawn eventually
 /// trips `max_restarts` instead of cycling forever at a 1s backoff.
+///
+/// Both signal channels can also CLOSE — their senders drop without either
+/// ever firing — and a closed `watch` channel is not an event: `changed()`
+/// resolves `Ready(Err(_))` forever, so each branch must be excluded from the
+/// `select!` rather than looped over. `shutdown_rx` latches `shutdown_closed`
+/// (#3023); `unhealthy_signal` re-reads `has_changed()` each iteration
+/// (#3026), because it is swapped for the new client's receiver on every
+/// respawn and must start being watched again.
 /// Test: `supervisor_restarts_on_crash`,
-/// `supervisor_intentional_shutdown_does_not_respawn`.
+/// `supervisor_intentional_shutdown_does_not_respawn`,
+/// `supervisor_closed_unhealthy_signal_does_not_busy_spin`,
+/// `supervisor_health_branch_is_live_again_after_respawn`.
 /// Test-only iteration counter (issue #3023 regression test): bumped once per
 /// `supervision_loop` pass so `supervisor_tests.rs` can assert the loop
 /// blocks normally — rather than busy-spinning — once `shutdown_rx`'s sender
@@ -631,6 +641,26 @@ async fn supervision_loop(
             last_wedge_restart_at = None;
         }
 
+        // #3026: `watch::Receiver::changed()` resolves `Ready(Err(_))` on
+        // every poll once the last sender drops, and an immediately-ready
+        // future never yields to the scheduler — so an `Err` arm that loops
+        // back around (what this branch used to do) re-enters the `select!`,
+        // wins it again instantly, and busy-spins a tokio worker for the
+        // remaining lifetime of the child. Same hazard #3023 fixed for
+        // `shutdown_rx`. Reading `has_changed()` first excludes the branch
+        // from the `select!` before its future is ever polled, so a closed
+        // channel costs zero extra iterations and supervision continues via
+        // `child.wait()` / `shutdown_rx` alone.
+        //
+        // Recomputed each iteration rather than latched in a
+        // `shutdown_closed`-style flag: `shutdown_rx`'s sender lives for the
+        // whole supervision, but `unhealthy_signal` is REPLACED by the newly
+        // spawned client's receiver after every successful respawn (see the
+        // respawn arm below). A latched flag would keep the branch disabled
+        // across that swap, so the replacement sidecar's health would never
+        // be watched and a wedged one would never be restarted.
+        let unhealthy_open = unhealthy_signal.has_changed().is_ok();
+
         // Race the child actually exiting against the live client reporting
         // itself unhealthy (#1448/#1450) — whichever happens first drives
         // this iteration.
@@ -647,11 +677,15 @@ async fn supervision_loop(
                                 return;
                             }
                         },
-                        changed = unhealthy_signal.changed() => {
+                        changed = unhealthy_signal.changed(), if unhealthy_open => {
                             if changed.is_err() {
-                                // The sender side closed without ever firing —
-                                // treat conservatively as "keep waiting on
-                                // child.wait() only" by looping back around.
+                                // The sender closed while we were parked here.
+                                // A closed channel is NOT a health event — the
+                                // sidecar may still be running fine — so keep
+                                // supervising via `child.wait()`. The
+                                // `unhealthy_open` guard above reads `false` on
+                                // the next pass, so this arm runs at most once
+                                // per receiver rather than spinning (#3026).
                                 tracing::debug!(
                                     "EmbedderSupervisor: unhealthy_signal channel closed \
                                      without firing — continuing to watch child.wait()"

--- a/crates/trusty-common/src/embedder_client/supervisor_tests.rs
+++ b/crates/trusty-common/src/embedder_client/supervisor_tests.rs
@@ -435,6 +435,48 @@ exit 1
         (dir, path)
     }
 
+    /// Like `write_mock_embedderd`, but every invocation answers its startup
+    /// probe, waits a second, then closes its stdout and idles forever
+    /// WITHOUT exiting — the wedged-sidecar shape that only the health signal
+    /// can detect.
+    ///
+    /// Why (issue #3026): proving the `unhealthy_signal` `select!` branch is
+    /// live again after a respawn needs a restart trigger that `child.wait()`
+    /// cannot supply. Closing stdout makes the client's reader task hit EOF,
+    /// which flips `unhealthy_tx` to `true` (see
+    /// `reader_eof_exit_also_signals_unhealthy` in `stdio_tests.rs`) while the
+    /// process itself stays alive, so a supervisor that stopped watching the
+    /// health channel would sit on a wedged sidecar forever.
+    /// What: identical wire protocol to `write_mock_embedderd` for the single
+    /// probe request, then `sleep 1`, `exec 1>&-` (close stdout), then an
+    /// endless idle loop. The one-second wait is load-bearing:
+    /// `watch::Sender::subscribe` marks the current value as SEEN, so an EOF
+    /// that beat `spawn_child`'s return would flip the flag before
+    /// `unhealthy_signal()` subscribed and the new receiver would never
+    /// report it.
+    /// Test: `supervisor_health_branch_is_live_again_after_respawn`.
+    fn write_mock_embedderd_wedges_after_probe() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("mock-embedderd-wedges.sh");
+        std::fs::write(
+            &path,
+            r#"#!/bin/sh
+IFS= read -r line
+id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+[ -n "$id" ] || id=1
+printf '{"jsonrpc":"2.0","result":{"embeddings":[[0.1]]},"id":%s}\n' "$id"
+sleep 1
+exec 1>&-
+while :; do sleep 1; done
+"#,
+        )
+        .expect("write mock script");
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).expect("chmod +x");
+        (dir, path)
+    }
+
     /// Like `write_mock_embedderd_crash_once`, but only the FIRST invocation
     /// crashes — every later invocation (detected via a marker file dropped
     /// on the first run, same technique as
@@ -518,6 +560,7 @@ exit 1
     /// detaching, assert the OS process is gone.
     /// Test: this test.
     #[tokio::test]
+    #[serial]
     async fn supervisor_shutdown_kills_child() {
         let (_dir, binary) = write_mock_embedderd();
         let cfg = SupervisorConfig {
@@ -551,6 +594,7 @@ exit 1
     /// child is gone and `child_pid_slot` was cleared to 0.
     /// Test: this test.
     #[tokio::test]
+    #[serial]
     async fn supervisor_shutdown_handle_is_reachable_and_stops_child() {
         let (_dir, binary) = write_mock_embedderd();
         let cfg = SupervisorConfig {
@@ -592,6 +636,7 @@ exit 1
     /// published a fresh non-zero PID.
     /// Test: this test.
     #[tokio::test]
+    #[serial]
     async fn supervisor_intentional_shutdown_does_not_respawn() {
         let (_dir, binary) = write_mock_embedderd();
         let cfg = SupervisorConfig {
@@ -648,6 +693,7 @@ exit 1
     /// after waiting past what the full backoff + respawn would have taken.
     /// Test: this test.
     #[tokio::test]
+    #[serial]
     async fn supervisor_shutdown_during_respawn_backoff_returns_promptly() {
         let (_dir, binary) = write_mock_embedderd_crash_once();
         let cfg = SupervisorConfig {
@@ -745,6 +791,7 @@ exit 1
     /// (`shutdown_closed`) and did not wedge ongoing supervision.
     /// Test: this test.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial]
     async fn supervisor_dropped_handle_does_not_busy_spin() {
         let (_dir, binary) = write_mock_embedderd();
         let cfg = SupervisorConfig {
@@ -829,6 +876,7 @@ exit 1
     /// (never a fixed sleep-and-hope) until it flips.
     /// Test: this test.
     #[tokio::test]
+    #[serial]
     async fn supervisor_gives_up_after_max_restarts_flips_has_given_up() {
         let (_dir, binary) = write_mock_embedderd_crash_once();
         let cfg = SupervisorConfig {
@@ -953,6 +1001,7 @@ exit 1
     ///   5. Assert `has_given_up()` is still `false`.
     /// Test: this test.
     #[tokio::test]
+    #[serial]
     async fn supervisor_transient_crash_then_sustained_health_resets_counter_no_premature_give_up()
     {
         let (_dir, binary) = write_mock_embedderd_crash_once_then_healthy();
@@ -1052,6 +1101,7 @@ exit 1
     /// `true` or a generous timeout.
     /// Test: this test.
     #[tokio::test]
+    #[serial]
     async fn supervisor_terminated_signal_fires_after_exhausting_max_restarts() {
         let (_dir, binary) = write_mock_embedderd_crash_once();
         let cfg = SupervisorConfig {
@@ -1115,6 +1165,7 @@ exit 1
     /// `false` throughout and after.
     /// Test: this test.
     #[tokio::test]
+    #[serial]
     async fn supervisor_terminated_signal_stays_false_on_intentional_shutdown() {
         let (_dir, binary) = write_mock_embedderd();
         let cfg = SupervisorConfig {
@@ -1136,5 +1187,168 @@ exit 1
             "an intentional cooperative shutdown must never set terminated_signal"
         );
         assert_eq!(pid_slot.load(Ordering::Acquire), 0);
+    }
+
+    /// Regression test for issue #3026: closing `unhealthy_signal`'s sender
+    /// while the sidecar is still alive must not busy-spin the supervision
+    /// loop, and must not be read as a health event.
+    ///
+    /// Why: `watch::Receiver::changed()` resolves `Ready(Err(_))` on every
+    /// poll once the last sender drops, and an immediately-ready future never
+    /// yields, so the old `Err` arm — which logged and `continue`d — re-armed
+    /// the same ready future and monopolised a tokio worker for the rest of
+    /// the child's life. That is the `shutdown_rx` hazard #3023 fixed, on the
+    /// branch beside it. Before the fix this test's iteration count runs into
+    /// the millions.
+    /// What: spawns the idling mock sidecar, then overwrites the supervisor's
+    /// `unhealthy_signal` field with a receiver whose sender is already
+    /// dropped — the field swap is what makes the closed-channel state
+    /// reachable at all, since the live client owns its own sender. Two
+    /// worker threads deliberately: a regression then shows up as a failed
+    /// assertion on the count rather than a hang. Asserts (a) the loop stays
+    /// bounded over a 300ms window, (b) the pid is unchanged, so a closed
+    /// channel was not misread as `RestartTrigger::Unhealthy` and did not
+    /// kill a healthy sidecar, and (c) supervision still works — an
+    /// out-of-band kill is noticed and respawned, and `shutdown()` still
+    /// stops the loop.
+    /// Test: this test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial]
+    async fn supervisor_closed_unhealthy_signal_does_not_busy_spin() {
+        let (_dir, binary) = write_mock_embedderd();
+        let cfg = SupervisorConfig {
+            startup_timeout_secs: 5,
+            max_restarts: 5,
+            ..SupervisorConfig::default()
+        };
+        let (mut supervisor, _client_slot, pid_slot) = EmbedderSupervisor::spawn_stdio(binary, cfg)
+            .await
+            .expect("spawn_stdio failed");
+        let initial_pid = pid_slot.load(Ordering::Acquire);
+        assert!(initial_pid > 0, "pid_slot must be populated after spawn");
+
+        // Hand the loop a health channel that is already closed, leaving the
+        // sidecar itself running — the state the loop must tolerate.
+        let (dead_tx, dead_rx) = watch::channel(false);
+        drop(dead_tx);
+        supervisor.unhealthy_signal = dead_rx;
+
+        super::SUPERVISION_LOOP_ITERATIONS.store(0, Ordering::Relaxed);
+        let handle = supervisor.start_supervisor_task();
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let iterations = super::SUPERVISION_LOOP_ITERATIONS.load(Ordering::Relaxed);
+        assert!(
+            iterations < 200,
+            "supervision_loop iterated {iterations} times in 300ms with a closed \
+             unhealthy_signal channel — expected a small, bounded count (the loop \
+             blocked on child.wait() as usual), not a busy-spin re-polling the \
+             immediately-ready Err future"
+        );
+        assert_eq!(
+            pid_slot.load(Ordering::Acquire),
+            initial_pid,
+            "a closed unhealthy_signal channel is not a health event — the live \
+             sidecar must not be killed and respawned because its sender dropped"
+        );
+
+        // Supervision must still function: kill the child out-of-band and
+        // confirm the loop notices the exit and respawns it.
+        std::process::Command::new("kill")
+            .args(["-9", &initial_pid.to_string()])
+            .status()
+            .expect("kill -9 mock child");
+
+        let respawned = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let pid = pid_slot.load(Ordering::Acquire);
+                if pid != 0 && pid != initial_pid {
+                    return pid;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(
+            respawned.is_ok(),
+            "supervisor never respawned the killed child within 10s — a closed \
+             unhealthy_signal channel must not wedge ongoing supervision"
+        );
+
+        // And cooperative shutdown still reaches the loop afterwards.
+        handle.shutdown().await;
+        assert_eq!(pid_slot.load(Ordering::Acquire), 0);
+    }
+
+    /// Issue #3026, the half a naive fix gets wrong: after a respawn the
+    /// supervisor watches the NEW client's health signal again, even though
+    /// the previous receiver's channel was closed.
+    ///
+    /// Why: `shutdown_rx`'s sender lives for the whole supervision, so #3023
+    /// could latch `shutdown_closed` once and never revisit it. Copying that
+    /// shape onto `unhealthy_signal` would be wrong — the supervisor replaces
+    /// that receiver on every successful respawn, and a latched flag would
+    /// leave the branch disabled for the replacement sidecar. Nothing else in
+    /// the suite would catch it: a sidecar that wedges without exiting is
+    /// invisible to `child.wait()`, so the supervisor would simply sit on it.
+    /// What: starts with a closed health channel (same field swap as
+    /// `supervisor_closed_unhealthy_signal_does_not_busy_spin`), kills the
+    /// child to force a respawn, and then relies on
+    /// `write_mock_embedderd_wedges_after_probe` — every replacement answers
+    /// its probe and then closes stdout while staying alive, so the ONLY
+    /// signal that can drive another restart is the health channel. With
+    /// `max_restarts: 2` the loop reaches `should_give_up` after the initial
+    /// crash plus two wedge restarts, so `terminated_signal()` flipping is
+    /// proof the branch fired again. A latched-flag fix never reaches it and
+    /// this test times out.
+    /// Test: this test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial]
+    async fn supervisor_health_branch_is_live_again_after_respawn() {
+        let (_dir, binary) = write_mock_embedderd_wedges_after_probe();
+        let cfg = SupervisorConfig {
+            startup_timeout_secs: 5,
+            backoff_max_secs: 0,
+            max_restarts: 2,
+            ..SupervisorConfig::default()
+        };
+        let (mut supervisor, _client_slot, pid_slot) = EmbedderSupervisor::spawn_stdio(binary, cfg)
+            .await
+            .expect("spawn_stdio failed");
+        let initial_pid = pid_slot.load(Ordering::Acquire);
+        assert!(initial_pid > 0, "pid_slot must be populated after spawn");
+
+        let (dead_tx, dead_rx) = watch::channel(false);
+        drop(dead_tx);
+        supervisor.unhealthy_signal = dead_rx;
+
+        let terminated = supervisor.terminated_signal();
+        let handle = supervisor.start_supervisor_task();
+
+        // Force the first respawn, which is where the loop picks up the
+        // replacement client's (open) health receiver.
+        std::process::Command::new("kill")
+            .args(["-9", &initial_pid.to_string()])
+            .status()
+            .expect("kill -9 mock child");
+
+        let gave_up = tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                if terminated.load(Ordering::Acquire) {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        assert!(
+            gave_up.is_ok(),
+            "the supervisor never escalated past max_restarts — after the respawn \
+             it stopped watching the replacement sidecar's unhealthy_signal, so a \
+             wedged (stdout-closed but still running) sidecar was never restarted"
+        );
+
+        handle.shutdown().await;
     }
 }


### PR DESCRIPTION
Closes #3026. Sibling of the #3023 fix, on the branch beside it.

## Defect

`supervision_loop` races `child.wait()` against `unhealthy_signal.changed()` and `shutdown_rx.changed()`. `watch::Receiver::changed()` resolves `Ready(Err(_))` on every poll once the last sender drops, and an immediately-ready future never yields to the scheduler. The `unhealthy_signal` arm logged that case and `continue`d, which re-armed the same ready future and won the `select!` again instantly — so a closed health channel busy-spun a tokio worker for the remaining lifetime of the child.

Measured on the pre-fix code with the new test: **88,897 loop passes in 300ms**.

The issue asked whether the branch disables itself or re-polls a `Ready(Err)` in a loop. It re-polls.

## Fix

`crates/trusty-common/src/embedder_client/supervisor.rs:661` computes `unhealthy_signal.has_changed().is_ok()` once per iteration and uses it as the branch's `select!` precondition, so a closed channel is excluded before its future is ever polled. Supervision continues through `child.wait()` and `shutdown_rx` alone. A closed channel is not read as a health event — the sidecar may still be running fine.

The state is recomputed per iteration rather than latched in a `shutdown_closed`-style flag, and that difference is the point: `shutdown_rx`'s sender lives for the whole supervision, but `unhealthy_signal` is replaced by the new client's receiver after every successful respawn (`supervisor.rs:942`). A latched flag would keep the branch disabled across that swap, and a sidecar that wedges without exiting is invisible to `child.wait()` — so the replacement would never be restarted.

## Acceptance criteria

1. A closed health channel costs a bounded number of loop iterations, not a hot loop.
2. Sender-drop is not a restart trigger — the live sidecar keeps running.
3. The branch is live again after a respawn, so a wedged replacement is still detected.
4. `child.wait()` and cooperative `shutdown()` still work while the branch is disabled.

## Tests

`supervisor_closed_unhealthy_signal_does_not_busy_spin` covers 1, 2 and 4. It overwrites the supervisor's `unhealthy_signal` field with a receiver whose sender is already dropped (the live client owns its own sender, so that field swap is the only way to reach the state), then asserts the iteration count stays bounded, the pid is unchanged, an out-of-band `kill -9` is still noticed and respawned, and `shutdown()` still stops the loop. It fails on the pre-fix code with the 88,897-iteration count above.

`supervisor_health_branch_is_live_again_after_respawn` covers 3 — the half a naive latched-flag fix gets wrong. A new mock answers its startup probe, then closes stdout and idles without exiting, so the health channel is the only signal that can drive a restart. With `max_restarts: 2` the loop escalates past `should_give_up` and flips `terminated_signal()`; a latched-flag fix never reaches it.

Also folded in the follow-up recorded on #3026 from the #3023 delta review: `#[serial]` on the `shutdown_tests` tokio tests, so the process-wide `SUPERVISION_LOOP_ITERATIONS` counter is not raced by a concurrent supervision loop. That makes both busy-spin assertions genuinely race-free rather than margin-dependent.

No public API change — the edit is inside a private `async fn`.

## Test ladder: rung 4

`trusty-common` is a shared library, so rung 3 on the library plus `check --workspace` and the direct dependents.

```
cargo fmt --check                                                                    EXIT=0
cargo check -p trusty-common --features embedder-client,embedder-bundled-ort --all-targets   EXIT=0
cargo clippy -p trusty-common --features embedder-client,embedder-bundled-ort --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-common --features embedder-client,embedder-bundled-ort
    test result: ok. 513 passed; 0 failed; 10 ignored; 0 measured; 0 filtered out
cargo check --workspace --all-targets                                                EXIT=0
cargo test -p trusty-search --lib
    test result: ok. 1769 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
cargo test -p trusty-embedderd-py --lib
    test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
bash scripts/check_line_cap.sh          4097 tracked .rs files, 0 violations — OK
bash scripts/check_test_pointers.sh     25958 Test: citations, 0 dangling — OK
bash scripts/check_changelog_fragment.sh  trusty-common fragment present and valid
```

The two new tests are timing-adjacent, so `shutdown_tests` was run 10 consecutive times: 11 passed / 0 failed each time.

Baseline for the regression test, with the `select!` precondition reverted to the pre-fix `if true`:

```
thread '...supervisor_closed_unhealthy_signal_does_not_busy_spin' panicked at
crates/trusty-common/src/embedder_client/supervisor_tests.rs:1242:9:
supervision_loop iterated 88897 times in 300ms with a closed unhealthy_signal
channel — expected a small, bounded count (the loop blocked on child.wait() as
usual), not a busy-spin re-polling the immediately-ready Err future

test result: FAILED. 0 passed; 1 failed
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
