### PR TITLE
fix(trusty-search): clustering feature compiles, and env_tests asserts the environment it claims

### DIFF
--- a/crates/trusty-search/changelog.d/5709-env-tests-clean-environment.md
+++ b/crates/trusty-search/changelog.d/5709-env-tests-clean-environment.md
@@ -1,0 +1,3 @@
+Fixed
+
+- **`neither_source_leaves_the_project_fallback_intact` read the invoking shell's `TRUSTY_INDEX` instead of the clean environment it asserts.** Two of its rows parsed in-process, and clap resolves `env = "TRUSTY_INDEX"` from the live process environment during `try_parse_from`. The first row failed outright under any shell that exports the variable. The second masked more than it reported: it asserts that `--project` still derives an index id when nothing else pins one (#1373), and with the variable set it passed on the environment value, so the derivation it names was never exercised. Both rows now spawn the clean child process the module's other rows already use (closes [#5709](https://github.com/bobmatnyc/trusty-tools/issues/5709))

--- a/crates/trusty-search/changelog.d/5931-clustering-feature-compiles.md
+++ b/crates/trusty-search/changelog.d/5931-clustering-feature-compiles.md
@@ -1,0 +1,3 @@
+Fixed
+
+- **The `clustering` feature did not compile.** `concept_cluster`'s `chunk_with` test helper builds a `CodeChunk` literal and predates the `on_branch` and `archive_reason` fields; `#[serde(default)]` on those two covers deserialization only, so the literal failed `E0063`. The module sits behind the off-by-default `clustering` feature and no CI job passes that flag, so its 7 tests had never run. The helper now names both fields (closes [#5931](https://github.com/bobmatnyc/trusty-tools/issues/5931))

--- a/crates/trusty-search/src/commands/serve_index_env_tests.rs
+++ b/crates/trusty-search/src/commands/serve_index_env_tests.rs
@@ -206,13 +206,19 @@ fn explicit_flag_alone_pins_the_index() {
 /// What: asserts neither source resolves anything when both are absent, so the
 /// arm still falls through to the `--project` derivation, and that the
 /// derivation itself still runs.
+///
+/// #5709 note on shape: both rows run in a child, because both describe an
+/// absent `TRUSTY_INDEX` and neither passes `--index`. An in-process row cannot
+/// state that — clap reads `env` from the live process environment, so the
+/// first row asserted `None` against whatever the invoking shell exported, and
+/// the second passed on the environment value rather than on the `--project`
+/// derivation it names.
 /// Test: this function.
 #[test]
 fn neither_source_leaves_the_project_fallback_intact() {
-    assert_eq!(parse(&["trusty-search", "serve"]).pin, None);
     assert_eq!(parse_with_env(None, "serve").pin, None);
 
-    let derived = parse(&["trusty-search", "serve", "--project", "/tmp/some-project"]).pin;
+    let derived = parse_with_env(None, "serve --project /tmp/some-project").pin;
     assert!(
         derived.is_some(),
         "--project must still derive an index id when nothing else pins one (#1373)"

--- a/crates/trusty-search/src/core/concept_cluster.rs
+++ b/crates/trusty-search/src/core/concept_cluster.rs
@@ -273,6 +273,10 @@ mod tests {
             inherits_from: vec![],
             chunk_depth: 0,
             index_id: None,
+            // #5931: `#[serde(default)]` on these two only covers
+            // deserialization; a struct literal must still name them.
+            on_branch: false,
+            archive_reason: None,
         }
     }
 


### PR DESCRIPTION
Two independent trusty-search bugs, both invisible to the gates the repo runs.

## #5931 — the `clustering` feature did not compile

`concept_cluster`'s `chunk_with` test helper builds a `CodeChunk` struct literal and predates the `on_branch` and `archive_reason` fields. `#[serde(default)]` on those two covers deserialization only, so the literal failed E0063. The module is behind the off-by-default `clustering` feature, no workspace crate enables it, and no CI job passes the flag — its 7 tests had never run.

Reproduced before the fix, `cargo test -p trusty-search --features ner,clustering,test-support --no-run`, exit 101:

```
error[E0063]: missing fields `archive_reason` and `on_branch` in initializer of `indexer::types::CodeChunk`
   --> crates/trusty-search/src/core/concept_cluster.rs:259:9
```

After: `cargo test -p trusty-search --features ner,clustering,test-support --lib concept_cluster` → `test result: ok. 7 passed; 0 failed; 0 ignored`.

## #5709 — the row asserted a clean environment and read the live one

`neither_source_leaves_the_project_fallback_intact` parsed two of its rows in-process, and clap resolves `env = "TRUSTY_INDEX"` from the live process environment during `try_parse_from`.

**It was masking a real leak.** Only the first row failed visibly. The second — `--project must still derive an index id when nothing else pins one (#1373)` — passed for the wrong reason: with `TRUSTY_INDEX` set, `resolve_pinned_index` returns the environment value and never reaches the `--project` derivation, so `derived.is_some()` held while the thing it names went untested. Both rows now spawn the clean child process the module's other rows already use.

Closure condition met — the test passes both with and without `TRUSTY_INDEX` exported:

```
TRUSTY_INDEX=trusty-tools  → test result: ok. 6 passed; 0 failed
unset TRUSTY_INDEX         → test result: ok. 6 passed; 0 failed
```

## Gates — rung 3

```
cargo fmt --check                                              EXIT=0
cargo check -p trusty-search                                   EXIT=0
cargo clippy -p trusty-search --all-targets -- -D warnings     EXIT=0
cargo test -p trusty-search                                    EXIT=0   1769 + 435 passed, 0 failed
bash scripts/check_test_pointers.sh                            EXIT=0   26116 resolved, 0 dangling
```

Feature-gated, since default-features compiles none of `concept_cluster`:

```
cargo test -p trusty-search --features ner,clustering,test-support --lib concept_cluster   7 passed, 0 failed
cargo test -p trusty-search --bin trusty-search index_env                                  6 passed, 0 failed
```

## Known red, not caused here

`cargo clippy -p trusty-search --all-targets --features ner,clustering,test-support -- -D warnings` fails on a `clippy::needless_return` in `src/core/ner.rs:66` — a file this PR does not touch, under the `ner` feature. Confirmed pre-existing by running the same command on a clean `origin/main` tree. It is the same blind spot #5931 describes, one feature over, and wants its own issue.

Refs #5931
Refs #5709

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools