### PR TITLE
fix(trusty-review): the authorship report states its own data gaps

### DIFF
--- a/crates/trusty-review/changelog.d/6046-authorship-document-states-its-gaps.md
+++ b/crates/trusty-review/changelog.d/6046-authorship-document-states-its-gaps.md
@@ -1,0 +1,11 @@
+Fixed
+
+- **The standalone authorship report now states why it has no data**
+  ([#6046](https://github.com/bobmatnyc/trusty-tools/issues/6046)).
+  A repository whose authorship artifact fails to load renders the section as
+  `_No data available — see Gaps & Caveats._`, and since the split that section
+  lives in the code-review report — so a reader holding only the authorship
+  document saw the collapse line and no reason for it. The authorship-load gap
+  lines now render as a `Data gaps in this assessment` block above the body.
+  Gaps from other legs stay out of it, and a run whose authorship leg succeeded
+  is byte-identical to before.

--- a/crates/trusty-review/src/report/reporter.rs
+++ b/crates/trusty-review/src/report/reporter.rs
@@ -146,7 +146,15 @@ impl Reporter {
         RenderedReports {
             code_review: contents_links::inject(&code_body),
             authorship: authorship_section.map(|section| {
-                split::authorship_document(&model.title, &model.generated_date, &section)
+                // #6046: the model's authorship-load gaps travel WITH the
+                // section — the Gaps & Caveats section its no-data line points
+                // at renders in the code-review document, not this one.
+                split::authorship_document(
+                    &model.title,
+                    &model.generated_date,
+                    &section,
+                    &model.gaps,
+                )
             }),
         }
     }

--- a/crates/trusty-review/src/report/split.rs
+++ b/crates/trusty-review/src/report/split.rs
@@ -29,6 +29,10 @@ const AUTHORSHIP_HEADING_NEEDLE: &str = "Authorship";
 /// Filename suffix the authorship document is written under.
 pub const AUTHORSHIP_STEM_SUFFIX: &str = "-authorship";
 
+/// Prefix every authorship-load gap line carries, set in one place by
+/// `model.rs`'s fail-open arm (#5453/#6004).
+const AUTHORSHIP_GAP_PREFIX: &str = "Authorship (";
+
 /// Remove the authorship section from a rendered document.
 ///
 /// Why: the split is a post-render cut rather than a second template, so both
@@ -93,10 +97,26 @@ fn rejoin(lines: &[&str], source: &str) -> String {
 /// nothing else.
 /// What: promotes the section's `## ` heading to the document's `# ` title,
 /// suffixed with the report codename, then the provenance legend, a line naming
-/// the companion report and the generation date, and the section body verbatim.
+/// the companion report and the generation date, the authorship-load gaps from
+/// `gaps`, and the section body verbatim.
+///
+/// The gap lines are what keeps an authorship-leg failure legible on its own.
+/// `polish` collapses a section with no data to `_No data available — see Gaps &
+/// Caveats._`, and since #6046 that referenced section renders in the OTHER
+/// document — so a reader holding only this one saw the collapse line and no
+/// reason for it. Restating the repository's own gap lines here costs nothing
+/// when the leg succeeded (`gaps` carries none) and is the whole explanation
+/// when it failed.
 /// Test: `split_tests::{authorship_document_carries_title_and_legend,
-/// authorship_document_keeps_the_section_body}`.
-pub fn authorship_document(title: &str, generated_date: &str, section: &str) -> String {
+/// authorship_document_keeps_the_section_body,
+/// authorship_document_states_its_own_data_gaps,
+/// authorship_document_omits_the_gap_block_when_the_leg_succeeded}`.
+pub fn authorship_document(
+    title: &str,
+    generated_date: &str,
+    section: &str,
+    gaps: &[String],
+) -> String {
     let mut lines = section.lines();
     let heading = lines
         .next()
@@ -108,10 +128,35 @@ pub fn authorship_document(title: &str, generated_date: &str, section: &str) -> 
 
     format!(
         "# {heading}: {title}\n\n{legend}\n\nCompanion to the technical \
-         due-diligence report for {title}; generated {generated_date}.\n\n{body}\n",
+         due-diligence report for {title}; generated {generated_date}.\n\n{gaps}{body}\n",
         legend = provenance::LEGEND,
+        gaps = gap_block(gaps),
         body = body.trim(),
     )
+}
+
+/// The authorship-load gap lines, as a leading block, or `""` when there are
+/// none.
+///
+/// Why: only the authorship leg's own gaps belong here — the code-review
+/// document keeps the full Gaps & Caveats list, and repeating an unrelated
+/// scan or metrics gap in this document would misattribute it to authorship.
+fn gap_block(gaps: &[String]) -> String {
+    let mine: Vec<&String> = gaps
+        .iter()
+        .filter(|g| g.starts_with(AUTHORSHIP_GAP_PREFIX))
+        .collect();
+    if mine.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("**Data gaps in this assessment:**\n\n");
+    for gap in mine {
+        out.push_str("- ");
+        out.push_str(gap);
+        out.push('\n');
+    }
+    out.push('\n');
+    out
 }
 
 #[cfg(test)]

--- a/crates/trusty-review/src/report/split_tests.rs
+++ b/crates/trusty-review/src/report/split_tests.rs
@@ -1,6 +1,10 @@
 //! Unit tests for the code-review / authorship output split (#6046).
 
 use super::*;
+use crate::report::Reporter;
+use crate::report::manifest::parse_manifest;
+use crate::report::model::ReportModel;
+use crate::report::template::TemplateLoader;
 
 /// A three-section document with the authorship section in the middle.
 fn document() -> String {
@@ -74,7 +78,7 @@ fn a_trailing_authorship_section_splits_to_the_end() {
 #[test]
 fn authorship_document_carries_title_and_legend() {
     let (_, section) = split_authorship(&document());
-    let doc = authorship_document("Acme DD", "2026-08-19", &section.expect("section"));
+    let doc = authorship_document("Acme DD", "2026-08-19", &section.expect("section"), &[]);
 
     assert!(
         doc.starts_with("# Authorship & Key-Person Risk: Acme DD\n"),
@@ -91,7 +95,7 @@ fn authorship_document_carries_title_and_legend() {
 #[test]
 fn authorship_document_keeps_the_section_body() {
     let (_, section) = split_authorship(&document());
-    let doc = authorship_document("Acme DD", "2026-08-19", &section.expect("section"));
+    let doc = authorship_document("Acme DD", "2026-08-19", &section.expect("section"), &[]);
 
     assert!(doc.contains("Bus factor 2."), "{doc}");
     assert!(doc.contains("| acme | 7 |"), "{doc}");
@@ -100,4 +104,144 @@ fn authorship_document_keeps_the_section_body() {
         "the heading is promoted to the title, not repeated:\n{doc}"
     );
     assert!(doc.ends_with('\n'), "must end with a newline");
+}
+
+/// Why: `polish` collapses a data-less section to `_No data available — see Gaps
+/// & Caveats._`, and since the split that referenced section renders in the
+/// code-review document. A reader holding only the authorship document must
+/// still learn why it is empty.
+/// What: an authorship-load gap reaches the document as a bullet above the body.
+#[test]
+fn authorship_document_states_its_own_data_gaps() {
+    let (_, section) = split_authorship(&document());
+    let gaps = vec![
+        "Authorship (Acme Web): could not load the authorship artifact (bad json). The report \
+         states no authorship/key-person signal for this application."
+            .to_string(),
+        "Scan (Acme Web): the working tree was not readable.".to_string(),
+    ];
+    let doc = authorship_document("Acme DD", "2026-08-19", &section.expect("section"), &gaps);
+
+    assert!(doc.contains("**Data gaps in this assessment:**"), "{doc}");
+    assert!(
+        doc.contains("could not load the authorship artifact"),
+        "{doc}"
+    );
+    assert!(
+        !doc.contains("the working tree was not readable"),
+        "a non-authorship gap must not be misattributed to this document:\n{doc}"
+    );
+    assert!(
+        doc.find("Data gaps").expect("gap block") < doc.find("Bus factor 2.").expect("body"),
+        "the gaps must precede the body they explain:\n{doc}"
+    );
+}
+
+/// Why: the gap block is failure-only — a successful run must render exactly as
+/// it did before this addition.
+/// What: a gap list carrying no authorship line produces no block at all.
+#[test]
+fn authorship_document_omits_the_gap_block_when_the_leg_succeeded() {
+    let (_, section) = split_authorship(&document());
+    let section = section.expect("section");
+    let gaps = vec!["Scan (Acme Web): the working tree was not readable.".to_string()];
+
+    let with_unrelated = authorship_document("Acme DD", "2026-08-19", &section, &gaps);
+    let with_none = authorship_document("Acme DD", "2026-08-19", &section, &[]);
+
+    assert_eq!(with_unrelated, with_none);
+    assert!(!with_none.contains("Data gaps"), "{with_none}");
+}
+
+/// A one-repository manifest declaring `authorship = <name>`, built through the
+/// real loader so the fail-open arm in `model.rs` is the thing under test.
+fn model_declaring_authorship(dir: &std::path::Path, declared: &str) -> ReportModel {
+    let toml = format!(
+        r#"
+        [report]
+        title = "Acme Due Diligence"
+        analyst = "bobmatnyc"
+
+        [[repositories]]
+        name = "Acme Web"
+        path = "/nonexistent/acme-web"
+        authorship = "{declared}"
+    "#
+    );
+    let manifest_path = dir.join("manifest.toml");
+    let manifest = parse_manifest(&toml, &manifest_path).expect("manifest parse");
+    ReportModel::build(&manifest, &manifest_path, "report-technical-dd", None)
+        .expect("a declared authorship path must never fail the build")
+}
+
+/// Why: the owner requirement behind #6046 — "I don't want the code review to be
+/// held up by authorship." A broken authorship artifact is the cheapest real
+/// failure to inject, and it must cost the code-review document nothing.
+/// What: writes a malformed artifact, builds the model through
+/// `ReportModel::build`, renders both documents, and asserts every code-review
+/// section still arrives, with the failure named in both documents.
+#[test]
+fn an_authorship_load_failure_leaves_the_code_review_document_complete() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("authorship-0.json"), "{not json").expect("write artifact");
+    let model = model_declaring_authorship(dir.path(), "authorship-0.json");
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+
+    let documents = Reporter::new(dir.path()).render_documents(&model, &template);
+
+    let code = &documents.code_review;
+    for heading in [
+        "## 1. Report Metadata",
+        "## 2. Executive Summary",
+        "## 3. Scoring Model Normalization",
+        "## 4. Per-Application Scorecard",
+        "## 5. Findings by Severity",
+        "## 6. Risk Registers",
+        "## 7. Graph-Ready Data Appendix",
+        "## 9. Gaps & Caveats",
+    ] {
+        assert!(code.contains(heading), "missing {heading}:\n{code}");
+    }
+    assert!(
+        !code.contains("## Authorship & Key-Person Risk"),
+        "the section still belongs to the other document:\n{code}"
+    );
+    assert!(
+        code.contains("could not load the authorship artifact"),
+        "the code-review report states the gap it hit:\n{code}"
+    );
+
+    let authorship = documents
+        .authorship
+        .expect("a failed leg still produces the document");
+    assert!(
+        authorship.contains("could not load the authorship artifact"),
+        "the failure must be legible without the companion report:\n{authorship}"
+    );
+}
+
+/// Why: the same guarantee for the OTHER authorship-leg failure shape — a
+/// declared path that is not there at all.
+/// What: the code-review document renders its executive summary and gap line,
+/// and the render does not fail.
+#[test]
+fn a_missing_authorship_artifact_leaves_the_code_review_document_complete() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let model = model_declaring_authorship(dir.path(), "not-written.json");
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+
+    let documents = Reporter::new(dir.path()).render_documents(&model, &template);
+
+    assert!(documents.code_review.contains("## 2. Executive Summary"));
+    assert!(
+        documents
+            .code_review
+            .contains("could not load the authorship artifact"),
+        "{}",
+        documents.code_review
+    );
 }


### PR DESCRIPTION
Verification of the #6052 split against the owner requirement — "I don't want
the code review to be held up by authorship."

The isolation holds: a failed authorship load is fail-open at
`model.rs:316-331`, and `render_documents` is infallible, so no authorship-leg
failure can abort the code-review render. What the split broke is the other
half — `polish` collapses a data-less section to `_No data available — see Gaps
& Caveats._`, and that referenced section now renders in the code-review
report, so a reader holding only the authorship document got the collapse line
and no reason for it.

`authorship_document` now takes the model's gap list and renders the
authorship-load lines above the body. Gaps from other legs are filtered out; a
run whose authorship leg succeeded is byte-identical to before.

Adds the end-to-end proof the split was missing: a malformed and an absent
authorship artifact, each built through `ReportModel::build`, each asserting
every code-review section still renders.

Rung 3 — `cargo fmt --check`, `cargo check -p trusty-review --all-targets`,
`cargo clippy -p trusty-review --all-targets -- -D warnings`,
`cargo test -p trusty-review` → `1697 passed; 0 failed; 5 ignored` plus 10
integration suites, 0 failed. Two of the four new tests fail without the change.

Refs #6046

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools