### PR TITLE
fix(trusty-installer): three fail-open reporting paths — pinned subset, footer shadow, self-update gate

### DIFF
--- a/crates/trusty-installer/changelog.d/5807-self-update-health-gate.md
+++ b/crates/trusty-installer/changelog.d/5807-self-update-health-gate.md
@@ -1,0 +1,8 @@
+Fixed
+- `tctl self-update` no longer reports success for a binary nothing has run. It
+  printed `trusty-installer updated to X. Restart to apply.` and exited 0 as
+  soon as the file was placed, so a broken or wrong-version download read as a
+  completed update. It now runs `--version` on the exact binary it just wrote
+  and cross-checks the reported version, matching the gate `tctl install` has
+  always applied to every other member; a failed probe or a mismatch is an error
+  and exit 1, never a cargo fallback (#5807).

--- a/crates/trusty-installer/changelog.d/5810-pinned-missing-binary-fails-closed.md
+++ b/crates/trusty-installer/changelog.d/5810-pinned-missing-binary-fails-closed.md
@@ -1,0 +1,7 @@
+Fixed
+- A pinned install no longer places a partial set and calls it complete. When a
+  binary the set named was absent from the staged extraction directory,
+  `copy_set_into_install_dir` skipped it silently and still returned `Ok`, so
+  the caller received a set missing a tool with no warning anywhere. The copy
+  phase now fails closed on that name, before the first commit rename, so its
+  "nothing was installed" text stays true (#5810).

--- a/crates/trusty-installer/changelog.d/5812-install-footer-reports-shadow.md
+++ b/crates/trusty-installer/changelog.d/5812-install-footer-reports-shadow.md
@@ -1,0 +1,7 @@
+Fixed
+- The `tctl install` footer now reports a PATH-shadowed component. A member that
+  installed and bootstrapped cleanly but is shadowed by a different, earlier
+  copy of the same name gave `all_ok: false` and exit 2 under a footer reading
+  `installed 1/1 required component(s)` with no error line. Shadowing was the
+  last `all_ok` input the footer left out; the human summary and the exit code
+  now agree on every input (#5812, completing #5806).

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -739,7 +739,13 @@ fn short_reason(e: &anyhow::Error) -> String {
 /// Test: `tests::select_prebuilt_bin_path_matches_by_filename`,
 /// `tests::select_prebuilt_bin_path_falls_back_when_no_match`,
 /// `tests::select_prebuilt_bin_path_does_not_substring_match`.
-fn select_prebuilt_bin_path(paths: &[PathBuf], binary: &str, install_dir: &Path) -> PathBuf {
+// #5807: `pub(super)` so `self_update` health-gates the binary it placed
+// through the SAME path selection this one does, rather than a second copy.
+pub(super) fn select_prebuilt_bin_path(
+    paths: &[PathBuf],
+    binary: &str,
+    install_dir: &Path,
+) -> PathBuf {
     paths
         .iter()
         .find(|p| p.file_name().and_then(|f| f.to_str()) == Some(binary))

--- a/crates/trusty-installer/src/commands/install_report.rs
+++ b/crates/trusty-installer/src/commands/install_report.rs
@@ -443,15 +443,11 @@ pub(super) struct SummaryLines {
 ///
 /// # Postconditions
 /// - Over a non-empty selection, `errors` is empty iff every gating member
-///   installed and bootstrapped AND every member passed verification — the same
-///   verdict [`InstallReport::all_ok`] reaches before the verify tail folds in.
-///   `build(vec![])` is the one deliberate exception: no member can fail, so
-///   `errors` is empty while `all_ok` is `false` ("installed nothing" is not a
-///   success).
-/// - PATH shadowing is the one `all_ok` input this footer does not restate. A
-///   shadow is reported at ERROR level the moment it is detected
-///   (`install_one`, #3554), so it reaches the operator on the human path
-///   without the footer repeating it.
+///   installed, bootstrapped and is unshadowed AND every member passed
+///   verification — the same verdict [`InstallReport::all_ok`] reaches before
+///   the verify tail folds in. `build(vec![])` is the one deliberate exception:
+///   no member can fail, so `errors` is empty while `all_ok` is `false`
+///   ("installed nothing" is not a success).
 /// - A member never appears in both `errors` and `skipped`.
 ///
 /// Test: `tests::summary_lines_match_the_gating_set`,
@@ -485,6 +481,18 @@ pub(super) fn summary_lines(report: &InstallReport) -> SummaryLines {
             .iter()
             .filter(|m| m.ok && !m.service_ok)
             .map(|m| format!("{}: {}", m.member, m.service_detail)),
+    );
+    // #5812: the last `all_ok` input the footer left out. A gating member with
+    // `ok && service_ok && !shadow_ok` gave `all_ok: false` and exit 2 under a
+    // footer reading `installed 1/1 required component(s)` with no error line.
+    // `install_one` already logs the shadow when it detects it, but a footer
+    // that omits what the exit code gates on is the same two-channel
+    // disagreement #5806 closed for every other input.
+    errors.extend(
+        gating
+            .iter()
+            .filter(|m| m.ok && !m.shadow_ok)
+            .map(|m| format!("{}: {}", m.member, m.shadow_detail)),
     );
     // #5518: an integrity failure is never a graceful degrade. A non-gating
     // member whose artifact failed verification is reported as an error, in the

--- a/crates/trusty-installer/src/commands/install_tests.rs
+++ b/crates/trusty-installer/src/commands/install_tests.rs
@@ -377,6 +377,19 @@ fn summary_errors_agree_with_all_ok_across_selection_shapes() {
         o
     };
 
+    // #5812: a member that installed and bootstrapped cleanly but is shadowed
+    // on $PATH by an earlier, different copy of the same name.
+    let shadowed = |member: &str, required: bool| {
+        let mut o = if required {
+            outcome(member, true, "installed")
+        } else {
+            optional_outcome(member, true, "installed")
+        };
+        o.shadow_ok = false;
+        o.shadow_detail = format!("`{member}` on PATH resolves to a different copy");
+        o
+    };
+
     let cases: Vec<(&str, Vec<InstallOutcome>)> = vec![
         (
             "all required, healthy",
@@ -389,6 +402,20 @@ fn summary_errors_agree_with_all_ok_across_selection_shapes() {
         (
             "all required, one service failure",
             vec![outcome("a", true, "installed"), service_failed("b", true)],
+        ),
+        // #5812: `ok && service_ok && !shadow_ok` — the one `all_ok` input the
+        // footer used to leave out, so it printed `installed 1/1 required
+        // component(s)` with no error line while `build` exited 2.
+        (
+            "all required, one shadowed member",
+            vec![outcome("a", true, "installed"), shadowed("b", true)],
+        ),
+        (
+            "mixed, required member shadowed",
+            vec![
+                shadowed("a", true),
+                optional_outcome("b", true, "installed"),
+            ],
         ),
         (
             "all optional, healthy",

--- a/crates/trusty-installer/src/commands/self_update.rs
+++ b/crates/trusty-installer/src/commands/self_update.rs
@@ -3,14 +3,16 @@
 //! Why: The installer binary manages the whole stack but has no automated path
 //! to update itself; this command closes that gap.
 //!
-//! What: Attempts a prebuilt download for "trusty-installer" into the current
-//! binary's parent directory. On success prints a restart hint (does NOT re-exec).
-//! On fallback, attempts `cargo install trusty-installer --locked` if cargo is on
-//! PATH; otherwise prints a manual install hint. Before either attempt, the target
-//! directory is probed for writability — `PermissionDenied`, `StorageFull`, and
-//! `ReadOnlyFilesystem` all abort up-front with distinct actionable errors (all
-//! three predict that the subsequent write into the same directory will also fail);
-//! genuinely transient/inconclusive errors fall through to the prebuilt-attempt +
+//! What: Attempts a prebuilt download for "trusty-installer" into the canonical
+//! cargo bin dir, then runs `--version` on the binary it just placed and
+//! cross-checks the version before printing a restart hint (#5807; does NOT
+//! re-exec). On fallback, attempts `cargo install trusty-installer --locked` if
+//! cargo is on PATH; otherwise prints a manual install hint. Before either
+//! attempt, the target directory is probed for writability —
+//! `PermissionDenied`, `StorageFull`, and `ReadOnlyFilesystem` all abort
+//! up-front with distinct actionable errors (all three predict that the
+//! subsequent write into the same directory will also fail); genuinely
+//! transient/inconclusive errors fall through to the prebuilt-attempt +
 //! cargo-fallback path.
 //!
 //! Test: `tests` covers the probe tri-state, the Outcome→message mapping,
@@ -107,16 +109,24 @@ pub fn probe_install_dir(dir: &Path) -> WriteProbe {
 /// default install dir as fallback), probes the directory with `probe_install_dir`
 /// — aborting on `PermissionDenied`, `StorageFull`, and `ReadOnlyFilesystem`
 /// (all predict the subsequent write will fail), falling through on other errors —
-/// then calls `try_install_prebuilt("trusty-installer", &dir)` and either prints
-/// the restart hint or falls back to cargo with a truthful location message.
+/// then calls `try_install_prebuilt("trusty-installer", &dir)` and either
+/// health-gates what it placed or falls back to cargo with a truthful location
+/// message.
 ///
 /// #5518: a `ChecksumMismatch` outcome is the one case that does NOT fall back.
 /// It prints the mismatch as an error and exits 1, because a source build here
 /// would turn a tamper signal into a slower-but-successful self-update.
 ///
+/// #5807: a successful placement exits 0 only after the placed binary answered
+/// `--version` with the version the download layer says it wrote. A failed
+/// probe or a version mismatch is an ERROR and exit 1 — never a cargo fallback,
+/// which would rebuild over a binary that is already on disk and hide why the
+/// prebuilt one did not run.
+///
 /// Test: `tests::outcome_installed_message`, `tests::probe_nonwritable_dir`,
 ///       `tests::cargo_updated_different_dir`,
-///       `tests::a_checksum_mismatch_aborts_self_update_without_a_cargo_fallback`.
+///       `tests::a_checksum_mismatch_aborts_self_update_without_a_cargo_fallback`,
+///       `tests::a_binary_that_fails_its_health_check_aborts_the_self_update`.
 pub fn run(json: bool) -> i32 {
     let narr = narrator(json);
     let install_dir = resolve_install_dir();
@@ -153,9 +163,26 @@ pub fn run(json: bool) -> i32 {
     ));
 
     match next_step(outcome) {
-        Next::Done(msg) => {
-            let _ = narr.info(&msg);
-            0
+        // #5807: placing the file is not the update. Probe the exact binary
+        // just written and cross-check its reported version before anything
+        // narrates success — the gate `install_one` has always run.
+        Next::Verify { paths, version } => {
+            let bin_path =
+                super::install::select_prebuilt_bin_path(&paths, INSTALLER_BINARY, &install_dir);
+            let probed = crate::commands::runtime::block_on(
+                trusty_common::update::verify_installed_binary_at_path(&bin_path),
+            )
+            .map_err(|e| e.to_string());
+            match health_gate_verdict(&bin_path, &version, probed) {
+                Ok(msg) => {
+                    let _ = narr.info(&msg);
+                    0
+                }
+                Err(msg) => {
+                    let _ = narr.error(&msg);
+                    1
+                }
+            }
         }
         Next::CargoFallback(msg) => {
             let _ = narr.info(&msg);
@@ -176,11 +203,20 @@ pub fn run(json: bool) -> i32 {
 /// makes "a checksum mismatch never reaches `cargo install`" a claim a test can
 /// check rather than one a reader has to take on trust.
 ///
-/// What: Success narrates and stops; a routine failure narrates and falls back;
-/// a checksum mismatch narrates AS AN ERROR and stops.
+/// What: A placement hands off to the health gate; a routine failure narrates
+/// and falls back; a checksum mismatch narrates AS AN ERROR and stops.
+///
+/// #5807 removed the `Done` variant. It was the terminal success `Installed`
+/// mapped straight to, and keeping it would leave a way to report an update
+/// without probing the binary.
 enum Next {
-    /// Installed. Narrate at info level, exit 0.
-    Done(String),
+    /// Files were placed. Health-gate them before reporting anything (#5807).
+    Verify {
+        /// Every path the download layer reports having written.
+        paths: Vec<PathBuf>,
+        /// The version that layer believes it placed.
+        version: String,
+    },
     /// Prebuilt genuinely unavailable. Narrate at info level, then run cargo.
     CargoFallback(String),
     /// Terminal. Narrate at ERROR level, exit 1, never run cargo.
@@ -194,11 +230,18 @@ enum Next {
 /// [`Next::CargoFallback`]. A source build would leave the operator with a
 /// working `tctl` and no reason to look at why the prebuilt failed.
 ///
+/// [`Outcome::Installed`] yields [`Next::Verify`], never a success verdict
+/// (#5807). Only [`health_gate_verdict`] can report an update, and only after
+/// the placed binary has answered `--version`.
+///
 /// Test: `tests::a_checksum_mismatch_aborts_self_update_without_a_cargo_fallback`,
-/// `tests::an_absent_prebuilt_still_falls_back_to_cargo`.
+/// `tests::an_absent_prebuilt_still_falls_back_to_cargo`,
+/// `tests::an_installed_prebuilt_is_not_reported_done_before_it_is_health_gated`.
 fn next_step(outcome: Outcome) -> Next {
     match outcome {
-        Outcome::Installed { version, .. } => Next::Done(installed_message(&version)),
+        // #5807: a placement is a claim, not a result. The verdict waits for
+        // the probe.
+        Outcome::Installed { paths, version } => Next::Verify { paths, version },
         Outcome::Fallback { reason } => {
             tracing::info!(%reason, "prebuilt self-update unavailable");
             Next::CargoFallback(format!("prebuilt unavailable: {reason}"))
@@ -206,6 +249,60 @@ fn next_step(outcome: Outcome) -> Next {
         // #5518: a failed checksum is terminal — no cargo fallback, nonzero exit.
         Outcome::ChecksumMismatch(mismatch) => Next::Abort(mismatch.to_string()),
     }
+}
+
+/// The binary whose `--version` proves a self-update took effect.
+///
+/// The tarball also ships the `tctl` alias; this is the name the stable set
+/// health-probes for the same crate (`stable_set`'s trusty-installer row).
+const INSTALLER_BINARY: &str = "trusty-installer";
+
+/// Decide what a self-update reports about the binary it just placed.
+///
+/// Why (#5807): `run` used to narrate `trusty-installer updated to X` the
+/// moment [`Outcome::Installed`] came back, so a placement that produced an
+/// unrunnable or wrong-version binary still exited 0. `install_one` has always
+/// gated the same claim; this is that gate, kept pure so the decision is
+/// testable without a real download.
+///
+/// # Preconditions
+/// `probed` is the outcome of running `--version` on `bin_path` itself —
+/// never a name re-resolved through `$PATH`, which a stale earlier copy could
+/// answer for.
+///
+/// # Postconditions
+/// `Ok` only when the binary at `bin_path` ran AND reported exactly
+/// `expected_version`. Every other input yields `Err` with a message that names
+/// the path and never carries the restart hint, so an abort can never be read
+/// as a completed update.
+///
+/// Test: `tests::a_binary_that_fails_its_health_check_aborts_the_self_update`,
+/// `tests::a_version_mismatch_after_placement_aborts_the_self_update`,
+/// `tests::a_verified_binary_reports_the_update`.
+fn health_gate_verdict(
+    bin_path: &Path,
+    expected_version: &str,
+    probed: Result<String, String>,
+) -> Result<String, String> {
+    let reported_line = probed.map_err(|e| {
+        format!(
+            "self-update aborted: the binary just placed at `{}` did not answer \
+             `--version`: {e}. The update was NOT verified — retry \
+             `tctl self-update`, or install manually: \
+             `cargo install trusty-installer --locked`",
+            bin_path.display()
+        )
+    })?;
+    let reported = crate::commands::update_engine::extract_version_from_line(&reported_line);
+    if reported.as_deref() != Some(expected_version) {
+        return Err(format!(
+            "self-update aborted: version {expected_version} was placed at `{}`, but that \
+             exact binary reports {reported:?} (raw `--version` output: {reported_line:?}) — \
+             refusing to report success",
+            bin_path.display()
+        ));
+    }
+    Ok(installed_message(expected_version))
 }
 
 /// Resolve the directory into which to place the updated binary.
@@ -445,6 +542,79 @@ mod tests {
             !msg.contains("prebuilt unavailable"),
             "must not read as a routine absence: {msg}"
         );
+    }
+
+    /// Why (#5807): placing a file is not evidence that the tool it stands for
+    /// works. `next_step` used to answer `Outcome::Installed` with a terminal
+    /// `Next::Done("trusty-installer updated to X. Restart to apply.")`, so a
+    /// self-update reported success for a binary nothing had run — the same
+    /// failure shape `install_one`'s health gate exists to catch. Against that
+    /// code this test read `!matches!(…, Next::Done(_))` and failed; `Done` is
+    /// gone now, because a variant that reports an update without a probe is
+    /// the defect itself.
+    /// What: Asserts an installed prebuilt routes to the health gate rather
+    /// than to any verdict. `health_gate_verdict` is the only producer of a
+    /// success message, and it runs the binary first.
+    /// Test: This is the test.
+    #[test]
+    fn an_installed_prebuilt_is_not_reported_done_before_it_is_health_gated() {
+        let outcome = Outcome::Installed {
+            paths: vec![PathBuf::from("/nonexistent/bin/trusty-installer")],
+            version: "0.8.0".to_owned(),
+        };
+        assert!(
+            matches!(next_step(outcome), Next::Verify { .. }),
+            "self-update must not report success before health-gating the \
+             binary it just placed (#5807)"
+        );
+    }
+
+    /// Why (#5807): a `--version` that cannot run at all is the loudest form of
+    /// "placed but not working"; it must abort, never narrate an update.
+    /// What: Feeds a probe error to `health_gate_verdict`; asserts the message
+    /// names the path and does not read as a completed update.
+    /// Test: This is the test.
+    #[test]
+    fn a_binary_that_fails_its_health_check_aborts_the_self_update() {
+        let path = PathBuf::from("/opt/bin/trusty-installer");
+        let msg = health_gate_verdict(&path, "0.8.0", Err("exec format error".to_owned()))
+            .expect_err("a failed health check must abort");
+        assert!(msg.contains("/opt/bin/trusty-installer"), "{msg}");
+        assert!(msg.contains("exec format error"), "{msg}");
+        assert!(
+            !msg.contains("Restart to apply"),
+            "must not read as done: {msg}"
+        );
+    }
+
+    /// Why (#5807): the health check passing is not enough on its own — a
+    /// pre-existing file at the destination can run and report another version,
+    /// which proves the probed binary is not the one just placed.
+    /// What: Feeds a `--version` line naming a different version; asserts the
+    /// abort names both versions.
+    /// Test: This is the test.
+    #[test]
+    fn a_version_mismatch_after_placement_aborts_the_self_update() {
+        let path = PathBuf::from("/opt/bin/trusty-installer");
+        let msg = health_gate_verdict(&path, "0.8.0", Ok("trusty-installer 0.7.1".to_owned()))
+            .expect_err("a version mismatch must abort");
+        assert!(msg.contains("0.8.0"), "{msg}");
+        assert!(msg.contains("0.7.1"), "{msg}");
+        assert!(
+            !msg.contains("Restart to apply"),
+            "must not read as done: {msg}"
+        );
+    }
+
+    /// Why (#5807): the gate must still let a genuine update through.
+    /// What: Feeds a matching `--version` line; asserts the restart hint.
+    /// Test: This is the test.
+    #[test]
+    fn a_verified_binary_reports_the_update() {
+        let path = PathBuf::from("/opt/bin/trusty-installer");
+        let msg = health_gate_verdict(&path, "0.8.0", Ok("trusty-installer 0.8.0".to_owned()))
+            .expect("a matching version must report success");
+        assert_eq!(msg, installed_message("0.8.0"));
     }
 
     /// Why: The abort must be specific to a failed checksum — a 404 on an

--- a/crates/trusty-installer/src/download/pinned.rs
+++ b/crates/trusty-installer/src/download/pinned.rs
@@ -679,10 +679,13 @@ struct Pending {
 ///
 /// What: Rejects a final path already occupied by a directory and a final path
 /// two tools in the set both claim — both would surface later as a confusing
-/// mid-commit failure. Then copies via `fetch::stage_binary`.
+/// mid-commit failure. Then copies via `fetch::stage_binary`. A name whose
+/// source file is absent is a third rejection (#5810), not a skip: placing a
+/// subset while returning `Ok` would report a partial set as a complete one.
 ///
 /// Test: `tests::a_set_places_nothing_when_a_later_tool_cannot_be_placed`,
-/// `tests::a_set_is_rejected_when_two_tools_claim_the_same_binary_name`.
+/// `tests::a_set_is_rejected_when_two_tools_claim_the_same_binary_name`,
+/// `tests::a_binary_missing_from_the_staged_set_is_never_silently_skipped`.
 fn copy_set_into_install_dir(
     staged: &[Staged],
     install_dir: &Path,
@@ -729,7 +732,23 @@ fn copy_set_into_install_dir(
             }
 
             match fetch::stage_binary(&s.extract_dir, install_dir, name) {
-                Ok(None) => continue,
+                // #5810: `stage_binary` answers `Ok(None)` when the source file
+                // is not there, and this arm used to `continue`. The pinned
+                // path then placed fewer binaries than it named and still
+                // returned `Ok` — a partial set reported as a complete one,
+                // which is the mixed-version outcome the pin exists to prevent.
+                // Fail closed here, before the first commit rename, so the
+                // "nothing was installed" text stays true.
+                Ok(None) => {
+                    discard(temporaries(&pending).chain(temporaries_of(&renames)));
+                    return Err(io(
+                        s,
+                        anyhow::anyhow!(
+                            "`{name}` was staged for installation but is not present in {}",
+                            s.extract_dir.display()
+                        ),
+                    ));
+                }
                 Ok(Some(tmp)) => {
                     claimed.push(dest.clone());
                     renames.push((tmp, dest));

--- a/crates/trusty-installer/src/download/pinned/tests.rs
+++ b/crates/trusty-installer/src/download/pinned/tests.rs
@@ -561,6 +561,39 @@ fn a_set_is_rejected_when_two_tools_claim_the_same_binary_name() {
     assert_nothing_installed(dir.path());
 }
 
+/// Why (#5810): `fetch::stage_binary` returns `Ok(None)` when the source file
+/// is absent, and the copy phase used to `continue` past it. A pinned set could
+/// then place fewer binaries than it staged and still return `Ok` — a partial
+/// set reported as a complete one, which is the mixed-version result the pin
+/// exists to prevent.
+/// What: Stages a tool whose name list contains a binary the extraction
+/// directory does not hold; asserts the copy phase fails closed, names the
+/// missing binary, and leaves the install directory empty.
+/// Test: This is the test.
+#[test]
+fn a_binary_missing_from_the_staged_set_is_never_silently_skipped() {
+    let src = tempfile::tempdir().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let mut staged = staged_fixture("tool-a", "1.0.0", &["tool-a"], src.path());
+    // The shared table promises an alias the extraction dir never received.
+    staged.binary_names.push("tool-a-alias".to_owned());
+
+    let err = copy_set_into_install_dir(&[staged], dir.path())
+        .expect_err("a binary the staging dir does not hold must fail closed");
+
+    assert!(matches!(err, PinnedError::Io { .. }), "got {err:?}");
+    let text = err.to_string();
+    assert!(
+        text.contains("tool-a-alias"),
+        "the missing binary must be named: {text}"
+    );
+    assert!(
+        text.contains("nothing was installed"),
+        "a phase-2 failure before any commit must report the truth: {text}"
+    );
+    assert_nothing_installed(dir.path());
+}
+
 /// Why: The copy phase creates hidden temporaries inside the install directory;
 /// if a failure left them there, "nothing was installed" would be a half-truth
 /// and the next run would find litter.


### PR DESCRIPTION
Three failure branches in `trusty-installer` that let state advance while the
failure went unreported. One commit each; see the commit messages for mechanism.

- Refs #5810 — a pinned set placed a subset and returned `Ok`.
- Refs #5812 — the install footer omitted the shadow error `all_ok` gates on.
- Refs #5807 — self-update reported success for a binary nothing had run.

#5812 continues [#5586](https://github.com/bobmatnyc/trusty-tools/pull/5586),
which merged today and made `errors.is_empty() == all_ok` hold for the checksum
input. That PR's `summary_errors_agree_with_all_ok_across_selection_shapes`
already asserts the equivalence, so this one adds two shadow rows to its table
and changes nothing else about it. Its `integrity_ok` handling and its
non-gating error arm are untouched.

## Gates — rung 3

Each fix carries one regression test that fails on the pre-fix tree. Recorded
together against `origin/main`:

```
running 3 tests
test commands::self_update::tests::an_installed_prebuilt_is_not_reported_done_before_it_is_health_gated ... FAILED
test commands::install::tests::summary_errors_agree_with_all_ok_across_selection_shapes ... FAILED
test download::pinned::tests::a_binary_missing_from_the_staged_set_is_never_silently_skipped ... FAILED
test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 655 filtered out
```

`summary_errors_agree_with_all_ok_across_selection_shapes` failed on
`all required, one shadowed member: the human footer and 'all_ok' disagree —
errors [], all_ok false`. The #5807 test read `!matches!(…, Next::Done(_))`
against that tree; `Next::Done` is deleted here, so the committed form asserts
`Next::Verify` instead.

```
cargo fmt --check                                       # exit 0
cargo check -p trusty-installer                         # exit 0
cargo clippy -p trusty-installer --all-targets -- -D warnings   # exit 0
cargo test -p trusty-installer                          # 657 passed; 0 failed; 4 ignored
                                                        # + 3 passed, 3 passed (integration)
bash scripts/check_test_pointers.sh                     # 26122 citations, 0 dangling
bash scripts/check_line_cap.sh                          # 0 violations
bash scripts/check_changelog_fragment.sh                # 3 fragments recorded
bash scripts/check_sld.sh                               # 0 errors, 0 warnings
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
