### PR TITLE
fix(trusty-review,trusty-analyze,tga): analyze fetches retry a broken pooled connection and default to 127.0.0.1

### DIFF
--- a/crates/trusty-analyze/changelog.d/6038-loopback-bind-constant.md
+++ b/crates/trusty-analyze/changelog.d/6038-loopback-bind-constant.md
@@ -1,0 +1,7 @@
+Changed
+
+- `serve` names the interface it binds as `LOOPBACK_BIND` instead of an unnamed
+  `[127, 0, 0, 1]` literal (#6038). Behaviour is identical — the daemon answers
+  on the IPv4 loopback and only there (ADR-0018) — but a client whose default
+  URL said `localhost` looked correct while resolving `::1` first on macOS, and
+  nothing in this file stated the address a client has to match.

--- a/crates/trusty-analyze/src/service/routes.rs
+++ b/crates/trusty-analyze/src/service/routes.rs
@@ -33,6 +33,21 @@ use tokio_stream::wrappers::BroadcastStream;
 use super::handlers;
 use super::ui;
 
+/// The one interface `serve` binds.
+///
+/// Why (#6038): this was an unnamed `[127, 0, 0, 1]` literal at the bind site,
+/// so nothing said out loud that the daemon answers on the IPv4 loopback and
+/// ONLY there. A client whose default URL said `localhost` therefore looked
+/// correct while resolving `::1` first on macOS and never reaching this socket;
+/// naming the address is what lets a reader check the two agree. It stays
+/// loopback: binding any other interface would expose an unauthenticated
+/// analysis API to the network (ADR-0018).
+/// What: the IPv4 loopback octets, paired with the caller's `start_port` in
+/// [`serve`].
+/// Test: `super::tests` bind their own ephemeral listeners; the loopback
+/// doctrine itself is inventoried in `docs/reference/threat-model.md`.
+const LOOPBACK_BIND: [u8; 4] = [127, 0, 0, 1];
+
 /// Build the axum router around `state`.
 ///
 /// Why: Composes the analyzer's HTTP surface in one place so callers (binary,
@@ -166,7 +181,7 @@ pub fn build_router_with_self_origins(
 /// Test: integration tests bind their own listener — exercised by
 /// `cargo test -p trusty-analyzer-service`.
 pub async fn serve(state: AnalyzerAppState, start_port: u16) -> Result<()> {
-    let start_addr: SocketAddr = ([127, 0, 0, 1], start_port).into();
+    let start_addr: SocketAddr = (LOOPBACK_BIND, start_port).into();
     let listener = trusty_common::bind_with_auto_port(start_addr, 64).await?;
     let actual = listener.local_addr()?;
     trusty_common::write_daemon_addr("trusty-analyze", &actual.to_string())?;

--- a/crates/trusty-git-analytics/changelog.d/6038-analyze-url-literal-loopback.md
+++ b/crates/trusty-git-analytics/changelog.d/6038-analyze-url-literal-loopback.md
@@ -1,0 +1,7 @@
+Fixed
+
+- `tga audit` defaults the analyze daemon address to `http://127.0.0.1:7879`
+  rather than `http://localhost:7879` (#6038). It must match
+  `trusty-review`'s default, which moved for the same reason: `trusty-analyze
+  serve` binds the IPv4 loopback only, and macOS resolves `localhost` to `::1`
+  first. `PR_INTELLIGENCE_ANALYZER_URL` still overrides it.

--- a/crates/trusty-git-analytics/src/audit/analyze.rs
+++ b/crates/trusty-git-analytics/src/audit/analyze.rs
@@ -58,7 +58,13 @@ pub const DEFAULT_ANALYZE_BIN: &str = "trusty-analyze";
 pub const ENV_ANALYZE_URL: &str = "PR_INTELLIGENCE_ANALYZER_URL";
 
 /// Default analyze daemon address, matching `trusty-review`'s own default.
-pub const DEFAULT_ANALYZE_URL: &str = "http://localhost:7879";
+///
+/// Why (#6038): the literal address, not `localhost`. `trusty-analyze serve`
+/// binds `127.0.0.1` only, and macOS resolves `localhost` to `::1` first, so
+/// the spelling decided whether the first connect reached the daemon at all.
+/// It tracks `trusty_review::config::DEFAULT_ANALYZER_URL` by hand — the two
+/// crates must not disagree about which daemon they mean.
+pub const DEFAULT_ANALYZE_URL: &str = "http://127.0.0.1:7879";
 
 /// The port `trusty-analyze serve` binds when the URL names none.
 pub const DEFAULT_ANALYZE_PORT: u16 = 7879;
@@ -104,7 +110,7 @@ pub struct AnalyzeDaemonUnavailable {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct AnalyzeGuard {
-    /// Base address of the daemon, e.g. `http://localhost:7879`.
+    /// Base address of the daemon, e.g. `http://127.0.0.1:7879`.
     pub url: String,
     /// Binary name or path to spawn when the daemon is absent.
     pub binary: String,

--- a/crates/trusty-review/changelog.d/6038-analyze-transport-retry.md
+++ b/crates/trusty-review/changelog.d/6038-analyze-transport-retry.md
@@ -1,0 +1,19 @@
+Fixed
+
+- `--analyze` no longer degrades to a scan-only report when the analyze daemon
+  closes a pooled connection (#6038). The adapter issues its GETs back to back
+  on one HTTP/1.1 keep-alive connection, and the daemon closing that connection
+  races the next request — the diagnostics fetch that followed a slow
+  `/complexity_distribution` failed with `error sending request`, and every
+  metrics-driven section fell back to the scan. A transport failure that is
+  neither a timeout nor a refused connect is now retried once on a fresh
+  connection; a refused connect and a timeout stay terminal, so a daemon that is
+  genuinely down still fails open at the same speed.
+- The default analyzer URL is `http://127.0.0.1:7879` rather than
+  `http://localhost:7879` (#6038). `trusty-analyze serve` binds the IPv4
+  loopback only, and macOS resolves `localhost` to `::1` first, so a stock run
+  could not reach a healthy daemon until the operator exported
+  `PR_INTELLIGENCE_ANALYZER_URL` by hand. The env-var override is unchanged.
+- Both analyze HTTP clients now build through
+  `trusty_common::http_client::loopback_client_builder`, so an exported
+  `HTTP_PROXY` no longer diverts a loopback fetch to a proxy (#4392).

--- a/crates/trusty-review/src/config/config_tests.rs
+++ b/crates/trusty-review/src/config/config_tests.rs
@@ -174,6 +174,28 @@ fn config_analyzer_url_default() {
     );
 }
 
+/// Why (#6038): the default named `localhost`, which macOS resolves `::1`
+/// first, while `trusty-analyze serve` binds `127.0.0.1` only — so a stock
+/// `--analyze` run could not reach a healthy daemon and every report degraded
+/// to scan until the operator exported the variable by hand. The default must
+/// name an address, not a hostname whose resolution decides whether the fetch
+/// works.
+/// What: asserts the constant is the literal IPv4 loopback, and that an
+/// unset `PR_INTELLIGENCE_ANALYZER_URL` loads exactly it.
+/// Test: This is the test.
+#[test]
+fn analyzer_url_defaults_to_the_literal_loopback_address() {
+    assert_eq!(
+        crate::config::DEFAULT_ANALYZER_URL,
+        "http://127.0.0.1:7879",
+        "the default must not depend on hostname resolution"
+    );
+    if std::env::var("PR_INTELLIGENCE_ANALYZER_URL").is_err() {
+        let config = ReviewConfig::from_env_and_file(None, None);
+        assert_eq!(config.analyzer_url, crate::config::DEFAULT_ANALYZER_URL);
+    }
+}
+
 #[test]
 fn live_review_requesters_parses_csv() {
     // The parser is pure aside from the env read; assert it lowercases,

--- a/crates/trusty-review/src/config/mod.rs
+++ b/crates/trusty-review/src/config/mod.rs
@@ -47,6 +47,20 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tracing::warn;
 
+// ─── Service defaults ─────────────────────────────────────────────────────────
+
+/// Where `--analyze` looks for the trusty-analyze daemon when
+/// `PR_INTELLIGENCE_ANALYZER_URL` is unset.
+///
+/// Why (#6038): the literal address, not `localhost`. `trusty-analyze serve`
+/// binds `127.0.0.1` only (ADR-0018, and `service/routes.rs::LOOPBACK_BIND`),
+/// while macOS resolves `localhost` to `::1` first — so the default URL named a
+/// socket that does not exist, the first connect was refused, and the operator
+/// had to export the variable by hand to get a populated report.
+/// What: `http://127.0.0.1:7879`. The env-var override is unchanged.
+/// Test: `config::tests::analyzer_url_defaults_to_the_literal_loopback_address`.
+pub const DEFAULT_ANALYZER_URL: &str = "http://127.0.0.1:7879";
+
 // ─── Provider identifier ──────────────────────────────────────────────────────
 
 /// LLM backend provider.
@@ -199,7 +213,7 @@ pub struct ReviewConfig {
     /// trusty-search base URL (`TRUSTY_SEARCH_URL`, default `http://localhost:7878`).
     pub search_url: String,
     /// trusty-analyze base URL (`PR_INTELLIGENCE_ANALYZER_URL`, default
-    /// `http://localhost:7879`).
+    /// [`DEFAULT_ANALYZER_URL`]).
     pub analyzer_url: String,
     /// Default trusty-search index (`TRUSTY_SEARCH_INDEX`, default `main`).
     ///
@@ -425,7 +439,7 @@ impl ReviewConfig {
             search_url: std::env::var("TRUSTY_SEARCH_URL")
                 .unwrap_or_else(|_| "http://localhost:7878".to_string()),
             analyzer_url: std::env::var("PR_INTELLIGENCE_ANALYZER_URL")
-                .unwrap_or_else(|_| "http://localhost:7879".to_string()),
+                .unwrap_or_else(|_| DEFAULT_ANALYZER_URL.to_string()),
             search_index: std::env::var("TRUSTY_SEARCH_INDEX")
                 .unwrap_or_else(|_| "main".to_string()),
             search_index_explicit: std::env::var("TRUSTY_SEARCH_INDEX").is_ok(),

--- a/crates/trusty-review/src/integrations/analyze_client.rs
+++ b/crates/trusty-review/src/integrations/analyze_client.rs
@@ -232,11 +232,14 @@ impl HttpAnalyzeClient {
     pub fn new(base_url: impl Into<String>) -> Result<Self, AnalyzeClientError> {
         let raw = base_url.into();
         let base_url = raw.trim_end_matches('/').to_string();
-        let probe_http = reqwest::Client::builder()
+        // #6038: both clients talk to the loopback analyze daemon, so both go
+        // through the shared constructor that applies `.no_proxy()` (#4392) —
+        // a bare builder here sends 127.0.0.1 to an exported HTTP_PROXY.
+        let probe_http = trusty_common::http_client::loopback_client_builder()
             .timeout(std::time::Duration::from_secs(5))
             .build()
             .map_err(|e| AnalyzeClientError::ClientInit(e.to_string()))?;
-        let analysis_http = reqwest::Client::builder()
+        let analysis_http = trusty_common::http_client::loopback_client_builder()
             .timeout(std::time::Duration::from_secs(180))
             .build()
             .map_err(|e| AnalyzeClientError::ClientInit(e.to_string()))?;

--- a/crates/trusty-review/src/mcp/mod.rs
+++ b/crates/trusty-review/src/mcp/mod.rs
@@ -219,7 +219,7 @@ pub(crate) async fn dispatch_deferred(
 /// builds the verifier provider (degrading to `None` on failure — embedded use
 /// must not hard-fail a host daemon over a missing verifier model), builds the
 /// HTTP search + analyze clients from config (the analyze client defaults to
-/// `http://localhost:7879`, i.e. loopback to the hosting analyze daemon, so
+/// [`crate::config::DEFAULT_ANALYZER_URL`], i.e. loopback to the hosting analyze daemon, so
 /// embedded reviews get authoritative static-analysis context), and returns the
 /// assembled `AppState`. #5064: the dedup requirement is declared through
 /// `DedupNeed::NotNeeded` rather than by passing a bare `None` — embedded

--- a/crates/trusty-review/src/report/analyze_adapter.rs
+++ b/crates/trusty-review/src/report/analyze_adapter.rs
@@ -36,6 +36,17 @@ use super::metrics::{
 /// Per-request HTTP timeout for analyze fetches (fail-open on timeout).
 const FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// How many extra attempts a retryable transport failure earns.
+///
+/// Why (#6038): the adapter issues four GETs back to back, and reqwest keeps
+/// them on one HTTP/1.1 keep-alive connection. The daemon closing that
+/// connection races the client's next write, so a GET can be committed to a
+/// socket that is already going away — which surfaced as
+/// `error sending request` and degraded every `--analyze` render to scan. The
+/// bound is one: a peer that closes the replacement connection too is not
+/// answering, and the report falls back to scan either way.
+const TRANSPORT_RETRIES: u32 = 1;
+
 // ─── Error type ────────────────────────────────────────────────────────────
 
 /// Errors produced while fetching analyze data. All are handled fail-open by
@@ -72,6 +83,22 @@ pub enum AnalyzeAdapterError {
 }
 
 type AdapterResult<T> = std::result::Result<T, AnalyzeAdapterError>;
+
+/// Does this transport failure describe a connection that went away mid-request?
+///
+/// Why (#6038): only that class earns a retry. A connect refusal means nothing
+/// is listening, and a timeout means the daemon is slower than
+/// [`FETCH_TIMEOUT`] — re-running either just doubles the wall-clock cost of a
+/// fetch that is going to fail open anyway. What is left is the case the client
+/// cannot avoid: a keep-alive connection the daemon closed after the request
+/// was already committed to it.
+/// What: true for a send/body failure that is neither a timeout nor a connect
+/// error.
+/// Test: `transport_failure_on_a_reused_connection_retries_once` (retried) and
+/// `fetch_returns_none_on_unreachable_daemon` (a refused connect is not).
+fn is_retryable_transport(e: &reqwest::Error) -> bool {
+    !e.is_timeout() && !e.is_connect() && !e.is_builder()
+}
 
 // ─── Wire types (trusty-analyze JSON, minimal shapes) ────────────────────────
 
@@ -537,7 +564,10 @@ impl HttpAnalyzeMetricsSource {
         if base.ends_with('/') {
             base.pop();
         }
-        let http = reqwest::Client::builder()
+        // #6038: the shared loopback constructor, not a bare builder — it is
+        // what applies `.no_proxy()`, so an exported HTTP_PROXY no longer
+        // diverts a 127.0.0.1 fetch to a proxy that never answers (#4392).
+        let http = trusty_common::http_client::loopback_client_builder()
             .timeout(FETCH_TIMEOUT)
             .connect_timeout(Duration::from_secs(3))
             .build()
@@ -548,21 +578,53 @@ impl HttpAnalyzeMetricsSource {
         })
     }
 
+    /// One attempt: send the GET and read the whole body.
+    ///
+    /// Why: separated from [`Self::get_json`] so the retry in that function can
+    /// re-run send AND body-read together — a connection torn down part-way
+    /// through the response fails at the read, not at the send.
+    /// What: returns the status and the body text, or the raw `reqwest::Error`
+    /// so the caller can classify it.
+    /// Test: exercised by every `get_json` test.
+    async fn send_once(&self, url: &str) -> reqwest::Result<(reqwest::StatusCode, String)> {
+        let resp = self.http.get(url).send().await?;
+        let status = resp.status();
+        let body = resp.text().await?;
+        Ok((status, body))
+    }
+
     /// GET `path` and deserialize the JSON body into `T`, mapping every failure
     /// mode to a typed [`AnalyzeAdapterError`].
+    ///
+    /// Why (#6038): a transport failure on a POOLED connection is not evidence
+    /// the daemon is down — HTTP/1.1 keep-alive makes "the server closed a
+    /// connection the client still held" an unavoidable race, and RFC 9112 §9.3
+    /// puts recovery on the client. A GET is idempotent, so one retry on a
+    /// fresh connection is safe and is the difference between a populated
+    /// `--analyze` report and a silent fall back to scan.
+    /// What: retries [`Self::send_once`] at most [`TRANSPORT_RETRIES`] times
+    /// when [`is_retryable_transport`] classifies the failure as a lost
+    /// connection; reqwest discards the errored connection, so the retry
+    /// necessarily dials a new one. Non-2xx and parse failures are terminal.
+    /// Test: `transport_failure_on_a_reused_connection_retries_once`,
+    /// `a_connection_that_keeps_dying_is_retried_exactly_once`.
     async fn get_json<T: serde::de::DeserializeOwned>(&self, path: &str) -> AdapterResult<T> {
         let url = format!("{}{path}", self.base_url);
-        let resp = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .map_err(|e| AnalyzeAdapterError::Transport(format!("GET {url}: {e}")))?;
-        let status = resp.status();
-        let body = resp
-            .text()
-            .await
-            .map_err(|e| AnalyzeAdapterError::Transport(format!("read body of {url}: {e}")))?;
+        let mut retries = 0;
+        let (status, body) = loop {
+            match self.send_once(&url).await {
+                Ok(answer) => break answer,
+                Err(e) if retries < TRANSPORT_RETRIES && is_retryable_transport(&e) => {
+                    retries += 1;
+                    tracing::debug!(
+                        %url,
+                        error = %e,
+                        "--analyze: pooled connection lost; retrying on a fresh one"
+                    );
+                }
+                Err(e) => return Err(AnalyzeAdapterError::Transport(format!("GET {url}: {e}"))),
+            }
+        };
         if !status.is_success() {
             return Err(AnalyzeAdapterError::Api {
                 status: status.as_u16(),

--- a/crates/trusty-review/src/report/analyze_adapter_tests.rs
+++ b/crates/trusty-review/src/report/analyze_adapter_tests.rs
@@ -7,6 +7,7 @@
 //! Test: this file.
 
 use super::*;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 // ─── Severity map ────────────────────────────────────────────────────────────
 
@@ -260,6 +261,116 @@ async fn fetch_returns_none_on_unreachable_daemon() {
     // Port 1 is never listening; the probe fails and fetch swallows it.
     let src = HttpAnalyzeMetricsSource::new("http://127.0.0.1:1").unwrap();
     assert!(src.fetch("demo").await.is_none());
+}
+
+/// A loopback stub that closes a connection part-way through a request instead
+/// of answering it, and counts how many connections it accepted.
+///
+/// Why (#6038): this is the failure the field hit. HTTP/1.1 keep-alive lets the
+/// server close a connection the client still believes is reusable, and the
+/// close races the client's next write — so the client sees the socket go away
+/// after it has already committed the request. Closing on the Nth request of a
+/// connection (rather than right after a response) makes the race
+/// deterministic: the connection is provably still in the client's pool when
+/// the next GET is checked out.
+/// What: binds `127.0.0.1:0` and serves `[]` to every request except the
+/// `poison_at`-th on each connection, which it answers by shutting the socket
+/// down. Returns `host:port` plus the accepted-connection counter.
+/// Test: `transport_failure_on_a_reused_connection_retries_once`,
+/// `a_connection_that_keeps_dying_is_retried_exactly_once`.
+async fn closing_stub(poison_at: u32) -> (String, std::sync::Arc<AtomicU32>) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback stub");
+    let addr = listener.local_addr().expect("stub addr").to_string();
+    let connections = std::sync::Arc::new(AtomicU32::new(0));
+    let counter = std::sync::Arc::clone(&connections);
+    tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            counter.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(async move {
+                let mut seen = 0u32;
+                let mut buf = [0u8; 1024];
+                loop {
+                    match stream.read(&mut buf).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(_) => {}
+                    }
+                    seen += 1;
+                    if seen == poison_at {
+                        // The close the client cannot anticipate: the request
+                        // is already on the wire, and no response follows it.
+                        let _ = stream.shutdown().await;
+                        return;
+                    }
+                    let _ = stream
+                        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n[]")
+                        .await;
+                }
+            });
+        }
+    });
+    (addr, connections)
+}
+
+/// Why (#6038): every `--analyze` render degraded to scan because one closed
+/// pooled connection was surfaced as a terminal transport error. The adapter
+/// issues three GETs back to back on one keep-alive connection, and the second
+/// one landing on a connection the daemon had closed collapsed the whole fetch.
+/// What: drives two `get_json` calls against a stub that closes the connection
+/// under the second; the first must succeed, and the second must succeed too —
+/// on the fresh connection the retry opens.
+/// Test: This is the test. Without the retry the second call returns
+/// `AnalyzeAdapterError::Transport`.
+#[tokio::test]
+async fn transport_failure_on_a_reused_connection_retries_once() {
+    let (addr, connections) = closing_stub(2).await;
+    let src = HttpAnalyzeMetricsSource::new(format!("http://{addr}")).expect("client builds");
+
+    let first: serde_json::Value = src
+        .get_json("/indexes")
+        .await
+        .expect("the first GET opens a connection and is answered");
+    assert_eq!(first, serde_json::json!([]));
+
+    let second: serde_json::Value = src
+        .get_json("/indexes/demo/diagnostics")
+        .await
+        .expect("a closed pooled connection must be retried on a fresh one");
+    assert_eq!(second, serde_json::json!([]));
+    assert_eq!(
+        connections.load(Ordering::SeqCst),
+        2,
+        "the retry must open exactly one replacement connection"
+    );
+}
+
+/// Why (#6038): "retry once" is a bound, not a loop. A peer that closes every
+/// connection must still fail-open promptly rather than spinning; the report
+/// falls back to scan either way and an unbounded retry only delays it.
+/// What: points the adapter at a stub that closes every connection on its first
+/// request, and asserts the call fails after exactly two connection attempts.
+/// Test: This is the test.
+#[tokio::test]
+async fn a_connection_that_keeps_dying_is_retried_exactly_once() {
+    let (addr, connections) = closing_stub(1).await;
+    let src = HttpAnalyzeMetricsSource::new(format!("http://{addr}")).expect("client builds");
+
+    let err = src
+        .get_json::<serde_json::Value>("/indexes")
+        .await
+        .expect_err("a peer that answers nothing cannot succeed");
+    assert!(
+        matches!(err, AnalyzeAdapterError::Transport(_)),
+        "expected a transport error, got {err:?}"
+    );
+    assert_eq!(
+        connections.load(Ordering::SeqCst),
+        2,
+        "one original attempt plus one retry, and no more"
+    );
 }
 
 #[test]

--- a/crates/trusty-review/src/report/manifest.rs
+++ b/crates/trusty-review/src/report/manifest.rs
@@ -133,8 +133,8 @@ pub struct ReportSection {
     /// Why: `--analyze` populates the complexity chart + finding bands from the
     /// analyze daemon; the URL is deployment-specific.  Precedence: this manifest
     /// key wins when set; otherwise `ReviewConfig.analyzer_url` (env
-    /// `PR_INTELLIGENCE_ANALYZER_URL`, itself defaulting to the loopback daemon
-    /// `http://localhost:7879` ≡ `http://127.0.0.1:7879`) applies.
+    /// `PR_INTELLIGENCE_ANALYZER_URL`, itself defaulting to
+    /// [`crate::config::DEFAULT_ANALYZER_URL`]) applies.
     #[serde(default)]
     pub analyze_url: Option<String>,
 }

--- a/docs/specs/DOC-67-tga-audit-mode.md
+++ b/docs/specs/DOC-67-tga-audit-mode.md
@@ -352,7 +352,7 @@ delivered a report with those three sections empty and exited 0.
 (`crates/trusty-git-analytics/src/audit/analyze.rs`): it probes `/health`,
 spawns `<binary> serve --port <port>` detached when there is no answer, and polls
 until the daemon answers. The binary is `TRUSTY_ANALYZE_BIN` else PATH, and the
-address is `PR_INTELLIGENCE_ANALYZER_URL` else `http://localhost:7879` — the same
+address is `PR_INTELLIGENCE_ANALYZER_URL` else `http://127.0.0.1:7879` (#6038) — the same
 variable `trusty-review` reads, so the daemon that gets started and the daemon
 that gets queried are the same process by construction. The probe/spawn/poll loop
 is `trusty_common::daemon_guard`, not a second copy.

--- a/docs/trusty-review/spec/COMPONENTS.md
+++ b/docs/trusty-review/spec/COMPONENTS.md
@@ -293,7 +293,7 @@ proceeds **DEGRADED** and is loudly labelled non-authoritative.
 
 ### 6.3 trusty-analyze client (`integrations/analyze_client.rs`)
 
-`HttpAnalyzeClient` over `PR_INTELLIGENCE_ANALYZER_URL` (default `http://localhost:7879`).
+`HttpAnalyzeClient` over `PR_INTELLIGENCE_ANALYZER_URL` (default `http://127.0.0.1:7879`).
 
 | Method | Endpoint | Timeout | Notes |
 |--------|----------|---------|-------|
@@ -365,7 +365,7 @@ Config file location: `--config <path>` flag or `$XDG_CONFIG_HOME/trusty-review/
 | `PR_INTELLIGENCE_EXCLUDED_AUTHORS` | `""` | Bot logins to skip |
 | `PR_REVIEW_BOT_USERNAME` | `""` | App login; triggers manual/live when requested as reviewer |
 | `PR_INTELLIGENCE_LOG_DIR` | `/data/app/data/pr-reviews` | Review log + dedup store directory |
-| `PR_INTELLIGENCE_ANALYZER_URL` | `http://localhost:7879` | trusty-analyze URL |
+| `PR_INTELLIGENCE_ANALYZER_URL` | `http://127.0.0.1:7879` | trusty-analyze URL |
 | `PR_INTELLIGENCE_MIN_FINDINGS_TO_POST` | `1` | Global min-findings gate |
 | `PR_INTELLIGENCE_SUPPRESS_ADVISORY_REVIEWS` | `false` | Global `suppress_advisory` |
 

--- a/docs/trusty-review/spec/report-generation.md
+++ b/docs/trusty-review/spec/report-generation.md
@@ -872,7 +872,8 @@ target and is O(corpus) (never a readiness probe, per REV-441).
 
 **Daemon URL.** Precedence: manifest `[report].analyze_url` (when set) > env
 `PR_INTELLIGENCE_ANALYZER_URL` (via `ReviewConfig.analyzer_url`) > default
-`http://127.0.0.1:7879` (the loopback `localhost:7879` the config defaults to).
+`http://127.0.0.1:7879` (the address the config defaults to; #6038 dropped the
+`localhost` spelling, which macOS resolves `::1`-first).
 
 **Metrics-resolution precedence (fail-open).** Declared metrics file (manifest
 `metrics` key) > `--analyze` live fetch > `None` (bare scan). `--analyze` fills a

--- a/docs/trusty-review/spec/research/source-analysis.md
+++ b/docs/trusty-review/spec/research/source-analysis.md
@@ -379,7 +379,7 @@ Multiple named `VectorSearchAdapter` instances used for different index targets:
 
 ### 6.2 trusty-analyze Adapter (`adapters/analyzer_adapter.py`)
 
-HTTP client for `PR_INTELLIGENCE_ANALYZER_URL` (default `http://localhost:7879`). Index from `TRUSTY_SEARCH_INDEX`.
+HTTP client for `PR_INTELLIGENCE_ANALYZER_URL` (default `http://127.0.0.1:7879`). Index from `TRUSTY_SEARCH_INDEX`.
 
 | Method | Endpoint | Timeout | Notes |
 |---|---|---|---|
@@ -487,7 +487,7 @@ Dispatch: prefers `SLACK_NOTIFICATION_CHANNEL` + `SLACK_BOT_TOKEN` (chat.postMes
 | `PR_INTELLIGENCE_EXCLUDED_AUTHORS` | `""` | Bot logins to skip (e.g. `duetto-snyk-svc`) |
 | `PR_REVIEW_BOT_USERNAME` | `""` | GitHub App login; triggers manual/live mode when requested as reviewer |
 | `PR_INTELLIGENCE_LOG_DIR` | `/data/app/data/pr-reviews` | Dry-run log directory |
-| `PR_INTELLIGENCE_ANALYZER_URL` | `http://localhost:7879` | trusty-analyze sidecar URL |
+| `PR_INTELLIGENCE_ANALYZER_URL` | `http://127.0.0.1:7879` | trusty-analyze sidecar URL |
 | `PR_INTELLIGENCE_EVAL_MODEL` | (varies) | Secondary model for eval comparisons (dry-run only) |
 | `PR_INTELLIGENCE_MIN_FINDINGS_TO_POST` | `1` | Global min findings gate (overrideable per-repo) |
 | `PR_INTELLIGENCE_SUPPRESS_ADVISORY_REVIEWS` | `false` | Global suppress_advisory flag |


### PR DESCRIPTION
Refs #6038 (no auto-close — closes after live verification; moves to `status:merged` on merge).

Every --analyze render silently degraded to scan when the diagnostics GET failed transport-level after a slow complexity fetch. Client-side fix: one retry on a fresh connection for retryable transport failures (GETs only; connect/timeout failures excluded so a down daemon stays one fail-open, not two), and both analyze clients now build through `trusty_common::http_client::loopback_client_builder()` — they were bare `reqwest` builders, bypassing #4392's `.no_proxy()`, so an exported HTTP_PROXY hijacked loopback fetches (a plausible field mechanism). Defaults align on 127.0.0.1: trusty-analyze binds 127.0.0.1 only (now a named constant), while clients defaulted to `localhost`, which macOS resolves ::1-first.

Rung 3 per touched crate: fmt/clippy clean; trusty-review 1680, trusty-analyze 489, tga 1332 lib tests passing, 0 failed; doc-pointer lint 26088/0 dangling; changelog fragments in all three crates. Both retry tests shown failing pre-fix with the exact field error text. Live verification (a real --analyze render) gates issue closure.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools