### PR TITLE
fix(ci): cancelled-shard verdict, apt retry, ignored-tests exclude, untracked-file pointer scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1999,6 +1999,20 @@ jobs:
   # `needs` lists every hard-gating job. `search-daemon-smoke` is now included:
   # it was excluded only because `continue-on-error: true` meant its result
   # never surfaced as `failure`, and that flag is gone.
+  #
+  # A CANCELLED SHARD IS NOT A FAILURE (#5998). The `test` job is an aggregator:
+  # it reads `needs.test-shard.result` and exits 1 on anything that is not
+  # `success`, so a shard cancelled by a newer push to the same concurrency
+  # group reached the classifier as `test=failure` and became red. Run
+  # 32154560958 (head 41fee6ac6) filed that false alarm on the `ci-red-main`
+  # issue with shards 5 and 6 cancelled 4 seconds before `2875e1f9d` landed, and
+  # that superseding run was fully green. So the classifier is handed the SHARD
+  # results directly, and the aggregate is reported as `cancelled` when the
+  # cancellation is what made it red — a cancelled shard lands in `inconclusive`
+  # ("this commit has NO verification result"), never in red, while a genuine
+  # `failure` from either job still lands in red unchanged. `test=` is kept, not
+  # replaced, so the aggregator breaking on its own (green shards, red `test`)
+  # is still caught.
   # --------------------------------------------------------------------------
   notify-main-failure:
     name: Notify on red main
@@ -2009,6 +2023,8 @@ jobs:
         fmt,
         clippy,
         test,
+        test-shard,
+        test-doc,
         msrv,
         agents-ui,
         audit-ui,
@@ -2031,7 +2047,9 @@ jobs:
           CI_JOB_RESULTS: >-
             fmt=${{ needs.fmt.result }}
             clippy=${{ needs.clippy.result }}
-            test=${{ needs.test.result }}
+            test=${{ (needs['test-shard'].result == 'cancelled' || needs['test-doc'].result == 'cancelled') && 'cancelled' || needs.test.result }}
+            test-shard=${{ needs['test-shard'].result }}
+            test-doc=${{ needs['test-doc'].result }}
             msrv=${{ needs.msrv.result }}
             agents-ui=${{ needs['agents-ui'].result }}
             audit-ui=${{ needs['audit-ui'].result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,14 @@
 # requires that path to exist at compile time; a placeholder is sufficient to
 # compile- and lint-verify the Rust side without pulling node/pnpm into CI.
 #
+# Every apt step in this file calls `scripts/ci-apt-install.sh` rather than
+# `sudo apt-get update -qq && sudo apt-get install …` (#5999). The raw pair had
+# no retry and no timeout, so a stalled mirror produced zero output and ate the
+# job's whole `timeout-minutes: 30` before cargo ran — `trusty-agents-ui clippy`
+# and `trusty-code-gui clippy` both died that way at 30m21s on PR #5992. The
+# wrapper retries each phase, kills a stalled attempt at its own ceiling, and
+# caps the total at ten minutes with an `::error::` line saying which.
+#
 # SKIP_UI_BUILD=1 is set globally: the four crates with build.rs Svelte
 # pipelines (trusty-search, trusty-memory, trusty-analyze, trusty-agents) skip
 # pnpm when this env var is set. The committed ui-dist/ artefacts embedded
@@ -363,8 +371,7 @@ jobs:
       - name: Install system dependencies
         if: needs.changes.outputs.docs_only != 'true'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
+          bash scripts/ci-apt-install.sh \
             build-essential \
             pkg-config \
             libssl-dev
@@ -566,8 +573,7 @@ jobs:
       - name: Install system dependencies
         if: needs.changes.outputs.docs_only != 'true'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
+          bash scripts/ci-apt-install.sh \
             build-essential \
             pkg-config \
             libssl-dev
@@ -1095,8 +1101,7 @@ jobs:
       - name: Install system dependencies
         if: needs.changes.outputs.docs_only != 'true'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
+          bash scripts/ci-apt-install.sh \
             build-essential \
             pkg-config \
             libssl-dev
@@ -1221,8 +1226,7 @@ jobs:
       - name: Install system dependencies
         if: needs.changes.outputs.docs_only != 'true'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
+          bash scripts/ci-apt-install.sh \
             build-essential \
             pkg-config \
             libssl-dev
@@ -1286,8 +1290,7 @@ jobs:
       - name: Install Tauri system dependencies
         if: needs.changes.outputs.docs_only != 'true'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
+          bash scripts/ci-apt-install.sh \
             build-essential \
             pkg-config \
             libssl-dev \
@@ -1359,8 +1362,7 @@ jobs:
       - name: Install Tauri system dependencies
         if: needs.changes.outputs.docs_only != 'true'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
+          bash scripts/ci-apt-install.sh \
             build-essential \
             pkg-config \
             libssl-dev \
@@ -1442,8 +1444,7 @@ jobs:
       - name: Install Tauri system dependencies
         if: needs.changes.outputs.docs_only != 'true'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
+          bash scripts/ci-apt-install.sh \
             build-essential \
             pkg-config \
             libssl-dev \
@@ -1515,8 +1516,7 @@ jobs:
       - name: Install Tauri system dependencies
         if: needs.changes.outputs.docs_only != 'true'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
+          bash scripts/ci-apt-install.sh \
             build-essential \
             pkg-config \
             libssl-dev \
@@ -1622,8 +1622,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
+          bash scripts/ci-apt-install.sh \
             build-essential \
             pkg-config \
             libssl-dev
@@ -1635,8 +1634,7 @@ jobs:
           wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
           rm -f cuda-keyring_1.1-1_all.deb
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends cuda-nvcc-12-8
+          bash scripts/ci-apt-install.sh cuda-nvcc-12-8
           echo "/usr/local/cuda-12.8/bin" >> "$GITHUB_PATH"
 
       - name: Verify nvcc is on PATH
@@ -1852,8 +1850,7 @@ jobs:
       - name: Install system dependencies
         if: needs.changes.outputs.docs_only != 'true'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
+          bash scripts/ci-apt-install.sh \
             build-essential \
             pkg-config \
             libssl-dev

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -80,6 +80,40 @@ assert_eq "success+cancelled after red"    "red"         "$(verdict_of 'a=failur
 assert_eq "the #4179 live run shape"      "inconclusive" \
   "$(verdict_of 'fmt=success clippy=cancelled test=cancelled msrv=cancelled smoke=cancelled')"
 
+# #5998, both halves of the same live run (32154560958, head 41fee6ac6): two of
+# eight shards cancelled by a newer push to the same concurrency group, every
+# other job green. Laundered through the `test` aggregator — which exits 1 on
+# any non-success matrix result — it arrives as `failure` and reads red; taken
+# from the shard job itself it arrives as `cancelled` and reads inconclusive.
+# The script is right either way, so the defect is entirely in WHICH of the two
+# it is handed, which is why the ci.yml wiring is asserted below.
+assert_eq "superseded shards, raw conclusions"   "inconclusive" \
+  "$(verdict_of 'fmt=success clippy=success test=cancelled test-shard=cancelled test-doc=success msrv=success')"
+assert_eq "superseded shards, laundered (#5998)" "red" \
+  "$(verdict_of 'fmt=success clippy=success test=failure msrv=success')"
+# The other direction: a shard that genuinely FAILED is still red, and a red
+# shard beside a cancelled sibling stays red.
+assert_eq "a genuinely failed shard is still red" "red" \
+  "$(verdict_of 'fmt=success clippy=success test=failure test-shard=failure test-doc=success msrv=success')"
+assert_eq "a failed doctest job is still red"     "red" \
+  "$(verdict_of 'fmt=success clippy=success test=failure test-shard=success test-doc=failure msrv=success')"
+
+# The wiring that decides which of the two shapes above the notifier produces.
+# Same guard pattern as the #4688 / #5407 ones further down: the script being
+# correct in isolation proves nothing while the workflow hands it a laundered
+# conclusion.
+notify_job="$(sed -n '/^  notify-main-failure:/,$p' .github/workflows/ci.yml)"
+assert_eq "notify waits on the shard matrix itself" "1" \
+  "$(grep -c '^        test-shard,$' <<<"${notify_job}" || true)"
+assert_eq "notify waits on the doctest job itself" "1" \
+  "$(grep -c '^        test-doc,$' <<<"${notify_job}" || true)"
+assert_eq "notify classifies the shard result directly (#5998)" "1" \
+  "$(grep -cF "test-shard=\${{ needs['test-shard'].result }}" <<<"${notify_job}" || true)"
+assert_eq "notify classifies the doctest result directly (#5998)" "1" \
+  "$(grep -cF "test-doc=\${{ needs['test-doc'].result }}" <<<"${notify_job}" || true)"
+assert_eq "a cancelled shard is not laundered into red (#5998)" "1" \
+  "$(grep -cF "needs['test-shard'].result == 'cancelled'" <<<"${notify_job}" || true)"
+
 # ---------------------------------------------------------------------------
 # detect-docs-only.sh
 # ---------------------------------------------------------------------------

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -441,6 +441,89 @@ assert_eq "all five disk-reclaim jobs call the helper" "5" \
   "$(grep -c 'bash scripts/ci-free-disk-space.sh' "${ci_wf}" || true)"
 
 # ---------------------------------------------------------------------------
+# ci-apt-install.sh (#5999)
+#
+# The step this replaces had no retry and no timeout: a stalled mirror printed
+# nothing and consumed the job's whole 30-minute budget. Both halves of the fix
+# are branch logic that only runs when apt is already misbehaving, which is
+# exactly the code nobody exercises before it matters. Drive every branch with a
+# stubbed `apt-get` (and a stubbed `sudo`, so the real invocation path including
+# the sudo prefix is what runs) rather than waiting on a real mirror.
+# ---------------------------------------------------------------------------
+echo
+echo "ci-apt-install:"
+
+# apt_stub_dir <script-body> — a PATH dir holding a fake apt-get with that body
+# plus a `sudo` that just runs its arguments.
+apt_stub_dir() {
+  local dir
+  dir="$(mktemp -d "${TMPDIR:-/tmp}/aptstub.XXXXXX")"
+  printf '#!/usr/bin/env bash\n%s\n' "$1" > "${dir}/apt-get"
+  printf '#!/usr/bin/env bash\nexec "$@"\n' > "${dir}/sudo"
+  chmod +x "${dir}/apt-get" "${dir}/sudo"
+  echo "${dir}"
+}
+
+# apt_run <stub-dir> — exit code of the wrapper, with the stub ahead on PATH.
+# Retry delay 0 and small ceilings so the failing cases cost nothing.
+apt_run() {
+  local dir="$1" rc=0
+  PATH="${dir}:${PATH}" CI_APT_RETRY_DELAY_S=0 CI_APT_ATTEMPTS=3 \
+    CI_APT_UPDATE_TIMEOUT_S=2 CI_APT_INSTALL_TIMEOUT_S=2 \
+    bash scripts/ci-apt-install.sh build-essential \
+    >"${dir}/out" 2>&1 || rc=$?
+  echo "$rc"
+}
+
+# Always succeeds — the ordinary path, and proof the wrapper is transparent.
+ok_dir="$(apt_stub_dir 'exit 0')"
+assert_eq "a healthy mirror installs, exit 0" "0" "$(apt_run "${ok_dir}")"
+assert_eq "  and it does not retry a success" "1" \
+  "$(grep -c 'apt-get update, attempt' "${ok_dir}/out" || true)"
+
+# Fails twice, then succeeds: the retry the step did not have. The stub counts
+# its own invocations through a file so the attempt count is observable.
+flaky_dir="$(apt_stub_dir '
+count_file="${0%/*}/calls"
+n=$(( $(cat "$count_file" 2>/dev/null || echo 0) + 1 ))
+echo "$n" > "$count_file"
+[ "$1" = "update" ] && [ "$n" -lt 3 ] && exit 100
+exit 0')"
+assert_eq "two transient failures then success" "0" "$(apt_run "${flaky_dir}")"
+assert_eq "  it took three update attempts"     "3" \
+  "$(grep -c 'apt-get update, attempt' "${flaky_dir}/out" || true)"
+
+# Never succeeds: bounded, and the failure names the phase rather than being a
+# generic job timeout.
+dead_dir="$(apt_stub_dir 'exit 100')"
+assert_eq "an unreachable mirror fails closed" "1" "$(apt_run "${dead_dir}")"
+assert_eq "  after exactly ATTEMPTS attempts"   "3" \
+  "$(grep -c 'apt-get update, attempt' "${dead_dir}/out" || true)"
+assert_eq "  and says so as a CI error"         "1" \
+  "$(grep -c '::error::ci-apt-install: apt-get update failed 3 time' "${dead_dir}/out" || true)"
+
+# THE ISSUE'S OWN CASE: a mirror that accepts the connection and then says
+# nothing. Unwrapped this is the 30-minute silent stall; here each attempt must
+# die at its 2s ceiling and be reported as a stall, not as a plain failure.
+if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+  stall_dir="$(apt_stub_dir 'sleep 300')"
+  assert_eq "a stalled mirror is killed at the ceiling" "1" "$(apt_run "${stall_dir}")"
+  assert_eq "  reported as a stall, not a plain failure" "3" \
+    "$(grep -c 'STALLED — killed at the 2s ceiling' "${stall_dir}/out" || true)"
+  rm -rf "${stall_dir}"
+else
+  echo "  skip 'stalled mirror' — no timeout(1) on PATH (GNU coreutils; present on the CI runners)"
+fi
+
+rm -rf "${ok_dir}" "${flaky_dir}" "${dead_dir}"
+
+# Wiring: the wrapper helps nobody while a job still inlines the raw pair.
+assert_eq "no raw apt-get left in ci.yml" "0" \
+  "$(grep -cE '^ *sudo apt-get' .github/workflows/ci.yml || true)"
+assert_eq "every apt step routes through the wrapper" "11" \
+  "$(grep -c 'bash scripts/ci-apt-install.sh' .github/workflows/ci.yml || true)"
+
+# ---------------------------------------------------------------------------
 # detect-pointer-lint-inputs.sh (#5311)
 # ---------------------------------------------------------------------------
 pointer_inputs_of() {

--- a/scripts/check_ignored_tests.sh
+++ b/scripts/check_ignored_tests.sh
@@ -93,7 +93,16 @@ done
   exit 3
 }
 
-EXCLUDES=(--exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui)
+# The four Tauri desktop crates, excluded for the same reason every headless
+# workspace job in ci.yml excludes them: they need WebKit2GTK, and nothing here
+# runs an ignored test of theirs. `trusty-audit-ui` was missing from this list
+# and compiled on every run of this gate (#5891).
+EXCLUDES=(
+  --exclude trusty-mpm-gui
+  --exclude trusty-code-gui
+  --exclude trusty-agents-ui
+  --exclude trusty-audit-ui
+)
 
 TMP_LIST="$(mktemp "${TMPDIR:-/tmp}/ignored-tests.list.XXXXXX")"
 TMP_SEL="$(mktemp "${TMPDIR:-/tmp}/ignored-tests.sel.XXXXXX")"

--- a/scripts/check_test_pointers.sh
+++ b/scripts/check_test_pointers.sh
@@ -14,7 +14,8 @@
 #   real one). This script turns that into a mechanical CI gate, mirroring
 #   scripts/check_line_cap.sh's ratcheted-allowlist shape.
 #
-# What: scans every tracked `.rs` file (`git ls-files '*.rs'`, minus
+# What: scans every tracked AND untracked-but-not-ignored `.rs` file
+#   (`git ls-files --cached --others --exclude-standard -- '*.rs'`, minus
 #   EXCLUDE_PREFIXES below) for `Test:` doc-comment annotations (a `///`/`//!`
 #   line whose stripped content starts with the literal `Test:`, plus any
 #   immediately-following `///`/`//!` continuation lines up to the next blank
@@ -498,10 +499,18 @@ scan() {
 
   # #4618: materialise the enumeration so a failing `git ls-files` is observable
   # instead of arriving as an empty stream that reads as "0 dangling pointers".
+  #
+  # #5798: `--others --exclude-standard` puts UNTRACKED, non-ignored `.rs` files
+  # in the corpus alongside the tracked ones. Tracked-only meant a developer who
+  # ran this before `git add` got a pass that said nothing about the file they
+  # were about to commit, and CI then failed on exactly that file (PR #5790:
+  # 24930 citations locally at 04:45, 24942 after the same files were tracked).
+  # `--cached` and `--others` are disjoint sets, so no file is listed twice, and
+  # `--exclude-standard` keeps `target/` and everything else gitignored out.
   rslist="$(mktemp "${TMPDIR:-/tmp}/tprslist.XXXXXX")"
-  if ! git ls-files '*.rs' > "$rslist"; then
-    echo "FAIL: TOOL ERROR — 'git ls-files *.rs' exited non-zero; nothing was" >&2
-    echo "      scanned. This is NOT a pass (issue #4618)." >&2
+  if ! git ls-files --cached --others --exclude-standard -- '*.rs' > "$rslist"; then
+    echo "FAIL: TOOL ERROR — 'git ls-files --cached --others *.rs' exited non-zero;" >&2
+    echo "      nothing was scanned. This is NOT a pass (issue #4618)." >&2
     rm -f "$raw" "$rslist"
     exit 1
   fi
@@ -751,6 +760,17 @@ mod tests {
 EOF
   ( cd "$tmp" && git init -q && git add -A && git -c user.email=t@t -c user.name=t commit -q -m fixture )
 
+  # #5798: written AFTER the commit and never `git add`ed, so it is untracked.
+  # `git ls-files '*.rs'` cannot see it, which is how a local run passed clean
+  # on PR #5790 while CI failed on this exact class of file. It must be scanned,
+  # and its dangling citation must be reported.
+  cat > "$tmp/crates/fixture/src/untracked_new.rs" <<'EOF'
+/// Why: fixture for the #5798 untracked-file case.
+/// What: nothing.
+/// Test: `untracked_file_dangling_test`.
+pub fn added_but_not_yet_staged() {}
+EOF
+
   local viol stale err checked rc
   viol="$(mktemp "${TMPDIR:-/tmp}/tpself.viol.XXXXXX")"
   stale="$(mktemp "${TMPDIR:-/tmp}/tpself.stale.XXXXXX")"
@@ -783,8 +803,14 @@ EOF
   # citation must resolve, not just `fn` citations (this is exactly the case
   # that shipped broken: module citations only ever passed via the
   # allowlist, never verified for real).
-  if [ "$(wc -l < "$viol" | tr -d ' ')" != "6" ]; then
-    echo "self-test FAIL: expected exactly 6 violations, got:" >&2
+  # ...plus untracked_file_dangling_test, cited by an UNTRACKED file (#5798) —
+  # seven in total.
+  if [ "$(wc -l < "$viol" | tr -d ' ')" != "7" ]; then
+    echo "self-test FAIL: expected exactly 7 violations, got:" >&2
+    cat "$viol" >&2
+    ok=0
+  elif ! grep -q "untracked_file_dangling_test" "$viol"; then
+    echo "self-test FAIL: the untracked file's dangling citation was not reported — the corpus is tracked-only again (issue #5798), got:" >&2
     cat "$viol" >&2
     ok=0
   elif ! grep -q "dangling_test_missing" "$viol"; then

--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# ci-apt-install.sh — install apt packages on a CI runner with a bounded,
+# observable retry (issue #5999).
+#
+# Why: every "Install system dependencies" / "Install Tauri system
+#   dependencies" step in ci.yml ran `sudo apt-get update -qq` with no retry and
+#   no timeout, under the job's `timeout-minutes: 30`. A stalled apt mirror
+#   produces NO output, so the step consumed the whole 30-minute budget and the
+#   job was killed before cargo ran even once. Observed twice on 2026-08-18:
+#   three required jobs on a PR at ~01:16 UTC, and `trusty-agents-ui clippy` +
+#   `trusty-code-gui clippy` on PR #5992 at 30m21s/30m22s (run 32158580446).
+#   The PR reads red on code that is fine, and the whole run has to be redone.
+#
+# What: runs `apt-get update` then `apt-get install`, each attempt wrapped in
+#   `timeout` and each phase retried up to ATTEMPTS times, with the whole thing
+#   capped by a total budget. A stall now dies at the per-attempt timeout with
+#   an `::error::` line naming the phase, the attempt, and the elapsed seconds,
+#   instead of stalling silently until the job is cancelled.
+#
+#   Defaults (each overridable by environment variable, which is also how the
+#   self-test drives every branch without waiting on a real mirror):
+#
+#     CI_APT_ATTEMPTS=3          attempts per phase
+#     CI_APT_UPDATE_TIMEOUT_S=120  per-attempt ceiling for `apt-get update`
+#     CI_APT_INSTALL_TIMEOUT_S=420 per-attempt ceiling for `apt-get install`
+#     CI_APT_RETRY_DELAY_S=5     pause between attempts
+#     CI_APT_TOTAL_BUDGET_S=600  hard ceiling across both phases
+#
+#   The total budget is the number that answers the issue: worst case is ten
+#   minutes, not thirty, and the ten minutes are spent visibly.
+#
+#   `timeout` is a GNU coreutils tool. It is present on the hosted Linux
+#   runners this script is written for; when it is absent (a bare macOS shell,
+#   for instance) the command runs unwrapped and a warning says so, because
+#   refusing to install is worse than installing without a per-attempt ceiling.
+#   The retry and the total budget still apply.
+#
+# Usage: bash scripts/ci-apt-install.sh <package> [<package> ...]
+#
+# Exit: 0 when the packages are installed. 1 when a phase exhausted its
+#   attempts or the total budget; the last apt exit code is reported (124 is
+#   `timeout`'s "the command was still running", i.e. the stall this exists
+#   for). 2 on usage error.
+#
+# Scope: `.github/workflows/ci.yml` routes every apt step through this. The
+#   release and pre-publish workflows still inline the raw two-liner; they can
+#   adopt this the next time one of them is touched.
+#
+# Test: scripts/check-ci-helpers-selftest.sh (`ci-apt-install:` cases) drives
+#   the succeeds-first-try, succeeds-after-a-retry, exhausts-attempts, and
+#   stalls-then-times-out branches against a stubbed `apt-get` on PATH.
+
+set -uo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: bash scripts/ci-apt-install.sh <package> [<package> ...]" >&2
+  exit 2
+fi
+
+ATTEMPTS="${CI_APT_ATTEMPTS:-3}"
+UPDATE_TIMEOUT_S="${CI_APT_UPDATE_TIMEOUT_S:-120}"
+INSTALL_TIMEOUT_S="${CI_APT_INSTALL_TIMEOUT_S:-420}"
+RETRY_DELAY_S="${CI_APT_RETRY_DELAY_S:-5}"
+TOTAL_BUDGET_S="${CI_APT_TOTAL_BUDGET_S:-600}"
+
+STARTED_AT="$(date +%s)"
+
+elapsed() { echo "$(( $(date +%s) - STARTED_AT ))"; }
+
+TIMEOUT_BIN="$(command -v timeout || command -v gtimeout || true)"
+if [ -z "$TIMEOUT_BIN" ]; then
+  echo "ci-apt-install: no 'timeout' on PATH — running apt unwrapped; the retry and total budget still apply." >&2
+fi
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+  SUDO="sudo"
+fi
+
+# run_phase <label> <per-attempt-timeout-s> <apt-get args...>
+#
+# Returns 0 on the first attempt that succeeds; 1 once the attempts or the total
+# budget are exhausted, having printed a GitHub `::error::` annotation naming
+# which of the two ran out.
+run_phase() {
+  local label="$1" per_attempt="$2"
+  shift 2
+
+  local attempt=1 rc=0 spent
+  while [ "$attempt" -le "$ATTEMPTS" ]; do
+    spent="$(elapsed)"
+    if [ "$spent" -ge "$TOTAL_BUDGET_S" ]; then
+      echo "::error::ci-apt-install: ${label} abandoned after ${spent}s — over the ${TOTAL_BUDGET_S}s total budget. The apt mirror is not responding; re-run the job."
+      return 1
+    fi
+
+    echo "ci-apt-install: ${label}, attempt ${attempt}/${ATTEMPTS} (${spent}s elapsed, ${per_attempt}s ceiling)" >&2
+    rc=0
+    if [ -n "$TIMEOUT_BIN" ]; then
+      "$TIMEOUT_BIN" "$per_attempt" ${SUDO:+"$SUDO"} "$@" || rc=$?
+    else
+      ${SUDO:+"$SUDO"} "$@" || rc=$?
+    fi
+
+    if [ "$rc" -eq 0 ]; then
+      echo "ci-apt-install: ${label} OK after ${attempt} attempt(s), $(elapsed)s elapsed" >&2
+      return 0
+    fi
+
+    if [ "$rc" -eq 124 ]; then
+      echo "ci-apt-install: ${label} attempt ${attempt} STALLED — killed at the ${per_attempt}s ceiling." >&2
+    else
+      echo "ci-apt-install: ${label} attempt ${attempt} failed (exit ${rc})." >&2
+    fi
+
+    attempt=$((attempt + 1))
+    [ "$attempt" -le "$ATTEMPTS" ] && sleep "$RETRY_DELAY_S"
+  done
+
+  echo "::error::ci-apt-install: ${label} failed ${ATTEMPTS} time(s), last exit ${rc}, $(elapsed)s elapsed. Exit 124 means the mirror stalled and the attempt was killed at its ${per_attempt}s ceiling."
+  return 1
+}
+
+run_phase "apt-get update" "$UPDATE_TIMEOUT_S" apt-get update -qq || exit 1
+run_phase "apt-get install" "$INSTALL_TIMEOUT_S" \
+  apt-get install -y --no-install-recommends "$@" || exit 1
+
+echo "ci-apt-install: installed $* in $(elapsed)s" >&2

--- a/scripts/classify-ci-results.sh
+++ b/scripts/classify-ci-results.sh
@@ -37,6 +37,20 @@
 #   mapping is then correct if it is ever fed raw check-run conclusions, where
 #   `timed_out` is a real value.
 #
+# FEED IT RAW CONCLUSIONS, NEVER A LAUNDERED ONE (#5998). This script can only
+#   classify what it is handed, so a caller that hands it an AGGREGATOR job's
+#   conclusion has already decided the verdict. `ci.yml`'s `test` job is one:
+#   it reads the shard matrix's result and `exit 1`s on anything that is not
+#   `success`, so two shards CANCELLED by a newer push to the same concurrency
+#   group reached this script as `test=failure` and were folded into red — run
+#   32154560958 on 41fee6ac6 filed a false alarm on the `ci-red-main` issue
+#   while the superseding run on 2875e1f9d was fully green. The fix is upstream
+#   of the mapping: `notify-main-failure` now classifies `test-shard` and
+#   `test-doc` directly, so a cancellation arrives as `cancelled` (inconclusive)
+#   and a genuine shard failure still arrives as `failure` (red). This is the
+#   mirror of #4179, which fixed cancelled-hides-a-failure; both hold only while
+#   the conclusions handed in are the jobs' own.
+#
 # Outputs (stdout, and appended to $GITHUB_OUTPUT when set):
 #   verdict=green|red|inconclusive
 #   summary=<one-line per-job breakdown>
@@ -46,7 +60,9 @@
 #
 # Test: scripts/check-ci-helpers-selftest.sh (`classify-ci-results:` cases)
 #   asserts the verdict for every conclusion value above, individually and in
-#   precedence combinations.
+#   precedence combinations, plus the #5998 pair — the raw superseded-shard set
+#   and the laundered one — and the ci.yml wiring that decides which of the two
+#   this script is handed.
 
 set -euo pipefail
 


### PR DESCRIPTION
Four CI/scripts bugs, one PR. Shell and workflow only — no crate source, so no
changelog fragment is owed (`scripts/check_changelog_fragment.sh` exempts
CI-only PRs).

Refs #5998, Refs #5999, Refs #5891, Refs #5798

## #5998 — a cancelled shard folded into a red verdict

The mapping in `classify-ci-results.sh` was never wrong; the input was. The
`test` job is an aggregator that exits 1 on any non-`success` matrix result, so
two shards cancelled by a newer push arrived as `test=failure`.
`notify-main-failure` now classifies `test-shard` / `test-doc` directly and
reports the aggregate as `cancelled` when a cancellation is what made it red.

Proven, same run shape both ways (run 32154560958, head `41fee6ac6`):

```
BEFORE  test=failure                                  -> verdict=red
AFTER   test=cancelled test-shard=cancelled test-doc=success -> verdict=inconclusive
STILL RED  test=failure test-shard=failure test-doc=success  -> verdict=red
STILL RED  test=failure test-shard=success test-doc=failure  -> verdict=red
```

Four mapping cases plus five wiring assertions in
`scripts/check-ci-helpers-selftest.sh`; the wiring greps return 0 against
`origin/main`'s `ci.yml`.

## #5999 — unretried apt stalls the job to its ceiling

Every apt step in `ci.yml` (11 sites) routes through the new
`scripts/ci-apt-install.sh`: three attempts per phase, a per-attempt `timeout`
(120s update / 420s install), a 600s total budget, and an `::error::` line
naming the phase and elapsed seconds.

Proven against one stalled-mirror stub:

```
BEFORE  raw pair, cut off by an external 8s timeout -> exit=124, nothing printed
AFTER   ci-apt-install.sh (2s ceiling, 3 attempts) -> exit=1 after 7s,
        "apt-get update attempt N STALLED — killed at the 2s ceiling" x3,
        then ::error::…failed 3 time(s), last exit 124
```

Nine self-test cases: healthy, two-transient-failures-then-success (asserting
the attempt count), never-succeeds, the stall, and the wiring (0 raw
`sudo apt-get` left, 11 wrapper calls). The four required Tauri clippy jobs
exercise the wrapper on a real runner in this PR's own CI.

## #5891 — `check_ignored_tests.sh` omitted `trusty-audit-ui`

```
$ cargo tree --depth 0 --workspace <3 excludes, as on main>  | grep trusty-audit-ui
trusty-audit-ui v0.1.0 (crates/trusty-audit/ui/src-tauri)
$ cargo tree --depth 0 --workspace <4 excludes, this branch> | grep trusty-audit-ui
(no Tauri UI crate selected)
```

Package selection is what `cargo nextest list --workspace --exclude` consumes,
so the crate is no longer compiled by that gate. The gate itself was not run —
it builds the whole workspace.

## #5798 — the test-pointer lint scanned tracked files only

Corpus is now `git ls-files --cached --others --exclude-standard -- '*.rs'`.
The self-test gained an untracked fixture file with a dangling citation:

```
BEFORE (tracked-only enumeration)  self-test FAIL: expected exactly 7 violations, got: <6 rows>
AFTER                              check_test_pointers self-test: OK
```

Real-tree run (this is the required `Doc-comment pointer lint` gate):

```
test-pointers: resolved 26116 Test: citation(s) (floor 5000) — 0 dangling pointers — OK.
```

Scan floor still fails closed: `check_scan_floor_selftest.sh test_pointers` — ok.

## Gates

```
bash scripts/check-ci-helpers-selftest.sh   -> all 176 cases passed
bash scripts/check_test_pointers.sh --self-test -> OK
bash scripts/check_test_pointers.sh         -> 26116 citations, 0 dangling
bash scripts/check_scan_floor_selftest.sh test_pointers -> 1 gate correctly refuses a vacuous scan
bash scripts/check_generation_artifacts.sh  -> 0 leaked artifacts
shellcheck <every edited script>            -> no new findings beyond the 8 pre-existing
                                               SC2016/SC2034/SC2164 infos on main
```

Rung 1 of the test ladder: no Rust source is touched, so no cargo gate applies.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
