### PR TITLE
fix: loopback daemon clients stop honouring an exported HTTP_PROXY (#4392)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11237,7 +11237,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-analyze"
-version     = "0.9.1"
+version     = "0.9.2"
 edition     = "2021"
 license.workspace    = true
 authors.workspace    = true

--- a/crates/trusty-analyze/changelog.d/4392-no-proxy-loopback-clients.md
+++ b/crates/trusty-analyze/changelog.d/4392-no-proxy-loopback-clients.md
@@ -1,0 +1,5 @@
+Fixed
+- `trusty-analyze health`, `daemon status` and the `setup` readiness poll no
+  longer report a healthy daemon as DOWN when `HTTP_PROXY` is exported. All
+  three build through `trusty_common::http_client`, which applies `.no_proxy()`
+  (#4392).

--- a/crates/trusty-analyze/src/commands/daemon.rs
+++ b/crates/trusty-analyze/src/commands/daemon.rs
@@ -214,7 +214,11 @@ pub async fn handle_status(port: u16) -> Result<()> {
 
     if reachable {
         let url = format!("http://127.0.0.1:{port}/health");
-        let client = reqwest::Client::new();
+        // #4392: loopback target — an exported HTTP_PROXY would otherwise
+        // report a healthy daemon as DOWN.
+        let client = trusty_common::http_client::loopback_client_builder()
+            .build()
+            .context("build health-probe client")?;
         match client
             .get(&url)
             .timeout(Duration::from_secs(2))

--- a/crates/trusty-analyze/src/commands/setup.rs
+++ b/crates/trusty-analyze/src/commands/setup.rs
@@ -318,7 +318,11 @@ async fn setup_daemon() -> Result<()> {
         }
 
         // Poll /health for up to 10 s.
-        let client = reqwest::Client::new();
+        // #4392: loopback target — an exported HTTP_PROXY would otherwise make
+        // this poll time out against a daemon that started correctly.
+        let client = trusty_common::http_client::loopback_client_builder()
+            .build()
+            .context("build health-poll client")?;
         let url = format!("http://127.0.0.1:{DEFAULT_PORT}/health");
         for _ in 0..20 {
             tokio::time::sleep(Duration::from_millis(500)).await;

--- a/crates/trusty-analyze/src/main.rs
+++ b/crates/trusty-analyze/src/main.rs
@@ -587,7 +587,9 @@ async fn main() -> Result<()> {
             );
             // The analyzer's own health is queried via HTTP if it's running.
             let analyzer_url = format!("http://127.0.0.1:{}", DEFAULT_PORT);
-            let client = reqwest::Client::new();
+            // #4392: loopback target — an exported HTTP_PROXY would otherwise
+            // report a healthy analyzer as DOWN.
+            let client = trusty_common::http_client::loopback_client()?;
             let analyzer_ok = client
                 .get(format!("{analyzer_url}/health"))
                 .send()

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -314,7 +314,14 @@ mcp = []
 # `index_id` / `daemon_addr` helpers it uses are already unconditional, so the
 # feature flag gates module compilation + the blocking client only. Off by
 # default so consumers that don't register indexes pay nothing.
-search-index = ["reqwest/blocking"]
+search-index = ["blocking-http"]
+# Enables `http_client::blocking_loopback_client_builder`, the synchronous
+# counterpart of the #4392 proxy-free loopback entry point, by turning on
+# `reqwest/blocking`. Named for what it provides rather than for one consumer:
+# `search-index` implies it (its index-registration and readiness paths run on
+# detached threads with no reactor), and any other off-reactor loopback caller
+# enables it directly instead of reaching for `reqwest::blocking` bare.
+blocking-http = ["reqwest/blocking"]
 # Enables the `session_naming` module: the ONE canonical tmux-session naming
 # rule (managed prefix, adjective+noun / dir-slug / serial derivation, and the
 # `is_managed_session_name` classifier) shared by trusty-mpm's SessionManager

--- a/crates/trusty-common/changelog.d/4392-no-proxy-loopback-clients.md
+++ b/crates/trusty-common/changelog.d/4392-no-proxy-loopback-clients.md
@@ -1,0 +1,15 @@
+Fixed
+- Loopback daemon calls no longer go through an exported `HTTP_PROXY` /
+  `http_proxy` / `ALL_PROXY`. reqwest 0.12 routes `127.0.0.1` through the proxy
+  — hyper-util's matcher has no loopback exemption — so on a machine with a
+  proxy configured every daemon call failed and the caller reported a healthy
+  daemon as down. The new `http_client` module is the one entry point that
+  applies `.no_proxy()`: `loopback_client_builder` (proxies off, caller keeps
+  its own timeouts), `loopback_client` (plus 2s connect / 5s request bounds),
+  and `blocking_loopback_client_builder` behind the new `blocking-http` feature.
+  `daemon_http_client`, `health_probe`, `daemon_guard`, `mcp::daemon_bridge`,
+  `mcp::memory_rpc`, `search_index`, `search_readiness`, the monitor search and
+  memory clients (request and SSE), and `embedder_client::RemoteEmbedderClient`
+  all route through it. Public-internet clients — `update`, `chat`,
+  `inference`, `openrouter_legacy` — deliberately still honour the operator's
+  proxy (#4392).

--- a/crates/trusty-common/src/daemon_guard.rs
+++ b/crates/trusty-common/src/daemon_guard.rs
@@ -330,9 +330,12 @@ fn address_reachable_blocking(host_port: &str) -> bool {
 /// simple and predictable across cold/warm starts.
 /// What: builds a one-shot reqwest client with `PROBE_TIMEOUT`, issues a GET,
 /// returns `true` on any 2xx status and `false` on any error or non-2xx.
-/// Test: `probe_once_returns_false_for_refused_port` (async unit test below).
+/// Test: `probe_once_returns_false_for_refused_port` (async unit test below);
+/// the proxy immunity is proven in `http_client::tests`.
 pub async fn probe_once(health_url: &str) -> bool {
-    let client = match reqwest::Client::builder()
+    // #4392: the target is a loopback daemon, so the client must not honour an
+    // exported HTTP_PROXY.
+    let client = match crate::http_client::loopback_client_builder()
         .timeout(PROBE_TIMEOUT)
         .connect_timeout(PROBE_TIMEOUT)
         .build()

--- a/crates/trusty-common/src/embedder_client/remote.rs
+++ b/crates/trusty-common/src/embedder_client/remote.rs
@@ -41,16 +41,18 @@ impl RemoteEmbedderClient {
     /// Why: callers pass the base URL (e.g. `http://127.0.0.1:7890`) and the
     /// client appends `/embed` for the POST endpoint.
     ///
-    /// What: builds a `reqwest::Client` with default TLS settings, stores the
+    /// What: builds a `reqwest::Client` with default TLS settings and proxies
+    /// disabled (#4392 — trusty-embedderd answers on loopback), stores the
     /// fully-qualified embed URL.
     ///
     /// Test: `remote_client_construction` below verifies the URL is stored
-    /// correctly without sending any network requests.
+    /// correctly without sending any network requests; the proxy immunity is
+    /// proven in `http_client::tests`.
     pub fn new(base_url: impl Into<String>) -> Self {
         let base = base_url.into();
         let base = base.trim_end_matches('/').to_owned();
         let embed_url = format!("{base}/embed");
-        let client = reqwest::Client::builder()
+        let client = crate::http_client::loopback_client_builder()
             .build()
             .expect("reqwest client construction is infallible on supported platforms");
         tracing::debug!(embed_url = %embed_url, "RemoteEmbedderClient constructed");

--- a/crates/trusty-common/src/health_probe.rs
+++ b/crates/trusty-common/src/health_probe.rs
@@ -17,10 +17,13 @@
 /// returns `true` only when the response is HTTP 2xx. Any client-builder error
 /// or transport failure returns `false`.
 /// Test: covered indirectly via `check_already_running_*` tests in
-/// `daemon_addr` module and the three daemon integration paths.
+/// `daemon_addr` module and the three daemon integration paths; the proxy
+/// immunity is proven in `http_client::tests`.
 pub async fn probe_health(base_url: &str, health_path: &str) -> bool {
     let probe = format!("{base_url}{health_path}");
-    let client = match reqwest::Client::builder()
+    // #4392: the target is a loopback daemon, so the client must not honour an
+    // exported HTTP_PROXY.
+    let client = match crate::http_client::loopback_client_builder()
         .timeout(std::time::Duration::from_secs(1))
         .build()
     {

--- a/crates/trusty-common/src/http_client.rs
+++ b/crates/trusty-common/src/http_client.rs
@@ -1,0 +1,246 @@
+//! The one HTTP-client constructor every loopback/daemon caller routes through
+//! (#4392).
+//!
+//! Why: reqwest 0.12 sends `127.0.0.1` through `HTTP_PROXY` / `http_proxy` /
+//! `ALL_PROXY` when one of them is exported. hyper-util's proxy matcher has no
+//! runtime loopback exemption — the only bypass is an explicit `NO_PROXY` entry
+//! the operator is not required to have — so on a machine with a corporate proxy
+//! configured, every tm↔daemon call is routed to the proxy and fails. The daemon
+//! is up; the caller reports it down. `.no_proxy()` on the builder is the fix,
+//! and it has to live at ONE entry point: the workspace held ~133 bare
+//! `reqwest::Client::builder()` sites and adding the call per-site guarantees the
+//! next site forgets it.
+//!
+//! What:
+//! - [`loopback_client_builder`] — the primitive. A `ClientBuilder` with proxies
+//!   disabled and NO timeout policy, for callers that own their own bounds (an
+//!   SSE stream must not carry a whole-request timeout at all).
+//! - [`loopback_client`] — that builder plus the standard
+//!   [`LOOPBACK_CONNECT_TIMEOUT`] / [`LOOPBACK_REQUEST_TIMEOUT`] bounds, for
+//!   callers with no bespoke timing requirement.
+//! - [`blocking_loopback_client_builder`] — the `reqwest::blocking` counterpart,
+//!   behind the `blocking-http` feature.
+//!
+//! Scope: LOOPBACK callers only. A client that genuinely talks to the public
+//! internet — crates.io in `update`, an inference provider in `inference` /
+//! `chat`, the GitHub API — must keep honouring the operator's proxy, and must
+//! NOT be routed through here.
+//!
+//! Test: `tests::loopback_client_ignores_exported_http_proxy` sets `HTTP_PROXY`
+//! to a dead address and proves both halves — a bare builder is diverted, this
+//! one still reaches a loopback stub.
+
+use std::time::Duration;
+
+/// TCP connect bound for a loopback call.
+///
+/// Why: a closed loopback port refuses instantly, but a firewalled or wedged one
+/// can hang for the OS default (~75s). Bounding connect separately from the whole
+/// request keeps a dead peer cheap.
+pub const LOOPBACK_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Whole-request bound (connect + headers + body) for a loopback call.
+///
+/// Why: a live daemon answers in single-digit milliseconds; 5s is generous for a
+/// loaded one and short enough that a CLI never appears to freeze.
+pub const LOOPBACK_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Start a `reqwest::Client` for a loopback/daemon target — proxies off, no
+/// timeout policy applied.
+///
+/// Why: `.no_proxy()` is the load-bearing call (see the module docs); leaving the
+/// timeouts to the caller is what lets every existing site adopt this entry point
+/// without changing its own timing contract, including the SSE readers that must
+/// have no whole-request bound.
+/// What: `reqwest::Client::builder().no_proxy()`. Chain the caller's own
+/// `.timeout()` / `.connect_timeout()` and `.build()`.
+/// Test: `tests::loopback_client_ignores_exported_http_proxy`.
+pub fn loopback_client_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder().no_proxy()
+}
+
+/// Build a ready-to-use loopback client with the standard bounds.
+///
+/// Why: most callers want "talk to the daemon, fail fast, never via a proxy" and
+/// should not restate the two timeouts.
+/// What: [`loopback_client_builder`] plus [`LOOPBACK_CONNECT_TIMEOUT`] and
+/// [`LOOPBACK_REQUEST_TIMEOUT`].
+/// Test: `tests::loopback_client_ignores_exported_http_proxy`,
+/// `tests::loopback_client_builds`.
+pub fn loopback_client() -> reqwest::Result<reqwest::Client> {
+    loopback_client_builder()
+        .connect_timeout(LOOPBACK_CONNECT_TIMEOUT)
+        .timeout(LOOPBACK_REQUEST_TIMEOUT)
+        .build()
+}
+
+/// [`loopback_client_builder`] for the synchronous `reqwest::blocking` API.
+///
+/// Why: the index-registration and search-readiness paths run on detached
+/// threads with no reactor, so they use the blocking client. They are loopback
+/// callers and inherit the same defect.
+/// What: `reqwest::blocking::Client::builder().no_proxy()`, with the timeout
+/// policy left to the caller for the same reason as the async form.
+/// Test: `tests::blocking_loopback_client_ignores_exported_http_proxy`.
+#[cfg(feature = "blocking-http")]
+pub fn blocking_loopback_client_builder() -> reqwest::blocking::ClientBuilder {
+    reqwest::blocking::Client::builder().no_proxy()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    /// A loopback stub that answers one `200 OK` per connection, forever.
+    ///
+    /// Returns the bound `host:port`. Modelled on
+    /// `daemon_guard::tests::spin_until_ready_returns_ok_for_live_server` — a
+    /// real listener rather than a mocked client, so the proxy behaviour under
+    /// test is the real transport's.
+    async fn stub_server() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback stub");
+        let addr = listener.local_addr().expect("stub addr").to_string();
+        tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    use tokio::io::AsyncWriteExt;
+                    let _ = stream
+                        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+                        .await;
+                });
+            }
+        });
+        addr
+    }
+
+    /// An address with nothing listening: bind port 0, read it, release it.
+    fn dead_addr() -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind to free a port");
+        let addr = listener.local_addr().expect("dead addr").to_string();
+        drop(listener);
+        addr
+    }
+
+    /// Set `HTTP_PROXY`, run `body`, restore the previous value.
+    ///
+    /// SAFETY: every caller is `#[serial]`, so no other test in this binary is
+    /// reading or writing the environment concurrently.
+    fn with_http_proxy<T>(value: &str, body: impl FnOnce() -> T) -> T {
+        let previous = std::env::var("HTTP_PROXY").ok();
+        unsafe { std::env::set_var("HTTP_PROXY", value) };
+        let out = body();
+        unsafe {
+            match previous {
+                Some(v) => std::env::set_var("HTTP_PROXY", v),
+                None => std::env::remove_var("HTTP_PROXY"),
+            }
+        }
+        out
+    }
+
+    /// Why (#4392): this is the whole defect. reqwest reads the proxy
+    /// environment at client-BUILD time and routes `127.0.0.1` through it, so a
+    /// developer with a corporate proxy exported sees every loopback daemon call
+    /// fail while the daemon is demonstrably up.
+    ///
+    /// Both halves are asserted so that deleting `.no_proxy()` as "hygiene"
+    /// fails loudly: a bare builder must be diverted to the dead proxy, and
+    /// [`loopback_client`] must still reach the stub.
+    /// What: exports `HTTP_PROXY` pointing at a released ephemeral port, builds
+    /// both clients under it, and issues the same loopback GET with each.
+    /// `#[serial]` because `HTTP_PROXY` is process-global.
+    /// Test: This is the test.
+    ///
+    /// If a future reqwest exempts loopback from proxies, the first assertion
+    /// becomes obsolete and should be deleted — `.no_proxy()` itself must stay,
+    /// because this crate cannot pin every consumer's reqwest patch level.
+    #[tokio::test]
+    #[serial]
+    async fn loopback_client_ignores_exported_http_proxy() {
+        let addr = stub_server().await;
+        let url = format!("http://{addr}/health");
+        let proxy = format!("http://{}", dead_addr());
+
+        let (leaky, guarded) = with_http_proxy(&proxy, || {
+            let leaky = reqwest::Client::builder()
+                .connect_timeout(Duration::from_millis(500))
+                .timeout(Duration::from_millis(500))
+                .build()
+                .expect("bare client builds");
+            let guarded = loopback_client().expect("loopback client builds");
+            (leaky, guarded)
+        });
+
+        let leaked = leaky.get(&url).send().await;
+        let reached = guarded.get(&url).send().await;
+
+        assert!(
+            leaked.is_err(),
+            "a client WITHOUT .no_proxy() must be diverted through HTTP_PROXY — \
+             that diversion IS the #4392 mechanism; got {leaked:?}"
+        );
+        assert!(
+            reached.is_ok_and(|r| r.status().is_success()),
+            "loopback_client() must reach a loopback peer with HTTP_PROXY exported"
+        );
+    }
+
+    /// Why (#4392): the blocking half of the entry point serves the
+    /// index-registration and readiness paths, which run off-reactor. It carries
+    /// the same defect and needs the same proof.
+    /// What: the async test's shape, on `reqwest::blocking`, driven from a
+    /// `spawn_blocking` so the blocking client never runs on a reactor thread.
+    /// Test: This is the test.
+    #[cfg(feature = "blocking-http")]
+    #[tokio::test]
+    #[serial]
+    async fn blocking_loopback_client_ignores_exported_http_proxy() {
+        let addr = stub_server().await;
+        let url = format!("http://{addr}/health");
+        let proxy = format!("http://{}", dead_addr());
+
+        let (leaked, reached) = tokio::task::spawn_blocking(move || {
+            with_http_proxy(&proxy, || {
+                let leaky = reqwest::blocking::Client::builder()
+                    .connect_timeout(Duration::from_millis(500))
+                    .timeout(Duration::from_millis(500))
+                    .build()
+                    .expect("bare blocking client builds");
+                let guarded = blocking_loopback_client_builder()
+                    .connect_timeout(LOOPBACK_CONNECT_TIMEOUT)
+                    .timeout(LOOPBACK_REQUEST_TIMEOUT)
+                    .build()
+                    .expect("blocking loopback client builds");
+                (
+                    leaky.get(&url).send().is_err(),
+                    guarded
+                        .get(&url)
+                        .send()
+                        .is_ok_and(|r| r.status().is_success()),
+                )
+            })
+        })
+        .await
+        .expect("blocking probe thread");
+
+        assert!(
+            leaked,
+            "a blocking client WITHOUT .no_proxy() must be diverted through HTTP_PROXY"
+        );
+        assert!(
+            reached,
+            "the blocking loopback builder must reach a loopback peer with HTTP_PROXY exported"
+        );
+    }
+
+    /// Why: the standard-bounds convenience form must construct.
+    /// What: builds it and drops it.
+    /// Test: This is the test.
+    #[test]
+    fn loopback_client_builds() {
+        drop(loopback_client().expect("loopback client builds"));
+    }
+}

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -897,6 +897,23 @@ pub mod daemon_addr;
 /// Test: covered via daemon_addr integration tests.
 pub mod health_probe;
 
+/// The single HTTP-client constructor for loopback/daemon targets (#4392).
+///
+/// Why: reqwest 0.12 routes `127.0.0.1` through an exported `HTTP_PROXY` /
+/// `ALL_PROXY` — hyper-util's matcher has no loopback exemption — so on a
+/// machine with a proxy configured every tm↔daemon call fails and the caller
+/// reports a healthy daemon as down. `.no_proxy()` fixes it, and it belongs at
+/// ONE entry point rather than across ~133 `Client::builder()` sites.
+/// What: Exposes [`http_client::loopback_client_builder`] (the primitive, no
+/// timeout policy), [`http_client::loopback_client`] (standard bounds), and
+/// [`http_client::blocking_loopback_client_builder`] behind `blocking-http`.
+/// Public-internet callers (crates.io, inference providers, the GitHub API)
+/// deliberately do NOT route through here — they must keep honouring the
+/// operator's proxy.
+/// Test: `cargo test -p trusty-common --features unconditional-only --
+/// http_client::tests`.
+pub mod http_client;
+
 /// Unix-domain-socket permission enforcement (issue #5099).
 ///
 /// Why: ADR-0031 and ADR-0032 both argue for UDS over loopback TCP on the

--- a/crates/trusty-common/src/mcp/daemon_bridge.rs
+++ b/crates/trusty-common/src/mcp/daemon_bridge.rs
@@ -135,9 +135,12 @@ impl DaemonBridgeConfig {
 /// carrying over from a failed probe to a later successful one.
 /// What: builds a one-shot client with `DAEMON_PROBE_TIMEOUT`, issues a GET,
 /// returns `true` on 2xx, `false` on any error or non-2xx.
-/// Test: `probe_health_once_returns_false_on_refused` (async unit test).
+/// Test: `probe_health_once_returns_false_on_refused` (async unit test); the
+/// proxy immunity is proven in `http_client::tests`.
 pub(crate) async fn probe_health_once(health_url: &str) -> bool {
-    let client = match reqwest::Client::builder()
+    // #4392: the target is a loopback daemon, so the client must not honour an
+    // exported HTTP_PROXY.
+    let client = match crate::http_client::loopback_client_builder()
         .timeout(DAEMON_PROBE_TIMEOUT)
         .connect_timeout(DAEMON_PROBE_TIMEOUT)
         .build()

--- a/crates/trusty-common/src/mcp/memory_rpc.rs
+++ b/crates/trusty-common/src/mcp/memory_rpc.rs
@@ -134,7 +134,9 @@ pub async fn call_memory_tool(method: &str, params: Value) -> Result<Value> {
 /// Test: `call_memory_tool_at_rejects_rpc_error`,
 /// `call_memory_tool_at_unreachable_daemon` (ignored).
 pub async fn call_memory_tool_at(base_url: &str, method: &str, params: Value) -> Result<Value> {
-    let client = reqwest::Client::builder()
+    // #4392: trusty-memory answers on loopback, so the client must not honour an
+    // exported HTTP_PROXY.
+    let client = crate::http_client::loopback_client_builder()
         .timeout(Duration::from_secs(5))
         .build()
         .context("build reqwest client")?;

--- a/crates/trusty-common/src/monitor/memory_client/client.rs
+++ b/crates/trusty-common/src/monitor/memory_client/client.rs
@@ -39,7 +39,9 @@ impl MemoryClient {
     /// timeout.
     /// Test: `memory_client_stores_base_url`.
     pub fn new(base: impl Into<String>) -> Self {
-        let http = reqwest::Client::builder()
+        // #4392: the daemon answers on loopback, so the client must not honour
+        // an exported HTTP_PROXY.
+        let http = crate::http_client::loopback_client_builder()
             .timeout(REQUEST_TIMEOUT)
             .build()
             .unwrap_or_default();
@@ -327,7 +329,8 @@ impl MemoryClient {
         use futures_util::StreamExt;
 
         // SSE is long-lived — bound only the connect phase, not the read.
-        let sse = reqwest::Client::builder()
+        // #4392: loopback target, so proxies stay off here too.
+        let sse = crate::http_client::loopback_client_builder()
             .connect_timeout(Duration::from_secs(5))
             .build()?;
         let resp = sse

--- a/crates/trusty-common/src/monitor/search_client.rs
+++ b/crates/trusty-common/src/monitor/search_client.rs
@@ -163,7 +163,9 @@ impl SearchClient {
     /// timeout so a hung daemon cannot stall the refresh loop.
     /// Test: `search_client_stores_base_url`.
     pub fn new(base: impl Into<String>) -> Self {
-        let http = reqwest::Client::builder()
+        // #4392: the daemon answers on loopback, so the client must not honour
+        // an exported HTTP_PROXY.
+        let http = crate::http_client::loopback_client_builder()
             .timeout(REQUEST_TIMEOUT)
             .build()
             .unwrap_or_default();
@@ -467,7 +469,8 @@ impl SearchClient {
 
         // SSE streams must outlive the short probe timeout — a large reindex
         // runs for minutes. A dedicated client bounds only the connect phase.
-        let sse = reqwest::Client::builder()
+        // #4392: loopback target, so proxies stay off here too.
+        let sse = crate::http_client::loopback_client_builder()
             .connect_timeout(Duration::from_secs(5))
             .build()?;
         let resp = sse

--- a/crates/trusty-common/src/search_index.rs
+++ b/crates/trusty-common/src/search_index.rs
@@ -739,7 +739,9 @@ fn relative_index_path(root: &Path, abs: &Path) -> String {
 /// (which builds and drives one), and by the daemon-down fail-open path in
 /// `index_files_inner_skips_gracefully_when_daemon_down`.
 fn build_index_client() -> reqwest::Result<reqwest::blocking::Client> {
-    reqwest::blocking::Client::builder()
+    // #4392: trusty-search answers on loopback, so the client must not honour an
+    // exported HTTP_PROXY.
+    crate::http_client::blocking_loopback_client_builder()
         .timeout(std::time::Duration::from_secs(2))
         .connect_timeout(std::time::Duration::from_millis(750))
         .build()
@@ -1018,7 +1020,8 @@ fn best_effort_create_index(
     let result = std::thread::spawn(move || {
         // 1s overall / 750ms connect cap: this runs synchronously on a hot
         // path, so the worst-case stall must stay small.
-        let client = reqwest::blocking::Client::builder()
+        // #4392: loopback target, so proxies stay off.
+        let client = crate::http_client::blocking_loopback_client_builder()
             .timeout(std::time::Duration::from_secs(1))
             .connect_timeout(std::time::Duration::from_millis(750))
             .build()?;
@@ -1108,7 +1111,8 @@ fn best_effort_trigger_reindex(base: &str, index_id: &str) {
         // 2s overall / 750ms connect cap: this runs synchronously on a hot path
         // (after best_effort_create_index's own 1s budget), so the worst-case
         // added stall must stay small.
-        let client = reqwest::blocking::Client::builder()
+        // #4392: loopback target, so proxies stay off.
+        let client = crate::http_client::blocking_loopback_client_builder()
             .timeout(std::time::Duration::from_secs(2))
             .connect_timeout(std::time::Duration::from_millis(750))
             .build()?;

--- a/crates/trusty-common/src/search_readiness.rs
+++ b/crates/trusty-common/src/search_readiness.rs
@@ -180,7 +180,9 @@ pub fn probe_index_readiness(project_root: &Path) -> Option<IndexReadiness> {
     // Blocking reqwest inside a tokio runtime panics on runtime drop; run it on
     // a dedicated OS thread (joined here) exactly like search_index's helpers.
     let body: serde_json::Value = std::thread::spawn(move || {
-        let client = reqwest::blocking::Client::builder()
+        // #4392: trusty-search answers on loopback, so the client must not
+        // honour an exported HTTP_PROXY.
+        let client = crate::http_client::blocking_loopback_client_builder()
             .timeout(std::time::Duration::from_millis(1500))
             .connect_timeout(std::time::Duration::from_millis(750))
             .build()

--- a/crates/trusty-common/src/server/mod.rs
+++ b/crates/trusty-common/src/server/mod.rs
@@ -24,7 +24,6 @@
 use anyhow::{Context, Result};
 use axum::{Json, Router, response::IntoResponse};
 use serde_json::json;
-use std::time::Duration;
 use tower_http::{
     compression::{
         CompressionLayer,
@@ -222,18 +221,16 @@ where
 /// Why: every CLI command that talks to the daemon must fail fast when the
 /// daemon is not running. Without timeouts, reqwest waits for the OS TCP
 /// stack (minutes on some platforms), freezing the terminal.
-/// What: 2 s connect timeout, 5 s total request timeout. Returns
+/// What: delegates to [`crate::http_client::loopback_client`] — proxies off
+/// (#4392), 2 s connect timeout, 5 s total request timeout. Returns
 /// `anyhow::Result` so callers can `?`-propagate alongside other anyhow
 /// errors without conversion boilerplate.
 /// Test: `daemon_http_client_builds` — construction succeeds with the
 /// configured timeouts; the timeout values themselves are exercised in the
-/// dependent CLIs (manual: stop daemon, run `trusty-search status`).
+/// dependent CLIs (manual: stop daemon, run `trusty-search status`). The proxy
+/// immunity is proven in `http_client::tests`.
 pub fn daemon_http_client() -> Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .connect_timeout(Duration::from_secs(2))
-        .timeout(Duration::from_secs(5))
-        .build()
-        .context("build daemon http client")
+    crate::http_client::loopback_client().context("build daemon http client")
 }
 
 /// Standard health-check handler returning `{"status":"ok","version":"<v>"}`.

--- a/crates/trusty-installer/changelog.d/4392-no-proxy-loopback-clients.md
+++ b/crates/trusty-installer/changelog.d/4392-no-proxy-loopback-clients.md
@@ -1,0 +1,8 @@
+Fixed
+- `tctl ensure`, `tctl port`, the readiness wait and project setup no longer
+  fail against a healthy daemon when `HTTP_PROXY` is exported. `ensure`'s
+  shared `build_client` now routes through
+  `trusty_common::http_client::loopback_client_builder`, which applies
+  `.no_proxy()`. `probe_http`'s own client routes through the same entry point,
+  so the property this crate proved for `/health` in #4246 cannot drift from
+  the rest of the workspace's loopback callers (#4392).

--- a/crates/trusty-installer/src/commands/ensure/daemon.rs
+++ b/crates/trusty-installer/src/commands/ensure/daemon.rs
@@ -65,11 +65,17 @@ pub fn resolve_base_url(app: &str) -> Result<Option<String>> {
 /// Build the `reqwest::Client` used for ensure's daemon calls.
 ///
 /// Why: one audited place for the timeout config so every ensure request fails
-/// fast against a dead daemon instead of hanging on the OS TCP timeout.
-/// What: a client with [`REQUEST_TIMEOUT`] applied to the whole request.
-/// Test: `tests::build_client_succeeds`.
+/// fast against a dead daemon instead of hanging on the OS TCP timeout. Every
+/// target is a loopback daemon, so it also has to be proxy-free: reqwest routes
+/// `127.0.0.1` through an exported `HTTP_PROXY` and `tctl ensure --wait` then
+/// waits out its whole budget against a daemon that is up (#4392).
+/// What: the shared `trusty_common::http_client` loopback builder with
+/// [`REQUEST_TIMEOUT`] applied to the whole request.
+/// Test: `tests::build_client_succeeds`; the proxy immunity is proven in
+/// `trusty_common::http_client::tests` and in
+/// `probe_http_tests::probe_ignores_http_proxy_env`.
 pub fn build_client() -> Result<reqwest::Client> {
-    reqwest::Client::builder()
+    trusty_common::http_client::loopback_client_builder()
         .timeout(REQUEST_TIMEOUT)
         .build()
         .context("build ensure HTTP client")

--- a/crates/trusty-installer/src/commands/probe_http.rs
+++ b/crates/trusty-installer/src/commands/probe_http.rs
@@ -18,10 +18,13 @@
 //! actually exists. Three properties are load-bearing and each has a named
 //! regression test — remove any one of them and #4246 comes straight back:
 //!
-//! 1. **[`build_probe_client`] calls `.no_proxy()`.** reqwest 0.12 honours
+//! 1. **[`build_probe_client`] is proxy-free.** reqwest 0.12 honours
 //!    `HTTP_PROXY`/`http_proxy`/`ALL_PROXY` for `127.0.0.1` — hyper-util's proxy
 //!    matcher has no loopback exemption, so a developer with a proxy exported
-//!    reproduces the identical false `down` through the NEW transport.
+//!    reproduces the identical false `down` through the NEW transport. Since
+//!    #4392 the `.no_proxy()` call itself lives in
+//!    `trusty_common::http_client::loopback_client_builder`, which this module
+//!    now builds on.
 //! 2. **Dual resolution with an explicit precedence rule** — see [`reconcile`].
 //!    A daemon that port-walked off its documented default (trusty-memory walks
 //!    `7070..=7079`) makes the fixed-port leg refuse while it is perfectly
@@ -293,10 +296,13 @@ impl ProbeOutcome {
 /// entry the user is not required to have. Without this call a developer with a
 /// proxy exported gets every daemon reported `down` through the new transport,
 /// and (pre-gate) every healthy daemon kickstarted — the exact #4246 signature,
-/// reintroduced. There is no other `.no_proxy()` in this workspace, so this is
-/// also the first place the property is asserted at all. The client is built per
-/// probe rather than cached because reqwest reads the proxy environment at BUILD
-/// time; a cached client would make the behaviour depend on process start order.
+/// reintroduced. #4392 moved the `.no_proxy()` call to
+/// `trusty_common::http_client::loopback_client_builder` so every loopback
+/// caller in the workspace inherits it; this module keeps its own regression
+/// test because the property is load-bearing HERE regardless of where the call
+/// lives. The client is built per probe rather than cached because reqwest reads
+/// the proxy environment at BUILD time; a cached client would make the behaviour
+/// depend on process start order.
 /// What: a client with proxies disabled and both a connect and a whole-request
 /// bound.
 /// Test: `tests::probe_ignores_http_proxy_env` — sets `HTTP_PROXY` to a dead
@@ -315,7 +321,7 @@ pub fn build_probe_client() -> reqwest::Result<reqwest::Client> {
 /// shorter ones against a deliberately silent peer. The caller is expected to
 /// pass `connect` ≪ `request`, so that a silent peer's verdict is reached on the
 /// READ path rather than on the handshake.
-/// What: same client as [`build_probe_client`] — `.no_proxy()` included, since
+/// What: same client as [`build_probe_client`] — proxies stay disabled, since
 /// the proxy test needs both bounds AND the flag — with `connect`/`request`
 /// substituted.
 /// Test: `tests::probe_distinguishes_failure_causes`.
@@ -323,8 +329,9 @@ pub fn build_probe_client_with(
     connect: Duration,
     request: Duration,
 ) -> reqwest::Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .no_proxy()
+    // #4392: `.no_proxy()` now lives at the shared entry point, so this module's
+    // property and every other loopback caller's cannot drift apart.
+    trusty_common::http_client::loopback_client_builder()
         .connect_timeout(connect)
         .timeout(request)
         .build()

--- a/crates/trusty-installer/src/commands/probe_http_tests.rs
+++ b/crates/trusty-installer/src/commands/probe_http_tests.rs
@@ -390,7 +390,7 @@ async fn probe_distinguishes_failure_causes() {
     // hyper-util reports a connect timeout as `io::ErrorKind::TimedOut`, so both
     // land on `Timeout`. A loopback connect completes in microseconds, so 250ms
     // is ~1000x headroom while 2s leaves the read path an 8x margin over it.
-    // `build_probe_client_with` keeps `.no_proxy()`.
+    // `build_probe_client_with` keeps proxies disabled.
     let client = build_probe_client_with(Duration::from_millis(250), Duration::from_secs(2))
         .expect("probe client builds");
 
@@ -441,8 +441,11 @@ async fn probe_distinguishes_failure_causes() {
 
 // ── Proxy immunity ──────────────────────────────────────────────────────────
 
-/// Why: `.no_proxy()` is the single most load-bearing line in this module and
-/// there is no other `.no_proxy()` anywhere in the workspace. reqwest 0.12
+/// Why: proxy immunity is the single most load-bearing property of this module.
+/// Since #4392 the `.no_proxy()` call lives in
+/// `trusty_common::http_client::loopback_client_builder`, so this test now also
+/// guards against a caller here being rewritten back onto a bare
+/// `reqwest::Client::builder()`. reqwest 0.12
 /// honours `HTTP_PROXY`/`http_proxy`/`ALL_PROXY` for `127.0.0.1` — hyper-util's
 /// proxy matcher has no runtime loopback exemption — so a developer with a proxy
 /// exported reproduces the identical #4246 false `down` through the NEW

--- a/crates/trusty-search/changelog.d/4392-no-proxy-loopback-clients.md
+++ b/crates/trusty-search/changelog.d/4392-no-proxy-loopback-clients.md
@@ -1,0 +1,4 @@
+Fixed
+- `service::SearchClient` no longer routes its loopback daemon calls through an
+  exported `HTTP_PROXY`. It builds through
+  `trusty_common::http_client::loopback_client_builder` (#4392).

--- a/crates/trusty-search/src/service/client.rs
+++ b/crates/trusty-search/src/service/client.rs
@@ -8,10 +8,22 @@ pub struct SearchClient {
 }
 
 impl SearchClient {
+    /// Build a client for the trusty-search daemon at `base_url`.
+    ///
+    /// Why: the daemon answers on loopback, and reqwest routes `127.0.0.1`
+    /// through an exported `HTTP_PROXY` — so without the shared proxy-free
+    /// builder every call here fails on a machine with a proxy configured
+    /// (#4392).
+    /// What: `trusty_common::http_client::loopback_client_builder`, built. The
+    /// `expect` mirrors `reqwest::Client::new`'s own contract — it panics on a
+    /// build failure too, which only a broken TLS backend can cause.
+    /// Test: proxy immunity is proven in `trusty_common::http_client::tests`.
     pub fn new(base_url: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into(),
-            client: reqwest::Client::new(),
+            client: trusty_common::http_client::loopback_client_builder()
+                .build()
+                .expect("reqwest client construction is infallible on supported platforms"),
         }
     }
 


### PR DESCRIPTION
Closes #4392.

## Mechanism

reqwest 0.12 routes `127.0.0.1` through `HTTP_PROXY` / `http_proxy` / `ALL_PROXY` when one is exported. hyper-util's proxy matcher has no loopback exemption, and the only bypass is an explicit `NO_PROXY` entry the operator is not required to have. So on a machine with a corporate proxy configured, every tm↔daemon call went to the proxy and failed, and the caller reported a healthy daemon as down.

The workspace held ~133 bare `reqwest::Client::builder()` sites and exactly one `.no_proxy()` call — trusty-installer's #4246 health probe. Adding the call per-site guarantees the next site forgets it, so it now lives at one entry point.

## The entry point

New unconditional module `crates/trusty-common/src/http_client.rs`:

- `loopback_client_builder()` — the primitive: `.no_proxy()`, no timeout policy. Callers keep their own bounds, which is what lets every existing site adopt it without changing its timing contract (an SSE reader must carry no whole-request bound).
- `loopback_client()` — that builder plus 2s connect / 5s request.
- `blocking_loopback_client_builder()` — the `reqwest::blocking` counterpart, behind a new `blocking-http` feature. `search-index` implies it, so no consumer manifest changes.

Scope follows the issue: loopback callers only. `update` (crates.io), `chat`, `inference`, `openrouter_legacy`, and the GitHub/JIRA/Slack integrations deliberately keep honouring the operator's proxy and are not routed through here.

## Files changed per crate

**trusty-common** (the entry point, plus its own loopback callers)
- `src/http_client.rs` — new
- `src/lib.rs`, `Cargo.toml` — module declaration, `blocking-http` feature
- `src/server/mod.rs` — `daemon_http_client` now delegates to `loopback_client`
- `src/health_probe.rs`, `src/daemon_guard.rs`, `src/mcp/daemon_bridge.rs`, `src/mcp/memory_rpc.rs`
- `src/monitor/search_client.rs` (request + SSE), `src/monitor/memory_client/client.rs` (request + SSE)
- `src/search_index.rs` (×3), `src/search_readiness.rs` — blocking builder
- `src/embedder_client/remote.rs`

**trusty-installer**
- `src/commands/ensure/daemon.rs` — `build_client` is the shared constructor for all three paths the issue names (`ensure/daemon.rs`, `ensure/readiness.rs`, `ensure/project_setup.rs`), so one edit covers them
- `src/commands/probe_http.rs` + `probe_http_tests.rs` — routed through the shared builder; its own regression test stays, and the doc claims that said "there is no other `.no_proxy()` in this workspace" are corrected

**trusty-search**
- `src/service/client.rs` — `SearchClient::new`

**trusty-analyze**
- `src/main.rs`, `src/commands/daemon.rs`, `src/commands/setup.rs`

Changelog fragments in all four.

## Test ladder: rung 4

The new test is the honest arm: it exports `HTTP_PROXY` pointing at a released ephemeral port, then asserts **both** halves against a real loopback stub server — a bare builder is diverted and fails, and `loopback_client()` still reaches the stub. `#[serial]` (serial_test, already a dev-dep and this crate's convention) because `HTTP_PROXY` is process-global. A blocking twin covers `reqwest::blocking` off-reactor.

**Falsification check** — with `.no_proxy()` removed from `loopback_client_builder`, the test fails:

```
test http_client::tests::loopback_client_ignores_exported_http_proxy ... FAILED
thread '...' panicked at crates/trusty-common/src/http_client.rs:185:9
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 359 filtered out
```

Restored, it passes. Commands and counts:

```
cargo fmt --check                                                    EXIT=0
cargo check  -p trusty-common --all-targets --features unconditional-only              EXIT=0
cargo check  -p trusty-common --all-targets --features search-index,mcp,axum-server,monitor-tui  EXIT=0
cargo clippy -p trusty-common --all-targets --features unconditional-only -- -D warnings          EXIT=0
cargo clippy -p trusty-common --all-targets --features search-index,mcp,axum-server,monitor-tui -- -D warnings  EXIT=0
cargo clippy -p trusty-installer -p trusty-search -p trusty-analyze --all-targets -- -D warnings  EXIT=0

cargo test -p trusty-common --features unconditional-only
  test result: ok. 355 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out

cargo test -p trusty-common --features search-index,mcp,axum-server,monitor-tui
  test http_client::tests::loopback_client_builds ... ok
  test http_client::tests::blocking_loopback_client_ignores_exported_http_proxy ... ok
  test http_client::tests::loopback_client_ignores_exported_http_proxy ... ok
  test result: ok. 620 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
  test result: ok. 7 passed; 0 failed; 0 ignored (integration)

cargo check --workspace                                              EXIT=0

cargo test -p trusty-mpm
  test result: ok. 5156 passed; 0 failed; 7 ignored
  test result: ok. 1755 passed; 0 failed; 1 ignored   (×2 further binaries)
cargo test -p trusty-installer
  test commands::probe_http::tests::probe_ignores_http_proxy_env ... ok
  test result: ok. 638 passed; 0 failed; 4 ignored
cargo test -p trusty-analyze
  test result: ok. 473 passed; 0 failed; 0 ignored  (+5 further binaries, all ok)
```

The two `--features` runs are what CLAUDE.md #4901 requires: `unconditional-only` covers `http_client` itself (it is unconditional), and the second run names the features gating every other module edited — `search-index` (`search_index`, `search_readiness`, `blocking-http`), `mcp` (`daemon_bridge`, `memory_rpc`), `axum-server` (`server::daemon_http_client`), `monitor-tui` (the two monitor clients). `embedder_client` compiles under `cargo check --workspace` via consumer feature unification.

Repo gates: `check_line_cap.sh` EXIT=0, `check_test_pointers.sh` EXIT=0, `check_sld.sh` EXIT=0, `check_changelog_fragment.sh` EXIT=0 (`scanned 24 changed path(s); attributed 18 crate-source path(s); all 4 crate(s) with source changes are recorded`).

## Remaining unconsolidated sites

161 bare `Client::builder()` / `Client::new()` sites remain across 112 production files (test files excluded). Most are correctly out of scope — public-internet callers in trusty-git-analytics (JIRA/Linear/Confluence/Datadog/Shortcut/AzDO/Bitbucket/GitHub), trusty-gworkspace, trusty-channels, trusty-review's LLM and context integrations, trusty-mpm's Slack/Telegram/model providers, and trusty-common's own `chat` / `inference` / `update`.

The loopback callers that still need routing, as follow-up:

- **trusty-mpm** — `core/discovery.rs` (12), `client/http_client/{config,mod}.rs` (4), `daemon/doctor.rs` (3), `daemon/doctor_search_pin.rs`, `services/discoverer/mod.rs`, `session_manager/{index_delete_guard,search_gc}.rs`, `tui/health/probes.rs`, `tui/coordinator/banner.rs`, and several `bin/tm/commands/*`
- **trusty-agents** — `memory/trusty_client/`, `search/service{,_client}`, `stores/{index_feed,status}`, `system_status/`, `context/indexer.rs`
- **trusty-code** — `tui_client/rpc.rs`, `session/connector.rs`, `fs_browse/mpm_registry.rs`
- **trusty-memory** — six `commands/*` sites
- **trusty-review** — `integrations/{search_client,analyze_client,subprocess_analyze_client}`, `report/analyze_adapter.rs`
- **trusty-console** — `proxy/routes.rs`, `server/mod.rs`
- **trusty-search** — `commands/{doctor_pipeline,index_relocate,reindex_engine/driver}`, `mcp/tools/mod.rs`
- **trusty-analyze** — `commands/run.rs`
- **trusty-common** — `rpc/transport/http.rs` builds a `Client::new()` for a caller-supplied URL that is not necessarily loopback; it needs a decision, not a mechanical edit

Also left alone deliberately: the issue's **adjacent finding** that four probes carry no timeout at all. `trusty-search/src/service/client.rs` still has none — adding one would change behaviour beyond this fix, so it stays a separate outcome. The three trusty-analyze sites already bound each request individually.

Not merged, auto-merge not enabled.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
