### PR TITLE
fix(trusty-review): analyze fetch budgets outlive the daemon's deadline ladder, and endpoints fail independently

### DIFF
--- a/crates/trusty-review/changelog.d/6041-analyze-fetch-budget.md
+++ b/crates/trusty-review/changelog.d/6041-analyze-fetch-budget.md
@@ -1,0 +1,17 @@
+Fixed
+
+- `--analyze` gives each trusty-analyze endpoint its own request budget instead
+  of one flat 15 s. The diagnostics budget is derived from the daemon's own
+  deadline ladder (`TRUSTY_DIAGNOSTICS_DEADLINE_SECS`, default 180 s, plus its
+  90 s of handler/router/client headroom), so the daemon's answer — including
+  the structured report it sends when its own deadline is hit — always outlasts
+  the client. Measured live before the fix: diagnostics answered `200` at 142 s
+  with `tools_run: ["clippy"]` while the client gave up at 15 s. The cheap
+  endpoints keep the short budget. See #6041.
+- A trusty-analyze endpoint that fails no longer discards the data the other
+  endpoints returned. Complexity, diagnostics, and refactor suggestions are
+  fetched independently; whatever answered is rendered, and each endpoint that
+  did not is named under Gaps & Caveats along with why it dropped out (timed
+  out, unreachable, or an unusable answer). A fetch where no endpoint answered
+  still falls back to the repository scan rather than rendering empty metrics.
+  See #6041.

--- a/crates/trusty-review/src/report/analyze_adapter.rs
+++ b/crates/trusty-review/src/report/analyze_adapter.rs
@@ -7,9 +7,12 @@
 //! already optionally depends on trusty-review via its `review` feature), so
 //! this adapter is a thin HTTP client over the analyze daemon (`:7879`) plus a
 //! pure mapping from the daemon's wire JSON onto the report's v0
-//! [`AnalyzeMetrics`]. Every probe/fetch/parse failure is fail-open — the whole
+//! [`AnalyzeMetrics`]. Every probe/fetch/parse failure is fail-open — the
 //! adapter degrades to `None` and the report falls through to the built-in
-//! scan; a missing analyze index is never an error.
+//! scan; a missing analyze index is never an error. Since #6041 that degradation
+//! is per endpoint rather than per repository: a dataset that fails leaves the
+//! others' data in place and names itself under Gaps & Caveats. Only a fetch
+//! where NO dataset answered falls all the way back to scan.
 //!
 //! What: [`AnalyzeMetricsSource`] is the injectable fetch seam;
 //! [`HttpAnalyzeMetricsSource`] is the live implementation. The pure mapping
@@ -19,7 +22,9 @@
 //! owns those measured numbers.
 //!
 //! Test: `analyze_adapter_tests.rs` covers envelope parsing, the severity map,
-//! the complexity-bucket thresholds, and fail-open on malformed JSON.
+//! the complexity-bucket thresholds, fail-open on malformed JSON, and the
+//! per-endpoint budgets and independence (`a_failing_endpoint_keeps_what_the_
+//! others_returned`, `a_fetch_where_no_endpoint_answered_falls_back_to_scan`).
 
 use std::path::Path;
 use std::time::Duration;
@@ -31,10 +36,13 @@ use super::metrics::{
     AnalyzeMetrics, ComplexityBucket, ComplexityDistribution, MetricFinding, Severity,
 };
 
-// ─── Tunables ──────────────────────────────────────────────────────────────
+// The per-endpoint paths, budgets, and failure vocabulary live one module over,
+// beside each other, so an endpoint's cost and its timeout cannot drift apart.
+pub use super::analyze_endpoints::{
+    AnalyzeCaveat, AnalyzeEndpoint, EndpointFailure, diagnostics_budget_for,
+};
 
-/// Per-request HTTP timeout for analyze fetches (fail-open on timeout).
-const FETCH_TIMEOUT: Duration = Duration::from_secs(15);
+// ─── Tunables ──────────────────────────────────────────────────────────────
 
 /// How many extra attempts a retryable transport failure earns.
 ///
@@ -60,9 +68,17 @@ const TRANSPORT_RETRIES: u32 = 1;
 /// conversion; `error_display` covers the `Display` strings.
 #[derive(Debug, thiserror::Error)]
 pub enum AnalyzeAdapterError {
-    /// HTTP transport failure (connection refused, timeout, DNS, ...).
+    /// HTTP transport failure (connection refused, DNS, a connection that died).
     #[error("trusty-analyze transport error: {0}")]
     Transport(String),
+
+    /// The request outlived its per-endpoint budget.
+    ///
+    /// Separate from [`Self::Transport`] because the remedy differs: a timeout
+    /// points at a deadline to raise, not a daemon to start, and the gap line
+    /// says so.
+    #[error("trusty-analyze request timed out: {0}")]
+    Timeout(String),
 
     /// trusty-analyze returned a non-2xx status.
     #[error("trusty-analyze API returned {status}: {body}")]
@@ -84,12 +100,35 @@ pub enum AnalyzeAdapterError {
 
 type AdapterResult<T> = std::result::Result<T, AnalyzeAdapterError>;
 
+/// Classify a fetch failure into the category the report states.
+///
+/// Why: the Gaps & Caveats line names which endpoint failed and why, and "why"
+/// must come from the error class rather than from string-matching a message
+/// that can quote a URL. A 408/504 is the daemon reporting its OWN deadline was
+/// hit, so it lands in the same category as a client-side timeout — both mean
+/// the analysis ran out of time, not that nothing was listening.
+/// Test: `a_request_that_outlives_its_budget_is_a_timeout_not_a_transport_error`.
+fn classify_failure(e: &AnalyzeAdapterError) -> EndpointFailure {
+    match e {
+        AnalyzeAdapterError::Timeout(_) => EndpointFailure::TimedOut,
+        AnalyzeAdapterError::Api { status, .. } if *status == 408 || *status == 504 => {
+            EndpointFailure::TimedOut
+        }
+        AnalyzeAdapterError::Api { .. } | AnalyzeAdapterError::Parse(_) => {
+            EndpointFailure::Rejected
+        }
+        AnalyzeAdapterError::Transport(_) | AnalyzeAdapterError::ClientInit(_) => {
+            EndpointFailure::Unanswered
+        }
+    }
+}
+
 /// Does this transport failure describe a connection that went away mid-request?
 ///
 /// Why (#6038): only that class earns a retry. A connect refusal means nothing
-/// is listening, and a timeout means the daemon is slower than
-/// [`FETCH_TIMEOUT`] — re-running either just doubles the wall-clock cost of a
-/// fetch that is going to fail open anyway. What is left is the case the client
+/// is listening, and a timeout means the daemon outlived the endpoint's own
+/// [`AnalyzeEndpoint::budget`] — re-running either just doubles the wall-clock
+/// cost of a fetch that fails open anyway. What is left is the case the client
 /// cannot avoid: a keep-alive connection the daemon closed after the request
 /// was already committed to it.
 /// What: true for a send/body failure that is neither a timeout nor a connect
@@ -432,53 +471,6 @@ pub trait AnalyzeMetricsSource: Send + Sync {
     }
 }
 
-/// A dimension the daemon answered incompletely, for one repository (#5317,
-/// #5320).
-///
-/// Why: a fetch that succeeds is not the same as a fetch that answered
-/// everything, and the difference is invisible on the page. An empty RED band
-/// because no linter was installed reads exactly like a clean codebase; a
-/// missing complexity table reads like a rendering slip. Both are facts the
-/// report owes its reader, and both travel the same Gaps & Caveats path
-/// [`AnalyzeGap`] already uses.
-/// What: one variant per condition the fetch can distinguish, each with a fixed
-/// report-facing phrase carrying no run-specific detail.
-/// Test: `analyze_adapter_tests.rs::caveat_labels_are_stable`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[non_exhaustive]
-pub enum AnalyzeCaveat {
-    /// The daemon serves no full-corpus histogram, so the §7 complexity
-    /// distribution was left out rather than filled from a truncated top-N.
-    ComplexityDistributionUnavailable,
-    /// No external static-analysis tool was installed, so nothing could
-    /// populate the RED/defect band.
-    NoStaticAnalysisTools,
-}
-
-impl AnalyzeCaveat {
-    /// The report-facing sentence for this caveat.
-    ///
-    /// Why: read by a stranger to this toolchain, so it names the condition and
-    /// what it means for the section, not the variant.
-    /// What: a fixed string per variant — deterministic across runs.
-    /// Test: `analyze_adapter_tests.rs::caveat_labels_are_stable`.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::ComplexityDistributionUnavailable => {
-                "complexity distribution not available — the analysis daemon serves no \
-                 full-corpus histogram, and the truncated top-N hotspot sample it does serve \
-                 is not a distribution. The §7 complexity table is omitted rather than \
-                 filled with shares of a truncation"
-            }
-            Self::NoStaticAnalysisTools => {
-                "no external static-analysis tool was available to the analysis daemon — the \
-                 RED/CRITICAL band is populated only from such tools, so an empty band here \
-                 means unassessed, not clean"
-            }
-        }
-    }
-}
-
 /// Why one repository has no live analyze metrics (#5239, DOC-67 §9).
 ///
 /// Why: "the daemon was down" and "this repo was never indexed" are different
@@ -557,7 +549,11 @@ impl HttpAnalyzeMetricsSource {
     ///
     /// Why: the CLI resolves the URL from a manifest key / config / default and
     /// hands it here.
-    /// What: trims a trailing slash and builds a timeout-bounded reqwest client.
+    /// What: trims a trailing slash and builds the shared loopback client. Every
+    /// request sets its own timeout from [`AnalyzeEndpoint::budget`]; the
+    /// client-level default is the longest of them, so a future call site that
+    /// forgets to set one inherits a generous budget rather than a truncating
+    /// one.
     /// Test: `new_trims_trailing_slash`.
     pub fn new(base_url: impl Into<String>) -> AdapterResult<Self> {
         let mut base = base_url.into();
@@ -568,7 +564,7 @@ impl HttpAnalyzeMetricsSource {
         // what applies `.no_proxy()`, so an exported HTTP_PROXY no longer
         // diverts a 127.0.0.1 fetch to a proxy that never answers (#4392).
         let http = trusty_common::http_client::loopback_client_builder()
-            .timeout(FETCH_TIMEOUT)
+            .timeout(AnalyzeEndpoint::Diagnostics.budget())
             .connect_timeout(Duration::from_secs(3))
             .build()
             .map_err(|e| AnalyzeAdapterError::ClientInit(e.to_string()))?;
@@ -586,8 +582,12 @@ impl HttpAnalyzeMetricsSource {
     /// What: returns the status and the body text, or the raw `reqwest::Error`
     /// so the caller can classify it.
     /// Test: exercised by every `get_json` test.
-    async fn send_once(&self, url: &str) -> reqwest::Result<(reqwest::StatusCode, String)> {
-        let resp = self.http.get(url).send().await?;
+    async fn send_once(
+        &self,
+        url: &str,
+        budget: Duration,
+    ) -> reqwest::Result<(reqwest::StatusCode, String)> {
+        let resp = self.http.get(url).timeout(budget).send().await?;
         let status = resp.status();
         let body = resp.text().await?;
         Ok((status, body))
@@ -606,13 +606,21 @@ impl HttpAnalyzeMetricsSource {
     /// when [`is_retryable_transport`] classifies the failure as a lost
     /// connection; reqwest discards the errored connection, so the retry
     /// necessarily dials a new one. Non-2xx and parse failures are terminal.
+    /// `budget` is the endpoint's own timeout, applied per request: the daemon
+    /// answers a diagnostics call in minutes and a histogram call in seconds,
+    /// and one client-wide timeout cannot be right for both.
     /// Test: `transport_failure_on_a_reused_connection_retries_once`,
-    /// `a_connection_that_keeps_dying_is_retried_exactly_once`.
-    async fn get_json<T: serde::de::DeserializeOwned>(&self, path: &str) -> AdapterResult<T> {
+    /// `a_connection_that_keeps_dying_is_retried_exactly_once`,
+    /// `a_request_that_outlives_its_budget_is_a_timeout_not_a_transport_error`.
+    async fn get_json<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+        budget: Duration,
+    ) -> AdapterResult<T> {
         let url = format!("{}{path}", self.base_url);
         let mut retries = 0;
         let (status, body) = loop {
-            match self.send_once(&url).await {
+            match self.send_once(&url, budget).await {
                 Ok(answer) => break answer,
                 Err(e) if retries < TRANSPORT_RETRIES && is_retryable_transport(&e) => {
                     retries += 1;
@@ -621,6 +629,11 @@ impl HttpAnalyzeMetricsSource {
                         error = %e,
                         "--analyze: pooled connection lost; retrying on a fresh one"
                     );
+                }
+                Err(e) if e.is_timeout() => {
+                    return Err(AnalyzeAdapterError::Timeout(format!(
+                        "GET {url} exceeded {budget:?}"
+                    )));
                 }
                 Err(e) => return Err(AnalyzeAdapterError::Transport(format!("GET {url}: {e}"))),
             }
@@ -639,19 +652,65 @@ impl HttpAnalyzeMetricsSource {
     /// Why: distinguishes "repo not indexed" (a fail-open skip with a clear
     /// warning) from a transport error, per the indexing prerequisite (#2448).
     async fn index_served(&self, index_id: &str) -> AdapterResult<bool> {
-        let indexes: Vec<IndexInfo> = self.get_json("/indexes").await?;
+        let endpoint = AnalyzeEndpoint::IndexList;
+        let indexes: Vec<IndexInfo> = self
+            .get_json(&endpoint.path(index_id), endpoint.budget())
+            .await?;
         Ok(indexes.iter().any(|i| i.id == index_id))
+    }
+
+    /// Fetch one dataset endpoint, reporting a failure as a NAMED caveat rather
+    /// than aborting the whole repository's fetch.
+    ///
+    /// Why (#6041): the per-repo fetch used to be all-or-nothing — one endpoint
+    /// failing discarded the data every other endpoint had already returned. In
+    /// the field the diagnostics call was the slow one, so a complexity
+    /// histogram that answered in seconds was thrown away with it and the whole
+    /// report fell back to scan. Each endpoint now stands alone: what arrived is
+    /// kept, and what did not names itself.
+    /// What: `Some(T)` on success; on failure logs the detail to stderr, pushes
+    /// an [`AnalyzeCaveat::EndpointUnavailable`] naming the endpoint and the
+    /// failure category, and returns `None`. The error text never reaches the
+    /// caveat — it can quote a URL or a response body, and the artifact gets the
+    /// category only.
+    /// Test: `a_failing_endpoint_keeps_what_the_others_returned`,
+    /// `a_request_that_outlives_its_budget_is_a_timeout_not_a_transport_error`.
+    async fn fetch_dataset<T: serde::de::DeserializeOwned>(
+        &self,
+        index_id: &str,
+        endpoint: AnalyzeEndpoint,
+        caveats: &mut Vec<AnalyzeCaveat>,
+    ) -> Option<T> {
+        match self
+            .get_json(&endpoint.path(index_id), endpoint.budget())
+            .await
+        {
+            Ok(v) => Some(v),
+            Err(e) => {
+                let reason = classify_failure(&e);
+                tracing::warn!(index_id, endpoint = endpoint.as_str(), error = %e,
+                    "--analyze: endpoint unavailable; the rest of the fetch continues");
+                eprintln!(
+                    "[trusty-review report] --analyze: '{index_id}' {} unavailable ({e}); \
+                     the sections it feeds are marked unassessed",
+                    endpoint.as_str()
+                );
+                caveats.push(AnalyzeCaveat::EndpointUnavailable(endpoint, reason));
+                None
+            }
+        }
     }
 
     /// The success path behind [`AnalyzeMetricsSource::fetch`]: probe readiness,
     /// pull the datasets, and map them. Returns `Err` on any failure; the
     /// public `fetch` swallows it to `None`.
     ///
-    /// The complexity distribution is the one dataset whose absence is
-    /// tolerated rather than fatal (#5320): a daemon predating
-    /// `/complexity_distribution` answers 404, and the honest response to that
-    /// is to omit the §7 table and say so, not to abandon the findings that DID
-    /// come back.
+    /// Every dataset endpoint is fetched independently (#6041): a failure on one
+    /// leaves the others' data in place and adds a caveat naming the endpoint
+    /// that dropped out. Only the readiness probe is still fatal — without it
+    /// the adapter cannot tell an unindexed repository from a broken one — and
+    /// so is the case where NO dataset answered, which is a fetch that assessed
+    /// nothing and must fall back to scan rather than render an empty pass.
     async fn try_fetch(
         &self,
         index_id: &str,
@@ -670,39 +729,38 @@ impl HttpAnalyzeMetricsSource {
         }
         let mut caveats: Vec<AnalyzeCaveat> = Vec::new();
 
-        let distribution: Option<DistributionEnvelope> = match self
-            .get_json(&format!("/indexes/{index_id}/complexity_distribution"))
-            .await
-        {
-            Ok(d) => Some(d),
-            Err(e) => {
-                tracing::warn!(index_id, error = %e, "--analyze: no complexity distribution");
-                eprintln!(
-                    "[trusty-review report] --analyze: '{index_id}' complexity distribution \
-                     unavailable ({e}); the §7 table is omitted"
-                );
-                caveats.push(AnalyzeCaveat::ComplexityDistributionUnavailable);
-                None
-            }
-        };
+        let distribution: Option<DistributionEnvelope> = self
+            .fetch_dataset(
+                index_id,
+                AnalyzeEndpoint::ComplexityDistribution,
+                &mut caveats,
+            )
+            .await;
+        let diagnostics: Option<DiagnosticsEnvelope> = self
+            .fetch_dataset(index_id, AnalyzeEndpoint::Diagnostics, &mut caveats)
+            .await;
+        let refactors: Option<RefactorEnvelope> = self
+            .fetch_dataset(index_id, AnalyzeEndpoint::RefactorSuggestions, &mut caveats)
+            .await;
 
-        let diagnostics: DiagnosticsEnvelope = self
-            .get_json(&format!("/indexes/{index_id}/diagnostics"))
-            .await?;
-        if diagnostics.tools_run.is_empty() {
+        if distribution.is_none() && diagnostics.is_none() && refactors.is_none() {
+            // Nothing was assessed, so there is nothing partial to render.
+            // Reporting metrics here would put an empty findings table and an
+            // empty §7 on the page, which reads as a clean pass.
+            return Err(AnalyzeAdapterError::Transport(format!(
+                "no dataset endpoint answered for '{index_id}'"
+            )));
+        }
+        // An empty `tools_run` is the daemon answering that no linter existed —
+        // a different fact from the endpoint not answering at all (#5317).
+        if diagnostics.as_ref().is_some_and(|d| d.tools_run.is_empty()) {
             caveats.push(AnalyzeCaveat::NoStaticAnalysisTools);
         }
 
-        let refactors: RefactorEnvelope = self
-            .get_json(&format!("/indexes/{index_id}/refactor-suggestions"))
-            .await?;
-
+        let diags = diagnostics.map(|d| d.diagnostics).unwrap_or_default();
+        let refs = refactors.map(|r| r.suggestions).unwrap_or_default();
         Ok(Some((
-            map_metrics(
-                distribution.as_ref(),
-                &diagnostics.diagnostics,
-                &refactors.suggestions,
-            ),
+            map_metrics(distribution.as_ref(), &diags, &refs),
             caveats,
         )))
     }
@@ -865,7 +923,7 @@ pub async fn enrich_with_analyze_gaps(
     lines.extend(
         partial
             .into_iter()
-            .map(|(caveat, repos)| format!("{} — affects: {}.", caveat.as_str(), repos.join(", "))),
+            .map(|(caveat, repos)| format!("{caveat} — affects: {}.", repos.join(", "))),
     );
     lines
 }

--- a/crates/trusty-review/src/report/analyze_adapter_tests.rs
+++ b/crates/trusty-review/src/report/analyze_adapter_tests.rs
@@ -9,6 +9,10 @@
 use super::*;
 use std::sync::atomic::{AtomicU32, Ordering};
 
+/// A budget short enough to keep the transport tests fast and long enough that
+/// a loopback stub always beats it. Only the timeout tests want it hit.
+const CHEAP_TEST_BUDGET: Duration = Duration::from_secs(5);
+
 // ─── Severity map ────────────────────────────────────────────────────────────
 
 #[test]
@@ -330,13 +334,13 @@ async fn transport_failure_on_a_reused_connection_retries_once() {
     let src = HttpAnalyzeMetricsSource::new(format!("http://{addr}")).expect("client builds");
 
     let first: serde_json::Value = src
-        .get_json("/indexes")
+        .get_json("/indexes", CHEAP_TEST_BUDGET)
         .await
         .expect("the first GET opens a connection and is answered");
     assert_eq!(first, serde_json::json!([]));
 
     let second: serde_json::Value = src
-        .get_json("/indexes/demo/diagnostics")
+        .get_json("/indexes/demo/diagnostics", CHEAP_TEST_BUDGET)
         .await
         .expect("a closed pooled connection must be retried on a fresh one");
     assert_eq!(second, serde_json::json!([]));
@@ -359,7 +363,7 @@ async fn a_connection_that_keeps_dying_is_retried_exactly_once() {
     let src = HttpAnalyzeMetricsSource::new(format!("http://{addr}")).expect("client builds");
 
     let err = src
-        .get_json::<serde_json::Value>("/indexes")
+        .get_json::<serde_json::Value>("/indexes", CHEAP_TEST_BUDGET)
         .await
         .expect_err("a peer that answers nothing cannot succeed");
     assert!(
@@ -371,6 +375,222 @@ async fn a_connection_that_keeps_dying_is_retried_exactly_once() {
         2,
         "one original attempt plus one retry, and no more"
     );
+}
+
+// ─── Per-endpoint budgets and independence (#6041) ───────────────────────────
+
+/// Why (#6041): the adapter used one 15 s budget for every endpoint while
+/// trusty-analyze runs project-scoped clippy under a 180 s deadline, so the
+/// client gave up on a request the daemon answered 200 at 142 s. A client that
+/// gives up before the server's outermost rung turns every structured answer —
+/// including the daemon's own cutoff report — into a bare transport error.
+/// What: walks the configurable deadline range and asserts the client budget
+/// outlives the daemon's router rung (deadline + 30 s handler grace + 30 s
+/// router margin, from `trusty-analyze/src/core/deadlines.rs`) at every value.
+/// Test: This is the test. Fails against the old flat 15 s constant at every
+/// deadline.
+#[test]
+fn diagnostics_budget_outlives_the_daemon_deadline_ladder() {
+    for secs in [1u64, 60, 180, 270, 600, 3600] {
+        let deadline = Duration::from_secs(secs);
+        let router_rung = deadline + Duration::from_secs(60);
+        let budget = diagnostics_budget_for(deadline);
+        assert!(
+            budget > router_rung,
+            "deadline={secs}s: client budget {budget:?} must outlive the daemon's \
+             outermost responding rung {router_rung:?}, or the daemon's answer \
+             never reaches the report"
+        );
+    }
+    assert!(
+        AnalyzeEndpoint::Diagnostics.budget() > AnalyzeEndpoint::ComplexityDistribution.budget(),
+        "the endpoint that runs external tooling must not share a budget with a \
+         memory read"
+    );
+}
+
+/// Build a raw HTTP/1.1 response with a correct `Content-Length`.
+fn http_response(status: &str, body: &str) -> String {
+    format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    )
+}
+
+/// A loopback stub that answers each request from a path → response table.
+///
+/// Why (#6041): the defect is about what happens when endpoints disagree — one
+/// answers in milliseconds and another does not answer at all — so the stub has
+/// to route per path rather than reply uniformly.
+/// What: binds `127.0.0.1:0` and replies with the first route whose path is a
+/// substring of the request (so order the table most-specific first). An empty
+/// response body is the "never answer" route: the client must hit its own
+/// budget. An unmatched path gets a 404.
+/// Test: `a_failing_endpoint_keeps_what_the_others_returned`,
+/// `a_fetch_where_no_endpoint_answered_falls_back_to_scan`,
+/// `a_request_that_outlives_its_budget_is_a_timeout_not_a_transport_error`.
+async fn routing_stub(routes: Vec<(&'static str, String)>) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback stub");
+    let addr = listener.local_addr().expect("stub addr").to_string();
+    let routes = std::sync::Arc::new(routes);
+    tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let routes = std::sync::Arc::clone(&routes);
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                loop {
+                    let n = match stream.read(&mut buf).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(n) => n,
+                    };
+                    let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let reply = routes
+                        .iter()
+                        .find(|(path, _)| req.contains(path))
+                        .map(|(_, body)| body.clone());
+                    match reply {
+                        Some(r) if r.is_empty() => std::future::pending::<()>().await,
+                        Some(r) => {
+                            let _ = stream.write_all(r.as_bytes()).await;
+                        }
+                        None => {
+                            let _ = stream
+                                .write_all(http_response("404 Not Found", "{}").as_bytes())
+                                .await;
+                        }
+                    }
+                }
+            });
+        }
+    });
+    addr
+}
+
+/// A five-band histogram, the shape the §7 table renders from.
+const DISTRIBUTION_BODY: &str = r#"{"index_id":"demo","total":100,"buckets":[
+    {"grade":"A","label":"A: simple (0-5)","count":60},
+    {"grade":"B","label":"B: moderate (6-10)","count":20},
+    {"grade":"C","label":"C: elevated (11-15)","count":10},
+    {"grade":"D","label":"D: high (16-20)","count":7},
+    {"grade":"F","label":"F: very high (>20)","count":3}]}"#;
+
+/// Why (#6041): the per-repo fetch was all-or-nothing. Diagnostics is the slow
+/// endpoint, so its timeout discarded a complexity histogram that had already
+/// arrived in milliseconds and dropped the whole repository back to scan — the
+/// report lost data it was holding.
+/// What: a stub that answers the index probe, the histogram, and the refactor
+/// list normally while returning the daemon's own deadline 504 for diagnostics.
+/// Asserts the histogram survives, that exactly one caveat is raised, and that
+/// the caveat names diagnostics and says it ran out of time.
+/// Test: This is the test. Pre-fix the 504 propagated through `?` and
+/// `fetch_named` returned `Missing(Unreachable)` with no metrics at all.
+#[tokio::test]
+async fn a_failing_endpoint_keeps_what_the_others_returned() {
+    let addr = routing_stub(vec![
+        (
+            "/indexes/demo/complexity_distribution",
+            http_response("200 OK", DISTRIBUTION_BODY),
+        ),
+        (
+            "/indexes/demo/diagnostics",
+            // What trusty-analyze answers when its own deadline is hit.
+            http_response("504 Gateway Timeout", r#"{"error":"deadline exceeded"}"#),
+        ),
+        (
+            "/indexes/demo/refactor-suggestions",
+            http_response("200 OK", r#"{"suggestions":[]}"#),
+        ),
+        (
+            "/indexes",
+            http_response("200 OK", r#"[{"id":"demo","root_path":"/tmp/demo"}]"#),
+        ),
+    ])
+    .await;
+    let src = HttpAnalyzeMetricsSource::new(format!("http://{addr}")).expect("client builds");
+
+    match src.fetch_named("demo").await {
+        AnalyzeFetch::Fetched { metrics, caveats } => {
+            assert_eq!(
+                metrics.complexity.buckets.len(),
+                5,
+                "the histogram that answered in milliseconds must survive a slow \
+                 sibling endpoint"
+            );
+            let line = caveats
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(" | ");
+            assert_eq!(caveats.len(), 1, "only diagnostics dropped out: {line}");
+            assert!(line.contains("diagnostics"), "the gap must name it: {line}");
+            assert!(
+                line.contains("did not answer within the time allowed"),
+                "the gap must say why: {line}"
+            );
+            assert!(
+                line.contains("unassessed, not clean"),
+                "an emptied defect band must not read as a clean pass: {line}"
+            );
+        }
+        AnalyzeFetch::Missing(gap) => {
+            panic!("one slow endpoint must not discard the whole fetch: {gap:?}")
+        }
+    }
+}
+
+/// Why (#6041): per-endpoint independence must not become fail-SILENT. If every
+/// dataset drops out there is nothing partial to render, and reporting empty
+/// metrics would put an empty §7 and an empty findings table on the page — which
+/// reads as a clean pass.
+/// What: a stub whose index probe succeeds and whose every dataset endpoint
+/// answers 503; the fetch must fall back to scan, not to empty metrics.
+/// Test: This is the test.
+#[tokio::test]
+async fn a_fetch_where_no_endpoint_answered_falls_back_to_scan() {
+    let addr = routing_stub(vec![
+        (
+            "/indexes/demo/",
+            http_response("503 Service Unavailable", "{}"),
+        ),
+        ("/indexes", http_response("200 OK", r#"[{"id":"demo"}]"#)),
+    ])
+    .await;
+    let src = HttpAnalyzeMetricsSource::new(format!("http://{addr}")).expect("client builds");
+
+    match src.fetch_named("demo").await {
+        AnalyzeFetch::Missing(gap) => assert_eq!(gap, AnalyzeGap::Unreachable),
+        AnalyzeFetch::Fetched { .. } => {
+            panic!("a fetch that assessed nothing must not render as assessed")
+        }
+    }
+}
+
+/// Why (#6041): the gap line distinguishes "ran out of time" from "nothing was
+/// listening" because the remedies differ, and that distinction has to come from
+/// the error class rather than from matching a message that can quote a URL.
+/// What: points `get_json` at a stub that never replies, with a budget short
+/// enough to be hit, and asserts the failure is a `Timeout` classified as
+/// `TimedOut` — not the `Transport` variant a dead peer produces.
+/// Test: This is the test. Pre-fix `get_json` took no budget at all.
+#[tokio::test]
+async fn a_request_that_outlives_its_budget_is_a_timeout_not_a_transport_error() {
+    let addr = routing_stub(vec![("/indexes", String::new())]).await;
+    let src = HttpAnalyzeMetricsSource::new(format!("http://{addr}")).expect("client builds");
+
+    let err = src
+        .get_json::<serde_json::Value>("/indexes", Duration::from_millis(150))
+        .await
+        .expect_err("a stub that never replies cannot answer inside 150ms");
+
+    assert!(
+        matches!(err, AnalyzeAdapterError::Timeout(_)),
+        "expected a timeout, got {err:?}"
+    );
+    assert_eq!(classify_failure(&err), EndpointFailure::TimedOut);
 }
 
 #[test]
@@ -473,10 +693,28 @@ fn gap_labels_are_stable() {
 /// Test: itself.
 #[test]
 fn caveat_labels_are_stable() {
-    let dist = AnalyzeCaveat::ComplexityDistributionUnavailable.as_str();
+    let dist = AnalyzeCaveat::EndpointUnavailable(
+        AnalyzeEndpoint::ComplexityDistribution,
+        EndpointFailure::Rejected,
+    )
+    .to_string();
+    assert!(dist.contains("complexity distribution"), "{dist}");
     assert!(dist.contains("not a distribution"), "{dist}");
     assert!(dist.contains("omitted"), "{dist}");
-    let tools = AnalyzeCaveat::NoStaticAnalysisTools.as_str();
+
+    // #6041: the line must name the endpoint AND why it dropped out, because
+    // "raise the deadline" and "start the daemon" are different remedies.
+    let diag =
+        AnalyzeCaveat::EndpointUnavailable(AnalyzeEndpoint::Diagnostics, EndpointFailure::TimedOut)
+            .to_string();
+    assert!(diag.contains("diagnostics"), "{diag}");
+    assert!(
+        diag.contains("did not answer within the time allowed"),
+        "{diag}"
+    );
+    assert!(diag.contains("unassessed, not clean"), "{diag}");
+
+    let tools = AnalyzeCaveat::NoStaticAnalysisTools.to_string();
     assert!(tools.contains("unassessed, not clean"), "{tools}");
 }
 
@@ -491,7 +729,10 @@ async fn enrich_reports_caveats_for_partially_answered_repositories() {
     let source = StubSource(|| AnalyzeFetch::Fetched {
         metrics: Box::new(map_metrics(None, &[], &[])),
         caveats: vec![
-            AnalyzeCaveat::ComplexityDistributionUnavailable,
+            AnalyzeCaveat::EndpointUnavailable(
+                AnalyzeEndpoint::ComplexityDistribution,
+                EndpointFailure::Rejected,
+            ),
             AnalyzeCaveat::NoStaticAnalysisTools,
         ],
     });

--- a/crates/trusty-review/src/report/analyze_endpoints.rs
+++ b/crates/trusty-review/src/report/analyze_endpoints.rs
@@ -1,0 +1,254 @@
+//! The trusty-analyze endpoints `--analyze` fetches: their paths, their
+//! per-request budgets, and the report-facing vocabulary for the ones that fail.
+//!
+//! Why: the adapter used one 15 s budget for every endpoint, which is shorter
+//! than trusty-analyze's own deadline for `/diagnostics`. That daemon runs
+//! project-scoped clippy under a 180 s cooperative deadline and answers 200 at
+//! 142 s in the field, so the client gave up on a request the daemon went on to
+//! answer. A client timeout below the server's own deadline is the exact
+//! inversion #6034 fixed inside trusty-analyze: whoever gives up first decides
+//! what the caller sees, and only the daemon's answer carries which tools ran
+//! and what they found. The budgets therefore live beside the paths they apply
+//! to, so adding an endpoint forces a decision about its cost.
+//!
+//! What: [`AnalyzeEndpoint`] owns the path, the report-facing name, the
+//! consequence of losing it, and the request budget. [`AnalyzeCaveat`] and
+//! [`EndpointFailure`] carry a per-endpoint failure to the report's Gaps &
+//! Caveats list, so one slow endpoint names itself instead of erasing the whole
+//! fetch.
+//!
+//! Test: `analyze_adapter_tests.rs::{diagnostics_budget_outlives_the_daemon_
+//! deadline_ladder, caveat_labels_are_stable}`.
+
+use std::fmt;
+use std::time::Duration;
+
+// ─── Request budgets ─────────────────────────────────────────────────────────
+
+/// Per-request budget for the endpoints that answer from data already computed.
+///
+/// Why: `/indexes`, the complexity histogram, and the refactor list are reads
+/// over an in-memory corpus and answer in seconds. A short budget on them is
+/// what keeps an unreachable daemon from stalling a report for minutes.
+const CHEAP_BUDGET: Duration = Duration::from_secs(15);
+
+/// The environment variable trusty-analyze reads for its diagnostics deadline.
+///
+/// Why: the daemon's budget is operator-tunable, so a client budget pinned to
+/// the default would fall back below the deadline the moment anyone raised it.
+/// Reading the same variable keeps the ordering invariant at every configured
+/// value rather than only at the default.
+const DIAGNOSTICS_DEADLINE_ENV: &str = "TRUSTY_DIAGNOSTICS_DEADLINE_SECS";
+
+/// trusty-analyze's diagnostics deadline when the operator sets none.
+///
+/// Pinned to `DEFAULT_DIAGNOSTICS_DEADLINE_SECS` in
+/// `trusty-analyze/src/core/deadlines.rs`. It is a copy, not a shared constant:
+/// trusty-analyze optionally depends on this crate through its `review` feature,
+/// so a library dependency the other way is a cargo cycle.
+const DEFAULT_DIAGNOSTICS_DEADLINE: Duration = Duration::from_secs(180);
+
+/// Total headroom trusty-analyze stacks above its own cooperative deadline
+/// before anything gives up.
+///
+/// Why: the daemon's ladder is `deadline` → `+30 s` handler grace (a 504 with a
+/// JSON body naming what was cut off) → `+30 s` router `TimeoutLayer` (an
+/// empty-bodied 504) → `+30 s` MCP client. A client that gives up at or below
+/// the router rung turns every one of those structured answers into a bare
+/// transport error, which is what #6034 fixed for the MCP path. This client
+/// takes the same outermost rung, so the daemon's own response — including its
+/// cutoff report — always arrives.
+const SERVER_LADDER_HEADROOM: Duration = Duration::from_secs(90);
+
+/// The diagnostics deadline this client should assume the daemon is using.
+///
+/// What: reads [`DIAGNOSTICS_DEADLINE_ENV`] exactly as trusty-analyze does,
+/// falling back to [`DEFAULT_DIAGNOSTICS_DEADLINE`] on a missing, unparseable,
+/// or zero value.
+fn configured_diagnostics_deadline() -> Duration {
+    std::env::var(DIAGNOSTICS_DEADLINE_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .map_or(DEFAULT_DIAGNOSTICS_DEADLINE, Duration::from_secs)
+}
+
+/// The client budget for a diagnostics request against a daemon running
+/// `deadline`.
+///
+/// Why: taking the deadline as a parameter is what makes the ordering invariant
+/// testable across the whole configurable range without mutating process-wide
+/// environment state — the same reason trusty-analyze's `handler_budget_for`
+/// takes one.
+/// Test: `diagnostics_budget_outlives_the_daemon_deadline_ladder`.
+pub fn diagnostics_budget_for(deadline: Duration) -> Duration {
+    deadline + SERVER_LADDER_HEADROOM
+}
+
+// ─── Endpoints ───────────────────────────────────────────────────────────────
+
+/// One trusty-analyze endpoint the adapter fetches.
+///
+/// Why: the path, the budget, and the sentence a reader sees when it fails are
+/// three facts about the same endpoint, and keeping them apart is how the
+/// budget drifted from the cost in the first place.
+/// What: `path` builds the request path, `as_str` names the endpoint in the
+/// report, `consequence` says what its absence costs the report, and `budget`
+/// gives the per-request timeout.
+/// Test: `diagnostics_budget_outlives_the_daemon_deadline_ladder`,
+/// `caveat_labels_are_stable`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum AnalyzeEndpoint {
+    /// `GET /indexes` — the readiness probe.
+    IndexList,
+    /// `GET /indexes/{id}/complexity_distribution` — the §7 histogram.
+    ComplexityDistribution,
+    /// `GET /indexes/{id}/diagnostics` — the external static-analysis pass.
+    Diagnostics,
+    /// `GET /indexes/{id}/refactor-suggestions` — maintainability findings.
+    RefactorSuggestions,
+}
+
+impl AnalyzeEndpoint {
+    /// The request path for this endpoint against `index_id`.
+    pub fn path(self, index_id: &str) -> String {
+        match self {
+            Self::IndexList => "/indexes".to_string(),
+            Self::ComplexityDistribution => {
+                format!("/indexes/{index_id}/complexity_distribution")
+            }
+            Self::Diagnostics => format!("/indexes/{index_id}/diagnostics"),
+            Self::RefactorSuggestions => format!("/indexes/{index_id}/refactor-suggestions"),
+        }
+    }
+
+    /// The endpoint's name as the report states it.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::IndexList => "index list",
+            Self::ComplexityDistribution => "complexity distribution",
+            Self::Diagnostics => "diagnostics",
+            Self::RefactorSuggestions => "refactor suggestions",
+        }
+    }
+
+    /// What the report loses when this endpoint does not answer.
+    ///
+    /// Why: a named gap that only says which endpoint failed still leaves the
+    /// reader to guess which section is now unassessed. Every phrase here
+    /// refuses to let an emptied section read as a clean one.
+    fn consequence(self) -> &'static str {
+        match self {
+            Self::IndexList => {
+                "no dimension of this repository was assessed — the report falls back to the \
+                 repository scan alone"
+            }
+            Self::ComplexityDistribution => {
+                "the §7 complexity table is omitted rather than filled from a truncated top-N \
+                 sample, which is not a distribution"
+            }
+            Self::Diagnostics => {
+                "the RED/CRITICAL defect band is populated only from external static analysis, \
+                 so an empty band here means unassessed, not clean"
+            }
+            Self::RefactorSuggestions => {
+                "the maintainability findings are unlisted, which means unassessed, not clean"
+            }
+        }
+    }
+
+    /// The per-request timeout for this endpoint.
+    ///
+    /// Why: diagnostics is the one endpoint that runs external tooling — a
+    /// project-scoped `cargo clippy` — under the daemon's own deadline, so its
+    /// budget is derived from that ladder. Everything else reads memory and
+    /// keeps the short budget, which is what stops a dead daemon from holding
+    /// the report open for minutes.
+    /// Test: `diagnostics_budget_outlives_the_daemon_deadline_ladder`.
+    pub fn budget(self) -> Duration {
+        match self {
+            Self::Diagnostics => diagnostics_budget_for(configured_diagnostics_deadline()),
+            _ => CHEAP_BUDGET,
+        }
+    }
+}
+
+// ─── Failure vocabulary ──────────────────────────────────────────────────────
+
+/// How one endpoint failed, in terms a report reader can act on.
+///
+/// Why: "diagnostics did not answer" and "diagnostics ran out of time" point at
+/// different remedies — a daemon to start versus a deadline to raise — and the
+/// distinction survives into the artifact without carrying a URL or a response
+/// body with it.
+/// What: three categories the adapter can tell apart from its own error type.
+/// Test: `caveat_labels_are_stable`, `a_request_that_outlives_its_budget_is_a_timeout_not_a_transport_error`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum EndpointFailure {
+    /// The budget ran out, on either side of the connection.
+    TimedOut,
+    /// Nothing answered — the daemon was unreachable or the connection died.
+    Unanswered,
+    /// The daemon answered, but with something unusable (non-2xx, bad JSON).
+    Rejected,
+}
+
+impl EndpointFailure {
+    /// The clause the report uses for this failure.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TimedOut => "did not answer within the time allowed",
+            Self::Unanswered => "could not be reached",
+            Self::Rejected => "returned an answer this report could not use",
+        }
+    }
+}
+
+/// A dimension the daemon answered incompletely, for one repository (#5317,
+/// #5320, #6041).
+///
+/// Why: a fetch that succeeds is not the same as a fetch that answered
+/// everything, and the difference is invisible on the page. An empty RED band
+/// because no linter was installed reads exactly like a clean codebase; a
+/// missing complexity table reads like a rendering slip. Both are facts the
+/// report owes its reader, and both travel the same Gaps & Caveats path
+/// [`AnalyzeGap`](super::analyze_adapter::AnalyzeGap) already uses.
+/// What: one variant per condition the fetch can distinguish. The rendered
+/// sentence is built from fixed per-endpoint and per-failure phrases, so it
+/// names the endpoint and the reason while carrying no run-specific detail.
+/// Test: `analyze_adapter_tests.rs::caveat_labels_are_stable`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum AnalyzeCaveat {
+    /// One endpoint did not answer while others did.
+    EndpointUnavailable(AnalyzeEndpoint, EndpointFailure),
+    /// No external static-analysis tool was installed, so nothing could
+    /// populate the RED/defect band.
+    NoStaticAnalysisTools,
+}
+
+impl fmt::Display for AnalyzeCaveat {
+    /// The report-facing sentence for this caveat.
+    ///
+    /// Why: read by a stranger to this toolchain, so it names the condition and
+    /// what it means for the section, not the variant.
+    /// What: deterministic across runs — every fragment is a fixed string.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EndpointUnavailable(endpoint, reason) => write!(
+                f,
+                "the analysis daemon's {} endpoint {} — {}",
+                endpoint.as_str(),
+                reason.as_str(),
+                endpoint.consequence()
+            ),
+            Self::NoStaticAnalysisTools => f.write_str(
+                "no external static-analysis tool was available to the analysis daemon — the \
+                 RED/CRITICAL band is populated only from such tools, so an empty band here \
+                 means unassessed, not clean",
+            ),
+        }
+    }
+}

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -14,6 +14,8 @@
 //! lives in `crates/trusty-review/tests/report_e2e.rs`.
 
 pub mod analyze_adapter;
+// #6041: per-endpoint paths, request budgets, and partial-fetch vocabulary.
+pub mod analyze_endpoints;
 // #5453/#6004: the tga-authored authorship artifact, receiving half.
 pub mod authorship;
 pub mod benchmark;


### PR DESCRIPTION
Refs #6041 — MUST be "Refs", never "Closes": closure is gated on a live --analyze render per the issue lifecycle; the issue moves to `status:merged` on merge.

The analyze client gave the daemon 15s to answer a diagnostics request the daemon is entitled to take 210s over (its own deadline ladder), and one slow endpoint discarded every fast endpoint's data. Now: a new `analyze_endpoints` module owns each endpoint's path, name, consequence, and budget together; the diagnostics budget derives from the same env var the daemon reads plus the ladder's 90s headroom, so the client outlives the daemon's outermost responding rung at every configured deadline. Endpoints fetch independently — a failure yields a named partial gap ("unassessed, not clean") while everything that answered renders. A fetch where nothing answered still falls back to scan as fail-open. #6040's retry semantics untouched; timeouts get their own error variant.

Rung 3 (trusty-review): fmt/clippy clean; 1689 tests passing, 0 failed; doc-pointer lint 26100/0; changelog fragment present. Three regression tests shown failing pre-fix (one at compile time). Known limitation, documented in-code: the 180s default is a copy of trusty-analyze's constant (a library dep back would be a cargo cycle); hoisting the ladder to trusty-common is follow-up.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools