### PR TITLE
feat(trusty-review): render code-review and authorship reports as separate documents

### DIFF
--- a/crates/trusty-review/changelog.d/6046-split-report-outputs.md
+++ b/crates/trusty-review/changelog.d/6046-split-report-outputs.md
@@ -1,0 +1,12 @@
+Changed
+
+- `report` now renders two documents per run instead of one (#6046): the
+  code-review report keeps every section it had except Authorship & Key-Person
+  Risk, which becomes its own `<stem>-authorship.md` beside it, with its own
+  title, provenance legend, and generation date. Both come from one fill pass,
+  so the two cannot drift in wording or provenance tagging. The code-review
+  report's Contents jump list no longer links the authorship section, since it
+  no longer carries it. A run with no authorship data still writes the second
+  document, carrying the same no-data line the section used to show inline.
+  Both paths are printed to stdout as before, so `tga audit` picks them up and
+  `trusty-audit` packages both without change.

--- a/crates/trusty-review/src/report/mod.rs
+++ b/crates/trusty-review/src/report/mod.rs
@@ -50,6 +50,8 @@ pub mod scan;
 // #5747: the schema-tag parse both artifact loaders decide compatibility from.
 pub(crate) mod schema;
 pub mod section_instructions;
+// #6046: the code-review / authorship output split.
+pub mod split;
 pub mod synthesize;
 pub mod synthesize_digest;
 pub mod synthesize_guard;
@@ -89,8 +91,9 @@ pub use model::{ReportModel, RepositoryReport};
 pub use polish::{polish, polish_with_gaps, strip_template_comments};
 pub use provenance::{Provenance, tag};
 pub use redact::{report_secrets, scrub_finding, scrub_investigation, scrub_metrics, scrub_prose};
-pub use reporter::Reporter;
+pub use reporter::{RenderedReports, Reporter};
 pub use scan::{Framework, RepoScan, scan_repo};
+pub use split::{authorship_document, split_authorship};
 pub use synthesize::{FindingProse, RiskRow, Synthesis, SynthesisError, Synthesizer};
 pub use template::{DEFAULT_TEMPLATE, TemplateLoader, parse_section_instructions};
 pub use ticketing::{TicketingSummary, load_ticketing};

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -34,6 +34,8 @@ use super::reporter_graph_datasets::{
     inject_complexity_distribution_dataset, inject_loc_by_technology_dataset,
 };
 use super::reporter_performance::fill_performance_note;
+// #6046: the authorship section leaves as its own document.
+use super::split;
 
 /// Renders a [`ReportModel`] to markdown + JSON and writes them atomically.
 ///
@@ -76,19 +78,38 @@ impl Reporter {
         self
     }
 
-    /// Render the model into markdown using the supplied template source.
+    /// Render the model into the code-review markdown document.
     ///
     /// Why: exposed separately so tests can assert on rendered markdown without
-    /// touching disk.
+    /// touching disk. Since #6046 this is the CODE-REVIEW half only — the
+    /// authorship section renders as its own document, reachable through
+    /// [`render_documents`](Self::render_documents).
+    /// What: delegates to [`render_documents`](Self::render_documents) and
+    /// returns its code-review document.
+    /// Test: `reporter_tests.rs::{render_contains_expected,
+    /// reporter_strips_leading_comment_header}`.
+    pub fn render(&self, model: &ReportModel, template: &str) -> String {
+        self.render_documents(model, template).code_review
+    }
+
+    /// Render the model into both documents one `report` run produces (#6046).
+    ///
+    /// Why: the code review and the authorship assessment answer different
+    /// diligence questions from different data — analyze metrics versus git
+    /// history — and the owner asked to read them apart. Rendering both from
+    /// ONE fill pass is what keeps them consistent: a single [`Scope`], one
+    /// polish, one set of provenance markers, no second template to drift.
     /// What: strips the template's leading instructional `<!-- … -->` comment
     /// (live-QA defect #2314 — a generated report must never carry template
     /// authoring instructions, and the header's own literal `{{field}}` /
     /// BEGIN-END documentation examples would otherwise be mangled by the fill
-    /// engine), builds the fill [`Scope`] from the model, and renders the
-    /// remainder.
-    /// Test: `reporter_tests.rs::{render_contains_expected,
-    /// reporter_strips_leading_comment_header}`.
-    pub fn render(&self, model: &ReportModel, template: &str) -> String {
+    /// engine), builds the fill [`Scope`] from the model, renders and polishes
+    /// the whole document, then cuts the authorship section out of it. The cut
+    /// happens BEFORE the jump-list injection so the code-review document never
+    /// links a heading it no longer carries.
+    /// Test: `reporter_tests.rs::{render_splits_authorship_into_its_own_document,
+    /// render_without_authorship_data_still_produces_the_document}`.
+    pub fn render_documents(&self, model: &ReportModel, template: &str) -> RenderedReports {
         let scope = build_scope(model);
         // Fill deterministically, then polish the OUTPUT (#2342): strip every
         // non-dataset template comment, drop honesty-marker rows, collapse empty
@@ -115,11 +136,19 @@ impl Reporter {
         // sections, plus the rejected-evidence note, are appended after polish so
         // their measured/inferred rows are never subject to omit-empty.
         out.push_str(&super::investigate::report_sections(model));
+        // #6046: cut the authorship section out before the jump list is built,
+        // so the code-review document links only what it still carries.
+        let (code_body, authorship_section) = split::split_authorship(&out);
         // #6004: LAST — every section this render pass can produce has now been
         // appended, so this is the one point where the final `##` heading set is
         // known. Replaces the exec-summary jump-list sentinel with real links to
         // whichever of those headings actually survived.
-        contents_links::inject(&out)
+        RenderedReports {
+            code_review: contents_links::inject(&code_body),
+            authorship: authorship_section.map(|section| {
+                split::authorship_document(&model.title, &model.generated_date, &section)
+            }),
+        }
     }
 
     /// Render and write `{slug}.md` + `{slug}.json` atomically to `output_dir`.
@@ -141,6 +170,7 @@ impl Reporter {
     /// any I/O or serialisation failure.
     ///
     /// Test: `reporter_tests.rs::{write_emits_both,
+    /// write_emits_the_authorship_document_alongside,
     /// write_refuses_a_model_with_no_synthesis}`.
     pub fn write(&self, model: &ReportModel, template: &str) -> Result<Vec<PathBuf>> {
         // #5454: inference is required, so a synthesis-free model is a bug in the
@@ -155,7 +185,7 @@ impl Reporter {
         })?;
 
         let stem = report_stem(model);
-        let markdown = self.render(model, template);
+        let documents = self.render_documents(model, template);
         let json = serde_json::to_string_pretty(model).map_err(|source| ReportError::Metrics {
             path: PathBuf::from("<model.json>"),
             source,
@@ -163,12 +193,45 @@ impl Reporter {
 
         let md_path = self.output_dir.join(format!("{stem}.md"));
         let json_path = self.output_dir.join(format!("{stem}.json"));
-        atomic_write(&md_path, markdown.as_bytes())?;
+        atomic_write(&md_path, documents.code_review.as_bytes())?;
         atomic_write(&json_path, json.as_bytes())?;
         info!(md = %md_path.display(), json = %json_path.display(), "report written");
 
-        Ok(vec![md_path, json_path])
+        let mut written = vec![md_path, json_path];
+        // #6046: appended, never inserted — tga reads the `.json` path out of
+        // this list by extension, and every consumer that indexes it expects
+        // the code-review report first.
+        if let Some(authorship) = &documents.authorship {
+            let path = self
+                .output_dir
+                .join(format!("{stem}{}.md", split::AUTHORSHIP_STEM_SUFFIX));
+            atomic_write(&path, authorship.as_bytes())?;
+            info!(md = %path.display(), "authorship report written");
+            written.push(path);
+        }
+
+        Ok(written)
     }
+}
+
+/// The documents one render pass produces (#6046).
+///
+/// Why: `report` renders the code review and the authorship assessment as
+/// separate deliverables, and a caller needs both back from one call rather
+/// than rendering twice.
+/// What: `code_review` is every section except authorship; `authorship` is the
+/// standalone authorship document, `None` only when the template carries no
+/// authorship section at all. A run with no authorship data still produces the
+/// document, carrying the polished section's no-data line.
+/// Test: `reporter_tests.rs::{render_splits_authorship_into_its_own_document,
+/// render_without_authorship_data_still_produces_the_document}`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct RenderedReports {
+    /// The code-review report: every rendered section except authorship.
+    pub code_review: String,
+    /// The standalone authorship report, when the render produced one.
+    pub authorship: Option<String>,
 }
 
 /// Compute the output file stem for a report: `{date}-{title-slug}`.

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -255,6 +255,9 @@ fn build_model_from_manifest() {
 
 /// Why: `write` must emit both a markdown and a JSON file that round-trips.
 /// What: writes the report and asserts both files exist and the JSON parses.
+/// Since #6046 the bundled template also yields the authorship document, so the
+/// count is three — `write_emits_the_authorship_document_alongside` pins its
+/// name and ordering.
 /// Test: this test itself.
 #[test]
 fn write_emits_both() {
@@ -269,7 +272,7 @@ fn write_emits_both() {
         .expect("bundled template");
     let reporter = Reporter::new(&out_dir);
     let written = reporter.write(&model, &template).expect("write ok");
-    assert_eq!(written.len(), 2);
+    assert_eq!(written.len(), 3, "{written:?}");
 
     let md = written
         .iter()
@@ -2341,5 +2344,149 @@ fn key_facts_authorship_rows_survive_the_fill_order() {
     assert!(
         !trajectory.contains("Not computed"),
         "the named gap clobbered the measured trajectory:\n{trajectory}"
+    );
+}
+
+// ── #6046: the code-review / authorship output split ─────────────────────────
+
+/// Build a model whose single repo carries a loaded authorship artifact, so the
+/// Authorship & Key-Person Risk section has real rows and survives `polish`.
+fn fixture_model_with_authorship(dir: &Path) -> ReportModel {
+    let mut model = fixture_model(dir);
+    let repo = model.repositories.first_mut().expect("one repository");
+    repo.authorship = Some(crate::report::authorship::AuthorshipSummary {
+        schema_version: "v0".to_string(),
+        repository: "Acme Web".to_string(),
+        distinct_authors: 7,
+        bus_factor: 2,
+        top_author_share_pct: 61.0,
+        single_author_subsystems: vec!["src".to_string()],
+        monthly_trajectory: vec![crate::report::authorship::MonthlyActivity {
+            month: "2026-02".to_string(),
+            active_authors: 2,
+            commits: 40,
+        }],
+        unresolved_authors: 0,
+        caveats: vec!["squash-merge attribution is not corrected for".to_string()],
+    });
+    model
+}
+
+/// Why: the owner asked to read the code review apart from authorship (#6046),
+/// so one render must produce two documents with disjoint section membership.
+/// What: renders a model with authorship data and asserts the section is absent
+/// from the code-review document — including its jump list — and present, with
+/// its measured rows, in the authorship document.
+/// Test: this test itself.
+#[test]
+fn render_splits_authorship_into_its_own_document() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = fixture_model_with_authorship(tmp.path());
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+
+    let documents = Reporter::new(tmp.path()).render_documents(&model, &template);
+
+    assert!(
+        !documents
+            .code_review
+            .contains("## Authorship & Key-Person Risk"),
+        "the authorship section must not render in the code-review document:\n{}",
+        documents.code_review
+    );
+    assert!(
+        !documents.code_review.contains("| Acme Web | 7"),
+        "the authorship row must not render in the code-review document:\n{}",
+        documents.code_review
+    );
+    assert!(
+        !documents
+            .code_review
+            .contains("#authorship-key-person-risk"),
+        "the jump list must not link a section this document no longer carries"
+    );
+    // The frontloaded sections stay where the owner put them (#6004).
+    assert!(documents.code_review.contains("## Key Facts"));
+    assert!(documents.code_review.contains("## 2. Executive Summary"));
+    assert!(documents.code_review.contains("## 5. Findings by Severity"));
+
+    let authorship = documents.authorship.expect("authorship document rendered");
+    assert!(
+        authorship.starts_with("# Authorship & Key-Person Risk: Acme Due Diligence"),
+        "{authorship}"
+    );
+    assert!(authorship.contains("| Acme Web |"), "{authorship}");
+    assert!(authorship.contains("squash-merge"), "{authorship}");
+    assert!(
+        !authorship.contains("Findings by Severity"),
+        "the authorship document must carry only its own section:\n{authorship}"
+    );
+}
+
+/// Why: a run with no authorship data must still deliver the document — an
+/// absent file reads as "we forgot", where `polish`'s own no-data line reads as
+/// "we looked and there was nothing", which is what the Gaps & Caveats entry in
+/// the code-review report also says.
+/// What: the no-authorship fixture still renders a second document, carrying the
+/// collapsed section's no-data line rather than fabricated rows.
+/// Test: this test itself.
+#[test]
+fn render_without_authorship_data_still_produces_the_document() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = fixture_model(tmp.path());
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+
+    let documents = Reporter::new(tmp.path()).render_documents(&model, &template);
+    let authorship = documents.authorship.expect("authorship document rendered");
+    assert!(authorship.contains("No data available"), "{authorship}");
+    assert!(
+        !documents
+            .code_review
+            .contains("## Authorship & Key-Person Risk"),
+        "the section must leave the code-review document even with no data"
+    );
+}
+
+/// Why: the split is only delivered once both documents reach disk — tga reads
+/// the paths trusty-review prints, and trusty-audit packages every file in the
+/// output directory.
+/// What: writes a model with authorship data and asserts a third file appears,
+/// named `{stem}-authorship.md`, with the code-review report still first.
+/// Test: this test itself.
+#[test]
+fn write_emits_the_authorship_document_alongside() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut model = fixture_model_with_authorship(tmp.path());
+    model.synthesis = Some(crate::report::synthesize::Synthesis::default());
+    let out_dir = tmp.path().join("out");
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+
+    let written = Reporter::new(&out_dir)
+        .write(&model, &template)
+        .expect("write ok");
+
+    assert_eq!(written.len(), 3, "{written:?}");
+    let stem = report_stem(&model);
+    assert_eq!(written[0], out_dir.join(format!("{stem}.md")));
+    assert_eq!(written[1], out_dir.join(format!("{stem}.json")));
+    assert_eq!(written[2], out_dir.join(format!("{stem}-authorship.md")));
+    for path in &written {
+        assert!(path.exists(), "{} was not written", path.display());
+    }
+
+    let authorship = std::fs::read_to_string(&written[2]).expect("read authorship");
+    assert!(
+        authorship.contains("Authorship & Key-Person Risk"),
+        "{authorship}"
+    );
+    let code_review = std::fs::read_to_string(&written[0]).expect("read code review");
+    assert!(
+        !code_review.contains("## Authorship & Key-Person Risk"),
+        "{code_review}"
     );
 }

--- a/crates/trusty-review/src/report/split.rs
+++ b/crates/trusty-review/src/report/split.rs
@@ -1,0 +1,119 @@
+//! Cutting one rendered document into the code-review report and a standalone
+//! authorship report (#6046).
+//!
+//! Why: owner request 2026-08-19 — "I'd like to see the outputs of the code
+//! review separate from authorship." Authorship is derived by tga from git
+//! history and never reads source, so a diligence reader wants it as its own
+//! deliverable rather than a section two thirds of the way down the
+//! code-review document.
+//! What: [`split_authorship`] removes the Authorship & Key-Person Risk section
+//! from a rendered, polished document and hands it back separately;
+//! [`authorship_document`] wraps that section as a document with its own title
+//! and provenance legend. Both run inside `Reporter::render_documents`, after
+//! `polish` (so the section carries the same dropped-marker and no-data
+//! treatment it had inside the one document) and BEFORE
+//! `contents_links::inject` (so the code-review report's jump list never links
+//! a heading it no longer carries).
+//! Test: `split_tests.rs`.
+
+use super::provenance;
+
+/// Text that identifies the authorship section's level-2 heading.
+///
+/// Why: the bundled template heads it `## Authorship & Key-Person Risk`, but an
+/// operator template may number or reword it. Matching one distinctive word
+/// keeps a renamed heading splitting instead of silently landing back in the
+/// code-review document.
+const AUTHORSHIP_HEADING_NEEDLE: &str = "Authorship";
+
+/// Filename suffix the authorship document is written under.
+pub const AUTHORSHIP_STEM_SUFFIX: &str = "-authorship";
+
+/// Remove the authorship section from a rendered document.
+///
+/// Why: the split is a post-render cut rather than a second template, so both
+/// documents are filled from one scope and cannot drift in wording, provenance
+/// tagging, or honesty-marker handling.
+/// What: scans level-2 (`## `) headings in document order, tracking fenced code
+/// blocks with the same toggle guard [`super::contents_links::inject`] uses so
+/// a `## `-prefixed line inside quoted source bytes is never mistaken for a
+/// heading. Everything from the authorship heading up to the next level-2
+/// heading (or end of document) is returned as the second element; everything
+/// else is the first. A document with no authorship heading — a custom template
+/// that omits the section — returns `(rendered, None)` unchanged. A run with no
+/// authorship data still splits: `polish` keeps the heading and replaces the
+/// body with its no-data line, which is what the second document then carries.
+/// Test: `split_tests::{splits_the_authorship_section,
+/// no_authorship_heading_leaves_the_document_whole,
+/// a_fenced_heading_line_is_not_split_on,
+/// a_trailing_authorship_section_splits_to_the_end}`.
+pub fn split_authorship(rendered: &str) -> (String, Option<String>) {
+    let mut kept: Vec<&str> = Vec::new();
+    let mut section: Vec<&str> = Vec::new();
+    let mut in_fence = false;
+    let mut in_section = false;
+
+    for line in rendered.lines() {
+        let trimmed = line.trim_end();
+        if trimmed.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+        } else if !in_fence && let Some(text) = trimmed.strip_prefix("## ") {
+            in_section = text.contains(AUTHORSHIP_HEADING_NEEDLE);
+        }
+        if in_section {
+            section.push(line);
+        } else {
+            kept.push(line);
+        }
+    }
+
+    if section.is_empty() {
+        return (rendered.to_string(), None);
+    }
+    (rejoin(&kept, rendered), Some(rejoin(&section, rendered)))
+}
+
+/// Rejoin split lines, restoring the source's trailing newline.
+///
+/// Why: `str::lines` drops the final newline, and a markdown file that stops
+/// mid-line reads as truncated to every downstream tool.
+fn rejoin(lines: &[&str], source: &str) -> String {
+    let mut out = lines.join("\n");
+    if source.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+/// Wrap an extracted authorship section as a standalone document.
+///
+/// Why: the section alone has no title, no date, and no key to the provenance
+/// markers its own table cells carry — everything a reader needs travelled in
+/// the code-review document's header. This adds exactly that much back and
+/// nothing else.
+/// What: promotes the section's `## ` heading to the document's `# ` title,
+/// suffixed with the report codename, then the provenance legend, a line naming
+/// the companion report and the generation date, and the section body verbatim.
+/// Test: `split_tests::{authorship_document_carries_title_and_legend,
+/// authorship_document_keeps_the_section_body}`.
+pub fn authorship_document(title: &str, generated_date: &str, section: &str) -> String {
+    let mut lines = section.lines();
+    let heading = lines
+        .next()
+        .and_then(|l| l.trim_end().strip_prefix("## "))
+        .map(str::trim)
+        .unwrap_or("Authorship & Key-Person Risk")
+        .to_string();
+    let body = lines.collect::<Vec<_>>().join("\n");
+
+    format!(
+        "# {heading}: {title}\n\n{legend}\n\nCompanion to the technical \
+         due-diligence report for {title}; generated {generated_date}.\n\n{body}\n",
+        legend = provenance::LEGEND,
+        body = body.trim(),
+    )
+}
+
+#[cfg(test)]
+#[path = "split_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/report/split_tests.rs
+++ b/crates/trusty-review/src/report/split_tests.rs
@@ -1,0 +1,103 @@
+//! Unit tests for the code-review / authorship output split (#6046).
+
+use super::*;
+
+/// A three-section document with the authorship section in the middle.
+fn document() -> String {
+    "# Report\n\n## 5. Findings\n\nA finding.\n\n## Authorship & Key-Person Risk\n\n\
+     Bus factor 2.\n\n| App | Authors |\n|---|---|\n| acme | 7 |\n\n## 6. Risk Registers\n\nRows.\n"
+        .to_string()
+}
+
+/// Why: the split is the whole feature — the authorship section must leave the
+/// code-review document and arrive intact in the second one.
+/// What: asserts the section is absent from the remainder, present in the cut,
+/// and that the sections either side of it are untouched.
+#[test]
+fn splits_the_authorship_section() {
+    let (kept, section) = split_authorship(&document());
+    let section = section.expect("authorship section is present");
+
+    assert!(!kept.contains("Authorship & Key-Person Risk"), "{kept}");
+    assert!(!kept.contains("Bus factor 2"), "{kept}");
+    assert!(kept.contains("## 5. Findings"), "{kept}");
+    assert!(kept.contains("## 6. Risk Registers"), "{kept}");
+
+    assert!(section.starts_with("## Authorship & Key-Person Risk"));
+    assert!(section.contains("Bus factor 2"), "{section}");
+    assert!(section.contains("| acme | 7 |"), "{section}");
+    assert!(!section.contains("Risk Registers"), "{section}");
+}
+
+/// Why: a custom template without the section, or a run whose section `polish`
+/// collapsed for want of data, must render exactly as before.
+/// What: a document with no authorship heading comes back byte-identical, with
+/// no second document.
+#[test]
+fn no_authorship_heading_leaves_the_document_whole() {
+    let doc = "# Report\n\n## 5. Findings\n\nA finding.\n";
+    let (kept, section) = split_authorship(doc);
+    assert_eq!(kept, doc);
+    assert!(section.is_none());
+}
+
+/// Why: raw-evidence quotes carry source bytes verbatim, and a shell comment or
+/// markdown sample inside one can start with `## `. Cutting there would take the
+/// rest of the document with it.
+/// What: an authorship-looking heading inside a fenced block is not split on.
+#[test]
+fn a_fenced_heading_line_is_not_split_on() {
+    let doc = "# Report\n\n## 5. Findings\n\n```\n## Authorship & Key-Person Risk\n```\n\nAfter.\n";
+    let (kept, section) = split_authorship(doc);
+    assert!(section.is_none(), "fenced line must not start a section");
+    assert_eq!(kept, doc);
+}
+
+/// Why: the section may be the document's last, with nothing after it to bound
+/// the cut.
+/// What: a trailing authorship section splits to end-of-document.
+#[test]
+fn a_trailing_authorship_section_splits_to_the_end() {
+    let doc = "# Report\n\n## 5. Findings\n\nA finding.\n\n## Authorship\n\nBus factor 2.\n";
+    let (kept, section) = split_authorship(doc);
+    assert_eq!(kept, "# Report\n\n## 5. Findings\n\nA finding.\n\n");
+    assert!(
+        section.expect("section").contains("Bus factor 2"),
+        "trailing section must be captured"
+    );
+}
+
+/// Why: the extracted section arrives with no title, date, or key to the
+/// provenance markers its own cells carry — all of which lived in the
+/// code-review document's header.
+/// What: asserts the title line, the provenance legend, and the generation date.
+#[test]
+fn authorship_document_carries_title_and_legend() {
+    let (_, section) = split_authorship(&document());
+    let doc = authorship_document("Acme DD", "2026-08-19", &section.expect("section"));
+
+    assert!(
+        doc.starts_with("# Authorship & Key-Person Risk: Acme DD\n"),
+        "{doc}"
+    );
+    assert!(doc.contains(provenance::LEGEND), "{doc}");
+    assert!(doc.contains("generated 2026-08-19"), "{doc}");
+}
+
+/// Why: the wrapper must add a header and change nothing else — the rows are
+/// already filled, polished, and provenance-tagged.
+/// What: the section body survives verbatim and the duplicated `## ` heading is
+/// promoted to the `# ` title rather than repeated.
+#[test]
+fn authorship_document_keeps_the_section_body() {
+    let (_, section) = split_authorship(&document());
+    let doc = authorship_document("Acme DD", "2026-08-19", &section.expect("section"));
+
+    assert!(doc.contains("Bus factor 2."), "{doc}");
+    assert!(doc.contains("| acme | 7 |"), "{doc}");
+    assert!(
+        !doc.contains("## Authorship & Key-Person Risk"),
+        "the heading is promoted to the title, not repeated:\n{doc}"
+    );
+    assert!(doc.ends_with('\n'), "must end with a newline");
+}

--- a/crates/trusty-review/tests/report_e2e.rs
+++ b/crates/trusty-review/tests/report_e2e.rs
@@ -101,9 +101,17 @@ fn end_to_end_two_repo_report() {
     assert!(!md.contains("PLACEHOLDER SYNTAX"));
     assert!(!md.contains("trusty-review template:"));
 
-    // Write and verify the dual-output pair.
+    // Write and verify the outputs: the code-review markdown, its JSON twin,
+    // and — since #6046 — the authorship report as its own document.
     let written = reporter.write(&model, &template).expect("write ok");
-    assert_eq!(written.len(), 2);
+    assert_eq!(written.len(), 3, "{written:?}");
+    assert!(
+        written[2]
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.ends_with("-authorship.md")),
+        "{written:?}"
+    );
     for path in &written {
         assert!(path.exists(), "missing output {}", path.display());
     }


### PR DESCRIPTION
Refs #6046 — the output half only. Running the analyze pass and the tga sweep independently stays follow-up.

`Reporter::render_documents` cuts the `## Authorship & Key-Person Risk` section out of the rendered document after `polish` and before the Contents jump list is built, so the code-review report never links a section it no longer carries. The section is rewrapped by `split::authorship_document` with its own title, provenance legend, and generation date, and `write` puts it at `<stem>-authorship.md` beside the existing `<stem>.md` / `<stem>.json`. One fill pass produces both documents, so there is no second template to drift. A run with no authorship data still gets the second document, carrying the same no-data line the section used to show inline.

trusty-audit needs no change: `package::collect_dir` walks the run's output directory with `WalkDir` and collects every regular file with no name or extension filter, and `tga audit` hands `trusty-review report --out` that same directory. Both paths are still printed to stdout, so `audit::review::artifact_paths` picks up the new one and its `.json`-by-extension lookup is unaffected.

Test ladder rung 4 (public API on a library crate; no in-tree Cargo consumer of `report::Reporter`, confirmed by grep):

- `cargo fmt --check` → exit 0
- `cargo check -p trusty-review --all-targets` → exit 0
- `cargo clippy -p trusty-review --all-targets -- -D warnings` → exit 0
- `cargo test -p trusty-review` → `1693 passed; 0 failed; 5 ignored` (lib), plus `69 / 3 / 3 / 2 / 5 / 2 / 3 / 3` passed across the integration binaries, 0 failed
- `cargo check --workspace --all-targets` → exit 0 (17m07s)
- `scripts/check_line_cap.sh`, `scripts/check_sld.sh`, `scripts/check_changelog_fragment.sh` → exit 0

New regression coverage: `split_tests.rs` (6 tests over the cut itself — section boundaries, a trailing section, a fenced `## ` line, and the document wrapper) and `reporter_tests::{render_splits_authorship_into_its_own_document, render_without_authorship_data_still_produces_the_document, write_emits_the_authorship_document_alongside}`. `write_emits_both` and `report_e2e::end_to_end_two_repo_report` were updated to expect three written files rather than two.

Changelog fragment: `crates/trusty-review/changelog.d/6046-split-report-outputs.md`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
