### PR TITLE
feat(tga,trusty-review): Authorship & Key-Person Risk report section

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/5453-authorship-derivation.md
+++ b/crates/trusty-git-analytics/changelog.d/5453-authorship-derivation.md
@@ -3,11 +3,20 @@ Added
 - `tga audit` writes one authorship artifact per repository (#5453, #6004):
   ownership concentration, bus factor, single-author subsystems, and a
   trailing-12-month monthly trajectory, derived from `commits JOIN files`.
-  Bot commits and merge commits are excluded from every figure; squash-merge
-  attribution, `.mailmap`-free identity merging, and vendored-path exclusion
-  are NOT corrected for and are caveated verbatim in the artifact (derivation
-  lives in tga per #5468's ruling, never in trusty-review). The DD manifest's
-  `[[repositories]]` entries gain a new, additive `authorship` path field
-  mirroring the DOC-67 §8 `velocity` field precedent; a repository whose
+  Bot commits and merge commits are excluded from every figure. Authors are
+  grouped by the collection pass's own identity resolver
+  (`commits.author_id → authors.canonical_email`), so one person's aliases
+  collapse to one author; a commit the resolver never linked keeps its raw
+  email and is counted into the new `unresolved_authors` figure, which earns
+  its own caveat naming the count. Squash-merge attribution and vendored-path
+  exclusion are NOT corrected for and are caveated verbatim in the artifact
+  (derivation lives in tga per #5468's ruling, never in trusty-review). The DD
+  manifest's `[[repositories]]` entries gain a new, additive `authorship` path
+  field mirroring the DOC-67 §8 `velocity` field precedent; a repository whose
   artifact fails to write states that as a named gap on the manifest rather
   than aborting the run.
+- A repository name that matches no `commits.repository` value now states a
+  named gap instead of rendering "0 authors, bus factor 0" (#5453). The
+  aggregation cannot tell an unmatched name from an empty repository — both
+  count zero rows — so `tga audit` probes for the name first and, when nothing
+  matched, names the repository names the database actually holds.

--- a/crates/trusty-git-analytics/changelog.d/5453-authorship-derivation.md
+++ b/crates/trusty-git-analytics/changelog.d/5453-authorship-derivation.md
@@ -1,0 +1,13 @@
+Added
+
+- `tga audit` writes one authorship artifact per repository (#5453, #6004):
+  ownership concentration, bus factor, single-author subsystems, and a
+  trailing-12-month monthly trajectory, derived from `commits JOIN files`.
+  Bot commits and merge commits are excluded from every figure; squash-merge
+  attribution, `.mailmap`-free identity merging, and vendored-path exclusion
+  are NOT corrected for and are caveated verbatim in the artifact (derivation
+  lives in tga per #5468's ruling, never in trusty-review). The DD manifest's
+  `[[repositories]]` entries gain a new, additive `authorship` path field
+  mirroring the DOC-67 §8 `velocity` field precedent; a repository whose
+  artifact fails to write states that as a named gap on the manifest rather
+  than aborting the run.

--- a/crates/trusty-git-analytics/changelog.d/5453-repo-name-unification-fixed.md
+++ b/crates/trusty-git-analytics/changelog.d/5453-repo-name-unification-fixed.md
@@ -1,0 +1,7 @@
+Fixed
+
+- `GitCollector` and the DD manifest derive a repository's name through one
+  function (#5453). The collector had its own copy, which disagreed with the
+  manifest's whenever a configured name was blank or whitespace — and a name
+  the two sides spell differently joins zero rows rather than erroring, so the
+  authorship section rendered confident zeroes instead of an error.

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -1405,6 +1405,7 @@ fn repo_entry(name: &str, path: &std::path::Path) -> DdRepositoryEntry {
     DdRepositoryEntry {
         name: name.to_string(),
         path: path.to_path_buf(),
+        authorship: None,
     }
 }
 

--- a/crates/trusty-git-analytics/src/collect/git/extractor.rs
+++ b/crates/trusty-git-analytics/src/collect/git/extractor.rs
@@ -96,15 +96,11 @@ impl GitCollector {
         // Verify it's actually a repository up-front.
         let _ = Repository::open(&path)?;
 
-        let name = config
-            .name
-            .clone()
-            .or_else(|| {
-                path.file_name()
-                    .and_then(|s| s.to_str())
-                    .map(|s| s.to_string())
-            })
-            .unwrap_or_else(|| path.display().to_string());
+        // #5453: the name written into `commits.repository` and the name the DD
+        // manifest reads it back by must come from ONE function — a second copy
+        // here disagreed whenever a configured name was blank, and a mismatched
+        // name joins zero rows rather than erroring.
+        let name = crate::report::repo_name(config.name.as_deref(), &path);
 
         let since = parse_iso_date(config.since_date.as_deref())?;
         let until = parse_iso_date(config.until_date.as_deref())?;

--- a/crates/trusty-git-analytics/src/commands/audit.rs
+++ b/crates/trusty-git-analytics/src/commands/audit.rs
@@ -29,10 +29,12 @@ use tga::core::db::Database;
 // #5823: the relay that carries the sweep's stage events to a parent process.
 use tga::core::progress::{ProgressBus, ProgressEvent, Stage, StageRelay};
 use tga::report::dd_manifest::{
-    build_dd_manifest, configured_secrets, dd_repository_entries, DdManifestOptions,
+    build_dd_manifest, configured_secrets, dd_repository_entries, repo_name, DdManifestOptions,
 };
 // #5405: the board-correlation figures the DD report renders.
 use tga::report::build_ticketing_summary;
+// #5453/#6004: per-repository ownership/bus-factor/trajectory figures.
+use tga::report::build_authorship_summary;
 use trusty_common::credentials::scrub_secrets;
 
 /// Arguments for `tga audit`.
@@ -241,7 +243,7 @@ pub async fn run(config: Config, db: &mut Database, args: AuditArgs) -> anyhow::
     };
 
     gaps.push(DATA_HANDLING_NOTE.to_string());
-    let manifest = build_dd_manifest(
+    let mut manifest = build_dd_manifest(
         &config,
         &DdManifestOptions {
             title: args.resolved_title(),
@@ -252,6 +254,33 @@ pub async fn run(config: Config, db: &mut Database, args: AuditArgs) -> anyhow::
             ticketing,
         },
     )?;
+
+    // #5453/#6004: one authorship artifact per repository, written beside the
+    // manifest. A per-repository failure is a named gap on the MANIFEST
+    // itself (DOC-67 §9's "named gap, never a silent one" rule) rather than
+    // an aborted run — the report's Authorship section degrades to that gap
+    // for exactly the repositories it could not compute.
+    let mut authorship_gaps: Vec<String> = Vec::new();
+    for (i, (entry, repo_cfg)) in manifest
+        .repositories
+        .iter_mut()
+        .zip(&config.repositories)
+        .enumerate()
+    {
+        let repository = repo_name(repo_cfg.name.as_deref(), &repo_cfg.path);
+        match authorship_artifact(db, &output, &repository, i) {
+            Ok(path) => entry.authorship = Some(path),
+            Err(e) => authorship_gaps.push(scrub_secrets(
+                &format!(
+                    "Authorship ({}): could not write the authorship artifact ({e:#}). The \
+                     report states no authorship/key-person signal for this application.",
+                    entry.name
+                ),
+                &configured_secrets(&config),
+            )),
+        }
+    }
+    manifest.report.gaps.extend(authorship_gaps);
 
     let manifest_path = output.join(MANIFEST_FILE);
     std::fs::write(&manifest_path, manifest.to_toml()?)?;
@@ -344,6 +373,34 @@ fn ticketing_artifact(
     let summary = build_ticketing_summary(db.connection())?;
     std::fs::write(output.join(TICKETING_FILE), summary.to_json()?)?;
     Ok(Some(PathBuf::from(TICKETING_FILE)))
+}
+
+/// Write one repository's authorship figures beside the manifest (#5453/#6004).
+///
+/// Why: mirrors [`ticketing_artifact`]'s shape, but per-repository — `commits.
+/// repository` distinguishes repositories within tga's single-database-per-
+/// engagement audit flow, so authorship is computed with a `WHERE repository =
+/// ?` filter rather than a second database.
+/// What: `index` names the file uniquely (`authorship-{index}.json`) since two
+/// repositories can share a display name. The path returned is
+/// manifest-relative, matching every other artifact this command writes.
+/// Test: `tests::{authorship_artifact_is_written_per_repository,
+/// a_failed_authorship_write_is_a_named_gap}`.
+///
+/// # Errors
+///
+/// Propagates the database read and the file write; the caller turns either
+/// into a named gap rather than a failed run.
+fn authorship_artifact(
+    db: &Database,
+    output: &Path,
+    repository: &str,
+    index: usize,
+) -> anyhow::Result<PathBuf> {
+    let summary = build_authorship_summary(db.connection(), repository)?;
+    let filename = format!("authorship-{index}.json");
+    std::fs::write(output.join(&filename), summary.to_json()?)?;
+    Ok(PathBuf::from(filename))
 }
 
 /// Invoke `trusty-review report` and report what it produced.

--- a/crates/trusty-git-analytics/src/commands/audit.rs
+++ b/crates/trusty-git-analytics/src/commands/audit.rs
@@ -33,8 +33,10 @@ use tga::report::dd_manifest::{
 };
 // #5405: the board-correlation figures the DD report renders.
 use tga::report::build_ticketing_summary;
-// #5453/#6004: per-repository ownership/bus-factor/trajectory figures.
-use tga::report::build_authorship_summary;
+// #5453/#6004: per-repository ownership/bus-factor/trajectory figures, plus the
+// name-match probe that keeps an unmatched repository name from rendering as a
+// derived zero.
+use tga::report::{build_authorship_summary, recorded_repository_names, repository_has_commits};
 use trusty_common::credentials::scrub_secrets;
 
 /// Arguments for `tga audit`.
@@ -269,7 +271,13 @@ pub async fn run(config: Config, db: &mut Database, args: AuditArgs) -> anyhow::
     {
         let repository = repo_name(repo_cfg.name.as_deref(), &repo_cfg.path);
         match authorship_artifact(db, &output, &repository, i) {
-            Ok(path) => entry.authorship = Some(path),
+            Ok(AuthorshipArtifact::Written(path)) => entry.authorship = Some(path),
+            Ok(AuthorshipArtifact::NameMatchedNothing(recorded)) => {
+                authorship_gaps.push(scrub_secrets(
+                    &authorship_no_match_gap(&entry.name, &repository, &recorded),
+                    &configured_secrets(&config),
+                ));
+            }
             Err(e) => authorship_gaps.push(scrub_secrets(
                 &format!(
                     "Authorship ({}): could not write the authorship artifact ({e:#}). The \
@@ -384,8 +392,15 @@ fn ticketing_artifact(
 /// What: `index` names the file uniquely (`authorship-{index}.json`) since two
 /// repositories can share a display name. The path returned is
 /// manifest-relative, matching every other artifact this command writes.
+///
+/// A name matching NO commit row returns [`AuthorshipArtifact::NameMatchedNothing`]
+/// rather than an artifact (#5453 review): the aggregation cannot tell that case
+/// from a genuinely empty repository, and both would render as a confident
+/// "0 authors, bus factor 0" — so the probe runs first and the caller states a
+/// gap instead.
 /// Test: `tests::{authorship_artifact_is_written_per_repository,
-/// a_failed_authorship_write_is_a_named_gap}`.
+/// a_failed_authorship_write_is_a_named_gap,
+/// a_repository_name_matching_no_commits_is_a_named_gap_not_zero_authors}`.
 ///
 /// # Errors
 ///
@@ -396,11 +411,56 @@ fn authorship_artifact(
     output: &Path,
     repository: &str,
     index: usize,
-) -> anyhow::Result<PathBuf> {
+) -> anyhow::Result<AuthorshipArtifact> {
+    if !repository_has_commits(db.connection(), repository)? {
+        return Ok(AuthorshipArtifact::NameMatchedNothing(
+            recorded_repository_names(db.connection())?,
+        ));
+    }
     let summary = build_authorship_summary(db.connection(), repository)?;
     let filename = format!("authorship-{index}.json");
     std::fs::write(output.join(&filename), summary.to_json()?)?;
-    Ok(PathBuf::from(filename))
+    Ok(AuthorshipArtifact::Written(PathBuf::from(filename)))
+}
+
+/// The gap line for a repository whose name matched no collected commit.
+///
+/// Why: the two causes read identically from the aggregation but need different
+/// action from the operator — an empty database means collection produced
+/// nothing (its own stage gap already says so), while a populated one under
+/// other names means the config name and `commits.repository` drifted, and the
+/// remedy is naming the recorded value. So the line states which case it is.
+/// Test: `tests::a_repository_name_matching_no_commits_is_a_named_gap_not_zero_authors`.
+fn authorship_no_match_gap(display_name: &str, repository: &str, recorded: &[String]) -> String {
+    if recorded.is_empty() {
+        format!(
+            "Authorship ({display_name}): the sweep recorded no commits at all, so there is no \
+             authorship/key-person signal for this application."
+        )
+    } else {
+        format!(
+            "Authorship ({display_name}): no collected commit is recorded under the repository \
+             name `{repository}` (the database holds commits under: {}). The report states no \
+             authorship/key-person signal for this application rather than deriving zeroes from \
+             an unmatched name.",
+            recorded.join(", ")
+        )
+    }
+}
+
+/// What [`authorship_artifact`] produced for one repository.
+///
+/// Why: the two non-error outcomes are not interchangeable. Figures written
+/// from real rows go on the manifest; a name that matched nothing must never
+/// become an artifact of zeroes, because a reader cannot tell derived-zero from
+/// no-data once it is rendered.
+#[derive(Debug)]
+enum AuthorshipArtifact {
+    /// Figures were written; the manifest-relative path to them.
+    Written(PathBuf),
+    /// No `commits.repository` value equals this repository's name. Carries
+    /// every name that IS recorded, so the gap line can point at the drift.
+    NameMatchedNothing(Vec<String>),
 }
 
 /// Invoke `trusty-review report` and report what it produced.
@@ -733,6 +793,125 @@ mod tests {
         assert!(
             written.contains("\"commits\"") && written.contains("\"work_items\""),
             "the artifact must carry the board counts: {written}"
+        );
+    }
+
+    /// Seed one non-merge commit under `repository`, with one file touch.
+    fn seed_commit(db: &Database, sha: &str, repository: &str) {
+        db.connection()
+            .execute(
+                "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                 repository, is_merge) \
+                 VALUES (?1, 'Alice', 'alice@x.com', '2026-01-15T00:00:00Z', 'msg', ?2, 0)",
+                rusqlite::params![sha, repository],
+            )
+            .expect("insert commit");
+        let commit_id = db.connection().last_insert_rowid();
+        db.connection()
+            .execute(
+                "INSERT INTO files (commit_id, path, change_type) VALUES (?1, 'src/lib.rs', 'modified')",
+                rusqlite::params![commit_id],
+            )
+            .expect("insert file");
+    }
+
+    /// #5453/#6004: the write-success half of the fail-open contract
+    /// `authorship_artifact`'s doc comment states — figures for a repository
+    /// that has commits become a file named by INDEX (two repositories may
+    /// share a display name), and the returned path is MANIFEST-RELATIVE
+    /// because trusty-review resolves it against the manifest's directory.
+    #[test]
+    fn authorship_artifact_is_written_per_repository() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = Database::open(&dir.path().join("tga.db")).expect("open db");
+        seed_commit(&db, "a1", "acme-web");
+        seed_commit(&db, "b1", "acme-api");
+
+        let first = super::authorship_artifact(&db, dir.path(), "acme-web", 0).expect("write");
+        let second = super::authorship_artifact(&db, dir.path(), "acme-api", 1).expect("write");
+
+        let (super::AuthorshipArtifact::Written(first), super::AuthorshipArtifact::Written(second)) =
+            (first, second)
+        else {
+            panic!("both repositories have commits, so both must produce figures");
+        };
+        assert_eq!(first, std::path::PathBuf::from("authorship-0.json"));
+        assert_eq!(second, std::path::PathBuf::from("authorship-1.json"));
+
+        let written = std::fs::read_to_string(dir.path().join("authorship-0.json"))
+            .expect("artifact written");
+        assert!(
+            written.contains("\"repository\": \"acme-web\"") && written.contains("\"bus_factor\""),
+            "the artifact must carry THIS repository's figures: {written}"
+        );
+        assert!(
+            !written.contains("acme-api"),
+            "the per-repository filter must not leak the sibling's commits: {written}"
+        );
+    }
+
+    /// #5453/#6004: the error half — a write that cannot land is surfaced as an
+    /// `Err` for the caller to turn into a named gap, never swallowed into a
+    /// silent success that leaves the manifest pointing at a file which does not
+    /// exist. Constructed by aiming the write at a path that is not a directory.
+    #[test]
+    fn a_failed_authorship_write_is_a_named_gap() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = Database::open(&dir.path().join("tga.db")).expect("open db");
+        seed_commit(&db, "a1", "acme-web");
+
+        // A regular file where the output directory should be: every write
+        // beneath it fails at the OS layer.
+        let blocked = dir.path().join("not-a-directory");
+        std::fs::write(&blocked, "").expect("create blocking file");
+
+        let err = super::authorship_artifact(&db, &blocked, "acme-web", 0)
+            .expect_err("an unwritable output must surface, not be swallowed");
+        let rendered = format!("{err:#}");
+        assert!(
+            !rendered.is_empty(),
+            "the error must carry a reason for the gap line to quote"
+        );
+        assert!(
+            !blocked.join("authorship-0.json").exists(),
+            "nothing may be left behind by a failed write"
+        );
+    }
+
+    /// #5453 review: a repository name that matches no `commits.repository`
+    /// value is a NAMED GAP, not an artifact of zeroes. Without the probe the
+    /// aggregation returns "0 authors, bus factor 0" for a name that never
+    /// joined a single row — indistinguishable, to a reader, from a measured
+    /// finding that the codebase has no authors.
+    #[test]
+    fn a_repository_name_matching_no_commits_is_a_named_gap_not_zero_authors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = Database::open(&dir.path().join("tga.db")).expect("open db");
+        // Collection recorded `acme_web`; the manifest asks for `acme-web`.
+        seed_commit(&db, "a1", "acme_web");
+
+        let outcome = super::authorship_artifact(&db, dir.path(), "acme-web", 0).expect("no error");
+        let super::AuthorshipArtifact::NameMatchedNothing(recorded) = outcome else {
+            panic!("an unmatched name must never produce an artifact of zeroes");
+        };
+        assert_eq!(recorded, vec!["acme_web".to_string()]);
+        assert!(
+            !dir.path().join("authorship-0.json").exists(),
+            "no artifact may be written for a name that matched nothing"
+        );
+
+        let gap = super::authorship_no_match_gap("Acme Web", "acme-web", &recorded);
+        assert!(
+            gap.contains("acme-web") && gap.contains("acme_web"),
+            "the gap must name BOTH the name asked for and the name recorded: {gap}"
+        );
+
+        // The empty-database case reads differently — collection produced
+        // nothing at all, which is not a naming drift.
+        let empty = super::authorship_no_match_gap("Acme Web", "acme-web", &[]);
+        assert!(
+            empty.contains("no commits at all"),
+            "an empty sweep must not be reported as a name mismatch: {empty}"
         );
     }
 }

--- a/crates/trusty-git-analytics/src/report/authorship.rs
+++ b/crates/trusty-git-analytics/src/report/authorship.rs
@@ -1,0 +1,280 @@
+//! The tga → trusty-review authorship artifact (#5453, #6004).
+//!
+//! Why: owner ruling 2026-08-18 — the DD report needs a dedicated Authorship &
+//! Key-Person Risk section carrying ownership concentration, bus factor,
+//! single-author subsystems, and a high-level trailing-12-month trajectory.
+//! #5468 (CLOSED) ruled all contributor-profiling derivation lives in tga,
+//! never trusty-review — this module is that derivation. It mirrors
+//! [`super::ticketing`]'s read-side shape (a pure query-and-serialize builder;
+//! the caller writes the file), but is PER-REPOSITORY rather than
+//! engagement-wide, because `commits.repository` distinguishes repositories
+//! within tga's one-database-per-engagement audit flow and ownership is a
+//! per-codebase question — mirrors the precedent
+//! `RepositoryEntry.velocity: Option<PathBuf>` (DOC-67 §8 velocity spec) sets
+//! for a per-repo artifact field, rather than ticketing's engagement-wide one.
+//!
+//! ## The five data traps (issue #5453) — what this module handles vs. caveats
+//!
+//! - **Bot commits** — HANDLED. [`is_bot`] excludes machine-authored commits
+//!   (`dependabot`, `renovate[bot]`, `github-actions[bot]`, and similar) by a
+//!   name/email pattern match before any aggregation runs.
+//! - **Merge commits** — HANDLED. The query filters `is_merge = 0`; an
+//!   inflated merger count never reaches the aggregation.
+//! - **Squash-merge attribution, no `.mailmap` identity merging, vendored-path
+//!   exclusion** — NOT handled (each needs, respectively: nothing extra for
+//!   GitHub squash since `commits.author_name`/`author_email` already read
+//!   the PR author verbatim, per issue #5453's own finding — the residual
+//!   risk is a LOCAL `git merge --squash` by a human, which this derivation
+//!   cannot distinguish from a real commit; a per-engagement `.mailmap`/alias
+//!   table, which does not exist in this schema; and a vendored-path filter,
+//!   which needs a configurable ignore-list this module does not have). Named
+//!   explicitly in [`CAVEATS`], which the report section
+//!   renders verbatim rather than silently omitting the limitation.
+//!
+//! What: [`AuthorshipSummary`], [`build_authorship_summary`] which reads it
+//! from an open database for one repository, and
+//! [`AuthorshipSummary::to_json`].
+//! Test: `super::authorship_tests`.
+
+use std::collections::BTreeMap;
+
+use rusqlite::{params, Connection};
+use serde::Serialize;
+
+use crate::core::errors::Result;
+
+/// Schema tag written into the artifact — pairs with trusty-review's
+/// `report::authorship::SUPPORTED_SCHEMA_MAJOR`.
+pub const AUTHORSHIP_SCHEMA_VERSION: &str = "v0";
+
+/// One repository's ownership/bus-factor/trajectory figures.
+///
+/// Why: this is the whole tga→trusty-review authorship seam. Every figure is
+/// derived from `commits JOIN files`, never invented or estimated beyond the
+/// stated approximations (see field docs).
+/// What: `bus_factor` — the smallest number of top-touching authors whose
+/// combined share reaches 50% of all counted file-touches; `top_author_share`
+/// — the single largest author's share of all touches, as a percentage;
+/// `single_author_subsystems` — top-level path segments touched by exactly
+/// one non-bot author; `distinct_authors` and `monthly_trajectory` feed the
+/// report's Key Facts block and the trailing-12-month narrative.
+/// Test: `super::authorship_tests::builds_from_seeded_commits`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct AuthorshipSummary {
+    /// Artifact schema tag; always [`AUTHORSHIP_SCHEMA_VERSION`].
+    pub schema_version: String,
+    /// The repository name these figures describe (matches `commits.repository`).
+    pub repository: String,
+    /// Distinct non-bot authors with at least one non-merge commit.
+    pub distinct_authors: u64,
+    /// Smallest number of top-touching authors whose combined file-touch
+    /// share reaches 50%. `0` when there is no data.
+    pub bus_factor: u64,
+    /// The single largest author's share of all file-touches, in `0.0..=100.0`.
+    pub top_author_share_pct: f64,
+    /// Top-level path segments (e.g. `src`, `docs`) touched by exactly one
+    /// non-bot author, sorted.
+    pub single_author_subsystems: Vec<String>,
+    /// One entry per active month in the trailing 12 months, oldest first.
+    pub monthly_trajectory: Vec<MonthlyActivity>,
+    /// Data-trap limitations this run did NOT correct for (issue #5453) —
+    /// rendered verbatim by the report section's caption.
+    pub caveats: Vec<String>,
+}
+
+/// One month's active-author/commit-volume figures.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct MonthlyActivity {
+    /// `YYYY-MM`.
+    pub month: String,
+    /// Distinct non-bot authors with a non-merge commit in this month.
+    pub active_authors: u64,
+    /// Non-merge, non-bot commits in this month.
+    pub commits: u64,
+}
+
+/// The standing caveats every artifact this module writes carries (#5453).
+const CAVEATS: &[&str] = &[
+    "Squash-merge attribution: a GitHub squash-merge preserves the PR author, but a local \
+     `git merge --squash` by a human does not — this run cannot distinguish the two.",
+    "No .mailmap / identity-alias merging: one person committing under multiple names or \
+     emails is counted as multiple authors, which UNDERSTATES concentration and bus factor.",
+    "No vendored-path exclusion: a checked-in vendor/dependency directory can make its \
+     committer look like the sole owner of thousands of paths.",
+];
+
+/// Name/email substrings identifying a machine-authored commit (issue #5453).
+///
+/// Why: a case-insensitive substring match is deliberately permissive — a
+/// missed bot inflates a human's apparent ownership, which is the more
+/// dangerous direction of error for a key-man risk figure.
+const BOT_MARKERS: &[&str] = &[
+    "[bot]",
+    "dependabot",
+    "renovate",
+    "github-actions",
+    "gitlab-ci",
+    "greenkeeper",
+];
+
+/// True when `name` or `email` identifies a machine author.
+fn is_bot(name: &str, email: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    let email = email.to_ascii_lowercase();
+    BOT_MARKERS
+        .iter()
+        .any(|m| name.contains(m) || email.contains(m))
+}
+
+/// The top-level path segment of a file path — this module's "subsystem".
+fn subsystem_of(path: &str) -> String {
+    path.split('/').next().unwrap_or(path).to_string()
+}
+
+/// The `YYYY-MM` key of an ISO-8601 timestamp (first 7 characters).
+fn month_of(timestamp: &str) -> Option<String> {
+    timestamp.get(0..7).map(str::to_string)
+}
+
+/// Build one repository's authorship summary from an open database.
+///
+/// Why: the single function that reads `commits JOIN files` for this artifact
+/// — every other item in this module is a pure helper it calls.
+/// What: reads every non-merge commit for `repository`, drops bot-authored
+/// rows (issue #5453), then aggregates: per-author file-touch counts (for
+/// bus factor / concentration), per-subsystem author sets (for single-author
+/// subsystems), and per-month distinct-author/commit counts limited to the
+/// most recent 12 active months (for the trajectory).
+/// Test: `super::authorship_tests::{builds_from_seeded_commits,
+/// bots_and_merges_are_excluded, single_author_subsystem_detected}`.
+///
+/// # Errors
+///
+/// Propagates [`crate::core::errors::TgaError::DbError`] from either query.
+pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<AuthorshipSummary> {
+    let mut stmt = conn.prepare(
+        "SELECT c.author_name, c.author_email, c.timestamp, f.path \
+         FROM commits c JOIN files f ON f.commit_id = c.id \
+         WHERE c.repository = ?1 AND c.is_merge = 0",
+    )?;
+    let rows = stmt.query_map(params![repository], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+        ))
+    })?;
+
+    let mut touches_by_author: BTreeMap<String, u64> = BTreeMap::new();
+    let mut authors_by_subsystem: BTreeMap<String, std::collections::BTreeSet<String>> =
+        BTreeMap::new();
+    let mut months: BTreeMap<String, std::collections::BTreeSet<String>> = BTreeMap::new();
+    let mut month_commits: BTreeMap<String, u64> = BTreeMap::new();
+
+    for row in rows {
+        let (name, email, timestamp, path) = row?;
+        if is_bot(&name, &email) {
+            continue;
+        }
+        let author_key = if email.is_empty() {
+            name.clone()
+        } else {
+            email.clone()
+        };
+        *touches_by_author.entry(author_key.clone()).or_insert(0) += 1;
+        authors_by_subsystem
+            .entry(subsystem_of(&path))
+            .or_default()
+            .insert(author_key.clone());
+        if let Some(month) = month_of(&timestamp) {
+            months.entry(month.clone()).or_default().insert(author_key);
+            *month_commits.entry(month).or_insert(0) += 1;
+        }
+    }
+
+    let total_touches: u64 = touches_by_author.values().sum();
+    let mut ranked: Vec<(&String, &u64)> = touches_by_author.iter().collect();
+    ranked.sort_by_key(|(_, n)| std::cmp::Reverse(**n));
+
+    let top_author_share_pct = match ranked.first() {
+        Some((_, n)) if total_touches > 0 => (**n as f64 / total_touches as f64) * 100.0,
+        _ => 0.0,
+    };
+    let bus_factor = bus_factor_of(&ranked, total_touches);
+
+    let mut single_author_subsystems: Vec<String> = authors_by_subsystem
+        .into_iter()
+        .filter(|(_, authors)| authors.len() == 1)
+        .map(|(subsystem, _)| subsystem)
+        .collect();
+    single_author_subsystems.sort();
+
+    // Trailing 12 active months, oldest first — matches the report's
+    // "trajectory by month" framing without depending on wall-clock "now",
+    // which would make two runs of the same database disagree.
+    let mut month_keys: Vec<String> = months.keys().cloned().collect();
+    month_keys.sort();
+    let recent: Vec<String> = month_keys.into_iter().rev().take(12).rev().collect();
+    let monthly_trajectory = recent
+        .into_iter()
+        .map(|month| MonthlyActivity {
+            active_authors: months.get(&month).map(|s| s.len() as u64).unwrap_or(0),
+            commits: month_commits.get(&month).copied().unwrap_or(0),
+            month,
+        })
+        .collect();
+
+    Ok(AuthorshipSummary {
+        schema_version: AUTHORSHIP_SCHEMA_VERSION.to_string(),
+        repository: repository.to_string(),
+        distinct_authors: touches_by_author.len() as u64,
+        bus_factor,
+        top_author_share_pct,
+        single_author_subsystems,
+        monthly_trajectory,
+        caveats: CAVEATS.iter().map(|s| s.to_string()).collect(),
+    })
+}
+
+/// The smallest number of top-ranked authors whose combined share reaches 50%.
+///
+/// Why: the classic "bus factor" heuristic — how many people, if all left,
+/// would take half the project's institutional knowledge with them.
+/// What: `0` with no data; otherwise walks `ranked` (already sorted
+/// descending) accumulating touches until the running total reaches half of
+/// `total`.
+fn bus_factor_of(ranked: &[(&String, &u64)], total: u64) -> u64 {
+    if total == 0 {
+        return 0;
+    }
+    let half = total as f64 / 2.0;
+    let mut running = 0u64;
+    for (i, (_, n)) in ranked.iter().enumerate() {
+        running += **n;
+        if running as f64 >= half {
+            return (i + 1) as u64;
+        }
+    }
+    ranked.len() as u64
+}
+
+impl AuthorshipSummary {
+    /// Serialize to the JSON text trusty-review's loader reads.
+    ///
+    /// Why: keeping serialization here means the artifact's shape is testable
+    /// without touching disk, exactly as [`super::ticketing`] does.
+    /// What: `serde_json::to_string_pretty` over the declared field order.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::core::errors::TgaError`] when serialization fails.
+    pub fn to_json(&self) -> Result<String> {
+        Ok(serde_json::to_string_pretty(self)?)
+    }
+}
+
+#[cfg(test)]
+#[path = "authorship_tests.rs"]
+mod authorship_tests;

--- a/crates/trusty-git-analytics/src/report/authorship.rs
+++ b/crates/trusty-git-analytics/src/report/authorship.rs
@@ -20,16 +20,24 @@
 //!   name/email pattern match before any aggregation runs.
 //! - **Merge commits** — HANDLED. The query filters `is_merge = 0`; an
 //!   inflated merger count never reaches the aggregation.
-//! - **Squash-merge attribution, no `.mailmap` identity merging, vendored-path
-//!   exclusion** — NOT handled (each needs, respectively: nothing extra for
-//!   GitHub squash since `commits.author_name`/`author_email` already read
-//!   the PR author verbatim, per issue #5453's own finding — the residual
-//!   risk is a LOCAL `git merge --squash` by a human, which this derivation
-//!   cannot distinguish from a real commit; a per-engagement `.mailmap`/alias
-//!   table, which does not exist in this schema; and a vendored-path filter,
-//!   which needs a configurable ignore-list this module does not have). Named
-//!   explicitly in [`CAVEATS`], which the report section
-//!   renders verbatim rather than silently omitting the limitation.
+//! - **Identity aliases** — HANDLED, partially. Authors are grouped by the
+//!   collection pass's own identity resolver
+//!   (`collect::identity::IdentityResolver`, which populates
+//!   `commits.author_id → authors.canonical_email`), so one person committing
+//!   under several names or emails collapses to one author. A commit the
+//!   resolver never linked (`author_id IS NULL`) falls back to its raw commit
+//!   email, so its aliases stay split — [`AuthorshipSummary::unresolved_authors`]
+//!   counts exactly those identities, which is the honesty gate issue #5453
+//!   asked for.
+//! - **Squash-merge attribution, vendored-path exclusion** — NOT handled (each
+//!   needs, respectively: nothing extra for GitHub squash since
+//!   `commits.author_name`/`author_email` already read the PR author verbatim,
+//!   per issue #5453's own finding — the residual risk is a LOCAL `git merge
+//!   --squash` by a human, which this derivation cannot distinguish from a
+//!   real commit; and a vendored-path filter, which needs a configurable
+//!   ignore-list this module does not have). Named explicitly in [`CAVEATS`],
+//!   which the report section renders verbatim rather than silently omitting
+//!   the limitation.
 //!
 //! What: [`AuthorshipSummary`], [`build_authorship_summary`] which reads it
 //! from an open database for one repository, and
@@ -78,6 +86,16 @@ pub struct AuthorshipSummary {
     pub single_author_subsystems: Vec<String>,
     /// One entry per active month in the trailing 12 months, oldest first.
     pub monthly_trajectory: Vec<MonthlyActivity>,
+    /// Distinct raw commit identities the identity resolver never linked to an
+    /// `authors` row (`commits.author_id IS NULL`) — issue #5453's honesty gate.
+    ///
+    /// Why: every such identity is grouped by its raw commit email instead of a
+    /// canonical one, so its aliases stay split and concentration/bus factor
+    /// read LOWER than reality. A nonzero count is the caveat a reader needs to
+    /// discount the figures by; zero means every counted commit went through
+    /// the resolver.
+    /// Test: `super::authorship_tests::unresolved_authors_are_counted_and_caveated`.
+    pub unresolved_authors: u64,
     /// Data-trap limitations this run did NOT correct for (issue #5453) —
     /// rendered verbatim by the report section's caption.
     pub caveats: Vec<String>,
@@ -98,11 +116,26 @@ pub struct MonthlyActivity {
 const CAVEATS: &[&str] = &[
     "Squash-merge attribution: a GitHub squash-merge preserves the PR author, but a local \
      `git merge --squash` by a human does not — this run cannot distinguish the two.",
-    "No .mailmap / identity-alias merging: one person committing under multiple names or \
-     emails is counted as multiple authors, which UNDERSTATES concentration and bus factor.",
+    "Identity aliases are merged only as far as the collection pass resolved them: authors \
+     are grouped by `authors.canonical_email` where the resolver linked the commit, and by the \
+     raw commit email where it did not.",
     "No vendored-path exclusion: a checked-in vendor/dependency directory can make its \
      committer look like the sole owner of thousands of paths.",
 ];
+
+/// The caveat naming an unresolved-identity count, for a run that has one.
+///
+/// Why: a standing caveat a reader sees on every report teaches them to skip
+/// it; this one appears only when the figure is nonzero, and carries the
+/// figure. Splitting an author across aliases lowers every concentration
+/// number, so the direction of the error is stated too.
+fn unresolved_caveat(count: u64) -> String {
+    format!(
+        "{count} commit identity/identities in this repository were never linked to a resolved \
+         author, so their aliases stay split — concentration and bus factor read LOWER than \
+         reality by that much."
+    )
+}
 
 /// Name/email substrings identifying a machine-authored commit (issue #5453).
 ///
@@ -146,24 +179,35 @@ fn month_of(timestamp: &str) -> Option<String> {
 /// bus factor / concentration), per-subsystem author sets (for single-author
 /// subsystems), and per-month distinct-author/commit counts limited to the
 /// most recent 12 active months (for the trajectory).
+///
+/// Authors are keyed on `authors.canonical_email` via a LEFT JOIN on
+/// `commits.author_id` — the identity resolver's own output (#5453 requires
+/// reusing it rather than re-grouping raw commit emails). A commit the resolver
+/// never linked keeps its raw email as the key and is counted into
+/// [`AuthorshipSummary::unresolved_authors`].
 /// Test: `super::authorship_tests::{builds_from_seeded_commits,
-/// bots_and_merges_are_excluded, single_author_subsystem_detected}`.
+/// bots_and_merges_are_excluded, single_author_subsystem_detected,
+/// aliases_collapse_through_the_identity_resolver,
+/// unresolved_authors_are_counted_and_caveated}`.
 ///
 /// # Errors
 ///
 /// Propagates [`crate::core::errors::TgaError::DbError`] from either query.
 pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<AuthorshipSummary> {
     let mut stmt = conn.prepare(
-        "SELECT c.author_name, c.author_email, c.timestamp, f.path \
-         FROM commits c JOIN files f ON f.commit_id = c.id \
+        "SELECT c.author_name, c.author_email, a.canonical_email, c.timestamp, f.path \
+         FROM commits c \
+         JOIN files f ON f.commit_id = c.id \
+         LEFT JOIN authors a ON a.id = c.author_id \
          WHERE c.repository = ?1 AND c.is_merge = 0",
     )?;
     let rows = stmt.query_map(params![repository], |row| {
         Ok((
             row.get::<_, String>(0)?,
             row.get::<_, String>(1)?,
-            row.get::<_, String>(2)?,
+            row.get::<_, Option<String>>(2)?,
             row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
         ))
     })?;
 
@@ -172,16 +216,26 @@ pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<A
         BTreeMap::new();
     let mut months: BTreeMap<String, std::collections::BTreeSet<String>> = BTreeMap::new();
     let mut month_commits: BTreeMap<String, u64> = BTreeMap::new();
+    let mut unresolved: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
 
     for row in rows {
-        let (name, email, timestamp, path) = row?;
+        let (name, email, canonical_email, timestamp, path) = row?;
         if is_bot(&name, &email) {
             continue;
         }
-        let author_key = if email.is_empty() {
+        let raw_key = if email.is_empty() {
             name.clone()
         } else {
             email.clone()
+        };
+        // The resolver's canonical email wins; an unlinked commit falls back to
+        // its raw identity and is counted as an honesty caveat (#5453).
+        let author_key = match canonical_email.filter(|e| !e.is_empty()) {
+            Some(canonical) => canonical,
+            None => {
+                unresolved.insert(raw_key.clone());
+                raw_key
+            }
         };
         *touches_by_author.entry(author_key.clone()).or_insert(0) += 1;
         authors_by_subsystem
@@ -226,6 +280,12 @@ pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<A
         })
         .collect();
 
+    let unresolved_authors = unresolved.len() as u64;
+    let mut caveats: Vec<String> = CAVEATS.iter().map(|s| s.to_string()).collect();
+    if unresolved_authors > 0 {
+        caveats.push(unresolved_caveat(unresolved_authors));
+    }
+
     Ok(AuthorshipSummary {
         schema_version: AUTHORSHIP_SCHEMA_VERSION.to_string(),
         repository: repository.to_string(),
@@ -234,8 +294,49 @@ pub fn build_authorship_summary(conn: &Connection, repository: &str) -> Result<A
         top_author_share_pct,
         single_author_subsystems,
         monthly_trajectory,
-        caveats: CAVEATS.iter().map(|s| s.to_string()).collect(),
+        unresolved_authors,
+        caveats,
     })
+}
+
+/// True when at least one commit row carries `repository` as its name.
+///
+/// Why (#5453 review): `build_authorship_summary` cannot tell "this repository
+/// genuinely has no commits" from "the name the manifest used never matched a
+/// `commits.repository` value" — both aggregate zero rows and both would render
+/// as a confident "0 authors, bus factor 0". The caller needs the difference to
+/// choose between an artifact and a named gap, so the probe is its own query.
+/// What: a bare `SELECT 1 … LIMIT 1` existence check, merges included, because
+/// the question is whether the NAME matched anything at all.
+/// Test: `super::authorship_tests::a_name_that_matches_nothing_is_detectable`.
+///
+/// # Errors
+///
+/// Propagates [`crate::core::errors::TgaError::DbError`].
+pub fn repository_has_commits(conn: &Connection, repository: &str) -> Result<bool> {
+    let mut stmt = conn.prepare("SELECT 1 FROM commits WHERE repository = ?1 LIMIT 1")?;
+    Ok(stmt.exists(params![repository])?)
+}
+
+/// Every distinct `commits.repository` value in the database, sorted.
+///
+/// Why: when a manifest name matched nothing, the gap line is only actionable
+/// if it names what IS present — "no commits under 'acme-web' (the database
+/// holds: acme_web)" points straight at the drift, where a bare "no commits"
+/// does not.
+/// Test: `super::authorship_tests::a_name_that_matches_nothing_is_detectable`.
+///
+/// # Errors
+///
+/// Propagates [`crate::core::errors::TgaError::DbError`].
+pub fn recorded_repository_names(conn: &Connection) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare("SELECT DISTINCT repository FROM commits ORDER BY repository")?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+    let mut names = Vec::new();
+    for row in rows {
+        names.push(row?);
+    }
+    Ok(names)
 }
 
 /// The smallest number of top-ranked authors whose combined share reaches 50%.

--- a/crates/trusty-git-analytics/src/report/authorship_tests.rs
+++ b/crates/trusty-git-analytics/src/report/authorship_tests.rs
@@ -1,0 +1,192 @@
+//! Tests for the authorship artifact (#5453, #6004).
+
+use rusqlite::params;
+
+use super::{build_authorship_summary, AUTHORSHIP_SCHEMA_VERSION};
+use crate::core::db::Database;
+
+/// Insert one commit (with its file touches) into the seeded database.
+#[allow(clippy::too_many_arguments)]
+fn insert_commit(
+    db: &Database,
+    sha: &str,
+    author_name: &str,
+    author_email: &str,
+    timestamp: &str,
+    repository: &str,
+    is_merge: bool,
+    paths: &[&str],
+) {
+    db.connection()
+        .execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                                  repository, is_merge) \
+             VALUES (?1, ?2, ?3, ?4, 'msg', ?5, ?6)",
+            params![
+                sha,
+                author_name,
+                author_email,
+                timestamp,
+                repository,
+                is_merge as i64
+            ],
+        )
+        .expect("insert commit");
+    let commit_id = db.connection().last_insert_rowid();
+    for path in paths {
+        db.connection()
+            .execute(
+                "INSERT INTO files (commit_id, path, change_type) VALUES (?1, ?2, 'modified')",
+                params![commit_id, path],
+            )
+            .expect("insert file");
+    }
+}
+
+/// A single-author repository has bus factor 1 and 100% concentration.
+#[test]
+fn builds_from_seeded_commits() {
+    let db = Database::open_in_memory().expect("open");
+    insert_commit(
+        &db,
+        "a1",
+        "Alice",
+        "alice@x.com",
+        "2026-01-15T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    insert_commit(
+        &db,
+        "a2",
+        "Alice",
+        "alice@x.com",
+        "2026-02-15T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+
+    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    assert_eq!(summary.schema_version, AUTHORSHIP_SCHEMA_VERSION);
+    assert_eq!(summary.repository, "repo");
+    assert_eq!(summary.distinct_authors, 1);
+    assert_eq!(summary.bus_factor, 1);
+    assert!((summary.top_author_share_pct - 100.0).abs() < f64::EPSILON);
+    assert_eq!(summary.single_author_subsystems, vec!["src".to_string()]);
+    assert_eq!(summary.monthly_trajectory.len(), 2);
+    assert!(!summary.caveats.is_empty());
+}
+
+/// (#5453) Bot commits and merge commits are excluded from every figure.
+#[test]
+fn bots_and_merges_are_excluded() {
+    let db = Database::open_in_memory().expect("open");
+    insert_commit(
+        &db,
+        "h1",
+        "Alice",
+        "alice@x.com",
+        "2026-01-15T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    insert_commit(
+        &db,
+        "b1",
+        "dependabot[bot]",
+        "dependabot[bot]@users.noreply.github.com",
+        "2026-01-16T00:00:00Z",
+        "repo",
+        false,
+        &["deps/lock.json"],
+    );
+    insert_commit(
+        &db,
+        "m1",
+        "Bob",
+        "bob@x.com",
+        "2026-01-17T00:00:00Z",
+        "repo",
+        true,
+        &["src/merged.rs"],
+    );
+
+    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    assert_eq!(summary.distinct_authors, 1, "bot and merge author excluded");
+    assert_eq!(summary.single_author_subsystems, vec!["src".to_string()]);
+}
+
+/// A subsystem touched by two distinct authors is never listed as
+/// single-author.
+#[test]
+fn shared_subsystem_is_not_single_author() {
+    let db = Database::open_in_memory().expect("open");
+    insert_commit(
+        &db,
+        "a1",
+        "Alice",
+        "alice@x.com",
+        "2026-01-15T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    insert_commit(
+        &db,
+        "b1",
+        "Bob",
+        "bob@x.com",
+        "2026-01-16T00:00:00Z",
+        "repo",
+        false,
+        &["src/other.rs"],
+    );
+
+    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    assert_eq!(summary.distinct_authors, 2);
+    assert!(summary.single_author_subsystems.is_empty());
+    assert_eq!(summary.bus_factor, 1); // 50%-of-touches threshold, 1 of 2 needed
+}
+
+/// A repository with no commits at all still produces a (zeroed) summary
+/// rather than an error — the caller decides how to render zero data.
+#[test]
+fn empty_repository_yields_zeroed_summary() {
+    let db = Database::open_in_memory().expect("open");
+    let summary = build_authorship_summary(db.connection(), "nonexistent").expect("summary");
+    assert_eq!(summary.distinct_authors, 0);
+    assert_eq!(summary.bus_factor, 0);
+    assert!(summary.monthly_trajectory.is_empty());
+}
+
+/// The monthly trajectory keeps at most the most recent 12 active months,
+/// even when the database spans more than a year of history.
+#[test]
+fn trajectory_caps_at_twelve_months() {
+    let db = Database::open_in_memory().expect("open");
+    // 14 distinct months: 2024-11 .. 2025-12.
+    let months = [
+        "2024-11", "2024-12", "2025-01", "2025-02", "2025-03", "2025-04", "2025-05", "2025-06",
+        "2025-07", "2025-08", "2025-09", "2025-10", "2025-11", "2025-12",
+    ];
+    for (i, month) in months.iter().enumerate() {
+        insert_commit(
+            &db,
+            &format!("c{i}"),
+            "Alice",
+            "alice@x.com",
+            &format!("{month}-01T00:00:00Z"),
+            "repo",
+            false,
+            &["src/lib.rs"],
+        );
+    }
+    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    assert_eq!(summary.monthly_trajectory.len(), 12);
+    // Oldest-first, and only the most recent 12 survive — 2024-11/12 dropped.
+    assert_eq!(summary.monthly_trajectory.first().unwrap().month, "2025-01");
+    assert_eq!(summary.monthly_trajectory.last().unwrap().month, "2025-12");
+}

--- a/crates/trusty-git-analytics/src/report/authorship_tests.rs
+++ b/crates/trusty-git-analytics/src/report/authorship_tests.rs
@@ -2,8 +2,36 @@
 
 use rusqlite::params;
 
-use super::{build_authorship_summary, AUTHORSHIP_SCHEMA_VERSION};
+use super::{
+    build_authorship_summary, recorded_repository_names, repository_has_commits,
+    AUTHORSHIP_SCHEMA_VERSION,
+};
 use crate::core::db::Database;
+
+/// Insert one `authors` row — the identity resolver's output — and hand back
+/// its id, so a test can link commits to it exactly as `upsert_observed_authors`
+/// does at collection time.
+fn insert_author(db: &Database, canonical_name: &str, canonical_email: &str) -> i64 {
+    db.connection()
+        .execute(
+            "INSERT INTO authors (canonical_name, canonical_email) VALUES (?1, ?2)",
+            params![canonical_name, canonical_email],
+        )
+        .expect("insert author");
+    db.connection().last_insert_rowid()
+}
+
+/// Link an already-inserted commit to a resolved author.
+fn link_commit(db: &Database, sha: &str, author_id: i64) {
+    let updated = db
+        .connection()
+        .execute(
+            "UPDATE commits SET author_id = ?1 WHERE sha = ?2",
+            params![author_id, sha],
+        )
+        .expect("link commit");
+    assert_eq!(updated, 1, "the commit to link must exist: {sha}");
+}
 
 /// Insert one commit (with its file touches) into the seeded database.
 #[allow(clippy::too_many_arguments)]
@@ -189,4 +217,139 @@ fn trajectory_caps_at_twelve_months() {
     // Oldest-first, and only the most recent 12 survive — 2024-11/12 dropped.
     assert_eq!(summary.monthly_trajectory.first().unwrap().month, "2025-01");
     assert_eq!(summary.monthly_trajectory.last().unwrap().month, "2025-12");
+}
+
+/// (#5453) One person committing under two emails is ONE author, because the
+/// aggregation joins `commits.author_id → authors.canonical_email` rather than
+/// grouping raw commit emails. Against the raw-email grouping this replaced,
+/// `distinct_authors` reads 2 and `bus_factor` reads 1 out of a two-author
+/// field — the exact understatement of concentration issue #5453 named.
+#[test]
+fn aliases_collapse_through_the_identity_resolver() {
+    let db = Database::open_in_memory().expect("open");
+    let alice = insert_author(&db, "Alice", "alice@x.com");
+    for (sha, email, path) in [
+        ("a1", "alice@x.com", "src/lib.rs"),
+        ("a2", "alice@corp.example", "docs/readme.md"),
+    ] {
+        insert_commit(
+            &db,
+            sha,
+            "Alice",
+            email,
+            "2026-01-15T00:00:00Z",
+            "repo",
+            false,
+            &[path],
+        );
+        link_commit(&db, sha, alice);
+    }
+
+    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    assert_eq!(
+        summary.distinct_authors, 1,
+        "both aliases resolve to one canonical author"
+    );
+    assert!(
+        (summary.top_author_share_pct - 100.0).abs() < f64::EPSILON,
+        "one author holds every touch: {}",
+        summary.top_author_share_pct
+    );
+    assert_eq!(
+        summary.unresolved_authors, 0,
+        "every commit was linked, so nothing is unresolved"
+    );
+    assert!(
+        !summary.caveats.iter().any(|c| c.contains("never linked")),
+        "a fully-resolved run must not carry the unresolved caveat: {:?}",
+        summary.caveats
+    );
+}
+
+/// (#5453) A commit the resolver never linked keeps its raw identity AND is
+/// counted into `unresolved_authors`, which then earns its own caveat. This is
+/// the honesty gate: the figures are still published, but a reader is told how
+/// many identities they under-merge.
+#[test]
+fn unresolved_authors_are_counted_and_caveated() {
+    let db = Database::open_in_memory().expect("open");
+    let alice = insert_author(&db, "Alice", "alice@x.com");
+    insert_commit(
+        &db,
+        "a1",
+        "Alice",
+        "alice@x.com",
+        "2026-01-15T00:00:00Z",
+        "repo",
+        false,
+        &["src/lib.rs"],
+    );
+    link_commit(&db, "a1", alice);
+    // Never resolved: no `authors` row, so `author_id` stays NULL.
+    insert_commit(
+        &db,
+        "c1",
+        "Carol",
+        "carol@x.com",
+        "2026-01-16T00:00:00Z",
+        "repo",
+        false,
+        &["src/other.rs"],
+    );
+
+    let summary = build_authorship_summary(db.connection(), "repo").expect("summary");
+    assert_eq!(summary.distinct_authors, 2);
+    assert_eq!(
+        summary.unresolved_authors, 1,
+        "exactly Carol's identity is unresolved"
+    );
+    let caveat = summary
+        .caveats
+        .iter()
+        .find(|c| c.contains("never linked"))
+        .expect("an unresolved run must name the count in a caveat");
+    assert!(
+        caveat.contains('1'),
+        "the caveat must carry the figure: {caveat}"
+    );
+}
+
+/// (#5453 review) The probe that separates "this name matched nothing" from
+/// "this repository is empty" — the distinction `build_authorship_summary`
+/// cannot make, since both aggregate zero rows into a confident zero.
+#[test]
+fn a_name_that_matches_nothing_is_detectable() {
+    let db = Database::open_in_memory().expect("open");
+    assert!(
+        !repository_has_commits(db.connection(), "acme-web").expect("probe"),
+        "an empty database matches no name"
+    );
+    assert!(
+        recorded_repository_names(db.connection())
+            .expect("names")
+            .is_empty(),
+        "an empty database records no names"
+    );
+
+    insert_commit(
+        &db,
+        "a1",
+        "Alice",
+        "alice@x.com",
+        "2026-01-15T00:00:00Z",
+        "acme_web",
+        false,
+        &["src/lib.rs"],
+    );
+
+    assert!(repository_has_commits(db.connection(), "acme_web").expect("probe"));
+    assert!(
+        !repository_has_commits(db.connection(), "acme-web").expect("probe"),
+        "a name one character off must not match — that is the drift this catches"
+    );
+    assert_eq!(
+        recorded_repository_names(db.connection()).expect("names"),
+        vec!["acme_web".to_string()],
+        "the recorded name is what the gap line points the operator at"
+    );
 }

--- a/crates/trusty-git-analytics/src/report/dd_manifest.rs
+++ b/crates/trusty-git-analytics/src/report/dd_manifest.rs
@@ -294,17 +294,31 @@ fn anchor(base: &Path, path: &Path) -> PathBuf {
 
 /// The display name for a repository: its configured name, else the directory
 /// basename (`config/mod.rs`'s own documented fallback).
-/// `pub` (#5453/#6004): `commands::audit` needs the same name-fallback logic
-/// to match `commits.repository` when writing the per-repo authorship
-/// artifact — reusing this avoids a second, independently-driftable
-/// derivation of the same fallback.
+///
+/// Why: this is the ONE derivation of a repository's name in tga, and it has to
+/// be, because two independent copies is a silent-zero join. `commits.
+/// repository` is written by [`crate::collect::git::GitCollector`] at collection
+/// time and read back by an equality filter at report time (#5453's per-repo
+/// authorship artifact) — a name the two sides spell differently matches no rows
+/// and renders a confident "0 authors, bus factor 0" instead of an error. The
+/// collector calls this too since #5453's review; before that it had its own
+/// copy, which disagreed on a configured name that was empty or whitespace.
+/// What: the configured name when it is non-empty after trimming, else the
+/// basename of the tilde-expanded path, else the path itself. Expansion happens
+/// HERE so a caller holding the raw config path and a caller holding an
+/// already-expanded one still agree.
+/// Test: `super::dd_manifest_tests::{names_fall_back_to_the_directory_basename,
+/// a_blank_configured_name_falls_back_the_same_way_for_every_caller}`.
 pub fn repo_name(configured: Option<&str>, path: &Path) -> String {
     match configured.map(str::trim).filter(|n| !n.is_empty()) {
         Some(name) => name.to_string(),
-        None => path
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| path.display().to_string()),
+        None => {
+            let expanded = crate::core::config::expand_path(path);
+            expanded
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| expanded.display().to_string())
+        }
     }
 }
 

--- a/crates/trusty-git-analytics/src/report/dd_manifest.rs
+++ b/crates/trusty-git-analytics/src/report/dd_manifest.rs
@@ -168,6 +168,21 @@ pub struct DdRepositoryEntry {
     pub name: String,
     /// Local checkout path trusty-review scans.
     pub path: PathBuf,
+    /// Path to this repository's authorship artifact, relative to the
+    /// manifest (#5453/#6004) — mirrors the DOC-67 §8 `velocity` field
+    /// precedent: a new, separate, per-repository optional field rather than
+    /// routing through `metrics` (whose "declared metrics always win"
+    /// precedence would block the live `--analyze` fetch).
+    ///
+    /// Why: [`dd_repository_entries`] stays pure (no I/O, no database), so
+    /// this starts `None` for every entry it builds; the caller
+    /// (`commands::audit`) sets it after writing the artifact, once it has a
+    /// database connection open. Omitted from the TOML when absent — the
+    /// same backward-compatibility shape [`DdReportSection::ticketing`] uses
+    /// — so an older trusty-review, or a manifest whose authorship stage
+    /// failed, sees exactly what it saw before this field existed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorship: Option<PathBuf>,
 }
 
 impl DdManifest {
@@ -258,6 +273,7 @@ pub fn dd_repository_entries(cfg: &Config, base_dir: &Path) -> Vec<DdRepositoryE
         .map(|repo| DdRepositoryEntry {
             name: scrub_secrets(&repo_name(repo.name.as_deref(), &repo.path), &secrets),
             path: anchor(base_dir, &repo.path),
+            authorship: None,
         })
         .collect()
 }
@@ -278,7 +294,11 @@ fn anchor(base: &Path, path: &Path) -> PathBuf {
 
 /// The display name for a repository: its configured name, else the directory
 /// basename (`config/mod.rs`'s own documented fallback).
-fn repo_name(configured: Option<&str>, path: &Path) -> String {
+/// `pub` (#5453/#6004): `commands::audit` needs the same name-fallback logic
+/// to match `commits.repository` when writing the per-repo authorship
+/// artifact — reusing this avoids a second, independently-driftable
+/// derivation of the same fallback.
+pub fn repo_name(configured: Option<&str>, path: &Path) -> String {
     match configured.map(str::trim).filter(|n| !n.is_empty()) {
         Some(name) => name.to_string(),
         None => path

--- a/crates/trusty-git-analytics/src/report/dd_manifest_tests.rs
+++ b/crates/trusty-git-analytics/src/report/dd_manifest_tests.rs
@@ -61,6 +61,7 @@ fn maps_engagement_metadata() {
         vec![DdRepositoryEntry {
             name: "Northwind Web".to_string(),
             path: PathBuf::from("/src/northwind-web"),
+            authorship: None,
         }]
     );
 

--- a/crates/trusty-git-analytics/src/report/dd_manifest_tests.rs
+++ b/crates/trusty-git-analytics/src/report/dd_manifest_tests.rs
@@ -112,6 +112,35 @@ fn names_fall_back_to_the_directory_basename() {
     assert_eq!(names, vec!["northwind-web", "billing", "Ledger Service"]);
 }
 
+/// Why (#5453 review): `commits.repository` is written by
+/// [`crate::collect::git::GitCollector`] and read back by an equality filter
+/// when the per-repo authorship artifact is built. The collector used to derive
+/// the name itself, and its copy disagreed with this one on a configured name
+/// that was blank or whitespace — `Some("  ")` gave the collector `"  "` and the
+/// manifest `"billing"`, so the join matched zero rows and the section rendered
+/// a confident "0 authors, bus factor 0". Both sides call this function now, so
+/// the two agree by construction.
+/// What: pins the blank/whitespace cases the two copies disagreed on.
+/// Test: this test itself.
+#[test]
+fn a_blank_configured_name_falls_back_the_same_way_for_every_caller() {
+    use std::path::Path;
+
+    let path = Path::new("/src/billing");
+    for configured in [None, Some(""), Some("  "), Some("\t")] {
+        assert_eq!(
+            super::repo_name(configured, path),
+            "billing",
+            "a blank configured name must fall back to the basename: {configured:?}"
+        );
+    }
+    assert_eq!(
+        super::repo_name(Some("  Ledger Service  "), path),
+        "Ledger Service",
+        "a configured name is trimmed, not taken verbatim"
+    );
+}
+
 /// Why: repository order is the report's application order; a set that reorders
 /// between runs would make two audits of the same state incomparable.
 /// Test: itself.

--- a/crates/trusty-git-analytics/src/report/mod.rs
+++ b/crates/trusty-git-analytics/src/report/mod.rs
@@ -26,9 +26,12 @@ pub mod ticketed_stats;
 // #5405: the board-correlation figures the DD report renders.
 pub mod ticketing;
 
-pub use authorship::{build_authorship_summary, AuthorshipSummary, AUTHORSHIP_SCHEMA_VERSION};
+pub use authorship::{
+    build_authorship_summary, recorded_repository_names, repository_has_commits, AuthorshipSummary,
+    AUTHORSHIP_SCHEMA_VERSION,
+};
 pub use dd_manifest::{
-    build_dd_manifest, DdManifest, DdManifestError, DdManifestOptions, DdReportSection,
+    build_dd_manifest, repo_name, DdManifest, DdManifestError, DdManifestOptions, DdReportSection,
     DdRepositoryEntry,
 };
 pub use errors::{ReportError, Result};

--- a/crates/trusty-git-analytics/src/report/mod.rs
+++ b/crates/trusty-git-analytics/src/report/mod.rs
@@ -11,6 +11,8 @@
 //! - [`models`] — aggregated data structures
 //! - [`period_trends`] — N-week period roll-up for contributor profiles (#558)
 pub mod aggregator;
+// #5453/#6004: ownership/bus-factor/trajectory figures the DD report renders.
+pub mod authorship;
 pub mod dd_manifest;
 pub mod drilldown;
 pub mod errors;
@@ -24,6 +26,7 @@ pub mod ticketed_stats;
 // #5405: the board-correlation figures the DD report renders.
 pub mod ticketing;
 
+pub use authorship::{build_authorship_summary, AuthorshipSummary, AUTHORSHIP_SCHEMA_VERSION};
 pub use dd_manifest::{
     build_dd_manifest, DdManifest, DdManifestError, DdManifestOptions, DdReportSection,
     DdRepositoryEntry,

--- a/crates/trusty-review/changelog.d/5453-authorship-section.md
+++ b/crates/trusty-review/changelog.d/5453-authorship-section.md
@@ -12,4 +12,6 @@ Added
   repository only — never a silently absent section, never an aborted build.
   The Key Facts block's author-count and trajectory rows, left as named gaps
   by the earlier Code/Security/Performance change, now populate once
-  authorship data exists.
+  authorship data exists. The artifact's `unresolved_authors` count — commit
+  identities tga could not resolve to a canonical author — travels with the
+  figures, so a reader can tell how far the concentration numbers under-merge.

--- a/crates/trusty-review/changelog.d/5453-authorship-section.md
+++ b/crates/trusty-review/changelog.d/5453-authorship-section.md
@@ -1,0 +1,15 @@
+Added
+
+- The technical due-diligence report gains an "Authorship & Key-Person Risk"
+  section (#5453, #6004): bus factor, ownership concentration, single-author
+  subsystems, and a trailing-12-month trajectory per application, plus a new
+  `authorship_summary` LLM narrative slot (high-level, health-from-an-
+  authorship-perspective framing) on the existing synthesis call, inheriting
+  its numeric guardrail. Key-man risks render in this dedicated section, not
+  scattered across Top Risks. The manifest's per-repository entries accept a
+  new `authorship` key naming the JSON artifact `tga audit` writes; a
+  repository whose artifact fails to load states that as a named gap for that
+  repository only — never a silently absent section, never an aborted build.
+  The Key Facts block's author-count and trajectory rows, left as named gaps
+  by the earlier Code/Security/Performance change, now populate once
+  authorship data exists.

--- a/crates/trusty-review/src/report/authorship.rs
+++ b/crates/trusty-review/src/report/authorship.rs
@@ -53,6 +53,16 @@ pub struct AuthorshipSummary {
     /// One entry per active month in the trailing 12 months, oldest first.
     #[serde(default)]
     pub monthly_trajectory: Vec<MonthlyActivity>,
+    /// Commit identities tga's derivation could not link to a resolved author
+    /// (issue #5453's honesty gate).
+    ///
+    /// Why: a nonzero count means the figures beside it UNDERSTATE
+    /// concentration — those identities were grouped by raw commit email, so
+    /// one person's aliases were counted as several authors. tga also states
+    /// this in [`Self::caveats`]; the number is carried separately so the
+    /// section can render it as a measured figure rather than only as prose.
+    #[serde(default)]
+    pub unresolved_authors: u64,
     /// Data-trap limitations the derivation did NOT correct for (issue
     /// #5453) — rendered verbatim in the section's caption.
     #[serde(default)]

--- a/crates/trusty-review/src/report/authorship.rs
+++ b/crates/trusty-review/src/report/authorship.rs
@@ -1,0 +1,173 @@
+//! The tga → trusty-review authorship artifact, receiving half (#5453, #6004).
+//!
+//! Why: tga's `report::authorship` module (the derivation, per #5468's ruling
+//! that contributor-profiling derivation lives in tga, never here) writes one
+//! JSON artifact per repository; this module is the read side, mirroring
+//! [`super::ticketing`]'s and [`super::metrics`]'s loader shape.
+//! What: [`AuthorshipSummary`], [`load_authorship`] which parses it from a
+//! path the manifest declares and refuses a schema major this build does not
+//! read, plus rendering helpers the reporter uses for the Authorship &
+//! Key-Person Risk section's deterministic tables.
+//! Test: `super::authorship_tests`.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use super::error::ReportError;
+
+/// The artifact schema major this build reads — pairs with tga's
+/// `report::authorship::AUTHORSHIP_SCHEMA_VERSION`.
+const SUPPORTED_SCHEMA_MAJOR: u32 = 0;
+
+/// One repository's ownership/bus-factor/trajectory figures, as tga writes
+/// them.
+///
+/// Why: the cross-process contract — no Cargo edge to tga (#5468) — so every
+/// field defaults, matching [`super::ticketing::TicketingSummary`]'s shape.
+/// What: see tga's `report::authorship::AuthorshipSummary` for the derivation;
+/// this is its deserialization mirror.
+/// Test: `super::authorship_tests::parses_the_artifact_tga_writes`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[non_exhaustive]
+pub struct AuthorshipSummary {
+    /// Artifact schema tag, e.g. `v0`; empty when the artifact declared none.
+    #[serde(default)]
+    pub schema_version: String,
+    /// The repository these figures describe.
+    #[serde(default)]
+    pub repository: String,
+    /// Distinct non-bot authors with at least one non-merge commit.
+    #[serde(default)]
+    pub distinct_authors: u64,
+    /// Smallest number of top-touching authors whose combined file-touch
+    /// share reaches 50%.
+    #[serde(default)]
+    pub bus_factor: u64,
+    /// The single largest author's share of all file-touches, `0.0..=100.0`.
+    #[serde(default)]
+    pub top_author_share_pct: f64,
+    /// Top-level path segments touched by exactly one non-bot author.
+    #[serde(default)]
+    pub single_author_subsystems: Vec<String>,
+    /// One entry per active month in the trailing 12 months, oldest first.
+    #[serde(default)]
+    pub monthly_trajectory: Vec<MonthlyActivity>,
+    /// Data-trap limitations the derivation did NOT correct for (issue
+    /// #5453) — rendered verbatim in the section's caption.
+    #[serde(default)]
+    pub caveats: Vec<String>,
+}
+
+/// One month's active-author/commit-volume figures.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+pub struct MonthlyActivity {
+    /// `YYYY-MM`.
+    #[serde(default)]
+    pub month: String,
+    /// Distinct non-bot authors with a non-merge commit in this month.
+    #[serde(default)]
+    pub active_authors: u64,
+    /// Non-merge, non-bot commits in this month.
+    #[serde(default)]
+    pub commits: u64,
+}
+
+impl AuthorshipSummary {
+    /// A one-line, high-level trend description of [`Self::monthly_trajectory`].
+    ///
+    /// Why: the Key Facts block and the deterministic table both want a
+    /// compact "12-month trajectory" statement rather than requiring a reader
+    /// to eyeball a 12-row table.
+    /// What: compares the average commits/month across the first half of the
+    /// window against the second half and labels the trend increasing,
+    /// stable (within 10%), or decreasing; `None` when there is fewer than
+    /// one active month of data.
+    /// Test: `super::authorship_tests::{trajectory_summary_labels_increasing,
+    /// trajectory_summary_none_when_empty}`.
+    pub fn trajectory_summary(&self) -> Option<String> {
+        if self.monthly_trajectory.is_empty() {
+            return None;
+        }
+        let n = self.monthly_trajectory.len();
+        let mid = n.div_ceil(2);
+        let avg = |slice: &[MonthlyActivity]| -> f64 {
+            if slice.is_empty() {
+                0.0
+            } else {
+                slice.iter().map(|m| m.commits as f64).sum::<f64>() / slice.len() as f64
+            }
+        };
+        let first_half = avg(&self.monthly_trajectory[..mid]);
+        let second_half = avg(&self.monthly_trajectory[mid..]);
+        let trend = if first_half == 0.0 && second_half == 0.0 {
+            "flat"
+        } else if second_half > first_half * 1.1 {
+            "increasing"
+        } else if second_half < first_half * 0.9 {
+            "decreasing"
+        } else {
+            "stable"
+        };
+        let avg_authors = self
+            .monthly_trajectory
+            .iter()
+            .map(|m| m.active_authors as f64)
+            .sum::<f64>()
+            / n as f64;
+        let avg_commits = self
+            .monthly_trajectory
+            .iter()
+            .map(|m| m.commits as f64)
+            .sum::<f64>()
+            / n as f64;
+        Some(format!(
+            "{trend} over the trailing {n} month(s): avg {avg_commits:.1} commit(s)/mo across \
+             avg {avg_authors:.1} active author(s)/mo"
+        ))
+    }
+}
+
+/// Load and parse an authorship artifact from disk.
+///
+/// Why: mirrors [`super::ticketing::load_ticketing`] — a declared file that
+/// cannot be read is a typed, named failure the CALLER decides how to handle.
+/// Unlike ticketing (engagement-wide, hard-fails the whole build), a failed
+/// authorship load is fail-open at the model layer (#5453/#6004): one
+/// repository's artifact failing must produce a named gap for that
+/// repository, never abort a report that has data for every other one.
+/// What: reads `path`, parses it against [`AuthorshipSummary`], then refuses
+/// any [`super::schema::major`] other than [`SUPPORTED_SCHEMA_MAJOR`].
+/// Test: `super::authorship_tests::{parses_the_artifact_tga_writes,
+/// a_malformed_artifact_is_a_named_error,
+/// an_artifact_from_an_unknown_schema_major_is_a_named_error}`.
+///
+/// # Errors
+///
+/// [`ReportError::Io`] when the file cannot be read,
+/// [`ReportError::Authorship`] when it does not parse, and
+/// [`ReportError::AuthorshipSchema`] when it declares an unreadable major.
+pub fn load_authorship(path: &Path) -> std::result::Result<AuthorshipSummary, ReportError> {
+    let text = std::fs::read_to_string(path).map_err(|source| ReportError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let summary: AuthorshipSummary =
+        serde_json::from_str(&text).map_err(|source| ReportError::Authorship {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    if super::schema::major(&summary.schema_version) != Some(SUPPORTED_SCHEMA_MAJOR) {
+        return Err(ReportError::AuthorshipSchema {
+            path: path.to_path_buf(),
+            found: summary.schema_version,
+            supported: SUPPORTED_SCHEMA_MAJOR,
+        });
+    }
+    Ok(summary)
+}
+
+#[cfg(test)]
+#[path = "authorship_tests.rs"]
+mod authorship_tests;

--- a/crates/trusty-review/src/report/authorship_tests.rs
+++ b/crates/trusty-review/src/report/authorship_tests.rs
@@ -11,7 +11,8 @@ const ARTIFACT: &str = r#"{
     {"month": "2026-01", "active_authors": 2, "commits": 10},
     {"month": "2026-02", "active_authors": 3, "commits": 15}
   ],
-  "caveats": ["no mailmap"]
+  "unresolved_authors": 2,
+  "caveats": ["2 commit identity/identities in this repository were never linked"]
 }"#;
 
 #[test]
@@ -28,7 +29,26 @@ fn parses_the_artifact_tga_writes() {
     assert!((summary.top_author_share_pct - 82.5).abs() < f64::EPSILON);
     assert_eq!(summary.single_author_subsystems, vec!["src", "scripts"]);
     assert_eq!(summary.monthly_trajectory.len(), 2);
-    assert_eq!(summary.caveats, vec!["no mailmap".to_string()]);
+    // #5453: the unresolved-identity count crosses the process boundary as a
+    // figure, not only as caveat prose — a reader (and the JSON output) needs
+    // to know how far the concentration numbers under-merge.
+    assert_eq!(summary.unresolved_authors, 2);
+    assert_eq!(summary.caveats.len(), 1);
+}
+
+/// An older tga wrote no `unresolved_authors` key. Reading it as `0` is the
+/// only safe default the `#[serde(default)]` on every field already implies —
+/// and it must not turn the load into an error, since the schema major is
+/// unchanged.
+#[test]
+fn an_artifact_without_the_unresolved_count_still_loads() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("authorship.json");
+    std::fs::write(&path, r#"{"schema_version": "v0", "distinct_authors": 3}"#).expect("write");
+
+    let summary = load_authorship(&path).expect("parses");
+    assert_eq!(summary.distinct_authors, 3);
+    assert_eq!(summary.unresolved_authors, 0);
 }
 
 #[test]

--- a/crates/trusty-review/src/report/authorship_tests.rs
+++ b/crates/trusty-review/src/report/authorship_tests.rs
@@ -1,0 +1,85 @@
+use super::{AuthorshipSummary, load_authorship};
+
+const ARTIFACT: &str = r#"{
+  "schema_version": "v0",
+  "repository": "acme-web",
+  "distinct_authors": 3,
+  "bus_factor": 1,
+  "top_author_share_pct": 82.5,
+  "single_author_subsystems": ["src", "scripts"],
+  "monthly_trajectory": [
+    {"month": "2026-01", "active_authors": 2, "commits": 10},
+    {"month": "2026-02", "active_authors": 3, "commits": 15}
+  ],
+  "caveats": ["no mailmap"]
+}"#;
+
+#[test]
+fn parses_the_artifact_tga_writes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("authorship.json");
+    std::fs::write(&path, ARTIFACT).expect("write");
+
+    let summary = load_authorship(&path).expect("parses");
+    assert_eq!(summary.schema_version, "v0");
+    assert_eq!(summary.repository, "acme-web");
+    assert_eq!(summary.distinct_authors, 3);
+    assert_eq!(summary.bus_factor, 1);
+    assert!((summary.top_author_share_pct - 82.5).abs() < f64::EPSILON);
+    assert_eq!(summary.single_author_subsystems, vec!["src", "scripts"]);
+    assert_eq!(summary.monthly_trajectory.len(), 2);
+    assert_eq!(summary.caveats, vec!["no mailmap".to_string()]);
+}
+
+#[test]
+fn a_malformed_artifact_is_a_named_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("authorship.json");
+    std::fs::write(&path, "{not json").expect("write");
+    let err = load_authorship(&path).expect_err("must fail");
+    assert!(matches!(
+        err,
+        crate::report::error::ReportError::Authorship { .. }
+    ));
+}
+
+#[test]
+fn an_artifact_from_an_unknown_schema_major_is_a_named_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("authorship.json");
+    std::fs::write(&path, r#"{"schema_version": "v99"}"#).expect("write");
+    let err = load_authorship(&path).expect_err("must fail");
+    assert!(matches!(
+        err,
+        crate::report::error::ReportError::AuthorshipSchema { .. }
+    ));
+}
+
+/// An absent `schema_version` is refused, not read as v0 — every tga that
+/// writes this artifact writes the tag (mirrors ticketing's, not metrics',
+/// behavior — see `load_authorship`'s doc comment).
+#[test]
+fn an_untagged_artifact_is_refused() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("authorship.json");
+    std::fs::write(&path, r#"{"repository": "acme-web"}"#).expect("write");
+    let err = load_authorship(&path).expect_err("must fail");
+    assert!(matches!(
+        err,
+        crate::report::error::ReportError::AuthorshipSchema { .. }
+    ));
+}
+
+#[test]
+fn trajectory_summary_labels_increasing() {
+    let s: AuthorshipSummary = serde_json::from_str(ARTIFACT).expect("parse");
+    let summary = s.trajectory_summary().expect("some trend");
+    assert!(summary.contains("increasing"));
+    assert!(summary.contains("2 month"));
+}
+
+#[test]
+fn trajectory_summary_none_when_empty() {
+    let s = AuthorshipSummary::default();
+    assert!(s.trajectory_summary().is_none());
+}

--- a/crates/trusty-review/src/report/benchmark_tests.rs
+++ b/crates/trusty-review/src/report/benchmark_tests.rs
@@ -89,6 +89,7 @@ fn repo(slug: &str, m: Option<AnalyzeMetrics>) -> RepositoryReport {
         local_path: None,
         scan: None,
         metrics: m,
+        authorship: None,
     }
 }
 

--- a/crates/trusty-review/src/report/error.rs
+++ b/crates/trusty-review/src/report/error.rs
@@ -210,6 +210,44 @@ pub enum ReportError {
         #[source]
         source: std::io::Error,
     },
+
+    /// A declared authorship artifact exists but could not be parsed
+    /// (#5453/#6004).
+    ///
+    /// Why: unlike [`ReportError::Ticketing`], this variant is never
+    /// propagated out of [`super::model::ReportModel::build`] as a hard
+    /// failure — a per-repository authorship load is fail-open (#5453's
+    /// "named gap, never a silently absent section" rule), so callers convert
+    /// this into a gap line rather than aborting the build. It stays a typed
+    /// error (rather than silently returning `None`) so the loader itself is
+    /// testable independent of that fail-open policy.
+    #[error("failed to parse authorship JSON at {path}: {source}")]
+    Authorship {
+        /// The authorship artifact path that failed to parse.
+        path: PathBuf,
+        /// The underlying serde_json error.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// An authorship artifact parsed, but declares a schema major this build
+    /// does not read (#5453/#6004).
+    ///
+    /// Why: mirrors [`ReportError::TicketingSchema`]'s reasoning — tga and
+    /// trusty-review are versioned and installed independently.
+    #[error(
+        "authorship artifact at {path} declares schema_version {found:?}, which this build \
+         cannot read; it reads schema major {supported} (an empty value means the artifact \
+         carried no schema_version)"
+    )]
+    AuthorshipSchema {
+        /// The authorship artifact whose schema tag was refused.
+        path: PathBuf,
+        /// The `schema_version` the artifact declared; empty when absent.
+        found: String,
+        /// The schema major this build reads.
+        supported: u32,
+    },
 }
 
 /// Convenience `Result` alias for the report pipeline.

--- a/crates/trusty-review/src/report/manifest.rs
+++ b/crates/trusty-review/src/report/manifest.rs
@@ -161,6 +161,12 @@ pub struct RepositoryEntry {
     pub git_ref: Option<String>,
     /// Optional path to a trusty-analyze metrics JSON file for this repo.
     pub metrics: Option<PathBuf>,
+    /// Optional path to this repository's authorship artifact tga writes
+    /// (#5453/#6004) — mirrors `metrics`'s "declared path, resolved against
+    /// the manifest directory" shape, but a separate field: `metrics`'s
+    /// "declared metrics always win" precedence must not gate the
+    /// authorship load too.
+    pub authorship: Option<PathBuf>,
 }
 
 /// The origin of a repository — a local checkout or a declared remote.
@@ -233,6 +239,8 @@ struct RawRepositoryEntry {
     git_ref: Option<String>,
     #[serde(default)]
     metrics: Option<PathBuf>,
+    #[serde(default)]
+    authorship: Option<PathBuf>,
 }
 
 // ─── Loader ─────────────────────────────────────────────────────────────────
@@ -313,6 +321,7 @@ fn validate(raw: RawManifest) -> std::result::Result<Manifest, ManifestError> {
             username: entry.username,
             git_ref: entry.git_ref,
             metrics: entry.metrics,
+            authorship: entry.authorship,
         });
     }
 

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -14,6 +14,8 @@
 //! lives in `crates/trusty-review/tests/report_e2e.rs`.
 
 pub mod analyze_adapter;
+// #5453/#6004: the tga-authored authorship artifact, receiving half.
+pub mod authorship;
 pub mod benchmark;
 // #6004: exec-summary jump-list — post-render anchor-link injection.
 pub mod contents_links;
@@ -31,6 +33,8 @@ pub mod polish;
 pub mod provenance;
 pub mod redact;
 pub mod reporter;
+// #5453/#6004: Authorship & Key-Person Risk deterministic fill.
+pub mod reporter_authorship;
 // #6004: Code Quality & Architecture / Security Posture deterministic fill.
 pub mod reporter_codesec;
 // #6004: engagement-wide Key Facts block.

--- a/crates/trusty-review/src/report/model.rs
+++ b/crates/trusty-review/src/report/model.rs
@@ -361,3 +361,7 @@ fn resolve(manifest_dir: &Path, path: &Path) -> std::path::PathBuf {
         manifest_dir.join(path)
     }
 }
+
+#[cfg(test)]
+#[path = "model_tests.rs"]
+mod model_tests;

--- a/crates/trusty-review/src/report/model.rs
+++ b/crates/trusty-review/src/report/model.rs
@@ -183,6 +183,19 @@ pub struct RepositoryReport {
     pub scan: Option<RepoScan>,
     /// Pre-produced trusty-analyze metrics for this repo, if a path was given.
     pub metrics: Option<AnalyzeMetrics>,
+    /// tga's authorship/bus-factor/trajectory figures for this repo, if a path
+    /// was given AND it loaded (#5453/#6004).
+    ///
+    /// Why: unlike `metrics`, a declared-but-unreadable authorship artifact
+    /// does NOT fail the build — [`ReportModel::build`] converts the load
+    /// failure into a named line on [`ReportModel::gaps`] instead, so one
+    /// repository's authorship problem never aborts a report that has real
+    /// data for every other section. `None` therefore means either "no path
+    /// declared" or "declared but failed to load"; the gap line (present only
+    /// in the second case) is what a reader relies on to tell them apart.
+    /// Test: `model_tests::{authorship_loads_when_declared,
+    /// unreadable_authorship_is_a_named_gap_not_a_build_failure}`.
+    pub authorship: Option<super::authorship::AuthorshipSummary>,
 }
 
 impl ReportModel {
@@ -215,8 +228,14 @@ impl ReportModel {
         };
 
         let mut repositories = Vec::with_capacity(manifest.repositories.len());
+        // #5453/#6004: authorship-load failures are fail-open — collected here
+        // rather than propagated, so one repository's unreadable artifact
+        // never aborts a report with real data for every other section.
+        let mut gaps = manifest.report.gaps.clone();
         for entry in &manifest.repositories {
-            repositories.push(build_repository(entry, manifest_dir, &secrets)?);
+            let (repo, authorship_gap) = build_repository(entry, manifest_dir, &secrets)?;
+            gaps.extend(authorship_gap);
+            repositories.push(repo);
         }
 
         Ok(ReportModel {
@@ -233,7 +252,8 @@ impl ReportModel {
             repositories,
             // #5239: the manifest author's own unassessed areas travel with the
             // report; the analyze pass appends its named gaps to the same list.
-            gaps: manifest.report.gaps.clone(),
+            // #5453/#6004: per-repository authorship-load failures joined in above.
+            gaps,
             synthesis: None,
             benchmark: None,
             investigation: None,
@@ -252,19 +272,23 @@ impl ReportModel {
     }
 }
 
-/// Resolve one manifest entry into a [`RepositoryReport`].
+/// Resolve one manifest entry into a [`RepositoryReport`], plus any
+/// authorship-load gap line for it (#5453/#6004).
 ///
 /// Why: keeps `ReportModel::build` readable by isolating per-entry enrichment.
 /// What: records source kind/origin, gathers git info for local checkouts, and
 /// loads metrics (relative paths resolved against `manifest_dir`), scrubbing the
-/// loaded metrics against `secrets` before they reach the model (#5323).
+/// loaded metrics against `secrets` before they reach the model (#5323). A
+/// declared `authorship` path that fails to load returns `(repo, Some(gap))`
+/// rather than an `Err` — the fail-open contract [`ReportModel::build`]'s doc
+/// comment states.
 /// Test: exercised by `build_model_from_manifest` and
 /// `declared_metrics_file_findings_are_scrubbed`.
 fn build_repository(
     entry: &RepositoryEntry,
     manifest_dir: &Path,
     secrets: &[String],
-) -> Result<RepositoryReport> {
+) -> Result<(RepositoryReport, Option<String>)> {
     let (source_kind, git_info, scan, local_path) = match &entry.source {
         RepositorySource::LocalPath { path } => {
             let resolved = resolve(manifest_dir, path);
@@ -289,18 +313,39 @@ fn build_repository(
         None => None,
     };
 
-    Ok(RepositoryReport {
-        name: entry.name.clone(),
-        slug: entry.slug.clone(),
-        source: entry.source.describe(),
-        source_kind: source_kind.to_string(),
-        username: entry.username.clone(),
-        git_ref: entry.git_ref.clone(),
-        git_info,
-        local_path,
-        scan,
-        metrics,
-    })
+    // #5453/#6004: fail-open — a declared-but-unreadable authorship artifact
+    // becomes a named gap on THIS repository, never a build failure.
+    let (authorship, authorship_gap) = match &entry.authorship {
+        Some(p) => match super::authorship::load_authorship(&resolve(manifest_dir, p)) {
+            Ok(a) => (Some(a), None),
+            Err(e) => (
+                None,
+                Some(format!(
+                    "Authorship ({}): could not load the authorship artifact ({e}). The report \
+                     states no authorship/key-person signal for this application.",
+                    entry.name
+                )),
+            ),
+        },
+        None => (None, None),
+    };
+
+    Ok((
+        RepositoryReport {
+            name: entry.name.clone(),
+            slug: entry.slug.clone(),
+            source: entry.source.describe(),
+            source_kind: source_kind.to_string(),
+            username: entry.username.clone(),
+            git_ref: entry.git_ref.clone(),
+            git_info,
+            local_path,
+            scan,
+            metrics,
+            authorship,
+        },
+        authorship_gap,
+    ))
 }
 
 /// Resolve a possibly-relative path against the manifest directory.

--- a/crates/trusty-review/src/report/model_tests.rs
+++ b/crates/trusty-review/src/report/model_tests.rs
@@ -1,0 +1,124 @@
+//! `ReportModel::build`'s authorship fail-open contract (#5453, #6004).
+//!
+//! Why: `RepositoryReport::authorship` and `ReportModel::build` both promise
+//! that a declared-but-unreadable authorship artifact becomes a NAMED GAP
+//! rather than a failed build — the opposite of how a declared metrics or
+//! ticketing file behaves. Nothing proved that until these tests; the contract
+//! existed only in prose.
+
+use std::path::Path;
+
+use crate::report::manifest::parse_manifest;
+use crate::report::model::ReportModel;
+
+/// The artifact tga writes, as trusty-review reads it back.
+const ARTIFACT: &str = r#"{
+  "schema_version": "v0",
+  "repository": "acme-web",
+  "distinct_authors": 4,
+  "bus_factor": 1,
+  "top_author_share_pct": 71.5,
+  "single_author_subsystems": ["migrations"],
+  "monthly_trajectory": [
+    {"month": "2026-01", "active_authors": 2, "commits": 10}
+  ],
+  "unresolved_authors": 0,
+  "caveats": ["no vendored-path exclusion"]
+}"#;
+
+/// Build a one-repository manifest declaring `authorship = <name>`, then build
+/// the model from it. Returns the built model so a caller can assert on both
+/// the loaded figures and the gap list.
+fn model_with_authorship(dir: &Path, declared: &str) -> ReportModel {
+    let toml = format!(
+        r#"
+        [report]
+        title = "Acme Due Diligence"
+        analyst = "bobmatnyc"
+
+        [[repositories]]
+        name = "Acme Web"
+        path = "/nonexistent/acme-web"
+        authorship = "{declared}"
+    "#
+    );
+    let manifest_path = dir.join("manifest.toml");
+    let manifest = parse_manifest(&toml, &manifest_path).expect("manifest parse");
+    ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None)
+        .expect("a declared authorship path must never fail the build")
+}
+
+/// A declared artifact that reads and parses lands on the repository, resolved
+/// against the MANIFEST's directory (the path is relative, as tga writes it),
+/// and contributes no gap.
+#[test]
+fn authorship_loads_when_declared() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("authorship-0.json"), ARTIFACT).expect("write artifact");
+
+    let model = model_with_authorship(dir.path(), "authorship-0.json");
+
+    let a = model.repositories[0]
+        .authorship
+        .as_ref()
+        .expect("a readable artifact must reach the model");
+    assert_eq!(a.repository, "acme-web");
+    assert_eq!(a.distinct_authors, 4);
+    assert_eq!(a.bus_factor, 1);
+    assert_eq!(a.single_author_subsystems, vec!["migrations".to_string()]);
+    assert!(
+        !model.gaps.iter().any(|g| g.starts_with("Authorship (")),
+        "a successful load states no gap: {:?}",
+        model.gaps
+    );
+}
+
+/// The fail-open half: an unreadable artifact leaves `authorship: None`, adds
+/// one gap line naming the repository, and — the point of the contract —
+/// returns `Ok`, so a report with real data for every other section still
+/// renders.
+///
+/// Against a `?`-propagating load (the shape `metrics` and `ticketing` use)
+/// `ReportModel::build` returns `Err` here and the whole report is lost.
+#[test]
+fn unreadable_authorship_is_a_named_gap_not_a_build_failure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("authorship-0.json"), "{not json").expect("write artifact");
+
+    let model = model_with_authorship(dir.path(), "authorship-0.json");
+
+    assert!(
+        model.repositories[0].authorship.is_none(),
+        "a failed load must not leave half-parsed figures behind"
+    );
+    let gap = model
+        .gaps
+        .iter()
+        .find(|g| g.starts_with("Authorship ("))
+        .expect("the failure must be stated, never silent");
+    assert!(
+        gap.contains("Acme Web"),
+        "the gap must name the repository it belongs to: {gap}"
+    );
+    assert!(
+        gap.contains("no authorship/key-person signal"),
+        "the gap must say what the report will state instead: {gap}"
+    );
+}
+
+/// A declared path that does not exist at all takes the same fail-open route as
+/// a malformed one — the two failures reach the reader identically, which is
+/// what lets the section degrade to one gap line either way.
+#[test]
+fn a_missing_authorship_file_is_the_same_named_gap() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let model = model_with_authorship(dir.path(), "authorship-0.json");
+
+    assert!(model.repositories[0].authorship.is_none());
+    assert!(
+        model.gaps.iter().any(|g| g.starts_with("Authorship (")),
+        "a missing file is stated, not skipped: {:?}",
+        model.gaps
+    );
+}

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -23,6 +23,7 @@ use super::metrics::Severity;
 use super::model::{ReportModel, RepositoryReport};
 use super::polish::polish_with_gaps;
 use super::provenance::{self, Provenance, tag};
+use super::reporter_authorship::{fill_authorship_facts, push_authorship_rows};
 use super::reporter_codesec::{push_code_quality_rows, push_security_violation_rows};
 use super::reporter_facts::fill_key_facts;
 use super::reporter_fill::{
@@ -230,9 +231,12 @@ fn build_scope(model: &ReportModel) -> Scope {
     root.set("report_version", tag(crate_version(), Provenance::Measured));
     root.set("provenance_legend", provenance::LEGEND);
     root.set("analyst_instructions_block", instructions_block(model));
-    // #6004: the Key Facts block frontloads density/complexity/(author/
-    // trajectory once PR B lands) facts ahead of the executive summary.
+    // #6004: the Key Facts block frontloads density/complexity/author/
+    // trajectory facts ahead of the executive summary.
     fill_key_facts(&mut root, model);
+    // #5453/#6004: completes the author-count/trajectory rows PR A left as
+    // named gaps, once a repository's authorship artifact loaded.
+    fill_authorship_facts(&mut root, model);
     // #6004: deterministic structure, never data — always set.
     contents_links::set_contents_placeholder(&mut root);
     // Declared deal-side fields: filled + tagged when the manifest supplies them,
@@ -350,6 +354,11 @@ fn build_scope(model: &ReportModel) -> Scope {
     push_code_quality_rows(&mut root, model);
     push_security_violation_rows(&mut root, model);
     fill_performance_note(&mut root);
+    // #5453/#6004: key-man risk rows render IN this section, never scattered
+    // across Top Risks — the deterministic half of Authorship & Key-Person
+    // Risk. A repository whose artifact failed to load contributes no row;
+    // its gap already lives in `model.gaps` (fail-open, set by model.rs).
+    push_authorship_rows(&mut root, model);
 
     // #5318: §2 has a deterministic source.  It used to be filled ONLY from
     // verified synthesis, so a run without `--synthesize` — which was every
@@ -420,6 +429,12 @@ fn inject_synthesis_summary(root: &mut Scope, syn: &super::synthesize::Synthesis
         root.set(
             "security_summary_paragraph",
             tag(sec.clone(), Provenance::Inferred),
+        );
+    }
+    if let Some(au) = &syn.authorship_summary {
+        root.set(
+            "authorship_summary_paragraph",
+            tag(au.clone(), Provenance::Inferred),
         );
     }
 

--- a/crates/trusty-review/src/report/reporter_authorship.rs
+++ b/crates/trusty-review/src/report/reporter_authorship.rs
@@ -1,0 +1,148 @@
+//! Authorship & Key-Person Risk: deterministic tables from the tga-authored
+//! authorship artifact, plus the Key Facts block's author/trajectory rows
+//! (#5453, #6004).
+//!
+//! Why: owner ruling (issue #5453, 2026-08-18) — key-man risks render IN a
+//! dedicated section, not scattered across Top-Risks rows; the section
+//! carries a high-level trailing-12-month development-trajectory narrative
+//! and a bus-factor/concentration/single-author-subsystem table. All figures
+//! come from `RepositoryReport.authorship`, which `model.rs` already loaded
+//! fail-open (#5453/#6004) — a repository whose artifact failed to load
+//! carries `None` here and simply contributes no row, its gap already stated
+//! in `model.gaps`.
+//! What: [`push_authorship_rows`] fills the section's per-repository table;
+//! [`fill_authorship_facts`] completes the Key Facts block's
+//! `facts_author_count`/`facts_trajectory` rows PR A left as named gaps.
+//! Test: `reporter_authorship_tests.rs`.
+
+use super::fill::Scope;
+use super::model::ReportModel;
+use super::provenance::{Provenance, tag};
+
+/// Push one `authorship_row` per repository carrying a loaded authorship
+/// artifact.
+///
+/// Why: the deterministic half of the Authorship & Key-Person Risk section —
+/// bus factor, concentration, and single-author subsystems are exactly the
+/// key-man risk figures issue #5453 asked to be rendered in this section
+/// rather than folded into Top Risks.
+/// What: `au_single_author_subsystems` joins the list (or states "none" as a
+/// real, measured fact — an empty list is a genuine finding, not an absence);
+/// `au_caveats` restates the derivation's own data-trap disclosures verbatim
+/// so the section's limitations travel with its numbers.
+/// Test: `reporter_authorship_tests::populates_rows_from_loaded_artifacts`.
+pub fn push_authorship_rows(root: &mut Scope, model: &ReportModel) {
+    for repo in &model.repositories {
+        let Some(a) = &repo.authorship else { continue };
+        let mut row = Scope::new();
+        row.set("au_app_name", repo.name.clone());
+        row.set(
+            "au_distinct_authors",
+            tag(a.distinct_authors.to_string(), Provenance::Measured),
+        );
+        row.set(
+            "au_bus_factor",
+            tag(a.bus_factor.to_string(), Provenance::Measured),
+        );
+        row.set(
+            "au_top_author_share",
+            tag(
+                format!("{:.0}%", a.top_author_share_pct),
+                Provenance::Measured,
+            ),
+        );
+        let subsystems = if a.single_author_subsystems.is_empty() {
+            "none".to_string()
+        } else {
+            a.single_author_subsystems.join(", ")
+        };
+        row.set(
+            "au_single_author_subsystems",
+            tag(subsystems, Provenance::Measured),
+        );
+        if let Some(trend) = a.trajectory_summary() {
+            row.set("au_trajectory", tag(trend, Provenance::Measured));
+        }
+        root.push_block("authorship_row", row);
+    }
+    if let Some(caveats) = caveats_line(model) {
+        root.set("au_caveats", tag(caveats, Provenance::Measured));
+    }
+}
+
+/// The union of every loaded artifact's caveats, de-duplicated, prefixed for
+/// standalone-paragraph rendering.
+///
+/// Why: the template places `{{au_caveats}}` on its own paragraph line (no
+/// wrapping prose) SPECIFICALLY so an unset value renders as the bare
+/// honesty marker and is dropped by `polish.rs`'s standalone-paragraph rule
+/// (an exact `trimmed == HONESTY_MARKER` match) — wrapping text here would
+/// defeat that and leak "not stated in source data" into a report with no
+/// authorship data at all. The "Derivation caveats: " label therefore lives
+/// in the VALUE, not the template.
+fn caveats_line(model: &ReportModel) -> Option<String> {
+    let mut seen: Vec<&str> = Vec::new();
+    for repo in &model.repositories {
+        let Some(a) = &repo.authorship else { continue };
+        for c in &a.caveats {
+            if !seen.contains(&c.as_str()) {
+                seen.push(c);
+            }
+        }
+    }
+    if seen.is_empty() {
+        None
+    } else {
+        Some(format!("Derivation caveats: {}", seen.join(" ")))
+    }
+}
+
+/// Complete the Key Facts block's author-count and trajectory rows (#6004).
+///
+/// Why: PR A shipped `facts_total_loc`/`facts_complexity_summary`/etc. and
+/// left `facts_author_count`/`facts_trajectory` unset (rendering as a named
+/// gap) because no authorship data existed yet. This is that completion.
+/// What: `facts_author_count` sums `distinct_authors` across every
+/// repository with a loaded artifact — a simplification that does not
+/// de-duplicate an author active in more than one repository (caveated
+/// inline, since `AuthorshipSummary` carries no cross-repo author identity).
+/// `facts_trajectory` states the single repository's trend when there is
+/// exactly one, or a qualified "see Authorship section" pointer when there
+/// are several (a single merged sentence would blur per-repo trends that
+/// disagree). `facts_work_estimate` stays unset — see `reporter_facts.rs`'s
+/// module doc; tga has no effort-estimation metric.
+/// Test: `reporter_authorship_tests::completes_key_facts_author_rows`.
+pub fn fill_authorship_facts(root: &mut Scope, model: &ReportModel) {
+    let with_authorship: Vec<&super::authorship::AuthorshipSummary> = model
+        .repositories
+        .iter()
+        .filter_map(|r| r.authorship.as_ref())
+        .collect();
+    if with_authorship.is_empty() {
+        return;
+    }
+
+    let total_authors: u64 = with_authorship.iter().map(|a| a.distinct_authors).sum();
+    let note = if with_authorship.len() > 1 {
+        " (sum across repositories — an author active in more than one is counted once per \
+         repository)"
+    } else {
+        ""
+    };
+    root.set(
+        "facts_author_count",
+        tag(format!("{total_authors}{note}"), Provenance::Measured),
+    );
+
+    let trajectory = match with_authorship.as_slice() {
+        [only] => only.trajectory_summary(),
+        _ => Some("varies by application — see Authorship & Key-Person Risk".to_string()),
+    };
+    if let Some(t) = trajectory {
+        root.set("facts_trajectory", tag(t, Provenance::Measured));
+    }
+}
+
+#[cfg(test)]
+#[path = "reporter_authorship_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/reporter_authorship_tests.rs
+++ b/crates/trusty-review/src/report/reporter_authorship_tests.rs
@@ -1,0 +1,121 @@
+use super::*;
+use crate::report::authorship::{AuthorshipSummary, MonthlyActivity};
+use crate::report::model::RepositoryReport;
+
+fn repo(authorship: Option<AuthorshipSummary>) -> RepositoryReport {
+    RepositoryReport {
+        name: "app".to_string(),
+        slug: "app".to_string(),
+        source: "/tmp/app".to_string(),
+        source_kind: "local_path".to_string(),
+        username: None,
+        git_ref: None,
+        git_info: None,
+        local_path: None,
+        scan: None,
+        metrics: None,
+        authorship,
+    }
+}
+
+fn model_with(repos: Vec<RepositoryReport>) -> ReportModel {
+    ReportModel {
+        title: "Test".to_string(),
+        template: "report-technical-dd".to_string(),
+        analyst: None,
+        client: None,
+        vendor_methodology: crate::report::model::vendor_methodology(),
+        instructions: None,
+        instructions_source: None,
+        report_date: "2026-08-18".to_string(),
+        generated_date: "2026-08-18".to_string(),
+        manifest_path: "manifest.toml".to_string(),
+        repositories: repos,
+        gaps: vec![],
+        synthesis: None,
+        benchmark: None,
+        investigation: None,
+        section_instructions: Default::default(),
+        ticketing: None,
+    }
+}
+
+fn summary() -> AuthorshipSummary {
+    AuthorshipSummary {
+        schema_version: "v0".to_string(),
+        repository: "app".to_string(),
+        distinct_authors: 3,
+        bus_factor: 1,
+        top_author_share_pct: 80.0,
+        single_author_subsystems: vec!["src".to_string()],
+        monthly_trajectory: vec![
+            MonthlyActivity {
+                month: "2026-01".to_string(),
+                active_authors: 1,
+                commits: 5,
+            },
+            MonthlyActivity {
+                month: "2026-02".to_string(),
+                active_authors: 2,
+                commits: 10,
+            },
+        ],
+        caveats: vec!["no mailmap".to_string()],
+    }
+}
+
+/// A model with a loaded artifact yields a populated row, never blank.
+#[test]
+fn populates_rows_from_loaded_artifacts() {
+    let model = model_with(vec![repo(Some(summary()))]);
+    let mut root = Scope::new();
+    push_authorship_rows(&mut root, &model);
+
+    let template = "<!-- BEGIN authorship_row -->{{au_app_name}}|{{au_distinct_authors}}|{{au_bus_factor}}|{{au_top_author_share}}|{{au_single_author_subsystems}}<!-- END authorship_row -->{{au_caveats}}";
+    let rendered = crate::report::fill::render(template, &root);
+    assert!(rendered.contains("app|3"));
+    assert!(rendered.contains("|1 "), "rendered: {rendered}");
+    assert!(rendered.contains("80%"));
+    assert!(rendered.contains("src"));
+    assert!(rendered.contains("no mailmap"));
+}
+
+/// A repository with no loaded artifact contributes no row — fail-open, the
+/// gap already lives in `model.gaps` from the load step.
+#[test]
+fn no_artifact_yields_no_row() {
+    let model = model_with(vec![repo(None)]);
+    let mut root = Scope::new();
+    push_authorship_rows(&mut root, &model);
+    let template = "<!-- BEGIN authorship_row -->{{au_app_name}}<!-- END authorship_row -->";
+    let rendered = crate::report::fill::render(template, &root);
+    assert_eq!(rendered, "");
+}
+
+/// Key Facts author-count and trajectory complete once authorship data
+/// exists.
+#[test]
+fn completes_key_facts_author_rows() {
+    let model = model_with(vec![repo(Some(summary()))]);
+    let mut root = Scope::new();
+    fill_authorship_facts(&mut root, &model);
+    let rendered =
+        crate::report::fill::render("{{facts_author_count}}|{{facts_trajectory}}", &root);
+    assert!(rendered.contains('3'));
+    assert!(rendered.contains("increasing") || rendered.contains("month"));
+}
+
+/// No repository has authorship data — Key Facts rows stay unset (honesty
+/// marker, folded to a gap by the caller's omit-empty pass).
+#[test]
+fn no_authorship_data_leaves_facts_unset() {
+    let model = model_with(vec![repo(None)]);
+    let mut root = Scope::new();
+    fill_authorship_facts(&mut root, &model);
+    let rendered =
+        crate::report::fill::render("{{facts_author_count}}|{{facts_trajectory}}", &root);
+    assert_eq!(
+        rendered,
+        format!("{h}|{h}", h = crate::report::fill::HONESTY_MARKER)
+    );
+}

--- a/crates/trusty-review/src/report/reporter_authorship_tests.rs
+++ b/crates/trusty-review/src/report/reporter_authorship_tests.rs
@@ -60,7 +60,8 @@ fn summary() -> AuthorshipSummary {
                 commits: 10,
             },
         ],
-        caveats: vec!["no mailmap".to_string()],
+        unresolved_authors: 0,
+        caveats: vec!["no vendored-path exclusion".to_string()],
     }
 }
 
@@ -77,7 +78,7 @@ fn populates_rows_from_loaded_artifacts() {
     assert!(rendered.contains("|1 "), "rendered: {rendered}");
     assert!(rendered.contains("80%"));
     assert!(rendered.contains("src"));
-    assert!(rendered.contains("no mailmap"));
+    assert!(rendered.contains("no vendored-path exclusion"));
 }
 
 /// A repository with no loaded artifact contributes no row — fail-open, the

--- a/crates/trusty-review/src/report/reporter_codesec_tests.rs
+++ b/crates/trusty-review/src/report/reporter_codesec_tests.rs
@@ -17,6 +17,7 @@ fn repo(metrics: Option<AnalyzeMetrics>) -> RepositoryReport {
         local_path: None,
         scan: None,
         metrics,
+        authorship: None,
     }
 }
 

--- a/crates/trusty-review/src/report/reporter_facts_tests.rs
+++ b/crates/trusty-review/src/report/reporter_facts_tests.rs
@@ -16,6 +16,7 @@ fn repo(metrics: Option<AnalyzeMetrics>) -> RepositoryReport {
         local_path: None,
         scan: None,
         metrics,
+        authorship: None,
     }
 }
 

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -305,6 +305,7 @@ fn reporter_injects_synthesis_prose() {
     model.synthesis = Some(Synthesis {
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         executive_summary: Some("A grounded acquirer-relevant summary.".to_string()),
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -365,6 +366,7 @@ fn reporter_appends_guardrail_rejection_note() {
     model.synthesis = Some(Synthesis {
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         notes: vec![
             "synthesis: rejected (unverified figure) in executive summary: 9999".to_string(),
         ],
@@ -513,6 +515,7 @@ fn evidence_renders_as_fenced_block() {
     model.synthesis = Some(Synthesis {
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         executive_summary: None,
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -567,6 +570,7 @@ fn evidence_with_blank_line_fences_cleanly() {
     model.synthesis = Some(Synthesis {
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         executive_summary: None,
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -624,6 +628,7 @@ fn evidence_containing_triple_backticks_uses_longer_fence() {
     model.synthesis = Some(Synthesis {
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         executive_summary: None,
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -700,6 +705,7 @@ fn evidence_with_adjacent_hash_comment_lines_renders_byte_identical() {
     model.synthesis = Some(Synthesis {
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         executive_summary: None,
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -765,6 +771,7 @@ fn evidence_with_blank_line_full_render_has_no_fenced_splice() {
     model.synthesis = Some(Synthesis {
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         executive_summary: None,
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -941,6 +948,7 @@ fn reporter_merges_synthesis_prose_onto_deterministic_finding() {
     model.synthesis = Some(Synthesis {
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         executive_summary: None,
         top_risks: vec![],
         findings: vec![FindingProse {
@@ -1354,6 +1362,7 @@ fn reporter_tags_top_risks_as_inferred() {
     model.synthesis = Some(Synthesis {
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         executive_summary: Some("Summary.".to_string()),
         top_risks: vec![RiskRow {
             description: "Unpatched dependency chain".to_string(),
@@ -1401,6 +1410,7 @@ fn reporter_renders_all_top_risk_rows() {
     model.synthesis = Some(Synthesis {
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         executive_summary: Some("Summary.".to_string()),
         top_risks: (1..=5).map(risk).collect(),
         findings: vec![],
@@ -1453,6 +1463,7 @@ fn reporter_collapses_empty_top_risks() {
     model.synthesis = Some(Synthesis {
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         executive_summary: Some("Summary.".to_string()),
         top_risks: vec![],
         findings: vec![],
@@ -1494,6 +1505,7 @@ fn reporter_renders_defaulted_top_risk_severity_honestly() {
         executive_summary: Some("Summary.".to_string()),
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         top_risks: vec![RiskRow {
             description: "Plaintext secrets at rest".to_string(),
             severity: String::new(),
@@ -1940,6 +1952,7 @@ fn reporter_prefers_synthesis_over_deterministic_summary() {
     model.synthesis = Some(Synthesis {
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         executive_summary: Some("An acquirer-relevant judgement.".to_string()),
         top_risks: vec![RiskRow {
             description: "Credential exposure".to_string(),

--- a/crates/trusty-review/src/report/section_instructions.rs
+++ b/crates/trusty-review/src/report/section_instructions.rs
@@ -31,6 +31,9 @@ pub const FINDING_ELABORATION: &str = "finding_elaboration";
 pub const CODE_QUALITY_SUMMARY: &str = "code_quality_summary";
 /// Section id: the Security Posture narrative paragraph (#6004).
 pub const SECURITY_SUMMARY: &str = "security_summary";
+/// Section id: the Authorship & Key-Person Risk narrative paragraph
+/// (#5453, #6004).
+pub const AUTHORSHIP_SUMMARY: &str = "authorship_summary";
 
 /// Every recognised section id, in the order they appear in the synthesis output.
 pub const ALL_SECTION_IDS: &[&str] = &[
@@ -39,6 +42,7 @@ pub const ALL_SECTION_IDS: &[&str] = &[
     FINDING_ELABORATION,
     CODE_QUALITY_SUMMARY,
     SECURITY_SUMMARY,
+    AUTHORSHIP_SUMMARY,
 ];
 
 /// True when `id` names a recognised synthesized section.
@@ -103,6 +107,16 @@ pub fn default_instruction(id: &str) -> Option<&'static str> {
              limitation if it changes how a risk should be read. Take the acquirer's \
              skeptical side while still crediting a genuinely clean signal where the data \
              supports it.",
+        ),
+        AUTHORSHIP_SUMMARY => Some(
+            "Write ONE high-level paragraph on the codebase's health from an authorship \
+             perspective, grounded strictly in the bus factor, ownership concentration, \
+             single-author subsystems, and trailing-12-month trajectory data provided. This \
+             is a narrative of development trajectory over the past year, not a data dump — \
+             do not restate every number in the table; characterise the trend and what it \
+             means for continuity risk. Take the acquirer's skeptical side on key-person \
+             risk while crediting genuine strengths (e.g. a widening contributor base) the \
+             data supports, evenhandedly.",
         ),
         _ => None,
     }

--- a/crates/trusty-review/src/report/synthesize.rs
+++ b/crates/trusty-review/src/report/synthesize.rs
@@ -77,6 +77,11 @@ pub struct Synthesis {
     /// emitted (#6004). Same guardrail path as `executive_summary`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub security_summary: Option<String>,
+    /// Verified Authorship & Key-Person Risk narrative, or `None` when
+    /// rejected or never emitted (#5453, #6004). Same guardrail path as
+    /// `executive_summary`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorship_summary: Option<String>,
     /// Verified top-risk rows (rejected rows are dropped).
     #[serde(default)]
     pub top_risks: Vec<RiskRow>,
@@ -443,6 +448,9 @@ struct RawSynthesis {
     /// #6004: same schema/call/guardrail as `executive_summary`.
     #[serde(default)]
     security_summary: String,
+    /// #5453/#6004: same schema/call/guardrail as `executive_summary`.
+    #[serde(default)]
+    authorship_summary: String,
     #[serde(default)]
     top_risks: Vec<RiskRow>,
     #[serde(default)]
@@ -554,13 +562,14 @@ fn parse_markdown_fallback(text: &str) -> Option<RawSynthesis> {
     }
     Some(RawSynthesis {
         executive_summary: exec,
-        // #6004 fields are never recoverable from this free-text fallback —
-        // reconstructing them from prose would mean inventing content the
-        // model never structured; they stay empty and the guardrail leaves
-        // them absent from `Synthesis`, same honesty-marker path as an
-        // outright-rejected field.
+        // #6004/#5453 fields are never recoverable from this free-text
+        // fallback — reconstructing them from prose would mean inventing
+        // content the model never structured; they stay empty and the
+        // guardrail leaves them absent from `Synthesis`, same honesty-marker
+        // path as an outright-rejected field.
         code_quality_summary: String::new(),
         security_summary: String::new(),
+        authorship_summary: String::new(),
         top_risks: Vec::new(),
         findings: Vec::new(),
     })
@@ -659,6 +668,15 @@ fn apply_guardrail(
                 .push(format!("{REJECTED_NOTE} in security summary: {tok}")),
         }
     }
+    let authorship = raw.authorship_summary.trim();
+    if !authorship.is_empty() {
+        match verify_prose(authorship, allowed) {
+            Ok(()) => out.authorship_summary = Some(authorship.to_string()),
+            Err(tok) => out
+                .notes
+                .push(format!("{REJECTED_NOTE} in authorship summary: {tok}")),
+        }
+    }
 
     // Top-risk rows.
     for (i, r) in raw.top_risks.into_iter().enumerate() {
@@ -701,6 +719,7 @@ fn apply_guardrail(
     if out.executive_summary.is_none()
         && out.code_quality_summary.is_none()
         && out.security_summary.is_none()
+        && out.authorship_summary.is_none()
         && out.top_risks.is_empty()
         && out.findings.is_empty()
     {

--- a/crates/trusty-review/src/report/synthesize_digest_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_digest_tests.rs
@@ -41,6 +41,7 @@ fn repo(slug: &str, findings: Vec<MetricFinding>) -> RepositoryReport {
             findings,
             ..Default::default()
         }),
+        authorship: None,
     }
 }
 

--- a/crates/trusty-review/src/report/synthesize_normalize.rs
+++ b/crates/trusty-review/src/report/synthesize_normalize.rs
@@ -44,10 +44,12 @@ type FieldTable = &'static [(&'static str, &'static [&'static str])];
 /// before `serde_json::from_value`, so a narrative slot absent from this
 /// table is silently dropped as "unrecognized" even though `RawSynthesis`
 /// and [`super::synthesize_prompt::synthesis_schema`] both declare it.
+/// #5453: `authorship_summary` joins the same list for the same reason.
 const TOP_LEVEL_FIELDS: FieldTable = &[
     ("executive_summary", &[]),
     ("code_quality_summary", &[]),
     ("security_summary", &[]),
+    ("authorship_summary", &[]),
     ("top_risks", &[]),
     ("findings", &[]),
 ];

--- a/crates/trusty-review/src/report/synthesize_prompt.rs
+++ b/crates/trusty-review/src/report/synthesize_prompt.rs
@@ -38,7 +38,8 @@
 use crate::llm::{ChatMessage, LlmRequest, ResponseSchema, strip_provider_prefix};
 use crate::report::model::ReportModel;
 use crate::report::section_instructions::{
-    self, CODE_QUALITY_SUMMARY, EXECUTIVE_SUMMARY, FINDING_ELABORATION, SECURITY_SUMMARY, TOP_RISKS,
+    self, AUTHORSHIP_SUMMARY, CODE_QUALITY_SUMMARY, EXECUTIVE_SUMMARY, FINDING_ELABORATION,
+    SECURITY_SUMMARY, TOP_RISKS,
 };
 use crate::report::synthesize_digest::{
     build_split, gather_compact_findings, render_context_section, render_elaboration_section,
@@ -97,6 +98,11 @@ pub(crate) fn synthesis_schema(top_risks_cap: usize) -> ResponseSchema {
                 "security_summary": {
                     "type": "string",
                     "description": "ONE paragraph characterising security posture from the lint-graded RED/AMBER findings ONLY — this is code-hygiene signal, not a SAST/CVE/secrets scan. Empty string if the data supports nothing."
+                },
+                // #5453/#6004: high-level authorship/key-person-risk narrative slot.
+                "authorship_summary": {
+                    "type": "string",
+                    "description": "ONE high-level paragraph on codebase health from an authorship perspective — trailing-12-month trajectory and key-person risk, grounded ONLY in the bus-factor/concentration/trajectory data provided. Not a data dump. Empty string if the data supports nothing."
                 },
                 "top_risks": {
                     "type": "array",
@@ -262,6 +268,11 @@ fn synthesis_system_prompt(
         .get(SECURITY_SUMMARY)
         .map(String::as_str)
         .unwrap_or_default();
+    // #5453/#6004: the high-level authorship/key-person-risk narrative slot.
+    let authorship = resolved
+        .get(AUTHORSHIP_SUMMARY)
+        .map(String::as_str)
+        .unwrap_or_default();
 
     let mut prompt = format!(
         r#"You are a senior technical due-diligence analyst writing the narrative sections of an acquisition-grade report from pre-computed repository analysis data.
@@ -291,7 +302,8 @@ Populate the structured response:
 - `top_risks`: {risks}
 - `findings`: {elaboration}
 - `code_quality_summary`: {code_quality}
-- `security_summary`: {security}"#
+- `security_summary`: {security}
+- `authorship_summary`: {authorship}"#
     );
 
     if retry_concise {
@@ -392,6 +404,28 @@ fn build_digest(model: &ReportModel) -> String {
             ));
         } else {
             msg.push_str("- No metrics available for this application.\n");
+        }
+        // #5453/#6004: the authorship_summary slot has no other route to real
+        // data — model.ticketing's precedent plumbs a figure to the TEMPLATE
+        // but never the PROMPT (issue #5453), which starves the narrative of
+        // anything to ground itself in. Fed here, not into the findings
+        // digest, since it is its own section, not a Top-Risks input.
+        if let Some(a) = &repo.authorship {
+            msg.push_str(&format!(
+                "- Authorship: {} distinct author(s), bus factor {}, top author {:.0}% of \
+                 touches, single-author subsystems: {}\n",
+                a.distinct_authors,
+                a.bus_factor,
+                a.top_author_share_pct,
+                if a.single_author_subsystems.is_empty() {
+                    "none".to_string()
+                } else {
+                    a.single_author_subsystems.join(", ")
+                }
+            ));
+            if let Some(trend) = a.trajectory_summary() {
+                msg.push_str(&format!("- Authorship trajectory: {trend}\n"));
+            }
         }
         msg.push('\n');
     }

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -173,6 +173,7 @@ fn fixture_model(findings: Vec<MetricFinding>) -> ReportModel {
             local_path: None,
             scan: None,
             metrics: Some(metrics),
+            authorship: None,
         }],
         gaps: Vec::new(),
         synthesis: None,
@@ -303,6 +304,8 @@ fn synthesis_schema_shape() {
     // schema value as executive_summary.
     assert!(props["code_quality_summary"].is_object());
     assert!(props["security_summary"].is_object());
+    // #5453: same for the authorship narrative slot.
+    assert!(props["authorship_summary"].is_object());
     assert!(props["top_risks"].is_object());
     assert!(props["findings"].is_object());
     assert_eq!(props["top_risks"]["maxItems"], 5);
@@ -330,6 +333,8 @@ fn schema_contract_statement_lists_every_field_name() {
         // value, so these must be named alongside executive_summary.
         "code_quality_summary",
         "security_summary",
+        // #5453: same for the authorship narrative slot.
+        "authorship_summary",
         "top_risks",
         "findings",
         "description",
@@ -366,6 +371,8 @@ fn schema_contract_statement_reaches_system_prompt() {
     // system prompt text, not just `response_format`.
     assert!(req.system.contains("code_quality_summary"));
     assert!(req.system.contains("security_summary"));
+    // #5453: same for the authorship narrative slot.
+    assert!(req.system.contains("authorship_summary"));
     assert!(req.system.contains("top_risks"));
     assert!(req.system.contains("findings"));
 }
@@ -526,13 +533,15 @@ async fn synthesize_happy_path_injects() {
 }
 
 /// Why: regression for the rebase seam between #6009/#6014's whitelist
-/// normalizer and #6004's two new narrative slots — a normalizer whitelist
-/// keyed only off the pre-#6004 field set silently drops
-/// `code_quality_summary`/`security_summary` as "unrecognized" even though
-/// both the schema and `RawSynthesis` declare them.
-/// What: a full-shape response carrying both new fields, grounded in figures
-/// present in the fixture model; asserts both survive parse → normalize →
-/// guardrail into `Synthesis`, and that no drop note was recorded for either.
+/// normalizer and the three narrative slots #6004/#5453 added on top of it —
+/// a normalizer whitelist keyed only off the pre-#6004 field set silently
+/// drops `code_quality_summary`/`security_summary`/`authorship_summary` as
+/// "unrecognized" even though both the schema and `RawSynthesis` declare
+/// them.
+/// What: a full-shape response carrying all three new fields, grounded in
+/// figures present in the fixture model; asserts each survives parse →
+/// normalize → guardrail into `Synthesis`, and that no drop note was
+/// recorded for any of them.
 /// Test: this test itself.
 #[tokio::test]
 async fn synthesize_happy_path_injects_new_narrative_fields() {
@@ -541,6 +550,7 @@ async fn synthesize_happy_path_injects_new_narrative_fields() {
       "executive_summary": "The 8,200 LoC Rust codebase spans 120 files and 640 functions with one critical security gap.",
       "code_quality_summary": "The 8,200 LoC codebase spans 120 files, a moderate footprint.",
       "security_summary": "640 functions were assessed; one RED finding stands out.",
+      "authorship_summary": "120 files were assessed for authorship concentration.",
       "top_risks": [],
       "findings": []
     }"#
@@ -562,9 +572,13 @@ async fn synthesize_happy_path_injects_new_narrative_fields() {
         result.security_summary.as_deref(),
         Some("640 functions were assessed; one RED finding stands out.")
     );
+    assert_eq!(
+        result.authorship_summary.as_deref(),
+        Some("120 files were assessed for authorship concentration.")
+    );
     assert!(
         result.notes.is_empty(),
-        "neither new field is unrecognized or unverified: {:?}",
+        "none of the three new fields is unrecognized or unverified: {:?}",
         result.notes
     );
 }
@@ -767,6 +781,7 @@ fn code_quality_summary_guardrail_rejects_unverified_figure() {
         executive_summary: String::new(),
         code_quality_summary: "Complexity sits at 9999 on average.".to_string(),
         security_summary: String::new(),
+        authorship_summary: String::new(),
         top_risks: vec![super::RiskRow {
             description: "moderate".to_string(),
             severity: "AMBER".to_string(),
@@ -916,6 +931,7 @@ fn status_lines_render_banners() {
     let syn = Synthesis {
         code_quality_summary: None,
         security_summary: None,
+        authorship_summary: None,
         notes: vec!["synthesis: rejected (unverified figure) in top-risk row 1: 42".to_string()],
         ..Default::default()
     };
@@ -979,10 +995,10 @@ async fn synthesize_recovers_executive_summary_from_markdown_fallback() {
         result.findings.is_empty(),
         "prose is never reconstructed into findings"
     );
-    // #6004: the markdown fallback recovers executive_summary ONLY — the two
-    // new narrative slots are absent from this response shape entirely, so
-    // they stay `None` (the reporter's honesty-marker path), same as
-    // top_risks/findings above.
+    // #6004/#5453: the markdown fallback recovers executive_summary ONLY —
+    // the three new narrative slots are absent from this response shape
+    // entirely, so they stay `None` (the reporter's honesty-marker path),
+    // same as top_risks/findings above.
     assert!(
         result.code_quality_summary.is_none(),
         "the markdown fallback never recovers code_quality_summary"
@@ -990,6 +1006,10 @@ async fn synthesize_recovers_executive_summary_from_markdown_fallback() {
     assert!(
         result.security_summary.is_none(),
         "the markdown fallback never recovers security_summary"
+    );
+    assert!(
+        result.authorship_summary.is_none(),
+        "the markdown fallback never recovers authorship_summary"
     );
     assert!(
         result.notes.is_empty(),

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -490,6 +490,70 @@ fn system_prompt_asks_for_unregistered_target_gaps() {
     );
 }
 
+/// Why (#5453/#6004): the `authorship_summary` slot asks the model for a
+/// key-person narrative, and the ONLY route real ownership figures take into
+/// the prompt is the per-repository digest block. Every other fixture leaves
+/// `authorship: None`, so nothing proved the wiring — a regression that dropped
+/// it would leave the model writing that section from no data at all, which is
+/// exactly the ungrounded prose the guardrail exists to reject.
+/// What: attaches a loaded artifact to the fixture repository and asserts the
+/// digest carries the ownership figures and the trajectory line; then asserts a
+/// repository WITHOUT an artifact contributes neither, so the absence is a real
+/// absence rather than a zeroed row.
+/// Test: this test itself.
+#[test]
+fn authorship_figures_reach_the_synthesis_prompt() {
+    use crate::report::authorship::{AuthorshipSummary, MonthlyActivity};
+
+    let mut model = fixture_model(vec![]);
+    model.repositories[0].authorship = Some(AuthorshipSummary {
+        schema_version: "v0".to_string(),
+        repository: "acme-core".to_string(),
+        distinct_authors: 4,
+        bus_factor: 1,
+        top_author_share_pct: 71.0,
+        single_author_subsystems: vec!["migrations".to_string()],
+        monthly_trajectory: vec![
+            MonthlyActivity {
+                month: "2026-01".to_string(),
+                active_authors: 2,
+                commits: 4,
+            },
+            MonthlyActivity {
+                month: "2026-02".to_string(),
+                active_authors: 3,
+                commits: 20,
+            },
+        ],
+        unresolved_authors: 0,
+        caveats: vec![],
+    });
+
+    let req = build_synthesis_prompt(&model, "stub/model", false);
+    let digest = &req.messages[0].content;
+    assert!(
+        digest.contains("Authorship:"),
+        "the ownership figures must reach the prompt: {digest}"
+    );
+    for needle in ["4 distinct author(s)", "bus factor 1", "migrations"] {
+        assert!(
+            digest.contains(needle),
+            "the digest must carry {needle:?}: {digest}"
+        );
+    }
+    assert!(
+        digest.contains("Authorship trajectory: increasing"),
+        "the trailing-window trend must reach the prompt too: {digest}"
+    );
+
+    let without = build_synthesis_prompt(&fixture_model(vec![]), "stub/model", false);
+    assert!(
+        !without.messages[0].content.contains("Authorship:"),
+        "a repository with no artifact must contribute no authorship line at all: {}",
+        without.messages[0].content
+    );
+}
+
 // ── Synthesize: happy path + fail-closed paths ──────────────────────────────
 
 fn good_response() -> String {
@@ -826,6 +890,7 @@ fn security_summary_guardrail_rejects_unverified_figure() {
         executive_summary: String::new(),
         code_quality_summary: String::new(),
         security_summary: "9999 vulnerable dependencies were flagged.".to_string(),
+        authorship_summary: String::new(),
         top_risks: vec![super::RiskRow {
             description: "moderate".to_string(),
             severity: "AMBER".to_string(),

--- a/crates/trusty-review/templates/report-technical-dd.md
+++ b/crates/trusty-review/templates/report-technical-dd.md
@@ -246,6 +246,29 @@ evidence the codebase has been screened for exploitable vulnerabilities.*
 
 {{performance_assessment_note}}
 
+## Authorship & Key-Person Risk
+
+<!-- #5453/#6004: derivation lives in tga, never here (#5468 ruling). Key-man
+     risks render IN this section — bus factor, ownership concentration,
+     single-author subsystems — never scattered across Top Risks. Five known
+     data traps (issue #5453): bot commits and merge commits are excluded by
+     the derivation; squash-merge attribution, missing .mailmap identity
+     merging, and vendored-path exclusion are NOT corrected for and are
+     caveated below verbatim. A repository whose artifact failed to load
+     contributes no row here — its own gap line names the omission under
+     Gaps & Caveats, never a silently absent section. -->
+
+{{authorship_summary_paragraph}}
+
+<!-- High-level trailing-12-month development-trajectory narrative — codebase
+     health from an authorship perspective, not a data dump. -->
+
+| Application | Distinct authors | Bus factor | Top author share | Single-author subsystems | 12-mo trajectory |
+|---|---|---|---|---|---|<!-- BEGIN authorship_row -->
+| {{au_app_name}} | {{au_distinct_authors}} | {{au_bus_factor}} | {{au_top_author_share}} | {{au_single_author_subsystems}} | {{au_trajectory}} |<!-- END authorship_row -->
+
+{{au_caveats}}
+
 ## 6. Risk Registers
 
 ### 6.1 Open-Source / CVE Exposure


### PR DESCRIPTION
Refs #5453 (do NOT write "Closes" — per the issue lifecycle in CLAUDE.md the issue closes only after live verification; it moves to `status:merged` on merge). Prior art: #6004, #6015.

Adds the Authorship & Key-Person Risk section to the acquisition DD report: a per-repository authorship artifact derived in tga (bot and merge-commit exclusion; identities resolved through the existing author_id → canonical_email resolver with an `unresolved_authors` honesty count) and a trusty-review report section + synthesis-prompt wiring. Failure paths are named gaps, never silent: an unreadable artifact, a missing file, and a repo-name that matches no commits each produce distinct gap text (the no-match case names the recorded repository names). Vendored-path filtering is deferred with a disclosed caveat (owner decision pending on #5453).

Test ladder rung 4 (cross-crate: tga library, trusty-review consumer): `cargo fmt --check` · `cargo check --workspace` · `cargo clippy -p tga -p trusty-review --all-targets -- -D warnings` · `cargo test -p tga` → 1332 passed · `cargo test -p trusty-review` → 1670 passed. Two code-critic rounds: BLOCK (five findings) → all fixed with red-before-green proof → APPROVE with spot-reverted verification. Credential scan clean. Known pre-existing red not from this branch: three rustdoc intra-doc links broken by main commits c73cf71c6/4a57a9727/a554b0f9c (not a required check).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools