### PR TITLE
fix(trusty-review): exec-summary guardrail accepts conventional roundings of measured figures

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -721,8 +721,6 @@ crates/trusty-review/src/report/mermaid.rs	parses_table_rows
 crates/trusty-review/src/report/mermaid.rs	renders_bar
 crates/trusty-review/src/report/polish.rs	polish_end_to_end
 crates/trusty-review/src/report/synthesize_guard.rs	canonicalize_number_variants
-crates/trusty-review/src/report/synthesize_guard.rs	verify_prose_passes_faithful
-crates/trusty-review/src/report/synthesize_guard.rs	verify_prose_rejects_fabricated
 crates/trusty-review/src/service/handlers.rs	health_inference_ok_when_llm_ok
 crates/trusty-review/src/service/handlers.rs	health_returns_ok_json
 crates/trusty-review/src/service/handlers.rs	new_for_test

--- a/crates/trusty-review/changelog.d/6030-rounding-aware-verifier.md
+++ b/crates/trusty-review/changelog.d/6030-rounding-aware-verifier.md
@@ -1,0 +1,16 @@
+Fixed
+
+- **A synthesized narrative that rounds a measured figure is no longer dropped as
+  fabricated**
+  ([#6030](https://github.com/bobmatnyc/trusty-tools/issues/6030)).
+  The numeric guardrail compared canonical strings, so an authorship summary
+  writing a measured `top_author_share_pct` of 85.19 as "85%" produced
+  `rejected (unverified figure) in authorship summary: 85` and the whole LLM
+  narrative fell back to the deterministic composer. Live verification of #6037
+  failed on exactly that.
+- `allowed_numbers` now widens each measured figure with its conventional
+  roundings — the truncation and the round-half-up form at every coarser decimal
+  precision, carries included (85.19 admits 85.1, 85.2 and 85; 9.99 admits 10).
+  Integer figures are not widened, so a measured 8234 still never admits 8,000,
+  and a figure matching no measured value under any rounding is rejected exactly
+  as before, dropping the field with its raw-response capture.

--- a/crates/trusty-review/src/report/synthesize_guard.rs
+++ b/crates/trusty-review/src/report/synthesize_guard.rs
@@ -11,9 +11,11 @@
 //! What: [`allowed_numbers`] builds the canonical set of numbers the source model
 //! actually contains (walking the serialized model); [`verify_prose`] checks that
 //! every number token in a candidate string is in that set, tolerating formatting
-//! variants (thousands separators, `$`, `%`, trailing-zero decimals).
+//! variants (thousands separators, `$`, `%`, trailing-zero decimals) and
+//! conventional roundings of a measured value (#6030 — see [`rounded_forms`]).
 //! Test: `synthesize_tests.rs` covers extraction, canonicalisation, the
-//! formatting-variant equivalences, and the reject path.
+//! formatting-variant equivalences, the rounding equivalences, and the reject
+//! path.
 
 use std::collections::HashSet;
 use std::sync::OnceLock;
@@ -66,6 +68,64 @@ pub fn numbers_in(text: &str) -> Vec<String> {
         .collect()
 }
 
+/// Increment a bare digit string by one, carrying left.
+///
+/// `"9"` → `"10"`, `"099"` → `"100"`.  A full carry grows the string by one
+/// digit, which the caller detects by comparing lengths.  Input is always a
+/// digit run taken from an already-canonicalised key, so no parse can fail.
+fn increment_digits(digits: &str) -> String {
+    let mut out = digits.as_bytes().to_vec();
+    for i in (0..out.len()).rev() {
+        if out[i] == b'9' {
+            out[i] = b'0';
+        } else {
+            out[i] += 1;
+            return String::from_utf8_lossy(&out).into_owned();
+        }
+    }
+    format!("1{}", String::from_utf8_lossy(&out))
+}
+
+/// Re-join an integer part and a (possibly empty) fraction into a canonical key.
+fn join_parts(int_part: &str, frac: &str) -> String {
+    if frac.is_empty() {
+        canonicalize(int_part)
+    } else {
+        canonicalize(&format!("{int_part}.{frac}"))
+    }
+}
+
+/// Every conventional rounding of a canonical key at a coarser decimal precision.
+///
+/// Why: #6030 — a narrative that writes a measured 85.19 as "85%" or "85.2%" is
+/// restating the source figure, not inventing one, and rejecting it dropped the
+/// entire LLM narrative.  The guardrail compares canonical STRINGS, so the only
+/// way a coarser spelling can verify is for the allowed set to carry it.
+/// What: for a key with a fraction, emits both the truncation and the
+/// round-half-up form at every precision coarser than the key's own — `85.19`
+/// yields `85.1`, `85.2`, and `85`.  Carries propagate (`9.99` yields `10`).  An
+/// integer key yields nothing: this widens decimal precision only, so a measured
+/// 8234 never admits "8,000".
+/// Test: `allowed_numbers_admits_rounded_forms`, `verify_prose_accepts_rounding`.
+fn rounded_forms(canonical: &str) -> Vec<String> {
+    let Some(dot) = canonical.find('.') else {
+        return Vec::new();
+    };
+    let (int_part, frac) = (&canonical[..dot], &canonical[dot + 1..]);
+    let mut out = Vec::new();
+    for k in 0..frac.len() {
+        out.push(join_parts(int_part, &frac[..k]));
+        if frac.as_bytes()[k] >= b'5' {
+            let kept = format!("{int_part}{}", &frac[..k]);
+            let bumped = increment_digits(&kept);
+            let int_len = int_part.len() + (bumped.len() - kept.len());
+            let (bumped_int, bumped_frac) = bumped.split_at(int_len);
+            out.push(join_parts(bumped_int, bumped_frac));
+        }
+    }
+    out
+}
+
 /// Build the set of numbers the deterministic source model legitimately contains.
 ///
 /// Why: the guardrail's ground truth is "what figures does the report's own data
@@ -73,8 +133,9 @@ pub fn numbers_in(text: &str) -> Vec<String> {
 /// metric, count, LoC total, git SHA digit-run, and date the report is derived
 /// from, with no hand-maintained field list to drift.
 /// What: walks the serialized [`Value`], adding canonical keys for every JSON
-/// number node and every number token found inside every string node.
-/// Test: `allowed_numbers_covers_metrics`.
+/// number node and every number token found inside every string node, plus each
+/// key's conventional roundings ([`rounded_forms`], #6030).
+/// Test: `allowed_numbers_covers_metrics`, `allowed_numbers_admits_rounded_forms`.
 pub fn allowed_numbers(model: &Value) -> HashSet<String> {
     let mut set = HashSet::new();
     collect(model, &mut set);
@@ -84,18 +145,18 @@ pub fn allowed_numbers(model: &Value) -> HashSet<String> {
 /// Recursively collect canonical number keys from a JSON value tree.
 fn collect(value: &Value, set: &mut HashSet<String>) {
     match value {
-        Value::Number(n) => {
-            set.insert(canonicalize(&n.to_string()));
-        }
-        Value::String(s) => {
-            for k in numbers_in(s) {
-                set.insert(k);
-            }
-        }
+        Value::Number(n) => insert_key(set, canonicalize(&n.to_string())),
+        Value::String(s) => numbers_in(s).into_iter().for_each(|k| insert_key(set, k)),
         Value::Array(items) => items.iter().for_each(|v| collect(v, set)),
         Value::Object(map) => map.values().for_each(|v| collect(v, set)),
         Value::Bool(_) | Value::Null => {}
     }
+}
+
+/// Add a canonical key and every coarser rounding of it to the allowed set.
+fn insert_key(set: &mut HashSet<String>, key: String) {
+    set.extend(rounded_forms(&key));
+    set.insert(key);
 }
 
 /// Verify that every number in `prose` traces back to the allowed set.
@@ -106,7 +167,15 @@ fn collect(value: &Value, set: &mut HashSet<String>) {
 /// What: returns `Ok(())` when every canonical number token in `prose` is a
 /// member of `allowed`; otherwise `Err(first_offending_token)`.  Prose with no
 /// numbers always passes.
-/// Test: `verify_prose_passes_faithful`, `verify_prose_rejects_fabricated`.
+///
+/// The acceptance rule is membership in a set that [`allowed_numbers`] has
+/// already widened by rounding (#6030), so a token verifies when it equals a
+/// measured figure under formatting normalisation (commas, `$`, `%`,
+/// trailing-zero decimals) OR equals that figure truncated or rounded half-up to
+/// any coarser decimal precision — measured 85.19 admits `85.1`, `85.2`, and
+/// `85`.  A token matching no measured figure under any of those readings still
+/// fails, and the caller still drops the whole field.
+/// Test: `verify_prose_passes_and_rejects`, `verify_prose_accepts_rounding`.
 pub fn verify_prose(prose: &str, allowed: &HashSet<String>) -> Result<(), String> {
     for token in numbers_in(prose) {
         if !allowed.contains(&token) {

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -254,6 +254,62 @@ fn verify_prose_passes_and_rejects() {
     );
 }
 
+/// Why: #6030 — the guardrail compares canonical strings, so a measured 85.19
+/// written as "85%" looked fabricated and the whole narrative was dropped. The
+/// allowed set must therefore carry the coarser spellings of every measured
+/// figure.
+/// What: asserts both the truncation and the round-half-up form at each coarser
+/// precision are admitted (including a carry, 9.99 → 10), and that neighbouring
+/// values that are no rounding of the source are still absent.
+/// Test: this test itself.
+#[test]
+fn allowed_numbers_admits_rounded_forms() {
+    let allowed = allowed_numbers(&serde_json::json!({
+        "top_author_share_pct": 85.19,
+        "score": 9.99,
+    }));
+    // The set holds canonical keys, so 10.0 is present under the key "10".
+    for form in ["85.19", "85.1", "85.2", "85", "9.99", "9.9", "10"] {
+        assert!(allowed.contains(form), "{form} is a rounding of the source");
+    }
+    for absent in ["85.3", "84", "86", "8.9", "11"] {
+        assert!(
+            !allowed.contains(absent),
+            "{absent} is no rounding of any source figure"
+        );
+    }
+}
+
+/// Why: #6030 regression — live verification of #6037 failed because the
+/// authorship narrative said "85%" for a measured `top_author_share_pct` of
+/// 85.19 and the guardrail reported "rejected (unverified figure): 85".
+/// What: the rounded spellings verify; a figure that is no rounding of any
+/// measured value is still rejected with the offending token surfaced.
+/// Test: this test itself.
+#[test]
+fn verify_prose_accepts_rounding() {
+    let allowed = allowed_numbers(&serde_json::json!({ "top_author_share_pct": 85.19 }));
+    for prose in [
+        "The top author owns 85% of the code.",
+        "The top author owns 85.2% of the code.",
+        "The top author owns 85.1% of the code.",
+        "The top author owns 85.19% of the code.",
+    ] {
+        assert!(
+            verify_prose(prose, &allowed).is_ok(),
+            "a conventional rounding must verify: {prose}"
+        );
+    }
+    assert_eq!(
+        verify_prose("The top author owns 84% of the code.", &allowed),
+        Err("84".to_string())
+    );
+    assert_eq!(
+        verify_prose("The top author owns 85.3% of the code.", &allowed),
+        Err("85.3".to_string())
+    );
+}
+
 // ── Prompt / schema ─────────────────────────────────────────────────────────
 
 /// Why: the no-green-analysis rule must be STRUCTURAL — greens never reach the
@@ -643,6 +699,101 @@ async fn synthesize_happy_path_injects_new_narrative_fields() {
     assert!(
         result.notes.is_empty(),
         "none of the three new fields is unrecognized or unverified: {:?}",
+        result.notes
+    );
+}
+
+/// Build the fixture model with an authorship artifact whose top-author share is
+/// `pct` — the shape behind #6030's live failure.
+fn fixture_model_with_top_author_share(pct: f64) -> ReportModel {
+    use crate::report::authorship::AuthorshipSummary;
+
+    let mut model = fixture_model(vec![]);
+    model.repositories[0].authorship = Some(AuthorshipSummary {
+        schema_version: "v0".to_string(),
+        repository: "acme-core".to_string(),
+        distinct_authors: 4,
+        bus_factor: 1,
+        top_author_share_pct: pct,
+        single_author_subsystems: vec!["migrations".to_string()],
+        monthly_trajectory: vec![],
+        unresolved_authors: 0,
+        caveats: vec![],
+    });
+    model
+}
+
+/// Why: #6030 end-to-end regression — the run that failed live verification of
+/// #6037 rendered "rejected (unverified figure) in authorship summary: 85"
+/// against a measured `top_author_share_pct` of 85.19, so the narrative was
+/// dropped for restating a real figure at report precision.
+/// What: drives a full synthesize with an authorship narrative that writes 85.19
+/// as "85%"; asserts the field survives and no rejection note was recorded.
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_accepts_rounded_authorship_figure() {
+    let model = fixture_model_with_top_author_share(85.19);
+    let body = r#"{
+      "executive_summary": "The 8,200 LoC Rust codebase spans 120 files.",
+      "authorship_summary": "One author owns 85% of the code, leaving a bus factor of 1.",
+      "top_risks": [],
+      "findings": []
+    }"#
+    .to_string();
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body,
+        finish_reason: Some("stop".to_string()),
+    });
+    let result = Synthesizer::new(llm, "stub/model")
+        .synthesize(&model)
+        .await
+        .expect("a rounded but faithful figure synthesizes");
+
+    assert_eq!(
+        result.authorship_summary.as_deref(),
+        Some("One author owns 85% of the code, leaving a bus factor of 1.")
+    );
+    assert!(
+        result.notes.is_empty(),
+        "a rounding of a measured figure records no rejection note: {:?}",
+        result.notes
+    );
+}
+
+/// Why: widening the guardrail for roundings must not widen it for wrong
+/// figures — 84 is neither the truncation nor the round-half-up form of 85.19.
+/// What: the same shape as the accepting case with the share misstated; asserts
+/// the field is dropped and the rejection note names the offending token.
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesize_still_rejects_a_wrong_authorship_figure() {
+    let model = fixture_model_with_top_author_share(85.19);
+    let body = r#"{
+      "executive_summary": "The 8,200 LoC Rust codebase spans 120 files.",
+      "authorship_summary": "One author owns 84% of the code.",
+      "top_risks": [],
+      "findings": []
+    }"#
+    .to_string();
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm {
+        body,
+        finish_reason: Some("stop".to_string()),
+    });
+    let result = Synthesizer::new(llm, "stub/model")
+        .synthesize(&model)
+        .await
+        .expect("the executive summary still verifies, so the pass succeeds");
+
+    assert!(
+        result.authorship_summary.is_none(),
+        "a figure matching no rounding must still drop the field"
+    );
+    assert!(
+        result
+            .notes
+            .iter()
+            .any(|n| n.contains("authorship summary: 84")),
+        "the rejection note must name the offending token: {:?}",
         result.notes
     );
 }


### PR DESCRIPTION
Refs #6030

The numeric guardrail compared canonical number strings, so a narrative writing a measured `top_author_share_pct` of 85.19 as "85%" matched nothing in the allowed set — the field was dropped as fabricated and the whole LLM narrative fell back to the deterministic composer, which is how live verification of #6037 failed. `allowed_numbers` now widens each measured decimal figure with its conventional roundings: the truncation and the round-half-up form at every coarser decimal precision, carries propagating (85.19 admits 85.1, 85.2 and 85; 9.99 admits 10). Integer keys are not widened, so a measured 8234 still never admits 8,000, and a figure matching no measured value under any rounding still drops the field with its rejection note and raw-response capture unchanged.

Rung 3 — cargo fmt --check; cargo check/clippy/test -p trusty-review: 1688 passed, 0 failed. Four regression tests, three shown failing pre-fix via production-file stash.

Changelog fragment: `crates/trusty-review/changelog.d/6030-rounding-aware-verifier.md`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
