### PR TITLE
fix(trusty-review): Key Facts reads the scan, and the executive summary describes the codebase

### DIFF
--- a/crates/trusty-review/changelog.d/6029-key-facts-reads-scan.md
+++ b/crates/trusty-review/changelog.d/6029-key-facts-reads-scan.md
@@ -1,0 +1,13 @@
+Fixed
+
+- The report's Key Facts block no longer renders "No data available" while the
+  sweep holds the numbers (#6029). It read only a `--analyze` metrics file, so
+  an ordinary run — which always produces a repository scan — left every
+  density row empty and the polish pass collapsed the whole block; one real
+  engagement showed that line above a scan that had measured 1.5M LoC. LoC,
+  file count, and languages now take the same metrics-then-scan precedence the
+  per-application Profile table already used. A row whose input is genuinely
+  absent states which input is missing — complexity names `--analyze`, author
+  count and trajectory name the tga authorship artifact, and the work estimate
+  names the upstream effort metric that does not exist yet — instead of
+  dropping out of the table and blanking the rows around it.

--- a/crates/trusty-review/changelog.d/6030-exec-summary-describes-the-codebase.md
+++ b/crates/trusty-review/changelog.d/6030-exec-summary-describes-the-codebase.md
@@ -1,0 +1,13 @@
+Changed
+
+- The synthesized executive summary now describes what the audited codebase is
+  and does, and analyzes its major components, before covering risk (#6030) —
+  it was risk-only. The instruction is static in the synthesis system prompt,
+  like #5886's coverage-gaps note, so a template that overrides the
+  `executive_summary` section instruction cannot drop it; the forced-output
+  schema states the same requirement. The synthesis digest now also carries
+  each application's repository-scan profile — LoC, languages, file count, and
+  the detected build manifests with their declared project names and top
+  dependencies — so the component analysis is grounded in real data rather
+  than invented. Before this, a run without `--analyze` sent the model "No
+  metrics available for this application" while the scan held all of it.

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -235,7 +235,9 @@ fn build_scope(model: &ReportModel) -> Scope {
     // trajectory facts ahead of the executive summary.
     fill_key_facts(&mut root, model);
     // #5453/#6004: completes the author-count/trajectory rows PR A left as
-    // named gaps, once a repository's authorship artifact loaded.
+    // named gaps, once a repository's authorship artifact loaded. Must run
+    // AFTER `fill_key_facts`, which seeds those rows with gap text (#6029) —
+    // pinned by `reporter_tests::key_facts_authorship_rows_survive_the_fill_order`.
     fill_authorship_facts(&mut root, model);
     // #6004: deterministic structure, never data — always set.
     contents_links::set_contents_placeholder(&mut root);

--- a/crates/trusty-review/src/report/reporter_facts.rs
+++ b/crates/trusty-review/src/report/reporter_facts.rs
@@ -10,38 +10,54 @@
 //! than duplicating it.
 //! What: [`fill_key_facts`] sets the `facts_*` scalars on the root [`Scope`]
 //! from data already loaded onto the model (LoC, file counts, languages,
-//! complexity distribution — all from `AnalyzeMetrics`, re-aggregated across
-//! every repository). Author count, work-volume estimate, and monthly
-//! trajectory are PR B's authorship-artifact fields (#5453) — left unset here
-//! so each renders as the honesty marker and surfaces its own line under
-//! Gaps & Caveats until that data exists, per the omit-empty row rule
-//! (`polish.rs::process_table`). tga has no effort-estimation metric today
-//! (verified: `story_points` fields are documented placeholders, always
-//! zero) — `facts_work_estimate` stays unset rather than inventing one.
+//! complexity distribution), re-aggregated across every repository. Density
+//! rows take the same source precedence `reporter_fill::fill_profile` uses —
+//! `AnalyzeMetrics` when a `--analyze` run supplied it, else the built-in
+//! `RepoScan` every model build produces (#6029). Complexity has no scan
+//! equivalent, and author count / work estimate / trajectory come from tga's
+//! authorship artifact (#5453, completed by
+//! `reporter_authorship::fill_authorship_facts`); when any of those inputs is
+//! genuinely absent, its row states the named reason rather than dropping out
+//! of the table. tga has no effort-estimation metric today (verified:
+//! `story_points` fields are documented placeholders, always zero) — the work
+//! estimate is a named gap in every run rather than an invented figure.
 //! Test: `reporter_facts_tests.rs`.
 
 use super::fill::Scope;
-use super::model::ReportModel;
+use super::metrics::LanguageLoc;
+use super::model::{ReportModel, RepositoryReport};
 use super::provenance::{Provenance, tag};
+
+// #6029: a genuinely absent input states WHY it is absent, in its own row.
+// Before this, every such row rendered the honesty marker, the omit-empty pass
+// dropped all of them, and an empty table collapsed the whole Key Facts block
+// to `_No data available — see Gaps & Caveats._` — even in a run whose scan
+// had measured 1.5M LoC that never reached the block at all.
+
+/// The complexity row's text when no `--analyze` metrics reached this run.
+const GAP_COMPLEXITY: &str =
+    "Not computed — this run carried no trusty-analyze metrics; re-run with `--analyze`";
+/// The author-count and trajectory rows' text when no authorship artifact loaded.
+const GAP_AUTHORSHIP: &str = "Not computed — this run carried no tga authorship artifact";
+/// The work-estimate row's text; no upstream effort metric exists yet.
+const GAP_WORK_ESTIMATE: &str = "Not computed — no upstream effort-estimation metric exists";
 
 /// Fill the Key Facts scalars from data already on `model`.
 ///
 /// Why: single entry point `reporter::build_scope` calls; keeps the
 /// aggregation logic out of `reporter.rs` (SLOC pressure — see its module
 /// doc) and testable in isolation.
-/// What: sums LoC/file counts across every repository with metrics, ranks
-/// languages by aggregate LoC, and re-projects the merged complexity
-/// distribution as a compact percentage summary. Each scalar is set only
-/// when the underlying data is non-empty, so an all-remote or metrics-free
-/// manifest leaves every row as a named gap rather than a stated zero.
-/// Test: `reporter_facts_tests::{fills_aggregate_facts, empty_model_is_all_gaps}`.
+/// What: sums LoC/file counts across every repository and ranks languages by
+/// aggregate LoC, reading each repository's `AnalyzeMetrics` when present and
+/// falling back to its `RepoScan` otherwise (#6029); then re-projects the
+/// merged complexity distribution as a compact percentage summary. A density
+/// scalar is set only when the underlying data is non-empty, so an all-remote
+/// manifest states no figure rather than a fabricated zero — but it then
+/// states the named reason instead, never a blank row.
+/// Test: `reporter_facts_tests::{fills_aggregate_facts,
+/// scan_only_model_fills_density_facts, empty_model_is_all_gaps}`.
 pub fn fill_key_facts(root: &mut Scope, model: &ReportModel) {
-    let total_loc: u64 = model
-        .repositories
-        .iter()
-        .filter_map(|r| r.metrics.as_ref())
-        .map(|m| m.loc.total)
-        .sum();
+    let total_loc: u64 = model.repositories.iter().map(repo_loc).sum();
     if total_loc > 0 {
         root.set(
             "facts_total_loc",
@@ -49,12 +65,7 @@ pub fn fill_key_facts(root: &mut Scope, model: &ReportModel) {
         );
     }
 
-    let total_files: u64 = model
-        .repositories
-        .iter()
-        .filter_map(|r| r.metrics.as_ref())
-        .map(|m| m.counts.files)
-        .sum();
+    let total_files: u64 = model.repositories.iter().map(repo_files).sum();
     if total_files > 0 {
         root.set(
             "facts_total_files",
@@ -70,27 +81,84 @@ pub fn fill_key_facts(root: &mut Scope, model: &ReportModel) {
         );
     }
 
-    if let Some(summary) = complexity_profile(model) {
-        root.set(
+    match complexity_profile(model) {
+        Some(summary) => root.set(
             "facts_complexity_summary",
             tag(summary, Provenance::Measured),
-        );
+        ),
+        // #6029: the complexity row names its missing input instead of
+        // vanishing — the scan has no complexity equivalent to fall back to.
+        None => root.set(
+            "facts_complexity_summary",
+            tag(GAP_COMPLEXITY, Provenance::NotStated),
+        ),
     }
 
-    // #5453: facts_author_count / facts_work_estimate / facts_trajectory are
-    // intentionally left unset in PR A — see module doc. PR B's authorship
-    // artifact completes them.
+    // #6029: authorship rows state their named gap here; when a repository's
+    // artifact did load, `reporter_authorship::fill_authorship_facts` runs
+    // next and overwrites both with the real figures.
+    root.set(
+        "facts_author_count",
+        tag(GAP_AUTHORSHIP, Provenance::NotStated),
+    );
+    root.set(
+        "facts_trajectory",
+        tag(GAP_AUTHORSHIP, Provenance::NotStated),
+    );
+    root.set(
+        "facts_work_estimate",
+        tag(GAP_WORK_ESTIMATE, Provenance::NotStated),
+    );
 }
 
-/// The top 5 languages by aggregate LoC across every repository with metrics.
+/// This repository's total LoC — declared metrics first, else the repo scan.
+///
+/// Why: `RepoScan` is produced on every model build while `AnalyzeMetrics`
+/// arrives only from a `--analyze` run, so reading metrics alone left the
+/// whole Key Facts block empty on an ordinary sweep (#6029). The precedence
+/// mirrors `reporter_fill::fill_profile`, which already made this choice for
+/// the per-application Profile table.
+/// What: `0` when neither source carries a positive figure.
+/// Test: `reporter_facts_tests::{scan_only_model_fills_density_facts,
+/// metrics_win_over_scan_in_key_facts}`.
+fn repo_loc(repo: &RepositoryReport) -> u64 {
+    repo.metrics
+        .as_ref()
+        .map(|m| m.loc.total)
+        .filter(|n| *n > 0)
+        .or_else(|| repo.scan.as_ref().map(|s| s.total_loc).filter(|n| *n > 0))
+        .unwrap_or(0)
+}
+
+/// This repository's tracked file count, with the same precedence as [`repo_loc`].
+fn repo_files(repo: &RepositoryReport) -> u64 {
+    repo.metrics
+        .as_ref()
+        .map(|m| m.counts.files)
+        .filter(|n| *n > 0)
+        .or_else(|| repo.scan.as_ref().map(|s| s.file_count).filter(|n| *n > 0))
+        .unwrap_or(0)
+}
+
+/// This repository's per-language LoC breakdown, with the same precedence.
+fn repo_languages(repo: &RepositoryReport) -> &[LanguageLoc] {
+    match repo
+        .metrics
+        .as_ref()
+        .filter(|m| !m.loc.by_language.is_empty())
+    {
+        Some(m) => &m.loc.by_language,
+        None => repo.scan.as_ref().map_or(&[], |s| &s.by_language),
+    }
+}
+
+/// The top 5 languages by aggregate LoC across every repository.
 fn aggregate_languages(model: &ReportModel) -> Vec<String> {
     let mut totals: Vec<(String, u64)> = Vec::new();
-    for m in model.repositories.iter().filter_map(|r| r.metrics.as_ref()) {
-        for lang in &m.loc.by_language {
-            match totals.iter_mut().find(|(name, _)| *name == lang.language) {
-                Some(entry) => entry.1 += lang.loc,
-                None => totals.push((lang.language.clone(), lang.loc)),
-            }
+    for lang in model.repositories.iter().flat_map(repo_languages) {
+        match totals.iter_mut().find(|(name, _)| *name == lang.language) {
+            Some(entry) => entry.1 += lang.loc,
+            None => totals.push((lang.language.clone(), lang.loc)),
         }
     }
     totals.sort_by_key(|(_, loc)| std::cmp::Reverse(*loc));

--- a/crates/trusty-review/src/report/reporter_facts_tests.rs
+++ b/crates/trusty-review/src/report/reporter_facts_tests.rs
@@ -1,10 +1,15 @@
 use super::*;
 use crate::report::metrics::{
-    AnalyzeMetrics, ComplexityBucket, ComplexityDistribution, CountMetrics, LanguageLoc, LocMetrics,
+    AnalyzeMetrics, ComplexityBucket, ComplexityDistribution, CountMetrics, LocMetrics,
 };
 use crate::report::model::RepositoryReport;
+use crate::report::scan::RepoScan;
 
 fn repo(metrics: Option<AnalyzeMetrics>) -> RepositoryReport {
+    repo_with(metrics, None)
+}
+
+fn repo_with(metrics: Option<AnalyzeMetrics>, scan: Option<RepoScan>) -> RepositoryReport {
     RepositoryReport {
         name: "app".to_string(),
         slug: "app".to_string(),
@@ -14,9 +19,16 @@ fn repo(metrics: Option<AnalyzeMetrics>) -> RepositoryReport {
         git_ref: None,
         git_info: None,
         local_path: None,
-        scan: None,
+        scan,
         metrics,
         authorship: None,
+    }
+}
+
+fn lang(name: &str, loc: u64) -> LanguageLoc {
+    LanguageLoc {
+        language: name.to_string(),
+        loc,
     }
 }
 
@@ -95,21 +107,100 @@ fn fills_aggregate_facts() {
     assert!(!rendered.contains("facts_author_count"));
 }
 
-/// (b)-style: a model with no metrics produces honesty markers, never
-/// fabricated values — every `facts_*` scalar stays unset.
+/// (b)-style: a model with neither metrics nor scan never fabricates a
+/// density figure — the three density rows stay unset, and the rows whose
+/// input is genuinely absent name that input instead of blanking (#6029).
 #[test]
 fn empty_model_is_all_gaps() {
     let model = model_with(vec![repo(None)]);
     let mut scope = Scope::new();
     fill_key_facts(&mut scope, &model);
-    let rendered = crate::report::fill::render(
-        "{{facts_total_loc}}|{{facts_total_files}}|{{facts_languages}}|{{facts_complexity_summary}}",
+    let density = crate::report::fill::render(
+        "{{facts_total_loc}}|{{facts_total_files}}|{{facts_languages}}",
         &scope,
     );
     assert_eq!(
-        rendered,
-        format!("{h}|{h}|{h}|{h}", h = crate::report::fill::HONESTY_MARKER)
+        density,
+        format!("{h}|{h}|{h}", h = crate::report::fill::HONESTY_MARKER)
     );
+
+    let named = crate::report::fill::render(
+        "{{facts_complexity_summary}}|{{facts_author_count}}|{{facts_work_estimate}}|{{facts_trajectory}}",
+        &scope,
+    );
+    assert!(named.contains("--analyze"), "{named}");
+    assert_eq!(named.matches("authorship artifact").count(), 2, "{named}");
+    assert!(named.contains("effort-estimation"), "{named}");
+    assert!(
+        !named.contains(crate::report::fill::HONESTY_MARKER),
+        "a genuinely absent input must name itself, never blank: {named}"
+    );
+}
+
+/// #6029 regression: a sweep with no `--analyze` still carries `RepoScan`
+/// data on every repository, and the Key Facts block must render that LoC
+/// figure. Before the fix `fill_key_facts` read `metrics` alone, every row
+/// fell to the honesty marker, and the omit-empty pass collapsed the whole
+/// block to `_No data available — see Gaps & Caveats._` while the scan held
+/// the number.
+#[test]
+fn scan_only_model_fills_density_facts() {
+    let scan = RepoScan {
+        total_loc: 1_500_000,
+        file_count: 8_432,
+        by_language: vec![lang("Rust", 1_400_000), lang("TypeScript", 100_000)],
+        frameworks: vec![],
+    };
+    let model = model_with(vec![repo_with(None, Some(scan))]);
+
+    let mut scope = Scope::new();
+    fill_key_facts(&mut scope, &model);
+    let rendered = crate::report::fill::render(
+        "{{facts_total_loc}}|{{facts_total_files}}|{{facts_languages}}",
+        &scope,
+    );
+
+    assert!(rendered.contains("1500000"), "{rendered}");
+    assert!(rendered.contains("8432"), "{rendered}");
+    assert!(rendered.contains("Rust"), "{rendered}");
+    assert!(
+        !rendered.contains(crate::report::fill::HONESTY_MARKER),
+        "scan data must reach every density row: {rendered}"
+    );
+}
+
+/// A `--analyze` figure wins over the scan's for the same repository, the
+/// precedence `reporter_fill::fill_profile` already established.
+#[test]
+fn metrics_win_over_scan_in_key_facts() {
+    let metrics = AnalyzeMetrics {
+        loc: LocMetrics {
+            total: 900,
+            by_language: vec![lang("Rust", 900)],
+        },
+        counts: CountMetrics {
+            files: 9,
+            functions: 90,
+        },
+        ..Default::default()
+    };
+    let scan = RepoScan {
+        total_loc: 111,
+        file_count: 1,
+        by_language: vec![lang("Shell", 111)],
+        frameworks: vec![],
+    };
+    let model = model_with(vec![repo_with(Some(metrics), Some(scan))]);
+
+    let mut scope = Scope::new();
+    fill_key_facts(&mut scope, &model);
+    let rendered = crate::report::fill::render(
+        "{{facts_total_loc}}|{{facts_total_files}}|{{facts_languages}}",
+        &scope,
+    );
+    assert!(rendered.contains("900"), "{rendered}");
+    assert!(!rendered.contains("111"), "{rendered}");
+    assert!(!rendered.contains("Shell"), "{rendered}");
 }
 
 /// Complexity buckets with the same label across repositories merge counts

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -2213,3 +2213,60 @@ fn cast_reporter_states_a_zero_coverage_run_rather_than_omitting_it() {
 fn a_missing_ticketing_artifact_is_named_in_the_cast_template_too() {
     assert_template_names_a_missing_ticketing_artifact("report-technical-dd-cast");
 }
+
+/// #6029 regression: a sweep run WITHOUT `--analyze` carries no
+/// `AnalyzeMetrics`, but `RepoScan` is built on every model build — and the
+/// rendered Key Facts block must show that LoC figure. Before the fix
+/// `fill_key_facts` read `metrics` alone, so every row fell to the honesty
+/// marker, the omit-empty pass dropped all of them, and the polish pass
+/// collapsed the whole block to `_No data available — see Gaps & Caveats._`
+/// while the scan held 1.5M LoC. Assert the heading, the figure, and the
+/// absence of the collapse line together — the figure alone would pass on a
+/// report that had also dropped the heading.
+#[test]
+fn key_facts_renders_scan_loc_without_analyze_metrics() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut model = fixture_model(tmp.path());
+    // Reproduce the no-`--analyze` shape: scan data present, metrics absent.
+    let repo = model.repositories.first_mut().expect("one repository");
+    repo.metrics = None;
+    repo.scan = Some(crate::report::scan::RepoScan {
+        total_loc: 1_500_000,
+        file_count: 8_432,
+        by_language: vec![crate::report::metrics::LanguageLoc {
+            language: "Rust".to_string(),
+            loc: 1_500_000,
+        }],
+        frameworks: vec![],
+    });
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(md.contains("## Key Facts"), "{md}");
+    let section = md.split("## Key Facts").nth(1).expect("key facts body");
+    let block = section.split("## 2.").next().expect("block before §2");
+    assert!(
+        block.contains("1500000"),
+        "the scan's LoC figure must reach Key Facts:\n{block}"
+    );
+    assert!(
+        block.contains("8432"),
+        "the scan's file count must reach Key Facts:\n{block}"
+    );
+    assert!(
+        !block.contains("No data available"),
+        "Key Facts must never collapse while the sweep holds data:\n{block}"
+    );
+    // A genuinely absent input names itself in its own row rather than
+    // blanking the block around the data that IS present.
+    assert!(
+        block.contains("--analyze"),
+        "the complexity row must name its missing input:\n{block}"
+    );
+    assert!(
+        block.contains("authorship artifact"),
+        "the author rows must name their missing input:\n{block}"
+    );
+}

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -2270,3 +2270,76 @@ fn key_facts_renders_scan_loc_without_analyze_metrics() {
         "the author rows must name their missing input:\n{block}"
     );
 }
+
+/// #6029 regression: `fill_key_facts` writes named-gap text into
+/// `facts_author_count`/`facts_trajectory` unconditionally, so the measured
+/// figures reach the report only because `reporter::build_scope` runs
+/// `fill_authorship_facts` AFTER it (reporter.rs:236, 239). Nothing else in the
+/// suite exercises both together — `completes_key_facts_author_rows` calls
+/// `fill_authorship_facts` alone, and no other full-render test loads an
+/// authorship artifact — so swapping the two calls would clobber measured
+/// authorship data with "Not computed" and leave every test green. This renders
+/// the whole report with an artifact loaded and asserts the measured figures
+/// win in the Key Facts table.
+#[test]
+fn key_facts_authorship_rows_survive_the_fill_order() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut model = fixture_model(tmp.path());
+    let repo = model.repositories.first_mut().expect("one repository");
+    repo.authorship = Some(crate::report::authorship::AuthorshipSummary {
+        schema_version: "v0".to_string(),
+        repository: "Acme Web".to_string(),
+        distinct_authors: 7,
+        bus_factor: 2,
+        top_author_share_pct: 61.0,
+        single_author_subsystems: vec!["src".to_string()],
+        monthly_trajectory: vec![
+            crate::report::authorship::MonthlyActivity {
+                month: "2026-01".to_string(),
+                active_authors: 1,
+                commits: 5,
+            },
+            crate::report::authorship::MonthlyActivity {
+                month: "2026-02".to_string(),
+                active_authors: 2,
+                commits: 40,
+            },
+        ],
+        unresolved_authors: 0,
+        caveats: vec![],
+    });
+
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    let section = md.split("## Key Facts").nth(1).expect("key facts body");
+    let block = section.split("## 2.").next().expect("block before §2");
+
+    let authors = block
+        .lines()
+        .find(|l| l.starts_with("| Number of authors |"))
+        .expect("author-count row");
+    assert!(
+        authors.contains('7'),
+        "the measured author count must win over the named gap:\n{authors}"
+    );
+    assert!(
+        !authors.contains("Not computed"),
+        "the named gap clobbered the measured author count:\n{authors}"
+    );
+
+    let trajectory = block
+        .lines()
+        .find(|l| l.starts_with("| 12-month trajectory |"))
+        .expect("trajectory row");
+    assert!(
+        trajectory.contains("increasing"),
+        "the measured trajectory must win over the named gap:\n{trajectory}"
+    );
+    assert!(
+        !trajectory.contains("Not computed"),
+        "the named gap clobbered the measured trajectory:\n{trajectory}"
+    );
+}

--- a/crates/trusty-review/src/report/section_instructions.rs
+++ b/crates/trusty-review/src/report/section_instructions.rs
@@ -68,12 +68,21 @@ pub fn default_instruction(id: &str) -> Option<&'static str> {
         // "acquirer-side, skeptical, strengths and risks presented evenhandedly
         // but risk hunted adversarially, never promotional." Applied to every
         // default below; a template's `instruct:` override may still replace it.
+        // #6030: open with what the system does and its major components,
+        // then the risk analysis — see the "What the codebase does" block in
+        // `synthesize_prompt::synthesis_system_prompt`, which restates this
+        // statically so a template override cannot drop the requirement.
         EXECUTIVE_SUMMARY => Some(
-            "Write ONE deal-analytic paragraph synthesising the verified findings, \
-             severity-weighted (RED findings first), tied to what an acquirer must act \
-             on. Write from the acquirer's side: skeptical and adversarial about risk — \
-             hunt for what should worry a buyer — while still naming genuine strengths \
-             the data supports, evenhandedly, never as promotional filler. Reference a \
+            "Open by describing what the audited codebase is and does, then name its \
+             major components and each one's role, drawn from the applications, build \
+             manifests, and dependencies in the data. Then close with a \
+             deal-analytic paragraph synthesising the verified findings, \
+             severity-weighted (RED findings first), tied to what an acquirer \
+             must act on. Keep the whole thing short — a few tight paragraphs, not a \
+             tour of the report. Write from the acquirer's side: skeptical and \
+             adversarial about risk — hunt for what should worry a buyer — while still \
+             naming genuine strengths the data supports, evenhandedly, never as \
+             promotional filler. Reference a \
              coverage gap ONLY if one is genuinely named in the coverage data above (a \
              listed not-investigated dimension or a named failed batch) — and name it \
              specifically; never imply a gap that isn't documented there.",

--- a/crates/trusty-review/src/report/synthesize_prompt.rs
+++ b/crates/trusty-review/src/report/synthesize_prompt.rs
@@ -85,9 +85,12 @@ pub(crate) fn synthesis_schema(top_risks_cap: usize) -> ResponseSchema {
         serde_json::json!({
             "type": "object",
             "properties": {
+                // #6030: the summary opens with what the system is and does and
+                // names its major components, then covers risk — see the
+                // "What the codebase does" block in `synthesis_system_prompt`.
                 "executive_summary": {
                     "type": "string",
-                    "description": "ONE deal-relevant paragraph synthesised across all applications. Use ONLY figures present in the provided data; never invent numbers; preserve any \"(approx)\" marker verbatim."
+                    "description": "A short deal-relevant executive summary synthesised across all applications: open by stating what the audited codebase IS and DOES, name its major components and each one's role, then cover the risk picture. Use ONLY figures present in the provided data; never invent numbers; preserve any \"(approx)\" marker verbatim."
                 },
                 // #6004: two additional narrative slots, same schema/call/guardrail as
                 // executive_summary — see synthesize.rs::apply_guardrail.
@@ -221,8 +224,9 @@ pub(crate) fn schema_contract_statement(schema: &serde_json::Value) -> String {
 /// template or analyst may steer — see [`section_instructions`] for the
 /// generic → template → analyst layering (the same shape as the crate's
 /// existing stock → principles → voice reviewer layering, see `src/voice/`).
-/// What: the "Absolute rules", "Required JSON object shape", and "Coverage
-/// gaps in the assessed set" blocks are static invariants; the "Required JSON
+/// What: the "Absolute rules", "Required JSON object shape", "What the
+/// codebase does", and "Coverage gaps in the assessed set" blocks are static
+/// invariants; the "Required JSON
 /// object shape" block is `contract` — [`schema_contract_statement`] run over
 /// the SAME [`synthesis_schema`] value this request forces via
 /// `response_format`, so the two can never say different things (#6009 shape
@@ -238,9 +242,15 @@ pub(crate) fn schema_contract_statement(schema: &serde_json::Value) -> String {
 /// go.  It is scoped to targets ABSENT from the assessed set, which is a
 /// different question from the per-repo dimension coverage that
 /// [`super::investigate::render::coverage_prompt_summary`] already mandates.
+///
+/// #6030's "What the codebase does" block is static for the same reason: the
+/// owner requires every executive summary to describe the product and analyze
+/// its major components, so a template `instruct:` override must not be able
+/// to drop that requirement while restyling the section.
 /// Test: `synthesize_tests.rs::{system_prompt_embeds_resolved_instructions,
 /// system_prompt_concise_retry_directive,
 /// system_prompt_asks_for_unregistered_target_gaps,
+/// system_prompt_asks_what_the_codebase_does,
 /// schema_contract_statement_reaches_system_prompt}`.
 fn synthesis_system_prompt(
     resolved: &std::collections::BTreeMap<String, String>,
@@ -289,6 +299,12 @@ Write from the acquirer's side: balanced but adversarial. Hunt for risk skeptica
 
 ## Required JSON object shape
 Respond with ONLY a single JSON object — no markdown headings, no prose outside it, no fenced code block. {contract}
+
+## What the codebase does
+- OPEN the executive summary by stating what the audited system IS and what it DOES — its purpose in plain product terms — before any risk sentence. A risk-only summary is incomplete.
+- Then analyze the major components: name each one and what its role in the system is. Draw them from the applications listed above and from the build manifests, frameworks, and declared dependencies the data names for each.
+- Ground both from the provided data ONLY — application names, detected manifests and frameworks, language mix, LoC, authorship figures. Where the data does not support a claim about purpose, describe what the components do and stop. Never invent a product, a market, a customer, or a component the data does not name.
+- Risk remains the summary's core. The purpose and component narrative sets up the risk discussion; it does not replace it.
 
 ## Coverage gaps in the assessed set
 - The applications listed under "Applications assessed" are the ENTIRE assessed set. When the data references a repository, service, database schema, or project board that is not one of them, name it in a short coverage-gaps note closing the executive summary.
@@ -360,6 +376,66 @@ pub(super) fn build_synthesis_prompt(
     }
 }
 
+/// One application's profile bullets for the digest — density plus the
+/// component grounding the executive summary is required to analyze (#6030).
+///
+/// Why: the "What the codebase does" instruction can only be obeyed from data
+/// in the prompt, and the build manifests, declared project names, and top
+/// dependencies the repository scan already detects ARE the component
+/// evidence. They reached the rendered Profile table
+/// (`reporter_fill::fill_profile`) but never the synthesis prompt.
+/// What: LoC and languages from `AnalyzeMetrics` when a `--analyze` run
+/// supplied it, else from `RepoScan`; file/function counts from whichever
+/// source carries them; and the scan's framework line rendered through
+/// `reporter_fill::format_frameworks`, so the prompt and the report state the
+/// same manifests. Returns an empty string when neither source has anything —
+/// the caller then says so rather than emitting a headed but empty block.
+/// Test: `synthesize_tests.rs::{digest_carries_scan_profile_without_metrics,
+/// digest_names_build_manifests_as_component_evidence}`.
+fn repo_profile_lines(repo: &super::model::RepositoryReport) -> String {
+    let metrics = repo.metrics.as_ref();
+    let scan = repo.scan.as_ref();
+    let mut out = String::new();
+
+    let loc = metrics
+        .map(|m| m.loc.total)
+        .filter(|n| *n > 0)
+        .or_else(|| scan.map(|s| s.total_loc).filter(|n| *n > 0));
+    if let Some(n) = loc {
+        out.push_str(&format!("- Total LoC: {n}\n"));
+    }
+
+    let langs = metrics
+        .map(|m| m.primary_languages(4))
+        .filter(|l| !l.is_empty())
+        .or_else(|| {
+            scan.map(|s| s.primary_languages(4))
+                .filter(|l| !l.is_empty())
+        });
+    if let Some(l) = langs {
+        out.push_str(&format!("- Primary languages: {}\n", l.join(", ")));
+    }
+
+    if let Some(m) = metrics {
+        out.push_str(&format!(
+            "- Files: {}; Functions: {}\n",
+            m.counts.files, m.counts.functions
+        ));
+    } else if let Some(s) = scan.filter(|s| s.file_count > 0) {
+        out.push_str(&format!("- Files: {}\n", s.file_count));
+    }
+
+    // #6030: the component evidence — which manifests exist, what project each
+    // declares, and its top declared dependencies.
+    if let Some(fw) = scan
+        .map(super::reporter_fill::format_frameworks)
+        .filter(|f| !f.is_empty())
+    {
+        out.push_str(&format!("- Build manifests / frameworks: {fw}\n"));
+    }
+    out
+}
+
 /// Build the user-message data digest — per-application profile numbers plus
 /// the COMPACT findings digest (#2357 follow-up; never the full prose).
 ///
@@ -368,12 +444,13 @@ pub(super) fn build_synthesis_prompt(
 /// impact/remediation prose that already lives in the report body once
 /// verified — that separation is what keeps this call's input AND output
 /// bounded regardless of how many findings exist.
-/// What: writes a report header, then per application its profile numbers
-/// (LoC, languages, files/functions — unchanged from before); then ONE
-/// combined compact-findings context section and ONE elaboration-targets
-/// section (see [`super::synthesize_digest`]); then the wave-3 coverage
-/// summary (unchanged) and the analyst focus directives (unchanged, additive
-/// on top of whichever section instructions are active).
+/// What: writes a report header, then per application its profile bullets
+/// (LoC, languages, files/functions, and the detected build manifests — see
+/// [`repo_profile_lines`]); then ONE combined compact-findings context
+/// section and ONE elaboration-targets section (see
+/// [`super::synthesize_digest`]); then the wave-3 coverage summary
+/// (unchanged) and the analyst focus directives (unchanged, additive on top
+/// of whichever section instructions are active).
 /// Test: `synthesize_tests.rs::{prompt_excludes_greens, digest_stays_bounded_at_100_findings}`.
 fn build_digest(model: &ReportModel) -> String {
     let mut msg = String::with_capacity(4096);
@@ -390,20 +467,16 @@ fn build_digest(model: &ReportModel) -> String {
 
     for repo in &model.repositories {
         msg.push_str(&format!("## {} (slug: {})\n", repo.name, repo.slug));
-        if let Some(m) = &repo.metrics {
-            if m.loc.total > 0 {
-                msg.push_str(&format!("- Total LoC: {}\n", m.loc.total));
-            }
-            let langs = m.primary_languages(4);
-            if !langs.is_empty() {
-                msg.push_str(&format!("- Primary languages: {}\n", langs.join(", ")));
-            }
-            msg.push_str(&format!(
-                "- Files: {}; Functions: {}\n",
-                m.counts.files, m.counts.functions
-            ));
-        } else {
+        // #6029/#6030: `metrics` arrives only from a `--analyze` run, but
+        // `scan` is built on every model build. Reading metrics alone printed
+        // "No metrics available" for an ordinary sweep, leaving the executive
+        // summary nothing to ground a purpose or component claim on. Same
+        // metrics-then-scan precedence as `reporter_fill::fill_profile`.
+        let profile = repo_profile_lines(repo);
+        if profile.is_empty() {
             msg.push_str("- No metrics available for this application.\n");
+        } else {
+            msg.push_str(&profile);
         }
         // #5453/#6004: the authorship_summary slot has no other route to real
         // data — model.ticketing's precedent plumbs a figure to the TEMPLATE

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -1407,3 +1407,112 @@ async fn synthesize_rejects_a_wholly_unrecognized_shape() {
         "expected NoVerifiableContent, got {err:?}"
     );
 }
+
+/// Why (#6030): the owner ruled that an executive summary "should describe
+/// what this codebase does (as well as analyze the major components)", and
+/// today's is risk-only. Like #5886's coverage-gaps note, this requirement is
+/// static rather than a section instruction, so a template `instruct:`
+/// override must not be able to drop it while restyling the section.
+/// What: overrides `executive_summary`, then asserts the purpose-and-
+/// components instruction still reaches the system prompt, and that the
+/// digest carries the assessed set the instruction names components from.
+#[test]
+fn system_prompt_asks_what_the_codebase_does() {
+    let mut model = fixture_model(vec![]);
+    model.section_instructions.insert(
+        "executive_summary".to_string(),
+        "OVERRIDE: lead with the TQI posture.".to_string(),
+    );
+    let req = build_synthesis_prompt(&model, "stub/model", false);
+    for needle in [
+        "What the codebase does",
+        "what the audited system IS and what it DOES",
+        "analyze the major components",
+        "Never invent a product, a market, a customer, or a component the data does not name",
+        "Risk remains the summary's core",
+    ] {
+        assert!(
+            req.system.contains(needle),
+            "the purpose/components instruction must survive a template override and contain \
+             {needle:?}: {}",
+            req.system
+        );
+    }
+    // The forced-output schema states the same requirement in the field's own
+    // description, so a model steering off `response_format` alone cannot
+    // revert to a risk-only summary.
+    let schema = req.response_schema.as_ref().expect("forced schema");
+    let description = schema.schema["properties"]["executive_summary"]["description"]
+        .as_str()
+        .expect("executive_summary description");
+    assert!(
+        description.contains("open by stating what the audited codebase IS and DOES"),
+        "the forced schema must state the requirement too: {description}"
+    );
+    assert!(
+        req.messages[0].content.contains("Applications assessed"),
+        "the digest must name the set whose components the instruction asks about: {}",
+        req.messages[0].content
+    );
+}
+
+/// Why (#6030/#6029): the instruction above can only be obeyed from data in
+/// the prompt. A sweep without `--analyze` carries no `AnalyzeMetrics`, and
+/// the digest previously wrote "No metrics available for this application"
+/// for exactly that run — starving the summary of density AND component
+/// evidence while `RepoScan` held both.
+/// What: metrics absent, scan present; asserts the scan's LoC, languages and
+/// file count all reach `messages[0]`.
+#[test]
+fn digest_carries_scan_profile_without_metrics() {
+    let mut model = fixture_model(vec![]);
+    let repo = model.repositories.first_mut().expect("one repository");
+    repo.metrics = None;
+    repo.scan = Some(crate::report::scan::RepoScan {
+        total_loc: 1_500_000,
+        file_count: 8_432,
+        by_language: vec![LanguageLoc {
+            language: "Rust".to_string(),
+            loc: 1_500_000,
+        }],
+        frameworks: vec![],
+    });
+
+    let digest = build_synthesis_prompt(&model, "stub/model", false).messages[0]
+        .content
+        .clone();
+    assert!(digest.contains("Total LoC: 1500000"), "{digest}");
+    assert!(digest.contains("Primary languages: Rust"), "{digest}");
+    assert!(digest.contains("Files: 8432"), "{digest}");
+    assert!(
+        !digest.contains("No metrics available"),
+        "a scanned application is not a metrics-free one: {digest}"
+    );
+}
+
+/// The component evidence itself: the build manifests, the project each
+/// declares, and its top dependencies are what the executive summary names
+/// components from, and they never reached the prompt before #6030.
+#[test]
+fn digest_names_build_manifests_as_component_evidence() {
+    let mut model = fixture_model(vec![]);
+    let repo = model.repositories.first_mut().expect("one repository");
+    repo.scan = Some(crate::report::scan::RepoScan {
+        total_loc: 8200,
+        file_count: 120,
+        by_language: vec![],
+        frameworks: vec![crate::report::scan::Framework {
+            manifest: "package.json".to_string(),
+            name: "acme-web".to_string(),
+            deps: vec!["react".to_string(), "vite".to_string()],
+        }],
+    });
+
+    let digest = build_synthesis_prompt(&model, "stub/model", false).messages[0]
+        .content
+        .clone();
+    assert!(digest.contains("Build manifests / frameworks:"), "{digest}");
+    assert!(digest.contains("package.json"), "{digest}");
+    assert!(digest.contains("acme-web"), "{digest}");
+    assert!(digest.contains("react"), "{digest}");
+}

--- a/crates/trusty-review/templates/report-technical-dd.md
+++ b/crates/trusty-review/templates/report-technical-dd.md
@@ -88,12 +88,15 @@
      count, estimated work volume, and its trajectory by month — ahead of the
      narrative below. Every row is deterministic, never LLM-touched (it is
      the same anchor set the numeric guardrail validates narrative against).
-     Author count and monthly trajectory are the tga-side authorship artifact
-     (#5453); a manifest without one renders those two rows as named gaps,
-     never a silent zero. "Estimated work volume" is a named gap in every run
-     today — tga has no effort-estimation metric (its `story_points` fields
-     are documented placeholders, always zero) — rather than an invented
-     figure. -->
+     Density rows (LoC, file count, languages) come from a `--analyze` metrics
+     file when one was supplied, else from the built-in repository scan every
+     run produces (#6029). Complexity needs `--analyze`; author count and
+     monthly trajectory need the tga-side authorship artifact (#5453);
+     "Estimated work volume" is absent in every run today, because tga has no
+     effort-estimation metric (its `story_points` fields are documented
+     placeholders, always zero). Each of those rows states its own missing
+     input by name — never an invented figure, and never a blanket "no data"
+     covering the rows the run did populate. -->
 
 | Metric | Value |
 |---|---|
@@ -109,10 +112,15 @@
 
 {{executive_summary_paragraph}}
 
-<!-- One paragraph, deal-relevant: what matters to an acquirer, synthesized
-     across all applications — not a restatement of section headers. Voice is
+<!-- Deal-relevant, synthesized across all applications — not a restatement of
+     section headers. Owner ruling 2026-08-19 (#6030): it opens by describing
+     what the codebase IS and DOES, then analyzes the major components and
+     each one's role, then covers risk. Risk is still the core; the purpose
+     and component narrative sets it up rather than replacing it. Voice is
      balanced/adversarial: acquirer-side, skeptical of risk, evenhanded about
-     genuine strengths, never promotional. -->
+     genuine strengths, never promotional. Every claim is grounded in the
+     provided scan/dependency/authorship data — no invented product, market,
+     customer, component, or figure. -->
 
 {{report_contents_block}}
 


### PR DESCRIPTION
Refs #6029, #6030 (no auto-close — per the issue lifecycle, both close after live verification; they move to `status:merged` on merge).

#6029: Key Facts only ever read `--analyze` metrics and collapsed to "No data available" while the scan (LoC, files, languages) sat populated on the model. Now metrics-then-scan precedence (mirroring the Profile table's existing choice), with missing inputs itemized as named gaps inside the block. #6030: the synthesis prompt now requires the executive summary to open with what the system is and does and analyze the major components, grounded in a new scan/manifest profile fed to the digest — static block, so a template `instruct:` override cannot drop it. Known scope hold (recorded on #6030): the non-synthesis exec-summary composer is unchanged.

Test ladder rung 3 (trusty-review only): fmt/check/clippy clean; `cargo test -p trusty-review` → 1677 lib + 69 bin + 21 integration passed, 0 failed. Six regression tests, each shown failing pre-fix — including an ordering-dependency test proven to bite by flipping the production fill order. code-critic round: WARN (one MEDIUM, the ordering test) → fixed. Doc-pointer lint 0 dangling; changelog fragments for both issues present.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools