### PR TITLE
fix(trusty-mpm): an unreachable tmux probe no longer reads as a dead session

### DIFF
--- a/crates/trusty-mpm/changelog.d/5859-session-exists-fail-closed.md
+++ b/crates/trusty-mpm/changelog.d/5859-session-exists-fail-closed.md
@@ -1,0 +1,7 @@
+Fixed
+
+- A tmux liveness probe that fails now refuses `tm session delete`, `tm session
+  prune`/`decommission`, and `tm session resume` instead of reading the session
+  as dead. Previously a transient `list-sessions` failure (or the no-op driver
+  installed when tmux cannot be discovered) let an unforced prune tear down a
+  live session and let resume kill and rebuild a live pane (#5859).

--- a/crates/trusty-mpm/src/runtime/test_helpers.rs
+++ b/crates/trusty-mpm/src/runtime/test_helpers.rs
@@ -99,8 +99,10 @@ impl ManagedTmuxDriver for FakeTmux {
         Ok(Vec::new())
     }
 
-    fn session_exists(&self, _name: &str) -> bool {
-        false
+    /// #5859: overrides the CHECKED probe so `session_exists` (which now
+    /// delegates to it) keeps answering `false` rather than diverging.
+    fn session_exists_checked(&self, _name: &str) -> Result<bool, ManagedError> {
+        Ok(false)
     }
 
     fn set_environment(&self, name: &str, key: &str, value: &str) -> Result<(), ManagedError> {

--- a/crates/trusty-mpm/src/session_manager/delete.rs
+++ b/crates/trusty-mpm/src/session_manager/delete.rs
@@ -56,7 +56,11 @@ impl SessionManager {
     /// deletes cleanly without `--force`. Otherwise transitions the record to
     /// `Deleted`, persists it, and returns the PRE-deletion [`SessionRecord`]
     /// snapshot (so callers can render the state it was in before deletion).
+    /// A liveness probe that could not reach tmux at all is neither "running"
+    /// nor "not running": its error surfaces as
+    /// [`ManagedError::TmuxUnavailable`] and no record is touched (#5859).
     /// Test: `delete_record_marks_deleted`,
+    /// `delete_record_refuses_when_the_tmux_probe_fails` (#5859),
     /// `delete_record_refuses_running_without_force`,
     /// `delete_record_force_bypasses_running_guard`,
     /// `delete_record_never_touches_workspace_dir`,
@@ -68,7 +72,9 @@ impl SessionManager {
         force: bool,
     ) -> Result<SessionRecord, ManagedError> {
         let record = self.get(id).await?;
-        if !force && is_running(&record, self.tmux.as_ref()) {
+        // #5859: `?` — a probe that could not reach tmux refuses the delete
+        // instead of answering "not running" and dropping a live session.
+        if !force && is_running(&record, self.tmux.as_ref())? {
             return Err(ManagedError::InvalidState(
                 id.to_string(),
                 format!(

--- a/crates/trusty-mpm/src/session_manager/driver.rs
+++ b/crates/trusty-mpm/src/session_manager/driver.rs
@@ -359,11 +359,44 @@ pub trait ManagedTmuxDriver: Send + Sync {
     /// Return all live tmux session names on the host.
     fn list_sessions(&self) -> Result<Vec<String>, ManagedError>;
 
-    /// True if a tmux session with this name currently exists.
-    fn session_exists(&self, name: &str) -> bool {
+    /// Whether a tmux session with this name currently exists, keeping
+    /// "confirmed absent" and "could not tell" apart (#5859).
+    ///
+    /// Why: [`Self::session_exists`] answers `false` for both, and two
+    /// destructive guards used to read that `false` as proof of death — the
+    /// delete/prune running-guard ([`super::prune::is_running`]) and
+    /// [`super::SessionManager::resume`]'s reuse-or-recreate branch. A
+    /// transient `list-sessions` failure, or the
+    /// [`super::real_tmux::NoopTmuxDriver`] installed whenever
+    /// `RealTmuxDriver::discover()` fails, then read a live attached pane as
+    /// prunable without `--force`, or as a dead pane to kill and rebuild.
+    /// This is the same "a liveness check that cannot see tmux is not proof of
+    /// death" rule [`super::SessionManager::observed_live_managed_names`]
+    /// already applies to the boot-time passes (#5856).
+    /// What: propagates [`Self::list_sessions`]'s error instead of folding it
+    /// into `false`. A driver that can probe one session more cheaply than
+    /// listing them all may override this; overriding THIS method (rather than
+    /// `session_exists`) keeps both spellings of the question consistent.
+    /// Test: `delete_record_refuses_when_the_tmux_probe_fails`,
+    /// `prune_refuses_when_the_tmux_probe_fails`,
+    /// `resume_refuses_when_the_tmux_probe_fails`.
+    fn session_exists_checked(&self, name: &str) -> Result<bool, ManagedError> {
         self.list_sessions()
             .map(|names| names.iter().any(|n| n == name))
-            .unwrap_or(false)
+    }
+
+    /// True if a tmux session with this name currently exists, reading an
+    /// undeterminable probe as absent.
+    ///
+    /// Why: display and best-effort callers (status rendering, name-collision
+    /// avoidance, the worktree inventory report) already tolerate an unknown
+    /// answer and must not fail for it. A caller that ACTS destructively on
+    /// `false` must call [`Self::session_exists_checked`] instead (#5859).
+    /// What: [`Self::session_exists_checked`] with `Err` mapped to `false`.
+    /// Test: covered through its callers; the error arm is pinned by
+    /// `session_exists_reads_an_unobservable_probe_as_absent`.
+    fn session_exists(&self, name: &str) -> bool {
+        self.session_exists_checked(name).unwrap_or(false)
     }
 
     /// Probe whether the runtime inside `name`'s pane is READY to accept typed

--- a/crates/trusty-mpm/src/session_manager/liveness_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/liveness_tests.rs
@@ -12,11 +12,17 @@
 //! one via `delete_record`, one via `prune_managed` (which also backs `tm
 //! session prune`/`tm session decommission`) — while a genuinely LIVE session
 //! stays guarded in both paths.
+//!
+//! #5859 extends the file to the OTHER arm of the same probe: a probe that
+//! could not reach tmux at all. Three tests prove `delete_record`,
+//! `prune_managed`, and `resume` refuse rather than reading that as death, and
+//! a fourth pins the display-only `session_exists` wrapper still answering
+//! `false` for it.
 //! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
 
 use tempfile::TempDir;
 
-use super::manager::ManagedTmuxDriver;
+use super::manager::{ManagedError, ManagedTmuxDriver};
 use super::record::{ManagedSessionId, ManagedSessionState};
 use super::tests::{make_manager, seed_record};
 
@@ -107,4 +113,161 @@ async fn prune_stale_active_removable_without_force_when_tmux_dead() {
         ManagedSessionState::Active,
         "a genuinely live (tmux-alive) session must still be guarded"
     );
+}
+
+// ---------------------------------------------------------------------------
+// #5859: an UNDETERMINABLE liveness probe is not a confirmed-absent session.
+// ---------------------------------------------------------------------------
+
+/// `delete_record`'s running-guard REFUSES when the tmux probe itself fails
+/// (#5859).
+///
+/// Why: the guard used to call `session_exists`, which folded a
+/// `list-sessions` error into `false`. A transient tmux failure — or the
+/// `NoopTmuxDriver` installed whenever `RealTmuxDriver::discover()` fails —
+/// therefore read a live, attached session as not-running, and an unforced
+/// `tm session delete` dropped it. "Could not tell" must not be spelled the
+/// same way as "confirmed dead".
+/// What: seeds an `Active` record (whose tmux session the fake driver reports
+/// as live), makes `list_sessions` fail, and asserts `delete_record(id,
+/// force=false)` returns `TmuxUnavailable` with the record untouched. Pre-fix
+/// this returned `Ok` and marked the record `Deleted`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn delete_record_refuses_when_the_tmux_probe_fails() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+    let id = ManagedSessionId::new();
+    seed_record(&mgr, &dir, id, ManagedSessionState::Active, false).await;
+
+    // tmux is live and so is the session — but the probe cannot reach it.
+    *fake.list_sessions_should_fail.lock().unwrap() = true;
+
+    let err = mgr
+        .delete_record(&id, false)
+        .await
+        .expect_err("an unobservable liveness probe must refuse the delete (#5859)");
+    assert!(
+        matches!(err, ManagedError::TmuxUnavailable(_)),
+        "expected TmuxUnavailable, got {err:?}"
+    );
+    assert_eq!(
+        mgr.get(&id).await.expect("record still tracked").state,
+        ManagedSessionState::Active,
+        "no record may be touched when liveness could not be established"
+    );
+}
+
+/// `prune_managed`'s running-guard REFUSES the whole sweep when the tmux probe
+/// fails, and `include_active` still short-circuits it (#5859).
+///
+/// Why: the same fail-open as `delete_record`, reached through `tm session
+/// prune` / `tm session decommission`, which additionally tear the WORKSPACE
+/// down. The short-circuit half matters too: `decommission_all_ephemeral`
+/// passes `include_active=true` and ignores liveness by design, so it must keep
+/// working on a host where tmux cannot be observed at all.
+/// What: seeds an `Active` record, makes `list_sessions` fail, and asserts the
+/// `include_active=false` prune returns `TmuxUnavailable` while the record stays
+/// `Active`; then asserts the `include_active=true` prune still reaps it.
+/// Pre-fix the first call returned `Ok` and decommissioned the live session.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn prune_refuses_when_the_tmux_probe_fails() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+    let id = ManagedSessionId::new();
+    seed_record(&mgr, &dir, id, ManagedSessionState::Active, false).await;
+
+    *fake.list_sessions_should_fail.lock().unwrap() = true;
+
+    let err = mgr
+        .prune_managed(crate::session_manager::PruneFilter::All, false, false, None)
+        .await
+        .expect_err("an unobservable liveness probe must refuse the prune (#5859)");
+    assert!(
+        matches!(err, ManagedError::TmuxUnavailable(_)),
+        "expected TmuxUnavailable, got {err:?}"
+    );
+    assert_eq!(
+        mgr.get(&id).await.expect("record still tracked").state,
+        ManagedSessionState::Active,
+        "a live session must survive a prune whose liveness probe failed"
+    );
+
+    // `include_active` never consults the probe, so it is unaffected.
+    let outcome = mgr
+        .prune_managed(crate::session_manager::PruneFilter::All, false, true, None)
+        .await
+        .expect("include_active skips the liveness gate entirely");
+    assert_eq!(outcome.count(), 1);
+}
+
+/// `resume` REFUSES rather than killing and rebuilding the pane when the tmux
+/// probe fails (#5859).
+///
+/// Why: `resume`'s else-branch is destructive — it `kill_session`s and creates
+/// a fresh pane. Reading an unobservable probe as "no live pane" destroyed the
+/// pane the operator was looking at, along with any sibling window in that tmux
+/// session.
+/// What: seeds a `Stopped` record, registers its tmux name as live on the fake
+/// driver, makes `list_sessions` fail, and asserts `resume` returns
+/// `TmuxUnavailable` with no `kill_session` and no `create_session` issued, and
+/// the record still `Stopped`. Pre-fix this killed and recreated the pane.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn resume_refuses_when_the_tmux_probe_fails() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+    let id = ManagedSessionId::new();
+    seed_record(&mgr, &dir, id, ManagedSessionState::Stopped, false).await;
+
+    // The pane survived the runtime exit (#2148) — it is genuinely alive.
+    fake.seeded_names
+        .lock()
+        .unwrap()
+        .push(format!("tmpm-seed-{id}"));
+    *fake.list_sessions_should_fail.lock().unwrap() = true;
+
+    let err = mgr
+        .resume(&id)
+        .await
+        .expect_err("an unobservable liveness probe must refuse the resume (#5859)");
+    assert!(
+        matches!(err, ManagedError::TmuxUnavailable(_)),
+        "expected TmuxUnavailable, got {err:?}"
+    );
+    assert!(
+        fake.kill_calls.lock().unwrap().is_empty(),
+        "resume must not kill a pane it could not prove dead"
+    );
+    assert!(
+        fake.create_cwd_calls.lock().unwrap().is_empty(),
+        "resume must not rebuild a pane it could not prove dead"
+    );
+    assert_eq!(
+        mgr.get(&id).await.expect("record still tracked").state,
+        ManagedSessionState::Stopped
+    );
+}
+
+/// The display-only `session_exists` wrapper still reads an unobservable probe
+/// as absent (#5859).
+///
+/// Why: the fix must not turn every status render, name-collision check, and
+/// worktree inventory row into a hard error — those callers act on nothing and
+/// already tolerate an unknown. Splitting the probe is only safe while this half
+/// keeps its old, lenient answer.
+/// What: makes `list_sessions` fail and asserts `session_exists` is `false`
+/// while `session_exists_checked` is `Err` for the same name.
+/// Test: this function IS the test.
+#[test]
+fn session_exists_reads_an_unobservable_probe_as_absent() {
+    let fake = super::tests::FakeTmuxDriver::new();
+    *fake.list_sessions_should_fail.lock().unwrap() = true;
+
+    assert!(!fake.session_exists("tmpm-anything"));
+    assert!(matches!(
+        fake.session_exists_checked("tmpm-anything"),
+        Err(ManagedError::TmuxUnavailable(_))
+    ));
 }

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -788,7 +788,9 @@ impl SessionManager {
     /// existence-checks `last_cwd` → `workspace_path` → `cwd` in order,
     /// erroring with [`ManagedError::WorkspaceMissing`] rather than handing a
     /// stale/removed path to tmux when none remain), then branches on
-    /// [`ManagedTmuxDriver::session_exists`]: if the tmux SESSION is STILL
+    /// [`ManagedTmuxDriver::session_exists_checked`] — a probe that cannot
+    /// reach tmux refuses the resume rather than falling into the destructive
+    /// recreate branch below (#5859): if the tmux SESSION is STILL
     /// alive, it is (usually) reused as-is — no `kill_session`, no
     /// `create_session` — because the caller (e.g. `resume_managed`)
     /// re-spawns the runtime via `RuntimeAdapter::spawn_resume`, which now
@@ -823,7 +825,10 @@ impl SessionManager {
     /// `resume_reattach_tests.rs`'s
     /// `resume_refuses_when_stored_pane_gone_but_session_alive` — asserts a
     /// confirmed-gone recorded pane refuses with `PaneGone` and never falls
-    /// through to a session-scoped reuse or a session-wide kill/recreate.
+    /// through to a session-scoped reuse or a session-wide kill/recreate;
+    /// `liveness_tests.rs`'s `resume_refuses_when_the_tmux_probe_fails` —
+    /// asserts an unobservable probe refuses instead of killing the pane
+    /// (#5859).
     pub async fn resume(&self, id: &ManagedSessionId) -> Result<SessionRecord, ManagedError> {
         let mut record = self.get(id).await?;
         match record.state {
@@ -839,14 +844,9 @@ impl SessionManager {
         }
 
         // #3823: guarantee the tmux SERVER exists before the FIRST tmux call
-        // below (`session_exists`'s `list-sessions` probe). Its default trait
-        // implementation swallows a `list-sessions` failure into `false`
-        // (harmless here — the recreate branch below already routes through
-        // the #3386/#3722 `create_managed_session` choke point, which starts
-        // the server itself), but resuming should not depend on that
-        // swallow-and-recreate side effect being correct forever; an explicit
-        // guard makes the guarantee the issue asks for ("session creation
-        // *and resume*") structural rather than incidental. Also redundant
+        // below (`session_exists_checked`'s `list-sessions` probe), so a cold
+        // socket is STARTED rather than reported as a probe failure the
+        // #5859 guard below would (correctly) refuse to resume through. Also redundant
         // (cheap no-op `tmux start-server`) with the recreate branch's own
         // eventual #3386/#3722 `ensure_server_up` when the pane needs
         // rebuilding — accepted for the same reason as the create paths'
@@ -865,7 +865,12 @@ impl SessionManager {
         // #2148: a pane that survived the runtime exit (e.g.
         // `mark_runtime_exited_stopped`, #2023 A) must be REUSED, not destroyed.
         // Only recreate the tmux session when no live pane remains.
-        if self.tmux.session_exists(&record.tmux_name) {
+        //
+        // #5859: `session_exists_checked` + `?`, not `session_exists`. The else
+        // branch below KILLS the session and rebuilds the pane, so an
+        // undeterminable probe answering `false` destroyed a live pane. Refuse
+        // the resume instead — the operator can retry once tmux answers.
+        if self.tmux.session_exists_checked(&record.tmux_name)? {
             // Sibling-window hijack fix (follow-up to #2456): `session_exists`
             // only proves SOME pane in this tmux session is alive — it says
             // nothing about whether it is the SPECIFIC pane this record is

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -187,14 +187,22 @@ fn canonicalize_failure_streaks() -> &'static std::sync::Mutex<CanonicalizeFailu
 /// session (and, as a bonus, closes the reverse gap noted in #2022 where a
 /// stale non-running `state` could under-guard a session whose tmux is
 /// somehow still alive).
+///
+/// #5859: an UNDETERMINABLE probe is not an absent session. `Err` propagates to
+/// the caller, which refuses the teardown, rather than folding into `false` and
+/// letting a live pane be pruned without `--force`.
 /// Test: `prune_by_state_never_touches_active` (live session still guarded),
 /// `delete_record_refuses_running_without_force` (live session still
 /// guarded), `delete_record_stale_active_deletable_when_tmux_dead` (#2022 —
 /// stale `Active` with a dead tmux is deletable without `--force`),
 /// `prune_stale_active_removable_without_force_*` (#2022 — same for
-/// `prune_managed`).
-pub(super) fn is_running(record: &SessionRecord, tmux: &dyn ManagedTmuxDriver) -> bool {
-    tmux.session_exists(&record.tmux_name)
+/// `prune_managed`), `delete_record_refuses_when_the_tmux_probe_fails` and
+/// `prune_refuses_when_the_tmux_probe_fails` (#5859 — the error arm).
+pub(super) fn is_running(
+    record: &SessionRecord,
+    tmux: &dyn ManagedTmuxDriver,
+) -> Result<bool, ManagedError> {
+    tmux.session_exists_checked(&record.tmux_name)
 }
 
 /// Whether a record is a terminal tombstone — the two states prune COMPACTS
@@ -427,12 +435,20 @@ impl SessionManager {
 
         // Select the in-scope records, applying the running safety gate — a REAL
         // tmux liveness probe (#2022), not the persisted `state` field.
+        //
+        // #5859: the gate fails CLOSED. `is_running` now returns `Err` when tmux
+        // could not be observed at all, and that error aborts the whole prune
+        // rather than reading as "not running" and tearing down a live pane.
+        // `include_active` short-circuits before the probe, so the bulk
+        // ephemeral sweep (which ignores liveness by design) still runs on a
+        // host with no reachable tmux.
         let tmux = self.tmux.as_ref();
-        let targets: Vec<SessionRecord> = all
-            .into_iter()
-            .filter(|r| matches_filter(r, filter))
-            .filter(|r| include_active || !is_running(r, tmux))
-            .collect();
+        let mut targets: Vec<SessionRecord> = Vec::new();
+        for record in all.into_iter().filter(|r| matches_filter(r, filter)) {
+            if include_active || !is_running(&record, tmux)? {
+                targets.push(record);
+            }
+        }
 
         // Worktree base names for the slot-release guard below, resolved AT MOST
         // ONCE per prune and only when a tombstone is actually compacted —

--- a/crates/trusty-mpm/src/session_manager/real_tmux.rs
+++ b/crates/trusty-mpm/src/session_manager/real_tmux.rs
@@ -289,8 +289,10 @@ impl ManagedTmuxDriver for NoopTmuxDriver {
     /// route through
     /// [`super::SessionManager::observed_live_managed_names`] and skip their
     /// pass on `Err` rather than inventing an empty set. The one caller that
-    /// can tolerate an unknown still degrades explicitly: the trait's
-    /// `session_exists` default maps `Err` to `false` (#5859).
+    /// can tolerate an unknown still degrades explicitly, and only there: the
+    /// trait's `session_exists` maps `Err` to `false` for display and
+    /// best-effort callers, while every destructive guard routes through
+    /// `session_exists_checked`, which propagates it (#5859).
     /// Test: `noop_driver_list_sessions_refuses_rather_than_reporting_zero`,
     /// and end-to-end by
     /// `dedup_refuses_on_the_noop_driver_rather_than_reading_zero_as_dead`.

--- a/crates/trusty-mpm/tests/session_control_api.rs
+++ b/crates/trusty-mpm/tests/session_control_api.rs
@@ -95,11 +95,14 @@ impl ManagedTmuxDriver for RecordingDriver {
     fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
         Ok(self.live.lock().unwrap().clone())
     }
-    fn session_exists(&self, name: &str) -> bool {
+    /// #5859: overrides the CHECKED probe, so `force_alive` still steers both
+    /// the display-only `session_exists` (which delegates here) and the
+    /// destructive guards that call this method directly.
+    fn session_exists_checked(&self, name: &str) -> Result<bool, ManagedError> {
         if let Some(f) = *self.force_alive.lock().unwrap() {
-            return f;
+            return Ok(f);
         }
-        self.live.lock().unwrap().iter().any(|n| n == name)
+        Ok(self.live.lock().unwrap().iter().any(|n| n == name))
     }
 }
 

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -107,8 +107,10 @@ impl ManagedTmuxDriver for RecordingTmux {
     fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
         Ok(Vec::new())
     }
-    fn session_exists(&self, _name: &str) -> bool {
-        false
+    /// #5859: overrides the CHECKED probe so `session_exists` (which now
+    /// delegates to it) keeps answering `false` rather than diverging.
+    fn session_exists_checked(&self, _name: &str) -> Result<bool, ManagedError> {
+        Ok(false)
     }
 }
 


### PR DESCRIPTION
`session_exists` folded a `list-sessions` error into `false`, and three
destructive paths read that `false` as proof the session was dead — see #5859.
The guards now call a `session_exists_checked` that propagates the error and
refuse; `session_exists` keeps the lenient answer for display-only callers.
`include_active` still short-circuits before the probe, so
`decommission_all_ephemeral` is unaffected.

## Rung 3

```
cargo fmt --check                                   EXIT=0
cargo check -p trusty-mpm --all-targets             EXIT=0
cargo clippy -p trusty-mpm --all-targets -D warnings EXIT=0
cargo test -p trusty-mpm --lib                      5191 passed; 0 failed; 7 ignored
cargo test -p trusty-mpm --test session_control_api --test session_manager_mvp \
  --test session_lifecycle --test resume_unresumable_mapping \
  --test session_manager_slots --test orphan_gc_sweep --test manager_routes \
  --test test_session_lifecycle                     60 passed; 0 failed; 2 ignored
bash scripts/check_test_pointers.sh                 EXIT=0
bash scripts/check_changelog_fragment.sh            EXIT=0
bash scripts/check_line_cap.sh                      EXIT=0
bash scripts/check_sld.sh                           EXIT=0
```

Three new tests in `liveness_tests.rs` exercise the probe-FAILURE branch, not
the absent branch. Each was run against a working tree with the two guard sites
restored to their pre-fix spelling and each failed there:

```
test resume_refuses_when_the_tmux_probe_fails ... FAILED
test delete_record_refuses_when_the_tmux_probe_fails ... FAILED
test prune_refuses_when_the_tmux_probe_fails ... FAILED
```

The prune failure shows the damage directly — the pre-fix run returned
`PruneOutcome { … action: DecommissionedWorktreeRetained }` for the live
session. A fourth test pins the display-only wrapper still answering `false`.

## Baseline

`cargo test -p trusty-mpm --bin tm` deadlocks on this machine: five
`#[serial_test::serial]` tests in `tests_behavior_b`/`tests_behavior_c` block
forever at 0% CPU with no child processes, on the `ENV_MUTEX` those tests share
with `serial_test`'s own lock. It reproduces identically with this branch's
`crates/trusty-mpm/` reverted to `origin/main`, so it is pre-existing and
unrelated — this branch touches no file under `src/bin/`. Not filed here.

## Scope

`session_exists` and its destructive callers only. `naming.rs`'s
collision check and `worktree_reconcile.rs`'s inventory report still use the
lenient wrapper deliberately: neither acts on the answer. #5949/#5830
decommission/prune territory is untouched.

Refs #5859

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
