### PR TITLE
fix(website): mark trusty-audit released — its CHANGELOG carries 0.6.0

### DIFF
--- a/website/src/lib/changelog/errors.ts
+++ b/website/src/lib/changelog/errors.ts
@@ -1,5 +1,5 @@
 /**
- * Why: "What's New" is a DERIVED view of six files this site does not own. If
+ * Why: "What's New" is a DERIVED view of files this site does not own. If
  * one of them stops parsing, the honest outcome is a red build — a page that
  * renders an empty strip instead is instrumentation reporting success over a
  * failure, and the reader has no way to tell the difference between "nothing

--- a/website/src/lib/changelog/parse.ts
+++ b/website/src/lib/changelog/parse.ts
@@ -1,5 +1,5 @@
 /**
- * Why: the six flagship `CHANGELOG.md` files ARE the source of truth for what
+ * Why: the flagship `CHANGELOG.md` files ARE the source of truth for what
  * shipped. This site only makes them readable — nothing here writes back to a
  * changelog, and nothing here invents a release. That means the parser has to
  * take the corpus as it actually is rather than as Keep a Changelog describes

--- a/website/src/lib/changelog/site.test.ts
+++ b/website/src/lib/changelog/site.test.ts
@@ -69,7 +69,7 @@ const failuresOf = (run: () => unknown) => {
 	throw new Error('expected the build to fail, but it succeeded');
 };
 
-describe('the real six-crate corpus', () => {
+describe('the real flagship-crate corpus', () => {
 	let site: ChangelogSite;
 
 	beforeAll(() => {
@@ -112,7 +112,7 @@ describe('the real six-crate corpus', () => {
 	/**
 	 * `beforeAll` already throws if any link in the corpus fails to resolve, so
 	 * this states what a green build means rather than adding new coverage: no
-	 * relative link in the six changelogs escapes the repository or points at a
+	 * relative link in the corpus escapes the repository or points at a
 	 * missing path, and every one that survived is a `blob/main` link.
 	 */
 	it('resolves every relative link in the corpus, none escaping the repository', () => {
@@ -133,15 +133,15 @@ describe('the real six-crate corpus', () => {
 	});
 
 	/**
-	 * trusty-audit is a FLAGSHIP with a page and a card, and still absent here:
-	 * it has no release, so `released` is false and the release-driven surfaces
-	 * skip it. Asserting that explicitly is what keeps a future `released: true`
-	 * from silently landing an empty section.
+	 * trusty-audit's CHANGELOG.md carries a real `## [0.6.0]` release, so it
+	 * joined RELEASED_FLAGSHIPS (`Tool.released`) alongside the others. Only
+	 * non-flagship crates such as `trusty-common` — never carded or paged —
+	 * stay out of this surface.
 	 */
-	it('keeps the unreleased flagship and the other crates out of both surfaces', () => {
+	it('includes every released flagship, and only non-flagship crates stay out', () => {
 		expect(site.crates.map((c) => c.name)).not.toContain('trusty-common');
-		expect(site.crates.map((c) => c.name)).not.toContain('trusty-audit');
-		expect(site.crates).toHaveLength(6);
+		expect(site.crates.map((c) => c.name)).toContain('trusty-audit');
+		expect(site.crates).toHaveLength(RELEASED_FLAGSHIPS.length);
 	});
 });
 
@@ -269,7 +269,7 @@ describe('the landing-page strip', () => {
 		]);
 	});
 
-	it('produces a non-empty strip for all six real crates', () => {
+	it('produces a non-empty strip for every real flagship crate', () => {
 		for (const crate of buildChangelogSite(REPO_ROOT).crates) {
 			const lines = stripItems(crate.latest);
 			expect(lines.length, crate.name).toBeGreaterThan(0);

--- a/website/src/lib/changelog/site.ts
+++ b/website/src/lib/changelog/site.ts
@@ -1,14 +1,14 @@
 /**
  * Why: the single build-time entry point behind both surfaces — the "What's
- * new" strip on the landing page and the `/whats-new` page. Reading the six
- * files once and memoising is not an optimisation: the landing page and
- * `/whats-new` would otherwise each re-read and re-parse 8 400 lines of
- * markdown to reach the same answer.
+ * new" strip on the landing page and the `/whats-new` page. Reading each
+ * flagship's file once and memoising is not an optimisation: the landing page
+ * and `/whats-new` would otherwise each re-read and re-parse thousands of
+ * lines of markdown to reach the same answer.
  *
  * Scope is the RELEASED FLAGSHIPS and only them (`$lib/site`'s
  * `RELEASED_FLAGSHIPS`). The other crates' changelogs are read in the
  * repository by the people who need them; putting 21 more sections on a
- * marketing page would bury the six that a visitor came for. A flagship that
+ * marketing page would bury the ones a visitor came for. A flagship that
  * has never shipped is excluded by the same rule the NO_RELEASES gate below
  * enforces — it would have nothing to render.
  *
@@ -23,7 +23,7 @@
  *
  * There is no placeholder, no empty-array default, and no "no changes yet"
  * string anywhere below. A green build is therefore itself the evidence that
- * all six sections are populated.
+ * every section is populated.
  *
  * This runs in Node at BUILD time only. Its output is prerendered into static
  * HTML, so the published page reads no file and opens no connection.
@@ -169,8 +169,9 @@ function readChangelog(
 /**
  * How many releases per crate carry their full item detail on `/whats-new`.
  *
- * Why a cap at all: the six changelogs are 672 kB of markdown, and a page
- * carrying every item of all 234 releases weighed 2.4 MB — because SvelteKit
+ * Why a cap at all: the flagship changelogs are hundreds of kB of markdown
+ * combined, and a page carrying every item of all 234 releases weighed
+ * 2.4 MB — because SvelteKit
  * inlines the load's data for hydration ON TOP of the rendered HTML, and emits
  * it a third time as `__data.json`. That is a worse way to read the archive
  * than the file this page already links to. Detail for what shipped recently,

--- a/website/src/lib/site.ts
+++ b/website/src/lib/site.ts
@@ -49,8 +49,10 @@ export const FLAGSHIPS: Flagship[] = TOOLS;
  * Why a subset rather than `FLAGSHIPS`: `$lib/changelog/site` fails the build
  * for a crate whose `CHANGELOG.md` parses to zero release sections, because an
  * empty section is indistinguishable from "nothing shipped". trusty-audit is
- * `publish = false` and has no release tag, so it is carded and paged like the
- * rest and carries no strip until its first release (`Tool.released`).
+ * `publish = false` (it ships a signed binary via install script, not
+ * crates.io) but does cut its own tagged releases, so once its CHANGELOG.md
+ * carried a real `## [0.6.0]` heading it joined this set (`Tool.released`)
+ * like the rest.
  */
 export const RELEASED_FLAGSHIPS: Flagship[] = FLAGSHIPS.filter((f) => f.released);
 
@@ -60,13 +62,13 @@ export interface CrateGroup {
 }
 
 /**
- * Why: what a visitor wants below the six flagship cards is "what else can I
+ * Why: what a visitor wants below the flagship cards is "what else can I
  * install, and what is coming" — not an inventory of every workspace member.
  * Internal plumbing is deliberately absent: shared libraries (`trusty-common`,
  * `trusty-progress`), private launchers, release tooling, and sidecars that
  * are installed BY another crate rather than on their own (`trusty-embedderd`,
  * whose own README says it is not installed standalone) have nothing to offer
- * a reader here. The six flagships are carded above and are not repeated.
+ * a reader here. The flagships are carded above and are not repeated.
  *
  * What: two groups, split on release state rather than on subject matter.
  * Placement was checked per crate against crates.io and this repository's
@@ -76,7 +78,7 @@ export interface CrateGroup {
  *
  * Deliberately omitted here, like the crate COUNT above: any per-crate version
  * number. A number TYPED INTO THIS FILE is stale the next time that crate
- * ships. The six flagship cards do now show one, and that is not a reversal of
+ * ships. The flagship cards do now show one, and that is not a reversal of
  * the same rule — `$lib/changelog` derives it from the crate's own
  * `CHANGELOG.md` at build time, so it cannot disagree with the repository. The
  * rule is "never hand-write a version", not "never show one".

--- a/website/src/lib/tools.ts
+++ b/website/src/lib/tools.ts
@@ -221,7 +221,7 @@ export const TOOLS: Tool[] = [
 				'curl -fsSL https://raw.githubusercontent.com/bobmatnyc/trusty-tools/main/crates/trusty-audit/install.sh | sh',
 			note: 'One command, macOS on Apple Silicon only. It verifies the release tarball against its published SHA-256 before anything reaches your PATH, installs into ${CARGO_HOME:-$HOME/.cargo}/bin with an atomic rename, and then launches the binary.'
 		},
-		released: false,
+		released: true,
 		docsPath: null
 	}
 ];

--- a/website/src/routes/whats-new/+page.server.ts
+++ b/website/src/routes/whats-new/+page.server.ts
@@ -1,5 +1,5 @@
 /**
- * Why: the whole page is one build-time computation over six files that live
+ * Why: the whole page is one build-time computation over files that live
  * ABOVE `website/`, exactly like the doc reader (`src/routes/docs/[...slug]`).
  * Prerendering bakes the result into static HTML, so the published page reads
  * no changelog at request time and opens no connection to GitHub.

--- a/website/src/routes/whats-new/+page.svelte
+++ b/website/src/routes/whats-new/+page.svelte
@@ -4,7 +4,7 @@
 	 * shipped; this page only organises them. Everything below is already HTML
 	 * by the time it arrives — parsed and serialised at build time by
 	 * `$lib/changelog` — so `{@html}` is placing markup this build produced from
-	 * six files in this repository, not rendering anything from a request.
+	 * files in this repository, not rendering anything from a request.
 	 *
 	 * What: one section per flagship in `RELEASED_FLAGSHIPS` order, each with
 	 * `id="<crate-name>"` so the landing page's "All changes →" lands on it.
@@ -19,7 +19,7 @@
 	let { data } = $props();
 
 	const description =
-		'What shipped in the six flagship trusty-tools crates, generated from the crates’ own CHANGELOG.md files.';
+		'What shipped in the flagship trusty-tools crates, generated from the crates’ own CHANGELOG.md files.';
 </script>
 
 <svelte:head>
@@ -171,7 +171,7 @@
 	<div class="card">
 		<h2 class="font-display text-xl font-semibold">The rest of the workspace</h2>
 		<p class="mt-2 text-sm text-foundry-secondary">
-			Only the six flagship crates are published here. Every other crate keeps its changelog
+			Only the flagship crates are published here. Every other crate keeps its changelog
 			alongside its source — see
 			<a
 				href={data.cratesDirUrl}


### PR DESCRIPTION
Release PR #6045 assembled trusty-audit's CHANGELOG.md `## [0.6.0]` heading but never flipped `Tool.released` in `website/src/lib/tools.ts`, so the Vitest drift test caught main disagreeing with itself. Flipping the flag surfaced a second, deliberate trip-wire test in `site.test.ts` that asserted trusty-audit stayed out of the release-driven surfaces — updated to match, along with every stale "six flagship" count in surrounding prose.

`pnpm test` (from `website/`): 14 test files passed, 252 tests passed, including the previously-failing `marks a tool released only when its CHANGELOG.md carries a release`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools